### PR TITLE
add several zocl sysfs nodes

### DIFF
--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -2,7 +2,7 @@
  * Compute unit execution, interrupt management and
  * client context core data structures.
  *
- * Copyright (C) 2017 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2017-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
@@ -233,6 +233,8 @@ struct sched_client_ctx {
  * @num_slot_masks: Number of slots status masks used
  * @cu_status: Status (busy(1)/free(0)) of CUs. Unused in ERT mode.
  * @num_cu_masks: Number of CU masks used (computed from @num_cus)
+ * @cu_addr_phy: Physical address of CUs.
+ * @cu_usage: How many times the CUs are excecuted.
  * @ops: Scheduler operations vtable
  */
 struct sched_exec_core {
@@ -261,6 +263,9 @@ struct sched_exec_core {
 
 	u32                        cu_status[MAX_U32_CU_MASKS];
 	unsigned int               num_cu_masks; /* ((num_cus-1)>>5+1 */
+
+	u32                        cu_addr_phy[MAX_CUS];
+	u32                        cu_usage[MAX_CUS];
 
 	struct sched_ops          *ops;
 	struct task_struct        *cq_thread;
@@ -307,6 +312,7 @@ struct sched_cmd {
 	struct list_head list;
 	struct drm_device *ddev;
 	struct scheduler *sched;
+	struct sched_exec_core *exec;
 	enum cmd_state state;
 	int cu_idx; /* running cu, initialized to -1 */
 	int slot_idx;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
@@ -112,5 +112,6 @@ int zocl_init_sysfs(struct device *dev);
 void zocl_fini_sysfs(struct device *dev);
 void zocl_free_sections(struct drm_zocl_dev *zdev);
 void zocl_free_bo(struct drm_gem_object *obj);
+void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count);
 
 #endif

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_sysfs.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *
@@ -16,66 +16,130 @@
  */
 
 #include "zocl_drv.h"
+#include "sched_exec.h"
 #include "xclbin.h"
 
 static ssize_t xclbinid_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	ssize_t size;
 
-	return sprintf(buf, "%llx\n", zdev->unique_id_last_bitstream);
+	if (!zdev)
+		return 0;
+
+	size = sprintf(buf, "%llx\n", zdev->unique_id_last_bitstream);
+
+	return size;
 }
-
 static DEVICE_ATTR_RO(xclbinid);
 
-#if 0
-static ssize_t dr_base_addr_show(struct device *dev,
-		struct device_attribute *attr, char *buf)
-{
-	return sprintf(buf, "%u\n", 0);
-}
-
-static DEVICE_ATTR_RO(dr_base_addr);
-#endif
-
-static ssize_t mem_topology_show(struct device *dev,
+static ssize_t kds_numcus_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
-	size_t size = sizeof_section(zdev->topology, m_mem_data);
+	ssize_t size;
 
-	memcpy(buf, zdev->topology, size);
+	if (!zdev || !zdev->exec)
+		return 0;
+
+	size = sprintf(buf, "%d\n", zdev->exec->num_cus);
+
+	return size;
+}
+static DEVICE_ATTR_RO(kds_numcus);
+
+static ssize_t kds_custat_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	ssize_t size = 0;
+	int i;
+
+	if (!zdev || !zdev->exec)
+		return 0;
+
+	read_lock(&zdev->attr_rwlock);
+
+	for (i = 0; i < zdev->exec->num_cus; i++)
+		size += sprintf(buf + size, "CU[@0x%x] : %d\n",
+		    zdev->exec->cu_addr_phy[i], zdev->exec->cu_usage[i]);
+
+	read_unlock(&zdev->attr_rwlock);
+
+	return size;
+}
+static DEVICE_ATTR_RO(kds_custat);
+
+static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	struct mem_topology *topo;
+	ssize_t size = 0;
+	ssize_t count;
+	size_t memory_usage;
+	unsigned int bo_count;
+	const char *txt_fmt = "[%s] %s@0x%012llx\t(%4lluMB):\t%lluKB\t%dBOs\n";
+	const char *raw_fmt = "%llu %d\n";
+	int i;
+
+	if (!zdev || !zdev->topology)
+		return 0;
+
+	topo = zdev->topology;
+	read_lock(&zdev->attr_rwlock);
+
+	for (i = 0; i < topo->m_count; i++) {
+		if (topo->m_mem_data[i].m_type == MEM_STREAMING)
+			continue;
+
+		memory_usage = topo->m_mem_data[i].m_used ?
+		    zdev->mm_usage.memory_usage : 0;
+		bo_count = topo->m_mem_data[i].m_used ?
+		    zdev->mm_usage.bo_count : 0;
+
+		if (raw)
+			count = sprintf(buf, raw_fmt, memory_usage, bo_count);
+		else {
+			count = sprintf(buf, txt_fmt,
+			    topo->m_mem_data[i].m_used ? "IN-USE" : "UNUSED",
+			    topo->m_mem_data[i].m_tag,
+			    topo->m_mem_data[i].m_base_address,
+			    topo->m_mem_data[i].m_size / 1024,
+			    memory_usage / 1024,
+			    bo_count);
+		}
+		buf += count;
+		size += count;
+	}
+
+	read_unlock(&zdev->attr_rwlock);
 
 	return size;
 }
 
-static DEVICE_ATTR_RO(mem_topology);
-
-static ssize_t connectivity_show(struct device *dev,
+static ssize_t memstat_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
-	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
-	size_t size = sizeof_section(zdev->connectivity, m_connection);
-
-	memcpy(buf, zdev->connectivity, size);
-
-	return size;
+	return zocl_get_memstat(dev, buf, false);
 }
+static DEVICE_ATTR_RO(memstat);
 
-static DEVICE_ATTR_RO(connectivity);
-
-static ssize_t ip_layout_show(struct device *dev,
+static ssize_t memstat_raw_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
-	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
-	size_t size = sizeof_section(zdev->ip, m_ip_data);
-
-	memcpy(buf, zdev->ip, size);
-
-	return size;
+	return zocl_get_memstat(dev, buf, true);
 }
+static DEVICE_ATTR_RO(memstat_raw);
 
-static DEVICE_ATTR_RO(ip_layout);
+static struct attribute *zocl_attrs[] = {
+	&dev_attr_xclbinid.attr,
+	&dev_attr_kds_numcus.attr,
+	&dev_attr_kds_custat.attr,
+	&dev_attr_memstat.attr,
+	&dev_attr_memstat_raw.attr,
+	NULL,
+};
 
 static ssize_t read_debug_ip_layout(struct file *filp, struct kobject *kobj,
 		struct bin_attribute *attr, char *buf, loff_t off, size_t count)
@@ -85,6 +149,11 @@ static ssize_t read_debug_ip_layout(struct file *filp, struct kobject *kobj,
 	u32 nread = 0;
 
 	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
+	if (!zdev || !zdev->debug_ip)
+		return 0;
+
+	read_lock(&zdev->attr_rwlock);
+
 	size = sizeof_section(zdev->debug_ip, m_debug_ip_data);
 
 	if (off >= size)
@@ -97,10 +166,102 @@ static ssize_t read_debug_ip_layout(struct file *filp, struct kobject *kobj,
 
 	memcpy(buf, ((char *)zdev->debug_ip) + off, nread);
 
+	read_unlock(&zdev->attr_rwlock);
+
 	return nread;
 }
 
-static struct bin_attribute debug_ip_layout_attrs = {
+static ssize_t read_ip_layout(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	struct drm_zocl_dev *zdev;
+	size_t size;
+	u32 nread = 0;
+
+	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
+	if (!zdev || !zdev->ip)
+		return 0;
+
+	read_lock(&zdev->attr_rwlock);
+
+	size = sizeof_section(zdev->ip, m_ip_data);
+
+	if (off > size)
+		return 0;
+
+	if (count < size - off)
+		nread = count;
+	else
+		nread = size - off;
+
+	memcpy(buf, ((char *)zdev->ip) + off, nread);
+
+	read_unlock(&zdev->attr_rwlock);
+
+	return nread;
+}
+
+static ssize_t read_connectivity(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	struct drm_zocl_dev *zdev;
+	size_t size;
+	u32 nread = 0;
+
+	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
+	if (!zdev || !zdev->connectivity)
+		return 0;
+
+	read_lock(&zdev->attr_rwlock);
+
+	size = sizeof_section(zdev->connectivity, m_connection);
+
+	if (off > size)
+		return 0;
+
+	if (count < size - off)
+		nread = count;
+	else
+		nread = size - off;
+
+	memcpy(buf, ((char *)zdev->connectivity + off), nread);
+
+	read_unlock(&zdev->attr_rwlock);
+
+	return nread;
+}
+
+static ssize_t read_mem_topology(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	struct drm_zocl_dev *zdev;
+	size_t size;
+	u32 nread = 0;
+
+	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
+	if (!zdev || !zdev->topology)
+		return 0;
+
+	read_lock(&zdev->attr_rwlock);
+
+	size = sizeof_section(zdev->topology, m_mem_data);
+
+	if (off > size)
+		return 0;
+
+	if (count < size - off)
+		nread = count;
+	else
+		nread = size - off;
+
+	memcpy(buf, ((char *)zdev->topology + off), nread);
+
+	read_unlock(&zdev->attr_rwlock);
+
+	return nread;
+}
+
+static struct bin_attribute debug_ip_layout_attr = {
 	.attr = {
 		.name = "debug_ip_layout",
 		.mode = 0444
@@ -110,50 +271,63 @@ static struct bin_attribute debug_ip_layout_attrs = {
 	.size = 0
 };
 
+static struct bin_attribute ip_layout_attr = {
+	.attr = {
+		.name = "ip_layout",
+		.mode = 0444
+	},
+	.read = read_ip_layout,
+	.write = NULL,
+	.size = 0
+};
+
+static struct bin_attribute connectivity_attr = {
+	.attr = {
+		.name = "connectivity",
+		.mode = 0444
+	},
+	.read = read_connectivity,
+	.write = NULL,
+	.size = 0
+};
+
+static struct bin_attribute mem_topology_attr = {
+	.attr = {
+		.name = "mem_topology",
+		.mode = 0444
+	},
+	.read = read_mem_topology,
+	.write = NULL,
+	.size = 0
+};
+
+
+static struct bin_attribute *zocl_bin_attrs[] = {
+	&debug_ip_layout_attr,
+	&ip_layout_attr,
+	&connectivity_attr,
+	&mem_topology_attr,
+	NULL,
+};
+
+static struct attribute_group zocl_attr_group = {
+	.attrs = zocl_attrs,
+	.bin_attrs = zocl_bin_attrs,
+};
+
 int zocl_init_sysfs(struct device *dev)
 {
 	int ret;
 
-	ret = device_create_file(dev, &dev_attr_xclbinid);
+	ret = sysfs_create_group(&dev->kobj, &zocl_attr_group);
 	if (ret)
-		goto out0;
+		DRM_ERROR("Create zocl attrs failed: %d\n", ret);
 
-	ret = device_create_file(dev, &dev_attr_connectivity);
-	if (ret)
-		goto out1;
-
-	ret = device_create_file(dev, &dev_attr_ip_layout);
-	if (ret)
-		goto out2;
-
-	ret = device_create_file(dev, &dev_attr_mem_topology);
-	if (ret)
-		goto out3;
-
-	ret = device_create_bin_file(dev, &debug_ip_layout_attrs);
-	if (ret)
-		goto out4;
-
-	return ret;
-
-out4:
-	device_remove_file(dev, &dev_attr_mem_topology);
-out3:
-	device_remove_file(dev, &dev_attr_ip_layout);
-out2:
-	device_remove_file(dev, &dev_attr_connectivity);
-out1:
-	device_remove_file(dev, &dev_attr_xclbinid);
-out0:
 	return ret;
 }
 
 void zocl_fini_sysfs(struct device *dev)
 {
-	device_remove_file(dev, &dev_attr_xclbinid);
-	device_remove_file(dev, &dev_attr_mem_topology);
-	device_remove_file(dev, &dev_attr_connectivity);
-	device_remove_file(dev, &dev_attr_ip_layout);
-	device_remove_bin_file(dev, &debug_ip_layout_attrs);
+	sysfs_remove_group(&dev->kobj, &zocl_attr_group);
 }
 

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Min Ma <min.ma@xilinx.com>
@@ -38,6 +38,11 @@
 	(ret); \
 })
 
+struct drm_zocl_mm_stat {
+	size_t memory_usage;
+	unsigned int bo_count;
+};
+
 struct drm_zocl_dev {
 	struct drm_device       *ddev;
 	struct fpga_manager     *fpga_mgr;
@@ -56,7 +61,18 @@ struct drm_zocl_dev {
 	struct ip_layout	*ip;
 	struct debug_ip_layout	*debug_ip;
 	struct connectivity	*connectivity;
+	struct drm_zocl_mm_stat	 mm_usage;
 	u64			 unique_id_last_bitstream;
+
+	/*
+	 * This RW lock is to protect the sysfs nodes exported
+	 * by zocl driver. Currently, all zocl attributes exported
+	 * to sysfs nodes are protected by a single lock. Any read
+	 * functions which not atomically touch those attributes should
+	 * hold read lock; And all write functions which not atomically
+	 * touch those attributes should hold write lock.
+	 */
+	rwlock_t		attr_rwlock;
 };
 
 #endif


### PR DESCRIPTION
1. Modify/add following zocl sysfs BIN attributes
    debug_ip_layout
    ip_layout
    connectivity
    mem_topology
2. Add following sysfs zocl regular attributes
    xclbinid
    kds_numcus
    kds_custat
    memstat
    memstat_raw
3. Fix a hang situations (when configured with interrupt mode but unsuccessfully configuring interrupt)
4. Enhance zocl driver probe to handle some failure situations. 