### PR TITLE
whitelist CentOS version 7.6 in setup.csh and setup.sh

### DIFF
--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -39,7 +39,7 @@ if ( "$OSDIST" =~ "ubuntu" ) then
 endif
 
 if ( "$OSDIST" =~ centos  || "$OSDIST" =~ redhat* ) then
-    if ( "$OSREL" !~ 7.4* && "$OSREL" !~ 7.5* ) then
+    if ( "$OSREL" !~ 7.4* && "$OSREL" !~ 7.5* && "$OSREL" !~ 7.6* ) then
         echo "ERROR: Centos or RHEL release version must be 7.4 or later"
         exit 1
     endif

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -15,7 +15,7 @@ if [[ $OSDIST == "ubuntu" ]]; then
 fi
 
 if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "redhat"* ]]; then
-    if [[ $OSREL != "7.4"* ]] &&  [[ $OSREL != "7.5"* ]]; then
+    if [[ $OSREL != "7.4"* ]] &&  [[ $OSREL != "7.5"* ]] && [[ $OSREL != "7.6"* ]]; then
         echo "ERROR: Centos or RHEL release version must be 7.4 or later"
         return 1
     fi


### PR DESCRIPTION
Add support for CentOS 7.6 in setup scripts. This should be merged into 2018.3 and then I will cherrypick this into 2018.3.RC3 branch.