### PR TITLE
if Xilinx device has no USER PF or MGMT PF, continue

### DIFF
--- a/src/runtime_src/driver/xclng/xrt/user_gem/scan.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/scan.cpp
@@ -354,8 +354,7 @@ int xcldev::pci_device_scanner::scan(bool print)
         } else if ((board_info = get_user_devinfo(device.vendor_id, device.device_id, device.subsystem_id))) {
             bar = board_info->priv_data->user_bar; 
         } else {
-            retVal = -ENODEV;
-            break;
+            continue;
         }
 
         device.user_bar = bar;


### PR DESCRIPTION
I meet a scan issue on a DSA with 3-port PCIe switch IP. It has Xilinx vendor id. But there are no USRE PF or MGMT PF. Instead of break and error out, it should continue check other PCIe devices.