### PR TITLE
Removed the leading blank lines from the debian control files.

### DIFF
--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -639,7 +639,6 @@ dodebdev()
     mkdir -p $pkgdir/DEBIAN
 
 cat <<EOF > $pkgdir/DEBIAN/control
-
 Package: $dsa-dev
 Architecture: amd64
 Version: $version-$revision
@@ -684,7 +683,6 @@ dodeb()
     mkdir -p $pkgdir/DEBIAN
 
 cat <<EOF > $pkgdir/DEBIAN/control
-
 Package: $dsa
 Architecture: all
 Version: $version-$revision


### PR DESCRIPTION
Removed the leading blank lines from the debian control files when packaging a deployment or development DSA.