### PR TITLE
axis monitoring without tlast, Use unique ID for sw CU events and reset accelerator monitor using hal

### DIFF
--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -242,6 +242,10 @@ namespace xclhwemhal2 {
           counterResults.CuBusyCycles[counter] = counterResults.CuExecCycles[counter];
           counterResults.CuMaxParallelIter[counter] = 1;
         } else if (iptype == 3) {
+          // AXIS without TLAST is assumed to be one long transfer
+          if (str_num_tranx == 0 && str_data_bytes > 0) {
+            str_num_tranx = 1;
+          }
           counterResults.StrNumTranx[counter] = str_num_tranx;
           counterResults.StrDataBytes[counter] = str_data_bytes;
           counterResults.StrBusyCycles[counter] = str_busy_cycles;

--- a/src/runtime_src/driver/include/xcl_perfmon_parameters.h
+++ b/src/runtime_src/driver/include/xcl_perfmon_parameters.h
@@ -127,6 +127,7 @@
 
 /* SAM Trace Control Masks */
 #define XSAM_TRACE_STALL_SELECT_MASK    0x0000001c
+#define XSAM_COUNTER_RESET_MASK         0x00000002
 
 /* Debug IP layout properties mask bits */
 #define XSAM_STALL_PROPERTY_MASK        0x4

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -733,6 +733,10 @@ namespace xocl {
       size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON,
                       baseAddress + XSSPM_STARVE_CYCLES_OFFSET, 
                       &counterResults.StrStarveCycles[s], 8);
+      // AXIS without TLAST is assumed to be one long transfer
+      if (counterResults.StrNumTranx[s] == 0 && counterResults.StrDataBytes[s] > 0) {
+        counterResults.StrNumTranx[s] = 1;
+      }
       if (mLogStream.is_open()) {
         mLogStream << "Reading AXI Stream Monitor... SlotNum : " << s << std::endl;
         mLogStream << "Reading AXI Stream Monitor... NumTranx : " << counterResults.StrNumTranx[s] << std::endl;

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -442,6 +442,19 @@ namespace xocl {
       // 3. Read from sample register to ensure total time is read again at end
       size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSPM_SAMPLE_OFFSET, &regValue, 4);
     }
+    // Reset Accelerator Monitors
+    type = XCL_PERF_MON_ACCEL;
+    numSlots = getPerfMonNumberSlots(type);
+    for (uint32_t i=0; i < numSlots; i++) {
+      baseAddress = getPerfMonBaseAddress(type,i);
+      uint32_t origRegValue = 0;
+      size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &origRegValue, 4);
+      regValue = origRegValue | XSAM_COUNTER_RESET_MASK;
+      // Reset begin
+      size += xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      // Reset end
+      size += xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &origRegValue, 4);
+    }
     return size;
   }
 

--- a/src/runtime_src/xdp/profile/core/trace_logger.h
+++ b/src/runtime_src/xdp/profile/core/trace_logger.h
@@ -90,6 +90,9 @@ namespace xdp {
     void writeTimelineTrace(double traceTime, const std::string& commandString,
         const std::string& stageString, const std::string& eventString,
         const std::string& dependString, uint64_t objId, size_t size) const;
+    void writeTimelineTrace(double traceTime, const std::string& commandString,
+        const std::string& stageString, const std::string& eventString,
+        const std::string& dependString, uint64_t objId, size_t size, uint32_t cuId) const;
     void writeTimelineTrace(double traceTime, RTUtil::e_profile_command_kind kind,
    	    const std::string& commandString, const std::string& stageString,
         const std::string& eventString, const std::string& dependString,
@@ -117,6 +120,7 @@ namespace xdp {
     bool mFunctionStartLogged = false;
     int mMigrateMemCalls;
     uint32_t mCurrentContextId;
+    uint32_t mCuStarts;
     std::string mCurrentKernelName;
     std::string mCurrentDeviceName;
     std::string mCurrentBinaryName;
@@ -126,6 +130,7 @@ namespace xdp {
     std::map<uint64_t, BufferTrace*> mBufferTraceMap;
     std::map<uint64_t, DeviceTrace*> mDeviceTraceMap;
     std::map<std::string, std::queue<double>> mKernelStartsMap;
+    std::map<uint64_t, std::queue<uint32_t>> mCuStartsMap;
     std::set<std::thread::id> mThreadIdSet;
 
     ProfileCounters* mProfileCounters;

--- a/src/runtime_src/xdp/profile/writer/base_trace.cpp
+++ b/src/runtime_src/xdp/profile/writer/base_trace.cpp
@@ -71,6 +71,27 @@ namespace xdp {
     writeTableRowEnd(getStream());
   }
 
+  // Compute Unit events from sw
+  void TraceWriterI::writeCu(double traceTime, const std::string& commandString,
+            const std::string& stageString, const std::string& eventString,
+            const std::string& dependString, uint64_t objId, size_t size, uint32_t cuId)
+  {
+    if (!Trace_ofs.is_open())
+      return;
+
+    std::stringstream timeStr;
+    timeStr << std::setprecision(10) << traceTime;
+
+    std::stringstream strObjId;
+    strObjId << std::showbase << std::hex << std::uppercase << objId;
+
+    writeTableRowStart(getStream());
+    writeTableCells(getStream(), timeStr.str(), commandString,
+        stageString, strObjId.str(), size, std::to_string(cuId), "", "", "", "", "",
+        eventString, dependString);
+    writeTableRowEnd(getStream());
+  }
+
   // Write read/write/copy data transfer event to trace
   void TraceWriterI::writeTransfer(double traceTime, RTUtil::e_profile_command_kind kind,
   	        const std::string& commandString, const std::string& stageString,

--- a/src/runtime_src/xdp/profile/writer/base_trace.h
+++ b/src/runtime_src/xdp/profile/writer/base_trace.h
@@ -51,6 +51,9 @@ namespace xdp {
 	    void writeKernel(double traceTime, const std::string& commandString,
             const std::string& stageString, const std::string& eventString,
             const std::string& dependString, uint64_t objId, size_t size);
+      void writeCu(double traceTime, const std::string& commandString,
+            const std::string& stageString, const std::string& eventString,
+            const std::string& dependString, uint64_t objId, size_t size, uint32_t cuId);
 	    // Write timeline trace of read/write/copy data transfer
 	    void writeTransfer(double traceTime, RTUtil::e_profile_command_kind kind,
 	        const std::string& commandString, const std::string& stageString,


### PR DESCRIPTION
First commit lets us see data transfer for cases when tlast isn't present in AXI Stream
Second commit lets us use unique ID for every CU in sw emuation, allowing us to show overlaps
Third commit lets us reset accelerator monitors from hal at beginning of program