### PR TITLE
Fix xocl::memory synchronization when allocating boh

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -452,7 +452,7 @@ allocate_buffer_object(memory* mem)
 
     try {
       auto boh = alloc(mem,memidx);
-      XOCL_DEBUG(std::cout,"memory(",mem->get_uid(),") allocated on device(",m_uid,") in memory index(",flag,")\n");
+      XOCL_DEBUG(std::cout,"memory(",mem->get_uid(),") allocated on device(",m_uid,") in memory index(",memidx,")\n");
       return boh;
     }
     catch (const std::bad_alloc&) {
@@ -493,7 +493,7 @@ allocate_buffer_object(memory* mem, uint64_t memidx)
   }
 
   auto flag = (mem->get_ext_flags()) & 0xffffff;
-  if (flag && xdevice->hasBankAlloc()) {
+  if (flag && xdevice->hasBankAlloc() && !is_sw_emulation()) {
     auto bank = myctz(flag);
     auto midx = m_xclbin.banktag_to_memidx(std::string("bank")+std::to_string(bank));
     if (midx==-1)

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -372,7 +372,7 @@ public:
   virtual bool
   is_resident() const
   {
-    std::lock_guard<std::mutex> lk(m_boh_mutex);
+    std::lock_guard<std::recursive_mutex> lk(m_boh_mutex);
     return m_resident.size();
   }
 
@@ -382,7 +382,7 @@ public:
   virtual bool
   is_resident(const device* device) const
   {
-    std::lock_guard<std::mutex> lk(m_boh_mutex);
+    std::lock_guard<std::recursive_mutex> lk(m_boh_mutex);
     return (std::find(m_resident.begin(),m_resident.end(),device) != m_resident.end());
   }
 
@@ -392,7 +392,7 @@ public:
   virtual const device*
   get_resident_device() const
   {
-    std::lock_guard<std::mutex> lk(m_boh_mutex);
+    std::lock_guard<std::recursive_mutex> lk(m_boh_mutex);
     auto sz = m_resident.size();
     if (!sz || sz>1)
       return nullptr;
@@ -405,7 +405,7 @@ public:
   void
   set_resident(const device* device)
   {
-    std::lock_guard<std::mutex> lk(m_boh_mutex);
+    std::lock_guard<std::recursive_mutex> lk(m_boh_mutex);
     if (std::find(m_resident.begin(),m_resident.end(),device) == m_resident.end())
       m_resident.push_back(device);
   }
@@ -416,7 +416,7 @@ public:
   void
   clear_resident()
   {
-    std::lock_guard<std::mutex> lk(m_boh_mutex);
+    std::lock_guard<std::recursive_mutex> lk(m_boh_mutex);
     m_resident.clear();
   }
 
@@ -452,7 +452,7 @@ private:
   // allocation unless needed.
   std::unique_ptr<std::vector<std::function<void()>>> m_dtor_notify;
 
-  mutable std::mutex m_boh_mutex;
+  mutable std::recursive_mutex m_boh_mutex;
   bomap_type m_bomap;
   std::vector<const device*> m_resident;
 };


### PR DESCRIPTION
One unfortunate change in this PR is the need for recursive_mutex for
xocl::memory.  Recursive mutexes are bad coding style and usually
point at poor design.  I can't easily think of a better way here
though, there are multiple threads competing to create and access
buffer object handles and they share functions.

One example is set_kernel_arg calling get_buffer_object(kernel,arg),
which in turn competes with enqueue operations that create buffer
object handles using get_buffer_object(), both functions end up
calling the same buffer object creation routine after having made
several other checks that require mutex locked.  If any flaw, then it
is OpenCL that allows premature device side buffer allocation before
memory connections are known.