### PR TITLE
Suppress depmod info messages 

### DIFF
--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -9,7 +9,11 @@ if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
     find /lib/modules -type f -name awsmgmt.ko -delete
     find /lib/modules -type f -name awsmgmt.ko.kz -delete
     find /lib/modules -type f -name awsmgmt.ko.xz -delete
-    depmod -A
+    depmod -A > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: 'depmod -A' failed."
+    fi
+
 fi
 
 echo "Invoking xrt-aws common.postinst"

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -13,7 +13,10 @@ if [ -n "`dkms status -m xrt -v @XRT_VERSION_STRING@`" ]; then
     find /lib/modules -type f -name xclmgmt.ko.kz -delete
     find /lib/modules -type f -name xocl.ko.xz -delete
     find /lib/modules -type f -name xclmgmt.ko.xz -delete
-    depmod -A
+    depmod -A > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: 'depmod -A' failed."
+    fi
 fi
 
 DRACUT_CONF_PATH=/etc/dracut.conf.d

--- a/src/CMake/config/prerm-aws.in
+++ b/src/CMake/config/prerm-aws.in
@@ -7,7 +7,11 @@ echo "Unregistering XRT Linux kernel module sources @XRT_VERSION_STRING@ from dk
 dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
 find /lib/modules -type f -name awsmgmt.ko -delete
 find /lib/modules -type f -name awsmgmt.ko.kz -delete
-depmod -A
+depmod -A > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: 'depmod -A' failed."
+fi
+
 
 rm -f /etc/udev/rules.d/10-awsmgmt.rules
 

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -18,7 +18,10 @@ find /lib/modules -type f -name xocl.ko.kz -delete
 find /lib/modules -type f -name xclmgmt.ko.kz -delete
 find /lib/modules -type f -name xocl.ko.xz -delete
 find /lib/modules -type f -name xclmgmt.ko.xz -delete
-depmod -A
+depmod -A > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: 'depmod -A' failed."
+fi
 
 rm -f /etc/udev/rules.d/10-xocl.rules
 rm -f /etc/udev/rules.d/10-xclmgmt.rules

--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/Makefile
@@ -58,7 +58,7 @@ all:
 
 install: all
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
-	depmod -a
+	@depmod -a || (echo "Error: 'depmod -a' failed.")
 	install -m 644 10-xclmgmt.rules /etc/udev/rules.d
 	-rmmod -s xclmgmt || true
 	-modprobe xclmgmt

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/Makefile
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/Makefile
@@ -56,7 +56,7 @@ all:
 
 install: all
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules_install
-	depmod -a
+	@depmod -a || (echo "Error: 'depmod -a' failed.")
 	install -m 644 10-xocl.rules /etc/udev/rules.d
 	-rmmod -s xocl || true
 	-rmmod -s xdma || true


### PR DESCRIPTION
Weak dependencies cause info messages with "ERROR" in them, but they are not true failures for depmod. Suppressing the output unless the command fails. Addresses JIRA CR-1031286.