### PR TITLE
Acquire context on KDMA units before using them

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -2694,8 +2694,12 @@ static void client_release_implicit_cus(struct exec_core *exec,
 {
 	int i;
 
-	for (i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++)
+	SCHED_DEBUGF("-> %s", __func__);
+	for (i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++) {
+		SCHED_DEBUGF("+ cu(%d)", i);
 		clear_bit(i, client->cu_bitmap);
+	}
+	SCHED_DEBUGF("<- %s", __func__);
 }
 
 static void client_reserve_implicit_cus(struct exec_core *exec,
@@ -2703,8 +2707,12 @@ static void client_reserve_implicit_cus(struct exec_core *exec,
 {
 	int i;
 
-	for (i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++)
+	SCHED_DEBUGF("-> %s", __func__);
+	for (i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++) {
+		SCHED_DEBUGF("+ cu(%d)", i);
 		set_bit(i, client->cu_bitmap);
+	}
+	SCHED_DEBUGF("<- %s", __func__);
 }
 
 /**

--- a/src/runtime_src/xrt/scheduler/scheduler.cpp
+++ b/src/runtime_src/xrt/scheduler/scheduler.cpp
@@ -115,6 +115,9 @@ init(xrt::device* device, const axlf* top)
 {
   emu_50_disable_kds(device);
 
+  // In order to use virtual CUs (KDMA) we must open a virtual context
+  device->acquire_cu_context(-1,true);
+
   if (kds_enabled())
     kds::init(device,top);
   else


### PR DESCRIPTION
OCL needs to open a virtual context on the device to get access to
the implicit CU resources.

CR1025263