### PR TITLE
better check xmc error and show power string and "BMC" -> "SC"

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbflash/firmware_image.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbflash/firmware_image.cpp
@@ -144,7 +144,7 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& bm
         in.read(bmcbuf.get(), bmcSection->m_sectionSize);
         if (!in.good())
         {
-            std::cout << "Can't read BMC section from "<< filename << std::endl;
+            std::cout << "Can't read SC section from "<< filename << std::endl;
             return;
         }
         const struct bmc *bmc = reinterpret_cast<const struct bmc *>(bmcbuf.get());
@@ -206,7 +206,7 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
     }
     if (!dsa.bmcVer.empty())
     {
-        stream << ",[BMC=" << dsa.bmcVer << "]";
+        stream << ",[SC=" << dsa.bmcVer << "]";
     }
     return stream;
 }
@@ -258,7 +258,7 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
             if (bmcSection == nullptr)
             {
                 this->setstate(failbit);
-                std::cout << "Can't find BMC section in "<< file << std::endl;
+                std::cout << "Can't find SC section in "<< file << std::endl;
                 return;
             }
             // Load entire BMC section.
@@ -268,7 +268,7 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
             if (!in.good())
             {
                 this->setstate(failbit);
-                std::cout << "Can't read BMC section from "<< file << std::endl;
+                std::cout << "Can't read SC section from "<< file << std::endl;
                 return;
             }
             const struct bmc *bmc = reinterpret_cast<const struct bmc *>(bmcbuf.get());

--- a/src/runtime_src/driver/xclng/tools/xbflash/flasher.h
+++ b/src/runtime_src/driver/xclng/tools/xbflash/flasher.h
@@ -44,7 +44,7 @@ struct BoardInfo
     std::string mMacAddr2;
     std::string mMacAddr3;
     std::string mBMCVer;
-    unsigned int mMaxPowerLvl;
+    std::string mMaxPower;
     unsigned int mConfigMode;
     char mFanPresence;
 };

--- a/src/runtime_src/driver/xclng/tools/xbflash/xbflash.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbflash/xbflash.cpp
@@ -216,6 +216,7 @@ int updateDSA(unsigned boardIdx, unsigned dsaIdx, bool& reboot)
 
     bool same_dsa = false;
     bool same_bmc = false;
+    bool updated_dsa = false;
     DSAInfo current = flasher.getOnBoardDSA();
     if (!current.name.empty())
     {
@@ -227,19 +228,17 @@ int updateDSA(unsigned boardIdx, unsigned dsaIdx, bool& reboot)
     if (same_dsa && same_bmc)
     {
         std::cout << "update not needed" << std::endl;
-        return -EINVAL;
     }
 
     if (!same_bmc)
     {
-        std::cout << "Updating BMC firmware on card[" << boardIdx << "]"
+        std::cout << "Updating SC firmware on card[" << boardIdx << "]"
             << std::endl;
         int ret = flashBMC(flasher, candidate);
         if (ret != 0)
         {
-            std::cout << "Failed to update BMC firmware on card["
+            std::cout << "WARNING: Failed to update SC firmware on card["
                 << boardIdx << "]" << std::endl;
-            return ret;
         }
     }
 
@@ -249,12 +248,17 @@ int updateDSA(unsigned boardIdx, unsigned dsaIdx, bool& reboot)
         int ret = flashDSA(flasher, candidate);
         if (ret != 0)
         {
-            std::cout << "Failed to update DSA on card[" << boardIdx << "]"
-                << std::endl;
-            return ret;
+            std::cout << "ERROR: Failed to update DSA on card["
+                << boardIdx << "]" << std::endl;
+        } else {
+            updated_dsa = true;
         }
-        reboot = true;
     }
+
+    reboot = updated_dsa;
+    
+    if (!same_dsa && !updated_dsa)
+	    return -EINVAL;
 
     return 0;
 }
@@ -416,7 +420,7 @@ int main( int argc, char *argv[] )
         {
             ret = flasher.upgradeBMCFirmware(args.bmc.get());
             if (ret == 0)
-                std::cout << "BMC firmware flashed successfully" << std::endl;
+                std::cout << "SC firmware flashed successfully" << std::endl;
         }
         else
         {
@@ -608,7 +612,7 @@ int scanDevices(int argc, char *argv[])
             std::cout << "\tCard S/N: \t\t" << info.mSerialNum << std::endl;
             std::cout << "\tConfig mode: \t\t" << info.mConfigMode << std::endl;
             std::cout << "\tFan presence:\t\t" << info.mFanPresence << std::endl;
-            std::cout << "\tMax power level:\t" << info.mMaxPowerLvl << std::endl;
+            std::cout << "\tMax power level:\t" << info.mMaxPower << std::endl;
             std::cout << "\tMAC address0:\t\t" << info.mMacAddr0 << std::endl;
             std::cout << "\tMAC address1:\t\t" << info.mMacAddr1 << std::endl;
             std::cout << "\tMAC address2:\t\t" << info.mMacAddr2 << std::endl;

--- a/src/runtime_src/driver/xclng/tools/xbflash/xmc.h
+++ b/src/runtime_src/driver/xclng/tools/xbflash/xmc.h
@@ -25,8 +25,8 @@
 #include <vector>
 
 // Register offset in mgmt pf BAR 0
-#define XMC_REG_BASE                0x120000
-#define XMC_GPIO_RESET              0x131000
+#define XMC_REG_BASE                        0x120000
+#define XMC_GPIO_RESET                      0x131000
 
 // Register offset in register map of XMC
 #define XMC_REG_OFF_MAGIC                   0x0
@@ -52,7 +52,19 @@
 #define XMC_HOST_MSG_MSP432_FW_LENGTH_ERR   0x04
 #define XMC_HOST_MSG_BRD_INFO_MISSING_ERR   0x05
 
-#define BMC_MODE()    (readReg(XMC_REG_OFF_STATUS) >> 28)
+#define XMC_MODE()      (readReg(XMC_REG_OFF_STATUS) & 0x3)
+#define BMC_MODE()      (readReg(XMC_REG_OFF_STATUS) >> 28)
+
+enum bmc_state {
+        BMC_STATE_UNKNOWN = 0,
+        BMC_STATE_READY,
+        BMC_STATE_BSL_UNSYNC,
+        BMC_STATE_BSL_SYNC
+};
+
+#define XMC_READY       (0x1 << 0)
+#define XMC_STOPPED     (0x1 << 1)
+#define XMC_PAUSED      (0x1 << 2)
 
 enum xmc_packet_op {
     XPO_UNKNOWN = 0,
@@ -109,6 +121,8 @@ private:
     int waitTillIdle();
     unsigned readReg(unsigned RegOffset);
     int writeReg(unsigned RegOffset, unsigned value);
+    bool isXMCReady();
+    bool isBMCReady();
 };
 
 #endif


### PR DESCRIPTION
This change fixes:
CR-1015457: Improved XMC error messaging and checking
CR-1015461: Show max power available in Watts
CR-1017807: xbutil : "BMC" output should be changed to "Satellite Controller"
This is for 2019.1