### PR TITLE
xrt package name change

### DIFF
--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -546,7 +546,7 @@ EOF
     mkdir -p $opt_pkgdir/$dir/opt/xilinx/dsa/$opt_dsa/test
     rsync -avz ${opt_dsadir}/test/ $opt_pkgdir/$dir/opt/xilinx/dsa/$opt_dsa/test
     chmod -R +r $opt_pkgdir/$dir/opt/xilinx/dsa/$opt_dsa
-    dpkg-deb --build $opt_pkgdir/$dir 
+    dpkg-deb --build $opt_pkgdir/$dir
 
     echo "================================================================"
     echo "* Please locate dep for $dsa in: $opt_pkgdir/$dir"


### PR DESCRIPTION
to support ubuntu 16.04 and 18.04
ran a test on both ubuntu and centos builds. the new package names are as following:
ubuntu: xrt_2.1.0_16.04.deb 
centos: xrt_2.1.0_7.5.1804.rpm 