### PR TITLE
Return correct values from xcl{Sync,Read,Write}BO

### DIFF
--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
@@ -17,6 +17,7 @@
 #include "shim.h"
 #include <string.h>
 #include <boost/property_tree/xml_parser.hpp>
+#include <errno.h>
 #include <unistd.h>
 
 namespace xclhwemhal2 {
@@ -1988,16 +1989,22 @@ int HwEmShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t si
     return -1;
   }
 
-  int returnVal = -1;
+  int returnVal = 0;
   if(dir == XCL_BO_SYNC_BO_TO_DEVICE)
   {
     void* buffer =  bo->userptr ? bo->userptr : bo->buf;
-    returnVal = xclCopyBufferHost2Device(bo->base,buffer, size,offset, bo->topology);
+    if (xclCopyBufferHost2Device(bo->base, buffer, size, offset, bo->topology) != size)
+    {
+      returnVal = EIO;
+    }
   }
   else
   {
     void* buffer =  bo->userptr ? bo->userptr : bo->buf;
-    returnVal = xclCopyBufferDevice2Host(buffer, bo->base, size,offset, bo->topology);
+    if (xclCopyBufferDevice2Host(buffer, bo->base, size,offset, bo->topology) != size)
+    {
+      returnVal = EIO;
+    }
   }
   PRINTENDFUNC;
   return returnVal;
@@ -2042,7 +2049,11 @@ size_t HwEmShim::xclWriteBO(unsigned int boHandle, const void *src, size_t size,
     PRINTENDFUNC;
     return -1;
   }
-  int returnVal = xclCopyBufferHost2Device( bo->base, src, size,seek,bo->topology);
+  int returnVal = 0;
+  if (xclCopyBufferHost2Device(bo->base, src, size, seek, bo->topology) != size)
+  {
+    returnVal = EIO;
+  }
   PRINTENDFUNC;
   return returnVal;
 }
@@ -2062,7 +2073,11 @@ size_t HwEmShim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t
     PRINTENDFUNC;
     return -1;
   }
-  int returnVal = xclCopyBufferDevice2Host(dst, bo->base, size, skip, bo->topology);
+  int returnVal = 0;
+  if (xclCopyBufferDevice2Host(dst, bo->base, size, skip, bo->topology) != size)
+  {
+    returnVal = EIO;
+  }
   PRINTENDFUNC;
   return returnVal;
 }


### PR DESCRIPTION
These functions should return 0 on success and proper errno on failure,
as per the documentations. However, it wasn't the case for the emulation
drivers.

Reference:
[xclSyncBO](https://xilinx.github.io/XRT/master/html/xclhal2.main.html#c.xclSyncBO)
[xclReadBO](https://xilinx.github.io/XRT/master/html/xclhal2.main.html#c.xclReadBO)
[xclWriteBO](https://xilinx.github.io/XRT/master/html/xclhal2.main.html#c.xclWriteBO)