### PR TITLE
fix compilation warning on CentOS and host crash when firewall trips

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -856,7 +856,7 @@ static int icap_write(struct icap *icap, const u32 *word_buf, int size)
 
 static uint64_t icap_get_section_size(struct icap *icap, enum axlf_section_kind kind)
 {
-	uint64_t size;
+	uint64_t size = 0;
 
 	switch(kind){
 		case IP_LAYOUT:
@@ -2088,7 +2088,7 @@ static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
 	uint64_t section_size = 0, sect_sz = 0;
 	uint64_t copy_buffer_size = 0;
 	struct axlf* copy_buffer = NULL;
-	void **target;
+	void **target = NULL;
 
 	if (copy_from_user((void *)&bin_obj, u_xclbin, sizeof(struct axlf)))
 		return -EFAULT;
@@ -2121,7 +2121,7 @@ static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
 
 	switch(kind){
 		case IP_LAYOUT:
-		  target = (void **)&icap->ip_layout;
+			target = (void **)&icap->ip_layout;
 			break;
 		case MEM_TOPOLOGY:
 			target = (void **)&icap->mem_topo;
@@ -2129,15 +2129,16 @@ static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
 		case DEBUG_IP_LAYOUT:
 			target = (void **)&icap->debug_layout;
 			break;
-			break;
 		case CONNECTIVITY:
 			target = (void **)&icap->connectivity;
 			break;
 		default:
 			break;		
 	}
-	vfree(*target);
-	*target = NULL;
+	if (target) {
+		vfree(*target);
+		*target = NULL;
+	}
 	err = alloc_and_get_axlf_section(icap, copy_buffer, kind,
 		buffer, target, &section_size);
 	if (err != 0)
@@ -2163,7 +2164,7 @@ void *icap_get_axlf_section_data(struct platform_device *pdev,
 {
 
 	struct icap *icap = platform_get_drvdata(pdev);
-	void *target;
+	void *target = NULL;
 
 	mutex_lock(&icap->icap_lock);
 	switch(kind){

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -1295,9 +1295,14 @@ mark_mask_complete(struct exec_core *exec, u32 mask, unsigned int mask_idx)
 	SCHED_DEBUGF("-> mark_mask_complete(0x%x,%d)\n",mask,mask_idx);
 	if (!mask)
 		return;
-	for (bit_idx=0, cmd_idx=mask_idx<<5; bit_idx<32; mask>>=1,++bit_idx,++cmd_idx)
-		if (mask & 0x1)
+
+	for (bit_idx=0, cmd_idx=mask_idx<<5; bit_idx<32; mask>>=1,++bit_idx,++cmd_idx) {
+		/* mask could be -1 when firewall trips, double check
+		 * exec->submitted_cmds[cmd_idx] to make sure it's not NULL
+		 */
+		if ((mask & 0x1) && exec->submitted_cmds[cmd_idx])
 			mark_cmd_complete(exec->submitted_cmds[cmd_idx]);
+	}
 	SCHED_DEBUG("<- mark_mask_complete\n");
 }
 

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/xmc.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/xmc.c
@@ -714,9 +714,9 @@ static int get_temp_by_m_tag(struct xocl_xmc *xmc, char *m_tag)
 	 *   we check the index in m_tag to decide which temperature
 	 *   to get from XMC IP base address
 	 */
-	char *start, *left_parentness, *right_parentness;
+	char *start = NULL, *left_parentness = NULL, *right_parentness = NULL;
 	long idx;
-	int ret = 0, digit_len;
+	int ret = 0, digit_len = 0;
 	char temp[4];
 
 	if(!xmc)
@@ -746,8 +746,7 @@ static int get_temp_by_m_tag(struct xocl_xmc *xmc, char *m_tag)
 		//assumption, temperature won't higher than 3 digits, or the temp[digit_len] should be a null character
 		temp[digit_len] = '\0';
 		//convert to signed long, decimal base 
-		kstrtol(temp, 10, &idx);
-		if(idx < 4 && idx >=0)
+		if(kstrtol(temp, 10, &idx) == 0 && idx < 4 && idx >=0)
 			safe_read32(xmc, XMC_DIMM_TEMP0_REG+ (3*sizeof(int32_t)) * idx +sizeof(u32)*VOLTAGE_INS, &ret);
 		else{
 			ret = 0;


### PR DESCRIPTION
+ Fixes compilation warning on CentOS
+ When firewall trips, we may read 0xffffffff from CU registers. Driver may be confused. We need to double check exec->submitted_cmds[cmd_idx] to make sure we don't access NULL pointer.