### PR TITLE
download kernel-doc from latest linux

### DIFF
--- a/src/runtime_src/doc/Makefile
+++ b/src/runtime_src/doc/Makefile
@@ -1,4 +1,4 @@
-KERNELDOC_URL := https://raw.githubusercontent.com/torvalds/linux/master/scripts/kernel-doc
+KERNELDOC_URL := https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/plain/scripts/kernel-doc?h=v4.14.52
 KERNELDOC := ./kernel-doc
 
 SPHINX := sphinx-build

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -39,6 +39,7 @@ RH_LIST=(\
      rpm-build \
      strace \
      unzip \
+     curl \
      )
 
 UB_LIST=(\
@@ -75,6 +76,7 @@ UB_LIST=(\
      strace \
      unzip \
      uuid-dev \
+     curl \
 )
 
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}'`


### PR DESCRIPTION
Download kernel-doc from https://raw.githubusercontent.com/torvalds/linux/master/scripts/kernel-doc if it is not existed.

make clean will remove core/ and kernel-doc

Closes #24 