### PR TITLE
Fix linking with Boost

### DIFF
--- a/src/runtime_src/driver/common_em/CMakeLists.txt
+++ b/src/runtime_src/driver/common_em/CMakeLists.txt
@@ -40,8 +40,8 @@ set_target_properties(common_em PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
 target_link_libraries(common_em
-  ${BOOST_FILESYSTEM_LIBRARY}
-  ${BOOST_SYSTEM_LIBRARY}
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   dl
   pthread

--- a/src/runtime_src/driver/cpu_em/CMakeLists.txt
+++ b/src/runtime_src/driver/cpu_em/CMakeLists.txt
@@ -30,8 +30,8 @@ set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
 target_link_libraries(xrt_swemu
-  ${BOOST_FILESYSTEM_LIBRARY}
-  ${BOOST_SYSTEM_LIBRARY}
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   common_em
   rt

--- a/src/runtime_src/driver/hw_em/CMakeLists.txt
+++ b/src/runtime_src/driver/hw_em/CMakeLists.txt
@@ -31,8 +31,8 @@ set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
 target_link_libraries(xrt_hwemu
-  ${BOOST_FILESYSTEM_LIBRARY}
-  ${BOOST_SYSTEM_LIBRARY}
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   ${PROTOBUF_LIBRARY}
   common_em
   rt


### PR DESCRIPTION
Since inception linking with Boost in emulation libraries was wrong.
But only recently was Boost symbols actually required.

CR1023957

(cherry picked from commit 86957e4b2604553a507c8a8feadb0419331122cf)