### PR TITLE
skd: check for args being mapped successfully

### DIFF
--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -149,13 +149,19 @@ static void softKernelLoop(char *name, char *path, uint32_t cu_idx)
   }
 
   syslog(LOG_INFO, "%s_%d start running\n", name, cu_idx);
-    
+
   /* Set Kernel Ops */
   ops.getHostBO = &getHostBO;
   ops.mapBO     = &mapBO;
   ops.freeBO    = &freeBO;
 
   args_from_host = (unsigned *)getKernelArg(boh, cu_idx);
+  if (args_from_host == MAP_FAILED) {
+      syslog(LOG_ERR, "Failed to map soft kernel args for %s_%d", name, cu_idx);
+      freeBO(boh);
+      dlclose(sk_handle);
+      return;
+  }
 
   while (1) {
     ret = waitNextCmd(cu_idx);


### PR DESCRIPTION


getKernelArg() leads to a mapBO call which can fail as per the case with POSIX style
mmap() system calls. This commit adds a check for MAP_FAILED ((void *)(-1)).

Signed-off-by: Rohit Athavale <rathaval@xilinx.com>