### PR TITLE
Build XRT on AL2 (#1462)

### DIFF
--- a/src/CMake/cpack.cmake
+++ b/src/CMake/cpack.cmake
@@ -37,7 +37,7 @@ if (${LINUX_FLAVOR} STREQUAL Ubuntu)
   # xrt component dependencies
   SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-opencl-dev (>= 2.2.0), libboost-dev (>=1.58), libboost-filesystem-dev (>=1.58), uuid-dev (>= 2.27.1), dkms (>= 2.2.0), libprotoc-dev (>=2.6.1), protobuf-compiler (>=2.6.1), libncurses5-dev (>=6.0), lsb-release, libxml2-dev (>=2.9.1), libyaml-dev (>= 0.1.6)")
 
-elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS)")
+elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS|Amazon)")
   SET(CPACK_GENERATOR "RPM;TGZ")
   SET(PACKAGE_KIND "RPM")
   # Modify the package name for the xrt component
@@ -53,6 +53,10 @@ elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS)")
   SET(CPACK_RPM_AWS_PACKAGE_REQUIRES "xrt >= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH}")
   # xrt component dependencies
   SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd-devel >= 2.2, boost-devel >= 1.53, boost-filesystem >= 1.53, libuuid-devel >= 2.23.2, dkms >= 2.5.0, protobuf-devel >= 2.5.0, protobuf-compiler >= 2.5.0, ncurses-devel >= 5.9, redhat-lsb-core, libxml2-devel >= 2.9.1, libyaml-devel >= 0.1.4 ")
+  # Few extras necessary to install XRT on an AL2 image
+  if(${LINUX_FLAVOR} MATCHES "^Amazon")
+    SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "${CPACK_RPM_XRT_PACKAGE_REQUIRES} libdrm-devel >= 2.4.83, libpciaccess-devel >= 0.14, boost-static >= 1.53, gtest >= 1.7.0, glibc-static >= 2.26 gcc-c++ >= 7.3.1")
+  endif()
 else ()
   SET (CPACK_GENERATOR "TGZ")
 endif()

--- a/src/CMake/pkgconfig.cmake
+++ b/src/CMake/pkgconfig.cmake
@@ -2,7 +2,7 @@ message("-- Preparing XRT pkg-config")
 
 if (${LINUX_FLAVOR} STREQUAL Ubuntu)
   set(XRT_PKG_CONFIG_DIR "/usr/lib/pkgconfig")
-elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS)")
+elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS|Amazon)")
   set(XRT_PKG_CONFIG_DIR "/usr/lib64/pkgconfig")
 else ()
   set(XRT_PKG_CONFIG_DIR "/usr/share/pkgconfig")

--- a/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.c
@@ -30,7 +30,7 @@
 #include <linux/vmalloc.h>
 #include <linux/version.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/delay.h>
 
 MODULE_LICENSE("GPL v2");

--- a/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_debugfs.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_debugfs.h
@@ -23,7 +23,7 @@
 #include <linux/pci.h>
 #include <linux/debugfs.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/mutex.h>
 #include <linux/slab.h>
 

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -496,7 +496,7 @@ public:
       // allocate sufficiently aligned memory and reassign m_host_ptr
       if (posix_memalign(&m_host_ptr,alignment,sz))
         throw error(CL_MEM_OBJECT_ALLOCATION_FAILURE);
-    if (flags & CL_MEM_COPY_HOST_PTR)
+    if (flags & CL_MEM_COPY_HOST_PTR && host_ptr)
       std::memcpy(m_host_ptr,host_ptr,sz);
 
     m_aligned = (reinterpret_cast<uintptr_t>(m_host_ptr) % alignment)==0;


### PR DESCRIPTION
* Add changes for using gcc7.3 on AL2 with 4.14.94-89.73.amzn2.x86_64

* Add changes for using gcc7.3 on AL2 with 4.14.94-89.73.amzn2.x86_64

* Make changes to create RPM on AL2

This is one of the PR's for resolving #1489 
I'll create some more for 2019.1 and Master