### PR TITLE
Address a coverity error where SectionHeader::m_eType wasn't being initialized

### DIFF
--- a/src/runtime_src/tools/xclbin/SectionHeader.cxx
+++ b/src/runtime_src/tools/xclbin/SectionHeader.cxx
@@ -20,7 +20,9 @@
 #include <stdexcept>
 
 
-SectionHeader::SectionHeader() {
+SectionHeader::SectionHeader() 
+  : m_eType(BITSTREAM)
+{
   // Empty
 }
 


### PR DESCRIPTION
Fix coverity error: 
CID 194526 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member m_eType is not initialized in this constructor nor in any functions that it calls.

Link: https://scan9.coverity.com/reports.htm#v36690/p13446/fileInstanceId=46382729&defectInstanceId=6333852&mergedDefectId=194526