### PR TITLE
ECC mem controller support

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/devices.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/devices.h
@@ -52,6 +52,8 @@ struct xocl_subdev_info {
         char			*name;
         struct resource		*res;
         int			num_res;
+	void			*priv_data;
+	int			data_len;
 };
 
 struct xocl_board_private {
@@ -130,7 +132,7 @@ enum {
 #define	XOCL_MIG		"mig" SUBDEV_SUFFIX
 #define	XOCL_XMC		"xmc" SUBDEV_SUFFIX
 #define	XOCL_DNA		"dna" SUBDEV_SUFFIX
-enum {
+enum subdev_id {
 	XOCL_SUBDEV_FEATURE_ROM,
 	XOCL_SUBDEV_MM_DMA,
 	XOCL_SUBDEV_MB_SCHEDULER,
@@ -146,7 +148,7 @@ enum {
 	XOCL_SUBDEV_STR_DMA,
 	XOCL_SUBDEV_XMC,
 	XOCL_SUBDEV_DNA,
-        XOCL_SUBDEV_NUM
+	XOCL_SUBDEV_NUM
 };
 
 #define	XOCL_RES_FEATURE_ROM				\
@@ -184,36 +186,22 @@ enum {
 		ARRAY_SIZE(XOCL_RES_SYSMON),		\
 	}
 
-#define	XOCL_RES_MIG_6A8F					\
+/* Will be populated dynamically */
+#define	XOCL_RES_MIG					\
 		((struct resource []) {			\
 			{				\
-			.start	= 0x1000000,		\
-			.end 	= 0x10003FF,		\
+			.start	= 0x0,			\
+			.end 	= 0x3FF,		\
 			.flags  = IORESOURCE_MEM,	\
-			},				\
-			{				\
-			.start	= 0x70000,		\
-			.end 	= 0x703FF,		\
-			.flags  = IORESOURCE_MEM,	\
-			},				\
-			{				\
-			.start	= 0x1010000,		\
-			.end 	= 0x10103FF,		\
-			.flags  = IORESOURCE_MEM,	\
-			},				\
-			{				\
-			.start	= 0x1020000,		\
-			.end 	= 0x10203FF,		\
-			.flags  = IORESOURCE_MEM,	\
-			},				\
+			}				\
 		})
 
-#define	XOCL_DEVINFO_MIG_6A8F				\
+#define	XOCL_DEVINFO_MIG				\
 	{						\
 		XOCL_SUBDEV_MIG,			\
 		XOCL_MIG,				\
-		XOCL_RES_MIG_6A8F,			\
-		ARRAY_SIZE(XOCL_RES_MIG_6A8F),		\
+		XOCL_RES_MIG,				\
+		ARRAY_SIZE(XOCL_RES_MIG),		\
 	}
 
 
@@ -338,13 +326,14 @@ enum {
 	}
 
 
+/* Will be populated dynamically */
 #define	XOCL_RES_DNA					\
 	((struct resource []) {				\
 		{					\
-			.start	= 0x1100000,		\
-			.end	= 0x1100FFF,		\
+			.start	= 0x0,			\
+			.end	= 0xFFF,		\
 			.flags  = IORESOURCE_MEM,	\
-		},					\
+		}					\
 	})
 
 #define	XOCL_DEVINFO_DNA				\
@@ -806,7 +795,6 @@ enum {
 			XOCL_DEVINFO_XVC_PRI,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_MIG_6A8F,        \
 		})
 
 #define	XOCL_BOARD_MGMT_6A8F_DSA52					\
@@ -827,7 +815,6 @@ enum {
 			XOCL_DEVINFO_XVC_PRI,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_MIG_6A8F,        \
 		})
 
 #define	XOCL_BOARD_MGMT_XBB_DSA52					\

--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.c
@@ -752,7 +752,6 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	dev_set_drvdata(&pdev->dev, lro);
 	/* create a driver to device reference */
 	lro->core.pdev = pdev;
-	memset(lro->core.dyna_subdevs_id, 0xff, sizeof(u32) * XOCL_SUBDEV_NUM);
 	lro->pci_dev = pdev;
 	lro->ready = false;
 

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/dna.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/dna.c
@@ -162,30 +162,19 @@ static uint32_t dna_capability(struct platform_device *pdev)
 	return capability;
 }
 
-static void dna_write_cert(struct platform_device *pdev, const char __user *data, uint32_t len)
+static void dna_write_cert(struct platform_device *pdev, const uint32_t *cert, uint32_t len)
 {
 	struct xocl_xlnx_dna *xlnx_dna = platform_get_drvdata(pdev);
 	int i,j,k;
-	uint32_t *cert = NULL;
 	u32 status = 0, words;
 	uint8_t retries = 100;
 	bool sha256done = false;
 	uint32_t convert;
 	uint32_t sign_start, message_words = (len-512)>>2;
 	sign_start = message_words;
+
 	if (!xlnx_dna)
 		return;
-
-	cert = kmalloc(len, GFP_KERNEL);
-	if (!cert) {
-		xocl_err(&pdev->dev, "Failed to alloc buffer size 0x%x, out of memory", len);
-		return;
-	}
-	if (copy_from_user(cert, data, len)) {
-		xocl_err(&pdev->dev, "Failed to copy xclbin, out of memory");
-		goto copy_user_fail;
-	}
-
 
 	iowrite32(0x1, xlnx_dna->base+XLNX_DNA_MESSAGE_START_AXI_ONLY_REGISTER_OFFSET);
 	status = ioread32(xlnx_dna->base+XLNX_DNA_STATUS_REGISTER_OFFSET);
@@ -238,13 +227,11 @@ static void dna_write_cert(struct platform_device *pdev, const char __user *data
 	words  = ioread32(xlnx_dna->base+XLNX_DNA_FSM_CERTIFICATE_WORD_WRITE_COUNT_REGISTER_OFFSET);
 	xocl_info(&pdev->dev, "Signature: status %08x certificate words %d", status, words);
 
-copy_user_fail:
-	kfree(cert);
 	return;
 }
 
 static struct xocl_dna_funcs dna_ops = {
-	.status			= dna_status,
+	.status = dna_status,
 	.capability = dna_capability,
 	.write_cert = dna_write_cert,
 };

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/feature_rom.c
@@ -213,6 +213,9 @@ static bool verify_timestamp(struct platform_device *pdev, u64 timestamp)
 	rom = platform_get_drvdata(pdev);
 	BUG_ON(!rom);
 
+	xocl_info(&pdev->dev, "DSA timestamp: 0x%llx",
+		rom->header.TimeSinceEpoch);
+	xocl_info(&pdev->dev, "Verify timestamp: 0x%llx", timestamp);
 	return (rom->header.TimeSinceEpoch == timestamp);
 }
 
@@ -247,6 +250,7 @@ static int feature_rom_probe(struct platform_device *pdev)
 	struct resource *res;
 	u32	val;
 	u16	vendor, did;
+	char	*tmp;
 	int	ret;
 
 	rom = devm_kzalloc(&pdev->dev, sizeof(*rom), GFP_KERNEL);
@@ -345,7 +349,9 @@ static int feature_rom_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
-	xocl_info(&pdev->dev, "ROM magic : %s", rom->header.EntryPointString);
+	tmp = rom->header.EntryPointString;
+	xocl_info(&pdev->dev, "ROM magic : %c%c%c%c",
+		tmp[0], tmp[1], tmp[2], tmp[3]);
 	xocl_info(&pdev->dev, "VBNV: %s", rom->header.VBNVName);
 	xocl_info(&pdev->dev, "DDR channel count : %d",
 		rom->header.DDRChannelCount);

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -98,7 +98,8 @@ static inline bool uuid_is_null(const xuid_t *uuid)
 	(XDEV(xdev)->priv.mpsoc)
 
 #define	XOCL_DEV_ID(pdev)			\
-	PCI_DEVID(pdev->bus->number, pdev->devfn)
+	((pci_domain_nr(pdev->bus) << 16) |	\
+	PCI_DEVID(pdev->bus->number, pdev->devfn))
 
 #define XOCL_ARE_HOP 0x400000000ull
 
@@ -115,8 +116,7 @@ static inline bool uuid_is_null(const xuid_t *uuid)
 #define RHEL_P2P_SUPPORT  0
 #endif
 
-#define INVALID_SUBDEVICE 		~0U
-#define NUMS_OF_DYNA_IP_ADDR   4
+#define INVALID_SUBDEVICE ~0U
 
 extern struct class *xrt_class;
 
@@ -128,6 +128,15 @@ struct xocl_subdev {
 	struct platform_device 		*pldev;
 	void				*ops;
 };
+
+struct xocl_subdev_private {
+	int		id;
+	bool		is_multi;
+	char		priv_data[1];
+};
+
+#define	XOCL_GET_SUBDEV_PRIV(dev)				\
+	((struct xocl_subdev_private *)dev_get_platdata(dev))->priv_data
 
 typedef	void *	xdev_handle_t;
 
@@ -192,9 +201,6 @@ struct xocl_dev_core {
 	struct xocl_board_private priv;
 
 	char			ebuf[XOCL_EBUF_LEN + 1];
-
-	u32			dyna_subdevs_id[XOCL_SUBDEV_NUM];
-	u32			dyna_subdevs_num;
 };
 
 #define	XOCL_DSA_PCI_RESET_OFF(xdev_hdl)			\
@@ -412,7 +418,7 @@ struct xocl_mb_funcs {
 struct xocl_dna_funcs {
 	u32 (*status)(struct platform_device *pdev);
 	u32 (*capability)(struct platform_device *pdev);
-	void (*write_cert)(struct platform_device *pdev, const char __user *buf, u32 len);
+	void (*write_cert)(struct platform_device *pdev, const uint32_t *buf, u32 len);
 };
 
 #define	XMC_DEV(xdev)		\
@@ -563,15 +569,18 @@ xdev_handle_t xocl_get_xdev(struct platform_device *pdev);
 void xocl_init_dsa_priv(xdev_handle_t xdev_hdl);
 
 /* subdev functions */
+int xocl_subdev_create_multi_inst(xdev_handle_t xdev_hdl,
+	struct xocl_subdev_info *sdev_info);
 int xocl_subdev_create_one(xdev_handle_t xdev_hdl,
 	struct xocl_subdev_info *sdev_info);
 int xocl_subdev_create_all(xdev_handle_t xdev_hdl,
         struct xocl_subdev_info *sdev_info, u32 subdev_num);
 void xocl_subdev_destroy_one(xdev_handle_t xdev_hdl, u32 subdev_id);
 void xocl_subdev_destroy_all(xdev_handle_t xdev_hdl);
+void xocl_subdev_destroy_by_id(xdev_handle_t xdev_hdl, int id);
 
-uint32_t xocl_subdev_get_subid(uint32_t ip_type);
-int xocl_subdev_get_devinfo(struct xocl_subdev_info *subdev_info, struct resource *res, uint32_t sub_id);
+int xocl_subdev_get_devinfo(uint32_t subdev_id,
+	struct xocl_subdev_info *subdev_info, struct resource *res);
 
 void xocl_subdev_register(struct platform_device *pldev, u32 id,
 	void *cb_funcs);

--- a/src/runtime_src/driver/xclng/tools/xbutil/Makefile
+++ b/src/runtime_src/driver/xclng/tools/xbutil/Makefile
@@ -6,7 +6,7 @@ CL_EXT := cl
 AR := ar
 CXX := g++
 
-CXXFLAGS := -Wall -Werror -std=c++11 -pthread
+CXXFLAGS := -Wall -Werror -std=c++14 -pthread
 
 ROOT1 = $(dir $(dir $(CURDIR)))
 ROOT = $(ROOT1)..

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -685,6 +685,8 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "  list\n";
     std::cout << "  mem --read [-d card] [-a [0x]start_addr] [-i size_bytes] [-o output filename]\n";
     std::cout << "  mem --write [-d card] [-a [0x]start_addr] [-i size_bytes] [-e pattern_byte]\n";
+    std::cout << "  mem --query-ecc\n";
+    std::cout << "  mem --reset-ecc\n";
     std::cout << "  program [-d card] [-r region] -p xclbin\n";
     std::cout << "  query   [-d card [-r region]]\n";
     std::cout << "  reset   [-d card] [-h | -r region]\n";

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -231,7 +231,10 @@ int main(int argc, char *argv[])
         {"monitorfifolite", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
         {"monitorfifofull", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
         {"accelmonitor", no_argument, 0, xcldev::STATUS_UNSUPPORTED},
-        {"stream", no_argument, 0, xcldev::STREAM}
+        {"stream", no_argument, 0, xcldev::STREAM},
+        {"query-ecc", no_argument, 0, xcldev::MEM_QUERY_ECC},
+        {"reset-ecc", no_argument, 0, xcldev::MEM_RESET_ECC},
+        {0, 0, 0, 0}
     };
 
     int long_index;
@@ -301,6 +304,24 @@ int main(int argc, char *argv[])
                 return -1;
             }
             subcmd = xcldev::STREAM;
+            break;
+        }
+        case xcldev::MEM_QUERY_ECC : {
+            //--query-ecc
+            if (cmd != xcldev::MEM) {
+                std::cout << "ERROR: Option '" << long_options[long_index].name << "' cannot be used with command " << cmdname << "\n";
+                return -1;
+            }
+            subcmd = xcldev::MEM_QUERY_ECC;
+            break;
+        }
+        case xcldev::MEM_RESET_ECC : {
+            //--reset-ecc
+            if (cmd != xcldev::MEM) {
+                std::cout << "ERROR: Option '" << long_options[long_index].name << "' cannot be used with command " << cmdname << "\n";
+                return -1;
+            }
+            subcmd = xcldev::MEM_RESET_ECC;
             break;
         }
         //short options are dealt here
@@ -609,9 +630,12 @@ int main(int argc, char *argv[])
     case xcldev::MEM:
         if (subcmd == xcldev::MEM_READ) {
             result = deviceVec[index]->memread(outMemReadFile, startAddr, sizeInBytes);
-        }
-        else if (subcmd == xcldev::MEM_WRITE) {
+        } else if (subcmd == xcldev::MEM_WRITE) {
             result = deviceVec[index]->memwrite(startAddr, sizeInBytes, pattern_byte);
+        } else if(subcmd == xcldev::MEM_QUERY_ECC) {
+            result = deviceVec[index]->printEccInfo(std::cout);
+        } else if(subcmd == xcldev::MEM_RESET_ECC) {
+            result = deviceVec[index]->resetEccInfo();
         }
         break;
     case xcldev::DD:
@@ -1079,5 +1103,134 @@ int xcldev::xclValidate(int argc, char *argv[])
     }
 
     std::cout << "INFO: All cards validated successfully." << std::endl;
+    return 0;
+}
+
+static int getEccMemTags(const pcidev::pci_device *dev,
+    std::vector<std::string>& tags)
+{
+    std::string errmsg;
+    std::vector<char> buf;
+
+    dev->user->sysfs_get("", "mem_topology", errmsg, buf);
+    if (!errmsg.empty()) {
+        std::cout << errmsg << std::endl;
+        return -EINVAL;
+    }
+    const mem_topology *map = (mem_topology *)buf.data();
+
+    if(buf.empty() || map->m_count == 0) {
+        std::cout << "WARNING: 'mem_topology' not found, "
+            << "unable to query ECC info. Has the xclbin been loaded? "
+            << "See 'xbutil program'." << std::endl;
+        return -EINVAL;
+    }
+
+    // Only support DDR4 mem controller for ECC status
+    for(int32_t i = 0; i < map->m_count; i++) {
+        if(map->m_mem_data[i].m_type != MEM_DDR4 || !map->m_mem_data[i].m_used)
+            continue;
+        tags.emplace_back(
+            reinterpret_cast<const char *>(map->m_mem_data[i].m_tag));
+    }
+
+    if (tags.empty()) {
+        std::cout << "No supported ECC controller detected!" << std::endl;
+        return -ENOENT;
+    }
+
+    // See if xclbin contains ECC base addresses for supported in-use DDR type
+    unsigned onoff = 0;
+    dev->mgmt->sysfs_get(tags[0], "ecc_enabled", errmsg, onoff);
+    if (!errmsg.empty()) {
+        std::cout << "No supported ECC controller detected!" << std::endl;
+        return -ENOENT;
+    }
+
+    return 0;
+}
+
+static int eccStatus2String(unsigned int status, std::string& str)
+{
+    const int ce_mask = (0x1 << 1);
+    const int ue_mask = (0x1 << 0);
+
+    str.clear();
+
+    // If unknown status bits, can't support.
+    if (status & ~(ce_mask | ue_mask)) {
+        std::cout << "Bad ECC status detected!" << std::endl;
+        return -EINVAL;
+    }
+
+    if (status == 0) {
+        str = "(None)";
+        return 0;
+    }
+
+    if (status & ue_mask)
+        str += "UE ";
+    if (status & ce_mask)
+        str += "CE ";
+    // Remove the trailing space.
+    str.pop_back();
+    return 0;
+}
+
+int xcldev::device::printEccInfo(std::ostream& ostr) const
+{
+    std::string errmsg;
+    std::vector<std::string> tags;
+    auto dev = pcidev::get_dev(m_idx);
+
+    int err = getEccMemTags(dev, tags);
+    if (err)
+        return err;
+
+    // Report ECC status
+    ostr << std::endl;
+    ostr << std::left << std::setw(16) << "Tag" << std::setw(12) << "Errors"
+        << std::setw(12) << "CE Count" << std::setw(20) << "CE FFA"
+        << std::setw(20) << "UE FFA" << std::endl;
+    for (auto tag : tags) {
+        unsigned status = 0;
+        std::string st;
+        dev->mgmt->sysfs_get(tag, "ecc_status", errmsg, status);
+        err = eccStatus2String(status, st);
+        if (err)
+            return err;
+
+        unsigned ce_cnt = 0;
+        dev->mgmt->sysfs_get(tag, "ecc_ce_cnt", errmsg, ce_cnt);
+        uint64_t ce_ffa = 0;
+        dev->mgmt->sysfs_get(tag, "ecc_ce_ffa", errmsg, ce_ffa);
+        uint64_t ue_ffa = 0;
+        dev->mgmt->sysfs_get(tag, "ecc_ue_ffa", errmsg, ue_ffa);
+        ostr << std::left << std::setw(16) << tag << std::setw(12) << st
+            << std::setw(12) << ce_cnt << "0x" << std::setw(18) << std::hex
+            << ce_ffa << "0x" << std::setw(18) << ue_ffa << std::endl;
+    }
+    ostr << std::endl;
+    return 0;
+}
+
+int xcldev::device::resetEccInfo()
+{
+    std::string errmsg;
+    std::vector<std::string> tags;
+    auto dev = pcidev::get_dev(m_idx);
+
+    if ((getuid() != 0) && (geteuid() != 0)) {
+        std::cout << "ERROR: root privileges required." << std::endl;
+        return -EPERM;
+    }
+
+    int err = getEccMemTags(dev, tags);
+    if (err)
+        return err;
+
+    std::cout << "Resetting ECC info..." << std::endl;
+    for (auto tag : tags)
+        dev->mgmt->sysfs_put(tag, "ecc_reset", errmsg, "1");
     return 0;
 }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -80,7 +80,9 @@ enum subcommand {
     STATUS_LAPC,
     STATUS_SSPM,
     STREAM,
-    STATUS_UNSUPPORTED
+    STATUS_UNSUPPORTED,
+    MEM_QUERY_ECC,
+    MEM_RESET_ECC
 };
 enum statusmask {
     STATUS_NONE_MASK = 0x0,
@@ -113,7 +115,9 @@ static const std::pair<std::string, subcommand> subcmd_pairs[] = {
     std::make_pair("spm", STATUS_SPM),
     std::make_pair("lapc", STATUS_LAPC),
     std::make_pair("sspm", STATUS_SSPM),
-    std::make_pair("stream", STREAM)
+    std::make_pair("stream", STREAM),
+    std::make_pair("query-ecc", MEM_QUERY_ECC),
+    std::make_pair("reset-ecc", MEM_RESET_ECC)
 };
 
 static const std::vector<std::pair<std::string, std::string>> flash_types = {
@@ -1207,6 +1211,9 @@ public:
     }
 
     int validate(bool quick);
+
+    int printEccInfo(std::ostream& ostr) const;
+    int resetEccInfo();
 
 private:
     // Run a test case as <exe> <xclbin> [-d index] on this device and collect


### PR DESCRIPTION
This change is to support ECC controllers. The xbutil mem --query-ecc is added to report ECC errors. The xbutil mem --reset-ecc is added to reset ECC error status.