### PR TITLE
Routing xma log to syslog (master)

### DIFF
--- a/src/xma/include/lib/xmalimits.h
+++ b/src/xma/include/lib/xmalimits.h
@@ -21,7 +21,7 @@
 #define MAX_FILTER_OUTPUTS      MAX_SCALER_OUTPUTS
 #define MAX_DDR_MAP             16
 #define MAX_XILINX_DEVICES      16
-#define MAX_XILINX_KERNELS      16
+#define MAX_XILINX_KERNELS      60
 #define MAX_KERNEL_CONFIGS      60
 #define MAX_KERNEL_CHANS        64
 #define MAX_KERNEL_FREQS         2

--- a/src/xma/include/lib/xmalogger.h
+++ b/src/xma/include/lib/xmalogger.h
@@ -99,6 +99,7 @@ typedef struct XmaLogger
 {
     bool      use_stdout;
     bool      use_fileout;
+    bool      use_syslog;
     char      filename[PATH_MAX];
     int32_t   fd;
     int32_t   log_level;

--- a/src/xma/src/xmaapi/xmalogger.cpp
+++ b/src/xma/src/xmaapi/xmalogger.cpp
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <sched.h>
 #include <errno.h>
+#include <syslog.h>
 #include <cstdlib>
 #include <string>
 #include <fstream>
@@ -92,13 +93,25 @@ int xma_logger_init(XmaLogger *logger)
         printf("XMA Logger: defaulting to stdout, loglevel INFO\n");
         logger->use_stdout = true;
         logger->use_fileout = false;
+        logger->use_syslog = false;
         logger->log_level = XMA_INFO_LOG;
+    }
+    else if (strcmp(g_xma_singleton->systemcfg.logfile,"syslog") >= 0)
+    {
+        printf("XMA Logger: using syslog\n");
+        logger->use_stdout = false;
+        logger->use_fileout = false;
+        logger->use_syslog = true;
+        strcpy(logger->filename, g_xma_singleton->systemcfg.logfile);
+        logger->log_level = g_xma_singleton->systemcfg.loglevel;
+        openlog("xma: ", LOG_PID|LOG_CONS, LOG_USER);
     }
     else
     {
         printf("XMA Logger: using configuration file settings\n");
         logger->use_stdout = false;
         logger->use_fileout = true;
+        logger->use_syslog = false;
         strcpy(logger->filename, g_xma_singleton->systemcfg.logfile);
         logger->log_level = g_xma_singleton->systemcfg.loglevel;
     } 
@@ -131,6 +144,9 @@ int xma_logger_close(XmaLogger *logger)
 {
     /* Verify parameters */
     assert(logger);
+    if(logger->use_syslog){
+        closelog();
+    }
     xma_actor_destroy(logger->actor);
 
     return 0;
@@ -194,7 +210,12 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
     
     /* Format log message */
     //NOTE: Usage of program_invocation_short_name may hinder portability
-    sprintf(msg_buff, "%s.%03d %d %s %s %s ", log_time, millisec, getpid(), program_invocation_short_name, log_level, log_name);
+    if(logger->use_syslog){
+        sprintf(msg_buff, "%s %s %s ", program_invocation_short_name, log_level, log_name);
+    }
+    else{
+        sprintf(msg_buff, "%s.%03d %d %s %s %s ", log_time, millisec, getpid(), program_invocation_short_name, log_level, log_name);
+    }
     hdr_offset = strlen(msg_buff);
     va_start(ap, msg); 
     vsnprintf(&msg_buff[hdr_offset], (XMA_MAX_LOGMSG_SIZE - hdr_offset), msg, ap);
@@ -325,6 +346,16 @@ void* xma_logger_actor(void *data)
                         perror("XMA Logger: could not write to file: ");
                         break;
                     }
+                }
+                if (logger->use_syslog){
+                    uint8_t syslog_level = LOG_DEBUG;
+                    switch(logger->log_level){
+                        case XMA_CRITICAL_LOG: syslog_level = LOG_CRIT ; break;
+                        case XMA_ERROR_LOG   : syslog_level = LOG_ERR  ; break;
+                        case XMA_INFO_LOG    : syslog_level = LOG_INFO ; break;
+                        case XMA_DEBUG_LOG   : syslog_level = LOG_DEBUG; break;
+                    }
+                    syslog(syslog_level,"%s", logmsg);
                 }
                 if (logger->use_stdout)
                     printf("%s", logmsg);

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -666,8 +666,14 @@ static void xma_shm_close(XmaResConfig *xma_shm, bool rm_shm)
     xma_logmsg(XMA_DEBUG_LOG, XMA_RES_MOD, "%s()\n", __func__);
     munmap((void*)xma_shm, sizeof(XmaResConfig));
 
+    /* JPM eliminate need to remove shared memory as there is
+     * a possible race condition as we cannot ensure this
+     * operation is protected from concurrent access by another
+     * process wishing to open the existing XMA_SHM_FILE
+     * prior to this unlink operation completing.
     if (rm_shm)
         unlink(XMA_SHM_FILE);
+    */
 }
 
 static int xma_verify_process_res(pid_t pid)

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -495,6 +495,7 @@ static XmaResConfig *xma_shm_open(char *shm_filename, XmaSystemCfg *config)
     pthread_mutexattr_init(&proc_shared_lock);
     pthread_mutexattr_setpshared(&proc_shared_lock, PTHREAD_PROCESS_SHARED);
     pthread_mutexattr_setrobust(&proc_shared_lock, PTHREAD_MUTEX_ROBUST);
+    pthread_mutexattr_setprotocol(&proc_shared_lock, PTHREAD_PRIO_INHERIT);
     shm_map = (XmaResConfig *)mmap(NULL, sizeof(XmaResConfig),
                PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     pthread_mutex_init(&shm_map->lock, &proc_shared_lock);


### PR DESCRIPTION
This was needed by client. This will be later deprecated once XRT provides log level control for xclLogMsg()