### PR TITLE
Fix CentOS packaging to list each files installed by app.

### DIFF
--- a/src/runtime_src/tools/scripts/pkgapp.sh
+++ b/src/runtime_src/tools/scripts/pkgapp.sh
@@ -153,7 +153,11 @@ dorpm()
 {
     dir=rpmbuild
     mkdir -p $opt_pkgdir/$dir/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
-    approot=$(basename $app_root)
+    # all files installed by app (/<appdir>/opt/{files})
+    appfiles=(`find $app_root -type f`)
+    appdir=${app_root%/*}
+    # all files relative to install dir (/opt/{files})
+    appfiles=( "${appfiles[@]/$appdir/}" )
 
 cat <<EOF > $opt_pkgdir/$dir/SPECS/$opt_name.spec
 
@@ -175,15 +179,19 @@ Xilinx $opt_name application.
 %install
 rsync -avz $app_root %{buildroot}/
 
-%files
-%defattr(-,root,root,-)
-/$approot
 
 %changelog
 * Fri May 18 2018 Soren Soe <soren.soe@xilinx.com>
   Created by script
 
+%files
+%defattr(-,root,root,-)
 EOF
+
+    # append appfiles to spec, one file per line
+    for f in "${appfiles[@]}"; do
+        echo $f >> $opt_pkgdir/$dir/SPECS/$opt_name.spec
+    done
 
     echo "rpmbuild --define '_topdir $opt_pkgdir/$dir' -ba $opt_pkgdir/$dir/SPECS/$opt_name.spec"
     $dir --define '_topdir '"$opt_pkgdir/$dir" -ba $opt_pkgdir/$dir/SPECS/$opt_name.spec


### PR DESCRIPTION
CentOS was seeing transaction issues when installing packaged app.  This issue is related to the fact that the app was packaged to take ownership of parent directories, such as /opt and /opt/xilinx, when it should instead list only the files it installs.