### PR TITLE
Support CDMA base addresses per feature rom

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -29,12 +29,12 @@
 #define SCHED_UNUSED __attribute__((unused))
 #endif
 
-#define sched_error_on(exec,expr,msg)		                  \
+#define sched_error_on(exec,expr,msg)		                          \
 ({		                                                          \
 	unsigned int ret = 0;                                             \
 	if ((expr)) {						          \
 		xocl_err(&exec->pdev->dev, "Assertion failed %s %s",#expr,msg);\
-		exec->scheduler->error=1;                                       \
+		exec->scheduler->error=1;                                 \
 		ret = 1; 					          \
 	}                                                                 \
 	(ret);                                                            \
@@ -146,10 +146,16 @@ exec_get_pdev(struct exec_core *exec)
 }
 
 static inline struct exec_core *
+pdev_get_exec(struct platform_device *pdev)
+{
+	return platform_get_drvdata(pdev);
+}
+
+static inline struct exec_core *
 dev_get_exec(struct device *dev)
 {
 	struct platform_device *pdev = to_platform_device(dev);
-	return pdev ? platform_get_drvdata(pdev) : NULL;
+	return pdev ? pdev_get_exec(pdev) : NULL;
 }
 
 /**
@@ -880,7 +886,7 @@ configure(struct xocl_cmd *xcmd)
 	struct exec_core *exec=xcmd->exec;
 	struct xocl_dev *xdev = exec_get_xdev(exec);
 	bool ert = xocl_mb_sched_on(xdev);
-	bool cdma = xocl_cdma_on(xdev);
+	uint32_t *cdma = xocl_cdma_addr(xdev);
 	unsigned int dsa = xocl_dsa_version(xdev);
 	struct ert_configure_cmd *cfg;
 	int i;
@@ -921,15 +927,19 @@ configure(struct xocl_cmd *xcmd)
 	}
 
 	if (cdma && cfg->cdma) {
-		exec->num_cdma = 1; /* TBD */
+		struct client_ctx *client  = xcmd->client;
+		exec->num_cdma = 1; /* until verified that address is null terminated TBD */
 		exec->num_cus += exec->num_cdma;
+		mutex_lock(&client->lock);
 		for (; i<exec->num_cus; ++i) {
 			++cfg->num_cus;
 			++cfg->count;
-			exec->cu_addr_map[i] = 0x250000; // TBD
-			cfg->data[i] = 0x250000;
+			exec->cu_addr_map[i] = cdma[0];
+			cfg->data[i] = cdma[0];
+			set_bit(i,client->cu_bitmap); // implicit shared resource
 			SCHED_DEBUGF("++ configure cdma cu(%d) at 0x%x\n",i,exec->cu_addr_map[i]);
 		}
+		mutex_unlock(&client->lock);
 	}
 
 	if (ert && cfg->ert) {
@@ -1895,6 +1905,7 @@ create_client(struct platform_device *pdev, void **priv)
 	atomic_set(&client->trigger, 0);
 	atomic_set(&client->abort, 0);
 	atomic_set(&client->outstanding_execs, 0);
+	client->num_cus = 0;
 	mutex_lock(&xdev->ctx_list_lock);
 	client->xdev = xocl_get_xdev(pdev);
 	list_add_tail(&client->link, &xdev->ctx_list);
@@ -2020,21 +2031,24 @@ validate(struct platform_device *pdev, struct client_ctx *client, const struct d
 	u32 ctx_cus[4] = {0};
 	u32 cumasks = 0;
 	int i = 0;
+	int err = 0;
 
 	SCHED_DEBUGF("-> validate opcode(%d)\n",ecmd->opcode);
 
 	/* cus for start kernel commands only */
 	if (ecmd->opcode!=ERT_START_CU) {
-		SCHED_DEBUG("<- validate(0), not a CU cmd\n");
+		userpf_err(xocl_get_xdev(pdev),"validate got unexpected command opcode(%d)\n",ecmd->opcode);
 		return 0; /* ok */
 	}
+
+	/* client context cu bitmap may not change while validating */
+	mutex_lock(&client->lock);
 
 	/* no specific CUs selected, maybe ctx is not used by client */
 	if (bitmap_empty(client->cu_bitmap,MAX_CUS)) {
-		SCHED_DEBUG("<- validate(0), no CUs in ctx\n");
-		return 0; /* ok */
+		userpf_err(xocl_get_xdev(pdev),"validate found no CUs in ctx\n");
+		goto out; /* ok */
 	}
-
 
 	/* Check CUs in cmd BO against CUs in context */
 	cumasks = 1 + scmd->extra_cu_masks;
@@ -2049,12 +2063,17 @@ validate(struct platform_device *pdev, struct client_ctx *client, const struct d
 		if (cmd_cus & ~ctx_cus[i]) {
 			SCHED_DEBUGF("<- validate(1), CU mismatch in mask(%d) cmd(0x%x) ctx(0x%x)\n",
 				     i,cmd_cus,ctx_cus[i]);
-			return 1; /* error */
+			err = 1;
+			goto out; /* error */
 		}
 	}
 
-	SCHED_DEBUG("<- validate(0) cmd and ctx CUs match\n");
-	return 0;
+
+out:
+	mutex_unlock(&client->lock);
+	SCHED_DEBUGF("<- validate(%d) cmd and ctx CUs match\n",err);
+	return err;
+
 }
 
 struct xocl_mb_scheduler_funcs sche_ops = {
@@ -2080,7 +2099,7 @@ static ssize_t
 kds_numcdmas_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_dev *xdev = dev_get_xdev(dev);
-	bool cdma = xocl_cdma_on(xdev);
+	uint32_t *cdma = xocl_cdma_addr(xdev);
 	unsigned int cdmas = cdma ? 1 : 0; //TBD
 	return sprintf(buf,"%d\n",cdmas);
 }

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -131,11 +131,13 @@ struct xocl_dev	{
  *
  * @link: Client context is added to list in device
  * @xclbin_id: UUID for xclbin loaded by client, or nullid if no xclbin loaded
+ * @xclbin_locked: Flag to denote that this context locked the xclbin
  * @trigger: Poll wait counter for number of completed exec buffers
  * @outstanding_execs: Counter for number outstanding exec buffers
  * @abort: Flag to indicate that this context has detached from user space (ctrl-c)
+ * @num_cus: Number of resources (CUs) explcitly aquired
  * @lock: Mutex lock for exclusive access
- * @cu_bitmap: CUs reserved by this context
+ * @cu_bitmap: CUs reserved by this context, may contain implicit resources
  */
 struct client_ctx {
 	struct list_head	link;
@@ -144,9 +146,10 @@ struct client_ctx {
 	atomic_t		trigger;
 	atomic_t                outstanding_execs;
 	atomic_t                abort;
+	unsigned int            num_cus;     /* number of resource locked explicitly by client */
 	struct mutex		lock;
 	struct xocl_dev        *xdev;
-	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
+	DECLARE_BITMAP(cu_bitmap, MAX_CUS);  /* may contain implicitly aquired resources such as CDMA */
 	struct pid             *pid;
 };
 

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -193,6 +193,7 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	struct client_ctx *client = filp->driver_priv;
 	int ret = 0;
 
+	mutex_lock(&client->lock);
 	mutex_lock(&xdev->ctx_list_lock);
 	if (!uuid_equal(&xdev->xclbin_id, &args->xclbin_id)) {
 		ret = -EBUSY;
@@ -200,6 +201,7 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	}
 
 	if (args->cu_index >= xdev->layout->m_count) {
+		userpf_err(xdev, "cuidx(%d) >= numcus(%d)\n",args->cu_index,xdev->layout->m_count);
 		ret = -EINVAL;
 		goto out;
 	}
@@ -209,8 +211,10 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 		if (ret) // No context was previously allocated for this CU
 			goto out;
 
-		xdev->ip_reference[args->cu_index]--;
-		if (bitmap_empty(client->cu_bitmap, MAX_CUS)) {
+		// CU unlocked explicitly
+		--client->num_cus;
+		--xdev->ip_reference[args->cu_index];
+		if (!client->num_cus) {
                         // We just gave up the last context, give up the xclbin lock
 			ret = xocl_icap_unlock_bitstream(xdev, &xdev->xclbin_id,
 							 pid_nr(task_tgid(current)));
@@ -231,7 +235,7 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	if (bitmap_empty(client->cu_bitmap, MAX_CUS) && !atomic_read(&client->xclbin_locked))
+	if (!client->num_cus && !atomic_read(&client->xclbin_locked))
 		// Process has no other context on any CU yet, hence we need to lock the xclbin
 		// A process uses just one lock for all its contexts
 		acquire_lock = true;
@@ -257,12 +261,15 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	}
 
 	// Everything is good so far, hence increment the CU reference count
-	xdev->ip_reference[args->cu_index]++;
+	++client->num_cus; // explicitly acquired
+	++xdev->ip_reference[args->cu_index];
 	xocl_info(dev->dev, "CTX add(%pUb, %d, %u, %d)", &xdev->xclbin_id, pid_nr(task_tgid(current)), args->cu_index,acquire_lock);
 out:
-	if (bitmap_empty(client->cu_bitmap, MAX_CUS))
+	// If all explicit resources are given up, then release the xclbin
+	if (!client->num_cus)
 		atomic_set(&client->xclbin_locked,false);
 	mutex_unlock(&xdev->ctx_list_lock);
+	mutex_unlock(&client->lock);
 	return ret;
 }
 

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -233,7 +233,7 @@ struct xocl_rom_funcs {
 	bool (*is_unified)(struct platform_device *pdev);
 	bool (*mb_mgmt_on)(struct platform_device *pdev);
 	bool (*mb_sched_on)(struct platform_device *pdev);
-	bool (*cdma_on)(struct platform_device *pdev);
+	uint32_t* (*cdma_addr)(struct platform_device *pdev);
 	u16 (*get_ddr_channel_count)(struct platform_device *pdev);
 	u64 (*get_ddr_channel_size)(struct platform_device *pdev);
 	bool (*is_are)(struct platform_device *pdev);
@@ -254,8 +254,8 @@ struct xocl_rom_funcs {
 	(ROM_DEV(xdev) ? ROM_OPS(xdev)->mb_mgmt_on(ROM_DEV(xdev)) : false)
 #define	xocl_mb_sched_on(xdev)		\
 	(ROM_DEV(xdev) ? ROM_OPS(xdev)->mb_sched_on(ROM_DEV(xdev)) : false)
-#define	xocl_cdma_on(xdev)		\
-	(ROM_DEV(xdev) ? ROM_OPS(xdev)->cdma_on(ROM_DEV(xdev)) : false)
+#define	xocl_cdma_addr(xdev)		\
+	(ROM_DEV(xdev) ? ROM_OPS(xdev)->cdma_addr(ROM_DEV(xdev)) : 0)
 #define	xocl_get_ddr_channel_count(xdev) \
 	(ROM_DEV(xdev) ? ROM_OPS(xdev)->get_ddr_channel_count(ROM_DEV(xdev)) :\
 	0)

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -922,6 +922,7 @@ copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t ds
       unmap_buffer(dbuf,hbuf_dst);
       c->done();
     };
+    XOCL_DEBUG(std::cout,"xocl::device::copy_buffer schedules host copy\n");
     xdevice->schedule(cb,xrt::device::queue_type::misc,src_buffer,dst_buffer,src_offset,dst_offset,size,cmd);
     return;
   }


### PR DESCRIPTION
Number of changes to support CDMA as a shared resource ignored by user context.  Ultimately validation of exec buffer must ignore CUs that identify CDMA kernels.

To support this, the context now tracks regular CUs separately from CDMA kernels.  The CDMA kernels, which are used as regular CUs, are added to the context when the scheduler configuration assigns them a CU idx.