### PR TITLE
Use "card", instead of "device" or "board"

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbflash/flasher.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbflash/flasher.cpp
@@ -181,7 +181,7 @@ Flasher::Flasher(unsigned int index) :
     scanner.scan(false);
 
     if(mIdx >= scanner.device_list.size()) {
-        std::cout << "ERROR: Invalid device index." << std::endl;
+        std::cout << "ERROR: Invalid card index." << std::endl;
         return;
     }
     mDev = scanner.device_list.at(mIdx);
@@ -189,13 +189,13 @@ Flasher::Flasher(unsigned int index) :
     mHandle = xclOpenMgmt(mIdx);
     if (!mHandle)
     {
-        std::cout << "open device failed: " << errno << std::endl;
+        std::cout << "open card failed: " << errno << std::endl;
         return;
     }
     mMgmtMap = xclMapMgmt(mHandle);
     if (!mMgmtMap)
     {
-        std::cout << "map device failed" << std::endl;
+        std::cout << "map card failed" << std::endl;
         return;
     }
 
@@ -216,7 +216,7 @@ Flasher::Flasher(unsigned int index) :
     }
     else
     {
-        std::cout << "ERROR: Device not supported." << std::endl;
+        std::cout << "ERROR: card not supported." << std::endl;
     }
 }
 
@@ -307,7 +307,7 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
     DSAInfo onBoard = getOnBoardDSA();
     if (onBoard.vendor.empty() || onBoard.board.empty())
     {
-        std::cout << "Onboard DSA is unknown" << std::endl;
+        std::cout << "DSA on FPGA is unknown" << std::endl;
         return DSAs;
     }
 

--- a/src/runtime_src/driver/xclng/tools/xbflash/xbflash.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbflash/xbflash.cpp
@@ -27,9 +27,9 @@
 #include "firmware_image.h"
 
 const char* UsageMessages[] = {
-    "[-d device] -m primary_mcs [-n secondary_mcs] [-o spi|bpi]'",
-    "[-d device] -a <all | dsa> [-t timestamp]",
-    "[-d device] -p msp432_firmware",
+    "[-d card] -m primary_mcs [-n secondary_mcs] [-o spi|bpi]'",
+    "[-d card] -a <all | dsa> [-t timestamp]",
+    "[-d card] -p msp432_firmware",
     "scan [-v]",
 };
 const char* SudoMessage = "ERROR: root privileges required.";
@@ -132,7 +132,7 @@ unsigned selectDSA(unsigned idx, std::string& dsa, uint64_t ts)
 {
     unsigned candidateDSAIndex = UINT_MAX;
 
-    std::cout << "Probing board[" << idx << "]: ";
+    std::cout << "Probing card[" << idx << "]: ";
 
     Flasher flasher(idx);
     if(!flasher.isValid())
@@ -212,7 +212,7 @@ int updateDSA(unsigned boardIdx, unsigned dsaIdx, bool& reboot)
     Flasher flasher(boardIdx);
     if(!flasher.isValid())
     {
-        std::cout << "device not available" << std::endl;
+        std::cout << "card not available" << std::endl;
         return -EINVAL;
     }
 
@@ -237,12 +237,12 @@ int updateDSA(unsigned boardIdx, unsigned dsaIdx, bool& reboot)
 
     if (!same_bmc)
     {
-        std::cout << "Updating BMC firmware on board[" << boardIdx << "]"
+        std::cout << "Updating BMC firmware on card[" << boardIdx << "]"
             << std::endl;
         int ret = flashBMC(flasher, candidate);
         if (ret != 0)
         {
-            std::cout << "Failed to update BMC firmware on board["
+            std::cout << "Failed to update BMC firmware on card["
                 << boardIdx << "]" << std::endl;
             return ret;
         }
@@ -250,11 +250,11 @@ int updateDSA(unsigned boardIdx, unsigned dsaIdx, bool& reboot)
 
     if (!same_dsa)
     {
-        std::cout << "Updating DSA on board[" << boardIdx << "]" << std::endl;
+        std::cout << "Updating DSA on card[" << boardIdx << "]" << std::endl;
         int ret = flashDSA(flasher, candidate);
         if (ret != 0)
         {
-            std::cout << "Failed to update DSA on board[" << boardIdx << "]"
+            std::cout << "Failed to update DSA on card[" << boardIdx << "]"
                 << std::endl;
             return ret;
         }
@@ -303,7 +303,7 @@ int main( int argc, char *argv[] )
     }
     else
     {
-        std::cout <<"XBFLASH -- Xilinx Board Flash Utility" << std::endl;
+        std::cout <<"XBFLASH -- Xilinx Card Flash Utility" << std::endl;
     }
 
     if( argc <= optind )
@@ -372,7 +372,7 @@ int main( int argc, char *argv[] )
         case 'o': // optional
             notSeenOrDie(seen_o);
             std::cout <<"CAUTION: Overriding flash mode is not recommended. "
-                << "You may damage your device with this option." << std::endl;
+                << "You may damage your card with this option." << std::endl;
             if(!canProceed())
                 exit(-ECANCELED);
             args.flasherType = std::string(optarg);
@@ -436,7 +436,7 @@ int main( int argc, char *argv[] )
         }
 
         if (ret != 0)
-            std::cout << "Failed to flash board." << std::endl;
+            std::cout << "Failed to flash card." << std::endl;
         return ret;
     }
 
@@ -491,7 +491,7 @@ int main( int argc, char *argv[] )
     }
     if (boardsToCheck.empty())
     {
-        std::cout << "Board not found!" << std::endl;
+        std::cout << "Card not found!" << std::endl;
         exit(-ENOENT);
     }
 
@@ -508,10 +508,10 @@ int main( int argc, char *argv[] )
     bool needreboot = false;
     if (!boardsToUpdate.empty())
     {
-        std::cout << "DSA on below boards will be updated:" << std::endl;
+        std::cout << "DSA on below card(s) will be updated:" << std::endl;
         for (auto p : boardsToUpdate)
         {
-            std::cout << "Board [" << p.first << "]" << std::endl;
+            std::cout << "Card [" << p.first << "]" << std::endl;
         }
 
         // Prompt user about what boards will be updated and ask for permission.
@@ -531,7 +531,7 @@ int main( int argc, char *argv[] )
         }
     }
 
-    std::cout << success << " boards flashed successfully." << std::endl;
+    std::cout << success << " Card(s) flashed successfully." << std::endl;
     if (needreboot)
     {
         std::cout << "Cold reboot machine to load the new image on FPGA."
@@ -575,19 +575,19 @@ int scanDevices(int argc, char *argv[])
     scanner.scan(false);
 
     if ( xcldev::pci_device_scanner::device_list.size() == 0 )
-        std::cout << "No device is found!" << std::endl;
+        std::cout << "No card is found!" << std::endl;
 
     for(unsigned i = 0; i < xcldev::pci_device_scanner::device_list.size(); i++)
     {
-        std::cout << "Board [" << i << "]" << std::endl;
+        std::cout << "Card [" << i << "]" << std::endl;
 
         Flasher f(i);
         if (!f.isValid())
             continue;
 
         DSAInfo board = f.getOnBoardDSA();
-        std::cout << "\tDevice BDF:\t\t" << f.sGetDBDF() << std::endl;
-        std::cout << "\tDevice type:\t\t" << board.board << std::endl;
+        std::cout << "\tCard BDF:\t\t" << f.sGetDBDF() << std::endl;
+        std::cout << "\tCard type:\t\t" << board.board << std::endl;
         std::cout << "\tFlash type:\t\t" << f.sGetFlashType() << std::endl;
         std::cout << "\tDSA running on FPGA:" << std::endl;
         std::cout << "\t\t" << board << std::endl;
@@ -610,9 +610,9 @@ int scanDevices(int argc, char *argv[])
         BoardInfo info;
         if (verbose && f.getBoardInfo(info) == 0)
         {
-            std::cout << "\tBoard name\t\t" << info.mName << std::endl;
-            std::cout << "\tBoard rev\t\t" << info.mRev << std::endl;
-            std::cout << "\tBoard S/N: \t\t" << info.mSerialNum << std::endl;
+            std::cout << "\tCard name\t\t" << info.mName << std::endl;
+            std::cout << "\tCard rev\t\t" << info.mRev << std::endl;
+            std::cout << "\tCard S/N: \t\t" << info.mSerialNum << std::endl;
             std::cout << "\tConfig mode: \t\t" << info.mConfigMode << std::endl;
             std::cout << "\tFan presence:\t\t" << info.mFanPresence << std::endl;
             std::cout << "\tMax power level:\t" << info.mMaxPowerLvl << std::endl;

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -46,7 +46,7 @@ int bdf2index(std::string& bdfStr, unsigned& index)
     try {
         devScanner.scan(false);
     } catch (...) {
-        std::cout << "ERROR: failed to scan device" << std::endl;
+        std::cout << "ERROR: Failed to scan card" << std::endl;
         return -EINVAL;
     }
 
@@ -59,7 +59,7 @@ int bdf2index(std::string& bdfStr, unsigned& index)
         }
     }
 
-    std::cout << "ERROR: no device found for " << bdfStr << std::endl;
+    std::cout << "ERROR: No card found for " << bdfStr << std::endl;
     return -ENOENT;
 }
 
@@ -73,7 +73,7 @@ int str2index(const char *arg, unsigned& index)
         char *endptr;
         i = std::strtoul(arg, &endptr, 0);
         if (*endptr != '\0' || i >= UINT_MAX) {
-            std::cout << "ERROR: " << devStr << " is not a valid board index."
+            std::cout << "ERROR: " << devStr << " is not a valid card index."
                 << std::endl;
             return -EINVAL;
         }
@@ -461,7 +461,7 @@ int main(int argc, char *argv[])
     unsigned int count = xcldev::pci_device_scanner::device_list.size();
 
     if (count == 0) {
-        std::cout << "ERROR: No device found\n";
+        std::cout << "ERROR: No card found\n";
         return 1;
     }
 
@@ -473,7 +473,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    std::cout << "INFO: Found total " << count << " device(s), "
+    std::cout << "INFO: Found total " << count << " card(s), "
         << deviceVec.size() << " are usable" << std::endl;
 
     if (cmd == xcldev::LIST) {
@@ -489,9 +489,9 @@ int main(int argc, char *argv[])
 
     if (index >= deviceVec.size()) {
         if (index >= count)
-            std::cout << "ERROR: Device index " << index << "is out of range";
+            std::cout << "ERROR: Card index " << index << "is out of range";
         else
-            std::cout << "ERROR: Device [" << index << "] is not ready";
+            std::cout << "ERROR: Card [" << index << "] is not ready";
         std::cout << std::endl;
         return 1;
     }
@@ -581,39 +581,39 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "Running xbutil for 4.0+ DSA's \n\n";
     std::cout << "Usage: " << exe << " <command> [options]\n\n";
     std::cout << "Command and option summary:\n";
-    std::cout << "  clock   [-d device] [-r region] [-f clock1_freq_MHz] [-g clock2_freq_MHz]\n";
-    std::cout << "  dmatest [-d device] [-b [0x]block_size_KB]\n";
+    std::cout << "  clock   [-d card] [-r region] [-f clock1_freq_MHz] [-g clock2_freq_MHz]\n";
+    std::cout << "  dmatest [-d card] [-b [0x]block_size_KB]\n";
     std::cout << "  help\n";
     std::cout << "  list\n";
-    std::cout << "  mem     --read [-d device] [-a [0x]start_addr] [-i size_bytes] [-o output filename]\n";
-    std::cout << "  mem     --write [-d device] [-a [0x]start_addr] [-i size_bytes] [-e pattern_byte]\n";
-    std::cout << "  program [-d device] [-r region] -p xclbin\n";
-    std::cout << "  query   [-d device [-r region]]\n";
-    std::cout << "  reset   [-d device] [-h | -r region]\n";
+    std::cout << "  mem --read [-d card] [-a [0x]start_addr] [-i size_bytes] [-o output filename]\n";
+    std::cout << "  mem --write [-d card] [-a [0x]start_addr] [-i size_bytes] [-e pattern_byte]\n";
+    std::cout << "  program [-d card] [-r region] -p xclbin\n";
+    std::cout << "  query   [-d card [-r region]]\n";
+    std::cout << "  reset   [-d card] [-h | -r region]\n";
     std::cout << "  status  [--debug_ip_name]\n";   
     std::cout << "  scan\n";
     std::cout << "  top [-i seconds]\n";
-    std::cout << "  validate [-d device]\n";
+    std::cout << "  validate [-d card]\n";
     std::cout << " Requires root privileges:\n";
-    std::cout << "  boot    [-d device]\n";
-    std::cout << "  flash   [-d device] -m primary_mcs [-n secondary_mcs] [-o bpi|spi]\n";
-    std::cout << "  flash   [-d device] -a <all | dsa> [-t timestamp]\n";
-    std::cout << "  flash   [-d device] -p msp432_firmware\n";
+    std::cout << "  boot    [-d card]\n";
+    std::cout << "  flash   [-d card] -m primary_mcs [-n secondary_mcs] [-o bpi|spi]\n";
+    std::cout << "  flash   [-d card] -a <all | dsa> [-t timestamp]\n";
+    std::cout << "  flash   [-d card] -p msp432_firmware\n";
     std::cout << "  flash   scan [-v]\n";
     std::cout << "\nExamples:\n";
-    std::cout << "List all devices\n";
+    std::cout << "List all cards\n";
     std::cout << "  " << exe << " list\n";
-    std::cout << "Scan for Xilinx PCIe device(s) & associated drivers (if any) and relevant system information\n";
+    std::cout << "Scan for Xilinx PCIe card(s) & associated drivers (if any) and relevant system information\n";
     std::cout << "  " << exe << " scan\n";
-    std::cout << "Boot device 1 from PROM and retrain the PCIe link without rebooting the host\n";
+    std::cout << "Boot card 1 from PROM and retrain the PCIe link without rebooting the host\n";
     std::cout << "  " << exe << " boot -d 1\n";
-    std::cout << "Change the clock frequency of region 0 in device 0 to 100 MHz\n";
+    std::cout << "Change the clock frequency of region 0 in card 0 to 100 MHz\n";
     std::cout << "  " << exe << " clock -f 100\n";
-    std::cout << "For device 0 which supports multiple clocks, change the clock 1 to 200MHz and clock 2 to 250MHz\n";
+    std::cout << "For card 0 which supports multiple clocks, change the clock 1 to 200MHz and clock 2 to 250MHz\n";
     std::cout << "  " << exe << " clock -f 200 -g 250\n";
-    std::cout << "Download the accelerator program for device 2\n";
+    std::cout << "Download the accelerator program for card 2\n";
     std::cout << "  " << exe << " program -d 2 -p a.xclbin\n";
-    std::cout << "Run DMA test on device 1 with 32 KB blocks of buffer\n";
+    std::cout << "Run DMA test on card 1 with 32 KB blocks of buffer\n";
     std::cout << "  " << exe << " dmatest -d 1 -b 0x2000\n";
     std::cout << "Read 256 bytes from DDR starting at 0x1000 into file read.out\n";
     std::cout << "  " << exe << " mem --read -a 0x1000 -i 256 -o read.out\n";
@@ -623,11 +623,11 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "  " << "Default values for address is 0x0, size is DDR size and pattern is 0x0\n";
     std::cout << "List the debug IPs available on the platform\n";
     std::cout << "  " << exe << " status \n";
-    std::cout << "Flash all installed DSA for all boards, if not done\n";
+    std::cout << "Flash all installed DSA for all cards, if not done\n";
     std::cout << "  sudo " << exe << " flash -a all\n";
-    std::cout << "Show DSA related information for all boards in the system\n";
+    std::cout << "Show DSA related information for all cards in the system\n";
     std::cout << "  sudo " << exe << " flash scan\n";
-    std::cout << "Validate installation on device 1\n";
+    std::cout << "Validate installation on card 1\n";
     std::cout << "  " << exe << " validate -d 1\n";
 }
 
@@ -636,9 +636,9 @@ std::unique_ptr<xcldev::device> xcldev::xclGetDevice(unsigned index)
     try {
         unsigned int count = xcldev::pci_device_scanner::device_list.size();
         if (count == 0) {
-            std::cout << "ERROR: No devices found" << std::endl;
+            std::cout << "ERROR: No card found" << std::endl;
         } else if (index >= count) {
-            std::cout << "ERROR: Device index " << index << " out of range";
+            std::cout << "ERROR: Card index " << index << " out of range";
             std::cout << std::endl;
         } else {
             return std::unique_ptr<xcldev::device>
@@ -857,7 +857,7 @@ int xcldev::device::validate(bool quick)
     if (m_devinfo.mPCIeLinkSpeed != m_devinfo.mPCIeLinkSpeedMax ||
         m_devinfo.mPCIeLinkWidth != m_devinfo.mPCIeLinkWidthMax) {
         std::cout << "FAILED" << std::endl;
-        std::cout << "WARNING: Device trained to lower spec. "
+        std::cout << "WARNING: Card trained to lower spec. "
             << "Expect: Gen" << m_devinfo.mPCIeLinkSpeedMax << "x"
             << m_devinfo.mPCIeLinkWidthMax
             << ", Current: Gen" << m_devinfo.mPCIeLinkSpeed << "x"
@@ -873,9 +873,10 @@ int xcldev::device::validate(bool quick)
     // Run various test cases
 
     // Test verify kernel
-    std::cout << "INFO: Testing verify kernel: " << std::flush;
+    std::cout << "INFO: Starting verify kernel test: " << std::flush;
     int ret = runTestCase(std::string("validate.exe"),
         std::string("verify.xclbin"), output);
+    std::cout << std::endl;
     if (ret == -ENOENT) {
         if (m_idx == 0) {
             // Fall back to verify.exe
@@ -888,10 +889,11 @@ int xcldev::device::validate(bool quick)
         }
     }
     if (ret != 0 || output.find("Hello World") == std::string::npos) {
-        std::cout << "FAILED" << std::endl << output << std::endl;
+        std::cout << output << std::endl;
+        std::cout << "ERROR: verify kernel test FAILED" << std::endl;
         return ret == 0 ? -EINVAL : ret;
     }
-    std::cout << "PASSED" << std::endl;
+    std::cout << "INFO: verify kernel test PASSED" << std::endl;
 
     // Skip the rest of test cases for quicker turn around.
     if (quick)
@@ -901,7 +903,7 @@ int xcldev::device::validate(bool quick)
     std::cout << "INFO: Starting DMA test" << std::endl;
     ret = dmatest(0, false);
     if (ret != 0) {
-        std::cout << "INFO: DMA test FAILED" << std::endl;
+        std::cout << "ERROR: DMA test FAILED" << std::endl;
         return ret;
     }
     std::cout << "INFO: DMA test PASSED" << std::endl;
@@ -914,17 +916,19 @@ int xcldev::device::validate(bool quick)
     std::cout << "INFO: Starting DDR bandwidth test: " << std::flush;
     ret = runTestCase(std::string("kernel_bw.exe"),
         std::string("bandwidth.xclbin"), output);
+    std::cout << std::endl;
     if (ret != 0 || output.find("PASS") == std::string::npos) {
-        std::cout << "FAILED" << std::endl << output << std::endl;
+        std::cout << output << std::endl;
+        std::cout << "ERROR: DDR bandwidth test FAILED" << std::endl;
         return ret == 0 ? -EINVAL : ret;
     }
-    std::cout << "PASSED" << std::endl;
     // Print out max thruput
     size_t st = output.find("Maximum");
     if (st != std::string::npos) {
         size_t end = output.find("\n", st);
         std::cout << output.substr(st, end - st) << std::endl;
     }
+    std::cout << "INFO: DDR bandwidth test PASSED" << std::endl;
 
     return 0;
 }
@@ -964,47 +968,47 @@ int xcldev::xclValidate(int argc, char *argv[])
     std::vector<unsigned> boards;
     if (index == UINT_MAX) {
         if (count == 0) {
-            std::cout << "ERROR: No device found" << std::endl;
+            std::cout << "ERROR: No card found" << std::endl;
             return -ENOENT;
         }
         for (unsigned i = 0; i < count; i++)
             boards.push_back(i);
     } else {
         if (index >= count) {
-            std::cout << "ERROR: Device[" << index << "] not found" << std::endl;
+            std::cout << "ERROR: Card[" << index << "] not found" << std::endl;
             return -ENOENT;
         }
         boards.push_back(index);
     }
 
-    std::cout << "INFO: Found " << boards.size() << " devices" << std::endl;
+    std::cout << "INFO: Found " << boards.size() << " cards" << std::endl;
 
     bool validated = true;
     for (unsigned i : boards) {
         std::unique_ptr<device> dev = xclGetDevice(i);
         if (!dev) {
-            std::cout << "ERROR: Can't open device[" << i << "]" << std::endl;
+            std::cout << "ERROR: Can't open card[" << i << "]" << std::endl;
             validated = false;
             continue;
         }
 
-        std::cout << std::endl << "INFO: Validating device[" << i << "]: "
+        std::cout << std::endl << "INFO: Validating card[" << i << "]: "
             << dev->name() << std::endl;
 
         if (dev->validate(quick) != 0) {
             validated = false;
-            std::cout << "INFO: Device[" << i << "] failed to validate." << std::endl;
+            std::cout << "INFO: Card[" << i << "] failed to validate." << std::endl;
         } else {
-            std::cout << "INFO: Device[" << i << "] validated successfully." << std::endl;
+            std::cout << "INFO: Card[" << i << "] validated successfully." << std::endl;
         }
     }
     std::cout << std::endl;
 
     if (!validated) {
-        std::cout << "ERROR: Some devices failed to validate." << std::endl;
+        std::cout << "ERROR: Some cards failed to validate." << std::endl;
         return -EINVAL;
     }
 
-    std::cout << "INFO: All devices validated successfully." << std::endl;
+    std::cout << "INFO: All cards validated successfully." << std::endl;
     return 0;
 }

--- a/src/runtime_src/driver/xclng/xrt/user_common/memaccess.h
+++ b/src/runtime_src/driver/xclng/xrt/user_common/memaccess.h
@@ -73,7 +73,7 @@ namespace xcldev {
         ifs.read( (char*)&nfound, sizeof(nfound) );
         ifs.seekg( 0, ifs.beg );
         if( nfound == 0 ) {
-            std::cout << "ERROR: Memory topology is not available, ensure that a valid bitstream is programmed onto the device." << std::endl;
+            std::cout << "ERROR: Memory topology is not available, ensure that a valid bitstream is programmed onto the card." << std::endl;
             ifs.close();
             return nfound;
         }
@@ -142,7 +142,7 @@ namespace xcldev {
         std::vector<mem_bank_t> mems;
         int numBanks = getDDRBanks(mems);
         if (!numBanks) {
-          std::cout << "ERROR: Memory topology is not available, ensure that a valid bitstream is programmed onto the device \n";
+          std::cout << "ERROR: Memory topology is not available, ensure that a valid bitstream is programmed onto the card \n";
           return -1;
         }
 
@@ -178,7 +178,7 @@ namespace xcldev {
                 std::vector<mem_bank_t>& vec_banks, std::vector<mem_bank_t>::iterator& startbank) {
         int nbanks = getDDRBanks(vec_banks);
         if (!nbanks) {
-          std::cout << "ERROR: Memory topology is not available, ensure that a valid bitstream is programmed onto the device \n";
+          std::cout << "ERROR: Memory topology is not available, ensure that a valid bitstream is programmed onto the card \n";
           return -1;
         }
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/scan.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/scan.cpp
@@ -260,7 +260,7 @@ void xcldev::pci_device_scanner::print_pci_info(void)
     }
 
     if (disabled != 0) {
-        std::cout << "WARNING: " << disabled << " board(s) marked by '*' are not ready, "
+        std::cout << "WARNING: " << disabled << " card(s) marked by '*' are not ready, "
             << "run xbutil flash scan -v to further check the details."
             << std::endl;
     }

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -766,8 +766,8 @@ int xocl::XOCLShim::xclLoadXclBin(const xclBin *buffer)
         if (ret != 0) {
             if (ret == -EINVAL) {
                 std::stringstream output;
-                output << "Xclbin does not match DSA on board.\n"
-                    << "Please run xbutil flash -a all to flash board."
+                output << "Xclbin does not match DSA on card.\n"
+                    << "Please run xbutil flash -a all to flash card."
                     << std::endl;
                 if (mLogStream.is_open()) {
                     mLogStream << output.str();

--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -177,7 +177,7 @@ dsabinOutputFile=""
 
 XBUTIL=/opt/xilinx/xrt/bin/xbutil
 post_inst_msg="DSA package installed successfully.
-Please flash board manually by running below command:
+Please flash card manually by running below command:
 sudo ${XBUTIL} flash -a ${opt_dsa} -t"
 
 createEntityAttributeArray ()


### PR DESCRIPTION
According to the taxonomy guideline, we should use "card", not "device" or "board" in our UI and docs.
This change also tweaked some wording for xbutil validate output.
TARGET: 2018.2_XDF