### PR TITLE
skd: Re-use file path from first cu

### DIFF
--- a/src/runtime_src/driver/zynq/skd/sk_daemon.cpp
+++ b/src/runtime_src/driver/zynq/skd/sk_daemon.cpp
@@ -290,7 +290,7 @@ void configSoftKernel(xclSKCmd *cmd)
     if (pid == 0) {
       char path[XRT_MAX_PATH_LENGTH];
 
-      getSoftKernelPathName(i, path);
+      getSoftKernelPathName(cmd->start_cuidx, path);
 
       /* Start the soft kenel loop for each CU. */
       softKernelLoop(cmd->krnl_name, path, i);


### PR DESCRIPTION
This fix re-uses the file path that was created when dealing with the first instance of the soft kernel and re-using it when num_cus is more than one.

Signed-off-by: Rohit Athavale <rathaval@xilinx.com>