### PR TITLE
Updated hot reset to first stop XMC/ERT before going through reset

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-utils.c
@@ -237,6 +237,9 @@ long reset_hot_ioctl(struct xclmgmt_dev *lro)
 		xocl_reset(lro, true);
 	}
 
+	/* request XMC/ERT to stop */
+	xocl_mb_stop(lro);
+
 	if (!lro->reset_firewall) {
 		/*
 		 * if reset request comes from IOCTL, reset kernel and
@@ -294,6 +297,7 @@ long reset_hot_ioctl(struct xclmgmt_dev *lro)
 	if(dev_info->flags & XOCL_DSAFLAG_AXILITE_FLUSH)
 		platform_axilite_flush(lro);
 
+	/* restart XMC/ERT */
 	xocl_mb_reset(lro);
 
 #endif

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/microblaze.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/microblaze.c
@@ -607,11 +607,19 @@ static int load_sche_image(struct platform_device *pdev, const char *image,
 	return 0;
 }
 
+//Have a function stub but don't actually do anything when this is called
+static int mb_ignore(struct platform_device *pdev) {
+	return 0;
+}
+
 static struct xocl_mb_funcs mb_ops = {
 	.load_mgmt_image	= load_mgmt_image,
 	.load_sche_image	= load_sche_image,
 	.reset			= mb_reset,
+	.stop			= mb_ignore,
 };
+
+
 
 static int mb_remove(struct platform_device *pdev)
 {

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -402,6 +402,7 @@ struct xocl_firewall_funcs {
 /* microblaze callbacks */
 struct xocl_mb_funcs {
 	void (*reset)(struct platform_device *pdev);
+	int (*stop)(struct platform_device *pdev);
 	int (*load_mgmt_image)(struct platform_device *pdev, const char *buf,
 		u32 len);
 	int (*load_sche_image)(struct platform_device *pdev, const char *buf,
@@ -437,6 +438,10 @@ struct xocl_dna_funcs {
 #define	xocl_mb_reset(xdev)			\
 	(XMC_DEV(xdev) ? XMC_OPS(xdev)->reset(XMC_DEV(xdev)) : \
 	(MB_DEV(xdev) ? MB_OPS(xdev)->reset(MB_DEV(xdev)) : NULL))
+
+#define	xocl_mb_stop(xdev)			\
+	(XMC_DEV(xdev) ? XMC_OPS(xdev)->stop(XMC_DEV(xdev)) : \
+	(MB_DEV(xdev) ? MB_OPS(xdev)->stop(MB_DEV(xdev)) : -ENODEV))
 
 #define xocl_mb_load_mgmt_image(xdev, buf, len)		\
 	(XMC_DEV(xdev) ? XMC_OPS(xdev)->load_mgmt_image(XMC_DEV(xdev), buf, len) :\


### PR DESCRIPTION
Added stop xmc command which is copy pasted from load_xmc command. Maybe could optimize code and just have load_xmc call stop_xmc function instead of duplicated in code.

Created a stub for legacy mgmt microblaze which doesn't need to do anything for this