### PR TITLE
fix "AWS hardware emulation no profiling data" issue in 2019.1

### DIFF
--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/debug.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/debug.cxx
@@ -76,8 +76,17 @@ namespace xclhwemhal2 {
     memset(mAccelmonProperties, 0, sizeof(uint8_t)*XSAM_MAX_NUMBER_SLOTS);
     memset(mStreamMonProperties, 0, sizeof(uint8_t)*XSSPM_MAX_NUMBER_SLOTS);
 
-    mMemoryProfilingNumberSlots = getIPCountAddrNames(debugFileName, AXI_MM_MONITOR, mPerfMonBaseAddress,
+    if (isAWSLegacy()) {
+      // Per Bank Monitoring
+      mMemoryProfilingNumberSlots = 4;
+      mPerfMonSlotName[0] = "All";
+      mPerfMonSlotName[1] = "All";
+      mPerfMonSlotName[2] = "All";
+      mPerfMonSlotName[3] = "All";
+    } else {
+      mMemoryProfilingNumberSlots = getIPCountAddrNames(debugFileName, AXI_MM_MONITOR, mPerfMonBaseAddress,
       mPerfMonSlotName, mPerfmonProperties, XSPM_MAX_NUMBER_SLOTS);
+    }
     
     mAccelProfilingNumberSlots = getIPCountAddrNames(debugFileName, ACCEL_MONITOR, mAccelMonBaseAddress,
       mAccelMonSlotName, mAccelmonProperties, XSAM_MAX_NUMBER_SLOTS);

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -416,7 +416,7 @@ namespace xclhwemhal2 {
       {
 #ifndef _WINDOWS
 // add windows support
-#endif
+
         unsigned int samplessize = 0;
         // TODO: Windows build support
         // *_RPC_CALL uses unix_socket
@@ -550,6 +550,7 @@ namespace xclhwemhal2 {
             }
           }
         }
+#endif
       }
     }
 

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -224,7 +224,8 @@ namespace xclhwemhal2 {
           if (accel)
             return 0;
           std::string slot = std::to_string(counter);
-          char const * slotname = slot.c_str();
+          // Sahil suggested that it should be Bank0 instead of 0 by itself
+          char const * slotname = ("BANK" + slot).c_str();
           xclPerfMonReadCounters_RPC_CALL_AWS(xclPerfMonReadCounters,wr_byte_count,wr_trans_count,total_wr_latency,rd_byte_count,rd_trans_count,total_rd_latency,sampleIntervalUsec,slotname);
         } else {
           if (counter == XPAR_SPM0_HOST_SLOT && !accel && iptype != 3) // Ignore host slot
@@ -321,7 +322,7 @@ namespace xclhwemhal2 {
 
         if (isAWSLegacy()) {
           std::string slot = std::to_string(counter);
-          char const * slotname = slot.c_str();
+          char const * slotname = ("BANK" + slot).c_str();
           xclPerfMonGetTraceCount_RPC_CALL_AWS(xclPerfMonGetTraceCount,ack,no_of_samples,slotname);
         } else {
           char slotname[128];
@@ -416,11 +417,13 @@ namespace xclhwemhal2 {
         // *_RPC_CALL uses unix_socket
         char slotname[128];
         if (isAWSLegacy()) {
+          std::cout << "reading aws trace" << std::endl;
           if (accel) return 0;
           std::string slot = std::to_string(counter);
-          char const * slotname = slot.c_str();
+          char const * slotname = ("BANK" + slot).c_str();
           xclPerfMonReadTrace_RPC_CALL_AWS(xclPerfMonReadTrace,ack,samplessize,slotname);
           unsigned int i = 0;
+          std::cout << "sample size: " << samplessize << std::endl;
           for(; i<samplessize && index<(MAX_TRACE_NUMBER_SAMPLES-7); i++)
           {
             const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
@@ -437,6 +440,8 @@ namespace xclhwemhal2 {
             result.HostTimestamp = event.host_timestamp();
             result.EventID = XCL_PERF_MON_HW_EVENT;
             traceVector.mArray[index++] = result;
+            std::cout << "ReadBytes: " << result.ReadBytes << std::endl;
+            std::cout << "WriteBytes: " << result.WriteBytes << std::endl;
           }
           traceVector.mLength = index;
 

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -365,8 +365,10 @@ namespace xclhwemhal2 {
     for(; counter < numSlots; counter++)
     {
       // Ignore host
-      if (counter == XPAR_SPM0_HOST_SLOT && !accel && 3 != iptype)
+      /*
+      if (!accel && 3 != iptype)
         continue;
+      */
 
       unsigned int numberOfElementsAdded = 0;
 
@@ -417,7 +419,7 @@ namespace xclhwemhal2 {
         // *_RPC_CALL uses unix_socket
         char slotname[128];
         if (isAWSLegacy()) {
-          std::cout << "reading aws trace" << std::endl;
+          std::cout << "reading aws trace with counter " << counter << std::endl;
           if (accel) return 0;
           std::string slot = std::to_string(counter);
           char const * slotname = ("BANK" + slot).c_str();

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -443,8 +443,6 @@ namespace xclhwemhal2 {
             result.HostTimestamp = event.host_timestamp();
             result.EventID = XCL_PERF_MON_HW_EVENT;
             traceVector.mArray[index++] = result;
-            std::cout << "ReadBytes: " << result.ReadBytes << std::endl;
-            std::cout << "WriteBytes: " << result.WriteBytes << std::endl;
           }
           traceVector.mLength = index;
 

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -218,19 +218,30 @@ namespace xclhwemhal2 {
       //counterResults.NumSlots = numSlots;
       for(; counter < numSlots; counter++)
       {
-        if (counter == XPAR_SPM0_HOST_SLOT && !accel && iptype != 3) // Ignore host slot
-          continue;
-        char slotname[128];
-        getPerfMonSlotName(type,counter,slotname,128);
 
-        if (type != XCL_PERF_MON_STR) {
-          xclPerfMonReadCounters_RPC_CALL(xclPerfMonReadCounters,wr_byte_count,wr_trans_count,
-                                          total_wr_latency,rd_byte_count,rd_trans_count,
-                                          total_rd_latency,sampleIntervalUsec,slotname,accel);
+        if (isAWSLegacy()) {
+          // Not supported in aws platform
+          if (accel)
+            return 0;
+          std::string slot = std::to_string(counter);
+          char const * slotname = slot.c_str();
+          xclPerfMonReadCounters_RPC_CALL_AWS(xclPerfMonReadCounters,wr_byte_count,wr_trans_count,total_wr_latency,rd_byte_count,rd_trans_count,total_rd_latency,sampleIntervalUsec,slotname);
         } else {
-          xclPerfMonReadCounters_Streaming_RPC_CALL(xclPerfMonReadCounters_Streaming, str_num_tranx,str_data_bytes,str_busy_cycles,
-                                                      str_stall_cycles,str_starve_cycles,slotname);
+          if (counter == XPAR_SPM0_HOST_SLOT && !accel && iptype != 3) // Ignore host slot
+            continue;
+          char slotname[128];
+          getPerfMonSlotName(type,counter,slotname,128);
+
+          if (type != XCL_PERF_MON_STR) {
+            xclPerfMonReadCounters_RPC_CALL(xclPerfMonReadCounters,wr_byte_count,wr_trans_count,
+                                            total_wr_latency,rd_byte_count,rd_trans_count,
+                                            total_rd_latency,sampleIntervalUsec,slotname,accel);
+          } else {
+            xclPerfMonReadCounters_Streaming_RPC_CALL(xclPerfMonReadCounters_Streaming, str_num_tranx,str_data_bytes,str_busy_cycles,
+                                                        str_stall_cycles,str_starve_cycles,slotname);
+          }
         }
+
 #endif
         if (iptype == 1) {
           counterResults.WriteBytes[counter] = wr_byte_count;
@@ -307,10 +318,17 @@ namespace xclhwemhal2 {
 #ifndef _WINDOWS
         // TODO: Windows build support
         // *_RPC_CALL uses unix_socket
-        char slotname[128];
-        getPerfMonSlotName(type,counter,slotname,128);
 
-        xclPerfMonGetTraceCount_RPC_CALL(xclPerfMonGetTraceCount,ack,no_of_samples,slotname,accel);
+        if (isAWSLegacy()) {
+          std::string slot = std::to_string(counter);
+          char const * slotname = slot.c_str();
+          xclPerfMonGetTraceCount_RPC_CALL_AWS(xclPerfMonGetTraceCount,ack,no_of_samples,slotname);
+        } else {
+          char slotname[128];
+          getPerfMonSlotName(type,counter,slotname,128);
+          xclPerfMonGetTraceCount_RPC_CALL(xclPerfMonGetTraceCount,ack,no_of_samples,slotname,accel);
+        }
+
 #endif
       }
       no_of_final_samples = no_of_samples + list_of_events[counter].size();
@@ -391,33 +409,24 @@ namespace xclhwemhal2 {
       if (simulator_started == true)
       {
 #ifndef _WINDOWS
+// add windows support
+#endif
         unsigned int samplessize = 0;
         // TODO: Windows build support
         // *_RPC_CALL uses unix_socket
         char slotname[128];
-        getPerfMonSlotName(type,counter,slotname,128);
-
-        if (type != XCL_PERF_MON_STR) {
-          xclPerfMonReadTrace_RPC_CALL(xclPerfMonReadTrace,ack,samplessize,slotname,accel);
+        if (isAWSLegacy()) {
+          if (accel) return 0;
+          std::string slot = std::to_string(counter);
+          char const * slotname = slot.c_str();
+          xclPerfMonReadTrace_RPC_CALL_AWS(xclPerfMonReadTrace,ack,samplessize,slotname);
           unsigned int i = 0;
           for(; i<samplessize && index<(MAX_TRACE_NUMBER_SAMPLES-7); i++)
           {
-            // TODO: Windows build support
-            // r_msg is defined as part of *RPC_CALL definition
             const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
-
             xclTraceResults result;
             memset(&result, 0, sizeof(xclTraceResults));
-            // result.TraceID = accel ? counter + 64 : counter * 2;
-            if (iptype == 1) {
-              result.TraceID = counter * 2;
-            } else if (iptype == 2) {
-              result.TraceID = counter + 64;
-            } else if (iptype == 3) {
-              result.TraceID = counter + 576;
-            } else {
-              return 0;
-            }
+            result.TraceID = accel ? counter + 64 : counter * 2;
             result.Timestamp = event.timestamp();
             result.Overflow = (event.timestamp() >> 17) & 0x1;
             result.EventFlags = event.eventflags();
@@ -446,44 +455,94 @@ namespace xclhwemhal2 {
             eventObj.writeBytes = event.wr_bytes();
             list_of_events[counter].push_back(eventObj);
           }
-#endif
         } else {
-#ifndef _WINDOWS
-          xclPerfMonReadTrace_Streaming_RPC_CALL(xclPerfMonReadTrace_Streaming,ack,samplessize,slotname);
-          unsigned int i = 0;
-          for(; i<samplessize && index<(MAX_TRACE_NUMBER_SAMPLES-7); i++)
-          {
-            // TODO: Windows build support
-            // r_msg is defined as part of *RPC_CALL definition
-            const xclPerfMonReadTrace_Streaming_response::events &event = r_msg.output_data(i);
+          getPerfMonSlotName(type,counter,slotname,128);
 
-            xclTraceResults result;
-            memset(&result, 0, sizeof(xclTraceResults));
-            // result.TraceID = accel ? counter + 64 : counter * 2;
-            if (iptype == 3) {
-              result.TraceID = counter + 576;
+          if (type != XCL_PERF_MON_STR) {
+            xclPerfMonReadTrace_RPC_CALL(xclPerfMonReadTrace,ack,samplessize,slotname,accel);
+            unsigned int i = 0;
+            for(; i<samplessize && index<(MAX_TRACE_NUMBER_SAMPLES-7); i++)
+            {
+              // TODO: Windows build support
+              // r_msg is defined as part of *RPC_CALL definition
+              const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
+
+              xclTraceResults result;
+              memset(&result, 0, sizeof(xclTraceResults));
+              // result.TraceID = accel ? counter + 64 : counter * 2;
+              if (iptype == 1) {
+                result.TraceID = counter * 2;
+              } else if (iptype == 2) {
+                result.TraceID = counter + 64;
+              } else if (iptype == 3) {
+                result.TraceID = counter + 576;
+              } else {
+                return 0;
+              }
+              result.Timestamp = event.timestamp();
+              result.Overflow = (event.timestamp() >> 17) & 0x1;
+              result.EventFlags = event.eventflags();
+              result.ReadAddrLen = event.arlen();
+              result.WriteAddrLen = event.awlen();
+              result.WriteBytes = (event.wr_bytes());
+              result.ReadBytes  = (event.rd_bytes());
+              result.HostTimestamp = event.host_timestamp();
+              result.EventID = XCL_PERF_MON_HW_EVENT;
+              traceVector.mArray[index++] = result;
             }
-            result.Timestamp = event.timestamp();
-            result.Overflow = (event.timestamp() >> 17) & 0x1;
-            result.EventFlags = event.eventflags();
-            result.HostTimestamp = event.host_timestamp();
-            result.EventID = XCL_PERF_MON_HW_EVENT;
-            traceVector.mArray[index++] = result;
-          }
-          traceVector.mLength = index;
+            traceVector.mLength = index;
 
-          Event eventObj;
-          for(; i<samplessize ; i++)
-          {
-            // TODO: Windows build support
-            // r_msg is defined as part of *RPC_CALL definition
-            const xclPerfMonReadTrace_Streaming_response::events &event = r_msg.output_data(i);
-            eventObj.timestamp = event.timestamp();
-            eventObj.eventflags = event.eventflags();
-            eventObj.host_timestamp = event.host_timestamp();
-            list_of_events[counter].push_back(eventObj);
+            Event eventObj;
+            for(; i<samplessize ; i++)
+            {
+              // TODO: Windows build support
+              // r_msg is defined as part of *RPC_CALL definition
+              const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
+              eventObj.timestamp = event.timestamp();
+              eventObj.eventflags = event.eventflags();
+              eventObj.arlen = event.arlen();
+              eventObj.awlen = event.awlen();
+              eventObj.host_timestamp = event.host_timestamp();
+              eventObj.readBytes = event.rd_bytes();
+              eventObj.writeBytes = event.wr_bytes();
+              list_of_events[counter].push_back(eventObj);
+            }
+          } else {
+            xclPerfMonReadTrace_Streaming_RPC_CALL(xclPerfMonReadTrace_Streaming,ack,samplessize,slotname);
+            unsigned int i = 0;
+            for(; i<samplessize && index<(MAX_TRACE_NUMBER_SAMPLES-7); i++)
+            {
+              // TODO: Windows build support
+              // r_msg is defined as part of *RPC_CALL definition
+              const xclPerfMonReadTrace_Streaming_response::events &event = r_msg.output_data(i);
+
+              xclTraceResults result;
+              memset(&result, 0, sizeof(xclTraceResults));
+              // result.TraceID = accel ? counter + 64 : counter * 2;
+              if (iptype == 3) {
+                result.TraceID = counter + 576;
+              }
+              result.Timestamp = event.timestamp();
+              result.Overflow = (event.timestamp() >> 17) & 0x1;
+              result.EventFlags = event.eventflags();
+              result.HostTimestamp = event.host_timestamp();
+              result.EventID = XCL_PERF_MON_HW_EVENT;
+              traceVector.mArray[index++] = result;
+            }
+            traceVector.mLength = index;
+
+            Event eventObj;
+            for(; i<samplessize ; i++)
+            {
+              // TODO: Windows build support
+              // r_msg is defined as part of *RPC_CALL definition
+              const xclPerfMonReadTrace_Streaming_response::events &event = r_msg.output_data(i);
+              eventObj.timestamp = event.timestamp();
+              eventObj.eventflags = event.eventflags();
+              eventObj.host_timestamp = event.host_timestamp();
+              list_of_events[counter].push_back(eventObj);
+            }
           }
-#endif
         }
       }
     }

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/perf.cxx
@@ -366,9 +366,12 @@ namespace xclhwemhal2 {
     {
       // Ignore host
       /*
-      if (!accel && 3 != iptype)
+      if (counter == XPAR_SPM0_HOST_SLOT && !accel && 3 != iptype)
         continue;
       */
+      if (counter == XPAR_SPM0_HOST_SLOT && !accel && 3 != iptype && !isAWSLegacy()) {
+        continue;
+      }
 
       unsigned int numberOfElementsAdded = 0;
 
@@ -419,13 +422,11 @@ namespace xclhwemhal2 {
         // *_RPC_CALL uses unix_socket
         char slotname[128];
         if (isAWSLegacy()) {
-          std::cout << "reading aws trace with counter " << counter << std::endl;
           if (accel) return 0;
           std::string slot = std::to_string(counter);
           char const * slotname = ("BANK" + slot).c_str();
           xclPerfMonReadTrace_RPC_CALL_AWS(xclPerfMonReadTrace,ack,samplessize,slotname);
           unsigned int i = 0;
-          std::cout << "sample size: " << samplessize << std::endl;
           for(; i<samplessize && index<(MAX_TRACE_NUMBER_SAMPLES-7); i++)
           {
             const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
@@ -1183,29 +1183,41 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 
       if (simulator_started == true)
       {
-#ifndef _WINDOWS
         // TODO: Windows build support
         // *_RPC_CALL uses unix_socket
         do
         {
-          bool accel=false;
-          xclPerfMonReadTrace_RPC_CALL(xclPerfMonReadTrace,ack,samplessize,slotname,accel);
-#endif
-          for(unsigned int i = 0; i<samplessize ; i++)
-          {
-#ifndef _WINDOWS
-            // TODO: Windows build support
-            // r_msg is defined as part of *RPC_CALL definition
-            const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
-            eventObj.timestamp = event.timestamp();
-            eventObj.eventflags = event.eventflags();
-            eventObj.arlen = event.arlen();
-            eventObj.awlen = event.awlen();
-            eventObj.host_timestamp = event.host_timestamp();
-            eventObj.readBytes = event.rd_bytes();
-            eventObj.writeBytes = event.wr_bytes();
-            list_of_events[counter].push_back(eventObj);
-#endif
+          if (isAWSLegacy()) {
+            std::string slot = std::to_string(counter);
+            char const * slotname = slot.c_str();
+            xclPerfMonReadTrace_RPC_CALL_AWS(xclPerfMonReadTrace,ack,samplessize,slotname);
+            for(unsigned int i = 0; i<samplessize ; i++) {
+              const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
+              eventObj.timestamp = event.timestamp();
+              eventObj.eventflags = event.eventflags();
+              eventObj.arlen = event.arlen();
+              eventObj.awlen = event.awlen();
+              eventObj.host_timestamp = event.host_timestamp();
+              eventObj.readBytes = event.rd_bytes();
+              eventObj.writeBytes = event.wr_bytes();
+              list_of_events[counter].push_back(eventObj);
+            }
+          } else {
+            bool accel=false;
+            xclPerfMonReadTrace_RPC_CALL(xclPerfMonReadTrace,ack,samplessize,slotname,accel);
+            for(unsigned int i = 0; i<samplessize ; i++) {
+              // TODO: Windows build support
+              // r_msg is defined as part of *RPC_CALL definition
+              const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);
+              eventObj.timestamp = event.timestamp();
+              eventObj.eventflags = event.eventflags();
+              eventObj.arlen = event.arlen();
+              eventObj.awlen = event.awlen();
+              eventObj.host_timestamp = event.host_timestamp();
+              eventObj.readBytes = event.rd_bytes();
+              eventObj.writeBytes = event.wr_bytes();
+              list_of_events[counter].push_back(eventObj);
+            }
           }
         } while (samplessize != 0);
       }

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
@@ -1189,7 +1189,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
         {
           if (isAWSLegacy()) {
             std::string slot = std::to_string(counter);
-            char const * slotname = slot.c_str();
+            char const * slotname = ("BANK" + slot).c_str();
             xclPerfMonReadTrace_RPC_CALL_AWS(xclPerfMonReadTrace,ack,samplessize,slotname);
             for(unsigned int i = 0; i<samplessize ; i++) {
               const xclPerfMonReadTrace_response::events &event = r_msg.output_data(i);

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.cxx
@@ -1168,7 +1168,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 #ifndef _WINDOWS
     // TODO: Windows build support
     // *_RPC_CALL uses unix_socket
-#endif
+
     Event eventObj;
     uint32_t numSlots = getPerfMonNumberSlots(XCL_PERF_MON_MEMORY);
     bool ack = true;
@@ -1222,6 +1222,8 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
         } while (samplessize != 0);
       }
     }
+
+#endif
 
     xclGetDebugMessages(true);
     simulator_started = false;

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.h
@@ -206,7 +206,7 @@ using addr_type = uint64_t;
       void setXPR(bool _xpr) { bXPR = _xpr; }
       std::string deviceDirectory;
 
-      bool isAWSLegacy () { 
+      bool isAWSLegacy () {
         return std::string(mDeviceInfo.mName).find("xilinx_aws-vu9p-f1-04261818_dynamic_5_0") != std::string::npos; 
       }
 

--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/shim.h
@@ -206,6 +206,10 @@ using addr_type = uint64_t;
       void setXPR(bool _xpr) { bXPR = _xpr; }
       std::string deviceDirectory;
 
+      bool isAWSLegacy () { 
+        return std::string(mDeviceInfo.mName).find("xilinx_aws-vu9p-f1-04261818_dynamic_5_0") != std::string::npos; 
+      }
+
       //QDMA Support
       int xclCreateWriteQueue(xclQueueContext *q_ctx, uint64_t *q_hdl);
       int xclCreateReadQueue(xclQueueContext *q_ctx, uint64_t *q_hdl);

--- a/src/runtime_src/driver/include/xcl_api_macros.h
+++ b/src/runtime_src/driver/include/xcl_api_macros.h
@@ -694,6 +694,7 @@ mtx.unlock();
       RELEASE_MUTEX();\
       return 0; \
     }\
+    c_msg.set_accel(false); \
     c_msg.set_slotname(slotname); \
 
 #define xclPerfMonReadCounters_RPC_CALL_AWS(func_name,wr_byte_count,wr_trans_count,total_wr_latency,rd_byte_count,rd_trans_count,total_rd_latency,sampleIntervalUsec,slotname) \
@@ -712,6 +713,7 @@ mtx.unlock();
       return 0; \
     }\
   c_msg.set_ack(ack); \
+  c_msg.set_accel(false); \
   c_msg.set_slotname(slotname); \
 
 #define xclPerfMonGetTraceCount_RPC_CALL_AWS(func_name,ack,no_of_samples,slotname) \
@@ -729,7 +731,7 @@ mtx.unlock();
       return 0; \
     }\
     c_msg.set_ack(ack); \
-    c_msg.set_accel(true); \
+    c_msg.set_accel(false); \
     c_msg.set_slotname(slotname); \
 
 #define xclPerfMonReadTrace_RPC_CALL_AWS(func_name,ack,samplessize,slotname) \

--- a/src/runtime_src/driver/include/xcl_api_macros.h
+++ b/src/runtime_src/driver/include/xcl_api_macros.h
@@ -686,3 +686,54 @@ mtx.unlock();
   xclSetupInstance_SET_PROTO_RESPONSE(); \
   FREE_BUFFERS();
 
+//----------xclPerfMonReadCounters AWS------------
+
+#define xclPerfMonReadCounters_SET_PROTOMESSAGE_AWS() \
+    if(simulator_started == false) \
+    {\
+      RELEASE_MUTEX();\
+      return 0; \
+    }\
+    c_msg.set_slotname(slotname); \
+
+#define xclPerfMonReadCounters_RPC_CALL_AWS(func_name,wr_byte_count,wr_trans_count,total_wr_latency,rd_byte_count,rd_trans_count,total_rd_latency,sampleIntervalUsec,slotname) \
+    RPC_PROLOGUE(func_name); \
+    xclPerfMonReadCounters_SET_PROTOMESSAGE_AWS(); \
+    SERIALIZE_AND_SEND_MSG(func_name)\
+    xclPerfMonReadCounters_SET_PROTO_RESPONSE(); \
+    FREE_BUFFERS(); \
+    xclPerfMonReadCounters_RETURN();
+
+//----------xclPerfMonGetTraceCount AWS------------
+#define xclPerfMonGetTraceCount_SET_PROTOMESSAGE_AWS() \
+    if(simulator_started == false) \
+    {\
+      RELEASE_MUTEX();\
+      return 0; \
+    }\
+  c_msg.set_ack(ack); \
+  c_msg.set_slotname(slotname); \
+
+#define xclPerfMonGetTraceCount_RPC_CALL_AWS(func_name,ack,no_of_samples,slotname) \
+    RPC_PROLOGUE(func_name); \
+    xclPerfMonGetTraceCount_SET_PROTOMESSAGE_AWS(); \
+    SERIALIZE_AND_SEND_MSG(func_name)\
+    xclPerfMonGetTraceCount_SET_PROTO_RESPONSE(); \
+    FREE_BUFFERS();
+
+//----------xclPerfMonReadTrace_AWS------------
+#define xclPerfMonReadTrace_SET_PROTOMESSAGE_AWS() \
+    if(simulator_started == false) \
+    {\
+      RELEASE_MUTEX();\
+      return 0; \
+    }\
+    c_msg.set_ack(ack); \
+    c_msg.set_slotname(slotname); \
+
+#define xclPerfMonReadTrace_RPC_CALL_AWS(func_name,ack,samplessize,slotname) \
+    RPC_PROLOGUE(func_name); \
+    xclPerfMonReadTrace_SET_PROTOMESSAGE_AWS(); \
+    SERIALIZE_AND_SEND_MSG(func_name)\
+    xclPerfMonReadTrace_SET_PROTO_RESPONSE(); \
+    FREE_BUFFERS();

--- a/src/runtime_src/driver/include/xcl_api_macros.h
+++ b/src/runtime_src/driver/include/xcl_api_macros.h
@@ -729,6 +729,7 @@ mtx.unlock();
       return 0; \
     }\
     c_msg.set_ack(ack); \
+    c_msg.set_accel(true); \
     c_msg.set_slotname(slotname); \
 
 #define xclPerfMonReadTrace_RPC_CALL_AWS(func_name,ack,samplessize,slotname) \

--- a/src/runtime_src/xdp/profile/core/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/core/summary_writer.cpp
@@ -200,6 +200,12 @@ namespace xdp {
     bool deviceDataExists = (mDeviceBinaryCuSlotsMap.find(key) == mDeviceBinaryCuSlotsMap.end()) ? false : true;
     xclCounterResults rolloverResults = mRolloverCounterResultsMap.at(key);
     xclCounterResults rolloverCounts = mRolloverCountsMap.at(key);
+
+    if (mPluginHandle->getFlowMode() == xdp::RTUtil::HW_EM && mPluginHandle->isAwsDevice(deviceName)) {
+      mPluginHandle->setHostSlotIndex(4);
+      numSlots = 0;
+    }
+
     for (unsigned int s=0; s < numSlots; ++s) {
       mPluginHandle->getProfileSlotName(XCL_PERF_MON_ACCEL, deviceName, s, cuName);
       mPluginHandle->getProfileKernelName(deviceName, cuName, kernelName);
@@ -554,7 +560,13 @@ namespace xdp {
 
         std::string memoryName;
         std::string argNames;
-        mPluginHandle->getArgumentsBank(deviceName, cuName, portName, argNames, memoryName);
+
+        if (mPluginHandle->getFlowMode() == xdp::RTUtil::HW_EM && mPluginHandle->isAwsDevice(deviceName)) {
+          memoryName = std::to_string(s);
+          argNames = "All";
+        } else {
+          mPluginHandle->getArgumentsBank(deviceName, cuName, portName, argNames, memoryName);
+        }
 
         double totalCUTimeMsec = mProfileCounters->getComputeUnitTotalTime(deviceName, cuName);
 

--- a/src/runtime_src/xdp/profile/core/trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/core/trace_logger.cpp
@@ -431,7 +431,7 @@ namespace xdp {
                + "|" + cu_name + "|" + uniqueCuDataKey;
       if (objStage == RTUtil::START) {
         XDP_LOG("logKernelExecution: CU START @ %.3f msec for %s\n", deviceTimeStamp, cuName.c_str());
-        if (mPluginHandle->getFlowMode() == xdp::RTUtil::CPU) {
+        if (mPluginHandle->getFlowMode() == xdp::RTUtil::CPU || (mPluginHandle->isAwsDevice(deviceName) && mPluginHandle->getFlowMode() == xdp::RTUtil::HW_EM)) {
           mProfileCounters->logComputeUnitExecutionStart(cuName, deviceTimeStamp);
           mProfileCounters->logComputeUnitDeviceStart(newDeviceName, timeStamp);
           cuId = ++mCuStarts;
@@ -441,7 +441,7 @@ namespace xdp {
       else if (objStage == RTUtil::END) {
         XDP_LOG("logKernelExecution: CU END @ %.3f msec for %s\n", deviceTimeStamp, cuName.c_str());
         // This is updated through HAL
-        if (mPluginHandle->getFlowMode() != xdp::RTUtil::CPU) {
+        if (mPluginHandle->getFlowMode() != xdp::RTUtil::CPU && !(mPluginHandle->isAwsDevice(deviceName) && mPluginHandle->getFlowMode() == xdp::RTUtil::HW_EM)) {
           deviceTimeStamp = 0;
         } else {
           // Find CU Start for this End

--- a/src/runtime_src/xdp/profile/plugin/base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/base_plugin.h
@@ -180,10 +180,22 @@ namespace xdp {
           return iter->second;
         return 300;
       }
+    
+    public:
+      bool isAwsDevice(std::string const &deviceName) const {
+        return (deviceName.find(awsDeviceString) != std::string::npos);
+      }
 
-      // Lets profiler communicate to application
-      public:
-        virtual void sendMessage(const std::string &msg);
+      void setHostSlotIndex (int index) {
+        HostSlotIndex = index;
+      }
+
+      std::string awsDeviceString = "xilinx_aws-vu9p-f1-04261818_dynamic_5_0";
+      int HostSlotIndex;
+
+    // Lets profiler communicate to application
+    public:
+      virtual void sendMessage(const std::string &msg);
     };
 
 } // xdp


### PR DESCRIPTION
## Issue

There is no profiling data coming out of the emulation for the AWS platform.

## Cause

The changes we made to the 2018.2_XDF branch was not merged, and with the refactoring of XDP, the changes made are no longer compatible with the up-to-date code.

## Solution

Manually add the changes into the 2019.1 branch

## Review

@hackwa @jvillarre @IshitaGhosh Please try this XRT with the designs you have with AWS or non-AWS platforms and check if the profiling data is coming out as expected.

@jvillarre Please add the person who is supposed to test AWS.

@chvamshi-xilinx Please take a look at the changes in the code you own or pull in the person who should review it.