### PR TITLE
Added JSON output support to bit slice the properties value of IP_KERNELs

### DIFF
--- a/src/runtime_src/tools/xclbin/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.h
@@ -49,6 +49,7 @@ public:
 
  protected:
   const std::string getIPTypeStr(enum IP_TYPE _ipType) const;
+  const std::string getIPControlTypeStr(enum IP_CONTROL _ipControlType) const;
   enum IP_TYPE getIPType(std::string& _sIPType) const;
   enum IP_CONTROL getIPControlType(std::string& _sIPControlType) const;
 

--- a/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
@@ -307,7 +307,6 @@ XclBinUtilities::getUUIDAsString( const unsigned char (&_uuid)[16] )
 
 bool
 XclBinUtilities::findBytesInStream(std::fstream& _istream, const std::string& _searchString, unsigned int& _foundOffset) {
-  XUtil::TRACE(XUtil::format("Searching for: %s", _searchString.c_str()));
   _foundOffset = 0;
 
   unsigned int savedLocation = _istream.tellg();


### PR DESCRIPTION
When a xclbin archive's IP_LAYOUT JSON section is dumped.  For IP_KERNELs, the m_int_enable, m_interrupt_id, and m_ip_control values will be inserted into the schema instead of properties.