### PR TITLE
Fix bug in penguin_submit

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -1544,8 +1544,9 @@ static int
 get_free_cu(struct xocl_cmd *xcmd)
 {
 	int mask_idx=0;
+	int num_masks = cu_masks(xcmd);
 	SCHED_DEBUG("-> get_free_cu\n");
-	for (mask_idx=0; mask_idx<xcmd->exec->num_cu_masks; ++mask_idx) {
+	for (mask_idx=0; mask_idx<num_masks; ++mask_idx) {
 		u32 cmd_mask = xcmd->packet->data[mask_idx]; /* skip header */
 		u32 busy_mask = xcmd->exec->cu_status[mask_idx];
 		int cu_idx = ffs_or_neg_one((cmd_mask | busy_mask) ^ busy_mask);


### PR DESCRIPTION
For designs with more 32+ CUs and multiple kernels, there was a chance number of CU masks in command is less than total number of CU masks recorded in device's execution core.