### PR TITLE
fix zynq lib xrt_core's dependency on lib uuid

### DIFF
--- a/src/runtime_src/driver/zynq/user/CMakeLists.txt
+++ b/src/runtime_src/driver/zynq/user/CMakeLists.txt
@@ -26,6 +26,7 @@ set_target_properties(xrt_core PROPERTIES VERSION ${XRT_VERSION_STRING}
 target_link_libraries(xrt_core
   pthread
   rt
+  uuid
   boost_filesystem
   boost_system
   )


### PR DESCRIPTION
Since driver/common/scheduler.cpp now depends on libuuid, xrt_core depends on uuid as well.