### PR TITLE
Downgrade uuid package comparison to 2.23.0

### DIFF
--- a/src/CMake/config/libxmaapi.pc.in
+++ b/src/CMake/config/libxmaapi.pc.in
@@ -9,6 +9,6 @@ Version: 0.0.1
 Requires: yaml-0.1   >= 0.1.4 \
           libxml-2.0 >= 2.9.1 \
           xrt >= 2.1.0 \
-          uuid >= 2.27.0
+          uuid >= 2.23.0
 Libs: -L${libdir} -lxmaapi
 Cflags: -I${includedir}


### PR DESCRIPTION
* Changed uuid library package comparison from 2.27.0 to 2.23.0 as latest version of uuid on CentOs 7.4 is 2.23.0