### PR TITLE
Clean up overloaded use of cl_mem_ext_ptr_t

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -47,17 +47,59 @@
 extern "C" {
 #endif
 
-typedef struct cl_mem_ext_ptr_t {
-  cl_mem_ext_ptr_t()
-      :flags(0),obj(0),param(0){};
-  unsigned flags; //Top 8 bits reserved.
-  void *obj;
-  void *param;
-} cl_mem_ext_ptr_t;
-
 /**************************
 * Xilinx vendor extensions*
 **************************/
+
+/**
+ * struct cl_mem_ext_ptr: Xilinx specific memory extensions
+ *
+ * Control bank allocation of buffer object.
+ *
+ * @flags:    Legacy bank flag when @kernel is nullptr
+ * @argidx:   Same as @flags, argument index associated with valid @kernel
+ * @host_ptr: Host pointer when buffer is created with CL_MEM_USE_HOST_PTR
+ * @obj:      Same as @obj
+ * @param:    Same as @kernel
+ * @kernel:   Kernel associated with @argidx
+ *
+ * The default legacy layout has overloaded use of flags and param, which
+ * is redefined/aliased in interpreted layouts.
+ *
+ * Two usages are supported:
+ *  (1) Specify bank assignment for buffer with XCL_MEM mask. Optionally
+ *      use host_ptr for reusing host side buffer per CL_MEM_USE_HOST_PTR.
+ *  (2) Specify that buffer is for argument @argidx of kernel @kernel.
+ *      Optionally use host_ptr as for (1).
+ *
+ * To use cl_mem_ext_ptr_t, simply pass the struct object as the host_ptr
+ * clCreateBuffer and make sure cl_mem_flags specifies CL_MEM_EXT_PTR_XILINX
+ */
+typedef struct cl_mem_ext_ptr_t {
+  union {
+    struct { // legacy layout
+      unsigned int flags;   // Top 8 bits reserved.
+      void *obj;
+      void *param;
+    };
+    struct { // interpreted legcy bank assignment
+      unsigned int banks;   // Top 8 bits reserved.
+      void *host_ptr;
+      void *unused1;        // nullptr required
+    };
+    struct { // interpreted kernel arg assignment
+      unsigned int argidx;
+      void *host_ptr_;      // use as host_ptr
+      cl_kernel kernel;
+    };
+  };
+  cl_mem_ext_ptr_t()
+  : flags(0),obj(0),param(0) {}
+} cl_mem_ext_ptr_t;
+
+/* Make clCreateBuffer to interpret host_ptr argument as cl_mem_ext_ptr_t */
+#define CL_MEM_EXT_PTR_XILINX                       (1 << 31)
+
 #define CL_XILINX_UNIMPLEMENTED  -20
 
 /* New flags for cl_queue */
@@ -147,7 +189,7 @@ xclEnqueuePeerToPeerCopyBuffer(cl_command_queue    command_queue,
 
 
 /**
- * cl_stream_flags. Type of the stream , eg set to CL_STREAM_READ_ONLY for 
+ * cl_stream_flags. Type of the stream , eg set to CL_STREAM_READ_ONLY for
  * read only. Used in clCreateStream()
  */
 typedef cl_bitfield         cl_stream_flags;
@@ -163,7 +205,7 @@ typedef cl_uint             cl_stream_attributes;
 #define CL_PACKET                                   (1 << 1)
 
 /**
- * cl_stream_attributes. 
+ * cl_stream_attributes.
  * eg set it to CL_STREAM_CDH for Customer Defined Header.
  * Used in clReadStream() and clWriteStream()
  */
@@ -182,7 +224,7 @@ typedef struct _cl_stream_mem *  cl_stream_mem;
  * @ext         : The extension for kernel and argument matching.
  * @errcode_ret : The return value eg CL_SUCCESS
  */
-extern CL_API_ENTRY cl_stream CL_API_CALL 
+extern CL_API_ENTRY cl_stream CL_API_CALL
 clCreateStream(cl_device_id                /* device_id */,
 	       cl_stream_flags             /* flags */,
 	       cl_stream_attributes        /* attributes*/,
@@ -195,7 +237,7 @@ clCreateStream(cl_device_id                /* device_id */,
  * @stream: The stream to be released.
  * Return a cl_int
  */
-extern CL_API_ENTRY cl_int CL_API_CALL 
+extern CL_API_ENTRY cl_int CL_API_CALL
 clReleaseStream(cl_stream /*stream*/) CL_API_SUFFIX__VERSION_1_0;
 
 /**
@@ -329,10 +371,8 @@ extern CL_API_ENTRY cl_int CL_API_CALL
 //cl_mem_flags bitfield
 //accepted by the <flags> parameter of clCreateBuffer
 
-#define CL_MEM_EXT_PTR_XILINX                       (1 << 31)
 
-
-//valid flags in above
+//valid flags in cl_mem_ext_ptr_t
 #define XCL_MEM_DDR_BANK0               (1<<0)
 #define XCL_MEM_DDR_BANK1               (1<<1)
 #define XCL_MEM_DDR_BANK2               (1<<2)

--- a/src/runtime_src/xocl/api/clCreateBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateBuffer.cpp
@@ -33,7 +33,7 @@ inline void*
 get_host_ptr(cl_mem_flags flags, void* host_ptr)
 {
   return (flags & CL_MEM_EXT_PTR_XILINX)
-    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->obj
+    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->host_ptr
     : host_ptr;
 }
 
@@ -45,11 +45,11 @@ get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
     : 0;
 }
 
-inline void*
-get_xlnx_ext_param(cl_mem_flags flags, void* host_ptr)
+inline cl_kernel
+get_xlnx_ext_kernel(cl_mem_flags flags, void* host_ptr)
 {
   return (flags & CL_MEM_EXT_PTR_XILINX)
-    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->param
+    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->kernel
     : 0;
 }
 
@@ -147,12 +147,12 @@ clCreateBuffer(cl_context   context,
 
   // set fields in cl_buffer
   buffer->add_ext_flags(get_xlnx_ext_flags(flags,host_ptr));
-  buffer->add_xlnx_ext_param(get_xlnx_ext_param(flags,host_ptr));
+  buffer->add_ext_kernel(xocl::xocl(get_xlnx_ext_kernel(flags,host_ptr)));
 
   // allocate device buffer object if context has only one device
   // and if this is not a progvar (clCreateProgramWithBinary)
   if (!(flags & CL_MEM_PROGVAR)) {
-    if (auto device = singleContextDevice(context, flags)) 
+    if (auto device = singleContextDevice(context, flags))
       buffer->get_buffer_object(device);
   }
 

--- a/src/runtime_src/xocl/api/detail/memory.cpp
+++ b/src/runtime_src/xocl/api/detail/memory.cpp
@@ -28,7 +28,7 @@ inline const void*
 get_host_ptr(cl_mem_flags flags, const void* host_ptr)
 {
   return (host_ptr && (flags & CL_MEM_EXT_PTR_XILINX))
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->obj
+    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->host_ptr
     : host_ptr;
 }
 
@@ -40,11 +40,11 @@ get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
     : 0;
 }
 
-inline const void*
-get_xlnx_ext_param(cl_mem_flags flags, const void* host_ptr)
+inline const cl_kernel
+get_xlnx_ext_kernel(cl_mem_flags flags, const void* host_ptr)
 {
   return (host_ptr && (flags & CL_MEM_EXT_PTR_XILINX))
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->param
+    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->kernel
     : 0;
 }
 
@@ -140,7 +140,7 @@ validHostPtrOrError(cl_mem_flags flags, const void* host_ptr)
 
   if (auto ext_flags = get_xlnx_ext_flags(flags,host_ptr)) {
     return;
-    if(get_xlnx_ext_param(ext_flags,host_ptr)&&!(ext_flags&XCL_MEM_TOPOLOGY)) {
+    if (get_xlnx_ext_kernel(ext_flags,host_ptr) && !(ext_flags & XCL_MEM_TOPOLOGY)) {
       auto ddr_bank_mask = XCL_MEM_DDR_BANK0 | XCL_MEM_DDR_BANK1 | XCL_MEM_DDR_BANK2 | XCL_MEM_DDR_BANK3;
       // Test that only one bank flag is set
       if (std::bitset<12>(ext_flags & ddr_bank_mask).count() > 1)

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -236,23 +236,23 @@ alloc(memory* mem)
   return boh;
 }
 
-int 
+int
 device::
-get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, cl_mem_ext_ptr_t* ext, xrt::device::stream_handle* stream) 
+get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, const cl_mem_ext_ptr_t* ext, xrt::device::stream_handle* stream)
 {
-  const cl_kernel kernel = (const cl_kernel)(ext->param);
+  auto kernel = xocl::xocl(ext->kernel);
   uint64_t route = 0;
   uint64_t flow = 0;
 
- if(kernel != nullptr) {
-   const std::string& kernel_name = xocl(kernel)->get_name_from_constructor();
+ if (kernel != nullptr) {
+   auto& kernel_name = kernel->get_name_from_constructor();
    auto memidx = m_xclbin.get_memidx_from_arg(kernel_name,ext->flags);
-   const mem_topology* mems = m_xclbin.get_mem_topology();
+   auto mems = m_xclbin.get_mem_topology();
 
-   if(!mems)
+   if (!mems)
      throw xocl::error(CL_INVALID_OPERATION,"Mem topology section does not exist");
-  
-   if((memidx+1) < mems->m_count)
+
+   if ((memidx+1) < mems->m_count)
      throw xocl::error(CL_INVALID_OPERATION,"Mem topology section count is less than memidex");
 
 
@@ -260,23 +260,23 @@ get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, cl_
     flow = mems->m_mem_data[memidx].flow_id;
   }
 
-  if(flags & CL_STREAM_READ_ONLY) 
+  if (flags & CL_STREAM_READ_ONLY)
     return m_xdevice->createReadStream(flags, attrs, route, flow, stream);
-  else if(flags & CL_STREAM_WRITE_ONLY)
+  else if (flags & CL_STREAM_WRITE_ONLY)
     return m_xdevice->createWriteStream(flags, attrs, route, flow, stream);
   else
     throw xocl::error(CL_INVALID_OPERATION,"Unknown stream type specified");
   return -1;
 }
 
-int 
+int
 device::
-close_stream(xrt::device::stream_handle stream) 
+close_stream(xrt::device::stream_handle stream)
 {
   return m_xdevice->closeStream(stream);
 }
 
-ssize_t 
+ssize_t
 device::
 write_stream(xrt::device::stream_handle stream, const void* ptr, size_t offset, size_t size, xrt::device::stream_xfer_flags flags)
 {
@@ -285,7 +285,7 @@ write_stream(xrt::device::stream_handle stream, const void* ptr, size_t offset, 
 
 ssize_t
 device::
-read_stream(xrt::device::stream_handle stream, void* ptr, size_t offset, size_t size, xrt::device::stream_xfer_flags flags) 
+read_stream(xrt::device::stream_handle stream, void* ptr, size_t offset, size_t size, xrt::device::stream_xfer_flags flags)
 {
   return m_xdevice->readStream(stream, ptr, offset, size, flags);
 }
@@ -297,7 +297,7 @@ alloc_stream_buf(size_t size, xrt::device::stream_buf_handle* handle)
   return m_xdevice->allocStreamBuf(size,handle);
 }
 
-int 
+int
 device::
 free_stream_buf(xrt::device::stream_buf_handle handle)
 {
@@ -499,21 +499,21 @@ allocate_buffer_object(memory* mem)
     //Rest 24 bits directly indexes into mem topology section OR.
     //have legacy one-hot encoding.
     auto flag = mem->get_ext_flags();
-    auto param = mem->get_xlnx_ext_param();
     int32_t memidx = 0;
-    if(param) {
+    if (auto kernel = mem->get_ext_kernel()) {
       //param<==>kernel; flag<==>arg_index
       flag = flag & 0xffffff;
-      const cl_kernel kernel = (const cl_kernel)(param);
-      const std::string& kernel_name = xocl(kernel)->get_name_from_constructor();
+      auto& kernel_name = kernel->get_name_from_constructor();
       memidx = m_xclbin.get_memidx_from_arg(kernel_name,flag);
-    } else if(flag & XCL_MEM_TOPOLOGY) {
+    }
+    else if (flag & XCL_MEM_TOPOLOGY) {
       memidx = flag & 0xffffff;
-    }else {
+    }
+    else {
       flag = flag & 0xffffff;
       auto bank = myctz(flag);
       memidx = m_xclbin.banktag_to_memidx(std::string("bank")+std::to_string(bank));
-      if(memidx==-1){
+      if (memidx==-1){
         memidx = bank;
       }
     }

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -467,13 +467,13 @@ public:
   read_image(memory* image,const size_t* origin,const size_t* region,size_t row_pitch,size_t slice_pitch,void *ptr);
 
   //streaming APIs. TODO : document them.
-  int 
-  get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, cl_mem_ext_ptr_t* ext, xrt::device::stream_handle* stream);
+  int
+  get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, const cl_mem_ext_ptr_t* ext, xrt::device::stream_handle* stream);
 
-  int 
+  int
   close_stream(xrt::device::stream_handle stream);
 
-  ssize_t 
+  ssize_t
   write_stream(xrt::device::stream_handle stream, const void* ptr, size_t offset, size_t size, xrt::device::stream_xfer_flags flags);
 
   ssize_t
@@ -482,7 +482,7 @@ public:
   xrt::device::stream_buf
   alloc_stream_buf(size_t size, xrt::device::stream_buf_handle* handle);
 
-  int 
+  int
   free_stream_buf(xrt::device::stream_buf_handle handle);
   /**
    * Read a device register at specified offset

--- a/src/runtime_src/xocl/core/kernel.h
+++ b/src/runtime_src/xocl/core/kernel.h
@@ -416,7 +416,12 @@ public:
   const std::string&
   get_name_from_constructor() const
   {
-    return m_name;
+    // Remove this function, it is not needed
+    // Remove m_name from data members
+    // Fix ctor
+    if (m_name != m_symbol.name)
+      throw std::runtime_error("Internal Error");
+    return get_name();
   }
   /**
    * Return list of instances (CUs) in this kernel

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -30,6 +30,8 @@
 
 namespace xocl {
 
+class kernel;
+
 class memory : public refcount, public _cl_mem
 {
   using memory_flags_type  = property_object<cl_mem_flags>;
@@ -81,15 +83,15 @@ public:
   }
 
   void
-  add_xlnx_ext_param(void* param)
+  add_ext_kernel(const kernel* kernel)
   {
-    xlnx_ext_param = param;
+    m_ext_kernel = kernel;
   }
 
-  const void*
-  get_xlnx_ext_param()
+  const kernel*
+  get_ext_kernel()
   {
-    return xlnx_ext_param;
+    return m_ext_kernel;
   }
 
   context*
@@ -446,8 +448,10 @@ private:
   ptr<context> m_context;
 
   memory_flags_type m_flags {0};
+
+  // cl_mem_ext_ptr_t data.  move to buffer derived class
   memory_extension_flags_type m_ext_flags {0};
-  void* xlnx_ext_param {nullptr};
+  const kernel* m_ext_kernel {nullptr};
 
   // List of dtor callback functions. On heap to avoid
   // allocation unless needed.

--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -987,29 +987,32 @@ public:
   }
 
   xocl::xclbin::memidx_type
-  get_memidx_from_arg(const std::string& kernel_name, int32_t arg) 
+  get_memidx_from_arg(const std::string& kernel_name, int32_t arg)
   {
     if (!is_valid())
       return -1;
 
+    // iterate connectivity and look for CU that with name that matches kernel_name
     for (int32_t i=0; i<m_con->m_count; ++i) {
       if (m_con->m_connection[i].arg_index!=arg)
         continue;
-      //ip_layout section has format : kernel_name:cu_name
       auto ipidx = m_con->m_connection[i].m_ip_layout_index;
-      const char *ip_name = reinterpret_cast<const char*>(m_ip->m_ip_data[ipidx].m_name);
-      const char* sub = strstr(ip_name,kernel_name.c_str());
+      auto ip_name = reinterpret_cast<const char*>(m_ip->m_ip_data[ipidx].m_name);
+
+      // ip_name has format : kernel_name:cu_name
+      // For a match, kernel_name should be found at first location in ip_name
+      auto sub = strstr(ip_name,kernel_name.c_str());
       if (sub!=ip_name)
         continue;
 
-      //This connection already has a device storage allocated, so skip to 
-      //the next connection in the connection range which matches the 
-      //criteria - multiple cu case. 
-      //TODO: Check if this is ever hit. 
-      if(std::find(m_used_connections.begin(), m_used_connections.end(), i)
-	     != m_used_connections.end()) {
+      // This connection already has a device storage allocated, so skip to
+      // the next connection in the connection range which matches the
+      // criteria - multiple cu case.
+      // TODO: Check if this is ever hit.
+      if (std::find(m_used_connections.begin(), m_used_connections.end(), i)
+	     != m_used_connections.end())
 	  continue;
-      }
+
       // found the connection that match kernel_name,arg
       size_t memidx = m_con->m_connection[i].mem_data_index;
       assert(m_mem->m_mem_data[memidx].m_used);
@@ -1026,8 +1029,8 @@ public:
     return m_clk;
   }
 
-  const mem_topology* 
-  get_mem_topology() const 
+  const mem_topology*
+  get_mem_topology() const
   {
     return m_mem;
   }
@@ -1252,7 +1255,7 @@ struct xclbin::impl
   { return m_sections.banktag_to_memidx(banktag); }
 
   memidx_type
-  get_memidx_from_arg(const std::string& kernel_name, int32_t arg) 
+  get_memidx_from_arg(const std::string& kernel_name, int32_t arg)
   { return m_sections.get_memidx_from_arg(kernel_name, arg); }
 
   unsigned int
@@ -1480,7 +1483,7 @@ banktag_to_memidx(const std::string& tag) const
 
 xclbin::memidx_type
 xclbin::
-get_memidx_from_arg(const std::string& kernel_name, int32_t arg) 
+get_memidx_from_arg(const std::string& kernel_name, int32_t arg)
 {
   return m_impl->get_memidx_from_arg(kernel_name, arg);
 }


### PR DESCRIPTION
@hcneema, please review these relatively minor style changes.  I disliked the void* param member of xocl::memory and tried redefining cl_mem_ext_ptr_t to be more explicit which in turns allows for xocl::memory to store the kernel directly and eliminates the need for cast.  I added a few comments here and there.   The changes are not meant to change any functionality at all.

When reviewing the changes in GitHub you can add ?w=1 to the url to disregard the whitespace changes which often times get in the way of real changes.