### PR TITLE
Turn on cache for buffer allocated from clCreateBuffer on MPSoC

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -262,7 +262,7 @@ alloc(size_t sz, Domain domain, uint64_t memory_index, void* userptr)
     if (userptr)
       ubo->handle = m_ops->mAllocUserPtrBO(m_handle, userptr, sz, flags);
     else
-      ubo->handle = m_ops->mAllocBO(m_handle, sz, kind, flags);
+      ubo->handle = m_ops->mAllocBO(m_handle, sz, kind, flags | XCL_BO_FLAGS_CACHEABLE);
 
     if (ubo->handle == 0xffffffff)
       throw std::bad_alloc();


### PR DESCRIPTION
clCreateBuffer on MPSoC devices will allocate buffer from CMA and mapped to user space with cache disabled. Though we have write combine feature, the read performance (clEnqueuReadBuffer) is pretty bad. 

This PR add XCL_BO+FLAGS_CACHEABLE flag when allocation BO. On PCIe side, where a cacheable shadow buffer is allocated, this flag is ignored. But on MPSoC device, we will allocate cacheable buffer on this flag. This will greatly improve the clEnqueuReadBuffer.

And, from OpenCL layer, we have already taken care of the buffer synchronization so that the cache will be synched (flush/invalidate) whenever necessary. Also zocl driver has implemented xclSyncBO, So we maintains a good cache coherency while we improve the clEnqueueReadBuffer performance. Meanwhile, we will have a comparable clEnqueueReadBuffer and clEnqueuWriteBuffer. 

Please refer to CR1030911 for more information.