### PR TITLE
Updated CMakeLists.txt to find only static boost libraries.

### DIFF
--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -1,13 +1,14 @@
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../../driver/include
   )
-
+set(Boost_USE_STATIC_LIBS ON)               # Only find static libraries
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 
 # -----------------------------------------------------------------------------
 
 include_directories(${CMAKE_BINARY_DIR}/gen)
 
+set(VERBOSE 1)
 # -----------------------------------------------------------------------------
 
 file(GLOB XCLBINCAT_FILES
@@ -45,7 +46,7 @@ target_link_libraries(xclbinsplit -static ${Boost_LIBRARIES})
 # produce "Command not found" when running the executable.
 #   Therefore, we direct CMake to end with static, so that it doesn't do that:
 set_target_properties(xclbinsplit PROPERTIES LINK_SEARCH_END_STATIC 1)
-
+ 
 # -----------------------------------------------------------------------------
 
 file(GLOB XCLBINUTIL_FILES

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 
 include_directories(${CMAKE_BINARY_DIR}/gen)
 
-set(VERBOSE 1)
 # -----------------------------------------------------------------------------
 
 file(GLOB XCLBINCAT_FILES


### PR DESCRIPTION
Note: Prior to this change both the dynamic and static boost libraries were
being found.  Unfortunately, this led to compilation issues when CMAKE_MINIMUM_REQUIRED was updated to 3.5.1.

Note: This pull request addresses issue #645 . 