### PR TITLE
Fix bug in device BO bank check in sw_emu

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -570,7 +570,10 @@ device::
 get_boh_memidx(const xrt::device::BufferObjectHandle& boh) const
 {
   auto addr = get_boh_addr(boh);
-  return m_xclbin.mem_address_to_memidx(addr);
+  auto bset = m_xclbin.mem_address_to_memidx(addr);
+  if (bset.none() && is_sw_emulation())
+    bset.set(0); // default bank in sw_emu
+  return bset;
 }
 
 std::string


### PR DESCRIPTION
Due to lacking memory topology in sw_emu, recent XRT changes (PR #28)
incorrectly assumed that a memory buffer wasn't allocated on the
device when in fact it was.

A check to translate buffer device address into a device memory index
failed because sw_emu doesn't have memory topology data to cross
correlate buffer device address with corresponding bank.  Instead
sw_emu must default such checks to some default memory index (0).