### PR TITLE
update port map for STM rev16.

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_regs.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_regs.h
@@ -669,7 +669,7 @@ struct qdma_c2h_cmpt_cmpl_status {
 #define STM_SUPPORTED_REV_MIN		0x4
 #define	STM_MAX_SUPPORTED_QID		64
 #define STM_MAX_PKT_SIZE		4096
-#define STM_PORT_MAP			0xE1E1
+#define STM_PORT_MAP			0xE4E4
 #define IS_STM_ENABLED_DEVICE(pdev)     \
 	(((pdev)->device == 0x6aa0) || ((pdev)->device == 0x5011))
 


### PR DESCRIPTION
STM is upgraded v15->v16. The portmap needs to be changed for STM v16. The platform is already submitted.