### PR TITLE
AWS 2018.2 Data Retention

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
@@ -437,6 +437,7 @@ failed:
 void xocl_drm_fini(struct xocl_dev *xdev)
 {
 	xocl_cleanup_mem(xdev);
+        xocl_cleanup_connectivity(xdev);
 
 	drm_put_dev(xdev->ddev);
 
@@ -504,14 +505,6 @@ void xocl_cleanup_mem(struct xocl_dev *xdev)
 	u16 i, ddr;
 
 	topology = xdev->topology;
-
-	vfree(xdev->layout);
-	xdev->layout = NULL;
-	vfree(xdev->debug_layout);
-	xdev->debug_layout = NULL;
-	vfree(xdev->connectivity);
-	xdev->connectivity = NULL;
-
 	if (topology == NULL)
 		return;
 
@@ -529,6 +522,16 @@ void xocl_cleanup_mem(struct xocl_dev *xdev)
 		vfree(xdev->mm_usage_stat);
 	vfree(xdev->topology);
 	xdev->topology = NULL;
+}
+
+void xocl_cleanup_connectivity(struct xocl_dev *xdev)
+{
+        vfree(xdev->layout);
+        xdev->layout = NULL;
+        vfree(xdev->debug_layout);
+        xdev->debug_layout = NULL;
+        vfree(xdev->connectivity);
+        xdev->connectivity = NULL;        
 }
 
 ssize_t xocl_mm_sysfs_stat(struct xocl_dev *xdev, char *buf, bool raw)

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
@@ -437,10 +437,8 @@ failed:
 void xocl_drm_fini(struct xocl_dev *xdev)
 {
 	xocl_cleanup_mem(xdev);
-        xocl_cleanup_connectivity(xdev);
-
+	xocl_cleanup_connectivity(xdev);
 	drm_put_dev(xdev->ddev);
-
 	mutex_destroy(&xdev->ctx_list_lock);
 	mutex_destroy(&xdev->stat_lock);
 	mutex_destroy(&xdev->mm_lock);
@@ -526,12 +524,12 @@ void xocl_cleanup_mem(struct xocl_dev *xdev)
 
 void xocl_cleanup_connectivity(struct xocl_dev *xdev)
 {
-        vfree(xdev->layout);
-        xdev->layout = NULL;
-        vfree(xdev->debug_layout);
-        xdev->debug_layout = NULL;
-        vfree(xdev->connectivity);
-        xdev->connectivity = NULL;        
+	vfree(xdev->layout);
+	xdev->layout = NULL;
+	vfree(xdev->debug_layout);
+	xdev->debug_layout = NULL;
+	vfree(xdev->connectivity);
+	xdev->connectivity = NULL;
 }
 
 ssize_t xocl_mm_sysfs_stat(struct xocl_dev *xdev, char *buf, bool raw)

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.h
@@ -28,6 +28,7 @@ int xocl_drm_init(struct xocl_dev *xdev);
 void xocl_drm_fini(struct xocl_dev *xdev);
 
 void xocl_cleanup_mem(struct xocl_dev *xdev);
+void xocl_cleanup_connectivity(struct xocl_dev *xdev);
 int xocl_check_topology(struct xocl_dev *xdev);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -548,9 +548,8 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 
 	/* Compare MEM_TOPOLOGY previous vs new. Ignore this and keep disable preserve_mem if not for aws.*/
 	if (xocl_is_aws(xdev) && (xdev->topology != NULL)) {
-		// m_mem_data can be of different length but we would not compare them if topology match fails
-		if (!memcmp(new_topology, xdev->topology, size) &&
-		    (sizeof_sect(new_topology, m_mem_data) == sizeof_sect(xdev->topology, m_mem_data))) {
+		if ( (size == sizeof_sect(xdev->topology, m_mem_data)) &&
+		    !memcmp(new_topology, xdev->topology, size) ) {
 			printk(KERN_INFO "XOCL: MEM_TOPOLOGY match, preserve mem_topology.\n");
 			preserve_mem = 1;
 		} else {

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -546,8 +546,8 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 		goto done;
 	}
 
-	/* Compare MEM_TOPOLOGY previous vs new. */
-	if (xdev->topology != NULL) {
+	/* Compare MEM_TOPOLOGY previous vs new. Ignore this and keep disable preserve_mem if not for aws.*/
+	if (xocl_is_aws(xdev) && (xdev->topology != NULL)) {
 		// m_mem_data can be of different length but we would not compare them if topology match fails
 		if (!memcmp(new_topology, xdev->topology, size) &&
 		    (sizeof_sect(new_topology, m_mem_data) == sizeof_sect(xdev->topology, m_mem_data))) {

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -448,7 +448,7 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 	size_t num_of_sections;
 	size_t size;
         int preserve_mem = 0;
-        struct mem_topology new_topology;
+        struct mem_topology *new_topology;
 
 	userpf_info(xdev, "READ_AXLF IOCTL\n");
 
@@ -539,11 +539,11 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 
         /* 1, read MEM_TOPOLOGY */        
         /* Populating MEM_TOPOLOGY sections */
-	size = xocl_read_sect(MEM_TOPOLOGY, new_toplogy.topology, axlf, buf);
+	size = xocl_read_sect(MEM_TOPOLOGY, &new_topology, axlf, buf);
 	if (size <= 0) {
 		if (size != 0)
 			goto done;
-	} else if (sizeof_sect(new_toplogy.topology, m_mem_data) != size) {
+	} else if (sizeof_sect(new_topology, m_mem_data) != size) {
 		err = -EINVAL;
 		goto done;
 	}
@@ -571,7 +571,6 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
         /* 4, copy MEM_TOPOLOGY from new_toplogy if !preserve_mem */
         if (!preserve_mem) {
                 xdev->topology = new_topology;
-                new_topology = NULL;
         }
         
 	/* Populating IP_LAYOUT sections */

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -447,8 +447,8 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 	size_t size_of_header;
 	size_t num_of_sections;
 	size_t size;
-        int preserve_mem = 0;
-        struct mem_topology *new_topology;
+	int preserve_mem = 0;
+	struct mem_topology *new_topology;
 
 	userpf_info(xdev, "READ_AXLF IOCTL\n");
 
@@ -535,10 +535,8 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 		err = -EFAULT;
 		goto done;
 	}
-        
 
-        /* 1, read MEM_TOPOLOGY */        
-        /* Populating MEM_TOPOLOGY sections */
+	/* Populating MEM_TOPOLOGY sections. */
 	size = xocl_read_sect(MEM_TOPOLOGY, &new_topology, axlf, buf);
 	if (size <= 0) {
 		if (size != 0)
@@ -548,31 +546,30 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 		goto done;
 	}
 
-        /* 2, compare MEM_TOPOLOGY */
-        if (xdev->topology != NULL) {
-            if (!memcmp(new_topology, xdev->topology, size)) {
-                printk(KERN_INFO "XOCL: MEM_TOPOLOGY match, preserve mem_topology.\n");
-                preserve_mem =1;
-            } else {
-                printk(KERN_INFO "XOCL: MEM_TOPOLOGY mismatch, do not preserve mem_topology.\n");
-            }
-        }
-        
-        /* 3, cleanup */
-        //Switching the xclbin, make sure none of the buffers are used.
-        if (!preserve_mem) {
-            err = xocl_check_topology(xdev);
-            if(err)
-                    goto done;
-            xocl_cleanup_mem(xdev);            
-        }
-        xocl_cleanup_connectivity(xdev);
-        
-        /* 4, copy MEM_TOPOLOGY from new_toplogy if !preserve_mem */
-        if (!preserve_mem) {
-                xdev->topology = new_topology;
-        }
-        
+	/* Compare MEM_TOPOLOGY previous vs new. */
+	if (xdev->topology != NULL) {
+		if (!memcmp(new_topology, xdev->topology, size)) {
+			printk(KERN_INFO "XOCL: MEM_TOPOLOGY match, preserve mem_topology.\n");
+			preserve_mem =1;
+		} else {
+			printk(KERN_INFO "XOCL: MEM_TOPOLOGY mismatch, do not preserve mem_topology.\n");
+		}
+	}
+
+	/* Switching the xclbin, make sure none of the buffers are used. */
+	if (!preserve_mem) {
+		err = xocl_check_topology(xdev);
+		if(err)
+			goto done;
+		xocl_cleanup_mem(xdev);
+	}
+	xocl_cleanup_connectivity(xdev);
+
+	/* Copy MEM_TOPOLOGY from new_toplogy if not preserving memory. */
+	if (!preserve_mem) {
+		xdev->topology = new_topology;
+	}
+
 	/* Populating IP_LAYOUT sections */
 	/* zocl_read_sect return size of section when successfully find it */
 	size = xocl_read_sect(IP_LAYOUT, &xdev->layout, axlf, buf);

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -601,15 +601,11 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 		goto done;
 	}
 
-
-        
-        
-
-        if (!preserve_mem) {
-            err = xocl_init_mm(xdev);
-            if (err)
-                    goto done;
-        }
+	if (!preserve_mem) {
+		err = xocl_init_mm(xdev);
+		if (err)
+			goto done;
+	}
 
 	//Populate with "this" bitstream, so avoid redownload the next time
 	xdev->unique_id_last_bitstream = bin_obj.m_uniqueId;

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -568,9 +568,10 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 	xocl_cleanup_connectivity(xdev);
 
 	/* Copy MEM_TOPOLOGY from new_toplogy if not preserving memory. */
-	if (!preserve_mem) {
+	if (!preserve_mem)
 		xdev->topology = new_topology;
-	}
+	else
+		vfree(new_topology);
 
 	/* Populating IP_LAYOUT sections */
 	/* zocl_read_sect return size of section when successfully find it */

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -548,9 +548,11 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 
 	/* Compare MEM_TOPOLOGY previous vs new. */
 	if (xdev->topology != NULL) {
-		if (!memcmp(new_topology, xdev->topology, size)) {
+		// m_mem_data can be of different length but we would not compare them if topology match fails
+		if (!memcmp(new_topology, xdev->topology, size) &&
+		    (sizeof_sect(new_topology, m_mem_data) == sizeof_sect(xdev->topology, m_mem_data))) {
 			printk(KERN_INFO "XOCL: MEM_TOPOLOGY match, preserve mem_topology.\n");
-			preserve_mem =1;
+			preserve_mem = 1;
 		} else {
 			printk(KERN_INFO "XOCL: MEM_TOPOLOGY mismatch, do not preserve mem_topology.\n");
 		}

--- a/src/runtime_src/driver/xclng/xrt/user_aws/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/shim.cpp
@@ -174,13 +174,13 @@ namespace awsbwhal {
               opt.afi_id = afi_id;
               opt.slot_id = mBoardNumber;
               retVal = fpga_mgmt_load_local_image_with_options(&opt);
-	      if (retVal == FPGA_ERR_DRAM_DATA_RETENTION_NOT_POSSIBLE ||
-		  retVal == FPGA_ERR_DRAM_DATA_RETENTION_FAILED ||
-		  retVal == FPGA_ERR_DRAM_DATA_RETENTION_SETUP_FAILED) {
+              if (retVal == FPGA_ERR_DRAM_DATA_RETENTION_NOT_POSSIBLE ||
+                  retVal == FPGA_ERR_DRAM_DATA_RETENTION_FAILED ||
+                  retVal == FPGA_ERR_DRAM_DATA_RETENTION_SETUP_FAILED) {
                   std::cout << "INFO: Could not load AFI for data retention, code: " << retVal 
                             << " - Loading in classic mode." << std::endl;
-		  retVal = fpga_mgmt_load_local_image(mBoardNumber, afi_id);
-	      }	  
+                  retVal = fpga_mgmt_load_local_image(mBoardNumber, afi_id);
+              }
               // check retVal from image load
               if (retVal) {
                   std::cout << "Failed to load AFI, error: " << retVal << std::endl;
@@ -194,7 +194,7 @@ namespace awsbwhal {
                       std::cout << "IOCTL DRM_IOCTL_XOCL_READ_AXLF Failed: " << retVal << std::endl;
                   } else {
                       std::cout << "AFI load complete." << std::endl;
-                  }   
+                  }
               }
           }
           return retVal;


### PR DESCRIPTION
- Ready to merge these into the 2018.2_XDF branch. This is the branch used by Amr to generate the 2018.2 RPM with Data Retention + backward compatibility AFI load. 
- These belong in 2018.2_XDF or a copy of 2018.2_XDF tagged for AWS 2018.2 release. 
- The tag will be used as the submodule branch of XRT in the 2018.2 XRT submodule integration for AWS for the developer usecase we are referring to as "Step3". 