### PR TITLE
XMA changes for DDR mapping to support HBM and xclbins with more kernels (2019.1)

### DIFF
--- a/src/xma/include/lib/xmalimits.h
+++ b/src/xma/include/lib/xmalimits.h
@@ -19,10 +19,10 @@
 
 #define MAX_SCALER_OUTPUTS       8
 #define MAX_FILTER_OUTPUTS      MAX_SCALER_OUTPUTS
-#define MAX_DDR_MAP             16
+#define MAX_DDR_MAP             64
 #define MAX_XILINX_DEVICES      16
 #define MAX_XILINX_KERNELS      60
-#define MAX_KERNEL_CONFIGS      60
+#define MAX_KERNEL_CONFIGS      MAX_XILINX_KERNELS
 #define MAX_KERNEL_CHANS        64
 #define MAX_KERNEL_FREQS         2
 #define MAX_IMAGE_CONFIGS       16
@@ -30,8 +30,9 @@
 #define MAX_PLUGIN_NAME         32
 #define MAX_VENDOR_NAME         32
 #define MAX_KERNEL_NAME         64
-#define MAX_DSA_NAME            256
+#define MAX_DSA_NAME           256
 #define XMA_MAX_PLANES           3
 #define MAX_PLUGINS             16
-#define MAX_CONNECTION_ENTRIES  64
+#define MAX_REGS_PER_IP          1
+#define MAX_CONNECTION_ENTRIES  (MAX_DDR_MAP * MAX_XILINX_KERNELS * MAX_REGS_PER_IP)
 #endif

--- a/src/xma/include/lib/xmaxclbin.h
+++ b/src/xma/include/lib/xmaxclbin.h
@@ -59,8 +59,8 @@ typedef struct XmaXclbinInfo
     uint32_t            number_of_kernels;
     uint32_t            number_of_mem_banks;
     uint32_t            number_of_connections;
-    //uint16_t bitmap based on MAX_DDR_MAP=16
-    uint16_t            ip_ddr_mapping[MAX_KERNEL_CONFIGS];
+    //uint64_t bitmap based on MAX_DDR_MAP=64
+    uint64_t            ip_ddr_mapping[MAX_KERNEL_CONFIGS];
     //For execbo:
     uint32_t    num_ips;
     uuid_t      uuid;
@@ -69,5 +69,5 @@ typedef struct XmaXclbinInfo
 
 char *xma_xclbin_file_open(const char *xclbin_name);
 int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info);
-int xma_xclbin_map2ddr(uint16_t bit_map, int* ddr_banks, int* num_banks);
+int xma_xclbin_map2ddr(uint64_t bit_map, int* ddr_banks, int* num_banks);
 #endif

--- a/src/xma/src/xmaapi/xmaxclbin.cpp
+++ b/src/xma/src/xmaapi/xmaxclbin.cpp
@@ -86,7 +86,7 @@ static int get_xclbin_iplayout(char *buffer, XmaXclbinInfo *xclbin_info)
         return XMA_ERROR;
     }
 
-    uuid_copy(xclbin_info->uuid, xclbin->m_header.uuid); 
+    uuid_copy(xclbin_info->uuid, xclbin->m_header.uuid);
 
     return XMA_SUCCESS;
 }
@@ -171,14 +171,14 @@ int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info)
     if(rc == XMA_ERROR)
         return rc;
 
-    uint16_t map[MAX_KERNEL_CONFIGS] = {};
+    uint64_t map[MAX_KERNEL_CONFIGS] = {};
     for(uint32_t c = 0; c < info->number_of_connections; c++)
     {
         XmaAXLFConnectivity *xma_conn = &info->connectivity[c];
         map[xma_conn->m_ip_layout_index] |= 1 << (xma_conn->mem_data_index + 1);
     }
-    memcpy(info->ip_ddr_mapping,map,MAX_KERNEL_CONFIGS*sizeof(uint16_t));
-    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "\nCONNECTIONS (bitmap 15<-0)\n");
+    memcpy(info->ip_ddr_mapping,map,MAX_KERNEL_CONFIGS*sizeof(uint64_t));
+    xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "\nCONNECTIONS (bitmap 63<-0)\n");
     for(uint32_t i = 0; i < info->number_of_kernels; i++)
     {
         xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "%s - 0x%04x\n",info->ip_layout[i].kernel_name, info->ip_ddr_mapping[i]);
@@ -188,9 +188,9 @@ int xma_xclbin_info_get(char *buffer, XmaXclbinInfo *info)
     return XMA_SUCCESS;
 }
 
-int xma_xclbin_map2ddr(uint16_t bit_map, int* ddr_banks, int* num_banks)
+int xma_xclbin_map2ddr(uint64_t bit_map, int* ddr_banks, int* num_banks)
 {
-    //TODO HHS Based on uint16_t bitmap considering 16 DDRs as max
+    //TODO HHS Based on uint64_t bitmap considering 64 DDRs as max
     int ddr_bank_idx = -1;
     int count = 0;
     while (bit_map != 0)


### PR DESCRIPTION
Changing limits to handle more connections (eg. HBM, more kernels) & putting a place holder for MAX_REGS_PER_IP = 1, to take it into consideration in future
Changing a temporary struct variable to move from stack to heap to avoid causing stack smashing