### PR TITLE
dmatest should fail when no xclbin is loaded

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -865,7 +865,7 @@ public:
             }
             ifs.read((char*)&numDDR, sizeof(numDDR));
             ifs.seekg(0, ifs.beg);
-            if( numDDR == 0 ) {
+            if( !ifs.good() || numDDR == 0 ) {
                 std::cout << "WARNING: 'mem_topology' invalid, unable to perform DMA Test. Has the bitstream been loaded? See 'xbutil program'." << std::endl;
                 return -1;
             }else {


### PR DESCRIPTION
If no xclbin is loaded, the mem_topology sysfs entry would stilll be there but it contains no data. We should detect this and fail the dmatest.