### PR TITLE
Added support for a DTC section and removed DRC for an empty connectivity section.

### DIFF
--- a/src/runtime_src/driver/include/xclbin.h
+++ b/src/runtime_src/driver/include/xclbin.h
@@ -129,7 +129,8 @@ extern "C" {
         USER_METADATA,
         DNA_CERTIFICATE,
         PDI,
-        BITSTREAM_PARTIAL_PDI 
+        BITSTREAM_PARTIAL_PDI,
+        DTC
     };
 
     enum MEM_TYPE {

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -76,6 +76,7 @@ file(GLOB XCLBINUTIL_FILES
   "SectionUserMetadata.cxx"
   "SectionPDI.cxx"
   "SectionBitstreamPartialPDI.cxx"
+  "SectionDTC.cxx"
 )
 set(XCLBINUTIL_FILES_SRCS ${XCLBINUTIL_FILES})
 

--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -636,10 +636,10 @@ reportKernels( std::ostream & _ostream,
       throw std::runtime_error(errMsg);
     }
 
-    if (connectivity.empty()) {
-      std::string errMsg = "ERROR: Missing CONNECTIVTY section.  This usually is an indication of a malformed xclbin archive.";
-      throw std::runtime_error(errMsg);
-    }
+//    if (connectivity.empty()) {
+//      std::string errMsg = "ERROR: Missing CONNECTIVITY section.  This usually is an indication of a malformed xclbin archive.";
+//      throw std::runtime_error(errMsg);
+//    }
 
     if (ipLayout.empty()) {
       std::string errMsg = "ERROR: Missing IP_LAYOUT section.  This usually is an indication of a malformed xclbin archive.";

--- a/src/runtime_src/tools/xclbin/SectionDTC.cxx
+++ b/src/runtime_src/tools/xclbin/SectionDTC.cxx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "SectionDTC.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+// Static Variables / Classes
+SectionDTC::_init SectionDTC::_initializer;
+
+SectionDTC::SectionDTC() {
+  // Empty
+}
+
+SectionDTC::~SectionDTC() {
+  // Empty
+}
+
+
+
+

--- a/src/runtime_src/tools/xclbin/SectionDTC.h
+++ b/src/runtime_src/tools/xclbin/SectionDTC.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SectionDTC_h_
+#define __SectionDTC_h_
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+#include "Section.h"
+#include <boost/functional/factory.hpp>
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+// Forward declarations - use these instead whenever possible...
+
+// ------------------- C L A S S :   S e c t i o n ---------------------------
+
+/**
+ *    This class represents the base class for a given Section in the xclbin
+ *    archive.  
+*/
+
+class SectionDTC : public Section {
+ public:
+  SectionDTC();
+  virtual ~SectionDTC();
+
+ private:
+  // Purposefully private and undefined ctors...
+  SectionDTC(const SectionDTC& obj);
+  SectionDTC& operator=(const SectionDTC& obj);
+
+ private:
+  // Static initializer helper class
+  static class _init {
+   public:
+    _init() { registerSectionCtor(DTC, "DTC", "", false, boost::factory<SectionDTC*>()); }
+  } _initializer;
+};
+
+#endif

--- a/src/runtime_src/tools/xclbin/xclbincat1.cxx
+++ b/src/runtime_src/tools/xclbin/xclbincat1.cxx
@@ -454,6 +454,7 @@ namespace xclbincat1 {
       case DNA_CERTIFICATE: return "DNA_CERTIFICATE";
       case PDI: return "PDI";
       case BITSTREAM_PARTIAL_PDI: return "BITSTREAM_PARTIAL_PDI";
+      case DTC: return "DTC";
 
         break;
     }


### PR DESCRIPTION
1) Added support for a new DTC section.
2) Removed (commented out), checks for an empty connectivity section.  This is now a valid condition.
