### PR TITLE
Added support to auto add sections when reading from a compiled JSON file

### DIFF
--- a/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
@@ -65,7 +65,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
   }
 
   if (tokens.size() != 3) {
-    std::string errMsg = XUtil::format("Error: Expected format <section>:<file>:<format> when using adding a section.  Received: %s.", _formattedString.c_str());
+    std::string errMsg = XUtil::format("Error: Expected format <section>:<format>:<file> when using adding a section.  Received: %s.", _formattedString.c_str());
     throw std::runtime_error(errMsg);
   }
 
@@ -83,7 +83,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
   }
 
   if ( tokens[0].empty() && (m_formatType != Section::FT_JSON)) {
-    std::string errMsg = "Error: Empty sections are only permitted with JSON format files.";
+    std::string errMsg = "Error: Empty sections names are only permitted with JSON format files.";
     throw std::runtime_error(errMsg);
   }
   m_section = tokens[0];

--- a/src/runtime_src/tools/xclbin/Section.h
+++ b/src/runtime_src/tools/xclbin/Section.h
@@ -62,6 +62,7 @@ class Section {
   static void getKinds(std::vector< std::string > & kinds);
   static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind);
   static bool translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind);
+  static bool getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind);
   static enum FormatType getFormatType(const std::string _sFormatType);
 
  public:
@@ -75,6 +76,7 @@ class Section {
   virtual void readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader);
   virtual void readXclBinBinary(std::fstream& _istream, const boost::property_tree::ptree& _ptSection);
   void readXclBinBinary(std::fstream& _istream, enum FormatType _eFormatType);
+  void readJSONSectionImage(const boost::property_tree::ptree& _ptSection);
 
   virtual void initXclBinSectionHeader(axlf_section_header& _sectionHeader);
   virtual void writeXclBinSectionBuffer(std::fstream& _ostream) const;
@@ -82,6 +84,7 @@ class Section {
 
   void addMirrorPayload(boost::property_tree::ptree& _pt) const;
   void purgeBuffers();
+  void setName(const std::string &_sSectionName);
 
  protected:
   // Child class option to create an JSON metadata
@@ -93,7 +96,7 @@ class Section {
 
  protected:
   typedef std::function<Section*()> Section_factory;
-  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, Section_factory _Section_factory);
+  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, Section_factory _Section_factory);
 
  protected:
   enum axlf_section_kind m_eKind;
@@ -107,6 +110,7 @@ class Section {
   static std::map<enum axlf_section_kind, std::string> m_mapIdToName;
   static std::map<std::string, enum axlf_section_kind> m_mapNameToId;
   static std::map<enum axlf_section_kind, Section_factory> m_mapIdToCtor;
+  static std::map<std::string, enum axlf_section_kind> m_mapJSONNameToKind;
 
  private:
   // Purposefully private and undefined ctors...

--- a/src/runtime_src/tools/xclbin/SectionBMC.h
+++ b/src/runtime_src/tools/xclbin/SectionBMC.h
@@ -47,7 +47,7 @@ class SectionBMC : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BMC, "BMC", boost::factory<SectionBMC*>()); }
+    _init() { registerSectionCtor(BMC, "BMC", "", boost::factory<SectionBMC*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstream.h
@@ -47,7 +47,7 @@ class SectionBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", boost::factory<SectionBitstream*>()); }
+    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", boost::factory<SectionBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
@@ -51,7 +51,7 @@ class SectionBuildMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", boost::factory<SectionBuildMetadata*>()); }
+    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "FlowMetaData", boost::factory<SectionBuildMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClearBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionClearBitstream.h
@@ -47,7 +47,7 @@ class SectionClearBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", boost::factory<SectionClearBitstream*>()); }
+    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", boost::factory<SectionClearBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
@@ -55,7 +55,7 @@ class SectionClockFrequencyTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", boost::factory<SectionClockFrequencyTopology*>()); }
+    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", boost::factory<SectionClockFrequencyTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionConnectivity.h
+++ b/src/runtime_src/tools/xclbin/SectionConnectivity.h
@@ -53,7 +53,7 @@ class SectionConnectivity : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", boost::factory<SectionConnectivity*>()); }
+    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", boost::factory<SectionConnectivity*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugData.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugData.h
@@ -47,7 +47,7 @@ class SectionDebugData : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", boost::factory<SectionDebugData*>()); }
+    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", boost::factory<SectionDebugData*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
@@ -55,7 +55,7 @@ class SectionDebugIPLayout : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", boost::factory<SectionDebugIPLayout*>()); }
+    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", boost::factory<SectionDebugIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
+++ b/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
@@ -47,7 +47,7 @@ class SectionDesignCheckPoint : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", boost::factory<SectionDesignCheckPoint*>()); }
+    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", boost::factory<SectionDesignCheckPoint*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
@@ -47,7 +47,7 @@ class SectionEmbeddedMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", boost::factory<SectionEmbeddedMetadata*>()); }
+    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", boost::factory<SectionEmbeddedMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.h
@@ -55,7 +55,7 @@ class SectionIPLayout : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", boost::factory<SectionIPLayout*>()); }
+    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", boost::factory<SectionIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
@@ -47,7 +47,7 @@ class SectionKeyValueMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", boost::factory<SectionKeyValueMetadata*>()); }
+    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "", boost::factory<SectionKeyValueMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMCS.h
+++ b/src/runtime_src/tools/xclbin/SectionMCS.h
@@ -53,7 +53,7 @@ class SectionMCS : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MCS, "MCS", boost::factory<SectionMCS*>()); }
+    _init() { registerSectionCtor(MCS, "MCS", "", boost::factory<SectionMCS*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionManagementFW.h
+++ b/src/runtime_src/tools/xclbin/SectionManagementFW.h
@@ -47,7 +47,7 @@ class SectionManagementFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", boost::factory<SectionManagementFW*>()); }
+    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", boost::factory<SectionManagementFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMemTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionMemTopology.h
@@ -55,7 +55,7 @@ class SectionMemTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", boost::factory<SectionMemTopology*>()); }
+    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", boost::factory<SectionMemTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
+++ b/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
@@ -47,7 +47,7 @@ class SectionSchedulerFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", boost::factory<SectionSchedulerFW*>()); }
+    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", boost::factory<SectionSchedulerFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionUserMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionUserMetadata.h
@@ -47,7 +47,7 @@ class SectionUserMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", boost::factory<SectionUserMetadata*>()); }
+    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", boost::factory<SectionUserMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/XclBin.cxx
+++ b/src/runtime_src/tools/xclbin/XclBin.cxx
@@ -25,6 +25,7 @@
 #include <boost/uuid/uuid.hpp>          // for uuid
 #include <boost/uuid/uuid_io.hpp>       // for to_string
 #include <boost/uuid/uuid_generators.hpp> // generators
+#include <boost/filesystem.hpp>
 
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
@@ -37,7 +38,7 @@ static const std::string MIRROR_DATA_END = "XCLBIN_MIRROR_DATA_END";
 XclBin::XclBin()
     : m_xclBinHeader({ 0 })
     , m_SchemaVersionMirrorWrite({ 1, 0, 0 }) {
-  // Empty
+  initializeHeader( m_xclBinHeader);
 }
 
 XclBin::~XclBin() {
@@ -45,6 +46,22 @@ XclBin::~XclBin() {
     delete m_sections[index];
   }
   m_sections.clear();
+}
+
+
+
+void 
+XclBin::initializeHeader(axlf &_xclBinHeader)
+{
+  _xclBinHeader = {0};
+
+  std::string sMagic = "xclbin2";
+  XUtil::safeStringCopy(_xclBinHeader.m_magic, sMagic, sizeof(_xclBinHeader.m_magic));
+  memset( _xclBinHeader.m_cipher, 0xFF, sizeof(_xclBinHeader.m_cipher) );
+  memset( _xclBinHeader.m_keyBlock, 0xFF, sizeof(_xclBinHeader.m_keyBlock) );
+  _xclBinHeader.m_uniqueId = time( nullptr );
+  _xclBinHeader.m_header.m_timeStamp = time( nullptr );
+  _xclBinHeader.m_header.m_version = 2017;
 }
 
 // String Getters
@@ -446,7 +463,9 @@ XclBin::updateUUID() {
 }
 
 void
-XclBin::writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDInsertion) {
+XclBin::writeXclBinBinary(const std::string &_binaryFileName, 
+                          bool _bSkipUUIDInsertion,
+                          bool _bInsertValidationChecksum) {
   // Error checks
   if (_binaryFileName.empty()) {
     std::string errMsg = "ERROR: Missing file name to write to.";
@@ -490,8 +509,12 @@ XclBin::writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDIns
     unsigned int streamSize = ofXclBin.tellg();
 
     // Update Header
-    // Include soon to be added checksum value
-    m_xclBinHeader.m_header.m_length = streamSize + sizeof(struct checksum);
+    m_xclBinHeader.m_header.m_length = streamSize;
+
+    if (_bInsertValidationChecksum) {
+      // Include soon to be added checksum value
+      m_xclBinHeader.m_header.m_length += sizeof(struct checksum);
+    }
 
     // Write out the header...again
     ofXclBin.seekg(0, ofXclBin.beg);
@@ -502,7 +525,10 @@ XclBin::writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDIns
   // Close file
   ofXclBin.close();
 
-  XUtil::addCheckSumImage(_binaryFileName, CST_SDBM);
+  if (_bInsertValidationChecksum) {
+    XUtil::addCheckSumImage(_binaryFileName, CST_SDBM);
+  }
+
   std::cout << XUtil::format("Successfully wrote (%ld bytes) to output file: %s", m_xclBinHeader.m_header.m_length, _binaryFileName.c_str()) << std::endl;
 }
 
@@ -784,10 +810,14 @@ XclBin::replaceSection(ParameterSectionData &_PSD)
   pSection->purgeBuffers();
   pSection->readXclBinBinary(iSectionFile, _PSD.getFormatType());
 
+  boost::filesystem::path p(sSectionFileName);
+  std::string sBaseName = p.stem().string();
+  pSection->setName(sBaseName);
+
   XUtil::TRACE(XUtil::format("Section '%s' (%d) successfully added.", pSection->getSectionKindAsString().c_str(), pSection->getSectionKind()));
-  std::cout << std::endl << XUtil::format("Section '%s'(%d) was successfully added.\nFormat: %s\nFile  : '%s'", 
-                                          pSection->getSectionKindAsString().c_str(), 
-                                          pSection->getSectionKind(),
+  std::cout << std::endl << XUtil::format("Section: '%s'(%d) was successfully added.\nSize: %ld bytes\nFormat: %s\nFile  : '%s'", 
+                                          pSection->getSectionKindAsString().c_str(), pSection->getSectionKind(),
+                                          pSection->getSize(),
                                           _PSD.getFormatTypeAsStr().c_str(), sSectionFileName.c_str()) << std::endl;
 }
 
@@ -816,13 +846,82 @@ XclBin::addSection(ParameterSectionData &_PSD)
 
   Section * pSection = Section::createSectionObjectOfKind(eKind);
   pSection->readXclBinBinary(iSectionFile, _PSD.getFormatType());
+
+  boost::filesystem::path p(sSectionFileName);
+  std::string sBaseName = p.stem().string();
+  pSection->setName(sBaseName);
+
   addSection(pSection);
   XUtil::TRACE(XUtil::format("Section '%s' (%d) successfully added.", pSection->getSectionKindAsString().c_str(), pSection->getSectionKind()));
-  std::cout << std::endl << XUtil::format("Section '%s'(%d) was successfully added.\nFormat: %s\nFile  : '%s'", 
-                                          pSection->getSectionKindAsString().c_str(), 
-                                          pSection->getSectionKind(),
+  std::cout << std::endl << XUtil::format("Section: '%s'(%d) was successfully added.\nSize: %ld bytes\nFormat: %s\nFile  : '%s'", 
+                                          pSection->getSectionKindAsString().c_str(), pSection->getSectionKind(),
+                                          pSection->getSize(),
                                           _PSD.getFormatTypeAsStr().c_str(), sSectionFileName.c_str()) << std::endl;
 }
+
+
+void 
+XclBin::addSections(ParameterSectionData &_PSD)
+{
+  if (!_PSD.getSectionName().empty()) {
+    std::string errMsg = "Error: Section given for a wildcard JSON section add call.";
+    throw std::runtime_error(errMsg);
+  }
+
+  if (_PSD.getFormatType() != Section::FT_JSON) {
+    std::string errMsg = XUtil::format("Error: Expecting JSON format type, got '%s'.", _PSD.getFormatTypeAsStr().c_str());
+    throw std::runtime_error(errMsg);
+  }
+
+  std::string sJSONFileName = _PSD.getFile();
+
+  std::fstream fs;
+  fs.open(sJSONFileName, std::ifstream::in | std::ifstream::binary);
+  if (!fs.is_open()) {
+    std::string errMsg = "ERROR: Unable to open the file for reading: " + sJSONFileName;
+    throw std::runtime_error(errMsg);
+  }
+
+  //  Add a new element to the collection and parse the jason file
+  XUtil::TRACE("Reading JSON File: '" + sJSONFileName + '"');
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json( fs, pt );
+  
+  XUtil::TRACE("Examining the property tree from the JSON's file: '" + sJSONFileName + "'");
+  XUtil::TRACE("Property Tree: Root");
+  XUtil::TRACE_PrintTree("Root", pt);
+
+  for (boost::property_tree::ptree::iterator ptSection = pt.begin(); ptSection != pt.end(); ++ptSection) {
+    const std::string & sectionName = ptSection->first;
+    if (sectionName == "schema_version") {
+      XUtil::TRACE("Skipping: '" + sectionName + "'");
+      continue;
+    }
+
+    XUtil::TRACE("Processing: '" + sectionName + "'");
+
+    enum axlf_section_kind eKind;
+    if (Section::getKindOfJSON(sectionName, eKind) == false) {
+      std::string errMsg = XUtil::format("ERROR: Unknown JSON section '%s' in file: %s", sectionName.c_str(), sJSONFileName.c_str());
+      throw std::runtime_error(errMsg);
+    }
+
+    if (findSection(eKind) != nullptr) {
+      std::string errMsg = XUtil::format("Error: Section '%s' already exists.", _PSD.getSectionName().c_str());
+      throw std::runtime_error(errMsg);
+    }
+
+    Section * pSection = Section::createSectionObjectOfKind(eKind);
+    pSection->readJSONSectionImage(pt);
+    addSection(pSection);
+    XUtil::TRACE(XUtil::format("Section '%s' (%d) successfully added.", pSection->getSectionKindAsString().c_str(), pSection->getSectionKind()));
+    std::cout << std::endl << XUtil::format("Section '%s'(%d) was successfully added.\nFormat: %s\nFile  : '%s'", 
+                                          pSection->getSectionKindAsString().c_str(), 
+                                          pSection->getSectionKind(),
+                                          _PSD.getFormatTypeAsStr().c_str(), sectionName.c_str()) << std::endl;
+  }
+}
+
 
 void 
 XclBin::dumpSection(ParameterSectionData &_PSD) 
@@ -854,4 +953,79 @@ XclBin::dumpSection(ParameterSectionData &_PSD)
                                           pSection->getSectionKindAsString().c_str(), 
                                           pSection->getSectionKind(),
                                           _PSD.getFormatTypeAsStr().c_str(), sDumpFileName.c_str()) << std::endl;
+}
+
+
+void 
+XclBin::setKeyValue(const std::string & _keyValue)
+{
+  const std::string& delimiters = ":";      // Our delimiter
+
+  // Working variables
+  std::string::size_type pos = 0;
+  std::string::size_type lastPos = 0;
+  std::vector<std::string> tokens;
+
+  // Parse the string until the entire string has been parsed or 3 tokens have been found
+  while((lastPos < _keyValue.length() + 1) && 
+        (tokens.size() < 3))
+  {
+    pos = _keyValue.find_first_of(delimiters, lastPos);
+
+    if ( (pos == std::string::npos) ||
+         (tokens.size() == 2) ){
+       pos = _keyValue.length();
+    }
+
+    std::string token = _keyValue.substr(lastPos, pos-lastPos);
+    tokens.push_back(token);
+    lastPos = pos + 1;
+  }
+
+  if (tokens.size() != 3) {
+    std::string errMsg = XUtil::format("Error: Expected format [USER | SYS]:<key>:<value> when using adding a key value pair.  Received: %s.", _keyValue.c_str());
+    throw std::runtime_error(errMsg);
+  }
+
+  boost::to_upper(tokens[0]);
+  std::string sDomain = tokens[0];
+  std::string sKey = tokens[1];
+  std::string sValue = tokens[2];
+  
+  XUtil::TRACE(XUtil::format("Setting key-value pair \"%s\":  domain:'%s', key:'%s', value:'%s'", 
+                             _keyValue.c_str(), sDomain.c_str(), sKey.c_str(), sValue.c_str()));
+
+  if (sDomain == "SYS") {
+    if (sKey == "mode") {
+      if (sValue == "flat" ) {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_FLAT;
+      } else if (sValue == "hw_pr") {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_PR;
+      } else if (sValue == "tandem") {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_TANDEM_STAGE2;
+      } else if (sValue == "tandem_pr") {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_TANDEM_STAGE2_WITH_PR;
+      } else if (sValue == "hw_emu") {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_HW_EMU;
+      } else if (sValue == "sw_emu") {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_SW_EMU;
+      } else {
+        std::string errMsg = XUtil::format("Error: Unknown value '%s' for key '%s'. Key-value pair: '%s'.", sValue.c_str(), sKey.c_str(), _keyValue.c_str());
+        throw std::runtime_error(errMsg);
+      }
+      return; // Key processed 
+    }
+
+    std::string errMsg = XUtil::format("Error: Unknown key '%s' for key-value pair '%s'.", sKey.c_str(), _keyValue.c_str());
+    throw std::runtime_error(errMsg);
+  } 
+
+  if (sDomain == "USER") {
+
+    std::string errMsg = XUtil::format("Error: Unknown key '%s' for key-value pair '%s'.", sKey.c_str(), _keyValue.c_str());
+    throw std::runtime_error(errMsg);
+  }
+
+  std::string errMsg = XUtil::format("Error: Unknown key domain for key-value pair '%s'.  Expected either 'USER' or 'SYS'.", sDomain.c_str());
+  throw std::runtime_error(errMsg);
 }

--- a/src/runtime_src/tools/xclbin/XclBin.h
+++ b/src/runtime_src/tools/xclbin/XclBin.h
@@ -62,11 +62,13 @@ class XclBin {
   void printHeader();
 
   void readXclBinBinary(const std::string &_binaryFileName, bool _bMigrate = false);
-  void writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDInsertion = false);
+  void writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDInsertion, bool _bInsertValidationChecksum);
   void removeSection(const std::string & _sSectionToRemove);
   void addSection(ParameterSectionData &_PSD);
+  void addSections(ParameterSectionData &_PSD);
   void replaceSection(ParameterSectionData &_PSD);
   void dumpSection(ParameterSectionData &_PSD);
+  void setKeyValue(const std::string & _keyValue);
 
  public:
   Section *findSection(enum axlf_section_kind _eKind);
@@ -86,6 +88,8 @@ class XclBin {
   void removeSection(const Section* _pSection);
 
   void updateUUID();
+
+  void initializeHeader(axlf &_xclBinHeader);
 
   // Should be in their own separate class
  private:


### PR DESCRIPTION
    Work Done
    + Removed add-validation command
    + Added hidden option to skip adding a validation image
    + Added ability to set the name of a section.
    + When an xclbin header is created, it is now initialized with the correct values (instead of all zeros).
    + When sections are added, the size of the section is now reported.
    + Refactor code to have only one constructor for a section.
    + Added DRCs to verify that only one section exists when adding sections via JSON
    + Add key-value pair support
    + Added support to add sections via a multi-formatted JSON file.
    + Added multiplicity for the following options: --add-section, --remove-section, --dump-section, and --replace-section.