### PR TITLE
 Set cu_idx, CU start and done time in command packet

### DIFF
--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -296,7 +296,7 @@ cu_idx_to_addr(struct drm_device *dev, unsigned int cu_idx)
  * @xcmd: command to change internal state on
  * @state: new command state per ert.h
  */
-inline void
+static inline void
 set_cmd_int_state(struct sched_cmd *cmd, enum cmd_state state)
 {
 	SCHED_DEBUG("-> set_cmd_int_state(,%d)\n", state);
@@ -746,7 +746,7 @@ unconfigure_soft_kernel(struct sched_cmd *cmd)
  * @cmd: command object
  * @state: new state
  */
-inline void
+static inline void
 set_cmd_state(struct sched_cmd *cmd, enum cmd_state state)
 {
 	SCHED_DEBUG("-> set_cmd_state(,%d)\n", state);
@@ -763,7 +763,7 @@ set_cmd_state(struct sched_cmd *cmd, enum cmd_state state)
  * @cmd: command object
  * @cu_idx: CU idex
  */
-inline void
+static inline void
 set_cmd_ext_cu_idx(struct sched_cmd *cmd, int cu_idx)
 {
 	int mask_idx = cu_mask_idx(cu_idx);
@@ -781,7 +781,7 @@ set_cmd_ext_cu_idx(struct sched_cmd *cmd, int cu_idx)
  * @cmd: command object
  * @ts: timestamp type
  */
-inline void
+static inline void
 set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 {
 	u32 opc = opcode(cmd);

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -543,7 +543,7 @@ configure(struct sched_cmd *cmd)
 		 * Need cleanup.
 		 */
 		if (!zdev->ert && get_apt_index(zdev, cu_addr) < 0) {
-			DRM_ERROR("CU address %x is not found in XLBCIN\n",
+			DRM_ERROR("CU address %x is not found in XCLBIN\n",
 				  cfg->data[i]);
 			write_unlock(&zdev->attr_rwlock);
 			return 1;

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -890,6 +890,7 @@ cu_done(struct sched_cmd *cmd)
 		unsigned int mask_idx = cu_mask_idx(cu_idx);
 		unsigned int pos = cu_idx_in_mask(cu_idx);
 
+		set_cmd_ext_timestamp(cmd, CU_DONE_TIME);
 		zdev->exec->cu_status[mask_idx] ^= 1<<pos;
 		SCHED_DEBUG("<- cu_done returns 1\n");
 		return true;
@@ -1042,7 +1043,6 @@ mark_cmd_complete(struct sched_cmd *cmd)
 	if (zdev->ert || zdev->exec->polling_mode)
 		--cmd->sched->poll;
 	release_slot_idx(cmd->ddev, cmd->slot_idx);
-	set_cmd_ext_timestamp(cmd, CU_DONE_TIME);
 	notify_host(cmd);
 	SCHED_DEBUG("<- mark_cmd_complete\n");
 }

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -33,6 +33,14 @@
 #define U32_MASK 0xFFFFFFFF
 
 /**
+ * Timestamp only use in set_cmd_ext_timestamp()
+ */
+enum zocl_ts_type {
+	CU_START_TIME,
+	CU_DONE_TIME,
+};
+
+/**
  * Address constants per spec
  */
 #define WORD_SIZE                     4          /* 4 bytes */


### PR DESCRIPTION
In MPSoC KDS,
1.  Record the CU index of which CU execute the command.
2.  Record timestamp just before start CU and notify user application. 
Once the command finished, user could get that above information from the exec buf.

This change is only for start hardware CU.
For configure, soft kernel command etc., this should have no impact.