### PR TITLE
check if AppDebug is loaded and print user friendly error message if not loaded

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebug.py
+++ b/src/runtime_src/xdp/appdebug/appdebug.py
@@ -69,7 +69,10 @@ class infCallUtil():
 		return free_args, ptr, ""
 	
 	def check_app_debug_enabled(self):
-		isEnabled = self.callfunc("appdebug::isAppdebugEnabled", [])
+		try:
+			isEnabled = self.callfunc("appdebug::isAppdebugEnabled", [])
+		except:
+			raise ValueError("Application debug not available. Application debug will be available after the first OpenCL API call.")
 		if str(isEnabled) == "false":
 			raise ValueError("Application debug not enabled. Set attribute 'app_debug=true' under 'Debug' section of sdaccel.ini and restart application")
 		return


### PR DESCRIPTION
## CR fixing

### Issue 
some users were trying to use AppDebug before the very first OpenCL call which means AppDebug library is not loaded. Previously a system error will show up in Xgdb. 

### Fix
I have changed the behavior to catch the error and print a message to let the user know it will be available after the first OpenCL call.