### PR TITLE
Error when allocating device BO without xclbin loaded if ext ptr used.

### DIFF
--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -1308,184 +1308,193 @@ operator==(const xclbin& rhs) const
   return m_impl==rhs.m_impl;
 }
 
+xclbin::impl*
+xclbin::
+impl_or_error() const
+{
+  if (m_impl)
+    return m_impl.get();
+  throw std::runtime_error("xclbin has not been loaded");
+}
+
 xclbin::binary_type
 xclbin::
 binary() const
 {
-  return m_impl->m_binary;
+  return impl_or_error()->m_binary;
 }
 
 std::string
 xclbin::
 dsa_name() const
 {
-  return m_impl->dsa_name();
+  return impl_or_error()->dsa_name();
 }
 
 bool
 xclbin::
 is_unified() const
 {
-  return m_impl->is_unified();
+  return impl_or_error()->is_unified();
 }
 
 std::string
 xclbin::
 project_name() const
 {
-  return m_impl->project_name();
+  return impl_or_error()->project_name();
 }
 
 xclbin::target_type
 xclbin::
 target() const
 {
-  return m_impl->target();
+  return impl_or_error()->target();
 }
 
 xclbin::system_clocks_type
 xclbin::
 system_clocks()
 {
-  return m_impl->system_clocks();
+  return impl_or_error()->system_clocks();
 }
 
 xclbin::kernel_clocks_type
 xclbin::
 kernel_clocks()
 {
-  return m_impl->kernel_clocks();
+  return impl_or_error()->kernel_clocks();
 }
 
 unsigned int
 xclbin::
 num_kernels() const
 {
-  return m_impl->num_kernels();
+  return impl_or_error()->num_kernels();
 }
 
 std::vector<std::string>
 xclbin::
 kernel_names() const
 {
-  return m_impl->kernel_names();
+  return impl_or_error()->kernel_names();
 }
 
 std::vector<const xclbin::symbol*>
 xclbin::
 kernel_symbols() const
-{ return m_impl->kernel_symbols(); }
+{ return impl_or_error()->kernel_symbols(); }
 
 size_t
 xclbin::
 kernel_max_regmap_size() const
 {
-  return m_impl->kernel_max_regmap_size();
+  return impl_or_error()->kernel_max_regmap_size();
 }
 
 const xclbin::symbol&
 xclbin::
 lookup_kernel(const std::string& name) const
 {
-  return m_impl->lookup_kernel(name);
+  return impl_or_error()->lookup_kernel(name);
 }
 
 xclbin::profilers_type
 xclbin::
 profilers() const
 {
-  return m_impl->profilers();
+  return impl_or_error()->profilers();
 }
 
 const clock_freq_topology*
 xclbin::
 get_clk_freq_topology() const
 {
-  return m_impl->get_clk_freq_topology();
+  return impl_or_error()->get_clk_freq_topology();
 }
 
 const mem_topology*
 xclbin::
 get_mem_topology() const
 {
-  return m_impl->get_mem_topology();
+  return impl_or_error()->get_mem_topology();
 }
 
 size_t
 xclbin::
 cu_base_offset() const
 {
-  return m_impl->cu_base_offset();
+  return impl_or_error()->cu_base_offset();
 }
 
 size_t
 xclbin::
 cu_size() const
 {
-  return m_impl->cu_size();
+  return impl_or_error()->cu_size();
 }
 
 bool
 xclbin::
 cu_interrupt() const
 {
-  return m_impl->cu_interrupt();
+  return impl_or_error()->cu_interrupt();
 }
 
 std::vector<uint32_t>
 xclbin::
 cu_base_address_map() const
 {
-  return m_impl->cu_base_address_map();
+  return impl_or_error()->cu_base_address_map();
 }
 
 xclbin::memidx_bitmask_type
 xclbin::
 cu_address_to_memidx(addr_type cuaddr, int32_t arg) const
 {
-  return m_impl->cu_address_to_memidx(cuaddr,arg);
+  return impl_or_error()->cu_address_to_memidx(cuaddr,arg);
 }
 
 xclbin::memidx_bitmask_type
 xclbin::
 cu_address_to_memidx(addr_type cuaddr) const
 {
-  return m_impl->cu_address_to_memidx(cuaddr);
+  return impl_or_error()->cu_address_to_memidx(cuaddr);
 }
 
 xclbin::memidx_bitmask_type
 xclbin::
 mem_address_to_memidx(addr_type memaddr) const
 {
-  return m_impl->mem_address_to_memidx(memaddr);
+  return impl_or_error()->mem_address_to_memidx(memaddr);
 }
 
 xclbin::memidx_type
 xclbin::
 mem_address_to_first_memidx(addr_type memaddr) const
 {
-  return m_impl->mem_address_to_first_memidx(memaddr);
+  return impl_or_error()->mem_address_to_first_memidx(memaddr);
 }
 
 std::string
 xclbin::
 memidx_to_banktag(memidx_type bankidx) const
 {
-  return m_impl->memidx_to_banktag(bankidx);
+  return impl_or_error()->memidx_to_banktag(bankidx);
 }
 
 xclbin::memidx_type
 xclbin::
 banktag_to_memidx(const std::string& tag) const
 {
-  return m_impl->banktag_to_memidx(tag);
+  return impl_or_error()->banktag_to_memidx(tag);
 }
 
 xclbin::memidx_type
 xclbin::
 get_memidx_from_arg(const std::string& kernel_name, int32_t arg)
 {
-  return m_impl->get_memidx_from_arg(kernel_name, arg);
+  return impl_or_error()->get_memidx_from_arg(kernel_name, arg);
 }
 
 unsigned int
@@ -1493,13 +1502,13 @@ xclbin::
 conformance_rename_kernel(const std::string& hash)
 {
   assert(std::getenv("XCL_CONFORMANCE"));
-  return m_impl->conformance_rename_kernel(hash);
+  return impl_or_error()->conformance_rename_kernel(hash);
 }
 
 std::vector<std::string>
 xclbin::
 conformance_kernel_hashes() const
-{ return m_impl->conformance_kernel_hashes(); }
+{ return impl_or_error()->conformance_kernel_hashes(); }
 
 // Convert kernel arg data to string per type of argument
 // Interpret the passed data pointer as per the type of the arg and

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -54,6 +54,9 @@ class xclbin
   struct impl;
   std::shared_ptr<impl> m_impl;
 
+  impl*
+  impl_or_error() const;
+
 public:
   using addr_type = uint64_t;
   //Max 64 mem banks for now.
@@ -365,9 +368,9 @@ public:
   memidx_to_banktag(memidx_type memidx) const;
 
   /**
-   * Get the memory index for a given kernel name for specific arg. 
+   * Get the memory index for a given kernel name for specific arg.
    *
-   * @param kernel_name 
+   * @param kernel_name
        Kernel name to  retrieve the memory index for
    * @param arg
        Index of arg to retrieve the memory index for


### PR DESCRIPTION
If the buffer specified memory bank via cl_mem_ext_ptr_t, then it is not possible to allocate device side buffer without an xclbin loaded

This fixes #421