### PR TITLE
KDS scheuler loop should not keep checking CU status without any context switch.

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -60,6 +60,10 @@
 # define SCHED_DEBUG_PACKET(packet,size)
 #endif
 
+/* Scheduler call schedule() every MAX_SCHED_LOOP loop*/
+#define MAX_SCHED_LOOP 8
+static int    sched_loop_cnt;
+
 /* Forward declaration */
 struct exec_core;
 struct sched_ops;
@@ -1543,6 +1547,13 @@ scheduler_loop(struct xocl_sched *xs)
 
 	/* iterate all commands */
 	scheduler_iterate_cmds(xs);
+
+	if (sched_loop_cnt < MAX_SCHED_LOOP)
+		sched_loop_cnt++;
+	else {
+		sched_loop_cnt = 0;
+		schedule();
+	}
 }
 
 /**
@@ -1569,6 +1580,8 @@ init_scheduler_thread(void)
 	SCHED_DEBUGF("init_scheduler_thread use_count=%d\n",global_scheduler0.use_count);
 	if (global_scheduler0.use_count++)
 		return 0;
+
+	sched_loop_cnt = 0;
 
 	init_waitqueue_head(&global_scheduler0.wait_queue);
 	INIT_LIST_HEAD(&global_scheduler0.command_queue);

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -46,6 +46,10 @@
 # define SCHED_DEBUG(format, ...)
 #endif
 
+/* Scheduler call schedule() every MAX_SCHED_LOOP loop*/
+#define MAX_SCHED_LOOP 8
+static int    sched_loop_cnt;
+
 static struct scheduler g_sched0;
 static struct sched_ops penguin_ops;
 static struct sched_ops ps_ert_ops;
@@ -1162,6 +1166,13 @@ scheduler_loop(struct scheduler *sched)
 
 	/* iterate all commands */
 	scheduler_iterate_cmds(sched);
+
+	if (sched_loop_cnt < MAX_SCHED_LOOP)
+		sched_loop_cnt++;
+	else {
+		sched_loop_cnt = 0;
+		schedule();
+	}
 }
 
 /**
@@ -1191,6 +1202,8 @@ init_scheduler_thread(void)
 	SCHED_DEBUG("init_scheduler_thread use_count=%d\n", g_sched0.use_count);
 	if (g_sched0.use_count++)
 		return 0;
+
+	sched_loop_cnt = 0;
 
 	init_waitqueue_head(&g_sched0.wait_queue);
 	g_sched0.error = 0;


### PR DESCRIPTION
If KDS receive any kernel start command, it will keep polling CU status. This make KDS scheduler loop become a busy loop. This is not good since it will occupy a CPU core forever if CU is somehow not able to finished.
This is potentially leading to process hang.

Call schedule() to release the CPU for every MAX_SCHED_LOOP.

Test:
    Test on ZCU102 and fixed a hang issue.

This will need to be merged to 2018.2_xdf branch