### PR TITLE
Different HP ports can connect to same memory bank

### DIFF
--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -423,6 +423,13 @@ size_t
 kernel::
 validate_cus(const device* device, unsigned long argidx, int memidx) const
 {
+#if defined(__arm__)
+  // embedded platforms can have different HP ports connected to same memory bank
+  auto name = device->get_name();
+  if (name.find("_xdma_") == std::string::npos && name.find("_qdma_") == std::string::npos)
+    return m_cus.size();
+#endif
+
   XOCL_DEBUG(std::cout,"xocl::kernel::validate_cus(",argidx,",",memidx,")\n");
   xclbin::memidx_bitmask_type connections;
   connections.set(memidx);


### PR DESCRIPTION
Don't treat all HP ports as separate memory banks.  Disable the CU
trimming from kernels.  Re-work in 2019.2 to determine when ports are
connected to same memory bank.

CR: 1030777
(cherry picked from commit f1b6fdd22336b60b9a8505da2f60609564126b7e)