### PR TITLE
Clean up documentation

### DIFF
--- a/src/runtime_src/doc/toc/build.rst
+++ b/src/runtime_src/doc/toc/build.rst
@@ -19,7 +19,7 @@ Build the runtime
 
 ::
 
-   cd XRT/build
+   cd build
    ./build.sh
 
 ``build.sh`` script builds for both Debug and Release profiles.  On RHEL/CentOS, if ``build.sh`` was accidentally run prior to enabling the devtoolset, then it is necessary to clean stale files makefiles by running ``build.sh clean`` prior to the next build.
@@ -29,7 +29,7 @@ Build RPM package on RHEL/CentOS or DEB package on Ubuntu
 
 ::
 
-   cd XRT/build/Release
+   cd build/Release
    make package
 
 Install the XRT RPM package
@@ -53,6 +53,8 @@ XRT Documentation can be built automatically using Sphinx doc builder together w
 
 ::
 
-   cd XRT/src/runtime_src/doc/
-   make
-   firefox html/index.html
+   cd src/runtime_src/doc
+   cmake .
+   make xrt_doc
+   # To look at the generated local documentation with a web browser:
+   xdg-open html/index.html

--- a/src/runtime_src/doc/toc/build.rst
+++ b/src/runtime_src/doc/toc/build.rst
@@ -27,31 +27,36 @@ Build the runtime
 Build RPM package on RHEL/CentOS or DEB package on Ubuntu
 .........................................................
 
-::
+The package is actually automatically built for the ``Release``
+version but not for the ``Debug`` version::
 
    cd build/Release
+   make package
+   cd ../Debug
    make package
 
 Install the XRT RPM package
 ...........................
 
-::
+Install with (the actual package name might differ) ::
 
    yum reinstall ./XRT-2.1.0-Linux.rpm
 
 Install the XRT DEB package
 ...........................
 
-::
+Install with (the actual package name might differ) ::
 
-   apt install --reinstall ./XRT-2.1.0-Linux.deb
+   sudo apt install --reinstall ./xrt_201830.2.1.0_18.10.deb
 
 XRT Documentation
 ~~~~~~~~~~~~~~~~~
 
-XRT Documentation can be built automatically using Sphinx doc builder together with Linux kernel based kernel-doc utility.
+XRT Documentation can be built automatically using Sphinx doc builder
+together with Linux kernel based ``kernel-doc`` utility.
 
-::
+To compile and install the documentation into the ``doc`` directory at
+the top of the repository::
 
    cd src/runtime_src/doc
    cmake .

--- a/src/runtime_src/doc/toc/build.rst
+++ b/src/runtime_src/doc/toc/build.rst
@@ -38,14 +38,16 @@ version but not for the ``Debug`` version::
 Install the XRT RPM package
 ...........................
 
-Install with (the actual package name might differ) ::
+Install from inside either the ``Release`` or ``Debug`` directory
+according to purpose with (the actual package name might differ) ::
 
-   yum reinstall ./XRT-2.1.0-Linux.rpm
+   sudo yum reinstall ./XRT-2.1.0-Linux.rpm
 
 Install the XRT DEB package
 ...........................
 
-Install with (the actual package name might differ) ::
+Install from inside either the ``Release`` or ``Debug`` directory
+according to purpose with (the actual package name might differ) ::
 
    sudo apt install --reinstall ./xrt_201830.2.1.0_18.10.deb
 
@@ -59,6 +61,7 @@ To compile and install the documentation into the ``doc`` directory at
 the top of the repository::
 
    cd src/runtime_src/doc
+   # For now the CMake can work only locally
    cmake .
    make xrt_doc
    # To look at the generated local documentation with a web browser:

--- a/src/runtime_src/doc/toc/debug-faq.rst
+++ b/src/runtime_src/doc/toc/debug-faq.rst
@@ -74,7 +74,7 @@ all buffer allocation requests.
 Memory Read Before Write
 ........................
 
-Read-Before-Write in 5.0+ DSAs will cause MIG *ECC* error. This is typically a user error. For example if user expects a kernel to write 4KB of data in DDR but it produced only 1KB of data and now the user tries to transfer full 4KB of data to host. It can also happen if user supplied 1KB sized buffer to a kernel but the kernel tries to read 4KB of data. Note ECC read-before-write error occurs if -- since the last bitstream download which results in MIG initialization -- no data has been written to a memory location but a read request is made for that same memory location. ECC errors stall the affected MIG since usually kernels are not able to handle this error. This can manifest in two different ways:
+Read-Before-Write in 5.0+ DSAs will cause MIG *ECC* error. This is typically a user error. For example if user expects a kernel to write 4KB of data in DDR but it produced only 1KB of data and now the user tries to transfer full 4KB of data to host. It can also happen if user supplied 1KB sized buffer to a kernel but the kernel tries to read 4KB of data. Note ECC read-before-write error occurs if — since the last bitstream download which results in MIG initialization — no data has been written to a memory location but a read request is made for that same memory location. ECC errors stall the affected MIG since usually kernels are not able to handle this error. This can manifest in two different ways:
 
 1. CU may hang or stall because it does not know how to handle this error while reading/writing to/from the affected MIG. ``xbutil query`` will show that the CU is stuck in *BUSY* state and not making progress.
 2. AXI Firewall may trip if PCIe DMA request is made to the affected MIG as the DMA engine will be unable to complete request. AXI Firewall trips result in the Linux kernel driver killing all processes which have opened the device node with *SIGBUS* signal. ``xbutil query`` will show if an AXI Firewall has indeed tripped including its timestamp.
@@ -88,13 +88,13 @@ Incorrect frequency scaling usually indicates a tooling or
 infrastructure bug. Target frequencies for the dynamic (partial
 reconfiguration) region are frozen at compile time and specified in
 ``clock_freq_topology`` section of ``xclbin``. If clocks in the dynamic region
-are running at incorrect -- higher than specified -- frequency,
+are running at incorrect — higher than specified — frequency,
 kernels will demonstrate weird behavior.
 
 1. Often a CU will produce completely incorrect result with no identifiable pattern
 2. A CU might hang
 3. When run several times, a CU may produce correct results a few times and incorrect results rest of the time
-4. A single CU run may produce a pattern of correct and incorrect result segments. Hence for a CU which produces a very long vector output (e.g. vector add), a pattern of correct -- typically 64 bytes or one AXI burst -- segment followed by incorrect segments are generated.
+4. A single CU run may produce a pattern of correct and incorrect result segments. Hence for a CU which produces a very long vector output (e.g. vector add), a pattern of correct — typically 64 bytes or one AXI burst — segment followed by incorrect segments are generated.
 
 Users should check the frequency of the board with ``xbutil query``
 and compare it against the metadata in ``xclbin``. ``xclbincat`` may
@@ -130,7 +130,7 @@ Bitsream Download Failures
   messages in ``dmesg`` would reveal if MIG calibration failed.
 
 Incorrect Timing Constraints
-  If the platform or dynamic region has invalid timing constraints -- which is really a platform or SDx tool bug -- CUs would show bizarre behaviors. This may result in incorrect outputs or CU/application hangs.
+  If the platform or dynamic region has invalid timing constraints — which is really a platform or SDx tool bug — CUs would show bizarre behaviors. This may result in incorrect outputs or CU/application hangs.
 
 Board in Crashed State
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/runtime_src/doc/toc/debug-faq.rst
+++ b/src/runtime_src/doc/toc/debug-faq.rst
@@ -17,7 +17,7 @@ Tools of the Trade
 ``xbutil``
    Query status of Xilinx PCIe device
 ``xclbinsplit``
-   Unpack an xclbin
+   Unpack an ``xclbin``
 XRT API Trace
    Run failing application with HAL logging enabled in ``sdaccel.ini`` ::
 
@@ -30,7 +30,7 @@ Validating a Working Setup
 When observing an application failure on a board, it is important to step back and validate the board setup. That will help establish and validate a clean working environment before running the failing application. We need to ensure that the board is enumerating and functioning.
 
 Board Enumeration
-  Check if BIOS and Linux can see the board. So for Xilinx boards use lspci utility ::
+  Check if BIOS and Linux can see the board. So for Xilinx boards use ``lspci`` utility ::
 
     lspci -v -d 10ee:
 
@@ -55,9 +55,21 @@ Common Reasons For Failures
 Incorrect Memory Topology Usage
 ...............................
 
-5.0+ DSAs are considered dynamic platforms which use sparse connectivity between acceleration kernels and memory controllers (MIGs). This means that a kernel port can only read/write from/to a specific MIG. This connectivity is frozen at xclbin generation time in specified in mem_topology section of xclbin. The host application needs to ensure that it uses the correct memory banks for buffer allocation using cl_mem_ext_ptr_t for OpenCL applications. For XRT native applications the bank is specified in flags to xclAllocBO() and xclAllocUserPtr().
+5.0+ DSAs are considered dynamic platforms which use sparse
+connectivity between acceleration kernels and memory controllers
+(MIGs). This means that a kernel port can only read/write from/to a
+specific MIG. This connectivity is frozen at ``xclbin`` generation
+time in specified in ``mem_topology`` section of ``xclbin``. The host
+application needs to ensure that it uses the correct memory banks for
+buffer allocation using ``cl_mem_ext_ptr_t`` for OpenCL
+applications. For XRT native applications the bank is specified in
+flags to ``xclAllocBO()`` and ``xclAllocUserPtr()``.
 
-If an application is producing incorrect results it is important to review the host code to ensure that host application and xclbin agree on memory topology. One way to validate this at runtime is to enable HAL logging in sdaccel.ini and then carefully go through all buffer allocation requests.
+If an application is producing incorrect results it is important to
+review the host code to ensure that host application and ``xclbin``
+agree on memory topology. One way to validate this at runtime is to
+enable HAL logging in ``sdaccel.ini`` and then carefully go through
+all buffer allocation requests.
 
 Memory Read Before Write
 ........................
@@ -72,14 +84,21 @@ Users should review the host code carefully. One common example is compression w
 Incorrect Frequency Scaling
 ...........................
 
-Incorrect frequency scaling usually indicates a tooling or infrastructure bug. Target frequencies for the dynamic (patial reconfig) region are frozen at compile time and specified in clock_freq_topology section of xclbin. If clocks in the dynamic region are running at incorrect -- higher than specified -- frequency, kernels will demonstrate weird behavior.
+Incorrect frequency scaling usually indicates a tooling or
+infrastructure bug. Target frequencies for the dynamic (partial
+reconfiguration) region are frozen at compile time and specified in
+``clock_freq_topology`` section of ``xclbin``. If clocks in the dynamic region
+are running at incorrect -- higher than specified -- frequency,
+kernels will demonstrate weird behavior.
 
 1. Often a CU will produce completely incorrect result with no identifiable pattern
 2. A CU might hang
 3. When run several times, a CU may produce correct results a few times and incorrect results rest of the time
 4. A single CU run may produce a pattern of correct and incorrect result segments. Hence for a CU which produces a very long vector output (e.g. vector add), a pattern of correct -- typically 64 bytes or one AXI burst -- segment followed by incorrect segments are generated.
 
-Users should check the frequency of the board with ``xbutil query`` and compare it against the metadata in xclbin. ``xclbincat`` may be used to extract metadata from xclbin.
+Users should check the frequency of the board with ``xbutil query``
+and compare it against the metadata in ``xclbin``. ``xclbincat`` may
+be used to extract metadata from ``xclbin``.
 
 CU Deadlock
 ...........
@@ -94,15 +113,21 @@ TODO
 AXI Bus Deadlock
 ................
 
-AXI Bus deadlocks can be caused by `Memory Read Before Write`_, `CU Deadlock`_ or `Multiple CU DDR Access Deadlock`_ described above. These usually show up as CU hang and sometimes may cause AXI FireWall to trip. Run ``xbutil query`` to check if CU is stuck in *START* or *--* state or if one of the AXI Firewall has tripped. If CU seems stuck we can confirm the deadlock by runing ``xbutil status`` which should list and performance counter values. Optionally run ``xbutil dmatest`` which will force transfer over the deadlocked bus causing either DMA timeout or AXI Firewall trip.
+AXI Bus deadlocks can be caused by `Memory Read Before Write`_, `CU Deadlock`_ or `Multiple CU DDR Access Deadlock`_ described above. These usually show up as CU hang and sometimes may cause AXI FireWall to trip. Run ``xbutil query`` to check if CU is stuck in *START* or *--* state or if one of the AXI Firewall has tripped. If CU seems stuck we can confirm the deadlock by running ``xbutil status`` which should list and performance counter values. Optionally run ``xbutil dmatest`` which will force transfer over the deadlocked bus causing either DMA timeout or AXI Firewall trip.
 
 
 Platform Bugs
 .............
 
 Bitsream Download Failures
-  Bitstream download failures are usually caused because of incompatible xclbins. dmesg log would provide more insight into why the download failed. At OpenCL level they usually manifest as Invalid Binary (error -44).
-  Rarely MIG calibration might fail after bitstream download. This will also show up as bitstream download failure. Usually XRT driver messages in dmesg would reveal if MIG calibration failed.
+  Bitstream download failures are usually
+  caused because of incompatible ``xclbin``\ s. ``dmesg`` log would
+  provide more insight into why the download failed. At OpenCL level
+  they usually manifest as Invalid Binary (error -44).
+
+  Rarely MIG calibration might fail after bitstream download. This
+  will also show up as bitstream download failure. Usually XRT driver
+  messages in ``dmesg`` would reveal if MIG calibration failed.
 
 Incorrect Timing Constraints
   If the platform or dynamic region has invalid timing constraints -- which is really a platform or SDx tool bug -- CUs would show bizarre behaviors. This may result in incorrect outputs or CU/application hangs.
@@ -110,7 +135,10 @@ Incorrect Timing Constraints
 Board in Crashed State
 ~~~~~~~~~~~~~~~~~~~~~~
 
-When board is in crashed state PCIe read operations start returning 0XFF. In this state xbutil query would show bizzare metrics. For example Temp would be very high. Boards in crashed state may be recovered with PCIe hot reset ::
+When board is in crashed state PCIe read operations start returning
+``0XFF``. In this state ``xbutil`` query would show bizarre
+metrics. For example ``Temp`` would be very high. Boards in crashed state
+may be recovered with PCIe hot reset ::
 
   xbutil reset -h
 
@@ -119,7 +147,14 @@ If this does not recover the board perform a warm reboot. After reset/reboot ple
 XRT Scheduling Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
-XRT has three kernel execution schedulers today: ERT, KDS and legacy. By default XRT uses ERT which runs on Microblaze. ERT is accessed through KDS which runs inside xocl Linux kernel driver. If ERT is not available KDS uses its own built-in scheduler. From 2018.2 release onwards KDS (tgether with ERT if available in the DSA) is enabled by default. Users can optionally switch to legacy scheduler which runs in userspace. Switching scheduler will help isolate any scheduler related XRT bugs ::
+XRT has three kernel execution schedulers today: ERT, KDS and
+legacy. By default XRT uses ERT which runs on Microblaze. ERT is
+accessed through KDS which runs inside ``xocl`` Linux kernel
+driver. If ERT is not available KDS uses its own built-in
+scheduler. From 2018.2 release onward KDS (together with ERT if
+available in the DSA) is enabled by default. Users can optionally
+switch to legacy scheduler which runs in userspace. Switching
+scheduler will help isolate any scheduler related XRT bugs ::
 
   [Runtime]
   ert=false

--- a/src/runtime_src/doc/toc/formats.rst
+++ b/src/runtime_src/doc/toc/formats.rst
@@ -4,15 +4,40 @@ Binary Formats
 xclbin
 ~~~~~~
 
-xclbin container format is defined in file *xclbin.h*. Since 2017.1 tools use xclbin2 format also known as AXLF format. AXLF is an extensible, future proof container of (bitstream/platform) hardware as well as software (MPSoC/Microblaze elf files) design data.  This unified container can hold outputs of our hardware compilers (sdaccel xocc) as well as software compilers (processor elf formats for MPSoc/Microblaze). This allows for easier integration of embedded processors and SDx on the same device. It also has structures to describe the memory topology, acceleration kernel instantiations and kernel connectivity for each kernel.
+``xclbin`` container format is defined in file ``xclbin.h``. Since
+2017.1, tools use ``xclbin2`` format also known as AXLF format. AXLF is
+an extensible, future-proof container of (bitstream/platform) hardware
+as well as software (MPSoC/Microblaze ELF files) design data.  This
+unified container can hold outputs of our hardware compilers (SDAccel
+``xocc``) as well as software compilers (processor ELF formats for
+MPSoc/Microblaze). This allows for easier integration of embedded
+processors and SDx on the same device. It also has structures to
+describe the memory topology, acceleration kernel instantiations and
+kernel connectivity for each kernel.
 
-The compiler generates unique xclbin file for every design compiled. Runtime loadsThe vivado front end tools programtically populate this file (layout described in driver/include/xclbin.h, attached) and then the device drivers read the information and apply it accordingly.
+The compiler generates unique ``xclbin`` file for every design
+compiled. The Vivado front-end tools programmatically
+populate this file (layout described in ``driver/include/xclbin.h``,
+attached) and then the runtime & device drivers read the information and apply
+it accordingly.
 
-The path to xclbin.h is ``runtime/driver/include/xclbin.h`` under SDx installation directory.
+The path to ``xclbin.h`` is ``runtime/driver/include/xclbin.h`` under
+SDx installation directory.
 
 Feature ROM
 ~~~~~~~~~~~
 
-Feature ROM is like a BIOS like table for FPGA which describes key properties of the device like its name and features enabled in the Shell of the platform. The format for the data in Feature ROM is defined in file *xclfeatures.h*. It a section of memory mapped BRAM memory which can be used for data sharing, error checking, functionality discover and optimizations in SDx. The Vivado tools will programmatically capture and populate BRAM memory in the platform during platform creation time. Runtime components like drivers read it and enable functionality in driver and also use the information to perform hardware/software compatibilty checks.
+Feature ROM is like a BIOS like table for FPGA which describes key
+properties of the device like its name and features enabled in the
+Shell of the platform. The format for the data in Feature ROM is
+defined in file ``xclfeatures.h``. It a section of memory mapped BRAM
+memory which can be used for data sharing, error checking,
+functionality discover and optimizations in SDx. The Vivado tools will
+programmatically capture and populate BRAM memory in the platform
+during platform creation time. Runtime components like drivers read it
+and enable functionality in driver and also use the information to
+perform hardware/software compatibility checks.
 
-The path to xclfeatures.h is ``runtime/driver/include/xclfeatures.h`` under SDx installation directory.
+The path to ``xclfeatures.h`` is
+``runtime/driver/include/xclfeatures.h`` under SDx installation
+directory.

--- a/src/runtime_src/doc/toc/index.rst
+++ b/src/runtime_src/doc/toc/index.rst
@@ -20,4 +20,5 @@ provides software interface to Xilinx FPGA. The key user APIs are defined in
    formats.rst
    system_requirements.rst
    build.rst
+   test.rst
    debug-faq.rst

--- a/src/runtime_src/doc/toc/index.rst
+++ b/src/runtime_src/doc/toc/index.rst
@@ -5,7 +5,7 @@ Xilinx Runtime (XRT) Architecture
 Xilinx Runtime (XRT) is implemented as a combination of userspace and kernel
 driver components. XRT which supports both PCIe based boards and Zynq/MPSoC
 provides software interface to Xilinx FPGA. The key user APIs are defined in
-*xclhal2.h* header file.
+``xclhal2.h`` header file.
 
 .. toctree::
    :maxdepth: 1

--- a/src/runtime_src/doc/toc/multiprocess.rst
+++ b/src/runtime_src/doc/toc/multiprocess.rst
@@ -8,7 +8,7 @@ Requirements
 ============
 
 Multiple processes can share access to the same device provided each
-process use the same xclbin.
+process use the same ``xclbin``.
 
 Usage
 =====
@@ -17,14 +17,12 @@ Processes share access to all device resources; as of 2018.2, there is
 no support for exclusive access to resources by any process.
 
 If two or more processes execute the same kernel, then these processes
-will acquire the kernel's compute units per the xocl kernel driver
-compute unit scheduler, which is first come first serve.  All
+will acquire the kernel's compute units per the ``xocl`` kernel driver
+compute unit scheduler, which is first-come first-serve.  All
 processes have the same priority in XRT.
 
-To enable multiprocess support, add the following entry to sdaccel.ini
-in the same directory as the executable(s).
-
-::
+To enable multiprocess support, add the following entry to ``sdaccel.ini``
+in the same directory as the executable(s)::
 
   [Runtime]
   multiprocess=true
@@ -36,14 +34,12 @@ Known problems
 xclbin must be loaded
 ~~~~~~~~~~~~~~~~~~~~~
 
-The xclbin shared by multiple processes **must** be pre-programmed.
-Failure to pre-program the device results in the following error:
-
-::
+The ``xclbin`` shared by multiple processes **must** be pre-programmed.
+Failure to pre-program the device results in the following error::
 
   ERROR: Failed to load xclbin
   Error: Failed to create compute program from binary -44!
 
-An xclbin is programmed explicitly by using xbutil::
+An ``xclbin`` is programmed explicitly by using ``xbutil``::
 
   xbutil program -p <xclbin>

--- a/src/runtime_src/doc/toc/sysfs.rst
+++ b/src/runtime_src/doc/toc/sysfs.rst
@@ -1,32 +1,46 @@
 Linux Sys FileSystem Nodes
 --------------------------
 
-*xocl* and *xclmgmt* drivers expose several sysfs nodes under the pci device root node.
+``xocl`` and ``xclmgmt`` drivers expose several ``sysfs`` nodes under
+the ``pci`` device root node.
 
 xocl
 ~~~~
 
-xocl driver exposes various sections of xclbin image including the xclbin Id on sysfs. This makes it very convenient for tools (such as *xbutil*) to discover characteristics of image currently loaded on the FPGA. The data layout of xclbin sections are defined in file *xclbin.h* which can be found under ``runtime/driver/include directory``.
+The ``xocl`` driver exposes various sections of the ``xclbin`` image
+including the ``xclbin`` ``Id`` on ``sysfs``. This makes it very
+convenient for tools (such as ``xbutil``) to discover characteristics
+of the image currently loaded on the FPGA. The data layout of ``xclbin``
+sections are defined in file ``xclbin.h`` which can be found under
+``runtime/driver/include`` directory.
 
-1. ip_layout
-   Exposes IP LAYOUT section of xclbin
-2. connectivity
-   Exposes CONNECTIVITY section of xclbin
-3. mem_topology
-   Exposes MEM TOPOLOGY section of xclbin
-4. xclbinid
-   Exposes xclbin unique identifier
+``ip_layout``
+  Exposes IP LAYOUT section of ``xclbin``
+``connectivity``
+  Exposes CONNECTIVITY section of ``xclbin``
+``mem_topology``
+  Exposes MEM TOPOLOGY section of ``xclbin``
+``xclbinid``
+  Exposes ``xclbin`` unique identifier
 
 xclmgmt
 ~~~~~~~
 
-xclmgmt driver exposes the instance number (suffix used in /dev/xclmgmt%d) on sysfs. This makes it convenient to uniquely map a PCIe slot on sysfs to /dev/xclmgmt%d device node created by the driver.
+``xclmgmt`` driver exposes the instance number (suffix used in
+``/dev/xclmgmt%d``) on ``sysfs``. This makes it convenient to uniquely map a
+PCIe slot on ``sysfs`` to ``/dev/xclmgmt%d`` device node created by the
+driver.
 
-Device sensors are exposed as standard ``hwmon`` file hierarchy. Two hwmon nodes are created: *sysmon* and *microblaze*. sysmon exposes device temperature and voltages. microblaze exposes device currents on various rails by using an embedded board management firmware. Values with _input suffix represent live values. Thie values are compatible with Linux standard *lm-sensors* tool.
+Device sensors are exposed as standard ``hwmon`` file hierarchy. Two
+``hwmon`` nodes are created: ``sysmon`` and ``microblaze``. ``sysmon``
+exposes device temperature and voltages. ``microblaze`` exposes device
+currents on various rails by using an embedded board management
+firmware. Values with ``_input`` suffix represent live values. The
+values are compatible with the Linux standard ``lm-sensors`` tool.
 
-For example if the bus number of mgmt physical function is ``0000:01:00.1`` then hwmon would show up under ``/sys/bus/pci/devices/0000:01:00.1``. See sample session log below:
-
-::
+For example if the bus address of a physical function is
+``0000:01:00.1`` then ``hwmon`` would show up under
+``/sys/bus/pci/devices/0000:01:00.1``. See sample session log below::
 
    dx4300:~>tree -L 1 /sys/bus/pci/devices/0000:01:00.1/hwmon
    /sys/bus/pci/devices/0000:01:00.1/hwmon

--- a/src/runtime_src/doc/toc/test.rst
+++ b/src/runtime_src/doc/toc/test.rst
@@ -7,7 +7,7 @@ downtime provided you use a few scripts we have created:
 - ``build.sh`` build script that builds XRT for both Debug and Release profiles.
 - ``run.sh`` loader script that sets up environment assuming XRT was
   built with ``build.sh``.
-- ``board.sh`` harvests sprite UNIT_HW test cases and runs board tests.
+- ``board.sh`` harvests sprite ``UNIT_HW`` test cases and runs board tests.
 
 Building XRT
 ~~~~~~~~~~~~
@@ -74,8 +74,9 @@ nightly sprite area.  Without the ``-sync`` option, the board script will
 run all tests that were previously synced into the current directory.
 
 While tests run a file named ``results.all`` will list the test with
-PASS/FAIL keyword.  This file is appended (not removed between runs).
-A complete run should take 5-10 mins for approximately 70 tests.
+``PASS``\ /\ ``FAIL`` keyword.  This file is appended (not removed
+between runs).  A complete run should take 5-10 mins for approximately
+70 tests.
 
 
 Unit Testing XRT
@@ -113,10 +114,10 @@ This will add GTest static library symbolic links here:
   * ``/usr/lib/libgtest.a``
   * ``/usr/lib/libgtest_main.a``
 
-To add GTest support to a CMakeLists.txt use the following, and this is using 
-an example executable called 'xclbintest':
+CMake will handle linking, finding etc. for you.
 
-::
+To add GTest support to a ``CMakeLists.txt`` use the following, and this is using 
+an example executable called ``xclbintest``::
 
    find_package(GTest)
    if (GTEST_FOUND)
@@ -129,4 +130,3 @@ an example executable called 'xclbintest':
    else()
      message (STATUS "GTest was not found, skipping generation of test executables")
    endif()
-

--- a/src/runtime_src/doc/toc/test.rst
+++ b/src/runtime_src/doc/toc/test.rst
@@ -84,15 +84,20 @@ Unit Testing XRT
 We use GTest to do unit testing. The GTest package is installed by
 running ``XRT/src/runtime_src/tools/scripts/xrtdeps.sh``.
 
-The GTest package on CentOS/RHEL 7.5 provides the GTest libraries here:
- * /usr/lib64/libgtest.so 
- * /usr/lib64/libgtest_main.so
+The GTest package on CentOS/RHEL 7.5 provides the GTest libraries
+here:
 
-However, the GTest package on Ubuntu 16.04 provides source only!
+  * ``/usr/lib64/libgtest.so``
+  * ``/usr/lib64/libgtest_main.so``
 
-To use GTest on Ubuntu 16.04 use:
+In recent versions of Ubuntu, the GTest ``libgtest-dev`` package
+provides the compiled libraries in
 
-::
+  * ``/usr/lib/x86_64-linux-gnu/libgtest.a``
+  * ``/usr/lib/x86_64-linux-gnu/libgtest_main.a``
+
+However, the GTest package on Ubuntu up to 18.04 provides source only!
+So, to use GTest on older Ubuntu versions, use::
 
    cd /usr/src/gtest
    sudo cmake CMakeLists.txt
@@ -104,10 +109,9 @@ To use GTest on Ubuntu 16.04 use:
    ls *gtest*
 
 This will add GTest static library symbolic links here:
- * /usr/lib/libgtest.a
- * /usr/lib/libgtest_main.a
 
-CMake will handle linking, finding etc. for you.
+  * ``/usr/lib/libgtest.a``
+  * ``/usr/lib/libgtest_main.a``
 
 To add GTest support to a CMakeLists.txt use the following, and this is using 
 an example executable called 'xclbintest':

--- a/src/runtime_src/doc/toc/tools.rst
+++ b/src/runtime_src/doc/toc/tools.rst
@@ -2,6 +2,6 @@ Tools and Utilities
 -------------------
 
 xbutil
-~~~~~
+~~~~~~
 
 Xilinx Board Utility Tool

--- a/src/runtime_src/driver/include/xclhal2.h
+++ b/src/runtime_src/driver/include/xclhal2.h
@@ -1151,7 +1151,8 @@ XCL_DRIVER_DLLESPEC ssize_t xclWriteQueue(xclDeviceHandle handle, uint64_t q_hdl
  *         return only when the requested bytes are read (stream) or the entire packet is read (packet)
  *     non-blocking:
  *         return 0 immediatly.
- *     TODO: EOT
+ *     TODO:
+ *         EOT
  *
  */
 XCL_DRIVER_DLLESPEC ssize_t xclReadQueue(xclDeviceHandle handle, uint64_t q_hdl, xclQueueRequest *wr_req);


### PR DESCRIPTION
Fix documentation generation.

Connect the documentation about testing to the main page.

Clarify GTest usage for old and recent Ubuntu.

Do not assume that the repository is actually clone in XRT directory.

Clarify a few points while testing compilation.

Fix some typos.

This is mainly fixing a lot of ReST issues.

Use real em-dash instead of en-dash
