### PR TITLE
Python binding using ctypes

### DIFF
--- a/src/python/xclbin_binding.py
+++ b/src/python/xclbin_binding.py
@@ -1,0 +1,82 @@
+from ctypes import *
+from enum import *
+
+libc = CDLL("../../../build/Debug/opt/xilinx/xrt/lib/libxrt_core.so")
+
+
+class XCLBIN_MODE (Enum):
+    XCLBIN_FLAT = 1
+    XCLBIN_PR = 2
+    XCLBIN_TANDEM_STAGE2 = 3
+    XCLBIN_TANDEM_STAGE2_WITH_PR = 4
+    XCLBIN_HW_EMU = 5
+    XCLBIN_SW_EMU = 6
+    XCLBIN_MODE_MAX = 7
+
+
+class axlf_section_header (Structure):
+    _fields_ = [
+        ("m_sectionKind", c_uint32),
+        ("m_sectionName", c_char*16),
+        ("m_sectionOffset", c_uint64),
+        ("m_sectionSize", c_uint64)
+    ]
+
+
+class s1 (Structure):
+    _fields_ = [
+        ("m_platformId", c_uint64),
+        ("m_featureId", c_uint64)
+    ]
+
+
+class u1 (Union):
+    _fields_ = [
+        ("rom", s1),
+        ("rom_uuid", c_ubyte*16)
+    ]
+
+
+class u2 (Union):
+    _fields_ = [
+        ("m_next_axlf", c_char*16),
+        ("uuid", c_ubyte*16)  # uuid_t/xuid_t
+    ]
+
+
+class axlf_header (Structure):
+    _anonymous_ = ("u1","u2")
+    _fields_ = [
+        ("m_length", c_uint64),
+        ("m_timeStamp", c_uint64),
+        ("m_featureRomTimeStamp", c_uint64),
+        ("m_versionPatch", c_uint16),
+        ("m_versionMajor", c_uint8),
+        ("m_versionMinor", c_uint8),
+        ("m_mode", c_uint32),
+        ("u1", u1),
+        ("m_platformVBNV", c_ubyte*64),
+        ("u2", u2),
+        ("m_debug_bin", c_char*16),
+        ("m_numSections", c_uint32)
+    ]
+
+
+class axlf (Structure):
+    _fields_ = [
+        ("m_magic", c_char*8),
+        ("m_cipher", c_ubyte*32),
+        ("m_keyBlock", c_ubyte*256),
+        ("m_uniqueId", c_uint64),
+        ("m_header", axlf_header),
+        ("m_sections", axlf_section_header)
+    ]
+
+
+# def get_axlf_section(top, kind):
+#  libc.get_axlf_section.restype = POINTER(axlf_section_header)
+#  libc.get_axlf_scetion.argtypes = [POINTER(axlf), c_int]#axlf_section_kind]
+#  return libc.get_axlf_section(top, kind)
+    
+    
+# print("get_axlf_section %s") %get_axlf_section("kernel.xclbin",1)

--- a/src/python/xclhal2_binding.py
+++ b/src/python/xclhal2_binding.py
@@ -1,0 +1,285 @@
+from ctypes import *
+from enum import *
+from xclbin_binding import *
+
+
+libc = CDLL("../../../build/Debug/opt/xilinx/xrt/lib/libxrt_core.so")
+
+xclDeviceHandle = c_void_p
+
+
+class xclDeviceInfo2(Structure):
+    fields_= [
+     ("mMagic", c_uint),
+     ("mName", c_char*256),
+     ("mHALMajorVersion", c_ushort),
+     ("mHALMinorVersion", c_ushort),
+     ("mVendorId", c_ushort),
+     ("mDeviceId", c_ushort),
+     ("mSubsystemId", c_ushort),
+     ("mSubsystemVendorId", c_ushort),
+     ("mDeviceVersion", c_ushort),
+     ("mDDRSize", c_size_t),
+     ("mDataAlignment", c_size_t),
+     ("mDDRFreeSize", c_size_t),
+     ("mMinTransferSize", c_size_t),
+     ("mDDRBankCount", c_ushort),
+     ("mOCLFrequency", c_ushort*4),
+     ("mPCIeLinkWidth", c_ushort),
+     ("mPCIeLinkSpeed", c_ushort),
+     ("mDMAThreads", c_ushort),
+     ("mOnChipTemp", c_short),
+     ("mFanTemp", c_short),
+     ("mVInt", c_ushort),
+     ("mVAux", c_ushort),
+     ("mVBram", c_ushort),
+     ("mCurrent", c_float),
+     ("mNumClocks", c_ushort),
+     ("mFanSpeed", c_ushort),
+     ("mMigCalib", c_bool),
+     ("mXMCVersion", c_ulonglong),
+     ("mMBVersion", c_ulonglong),
+     ("m12VPex", c_short),
+     ("m12VAux", c_short),
+     ("mPexCurr", c_ulonglong),
+     ("mAuxCurr", c_ulonglong),
+     ("mFanRpm", c_ushort),
+     ("mDimmTemp", c_ushort*4),
+     ("mSE98Temp", c_ushort*4),
+     ("m3v3Pex", c_ushort),
+     ("m3v3Aux", c_ushort),
+     ("mDDRVppBottom",c_ushort),
+     ("mDDRVppTop", c_ushort),
+     ("mSys5v5", c_ushort),
+     ("m1v2Top", c_ushort),
+     ("m1v8Top", c_ushort),
+     ("m0v85", c_ushort),
+     ("mMgt0v9", c_ushort),
+     ("m12vSW", c_ushort),
+     ("mMgtVtt", c_ushort),
+     ("m1v2Bottom", c_ushort),
+     ("mDriverVersion, ", c_ulonglong),
+     ("mPciSlot", c_uint),
+     ("mIsXPR", c_bool),
+     ("mTimeStamp", c_ulonglong),
+     ("mFpga", c_char*256),
+     ("mPCIeLinkWidthMax", c_ushort),
+     ("mPCIeLinkSpeedMax", c_ushort),
+     ("mVccIntVol", c_ushort),
+     ("mVccIntCurr", c_ushort),
+     ("mNumCDMA", c_ushort)
+    ]
+
+
+class xclMemoryDomains(Enum):
+    XCL_MEM_HOST_RAM = 0
+    XCL_MEM_DEVICE_RAM = 1
+    XCL_MEM_DEVICE_BRAM = 2
+    XCL_MEM_SVM = 3
+    XCL_MEM_CMA = 4
+    XCL_MEM_DEVICE_REG = 5
+
+
+class xclDDRFlags (Enum):
+    XCL_DEVICE_RAM_BANK0 = 0
+    XCL_DEVICE_RAM_BANK1 = 2
+    XCL_DEVICE_RAM_BANK2 = 4
+    XCL_DEVICE_RAM_BANK3 = 8
+
+
+class xclBOKind (Enum):
+    XCL_BO_SHARED_VIRTUAL = 0
+    XCL_BO_SHARED_PHYSICAL = 1
+    XCL_BO_MIRRORED_VIRTUAL = 2
+    XCL_BO_DEVICE_RAM = 3
+    XCL_BO_DEVICE_BRAM = 4
+    XCL_BO_DEVICE_PREALLOCATED_BRAM = 5
+
+
+class xclBOSyncDirection (Enum):
+    XCL_BO_SYNC_BO_TO_DEVICE = 0
+    XCL_BO_SYNC_BO_FROM_DEVICE = 1
+
+
+class xclAddressSpace (Enum):
+    XCL_ADDR_SPACE_DEVICE_FLAT = 0     # Absolute address space
+    XCL_ADDR_SPACE_DEVICE_RAM = 1      # Address space for the DDR memory
+    XCL_ADDR_KERNEL_CTRL = 2           # Address space for the OCL Region control port
+    XCL_ADDR_SPACE_DEVICE_PERFMON = 3  # Address space for the Performance monitors
+    XCL_ADDR_SPACE_DEVICE_CHECKER = 5  # Address space for protocol checker
+    XCL_ADDR_SPACE_MAX = 8
+
+
+class xclVerbosityLevel (Enum):
+    XCL_QUIET = 0
+    XCL_INFO = 1
+    XCL_WARN = 2
+    XCL_ERROR = 3
+
+
+class xclResetKind (Enum):
+    XCL_RESET_KERNEL = 0
+    XCL_RESET_FULL = 1
+
+
+class xclDeviceUsage (Structure):
+    _fields_ = [
+     ("h2c", c_size_t*8),
+     ("c2h", c_size_t*8),
+     ("ddeMemUsed", c_size_t*8),
+     ("ddrBOAllocated", c_uint *8),
+     ("totalContents", c_uint),
+     ("xclbinId", c_ulonglong),
+     ("dma_channel_cnt", c_uint),
+     ("mm_channel_cnt", c_uint),
+     ("memSize", c_ulonglong*8)
+    ]
+
+
+class xclBOProperties (Structure):
+    _fields_ = [
+     ("handle", c_uint),
+     ("flags" , c_uint),
+     ("size", c_uint),
+     ("paddr", c_uint),
+     ("domain", c_uint),
+    ]
+
+
+def xclClose(handle):
+    """
+    xclClose(): Close an opened device
+
+    :param handle: (xclDeviceHandle) device handle
+    :return: None
+    """
+    libc.xclClose.restype = None
+    libc.xclClose.argtype = xclDeviceHandle
+    libc.xclClose(handle)
+
+
+def xclProbe():
+    return libc.xclProbe()
+
+def xclVersion():
+    return libc.xclVersion()
+
+def xclOpen(deviceIndex, logFileName, level):
+    """
+    xclOpen(): Open a device and obtain its handle
+
+    :param deviceIndex: (unsigned int) Slot number of device 0 for first device, 1 for the second device...
+    :param logFileName: (const char pointer) Log file to use for optional logging
+    :param level: (int) Severity level of messages to log
+    :return: device handle
+    """
+    libc.xclOpen.restype = xclDeviceHandle
+    libc.xclOpen.argtypes = [c_uint, c_char_p, c_int]
+    return libc.xclOpen(deviceIndex, logFileName, level)
+
+
+def xclGetDeviceInfo2 (handle, info):
+    """
+    xclGetDeviceInfo2() - Obtain various bits of information from the device
+
+    :param handle: (xclDeviceHandle) device handle
+    :param info: (xclDeviceInfo pointer) Information record
+    :return: 0 on success or appropriate error number
+    """
+
+    libc.xclGetDeviceInfo2.restype = c_int
+    libc.xclGetDeviceInfo2.argtypes = [xclDeviceHandle, POINTER(xclDeviceInfo2)]
+    return libc.xclGetDeviceInfo2(handle, info)
+
+
+def xclLockDevice(handle):
+    """
+    Get exclusive ownership of the device
+
+    :param handle: (xclDeviceHandle) device handle
+    :return: 0 on success or appropriate error number
+
+    The lock is necessary before performing buffer migration, register access or bitstream downloads
+    """
+    libc.xclLockDevice.restype = c_int
+    libc.xclLockDevice.argtype = xclDeviceHandle
+    return libc.xclLockDevice(handle)
+
+
+def xclLoadXclBin(handle, buf):
+    """
+    Download FPGA image (xclbin) to the device
+
+    :param handle: (xclDeviceHandle) device handle
+    :param buf: (void pointer) Pointer to device image (xclbin) in memory
+    :return: 0 on success or appropriate error number
+
+    Download FPGA image (AXLF) to the device. The PR bitstream is encapsulated inside
+    xclbin as a section. xclbin may also contains other sections which are suitably
+    handled by the driver
+    """
+    libc.xclLoadXclBin.restype = c_int
+    libc.xclLoadXclBin.argtypes = [xclDeviceHandle, c_void_p]
+    return libc.xclLoadXclBin(handle, buf)
+
+
+def xclAllocBO(handle, size, domain, flags):
+    """
+    Allocate a BO of requested size with appropriate flags
+
+    :param handle: (xclDeviceHandle) device handle
+    :param size: (size_t) Size of buffer
+    :param domain: (xclBOKind) Memory domain
+    :param flags: (unsigned int) Specify bank information, etc
+    :return: BO handle
+    """
+    libc.xclAllocBO.restype = c_uint
+    libc.xclAllocBO.argtypes = [xclDeviceHandle, c_size_t, c_int, c_uint]
+    return libc.xclAllocBO(handle, size, domain, flags)
+
+
+def xclMapBO(handle, boHandle, write):
+    """
+    Memory map BO into user's address space
+
+    :param handle: (xclDeviceHandle) device handle
+    :param boHandle: (unsigned int) BO handle
+    :param write: (boolean) READ only or READ/WRITE mapping
+    :return: (void pointer) Memory mapped buffer
+
+    Map the contents of the buffer object into host memory
+    To unmap the buffer call POSIX unmap() on mapped void * pointer returned from xclMapBO
+    """
+    libc.xclMapBO.restype = c_void_p
+    libc.xclMapBO.argtypes = [xclDeviceHandle, c_uint, c_bool]
+    return libc.xclMapBO(handle, boHandle, write)
+
+
+def xclSyncBO(handle, boHandle, direction, size, offset):
+    """
+    Synchronize buffer contents in requested direction
+
+    :param handle: (xclDeviceHandle) device handle
+    :param boHandle: (unsigned int) BO handle
+    :param direction: (xclBOSyncDirection) To device or from device
+    :param size: (size_t) Size of data to synchronize
+    :param offset: (size_t) Offset within the BO
+    :return: 0 on success or standard errno
+    """
+    libc.xclSyncBO.restype = c_uint
+    libc.xclSyncBO.argtypes = [xclDeviceHandle, c_uint, c_int, c_size_t, c_size_t]
+    return libc.xclSyncBO(handle, boHandle, direction, size, offset)
+
+
+def xclGetBOProperties(handle, boHandle, properties):
+    """
+    Obtain xclBOProperties struct for a BO
+
+    :param handle: (xclDeviceHandle) device handle
+    :param boHandle: (unsigned int) BO handle
+    :param properties: BO properties struct pointer
+    :return: 0 on success
+    """
+    libc.xclGetBOProperties.restype = c_int
+    libc.xclGetBOProperties.argtypes = [xclDeviceHandle, c_uint, POINTER(xclBOProperties)]
+    return libc.xclGetBOProperties(handle, boHandle, properties)

--- a/tests/python/00_hello/Makefile
+++ b/tests/python/00_hello/Makefile
@@ -1,0 +1,14 @@
+OTHERDIR=../../../src/python
+
+run:
+	@python main.py -k $(filter-out $@, $(MAKECMDGOALS))
+
+clean:
+	@find . -name '*.pyc' -delete
+	@find $(OTHERDIR) -name '*.pyc' -delete
+
+help:
+	@python -c 'from main import printHelp; print printHelp();'
+
+%:
+	@true

--- a/tests/python/00_hello/main.py
+++ b/tests/python/00_hello/main.py
@@ -1,0 +1,127 @@
+import getopt
+import sys
+sys.path.append('../../../src/python/')
+from xclhal2_binding import *
+from utils_binding import *
+
+
+def main():
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "k:l:a:c:d:vhe", ["bitstream=", "hal_logfile=", "alignment=",
+                                                                   "cu_index=", "device=", "verbose", "help", "ert"])
+    except getopt.GetoptError:
+        print(printHelp())
+        sys.exit(2)
+        
+    sharedLibrary = "None"
+    bitstreamFile = None
+    halLogFile = ""
+    alignment = 128
+    option_index = 0
+    index = 0
+    cu_index = 0
+    verbose = False
+
+    for o, arg in opts:
+        if o in ("--bitstream", "-k"):
+            bitstreamFile = arg
+        elif o in ("--hal_logfile", "-l"):
+            halLogFile = arg
+        elif o in ("--alignment", "-a"):
+            alignment = int(arg)
+        elif o in ("--cu_index", "-c"):
+            cu_index = int(arg)
+        elif o in ("--device", "-d"):
+            index = int(arg)
+        elif o in ("--help", "-h"):
+            print(printHelp())
+        elif o == "-v":
+            verbose = True
+        elif o in ("-e", "--ert"):
+            print('ert')
+        else:
+            assert False, "unhandled option"
+
+    if bitstreamFile is None:
+        print("FAILED TEST"+ "\n" + "No bitstream specified")
+        sys.exit()
+    if halLogFile:
+        print("Using " + halLogFile + " as HAL driver logfile")
+    print("HAL driver = " + sharedLibrary)
+    print("Host buffer alignment "+str(alignment)+ " bytes")
+    print("Compiled kernel = " + bitstreamFile)
+
+    try:
+        handle = xclDeviceHandle
+        cu_base_addr = 0
+        first_mem = -1
+        if initXRT(bitstreamFile, index, halLogFile, handle, cu_index, cu_base_addr, first_mem):
+            return 1
+        if first_mem < 0:
+            return 1
+
+        boHandle1 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM.name, first_mem)
+        boHandle2 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM.name, first_mem)
+        bo1 = xclMapBO(handle, boHandle1, True)
+        # memset(bo1, 0, DATA_SIZE)
+        testVector = "hello\nthis is Xilinx OpenCL memory read write test\n:-)\n"
+        bol = testVector #??
+        # strcpy(bo1, testVector.c_str())
+
+        if xclSyncBO(handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE , DATA_SIZE,0):
+            return 1
+
+        p = xclBOProperties
+        bo2devAddr =p.pddr if not(xclGetBOProperties(handle, boHandle2, p)) else -1
+        bo1devAddr = p.pddr if not(xclGetBOProperties(handle, boHandle1, p)) else -1
+
+        if bo2devAddr is -1 or bo1devAddr is -1:
+            return 1
+
+        # Allocate the exec_bo unsigned
+        execHandle = xclAllocBO(handle, DATA_SIZE, xclBOKind.XCL_BO_SHARED_VIRTUAL.value, 1)
+
+        # Get the output
+
+        if xclSyncBO(handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE.value, DATA_SIZE, False):
+            bo2 = xclMapBO(handle, boHandle1, False)
+            # return 1
+            if len(bo1) == len(bo2) and all(x == y for x, y in zip(bo1,bo2)):
+                print("FAILED TEST")
+                print("Value read back does not match value written")
+                # return 1
+
+            # munmap(bo1, DATA_SIZE)
+            # munmap(bo2, DATA_SIZE)
+            # xclFreeBO(handle, boHandle1)
+            # xclFreeBO(handle, boHandle2)
+            # xclFreeBO(handle, execHandle)
+
+    except Exception as exp:
+        print("Exception: ")
+        print(exp)  # prints the err
+        sys.exit()
+
+    print("PASSED TEST")
+
+
+def printHelp():
+    print("usage: %s [options] -k <bitstream>")
+    print("  -k <bitstream>")
+    print("  -l <hal_logfile>")
+    print("  -a <alignment>")
+    print("  -d <device_index>")
+    print("  -c <cu_index>")
+    print("  -v")
+    print("  -h")
+    print("")
+    print("  [--ert] enable embedded runtime (default: false)")
+    print("")
+    print("* If HAL driver is not specified, application will try to find the HAL driver")
+    print("  using XILINX_OPENCL and XCL_PLATFORM environment variables")
+    print("* Bitstream is required")
+    print("* HAL logfile is optional but useful for capturing messages from HAL driver")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/00_hello/smoke_test.py
+++ b/tests/python/00_hello/smoke_test.py
@@ -1,0 +1,28 @@
+from ctypes import *
+import sys
+
+sys.path.append('../../../src/python/')
+from xclhal2_binding import *
+
+
+dev_0_info = xclDeviceInfo2()  # Allocate an instance of the struct to store device info
+
+print("xclProbe %s") %xclProbe()
+print("xclVersion %d") %xclVersion()
+dev_0 = xclOpen(0,"dev_log.txt", 1)
+d = xclGetDeviceInfo2(dev_0, byref(dev_0_info))
+print("xclGetDeviceInfo2 %d") % d
+print("DSA = %s") % dev_0_info.mMagic
+print("OCL Frequency = %s MHz") % dev_0_info.mOCLFrequency[0]
+
+print("xclLoadXclBin %d") %xclLoadXclBin(dev_0, byref(buf))
+print("xclLockDevice %d") %xclLockDevice(dev_0)
+boHandle = xclAllocBO(dev_0, 1024, xclBOKind.XCL_BO_DEVICE_RAM.value, -1)
+
+print("xclAllocBO %d") %boHandle
+print("xclMapBO %s") %xclMapBO(dev_0, boHandle, True)
+print("xclSyncBO %d") %xclSyncBO(dev_0, boHandle, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE.value, 1024, 0)
+p = xclBOProperties()
+print("xclGetBOProperties %d") %xclGetBOProperties(dev_0, boHandle, byref(p))
+
+xclClose(dev_0)

--- a/tests/python/00_hello/utils_binding.py
+++ b/tests/python/00_hello/utils_binding.py
@@ -1,0 +1,54 @@
+from ctypes import *
+import sys
+sys.path.append('../../../src/python/')
+from xclbin_binding import *
+from xclhal2_binding import *
+
+libc = CDLL("../../../build/Debug/opt/xilinx/xrt/lib/libxrt_core.so")
+
+
+def initXRT(bit, deviceIndex, halLog, handle, cu_index, cu_base_addr, first_mem_used):
+    deviceInfo = xclDeviceInfo2()
+    if deviceIndex >= xclProbe():
+        print("Error")
+        return -1
+    
+    handle = xclOpen(deviceIndex, halLog, xclVerbosityLevel.XCL_INFO)
+
+    if xclGetDeviceInfo2(handle, byref(deviceInfo)):
+        print("Error 2")
+        return -1
+
+    print("DSA = %s") % deviceInfo.mName
+    print("Index = %s") % deviceIndex
+    print("PCIe = GEN%s"+ " x %s") %(deviceInfo.mPCIeLinkSpeed, deviceInfo.mPCIeLinkWidth)
+    print("OCL Frequency = %s MHz") % deviceInfo.mOCLFrequency[0]
+    print("DDR Bank = %s") % deviceInfo.mDDRBankCount
+    print("Device Temp = %s C") % deviceInfo.mOnChipTemp
+    print("MIG Calibration = %s") % deviceInfo.mMigCalibs
+
+    cu_base_addr = 0xffffffffffffffff  # long
+    if not bit or not len(bit):
+        return 0
+    
+    if xclLockDevice(handle):
+        print("Cannot unlock device")
+        sys.exit()
+    
+    # tempFileName = bit[:]
+    # print(tempFileName)
+
+    with open(tempFileName, "rb") as f:
+        if f.read(8) == "xclbin2":
+            print("Invalid Bitsream")
+            sys.exit()
+        f.seek(0)
+
+        if xclLoadXclBin(handle, f.read()):
+            print("Bitsream download failed")
+
+        print("Finished downloading bitstream %s") % bit
+        # 83
+    return 0
+
+

--- a/tests/python/README.md
+++ b/tests/python/README.md
@@ -1,0 +1,57 @@
+# Python binding using Ctypes
+## Introduction
+Ctypes is a foreign function library for Python. It provides C compatible data types, 
+and allows calling functions in DLLs or shared libraries. It can be used to wrap these 
+libraries in pure Python.
+
+## Structure
+
+```
+XRT   
+│
+└───src
+│   │
+│   └───python
+│   |   │   README.md
+│   |   │   xclhal2_binding.py
+│   |   │   xclbin_binding.py
+│   │
+│   └───runtime_src
+│       │   ......
+│ 
+└───tests
+│   │
+│   └───python
+│   |   │
+│   |   └───00_hello
+│   |   │   |   main.py
+│   |   │   |   utils.py
+│   |   │   |   Makefile
+│   │
+│   └───xrt
+│   |   │
+│   |   └───00_hello
+│   |   │   |   ......
+
+```
+
+## Prerequisites
+1. Python
+2. Enum package: pip install Enum
+
+## Using source files
+Calling functions from xclhal2_binding.py and xclbin_binding.py
+* import source file:
+>> sys.path.append('< path of the source file >') <br>
+from < source file > import *
+* All functions from the source file are now callable 
+
+## Run 00_hello
+>> cd XRT/tests/python/00_hello <br/>
+cp kernel.xclbin . <br/>
+python main.py -k kernel.xclbin
+
+## Makefile for 00_hello
+1. run <kernel.xclbin>: runs 00_hello/main.py -k kernel.xclbin
+2. clean: cleans up all .pyc files
+3. help: prints help for the 00_hello test


### PR DESCRIPTION
## Introduction
Ctypes is a foreign function library for Python. It provides C compatible data types, and allows calling functions in DLLs or shared libraries. It can be used to wrap these  libraries in pure Python.
 ## Structure
 ```
XRT   
│
└───src
│   │
│   └───python
│   |   │   README.md
│   |   │   xclhal2_binding.py
│   |   │   xclbin_binding.py
│   │
│   └───runtime_src
│       │   ......
│ 
└───tests
│   │
│   └───python
│   |   │
│   |   └───00_hello
│   |   │   |   main.py
│   |   │   |   utils.py
│   |   │   |   Makefile
│   │
│   └───xrt
│   |   │
│   |   └───00_hello
│   |   │   |   ......
 ```
 ## Prerequisites
1. Python
2. Enum package: pip install Enum
 ## Using source files
Calling functions from xclhal2_binding.py and xclbin_binding.py
* import source file:
>> sys.path.append('< path of the source file >') <br>
from < source file > import *
* All functions from the source file are now callable 
 ## Run 00_hello
>> cd XRT/tests/python/00_hello <br/>
cp kernel.xclbin . <br/>
python main.py -k kernel.xclbin
 ## Makefile for 00_hello
1. run <kernel.xclbin>: runs 00_hello/main.py -k kernel.xclbin
2. clean: cleans up all .pyc files
3. help: prints help for the 00_hello test