### PR TITLE
XMA legacy logging removed

### DIFF
--- a/src/xma/include/app/xmalogger.h
+++ b/src/xma/include/app/xmalogger.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stddef.h>
 //#include "lib/xmalogger.h"
+#include <xrt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,18 +29,19 @@ extern "C" {
 /**
  * enum XmaLogLevelType - Describes the logging level associated with a log message.
 */
+
 typedef enum XmaLogLevelType
 {
-    XMA_CRITICAL_LOG = 0, /**< 0 */
-    XMA_ERROR_LOG,        /**< 1 */
-    XMA_INFO_LOG,         /**< 2 */
-    XMA_DEBUG_LOG,        /**< 3 */
+    XMA_CRITICAL_LOG = CRITICAL,
+    XMA_ERROR_LOG = ERROR,
+    XMA_INFO_LOG = INFO,
+    XMA_DEBUG_LOG = DEBUG
 } XmaLogLevelType;
 
 /**
  * typedef XmaLoggerCallback - Describes the function signature for an XMA logger callback.
-*/
 typedef void (*XmaLoggerCallback)(char *msg); 
+*/
 
 /**
  * xma_logmsg() - This function logs a message to stdout, a file, or both depending on
@@ -78,9 +80,9 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...);
  * @level:    The level of log messages to be sent to the callback
  * function.  All messages of equal or greater severity are 
  * forwarded to the callback function
-*/
 void
 xma_logger_callback(XmaLoggerCallback callback, XmaLogLevelType level);
+*/
 
 
 #ifdef __cplusplus

--- a/src/xma/src/xmaapi/xmalogger.cpp
+++ b/src/xma/src/xmaapi/xmalogger.cpp
@@ -46,6 +46,8 @@
 #define XMA_DBG_PRINTF(format, ...)
 #endif
 
+extern XmaSingleton *g_xma_singleton;
+/*
 typedef struct XmaLoggerCbData
 {
     XmaLoggerCallback callback;
@@ -53,8 +55,6 @@ typedef struct XmaLoggerCbData
 } XmaLoggerCbData;
 
 XmaLoggerCbData *g_xma_loggercb_singleton;
-
-extern XmaSingleton *g_xma_singleton;
 
 typedef struct XmaLogLevel2Str
 {
@@ -68,10 +68,10 @@ XmaLogLevel2Str g_loglevel_tbl[] = {
     {XMA_INFO_LOG,     "INFO    "},
     {XMA_DEBUG_LOG,    "DEBUG   "}
 };
-
+*/
 /* Prototype for the logger actor thread */
 //void* xma_logger_actor(void *data);
-
+/*
 void xma_logger_callback(XmaLoggerCallback callback, XmaLogLevelType level)
 {
     // Allocate singleton if it doesn't exist
@@ -82,7 +82,7 @@ void xma_logger_callback(XmaLoggerCallback callback, XmaLogLevelType level)
     g_xma_loggercb_singleton->level = level;
 
 }
-
+*/
 int xma_logger_init(XmaLogger *logger)
 {
     /* Verify parameters */
@@ -116,7 +116,7 @@ int xma_logger_init(XmaLogger *logger)
         logger->log_level = g_xma_singleton->systemcfg.loglevel;
     }
 
-    /* Save FD of output file */
+    /* Save FD of output file *--/
     if (logger->use_fileout)
     {
         logger->fd = open((const char*)logger->filename,
@@ -130,25 +130,19 @@ int xma_logger_init(XmaLogger *logger)
     else
         logger->fd = -1;
 
-    /* Create logger actor */
-    /*
-    //std::cout << "Sarab: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
-    logger->actor = xma_actor_create(xma_logger_actor,
-                                     XMA_MAX_LOGMSG_SIZE,
-                                     XMA_MAX_LOGMSG_Q_ENTRIES);
-    */
+    /--* Create logger actor *--/
     logger->actor = xma_actor_create();
 
     //std::cout << "Sarab: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
     xma_actor_start(logger->actor);
     //std::cout << "Sarab: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
-
+    */
     return 0;
 }
-
+/*
 int xma_logger_close(XmaLogger *logger)
 {
-    /* Verify parameters */
+    /--* Verify parameters *--/
     assert(logger);
     if(logger->use_syslog){
         closelog();
@@ -157,7 +151,7 @@ int xma_logger_close(XmaLogger *logger)
 
     return 0;
 }
-
+*/
 void
 xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
 {
@@ -166,23 +160,23 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
 
     /* Create message buffer on the stack */
     char            msg_buff[XMA_MAX_LOGMSG_SIZE];
-    struct tm      *tm_info;
-    struct timeval  tv;
-    int32_t         millisec;
-    char            log_time[40] = {0};
+    //struct tm      *tm_info;
+    //struct timeval  tv;
+    //int32_t         millisec;
+    //char            log_time[40] = {0};
     char            log_name[40] = {0};
-    const char     *log_level;
+    //const char     *log_level;
     int32_t         hdr_offset;
-    bool            send2callback = false;
-    bool            send2actor = false;
-    char           *buffer;
+    //bool            send2callback = false;
+    //bool            send2actor = false;
+    //char           *buffer;
 
     /* Get XMA logger */
-    XmaLogger *logger = &g_xma_singleton->logger;
-    XmaLoggerCbData *cbdata = g_xma_loggercb_singleton;
+    //XmaLogger *logger = &g_xma_singleton->logger;
+    //XmaLoggerCbData *cbdata = g_xma_loggercb_singleton;
 
     memset(msg_buff, 0, sizeof(msg_buff));
-
+    /*
     if (cbdata)
     {
         if (level <= cbdata->level)
@@ -195,7 +189,7 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
     if (!(send2callback || send2actor))
         return;
 
-    /* Get time */
+    /--* Get time *--/
     gettimeofday(&tv, NULL);
     millisec = lrint(tv.tv_usec/1000.0);
     if (millisec >= 1000)
@@ -205,16 +199,16 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
     }
     tm_info = localtime(&tv.tv_sec);
     strftime(log_time, sizeof(log_time), "%Y-%m-%d %H:%M:%S", tm_info);
-
+    */
     /* Set component name */
     if (name == NULL)
         strncpy(log_name, "XMA-default", sizeof(log_name));
     else
         strncpy(log_name, name, sizeof(log_name)-1);
 
-    log_level = g_loglevel_tbl[level].lvl_str;
+    //log_level = g_loglevel_tbl[level].lvl_str;
 
-    /* Format log message */
+    /* Format log message *--/
     //NOTE: Usage of program_invocation_short_name may hinder portability
     if(logger->use_syslog){
         sprintf(msg_buff, "%s %s %s ", program_invocation_short_name, log_level, log_name);
@@ -222,13 +216,17 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
     else{
         sprintf(msg_buff, "%s.%03d %d %s %s %s ", log_time, millisec, getpid(), program_invocation_short_name, log_level, log_name);
     }
+    */
+    sprintf(msg_buff, "%s %s ", program_invocation_short_name, log_name);
     hdr_offset = strlen(msg_buff);
     va_start(ap, msg);
     vsnprintf(&msg_buff[hdr_offset], (XMA_MAX_LOGMSG_SIZE - hdr_offset), msg, ap);
     va_end(ap);
+    //xclLogMsg(NULL, xclLogMsgLevel::INFO, "XMA",logmsg);
+    xclLogMsg(NULL, (xclLogMsgLevel)level, "XMA", msg_buff);
 
     /* Send message buffer to logger Actor -
-       will be copied to loggers message buffer */
+       will be copied to loggers message buffer *--/
     if (send2actor)
         xma_actor_sendmsg(logger->actor, msg_buff, sizeof(msg_buff));
 
@@ -238,8 +236,10 @@ xma_logmsg(XmaLogLevelType level, const char *name, const char *msg, ...)
         strcpy(buffer, msg_buff);
         cbdata->callback(buffer);
     }
+    */
 }
 
+/*
 //void* xma_logger_actor(void *data)
 void xma_logger_actor(XmaActor *actor)
 {
@@ -272,7 +272,7 @@ void xma_logger_actor(XmaActor *actor)
             xclLogMsg(NULL, xclLogMsgLevel::INFO, "XMA",logmsg);
         }
         else
-            /* Logger has been shutdown - so return from thread */
+            /--* Logger has been shutdown - so return from thread *--/
             break;
     }
     printf("XMA Logger: shutting down\n");
@@ -281,6 +281,7 @@ void xma_logger_actor(XmaActor *actor)
 
     //return NULL;
 }
+*/
 
 /* XmaThread APIs */
 /*
@@ -407,42 +408,13 @@ int32_t xma_msgq_dequeue(XmaMsgQ *msgq, void *msg, size_t size)
 }
 */
 
-/* XmaActor APIs */
-/*
-XmaActor *xma_actor_create(XmaThreadFunc    func,
-                           size_t           msg_size,
-                           size_t           max_msg_entries)
-*/
+/* XmaActor APIs *--/
 XmaActor *xma_actor_create()
 {
-    //std::cout << "Sarab: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
-    /*
-    XmaActor *actor = (XmaActor*) malloc(sizeof(XmaActor));
-    pthread_mutex_init(&actor->lock, NULL);
-    pthread_cond_init(&actor->queued_cond, NULL);
-    pthread_cond_init(&actor->dequeued_cond, NULL);
-    actor->msg_q = xma_msgq_create(msg_size, max_msg_entries);
-    */
     XmaActor *actor =  new XmaActor();
     actor->thread = new XmaThread();
     actor->thread->is_running = false;
     
-    /*
-    std::cout << "Sarab: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
-    actor->logger_queue_mutex.reset(new std::mutex());
-    exit(0);
-
-
-
-    actor->logger_queue_mutex = std::unique_ptr<std::mutex>(new std::mutex());
-    actor->logger_queue_cv = std::unique_ptr<std::condition_variable>(new std::condition_variable());
-    actor->logger_queue_locked = std::unique_ptr<std::atomic<bool>>(new std::atomic<bool>());
-    *(actor->logger_queue_locked) = false;
-
-    std::cout << "Sarab: " << __func__ << " , " << std::dec << __LINE__ << std::endl;
-    actor->logger_queue = std::unique_ptr<std::queue<std::string>>(new std::queue<std::string>());
-    */
-
     return actor;
 }
 
@@ -457,7 +429,7 @@ void xma_actor_destroy(XmaActor *actor)
 {
     char *shutdown = (char*) "shutdown\0";
 
-    /* Send shutdown message to Actor */
+    /--* Send shutdown message to Actor *--/
     XMA_DBG_PRINTF("%s", "XMA sending shutdown message\n");
     xma_actor_sendmsg(actor, shutdown, strlen(shutdown));
     if (actor->thread->thread_obj.joinable()) {
@@ -474,36 +446,6 @@ void xma_actor_destroy(XmaActor *actor)
 
 int32_t xma_actor_sendmsg(XmaActor *actor, void *msg, size_t msg_size)
 {
-    /*
-    int32_t rc;
-    bool    was_empty;
-
-    pthread_mutex_lock(&actor->lock);
-    XMA_DBG_PRINTF("XMA actor sendmsg on entry depth=%d, front=%d, back=%d\n",
-            actor->msg_q->num_entries,
-            actor->msg_q->front,
-            actor->msg_q->back);
-    if (xma_msgq_isfull(actor->msg_q))
-    {
-        XMA_DBG_PRINTF("%s", "Waiting: msgq_isfull\n");
-        pthread_cond_wait(&actor->dequeued_cond, &actor->lock);
-        XMA_DBG_PRINTF("%s", "Waiting: msgq_isfull done\n");
-    }
-    was_empty = xma_msgq_isempty(actor->msg_q);
-    rc = xma_msgq_enqueue(actor->msg_q, msg, msg_size);
-    if (rc == 0 && was_empty)
-    {
-        XMA_DBG_PRINTF("%s", "Sending queued_cond for previously empty queue\n");
-        pthread_cond_broadcast(&actor->queued_cond);
-    }
-
-    XMA_DBG_PRINTF("XMA actor sendmsg on exit depth=%d, front=%d, back=%d\n",
-            actor->msg_q->num_entries,
-            actor->msg_q->front,
-            actor->msg_q->back);
-
-    pthread_mutex_unlock(&actor->lock);
-    */
     // First acquire queue lock
     bool expected = false;
     bool desired = true;
@@ -524,36 +466,6 @@ int32_t xma_actor_sendmsg(XmaActor *actor, void *msg, size_t msg_size)
 
 int32_t xma_actor_recvmsg(XmaActor *actor, void *msg, size_t msg_size)
 {
-    /*
-    int32_t rc;
-    bool    was_full;
-
-    pthread_mutex_lock(&actor->lock);
-
-    XMA_DBG_PRINTF("XMA actor recvmsg on entry depth=%d, front=%d, back=%d\n",
-            actor->msg_q->num_entries,
-            actor->msg_q->front,
-            actor->msg_q->back);
-
-
-    if (xma_msgq_isempty(actor->msg_q))
-        pthread_cond_wait(&actor->queued_cond, &actor->lock);
-
-    was_full = xma_msgq_isfull(actor->msg_q);
-    rc = xma_msgq_dequeue(actor->msg_q, msg, msg_size);
-    if (was_full)
-    {
-        XMA_DBG_PRINTF("%s", "sending dequeued_cond\n");
-        pthread_cond_broadcast(&actor->dequeued_cond);
-    }
-
-    XMA_DBG_PRINTF("XMA actor recvmsg on exit depth=%d, front=%d, back=%d\n",
-            actor->msg_q->num_entries,
-            actor->msg_q->front,
-            actor->msg_q->back);
-
-    pthread_mutex_unlock(&actor->lock);
-    */
 
     // First acquire queue lock
     bool lock_acquired = false;
@@ -592,3 +504,4 @@ int32_t xma_actor_recvmsg(XmaActor *actor, void *msg, size_t msg_size)
 
     return 0;
 }
+*/


### PR DESCRIPTION
From 2019.1 XMA will only use XRT logging features. So XRT.ini file settings will be used for log messages. Example ini settings: verbosity=7 and runtime_log="/tmp/logfile.txt"

@maxzhen Please do the needful