### PR TITLE
Virtual CU context

### DIFF
--- a/src/runtime_src/driver/common/scheduler.cpp
+++ b/src/runtime_src/driver/common/scheduler.cpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 #include <cstring>
+#include <uuid/uuid.h>
 
 // This is interim, must be consolidated with runtime_src/xrt/scheduler
 // when XRT C++ code is refactored.
@@ -146,6 +147,7 @@ namespace xrt_core { namespace scheduler {
 int
 init(xclDeviceHandle handle, const axlf* top)
 {
+  uuid_t uuid;
   auto execbo = create_exec_bo(handle,0x1000);
   auto ecmd = reinterpret_cast<ert_configure_cmd*>(execbo->data);
   ecmd->state = ERT_CMD_STATE_NEW;
@@ -167,12 +169,18 @@ init(xclDeviceHandle handle, const axlf* top)
   std::copy(cus.begin(), cus.end(), ecmd->data);
   ecmd->count = 5 + cus.size();
 
+  uuid_copy(uuid, top->m_header.uuid);
+  if (xclOpenContext(handle,uuid,-1,true))
+    throw std::runtime_error("unable to reserve virtual CU");
+
   if (xclExecBuf(handle,execbo->bo))
     throw std::runtime_error("unable to issue xclExecBuf");
 
   // wait for command to complete
   while (ecmd->state < ERT_CMD_STATE_COMPLETED)
     while (xclExecWait(handle,1000)==0) ;
+
+  (void) xclCloseContext(handle,uuid,-1);
 
   return 0;
 }

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/icap.c
@@ -1777,24 +1777,12 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 
 		need_download = (icap->icap_bitstream_id != xclbin->m_uniqueId);
 
-		if (!need_download) {
-			/*
-			 * No need to download, if xclbin exists already.
-			 * But, still need to reset CUs.
-			 */
-			if (!icap_bitstream_in_use(icap, 0)) {
-				icap_freeze_axi_gate(icap);
-				msleep(50);
-				icap_free_axi_gate(icap);
-				msleep(50);
-			}
-			ICAP_INFO(icap, "bitstream already exists, skip downloading");
-		}
-
 		mutex_unlock(&icap->icap_lock);
 
-		if (!need_download)
+		if(!need_download) {
+			ICAP_INFO(icap, "bitstream exists, skip downloading");
 			return 0;
+		}
 
 		/*
 		 * Find sections in xclbin.

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/common.h
@@ -106,28 +106,27 @@ struct xocl_dev	{
  * struct client_ctx: Manage user space client attached to device
  *
  * @link: Client context is added to list in device
- * @xclbin_id: UUID for xclbin loaded by client, or nullid if no xclbin loaded
- * @xclbin_locked: Flag to denote that this context locked the xclbin
  * @trigger: Poll wait counter for number of completed exec buffers
  * @outstanding_execs: Counter for number outstanding exec buffers
  * @abort: Flag to indicate that this context has detached from user space (ctrl-c)
  * @num_cus: Number of resources (CUs) explcitly aquired
  * @lock: Mutex lock for exclusive access
  * @cu_bitmap: CUs reserved by this context, may contain implicit resources
+ * @virt_cu_ref: ref count for implicit resources reserved by this context.
  */
 struct client_ctx {
 	struct list_head	link;
-	xuid_t                  xclbin_id;
-	unsigned int            xclbin_locked;
 	unsigned int            abort;
-	unsigned int            num_cus;     /* number of resource locked explicitly by client */
-	atomic_t 		trigger;     /* count of poll notification to acknowledge */
+	unsigned int            num_cus;
+	atomic_t 		trigger;
 	atomic_t                outstanding_execs;
 	struct mutex		lock;
 	struct xocl_dev        *xdev;
-	DECLARE_BITMAP(cu_bitmap, MAX_CUS);  /* may contain implicitly aquired resources such as CDMA */
+	DECLARE_BITMAP		(cu_bitmap, MAX_CUS);
 	struct pid             *pid;
+	unsigned int		virt_cu_ref;
 };
+#define	CLIENT_NUM_CU_CTX(client) ((client)->num_cus + (client)->virt_cu_ref)
 
 struct xocl_mm_wrapper {
   struct drm_mm *mm;

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_ioctl.c
@@ -236,7 +236,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		memcpy(&bin_obj.m_header.uuid, &bin_obj.m_header.m_timeStamp, 8);
 	}
 
-	xclbin_id = (xuid_t *)xocl_icap_get_data(xdev, XCLBIN_UUID);
+	xclbin_id = XOCL_XCLBIN_ID(xdev);
 	if (!xclbin_id)
 		return -EINVAL;
 	/*
@@ -353,21 +353,10 @@ int xocl_read_axlf_ioctl(struct drm_device *dev,
 	struct drm_xocl_axlf *axlf_obj_ptr = data;
 	struct xocl_drm *drm_p = dev->dev_private;
 	struct xocl_dev *xdev = drm_p->xdev;
-	struct client_ctx *client = filp->driver_priv;
 	int err = 0;
-	xuid_t *xclbin_id;
 
 	mutex_lock(&xdev->ctx_list_lock);
 	err = xocl_read_axlf_helper(drm_p, axlf_obj_ptr);
-	/*
-	 * Record that user land configured this context for current device xclbin
-	 * It doesn't mean that the context has a lock on the xclbin, only that
-	 * when a lock is eventually acquired it can be verified to be against to
-	 * be a lock on expected xclbin
-	 */
-	xclbin_id = (xuid_t *)xocl_icap_get_data(xdev, XCLBIN_UUID);
-	uuid_copy(&client->xclbin_id,
-			((err || !xclbin_id) ? &uuid_null : xclbin_id));
 	mutex_unlock(&xdev->ctx_list_lock);
 	return err;
 }

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_sysfs.c
@@ -26,7 +26,7 @@ static ssize_t xclbinuuid_show(struct device *dev,
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 	xuid_t *xclbin_id;
 
-	xclbin_id = (xuid_t *)xocl_icap_get_data(xdev, XCLBIN_UUID);
+	xclbin_id = XOCL_XCLBIN_ID(xdev);
 	return sprintf(buf, "%pUb\n", xclbin_id ? xclbin_id : 0);
 }
 
@@ -59,7 +59,7 @@ static ssize_t kdsstat_show(struct device *dev,
 	int size;
 	xuid_t *xclbin_id;
 
-	xclbin_id = (xuid_t *)xocl_icap_get_data(xdev, XCLBIN_UUID);
+	xclbin_id = XOCL_XCLBIN_ID(xdev);
 	size = sprintf(buf,
 			   "xclbin:\t\t\t%pUb\noutstanding execs:\t%d\ntotal execs:\t\t%ld\ncontexts:\t\t%d\n",
 			   xclbin_id ? xclbin_id : 0,

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -411,11 +411,11 @@ struct xocl_mb_scheduler_funcs {
 	-ENODEV)
 
 #define XOCL_MEM_TOPOLOGY(xdev)						\
-	((struct mem_topology *)					\
-	xocl_icap_get_data(xdev, MEMTOPO_AXLF))
+	((struct mem_topology *)xocl_icap_get_data(xdev, MEMTOPO_AXLF))
 #define XOCL_IP_LAYOUT(xdev)						\
-	((struct ip_layout *)						\
-	xocl_icap_get_data(xdev, IPLAYOUT_AXLF))
+	((struct ip_layout *)xocl_icap_get_data(xdev, IPLAYOUT_AXLF))
+#define XOCL_XCLBIN_ID(xdev)						\
+	((xuid_t *)xocl_icap_get_data(xdev, XCLBIN_UUID))
 
 #define	XOCL_IS_DDR_USED(xdev, ddr)					\
 	(XOCL_MEM_TOPOLOGY(xdev)->m_mem_data[ddr].m_used == 1)

--- a/src/runtime_src/driver/xclng/include/xocl_ioctl.h
+++ b/src/runtime_src/driver/xclng/include/xocl_ioctl.h
@@ -315,9 +315,9 @@ enum drm_xocl_ctx_code {
         XOCL_CTX_OP_FREE_CTX
 };
 
-#define XOCL_CTX_SHARED    0x0
-#define XOCL_CTX_EXCLUSIVE 0x1
-
+#define	XOCL_CTX_SHARED		0x0
+#define	XOCL_CTX_EXCLUSIVE	0x1
+#define	XOCL_CTX_VIRT_CU_INDEX	0xffffffff
 /**
  * struct drm_xocl_ctx - Open or close a context on a compute unit on device
  * used with DRM_XOCL_CTX ioctl
@@ -331,11 +331,11 @@ enum drm_xocl_ctx_code {
  */
 struct drm_xocl_ctx {
 	enum drm_xocl_ctx_code op;
-        xuid_t   xclbin_id;
-        uint32_t cu_index;
-        uint32_t flags;
-        // unused, in future it would return context id
-        uint32_t handle;
+	xuid_t   xclbin_id;
+	uint32_t cu_index;
+	uint32_t flags;
+	// unused, in future it would return context id
+	uint32_t handle;
 };
 
 struct drm_xocl_info {

--- a/src/runtime_src/driver/xclng/tools/xbmgmt/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/xbmgmt/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(xbmgmt
   pthread
   boost_filesystem
   boost_system
+  uuid
   )
 
 install (TARGETS xbmgmt RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)

--- a/src/runtime_src/driver/xclng/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/tools/xbutil/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(xbutil
   rt
   boost_filesystem
   boost_system
+  uuid
   ${CURSES_LIBRARIES}
   )
 

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -970,17 +970,13 @@ int xcldev::device::runTestCase(const std::string& exe,
     }
 
     // Program xclbin first.
-#if 0
-    // Workaround auto configure locking issues where the process which
-    // downloads xclbin auto acquires xclbin lock and only gives up at
-    // process exit time
     int ret = program(xclbinPath, 0);
     if (ret != 0) {
         output += "ERROR: Failed to download xclbin: ";
         output += xclbin;
         return -EINVAL;
     }
-#endif
+
     if (m_idx != 0)
         idxOption = "-d " + std::to_string(m_idx);
 

--- a/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(xrt_core
   rt
   boost_filesystem
   boost_system
+  uuid
   )
 
 install(TARGETS xrt_core


### PR DESCRIPTION
This change introduce virtual CU (index number is -1). Application can reserve virtual CU if it does not need to use any real CUs, but would like to lock down xclbin for performing other activities, such as KDMA.