### PR TITLE
2019.1: skd: Change process name to match soft kernel name

### DIFF
--- a/src/runtime_src/driver/zynq/skd/sk_daemon.cpp
+++ b/src/runtime_src/driver/zynq/skd/sk_daemon.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
+#include <sys/prctl.h>
 
 #include "sk_types.h"
 #include "sk_daemon.h"
@@ -126,7 +127,7 @@ static void softKernelLoop(char *name, char *path, uint32_t cu_idx)
   unsigned *args_from_host;
   unsigned int boh;
   int ret;
- 
+
   devHdl = initXRTHandle(0);
 
   ret = createSoftKernel(&boh, cu_idx);
@@ -149,7 +150,7 @@ static void softKernelLoop(char *name, char *path, uint32_t cu_idx)
   }
 
   syslog(LOG_INFO, "%s_%d start running\n", name, cu_idx);
-    
+
   /* Set Kernel Ops */
   ops.getHostBO = &getHostBO;
   ops.mapBO     = &mapBO;
@@ -267,6 +268,7 @@ static void sigAct(int sig)
   wait((int *)0);
 }
 
+#define PNAME_LEN	(16)
 void configSoftKernel(xclSKCmd *cmd)
 {
   pid_t pid;
@@ -289,6 +291,12 @@ void configSoftKernel(xclSKCmd *cmd)
     pid = fork();
     if (pid == 0) {
       char path[XRT_MAX_PATH_LENGTH];
+      char proc_name[PNAME_LEN] = {};
+
+      (void)snprintf(proc_name, PNAME_LEN, "%s%d", cmd->krnl_name, i);
+      if (prctl(PR_SET_NAME, (char *)proc_name) != 0) {
+          syslog(LOG_ERR, "Unable to set process name to %s due to %s\n", proc_name, strerror(errno));
+      }
 
       getSoftKernelPathName(cmd->start_cuidx, path);
 


### PR DESCRIPTION
Commit 9270ab0 was merged into XRT/master by PR-1512. This commit applies it to XRT/2019.1
https://github.com/Xilinx/XRT/pull/1512

The commit tries to change the process name to match the soft kernel name.
This proves to be useful when trying to debug the performance of specific
soft kernels, unique names aids in tracking in these details.

Note: This still only impacts the name seen in top, ps still remains the same process name.

Signed-off-by: Rohit Athavale <rathaval@xilinx.com>
Reviewed-by: Larry Liu <yliu@xilinx.com>