### PR TITLE
Bug Fix: Kernel information was not being displayed when using hierachy JSON queries.

### DIFF
--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -289,7 +289,8 @@ reportXclbinInfo( std::ostream & _ostream,
   {
     std::string sKernels;
     if (!_ptMetaData.empty()) {
-      std::vector<boost::property_tree::ptree> userRegions = as_vector<boost::property_tree::ptree>(_ptMetaData,"xclbin.user_regions");
+      boost::property_tree::ptree &ptXclBin = _ptMetaData.get_child("xclbin");
+      std::vector<boost::property_tree::ptree> userRegions = as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
       for (auto & userRegion : userRegions) {
         std::vector<boost::property_tree::ptree> kernels = as_vector<boost::property_tree::ptree>(userRegion,"kernels");
         for (auto & kernel : kernels) {
@@ -641,7 +642,8 @@ reportKernels( std::ostream & _ostream,
     }
   }
 
-  std::vector<boost::property_tree::ptree> userRegions = as_vector<boost::property_tree::ptree>(_ptMetaData,"xclbin.user_regions");
+  boost::property_tree::ptree &ptXclBin = _ptMetaData.get_child("xclbin");
+  std::vector<boost::property_tree::ptree> userRegions = as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
   for (auto & userRegion : userRegions) {
     std::vector<boost::property_tree::ptree> kernels = as_vector<boost::property_tree::ptree>(userRegion,"kernels");
     for (auto & ptKernel : kernels) {


### PR DESCRIPTION
Issue: There was a problem where Kernels were not being listed when using JSON hierarchy queries and the as_vector<> template.

This issue has been address by first getting the base ptree child and then calling as_vector<>.