### PR TITLE
libxdp.so linked against libxilinxopencl.so and dlopen uses RTLD_NOW

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -47,6 +47,10 @@ set (CMAKE_SHARED_LINKER_FLAGS "-Wl,-Bsymbolic")
 set_target_properties(xilinxopencl PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_VERSION_MAJOR})
 
+target_link_libraries(xdp
+  xilinxopencl
+  )
+
 target_link_libraries(xilinxopencl
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -217,7 +217,7 @@ load_xdp()
       if (!isDLL(p)) {
         throw std::runtime_error("Library " + p.string() + " not found!");
       }
-      auto handle = dlopen(p.string().c_str(), RTLD_LAZY | RTLD_GLOBAL);
+      auto handle = dlopen(p.string().c_str(), RTLD_NOW | RTLD_GLOBAL);
       if (!handle)
         throw std::runtime_error("Failed to open XDP library '" + p.string() + "'\n" + dlerror());
 


### PR DESCRIPTION
Hi Soren, Take a look at the 2 changes I have. The failing test now passes, we need to check if the problem is fixed on all machines