### PR TITLE
Not allocating memory in default bank in hw_emu & data_flow fixes in hw_emu

### DIFF
--- a/src/runtime_src/driver/common_em/em_defines.h
+++ b/src/runtime_src/driver/common_em/em_defines.h
@@ -190,12 +190,13 @@ namespace xclemulation {
     int                   fd;
   };
 
-  static inline unsigned xocl_bo_ddr_idx(unsigned flags)
+  //we should not create a memory in default bank for hw_emu. As sw_emu doesnt have rtd information, we are not doing any error check
+  static inline unsigned xocl_bo_ddr_idx(unsigned flags, bool is_sw_emu = true)
   {
     unsigned flag = flags & 0xFFFFFFLL;
     //unsigned type = flags & 0xFF000000LL ;
 
-    if(flag == 0 || flag == 0xFFFFFFLL)
+    if(flag == 0 || ((flag == 0xFFFFFFLL) && is_sw_emu))
       return 0;
     
     return flag;

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
@@ -1664,7 +1664,7 @@ static bool check_bo_user_flags(HwEmShim* dev, unsigned flags)
 	if (flags == 0xffffffff)
 		return true;
 
-  ddr = xclemulation::xocl_bo_ddr_idx(flags);
+  ddr = xclemulation::xocl_bo_ddr_idx(flags,false);
   if (ddr > ddr_count)
 		return false;
 
@@ -1719,7 +1719,7 @@ int HwEmShim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *propert
 uint64_t HwEmShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
 {
 	size_t size = info->size;
-  unsigned ddr = xclemulation::xocl_bo_ddr_idx(info->flags);
+  unsigned ddr = xclemulation::xocl_bo_ddr_idx(info->flags,false);
 
   if (!size)
   {


### PR DESCRIPTION
Hi,

This change contains a fix to not allocate memory in default DDR bank in hw_emu.

Thanks
Vamshi Krishna