### PR TITLE
Dataflow (AP_CTRL_CHAIN) now polls AP_DONE only

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -676,6 +676,7 @@ struct xocl_cu {
 	void __iomem       *base;
 	u32                addr;
 	u32                polladdr;
+	u32                ap_check;
 
 	u32                ctrlreg;
 	unsigned int       done_cnt;
@@ -692,6 +693,7 @@ cu_reset(struct xocl_cu *xcu, unsigned int idx, void __iomem *base, u32 addr, u3
 	xcu->base = base;
 	xcu->addr = addr & ~(0xFF); // clear encoded handshake
 	xcu->polladdr = polladdr;
+	xcu->ap_check = (xcu->control == AP_CTRL_CHAIN) ? (AP_DONE) : (AP_DONE | AP_IDLE);
 	xcu->ctrlreg = 0;
 	xcu->done_cnt = 0;
 	xcu->run_cnt = 0;
@@ -790,7 +792,7 @@ cu_poll(struct xocl_cu *xcu)
 
 	SCHED_DEBUGF("+ ctrlreg(0x%x)\n", xcu->ctrlreg);
 
-	if (xcu->run_cnt && (xcu->ctrlreg & (AP_DONE|AP_IDLE))) {
+	if (xcu->run_cnt && (xcu->ctrlreg & xcu->ap_check)) {
 		++xcu->done_cnt; // assert done_cnt <= |running_queue|
 		--xcu->run_cnt;
 		cu_continue(xcu);

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -1135,7 +1135,7 @@ scheduler_loop()
           continue; // CU is not used
 
         auto cuvalue = read_reg(cu_idx_to_addr(cuidx));
-        if (!(cuvalue & (AP_DONE | AP_IDLE)))
+        if (!(cuvalue & AP_DONE))
           continue;
 
         cu_status.toggle(cuidx); // disable polling until host re-enables


### PR DESCRIPTION
This under the assumption that AP_DONE remains asserted until
AP_CONTINUE is sent to acknowledge AP_DONE.

(cherry picked from commit 698a9054f46da7b9a5d28a4bfeb35f387aca64ac)