### PR TITLE
xclbincat and xclbinsplit are now deprecated

### DIFF
--- a/src/runtime_src/tools/xclbin/SectionHeader.cxx
+++ b/src/runtime_src/tools/xclbin/SectionHeader.cxx
@@ -20,7 +20,9 @@
 #include <stdexcept>
 
 
-SectionHeader::SectionHeader() {
+SectionHeader::SectionHeader() 
+  : m_eType(BITSTREAM)
+{
   // Empty
 }
 

--- a/src/runtime_src/tools/xclbin/xclbincat.cxx
+++ b/src/runtime_src/tools/xclbin/xclbincat.cxx
@@ -72,6 +72,15 @@ int main_( int argc, char** argv )
 
 int main( int argc, char** argv )
 {
+  std::cout << std::endl;
+  std::cout << "**** DEPRICATION WARNING ****"                                             << std::endl;
+  std::cout << "xclbincat and xclbinsplit utilities are replaced by xclbinutil."           << std::endl; 
+  std::cout << "You are recommended to use xclbinutil instead."                            << std::endl;
+  std::cout <<  std::endl;
+  std::cout << "The xclbincat and xclbinsplit utilities will be obsoleted and removed in " << std::endl; 
+  std::cout << "the next software release."                                                << std::endl;
+  std::cout << std::endl;
+
   try {
     return main_( argc, argv );
   } catch ( std::exception &e ) {

--- a/src/runtime_src/tools/xclbin/xclbinsplit.cxx
+++ b/src/runtime_src/tools/xclbin/xclbinsplit.cxx
@@ -66,6 +66,15 @@ int main_( int argc, char** argv )
 
 int main( int argc, char** argv )
 {
+  std::cout << std::endl;
+  std::cout << "**** DEPRICATION WARNING ****"                                             << std::endl;
+  std::cout << "xclbincat and xclbinsplit utilities are replaced by xclbinutil."           << std::endl; 
+  std::cout << "You are recommended to use xclbinutil instead."                            << std::endl;
+  std::cout << std::endl;
+  std::cout << "The xclbincat and xclbinsplit utilities will be obsoleted and removed in " << std::endl; 
+  std::cout << "the next software release."                                                << std::endl;
+  std::cout << std::endl;
+
   try {
     return main_( argc, argv );
   } catch ( std::exception &e ) {


### PR DESCRIPTION
Created deprecation message for xclbincat and xclbinsplit.  
Fixed issue where the SectionHeader variable m_eType wasn't being initialized in the class constructor.