### PR TITLE
Fix ICD loader problem after adding libxrt_coreutil.so dependency

### DIFF
--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -64,8 +64,11 @@ endif()
 set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
 set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
 
-set_target_properties(xilinxopencl PROPERTIES VERSION ${XRT_VERSION_STRING}
-  SOVERSION ${XRT_SOVERSION})
+set_target_properties(xilinxopencl PROPERTIES
+  VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION}
+  INSTALL_RPATH $ORIGIN
+  )
 
 target_link_libraries(oclxdp
   xdp


### PR DESCRIPTION
When using ICD loader all dependencies of libxilinxopencl.so must be
located.  Since LD_LIBRARY_PATH is not set, the dependent
libxrt_coreutil.so cannot be found.  To resolve this, make sure to set
run-time search path (RPATH) in libxilinxopencl.so to ORIGIN.