### PR TITLE
XMA changes 2019-02-19 (2018.3)

### DIFF
--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -25,4 +25,7 @@ rm -f /etc/udev/rules.d/10-xclmgmt.rules
 rm -f /etc/dracut.conf.d/xocl.dracut.conf
 rm -f /etc/dracut.conf.d/xclmgmt.dracut.conf
 
+echo "Cleaning up XMA..."
+rm -f /tmp/xma_shm_db
+
 exit 0

--- a/src/xma/include/lib/xmalimits.h
+++ b/src/xma/include/lib/xmalimits.h
@@ -21,7 +21,7 @@
 #define MAX_FILTER_OUTPUTS      MAX_SCALER_OUTPUTS
 #define MAX_DDR_MAP             16
 #define MAX_XILINX_DEVICES      16
-#define MAX_XILINX_KERNELS      16
+#define MAX_XILINX_KERNELS      60
 #define MAX_KERNEL_CONFIGS      60
 #define MAX_KERNEL_CHANS        64
 #define MAX_KERNEL_FREQS         2

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -666,8 +666,14 @@ static void xma_shm_close(XmaResConfig *xma_shm, bool rm_shm)
     xma_logmsg(XMA_DEBUG_LOG, XMA_RES_MOD, "%s()\n", __func__);
     munmap((void*)xma_shm, sizeof(XmaResConfig));
 
+    /* JPM eliminate need to remove shared memory as there is
+     * a possible race condition as we cannot ensure this
+     * operation is protected from concurrent access by another
+     * process wishing to open the existing XMA_SHM_FILE
+     * prior to this unlink operation completing.
     if (rm_shm)
         unlink(XMA_SHM_FILE);
+    */
 }
 
 static int xma_verify_process_res(pid_t pid)

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -495,6 +495,7 @@ static XmaResConfig *xma_shm_open(char *shm_filename, XmaSystemCfg *config)
     pthread_mutexattr_init(&proc_shared_lock);
     pthread_mutexattr_setpshared(&proc_shared_lock, PTHREAD_PROCESS_SHARED);
     pthread_mutexattr_setrobust(&proc_shared_lock, PTHREAD_MUTEX_ROBUST);
+    pthread_mutexattr_setprotocol(&proc_shared_lock, PTHREAD_PRIO_INHERIT);
     shm_map = (XmaResConfig *)mmap(NULL, sizeof(XmaResConfig),
                PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     pthread_mutex_init(&shm_map->lock, &proc_shared_lock);


### PR DESCRIPTION
1. Removing persistent shm_db before installation, in context of fix for mutex contention
2. Add PTHREAD_PRIO_INHERIT attribute to shm mutex
3. Do not remove xma shm db file when ref count reaches 0
4. Add logging to mutex handling for xma shm db
5. Increasing number of kernels supported by XMA from 16 to 60 (CR-1020279)
