### PR TITLE
Acquire CU context if necessary for kernel execution

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -61,6 +61,7 @@ target_link_libraries(xilinxopencl
   dl
   pthread
   crypt
+  uuid
   rt
   )
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -1197,7 +1197,7 @@ int xocl::XOCLShim::xclExecWait(int timeoutMilliSec)
 /*
  * xclOpenContext
  */
-int xocl::XOCLShim::xclOpenContext(uuid_t xclbinId, unsigned int ipIndex, bool shared) const
+int xocl::XOCLShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const
 {
     unsigned int flags = shared ? XOCL_CTX_SHARED : XOCL_CTX_EXCLUSIVE;
     int ret;
@@ -1212,7 +1212,7 @@ int xocl::XOCLShim::xclOpenContext(uuid_t xclbinId, unsigned int ipIndex, bool s
 /*
  * xclCloseContext
  */
-int xocl::XOCLShim::xclCloseContext(uuid_t xclbinId, unsigned int ipIndex) const
+int xocl::XOCLShim::xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const
 {
     int ret;
     drm_xocl_ctx ctx = {XOCL_CTX_OP_FREE_CTX};

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -238,8 +238,8 @@ public:
     int xclExecBuf(unsigned int cmdBO,size_t numdeps, unsigned int* bo_wait_list);
     int xclRegisterEventNotify(unsigned int userInterrupt, int fd);
     int xclExecWait(int timeoutMilliSec);
-    int xclOpenContext(uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
-    int xclCloseContext(uuid_t xclbinId, unsigned int ipIndex) const;
+    int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+    int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
 
     int getBoardNumber( void ) { return mBoardNumber; }
     const char *getLogfileName( void ) { return mLogfileName; }

--- a/src/runtime_src/xocl/core/compute_unit.cpp
+++ b/src/runtime_src/xocl/core/compute_unit.cpp
@@ -38,9 +38,9 @@ get_base_addr(const xocl::xclbin::symbol* symbol, const std::string& kinst)
   std::transform(controlport.begin(), controlport.end(), controlport.begin(), ::tolower);
   if (port != controlport)
     throw std::runtime_error
-      ("internal error: kernel instance '" 
-       + kinst + "' in kernel '" 
-       + symbol->name + "' doesn't match control port '" 
+      ("internal error: kernel instance '"
+       + kinst + "' in kernel '"
+       + symbol->name + "' doesn't match control port '"
        + symbol->controlport + "' != '" + port + "'");
   return (*itr).base;
 }
@@ -68,7 +68,7 @@ compute_unit(const xclbin::symbol* s, const std::string& n, device* d)
 }
 
 compute_unit::
-~compute_unit() 
+~compute_unit()
 {
   XOCL_DEBUG(std::cout,"xocl::compute_unit::~compute_unit(",m_uid,")\n");
 }
@@ -116,4 +116,3 @@ get_memidx_union() const
 }
 
 } // xocl
-

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -486,7 +486,7 @@ public:
   int
   free_stream_buf(xrt::device::stream_buf_handle handle);
 
-  int 
+  int
   poll_streams(xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout);
 
   /**
@@ -651,6 +651,28 @@ public:
     return m_computeunits.size();
   }
 
+  /**
+   * Acquire a context for a given compute unit on this device
+   *
+   * Throws exception if context cannot be acquired on device
+   *
+   * @return
+   *   @true on success, @false if no program loaded.
+   */
+  bool
+  acquire_context(compute_unit* cu, bool shared=true) const;
+
+  /**
+   * Release a context for a given compute unit on this device
+   *
+   * Throws exception if context cannot be release properly.
+   *
+   * @return
+   *   @true on success, @false if no program loaded.
+   */
+  bool
+  release_context(compute_unit* cu) const;
+
   size_t
   get_num_cdmas() const
   {
@@ -659,7 +681,8 @@ public:
 
   void clear_connection(connidx_type conn);
 
-protected:
+private:
+
   /**
    * Add a cu this device can use
    *
@@ -671,7 +694,9 @@ protected:
     m_computeunits.emplace_back(std::move(cu));
   }
 
-private:
+  void
+  clear_cus();
+
   /**
    * Set xrt device when the final device is determined
    *

--- a/src/runtime_src/xocl/core/execution_context.cpp
+++ b/src/runtime_src/xocl/core/execution_context.cpp
@@ -252,6 +252,11 @@ add_compute_units(device* device)
     // away once we ensure that only one kernel per symbol is created in
     // which case the kernel object address can be used from comparison.
     if(cu->get_symbol()->uid==m_kernel.get()->get_symbol_uid()) {
+
+      // Check context creation
+      if (!device->acquire_context(cu))
+        continue;
+
       XOCL_DEBUGF("execution_context(%d) adding cu(%d)\n",m_uid,cu->get_uid());
       m_cus.push_back(cu);
     }

--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -938,6 +938,7 @@ public:
 
 class xclbin_data_sections
 {
+  const ::axlf* m_top                  = nullptr;
   const ::connectivity* m_con          = nullptr;
   const ::mem_topology* m_mem          = nullptr;
   const ::ip_layout* m_ip              = nullptr;
@@ -957,7 +958,8 @@ class xclbin_data_sections
 public:
   explicit
   xclbin_data_sections(const xocl::xclbin::binary_type& binary)
-    : m_con(reinterpret_cast<const ::connectivity*>(binary.connectivity_data().first))
+    : m_top(reinterpret_cast<const ::axlf*>(binary.binary_data().first))
+    , m_con(reinterpret_cast<const ::connectivity*>(binary.connectivity_data().first))
     , m_mem(reinterpret_cast<const ::mem_topology*>(binary.mem_topology_data().first))
     , m_ip(reinterpret_cast<const ::ip_layout*>(binary.ip_layout_data().first))
     , m_clk(reinterpret_cast<const ::clock_freq_topology*>(binary.clk_freq_data().first))
@@ -1144,6 +1146,12 @@ public:
         return mb.index;
     return -1;
   }
+
+  xocl::xclbin::uuid_type
+  uuid() const
+  {
+    return m_top->m_header.uuid;
+  }
 };
 
 } // namespace
@@ -1228,6 +1236,10 @@ struct xclbin::impl
   std::vector<uint32_t>
   cu_base_address_map() const
   { return m_xml.cu_base_address_map(); }
+
+  uuid_type
+  uuid() const
+  { return m_sections.uuid(); }
 
   const clock_freq_topology*
   get_clk_freq_topology() const
@@ -1333,6 +1345,13 @@ xclbin::
 binary() const
 {
   return impl_or_error()->m_binary;
+}
+
+xclbin::uuid_type
+xclbin::
+uuid() const
+{
+  return impl_or_error()->uuid();
 }
 
 std::string

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -21,6 +21,7 @@
 
 #include "xocl/core/refcount.h"
 #include "xclbin/binary.h"
+#include "xrt/util/uuid.h"
 
 #include <map>
 #include <string>
@@ -175,6 +176,13 @@ public:
    */
   std::string
   dsa_name() const;
+
+  /**
+   * Get uuid of xclbin
+   */
+  using uuid_type = xrt::uuid;
+  uuid_type
+  uuid() const;
 
   /**
    * Check if unified platform
@@ -375,7 +383,7 @@ public:
        Kernel name to  retrieve the memory index for
    * @param arg
        Index of arg to retrieve the memory index for
-   * @param conn 
+   * @param conn
    *   Index into the connectivity section allocated.
    * @return
    *   Memory idx

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -162,6 +162,14 @@ public:
     m_hal->close();
   }
 
+  void
+  acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared)
+  { m_hal->acquire_cu_context(uuid,cuidx,shared); }
+
+  void
+  release_cu_context(const uuid& uuid,size_t cuidx)
+  { m_hal->release_cu_context(uuid,cuidx); }
+
   ExecBufferObjectHandle
   allocExecBuffer(size_t sz)
   {
@@ -492,7 +500,7 @@ public:
   };
 
   int
-  pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)    
+  pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)
   {
     return m_hal->pollStreams(comps, min,max,actual,timeout);
   };
@@ -649,22 +657,6 @@ public:
   writeKernelCtrl(uint64_t offset,const void* hbuf,size_t size)
   {
     return m_hal->writeKernelCtrl(offset,hbuf,size);
-  }
-
-  /**
-   * Reset device program
-   *
-   * @param kind
-   *   Type of set
-   * @returns
-   *   A pair <int,bool> where bool is set to true if
-   *   and only if the return int value is valid. The
-   *   return value is implementation dependent.
-   */
-  hal::operations_result<int>
-  resetKernel()
-  {
-    return m_hal->resetKernel();
   }
 
   /**

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -21,6 +21,7 @@
 #include "xrt/util/task.h"
 #include "xrt/util/event.h"
 #include "xrt/util/range.h"
+#include "xrt/util/uuid.h"
 
 #include "driver/include/xclperf.h"
 #include "driver/include/xcl_app_debug.h"
@@ -159,6 +160,12 @@ public:
 
   virtual void
   close() = 0;
+
+  virtual void
+  acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared) {}
+
+  virtual void
+  release_cu_context(const uuid& uuid,size_t cuidx) {}
 
   // Hack to copy hw_em device info to sw_em device info
   // Should not be necessary when we move to sw_emu
@@ -449,22 +456,6 @@ public:
   writeKernelCtrl(uint64_t offset,const void* hbuf,size_t size)
   {
     return operations_result<ssize_t>();
-  }
-
-  /**
-   * Reset device program
-   *
-   * @param kind
-   *   Type of set
-   * @returns
-   *   A pair <int,bool> where bool is set to true if
-   *   and only if the return int value is valid. The
-   *   return value is implementation dependent.
-   */
-  virtual operations_result<int>
-  resetKernel()
-  {
-    return operations_result<int>();
   }
 
   /**

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -206,6 +206,12 @@ public:
     }
   }
 
+  virtual void
+  acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared);
+
+  virtual void
+  release_cu_context(const uuid& uuid,size_t cuidx);
+
   virtual task::queue*
   getQueue(hal::queue_type qt)
   {
@@ -344,7 +350,7 @@ public:
   virtual ssize_t
   readStream(hal::StreamHandle stream, void* ptr, size_t offset, size_t size, hal::StreamXferReq* req);
 
-  virtual int 
+  virtual int
   pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout);
 
 public:

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -35,6 +35,8 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mGetBOProperties(0)
   ,mExecBuf(0)
   ,mExecWait(0)
+  ,mOpenContext(0)
+  ,mCloseContext(0)
   ,mFreeBO(0)
   ,mWriteBO(0)
   ,mReadBO(0)
@@ -97,6 +99,9 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mGetBOProperties = (getBOPropertiesFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclGetBOProperties");
   mExecBuf = (execBOFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclExecBuf");
   mExecWait = (execWaitFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclExecWait");
+
+  mOpenContext = (openContextFuncType)dlsym(const_cast<void*>(mDriverHandle), "xclOpenContext");
+  mCloseContext = (closeContextFuncType)dlsym(const_cast<void*>(mDriverHandle), "xclCloseContext");
 
   mFreeBO   = (freeBOFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclFreeBO");
   if(!mFreeBO)
@@ -214,5 +219,3 @@ operations::
 }
 
 }} // hal2,xrt
-
-

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -111,7 +111,11 @@ private:
   typedef size_t (* debugReadIPStatusFuncType)(xclDeviceHandle handle, xclDebugReadType type,
                                                void* debugResults);
 
-//Streaming 
+  typedef int (* openContextFuncType)(xclDeviceHandle handle, const uuid_t xclbinId, unsigned int ipIndex,
+                                      bool shared);
+  typedef int (* closeContextFuncType)(xclDeviceHandle handle, const uuid_t xclbinId, unsigned ipIndex);
+
+  //Streaming
   typedef int     (*createWriteQueueFuncType)(xclDeviceHandle handle,xclQueueContext *q_ctx, uint64_t *q_hdl);
   typedef int     (*createReadQueueFuncType)(xclDeviceHandle handle,xclQueueContext *q_ctx, uint64_t *q_hdl);
   typedef int     (*destroyQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl);
@@ -158,6 +162,9 @@ public:
 
   execBOFuncType mExecBuf;
   execWaitFuncType mExecWait;
+
+  openContextFuncType mOpenContext;
+  closeContextFuncType mCloseContext;
 
   freeBOFuncType mFreeBO;
   writeBOFuncType mWriteBO;
@@ -230,7 +237,7 @@ public:
       : p.size;
   }
 
-  uint64_t 
+  uint64_t
   mGetDeviceAddr(xclDeviceHandle handle, unsigned int boHandle) const
   {
     xclBOProperties p;
@@ -244,5 +251,3 @@ public:
 }} // hal2,xrt
 
 #endif
-
-

--- a/src/runtime_src/xrt/util/uuid.h
+++ b/src/runtime_src/xrt/util/uuid.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2016-2017 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef xrt_uuid_h_
+#define xrt_uuid_h_
+
+#include <uuid/uuid.h>
+
+namespace xrt {
+
+/**
+ * uuid wrapper to treat uuid_t as a value type
+ * supports copying
+ */
+struct uuid
+{
+  uuid_t m_uuid;
+
+  uuid(const uuid_t val)
+  {
+    uuid_copy(m_uuid,val);
+  }
+
+  uuid(const uuid& rhs)
+  {
+    uuid_copy(m_uuid,rhs.m_uuid);
+  }
+
+  uuid(uuid&&) = default;
+  uuid& operator=(uuid&&) = default;
+
+  uuid& operator=(const uuid& rhs)
+  {
+    uuid source(rhs);
+    std::swap(*this,source);
+    return *this;
+  }
+
+  const uuid_t& get() const
+  {
+    return m_uuid;
+  }
+
+  std::string
+  to_string() const
+  {
+    char str[40] = {0};
+    uuid_unparse_lower(m_uuid,str);
+    return str;
+  }
+};
+
+} // xrt
+
+
+#endif


### PR DESCRIPTION
If a context is aquired succesfully, it remains valid until the program
is unloaded. If a context cannot be acquired, then kernel execution fails.

Currently calls to xclOpenContext are disabled in runtime_src/xrt/device/hal2.cpp