### PR TITLE
Various build fixes

### DIFF
--- a/src/runtime_src/doc/CMakeLists.txt
+++ b/src/runtime_src/doc/CMakeLists.txt
@@ -13,12 +13,12 @@ file(GLOB XRT_XMA_PLUGIN_H ${XRT_RUNTIME_SRC_DIR}/../xma/include/xmaplugin.h)
 file(MAKE_DIRECTORY ${DOC_CORE_DIR})
 file(COPY ${XRT_DOC_TOC_DIR} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-set(KERNELDOC "./kernel-doc")
+set(KERNELDOC "kernel-doc")
 set(KERNELDOC_URL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/plain/scripts/kernel-doc?h=v4.14.52")
 MESSAGE(STATUS "${KERNELDOC} downloading")
-file(DOWNLOAD ${KERNELDOC_URL} ${KERNELDOC})
+file(DOWNLOAD ${KERNELDOC_URL} "./${KERNELDOC}")
 execute_process(COMMAND chmod +x ${KERNELDOC})
-find_program(KERNELDOC_EXECUTABLE ${KERNELDOC} PATHS "./")
+find_program(KERNELDOC_EXECUTABLE ${KERNELDOC} PATHS ${CMAKE_BINARY_DIR})
 
 find_program(SPHINX_EXECUTABLE sphinx-build)
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -1013,8 +1013,8 @@ namespace xocl {
     info->user_instance = user_instance;
     info->mgmt_instance = mgmt_instance;
     info->nifd_instance = nifd_instance;
-    strncpy(info->device_name, device_name.c_str(), MAX_NAME_LEN);
-    strncpy(info->nifd_name, nifd_name.c_str(), MAX_NAME_LEN);
+    strncpy(info->device_name, device_name.c_str(), MAX_NAME_LEN - 1);
+    strncpy(info->nifd_name, nifd_name.c_str(), MAX_NAME_LEN - 1);
     info->device_name[MAX_NAME_LEN-1] = '\0';
     info->nifd_name[MAX_NAME_LEN-1] = '\0';
     return 0;

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -488,7 +488,7 @@ public:
       // allocate sufficiently aligned memory and reassign m_host_ptr
       if (posix_memalign(&m_host_ptr,alignment,sz))
         throw error(CL_MEM_OBJECT_ALLOCATION_FAILURE);
-    if (flags & CL_MEM_COPY_HOST_PTR)
+    if (flags & CL_MEM_COPY_HOST_PTR && host_ptr)
       std::memcpy(m_host_ptr,host_ptr,sz);
 
     m_aligned = (reinterpret_cast<uintptr_t>(m_host_ptr) % alignment)==0;

--- a/src/xma/src/xmaapi/xmalogger.cpp
+++ b/src/xma/src/xmaapi/xmalogger.cpp
@@ -204,7 +204,8 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
     if (name == NULL)
         strncpy(log_name, "XMA-default", sizeof(log_name));
     else
-        strncpy(log_name, name, sizeof(log_name));
+        strncpy(log_name, name, sizeof(log_name) - 1);
+    log_name[sizeof(log_name) - 1] = '\0';
 
     log_level = g_loglevel_tbl[level].lvl_str;
     


### PR DESCRIPTION
This is a collection of 3 fixes I needed to get XRT building on a Debian Buster system - in particular 2 cleanups for warnings in GCC 8.3.0, plus a fixup to correctly use the local kernel-doc copy. I understand Debian is probably not a supported distro, but these fixes seem relevant to other systems.