### PR TITLE
 Message when DKMS fails to install XRT kernel modules

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -36,4 +36,13 @@ if [ $? -eq 0 ]; then
     udevadm trigger
 fi
 
+if [ -z "`dkms status -m xrt -v @XRT_VERSION_STRING@ |grep installed`" ]; then
+    echo "****************************************************************"
+    echo "* DKMS failed to install drivers."
+    echo "* Please check if kernel development headers are installed for OS variant used."
+    echo "* "
+    echo "* Check build logs in /var/lib/dkms/xrt/@XRT_VERSION_STRING@"
+    echo "****************************************************************"
+fi
+
 exit 0


### PR DESCRIPTION
The XRT packages cannot add a dependency on kernel development
headers, the user has to install these manually.