### PR TITLE
Add zocl open close context nop interfaces.

### DIFF
--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -669,6 +669,16 @@ int xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
 //
 // TODO: pending implementations
 //
+int xclOpenContext(xclDeviceHandle handle, uuid_t xclbinId, unsigned int ipIndex, bool shared)
+{
+  return 0;
+}
+
+int xclCloseContext(xclDeviceHandle handle, uuid_t xclbinId, unsigned ipIndex)
+{
+  return 0;
+}
+
 size_t xclGetDeviceTimestamp(xclDeviceHandle handle)
 {
   return 0;


### PR DESCRIPTION
Add xclOpenContext() and xclCloseContext() interfaces on embedded platform so that applications on x86 can compile/run on embedded. These functions are no operation for now.