### PR TITLE
update help message to indicate how to deal with multi-card system in xbutil status

### DIFF
--- a/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/driver/xclng/tools/xbutil/xbutil.cpp
@@ -710,7 +710,7 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "  program [-d card] [-r region] -p xclbin\n";
     std::cout << "  query   [-d card [-r region]]\n";
     std::cout << "  reset   [-d card]\n";
-    std::cout << "  status  [--debug_ip_name]\n";
+    std::cout << "  status [-d card] [--debug_ip_name]\n";
     std::cout << "  scan\n";
     std::cout << "  top [-i seconds]\n";
     std::cout << "  validate [-d card]\n";


### PR DESCRIPTION
In a recent CR, the tester was confused by `xbutil status --spm` on a P2P system where he though the `xbutil status --spm` was showing incorrect/empty data. `xbutil` was actually behaving correctly, but the documentation was indicating that xbutil should iterate through the devices as it doesn't take a device index argument. However, `xbutil status` does take a device index and behaves exactly like other `xbutil` commands, so I added in the documentation in the help message in this pull request.