### PR TITLE
add logging to xclExecBuf

### DIFF
--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -996,12 +996,22 @@ ssize_t xocl::XOCLShim::xclUnmgdPread(unsigned flags, void *buf, size_t count, u
  */
 int xocl::XOCLShim::xclExecBuf(unsigned int cmdBO)
 {
+    if (mLogStream.is_open()) {
+        mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << cmdBO << std::endl;
+    }
     drm_xocl_execbuf exec = {0, cmdBO, 0,0,0,0,0,0,0,0};
     return ioctl(mUserHandle, DRM_IOCTL_XOCL_EXECBUF, &exec);
 }
 
+/*
+ * xclExecBuf()
+ */
 int xocl::XOCLShim::xclExecBuf(unsigned int cmdBO, size_t num_bo_in_wait_list, unsigned int *bo_wait_list)
 {
+    if (mLogStream.is_open()) {
+        mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
+                   << cmdBO << ", " << num_bo_in_wait_list << ", " << bo_wait_list << std::endl;
+    }
     unsigned int bwl[8] = {0};
     std::memcpy(bwl,bo_wait_list,num_bo_in_wait_list*sizeof(unsigned int));
     drm_xocl_execbuf exec = {0, cmdBO, bwl[0],bwl[1],bwl[2],bwl[3],bwl[4],bwl[5],bwl[6],bwl[7]};


### PR DESCRIPTION
Add logging in shim.cpp xclExecBuf().
Closes #19 