### PR TITLE
Enhancement request to update the migration error message to be more helpful.

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBin.cxx
+++ b/src/runtime_src/tools/xclbin/XclBin.cxx
@@ -448,7 +448,13 @@ XclBin::findAndReadMirrorData(std::fstream& _istream, boost::property_tree::ptre
     XUtil::TRACE(XUtil::format("Found MIRROR_DATA_START at offset: 0x%lx", startOffset));
     startOffset += MIRROR_DATA_START.length();
   }  else {
-    std::string errMsg = "ERROR: Mirror backup data not found in given file.";
+    std::string errMsg;
+    errMsg  = "ERROR: Mirror backup data not found in given file.\n"; 
+    errMsg += "       The given archive image does not contain any metadata to\n";
+    errMsg += "       migrate the data image to the current format.\n";
+    errMsg += "       The lack of metadata is usually the result of attempting\n";
+    errMsg += "       to migrate a pre-2018.3 archive.";
+                          
     throw std::runtime_error(errMsg);
   }
 


### PR DESCRIPTION
The missing mirror backup data message has been updated to the following:

ERROR: Mirror backup data not found in given file.
       The given archive image does not contain any metadata to
       migrate the data image to the current format.
       The lack of metadata is usually the result of attempting
       to migrate a pre-2018.3 archive.
