### PR TITLE
Pyopencl install

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -173,7 +173,7 @@ validate()
 install()
 {
     if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
-        echo "Installing packages..."
+        echo "Installing packages..."``
         ${SUDO} apt install -y "${UB_LIST[@]}"
         ${SUDO} -H pip install pyopencl
     fi

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -78,6 +78,7 @@ RH_LIST=(\
      protobuf-compiler \
      protobuf-static \
      python \
+     python-pip \
      redhat-lsb \
      rpm-build \
      strace \
@@ -120,6 +121,7 @@ UB_LIST=(\
      pciutils \
      pkg-config \
      protobuf-compiler \
+     python-pip \
      python3-sphinx \
      python3-sphinx-rtd-theme \
      sphinx-common \
@@ -173,6 +175,7 @@ install()
     if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
         echo "Installing packages..."
         ${SUDO} apt install -y "${UB_LIST[@]}"
+        ${SUDO} -H pip install pyopencl
     fi
 
     # Enable EPEL on CentOS/RHEL
@@ -203,6 +206,8 @@ install()
         echo "Installing RHEL/CentOS packages..."
         ${SUDO} yum install -y "${RH_LIST[@]}"
         ${SUDO} yum install -y devtoolset-6
+        ${SUDO} -H pip install pyopencl
+        ${SUDO} pip install --ignore-installed numpy==1.8
     fi
 }
 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -173,8 +173,9 @@ validate()
 install()
 {
     if [ $FLAVOR == "ubuntu" ] || [ $FLAVOR == "debian" ]; then
-        echo "Installing packages..."``
+        echo "Installing packages..."
         ${SUDO} apt install -y "${UB_LIST[@]}"
+        ${SUDO} -H pip install --upgrade setuptools 
         ${SUDO} -H pip install pyopencl
     fi
 

--- a/tests/pyopencl_example.py
+++ b/tests/pyopencl_example.py
@@ -28,5 +28,8 @@ if platform_ID is None:
 devices = platforms[platform_ID].get_devices()
 print("\n%d devices were found" %len(devices))
 print(devices)
+ 
 
-ctx = 
+
+
+

--- a/tests/pyopencl_example.py
+++ b/tests/pyopencl_example.py
@@ -7,7 +7,7 @@ print("List all available platforms:")
 platforms = cl.get_platforms()
 print(platforms)
 
-
+# get Xilinx platform 
 
 for i in platforms:
     if i.name == "Xilinx":
@@ -18,10 +18,15 @@ for i in platforms:
         print(platforms[platform_ID].profile)
         print(platforms[platform_ID].extensions)
         break
+
 if platform_ID is None:
     print("ERROR: Plaform not found")
     sys.exit()
 
+# get all devices
 
 devices = platforms[platform_ID].get_devices()
+print("\n%d devices were found" %len(devices))
 print(devices)
+
+ctx = 

--- a/tests/xclexample.py
+++ b/tests/xclexample.py
@@ -1,0 +1,27 @@
+import pyopencl as cl
+import sys
+
+platform_ID = None
+
+print("List all available platforms:")
+platforms = cl.get_platforms()
+print(platforms)
+
+
+
+for i in platforms:
+    if i.name == "Xilinx":
+        platform_ID = platforms.index(i)
+        print("\nPlatform Information:")
+        print(platforms[platform_ID].name)
+        print(platforms[platform_ID].version)
+        print(platforms[platform_ID].profile)
+        print(platforms[platform_ID].extensions)
+        break
+if platform_ID is None:
+    print("ERROR: Plaform not found")
+    sys.exit()
+
+
+devices = platforms[platform_ID].get_devices()
+print(devices)


### PR DESCRIPTION
- Added pyopencl installation to xrtdeps.sh
- Example to discover Xilinx platform and devices on the platform
- Tested on Ubuntu 16.04, 18.04 and centOS 7.6

Output:
```
List all available platforms:
[<pyopencl.Platform 'Oclgrind' at 0x1fd3330>, <pyopencl.Platform 'Portable Computing Language' at 0x7ff227dc2320>, <pyopencl.Platform 'Xilinx' at 0x1fd2888>]

Platform Information:
Xilinx
OpenCL 1.0
EMBEDDED_PROFILE
cl_khr_icd

1 devices were found
[<pyopencl.Device 'xilinx_vcu1525_xdma_201830_1' on 'Xilinx' at 0x1fd4420>]
```
