### PR TITLE
kernel arg connectivity deduction

### DIFF
--- a/src/runtime_src/xocl/api/api.h
+++ b/src/runtime_src/xocl/api/api.h
@@ -20,7 +20,7 @@
 #include <CL/opencl.h>
 
 /**
- * Extern declration of xocl::api function that are used 
+ * Extern declration of xocl::api function that are used
  * in implementation of OCL api functions.
  *
  * Calling functions in this API will bypass profile logging
@@ -97,6 +97,12 @@ clCreateKernel(cl_program      program,
                const char *    kernel_name,
                cl_int *        errcode_ret);
 
+cl_kernel
+clSetKernelArg(cl_kernel    kernel,
+               cl_uint      arg_index,
+               size_t       arg_size,
+               const void * arg_value);
+
 cl_int
 clEnqueueBarrierWithWaitList(cl_command_queue  command_queue ,
                              cl_uint            num_events_in_wait_list ,
@@ -109,5 +115,3 @@ clReleaseEvent(cl_event event);
 }} // api,xocl
 
 #endif
-
-

--- a/src/runtime_src/xocl/api/clCreateBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateBuffer.cpp
@@ -23,6 +23,8 @@
 #include "detail/memory.h"
 #include "detail/context.h"
 
+#include  "api.h"
+
 #include <bitset>
 #include "plugin/xdp/profile.h"
 
@@ -52,6 +54,12 @@ get_xlnx_ext_kernel(cl_mem_flags flags, void* host_ptr)
     : 0;
 }
 
+inline unsigned int
+get_xlnx_ext_argidx(cl_mem_flags flags, void* host_ptr)
+{
+  return get_xlnx_ext_flags(flags,host_ptr);
+}
+
 // Hack to determine if a context is associated with exactly one
 // device.  Additionally, in emulation mode, the device must be
 // active, e.g. loaded through a call to loadBinary.
@@ -73,12 +81,11 @@ singleContextDevice(cl_context context, cl_mem_flags flags)
   if (!device->is_active())
     return nullptr;
 
-  // check that all CUs in device has same single mem connectivity
   if(flags & CL_MEM_EXT_PTR_XILINX) {
-    //This should be treated as single device context.
-    //MLx use case.
-    //do nothing, proceed to returning the device.
+    // Explicit memory bank assignment should be treated as single device context.
+    // MLx use case. Do nothing, proceed to returning the device.
   } else {
+    // Check that all CUs in device has same single mem connectivity
     xocl::device::memidx_bitmask_type ucon;
     for (auto cu : device->get_cu_range())
       ucon |= cu->get_memidx_union();
@@ -145,14 +152,24 @@ clCreateBuffer(cl_context   context,
   auto buffer = std::make_unique<xocl::buffer>(xocl::xocl(context),flags,size,ubuf);
 
   // set fields in cl_buffer
-  buffer->add_ext_flags(get_xlnx_ext_flags(flags,host_ptr));
-  buffer->add_ext_kernel(xocl::xocl(get_xlnx_ext_kernel(flags,host_ptr)));
+  buffer->set_ext_flags(get_xlnx_ext_flags(flags,host_ptr));
+  buffer->set_ext_kernel(xocl::xocl(get_xlnx_ext_kernel(flags,host_ptr)));
 
-  // allocate device buffer object if context has only one device
+  // Allocate device buffer object if context CUs have single bank connectivity
   // and if this is not a progvar (clCreateProgramWithBinary)
   if (!(flags & CL_MEM_PROGVAR)) {
-    if (auto device = singleContextDevice(context, flags))
-      buffer->get_buffer_object(device);
+    if (auto device = singleContextDevice(context, flags)) {
+      if (auto kernel = get_xlnx_ext_kernel(flags,host_ptr)) {
+        // Kernel specified in ext flags do allocation in proper bank by setting arg
+        auto argidx = get_xlnx_ext_argidx(flags,host_ptr);
+        cl_mem mem = buffer.get(); // cast to cl_mem is important before going void*
+        api::clSetKernelArg(kernel,argidx,sizeof(cl_mem),&mem);
+      }
+      else {
+        // Explicit bank specification or none at all, either way just allocate
+        buffer->get_buffer_object(device);
+      }
+    }
   }
 
   xocl::assign(errcode_ret,CL_SUCCESS);

--- a/src/runtime_src/xocl/api/clCreateImage.cpp
+++ b/src/runtime_src/xocl/api/clCreateImage.cpp
@@ -564,7 +564,7 @@ mkImageCore (cl_context context,
     //set fields in cl_buffer
     //
     unsigned memExtension = 0;
-    xocl::xocl(image)->add_ext_flags(memExtension);
+    xocl::xocl(image)->set_ext_flags(memExtension);
 
     // allocate device buffer object if context has only one device
     // and if this is not a progvar (clCreateProgramWithBinary)

--- a/src/runtime_src/xocl/api/clEnqueueNDRangeKernel.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueNDRangeKernel.cpp
@@ -251,8 +251,8 @@ validOrError(cl_command_queue command_queue,
     if (auto mem = arg->get_memory_object()) {
       mem->get_buffer_object(xdevice); // make sure buffer is allocated on device
       auto mem_memidx_mask = mem->get_memidx(xdevice);
-      for (auto& cu : xdevice->get_cu_range()) {
-        if (cu->get_symbol()->uid!=xkernel->get_symbol_uid())
+      for (auto cu : xocl::xocl(kernel)->get_cus()) {
+        if (cu->get_device() != xdevice)
           continue;
         auto cu_memidx_mask = cu->get_memidx(argidx);
         if ((cu_memidx_mask & mem_memidx_mask).none()) {

--- a/src/runtime_src/xocl/api/clGetMemObjectInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetMemObjectInfo.cpp
@@ -31,7 +31,7 @@ namespace xocl {
 
 static void
 validOrError(cl_mem           memobj,
-             cl_mem_info      param_name, 
+             cl_mem_info      param_name,
              size_t           param_value_size,
              void *           param_value,
              size_t *         param_value_size_ret)
@@ -72,7 +72,7 @@ validOrError(cl_mem           memobj,
 
 static cl_int
 clGetMemObjectInfo(cl_mem           memobj,
-                   cl_mem_info      param_name, 
+                   cl_mem_info      param_name,
                    size_t           param_value_size,
                    void *           param_value,
                    size_t *         param_value_size_ret )
@@ -110,15 +110,8 @@ clGetMemObjectInfo(cl_mem           memobj,
       buffer.as<size_t>() = xocl(memobj)->get_sub_buffer_offset();
       break;
     case CL_MEM_BANK:
-      {
-        size_t idx = 0;
-        auto memidx_mask = xocl(memobj)->get_memidx();
-        for (idx=0; idx<memidx_mask.size(); ++idx)
-          if (memidx_mask.test(idx))
-            break;
-        buffer.as<int>() = idx;
-        break;
-      }
+      buffer.as<int>() = xocl(memobj)->get_memidx();
+      break;
     default:
       throw error(CL_INVALID_VALUE,"clGetMemObjectInfo invalud param name");
       break;
@@ -131,7 +124,7 @@ clGetMemObjectInfo(cl_mem           memobj,
 
 cl_int
 clGetMemObjectInfo(cl_mem           memobj,
-                   cl_mem_info      param_name, 
+                   cl_mem_info      param_name,
                    size_t           param_value_size,
                    void *           param_value,
                    size_t *         param_value_size_ret)
@@ -150,5 +143,3 @@ clGetMemObjectInfo(cl_mem           memobj,
     return CL_OUT_OF_HOST_MEMORY;
   }
 }
-
-

--- a/src/runtime_src/xocl/api/clSetKernelArg.cpp
+++ b/src/runtime_src/xocl/api/clSetKernelArg.cpp
@@ -108,6 +108,19 @@ clSetKernelArg(cl_kernel    kernel,
   return CL_SUCCESS;
 }
 
+namespace api {
+
+cl_int
+clSetKernelArg(cl_kernel    kernel,
+               cl_uint      arg_index,
+               size_t       arg_size,
+               const void * arg_value)
+{
+  return ::xocl::clSetKernelArg(kernel,arg_index,arg_size,arg_value);
+}
+
+} // api
+
 } // xocl
 
 cl_int
@@ -136,5 +149,3 @@ clSetKernelArg(cl_kernel    kernel,
     return CL_OUT_OF_RESOURCES;
   }
 }
-
-

--- a/src/runtime_src/xocl/api/xlnx/xclGetMemObjectFromFd.cpp
+++ b/src/runtime_src/xocl/api/xlnx/xclGetMemObjectFromFd.cpp
@@ -85,7 +85,7 @@ clGetMemObjectFromFd(cl_context context,
   if (auto boh = xdevice->get_xrt_device()->getBufferFromFd(fd, size, iflags)) {
     auto buffer = std::make_unique<xocl::buffer>(xcontext, flags, size, nullptr);
     // set fields in cl_buffer
-    buffer->add_ext_flags(get_xlnx_ext_flags(flags,nullptr));
+    buffer->set_ext_flags(get_xlnx_ext_flags(flags,nullptr));
 
     buffer->update_buffer_object_map(xdevice,boh);
     *mem = buffer.release();
@@ -105,7 +105,7 @@ clGetMemObjectFromFd(cl_context context,
     }
     */
 
-  } 
+  }
 
   throw error(CL_INVALID_MEM_OBJECT, "CreateBufferFromFd: Unable to get MemObject Handle from FD");
 }
@@ -146,5 +146,3 @@ xclGetMemObjectFromFd(cl_context context,
 {
   return xlnx::clGetMemObjectFromFd(context, device, flags, fd, mem);
 }
-
-

--- a/src/runtime_src/xocl/core/compute_unit.cpp
+++ b/src/runtime_src/xocl/core/compute_unit.cpp
@@ -51,7 +51,7 @@ namespace xocl {
 
 compute_unit::
 compute_unit(const xclbin::symbol* s, const std::string& n, device* d)
-  : m_symbol(s), m_name(n), m_device(d), m_address(get_base_addr(m_symbol,m_name))
+  : m_symbol(s), m_name(n), m_device(d), m_address(::get_base_addr(m_symbol,m_name))
 {
   static unsigned int count = 0;
   m_uid = count++;

--- a/src/runtime_src/xocl/core/compute_unit.h
+++ b/src/runtime_src/xocl/core/compute_unit.h
@@ -49,7 +49,7 @@ public:
    * Address extracted from xclbin
    */
   size_t
-  get_physical_address() const
+  get_base_addr() const
   {
     return m_address;
   }
@@ -121,18 +121,24 @@ public:
     return m_context_type;
   }
 
+  const device*
+  get_device() const
+  {
+    return m_device;
+  }
+
 private:
 
   // Used by xocl::device to cache the acquire context for
   void
-  set_context_type(bool shared)
+  set_context_type(bool shared) const
   {
     m_context_type = shared ? compute_unit::context_type::shared : compute_unit::context_type::exclusive;
   }
 
   // Used by xocl::device when context is released for this CU
   void
-  reset_context_type()
+  reset_context_type() const
   {
     m_context_type = compute_unit::context_type::none;
   }
@@ -143,7 +149,7 @@ private:
   device* m_device = nullptr;
   size_t m_address = 0;
   size_t m_index = 0;
-  context_type m_context_type = context_type::none;
+  mutable context_type m_context_type = context_type::none;
 
   // Map CU arg to memory bank indicies. An argument can
   // be connected to multiple memory banks.

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -42,6 +42,7 @@ public:
   using compute_unit_range = compute_unit_vector_type;
   using compute_unit_iterator = compute_unit_vector_type::const_iterator;
   using cmd_type = std::shared_ptr<xrt::command>;
+  using memidx_type = xclbin::memidx_type;
   using connidx_type = xclbin::connidx_type;
 
   /**
@@ -279,7 +280,7 @@ public:
    *   The buffer object that was created.
    */
   xrt::device::BufferObjectHandle
-  allocate_buffer_object(memory* mem, uint64_t memidx);
+  allocate_buffer_object(memory* mem, memidx_type memidx);
 
   /**
    * Special interface to allocate a buffer object undconditionally
@@ -341,7 +342,7 @@ public:
    * @return Memory index for DDR bank if all CUs are uniquely connected
    *  to same DDR bank for all arguments, -1 otherwise
    */
-  int
+  memidx_type
   get_cu_memidx() const;
 
   /**
@@ -660,7 +661,7 @@ public:
    *   @true on success, @false if no program loaded.
    */
   bool
-  acquire_context(compute_unit* cu, bool shared=true) const;
+  acquire_context(const compute_unit* cu, bool shared=true) const;
 
   /**
    * Release a context for a given compute unit on this device
@@ -671,7 +672,7 @@ public:
    *   @true on success, @false if no program loaded.
    */
   bool
-  release_context(compute_unit* cu) const;
+  release_context(const compute_unit* cu) const;
 
   /**
    * @return
@@ -729,7 +730,7 @@ private:
    *  Buffer object handle for allocated memory
    */
   xrt::device::BufferObjectHandle
-  alloc(memory* mem, unsigned int bank);
+  alloc(memory* mem, memidx_type memidx);
 
   /**
    * Allocate device side buffer in first available DDR bank
@@ -780,7 +781,7 @@ private:
   compute_unit_vector_type m_computeunits;
 
   // Caching.  Purely implementation detail (-2 => not initialized)
-  mutable int m_cu_memidx = -2;
+  mutable memidx_type m_cu_memidx = -2;
 };
 
 } // xocl

--- a/src/runtime_src/xocl/core/kernel.h
+++ b/src/runtime_src/xocl/core/kernel.h
@@ -29,6 +29,8 @@
 
 namespace xocl {
 
+class compute_unit;
+
 class kernel : public refcount, public _cl_kernel
 {
 public:
@@ -569,6 +571,12 @@ public:
     return boost::join(m_printf_args,m_rtinfo_args);
   }
 
+  std::vector<const compute_unit*>
+  get_cus() const
+  {
+    return m_cus;
+  }
+
   ////////////////////////////////////////////////////////////////
   // Conformance helpers
   ////////////////////////////////////////////////////////////////
@@ -576,6 +584,25 @@ public:
   {
     return m_symbol.hash;
   }
+
+private:
+  // Compute units that can be used by this kernel object
+  // The list is dynamically trimmed as kernel arguments are added
+  std::vector<const compute_unit*> m_cus;
+
+  // Trim CUs to keep only those where argument at argidx is
+  // connected to memory bank with memidx
+  void
+  trim_cus(unsigned long argidx, int memidx);
+
+  // Select a CU for argument buffer
+  const compute_unit*
+  select_cu(const memory* buf) const;
+
+  // Assign a buffer argument to a memory bank based on
+  // explicit connection if any or based on CU connectivity
+  void
+  assign_buffer_to_connection(memory* mem, unsigned long argidx);
 
 private:
   unsigned int m_uid = 0;

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -177,7 +177,7 @@ program::
 get_xclbin(const device* d) const
 {
   // switch to parent device if any
-  d = d->get_root_device();
+  d = d ? d->get_root_device() : nullptr;
   if (d) {
     auto itr = m_binaries.find(d);
     if (itr==m_binaries.end())

--- a/src/runtime_src/xrt/scheduler/sws.cpp
+++ b/src/runtime_src/xrt/scheduler/sws.cpp
@@ -266,6 +266,8 @@ configure_cu(slot_info* slot, size_type cu)
   auto cu_addr = cu_idx_to_addr(cu);
   auto size = regmap_size(slot->header_value);
 
+  XRT_DEBUGF("configuring cu(%d) at addr(0%x)\n",cu,cu_addr);
+
   // data past header and cu_masks
   auto regmap = slot->get_packet().data() + 1 + cu_masks(slot->header_value);
 

--- a/src/runtime_src/xrt/util/config_reader.cpp
+++ b/src/runtime_src/xrt/util/config_reader.cpp
@@ -86,7 +86,7 @@ struct tree
   {
     try {
       read_ini(path,m_tree);
-      
+
       // set env vars to expose sdaccel.ini to hal layer
       setenv();
     }
@@ -119,6 +119,12 @@ static tree s_tree;
 namespace xrt { namespace config {
 
 namespace detail {
+
+const char*
+get_env_value(const char* env)
+{
+  return std::getenv(env);
+}
 
 bool
 get_bool_value(const char* key, bool default_value)
@@ -163,5 +169,3 @@ debug(std::ostream& ostr, const std::string& ini)
 } // detail
 
 }}
-
-

--- a/src/runtime_src/xrt/util/config_reader.h
+++ b/src/runtime_src/xrt/util/config_reader.h
@@ -60,6 +60,7 @@ namespace detail {
  * See xrt/test/util/tconfig.cpp for unit test
  */
 bool          get_bool_value(const char*, bool);
+const char*   get_env_value(const char*);
 std::string   get_string_value(const char*, const std::string&);
 unsigned int  get_uint_value(const char*, unsigned int);
 std::ostream& debug(std::ostream&, const std::string& ini="");
@@ -283,6 +284,12 @@ get_cdma()
 {
   static unsigned int value = detail::get_bool_value("Runtime.cdma",false);
   return value;
+}
+
+inline bool
+get_feature_toggle(const std::string& feature)
+{
+  return detail::get_bool_value(feature.c_str(),false) || detail::get_env_value(feature.c_str());
 }
 
 inline std::string

--- a/tests/unit_test/cuselect/Makefile
+++ b/tests/unit_test/cuselect/Makefile
@@ -1,0 +1,80 @@
+# Copyright (C) 2016-2017 Xilinx, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+XOCC := $(XILINX_SDX)/bin/xocc
+EMCONFIGUTIL := $(XILINX_SDX)/bin/emconfigutil
+MODE := hw_emu
+DSA := xilinx_vcu1525_dynamic_5_1
+
+# % env XILINX_SDX=/proj/xbuilds/2018.3_daily_latest/installs/lin64/SDx/2018.3 make xclbin
+# % env XILINX_SDX=/proj/xbuilds/2018.3_daily_latest/installs/lin64/SDx/2018.3 make emconfig
+# % run.sh make host.exe
+# % run.sh ./host.exe cuselect.xclbin
+
+# sources
+KERNEL_SRC := vadd.cl
+HOST_SRC := main.cpp
+
+# targets
+HOST_EXE := host.exe
+XOS := cuselect.$(MODE).xo
+XCLBIN := cuselect.$(MODE).xclbin
+EMCONFIG_FILE := emconfig.json
+
+# flags
+XOCC_LINK_OPTS := \
+--nk vadd:4 \
+--sp vadd_1.A:bank0 --sp vadd_1.B:bank1 --sp vadd_1.C:bank2 --sp vadd_1.D:bank3 \
+--sp vadd_2.A:bank1 --sp vadd_2.B:bank2 --sp vadd_2.C:bank3 --sp vadd_2.D:bank0 \
+--sp vadd_3.A:bank2 --sp vadd_3.B:bank3 --sp vadd_3.C:bank0 --sp vadd_3.D:bank1 \
+--sp vadd_4.A:bank3 --sp vadd_4.B:bank0 --sp vadd_4.C:bank1 --sp vadd_4.D:bank2 \
+
+XOCC_COMMON_OPTS := -s -t $(MODE) --platform $(DSA)
+CFLAGS := -g -std=c++14 -I$(XILINX_XRT)/include
+LFLAGS := -L$(XILINX_XRT)/lib -lxilinxopencl -lpthread -lrt
+NUMDEVICES := 1
+
+# run time args
+EXE_OPT := cuselect.$(MODE).xclbin
+
+# primary build targets
+.PHONY: xclbin compile all clean run
+
+xclbin:  $(XCLBIN)
+compile: $(HOST_EXE)
+
+all: clean xclbin compile run
+
+clean:
+	-$(RM) $(EMCONFIG_FILE) $(HOST_EXE) $(XCLBIN) $(XOS)
+
+# kernel rules
+$(XOS): $(KERNEL_SRC)
+	$(RM) $@
+	$(XOCC) $(XOCC_COMMON_OPTS) -c -o $@ $+
+
+
+$(XCLBIN): $(XOS)
+	$(XOCC) $(XOCC_COMMON_OPTS) -l -o $@ $+ $(XOCC_LINK_OPTS)
+
+# host rules
+$(HOST_EXE): $(HOST_SRC)
+	g++ $(CFLAGS) -o $@ $+ $(LFLAGS)
+	@echo 'Compiled Host Executable: $(HOST_EXE)'
+
+$(EMCONFIG_FILE):
+	$(EMCONFIGUTIL) --nd $(NUMDEVICES) --od . --platform $(DSA)
+
+run: $(XCLBIN) $(HOST_EXE) $(EMCONFIG_FILE)
+	./host.exe $(EXE_OPT)

--- a/tests/unit_test/cuselect/main.cpp
+++ b/tests/unit_test/cuselect/main.cpp
@@ -1,0 +1,289 @@
+/**
+ * Copyright (C) 2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <CL/cl_ext_xilinx.h>
+#include <CL/cl.h>
+#include <fstream>
+#include <stdexcept>
+#include <numeric>
+#include <iostream>
+#include <array>
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <chrono>
+#include <thread>
+
+const size_t NUM_WORKGROUPS = 1;
+const size_t WORKGROUP_SIZE = 16;
+const size_t LENGTH = NUM_WORKGROUPS * WORKGROUP_SIZE;
+const size_t data_size = LENGTH;
+
+
+static void
+throw_if_error(cl_int errcode, const char* msg=nullptr)
+{
+  if (!errcode)
+    return;
+  std::string err = "errcode '";
+  err.append(std::to_string(errcode)).append("'");
+  if (msg)
+    err.append(" ").append(msg);
+  throw std::runtime_error(err);
+}
+
+// vadd has 8 CUs each with 4 arguments connected as follows
+//  vadd_1 (0,1,2,3)
+//  vadd_2 (0,1,2,3)
+//  vadd_3 (1,2,3,0)
+//  vadd_4 (1,2,3,0)
+//  vadd_5 (2,3,0,1)
+//  vadd_6 (2,3,0,1)
+//  vadd_7 (3,0,1,2)
+//  vadd_8 (3,0,1,2)
+// Purpose of this test is to execute 4 kernel jobs with auto select
+// of matching CUs based on the connectivity of the buffer arguments.
+
+using data_type = int;
+const size_t buffer_size = data_size*sizeof(data_type);
+
+// Flag to stop job rescheduling.  Is set to true after
+// specified number of seconds.
+static bool stop = true;
+
+// Forward declaration of event callback function for event of last
+// copy stage of a job.
+static void
+kernel_done(cl_event event, cl_int status, void* data);
+
+struct job_type
+{
+  size_t id = 0;
+  size_t runs = 0;
+  bool running = false;
+
+  cl_context context = nullptr;
+  cl_command_queue queue = nullptr;
+  cl_program program = nullptr;
+  cl_kernel kernel = nullptr;
+
+  std::array<cl_mem,4> args;
+
+  std::array<int,buffer_size/sizeof(data_type)> dataA;
+  std::array<int,buffer_size/sizeof(data_type)> dataB;
+  std::array<int,buffer_size/sizeof(data_type)> dataC;
+  std::array<int,buffer_size/sizeof(data_type)> dataO;
+
+  std::array<void*,3> input_data;
+  std::array<void*,1> output_data;
+
+  job_type(cl_context c, cl_command_queue q, cl_program p, const std::array<int,4>& banks)
+    : context(c), queue(q), program(p)
+  {
+    static size_t count = 0;
+    id = count++;
+
+    std::iota(dataA.begin(),dataA.end(),0);
+    std::iota(dataB.begin(),dataB.end(),1);
+    std::iota(dataC.begin(),dataC.end(),2);
+    input_data[0] = dataA.data();
+    input_data[1] = dataB.data();
+    input_data[2] = dataC.data();
+
+    std::fill(dataO.begin(),dataO.end(),0);
+    output_data[0] = dataO.data();
+
+    cl_int err=CL_SUCCESS;
+
+    kernel = clCreateKernel(program,"vadd",&err);
+    throw_if_error(err,"failed to allocate kernel object");
+
+    // Set kernel inputs
+    for (size_t arg=0; arg<3; ++arg) {
+      unsigned int bank = (XCL_MEM_DDR_BANK0 << banks[arg]);
+      cl_mem_ext_ptr_t ext = {bank,input_data[arg],nullptr};
+      args[arg] = clCreateBuffer(context,CL_MEM_READ_ONLY|CL_MEM_EXT_PTR_XILINX|CL_MEM_COPY_HOST_PTR,buffer_size,&ext,&err);
+      throw_if_error(err,"failed to allocate input buffer");
+      throw_if_error(clSetKernelArg(kernel,arg,sizeof(cl_mem),&args[arg]),"failed to set kernel input arg");
+    }
+
+    // Set kernel output
+    unsigned int bank = (XCL_MEM_DDR_BANK0 << banks[3]);
+    cl_mem_ext_ptr_t ext = {bank,output_data[0],nullptr};
+    args[3] = clCreateBuffer(context,CL_MEM_READ_WRITE|CL_MEM_EXT_PTR_XILINX|CL_MEM_COPY_HOST_PTR,buffer_size,&ext,&err);
+    throw_if_error(clSetKernelArg(kernel,3,sizeof(cl_mem),&args[3]),"failed to set kernel output arg");
+
+      // Migrate all memory objects to device
+    clEnqueueMigrateMemObjects(queue,args.size(),args.data(),0,0,nullptr,nullptr);
+  }
+
+  ~job_type()
+  {
+    clReleaseKernel(kernel);
+    std::for_each(args.begin(),args.end(),[](cl_mem m)      { clReleaseMemObject(m); });
+  }
+
+  // Event callback for last job event
+  void
+  done()
+  {
+    verify_results();
+    running = false;
+
+    // Reschedule job unless stop is asserted.
+    // This ties up the XRT thread that notifies host that event is done
+    // Probably not too bad given that enqueue (run()) time should be very fast.
+    if (!stop)
+      run();
+  }
+
+  void
+  run()
+  {
+    running = true;
+    ++runs;
+
+    cl_int err = CL_SUCCESS;
+    cl_event kevent = nullptr;
+
+    size_t global[1] = {NUM_WORKGROUPS * WORKGROUP_SIZE};
+    size_t local[1] = {WORKGROUP_SIZE};
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, global, local, 0, nullptr, &kevent);
+    clSetEventCallback(kevent,CL_COMPLETE,&kernel_done,this);
+  }
+
+  // Verify data of last stage addone output.  Note that last output
+  // has been copied back to in[0] up job completion
+  void
+  verify_results()
+  {
+    // The addone kernel adds 1 to the first element in input a, since
+    // the job has 4 stages, the resulting first element of a[0] will
+    // be incremented by 4.
+    std::array<int,data_size> result;
+    auto bytes = data_size*sizeof(data_type);
+    cl_int err = clEnqueueReadBuffer(queue,args[3],CL_TRUE,0,bytes,result.data(),0,nullptr,nullptr);
+    throw_if_error(err,"failed to read results");
+    for (size_t idx=0; idx<data_size; ++idx) {
+      unsigned long add = dataA[idx] + dataB[idx] + dataC[idx];
+      if (result[idx] != add) {
+        std::cout << "got result[" << idx << "] = " << result[idx] << " expected " << add << "\n";
+        throw std::runtime_error("VERIFY FAILED");
+      }
+    }
+  }
+};
+
+static void
+kernel_done(cl_event event, cl_int status, void* data)
+{
+  reinterpret_cast<job_type*>(data)->done();
+  clReleaseEvent(event);
+}
+
+int
+run_test(cl_context context, cl_command_queue queue, cl_program program)
+{
+  // create the jobs
+  std::vector<job_type> jobs;
+  jobs.reserve(4);
+
+  // success jobs
+  jobs.emplace_back(context,queue,program,std::array<int,4>{0,1,2,3});
+  jobs.emplace_back(context,queue,program,std::array<int,4>{1,2,3,0});
+  jobs.emplace_back(context,queue,program,std::array<int,4>{2,3,0,1});
+  jobs.emplace_back(context,queue,program,std::array<int,4>{3,0,1,2});
+
+  // failed jobs
+  try {
+    jobs.emplace_back(context,queue,program,std::array<int,4>{3,0,1,0});
+    std::cout << "jobs creation succeeded unexpectedly\n";
+  }
+  catch (const std::exception& ex) {
+    std::cout << "jobs creation failed as expected: " << ex.what() << "\n";
+  }
+
+  std::for_each(jobs.begin(),jobs.end(),[](job_type& j){j.run();});
+  clFinish(queue);
+
+  return 0;
+}
+
+int
+run(int argc, char** argv)
+{
+  if (argc < 2)
+    throw std::runtime_error("usage: host.exe <xclbin>");
+
+  // Init OCL
+  cl_int err = CL_SUCCESS;
+  cl_platform_id platform = nullptr;
+  throw_if_error(clGetPlatformIDs(1,&platform,nullptr));
+
+  cl_uint num_devices = 0;
+  throw_if_error(clGetDeviceIDs(platform,CL_DEVICE_TYPE_ACCELERATOR,0,nullptr,&num_devices));
+  throw_if_error(num_devices==0,"no devices");
+  std::vector<cl_device_id> devices(num_devices);
+  throw_if_error(clGetDeviceIDs(platform,CL_DEVICE_TYPE_ACCELERATOR,num_devices,devices.data(),nullptr));
+  cl_device_id device = devices.front();
+
+  cl_context context = clCreateContext(0,1,&device,nullptr,nullptr,&err);
+  throw_if_error(err);
+
+  cl_command_queue queue = clCreateCommandQueue(context,device,CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,&err);
+  throw_if_error(err,"failed to create command queue");
+
+  // Read xclbin and create program
+  std::string fnm = argv[1];
+  std::ifstream stream(fnm);
+  stream.seekg(0,stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
+  std::vector<char> xclbin(size);
+  stream.read(xclbin.data(),size);
+  const unsigned char* data = reinterpret_cast<unsigned char*>(xclbin.data());
+  cl_int status = CL_SUCCESS;
+  cl_program program = clCreateProgramWithBinary(context,1,&device,&size,&data,&status,&err);
+  throw_if_error(err,"failed to create program");
+
+  run_test(context,queue,program);
+
+  clReleaseProgram(program);
+  clReleaseCommandQueue(queue);
+  clReleaseContext(context);
+  clReleaseDevice(device);
+  std::for_each(devices.begin(),devices.end(),[](cl_device_id d){clReleaseDevice(d);});
+
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    run(argc,argv);
+    std::cout << "TEST SUCCESS\n";
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}

--- a/tests/unit_test/cuselect/readme.txt
+++ b/tests/unit_test/cuselect/readme.txt
@@ -1,0 +1,15 @@
+Re: PR to support dynamic CU selection
+
+- Create kernel with multiple CUs connected to different memory banks.
+- Use clCreateBuffer explicitly targeting memory bank.
+- Use clSetKernelArg to filter kernel CUs to those that support the
+  requested connectivity.
+- Execute kernel.
+
+- Also test error condition where requested connectivity is not
+  supported.
+
+To build and run locally
+% env XILINX_XRT=/opt/xilin/xrt make host.exe
+% env XILINX_XRT=/opt/xilinx/xrt XILINX_SDX=<TA path> make MODE=hw DSA=xilinx_vcu1525_dynamic_5_1 xclbin
+% [run.sh] ./host.exe addone.xclbin

--- a/tests/unit_test/cuselect/sdaccel.ini
+++ b/tests/unit_test/cuselect/sdaccel.ini
@@ -1,0 +1,2 @@
+[Runtime]
+auto_trim_cus=true

--- a/tests/unit_test/cuselect/sdainfo.yml
+++ b/tests/unit_test/cuselect/sdainfo.yml
@@ -1,0 +1,47 @@
+# Copyright (C) 2016-2017 Xilinx, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+args: cuselect.xclbin
+board_copy: [cuselect.xclbin]
+copy: [main.cpp, vadd.cl]
+devices:
+- [xilinx_.*]
+flags: -g -Wall -std=c++14
+flows: [hw_all]
+krnls:
+- name: vadd
+  srcs: [vadd.cl]
+  type: clc
+name: cuselect
+owner: soeren
+srcs: [main.cpp]
+xclbins:
+- cus:
+  - {krnl: vadd, name: vadd1}
+  - {krnl: vadd, name: vadd2}
+  - {krnl: vadd, name: vadd3}
+  - {krnl: vadd, name: vadd4}
+  - {krnl: vadd, name: vadd5}
+  - {krnl: vadd, name: vadd6}
+  - {krnl: vadd, name: vadd7}
+  - {krnl: vadd, name: vadd9}
+  link_flags: --sp vadd_1.A:bank0 --sp vadd_1.B:bank1 --sp vadd_1.C:bank2 --sp vadd_1.D:bank3 \
+              --sp vadd_2.A:bank0 --sp vadd_2.B:bank1 --sp vadd_2.C:bank2 --sp vadd_2.D:bank3 \
+              --sp vadd_3.A:bank1 --sp vadd_3.B:bank2 --sp vadd_3.C:bank3 --sp vadd_3.D:bank0 \
+              --sp vadd_4.A:bank1 --sp vadd_4.B:bank2 --sp vadd_4.C:bank3 --sp vadd_4.D:bank0 \
+              --sp vadd_5.A:bank2 --sp vadd_5.B:bank3 --sp vadd_5.C:bank0 --sp vadd_5.D:bank1 \
+              --sp vadd_6.A:bank2 --sp vadd_6.B:bank3 --sp vadd_6.C:bank0 --sp vadd_6.D:bank1 \
+              --sp vadd_7.A:bank3 --sp vadd_7.B:bank0 --sp vadd_7.C:bank1 --sp vadd_7.D:bank2 \
+              --sp vadd_8.A:bank3 --sp vadd_8.B:bank0 --sp vadd_8.C:bank1 --sp vadd_8.D:bank2
+  name: cuselect
+  region: OCL_REGION_0

--- a/tests/unit_test/cuselect/vadd.cl
+++ b/tests/unit_test/cuselect/vadd.cl
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2016-2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+__kernel void vadd (
+__global int* A,
+__global int* B,
+__global int* C,
+__global int* D
+)
+{
+  const int length=16;
+  int offset = get_global_id(0);
+  int stride = get_global_size(0);
+
+  while (offset < length) {
+    D[offset] = C[offset] + A[offset] + B[offset];
+    offset += stride;
+  }
+
+  return;
+}

--- a/tests/unit_test/subdevice/Makefile
+++ b/tests/unit_test/subdevice/Makefile
@@ -1,0 +1,87 @@
+# Copyright (C) 2016-2017 Xilinx, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+XOCC := $(XILINX_SDX)/bin/xocc
+EMCONFIGUTIL := $(XILINX_SDX)/bin/emconfigutil
+MODE ?= hw_emu
+DSA ?= xilinx_vcu1525_dynamic_5_1
+
+# % env XILINX_SDX=/proj/xbuilds/2018.3_daily_latest/installs/lin64/SDx/2018.3 make xclbin
+# % env XILINX_SDX=/proj/xbuilds/2018.3_daily_latest/installs/lin64/SDx/2018.3 make emconfig
+# % run.sh make host.exe
+# % run.sh ./host.exe cuselect.xclbin
+
+# sources
+KERNEL_SRC := addone.cl
+HOST_SRC := main.cpp
+
+# targets
+HOST_EXE := host.exe
+XOS := addone.$(MODE).xo
+XCLBIN := addone.$(MODE).xclbin
+EMCONFIG_FILE := emconfig.json
+
+# flags
+XOCC_LINK_OPTS :=  \
+ --nk addone:4 \
+ --sp addone_1.a:bank0 \
+ --sp addone_1.b:bank1 \
+ --sp addone_2.a:bank1 \
+ --sp addone_2.b:bank2 \
+ --sp addone_3.a:bank2 \
+ --sp addone_3.b:bank3 \
+ --sp addone_4.a:bank3  \
+ --sp addone_4.b:bank0
+
+XOCC_COMMON_OPTS := -s -t $(MODE) --platform $(DSA)
+CFLAGS := -g -std=c++14 -I$(XILINX_XRT)/include
+LFLAGS := -L$(XILINX_XRT)/lib -lxilinxopencl -lpthread -lrt
+NUMDEVICES := 1
+
+# run time args
+EXE_OPT := addone.$(MODE).xclbin
+
+# primary build targets
+.PHONY: xclbin compile all clean
+
+xclbin: $(XCLBIN)
+compile: $(HOST_EXE)
+all: clean xclbin compile run
+
+clean:
+	-$(RM) $(EMCONFIG_FILE) $(HOST_EXE) $(XCLBIN) $(XOS)
+
+# kernel rules
+$(XOS): $(KERNEL_SRC)
+	$(RM) $@
+	$(XOCC) $(XOCC_COMMON_OPTS) -c -o $@ $+
+
+
+$(XCLBIN): $(XOS)
+	$(XOCC) $(XOCC_COMMON_OPTS) -l -o $@ $+ $(XOCC_LINK_OPTS)
+
+# host rules
+$(HOST_EXE): $(HOST_SRC)
+	g++ $(CFLAGS) -o $@ $+ $(LFLAGS)
+	@echo 'Compiled Host Executable: $(HOST_EXE)'
+
+ifneq ($(MODE),hw)
+$(EMCONFIG_FILE):
+	$(EMCONFIGUTIL) --nd $(NUMDEVICES) --od . --platform $(DSA)
+else
+$(EMCONFIG_FILE):
+endif
+
+run: $(XCLBIN) $(HOST_EXE) $(EMCONFIG_FILE)
+	./host.exe $(EXE_OPT)

--- a/tests/unit_test/subdevice/addone.cl
+++ b/tests/unit_test/subdevice/addone.cl
@@ -1,0 +1,22 @@
+/*
+  OpenCL Task (1 work item)
+  512 bit wide add one
+  512 bits = 8 vector of 64 bit unsigned
+    Add one to first element in vector
+    Copy through remaining elements
+*/
+
+__kernel __attribute__ ((reqd_work_group_size(1, 1 , 1)))
+void addone (__global ulong8 *a, __global ulong8 * b, unsigned int  elements)
+{
+  ulong8 temp;
+  unsigned int i;
+
+  for(i=0;i< elements;i++){
+    temp=a[i];
+    //add one to first element in vector
+    temp.s0=temp.s0+1;
+    b[i]=temp;
+  }
+  return;
+}

--- a/tests/unit_test/subdevice/main.cpp
+++ b/tests/unit_test/subdevice/main.cpp
@@ -1,0 +1,180 @@
+// Copyright (C) 2018 Xilinx Inc.
+// All rights reserved.
+
+#include <CL/cl_ext_xilinx.h>   // to suppress deprecation warnings
+#include <CL/cl.h>
+#include <fstream>
+#include <stdexcept>
+#include <numeric>
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <string>
+
+const size_t ELEMENTS = 16;
+const size_t ARRAY_SIZE = 8;
+
+static void
+throw_if_error(cl_int errcode, const char* msg=nullptr)
+{
+  if (!errcode)
+    return;
+  std::string err = "errcode '";
+  err.append(std::to_string(errcode)).append("'");
+  if (msg)
+    err.append(" ").append(msg);
+  throw std::runtime_error(err);
+}
+
+int
+run_cu(cl_context context, cl_command_queue queue, cl_kernel kernel)
+{
+  using data_type = unsigned long;
+  const size_t size = ELEMENTS * ARRAY_SIZE;
+  const size_t bytes = sizeof(data_type) * size;
+
+  auto a = clCreateBuffer(context,CL_MEM_READ_ONLY,bytes,nullptr,nullptr);
+  auto b = clCreateBuffer(context,CL_MEM_WRITE_ONLY,bytes,nullptr,nullptr);
+  throw_if_error(a==nullptr,"failed to create buffer for a");
+  throw_if_error(b==nullptr,"failed to create buffer for b");
+
+  // set kernel args prior to enqueue operation such that proper
+  // device side allocation can be determined
+  throw_if_error(clSetKernelArg(kernel,0,sizeof(cl_mem),&a),"failed to set kernel arg 0");
+  throw_if_error(clSetKernelArg(kernel,1,sizeof(cl_mem),&b),"failed to set kernel arg 1");
+  throw_if_error(clSetKernelArg(kernel,2,sizeof(int),&ELEMENTS),"failed to set kernel arg 2");
+
+  cl_int err = CL_SUCCESS;
+  auto a_data = (data_type*) clEnqueueMapBuffer(queue,a,true,CL_MAP_WRITE,0,bytes,0,nullptr,nullptr,&err);
+  throw_if_error(err,"failed to map buffer a");
+  throw_if_error(clEnqueueUnmapMemObject(queue,a,a_data,0,nullptr,nullptr));
+  auto b_data = (data_type*) clEnqueueMapBuffer(queue,b,true,CL_MAP_READ,0,bytes,0,nullptr,nullptr,&err);
+  throw_if_error(err,"failed to map buffer b");
+  throw_if_error(clEnqueueUnmapMemObject(queue,b,b_data,0,nullptr,nullptr));
+
+  std::iota(a_data,a_data+size,0);
+
+  cl_event migrate_event = nullptr;
+  cl_mem mems[2] = {a,b};
+  throw_if_error(clEnqueueMigrateMemObjects(queue,2,mems,0,0,nullptr,&migrate_event));
+
+  cl_event ndrange_event = nullptr;
+  clEnqueueTask(queue,kernel,1,&migrate_event,&ndrange_event);
+  clReleaseEvent(migrate_event);
+
+  throw_if_error(clEnqueueMigrateMemObjects(queue,1,mems+1,CL_MIGRATE_MEM_OBJECT_HOST,1,&ndrange_event,&migrate_event));
+  clReleaseEvent(ndrange_event);
+
+  clWaitForEvents(1,&migrate_event);
+  clReleaseEvent(migrate_event);
+
+  // verify
+  for (size_t idx=0; idx<size; ++idx) {
+    auto expect = a_data[idx] + (idx%8 ? 0 : 1);
+    if (b_data[idx] != expect) {
+      std::cout << "b_data[" << idx << "] = " << b_data[idx]
+                << " expected " << expect << "\n";
+      err=1;
+    }
+  }
+  throw_if_error(err,"Results did not match");
+
+  clReleaseMemObject(a);
+  clReleaseMemObject(b);
+
+  return 0;
+}
+
+int
+run_kernel(cl_device_id device,cl_command_queue queue,cl_program program)
+{
+  // Create sub devices
+  cl_uint num_devices = 0;
+  cl_device_partition_property props[3] = {CL_DEVICE_PARTITION_EQUALLY,1,0};
+  throw_if_error(clCreateSubDevices(device,props,0,nullptr,&num_devices));
+  std::vector<cl_device_id> devices(num_devices);
+  throw_if_error(clCreateSubDevices(device,props,num_devices,devices.data(),nullptr));
+
+  std::for_each(devices.begin(),devices.end(),[program](cl_device_id sdev) {
+      cl_int err = CL_SUCCESS;
+      auto context = clCreateContext(0,1,&sdev,nullptr,nullptr,&err);
+      throw_if_error(err,"failed to create context from sub device");
+      auto queue = clCreateCommandQueue(context,sdev,CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,&err);
+      throw_if_error(err,"failed to create command queue from context");
+      auto kernel = clCreateKernel(program,"addone",&err);
+      throw_if_error(err,"failed to create kernel from program");
+      run_cu(context,queue,kernel);
+      throw_if_error(clReleaseKernel(kernel));
+      throw_if_error(clReleaseCommandQueue(queue));
+      throw_if_error(clReleaseContext(context));
+      throw_if_error(clReleaseDevice(sdev));
+    });
+
+  return 0;
+}
+
+int
+run(int argc, char** argv)
+{
+  if (argc < 2)
+    throw std::runtime_error("usage: host.exe <xclbin>");
+
+  // Init OCL
+  cl_int err = CL_SUCCESS;
+  cl_platform_id platform = nullptr;
+  throw_if_error(clGetPlatformIDs(1,&platform,nullptr));
+
+  cl_uint num_devices = 0;
+  throw_if_error(clGetDeviceIDs(platform,CL_DEVICE_TYPE_ACCELERATOR,0,nullptr,&num_devices));
+  throw_if_error(num_devices==0,"no devices");
+  std::vector<cl_device_id> devices(num_devices);
+  throw_if_error(clGetDeviceIDs(platform,CL_DEVICE_TYPE_ACCELERATOR,num_devices,devices.data(),nullptr));
+  cl_device_id device = devices.front();
+
+  cl_context context = clCreateContext(0,1,&device,nullptr,nullptr,&err);
+  throw_if_error(err);
+
+  cl_command_queue queue = clCreateCommandQueue(context,device,0,&err);
+  throw_if_error(err,"failed to create command queue");
+
+  // Read xclbin and create program
+  std::string fnm = argv[1];
+  std::ifstream stream(fnm);
+  stream.seekg(0,stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
+  std::vector<char> xclbin(size);
+  stream.read(xclbin.data(),size);
+  const unsigned char* data = reinterpret_cast<unsigned char*>(xclbin.data());
+  cl_int status = CL_SUCCESS;
+  cl_program program = clCreateProgramWithBinary(context,1,&device,&size,&data,&status,&err);
+  throw_if_error(err,"failed to create program");
+
+  run_kernel(device,queue,program);
+
+  clReleaseProgram(program);
+  clReleaseCommandQueue(queue);
+  clReleaseContext(context);
+  clReleaseDevice(device);
+  std::for_each(devices.begin(),devices.end(),[](cl_device_id d){clReleaseDevice(d);});
+
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    run(argc,argv);
+    std::cout << "TEST SUCCESS\n";
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}

--- a/tests/unit_test/subdevice/readme.txt
+++ b/tests/unit_test/subdevice/readme.txt
@@ -1,0 +1,11 @@
+Re: CR-988905
+Create kernel with multiple CUs connected to different memory banks.
+Create sub-device for each CU and a context for each sub-device.
+Use clCreateBuffer without specifying memory bank.
+Execute kernel.
+
+To build and run locally
+
+% env XILINX_XRT=/opt/xilin/xrt make host.exe
+% env XILINX_XRT=/opt/xilinx/xrt XILINX_SDX=<TA path> make MODE=hw DSA=xilinx_vcu1525_dynamic_5_1 xclbin
+% [run.sh] ./host.exe addone.xclbin

--- a/tests/unit_test/subdevice/sdainfo.yml
+++ b/tests/unit_test/subdevice/sdainfo.yml
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2017 Xilinx, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+args: addone.xclbin
+board_copy: [cuselect.xclbin]
+copy: [main.cpp, addone.cl]
+devices:
+- [xilinx_.*]
+flags: -g -Wall -std=c++14
+flows: [hw_all]
+krnls:
+- name: addone
+  srcs: [addone.cl]
+  type: clc
+name: subdevice
+owner: soeren
+srcs: [main.cpp]
+xclbins:
+- cus:
+  - {krnl: addone, name: addone_1}
+  - {krnl: addone, name: addone_2}
+  - {krnl: addone, name: addone_3}
+  - {krnl: addone, name: addone_4}
+  link_flags: --sp addone_1.a:bank0 --sp addone_1.b:bank1 --sp addone_2.a:bank1 --sp addone_2.b:bank2 --sp addone_3.a:bank2 --sp addone_3.b:bank3 --sp addone_4.a:bank3  --sp addone_4.b:bank0
+  name: addone
+  region: OCL_REGION_0


### PR DESCRIPTION
Multiple changes to support clSetKernelArg deducing device buffer
memory connectitivity.

Kernel is constructed with all device CUs based on loaded program.
The kernel CUs are dynamically filtered based on connectivity
requirements of kernel arguments.

The kernel CUs that remain after filtering are sticky in the sense
that when reusing a kernel object, only the prior filtered resulting
CUs are avaiable, if other CUs are required, a new kernel object should
be constructed.

This commit also does away with the memory extention where
{kernel,argidx} is specified, Though still supported, clCreateBuffer
simply calls clSetKernelArg under the hood when the the buffer carries
the now obsolete extension.

The deduced memory connectivity of a cl_mem buffer is stored as a data
member on the memory object.  This is used for the cases where the
targeted device is unknown until first clEnqueue operation involving
the buffer.