### PR TITLE
disabling ert for QDMA platform to match hardware functionality

### DIFF
--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/mbscheduler.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/mbscheduler.cxx
@@ -75,6 +75,10 @@ namespace xclhwemhal2 {
       cu_addr_map[i] = 0;
       cu_usage[i] = 0;
     }
+    
+    for (unsigned int i=0; i<MAX_U32_CU_MASKS; ++i)
+      cu_status[i] = 0;
+      
     ert = true;
     
     num_slot_masks = 1;
@@ -137,7 +141,9 @@ namespace xclhwemhal2 {
   
   unsigned int getFirstSetBitPos(int n) 
   { 
-    return log2(n & -n) + 1; 
+    if(!n)
+      return -1;
+    return log2(n & -n) ; 
   } 
 
   int MBScheduler::get_free_cu(struct xocl_cmd *xcmd)
@@ -349,7 +355,7 @@ namespace xclhwemhal2 {
         exec->cu_addr_map[i] = cfg->data[i];
       }
 
-      if (cfg->ert) 
+      if (cfg->ert && mParent->isMBSchedulerEnabled())
       {
         exec->ert=true;
         exec->polling_mode = 1; //cfg->polling;
@@ -357,7 +363,7 @@ namespace xclhwemhal2 {
       }
       else 
       {
-        //exec->ert=false;
+        exec->ert=false;
         exec->polling_mode = 1; //cfg->polling;
       }
       return 0;

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
@@ -1433,13 +1433,16 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
   bool HwEmShim::isMBSchedulerEnabled()
   {
     bool mbSchEnabled = mFeatureRom.FeatureBitMap & FeatureBitMask::MB_SCHEDULER;
-    return mbSchEnabled;
+    bool QDMAPlatform = (getDsaVersion() == 60)? true: false;
+    return mbSchEnabled && !QDMAPlatform;
   }
 
   //following code is copied from driver/xclng/drm/xocl/subdev/feature_rom.c
   unsigned int HwEmShim::getDsaVersion()
   {
-    std::string vbnv (mFeatureRom.VBNVName, mFeatureRom.VBNVName + sizeof(mFeatureRom.VBNVName)/sizeof(mFeatureRom.VBNVName[0]));
+    std::string vbnv  = mDeviceInfo.mName;
+    if(vbnv.empty())
+      return 52;
     if (vbnv.find("5_0") != std::string::npos)
       return 50;
     else if ( (vbnv.find("5_1") != std::string::npos)


### PR DESCRIPTION
Hi All,

This change contains disabling ERT for QDMA platform. This change is made to match the hardware functionality. Same change has been made in hardware couple of weeks ago.

Thanks
Vamshi Krishna