### PR TITLE
Lock xclbin prior to using KDS

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -474,20 +474,20 @@ add_xcmd(struct xocl_cmd *xcmd)
 {
 	struct xocl_dev *xdev = xocl_get_xdev(xcmd->exec->pdev);
 
-	SCHED_DEBUGF("-> add_xcmd(%lu)\n",xcmd->id);
+	SCHED_DEBUGF("-> add_xcmd(%lu) pid(%d)\n",xcmd->id,pid_nr(task_tgid(current)));
 
 	cmd_set_state(xcmd,ERT_CMD_STATE_NEW);
 	mutex_lock(&pending_cmds_mutex);
 	list_add_tail(&xcmd->list,&pending_cmds);
+	atomic_inc(&num_pending);
 	mutex_unlock(&pending_cmds_mutex);
 
 	/* wake scheduler */
-	atomic_inc(&num_pending);
 	atomic_inc(&xdev->outstanding_execs);
 	atomic64_inc(&xdev->total_execs);
 	wake_up_interruptible(&xcmd->xs->wait_queue);
 
-	SCHED_DEBUGF("<- add_xcmd opcode(%d) type(%d)\n",opcode(xcmd),type(xcmd));
+	SCHED_DEBUGF("<- add_xcmd opcode(%d) type(%d) num_pending(%d)\n",opcode(xcmd),type(xcmd),atomic_read(&num_pending));
 	return 0;
 }
 
@@ -1878,6 +1878,7 @@ create_client(struct platform_device *pdev, void **priv)
 
 	client->pid = task_tgid(current);
 	mutex_init(&client->lock);
+	atomic_set(&client->xclbin_locked,false);
 	atomic_set(&client->trigger, 0);
 	atomic_set(&client->abort, 0);
 	atomic_set(&client->outstanding_execs, 0);

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -140,6 +140,7 @@ struct xocl_dev	{
 struct client_ctx {
 	struct list_head	link;
 	xuid_t                  xclbin_id;
+	atomic_t                xclbin_locked;
 	atomic_t		trigger;
 	atomic_t                outstanding_execs;
 	atomic_t                abort;

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
@@ -210,10 +210,8 @@ static void xocl_client_release(struct drm_device *dev, struct drm_file *filp)
 		bit = find_next_bit(client->cu_bitmap, xdev->layout->m_count, bit + 1);
 	}
 	bitmap_zero(client->cu_bitmap, MAX_CUS);
-	if (!uuid_is_null(&client->xclbin_id)) {
-		(void) xocl_icap_unlock_bitstream(xdev, &client->xclbin_id,
-			pid_nr(task_tgid(current)));
-	}
+	if (atomic_read(&client->xclbin_locked))
+		(void) xocl_icap_unlock_bitstream(xdev, &client->xclbin_id,pid_nr(task_tgid(current)));
 
 	if (MB_SCHEDULER_DEV(xdev))
 		xocl_exec_destroy_client(xdev, &filp->driver_priv);

--- a/src/runtime_src/xrt/scheduler/kds.cpp
+++ b/src/runtime_src/xrt/scheduler/kds.cpp
@@ -267,7 +267,7 @@ init(xrt::device* device, size_t regmap_size, bool cu_isr, size_t num_cus, size_
   // payload size
   epacket->count = 5 + cu_addr_map.size();
 
-  XRT_DEBUG(std::cout,"configure scheduler\n");
+  XRT_DEBUG(std::cout,"configure scheduler(",getpid(),")\n");
   auto exec_bo = configure->get_exec_bo();
   device->exec_buf(exec_bo);
 
@@ -285,7 +285,7 @@ init(xrt::device* device, size_t regmap_size, bool cu_isr, size_t num_cus, size_
     s_device_monitor_threads.emplace(device,xrt::thread(::monitor,device));
   }
 
-  XRT_DEBUG(std::cout,"configure complete\n");
+  XRT_DEBUG(std::cout,"configure complete(",getpid(),")\n");
 }
 
 }} // kds,xrt


### PR DESCRIPTION
Fixes problem related to xclbin locking and icap reset of kds as part of AXI reset.  The AXI reset is performed when a process tries to download an xclbin (icap_download_bitstream_axlf) *and* that xclbin is unused (first download or already downloaded but unlocked).

- P1 downloads xclbin calling xocl_read_axlf_helper
-- not locked so resets AXI => resets KDS
-- aquires xclbin lock (ref=1)
-- releases xclbin lock (ref=0)
- P1 configures scheduler
-- This does not mess with xclbin locking, which remains ref=0
-- Configure command enters KDS command queue
-- P1 waits in execWait for configure command to complete
- P2 downloads xclbin
-- not locked so resets AXI => resets KDS
-- The pending P1 configure command is ‘stale’ from KDSs perspective, this is the point of reset, so the command is removed
-- acquires xclbin lock (ref=1)
-- releases xclbin lock (ref=0)

If P1 is slow getting serviced by KDS, P1 will never complete, it hangs in xclExecWait for configure command.

The fix in this PR is to lock the xclbin for a client context prior to submitting a command to KDS.  The xclbin is locked only if necessary, no repeated attempts to lock an already locked xclbin.

Error check that context locks the expected xclbin, not some xclbin swapped in by another process.

A process must now acquire a context on the device (lock the xclbin) before submitting any commands to the scheduler.  In this PR the lock on the xclbin lock is acquired implicitly if necessary, but if and only if the current process did indeed download the xclbin.