### PR TITLE
disable ERT for u200

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/devices.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/devices.h
@@ -628,6 +628,15 @@ enum {
 		.intr_bar = 1,						\
 	}
 
+#define	XOCL_BOARD_USER_XDMA_ERT_OFF					\
+	(struct xocl_board_private){					\
+		.flags		= XOCL_DSAFLAG_MB_SCHE_OFF,		\
+		.subdev_info	= USER_RES_XDMA,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_XDMA),		\
+		.user_bar = 0,						\
+		.intr_bar = 1,						\
+	}
+
 #define XOCL_BOARD_USER_AWS                         \
    (struct xocl_board_private){                    \
        .flags      = 0,                    \
@@ -923,7 +932,7 @@ enum {
 	{ XOCL_PCI_DEVID(0x10EE, 0x7890, 0x4351, USER_XDMA) },		\
 	{ XOCL_PCI_DEVID(0x10EE, 0x7890, 0x4352, USER_DSA52) },		\
 	{ XOCL_PCI_DEVID(0x10EE, 0x7990, 0x4352, USER_DSA52) },		\
-	{ XOCL_PCI_DEVID(0x10EE, 0x5001, PCI_ANY_ID, USER_XDMA) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5001, PCI_ANY_ID, USER_XDMA_ERT_OFF) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5005, PCI_ANY_ID, USER_DSA52) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0065, PCI_ANY_ID, USER_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x1D0F, 0x1042, PCI_ANY_ID, USER_AWS) },	\


### PR DESCRIPTION
root@XSJBRD1:~# lspci -vd 10ee:
b3:00.0 Processing accelerators: Xilinx Corporation Device 5000
	Subsystem: Xilinx Corporation Device 000e
	Flags: bus master, fast devsel, latency 0
	Memory at f8000000 (32-bit, non-prefetchable) [size=32M]
	Memory at fa000000 (32-bit, non-prefetchable) [size=128K]
	Capabilities: [40] Power Management version 3
	Capabilities: [60] MSI-X: Enable- Count=33 Masked-
	Capabilities: [70] Express Endpoint, MSI 00
	Capabilities: [100] Advanced Error Reporting
	Capabilities: [1c0] #19
	Capabilities: [400] Access Control Services
	Kernel driver in use: xclmgmt
	Kernel modules: xclmgmt

b3:00.1 Processing accelerators: Xilinx Corporation Device 5001
	Subsystem: Xilinx Corporation Device 000e
	Flags: bus master, fast devsel, latency 0, IRQ 125
	Memory at f6000000 (32-bit, non-prefetchable) [size=32M]
	Memory at fa020000 (32-bit, non-prefetchable) [size=64K]
	Capabilities: [40] Power Management version 3
	Capabilities: [60] MSI-X: Enable+ Count=33 Masked-
	Capabilities: [70] Express Endpoint, MSI 00
	Capabilities: [100] Advanced Error Reporting
	Capabilities: [400] Access Control Services
	Kernel driver in use: xocl_xdma
	Kernel modules: xocl

root@XSJBRD1:~/temp/opt/xilinx/dsa/xilinx_u200_xdma_201830_1/test# ./validate.exe verify.xclbin 

Platform information
Platform name:       Xilinx
Platform version:    OpenCL 1.0
Platform profile:    EMBEDDED_PROFILE
Platform extensions: cl_khr_icd

Found 1 compute devices!:
loading verify.xclbin

RESULT:
Hello World
root@XSJBRD1:~/temp/opt/xilinx/dsa/xilinx_u200_xdma_201830_1/test# 
root@XSJBRD1:~/temp/opt/xilinx/dsa/xilinx_u200_xdma_201830_1/test# 
root@XSJBRD1:~/temp/opt/xilinx/dsa/xilinx_u200_xdma_201830_1/test# ls
bandwidth.xclbin  kernel_bw.exe  validate.exe  verify.xclbin
root@XSJBRD1:~/temp/opt/xilinx/dsa/xilinx_u200_xdma_201830_1/test# ./kernel_bw.exe bandwidth.xclbin 

Found 1 compute devices!:
loading bandwidth.xclbin
LOOP PIPELINE 16 beats
Test : 0, Throughput: 6008.934570 MB/s
LOOP PIPELINE 64 beats
Test : 1, Throughput: 17248.339844 MB/s
LOOP PIPELINE 256 beats
Test : 2, Throughput: 32177.826172 MB/s
LOOP PIPELINE 1024 beats
Test : 3, Throughput: 43222.679688 MB/s
TTTT : 6008.934570
Maximum throughput: 43222.679688 MB/s
PASSED
root@XSJBRD1:~/temp/opt/xilinx/dsa/xilinx_u200_xdma_201830_1/test# 