### PR TITLE
Fix bug in kernel auto compute select

### DIFF
--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -421,7 +421,8 @@ kernel::
 validate_cus(unsigned long argidx, int memidx) const
 {
   XOCL_DEBUG(std::cout,"xocl::kernel::validate_cus(",argidx,",",memidx,")\n");
-  xclbin::memidx_bitmask_type connections(1<<memidx);
+  xclbin::memidx_bitmask_type connections;
+  connections.set(memidx);
   auto end = m_cus.end();
   for (auto itr=m_cus.begin(); itr!=end; ) {
     auto cu = (*itr);


### PR DESCRIPTION
Bitset constructed from overflow value.
http://jira.xilinx.com/browse/CR-1020412