### PR TITLE
Added support to allocate cacheable CMA

### DIFF
--- a/src/runtime_src/driver/include/CMakeLists.txt
+++ b/src/runtime_src/driver/include/CMakeLists.txt
@@ -9,7 +9,8 @@ set(XRT_HEADER_SRC
   xcl_app_debug.h
   xcl_macros.h
   xcl_app_debug.h
-  xclperf.h)
+  xclperf.h
+  xclhal2_mem.h)
 
 install (FILES ${XRT_HEADER_SRC} DESTINATION ${XRT_INSTALL_DIR}/include)
 

--- a/src/runtime_src/driver/include/xclhal2.h
+++ b/src/runtime_src/driver/include/xclhal2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018, Xilinx Inc - All rights reserved
+ * Copyright (C) 2015-2019, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -42,6 +42,7 @@
 #include "xclperf.h"
 #include "xcl_app_debug.h"
 #include "xclerr.h"
+#include "xclhal2_mem.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -141,14 +142,6 @@ enum xclMemoryDomains {
     XCL_MEM_SVM =         0x00000003,
     XCL_MEM_CMA =         0x00000004,
     XCL_MEM_DEVICE_REG  = 0x00000005
-};
-
-/* byte-0 lower 4 bits for DDR Flags are one-hot encoded */
-enum xclDDRFlags {
-    XCL_DEVICE_RAM_BANK0 = 0x00000000,
-    XCL_DEVICE_RAM_BANK1 = 0x00000002,
-    XCL_DEVICE_RAM_BANK2 = 0x00000004,
-    XCL_DEVICE_RAM_BANK3 = 0x00000008
 };
 
 /**

--- a/src/runtime_src/driver/include/xclhal2_mem.h
+++ b/src/runtime_src/driver/include/xclhal2_mem.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019, Xilinx Inc - All rights reserved.
+ * Xilinx Runtime (XRT) APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XCLHAL2_MEM_H_
+#define _XCLHAL2_MEM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * XCL BO Flags bits layout
+ *
+ * bits  0 ~ 15: DDR BANK index
+ * bits 16 ~ 31: BO flags
+ */
+#define	XCL_BO_FLAGS_CACHEABLE		(1 << 24)
+#define	XCL_BO_FLAGS_HOST_BO		(1 << 25)
+#define	XCL_BO_FLAGS_COHERENT		(1 << 26)
+#define	XCL_BO_FLAGS_SVM		(1 << 27)
+#define	XCL_BO_FLAGS_USERPTR		(1 << 28)
+#define	XCL_BO_FLAGS_CMA		(1 << 29)
+#define	XCL_BO_FLAGS_P2P		(1 << 30)
+#define	XCL_BO_FLAGS_EXECBUF		(1 << 31)
+
+/**
+ * This is the legacy usage of XCL DDR Flags.
+ *
+ * byte-0 lower 4 bits for DDR Flags are one-hot encoded
+ */
+enum xclDDRFlags {
+    XCL_DEVICE_RAM_BANK0 = 0x00000000,
+    XCL_DEVICE_RAM_BANK1 = 0x00000002,
+    XCL_DEVICE_RAM_BANK2 = 0x00000004,
+    XCL_DEVICE_RAM_BANK3 = 0x00000008,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
@@ -2,7 +2,7 @@
  * A GEM style (optionally CMA backed) device manager for ZynQ based
  * OpenCL accelerators.
  *
- * Copyright (C) 2016 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
@@ -28,6 +28,7 @@
 #include "zocl_ioctl.h"
 #include "zocl_ert.h"
 #include "zocl_util.h"
+#include "xclhal2_mem.h"
 
 struct drm_zocl_exec_metadata {
 	enum drm_zocl_execbuf_state state;
@@ -66,13 +67,13 @@ drm_zocl_bo *to_zocl_bo(struct drm_gem_object *bo)
 	static inline bool
 zocl_bo_userptr(const struct drm_zocl_bo *bo)
 {
-	return (bo->flags & DRM_ZOCL_BO_FLAGS_USERPTR);
+	return (bo->flags & XCL_BO_FLAGS_USERPTR);
 }
 
 	static inline bool
 zocl_bo_execbuf(const struct drm_zocl_bo *bo)
 {
-	return (bo->flags & DRM_ZOCL_BO_FLAGS_EXECBUF);
+	return (bo->flags & XCL_BO_FLAGS_EXECBUF);
 }
 
 

--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
  * Author(s): Hem C. Neema
  *          : Min Ma
  * ZNYQ HAL Driver layered on top of ZYNQ kernel driver
@@ -299,8 +299,15 @@ int ZYNQShim::xclGetDeviceInfo2(xclDeviceInfo2 *info)
 
 int ZYNQShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, size_t offset)
 {
-  //no need to sync for MPSOC.
-  return 0;
+  drm_zocl_sync_bo_dir zocl_dir;
+  if (dir == XCL_BO_SYNC_BO_TO_DEVICE)
+      zocl_dir = DRM_ZOCL_SYNC_BO_TO_DEVICE;
+  else if (dir == XCL_BO_SYNC_BO_FROM_DEVICE)
+      zocl_dir = DRM_ZOCL_SYNC_BO_FROM_DEVICE;
+  else
+      return -EINVAL;
+  drm_zocl_sync_bo syncInfo = { boHandle, zocl_dir, offset, size };
+  return ioctl(mKernelFD, DRM_IOCTL_ZOCL_SYNC_BO, &syncInfo);
 }
 
 #ifndef __HWEM__


### PR DESCRIPTION
This PR adds support to allocate cacheable BO backed by CMA buffer. It includes 3 main changes/enhancement

1) Add a new interface file xclhal2_mem.h. Currently, move the legacy BO flags to this file and also add new BO flags. Eventually, those new flags will be unified by both x86 and embedded code. But this PR only defines the flags and modify all zocl driver to use them.

2) Modify zocl mmap() entry point zocl_mmap() interface to map the BO as cacheable to user application if user sets CACHEABLE flag when creating BO.

3) Enhance the zocl_sycn_bo_ioctl to actually invalidate/flush read/write cache. It used to be NOP on embedded system because our BO memory used to be always coherent.

