### PR TITLE
Added code for xclLogMsg to AWS shim & awssak

### DIFF
--- a/src/runtime_src/driver/xclng/tools/awssak/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/awssak/CMakeLists.txt
@@ -21,6 +21,8 @@ if(${INTERNAL_TESTING})
     xrt_awsstatic
     pthread
     rt
+    boost_filesystem
+    boost_system
     )
 else()
   include_directories(${AWS_FPGA_REPO_DIR}/sdk/userspace/include/) # path to fpga_mgmt.h
@@ -30,6 +32,8 @@ else()
     xrt_awsstatic
     pthread
     rt
+    boost_filesystem
+    boost_system
     ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a
     )
 endif()

--- a/src/runtime_src/driver/xclng/xrt/user_aws/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/shim.h
@@ -245,6 +245,9 @@ public:
         int xclOpenContext(uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
         int xclCloseContext(uuid_t xclbinId, unsigned int ipIndex) const;
 
+        static int xclLogMsg(xclDeviceHandle handle, xclLogMsgLevel level, const char* tag, const char* format, va_list args1);
+
+
         // Sanity checks
         int xclGetDeviceInfo2(xclDeviceInfo2 *info);
         static AwsXcl *handleCheck(void *handle);


### PR DESCRIPTION
Added code for xclLogMsg to AWS shim & awssak
This is for 2019.1 release. Merging to master branch only.
@sonals  Please check
@rradjabi  Please review changes to CMakeList as well