### PR TITLE
Use ERT for CU polling in dataflow mode

### DIFF
--- a/src/runtime_src/driver/common/config_reader.cpp
+++ b/src/runtime_src/driver/common/config_reader.cpp
@@ -31,9 +31,15 @@
 namespace {
 
 static const char*
-valueOrEmpty(const char* cstr)
+value_or_empty(const char* cstr)
 {
   return cstr ? cstr : "";
+}
+
+static bool
+is_true(const std::string& str)
+{
+  return str=="true";
 }
 
 static std::string
@@ -52,7 +58,7 @@ static std::string
 get_ini_path()
 {
   try {
-    auto ini_path = boost::filesystem::path(valueOrEmpty(std::getenv("SDACCEL_INI_PATH")));
+    auto ini_path = boost::filesystem::path(value_or_empty(std::getenv("SDACCEL_INI_PATH")));
     // Support SDACCEL_INI_PATH with/without actual filename
     if (ini_path.filename() != "sdaccel.ini")
       ini_path /= "sdaccel.ini";
@@ -85,7 +91,7 @@ struct tree
   {
     try {
       read_ini(path,m_tree);
-      
+
       // set env vars to expose sdaccel.ini to hal layer
       setenv();
     }
@@ -119,9 +125,18 @@ namespace xrt_core { namespace config {
 
 namespace detail {
 
+const char*
+get_env_value(const char* env)
+{
+  return std::getenv(env);
+}
+
 bool
 get_bool_value(const char* key, bool default_value)
 {
+  if (auto env = get_env_value(key))
+    return is_true(env);
+
   return s_tree.m_tree.get<bool>(key,default_value);
 }
 
@@ -162,5 +177,3 @@ debug(std::ostream& ostr, const std::string& ini)
 } // detail
 
 }}
-
-

--- a/src/runtime_src/driver/common/config_reader.h
+++ b/src/runtime_src/driver/common/config_reader.h
@@ -60,6 +60,7 @@ namespace detail {
  * See xrt/test/util/tconfig.cpp for unit test
  */
 bool          get_bool_value(const char*, bool);
+const char*   get_env_value(const char*);
 std::string   get_string_value(const char*, const std::string&);
 unsigned int  get_uint_value(const char*, unsigned int);
 std::ostream& debug(std::ostream&, const std::string& ini="");
@@ -283,6 +284,12 @@ get_cdma()
 {
   static unsigned int value = detail::get_bool_value("Runtime.cdma",false);
   return value;
+}
+
+inline bool
+get_feature_toggle(const std::string& feature)
+{
+  return detail::get_bool_value(feature.c_str(),false);
 }
 
 inline std::string

--- a/src/runtime_src/driver/common/scheduler.cpp
+++ b/src/runtime_src/driver/common/scheduler.cpp
@@ -164,6 +164,7 @@ init(xclDeviceHandle handle, const axlf* top)
   ecmd->cu_dma  = xrt_core::config::get_ert_cudma();
   ecmd->cu_isr  = xrt_core::config::get_ert_cuisr() && get_cuisr(top);
   ecmd->cq_int  = xrt_core::config::get_ert_cqint();
+  ecmd->dataflow = xrt_core::config::get_feature_toggle("Runtime.dataflow");
 
   // cu addr map
   std::copy(cus.begin(), cus.end(), ecmd->data);

--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -178,7 +178,8 @@ struct ert_configure_cmd {
   uint32_t cu_isr:1;
   uint32_t cq_int:1;
   uint32_t cdma:1;
-  uint32_t unusedf:25;
+  uint32_t dataflow:1;
+  uint32_t unusedf:24;
   uint32_t dsa52:1;
 
   /* cu address map size is num_cus */
@@ -239,7 +240,7 @@ enum ert_cmd_opcode {
   ERT_START_CU     = 0,
   ERT_START_KERNEL = 0,
   ERT_CONFIGURE    = 2,
-  ERT_STOP         = 3,
+  ERT_EXIT         = 3,
   ERT_ABORT        = 4,
   ERT_WRITE        = 5,
   ERT_CU_STAT      = 6,
@@ -374,10 +375,10 @@ enum ert_cmd_type {
 #define ERT_CUISR_LUT_ADDR                (ERT_CSR_ADDR + 0x400)
 
 /**
- * ERT stop command/ack
+ * ERT exit command/ack
  */
-#define	ERT_STOP_CMD			  ((ERT_STOP << 23) | ERT_CMD_STATE_NEW)
-#define	ERT_STOP_ACK			  (ERT_CMD_STATE_COMPLETED)
+#define	ERT_EXIT_CMD			  ((ERT_EXIT << 23) | ERT_CMD_STATE_NEW)
+#define	ERT_EXIT_ACK			  (ERT_CMD_STATE_COMPLETED)
 
 /**
  * State machine for both CUDMA and CUISR modules

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/xmc.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/xmc.c
@@ -1152,9 +1152,9 @@ static int stop_xmc_nolock(struct platform_device *pdev)
 		/* Need to check if ERT is loaded before we attempt to stop it */
 		if (!SELF_JUMP(READ_IMAGE_SCHED(xmc, 0))) {
 			reg_val = XOCL_READ_REG32(xmc->base_addrs[IO_CQ]);
-			if (!(reg_val & ERT_STOP_ACK)) {
+			if (!(reg_val & ERT_EXIT_ACK)) {
 				xocl_info(&xmc->pdev->dev, "Stopping scheduler...");
-				XOCL_WRITE_REG32(ERT_STOP_CMD, xmc->base_addrs[IO_CQ]);
+				XOCL_WRITE_REG32(ERT_EXIT_CMD, xmc->base_addrs[IO_CQ]);
 			}
 		}
 
@@ -1173,9 +1173,9 @@ static int stop_xmc_nolock(struct platform_device *pdev)
 			xmc->state = XMC_STATE_ERROR;
 			return -ETIMEDOUT;
 		} else if (!SELF_JUMP(READ_IMAGE_SCHED(xmc, 0)) &&
-			 !(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_STOP_ACK)) {
+			 !(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_EXIT_ACK)) {
 			while (retry++ < MAX_ERT_RETRY &&
-				!(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_STOP_ACK))
+				!(XOCL_READ_REG32(xmc->base_addrs[IO_CQ]) & ERT_EXIT_ACK))
 				msleep(RETRY_INTERVAL);
 			if (retry >= MAX_ERT_RETRY) {
 				xocl_err(&xmc->pdev->dev,

--- a/src/runtime_src/xrt/util/config_reader.cpp
+++ b/src/runtime_src/xrt/util/config_reader.cpp
@@ -32,9 +32,15 @@
 namespace {
 
 static const char*
-valueOrEmpty(const char* cstr)
+value_or_empty(const char* cstr)
 {
   return cstr ? cstr : "";
+}
+
+static bool
+is_true(const std::string& str)
+{
+  return str=="true";
 }
 
 static std::string
@@ -52,7 +58,7 @@ get_self_path()
 static std::string
 get_ini_path()
 {
-  auto ini_path = boost::filesystem::path(valueOrEmpty(std::getenv("SDACCEL_INI_PATH")));
+  auto ini_path = boost::filesystem::path(value_or_empty(std::getenv("SDACCEL_INI_PATH")));
   if (ini_path.empty()) {
     auto self_path = boost::filesystem::path(get_self_path());
     if (self_path.empty())
@@ -129,6 +135,9 @@ get_env_value(const char* env)
 bool
 get_bool_value(const char* key, bool default_value)
 {
+  if (auto env = get_env_value(key))
+    return is_true(env);
+
   return s_tree.m_tree.get<bool>(key,default_value);
 }
 

--- a/src/runtime_src/xrt/util/config_reader.h
+++ b/src/runtime_src/xrt/util/config_reader.h
@@ -289,7 +289,7 @@ get_cdma()
 inline bool
 get_feature_toggle(const std::string& feature)
 {
-  return detail::get_bool_value(feature.c_str(),false) || detail::get_env_value(feature.c_str());
+  return detail::get_bool_value(feature.c_str(),false);
 }
 
 inline std::string


### PR DESCRIPTION
In dataflow mode KDS configures, starts, and checks CU status
directly.

If KDS is configured with ert=false, then CUs are polled for
completion in a busy loop.

If KDS is configured with ert=true (and KDS is in dataflow mode), then
ERT is used to poll CUs for completion and notify KDS when one
completes.  If KDS is not busy attempting to start commands, then it
will be waiting for ERT notification.  The ERT command queue is
divided into CU slots, where each slot corresponds to a CU.  KDS
requests ERT polling of a CU by writing AP_START or AP_CONTINUE into
the CQ slot corresponding to the CU.

Until xclbin meta data advertises dataflow kernels, sdaccel.ini can be
used to trigger dataflow mode by setting Runtime.dataflow=true.  Note
that together with ert=true (the default) the requires updated ERT
firmware part of the PR that supports polling of CUS.