### PR TITLE
[Leak] free fpriv when release client.

### DIFF
--- a/src/runtime_src/driver/zynq/kernel2/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/driver/zynq/kernel2/drm/zocl/zocl_drv.c
@@ -259,6 +259,7 @@ static void zocl_client_release(struct drm_device *dev, struct drm_file *filp)
 		return;
 
 	zocl_untrack_ctx(dev, fpriv);
+	kfree(fpriv);
 
 	DRM_INFO("Pid %d closed device\n", pid_nr(task_tgid(current)));
 }


### PR DESCRIPTION
fpriv was not free in zocl_client_release().

