### PR TITLE
Fatal Bug Fix - Fixed issue where the xclbin archive wasn't be formed correct.

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -245,13 +245,12 @@ XclBin::writeXclBinBinarySections(std::fstream& _ostream, boost::property_tree::
   }
 
   // Prepare the array
-  struct axlf_section_header *sectionHeader = new struct axlf_section_header[m_sections.size()];
-  memset(sectionHeader, 0, sizeof(struct axlf_section_header) * m_sections.size());  // Zero out memory
+  struct axlf_section_header sectionHeader[m_sections.size()];
+  memset(&sectionHeader, 0, sizeof(sectionHeader));  // Zero out memory
 
 
   // Populate the array size and offsets
-  uint64_t currentOffset = (uint64_t) (sizeof(axlf) - sizeof(axlf_section_header) + (sizeof(axlf_section_header) * m_sections.size()));
-  for (unsigned int index = 0; index < m_sections.size(); ++index) {
+  uint64_t currentOffset = (uint64_t) (sizeof(axlf) - sizeof(axlf_section_header) + sizeof(sectionHeader));  for (unsigned int index = 0; index < m_sections.size(); ++index) {
     // Calculate padding
     currentOffset += (uint64_t) XUtil::bytesToAlign(currentOffset);
 
@@ -317,7 +316,6 @@ XclBin::writeXclBinBinarySections(std::fstream& _ostream, boost::property_tree::
       _mirroredData.add_child("section_header", pt_sectionHeader);
     }
   }
-  delete[] sectionHeader;
 }
 
 


### PR DESCRIPTION
This fix reverts a change made previously for the windows port.  This previous submission unfortunately causes the xrtbin image to be malformed.