### PR TITLE
Add version and symlink for xdp and oclxdp

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -65,6 +65,9 @@ target_link_libraries(oclxdp
   xilinxopencl
  )
 
+set_target_properties(oclxdp PROPERTIES VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION})
+
 target_link_libraries(xilinxopencl
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -68,6 +68,9 @@ target_link_libraries(oclxdp
 set_target_properties(oclxdp PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+set_target_properties(xdp PROPERTIES VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION})
+
 target_link_libraries(xilinxopencl
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}


### PR DESCRIPTION
As requested, symlinks and versions are needed for the embedded side submission, so all the xdp libraries are now versioned the same as XRT.

Installation after the change:
```
libcommon_em.so        liboclxdp.so.2	   libxdp.so.2.2.0	     libxmaapi.so	 libxmaplugin.so.2	libxrt_aws.so.2.2.0   libxrt_hwemu.so	     libxrt_swemu.so.2
libcommon_em.so.2      liboclxdp.so.2.2.0  libxilinxopencl.so	     libxmaapi.so.2	 libxmaplugin.so.2.2.0	libxrt_core.so	      libxrt_hwemu.so.2      libxrt_swemu.so.2.2.0
libcommon_em.so.2.2.0  libxdp.so	   libxilinxopencl.so.2      libxmaapi.so.2.2.0  libxrt_aws.so		libxrt_core.so.2      libxrt_hwemu.so.2.2.0
liboclxdp.so	       libxdp.so.2	   libxilinxopencl.so.2.2.0  libxmaplugin.so	 libxrt_aws.so.2	libxrt_core.so.2.2.0  libxrt_swemu.so
```