### PR TITLE
Routing xma log to syslog (2018.3)

### DIFF
--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -25,4 +25,7 @@ rm -f /etc/udev/rules.d/10-xclmgmt.rules
 rm -f /etc/dracut.conf.d/xocl.dracut.conf
 rm -f /etc/dracut.conf.d/xclmgmt.dracut.conf
 
+echo "Cleaning up XMA..."
+rm -f /tmp/xma_shm_db
+
 exit 0

--- a/src/xma/include/lib/xmalimits.h
+++ b/src/xma/include/lib/xmalimits.h
@@ -21,7 +21,7 @@
 #define MAX_FILTER_OUTPUTS      MAX_SCALER_OUTPUTS
 #define MAX_DDR_MAP             16
 #define MAX_XILINX_DEVICES      16
-#define MAX_XILINX_KERNELS      16
+#define MAX_XILINX_KERNELS      60
 #define MAX_KERNEL_CONFIGS      60
 #define MAX_KERNEL_CHANS        64
 #define MAX_KERNEL_FREQS         2

--- a/src/xma/include/lib/xmalogger.h
+++ b/src/xma/include/lib/xmalogger.h
@@ -87,7 +87,7 @@ typedef struct XmaActor
 
 /* XmaActor APIs */
 XmaActor *xma_actor_create(XmaThreadFunc      func,
-                           size_t             msg_size, 
+                           size_t             msg_size,
                            size_t             max_msg_entries);
 void xma_actor_start(XmaActor *actor);
 void xma_actor_destroy(XmaActor *actor);
@@ -99,6 +99,7 @@ typedef struct XmaLogger
 {
     bool      use_stdout;
     bool      use_fileout;
+    bool      use_syslog;
     char      filename[PATH_MAX];
     int32_t   fd;
     int32_t   log_level;

--- a/src/xma/src/xmaapi/xmalogger.cpp
+++ b/src/xma/src/xmaapi/xmalogger.cpp
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <sched.h>
 #include <errno.h>
+#include <syslog.h>
 
 #include "lib/xmaapi.h"
 #include "app/xmalogger.h"
@@ -81,7 +82,7 @@ void xma_logger_callback(XmaLoggerCallback callback, XmaLogLevelType level)
 
     g_xma_loggercb_singleton->callback = callback;
     g_xma_loggercb_singleton->level = level;
-    
+
 }
 
 int xma_logger_init(XmaLogger *logger)
@@ -94,21 +95,33 @@ int xma_logger_init(XmaLogger *logger)
         printf("XMA Logger: defaulting to stdout, loglevel INFO\n");
         logger->use_stdout = true;
         logger->use_fileout = false;
+        logger->use_syslog = false;
         logger->log_level = XMA_INFO_LOG;
+    }
+    else if (strcmp(g_xma_singleton->systemcfg.logfile,"syslog") >= 0)
+    {
+        printf("XMA Logger: using syslog\n");
+        logger->use_stdout = false;
+        logger->use_fileout = false;
+        logger->use_syslog = true;
+        strcpy(logger->filename, g_xma_singleton->systemcfg.logfile);
+        logger->log_level = g_xma_singleton->systemcfg.loglevel;
+        openlog("xma: ", LOG_PID|LOG_CONS, LOG_USER);
     }
     else
     {
         printf("XMA Logger: using configuration file settings\n");
         logger->use_stdout = false;
         logger->use_fileout = true;
+        logger->use_syslog = false;
         strcpy(logger->filename, g_xma_singleton->systemcfg.logfile);
         logger->log_level = g_xma_singleton->systemcfg.loglevel;
-    } 
+    }
 
     /* Save FD of output file */
     if (logger->use_fileout)
     {
-        logger->fd = open((const char*)logger->filename, 
+        logger->fd = open((const char*)logger->filename,
                           O_APPEND | O_CREAT | O_WRONLY, 00666);
         if (logger->fd == -1)
         {
@@ -133,6 +146,9 @@ int xma_logger_close(XmaLogger *logger)
 {
     /* Verify parameters */
     assert(logger);
+    if(logger->use_syslog){
+        closelog();
+    }
     xma_actor_destroy(logger->actor);
 
     return 0;
@@ -174,7 +190,7 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
 
     if (!(send2callback || send2actor))
         return;
-    
+
     /* Get time */
     gettimeofday(&tv, NULL);
     millisec = lrint(tv.tv_usec/1000.0);
@@ -193,16 +209,21 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
         strncpy(log_name, name, sizeof(log_name));
 
     log_level = g_loglevel_tbl[level].lvl_str;
-    
+
     /* Format log message */
     //NOTE: Usage of program_invocation_short_name may hinder portability
-    sprintf(msg_buff, "%s.%03d %d %s %s %s ", log_time, millisec, getpid(), program_invocation_short_name, log_level, log_name);
+    if(logger->use_syslog){
+        sprintf(msg_buff, "%s %s %s ", program_invocation_short_name, log_level, log_name);
+    }
+    else{
+        sprintf(msg_buff, "%s.%03d %d %s %s %s ", log_time, millisec, getpid(), program_invocation_short_name, log_level, log_name);
+    }
     hdr_offset = strlen(msg_buff);
-    va_start(ap, msg); 
+    va_start(ap, msg);
     vsnprintf(&msg_buff[hdr_offset], (XMA_MAX_LOGMSG_SIZE - hdr_offset), msg, ap);
     va_end(ap);
 
-    /* Send message buffer to logger Actor - 
+    /* Send message buffer to logger Actor -
        will be copied to loggers message buffer */
     if (send2actor)
         xma_actor_sendmsg(logger->actor, msg_buff, sizeof(msg_buff));
@@ -262,7 +283,7 @@ void* xma_logger_actor(void *data)
             }
         }
     }
-    
+
     //std::cout << "ERROR: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
     //std::cout << "ERROR: ini_file1: " << ini_file1 << std::endl;
     //std::cout << "ERROR: ini_file2: " << ini_file2 << std::endl;
@@ -311,7 +332,7 @@ void* xma_logger_actor(void *data)
                 printf("XMA logger: received shutdown\n");
                 break;
             }
-            
+
             if (found_sdaccel_ini_file) {
                 /* Format log message
                 sprintf(msg_buff, "%s.%03d %d %s %s ", log_time, millisec, getpid(), log_level, log_name);
@@ -327,6 +348,16 @@ void* xma_logger_actor(void *data)
                         perror("XMA Logger: could not write to file: ");
                         break;
                     }
+                }
+                if (logger->use_syslog){
+                    uint8_t syslog_level = LOG_DEBUG;
+                    switch(logger->log_level){
+                        case XMA_CRITICAL_LOG: syslog_level = LOG_CRIT ; break;
+                        case XMA_ERROR_LOG   : syslog_level = LOG_ERR  ; break;
+                        case XMA_INFO_LOG    : syslog_level = LOG_INFO ; break;
+                        case XMA_DEBUG_LOG   : syslog_level = LOG_DEBUG; break;
+                    }
+                    syslog(syslog_level,"%s", logmsg);
                 }
                 if (logger->use_stdout)
                     printf("%s", logmsg);
@@ -351,7 +382,7 @@ XmaThread *xma_thread_create(XmaThreadFunc func, void *data)
     thread->data = data;
     thread->is_running = false;
 
-    return thread; 
+    return thread;
 }
 
 void xma_thread_destroy(XmaThread *thread)
@@ -367,10 +398,10 @@ void *xma_thread_entry_func(void *data)
 
     return 0;
 };
-    
+
 void xma_thread_start(XmaThread *thread)
 {
-    pthread_create(&thread->tid, NULL, xma_thread_entry_func, thread);  
+    pthread_create(&thread->tid, NULL, xma_thread_entry_func, thread);
 }
 
 bool xma_thread_is_running(XmaThread *thread)
@@ -392,7 +423,7 @@ XmaMsgQ *xma_msgq_create(size_t msg_size, size_t max_msg_entries)
     msgq->msg_array = (uint8_t*) malloc(msg_size * max_msg_entries);
     msgq->num_entries = 0;
     msgq->front = 0;
-    msgq->back = 0; 
+    msgq->back = 0;
 
     return msgq;
 }
@@ -410,7 +441,7 @@ bool xma_msgq_isfull(XmaMsgQ *msgq)
 
 bool xma_msgq_isempty(XmaMsgQ *msgq)
 {
-    return (msgq->num_entries == 0); 
+    return (msgq->num_entries == 0);
 }
 
 int32_t xma_msgq_enqueue(XmaMsgQ *msgq, void *msg, size_t size)
@@ -426,16 +457,16 @@ int32_t xma_msgq_enqueue(XmaMsgQ *msgq, void *msg, size_t size)
         XMA_DBG_PRINTF("%s", "XMA msgq enqueue: too Large\n");
         return XMA_MSGQ_MSG_TOO_LARGE;
     }
-    
+
     uint8_t *msgdst = msgq->msg_array + (msgq->msg_size * msgq->back);
     memcpy(msgdst, msg, size);
-    
+
     msgq->back = (msgq->back + 1) % (msgq->max_msg_entries);
     msgq->num_entries++;
 
     return 0;
 }
-    
+
 int32_t xma_msgq_dequeue(XmaMsgQ *msgq, void *msg, size_t size)
 {
     if (xma_msgq_isempty(msgq))
@@ -450,8 +481,8 @@ int32_t xma_msgq_dequeue(XmaMsgQ *msgq, void *msg, size_t size)
         return XMA_MSGQ_MSG_TOO_SMALL;
     }
 
-    uint8_t *msgsrc = msgq->msg_array + (msgq->msg_size * msgq->front); 
-    memcpy(msg, msgsrc, msgq->msg_size); 
+    uint8_t *msgsrc = msgq->msg_array + (msgq->msg_size * msgq->front);
+    memcpy(msg, msgsrc, msgq->msg_size);
 
     msgq->front = (msgq->front + 1) % (msgq->max_msg_entries);
     msgq->num_entries--;
@@ -470,7 +501,7 @@ XmaActor *xma_actor_create(XmaThreadFunc    func,
     pthread_cond_init(&actor->dequeued_cond, NULL);
     actor->msg_q = xma_msgq_create(msg_size, max_msg_entries);
     actor->thread = xma_thread_create(func, actor);
-    
+
     return actor;
 }
 
@@ -499,7 +530,7 @@ int32_t xma_actor_sendmsg(XmaActor *actor, void *msg, size_t msg_size)
     bool    was_empty;
 
     pthread_mutex_lock(&actor->lock);
-    XMA_DBG_PRINTF("XMA actor sendmsg on entry depth=%d, front=%d, back=%d\n", 
+    XMA_DBG_PRINTF("XMA actor sendmsg on entry depth=%d, front=%d, back=%d\n",
             actor->msg_q->num_entries,
             actor->msg_q->front,
             actor->msg_q->back);
@@ -517,15 +548,15 @@ int32_t xma_actor_sendmsg(XmaActor *actor, void *msg, size_t msg_size)
         pthread_cond_broadcast(&actor->queued_cond);
     }
 
-    XMA_DBG_PRINTF("XMA actor sendmsg on exit depth=%d, front=%d, back=%d\n", 
+    XMA_DBG_PRINTF("XMA actor sendmsg on exit depth=%d, front=%d, back=%d\n",
             actor->msg_q->num_entries,
             actor->msg_q->front,
             actor->msg_q->back);
 
     pthread_mutex_unlock(&actor->lock);
 
-    return rc; 
-        
+    return rc;
+
 }
 
 int32_t xma_actor_recvmsg(XmaActor *actor, void *msg, size_t msg_size)
@@ -535,7 +566,7 @@ int32_t xma_actor_recvmsg(XmaActor *actor, void *msg, size_t msg_size)
 
     pthread_mutex_lock(&actor->lock);
 
-    XMA_DBG_PRINTF("XMA actor recvmsg on entry depth=%d, front=%d, back=%d\n", 
+    XMA_DBG_PRINTF("XMA actor recvmsg on entry depth=%d, front=%d, back=%d\n",
             actor->msg_q->num_entries,
             actor->msg_q->front,
             actor->msg_q->back);
@@ -552,7 +583,7 @@ int32_t xma_actor_recvmsg(XmaActor *actor, void *msg, size_t msg_size)
         pthread_cond_broadcast(&actor->dequeued_cond);
     }
 
-    XMA_DBG_PRINTF("XMA actor recvmsg on exit depth=%d, front=%d, back=%d\n", 
+    XMA_DBG_PRINTF("XMA actor recvmsg on exit depth=%d, front=%d, back=%d\n",
             actor->msg_q->num_entries,
             actor->msg_q->front,
             actor->msg_q->back);

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -666,8 +666,14 @@ static void xma_shm_close(XmaResConfig *xma_shm, bool rm_shm)
     xma_logmsg(XMA_DEBUG_LOG, XMA_RES_MOD, "%s()\n", __func__);
     munmap((void*)xma_shm, sizeof(XmaResConfig));
 
+    /* JPM eliminate need to remove shared memory as there is
+     * a possible race condition as we cannot ensure this
+     * operation is protected from concurrent access by another
+     * process wishing to open the existing XMA_SHM_FILE
+     * prior to this unlink operation completing.
     if (rm_shm)
         unlink(XMA_SHM_FILE);
+    */
 }
 
 static int xma_verify_process_res(pid_t pid)

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -495,6 +495,7 @@ static XmaResConfig *xma_shm_open(char *shm_filename, XmaSystemCfg *config)
     pthread_mutexattr_init(&proc_shared_lock);
     pthread_mutexattr_setpshared(&proc_shared_lock, PTHREAD_PROCESS_SHARED);
     pthread_mutexattr_setrobust(&proc_shared_lock, PTHREAD_MUTEX_ROBUST);
+    pthread_mutexattr_setprotocol(&proc_shared_lock, PTHREAD_PRIO_INHERIT);
     shm_map = (XmaResConfig *)mmap(NULL, sizeof(XmaResConfig),
                PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     pthread_mutex_init(&shm_map->lock, &proc_shared_lock);


### PR DESCRIPTION
This was needed by client. This will be later deprecated once XRT provides log level control for xclLogMsg()