### PR TITLE
Added versioning support.

### DIFF
--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -2,9 +2,16 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../../driver/include
   )
 
+# -----------------------------------------------------------------------------
+
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 
 # -----------------------------------------------------------------------------
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
+
+# -----------------------------------------------------------------------------
+
 
 file(GLOB XCLBINCAT_FILES
   "xclbincat.cxx"
@@ -68,10 +75,27 @@ set(XCLBINUTIL_FILES_SRCS ${XCLBINUTIL_FILES})
 file(GLOB XCLBINUTIL_MAIN_FILE
   "xclbinutil.cxx"
 )
-set(XCLBINUTIL_SRCS ${XCLBINUTIL_MAIN_FILE} ${XCLBINUTIL_FILES_SRCS})
+
+set(XCLBINUTIL_SRCS ${XCLBINUTIL_MAIN_FILE} ${XCLBINUTIL_FILES_SRCS} "${CMAKE_CURRENT_BINARY_DIR}/generated)/version.h")
 
 add_executable(xclbinutil ${XCLBINUTIL_SRCS})
-target_link_libraries(xclbinutil -static ${Boost_LIBRARIES} )
+target_link_libraries(xclbinutil -static ${Boost_LIBRARIES})
+
+# --- NOTE ---
+# It is intential that the version.h file is regenerated each time the build
+# is performed. This causes xclbintil and any sources that includes this header
+# file to be rebuilt. 
+# 
+# Ultimately, this functionality should be moved to the top most CMakeList target
+# ---
+add_custom_command(
+OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated)/version.h"
+COMMAND ${CMAKE_COMMAND}
+    -Dlocal_dir="${CMAKE_CURRENT_SOURCE_DIR}"
+    -Doutput_dir="${CMAKE_CURRENT_BINARY_DIR}"
+    -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.cmake"
+#  COMMENT "Generating generated/version.h header file"
+)
 
 # -----------------------------------------------------------------------------
 

--- a/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
@@ -24,12 +24,17 @@
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/classification.hpp>
 #include <stdexcept>
 
 // System - Include Files
 #include <iostream>
 #include <string>
 
+// Generated include files
+#include <version.h>
+ 
 namespace XUtil = XclBinUtilities;
 
 namespace {
@@ -53,6 +58,7 @@ int main_(int argc, char** argv) {
   bool bListSections = false;
   bool bInfo = false;
   bool bSkipUUIDInsertion = false;
+  bool bVersion = false;
 
   std::string sInputFile;
   std::string sOutputFile;
@@ -80,7 +86,8 @@ int main_(int argc, char** argv) {
       ("info", boost::program_options::bool_switch(&bInfo), "Print Section Info")
       ("list-names,n", boost::program_options::bool_switch(&bListNames), "List the available names")
       ("list-sections,l", boost::program_options::bool_switch(&bListSections), "List the sections")
-  ;
+      ("version", boost::program_options::bool_switch(&bVersion), "Version information regarding this executable")
+ ;
 
 // --remove-section=section
 //    Remove the section matching the section name. Note that using this option inappropriately may make the output file unusable.
@@ -132,14 +139,33 @@ int main_(int argc, char** argv) {
   //       and not how the customer would use it.
   XUtil::setVerbose(bTrace);
 
+  if (bVersion) {
+    std::cout << std::endl;
+    std::cout << XUtil::format("XRT Build Version: %s", GIT_XRT_VERSION) << std::endl;
+    std::cout << XUtil::format(" Last commit hash: %s", GIT_LAST_COMMIT_HASH) << std::endl;
+    std::cout << XUtil::format("       Build Date: %s", BUILD_DATE) << std::endl;
+    std::vector<std::string> modifiedFiles;
+    boost::split(modifiedFiles, GIT_MODIFIED_FILES, boost::is_any_of(","), boost::token_compress_on);
+
+    if (!modifiedFiles.empty()) {
+      std::cout << std::endl << "Note: This program was build with the following modified / unknown file(s):" << std::endl;
+      unsigned int index;
+      for (index = 0; index < modifiedFiles.size(); ++index) {
+        std::cout << XUtil::format("  %d) %s", index, modifiedFiles[index].c_str()) << std::endl;
+      }
+    }
+    std::cout << std::endl;
+    return RC_SUCCESS;
+  }
+
   if (argc == 1) {
     std::cout << "This utility operations on a xclbin produced by xocc." << std::endl << std::endl;
     std::cout << "For example:" << std::endl;
-    std::cout << "1) Reporting xclbin information  : xclbinutil --info --input binary_container_1.xclbin" << std::endl;
-    std::cout << "2) Extracting the bitstream image: xclbinutil --dump-section BITSTREAM:RAW:bitstream.bit --input binary_container_1.xclbin" << std::endl;
-    std::cout << "3) Extracting the build metadata : xclbinutil --dump-section BUILD_METADATA:HTML:buildMetadata.json --input binary_container_1.xclbin" << std::endl;
-    std::cout << "4) Removing a section            : xclbinutil --remove-section BITSTREAM --input binary_container_1.xclbin --output binary_container_modified.xclbin" << std::endl;
-    std::cout << "5) Checking xclbin integrity     : xclbinutil --validate --input binary_containter_1.xclbin" <<std::endl;
+    std::cout << "  1) Reporting xclbin information  : xclbinutil --info --input binary_container_1.xclbin" << std::endl;
+    std::cout << "  2) Extracting the bitstream image: xclbinutil --dump-section BITSTREAM:RAW:bitstream.bit --input binary_container_1.xclbin" << std::endl;
+    std::cout << "  3) Extracting the build metadata : xclbinutil --dump-section BUILD_METADATA:HTML:buildMetadata.json --input binary_container_1.xclbin" << std::endl;
+    std::cout << "  4) Removing a section            : xclbinutil --remove-section BITSTREAM --input binary_container_1.xclbin --output binary_container_modified.xclbin" << std::endl;
+    std::cout << "  5) Checking xclbin integrity     : xclbinutil --validate --input binary_containter_1.xclbin" <<std::endl;
 
     std::cout << std::endl 
               << "Command Line Options" << std::endl

--- a/src/runtime_src/tools/xclbin/cmake/version.cmake
+++ b/src/runtime_src/tools/xclbin/cmake/version.cmake
@@ -1,0 +1,61 @@
+# cmake/version.cmake
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+ 
+message(STATUS "Resolving Versions...")
+
+set(GIT_BRANCH "Unknown")
+set(GIT_XRT_VERSION "Unknown")
+set(GIT_LAST_COMMIT_HASH "Unknown")
+set(BUILD_DATE "Unknown")
+set(GIT_MODIFIED_FILES "Empty")
+
+find_package(Git)
+if(GIT_FOUND)
+  # Variable: GIT_BRANCH
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  
+  # Variable: GIT_XRT_VERSION
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} --no-pager describe --tags --always
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_XRT_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  
+  # Variable: GIT_LAST_COMMIT_HASH
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_LAST_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  
+  # Variable: GIT_MODIFIED_FILES
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status --porcelain
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_MODIFIED_FILES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  string(REPLACE "\n" "," GIT_MODIFIED_FILES "${GIT_MODIFIED_FILES}")
+  
+  # Variable: BUILD_DATE
+  execute_process(
+    COMMAND date --iso=seconds
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE BUILD_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+else()
+  message(STATUS "GIT not found")
+endif()
+
+configure_file(${local_dir}/cmake/version.h.in ${output_dir}/generated/version.h)
+
+message(STATUS "Generated the file: ${output_dir}/generated/version.h")
+

--- a/src/runtime_src/tools/xclbin/cmake/version.h.in
+++ b/src/runtime_src/tools/xclbin/cmake/version.h.in
@@ -1,0 +1,11 @@
+#ifndef version_h
+#define version_h
+
+#define GIT_BRANCH "@GIT_BRANCH@"
+#define GIT_XRT_VERSION "@GIT_XRT_VERSION@"
+#define GIT_LAST_COMMIT_HASH "@GIT_LAST_COMMIT_HASH@"
+#define GIT_MODIFIED_FILES "@GIT_MODIFIED_FILES@"
+#define BUILD_DATE "@BUILD_DATE@"
+
+
+#endif


### PR DESCRIPTION
Work Done
+ As part of the project build process a header file, version.h, is produced that contains build and version information.
+ xclbinutil has been updated with a "--version" option to report the contents of the version.h

Note
Because the version.h file is produced each time a build is involked, xclbinutil will be re-linked with any of its objects that are depended on this header file.