### PR TITLE
Fixed various bugs and added additional functionality.  See below for more details.

### DIFF
--- a/src/CMake/config/version.h.in
+++ b/src/CMake/config/version.h.in
@@ -18,9 +18,10 @@ const char xrt_build_version_date[] = "@XRT_DATE@";
 const char xrt_modified_files[] = "@XRT_MODIFIED_FILES@";
 
 # ifdef __cplusplus
-namespace xrt { 
 #include <iostream>
 #include <string>
+
+namespace xrt { 
 
 class version {
  public:
@@ -36,22 +37,21 @@ class version {
      std::string modifiedFiles(xrt_modified_files);
      if ( !modifiedFiles.empty() ) {
         const std::string& delimiters = ",";      // Our delimiter
-        std::string::size_type pos = 0;
         std::string::size_type lastPos = 0;
         int runningIndex = 1;
         while(lastPos < modifiedFiles.length() + 1) {
           if (runningIndex == 1) {
              output << "  Current Modified Files: ";
-  	} else {
+          } else {
              output << "                          ";
           }
-  	output << runningIndex++ << ") ";
+          output << runningIndex++ << ") ";
   
-          pos = modifiedFiles.find_first_of(delimiters, lastPos);
+          std::string::size_type pos = modifiedFiles.find_first_of(delimiters, lastPos);
   
           if (pos == std::string::npos) {
             pos = modifiedFiles.length();
-  	}
+          }
   
           output << modifiedFiles.substr(lastPos, pos-lastPos) << std::endl;
   

--- a/src/CMake/config/version.h.in
+++ b/src/CMake/config/version.h.in
@@ -18,47 +18,49 @@ const char xrt_build_version_date[] = "@XRT_DATE@";
 const char xrt_modified_files[] = "@XRT_MODIFIED_FILES@";
 
 # ifdef __cplusplus
-namespace xrt { namespace version {
+namespace xrt { 
 #include <iostream>
 #include <string>
 
-void print(std::ostream & output)
-{
-   output << "       XRT Build Version: " << xrt_build_version << std::endl;
-   output << "  Build Version Extended: " << xrt_build_version_branch_extended << std::endl;
-   output << "    Build Version Branch: " << xrt_build_version_branch << std::endl;
-   output << "      Build Version Hash: " << xrt_build_version_hash << std::endl;
-   output << " Build Version Hash Date: " << xrt_build_version_hash_date << std::endl;
-   output << "      Build Version Date: " << xrt_build_version_date_rfc << std::endl;
-
-   std::string modifiedFiles(xrt_modified_files);
-   if ( !modifiedFiles.empty() ) {
-      const std::string& delimiters = ",";      // Our delimiter
-      std::string::size_type pos = 0;
-      std::string::size_type lastPos = 0;
-      int runningIndex = 1;
-      while(lastPos < modifiedFiles.length() + 1) {
-        if (runningIndex == 1) {
-           output << "  Current Modified Files: ";
-	} else {
-           output << "                          ";
+class version {
+ public:
+  static void print(std::ostream & output)
+  {
+     output << "       XRT Build Version: " << xrt_build_version << std::endl;
+     output << "  Build Version Extended: " << xrt_build_version_branch_extended << std::endl;
+     output << "    Build Version Branch: " << xrt_build_version_branch << std::endl;
+     output << "      Build Version Hash: " << xrt_build_version_hash << std::endl;
+     output << " Build Version Hash Date: " << xrt_build_version_hash_date << std::endl;
+     output << "      Build Version Date: " << xrt_build_version_date_rfc << std::endl;
+  
+     std::string modifiedFiles(xrt_modified_files);
+     if ( !modifiedFiles.empty() ) {
+        const std::string& delimiters = ",";      // Our delimiter
+        std::string::size_type pos = 0;
+        std::string::size_type lastPos = 0;
+        int runningIndex = 1;
+        while(lastPos < modifiedFiles.length() + 1) {
+          if (runningIndex == 1) {
+             output << "  Current Modified Files: ";
+  	} else {
+             output << "                          ";
+          }
+  	output << runningIndex++ << ") ";
+  
+          pos = modifiedFiles.find_first_of(delimiters, lastPos);
+  
+          if (pos == std::string::npos) {
+            pos = modifiedFiles.length();
+  	}
+  
+          output << modifiedFiles.substr(lastPos, pos-lastPos) << std::endl;
+  
+          lastPos = pos + 1;
         }
-	output << runningIndex++ << ") ";
-
-        pos = modifiedFiles.find_first_of(delimiters, lastPos);
-
-        if (pos == std::string::npos) {
-          pos = modifiedFiles.length();
-	}
-
-        output << modifiedFiles.substr(lastPos, pos-lastPos) << std::endl;
-
-        lastPos = pos + 1;
-      }
-   }
+     }
+  }
+};
 }
-
-}}
 #endif
 
 #endif 

--- a/src/runtime_src/tools/xclbin/FormattedOutput.h
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 #include <xclbin.h>
+#include <boost/property_tree/ptree.hpp>
+
 
 // #includes here - please keep these to a bare minimum!
 
@@ -32,6 +34,7 @@ class Section;
 
 namespace FormattedOutput {
   void printHeader(std::ostream &_ostream, const axlf &_xclBinHeader, const std::vector<Section*> _sections);
+  void getKernelDDRMemory(const std::string _sKernelInstanceName, const std::vector<Section*> _sections, boost::property_tree::ptree &_ptKernelInstance, boost::property_tree::ptree &_ptMemoryConnections);
 
   std::string getTimeStampAsString(const axlf &_xclBinHeader);
   std::string getFeatureRomTimeStampAsString(const axlf &_xclBinHeader);

--- a/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
@@ -26,6 +26,7 @@ ParameterSectionData::ParameterSectionData(const std::string &_formattedString)
   , m_file("")
   , m_section("")
   , m_eKind(BITSTREAM)
+  , m_originalString(_formattedString)
 {
   transformFormattedString(_formattedString);
 }
@@ -121,4 +122,10 @@ const std::string &
 ParameterSectionData::getFormatTypeAsStr()
 {
   return m_formatTypeStr;
+}
+
+const std::string &
+ParameterSectionData::getOriginalFormattedString()
+{
+  return m_originalString;
 }

--- a/src/runtime_src/tools/xclbin/ParameterSectionData.h
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.h
@@ -45,6 +45,7 @@ class ParameterSectionData {
   const std::string &getFormatTypeAsStr();
   const std::string &getSectionName();
   enum axlf_section_kind &getSectionKind();
+  const std::string &getOriginalFormattedString();
 
  protected:
    enum Section::FormatType m_formatType;
@@ -52,6 +53,7 @@ class ParameterSectionData {
    std::string m_file;
    std::string m_section;
    enum axlf_section_kind m_eKind;
+   std::string m_originalString;
 
  protected:
    void transformFormattedString(const std::string _formattedString);

--- a/src/runtime_src/tools/xclbin/Section.cxx
+++ b/src/runtime_src/tools/xclbin/Section.cxx
@@ -246,6 +246,11 @@ Section::readJSONSectionImage(const boost::property_tree::ptree& _ptSection)
 
   // -- Read contents into memory buffer --
   m_bufferSize = buffer.tellp();
+
+  if (m_bufferSize == 0) {
+    std::string errMsg = XUtil::format("ERROR: Section '%s' content is empty.  No data in the given JSON file.", getSectionKindAsString().c_str());
+    throw std::runtime_error(errMsg);
+  }
   m_pBuffer = new char[m_bufferSize];
   memcpy(m_pBuffer, buffer.str().c_str(), m_bufferSize);
 }
@@ -463,7 +468,6 @@ Section::dumpContents(std::fstream& _ostream, enum FormatType _eFormatType) cons
     // Do nothing;
     break;
   case FT_UNDEFINED:
-    // Do nothing;
     break;
   }
 }

--- a/src/runtime_src/tools/xclbin/SectionBuildMetadata.cxx
+++ b/src/runtime_src/tools/xclbin/SectionBuildMetadata.cxx
@@ -21,11 +21,7 @@
 
 #include "XclBinUtilities.h"
 
-//#include "version.h" // Globally included from main
-// This should be an alternative, but then these variables are "undefined"
-//extern const char xrt_build_version[];
-//extern const char xrt_build_version_hash[];
-//extern const char xrt_build_version_date_rfc[];
+#include "version.h" // Globally included from main
 
 namespace XUtil = XclBinUtilities;
 
@@ -57,7 +53,10 @@ SectionBuildMetadata::marshalToJSON(char* _pDataSection,
     // TODO: Catch the exception (if any) from this call and produce a nice message
     XUtil::TRACE_BUF("BUILD_METADATA", (const char *) memBuffer.get(), _sectionSize+1);
     try {
-      boost::property_tree::read_json(ss, _ptree);
+      boost::property_tree::ptree pt;
+      boost::property_tree::read_json(ss, pt);
+      boost::property_tree::ptree &buildMetaData = pt.get_child("build_metadata");
+      _ptree.add_child("build_metadata", buildMetaData);
     } catch (const std::exception & e) {
       std::string msg("ERROR: Bad JSON format detected while marshaling build metadata (");
       msg += e.what();
@@ -73,9 +72,9 @@ SectionBuildMetadata::marshalFromJSON(const boost::property_tree::ptree& _ptSect
    XUtil::TRACE("BUILD_METADATA");
    boost::property_tree::ptree ptWritable = _ptSection;
    ptWritable.put("build_metadata.xclbin.packaged_by.name", "xclbinutil");
-   ptWritable.put("build_metadata.xclbin.packaged_by.version", "2.1.0");//xrt_build_version);
-   ptWritable.put("build_metadata.xclbin.packaged_by.hash", "6f3b6b0dc6cf73effa3a13d29706077363f81714");//xrt_build_version_hash);
-   ptWritable.put("build_metadata.xclbin.packaged_by.time_stamp", "Tue, 09 Oct 2018 16:25:00 -0600");//xrt_build_version_date_rfc);
+   ptWritable.put("build_metadata.xclbin.packaged_by.version", xrt_build_version); 
+   ptWritable.put("build_metadata.xclbin.packaged_by.hash", xrt_build_version_hash);
+   ptWritable.put("build_metadata.xclbin.packaged_by.time_stamp", xrt_build_version_date_rfc);
    boost::property_tree::write_json(_buf, ptWritable, false );
 }
 

--- a/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
@@ -38,6 +38,10 @@ class SectionKeyValueMetadata : public Section {
   SectionKeyValueMetadata();
   virtual ~SectionKeyValueMetadata();
 
+ protected:
+  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
+  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
+
  private:
   // Purposefully private and undefined ctors...
   SectionKeyValueMetadata(const SectionKeyValueMetadata& obj);
@@ -47,7 +51,7 @@ class SectionKeyValueMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "", boost::factory<SectionKeyValueMetadata*>()); }
+    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", boost::factory<SectionKeyValueMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/XclBin.h
+++ b/src/runtime_src/tools/xclbin/XclBin.h
@@ -50,6 +50,7 @@ class XclBin {
   void addSections(ParameterSectionData &_PSD);
   void replaceSection(ParameterSectionData &_PSD);
   void dumpSection(ParameterSectionData &_PSD);
+  void dumpSections(ParameterSectionData &_PSD);
   void setKeyValue(const std::string & _keyValue);
 
  public:

--- a/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
@@ -41,7 +41,7 @@ XclBinUtilities::TRACE(const std::string& _msg, bool _endl) {
   if (!m_bVerbose)
     return;
 
-  std::cout << "Trace: " << _msg;
+  std::cout << "Trace: " << _msg.c_str();
 
   if (_endl)
     std::cout << std::endl << std::flush;

--- a/src/runtime_src/tools/xclbin/xclbinutil.cxx
+++ b/src/runtime_src/tools/xclbin/xclbinutil.cxx
@@ -29,9 +29,7 @@ int main( int argc, char** argv )
     if ( msg.empty() )
       std::cerr << "ERROR: Caught an internal exception no message information is available.\n";
     else {
-        std::cerr << "Unhandled Exception caught in main(): " << std::endl
-            << e.what() << std::endl
-            << "exiting" << std::endl;
+      std::cerr << e.what() << std::endl;
     }
   } catch ( ... ) {
     std::cerr << "ERROR: Caught an internal exception no exception information is available.\n";


### PR DESCRIPTION
Work Done
    + Added code to parse the xocc command line options from a signel string.
    + Replace DSA print entries with shell
    + Fixed a bug where null characters were being added to the end of the mirror json section
    + Fixed print issues were "NULL" characters were being printed.
    + Added some additional error checking DRCs around incorrectly formed --dump-section <section>:<format>:<file> values.
    + Fixed bug where the key-value update was not changing the value string.
    + Added key-value support
    + Added some additional DRC checks for empty data structures
    + Added support to --dump-section to dump all JSON supported sections to a common file.
    + Fixed bug in SectionBuildMetadata::marshalToJSON where the JSON output was stomping on the parent ptree.
    + Refactored "version" namespace to be a class to prevent function name conflicts with the 'c' print() function.
    + Updated header information with the above changes.
    + Cleaned up event catch wrappers to be more user friendly.
    + Added support to report the base addresses of kernel instances and the memory it is connected to.
    + Move use-case examples into the help section.
    + Added support to report kernel / memory bindings.
    + Added last hash commit timestamp support
    + Added to detect file input / output conflicts
    + Added support for force (currently on always until xocc is updated)
    + Refactored 'pretty print" code to a common file.
    + Fix replace section bug
    + Removed obsolete test.cxx testing harness
    + Update TestMetaData suite to pass once again
    + Moved Section header pretty print to the Section class
    + Updated various method parameters to be const