### PR TITLE
Phase 3: xclbinutil changes

### DIFF
--- a/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
@@ -41,7 +41,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
 // String being parsed:  <section>:<formatType>:<filename>
 // Example String:       BUILD_METADATA:JSON:MY_FILE.JSON
 {
-  const std::string& delimiters = ":";      // Our delimiter
+  const std::string delimiters = ":";      // Our delimiter
 
   // Working variables
   std::string::size_type pos = 0;
@@ -65,7 +65,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
   }
 
   if (tokens.size() != 3) {
-    std::string errMsg = XUtil::format("Error: Expected format <section>:<file>:<format> when using adding a section.  Received: %s.", _formattedString.c_str());
+    std::string errMsg = XUtil::format("Error: Expected format <section>:<format>:<file> when using adding a section.  Received: %s.", _formattedString.c_str());
     throw std::runtime_error(errMsg);
   }
 
@@ -83,7 +83,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
   }
 
   if ( tokens[0].empty() && (m_formatType != Section::FT_JSON)) {
-    std::string errMsg = "Error: Empty sections are only permitted with JSON format files.";
+    std::string errMsg = "Error: Empty sections names are only permitted with JSON format files.";
     throw std::runtime_error(errMsg);
   }
   m_section = tokens[0];

--- a/src/runtime_src/tools/xclbin/Section.cxx
+++ b/src/runtime_src/tools/xclbin/Section.cxx
@@ -28,6 +28,7 @@ namespace XUtil = XclBinUtilities;
 std::map<enum axlf_section_kind, std::string> Section::m_mapIdToName;
 std::map<std::string, enum axlf_section_kind> Section::m_mapNameToId;
 std::map<enum axlf_section_kind, Section::Section_factory> Section::m_mapIdToCtor;
+std::map<std::string, enum axlf_section_kind> Section::m_mapJSONNameToKind;
 
 Section::Section()
     : m_eKind(BITSTREAM)
@@ -53,6 +54,12 @@ Section::purgeBuffers()
 }
 
 void
+Section::setName(const std::string &_sSectionName)
+{
+   m_name = _sSectionName;
+}
+
+void
 Section::getKinds(std::vector< std::string > & kinds) {
   for (auto & item : m_mapNameToId) {
     kinds.push_back(item.first);
@@ -62,6 +69,7 @@ Section::getKinds(std::vector< std::string > & kinds) {
 void
 Section::registerSectionCtor(enum axlf_section_kind _eKind,
                              const std::string& _sKindStr,
+                             const std::string& _sHeaderJSONName,
                              Section_factory _Section_factory) {
   // Some error checking
   if (_sKindStr.empty()) {
@@ -82,12 +90,22 @@ Section::registerSectionCtor(enum axlf_section_kind _eKind,
     throw std::runtime_error(errMsg);
   }
 
+  if (!_sHeaderJSONName.empty()) {
+    if (m_mapJSONNameToKind.find(_sHeaderJSONName) != m_mapJSONNameToKind.end()) {
+      std::string errMsg = XUtil::format("Error: Attempting to register: (%d : %s). JSON mapping name '%s' already registered to eKind (%d).",
+                                         (unsigned int)_eKind, _sKindStr.c_str(),
+                                         _sHeaderJSONName.c_str(), (unsigned int)m_mapJSONNameToKind[_sHeaderJSONName]);
+      throw std::runtime_error(errMsg);
+    }
+    m_mapJSONNameToKind[_sHeaderJSONName] = _eKind;
+  }
 
+  
   // At this point we know we are good, lets initialize the arrays
   m_mapIdToName[_eKind] = _sKindStr;
   m_mapNameToId[_sKindStr] = _eKind;
   m_mapIdToCtor[_eKind] = _Section_factory;
-
+  
   //std::cout << "Kind(" << _eKind << "): " << _sKindStr << std::endl;
 }
 
@@ -117,6 +135,18 @@ Section::getFormatType(const std::string _sFormatType)
   
   return FT_UNKNOWN;
 }
+
+bool 
+Section::getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind) {
+  if (_sJSONStr.empty() ||
+     (m_mapJSONNameToKind.find(_sJSONStr) == m_mapJSONNameToKind.end()) ) {
+    return false;
+  }
+
+  _eKind = m_mapJSONNameToKind[_sJSONStr];
+  return true;
+}
+
 
 Section*
 Section::createSectionObjectOfKind(enum axlf_section_kind _eKind) {
@@ -207,6 +237,19 @@ Section::readXclBinBinary(std::fstream& _istream, const axlf_section_header& _se
   XUtil::TRACE(XUtil::format("  m_size: %ld", m_bufferSize));
 }
 
+
+void 
+Section::readJSONSectionImage(const boost::property_tree::ptree& _ptSection)
+{
+  std::ostringstream buffer;
+  marshalFromJSON(_ptSection, buffer);
+
+  // -- Read contents into memory buffer --
+  m_bufferSize = buffer.tellp();
+  m_pBuffer = new char[m_bufferSize];
+  memcpy(m_pBuffer, buffer.str().c_str(), m_bufferSize);
+}
+
 void
 Section::readXclBinBinary(std::fstream& _istream,
                           const boost::property_tree::ptree& _ptSection) {
@@ -229,13 +272,7 @@ Section::readXclBinBinary(std::fstream& _istream,
 
   if (ptPayload.is_initialized()) {
     XUtil::TRACE(XUtil::format("Reading in the section '%s' (%d) via metadata.", getSectionKindAsString().c_str(), (unsigned int)getSectionKind()));
-    std::ostringstream buffer;
-    marshalFromJSON(ptPayload.get(), buffer);
-
-    // -- Read contents into memory buffer --
-    m_bufferSize = buffer.tellp();
-    m_pBuffer = new char[m_bufferSize];
-    memcpy(m_pBuffer, buffer.str().c_str(), m_bufferSize);
+    readJSONSectionImage(ptPayload.get());
   } else {
     // We don't initialize the buffer via any metadata.  Just read in the section as is
     XUtil::TRACE(XUtil::format("Reading in the section '%s' (%d) as a image.", getSectionKindAsString().c_str(), (unsigned int)getSectionKind()));
@@ -260,7 +297,7 @@ Section::readXclBinBinary(std::fstream& _istream,
 
 
 void
-Section::addMirrorPayload(boost::property_tree::ptree& _pt) const {
+Section::getPayload(boost::property_tree::ptree& _pt) const {
   marshalToJSON(m_pBuffer, m_bufferSize, _pt);
 }
 
@@ -279,6 +316,63 @@ Section::marshalFromJSON(const boost::property_tree::ptree& _ptSection,
   std::string errMsg = XUtil::format("Error: Section '%s' (%d) missing payload parser.", getSectionKindAsString().c_str(), (unsigned int)getSectionKind());
   throw std::runtime_error(errMsg);
 }
+
+
+void 
+Section::readPayload(std::fstream& _istream, enum FormatType _eFormatType)
+{
+    switch (_eFormatType) {
+    case FT_RAW:
+      {
+        axlf_section_header sectionHeader = (axlf_section_header){ 0 };
+        sectionHeader.m_sectionKind = getSectionKind();
+        sectionHeader.m_sectionOffset = 0;
+        _istream.seekg(0, _istream.end);
+        sectionHeader.m_sectionSize = _istream.tellg();
+
+        readXclBinBinary(_istream, sectionHeader);
+        break;
+      }
+    case FT_JSON:
+      {
+        // Bring the file into memory
+        _istream.seekg(0, _istream.end);
+        unsigned int fileSize = _istream.tellg();
+
+        std::unique_ptr<unsigned char> memBuffer(new unsigned char[fileSize]);
+        _istream.clear();
+        _istream.seekg(0);
+        _istream.read((char*)memBuffer.get(), fileSize);
+
+        XUtil::TRACE_BUF("Buffer", (char*)memBuffer.get(), fileSize);
+
+        // Convert the JSON file to a boost property tree
+        std::stringstream ss;
+        ss.write((char*) memBuffer.get(), fileSize);
+
+        boost::property_tree::ptree pt;
+        boost::property_tree::read_json(ss, pt);
+
+        // O.K. - Lint checking is done and write it to our buffer
+        readJSONSectionImage(pt);
+        break;
+      }
+    case FT_HTML:
+      // Do nothing
+      break;
+    case FT_TXT:
+      // Do nothing
+      break;
+    case FT_UNKNOWN:
+      // Do nothing
+      break;
+    case FT_UNDEFINED:
+      // Do nothing
+      break;
+    }
+}
+
+
 
 
 void 
@@ -310,7 +404,8 @@ Section::readXclBinBinary(std::fstream& _istream, enum FormatType _eFormatType)
       XUtil::TRACE_BUF("Buffer", (char*)memBuffer.get(), fileSize);
 
       // Convert the JSON file to a boost property tree
-      std::stringstream ss((char*)memBuffer.get());
+      std::stringstream ss;
+      ss.write((char*) memBuffer.get(), fileSize);
 
       boost::property_tree::ptree pt;
       boost::property_tree::read_json(ss, pt);

--- a/src/runtime_src/tools/xclbin/Section.h
+++ b/src/runtime_src/tools/xclbin/Section.h
@@ -62,6 +62,7 @@ class Section {
   static void getKinds(std::vector< std::string > & kinds);
   static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind);
   static bool translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind);
+  static bool getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind);
   static enum FormatType getFormatType(const std::string _sFormatType);
 
  public:
@@ -75,13 +76,16 @@ class Section {
   virtual void readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader);
   virtual void readXclBinBinary(std::fstream& _istream, const boost::property_tree::ptree& _ptSection);
   void readXclBinBinary(std::fstream& _istream, enum FormatType _eFormatType);
+  void readJSONSectionImage(const boost::property_tree::ptree& _ptSection);
+  void readPayload(std::fstream& _istream, enum FormatType _eFormatType);
 
   virtual void initXclBinSectionHeader(axlf_section_header& _sectionHeader);
   virtual void writeXclBinSectionBuffer(std::fstream& _ostream) const;
   void dumpContents(std::fstream& _ostream, enum FormatType _eFormatType) const;
 
-  void addMirrorPayload(boost::property_tree::ptree& _pt) const;
+  void getPayload(boost::property_tree::ptree& _pt) const;
   void purgeBuffers();
+  void setName(const std::string &_sSectionName);
 
  protected:
   // Child class option to create an JSON metadata
@@ -93,7 +97,7 @@ class Section {
 
  protected:
   typedef std::function<Section*()> Section_factory;
-  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, Section_factory _Section_factory);
+  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, Section_factory _Section_factory);
 
  protected:
   enum axlf_section_kind m_eKind;
@@ -107,6 +111,7 @@ class Section {
   static std::map<enum axlf_section_kind, std::string> m_mapIdToName;
   static std::map<std::string, enum axlf_section_kind> m_mapNameToId;
   static std::map<enum axlf_section_kind, Section_factory> m_mapIdToCtor;
+  static std::map<std::string, enum axlf_section_kind> m_mapJSONNameToKind;
 
  private:
   // Purposefully private and undefined ctors...

--- a/src/runtime_src/tools/xclbin/SectionBMC.h
+++ b/src/runtime_src/tools/xclbin/SectionBMC.h
@@ -47,7 +47,7 @@ class SectionBMC : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BMC, "BMC", boost::factory<SectionBMC*>()); }
+    _init() { registerSectionCtor(BMC, "BMC", "", boost::factory<SectionBMC*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstream.h
@@ -47,7 +47,7 @@ class SectionBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", boost::factory<SectionBitstream*>()); }
+    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", boost::factory<SectionBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
@@ -51,7 +51,7 @@ class SectionBuildMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", boost::factory<SectionBuildMetadata*>()); }
+    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", boost::factory<SectionBuildMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClearBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionClearBitstream.h
@@ -47,7 +47,7 @@ class SectionClearBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", boost::factory<SectionClearBitstream*>()); }
+    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", boost::factory<SectionClearBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
@@ -55,7 +55,7 @@ class SectionClockFrequencyTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", boost::factory<SectionClockFrequencyTopology*>()); }
+    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", boost::factory<SectionClockFrequencyTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionConnectivity.h
+++ b/src/runtime_src/tools/xclbin/SectionConnectivity.h
@@ -53,7 +53,7 @@ class SectionConnectivity : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", boost::factory<SectionConnectivity*>()); }
+    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", boost::factory<SectionConnectivity*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugData.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugData.h
@@ -47,7 +47,7 @@ class SectionDebugData : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", boost::factory<SectionDebugData*>()); }
+    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", boost::factory<SectionDebugData*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
@@ -55,7 +55,7 @@ class SectionDebugIPLayout : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", boost::factory<SectionDebugIPLayout*>()); }
+    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", boost::factory<SectionDebugIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
+++ b/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
@@ -47,7 +47,7 @@ class SectionDesignCheckPoint : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", boost::factory<SectionDesignCheckPoint*>()); }
+    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", boost::factory<SectionDesignCheckPoint*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
@@ -47,7 +47,7 @@ class SectionEmbeddedMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", boost::factory<SectionEmbeddedMetadata*>()); }
+    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", boost::factory<SectionEmbeddedMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.h
@@ -55,7 +55,7 @@ class SectionIPLayout : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", boost::factory<SectionIPLayout*>()); }
+    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", boost::factory<SectionIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
@@ -47,7 +47,7 @@ class SectionKeyValueMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", boost::factory<SectionKeyValueMetadata*>()); }
+    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "", boost::factory<SectionKeyValueMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMCS.h
+++ b/src/runtime_src/tools/xclbin/SectionMCS.h
@@ -53,7 +53,7 @@ class SectionMCS : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MCS, "MCS", boost::factory<SectionMCS*>()); }
+    _init() { registerSectionCtor(MCS, "MCS", "", boost::factory<SectionMCS*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionManagementFW.h
+++ b/src/runtime_src/tools/xclbin/SectionManagementFW.h
@@ -47,7 +47,7 @@ class SectionManagementFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", boost::factory<SectionManagementFW*>()); }
+    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", boost::factory<SectionManagementFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMemTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionMemTopology.h
@@ -55,7 +55,7 @@ class SectionMemTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", boost::factory<SectionMemTopology*>()); }
+    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", boost::factory<SectionMemTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
+++ b/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
@@ -47,7 +47,7 @@ class SectionSchedulerFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", boost::factory<SectionSchedulerFW*>()); }
+    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", boost::factory<SectionSchedulerFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionUserMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionUserMetadata.h
@@ -47,7 +47,7 @@ class SectionUserMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", boost::factory<SectionUserMetadata*>()); }
+    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", boost::factory<SectionUserMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/XclBin.h
+++ b/src/runtime_src/tools/xclbin/XclBin.h
@@ -62,16 +62,19 @@ class XclBin {
   void printHeader();
 
   void readXclBinBinary(const std::string &_binaryFileName, bool _bMigrate = false);
-  void writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDInsertion = false);
+  void writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDInsertion, bool _bInsertValidationChecksum);
   void removeSection(const std::string & _sSectionToRemove);
   void addSection(ParameterSectionData &_PSD);
+  void addSections(ParameterSectionData &_PSD);
   void replaceSection(ParameterSectionData &_PSD);
   void dumpSection(ParameterSectionData &_PSD);
+  void setKeyValue(const std::string & _keyValue);
 
  public:
   Section *findSection(enum axlf_section_kind _eKind);
 
  private:
+  void updateHeaderFromSection(Section *_pSection);
   void readXclBinBinaryHeader(std::fstream& _istream);
   void readXclBinBinarySections(std::fstream& _istream);
 
@@ -86,6 +89,8 @@ class XclBin {
   void removeSection(const Section* _pSection);
 
   void updateUUID();
+
+  void initializeHeader(axlf &_xclBinHeader);
 
   // Should be in their own separate class
  private:

--- a/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
@@ -44,7 +44,7 @@ XclBinUtilities::TRACE(const std::string& _msg, bool _endl) {
   std::cout << "Trace: " << _msg;
 
   if (_endl)
-    std::cout << std::endl;
+    std::cout << std::endl << std::flush;
 }
 
 


### PR DESCRIPTION
+ Cleans up some messaging things
+ Adds the ability to parse the build RTD into the header
+ Fixed a bug where the stringstream was not being initialized correctly via an in-memory buffer.
+ Added support to update a header section when replacing a section.
+ Refactored code to easily extract JSON section data
+ Added hooks to enable extraction of JSON data when a new section is added.
+ Updated BUILD_METADATA JSON section name to match what is used by xocc
+ Updated addSection to add the payload instead of trying to "build" a section object - bug fix.
+ Created the Section::readPayload() method to read a section's payload
+ Removed add-validation command
+ Added hidden option to skip adding a validation image
+ Added ability to set the name of a section.
+ When an xclbin header is created, it is now initialized with the correct values (instead of all zeros).
+ When sections are added, the size of the section is now reported.
+ Refactor code to have only one constructure for a section.
+ Added DRCs to verify that only one section exists when adding sections via JSON
+ Add key-value pair support
+ Added support to add sections via a multiformatted JSON file.
+ Added multiplicty for the following options: --add-section, --remove-section, --dump-section, and --replace-section.
+ Removed add-validation command
+ Added hidden option to skip adding a validation image
+ Added ability to set the name of a section.
+ When an xclbin header is created, it is now initialized with the correct values (instead of all zeros).
+ When sections are added, the size of the section is now reported.
+ Refactor code to have only one constructure for a section.
+ Added DRCs to verify that only one section exists when adding sections via JSON
+ Add key-value pair support
+ Added support to add sections via a multiformatted JSON file.
+ Added multiplicty for the following options: --add-section, --remove-section, --dump-section, and --replace-section.