### PR TITLE
Drop crude uuid hack in xclbin.h in favor of standard uuid/uuid.h

### DIFF
--- a/src/runtime_src/driver/include/xclbin.h
+++ b/src/runtime_src/driver/include/xclbin.h
@@ -47,19 +47,14 @@
 #include <cstdlib>
 #include <cstdint>
 #include <algorithm>
+#include <uuid/uuid.h>
 #else
 #include <stdlib.h>
 #include <stdint.h>
+#include <uuid/uuid.h>
 #endif
 
 #if !defined(__KERNEL__)
-#if !defined _UUID_UUID_H
-/*
- * Crude workaround to define uuid_t till we start including "uuid/uuid.h" from
- * "/usr/include" area
- */
-typedef unsigned char uuid_t[16];
-#endif
 typedef uuid_t xuid_t;
 #else //(__KERNEL__)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
@@ -366,7 +361,7 @@ extern "C" {
     {
         CST_UNKNOWN = 0,
         CST_SDBM = 1,
-        CST_LAST 
+        CST_LAST
     };
 
     /**** END : Xilinx internal section *****/

--- a/src/runtime_src/driver/include/xclhal2.h
+++ b/src/runtime_src/driver/include/xclhal2.h
@@ -18,8 +18,6 @@
 #ifndef _XCL_HAL2_H_
 #define _XCL_HAL2_H_
 
-//#include <uuid.h>
-
 #ifdef __cplusplus
 #include <cstdlib>
 #include <cstdint>
@@ -43,14 +41,6 @@
 #include "xclperf.h"
 #include "xcl_app_debug.h"
 #include "xclerr.h"
-
-#ifndef _UUID_UUID_H
-/*
- * Crude workaround to define uuid_t till we start including "uuid/uuid.h" from
- * "/usr/include" area
- */
-typedef unsigned char uuid_t[16];
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -1173,8 +1163,8 @@ XCL_DRIVER_DLLESPEC ssize_t xclReadQueue(xclDeviceHandle handle, uint64_t q_hdl,
  * @timeout:		timeout
  *
  * return number of requests been completed.
- */ 
-XCL_DRIVER_DLLESPEC int xclPollCompletion(xclDeviceHandle handle, int min_compl, int max_compl, xclReqCompletion *comps, int* actual_compl, int timeout); 
+ */
+XCL_DRIVER_DLLESPEC int xclPollCompletion(xclDeviceHandle handle, int min_compl, int max_compl, xclReqCompletion *comps, int* actual_compl, int timeout);
 
 /* Hack for xbflash only */
 XCL_DRIVER_DLLESPEC char *xclMapMgmt(xclDeviceHandle handle);

--- a/src/runtime_src/driver/xclng/include/xocl_ioctl.h
+++ b/src/runtime_src/driver/xclng/include/xocl_ioctl.h
@@ -82,9 +82,11 @@
 #elif defined(__cplusplus)
 #include <cstdlib>
 #include <cstdint>
+#include <uuid/uuid.h>
 #else
 #include <stdlib.h>
 #include <stdint.h>
+#include <uuid/uuid.h>
 #endif
 
 #if defined(__KERNEL__)


### PR DESCRIPTION
uuid package has been a requirement for some time now. Remove our UUID hack from xclbin.