### PR TITLE
adding interrupt sysfs debugging info for zocl driver

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -505,6 +505,10 @@ static irqreturn_t sched_exec_isr(int irq, void *arg)
 	isr = ioread32(virt_addr + 3);
 	iowrite32(isr, virt_addr + 3);
 
+#ifdef ZOCL_DEBUG
+	atomic_inc(&zdev->exec->sec_intr_recv);
+#endif
+
 	/* wake up all scheduler ... currently one only
 	 *
 	 * This might have race with sched_wait_cond(), which will read then set
@@ -1544,6 +1548,10 @@ configure_cu(struct sched_cmd *cmd, int cu_idx)
 	/* start CU at base + 0x0 */
 	iowrite32(0x1, virt_addr);
 
+#ifdef ZOCL_DEBUG
+	atomic_inc(&cmd->exec->sec_intr_send);
+#endif
+
 	SCHED_DEBUG("<- configure_cu\n");
 }
 
@@ -2415,6 +2423,11 @@ sched_init_exec(struct drm_device *drm)
 
 		exec_core->cq_thread = kthread_run(cq_check, zdev, name);
 	}
+
+#ifdef ZOCL_DEBUG
+	atomic_set(&exec_core->sec_intr_send, 0); 
+	atomic_set(&exec_core->sec_intr_recv, 0); 
+#endif
 
 	SCHED_DEBUG("<- sched_init_exec\n");
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.h
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.h
@@ -133,6 +133,11 @@ struct sched_exec_core {
 	struct sched_ops          *ops;
 	struct task_struct        *cq_thread;
 	wait_queue_head_t          cq_wait_queue;
+
+#ifdef ZOCL_DEBUG
+	atomic_t 		  sec_intr_send;
+	atomic_t 		  sec_intr_recv;
+#endif
 };
 
 /**

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
@@ -30,6 +30,10 @@
 #include "zocl_util.h"
 #include "xclhal2_mem.h"
 
+#if 0
+#define ZOCL_DEBUG
+#endif
+
 struct drm_zocl_exec_metadata {
 	enum drm_zocl_execbuf_state state;
 	unsigned int                index;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -71,6 +71,24 @@ static ssize_t kds_custat_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(kds_custat);
 
+#ifdef ZOCL_DEBUG
+static ssize_t intr_stat_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	ssize_t size = 0;
+
+	if (!zdev || !zdev->exec)
+		return 0;
+
+	size = sprintf(buf, "Triggered: %d, Signaled: %d\n",
+		atomic_read(&zdev->exec->sec_intr_send),
+		atomic_read(&zdev->exec->sec_intr_recv));
+	return size;
+}
+static DEVICE_ATTR_RO(intr_stat);
+#endif
+
 static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
@@ -138,6 +156,9 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_kds_custat.attr,
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,
+#ifdef ZOCL_DEBUG
+	&dev_attr_intr_stat.attr,
+#endif
 	NULL,
 };
 


### PR DESCRIPTION
While we were doing the debugging for interrupt bugs, we realized that the info of handling interrupts is the key info to narrow down the issue. It is better to have those code around when we have to debug it for some reason (as of today, we don't support data flow in zocl driver yet, in the future we will need this change). So,  just keep this code for debugging only, product code should not enable this. Hence, by default it is disabled.

In the future, we would enhance the build.sh to make zocl driver built automatically with debug/non-debug flags.