### PR TITLE
Enhance the DNA Certificate Section to support JSON output.

### DIFF
--- a/src/runtime_src/tools/xclbin/SectionDNACertificate.cxx
+++ b/src/runtime_src/tools/xclbin/SectionDNACertificate.cxx
@@ -15,6 +15,7 @@
  */
 
 #include "SectionDNACertificate.h"
+#include <string>
 
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
@@ -30,5 +31,102 @@ SectionDNACertificate::~SectionDNACertificate() {
   // Empty
 }
 
+#define signatureSizeBytes 512
+
+#define dnaEntrySizeBytes 12
+struct dnaEntry {
+  char bytes[dnaEntrySizeBytes];
+};
 
 
+#define dnaByteAlignment 64
+
+void 
+SectionDNACertificate::marshalToJSON(char* _pDataSection, 
+                                     unsigned int _sectionSize, 
+                                     boost::property_tree::ptree& _ptree) const
+{
+  XUtil::TRACE("");
+  XUtil::TRACE("Extracting: DNA_CERTIFICATE");
+  XUtil::TRACE_BUF("Section Buffer", reinterpret_cast<const char*>(_pDataSection), _sectionSize);
+
+  if ((_sectionSize % dnaByteAlignment ) != 0) {
+    std::string errMsg = XUtil::format("ERROR: The DNA_CERTIFICATE section size doesn't align to 64 byte boundaries.  Current size: %ld", _sectionSize).c_str();
+    throw std::runtime_error(errMsg);
+  }
+
+  static const int minimumSectionSizeBytes = signatureSizeBytes + dnaByteAlignment;
+  if (_sectionSize < minimumSectionSizeBytes ) {
+    std::string errMsg = XUtil::format("ERROR: The DNA_CERTIFICATE section size (%ld) is smaller then the minimum section permitted (%ld).", _sectionSize, minimumSectionSizeBytes).c_str();
+    throw std::runtime_error(errMsg);
+  }
+
+  // Get the dnsSignature
+  std::string sDNSSignature;
+  XUtil::binaryBufferToHexString((unsigned char *) &_pDataSection[_sectionSize - signatureSizeBytes], signatureSizeBytes, sDNSSignature);
+
+  // Get the number of sections
+  char *pWorking = (char *) &_pDataSection[_sectionSize - signatureSizeBytes - sizeof (uint64_t)];
+  XUtil::TRACE_BUF("DNA Entries", pWorking, sizeof(uint64_t));
+  uint64_t dnaEntriesBitSize = 0;;
+  for (unsigned int index = 0; index < sizeof(uint64_t); ++index) {
+      dnaEntriesBitSize = dnaEntriesBitSize << 8;
+    dnaEntriesBitSize += (uint64_t) pWorking[index];
+  }
+
+  if ((dnaEntriesBitSize % (8 * dnaEntrySizeBytes)) != 0) {
+    std::string errMsg = XUtil::format("ERROR: The DNA_CERTIFICATE reserved DNA entries bit size (0x%x) does not align with the byte boundary (0x%lx)", dnaEntriesBitSize, (8 * dnaEntrySizeBytes)).c_str();
+    throw std::runtime_error(errMsg);
+  }
+
+  if (((dnaEntriesBitSize / 8) > _sectionSize)) {
+    std::string errMsg = XUtil::format("ERROR: The message DNA length (0x%x bytes) exceeds the DNA_CERTIFICATE size (0x%x bytes).", dnaEntriesBitSize / 8, _sectionSize).c_str();
+    throw std::runtime_error(errMsg);
+  }
+
+  uint64_t dnaEntryCount = (dnaEntriesBitSize / 8) / dnaEntrySizeBytes;
+  XUtil::TRACE("DNA Entry Count: " + std::to_string(dnaEntryCount));
+
+  // Get padding string
+  std::string sPadding;
+  unsigned int paddingOffset = dnaEntryCount * dnaEntrySizeBytes;
+  unsigned int paddingSize = (_sectionSize - signatureSizeBytes) - paddingOffset;
+  XUtil::binaryBufferToHexString((unsigned char *) &_pDataSection[paddingOffset], paddingSize, sPadding);
+
+
+
+  boost::property_tree::ptree dna_list;
+  struct dnaEntry *dnaEntries = reinterpret_cast<struct dnaEntry *>((void *)_pDataSection);
+
+  for (unsigned int index = 0; index < dnaEntryCount; ++index) {
+    std::string dnaString;
+    XUtil::binaryBufferToHexString((unsigned char *) &dnaEntries[index], dnaEntrySizeBytes, dnaString);
+
+    boost::property_tree::ptree ptDNA;
+    ptDNA.put("", dnaString.c_str());
+    dna_list.push_back(std::make_pair("", ptDNA));
+  }
+  XUtil::TRACE_PrintTree("DNA_LIST", dna_list);
+
+  boost::property_tree::ptree ptDNACertificate;
+  ptDNACertificate.add_child("dna_list", dna_list);
+  ptDNACertificate.put("padding", sPadding.c_str());
+  ptDNACertificate.put("signature", sDNSSignature.c_str());
+
+  XUtil::TRACE_PrintTree("DNA_TREE", ptDNACertificate);
+
+  _ptree.add_child("dna_certificate", ptDNACertificate);
+}
+
+
+bool 
+SectionDNACertificate::doesSupportDumpFormatType(FormatType _eFormatType) const
+{
+    if ((_eFormatType == FT_JSON) ||
+        (_eFormatType == FT_HTML))
+    {
+      return true;
+    }
+
+    return false;
+}

--- a/src/runtime_src/tools/xclbin/SectionDNACertificate.h
+++ b/src/runtime_src/tools/xclbin/SectionDNACertificate.h
@@ -38,6 +38,12 @@ class SectionDNACertificate : public Section {
   SectionDNACertificate();
   virtual ~SectionDNACertificate();
 
+ public:
+  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+
+ protected:
+  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
+
  private:
   // Purposefully private and undefined ctors...
   SectionDNACertificate(const SectionDNACertificate& obj);

--- a/src/runtime_src/tools/xclbin/XclBin.cxx
+++ b/src/runtime_src/tools/xclbin/XclBin.cxx
@@ -293,7 +293,10 @@ XclBin::writeXclBinBinarySections(std::fstream& _ostream, boost::property_tree::
       pt_sectionHeader.put("Size", XUtil::format("0x%lx", sectionHeader[index].m_sectionSize).c_str());
 
       boost::property_tree::ptree pt_Payload;
-      m_sections[index]->getPayload(pt_Payload);
+      if (m_sections[index]->doesSupportAddFormatType(Section::FT_JSON) && 
+          m_sections[index]->doesSupportDumpFormatType(Section::FT_JSON)) {
+        m_sections[index]->getPayload(pt_Payload);
+      }
 
       if (pt_Payload.size() != 0) {
         pt_sectionHeader.add_child("payload", pt_Payload);

--- a/src/runtime_src/tools/xclbin/xclbindata.cxx
+++ b/src/runtime_src/tools/xclbin/xclbindata.cxx
@@ -341,6 +341,22 @@ XclBinData::extractSectionData( int sectionNum, const char* name )
     type = "debug";
     ext = ".bin";
   }
+  else if ( header.m_sectionKind == DNA_CERTIFICATE ) {
+    type = "dna_certificate";
+    ext = ".bin";
+  }
+  else if ( header.m_sectionKind == BUILD_METADATA ) {
+    type = "build_metadata";
+    ext = ".bin";
+  }
+  else if ( header.m_sectionKind == KEYVALUE_METADATA ) {
+    type = "keyvalue_metadata";
+    ext = ".bin";
+  }
+  else if ( header.m_sectionKind == USER_METADATA ) {
+    type = "user_metadata";
+    ext = ".bin";
+  }
   else if ( header.m_sectionKind == MEM_TOPOLOGY ) {
     type = "mem_topology";
     ext = ".bin";
@@ -373,8 +389,13 @@ XclBinData::extractSectionData( int sectionNum, const char* name )
   else if ( header.m_sectionKind == BMC ) {
     extractAndWriteBMCImages((char*) data.get(), sectionSize);
     return true;
+  } else {
+    static unsigned int uniqueCount = 1;
+    type = "unknown(" + std::to_string(uniqueCount) + ")";
+    ext = ".bin";
   }
-  // Note: BUILD_METADATA, KEYVALUE_METADATA, USER_METADATA extraction currently not support
+
+  
 
 
   std::string id = "";

--- a/src/runtime_src/tools/xclbin/xclbindata.cxx
+++ b/src/runtime_src/tools/xclbin/xclbindata.cxx
@@ -393,6 +393,7 @@ XclBinData::extractSectionData( int sectionNum, const char* name )
     static unsigned int uniqueCount = 1;
     type = "unknown(" + std::to_string(uniqueCount) + ")";
     ext = ".bin";
+    ++uniqueCount;
   }
 
   


### PR DESCRIPTION
    Work Done
    + DNA_CERTIFICATE Section now supports dumping the contents out in a JSON format
    + Updated the MIRROR DATA section to only insert JSON data if only the section being inserted supports both readering and wriing JSON
    + Updated xclbinsplit to add the section names to the output file for DNA_CERTIFICATE, BUILD_METADATA, KEYVALUE_PAIRS, and USER_METADATA sections.
    + Updated xclbinsplit to add 'unknown(#)' if the section name is not know (future proofing).