### PR TITLE
2018.3 : Pull Request to constantify the alloc_chan_mp callback and add to XMA Decoder Properties

### DIFF
--- a/src/xma/include/app/xmadecoder.h
+++ b/src/xma/include/app/xmadecoder.h
@@ -223,6 +223,14 @@ typedef struct XmaDecoderProperties
     XmaParameter    *params;
     /** count of custom parameters for port */
     uint32_t        param_cnt;
+    /** bits per pixel for primary plane of input video */
+    int32_t         bits_per_pixel;
+    /** width width in pixels of incoming video stream/data */
+    int32_t         width;
+    /** height height in pixels of incoming video stream/data */
+    int32_t         height;
+    /** framerate data structure specifying frame rate per second */
+    XmaFraction     framerate;
 } XmaDecoderProperties;
 
 /* Forward declaration */

--- a/src/xma/include/plg/xmasess.h
+++ b/src/xma/include/plg/xmasess.h
@@ -99,9 +99,9 @@ typedef struct {
  * channel
 */
 typedef int32_t (*xma_plg_alloc_chan_mp)(XmaSession *pending_sess,
-                                      uint16_t    curr_kern_load,
-                                      int32_t    *chan_ids,
-                                      uint8_t     chan_ids_cnt,
+                                      const uint16_t    curr_kern_load,
+                                      const int32_t    *chan_ids,
+                                      const uint8_t     chan_ids_cnt,
                                       XmaChannel *new_channel);
 /**
  * xma_plg_alloc_chan() - Optional plugin callback called when app calls xma_enc_session_create()

--- a/src/xma/include/plg/xmasess.h
+++ b/src/xma/include/plg/xmasess.h
@@ -137,7 +137,7 @@ typedef int32_t (*xma_plg_alloc_chan)(XmaSession *pending_sess,
  *
  * RETURN: next available channel id
 */
-static inline int32_t xma_plg_find_next_chan_id(int32_t *chan_ids, uint8_t cnt)
+static inline int32_t xma_plg_find_next_chan_id(const int32_t *chan_ids, const uint8_t cnt)
 {
     int i;
 


### PR DESCRIPTION
There are three commits in this pull request

1. The important one being the addition of video image properties to the XmaDecoderProperties structure, so that from an FFmpeg plugin, capacity related details can be passed to XMA. 

commit 1f92035 xma: include: app: xmadecoder.h : Add more details to XmaDecoderProperties

2. There are two trivial commits that constantify some parameters in the xmasess.h header

commit 77b972d xma : include : plg: xmasess.h : constantify the helper routine
commit ffb2a96   xma : include : xmasess.h : Constantify alloc_chan_mp function parameters