### PR TITLE
Cross compile libxilinxopencl.so and libxclzynqdrv.so

### DIFF
--- a/src/runtime_src/Makefile
+++ b/src/runtime_src/Makefile
@@ -1,0 +1,88 @@
+# Build xilinxopencl.so for ARM
+
+CROSS_COMPILE := aarch64-linux-gnu-
+CXX := $(CROSS_COMPILE)g++
+
+ifeq ($(CROSS_COMPILE), aarch64-linux-gnu-)
+	ARCH := aarch64
+else
+	ARCH := arm
+endif
+
+CXXFLAGS := -Wreturn-type -std=gnu++11 -fPIC -Dxilinxopencl_EXPORTS
+LDFLAGS := -L$(BOOST_LIB_DIR)
+LDFLAGS += -shared -lboost_filesystem_static -lboost_system_static
+LDFLAGS += -Wl,-Bsymbolic -ldl -lpthread -lcrypt -lrt
+
+RUNTIME_SRC_DIR  = $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+BUILD_DIR        = $(realpath ${RUNTIME_SRC_DIR}/../../build)
+OUT_DIR         := ${BUILD_DIR}/Debug/arm_libs/$(ARCH)/xilinxopencl
+
+ifeq ($(debug), 1)
+	CXXFLAGS += -g
+else
+	CXXFLAGS += -O3
+endif
+
+XOCL_DIR   = ${RUNTIME_SRC_DIR}/xocl
+XRT_DIR    = ${RUNTIME_SRC_DIR}/xrt
+IMPL_DIR   = ${RUNTIME_SRC_DIR}/impl
+XCLBIN_DIR = ${RUNTIME_SRC_DIR}/xclbin
+
+XOCL_API_SRC = $(wildcard $(XOCL_DIR)/api/*.cpp \
+			  $(XOCL_DIR)/api/detail/*.cpp \
+			  $(XOCL_DIR)/api/icd/*.cpp \
+			  $(XOCL_DIR)/api/khronos/*.cpp \
+			  $(XOCL_DIR)/api/xlnx/*.cpp \
+			  $(XOCL_DIR)/api/printf/*.cpp \
+			  $(XOCL_DIR)/api/plugin/xdp/*.cpp \
+		)
+XOCL_API_SRC_SORTED = $(sort $(XOCL_API_SRC))
+XOCL_CORE_SRC = $(wildcard $(XOCL_DIR)/core/*.cpp)
+XOCL_XCLBIN_SRC = $(wildcard $(XOCL_DIR)/xclbin/*.cpp)
+XOCL_SRC = $(XOCL_API_SRC_SORTED) $(XOCL_CORE_SRC) $(XOCL_XCLBIN_SRC)
+XOCL_OBJS = $(patsubst $(RUNTIME_SRC_DIR)/%.cpp, $(OUT_DIR)/%.o, $(XOCL_SRC))
+
+XRT_DEVICE_SRC = $(wildcard $(XRT_DIR)/device/*.cpp)
+XRT_SCHED_SRC  = $(wildcard $(XRT_DIR)/scheduler/*.cpp)
+XRT_UTIL_SRC   = $(wildcard $(XRT_DIR)/util/*.cpp)
+XRT_SRC = $(XRT_DEVICE_SRC) $(XRT_SCHED_SRC) $(XRT_UTIL_SRC)
+XRT_OBJS = $(patsubst $(RUNTIME_SRC_DIR)/%.cpp, $(OUT_DIR)/%.o, $(XRT_SRC))
+
+XCLBIN_SRC = $(wildcard $(XCLBIN_DIR)/*.cpp)
+XCLBIN_OBJS = $(patsubst $(RUNTIME_SRC_DIR)/%.cpp, $(OUT_DIR)/%.o, $(XCLBIN_SRC))
+
+IMPL_SRC = $(wildcard $(IMPL_DIR)/*.cpp)
+IMPL_OBJS = $(patsubst $(RUNTIME_SRC_DIR)/%.cpp, $(OUT_DIR)/%.o, $(IMPL_SRC))
+
+ALL_OBJS = $(XOCL_OBJS) $(XRT_OBJS) $(XCLBIN_OBJS) $(IMPL_OBJS)
+
+CXXFLAGS += -I$(RUNTIME_SRC_DIR) -I$(RUNTIME_SRC_DIR)/../include/1_2 -I$(CL_INC_DIR) -I$(RUNTIME_SRC_DIR)/driver/include -I$(XOCL_DIR)/api -I$(BOOST_INC_DIR)
+
+$(OUT_DIR)/%.o: $(RUNTIME_SRC_DIR)/%.cpp
+	@mkdir -p $(@D)
+	$(CXX) -c $(CXXFLAGS) -o $@ $^
+
+all: check-boost-inc check-cl-inc check-boost-lib $(OUT_DIR)/libxilinxopencl.so 
+
+$(OUT_DIR)/libxilinxopencl.so: $(ALL_OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) 
+
+clean:
+	rm -rf $(OUT_DIR)
+
+check-boost-inc:
+ifndef BOOST_INC_DIR
+	$(error BOOST_INC_DIR is undefined. This should point to BOOST header)
+endif
+
+check-boost-lib:
+ifndef BOOST_LIB_DIR
+	$(error BOOST_LIB_DIR is undefined. This should point to BOOST library)
+endif
+
+check-cl-inc:
+ifndef CL_INC_DIR
+	$(error CL_INC_DIR is undefined. This should point to where has CL/ and ocl_icd.h)
+endif
+

--- a/src/runtime_src/driver/zynq/user/Makefile
+++ b/src/runtime_src/driver/zynq/user/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS :=  -Werror -std=c++11
 LIBNAME := libxclzynqdrv.so
 XCLHAL_VER =-DXCLHAL_MAJOR_VER=1 -DXCLHAL_MINOR_VER=1
 
-SHIM_INC := -I../../../ -I$(XILINX_SDX)/runtime/driver/include
+SHIM_INC := -I../../../
 CXXFLAGS += $(CXXFLAGS) $(XCLHAL_VER) $(SHIM_INC) -fpic -fvisibility=hidden -lrt
 
 ifeq ($(debug),1)

--- a/src/runtime_src/tools/scripts/make_arm.sh
+++ b/src/runtime_src/tools/scripts/make_arm.sh
@@ -4,11 +4,11 @@ set -e
 
 usage()
 {
-	echo "Usage: make_arm.sh <target>"
+	echo "Usage: make_arm.sh --boost_inc <Boost include> --boost_lib <Boost library> --target <target>"
+	echo "--boost_inc	The path of boost include directory"
+	echo "--boost_lib	The path of boost library directory"
+	echo "--target		Target architecture (arm/aarch64)"
 	echo ""
-	echo "target:"
-	echo "    arm      Build ARM 32bit library (e.g. zc702/zc706)"
-	echo "    aarch64  Build ARM 64bit library (e.g. zcu102/zcu106)"
 }
 
 usage_exit()
@@ -40,27 +40,69 @@ make_libxclzynqdrv()
 	cd $cur_dir
 }
 
+make_xilinxopencl()
+{
+	cc=$1
+	runtime_src_dir=$2
+	debug_dir=$3
+	release_dir=$4
+	boost_inc=$5
+	boost_lib=$6
+
+	cur_dir=$(pwd)
+
+	cd $runtime_src_dir
+	cl_inc=${debug_dir}/include
+	out_dir=${debug_dir}/xilinxopencl
+	make debug=1 CROSS_COMPILE=$cc OUT_DIR=$out_dir BOOST_INC_DIR=$boost_inc BOOST_LIB_DIR=$boost_lib CL_INC_DIR=$cl_inc -j4
+
+	cl_inc=${release_dir}/include
+	out_dir=${release_dir}/xilinxopencl
+	make debug=0 CROSS_COMPILE=$cc OUT_DIR=$out_dir BOOST_INC_DIR=$boost_inc BOOST_LIB_DIR=$boost_lib CL_INC_DIR=$cl_inc -j4
+
+	cd $cur_dir
+}
+
 target=aarch64
 script_dir=$(dirname "$0")
 shim_dir=$(readlink -f ${script_dir}/../../driver/zynq/user)
-build_dir=$(readlink -f ${script_dir}/../../../../build/)
+build_dir=$(readlink -f ${script_dir}/../../../../build)
+runtime_src_dir=$(readlink -f ${script_dir}/../..)
 
-if [ $# -eq 1 ]; then
+boost_inc=
+boost_lib=
+
+while [ $# -gt 0 ]; do
 	case $1 in
-		arm)
-			target=arm
+		--target | -t)
+			if [ $2 == "aarch64" ]; then
+				target=aarch64
+			else
+				target=arm
+			fi
+			shift
 			;;
-		aarch64)
-			target=aarch64
+		--boost_inc)
+			boost_inc=$2
+			shift
+			;;
+		--boost_lib)
+			echo boost_lib $2
+			boost_lib=$2
+			shift
 			;;
 		*)
 			usage_exit
+			shift
 			;;
 	esac
-else
-			usage_exit
-fi
+	shift
+done
 
+echo ${boost_inc}
+echo ${boost_lib}
+
+# Build ---- libxclzynqdrv.so ----
 # Check Debug/Release directory. If not exist, create
 if [ ! -d $build_dir/Debug ]; then
 	echo "Directory $build_dir/Debug no exist, creating"
@@ -96,3 +138,40 @@ mkdir -p ${build_dir}/Release/arm_libs/${target}
 release_dir=${build_dir}/Release/arm_libs/${target}
 
 make_libxclzynqdrv $cc $shim_dir $debug_dir $release_dir
+# end build libxclzynqdrv.so
+
+# Build ---- libxilinxopencl.so ----
+# Check required header files and copy it
+if [ -d /usr/include/CL ]; then
+	mkdir -p ${debug_dir}/include
+	mkdir -p ${release_dir}/include
+	cp -rf /usr/include/CL ${debug_dir}/include
+	cp -rf /usr/include/CL ${release_dir}/include
+else
+	echo "Could not find OpenCL header at /usr/include"
+	echo "OpenCL headers are required to cross-compile libxilinxopencl.so"
+	echo "Please install all XRT dependecies by run xrtdeps.sh"
+	exit 1
+fi
+
+if [ -f /usr/include/ocl_icd.h ]; then
+	cp -rf /usr/include/ocl_icd.h ${debug_dir}/include
+	cp -rf /usr/include/ocl_icd.h ${release_dir}/include
+else
+	echo "Could not find ocl_icd.h at /usr/include"
+	echo "ocl_icd.h are required to cross-compile libxilinxopencl.so"
+	echo "Please install all XRT dependecies by run xrtdeps.sh"
+	exit 1
+fi
+
+if [ -z $boost_inc ]; then
+	echo "--boost_inc could not be empty."
+fi
+
+if [ -z $boost_lib ]; then
+	echo "--boost_lib could not be empty."
+fi
+
+make_xilinxopencl $cc $runtime_src_dir $debug_dir $release_dir $boost_inc $boost_lib
+
+# end build libxilinxopencl.so

--- a/src/runtime_src/tools/scripts/make_arm.sh
+++ b/src/runtime_src/tools/scripts/make_arm.sh
@@ -1,0 +1,98 @@
+#! /bin/bash --
+
+set -e
+
+usage()
+{
+	echo "Usage: make_arm.sh <target>"
+	echo ""
+	echo "target:"
+	echo "    arm      Build ARM 32bit library (e.g. zc702/zc706)"
+	echo "    aarch64  Build ARM 64bit library (e.g. zcu102/zcu106)"
+}
+
+usage_exit()
+{
+	usage
+	exit 1
+}
+
+make_libxclzynqdrv()
+{
+	cc=$1
+	shim_dir=$2
+	debug_dir=$3
+	release_dir=$4
+	cur_dir=$(pwd)
+
+	cd $shim_dir
+
+	make clean > /dev/null
+	make debug=1 CROSS_COMPILE=$cc
+	mv libxclzynqdrv.so $debug_dir
+	make clean
+
+	make clean > /dev/null
+	make debug=0 CROSS_COMPILE=$cc
+	mv libxclzynqdrv.so $release_dir
+	make clean
+
+	cd $cur_dir
+}
+
+target=aarch64
+script_dir=$(dirname "$0")
+shim_dir=$(readlink -f ${script_dir}/../../driver/zynq/user)
+build_dir=$(readlink -f ${script_dir}/../../../../build/)
+
+if [ $# -eq 1 ]; then
+	case $1 in
+		arm)
+			target=arm
+			;;
+		aarch64)
+			target=aarch64
+			;;
+		*)
+			usage_exit
+			;;
+	esac
+else
+			usage_exit
+fi
+
+# Check Debug/Release directory. If not exist, create
+if [ ! -d $build_dir/Debug ]; then
+	echo "Directory $build_dir/Debug no exist, creating"
+	mkdir $build_dir/Debug
+fi
+
+if [ ! -d $build_dir/Release ]; then
+	echo "Directory $build_dir/Release no exist, creating"
+	mkdir $build_dir/Release
+fi
+
+if [ $target == "arm" ]; then
+	if [ ! -x "$(command -v arm-linux-gnueabihf-gcc)" ]; then
+		echo "Could not found arm-linux-gnueabihf-gcc. Please install Xilinx SDK"
+		echo "Then source $XILINX_SDK/setting64.sh or $XILINX_SDK/setting64.csh"
+		exit 1
+	fi
+
+	cc=arm-linux-gnueabihf-
+else
+	if [ ! -x "$(command -v aarch64-linux-gnu-gcc)" ]; then
+		echo "Could not found aarch64-linux-gnu-gcc. Please install Xilinx SDK"
+		echo "Then source $XILINX_SDK/setting64.sh or $XILINX_SDK/setting64.csh"
+		exit 1
+	fi
+
+	cc=aarch64-linux-gnu-
+fi
+
+mkdir -p ${build_dir}/Debug/arm_libs/${target}
+debug_dir=${build_dir}/Debug/arm_libs/${target}
+mkdir -p ${build_dir}/Release/arm_libs/${target}
+release_dir=${build_dir}/Release/arm_libs/${target}
+
+make_libxclzynqdrv $cc $shim_dir $debug_dir $release_dir


### PR DESCRIPTION
Add a script and a Makefile to compile XRT library for Zynq platforms.

1. Run xrtdeps.sh to install necessary header file
2. Depend on Boost library

How to use this script:
$./make_arm.sh --boost_inc <Boost include> --boost_lib <Boost library> --target aarch64