### PR TITLE
Add changes for using gcc7.3 on AL2 with 4.14.94-89.73.amzn2.x86_64

### DIFF
--- a/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.c
@@ -30,7 +30,7 @@
 #include <linux/vmalloc.h>
 #include <linux/version.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/delay.h>
 
 MODULE_LICENSE("GPL v2");

--- a/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_debugfs.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_debugfs.h
@@ -23,7 +23,7 @@
 #include <linux/pci.h>
 #include <linux/debugfs.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/mutex.h>
 #include <linux/slab.h>
 

--- a/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
+++ b/src/runtime_src/driver/xclng/xrt/CMakeLists.txt
@@ -77,6 +77,7 @@ else()
   rt
   boost_filesystem
   boost_system
+  uuid
   ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a
 )
 endif()

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -13,6 +13,8 @@ include_directories(
   ${XRT_XOCL_API_DIR}
 )
 
+add_compile_options("-Wno-nonnull")
+
 file(GLOB XRT_XOCL_API_FILES
   "${XRT_XOCL_API_DIR}/*.h"
   "${XRT_XOCL_API_DIR}/*.cpp"

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -13,7 +13,9 @@ include_directories(
   ${XRT_XOCL_API_DIR}
 )
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.3.0")
 add_compile_options("-Wno-nonnull")
+endif()
 
 file(GLOB XRT_XOCL_API_FILES
   "${XRT_XOCL_API_DIR}/*.h"


### PR DESCRIPTION
This change only includes changes needed to build (compile/link) the XRT on AL2. A newPR will be submitted for creating install-able rpm package.