### PR TITLE
 KDMA copying requires 64 byte block size

### DIFF
--- a/src/runtime_src/driver/hw_em/generic_pcie_hal2/mbscheduler.cxx
+++ b/src/runtime_src/driver/hw_em/generic_pcie_hal2/mbscheduler.cxx
@@ -70,19 +70,19 @@ namespace xclhwemhal2 {
 
     for(unsigned i=0; i <MAX_SLOTS; ++i)
       submitted_cmds[i] = NULL;
-    
-    for (unsigned int i=0; i<MAX_CUS; ++i) 
+
+    for (unsigned int i=0; i<MAX_CUS; ++i)
     {
       cu_addr_map[i] = 0;
       cu_usage[i] = 0;
     }
-    
+
     for (unsigned int i=0; i<MAX_U32_CU_MASKS; ++i)
       cu_status[i] = 0;
-      
+
     ertfull = true;
     ertpoll = false;
-    
+
     num_slot_masks = 1;
 
     sr0 = 0;
@@ -94,7 +94,7 @@ namespace xclhwemhal2 {
   exec_core::~exec_core()
   {
   }
- 
+
   xocl_cu::xocl_cu()
   {
     idx = 0;
@@ -136,7 +136,7 @@ namespace xclhwemhal2 {
   void MBScheduler::cu_poll(struct xocl_cu *xcu)
   {
     mParent->xclRead(XCL_ADDR_KERNEL_CTRL,xcu->base + xcu->addr,(void*)&(xcu->ctrlreg),4);
-    if (xcu->run_cnt && (xcu->ctrlreg & (HwEmShim::CONTROL_AP_DONE | HwEmShim::CONTROL_AP_IDLE))) 
+    if (xcu->run_cnt && (xcu->ctrlreg & (HwEmShim::CONTROL_AP_DONE | HwEmShim::CONTROL_AP_IDLE)))
     {
       ++xcu->done_cnt;
       --xcu->run_cnt;
@@ -152,13 +152,13 @@ namespace xclhwemhal2 {
     bool bReady = xcu->dataflow ? !(xcu->ctrlreg & HwEmShim::CONTROL_AP_START) : xcu->run_cnt == 0;
     return bReady;
   }
-  
+
   static inline uint32_t* cmd_regmap(struct xocl_cmd *xcmd)
   {
     struct ert_start_kernel_cmd *ecmd = (struct ert_start_kernel_cmd *)xcmd->packet;
     return ecmd->data + ecmd->extra_cu_masks;
   }
-  
+
   void MBScheduler::cu_configure_ino(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
   {
     unsigned int size = regmap_size(xcmd);
@@ -167,21 +167,21 @@ namespace xclhwemhal2 {
 
     for (idx = 4; idx < size; ++idx)
     {
-      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcu->base + xcu->addr + (idx << 2), (void*)(regmap+idx) ,4); 
+      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcu->base + xcu->addr + (idx << 2), (void*)(regmap+idx) ,4);
     }
   }
-  
+
   void MBScheduler::cu_configure_ooo(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
   {
     unsigned int size = regmap_size(xcmd);
     uint32_t *regmap = cmd_regmap(xcmd);
     unsigned int idx;
 
-    for (idx = 4; idx < size - 1; idx += 2) 
+    for (idx = 4; idx < size - 1; idx += 2)
     {
       uint32_t offset = *(regmap + idx);
       uint32_t val = *(regmap + idx + 1);
-      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcu->base + offset , (void*)(&val) ,4); 
+      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcu->base + offset , (void*)(&val) ,4);
     }
   }
 
@@ -231,27 +231,27 @@ namespace xclhwemhal2 {
     (xcu->running_queue).pop();
     --xcu->done_cnt;
   }
-  
-  unsigned int getFirstSetBitPos(int n) 
-  { 
+
+  unsigned int getFirstSetBitPos(int n)
+  {
     if(!n)
       return -1;
-    return log2(n & -n) ; 
-  } 
+    return log2(n & -n) ;
+  }
 
-  bool isKthBitSet(int n, int k) 
-  { 
-    if (n & (1 << (k))) 
+  bool isKthBitSet(int n, int k)
+  {
+    if (n & (1 << (k)))
       return true;
     else
       return false;
-  } 
+  }
 
   bool MBScheduler::cmd_has_cu(struct xocl_cmd* xcmd, uint32_t f_cu_idx)
   {
     uint32_t mask_idx = 0;
     uint32_t num_masks = cu_masks(xcmd);
-    for (mask_idx=0; mask_idx<num_masks; ++mask_idx) 
+    for (mask_idx=0; mask_idx<num_masks; ++mask_idx)
     {
       uint32_t cmd_mask = xcmd->packet->data[mask_idx]; /* skip header */
       uint32_t cu_idx = cu_idx_from_mask (f_cu_idx, mask_idx);
@@ -263,7 +263,7 @@ namespace xclhwemhal2 {
     }
     return false;
   }
-  
+
   void cu_reset(xocl_cu* xcu, unsigned int idx, uint32_t base, uint32_t addr, uint32_t polladdr)
   {
     xcu->idx = idx;
@@ -290,7 +290,7 @@ namespace xclhwemhal2 {
     mScheduler = NULL;
     num_pending = 0;
   }
- 
+
 //KDS FLOW STARTED...
   static uint32_t cu_idx_to_addr(struct exec_core *exec,unsigned int cu_idx)
   {
@@ -306,7 +306,7 @@ namespace xclhwemhal2 {
     /* done is indicated by AP_DONE(2) alone or by AP_DONE(2) | AP_IDLE(4)
      * but not by AP_IDLE itself.  Since 0x10 | (0x10 | 0x100) = 0x110
      * checking for 0x10 is sufficient. */
-    if(mask & 2) 
+    if(mask & 2)
     {
       unsigned int mask_idx = cu_mask_idx(cu_idx);
       unsigned int pos = cu_idx_in_mask(cu_idx);
@@ -322,7 +322,7 @@ namespace xclhwemhal2 {
 
     return acquire_slot_idx(xcmd->exec);
   }
-  
+
   int MBScheduler::get_free_cu(struct xocl_cmd *xcmd)
   {
     uint32_t mask_idx=0;
@@ -331,7 +331,7 @@ namespace xclhwemhal2 {
       uint32_t cmd_mask = xcmd->packet->data[mask_idx]; /* skip header */
       uint32_t busy_mask = xcmd->exec->cu_status[mask_idx];
       int cu_idx = getFirstSetBitPos((cmd_mask | busy_mask) ^ busy_mask);
-      if (cu_idx>=0) 
+      if (cu_idx>=0)
       {
         xcmd->exec->cu_status[mask_idx] ^= 1<<cu_idx;
         return cu_idx_from_mask(cu_idx,mask_idx);
@@ -370,7 +370,7 @@ namespace xclhwemhal2 {
     /* start CU at base + 0x0 */
     int ap_start = 0x1;
     mParent->xclWrite(XCL_ADDR_KERNEL_CTRL,exec->base + cu_addr, (void*)&ap_start , 4 );
-  } 
+  }
 
 //  static unsigned int get_cu_idx(struct exec_core *exec, unsigned int cmd_idx)
 //  {
@@ -379,7 +379,7 @@ namespace xclhwemhal2 {
 //      return -1;
 //    return xcmd->cu_idx;
 //  }
-  
+
   int MBScheduler::penguin_submit(xocl_cmd* xcmd)
   {
     /* execution done by submit_cmds, ensure the cmd retired properly */
@@ -393,11 +393,11 @@ namespace xclhwemhal2 {
 
     // Find a ready CU
     struct exec_core *exec = xcmd->exec;
-    for (unsigned int cuidx = 0; cuidx < exec->num_cus; ++cuidx) 
+    for (unsigned int cuidx = 0; cuidx < exec->num_cus; ++cuidx)
     {
       xocl_cu *xcu = exec->cus[cuidx];
 
-      if (cmd_has_cu(xcmd, cuidx) && cu_ready(xcu) && cu_start(xcu, xcmd)) 
+      if (cmd_has_cu(xcmd, cuidx) && cu_ready(xcu) && cu_start(xcu, xcmd))
       {
         xcmd->slot_idx = acquire_slot(xcmd);
         if (xcmd->slot_idx<0)
@@ -430,7 +430,7 @@ namespace xclhwemhal2 {
         return;
       }
       struct xocl_cu *xcu = xcmd->exec->cus[xcmd->cu_idx];
-      if (xcu && cu_first_done(xcu) == xcmd) 
+      if (xcu && cu_first_done(xcu) == xcmd)
       {
         cu_pop_done(xcu);
         mark_cmd_complete(xcmd);
@@ -464,7 +464,7 @@ namespace xclhwemhal2 {
       do{
         mParent->xclRead(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + csr_addr, (void*)&mask, 4);
       }while(waitForResp && !mask);
-      
+
       if (mask)
       {
 #ifdef EM_DEBUG_KDS
@@ -479,7 +479,7 @@ namespace xclhwemhal2 {
   {
     unsigned int mask_idx=0, slot_idx=-1;
     uint32_t mask;
-    for (mask_idx=0; mask_idx<exec->num_slot_masks; ++mask_idx) 
+    for (mask_idx=0; mask_idx<exec->num_slot_masks; ++mask_idx)
     {
       mask = exec->slot_status[mask_idx];
       slot_idx = ffz_or_neg_one(mask);
@@ -512,18 +512,18 @@ namespace xclhwemhal2 {
     slot_addr = ERT_CQ_BASE_ADDR + xcmd->slot_idx*slot_size(xcmd->exec);
 
     /* TODO write packet minus header */
-    mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4, xcmd->packet->data,(packet_size(xcmd)-1)*sizeof(uint32_t)); 
+    mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4, xcmd->packet->data,(packet_size(xcmd)-1)*sizeof(uint32_t));
     //memcpy_toio(xcmd->exec->base + slot_addr + 4,xcmd->packet->data,(packet_size(xcmd)-1)*sizeof(uint32_t));
 
     /* TODO write header */
-    mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr, (void*)(&xcmd->packet->header) ,4); 
+    mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr, (void*)(&xcmd->packet->header) ,4);
     //iowrite32(xcmd->packet->header,xcmd->exec->base + slot_addr);
 
     /* trigger interrupt to embedded scheduler if feature is enabled */
     if (xcmd->exec->cq_interrupt) {
       uint32_t cq_int_addr = ERT_CQ_STATUS_REGISTER_ADDR + (slot_mask_idx(xcmd->slot_idx)<<2);
       uint32_t mask = 1<<slot_idx_in_mask(xcmd->slot_idx);
-      //TODO 
+      //TODO
       mParent->xclWrite(XCL_ADDR_KERNEL_CTRL,xcmd->exec->base + cq_int_addr, (void*)(&mask) ,4);
         //iowrite32(mask,xcmd->exec->base + cq_int_addr);
     }
@@ -541,7 +541,7 @@ namespace xclhwemhal2 {
 
     return mb_submit(xcmd);
   }
-  
+
   void MBScheduler::ert_poll_query_ctrl(struct xocl_cmd *xcmd)
   {
     if (opcode(xcmd) == ERT_CU_STAT)
@@ -555,7 +555,7 @@ namespace xclhwemhal2 {
   {
     return penguin_submit(xcmd);
   }
-  
+
   void MBScheduler::ert_poll_query(xocl_cmd *xcmd)
   {
     exec_core *exec = xcmd->exec;
@@ -598,7 +598,7 @@ namespace xclhwemhal2 {
     bool ert_poll = (ert && cfg->ert && cfg->dataflow);
     bool ert_full = (ert && cfg->ert && !cfg->dataflow);
 
-    if (exec->configured==0) 
+    if (exec->configured==0)
     {
       exec->base = 0;
       exec->num_slot_masks = 1;
@@ -609,7 +609,7 @@ namespace xclhwemhal2 {
       exec->num_cu_masks = ((exec->num_cus-1)>>5) + 1;
 
       unsigned int cuidx = 0;
-      for ( cuidx=0; cuidx<exec->num_cus; cuidx++) 
+      for ( cuidx=0; cuidx<exec->num_cus; cuidx++)
       {
         exec->cu_addr_map[cuidx] = cfg->data[cuidx];
         xocl_cu* nCu = new xocl_cu();
@@ -619,10 +619,10 @@ namespace xclhwemhal2 {
       }
 
       bool cdmaEnabled = false;
-      if (mParent->isCdmaEnabled()) 
+      if (mParent->isCdmaEnabled())
       {
         uint32_t addr=0;
-        for (unsigned int i = 0 ; i < 4; i++) 
+        for (unsigned int i = 0 ; i < 4; i++)
         { /* 4 is from xclfeatures.h */
           addr = mParent->getCdmaBaseAddress(i);
           if (addr)
@@ -643,7 +643,7 @@ namespace xclhwemhal2 {
         }
       }
 
-      if (ert_poll) 
+      if (ert_poll)
       {
         cfg->slot_size = ERT_CQ_SIZE / MAX_CUS;
         cfg->cu_isr = 0;
@@ -662,7 +662,7 @@ namespace xclhwemhal2 {
         exec->cq_interrupt = cfg->cq_int;
         cfg->cdma = cdmaEnabled ? 1 : 0;
       }
-      else 
+      else
       {
         exec->ertpoll = false;
         exec->ertfull = false;
@@ -742,7 +742,7 @@ namespace xclhwemhal2 {
 
     exec_core *exec = xcmd->exec;
     bool submitted  = false;
-    if(exec->ertfull) 
+    if(exec->ertfull)
     {
       submitted = mb_submit(xcmd);
     }
@@ -792,8 +792,8 @@ namespace xclhwemhal2 {
   {
     xocl_cmd* cmd = new xocl_cmd;
     return cmd;
-  } 
-  
+  }
+
   int MBScheduler::convert_execbuf(exec_core *exec, xclemulation::drm_xocl_bo *xobj, xocl_cmd* xcmd)
   {
     size_t src_off;
@@ -818,12 +818,12 @@ namespace xclhwemhal2 {
 
     dst_off = ert_copybo_dst_offset(scmd);
     xclemulation::drm_xocl_bo* dBo = mParent->xclGetBoByHandle(scmd->dst_bo_hdl);
-    
+
     if(!sBo && !dBo)
     {
       return -EINVAL;
     }
-    
+
     if(sBo)
       src_addr = sBo->base;
     if(dBo)
@@ -840,7 +840,12 @@ namespace xclhwemhal2 {
     if (exec->num_cdma == 0)
       return -EINVAL;
 
-    ert_fill_copybo_cmd(scmd, 0, 0, src_addr, dst_addr, sz);
+    if ((dst_addr + dst_off) % KDMA_BLOCK_SIZE ||
+        (src_addr + src_off) % KDMA_BLOCK_SIZE ||
+        sz % KDMA_BLOCK_SIZE)
+      return -EINVAL;
+
+    ert_fill_copybo_cmd(scmd, 0, 0, src_addr, dst_addr, sz / KDMA_BLOCK_SIZE);
 
     for (unsigned int i = exec->num_cus - exec->num_cdma; i < exec->num_cus; i++)
       scmd->cu_mask[i / 32] |= 1 << (i % 32);
@@ -873,8 +878,8 @@ namespace xclhwemhal2 {
     return ret;
   }
 
-  
-  
+
+
   int MBScheduler::scheduler_wait_condition()
   {
     bool bSchComeOutOfCond = false;
@@ -935,7 +940,7 @@ namespace xclhwemhal2 {
      //if(mScheduler->command_queue.size() > 0)
      //  std::cout<<" command_queue size is "<<mScheduler->command_queue.size()<< std::endl;
 #endif
-     for (auto itr=mScheduler->command_queue.begin(); itr!=end; ) 
+     for (auto itr=mScheduler->command_queue.begin(); itr!=end; )
      {
        xocl_cmd *xcmd = *itr;
        if (xcmd->state == ERT_CMD_STATE_QUEUED)
@@ -949,7 +954,7 @@ namespace xclhwemhal2 {
        {
          running_to_complete(xcmd);
        }
-       
+
        if (xcmd->state == ERT_CMD_STATE_COMPLETED)
        {
 #ifdef EM_DEBUG_KDS
@@ -1003,7 +1008,7 @@ namespace xclhwemhal2 {
 
     int returnStatus  =  pthread_create(&(mScheduler->scheduler_thread) , NULL, scheduler, (void *)mScheduler);
 
-    if (returnStatus != 0) 
+    if (returnStatus != 0)
     {
       std::cout << __func__ <<  " pthread_create failed " << " " << returnStatus<< std::endl;
       exit(1);
@@ -1012,7 +1017,7 @@ namespace xclhwemhal2 {
 
     return 0;
   }
-  
+
   int MBScheduler::fini_scheduler_thread(void)
   {
     if (!mScheduler->bThreadCreated)
@@ -1033,7 +1038,7 @@ namespace xclhwemhal2 {
     free_cmds.clear();
 
     return retval;
-  } 
+  }
 
   int MBScheduler::add_exec_buffer(exec_core* exec, xclemulation::drm_xocl_bo *buf)
   {

--- a/src/runtime_src/driver/include/ert.h
+++ b/src/runtime_src/driver/include/ert.h
@@ -109,7 +109,7 @@ struct ert_start_kernel_cmd {
   uint32_t data[1];          /* count-1 number of words */
 };
 
-#define COPYBO_UNIT   64     /* Limited by KDMA CU */
+#define KDMA_BLOCK_SIZE 64   /* Limited by KDMA CU */
 struct ert_start_copybo_cmd {
   uint32_t state:4;          /* [3-0], must be ERT_CMD_STATE_NEW */
   uint32_t unused:6;         /* [9-4] */
@@ -125,7 +125,7 @@ struct ert_start_copybo_cmd {
   uint32_t dst_addr_lo;      /* low 32 bit of dst addr */
   uint32_t dst_addr_hi;      /* high 32 bit of dst addr */
   uint32_t dst_bo_hdl;       /* dst bo handle, cleared by driver */
-  uint32_t size;             /* size in COPYBO_UNIT byte */
+  uint32_t size;             /* size in bytes */
   void     *arg;             /* pointer to aux data for KDS */
 };
 
@@ -488,7 +488,7 @@ ert_fill_copybo_cmd(struct ert_start_copybo_cmd *pkt, uint32_t src_bo,
   pkt->dst_addr_lo = dst_offset;
   pkt->dst_addr_hi = (dst_offset >> 32) & 0xFFFFFFFF;
   pkt->dst_bo_hdl = dst_bo;
-  pkt->size = size / COPYBO_UNIT;
+  pkt->size = size;
   pkt->arg = 0;
 }
 static inline uint64_t
@@ -504,8 +504,7 @@ ert_copybo_dst_offset(struct ert_start_copybo_cmd *pkt)
 static inline uint64_t
 ert_copybo_size(struct ert_start_copybo_cmd *pkt)
 {
-  uint64_t sz = pkt->size;
-  return sz * COPYBO_UNIT;
+  return pkt->size;
 }
 
 #endif

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -918,17 +918,21 @@ copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t ds
     auto dst_boh = dst_buffer->get_buffer_object(this);
     xdevice->fill_copy_pkt(dst_boh,src_boh,size,dst_offset,src_offset,cppkt);
 
-    cmd->start();  // done() called by scheduler on success
-    if (cmd->execute() == 0) {
+    cmd->start();    // done() called by scheduler on success
+    try {
+      cmd->execute();  // throws on error
+      XOCL_DEBUG(std::cout,"xocl::device::copy_buffer scheduled kdma copy\n");
       // Driver fills dst buffer same as migrate_buffer does, hence dst buffer
       // is resident after KDMA is done even if host does explicitly migrate.
       dst_buffer->set_resident(this);
       return;
     }
+    catch (...) {
+    }
   }
 
   // Copy via host of local buffers and no kdma and neither buffer is p2p (no shadow buffer in host)
-  if (!get_num_cdmas() && !imported && !src_buffer->is_p2p_memory() && !dst_buffer->is_p2p_memory()) {
+  if (!imported && !src_buffer->is_p2p_memory() && !dst_buffer->is_p2p_memory()) {
     // non p2p BOs then copy through host
     auto cb = [this](memory* sbuf, memory* dbuf, size_t soff, size_t doff, size_t sz,const cmd_type& c) {
       try {

--- a/src/runtime_src/xrt/scheduler/command.cpp
+++ b/src/runtime_src/xrt/scheduler/command.cpp
@@ -126,12 +126,12 @@ command::
   }
 }
 
-int
+void
 command::
 execute()
 {
   m_done=false;
-  return xrt::scheduler::schedule(get_ptr());
+  xrt::scheduler::schedule(get_ptr());
 }
 
 } // xrt

--- a/src/runtime_src/xrt/scheduler/command.h
+++ b/src/runtime_src/xrt/scheduler/command.h
@@ -179,7 +179,7 @@ public:
   /**
    * Execute this command
    */
-  int
+  void
   execute();
 
   /**

--- a/src/runtime_src/xrt/scheduler/scheduler.cpp
+++ b/src/runtime_src/xrt/scheduler/scheduler.cpp
@@ -101,13 +101,13 @@ stop()
 /**
  * Schedule a command for execution on either sws or kds
  */
-int
+void
 schedule(const command_type& cmd)
 {
   if (kds_enabled())
-    return kds::schedule(cmd);
+    kds::schedule(cmd);
   else
-    return sws::schedule(cmd);
+    sws::schedule(cmd);
 }
 
 void

--- a/src/runtime_src/xrt/scheduler/scheduler.h
+++ b/src/runtime_src/xrt/scheduler/scheduler.h
@@ -29,7 +29,7 @@ using command_type = std::shared_ptr<command>;
  */
 namespace sws {
 
-int
+void
 schedule(const command_type& cmd);
 
 void
@@ -51,7 +51,7 @@ init(xrt::device* device, const std::vector<uint64_t>& cu_addr_map);
  */
 namespace kds {
 
-int
+void
 schedule(const command_type& cmd);
 
 void
@@ -69,7 +69,7 @@ namespace scheduler {
 /**
  * Schedule a command for execution on either sws or mbs
  */
-int
+void
 schedule(const command_type& cmd);
 
 void

--- a/src/runtime_src/xrt/scheduler/sws.cpp
+++ b/src/runtime_src/xrt/scheduler/sws.cpp
@@ -806,7 +806,7 @@ scheduler_loop()
 
 namespace xrt { namespace sws {
 
-int
+void
 schedule(const cmd_ptr& cmd)
 {
   auto device = cmd->get_device();
@@ -819,7 +819,6 @@ schedule(const cmd_ptr& cmd)
   s_pending_cmds.push_back(xcmd);
   ++s_num_pending;
   scheduler->notify();
-  return 0;
 }
 
 void

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -52,11 +52,11 @@ command(xrt_device* device, ert_cmd_opcode opcode)
   : m_impl(std::make_shared<impl>(static_cast<xrt::device*>(device),opcode))
 {}
 
-int
+void
 command::
 execute()
 {
-  return m_impl->execute();
+  m_impl->execute();
 }
 
 void

--- a/src/runtime_src/xrt/xrt++/xrtexec.hpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.hpp
@@ -63,7 +63,12 @@ protected:
   command(xrt_device* dev, ert_cmd_opcode opcode);
 
 public:
-  int
+  /**
+   * Execute a command
+   *
+   * Throws on error
+   */
+  void
   execute();
 
   void


### PR DESCRIPTION
Don't use KDMA if src or dst offset or total copy size is not a
multiple of 64 bytes.

This PR also reverts a mistake made in PR #1307 where exec_buf in C++
land was changed to return a code.  XRT C++ error handling is via
exceptions and exec_buf indeed throws at a lower level thus never
returns error code.

The complication in this PR was primarily due to kds.cpp where cmds
are added to submitted (monitor) list before they are successfully
submitted via exec_buf.  If exec_buf throws, then these unsubmitted
commands must be removed again.  Unfortunately this seemingly reverse
order cannot be avoided (code comment explains why), but is kosher
because exec_buf throwing is really on the error path, e.g. not on a
critical success path.

CR: 1030607