### PR TITLE
Update memory bank index when importing buffer

### DIFF
--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -95,7 +95,7 @@ public:
   }
 
   memidx_type
-  get_ext_memidx(xclbin xclbin) const;
+  get_ext_memidx(const xclbin& xclbin) const;
 
   /**
    * Record that this buffer is used as argument to kernel at argidx
@@ -287,7 +287,7 @@ public:
    *   true or throws runtime error
    */
   virtual void
-  update_buffer_object_map(device* device, buffer_object_handle boh);
+  update_buffer_object_map(const device* device, buffer_object_handle boh);
 
 
   /**
@@ -443,7 +443,10 @@ private:
   get_memidx_nolock(const device* d) const;
 
   memidx_type
-  get_ext_memidx_nolock(xclbin xclbin) const;
+  get_ext_memidx_nolock(const xclbin& xclbin) const;
+
+  memidx_type
+  update_memidx_nolock(const device* device, const buffer_object_handle& boh);
 
 private:
   unsigned int m_uid = 0;


### PR DESCRIPTION
The cached memory index must reflect the bank on which the device buffer is allocated.  In non-import flow, the memory index is determined before the boh is allocated, but in import flow, the boh comes first.