### PR TITLE
Release virtual CU on program unload

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1183,6 +1183,9 @@ load_program(program* program)
   m_active = program;
   profile::add_to_active_devices(get_unique_name());
 
+  // In order to use virtual CUs (KDMA) we must open a virtual context
+  m_xdevice->acquire_cu_context(-1,true);
+
   init_scheduler(this);
 }
 
@@ -1192,6 +1195,7 @@ unload_program(const program* program)
 {
   if (m_active == program) {
     clear_cus();
+    m_xdevice->release_cu_context(-1); // release virtual CU context
     m_active = nullptr;
   }
 }

--- a/src/runtime_src/xrt/scheduler/scheduler.cpp
+++ b/src/runtime_src/xrt/scheduler/scheduler.cpp
@@ -115,9 +115,6 @@ init(xrt::device* device, const axlf* top)
 {
   emu_50_disable_kds(device);
 
-  // In order to use virtual CUs (KDMA) we must open a virtual context
-  device->acquire_cu_context(-1,true);
-
   if (kds_enabled())
     kds::init(device,top);
   else


### PR DESCRIPTION
This is important and necessary if host application swaps an xclbin, otherwise
stale acquire resources keeps first device busy which prevents swapping the xclbin.