### PR TITLE
various bug fixes

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -2120,6 +2120,10 @@ static int icap_remove(struct platform_device *pdev)
 static void icap_probe_chip(struct icap *icap)
 {
 	u32 w;
+
+	if (!ICAP_PRIVILEGED(icap))
+		return;
+
 	w = reg_rd(&icap->icap_regs->ir_sr);
 	w = reg_rd(&icap->icap_regs->ir_sr);
 	reg_wr(&icap->icap_regs->ir_gier, 0x0);

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -2077,7 +2077,7 @@ kds_custat_show(struct device *dev, struct device_attribute *attr, char *buf)
 	struct xocl_dev *xdev = exec_get_xdev(exec);
 	struct client_ctx client;
 	struct ert_packet packet;
-	unsigned int count;
+	unsigned int count = 0;
 	ssize_t sz = 0;
 
 	/* minimum required initialization of client */

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_bo.c
@@ -452,7 +452,6 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 	//unsigned bar_mapped = (args->flags & DRM_XOCL_BO_P2P) ? 1 : 0;
 	unsigned bar_mapped = (args->type & DRM_XOCL_BO_P2P) ? 1 : 0;
 	uint64_t base_addr_offset;
-	base_addr_offset = xdev->topology->m_mem_data[0].m_base_address;
 
 //	//Only one bit should be set in ddr. Other bits are now in "type"
 //	if (hweight_long(ddr) > 1)
@@ -477,6 +476,7 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		return PTR_ERR(xobj);
 	}
 
+	base_addr_offset = xdev->topology->m_mem_data[0].m_base_address;
 	if(bar_mapped){
 		if((xobj->mm_node->start - base_addr_offset
 			   + xobj->mm_node->size) > xdev->bypass_bar_len){

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_sysfs.c
@@ -52,7 +52,6 @@ static DEVICE_ATTR_RO(user_pf);
 static ssize_t kdsstat_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-	int i;
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 	int size = sprintf(buf,
 			   "xclbin:\t\t\t%pUl\noutstanding execs:\t%d\ntotal execs:\t\t%ld\ncontexts:\t\t%d\n",

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -336,8 +336,10 @@ struct xocl_mb_scheduler_funcs {
         -ENODEV)
 #define	XOCL_IS_DDR_USED(xdev, ddr)		\
 	(xdev->topology->m_mem_data[ddr].m_used == 1)
+#define	XOCL_DDR_COUNT_UNIFIED(xdev)		\
+	((xdev)->topology ? (xdev)->topology->m_count : 0)
 #define	XOCL_DDR_COUNT(xdev)			\
-	((xocl_is_unified(xdev) ? xdev->topology->m_count :	\
+	((xocl_is_unified(xdev) ? XOCL_DDR_COUNT_UNIFIED(xdev) :	\
 	xocl_get_ddr_channel_count(xdev)))
 
 /* sysmon callbacks */


### PR DESCRIPTION
Fixed a few bugs in driver xocl:
1. icap->icap_regs is NULL in xocl, can't be dereferenced in icap_probe_chip().
2. count in kds_custat_show() should be initialized before comparing to 20.
3. xdev->topology maybe NULL when no xclbin is ever downloaded.
4. i in kdsstat_show() is not used, causing compilation warning.