### PR TITLE
Include 'linux/limits.h' conditionally in xmalogger.h

### DIFF
--- a/src/xma/include/lib/xmalogger.h
+++ b/src/xma/include/lib/xmalogger.h
@@ -23,6 +23,10 @@
 #include <pthread.h>
 #include <limits.h>
 
+#if !defined (PATH_MAX) || !defined (NAME_MAX)
+#include <linux/limits.h>
+#endif
+
 #define XMA_MAX_LOGMSG_SIZE          255
 #define XMA_MAX_LOGMSG_Q_ENTRIES     128
 


### PR DESCRIPTION
Include 'linux/limits.h' conditionally in xmalogger.h. This is to resolve build issues observed while building xma plugins on CentOS and RHEL machines.

Please review.
@sarab96