### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/src/runtime_src/xclbin/binary.h
+++ b/src/runtime_src/xclbin/binary.h
@@ -31,7 +31,7 @@ namespace xclbin {
 
 using data_range = std::pair<const char*, const char*>;
 
-inline bool 
+inline bool
 valid_range(const xclbin::data_range& range)
 {
   return (range.first!=nullptr && range.second!=nullptr && range.first < range.second);
@@ -39,9 +39,10 @@ valid_range(const xclbin::data_range& range)
 
 class error : public std::runtime_error
 {
- public:
+public:
+  explicit
   error(const std::string& what = "")
-    : std::runtime_error(what)
+  : std::runtime_error(what)
   {}
 };
 
@@ -49,10 +50,10 @@ class error : public std::runtime_error
  * An xcl binary is managed by the binary class.
  *
  * This class can present any binary xclbin version.  The class API
- * may have functions that are valid for a particular version of 
+ * may have functions that are valid for a particular version of
  * an xclbin only.  If an invalid function is called, it will throw
  * an xclbin::error exception.
- * 
+ *
  * Then entire xclbin binary data is copied into this class, any data
  * returned through APIs maybe referencing a range of the data
  * maintained by the class, so the binary object must stay alive while
@@ -84,7 +85,7 @@ public:
     : m_content(nullptr)
   {}
 
-  binary(const binary& rhs) 
+  binary(const binary& rhs)
     : m_content(rhs.m_content)
   {}
 
@@ -92,10 +93,11 @@ public:
    * Construct from xclbin in memory.
    *
    * The ownership of the data is transferred to this class object.
-   * 
+   *
    * @param xb
    *  xclbin file read into memory
    */
+  explicit
   binary(std::vector<char>&& xb);
 
   binary&
@@ -127,13 +129,13 @@ public:
   data_range
   connectivity_data() const { return m_content->connectivity_data(); }
 
-  data_range 
+  data_range
   mem_topology_data() const { return m_content->mem_topology_data(); }
 
-  data_range 
+  data_range
   ip_layout_data() const { return m_content->ip_layout_data(); }
 
-  data_range 
+  data_range
   clk_freq_data() const { return m_content->clk_freq_data(); }
 };
 
@@ -143,5 +145,3 @@ public:
 
 
 #endif
-
-

--- a/src/runtime_src/xclbin/xclbin2.cpp
+++ b/src/runtime_src/xclbin/xclbin2.cpp
@@ -37,6 +37,7 @@ struct xclbin2 : public binary::impl
   const axlf* m_axlf = nullptr;
   const axlf_header* m_header = nullptr;
 
+  explicit
   xclbin2(std::vector<char>&& xb)
     : m_xclbin(std::move(xb)), m_raw(&m_xclbin[0])
     , m_axlf(reinterpret_cast<const axlf*>(m_raw))
@@ -152,7 +153,7 @@ create_xclbin2(std::vector<char>&& xb)
   if (xb.size() < hdr->m_length)
     throw error ("axlf length mismatch");
 
-  // Ok we are probably good, any throws now breaks 
+  // Ok we are probably good, any throws now breaks
   // strong exception safety guarantee as xb is being
   // moved
   return xrt::make_unique<xclbin2>(std::move(xb));
@@ -160,6 +161,3 @@ create_xclbin2(std::vector<char>&& xb)
 
 
 }
-
-
-

--- a/src/runtime_src/xocl/api/clCreateImage.cpp
+++ b/src/runtime_src/xocl/api/clCreateImage.cpp
@@ -38,7 +38,7 @@ namespace {
 // emulation mode before clCreateProgramWithBinary->loadBinary has
 // been called.  The call to loadBinary can end up switching the
 // device from swEm to hwEm.
-// 
+//
 // In non emulation mode it is sufficient to check that the context
 // has only one device.
 static xocl::device*
@@ -68,7 +68,7 @@ validImageFormatOrError(const cl_image_format* image_format)
 
   auto type = image_format->image_channel_data_type;
   auto order = image_format->image_channel_order;
-  
+
   switch (order) {
   // CL_INTENSITY This format can only be used if channel data type =
   // CL_UNORM_INT8, CL_UNORM_INT16, CL_SNORM_INT8, CL_SNORM_INT16,
@@ -158,7 +158,7 @@ validImageFormatOrError(const cl_image_format* image_format)
 }
 
 static void
-validImageDescriptorOrError(const cl_image_desc*   image_desc, 
+validImageDescriptorOrError(const cl_image_desc*   image_desc,
                             void*                  host_ptr)
 {
   auto type = image_desc->image_type;
@@ -181,7 +181,7 @@ validImageDescriptorOrError(const cl_image_desc*   image_desc,
       type != CL_MEM_OBJECT_IMAGE2D_ARRAY && type != CL_MEM_OBJECT_IMAGE3D)
     throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->type");
 
-  // image_width The width of the image in pixels. 
+  // image_width The width of the image in pixels.
   // For a 2D image and image array, the image width must be a value
   // >= 1 and ≤ CL_DEVICE_IMAGE2D_MAX_WIDTH.
   if (type == CL_MEM_OBJECT_IMAGE2D || type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
@@ -189,7 +189,7 @@ validImageDescriptorOrError(const cl_image_desc*   image_desc,
       throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->image_width");
 
   // For a 3D image, the image width must be a value ≥ 1 and ≤
-  // CL_DEVICE_IMAGE3D_MAX_WIDTH. 
+  // CL_DEVICE_IMAGE3D_MAX_WIDTH.
   if (type == CL_MEM_OBJECT_IMAGE3D)
     if (width < 1 /* || width > CL_DEVICE_IMAGE3D_MAX_WIDTH */)
       throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->image_width");
@@ -199,7 +199,7 @@ validImageDescriptorOrError(const cl_image_desc*   image_desc,
   if (type == CL_MEM_OBJECT_IMAGE1D_BUFFER)
     if (width < 1 /* || width > CL_DEVICE_IMAGE_MAX_BUFFER_SIZE */)
       throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->image_width");
-  
+
   // For a 1D image and 1D image array, the image width must be a
   // value ≥ 1 and ≤ CL_DEVICE_IMAGE2D_MAX_WIDTH.
   if (type == CL_MEM_OBJECT_IMAGE1D || type == CL_MEM_OBJECT_IMAGE1D_ARRAY)
@@ -207,7 +207,7 @@ validImageDescriptorOrError(const cl_image_desc*   image_desc,
       throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->image_width");
 
   // image_height The height of the image in pixels. This is only used
-  // if the image is a 2D or 3D image, or a 2D image array. 
+  // if the image is a 2D or 3D image, or a 2D image array.
   // For a 2D image or image array, the image height must be a value ≥
   // 1 and ≤ CL_DEVICE_IMAGE2D_MAX_HEIGHT.
   if (type == CL_MEM_OBJECT_IMAGE2D || type == CL_MEM_OBJECT_IMAGE2D_ARRAY)
@@ -265,7 +265,7 @@ validImageDescriptorOrError(const cl_image_desc*   image_desc,
     throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->image_slice_pitch");
   /* ??? */
 
-  
+
   // num_mip_level, num_samples Must be 0.
   if (num_mip_levels || num_samples)
     throw xocl::error(CL_INVALID_IMAGE_DESCRIPTOR,"bad image_desc->num_mip_levels or num_samples");
@@ -299,7 +299,7 @@ static void
 validOrError(cl_context             context,
              cl_mem_flags           flags,
              const cl_image_format* image_format,
-             const cl_image_desc*   image_desc, 
+             const cl_image_desc*   image_desc,
              void*                  host_ptr,
              cl_int*                errcode_ret)
 
@@ -370,8 +370,8 @@ validOrError(cl_context             context,
   /* ??? */
 }
 
-static unsigned 
-getBytesPerPixel(const cl_image_format *format) 
+static unsigned
+getBytesPerPixel(const cl_image_format *format)
 {
   unsigned bpp = 0;
   const uint32_t type = format->image_channel_data_type;
@@ -380,7 +380,7 @@ getBytesPerPixel(const cl_image_format *format)
   switch(type) {
   case CL_SNORM_INT8:
     bpp = 1;
-    break; 
+    break;
   case CL_SNORM_INT16:
     bpp = 2;
     break;
@@ -394,6 +394,7 @@ getBytesPerPixel(const cl_image_format *format)
   case CL_UNORM_SHORT_565:
   case CL_UNORM_SHORT_555:
     bpp = 2;
+    break;
   case CL_UNORM_INT_101010:
     bpp = 4;
     break;
@@ -406,13 +407,13 @@ getBytesPerPixel(const cl_image_format *format)
   case CL_SIGNED_INT32:
     bpp = 4;
     break;
-  case CL_UNSIGNED_INT8:	
+  case CL_UNSIGNED_INT8:
     bpp = 1;
     break;
   case CL_UNSIGNED_INT16:
     bpp = 2;
     break;
-  case CL_UNSIGNED_INT32:	
+  case CL_UNSIGNED_INT32:
     bpp = 4;
     break;
   case CL_HALF_FLOAT:
@@ -426,29 +427,29 @@ getBytesPerPixel(const cl_image_format *format)
   }
 
   switch (order) {
-    case CL_R: 
+    case CL_R:
     case CL_Rx:
-    case CL_A: 
+    case CL_A:
       break;
     case CL_INTENSITY:
     case CL_LUMINANCE:
       break;
-    case CL_RA: 
+    case CL_RA:
     case CL_RGx:
-    case CL_RG: 
-      bpp *= 2; 
+    case CL_RG:
+      bpp *= 2;
       break;
     case CL_RGB:
     case CL_RGBx:
       break;
-    case CL_RGBA: 
-      bpp *= 4; 
+    case CL_RGBA:
+      bpp *= 4;
       break;
     case CL_ARGB:
     case CL_BGRA:
       bpp *= 4;
       break;
-    default: 
+    default:
       throw xocl::error(CL_INVALID_IMAGE_FORMAT_DESCRIPTOR, "clCreateImage");
   }
 
@@ -459,7 +460,7 @@ static cl_mem
 mkImageCore (cl_context context,
 	cl_mem_flags flags,
 	const cl_image_format * format,
-	const cl_image_desc * desc, 
+	const cl_image_desc * desc,
 	const cl_mem_object_type image_type,
 	size_t w,
 	size_t h,
@@ -471,9 +472,9 @@ mkImageCore (cl_context context,
 	cl_int *     errcode_ret)
 {
     if (xocl::config::api_checks()) {
-	if(w==0) 
+	if(w==0)
 	    throw xocl::error(CL_INVALID_IMAGE_SIZE, "clCreateImage");
-	
+
 	if(h==0) {
 	    if((image_type != CL_MEM_OBJECT_IMAGE1D &&
 			image_type != CL_MEM_OBJECT_IMAGE1D_ARRAY &&
@@ -532,22 +533,22 @@ mkImageCore (cl_context context,
     //Initialize the size.
     sz = adjusted_row_pitch * adjusted_h * depth;
 
-    if(image_type == CL_MEM_OBJECT_IMAGE1D_BUFFER) 
+    if(image_type == CL_MEM_OBJECT_IMAGE1D_BUFFER)
 	throw xocl::error(CL_IMAGE_FORMAT_NOT_SUPPORTED, "clCreateImage: Image1D buffer");
 
-    if (image_type == CL_MEM_OBJECT_IMAGE2D && buffer)  
+    if (image_type == CL_MEM_OBJECT_IMAGE2D && buffer)
 	throw xocl::error(CL_IMAGE_FORMAT_NOT_SUPPORTED, "clCreateImage: Image2D buffer");
 
     if(user_ptr)
 	throw xocl::error(CL_IMAGE_FORMAT_NOT_SUPPORTED, "clCreateImage: Image1D buffer");
 
     //cxt, flags, sz, w, h, depth , row, slice, "image_type", *format, xlnx_fmt, bpp
-    auto ubuffer = xrt::make_unique<xocl::image>(xocl::xocl(context),flags,sz,w,h,depth, 
+    auto ubuffer = xrt::make_unique<xocl::image>(xocl::xocl(context),flags,sz,w,h,depth,
 	    adjusted_row_pitch,adjusted_slice_pitch,bpp,image_type,*format,user_ptr);
 
     cl_mem image = ubuffer.get();
 
-    if (image_type == CL_MEM_OBJECT_IMAGE1D || image_type == CL_MEM_OBJECT_IMAGE2D 
+    if (image_type == CL_MEM_OBJECT_IMAGE1D || image_type == CL_MEM_OBJECT_IMAGE2D
 	    || image_type == CL_MEM_OBJECT_IMAGE1D_BUFFER)
 	adjusted_slice_pitch = 0;
 
@@ -582,7 +583,7 @@ static cl_mem
 mkImageFromBuffer(cl_context             context,
                   cl_mem_flags           flags,
                   const cl_image_format* format,
-                  const cl_image_desc*   desc, 
+                  const cl_image_desc*   desc,
                   cl_int*                errcode_ret)
 {
   //This will call mkImageCore() function after modifying the arguments of desc.
@@ -590,18 +591,18 @@ mkImageFromBuffer(cl_context             context,
   return nullptr;
 }
 
-static cl_mem 
+static cl_mem
 mkImage(cl_context             context,
 	cl_mem_flags           flags,
 	const cl_image_format* format,
-	const cl_image_desc*   desc, 
+	const cl_image_desc*   desc,
 	void*                  host_ptr,
 	cl_int*                errcode_ret)
 {
   switch (desc->image_type) {
   case CL_MEM_OBJECT_IMAGE1D:
   case CL_MEM_OBJECT_IMAGE3D:
-    return mkImageCore(context,flags,format,desc,desc->image_type, 
+    return mkImageCore(context,flags,format,desc,desc->image_type,
                        desc->image_width,desc->image_height,desc->image_depth,
                        desc->image_row_pitch, desc->image_slice_pitch,
                        host_ptr,nullptr,errcode_ret);
@@ -633,7 +634,7 @@ static cl_mem
 clCreateImage(cl_context             context,
               cl_mem_flags           flags,
               const cl_image_format* image_format,
-              const cl_image_desc*   image_desc, 
+              const cl_image_desc*   image_desc,
               void*                  host_ptr,
               cl_int*                errcode_ret)
 {
@@ -662,7 +663,7 @@ cl_mem
 clCreateImage(cl_context              context,
               cl_mem_flags            flags,
               const cl_image_format*  image_format,
-              const cl_image_desc*    image_desc, 
+              const cl_image_desc*    image_desc,
               void*                   host_ptr,
               cl_int*                 errcode_ret)
 {
@@ -681,6 +682,3 @@ clCreateImage(cl_context              context,
     }
     return nullptr;
 }
-
-
-

--- a/src/runtime_src/xocl/api/clCreateKernel.cpp
+++ b/src/runtime_src/xocl/api/clCreateKernel.cpp
@@ -101,7 +101,7 @@ clCreateKernel(cl_program      program,
     std::string fnm;
     for (unsigned int idx=0; ; ++idx) {
       char ext[4];
-      sprintf(ext,"%03d",idx);
+      sprintf(ext,"%03u",idx);
       auto path = bfs::path(kernel_name);
       // path.append("_").append(ext).append(".cl");
       // Changed to use /= since boost 1.53.0 path::append() which
@@ -182,5 +182,3 @@ clCreateKernel(cl_program      program,
   }
   return nullptr;
 }
-
-

--- a/src/runtime_src/xocl/api/clCreateSubBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateSubBuffer.cpp
@@ -100,15 +100,15 @@ clCreateSubBuffer(cl_mem                   parentbuffer,
 
   // Inherit device access flags from parent buffer if not specified
   auto device_access_flags = (CL_MEM_READ_WRITE | CL_MEM_READ_ONLY | CL_MEM_WRITE_ONLY);
-  flags = (flags | (flags & device_access_flags ? 0 : pflags & device_access_flags));
+  flags = (flags | ((flags & device_access_flags) ? 0 : (pflags & device_access_flags)));
 
   // Inherit host ptr flags from parent buffer
   auto host_ptr_flags = (CL_MEM_USE_HOST_PTR | CL_MEM_ALLOC_HOST_PTR | CL_MEM_COPY_HOST_PTR);
   flags = (flags | (pflags & host_ptr_flags));
-  
+
   // Inherit host access flags from parent buffer if not specified
   auto host_access_flags = (CL_MEM_HOST_WRITE_ONLY | CL_MEM_HOST_READ_ONLY | CL_MEM_HOST_NO_ACCESS);
-  flags = (flags | (flags & host_access_flags ? 0 : pflags & host_access_flags));
+  flags = (flags | ((flags & host_access_flags) ? 0 : (pflags & host_access_flags)));
 
   size_t sz = 0;
   size_t offset = 0;
@@ -116,7 +116,7 @@ clCreateSubBuffer(cl_mem                   parentbuffer,
     auto region = reinterpret_cast<const cl_buffer_region*>(buffer_create_info);
     sz = region->size;
     offset = region->origin;
-  } 
+  }
 
   auto usb = xrt::make_unique<sub_buffer>(xocl(parentbuffer),flags,offset,sz);
 
@@ -148,6 +148,3 @@ clCreateSubBuffer(cl_mem                   parentbuffer,
   }
   return nullptr;
 }
-
-
-

--- a/src/runtime_src/xocl/core/kernel.h
+++ b/src/runtime_src/xocl/core/kernel.h
@@ -355,7 +355,7 @@ public:
   friend class program; // only program constructs kernels
   kernel(program* prog, const std::string& name,const xclbin::symbol&);
   kernel(program* prog, const std::string& name);
-  kernel(program* prog);
+  explicit kernel(program* prog);
 
 public:
   virtual ~kernel();

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -432,8 +432,8 @@ private:
   unsigned int m_uid = 0;
   ptr<context> m_context;
 
-  memory_flags_type m_flags = 0;
-  memory_extension_flags_type m_ext_flags = 0;
+  memory_flags_type m_flags {0};
+  memory_extension_flags_type m_ext_flags {0};
 
   // List of dtor callback functions. On heap to avoid
   // allocation unless needed.
@@ -582,20 +582,15 @@ class image : public buffer
 
 public:
   image(context* ctx,cl_mem_flags flags, size_t sz,
-	  size_t w, size_t h, size_t depth,
-	  size_t row_pitch, size_t slice_pitch,
-	  uint32_t bpp, cl_mem_object_type type,
-	  cl_image_format fmt, void* host_ptr)
+        size_t w, size_t h, size_t d,
+        size_t row_pitch, size_t slice_pitch,
+        uint32_t bpp, cl_mem_object_type type,
+        cl_image_format fmt, void* host_ptr)
     : buffer(ctx,flags,sz+sizeof(image_info), host_ptr)
+    , m_width(w), m_height(h), m_depth(d)
+    , m_row_pitch(row_pitch), m_slice_pitch(slice_pitch)
+    , m_bpp(bpp), m_image_type(type), m_format(fmt)
   {
-      m_width = w;
-      m_height = h;
-      m_depth = depth;
-      m_row_pitch = row_pitch;
-      m_slice_pitch = slice_pitch;
-      m_bpp = bpp;
-      m_image_type = type;
-      m_format = fmt;
   }
 
   virtual cl_mem_object_type

--- a/src/runtime_src/xocl/core/param.h
+++ b/src/runtime_src/xocl/core/param.h
@@ -40,8 +40,8 @@ class param_buffer
     void* m_buffer;    // user supplied buffer to write to
     size_t m_size;     // size of buffer
 
-    buffer(void* buffer, size_t size) 
-      : m_buffer(buffer), m_size(size) 
+    buffer(void* buffer, size_t size)
+      : m_buffer(buffer), m_size(size)
     {}
   };
 
@@ -74,6 +74,7 @@ class param_buffer
     typedef T value_type;
     param_buffer& m_host;
 
+    // implicit
     assignee(param_buffer& pb)
       : m_host(pb)
     {}
@@ -99,7 +100,7 @@ class param_buffer
         }
       };
 
-      static size_t 
+      static size_t
       write(buffer& b, S t)
       {
         return writer_helper<T,std::is_scalar<T>::value>::write(b,t);
@@ -127,7 +128,7 @@ class param_buffer
       static_assert(std::is_convertible<char,T>::value,"type mismatch: cannot convert char to T");
 
       static size_t
-      write(buffer& b, const char* str) 
+      write(buffer& b, const char* str)
       {
         size_t l = std::strlen(str);
         auto buffer = allocator<T>::get(b,l+1);
@@ -146,7 +147,7 @@ class param_buffer
       static_assert(std::is_convertible<char,T>::value,"type mismatch: cannot convert char to T");
 
       static size_t
-      write(buffer& b, const std::string& str) 
+      write(buffer& b, const std::string& str)
       {
         size_t l = str.length();
         auto buffer = allocator<T>::get(b,l+1);
@@ -274,5 +275,3 @@ public:
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -126,16 +126,6 @@ program::
   global::remove(this);
 }
 
-program&
-program::
-operator=(const program& rhs)
-{
-  m_context = rhs.m_context;
-  m_devices = rhs.m_devices;
-  return *this;
-}
-
-
 void
 program::
 add_device(device* d)

--- a/src/runtime_src/xocl/core/program.h
+++ b/src/runtime_src/xocl/core/program.h
@@ -63,14 +63,12 @@ public:
   /**
    * Delegating contstrutor
    */
+  explicit
   program(context* ctx)
     : program(ctx,"")
   {}
 
   virtual ~program();
-
-  program&
-  operator=(const program& rhs);
 
   unsigned int
   get_uid() const
@@ -96,8 +94,8 @@ public:
     return m_context.get();
   }
 
-  const std::string& 
-  get_source() const 
+  const std::string&
+  get_source() const
   {
     return m_source;
   }
@@ -178,7 +176,7 @@ public:
    * get_device_range.
    *
    * Not a cool dependency on device range. Subject to removal.
-   * 
+   *
    * @return
    *   List of binary sizes
    */
@@ -219,7 +217,7 @@ public:
   }
 
   bool
-  has_kernel(const std::string& kname) const 
+  has_kernel(const std::string& kname) const
   {
     auto kernels = get_kernel_names();
     return range_find(kernels,[&kname](const std::string& s){return s==kname;})!=kernels.end();
@@ -268,14 +266,14 @@ public:
       ? (*itr).second
       : "";
   }
-  
+
   /**
    * Get the build log for argument device
    *
    * @param dev
    *  Device for which to get build log.
    * @return
-   *  Build log argument device, or empty string if program wasn't 
+   *  Build log argument device, or empty string if program wasn't
    *  explicitly build by runtime.
    */
   std::string
@@ -358,5 +356,3 @@ get_global_programs();
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/core/property.h
+++ b/src/runtime_src/xocl/core/property.h
@@ -47,6 +47,7 @@ public:
     : m_props(0)
   {}
 
+  // implicit
   property_object(Rep props)
     : m_props(props)
   {}
@@ -107,7 +108,7 @@ class property_list
       return reinterpret_cast<T>(m_value);
     }
 
-    bool operator< (const element& e) const 
+    bool operator< (const element& e) const
     {
       return m_key < e.m_key;
     }
@@ -121,7 +122,7 @@ public:
 
   property_list()
   {}
-  
+
   property_list(const Rep* props)
   {
     std::set<Rep> keys;
@@ -162,5 +163,3 @@ public:
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/core/refcount.h
+++ b/src/runtime_src/xocl/core/refcount.h
@@ -27,7 +27,7 @@ namespace xocl {
 
 /**
  * Base class for reference counted xocl objects.
- * 
+ *
  * Too bad that OpenCL API pointer objects cannot be redefined as
  * some smart pointer type. E.g. not much to do about
  * cl.h: typedef _cl_program* cl_program;
@@ -36,33 +36,33 @@ namespace xocl {
  * implementation to use the count appropriately via the
  * implementation of CL API methods clRetain... and clRelease...
  */
-class refcount 
+class refcount
 {
   std::atomic<unsigned int> m_refcount;
  public:
   refcount() : m_refcount(1) {}
-  
+
   /**
    * Increment refcount.
    */
   void
-  retain() 
-  { 
+  retain()
+  {
     assert(m_refcount>0);  // retaining a floating object
-    ++m_refcount; 
+    ++m_refcount;
   }
 
   /**
    * Decrement refcount.
    *
-   * @return 
+   * @return
    *   true of refcount reaches zero, false otherwise
    */
   bool
-  release() 
-  { 
+  release()
+  {
     assert(m_refcount>0);
-    return (--m_refcount)==0; 
+    return (--m_refcount)==0;
   }
 
   /**
@@ -80,7 +80,7 @@ class refcount
  *
  * This pointer class is used to retain ownership of a CL object.  When
  * the pointer object goes out of scope the object is released and if
- * the resulting reference count is zero, the object is deleted.  
+ * the resulting reference count is zero, the object is deleted.
  *
  * The pointer class is used in the core implementation to represent the
  * OpenCL object model.
@@ -92,6 +92,7 @@ class shared_ptr
 public:
   typedef T* value_type;
 
+  // implicit
   shared_ptr(T* t=nullptr) : m_t(t)
   {
     if (m_t)
@@ -102,7 +103,7 @@ public:
     if (m_t && m_t->release())
       delete m_t;
   }
-  
+
   shared_ptr(shared_ptr&& rhs)
     : m_t(rhs.m_t)
   {
@@ -116,7 +117,7 @@ public:
       m_t->retain();
   }
 
-  shared_ptr& 
+  shared_ptr&
   operator= (shared_ptr rhs)
   {
     std::swap(m_t,rhs.m_t);
@@ -129,12 +130,12 @@ public:
     return m_t == rhs;
   }
 
-  bool 
+  bool
   operator==(const shared_ptr& rhs) const
   {
     return m_t == rhs.m_t;
   }
-  
+
   T* operator->() const
   {
     return m_t;
@@ -169,7 +170,7 @@ using ptr = shared_ptr<T>;
  *  device* dev = *(dr.begin());
  * \code
  *
- * This iterator is in particular relied upon when ranges are 
+ * This iterator is in particular relied upon when ranges are
  * assigned to a param_buffer in clGetXInfo() calls.
  */
 template <typename Iterator>
@@ -179,6 +180,7 @@ struct ptr_iterator : public Iterator
   using value_type = typename iterator_value_type::value_type;
   static_assert(std::is_pointer<value_type>::value,"Only pointer type support");
 
+  // implicit
   ptr_iterator(Iterator itr)
     : Iterator(itr)
   {}
@@ -193,5 +195,3 @@ struct ptr_iterator : public Iterator
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -57,7 +57,7 @@ iequals(std::string s1, std::string s2)
   return s1==s2;
 }
 
-void 
+void
 setXYZ(size_t result[3], const pt::ptree& xml_element)
 {
   result[0] = xml_element.get<size_t>("<xmlattr>.x");
@@ -105,6 +105,7 @@ private:
     }
 
   public:
+    explicit
     platform_wrapper(const xml_platform_type& p)
       : xml_platform(p)
     {
@@ -116,7 +117,7 @@ private:
     }
 
     const xml_platform_type&
-    xml() const 
+    xml() const
     { return xml_platform; }
 
     const std::string&
@@ -173,7 +174,7 @@ private:
     {}
 
     const xml_device_type&
-    xml() const 
+    xml() const
     { return xml_device; }
 
     std::string
@@ -186,7 +187,7 @@ private:
       xocl::xclbin::system_clocks_type clocks;
       pt::ptree default_value;
       for (auto& xml_clock : xml_device.get_child("systemClocks",default_value)) {
-        if (xml_clock.first != "clock") 
+        if (xml_clock.first != "clock")
           continue;
         auto port = xml_clock.second.get<std::string>("<xmlattr>.port");
         auto freq = convert(xml_clock.second.get<std::string>("<xmlattr>.frequency"));
@@ -212,7 +213,7 @@ private:
     const xml_core_type& xml_core;
 
   private:
-    void 
+    void
     valid_or_throw() const
     {
       type();   // throws on error
@@ -231,8 +232,8 @@ private:
       valid_or_throw();
     }
 
-    const xml_core_type& 
-    xml() const 
+    const xml_core_type&
+    xml() const
     { return xml_core; }
 
     const xml_connection_type&
@@ -251,7 +252,7 @@ private:
 
       throw xocl::error
         (CL_INVALID_BINARY,
-         "No connection matching srcinst='" + src + 
+         "No connection matching srcinst='" + src +
          "' and srcport='" + port + "'");
     }
 
@@ -306,7 +307,7 @@ private:
     }
 
     std::string
-    name() const 
+    name() const
     {
       return xml_core.get<std::string>("<xmlattr>.name");
     }
@@ -407,7 +408,7 @@ private:
     const core_wrapper* core() const { return m_core; }
 
     const xml_kernel_type&
-    xml() const 
+    xml() const
     { return xml_kernel; }
 
     ////////////////////////////////////////////////////////////////
@@ -457,7 +458,7 @@ private:
             return arg_type::printf;
           else if (nm.find("__xcl_gv_")==0)
             return arg_type::progvar;
-          else 
+          else
             return arg_type::rtinfo;
         }
       };
@@ -597,14 +598,14 @@ private:
         // Get one kernel instance (doesn't matter which one)
         auto kinst = xml_kernel.get<std::string>("instance.<xmlattr>.name");
 
-        // Find connection matching srcInst=kinstnm and srcPort=pvport 
+        // Find connection matching srcInst=kinstnm and srcPort=pvport
         // and get its dst instance
         auto& xml_conn = m_core->get_connection_or_error(kinst,pvport);
         auto dstinst = xml_conn.get<std::string>("<xmlattr>.dstInst");
 
         // Find memory instance with name==dstinst
         auto& xml_meminst = m_core->get_meminst_or_error(dstinst);
-      
+
         // Get the base addr remap
         for (auto& xml_remap : xml_meminst) {
           if (xml_remap.first != "addrRemap")
@@ -679,7 +680,7 @@ private:
       std::string name = m_name;
       m_name = name.substr(0,name.find_last_of("_"));
       m_symbol.name = m_name;
-      return name; 
+      return name;
     }
 
     bool
@@ -723,6 +724,7 @@ private:
   }
 
 public:
+  explicit
   metadata(const data_range& xml)
   {
     try {
@@ -774,15 +776,14 @@ public:
     for (auto& xml_kernel : xml_project.get_child("project.platform.device.core")) {
       if (xml_kernel.first != "kernel")
         continue;
-      std::string name = xml_kernel.second.get<std::string>("<xmlattr>.name");
-      XOCL_DEBUG(std::cout,"xclbin found kernel '" + name + "'\n");
+      XOCL_DEBUG(std::cout,"xclbin found kernel '" + xml_kernel.second.get<std::string>("<xmlattr>.name") + "'\n");
       m_kernels.emplace_back(xrt::make_unique<kernel_wrapper>(platform,device,core,xml_kernel.second));
     }
   }
 
   xocl::xclbin::system_clocks_type
   system_clocks() const
-  { 
+  {
     xocl::xclbin::system_clocks_type clocks;
     for (auto& device : m_devices) {
       auto cclocks = device->system_clocks();
@@ -793,7 +794,7 @@ public:
 
   xocl::xclbin::kernel_clocks_type
   kernel_clocks() const
-  { 
+  {
     xocl::xclbin::kernel_clocks_type clocks;
     for (auto& core : m_cores) {
       auto cclocks = core->kernel_clocks();
@@ -819,7 +820,7 @@ public:
 
   std::vector<const xocl::xclbin::symbol*>
   kernel_symbols() const
-  { 
+  {
     std::vector<const xocl::xclbin::symbol*> symbols;
     for (auto& kernel : m_kernels)
       symbols.push_back(&kernel->symbol());
@@ -853,8 +854,8 @@ public:
 
   bool
   is_unified() const
-  { 
-    return m_platforms[0]->is_unified(); 
+  {
+    return m_platforms[0]->is_unified();
   }
 
   std::string
@@ -865,7 +866,7 @@ public:
 
   target_type
   target() const
-  { 
+  {
     return m_cores[0]->target();
   }
 
@@ -877,7 +878,7 @@ public:
 
   size_t
   cu_base_offset() const
-  { 
+  {
     size_t offset = std::numeric_limits<size_t>::max();
     for (auto& kernel : m_kernels)
       offset = std::min(offset,kernel->cu_base_offset());
@@ -886,13 +887,13 @@ public:
 
   size_t
   cu_size() const
-  { 
+  {
     return m_platforms[0]->is_unified() ? 16 : 12;
   }
 
   bool
   cu_interrupt() const
-  { 
+  {
     bool retval = true;
     for (auto& kernel : m_kernels)
       if (!kernel->cu_interrupt())
@@ -952,6 +953,7 @@ class xclbin_data_sections
   std::vector<membank> m_membanks;
 
 public:
+  explicit
   xclbin_data_sections(const xocl::xclbin::binary_type& binary)
     : m_con(reinterpret_cast<const ::connectivity*>(binary.connectivity_data().first))
     , m_mem(reinterpret_cast<const ::mem_topology*>(binary.mem_topology_data().first))
@@ -983,8 +985,8 @@ public:
 #endif
   }
 
-  const clock_freq_topology* 
-  get_clk_freq_topology() const 
+  const clock_freq_topology*
+  get_clk_freq_topology() const
   {
     return m_clk;
   }
@@ -1019,7 +1021,7 @@ public:
   }
 
   xocl::xclbin::memidx_bitmask_type
-  cu_address_to_memidx(addr_type cuaddr) const 
+  cu_address_to_memidx(addr_type cuaddr) const
   {
     if (!is_valid())
       return -1;
@@ -1039,7 +1041,7 @@ public:
 
   xocl::xclbin::memidx_bitmask_type
   mem_address_to_memidx(addr_type addr) const
-  { 
+  {
     // m_membanks are sorted decreasing based on ddr base addresses
     // 30,20,10,0
     xocl::xclbin::memidx_bitmask_type bitmask = 0;
@@ -1073,7 +1075,7 @@ public:
   }
 
   std::string
-  memidx_to_banktag(xocl::xclbin::memidx_type memidx) const 
+  memidx_to_banktag(xocl::xclbin::memidx_type memidx) const
   {
     if (!m_mem)
       return "";
@@ -1121,7 +1123,7 @@ struct xclbin::impl
   { return m_xml.is_unified(); }
 
   std::string
-  project_name() const 
+  project_name() const
   { return m_xml.project_name(); }
 
   target_type
@@ -1176,7 +1178,7 @@ struct xclbin::impl
   cu_base_address_map() const
   { return m_xml.cu_base_address_map(); }
 
-  const clock_freq_topology* 
+  const clock_freq_topology*
   get_clk_freq_topology() const
   { return m_sections.get_clk_freq_topology(); }
 
@@ -1247,7 +1249,7 @@ operator=(const xclbin& rhs)
   return *this;
 }
 
-bool 
+bool
 xclbin::
 operator==(const xclbin& rhs) const
 {
@@ -1277,7 +1279,7 @@ is_unified() const
 
 std::string
 xclbin::
-project_name() const 
+project_name() const
 {
   return m_impl->project_name();
 }
@@ -1331,7 +1333,7 @@ kernel_max_regmap_size() const
 
 const xclbin::symbol&
 xclbin::
-lookup_kernel(const std::string& name) const 
+lookup_kernel(const std::string& name) const
 {
   return m_impl->lookup_kernel(name);
 }
@@ -1343,7 +1345,7 @@ profilers() const
   return m_impl->profilers();
 }
 
-const clock_freq_topology* 
+const clock_freq_topology*
 xclbin::
 get_clk_freq_topology() const
 {
@@ -1380,7 +1382,7 @@ cu_base_address_map() const
 
 xclbin::memidx_bitmask_type
 xclbin::
-cu_address_to_memidx(addr_type cuaddr, int32_t arg) const 
+cu_address_to_memidx(addr_type cuaddr, int32_t arg) const
 {
   return m_impl->cu_address_to_memidx(cuaddr,arg);
 }
@@ -1438,7 +1440,7 @@ conformance_kernel_hashes() const
 // return a string representation of it.
 std::string
 xclbin::symbol::arg::
-get_string_value(const unsigned char* data) const 
+get_string_value(const unsigned char* data) const
 {
   std::stringstream sstr;
   if ( (type == "float") || (type == "double") ) {
@@ -1462,5 +1464,3 @@ get_string_value(const unsigned char* data) const
 }
 
 } // xocl
-
-

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -29,7 +29,7 @@
 #include <array>
 #include <bitset>
 
-namespace xocl { 
+namespace xocl {
 
 class device;
 class kernel;
@@ -47,7 +47,7 @@ class kernel;
  *          uses                          uses    uses
  *           |                             |       |
  *         [xocl]                        [xrt]    [hal]
- *     
+ *
  */
 class xclbin
 {
@@ -128,7 +128,7 @@ public:
     std::string hash;                // kernel conformance hash
     std::string controlport;         // kernel axi slave control port
     size_t workgroupsize = 0;
-    size_t compileworkgroupsize[3] = {0};   // 
+    size_t compileworkgroupsize[3] = {0};   //
     size_t maxworkgroupsize[3] = {0};// xilinx extension
     std::vector<arg> arguments;      // the args of this kernel
     std::vector<instance> instances; // the kernel instances
@@ -143,6 +143,7 @@ public:
    * The underlying binary type that represents the raw
    * binary xclbin file per xclBin structs.
    */
+  // implicit
   xclbin(std::vector<char>&& xb);
   xclbin(xclbin&& rhs);
 
@@ -152,12 +153,12 @@ public:
   xclbin&
   operator=(const xclbin& rhs);
 
-  bool 
+  bool
   operator==(const xclbin& rhs) const;
 
   /**
    * Access the raw binary xclbin
-   * 
+   *
    * The binary type API conforms to the xclBin struct interface
    */
   using binary_type = ::xclbin::binary;
@@ -249,7 +250,7 @@ public:
   /**
    * Get the list of profilers
    *
-   * @return 
+   * @return
    *  Vector of profiler struct objects constructed from the xclbin meta data.
    */
   using profilers_type = std::vector<profiler>;
@@ -259,7 +260,7 @@ public:
   /**
    * Get the clock frequency sections in xclbin
    */
-  const clock_freq_topology* 
+  const clock_freq_topology*
   get_clk_freq_topology() const;
 
   /**
@@ -316,7 +317,7 @@ public:
   cu_address_to_memidx(addr_type cuaddr, int32_t arg) const;
 
   /**
-   * @return 
+   * @return
    *   Memory connection indeces as the union of connections for all
    *   arguments of CU as specified address.
    */
@@ -355,7 +356,7 @@ public:
    */
   std::string
   memidx_to_banktag(memidx_type memidx) const;
-    
+
   /**
    * Get the memory index with the specified tag.
    *
@@ -380,5 +381,3 @@ public:
 } // xocl
 
 #endif
-
-

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -45,6 +45,7 @@ public:
   using queue_type = hal::queue_type;
   using stream_handle = hal::StreamHandle;
 
+  explicit
   device(std::unique_ptr<hal::device>&& hal)
     : m_hal(std::move(hal)), m_setup_done(false)
   {
@@ -103,7 +104,7 @@ public:
   }
 
   /**
-   * @return 
+   * @return
    *   List of clock frequency from device info
    */
   range<const unsigned short*>
@@ -177,7 +178,7 @@ public:
    * @param bo
    *  The existing buffer object from which the new one will be created
    * @param sz
-   *  The size to carve out of the existing buffer object when 
+   *  The size to carve out of the existing buffer object when
    *  creating the new one
    * @param offset
    *  The offset to add to existing buffer object when creating
@@ -340,7 +341,7 @@ public:
   exec_buf(const ExecBufferObjectHandle& bo)
   { return m_hal->exec_buf(bo); }
 
-  int 
+  int
   exec_wait(int timeout_ms) const
   { return m_hal->exec_wait(timeout_ms); }
 
@@ -819,5 +820,3 @@ loadDevices()
 } // xrt
 
 #endif
-
-

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -33,7 +33,7 @@
 //struct xclBin;
 struct axlf;
 
-namespace xrt { 
+namespace xrt {
 
 namespace hal {
 
@@ -44,12 +44,12 @@ struct exec_buffer_object {};
 using BufferObjectHandle = std::shared_ptr<buffer_object>;
 using ExecBufferObjectHandle = std::shared_ptr<exec_buffer_object>;
 
-enum class verbosity_level : unsigned short 
-{ 
+enum class verbosity_level : unsigned short
+{
   quiet
  ,info
  ,warning
- ,error 
+ ,error
 };
 
 enum class queue_type : unsigned short
@@ -65,9 +65,9 @@ typedef void* PacketObject;
 typedef unsigned short StreamHandle;
 
 /**
- * Helper class to encapsulate return values from HAL operations.  
+ * Helper class to encapsulate return values from HAL operations.
  *
- * The HAL operation return value is valid if and only of the 
+ * The HAL operation return value is valid if and only of the
  * HAL operations function is defined and was called.  Using this
  * class avoids client code littered with tests prior to call.
  */
@@ -78,6 +78,7 @@ class operations_result
   bool m_valid;
 
 public:
+  // implicit
   operations_result(ReturnValueType&& v)
     : m_value(std::move(v)),m_valid(true)
   {}
@@ -96,6 +97,7 @@ class operations_result<void>
   bool m_valid;
 
 public:
+  // implicit
   operations_result(int)
     : m_valid(true)
   {}
@@ -143,10 +145,10 @@ public:
     ,XRT_DEVICE_P2P_RAM
   };
 
-  virtual bool 
+  virtual bool
   open(const char* log, verbosity_level l) = 0;
 
-  virtual void 
+  virtual void
   close() = 0;
 
   // Hack to copy hw_em device info to sw_em device info
@@ -154,13 +156,13 @@ public:
   virtual void
   copyDeviceInfo(const device* src) {}
 
-  virtual std::string 
+  virtual std::string
   getDriverLibraryName() const = 0;
 
-  virtual std::string 
+  virtual std::string
   getName() const = 0;
 
-  virtual unsigned int 
+  virtual unsigned int
   getBankCount() const = 0;
 
   virtual size_t
@@ -173,7 +175,7 @@ public:
   virtual range<const unsigned short*>
   getClockFrequencies() const = 0;
 
-  virtual std::ostream& 
+  virtual std::ostream&
   printDeviceInfo(std::ostream&) const = 0;
 
   virtual ExecBufferObjectHandle
@@ -187,7 +189,7 @@ public:
 
   /**
    * Allocate buffer object in specified memory bank index
-   * 
+   *
    * The bank index is an index into mem topology array and not
    * necessarily the logical bank number used in the host code.
    */
@@ -222,10 +224,10 @@ public:
   copy(const BufferObjectHandle& dst_bo, const BufferObjectHandle& src_bo, size_t sz,
        size_t dst_offset, size_t src_offset) = 0;
 
-  virtual size_t 
+  virtual size_t
   read_register(size_t offset, void* buffer, size_t size) = 0;
 
-  virtual size_t 
+  virtual size_t
   write_register(size_t offset, const void* buffer, size_t size) = 0;
 
   virtual void*
@@ -241,14 +243,14 @@ public:
   unmap(const ExecBufferObjectHandle& bo) = 0;
 
   virtual int
-  exec_buf(const ExecBufferObjectHandle& bo) 
-  { 
+  exec_buf(const ExecBufferObjectHandle& bo)
+  {
     throw std::runtime_error("exec_buf not supported");
   }
 
   virtual int
   exec_wait(int timeout_ms) const
-  { 
+  {
     throw std::runtime_error("exec_wait not supported");
   }
 
@@ -278,7 +280,7 @@ public:
    * @returns
    *   The device address of a buffer object
    */
-  virtual uint64_t 
+  virtual uint64_t
   getDeviceAddr(const BufferObjectHandle& boh) = 0;
 
   /**
@@ -384,7 +386,7 @@ public:
   /**
    * Check if bank allocation is supported
    *
-   * @return 
+   * @return
    *   true if bank allocation is supported, false otherwise
    */
   virtual bool
@@ -606,7 +608,7 @@ loadDevices();
 
 } // namespace hal
 
-namespace hal2 { 
+namespace hal2 {
 
 /**
  * Populate hal device list with hal2 devices as probed by DLL
@@ -629,5 +631,3 @@ createDevices(hal::device_list&,const std::string&,void*,unsigned int,void* pmd=
 } // xrt
 
 #endif
-
-

--- a/src/runtime_src/xrt/util/error.h
+++ b/src/runtime_src/xrt/util/error.h
@@ -31,6 +31,7 @@ public:
     : std::runtime_error(what), m_code(ec)
   {}
 
+  explicit
   error(const std::string& what)
     : std::runtime_error(what), m_code(0)
   {}
@@ -57,5 +58,3 @@ send_exception_message(const char* msg)
 } // xrt
 
 #endif
-
-

--- a/src/runtime_src/xrt/util/event.h
+++ b/src/runtime_src/xrt/util/event.h
@@ -19,7 +19,7 @@
 
 #include "xrt/util/error.h"
 
-namespace xrt { 
+namespace xrt {
 
 /**
  * Event class providing an abstraction over different event implementations.
@@ -28,11 +28,11 @@ namespace xrt {
  * providing a consistent API (wait(), ready()) to clients.
  *
  * The enclosed concrete event types must define
- *   value_type: 
+ *   value_type:
  *     type of the value encapsulated by the event
- *   value_type wait() const: 
+ *   value_type wait() const:
  *     waits on the event and returns its value
- *   bool ready() const: 
+ *   bool ready() const:
  *     returns immediately with true if event is ready, false otherwise
  *
  * A sample event class that fits the above requirements is:
@@ -110,11 +110,11 @@ class event
   {
     return dynamic_cast<value_holder<ValueType>*>(m_content.get());
   }
-  
+
 
 public:
 
-  event() 
+  event()
     : m_content(nullptr)
   {}
 
@@ -140,7 +140,7 @@ public:
   bool
   ready() const
   {
-    return m_content 
+    return m_content
       ? m_content->ready()
       : true;
   }
@@ -153,7 +153,7 @@ public:
   }
 
   template <typename ValueType>
-  ValueType 
+  ValueType
   get() const
   {
     value_holder<ValueType>* vt = value_cast<ValueType>();
@@ -173,6 +173,7 @@ class typed_event
 public:
   typedef T value_type;
 
+  explicit
   typed_event(T&& t) : m_value(std::move(t)) {}
 
   T wait() const { return m_value; }
@@ -191,5 +192,3 @@ public:
 } // xrt
 
 #endif
-
-

--- a/src/runtime_src/xrt/util/message.cpp
+++ b/src/runtime_src/xrt/util/message.cpp
@@ -72,7 +72,7 @@ private:
 class syslog_dispatch : public message_dispatch
 {
 public:
-  syslog_dispatch(); 
+  syslog_dispatch();
   virtual ~syslog_dispatch();
   virtual void send(severity_level l, const char* msg) override;
 private:
@@ -93,9 +93,10 @@ private:
 class file_dispatch : public message_dispatch
 {
 public:
-  file_dispatch(const std::string& file); 
+  explicit
+  file_dispatch(const std::string& file);
   virtual ~file_dispatch();
-  virtual void send(severity_level l, const char* msg) override; 
+  virtual void send(severity_level l, const char* msg) override;
 private:
   std::ofstream handle;
   std::map<severity_level, const char*> severityMap = {
@@ -126,9 +127,9 @@ message_dispatch::make_dispatcher(const std::string& choice)
       std::string file = choice;
       file.erase(0, 1);
       file.erase(file.size()-1);
-      return new file_dispatch(file); 
+      return new file_dispatch(file);
     }else
-      return new file_dispatch(choice); 
+      return new file_dispatch(choice);
   }
   return nullptr;
 }
@@ -142,7 +143,7 @@ syslog_dispatch::~syslog_dispatch() {
   closelog();
 }
 
-void 
+void
 syslog_dispatch::send(severity_level l, const char* msg) {
   syslog(severityMap[l], "%s", msg);
 }
@@ -156,13 +157,13 @@ file_dispatch::~file_dispatch() {
   handle.close();
 }
 
-void 
+void
 file_dispatch::send(severity_level l, const char* msg) {
   handle << severityMap[l] << msg << std::endl;
 }
 
 //console ops
-void 
+void
 console_dispatch::send(severity_level l, const char* msg) {
   std::cout << severityMap[l]  << msg << std::endl;
 }
@@ -171,7 +172,7 @@ console_dispatch::send(severity_level l, const char* msg) {
 
 namespace xrt { namespace message {
 
-void 
+void
 send(severity_level l, const char* msg)
 {
   static const std::string logger =  xrt::config::get_logging();
@@ -180,5 +181,3 @@ send(severity_level l, const char* msg)
 }
 
 }} // message,xrt
-
-

--- a/src/runtime_src/xrt/util/regmap.h
+++ b/src/runtime_src/xrt/util/regmap.h
@@ -49,7 +49,7 @@ private:
   __attribute__((aligned(Align))) regmap_t m_regmap {{0}};
 #else
   // gcc supports upto 128 only with alignas
-  alignas(Align) regmap_t m_regmap {{0}}; 
+  alignas(Align) regmap_t m_regmap {{0}};
 #endif
   std::size_t m_size {0};
 public:
@@ -66,7 +66,7 @@ public:
     return m_regmap.at(idx);
   }
 
-  bool 
+  bool
   operator==(const regmap& rhs) const
   {
     if (m_size != rhs.m_size)
@@ -139,10 +139,12 @@ private:
   value_type* m_regmap = nullptr;
   std::size_t m_size {0};
 public:
+  explicit
   regmap_placed(value_type* data)
     : m_regmap(data)
   {}
 
+  explicit
   regmap_placed(void* data)
     : regmap_placed(static_cast<value_type*>(data))
   {}
@@ -160,7 +162,7 @@ public:
     return m_regmap[idx];
   }
 
-  bool 
+  bool
   operator==(const regmap_placed& rhs) const
   {
     if (m_size != rhs.m_size)
@@ -232,5 +234,3 @@ public:
 } // xrt
 
 #endif
-
-

--- a/src/runtime_src/xrt/util/task.h
+++ b/src/runtime_src/xrt/util/task.h
@@ -118,7 +118,7 @@ public:
   mpmcqueue()
   {}
 
-  mpmcqueue(bool dbg)
+  explicit mpmcqueue(bool dbg)
     : debug(dbg)
   {}
 

--- a/src/runtime_src/xrt/util/time.h
+++ b/src/runtime_src/xrt/util/time.h
@@ -34,6 +34,7 @@ class time_guard
   unsigned long zero = 0;
   unsigned long& tally;
 public:
+  explicit
   time_guard(unsigned long& t)
     : zero(time_ns()), tally(t)
   {}
@@ -47,5 +48,3 @@ public:
 } // xocl
 
 #endif
-
-


### PR DESCRIPTION
Mostly explicit single argument constructors.  However, many single
arg constructors remain and are intentional.