### PR TITLE
Add checks for the existence of AppDebug library before invoking gdb call

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebugint.py
+++ b/src/runtime_src/xdp/appdebug/appdebugint.py
@@ -104,6 +104,11 @@ class xstatusSPMInfo (gdb.Command,infCallUtil):
 		super (xstatusSPMInfo, self).__init__ ("xstatus spm", 
                          gdb.COMMAND_USER)
 	def invoke (self, arg, from_tty):
+		try:
+			self.check_app_debug_enabled()
+		except ValueError as e:
+			print (e.message)
+			return
 		obj_spm.invoke(arg, 0)
 xstatusSPMInfo()
 class xstatusSSPMInfo (gdb.Command,infCallUtil):
@@ -112,6 +117,11 @@ class xstatusSSPMInfo (gdb.Command,infCallUtil):
 		super (xstatusSSPMInfo, self).__init__ ("xstatus sspm", 
                          gdb.COMMAND_USER)
 	def invoke (self, arg, from_tty):
+		try:
+			self.check_app_debug_enabled()
+		except ValueError as e:
+			print (e.message)
+			return
 		obj_sspm.invoke(arg, 0)
 xstatusSSPMInfo()
 
@@ -121,6 +131,11 @@ class xstatusLAPCInfo (gdb.Command,infCallUtil):
 		super (xstatusLAPCInfo, self).__init__ ("xstatus lapc", 
                          gdb.COMMAND_USER)
 	def invoke (self, arg, from_tty):
+		try:
+			self.check_app_debug_enabled()
+		except ValueError as e:
+			print (e.message)
+			return
 		obj_lapc.invoke(arg, 0)
 xstatusLAPCInfo()
 
@@ -130,6 +145,11 @@ class xstatusAllInfo (gdb.Command,infCallUtil):
 		super (xstatusAllInfo, self).__init__ ("xstatus all", 
                          gdb.COMMAND_USER)
 	def invoke (self, arg, from_tty):
+		try:
+			self.check_app_debug_enabled()
+		except ValueError as e:
+			print (e.message)
+			return
 		obj_spm.invoke(arg, 0)
 		obj_lapc.invoke(arg, 0)
 xstatusAllInfo()


### PR DESCRIPTION
**Change description:**
Add checks for the existence of AppDebug library before invoking gdb calls and throw warning message to let users know AppDebug will only be available when loaded by the first OpenCL API call.

**Issue reported from CR:**
AppDebug throws Python exception when called xstatus all in xgdb

**Cause:**
AppDebug xstatus is not checking the existence of C library before invoking the symbol call

**Fix:**
add checks and catch the exception. Then print out warning information

**Behavious before fix:**
```bash
(gdb) xstatus all
Python Exception <class 'gdb.error'> No symbol "appdebug" in current context.: 
Error occurred in Python command: No symbol "appdebug" in current context.
```

**Behavious after fix:**
```bash
(gdb) xstatus all
Application debug not available. Application debug will be available after the first OpenCL API call.

(gdb) 
149	    q.enqueueMigrateMemObjects({buffer_a,buffer_b},0/* 0 means from host*/);

(gdb) xstatus all
SDx Performance Monitor Counters
CU Name         AXI Portname                Write Bytes       Write Tranx.      Read Bytes        Read Tranx.       Outstanding Cnt   Last Wr Addr      Last Wr Data      Last Rd Addr      Last Rd Data    
slr0            axi_cdc_data_M_AXI          0                 0                 0                 0                 0                 0x0                 0                 0x0                 0               
slr1            axi_cdc_data_static_M_AXI   32768             128               0                 0                 0                 0x0                 0                 0x3f00              10              
slr1            axi_cdc_data_dynamic_M_AXI  0                 0                 0                 0                 0                 0x0                 0                 0x0                 0               
slr2            axi_cdc_data_M_AXI          0                 0                 0                 0                 0                 0x0                 0                 0x0                 0               
krnl_vadd_1     M_AXI_GMEM-DDR[0]           0                 0                 0                 0                 0                 0x0                 0                 0x0                 0               

Light-weight AXI protocol checker status
No AXI violations found 
```
