### PR TITLE
Python CMake

### DIFF
--- a/src/CMake/native.cmake
+++ b/src/CMake/native.cmake
@@ -99,6 +99,10 @@ set(XMA_SOVERSION ${XRT_SOVERSION})
 add_subdirectory(xma)
 #XMA settings END
 
+# Python bindings
+set(PY_INSTALL_DIR "${XRT_INSTALL_DIR}/python")
+add_subdirectory(python)
+
 
 message("-- XRT version: ${XRT_VERSION_STRING}")
 

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,0 +1,3 @@
+install(FILES xrt_binding.py    DESTINATION ${PY_INSTALL_DIR})
+install(FILES ert_binding.py    DESTINATION ${PY_INSTALL_DIR})
+install(FILES xclbin_binding.py DESTINATION ${PY_INSTALL_DIR})

--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -59,6 +59,13 @@ else
    setenv PATH $XILINX_XRT/bin:$PATH
 endif
 
+if ( ! $?PYTHONPATH ) then
+    setenv PYTHONPATH $XILINX_XRT/python
+else
+    setenv PYTHONPATH $XILINX_XRT/python:$PYTHONPATH
+endif
+
 echo "XILINX_XRT      : $XILINX_XRT"
 echo "PATH            : $PATH"
 echo "LD_LIBRARY_PATH : $LD_LIBRARY_PATH"
+echo "PYTHONPATH     : $PYTHONPATH"

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -32,7 +32,9 @@ fi
 export XILINX_XRT
 export LD_LIBRARY_PATH=$XILINX_XRT/lib:$LD_LIBRARY_PATH
 export PATH=$XILINX_XRT/bin:$PATH
+export PYTHONPATH=$XILINX_XRT/python:$PYTHONPATH
 
 echo "XILINX_XRT      : $XILINX_XRT"
 echo "PATH            : $PATH"
 echo "LD_LIBRARY_PATH : $LD_LIBRARY_PATH"
+echo "PYTHON_PATH     : $PYTHON_PATH"

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -78,6 +78,8 @@ RH_LIST=(\
      protobuf-compiler \
      protobuf-static \
      python \
+     python-enum \
+     python-cffi \
      redhat-lsb \
      rpm-build \
      strace \
@@ -117,6 +119,8 @@ UB_LIST=(\
      ocl-icd-opencl-dev \
      perl \
      python \
+     python-enum34 \
+     python-cffi \
      pciutils \
      pkg-config \
      protobuf-compiler \

--- a/tests/python/00_hello/main.py
+++ b/tests/python/00_hello/main.py
@@ -1,7 +1,5 @@
 import sys
-# import source files
-sys.path.append('../../../src/python/')
-sys.path.append('../')
+sys.path.append('../') # utils_binding.py
 from xrt_binding import *
 from utils_binding import *
 from cffi import FFI

--- a/tests/python/22_verify/main.py
+++ b/tests/python/22_verify/main.py
@@ -1,8 +1,6 @@
 import sys
-# import source files
-sys.path.append('../../../src/python/')
-from xrt_binding import *
-sys.path.append('../')
+from xrt_binding import * # found in PYTHONPATH
+sys.path.append('../') # utils_binding.py
 from utils_binding import *
 from cffi import FFI
 

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -1,7 +1,6 @@
 from ctypes import *
 import sys, getopt, struct
-# import source files
-sys.path.append('../../../src/python/')
+# source files imported from PYTHONPATH
 from xclbin_binding import *
 from xrt_binding import *
 from ert_binding import *


### PR DESCRIPTION
Deploys Py bindings to opt/xilinx/xrt/python and adds this to $PYTHONPATH in setup.csh/sh. Once done, a user can source setup.sh, and quickly open a Python shell and test xclProbe(). Two python packages are required: python-enum and python-cffi. 

```
xsjrradjabi40:~>source /opt/xilinx/xrt/setup.csh
XILINX_XRT      : /opt/xilinx/xrt
PATH            : /opt/rh/devtoolset-7/root/usr/bin:/home/rradjabi/bin:/usr/local/bin:/mis/TREE/bin:/usr/bin:/bin:/opt/puppetlabs/bin:/sbin/:/usr/sbin:/opt/intel/opencl/bin:/home/rradjabi/bin
LD_LIBRARY_PATH : /opt/xilinx/xrt/lib:/opt/xilinx/xrt/lib
PYTHONPATH     : /opt/xilinx/xrt/python:/opt/xilinx/xrt/python
xsjrradjabi40:~>python
Python 2.7.5 (default, Jul 13 2018, 13:06:57) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-28)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import xrt_binding as xrt
>>> xrt.xclProbe()
1
>>> 

```