### PR TITLE
Python 22_verify test case

### DIFF
--- a/tests/python/22_verify/main.py
+++ b/tests/python/22_verify/main.py
@@ -25,44 +25,54 @@ XHELLO_HELLO_CONTROL_BITS_ACCESS1_DATA = 64
 
 
 def runKernel(opt):
+    xclOpenContext(opt.handle, opt.xuuid, 0, True)
+
     boHandle = xclAllocBO(opt.handle, opt.DATA_SIZE, xclBOKind.XCL_BO_DEVICE_RAM, opt.first_mem)
+    if(boHandle == -1):
+        print("Error alloc") #exit and cleanup
     bo = xclMapBO(opt.handle, boHandle, True)
+    if not bo:
+        print("error map") #exit and cleanup
     ctypes.memset(bo, 0, opt.DATA_SIZE)
 
     if xclSyncBO(opt.handle, boHandle, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, opt.DATA_SIZE, 0):
-        return 1
+        return 1 #cleanup 
 
-    print("Original string = [%s]\n") % bo.contents[:]
+    # print("Original string = [%s]\n") % bo.contents[:]
 
     p = xclBOProperties()
     bodevAddr = p.paddr if not (xclGetBOProperties(opt.handle, boHandle, p)) else -1
 
     if bodevAddr is -1:
-        return 1
+        return 1 #cleanup
 
     # Allocate the exec_bo
     execHandle = xclAllocBO(opt.handle, opt.DATA_SIZE, xclBOKind.XCL_BO_SHARED_VIRTUAL, (1 << 31))
+    if(execHandle == -1):
+        print("Error alloc") #exit and cleanup
     execData = xclMapBO(opt.handle, execHandle, True)  # returns mmap()
+    if not execData:
+        print("Error map")#exit and cleanup
 
     print("Construct the exe buf cmd to configure FPGA")
 
     ecmd = ert_configure_cmd.from_buffer(execData.contents)
-    ecmd.m_uert.m_cmd_struct.state = 1  # ERT_CMD_STATE_NEW
+    # ecmd.m_uert.m_cmd_struct.state = 1  # ERT_CMD_STATE_NEW -> ?
     ecmd.m_uert.m_cmd_struct.opcode = 2  # ERT_CONFIGURE
 
-    ecmd.slot_size = opt.DATA_SIZE
-    ecmd.num_cus = 1
-    ecmd.cu_shift = 16
-    ecmd.cu_base_addr = opt.cu_base_addr
+    # ecmd.slot_size = opt.DATA_SIZE-> how does it know the size?
+    # ecmd.num_cus = 1
+    # ecmd.cu_shift = 16
+    # ecmd.cu_base_addr = opt.cu_base_addr
 
-    ecmd.m_features.ert = opt.ert
-    if opt.ert:
-        ecmd.m_features.cu_dma = 1
-        ecmd.m_features.cu_isr = 1
+    # ecmd.m_features.ert = opt.ert -> ?
+    # if opt.ert:
+    #     ecmd.m_features.cu_dma = 1
+    #     ecmd.m_features.cu_isr = 1
 
     # CU -> base address mapping
-    ecmd.data[0] = opt.cu_base_addr
-    ecmd.m_uert.m_cmd_struct.count = 5 + ecmd.num_cus
+    # ecmd.data[0] = opt.cu_base_addr
+    # ecmd.m_uert.m_cmd_struct.count = 5 + ecmd.num_cus
 
 #    sz = sizeof(ert_configure_cmd)
     print("Send the exec command and configure FPGA (ERT)")
@@ -71,7 +81,7 @@ def runKernel(opt):
     ret = xclExecBuf(opt.handle, execHandle)
 
     if ret:
-        print("Unable to issue xclExecBuf")
+        print("Unable to issue xclExecBuf") #cleanup
         return 1
 
     print("Wait until the command finish")
@@ -79,13 +89,12 @@ def runKernel(opt):
     while xclExecWait(opt.handle, 1000) == 0:
         print(".")
 
-    if ecmd.m_uert.m_cmd_struct.state != 4:
-        print("configure command failed")
-        return 1
+    # if ecmd.m_uert.m_cmd_struct.state != 4:
+    #     print("configure command failed")
+    #     return 1
 
     print("Construct the exec command to run the kernel on FPGA")
 
-    xclOpenContext(opt.handle, opt.xuuid, 0, True)
     # construct the exec buffer cmd to start the kernel
     start_cmd = ert_start_kernel_cmd.from_buffer(execData.contents)
     rsz = (XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA / 4 + 1) + 1  # regmap array size
@@ -113,9 +122,9 @@ def runKernel(opt):
     while xclExecWait(opt.handle, 100) == 0:
         print(".")
 
-    if start_cmd.m_uert.m_start_cmd_struct.state != 4:
-        print("configure command failed")
-        return 1
+    # if start_cmd.m_uert.m_start_cmd_struct.state != 4:
+    #     print("configure command failed")
+    #     return 1
 
     # get the output xclSyncBO
     print("Get the output data from the device")

--- a/tests/python/22_verify/main.py
+++ b/tests/python/22_verify/main.py
@@ -1,6 +1,7 @@
 import sys
 import uuid
 from xrt_binding import * # found in PYTHONPATH
+from ert_binding import * # found in PYTHONPATH
 sys.path.append('../') # utils_binding.py
 from utils_binding import *
 
@@ -29,69 +30,77 @@ def runKernel(opt):
 
     boHandle = xclAllocBO(opt.handle, opt.DATA_SIZE, xclBOKind.XCL_BO_DEVICE_RAM, opt.first_mem)
     if(boHandle == -1):
-        print("Error alloc") #exit and cleanup
+        xclFreeBO(opt.handle, boHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unabe to alloc BO") 
+        return 1
+
     bo = xclMapBO(opt.handle, boHandle, True)
-    if not bo:
-        print("error map") #exit and cleanup
+    if not bo: # checks NULLBO
+        xclFreeBO(opt.handle, boHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to map BO")
+        return 1
+
     ctypes.memset(bo, 0, opt.DATA_SIZE)
 
     if xclSyncBO(opt.handle, boHandle, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, opt.DATA_SIZE, 0):
-        return 1 #cleanup 
+        xclFreeBO(opt.handle, boHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to sync BO")
+        return 1  
 
-    # print("Original string = [%s]\n") % bo.contents[:]
+    print("Original string = [%s]\n") % bo.contents[:]
 
     p = xclBOProperties()
     bodevAddr = p.paddr if not (xclGetBOProperties(opt.handle, boHandle, p)) else -1
 
     if bodevAddr is -1:
-        return 1 #cleanup
+        xclFreeBO(opt.handle, boHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to get BO properties")
+        return 1
 
     # Allocate the exec_bo
     execHandle = xclAllocBO(opt.handle, opt.DATA_SIZE, xclBOKind.XCL_BO_SHARED_VIRTUAL, (1 << 31))
     if(execHandle == -1):
-        print("Error alloc") #exit and cleanup
+        xclFreeBO(opt.handle, boHandle)
+        xclFreeBO(opt.handle, execHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to alloc exec BO")
+        return 1
     execData = xclMapBO(opt.handle, execHandle, True)  # returns mmap()
     if not execData:
-        print("Error map")#exit and cleanup
+        xclFreeBO(opt.handle, boHandle)
+        xclFreeBO(opt.handle, execHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to map exec BO")
+        return 1
 
     print("Construct the exe buf cmd to configure FPGA")
 
     ecmd = ert_configure_cmd.from_buffer(execData.contents)
-    # ecmd.m_uert.m_cmd_struct.state = 1  # ERT_CMD_STATE_NEW -> ?
     ecmd.m_uert.m_cmd_struct.opcode = 2  # ERT_CONFIGURE
 
-    # ecmd.slot_size = opt.DATA_SIZE-> how does it know the size?
-    # ecmd.num_cus = 1
-    # ecmd.cu_shift = 16
-    # ecmd.cu_base_addr = opt.cu_base_addr
+    ecmd.m_features.ert = opt.ert
+    if opt.ert:
+        ecmd.m_features.cu_dma = 1
+        ecmd.m_features.cu_isr = 1
 
-    # ecmd.m_features.ert = opt.ert -> ?
-    # if opt.ert:
-    #     ecmd.m_features.cu_dma = 1
-    #     ecmd.m_features.cu_isr = 1
-
-    # CU -> base address mapping
-    # ecmd.data[0] = opt.cu_base_addr
-    # ecmd.m_uert.m_cmd_struct.count = 5 + ecmd.num_cus
-
-#    sz = sizeof(ert_configure_cmd)
     print("Send the exec command and configure FPGA (ERT)")
 
     # Send the command.
-    ret = xclExecBuf(opt.handle, execHandle)
-
-    if ret:
-        print("Unable to issue xclExecBuf") #cleanup
+    if xclExecBuf(opt.handle, execHandle):
+        xclFreeBO(opt.handle, boHandle)
+        xclFreeBO(opt.handle, execHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to issue exec buf")
         return 1
 
     print("Wait until the command finish")
-
-    while xclExecWait(opt.handle, 1000) == 0:
-        print(".")
-
-    # if ecmd.m_uert.m_cmd_struct.state != 4:
-    #     print("configure command failed")
-    #     return 1
+    while ecmd.m_uert.m_cmd_struct.state < ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+        while xclExecWait(opt.handle, 1000) == 0:
+            print(".")
 
     print("Construct the exec command to run the kernel on FPGA")
 
@@ -111,24 +120,26 @@ def runKernel(opt):
     new_data[XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA / 4 + 1] = (bodevAddr >> 32) & 0xFFFFFFFF
 
     if xclExecBuf(opt.handle, execHandle):
-        print("Unable to issue xclExecBuf")
+        xclFreeBO(opt.handle, boHandle)
+        xclFreeBO(opt.handle, execHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to issue exec buf")
         return 1
     else:
         print("Kernel start command issued through xclExecBuf : start_kernel")
         print("Now wait until the kernel finish")
 
     print("Wait until the command finish")
+    while ecmd.m_uert.m_cmd_struct.state < ert_cmd_state.ERT_CMD_STATE_COMPLETED:
+        while xclExecWait(opt.handle, 100) == 0: 
+            print(".")
 
-    while xclExecWait(opt.handle, 100) == 0:
-        print(".")
-
-    # if start_cmd.m_uert.m_start_cmd_struct.state != 4:
-    #     print("configure command failed")
-    #     return 1
-
-    # get the output xclSyncBO
     print("Get the output data from the device")
     if xclSyncBO(opt.handle, boHandle, xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, opt.DATA_SIZE, 0):
+        xclFreeBO(opt.handle, boHandle)
+        xclFreeBO(opt.handle, execHandle)
+        xclCloseContext(opt.handle, opt.xuuid, 0)
+        print("Error: Unable to sync BO")
         return 1
 
     result = bo.contents[:len("Hello World")]

--- a/tests/python/22_verify/sdainfo.yml
+++ b/tests/python/22_verify/sdainfo.yml
@@ -1,0 +1,6 @@
+description: Python test
+args: -k verify.xclbin
+copy: [utils_binding.py]
+srcs: [main.py]
+user:
+  xclbin_suites: [xrt_pipeline]

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -177,7 +177,7 @@ def initXRT(opt):
         for i in range(topo.m_count):
             print("[%d] %s @0x%x") % (i, ctypes.cast(mem[i].m_tag, ctypes.c_char_p).value, mem[i].mem_u2.m_base_address)
             if (mem[i].m_used == 0):
-                continue;
+                continue
             opt.first_mem = i
             break
 


### PR DESCRIPTION
* removed ert manual config
* added cleanups during error exits
* yml file for adding this testcase to xrt_pipeline (not sure if this works)
* Output:
```
Host buffer alignment 4096 bytes
Compiled kernel = /opt/xilinx/dsa/xilinx_vcu1525_xdma_201830_2/test/verify.xclbin
DSA = xilinx_vcu1525_xdma_201830_2
Index = 0
PCIe = GEN3 x 16
OCL Frequency = 300 MHz
DDR Bank = 4
Device Temp = -1 C
MIG Calibration = True
Finished downloading bitstream /opt/xilinx/dsa/xilinx_vcu1525_xdma_201830_2/test/verify.xclbin
CU[0] hello:hello_1 @0x1800000
[0] bank0 @0x4000000000
[1] bank1 @0x5000000000
Original string = []

Construct the exe buf cmd to configure FPGA
Send the exec command and configure FPGA (ERT)
Wait until the command finish
Construct the exec command to run the kernel on FPGA
Kernel start command issued through xclExecBuf : start_kernel
Now wait until the kernel finish
Wait until the command finish
Get the output data from the device
Result string = [Hello World]

PASSED TEST
```
