### PR TITLE
Bug Fixes

### DIFF
--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -319,7 +319,6 @@ reportXclbinInfo( std::ostream & _ostream,
     _ostream << XUtil::format("   %-23s %s", "Content:", sContent.c_str()).c_str() << std::endl;
   }
    
-  // UUID
   {
     std::string sUUID = XUtil::getUUIDAsString(_xclBinHeader.m_header.uuid);
     _ostream << XUtil::format("   %-23s %s", "UUID:", sUUID.c_str()).c_str() << std::endl;
@@ -472,11 +471,27 @@ reportHardwarePlatform( std::ostream & _ostream,
     }
   }
 
+  // Platform VBNV
+  {
+    std::string sPlatformVBNV = (char *) _xclBinHeader.m_header.m_platformVBNV;
+    if (sPlatformVBNV.empty()) {
+      sPlatformVBNV = "<not defined>";
+    }
+    _ostream << XUtil::format("   %-23s %s", "Platform VBNV:", sPlatformVBNV.c_str()).c_str() << std::endl;
+  }
+
   // Static UUID
   {
     std::string sStaticUUID = XUtil::getUUIDAsString(_xclBinHeader.m_header.rom_uuid);
     _ostream << XUtil::format("   %-23s %s", "Static UUID:", sStaticUUID.c_str()).c_str() << std::endl;
   }
+
+  // TimeStamp
+  {
+     _ostream << XUtil::format("   %-23s %ld", "Feature ROM TimeStamp:", _xclBinHeader.m_header.m_featureRomTimeStamp).c_str() << std::endl;
+  }
+ 
+
 }
 
 

--- a/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.cxx
@@ -25,6 +25,7 @@ ParameterSectionData::ParameterSectionData(const std::string &_formattedString)
   , m_formatTypeStr("")
   , m_file("")
   , m_section("")
+  , m_subSection("")
   , m_eKind(BITSTREAM)
   , m_originalString(_formattedString)
 {
@@ -76,18 +77,34 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
 
   // -- Section --
   if ( !tokens[0].empty() ) {
+    // TODO: Better subsection integration
+    std::string sSectionName = tokens[0];
+    std::string sSubSectionName;
+    std::string::size_type sectionPos = tokens[0].find_first_of("-", 0);
+    if (sectionPos != std::string::npos) {
+      sSectionName = tokens[0].substr(0, sectionPos);
+      sSubSectionName = tokens[0].substr(sectionPos+1, tokens[0].length()-sectionPos-1);
+    }
+
     enum axlf_section_kind eKind;
-    if (Section::translateSectionKindStrToKind(tokens[0], eKind) == false) {
-      std::string errMsg = XUtil::format("Error: Section '%s' isn't a valid section name.", tokens[0].c_str());
+    if (Section::translateSectionKindStrToKind(sSectionName, eKind) == false) {
+      std::string errMsg = XUtil::format("Error: Section '%s' isn't a valid section name.", sSectionName.c_str());
       throw std::runtime_error(errMsg);
     }
+
+    if (!sSubSectionName.empty() && (Section::supportsSubSections(eKind) == false) ) {
+      std::string errMsg = XUtil::format("Error: The section '%s' doesn't support subsections (e.g., '%s').", sSectionName.c_str(), sSubSectionName.c_str());
+      throw std::runtime_error(errMsg);
+    }
+
+    m_section = sSectionName;
+    m_subSection = sSubSectionName;
   }
 
   if ( tokens[0].empty() && (m_formatType != Section::FT_JSON)) {
     std::string errMsg = "Error: Empty sections names are only permitted with JSON format files.";
     throw std::runtime_error(errMsg);
   }
-  m_section = tokens[0];
 
   // -- File --
   m_file = tokens[2];
@@ -109,6 +126,12 @@ const std::string &
 ParameterSectionData::getSectionName()
 {
   return m_section;
+}
+
+const std::string &
+ParameterSectionData::getSubSectionName()
+{
+  return m_subSection;
 }
 
 enum axlf_section_kind &

--- a/src/runtime_src/tools/xclbin/ParameterSectionData.h
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.h
@@ -44,6 +44,7 @@ class ParameterSectionData {
   enum Section::FormatType getFormatType();
   const std::string &getFormatTypeAsStr();
   const std::string &getSectionName();
+  const std::string &getSubSectionName();
   enum axlf_section_kind &getSectionKind();
   const std::string &getOriginalFormattedString();
 
@@ -52,6 +53,7 @@ class ParameterSectionData {
    std::string m_formatTypeStr;
    std::string m_file;
    std::string m_section;
+   std::string m_subSection;
    enum axlf_section_kind m_eKind;
    std::string m_originalString;
 

--- a/src/runtime_src/tools/xclbin/Section.cxx
+++ b/src/runtime_src/tools/xclbin/Section.cxx
@@ -29,6 +29,7 @@ std::map<enum axlf_section_kind, std::string> Section::m_mapIdToName;
 std::map<std::string, enum axlf_section_kind> Section::m_mapNameToId;
 std::map<enum axlf_section_kind, Section::Section_factory> Section::m_mapIdToCtor;
 std::map<std::string, enum axlf_section_kind> Section::m_mapJSONNameToKind;
+std::map<enum axlf_section_kind, bool> Section::m_mapIdToSubSectionSupport;
 
 Section::Section()
     : m_eKind(BITSTREAM)
@@ -70,6 +71,7 @@ void
 Section::registerSectionCtor(enum axlf_section_kind _eKind,
                              const std::string& _sKindStr,
                              const std::string& _sHeaderJSONName,
+                             bool _bSupportsSubSections,
                              Section_factory _Section_factory) {
   // Some error checking
   if (_sKindStr.empty()) {
@@ -105,8 +107,7 @@ Section::registerSectionCtor(enum axlf_section_kind _eKind,
   m_mapIdToName[_eKind] = _sKindStr;
   m_mapNameToId[_sKindStr] = _eKind;
   m_mapIdToCtor[_eKind] = _Section_factory;
-  
-  //std::cout << "Kind(" << _eKind << "): " << _sKindStr << std::endl;
+  m_mapIdToSubSectionSupport[_eKind] = _bSupportsSubSections;
 }
 
 bool
@@ -119,6 +120,14 @@ Section::translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_s
   return true;
 }
 
+bool
+Section::supportsSubSections(enum axlf_section_kind &_eKind)
+{
+  if (m_mapIdToSubSectionSupport.find(_eKind) == m_mapIdToSubSectionSupport.end()) {
+    return false;   
+  }
+  return m_mapIdToSubSectionSupport[_eKind];
+}
 
 enum Section::FormatType 
 Section::getFormatType(const std::string _sFormatType)

--- a/src/runtime_src/tools/xclbin/Section.h
+++ b/src/runtime_src/tools/xclbin/Section.h
@@ -64,6 +64,7 @@ class Section {
   static bool translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind);
   static bool getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind);
   static enum FormatType getFormatType(const std::string _sFormatType);
+  static bool supportsSubSections(enum axlf_section_kind &_eKind);
 
  public:
   virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
@@ -102,7 +103,7 @@ class Section {
 
  protected:
   typedef std::function<Section*()> Section_factory;
-  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, Section_factory _Section_factory);
+  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, bool _bSupportsSubSections, Section_factory _Section_factory);
 
  protected:
   enum axlf_section_kind m_eKind;
@@ -117,6 +118,7 @@ class Section {
   static std::map<std::string, enum axlf_section_kind> m_mapNameToId;
   static std::map<enum axlf_section_kind, Section_factory> m_mapIdToCtor;
   static std::map<std::string, enum axlf_section_kind> m_mapJSONNameToKind;
+  static std::map<enum axlf_section_kind, bool> m_mapIdToSubSectionSupport;
 
  private:
   // Purposefully private and undefined ctors...

--- a/src/runtime_src/tools/xclbin/SectionBMC.h
+++ b/src/runtime_src/tools/xclbin/SectionBMC.h
@@ -47,7 +47,7 @@ class SectionBMC : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BMC, "BMC", "", boost::factory<SectionBMC*>()); }
+    _init() { registerSectionCtor(BMC, "BMC", "", false, boost::factory<SectionBMC*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstream.h
@@ -50,7 +50,7 @@ class SectionBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", boost::factory<SectionBitstream*>()); }
+    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", false, boost::factory<SectionBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
@@ -56,7 +56,7 @@ class SectionBuildMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", boost::factory<SectionBuildMetadata*>()); }
+    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", false, boost::factory<SectionBuildMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClearBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionClearBitstream.h
@@ -47,7 +47,7 @@ class SectionClearBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", boost::factory<SectionClearBitstream*>()); }
+    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", false, boost::factory<SectionClearBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
@@ -59,7 +59,7 @@ class SectionClockFrequencyTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", boost::factory<SectionClockFrequencyTopology*>()); }
+    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", false, boost::factory<SectionClockFrequencyTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionConnectivity.h
+++ b/src/runtime_src/tools/xclbin/SectionConnectivity.h
@@ -58,7 +58,7 @@ public:
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", boost::factory<SectionConnectivity*>()); }
+    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", false, boost::factory<SectionConnectivity*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugData.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugData.h
@@ -47,7 +47,7 @@ class SectionDebugData : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", boost::factory<SectionDebugData*>()); }
+    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", false, boost::factory<SectionDebugData*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
@@ -59,7 +59,7 @@ class SectionDebugIPLayout : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", boost::factory<SectionDebugIPLayout*>()); }
+    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", false, boost::factory<SectionDebugIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
+++ b/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
@@ -47,7 +47,7 @@ class SectionDesignCheckPoint : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", boost::factory<SectionDesignCheckPoint*>()); }
+    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", false, boost::factory<SectionDesignCheckPoint*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
@@ -47,7 +47,7 @@ class SectionEmbeddedMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", boost::factory<SectionEmbeddedMetadata*>()); }
+    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", false, boost::factory<SectionEmbeddedMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.h
@@ -59,7 +59,7 @@ public:
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", boost::factory<SectionIPLayout*>()); }
+    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", false, boost::factory<SectionIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
@@ -55,7 +55,7 @@ class SectionKeyValueMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", boost::factory<SectionKeyValueMetadata*>()); }
+    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", false, boost::factory<SectionKeyValueMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMCS.h
+++ b/src/runtime_src/tools/xclbin/SectionMCS.h
@@ -53,7 +53,7 @@ class SectionMCS : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MCS, "MCS", "", boost::factory<SectionMCS*>()); }
+    _init() { registerSectionCtor(MCS, "MCS", "", false, boost::factory<SectionMCS*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionManagementFW.h
+++ b/src/runtime_src/tools/xclbin/SectionManagementFW.h
@@ -47,7 +47,7 @@ class SectionManagementFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", boost::factory<SectionManagementFW*>()); }
+    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", false, boost::factory<SectionManagementFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMemTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionMemTopology.h
@@ -59,7 +59,7 @@ class SectionMemTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", boost::factory<SectionMemTopology*>()); }
+    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", false, boost::factory<SectionMemTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
+++ b/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
@@ -47,7 +47,7 @@ class SectionSchedulerFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", boost::factory<SectionSchedulerFW*>()); }
+    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", false, boost::factory<SectionSchedulerFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionUserMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionUserMetadata.h
@@ -47,7 +47,7 @@ class SectionUserMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", boost::factory<SectionUserMetadata*>()); }
+    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", false, boost::factory<SectionUserMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/XclBin.cxx
+++ b/src/runtime_src/tools/xclbin/XclBin.cxx
@@ -501,7 +501,9 @@ XclBin::readXclBinHeader(const boost::property_tree::ptree& _ptHeader,
   std::string sFeatureRomUUID = _ptHeader.get<std::string>("FeatureRomUUID");
   XUtil::hexStringToBinaryBuffer(sFeatureRomUUID, (unsigned char*)&_axlfHeader.m_header.rom_uuid, sizeof(axlf_header::rom_uuid));
   std::string sPlatformVBNV = _ptHeader.get<std::string>("PlatformVBNV");
-  XUtil::safeStringCopy((char*)&_axlfHeader.m_header.m_platformVBNV, sPlatformVBNV, sizeof(axlf_header::m_platformVBNV));
+  XUtil::safeStringCopy((char*)&_axlfHeader.m_header.m_platformVBNV,
+  
+                        sPlatformVBNV, sizeof(axlf_header::m_platformVBNV));
   std::string sXclBinUUID = _ptHeader.get<std::string>("XclBinUUID");
   XUtil::hexStringToBinaryBuffer(sXclBinUUID, (unsigned char*)&_axlfHeader.m_header.uuid, sizeof(axlf_header::uuid));
 
@@ -696,14 +698,10 @@ XclBin::updateHeaderFromSection(Section *_pSection)
 void 
 XclBin::addSection(ParameterSectionData &_PSD)
 {
+  XUtil::TRACE("Add Section");
   enum axlf_section_kind eKind;
   if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
     std::string errMsg = XUtil::format("Error: Section '%s' isn't a valid section name.", _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
-
-  if (findSection(eKind) != nullptr) {
-    std::string errMsg = XUtil::format("Error: Section '%s' already exists.", _PSD.getSectionName().c_str());
     throw std::runtime_error(errMsg);
   }
 
@@ -716,7 +714,18 @@ XclBin::addSection(ParameterSectionData &_PSD)
     throw std::runtime_error(errMsg);
   }
 
-  Section * pSection = Section::createSectionObjectOfKind(eKind);
+  Section *pSection = findSection(eKind);
+  if (pSection != nullptr) {
+    std::string sSubSection = _PSD.getSubSectionName();
+
+    if (sSubSection.empty()) {
+      std::string errMsg = XUtil::format("Error: Section '%s' already exists.", _PSD.getSectionName().c_str());
+      throw std::runtime_error(errMsg);
+    }
+  } else {
+    pSection = Section::createSectionObjectOfKind(eKind);
+  }
+
   if (pSection->doesSupportAddFormatType(_PSD.getFormatType()) == false) {
     std::string errMsg = XUtil::format("ERROR: The %s section does not support reading the %s file type.",
                                         pSection->getSectionKindAsString().c_str(),
@@ -731,9 +740,14 @@ XclBin::addSection(ParameterSectionData &_PSD)
 
   addSection(pSection);
   updateHeaderFromSection(pSection);
-  XUtil::TRACE(XUtil::format("Section '%s' (%d) successfully added.", pSection->getSectionKindAsString().c_str(), pSection->getSectionKind()));
+  std::string sSectionAddedName = pSection->getSectionKindAsString();
+  if (!_PSD.getSubSectionName().empty()) {
+    sSectionAddedName += "-" + _PSD.getSubSectionName();
+  }
+
+  XUtil::TRACE(XUtil::format("Section '%s' (%d) successfully added.", sSectionAddedName.c_str(), pSection->getSectionKind()));
   std::cout << std::endl << XUtil::format("Section: '%s'(%d) was successfully added.\nSize   : %ld bytes\nFormat : %s\nFile   : '%s'", 
-                                          pSection->getSectionKindAsString().c_str(), pSection->getSectionKind(),
+                                          sSectionAddedName.c_str(), pSection->getSectionKind(),
                                           pSection->getSize(),
                                           _PSD.getFormatTypeAsStr().c_str(), sSectionFileName.c_str()).c_str() << std::endl;
 }
@@ -840,7 +854,6 @@ XclBin::dumpSection(ParameterSectionData &_PSD)
                                         _PSD.getFormatTypeAsStr().c_str());
     throw std::runtime_error(errMsg);
   }
-
 
   std::string sDumpFileName = _PSD.getFile();
   // Write the xclbin file image
@@ -978,6 +991,16 @@ XclBin::setKeyValue(const std::string & _keyValue)
       return; // Key processed 
     }
 
+    if (sKey == "FeatureRomTimestamp") {
+      m_xclBinHeader.m_header.m_featureRomTimeStamp = XUtil::stringToUInt64(sValue);
+      return; // Key processed 
+    }
+
+    if (sKey == "PlatformVBNV") {
+      XUtil::safeStringCopy((char*)&m_xclBinHeader.m_header.m_platformVBNV, sValue, sizeof(axlf_header::m_platformVBNV));
+      return; // Key processed 
+    }
+
     std::string errMsg = XUtil::format("Error: Unknown key '%s' for key-value pair '%s'.", sKey.c_str(), _keyValue.c_str());
     throw std::runtime_error(errMsg);
   } 
@@ -1036,6 +1059,60 @@ XclBin::setKeyValue(const std::string & _keyValue)
   std::string errMsg = XUtil::format("Error: Unknown key domain for key-value pair '%s'.  Expected either 'USER' or 'SYS'.", sDomain.c_str());
   throw std::runtime_error(errMsg);
 }
+
+void 
+XclBin::removeKey(const std::string & _sKey)
+{
+
+  XUtil::TRACE(XUtil::format("Removing User Key: '%s'", _sKey.c_str()));
+
+  Section *pSection = findSection(KEYVALUE_METADATA);
+  if (pSection == nullptr) {
+    std::string errMsg = XUtil::format("Error: Key '%s' not found.", _sKey.c_str());
+    throw std::runtime_error(errMsg);
+  }
+
+  boost::property_tree::ptree ptKeyValueMetadata;
+   pSection->getPayload(ptKeyValueMetadata);
+
+   XUtil::TRACE_PrintTree("KEYVALUE:", ptKeyValueMetadata);
+   boost::property_tree::ptree ptKeyValues = ptKeyValueMetadata.get_child("keyvalue_metadata");
+   std::vector<boost::property_tree::ptree> keyValues = as_vector<boost::property_tree::ptree>(ptKeyValues, "key_values");
+
+   // Update existing key
+   bool bKeyFound = false;
+   for (unsigned int index = 0; index < keyValues.size(); ++index) {
+      if (keyValues[index].get<std::string>("key") == _sKey) {
+         bKeyFound = true;
+         std::cout << "Removing key '" + _sKey + "'" << std::endl;
+         keyValues.erase(keyValues.begin() + index);
+         break;
+      }
+    }
+
+   if (bKeyFound == false) {
+     std::string errMsg = XUtil::format("Error: Key '%s' not found.", _sKey.c_str());
+     throw std::runtime_error(errMsg);
+   }
+
+   // Now create a new tree to add back into the section
+   boost::property_tree::ptree ptKeyValuesNew;
+   for (auto keyvalue : keyValues) {
+     ptKeyValuesNew.add_child("kv_data", keyvalue);
+   }
+
+   boost::property_tree::ptree ptKeyValueMetadataNew;
+   ptKeyValueMetadataNew.add_child("key_values", ptKeyValuesNew);
+
+   boost::property_tree::ptree pt;
+   pt.add_child("keyvalue_metadata", ptKeyValueMetadataNew);
+
+   XUtil::TRACE_PrintTree("Final KeyValue",pt);
+   pSection->readJSONSectionImage(pt);
+   return;
+}
+
+
 
 void
 XclBin::reportInfo(std::ostream &_ostream, const std::string & _sInputFile, bool _bVerbose) const

--- a/src/runtime_src/tools/xclbin/XclBin.h
+++ b/src/runtime_src/tools/xclbin/XclBin.h
@@ -52,6 +52,7 @@ class XclBin {
   void dumpSection(ParameterSectionData &_PSD);
   void dumpSections(ParameterSectionData &_PSD);
   void setKeyValue(const std::string & _keyValue);
+  void removeKey(const std::string & _keyValue);
 
  public:
   Section *findSection(enum axlf_section_kind _eKind);


### PR DESCRIPTION
    + The info option now report both the Feature ROM's VBNV and timestamp
    + Added support to remove the key for a key-value pair
    + Added positional argument detection that produces an error if no option was specified with it.
    + Removed obsolete help example
    + Added warning if user didn't specify and output file
    + Added initial support for sub-sections