### PR TITLE
Remove python-cffi from xrtdeps.sh

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -79,7 +79,6 @@ RH_LIST=(\
      protobuf-static \
      python \
      python-enum \
-     python-cffi \
      redhat-lsb \
      rpm-build \
      strace \
@@ -120,7 +119,6 @@ UB_LIST=(\
      perl \
      python \
      python-enum34 \
-     python-cffi \
      pciutils \
      pkg-config \
      protobuf-compiler \


### PR DESCRIPTION
Sonal's PR Xilinx/XRT#832 removes the dependency on cffi, so this can be removed from xrtdeps.sh.