### PR TITLE
Fix logic bug in connectivity computation

### DIFF
--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -407,11 +407,11 @@ get_memidx(const device* device, unsigned int argidx) const
   for (auto cu : m_cus)
     kcu.set(cu->get_index());
 
+  // Compute the union of all connections for all CUs
   memidx_bitmask_type mset;
-  mset.set();
   for (auto& scu : device->get_cus())
     if (kcu.test(scu->get_index()) && scu->get_symbol_uid()==get_symbol_uid())
-      mset &= scu->get_memidx(argidx);
+      mset |= scu->get_memidx(argidx);
 
   return mset;
 }


### PR DESCRIPTION
When checking the possible connections for a kernel argument, the union of each CUs connectivity for that argument must be returned. Filtering to specific CU is done at the point where the intersection of a buffers possible connections across all specified {kernel,argidx} can be computed.

CR1021037