### PR TITLE
Do not require P2P buffer to be resident on device

### DIFF
--- a/src/runtime_src/xocl/api/xlnx/xclGetMemObjectFd.cpp
+++ b/src/runtime_src/xocl/api/xlnx/xclGetMemObjectFd.cpp
@@ -48,8 +48,7 @@ clGetMemObjectFd(cl_mem mem,
   auto xmem = xocl(mem);
   auto context = xmem->get_context();
   for (auto device : context->get_device_range()) {
-    if (xmem->is_resident(device)) {
-      auto boh = xmem->get_buffer_object_or_error(device);
+    if (auto boh = xmem->get_buffer_object_or_null(device)) {
       *fd = device->get_xrt_device()->getMemObjectFd(boh);
       return CL_SUCCESS;
     }


### PR DESCRIPTION
The P2P exported buffer must be allocated (xclAlloc) but is not
required to be resident (xclSync) on device.

CR1023406