### PR TITLE
Sync the portion of buffer while CL_MAP_READ is set

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -655,9 +655,14 @@ map_buffer(memory* buffer, cl_map_flags map_flags, size_t offset, size_t size, v
   auto xdevice = get_xrt_device();
   xrt::device::BufferObjectHandle boh;
 
+  // If map_flags set as CL_MAP_READ, we only sync the portion of BO for mapping
+  if ((map_flags & CL_MAP_READ) && buffer->is_resident(this)) {
+    boh = buffer->get_buffer_object_or_error(this);
+    xdevice->sync(boh,size,offset,xrt::hal::device::direction::DEVICE2HOST,false);
+  }
   // If buffer is resident it must be refreshed unless CL_MAP_INVALIDATE_REGION
   // is specified in which case host will discard current content
-  if (!(map_flags & CL_MAP_WRITE_INVALIDATE_REGION) && buffer->is_resident(this)) {
+  else if (!(map_flags & CL_MAP_WRITE_INVALIDATE_REGION) && buffer->is_resident(this)) {
     boh = buffer->get_buffer_object_or_error(this);
     xdevice->sync(boh,buffer->get_size(),0,xrt::hal::device::direction::DEVICE2HOST,false);
   }


### PR DESCRIPTION
We only sync part of (offset, offset+size) buffer while cl_map_flags == CL_MAP_READ,

Because it is mapped only for reading, it won't and shouldn't change any single byte either in host memory or device memory.

Can save time if you allocate a large buffer and only need portion of it.

clEnqueueUnmapMemObject only sync from HOST2DEVICE if flag is set as CL_MAP_WRITE*.
 