### PR TITLE
Rename HAL core library to xrt_core

### DIFF
--- a/src/CMake/config/xrt.pc.in
+++ b/src/CMake/config/xrt.pc.in
@@ -6,5 +6,5 @@ includedir=${prefix}/include
 Name: XRT
 Description: Xilinx RunTime
 Version: @XRT_VERSION_STRING@
-Libs: -L${libdir} -lxrtcore
+Libs: -L${libdir} -lxrt_core
 Cflags: -I${includedir}

--- a/src/runtime_src/driver/xclng/tools/xbflash/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/xbflash/CMakeLists.txt
@@ -14,7 +14,7 @@ set(XBFLASH_SRC ${XBFLASH_FILES})
 add_executable(xbflash ${XBFLASH_SRC})
 
 target_link_libraries(xbflash
-  xrtcorestatic
+  xrt_corestatic
   pthread
   )
 

--- a/src/runtime_src/driver/xclng/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/xbutil/CMakeLists.txt
@@ -15,7 +15,7 @@ set(XBUTIL_SRC ${XBUTIL_FILES})
 add_executable(xbutil ${XBUTIL_SRC})
 
 target_link_libraries(xbutil
-  xrtcorestatic
+  xrt_corestatic
   pthread
   rt
   ${CURSES_LIBRARIES}

--- a/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
@@ -5,29 +5,29 @@ include_directories(
 
 set(XRT_SRC "")
 
-add_library(xrtcore SHARED ${XRT_SRC}
+add_library(xrt_core SHARED ${XRT_SRC}
   $<TARGET_OBJECTS:user_common>
   $<TARGET_OBJECTS:user_gem>
   )
 
-add_library(xrtcorestatic STATIC ${XRT_SRC}
+add_library(xrt_corestatic STATIC ${XRT_SRC}
   $<TARGET_OBJECTS:user_common>
   $<TARGET_OBJECTS:user_gem>
   )
 
-set_target_properties(xrtcore PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties(xrt_core PROPERTIES LINKER_LANGUAGE CXX)
 add_compile_options("-fPIC" "-fvisibility=hidden")
 #set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 add_subdirectory(user_common)
 add_subdirectory(user_gem)
 
-set_target_properties(xrtcore PROPERTIES VERSION ${XRT_VERSION_STRING}
+set_target_properties(xrt_core PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_VERSION_MAJOR})
 
-target_link_libraries(xrtcore
+target_link_libraries(xrt_core
   pthread
   rt
   )
 
-install (TARGETS xrtcore LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)
+install (TARGETS xrt_core LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)

--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -5,7 +5,7 @@ set script_path=""
 set xrt_dir=""
 
 # revisit if there is a better way than lsof to obtain the script path
-# in non-interactive mode.  If lsof is needed, then revisit why 
+# in non-interactive mode.  If lsof is needed, then revisit why
 # why sbin need to be prepended looks like some environment issue in
 # user shell, e.g. /usr/local/bin/mis_env: No such file or directory.
 # is because user path contain bad directories that are searched when
@@ -58,11 +58,6 @@ if ( ! $?PATH ) then
 else
    setenv PATH $XILINX_XRT/bin:$PATH
 endif
-
-unsetenv XILINX_SDACCEL
-unsetenv XILINX_SDX
-unsetenv XILINX_OPENCL
-unsetenv XCL_EMULATION_MODE
 
 echo "XILINX_XRT      : $XILINX_XRT"
 echo "PATH            : $PATH"

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -32,10 +32,6 @@ fi
 export XILINX_XRT
 export LD_LIBRARY_PATH=$XILINX_XRT/lib:$LD_LIBRARY_PATH
 export PATH=$XILINX_XRT/bin:$PATH
-unset XILINX_SDACCEL
-unset XILINX_SDX
-unset XILINX_OPENCL
-unset XCL_EMULATION_MODE
 
 echo "XILINX_XRT      : $XILINX_XRT"
 echo "PATH            : $PATH"

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -41,6 +41,7 @@ directoryOrError(const bfs::path& path)
     throw std::runtime_error("No such directory '" + path.string() + "'");
 }
 
+XRT_UNUSED
 static const char*
 getPlatform()
 {
@@ -70,15 +71,6 @@ versionFunc()
   static std::string sVersionFunc = "xclVersion";
   return sVersionFunc;
 }
-
-//#ifdef PMD_OCL
-//static std::string&
-//pmdPropeFunc()
-//{
-//  static std::string sPropeFunc = "pmdProbe";
-//  return sPropeFunc;
-//}
-//#endif
 
 static boost::filesystem::path&
 dllExt()
@@ -141,22 +133,6 @@ createHalDevices(hal::device_list& devices, const std::string& dll, unsigned int
   }
 }
 
-static void
-loadHalDevices(hal::device_list& devices, const bfs::path& dir)
-{
-  // Iterator directory looking for driver dlls
-  bfs::directory_iterator end;
-  for (bfs::directory_iterator itr(dir);itr!=end;++itr) {
-    bfs::path file(itr->path());
-    if (isDLL(file))
-    {
-      if (!file.filename().compare("libxrt_hwemu.so") || !file.filename().compare("libxrt_swemu.so") || !file.filename().compare("libcommon_em.so"))
-        continue;
-      createHalDevices(devices,file.string());
-    }
-  }
-}
-
 } // namespace
 
 namespace xrt { namespace hal {
@@ -176,90 +152,45 @@ loadDevices()
 {
   hal::device_list devices;
 
-  bfs::path opencl(emptyOrValue(getenv("XILINX_OPENCL")));
-  if (!opencl.empty()) {
-    directoryOrError(opencl);
-    bfs::path path(opencl / "runtime/platforms");
-    bfs::directory_iterator end;
-    if(bfs::exists(path)) {
-     for (bfs::directory_iterator itr(path); itr!=end; ++itr) {
-       bfs::path p(itr->path());
-       if (!p.filename().compare("hw_em") || !p.filename().compare("sw_em") || isEmulationMode())
-         continue;
-       p /= "driver";
-       if (bfs::is_directory(p))
-         loadHalDevices(devices,p);
-     }
-    }
-  }
-
-  // [optional]/xrt
+  // xrt
   bfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
   if (!xrt.empty() && !isEmulationMode()) {
     directoryOrError(xrt);
-    bfs::path p(xrt / "lib");
-    if (bfs::is_directory(p))
-      loadHalDevices(devices,p);
+    bfs::path p(xrt / "lib/libxrt_core.so");
+    if (isDLL(p))
+      createHalDevices(devices,p.string());
   }
 
-  bfs::path sdaccel(emptyOrValue(getenv("XILINX_SDX")));
-  if (xrt.empty() && !sdaccel.empty() && !isEmulationMode()) {
-    directoryOrError(sdaccel);
-    bfs::path p(sdaccel / "data/sdaccel/pcie");
-    p /= getPlatform();
-    if (bfs::is_directory(p))
-      loadHalDevices(devices,p);
+  if (!xrt.empty() && isEmulationMode()) {
+    directoryOrError(xrt);
+
+    auto hw_em_driver_path = xrt::config::get_hw_em_driver();
+    if (hw_em_driver_path == "null") {
+      bfs::path p(xrt / "lib/libxrt_hwemu.so");
+      if (isDLL(p))
+        hw_em_driver_path = p.string();
+    }
+
+    if (isDLL(hw_em_driver_path))
+      createHalDevices(devices,hw_em_driver_path);
   }
 
-  if (!sdaccel.empty() && isEmulationMode()) {
-    bfs::path em_platform = (strcmp(getPlatform(),"aarch64") == 0) ? "zynqu" : (((strcmp(getPlatform(),"arm64")==0) ? "zynq":"generic_pcie")) ;
-    // Load emulation HAL
-    bfs::path hw_em(sdaccel / "data/emulation/unified/hw_em" / em_platform / "driver/libhw_em.so");
-    if(!xrt.empty()) {
-      bfs::path hw_em_from_xrt (xrt / "lib/libxrt_hwemu.so");
-      if (isDLL(hw_em_from_xrt)) {
-        hw_em = hw_em_from_xrt;
-      }
+  if (!xrt.empty() && isEmulationMode()) {
+    directoryOrError(xrt);
+
+    auto sw_em_driver_path = xrt::config::get_sw_em_driver();
+    if (sw_em_driver_path == "null") {
+      bfs::path p(xrt / "lib/libxrt_swemu.so");
+      if (isDLL(p))
+        sw_em_driver_path = p.string();
     }
 
-    //give high priority to the driver provided in sdaccel.ini
-    std::string hw_em_driver_path = xrt::config::get_hw_em_driver();
-    if (!hw_em_driver_path.compare("null"))
-      hw_em_driver_path.clear();
-
-    if(hw_em_driver_path.size())
-      hw_em = hw_em_driver_path;
-
-    int numHwEm = 0;
-    if (isDLL(hw_em)) {
-      numHwEm = devices.size();
-      createHalDevices(devices,hw_em.string());
-      numHwEm = devices.size() - numHwEm;
-    }
-
-    bfs::path sw_em (sdaccel / "data/emulation/unified/cpu_em" / em_platform / "driver/libcpu_em.so");
-    if(!xrt.empty()) {
-      bfs::path sw_em_from_xrt (xrt / "lib/libxrt_swemu.so");
-      if (isDLL(sw_em_from_xrt)) {
-        sw_em = sw_em_from_xrt;
-      }
-    }
-
-    //give high priority to the driver provided in sdaccel.ini
-    std::string sw_em_driver_path = xrt::config::get_sw_em_driver();
-    if (!sw_em_driver_path.compare("null"))
-      sw_em_driver_path.clear();
-
-    if(sw_em_driver_path.size())
-      sw_em = sw_em_driver_path;
-
-    if (isDLL(sw_em))
-      // sw_emu uses the json file used to by hwem so sw-em will match hw-em
-      createHalDevices(devices,sw_em.string());
+    if (isDLL(sw_em_driver_path))
+      createHalDevices(devices,sw_em_driver_path);
   }
 
-  if (xrt.empty() && sdaccel.empty() && opencl.empty())
-    throw std::runtime_error("Either XILINX_OPENCL or XILINX_SDX must be set");
+  if (xrt.empty())
+    throw std::runtime_error("XILINX_XRT must be set");
 
   return devices;
 }


### PR DESCRIPTION
- Change HAL loader to load rename core libary
- Clean up how HAL loader loads emulation libraries
- Don't mess with ENV vars unrelated to XRT in setup.csh and setup.sh