### PR TITLE
Fix unexpected died KDS command monitor

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -459,7 +459,11 @@ exec_wait(int timeout_ms) const
 {
   auto retval = m_ops->mExecWait(m_handle,timeout_ms);
   if (retval==-1)
-    throw std::runtime_error(std::string("exec wait failed '") + std::strerror(errno) + "'");
+    // We should not treat interrupted syscall as an error
+    if (errno == EINTR)
+      retval = 0;
+    else
+      throw std::runtime_error(std::string("exec wait failed '") + std::strerror(errno) + "'");
   return retval;
 }
 

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -458,12 +458,13 @@ device::
 exec_wait(int timeout_ms) const
 {
   auto retval = m_ops->mExecWait(m_handle,timeout_ms);
-  if (retval==-1)
+  if (retval==-1) {
     // We should not treat interrupted syscall as an error
     if (errno == EINTR)
       retval = 0;
     else
       throw std::runtime_error(std::string("exec wait failed '") + std::strerror(errno) + "'");
+  }
   return retval;
 }
 


### PR DESCRIPTION
When poll() is interrupted by SIGNAL, we should not treat it as an error. We should just return 0 so that we can restart the poll.