### PR TITLE
xbsak top

### DIFF
--- a/src/runtime_src/driver/include/xclhal2.h
+++ b/src/runtime_src/driver/include/xclhal2.h
@@ -211,6 +211,8 @@ struct xclDeviceUsage {
     unsigned ddrBOAllocated[8];
     unsigned totalContexts;
     uint64_t xclbinId[4];
+    unsigned dma_channel_cnt;
+    unsigned mm_channel_cnt;
 };
 
 struct xclBOProperties {

--- a/src/runtime_src/driver/xclng/tools/xbsak_gem/Makefile
+++ b/src/runtime_src/driver/xclng/tools/xbsak_gem/Makefile
@@ -37,7 +37,7 @@ all : $(EXENAME)
 	$(CXX) $(CXXFLAGS) $(MYCFLAGS) $(MYCXXFLAGS) -c -MM $< -o $(patsubst %.o, %.d, $@)
 
 $(EXENAME): $(OBJS) $(HAL_LIBNAME)
-	$(CXX) -o $@ $(OBJS) $(LDFLAGS) $(HAL_LIBNAME) -lrt
+	$(CXX) -o $@ $(OBJS) $(LDFLAGS) $(HAL_LIBNAME) -lrt -lncurses
 
 clean:
 	rm -rf *.o *.d $(EXENAME)

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -821,6 +821,8 @@ int xocl::XOCLShim::xclGetUsageInfo(xclDeviceUsage *info)
         info->ddrMemUsed[i] = stat.mm[i].memory_usage;
         info->ddrBOAllocated[i] = stat.mm[i].bo_count;
     }
+    info->dma_channel_cnt = stat.dma_channel_count;
+    info->mm_channel_cnt = stat.mm_channel_count;
     return 0;
 }
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/xbsak.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/xbsak.h
@@ -785,10 +785,16 @@ public:
         }
         return 0;
     }
+
+    int usageInfo(xclDeviceUsage& devstat) const {
+        return xclGetUsageInfo(m_handle, &devstat);
+    }
 };
 
 void printHelp(const std::string& exe);
 int xclXbsak(int argc, char *argv[]);
+int xclTop(int argc, char *argv[]);
+std::unique_ptr<xcldev::device> xclGetDevice(int index);
 
 } // end namespace xcldev
 


### PR DESCRIPTION
This is to support xbsak top functionality:
Usage: xbsak top [-i interval] [-d device]
Default interval is 1 second and device index is 0.

Output is something like below for now:
Total DMA Transfer Metrics:
  Chan[0].h2c:  8531969 KB
  Chan[0].c2h:  8388610 KB
  Chan[1].h2c:  8245248 KB
  Chan[1].c2h:  8388608 KB

Device Memory Usage:
  Bank[0].mem:  0 KB
  Bank[0].bo:  0
  Bank[1].mem:  0 KB
  Bank[1].bo:  0
  Bank[2].mem:  0 KB
  Bank[2].bo:  0
  Bank[3].mem:  0 KB
  Bank[3].bo:  0

The content and format is subject to change/evolve in the future.
