### PR TITLE
keep dna with blank certificate

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -1896,8 +1896,10 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 			if (alloc_and_get_axlf_section(icap, copy_buffer,
 				DNA_CERTIFICATE, buffer,
 				(void **)&cert, &section_size) != 0) {
+
+				// We keep dna sub device if IP_DNASC presents
 				ICAP_ERR(icap, "Can't get certificate section");
-				goto done;
+				goto dna_cert_fail;
 			}
 
 			ICAP_INFO(icap, "DNA Certificate Size 0x%llx", section_size);
@@ -1915,7 +1917,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 			err = 0; /* xclbin is valid */
 		} else {
 			ICAP_ERR(icap, "DNA inside xclbin is invalid");
-			goto done;
+			goto dna_cert_fail;
 		}
 	}
 
@@ -1945,6 +1947,7 @@ done:
 		xocl_subdev_destroy_by_id(xdev, XOCL_SUBDEV_DNA);
 		xocl_subdev_destroy_by_id(xdev, XOCL_SUBDEV_MIG);
 	}
+dna_cert_fail:
 	mutex_unlock(&icap->icap_lock);
 	vfree(layout);
 	vfree(memtopo);

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_subdev.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_subdev.c
@@ -310,6 +310,7 @@ static void xocl_subdev_destroy_common(xdev_handle_t xdev_hdl,
 {
 	int i;
 	struct xocl_subdev_private *priv;
+	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev_hdl;
 
 	bus_for_each_dev(&platform_bus_type, NULL, subdevs,
 		match);
@@ -329,6 +330,8 @@ static void xocl_subdev_destroy_common(xdev_handle_t xdev_hdl,
 		if (priv->is_multi)
 			ida_simple_remove(&subdev_multi_inst_ida,
 				subdevs->pldevs[i]->id);
+		else
+			core->subdevs[subdevs->id].pldev = NULL;
 		device_release_driver(&subdevs->pldevs[i]->dev);
 		platform_device_unregister(subdevs->pldevs[i]);
 	}

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -598,13 +598,15 @@ public:
         sensor_tree::put( "board.info.dma_threads", m_devinfo.mDMAThreads );
         sensor_tree::put( "board.info.mig_calibrated", m_devinfo.mMigCalib );
         {
-            std::string idcode, fpga, errmsg;
+            std::string idcode, fpga, dna, errmsg;
             pcidev::get_dev(m_idx)->mgmt->sysfs_get("icap", "idcode", errmsg, idcode);
             sensor_tree::put( "board.info.idcode", idcode );
             pcidev::get_dev(m_idx)->mgmt->sysfs_get("rom", "FPGA", errmsg, fpga);
             sensor_tree::put( "board.info.fpga_name", fpga );
+            pcidev::get_dev(m_idx)->mgmt->sysfs_get("dna", "dna", errmsg, dna);
+            sensor_tree::put( "board.info.dna", dna);
         }
-        //sensor_tree::put( "board.info.dna",
+        
 
         // physical
         sensor_tree::put( "board.physical.thermal.pcb.top_front",                m_devinfo.mSE98Temp[ 0 ] );
@@ -746,7 +748,8 @@ public:
              << std::setw(16) << sensor_tree::get( "board.physical.electrical.mgt_vtt.voltage", -1 ) << std::endl;
         ostr << std::setw(16) << "VCCINT VOL" << std::setw(16) << "VCCINT CURR" << std::setw(16) << "DNA" << std::endl;
         ostr << std::setw(16) << sensor_tree::get( "board.physical.electrical.vccint.voltage", -1 )
-             << std::setw(16) << sensor_tree::get( "board.physical.electrical.vccint.current", -1 ) << std::endl;
+             << std::setw(16) << sensor_tree::get( "board.physical.electrical.vccint.current", -1 )
+             << std::setw(16) << sensor_tree::get<std::string>( "board.info.dna", "N/A" ) << std::endl;
 
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         ostr << "Board Power\n";


### PR DESCRIPTION
http://jira.xilinx.com/browse/CR-1017137?filter=-1

We should wipe out everything if xclbin download fails, 

however, if we remove dna device, there is no way for DNA IP users to retrieve dna.

We treat it as invalid dna xclbin but keep dna sub device if and only if there is a blank certificate for development purpose.


and add dna entry to json
