### PR TITLE
Fix block in/unindent error

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mailbox.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mailbox.c
@@ -94,9 +94,11 @@
  *
  * At the highest layer, the driver implements a request-response communication
  * model. Three types of msgs can be sent/received in this model:
- *   - A request msg which requires a response.
- *   - A notification msg which does not require a response.
- *   - A response msg which is used to respond a request.
+ *
+ * - A request msg which requires a response.
+ * - A notification msg which does not require a response.
+ * - A response msg which is used to respond a request.
+ *
  * The OP code of the request determines whether it's a request or notification.
  *
  * If provided, a response msg must match a request msg by msg ID, or it'll be


### PR DESCRIPTION
23:08:50 [xrt-ubuntu16.04] pickling environment... core/mailbox.rst:82: ERROR: Unexpected indentation.
23:08:50 [xrt-ubuntu16.04] core/mailbox.rst:85: WARNING: Block quote ends without a blank line; unexpected unindent.