### PR TITLE
Suppress benign messages if command returns successful (weak-modules)

### DIFF
--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -22,15 +22,9 @@ echo "Invoking xrt-aws common.postinst"
 #that prints benign 'Error' messages. These are not truly errors, so (for RHEL/CentOS)
 #we are capturing them in the 'res' variable, and only displaying them if the
 #command returns non-zero.
-if [ -f /etc/lsb-release ]; then #Ubuntu
-    /usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
-else #RHEL/CentOS
-    res=$("(/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2)" 2>&1)
-fi
+res=$(/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ '' '' $2)
 if [ $? -ne 0 ]; then
-    if [ -e res ]; then
-        echo "Error: common.postinst: $res"
-    fi
+    echo "Error: $res"
 else
     echo "Finished xrt-aws common.postinst"
     install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/kernel/mgmt/10-awsmgmt.rules /etc/udev/rules.d

--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -4,22 +4,24 @@ if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
     modprobe -r awsmgmt
 
     echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-    dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+    res=$(dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all)
     if [ $? -ne 0 ]; then
-        echo "Error: 'dkms remove -m xrt-aws' failed"
+        echo "Error: dkms: $res"
     fi
     find /lib/modules -type f -name awsmgmt.ko -delete
     find /lib/modules -type f -name awsmgmt.ko.kz -delete
     find /lib/modules -type f -name awsmgmt.ko.xz -delete
-    depmod -A > /dev/null 2>&1
+    res=$(depmod -A)
     if [ $? -ne 0 ]; then
-        echo "Error: 'depmod -A' failed"
+        echo "Error: depmod: $res"
     fi
 fi
 
+res=$((/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2) 2>&1)
 echo "Invoking xrt-aws common.postinst"
-/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2 > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+if [ $? -ne 0 ]; then
+    echo "Error: common.postinst: $res"
+else
     echo "Finished xrt-aws common.postinst"
     install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/kernel/mgmt/10-awsmgmt.rules /etc/udev/rules.d
 

--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -1,19 +1,24 @@
 #!/bin/sh
-
 if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
     echo "Unloading old XRT Linux kernel modules"
     modprobe -r awsmgmt
 
     echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-    dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
+    dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: 'dkms remove -m xrt-aws' failed"
+    fi
     find /lib/modules -type f -name awsmgmt.ko -delete
     find /lib/modules -type f -name awsmgmt.ko.kz -delete
     find /lib/modules -type f -name awsmgmt.ko.xz -delete
-    depmod -A
+    depmod -A > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: 'depmod -A' failed"
+    fi
 fi
 
 echo "Invoking xrt-aws common.postinst"
-/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
+/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2 > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     echo "Finished xrt-aws common.postinst"
     install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/kernel/mgmt/10-awsmgmt.rules /etc/udev/rules.d

--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -19,7 +19,7 @@ fi
 
 echo "Invoking xrt-aws common.postinst"
 #DKMS common.postinst behaves differently on RHEL/CentOS due to 'weak-modules' feature
-#that prints benign 'Error' messages. These are not truly errors, so (for RHEL/CentOS)
+#that prints benign 'Error' messages. These are not truly errors, so
 #we are capturing them in the 'res' variable, and only displaying them if the
 #command returns non-zero.
 res=$(/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ '' '' $2)

--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -18,9 +18,13 @@ if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
 fi
 
 echo "Invoking xrt-aws common.postinst"
-if [ -f /etc/lsb-release ]; then
+#DKMS common.postinst behaves differently on RHEL/CentOS due to 'weak-modules' feature
+#that prints benign 'Error' messages. These are not truly errors, so (for RHEL/CentOS)
+#we are capturing them in the 'res' variable, and only displaying them if the
+#command returns non-zero.
+if [ -f /etc/lsb-release ]; then #Ubuntu
     /usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
-else
+else #RHEL/CentOS
     res=$("(/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2)" 2>&1)
 fi
 if [ $? -ne 0 ]; then

--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -17,10 +17,16 @@ if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
     fi
 fi
 
-res=$((/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2) 2>&1)
 echo "Invoking xrt-aws common.postinst"
+if [ -f /etc/lsb-release ]; then
+    /usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
+else
+    res=$("(/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2)" 2>&1)
+fi
 if [ $? -ne 0 ]; then
-    echo "Error: common.postinst: $res"
+    if [ -e res ]; then
+        echo "Error: common.postinst: $res"
+    fi
 else
     echo "Finished xrt-aws common.postinst"
     install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/kernel/mgmt/10-awsmgmt.rules /etc/udev/rules.d

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -6,14 +6,20 @@ if [ -n "`dkms status -m xrt -v @XRT_VERSION_STRING@`" ]; then
     modprobe -r xclmgmt
 
     echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-    dkms remove -m xrt -v @XRT_VERSION_STRING@ --all
+    dkms remove -m xrt -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: 'dkms remove -m xrt' failed"
+    fi
     find /lib/modules -type f -name xocl.ko -delete
     find /lib/modules -type f -name xclmgmt.ko -delete
     find /lib/modules -type f -name xocl.ko.kz -delete
     find /lib/modules -type f -name xclmgmt.ko.kz -delete
     find /lib/modules -type f -name xocl.ko.xz -delete
     find /lib/modules -type f -name xclmgmt.ko.xz -delete
-    depmod -A
+    depmod -A > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: 'depmod -A' failed"
+    fi
 fi
 
 DRACUT_CONF_PATH=/etc/dracut.conf.d
@@ -23,7 +29,7 @@ if [ -e $DRACUT_CONF_PATH ]; then
 fi
 
 echo "Invoking DKMS common.postinst for xrt"
-/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2
+/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2 > /dev/null 2>&1
 if [ $? -eq 0 ]; then
     echo "Finished DKMS common.postinst"
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/10-xocl.rules /etc/udev/rules.d

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -29,9 +29,15 @@ if [ -e $DRACUT_CONF_PATH ]; then
 fi
 
 echo "Invoking DKMS common.postinst for xrt"
-res=$((/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2) 2>&1)
+if [ -f /etc/lsb-release ]; then
+    /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2
+else
+    res=$("( /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2 )" 2>&1 )
+fi
 if [ $? -ne 0 ]; then
-    echo "Error: common.postinst: $res"
+    if [ -e res ]; then
+        echo "Error: common.postinst: $res"
+    fi
 else
     echo "Finished DKMS common.postinst"
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/10-xocl.rules /etc/udev/rules.d

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -33,15 +33,9 @@ echo "Invoking DKMS common.postinst for xrt"
 #that prints benign 'Error' messages. These are not truly errors, so (for RHEL/CentOS)
 #we are capturing them in the 'res' variable, and only displaying them if the 
 #command returns non-zero.
-if [ -f /etc/lsb-release ]; then #Ubuntu
-    /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2
-else #RHEL/CentOS
-    res=$("( /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2 )" 2>&1 )
-fi
+res=$(/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ '' '' $2)
 if [ $? -ne 0 ]; then
-    if [ -e res ]; then
-        echo "Error: common.postinst: $res"
-    fi
+    echo "Error: $res"
 else
     echo "Finished DKMS common.postinst"
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/10-xocl.rules /etc/udev/rules.d

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -6,9 +6,9 @@ if [ -n "`dkms status -m xrt -v @XRT_VERSION_STRING@`" ]; then
     modprobe -r xclmgmt
 
     echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-    dkms remove -m xrt -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+    res=$(dkms remove -m xrt -v @XRT_VERSION_STRING@ --all)
     if [ $? -ne 0 ]; then
-        echo "Error: 'dkms remove -m xrt' failed"
+        echo "Error: dkms: $res"
     fi
     find /lib/modules -type f -name xocl.ko -delete
     find /lib/modules -type f -name xclmgmt.ko -delete
@@ -16,9 +16,9 @@ if [ -n "`dkms status -m xrt -v @XRT_VERSION_STRING@`" ]; then
     find /lib/modules -type f -name xclmgmt.ko.kz -delete
     find /lib/modules -type f -name xocl.ko.xz -delete
     find /lib/modules -type f -name xclmgmt.ko.xz -delete
-    depmod -A > /dev/null 2>&1
+    res=$(depmod -A)
     if [ $? -ne 0 ]; then
-        echo "Error: 'depmod -A' failed"
+        echo "Error: depmod: $res"
     fi
 fi
 
@@ -29,8 +29,10 @@ if [ -e $DRACUT_CONF_PATH ]; then
 fi
 
 echo "Invoking DKMS common.postinst for xrt"
-/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2 > /dev/null 2>&1
-if [ $? -eq 0 ]; then
+res=$((/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2) 2>&1)
+if [ $? -ne 0 ]; then
+    echo "Error: common.postinst: $res"
+else
     echo "Finished DKMS common.postinst"
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/userpf/10-xocl.rules /etc/udev/rules.d
     install -m 644 /usr/src/xrt-@XRT_VERSION_STRING@/driver/xclng/drm/xocl/mgmtpf/10-xclmgmt.rules /etc/udev/rules.d
@@ -41,6 +43,7 @@ if [ $? -eq 0 ]; then
     modprobe xocl
     udevadm trigger
 fi
+
 
 if [ -z "`dkms status -m xrt -v @XRT_VERSION_STRING@ |grep installed`" ]; then
     echo "****************************************************************"

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -30,7 +30,7 @@ fi
 
 echo "Invoking DKMS common.postinst for xrt"
 #DKMS common.postinst behaves differently on RHEL/CentOS due to 'weak-modules' feature
-#that prints benign 'Error' messages. These are not truly errors, so (for RHEL/CentOS)
+#that prints benign 'Error' messages. These are not truly errors, so
 #we are capturing them in the 'res' variable, and only displaying them if the 
 #command returns non-zero.
 res=$(/usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ '' '' $2)

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -29,9 +29,13 @@ if [ -e $DRACUT_CONF_PATH ]; then
 fi
 
 echo "Invoking DKMS common.postinst for xrt"
-if [ -f /etc/lsb-release ]; then
+#DKMS common.postinst behaves differently on RHEL/CentOS due to 'weak-modules' feature
+#that prints benign 'Error' messages. These are not truly errors, so (for RHEL/CentOS)
+#we are capturing them in the 'res' variable, and only displaying them if the 
+#command returns non-zero.
+if [ -f /etc/lsb-release ]; then #Ubuntu
     /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2
-else
+else #RHEL/CentOS
     res=$("( /usr/lib/dkms/common.postinst xrt @XRT_VERSION_STRING@ "" "" $2 )" 2>&1 )
 fi
 if [ $? -ne 0 ]; then
@@ -49,7 +53,6 @@ else
     modprobe xocl
     udevadm trigger
 fi
-
 
 if [ -z "`dkms status -m xrt -v @XRT_VERSION_STRING@ |grep installed`" ]; then
     echo "****************************************************************"

--- a/src/CMake/config/prerm-aws.in
+++ b/src/CMake/config/prerm-aws.in
@@ -4,15 +4,15 @@ echo "Unloading old AWS Linux kernel modules"
 modprobe -r awsmgmt
 
 echo "Unregistering AWS Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+res=$(dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all)
 if [ $? -ne 0 ]; then
-    echo "Error: 'dkms remove of xrt-aws' failed"
+    echo "Error: dkms: $res"
 fi
 find /lib/modules -type f -name awsmgmt.ko -delete
 find /lib/modules -type f -name awsmgmt.ko.kz -delete
-depmod -A > /dev/null 2>&1
+res=$(depmod -A)
 if [ $? -ne 0 ]; then
-    echo "Error: 'depmod -A' failed"
+    echo "Error: depmod: $res"
 fi
 
 rm -f /etc/udev/rules.d/10-awsmgmt.rules

--- a/src/CMake/config/prerm-aws.in
+++ b/src/CMake/config/prerm-aws.in
@@ -4,10 +4,16 @@ echo "Unloading old AWS Linux kernel modules"
 modprobe -r awsmgmt
 
 echo "Unregistering AWS Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
+dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: 'dkms remove of xrt-aws' failed"
+fi
 find /lib/modules -type f -name awsmgmt.ko -delete
 find /lib/modules -type f -name awsmgmt.ko.kz -delete
-depmod -A
+depmod -A > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: 'depmod -A' failed"
+fi
 
 rm -f /etc/udev/rules.d/10-awsmgmt.rules
 

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -11,9 +11,9 @@ modprobe -r xocl
 modprobe -r xclmgmt
 
 echo "Unregistering XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-dkms remove -m xrt -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+res=$(dkms remove -m xrt -v @XRT_VERSION_STRING@ --all)
 if [ $? -ne 0 ]; then
-    echo "Error: 'dkms remove -m xrt' failed"
+    echo "Error: dkms: $res"
 fi
 find /lib/modules -type f -name xocl.ko -delete
 find /lib/modules -type f -name xclmgmt.ko -delete
@@ -21,9 +21,9 @@ find /lib/modules -type f -name xocl.ko.kz -delete
 find /lib/modules -type f -name xclmgmt.ko.kz -delete
 find /lib/modules -type f -name xocl.ko.xz -delete
 find /lib/modules -type f -name xclmgmt.ko.xz -delete
-depmod -A > /dev/null 2>&1
+res=$(depmod -A)
 if [ $? -ne 0 ]; then
-    echo "Error: 'depmod -A' failed"
+    echo "Error: depmod: $res"
 fi
 
 rm -f /etc/udev/rules.d/10-xocl.rules

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -11,14 +11,20 @@ modprobe -r xocl
 modprobe -r xclmgmt
 
 echo "Unregistering XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-dkms remove -m xrt -v @XRT_VERSION_STRING@ --all
+dkms remove -m xrt -v @XRT_VERSION_STRING@ --all > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: 'dkms remove -m xrt' failed"
+fi
 find /lib/modules -type f -name xocl.ko -delete
 find /lib/modules -type f -name xclmgmt.ko -delete
 find /lib/modules -type f -name xocl.ko.kz -delete
 find /lib/modules -type f -name xclmgmt.ko.kz -delete
 find /lib/modules -type f -name xocl.ko.xz -delete
 find /lib/modules -type f -name xclmgmt.ko.xz -delete
-depmod -A
+depmod -A > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: 'depmod -A' failed"
+fi
 
 rm -f /etc/udev/rules.d/10-xocl.rules
 rm -f /etc/udev/rules.d/10-xclmgmt.rules


### PR DESCRIPTION
RHEL/CentOS 'weak-modules' feature produces benign 'Error' messages from depmod and dkms. Instead of printing these to stdout, we are capturing them in a variable and only displaying if the call returns non-zero. This avoids confusion of seeing 'Error' when it is actually benign. 

Addresses JIRA CR-1031286