### PR TITLE
[MPSoC] Link libxrt_coreutil.so library

### DIFF
--- a/src/runtime_src/driver/zynq/hw_em/CMakeLists.txt
+++ b/src/runtime_src/driver/zynq/hw_em/CMakeLists.txt
@@ -31,6 +31,7 @@ set_target_properties(xrt_hwemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 target_link_libraries(xrt_hwemu
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
+  xrt_coreutil
   rt
   )
 

--- a/src/runtime_src/driver/zynq/sw_em/CMakeLists.txt
+++ b/src/runtime_src/driver/zynq/sw_em/CMakeLists.txt
@@ -31,6 +31,7 @@ set_target_properties(xrt_swemu PROPERTIES VERSION ${XRT_VERSION_STRING}
 target_link_libraries(xrt_swemu
   ${Boost_FILESYSTEM_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
+  xrt_coreutil
   rt
   )
 

--- a/src/runtime_src/driver/zynq/user/CMakeLists.txt
+++ b/src/runtime_src/driver/zynq/user/CMakeLists.txt
@@ -24,6 +24,7 @@ set_target_properties(xrt_core PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
 target_link_libraries(xrt_core
+  xrt_coreutil
   pthread
   rt
   uuid


### PR DESCRIPTION
After #1225, we should link libxrt_coreutil.so for MPSoC platform.
 