### PR TITLE
Fix scheduler for 2018.3 boards

### DIFF
--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -226,10 +226,12 @@ enum ert_cmd_opcode {
  *
  * @ERT_DEFAULT:        default command type
  * @ERT_KDS_LOCAL:      command processed by KDS locally
+ * @ERT_CTRL:           control command uses reserved command queue slot
  */
 enum ert_cmd_type {
   ERT_DEFAULT = 0,
   ERT_KDS_LOCAL = 1,
+  ERT_CTRL = 2,
 };
 
 /**

--- a/src/runtime_src/driver/xclng/drm/xocl/lib/libxdma.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/lib/libxdma.c
@@ -3503,6 +3503,7 @@ static int pci_check_extended_tag(struct xdma_dev *xdev, struct pci_dev *pdev)
 	v =  read_register(reg);
 	v = (v & 0xFF) | (((u32)32) << 8);
 	write_register(v, reg, XDMA_OFS_CONFIG + 0x4C);
+	return 0;
 }
 
 void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
@@ -4427,5 +4428,3 @@ int xdma_cyclic_transfer_teardown(struct xdma_engine *engine)
 
 	return 0;
 }
-
-

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/feature_rom.c
@@ -321,7 +321,8 @@ static int feature_rom_probe(struct platform_device *pdev)
 		rom->dsa_version = 51;
 	else if (strstr(rom->header.VBNVName,"5_2")
 		 || strstr(rom->header.VBNVName,"u200_xdma_201820_2")
-		 || strstr(rom->header.VBNVName,"u250_xdma_201820_1"))
+		 || strstr(rom->header.VBNVName,"u250_xdma_201820_1")
+		 || strstr(rom->header.VBNVName,"201830"))
 		rom->dsa_version = 52;
 	else if (strstr(rom->header.VBNVName,"5_3"))
 		rom->dsa_version = 53;


### PR DESCRIPTION
Recognize 201830 DSAs in feature_rom.c such that ERT will be enabled properly.
Ensure that KDS submits control commands to slot 0 always.
Add missing return value in libxdma.c.