### PR TITLE
refactoring xbutil query

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -191,12 +191,12 @@ int main(int argc, char *argv[])
         return execv( std::string( path + "/xbflash" ).c_str(), argv );
     } /* end of call to xbflash */
 
-    if( std::string( argv[ 1 ] ).compare( "validate" ) == 0 ) {
+    if( std::strcmp( argv[1], "validate") == 0 ) {
         optind++;
         return xcldev::xclValidate(argc, argv);
     }
 
-    if( std::string( argv[ 1 ] ).compare( "top" ) == 0 ) {
+    if( std::strcmp( argv[1], "top") == 0) {
         optind++;
         return xcldev::xclTop(argc, argv);
     }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -229,8 +229,7 @@ int main(int argc, char *argv[])
 	{"monitorfifolite", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
 	{"monitorfifofull", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
     {"accelmonitor", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
-    {"topology", no_argument, 0, xcldev::TOPOLOGY},
-    {"xclbin", no_argument, 0, xcldev::XCLBIN_ID},
+    {"stream", no_argument, 0, xcldev::STREAM},
 
     };
     int long_index;
@@ -465,21 +464,13 @@ int main(int argc, char *argv[])
             hot = true;
             break;
         }
-        case xcldev::TOPOLOGY:
+        case xcldev::STREAM:
         {
             if(cmd != xcldev::QUERY){
                 std::cout << "ERROR: '-t' only allowed with 'query' command\n";
                 return -1;
             }
-            subcmd = xcldev::TOPOLOGY;
-            break;
-        }
-        case xcldev::XCLBIN_ID:{
-            if(cmd != xcldev::QUERY){
-                std::cout << "ERROR: '-x' only allowed with 'query' command\n";
-                return -1;
-            }
-            subcmd = xcldev::XCLBIN_ID;
+            subcmd = xcldev::STREAM;
             break;
         }
         default:
@@ -593,11 +584,13 @@ int main(int argc, char *argv[])
     case xcldev::QUERY:
         try
         {
-            if(subcmd == xcldev::XCLBIN_ID){
-                    result = deviceVec[index] -> xclbinID_print(std::cout);
+            if(subcmd == xcldev::STREAM)
+            {
+                result = deviceVec[index] -> str_topology_print(std::cout);
             }
-            else if(subcmd == xcldev::TOPOLOGY){
-                result = deviceVec[index] -> mem_str_topology_print(std::cout);
+            else
+            {
+                result = deviceVec[index] -> dump(std::cout);
             }
         }
         catch (...)

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -190,10 +190,6 @@ int main(int argc, char *argv[])
         return execv( std::string( path + "/xbflash" ).c_str(), argv );
     } /* end of call to xbflash */
 
-    if( std::string( argv[ 1 ] ).compare( "top" ) == 0 ) {
-        optind++;
-        return xcldev::xclTop(argc, argv);
-    }
     if( std::string( argv[ 1 ] ).compare( "validate" ) == 0 ) {
         optind++;
         return xcldev::xclValidate(argc, argv);
@@ -466,7 +462,7 @@ int main(int argc, char *argv[])
         }
         case xcldev::STREAM:
         {
-            if(cmd != xcldev::QUERY){
+            if(cmd != xcldev::QUERY && cmd != xcldev::TOP) {
                 std::cout << "ERROR: Option '" << long_options[long_index].name << "' cannot be used with command " << cmdname << "\n";
                 return -1;
             }
@@ -497,6 +493,7 @@ int main(int argc, char *argv[])
     case xcldev::QUERY:
     case xcldev::SCAN:
     case xcldev::STATUS:
+    case xcldev::TOP:
         break;
     case xcldev::PROGRAM:
     {
@@ -598,6 +595,18 @@ int main(int argc, char *argv[])
             std::cout << "ERROR: query failed" << std::endl;
         }
         break;
+
+    case xcldev::TOP:
+        if(subcmd == xcldev::STREAM)
+        {
+            result = deviceVec[index] -> printStreamInfo(std::cout);
+        }
+        else
+        {
+            result = xcldev::xclTop(argc, argv);
+        }
+        break;
+
     case xcldev::RESET:
         if (hot) regionIndex = 0xffffffff;
         result = deviceVec[index]->reset(regionIndex);
@@ -742,6 +751,9 @@ static void topPrintUsage(const xcldev::device *dev, xclDeviceUsage& devstat,
     dev->m_devinfo_stringize_power(devinfo, lines);
     
     dev->m_mem_usage_stringize_dynamics(devstat, devinfo, lines);
+
+    //shows stream
+    dev -> m_stream_usage_stringize_dynamics(devinfo, lines);
 
     for(auto line:lines){
             printw("%s\n", line.c_str());

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -80,8 +80,8 @@ int str2index(const char *arg, unsigned& index)
     return 0;
 }
 
-void print_pci_info(void)
-{
+
+void print_pci_info(void){
     auto print = [](const std::unique_ptr<pcidev::pci_func>& dev) {
         std::cout << std::hex;
         std::cout << ":[" << std::setw(2) << std::setfill('0') << dev->bus
@@ -228,10 +228,13 @@ int main(int argc, char *argv[])
 	{"tracefunnel", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
 	{"monitorfifolite", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
 	{"monitorfifofull", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
-	{"accelmonitor", no_argument, 0, xcldev::STATUS_UNSUPPORTED}
+    {"accelmonitor", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
+    {"topology", no_argument, 0, xcldev::TOPOLOGY},
+    {"xclbin", no_argument, 0, xcldev::XCLBIN_ID},
+
     };
     int long_index;
-    const char* short_options = "a:b:c:d:e:f:g:hi:m:n:o:p:r:s:"; //don't add numbers
+    const char* short_options = "a:b:c:d:e:f:g:hi:m:n:o:p:r:s"; //don't add numbers
     while ((c = getopt_long(argc, argv, short_options, long_options, &long_index)) != -1)
     {
         if (cmd == xcldev::LIST) {
@@ -462,6 +465,23 @@ int main(int argc, char *argv[])
             hot = true;
             break;
         }
+        case xcldev::TOPOLOGY:
+        {
+            if(cmd != xcldev::QUERY){
+                std::cout << "ERROR: '-t' only allowed with 'query' command\n";
+                return -1;
+            }
+            subcmd = xcldev::TOPOLOGY;
+            break;
+        }
+        case xcldev::XCLBIN_ID:{
+            if(cmd != xcldev::QUERY){
+                std::cout << "ERROR: '-x' only allowed with 'query' command\n";
+                return -1;
+            }
+            subcmd = xcldev::XCLBIN_ID;
+            break;
+        }
         default:
             xcldev::printHelp(exe);
             return 1;
@@ -573,7 +593,12 @@ int main(int argc, char *argv[])
     case xcldev::QUERY:
         try
         {
-            result = deviceVec[index]->dump(std::cout);
+            if(subcmd == xcldev::XCLBIN_ID){
+                    result = deviceVec[index] -> xclbinID_print(std::cout);
+            }
+            else if(subcmd == xcldev::TOPOLOGY){
+                result = deviceVec[index] -> mem_str_topology_print(std::cout);
+            }
         }
         catch (...)
         {

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -220,14 +220,14 @@ int main(int argc, char *argv[])
 
     argv[0] = const_cast<char *>(exe);
     static struct option long_options[] = {
-	{"read", no_argument, 0, xcldev::MEM_READ},
-	{"write", no_argument, 0, xcldev::MEM_WRITE},
-	{"spm", no_argument, 0, xcldev::STATUS_SPM},
-	{"lapc", no_argument, 0, xcldev::STATUS_LAPC},
-	{"sspm", no_argument, 0, xcldev::STATUS_SSPM},
-	{"tracefunnel", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
-	{"monitorfifolite", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
-	{"monitorfifofull", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
+    {"read", no_argument, 0, xcldev::MEM_READ},
+    {"write", no_argument, 0, xcldev::MEM_WRITE},
+    {"spm", no_argument, 0, xcldev::STATUS_SPM},
+    {"lapc", no_argument, 0, xcldev::STATUS_LAPC},
+    {"sspm", no_argument, 0, xcldev::STATUS_SSPM},
+    {"tracefunnel", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
+    {"monitorfifolite", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
+    {"monitorfifofull", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
     {"accelmonitor", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
     {"stream", no_argument, 0, xcldev::STREAM},
 
@@ -467,7 +467,7 @@ int main(int argc, char *argv[])
         case xcldev::STREAM:
         {
             if(cmd != xcldev::QUERY){
-                std::cout << "ERROR: '-t' only allowed with 'query' command\n";
+                std::cout << "ERROR: Option '" << long_options[long_index].name << "' cannot be used with command " << cmdname << "\n";
                 return -1;
             }
             subcmd = xcldev::STREAM;
@@ -586,7 +586,7 @@ int main(int argc, char *argv[])
         {
             if(subcmd == xcldev::STREAM)
             {
-                result = deviceVec[index] -> str_topology_print(std::cout);
+                result = deviceVec[index] -> printStreamInfo(std::cout);
             }
             else
             {

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -79,8 +79,7 @@ enum subcommand {
     STATUS_SPM,
     STATUS_LAPC,
     STATUS_SSPM,
-    XCLBIN_ID,
-    TOPOLOGY,
+    STREAM,
     STATUS_UNSUPPORTED
 };
 enum statusmask {
@@ -114,8 +113,7 @@ static const std::pair<std::string, subcommand> subcmd_pairs[] = {
     std::make_pair("spm", STATUS_SPM),
     std::make_pair("lapc", STATUS_LAPC),
     std::make_pair("sspm", STATUS_SSPM),
-    std::make_pair("topology", TOPOLOGY),
-    std::make_pair("xclbin", XCLBIN_ID)
+    std::make_pair("stream", STREAM)
 };
 
 static const std::vector<std::pair<std::string, std::string>> flash_types = {
@@ -719,7 +717,7 @@ public:
      * TODO: Refactor to make function much shorter.
      */
     int dump(std::ostream& ostr) const {
-        std::vector<std::string> lines;
+        std::vector<std::string> lines, usage_lines;
 
         m_devinfo_stringize(m_devinfo, lines);
  
@@ -748,21 +746,25 @@ public:
             ostr << "\n";
         }
         ostr << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
-        ostr << std::setfill(' ');
+        ostr << std::setfill(' ')<< "\n";
 #endif // AXI Firewall
+        xclDeviceUsage devstat = { 0 };
+        (void) xclGetUsageInfo(m_handle, &devstat);
 
+        m_mem_usage_stringize_dynamics(devstat, m_devinfo, usage_lines);
+        for(auto line:usage_lines){
+            ostr << line << "\n";
+        }
+        str_topology_print(ostr);
+        xclbinID_print(ostr);
         return 0;
     }
 
 
-    //MEM topology
-    int mem_str_topology_print(std::ostream& ostr) const {
+    //STR topology
+    int str_topology_print(std::ostream& ostr) const {
         std::vector<std::string> usage_lines;
-        xclDeviceUsage devstat = { 0 };
-        (void) xclGetUsageInfo(m_handle, &devstat);
-        m_mem_usage_stringize_dynamics(devstat, m_devinfo, usage_lines);
-
-    m_stream_usage_stringize_dynamics(m_devinfo, usage_lines);
+        m_stream_usage_stringize_dynamics(m_devinfo, usage_lines);
 
         for(auto line:usage_lines){
             ostr << line << "\n";
@@ -808,6 +810,7 @@ public:
         }
         //ostr << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
         ostr << std::setfill(' ') << "\n";
+
         return 0;
     }
 

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -746,7 +746,7 @@ public:
             ostr << "\n";
         }
         ostr << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
-        ostr << std::setfill(' ')<< "\n";
+        ostr << std::setfill(' ') << "\n";
 #endif // AXI Firewall
         xclDeviceUsage devstat = { 0 };
         (void) xclGetUsageInfo(m_handle, &devstat);
@@ -755,14 +755,14 @@ public:
         for(auto line:usage_lines){
             ostr << line << "\n";
         }
-        str_topology_print(ostr);
-        xclbinID_print(ostr);
+        printStreamInfo(ostr);
+        printXclbinID(ostr);
         return 0;
     }
 
 
-    //STR topology
-    int str_topology_print(std::ostream& ostr) const {
+    //stream topology
+    int printStreamInfo(std::ostream& ostr) const {
         std::vector<std::string> usage_lines;
         m_stream_usage_stringize_dynamics(m_devinfo, usage_lines);
 
@@ -772,7 +772,7 @@ public:
         return 0;
     }
 
-    int xclbinID_print(std::ostream& ostr) const{
+    int printXclbinID(std::ostream& ostr) const{
         // report xclbinid
         std::string errmsg;
         std::string xclbinid;
@@ -808,7 +808,6 @@ public:
                 ostr << std::setw(40) << "-- none found --. See 'xbutil program'.";
             }
         }
-        //ostr << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
         ostr << std::setfill(' ') << "\n";
 
         return 0;

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -71,8 +71,7 @@ enum command {
     MEM,
     DD,
     STATUS,
-    CMD_MAX,
-    TOP
+    CMD_MAX
 };
 enum subcommand {
     MEM_READ = 0,
@@ -105,8 +104,7 @@ static const std::pair<std::string, command> map_pairs[] = {
     std::make_pair("scan", SCAN),
     std::make_pair("mem", MEM),
     std::make_pair("dd", DD),
-    std::make_pair("status", STATUS),
-    std::make_pair("top", TOP),
+    std::make_pair("status", STATUS)
 };
 
 static const std::pair<std::string, subcommand> subcmd_pairs[] = {
@@ -658,9 +656,9 @@ public:
             return;
         } else {
             ss << std::setw(16) << "Tag"  << std::setw(10) << "Route"
-                << std::setw(10) << "Flow" << std::setw(10) << "Status"
-                << std::setw(16) << "Request (B/#)" << std::setw(16) << "Complete (B/#)"
-                << std::setw(16) << "Pending bytes" << "\n";
+               << std::setw(10) << "Flow" << std::setw(10) << "Status"
+               << std::setw(16) << "Request (B/#)" << std::setw(16) << "Complete (B/#)"
+               << "\n";
         }
 
         for(unsigned i = 0; i < num; i++) {
@@ -705,9 +703,6 @@ public:
                 ss << std::setw(16) << stat_map[std::string("total_complete_bytes")] +
                     "/" + stat_map[std::string("total_complete_num")];
             }
-
-            //<-----------------------add another counter here----------------------------->
-
             ss << "\n";
         }
 
@@ -756,7 +751,7 @@ public:
         (void) xclGetUsageInfo(m_handle, &devstat);
 
         m_mem_usage_stringize_dynamics(devstat, m_devinfo, usage_lines);
-        for(auto line:usage_lines){
+        for(auto line:usage_lines) {
             ostr << line << "\n";
         }
         printStreamInfo(ostr);
@@ -765,7 +760,9 @@ public:
     }
 
 
-    //stream topology
+    /*
+     * print stream topology
+     */
     int printStreamInfo(std::ostream& ostr) const {
         std::vector<std::string> usage_lines;
         m_stream_usage_stringize_dynamics(m_devinfo, usage_lines);
@@ -776,12 +773,14 @@ public:
         return 0;
     }
 
-    int printXclbinID(std::ostream& ostr) const{
+    /*
+     * print Xclbin ID
+     */
+    int printXclbinID(std::ostream& ostr) const {
         // report xclbinid
         std::string errmsg;
         std::string xclbinid;
-        pcidev::get_dev(m_idx)->user->sysfs_get(
-            "", "xclbinid", errmsg, xclbinid);
+        pcidev::get_dev(m_idx)->user->sysfs_get("", "xclbinid", errmsg, xclbinid);
 
         if(errmsg.empty()) {
             ostr << std::setw(16) << "\nXclbin ID:" << "\n";

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -71,7 +71,8 @@ enum command {
     MEM,
     DD,
     STATUS,
-    CMD_MAX
+    CMD_MAX,
+    TOP
 };
 enum subcommand {
     MEM_READ = 0,
@@ -105,6 +106,7 @@ static const std::pair<std::string, command> map_pairs[] = {
     std::make_pair("mem", MEM),
     std::make_pair("dd", DD),
     std::make_pair("status", STATUS),
+    std::make_pair("top", TOP),
 };
 
 static const std::pair<std::string, subcommand> subcmd_pairs[] = {
@@ -658,7 +660,7 @@ public:
             ss << std::setw(16) << "Tag"  << std::setw(10) << "Route"
                 << std::setw(10) << "Flow" << std::setw(10) << "Status"
                 << std::setw(16) << "Request (B/#)" << std::setw(16) << "Complete (B/#)"
-                << "\n";
+                << std::setw(16) << "Pending bytes" << "\n";
         }
 
         for(unsigned i = 0; i < num; i++) {
@@ -703,6 +705,8 @@ public:
                 ss << std::setw(16) << stat_map[std::string("total_complete_bytes")] +
                     "/" + stat_map[std::string("total_complete_num")];
             }
+
+            //<-----------------------add another counter here----------------------------->
 
             ss << "\n";
         }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -79,6 +79,8 @@ enum subcommand {
     STATUS_SPM,
     STATUS_LAPC,
     STATUS_SSPM,
+    XCLBIN_ID,
+    TOPOLOGY,
     STATUS_UNSUPPORTED
 };
 enum statusmask {
@@ -111,7 +113,9 @@ static const std::pair<std::string, subcommand> subcmd_pairs[] = {
     std::make_pair("write", MEM_WRITE),
     std::make_pair("spm", STATUS_SPM),
     std::make_pair("lapc", STATUS_LAPC),
-    std::make_pair("sspm", STATUS_SSPM)
+    std::make_pair("sspm", STATUS_SSPM),
+    std::make_pair("topology", TOPOLOGY),
+    std::make_pair("xclbin", XCLBIN_ID)
 };
 
 static const std::vector<std::pair<std::string, std::string>> flash_types = {
@@ -715,7 +719,7 @@ public:
      * TODO: Refactor to make function much shorter.
      */
     int dump(std::ostream& ostr) const {
-        std::vector<std::string> lines, usage_lines;
+        std::vector<std::string> lines;
 
         m_devinfo_stringize(m_devinfo, lines);
  
@@ -747,6 +751,26 @@ public:
         ostr << std::setfill(' ');
 #endif // AXI Firewall
 
+        return 0;
+    }
+
+
+    //MEM topology
+    int mem_str_topology_print(std::ostream& ostr) const {
+        std::vector<std::string> usage_lines;
+        xclDeviceUsage devstat = { 0 };
+        (void) xclGetUsageInfo(m_handle, &devstat);
+        m_mem_usage_stringize_dynamics(devstat, m_devinfo, usage_lines);
+
+    m_stream_usage_stringize_dynamics(m_devinfo, usage_lines);
+
+        for(auto line:usage_lines){
+            ostr << line << "\n";
+        }
+        return 0;
+    }
+
+    int xclbinID_print(std::ostream& ostr) const{
         // report xclbinid
         std::string errmsg;
         std::string xclbinid;
@@ -782,19 +806,8 @@ public:
                 ostr << std::setw(40) << "-- none found --. See 'xbutil program'.";
             }
         }
-        ostr << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
+        //ostr << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
         ostr << std::setfill(' ') << "\n";
-
-        xclDeviceUsage devstat = { 0 };
-        (void) xclGetUsageInfo(m_handle, &devstat);
-        m_mem_usage_stringize_dynamics(devstat, m_devinfo, usage_lines);
-
-	m_stream_usage_stringize_dynamics(m_devinfo, usage_lines);
-
-        for(auto line:usage_lines){
-            ostr << line << "\n";
-        }
-
         return 0;
     }
 


### PR DESCRIPTION
Made stream a secondary option 

```
XSJBRD2:~/github/XRT/build/Debug/opt/xilinx/xrt/bin% ./xbutil query --stream
INFO: Found total 1 card(s), 1 are usable

###############################################################################
Stream Topology
Tag             Route     Flow      Status    Request (B/#)   Complete (B/#)
 [3] stream0    0         0         Inactive  N/A             N/A
 [4] stream1    0         0         Inactive  N/A             N/A
 [5] stream2    65536     16        Inactive  N/A             N/A
 [6] stream3    65536     16        Inactive  N/A             N/A
 [7] stream4    65537     17        Inactive  N/A             N/A
 [8] stream5    65537     17        Inactive  N/A             N/A
 [9] stream6    131072    32        Inactive  N/A             N/A
 [10] stream7   131072    32        Inactive  N/A             N/A

INFO: xbutil query succeeded.
XSJBRD2:~/github/XRT/build/Debug/opt/xilinx/xrt/bin%

```