### PR TITLE
longer mailbox rx timeout

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mailbox.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mailbox.c
@@ -154,7 +154,7 @@ MODULE_PARM_DESC(mailbox_no_intr,
 	xocl_dbg(&mbx->mbx_pdev->dev, fmt "\n", ##arg)
 
 #define	MAILBOX_TIMER	(HZ / 5) /* in jiffies */
-#define	MSG_RX_TTL	50UL	/* in MAILBOX_TIMER */
+#define	MSG_RX_TTL	100UL	/* in MAILBOX_TIMER */
 #define	MSG_TX_TTL	10UL	/* in MAILBOX_TIMER */
 #define	MSG_MAX_TTL	0xFFFFFFFF
 #define	TEST_MSG_LEN	128


### PR DESCRIPTION
10 seconds timeout does not give enough margin since xclbin download may take 8 seconds on u250.