### PR TITLE
add enablerepo=extras for centos

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -195,7 +195,7 @@ install()
         sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
     elif [ $FLAVOR == "centos" ]; then
         echo "Enabling CentOS SCL repository..."
-        sudo yum install centos-release-scl
+        sudo yum --enablerepo=extras install centos-release-scl
     fi
 
     if [ $FLAVOR == "rhel" ] || [ $FLAVOR == "centos" ]; then


### PR DESCRIPTION
In order to avoid following error:
Error: Package: centos-release-scl-2-2.el7.centos.noarch (devtools)
           Requires: centos-release-scl-rh
changed to --enablerepo=extras