### PR TITLE
Added DTC image support

### DIFF
--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -77,6 +77,10 @@ file(GLOB XCLBINUTIL_FILES
   "SectionPDI.cxx"
   "SectionBitstreamPartialPDI.cxx"
   "SectionDTC.cxx"
+  "DTC.cxx"
+  "DTCStringsBlock.cxx"
+  "FDTNode.cxx"
+  "FDTProperty.cxx"
 )
 set(XCLBINUTIL_FILES_SRCS ${XCLBINUTIL_FILES})
 

--- a/src/runtime_src/tools/xclbin/DTC.cxx
+++ b/src/runtime_src/tools/xclbin/DTC.cxx
@@ -1,0 +1,215 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "DTC.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+#include <arpa/inet.h>
+
+
+DTC::DTC() 
+  : m_pTopFDTNode(NULL)
+{
+  // Empty
+}
+
+DTC::DTC(const char* _pBuffer, const unsigned int _size) 
+  : DTC()
+{
+  marshalFromDTCImage(_pBuffer, _size);
+}
+
+DTC::DTC(const boost::property_tree::ptree &_ptDTC)
+  : DTC()
+{
+  marshalFromJSON(_ptDTC);
+}
+
+
+DTC::~DTC() {
+  if ( m_pTopFDTNode != NULL ) {
+    delete m_pTopFDTNode;
+    m_pTopFDTNode = NULL;
+  }
+}
+
+// DTC Header
+struct fdt_header {
+  uint32_t magic;
+  uint32_t totalsize;
+  uint32_t off_dt_struct;
+  uint32_t off_dt_strings;
+  uint32_t off_mem_rsvmap;
+  uint32_t version;
+  uint32_t last_comp_version;
+  uint32_t boot_cpuid_phys;
+  uint32_t size_dt_strings;
+  uint32_t size_dt_struct;
+};
+
+void
+DTC::marshalFromDTCImage( const char* _pBuffer, const unsigned int _size) 
+{
+  XUtil::TRACE("Marshalling from DTC Image");
+
+  // -- Validate the buffer --
+  if ( _pBuffer == NULL ) {
+      throw std::runtime_error("ERROR: The given buffer pointer is NULL.");
+  }
+
+  static const uint32_t FDT_HEADER_SIZE = sizeof(fdt_header);
+
+  // Check the header size
+  if ( _size < FDT_HEADER_SIZE) {
+    std::string err = XUtil::format("ERROR: The given DTC buffer's header size (%d bytes) is smaller then the expected size (%d bytes).", _size, FDT_HEADER_SIZE);
+    throw std::runtime_error(err);
+  }
+
+  const fdt_header * pHdr = (const fdt_header *) _pBuffer;
+
+  // Look for the magic number
+  static const uint32_t MAGIC = 0xd00dfeed;
+
+  if ( ntohl(pHdr->magic) != MAGIC ) {
+      std::string err = XUtil::format("ERROR: Missing DTC magic number.  Expected: 0x%x, Found: 0x%x.", MAGIC, ntohl(pHdr->magic));
+      throw std::runtime_error(err);
+  }
+
+  // Validate Size
+  if ( ntohl(pHdr->totalsize) != _size ) {
+      std::string err = XUtil::format("ERROR: The expected size (%d bytes) does not match actual (%d bytes)", ntohl(pHdr->totalsize), _size);
+      throw std::runtime_error(err);
+  }
+
+  // -- Get and validate the strings offset --
+  if ( ntohl(pHdr->off_dt_strings) > _size ) {
+      std::string err = XUtil::format("ERROR: The string block offset (0x%x) exceeds then image size (0x%x)", ntohl(pHdr->off_dt_strings), _size);
+      throw std::runtime_error(err);
+  }
+
+  if ( (ntohl(pHdr->off_dt_strings) + ntohl(pHdr->size_dt_strings)) > _size ) {
+      std::string err = XUtil::format("ERROR: The string block offset and size (0x%x) exceeds then image size (0x%x)", (ntohl(pHdr->off_dt_strings) + ntohl(pHdr->size_dt_strings)), _size);
+      throw std::runtime_error(err);
+  }
+
+  // -- Get the strings block --
+  const char* pStringBuffer = _pBuffer + ntohl(pHdr->off_dt_strings);
+  unsigned int stringBufferSize = ntohl(pHdr->size_dt_strings);
+  m_DTCStringsBlock.parseDTCStringsBlock(pStringBuffer, stringBufferSize);
+
+  // -- Get the validate the structure nodes offset --
+  if ( ntohl(pHdr->off_dt_struct) > _size ) {
+      std::string err = XUtil::format("ERROR: The structure block offset (0x%x) exceeds then image size (0x%x)", ntohl(pHdr->off_dt_struct), _size);
+      throw std::runtime_error(err);
+  }
+
+  if ( (ntohl(pHdr->off_dt_struct) + ntohl(pHdr->size_dt_struct)) > _size ) {
+      std::string err = XUtil::format("ERROR: The structure block offset and size (0x%x) exceeds then image size (0x%x)", (ntohl(pHdr->off_dt_struct) + ntohl(pHdr->size_dt_struct)), _size);
+      throw std::runtime_error(err);
+  }
+
+  // -- Get the top FDT Note (which will include the node tree) --
+  const char* pStructureBuffer = _pBuffer + ntohl(pHdr->off_dt_struct);
+  unsigned int structureBufferSize = ntohl(pHdr->size_dt_struct);
+  m_pTopFDTNode = FDTNode::marshalFromDTC(pStructureBuffer, structureBufferSize, m_DTCStringsBlock);
+
+  XUtil::TRACE("Marshalling complete");
+}
+
+
+void 
+DTC::marshalToJSON(boost::property_tree::ptree &_dtcTree) const
+{
+  XUtil::TRACE("");
+
+  if ( m_pTopFDTNode == nullptr ) {
+     throw std::runtime_error("ERROR: There are no structure nodes in this design.");
+  }
+
+  m_pTopFDTNode->marshalToJSON(_dtcTree);
+}
+
+
+void 
+DTC::marshalFromJSON(const boost::property_tree::ptree &_ptDTC)
+{
+    XUtil::TRACE("Marshalling from JSON Image");
+
+    m_pTopFDTNode = FDTNode::marshalFromJSON(_ptDTC);
+}
+
+
+#define FDT_END         0x00000009
+#define FDT_MAGIC       0xd00dfeed
+
+void 
+DTC::marshalToDTC(std::ostringstream& _buf) const
+{
+  XUtil::TRACE("");
+
+  if ( m_pTopFDTNode == NULL ) {
+     throw std::runtime_error("ERROR: There are no structure nodes in this design.");
+  }
+
+  unsigned int runningOffset = 0;
+
+  // -- Create header --
+  fdt_header header = {0};
+  header.magic = htonl(FDT_MAGIC);
+  header.version = htonl(0x11);
+  header.boot_cpuid_phys = htonl(0);
+  runningOffset += sizeof(fdt_header);
+ 
+  // -- Create dummy "memory block" --
+  std::ostringstream memoryBlock;
+  static unsigned int FDTReservedEntrySize = 16;
+  for (unsigned index = 0; index < FDTReservedEntrySize; ++index) {
+    char emptyByte = '\0';
+    memoryBlock.write(&emptyByte, sizeof(char));
+  }
+  std::string sMemoryBlock = memoryBlock.str();
+  header.off_mem_rsvmap = htonl(runningOffset);
+  runningOffset += sMemoryBlock.size();
+
+  // -- Create structure node image --
+  std::ostringstream structureNodesBuf;
+  DTCStringsBlock stringsBlock;
+  m_pTopFDTNode->marshalToDTC(stringsBlock, structureNodesBuf);
+  XUtil::write_htonl(structureNodesBuf, FDT_END);
+  std::string sStructureNodes = structureNodesBuf.str();
+  header.off_dt_struct = htonl(runningOffset);
+  header.size_dt_struct = htonl(sStructureNodes.size());
+  runningOffset += sStructureNodes.size();
+
+  // -- Create strings block --
+  std::ostringstream stringBlock;
+  stringsBlock.marshalToDTC(stringBlock);
+  std::string sStringBlock = stringBlock.str();
+  header.off_dt_strings = htonl(runningOffset);
+  header.size_dt_strings = htonl(sStringBlock.size());
+  runningOffset += sStringBlock.size();
+
+  // Complete the header 
+  header.totalsize = htonl(runningOffset);
+
+  // -- Put it all together --
+  _buf.write((char *) &header, sizeof(fdt_header));
+  _buf.write(sMemoryBlock.c_str(), sMemoryBlock.size());
+  _buf.write(sStructureNodes.c_str(), sStructureNodes.size());
+  _buf.write(sStringBlock.c_str(), sStringBlock.size());
+}

--- a/src/runtime_src/tools/xclbin/DTC.h
+++ b/src/runtime_src/tools/xclbin/DTC.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,39 +14,45 @@
  * under the License.
  */
 
-#ifndef __SectionHeader_h_
-#define __SectionHeader_h_
+#ifndef __DTC_h_
+#define __DTC_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
 
 // #includes here - please keep these to a bare minimum!
-
-#include <string>
-#include <fstream>
-#include "xclbin.h"
+#include "DTCStringsBlock.h"
+#include "FDTNode.h"
+#include <boost/property_tree/ptree.hpp>
 
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------ C L A S S :   S e c t i o n H e a d e r ----------------------
+// ------------------- C L A S S :   S e c t i o n ---------------------------
 
-class SectionHeader {
- public:
-  SectionHeader();
-  virtual ~SectionHeader();
+class DTC {
 
  public:
-  void readXclBinBinarySection(std::fstream& _istream, unsigned int _section);
+  DTC(const char* _pBuffer, const unsigned int _size);
+  DTC(const boost::property_tree::ptree &_ptDTC);
+  virtual ~DTC();
 
- private:
-  enum axlf_section_kind m_eType;  /* Type of section */
-  std::string m_name;              /* Name of section (not really used in the xclbin anymore */
+ public:
+  void marshalToJSON(boost::property_tree::ptree &_dtcTree) const;
+  void marshalToDTC(std::ostringstream& _buf) const;
+
+ protected:
+  void marshalFromDTCImage( const char* _pBuffer, const unsigned int _size);
+  void marshalFromJSON(const boost::property_tree::ptree &_ptDTC);
 
  private:
   // Purposefully private and undefined ctors...
-  SectionHeader(const SectionHeader& obj);
-  SectionHeader& operator=(const SectionHeader& obj);
-};
+  DTC();
+  DTC(const DTC& obj);
+  DTC& operator=(const DTC& obj);
 
+ private:
+  DTCStringsBlock m_DTCStringsBlock;    // Block of property strings
+  FDTNode * m_pTopFDTNode;              // Top FDTNode
+};
 
 #endif

--- a/src/runtime_src/tools/xclbin/DTCStringsBlock.cxx
+++ b/src/runtime_src/tools/xclbin/DTCStringsBlock.cxx
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "DTCStringsBlock.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+
+DTCStringsBlock::DTCStringsBlock() 
+  : m_pDTCStringBlock(new std::ostringstream())
+{
+  // Empty
+}
+
+
+DTCStringsBlock::~DTCStringsBlock() 
+{
+  if (m_pDTCStringBlock != NULL) {
+    delete m_pDTCStringBlock;
+    m_pDTCStringBlock = NULL;
+  }
+}
+
+void
+DTCStringsBlock::parseDTCStringsBlock(const char* _pBuffer, const unsigned int _size)
+{
+
+  XUtil::TRACE("Examining and extracting strings from the strings block image.");
+
+  // Validate the buffer
+  if (_pBuffer == NULL ) {
+     throw std::runtime_error("ERROR: The given buffer pointer is NULL.");
+  }
+
+  if (_size == 0) {
+    throw std::runtime_error("ERROR: The given buffer is empty.");
+  }
+
+  XUtil::TRACE_BUF("DTC Strings Block", _pBuffer, _size);
+
+  if (_pBuffer[_size - 1] != 0) {
+    throw std::runtime_error("Error: End of the strings block isn't terminated by null character.");
+  }
+
+  // Extract the data
+  unsigned int index = 0;
+  unsigned int lastIndex = 0;
+  for (index = 0; index < _size; ++index) {
+    if (_pBuffer[index] == 0) {
+      int bufferLen = (index - lastIndex);
+      std::string dtcString(&_pBuffer[lastIndex], bufferLen);
+
+      XUtil::TRACE(XUtil::format("Adding DTCString: %s", dtcString.c_str()).c_str());
+      unsigned int offset = addString(dtcString);
+      
+      if (offset != lastIndex) {
+        std::string err = XUtil::format("ERROR: DTC string offset mismatch.  Expected: 0x%x, Actual: 0x%x", lastIndex, offset);
+        throw std::runtime_error(err);
+      }
+
+      ++index;
+      lastIndex = index;
+    }
+  }
+}
+
+unsigned int 
+DTCStringsBlock::addString(const std::string _dtcString)
+{
+  // Has the string already been added
+  std::string haystackString = m_pDTCStringBlock->str();
+  std::size_t index = 0;
+
+  // Create a new string that "includes" the null termination character
+  std::string sNeedleString(_dtcString.c_str(), _dtcString.length()+ 1);
+  index = haystackString.find(sNeedleString);
+
+  // Did we find it?
+  if (index != std::string::npos) {
+    return index;
+  }
+
+  // Not found, lets add it
+  index = m_pDTCStringBlock->tellp();
+
+  *m_pDTCStringBlock << _dtcString << '\0';
+ 
+  return index;
+}
+
+
+std::string  
+DTCStringsBlock::getString(unsigned int _offset) const
+{
+  std::string blockString = m_pDTCStringBlock->str();
+
+  if (_offset > blockString.size()) {
+    std::string err = XUtil::format("ERROR: Offset (0x%x) is greater then the string buffer (0x%x).", _offset, blockString.size());
+    throw std::runtime_error(err);
+  }
+
+  std::string returnString(blockString.c_str()+_offset);
+  return returnString;
+}
+
+
+void 
+DTCStringsBlock::marshalToDTC(std::ostream& _buf) const
+{
+  std::string blockString = m_pDTCStringBlock->str();
+  _buf.write(blockString.c_str(), blockString.size());
+}

--- a/src/runtime_src/tools/xclbin/DTCStringsBlock.h
+++ b/src/runtime_src/tools/xclbin/DTCStringsBlock.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,39 +14,40 @@
  * under the License.
  */
 
-#ifndef __SectionHeader_h_
-#define __SectionHeader_h_
+#ifndef __DTCStringsBlock_h_
+#define __DTCStringsBlock_h_
 
 // ----------------------- I N C L U D E S -----------------------------------
 
 // #includes here - please keep these to a bare minimum!
-
 #include <string>
-#include <fstream>
-#include "xclbin.h"
+#include <sstream>
 
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------ C L A S S :   S e c t i o n H e a d e r ----------------------
+// ------------------- C L A S S :   S e c t i o n ---------------------------
 
-class SectionHeader {
- public:
-  SectionHeader();
-  virtual ~SectionHeader();
+class DTCStringsBlock {
 
  public:
-  void readXclBinBinarySection(std::fstream& _istream, unsigned int _section);
+  DTCStringsBlock();
+  virtual ~DTCStringsBlock();
 
- private:
-  enum axlf_section_kind m_eType;  /* Type of section */
-  std::string m_name;              /* Name of section (not really used in the xclbin anymore */
+ public:
+  unsigned int addString(const std::string _dtcString);
+  std::string getString(unsigned int _offset) const;
+
+  void parseDTCStringsBlock(const char* _pBuffer, const unsigned int _size);
+  void marshalToDTC(std::ostream& _buf) const;
 
  private:
   // Purposefully private and undefined ctors...
-  SectionHeader(const SectionHeader& obj);
-  SectionHeader& operator=(const SectionHeader& obj);
-};
+  DTCStringsBlock(const DTCStringsBlock& obj);
+  DTCStringsBlock& operator=(const DTCStringsBlock& obj);
 
+ private:
+   std::ostringstream * m_pDTCStringBlock;
+};
 
 #endif

--- a/src/runtime_src/tools/xclbin/FDTNode.cxx
+++ b/src/runtime_src/tools/xclbin/FDTNode.cxx
@@ -1,0 +1,337 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "FDTNode.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+#include "FDTProperty.h"
+#include "DTCStringsBlock.h"
+#include <arpa/inet.h>
+
+
+FDTNode::FDTNode() {
+  // Empty
+}
+
+
+FDTNode::~FDTNode() 
+{
+  // Delete the pointers and clear the m_nestedNodes vector
+  for (auto pNode : m_nestedNodes) {
+    delete pNode;
+  }
+  m_nestedNodes.clear();
+
+  // Delete the pointers and clear the m_properties vector
+  for (auto pProperty : m_properties) {
+    delete pProperty;
+  }
+  m_properties.clear();
+}
+
+
+void
+FDTNode::runningBufferCheck(const unsigned int _bytesExamined, 
+                            const unsigned int _size) 
+{
+  if (_bytesExamined > _size) {
+    throw std::runtime_error("ERROR: Bytes examined exceeded size of buffer.");
+  }
+}
+
+
+#define FDT_BEGIN_NODE  0x00000001
+#define FDT_END_NODE    0x00000002
+#define FDT_PROP        0x00000003
+#define FDT_NOP         0x00000004
+#define FDT_END         0x00000009
+
+
+FDTNode::FDTNode(const char* _pBuffer,
+                 const unsigned int _size,
+                 const DTCStringsBlock& _dtcStringsBlock,
+                 unsigned int& _bytesExamined)
+  : FDTNode() 
+{
+  XUtil::TRACE("Extracting FDT Node.");
+  XUtil::TRACE_BUF("FDT Node Buffer", _pBuffer, _size);
+
+  // Initialize return variables
+  _bytesExamined = 0;
+
+  // Validate the buffer
+  if (_pBuffer == NULL) {
+    throw std::runtime_error("ERROR: The given buffer pointer is NULL.");
+  }
+
+  if (_size == 0) {
+    throw std::runtime_error("ERROR: The given buffer is empty.");
+  }
+
+  unsigned index = 0;                   // Running index
+  // Get the node name
+  {
+    m_name = _pBuffer;                  // Get the null terminated ascii string
+    index += m_name.size() + 1;         // Count the "null" character
+    runningBufferCheck(index, _size);
+
+    XUtil::TRACE(XUtil::format("DTC Node Name: '%s'", m_name.c_str()));
+
+    // Advance index to nearest 4 byte boundary
+    if ((index % 4) != 0) {
+      index += 3 - (index % 4);    // End of current word
+      ++index;                     // Point to next word
+    }
+    runningBufferCheck(index, _size);
+  }
+
+  // Loop over the next group of tokens until an exit condition occurs
+  while (true) {
+    XUtil::TRACE(XUtil::format("Looping Index: %d (0x%x)", index, index));
+    runningBufferCheck(index + sizeof(uint32_t), _size);
+    uint32_t dtcToken = ntohl(*((const uint32_t*)&_pBuffer[index]));
+    index += sizeof(uint32_t);
+
+    // FDT_NOP
+    switch (dtcToken) {
+      case FDT_NOP:
+        XUtil::TRACE("Token: FDT_NOP");
+        continue;
+        break;
+
+      case FDT_BEGIN_NODE: {
+          XUtil::TRACE("Token: FDT_BEGIN_NODE");
+          const char* pBeginBuffer = &_pBuffer[index];
+          unsigned int remainingSize = _size - index;
+          unsigned int bytesExamined = 0;
+          FDTNode* pNode = new FDTNode(pBeginBuffer, remainingSize, _dtcStringsBlock, bytesExamined);
+          index += bytesExamined;
+          runningBufferCheck(index, _size);
+          m_nestedNodes.push_back(pNode);
+          break;
+        }
+
+      case FDT_PROP: {
+          XUtil::TRACE("Token: FDT_PROP");
+          const char* pBeginBuffer = &_pBuffer[index];
+          unsigned int remainingSize = _size - index;
+          unsigned int bytesExamined = 0;
+          FDTProperty* pProperty = new FDTProperty(pBeginBuffer, remainingSize, _dtcStringsBlock, bytesExamined);
+          index += bytesExamined;
+          runningBufferCheck(index, _size);
+          m_properties.push_back(pProperty);
+          break;
+        }
+
+      case FDT_END_NODE: {
+          XUtil::TRACE("Token: FDT_END_NODE");
+          _bytesExamined = index;
+          return;             // <== Return from method
+          break;
+        }
+
+      default: {
+          std::string err = XUtil::format("ERROR: Unknown token: 0x%x", dtcToken);
+          throw std::runtime_error(err);
+        }
+    }
+  }
+}
+
+FDTNode::FDTNode(const boost::property_tree::ptree& _ptDTC, std::string & _nodeName)
+  : FDTNode() 
+{
+  m_name = _nodeName;
+
+  // Iterator over the JSON element adding properties and subnodes
+
+  for (boost::property_tree::ptree::const_iterator iter = _ptDTC.begin();
+       iter != _ptDTC.end();
+       ++iter) {
+    std::string keyName = iter->first;
+    if (FDTProperty::isProperty(keyName)) {
+      XUtil::TRACE(XUtil::format("Property Found: %s", keyName.c_str()).c_str());
+      FDTProperty * pProperty = new FDTProperty(iter);
+      m_properties.push_back(pProperty);
+    } else {
+      XUtil::TRACE(XUtil::format("Node Found: %s", keyName.c_str()).c_str());
+      FDTNode * pFDTNode = new FDTNode(iter->second, keyName);
+      m_nestedNodes.push_back(pFDTNode);
+    }
+  }
+}
+
+
+FDTNode*
+FDTNode::marshalFromDTC( const char* _pBuffer, 
+                         const unsigned int _size, 
+                         const DTCStringsBlock& _dtcStringsBlock) 
+{
+  XUtil::TRACE("Examining and extracting nodes from the structure block image.");
+
+  // -- Validate the buffer and size --
+  if (_pBuffer == NULL) {
+    throw std::runtime_error("ERROR: The given buffer pointer is NULL.");
+  }
+
+  if (_size == 0) {
+    throw std::runtime_error("ERROR: The given buffer is empty.");
+  }
+
+  XUtil::TRACE_BUF("Structure Block", _pBuffer, _size);
+
+  const static unsigned int MinSizeBytes = sizeof(uint32_t) * 3; // 3 Words
+  if (_size < MinSizeBytes) {
+    std::string err = XUtil::format("ERROR: The size of the structure block is too small.  Minimum size: 0x%x", MinSizeBytes);
+    throw std::runtime_error(err);
+  }
+
+  if ((_size % 4) != 0) {
+    std::string err = XUtil::format("ERROR: The size of the structure block is not word aligned. Size: 0x%x", _size);
+    throw std::runtime_error(err);
+  }
+
+  // -- Validate the first and and last tokens
+  uint32_t startDtcToken = ntohl(*((const uint32_t*)&_pBuffer[0]));
+
+  if (startDtcToken != FDT_BEGIN_NODE) {
+    std::string err = XUtil::format("ERROR: Missing FDT_BEGIN_NODE token at the start of the structure block. Expected: 0x%x, Actual: 0x%x", FDT_BEGIN_NODE, startDtcToken);
+    throw std::runtime_error(err);
+  }
+
+  uint32_t lastDtcToken = ntohl(*((const uint32_t*)&_pBuffer[(_size - sizeof(uint32_t))]));
+
+  if (lastDtcToken != FDT_END) {
+    std::string err = XUtil::format("ERROR: Missing FDT_END token at end of the structure block. Expected: 0x%x, Actual: 0x%x", FDT_END, lastDtcToken);
+    throw std::runtime_error(err);
+  }
+
+  // -- Parse the nodes --
+  unsigned index = 0;
+  index += sizeof(uint32_t);    // Skip first token
+
+  const char* pNodeBuffer = &_pBuffer[index];
+  unsigned nodeBufferSize = _size - index;
+
+  uint32_t bytesExamined = 0;
+  FDTNode* pTopNode = new FDTNode(pNodeBuffer, nodeBufferSize, _dtcStringsBlock, bytesExamined);
+  index += bytesExamined;
+  runningBufferCheck(index, _size);
+
+  uint32_t endDtcToken = ntohl(*((const uint32_t*)&_pBuffer[index]));
+  index += sizeof(uint32_t);
+  runningBufferCheck(index, _size);
+
+  if (endDtcToken != FDT_END) {
+    std::string err = XUtil::format("ERROR: Missing FDT_END_NODE token at end of the structure block. Expected: 0x%x, Actual: 0x%x", FDT_END, endDtcToken);
+    throw std::runtime_error(err);
+  }
+
+  // -- Validate that all of the bytes were examined --
+  if (_size != index) {
+    std::string err = XUtil::format("ERROR: Structure Node Buffer wasn't completely examined.  Expected: 0x%x, Actual: 0x%s.", _size, index);
+    throw std::runtime_error(err);
+  }
+
+  return pTopNode;
+}
+
+
+
+FDTNode*
+FDTNode::marshalFromJSON(const boost::property_tree::ptree& _ptDTC) 
+{
+  std::string topName = "";
+  return new FDTNode(_ptDTC, topName);
+}
+
+
+
+void
+FDTNode::marshalSubNodeToJSON(boost::property_tree::ptree& _ptTree) const 
+{
+  XUtil::TRACE(XUtil::format("** Examining SubNode: '%s'", m_name.c_str()));
+
+  if (m_name.length() == 0) {
+    std::string err = XUtil::format("ERROR: All nodes need a name.", m_name.c_str());
+    throw std::runtime_error(err);
+  }
+
+  boost::property_tree::ptree ptSubNode;
+
+  // Add the Properties
+  for (auto pFDTProperty : m_properties) {
+    pFDTProperty->marshalToJSON(ptSubNode);
+  }
+
+  // Add the underlying nodes
+  for (auto pFDTNode : m_nestedNodes) {
+    pFDTNode->marshalSubNodeToJSON(ptSubNode);
+  }
+
+  _ptTree.add_child(m_name.c_str(), ptSubNode);
+}
+
+
+void
+FDTNode::marshalToJSON(boost::property_tree::ptree& _ptTree) const 
+{
+  XUtil::TRACE(XUtil::format("** Examining Node: '%s'", m_name.c_str()));
+
+  if (m_name.length() != 0) {
+    std::string err = XUtil::format("ERROR: The given node '%s' is not the top node of the tree.", m_name.c_str());
+    throw std::runtime_error(err);
+  }
+
+  // Add the Properties
+  for (auto pFDTProperty : m_properties) {
+    pFDTProperty->marshalToJSON(_ptTree);
+  }
+
+  // Add the underlying nodes
+  for (auto pFDTNode : m_nestedNodes) {
+    pFDTNode->marshalSubNodeToJSON(_ptTree);
+  }
+}
+
+
+void
+FDTNode::marshalToDTC(DTCStringsBlock& _dtcStringsBlock, std::ostream& _buf) const 
+{
+  // Add node keyword
+  XUtil::write_htonl(_buf, FDT_BEGIN_NODE);
+
+  // Add node name followed by null character
+  _buf << m_name << '\0';
+
+  // Pad if necessary
+  XUtil::alignBytes(_buf, sizeof(uint32_t));
+
+  // Write out the properties
+  for (auto pFDTProperty : m_properties) {
+    pFDTProperty->marshalToDTC(_dtcStringsBlock, _buf);
+  }
+
+  // Write out the nested nodes
+  for (auto pFDTNode : m_nestedNodes) {
+    pFDTNode->marshalToDTC(_dtcStringsBlock, _buf);
+  }
+
+  // Done with adding the node
+  XUtil::write_htonl(_buf, FDT_END_NODE);
+}

--- a/src/runtime_src/tools/xclbin/FDTNode.h
+++ b/src/runtime_src/tools/xclbin/FDTNode.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __FDTNode_h_
+#define __FDTNode_h_
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+
+#include <string>
+#include <vector>
+#include <boost/property_tree/ptree.hpp>
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+// Forward declarations - use these instead whenever possible...
+class FDTProperty;
+class DTCStringsBlock;
+
+// ------------------- C L A S S :   S e c t i o n ---------------------------
+
+class FDTNode {
+
+ private:
+  FDTNode(const char* _pBuffer, const unsigned int _size, const DTCStringsBlock& _dtcStringsBlock, unsigned int& _bytesExamined);
+  FDTNode(const boost::property_tree::ptree& _ptDTC, std::string & _nodeName);
+
+ public:
+  virtual ~FDTNode();
+
+ public:
+  static FDTNode* marshalFromDTC(const char* _pBuffer, const unsigned int _size, const DTCStringsBlock& _dtcStringsBlock);
+  static FDTNode* marshalFromJSON(const boost::property_tree::ptree& _ptDTC);
+
+  void marshalToJSON(boost::property_tree::ptree& _dtcTree) const;
+  void marshalToDTC(DTCStringsBlock& _dtcStringsBlock, std::ostream& _buf) const;
+
+ protected:
+  void marshalSubNodeToJSON(boost::property_tree::ptree& _ptTree) const;
+  static void runningBufferCheck(const unsigned int _bytesExamined, const unsigned int _size);
+
+ private:
+  // Purposefully private and undefined ctors...
+  FDTNode();
+  FDTNode(const FDTNode& obj);
+  FDTNode& operator=(const FDTNode& obj);
+
+ private:
+  std::string m_name;                      // Name of the node
+  std::vector<FDTNode*> m_nestedNodes;     // Collection of nested nodes
+  std::vector<FDTProperty*> m_properties;  // Node properties
+};
+
+#endif

--- a/src/runtime_src/tools/xclbin/FDTProperty.cxx
+++ b/src/runtime_src/tools/xclbin/FDTProperty.cxx
@@ -1,0 +1,565 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "FDTProperty.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+#include <arpa/inet.h>
+#include <limits>
+#include "DTCStringsBlock.h"
+
+FDTProperty::FDTProperty()
+  : m_dataLength(0)
+  , m_pDataBuffer(NULL)
+{
+  // Empty
+}
+
+
+FDTProperty::~FDTProperty() 
+{
+  // Delete m_pDataBuffer 
+  if (m_pDataBuffer != NULL) {
+    delete m_pDataBuffer;
+    m_pDataBuffer = NULL;
+  }
+  m_dataLength = 0;
+}
+
+
+void
+FDTProperty::runningBufferCheck(const unsigned int _bytesExamined, const unsigned int _size)
+{
+  if (_bytesExamined > _size) {
+    throw std::runtime_error("ERROR: Bytes examined exceeded size of buffer.");
+  }
+}
+
+
+struct FDTLenOffset {
+  uint32_t len;
+  uint32_t nameoff;
+};
+
+FDTProperty::FDTProperty(const char* _pBuffer, 
+                         const unsigned int _size, 
+                         const DTCStringsBlock & _dtcStringsBlock,
+                         unsigned int & _bytesExamined)
+  : FDTProperty()
+{
+  XUtil::TRACE("Extracting FDT Property.");
+
+  // Initialize return variables
+  _bytesExamined = 0;
+
+  // Validate the buffer
+  if (_pBuffer == NULL ) {
+     throw std::runtime_error("ERROR: The given property buffer pointer is NULL.");
+  }
+
+  if (_size == 0) {
+    throw std::runtime_error("ERROR: The given property size is empty.");
+  }
+
+  // Check the header size
+  if ( _size < sizeof(FDTLenOffset)) {
+    std::string err = XUtil::format("ERROR: The given property buffer's header size (%d bytes) is smaller then its header (%d bytes).", _size, sizeof(FDTLenOffset));
+    throw std::runtime_error(err);
+  }
+
+  // -- Get the len / offset values --
+  unsigned int index = 0;
+
+  const FDTLenOffset *pHdr = (const FDTLenOffset *) &_pBuffer[index];
+  index += sizeof(FDTLenOffset);
+  runningBufferCheck(index, _size);
+
+  m_name = _dtcStringsBlock.getString(ntohl(pHdr->nameoff));
+  m_dataLength = ntohl(pHdr->len);
+
+  XUtil::TRACE(XUtil::format("Property Name: '%s', length: %d", m_name.c_str(), m_dataLength).c_str());
+
+  // Get the data (if any)
+  if (m_dataLength != 0) {
+      m_pDataBuffer = new char[m_dataLength];
+      memcpy(m_pDataBuffer, &_pBuffer[index], m_dataLength);
+      XUtil::TRACE_BUF("Property Data", m_pDataBuffer, m_dataLength);
+  } 
+
+  // Update index
+  index += m_dataLength;
+
+  // Align to uint32 byte boundary
+  if ((index % 4) != 0) {
+    index += 4 - (index % 4);
+  }
+
+  _bytesExamined = index;
+}
+
+bool 
+FDTProperty::hasEnding(std::string const &_sFullString, std::string const & _sEndSubString)
+{
+  // See if there is room
+  if (_sFullString.length() < _sEndSubString.length()) {
+    return false;
+  }
+
+  // Compare the ending of the string to see if they don't match
+  if (_sFullString.compare(_sFullString.length() - _sEndSubString.length(), _sEndSubString.length(), _sEndSubString) != 0 ) {
+    return false;
+  }
+
+  // If we get this far, then they match
+  return true;
+}
+
+
+void
+FDTProperty::au16MarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: Array of 16 bits");
+
+  // Check and make sure that all is good 
+  static unsigned int byteBoundary = 2;
+  if ((m_dataLength % byteBoundary) != 0) {
+    std::string err = XUtil::format("ERROR: Data length (%d) does not end on a 2-byte boundary.", m_dataLength);
+    throw std::runtime_error(err);
+  }
+
+  unsigned int numElements = m_dataLength / byteBoundary;
+  const uint16_t * uint16Array = (const uint16_t *) m_pDataBuffer;
+
+  boost::property_tree::ptree ptProperty;
+  for (unsigned int index = 0; index < numElements; ++index) {
+    boost::property_tree::ptree ptChildArrayElement;
+    ptChildArrayElement.put("", XUtil::format("0x%x", ntohs(uint16Array[index])).c_str());
+    ptProperty.push_back(std::make_pair("", ptChildArrayElement));
+  }
+  _ptTree.add_child(m_name.c_str(), ptProperty);
+}
+
+void
+FDTProperty::au8MarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: Array of 8 bits");
+
+  const uint8_t * uint8Array = (const uint8_t *) m_pDataBuffer;
+
+  boost::property_tree::ptree ptProperty;
+  for (unsigned int index = 0; index < m_dataLength; ++index) {
+    boost::property_tree::ptree ptChildArrayElement;
+    ptChildArrayElement.put("", XUtil::format("0x%x", uint8Array[index]).c_str());
+    ptProperty.push_back(std::make_pair("", ptChildArrayElement));
+  }
+  _ptTree.add_child(m_name.c_str(), ptProperty);
+}
+
+void
+FDTProperty::u16MarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: 16 bits");
+
+  // Check and make sure that all is good 
+  static unsigned int byteBoundary = 2;
+  if ((m_dataLength % byteBoundary) != 0) {
+    std::string err = XUtil::format("ERROR: Data length (%d) does not end on a 2-byte boundary.", m_dataLength);
+    throw std::runtime_error(err);
+  }
+
+  const uint16_t uint16Value = ntohs(*((const uint16_t *) m_pDataBuffer));
+  _ptTree.put(m_name.c_str(), XUtil::format("0x%x", uint16Value).c_str());
+}
+
+void
+FDTProperty::u32MarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: 32 bits");
+
+  // Check and make sure that all is good 
+  if (m_dataLength != sizeof(uint32_t)) {
+    std::string err = XUtil::format("ERROR: Data length for a 32-bit word is invalid: Expected: %d, Actual: %d", sizeof(uint32_t), m_dataLength);
+    throw std::runtime_error(err);
+  }
+
+  const uint32_t uint32Value = ntohl(*((const uint32_t *) m_pDataBuffer));
+  _ptTree.put(m_name.c_str(), XUtil::format("0x%x", uint32Value).c_str());
+}
+
+void
+FDTProperty::u128MarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: 128 bits");
+
+  // Check and make sure that all is good 
+  static unsigned int expectedSize = 16;
+  if (m_dataLength != expectedSize) {
+    std::string err = XUtil::format("ERROR: Data length for a 128-bit word is invalid: Expected: %d, Actual: %d", expectedSize, m_dataLength);
+    throw std::runtime_error(err);
+  }
+
+  std::string s128Hex;
+
+  XUtil::binaryBufferToHexString((const unsigned char *) m_pDataBuffer, m_dataLength, s128Hex);
+  _ptTree.put(m_name.c_str(), XUtil::format("0x%s", s128Hex.c_str()).c_str());
+}
+
+void
+FDTProperty::au64MarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: Array 64 bits");
+
+  // Check and make sure that all is good 
+  static unsigned int byteBoundary = 8;
+  if ((m_dataLength % byteBoundary) != 0) {
+    std::string err = XUtil::format("ERROR: Data length (%d) does not end on a 8-byte boundary.", m_dataLength);
+    throw std::runtime_error(err);
+  }
+
+  boost::property_tree::ptree ptProperty;
+  for (unsigned int index = 0; index < m_dataLength; index += byteBoundary) {
+    boost::property_tree::ptree ptChildArrayElement;
+    std::string s64Hex;
+    XUtil::binaryBufferToHexString((const unsigned char *) &m_pDataBuffer[index], byteBoundary, s64Hex);
+    ptChildArrayElement.put("", XUtil::format("0x%s", s64Hex.c_str()).c_str());
+    ptProperty.push_back(std::make_pair("", ptChildArrayElement));
+  }
+
+  _ptTree.add_child(m_name.c_str(), ptProperty);
+}
+
+
+void
+FDTProperty::szMarshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE("   Type: String");
+
+  // Check and make sure that all is good 
+  if (m_dataLength == 0) {
+    throw std::runtime_error("ERROR: Malformed string.  Missing terminator.");
+  }
+
+  if (m_pDataBuffer[m_dataLength - 1] != '\0') {
+    throw std::runtime_error("ERROR: Missing string terminator.");
+  }
+
+  _ptTree.put(m_name.c_str(), m_pDataBuffer);
+}
+
+
+unsigned int 
+FDTProperty::getWordLength(enum DataFormat _eDataFormat)
+{
+  switch (_eDataFormat) {
+    case DF_au8:
+    case DF_sz:
+      return 1;
+      break;
+
+    case DF_au16: 
+    case DF_u16:
+      return 2;
+      break;
+
+    case DF_u32:
+      return 4;
+      break;
+
+    case DF_au64:
+      return 8;
+      break;
+
+    case DF_u128:
+      return 16;
+      break;
+
+    case DF_unknown:
+    default:
+      // Do nothing
+      break;
+  }
+
+  std::string err = XUtil::format("ERROR: Unknown data format: %d", (unsigned int) _eDataFormat);
+  throw std::runtime_error(err);
+  return 0;
+}
+
+FDTProperty::DataFormat 
+FDTProperty::getDataFormat(const std::string _sVariableName)
+{
+  if (hasEnding(m_name,"_au16")) {
+    return DF_au16;
+  } else if (hasEnding(m_name,"_u16")) {
+    return DF_u16;
+  } else if (hasEnding(m_name,"_u32")) {
+    return DF_u32;
+  } else if (hasEnding(m_name,"_u128")) {
+    return DF_u128;
+  } else if (hasEnding(m_name,"_sz")) {
+    return DF_sz;
+  } else if (hasEnding(m_name,"_au64")) {
+    return DF_au64;
+  } 
+
+  return DF_unknown;
+}
+
+bool
+FDTProperty::isDataFormatArray(enum DataFormat _eDataFormat)
+{
+  switch (_eDataFormat) {
+    case DF_au16:
+    case DF_au64:
+    case DF_au8:
+      return true;
+      break;
+
+    case DF_unknown:
+    case DF_u16:
+    case DF_u32:
+    case DF_u128:
+    case DF_sz:
+    default:
+      return false;
+      break;
+  }
+  return false;
+}
+
+void
+FDTProperty::writeDataWord(enum DataFormat _eDataFormat,
+                           char * _buffer, 
+                           const std::string & _sData)
+{
+  XUtil::TRACE(XUtil::format("Storing property: '%s' with value: '%s'", m_name.c_str(), _sData.c_str()));
+
+  switch (_eDataFormat) {
+    case DF_sz:
+      // Copy the string + the '\0' byte
+      memcpy(_buffer, _sData.c_str(), (_sData.size() + 1));
+      break;
+
+    case DF_au8:
+      {
+        uint64_t dataWord = std::strtoul(_sData.c_str(), NULL, 0);
+        if (dataWord > std::numeric_limits<uint8_t>::max()) {
+          std::string err = XUtil::format("ERROR: Property '%s' data value '%s' exceeds the maximum byte storage space'.", m_name.c_str(), _sData.c_str());
+          throw std::runtime_error(err);
+        }
+
+        uint8_t * pWord = (uint8_t *) _buffer;
+        *pWord = (uint8_t) dataWord;
+      }
+      break;
+      
+    case DF_au16:
+    case DF_u16:
+      {
+        uint64_t dataWord = std::strtoul(_sData.c_str(), NULL, 0);
+        if (dataWord > std::numeric_limits<uint16_t>::max()) {
+          std::string err = XUtil::format("ERROR: Property '%s' data value '%s' exceeds the maximum uint16_t storage space.", m_name.c_str(), _sData.c_str());
+          throw std::runtime_error(err);
+        }
+
+        uint16_t * pWord = (uint16_t *) _buffer;
+        *pWord = htons((uint16_t) dataWord);
+      }
+      break;
+
+    case DF_u32:
+      {
+        uint64_t dataWord = std::strtoul(_sData.c_str(), NULL, 0);
+        if (dataWord > std::numeric_limits<uint32_t>::max()) {
+          std::string err = XUtil::format("ERROR: Property '%s' data value '%s' exceeds the maximum uint32_t storage space.", m_name.c_str(), _sData.c_str());
+          throw std::runtime_error(err);
+        }
+
+        uint32_t * pWord = (uint32_t *) _buffer;
+        *pWord = htonl((uint32_t) dataWord);
+      }
+      break;
+
+    case DF_au64:
+      {
+        uint64_t dataWord = std::strtoul(_sData.c_str(), NULL, 0);
+        if (errno == ERANGE) {
+          std::string err = XUtil::format("ERROR: Property '%s' data value '%s' exceeds the maximum uint64_t storage space.", m_name.c_str(), _sData.c_str());
+          throw std::runtime_error(err);
+        }
+
+        uint64_t * pWord = (uint64_t *) _buffer;
+        *pWord = __builtin_bswap64((uint64_t) dataWord);
+      }
+      break;
+
+    case DF_u128:
+      {
+        // Only support hex values
+        if ((_sData.compare(0, 2, "0x") != 0) &&
+            (_sData.compare(0, 2, "0X") != 0)) {
+          std::string err = XUtil::format("ERROR: Property '%s' data value '%s' must be a hex value (e.g., start with '0x').", m_name.c_str(), _sData.c_str());
+          throw std::runtime_error(err);
+        }
+
+        // Must be of even length
+        if ((_sData.size() % 2) != 0) {
+            std::string err = XUtil::format("ERROR: Property '%s' data value '%s' doesn't support nibble length values, must be full byte values.", m_name.c_str(), _sData.c_str());
+            throw std::runtime_error(err);
+        }
+
+        // Must not be too long
+        if (_sData.size() > 34) {
+          std::string err = XUtil::format("ERROR: Property '%s' data value '%s' exceeds the maximum uint128_t storage space.", m_name.c_str(), _sData.c_str());
+          throw std::runtime_error(err);
+        }
+
+        std::string sHex(_sData.c_str() + 2);  // Strip off the 2 two characters
+
+        static int sizeWord = 16;
+        uint8_t dataWord[sizeWord] = {0};
+        XUtil::hexStringToBinaryBuffer(sHex, &dataWord[0], sizeWord);
+
+        memcpy(_buffer, &dataWord[0], sizeWord);
+      }
+      break;
+
+    case DF_unknown:
+    default:
+      {
+        std::string err = XUtil::format("ERROR: Unknown data type for property '%s'", m_name.c_str());
+        throw std::runtime_error(err);
+      }
+      break;
+  }
+}
+
+void 
+FDTProperty::marshalDataFromJSON(boost::property_tree::ptree::const_iterator & _iter)
+{
+  m_name = _iter->first;
+
+  DataFormat eDataFormat = getDataFormat(m_name);
+  unsigned int wordSizeBytes = getWordLength(eDataFormat);
+  const boost::property_tree::ptree & ptData = _iter->second;
+  unsigned int arraySize = ptData.size();
+
+  // Make sure that we are not dealing with an array of data for non arrays
+  if ((arraySize > 1) && !isDataFormatArray(eDataFormat)) {
+    std::string err = XUtil::format("ERROR: Array of data found for the variable: '%s'", m_name.c_str());
+    throw std::runtime_error(err);
+  }
+
+  // Address the non-array values first
+  if (isDataFormatArray(eDataFormat) == false) {
+    std::string sData = ptData.data();  
+
+    if (eDataFormat == DF_sz) {
+      m_dataLength = sData.size() + 1; // Add room for the '\0' character
+    } else {
+      m_dataLength = wordSizeBytes;
+    }
+
+    m_pDataBuffer = new char[m_dataLength]();
+    writeDataWord(eDataFormat, m_pDataBuffer, sData);
+    return;
+  }
+
+  // Just arrays are remaining
+  m_dataLength = wordSizeBytes * arraySize;
+  m_pDataBuffer = new char[m_dataLength]();
+
+  int index = 0;
+  for (auto localIter : ptData) {
+    std::string sData = localIter.second.data();
+    writeDataWord(eDataFormat, m_pDataBuffer + (index * wordSizeBytes), sData);
+    ++index;
+  }
+  return;
+}
+
+
+FDTProperty::FDTProperty(boost::property_tree::ptree::const_iterator & _iter)
+  : FDTProperty()
+{
+  marshalDataFromJSON(_iter);
+}
+
+
+
+
+bool 
+FDTProperty::isProperty(const std::string &_sName)
+{
+  if ((hasEnding(_sName, "_au16")) ||
+      (hasEnding(_sName, "_u16")) ||
+      (hasEnding(_sName, "_u32")) ||
+      (hasEnding(_sName, "_u128")) ||
+      (hasEnding(_sName, "_sz")) ||
+      (hasEnding(_sName, "_au64")) ||
+      (hasEnding(_sName, "_au8"))) {
+    return true;
+  }
+  return false;
+}
+
+
+void 
+FDTProperty::marshalToJSON(boost::property_tree::ptree &_ptTree) const
+{
+  XUtil::TRACE(XUtil::format("-- Examining Property: '%s'", m_name.c_str()));
+
+  boost::property_tree::ptree ptProperty;
+
+  if (hasEnding(m_name,"_au16")) {
+    au16MarshalToJSON(_ptTree);
+  } else if (hasEnding(m_name,"_u16")) {
+    u16MarshalToJSON(_ptTree);
+  } else if (hasEnding(m_name,"_u32")) {
+    u32MarshalToJSON(_ptTree);
+  } else if (hasEnding(m_name,"_u128")) {
+    u128MarshalToJSON(_ptTree);
+  } else if (hasEnding(m_name,"_sz")) {
+    szMarshalToJSON(_ptTree);
+  } else if (hasEnding(m_name,"_au64")) {
+    au64MarshalToJSON(_ptTree);
+  } else {
+    au8MarshalToJSON(_ptTree);
+  }
+}
+
+
+#define FDT_PROP        0x00000003
+
+void 
+FDTProperty::marshalToDTC(DTCStringsBlock & _dtcStringsBlock, std::ostream& _buf) const
+{
+  // Add property keyword
+  XUtil::write_htonl(_buf, FDT_PROP);
+
+  // Add length and offset values
+  XUtil::write_htonl(_buf, m_dataLength);
+  XUtil::write_htonl(_buf, _dtcStringsBlock.addString(m_name));
+
+  // Add data (if any)
+  if (m_dataLength != 0) {
+    _buf.write(m_pDataBuffer, m_dataLength);
+  }
+
+  // Pad if necessary
+  XUtil::alignBytes(_buf, sizeof(uint32_t));
+}

--- a/src/runtime_src/tools/xclbin/FDTProperty.h
+++ b/src/runtime_src/tools/xclbin/FDTProperty.h
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __FDTProperty_h_
+#define __FDTProperty_h_
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+#include <string>
+#include <boost/property_tree/ptree.hpp>
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+// Forward declarations - use these instead whenever possible...
+class DTCStringsBlock;
+
+// ------------------- C L A S S :   S e c t i o n ---------------------------
+
+class FDTProperty {
+
+ public:
+  FDTProperty(const char* _pBuffer, const unsigned int _size, const DTCStringsBlock & _dtcStringsBlock, unsigned int & _bytesExamined);
+  FDTProperty(boost::property_tree::ptree::const_iterator & _iter);
+  virtual ~FDTProperty();
+
+ public:
+  static bool isProperty(const std::string &_sName);
+
+ public:
+  void marshalToDTC(DTCStringsBlock & _dtcStringsBlock, std::ostream& _buf) const;
+  void marshalToJSON(boost::property_tree::ptree &_dtcTree) const;
+
+ protected: 
+  enum DataFormat {
+   DF_unknown,
+   DF_au16,
+   DF_u16,
+   DF_u32,
+   DF_u128,
+   DF_sz,
+   DF_au64,
+   DF_au8,
+  };
+
+  unsigned int getWordLength(enum DataFormat _eDataFormat);
+  DataFormat getDataFormat(const std::string _sVariableName);
+  bool isDataFormatArray(enum DataFormat _eDataFormat);
+
+  static void runningBufferCheck(const unsigned int _bytesExamined, const unsigned int _size);
+  static bool hasEnding(std::string const &_sFullString, std::string const & _sEndSubString);
+
+  void au16MarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+  void au8MarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+  void u16MarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+  void u32MarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+  void u128MarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+  void szMarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+  void au64MarshalToJSON(boost::property_tree::ptree &_ptTree) const;
+
+  void marshalDataFromJSON(boost::property_tree::ptree::const_iterator & _iter);
+
+ private:
+  void writeDataWord(enum DataFormat _eDataFormat, char * _buffer, const std::string & _sData);
+
+ private:
+  // Purposefully private and undefined ctors...
+  FDTProperty();
+  FDTProperty(const FDTProperty& obj);
+  FDTProperty& operator=(const FDTProperty& obj);
+
+ private:
+  unsigned int m_dataLength;  // The length of the data buffer
+  char * m_pDataBuffer;       // The databuffer
+  std::string m_name;         // The name of the property
+};
+
+
+#endif

--- a/src/runtime_src/tools/xclbin/Section.h
+++ b/src/runtime_src/tools/xclbin/Section.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -34,13 +34,6 @@
 // Forward declarations - use these instead whenever possible...
 
 // ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- * Section:
- *
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
 
 class Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionBMC.h
+++ b/src/runtime_src/tools/xclbin/SectionBMC.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// --------------- C L A S S :   S e c t i o n B M C -------------------------
 
 class SectionBMC : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstream.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// --------- C L A S S :   S e c t i o n B i t s t r e a m -------------------
 
 class SectionBitstream : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionBitstreamPartialPDI.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstreamPartialPDI.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,7 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
+// ---- C L A S S :   S e c t i o n B i t s t r e a m P a r t i a l P D I ----
 
 class SectionBitstreamPartialPDI : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,12 +27,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ----- C L A S S :   S e c t i o n B u i l d M e t a d a t a ---------------
 
 class SectionBuildMetadata : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionClearBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionClearBitstream.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------ C L A S S :   S e c t i o n C l e a r B i t s t r e a m ------------
 
 class SectionClearBitstream : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,8 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
+// - C L A S S :   S e c t i o n C l o c k F r e q u e n c y T o p o l o g y -
 
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
 
 class SectionClockFrequencyTopology : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionConnectivity.h
+++ b/src/runtime_src/tools/xclbin/SectionConnectivity.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------ C L A S S :   S e c t i o n C o n n e c t i v i t y ----------------
 
 class SectionConnectivity : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionDNACertificate.h
+++ b/src/runtime_src/tools/xclbin/SectionDNACertificate.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ----- C L A S S :   S e c t i o n D N A C e r t i f i c a t e -------------
 
 class SectionDNACertificate : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionDTC.h
+++ b/src/runtime_src/tools/xclbin/SectionDTC.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,17 +26,20 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------------- C L A S S :   S e c t i o n D T C ---------------------------
 
 class SectionDTC : public Section {
  public:
   SectionDTC();
   virtual ~SectionDTC();
+
+ public:
+  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
+  virtual bool doesSupportDumpFormatType(FormatType _eFormatType) const;
+
+ protected:
+  virtual void marshalToJSON(char* _pDataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
+  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
 
  private:
   // Purposefully private and undefined ctors...

--- a/src/runtime_src/tools/xclbin/SectionDebugData.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugData.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// -------- C L A S S :   S e c t i o n D e b u g D a t a --------------------
 
 class SectionDebugData : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------ C L A S S :   S e c t i o n D e b u g I P L a y o u t --------------
 
 class SectionDebugIPLayout : public Section {
  private:

--- a/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
+++ b/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------ C L A S S :   S e c t i o n D e s i g n C h e c k P o i n t --------
 
 class SectionDesignCheckPoint : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ----- C L A S S :   S e c t i o n E m b e d d e d M e t a d a t a ---------
 
 class SectionEmbeddedMetadata : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 -2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// --------- C L A S S :   S e c t i o n I P L a y o u t ---------------------
 
 class SectionIPLayout : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ----- C L A S S :   S e c t i o n K e y V a l u e M e t a d a t a ---------
 
 class SectionKeyValueMetadata : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionMCS.h
+++ b/src/runtime_src/tools/xclbin/SectionMCS.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// --------------- C L A S S :   S e c t i o n M C S -------------------------
 
 class SectionMCS : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionManagementFW.h
+++ b/src/runtime_src/tools/xclbin/SectionManagementFW.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------- C L A S S :   S e c t i o n M a n a g e m e n t F W ---------------
 
 class SectionManagementFW : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionMemTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionMemTopology.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------- C L A S S :   S e c t i o n M e m T o p o l o g y -----------------
 
 class SectionMemTopology : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionPDI.h
+++ b/src/runtime_src/tools/xclbin/SectionPDI.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 -2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// --------------- C L A S S :   S e c t i o n P D I -------------------------
 
 class SectionPDI : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
+++ b/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------ C L A S S :   S e c t i o n S c h e d u l e r F W ------------------
 
 class SectionSchedulerFW : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/SectionUserMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionUserMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,12 +26,7 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 
-// ------------------- C L A S S :   S e c t i o n ---------------------------
-
-/**
- *    This class represents the base class for a given Section in the xclbin
- *    archive.  
-*/
+// ------ C L A S S :   S e c t i o n U s e r M e t a d a t a ----------------
 
 class SectionUserMetadata : public Section {
  public:

--- a/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.cxx
@@ -28,6 +28,7 @@
 #include <boost/uuid/uuid.hpp>          // for uuid
 #include <boost/uuid/uuid_io.hpp>       // for to_string
 
+#include <arpa/inet.h>
 
 namespace XUtil = XclBinUtilities;
 
@@ -196,6 +197,24 @@ XclBinUtilities::bytesToAlign(unsigned int _offset) {
   unsigned int bytesToAlign = (_offset & 0x7) ? 0x8 - (_offset & 0x7) : 0;
 
   return bytesToAlign;
+}
+
+unsigned int
+XclBinUtilities::alignBytes(std::ostream & _buf, unsigned int _byteBoundary)
+{
+  _buf.seekp(0, std::ios_base::end);
+  unsigned int bufSize = _buf.tellp();
+  unsigned int bytesAdded = 0;
+
+  if ((bufSize % _byteBoundary) != 0 ) {
+    bytesAdded = _byteBoundary - (bufSize % _byteBoundary);
+    for (unsigned int index = 0; index < bytesAdded; ++index) {
+      char emptyByte = '\0';
+      _buf.write(&emptyByte, sizeof(char));
+    }
+  }
+
+  return bytesAdded;
 }
 
 
@@ -533,6 +552,12 @@ XclBinUtilities::addSignature(const std::string& _sInputFile, const std::string&
   outputStream.close();
 }
 
+void 
+XclBinUtilities::write_htonl(std::ostream & _buf, uint32_t _word32)
+{
+  uint32_t word32 = htonl(_word32);
+  _buf.write((char *) &word32, sizeof(uint32_t));
+}
 
 
 

--- a/src/runtime_src/tools/xclbin/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.h
@@ -21,6 +21,8 @@
 #include "xclbin.h"
 #include <string>
 #include <memory>
+#include <sstream>
+#include <fstream>
 #include <boost/property_tree/ptree.hpp>
 
 
@@ -60,12 +62,15 @@ void TRACE_BUF(const std::string& _msg, const char* _pData, unsigned long _size)
 
 void safeStringCopy(char* _destBuffer, const std::string& _source, unsigned int _bufferSize);
 unsigned int bytesToAlign(unsigned int _offset);
+unsigned int alignBytes(std::ostream & _buf, unsigned int _byteBoundary);
 
 void binaryBufferToHexString(const unsigned char* _binBuf, unsigned int _size, std::string& _outputString);
 void hexStringToBinaryBuffer(const std::string& _inputString, unsigned char* _destBuf, unsigned int _bufferSize);
 uint64_t stringToUInt64(const std::string& _sInteger);
 void printKinds();
 std::string getUUIDAsString( const unsigned char (&_uuid)[16] );
+
+void write_htonl(std::ostream & _buf, uint32_t _word32);
 };
 
 #endif


### PR DESCRIPTION
Added xclbinutil image support for the DTC (Device Tree Compiled) image.  This includes:
1) Creating a new section for the DTC image.
2) Adding support to parse the DTC.
3) Adding an object oriented database representing the DTC image.
4) Adding support to marshal the OO DB to a DTC image.
5) Adding support to marshal the OO DB to a JSON image.
6) Adding support to marshal a JSON image to the DTC OO DB.

In addition, several header comments were cleaned up.

Note: All this work is NEW code and shouldn't impact the existing code flows.
