### PR TITLE
Opencl headers append

### DIFF
--- a/src/platform/recipes-xrt/opencl-headers/opencl-headers_git.bbappend
+++ b/src/platform/recipes-xrt/opencl-headers/opencl-headers_git.bbappend
@@ -1,0 +1,1 @@
+ALLOW_EMPTY_${PN} = "1"

--- a/src/runtime_src/doc/toc/yocto.rst
+++ b/src/runtime_src/doc/toc/yocto.rst
@@ -33,7 +33,7 @@ All of the XRT recipes are in ``<XRT>/src/platform/recipes-xrt`` directory. Wher
         $ petalinux-create -t project -n <name> --template zynqMP
 
         # Get HDF file, which is exported by Vivado
-        # It will show a menu to config this project, use below config to avoid password for login.
+        # A menu will show up for configuration, use below config to avoid password for login.
         #       menu -> "Yocto Setting" -> "Enable Debug Tweaks"
         $ petalinux-config -p <name> --get-hw-description=<HDF>
 

--- a/src/runtime_src/doc/toc/yocto.rst
+++ b/src/runtime_src/doc/toc/yocto.rst
@@ -33,6 +33,8 @@ All of the XRT recipes are in ``<XRT>/src/platform/recipes-xrt`` directory. Wher
         $ petalinux-create -t project -n <name> --template zynqMP
 
         # Get HDF file, which is exported by Vivado
+        # It will show a menu to config this project, use below config to avoid password for login.
+        #       menu -> "Yocto Setting" -> "Enable Debug Tweaks"
         $ petalinux-config -p <name> --get-hw-description=<HDF>
 
         # Go to the project specific directory of the project
@@ -53,6 +55,7 @@ Still stay in ``meta-user`` directory. Open ``recipes-core/images/petalinux-imag
         | IMAGE_INSTALL_append = " xrt-dev"
         | IMAGE_INSTALL_append = " xrt"
         | IMAGE_INSTALL_append = " zocl"
+        | IMAGE_INSTALL_append = " opencl-headers-dev"
 
 Add XRT kernel node in device tree
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The OpenCL header recipe does not support install to the rootfs. This is because it contains header files only. Create a .bbappend recipe to fix this issue.