### PR TITLE
Added XRT versioning support to both the xclbin archives and xclbinutil.

### DIFF
--- a/src/runtime_src/driver/include/xclbin.h
+++ b/src/runtime_src/driver/include/xclbin.h
@@ -189,7 +189,9 @@ extern "C" {
         uint64_t m_length;                  /* Total size of the xclbin file */
         uint64_t m_timeStamp;               /* Number of seconds since epoch when xclbin was created */
         uint64_t m_featureRomTimeStamp;     /* TimeSinceEpoch of the featureRom */
-        uint32_t m_version;                 /* Tool version used to create xclbin */
+        uint16_t m_versionPatch;            /* Patch Version */
+        uint8_t m_versionMajor;             /* Major Version - Version: 2.1.0*/
+        uint8_t m_versionMinor;             /* Minor Version */
         uint32_t m_mode;                    /* XCLBIN_MODE */
 	union {
 	    struct {
@@ -363,18 +365,6 @@ extern "C" {
         CST_UNKNOWN = 0,
         CST_SDBM = 1,
         CST_LAST 
-    };
-
-    struct checksum
-    {
-       char m_magic[8];                   /* XCHKSUM */
-       uint8_t m_type;                    /* Checksum Type*/
-       uint8_t padding[7];
-
-       union {
-          uint64_t m_64bit;             
-          unsigned char m_maxKeySize[256];  /* Do not change */
-       };
     };
 
     /**** END : Xilinx internal section *****/

--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -43,7 +43,7 @@ FormattedOutput::getFeatureRomTimeStampAsString(const axlf &_xclBinHeader) {
 
 std::string
 FormattedOutput::getVersionAsString(const axlf &_xclBinHeader) {
-  return XUtil::format("%d", _xclBinHeader.m_header.m_version);
+  return XUtil::format("%d.%d.%d", _xclBinHeader.m_header.m_versionMajor, _xclBinHeader.m_header.m_versionMinor, _xclBinHeader.m_header.m_versionPatch);
 }
 
 // String Getters
@@ -220,7 +220,7 @@ void
 reportBuildVersion( std::ostream & _ostream,
                     bool _bVerbose)
 {
-  _ostream << XUtil::format("%17s: %d.%d.%d", "XRT Build Version", 2, 1, 0).c_str() << std::endl;
+  _ostream << XUtil::format("%17s: %s", "XRT Build Version", xrt_build_version).c_str() << std::endl;
   _ostream << XUtil::format("%17s: %s", "Build Date", xrt_build_version_date).c_str() << std::endl;
   _ostream << XUtil::format("%17s: %s", "Hash ID", xrt_build_version_hash).c_str() << std::endl;
 }
@@ -268,7 +268,7 @@ reportXclbinInfo( std::ostream & _ostream,
   }
 
   // Version:
-  _ostream << XUtil::format("   %-23s %d.%d.%d", "Version:", 2, 1, 0).c_str() << std::endl;
+  _ostream << XUtil::format("   %-23s %d.%d.%d", "Version:", _xclBinHeader.m_header.m_versionMajor, _xclBinHeader.m_header.m_versionMinor, _xclBinHeader.m_header.m_versionPatch).c_str() << std::endl;
 
   // Kernels
   {

--- a/src/runtime_src/tools/xclbin/xclbincat1.cxx
+++ b/src/runtime_src/tools/xclbin/xclbincat1.cxx
@@ -30,6 +30,8 @@
 #include <vector>
  
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/uuid/uuid.hpp>          // for uuid
 #include <boost/uuid/uuid_generators.hpp> // generators
 #include <boost/uuid/uuid_io.hpp>       // for to_string
@@ -562,7 +564,9 @@ namespace xclbincat1 {
     memset( data.getHead().m_keyBlock, 0xFF, sizeof(data.getHead().m_keyBlock) );
     data.getHead().m_uniqueId = time( nullptr );
     data.getHead().m_header.m_timeStamp = time( nullptr );
-    data.getHead().m_header.m_version = 2017;
+    data.getHead().m_header.m_versionMajor = 0;
+    data.getHead().m_header.m_versionMinor = 0;
+    data.getHead().m_header.m_versionPatch = 2017;
     populateXclbinUUID(data);
   }
 
@@ -685,7 +689,16 @@ namespace xclbincat1 {
       } else if ( strcmp( key.c_str(), "featureRomTimestamp" ) == 0 ) {
         populateFeatureRomTimestamp( value.c_str(), _data );
       } else if ( strcmp( key.c_str(), "version" ) == 0 ) {
-        ss >> std::hex >> _data.getHead().m_header.m_version;
+        std::vector<std::string> tokens;
+        boost::split(tokens, value, boost::is_any_of("."));
+        if ( tokens.size() != 3 ) {
+          std::ostringstream errMsgBuf;
+          errMsgBuf << "ERROR: The version value (" << value << "') is not in the form <major>.<minor>.<patch>.  For example: 2.1.0\n";
+          throw std::runtime_error(errMsgBuf.str());
+        }
+        _data.getHead().m_header.m_versionMajor = (uint8_t) std::stoi(tokens[0]);
+        _data.getHead().m_header.m_versionMinor = (uint8_t) std::stoi(tokens[1]);
+        _data.getHead().m_header.m_versionPatch = (uint16_t) std::stoi(tokens[2]);
       } else if ( strcmp( key.c_str(), "mode" ) == 0 ) {
         if ( ! populateMode( value.c_str(), _data ) ) {
           std::ostringstream errMsgBuf;

--- a/src/runtime_src/tools/xclbin/xclbindata.cxx
+++ b/src/runtime_src/tools/xclbin/xclbindata.cxx
@@ -466,7 +466,9 @@ bool
 XclBinData::reportHeader() 
 {
   std::cout << "xclbin1 Size:           " << m_xclBinHead.m_header.m_length << "\n";
-  std::cout << "Version:                " << m_xclBinHead.m_header.m_version << "\n";
+  std::cout << "Version:                " << m_xclBinHead.m_header.m_versionMajor 
+                                            << "." << m_xclBinHead.m_header.m_versionMinor 
+                                            << "." << m_xclBinHead.m_header.m_versionPatch << "\n";
   std::cout << "Timestamp:              " << m_xclBinHead.m_header.m_timeStamp << "\n";
   std::cout << "Feature ROM Timestamp:  " << m_xclBinHead.m_header.m_featureRomTimeStamp << "\n";
   std::cout << "Mode:                   " << (int)m_xclBinHead.m_header.m_mode << "\n";


### PR DESCRIPTION
Work Done

1. Replaced axlf_header m_version (uint32_t) with m_versionPatch (uint16_t), m_versionMajor (uint8_t), and m_versionMinor (uint8_t).  Note: The order in the structure is import so that the old version of 2017, will be used for the patch version.
2. Updated xclbinutil, xclbincat, and xclbinsplit to support this new versioning schema.
3. Removed the CRC checksum dead code.
