### PR TITLE
Automapping DDR Banks (2018.3)

### DIFF
--- a/src/runtime_src/driver/include/xclbin.h
+++ b/src/runtime_src/driver/include/xclbin.h
@@ -201,17 +201,17 @@ extern "C" {
 
     /****   MEMORY TOPOLOGY SECTION ****/
     struct mem_data {
-	uint8_t m_type; //enum corresponding to mem_type.
-	uint8_t m_used; //if 0 this bank is not present
-	union {
-	    uint64_t m_size; //if mem_type DDR, then size in KB;
-	    uint64_t route_id; //if streaming then "route_id"
-	};
-	union {
-	    uint64_t m_base_address;//if DDR then the base address;
-	    uint64_t flow_id; //if streaming then "flow id"
-	};
-	unsigned char m_tag[16]; //DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
+        uint8_t m_type; //enum corresponding to mem_type.
+        uint8_t m_used; //if 0 this bank is not present
+        union {
+            uint64_t m_size; //if mem_type DDR, then size in KB;
+            uint64_t route_id; //if streaming then "route_id"
+        };
+        union {
+            uint64_t m_base_address;//if DDR then the base address;
+            uint64_t flow_id; //if streaming then "flow id"
+        };
+        unsigned char m_tag[16]; //DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
     };
 
     struct mem_topology {

--- a/src/xma/include/lib/xmaxclbin.h
+++ b/src/xma/include/lib/xmaxclbin.h
@@ -32,11 +32,35 @@ typedef struct XmaIpLayout
     uint32_t     reserved[16];
 } XmaIpLayout;
 
+typedef struct XmaMemTopology
+{
+    uint8_t       m_type;
+    uint8_t       m_used;
+    uint64_t      m_size;
+    uint64_t      m_base_address;
+    unsigned char m_tag[16];
+} XmaMemTopology;
+
+typedef struct XmaAXLFConnectivity
+{
+    int32_t arg_index;
+    int32_t m_ip_layout_index;
+    int32_t mem_data_index;
+} XmaAXLFConnectivity;
+
 typedef struct XmaXclbinInfo
 {
-    char        xclbin_name[PATH_MAX + NAME_MAX];
-    uint16_t    freq_list[MAX_KERNEL_FREQS];
-    XmaIpLayout ip_layout[MAX_KERNEL_CONFIGS];
+    char                xclbin_name[PATH_MAX + NAME_MAX];
+    uint16_t            freq_list[MAX_KERNEL_FREQS];
+    XmaIpLayout         ip_layout[MAX_KERNEL_CONFIGS];
+    //TODO HHS Change the limits to be appropriate
+    XmaMemTopology      mem_topology[MAX_DDR_MAP];
+    XmaAXLFConnectivity connectivity[MAX_CONNECTION_ENTRIES];
+    uint32_t            number_of_kernels;
+    uint32_t            number_of_mem_banks;
+    uint32_t            number_of_connections;
+    //uint16_t bitmap based on MAX_DDR_MAP=16
+    uint16_t            ip_ddr_mapping[MAX_KERNEL_CONFIGS];
     //For execbo:
     uint32_t    num_ips;
     uuid_t      uuid;
@@ -45,5 +69,5 @@ typedef struct XmaXclbinInfo
 
 char *xma_xclbin_file_open(const char *xclbin_name);
 int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info);
-
+int xma_xclbin_map2ddr(uint16_t bit_map, int* ddr_banks, int* num_banks);
 #endif

--- a/src/xma/src/xmaapi/xmacfg.c
+++ b/src/xma/src/xmaapi/xmacfg.c
@@ -94,7 +94,7 @@ static XmaSystemCfgSM systemcfg_sm[] = {
 { "plugin",        &set_plugin,        true },
 { "vendor",        &set_vendor,        true },
 { "name",          &set_name,          true },
-{ "ddr_map",       &set_ddr_map,       true },
+{ "ddr_map",       &set_ddr_map,       false },
 { NULL,            NULL},
 };
 
@@ -313,6 +313,8 @@ int set_name(XmaData *data)
 
 int set_ddr_map(XmaData *data)
 {
+    xma_cfg_log_err("ddr_map field found in cfg file. This is depricated\n");
+    xma_cfg_log_err("This will be ignored and it will be derived from xclbin!\n");
     yaml_node_t *next_node;
     int          i = data->imagecfg_idx;
     int          k = data->kernelcfg_idx;
@@ -331,8 +333,8 @@ int set_ddr_map(XmaData *data)
         if (is_end_of_num_sequence(next_node))
             break;
 
-        data->systemcfg->imagecfg[i].kernelcfg[k].ddr_map[m] =
-            atoi((const char*)next_node->data.scalar.value);
+        // data->systemcfg->imagecfg[i].kernelcfg[k].ddr_map[m] =
+        //     atoi((const char*)next_node->data.scalar.value);
     }
 
     if (m < instances - 1)
@@ -342,34 +344,6 @@ int set_ddr_map(XmaData *data)
         return XMA_ERROR_INVALID;
     }
 
-    /* The next node could be any of the following possibilities:
-     * NULL = end of configuration - we are done
-     * key = "instances" - we have one or more kernels to configure
-     * key = "ImageCfg" - we have one or more images to configure
-    */
-    next_node = get_next_scalar_node(data->document, &data->node_idx);
-    if (!next_node)
-        data->state_idx++;
-    else if (isdigit(next_node->data.scalar.value[0]))
-    {
-        xma_cfg_log_err("Number of items in ddr_map greater than expected\n");
-        return XMA_ERROR_INVALID;
-    }
-    else
-    {
-        data->state_idx =
-            find_state_entry((char*)next_node->data.scalar.value);
-
-        if (strcmp("instances",
-                   (const char*)next_node->data.scalar.value) == 0)
-        {
-            data->kernelcfg_idx++;
-            data->systemcfg->imagecfg[i].num_kernelcfg_entries++;
-        }
-    }
-
-    /* Backup to previous node */
-    data->node_idx--;
     return XMA_SUCCESS;
 }
 
@@ -446,7 +420,7 @@ int run_state_machine(yaml_document_t *document,
     data.kernelcfg_idx = -1;
 
     state_entry = &systemcfg_sm[data.state_idx];
-    
+
 
     while (state_entry->key)
     {
@@ -467,11 +441,39 @@ int run_state_machine(yaml_document_t *document,
                 continue;
             }
                 return XMA_ERROR;
-        } 
+        }
         get_next = true;
         rc = state_entry->transition(&data);
         if (rc == XMA_ERROR)
             break;
+
+        /* The next node could be any of the following possibilities:
+         * NULL = end of configuration - we are done
+         * key = "instances" - we have one or more kernels to configure
+         * key = "ImageCfg" - we have one or more images to configure
+         */
+        yaml_node_t *next_node;
+        int          i = data.imagecfg_idx;
+        if(!strcmp(state_entry->key,"name") || !strcmp(state_entry->key,"ddr_map"))
+        {
+            next_node = get_next_scalar_node(data.document, &data.node_idx);
+            if (!next_node)
+                data.state_idx++;
+            else
+            {
+                data.state_idx =
+                    find_state_entry((char*)next_node->data.scalar.value);
+
+                if (strcmp("instances",
+                        (const char*)next_node->data.scalar.value) == 0)
+                {
+                    data.kernelcfg_idx++;
+                    data.systemcfg->imagecfg[i].num_kernelcfg_entries++;
+                }
+                /* Backup to previous node */
+                data.node_idx--;
+            }
+        }
         data.key_no++;
         state_entry = &systemcfg_sm[data.state_idx];
     }

--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -26,17 +26,19 @@
 #include <xclhal2.h>
 //#include <xclbin.h>
 #include "app/xmaerror.h"
+#include "app/xmalogger.h"
 #include "lib/xmaxclbin.h"
 #include "lib/xmahw_hal.h"
 #include "lib/xmahw_private.h"
-
 #include <dlfcn.h>
 #include <iostream>
 #include "ert.h"
+
+//#define xma_logmsg(f_, ...) printf((f_), ##__VA_ARGS__)
+#define XMAAPI_MOD "xmahw_hal"
+
 using namespace std;
 const uint64_t mNullBO = 0xffffffff;
-
-#define xma_logmsg(f_, ...) printf((f_), ##__VA_ARGS__)
 
 typedef struct XmaHALDevice
 {
@@ -111,7 +113,7 @@ int32_t create_contexts(xclDeviceHandle handle, XmaXclbinInfo &info)
     {
         if (xclOpenContext(handle, info.uuid, i, true) != 0)
         {
-            xma_logmsg("Failed to open context\n");
+            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Failed to open context\n");
             return XMA_ERROR;
         }
     }
@@ -125,26 +127,26 @@ int hal_probe(XmaHwCfg *hwcfg)
     XmaHALDevice   xlnx_devices[MAX_XILINX_DEVICES];
     uint32_t       device_count;
 
-    xma_logmsg("Using HAL layer\n");
+    xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "Using HAL layer\n");
 
     int32_t      rc = 0;
 
     device_count = xclProbe();
 	if (device_count == 0) 
     {
-        xma_logmsg("ERROR: No Xilinx device found\n");
+        xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "ERROR: No Xilinx device found\n");
         return XMA_ERROR;
 	}
     for (uint32_t i = 0; i < device_count; i++)
     {
         xlnx_devices[i].handle = xclOpen(i, NULL, XCL_QUIET);
         xlnx_devices[i].dev_index = i;
-        xma_logmsg("get_device_list xclOpen handle = %p\n",
+        xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "get_device_list xclOpen handle = %p\n",
             xlnx_devices[i].handle);
         rc = xclGetDeviceInfo2(xlnx_devices[i].handle, &xlnx_devices[i].info);
         if (rc != 0)
         {
-            xma_logmsg("xclGetDeviceInfo2 failed for device id: %d, rc=%d\n",
+            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "xclGetDeviceInfo2 failed for device id: %d, rc=%d\n",
                         i, rc);
             return XMA_ERROR;
         }
@@ -172,9 +174,9 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
     if (num_devices_requested > hwcfg->num_devices ||
         max_dev_id > (hwcfg->num_devices - 1))
     {
-        xma_logmsg("Requested %d devices but only %d devices found\n",
+        xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "Requested %d devices but only %d devices found\n",
                    num_devices_requested, hwcfg->num_devices);
-        xma_logmsg("Max device id specified in YAML cfg %d\n", max_dev_id);
+        xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "Max device id specified in YAML cfg %d\n", max_dev_id);
         return false;
     }
 
@@ -183,7 +185,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
     {
         if (strcmp(systemcfg->dsa, hwcfg->devices[i].dsa) != 0)
         {
-            xma_logmsg("DSA mismatch: requested %s found %s\n",
+            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "DSA mismatch: requested %s found %s\n",
                        systemcfg->dsa, hwcfg->devices[i].dsa);
             return false;
         }
@@ -196,7 +198,6 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
 {
     std::string   xclbinpath = systemcfg->xclbinpath;
     XmaXclbinInfo info;
-    int32_t ddr_table[] = {0, 3, 1, 2};
 
     /* Download the requested image to the associated device */
     for (int32_t i = 0; i < systemcfg->num_images; i++)
@@ -206,14 +207,14 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
         char *buffer = xma_xclbin_file_open(xclfullname.c_str());
         if (!buffer)
         {
-            xma_logmsg("Could not open xclbin file %s\n",
+            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not open xclbin file %s\n",
                        xclfullname.c_str());
             return false;
         }
         int32_t rc = xma_xclbin_info_get(buffer, &info);
         if (rc != XMA_SUCCESS)
         {
-            xma_logmsg("Could not get info for xclbin file %s\n",
+            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not get info for xclbin file %s\n",
                        xclfullname.c_str());
             free(buffer);
             return false;
@@ -234,12 +235,21 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
                 {
                     strcpy((char*)hwcfg->devices[dev_id].kernels[t].name,
                        (const char*)info.ip_layout[t].kernel_name);
+                    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD,"[%d] %s \t",
+                               t, hwcfg->devices[dev_id].kernels[t].name);
                     hwcfg->devices[dev_id].kernels[t].base_address =
                        info.ip_layout[t].base_addr;
-                    int32_t ddr_bank = systemcfg->imagecfg[i].kernelcfg[k].ddr_map[x];
-                    hwcfg->devices[dev_id].kernels[t].ddr_bank = ddr_table[ddr_bank];
-                    printf("ddr_table value = %d\n",
-                        hwcfg->devices[dev_id].kernels[t].ddr_bank);
+                    int32_t ip_ddr_map = info.ip_ddr_mapping[t];
+                    int num_ddr_used = 0;
+                    int ddr_banks[MAX_DDR_MAP] = {-1};
+                    xma_xclbin_map2ddr(ip_ddr_map, ddr_banks, &num_ddr_used);
+                    for(int d=0; d < num_ddr_used; d++)
+                    {
+                        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "[%d] ddr_table value-xclbin = %d\n",
+                        t, ddr_banks[d]);
+                    }
+                    //HHS currently the support is just for 1 Bank per 1 Kernel support
+                    hwcfg->devices[dev_id].kernels[t].ddr_bank = ddr_banks[0];
                 }
             }
 
@@ -248,7 +258,7 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
             free(buffer);
             if (rc != 0)
             {
-                xma_logmsg("Could not download xclbin file %s to device %d\n",
+                xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not download xclbin file %s to device %d\n",
                            xclfullname.c_str(),
                            systemcfg->imagecfg[i].device_id_map[d]);
                 return false;
@@ -282,12 +292,12 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
                     }
                     if (!found) 
                     {
-                        xma_logmsg("ERROR: CU not found. Couldn't create cu_cmd execbo\n");
+                        xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "CU not found. Couldn't create cu_cmd execbo\n");
                         return false;
                     }
                     if (cu_bit_mask == 0) 
                     {
-                        xma_logmsg("ERROR: XMA library doesn't support more than 32 CUs\n");
+                        xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "XMA library doesn't support more than 32 CUs\n");
                         return false;
                     }
                     for (int i_execbo = 0; i_execbo < MAX_EXECBO_POOL_SIZE; i_execbo++) 
@@ -302,7 +312,7 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
                                                execBO_flags);
                         if (!bo_handle || bo_handle == mNullBO) 
                         {
-                            xma_logmsg("ERROR: Unable to create bo for cu start\n");
+                            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Unable to create bo for cu start\n");
                             return false;
                         }
                         bo_data = (char*)xclMapBO(hal->dev_handle, bo_handle, true);

--- a/src/xma/src/xmaapi/xmaxclbin.cpp
+++ b/src/xma/src/xmaapi/xmaxclbin.cpp
@@ -19,18 +19,21 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-//#include <xclbin.h>
+#include "xclbin.h"
 #include "app/xmaerror.h"
+#include "app/xmalogger.h"
 #include "lib/xmaxclbin.h"
 
-#define xma_logmsg(f_, ...) printf((f_), ##__VA_ARGS__)
+#define XMAAPI_MOD "xmaxclbin"
 
 /* Private function */
-//static int get_xclbin_iplayout(char *buffer, XmaIpLayout *layout);
+static int get_xclbin_iplayout(char *buffer, XmaXclbinInfo *xclbin_info);
+static int get_xclbin_mem_topology(char *buffer, XmaXclbinInfo *xclbin_info);
+static int get_xclbin_connectivity(char *buffer, XmaXclbinInfo *xclbin_info);
 
 char *xma_xclbin_file_open(const char *xclbin_name)
 {
-    xma_logmsg("Loading %s\n", xclbin_name);
+    xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "Loading %s\n", xclbin_name);
 
     std::ifstream file(xclbin_name, std::ios::binary | std::ios::ate);
     std::streamsize size = file.tellg();
@@ -39,7 +42,7 @@ char *xma_xclbin_file_open(const char *xclbin_name)
     char *buffer = (char*)malloc(size);
     if (!file.read(buffer, size))
     {
-        xma_logmsg("Could not read file %s\n", xclbin_name);
+        xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not read file %s\n", xclbin_name);
         free(buffer);
         buffer = NULL;
     }
@@ -47,38 +50,153 @@ char *xma_xclbin_file_open(const char *xclbin_name)
     return buffer;
 }
 
-int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info)
+static int get_xclbin_iplayout(char *buffer, XmaXclbinInfo *xclbin_info)
 {
+    //int rc = XMA_SUCCESS;
     axlf *xclbin = reinterpret_cast<axlf *>(buffer);
 
-    const axlf_section_header *ip_hdr = xclbin::get_axlf_section(xclbin,
-                                                                IP_LAYOUT);
+    const axlf_section_header *ip_hdr = xclbin::get_axlf_section(xclbin, IP_LAYOUT);
     if (ip_hdr)
     {
         char *data = &buffer[ip_hdr->m_sectionOffset];
         const ip_layout *ipl = reinterpret_cast<ip_layout *>(data);
-        //For execbo:
-        info->num_ips = 0; 
+        XmaIpLayout* layout = xclbin_info->ip_layout;
+        xclbin_info->number_of_kernels = ipl->m_count;
+        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "IP LAYOUT - %d kernels\n", xclbin_info->number_of_kernels);
         for (int i = 0; i < ipl->m_count; i++)
         {
             if (ipl->m_ip_data[i].m_type != IP_KERNEL)
                 continue;
-            memcpy(info->ip_layout[i].kernel_name,
+            memcpy(xclbin_info->ip_layout[i].kernel_name,
                    ipl->m_ip_data[i].m_name, MAX_KERNEL_NAME);
-            info->ip_layout[i].base_addr = ipl->m_ip_data[i].m_base_address;
-            printf("kernel name = %s, base_addr = %lx\n",
-                   info->ip_layout[i].kernel_name,
-                   info->ip_layout[i].base_addr);
-            info->num_ips++;
+            layout[i].base_addr = ipl->m_ip_data[i].m_base_address;
+            xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "index = %d, kernel name = %s, base_addr = %lx\n",
+                    i, layout[i].kernel_name, layout[i].base_addr);
         }
     }
     else
     {
-        printf("Could not find IP_LAYOUT in xclbin ip_hdr=%p\n", ip_hdr);
+        xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not find IP_LAYOUT in xclbin ip_hdr=%p\n", ip_hdr);
+        //rc = XMA_ERROR;
         return XMA_ERROR;
     }
 
-    uuid_copy(info->uuid, xclbin->m_header.uuid); 
+    uuid_copy(xclbin_info->uuid, xclbin->m_header.uuid); 
 
+    return XMA_SUCCESS;
+}
+
+static int get_xclbin_mem_topology(char *buffer, XmaXclbinInfo *xclbin_info)
+{
+    //int rc = XMA_SUCCESS;
+    axlf *xclbin = reinterpret_cast<axlf *>(buffer);
+
+    const axlf_section_header *ip_hdr = xclbin::get_axlf_section(xclbin, MEM_TOPOLOGY);
+    if (ip_hdr)
+    {
+        char *data = &buffer[ip_hdr->m_sectionOffset];
+        const mem_topology *mem_topo = reinterpret_cast<mem_topology *>(data);
+        XmaMemTopology *topology = xclbin_info->mem_topology;
+        xclbin_info->number_of_mem_banks = mem_topo->m_count;
+        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "MEM TOPOLOGY - %d banks\n",xclbin_info->number_of_mem_banks);
+        for (int i = 0; i < mem_topo->m_count; i++)
+        {
+            topology[i].m_type = mem_topo->m_mem_data[i].m_type;
+            topology[i].m_used = mem_topo->m_mem_data[i].m_used;
+            topology[i].m_size = mem_topo->m_mem_data[i].m_size;
+            topology[i].m_base_address = mem_topo->m_mem_data[i].m_base_address;
+            //HHS change limits from MAX_DDR_MAP = 16 if needed
+            memcpy(topology[i].m_tag, mem_topo->m_mem_data[i].m_tag, MAX_DDR_MAP*sizeof(unsigned char));
+            xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "index=%d, tag=%s, type = %d, used = %d, size = %lx, base = %lx\n",
+                   i,topology[i].m_tag, topology[i].m_type, topology[i].m_used,
+                   topology[i].m_size, topology[i].m_base_address);
+        }
+    }
+    else
+    {
+        printf("Could not find MEM_TOPOLOGY in xclbin ip_hdr=%p\n", ip_hdr);
+        return XMA_ERROR;
+    }
+
+    return XMA_SUCCESS;
+}
+
+static int get_xclbin_connectivity(char *buffer, XmaXclbinInfo *xclbin_info)
+{
+    //int rc = XMA_SUCCESS;
+    axlf *xclbin = reinterpret_cast<axlf *>(buffer);
+
+    const axlf_section_header *ip_hdr = xclbin::get_axlf_section(xclbin, CONNECTIVITY);
+    if (ip_hdr)
+    {
+        char *data = &buffer[ip_hdr->m_sectionOffset];
+        const connectivity *axlf_conn = reinterpret_cast<connectivity *>(data);
+        XmaAXLFConnectivity *xma_conn = xclbin_info->connectivity;
+        xclbin_info->number_of_connections = axlf_conn->m_count;
+        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "CONNECTIVITY - %d connections\n",xclbin_info->number_of_connections);
+        for (int i = 0; i < axlf_conn->m_count; i++)
+        {
+            xma_conn[i].arg_index         = axlf_conn->m_connection[i].arg_index;
+            xma_conn[i].m_ip_layout_index = axlf_conn->m_connection[i].m_ip_layout_index;
+            xma_conn[i].mem_data_index    = axlf_conn->m_connection[i].mem_data_index;
+            xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "index = %d, arg_idx = %d, ip_idx = %d, mem_idx = %d\n",
+                     i, xma_conn[i].arg_index, xma_conn[i].m_ip_layout_index,
+                     xma_conn[i].mem_data_index);
+        }
+    }
+    else
+    {
+        xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not find CONNECTIVITY in xclbin ip_hdr=%p\n", ip_hdr);
+        return XMA_ERROR;
+    }
+
+    return XMA_SUCCESS;
+}
+
+int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info)
+{
+    int rc = 0;
+    rc = get_xclbin_mem_topology(buffer, info);
+    if(rc == XMA_ERROR)
+        return rc;
+    rc = get_xclbin_connectivity(buffer, info);
+    if(rc == XMA_ERROR)
+        return rc;
+    rc = get_xclbin_iplayout(buffer, info);
+    if(rc == XMA_ERROR)
+        return rc;
+
+    uint16_t map[MAX_KERNEL_CONFIGS] = {};
+    for(uint32_t c = 0; c < info->number_of_connections; c++)
+    {
+        XmaAXLFConnectivity *xma_conn = &info->connectivity[c];
+        map[xma_conn->m_ip_layout_index] |= 1 << (xma_conn->mem_data_index + 1);
+    }
+    memcpy(info->ip_ddr_mapping,map,MAX_KERNEL_CONFIGS*sizeof(uint16_t));
+    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "\nCONNECTIONS (bitmap 15<-0)\n");
+    for(uint32_t i = 0; i < info->number_of_kernels; i++)
+    {
+        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "%s - 0x%04x\n",info->ip_layout[i].kernel_name, info->ip_ddr_mapping[i]);
+    }
+    //For execbo:
+    info->num_ips = info->number_of_kernels;
+    return XMA_SUCCESS;
+}
+
+int xma_xclbin_map2ddr(uint16_t bit_map, int* ddr_banks, int* num_banks)
+{
+    //TODO HHS Based on uint16_t bitmap considering 16 DDRs as max
+    int ddr_bank_idx = -1;
+    int count = 0;
+    while (bit_map != 0)
+    {
+        ddr_bank_idx++;
+        if (bit_map & 1)
+        {
+            ddr_banks[count++]=ddr_bank_idx-1;
+        }
+        bit_map = bit_map >> 1;
+    }
+    *num_banks = count;
     return XMA_SUCCESS;
 }


### PR DESCRIPTION
 This commit removes reading DDR mapping from the configuration file. Instead it reads the xclbin for IPLayout, Mem Topology and Connectivity axlf sections and finds correct mapping automatically.

Also added xma logging support for some legacy printfs

Limitation:
- Supports 16 DDR Banks Max
- Supports 1 Kernel to 1 DDR Mapping at present