### PR TITLE
Add support for probing IDCODE and exporting on sysfs

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -115,7 +115,7 @@ struct icap {
 	struct mutex		icap_lock;
 	struct icap_reg		*icap_regs;
 	struct icap_generic_state *icap_state;
-
+	unsigned int            idcode;
 	bool			icap_axi_gate_frozen;
 	struct icap_axi_gate	*icap_axi_gate;
 
@@ -232,7 +232,7 @@ static void reset_scheduler(struct icap *icap)
 			err = -EFAULT;
 			goto failed;
 		}
-	
+
 		err = reset(user_dev);
 
 		xocl_release_userdev(user_dev);
@@ -699,10 +699,10 @@ static int icap_ocl_update_clock_freq_topology(struct platform_device *pdev, str
 		}
 	}
 	else{
-		ICAP_ERR(icap, "ERROR: There isn't a hardware accelerator loaded in the dynamic region." 
+		ICAP_ERR(icap, "ERROR: There isn't a hardware accelerator loaded in the dynamic region."
 			" Validation of accelerator frequencies cannot be determine");
 		err = -EDOM;
-		goto done;		
+		goto done;
 	}
 
 	err = set_freqs(icap, freq_obj->ocl_target_freq, ARRAY_SIZE(freq_obj->ocl_target_freq));
@@ -1814,7 +1814,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 				err = -EACCES;
 				goto dna_check_failed;
 			}
-			
+
 			if(certificate->m_sectionSize % 64 || certificate->m_sectionSize < 576) {
 				ICAP_ERR(icap, "invalid certificate size, should be at least 576 bytes and a multiple of 64 bytes but size %llu", certificate->m_sectionSize);
 				err = -EACCES;
@@ -2071,9 +2071,19 @@ static ssize_t clock_freqs_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(clock_freqs);
 
+static ssize_t idcode_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct icap *icap = platform_get_drvdata(to_platform_device(dev));
+	return sprintf(buf, "0x%x\n", icap->idcode);
+}
+
+static DEVICE_ATTR_RO(idcode);
+
 static struct attribute *icap_attrs[] = {
 	&dev_attr_clock_freq_topology.attr,
 	&dev_attr_clock_freqs.attr,
+	&dev_attr_idcode.attr,
 	NULL,
 };
 
@@ -2106,6 +2116,38 @@ static int icap_remove(struct platform_device *pdev)
 
 	kfree(icap);
 	return 0;
+}
+
+/*
+ * Run the following sequence of canned commands to obtain IDCODE of the FPGA
+ */
+static void icap_probe_chip(struct icap *icap)
+{
+	u32 w;
+	w = reg_rd(&icap->icap_regs->ir_sr);
+	w = reg_rd(&icap->icap_regs->ir_sr);
+	reg_wr(&icap->icap_regs->ir_gier, 0x0);
+	w = reg_rd(&icap->icap_regs->ir_wfv);
+	reg_wr(&icap->icap_regs->ir_wf, 0xffffffff);
+	reg_wr(&icap->icap_regs->ir_wf, 0xaa995566);
+	reg_wr(&icap->icap_regs->ir_wf, 0x20000000);
+	reg_wr(&icap->icap_regs->ir_wf, 0x20000000);
+	reg_wr(&icap->icap_regs->ir_wf, 0x28018001);
+	reg_wr(&icap->icap_regs->ir_wf, 0x20000000);
+	reg_wr(&icap->icap_regs->ir_wf, 0x20000000);
+	w = reg_rd(&icap->icap_regs->ir_cr);
+	reg_wr(&icap->icap_regs->ir_cr, 0x1);
+	w = reg_rd(&icap->icap_regs->ir_cr);
+	w = reg_rd(&icap->icap_regs->ir_cr);
+	w = reg_rd(&icap->icap_regs->ir_sr);
+	w = reg_rd(&icap->icap_regs->ir_cr);
+	w = reg_rd(&icap->icap_regs->ir_sr);
+	reg_wr(&icap->icap_regs->ir_sz, 0x1);
+	w = reg_rd(&icap->icap_regs->ir_cr);
+	reg_wr(&icap->icap_regs->ir_cr, 0x2);
+	w = reg_rd(&icap->icap_regs->ir_rfo);
+	icap->idcode = reg_rd(&icap->icap_regs->ir_rf);
+	w = reg_rd(&icap->icap_regs->ir_cr);
 }
 
 static int icap_probe(struct platform_device *pdev)
@@ -2178,7 +2220,8 @@ static int icap_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
-	ICAP_INFO(icap, "successfully initialized");
+	icap_probe_chip(icap);
+	ICAP_INFO(icap, "successfully initialized FPGA IDCODE 0x%x", icap->idcode);
 	xocl_subdev_register(pdev, XOCL_SUBDEV_ICAP, &icap_ops);
 	return 0;
 

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -211,10 +211,13 @@ public:
         std::vector<std::string> &lines) const
     {
         std::stringstream ss, subss, ssdevice;
+        std::string idcode, fpga, errmsg;
+        pcidev::get_dev(m_idx)->mgmt->sysfs_get("icap", "idcode", errmsg, idcode);
+        pcidev::get_dev(m_idx)->mgmt->sysfs_get("rom", "FPGA", errmsg, fpga);
 
         ss << std::left;
-        ss << std::setw(16) << "DSA name" <<"\n";
-        ss << std::setw(16) << m_devinfo.mName << "\n\n";
+        ss << std::setw(8) << m_devinfo.mName;
+        ss << " [" << fpga << '(' << idcode << ")]\n\n";
         ss << std::setw(16) << "Vendor" << std::setw(16) << "Device";
         ss << std::setw(16) << "SubDevice" <<  std::setw(16) << "SubVendor";
         ss << std::setw(16) << "XMC fw version" << "\n";
@@ -228,7 +231,7 @@ public:
         ss << std::setw(16) << (m_devinfo.mXMCVersion != XCL_NO_SENSOR_DEV_LL ? m_devinfo.mXMCVersion : m_devinfo.mMBVersion) << "\n\n";
 
         ss << std::setw(16) << "DDR size" << std::setw(16) << "DDR count";
-        ss << std::setw(16) << "OCL Frequency";
+        ss << std::setw(16) << "Kernel Freq";
 
         subss << std::left << std::setw(16) << unitConvert(m_devinfo.mDDRSize);
         subss << std::setw(16) << m_devinfo.mDDRBankCount << std::setw(16) << " ";
@@ -239,7 +242,7 @@ public:
         }
         ss << "\n" << subss.str() << "\n\n";
 
-        ss << std::setw(16) << "PCIe" << std::setw(32) << "DMA bi-directional threads";
+        ss << std::setw(16) << "PCIe" << std::setw(32) << "DMA chan(bidir)";
         ss << std::setw(16) << "MIG Calibrated " << "\n";
 
         ss << "GEN " << m_devinfo.mPCIeLinkSpeed << "x" << std::setw(10) << m_devinfo.mPCIeLinkWidth;
@@ -413,7 +416,7 @@ public:
         else
             ss << std::setw(16) << std::to_string((float)m_devinfo.m1v8Top/1000).substr(0,4) + "V";
 
-  
+
 
         if(m_devinfo.m0v85 == XCL_NO_SENSOR_DEV_S)
             ss << std::setw(16) << "Not support" << "\n\n";
@@ -436,10 +439,10 @@ public:
 
 
         if(m_devinfo.m12vSW == XCL_NO_SENSOR_DEV_S)
-            ss << std::setw(16) << "Not support"; 
+            ss << std::setw(16) << "Not support";
         else if(m_devinfo.m12vSW == XCL_INVALID_SENSOR_VAL)
             ss << std::setw(16) << "Not support";
-        else 
+        else
             ss << std::setw(16) << std::to_string((float)m_devinfo.m12vSW/1000).substr(0,4) + "V";
 
 
@@ -482,7 +485,7 @@ public:
         m_devinfo_stringize_power(m_devinfo, lines);
 
         ss << std::right << std::setw(80) << std::setfill('#') << std::left << "\n";
-        lines.push_back(ss.str());         
+        lines.push_back(ss.str());
     }
 
     void m_devinfo_stringize(const xclDeviceInfo2& m_devinfo,
@@ -710,7 +713,7 @@ public:
                     stat_map[std::string(key)] = std::to_string(value);
                 }
 
-                ss << std::setw(16) << stat_map[std::string("total_req_bytes")] + 
+                ss << std::setw(16) << stat_map[std::string("total_req_bytes")] +
                     "/" + stat_map[std::string("total_req_num")];
 
                 ss << std::setw(16) << stat_map[std::string("total_complete_bytes")] +
@@ -732,7 +735,7 @@ public:
         std::vector<std::string> lines, usage_lines;
 
         m_devinfo_stringize(m_devinfo, lines);
- 
+
         for(auto line : lines) {
             ostr << line;
         }
@@ -829,8 +832,8 @@ public:
                     dev->mgmt->sysfs_get("dna", "status", errmsg, dnaStatus);
                     ostr << "\nIP[" << cuCnt << "]: "
                          << computeUnits.at( i ).m_name
-                         << "@0x" << std::hex << computeUnits.at( i ).m_base_address << " " 
-                         << std::dec << parseDNAStatus(dnaStatus) << "\n"; 
+                         << "@0x" << std::hex << computeUnits.at( i ).m_base_address << " "
+                         << std::dec << parseDNAStatus(dnaStatus) << "\n";
                     cuCnt++;
                 }
             }


### PR DESCRIPTION
Customers want to see the IDCODE (and FPGA part name) in xbutil query