### PR TITLE
support P2P mem bank auto deduce thru cl_mem_ext_ptr

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -80,17 +80,17 @@ extern "C" {
 typedef struct cl_mem_ext_ptr_t {
   union {
     struct { // legacy layout
-      unsigned int flags;   // Top 8 bits reserved.
+      unsigned int flags;   // Top 8 bits reserved for XCL_MEM_EXT flags
       void *obj;
       void *param;
     };
     struct { // interpreted legcy bank assignment
-      unsigned int banks;   // Top 8 bits reserved.
+      unsigned int banks;   // Top 8 bits reserved for XCL_MEM_EXT flags
       void *host_ptr;
       void *unused1;        // nullptr required
     };
     struct { // interpreted kernel arg assignment
-      unsigned int argidx;
+      unsigned int argidx;  // Top 8 bits reserved for XCL_MEM_EXT flags
       void *host_ptr_;      // use as host_ptr
       cl_kernel kernel;
     };

--- a/src/runtime_src/xocl/api/clCreateBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateBuffer.cpp
@@ -30,36 +30,6 @@
 
 namespace {
 
-inline void*
-get_host_ptr(cl_mem_flags flags, void* host_ptr)
-{
-  return (flags & CL_MEM_EXT_PTR_XILINX)
-    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->host_ptr
-    : host_ptr;
-}
-
-inline unsigned int
-get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
-{
-  return (flags & CL_MEM_EXT_PTR_XILINX)
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->flags
-    : 0;
-}
-
-inline cl_kernel
-get_xlnx_ext_kernel(cl_mem_flags flags, void* host_ptr)
-{
-  return (flags & CL_MEM_EXT_PTR_XILINX)
-    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->kernel
-    : 0;
-}
-
-inline unsigned int
-get_xlnx_ext_argidx(cl_mem_flags flags, void* host_ptr)
-{
-  return get_xlnx_ext_flags(flags,host_ptr) & 0xffffff;
-}
-
 // Hack to determine if a context is associated with exactly one
 // device and memory bank can be determined for memory allocation.
 // Additionally, in emulation mode, the device must be active, e.g.
@@ -77,7 +47,7 @@ singleContextDevice(cl_context context, cl_mem_flags flags, const void *host_ptr
     return nullptr;
 
   if (flags & CL_MEM_EXT_PTR_XILINX) {
-    auto xflags = get_xlnx_ext_flags(flags, host_ptr);
+    auto xflags = xocl::get_xlnx_ext_flags(flags, host_ptr);
     if (!(xflags & XCL_MEM_TOPOLOGY) && !(xflags & 0xffffff))
       return nullptr;
     // Explicit memory bank assignment should be treated as single device context.

--- a/src/runtime_src/xocl/api/clCreateBuffer.cpp
+++ b/src/runtime_src/xocl/api/clCreateBuffer.cpp
@@ -57,7 +57,7 @@ get_xlnx_ext_kernel(cl_mem_flags flags, void* host_ptr)
 inline unsigned int
 get_xlnx_ext_argidx(cl_mem_flags flags, void* host_ptr)
 {
-  return get_xlnx_ext_flags(flags,host_ptr);
+  return get_xlnx_ext_flags(flags,host_ptr) & 0xffffff;
 }
 
 // Hack to determine if a context is associated with exactly one
@@ -78,7 +78,7 @@ singleContextDevice(cl_context context, cl_mem_flags flags, const void *host_ptr
 
   if (flags & CL_MEM_EXT_PTR_XILINX) {
     auto xflags = get_xlnx_ext_flags(flags, host_ptr);
-    if (!(xflags & XCL_MEM_TOPOLOGY) || !(xflags & 0xffff))
+    if (!(xflags & XCL_MEM_TOPOLOGY) && !(xflags & 0xffffff))
       return nullptr;
     // Explicit memory bank assignment should be treated as single device context.
     // MLx use case. Do nothing, proceed to returning the device.

--- a/src/runtime_src/xocl/api/detail/memory.cpp
+++ b/src/runtime_src/xocl/api/detail/memory.cpp
@@ -23,39 +23,6 @@
 #include <string>
 #include <map>
 
-namespace {
-inline const void*
-get_host_ptr(cl_mem_flags flags, const void* host_ptr)
-{
-  return (host_ptr && (flags & CL_MEM_EXT_PTR_XILINX))
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->host_ptr
-    : host_ptr;
-}
-
-inline unsigned int
-get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
-{
-  return (host_ptr && (flags & CL_MEM_EXT_PTR_XILINX))
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->flags
-    : 0;
-}
-
-inline cl_kernel
-get_xlnx_ext_kernel(cl_mem_flags flags, const void* host_ptr)
-{
-  return (host_ptr && (flags & CL_MEM_EXT_PTR_XILINX))
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->kernel
-    : 0;
-}
-
-inline unsigned int
-get_ocl_flags(cl_mem_flags flags)
-{
-  return ( flags & ~(CL_MEM_EXT_PTR_XILINX | CL_MEM_PROGVAR) );
-}
-
-} // namespace
-
 namespace xocl { namespace detail {
 
 namespace memory {

--- a/src/runtime_src/xocl/api/xlnx/xclGetMemObjectFromFd.cpp
+++ b/src/runtime_src/xocl/api/xlnx/xclGetMemObjectFromFd.cpp
@@ -24,16 +24,6 @@
 #include "xocl/api/detail/device.h"
 #include "xocl/api/detail/context.h"
 
-
-inline unsigned int
-get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
-{
-  return (flags & CL_MEM_EXT_PTR_XILINX)
-    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->flags
-    : 0;
-}
-
-
 namespace xocl {
 
 void

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -778,6 +778,50 @@ private:
   void* m_host_ptr = nullptr;
 };
 
+inline const void*
+get_host_ptr(cl_mem_flags flags, const void* host_ptr)
+{
+  return (flags & CL_MEM_EXT_PTR_XILINX)
+    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->host_ptr
+    : host_ptr;
+}
+
+inline void*
+get_host_ptr(cl_mem_flags flags, void* host_ptr)
+{
+  return (flags & CL_MEM_EXT_PTR_XILINX)
+    ? reinterpret_cast<cl_mem_ext_ptr_t*>(host_ptr)->host_ptr
+    : host_ptr;
+}
+
+inline unsigned int
+get_xlnx_ext_flags(cl_mem_flags flags, const void* host_ptr)
+{
+  return (flags & CL_MEM_EXT_PTR_XILINX)
+    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->flags
+    : 0;
+}
+
+inline cl_kernel
+get_xlnx_ext_kernel(cl_mem_flags flags, const void* host_ptr)
+{
+  return (flags & CL_MEM_EXT_PTR_XILINX)
+    ? reinterpret_cast<const cl_mem_ext_ptr_t*>(host_ptr)->kernel
+    : 0;
+}
+
+inline unsigned int
+get_xlnx_ext_argidx(cl_mem_flags flags, const void* host_ptr)
+{
+  return get_xlnx_ext_flags(flags,host_ptr) & 0xffffff;
+}
+
+inline unsigned int
+get_ocl_flags(cl_mem_flags flags)
+{
+  return ( flags & ~(CL_MEM_EXT_PTR_XILINX | CL_MEM_PROGVAR) );
+}
+
 } // xocl
 
 #endif


### PR DESCRIPTION
this also fixes a bug causing legacy XCL_MEM_DDR_BANKx flag not to work.