### PR TITLE
Create cl_ext.h to include cl_ext_xilinx.h

### DIFF
--- a/src/runtime_src/driver/include/CMakeLists.txt
+++ b/src/runtime_src/driver/include/CMakeLists.txt
@@ -11,12 +11,7 @@ set(XRT_HEADER_SRC
 
 install (FILES ${XRT_HEADER_SRC} DESTINATION ${XRT_INSTALL_DIR}/include)
 
-set(XRT_CL_EXT_SRC
-  CL/cl_ext_xilinx.h)
-
-install (FILES ${XRT_CL_EXT_SRC} DESTINATION ${XRT_INSTALL_DIR}/include/CL)
-
 message("-- XRT header files")
-foreach (header ${XRT_HEADER_SRC} ${XRT_CL_EXT_SRC})
+foreach (header ${XRT_HEADER_SRC})
   message("-- ${header}")
 endforeach()

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -49,3 +49,14 @@ set(XRT_XOCL_ALL_SRC
   )
 
 add_library(xocl OBJECT ${XRT_XOCL_ALL_SRC})
+
+set(XRT_CL_EXT_SRC
+  api/xlnx/cl_ext_xilinx.h
+  api/xlnx/cl_ext.h)
+
+install (FILES ${XRT_CL_EXT_SRC} DESTINATION ${XRT_INSTALL_DIR}/include/CL)
+
+message("-- XRT CL extension header files")
+foreach (header ${XRT_CL_EXT_SRC})
+  message("-- ${header}")
+endforeach()

--- a/src/runtime_src/xocl/api/xlnx/cl_ext.h
+++ b/src/runtime_src/xocl/api/xlnx/cl_ext.h
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2015 The Khronos Group Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and/or associated documentation files (the
+ * "Materials"), to deal in the Materials without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Materials, and to
+ * permit persons to whom the Materials are furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Materials.
+ *
+ * MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+ * KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+ * SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+ *    https://www.khronos.org/registry/
+ *
+ * THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+ ******************************************************************************/
+
+/*
+ * Copyright (C) 2018, Xilinx Inc - All rights reserved
+ */
+
+#ifndef __XOCL_CL_EXT_H
+#define __XOCL_CL_EXT_H
+
+// This isn't the coolest.  If an application truly needs cl_ext.h
+// and finds this one first, then the warning is bogus.
+#warning Deprecated Xilinx cl_ext.h included, please replace with cl_ext_xilinx.h
+#include <CL/cl_ext_xilinx.h>
+
+#endif

--- a/src/runtime_src/xocl/api/xlnx/cl_ext_xilinx.h
+++ b/src/runtime_src/xocl/api/xlnx/cl_ext_xilinx.h
@@ -33,7 +33,8 @@
 #ifndef __CL_EXT_XILINX_H
 #define __CL_EXT_XILINX_H
 
-#include <CL/cl_ext.h>
+// Do *not* include cl_ext.h from this directory
+#include_next <CL/cl_ext.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
cl_ext_xilinx.h in turn includes (#include_next) cl_ext.h from OpenCL.  Applications should be changed to #include cl_ext_xilinx.h for Xilinx specific extensions, but will continue to work provided they include $XILINX_XRT/include/cl_ext.h.  

Revisit and remove $XILINX_XRT/include/cl_ext.h when no longer needed.