### PR TITLE
 Add exec_write command for non-consecutive CU layout

### DIFF
--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -237,14 +237,14 @@ enum ert_cmd_state {
  *                      before cmd reach to scheduler, short-term hack
  */
 enum ert_cmd_opcode {
-  ERT_START_CU     = 0,
-  ERT_START_KERNEL = 0,
-  ERT_CONFIGURE    = 2,
-  ERT_EXIT         = 3,
-  ERT_ABORT        = 4,
-  ERT_EXEC_WRITE   = 5,
-  ERT_CU_STAT      = 6,
-  ERT_START_COPYBO = 7,
+  ERT_START_CU      = 0,
+  ERT_START_KERNEL  = 0,
+  ERT_CONFIGURE     = 2,
+  ERT_EXIT          = 3,
+  ERT_ABORT         = 4,
+  ERT_EXEC_WRITE    = 5,
+  ERT_CU_STAT       = 6,
+  ERT_START_COPYBO  = 7,
 };
 
 /**
@@ -253,11 +253,13 @@ enum ert_cmd_opcode {
  * @ERT_DEFAULT:        default command type
  * @ERT_KDS_LOCAL:      command processed by KDS locally
  * @ERT_CTRL:           control command uses reserved command queue slot
+ * @ERT_CU:             compute unit command
  */
 enum ert_cmd_type {
   ERT_DEFAULT = 0,
   ERT_KDS_LOCAL = 1,
   ERT_CTRL = 2,
+  ERT_CU = 3,
 };
 
 /**

--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -231,7 +231,7 @@ enum ert_cmd_state {
  * @ERT_START_CU:       start a workgroup on a CU
  * @ERT_START_KERNEL:   currently aliased to ERT_START_CU
  * @ERT_CONFIGURE:      configure command scheduler
- * @ERT_WRITE:          write pairs of addr and value
+ * @ERT_EXEC_WRITE:     execute a specified CU after writing
  * @ERT_CU_STAT:        get stats about CU execution
  * @ERT_START_COPYBO:   start KDMA CU or P2P, may be converted to ERT_START_CU
  *                      before cmd reach to scheduler, short-term hack
@@ -242,7 +242,7 @@ enum ert_cmd_opcode {
   ERT_CONFIGURE    = 2,
   ERT_EXIT         = 3,
   ERT_ABORT        = 4,
-  ERT_WRITE        = 5,
+  ERT_EXEC_WRITE   = 5,
   ERT_CU_STAT      = 6,
   ERT_START_COPYBO = 7,
 };

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -608,7 +608,7 @@ cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
 	xcmd->ert_pkt = (struct ert_packet *)bo->vmapping;
 
 	// in kds mode copy pkt cus to command object cu bitmap
-	if (penguin && cmd_opcode(xcmd) == ERT_START_CU) {
+	if (penguin && cmd_type(xcmd) == ERT_CU) {
 		unsigned int i = 0;
 		u32 cumasks[4] = {0};
 
@@ -843,8 +843,11 @@ cu_pop_done(struct xocl_cu *xcu)
 		     xcu->idx, xcmd->uid, xcu->done_cnt, xcu->run_cnt);
 }
 
+/**
+ * cu_configure_ooo() - Configure a CU with {addr,val} pairs
+ */
 static void
-cu_write_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
+cu_configure_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 {
 	unsigned int size = cmd_regmap_size(xcmd);
 	u32 *regmap = cmd_regmap(xcmd);
@@ -852,8 +855,8 @@ cu_write_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 
 	SCHED_DEBUGF("-> %s cu(%d) xcmd(%lu)\n", __func__, xcu->idx, xcmd->uid);
 	for (idx = 4; idx < size - 1; idx += 2) {
-		u32 offset = ecmd->data[idx];
-		u32 val = ecmd->data[idx+1];
+		u32 offset = *(regmap + idx);
+		u32 val = *(regmap + idx + 1);
 
 		SCHED_DEBUGF("+ base[0x%x] = 0x%x\n", offset, val);
 		iowrite32(val, xcu->base + offset);
@@ -861,8 +864,11 @@ cu_write_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
+/**
+ * cu_configure_ino() - Configure a CU with consecutive layout
+ */
 static void
-cu_write_ino(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
+cu_configure_ino(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 {
 	unsigned int size = cmd_regmap_size(xcmd);
 	u32 *regmap = cmd_regmap(xcmd);
@@ -883,16 +889,10 @@ static bool
 cu_start(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 {
 	// assert(!(ctrlreg & AP_START), "cu not ready");
-
-	// data past header and cu_masks
-	unsigned int size = cmd_regmap_size(xcmd);
-	u32 *regmap = cmd_regmap(xcmd);
-	unsigned int i;
-
 	SCHED_DEBUGF("-> %s cu(%d) cmd(%lu)\n", __func__, xcu->idx, xcmd->uid);
 
 	// past header, past cumasks
-	SCHED_DEBUG_PACKET(regmap, size);
+	SCHED_DEBUG_PACKET(cmd_regmap(xcmd), cmd_regmap_size(xcmd));
 
 	/* write register map, starting at base + 0x10
 	 * 0x0 used for control register
@@ -900,9 +900,9 @@ cu_start(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 	 * 0xC used for interrupt status, which is set by hardware
 	 */
 	if (cmd_opcode(xcmd) == ERT_EXEC_WRITE)
-		cu_write_ooo(xcu,cmd);
+		cu_configure_ooo(xcu, xcmd);
 	else
-		cu_write_ino(xcu,cmd);
+		cu_configure_ino(xcu, xcmd);
 
 	// start cu.  update local state as we may not be polling prior
 	// to next ready check.
@@ -1803,7 +1803,6 @@ exec_penguin_start_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
 	unsigned int cuidx;
 	u32 opcode = cmd_opcode(xcmd);
-	struct xocl_cu *xcu;
 
 	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d)\n", __func__, xcmd->uid, opcode);
 
@@ -1812,8 +1811,8 @@ exec_penguin_start_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 		return false;
 	}
 
-	if (opcode != ERT_START_CU && opcode != ERT_EXEC_WRITE) {
-		SCHED_DEBUGF("<- %s not ERT_START_CU -> true\n", __func__);
+	if (cmd_type(xcmd) != ERT_CU) {
+		SCHED_DEBUGF("<- %s not a CU style command -> true\n", __func__);
 		return true;
 	}
 
@@ -1847,7 +1846,6 @@ exec_penguin_start_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 static void
 exec_penguin_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
-	u32 cmdopcode = cmd_opcode(xcmd);
 	u32 cmdtype = cmd_type(xcmd);
 
 	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d) type(%d) slot_idx=%d\n",
@@ -1855,7 +1853,7 @@ exec_penguin_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 
 	if (cmdtype == ERT_KDS_LOCAL || cmdtype == ERT_CTRL)
 		exec_mark_cmd_complete(exec, xcmd);
-	else if (cmdopcode == ERT_START_CU) {
+	else if (cmdtype == ERT_CU) {
 		struct xocl_cu *xcu = exec->cus[xcmd->cu_idx];
 
 		if (cu_first_done(xcu) == xcmd) {
@@ -3003,6 +3001,10 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	uint64_t dst_addr;
 	struct ert_start_copybo_cmd *scmd = (struct ert_start_copybo_cmd *)xobj->vmapping;
 
+	/* CU style commands must specify CU type */
+	if (scmd->opcode == ERT_START_CU || scmd->opcode == ERT_EXEC_WRITE)
+		scmd->type = ERT_CU;
+
 	/* Only convert COPYBO cmd for now. */
 	if (scmd->opcode != ERT_START_COPYBO)
 		return 0;
@@ -3038,6 +3040,7 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 		scmd->cu_mask[i / 32] |= 1 << (i % 32);
 
 	scmd->opcode = ERT_START_CU;
+	scmd->type = ERT_CU;
 
 	return 0;
 }
@@ -3226,7 +3229,7 @@ validate(struct platform_device *pdev, struct client_ctx *client, const struct d
 	SCHED_DEBUGF("-> %s(%d)\n", __func__, ecmd->opcode);
 
 	/* cus for start kernel commands only */
-	if (ecmd->opcode != ERT_START_CU)
+	if (ecmd->type != ERT_CU)
 		return 0; /* ok */
 
 	/* client context cu bitmap may not change while validating */

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -19,6 +19,7 @@
 
 #include "xrt/device/hal.h"
 #include "xrt/util/range.h"
+#include "driver/include/xclbin.h"
 
 #include <set>
 #include <vector>
@@ -173,6 +174,14 @@ public:
   void
   release_cu_context(const uuid& uuid,size_t cuidx)
   { m_hal->release_cu_context(uuid,cuidx); }
+
+  void
+  acquire_cu_context(size_t cuidx,bool shared)
+  { acquire_cu_context(m_uuid,cuidx,shared); }
+
+  void
+  release_cu_context(size_t cuidx)
+  { release_cu_context(m_uuid,cuidx); }
 
   ExecBufferObjectHandle
   allocExecBuffer(size_t sz)
@@ -594,6 +603,7 @@ public:
   hal::operations_result<int>
   loadXclBin(const axlf* xclbin)
   {
+    m_uuid = xclbin->m_header.uuid;
     return m_hal->loadXclBin(xclbin);
   }
 
@@ -857,6 +867,7 @@ private:
   std::unique_ptr<hal::device> m_hal;
   std::vector<BufferObjectHandle> m_buffers;
   mutable std::mutex m_buffers_mutex;
+  xrt::uuid m_uuid;
   bool m_setup_done;
 };
 

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -122,7 +122,6 @@ void
 device::
 acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared)
 {
-#if 1
   if (m_handle && m_ops->mOpenContext) {
     if (m_ops->mOpenContext(m_handle,uuid.get(),cuidx,shared))
       throw std::runtime_error(std::string("failed to acquire CU(")
@@ -131,14 +130,12 @@ acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared)
                                + std::strerror(errno)
                                + "'");
   }
-#endif
 }
 
 void
 device::
 release_cu_context(const uuid& uuid,size_t cuidx)
 {
-#if 1
   if (m_handle && m_ops->mCloseContext) {
     if (m_ops->mCloseContext(m_handle,uuid.get(),cuidx))
       throw std::runtime_error(std::string("failed to release CU(")
@@ -147,7 +144,6 @@ release_cu_context(const uuid& uuid,size_t cuidx)
                                + std::strerror(errno)
                                + "'");
   }
-#endif
 }
 
 ExecBufferObjectHandle

--- a/src/runtime_src/xrt/scheduler/command.cpp
+++ b/src/runtime_src/xrt/scheduler/command.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "command.h"
+#include "scheduler.h"
 
 #include <map>
 #include <vector>
@@ -123,6 +124,14 @@ command::
     m_device->unmap(m_exec_bo);
     free_buffer(m_device,m_exec_bo);
   }
+}
+
+void
+command::
+execute()
+{
+  m_done=false;
+  xrt::scheduler::schedule(get_ptr());
 }
 
 } // xrt

--- a/src/runtime_src/xrt/scheduler/command.h
+++ b/src/runtime_src/xrt/scheduler/command.h
@@ -23,6 +23,7 @@
 
 #include <cstddef>
 #include <array>
+#include <memory>
 
 namespace xrt {
 
@@ -32,7 +33,7 @@ namespace xrt {
  * A command consist of a 4K packet.  Each word (u32) of the packet
  * can be accessed through the command API.
  */
-class command
+class command : public std::enable_shared_from_this<command>
 {
   static constexpr auto regmap_size = 4096/sizeof(uint32_t);
 public:
@@ -56,6 +57,12 @@ public:
    * Dtor.  Recycles the underlying exec buffer
    */
   ~command();
+
+  std::shared_ptr<command>
+  get_ptr()
+  {
+    return shared_from_this();
+  }
 
   /**
    * Unique ID for this command.
@@ -168,6 +175,12 @@ public:
   {
     return reinterpret_cast<ERT_COMMAND_TYPE>(m_packet.data());
   }
+
+  /**
+   * Execute this command
+   */
+  void
+  execute();
 
   /**
    * Wait for command completion

--- a/src/runtime_src/xrt/util/uuid.h
+++ b/src/runtime_src/xrt/util/uuid.h
@@ -29,6 +29,11 @@ struct uuid
 {
   uuid_t m_uuid;
 
+  uuid()
+  {
+    uuid_clear(m_uuid);
+  }
+
   uuid(const uuid_t val)
   {
     uuid_copy(m_uuid,val);

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -62,18 +62,28 @@ completed() const
 
 write_command::
 write_command(xrt_device* device)
-  : command(device,ERT_WRITE)
+  : command(device,ERT_EXEC_WRITE)
 {
   m_impl->ecmd->type = ERT_KDS_LOCAL;
+  m_impl->ecmd->count = 1+4; // cumask + 4 ctrl
+}
+
+void
+write_command::
+add_cu(value_type cuidx)
+{
+  if (cuidx>=32)
+    throw std::runtime_error("write_command supports at most 32 CUs");
+  auto wcmd = static_cast<ert_start_kernel_cmd *>(m_impl->ecmd);
+  wcmd->cumask |= 1<<cuidx;
 }
 
 void
 write_command::
 add(addr_type addr, value_type value)
 {
-  (*m_impl)[offset++] = addr;
-  (*m_impl)[offset++] = value;
-  m_impl->ecmd->count += 2;
+  (*m_impl)[++m_impl->ecmd->count] = addr;
+  (*m_impl)[++m_impl->ecmd->count] = value;
 }
 
 }} // exec,xrt

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -16,7 +16,6 @@
 #include "xrtexec.hpp"
 #include "xrt/device/device.h"
 #include "xrt/scheduler/command.h"
-#include "xrt/scheduler/scheduler.h"
 
 namespace xrtcpp {
 
@@ -43,7 +42,7 @@ void
 command::
 execute()
 {
-  xrt::scheduler::schedule(m_impl);
+  m_impl->execute();
 }
 
 void
@@ -60,26 +59,29 @@ completed() const
   return m_impl->completed();
 }
 
-write_command::
-write_command(xrt_device* device)
+exec_write_command::
+exec_write_command(xrt_device* device)
   : command(device,ERT_EXEC_WRITE)
 {
-  m_impl->ecmd->type = ERT_KDS_LOCAL;
+  m_impl->ecmd->type = ERT_CU;
   m_impl->ecmd->count = 1+4; // cumask + 4 ctrl
 }
 
 void
-write_command::
+exec_write_command::
 add_cu(value_type cuidx)
 {
   if (cuidx>=32)
     throw std::runtime_error("write_command supports at most 32 CUs");
-  auto wcmd = static_cast<ert_start_kernel_cmd *>(m_impl->ecmd);
-  wcmd->cumask |= 1<<cuidx;
+  auto skcmd = reinterpret_cast<ert_start_kernel_cmd*>(m_impl->ecmd);
+  skcmd->cu_mask |= 1<<cuidx;
+
+  auto xdevice = m_impl->get_device();
+  xdevice->acquire_cu_context(cuidx,true);
 }
 
 void
-write_command::
+exec_write_command::
 add(addr_type addr, value_type value)
 {
   (*m_impl)[++m_impl->ecmd->count] = addr;

--- a/src/runtime_src/xrt/xrt++/xrtexec.hpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.hpp
@@ -59,15 +59,26 @@ public:
 };
 
 /**
- * class write_command : concrete class for ERT_WRITE
+ * class exec_write_command : concrete class for ERT_EXEC_WRITE
  *
- * The write command allows XRT to values to specific
- * addresses exposed over AXI-lite.
+ * The exec write command allows XRT to values to specific
+ * addresses exposed over AXI-lite.  The command value pairs
+ * are written to offset associated with selected CU.  After
+ * writing, the CU itself is started.
  */
-class write_command : public command
+class exec_write_command : public command
 {
 public:
-  write_command(xrt_device* dev);
+  exec_write_command(xrt_device* dev);
+
+  /**
+   * Add cu to command package pair to the command
+   *
+   * @cuidx: index of cu to execute
+   * @value: the value to write to @addr
+   */
+  void
+  add_cu(value_type cuidx);
 
   /**
    * Add {addr,value} pair to the command
@@ -77,9 +88,6 @@ public:
    */
   void
   add(addr_type addr, value_type value);
-
-private:
-  size_t offset = 1;
 };
 
 }} //exec, xrtcpp


### PR DESCRIPTION
Expose C++ API level command interface that allows host code to construct, execute, and wait for commands to complete.

Introduce new command type (ERT_CU) to support multiple opcodes for CU commands, one new opcode being ERT_EXEC_WRITE.