### PR TITLE
Kernel Upgrade Fix for F1

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -111,6 +111,11 @@ struct xocl_dev	{
 	/*should be removed after mailbox is supported */
 	u64			        unique_id_last_bitstream;
 	/* remove the previous id after we move to uuid */
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 16, 0) || RHEL_P2P_SUPPORT_76
+  struct dev_pagemap pgmap;
+#endif
+
 	xuid_t                          xclbin_id;
 	unsigned                        ip_reference[MAX_CUS];
 	struct list_head                ctx_list;

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -103,17 +103,25 @@ static inline bool uuid_is_null(const xuid_t *uuid)
 #define	XOCL_CHARDEV_REG_COUNT	16
 
 #ifdef RHEL_RELEASE_VERSION
-#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,3)
-#define RHEL_P2P_SUPPORT  1
-#else
-#define RHEL_P2P_SUPPORT  0
+
+#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,6)
+#define RHEL_P2P_SUPPORT_74  0
+#define RHEL_P2P_SUPPORT_76  1
+#elif RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7,3) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7,6)
+#define RHEL_P2P_SUPPORT_74  1
+#define RHEL_P2P_SUPPORT_76  0
 #endif
 #else
-#define RHEL_P2P_SUPPORT  0
+#define RHEL_P2P_SUPPORT_74  0
+#define RHEL_P2P_SUPPORT_76  0
 #endif
 
 #define INVALID_SUBDEVICE 		~0U
 #define NUMS_OF_DYNA_IP_ADDR   4
+
+#define RHEL_P2P_SUPPORT (RHEL_P2P_SUPPORT_74 | RHEL_P2P_SUPPORT_76)
+
+#define XOCL_INVALID_MINOR -1
 
 extern struct class *xrt_class;
 

--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -39,7 +39,7 @@ if ( "$OSDIST" =~ "ubuntu" ) then
 endif
 
 if ( "$OSDIST" =~ centos  || "$OSDIST" =~ redhat* ) then
-    if ( "$OSREL" !~ 7.4* && "$OSREL" !~ 7.5* ) then
+    if ( "$OSREL" !~ 7.4* && "$OSREL" !~ 7.5* && "$OSREL" !~ 7.6* ) then
         echo "ERROR: Centos or RHEL release version must be 7.4 or later"
         exit 1
     endif

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -15,7 +15,7 @@ if [[ $OSDIST == "ubuntu" ]]; then
 fi
 
 if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "redhat"* ]]; then
-    if [[ $OSREL != "7.4"* ]] &&  [[ $OSREL != "7.5"* ]]; then
+    if [[ $OSREL != "7.4"* ]] &&  [[ $OSREL != "7.5"* ]] && [[ $OSREL != "7.6"* ]]; then
         echo "ERROR: Centos or RHEL release version must be 7.4 or later"
         return 1
     fi


### PR DESCRIPTION
Due to issues found by AWS F1 customers who upgraded the Linux kernel to 3.10.0-957, we have added driver support. This has been sanity tested on F1, but needs a full regression suite. 