### PR TITLE
add API into the XRT device to retrieve hal device handle

### DIFF
--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -607,7 +607,7 @@ public:
   getQueue(hal::queue_type qt) {return nullptr; }
 
   virtual void*
-  getHalDeviceHandle() = 0;
+  getHalDeviceHandle() {return nullptr;}
 };
 
 

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -605,6 +605,9 @@ public:
 
   virtual task::queue*
   getQueue(hal::queue_type qt) {return nullptr; }
+
+  virtual void*
+  getHalDeviceHandle() = 0;
 };
 
 

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -574,6 +574,11 @@ public:
       return hal::operations_result<size_t>();
     return m_ops->mStopTrace(m_handle,type);
   }
+
+  virtual void*
+  getHalDeviceHandle() { 
+    return m_handle; 
+  }
 };
 
 }} // hal2,xrt


### PR DESCRIPTION
To refactor XDP, we want xma, OpenCL, and HAL (XfDNN and Deephi on the way) profiling to share as much code as much, so we want to contain the device related data and depend only on HAL. To do that, we will need the raw HAL device handle from the OpenCL device object. Therefore, this API is added to prepare the refactoring.