### PR TITLE
Bug Fixes

### DIFF
--- a/src/runtime_src/driver/include/xclbin.h
+++ b/src/runtime_src/driver/include/xclbin.h
@@ -127,7 +127,7 @@ extern "C" {
         BUILD_METADATA,
         KEYVALUE_METADATA,
         USER_METADATA,
-        DNA_CERTIFICATE
+        DNA_CERTIFICATE 
     };
 
     enum MEM_TYPE {
@@ -140,6 +140,7 @@ extern "C" {
         MEM_HBM,
         MEM_BRAM,
         MEM_URAM,
+        MEM_STREAMING_CONNECTION
     };
 
     enum IP_TYPE {

--- a/src/runtime_src/tools/xclbin/XclBin.cxx
+++ b/src/runtime_src/tools/xclbin/XclBin.cxx
@@ -354,7 +354,7 @@ XclBin::writeXclBinBinary(const std::string &_binaryFileName,
   std::fstream ofXclBin;
   ofXclBin.open(_binaryFileName, std::ifstream::out | std::ifstream::binary);
   if (!ofXclBin.is_open()) {
-    std::string errMsg = "ERROR: Unable to open the file for reading: " + _binaryFileName;
+    std::string errMsg = "ERROR: Unable to open the file for writing: " + _binaryFileName;
     throw std::runtime_error(errMsg);
   }
 

--- a/src/runtime_src/tools/xclbin/xclbindata.cxx
+++ b/src/runtime_src/tools/xclbin/xclbindata.cxx
@@ -731,6 +731,9 @@ XclBinData::getMemType( std::string &_sMemType ) const
   if ( _sMemType == "MEM_ARE" )
       return MEM_ARE;
 
+  if ( _sMemType == "MEM_STREAMING_CONNECTION" )
+      return MEM_STREAMING_CONNECTION;
+
   std::string errMsg = "ERROR: Unknown memory type: '" + _sMemType + "'";
   throw std::runtime_error(errMsg);
 }
@@ -1325,6 +1328,7 @@ XclBinData::getMemTypeStr(enum MEM_TYPE _memType) const
     case MEM_STREAMING: return "MEM_STREAMING";
     case MEM_PREALLOCATED_GLOB: return "MEM_PREALLOCATED_GLOB";
     case MEM_ARE: return "MEM_ARE";
+    case MEM_STREAMING_CONNECTION: return "MEM_STREAMING_CONNECTION";
   }
 
   return XclBinUtil::format("UNKNOWN (%d)", (unsigned int) _memType);


### PR DESCRIPTION
Bug Fixes

1) Updated xclbinutil error working regarding creating an output file.
2) Added support (via a CR and -deploy option) to support creating in both a development and deployment package in one session.
3) Fixed issue in the flow where the dsabin package directory (e.g., firmware) may not have been created.
4) Added more descriptive messages when creating both a deployment and development package.
5) Error out of the pkgdsa.sh script if xclbinutil tool fails.
6) For debian packages, added a revision value to the package name.  Note: This is already done for CentOS packages.