### PR TITLE
Json schema change

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -84,7 +84,7 @@ enum subcommand {
     STATUS_SPM,
     STATUS_LAPC,
     STATUS_SSPM,
-    STATUS_SPC, 
+    STATUS_SPC,
     STREAM,
     STATUS_UNSUPPORTED,
 };
@@ -261,11 +261,10 @@ public:
             if (computeUnits.at( i ).m_type != IP_KERNEL)
                 continue;
             xclRead(m_handle, XCL_ADDR_KERNEL_CTRL, computeUnits.at( i ).m_base_address, &statusBuf, 4);
-            ptCu.put( "index",        i );
             ptCu.put( "name",         computeUnits.at( i ).m_name );
             ptCu.put( "base_address", computeUnits.at( i ).m_base_address );
             ptCu.put( "status",       parseCUStatus( statusBuf ) );
-            sensor_tree::add_child( "board.compute_unit.cu", ptCu );
+            sensor_tree::add_child( std::string("board.compute_unit." + std::to_string(i)), ptCu );
         }
         return 0;
     }
@@ -353,7 +352,7 @@ public:
             ss << "WARNING: 'memstat_raw' invalid, unable to report memory stats. "
                 << "Has the bitstream been loaded? See 'xbutil program'.";
             lines.push_back(ss.str());
-            return;            
+            return;
         }
         unsigned numDDR = map->m_count;
         for(unsigned i = 0; i < numDDR; i++ ) {
@@ -363,7 +362,7 @@ public:
                 continue;
             uint64_t memoryUsage, boCount;
             std::stringstream mem_usage(mm_buf[i]);
-            mem_usage >> memoryUsage >> boCount;            
+            mem_usage >> memoryUsage >> boCount;
 
             float percentage = (float)memoryUsage * 100 /
                 (map->m_mem_data[i].m_size << 10);
@@ -404,42 +403,39 @@ public:
             if (map->m_mem_data[i].m_type == MEM_STREAMING || map->m_mem_data[i].m_type == MEM_STREAMING_CONNECTION) {
                 std::string lname, status = "Inactive", total = "N/A", pending = "N/A";
                 boost::property_tree::ptree ptStream;
-		std::map<std::string, std::string> stat_map;
-
-		lname = std::string((char *)map->m_mem_data[i].m_tag);
+                std::map<std::string, std::string> stat_map;
+                lname = std::string((char *)map->m_mem_data[i].m_tag);
                 if (lname.back() == 'w')
                     lname = "route" + std::to_string(map->m_mem_data[i].route_id) + "/stat";
                 else if (lname.back() == 'r')
                     lname = "flow" + std::to_string(map->m_mem_data[i].flow_id) + "/stat";
-		else
+                else
                     status = "N/A";
 
-	        pcidev::get_dev(m_idx)->user->sysfs_get("qdma", lname, errmsg, stream_stat);
+                pcidev::get_dev(m_idx)->user->sysfs_get("qdma", lname, errmsg, stream_stat);
                 if (errmsg.empty()) {
                     status = "Active";
-		    for (unsigned k = 0; k < stream_stat.size(); k++) {
-			char key[50];
-			int64_t value;
+                    for (unsigned k = 0; k < stream_stat.size(); k++) {
+                        char key[50];
+                        int64_t value;
 
-			std::sscanf(stream_stat[k].c_str(), "%[^:]:%ld", key, &value);
-			stat_map[std::string(key)] = std::to_string(value);
-		    }
+                        std::sscanf(stream_stat[k].c_str(), "%[^:]:%ld", key, &value);
+                        stat_map[std::string(key)] = std::to_string(value);
+                    }
 
-                    total = stat_map[std::string("complete_bytes")] +
-                        "/" + stat_map[std::string("complete_requests")];
-                    pending = stat_map[std::string("pending_bytes")] +
-                        "/" + stat_map[std::string("pending_requests")];
-		}
+                    total = stat_map[std::string("complete_bytes")] + "/" + stat_map[std::string("complete_requests")];
+                    pending = stat_map[std::string("pending_bytes")] + "/" + stat_map[std::string("pending_requests")];
+                }
 
-		ptStream.put( "index",	i);
+                ptStream.put( "index", i );
                 ptStream.put( "tag", map->m_mem_data[i].m_tag );
                 ptStream.put( "flow_id", map->m_mem_data[i].flow_id );
                 ptStream.put( "route_id", map->m_mem_data[i].route_id );
-		ptStream.put( "status", status );
-		ptStream.put( "total", total );
-		ptStream.put( "pending", pending );
-		sensor_tree::add_child( "board.memory.stream", ptStream);
-		continue;
+                ptStream.put( "status", status );
+                ptStream.put( "total", total );
+                ptStream.put( "pending", pending );
+                sensor_tree::add_child( "board.memory.stream", ptStream);
+                continue;
             }
 
             std::string str = "**UNUSED**";
@@ -451,7 +447,6 @@ public:
             ss >> memoryUsage >> boCount;
 
             boost::property_tree::ptree ptMem;
-            ptMem.put( "index",     i );
             ptMem.put( "type",      str );
             ptMem.put( "temp",      temp_buf.empty() ? XCL_NO_SENSOR_DEV : temp[i]);
             ptMem.put( "tag",       map->m_mem_data[i].m_tag );
@@ -459,7 +454,7 @@ public:
             ptMem.put( "size",      unitConvert(map->m_mem_data[i].m_size << 10) );
             ptMem.put( "mem_usage", unitConvert(memoryUsage));
             ptMem.put( "bo_count",  boCount);
-            sensor_tree::add_child( "board.memory.mem", ptMem );
+            sensor_tree::add_child( std::string("board.memory." + std::to_string(i)), ptMem );
         }
     }
 
@@ -700,10 +695,9 @@ public:
         (void) xclGetUsageInfo(m_handle, &devstat);
         for (unsigned i = 0; i < 2; i++) {
             boost::property_tree::ptree pt_dma;
-            pt_dma.put( "index", i );
             pt_dma.put( "h2c", unitConvert(devstat.h2c[i]) );
             pt_dma.put( "c2h", unitConvert(devstat.c2h[i]) );
-            sensor_tree::add_child( "board.pcie_dma.transfer_metrics.chan", pt_dma );
+            sensor_tree::add_child( std::string("board.pcie_dma.transfer_metrics.chan." + std::to_string(i)), pt_dma );
         }
         getMemTopology( devstat );
         // stream
@@ -740,12 +734,12 @@ public:
         sensor_tree::put("debug_profile.device_info.nifd_name", std::string(info.nifd_name));
         /** End of debug and profile device information */
 
-	// p2p enable
-	int p2p_enabled;
+        // p2p enable
+        int p2p_enabled;
         pcidev::get_dev(m_idx)->user->sysfs_get("", "p2p_enable", errmsg, p2p_enabled);
-	if(errmsg.empty()) {
-		sensor_tree::put( "board.info.p2p_enabled", p2p_enabled );
-	}
+        if(errmsg.empty()) {
+            sensor_tree::put( "board.info.p2p_enabled", p2p_enabled );
+        }
         return 0;
     }
 
@@ -868,27 +862,25 @@ public:
 
         try {
           for (auto& v : sensor_tree::get_child("board.memory")) {
-            if( v.first == "mem" ) {
+            int index = std::stoi(v.first);
+            if( index >= 0 ) {
               std::string mem_usage, tag, size, type, temp;
-              int index = 0;
               unsigned bo_count = 0;
               for (auto& subv : v.second) {
-                if( subv.first == "index" ) {
-                  index = subv.second.get_value<int>();
-                } else if( subv.first == "type" ) {
-                  type = subv.second.get_value<std::string>();
-                } else if( subv.first == "tag" ) {
-                  tag = subv.second.get_value<std::string>();
-                } else if( subv.first == "temp" ) {
-                  unsigned int t = subv.second.get_value<unsigned int>();
-                  temp = sensor_tree::pretty<unsigned int>(t == XCL_INVALID_SENSOR_VAL ? XCL_NO_SENSOR_DEV : t, "N/A");
-                } else if( subv.first == "bo_count" ) {
-                  bo_count = subv.second.get_value<unsigned>();
-                } else if( subv.first == "mem_usage" ) {
-                  mem_usage = subv.second.get_value<std::string>();
-                } else if( subv.first == "size" ) {
-                  size = subv.second.get_value<std::string>();
-                }
+                  if( subv.first == "type" ) {
+                      type = subv.second.get_value<std::string>();
+                  } else if( subv.first == "tag" ) {
+                      tag = subv.second.get_value<std::string>();
+                  } else if( subv.first == "temp" ) {
+                      unsigned int t = subv.second.get_value<unsigned int>();
+                      temp = sensor_tree::pretty<unsigned int>(t == XCL_INVALID_SENSOR_VAL ? XCL_NO_SENSOR_DEV : t, "N/A");
+                  } else if( subv.first == "bo_count" ) {
+                      bo_count = subv.second.get_value<unsigned>();
+                  } else if( subv.first == "mem_usage" ) {
+                      mem_usage = subv.second.get_value<std::string>();
+                  } else if( subv.first == "size" ) {
+                      size = subv.second.get_value<std::string>();
+                  }
               }
               ostr << std::left
                    << "[" << std::right << std::setw(2) << index << "] " << std::left
@@ -908,20 +900,19 @@ public:
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         ostr << "DMA Transfer Metrics" << std::endl;
         try {
-          for (auto& v : sensor_tree::get_child( "board.pcie_dma.transfer_metrics" )) {
-            if( v.first == "chan" ) {
-              std::string chan_index, chan_h2c, chan_c2h, chan_val = "N/A";
+          for (auto& v : sensor_tree::get_child( "board.pcie_dma.transfer_metrics.chan" )) {
+            int index = std::stoi(v.first);
+            if( index >= 0 ) {
+              std::string chan_h2c, chan_c2h, chan_val = "N/A";
               for (auto& subv : v.second ) {
                 chan_val = subv.second.get_value<std::string>();
-                if( subv.first == "index" )
-                  chan_index = chan_val;
-                else if( subv.first == "h2c" )
+                if( subv.first == "h2c" )
                   chan_h2c = chan_val;
                 else if( subv.first == "c2h" )
                   chan_c2h = chan_val;
               }
-              ostr << "Chan[" << chan_index << "].h2c:  " << chan_h2c << std::endl;
-              ostr << "Chan[" << chan_index << "].c2h:  " << chan_c2h << std::endl;
+              ostr << "Chan[" << index << "].h2c:  " << chan_h2c << std::endl;
+              ostr << "Chan[" << index << "].c2h:  " << chan_c2h << std::endl;
             }
           }
         }
@@ -934,7 +925,7 @@ public:
         ostr << std::setw(17) << "     Tag"  << std::setw(9) << "Flow ID"
              << std::setw(9)  << "Route ID"   << std::setw(9)  << "Status";
         ostr << std::setw(16) << "Total (B/#)" << std::setw(10)  << "Pending (B/#)" << std::endl;
-	try {
+        try {
           for (auto& v : sensor_tree::get_child("board.memory")) {
             if( v.first == "stream" ) {
               std::string status, tag, total, pending;
@@ -955,7 +946,7 @@ public:
                   total = subv.second.get_value<std::string>();
                 } else if ( subv.first == "pending" ) {
                   pending = subv.second.get_value<std::string>();
-		}
+                }
               }
               ostr << std::left
                    << "[" << std::right << std::setw(2) << index << "] " << std::left
@@ -963,11 +954,11 @@ public:
                    << std::setw(9) << flow_id
                    << std::setw(9)  << route_id
                    << std::setw(9)  << status
-		   << std::setw(16) << total
-		   << std::setw(10) << pending << std::endl;
-	    }
-	  }
-	}
+                   << std::setw(16) << total
+                   << std::setw(10) << pending << std::endl;
+            }
+          }
+        }
         catch( std::exception const& e) {
           // eat the exception, probably bad path
         }
@@ -979,13 +970,12 @@ public:
         ostr << "Compute Unit Status\n";
         try {
           for (auto& v : sensor_tree::get_child( "board.compute_unit" )) {
-            if( v.first == "cu" ) {
+            int index = std::stoi(v.first);
+            if( index >= 0 ) {
               std::string cu_n, cu_s, cu_ba;
               int cu_i = 0;
               for (auto& subv : v.second) {
-                if( subv.first == "index" )
-                  cu_i = subv.second.get_value<int>();
-                else if( subv.first == "name" )
+                if( subv.first == "name" )
                   cu_n = subv.second.get_value<std::string>();
                 else if( subv.first == "base_address" )
                   cu_ba = sensor_tree::pretty<int>(subv.second.get_value<int>(), "N/A", true);
@@ -1053,7 +1043,7 @@ public:
         const xclBin *header = (const xclBin *)buffer;
         int result = xclLockDevice(m_handle);
         if (result == 0)
-		result = xclLoadXclBin(m_handle, header);
+            result = xclLoadXclBin(m_handle, header);
         delete [] buffer;
         (void) xclUnlockDevice(m_handle);
 

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -866,7 +866,7 @@ public:
         ostr << std::setw(16) << "Mem Usage" << std::setw(8)  << "BO count" << std::endl;
 
         try {
-          for (auto& v : sensor_tree::get_child("board.memory")) {
+          for (auto& v : sensor_tree::get_child("board.memory.mem")) {
             int index = std::stoi(v.first);
             if( index >= 0 ) {
               std::string mem_usage, tag, size, type, temp;
@@ -931,15 +931,14 @@ public:
              << std::setw(9)  << "Route ID"   << std::setw(9)  << "Status";
         ostr << std::setw(16) << "Total (B/#)" << std::setw(10)  << "Pending (B/#)" << std::endl;
         try {
-          for (auto& v : sensor_tree::get_child("board.memory")) {
-            if( v.first == "stream" ) {
+          for (auto& v : sensor_tree::get_child("board.memory.stream")) {
+            int stream_index = std::stoi(v.first);
+            if( stream_index >= 0 ) {
               std::string status, tag, total, pending;
               int index = 0;
               unsigned int flow_id = 0, route_id = 0;
               for (auto& subv : v.second) {
-                if( subv.first == "index" ) {
-                  index = subv.second.get_value<int>();
-                } else if( subv.first == "tag" ) {
+                if( subv.first == "tag" ) {
                   tag = subv.second.get_value<std::string>();
                 } else if( subv.first == "flow_id" ) {
                   flow_id = subv.second.get_value<unsigned int>();
@@ -961,6 +960,7 @@ public:
                    << std::setw(9)  << status
                    << std::setw(16) << total
                    << std::setw(10) << pending << std::endl;
+              index++;
             }
           }
         }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.h
@@ -399,6 +399,9 @@ public:
         if(buf.empty() || mm_buf.empty())
             return;
 
+        int j = 0; // stream index
+        int m = 0; // mem index
+
         for(int i = 0; i < map->m_count; i++) {
             if (map->m_mem_data[i].m_type == MEM_STREAMING || map->m_mem_data[i].m_type == MEM_STREAMING_CONNECTION) {
                 std::string lname, status = "Inactive", total = "N/A", pending = "N/A";
@@ -427,14 +430,14 @@ public:
                     pending = stat_map[std::string("pending_bytes")] + "/" + stat_map[std::string("pending_requests")];
                 }
 
-                ptStream.put( "index", i );
                 ptStream.put( "tag", map->m_mem_data[i].m_tag );
                 ptStream.put( "flow_id", map->m_mem_data[i].flow_id );
                 ptStream.put( "route_id", map->m_mem_data[i].route_id );
                 ptStream.put( "status", status );
                 ptStream.put( "total", total );
                 ptStream.put( "pending", pending );
-                sensor_tree::add_child( "board.memory.stream", ptStream);
+                sensor_tree::add_child( std::string("board.memory.stream." + std::to_string(j)), ptStream);
+                j++;
                 continue;
             }
 
@@ -454,7 +457,8 @@ public:
             ptMem.put( "size",      unitConvert(map->m_mem_data[i].m_size << 10) );
             ptMem.put( "mem_usage", unitConvert(memoryUsage));
             ptMem.put( "bo_count",  boCount);
-            sensor_tree::add_child( std::string("board.memory." + std::to_string(i)), ptMem );
+            sensor_tree::add_child( std::string("board.memory.mem." + std::to_string(m)), ptMem );
+            m++;
         }
     }
 
@@ -599,6 +603,7 @@ public:
 
     int readSensors( void ) const
     {
+        sensor_tree::put( "version",                 "1.1.0" ); // json schema version
         sensor_tree::put( "runtime.build.version",   xrt_build_version );
         sensor_tree::put( "runtime.build.hash",      xrt_build_version_hash );
         sensor_tree::put( "runtime.build.date",      xrt_build_version_date );


### PR DESCRIPTION
Addresses JIRA CR-1024994

Removes duplicate entries for things like compute units, memory. Instead of having memory entries listed as:
```
memory: {
    mem: {
        index: 0
         ....
    },
    mem: {
         index: 1
         ....
    }
```

We have replaced "mem" with "index" and removed the "index" entry. Here is an example output:
```
        "memory": {
            "mem": {
                "0": {
                    "type": "**UNUSED**",
                    "temp": "32",
                    "tag": "bank0",
                    "enabled": "false",
                    "size": "16 GB",
                    "mem_usage": "0 Byte",
                    "bo_count": "0"
                },
                "1": {
                    "type": "MEM_DDR4",
                    "temp": "35",
                    "tag": "bank1",
                    "enabled": "true",
                    "size": "16 GB",
                    "mem_usage": "0 Byte",
                    "bo_count": "0"
                },
                "2": {
                    "type": "**UNUSED**",
                    "temp": "37",
                    "tag": "bank2",
                    "enabled": "false",
                    "size": "16 GB",
                    "mem_usage": "0 Byte",
                    "bo_count": "0"
                },

```

This conforms to a more-standard format for parsing entry lists. Standard JSON parsers do not support duplicate keys. 

Also adding the json schema version, named "version" at root. This change bumps from 1.0.0 to 1.1.0. I should back-port the version into 2018.3 and keep as 1.0.0.

