### PR TITLE
Release awsmgmt bug-fix in 2018.3

### DIFF
--- a/src/CMake/native.cmake
+++ b/src/CMake/native.cmake
@@ -108,6 +108,7 @@ include (CMake/lint.cmake)
 
 set (XRT_DKMS_DRIVER_SRC_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime_src")
 include (CMake/dkms.cmake)
+include (CMake/dkms-aws.cmake)
 
 include (CMake/icd.cmake)
 


### PR DESCRIPTION
Add dkms-aws.cmake to native builds to release awsmgmt in the -aws package.

Refs #803 
Refs #804 (same commit in 2019.1/master)