### PR TITLE
In dataflow mode up the limit of cmds sent to scheduler

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1259,6 +1259,15 @@ get_xclbin() const
   return m_xclbin;
 }
 
+const axlf*
+device::
+get_axlf() const
+{
+  assert(!m_active || m_active->get_xclbin(this)==m_xclbin);
+  auto binary = m_xclbin.binary();
+  auto binary_data = binary.binary_data();
+  return reinterpret_cast<const axlf*>(binary_data.first);
+}
 
 unsigned short
 device::

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -565,6 +565,13 @@ public:
   get_xclbin() const;
 
   /**
+   * @return
+   *  AXLF top
+   */
+  const axlf*
+  get_axlf() const;
+
+  /**
    * Check if this device is active, meaning it is programmed
    */
   bool

--- a/src/runtime_src/xocl/core/execution_context.cpp
+++ b/src/runtime_src/xocl/core/execution_context.cpp
@@ -547,10 +547,12 @@ execute()
   // In order to keep scheduler busy, we need more than just one
   // workgroup at a time, so here we try to ensure that the scheduled
   // commands at any given time is twice the number of available CUs.
-  auto limit = 2*m_cus.size();
+  auto limit = 20*m_cus.size();
+  //auto limit = 2*m_cus.size();
   for (size_t i=m_active; !m_done && i<limit; ++i) {
     start();
     update_work();
+    XOCL_DEBUG(std::cout,"active=",m_active,"\n");
   }
 
   return m_done;

--- a/src/runtime_src/xocl/core/execution_context.cpp
+++ b/src/runtime_src/xocl/core/execution_context.cpp
@@ -21,6 +21,8 @@
 #include "xrt/scheduler/command.h"
 #include "xrt/scheduler/scheduler.h"
 
+#include "driver/common/xclbin_parser.h"
+
 #include "impl/spir.h"
 
 #include <iostream>
@@ -239,6 +241,9 @@ execution_context(device* device
 
   // Compute units to use
   add_compute_units(device);
+
+  m_dataflow = xrt_core::xclbin::get_dataflow(device->get_axlf());
+  XOCL_DEBUGF("execution_context(%d) has dataflow(%d)\n",m_uid,m_dataflow);
 }
 
 void
@@ -547,8 +552,7 @@ execute()
   // In order to keep scheduler busy, we need more than just one
   // workgroup at a time, so here we try to ensure that the scheduled
   // commands at any given time is twice the number of available CUs.
-  auto limit = 20*m_cus.size();
-  //auto limit = 2*m_cus.size();
+  auto limit = m_dataflow ? 20*m_cus.size() : 2*m_cus.size();
   for (size_t i=m_active; !m_done && i<limit; ++i) {
     start();
     update_work();

--- a/src/runtime_src/xocl/core/execution_context.h
+++ b/src/runtime_src/xocl/core/execution_context.h
@@ -46,7 +46,7 @@ class event;
  * When a command is constructed all registered construction callbacks
  * are invoked.  When the command completes, all registered completion
  * callbacks are called before the command itself is deleted.
- * 
+ *
  * Command ownership is managed by execution context.
  */
 class execution_context
@@ -93,15 +93,17 @@ private:
   using argument_iterator_type = argument_vector_type::const_iterator;
   argument_vector_type m_kernel_args;
 
+  bool m_dataflow = false;
+
   // The context maintains a list of kernel compute units represented
   // by xcl::cu.  These cus (their base addresses) are used in the command
-  // that starts the mbs. 
+  // that starts the mbs.
   std::vector<const compute_unit*> m_cus;
 
   // Number of active start_kernel commands in this context
   size_t m_active = 0;
 
-  // Flag to indicate the execution context has no more work 
+  // Flag to indicate the execution context has no more work
   // to be scheduled
   bool m_done = false;
 
@@ -163,15 +165,15 @@ public:
   }
 
   const size_t*
-  get_global_work_size() const 
+  get_global_work_size() const
   { return m_gsize.data(); }
 
   size_t
-  get_global_work_size(unsigned int d) const 
+  get_global_work_size(unsigned int d) const
   { return m_gsize[d]; }
 
   const size_t*
-  get_local_work_size() const 
+  get_local_work_size() const
   { return m_lsize.data(); }
 
   size_t
@@ -240,7 +242,7 @@ public:
    * soon as an event changes state to CL_SUBMITTED.
    *
    * The context creates scheduler commands and submits
-   * these commands to the command queue. 
+   * these commands to the command queue.
    *
    * @return
    *    true if last work group was started, false otherwise
@@ -277,4 +279,3 @@ void add_command_done_callback(command_callback_function_type fcn);
 } // xocl
 
 #endif
-


### PR DESCRIPTION
For NDRange kernels (non-datflow) with multiple workgroups, we limit
the number of workgroups (cmds) sent to scheduler in order to prevent
filling CQ with cmds all waiting for same CUs.

For dataflow kernels the limit is increased since each CU now
pipelines cmds up to the pipeline depth.  This depth is unknown so the
fix in far from ideal but good for 2019.1 where we are not limited by
a HW CQ in dataflow mode.

CR1028815: Not seeing dataflow in design