### PR TITLE
CR-1026071 Multi-process : Add 50 ms delay before checking read bit of database file

### DIFF
--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -584,7 +584,7 @@ eexist:
     /* Check to see that read bit has been asserted by process in control of shm
      * indicating that the mutex and other header info of the shm db is ready */
     ret = access(shm_filename, R_OK | W_OK);
-    for (max_retry = 50; ret < 0 && max_retry > 0; max_retry--)
+    for (max_retry = 500; ret < 0 && max_retry > 0; max_retry--)
     {
         ret = access(shm_filename, R_OK);
         usleep(100);

--- a/src/xma/src/xmaapi/xmares.c
+++ b/src/xma/src/xmaapi/xmares.c
@@ -530,6 +530,7 @@ int32_t xma_res_kern_chan_id_get(XmaKernelRes *kern_res)
 static XmaResConfig *xma_shm_open(char *shm_filename, XmaSystemCfg *config)
 {
     extern XmaSingleton *g_xma_singleton;
+    struct stat shm_file_stat;
     int i, ret, fd, max_retry;
     bool shm_initalized;
     int max_wait = xma_cfg_dev_cnt_get() * 10; /* 10s per device programmed */
@@ -583,10 +584,18 @@ eexist:
 
     /* Check to see that read bit has been asserted by process in control of shm
      * indicating that the mutex and other header info of the shm db is ready */
-    ret = access(shm_filename, R_OK | W_OK);
+    stat(shm_filename,&shm_file_stat);
+    if(shm_file_stat.st_mode & S_IRUSR)
+	    ret = 0;
+    else
+	    ret = -1;
     for (max_retry = 500; ret < 0 && max_retry > 0; max_retry--)
     {
-        ret = access(shm_filename, R_OK);
+        stat(shm_filename,&shm_file_stat);
+        if(shm_file_stat.st_mode & S_IRUSR)
+	        ret = 0;
+        else
+	        ret = -1;
         usleep(100);
     }
 


### PR DESCRIPTION
If two processes tries to access database file and first process get the lock on data base file and before 1st process release lock on database file or before first process change permission of database file to 666, 2nd process timed out after 5ms as database file doesn't have read permission after waiting for 5 ms on slower systems.

To resolve above problem we have increased time delay from 5ms to 50ms.