### PR TITLE
Bug fix for MPSoC interrupt when OpenCL API is using

### DIFF
--- a/src/platform/zcu102ng/src/a53/xrt/image/init.sh
+++ b/src/platform/zcu102ng/src/a53/xrt/image/init.sh
@@ -1,2 +1,6 @@
 cp /mnt/platform_desc.txt /etc/xocl.txt
-source /opt/xilinx/xrt/setup.sh
+
+# XRT is install into linux standard path for MPSoC
+# Headers in /usr/include
+# Libraries in /usr/lib
+export XILINX_XRT=/usr

--- a/src/platform/zcu102ng_svm/src/a53/xrt/image/init.sh
+++ b/src/platform/zcu102ng_svm/src/a53/xrt/image/init.sh
@@ -1,2 +1,6 @@
 cp /mnt/platform_desc.txt /etc/xocl.txt
-source /opt/xilinx/xrt/setup.sh
+
+# XRT is install into linux standard path for MPSoC
+# Headers in /usr/include
+# Libraries in /usr/lib
+export XILINX_XRT=/usr

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -801,9 +801,12 @@ cu_start(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 	// past header, past cumasks
 	SCHED_DEBUG_PACKET(regmap, size);
 
-	// write register map, starting at base + 0xC
-	// 0x4, 0x8 used for interrupt, which is initialized in setu
-	for (i = 1; i < size; ++i)
+	/* write register map, starting at base + 0x10
+	 * 0x0 used for control register
+	 * 0x4, 0x8 used for interrupt, which is initialized in setup of ERT
+	 * 0xC used for interrupt status, which is set by hardware
+	 */
+	for (i = 4; i < size; ++i)
 		iowrite32(*(regmap + i), xcu->base + xcu->addr + (i << 2));
 
 	// start cu.  update local state as we may not be polling prior

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -554,7 +554,7 @@ configure(struct sched_cmd *cmd)
 	/* Right now only support 32 CUs interrupts
 	 * If there are more than 32 CUs, fall back to polling mode
 	 */
-	if (exec->num_cus > 32) {
+	if (!exec->polling_mode && exec->num_cus > 32) {
 		DRM_WARN("Only support up to 32 CUs interrupts, "
 		    "request %d CUs. Fall back to polling mode\n",
 		    exec->num_cus);

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
@@ -517,7 +517,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		irq = platform_get_irq(pdev, index);
 		if (irq < 0)
 			break;
-		DRM_INFO("CU(%d) IRQ %d\n", index, irq);
+		DRM_DEBUG("CU(%d) IRQ %d\n", index, irq);
 		zdev->irq[index] = irq;
 	}
 	zdev->cu_num = index;

--- a/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc.dts
+++ b/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc.dts
@@ -8,7 +8,7 @@
 		xlnx,kind-of-intr = <0x0>;
 		xlnx,num-intr-inputs = <0x20>;
 		interrupt-parent = <&gic>;
-		interrupts = <0 89 4>;
+		interrupts = <0 89 1>;
 	};
 
 	zyxclmm_drm {


### PR DESCRIPTION
OpenCL layer is not going to enable interrupt in regmap. MicroBlaze ERT will enable CU interrupt based on ert_polling configure. For MPSoC platform, KDS need to enable interrupt, otherwise the user's application will hang on interrupt mode.

XILINX_XRT should point to /usr for MPSoC platform. Since all of the header files and libraries are installed in linux standard directory.

Other refine:
Skip 0x4, 0x8, 0xC register configure when start CU. They are used for enable interrupt and identify CU interrupt status. Apply for both xocl and zocl.