### PR TITLE
board reset init'ed from user pf

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.c
@@ -69,8 +69,6 @@ static int char_open(struct inode *inode, struct file *file)
 {
 	struct xclmgmt_char *lro_char;
 	struct xclmgmt_dev *lro;
-	struct xclmgmt_proc_ctx ctx;
-	int	ret;
 
 	/* pointer to containing data structure of the character device inode */
 	lro_char = container_of(inode->i_cdev, struct xclmgmt_char, cdev);
@@ -79,23 +77,6 @@ static int char_open(struct inode *inode, struct file *file)
 	file->private_data = lro_char;
 	lro = lro_char->lro;
 	BUG_ON(!lro);
-
-	mutex_lock(&lro->busy_mutex);
-	if (lro->reset_firewall) {
-		mutex_unlock(&lro->busy_mutex);
-		mgmt_err(lro, "resetting firewall");
-		return -EAGAIN;
-	}
-	mutex_unlock(&lro->busy_mutex);
-
-	ctx.pid = task_tgid(current);
-	ctx.lro = lro;
-	ctx.signaled = false;
-	ret = xocl_ctx_add(&lro->ctx_table, &ctx, sizeof (ctx));
-	if (ret && ret != -EEXIST) {
-		mgmt_err(lro, "add proc context failed, ret = %d", ret);
-		return ret;
-	}
 
 	mgmt_info(lro, "opened file %p by pid: %d\n",
 		file, pid_nr(task_tgid(current)));
@@ -110,7 +91,6 @@ static int char_close(struct inode *inode, struct file *file)
 {
 	struct xclmgmt_dev *lro;
 	struct xclmgmt_char *lro_char;
-	struct xclmgmt_proc_ctx ctx;
 
 	lro_char = (struct xclmgmt_char *)file->private_data;
 	BUG_ON(!lro_char);
@@ -118,10 +98,6 @@ static int char_close(struct inode *inode, struct file *file)
 	/* fetch device specific data stored earlier during open */
 	lro = lro_char->lro;
 	BUG_ON(!lro);
-
-	ctx.pid = task_tgid(current);
-	ctx.lro = lro;
-	(void) xocl_ctx_remove(&lro->ctx_table, &ctx);
 
 	mgmt_info(lro, "Closing file %p by pid: %d\n",
 		file, pid_nr(task_tgid(current)));
@@ -463,69 +439,27 @@ static void check_sysmon(struct xclmgmt_dev *lro)
         check_volt_within_range(lro, val);
 }
 
-static int kill_process(struct xocl_context_hash *ctx_hash, void *arg)
-{
-        struct xclmgmt_proc_ctx *ctx = arg;
-        int     ret = 0;
-
-        if (!ctx->signaled) {
-                ret = kill_pid(ctx->pid, SIGBUS, 1);
-                if (ret != 0)
-                        mgmt_err(ctx->lro, "Killing pid: %d failed. Err: %d",
-                                pid_nr(ctx->pid), ret);
-                ctx->signaled = true;
-        }
-
-        return ret;
-}
-
 static int health_check_cb(void *data)
 {
         struct xclmgmt_dev *lro = (struct xclmgmt_dev *)data;
-        int     ret = 0;
+	struct mailbox_req mbreq = { MAILBOX_REQ_FIREWALL, };
+	bool tripped;
 
         if (!health_check)
                 return 0;
-        mutex_lock(&lro->busy_mutex);
-        if (!xocl_af_check(lro, NULL)) {
-                check_sysmon(lro);
-        } else {
-                ret = xocl_ctx_traverse(&lro->ctx_table, kill_process);
-		/* stop user pf */
-		xocl_reset(lro, true);
-                if (xocl_af_clear(lro) && !XOCL_DSA_PCI_RESET_OFF(lro)) {
-			mgmt_info(lro, "Issuing pcie hot reset.");
-                        xclmgmt_reset_pci(lro);
-                }
-		xocl_af_check(lro, NULL);
 
-		freezeAXIGate(lro);
-	        msleep(500);
-	        freeAXIGate(lro);
-	        msleep(500);
-		xocl_reset(lro, false);
-        }
+        mutex_lock(&lro->busy_mutex);
+	tripped = xocl_af_check(lro, NULL);
         mutex_unlock(&lro->busy_mutex);
 
+        if (!tripped) {
+                check_sysmon(lro);
+        } else {
+		mgmt_info(lro, "firewall tripped, notify peer");
+                (void) xocl_peer_notify(lro, &mbreq);
+        }
+
         return 0;
-}
-
-static u32 proc_hash(void *arg)
-{
-        struct xclmgmt_proc_ctx *ctx = arg;
-        u32 pid = pid_nr(ctx->pid);
-
-        return (pid % MGMT_PROC_TABLE_HASH_SZ);
-}
-
-static int proc_cmp(void *arg_o, void *arg_n)
-{
-        struct xclmgmt_proc_ctx *ctx_o = arg_o;
-        struct xclmgmt_proc_ctx *ctx_n = arg_n;
-        u32 pid_o = pid_nr(ctx_o->pid);
-        u32 pid_n = pid_nr(ctx_n->pid);
-
-        return (pid_o - pid_n);
 }
 
 static inline bool xclmgmt_support_intr(struct xclmgmt_dev *lro)
@@ -643,6 +577,9 @@ static void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			req->u.req_bit_lock.pid);
 		(void) xocl_peer_response(lro, msgid, &ret, sizeof (ret));
 		break;
+	case MAILBOX_REQ_HOT_RESET:
+		ret = (int) reset_hot_ioctl(lro);
+		(void) xocl_peer_response(lro, msgid, &ret, sizeof (ret));
 	default:
 		break;
 	}
@@ -692,13 +629,6 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 	ret = xocl_icap_download_boot_firmware(lro);
 	if (ret)
 		goto fail_all_subdev;
-
-	ret = xocl_ctx_init(&pdev->dev, &lro->ctx_table,
-		MGMT_PROC_TABLE_HASH_SZ, proc_hash, proc_cmp);
-	if (ret) {
-		xocl_err(&pdev->dev, "failed to create ctx table\n");
-		goto fail_all_subdev;
-	}
 
 	xocl_af_start_health_check(lro, health_check_cb, lro,
 		health_interval * 1000);
@@ -844,9 +774,6 @@ static void xclmgmt_remove(struct pci_dev *pdev)
 	mgmt_fini_sysfs(&pdev->dev);
 
 	xocl_subdev_destroy_all(lro);
-
-	/* free contexts */
-	xocl_ctx_fini(&pdev->dev, &lro->ctx_table);
 
 	xclmgmt_teardown_msix(lro);
 	/* remove user character device */

--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.c
@@ -410,56 +410,56 @@ struct pci_dev *find_user_node(const struct pci_dev *pdev)
 
 inline void check_temp_within_range(struct xclmgmt_dev *lro, u32 temp)
 {
-        if(temp < LOW_TEMP || temp > HI_TEMP) {
-                mgmt_err(lro, "Temperature outside normal range (%d-%d) %d.",
-                        LOW_TEMP, HI_TEMP, temp);
-        }
+	if(temp < LOW_TEMP || temp > HI_TEMP) {
+		mgmt_err(lro, "Temperature outside normal range (%d-%d) %d.",
+			LOW_TEMP, HI_TEMP, temp);
+	}
 }
 
 inline void check_volt_within_range(struct xclmgmt_dev *lro, u16 volt)
 {
-        if(volt < LOW_MILLVOLT || volt > HI_MILLVOLT) {
-                mgmt_err(lro, "Voltage outside normal range (%d-%d)mV %d.",
-                        LOW_MILLVOLT, HI_MILLVOLT, volt);
-        }
+	if(volt < LOW_MILLVOLT || volt > HI_MILLVOLT) {
+		mgmt_err(lro, "Voltage outside normal range (%d-%d)mV %d.",
+			LOW_MILLVOLT, HI_MILLVOLT, volt);
+	}
 }
 
 static void check_sysmon(struct xclmgmt_dev *lro)
 {
-        u32             val;
+	u32 val;
 
-        xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_TEMP, &val);
-        check_temp_within_range(lro, val);
+	xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_TEMP, &val);
+	check_temp_within_range(lro, val);
 
-        xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_VCC_INT, &val);
-        check_volt_within_range(lro, val);
-        xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_VCC_AUX, &val);
-        check_volt_within_range(lro, val);
-        xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_VCC_BRAM, &val);
-        check_volt_within_range(lro, val);
+	xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_VCC_INT, &val);
+	check_volt_within_range(lro, val);
+	xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_VCC_AUX, &val);
+	check_volt_within_range(lro, val);
+	xocl_sysmon_get_prop(lro, XOCL_SYSMON_PROP_VCC_BRAM, &val);
+	check_volt_within_range(lro, val);
 }
 
 static int health_check_cb(void *data)
 {
-        struct xclmgmt_dev *lro = (struct xclmgmt_dev *)data;
+	struct xclmgmt_dev *lro = (struct xclmgmt_dev *)data;
 	struct mailbox_req mbreq = { MAILBOX_REQ_FIREWALL, };
 	bool tripped;
 
-        if (!health_check)
-                return 0;
+	if (!health_check)
+		return 0;
 
-        mutex_lock(&lro->busy_mutex);
+	mutex_lock(&lro->busy_mutex);
 	tripped = xocl_af_check(lro, NULL);
-        mutex_unlock(&lro->busy_mutex);
+	mutex_unlock(&lro->busy_mutex);
 
-        if (!tripped) {
-                check_sysmon(lro);
-        } else {
+	if (!tripped) {
+		check_sysmon(lro);
+	} else {
 		mgmt_info(lro, "firewall tripped, notify peer");
-                (void) xocl_peer_notify(lro, &mbreq);
-        }
+		(void) xocl_peer_notify(lro, &mbreq);
+	}
 
-        return 0;
+	return 0;
 }
 
 static inline bool xclmgmt_support_intr(struct xclmgmt_dev *lro)

--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-core.h
@@ -94,10 +94,7 @@ struct xclmgmt_dev {
 	int axi_gate_frozen;
 	unsigned short ocl_frequency[4];
 
-	struct xocl_context_hash ctx_table;
-
 	struct mutex busy_mutex;
-	bool reset_firewall;
 	struct mgmt_power power;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
@@ -117,8 +114,6 @@ struct xclmgmt_char {
 extern int health_check;
 
 int ocl_freqscaling_ioctl(struct xclmgmt_dev *lro, const void __user *arg);
-void freezeAXIGate(struct xclmgmt_dev *lro);
-void freeAXIGate(struct xclmgmt_dev *lro);
 void platform_axilite_flush(struct xclmgmt_dev *lro);
 u16 get_dsa_version(struct xclmgmt_dev *lro);
 void fill_frequency_info(struct xclmgmt_dev *lro, struct xclmgmt_ioc_info *obj);
@@ -131,19 +126,14 @@ void get_pcie_link_info(struct xclmgmt_dev *lro,
 unsigned compute_unit_busy(struct xclmgmt_dev *lro);
 int pci_fundamental_reset(struct xclmgmt_dev *lro);
 
-/* Note: Use reset_hot_ioctl over pcie fundamental reset.
- * This method is known to work better.
- */
 long reset_hot_ioctl(struct xclmgmt_dev *lro);
 void xdma_reset(struct pci_dev *pdev, bool prepare);
-void xocl_reset(struct xclmgmt_dev *lro, bool prepare);
 void xclmgmt_reset_pci(struct xclmgmt_dev *lro);
 
 // firewall.c
 void init_firewall(struct xclmgmt_dev *lro);
 void xclmgmt_killall_processes(struct xclmgmt_dev *lro);
 void xclmgmt_list_add(struct xclmgmt_dev *lro, struct pid *new_pid);
-//struct proc_list *xclmgmt_find_by_pid(struct xclmgmt_dev *lro, struct pid *find_pid);
 void xclmgmt_list_remove(struct xclmgmt_dev *lro, struct pid *remove_pid);
 void xclmgmt_list_del(struct xclmgmt_dev *lro);
 bool xclmgmt_check_proc(struct xclmgmt_dev *lro, struct pid *pid);

--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-ioctl.c
@@ -67,8 +67,7 @@ static int version_ioctl(struct xclmgmt_dev *lro, void __user *arg)
 
 static long reset_ocl_ioctl(struct xclmgmt_dev *lro)
 {
-	freezeAXIGate(lro);
-	freeAXIGate(lro);
+	xocl_icap_reset_axi_gate(lro);
 	return compute_unit_busy(lro) ? -EBUSY : 0;
 }
 
@@ -108,11 +107,6 @@ long mgmt_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		return -EFAULT;
 
 	mutex_lock(&lro->busy_mutex);
-	if (lro->reset_firewall) {
-		mgmt_err(lro, "Firewall tripped!");
-		mutex_unlock(&lro->busy_mutex);
-		return -EBUSY;
-	}
 
 	switch (cmd) {
 	case XCLMGMT_IOCINFO:

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -182,6 +182,7 @@ void xocl_fini_sysfs(struct device *dev);
 ssize_t xocl_mm_sysfs_stat(struct xocl_dev *xdev, char *buf, bool raw);
 
 /* helper functions */
+int xocl_hot_reset(struct xocl_dev *xdev, bool force);
 void xocl_reset_notify(struct pci_dev *pdev, bool prepare);
 int xocl_reset_scheduler(struct pci_dev *pdev);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xdma.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xdma.c
@@ -59,10 +59,7 @@ static int user_dev_online(xdev_handle_t xdev_hdl)
 {
 	struct xocl_dev *xdev = (struct xocl_dev *)xdev_hdl;
 
-	if (xdev->offline) {
-		xdma_device_online(xdev->core.pdev, xdev->dma_handle);
-		xdev->offline = false;
-	}
+	xdma_device_online(xdev->core.pdev, xdev->dma_handle);
 	xocl_info(&xdev->core.pdev->dev, "Device online");
 
 	return 0;
@@ -72,10 +69,7 @@ static int user_dev_offline(xdev_handle_t xdev_hdl)
 {
 	struct xocl_dev *xdev = (struct xocl_dev *)xdev_hdl;
 
-	if (!xdev->offline) {
-		xdma_device_offline(xdev->core.pdev, xdev->dma_handle);
-		xdev->offline = true;
-	}
+	xdma_device_offline(xdev->core.pdev, xdev->dma_handle);
 	xocl_info(&xdev->core.pdev->dev, "Device offline");
 	return 0;
 }

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -37,31 +37,26 @@ xuid_t uuid_null = NULL_UUID_LE;
 static int
 xocl_client_lock_bitstream(struct xocl_dev *xdev, struct client_ctx *client)
 {
+	int pid = pid_nr(task_tgid(current));
+
 	if (atomic_read(&client->xclbin_locked))
 		return 0;
 
-	if (xocl_icap_lock_bitstream(xdev, &xdev->xclbin_id,pid_nr(task_tgid(current)))) {
-		userpf_err(xdev,"could not lock bitstream for process %d",pid_nr(task_tgid(current)));
+	if (!uuid_equal(&xdev->xclbin_id, &client->xclbin_id)) {
+		userpf_err(xdev, "device xclbin does not match context xclbin, "
+			"cannot obtain lock for process %d", pid);
 		return 1;
 	}
 
-//      Allow second process to use current xclbin without downloading
-//	if (uuid_is_null(&client->xclbin_id))
-//		uuid_copy(&client->xclbin_id,&xdev->xclbin_id);
-//	else
-	if (!uuid_equal(&xdev->xclbin_id,&client->xclbin_id)) {
-		userpf_err(xdev,"device xclbin does not match context xclbin, cannot obtain lock for process %d",
-			   pid_nr(task_tgid(current)));
-		goto out;
+	if (xocl_icap_lock_bitstream(xdev, &xdev->xclbin_id, pid) < 0) {
+		userpf_err(xdev,
+			"could not lock bitstream for process %d", pid);
+		return 1;
 	}
 
 	atomic_set(&client->xclbin_locked,true);
-	userpf_info(xdev,"process %d successfully locked xcblin",pid_nr(task_tgid(current)));
+	userpf_info(xdev, "process %d successfully locked xcblin", pid);
 	return 0;
-
-out:
-	(void) xocl_icap_unlock_bitstream(xdev, &xdev->xclbin_id,pid_nr(task_tgid(current)));
-	return 1;
 }
 
 
@@ -192,6 +187,7 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	struct xocl_dev *xdev = dev->dev_private;
 	struct client_ctx *client = filp->driver_priv;
 	int ret = 0;
+	int pid = pid_nr(task_tgid(current));
 
 	mutex_lock(&client->lock);
 	mutex_lock(&xdev->ctx_list_lock);
@@ -201,13 +197,15 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	}
 
 	if (args->cu_index >= xdev->layout->m_count) {
-		userpf_err(xdev, "cuidx(%d) >= numcus(%d)\n",args->cu_index,xdev->layout->m_count);
+		userpf_err(xdev, "cuidx(%d) >= numcus(%d)\n",
+			args->cu_index,xdev->layout->m_count);
 		ret = -EINVAL;
 		goto out;
 	}
 
 	if (args->op == XOCL_CTX_OP_FREE_CTX) {
-		ret = test_and_clear_bit(args->cu_index, client->cu_bitmap) ? 0 : -EINVAL;
+		ret = test_and_clear_bit(args->cu_index,
+			client->cu_bitmap) ? 0 : -EINVAL;
 		if (ret) // No context was previously allocated for this CU
 			goto out;
 
@@ -215,12 +213,14 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 		--client->num_cus;
 		--xdev->ip_reference[args->cu_index];
 		if (!client->num_cus) {
-                        // We just gave up the last context, give up the xclbin lock
+			// We just gave up the last context, unlock the xclbin
 			ret = xocl_icap_unlock_bitstream(xdev, &xdev->xclbin_id,
-							 pid_nr(task_tgid(current)));
+				pid);
+			if (ret == 0)
+				xocl_exec_reset(xdev);
 		}
-		xocl_info(dev->dev, "CTX del(%pUb, %d, %u)", &xdev->xclbin_id, pid_nr(task_tgid(current)),
-			  args->cu_index);
+		xocl_info(dev->dev,"CTX del(%pUb, %d, %u)",
+			&xdev->xclbin_id, pid, args->cu_index);
 		goto out;
 	}
 
@@ -230,27 +230,31 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	}
 
 	if ((args->flags != XOCL_CTX_SHARED)) {
-		userpf_err(xdev, "Only shared contexts are supported in this release");
+		userpf_err(xdev,
+			"Only shared contexts are supported in this release");
 		ret = -EPERM;
 		goto out;
 	}
 
 	if (!client->num_cus && !atomic_read(&client->xclbin_locked))
-		// Process has no other context on any CU yet, hence we need to lock the xclbin
-		// A process uses just one lock for all its contexts
+		// Process has no other context on any CU yet, hence we
+		// need to lock the xclbin. A process uses just one lock for
+		// all its contexts.
 		acquire_lock = true;
 
 	if (test_and_set_bit(args->cu_index, client->cu_bitmap)) {
-		userpf_info(xdev, "Context has already been allocated before by this process");
-		// Context was previously allocated for the same CU, cannot allocate again
+		userpf_info(xdev, "CTX already allocated by this process");
+		// Context was previously allocated for the same CU,
+		// cannot allocate again
 		ret = 0;
 		goto out;
 	}
 
 	if (acquire_lock) {
-                // This is the first context on any CU for this process, lock the xclbin
+                // This is the first context on any CU for this process,
+		// lock the xclbin
 		ret = xocl_client_lock_bitstream(xdev, client);
-		if (ret) {
+		if (ret < 0) {
 			// Locking of xclbin failed, give up our context
 			clear_bit(args->cu_index, client->cu_bitmap);
 			goto out;
@@ -263,7 +267,8 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	// Everything is good so far, hence increment the CU reference count
 	++client->num_cus; // explicitly acquired
 	++xdev->ip_reference[args->cu_index];
-	xocl_info(dev->dev, "CTX add(%pUb, %d, %u, %d)", &xdev->xclbin_id, pid_nr(task_tgid(current)), args->cu_index,acquire_lock);
+	xocl_info(dev->dev, "CTX add(%pUb, %d, %u, %d)",
+		&xdev->xclbin_id, pid, args->cu_index,acquire_lock);
 out:
 	// If all explicit resources are given up, then release the xclbin
 	if (!client->num_cus)
@@ -625,8 +630,9 @@ xocl_read_axlf_helper(struct xocl_dev *xdev, struct drm_xocl_axlf *axlf_ptr)
 
 	err = xocl_icap_lock_bitstream(xdev, &bin_obj.m_header.uuid,
 		pid_nr(task_tgid(current)));
-	if (err)
+	if (err < 0)
 		goto done;
+	err = 0;
 
 	if (uuid_equal(&xdev->xclbin_id, &bin_obj.m_header.uuid)) {
 		printk(KERN_INFO "Skipping repopulating topology, connectivity,ip_layout data\n");

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_sysfs.c
@@ -235,6 +235,18 @@ static struct bin_attribute mem_topology_attr = {
 	.size = 0
 };
 
+static ssize_t reset_store(struct device *dev, struct device_attribute *da,
+	const char *buf, size_t count)
+{
+	int ret = xocl_hot_reset(dev_get_drvdata(dev), false);
+
+	if (ret == 0)
+		return count;
+
+	return ret;
+}
+static DEVICE_ATTR_WO(reset);
+
 static struct attribute *xocl_attrs[] = {
 	&dev_attr_xclbinuuid.attr,
 	&dev_attr_userbar.attr,
@@ -242,6 +254,7 @@ static struct attribute *xocl_attrs[] = {
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,
 	&dev_attr_user_pf.attr,
+	&dev_attr_reset.attr,
 	NULL,
 };
 

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -479,9 +479,8 @@ enum mailbox_request {
 	MAILBOX_REQ_TEST_READ,
 	MAILBOX_REQ_LOCK_BITSTREAM,
 	MAILBOX_REQ_UNLOCK_BITSTREAM,
-	MAILBOX_REQ_HOT_RESET_BEGIN,
-	MAILBOX_REQ_HOT_RESET_END,
-	MAILBOX_REQ_RESET_ERT,
+	MAILBOX_REQ_HOT_RESET,
+	MAILBOX_REQ_FIREWALL,
 };
 
 struct mailbox_req_bitstream_lock {
@@ -529,8 +528,7 @@ struct xocl_mailbox_funcs {
 	end) : -ENODEV)
 
 struct xocl_icap_funcs {
-	int (*freeze_axi_gate)(struct platform_device *pdev);
-	int (*free_axi_gate)(struct platform_device *pdev);
+	void (*reset_axi_gate)(struct platform_device *pdev);
 	int (*reset_bitstream)(struct platform_device *pdev);
 	int (*download_bitstream_axlf)(struct platform_device *pdev,
 		const void __user *arg);
@@ -548,10 +546,8 @@ struct xocl_icap_funcs {
 #define	ICAP_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_ICAP).pldev
 #define	ICAP_OPS(xdev)							\
 	((struct xocl_icap_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ICAP).ops)
-#define	xocl_icap_freeze_axi_gate(xdev)					\
-	ICAP_OPS(xdev)->freeze_axi_gate(ICAP_DEV(xdev))
-#define	xocl_icap_free_axi_gate(xdev)					\
-	ICAP_OPS(xdev)->free_axi_gate(ICAP_DEV(xdev))
+#define	xocl_icap_reset_axi_gate(xdev)					\
+	ICAP_OPS(xdev)->reset_axi_gate(ICAP_DEV(xdev))
 #define	xocl_icap_reset_bitstream(xdev)					\
 	ICAP_OPS(xdev)->reset_bitstream(ICAP_DEV(xdev))
 #define	xocl_icap_download_axlf(xdev, xclbin)				\
@@ -594,8 +590,6 @@ int xocl_subdev_get_devinfo(uint32_t subdev_id,
 void xocl_subdev_register(struct platform_device *pldev, u32 id,
 	void *cb_funcs);
 void xocl_fill_dsa_priv(xdev_handle_t xdev_hdl, struct xocl_board_private *in);
-struct pci_dev *xocl_hold_userdev(xdev_handle_t xdev_hdl);
-void xocl_release_userdev(struct pci_dev *userdev);
 int xocl_xrt_version_check(xdev_handle_t xdev_hdl,
         struct axlf *bin_obj, bool major_only);
 int xocl_alloc_dev_minor(xdev_handle_t xdev_hdl);

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_subdev.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_subdev.c
@@ -432,63 +432,6 @@ void xocl_fill_dsa_priv(xdev_handle_t xdev_hdl, struct xocl_board_private *in)
 	}
 }
 
-static int match_user_rom_dev(struct device *dev, void *data)
-{
-	struct platform_device *pldev = to_platform_device(dev);
-	struct xocl_dev_core *core;
-	struct pci_dev *pdev;
-	unsigned long slot;
-
-	if (strncmp(dev_name(dev), XOCL_FEATURE_ROM_USER,
-		strlen(XOCL_FEATURE_ROM_USER)) == 0) {
-		core = (struct xocl_dev_core *)xocl_get_xdev(pldev); 
-		pdev = core->pdev;
-		slot = PCI_SLOT(pdev->devfn);
-
-		if (slot == (unsigned long)data)
-			return true;
-	}
-
-	return false;
-}
-
-struct pci_dev *xocl_hold_userdev(xdev_handle_t xdev_hdl)
-{
-	struct device *user_rom_dev;
-	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev_hdl;
-        struct pci_dev *pdev = core->pdev;
-	struct pci_dev *userdev;
-	unsigned long slot = PCI_SLOT(pdev->devfn);
-	struct xocl_dev_core *user_core;
-
-	user_rom_dev = bus_find_device(&platform_bus_type, NULL, (void *)slot,
-		match_user_rom_dev);
-
-	if (!user_rom_dev)
-		return NULL;
-
-	user_core = (struct xocl_dev_core *)xocl_get_xdev(
-		to_platform_device(user_rom_dev));
-	userdev = user_core->pdev;
-
-	if (!get_device(&userdev->dev))
-		return NULL;
-
-	device_lock(&userdev->dev);
-	if (!userdev->dev.driver) {
-		device_unlock(&pdev->dev);
-		return NULL;
-	}
-
-	return user_core->pdev;
-}
-
-void xocl_release_userdev(struct pci_dev *userdev)
-{
-	device_unlock(&userdev->dev);
-	put_device(&userdev->dev);
-}
-
 int xocl_xrt_version_check(xdev_handle_t xdev_hdl,
 	struct axlf *bin_obj, bool major_only)
 {

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -66,7 +66,6 @@ enum command {
     HELP,
     QUERY,
     DUMP,
-    RESET,
     RUN,
     FAN,
     DMATEST,
@@ -103,7 +102,6 @@ static const std::pair<std::string, command> map_pairs[] = {
     std::make_pair("help", HELP),
     std::make_pair("query", QUERY),
     std::make_pair("dump", DUMP),
-    std::make_pair("reset", RESET),
     std::make_pair("run", RUN),
     std::make_pair("fan", FAN),
     std::make_pair("dmatest", DMATEST),
@@ -954,11 +952,6 @@ public:
         }
     }
 
-    int reset(unsigned region) {
-        const xclResetKind kind = (region == 0xffffffff) ? XCL_RESET_FULL : XCL_RESET_KERNEL;
-        return xclResetDevice(m_handle, kind);
-    }
-
     int run(unsigned region, unsigned cu) {
         std::cout << "ERROR: Not implemented\n";
         return -1;
@@ -1240,6 +1233,7 @@ public:
 
     int printEccInfo(std::ostream& ostr) const;
     int resetEccInfo();
+    int reset(xclResetKind kind);
 
 private:
     // Run a test case as <exe> <xclbin> [-d index] on this device and collect
@@ -1251,6 +1245,7 @@ private:
 
 void printHelp(const std::string& exe);
 int xclTop(int argc, char *argv[]);
+int xclReset(int argc, char *argv[]);
 int xclValidate(int argc, char *argv[]);
 std::unique_ptr<xcldev::device> xclGetDevice(unsigned index);
 } // end namespace xcldev


### PR DESCRIPTION
With this change, the reset will be initiated from user pf when you do xbutil reset (same as xbutil reset -h now). Xbutil reset -x and -f are added as hidden options for performing OCL reset and hot reset through xclmgmt respectively. They requires sudo and does not involve xocl any more (meant for debug usage only).