### PR TITLE
Initial hard-coded implementation of Zynq function to retreive the pa…

### DIFF
--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -449,6 +449,22 @@ int ZYNQShim::xclExecWait(int timeoutMilliSec)
   return poll(&uifdVector[0], uifdVector.size(), timeoutMilliSec);
 }
 
+int ZYNQShim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)
+{
+  // Until we have a programmatic way to determine what this directory
+  //  is on Zynq platforms, this is hard-coded so we can test out 
+  //  debug and profile features.
+  std::string path = "/sys/devices/platform/amba/a0000000.zyxclmm_drm/";
+  path += entry ;
+
+  if (path.length() >= size) return -1 ;
+
+  // Since path.length() < size, we are sure to copy over the null 
+  //  terminating byte.
+  strncpy(sysfsPath, path.c_str(), size) ;
+  return 0 ;
+}
+
 }
 ;
 //end namespace ZYNQ
@@ -664,6 +680,15 @@ int xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
   if (!drv)
     return -EINVAL;
   return drv->xclExecWait(timeoutMilliSec);
+}
+
+int xclGetSysfsPath(xclDeviceHandle handle, const char* subdev, 
+		    const char* entry, char* sysfsPath, size_t size)
+{
+  ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+  if (!drv)
+    return -EINVAL;
+  return drv->xclGetSysfsPath(subdev, entry, sysfsPath, size);
 }
 
 //

--- a/src/runtime_src/driver/zynq/user/shim.h
+++ b/src/runtime_src/driver/zynq/user/shim.h
@@ -52,6 +52,8 @@ public:
   int xclExecBuf(unsigned int cmdBO);
   int xclExecWait(int timeoutMilliSec);
 
+  int xclGetSysfsPath(const char* subdev, const char* entry, char* sysfPath, size_t size);
+
   // Bitstream/bin download
   int xclLoadXclBin(const xclBin *buffer);
 	int xclLoadAxlf(const axlf *buffer);


### PR DESCRIPTION
…th to a file in the sysfs directory (specifically debug_ip_layout).  This is necessary to test out profile and debug features and should be updated when we have a programmatic way to find this directory on Zynq platforms