### PR TITLE
DNA AXI with integrated xclbin and cert

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -1773,6 +1773,12 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 		/* should be removed after integrated certificate with xclbin*/
 		if(xocl_dna_capability(xdev) & 0x1){
 			certificate = get_axlf_section(icap, copy_buffer, DNA_CERTIFICATE);
+			if(certificate == NULL) {
+				ICAP_ERR(icap, "Can't get certificate section");
+				err = -EACCES;
+				goto dna_check_failed;
+			}
+			
 			if(certificate->m_sectionSize % 64 || certificate->m_sectionSize < 576) {
 				ICAP_ERR(icap, "invalid certificate size, should be at least 576 bytes and a multiple of 64 bytes but size %llu", certificate->m_sectionSize);
 				err = -EACCES;

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -1522,6 +1522,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 	const struct axlf_section_header* primaryHeader = NULL;
 	const struct axlf_section_header* secondaryHeader = NULL;
 	const struct axlf_section_header* ipLayout = NULL;
+	const struct axlf_section_header* certificate = NULL;
 	uint64_t copy_buffer_size = 0;
 	struct axlf* copy_buffer = NULL;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -1538,9 +1539,6 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 	uint32_t nums_of_ip_section[XOCL_SUBDEV_NUM];
 	uint32_t sub_id;
 	uint32_t id, idx;
-	char cert_name[32];
-	const struct firmware *cert;
-	struct pci_dev *pcidev = XOCL_PL_TO_PCI_DEV(pdev);
 
 	/* Can only be done from mgmt pf. */
 	if (!ICAP_PRIVILEGED(icap))
@@ -1774,22 +1772,11 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 		ICAP_INFO(icap, "DNA version: %s", (xocl_dna_capability(xdev) & 0x1)? "AXI" : "BRAM");
 		/* should be removed after integrated certificate with xclbin*/
 		if(xocl_dna_capability(xdev) & 0x1){
-			snprintf(cert_name, sizeof(cert_name), "xilinx/dnas_cert.bin");
-			ICAP_INFO(icap, "certificate name is %s", cert_name);
-			err = request_firmware(&cert, cert_name, &pcidev->dev);
-			if (err) {
-				ICAP_ERR(icap, "unable to find certificate %s", cert_name);
-				err = -EACCES;
-				goto dna_check_failed;
-			}
-			if(cert->size % 64 || cert->size < 576) {
-				ICAP_ERR(icap, "invalid certificate size, should be at least 576 bytes and a multiple of 64 bytes but size %lu", cert->size);
-				err = -EACCES;
-				release_firmware(cert);
-				goto dna_check_failed;
-			}
-			xocl_dna_write_cert(xdev, cert->data, cert->size);
-			release_firmware(cert);
+			certificate = get_axlf_section(icap, copy_buffer, DNA_CERTIFICATE);
+			ICAP_INFO(icap, "DNA Certificate Size 0x%llx", certificate->m_sectionSize);
+			buffer = (char __user *)u_xclbin;
+			buffer += certificate->m_sectionOffset;
+			xocl_dna_write_cert(xdev, buffer, certificate->m_sectionSize);
 		}
 		err = (0x1 & xocl_dna_status(xdev)) ? 0 : -EACCES;
 		if (err){

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -1773,6 +1773,11 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 		/* should be removed after integrated certificate with xclbin*/
 		if(xocl_dna_capability(xdev) & 0x1){
 			certificate = get_axlf_section(icap, copy_buffer, DNA_CERTIFICATE);
+			if(certificate->m_sectionSize % 64 || certificate->m_sectionSize < 576) {
+				ICAP_ERR(icap, "invalid certificate size, should be at least 576 bytes and a multiple of 64 bytes but size %llu", certificate->m_sectionSize);
+				err = -EACCES;
+				goto dna_check_failed;
+			}
 			ICAP_INFO(icap, "DNA Certificate Size 0x%llx", certificate->m_sectionSize);
 			buffer = (char __user *)u_xclbin;
 			buffer += certificate->m_sectionOffset;

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -411,7 +411,7 @@ struct xocl_mb_funcs {
 struct xocl_dna_funcs {
 	u32 (*status)(struct platform_device *pdev);
 	u32 (*capability)(struct platform_device *pdev);
-	void (*write_cert)(struct platform_device *pdev, const char *buf, u32 len);
+	void (*write_cert)(struct platform_device *pdev, const char __user *buf, u32 len);
 };
 
 #define	XMC_DEV(xdev)		\


### PR DESCRIPTION
don't need dnas_cert.bin under /lib/firmware/xilinx/ anymore

get certificate section from xclbin, copy the section, parse and write message and signature in driver