### PR TITLE
Support kernel version 4.19 in zocl and fix a cmake issue in cmake 3.12

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -1,4 +1,4 @@
-if( ${CMAKE_BUILD_TYPE} STREQUAL "Release")
+if(${CMAKE_BUILD_TYPE} STREQUAL "Release" AND ${XRT_NATIVE_BUILD} STREQUAL "yes")
   add_subdirectory(doc)
 endif()
 
@@ -9,6 +9,7 @@ include_directories(
   )
 
 set(OPENCL_SRC "")
+
 
 add_library(xilinxopencl SHARED ${OPENCL_SRC}
   $<TARGET_OBJECTS:xocl>

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
@@ -150,7 +150,11 @@ void zocl_free_bo(struct drm_gem_object *obj)
 	zocl_iommu_unmap_bo(obj->dev, zocl_obj);
 	if (zocl_obj->pages) {
 		if (zocl_bo_userptr(zocl_obj)) {
-			release_pages(zocl_obj->pages, npages, 0);
+#if KERNEL_VERSION(4, 15, 0) <= LINUX_VERSION_CODE
+			release_pages(zocl_obj->pages, npages);
+#else
+			release_pages(pages, nr, 0);
+#endif
 			kvfree(zocl_obj->pages);
 		} else
 			drm_gem_put_pages(obj, zocl_obj->pages, false, false);

--- a/src/runtime_src/impl/CMakeLists.txt
+++ b/src/runtime_src/impl/CMakeLists.txt
@@ -19,3 +19,4 @@ set(XRT_IMPL_ALL_SRC
   )
 
 add_library(impl OBJECT ${XRT_IMPL_ALL_SRC})
+set_target_properties(impl PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
1. PetaLinux will update to kernel version 4.19 in 19.1 release. The release_page() API changed since kernel 4.15.
2. Library impl has header files only. Cmake 3.12 complains not able to determine linker language. Update CMakeList.txt in impl/, issue fixed.
3. Update ocl-icd license in the recipe to avoid warning.