### PR TITLE
clean up AppDebug naming

### DIFF
--- a/src/runtime_src/xdp/appdebug/appdebug.cpp
+++ b/src/runtime_src/xdp/appdebug/appdebug.cpp
@@ -1158,7 +1158,7 @@ spm_debug_view::getstring(int aVerbose, int aJSONFormat) {
     sstr << "]";
   }
   else {
-    sstr<< "SDx Performance Monitor Counters\n";
+    sstr<< "Performance Monitor Counters\n";
     int col1 = std::max(widths.first, strlen("Region or CU")) + 4;
     int col2 = std::max(widths.second, strlen("Type or Port"));
 
@@ -1328,7 +1328,7 @@ std::string
 sspm_debug_view::getXGDBString(bool aVerbose) {
   std::stringstream sstr;
 
-  sstr << "SDx Streaming Performance Monitor Counters\n" ;
+  sstr << "Streaming Performance Monitor Counters\n" ;
   sstr << std::left
        <<         std::setw(32) << "Number of Transactions"
        << "  " << std::setw(16) << "Data Bytes" 

--- a/src/runtime_src/xdp/appdebug/appdebugint.py
+++ b/src/runtime_src/xdp/appdebug/appdebugint.py
@@ -8,7 +8,7 @@ sys.path.append(script_path)
 from appdebug import infCallUtil
 
 class printSPMInfo (infCallUtil):
-	"Print the SDx Performance Monitor counters"
+	"Print the Performance Monitor counters"
 	def invoke (self, arg, jsonformat):
 		fargs = []
 		free_args,spm_ptr,errmsg = self.callfunc_verify("appdebug::clGetDebugCounters",fargs, "SPM")
@@ -35,7 +35,7 @@ class printSPMInfo (infCallUtil):
 obj_spm = printSPMInfo ()
 
 class printSSPMInfo (infCallUtil):
-	"Print the SDx Streaming Performance Monitor counters"
+	"Print the Streaming Performance Monitor counters"
 	def invoke (self, arg, jsonformat):
 		fargs = []
 		free_args,sspm_ptr,errmsg = self.callfunc_verify("appdebug::clGetDebugStreamCounters",fargs, "SSPM")
@@ -99,7 +99,7 @@ class xstatusPrefix(gdb.Command):
 						True)
 xstatusPrefix()
 class xstatusSPMInfo (gdb.Command,infCallUtil):
-	"Print the SDx Performance Monitor counters when available"
+	"Print the Performance Monitor counters when available"
 	def __init__ (self):
 		super (xstatusSPMInfo, self).__init__ ("xstatus spm", 
                          gdb.COMMAND_USER)
@@ -112,7 +112,7 @@ class xstatusSPMInfo (gdb.Command,infCallUtil):
 		obj_spm.invoke(arg, 0)
 xstatusSPMInfo()
 class xstatusSSPMInfo (gdb.Command,infCallUtil):
-	"Print the SDx Streaming Performance Monitor counters when available"
+	"Print the Streaming Performance Monitor counters when available"
 	def __init__ (self):
 		super (xstatusSSPMInfo, self).__init__ ("xstatus sspm", 
                          gdb.COMMAND_USER)


### PR DESCRIPTION
Remove all the SDx related namings in AppDebug in preparation for the more generic naming scheme in the future.