### PR TITLE
util is not a shared library, should not be a link target

### DIFF
--- a/src/runtime_src/driver/zynq/hw_em/CMakeLists.txt
+++ b/src/runtime_src/driver/zynq/hw_em/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(xrt_hwemu
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   rt
-  util
   )
 
 install (TARGETS xrt_hwemu LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)

--- a/src/runtime_src/driver/zynq/sw_em/CMakeLists.txt
+++ b/src/runtime_src/driver/zynq/sw_em/CMakeLists.txt
@@ -32,7 +32,6 @@ target_link_libraries(xrt_swemu
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   rt
-  util
   )
 
 install (TARGETS xrt_swemu LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)


### PR DESCRIPTION
I see this error when compile xrt in petalinux:

| CMake Error at runtime_src/driver/zynq/hw_em/CMakeLists.txt:31 (target_link_libraries):
|   Target "util" of type OBJECT_LIBRARY may not be linked into another target.
|   One may link only to STATIC or SHARED libraries, or to executables with the
|   ENABLE_EXPORTS property set.
|
|
| CMake Error at runtime_src/driver/zynq/sw_em/CMakeLists.txt:31 (target_link_libraries):
|   Target "util" of type OBJECT_LIBRARY may not be linked into another target.
|   One may link only to STATIC or SHARED libraries, or to executables with the
|   ENABLE_EXPORTS property set.
|
|
| -- XRT version: 2.2.0
| -- Configuring incomplete, errors occurred!

It is because the util is a object. It should not be a link library.

@Himanshu-xilinx I could not add you into the reviewers