### PR TITLE
Support CU selection with clCreateKernel

### DIFF
--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -26,10 +26,6 @@
 #include <algorithm>
 #include <regex>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/algorithm/string/classification.hpp>
-
-
 namespace xocl {
 
 std::string
@@ -558,8 +554,10 @@ get_cu_names(const std::string& kname)
   const std::regex r("^(.+):\\{(([\\w]+)(,\\S+[^,\\s]*)*)\\}$");
   std::smatch match;
   if (std::regex_search(kname,match,r) && match[2].matched) {
-    std::string names = match[2];
-    boost::split(cus,names,boost::is_any_of(","));
+    std::istringstream is(match[2]);
+    std::string cu;
+    while (std::getline(is,cu,','))
+      cus.push_back(cu);
   }
   return cus;
 }

--- a/src/runtime_src/xocl/core/kernel.h
+++ b/src/runtime_src/xocl/core/kernel.h
@@ -657,6 +657,16 @@ private:
   argument_vector_type m_rtinfo_args;
 };
 
+namespace kernel_utils {
+
+std::string
+normalize_kernel_name(const std::string& kernel_name);
+
+std::vector<std::string>
+get_cu_names(const std::string& kernel_name);
+
+} // kernel_utils
+
 } // xocl
 
 #endif

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -210,6 +210,15 @@ get_binary_sizes() const
   return sizes;
 }
 
+bool
+program::
+has_kernel(const std::string& kname) const
+{
+  auto name = kernel_utils::normalize_kernel_name(kname);
+  auto kernels = get_kernel_names();
+  return range_find(kernels,[&name](const std::string& s){return s==name;})!=kernels.end();
+}
+
 std::unique_ptr<kernel,std::function<void(kernel*)>>
 program::
 create_kernel(const std::string& kernel_name)
@@ -226,8 +235,10 @@ create_kernel(const std::string& kernel_name)
   // Look up kernel symbol from arbitrary (first) xclbin
   if (m_binaries.empty())
     throw xocl::error(CL_INVALID_PROGRAM_EXECUTABLE,"No binary for program");
+
+  auto symbol_name = kernel_utils::normalize_kernel_name(kernel_name);
   auto& xclbin = m_binaries.begin()->second;
-  auto& symbol = xclbin.lookup_kernel(kernel_name);
+  auto& symbol = xclbin.lookup_kernel(symbol_name);
   auto k = std::make_unique<kernel>(this,kernel_name,symbol);
   return std::unique_ptr<kernel,decltype(deleter)>(k.release(),deleter);
 }

--- a/src/runtime_src/xocl/core/program.h
+++ b/src/runtime_src/xocl/core/program.h
@@ -217,12 +217,7 @@ public:
   }
 
   bool
-  has_kernel(const std::string& kname) const
-  {
-    auto kernels = get_kernel_names();
-    return range_find(kernels,[&kname](const std::string& s){return s==kname;})!=kernels.end();
-
-  }
+  has_kernel(const std::string& kname) const;
 
   /**
    * Create a kernel.


### PR DESCRIPTION
cl_kernel clCreateKernel(program, kernel_name, err) now supports an
extension to the kernel_name such that it can include the compute unit
that should be used.

The format of the kernel_name argument is "kernel:{cu1,cu2,...}" where
"kernel" is the name of the kernel as normal and "cu1" through "cu_n"
are the names of the compute units to use.  It is strictly enforced
that the CU list is enclosed in a comma separated list without any
spaces between the CU names, commas, and curly braces.  It is also
strictly enforced that the list must follow a ":" separating a legal
kernel name.  Invalid CU names are currently ignored without warning,
but error is thrown if no CUs matched.