### PR TITLE
 Add makefiles to build xclbincat and xclbinsplit

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 set_target_properties(xilinxopencl PROPERTIES LINKER_LANGUAGE CXX)
 add_compile_options("-fPIC")
 add_subdirectory(xdp)
+#add_subdirectory(tools/xclbin)
 
 add_compile_options("-Wall" "-Werror")
 add_subdirectory(impl)

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -1,0 +1,25 @@
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../driver/include
+  )
+
+file(GLOB XCLBINCAT_FILES
+  "xclbincat*.cxx"
+  "xclbincat*.h"
+  "xclbindata.*"
+  "xclbinutil.*"
+  )
+
+set(XCLBINCAT_SRC ${XCLBINCAT_FILES})
+add_executable(xclbincat ${XCLBINCAT_SRC})
+
+file(GLOB XCLBINSPLIT_FILES
+  "xclbinsplit*.cxx"
+  "xclbinsplit*.h"
+  "xclbindata.*"
+  "xclbinutil.*"
+  )
+
+set(XCLBINSPLIT_SRC ${XCLBINSPLIT_FILES})
+add_executable(xclbinsplit ${XCLBINSPLIT_SRC})
+
+install (TARGETS xclbincat xclbinsplit RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)


### PR DESCRIPTION
Currently disabled.  Enable by uncommenting following line from
runtime_src/CMakeLists.txt

This is for #77