### PR TITLE
Use DKMS postinst script to build/install drivers

### DIFF
--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -8,27 +8,20 @@ if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
     dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
     find /lib/modules -type f -name awsmgmt.ko -delete
     find /lib/modules -type f -name awsmgmt.ko.kz -delete
+    find /lib/modules -type f -name awsmgmt.ko.xz -delete
     depmod -A
 fi
 
-if [ -z "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
-    echo "Registering new XRT Linux kernel module sources @XRT_VERSION_STRING@ with dkms"
-    dkms add -m xrt-aws -v "@XRT_VERSION_STRING@"
-fi
-
-if [ -e /lib/modules/`uname -r`/build/include ]; then
-    echo "Building XRT Linux kernel modules sources with dkms"
-    dkms build -m xrt-aws -v "@XRT_VERSION_STRING@"
-    echo "Installing XRT Linux kernel modules sources with dkms"
-    dkms install -m xrt-aws -v "@XRT_VERSION_STRING@" --force
+echo "Invoking xrt-aws common.postinst"
+/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
+if [ $? -eq 0 ]; then
+    echo "Finished xrt-aws common.postinst"
     install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/kernel/mgmt/10-awsmgmt.rules /etc/udev/rules.d
 
-    echo "Loading new XRT Linux kernel modules"
+    echo "Loading new XRT AWS Linux kernel modules"
     udevadm control --reload-rules
     modprobe awsmgmt
     udevadm trigger
-else
-    echo "Build/Install of XRT Linux kernel modules skipped since Linux kernel headers are not installed"
 fi
 
 exit 0

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -16,22 +16,16 @@ if [ -n "`dkms status -m xrt -v @XRT_VERSION_STRING@`" ]; then
     depmod -A
 fi
 
-if [ -z "`dkms status -m xrt -v @XRT_VERSION_STRING@`" ]; then
-    echo "Registering new XRT Linux kernel module sources @XRT_VERSION_STRING@ with dkms"
-    dkms add -m xrt -v "@XRT_VERSION_STRING@"
-fi
-
 DRACUT_CONF_PATH=/etc/dracut.conf.d
 if [ -e $DRACUT_CONF_PATH ]; then
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/xocl.dracut.conf $DRACUT_CONF_PATH
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/mgmtpf/xclmgmt.dracut.conf $DRACUT_CONF_PATH
 fi
 
-if [ -e /lib/modules/`uname -r`/build/include ]; then
-    echo "Building XRT Linux kernel modules sources with dkms"
-    dkms build -m xrt -v "@XRT_VERSION_STRING@"
-    echo "Installing XRT Linux kernel modules sources with dkms"
-    dkms install -m xrt -v "@XRT_VERSION_STRING@" --force
+echo "Invoking DKMS common.postinst"
+/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2
+if [ $? -eq 0 ]; then
+    echo "Finished common.postinst"
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/10-xocl.rules /etc/udev/rules.d
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/mgmtpf/10-xclmgmt.rules /etc/udev/rules.d
 
@@ -40,8 +34,6 @@ if [ -e /lib/modules/`uname -r`/build/include ]; then
     modprobe xclmgmt
     modprobe xocl
     udevadm trigger
-else
-    echo "Build/Install of XRT Linux kernel modules skipped since Linux kernel headers are not installed"
 fi
 
 exit 0

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -22,10 +22,10 @@ if [ -e $DRACUT_CONF_PATH ]; then
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/mgmtpf/xclmgmt.dracut.conf $DRACUT_CONF_PATH
 fi
 
-echo "Invoking DKMS common.postinst"
+echo "Invoking DKMS common.postinst for xrt"
 /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2
 if [ $? -eq 0 ]; then
-    echo "Finished common.postinst"
+    echo "Finished DKMS common.postinst"
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/10-xocl.rules /etc/udev/rules.d
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/mgmtpf/10-xclmgmt.rules /etc/udev/rules.d
 

--- a/src/runtime_src/xocl/api/clGetExtensionFunctionAddressForPlatform.cpp
+++ b/src/runtime_src/xocl/api/clGetExtensionFunctionAddressForPlatform.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +14,6 @@
  * under the License.
  */
 
-// Copyright 2017 Xilinx, Inc. All rights reserved.
 
 #include <CL/cl.h>
 #include <map>


### PR DESCRIPTION
DKMS postinst script installs drivers for multiple kernel versions installed on the same system. This helps in cases where a user is running kernel A.n but A.(n+1) is also installed perhaps as security update. Now when user installs XRT we should install for both A.n and A.(n+1) otherwise when user reboots into A.(n+1) he will notice that xocl/xclmgmt drivers are missing.