### PR TITLE
Do not throw bad_alloc if kernel argument bank check fails

### DIFF
--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -172,7 +172,7 @@ get_buffer_object(kernel* kernel, unsigned long argidx)
       throw std::bad_alloc();
     }
   }
-  throw std::bad_alloc();
+  return nullptr;
 }
 
 memory::buffer_object_handle


### PR DESCRIPTION
Kernel argument check is called during set_argument, but may not be
able to do allocation check if the device context has multiple
devices.  At the time the kernel argument is set the targeted device
is unknown.  In other words, the argument cannot be allocated before
an enqueue operation where the targeted device is known.