### PR TITLE
Enhance clEnqueueCopyBuffer to cover p2p

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -3071,6 +3071,9 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	}
 
 	/* Both BOs are local, copy via KDMA CU */
+	if (exec->num_cdma == 0)
+		return -EINVAL;
+
 	ert_fill_copybo_cmd(scmd, 0, 0, src_addr, dst_addr, sz);
 
 	for (i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++)

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -187,6 +187,14 @@ get_xclbin_cus(const xocl::device* device)
   return xrt_core::xclbin::get_cus(device->get_axlf());
 }
 
+
+XOCL_UNUSED static bool
+is_emulation_mode()
+{
+  static bool val = is_sw_emulation() || is_hw_emulation();
+  return val;
+}
+
 static void
 init_scheduler(xocl::device* device)
 {
@@ -243,8 +251,7 @@ alloc(memory* mem, memidx_type memidx)
     return boh;
   }
 
-  auto p2p_flag = (mem->get_ext_flags() >> 30) & 0x1;
-  auto domain = p2p_flag
+  auto domain = mem->is_p2p_memory()
     ? xrt::device::memoryDomain::XRT_DEVICE_P2P_RAM
     : xrt::device::memoryDomain::XRT_DEVICE_RAM;
 
@@ -639,6 +646,14 @@ free(const memory* mem)
   m_memobjs.erase(itr);
 }
 
+bool
+device::
+is_imported(const memory* mem) const
+{
+  auto boh = mem->get_buffer_object_or_null(this);
+  return boh ? m_xdevice->is_imported(boh) : false;
+}
+
 xrt::device::BufferObjectHandle
 device::
 allocate_buffer_object(memory* mem, xrt::device::memoryDomain domain, uint64_t memoryIndex, void* user_ptr)
@@ -898,7 +913,27 @@ copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t ds
 {
   auto xdevice = get_xrt_device();
 
-  if (!get_num_cdmas() || is_sw_emulation()) {
+  // Check if any of the buffers are imported
+  bool imported = is_imported(src_buffer) || is_imported(dst_buffer);
+
+  // Copy via driver if p2p or device has kdma
+  if (!is_sw_emulation() && (imported || get_num_cdmas())) {
+    auto cppkt = xrt::command_cast<ert_start_copybo_cmd*>(cmd);
+    auto src_boh = src_buffer->get_buffer_object(this);
+    auto dst_boh = dst_buffer->get_buffer_object(this);
+    xdevice->fill_copy_pkt(dst_boh,src_boh,size,dst_offset,src_offset,cppkt);
+
+    if (cmd->execute() == 0) {
+      // Driver fills dst buffer same as migrate_buffer does, hence dst buffer
+      // is resident after KDMA is done even if host does explicitly migrate.
+      dst_buffer->set_resident(this);
+      return;
+    }
+  }
+
+  // Copy via host of local buffers and no kdma
+  if (!get_num_cdmas() && !imported) {
+    // non p2p BOs then copy through host
     auto cb = [this](memory* sbuf, memory* dbuf, size_t soff, size_t doff, size_t sz,const cmd_type& c) {
       try {
         c->start();
@@ -918,48 +953,22 @@ copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t ds
     return;
   }
 
-  // CDMA.  TODO, this needs to be done at lower shim level, not in OCL land
-  auto sk_cmd = xrt::command_cast<ert_start_kernel_cmd*>(cmd);
-  auto packet = cmd->get_packet();
-  size_t offset = 1; // packet offset past header
-
-  auto maxidx = get_num_cus() + get_num_cdmas();
-
-  for (auto cu_idx=get_num_cus(); cu_idx<maxidx; ++cu_idx) {
-    auto mask_idx = cu_idx/32;
-    auto cu_mask_idx = cu_idx - mask_idx*32;
-    packet[offset + mask_idx] |= 1 << cu_mask_idx;
+  // Ideally all cases should be handled above regardless of flow
+  // target and buffer type.  Need to enhance emulation drivers to
+  // ensure this being the case.
+  if (is_sw_emulation()) {
+    // Old code path for p2p buffer xclEnqueueP2PCopy
+    if (imported) {
+      // old code path for p2p buffer
+      copy_p2p_buffer(src_buffer,dst_buffer,src_offset,dst_offset,size);
+      return;
+    }
   }
-  sk_cmd->extra_cu_masks = maxidx/32;
-  sk_cmd->opcode = ERT_START_CU;
-  offset += maxidx/32 + 1; // packet offset past cumasks
 
-  // Insert copy command content
-  auto src_boh = src_buffer->get_buffer_object(this);
-  auto src_addr = xdevice->getDeviceAddr(src_boh) + src_offset;
-  auto dst_boh = dst_buffer->get_buffer_object(this);
-  auto dst_addr = xdevice->getDeviceAddr(dst_boh) + dst_offset;
-
-  packet[offset++] = 0; // 0x0 reserved CU AP_CTRL
-  packet[offset++] = 0; // 0x4 reserved CU GIE
-  packet[offset++] = 0; // 0xc reserved CU IER
-  packet[offset++] = 0; // 0xc reserved CU ISR
-  packet[offset++] = src_addr;                       // 0x10
-  packet[offset++] = (src_addr >> 32) & 0xFFFFFFFF;  // 0x14
-  packet[offset++] = 0;                              // 0x18
-  packet[offset++] = dst_addr;                       // 0x1c
-  packet[offset++] = (dst_addr >> 32) & 0xFFFFFFFF;  // 0x20
-  packet[offset++] = 0;                              // 0x24
-  packet[offset++] = (size*8) / 512;                 // 0x28 units of 512 bits
-
-  sk_cmd->count = offset-1; // number of words in payload (excludes header)
-  XOCL_DEBUGF("xocl::device::copy_buffer schedules cdma(%p,%p,%d)\n",dst_addr,src_addr,size);
-  cmd->start();
-  xrt::scheduler::schedule(cmd);
-
-  // KDMA fills dst buffer same as migrate_buffer does, hence dst buffer
-  // is resident after KDMA is done even if host does explicitly migrate.
-  dst_buffer->set_resident(this);
+  // Could not copy
+  std::stringstream err;
+  err << "copy_buffer failed. imported(" << imported << ") kdma(" << get_num_cdmas() << ")";
+  throw std::runtime_error(err.str());
 }
 
 void
@@ -969,7 +978,16 @@ copy_p2p_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_
   auto xdevice = get_xrt_device();
   auto src_boh = src_buffer->get_buffer_object(this);
   auto dst_boh = dst_buffer->get_buffer_object(this);
-  xdevice->copy(dst_boh, src_boh, size, dst_offset, src_offset);
+  auto rv = xdevice->copy(dst_boh, src_boh, size, dst_offset, src_offset);
+  if (rv.get<int>() == 0)
+    return;
+
+  // Could not copy
+  std::stringstream err;
+  err << "copy_p2p_buffer failed "
+      << "src_buffer " << src_buffer->get_uid() << ") "
+      << "dst_buffer(" << dst_buffer->get_uid() << ")";
+  throw std::runtime_error(err.str());
 }
 
 void
@@ -1078,28 +1096,6 @@ write_register(memory* mem, size_t offset,const void* ptr, size_t size)
   if (!(mem->get_flags() & CL_MEM_REGISTER_MAP))
     throw xocl::error(CL_INVALID_OPERATION,"write_register requires mem object with CL_MEM_REGISTER_MAP");
   get_xrt_device()->write_register(offset,ptr,size);
-#if 0
-  auto cmd = std::make_shared<xrt::command>(get_xrt_device(),ERT_WRITE);
-  auto packet = cmd->get_packet();
-  auto idx = packet.size() + 1; // past header is start of payload
-  auto addr = offset;
-  auto value = reinterpret_cast<const uint32_t*>(ptr);
-
-  while (size>0) {
-    packet[idx++] = addr;
-    packet[idx++] = *value;
-    ++value;
-    addr+=4;
-    size-=4;
-  }
-
-  auto ecmd = xrt::command_cast<ert_packet*>(cmd);
-  ecmd->type = ERT_KDS_LOCAL;
-  ecmd->count = packet.size() - 1; // substract header
-
-  xrt::scheduler::schedule(cmd);
-  cmd->wait();
-#endif
 }
 
 void

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -311,6 +311,17 @@ public:
   free(const memory* mem);
 
   /**
+   * Check if buffer is imported to this device
+   *
+   * If the buffer is allocated on this device, then check if the
+   * corresponding buffer object is an imported buffer object
+   *
+   * @return: true if imported, false otherwise
+   */
+  bool
+  is_imported(const memory* mem) const;
+
+  /**
    * Get memory addr for the given boh
    *
    * @return

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -207,7 +207,6 @@ get_buffer_object_or_null(const device* device) const
     : (*itr).second;
 }
 
-
 memory::buffer_object_handle
 memory::
 try_get_buffer_object_or_error(const device* device) const

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -128,7 +128,7 @@ public:
   bool
   is_p2p_memory() const
   {
-    return (m_ext_flags >> 30) & 0x1 ? true : false;
+    return m_ext_flags & XCL_MEM_EXT_P2P_BUFFER;
   }
 
   // Derived classes accessors

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -20,6 +20,7 @@
 #include "xrt/device/hal.h"
 #include "xrt/util/range.h"
 #include "driver/include/xclbin.h"
+#include "driver/include/ert.h"
 
 #include <set>
 #include <vector>
@@ -300,6 +301,11 @@ public:
   copy(const BufferObjectHandle& dst_bo, const BufferObjectHandle& src_bo, size_t sz, size_t dst_offset, size_t src_offset)
   { return m_hal->copy(dst_bo,src_bo,sz,dst_offset,src_offset); }
 
+  void
+  fill_copy_pkt(const BufferObjectHandle& dst_bo, const BufferObjectHandle& src_bo
+                ,size_t sz, size_t dst_offset, size_t src_offset,ert_start_copybo_cmd* pkt)
+  { return m_hal->fill_copy_pkt(dst_bo,src_bo,sz,dst_offset,src_offset,pkt); }
+
   /**
    * Read a device register
    *
@@ -388,6 +394,17 @@ public:
   { return m_hal->exec_wait(timeout_ms); }
 
 public:
+  /**
+   * @returns
+   *   True of this buffer object is imported from another device,
+   *   false otherwise
+   */
+  virtual bool
+  is_imported(const BufferObjectHandle& boh) const
+  {
+    return m_hal->is_imported(boh);
+  }
+
   /**
    * Get the device address of a buffer object
    *

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -26,6 +26,7 @@
 #include "driver/include/xclperf.h"
 #include "driver/include/xcl_app_debug.h"
 #include "driver/include/stream.h"
+#include "driver/include/ert.h"
 
 #include <memory>
 #include <string>
@@ -243,6 +244,10 @@ public:
   copy(const BufferObjectHandle& dst_bo, const BufferObjectHandle& src_bo, size_t sz,
        size_t dst_offset, size_t src_offset) = 0;
 
+  virtual void
+  fill_copy_pkt(const BufferObjectHandle& dst_boh, const BufferObjectHandle& src_boh
+                ,size_t sz, size_t dst_offset, size_t src_offset,ert_start_copybo_cmd* pkt) = 0;
+
   virtual size_t
   read_register(size_t offset, void* buffer, size_t size) = 0;
 
@@ -299,6 +304,14 @@ public:
   pollStreams(StreamXferCompletions* comps, int min, int max, int* actual, int timeout) = 0;
 
 public:
+  /**
+   * @returns
+   *   True of this buffer object is imported from another device,
+   *   false otherwise
+   */
+  virtual bool
+  is_imported(const BufferObjectHandle& boh) const = 0;
+
   /**
    * @returns
    *   The device address of a buffer object

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -16,6 +16,7 @@
 
 #include "hal2.h"
 #include "xrt/util/thread.h"
+#include "driver/include/ert.h"
 
 #include <cstring> // for std::memcpy
 #include <iostream>
@@ -389,6 +390,17 @@ copy(const BufferObjectHandle& dst_boh, const BufferObjectHandle& src_boh, size_
   return event(typed_event<int>(m_ops->mCopyBO(m_handle, dst_bo->handle, src_bo->handle, sz, dst_offset, src_offset)));
 }
 
+void
+device::
+fill_copy_pkt(const BufferObjectHandle& dst_boh, const BufferObjectHandle& src_boh
+              ,size_t sz, size_t dst_offset, size_t src_offset, ert_start_copybo_cmd* pkt)
+{
+  BufferObject* dst_bo = getBufferObject(dst_boh);
+  BufferObject* src_bo = getBufferObject(src_boh);
+  ert_fill_copybo_cmd(pkt,src_bo->handle,dst_bo->handle,src_offset,dst_offset,sz);
+  return;
+}
+
 size_t
 device::
 read_register(size_t offset, void* buffer, size_t size)
@@ -482,6 +494,14 @@ getDeviceAddr(const BufferObjectHandle& boh)
   return bo->deviceAddr;
 }
 
+bool
+device::
+is_imported(const BufferObjectHandle& boh) const
+{
+  auto bo = getBufferObject(boh);
+  return bo->imported;
+}
+
 int
 device::
 getMemObjectFd(const BufferObjectHandle& boh)
@@ -512,13 +532,13 @@ getBufferFromFd(const int fd, size_t& size, unsigned flags)
   if (ubo->handle == 0xffffffff)
     throw std::runtime_error("getBufferFromFd-Create XRT-BO: BOH handle is invalid");
 
-
   ubo->kind = XCL_BO_DEVICE_RAM;
   ubo->size = m_ops->mGetBOSize(m_handle, ubo->handle);
   size = ubo->size;
   ubo->owner = m_handle;
   ubo->deviceAddr = m_ops->mGetDeviceAddr(m_handle, ubo->handle);
   ubo->hostAddr = m_ops->mMapBO(m_handle, ubo->handle, true /*write*/);
+  ubo->imported = true;
 
   return BufferObjectHandle(ubo.release(), delBufferObject);
 }
@@ -646,7 +666,8 @@ readStream(hal::StreamHandle stream, void* ptr, size_t size, hal::StreamXferReq*
 
 int
 device::
-pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout) {
+pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)
+{
   xclReqCompletion* req = reinterpret_cast<xclReqCompletion*>(comps);
   return m_ops->mPollQueues(m_handle,min,max,req,actual,timeout);
 }

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -21,6 +21,8 @@
 #include "xrt/device/halops2.h"
 #include "xrt/device/PMDOperations.h"
 
+#include "driver/include/ert.h"
+
 #include <cassert>
 
 #include <functional>
@@ -78,6 +80,7 @@ class device : public xrt::hal::device
     unsigned int flags = 0;
     hal2::device_handle owner = nullptr;
     BufferObjectHandle parent = nullptr;
+    bool imported = false;
   };
 
   struct ExecBufferObject : hal::exec_buffer_object
@@ -303,6 +306,10 @@ public:
   virtual event
   copy(const BufferObjectHandle& dst_bo, const BufferObjectHandle& src_bo, size_t sz, size_t dst_offset, size_t src_offset);
 
+  virtual void
+  fill_copy_pkt(const BufferObjectHandle& dst_boh, const BufferObjectHandle& src_boh
+                ,size_t sz, size_t dst_offset, size_t src_offset,ert_start_copybo_cmd* pkt);
+
   virtual size_t
   read_register(size_t offset, void* buffer, size_t size);
 
@@ -354,6 +361,9 @@ public:
   pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout);
 
 public:
+  virtual bool
+  is_imported(const BufferObjectHandle& boh) const;
+
   virtual uint64_t
   getDeviceAddr(const BufferObjectHandle& boh);
 
@@ -576,7 +586,7 @@ public:
   }
 
   virtual void*
-  getHalDeviceHandle() { 
+  getHalDeviceHandle() {
     return m_handle;
   }
 

--- a/src/runtime_src/xrt/scheduler/command.cpp
+++ b/src/runtime_src/xrt/scheduler/command.cpp
@@ -126,12 +126,12 @@ command::
   }
 }
 
-void
+int
 command::
 execute()
 {
   m_done=false;
-  xrt::scheduler::schedule(get_ptr());
+  return xrt::scheduler::schedule(get_ptr());
 }
 
 } // xrt

--- a/src/runtime_src/xrt/scheduler/command.h
+++ b/src/runtime_src/xrt/scheduler/command.h
@@ -179,7 +179,7 @@ public:
   /**
    * Execute this command
    */
-  void
+  int
   execute();
 
   /**

--- a/src/runtime_src/xrt/scheduler/kds.cpp
+++ b/src/runtime_src/xrt/scheduler/kds.cpp
@@ -100,7 +100,7 @@ check(const command_type& cmd)
   return true;
 }
 
-static void
+static int
 launch(command_type cmd)
 {
   XRT_DEBUG(std::cout,"xrt::kds::command(",cmd->get_uid(),") [new->submitted->running]\n");
@@ -118,7 +118,7 @@ launch(command_type cmd)
 
   // Submit the command
   auto exec_bo = cmd->get_exec_bo();
-  device->exec_buf(exec_bo);
+  return device->exec_buf(exec_bo);
 }
 
 static void
@@ -189,10 +189,10 @@ monitor(const xrt::device* device)
 
 namespace xrt { namespace kds {
 
-void
+int
 schedule(const command_type& cmd)
 {
-  launch(cmd);
+  return launch(cmd);
 }
 
 void

--- a/src/runtime_src/xrt/scheduler/scheduler.cpp
+++ b/src/runtime_src/xrt/scheduler/scheduler.cpp
@@ -101,13 +101,13 @@ stop()
 /**
  * Schedule a command for execution on either sws or kds
  */
-void
+int
 schedule(const command_type& cmd)
 {
   if (kds_enabled())
-    kds::schedule(cmd);
+    return kds::schedule(cmd);
   else
-    sws::schedule(cmd);
+    return sws::schedule(cmd);
 }
 
 void

--- a/src/runtime_src/xrt/scheduler/scheduler.h
+++ b/src/runtime_src/xrt/scheduler/scheduler.h
@@ -29,7 +29,7 @@ using command_type = std::shared_ptr<command>;
  */
 namespace sws {
 
-void
+int
 schedule(const command_type& cmd);
 
 void
@@ -51,7 +51,7 @@ init(xrt::device* device, const std::vector<uint64_t>& cu_addr_map);
  */
 namespace kds {
 
-void
+int
 schedule(const command_type& cmd);
 
 void
@@ -69,7 +69,7 @@ namespace scheduler {
 /**
  * Schedule a command for execution on either sws or mbs
  */
-void
+int
 schedule(const command_type& cmd);
 
 void

--- a/src/runtime_src/xrt/scheduler/sws.cpp
+++ b/src/runtime_src/xrt/scheduler/sws.cpp
@@ -806,7 +806,7 @@ scheduler_loop()
 
 namespace xrt { namespace sws {
 
-void
+int
 schedule(const cmd_ptr& cmd)
 {
   auto device = cmd->get_device();
@@ -819,6 +819,7 @@ schedule(const cmd_ptr& cmd)
   s_pending_cmds.push_back(xcmd);
   ++s_num_pending;
   scheduler->notify();
+  return 0;
 }
 
 void

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -38,11 +38,11 @@ command(xrt_device* device, ert_cmd_opcode opcode)
   : m_impl(std::make_shared<impl>(static_cast<xrt::device*>(device),opcode))
 {}
 
-void
+int
 command::
 execute()
 {
-  m_impl->execute();
+  return m_impl->execute();
 }
 
 void

--- a/src/runtime_src/xrt/xrt++/xrtexec.hpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.hpp
@@ -48,7 +48,7 @@ protected:
   command(xrt_device* dev, ert_cmd_opcode opcode);
 
 public:
-  void
+  int
   execute();
 
   void


### PR DESCRIPTION
clEnqueueCopyBuffer now handles buffers local to enqueued device and
cases where either src or dst is imported from another device.  This
eliminates the need for xclEnqueuePeerToPeerCopyBuffer, which will be
removed once all tests have been updated.

HW emulation driver is expected to handle copy buffer exactly as HW
driver.  SW emulation does not support p2p because scheduling is
through software scheduler (sws) which is not enhanced to handle
ERT_START_COPYBO.