### PR TITLE
fix missing interrupt issue for mailbox

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mailbox.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mailbox.c
@@ -429,6 +429,7 @@ static void msg_done(struct mailbox_msg *msg, int err)
 	} else {
 		complete(&msg->mbm_complete);
 	}
+	chan_config_timer(ch);
 }
 
 static void chan_msg_done(struct mailbox_channel *ch, int err)
@@ -439,8 +440,6 @@ static void chan_msg_done(struct mailbox_channel *ch, int err)
 	msg_done(ch->mbc_cur_msg, err);
 	ch->mbc_cur_msg = NULL;
 	ch->mbc_bytes_done = 0;
-
-	chan_config_timer(ch);
 }
 
 void timeout_msg(struct mailbox_channel *ch)


### PR DESCRIPTION
This change fixed the missing interrupt issue for mailbox. It also disables mailbox timer when no msg is in the queue (2nd try).
It passed Soren's board test.