### PR TITLE
Add XCL_HW_STREAM sentinel defined as NULL

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -443,6 +443,11 @@ typedef cl_uint cl_program_target_type;
 #define CL_PROGRAM_TARGET_TYPE_SW_EMU   0x2
 #define CL_PROGRAM_TARGET_TYPE_HW_EMU   0x4
 
+// K2K kernel argument sentinel
+// XCL_HW_STREAM is a global sentinel value that XRT knows to
+// represent an argument transferred via a hardware stream connection.
+// Such arguments require no direct software intervention.
+#define XCL_HW_STREAM NULL
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
XCL_HW_STREAM is a global sentinel value that XRT knows to represent an argument transferred via a hardware stream connection. Such arguments require no direct software intervention and are optional.
    OCL_CHECK(err, err = krnl_mem_read.setArg(0, buffer_input));
    OCL_CHECK(err, err = krnl_mem_read.setArg(1, XCL_HW_STREAM));
    OCL_CHECK(err, err = krnl_mem_read.setArg(2, size));
    OCL_CHECK(err, err = krnl_increment.setArg(0, XCL_HW_STREAM));
    OCL_CHECK(err, err = krnl_increment.setArg(1, XCL_HW_STREAM));
    OCL_CHECK(err, err = krnl_increment.setArg(2, size));
    OCL_CHECK(err, err = krnl_mem_write.setArg(0, XCL_HW_STREAM));
    OCL_CHECK(err, err = krnl_mem_write.setArg(1, buffer_output));
    OCL_CHECK(err, err = krnl_mem_write.setArg(2, size));