### PR TITLE
Fill entries for i>4 with data-type max, so they are parsed as 'N/A'

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -358,7 +358,16 @@ public:
             boost::property_tree::ptree ptMem;
             ptMem.put( "index",     i );
             ptMem.put( "type",      str );
-            ptMem.put( "temp",      m_devinfo.mDimmTemp[i] );
+ 
+            /* TODO:
+             * Only 4 entries in mDimmTemp[]. m_count can be greater than 4, so this will
+             * overrun mDimmTemp[]. Fill any further entries with the data type (unsigned short)
+             * max value of 65535. This get's parsed as "N/A" by sensor_tree::get_pretty().
+             */
+            if( i < 4 )
+                ptMem.put( "temp",      m_devinfo.mDimmTemp[i] ); 
+            else
+                ptMem.put( "temp", 65535 ); 
             ptMem.put( "tag",       map->m_mem_data[i].m_tag );
             ptMem.put( "enabled",   map->m_mem_data[i].m_used ? true : false );
             ptMem.put( "size",      unitConvert(map->m_mem_data[i].m_size << 10) );


### PR DESCRIPTION
Since data-type for mem_topology->temp in sensor_tree is unsigned short, if we write in 65535 it is detected as a max/invalid value and parsed as "N/A" by sensor_tree::get().

Fixes #745 