### PR TITLE
Update the pkgdsa.sh script to be more driver friendly.

### DIFF
--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -260,6 +260,15 @@ readDsaMetaData()
       pci_device_id="${ENTITY_ATTRIBUTES_ARRAY[Device]}"
       pci_subsystem_id="${ENTITY_ATTRIBUTES_ARRAY[Subsystem]}"
     fi    
+
+    # FeatureRom Data
+    if [ "${ENTITY_NAME}" == "FeatureRom" ]; then
+      createEntityAttributeArray
+
+      # Overright previous value
+      featureRomTimestamp="${ENTITY_ATTRIBUTES_ARRAY[TimeSinceEpoch]}"
+    fi    
+
   done < "${dsaXmlFile}"
 }
 
@@ -379,7 +388,9 @@ dodsabin()
       localFeatureRomTimestamp="0"
     fi
 
-    dsabinOutputFile=$(printf "%s-%s-%s-%016d.dsabin" "${pci_vendor_id#0x}" "${pci_device_id#0x}" "${pci_subsystem_id#0x}" "${localFeatureRomTimestamp}")
+    # Build output file and lowercase the name
+    dsabinOutputFile=$(printf "%s-%s-%s-%016x.dsabin" "${pci_vendor_id#0x}" "${pci_device_id#0x}" "${pci_subsystem_id#0x}" "${localFeatureRomTimestamp}")
+    dsabinOutputFile="${dsabinOutputFile,,}"
     xclbinOpts+=" -o ./firmware/${dsabinOutputFile}"    
 
 


### PR DESCRIPTION
To better help the XRT drivers to discover the dsabin file, some changes were needed to be made to the name of the output file.

Work done:
1) Lowercase the output name of the dsabin file.
2) Picked up the FeatureRom Timestamp from the "FeatureRom" section "if exists" instead of the DSA section.  In some cases, the DSA FeatureRomTimestamp was set to "0" in the DSA.