### PR TITLE
Fix kernel panic while unload p2p memory region in CentOS 7.3 and beyond

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -106,6 +106,7 @@ struct xocl_dev	{
 	/*should be removed after mailbox is supported */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
 	struct percpu_ref ref;
+  struct completion cmp;
 #endif
 	/*should be removed after mailbox is supported */
 	u64			        unique_id_last_bitstream;


### PR DESCRIPTION
wait for percpu_ref release completion before percpu_ref can exit