### PR TITLE
[MPSoC] Floating cu address

### DIFF
--- a/src/runtime_src/driver/common/scheduler.cpp
+++ b/src/runtime_src/driver/common/scheduler.cpp
@@ -212,7 +212,7 @@ get_dbg_ips_pair(const axlf* top)
  * Check sdaccel.ini for default overrides.
  */
 int
-init(xclDeviceHandle handle, const axlf* top, int encode)
+init(xclDeviceHandle handle, const axlf* top, bool encode)
 {
   uuid_t uuid;
   auto execbo = create_exec_bo(handle,0x1000);

--- a/src/runtime_src/driver/common/scheduler.cpp
+++ b/src/runtime_src/driver/common/scheduler.cpp
@@ -22,7 +22,6 @@
 #include <sys/mman.h>
 #include <memory>
 #include <string>
-#include <vector>
 #include <cstring>
 #include <uuid/uuid.h>
 
@@ -85,7 +84,7 @@ get_axlf_section(const axlf* top, axlf_section_kind kind)
 }
 
 static std::vector<uint64_t>
-get_cus(const axlf* top)
+get_cus(const axlf* top, bool encoding)
 {
   std::vector<uint64_t> cus;
   auto ip_layout = get_axlf_section<const ::ip_layout>(top,axlf_section_kind::IP_LAYOUT);
@@ -95,14 +94,43 @@ get_cus(const axlf* top)
   for (int32_t count=0; count <ip_layout->m_count; ++count) {
     const auto& ip_data = ip_layout->m_ip_data[count];
     if (ip_data.m_type == IP_TYPE::IP_KERNEL) {
-      // encode handshaking control in lower unused address bits
       uint64_t addr = ip_data.m_base_address;
-      addr |= ((ip_data.properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT);
+      if (encoding) {
+          // encode handshaking control in lower unused address bits
+          addr |= ((ip_data.properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT);
+      }
       cus.push_back(addr);
     }
   }
   std::sort(cus.begin(),cus.end());
   return cus;
+}
+
+static std::vector<std::pair<uint64_t, size_t> >
+get_debug_ips(const axlf* top)
+{
+  std::vector<std::pair<uint64_t, size_t> > ips;
+  auto debug_ip_layout = get_axlf_section<const ::debug_ip_layout>(top,
+                         axlf_section_kind::DEBUG_IP_LAYOUT);
+  if (!debug_ip_layout)
+    return ips;
+
+  for (int32_t count=0; count < debug_ip_layout->m_count; ++count) {
+    const auto& debug_ip_data = debug_ip_layout->m_debug_ip_data[count];
+    uint64_t addr = debug_ip_data.m_base_address;
+    // There is no size for each debug IP in the xclbin. Use hardcoding size now.
+    // The default size is 64KB.
+    size_t size = 0x10000;
+    if (debug_ip_data.m_type == AXI_MONITOR_FIFO_LITE
+        || debug_ip_data.m_type == AXI_MONITOR_FIFO_FULL)
+       // The size of these two type of IPs is 8KB
+       size = 0x2000;
+
+    ips.push_back(std::make_pair(addr, size));
+  }
+
+  std::sort(ips.begin(), ips.end());
+  return ips;
 }
 
 static uint64_t
@@ -153,10 +181,28 @@ get_dataflow(const axlf* top)
   return false;
 }
 
-
 } // unnamed
 
 namespace xrt_core { namespace scheduler {
+
+std::vector<std::pair<uint64_t, size_t> >
+get_cus_pair(const axlf* top)
+{
+  std::vector<uint64_t> cus;
+  std::vector<std::pair<uint64_t, size_t> > ret;
+  cus = get_cus(top, false);
+
+  for (auto it = cus.begin(); it != cus.end(); ++it)
+    ret.push_back(std::make_pair(*it, 0x10000));
+
+  return ret;
+}
+
+std::vector<std::pair<uint64_t, size_t> >
+get_dbg_ips_pair(const axlf* top)
+{
+  return get_debug_ips(top);
+}
 
 /**
  * init() - Initialize scheduler
@@ -166,7 +212,7 @@ namespace xrt_core { namespace scheduler {
  * Check sdaccel.ini for default overrides.
  */
 int
-init(xclDeviceHandle handle, const axlf* top)
+init(xclDeviceHandle handle, const axlf* top, int encode)
 {
   uuid_t uuid;
   auto execbo = create_exec_bo(handle,0x1000);
@@ -174,7 +220,7 @@ init(xclDeviceHandle handle, const axlf* top)
   ecmd->state = ERT_CMD_STATE_NEW;
   ecmd->opcode = ERT_CONFIGURE;
 
-  auto cus = get_cus(top);
+  auto cus = get_cus(top, encode);
 
   ecmd->slot_size = config::get_ert_slotsize();
   ecmd->num_cus = cus.size();

--- a/src/runtime_src/driver/common/scheduler.cpp
+++ b/src/runtime_src/driver/common/scheduler.cpp
@@ -95,10 +95,9 @@ get_cus(const axlf* top, bool encoding)
     const auto& ip_data = ip_layout->m_ip_data[count];
     if (ip_data.m_type == IP_TYPE::IP_KERNEL) {
       uint64_t addr = ip_data.m_base_address;
-      if (encoding) {
+      if (encoding)
           // encode handshaking control in lower unused address bits
           addr |= ((ip_data.properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT);
-      }
       cus.push_back(addr);
     }
   }

--- a/src/runtime_src/driver/common/scheduler.cpp
+++ b/src/runtime_src/driver/common/scheduler.cpp
@@ -85,7 +85,7 @@ namespace xrt_core { namespace scheduler {
  * Check sdaccel.ini for default overrides.
  */
 int
-init(xclDeviceHandle handle, const axlf* top, bool encode)
+init(xclDeviceHandle handle, const axlf* top)
 {
   uuid_t uuid;
   auto execbo = create_exec_bo(handle,0x1000);
@@ -93,7 +93,7 @@ init(xclDeviceHandle handle, const axlf* top, bool encode)
   ecmd->state = ERT_CMD_STATE_NEW;
   ecmd->opcode = ERT_CONFIGURE;
 
-  auto cus = xclbin::get_cus(top, encode);
+  auto cus = xclbin::get_cus(top, true);
 
   ecmd->slot_size = config::get_ert_slotsize();
   ecmd->num_cus = cus.size();

--- a/src/runtime_src/driver/common/scheduler.h
+++ b/src/runtime_src/driver/common/scheduler.h
@@ -33,7 +33,7 @@ namespace xrt_core { namespace scheduler {
  * Check sdaccel.ini for default overrides.
  */
 int
-init(xclDeviceHandle handle, const axlf* top, bool encode);
+init(xclDeviceHandle handle, const axlf* top);
 
 }} // utils,xrt
 

--- a/src/runtime_src/driver/common/scheduler.h
+++ b/src/runtime_src/driver/common/scheduler.h
@@ -19,24 +19,11 @@
 
 #include "driver/include/xclhal2.h"
 #include "driver/include/xclbin.h"
-#include <vector>
 
 // This is interim, must be consolidated with runtime_src/xrt/scheduler
 // when XRT C++ code is refactored.
 
 namespace xrt_core { namespace scheduler {
-
-/**
- * get_cus_pair() - Get list CUs physical address & size pair
- */
-std::vector<std::pair<uint64_t, size_t> >
-get_cus_pair(const axlf* top);
-
-/**
- * get_dbg_ips_pair() - Get list of Debug IPs physical address & size pair
- */
-std::vector<std::pair<uint64_t, size_t> >
-get_dbg_ips_pair(const axlf* top);
 
 /**
  * init() - Initialize scheduler

--- a/src/runtime_src/driver/common/scheduler.h
+++ b/src/runtime_src/driver/common/scheduler.h
@@ -19,11 +19,25 @@
 
 #include "driver/include/xclhal2.h"
 #include "driver/include/xclbin.h"
+#include <map>
+#include <vector>
 
 // This is interim, must be consolidated with runtime_src/xrt/scheduler
 // when XRT C++ code is refactored.
 
 namespace xrt_core { namespace scheduler {
+
+/**
+ * get_cus_pair() - Get list CUs physical address & size pair
+ */
+std::vector<std::pair<uint64_t, size_t> >
+get_cus_pair(const axlf* top);
+
+/**
+ * get_dbg_ips_pair() - Get list of Debug IPs physical address & size pair
+ */
+std::vector<std::pair<uint64_t, size_t> >
+get_dbg_ips_pair(const axlf* top);
 
 /**
  * init() - Initialize scheduler
@@ -33,7 +47,7 @@ namespace xrt_core { namespace scheduler {
  * Check sdaccel.ini for default overrides.
  */
 int
-init(xclDeviceHandle handle, const axlf* top);
+init(xclDeviceHandle handle, const axlf* top, int encode);
 
 }} // utils,xrt
 

--- a/src/runtime_src/driver/common/scheduler.h
+++ b/src/runtime_src/driver/common/scheduler.h
@@ -19,7 +19,6 @@
 
 #include "driver/include/xclhal2.h"
 #include "driver/include/xclbin.h"
-#include <map>
 #include <vector>
 
 // This is interim, must be consolidated with runtime_src/xrt/scheduler

--- a/src/runtime_src/driver/common/scheduler.h
+++ b/src/runtime_src/driver/common/scheduler.h
@@ -47,7 +47,7 @@ get_dbg_ips_pair(const axlf* top);
  * Check sdaccel.ini for default overrides.
  */
 int
-init(xclDeviceHandle handle, const axlf* top, int encode);
+init(xclDeviceHandle handle, const axlf* top, bool encode);
 
 }} // utils,xrt
 

--- a/src/runtime_src/driver/common/xclbin_parser.cpp
+++ b/src/runtime_src/driver/common/xclbin_parser.cpp
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "xclbin_parser.h"
+
+// This is xclbin parser. Update this file if xclbin format has changed.
+
+namespace xrt_core { namespace xclbin {
+
+template <typename SectionType>
+static SectionType*
+get_axlf_section(const axlf* top, axlf_section_kind kind)
+{
+  if (auto header = ::xclbin::get_axlf_section(top, kind)) {
+    auto begin = reinterpret_cast<const char*>(top) + header->m_sectionOffset ;
+    return reinterpret_cast<SectionType*>(begin);
+  }
+  return nullptr;
+}
+
+std::vector<uint64_t>
+get_cus(const axlf* top, bool encoding)
+{
+  std::vector<uint64_t> cus;
+  auto ip_layout = get_axlf_section<const ::ip_layout>(top,axlf_section_kind::IP_LAYOUT);
+  if (!ip_layout)
+   return cus;
+
+  for (int32_t count=0; count <ip_layout->m_count; ++count) {
+    const auto& ip_data = ip_layout->m_ip_data[count];
+    if (ip_data.m_type == IP_TYPE::IP_KERNEL) {
+      uint64_t addr = ip_data.m_base_address;
+      if (encoding)
+          // encode handshaking control in lower unused address bits
+          addr |= ((ip_data.properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT);
+      cus.push_back(addr);
+    }
+  }
+  std::sort(cus.begin(),cus.end());
+  return cus;
+}
+
+std::vector<std::pair<uint64_t, size_t> >
+get_debug_ips(const axlf* top)
+{
+  std::vector<std::pair<uint64_t, size_t> > ips;
+  auto debug_ip_layout = get_axlf_section<const ::debug_ip_layout>(top,
+                         axlf_section_kind::DEBUG_IP_LAYOUT);
+  if (!debug_ip_layout)
+    return ips;
+
+  for (int32_t count=0; count < debug_ip_layout->m_count; ++count) {
+    const auto& debug_ip_data = debug_ip_layout->m_debug_ip_data[count];
+    uint64_t addr = debug_ip_data.m_base_address;
+    // There is no size for each debug IP in the xclbin. Use hardcoding size now.
+    // The default size is 64KB.
+    size_t size = 0x10000;
+    if (debug_ip_data.m_type == AXI_MONITOR_FIFO_LITE
+        || debug_ip_data.m_type == AXI_MONITOR_FIFO_FULL)
+       // The size of these two type of IPs is 8KB
+       size = 0x2000;
+
+    ips.push_back(std::make_pair(addr, size));
+  }
+
+  std::sort(ips.begin(), ips.end());
+  return ips;
+}
+
+uint64_t
+get_cu_base_offset(const axlf* top)
+{
+  std::vector<uint64_t> cus;
+  auto ip_layout = get_axlf_section<const ::ip_layout>(top,axlf_section_kind::IP_LAYOUT);
+  if (!ip_layout)
+    return 0;
+
+  uint64_t base = std::numeric_limits<uint32_t>::max();
+  for (int32_t count=0; count <ip_layout->m_count; ++count) {
+    const auto& ip_data = ip_layout->m_ip_data[count];
+    if (ip_data.m_type == IP_TYPE::IP_KERNEL)
+      base = std::min(base,ip_data.m_base_address);
+  }
+  return base;
+}
+
+bool
+get_cuisr(const axlf* top)
+{
+  auto ip_layout = get_axlf_section<const ::ip_layout>(top,axlf_section_kind::IP_LAYOUT);
+  if (!ip_layout)
+    return false;
+
+  for (int32_t count=0; count <ip_layout->m_count; ++count) {
+    const auto& ip_data = ip_layout->m_ip_data[count];
+    if (ip_data.m_type==IP_TYPE::IP_KERNEL && !(ip_data.properties & 0x1))
+      return false;
+  }
+  return true;
+}
+
+bool
+get_dataflow(const axlf* top)
+{
+  auto ip_layout = get_axlf_section<const ::ip_layout>(top,axlf_section_kind::IP_LAYOUT);
+  if (!ip_layout)
+    return false;
+
+  for (int32_t count=0; count <ip_layout->m_count; ++count) {
+    const auto& ip_data = ip_layout->m_ip_data[count];
+    if (ip_data.m_type == IP_TYPE::IP_KERNEL &&
+        ((ip_data.properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT) == AP_CTRL_CHAIN)
+        return true;
+  }
+  return false;
+}
+
+std::vector<std::pair<uint64_t, size_t> >
+get_cus_pair(const axlf* top)
+{
+  std::vector<uint64_t> cus;
+  std::vector<std::pair<uint64_t, size_t> > ret;
+  cus = get_cus(top, false);
+
+  for (auto it = cus.begin(); it != cus.end(); ++it)
+    // CU size is 64KB
+    ret.push_back(std::make_pair(*it, 0x10000));
+
+  return ret;
+}
+
+std::vector<std::pair<uint64_t, size_t> >
+get_dbg_ips_pair(const axlf* top)
+{
+  return get_debug_ips(top);
+}
+
+} // namespace xclbin
+} // namespace xrt_core

--- a/src/runtime_src/driver/common/xclbin_parser.h
+++ b/src/runtime_src/driver/common/xclbin_parser.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef xclbin_parser_h_
+#define xclbin_parser_h_
+
+#include "driver/include/xclbin.h"
+#include <vector>
+
+namespace xrt_core { namespace xclbin {
+
+std::vector<uint64_t>
+get_cus(const axlf* top, bool encoding);
+
+std::vector<std::pair<uint64_t, size_t> >
+get_debug_ips(const axlf* top);
+
+uint64_t
+get_cu_base_offset(const axlf* top);
+
+bool
+get_cuisr(const axlf* top);
+
+bool
+get_dataflow(const axlf* top);
+
+/**
+ * get_cus_pair() - Get list CUs physical address & size pair
+ */
+std::vector<std::pair<uint64_t, size_t> >
+get_cus_pair(const axlf* top);
+
+/**
+ * get_dbg_ips_pair() - Get list of Debug IPs physical address & size pair
+ */
+std::vector<std::pair<uint64_t, size_t> >
+get_dbg_ips_pair(const axlf* top);
+
+} // xclbin
+} // xrt_core
+
+#endif

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/halapi.cxx
@@ -317,7 +317,7 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
     return -1;
   auto ret = drv->xclLoadXclBin(buffer);
   if (!ret)
-      ret = xrt_core::scheduler::init(handle,buffer);
+      ret = xrt_core::scheduler::init(handle, buffer, true);
   return ret;
 }
 

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/halapi.cxx
@@ -317,7 +317,7 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
     return -1;
   auto ret = drv->xclLoadXclBin(buffer);
   if (!ret)
-      ret = xrt_core::scheduler::init(handle, buffer, true);
+      ret = xrt_core::scheduler::init(handle, buffer);
   return ret;
 }
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -1908,7 +1908,7 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
     xocl::XOCLShim *drv = xocl::XOCLShim::handleCheck(handle);
     auto ret = drv ? drv->xclLoadXclBin(buffer) : -ENODEV;
     if (!ret)
-      ret = xrt_core::scheduler::init(handle, buffer, true);
+      ret = xrt_core::scheduler::init(handle, buffer);
     return ret;
 }
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.cpp
@@ -1908,7 +1908,7 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
     xocl::XOCLShim *drv = xocl::XOCLShim::handleCheck(handle);
     auto ret = drv ? drv->xclLoadXclBin(buffer) : -ENODEV;
     if (!ret)
-      ret = xrt_core::scheduler::init(handle,buffer);
+      ret = xrt_core::scheduler::init(handle, buffer, true);
     return ret;
 }
 

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -291,26 +291,6 @@ cu_idx_to_addr(struct drm_device *dev, unsigned int cu_idx)
 }
 
 /**
- * addr_to_cu_idx - Find the CU idx by physical address
- *
- * @cu_list: CU physical address list
- * @num_cus: The length of the address list
- * @addr: The address of the CU we are looking for
- * Return: The index of the CU. If return equals to num_cus, CU is not found
- */
-int addr_to_cu_idx(struct drm_device *dev, u32 addr)
-{
-	struct drm_zocl_dev *zdev = dev->dev_private;
-	int i;
-
-	for (i = 0; i < zdev->exec->num_cus; i++) {
-		if (zdev->exec->cu_addr_phy[i] == addr)
-			break;
-	}
-	return i;
-}
-
-/**
  * set_cmd_int_state() - Set internal command state used by scheduler only
  *
  * @xcmd: command to change internal state on

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -210,7 +210,6 @@ slot_idx_from_mask_idx(unsigned int slot_idx, unsigned int mask_idx)
 	return slot_idx + (mask_idx << 5);
 }
 
-
 /**
  * opcode() - Command opcode
  *
@@ -277,34 +276,38 @@ regmap_size(struct sched_cmd *cmd)
 }
 
 /**
- * cu_idx_to_addr() - Convert CU idx into it physical address.
+ * cu_idx_to_addr() - Convert CU idx into it virtual address.
  *
  * @dev: Device handle
  * @cu_idx: Global CU idx
- * Return: Address of CU relative to bar
+ * Return: Virturl address of the CU
  */
-inline u32
+inline void __iomem *
 cu_idx_to_addr(struct drm_device *dev, unsigned int cu_idx)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
 
-	return (cu_idx << zdev->exec->cu_shift_offset)
-		     + zdev->exec->cu_base_addr;
+	return zdev->exec->cu_addr_virt[cu_idx];
 }
 
 /**
- * cu_idx_to_offset() - Convert CU idx into address offset
+ * addr_to_cu_idx - Find the CU idx by physical address
  *
- * @dev: Device handle
- * @cu_idx: Global CU idx
- * Return: Address of CU relative to bar
+ * @cu_list: CU physical address list
+ * @num_cus: The length of the address list
+ * @addr: The address of the CU we are looking for
+ * Return: The index of the CU. If return equals to num_cus, CU is not found
  */
-inline u32
-cu_idx_to_offset(struct drm_device *dev, unsigned int cu_idx)
+int addr_to_cu_idx(struct drm_device *dev, u32 addr)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
+	int i;
 
-	return cu_idx << zdev->exec->cu_shift_offset;
+	for (i = 0; i < zdev->exec->num_cus; i++) {
+		if (zdev->exec->cu_addr_phy[i] == addr)
+			break;
+	}
+	return i;
 }
 
 /**
@@ -379,9 +382,9 @@ void setup_ert_hw(struct drm_zocl_dev *zdev)
 }
 
 inline void
-disable_interrupts(struct drm_device *dev, u32 *base, int cu_idx)
+disable_interrupts(struct drm_device *dev, int cu_idx)
 {
-	u32 __iomem *virt_addr = base + cu_idx_to_offset(dev, cu_idx);
+	u32 __iomem *virt_addr = cu_idx_to_addr(dev, cu_idx);
 
 	/* 0x04 and 0x08 -- Interrupt Enable Registers */
 	iowrite32(0x0, virt_addr + 1);
@@ -390,9 +393,9 @@ disable_interrupts(struct drm_device *dev, u32 *base, int cu_idx)
 }
 
 inline void
-enable_interrupts(struct drm_device *dev, u32 *base, int cu_idx)
+enable_interrupts(struct drm_device *dev, int cu_idx)
 {
-	u32 __iomem *virt_addr = base + cu_idx_to_offset(dev, cu_idx);
+	u32 __iomem *virt_addr = cu_idx_to_addr(dev, cu_idx);
 
 	/* 0x04 and 0x08 -- Interrupt Enable Registers */
 	iowrite32(0x1, virt_addr + 1);
@@ -421,7 +424,7 @@ static irqreturn_t sched_exec_isr(int irq, void *arg)
 		return IRQ_NONE;
 	}
 
-	virt_addr = zdev->regs + cu_idx_to_offset(zdev->ddev, cu_idx);
+	virt_addr = cu_idx_to_addr(zdev->ddev, cu_idx);
 	/* Clear all interrupts of the CU
 	 *
 	 * HLS style kernel has Interrupt Status Register at offset 0x0C
@@ -509,7 +512,7 @@ configure(struct sched_cmd *cmd)
 	cfg = (struct configure_cmd *)(cmd->packet);
 
 	if (exec->configured != 0) {
-		DRM_ERROR("Reconfiguration not supported\n");
+		DRM_WARN("Reconfiguration not supported\n");
 		return 1;
 	}
 
@@ -546,9 +549,18 @@ configure(struct sched_cmd *cmd)
 	}
 
 	for (i = 0; i < exec->num_cus; i++) {
+		if (is_valid_apts(zdev, cfg->data[i]) == -EINVAL) {
+			write_unlock(&zdev->attr_rwlock);
+			return 1;
+		}
 		exec->cu_addr_phy[i] = cfg->data[i];
-		SCHED_DEBUG("++ configure cu(%d) at 0x%x\n", i,
-		    exec->cu_addr_phy[i]);
+		exec->cu_addr_virt[i] = ioremap(exec->cu_addr_phy[i], CU_SIZE);
+		if (!exec->cu_addr_virt[i]) {
+			write_unlock(&zdev->attr_rwlock);
+			return 1;
+		}
+		SCHED_DEBUG("++ configure cu(%d) at 0x%x map to 0x%x\n", i,
+		    exec->cu_addr_phy[i], exec->cu_addr_virt[i]);
 	}
 
 	if (zdev->ert)
@@ -593,10 +605,10 @@ set_cu_and_print:
 	/* Do not trust user's interrupt enable setting in the start cu cmd */
 	if (exec->polling_mode)
 		for (i = 0; i < exec->num_cus; i++)
-			disable_interrupts(cmd->ddev, zdev->regs, i);
+			disable_interrupts(cmd->ddev, i);
 	else
 		for (i = 0; i < exec->num_cus; i++)
-			enable_interrupts(cmd->ddev, zdev->regs, i);
+			enable_interrupts(cmd->ddev, i);
 
 print_and_out:
 	write_unlock(&zdev->attr_rwlock);
@@ -828,7 +840,7 @@ inline int
 cu_done(struct drm_device *dev, unsigned int cu_idx)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
-	u32 *virt_addr = zdev->regs + cu_idx_to_offset(dev, cu_idx);
+	u32 *virt_addr = cu_idx_to_addr(dev, cu_idx);
 	u32 status;
 
 	SCHED_DEBUG("-> cu_done(,%d) checks cu at address 0x%p\n",
@@ -949,7 +961,7 @@ inline int
 ert_cu_done(struct drm_device *dev, unsigned int cu_idx)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
-	u32 *virt_addr = zdev->regs + cu_idx_to_offset(dev, cu_idx);
+	u32 *virt_addr = cu_idx_to_addr(dev, cu_idx);
 	u32 status;
 
 	SCHED_DEBUG("-> ert_cu_done(,%d) checks cu at address 0x%p\n",
@@ -1306,9 +1318,8 @@ get_free_cu(struct sched_cmd *cmd, enum zocl_cu_type cu_type)
 static void
 configure_cu(struct sched_cmd *cmd, int cu_idx)
 {
-	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
 	u32 i, size = regmap_size(cmd);
-	u32 *virt_addr = zdev->regs + cu_idx_to_offset(cmd->ddev, cu_idx);
+	u32 *virt_addr = cu_idx_to_addr(cmd->ddev, cu_idx);
 	struct start_kernel_cmd *sk = (struct start_kernel_cmd *)cmd->packet;
 
 	SCHED_DEBUG("-> configure_cu cu_idx=%d, cu_addr=0x%p, regmap_size=%d\n",
@@ -1341,9 +1352,8 @@ configure_cu(struct sched_cmd *cmd, int cu_idx)
 static void
 ert_configure_cu(struct sched_cmd *cmd, int cu_idx)
 {
-	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
 	u32 i, size = regmap_size(cmd);
-	u32 *virt_addr = zdev->regs + cu_idx_to_offset(cmd->ddev, cu_idx);
+	u32 *virt_addr = cu_idx_to_addr(cmd->ddev, cu_idx);
 	struct start_kernel_cmd *sk = (struct start_kernel_cmd *)cmd->packet;
 
 	SCHED_DEBUG("-> ert_configure_cu ");
@@ -2148,7 +2158,6 @@ sched_init_exec(struct drm_device *drm)
 	init_waitqueue_head(&exec_core->poll_wait_queue);
 
 	exec_core->scheduler = &g_sched0;
-	exec_core->base = zdev->regs;
 	exec_core->num_slots = 16;
 	exec_core->num_cus = 0;
 	exec_core->cu_base_addr = 0;

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -536,7 +536,9 @@ configure(struct sched_cmd *cmd)
 		 * Now the zdev->ert is heavily used in configure()
 		 * Need cleanup.
 		 */
-		if (!zdev->ert && is_valid_apts(zdev, cfg->data[i]) < 0) {
+		if (!zdev->ert && get_apt_index(zdev, cfg->data[i]) < 0) {
+			DRM_ERROR("CU address %x is not found in XLBCIN\n",
+				  cfg->data[i]);
 			write_unlock(&zdev->attr_rwlock);
 			return 1;
 		}
@@ -548,6 +550,7 @@ configure(struct sched_cmd *cmd)
 		exec->cu_addr_phy[i] = zdev->res_start + cfg->data[i];
 		exec->cu_addr_virt[i] = ioremap(exec->cu_addr_phy[i], CU_SIZE);
 		if (!exec->cu_addr_virt[i]) {
+			DRM_ERROR("Mapping CU failed\n");
 			write_unlock(&zdev->attr_rwlock);
 			return 1;
 		}

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -340,6 +340,7 @@ struct sched_exec_core {
 	u32                        scu_status[MAX_U32_CU_MASKS];
 
 	u32                        cu_addr_phy[MAX_CUS];
+	void __iomem              *cu_addr_virt[MAX_CUS];
 	u32                        cu_usage[MAX_CUS];
 
 	struct sched_ops          *ops;
@@ -418,5 +419,7 @@ int sched_fini_exec(struct drm_device *drm);
 
 void zocl_track_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 void zocl_untrack_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
+
+int addr_to_cu_idx(struct drm_device *dev, u32 addr);
 
 #endif

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -27,9 +27,9 @@
 #include "zocl_drv.h"
 
 #define MAX_SLOTS 128
-#define MAX_CUS 128
 #define MAX_U32_SLOT_MASKS (((MAX_SLOTS-1)>>5) + 1)
-#define MAX_U32_CU_MASKS (((MAX_CUS-1)>>5) + 1)
+/* MAX_CU_NUM are defined in zocl_util.h */
+#define MAX_U32_CU_MASKS (((MAX_CU_NUM-1)>>5) + 1)
 #define U32_MASK 0xFFFFFFFF
 
 /**
@@ -339,9 +339,9 @@ struct sched_exec_core {
 	/* Soft kernel definitions */
 	u32                        scu_status[MAX_U32_CU_MASKS];
 
-	u32                        cu_addr_phy[MAX_CUS];
-	void __iomem              *cu_addr_virt[MAX_CUS];
-	u32                        cu_usage[MAX_CUS];
+	u32                        cu_addr_phy[MAX_CU_NUM];
+	void __iomem              *cu_addr_virt[MAX_CU_NUM];
+	u32                        cu_usage[MAX_CU_NUM];
 
 	struct sched_ops          *ops;
 	struct task_struct        *cq_thread;

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -420,6 +420,4 @@ int sched_fini_exec(struct drm_device *drm);
 void zocl_track_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 void zocl_untrack_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 
-int addr_to_cu_idx(struct drm_device *dev, u32 addr);
-
 #endif

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
@@ -557,13 +557,8 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	if (!zdev)
 		return -ENOMEM;
 
-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	/* If res is NULL, skip */
-	if (res)
-		zdev->res_start = res->start;
-
 	/* Record and get IRQ number */
-	for (index = 0; index < MAX_CUS; index++) {
+	for (index = 0; index < MAX_CU_NUM; index++) {
 		irq = platform_get_irq(pdev, index);
 		if (irq < 0)
 			break;
@@ -586,6 +581,16 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	subdev = find_pdev("80180000.ert_hw");
 	if (subdev) {
 		DRM_INFO("ert_hw found -> %p\n", subdev);
+		/* Trust device tree for now, but a better place should be
+		 * feature rom.
+		 */
+		res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+		if (!res) {
+			DRM_ERROR("The base address of CU is not found or 0\n");
+			return -EINVAL;
+		}
+
+		zdev->res_start = res->start;
 		zdev->ert = (struct zocl_ert_dev *)platform_get_drvdata(subdev);
 	}
 

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
@@ -121,6 +121,6 @@ void zocl_free_sections(struct drm_zocl_dev *zdev);
 void zocl_free_bo(struct drm_gem_object *obj);
 void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count);
 
-int is_valid_apts(struct drm_zocl_dev *zdev, phys_addr_t addr);
+int get_apt_index(struct drm_zocl_dev *zdev, phys_addr_t addr);
 
 #endif

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.h
@@ -121,4 +121,6 @@ void zocl_free_sections(struct drm_zocl_dev *zdev);
 void zocl_free_bo(struct drm_gem_object *obj);
 void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count);
 
+int is_valid_apts(struct drm_zocl_dev *zdev, phys_addr_t addr);
+
 #endif

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
@@ -416,7 +416,7 @@ zocl_update_apertures(struct drm_zocl_dev *zdev)
 		return -EINVAL;
 	}
 
-	apt = kcalloc(total * sizeof(struct addr_aperture), GFP_KERNEL);
+	apt = kcalloc(total, sizeof(struct addr_aperture), GFP_KERNEL);
 	if (!apt) {
 		DRM_ERROR("Out of memory\n");
 		return -ENOMEM;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
@@ -385,6 +385,46 @@ zocl_read_sect(enum axlf_section_kind kind, void *sect,
 	return size;
 }
 
+/* Record all of the hardware address apertures in the XCLBIN
+ * This could be used to verify if the configure command set wrong CU base
+ * address and allow user map one of the aperture to user space.
+ *
+ * The xclbin doesn't contain IP size. Use hardcoding size for now.
+ */
+void
+zocl_update_apertures(struct drm_zocl_dev *zdev)
+{
+	struct ip_data *ip;
+	struct debug_ip_data *dbg_ip;
+	int i;
+
+	if (zdev->ip) {
+		for (i = 0; i < zdev->ip->m_count; ++i) {
+			ip = &zdev->ip->m_ip_data[i];
+			zdev->apertures[zdev->num_apts].addr = ip->m_base_address;
+			zdev->apertures[zdev->num_apts].size = CU_SIZE;
+			zdev->num_apts++;
+		}
+	}
+
+	if (zdev->debug_ip) {
+		for (i = 0; i < zdev->debug_ip->m_count; ++i) {
+			dbg_ip = &zdev->debug_ip->m_debug_ip_data[i];
+			zdev->apertures[zdev->num_apts].addr = dbg_ip->m_base_address;
+			if (dbg_ip->m_type == AXI_MONITOR_FIFO_LITE
+			    || dbg_ip->m_type == AXI_MONITOR_FIFO_FULL)
+				/* FIFO_LITE has 4KB and FIFO FULL has 8KB
+				 * address range. Use both 8K is okay.
+				 */
+				zdev->apertures[zdev->num_apts].size = _8KB;
+			else
+				/* Others debug IPs have 64KB address range*/
+				zdev->apertures[zdev->num_apts].size = _64KB;
+			zdev->num_apts++;
+		}
+	}
+}
+
 int
 zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 {
@@ -457,6 +497,8 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		ret = -EINVAL;
 		goto out0;
 	}
+
+	zocl_update_apertures(zdev);
 
 	/* Populating CONNECTIVITY sections */
 	size = zocl_read_sect(CONNECTIVITY, &zdev->connectivity, axlf, xclbin);

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
@@ -401,7 +401,6 @@ zocl_update_apertures(struct drm_zocl_dev *zdev)
 	int i;
 
 	/* Update aperture should only happen when loading xclbin */
-	DRM_INFO("minm clean apertures\n");
 	kfree(zdev->apertures);
 	zdev->num_apts = 0;
 

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
@@ -28,7 +28,7 @@
 #define _8KB	0x2000
 #define _64KB	0x10000
 
-#define MAX_CUS 128
+#define MAX_CU_NUM 128
 #define CU_SIZE _64KB
 
 /* Now only for CUs and Debug IPs */
@@ -66,7 +66,7 @@ struct drm_zocl_dev {
 	/* Record start address, this is only for MPSoC as PCIe platform */
 	phys_addr_t		 res_start;
 	unsigned int		 cu_num;
-	unsigned int             irq[MAX_CUS];
+	unsigned int             irq[MAX_CU_NUM];
 	struct sched_exec_core  *exec;
 
 	struct mem_topology	*topology;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
@@ -31,9 +31,6 @@
 #define MAX_CU_NUM 128
 #define CU_SIZE _64KB
 
-/* Now only for CUs and Debug IPs */
-#define MAX_APERTURES 144
-
 #define CLEAR(x) \
 	memset(&x, 0, sizeof(x))
 
@@ -73,7 +70,7 @@ struct drm_zocl_dev {
 	struct ip_layout	*ip;
 	struct debug_ip_layout	*debug_ip;
 	struct connectivity	*connectivity;
-	struct addr_aperture	 apertures[MAX_APERTURES];
+	struct addr_aperture	*apertures;
 	unsigned int		 num_apts;
 	struct drm_zocl_mm_stat	 mm_usage;
 	u64			 unique_id_last_bitstream;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_util.h
@@ -24,7 +24,15 @@
 #define zocl_dbg(dev, fmt, args...)     \
 	dev_dbg(dev, "%s: "fmt, __func__, ##args)
 
-#define MAX_CU_NUM 128
+#define _4KB	0x1000
+#define _8KB	0x2000
+#define _64KB	0x10000
+
+#define MAX_CUS 128
+#define CU_SIZE _64KB
+
+/* Now only for CUs and Debug IPs */
+#define MAX_APERTURES 144
 
 #define CLEAR(x) \
 	memset(&x, 0, sizeof(x))
@@ -43,24 +51,30 @@ struct drm_zocl_mm_stat {
 	unsigned int bo_count;
 };
 
+struct addr_aperture {
+	phys_addr_t	addr;
+	size_t		size;
+};
+
 struct drm_zocl_dev {
 	struct drm_device       *ddev;
 	struct fpga_manager     *fpga_mgr;
 	struct zocl_ert_dev     *ert;
 	struct iommu_domain     *domain;
-	void __iomem            *regs;
-	phys_addr_t              res_start;
-	resource_size_t          res_len;
 	phys_addr_t              host_mem;
 	resource_size_t          host_mem_len;
+	/* Record start address, this is only for MPSoC as PCIe platform */
+	phys_addr_t		 res_start;
 	unsigned int		 cu_num;
-	unsigned int             irq[MAX_CU_NUM];
+	unsigned int             irq[MAX_CUS];
 	struct sched_exec_core  *exec;
 
 	struct mem_topology	*topology;
 	struct ip_layout	*ip;
 	struct debug_ip_layout	*debug_ip;
 	struct connectivity	*connectivity;
+	struct addr_aperture	 apertures[MAX_APERTURES];
+	unsigned int		 num_apts;
 	struct drm_zocl_mm_stat	 mm_usage;
 	u64			 unique_id_last_bitstream;
 

--- a/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc.dts
+++ b/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc.dts
@@ -14,7 +14,6 @@
 	zyxclmm_drm {
 		compatible = "xlnx,zocl";
 		status = "okay";
-		reg = <0x0 0xA0000000 0x0 0x800000>;
 		interrupt-parent = <&axi_intc_0>;
 		interrupts = <0  4>, <1  4>, <2  4>, <3  4>,
 			     <4  4>, <5  4>, <6  4>, <7  4>,

--- a/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc_smmu.dts
+++ b/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_mpsoc_smmu.dts
@@ -1,15 +1,8 @@
 
-/{
-	xlnk {
-		compatible = "xlnx,xlnk-1.0";
-	};
-};
-
 &amba {
         zyxclmm_drm: zyxclmm_drm@0xA0000000 {
                 compatible = "xlnx,zoclsvm";
                 status = "okay";
-		reg = <0x0 0xA0000000 0x0 0x800000>;
                 #stream-id-cells = <1>;
                 iommus = <&smmu 0xe80>;
         };

--- a/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_zynq.dts
+++ b/src/runtime_src/driver/zynq/fragments/xlnk_dts_fragment_zynq.dts
@@ -1,15 +1,8 @@
 
-/{
-	xlnk {
-		compatible = "xlnx,xlnk-1.0";
-	};
-};
-
 &amba {
 	zyxclmm_drm {
 		compatible = "xlnx,zocl";
 		status = "okay";
-		reg = <0x40000000 0x800000>;
 	};
 };
 

--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -38,11 +38,6 @@
 #include <assert.h>
 
 #define GB(x)   ((size_t) (x) << 30)
-#ifdef __aarch64__
-#define BASE_ADDRESS 0xA0000000
-#else
-#define BASE_ADDRESS 0x40000000
-#endif
 
 static std::string parseCUStatus(unsigned val) {
   char delim = '(';
@@ -113,15 +108,7 @@ ZYNQShim::ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel ve
   profiling = new ZYNQShimProfiling(this);
   //TODO: Use board number
   mKernelFD = open("/dev/dri/renderD128", O_RDWR);
-  if(mKernelFD) {
-    mKernelControlPtr = (uint32_t*)mmap(0, 0x800000, PROT_READ | PROT_WRITE, MAP_SHARED, mKernelFD, 0);
-    if (mKernelControlPtr == MAP_FAILED) {
-        printf("Map failed \n");
-        close(mKernelFD);
-        mKernelFD = -1;
-    }
-//    printf("Compute Unit addr: %p\n", mKernelControlPtr);
-  } else {
+  if (!mKernelFD) {
     printf("Cannot open /dev/dri/renderD128 \n");
   }
   if (logfileName && (logfileName[0] != '\0')) {
@@ -130,6 +117,7 @@ ZYNQShim::ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel ve
     mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
   }
 }
+
 #ifndef __HWEM__
 ZYNQShim::~ZYNQShim()
 {
@@ -146,40 +134,105 @@ ZYNQShim::~ZYNQShim()
 }
 #endif
 
+// This function is for internal mapping CU and debug IP only.
+// For the future, this could be used to support any address aperture.
+int ZYNQShim::mapKernelControl(const std::vector<std::pair<uint64_t, size_t>>& offsets) {
+  void *ptr = NULL;
 
-//TODO: UKP: return definition is not defined.
+  if (offsets.size() == 0) {
+    // The offsets list is empty. Just skip mapping.
+    return 0;
+  }
+
+  auto offset_it = offsets.begin();
+  auto end = offsets.end();
+
+  while (offset_it != end) {
+    auto it = mKernelControl.find(offset_it->first);
+    if (it == mKernelControl.end()) {
+      ptr = mmap(0, offset_it->second, PROT_READ | PROT_WRITE, MAP_SHARED, mKernelFD, offset_it->first);
+      if (!ptr) {
+          printf("Map failed for aperture 0x%lx, size 0x%x\n", offset_it->first, offset_it->second);
+          return -1;
+      }
+      mKernelControl.insert(it, std::pair<uint64_t, uint32_t *>(offset_it->first, (uint32_t *)ptr));
+    }
+    offset_it++;
+  }
+
+  return 0;
+}
+
+// This function is for internal use only.
+// It is used to find CUs or Debug IP's virtual address.
+void *ZYNQShim::getVirtAddressOfApture(xclAddressSpace space, const uint64_t phy_addr, uint64_t& offset)
+{
+    void *vaddr = NULL;
+    uint64_t mask = 0xFFFF;
+
+    // If CU size is still 64KiB, this is safe.
+    vaddr  = mKernelControl[phy_addr & ~mask];
+    offset = phy_addr & mask;
+    if (!vaddr && space == XCL_ADDR_SPACE_DEVICE_PERFMON) {
+      // Get base address again for Debug IPs.
+      // Since some Debug IP has 4KiB/8KiB register space.
+      // There is a risk that we only check 8KiB register space.
+      // The profiling library make sure that the offset will not be abused.
+      mask   = 0x1FFF;
+      vaddr  = mKernelControl[phy_addr & ~mask];
+      offset = phy_addr & mask;
+    }
+    if (!vaddr)
+        std::cout  << "Could not found the mapped address. Check if XCLBIN is loaded." << std::endl;
+
+    // If could not found the phy_addr in the mapping table, return will be NULL.
+    return vaddr;
+}
+
+// For xclRead and xclWrite. The offset is comming from XCLBIN.
+// It is the physical address on MPSoC.
+// It consists of base address of the aperture and offset in the aperture
+// Now the aceptable aperture are CUs and Debug IPs
 size_t ZYNQShim::xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
 {
-  if(!hostBuf) {
+  uint64_t off;
+  void *vaddr = NULL;
+
+  if (!hostBuf) {
+    std::cout  << "Invalid hostBuf." << std::endl;
     return -1;
   }
 
-  if(XCL_ADDR_KERNEL_CTRL == space || XCL_ADDR_SPACE_DEVICE_PERFMON == space) {
-    // Temp fix for offset issue. TODO: Umang
-    if(offset >= BASE_ADDRESS )
-      offset = offset - BASE_ADDRESS;
-    wordcopy((char*)mKernelControlPtr + offset, hostBuf, size);
-    return size;
+  vaddr = getVirtAddressOfApture(space, offset, off);
+  if (!vaddr) {
+    std::cout  << "Invalid offset." << std::endl;
+    return -1;
   }
-  return -1;
+
+  // Once reach here, vaddr and hostBuf should already be checked.
+  wordcopy((char *)vaddr + off, hostBuf, size);
+  return size;
 }
 
 size_t ZYNQShim::xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
 {
+  uint64_t off;
+  void *vaddr = NULL;
 
-  if(!hostBuf) {
+  if (!hostBuf) {
+    std::cout  << "Invalid hostBuf." << std::endl;
     return -1;
   }
 
-  if(XCL_ADDR_KERNEL_CTRL == space || XCL_ADDR_SPACE_DEVICE_PERFMON == space) {
-    // Temp fix for offset issue. TODO: Umang
-    if(offset >= BASE_ADDRESS )
-      offset = offset - BASE_ADDRESS;
-    wordcopy(hostBuf, (char*) mKernelControlPtr + offset, size );
-    return size;
+  vaddr = getVirtAddressOfApture(space, offset, off);
+  if (!vaddr) {
+    std::cout  << "Invalid offset." << std::endl;
+    return -1;
   }
 
-  return -1;
+  // Once reach here, vaddr and hostBuf should already be checked.
+  wordcopy(hostBuf, (char *)vaddr + off, size);
+  return size;
 }
 
 unsigned int ZYNQShim::xclAllocBO(size_t size, xclBOKind domain, unsigned flags) {
@@ -224,8 +277,6 @@ void ZYNQShim::xclFreeBO(unsigned int boHandle)
     mLogStream << "xclFreeBO result = " << result << std::endl;
   }
 }
-
-
 
 int ZYNQShim::xclGetBOInfo(uint64_t handle)
 {
@@ -673,9 +724,26 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
 {
     ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
     auto ret = drv ? drv->xclLoadXclBin(buffer) : -ENODEV;
-    if (!ret)
-        ret = xrt_core::scheduler::init(handle,buffer);
-    return ret;
+    if (ret) {
+        printf("Load Xclbin Failed\n");
+        return ret;
+    }
+    ret = xrt_core::scheduler::init(handle, buffer, true);
+    if (ret) {
+        printf("Scheduler init failed\n");
+        return ret;
+    }
+    ret = drv->mapKernelControl(xrt_core::scheduler::get_cus_pair(buffer));
+    if (ret) {
+        printf("Map CUs Failed\n");
+        return ret;
+    }
+    ret = drv->mapKernelControl(xrt_core::scheduler::get_dbg_ips_pair(buffer));
+    if (ret) {
+        printf("Map Debug IPs Failed\n");
+        return ret;
+    }
+    return 0;
 }
 
 size_t xclWrite(xclDeviceHandle handle, xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
@@ -801,23 +869,28 @@ size_t xclGetDeviceTimestamp(xclDeviceHandle handle)
 {
   return 0;
 }
+
 double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 {
   return 0;
 }
+
 double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   return 9600.0 ; // Needs to be adjusted to SoC value
 }
+
 double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   return 9600.0 ; // Needs to be adjusted to SoC value
 }
+
 void xclSetProfilingNumberSlots(xclDeviceHandle handle, xclPerfMonType type, uint32_t numSlots)
 {
   // No longer supported at this level
   return;
 }
+
 uint32_t xclGetProfilingNumberSlots(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -827,6 +900,7 @@ uint32_t xclGetProfilingNumberSlots(xclDeviceHandle handle, xclPerfMonType type)
     return -EINVAL;
   return drv->profiling->getProfilingNumberSlots(type);
 }
+
 void xclGetProfilingSlotName(xclDeviceHandle handle, xclPerfMonType type,
                              uint32_t slotnum, char* slotName, uint32_t length)
 {
@@ -837,6 +911,7 @@ void xclGetProfilingSlotName(xclDeviceHandle handle, xclPerfMonType type,
     return;
   drv->profiling->getProfilingSlotName(type, slotnum, slotName, length);
 }
+
 size_t xclPerfMonClockTraining(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -846,6 +921,7 @@ size_t xclPerfMonClockTraining(xclDeviceHandle handle, xclPerfMonType type)
     return -EINVAL;
   return 1; // Not yet enabled
 }
+
 size_t xclPerfMonStartCounters(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -855,6 +931,7 @@ size_t xclPerfMonStartCounters(xclDeviceHandle handle, xclPerfMonType type)
     return -EINVAL;
   return drv->profiling->xclPerfMonStartCounters(type);
 }
+
 size_t xclPerfMonStopCounters(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -864,6 +941,7 @@ size_t xclPerfMonStopCounters(xclDeviceHandle handle, xclPerfMonType type)
     return -EINVAL;
   return drv->profiling->xclPerfMonStopCounters(type);
 }
+
 size_t xclPerfMonReadCounters(xclDeviceHandle handle, xclPerfMonType type, xclCounterResults& counterResults)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -873,6 +951,7 @@ size_t xclPerfMonReadCounters(xclDeviceHandle handle, xclPerfMonType type, xclCo
     return -EINVAL;
   return drv->profiling->xclPerfMonReadCounters(type, counterResults);
 }
+
 size_t xclPerfMonStartTrace(xclDeviceHandle handle, xclPerfMonType type, uint32_t startTrigger)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -882,6 +961,7 @@ size_t xclPerfMonStartTrace(xclDeviceHandle handle, xclPerfMonType type, uint32_
     return -EINVAL;
   return drv->profiling->xclPerfMonStartTrace(type, startTrigger);
 }
+
 size_t xclPerfMonStopTrace(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -891,6 +971,7 @@ size_t xclPerfMonStopTrace(xclDeviceHandle handle, xclPerfMonType type)
     return -EINVAL;
   return drv->profiling->xclPerfMonStopTrace(type);
 }
+
 uint32_t xclPerfMonGetTraceCount(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -900,6 +981,7 @@ uint32_t xclPerfMonGetTraceCount(xclDeviceHandle handle, xclPerfMonType type)
     return -EINVAL;
   return drv->profiling->xclPerfMonGetTraceCount(type);
 }
+
 size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTraceResultsVector& traceVector)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
@@ -909,6 +991,7 @@ size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTrace
     return -EINVAL;
   return drv->profiling->xclPerfMonReadTrace(type, traceVector);
 }
+
 size_t xclDebugReadIPStatus(xclDeviceHandle handle, xclDebugReadType type,
                             void* debugResults)
 {

--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -729,7 +729,7 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
         printf("Load Xclbin Failed\n");
         return ret;
     }
-    ret = xrt_core::scheduler::init(handle, buffer, false);
+    ret = xrt_core::scheduler::init(handle, buffer);
     if (ret) {
         printf("Scheduler init failed\n");
         return ret;

--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -34,6 +34,7 @@
 #include <poll.h>
 #include "driver/common/message.h"
 #include "driver/common/scheduler.h"
+#include "driver/common/xclbin_parser.h"
 //#include "xclbin.h"
 #include <assert.h>
 
@@ -733,12 +734,12 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
         printf("Scheduler init failed\n");
         return ret;
     }
-    ret = drv->mapKernelControl(xrt_core::scheduler::get_cus_pair(buffer));
+    ret = drv->mapKernelControl(xrt_core::xclbin::get_cus_pair(buffer));
     if (ret) {
         printf("Map CUs Failed\n");
         return ret;
     }
-    ret = drv->mapKernelControl(xrt_core::scheduler::get_dbg_ips_pair(buffer));
+    ret = drv->mapKernelControl(xrt_core::xclbin::get_dbg_ips_pair(buffer));
     if (ret) {
         printf("Map Debug IPs Failed\n");
         return ret;

--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -728,7 +728,7 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
         printf("Load Xclbin Failed\n");
         return ret;
     }
-    ret = xrt_core::scheduler::init(handle, buffer, true);
+    ret = xrt_core::scheduler::init(handle, buffer, false);
     if (ret) {
         printf("Scheduler init failed\n");
         return ret;

--- a/src/runtime_src/driver/zynq/user/shim.h
+++ b/src/runtime_src/driver/zynq/user/shim.h
@@ -26,6 +26,8 @@
 //#include "driver/zynq/include/zynq_perfmon_params.h"
 #include <cstdint>
 #include <fstream>
+#include <map>
+#include <vector>
 
 namespace ZYNQ {
 
@@ -37,23 +39,33 @@ class ZYNQShim {
   static const int BUFFER_ALIGNMENT = 0x80; // TODO: UKP
 public:
   ~ZYNQShim();
-  ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity);
-  ZYNQShimProfiling* profiling ;
+  ZYNQShim(unsigned index, const char *logfileName,
+           xclVerbosityLevel verbosity);
+
+  // The entry of profiling functions
+  ZYNQShimProfiling* profiling;
+
+  int mapKernelControl(const std::vector<std::pair<uint64_t, size_t>>& offsets);
+  void *getVirtAddressOfApture(xclAddressSpace space, const uint64_t phy_addr, uint64_t& offset);
 
   // Raw read/write
-  size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
-  size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);
+  size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf,
+                  size_t size);
+  size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf,
+                 size_t size);
   unsigned int xclAllocBO(size_t size, xclBOKind domain, unsigned flags);
   unsigned int xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags);
   unsigned int xclGetHostBO(uint64_t paddr, size_t size);
   void xclFreeBO(unsigned int boHandle);
   int xclGetBOInfo(uint64_t handle);
-  int xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t seek);
+  int xclWriteBO(unsigned int boHandle, const void *src, size_t size,
+                 size_t seek);
   int xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip);
   void *xclMapBO(unsigned int boHandle, bool write);
   int xclExportBO(unsigned int boHandle);
   unsigned int xclImportBO(int fd, unsigned flags);
-  unsigned int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
+  unsigned int xclGetBOProperties(unsigned int boHandle,
+                                  xclBOProperties *properties);
   int xclExecBuf(unsigned int cmdBO);
   int xclExecWait(int timeoutMilliSec);
   int xclSKGetCmd(xclSKCmd *cmd);
@@ -62,11 +74,12 @@ public:
 
   uint xclGetNumLiveProcesses();
 
-  int xclGetSysfsPath(const char* subdev, const char* entry, char* sysfPath, size_t size);
+  int xclGetSysfsPath(const char *subdev, const char *entry, char *sysfPath,
+                      size_t size);
 
   // Bitstream/bin download
   int xclLoadXclBin(const xclBin *buffer);
-	int xclLoadAxlf(const axlf *buffer);
+  int xclLoadAxlf(const axlf *buffer);
 
   int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size,
                 size_t offset);
@@ -76,7 +89,7 @@ public:
   void xclWriteHostEvent(xclPerfMonEventType type, xclPerfMonEventID id);
 
   bool isGood() const;
-  static ZYNQShim *handleCheck(void * handle);
+  static ZYNQShim *handleCheck(void *handle);
 
 private:
   const int mBoardNumber = -1;
@@ -84,10 +97,8 @@ private:
   std::ifstream mVBNV;
   xclVerbosityLevel mVerbosity;
   int mKernelFD;
-  uint32_t* mKernelControlPtr;
+  std::map<uint64_t, uint32_t *> mKernelControl;
 };
-
-}
-;
+};
 
 #endif


### PR DESCRIPTION
1. Get rid of 'reg' in device tree, instead, use CU address from configure command.
2. Map CU to user space right after configure command. CU address and virtual address is recorded by a map.
3. Re-implemented xclRead() and xclWrite. Get rid of hard coding address