### PR TITLE
Replacing old terminology of CPU emu with Software Emulation

### DIFF
--- a/src/runtime_src/driver/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/cpu_em/generic_pcie_hal2/shim.cxx
@@ -175,7 +175,7 @@ namespace xclcpuemhal2 {
 	  // One of the spawned processes died for some reason,
 	  //  kill all of the others and exit the host code
 	  saveDeviceProcessOutputs() ;
-	  std::cerr << "CPU emulation compute unit exited unexpectedly" 
+	  std::cerr << "Software emulation of compute unit(s) exited unexpectedly" 
 		    << std::endl ;
 	  kill(0, SIGTERM) ; 
 	  exit(1) ;


### PR DESCRIPTION
This message will be presented to user, user is aware of sw_emu as XCL_EMULATION_MODE.
We dont wish to use multiple terminologies, hence replacing word cpu by software