### PR TITLE
Completes the logic for checking UUID instead of XclbinId on F1

### DIFF
--- a/src/runtime_src/driver/xclng/tools/awssak/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/awssak/CMakeLists.txt
@@ -21,6 +21,7 @@ if(${INTERNAL_TESTING})
     xrt_awsstatic
     pthread
     rt
+    uuid
     )
 else()
   include_directories(${AWS_FPGA_REPO_DIR}/sdk/userspace/include/) # path to fpga_mgmt.h
@@ -30,6 +31,7 @@ else()
     xrt_awsstatic
     pthread
     rt
+    uuid
     ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a
     )
 endif()

--- a/src/runtime_src/driver/xclng/xrt/user_aws/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/shim.cpp
@@ -172,7 +172,7 @@ namespace awsbwhal {
           if( int retVal = xclGetXclBinUuidFromSysfs( xclbin_uuid_from_sysfs ) != 0 )
              return retVal;
 
-          if ( (xclbin_uuid_from_sysfs == 0) || (axlfbuffer->m_uniqueId != xclbin_uuid_from_sysfs) || checkAndSkipReload(afi_id, &orig_info) ) {
+          if ( (xclbin_uuid_from_sysfs == 0) || (axlfbuffer->m_header.uuid != xclbin_uuid_from_sysfs) || checkAndSkipReload(afi_id, &orig_info) ) {
               // force data retention option
               union fpga_mgmt_load_local_image_options opt;
               fpga_mgmt_init_load_local_image_options(&opt);

--- a/src/runtime_src/driver/xclng/xrt/user_aws/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/shim.h
@@ -189,7 +189,7 @@ public:
 
 
         // Bitstreams
-        int xclGetXclBinIdFromSysfs(uint64_t &xclbinid);
+        int xclGetXclBinUuidFromSysfs(uuid_t &xclbinid);
         int xclLoadXclBin(const xclBin *buffer);
         int xclLoadAxlf(const axlf *buffer);
         int xclUpgradeFirmware(const char *fileName);


### PR DESCRIPTION
The changes in #881 are incomplete and fail to parse xclbinuuid on sysfs. This change provides the correct result. I have begun testing this revision on F1 and believe if should be the next release candidate. Please tag this revision as 2018.3.RC3 after this commit is merged in 2018.3.