### PR TITLE
Ensure minimum CU register map size of 4 words to prevent CUDMA rollover

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/devices.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/devices.h
@@ -760,7 +760,7 @@ enum subdev_id {
 
 #define	XOCL_BOARD_USER_QDMA						\
 	(struct xocl_board_private){					\
-		.flags		= XOCL_DSAFLAG_CUDMA_OFF,					\
+		.flags		= 0,					\
 		.subdev_info	= USER_RES_QDMA,			\
 		.subdev_num = ARRAY_SIZE(USER_RES_QDMA),		\
 	}

--- a/src/runtime_src/xocl/core/execution_context.cpp
+++ b/src/runtime_src/xocl/core/execution_context.cpp
@@ -400,7 +400,10 @@ start()
 
   // Ensure that S_AXI_CONTROL is created even when kernel
   // has no arguments.
-  packet[offset] = 0;
+  packet[offset]   = 0;  // control signals
+  packet[offset+1] = 0;  // gier
+  packet[offset+2] = 0;  // ier
+  packet[offset+3] = 0;  // isr
 
   size3 num_workgroups {0,0,0};
   for (auto d : {0,1,2}) {


### PR DESCRIPTION
CUDMA expects a minimum register map size.  If the regmap size is less
than 4 words some internal counter rolls over and all hell breaks loose.

This PR works around CUDMA by ensuring minimum register map size.

CR: 1028635