### PR TITLE
Compilation on Debian

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -109,7 +109,7 @@ UB_LIST=(\
      libyaml-dev \
      linux-libc-dev \
      lm-sensors \
-     lsb \
+     lsb-release \
      make \
      ocl-icd-dev \
      ocl-icd-libopencl1 \

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -140,7 +140,7 @@ SUDO=${SUDO:-sudo}
 
 #dmidecode is only applicable for x86_64
 if [ $ARCH == "x86_64" ]; then
-    if [ $FLAVOR == "ubuntu" ]; then
+    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
 	UB_LIST+=( dmidecode )
     fi
     if [ $FLAVOR == "centos" ] || [ $FLAVOR == "rhel" ] ; then
@@ -150,7 +150,7 @@ fi
 
 validate()
 {
-    if [ $FLAVOR == "ubuntu" ]; then
+    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
         #apt -qq list "${UB_LIST[@]}"
         dpkg -l "${UB_LIST[@]}" > /dev/null
         if [ $? == 0 ] ; then
@@ -170,8 +170,8 @@ validate()
 
 install()
 {
-    if [ $FLAVOR == "ubuntu" ]; then
-        echo "Installing Ubuntu packages..."
+    if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
+        echo "Installing packages..."
         ${SUDO} apt install -y "${UB_LIST[@]}"
     fi
 


### PR DESCRIPTION
Add compilation support for the runtime on Debian, or more accurately fixes the prerequisite package installation/verification script so it can compile.
It fixes also an Ubuntu package bug.
I was able to compile the runtime on `Debian/unstable` amd64.
It fails on Linux kernel driver compilation, but I think this is another story, related to https://github.com/Xilinx/XRT/issues/1136 and the fact I run Linux `4.19.0-5-amd64`.
I have no idea about which branch I am supposed to merge this too. Is this documented somewhere?

This is a request from Sergei Storojev for a customer.