### PR TITLE
xrtdeps.sh - allow use of arbitrary sudo program

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -136,6 +136,7 @@ fi
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}'`
 FLAVOR=`echo $FLAVOR | tr -d '"'`
 ARCH=`uname -m`
+SUDO=${SUDO:-sudo}
 
 #dmidecode is only applicable for x86_64
 if [ $ARCH == "x86_64" ]; then
@@ -171,35 +172,35 @@ install()
 {
     if [ $FLAVOR == "ubuntu" ]; then
         echo "Installing Ubuntu packages..."
-        sudo apt install -y "${UB_LIST[@]}"
+        ${SUDO} apt install -y "${UB_LIST[@]}"
     fi
 
     # Enable EPEL on CentOS/RHEL
     if [ $FLAVOR == "centos" ]; then
         echo "Enabling EPEL repository..."
-        sudo yum install epel-release
+        ${SUDO} yum install epel-release
     elif [ $FLAVOR == "rhel" ]; then
         echo "Enabling EPEL repository..."
         rpm -q --quiet epel-release
         if [ $? != 0 ]; then
-	    sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-	    sudo yum check-update
+	    ${SUDO} yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+	    ${SUDO} yum check-update
         fi
     fi
 
     # Enable GCC 6 compiler set on RHEL/CentOS 7.X
     if [ $FLAVOR == "rhel" ]; then
         echo "Enabling RHEL SCL repository..."
-        sudo yum-config-manager --enable rhel-server-rhscl-7-rpms
+        ${SUDO} yum-config-manager --enable rhel-server-rhscl-7-rpms
     elif [ $FLAVOR == "centos" ]; then
         echo "Enabling CentOS SCL repository..."
-        sudo yum --enablerepo=extras install centos-release-scl
+        ${SUDO} yum --enablerepo=extras install centos-release-scl
     fi
 
     if [ $FLAVOR == "rhel" ] || [ $FLAVOR == "centos" ]; then
         echo "Installing RHEL/CentOS packages..."
-        sudo yum install -y "${RH_LIST[@]}"
-        sudo yum install devtoolset-6
+        ${SUDO} yum install -y "${RH_LIST[@]}"
+        ${SUDO} yum install devtoolset-6
     fi
 }
 


### PR DESCRIPTION
Xilinx internal servers frequently use /tools/xgs/bin/sudo rather than
a version of the tool on the normal system path. This change allows
an environment variable called $SUDO to be used to point to the tool,
otherwise if unset it reverts to the simple bare `sudo` command as
before.