### PR TITLE
DNA axi ver EA

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/dna.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/dna.c
@@ -162,9 +162,78 @@ static uint32_t dna_capability(struct platform_device *pdev)
 	return capability;
 }
 
+static void dna_write_cert(struct platform_device *pdev, const char* data, uint32_t len)
+{
+	struct xocl_xlnx_dna *xlnx_dna = platform_get_drvdata(pdev);
+	int i,j,k;
+	uint32_t *cert = (uint32_t*)data;
+	u32 status = 0, words;
+	uint8_t retries = 100;
+	bool sha256done = false;
+	uint32_t convert;
+	uint32_t sign_start, message_words = (len-512)>>2;
+	sign_start = message_words;
+	if (!xlnx_dna)
+		return;
+
+	iowrite32(0x1, xlnx_dna->base+XLNX_DNA_MESSAGE_START_AXI_ONLY_REGISTER_OFFSET);
+	status = ioread32(xlnx_dna->base+XLNX_DNA_STATUS_REGISTER_OFFSET);
+	xocl_info(&pdev->dev, "Start: status %08x", status);
+
+	for(i=0;i<message_words;i+=16){
+		
+		retries = 100;
+		sha256done = false;
+		
+		while(!sha256done && retries){
+			status = ioread32(xlnx_dna->base+XLNX_DNA_STATUS_REGISTER_OFFSET);
+			if(!(status>>4 & 0x1)){
+				sha256done = true;
+				break;
+			}
+			msleep(10);
+			retries--;
+		}
+		for(j=0;j<16;++j){
+			convert = (*(cert+i+j)>>24 & 0xff) | (*(cert+i+j)>>8 & 0xff00) | (*(cert+i+j)<<8 & 0xff0000) | ((*(cert+i+j) & 0xff)<<24);
+			iowrite32(convert, xlnx_dna->base+XLNX_DNA_DATA_AXI_ONLY_REGISTER_OFFSET+j*4);
+		}
+	}
+	retries = 100;
+	sha256done = false;
+	while(!sha256done && retries){
+		status = ioread32(xlnx_dna->base+XLNX_DNA_STATUS_REGISTER_OFFSET);
+		if(!(status>>4 & 0x1)){
+			sha256done = true;
+			break;
+		}
+		msleep(10);
+		retries--;
+	}
+
+	status = ioread32(xlnx_dna->base+XLNX_DNA_STATUS_REGISTER_OFFSET);
+	words  = ioread32(xlnx_dna->base+XLNX_DNA_FSM_DNA_WORD_WRITE_COUNT_REGISTER_OFFSET);
+	xocl_info(&pdev->dev, "Message: status %08x dna words %d", status, words);
+
+	for(k=0;k<128;k+=16){
+		for(i=0;i<16;i++){
+			j=k+i+sign_start;
+			convert = (*(cert+j)>>24 & 0xff) | (*(cert+j)>>8 & 0xff00) | (*(cert+j)<<8 & 0xff0000) | ((*(cert+j) & 0xff)<<24);
+			iowrite32(convert, xlnx_dna->base+XLNX_DNA_CERTIFICATE_DATA_AXI_ONLY_REGISTER_OFFSET+i*4);
+		}
+	}
+
+	status = ioread32(xlnx_dna->base+XLNX_DNA_STATUS_REGISTER_OFFSET);
+	words  = ioread32(xlnx_dna->base+XLNX_DNA_FSM_CERTIFICATE_WORD_WRITE_COUNT_REGISTER_OFFSET);
+	xocl_info(&pdev->dev, "Signature: status %08x certificate words %d", status, words);
+	
+	return;
+}
+
 static struct xocl_dna_funcs dna_ops = {
 	.status			= dna_status,
 	.capability = dna_capability,
+	.write_cert = dna_write_cert,
 };
 
 

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -411,6 +411,7 @@ struct xocl_mb_funcs {
 struct xocl_dna_funcs {
 	u32 (*status)(struct platform_device *pdev);
 	u32 (*capability)(struct platform_device *pdev);
+	void (*write_cert)(struct platform_device *pdev, const char *buf, u32 len);
 };
 
 #define	XMC_DEV(xdev)		\
@@ -428,6 +429,8 @@ struct xocl_dna_funcs {
 	(DNA_DEV(xdev) ? DNA_OPS(xdev)->status(DNA_DEV(xdev)) : 0)
 #define	xocl_dna_capability(xdev)			\
 	(DNA_DEV(xdev) ? DNA_OPS(xdev)->capability(DNA_DEV(xdev)) : 2)
+#define xocl_dna_write_cert(xdev, data, len)  \
+	(DNA_DEV(xdev) ? DNA_OPS(xdev)->write_cert(DNA_DEV(xdev), data, len) : 0)
 
 #define	MB_DEV(xdev)		\
 	SUBDEV(xdev, XOCL_SUBDEV_MB).pldev


### PR DESCRIPTION
This PR is for DNA axi version before framework team put certificate and xclbin together.

Assumption:
1. dna certificate must be named as "dnas_cert.bin" and place under /lib/firmware/xilinx/
2. dna signature must be 4096 bits
3. dna certificate size must be a multiple of 512 bits and size = 512*n+4096 bits, n>=1

Revert this change after framework team put certificate and xclbin together.
