### PR TITLE
fix for correctly picking sdaccel.ini

### DIFF
--- a/src/runtime_src/driver/common/config_reader.cpp
+++ b/src/runtime_src/driver/common/config_reader.cpp
@@ -51,19 +51,19 @@ get_self_path()
 static std::string
 get_ini_path()
 {
-  auto ini_path = boost::filesystem::path(valueOrEmpty(std::getenv("SDACCEL_INI_PATH")));
-  // Support SDACCEL_INI_PATH with/without actual filename
-  if (ini_path.filename() != "sdaccel.ini")
-    ini_path /= "sdaccel.ini";
-  if (boost::filesystem::exists(ini_path))
-    return ini_path.string();
-  auto exe_path = boost::filesystem::path(get_self_path()).parent_path()/"sdaccel.ini";
-  if (boost::filesystem::exists(exe_path))
-    return exe_path.string();
-  auto self_path = boost::filesystem::current_path()/"sdaccel.ini";
   try {
-    if (boost::filesystem::exists(self_path))
-      return self_path.string();
+    auto ini_path = boost::filesystem::path(valueOrEmpty(std::getenv("SDACCEL_INI_PATH")));
+    // Support SDACCEL_INI_PATH with/without actual filename
+    if (ini_path.filename() != "sdaccel.ini")
+      ini_path /= "sdaccel.ini";
+    if (boost::filesystem::exists(ini_path))
+      return ini_path.string();
+    auto exe_path = boost::filesystem::path(get_self_path()).parent_path()/"sdaccel.ini";
+    if (boost::filesystem::exists(exe_path))
+      return exe_path.string();
+    auto self_path = boost::filesystem::current_path()/"sdaccel.ini";
+      if (boost::filesystem::exists(self_path))
+        return self_path.string();
   }  catch (const boost::filesystem::filesystem_error& e){ }
 
   return "";


### PR DESCRIPTION
This is a fix to correctly catch the file does not exist error. Without this, "xbutil flash scan" gives files not found error if the user does not have all permissions to the directory