### PR TITLE
Multiprocess work around for xclbin locking and icap reset of kds

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -474,20 +474,20 @@ add_xcmd(struct xocl_cmd *xcmd)
 {
 	struct xocl_dev *xdev = xocl_get_xdev(xcmd->exec->pdev);
 
-	SCHED_DEBUGF("-> add_xcmd(%lu)\n",xcmd->id);
+	SCHED_DEBUGF("-> add_xcmd(%lu) pid(%d)\n",xcmd->id,pid_nr(task_tgid(current)));
 
 	cmd_set_state(xcmd,ERT_CMD_STATE_NEW);
 	mutex_lock(&pending_cmds_mutex);
 	list_add_tail(&xcmd->list,&pending_cmds);
+	atomic_inc(&num_pending);
 	mutex_unlock(&pending_cmds_mutex);
 
 	/* wake scheduler */
-	atomic_inc(&num_pending);
 	atomic_inc(&xdev->outstanding_execs);
 	atomic64_inc(&xdev->total_execs);
 	wake_up_interruptible(&xcmd->xs->wait_queue);
 
-	SCHED_DEBUGF("<- add_xcmd opcode(%d) type(%d)\n",opcode(xcmd),type(xcmd));
+	SCHED_DEBUGF("<- add_xcmd opcode(%d) type(%d) num_pending(%d)\n",opcode(xcmd),type(xcmd),atomic_read(&num_pending));
 	return 0;
 }
 

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -188,7 +188,7 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	if (bitmap_empty(client->cu_bitmap, MAX_CUS))
+	if (bitmap_empty(client->cu_bitmap, MAX_CUS) && uuid_is_null(&client->xclbin_id))
 		// Process has no other context on any CU yet, hence we need to lock the xclbin
 		// A process uses just one lock for all its contexts
 		acquire_lock = true;
@@ -693,8 +693,12 @@ done:
 	 * Always give up ownership for multi process use case; the real locking
 	 * is done by context creation API
 	 */
+#if 0   // doesn't quite work because icap reset scheduler when the lock falls to 0
+	// and no lock is acquire by configure.  Even if configure locked xclbin
+	// it would have to unlock when done and lock could again go 0.
 	(void) xocl_icap_unlock_bitstream(xdev, &bin_obj.m_header.uuid,
 					  pid_nr(task_tgid(current)));
+#endif
 	printk(KERN_INFO "%s err: %ld\n", __FUNCTION__, err);
 	vfree(axlf);
 	return err;

--- a/src/runtime_src/xrt/scheduler/kds.cpp
+++ b/src/runtime_src/xrt/scheduler/kds.cpp
@@ -267,7 +267,7 @@ init(xrt::device* device, size_t regmap_size, bool cu_isr, size_t num_cus, size_
   // payload size
   epacket->count = 5 + cu_addr_map.size();
 
-  XRT_DEBUG(std::cout,"configure scheduler\n");
+  XRT_DEBUG(std::cout,"configure scheduler(",getpid(),")\n");
   auto exec_bo = configure->get_exec_bo();
   device->exec_buf(exec_bo);
 
@@ -285,7 +285,7 @@ init(xrt::device* device, size_t regmap_size, bool cu_isr, size_t num_cus, size_
     s_device_monitor_threads.emplace(device,xrt::thread(::monitor,device));
   }
 
-  XRT_DEBUG(std::cout,"configure complete\n");
+  XRT_DEBUG(std::cout,"configure complete(",getpid(),")\n");
 }
 
 }} // kds,xrt


### PR DESCRIPTION
Fixes problem related to xclbin locking and icap reset of kds as part of AXI reset.  The AXI reset is performed when a process tries to download an xclbin (icap_download_bitstream_axlf) *and* that xclbin is unused (first download or already downloaded but unlocked).

- P1 downloads xclbin calling xocl_read_axlf_helper
-- not locked so resets AXI => resets KDS
-- aquires xclbin lock (ref=1)
-- releases xclbin lock (ref=0)
- P1 configures scheduler
-- This does not mess with xclbin locking, which remains ref=0
-- Configure command enters KDS command queue
-- P1 waits in execWait for configure command to complete
- P2 downloads xclbin
-- not locked so resets AXI => resets KDS
-- The pending P1 configure command is ‘stale’ from KDSs perspective, this is the point of reset, so the command is removed
-- acquires xclbin lock (ref=1)
-- releases xclbin lock (ref=0)

If P1 is slow getting serviced by KDS, P1 will never complete, it hangs in xclExecWait for configure command.

The work-around is to not release lock after xclbin download, meaning that all processes must agree to same xclbin.