### PR TITLE
Change the AppDebug warning message to indicate that only functional OpenCL API call will trigger the loading of XDP

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebug.py
+++ b/src/runtime_src/xdp/appdebug/appdebug.py
@@ -72,7 +72,7 @@ class infCallUtil():
 		try:
 			isEnabled = self.callfunc("appdebug::isAppdebugEnabled", [])
 		except:
-			raise ValueError("Application debug not available. Application debug will be available after the first OpenCL API call.")
+			raise ValueError("Application debug not available. Application debug will be available after the first functional OpenCL API call (OpenCL variable construction doesn't count).")
 		if str(isEnabled) == "false":
 			raise ValueError("Application debug not enabled. Set attribute 'app_debug=true' under 'Debug' section of sdaccel.ini and restart application")
 		return

--- a/src/runtime_src/xdp/appdebug/appdebug.py
+++ b/src/runtime_src/xdp/appdebug/appdebug.py
@@ -72,7 +72,7 @@ class infCallUtil():
 		try:
 			isEnabled = self.callfunc("appdebug::isAppdebugEnabled", [])
 		except:
-			raise ValueError("Application debug not available. Application debug will be available after the first functional OpenCL API call (OpenCL variable construction doesn't count).")
+			raise ValueError("Application debug not available. Application debug will be loaded upon the first call to an OpenCL API (not a declaration of an OpenCL variable).")
 		if str(isEnabled) == "false":
 			raise ValueError("Application debug not enabled. Set attribute 'app_debug=true' under 'Debug' section of sdaccel.ini and restart application")
 		return


### PR DESCRIPTION
Some users were confused by the message that AppDebug will only become available after the first OpenCL call, but it doesn't after the OpenCL object construction. 

The behavior is correct, but the warning message is not completely correct. OpenCL API call is referring to functional API calls. The default OpenCL object constructor only does the memory allocation which won't trigger any loading actions.

Added the word "functional" and "variable initialization won't work" into the warning message.