### PR TITLE
Reset scheduler on first reference on xclbin

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -2086,6 +2086,8 @@ static int icap_lock_bitstream(struct platform_device *pdev, const xuid_t *id,
 
 		if (err >= 0)
 			err = icap->icap_bitstream_ref;
+		if (err==1) /* reset on first reference */
+			xocl_exec_reset(xocl_get_xdev(pdev));
 	}
 	else {
 		mutex_unlock(&icap->icap_lock);
@@ -2122,7 +2124,7 @@ static int icap_unlock_bitstream(struct platform_device *pdev, const xuid_t *id,
 		if (err >= 0)
 			err = icap->icap_bitstream_ref;
 		if (err==0)
-			xocl_exec_reset(xocl_get_xdev(pdev));
+			xocl_exec_stop(xocl_get_xdev(pdev));
 	} else {
 		mutex_unlock(&icap->icap_lock);
 		BUG_ON("mgmt should not call icap_unlock");

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drv.c
@@ -63,6 +63,7 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare)
 		reset_notify_client_ctx(xdev);
 		xocl_user_dev_online(xdev);
 		xocl_mailbox_reset(xdev, true);
+		xocl_exec_reset(xdev);
         }
 }
 


### PR DESCRIPTION
Move reset from release of last reference to where first reference is acquired.
This change is needed for xbutil top to show execution status after application finishes.