### PR TITLE
Add platform spfm to development DSA package

### DIFF
--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -174,8 +174,10 @@ maintainer: soren.soe@xilinx.com
 EOF
 
     mkdir -p $opt_pkgdir/$dir/opt/xilinx/platform/$opt_dsa/hw
+    mkdir -p $opt_pkgdir/$dir/opt/xilinx/platform/$opt_dsa/sw
     rsync -avz $opt_dsadir/$opt_dsa.xpfm $opt_pkgdir/$dir/opt/xilinx/platform/$opt_dsa/
     rsync -avz $opt_dsadir/hw/$opt_dsa.dsa $opt_pkgdir/$dir/opt/xilinx/platform/$opt_dsa/hw/
+    rsync -avz $opt_dsadir/sw/$opt_dsa.spfm $opt_pkgdir/$dir/opt/xilinx/platform/$opt_dsa/sw/
     dpkg-deb --build $opt_pkgdir/$dir
 
     echo "================================================================"
@@ -235,8 +237,10 @@ Xilinx development DSA.
 
 %install
 mkdir -p %{buildroot}/opt/xilinx/platform/$opt_dsa/hw
+mkdir -p %{buildroot}/opt/xilinx/platform/$opt_dsa/sw
 rsync -avz $opt_dsadir/$opt_dsa.xpfm %{buildroot}/opt/xilinx/platform/$opt_dsa/
 rsync -avz $opt_dsadir/hw/$opt_dsa.dsa %{buildroot}/opt/xilinx/platform/$opt_dsa/hw/
+rsync -avz $opt_dsadir/sw/$opt_dsa.spfm %{buildroot}/opt/xilinx/platform/$opt_dsa/sw/
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
This fixes emconfigutil error when using xbb expanded platform
folder. It likely fixes similar xocc errors also.