### PR TITLE
Make header files C friendly

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -399,7 +399,7 @@ extern CL_API_ENTRY cl_int CL_API_CALL
  * Low level access to XRT device for use with xrt++
  */
 struct xrt_device;
-extern CL_API_ENTRY xrt_device*
+extern CL_API_ENTRY struct xrt_device*
 xclGetXrtDevice(cl_device_id device,
                 cl_int* errcode);
 

--- a/src/runtime_src/driver/include/xclhal2.h
+++ b/src/runtime_src/driver/include/xclhal2.h
@@ -360,7 +360,7 @@ XCL_DRIVER_DLLESPEC int xclLoadXclBin(xclDeviceHandle handle, const struct axlf 
  * xclbin as a section. xclbin may also contains other sections which are suitably
  * handled by the driver.
  */
-XCL_DRIVER_DLLESPEC int xclLoadXclBinMgmt(xclDeviceHandle handle, const axlf *buffer);
+XCL_DRIVER_DLLESPEC int xclLoadXclBinMgmt(xclDeviceHandle handle, const struct axlf *buffer);
 /**
  * xclGetSectionInfo() - Get Information from sysfs about the downloaded xclbin sections
  *
@@ -501,7 +501,7 @@ XCL_DRIVER_DLLESPEC unsigned int xclVersion();
  *
  * Return:         0 on success or appropriate error number
  */
-XCL_DRIVER_DLLESPEC int xclLogMsg(xclDeviceHandle handle, xclLogMsgLevel level, const char* tag, const char* format, ...);
+XCL_DRIVER_DLLESPEC int xclLogMsg(xclDeviceHandle handle, enum xclLogMsgLevel level, const char* tag, const char* format, ...);
 
 /**
  * DOC: XRT Buffer Management APIs
@@ -1302,7 +1302,7 @@ XCL_DRIVER_DLLESPEC int xclMSD(xclDeviceHandle handle, struct drm_xocl_sw_mailbo
 
 /* Hack for xbflash only */
 XCL_DRIVER_DLLESPEC char *xclMapMgmt(xclDeviceHandle handle);
-XCL_DRIVER_DLLESPEC xclDeviceHandle xclOpenMgmt(unsigned deviceIndex, const char *logFileName, xclVerbosityLevel level);
+XCL_DRIVER_DLLESPEC xclDeviceHandle xclOpenMgmt(unsigned deviceIndex, const char *logFileName, enum xclVerbosityLevel level);
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/driver/include/xclperf.h
+++ b/src/runtime_src/driver/include/xclperf.h
@@ -437,7 +437,7 @@ enum DeviceType {
  * nifd driver.
  */
 typedef struct {
-  DeviceType device_type;
+  enum DeviceType device_type;
   unsigned int device_index;
   unsigned int mgmt_instance;
   unsigned int user_instance;


### PR DESCRIPTION
PR #843 make xclhal2.h C friendly to allow it's inclusion in C code (particularly ensuring that the enum and struct keywords were used where appropriate). Further C++isms have creeped in, breaking C compilation.
Fix them.