### PR TITLE
Reset sector select before trying to flash mcs files. (#871)

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbflash/xspi.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbflash/xspi.cpp
@@ -1242,6 +1242,8 @@ bool XSPI_Flasher::prepareXSpi()
     if(TEST_MODE)
         return true;
 
+    //Resetting selected_sector
+    selected_sector = -1;
 
     XSPI_UNUSED uint32_t tControlReg = XSpi_GetControlReg();
     XSPI_UNUSED uint32_t tStatusReg = XSpi_GetStatusReg();


### PR DESCRIPTION
This is a quick fix. Proper fix will follow. (cherry-pick from 2018.3)