### PR TITLE
basic interrupt support, 32 CUs, harden interrrupt in dts

### DIFF
--- a/src/platform/zcu102ng/dynamic_postlink.tcl
+++ b/src/platform/zcu102ng/dynamic_postlink.tcl
@@ -35,7 +35,8 @@ proc add_interrupt_ctrl_concat { __cu_num } {
   foreach __pair $__inst_intrs_list {
     lassign $__pair __intc_inst_num __intrs_num
     create_bd_cell -type ip -vlnv xilinx.com:ip:axi_intc axi_intc_${__intc_inst_num}
-    set_property -dict [list CONFIG.C_IRQ_IS_LEVEL {0} CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_${__intc_inst_num}]
+    set_property -dict [list CONFIG.C_KIND_OF_INTR.VALUE_SRC USER] [get_bd_cells axi_intc_${__intc_inst_num}]
+    set_property -dict [list CONFIG.C_KIND_OF_INTR {0xFFFFFFFF} CONFIG.C_IRQ_IS_LEVEL {0} CONFIG.C_IRQ_CONNECTION {1}] [get_bd_cells axi_intc_${__intc_inst_num}]
     create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat xlconcat_intc_${__intc_inst_num}
     set_property -dict [list CONFIG.NUM_PORTS ${__intrs_num}] [get_bd_cells xlconcat_intc_${__intc_inst_num}]
 
@@ -57,7 +58,7 @@ proc add_interrupt_ctrl_concat { __cu_num } {
       # Connect interrupt controlor to HPM0
       apply_bd_automation -rule xilinx.com:bd_rule:axi4 -config { Clk_master {Auto} Clk_slave {Auto} Clk_xbar {Auto} Master {/ps_e/M_AXI_HPM0_FPD} Slave {/axi_intc_${__intc_inst_num}/s_axi} intc_ip {Auto} master_apm {0}}  [get_bd_intf_pins axi_intc_${__intc_inst_num}/s_axi]
       # Hard code address for now...
-      set offset [expr 0xA0800000 + ${__intc_inst_num} * 0x1000]
+      set offset [expr 0xA8000000 + ${__intc_inst_num} * 0x1000]
       set_property offset $offset [get_bd_addr_segs "ps_e/Data/SEG_axi_intc_${__intc_inst_num}_Reg"]
     } else {
       puts "(Post-linking DSA Tcl hook) No available xlconcat pins found"

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -276,6 +276,7 @@ struct sched_exec_core {
  * @error: set to 1 to indicate scheduler error
  * @stop: set to 1 to indicate scheduler should stop
  * @cq: list of command objects managed by scheduler
+ * @intc: set when there is a pending interrupt for command completion
  * @poll: number of running commands in polling mode
  */
 struct scheduler {
@@ -287,6 +288,7 @@ struct scheduler {
 	unsigned int               stop;
 
 	struct list_head           cq;
+	unsigned int               intc; /* pending intr shared with isr*/
 	unsigned int               poll; /* number of cmds to poll */
 };
 

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
@@ -27,6 +27,7 @@
 #include <linux/io.h>
 #include <linux/kernel.h>
 #include <linux/of_address.h>
+#include <linux/of_irq.h>
 #include "zocl_drv.h"
 #include "sched_exec.h"
 
@@ -477,6 +478,8 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	struct resource *res;
 	struct resource res_mem;
 	void __iomem *map;
+	int index;
+	int irq;
 	int ret;
 
 	id = of_match_node(zocl_drm_of_match, pdev->dev.of_node);
@@ -498,6 +501,16 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	zdev->regs       = map;
 	zdev->res_start  = res->start;
 	zdev->res_len    = resource_size(res);
+
+	/* Record and get IRQ number */
+	for (index = 0; index < MAX_CU_NUM; index++) {
+		irq = platform_get_irq(pdev, index);
+		if (irq < 0)
+			break;
+		DRM_INFO("CU(%d) IRQ %d\n", index, irq);
+		zdev->irq[index] = irq;
+	}
+	zdev->cu_num = index;
 
 	zdev->host_mem = 0xFFFFFFFFFFFFFFFF;
 	zdev->host_mem_len = 0;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
@@ -24,6 +24,8 @@
 #define zocl_dbg(dev, fmt, args...)     \
 	dev_dbg(dev, "%s: "fmt, __func__, ##args)
 
+#define MAX_CU_NUM 128
+
 #define CLEAR(x) \
 	memset(&x, 0, sizeof(x))
 
@@ -46,7 +48,8 @@ struct drm_zocl_dev {
 	resource_size_t          res_len;
 	phys_addr_t              host_mem;
 	resource_size_t          host_mem_len;
-	unsigned int             irq;
+	unsigned int		 cu_num;
+	unsigned int             irq[MAX_CU_NUM];
 	struct sched_exec_core  *exec;
 
 	struct mem_topology	*topology;

--- a/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc.dts
+++ b/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc.dts
@@ -1,16 +1,29 @@
 
-/{
-	xlnk {
-		compatible = "xlnx,xlnk-1.0";
-	};
-};
-
 &amba {
+	axi_intc_0: axi-interrupt-ctrl {
+		#interrupt-cells = <2>;
+		compatible = "xlnx,xps-intc-1.00.a";
+		interrupt-controller;
+		reg = <0x0 0xA8000000 0x0 0x1000>;
+		xlnx,kind-of-intr = <0x0>;
+		xlnx,num-intr-inputs = <0x20>;
+		interrupt-parent = <&gic>;
+		interrupts = <0 89 4>;
+	};
+
 	zyxclmm_drm {
 		compatible = "xlnx,zocl";
 		status = "okay";
 		reg = <0x0 0xA0000000 0x0 0x800000>;
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0  4>, <1  4>, <2  4>, <3  4>,
+			     <4  4>, <5  4>, <6  4>, <7  4>,
+			     <8  4>, <9  4>, <10 4>, <11 4>,
+			     <12 4>, <13 4>, <14 4>, <15 4>,
+			     <16 4>, <17 4>, <18 4>, <19 4>,
+			     <20 4>, <21 4>, <22 4>, <23 4>,
+			     <24 4>, <25 4>, <26 4>, <27 4>,
+			     <28 4>, <29 4>, <30 4>, <31 4>;
 	};
 };
-
 


### PR DESCRIPTION
1. Add one interrupt controller to support up to 32 CUs interrupt
2. Harden 32 CUs interrupt for now. Show fix this after we could dynamically get interrupts from XCLBIN.
3. Basic interrupt support, including handler, user configure polling
