### PR TITLE
properly ref count pid

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -2770,7 +2770,7 @@ create_client(struct platform_device *pdev, void **priv)
 	mutex_lock(&xdev->dev_lock);
 
 	if (!xdev->offline) {
-		client->pid = task_tgid(current);
+		client->pid = get_pid(task_pid(current));
 		client->abort = false;
 		atomic_set(&client->trigger, 0);
 		atomic_set(&client->outstanding_execs, 0);
@@ -2835,6 +2835,8 @@ static void destroy_client(struct platform_device *pdev, void **priv)
 	mutex_lock(&xdev->dev_lock);
 
 	pid = pid_nr(client->pid);
+	put_pid(client->pid);
+	client->pid = NULL;
 
 	list_del(&client->link);
 	DRM_INFO("client exits pid(%d)\n", pid);


### PR DESCRIPTION
@sonals, @houlz0507, I think we should use get/pud_pid() to properly ref count the struct pid before we cache the pointer to it.
Also, instead of caching group leader's pid, we probably should just cache the one for the current process.
Please let me know what you think.