### PR TITLE
Use PCI_IDS to disable MB scheduler (ERT).

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/devices.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/devices.h
@@ -615,7 +615,7 @@ enum {
 
 #define	XOCL_BOARD_USER_XDMA_DSA50					\
 	(struct xocl_board_private){					\
-		.flags		= 0,					\
+		.flags		= XOCL_DSAFLAG_MB_SCHE_OFF,		\
 		.subdev_info	= USER_RES_XDMA_DSA50,			\
 		.subdev_num = ARRAY_SIZE(USER_RES_XDMA_DSA50),		\
 		.user_bar = 0,						\

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/feature_rom.c
@@ -143,7 +143,7 @@ static bool mb_sched_on(struct platform_device *pdev)
 	rom = platform_get_drvdata(pdev);
 	BUG_ON(!rom);
 
-	return rom->mb_sche_enabled;
+	return rom->mb_sche_enabled && !XOCL_DSA_MB_SCHE_OFF(xocl_get_xdev(pdev));
 }
 
 static bool cdma_on(struct platform_device *pdev)
@@ -327,18 +327,16 @@ static int feature_rom_probe(struct platform_device *pdev)
 	else if (strstr(rom->header.VBNVName,"5_3"))
 		rom->dsa_version = 53;
 
-	if(rom->header.FeatureBitMap & UNIFIED_PLATFORM) {
+	if(rom->header.FeatureBitMap & UNIFIED_PLATFORM)
 		rom->unified = true;
-	}
-	if(rom->header.FeatureBitMap & BOARD_MGMT_ENBLD) {
+
+	if(rom->header.FeatureBitMap & BOARD_MGMT_ENBLD)
 		rom->mb_mgmt_enabled = true;
-	}
-	if( (rom->header.FeatureBitMap & MB_SCHEDULER)
-	    && rom->dsa_version>=51
-	    && !strstr(rom->header.VBNVName,"kcu1500")) {
+
+	if(rom->header.FeatureBitMap & MB_SCHEDULER)
 		rom->mb_sche_enabled = true;
-	}
-	if(rom->dsa_version>=53 && strstr(rom->header.VBNVName,"vcu1525"))
+
+	if(rom->header.FeatureBitMap & CDMA)
 	    rom->cdma_enabled = true;
 
 	ret = sysfs_create_group(&pdev->dev.kobj, &rom_attr_group);

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -794,7 +794,7 @@ configure(struct xocl_cmd *xcmd)
 {
 	struct exec_core *exec=xcmd->exec;
 	struct xocl_dev *xdev = exec_get_xdev(exec);
-	bool ert = xocl_mb_sched_on(xdev) && !XOCL_DSA_MB_SCHE_OFF(xdev);
+	bool ert = xocl_mb_sched_on(xdev);
 	bool cdma = xocl_cdma_on(xdev);
 	unsigned int dsa = xocl_dsa_version(xdev);
 	struct ert_configure_cmd *cfg;

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/microblaze.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/microblaze.c
@@ -496,8 +496,7 @@ static int mb_start(struct xocl_mb *mb)
 		COPY_MGMT(mb, mb->mgmt_binary, mb->mgmt_binary_length);
 	}
 
-	if (!XOCL_DSA_MB_SCHE_OFF(xocl_get_xdev(mb->pdev)) &&
-		xocl_mb_sched_on(xdev_hdl)) {
+	if (xocl_mb_sched_on(xdev_hdl)) {
 		xocl_info(&mb->pdev->dev, "Copying scheduler image len %d",
 			mb->sche_binary_length);
 		COPY_SCHE(mb, mb->sche_binary, mb->sche_binary_length);

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/xmc.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/xmc.c
@@ -930,11 +930,11 @@ static int stop_xmc_nolock(struct platform_device *pdev) {
 		}
 
 		retry=0;
-		while (retry++ < MAX_RETRY && 
-			!(READ_REG32(xmc, XMC_STATUS_REG) & STATUS_MASK_STOPPED)) 
+		while (retry++ < MAX_RETRY &&
+			!(READ_REG32(xmc, XMC_STATUS_REG) & STATUS_MASK_STOPPED))
 			msleep(RETRY_INTERVAL);
 
-		//Wait for XMC to stop and then check that ERT has also finished 
+		//Wait for XMC to stop and then check that ERT has also finished
 		if (retry >= MAX_RETRY) {
 			xocl_err(&xmc->pdev->dev,
 				"Failed to stop XMC");
@@ -943,10 +943,10 @@ static int stop_xmc_nolock(struct platform_device *pdev) {
 				READ_REG32(xmc, XMC_ERROR_REG));
 			xmc->state = XMC_STATE_ERROR;
 			return -ETIMEDOUT;
-		} else if (!SELF_JUMP(READ_IMAGE_SCHED(xmc, 0)) && 
+		} else if (!SELF_JUMP(READ_IMAGE_SCHED(xmc, 0)) &&
 			 !(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_STOP_ACK)) {
-			while (retry++ < MAX_RETRY && 
-				!(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_STOP_ACK)) 
+			while (retry++ < MAX_RETRY &&
+				!(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_STOP_ACK))
 				msleep(RETRY_INTERVAL);
 			if (retry >= MAX_RETRY) {
 				xocl_err(&xmc->pdev->dev,
@@ -1012,7 +1012,7 @@ static int load_xmc(struct xocl_xmc *xmc)
 	if (!xmc->enabled) {
 		return -ENODEV;
 	}
-    
+
 
 	mutex_lock(&xmc->xmc_lock);
 
@@ -1030,8 +1030,7 @@ static int load_xmc(struct xocl_xmc *xmc)
 		COPY_MGMT(xmc, xmc->mgmt_binary, xmc->mgmt_binary_length);
 	}
 
-	if (!XOCL_DSA_MB_SCHE_OFF(xocl_get_xdev(xmc->pdev)) &&
-		xocl_mb_sched_on(xdev_hdl)) {
+	if (xocl_mb_sched_on(xdev_hdl)) {
 		xocl_info(&xmc->pdev->dev, "Copying scheduler image len %d",
 			xmc->sche_binary_length);
 		COPY_SCHE(xmc, xmc->sche_binary, xmc->sche_binary_length);
@@ -1052,8 +1051,8 @@ static int load_xmc(struct xocl_xmc *xmc)
 	if(!(reg_val & STATUS_MASK_INIT_DONE)) {
 		xocl_info(&xmc->pdev->dev, "Waiting for XMC to finish init...");
 		retry=0;
-		while (retry++ < MAX_RETRY && 
-			!(READ_REG32(xmc, XMC_STATUS_REG) & STATUS_MASK_INIT_DONE)) 
+		while (retry++ < MAX_RETRY &&
+			!(READ_REG32(xmc, XMC_STATUS_REG) & STATUS_MASK_INIT_DONE))
 			msleep(RETRY_INTERVAL);
 		if (retry >= MAX_RETRY) {
 			xocl_err(&xmc->pdev->dev,


### PR DESCRIPTION
The global switch is through featureROM, the finer grained switch is via PCI_IDSs in devices.h; both are verified in feature_rom.c:mb_sched_on(pdev).

Move logic to disable ERT for kcu1500 (5.0 DSA) to devices.h.