### PR TITLE
Pulling xdp IP register reading from hal layer to xdp layer

### DIFF
--- a/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
@@ -47,11 +47,24 @@ ProfileIP::~ProfileIP() {
 } 
 
 void ProfileIP::request_exclusive_ip_access(xclDeviceHandle handle, int index) {
+    /**
+     * TODO: when the XRT implements the exclusive context hal API, this
+     * method should try to open a exclusive context here and set the
+     * exclusive flag to be true if successful and save the context object
+     * into a member variable. If it fails, it should show a proper warning
+     * and return gracefully.
+     */
     exclusive = true;
     return;
 }
 
 void ProfileIP::release_exclusive_ip_access(xclDeviceHandle handle, int index) {
+    /**
+     * TODO: when the XRT implements the exclusive context hal API, this
+     * method should close the previously requested exclusive context if
+     * one was request and then set the exclusive flag back to false. If
+     * it fails, it should show a proper warning and return gracefully.
+     */
     exclusive = false;
     return;
 }

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
@@ -70,6 +70,11 @@ void ProfileIP::release_exclusive_ip_access(xclDeviceHandle handle, int index) {
 }
 
 void ProfileIP::map() {
+    /**
+     * TODO: so far we are asking the debug_ip_layout where the IP is. Once the XRT hal implements
+     * the function that maps the IP registers to user memory space, this method should be simplified
+     * to one function call to the hal API and saves the result in a mapped_address and set mapped flag.
+     */
     if (!exclusive) {
         return;
     }
@@ -111,6 +116,10 @@ void ProfileIP::map() {
 }
 
 void ProfileIP::unmap() {
+    /**
+     * TODO: This should use the unmapping API provided by XRT hal in
+     * the future. Now the API is not in place
+     */
     if (!exclusive || !mapped) {
         return;
     }
@@ -120,6 +129,11 @@ void ProfileIP::unmap() {
 }
 
 int ProfileIP::read(uint64_t offset, size_t size, void* data) {
+    /**
+     * TODO: so far we are using xclRead under the hood because the hal API that maps
+     * the IP is not ready yet. Once the API is ready, xclRead should be replaced by a
+     * memcpy from the mapped address with exception handling.
+     */
     if (!exclusive || !mapped) {
         return -1;
     }
@@ -133,6 +147,11 @@ int ProfileIP::read(uint64_t offset, size_t size, void* data) {
 }
 
 int ProfileIP::write(uint64_t offset, size_t size, void* data) {
+    /**
+     * TODO: so far we are using xclWrite under the hood because the hal API that maps
+     * the IP is not ready yet. Once the API is ready, xclWrite should be replaced by a
+     * memcpy to the mapped address with exception handling.
+     */
     if (!exclusive || !mapped) {
         return -1;
     }

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2019-2020, Xilinx Inc - All rights reserved
+ * Xilinx Debug & Profile (XDP) APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "profile_ip_access.h"
+
+namespace xdp {
+
+ProfileIP::ProfileIP(xclDeviceHandle handle, int index) {
+    // initialize member variables
+    exclusive = false;
+    mapped = false;
+    mapped_address = 0;
+    device_handle = nullptr;
+    ip_index = -1;
+
+    // check for exclusive access to this IP
+    request_exclusive_ip_access(handle, index);
+    if (exclusive) {
+        device_handle = handle;
+        ip_index = index;
+    } else {
+        show_warning();
+    }
+}
+
+ProfileIP::~ProfileIP() {
+    if (mapped) {
+        unmap();
+    }
+    if (exclusive) {
+        release_exclusive_ip_access(device_handle, ip_index);
+    }
+} 
+
+void ProfileIP::request_exclusive_ip_access(xclDeviceHandle handle, int index) {
+    exclusive = true;
+    return;
+}
+
+void ProfileIP::release_exclusive_ip_access(xclDeviceHandle handle, int index) {
+    exclusive = false;
+    return;
+}
+
+void ProfileIP::map() {
+    if (!exclusive) {
+        return;
+    }
+    std::string subdev = "icap";
+    std::string entry = "debug_ip_layout";
+    size_t max_path_size = 256;
+    char raw_sysfs_path[max_path_size];
+    int sysfs_ret = xclGetSysfsPath(device_handle, subdev.c_str(), entry.c_str(), raw_sysfs_path, max_path_size);
+    if (sysfs_ret < 0) {
+        show_warning();
+        return;
+    }
+    std::string sysfs_open_path(raw_sysfs_path);
+    return;
+}
+
+void ProfileIP::unmap() {
+    return;
+}
+
+int read(size_t offset, size_t size, void* data) {
+    return 0;
+}
+
+int write(size_t offset, size_t size, void* data) {
+    return 0;
+}
+
+} //  xdp

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
@@ -176,3 +176,4 @@ void ProfileIP::show_warning(std::string reason) {
 }
 
 } //  xdp
+

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.cpp
@@ -96,8 +96,8 @@ void ProfileIP::map() {
             }
             debug_ip_data ip_data = layout->m_debug_ip_data[ip_index];
             ip_name = std::string((char*)(&ip_data.m_name));
-            std::cout << "Mapping " << ip_name << std::endl;
             mapped_address = ip_data.m_base_address;
+            std::cout << "Mapping " << ip_name << " to address 0x" << std::hex << mapped_address << std::dec << std::endl;
             mapped = true;
             return;
         } else {

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.h
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2019-2020, Xilinx Inc - All rights reserved
+ * Xilinx Debug & Profile (XDP) APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef XDP_PROFILE_DEVICE_PROFILE_IP_ACCESS_H_
+#define XDP_PROFILE_DEVICE_PROFILE_IP_ACCESS_H_
+
+#include <stdexcept>
+#include "xclhal.h"
+
+namespace xdp {
+
+/**
+ * ProfileIP (IP with safe access)
+ * 
+ * Description:
+ * 
+ * This class represents the high level exclusive and OS protected 
+ * access to a profiling IP on the device.
+ * 
+ * Note:
+ * 
+ * This class only aims at providing interface for easy and
+ * safe access to a single profiling IP. Managing the 
+ * association between IPs and devices should be done in a 
+ * different data structure that is built on top of this class.
+ */
+class ProfileIP {
+public:
+
+    /**
+     * The constructor takes a device handle and a ip index
+     * means that the instance of this class has a one-to-one
+     * association with one specific IP on one specific device.
+     * During the construction, the exclusive access to this
+     * IP will be requested, otherwise exception will be thrown.
+     */
+    ProfileIP(xclDeviceHandle handle /** < [in] the xrt hal device handle */, 
+                int index /** < [in] the index of the IP in debug_ip_layout */);
+
+    /**
+     * The exclusive access should be release in the destructor
+     * to prevent potential card hang.
+     */
+    ~ProfileIP();
+
+    /**
+     * The request_exclusive_ip_access API tries to claim exclusive
+     * access to a certain IP on a certain device through hal
+     * (driver) and set the exclusive flag if exclusive access is 
+     * granted.
+     */
+    void request_exclusive_ip_access(xclDeviceHandle handle, int index);
+
+    /**
+     * The release_exclusive_ip_access API will release the exclusive
+     * access granted to this IP to prevent potential card hang, and clear
+     * the exclusive flag if success.
+     */
+    void release_exclusive_ip_access(xclDeviceHandle handle, int index);
+
+    /**
+     * The map API tries to map the IP specified into user space. The 
+     * mapped_address and mapped will be set if success. Exception will
+     * be thrown if it fails to map.
+     */
+    void map();
+
+    /**
+     * The unmap API tries to clean up the association between user space
+     * address and the IP registers. The mapped_address and mapped will
+     * be cleared if success. Exception will be thrown if it fails to 
+     * unmap.
+     */
+    void unmap();
+
+    /**
+     * The read method act the same way as xclRead with the 
+     * following differences:
+     *  1. It does not take a base address as the base address
+     *     will be determined from the ip_index at construction
+     *  2. The address space is OS protected, so if the size
+     *     goes out of the allow address space, a excpetion will
+     *     be thrown.
+     *  3. It provides exclusive access, so if it instantiates
+     *     without error, exclusive access to the ip specified 
+     *     is guaranteed.
+     */
+    int read(size_t offset, size_t size, void* data);
+
+    /**
+     * The write method act the same way as xclWrite with the 
+     * following differences:
+     *  1. It does not take a base address as the base address
+     *     will be determined from the ip_index at construction
+     *  2. The address space is OS protected, so if the size
+     *     goes out of the allow address space, a excpetion will
+     *     be thrown.
+     *  3. It provides exclusive access, so if it instantiates
+     *     without error, exclusive access to the ip specified 
+     *     is guaranteed.
+     */
+    int write(size_t offset, size_t size, void* data);
+
+    /**
+     * Since this API as part of the profiling code should not
+     * crash the rest of the code, it will need to simply warn
+     * the user about the failure and move on.
+     */
+    void show_warning();
+
+private:
+    xclDeviceHandle device_handle; /** < the xrt device handle from the hal layer */
+    uint64_t mapped_address; /** < the mapped address in user space used 
+                                        to access the registers */
+    bool mapped; /** < a flag to keep track of if the ip has been mapped */
+    bool exclusive; /** < a flag indicating if the IP has exclusive access */
+    int ip_index; /** the index of the IP in debug_ip_layout */
+
+    // TODO: the exclusive context from hal
+};
+
+} //  xdp
+
+#endif

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.h
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.h
@@ -19,7 +19,10 @@
 #define XDP_PROFILE_DEVICE_PROFILE_IP_ACCESS_H_
 
 #include <stdexcept>
-#include "xclhal.h"
+#include <fstream>
+#include <iostream>
+#include "xclhal2.h"
+#include "xclbin.h"
 
 namespace xdp {
 
@@ -99,7 +102,7 @@ public:
      *     without error, exclusive access to the ip specified 
      *     is guaranteed.
      */
-    int read(size_t offset, size_t size, void* data);
+    int read(uint64_t offset, size_t size, void* data);
 
     /**
      * The write method act the same way as xclWrite with the 
@@ -113,14 +116,14 @@ public:
      *     without error, exclusive access to the ip specified 
      *     is guaranteed.
      */
-    int write(size_t offset, size_t size, void* data);
+    int write(uint64_t offset, size_t size, void* data);
 
     /**
      * Since this API as part of the profiling code should not
      * crash the rest of the code, it will need to simply warn
      * the user about the failure and move on.
      */
-    void show_warning();
+    void show_warning(std::string reason);
 
 private:
     xclDeviceHandle device_handle; /** < the xrt device handle from the hal layer */
@@ -128,9 +131,12 @@ private:
                                         to access the registers */
     bool mapped; /** < a flag to keep track of if the ip has been mapped */
     bool exclusive; /** < a flag indicating if the IP has exclusive access */
-    int ip_index; /** the index of the IP in debug_ip_layout */
+    int ip_index; /** < the index of the IP in debug_ip_layout */
+    std::string ip_name; /** < the string name of the IP for better debuggability */ 
 
-    // TODO: the exclusive context from hal
+    /**
+     * TODO: the exclusive context from hal
+     */
 };
 
 } //  xdp

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.h
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.h
@@ -142,3 +142,4 @@ private:
 } //  xdp
 
 #endif
+


### PR DESCRIPTION
So far we have been reading xdp IPs within the hal and get the values through hal APIs. This makes it hard to manage the xdp implementation and hal api header file. This PR is the most basic structures to support register reading at xdp level.

> note: The code is not used anywhere now. The purpose of this PR is to provide the basic component for xdp refactoring for @pgschuey @hackwa 