### PR TITLE
Should return -errno instead of errno

### DIFF
--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -789,7 +789,7 @@ int xocl::XOCLShim::xclLoadXclBin(const xclBin *buffer)
         std::ifstream errorLog( path );
         if( !errorLog.is_open() ) {
             std::cout << "Error opening: " << path << std::endl;
-            return errno;
+            return -errno;
         } else {
             std::string line;
             std::getline( errorLog, line );
@@ -813,6 +813,7 @@ int xocl::XOCLShim::xclLoadAxlf(const axlf *buffer)
     }
 
     if (!mLocked) {
+         std::cout << __func__ << " ERROR: Device is not locked" << std::endl;
         return -EPERM;
     }
 
@@ -1795,14 +1796,14 @@ int xclRemoveAndScanFPGA( void )
         std::ofstream userFile( dev_name_pf_user );
         if( !userFile.is_open() ) {
             perror( dev_name_pf_user.c_str() );
-            return errno;
+            return -errno;
         }
         userFile << input;
 
         std::ofstream mgmtFile( dev_name_pf_mgmt );
         if( !mgmtFile.is_open() ) {
             perror( dev_name_pf_mgmt.c_str() );
-            return errno;
+            return -errno;
         }
         mgmtFile << input;
     }

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1150,8 +1150,6 @@ load_program(program* program)
     if (xbrv.valid() && xbrv.get()){
       if(xbrv.get() == -EACCES)
         throw xocl::error(CL_INVALID_PROGRAM,"Failed to load xclbin. Invalid DNA");
-      else if (xbrv.get() == -EPERM)
-        throw xocl::error(CL_INVALID_PROGRAM,"Failed to load xclbin. Must download xclbin via mgmt pf");
       else if (xbrv.get() == -EBUSY)
         throw xocl::error(CL_INVALID_PROGRAM,"Failed to load xclbin. Device Busy, see dmesg for details");
       else if (xbrv.get() == -ETIMEDOUT)


### PR DESCRIPTION
This change for 2018.2_XDF

should return -errno(-EINVAL) instead of errno(EINVAL).

Remove ambiguous error messaging