### PR TITLE
Update the pkgdsa.sh script to:

### DIFF
--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -6,10 +6,6 @@
 # The script is assumed to run on a host or docker that has all the
 # necessary rpm/deb tools installed.
 #
-# The script uses xbinst to extract the platform deployment files
-#   - dsabin, msc, bit
-# xbinst is invoked from the specified or default sdx location
-#
 # Examples:
 #
 #  Package DSA from platform dir in default sdx install
@@ -25,7 +21,7 @@
 #       -xrt 2.1.0 \
 #       -cl 12345678
 #
-#  Package DSA from specified DSA platform dir using xbinst from default sdx
+#  Package DSA from specified DSA platform dir 
 #  % pkgdsa.sh -dsa xilinx_vcu1525_dynamic_5_1 \
 #       -dsadir <workspace>2018.2/prep/rdi/sdx/platforms/xilinx_vcu1525_dynamic_5_1 \
 #       -xrt 2.1.0 \
@@ -131,39 +127,266 @@ if [ "X$opt_xrt" == "X" ]; then
   exit 1;
 fi
 
+if [ "X${XILINX_XRT}" == "X" ]; then
+  echo "Environment variable XILINX_XRT is not set.  Please the XRT setup script."
+#  exit 1;
+fi
+
 # get dsa, version, and revision
 dsa=$(echo ${opt_dsa:0:${#opt_dsa}-4} | tr '_' '-')
 version=$(echo ${opt_dsa:(-3)} | tr '_' '.')
 revision=$opt_cl
 
 echo "================================================================"
-echo "DSA     : $dsa"
-echo "DSADIR  : $opt_dsadir"
-echo "PKGDIR  : $opt_pkgdir"
-echo "XRT     : $opt_xrt"
-echo "VERSION : $version"
-echo "REVISION: $revision"
+echo "DSA       : $dsa"
+echo "DSADIR    : $opt_dsadir"
+echo "PKGDIR    : $opt_pkgdir"
+echo "XRT       : $opt_xrt"
+echo "VERSION   : $version"
+echo "REVISION  : $revision"
+echo "XILINX_XRT: $XILINX_XRT"
 echo "================================================================"
 
-doxbinst()
+# DSABIN variables
+dsaFile=""
+mcsPrimary=""
+mcsSecondary=""
+fullBitFile=""
+clearBitstreamFile=""
+dsaXmlFile="dsa.xml"
+featureRomTimestamp=""
+fwScheduler=""
+fwManagement=""
+vbnv=""
+pci_vendor_id="0x0000"
+pci_device_id="0x0000"
+pci_subsystem_id="0x0000"
+dsabinOutputFile=""
+
+createEntityAttributeArray ()
 {
-    mkdir -p $opt_pkgdir/xbinst
+  unset ENTITY_ATTRIBUTES_ARRAY
+  declare -A -g ENTITY_ATTRIBUTES_ARRAY
+
+  for kvp in $ENTITY_ATTRIBUTES; do
+    set -- `echo $kvp | tr '=' ' '`
+    # Remove leading and trailing quotes
+    value=$2
+    value="${value%\"}"
+    value="${value#\"}"
+    ENTITY_ATTRIBUTES_ARRAY[$1]=$value
+  done
+}
+
+readSAX () {
+  # Set Input Field Spearator to be local to this function and change it to
+  # the '>' character
+  local IFS=\>
+
+  # Read the input from stdin and stop when the '<' character is seen.
+  read -d \< ENTITY_LINE
+
+  local ret=$?
+
+  # Remove any trailing "/>" characters
+  ENTITY_LINE="${ENTITY_LINE///>/}"
+
+  # Remove any carriage returns
+  ENTITY_LINE="${ENTITY_LINE//$'\n'/}"
+
+  # Remove any training whitespaces
+  ENTITY_LINE="${ENTITY_LINE%"${ENTITY_LINE##*[![:space:]]}"}" 
+
+  ENTITY_NAME="${ENTITY_LINE%% *}"
+  ENTITY_ATTRIBUTES="${ENTITY_LINE#* }"
+
+  return $ret
+}
+
+recordDsaFiles()
+{
+   # Full Static Bitstream
+   if [ "${ENTITY_ATTRIBUTES_ARRAY[Type]}" == "FULL_BIT" ]; then
+     fullBitFile="${ENTITY_ATTRIBUTES_ARRAY[Name]}"
+   fi
+
+   # MCS Primary
+   if [ "${ENTITY_ATTRIBUTES_ARRAY[Type]}" == "MCS" ]; then
+     mcsPrimary="firmware/${ENTITY_ATTRIBUTES_ARRAY[Name]}"
+   fi
+
+   # MCS Secondary
+   if [ "${ENTITY_ATTRIBUTES_ARRAY[Type]}" == "SECONDARY_MCS" ]; then
+     mcsSecondary="firmware/${ENTITY_ATTRIBUTES_ARRAY[Name]}"
+   fi
+
+   # Clear Bitstream
+   if [ "${ENTITY_ATTRIBUTES_ARRAY[Type]}" == "CLEAR_BIT" ]; then
+     clearBitstreamFile="${ENTITY_ATTRIBUTES_ARRAY[Name]}"
+   fi
+}
+
+readDsaMetaData()
+{
+  # -- Extract the dsa.xml metadata file --
+  unzip -q -d . "${dsaFile}" "${dsaXmlFile}"
+
+  while readSAX; do
+    # Record the data types
+    if [ "${ENTITY_NAME}" == "File" ]; then
+      createEntityAttributeArray
+      recordDsaFiles
+    fi    
+
+    # Record the FeatureRomTimestamp
+    if [ "${ENTITY_NAME}" == "DSA" ]; then
+      createEntityAttributeArray
+
+      featureRomTimestamp="${ENTITY_ATTRIBUTES_ARRAY[FeatureRomTimestamp]}"
+
+      vendor="${ENTITY_ATTRIBUTES_ARRAY[Vendor]}"
+      board="${ENTITY_ATTRIBUTES_ARRAY[BoardId]}"
+      name="${ENTITY_ATTRIBUTES_ARRAY[Name]}"
+      versionMajor="${ENTITY_ATTRIBUTES_ARRAY[VersionMajor]}"
+      versionMinor="${ENTITY_ATTRIBUTES_ARRAY[VersionMinor]}"
+      vbnv=$(printf "%s:%s:%s:%s.%s" "${vendor}" "${board}" "${name}" "${versionMajor}" "${versionMinor}")
+    fi    
+
+    # Record the PCIeID information 
+    if [ "${ENTITY_NAME}" == "PCIeId" ]; then
+      createEntityAttributeArray
+
+      pci_vendor_id="${ENTITY_ATTRIBUTES_ARRAY[Vendor]}"
+      pci_device_id="${ENTITY_ATTRIBUTES_ARRAY[Device]}"
+      pci_subsystem_id="${ENTITY_ATTRIBUTES_ARRAY[Subsystem]}"
+    fi    
+  done < "${dsaXmlFile}"
+}
+
+initDsaBinEnvAndVars()
+{
+    # Clean out the dsabin directory
+    /bin/rm -rf "${opt_pkgdir}/dsabin"
+    mkdir -p "${opt_pkgdir}/dsabin"
+    cd "${opt_pkgdir}/dsabin"
+
+    # -- Get the DSA for this platform --
+    dsaFile="${opt_dsadir}/hw/${opt_dsa}.dsa"
+    if [ ! -f "${dsaFile}" ]; then
+       echo "Error: DSA file does not exist: ${dsaFile}"
+       popd >/dev/null
+       exit 1
+    fi
+  
+    # Read the metadata from the dsa.xml file 
+    readDsaMetaData
+  
+    # -- Extract the MCS Files --
+    if [ "${mcsPrimary}" != "" ]; then
+       echo "Info: Extracting MCS Primary file: ${mcsPrimary}"
+       unzip -q -d . "${dsaFile}" "${mcsPrimary}"
+    fi
+
+    if [ "${mcsSecondary}" != "" ]; then
+       echo "Info: Extracting MCS Secondary file: ${mcsSecondary}"
+       unzip -q -d . "${dsaFile}" "${mcsSecondary}"
+    fi
+
+    # -- Extract the bitstreams --
+    if [ "${fullBitFile}" != "" ]; then
+       echo "Info: Extracting Full Bitstream file: ${fullBitFile}"
+       unzip -q -d "./firmware" "${dsaFile}" "${fullBitFile}"
+    fi
+
+    if [ "${clearBitstreamFile}" != "" ]; then
+       echo "Info: Extracting Clear Bitstream file: ${clearBitstreamFile}"
+       unzip -q -d "./firmware" "${dsaFile}" "${clearBitstreamFile}"
+    fi
+
+    # -- Determine firmware --
+    if [[ ${opt_dsa} =~ "xdma" ]]; then
+      fwScheduler="${XILINX_XRT}/share/fw/sched.bin"
+      fwManagement="${XILINX_XRT}/share/fw/xmc.bin"
+    else
+      fwScheduler="${XILINX_XRT}/share/fw/sched.bin"
+      fwManagement="${XILINX_XRT}/share/fw/mgmt.bin"
+    fi
+}
+
+dodsabin()
+{
     pushd $opt_pkgdir > /dev/null
-    cd $opt_pkgdir
-    if [ -d $opt_pkgdir/xbinst/$opt_dsa ]; then
-        /bin/rm -rf $opt_pkgdir/xbinst/$opt_dsa
+    echo "Creating dsabin for: ${opt_dsa}"
+
+    initDsaBinEnvAndVars
+
+    # Build the xclbincat options
+    xclbinOpts=""
+
+    # -- MCS_PRIMARY image --
+    if [ "$mcsPrimary" != "" ]; then
+       xclbinOpts+=" -s MCS_PRIMARY ${mcsPrimary}"
     fi
-    $opt_sdx/bin/xbinst -f $opt_dsadir/$opt_dsa.xpfm -d $opt_pkgdir/xbinst/$opt_dsa
-    test=$?
+    
+    # -- MCS_SECONDARY image --
+    if [ "$mcsSecondary" != "" ]; then
+       xclbinOpts+=" -s MCS_SECONDARY ${mcsSecondary}"
+    fi
+    
+    # -- Firmware: Scheduler --
+    if [ "${fwScheduler}" != "" ]; then
+       if [ -f "${fwScheduler}" ]; then
+         xclbinOpts+=" -s SCHEDULER ${fwScheduler}"
+       else
+         echo "Warning: Scheduler firmware does not exist: ${fwScheduler}"
+       fi
+    fi
+    
+    # -- Firmware: Management --
+    if [ "${fwManagement}" != "" ]; then
+       if [ -f "${fwManagement}" ]; then
+         xclbinOpts+=" -s FIRMWARE ${fwManagement}"
+       else
+         echo "Warning: Management firmware does not exist: ${fwManagement}"
+      fi
+    fi
+
+    # -- Clear bitstream --
+    if [ "${clearBitstreamFile}" != "" ]; then
+       xclbinOpts+=" -s CLEAR_BITSTREAM ./firmware/${clearBitstreamFile}"
+    fi
+
+    # -- FeatureRom Timestamp --
+    if [ "${featureRomTimestamp}" != "" ]; then
+       xclbinOpts+=" --kvp featureRomTimestamp:${featureRomTimestamp}"
+    else
+       echo "Warning: Missing featureRomTimestamp"
+    fi
+
+    # -- VBNV --
+    if [ "${vbnv}" != "" ]; then
+       xclbinOpts+=" --kvp platformVBNV:${vbnv}"
+    else
+       echo "Warning: Missing Platform VBNV value"
+    fi
+
+    # -- Mode Hardware PR --
+    xclbinOpts+=" --kvp mode:hw_pr"
+
+    # -- Output filename --
+    localFeatureRomTimestamp="${featureRomTimestamp}"
+    if [ "${localFeatureRomTimestamp}" == "" ]; then
+      localFeatureRomTimestamp="0"
+    fi
+
+    dsabinOutputFile=$(printf "%s-%s-%s-%016d.dsabin" "${pci_vendor_id#0x}" "${pci_device_id#0x}" "${pci_subsystem_id#0x}" "${localFeatureRomTimestamp}")
+    xclbinOpts+=" -o ./firmware/${dsabinOutputFile}"    
+
+
+    echo "${XILINX_XRT}/bin/xclbincat ${xclbinOpts}"
+    ${XILINX_XRT}/bin/xclbincat ${xclbinOpts}
+
     popd >/dev/null
-    if [ "$test" != 0 ]; then
-	echo
-	echo
-	echo "There was an unexpected ERROR executing: "
-	echo "$opt_sdx/bin/xbinst -f $opt_dsadir/$opt_dsa.xpfm -d $opt_pkgdir/xbinst/$opt_dsa"
-	echo "################ xbinst failed! ###############"
-	exit $test
-    fi
 }
 
 dodebdev()
@@ -212,9 +435,9 @@ maintainer: soren.soe@xilinx.com
 EOF
 
     mkdir -p $opt_pkgdir/$dir/lib/firmware/xilinx
-    rsync -avz $opt_pkgdir/xbinst/$opt_dsa/xbinst/firmware/ $opt_pkgdir/$dir/lib/firmware/xilinx
+    rsync -avz $opt_pkgdir/dsabin/firmware/ $opt_pkgdir/$dir/lib/firmware/xilinx
     mkdir -p $opt_pkgdir/$dir/opt/xilinx/dsa/$opt_dsa/test
-    rsync -avz $opt_pkgdir/xbinst/$opt_dsa/xbinst/test/ $opt_pkgdir/$dir/opt/xilinx/dsa/$opt_dsa/test
+    rsync -avz ${opt_dsadir}/test/ $opt_pkgdir/$dir/opt/xilinx/dsa/$opt_dsa/test
     dpkg-deb --build $opt_pkgdir/$dir
 
     echo "================================================================"
@@ -293,9 +516,9 @@ Xilinx deployment DSA.  This DSA depends on xrt >= $opt_xrt.
 
 %install
 mkdir -p %{buildroot}/lib/firmware/xilinx
-cp $opt_pkgdir/xbinst/$opt_dsa/xbinst/firmware/* %{buildroot}/lib/firmware/xilinx
+cp $opt_pkgdir/dsabin/firmware/* %{buildroot}/lib/firmware/xilinx
 mkdir -p %{buildroot}/opt/xilinx/dsa/$opt_dsa/test
-cp $opt_pkgdir/xbinst/$opt_dsa/xbinst/test/* %{buildroot}/opt/xilinx/dsa/$opt_dsa/test
+cp ${opt_dsadir}/test/* %{buildroot}/opt/xilinx/dsa/$opt_dsa/test
 
 %files
 %defattr(-,root,root,-)
@@ -323,7 +546,7 @@ if [ $FLAVOR == "centos" ]; then
  if [ $opt_dev == 1 ]; then
      dorpmdev
  else
-     doxbinst
+     dodsabin
      dorpm
  fi
 fi
@@ -332,7 +555,7 @@ if [ $FLAVOR == "ubuntu" ]; then
  if [ $opt_dev == 1 ]; then
      dodebdev
  else
-     doxbinst
+     dodsabin
      dodeb
  fi
 fi


### PR DESCRIPTION
1. No longer depend on xbinst
2. Call xclbincat directly to build the dsabin file
3. Package MCS images into the dsabin
4. Support using the management "xmc" firmware image for the XBB boards

Work Done
---------
1) Replace xbinst call to extract the binary images directly from the DSA and parse the dsa.xml file.
2) Update the script to be dependent on the XILINX_XRT environment variable, which is set by setup.sh in the xrt directory.
3) Added error checking for many of the variable.
4) Examines the XBB DSA to determine which firmware images to load into the dsabin.
5) Update both the dep and rpm packages to support this new flow.
6) xclbincat is call directly instead of relying on the path to discover it.

Besides running this script locally, I gave Nasser a copy and his team ran it on a server to validate correct operation.  He too validated correct operation.