### PR TITLE
XMA changes for DDR mapping to support HBM and xclbins with more kernels (2018.3)

### DIFF
--- a/src/xma/include/lib/xmalimits.h
+++ b/src/xma/include/lib/xmalimits.h
@@ -19,10 +19,10 @@
 
 #define MAX_SCALER_OUTPUTS       8
 #define MAX_FILTER_OUTPUTS      MAX_SCALER_OUTPUTS
-#define MAX_DDR_MAP             16
+#define MAX_DDR_MAP             64
 #define MAX_XILINX_DEVICES      16
 #define MAX_XILINX_KERNELS      60
-#define MAX_KERNEL_CONFIGS      60
+#define MAX_KERNEL_CONFIGS      MAX_XILINX_KERNELS
 #define MAX_KERNEL_CHANS        64
 #define MAX_KERNEL_FREQS         2
 #define MAX_IMAGE_CONFIGS       16
@@ -30,8 +30,9 @@
 #define MAX_PLUGIN_NAME         32
 #define MAX_VENDOR_NAME         32
 #define MAX_KERNEL_NAME         64
-#define MAX_DSA_NAME            256
+#define MAX_DSA_NAME           256
 #define XMA_MAX_PLANES           3
 #define MAX_PLUGINS             16
-#define MAX_CONNECTION_ENTRIES  64
+#define MAX_REGS_PER_IP          1
+#define MAX_CONNECTION_ENTRIES  (MAX_DDR_MAP * MAX_XILINX_KERNELS * MAX_REGS_PER_IP)
 #endif

--- a/src/xma/include/lib/xmaxclbin.h
+++ b/src/xma/include/lib/xmaxclbin.h
@@ -59,8 +59,8 @@ typedef struct XmaXclbinInfo
     uint32_t            number_of_kernels;
     uint32_t            number_of_mem_banks;
     uint32_t            number_of_connections;
-    //uint16_t bitmap based on MAX_DDR_MAP=16
-    uint16_t            ip_ddr_mapping[MAX_KERNEL_CONFIGS];
+    //uint64_t bitmap based on MAX_DDR_MAP=64
+    uint64_t            ip_ddr_mapping[MAX_KERNEL_CONFIGS];
     //For execbo:
     uint32_t    num_ips;
     uuid_t      uuid;
@@ -69,5 +69,5 @@ typedef struct XmaXclbinInfo
 
 char *xma_xclbin_file_open(const char *xclbin_name);
 int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info);
-int xma_xclbin_map2ddr(uint16_t bit_map, int* ddr_banks, int* num_banks);
+int xma_xclbin_map2ddr(uint64_t bit_map, int* ddr_banks, int* num_banks);
 #endif

--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -46,7 +46,7 @@ typedef struct XmaHALDevice
     xclDeviceInfo2     info;
     //For execbo:
     uint32_t           dev_index;
-    uuid_t             uuid; 
+    uuid_t             uuid;
 } XmaHALDevice;
 
 static void set_hw_cfg(uint32_t        device_count,
@@ -106,7 +106,7 @@ int get_max_dev_id(XmaSystemCfg *systemcfg)
 
     return max_dev_id;
 }
- 
+
 int32_t create_contexts(xclDeviceHandle handle, XmaXclbinInfo &info)
 {
     for (uint32_t i = 0; i < info.num_ips; i++)
@@ -119,7 +119,7 @@ int32_t create_contexts(xclDeviceHandle handle, XmaXclbinInfo &info)
     }
 
     return XMA_SUCCESS;
-}    
+}
 
 /* Public function implementation */
 int hal_probe(XmaHwCfg *hwcfg)
@@ -132,7 +132,7 @@ int hal_probe(XmaHwCfg *hwcfg)
     int32_t      rc = 0;
 
     device_count = xclProbe();
-	if (device_count == 0) 
+	if (device_count == 0)
     {
         xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "ERROR: No Xilinx device found\n");
         return XMA_ERROR;
@@ -197,7 +197,8 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
 bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
 {
     std::string   xclbinpath = systemcfg->xclbinpath;
-    XmaXclbinInfo info;
+    //allocating larger than required to avoid stack smashing and mem corruption
+    XmaXclbinInfo* pInfo = (XmaXclbinInfo*)calloc(2,sizeof(XmaXclbinInfo));
 
     /* Download the requested image to the associated device */
     for (int32_t i = 0; i < systemcfg->num_images; i++)
@@ -209,14 +210,16 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
         {
             xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not open xclbin file %s\n",
                        xclfullname.c_str());
+            free(pInfo);
             return false;
         }
-        int32_t rc = xma_xclbin_info_get(buffer, &info);
+        int32_t rc = xma_xclbin_info_get(buffer, pInfo);
         if (rc != XMA_SUCCESS)
         {
             xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not get info for xclbin file %s\n",
                        xclfullname.c_str());
             free(buffer);
+            free(pInfo);
             return false;
         }
 
@@ -235,12 +238,12 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
                      x++, t++)
                 {
                     strcpy((char*)hwcfg->devices[dev_id].kernels[t].name,
-                       (const char*)info.ip_layout[t].kernel_name);
+                       (const char*)pInfo->ip_layout[t].kernel_name);
                     xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD,"[%d] %s \t",
                                t, hwcfg->devices[dev_id].kernels[t].name);
                     hwcfg->devices[dev_id].kernels[t].base_address =
-                       info.ip_layout[t].base_addr;
-                    int32_t ip_ddr_map = info.ip_ddr_mapping[t];
+                       pInfo->ip_layout[t].base_addr;
+                    uint64_t ip_ddr_map = pInfo->ip_ddr_mapping[t];
                     int num_ddr_used = 0;
                     int ddr_banks[MAX_DDR_MAP] = {-1};
                     xma_xclbin_map2ddr(ip_ddr_map, ddr_banks, &num_ddr_used);
@@ -259,6 +262,7 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
             if (rc != 0)
             {
                 free(buffer);
+                free(pInfo);
                 xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Could not download xclbin file %s to device %d\n",
                            xclfullname.c_str(),
                            systemcfg->imagecfg[i].device_id_map[d]);
@@ -266,70 +270,74 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
             }
 
             /* Create all kernel contexts on the device */
-            rc = create_contexts(hal->dev_handle, info);
+            rc = create_contexts(hal->dev_handle, *pInfo);
             if (rc != XMA_SUCCESS)
             {
                 free(buffer);
+                free(pInfo);
                 return false;
 	    }
 
             //Setup execbo for use with kernel commands
             for (int32_t k = 0, t = 0;
                 t < MAX_KERNEL_CONFIGS &&
-                k < systemcfg->imagecfg[i].num_kernelcfg_entries; k++) 
+                k < systemcfg->imagecfg[i].num_kernelcfg_entries; k++)
             {
                 for (int32_t x = 0;
                      x < systemcfg->imagecfg[i].kernelcfg[k].instances;
-                     x++, t++) 
+                     x++, t++)
                 {
                     bool found = false;
                     uint32_t cu_bit_mask = 1;
-                    for (uint32_t i_ips = 0; i_ips < info.num_ips; i_ips++) 
+                    for (uint32_t i_ips = 0; i_ips < pInfo->num_ips; i_ips++)
                     {
-                        if (info.ip_layout[i_ips].base_addr == 
-                            hwcfg->devices[dev_id].kernels[t].base_address) 
+                        if (pInfo->ip_layout[i_ips].base_addr ==
+                            hwcfg->devices[dev_id].kernels[t].base_address)
                         {
                             found = true;
-                        } else if (info.ip_layout[i_ips].base_addr <
+                        } else if (pInfo->ip_layout[i_ips].base_addr <
                             hwcfg->devices[dev_id].kernels[t].base_address) {
                             cu_bit_mask = cu_bit_mask << 1;
                         }
                     }
-                    if (!found) 
+                    if (!found)
                     {
                         free(buffer);
+                        free(pInfo);
                         xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "CU not found. Couldn't create cu_cmd execbo\n");
                         return false;
                     }
-                    if (cu_bit_mask == 0) 
+                    if (cu_bit_mask == 0)
                     {
                         free(buffer);
+                        free(pInfo);
                         xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "XMA library doesn't support more than 32 CUs\n");
                         return false;
                     }
-                    for (int i_execbo = 0; i_execbo < MAX_EXECBO_POOL_SIZE; i_execbo++) 
+                    for (int i_execbo = 0; i_execbo < MAX_EXECBO_POOL_SIZE; i_execbo++)
                     {
                         uint32_t  bo_handle;
                         int       execBO_size = 1024;
                         uint32_t  execBO_flags = (1<<31);
                         char     *bo_data;
-                        bo_handle = xclAllocBO(hal->dev_handle, 
-                                               execBO_size, 
-                                               XCL_BO_DEVICE_RAM, 
+                        bo_handle = xclAllocBO(hal->dev_handle,
+                                               execBO_size,
+                                               XCL_BO_DEVICE_RAM,
                                                execBO_flags);
-                        if (!bo_handle || bo_handle == mNullBO) 
+                        if (!bo_handle || bo_handle == mNullBO)
                         {
                             free(buffer);
+                            free(pInfo);
                             xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "Unable to create bo for cu start\n");
                             return false;
                         }
                         bo_data = (char*)xclMapBO(hal->dev_handle, bo_handle, true);
                         memset((void*)bo_data, 0x0, execBO_size);
-                        hwcfg->devices[dev_id].kernels[t].kernel_execbo_handle[i_execbo] = 
+                        hwcfg->devices[dev_id].kernels[t].kernel_execbo_handle[i_execbo] =
                             bo_handle;
-                        hwcfg->devices[dev_id].kernels[t].kernel_execbo_data[i_execbo] = 
+                        hwcfg->devices[dev_id].kernels[t].kernel_execbo_data[i_execbo] =
                             bo_data;
-                        hwcfg->devices[dev_id].kernels[t].kernel_execbo_inuse[i_execbo] = 
+                        hwcfg->devices[dev_id].kernels[t].kernel_execbo_inuse[i_execbo] =
                             false;
                         ert_start_kernel_cmd* cu_start_cmd = (ert_start_kernel_cmd*) bo_data;
                         cu_start_cmd->state = ERT_CMD_STATE_NEW;
@@ -341,6 +349,7 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
         }
         free(buffer);
     }
+    free(pInfo);
     return true;
 }
 

--- a/src/xma/src/xmaapi/xmaxclbin.cpp
+++ b/src/xma/src/xmaapi/xmaxclbin.cpp
@@ -88,7 +88,7 @@ static int get_xclbin_iplayout(char *buffer, XmaXclbinInfo *xclbin_info)
         return XMA_ERROR;
     }
 
-    uuid_copy(xclbin_info->uuid, xclbin->m_header.uuid); 
+    uuid_copy(xclbin_info->uuid, xclbin->m_header.uuid);
 
     return XMA_SUCCESS;
 }
@@ -173,14 +173,14 @@ int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info)
     if(rc == XMA_ERROR)
         return rc;
 
-    uint16_t map[MAX_KERNEL_CONFIGS] = {};
+    uint64_t map[MAX_KERNEL_CONFIGS] = {};
     for(uint32_t c = 0; c < info->number_of_connections; c++)
     {
         XmaAXLFConnectivity *xma_conn = &info->connectivity[c];
         map[xma_conn->m_ip_layout_index] |= 1 << (xma_conn->mem_data_index + 1);
     }
-    memcpy(info->ip_ddr_mapping,map,MAX_KERNEL_CONFIGS*sizeof(uint16_t));
-    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "\nCONNECTIONS (bitmap 15<-0)\n");
+    memcpy(info->ip_ddr_mapping,map,MAX_KERNEL_CONFIGS*sizeof(uint64_t));
+    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "\nCONNECTIONS (bitmap 63<-0)\n");
     for(uint32_t i = 0; i < info->number_of_kernels; i++)
     {
         xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "%s - 0x%04x\n",info->ip_layout[i].kernel_name, info->ip_ddr_mapping[i]);
@@ -190,9 +190,9 @@ int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info)
     return XMA_SUCCESS;
 }
 
-int xma_xclbin_map2ddr(uint16_t bit_map, int* ddr_banks, int* num_banks)
+int xma_xclbin_map2ddr(uint64_t bit_map, int* ddr_banks, int* num_banks)
 {
-    //TODO HHS Based on uint16_t bitmap considering 16 DDRs as max
+    //TODO HHS Based on uint64_t bitmap considering 64 DDRs as max
     int ddr_bank_idx = -1;
     int count = 0;
     while (bit_map != 0)


### PR DESCRIPTION
1. Changing limits to handle more connections (eg. HBM, more kernels) & putting a place holder for MAX_REGS_PER_IP = 1, to take it into consideration in future
2. Changing a temporary struct variable to move from stack to heap to avoid causing stack smashing