### PR TITLE
 Improve sub buffer alignment message in clEnqueueCopyBuffer

### DIFF
--- a/src/runtime_src/xocl/api/clEnqueueCopyBuffer.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueCopyBuffer.cpp
@@ -40,16 +40,28 @@ getDeviceMemBaseAddrAlign(cl_device_id device)
 {
   cl_uint size = 0;
   api::clGetDeviceInfo(device,CL_DEVICE_MEM_BASE_ADDR_ALIGN,sizeof(cl_uint),&size,nullptr);
-  return size;
+  return size / 8; // bytes
+}
+
+static std::string
+alignmentMessage(cl_mem sbuf, size_t alignment)
+{
+  std::string msg = "clEnqueueCopyBuffer sub buffer offset is ";
+  msg
+    .append(std::to_string(xocl(sbuf)->get_sub_buffer_offset()))
+    .append(" bytes but must be ")
+    .append(std::to_string(alignment))
+    .append(" bytes aligned");
+  return msg;
 }
 
 static void
-validOrError(cl_command_queue    command_queue, 
+validOrError(cl_command_queue    command_queue,
              cl_mem              src_buffer,
-             cl_mem              dst_buffer, 
+             cl_mem              dst_buffer,
              size_t              src_offset,
              size_t              dst_offset,
-             size_t              size, 
+             size_t              size,
              cl_uint             num_events_in_wait_list,
              const cl_event *    event_wait_list,
              cl_event *          event_parameter)
@@ -99,9 +111,9 @@ validOrError(cl_command_queue    command_queue,
   // associated with queue.
   auto align = getDeviceMemBaseAddrAlign(xocl(command_queue)->get_device());
   if (xocl(src_buffer)->is_sub_buffer() && (xocl(src_buffer)->get_sub_buffer_offset() % align))
-    throw error(CL_MISALIGNED_SUB_BUFFER_OFFSET,"clEnqueueCopyBuffer bad src sub buffer offset");
+    throw error(CL_MISALIGNED_SUB_BUFFER_OFFSET,alignmentMessage(src_buffer,align));
   if (xocl(dst_buffer)->is_sub_buffer() && (xocl(dst_buffer)->get_sub_buffer_offset() % align))
-    throw error(CL_MISALIGNED_SUB_BUFFER_OFFSET,"clEnqueueCopyBuffer bad dst sub buffer offset");
+    throw error(CL_MISALIGNED_SUB_BUFFER_OFFSET,alignmentMessage(dst_buffer,align));
 
   // CL_MEM_COPY_OVERLAP if src_buffer and dst_buffer are the same
   // buffer or subbuffer object and the source and destination regions
@@ -110,11 +122,11 @@ validOrError(cl_command_queue    command_queue,
   // regions overlap if src_offset ≤ dst_offset ≤ src_offset + size -
   // 1, or if dst_offset ≤ src_offset ≤ dst_offset + size - 1.
   if ((src_buffer==dst_buffer) &&
-      (( (src_offset<=dst_offset) && (dst_offset<=src_offset+size-1) ) || 
+      (( (src_offset<=dst_offset) && (dst_offset<=src_offset+size-1) ) ||
        ( (dst_offset<=src_offset) && (src_offset<=dst_offset+size-1) )
       ))
     throw xocl::error(CL_MEM_COPY_OVERLAP,"clEnqueueCopyBuffer mem copy overlap");
-  
+
   // CL_MEM_OBJECT_ALLOCATION_FAILURE if there is a failure to
   // allocate memory for data store associated with src_buffer or
   // dst_buffer.
@@ -127,12 +139,12 @@ validOrError(cl_command_queue    command_queue,
 }
 
 static cl_int
-clEnqueueCopyBuffer(cl_command_queue    command_queue, 
+clEnqueueCopyBuffer(cl_command_queue    command_queue,
                     cl_mem              src_buffer,
-                    cl_mem              dst_buffer, 
+                    cl_mem              dst_buffer,
                     size_t              src_offset,
                     size_t              dst_offset,
-                    size_t              size, 
+                    size_t              size,
                     cl_uint             num_events_in_wait_list,
                     const cl_event *    event_wait_list,
                     cl_event *          event_parameter)
@@ -155,12 +167,12 @@ clEnqueueCopyBuffer(cl_command_queue    command_queue,
 } // xocl
 
 cl_int
-clEnqueueCopyBuffer(cl_command_queue    command_queue, 
+clEnqueueCopyBuffer(cl_command_queue    command_queue,
                     cl_mem              src_buffer,
-                    cl_mem              dst_buffer, 
+                    cl_mem              dst_buffer,
                     size_t              src_offset,
                     size_t              dst_offset,
-                    size_t              size, 
+                    size_t              size,
                     cl_uint             num_events_in_wait_list,
                     const cl_event *    event_wait_list,
                     cl_event *          event_parameter)
@@ -180,5 +192,3 @@ clEnqueueCopyBuffer(cl_command_queue    command_queue,
     return CL_OUT_OF_HOST_MEMORY;
   }
 }
-
-

--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -119,7 +119,7 @@ clGetDeviceInfo(cl_device_id   device,
     buffer.as<cl_uint>() = 64;
     break;
   case CL_DEVICE_MAX_MEM_ALLOC_SIZE:
-    buffer.as<cl_ulong>() = 
+    buffer.as<cl_ulong>() =
 #ifdef __x86_64__
       512*1024*1024; //512 MB
 #else
@@ -163,7 +163,7 @@ clGetDeviceInfo(cl_device_id   device,
     buffer.as<size_t>() = 2048;
     break;
   case CL_DEVICE_MEM_BASE_ADDR_ALIGN:
-    buffer.as<cl_uint>() = 4096 << 3; // 32768
+    buffer.as<cl_uint>() = xocl(device)->get_alignment() << 3;  // in bits
     break;
   case CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE:
     buffer.as<cl_uint>() = 128;
@@ -223,9 +223,9 @@ clGetDeviceInfo(cl_device_id   device,
     buffer.as<cl_device_exec_capabilities>() = CL_EXEC_KERNEL;
     break;
   case CL_DEVICE_QUEUE_PROPERTIES:
-    buffer.as<cl_command_queue_properties>() = 
+    buffer.as<cl_command_queue_properties>() =
       (
-       CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE 
+       CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE
        | CL_QUEUE_PROFILING_ENABLE
        | CL_QUEUE_DPDK
      );
@@ -271,14 +271,14 @@ clGetDeviceInfo(cl_device_id   device,
     buffer.as<cl_uint>() = xdevice->get_num_cus();
     break;
   case CL_DEVICE_PARTITION_PROPERTIES:
-    buffer.as<cl_device_partition_property>() = 
+    buffer.as<cl_device_partition_property>() =
       xocl::get_range(std::initializer_list<cl_device_partition_property>({0,0,0,0}));
     break;
   case CL_DEVICE_PARTITION_AFFINITY_DOMAIN:
     buffer.as<cl_device_affinity_domain>() = 0;
     break;
   case CL_DEVICE_PARTITION_TYPE:
-    buffer.as<cl_device_partition_property>() = 
+    buffer.as<cl_device_partition_property>() =
       xocl::get_range(std::initializer_list<cl_device_partition_property>({0,0,0,0}));
     break;
   case CL_DEVICE_REFERENCE_COUNT:
@@ -342,5 +342,3 @@ clGetDeviceInfo(cl_device_id    device,
     return CL_OUT_OF_HOST_MEMORY;
   }
 }
-
-

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -218,6 +218,15 @@ public:
 
 public:
   /**
+   * @return Minimum buffer alignment in bytes
+   */
+  size_t
+  get_alignment() const
+  {
+    return m_xdevice ? m_xdevice->getAlignment() : getpagesize();
+  }
+
+  /**
    * Check if memory is aligned per device requirement.
    *
    * Default is page size if no backing xrt device
@@ -228,8 +237,7 @@ public:
   bool
   is_aligned_ptr(void* p) const
   {
-    auto alignment = m_xdevice ? m_xdevice->getAlignment() : getpagesize();
-    return p && (reinterpret_cast<uintptr_t>(p) % alignment)==0;
+    return p && (reinterpret_cast<uintptr_t>(p) % get_alignment())==0;
   }
 
   /**


### PR DESCRIPTION
To copy between sub-buffers, the buffers must be aligned same as regular buffers.