### PR TITLE
2018.3 branch XMA changes 2019-01-24

### DIFF
--- a/src/xma/include/lib/xmares.h
+++ b/src/xma/include/lib/xmares.h
@@ -246,9 +246,11 @@ void xma_res_mark_xma_ready(XmaResources shm_cfg);
  * @brief Before attempting hw config, verify that hw init hasn't already
  * completed
  *
+ * @param shm_cfg shared memory pointer
+ *
  * @returns true if init is already complete, false otherwise
 */
-bool xma_res_xma_init_completed(void);
+bool xma_res_xma_init_completed(XmaResources shm_cfg);
 
 /** @} */
 #ifdef __cplusplus

--- a/src/xma/src/xmaapi/xmaapi.c
+++ b/src/xma/src/xmaapi/xmaapi.c
@@ -25,7 +25,7 @@
 #include "lib/xmahw_hal.h"
 #include "lib/xmasignal.h"
 
-#define XMA_CFG_DEFAULT "/var/tmp/xmacfg.yaml"
+#define XMA_CFG_DEFAULT "/var/tmp/xilinx/xmacfg.yaml"
 #define XMAAPI_MOD "xmaapi"
 
 XmaSingleton *g_xma_singleton;

--- a/src/xma/src/xmaapi/xmaapi.c
+++ b/src/xma/src/xmaapi/xmaapi.c
@@ -15,6 +15,10 @@
  * under the License.
  */
 
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
@@ -26,17 +30,32 @@
 #include "lib/xmasignal.h"
 
 #define XMA_CFG_DEFAULT "/var/tmp/xilinx/xmacfg.yaml"
+#define XMA_CFG_DIR "/var/tmp/xilinx"
 #define XMAAPI_MOD "xmaapi"
 
 XmaSingleton *g_xma_singleton;
+
+int32_t xma_check_default_cfg_dir(void)
+{
+    if (!access(XMA_CFG_DIR, R_OK | W_OK | X_OK))
+        return XMA_SUCCESS;
+
+    printf("XMA CFG ERROR: Unable to access directory " XMA_CFG_DIR " properly.  Errno = %d\n",
+           errno);
+    return XMA_ERROR;
+}
 
 int32_t xma_initialize(char *cfgfile)
 {
     int32_t ret;
     bool    rc;
 
-    if (!cfgfile)
+    if (!cfgfile) {
         cfgfile = XMA_CFG_DEFAULT;
+        ret = xma_check_default_cfg_dir();
+        if (ret)
+            return ret;
+    }
 
     g_xma_singleton = malloc(sizeof(*g_xma_singleton));
     memset(g_xma_singleton, 0, sizeof(*g_xma_singleton));

--- a/src/xma/src/xmaapi/xmaapi.c
+++ b/src/xma/src/xmaapi/xmaapi.c
@@ -70,7 +70,7 @@ int32_t xma_initialize(char *cfgfile)
     xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "Configure hardware\n");
     rc = xma_hw_configure(&g_xma_singleton->hwcfg,
                           &g_xma_singleton->systemcfg,
-                          xma_res_xma_init_completed());
+                          xma_res_xma_init_completed(g_xma_singleton->shm_res_cfg));
     if (!rc)
         goto error;
 

--- a/src/xma/src/xmaapi/xmaencoder.c
+++ b/src/xma/src/xmaapi/xmaencoder.c
@@ -310,7 +310,7 @@ xma_enc_session_recv_data(XmaEncoderSession *session,
 void 
 xma_enc_session_statsfile_init(XmaEncoderSession *session)
 {
-    char            *path = "/var/tmp";
+    char            *path = "/var/tmp/xilinx";
     char            *enc_type_str;
     char            *vendor;
     int32_t          dev_id = 0;

--- a/src/xma/src/xmaapi/xmalogger.cpp
+++ b/src/xma/src/xmaapi/xmalogger.cpp
@@ -15,6 +15,8 @@
  * under the License.
  */
 
+#define _GNU_SOURCE
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -27,10 +29,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sched.h>
-#include <cstdlib>
-#include <string>
-#include <fstream>
-#include <iostream>
+#include <errno.h>
 
 #include "lib/xmaapi.h"
 #include "app/xmalogger.h"
@@ -192,7 +191,8 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
     log_level = g_loglevel_tbl[level].lvl_str;
     
     /* Format log message */
-    sprintf(msg_buff, "%s.%03d %d %s %s ", log_time, millisec, getpid(), log_level, log_name);
+    //NOTE: Usage of program_invocation_short_name may hinder portability
+    sprintf(msg_buff, "%s.%03d %d %s %s %s ", log_time, millisec, getpid(), program_invocation_short_name, log_level, log_name);
     hdr_offset = strlen(msg_buff);
     va_start(ap, msg); 
     vsnprintf(&msg_buff[hdr_offset], (XMA_MAX_LOGMSG_SIZE - hdr_offset), msg, ap);

--- a/src/xma/src/xmaapi/xmalogger.cpp
+++ b/src/xma/src/xmaapi/xmalogger.cpp
@@ -15,8 +15,12 @@
  * under the License.
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
+#include <iostream>
+#include <fstream>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -965,10 +965,10 @@ static int32_t xma_res_alloc_kernel(XmaResources shm_cfg,
     }
 
     xma_logmsg(XMA_ERROR_LOG, XMA_RES_MOD, "No available kernels of type '%s' from vendor %s\n",
-               kern_props->kernel_spec.scal_type ? "scaler" :
-               kern_props->kernel_spec.enc_type ? "encoder" :
-               kern_props->kernel_spec.dec_type ? "decoder" :
-               kern_props->kernel_spec.filter_type ? "filter" :
+               type == xma_res_scaler ? "scaler" :
+               type == xma_res_encoder ? "encoder" :
+               type == xma_res_decoder ? "decoder" :
+               type == xma_res_filter ? "filter" :
                "kernel", kern_props->vendor);
     return XMA_ERROR_NO_KERNEL;
 


### PR DESCRIPTION
a2dc21b Check for existence of default directory path for cfg file
854c65b Add flag to indicate resources have been programmed
13d1515 Close possible race condition in init of shm db and mutex
be86e0b Fix for kernel alloc issue via kernel affinity
8c1da80 Adding exec name in xma log
07f27e0 Changing config yaml and stats files paths
aa6374a Fix log message in error path of xmares kernel reservation
