### PR TITLE
fix/wrong-appdebug-debug-ip-layout-location

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1257,8 +1257,6 @@ clGetDebugCounters() {
 
   auto adv = new app_debug_view <spm_debug_view> (spm_view, [spm_view](){delete spm_view;}, false, "");
 
-  std::cout << "DEBUGGING: spm clGetDebugCounters ends, sysfs path: " << sysfs_open_path << std::endl;
-
   return adv;
 }
 

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1257,6 +1257,8 @@ clGetDebugCounters() {
 
   auto adv = new app_debug_view <spm_debug_view> (spm_view, [spm_view](){delete spm_view;}, false, "");
 
+  std::cout << "DEBUGGING: spm clGetDebugCounters ends, sysfs path: " << sysfs_open_path << std::endl;
+
   return adv;
 }
 

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1028,7 +1028,6 @@ uint32_t getIPCountAddrNames(std::string& devUserName, int type, std::vector<uin
   // Get the path to the device from the HAL
   // std::string path = "/sys/bus/pci/devices/" + devUserName + "/debug_ip_layout";
   std::string path = devUserName;
-  std::cout << "using: " << path << std::endl;
   std::ifstream ifs(path.c_str(), std::ifstream::binary);
   uint32_t count = 0;
   char buffer[debug_ip_layout_max_size];

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1201,7 +1201,7 @@ isEmulationMode()
 
 app_debug_view<spm_debug_view>*
 clGetDebugCounters() {
-  std::cout << "DEBUGGING: clGetDebugCounters starts" << std::endl;
+  std::cout << "DEBUGGING: spm clGetDebugCounters starts" << std::endl;
   cl_int ret = CL_SUCCESS;
   xclDebugCountersResults debugResults = {0};
 
@@ -1262,11 +1262,11 @@ clGetDebugCounters() {
   spm_view->DevUserName = debugResults.DevUserName;
   spm_view->SysfsPath = sysfs_open_path;
 
-  std::cout << "DEBUGGING: constructing new spm debug view adv" << std::endl;
+  std::cout << "DEBUGGING: constructing new spm debug view adv, sysfs path: " << sysfs_open_path << std::endl;
 
   auto adv = new app_debug_view <spm_debug_view> (spm_view, [spm_view](){delete spm_view;}, false, "");
 
-  std::cout << "DEBUGGING: clGetDebugCounters ends" << std::endl;
+  std::cout << "DEBUGGING: spm clGetDebugCounters ends" << std::endl;
 
   return adv;
 }

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1201,7 +1201,6 @@ isEmulationMode()
 
 app_debug_view<spm_debug_view>*
 clGetDebugCounters() {
-  std::cout << "DEBUGGING: spm clGetDebugCounters starts" << std::endl;
   cl_int ret = CL_SUCCESS;
   xclDebugCountersResults debugResults = {0};
 
@@ -1220,8 +1219,6 @@ clGetDebugCounters() {
     return adv;
   }
 
-  std::cout << "DEBUGGING: getting ocl platform id" << std::endl;
-
   auto platform = rts->getcl_platform_id();
   // Iterates over all devices, but assumes only one device
   memset(&debugResults,0, sizeof(xclDebugCountersResults));
@@ -1239,14 +1236,10 @@ clGetDebugCounters() {
   }
   std::string sysfs_open_path(raw_sysfs_path);
 
-  std::cout << "DEBUGGING: sysfs path retrieved" << std::endl;
-
   if (ret) {
     auto adv = new app_debug_view<spm_debug_view>(nullptr, nullptr, true, "Error reading spm counters");
     return adv;
   }
-
-  std::cout << "DEBUGGING: constructing spm debug view" << std::endl;
 
   auto spm_view = new spm_debug_view ();
   std::copy(debugResults.WriteBytes, debugResults.WriteBytes+XSPM_MAX_NUMBER_SLOTS, spm_view->WriteBytes);
@@ -1262,11 +1255,9 @@ clGetDebugCounters() {
   spm_view->DevUserName = debugResults.DevUserName;
   spm_view->SysfsPath = sysfs_open_path;
 
-  std::cout << "DEBUGGING: constructing new spm debug view adv, sysfs path: " << sysfs_open_path << std::endl;
-
   auto adv = new app_debug_view <spm_debug_view> (spm_view, [spm_view](){delete spm_view;}, false, "");
 
-  std::cout << "DEBUGGING: spm clGetDebugCounters ends" << std::endl;
+  std::cout << "DEBUGGING: spm clGetDebugCounters ends, sysfs path: " << sysfs_open_path << std::endl;
 
   return adv;
 }

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1221,19 +1221,18 @@ clGetDebugCounters() {
   auto platform = rts->getcl_platform_id();
   // Iterates over all devices, but assumes only one device
   memset(&debugResults,0, sizeof(xclDebugCountersResults));
-  char raw_sysfs_path[256];
   std::string subdev = "icap";
   std::string entry = "debug_ip_layout";
+  std::string sysfs_open_path;
   for (auto device : platform->get_device_range()) {
     if (device->is_active()) {
       //memset(&debugResults,0, sizeof(xclDebugCountersResults));
       //At this point we deal with only one deviceyy
       device->get_xrt_device()->debugReadIPStatus(XCL_DEBUG_READ_TYPE_SPM, &debugResults);
-      device->get_xrt_device()->getSysfsPath(subdev, entry, raw_sysfs_path, 256);
+      sysfs_open_path = device->get_xrt_device()->getSysfsPath(subdev, entry).get();
       //ret |= xdp::profile::device::debugReadIPStatus(device, XCL_DEBUG_READ_TYPE_SPM, &debugResults);
     }
   }
-  std::string sysfs_open_path(raw_sysfs_path);
 
   if (ret) {
     auto adv = new app_debug_view<spm_debug_view>(nullptr, nullptr, true, "Error reading spm counters");
@@ -1371,9 +1370,9 @@ clGetDebugStreamCounters()
 
   xclStreamingDebugCountersResults streamingDebugCounters;  
   memset(&streamingDebugCounters, 0, sizeof(xclStreamingDebugCountersResults));
-  char raw_sysfs_path[256];
   std::string subdev = "icap";
   std::string entry = "debug_ip_layout";
+  std::string sysfs_open_path;
   auto platform = rts->getcl_platform_id();
   for (auto device : platform->get_device_range())
   {
@@ -1381,11 +1380,10 @@ clGetDebugStreamCounters()
     {
       // At this point, we are dealing with only one device
       device->get_xrt_device()->debugReadIPStatus(XCL_DEBUG_READ_TYPE_SSPM, &streamingDebugCounters);
-      device->get_xrt_device()->getSysfsPath(subdev, entry, raw_sysfs_path, 256);
+      sysfs_open_path = device->get_xrt_device()->getSysfsPath(subdev, entry).get();
       //ret |= xdp::profile::device::debugReadIPStatus(device, XCL_DEBUG_READ_TYPE_SSPM, &streamingDebugCounters);
     }
   }
-  std::string sysfs_open_path(raw_sysfs_path);
 
   if (ret) 
   {
@@ -1585,9 +1583,9 @@ clGetDebugCheckers() {
     auto adv = new app_debug_view<lapc_debug_view>(nullptr, nullptr, true, "Error: Runtime instance not available");
     return adv;
   }
-  char raw_sysfs_path[256];
   std::string subdev = "icap";
   std::string entry = "debug_ip_layout";
+  std::string sysfs_open_path;
   auto platform = rts->getcl_platform_id();
   // Iterates over all devices, but assumes only one device
   memset(&debugCheckers,0, sizeof(xclDebugCheckersResults));
@@ -1596,12 +1594,10 @@ clGetDebugCheckers() {
       //memset(&debugCheckers,0, sizeof(xclDebugCheckersResults));
       //At this point we deal with only one deviceyy
       device->get_xrt_device()->debugReadIPStatus(XCL_DEBUG_READ_TYPE_LAPC, &debugCheckers);
-      device->get_xrt_device()->getSysfsPath(subdev, entry, raw_sysfs_path, 256);
+      sysfs_open_path = device->get_xrt_device()->getSysfsPath(subdev, entry).get();
       //ret |= xdp::profile::device::debugReadIPStatus(device, XCL_DEBUG_READ_TYPE_LAPC, &debugCheckers);
     }
   }
-  std::string sysfs_open_path(raw_sysfs_path);
-
   if (ret) {
     auto adv = new app_debug_view<lapc_debug_view>(nullptr, nullptr, true, "Error reading lapc status");
     return adv;

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1262,7 +1262,12 @@ clGetDebugCounters() {
   spm_view->DevUserName = debugResults.DevUserName;
   spm_view->SysfsPath = sysfs_open_path;
 
+  std::cout << "DEBUGGING: constructing new spm debug view adv" << std::endl;
+
   auto adv = new app_debug_view <spm_debug_view> (spm_view, [spm_view](){delete spm_view;}, false, "");
+
+  std::cout << "DEBUGGING: clGetDebugCounters ends" << std::endl;
+
   return adv;
 }
 

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1201,6 +1201,7 @@ isEmulationMode()
 
 app_debug_view<spm_debug_view>*
 clGetDebugCounters() {
+  std::cout << "clGetDebugCounters starts" << std::endl;
   cl_int ret = CL_SUCCESS;
   xclDebugCountersResults debugResults = {0};
 

--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1201,7 +1201,7 @@ isEmulationMode()
 
 app_debug_view<spm_debug_view>*
 clGetDebugCounters() {
-  std::cout << "clGetDebugCounters starts" << std::endl;
+  std::cout << "DEBUGGING: clGetDebugCounters starts" << std::endl;
   cl_int ret = CL_SUCCESS;
   xclDebugCountersResults debugResults = {0};
 
@@ -1220,6 +1220,8 @@ clGetDebugCounters() {
     return adv;
   }
 
+  std::cout << "DEBUGGING: getting ocl platform id" << std::endl;
+
   auto platform = rts->getcl_platform_id();
   // Iterates over all devices, but assumes only one device
   memset(&debugResults,0, sizeof(xclDebugCountersResults));
@@ -1237,10 +1239,15 @@ clGetDebugCounters() {
   }
   std::string sysfs_open_path(raw_sysfs_path);
 
+  std::cout << "DEBUGGING: sysfs path retrieved" << std::endl;
+
   if (ret) {
     auto adv = new app_debug_view<spm_debug_view>(nullptr, nullptr, true, "Error reading spm counters");
     return adv;
   }
+
+  std::cout << "DEBUGGING: constructing spm debug view" << std::endl;
+
   auto spm_view = new spm_debug_view ();
   std::copy(debugResults.WriteBytes, debugResults.WriteBytes+XSPM_MAX_NUMBER_SLOTS, spm_view->WriteBytes);
   std::copy(debugResults.WriteTranx, debugResults.WriteTranx+XSPM_MAX_NUMBER_SLOTS, spm_view->WriteTranx);

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -810,10 +810,10 @@ public:
     return m_hal->stopTrace(type);
   }
 
-  hal::operations_result<size_t>
-  getSysfsPath(std::string& subdev, std::string& entry, char* path, int size)
+  hal::operations_result<std::string>
+  getSysfsPath(std::string& subdev, std::string& entry)
   {
-    return m_hal->getSysfsPath(subdev, entry, path, size);
+    return m_hal->getSysfsPath(subdev, entry);
   }
 
   /**

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -811,7 +811,7 @@ public:
   }
 
   hal::operations_result<std::string>
-  getSysfsPath(std::string& subdev, std::string& entry)
+  getSysfsPath(const std::string& subdev, const std::string& entry)
   {
     return m_hal->getSysfsPath(subdev, entry);
   }

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -810,6 +810,12 @@ public:
     return m_hal->stopTrace(type);
   }
 
+  hal::operations_result<size_t>
+  getSysfsPath(std::string& subdev, std::string& entry, char* path, int size)
+  {
+    return m_hal->getSysfsPath(subdev, entry, path, size);
+  }
+
   /**
    * Explicitly schedule an arbitrary function on the device's
    * task queue.

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -603,10 +603,10 @@ public:
     return operations_result<size_t>();
   }
 
-  virtual operations_result<size_t>
-  getSysfsPath(std::string subdev, std::string entry, char* path, int size)
+  virtual operations_result<std::string>
+  getSysfsPath(std::string subdev, std::string entry)
   {
-    return operations_result<size_t>();
+    return operations_result<std::string>();
   }
 
   virtual task::queue*

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -604,7 +604,7 @@ public:
   }
 
   virtual operations_result<std::string>
-  getSysfsPath(std::string subdev, std::string entry)
+  getSysfsPath(const std::string subdev, const std::string entry)
   {
     return operations_result<std::string>();
   }

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -603,6 +603,12 @@ public:
     return operations_result<size_t>();
   }
 
+  virtual operations_result<size_t>
+  getSysfsPath(std::string subdev, std::string entry, char* path, int size)
+  {
+    return operations_result<size_t>();
+  }
+
   virtual task::queue*
   getQueue(hal::queue_type qt) {return nullptr; }
 };

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -604,7 +604,7 @@ public:
   }
 
   virtual operations_result<std::string>
-  getSysfsPath(const std::string subdev, const std::string entry)
+  getSysfsPath(const std::string& subdev, const std::string& entry)
   {
     return operations_result<std::string>();
   }

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -576,7 +576,7 @@ public:
   }
 
   virtual hal::operations_result<std::string>
-  getSysfsPath(const std::string subdev, const std::string entry)
+  getSysfsPath(const std::string& subdev, const std::string& entry)
   {
     if (!m_ops->mGetSysfsPath)
       return hal::operations_result<std::string>();

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -576,7 +576,7 @@ public:
   }
 
   virtual hal::operations_result<std::string>
-  getSysfsPath(std::string subdev, std::string entry)
+  getSysfsPath(const std::string subdev, const std::string entry)
   {
     if (!m_ops->mGetSysfsPath)
       return hal::operations_result<std::string>();

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -575,12 +575,19 @@ public:
     return m_ops->mStopTrace(m_handle,type);
   }
 
-  virtual hal::operations_result<size_t>
-  getSysfsPath(std::string subdev, std::string entry, char* path, int size)
+  virtual hal::operations_result<std::string>
+  getSysfsPath(std::string subdev, std::string entry)
   {
     if (!m_ops->mGetSysfsPath)
-      return hal::operations_result<size_t>();
-    return m_ops->mGetSysfsPath(m_handle, subdev.c_str(), entry.c_str(), path, size);
+      return hal::operations_result<std::string>();
+    size_t max_path = 256;
+    char path_buf[max_path];
+    if (m_ops->mGetSysfsPath(m_handle, subdev.c_str(), entry.c_str(), path_buf, max_path)) {
+      return hal::operations_result<std::string>();
+    }
+    path_buf[max_path - 1] = '\0';
+    std::string sysfs_path = std::string(path_buf);
+    return sysfs_path;
   }
 };
 

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -574,6 +574,14 @@ public:
       return hal::operations_result<size_t>();
     return m_ops->mStopTrace(m_handle,type);
   }
+
+  virtual hal::operations_result<size_t>
+  getSysfsPath(std::string subdev, std::string entry, char* path, int size)
+  {
+    if (!m_ops->mGetSysfsPath)
+      return hal::operations_result<size_t>();
+    return m_ops->mGetSysfsPath(m_handle, subdev.c_str(), entry.c_str(), path, size);
+  }
 };
 
 }} // hal2,xrt

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -75,6 +75,7 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mWriteQueue(0)
   ,mReadQueue(0)
   ,mPollQueues(0)
+  ,mGetSysfsPath(0)
 {
   mProbe = (probeFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclProbe");
   if (!mProbe)
@@ -161,6 +162,8 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mWriteHostEvent = (writeHostEventFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclWriteHostEvent");
   mDebugReadIPStatus = (debugReadIPStatusFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclDebugReadIPStatus");
 
+  // Experimental xdp apis
+  mGetSysfsPath = (xclGetSysfsPathFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclGetSysfsPath");
 }
 
 operations::

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -125,6 +125,10 @@ private:
   typedef ssize_t (*writeQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, xclQueueRequest *wr);
   typedef ssize_t (*readQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, xclQueueRequest *wr);
   typedef int     (*pollQueuesFuncType)(xclDeviceHandle handle,int min, int max, xclReqCompletion* completions, int* actual, int timeout);
+
+  //xdp experimental apis
+  typedef int     (*xclGetSysfsPathFuncType)(xclDeviceHandle handle, const char* subdev, const char* entry, char* sysfsPath, size_t size);
+
 //End Streaming
 //
 #if 0
@@ -208,6 +212,9 @@ public:
   readQueueFuncType mReadQueue;
   pollQueuesFuncType mPollQueues;
 //End Streaming
+
+//Experimental xdp apis
+  xclGetSysfsPathFuncType mGetSysfsPath;
 
 #if 0
   /* TBD */


### PR DESCRIPTION
The location of debug_ip_layout used in AppDebug was wrong. This PR contains propagating the HAL API for getting SYSFS path up to XRT device and use that XRT device API to get debug_ip_layout in AppDebug.