### PR TITLE
initial changes for PLRAM support in runtime

### DIFF
--- a/src/runtime_src/xdp/profile/rt_perf_counters.cpp
+++ b/src/runtime_src/xdp/profile/rt_perf_counters.cpp
@@ -499,13 +499,13 @@ namespace XCL {
   }
 
   void PerformanceCounter::writeKernelTransferSummary(WriterI* writer, std::string& deviceName,
-      std::string& cuPortName, const std::string& argNames, uint32_t ddrBank, bool isRead,
-	  uint64_t totalBytes, uint64_t totalTranx, double totalKernelTimeMsec,
+      std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
+      bool isRead, uint64_t totalBytes, uint64_t totalTranx, double totalKernelTimeMsec,
 	  double totalTransferTimeMsec, double maxTransferRateMBps) const
   {
     std::string transferType = (isRead) ? "READ" : "WRITE";
 
-    writer->writeKernelTransferSummary(deviceName, cuPortName, argNames, ddrBank, transferType,
+    writer->writeKernelTransferSummary(deviceName, cuPortName, argNames, memoryName, transferType,
     	totalBytes, totalTranx, totalKernelTimeMsec, totalTransferTimeMsec, maxTransferRateMBps);
   }
 

--- a/src/runtime_src/xdp/profile/rt_perf_counters.h
+++ b/src/runtime_src/xdp/profile/rt_perf_counters.h
@@ -108,7 +108,7 @@ namespace XCL {
     void writeHostTransferSummary(WriterI* writer, bool isRead, uint64_t totalBytes,
         double totalTimeMsec, double maxTransferRateMBps) const;
     void writeKernelTransferSummary(WriterI* writer, std::string& deviceName,
-    	std::string& cuPortName, const std::string& argNames, uint32_t ddrBank,
+    	std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
     	bool isRead, uint64_t totalBytes, uint64_t totalTranx, double totalKernelTimeMsec,
         double totalTransferTimeMsec, double maxTransferRateMBps) const;
     void writeDeviceTransferSummary(WriterI* writer, bool isRead) const;

--- a/src/runtime_src/xdp/profile/rt_profile.h
+++ b/src/runtime_src/xdp/profile/rt_profile.h
@@ -233,11 +233,6 @@ namespace XCL {
       return (timeNsec / 1.0e6);
     }
 
-    int getCUPortsToDDRBank(int banknum) {
-   	  if (banknum >= MAX_DDR_BANKS) return 0;
-      return CUPortsToDDRBanks[banknum];
-    }
-
   public:
     void addToActiveDevices(const std::string& deviceName);
     bool isDeviceActive(const std::string& deviceName) const;
@@ -270,14 +265,15 @@ namespace XCL {
   public:
     void getArgumentsBank(const std::string& deviceName, const std::string& cuName,
     	                  const std::string& portName, std::string& argNames,
-						  uint32_t& banknum) const;
+						  std::string& memoryName) const;
 
   private:
-    typedef std::tuple<std::string, std::string, std::string, uint32_t, uint32_t> CUPortArgsBankType;
+    typedef std::tuple<std::string, std::string, std::string, std::string, uint32_t> CUPortArgsBankType;
     std::vector<CUPortArgsBankType> CUPortVector;
 
   public:
     std::vector<CUPortArgsBankType> getCUPortVector() const {return CUPortVector;}
+    std::map<std::string, int> getCUPortsToMemoryMap() const {return CUPortsToMemoryMap;}
 
   private:
     bool IsZynq = false;
@@ -315,9 +311,7 @@ namespace XCL {
   private:
     std::vector<WriterI*> Writers;
     std::set<std::string> ActiveDevices;
-
-    const static int MAX_DDR_BANKS = 8;
-    int CUPortsToDDRBanks[MAX_DDR_BANKS];
+    std::map<std::string, int> CUPortsToMemoryMap;
 
   // Platform data and Device data
   private:

--- a/src/runtime_src/xdp/profile/rt_profile_writers.h
+++ b/src/runtime_src/xdp/profile/rt_profile_writers.h
@@ -77,7 +77,7 @@ namespace XCL {
           double totalTimeMsec, double maxTransferRateMBps);
       // Write Read/Write Kernel transfer stats
       void writeKernelTransferSummary(const std::string& deviceName,
-          const std::string& cuPortName, const std::string& argNames, uint32_t ddrBank,
+          const std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
 		  const std::string& transferType, uint64_t totalBytes, uint64_t totalTranx,
 		  double totalKernelTimeMsec, double totalTransferTimeMsec, double maxTransferRateMBps);
 	  void writeStallSummary(std::string& cuName, uint32_t cuRunCount, double cuRunTimeMsec,


### PR DESCRIPTION
in the kernel transfer table in the profile summary, the memory resource name string is now used instead of a determined DDR bank number; this will allow names like "DDR[0]" as well as "PLRAM[0]"; this supports http://jira.xilinx.com/browse/PR-10442; See here for more info:
http://confluence.xilinx.com/pages/viewpage.action?pageId=93090054