### PR TITLE
Support memory bank buffer allocation without cl_ext pointer.

### DIFF
--- a/src/include/1_2/CL/cl_ext.h
+++ b/src/include/1_2/CL/cl_ext.h
@@ -228,7 +228,7 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *clIcdGetPlatformIDsKHR_fn)(
 #define CL_PIPE_ATTRIBUTE_DPDK_ID                   (1 << 31)
 
 /* Additional cl_device_partition_property */
-#define CL_DEVICE_PARTITION_BY_CLUSTER              (1 << 31)
+#define CL_DEVICE_PARTITION_BY_CONNECTIVITY         (1 << 31)
 
 
 /**

--- a/src/runtime_src/xocl/api/clCreateBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateBuffer.cpp
@@ -54,19 +54,28 @@ get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
 // emulation mode before clCreateProgramWithBinary->loadBinary has
 // been called.  The call to loadBinary can end up switching the
 // device from swEm to hwEm.
-// 
+//
 // In non emulation mode it is sufficient to check that the context
 // has only one device.
-static xocl::device*
+XRT_UNUSED static xocl::device*
 singleContextDevice(cl_context context)
 {
   auto device = xocl::xocl(context)->get_device_if_one();
   if (!device)
     return nullptr;
 
-  return (device->is_active())
-    ? device
-    : nullptr;
+  if (!device->is_active())
+    return nullptr;
+
+  // check that all CUs in device has same single mem connectivity
+  xocl::device::memidx_bitmask_type ucon;
+  for (auto cu : device->get_cu_range())
+    ucon |= cu->get_memidx_union();
+  if (ucon.count() > 1)
+    return nullptr;
+
+  XOCL_DEBUG(std::cout,"context(",xocl::xocl(context)->get_uid(),") has single device single connection\n");
+  return device;
 }
 
 }
@@ -96,12 +105,12 @@ validOrError(cl_context   context,
 
   // CL_INVALID_HOST_PTR if host_ptr is NULL and CL_MEM_EXT_PTR_XILINX is set
   // In this case host_ptr is actually a ptr to some struct
-  // 
+  //
   // CL_INVALID_HOST_PTR if host_ptr is NULL and CL_MEM_USE_HOST_PTR
   // or CL_MEM_COPY_HOST_PTR are set in flags or if host_ptr is not
   // NULL but CL_MEM_COPY_HOST_PTR or CL_MEM_USE_HOST_PTR are not set
   // in flags.
-  // 
+  //
   // xlnx: CL_INVALID_VALUE if multiple banks are specified
   detail::memory::validHostPtrOrError(flags,host_ptr);
 }
@@ -120,7 +129,7 @@ clCreateBuffer(cl_context   context,
   validOrError(context,flags,size,host_ptr,errcode_ret);
 
   // Adjust host_ptr based on ext flags if any
-  auto ubuf = get_host_ptr(flags,host_ptr); 
+  auto ubuf = get_host_ptr(flags,host_ptr);
   auto buffer = xrt::make_unique<xocl::buffer>(xocl::xocl(context),flags,size,ubuf);
 
   // set fields in cl_buffer
@@ -133,7 +142,7 @@ clCreateBuffer(cl_context   context,
       buffer->get_buffer_object(device);
     }
   }
-    
+
   xocl::assign(errcode_ret,CL_SUCCESS);
   return buffer.release();
 }
@@ -162,5 +171,3 @@ clCreateBuffer(cl_context   context,
   }
   return nullptr;
 }
-
-

--- a/src/runtime_src/xocl/api/clCreateSubDevices.cpp
+++ b/src/runtime_src/xocl/api/clCreateSubDevices.cpp
@@ -59,11 +59,17 @@ validOrError(cl_device_id                        in_device,
   if (!properties)
     throw error(CL_INVALID_VALUE,"No device partitioning property provided");
   
-  // Support only CL_DEVICE_PARTITION_EQUALLY
-  if (properties[0] != CL_DEVICE_PARTITION_EQUALLY)
-    throw error(CL_INVALID_VALUE,"Invalid partition property, only CL_DEVICE_PARTITION_EQUALLY supported");
-  if (properties[1] != 1)
-    throw error(CL_INVALID_VALUE,"Only one CU per subdevice is supported");
+  // Support CL_DEVICE_PARTITION_EQUALLY
+  if (properties[0] == CL_DEVICE_PARTITION_EQUALLY) {
+    if (properties[1] != 1)
+      throw error(CL_INVALID_VALUE,"Only one CU per subdevice is supported");
+  }
+  else if (properties[0] == CL_DEVICE_PARTITION_BY_CONNECTIVITY) {
+  }
+  else {
+    throw error(CL_INVALID_VALUE,"Invalid partition property, \
+                only CL_DEVICE_PARTITION_EQUALLY and CL_DEVICE_PARTITION_BY_CONNECTIVITY supported");
+  }
 
   // CL_INVALID_VALUE if out_devices is not NULL and num_devices is
   // less than the number of sub-devices created by the partition

--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -29,37 +29,37 @@ namespace xocl {
 
 std::unique_ptr<kernel::argument>
 kernel::argument::
-create(arginfo_type arg)
+create(arginfo_type arg, kernel* kernel)
 {
   switch (arg->address_qualifier) {
   case 0:
-    return xrt::make_unique<kernel::scalar_argument>(arg);
+    return xrt::make_unique<kernel::scalar_argument>(arg,kernel);
     break;
   case 1:
-    return xrt::make_unique<kernel::global_argument>(arg);
+    return xrt::make_unique<kernel::global_argument>(arg,kernel);
     break;
   case 2:
-    return xrt::make_unique<kernel::constant_argument>(arg);
+    return xrt::make_unique<kernel::constant_argument>(arg,kernel);
     break;
   case 3:
-    return xrt::make_unique<kernel::local_argument>(arg);
+    return xrt::make_unique<kernel::local_argument>(arg,kernel);
     break;
   case 4:
     // hack for progvar (064_pipe_num_packets_hw_xilinx_adm-pcie-ku3_2ddr_3_3)
     // do not understand this code at all, but reuse global_argument all that
     // matters is that cu_ffa gets proper xclbin arg properties (size,offset,etc)
-    if (arg->atype==xclbin::symbol::arg::argtype::progvar) 
-      return xrt::make_unique<kernel::global_argument>(arg);
+    if (arg->atype==xclbin::symbol::arg::argtype::progvar)
+      return xrt::make_unique<kernel::global_argument>(arg,kernel);
     throw std::runtime_error("unsupported address qualifier 'pipe' for argument '" + arg->name + "'.");
     break;
   default:
-    throw xocl::error(CL_INVALID_BINARY,"invalid address qualifier: " 
+    throw xocl::error(CL_INVALID_BINARY,"invalid address qualifier: "
                       + std::to_string(arg->address_qualifier)
                       + "(id: " + arg->id +")");
   }
 }
 
-cl_kernel_arg_address_qualifier 
+cl_kernel_arg_address_qualifier
 kernel::argument::
 get_address_qualifier() const
 {
@@ -79,7 +79,7 @@ get_address_qualifier() const
   }
 }
 
-std::unique_ptr<kernel::argument> 
+std::unique_ptr<kernel::argument>
 kernel::scalar_argument::
 clone()
 {
@@ -95,12 +95,12 @@ add(arginfo_type arg)
   return m_sz;
 }
 
-void 
+void
 kernel::scalar_argument::
 set(size_t size, const void* cvalue)
 {
   if (size != m_sz)
-    throw error(CL_INVALID_ARG_SIZE,"Invalid scalar argument size, expected " 
+    throw error(CL_INVALID_ARG_SIZE,"Invalid scalar argument size, expected "
                 + std::to_string(m_sz) + " got " + std::to_string(size));
   // construct vector from iterator range.
   // the value can be gathered with m_value.data()
@@ -131,14 +131,14 @@ get_string_value() const
   return sstr.str();
 }
 
-std::unique_ptr<kernel::argument> 
+std::unique_ptr<kernel::argument>
 kernel::global_argument::
 clone()
 {
   return xrt::make_unique<global_argument>(*this);
 }
 
-void 
+void
 kernel::global_argument::
 set(size_t size, const void* cvalue)
 {
@@ -149,6 +149,8 @@ set(size_t size, const void* cvalue)
   auto mem = value ? *static_cast<cl_mem*>(value) : nullptr;
 
   m_buf = xocl(mem);
+  if (m_argidx < std::numeric_limits<unsigned long>::max())
+    m_buf->get_buffer_object(m_kernel,m_argidx);
   m_set = true;
 }
 
@@ -165,14 +167,14 @@ set_svm(size_t size, const void* cvalue)
   m_set = true;
 }
 
-std::unique_ptr<kernel::argument> 
+std::unique_ptr<kernel::argument>
 kernel::local_argument::
 clone()
 {
   return xrt::make_unique<local_argument>(*this);
 }
 
-void 
+void
 kernel::local_argument::
 set(size_t size, const void* value)
 {
@@ -186,14 +188,14 @@ set(size_t size, const void* value)
   m_set = true;
 }
 
-std::unique_ptr<kernel::argument> 
+std::unique_ptr<kernel::argument>
 kernel::constant_argument::
 clone()
 {
   return xrt::make_unique<constant_argument>(*this);
 }
 
-void 
+void
 kernel::constant_argument::
 set(size_t size, const void* cvalue)
 {
@@ -202,31 +204,32 @@ set(size_t size, const void* cvalue)
   auto value = const_cast<void*>(cvalue);
   auto mem = value ? *static_cast<cl_mem*>(value) : nullptr;
   m_buf = xocl(mem);
+  m_buf->get_buffer_object(m_kernel,m_argidx);
   m_set = true;
 }
 
-std::unique_ptr<kernel::argument> 
+std::unique_ptr<kernel::argument>
 kernel::image_argument::
 clone()
 {
   return xrt::make_unique<image_argument>(*this);
 }
 
-void 
+void
 kernel::image_argument::
 set(size_t size, const void* value)
 {
   throw std::runtime_error("not implemented");
 }
 
-std::unique_ptr<kernel::argument> 
+std::unique_ptr<kernel::argument>
 kernel::sampler_argument::
 clone()
 {
   return xrt::make_unique<sampler_argument>(*this);
 }
 
-void 
+void
 kernel::sampler_argument::
 set(size_t size, const void* value)
 {
@@ -249,7 +252,7 @@ kernel(program* prog, const std::string& name, const xclbin::symbol& symbol)
     case xclbin::symbol::arg::argtype::printf:
       if (m_printf_args.size())
         throw xocl::error(CL_INVALID_BINARY,"Only one printf argument allowed");
-      m_printf_args.emplace_back(argument::create(&arg));
+      m_printf_args.emplace_back(argument::create(&arg,this));
       break;
     case xclbin::symbol::arg::argtype::progvar:
     {
@@ -258,7 +261,7 @@ kernel(program* prog, const std::string& name, const xclbin::symbol& symbol)
         throw std::runtime_error
           ("progvar with address_qualifiler " + std::to_string(arg.address_qualifier)
            + " not implemented");
-      m_progvar_args.emplace_back(argument::create(&arg));
+      m_progvar_args.emplace_back(argument::create(&arg,this));
       if (arg.address_qualifier==1) {
         auto& pvar = m_progvar_args.back();
         auto mem = clCreateBuffer(get_context(),CL_MEM_PROGVAR,arg.memsize,nullptr,nullptr);
@@ -277,18 +280,18 @@ kernel(program* prog, const std::string& name, const xclbin::symbol& symbol)
                             [&nm](const argument_value_type& arg)
                             { return arg->get_name()==nm; });
       if (itr==m_rtinfo_args.end())
-        m_rtinfo_args.emplace_back(argument::create(&arg));
+        m_rtinfo_args.emplace_back(argument::create(&arg,this));
       else
         (*itr)->add(&arg);
       break;
     }
-    case xclbin::symbol::arg::argtype::indexed: 
+    case xclbin::symbol::arg::argtype::indexed:
     {
       assert(!arg.id.empty());
       auto idx  = std::stoul(arg.id,0,0);
       if (idx==m_indexed_args.size())
         // next argument
-        m_indexed_args.emplace_back(argument::create(&arg));
+        m_indexed_args.emplace_back(argument::create(&arg,this));
       else if (idx<m_indexed_args.size())
         // previous argument a second time (e.g. 229_vadd-long)
         // scalar vector, e.g. long2, long4, etc.
@@ -314,9 +317,9 @@ temp_get_symbol(program* prog, std::string name)
     static xclbin::symbol s;
     // set workgroup size to CL_DEVICE_MAX_WORK_GROUP_SIZE
     // this is a carry over from clCreateKernel where conformance
-    // mode is faking a kernel.  need to better understand that 
+    // mode is faking a kernel.  need to better understand that
     // part of the code and find another way
-    s.workgroupsize = 4096; 
+    s.workgroupsize = 4096;
     return s;
   }
 
@@ -367,5 +370,3 @@ get_instance_names() const
 }
 
 } // xocl
-
-

--- a/src/runtime_src/xocl/core/kernel.h
+++ b/src/runtime_src/xocl/core/kernel.h
@@ -23,6 +23,7 @@
 #include "xocl/xclbin/xclbin.h"
 
 #include "xrt/util/td.h"
+#include <limits>
 
 namespace xocl {
 
@@ -34,10 +35,10 @@ public:
    * class argument is a class hierarchy that represents a kernel
    * object argument constructed from xclbin::symbol::arg meta data.
    *
-   * The class is in flux, and will change much as upstream cu_ffa 
+   * The class is in flux, and will change much as upstream cu_ffa
    * and execution context are adapated.
    */
-  class argument 
+  class argument
   {
   public:
     using argtype = xclbin::symbol::arg::argtype;
@@ -56,8 +57,11 @@ public:
     { throw std::runtime_error("not implemented"); }
 
   public:
-    bool 
-    is_set() const 
+
+    argument(kernel* kernel) : m_kernel(kernel) {}
+
+    bool
+    is_set() const
     { return m_set; }
 
     void
@@ -80,26 +84,26 @@ public:
     /**
      * Get argument address qualifier
      *
-     * This is a simple translation of address space per 
+     * This is a simple translation of address space per
      * get_address_space
      */
-    cl_kernel_arg_address_qualifier 
+    cl_kernel_arg_address_qualifier
     get_address_qualifier() const;
 
     bool
-    is_indexed() const 
+    is_indexed() const
     { return get_argtype()==argtype::indexed; }
 
     bool
-    is_printf() const 
+    is_printf() const
     { return get_argtype()==argtype::printf; }
 
     bool
-    is_progvar() const 
+    is_progvar() const
     { return get_argtype()==argtype::progvar; }
 
     bool
-    is_rtinfo() const 
+    is_rtinfo() const
     { return get_argtype()==argtype::rtinfo; }
 
     virtual ~argument() {}
@@ -113,19 +117,19 @@ public:
      * Asserts that the argument has been set, otherwise
      * it makes no sense to clone it.
      */
-    virtual std::unique_ptr<argument> 
+    virtual std::unique_ptr<argument>
     clone() = 0;
 
     /**
      * Set an argument (clSetKernelArg) to some value.
      */
-    virtual void 
+    virtual void
     set(size_t sz, const void* arg) = 0;
 
     /**
      * Set an svm argument (clSetKernelArgSVMPointer) to some value.
      */
-    virtual void 
+    virtual void
     set_svm(size_t sz, const void* arg)
     { throw std::runtime_error("not implemented"); }
 
@@ -140,20 +144,20 @@ public:
      * @return
      *   Argument size after component was added.
      */
-    virtual size_t 
+    virtual size_t
     add(arginfo_type arg)
     { throw xocl::error(CL_INVALID_BINARY,"Cannot add component to argument"); }
 
     /**
      */
-    virtual size_t 
-    get_address_space() const 
+    virtual size_t
+    get_address_space() const
     { throw std::runtime_error("not implemented"); }
 
     /**
      * Get argument name
      */
-    virtual std::string 
+    virtual std::string
     get_name() const
     { throw std::runtime_error("not implemented"); }
 
@@ -166,8 +170,8 @@ public:
      *   xocl::memory pointer or nullptr if argument is not backed
      *   by a cl_mem object
      */
-    virtual memory* 
-    get_memory_object() const 
+    virtual memory*
+    get_memory_object() const
     { return nullptr; }
 
     /**
@@ -178,21 +182,21 @@ public:
      * @return
      *   void* pointer or nullptr if argument is not svm
      */
-    virtual void* 
-    get_svm_object() const 
+    virtual void*
+    get_svm_object() const
     { throw std::runtime_error("not implemented"); }
 
     /**
-     * 
+     *
      */
-    virtual size_t 
-    get_size() const 
+    virtual size_t
+    get_size() const
     { return 0; }
 
     /**
      */
-    virtual const void* 
-    get_value() const 
+    virtual const void*
+    get_value() const
     { return nullptr; }
 
     virtual const std::string
@@ -210,22 +214,24 @@ public:
     /**
      * Get component argument info range
      */
-    virtual arginfo_range_type 
+    virtual arginfo_range_type
     get_arginfo_range() const
     { throw std::runtime_error("not implemented"); }
 
     static std::unique_ptr<kernel::argument>
-    create(arginfo_type arg);
+      create(arginfo_type arg,kernel* kernel);
 
   protected:
-    unsigned long m_argidx = -1;
+    kernel* m_kernel = nullptr;
+    unsigned long m_argidx = std::numeric_limits<unsigned long>::max();
     bool m_set = false;
   };
 
   class scalar_argument : public argument
   {
   public:
-    scalar_argument(arginfo_type arg) : m_sz(arg->hostsize)
+    scalar_argument(arginfo_type arg,kernel* kernel)
+      : argument(kernel), m_sz(arg->hostsize)
     {
       m_components.push_back(arg);
     }
@@ -238,7 +244,7 @@ public:
     virtual size_t get_size() const { return m_sz; }
     virtual const void* get_value() const { return m_value.data(); }
     virtual const std::string get_string_value() const;
-    virtual arginfo_range_type get_arginfo_range() const 
+    virtual arginfo_range_type get_arginfo_range() const
     { return arginfo_range_type(m_components.begin(),m_components.end()); }
   private:
     size_t m_sz;
@@ -251,7 +257,8 @@ public:
   class global_argument : public argument
   {
   public:
-    global_argument(arginfo_type arg) : m_arg_info(arg) {}
+    global_argument(arginfo_type arg, kernel* kernel)
+      : argument(kernel), m_arg_info(arg) {}
     virtual argtype get_argtype() const { return m_arg_info->atype; }
     virtual std::string get_name() const { return m_arg_info->name; }
     virtual size_t get_address_space() const { return 1; }
@@ -264,7 +271,7 @@ public:
     virtual const void* get_value() const { return m_buf.get(); }
     virtual size_t get_baseaddr() const { return m_arg_info->baseaddr; }
     virtual std::string get_linkage() const { return m_arg_info->linkage; }
-    virtual arginfo_range_type get_arginfo_range() const 
+    virtual arginfo_range_type get_arginfo_range() const
     { return arginfo_range_type(&m_arg_info,&m_arg_info+1); }
   private:
     ptr<memory> m_buf;   // retain ownership
@@ -276,7 +283,8 @@ public:
   class progvar_argument : public global_argument
   {
   public:
-    progvar_argument(arginfo_type arg) : global_argument(arg) {}
+  progvar_argument(arginfo_type arg, kernel* kernel)
+    : m_kernel(kernel), global_argument(arg) {}
   private:
   };
 #endif
@@ -284,13 +292,14 @@ public:
   class local_argument : public argument
   {
   public:
-    local_argument(arginfo_type arg) : m_arg_info(arg) {}
+    local_argument(arginfo_type arg, kernel* kernel)
+      : argument(kernel), m_arg_info(arg) {}
     virtual argtype get_argtype() const { return m_arg_info->atype; }
     virtual std::string get_name() const { return m_arg_info->name; }
     virtual size_t get_address_space() const { return 3; }
     virtual std::unique_ptr<argument> clone();
     virtual void set(size_t sz, const void* arg);
-    virtual arginfo_range_type get_arginfo_range() const 
+    virtual arginfo_range_type get_arginfo_range() const
     { return arginfo_range_type(&m_arg_info,&m_arg_info+1); }
   private:
     arginfo_type m_arg_info;
@@ -299,7 +308,8 @@ public:
   class constant_argument : public argument
   {
   public:
-    constant_argument(arginfo_type arg) : m_arg_info(arg) {}
+    constant_argument(arginfo_type arg, kernel* kernel)
+      : argument(kernel), m_arg_info(arg) {}
     virtual std::string get_name() const { return m_arg_info->name; }
     virtual argtype get_argtype() const { return m_arg_info->atype; }
     virtual size_t get_address_space() const { return 2; }
@@ -308,7 +318,7 @@ public:
     virtual memory* get_memory_object() const { return m_buf.get(); }
     virtual size_t get_size() const { return sizeof(memory*); }
     virtual const void* get_value() const { return m_buf.get(); }
-    virtual arginfo_range_type get_arginfo_range() const 
+    virtual arginfo_range_type get_arginfo_range() const
     { return arginfo_range_type(&m_arg_info,&m_arg_info+1); }
   private:
     ptr<memory> m_buf;  // retain ownership
@@ -318,7 +328,8 @@ public:
   class image_argument : public argument
   {
   public:
-    image_argument(arginfo_type arg) {}
+    image_argument(arginfo_type arg, kernel* kernel)
+      : argument(kernel) {}
     virtual std::unique_ptr<argument> clone();
     virtual void set(size_t sz, const void* arg);
   };
@@ -326,7 +337,8 @@ public:
   class sampler_argument : public argument
   {
   public:
-    sampler_argument(arginfo_type arg) {}
+    sampler_argument(arginfo_type arg, kernel* kernel)
+      : argument(kernel) {}
     virtual std::unique_ptr<argument> clone();
     virtual void set(size_t sz, const void* arg);
   };
@@ -400,7 +412,7 @@ public:
   /**
    * Return list of instances (CUs) in this kernel
    *
-   * This function directly access the kernel symbol to 
+   * This function directly access the kernel symbol to
    * extract the names of the embedded kernel instances
    *
    * @return
@@ -422,7 +434,7 @@ public:
   }
 
   /**
-   * Get compile work group size per xclbin 
+   * Get compile work group size per xclbin
    */
   range<const size_t*>
   get_compile_wg_size_range() const
@@ -431,7 +443,7 @@ public:
   }
 
   /**
-   * Get max work group size per xclbin 
+   * Get max work group size per xclbin
    */
   range<const size_t*>
   get_max_wg_size_range() const
@@ -503,7 +515,7 @@ public:
   {
     return range<argument_iterator_type>(m_progvar_args.begin(),m_progvar_args.end());
   }
-  
+
   /**
    * @return Range of printf arguments
    */
@@ -514,7 +526,7 @@ public:
   }
 
   /**
-   * Get rtinfo args.  
+   * Get rtinfo args.
    *
    * This is used by cu_ffa, it does contain printf args, but only the
    * static part of the printf is used in cu_ffa.  Feels awkward, but
@@ -550,5 +562,3 @@ private:
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -46,7 +46,7 @@ public:
   virtual ~memory();
 
   unsigned int
-  get_uid() const 
+  get_uid() const
   {
     return m_uid;
   }
@@ -64,7 +64,7 @@ public:
   }
 
   const memory_extension_flags_type
-  get_ext_flags() const 
+  get_ext_flags() const
   {
     return m_ext_flags;
   }
@@ -76,7 +76,7 @@ public:
   }
 
   context*
-  get_context() const 
+  get_context() const
   {
     return m_context.get();
   }
@@ -90,8 +90,8 @@ public:
   // Derived classes accessors
   // May be structured differently when _xcl_mem is eliminated
   virtual size_t
-  get_size() const 
-  { 
+  get_size() const
+  {
     throw std::runtime_error("get_size on bad object");
   }
 
@@ -100,17 +100,17 @@ public:
    *
    * @param device
    *   Device to check allocation on
-   * @return bitmask identifying matching memory, or 0 if not 
+   * @return bitmask identifying matching memory, or 0 if not
    *   allocated on device.
    */
   virtual memidx_bitmask_type
   get_memidx(const device* d) const;
 
   /**
-   * Get memory index of DDR bank where this memory object is allocated 
+   * Get memory index of DDR bank where this memory object is allocated
    * if owning context has one device only.
    *
-   * @return bitmask identifying matching memory banks, or 0 if not 
+   * @return bitmask identifying matching memory banks, or 0 if not
    *   allocated on device or there are multiple devices in context.
    */
   virtual memidx_bitmask_type
@@ -126,7 +126,7 @@ public:
   try_get_address_bank(uint64_t& addr, std::string& bank) const;
 
   virtual void*
-  get_host_ptr() const 
+  get_host_ptr() const
   {
     throw std::runtime_error("get_host_ptr called on bad object");
   }
@@ -141,14 +141,14 @@ public:
   get_type() const = 0;
 
   virtual memory*
-  get_sub_buffer_parent() const 
-  { 
+  get_sub_buffer_parent() const
+  {
     //throw std::runtime_error("get_sub_buffer_parent called on bad object");
     return nullptr;
   }
 
   virtual size_t
-  get_sub_buffer_offset() const 
+  get_sub_buffer_offset() const
   {
     throw std::runtime_error("get_sub_buffer_offset called on bad object");
   }
@@ -160,36 +160,36 @@ public:
   }
 
   virtual size_t
-  get_image_data_offset() const 
+  get_image_data_offset() const
   {
     throw std::runtime_error("get_image_offset called on bad object");
   }
 
   virtual size_t
-  get_image_width() const 
+  get_image_width() const
   {
     throw std::runtime_error("get_image_width called on bad object");
   }
 
   virtual size_t
-  get_image_height() const 
+  get_image_height() const
   {
     throw std::runtime_error("get_image_height called on bad object");
   }
 
   virtual size_t
-  get_image_depth() const 
+  get_image_depth() const
   {
     throw std::runtime_error("get_image_depth called on bad object");
   }
 
   virtual size_t
-  get_image_bytes_per_pixel() const 
+  get_image_bytes_per_pixel() const
   {
     throw std::runtime_error("get_bytes_per_pixel called on bad object");
   }
 
-  virtual size_t 
+  virtual size_t
   get_image_row_pitch() const
   {
     throw std::runtime_error("get_image_row_pitch called on bad object");
@@ -202,26 +202,26 @@ public:
   }
 
   virtual void
-  set_image_row_pitch(size_t pitch) 
+  set_image_row_pitch(size_t pitch)
   {
     throw std::runtime_error("set_image_row_pitch called on bad object");
   }
 
   virtual void
-  set_image_slice_pitch(size_t pitch) 
+  set_image_slice_pitch(size_t pitch)
   {
     throw std::runtime_error("set_image_slice_pitch called on bad object");
   }
 
   virtual void*
-  get_pipe_host_ptr() const 
+  get_pipe_host_ptr() const
   {
     throw std::runtime_error("get_pipe_host_ptr called on bad object");
   }
 
   virtual const pipe_property_type
-  get_pipe_properties() const 
-  { 
+  get_pipe_properties() const
+  {
     throw std::runtime_error("get_pipe_properties called on bad object");
   }
 
@@ -282,6 +282,16 @@ public:
   get_buffer_object(device* device);
 
   /**
+   * Get or create the device buffer object for kernel and argument
+   *
+   * This function requires that the context in which the buffer is
+   * created has exactly one device.  CUs memory connection must
+   * match for all CUs associated with argument kernel.
+   */
+  buffer_object_handle
+  get_buffer_object(kernel* kernel, unsigned long argidx);
+
+  /**
    * Get the buffer object on argument device or error out if none
    * exists.
    *
@@ -290,9 +300,9 @@ public:
    * throws std::runtime_error.
    *
    * @param device
-   *   The device from which to get a buffer object.  
+   *   The device from which to get a buffer object.
    * @return
-   *   The buffer object associated with the device, or 
+   *   The buffer object associated with the device, or
    *   std::runtime_error if no buffer object exists.
    */
   buffer_object_handle
@@ -302,7 +312,7 @@ public:
    * Get the buffer object on argument device or nullptr if none
    *
    * This function return the buffer object that is associated
-   * argument device. If a buffer object does not exist the 
+   * argument device. If a buffer object does not exist the
    * function returns nullptr;
    *
    * @param device
@@ -388,7 +398,7 @@ public:
    * Clear resident devices
    */
   void
-  clear_resident() 
+  clear_resident()
   {
     std::lock_guard<std::mutex> lk(m_boh_mutex);
     m_resident.clear();
@@ -403,7 +413,7 @@ public:
 private:
   unsigned int m_uid = 0;
   ptr<context> m_context;
-  
+
   memory_flags_type m_flags = 0;
   memory_extension_flags_type m_ext_flags = 0;
 
@@ -442,7 +452,7 @@ public:
   }
 
   virtual cl_mem_object_type
-  get_type() const 
+  get_type() const
   {
     return CL_MEM_OBJECT_BUFFER;
   }
@@ -476,7 +486,7 @@ class sub_buffer : public buffer
 public:
   sub_buffer(memory* parent,cl_mem_flags flags,size_t offset, size_t sz)
   : buffer(parent->get_context(),flags,sz,
-           parent->get_host_ptr() 
+           parent->get_host_ptr()
            ? static_cast<char*>(parent->get_host_ptr())+offset
            : nullptr)
   , m_parent(parent),m_offset(offset)
@@ -533,7 +543,7 @@ public:
   }
 private:
   void
-  make_resident(const device* device) 
+  make_resident(const device* device)
   {
     memory::get_buffer_object(const_cast<xocl::device*>(device));
     memory::set_resident(device);
@@ -571,7 +581,7 @@ public:
   }
 
   virtual cl_mem_object_type
-  get_type() const 
+  get_type() const
   {
     return m_image_type;
   }
@@ -583,36 +593,36 @@ public:
   }
 
   virtual size_t
-  get_image_data_offset() const 
+  get_image_data_offset() const
   {
     return sizeof(image_info);
   }
 
   virtual size_t
-  get_image_width() const 
+  get_image_width() const
   {
     return m_width;
   }
 
   virtual size_t
-  get_image_height() const 
+  get_image_height() const
   {
     return m_height;
   }
 
   virtual size_t
-  get_image_depth() const 
+  get_image_depth() const
   {
     return m_depth;
   }
 
   virtual size_t
-  get_image_bytes_per_pixel() const 
+  get_image_bytes_per_pixel() const
   {
     return m_bpp;
   }
 
-  virtual size_t 
+  virtual size_t
   get_image_row_pitch() const
   {
     return m_row_pitch;
@@ -625,13 +635,13 @@ public:
   }
 
   virtual void
-  set_image_row_pitch(size_t pitch) 
+  set_image_row_pitch(size_t pitch)
   {
     m_row_pitch = pitch;
   }
 
   virtual void
-  set_image_slice_pitch(size_t pitch) 
+  set_image_slice_pitch(size_t pitch)
   {
     m_slice_pitch = pitch;
   }
@@ -688,7 +698,7 @@ public:
   }
 
   virtual cl_mem_object_type
-  get_type() const 
+  get_type() const
   {
     return CL_MEM_OBJECT_PIPE;
   }
@@ -727,5 +737,3 @@ private:
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -1054,7 +1054,7 @@ public:
     return bitmask;
   }
 
-  int32_t
+  xocl::xclbin::memidx_type
   mem_address_to_first_memidx(addr_type addr) const
   {
     // m_membanks are sorted decreasing based on ddr base addresses
@@ -1073,7 +1073,7 @@ public:
   }
 
   std::string
-  memidx_to_banktag(int32_t memidx) const 
+  memidx_to_banktag(xocl::xclbin::memidx_type memidx) const 
   {
     if (!m_mem)
       return "";
@@ -1083,7 +1083,7 @@ public:
     return reinterpret_cast<const char*>(m_mem->m_mem_data[memidx].m_tag);
   }
 
-  int32_t
+  xocl::xclbin::memidx_type
   banktag_to_memidx(const std::string& banktag) const
   {
     for (auto& mb : m_membanks)
@@ -1192,15 +1192,15 @@ struct xclbin::impl
   mem_address_to_memidx(addr_type memaddr) const
   { return m_sections.mem_address_to_memidx(memaddr); }
 
-  int32_t
+  memidx_type
   mem_address_to_first_memidx(addr_type memaddr) const
   { return m_sections.mem_address_to_first_memidx(memaddr); }
 
   std::string
-  memidx_to_banktag(int32_t memidx) const
+  memidx_to_banktag(memidx_type memidx) const
   { return m_sections.memidx_to_banktag(memidx); }
 
-  int32_t
+  memidx_type
   banktag_to_memidx(const std::string& banktag) const
   { return m_sections.banktag_to_memidx(banktag); }
 
@@ -1399,7 +1399,7 @@ mem_address_to_memidx(addr_type memaddr) const
   return m_impl->mem_address_to_memidx(memaddr);
 }
 
-int32_t
+xclbin::memidx_type
 xclbin::
 mem_address_to_first_memidx(addr_type memaddr) const
 {
@@ -1408,12 +1408,12 @@ mem_address_to_first_memidx(addr_type memaddr) const
 
 std::string
 xclbin::
-memidx_to_banktag(int32_t bankidx) const
+memidx_to_banktag(memidx_type bankidx) const
 {
   return m_impl->memidx_to_banktag(bankidx);
 }
 
-int32_t
+xclbin::memidx_type
 xclbin::
 banktag_to_memidx(const std::string& tag) const
 {

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -57,6 +57,7 @@ class xclbin
 public:
   using addr_type = uint64_t;
   using memidx_bitmask_type = std::bitset<24>;
+  using memidx_type = int32_t;
 
   enum class target_type{ bin,x86,zynqps7,csim,cosim,hwem,invalid};
 
@@ -341,7 +342,7 @@ public:
    *   index in the range 0,1,2...31
    *   -1 if no match
   */
-  int32_t
+  memidx_type
   mem_address_to_first_memidx(addr_type addr) const;
 
   /**
@@ -353,7 +354,7 @@ public:
    *   Tag name for memory idx
    */
   std::string
-  memidx_to_banktag(int32_t memidx) const;
+  memidx_to_banktag(memidx_type memidx) const;
     
   /**
    * Get the memory index with the specified tag.
@@ -363,7 +364,7 @@ public:
    * @return
    *   Tag memory index corresponding to tag name
    */
-  int32_t
+  memidx_type
   banktag_to_memidx(const std::string& tag) const;
 
   ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This enhances current support without requiring single master connection for each CU.  A CU can now be connected to multiple memory banks, device buffer allocation happens as part of clSetKernelArg,
where enough information is available to compute which bank to use.

No changes required for exisitng code.

To use the enhancement, the host code should call clSetKernelArg immediately after clCreateBuffer and before clEnqueueMigrateMemObjects. This implies that a pipe-lined or ping-pong application should allocate a working set of buffers and kernel objects upfront and reuse these objects in the loop body without calling clCreateKernel and clSetKernelArg in the body of the loop.