### PR TITLE
Error out if specify host pointer and p2p flag

### DIFF
--- a/src/runtime_src/xocl/api/detail/memory.cpp
+++ b/src/runtime_src/xocl/api/detail/memory.cpp
@@ -112,6 +112,8 @@ validHostPtrOrError(cl_mem_flags flags, const void* host_ptr)
       if (std::bitset<12>(ext_flags & ddr_bank_mask).count() > 1)
        throw xocl::error(CL_INVALID_VALUE,"Multiple bank flags specified");
     }
+    if (bool(ubuf) && bool(ext_flags & XCL_MEM_EXT_P2P_BUFFER))
+       throw error(CL_INVALID_HOST_PTR,"host_ptr with P2P buffer flags specified");
   }
 }
 


### PR DESCRIPTION
We should error out if user tries to create a P2P buffer and assign host pointer to it.

CR: http://jira.xilinx.com/browse/CR-1024102