### PR TITLE
Remove atomics that are not needed or flat out wrong

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -2035,6 +2035,8 @@ static int icap_unlock_bitstream(struct platform_device *pdev, const xuid_t *id,
 			err = icap->icap_bitstream_ref;
 	} else {
 		err = icap_lock_unlock_peer_bitstream(icap, id, pid, false);
+		if (err==0)
+			xocl_exec_reset(xocl_get_xdev(pdev));
 	}
 
 	ICAP_INFO(icap, "proc %d try to unlock bitstream %pUb, ref=%d, err=%d",

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -123,7 +123,7 @@ struct xocl_dev	{
 	unsigned                        ip_reference[MAX_CUS];
 	struct list_head                ctx_list;
 	struct mutex			ctx_list_lock;
-	atomic_t                        needs_reset;
+	unsigned int                    needs_reset; /* bool aligned */
 	atomic_t                        outstanding_execs;
 	atomic64_t                      total_execs;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
@@ -147,11 +147,11 @@ struct xocl_dev	{
 struct client_ctx {
 	struct list_head	link;
 	xuid_t                  xclbin_id;
-	atomic_t                xclbin_locked;
-	atomic_t		trigger;
-	atomic_t                outstanding_execs;
-	atomic_t                abort;
+	unsigned int            xclbin_locked;
+	unsigned int            abort;
 	unsigned int            num_cus;     /* number of resource locked explicitly by client */
+	atomic_t 		trigger;     /* count of poll notification to acknowledge */
+	atomic_t                outstanding_execs;
 	struct mutex		lock;
 	struct xocl_dev        *xdev;
 	DECLARE_BITMAP(cu_bitmap, MAX_CUS);  /* may contain implicitly aquired resources such as CDMA */

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
@@ -198,39 +198,32 @@ static void xocl_client_release(struct drm_device *dev, struct drm_file *filp)
 {
 	struct xocl_dev	*xdev = dev->dev_private;
 	struct client_ctx *client = filp->driver_priv;
-	unsigned bit = xdev->layout ? find_first_bit(client->cu_bitmap,
-		xdev->layout->m_count) : MAX_CUS;
+	unsigned bit = xdev->layout
+		? find_first_bit(client->cu_bitmap,xdev->layout->m_count)
+		: MAX_CUS;
+	int pid = pid_nr(task_tgid(current));
 
 	DRM_ENTER("");
 
 	/*
 	 * This happens when application exists without formally releasing the
 	 * contexts on CUs. Give up our contexts on CUs and our lock on xclbin.
-	 * Note, that implicitly CUs (such as CDMA) do not add to ip_reference.
+	 * Note, that implicit CUs (such as CDMA) do not add to ip_reference.
 	 */
 	while (xdev->layout && (bit < xdev->layout->m_count)) {
 		if (xdev->ip_reference[bit]) {
 			userpf_info(xdev, "CTX reclaim (%pUb, %d, %u)",
-				&client->xclbin_id, pid_nr(task_tgid(current)),
-				bit);
+				    &client->xclbin_id, pid,bit);
 			xdev->ip_reference[bit]--;
 		}
-		bit = find_next_bit(client->cu_bitmap, xdev->layout->m_count,
-			bit + 1);
+		bit = find_next_bit(client->cu_bitmap,xdev->layout->m_count,bit + 1);
 	}
 	bitmap_zero(client->cu_bitmap, MAX_CUS);
-	if (atomic_read(&client->xclbin_locked)) {
-		if (xocl_icap_unlock_bitstream(xdev, &client->xclbin_id,
-			pid_nr(task_tgid(current))) == 0)
-			xocl_exec_reset(xdev);
-	}
-
 	xocl_exec_destroy_client(xdev, &filp->driver_priv);
 }
 
 static uint xocl_poll(struct file *filp, poll_table *wait)
 {
-	uint result = 0;
 	struct drm_file *priv = filp->private_data;
 	struct drm_device *dev = priv->minor->dev;
 	struct xocl_dev	*xdev = dev->dev_private;
@@ -238,10 +231,7 @@ static uint xocl_poll(struct file *filp, poll_table *wait)
 	BUG_ON(!priv->driver_priv);
 
 	DRM_ENTER("");
-	if (MB_SCHEDULER_DEV(xdev))
-		result = xocl_exec_poll_client(xdev, filp, wait,
-					       priv->driver_priv);
-	return result;
+	return xocl_exec_poll_client(xdev, filp, wait,priv->driver_priv);
 }
 
 static const struct drm_ioctl_desc xocl_ioctls[] = {
@@ -425,7 +415,7 @@ int xocl_drm_init(struct xocl_dev *xdev)
 	struct drm_device	*ddev = NULL;
 	int			ret = 0;
 
-	sscanf(XRT_DRIVER_VERSION, "%d.%d.%d", 
+	sscanf(XRT_DRIVER_VERSION, "%d.%d.%d",
 		&mm_drm_driver.major,
 		&mm_drm_driver.minor,
 		&mm_drm_driver.patchlevel);
@@ -470,7 +460,7 @@ int xocl_drm_init(struct xocl_dev *xdev)
 	mutex_init(&xdev->ctx_list_lock);
 	INIT_LIST_HEAD(&xdev->ctx_list);
 	ddev->dev_private = xdev;
-	atomic_set(&xdev->needs_reset,0);
+	xdev->needs_reset=false;
 	atomic_set(&xdev->outstanding_execs, 0);
 	atomic64_set(&xdev->total_execs, 0);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -35,28 +35,37 @@ xuid_t uuid_null = NULL_UUID_LE;
 #endif
 
 static int
-xocl_client_lock_bitstream(struct xocl_dev *xdev, struct client_ctx *client)
+xocl_client_lock_bitstream_nolock(struct xocl_dev *xdev, struct client_ctx *client)
 {
 	int pid = pid_nr(task_tgid(current));
 
-	if (atomic_read(&client->xclbin_locked))
+	if (client->xclbin_locked)
 		return 0;
 
 	if (!uuid_equal(&xdev->xclbin_id, &client->xclbin_id)) {
 		userpf_err(xdev, "device xclbin does not match context xclbin, "
-			"cannot obtain lock for process %d", pid);
+			   "cannot obtain lock for process %d", pid);
 		return 1;
 	}
 
 	if (xocl_icap_lock_bitstream(xdev, &xdev->xclbin_id, pid) < 0) {
-		userpf_err(xdev,
-			"could not lock bitstream for process %d", pid);
+		userpf_err(xdev,"could not lock bitstream for process %d", pid);
 		return 1;
 	}
 
-	atomic_set(&client->xclbin_locked,true);
+	client->xclbin_locked=true;
 	userpf_info(xdev, "process %d successfully locked xcblin", pid);
 	return 0;
+}
+
+static int
+xocl_client_lock_bitstream(struct xocl_dev *xdev, struct client_ctx *client)
+{
+	int ret = 0;
+	mutex_lock(&client->lock);
+	ret = xocl_client_lock_bitstream_nolock(xdev,client);
+	mutex_unlock(&client->lock);
+	return ret;
 }
 
 
@@ -93,8 +102,8 @@ int xocl_execbuf_ioctl(struct drm_device *dev,
 	int numdeps;
 	int ret = 0;
 
-	if (atomic_read(&xdev->needs_reset)) {
-		userpf_err(xdev, "device needs reset, use 'xbsak reset -h'");
+	if (xdev->needs_reset) {
+		userpf_err(xdev, "device needs reset, use 'xbutil reset -h'");
 		return -EBUSY;
 	}
 
@@ -205,22 +214,19 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 
 	if (args->op == XOCL_CTX_OP_FREE_CTX) {
 		ret = test_and_clear_bit(args->cu_index,
-			client->cu_bitmap) ? 0 : -EINVAL;
+					 client->cu_bitmap) ? 0 : -EINVAL;
 		if (ret) // No context was previously allocated for this CU
 			goto out;
 
 		// CU unlocked explicitly
-		--client->num_cus;
 		--xdev->ip_reference[args->cu_index];
-		if (!client->num_cus) {
+		if (!--client->num_cus) {
 			// We just gave up the last context, unlock the xclbin
-			ret = xocl_icap_unlock_bitstream(xdev, &xdev->xclbin_id,
-				pid);
-			if (ret == 0)
-				xocl_exec_reset(xdev);
+			ret = xocl_icap_unlock_bitstream(xdev, &xdev->xclbin_id,pid);
+			client->xclbin_locked=false;
 		}
 		xocl_info(dev->dev,"CTX del(%pUb, %d, %u)",
-			&xdev->xclbin_id, pid, args->cu_index);
+			  &xdev->xclbin_id, pid, args->cu_index);
 		goto out;
 	}
 
@@ -230,16 +236,14 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	}
 
 	if ((args->flags != XOCL_CTX_SHARED)) {
-		userpf_err(xdev,
-			"Only shared contexts are supported in this release");
+		userpf_err(xdev,"Only shared contexts are supported in this release");
 		ret = -EPERM;
 		goto out;
 	}
 
-	if (!client->num_cus && !atomic_read(&client->xclbin_locked))
-		// Process has no other context on any CU yet, hence we
-		// need to lock the xclbin. A process uses just one lock for
-		// all its contexts.
+	if (!client->num_cus && !client->xclbin_locked)
+		// Process has no other context on any CU yet, hence we need to
+		// lock the xclbin A process uses just one lock for all its ctxs
 		acquire_lock = true;
 
 	if (test_and_set_bit(args->cu_index, client->cu_bitmap)) {
@@ -253,8 +257,8 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	if (acquire_lock) {
                 // This is the first context on any CU for this process,
 		// lock the xclbin
-		ret = xocl_client_lock_bitstream(xdev, client);
-		if (ret < 0) {
+		ret = xocl_client_lock_bitstream_nolock(xdev, client);
+		if (ret) {
 			// Locking of xclbin failed, give up our context
 			clear_bit(args->cu_index, client->cu_bitmap);
 			goto out;
@@ -268,11 +272,8 @@ int xocl_ctx_ioctl(struct drm_device *dev, void *data,
 	++client->num_cus; // explicitly acquired
 	++xdev->ip_reference[args->cu_index];
 	xocl_info(dev->dev, "CTX add(%pUb, %d, %u, %d)",
-		&xdev->xclbin_id, pid, args->cu_index,acquire_lock);
+		  &xdev->xclbin_id, pid, args->cu_index,acquire_lock);
 out:
-	// If all explicit resources are given up, then release the xclbin
-	if (!client->num_cus)
-		atomic_set(&client->xclbin_locked,false);
 	mutex_unlock(&xdev->ctx_list_lock);
 	mutex_unlock(&client->lock);
 	return ret;
@@ -788,6 +789,6 @@ uint get_live_client_size(struct xocl_dev *xdev) {
 
 void reset_notify_client_ctx(struct xocl_dev *xdev)
 {
-	atomic_set(&xdev->needs_reset,0);
+	xdev->needs_reset=false;
 	wmb();
 }


### PR DESCRIPTION
Fixes #766

Also fix xocl_client_release to properly call xocl_exec_destroy_client and let it reset the scheduler if necessary.