### PR TITLE
Should unmap buffer in XRT test cases

### DIFF
--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -215,6 +215,14 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         return 1;
     }
 
+    // Clean up stuff
+    munmap(bo1, DATA_SIZE);
+    munmap(bo2, DATA_SIZE);
+    munmap(execData, DATA_SIZE);
+    xclFreeBO(handle, boHandle1);
+    xclFreeBO(handle, boHandle2);
+    xclFreeBO(handle, execHandle);
+
     xclCloseContext(handle, xclbinId, cu_index);
 
     return 0;

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -275,6 +275,7 @@ int main(int argc, char** argv)
         //Clean up stuff
         munmap(bo1, DATA_SIZE);
         munmap(bo2, DATA_SIZE);
+        munmap(execData, DATA_SIZE);
         xclFreeBO(handle,boHandle1);
         xclFreeBO(handle,boHandle2);
         xclFreeBO(handle,execHandle);

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -296,6 +296,9 @@ int main(int argc, char** argv)
             return 1;
         }
         munmap(bo, DATA_SIZE*4);
+        munmap(execData, DATA_SIZE*4);
+        xclFreeBO(handle, boHandle);
+        xclFreeBO(handle, execHandle);
     }
     catch (std::exception const& e)
     {

--- a/tests/xrt/07_sequence/main.cpp
+++ b/tests/xrt/07_sequence/main.cpp
@@ -215,6 +215,12 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         return 1;
     }
 
+    //Clean up stuff
+    munmap(bo, DATA_SIZE * sizeof(unsigned));
+    munmap(execData, DATA_SIZE * sizeof(unsigned));
+    xclFreeBO(handle, boHandle);
+    xclFreeBO(handle, execHandle);
+
     xclCloseContext(handle, xclbinId, cu_index);
 
     return 0;

--- a/tests/xrt/11_fp_mmult256/main.cpp
+++ b/tests/xrt/11_fp_mmult256/main.cpp
@@ -256,6 +256,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
 
         munmap(bo1, DATA_SIZE*sizeof(float));
         munmap(bo2, DATA_SIZE*sizeof(float));
+        munmap(execData, DATA_SIZE*sizeof(float));
         xclFreeBO(handle,boHandle1);
         xclFreeBO(handle,boHandle2);
         xclFreeBO(handle,execHandle);

--- a/tests/xrt/13_add_one/main.cpp
+++ b/tests/xrt/13_add_one/main.cpp
@@ -219,7 +219,6 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         return 1;
     }
 
-
     // Validate our results
     //
     int err = 0;
@@ -248,6 +247,14 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
             std::cout<<std::endl;
         }
     }
+
+    //Clean up stuff
+    munmap(bo1, DATA_SIZE);
+    munmap(bo2, DATA_SIZE);
+    munmap(execData, DATA_SIZE);
+    xclFreeBO(handle, boHandle1);
+    xclFreeBO(handle, boHandle2);
+    xclFreeBO(handle, execHandle);
 
     xclCloseContext(handle, xclbinId, cu_index);
 

--- a/tests/xrt/15_buffer_size/main.cpp
+++ b/tests/xrt/15_buffer_size/main.cpp
@@ -172,6 +172,8 @@ static int transferSizeTest1(xclDeviceHandle &handle, size_t alignment, unsigned
     }
 
     std::cout << "transferSizeTest1 complete. Release buffer objects.\n";
+    munmap(writeBuffer, maxSize);
+    munmap(readBuffer, maxSize);
     xclFreeBO(handle,boHandle1);
     xclFreeBO(handle,boHandle2);
     for (std::list<uint64_t>::const_iterator i = deviceHandleList.begin(), e = deviceHandleList.end(); i != e; ++i)
@@ -244,6 +246,8 @@ static int transferSizeTest2(xclDeviceHandle &handle, size_t alignment, unsigned
         }
     }
     std::cout << "transferSizeTest2 complete. Release buffer objects.\n";
+    munmap(writeBuffer, maxSize);
+    munmap(readBuffer, maxSize);
     xclFreeBO(handle,boHandle1);
     xclFreeBO(handle,boHandle2);
     return 0;

--- a/tests/xrt/22_verify/main.cpp
+++ b/tests/xrt/22_verify/main.cpp
@@ -193,6 +193,11 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         return 1;
     }
 
+    // Clean up stuff
+    munmap(bo, 1024);
+    munmap(execData, 1024);
+    xclFreeBO(handle, boHandle);
+    xclFreeBO(handle, execHandle);
     xclCloseContext(handle, xclbinId, cu_index);
 
     return 0;


### PR DESCRIPTION
Some test cases didn't call unmap. This is no good coding style for test cases that everyone can see.