### PR TITLE
Only release CU context if it was previously acquired

### DIFF
--- a/src/runtime_src/xocl/core/compute_unit.h
+++ b/src/runtime_src/xocl/core/compute_unit.h
@@ -115,6 +115,12 @@ public:
     return m_symbol->uid;
   }
 
+  context_type
+  get_context_type() const
+  {
+    return m_context_type;
+  }
+
 private:
 
   // Used by xocl::device to cache the acquire context for

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1249,6 +1249,9 @@ bool
 device::
 release_context(compute_unit* cu) const
 {
+  if (cu->get_context_type() == compute_unit::context_type::none)
+    return true;
+
   if (auto program = m_active) {
     auto xclbin = program->get_xclbin(this);
     auto xdevice = get_xrt_device();
@@ -1257,6 +1260,7 @@ release_context(compute_unit* cu) const
     cu->reset_context_type();
     return true;
   }
+
   return false;
 }
 


### PR DESCRIPTION
Fixes OpenCL Khronos test failure (basic_079).  We need an XRT unit test for multiple CU design where only a subset of CUs are used.