### PR TITLE
Validate execBO against compute units specified in context

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -1885,7 +1885,7 @@ validate(struct platform_device *pdev, struct client_ctx *client, const struct d
 	bitmap_to_u32array(ctx_cus,cumasks,client->cu_bitmap,MAX_CUS);
 	for (i=0; i<cumasks; ++i) {
 		uint32_t cmd_cus = ecmd->data[i];
-		if (cmd_cus && !(cmd_cus & ctx_cus[i])) {
+		if (cmd_cus && ((cmd_cus ^ ctx_cus[i]) & cmd_cus)) {
 			SCHED_DEBUGF("<- validate(1), CU mismatch in mask(%d) cmd(0x%x) ctx(0x%x)\n",
 				     i,cmd_cus,ctx_cus[i]);
 			return 1; /* error */

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -1853,10 +1853,46 @@ reset(struct platform_device *pdev)
 	return 0;
 }
 
+/**
+ * validate() - Check if requested cmd is valid in the current context
+ */
 static int
-validate(struct platform_device *pdev, struct client_ctx *client, const struct drm_xocl_bo *cmd)
+validate(struct platform_device *pdev, struct client_ctx *client, const struct drm_xocl_bo *bo)
 {
-	// TODO: Add code to check if requested cmd is valid in the current context
+	struct ert_packet *ecmd = (struct ert_packet*)bo->vmapping;
+	struct ert_start_kernel_cmd *scmd = (struct ert_start_kernel_cmd*)bo->vmapping;
+	u32 ctx_cus[4] = {0};
+	u32 cumasks = 0;
+	int i = 0;
+
+	SCHED_DEBUGF("-> validate opcode(%d)\n",ecmd->opcode);
+
+	/* cus for start kernel commands only */
+	if (ecmd->opcode!=ERT_START_CU) {
+		SCHED_DEBUG("<- validate(0), not a CU cmd\n");
+		return 0; /* ok */
+	}
+
+	/* no specific CUs selected, maybe ctx is not used by client */
+	if (bitmap_empty(client->cu_bitmap,MAX_CUS)) {
+		SCHED_DEBUG("<- validate(0), no CUs in ctx\n");
+		return 0; /* ok */
+	}
+
+
+	/* Check CUs in cmd BO against CUs in context */
+	cumasks = 1 + scmd->extra_cu_masks;
+	bitmap_to_u32array(ctx_cus,cumasks,client->cu_bitmap,MAX_CUS);
+	for (i=0; i<cumasks; ++i) {
+		uint32_t cmd_cus = ecmd->data[i];
+		if (cmd_cus && !(cmd_cus & ctx_cus[i])) {
+			SCHED_DEBUGF("<- validate(1), CU mismatch in mask(%d) cmd(0x%x) ctx(0x%x)\n",
+				     i,cmd_cus,ctx_cus[i]);
+			return 1; /* error */
+		}
+	}
+
+	SCHED_DEBUG("<- validate(0) cmd and ctx CUs match\n");
 	return 0;
 }
 

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -97,6 +97,7 @@ int xocl_execbuf_ioctl(struct drm_device *dev,
 	ret = xocl_exec_validate(xdev, client, xobj);
 	if (ret) {
 		userpf_err(xdev, "Exec buffer validation failed\n");
+		ret = -EINVAL;
 		goto out;
 	}
 

--- a/src/runtime_src/xrt/scheduler/kds.cpp
+++ b/src/runtime_src/xrt/scheduler/kds.cpp
@@ -35,6 +35,7 @@
 
 #include <memory>
 #include <cstring>
+#include <cerrno>
 #include <algorithm>
 #include <thread>
 #include <list>
@@ -107,7 +108,8 @@ launch(command_type cmd)
   // Submit the command
   auto device = cmd->get_device();
   auto exec_bo = cmd->get_exec_bo();
-  device->exec_buf(exec_bo);
+  if (device->exec_buf(exec_bo))
+    throw std::runtime_error(std::string("failed to launch exec buffer '") + std::strerror(errno) + "'");
 
   // thread safe access, since guaranteed to be inserted in init
   auto& submitted_cmds = s_device_cmds[device];


### PR DESCRIPTION
If context has no CUs, validation is successful, otherwise the CUs specified in context must be a superset of those specfied in the command.

Update XRT command launcher to check return code of exec_buf and throw an exception if validation failed.