### PR TITLE
skip sync if p2p flag is set and throw error if fail to allocate mem object

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -784,7 +784,7 @@ unmap_buffer(memory* buffer, void* mapped_ptr)
   if (flags & (CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION)) {
     if (auto ubuf = static_cast<char*>(buffer->get_host_ptr()))
       xdevice->write(boh,ubuf+offset,size,offset,false);
-    if (buffer->is_resident(this))
+    if (buffer->is_resident(this) && !((buffer->get_ext_flags() >> 30) & 0x1))
       xdevice->sync(boh,size,offset,xrt::hal::device::direction::HOST2DEVICE,false);
   }
 }
@@ -798,8 +798,10 @@ migrate_buffer(memory* buffer,cl_mem_migration_flags flags)
     buffer_resident_or_error(buffer,this);
     auto boh = buffer->get_buffer_object_or_error(this);
     auto xdevice = get_xrt_device();
-    xdevice->sync(boh,buffer->get_size(),0,xrt::hal::device::direction::DEVICE2HOST,false);
-    sync_to_ubuf(buffer,0,buffer->get_size(),xdevice,boh);
+    if(!((buffer->get_ext_flags() >> 30) & 0x1)){
+      xdevice->sync(boh,buffer->get_size(),0,xrt::hal::device::direction::DEVICE2HOST,false);
+      sync_to_ubuf(buffer,0,buffer->get_size(),xdevice,boh);
+    }
     return;
   }
 
@@ -808,10 +810,11 @@ migrate_buffer(memory* buffer,cl_mem_migration_flags flags)
   auto xdevice = get_xrt_device();
   xrt::device::BufferObjectHandle boh = buffer->get_buffer_object(this);
 
-  // Sync from host to device to make make buffer resident of this device
-  sync_to_hbuf(buffer,0,buffer->get_size(),xdevice,boh);
-  xdevice->sync(boh,buffer->get_size(), 0, xrt::hal::device::direction::HOST2DEVICE,false);
-
+  if(!((buffer->get_ext_flags() >> 30) & 0x1)){
+    // Sync from host to device to make make buffer resident of this device
+    sync_to_hbuf(buffer,0,buffer->get_size(),xdevice,boh);
+    xdevice->sync(boh,buffer->get_size(), 0, xrt::hal::device::direction::HOST2DEVICE,false);
+  }
   // Now buffer is resident on this device and migrate is complete
   buffer->set_resident(this);
 }

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -544,23 +544,9 @@ allocate_buffer_object(memory* mem)
       return boh;
     }
     catch (const std::bad_alloc&) {
+      throw xocl::error(CL_MEM_OBJECT_ALLOCATION_FAILURE,"could not allocate with memidx: "+std::to_string(memidx));
     }
   }
-
-  // If buffer could not be allocated on the requested bank,
-  // or if no bank was specified, then allocate on the bank
-  // (memidx) matching the CU connectivity of CUs in device.
-  auto memidx = get_cu_memidx();
-  if (memidx>=0) {
-    try {
-      auto boh = alloc(mem,memidx);
-      XOCL_DEBUG(std::cout,"memory(",mem->get_uid(),") allocated on device(",m_uid,") in bank with idx(",memidx,")\n");
-      return boh;
-    }
-    catch (const std::bad_alloc&) {
-    }
-  }
-
   // Else just allocated on any bank
   XOCL_DEBUG(std::cout,"memory(",mem->get_uid(),") allocated on device(",m_uid,") in default bank\n");
   return alloc(mem);

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -784,7 +784,7 @@ unmap_buffer(memory* buffer, void* mapped_ptr)
   if (flags & (CL_MAP_WRITE | CL_MAP_WRITE_INVALIDATE_REGION)) {
     if (auto ubuf = static_cast<char*>(buffer->get_host_ptr()))
       xdevice->write(boh,ubuf+offset,size,offset,false);
-    if (buffer->is_resident(this) && !((buffer->get_ext_flags() >> 30) & 0x1))
+    if (buffer->is_resident(this) && !buffer->is_p2p_memory())
       xdevice->sync(boh,size,offset,xrt::hal::device::direction::HOST2DEVICE,false);
   }
 }
@@ -798,7 +798,7 @@ migrate_buffer(memory* buffer,cl_mem_migration_flags flags)
     buffer_resident_or_error(buffer,this);
     auto boh = buffer->get_buffer_object_or_error(this);
     auto xdevice = get_xrt_device();
-    if(!((buffer->get_ext_flags() >> 30) & 0x1)){
+    if(!buffer->is_p2p_memory()){
       xdevice->sync(boh,buffer->get_size(),0,xrt::hal::device::direction::DEVICE2HOST,false);
       sync_to_ubuf(buffer,0,buffer->get_size(),xdevice,boh);
     }
@@ -810,7 +810,7 @@ migrate_buffer(memory* buffer,cl_mem_migration_flags flags)
   auto xdevice = get_xrt_device();
   xrt::device::BufferObjectHandle boh = buffer->get_buffer_object(this);
 
-  if(!((buffer->get_ext_flags() >> 30) & 0x1)){
+  if(!buffer->is_p2p_memory()){
     // Sync from host to device to make make buffer resident of this device
     sync_to_hbuf(buffer,0,buffer->get_size(),xdevice,boh);
     xdevice->sync(boh,buffer->get_size(), 0, xrt::hal::device::direction::HOST2DEVICE,false);

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -106,6 +106,12 @@ public:
     return get_sub_buffer_parent() != nullptr;
   }
 
+  bool
+  is_p2p_memory() const
+  {
+    return (m_ext_flags >> 30) & 0x1 ? true : false;
+  }
+
   // Derived classes accessors
   // May be structured differently when _xcl_mem is eliminated
   virtual size_t


### PR DESCRIPTION
Hi all,

Thanks to Min's test case, help us to find out some corner cases.

1. It will attempt to allocate buffer once fail to do so, so just throw error explicitly.
2. sync a p2p BO doesn't make sense, no host buffer, direct read/write p2p BO by mmap, should skip sync any p2p BO both direction in runtime instead of handle by driver(sync_bo_ioctl will capture the attempt), it should fail earlier.


Change request are very welcome...