### PR TITLE
Support imported BO (P2P) copy via ert_start_copybo_cmd

### DIFF
--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -423,18 +423,12 @@ ert_fill_copybo_cmd(struct ert_start_copybo_cmd *pkt, uint32_t src_bo,
 static inline uint64_t
 ert_copybo_src_offset(struct ert_start_copybo_cmd *pkt)
 {
-  uint64_t off = pkt->src_addr_hi;
-  off <<= 32;
-  off |= pkt->src_addr_lo;
-  return off;
+  return (uint64_t)pkt->src_addr_hi << 32 | pkt->src_addr_lo;
 }
 static inline uint64_t
 ert_copybo_dst_offset(struct ert_start_copybo_cmd *pkt)
 {
-  uint64_t off = pkt->dst_addr_hi;
-  off <<= 32;
-  off |= pkt->dst_addr_lo;
-  return off;
+  return (uint64_t)pkt->dst_addr_hi << 32 | pkt->dst_addr_lo;
 }
 static inline uint64_t
 ert_copybo_size(struct ert_start_copybo_cmd *pkt)

--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -114,7 +114,7 @@ struct ert_start_copybo_cmd {
   uint32_t state:4;          /* [3-0], must be ERT_CMD_STATE_NEW */
   uint32_t unused:6;         /* [9-4] */
   uint32_t extra_cu_masks:2; /* [11-10], = 3 */
-  uint32_t count:11;         /* [22-12], = sizeof(ert_start_copybo_cmd)-1 */
+  uint32_t count:11;         /* [22-12], = 15, exclude 'arg' */
   uint32_t opcode:5;         /* [27-23], = ERT_START_COPYBO */
   uint32_t type:4;           /* [31-27], = ERT_DEFAULT */
   uint32_t cu_mask[4];       /* mandatory cu masks */
@@ -126,6 +126,7 @@ struct ert_start_copybo_cmd {
   uint32_t dst_addr_hi;      /* high 32 bit of dst addr */
   uint32_t dst_bo_hdl;       /* dst bo handle, cleared by driver */
   uint32_t size;             /* size in COPYBO_UNIT byte */
+  void     *arg;             /* pointer to aux data for KDS */
 };
 
 /**
@@ -394,13 +395,16 @@ enum ert_cmd_type {
 #define ERT_INTC_IAR_ADDR                 (ERT_INTC_ADDR + 0x0C) /* acknowledge */
 #define ERT_INTC_MER_ADDR                 (ERT_INTC_ADDR + 0x1C) /* master enable */
 
+/*
+ * Helper functions to hide details of ert_start_copybo_cmd
+ */
 static inline void
 ert_fill_copybo_cmd(struct ert_start_copybo_cmd *pkt, uint32_t src_bo,
   uint32_t dst_bo, uint64_t src_offset, uint64_t dst_offset, uint64_t size)
 {
   pkt->state = ERT_CMD_STATE_NEW;
   pkt->extra_cu_masks = 3;
-  pkt->count = sizeof (struct ert_start_copybo_cmd) / 4 - 1;
+  pkt->count = 15;
   pkt->opcode = ERT_START_COPYBO;
   pkt->type = ERT_DEFAULT;
   pkt->cu_mask[0] = 0;
@@ -414,6 +418,29 @@ ert_fill_copybo_cmd(struct ert_start_copybo_cmd *pkt, uint32_t src_bo,
   pkt->dst_addr_hi = (dst_offset >> 32) & 0xFFFFFFFF;
   pkt->dst_bo_hdl = dst_bo;
   pkt->size = size / COPYBO_UNIT;
+  pkt->arg = 0;
+}
+static inline uint64_t
+ert_copybo_src_offset(struct ert_start_copybo_cmd *pkt)
+{
+  uint64_t off = pkt->src_addr_hi;
+  off <<= 32;
+  off |= pkt->src_addr_lo;
+  return off;
+}
+static inline uint64_t
+ert_copybo_dst_offset(struct ert_start_copybo_cmd *pkt)
+{
+  uint64_t off = pkt->dst_addr_hi;
+  off <<= 32;
+  off |= pkt->dst_addr_lo;
+  return off;
+}
+static inline uint64_t
+ert_copybo_size(struct ert_start_copybo_cmd *pkt)
+{
+  uint64_t sz = pkt->size;
+  return sz * COPYBO_UNIT;
 }
 
 #endif

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -1493,7 +1493,16 @@ exec_execute_write_cmd(struct exec_core *exec, struct xocl_cmd* xcmd)
 static int
 exec_execute_copybo_cmd(struct exec_core *exec, struct xocl_cmd* xcmd)
 {
-	return 1; // error for now
+	int ret;
+	struct ert_start_copybo_cmd *ecmd =
+		(struct ert_start_copybo_cmd *)cmd_packet(xcmd);
+	struct drm_file *filp = (struct drm_file *)ecmd->arg;
+	struct drm_device *ddev = filp->minor->dev;
+
+	SCHED_DEBUGF("-> exec_copybo_cmd(%d,%lu)\n",exec->uid,xcmd->uid);
+	ret = xocl_copy_import_bo(ddev, filp, ecmd);
+	SCHED_DEBUG("<- exec_copybo\n");
+	return ret == 0 ? 0 : 1;
 }
 
 /*
@@ -2583,9 +2592,15 @@ static int get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 		userpf_err(xdev, "Failed to look up GEM BO 0x%x\n", bo_hdl);
 		return -ENOENT;
 	}
-	xobj = to_xocl_bo(obj);
 
-	if (obj->size <= off || obj->size < off + size || !xobj->mm_node) {
+	xobj = to_xocl_bo(obj);
+	if (!xobj->mm_node) {
+		/* Not a local BO */
+		drm_gem_object_unreference_unlocked(obj);
+		return -EADDRNOTAVAIL;
+	}
+
+	if (obj->size <= off || obj->size < off + size) {
 		userpf_err(xdev, "Failed to get paddr for BO 0x%x\n", bo_hdl);
 		drm_gem_object_unreference_unlocked(obj);
 		return -EINVAL;
@@ -2600,7 +2615,7 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	struct exec_core *exec, struct drm_xocl_bo *xobj)
 {
 	int i;
-	int ret;
+	int ret_src, ret_dst;
 	size_t src_off;
 	size_t dst_off;
 	size_t sz;
@@ -2613,22 +2628,33 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	if (scmd->opcode != ERT_START_COPYBO)
 		return 0;
 
-	sz = scmd->size * COPYBO_UNIT;
+	sz = ert_copybo_size(scmd);
 
-	src_off = scmd->src_addr_hi;
-	src_off <<= 32;
-	src_off |= scmd->src_addr_lo;
-	ret = get_bo_paddr(xdev, filp, scmd->src_bo_hdl, src_off, sz, &src_addr);
-	if (ret != 0)
-		return ret;
+	src_off = ert_copybo_src_offset(scmd);
+	ret_src = get_bo_paddr(xdev, filp, scmd->src_bo_hdl, src_off,
+		sz, &src_addr);
+	if (ret_src != 0 && ret_src != -EADDRNOTAVAIL)
+		return ret_src;
 
-	dst_off = scmd->dst_addr_hi;
-	dst_off <<= 32;
-	dst_off |= scmd->dst_addr_lo;
-	ret = get_bo_paddr(xdev, filp, scmd->dst_bo_hdl, dst_off, sz, &dst_addr);
-	if (ret != 0)
-		return ret;
+	dst_off = ert_copybo_dst_offset(scmd);
+	ret_dst = get_bo_paddr(xdev, filp, scmd->dst_bo_hdl, dst_off,
+		sz, &dst_addr);
+	if (ret_dst != 0 && ret_dst != -EADDRNOTAVAIL)
+		return ret_dst;
 
+	/* We need at least one local BO for copy */
+	if (ret_src == -EADDRNOTAVAIL && ret_dst == -EADDRNOTAVAIL)
+		return -EINVAL;
+
+	/* One of them is not local BO, perform P2P copy */
+	if (ret_src != ret_dst) {
+		/* Not a ERT cmd, make sure KDS will handle it. */
+		scmd->type = ERT_KDS_LOCAL;
+		scmd->arg = filp;
+		return 0;
+	}
+
+	/* Both BOs are local, copy via KDMA CU */
 	ert_fill_copybo_cmd(scmd, 0, 0, src_addr, dst_addr, sz);
 
 	for (i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++)

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -203,6 +203,7 @@ struct xocl_cmd
 	union {
 		struct ert_packet           *ecmd;
 		struct ert_start_kernel_cmd *kcmd;
+		struct ert_start_copybo_cmd *ccmd;
 	};
 
 	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
@@ -1494,8 +1495,7 @@ static int
 exec_execute_copybo_cmd(struct exec_core *exec, struct xocl_cmd* xcmd)
 {
 	int ret;
-	struct ert_start_copybo_cmd *ecmd =
-		(struct ert_start_copybo_cmd *)cmd_packet(xcmd);
+	struct ert_start_copybo_cmd *ecmd = xcmd->ccmd;
 	struct drm_file *filp = (struct drm_file *)ecmd->arg;
 	struct drm_device *ddev = filp->minor->dev;
 

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_bo.h
@@ -18,6 +18,7 @@
 #ifndef _XOCL_BO_H
 #define	_XOCL_BO_H
 
+#include <ert.h>
 #include "xocl_ioctl.h"
 #include "../xocl_drm.h"
 
@@ -103,8 +104,6 @@ int xocl_userptr_bo_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_sync_bo_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
-int xocl_copy_bo_ioctl(struct drm_device *dev, void *data,
-	struct drm_file *filp);
 int xocl_map_bo_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_info_bo_ioctl(struct drm_device *dev, void *data,
@@ -128,5 +127,7 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);
+int xocl_copy_import_bo(struct drm_device *dev, struct drm_file *filp,
+	struct ert_start_copybo_cmd *cmd);
 
 #endif

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
@@ -286,8 +286,6 @@ static const struct drm_ioctl_desc xocl_ioctls[] = {
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_EXECBUF, xocl_execbuf_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
-	DRM_IOCTL_DEF_DRV(XOCL_COPY_BO, xocl_copy_bo_ioctl,
-			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_HOT_RESET, xocl_hot_reset_ioctl,
 		  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_RECLOCK, xocl_reclock_ioctl,

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -379,9 +379,9 @@ struct xocl_dma_funcs {
 	SUBDEV(xdev, XOCL_SUBDEV_DMA).pldev
 #define	DMA_OPS(xdev)	\
 	((struct xocl_dma_funcs *)SUBDEV(xdev, XOCL_SUBDEV_DMA).ops)
-#define	xocl_migrate_bo(xdev, sgt, write, paddr, chan, len)	\
+#define	xocl_migrate_bo(xdev, sgt, to_dev, paddr, chan, len)	\
 	(DMA_DEV(xdev) ? DMA_OPS(xdev)->migrate_bo(DMA_DEV(xdev), \
-	sgt, write, paddr, chan, len) : 0)
+	sgt, to_dev, paddr, chan, len) : 0)
 #define	xocl_acquire_channel(xdev, dir)		\
 	(DMA_DEV(xdev) ? DMA_OPS(xdev)->ac_chan(DMA_DEV(xdev), dir) : \
 	-ENODEV)

--- a/src/runtime_src/driver/xclng/include/xocl_ioctl.h
+++ b/src/runtime_src/driver/xclng/include/xocl_ioctl.h
@@ -74,8 +74,6 @@
  *      interrupt
  * 13   Update device view with a specific     DRM_XOCL_READ_AXLF             drm_xocl_axlf
  *      xclbin image
- * 14   Write buffer from device to peer FPGA  DRM_IOCTL_XOCL_COPY_BO         drm_xocl_copy_bo
- *      buffer
  * ==== ====================================== ============================== ==================================
  */
 
@@ -146,8 +144,6 @@ enum drm_xocl_ops {
 	DRM_XOCL_USER_INTR,
 	/* Read xclbin/axlf */
 	DRM_XOCL_READ_AXLF,
-	/* Copy buffer to Destination buffer by using DMA */
-	DRM_XOCL_COPY_BO,
 	/* Hot reset request */
 	DRM_XOCL_HOT_RESET,
 	/* Reclock through userpf*/
@@ -170,6 +166,7 @@ enum drm_xocl_sync_bo_dir {
 #define DRM_XOCL_BO_BANK2   (0x1 << 2)
 #define DRM_XOCL_BO_BANK3   (0x1 << 3)
 
+#define DRM_XOCL_BO_IMPORT  (0x1 << 28)
 #define DRM_XOCL_BO_CMA     (0x1 << 29)
 #define DRM_XOCL_BO_P2P     (0x1 << 30)
 #define DRM_XOCL_BO_EXECBUF (0x1 << 31)
@@ -261,26 +258,6 @@ struct drm_xocl_info_bo {
 	uint64_t paddr;
 };
 
-/**
- * struct drm_xocl_copy_bo - copy source buffer to destination buffer
- * between device and device
- * used with DRM_IOCTL_XOCL_COPY_BO ioctl
- *
- * @dst_handle: destination bo handle
- * @src_handle: source bo handle
- * @flags:  Unused
- * @size: Number of bytes to synchronize
- * @dst_offset: Offset into the object to destination buffer to synchronize
- * @src_offset: Offset into the object to source buffer to synchronize
- */
-struct drm_xocl_copy_bo {
-  uint32_t dst_handle;
-  uint32_t src_handle;
-  uint32_t flags;
-  uint64_t size;
-  uint64_t dst_offset;
-  uint64_t src_offset;
-};
 /**
  * struct drm_xocl_axlf - load xclbin (AXLF) device image
  * used with DRM_IOCTL_XOCL_READ_AXLF ioctl
@@ -498,8 +475,6 @@ struct drm_xocl_reclock_info {
 					       DRM_XOCL_MAP_BO, struct drm_xocl_map_bo)
 #define DRM_IOCTL_XOCL_SYNC_BO	      DRM_IOW (DRM_COMMAND_BASE +       \
 					       DRM_XOCL_SYNC_BO, struct drm_xocl_sync_bo)
-#define DRM_IOCTL_XOCL_COPY_BO        DRM_IOW (DRM_COMMAND_BASE +       \
-                                               DRM_XOCL_COPY_BO, struct drm_xocl_copy_bo)
 #define DRM_IOCTL_XOCL_INFO_BO	      DRM_IOWR(DRM_COMMAND_BASE +       \
 					       DRM_XOCL_INFO_BO, struct drm_xocl_info_bo)
 #define DRM_IOCTL_XOCL_PWRITE_BO      DRM_IOW (DRM_COMMAND_BASE +       \


### PR DESCRIPTION
This is to support (P2P) copy of imported BO via ert_start_copybo_cmd, which is also used for KDMA copy. After this change, we should be able to start working on the support for KDMA and P2P BO copy through clEnqueueCopyBuffer() and remove xclCopyBO() API.