### PR TITLE
fix the bug where profile ignores the size argument in clEnqueueReadBuffer and always use the size of the buffer

### DIFF
--- a/src/runtime_src/xdp/profile/profile.cpp
+++ b/src/runtime_src/xdp/profile/profile.cpp
@@ -170,7 +170,7 @@ cb_action_ndrange (xocl::event* event,cl_int status,const std::string& cu_name, 
 }
 
 void
-cb_action_read (xocl::event* event,cl_int status, cl_mem buffer, size_t size, uint64_t address, const std::string& bank)
+cb_action_read (xocl::event* event,cl_int status, cl_mem buffer, size_t size, uint64_t address, const std::string& bank, bool entire_buffer, size_t user_size, size_t user_offset)
 {
     if (!isProfilingOn())
       return;
@@ -193,11 +193,18 @@ cb_action_read (xocl::event* event,cl_int status, cl_mem buffer, size_t size, ui
     auto threadId = std::this_thread::get_id();
     double timestampMsec = (status == CL_COMPLETE) ? event->time_end() / 1e6 : 0.0;
 
+    size_t actual_size = 0;
+    if (entire_buffer) {
+      actual_size = size;
+    } else {
+      actual_size = user_size;
+    }
+
     XCL::RTSingleton::Instance()->getProfileManager()->logDataTransfer
       (reinterpret_cast<uint64_t>(buffer)
        ,XCL::RTProfile::READ_BUFFER
        ,commandState
-       ,size
+       ,actual_size
        ,contextId
        ,numDevices
        ,deviceName

--- a/src/runtime_src/xocl/api/clEnqueueReadBuffer.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueReadBuffer.cpp
@@ -101,7 +101,7 @@ clEnqueueReadBuffer(cl_command_queue   command_queue,
   auto uevent = xocl::create_hard_event
     (command_queue,CL_COMMAND_READ_BUFFER,num_events_in_wait_list,event_wait_list);
   xocl::enqueue::set_event_action(uevent.get(),xocl::enqueue::action_read_buffer,buffer,offset,size,ptr);
-  xocl::profile::set_event_action(uevent.get(),xocl::profile::action_read,buffer);
+  xocl::profile::set_event_action(uevent.get(),xocl::profile::action_read,buffer,offset,size,false);
   xocl::appdebug::set_event_action(uevent.get(),xocl::appdebug::action_readwrite,buffer,offset,size,ptr);
  
   uevent->queue();

--- a/src/runtime_src/xocl/api/clEnqueueReadImage.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueReadImage.cpp
@@ -137,7 +137,7 @@ clEnqueueReadImage(cl_command_queue      command_queue ,
   xocl::enqueue::set_event_action
     (uevent.get(),xocl::enqueue::action_read_image,image,origin,region,row_pitch,slice_pitch,ptr);
   xocl::profile::set_event_action
-    (uevent.get(),xocl::profile::action_read,image);
+    (uevent.get(),xocl::profile::action_read,image,0,0,true);
   xocl::appdebug::set_event_action
     (uevent.get(),xocl::appdebug::action_readwrite_image,image,origin,region,row_pitch,slice_pitch,ptr);
 

--- a/src/runtime_src/xocl/api/plugin/xdp/profile.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/profile.cpp
@@ -249,16 +249,16 @@ action_ndrange(cl_event event, cl_kernel kernel)
 }
 
 xocl::event::action_profile_type
-action_read(cl_mem buffer)
+action_read(cl_mem buffer, size_t user_offset, size_t user_size, bool entire_buffer)
 {
   std::string bank;
   uint64_t address;
   get_address_bank(buffer, address, bank);
   auto size = xocl::xocl(buffer)->get_size();
 
-  return [buffer,size,address,bank](xocl::event* event,cl_int status, const std::string&) {
+  return [buffer,size,address,bank,user_offset,user_size,entire_buffer](xocl::event* event,cl_int status, const std::string&) {
     if (cb_action_read)
-      cb_action_read(event, status, buffer, size, address, bank);
+      cb_action_read(event, status, buffer, size, address, bank, entire_buffer, user_size, user_offset);
   };
 }
 

--- a/src/runtime_src/xocl/api/plugin/xdp/profile.h
+++ b/src/runtime_src/xocl/api/plugin/xdp/profile.h
@@ -44,7 +44,7 @@ using cb_action_ndrange_type = std::function<void (xocl::event* event,cl_int sta
                                                    std::string kname, std::string xname, size_t workGroupSize,
                                                    const size_t* globalWorkDim, const size_t* localWorkDim, unsigned int programId)>;
 using cb_action_read_type = std::function<void (xocl::event* event,cl_int status, cl_mem buffer, size_t size,
-                                          uint64_t address, const std::string& bank)>;
+                                          uint64_t address, const std::string& bank, size_t user_offset, size_t user_size, bool entire_buffer)>;
 using cb_action_map_type = std::function<void (xocl::event* event,cl_int status, cl_mem buffer, size_t size,
                                                uint64_t address, const std::string& bank, cl_map_flags map_flags)>;
 using cb_action_write_type = std::function<void (xocl::event* event,cl_int status, cl_mem buffer, size_t size,
@@ -115,7 +115,7 @@ xocl::event::action_profile_type
 action_ndrange(cl_event event,cl_kernel kernel);
 
 xocl::event::action_profile_type
-action_read(cl_mem buffer);
+action_read(cl_mem buffer, size_t offset, size_t size, bool entire_buffer);
 
 xocl::event::action_profile_type
 action_map(cl_mem buffer,cl_map_flags map_flags);


### PR DESCRIPTION
A CR was filed on profile timeline trace always report the same size no matter how much is actually migrated. 

Cause: the profiling plugin inside clEnqueueReadBuffer is only capturing the buffer object and getting the size from the buffer object.

Fix: also pass in the user-defined size and offset, and use the actual size in the report.