### PR TITLE
auto ddr bank deduce for p2p BO

### DIFF
--- a/src/runtime_src/xocl/api/clCreateBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateBuffer.cpp
@@ -61,24 +61,25 @@ get_xlnx_ext_argidx(cl_mem_flags flags, void* host_ptr)
 }
 
 // Hack to determine if a context is associated with exactly one
-// device.  Additionally, in emulation mode, the device must be
-// active, e.g. loaded through a call to loadBinary.
+// device and memory bank can be determined for memory allocation.
+// Additionally, in emulation mode, the device must be active, e.g.
+// loaded through a call to loadBinary.
 //
 // This works around a problem where clCreateBuffer is called in
 // emulation mode before clCreateProgramWithBinary->loadBinary has
 // been called.  The call to loadBinary can end up switching the
 // device from swEm to hwEm.
-//
-// In non emulation mode it is sufficient to check that the context
-// has only one device.
-XRT_UNUSED static xocl::device*
-singleContextDevice(cl_context context, cl_mem_flags flags)
+static xocl::device*
+singleContextDevice(cl_context context, cl_mem_flags flags, const void *host_ptr)
 {
   auto device = xocl::xocl(context)->get_single_active_device();
   if (!device)
     return nullptr;
 
-  if(flags & CL_MEM_EXT_PTR_XILINX) {
+  if (flags & CL_MEM_EXT_PTR_XILINX) {
+    auto xflags = get_xlnx_ext_flags(flags, host_ptr);
+    if (!(xflags & XCL_MEM_TOPOLOGY) || !(xflags & 0xffff))
+      return nullptr;
     // Explicit memory bank assignment should be treated as single device context.
     // MLx use case. Do nothing, proceed to returning the device.
   } else {
@@ -159,7 +160,7 @@ clCreateBuffer(cl_context   context,
     api::clSetKernelArg(kernel,argidx,sizeof(cl_mem),&mem);
   }
   else if (!(flags & CL_MEM_PROGVAR)) {
-    if (auto device = singleContextDevice(context,flags))
+    if (auto device = singleContextDevice(context,flags,host_ptr))
       buffer->get_buffer_object(device);
   }
 

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -227,14 +227,16 @@ get_ext_memidx_nolock(xclbin xclbin) const
     return m_memidx;
 
   if ((m_flags & CL_MEM_EXT_PTR_XILINX) && !m_ext_kernel) {
-    auto flag = m_ext_flags;
-    if (flag & XCL_MEM_TOPOLOGY)
-      m_memidx = flag & 0xffffff;
-    else {
-      auto bank = __builtin_ctz(flag & 0xffffff);
+    auto memid = m_ext_flags & 0xffff;
+    if (m_ext_flags & XCL_MEM_TOPOLOGY) {
+      m_memidx = memid;
+    } else if (memid != 0) {
+      auto bank = __builtin_ctz(memid);
       m_memidx = xclbin.banktag_to_memidx(std::string("bank")+std::to_string(bank));
       if (m_memidx==-1)
         m_memidx = bank;
+    } else {
+        m_memidx = -1;
     }
   }
   return m_memidx;


### PR DESCRIPTION
This code change is to add DDR bank auto deduce support for P2P BO. Bigstream is asking for this feature.