### PR TITLE
Provide functionality to override XMA default configuration file path through ENV variable.

### DIFF
--- a/src/xma/src/xmaapi/xmaapi.c
+++ b/src/xma/src/xmaapi/xmaapi.c
@@ -36,7 +36,8 @@ int32_t xma_initialize(char *cfgfile)
     bool    rc;
 
     if (!cfgfile)
-        cfgfile = XMA_CFG_DEFAULT;
+        if (!(cfgfile = getenv("XMA_CFG_OVERRIDE")))
+            cfgfile = XMA_CFG_DEFAULT;
 
     g_xma_singleton = malloc(sizeof(*g_xma_singleton));
     memset(g_xma_singleton, 0, sizeof(*g_xma_singleton));


### PR DESCRIPTION
Currently, we need the ability to target particular FPGA device with any transcoding application which calls `xma_initialize` without touching default configuration file `/var/tmp/xma_cfg.yaml` which will be reserved to use while serving production traffic. We need the ability to pass the configuration file path to `xma_initialize` through environment variable to override defaults in `XMA_CFG_DEFAULT`. Priority of config file path lookup will be in following descending order

- path provided by `xma_initialize(cfgfile)`
- the path provided by environment variable `XMA_CFG_OVERRIDE`
- path defined by `XMA_CFG_DEFAULT` which is `/var/tmp/xma_cfg.yaml`

This way I can run ffmpeg or any equivalent transcoding in two different ways 
```
# this will target FPGA devices according to device_id_map[]  defined in  /var/tmp/xma_cfg.yaml

~$ ffmpeg <transcoding options>


# to schlep transcoding to 2nd FPGA device, 
# create config with device_id_map [2] in /tmp/test_2nd_FPGA_device.yaml and 
# execute ffmpeg in following manner.
 
~$ XMA_CFG_OVERRIDE="/tmp/test_2nd_FPGA_device.yaml" ffmpeg <transcoding options>

```

If we need thread safety in `xma_initialize` then we can replace `get_env` with `secure_getenv`
