### PR TITLE
For RPM packages, swapped the version and "dev" entries.

### DIFF
--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -466,9 +466,11 @@ dorpmdev()
 
 cat <<EOF > $opt_pkgdir/$dir/SPECS/$opt_dsa-dev.spec
 
+%define _rpmfilename %%{ARCH}/%%{NAME}-%%{VERSION}-dev-%%{RELEASE}.%%{ARCH}.rpm
+
 buildroot:  %{_topdir}
 summary: Xilinx development DSA
-name: $dsa-dev
+name: $dsa
 version: $version
 release: $revision
 license: apache


### PR DESCRIPTION
For example:
    xilinx-u200-xdma-dev-201820.2-0.x86_64.rpm
becomes:
    xilinx-u200-xdma-201820.2-dev-0.x86_64.rpm