### PR TITLE
Make ccache root all header inclusion at 'XILINX_XRT/src

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -66,9 +66,11 @@ if [[ $clean == 1 ]]; then
 fi
 
 if [[ $ccache == 1 ]]; then
-    export RDI_ROOT=unused
-    export RDI_BUILDROOT=unused
+    SRCROOT=`readlink -f $BUILDDIR/../src`
+    export RDI_ROOT=$SRCROOT
+    export RDI_BUILDROOT=$SRCROOT
     export RDI_CCACHEROOT=/scratch/ccache/$USER
+    mkdir -p $RDI_CCACHEROOT
     # Run cleanup script once a day
     # Clean cache dir for stale files older than 30 days
     if [[ -e /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl ]]; then


### PR DESCRIPTION
This way cache can be shared between multiple clones or between
different developers (if developers share cache)