### PR TITLE
Properly set AWS_FPGA_REPO_DIR for F1 builds

### DIFF
--- a/src/runtime_src/driver/xclng/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Set INTERNAL_TESTING variable by setting the shell environment 
 # variable "AWS_F1_TARGET" when invoking build.sh or cmake. If it
 # is not defined, default to INTERNAL_TESTING = 1.
-if( $ENV{AWS_FPGA_REPO_DIR} )
+if(DEFINED ENV{AWS_FPGA_REPO_DIR} )
+    set(AWS_FPGA_REPO_DIR $ENV{AWS_FPGA_REPO_DIR})
     set(INTERNAL_TESTING 0)
 else()
     set(INTERNAL_TESTING 1) 

--- a/src/runtime_src/driver/xclng/tools/awssak/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/awssak/CMakeLists.txt
@@ -23,8 +23,8 @@ if(${INTERNAL_TESTING})
     rt
     )
 else()
-  include_directories(../../../../../../../sdk/userspace/include/) # path to fpga_mgmt.h
-  set(AWS_FPGA_MGMT_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../../sdk/userspace/lib)
+  include_directories(${AWS_FPGA_REPO_DIR}/sdk/userspace/include/) # path to fpga_mgmt.h
+  set(AWS_FPGA_MGMT_LIB_DIR ${AWS_FPGA_REPO_DIR}/sdk/userspace/lib)
 
   target_link_libraries(awssak
     xrt_awsstatic

--- a/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
@@ -63,7 +63,7 @@ if(${INTERNAL_TESTING})
   rt
   )
 else()
-  set(AWS_FPGA_MGMT_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../../sdk/userspace/lib)
+  set(AWS_FPGA_MGMT_LIB_DIR ${AWS_FPGA_REPO_DIR}/sdk/userspace/lib)
   target_link_libraries(xrt_aws
   pthread
   rt

--- a/src/runtime_src/driver/xclng/xrt/user_aws/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(${INTERNAL_TESTING})
   add_definitions(-DINTERNAL_TESTING)
 else()
-  include_directories(../../../../../../../sdk/userspace/include/)
+  include_directories(${AWS_FPGA_REPO_DIR}/sdk/userspace/include/)
 endif()
 
 include_directories(


### PR DESCRIPTION
Needed for 2018.2_XDF Release Candidate.