### PR TITLE
Enabled CMake Regression Testing Support

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -113,12 +113,14 @@ cd Debug
 echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src"
 time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src
 time make -j $jcore $verbose DESTDIR=$PWD install
+time ctest --output-on-failure
 cd $BUILDDIR
 
 cd Release
 echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src"
 time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src
 time make -j $jcore $verbose DESTDIR=$PWD install
+time ctest --output-on-failure
 time make package
 
 if [[ $driver == 1 ]]; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 PROJECT(XRT)
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
 
+ENABLE_TESTING()
+
 SET(PROJECT_DESCRIPTION "https://github.com/Xilinx/XRT")
 
 # Exported interface into XRT for include from implemenation

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -153,6 +153,19 @@ if (GTEST_FOUND)
 
   message (STATUS "GTest libraries: '${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread'")
   target_link_libraries(xclbintest ${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread )
+
+  message(STATUS "Configuring CMake to run unit test after building")
+  set(UNIT_TEST_XCLBINUTIL xclbintest)
+  add_test(NAME ${UNIT_TEST_XCLBINUTIL} COMMAND ${UNIT_TEST_XCLBINUTIL})
+# Execute unit tests after the xclbintest is created.
+# Note: This command works GREAT if the tests pass.  If they fail xclbintest is deleted :(
+#  add_custom_command(
+#     TARGET ${UNIT_TEST_XCLBINUTIL}
+#     COMMENT "Run xclbinutil unit-tests"
+#     POST_BUILD 
+#     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+#     COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE} -R ${UNIT_TEST_XCLBINUTIL} --output-on-failures
+#  )
 else()
   message (STATUS "GTest was not found, skipping generation of test executables")
 endif()

--- a/src/runtime_src/tools/xclbin/unittests/TestSerialization.cxx
+++ b/src/runtime_src/tools/xclbin/unittests/TestSerialization.cxx
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+#include "ParameterSectionData.h"
+#include "XclBinClass.h"
+
+TEST(Serialization, ReadXclbin_2018_2) {
+   XclBin xclBin;
+  
+   xclBin.readXclBinBinary("unittests/test_data/sample_1_2018.2.xclbin", false /* bMigrateForward */);
+}
+
+TEST(Serialization, ReadWriteReadXclbin) {
+   XclBin xclBin;
+  
+   xclBin.readXclBinBinary("unittests/test_data/sample_1_2018.2.xclbin", false /* bMigrateForward */);
+   xclBin.writeXclBinBinary("unittests/ReadWriteReadXclbin.xclbin", true /* Skip UUID insertion */);
+
+   XclBin xclBin2;
+   xclBin2.readXclBinBinary("unittests/ReadWriteReadXclbin.xclbin", false /* bMigrateForward */);
+}


### PR DESCRIPTION
+ Enabled CMake to produce testing targets.
+ Added xclbinutil gtest unit test (xclbintest) to a CMake target
+ Added new unit test to test for serialization compatibility between xclbin archives
+ Updated build.sh to execute unit tests after the build completes