### PR TITLE
Dataflow Support in Accelerator Monitors using ap_continue

### DIFF
--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/halapi.cxx
@@ -402,6 +402,14 @@ size_t xclPerfMonClockTraining(xclDeviceHandle handle, xclPerfMonType type)
   return drv->xclPerfMonClockTraining();
 }
 
+void xclPerfMonConfigureDataflow(xclDeviceHandle handle, xclPerfMonType type, unsigned *ip_config)
+{
+  xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
+  if (!drv)
+    return;
+  return drv->xclPerfMonConfigureDataflow(type, ip_config);
+}
+
 size_t xclPerfMonStartCounters(xclDeviceHandle handle, xclPerfMonType type)
 {
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -93,6 +93,12 @@ namespace xclhwemhal2 {
     return 0;
   }
 
+  // Implement this when hw em models support dataflow
+  void HwEmShim::xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config)
+  {
+    return;
+  }
+
   size_t HwEmShim::xclPerfMonStartCounters()
   {
     //TODO::Still to decide whether to start Performance Monitor or not

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.h
@@ -147,6 +147,7 @@ using addr_type = uint64_t;
       double xclGetReadMaxBandwidthMBps();
       double xclGetWriteMaxBandwidthMBps();
       size_t xclPerfMonClockTraining();
+      void xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config);
       size_t xclPerfMonStartCounters();
       size_t xclPerfMonStopCounters();
       size_t xclPerfMonReadCounters( xclPerfMonType type, xclCounterResults& counterResults);

--- a/src/runtime_src/driver/include/xcl_perfmon_parameters.h
+++ b/src/runtime_src/driver/include/xcl_perfmon_parameters.h
@@ -128,6 +128,7 @@
 /* SAM Trace Control Masks */
 #define XSAM_TRACE_STALL_SELECT_MASK    0x0000001c
 #define XSAM_COUNTER_RESET_MASK         0x00000002
+#define XSAM_DATAFLOW_EN_MASK           0x00000008
 
 /* Debug IP layout properties mask bits */
 #define XSAM_STALL_PROPERTY_MASK        0x4

--- a/src/runtime_src/driver/include/xclhal.h
+++ b/src/runtime_src/driver/include/xclhal.h
@@ -367,7 +367,7 @@ extern "C" {
 
     XCL_DRIVER_DLLESPEC size_t xclPerfMonClockTraining(xclDeviceHandle handle, xclPerfMonType type);
 
-    XCL_DRIVER_DLLESPEC size_t xclPerfMonConfigureDataflow(xclDeviceHandle handle, xclPerfMonType type, unsigned *ip_data);
+    XCL_DRIVER_DLLESPEC void xclPerfMonConfigureDataflow(xclDeviceHandle handle, xclPerfMonType type, unsigned *ip_data);
 
     XCL_DRIVER_DLLESPEC size_t xclPerfMonStartCounters(xclDeviceHandle handle, xclPerfMonType type);
 

--- a/src/runtime_src/driver/include/xclhal.h
+++ b/src/runtime_src/driver/include/xclhal.h
@@ -367,6 +367,8 @@ extern "C" {
 
     XCL_DRIVER_DLLESPEC size_t xclPerfMonClockTraining(xclDeviceHandle handle, xclPerfMonType type);
 
+    XCL_DRIVER_DLLESPEC size_t xclPerfMonConfigureDataflow(xclDeviceHandle handle, xclPerfMonType type, unsigned *ip_data);
+
     XCL_DRIVER_DLLESPEC size_t xclPerfMonStartCounters(xclDeviceHandle handle, xclPerfMonType type);
 
     XCL_DRIVER_DLLESPEC size_t xclPerfMonStopCounters(xclDeviceHandle handle, xclPerfMonType type);

--- a/src/runtime_src/driver/include/xrt.h
+++ b/src/runtime_src/driver/include/xrt.h
@@ -1202,6 +1202,8 @@ XCL_DRIVER_DLLESPEC uint32_t xclGetProfilingSlotProperties(xclDeviceHandle handl
 
 XCL_DRIVER_DLLESPEC size_t xclPerfMonClockTraining(xclDeviceHandle handle, enum xclPerfMonType type);
 
+XCL_DRIVER_DLLESPEC void xclPerfMonConfigureDataflow(xclDeviceHandle handle, xclPerfMonType type, unsigned *ip_data);
+
 XCL_DRIVER_DLLESPEC size_t xclPerfMonStartCounters(xclDeviceHandle handle, enum xclPerfMonType type);
 
 XCL_DRIVER_DLLESPEC size_t xclPerfMonStopCounters(xclDeviceHandle handle, enum xclPerfMonType type);

--- a/src/runtime_src/driver/xclng/xrt/user_aws/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/perf.cpp
@@ -269,19 +269,19 @@ namespace awsbwhal {
     if (!mIsDeviceProfiling)
       return;
 
-    // Configure only Accelerator monitors for now
-    type = XCL_PERF_MON_ACCEL;
     uint32_t numSlots = getPerfMonNumberSlots(type);
 
-    for (uint32_t i=0; i < numSlots; i++) {
-      if (!ip_config[i]) continue;
-      uint64_t baseAddress = getPerfMonBaseAddress(type,i);
-      uint32_t regValue = 0;
-      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      regValue = regValue | XSAM_DATAFLOW_EN_MASK;
-      xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      if (mLogStream.is_open()) {
-        mLogStream << "Dataflow enabled on slot : " << i << std::endl;
+    if (type == XCL_PERF_MON_ACCEL) {
+      for (uint32_t i=0; i < numSlots; i++) {
+        if (!ip_config[i]) continue;
+        uint64_t baseAddress = getPerfMonBaseAddress(type,i);
+        uint32_t regValue = 0;
+        xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        regValue = regValue | XSAM_DATAFLOW_EN_MASK;
+        xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        if (mLogStream.is_open()) {
+          mLogStream << "Dataflow enabled on slot : " << i << std::endl;
+        }
       }
     }
   }

--- a/src/runtime_src/driver/xclng/xrt/user_aws/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/perf.cpp
@@ -280,8 +280,6 @@ namespace awsbwhal {
       xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = regValue | XSAM_DATAFLOW_EN_MASK;
       xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      regValue = 0;
-      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       if (mLogStream.is_open()) {
         mLogStream << "Dataflow enabled on slot : " << i << std::endl;
       }

--- a/src/runtime_src/driver/xclng/xrt/user_aws/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/shim.h
@@ -219,6 +219,7 @@ public:
         double xclGetWriteMaxBandwidthMBps();
         void xclSetProfilingNumberSlots(xclPerfMonType type, uint32_t numSlots);
         size_t xclPerfMonClockTraining(xclPerfMonType type);
+        void xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config);
         // Counters
         size_t xclPerfMonStartCounters(xclPerfMonType type);
         size_t xclPerfMonStopCounters(xclPerfMonType type);

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -463,6 +463,7 @@ namespace xocl {
       std::cout << "Enable dataflow .." << std::endl;
       size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = regValue | XSAM_DATAFLOW_EN_MASK;
+      std::cout << "Writing regvalue : " << std::hex << regValue << std::dec << std::endl;
       size += xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = 0;
       size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -479,8 +479,6 @@ namespace xocl {
       xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = regValue | XSAM_DATAFLOW_EN_MASK;
       xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      regValue = 0;
-      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       if (mLogStream.is_open()) {
         mLogStream << "Dataflow enabled on slot : " << i << std::endl;
       }

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -460,6 +460,14 @@ namespace xocl {
   }
 
   void XOCLShim::xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config) {
+    if (mLogStream.is_open()) {
+      mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
+          << type << ", Configure Accelerator Monitors..." << std::endl;
+    }
+    readDebugIpLayout();
+    if (!mIsDeviceProfiling)
+      return 0;
+
     // Configure only Accelerator monitors for now
     type = XCL_PERF_MON_ACCEL;
     uint32_t numSlots = getPerfMonNumberSlots(type);

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -455,6 +455,15 @@ namespace xocl {
       // Reset end
       size += xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &origRegValue, 4);
     }
+
+    // Configure Accelerator monitors for dataflow
+    for (uint32_t i=0; i < numSlots; i++) {
+      baseAddress = getPerfMonBaseAddress(type,i);
+      size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      regValue = regValue | XSAM_DATAFLOW_EN_MASK;
+      size += xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+    }
+
     return size;
   }
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -466,7 +466,7 @@ namespace xocl {
     }
     readDebugIpLayout();
     if (!mIsDeviceProfiling)
-      return 0;
+      return;
 
     // Configure only Accelerator monitors for now
     type = XCL_PERF_MON_ACCEL;

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -55,6 +55,7 @@
 #include <time.h>
 #include <string.h>
 #include <chrono>
+#include <iostream>
 
 #ifndef _WINDOWS
 // TODO: Windows build support
@@ -459,9 +460,13 @@ namespace xocl {
     // Configure Accelerator monitors for dataflow
     for (uint32_t i=0; i < numSlots; i++) {
       baseAddress = getPerfMonBaseAddress(type,i);
+      std::cout << "Enable dataflow .." << std::endl;
       size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = regValue | XSAM_DATAFLOW_EN_MASK;
       size += xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      regValue = 0;
+      size += xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      std::cout << "Regvalue after dataflow en " << regValue << std::endl;
     }
 
     return size;

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -462,7 +462,7 @@ namespace xocl {
   void XOCLShim::xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config) {
     if (mLogStream.is_open()) {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
-          << type << ", Configure Accelerator Monitors..." << std::endl;
+          << type << ", Configure Monitors For Dataflow..." << std::endl;
     }
     readDebugIpLayout();
     if (!mIsDeviceProfiling)
@@ -476,14 +476,14 @@ namespace xocl {
       if (!ip_config[i]) continue;
       uint64_t baseAddress = getPerfMonBaseAddress(type,i);
       uint32_t regValue = 0;
-      std::cout << "Enable dataflow .." << std::endl;
       xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = regValue | XSAM_DATAFLOW_EN_MASK;
-      std::cout << "Writing regvalue : " << std::hex << regValue << std::dec << std::endl;
       xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = 0;
       xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      std::cout << "Regvalue after dataflow en " << regValue << std::endl;
+      if (mLogStream.is_open()) {
+        mLogStream << "Dataflow enabled on slot : " << i << std::endl;
+      }
     }
   }
 

--- a/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/perf.cpp
@@ -468,19 +468,19 @@ namespace xocl {
     if (!mIsDeviceProfiling)
       return;
 
-    // Configure only Accelerator monitors for now
-    type = XCL_PERF_MON_ACCEL;
     uint32_t numSlots = getPerfMonNumberSlots(type);
 
-    for (uint32_t i=0; i < numSlots; i++) {
-      if (!ip_config[i]) continue;
-      uint64_t baseAddress = getPerfMonBaseAddress(type,i);
-      uint32_t regValue = 0;
-      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      regValue = regValue | XSAM_DATAFLOW_EN_MASK;
-      xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      if (mLogStream.is_open()) {
-        mLogStream << "Dataflow enabled on slot : " << i << std::endl;
+    if (type == XCL_PERF_MON_ACCEL) {
+      for (uint32_t i=0; i < numSlots; i++) {
+        if (!ip_config[i]) continue;
+        uint64_t baseAddress = getPerfMonBaseAddress(type,i);
+        uint32_t regValue = 0;
+        xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        regValue = regValue | XSAM_DATAFLOW_EN_MASK;
+        xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        if (mLogStream.is_open()) {
+          mLogStream << "Dataflow enabled on slot : " << i << std::endl;
+        }
       }
     }
   }

--- a/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
+++ b/src/runtime_src/driver/xclng/xrt/user_gem/shim.h
@@ -220,6 +220,7 @@ public:
     void getPerfMonSlotName(xclPerfMonType type, uint32_t slotnum,
                             char* slotName, uint32_t length);
     size_t xclPerfMonClockTraining(xclPerfMonType type);
+    void xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config);
     // Counters
     size_t xclPerfMonStartCounters(xclPerfMonType type);
     size_t xclPerfMonStopCounters(xclPerfMonType type);

--- a/src/runtime_src/driver/zynq/user/shim-profile.cpp
+++ b/src/runtime_src/driver/zynq/user/shim-profile.cpp
@@ -112,7 +112,7 @@ namespace ZYNQ {
     if (!mIsDeviceProfiling)
       return;
 
-    uint32_t numSlots = getPerfMonNumberSlots(type);
+    uint32_t numSlots = getProfilingNumberSlots(type);
 
     if (type == XCL_PERF_MON_ACCEL) {
       for (uint32_t i=0; i < numSlots; i++) {

--- a/src/runtime_src/driver/zynq/user/shim-profile.cpp
+++ b/src/runtime_src/driver/zynq/user/shim-profile.cpp
@@ -104,6 +104,29 @@ namespace ZYNQ {
     
     strncpy(slotName, str.c_str(), length);
   }
+
+  void ZYNQShimProfiling::xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config)
+  {
+    // Update addresses for debug/profile IP
+    readDebugIpLayout();
+    if (!mIsDeviceProfiling)
+      return;
+
+    // Configure only Accelerator monitors for now
+    type = XCL_PERF_MON_ACCEL;
+    uint32_t numSlots = getPerfMonNumberSlots(type);
+
+    for (uint32_t i=0; i < numSlots; i++) {
+      if (!ip_config[i]) continue;
+      uint64_t baseAddress = getPerfMonBaseAddress(type,i);
+      uint32_t regValue = 0;
+      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      regValue = regValue | XSAM_DATAFLOW_EN_MASK;
+      xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      regValue = 0;
+      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+    }
+  }
   
   size_t ZYNQShimProfiling::xclPerfMonStartCounters(xclPerfMonType type)
   {

--- a/src/runtime_src/driver/zynq/user/shim-profile.cpp
+++ b/src/runtime_src/driver/zynq/user/shim-profile.cpp
@@ -112,17 +112,17 @@ namespace ZYNQ {
     if (!mIsDeviceProfiling)
       return;
 
-    // Configure only Accelerator monitors for now
-    type = XCL_PERF_MON_ACCEL;
     uint32_t numSlots = getPerfMonNumberSlots(type);
 
-    for (uint32_t i=0; i < numSlots; i++) {
-      if (!ip_config[i]) continue;
-      uint64_t baseAddress = getPerfMonBaseAddress(type,i);
-      uint32_t regValue = 0;
-      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      regValue = regValue | XSAM_DATAFLOW_EN_MASK;
-      xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+    if (type == XCL_PERF_MON_ACCEL) {
+      for (uint32_t i=0; i < numSlots; i++) {
+        if (!ip_config[i]) continue;
+        uint64_t baseAddress = getPerfMonBaseAddress(type,i);
+        uint32_t regValue = 0;
+        xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        regValue = regValue | XSAM_DATAFLOW_EN_MASK;
+        xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+      }
     }
   }
   

--- a/src/runtime_src/driver/zynq/user/shim-profile.cpp
+++ b/src/runtime_src/driver/zynq/user/shim-profile.cpp
@@ -119,9 +119,9 @@ namespace ZYNQ {
         if (!ip_config[i]) continue;
         uint64_t baseAddress = getPerfMonBaseAddress(type,i);
         uint32_t regValue = 0;
-        xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        shim->xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
         regValue = regValue | XSAM_DATAFLOW_EN_MASK;
-        xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
+        shim->xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       }
     }
   }

--- a/src/runtime_src/driver/zynq/user/shim-profile.cpp
+++ b/src/runtime_src/driver/zynq/user/shim-profile.cpp
@@ -123,8 +123,6 @@ namespace ZYNQ {
       xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
       regValue = regValue | XSAM_DATAFLOW_EN_MASK;
       xclWrite(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
-      regValue = 0;
-      xclRead(XCL_ADDR_SPACE_DEVICE_PERFMON, baseAddress + XSAM_CONTROL_OFFSET, &regValue, 4);
     }
   }
   

--- a/src/runtime_src/driver/zynq/user/shim-profile.h
+++ b/src/runtime_src/driver/zynq/user/shim-profile.h
@@ -86,6 +86,7 @@ namespace ZYNQ {
     uint32_t getProfilingNumberSlots(xclPerfMonType type);
     void getProfilingSlotName(xclPerfMonType type, uint32_t slotnum, char* slotName, uint32_t length);
 
+    void xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config);
     // Counters
     size_t xclPerfMonStartCounters(xclPerfMonType type);
     size_t xclPerfMonStopCounters(xclPerfMonType type);

--- a/src/runtime_src/driver/zynq/user/shim.cpp
+++ b/src/runtime_src/driver/zynq/user/shim.cpp
@@ -923,6 +923,16 @@ size_t xclPerfMonClockTraining(xclDeviceHandle handle, xclPerfMonType type)
   return 1; // Not yet enabled
 }
 
+void xclPerfMonConfigureDataflow(xclPerfMonType type, unsigned *ip_config)
+{
+  ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+  if (!drv)
+    return;
+  if (!(drv->profiling))
+    return;
+  return drv->profiling->xclPerfMonConfigureDataflow(type, ip_config);
+}
+
 size_t xclPerfMonStartCounters(xclDeviceHandle handle, xclPerfMonType type)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);

--- a/src/runtime_src/xdp/profile/device/trace_parser.cpp
+++ b/src/runtime_src/xdp/profile/device/trace_parser.cpp
@@ -369,6 +369,7 @@ Please use 'coarse' option for data transfer trace or turn off Stall profiling")
           "Incomplete CU profile trace detected. Timeline trace will have approximate CU End");
           kernelTrace.EndTime = lastTimeStamp;
           kernelTrace.End = convertDeviceToHostTimestamp(kernelTrace.EndTime, type, deviceName);
+          kernelTrace.EventID = mCuEventID++;
           // Insert is needed in case there are only stalls
           resultVector.insert(resultVector.begin(), kernelTrace);
         }
@@ -515,6 +516,7 @@ Please use 'coarse' option for data transfer trace or turn off Stall profiling")
             kernelTrace.Type = "Kernel";
             kernelTrace.StartTime = mAccelMonCuTime[s];
             kernelTrace.Start = mAccelMonCuHostTime[s] / 1e6;
+            kernelTrace.EventID = mCuEventID++;
             resultVector.push_back(kernelTrace);
             // Divide by 2 just to be safe
             mEmuTraceMsecOneCycle = (kernelTrace.End - kernelTrace.Start) / (2 *(kernelTrace.EndTime - kernelTrace.StartTime));

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -581,7 +581,7 @@ startCounters(key k, xclPerfMonType type)
     OCLProfiler::Instance()->getProfileManager()->getSampleIntervalMsec();
 
   // Depends on Debug IP Layout data loaded in hal
-  configureDataflow(k, type);
+  configureDataflow(k, XCL_PERF_MON_ACCEL);
   return CL_SUCCESS;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -580,9 +580,9 @@ startCounters(key k, xclPerfMonType type)
   xdevice->startCounters(type);
   data->mSampleIntervalMsec =
     OCLProfiler::Instance()->getProfileManager()->getSampleIntervalMsec();
-  // Only configure Accelerator Mons
-  // Dependent on Debug IP Layout data present in hal
-  configureDataflow(k, XCL_PERF_MON_ACCEL);
+
+  // Depends on Debug IP Layout data loaded in hal
+  configureDataflow(k, type);
   return CL_SUCCESS;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -577,12 +577,12 @@ startCounters(key k, xclPerfMonType type)
   if (deviceClockMHz > 0)
     OCLProfiler::Instance()->getProfileManager()->setDeviceClockFreqMHz( deviceClockMHz );
 
-  // Only configure Accelerator Mons
-  configureDataflow(k, XCL_PERF_MON_ACCEL);
-
   xdevice->startCounters(type);
   data->mSampleIntervalMsec =
     OCLProfiler::Instance()->getProfileManager()->getSampleIntervalMsec();
+  // Only configure Accelerator Mons
+  // Dependent on Debug IP Layout data present in hal
+  configureDataflow(k, XCL_PERF_MON_ACCEL);
   return CL_SUCCESS;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -577,6 +577,9 @@ startCounters(key k, xclPerfMonType type)
   if (deviceClockMHz > 0)
     OCLProfiler::Instance()->getProfileManager()->setDeviceClockFreqMHz( deviceClockMHz );
 
+  // Only configure Accelerator Mons
+  configureDataflow(k, XCL_PERF_MON_ACCEL);
+
   xdevice->startCounters(type);
   data->mSampleIntervalMsec =
     OCLProfiler::Instance()->getProfileManager()->getSampleIntervalMsec();

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -547,6 +547,22 @@ getMaxWrite(key k)
   return device->get_xrt_device()->getDeviceMaxWrite().get();
 }
 
+void configureDataflow(key k, xclPerfMonType type)
+{
+  unsigned num_slots = getProfileNumSlots(k, type);
+  auto ip_config = std::make_unique <unsigned []>(num_slots);
+  for (unsigned i=0; i < num_slots; i++) {
+    std::string slot;
+    getProfileSlotName(k, type, i, slot);
+    ip_config[i] = isAPCtrlChain(k, slot) ? 1 : 0;
+    std::cout << "Set dataflow for " << slot << std::endl;
+  }
+
+  auto device = k;
+  auto xdevice = device->get_xrt_device();
+  xdevice->configureDataflow(type, ip_config.get());
+}
+
 cl_int 
 startCounters(key k, xclPerfMonType type)
 {

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -555,7 +555,6 @@ void configureDataflow(key k, xclPerfMonType type)
     std::string slot;
     getProfileSlotName(k, type, i, slot);
     ip_config[i] = isAPCtrlChain(k, slot) ? 1 : 0;
-    std::cout << "Set dataflow for " << slot << std::endl;
   }
 
   auto device = k;

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -720,19 +720,24 @@ isAPCtrlChain(key k, const std::string& cu)
   auto device = k;
   if (!device)
     return false;
+  size_t base_addr = 0;
+  for (auto& xcu : device->get_cus()) {
+    if (xcu->get_name().compare(cu) == 0)
+      base_addr = xcu->get_base_addr();
+  }
   auto xclbin = device->get_xclbin();
   auto binary = xclbin.binary();
   auto binary_data = binary.binary_data();
   auto header = reinterpret_cast<const xclBin *>(binary_data.first);
   auto ip_layout = getAxlfSection<const ::ip_layout>(header, axlf_section_kind::IP_LAYOUT);
-  if (!ip_layout)
+  if (!ip_layout || !base_addr)
     return false;
   for (int32_t count=0; count <ip_layout->m_count; ++count) {
     const auto& ip_data = ip_layout->m_ip_data[count];
-    std::string current((char *)ip_data.m_name);
-    if (current.find(cu) == std::string::npos)
+    auto current = ip_data.m_base_address;
+    if (current != base_addr || ip_data.m_type != IP_TYPE::IP_KERNEL)
       continue;
-    if (ip_data.m_type==IP_TYPE::IP_KERNEL && ((ip_data.properties >> IP_CONTROL_SHIFT) & AP_CTRL_CHAIN))
+    if ((ip_data.properties >> IP_CONTROL_SHIFT) & AP_CTRL_CHAIN)
       return true;
   }
   return false;

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -800,6 +800,12 @@ public:
     return m_hal->writeHostEvent(type, id);
   }
 
+  hal::operations_result<void>
+  configureDataflow(xclPerfMonType type, unsigned *ip_config)
+  {
+    return m_hal->configureDataflow(type, ip_config);
+  }
+
   hal::operations_result<size_t>
   startCounters(xclPerfMonType type)
   {

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -579,6 +579,12 @@ public:
     return operations_result<void>();
   }
 
+  virtual operations_result<void>
+  configureDataflow(xclPerfMonType, unsigned *ip_config)
+  {
+    return operations_result<void>();
+  }
+
   virtual operations_result<size_t>
   startCounters(xclPerfMonType)
   {

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -543,6 +543,15 @@ public:
     return hal::operations_result<void>(0);
   }
 
+  virtual hal::operations_result<void>
+  configureDataflow(xclPerfMonType type, unsigned *ip_config)
+  {
+    if (!m_ops->mConfigureDataflow)
+      return hal::operations_result<void>();
+    m_ops->mConfigureDataflow(m_handle,type, ip_config);
+    return hal::operations_result<void>(0);
+  }
+
   virtual hal::operations_result<size_t>
   startCounters(xclPerfMonType type)
   {

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -58,6 +58,7 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mGetProfilingSlotName(0)
   ,mGetProfilingSlotProperties(0)
   ,mClockTraining(0)
+  ,mConfigureDataflow(0)
   ,mStartCounters(0)
   ,mStopCounters(0)
   ,mReadCounters(0)
@@ -153,6 +154,7 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mGetProfilingSlotProperties = (getSlotPropertiesFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclGetProfilingSlotProperties");
   mWriteHostEvent = (writeHostEventFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclWriteHostEvent");
   mClockTraining = (clockTrainingFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclPerfMonClockTraining");
+  mConfigureDataflow = (configureDataflowFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclPerfMonConfigureDataflow");
   mStartCounters = (startCountersFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclPerfMonStartCounters");
   mStopCounters = (stopCountersFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclPerfMonStopCounters");
   mReadCounters = (readCountersFuncType)dlsym(const_cast<void *>(mDriverHandle), "xclPerfMonReadCounters");

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -97,6 +97,7 @@ private:
                                        char* slotName, uint32_t length);
   typedef uint32_t (* getSlotPropertiesFuncType)(xclDeviceHandle handle, xclPerfMonType type, uint32_t slotnum);
   typedef size_t (* clockTrainingFuncType)(xclDeviceHandle handle, xclPerfMonType type);
+  typedef void  (* configureDataflowFuncType)(xclDeviceHandle handle, xclPerfMonType type, unsigned *ip_config);
   typedef size_t (* startCountersFuncType)(xclDeviceHandle handle, xclPerfMonType type);
   typedef size_t (* stopCountersFuncType)(xclDeviceHandle handle, xclPerfMonType type);
   typedef size_t (* readCountersFuncType)(xclDeviceHandle handle, xclPerfMonType type,
@@ -194,6 +195,7 @@ public:
   getSlotNameFuncType mGetProfilingSlotName;
   getSlotPropertiesFuncType mGetProfilingSlotProperties;
   clockTrainingFuncType mClockTraining;
+  configureDataflowFuncType mConfigureDataflow;
   startCountersFuncType mStartCounters;
   stopCountersFuncType mStopCounters;
   readCountersFuncType mReadCounters;


### PR DESCRIPTION
Determine if CU has dataflow enabled and configure accelerator monitor to use ap_continue signal.
This change is backwards compatible and older version of IP just ignores the configuration.