### PR TITLE
Fix for malformed xbutil formatting

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
@@ -62,7 +62,12 @@ uint32_t xcldev::device::getIPCountAddrNames(int type,
                 baseAddress->push_back(map->m_debug_ip_data[i].m_base_address);
             if(portNames) {
                 std::string portName;
+		// This makes sure that the c string is null terminated,
+		//  but it also copies a full 128 and fills unused spaces
+		//  with null characters.
                 portName.assign(map->m_debug_ip_data[i].m_name, 128);
+		// This statement strips away any extraneous null characters
+		portName.assign(portName.c_str());
                 portNames->push_back(portName);
             }
             ++count;

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
@@ -384,13 +384,9 @@ int xcldev::device::readStreamingCheckers(int aVerbose) {
                 << "  " << std::setw(16) << std::hex << debugResults.SnapshotPC[i]
                 << "  " << std::setw(16) << std::hex << debugResults.CurrentPC[i]
                 << std::dec << std::endl;
-<<<<<<< HEAD
     }
     // Restore formatting
     std::cout.copyfmt(saveFormat);
-=======
-    }      
->>>>>>> Adding support to xbutil to print out the values read from streaming AXI protocol checkers
   }
   return 0;
 }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
@@ -384,9 +384,13 @@ int xcldev::device::readStreamingCheckers(int aVerbose) {
                 << "  " << std::setw(16) << std::hex << debugResults.SnapshotPC[i]
                 << "  " << std::setw(16) << std::hex << debugResults.CurrentPC[i]
                 << std::dec << std::endl;
+<<<<<<< HEAD
     }
     // Restore formatting
     std::cout.copyfmt(saveFormat);
+=======
+    }      
+>>>>>>> Adding support to xbutil to print out the values read from streaming AXI protocol checkers
   }
   return 0;
 }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
@@ -387,6 +387,7 @@ int xcldev::device::readStreamingCheckers(int aVerbose) {
     }
     // Restore formatting
     std::cout.copyfmt(saveFormat);
+
   }
   return 0;
 }

--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil_debug.cpp
@@ -387,7 +387,6 @@ int xcldev::device::readStreamingCheckers(int aVerbose) {
     }
     // Restore formatting
     std::cout.copyfmt(saveFormat);
-
   }
   return 0;
 }

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -235,7 +235,6 @@ public:
     size_t xclDebugReadStreamingCounters(xclStreamingDebugCountersResults* streamingResult);
     size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
     size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
-    size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
 
 
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -237,7 +237,6 @@ public:
     size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
 
 
-
     // Trace
     size_t xclPerfMonStartTrace(xclPerfMonType type, uint32_t startTrigger);
     size_t xclPerfMonStopTrace(xclPerfMonType type);

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -235,6 +235,7 @@ public:
     size_t xclDebugReadStreamingCounters(xclStreamingDebugCountersResults* streamingResult);
     size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
     size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
+    size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
 
 
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -237,6 +237,7 @@ public:
     size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
 
 
+
     // Trace
     size_t xclPerfMonStartTrace(xclPerfMonType type, uint32_t startTrigger);
     size_t xclPerfMonStopTrace(xclPerfMonType type);

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -235,6 +235,7 @@ public:
     size_t xclDebugReadStreamingCounters(xclStreamingDebugCountersResults* streamingResult);
     size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
     size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
+    size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
 
 
     // Trace

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -235,7 +235,6 @@ public:
     size_t xclDebugReadStreamingCounters(xclStreamingDebugCountersResults* streamingResult);
     size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
     size_t xclDebugReadAccelMonitorCounters(xclAccelMonitorCounterResults* samResult);
-    size_t xclDebugReadStreamingCheckers(xclDebugStreamingCheckersResults* streamingCheckerResult);
 
 
     // Trace


### PR DESCRIPTION
Adding a statement to strip away extra null characters copied into a string, which adjusts the formatting.