### PR TITLE
Tell CMake to build .debs for Debian as well as Ubuntu

### DIFF
--- a/src/CMake/cpack.cmake
+++ b/src/CMake/cpack.cmake
@@ -22,7 +22,7 @@ execute_process(
 )
 
 SET(PACKAGE_KIND "TGZ")
-if (${LINUX_FLAVOR} STREQUAL Ubuntu)
+if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
   SET(CPACK_GENERATOR "DEB;TGZ")
   SET(PACKAGE_KIND "DEB")
   # Modify the package name for the xrt component


### PR DESCRIPTION
RPMS are built for RHEL + CentOS, but .debs are only enabled for Ubuntu. Correct this to build them for Debian proper as well.