### PR TITLE
CU init support on embedded

### DIFF
--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -109,6 +109,44 @@ struct ert_start_kernel_cmd {
   uint32_t data[1];          /* count-1 number of words */
 };
 
+/**
+ * struct ert_init_kernel_cmd: ERT initialize kernel command format
+ * this command initializes CUs by writing CU registers. CUs are
+ * represented by cu_mask and extra_cu_masks.
+ *
+ * @state:           [3-0] current state of a command
+ * @extra_cu_masks:  [11-10] extra CU masks in addition to mandatory mask
+ * @count:           [22-12] number of words following header
+ * @opcode:          [27-23] 0, opcode for init_kernel
+ * @type:            [31-27] 0, type of init_kernel
+ *
+ * @cu_mask:         first mandatory CU mask
+ * @data:            count-9 number of words representing interpreted payload
+ *
+ * The packet payload is comprised of reserved id field, 8 reserved fields,
+ * a mandatory CU mask, and extra_cu_masks per header field, followed by a
+ * CU register map of size (count - (9 + extra_cu_masks)) uint32_t words.
+ */
+struct ert_init_kernel_cmd {
+  union {
+    struct {
+      uint32_t state:4;          /* [3-0]   */
+      uint32_t unused:6;         /* [9-4]  */
+      uint32_t extra_cu_masks:2; /* [11-10]  */
+      uint32_t count:11;         /* [22-12] */
+      uint32_t opcode:5;         /* [27-23] */
+      uint32_t type:4;           /* [31-27] */
+    };
+    uint32_t header;
+  };
+
+  uint32_t reserved[8];      /* reserved for future use */
+
+  /* payload */
+  uint32_t cu_mask;          /* mandatory cu mask */
+  uint32_t data[1];          /* count-9 number of words */
+};
+
 #define KDMA_BLOCK_SIZE 64   /* Limited by KDMA CU */
 struct ert_start_copybo_cmd {
   uint32_t state:4;          /* [3-0], must be ERT_CMD_STATE_NEW */
@@ -313,6 +351,7 @@ enum ert_cmd_opcode {
   ERT_SK_CONFIG     = 8,
   ERT_SK_START      = 9,
   ERT_SK_UNCONFIG   = 10,
+  ERT_INIT_CU       = 11,
 };
 
 /**

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -21,6 +21,7 @@
 #include <linux/kthread.h>
 #include <linux/delay.h>
 #include <linux/sched.h>
+#include "ert.h"
 #include "sched_exec.h"
 #include "zocl_sk.h"
 
@@ -255,24 +256,46 @@ packet_size(struct sched_cmd *cmd)
 inline u32
 cu_masks(struct sched_cmd *cmd)
 {
-	struct start_kernel_cmd *sk;
+	struct ert_start_kernel_cmd *sk;
+	u32 op = opcode(cmd);
 
-	if (opcode(cmd) != OP_START_KERNEL && opcode(cmd) != OP_START_SKERNEL)
+	if (op != ERT_START_KERNEL && op != ERT_SK_START && op != ERT_INIT_CU)
 		return 0;
-	sk = (struct start_kernel_cmd *)cmd->packet;
+	sk = (struct ert_start_kernel_cmd *)cmd->packet;
 	return 1 + sk->extra_cu_masks;
 }
 
 /**
  * regmap_size() - Size of regmap
- *
+ *                 It is calculated by payload size + one packet header size -
+ *                 offset of cu_mask field - cu_masks
+ *                 This is based on the assumption that regmap is located
+ *                 right after the cu_masks (including extra_cu_masks).
  * @xcmd: Command object
  * Return: Size of register map in number of words
  */
 inline u32
 regmap_size(struct sched_cmd *cmd)
 {
-	return payload_size(cmd) - cu_masks(cmd);
+	switch (opcode(cmd)) {
+
+	case ERT_INIT_CU:
+		return
+		    payload_size(cmd) + 1 -
+		    offsetof(struct ert_init_kernel_cmd, cu_mask) / WORD_SIZE -
+		    cu_masks(cmd);
+
+	case ERT_START_CU:
+	case ERT_SK_START:
+		return
+		    payload_size(cmd) + 1 -
+		    offsetof(struct ert_start_kernel_cmd, cu_mask) / WORD_SIZE -
+		    cu_masks(cmd);
+
+	default:
+		DRM_WARN("Command %d does not support regmap.\n", opcode(cmd));
+		return 0;
+	}
 }
 
 /**
@@ -297,7 +320,7 @@ cu_idx_to_addr(struct drm_device *dev, unsigned int cu_idx)
  * @state: new command state per ert.h
  */
 static inline void
-set_cmd_int_state(struct sched_cmd *cmd, enum cmd_state state)
+set_cmd_int_state(struct sched_cmd *cmd, enum ert_cmd_state state)
 {
 	SCHED_DEBUG("-> set_cmd_int_state(,%d)\n", state);
 	cmd->state = state;
@@ -454,6 +477,105 @@ static irqreturn_t sched_exec_isr(int irq, void *arg)
 	return IRQ_HANDLED;
 }
 
+static void
+init_cu_by_idx(struct sched_cmd *cmd, int cu_idx)
+{
+	u32 i, size = regmap_size(cmd);
+	u32 *virt_addr = cu_idx_to_addr(cmd->ddev, cu_idx);
+	struct ert_init_kernel_cmd *ik;
+
+	ik = (struct ert_init_kernel_cmd *)cmd->packet;
+
+	/* Initialize CU by writing register map starting at
+	 * base_address + 0x10 (byte)
+	 * This based on the fact that kernel used
+	 *	0x00 -- Control Register
+	 *	0x04 and 0x08 -- Interrupt Enable Registers
+	 *	0x0C -- Interrupt Status Register
+	 * Skip the first 4 words in user regmap.
+	 */
+	for (i = 4; i < size; ++i)
+		iowrite32(*(ik->data + ik->extra_cu_masks + i), virt_addr + i);
+}
+
+/**
+ * init_cus() - Initialize CUs from user space command.
+ *
+ * Process the initialize CUs command sent from user space. Only one process
+ * can initialize a given CU, so if a CU in the CU masks is initialized,
+ * this function ignores the initialize request.
+ *
+ * The initialization is done by copying the user regmap to register map.
+ */
+static void
+init_cus(struct sched_cmd *cmd)
+{
+	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
+	struct ert_init_kernel_cmd *ik;
+	unsigned int i;
+	uint32_t *cmp;
+	int num_masks = cu_masks(cmd);
+	int mask_idx;
+	int warn_flag = 0;
+
+	ik = (struct ert_init_kernel_cmd*)cmd->packet;
+	cmp = &ik->cu_mask;
+
+	for (mask_idx = 0; mask_idx < num_masks; ++mask_idx) {
+		u32 cmd_mask = cmp[mask_idx];
+		u32 inited_mask = zdev->exec->cu_init[mask_idx];
+		u32 uninited_mask = (cmd_mask | inited_mask) ^ inited_mask;
+		u32 busy_mask = zdev->exec->cu_status[mask_idx];
+
+		/*
+		 * If some requested CUs are initialized already,
+		 * record a flag and post some log later.
+		 */
+		if (!warn_flag && (inited_mask & cmd_mask))
+			warn_flag = 1;
+
+		/*
+		 * We don't have uninitialized CU for this 32 mask_id.
+		 * Move to next 32 CUs.
+		 */
+		if (!uninited_mask)
+			continue;
+
+		for (i = 0; i < 32; ++i) {
+			int cu_idx;
+
+			if (!(uninited_mask & (1 << i))) 
+				continue;
+
+			cu_idx = cu_idx_from_mask(i, mask_idx);
+
+			if (busy_mask & (1 << i)) {
+				DRM_WARN("Can not init CU %d while running.\n",
+				   cu_idx);
+				continue;
+			}
+
+			if (cu_idx >= zdev->exec->num_cus) {
+				/*
+				 * Requested CU index exceeds the configured
+				 * CU numbers.
+				 */
+				DRM_WARN("Init CU %d fail: NOT configured.\n",
+				    cu_idx);
+				goto done;
+			}
+
+			init_cu_by_idx(cmd, cu_idx);
+
+			zdev->exec->cu_init[mask_idx] ^= (1 << i);
+		}
+	}
+
+done:
+	if (warn_flag)
+		DRM_INFO("CU can only be initialized once.\n");
+}
+
 /**
  * configure() - Configure the scheduler from user space command
  *
@@ -472,12 +594,12 @@ configure(struct sched_cmd *cmd)
 {
 	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
 	struct sched_exec_core *exec = zdev->exec;
-	struct configure_cmd *cfg;
+	struct ert_configure_cmd *cfg;
 	unsigned int i, j;
 	u32 cu_addr;
 	int ret;
 
-	if (sched_error_on(exec, opcode(cmd) != OP_CONFIGURE))
+	if (sched_error_on(exec, opcode(cmd) != ERT_CONFIGURE))
 		return 1;
 
 	if (!list_empty(&pending_cmds)) {
@@ -490,7 +612,7 @@ configure(struct sched_cmd *cmd)
 		return 1;
 	}
 
-	cfg = (struct configure_cmd *)(cmd->packet);
+	cfg = (struct ert_configure_cmd *)(cmd->packet);
 
 	if (exec->configured != 0) {
 		DRM_WARN("Reconfiguration not supported\n");
@@ -628,14 +750,14 @@ configure_soft_kernel(struct sched_cmd *cmd)
 {
 	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
 	struct soft_kernel *sk = zdev->soft_kernel;
-	struct configure_sk_cmd *cfg;
+	struct ert_configure_sk_cmd *cfg;
 	u32 i;
 	struct soft_kernel_cmd *scmd;
 	int ret;
 
 	SCHED_DEBUG("-> configure_soft_kernel ");
 
-	cfg = (struct configure_sk_cmd *)(cmd->packet);
+	cfg = (struct ert_configure_sk_cmd *)(cmd->packet);
 
 	mutex_lock(&sk->sk_lock);
 
@@ -669,7 +791,7 @@ configure_soft_kernel(struct sched_cmd *cmd)
 		goto fail;
 	}
 
-	scmd->skc_packet = (struct sched_packet *)cfg;
+	scmd->skc_packet = (struct ert_packet *)cfg;
 
 	mutex_lock(&sk->sk_lock);
 	list_add_tail(&scmd->skc_list, &sk->sk_cmd_list);
@@ -678,7 +800,7 @@ configure_soft_kernel(struct sched_cmd *cmd)
 	/* start CU by waking up Soft Kernel handler */
 	wake_up_interruptible(&sk->sk_wait_queue);
 
-	SCHED_DEBUG("<- ert_configure_cu\n");
+	SCHED_DEBUG("<- configure_soft_kernel\n");
 
 	return 0;
 
@@ -695,12 +817,12 @@ unconfigure_soft_kernel(struct sched_cmd *cmd)
 	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
 	struct soft_kernel *sk = zdev->soft_kernel;
 	struct soft_cu *scu;
-	struct unconfigure_sk_cmd *cfg;
+	struct ert_unconfigure_sk_cmd *cfg;
 	u32 i;
 
-	SCHED_DEBUG("-> configure_soft_kernel ");
+	SCHED_DEBUG("-> unconfigure_soft_kernel\n");
 
-	cfg = (struct unconfigure_sk_cmd *)(cmd->packet);
+	cfg = (struct ert_unconfigure_sk_cmd *)(cmd->packet);
 
 	mutex_lock(&sk->sk_lock);
 
@@ -734,6 +856,8 @@ unconfigure_soft_kernel(struct sched_cmd *cmd)
 
 	mutex_unlock(&sk->sk_lock);
 
+	SCHED_DEBUG("<- unconfigure_soft_kernel\n");
+
 	return 0;
 }
 
@@ -747,7 +871,7 @@ unconfigure_soft_kernel(struct sched_cmd *cmd)
  * @state: new state
  */
 static inline void
-set_cmd_state(struct sched_cmd *cmd, enum cmd_state state)
+set_cmd_state(struct sched_cmd *cmd, enum ert_cmd_state state)
 {
 	SCHED_DEBUG("-> set_cmd_state(,%d)\n", state);
 	cmd->state = state;
@@ -786,10 +910,12 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 {
 	u32 opc = opcode(cmd);
 	struct timeval tv;
-	struct start_kernel_cmd *sk = (struct start_kernel_cmd *)cmd->packet;
+	struct ert_start_kernel_cmd *sk;
+
+	sk = (struct ert_start_kernel_cmd *)cmd->packet;
 
 	/* Simply skip if it is not start CU command */
-	if (opc != OP_START_CU)
+	if (opc != ERT_START_CU)
 		return;
 	/* Use the first 4 32bits in the regmap to record CU start/end time.
 	 * To let user application know the CU start/end time.
@@ -936,10 +1062,10 @@ scu_configure_done(struct sched_cmd *cmd)
 	struct drm_device *dev = cmd->ddev;
 	struct drm_zocl_dev *zdev = dev->dev_private;
 	struct soft_kernel *sk = zdev->soft_kernel;
-	struct configure_sk_cmd *cfg;
+	struct ert_configure_sk_cmd *cfg;
 	int i;
 
-	cfg = (struct configure_sk_cmd *)(cmd->packet);
+	cfg = (struct ert_configure_sk_cmd *)(cmd->packet);
 
 	mutex_lock(&sk->sk_lock);
 
@@ -964,10 +1090,10 @@ scu_unconfig_done(struct sched_cmd *cmd)
 	struct drm_device *dev = cmd->ddev;
 	struct drm_zocl_dev *zdev = dev->dev_private;
 	struct soft_kernel *sk = zdev->soft_kernel;
-	struct unconfigure_sk_cmd *cfg;
+	struct ert_unconfigure_sk_cmd *cfg;
 	int i;
 
-	cfg = (struct unconfigure_sk_cmd *)(cmd->packet);
+	cfg = (struct ert_unconfigure_sk_cmd *)(cmd->packet);
 
 	mutex_lock(&sk->sk_lock);
 	for (i = cfg->start_cuidx; i < cfg->start_cuidx + cfg->num_cus; i++)
@@ -1039,7 +1165,7 @@ mark_cmd_complete(struct sched_cmd *cmd)
 
 	SCHED_DEBUG("-> mark_cmd_complete(,%d)\n", cmd->slot_idx);
 	zdev->exec->submitted_cmds[cmd->slot_idx] = NULL;
-	set_cmd_state(cmd, CMD_STATE_COMPLETED);
+	set_cmd_state(cmd, ERT_CMD_STATE_COMPLETED);
 	if (zdev->ert || zdev->exec->polling_mode)
 		--cmd->sched->poll;
 	release_slot_idx(cmd->ddev, cmd->slot_idx);
@@ -1113,7 +1239,7 @@ add_cmd(struct sched_cmd *cmd)
 	cmd->slot_idx = -1;
 	DRM_DEBUG("packet header 0x%08x, data 0x%08x\n",
 		  cmd->packet->header, cmd->packet->data[0]);
-	set_cmd_state(cmd, CMD_STATE_NEW);
+	set_cmd_state(cmd, ERT_CMD_STATE_NEW);
 	mutex_lock(&pending_cmds_mutex);
 	list_add_tail(&cmd->list, &pending_cmds);
 	mutex_unlock(&pending_cmds_mutex);
@@ -1142,7 +1268,7 @@ add_gem_bo_cmd(struct drm_device *dev, struct drm_zocl_bo *bo)
 {
 	struct sched_cmd *cmd;
 	struct drm_zocl_dev *zdev = dev->dev_private;
-	struct sched_packet *packet;
+	struct ert_packet *packet;
 	int ret;
 
 	cmd = get_free_sched_cmd();
@@ -1155,9 +1281,9 @@ add_gem_bo_cmd(struct drm_device *dev, struct drm_zocl_bo *bo)
 	cmd->buffer = (void *)bo;
 	cmd->exec = zdev->exec;
 	if (zdev->domain)
-		packet = (struct sched_packet *)bo->vmapping;
+		packet = (struct ert_packet *)bo->vmapping;
 	else
-		packet = (struct sched_packet *)bo->cma_base.vaddr;
+		packet = (struct ert_packet *)bo->cma_base.vaddr;
 	cmd->packet = packet;
 	cmd->cq_slot_idx = 0;
 	cmd->free_buffer = zocl_gem_object_unref;
@@ -1326,10 +1452,13 @@ configure_cu(struct sched_cmd *cmd, int cu_idx)
 {
 	u32 i, size = regmap_size(cmd);
 	u32 *virt_addr = cu_idx_to_addr(cmd->ddev, cu_idx);
-	struct start_kernel_cmd *sk = (struct start_kernel_cmd *)cmd->packet;
+	struct ert_start_kernel_cmd *sk;
 
 	SCHED_DEBUG("-> configure_cu cu_idx=%d, cu_addr=0x%p, regmap_size=%d\n",
 		    cu_idx, virt_addr, size);
+
+	sk = (struct ert_start_kernel_cmd *)cmd->packet;
+
 	/* Write register map, starting at base_address + 0x10 (byte)
 	 * This based on the fact that kernel used
 	 *	0x00 -- Control Register
@@ -1365,11 +1494,13 @@ ert_configure_cu(struct sched_cmd *cmd, int cu_idx)
 {
 	u32 i, size = regmap_size(cmd);
 	u32 *virt_addr = cu_idx_to_addr(cmd->ddev, cu_idx);
-	struct start_kernel_cmd *sk = (struct start_kernel_cmd *)cmd->packet;
+	struct ert_start_kernel_cmd *sk;
 
 	SCHED_DEBUG("-> ert_configure_cu ");
 	SCHED_DEBUG("cu_idx=%d, cu_addr=0x%p, regmap_size=%d\n",
 		    cu_idx, virt_addr, size);
+
+	sk = (struct ert_start_kernel_cmd *)cmd->packet;
 
 	for (i = 1; i < size; ++i)
 		iowrite32(*(sk->data + sk->extra_cu_masks + i), virt_addr + i);
@@ -1388,7 +1519,9 @@ ert_configure_scu(struct sched_cmd *cmd, int cu_idx)
 	struct soft_cu *scu;
 	u32 i, size = regmap_size(cmd);
 	u32 *cu_regfile;
-	struct start_kernel_cmd *skc = (struct start_kernel_cmd *)cmd->packet;
+	struct ert_start_kernel_cmd *skc;
+
+	skc = (struct ert_start_kernel_cmd *)cmd->packet;
 
 	SCHED_DEBUG("-> ert_configure_scu ");
 
@@ -1435,11 +1568,14 @@ queued_to_running(struct sched_cmd *cmd)
 	int retval = false;
 
 	SCHED_DEBUG("-> queued_to_running\n");
-	if (opcode(cmd) == OP_CONFIGURE)
+	if (opcode(cmd) == ERT_CONFIGURE)
 		configure(cmd);
 
+	if (opcode(cmd) == ERT_INIT_CU)
+		init_cus(cmd);
+
 	if (zdev->exec->ops->submit(cmd)) {
-		set_cmd_int_state(cmd, CMD_STATE_RUNNING);
+		set_cmd_int_state(cmd, ERT_CMD_STATE_RUNNING);
 		if (zdev->ert || zdev->exec->polling_mode)
 			++cmd->sched->poll;
 		zdev->exec->submitted_cmds[cmd->slot_idx] = cmd;
@@ -1503,7 +1639,7 @@ scheduler_queue_cmds(struct scheduler *sched)
 			continue;
 		list_del(&cmd->list);
 		list_add_tail(&cmd->list, &sched->cq);
-		set_cmd_int_state(cmd, CMD_STATE_QUEUED);
+		set_cmd_int_state(cmd, ERT_CMD_STATE_QUEUED);
 		atomic_dec(&num_pending);
 	}
 	mutex_unlock(&pending_cmds_mutex);
@@ -1523,11 +1659,11 @@ scheduler_iterate_cmds(struct scheduler *sched)
 	list_for_each_safe(pos, next, &sched->cq) {
 		cmd = list_entry(pos, struct sched_cmd, list);
 
-		if (cmd->state == CMD_STATE_QUEUED)
+		if (cmd->state == ERT_CMD_STATE_QUEUED)
 			queued_to_running(cmd);
-		if (cmd->state == CMD_STATE_RUNNING)
+		if (cmd->state == ERT_CMD_STATE_RUNNING)
 			running_to_complete(cmd);
-		if (cmd->state == CMD_STATE_COMPLETED)
+		if (cmd->state == ERT_CMD_STATE_COMPLETED)
 			complete_to_free(cmd);
 	}
 	SCHED_DEBUG("<- scheduler_iterate_cmds\n");
@@ -1701,11 +1837,12 @@ penguin_query(struct sched_cmd *cmd)
 	SCHED_DEBUG("-> penguin_queury() slot_idx=%d\n", cmd->slot_idx);
 	switch (opc) {
 
-	case OP_START_CU:
+	case ERT_START_CU:
 		if (!cu_done(cmd))
 			break;
 
-	case OP_CONFIGURE:
+	case ERT_INIT_CU:
+	case ERT_CONFIGURE:
 		mark_cmd_complete(cmd);
 		break;
 
@@ -1720,10 +1857,11 @@ penguin_query(struct sched_cmd *cmd)
  *
  * @cmd: command to submit
  *
- * Special processing for configure command. Configuration itself is
- * done/called by queued_to_running before calling penguin_submit. In penguin
- * mode configuration need to ensure that the command is retired properly by
- * scheduler, so assign it a slot index and let normal flow continue.
+ * Special processing for configure and init command.
+ * Configuration and initialization are done/called by queued_to_running
+ * before calling penguin_submit. In penguin mode configuration and
+ * initialization need to ensure that the commands are retired properly by
+ * scheduler, so assign them slot indexes and let normal flow continue.
  *
  * Return: %true on successful submit, %false otherwise
  */
@@ -1732,13 +1870,19 @@ penguin_submit(struct sched_cmd *cmd)
 {
 	SCHED_DEBUG("-> penguin_submit\n");
 
-	if (opcode(cmd) == OP_CONFIGURE) {
+	if (opcode(cmd) == ERT_CONFIGURE) {
 		cmd->slot_idx = acquire_slot_idx(cmd->ddev);
 		SCHED_DEBUG("<- penguin_submit (configure)\n");
 		return true;
 	}
 
-	if (opcode(cmd) != OP_START_CU)
+	if (opcode(cmd) == ERT_INIT_CU) {
+		cmd->slot_idx = acquire_slot_idx(cmd->ddev);
+		SCHED_DEBUG("<- penguin_submit (init CU)\n");
+		return true;
+	}
+
+	if (opcode(cmd) != ERT_START_CU)
 		return false;
 
 	/* extract cu list */
@@ -1785,27 +1929,27 @@ ps_ert_query(struct sched_cmd *cmd)
 	SCHED_DEBUG("-> ps_ert_queury() slot_idx=%d\n", cmd->slot_idx);
 	switch (opc) {
 
-	case OP_CONFIG_SKERNEL:
+	case ERT_SK_CONFIG:
 		if (scu_configure_done(cmd))
 			mark_cmd_complete(cmd);
 		break;
 
-	case OP_UNCONFIG_SKERNEL:
+	case ERT_SK_UNCONFIG:
 		if (scu_unconfig_done(cmd))
 			mark_cmd_complete(cmd);
 		break;
 
-	case OP_START_SKERNEL:
+	case ERT_SK_START:
 		if (scu_done(cmd))
 			mark_cmd_complete(cmd);
 		break;
 
-	case OP_START_CU:
+	case ERT_START_CU:
 		if (!cu_done(cmd))
 			break;
 		/* pass through */
 
-	case OP_CONFIGURE:
+	case ERT_CONFIGURE:
 		mark_cmd_complete(cmd);
 		break;
 
@@ -1837,11 +1981,11 @@ ps_ert_submit(struct sched_cmd *cmd)
 		return false;
 
 	switch (opcode(cmd)) {
-	case OP_CONFIGURE:
+	case ERT_CONFIGURE:
 		SCHED_DEBUG("<- ps_ert_submit (configure)\n");
 		break;
 
-	case OP_CONFIG_SKERNEL:
+	case ERT_SK_CONFIG:
 		SCHED_DEBUG("<- ps_ert_submit (configure soft kernel)\n");
 		if (configure_soft_kernel(cmd)) {
 			release_slot_idx(cmd->ddev, cmd->slot_idx);
@@ -1849,7 +1993,7 @@ ps_ert_submit(struct sched_cmd *cmd)
 		}
 		break;
 
-	case OP_UNCONFIG_SKERNEL:
+	case ERT_SK_UNCONFIG:
 		SCHED_DEBUG("<- ps_ert_submit (unconfigure soft kernel)\n");
 		if (unconfigure_soft_kernel(cmd)) {
 			release_slot_idx(cmd->ddev, cmd->slot_idx);
@@ -1857,7 +2001,7 @@ ps_ert_submit(struct sched_cmd *cmd)
 		}
 		break;
 
-	case OP_START_SKERNEL:
+	case ERT_SK_START:
 		cmd->cu_idx = get_free_cu(cmd, ZOCL_SOFT_CU);
 		if (cmd->cu_idx < 0) {
 			DRM_ERROR("Can not find free soft kernel slot.");
@@ -1873,7 +2017,7 @@ ps_ert_submit(struct sched_cmd *cmd)
 			    cmd->cu_idx, cmd->slot_idx, cmd->cq_slot_idx);
 		break;
 
-	case OP_START_CU:
+	case ERT_START_CU:
 		/* extract cu list */
 		cmd->cu_idx = get_free_cu(cmd, ZOCL_HARD_CU);
 		if (cmd->cu_idx < 0) {
@@ -1953,12 +2097,12 @@ out:
 	return ret;
 }
 
-struct sched_packet *
-get_next_packet(struct sched_packet *packet, unsigned int size)
+struct ert_packet *
+get_next_packet(struct ert_packet *packet, unsigned int size)
 {
 	char *bytes = (char *)packet;
 
-	return (struct sched_packet *)(bytes+size);
+	return (struct ert_packet *)(bytes+size);
 }
 
 void
@@ -1970,40 +2114,40 @@ zocl_cmd_buffer_free(struct sched_cmd *cmd)
 }
 
 static unsigned int
-get_packet_size(struct sched_packet *packet)
+get_packet_size(struct ert_packet *packet)
 {
 	unsigned int payload;
 
 	SCHED_DEBUG("-> get_packet_size");
 	switch (packet->opcode) {
 
-	case OP_CONFIGURE:
+	case ERT_CONFIGURE:
 		SCHED_DEBUG("configure cmd");
 		payload = 5 + packet->count;
 		break;
 
-	case OP_CONFIG_SKERNEL:
+	case ERT_SK_CONFIG:
 		SCHED_DEBUG("configure soft kernel cmd");
 		payload = packet->count;
 		break;
 
-	case OP_UNCONFIG_SKERNEL:
+	case ERT_SK_UNCONFIG:
 		SCHED_DEBUG("unconfigure soft kernel cmd");
 		payload = packet->count;
 		break;
 
-	case OP_START_SKERNEL:
+	case ERT_SK_START:
 		SCHED_DEBUG("start Soft CU/Kernel cmd");
 		payload = packet->count;
 		break;
 
-	case OP_START_CU:
+	case ERT_START_CU:
 		SCHED_DEBUG("start CU/Kernel cmd");
 		payload = packet->count;
 		break;
 
-	case OP_STOP:
-	case OP_ABORT:
+	case ERT_EXIT:
+	case ERT_ABORT:
 		SCHED_DEBUG("abort or stop cmd");
 
 	default:
@@ -2056,15 +2200,15 @@ add_ert_cq_cmd(struct drm_device *drm, void *buffer, unsigned int cq_idx)
  * Return: buffer pointer
  */
 static void*
-create_cmd_buffer(struct sched_packet *packet, unsigned slot_size)
+create_cmd_buffer(struct ert_packet *packet, unsigned slot_size)
 {
 	void *buffer;
 	size_t size;
 
-	if (packet->state != CMD_STATE_NEW)
+	if (packet->state != ERT_CMD_STATE_NEW)
 		return ERR_PTR(-EAGAIN);
 
-	packet->state = CMD_STATE_QUEUED;
+	packet->state = ERT_CMD_STATE_QUEUED;
 	SCHED_DEBUG("packet header 0x%8x, packet addr 0x%p slot size %d",
 		    packet->header, packet, slot_size);
 	buffer = kzalloc(slot_size, GFP_KERNEL);
@@ -2093,7 +2237,7 @@ iterate_packets(struct drm_device *drm)
 	struct drm_zocl_dev *zdev = drm->dev_private;
 	struct zocl_ert_dev *ert = zdev->ert;
 	struct sched_exec_core *exec_core = zdev->exec;
-	struct sched_packet *packet;
+	struct ert_packet *packet;
 	unsigned int slot_idx, num_slots, slot_sz;
 	void *buffer;
 	int ret;
@@ -2187,8 +2331,10 @@ sched_init_exec(struct drm_device *drm)
 	for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
 		exec_core->slot_status[i] = 0;
 
-	for (i = 0; i < MAX_U32_CU_MASKS; ++i)
+	for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
 		exec_core->cu_status[i] = 0;
+		exec_core->cu_init[i] = 0;
+	}
 
 	init_scheduler_thread();
 

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -1474,18 +1474,6 @@ configure_cu(struct sched_cmd *cmd, int cu_idx)
 
 	write_cu_regmap(sk->data + sk->extra_cu_masks, virt_addr, size);
 
-#if 0
-	/* Write register map, starting at base_address + 0x10 (byte)
-	 * This based on the fact that kernel used
-	 *	0x00 -- Control Register
-	 *	0x04 and 0x08 -- Interrupt Enable Registers
-	 *	0x0C -- Interrupt Status Register
-	 * Skip the first 4 words in user regmap.
-	 */
-	for (i = 4; i < size; ++i)
-		iowrite32(*(sk->data + sk->extra_cu_masks + i), virt_addr + i);
-#endif
-
 	/* Let user know which CU execute this command */
 	set_cmd_ext_cu_idx(cmd, cu_idx);
 

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.h
@@ -24,6 +24,7 @@
 #include <linux/init_task.h>
 #include <linux/list.h>
 #include <linux/wait.h>
+#include "ert.h"
 #include "zocl_drv.h"
 
 #define MAX_SLOTS 128
@@ -55,238 +56,6 @@ enum zocl_cu_type {
 
 struct sched_dev;
 struct sched_ops;
-
-/**
- * Command state
- *
- * @CMD_STATE_NEW:      Set by host before submitting a command to scheduler
- * @CMD_STATE_QUEUED:   Internal scheduler state
- * @CMD_STATE_RUNNING:  Internal scheduler state
- * @CMD_STATE_COMPLETE: Set by scheduler when command completes
- * @CMD_STATE_ERROR:    Set by scheduler if command failed
- * @CMD_STATE_ABORT:    Set by scheduler if command abort
- */
-enum cmd_state {
-	CMD_STATE_NEW = 1,
-	CMD_STATE_QUEUED = 2,
-	CMD_STATE_RUNNING = 3,
-	CMD_STATE_COMPLETED = 4,
-	CMD_STATE_ERROR = 5,
-	CMD_STATE_ABORT = 6,
-};
-
-/**
- * Opcode types for commands
- *
- * @OP_START_CU:       start a workgroup on a CU
- * @OP_START_KERNEL:   currently aliased to ERT_START_CU
- * @OP_CONFIGURE:      configure command scheduler
- * @OP_CONFIG_SKERNEL: configure soft kernel
- * @OP_START_SKERNEL:  start soft kernel
- * @OP_SK_UNCONFIG:    unconfigure a soft kernel
- */
-enum cmd_opcode {
-	OP_START_CU		= 0,
-	OP_START_KERNEL		= 0,
-	OP_CONFIGURE		= 2,
-	OP_STOP			= 3,
-	OP_ABORT		= 4,
-	OP_CONFIG_SKERNEL	= 8,
-	OP_START_SKERNEL	= 9,
-	OP_UNCONFIG_SKERNEL	= 10,
-};
-
-/**
- * struct sched_packet: scheduler generic packet format
- *
- * @state:   [3-0] current state of a command
- * @custom:  [11-4] custom per specific commands
- * @count:   [22-12] number of words in payload (data)
- * @opcode:  [27-23] opcode identifying specific command
- * @type:    [31-27] type of command (currently 0)
- * @data:    count number of words representing packet payload
- */
-struct sched_packet {
-	union {
-		struct {
-			uint32_t state:4;   /* [3-0]   */
-			uint32_t custom:8;  /* [11-4]  */
-			uint32_t count:11;  /* [22-12] */
-			uint32_t opcode:5;  /* [27-23] */
-			uint32_t type:4;    /* [31-27] */
-		};
-		uint32_t header;
-	};
-	uint32_t data[1];   /* count number of words */
-};
-
-/**
- * struct start_kernel_cmd: start kernel command format
- *
- * @state:           [3-0] current state of a command
- * @extra_cu_masks:  [11-10] extra CU masks in addition to mandatory mask
- * @count:           [22-12] number of words in payload (data)
- * @opcode:          [27-23] 0, opcode for start_kernel
- * @type:            [31-27] 0, type of start_kernel
- *
- * @cu_mask:         first mandatory CU mask
- * @data:            count number of words representing command payload
- *
- * The packet payload is comprised of 1 mandatory CU mask plus
- * extra_cu_masks per header field, followed a CU register map of size
- * (count - (1 + extra_cu_masks)) uint32_t words.
- */
-struct start_kernel_cmd {
-	union {
-		struct {
-			uint32_t state:4;          /* [3-0]   */
-			uint32_t unused:6;         /* [9-4]  */
-			uint32_t extra_cu_masks:2; /* [11-10]  */
-			uint32_t count:11;         /* [22-12] */
-			uint32_t opcode:5;         /* [27-23] */
-			uint32_t type:4;           /* [31-27] */
-		};
-		uint32_t header;
-	};
-
-	/* payload */
-	uint32_t cu_mask;          /* mandatory cu mask */
-	uint32_t data[1];          /* count-1 number of words */
-};
-
-/**
- * struct configure_cmd: configure command format
- *
- * @state:           [3-0] current state of a command
- * @count:           [22-12] number of words in payload (5 + num_cus)
- * @opcode:          [27-23] 1, opcode for configure
- * @type:            [31-27] 0, type of configure
- *
- * @slot_size:       command queue slot size
- * @num_cus:         number of compute units in program
- * @cu_shift:        shift value to convert CU idx to CU addr
- * @cu_base_addr:    base address to add to CU addr for actual physical address
- *
- * @ert:1            enable embedded HW scheduler
- * @polling:1        poll for command completion
- * @cu_dma:1         enable CUDMA custom module for HW scheduler
- * @cu_isr:1         enable CUISR custom module for HW scheduler
- * @cq_int:1         enable interrupt from host to HW scheduler
- * @unused:26
- * @dsa52:1          reserved for internal use
- *
- * @data             addresses of @num_cus_CUs
- */
-struct configure_cmd {
-	union {
-		struct {
-			uint32_t state:4;          /* [3-0]   */
-			uint32_t unused:8;         /* [11-4]  */
-			uint32_t count:11;         /* [22-12] */
-			uint32_t opcode:5;         /* [27-23] */
-			uint32_t type:4;           /* [31-27] */
-		};
-		uint32_t header;
-	};
-
-	/* payload */
-	uint32_t slot_size;
-	uint32_t num_cus;
-	uint32_t cu_shift;
-	uint32_t cu_base_addr;
-
-	/* features */
-	uint32_t ert:1;
-	uint32_t polling:1;
-	uint32_t cu_dma:1;
-	uint32_t cu_isr:1;
-	uint32_t cq_int:1;
-	uint32_t unusedf:26;
-	uint32_t dsa52:1;
-
-	/* cu addresses map size is num_cus */
-	uint32_t data[1];
-};
-
-/**
- * struct configure_sk_cmd: configure soft kernel command format
- *
- * @state:           [3-0] current state of a command
- * @count:           [22-12] number of words in payload (5 + num_cus)
- * @opcode:          [27-23] 1, opcode for configure
- * @type:            [31-27] 0, type of configure
- *
- * @start_cuidx:     start index of compute units
- * @num_cus:         number of compute units in program
- * @sk_size:         size in bytes of soft kernel image
- * @sk_name:         symbol name of soft kernel
- * @sk_addr:         soft kernel image's physical address (little endian)
- */
-struct configure_sk_cmd {
-	union {
-		struct {
-			uint32_t state:4;          /* [3-0]   */
-			uint32_t unused:8;         /* [11-4]  */
-			uint32_t count:11;         /* [22-12] */
-			uint32_t opcode:5;         /* [27-23] */
-			uint32_t type:4;           /* [31-27] */
-		};
-		uint32_t header;
-	};
-
-	/* payload */
-	uint32_t start_cuidx;
-	uint32_t num_cus;
-	uint32_t sk_size;
-	uint32_t sk_name[8];
-	uint64_t sk_addr;
-};
-
-/**
- * struct unconfigure_sk_cmd: unconfigure soft kernel command format
- *
- * @state:           [3-0] current state of a command
- * @count:           [22-12] number of words in payload (5 + num_cus)
- * @opcode:          [27-23] 1, opcode for configure
- * @type:            [31-27] 0, type of configure
- *
- * @start_cuidx:     start index of compute units
- * @num_cus:         number of compute units in program
- */
-struct unconfigure_sk_cmd {
-	union {
-		struct {
-			uint32_t state:4;          /* [3-0]   */
-			uint32_t unused:8;         /* [11-4]  */
-			uint32_t count:11;         /* [22-12] */
-			uint32_t opcode:5;         /* [27-23] */
-			uint32_t type:4;           /* [31-27] */
-		};
-		uint32_t header;
-	};
-
-	/* payload */
-	uint32_t start_cuidx;
-	uint32_t num_cus;
-};
-
-/**
- * struct abort_cmd: abort command format.
- *
- * @idx: The slot index of command to abort
- */
-struct abort_cmd {
-	union {
-		struct {
-			uint32_t state:4;          /* [3-0]   */
-			uint32_t unused:11;        /* [14-4]  */
-			uint32_t idx:8;            /* [22-15] */
-			uint32_t opcode:5;         /* [27-23] */
-			uint32_t type:4;           /* [31-27] */
-		};
-		uint32_t header;
-	};
-};
 
 struct sched_client_ctx {
 	struct list_head    link;
@@ -341,8 +110,12 @@ struct sched_exec_core {
 	u32                        slot_status[MAX_U32_SLOT_MASKS];
 	unsigned int               num_slot_masks; /* ((num_slots-1)>>5)+1 */
 
+	/* Bitmap tracks CU busy(1)/free(0) */ 
 	u32                        cu_status[MAX_U32_CU_MASKS];
 	unsigned int               num_cu_masks; /* ((num_cus-1)>>5+1 */
+
+	/* Bitmap tracks CU initialization initialized(1)/uninitialized(0) */
+	u32                        cu_init[MAX_U32_CU_MASKS];
 
 	/* Soft kernel definitions */
 	u32                        scu_status[MAX_U32_CU_MASKS];
@@ -397,7 +170,7 @@ struct sched_cmd {
 	struct drm_device *ddev;
 	struct scheduler *sched;
 	struct sched_exec_core *exec;
-	enum cmd_state state;
+	enum ert_cmd_state state;
 	int cu_idx; /* running cu, initialized to -1 */
 	int slot_idx;
 	int cq_slot_idx;
@@ -405,7 +178,7 @@ struct sched_cmd {
 	void (*free_buffer)(struct sched_cmd *xcmd);
 
 	/* The actual cmd object representation */
-	struct sched_packet *packet;
+	struct ert_packet *packet;
 };
 
 /**

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_sk.c
@@ -17,6 +17,7 @@
  * GNU General Public License for more details.
  */
 
+#include "ert.h"
 #include "zocl_drv.h"
 #include "zocl_sk.h"
 #include "sched_exec.h"
@@ -46,11 +47,11 @@ zocl_sk_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	kdata->opcode = scmd->skc_packet->opcode;
 
-	if (kdata->opcode == OP_CONFIG_SKERNEL) {
-		struct configure_sk_cmd *cmd;
+	if (kdata->opcode == ERT_SK_CONFIG) {
+		struct ert_configure_sk_cmd *cmd;
 
 		/* Copy the command to ioctl caller */
-		cmd = (struct configure_sk_cmd *)scmd->skc_packet;
+		cmd = (struct ert_configure_sk_cmd *)scmd->skc_packet;
 		kdata->start_cuidx = cmd->start_cuidx;
 		kdata->cu_nums = cmd->num_cus;
 		kdata->size = cmd->sk_size;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_sk.h
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_sk.h
@@ -54,7 +54,7 @@ struct soft_kernel {
 
 struct soft_kernel_cmd {
 	struct list_head	skc_list;
-	struct sched_packet	*skc_packet;
+	struct ert_packet	*skc_packet;
 };
 
 int zocl_init_soft_kernel(struct drm_device *drm);


### PR DESCRIPTION
1. Add support to initialize CUs on embedded platform. This is used to initiliaze CUs just once whle it is not running.
2. Eliminate duplicated ert commands definition in zocl driver