### PR TITLE
Check return value of exec_buf

### DIFF
--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -360,6 +360,12 @@ public:
   unmap(const ExecBufferObjectHandle& bo)
   { m_hal->unmap(bo); }
 
+  /**
+   * Submit exec buffer to device.
+   *
+   * @returns
+   *   0 on success, throws on error.
+   */
   int
   exec_buf(const ExecBufferObjectHandle& bo)
   { return m_hal->exec_buf(bo); }

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -440,7 +440,9 @@ device::
 exec_buf(const ExecBufferObjectHandle& boh)
 {
   auto bo = getExecBufferObject(boh);
-  return m_ops->mExecBuf(m_handle,bo->handle);
+  if (m_ops->mExecBuf(m_handle,bo->handle))
+    throw std::runtime_error(std::string("failed to launch exec buffer '") + std::strerror(errno) + "'");
+  return 0;
 }
 
 int

--- a/src/runtime_src/xrt/scheduler/kds.cpp
+++ b/src/runtime_src/xrt/scheduler/kds.cpp
@@ -108,8 +108,7 @@ launch(command_type cmd)
   // Submit the command
   auto device = cmd->get_device();
   auto exec_bo = cmd->get_exec_bo();
-  if (device->exec_buf(exec_bo))
-    throw std::runtime_error(std::string("failed to launch exec buffer '") + std::strerror(errno) + "'");
+  device->exec_buf(exec_bo);
 
   // thread safe access, since guaranteed to be inserted in init
   auto& submitted_cmds = s_device_cmds[device];


### PR DESCRIPTION
Throw on error at lowest xrt::hal level, that way upstream doesn't have to check.