### PR TITLE
100 CPU usage by MGMT driver

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_thread.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_thread.c
@@ -23,7 +23,7 @@ int health_thread(void *data)
 	struct xocl_health_thread_arg *thread_arg = data;
 
 	while (!kthread_should_stop()) {
-		msleep(thread_arg->interval);
+		msleep_interruptible(thread_arg->interval);
 
 		thread_arg->health_cb(thread_arg->arg);
 	}


### PR DESCRIPTION
Change it to msleep_interruptible() so that it does not hog up the CPU.
Fix  http://jira.xilinx.com/browse/CR-1017283