### PR TITLE
adjust build.sh -driver and -checkpatch

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -122,7 +122,7 @@ time make -j $jcore $verbose DESTDIR=$PWD install
 time make package
 
 if [[ $driver == 1 ]]; then
-    make -C usr/src/xrt-2.2.0/driver/xclng/drm/xocl
+    make -C usr/src/xrt-2.3.0/driver/xocl
 fi
 
 if [[ $docs == 1 ]]; then
@@ -135,10 +135,10 @@ fi
 
 if [[ $checkpatch == 1 ]]; then
     # check only driver released files
-    DRIVERROOT=`readlink -f $BUILDDIR/Release/usr/src/xrt-2.2.0/driver`
+    DRIVERROOT=`readlink -f $BUILDDIR/Release/usr/src/xrt-2.3.0/driver`
 
     # find corresponding source under src tree so errors can be fixed in place
-    XOCLROOT=`readlink -f $BUILDDIR/../src/runtime_src/driver`
+    XOCLROOT=`readlink -f $BUILDDIR/../src/runtime_src/core/pcie/driver`
     echo $XOCLROOT
     for f in $(find $DRIVERROOT -type f -name *.c -o -name *.h); do
         fsum=$(md5sum $f | cut -d ' ' -f 1)


### PR DESCRIPTION
build.sh -driver failed:
make: *** usr/src/xrt-2.2.0/driver/xclng/drm/xocl: No such file or directory.  Stop.
It should be:
make -C usr/src/xrt-2.3.0/driver/xocl/

build.sh -checkpath also should reflect code structure change as the following location:
/proj/xsjhdstaff2/davidzha/XRT/src/runtime_src/core/pcie/driver