### PR TITLE
Refine return value in pci_check_extended_tag

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/lib/libxdma.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/lib/libxdma.c
@@ -3470,8 +3470,10 @@ static void pci_enable_capability(struct pci_dev *pdev, int cap)
 static int pci_check_extended_tag(struct xdma_dev *xdev, struct pci_dev *pdev)
 {
 	u16 cap;
+#if 0
 	u32 v;
 	void *__iomem reg;
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,0)
 	pcie_capability_read_word(pdev, PCI_EXP_DEVCTL, &cap);
@@ -3493,6 +3495,15 @@ static int pci_check_extended_tag(struct xdma_dev *xdev, struct pci_dev *pdev)
 	/* extended tag not enabled */
 	pr_info("0x%p EXT_TAG disabled.\n", pdev);
 
+#if 0
+	/* Confirmed with Karen. This code is needed when ExtTag is disabled.
+	 * Reason to disable below code:
+	 * We observed that the ExtTag was cleared on some system. The SSD-
+	 * FPGA board will not work on that system (DMA failed). The solution
+	 * is that XDMA driver should enable ExtTag in that case.
+	 *
+	 * If ExtTag need to be disabled for your system, please enable this.
+	 */
 	if (xdev->config_bar_idx < 0) {
 		pr_info("pdev 0x%p, xdev 0x%p, config bar UNKNOWN.\n",
 				pdev, xdev);
@@ -3504,6 +3515,10 @@ static int pci_check_extended_tag(struct xdma_dev *xdev, struct pci_dev *pdev)
 	v = (v & 0xFF) | (((u32)32) << 8);
 	write_register(v, reg, XDMA_OFS_CONFIG + 0x4C);
 	return 0;
+#else
+	/* Return 1 will go to enable ExtTag */
+	return 1;
+#endif
 }
 
 void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,


### PR DESCRIPTION
After discussion with Karen, configure register "XDMA_OFS_CONFIG + 0x4C" is required for XDMA driver  when ExtTag is disabled.
The latest XDMA driver always enable ExtTag. For XRT driver, we disable this code by macro in case we need to re-enable it someday.