### PR TITLE
Fix Linux 5.0 compilation errors

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -4,8 +4,9 @@
  * Copyright (C) 2017-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *    Soren Soe <soren.soe@xilinx.com>
- *    Min Ma <min.ma@xilinx.com>
+ *    Soren Soe   <soren.soe@xilinx.com>
+ *    Min Ma      <min.ma@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -21,6 +22,7 @@
 #include <linux/kthread.h>
 #include <linux/delay.h>
 #include <linux/sched.h>
+#include <linux/version.h>
 #include "ert.h"
 #include "sched_exec.h"
 #include "zocl_sk.h"
@@ -967,6 +969,8 @@ set_cmd_ext_cu_idx(struct sched_cmd *cmd, int cu_idx)
  *
  * The timestamp is reflected externally through the command packet
  * TODO: Should have scheduler profiling solution in the future.
+ * TODO: Remove deprecated do_gettimeofday once kernels < 3.17 are no
+ * longer supported.
  *
  * @cmd: command object
  * @ts: timestamp type
@@ -975,7 +979,11 @@ static inline void
 set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 {
 	u32 opc = opcode(cmd);
-	struct timeval tv;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+	struct timespec64 tv;
+#else
+    struct timeval tv;
+#endif
 	struct ert_start_kernel_cmd *sk;
 
 	sk = (struct ert_start_kernel_cmd *)cmd->packet;
@@ -991,13 +999,25 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 	 * The fourth 32 bits - CU done  microseconds
 	 * Use 32 bits timestamp is good enough for this purpose for now.
 	 */
-	do_gettimeofday(&tv);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+    ktime_get_real_ts64(&tv);
+#else
+    do_gettimeofday(&tv);
+#endif
 	if (ts == CU_START_TIME) {
 		*(sk->data + sk->extra_cu_masks) = (u32)tv.tv_sec;
-		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_nsec / NSEC_PER_USEC;
+#else
+        *(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
+#endif
 	} else if (ts == CU_DONE_TIME) {
 		*(sk->data + sk->extra_cu_masks + 2) = (u32)tv.tv_sec;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+		*(sk->data + sk->extra_cu_masks + 3) = (u32)tv.tv_nsec / NSEC_PER_USEC;
+#else
 		*(sk->data + sk->extra_cu_masks + 3) = (u32)tv.tv_usec;
+#endif
 	}
 }
 
@@ -1273,16 +1293,25 @@ get_free_sched_cmd(void)
  *
  * Use the correct way to unreference a gem object
  *
+ * TODO: Remove drm_gem_object_unreference_unlocked as soon as kernels < 4.12
+ *       are no longer supported.
  */
 void zocl_gem_object_unref(struct sched_cmd *cmd)
 {
 	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
 	struct drm_zocl_bo *bo = cmd->buffer;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	if (zdev->domain)
+		drm_gem_object_put_unlocked(&bo->gem_base);
+	else
+		drm_gem_object_put_unlocked(&bo->cma_base.base);
+#else
 	if (zdev->domain)
 		drm_gem_object_unreference_unlocked(&bo->gem_base);
 	else
 		drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+#endif
 }
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -4,9 +4,9 @@
  * Copyright (C) 2017-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Soren Soe   <soren.soe@xilinx.com>
- *	  Min Ma	  <min.ma@xilinx.com>
- *	  Jan Stephan <j.stephan@hzdr.de>
+ *    Soren Soe   <soren.soe@xilinx.com>
+ *    Min Ma      <min.ma@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -37,7 +37,7 @@
 ({ \
 	unsigned int ret = 0; \
 	if ((expr)) { \
-		DRM_ERROR("Assertion failed: %s:%s\n",	__func__, #expr); \
+		DRM_ERROR("Assertion failed: %s:%s\n",  __func__, #expr); \
 		exec->scheduler->error = 1; \
 		ret = 1; \
 	} \
@@ -52,7 +52,7 @@
 
 /* Scheduler call schedule() every MAX_SCHED_LOOP loop*/
 #define MAX_SCHED_LOOP 8
-static int	  sched_loop_cnt;
+static int    sched_loop_cnt;
 
 static struct scheduler g_sched0;
 static struct sched_ops penguin_ops;
@@ -293,10 +293,10 @@ cu_masks(struct sched_cmd *cmd)
 
 /**
  * regmap_size() - Size of regmap
- *				   It is calculated by payload size + one packet header size -
- *				   offset of cu_mask field - cu_masks
- *				   This is based on the assumption that regmap is located
- *				   right after the cu_masks (including extra_cu_masks).
+ *                 It is calculated by payload size + one packet header size -
+ *                 offset of cu_mask field - cu_masks
+ *                 This is based on the assumption that regmap is located
+ *                 right after the cu_masks (including extra_cu_masks).
  * @xcmd: Command object
  * Return: Size of register map in number of words
  */
@@ -307,16 +307,16 @@ regmap_size(struct sched_cmd *cmd)
 
 	case ERT_INIT_CU:
 		return
-			payload_size(cmd) + 1 -
-			offsetof(struct ert_init_kernel_cmd, cu_mask) / WORD_SIZE -
-			cu_masks(cmd);
+		    payload_size(cmd) + 1 -
+		    offsetof(struct ert_init_kernel_cmd, cu_mask) / WORD_SIZE -
+		    cu_masks(cmd);
 
 	case ERT_START_CU:
 	case ERT_SK_START:
 		return
-			payload_size(cmd) + 1 -
-			offsetof(struct ert_start_kernel_cmd, cu_mask) / WORD_SIZE -
-			cu_masks(cmd);
+		    payload_size(cmd) + 1 -
+		    offsetof(struct ert_start_kernel_cmd, cu_mask) / WORD_SIZE -
+		    cu_masks(cmd);
 
 	default:
 		DRM_WARN("Command %d does not support regmap.\n", opcode(cmd));
@@ -603,7 +603,7 @@ init_cus(struct sched_cmd *cmd)
 
 			if (!zocl_cu_is_valid(zdev->exec, cu_idx)) {
 				DRM_WARN("Init CU %d fail: NOT a valid CU.\n",
-					cu_idx);
+				    cu_idx);
 				continue;
 			}
 
@@ -613,7 +613,7 @@ init_cus(struct sched_cmd *cmd)
 				 * CU numbers.
 				 */
 				DRM_WARN("Init CU %d fail: NOT configured.\n",
-					cu_idx);
+				    cu_idx);
 				goto done;
 			}
 
@@ -672,11 +672,11 @@ configure(struct sched_cmd *cmd)
 	}
 
 	SCHED_DEBUG("Configuring scheduler\n");
-	exec->num_slots		  = CQ_SIZE / cfg->slot_size;
-	exec->num_cus		  = cfg->num_cus;
+	exec->num_slots       = CQ_SIZE / cfg->slot_size;
+	exec->num_cus         = cfg->num_cus;
 	exec->cu_shift_offset = cfg->cu_shift;
-	exec->cu_base_addr	  = cfg->cu_base_addr;
-	exec->num_cu_masks	  = ((exec->num_cus - 1)>>5) + 1;
+	exec->cu_base_addr    = cfg->cu_base_addr;
+	exec->num_cu_masks    = ((exec->num_cus - 1)>>5) + 1;
 
 	write_lock(&zdev->attr_rwlock);
 
@@ -695,10 +695,10 @@ configure(struct sched_cmd *cmd)
 		exec->cu_dma = cfg->cu_dma;
 		exec->cu_isr = cfg->cu_isr;
 		DRM_INFO("PS ERT enabled features:");
-		DRM_INFO("	cu_dma(%d)", exec->cu_dma);
-		DRM_INFO("	cu_isr(%d)", exec->cu_isr);
-		DRM_INFO("	host_polling_mode(%d)", exec->polling_mode);
-		DRM_INFO("	cq_interrupt(%d)", exec->cq_interrupt);
+		DRM_INFO("  cu_dma(%d)", exec->cu_dma);
+		DRM_INFO("  cu_isr(%d)", exec->cu_isr);
+		DRM_INFO("  host_polling_mode(%d)", exec->polling_mode);
+		DRM_INFO("  cq_interrupt(%d)", exec->cq_interrupt);
 		setup_ert_hw(zdev);
 		exec->configured = 1;
 	}
@@ -743,7 +743,7 @@ configure(struct sched_cmd *cmd)
 			return 1;
 		}
 		SCHED_DEBUG("++ configure cu(%d) at 0x%x map to 0x%x\n", i,
-			exec->cu_addr_phy[i], exec->cu_addr_virt[i]);
+		    exec->cu_addr_phy[i], exec->cu_addr_virt[i]);
 	}
 
 	if (zdev->ert)
@@ -754,8 +754,8 @@ configure(struct sched_cmd *cmd)
 	 */
 	if (!exec->polling_mode && exec->num_cus > 32) {
 		DRM_WARN("Only support up to 32 CUs interrupts, "
-			"request %d CUs. Fall back to polling mode\n",
-			exec->num_cus);
+		    "request %d CUs. Fall back to polling mode\n",
+		    exec->num_cus);
 		exec->polling_mode = 1;
 	}
 
@@ -771,7 +771,7 @@ configure(struct sched_cmd *cmd)
 			continue;
 
 		ret = request_irq(zdev->irq[i], sched_exec_isr, 0,
-			"zocl", zdev);
+		    "zocl", zdev);
 		if (ret) {
 			/* Fail to install at least one interrupt
 			 * handler. We need to free the handler(s)
@@ -783,7 +783,7 @@ configure(struct sched_cmd *cmd)
 					free_irq(zdev->irq[j], zdev);
 			}
 			DRM_WARN("Fail to install CU %d interrupt handler: %d. "
-				"Fall back to polling mode.\n", i, ret);
+			    "Fall back to polling mode.\n", i, ret);
 			exec->polling_mode = 1;
 			break;
 		}
@@ -804,12 +804,12 @@ set_cu_and_print:
 print_and_out:
 	write_unlock(&zdev->attr_rwlock);
 	DRM_INFO("scheduler config ert(%d)", is_ert(cmd->ddev));
-	DRM_INFO("	cus(%d)", exec->num_cus);
-	DRM_INFO("	slots(%d)", exec->num_slots);
-	DRM_INFO("	num_cu_masks(%d)", exec->num_cu_masks);
-	DRM_INFO("	cu_shift(%d)", exec->cu_shift_offset);
-	DRM_INFO("	cu_base(0x%x)", exec->cu_base_addr);
-	DRM_INFO("	polling(%d)", exec->polling_mode);
+	DRM_INFO("  cus(%d)", exec->num_cus);
+	DRM_INFO("  slots(%d)", exec->num_slots);
+	DRM_INFO("  num_cu_masks(%d)", exec->num_cu_masks);
+	DRM_INFO("  cu_shift(%d)", exec->cu_shift_offset);
+	DRM_INFO("  cu_base(0x%x)", exec->cu_base_addr);
+	DRM_INFO("  polling(%d)", exec->polling_mode);
 	return 0;
 }
 
@@ -832,7 +832,7 @@ configure_soft_kernel(struct sched_cmd *cmd)
 	/* Check if the CU configuration exceeds maximum CU number */
 	if (cfg->start_cuidx + cfg->num_cus > MAX_CU_NUM) {
 		DRM_WARN("Soft kernel CU %d exceed maximum cu number %d.\n",
-			cfg->start_cuidx + cfg->num_cus, MAX_CU_NUM);
+		    cfg->start_cuidx + cfg->num_cus, MAX_CU_NUM);
 		mutex_unlock(&sk->sk_lock);
 		return -EINVAL;
 	}
@@ -841,7 +841,7 @@ configure_soft_kernel(struct sched_cmd *cmd)
 	for (i = cfg->start_cuidx; i < cfg->start_cuidx + cfg->num_cus; i++)
 		if (sk->sk_cu[i]) {
 			DRM_WARN("Soft Kernel CU %d is configured already.\n",
-				i);
+			    i);
 			mutex_unlock(&sk->sk_lock);
 			return -EINVAL;
 		}
@@ -897,7 +897,7 @@ unconfigure_soft_kernel(struct sched_cmd *cmd)
 	/* Check if the CU unconfiguration exceeds maximum CU number */
 	if (cfg->start_cuidx + cfg->num_cus > MAX_CU_NUM) {
 		DRM_WARN("Soft kernel CU %d exceed maximum cu number %d.\n",
-			cfg->start_cuidx + cfg->num_cus, MAX_CU_NUM);
+		    cfg->start_cuidx + cfg->num_cus, MAX_CU_NUM);
 		mutex_unlock(&sk->sk_lock);
 		return -EINVAL;
 	}
@@ -982,7 +982,7 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 	struct timespec64 tv;
 #else
-	struct timeval tv;
+    struct timeval tv;
 #endif
 	struct ert_start_kernel_cmd *sk;
 
@@ -1000,16 +1000,16 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 	 * Use 32 bits timestamp is good enough for this purpose for now.
 	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-	ktime_get_real_ts64(&tv);
+    ktime_get_real_ts64(&tv);
 #else
-	do_gettimeofday(&tv);
+    do_gettimeofday(&tv);
 #endif
 	if (ts == CU_START_TIME) {
 		*(sk->data + sk->extra_cu_masks) = (u32)tv.tv_sec;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_nsec / NSEC_PER_USEC;
 #else
-		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
+        *(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
 #endif
 	} else if (ts == CU_DONE_TIME) {
 		*(sk->data + sk->extra_cu_masks + 2) = (u32)tv.tv_sec;
@@ -1023,7 +1023,7 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 
 /**
  * acquire_slot_idx() - Acquire a slot index if available.
- *						Update slot status to busy so it cannot be reacquired.
+ *                      Update slot status to busy so it cannot be reacquired.
  *
  * This function is called from scheduler thread
  *
@@ -1045,7 +1045,7 @@ acquire_slot_idx(struct drm_device *dev)
 			continue;
 		zdev->exec->slot_status[mask_idx] ^= (1<<slot_idx);
 		SCHED_DEBUG("<- acquire_slot_idx returns %d\n",
-				slot_idx_from_mask_idx(slot_idx, mask_idx));
+			    slot_idx_from_mask_idx(slot_idx, mask_idx));
 		return slot_idx_from_mask_idx(slot_idx, mask_idx);
 	}
 	SCHED_DEBUG("<- acquire_slot_idx returns -1\n");
@@ -1069,7 +1069,7 @@ release_slot_idx(struct drm_device *dev, unsigned int slot_idx)
 	unsigned int pos = slot_idx_in_mask(slot_idx);
 
 	SCHED_DEBUG("<-> release_slot_idx slot_status[%d]=0x%x, pos=%d\n",
-			mask_idx, zdev->exec->slot_status[mask_idx], pos);
+		    mask_idx, zdev->exec->slot_status[mask_idx], pos);
 	zdev->exec->slot_status[mask_idx] ^= (1<<pos);
 }
 
@@ -1092,7 +1092,7 @@ cu_done(struct sched_cmd *cmd)
 	u32 status;
 
 	SCHED_DEBUG("-> cu_done(,%d) checks cu at address 0x%p\n",
-			cu_idx, virt_addr);
+		    cu_idx, virt_addr);
 	/* done is indicated by AP_DONE(2) alone or by AP_DONE(2) | AP_IDLE(4)
 	 * but not by AP_IDLE itself.  Since 0x10 | (0x10 | 0x100) = 0x110
 	 * checking for 0x10 is sufficient.
@@ -1120,7 +1120,7 @@ scu_done(struct sched_cmd *cmd)
 	u32 *virt_addr = sk->sk_cu[cu_idx]->sc_vregs;
 
 	SCHED_DEBUG("-> scu_done(,%d) checks scu at address 0x%p\n",
-			cu_idx, virt_addr);
+		    cu_idx, virt_addr);
 	/* We simulate hard CU here.
 	 * done is indicated by AP_DONE(2) alone or by AP_DONE(2) | AP_IDLE(4)
 	 * but not by AP_IDLE itself.  Since 0x10 | (0x10 | 0x100) = 0x110
@@ -1233,8 +1233,8 @@ notify_host(struct sched_cmd *cmd)
  * mark_cmd_complete() - Move a command to complete state
  *
  * Commands are marked complete in two ways
- *	1. Through polling of CUs or polling of MB status register
- *	2. Through interrupts from MB
+ *  1. Through polling of CUs or polling of MB status register
+ *  2. Through interrupts from MB
  * In both cases, the completed commands are residing in the completed_cmds
  * list and the number of completed commands is reflected in num_completed.
  *
@@ -1289,12 +1289,12 @@ get_free_sched_cmd(void)
  * zocl_gem_object_unref() - unreference a drm object
  *
  * @cmd: cmd owning the drm object to be unreference,
- *		 it could be CMA or normal gem buffer
+ *       it could be CMA or normal gem buffer
  *
  * Use the correct way to unreference a gem object
  *
  * TODO: Remove drm_gem_object_unreference_unlocked as soon as kernels < 4.12
- *		 are no longer supported.
+ *       are no longer supported.
  */
 void zocl_gem_object_unref(struct sched_cmd *cmd)
 {
@@ -1497,9 +1497,9 @@ reset_all(void)
 /**
  * get_free_cu() - get index of first available CU per command cu mask
  *
- * @cmd:	command containing CUs to check for availability
+ * @cmd:    command containing CUs to check for availability
  * @cu_type: ZOCL_SOFT_CU(1) to get free soft CU,
- *			 ZOCL_HARD_CU(0) to get free hard CU
+ *           ZOCL_HARD_CU(0) to get free hard CU
  *
  * This function is called kernel software scheduler mode only, in embedded
  * scheduler mode, the hardware scheduler handles the commands directly.
@@ -1519,8 +1519,8 @@ get_free_cu(struct sched_cmd *cmd, enum zocl_cu_type cu_type)
 	for (mask_idx = 0; mask_idx < num_masks; ++mask_idx) {
 		u32 cmd_mask = cmd->packet->data[mask_idx]; /* skip header */
 		u32 busy_mask = cu_type == ZOCL_SOFT_CU ?
-			exec->scu_status[mask_idx]
-			: exec->cu_status[mask_idx];
+		    exec->scu_status[mask_idx]
+		    : exec->cu_status[mask_idx];
 		u32 free_mask = (cmd_mask | busy_mask) ^ busy_mask;
 		/* For hardware cu, we have to search on valid CUs only. */
 		if (cu_type == ZOCL_HARD_CU)
@@ -1534,7 +1534,7 @@ get_free_cu(struct sched_cmd *cmd, enum zocl_cu_type cu_type)
 			else
 				zdev->exec->cu_status[mask_idx] ^= 1 << cu_idx;
 			SCHED_DEBUG("<- get_free_cu returns %d\n",
-					cu_idx_from_mask(cu_idx, mask_idx));
+				    cu_idx_from_mask(cu_idx, mask_idx));
 			return cu_idx_from_mask(cu_idx, mask_idx);
 		}
 	}
@@ -1544,7 +1544,7 @@ get_free_cu(struct sched_cmd *cmd, enum zocl_cu_type cu_type)
 
 /**
  * configure_cu() - transfer command register map to specified CU and
- *					start the CU.
+ *                  start the CU.
  *
  * @cmd: command with register map to transfer to CU
  * @cu_idx: index of CU to configure
@@ -1559,7 +1559,7 @@ configure_cu(struct sched_cmd *cmd, int cu_idx)
 	struct ert_start_kernel_cmd *sk;
 
 	SCHED_DEBUG("-> configure_cu cu_idx=%d, cu_addr=0x%p, regmap_size=%d\n",
-			cu_idx, virt_addr, size);
+		    cu_idx, virt_addr, size);
 
 	sk = (struct ert_start_kernel_cmd *)cmd->packet;
 
@@ -1578,7 +1578,7 @@ configure_cu(struct sched_cmd *cmd, int cu_idx)
 
 /**
  * ert_configure_cu() - transfer command register map to specified CU and
- *						start the CU.
+ *                      start the CU.
  *
  * @cmd: command with register map to transfer to CU
  * @cu_idx: index of CU to configure
@@ -1594,7 +1594,7 @@ ert_configure_cu(struct sched_cmd *cmd, int cu_idx)
 
 	SCHED_DEBUG("-> ert_configure_cu ");
 	SCHED_DEBUG("cu_idx=%d, cu_addr=0x%p, regmap_size=%d\n",
-			cu_idx, virt_addr, size);
+		    cu_idx, virt_addr, size);
 
 	sk = (struct ert_start_kernel_cmd *)cmd->packet;
 
@@ -1632,7 +1632,7 @@ ert_configure_scu(struct sched_cmd *cmd, int cu_idx)
 	cu_regfile = scu->sc_vregs;
 
 	SCHED_DEBUG("cu_idx=%d, cu_addr=0x%p, regmap_size=%d\n",
-			cu_idx, cu_regfile, size);
+		    cu_idx, cu_regfile, size);
 
 	/* Copy payload to soft CU register */
 	for (i = 1; i < size; ++i)
@@ -1769,9 +1769,9 @@ scheduler_iterate_cmds(struct scheduler *sched)
  * sched_wait_cond() - Check status of scheduler wait condition
  *
  * Scheduler must wait (sleep) if
- *	1. there are no pending commands
- *	2. no pending interrupt from embedded scheduler
- *	3. no pending complete commands in polling mode
+ *  1. there are no pending commands
+ *  2. no pending interrupt from embedded scheduler
+ *  3. no pending complete commands in polling mode
  *
  * Return: 1 if scheduler must wait, 0 othewise
  */
@@ -1997,7 +1997,7 @@ penguin_submit(struct sched_cmd *cmd)
 	configure_cu(cmd, cmd->cu_idx);
 
 	SCHED_DEBUG("<- penguin_submit cu_idx=%d slot=%d\n",
-			cmd->cu_idx, cmd->slot_idx);
+		    cmd->cu_idx, cmd->slot_idx);
 
 	return true;
 }
@@ -2110,7 +2110,7 @@ ps_ert_submit(struct sched_cmd *cmd)
 		}
 
 		SCHED_DEBUG("<- ps_ert_submit() cu_idx=%d slot=%d cq_slot=%d\n",
-				cmd->cu_idx, cmd->slot_idx, cmd->cq_slot_idx);
+			    cmd->cu_idx, cmd->slot_idx, cmd->cq_slot_idx);
 		break;
 
 	case ERT_START_CU:
@@ -2125,7 +2125,7 @@ ps_ert_submit(struct sched_cmd *cmd)
 		ert_configure_cu(cmd, cmd->cu_idx);
 
 		SCHED_DEBUG("<- ps_ert_submit() cu_idx=%d slot=%d cq_slot=%d\n",
-				cmd->cu_idx, cmd->slot_idx, cmd->cq_slot_idx);
+			    cmd->cu_idx, cmd->slot_idx, cmd->cq_slot_idx);
 		break;
 
 	default:
@@ -2306,7 +2306,7 @@ create_cmd_buffer(struct ert_packet *packet, unsigned slot_size)
 
 	packet->state = ERT_CMD_STATE_QUEUED;
 	SCHED_DEBUG("packet header 0x%8x, packet addr 0x%p slot size %d",
-			packet->header, packet, slot_size);
+		    packet->header, packet, slot_size);
 	buffer = kzalloc(slot_size, GFP_KERNEL);
 	if (!buffer)
 		return ERR_PTR(-ENOMEM);

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -982,7 +982,7 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 	struct timespec64 tv;
 #else
-    struct timeval tv;
+	struct timeval tv;
 #endif
 	struct ert_start_kernel_cmd *sk;
 
@@ -1000,16 +1000,16 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 	 * Use 32 bits timestamp is good enough for this purpose for now.
 	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-    ktime_get_real_ts64(&tv);
+	ktime_get_real_ts64(&tv);
 #else
-    do_gettimeofday(&tv);
+	do_gettimeofday(&tv);
 #endif
 	if (ts == CU_START_TIME) {
 		*(sk->data + sk->extra_cu_masks) = (u32)tv.tv_sec;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_nsec / NSEC_PER_USEC;
 #else
-        *(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
+		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
 #endif
 	} else if (ts == CU_DONE_TIME) {
 		*(sk->data + sk->extra_cu_masks + 2) = (u32)tv.tv_sec;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -213,13 +213,13 @@ zocl_create_svm_bo(struct drm_device *dev, void *data, struct drm_file *filp)
 		goto out_free;
 
 	zocl_describe(bo);
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->gem_base);
 #else
-    drm_gem_object_unreference_unlocked(&bo->gem_base);
+	drm_gem_object_unreference_unlocked(&bo->gem_base);
 #endif
 
 	/* Update memory usage statistics */
@@ -274,13 +274,13 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	zocl_describe(bo);
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->cma_base.base);
 #else
-    drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+	drm_gem_object_unreference_unlocked(&bo->cma_base.base);
 #endif
 
 	/*
@@ -372,13 +372,13 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	bo->flags |= XCL_BO_FLAGS_USERPTR;
 
 	zocl_describe(bo);
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->cma_base.base);
 #else
-    drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+	drm_gem_object_unreference_unlocked(&bo->cma_base.base);
 #endif
 
 	kvfree(pages);
@@ -417,13 +417,13 @@ int zocl_map_bo_ioctl(struct drm_device *dev,
 	zocl_describe(to_zocl_bo(gem_obj));
 
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 	return ret;
 }
@@ -481,13 +481,13 @@ int zocl_sync_bo_ioctl(struct drm_device *dev,
 		rc = -EINVAL;
 
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return rc;
@@ -511,13 +511,13 @@ int zocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->size = bo->cma_base.base.size;
 	args->paddr = bo->cma_base.paddr;
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return 0;
@@ -548,9 +548,9 @@ int zocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		ret = 0;
 		goto out;
 	}
-    /* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -565,13 +565,13 @@ int zocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -603,9 +603,9 @@ int zocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-    /* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -621,13 +621,13 @@ int zocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -705,24 +705,24 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 	}
 
 	zocl_describe(bo);
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->cma_base.base);
 #else
-    drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+	drm_gem_object_unreference_unlocked(&bo->cma_base.base);
 #endif
 
 	return ret;
 error:
-    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-     * no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+	 * no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&cma_obj->base)
 #else
-    drm_gem_object_unreference_unlocked(&cma_obj->base);
+	drm_gem_object_unreference_unlocked(&cma_obj->base);
 #endif
 	return ret;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -5,9 +5,9 @@
  * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Sonal Santan <sonal.santan@xilinx.com>
- *	  Umang Parekh <umang.parekh@xilinx.com>
- *	  Jan Stephan  <j.stephan@hzdr.de>
+ *    Sonal Santan <sonal.santan@xilinx.com>
+ *    Umang Parekh <umang.parekh@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -213,13 +213,13 @@ zocl_create_svm_bo(struct drm_device *dev, void *data, struct drm_file *filp)
 		goto out_free;
 
 	zocl_describe(bo);
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->gem_base);
 #else
-	drm_gem_object_unreference_unlocked(&bo->gem_base);
+    drm_gem_object_unreference_unlocked(&bo->gem_base);
 #endif
 
 	/* Update memory usage statistics */
@@ -274,21 +274,21 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	zocl_describe(bo);
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->cma_base.base);
 #else
-	drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+    drm_gem_object_unreference_unlocked(&bo->cma_base.base);
 #endif
 
 	/*
 	 * Update memory usage statistics.
 	 *
 	 * Note: We can not use args->size here because it is
-	 *		 the required size while gem object records the
-	 *		 actual size allocated.
+	 *       the required size while gem object records the
+	 *       actual size allocated.
 	 */
 	zocl_update_mem_stat(zdev, bo->gem_base.size, 1);
 
@@ -372,13 +372,13 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	bo->flags |= XCL_BO_FLAGS_USERPTR;
 
 	zocl_describe(bo);
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->cma_base.base);
 #else
-	drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+    drm_gem_object_unreference_unlocked(&bo->cma_base.base);
 #endif
 
 	kvfree(pages);
@@ -417,13 +417,13 @@ int zocl_map_bo_ioctl(struct drm_device *dev,
 	zocl_describe(to_zocl_bo(gem_obj));
 
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 	return ret;
 }
@@ -466,28 +466,28 @@ int zocl_sync_bo_ioctl(struct drm_device *dev,
 
 	/**
 	 * NOTE: We a little bit abuse the dma_sync_single_* API here because
-	 *		 it is documented as for the DMA buffer mapped by dma_map_*
-	 *		 API. The buffer we are syncing here is mapped through
-	 *		 remap_pfn_range(). But so far this is our best choice
-	 *		 and it works.
+	 *       it is documented as for the DMA buffer mapped by dma_map_*
+	 *       API. The buffer we are syncing here is mapped through
+	 *       remap_pfn_range(). But so far this is our best choice
+	 *       and it works.
 	 */
 	if (args->dir == DRM_ZOCL_SYNC_BO_TO_DEVICE) {
 		dma_sync_single_for_device(dev->dev, bus_addr, args->size,
-			DMA_TO_DEVICE);
+		    DMA_TO_DEVICE);
 	} else if (args->dir == DRM_ZOCL_SYNC_BO_FROM_DEVICE) {
 		dma_sync_single_for_cpu(dev->dev, bus_addr, args->size,
-			DMA_FROM_DEVICE);
+		    DMA_FROM_DEVICE);
 	} else
 		rc = -EINVAL;
 
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return rc;
@@ -511,13 +511,13 @@ int zocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->size = bo->cma_base.base.size;
 	args->paddr = bo->cma_base.paddr;
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return 0;
@@ -548,9 +548,9 @@ int zocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		ret = 0;
 		goto out;
 	}
-	/* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -565,13 +565,13 @@ int zocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -603,9 +603,9 @@ int zocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	/* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok macro once Linux < 5.0.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -621,13 +621,13 @@ int zocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -663,7 +663,7 @@ error:
 }
 
 int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
-			   struct drm_file *filp)
+		       struct drm_file *filp)
 {
 	struct drm_zocl_bo *bo;
 	struct drm_zocl_host_bo *args = data;
@@ -674,7 +674,7 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 	int ret;
 
 	if (!(host_mem_start <= args->paddr &&
-		  args->paddr + args->size <= host_mem_end)) {
+	      args->paddr + args->size <= host_mem_end)) {
 		DRM_ERROR("Buffer at out side of reserved memory region\n");
 		return -ENOMEM;
 	}
@@ -705,24 +705,24 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 	}
 
 	zocl_describe(bo);
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&bo->cma_base.base);
 #else
-	drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+    drm_gem_object_unreference_unlocked(&bo->cma_base.base);
 #endif
 
 	return ret;
 error:
-	/* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
-	 * no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked once Linux < 4.12 is
+     * no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&cma_obj->base)
 #else
-	drm_gem_object_unreference_unlocked(&cma_obj->base);
+    drm_gem_object_unreference_unlocked(&cma_obj->base);
 #endif
 	return ret;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -5,10 +5,10 @@
  * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Sonal Santan <sonal.santan@xilinx.com>
- *	  Umang Parekh <umang.parekh@xilinx.com>
- *	  Min Ma	   <min.ma@xilinx.com>
- *	  Jan Stephan  <j.stephan@hzdr.de>
+ *    Sonal Santan <sonal.santan@xilinx.com>
+ *    Umang Parekh <umang.parekh@xilinx.com>
+ *    Min Ma       <min.ma@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -35,18 +35,18 @@
 #include "zocl_sk.h"
 #include "sched_exec.h"
 
-#define ZOCL_DRIVER_NAME		"zocl"
-#define ZOCL_DRIVER_DESC		"Zynq BO manager"
-#define ZOCL_DRIVER_DATE		"20180313"
-#define ZOCL_DRIVER_MAJOR		2018
-#define ZOCL_DRIVER_MINOR		2
-#define ZOCL_DRIVER_PATCHLEVEL	1
+#define ZOCL_DRIVER_NAME        "zocl"
+#define ZOCL_DRIVER_DESC        "Zynq BO manager"
+#define ZOCL_DRIVER_DATE        "20180313"
+#define ZOCL_DRIVER_MAJOR       2018
+#define ZOCL_DRIVER_MINOR       2
+#define ZOCL_DRIVER_PATCHLEVEL  1
 
 /* This should be the same as DRM_FILE_PAGE_OFFSET_START in drm_gem.c */
 #if defined(CONFIG_ARM64)
-#define ZOCL_FILE_PAGE_OFFSET	0x00100000
+#define ZOCL_FILE_PAGE_OFFSET   0x00100000
 #else
-#define ZOCL_FILE_PAGE_OFFSET	0x00010000
+#define ZOCL_FILE_PAGE_OFFSET   0x00010000
 #endif
 
 #ifndef VM_RESERVED
@@ -274,13 +274,13 @@ zocl_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma)
 		 */
 		vma->vm_page_prot = prot;
 		rc = remap_pfn_range(vma, vma->vm_start,
-			cma_obj->paddr >> PAGE_SHIFT,
-			vma->vm_end - vma->vm_start,
-			prot);
+		    cma_obj->paddr >> PAGE_SHIFT,
+		    vma->vm_end - vma->vm_start,
+		    prot);
 
 	} else
 		rc = dma_mmap_wc(cma_obj->base.dev->dev, vma, cma_obj->vaddr,
-			cma_obj->paddr, vma->vm_end - vma->vm_start);
+		    cma_obj->paddr, vma->vm_end - vma->vm_start);
 
 	if (rc)
 		drm_gem_vm_close(vma);
@@ -294,12 +294,12 @@ zocl_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma)
  */
 static int zocl_mmap(struct file *filp, struct vm_area_struct *vma)
 {
-	struct drm_file		*priv = filp->private_data;
-	struct drm_device	*dev = priv->minor->dev;
+	struct drm_file     *priv = filp->private_data;
+	struct drm_device   *dev = priv->minor->dev;
 	struct drm_zocl_dev *zdev = dev->dev_private;
-	struct drm_zocl_bo	*bo = NULL;
-	unsigned long		 vsize;
-	phys_addr_t			 phy_addr;
+	struct drm_zocl_bo  *bo = NULL;
+	unsigned long        vsize;
+	phys_addr_t          phy_addr;
 	int apt_idx;
 	int rc;
 
@@ -498,40 +498,40 @@ static const struct drm_ioctl_desc zocl_ioctls[] = {
 };
 
 static const struct file_operations zocl_driver_fops = {
-	.owner			= THIS_MODULE,
-	.open			= drm_open,
-	.mmap			= zocl_mmap,
-	.poll			= zocl_poll,
-	.read			= drm_read,
+	.owner          = THIS_MODULE,
+	.open           = drm_open,
+	.mmap           = zocl_mmap,
+	.poll           = zocl_poll,
+	.read           = drm_read,
 	.unlocked_ioctl = drm_ioctl,
-	.release		= drm_release,
+	.release        = drm_release,
 };
 
 static struct drm_driver zocl_driver = {
-	.driver_features		   = DRIVER_GEM | DRIVER_PRIME | DRIVER_RENDER,
-	.open					   = zocl_client_open,
-	.postclose				   = zocl_client_release,
-	.gem_free_object		   = zocl_free_bo,
-	.gem_vm_ops				   = &zocl_bo_vm_ops,
-	.gem_create_object		   = zocl_gem_create_object,
-	.prime_handle_to_fd		   = drm_gem_prime_handle_to_fd,
-	.prime_fd_to_handle		   = drm_gem_prime_fd_to_handle,
-	.gem_prime_import		   = drm_gem_prime_import,
-	.gem_prime_export		   = drm_gem_prime_export,
+	.driver_features           = DRIVER_GEM | DRIVER_PRIME | DRIVER_RENDER,
+	.open                      = zocl_client_open,
+	.postclose                 = zocl_client_release,
+	.gem_free_object           = zocl_free_bo,
+	.gem_vm_ops                = &zocl_bo_vm_ops,
+	.gem_create_object         = zocl_gem_create_object,
+	.prime_handle_to_fd        = drm_gem_prime_handle_to_fd,
+	.prime_fd_to_handle        = drm_gem_prime_fd_to_handle,
+	.gem_prime_import          = drm_gem_prime_import,
+	.gem_prime_export          = drm_gem_prime_export,
 	.gem_prime_get_sg_table    = drm_gem_cma_prime_get_sg_table,
 	.gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table,
-	.gem_prime_vmap			   = drm_gem_cma_prime_vmap,
-	.gem_prime_vunmap		   = drm_gem_cma_prime_vunmap,
-	.gem_prime_mmap			   = drm_gem_cma_prime_mmap,
-	.ioctls					   = zocl_ioctls,
-	.num_ioctls				   = ARRAY_SIZE(zocl_ioctls),
-	.fops					   = &zocl_driver_fops,
-	.name					   = ZOCL_DRIVER_NAME,
-	.desc					   = ZOCL_DRIVER_DESC,
-	.date					   = ZOCL_DRIVER_DATE,
-	.major					   = ZOCL_DRIVER_MAJOR,
-	.minor					   = ZOCL_DRIVER_MINOR,
-	.patchlevel				   = ZOCL_DRIVER_PATCHLEVEL,
+	.gem_prime_vmap            = drm_gem_cma_prime_vmap,
+	.gem_prime_vunmap          = drm_gem_cma_prime_vunmap,
+	.gem_prime_mmap            = drm_gem_cma_prime_mmap,
+	.ioctls                    = zocl_ioctls,
+	.num_ioctls                = ARRAY_SIZE(zocl_ioctls),
+	.fops                      = &zocl_driver_fops,
+	.name                      = ZOCL_DRIVER_NAME,
+	.desc                      = ZOCL_DRIVER_DESC,
+	.date                      = ZOCL_DRIVER_DATE,
+	.major                     = ZOCL_DRIVER_MAJOR,
+	.minor                     = ZOCL_DRIVER_MINOR,
+	.patchlevel                = ZOCL_DRIVER_PATCHLEVEL,
 };
 
 static const struct of_device_id zocl_drm_of_match[] = {
@@ -651,7 +651,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		goto err0;
 
 	drm->dev_private = zdev;
-	zdev->ddev		 = drm;
+	zdev->ddev       = drm;
 
 	/* Initial sysfs */
 	rwlock_init(&zdev->attr_rwlock);
@@ -668,11 +668,11 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 err1:
 	zocl_fini_sysfs(drm->dev);
 err0:
-	/* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
+    /* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 	drm_dev_put(drm);
 #else
-	drm_dev_unref(drm);
+    drm_dev_unref(drm);
 #endif
 	return ret;
 }
@@ -700,11 +700,11 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 
 	if (drm) {
 		drm_dev_unregister(drm);
-	/* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
+    /* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 		drm_dev_put(drm);
 #else
-		drm_dev_unref(drm);
+        drm_dev_unref(drm);
 #endif
 	}
 
@@ -715,7 +715,7 @@ static struct platform_driver zocl_drm_private_driver = {
 	.probe			= zocl_drm_platform_probe,
 	.remove			= zocl_drm_platform_remove,
 	.driver			= {
-		.name				= "zocl-drm",
+		.name		        = "zocl-drm",
 		.of_match_table	= zocl_drm_of_match,
 	},
 };

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -30,7 +30,6 @@
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
 #include <linux/spinlock.h>
-#include <linux/version.h>
 #include "zocl_drv.h"
 #include "zocl_sk.h"
 #include "sched_exec.h"
@@ -668,12 +667,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 err1:
 	zocl_fini_sysfs(drm->dev);
 err0:
-	/* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
-	drm_dev_put(drm);
-#else
-	drm_dev_unref(drm);
-#endif
+	ZOCL_DRM_DEV_PUT(drm);
 	return ret;
 }
 
@@ -700,12 +694,7 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 
 	if (drm) {
 		drm_dev_unregister(drm);
-	/* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
-		drm_dev_put(drm);
-#else
-		drm_dev_unref(drm);
-#endif
+		ZOCL_DRM_DEV_PUT(drm);
 	}
 
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -668,11 +668,11 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 err1:
 	zocl_fini_sysfs(drm->dev);
 err0:
-    /* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
+	/* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 	drm_dev_put(drm);
 #else
-    drm_dev_unref(drm);
+	drm_dev_unref(drm);
 #endif
 	return ret;
 }
@@ -700,11 +700,11 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 
 	if (drm) {
 		drm_dev_unregister(drm);
-    /* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
+	/* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 		drm_dev_put(drm);
 #else
-        drm_dev_unref(drm);
+		drm_dev_unref(drm);
 #endif
 	}
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -8,6 +8,7 @@
  *    Sonal Santan <sonal.santan@xilinx.com>
  *    Umang Parekh <umang.parekh@xilinx.com>
  *    Min Ma       <min.ma@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -29,6 +30,7 @@
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
 #include <linux/spinlock.h>
+#include <linux/version.h>
 #include "zocl_drv.h"
 #include "zocl_sk.h"
 #include "sched_exec.h"
@@ -666,7 +668,12 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 err1:
 	zocl_fini_sysfs(drm->dev);
 err0:
-	drm_dev_unref(drm);
+    /* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+	drm_dev_put(drm);
+#else
+    drm_dev_unref(drm);
+#endif
 	return ret;
 }
 
@@ -693,7 +700,12 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 
 	if (drm) {
 		drm_dev_unregister(drm);
-		drm_dev_unref(drm);
+    /* TODO: Remove drm_dev_unref once Linux < 4.15 is no longer supported. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+		drm_dev_put(drm);
+#else
+        drm_dev_unref(drm);
+#endif
 	}
 
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -6,6 +6,7 @@
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -18,6 +19,7 @@
  */
 
 #include <linux/fpga/fpga-mgr.h>
+#include <linux/version.h>
 #include "zocl_drv.h"
 #include "xclbin.h"
 
@@ -288,7 +290,14 @@ int zocl_pcap_download_ioctl(struct drm_device *dev, void *data,
 
 	buffer = (char __user *)args->xclbin;
 
+    /* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
+     * supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	if (!access_ok(buffer, bin_obj.m_length))
+#else
 	if (!access_ok(VERIFY_READ, buffer, bin_obj.m_length))
+#endif
 		return -EFAULT;
 
 	buffer += primary_fw_off;
@@ -499,7 +508,14 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	xclbin = (char __user *)axlf_obj->xclbin;
-	ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
+    /* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
+     * supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	ret = !access_ok(xclbin, axlf_head.m_header.m_length);
+#else
+    ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
+#endif
 	if (ret) {
 		ret = -EFAULT;
 		goto out0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Sonal Santan <sonal.santan@xilinx.com>
- *	  Jan Stephan  <j.stephan@hzdr.de>
+ *    Sonal Santan <sonal.santan@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -28,25 +28,25 @@
  * Bitstream header information.
  */
 struct {
-	unsigned int HeaderLength;	   /* Length of header in 32 bit words */
+	unsigned int HeaderLength;     /* Length of header in 32 bit words */
 	unsigned int BitstreamLength;  /* Length of bitstream to read in bytes*/
-	unsigned char *DesignName;	   /* Design name get from bitstream */
-	unsigned char *PartName;	   /* Part name read from bitstream */
-	unsigned char *Date;		   /* Date read from bitstream header */
-	unsigned char *Time;		   /* Bitstream creation time*/
-	unsigned int MagicLength;	   /* Length of the magic numbers*/
+	unsigned char *DesignName;     /* Design name get from bitstream */
+	unsigned char *PartName;       /* Part name read from bitstream */
+	unsigned char *Date;           /* Date read from bitstream header */
+	unsigned char *Time;           /* Bitstream creation time*/
+	unsigned int MagicLength;      /* Length of the magic numbers*/
 } XHwIcap_Bit_Header;
 
 /* Used for parsing bitstream header */
-#define XHI_EVEN_MAGIC_BYTE		0x0f
-#define XHI_ODD_MAGIC_BYTE		0xf0
+#define XHI_EVEN_MAGIC_BYTE     0x0f
+#define XHI_ODD_MAGIC_BYTE      0xf0
 
 /* Extra mode for IDLE */
 #define XHI_OP_IDLE  -1
 #define XHI_BIT_HEADER_FAILURE -1
 
 /* The imaginary module length register */
-#define XHI_MLR					 15
+#define XHI_MLR                  15
 
 #define DMA_HWICAP_BITFILE_BUFFER_SIZE 1024
 #define BITFILE_BUFFER_SIZE DMA_HWICAP_BITFILE_BUFFER_SIZE
@@ -75,10 +75,10 @@ static int bitstream_parse_header(const unsigned char *Data, unsigned int Size,
 	for (i = 0; i < Header->Magiclength - 1; i++) {
 		tmp = Data[idx++];
 		if (i%2 == 0 && tmp != XHI_EVEN_MAGIC_BYTE)
-			return -1;	 /* INVALID_FILE_HEADER_ERROR */
+			return -1;   /* INVALID_FILE_HEADER_ERROR */
 
 		if (i%2 == 1 && tmp != XHI_ODD_MAGIC_BYTE)
-			return -1;	 /* INVALID_FILE_HEADER_ERROR */
+			return -1;   /* INVALID_FILE_HEADER_ERROR */
 
 	}
 
@@ -191,7 +191,7 @@ static int bitstream_parse_header(const unsigned char *Data, unsigned int Size,
 }
 
 static int zocl_pcap_download(struct drm_zocl_dev *zdev,
-				  const void __user *bit_buf, unsigned long length)
+			      const void __user *bit_buf, unsigned long length)
 {
 	struct fpga_manager *fpga_mgr = zdev->fpga_mgr;
 	XHwIcap_Bit_Header bit_header;
@@ -266,7 +266,7 @@ free_buffers:
 }
 
 int zocl_pcap_download_ioctl(struct drm_device *dev, void *data,
-				 struct drm_file *filp)
+			     struct drm_file *filp)
 {
 	struct xclBin bin_obj;
 	char __user *buffer;
@@ -290,9 +290,9 @@ int zocl_pcap_download_ioctl(struct drm_device *dev, void *data,
 
 	buffer = (char __user *)args->xclbin;
 
-	/* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(buffer, bin_obj.m_length))
 #else
@@ -348,8 +348,8 @@ zocl_check_section(struct axlf_section_header *header, uint64_t xclbin_len,
 	uint64_t size;
 
 	DRM_INFO("Section %s details:", kind_to_string(kind));
-	DRM_INFO("	offset = 0x%llx", header->m_sectionOffset);
-	DRM_INFO("	size = 0x%llx", header->m_sectionSize);
+	DRM_INFO("  offset = 0x%llx", header->m_sectionOffset);
+	DRM_INFO("  size = 0x%llx", header->m_sectionSize);
 
 	offset = header->m_sectionOffset;
 	size = header->m_sectionSize;
@@ -445,7 +445,7 @@ zocl_update_apertures(struct drm_zocl_dev *zdev)
 			dbg_ip = &zdev->debug_ip->m_debug_ip_data[i];
 			apt[zdev->num_apts].addr = dbg_ip->m_base_address;
 			if (dbg_ip->m_type == AXI_MONITOR_FIFO_LITE
-				|| dbg_ip->m_type == AXI_MONITOR_FIFO_FULL)
+			    || dbg_ip->m_type == AXI_MONITOR_FIFO_FULL)
 				/* FIFO_LITE has 4KB and FIFO FULL has 8KB
 				 * address range. Use both 8K is okay.
 				 */
@@ -508,13 +508,13 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	xclbin = (char __user *)axlf_obj->xclbin;
-	/* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	ret = !access_ok(xclbin, axlf_head.m_header.m_length);
 #else
-	ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
+    ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
 #endif
 	if (ret) {
 		ret = -EFAULT;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -19,7 +19,6 @@
  */
 
 #include <linux/fpga/fpga-mgr.h>
-#include <linux/version.h>
 #include "zocl_drv.h"
 #include "xclbin.h"
 
@@ -290,14 +289,7 @@ int zocl_pcap_download_ioctl(struct drm_device *dev, void *data,
 
 	buffer = (char __user *)args->xclbin;
 
-	/* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	if (!access_ok(buffer, bin_obj.m_length))
-#else
-	if (!access_ok(VERIFY_READ, buffer, bin_obj.m_length))
-#endif
+	if (!ZOCL_ACCESS_OK(VERIFY_READ, buffer, bin_obj.m_length))
 		return -EFAULT;
 
 	buffer += primary_fw_off;
@@ -508,14 +500,7 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	xclbin = (char __user *)axlf_obj->xclbin;
-	/* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	ret = !access_ok(xclbin, axlf_head.m_header.m_length);
-#else
-	ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
-#endif
+	ret = !ZOCL_ACCESS_OK(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
 	if (ret) {
 		ret = -EFAULT;
 		goto out0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -290,9 +290,9 @@ int zocl_pcap_download_ioctl(struct drm_device *dev, void *data,
 
 	buffer = (char __user *)args->xclbin;
 
-    /* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(buffer, bin_obj.m_length))
 #else
@@ -508,13 +508,13 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	xclbin = (char __user *)axlf_obj->xclbin;
-    /* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok as soon as Linux < 5.0.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	ret = !access_ok(xclbin, axlf_head.m_header.m_length);
 #else
-    ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
+	ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
 #endif
 	if (ret) {
 		ret = -EFAULT;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -112,13 +112,13 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	sk->sk_cu[cu_idx]->sc_vregs = bo->cma_base.vaddr;
 	sema_init(&sk->sk_cu[cu_idx]->sc_sem, 0);
 
-    /* TODO: Remove drm_gem_object_unreference as soon as Linux < 4.12 is no
-     * longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference as soon as Linux < 4.12 is no
+	 * longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -18,8 +18,6 @@
  * GNU General Public License for more details.
  */
 
-#include <linux/version.h>
-
 #include "ert.h"
 #include "zocl_drv.h"
 #include "zocl_sk.h"
@@ -112,14 +110,7 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	sk->sk_cu[cu_idx]->sc_vregs = bo->cma_base.vaddr;
 	sema_init(&sk->sk_cu[cu_idx]->sc_sem, 0);
 
-	/* TODO: Remove drm_gem_object_unreference as soon as Linux < 4.12 is no
-	 * longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(gem_obj);
-#else
-	drm_gem_object_unreference_unlocked(gem_obj);
-#endif
+	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -6,6 +6,7 @@
  *
  * Authors:
  *    Larry Liu       <yliu@xilinx.com>
+ *    Jan Stephan     <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -16,6 +17,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+
+#include <linux/version.h>
 
 #include "ert.h"
 #include "zocl_drv.h"
@@ -109,7 +112,14 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	sk->sk_cu[cu_idx]->sc_vregs = bo->cma_base.vaddr;
 	sema_init(&sk->sk_cu[cu_idx]->sc_sem, 0);
 
-	drm_gem_object_unreference_unlocked(gem_obj);
+    /* TODO: Remove drm_gem_object_unreference as soon as Linux < 4.12 is no
+     * longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(gem_obj);
+#else
+    drm_gem_object_unreference_unlocked(gem_obj);
+#endif
 
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -5,8 +5,8 @@
  * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Larry Liu		  <yliu@xilinx.com>
- *	  Jan Stephan	  <j.stephan@hzdr.de>
+ *    Larry Liu       <yliu@xilinx.com>
+ *    Jan Stephan     <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -38,13 +38,13 @@ zocl_sk_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	while (list_empty(&sk->sk_cmd_list)) {
 		mutex_unlock(&sk->sk_lock);
 		if (wait_event_interruptible(sk->sk_wait_queue,
-			!list_empty(&sk->sk_cmd_list)))
+		    !list_empty(&sk->sk_cmd_list)))
 			return -ERESTARTSYS;
 		mutex_lock(&sk->sk_lock);
 	}
 
 	scmd = list_first_entry(&sk->sk_cmd_list, struct soft_kernel_cmd,
-		skc_list);
+	    skc_list);
 	list_del(&scmd->skc_list);
 	mutex_unlock(&sk->sk_lock);
 
@@ -63,11 +63,11 @@ zocl_sk_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		kdata->paddr = cmd->sk_addr;
 
 		snprintf(kdata->name, ZOCL_MAX_NAME_LENGTH, "%s",
-			(char *)cmd->sk_name);
+		    (char *)cmd->sk_name);
 	} else
 		/* We will handle more opcodes */
 		DRM_WARN("Unknown soft kernel command: %d\n",
-			kdata->opcode);
+		    kdata->opcode);
 
 	kfree(scmd);
 	return 0;
@@ -87,7 +87,7 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	if (sk->sk_cu[cu_idx]) {
 		DRM_ERROR("Fail to create soft kernel: CU %d created.\n",
-			cu_idx);
+		    cu_idx);
 		mutex_unlock(&sk->sk_lock);
 		return -EINVAL;
 	}
@@ -105,20 +105,20 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	gem_obj = zocl_gem_object_lookup(dev, filp, args->handle);
 	if (!gem_obj) {
 		DRM_ERROR("Fail to create soft kernel: BO %d does not exist.\n",
-			args->handle);
+		    args->handle);
 		return -ENXIO;
 	}
 	bo = to_zocl_bo(gem_obj);
 	sk->sk_cu[cu_idx]->sc_vregs = bo->cma_base.vaddr;
 	sema_init(&sk->sk_cu[cu_idx]->sc_sem, 0);
 
-	/* TODO: Remove drm_gem_object_unreference as soon as Linux < 4.12 is no
-	 * longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference as soon as Linux < 4.12 is no
+     * longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return 0;
@@ -126,7 +126,7 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 int
 zocl_sk_report_ioctl(struct drm_device *dev, void *data,
-		struct drm_file *filp)
+   		struct drm_file *filp)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
 	struct soft_kernel *sk = zdev->soft_kernel;
@@ -141,7 +141,7 @@ zocl_sk_report_ioctl(struct drm_device *dev, void *data,
 
 	if (args->cu_idx > sk->sk_ncus) {
 		DRM_ERROR("Fail to get cu state: CU %d does not exist.\n",
-			cu_idx);
+		    cu_idx);
 		mutex_unlock(&sk->sk_lock);
 		return -ENXIO;
 	}
@@ -197,8 +197,8 @@ zocl_sk_report_ioctl(struct drm_device *dev, void *data,
 int
 zocl_init_soft_kernel(struct drm_device *drm)
 {
-		struct drm_zocl_dev *zdev = drm->dev_private;
-		struct soft_kernel *sk;
+        struct drm_zocl_dev *zdev = drm->dev_private;
+        struct soft_kernel *sk;
 
 	sk = devm_kzalloc(drm->dev, sizeof (*sk), GFP_KERNEL);
 	if (!sk)

--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
@@ -267,16 +267,16 @@ static long char_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	if (_IOC_TYPE(cmd) != XCLMGMT_IOC_MAGIC)
 		return -ENOTTY;
 
-    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	result =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 #else
-    if (_IOC_DIR(cmd) & _IOC_READ)
-        result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
-    else if(_IOC_DIR(cmd) & _IOC_WRITE)
-        result =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+	if (_IOC_DIR(cmd) & _IOC_READ)
+		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+	else if(_IOC_DIR(cmd) & _IOC_WRITE)
+		result = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 #endif
 	if (result)
 		return -EFAULT;

--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
@@ -267,17 +267,11 @@ static long char_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	if (_IOC_TYPE(cmd) != XCLMGMT_IOC_MAGIC)
 		return -ENOTTY;
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	result =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
-#else
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		result = !AWSMGMT_ACCESS_OK(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
 	else if(_IOC_DIR(cmd) & _IOC_WRITE)
-		result = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
-#endif
+		result = !AWSMGMT_ACCESS_OK(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+
 	if (result)
 		return -EFAULT;
 

--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.c
@@ -7,6 +7,7 @@
  *
  * Author(s):
  * Sonal Santan <sonal.santan@xilinx.com>
+ * Jan Stephan  <j.stephan@hzdr.de>
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
@@ -266,11 +267,17 @@ static long char_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	if (_IOC_TYPE(cmd) != XCLMGMT_IOC_MAGIC)
 		return -ENOTTY;
 
-	if (_IOC_DIR(cmd) & _IOC_READ)
-		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
-	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		result =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
-
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	result =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+#else
+    if (_IOC_DIR(cmd) & _IOC_READ)
+        result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+    else if(_IOC_DIR(cmd) & _IOC_WRITE)
+        result =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+#endif
 	if (result)
 		return -EFAULT;
 

--- a/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/aws/kernel/mgmt/mgmt-core.h
@@ -23,6 +23,14 @@
 #define AWSMGMT_DRIVER_MINOR 2
 #define AWSMGMT_DRIVER_PATCHLEVEL 1
 
+/* Ensure compatibility with newer Linux kernels. */
+/* access_ok lost its first parameter with Linux 5.0. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	#define AWSMGMT_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(ADDR, SIZE)
+#else
+	#define AWSMGMT_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(TYPE, ADDR, SIZE)
+#endif
+
 enum AWSMGMT_BARS {
     AWSMGMT_MAIN_BAR = 0,
     AWSMGMT_MAILBOX_BAR,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_compat.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_compat.h
@@ -45,17 +45,6 @@
 
 #endif
 
-/* use simple wait queue (swaitq) with newer kernels */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-#include <linux/swait.h>
-
-#define qdma_wait_queue			struct swait_queue_head
-#define qdma_waitq_init			init_swait_queue_head
-#define qdma_waitq_wakeup		swake_up
-#define qdma_waitq_wait_event		swait_event_interruptible
-#define qdma_waitq_wait_event_timeout	swait_event_interruptible_timeout
-
-#else
 #include <linux/wait.h>
 
 #define qdma_wait_queue			wait_queue_head_t
@@ -63,8 +52,6 @@
 #define qdma_waitq_wakeup		wake_up_interruptible
 #define qdma_waitq_wait_event		wait_event_interruptible
 #define qdma_waitq_wait_event_timeout	wait_event_interruptible_timeout
-
-#endif	/* swaitq */
 
 /* timer */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
@@ -114,16 +114,16 @@ long mgmt_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	if (!lro->ready || _IOC_TYPE(cmd) != XCLMGMT_IOC_MAGIC)
 		return -ENOTTY;
 
-    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	result = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 #else
-    if (_IOC_DIR(cmd) & _IOC_READ)
-        result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
-    else if (_IOC_DIR(cmd) & _IOC_WRITE)
-        result =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+	if (_IOC_DIR(cmd) & _IOC_READ)
+		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+	else if (_IOC_DIR(cmd) & _IOC_WRITE)
+		result = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 #endif
 	if (result)
 		return -EFAULT;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-ioctl.c
@@ -16,7 +16,6 @@
  */
 
 #include "mgmt-core.h"
-#include <linux/version.h>
 
 static int err_info_ioctl(struct xclmgmt_dev *lro, void __user *arg)
 {
@@ -114,17 +113,11 @@ long mgmt_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	if (!lro->ready || _IOC_TYPE(cmd) != XCLMGMT_IOC_MAGIC)
 		return -ENOTTY;
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	result = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
-#else
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		result = !XOCL_ACCESS_OK(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		result = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
-#endif
+		result = !XOCL_ACCESS_OK(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+
 	if (result)
 		return -EFAULT;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -274,11 +274,11 @@ static const struct attribute_group firewall_attrgroup = {
 static u32 check_firewall(struct platform_device *pdev, int *level)
 {
 	struct firewall	*fw;
-    /* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported. */
+	/* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 	struct timespec64 time;
 #else
-    struct timeval time;
+	struct timeval time;
 #endif
 	int	i;
 	u32	val = 0;
@@ -296,13 +296,13 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 			if (!fw->curr_status) {
 				fw->err_detected_status = val;
 				fw->err_detected_level = i;
-                /* TODO: Remove do_gettimeofday once Linux < 3.17 is no longer
-                 * supported.
-                 */
+				/* TODO: Remove do_gettimeofday once Linux < 3.17 is no longer
+				 * supported.
+				 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-                ktime_get_real_ts64(&time);
+				ktime_get_real_ts64(&time);
 #else
-                do_gettimeofday(&time);
+				do_gettimeofday(&time);
 #endif
 				fw->err_detected_time = (u64)(time.tv_sec -
 					(sys_tz.tz_minuteswest * 60));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -20,7 +20,6 @@
 #include <linux/platform_device.h>
 #include <linux/hwmon-sysfs.h>
 #include <linux/rtc.h>
-#include <linux/version.h>
 #include "../xocl_drv.h"
 
 /* Firewall registers */
@@ -274,12 +273,7 @@ static const struct attribute_group firewall_attrgroup = {
 static u32 check_firewall(struct platform_device *pdev, int *level)
 {
 	struct firewall	*fw;
-	/* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported. */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-	struct timespec64 time;
-#else
-	struct timeval time;
-#endif
+	XOCL_TIMESPEC time;
 	int	i;
 	u32	val = 0;
 
@@ -296,14 +290,7 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 			if (!fw->curr_status) {
 				fw->err_detected_status = val;
 				fw->err_detected_level = i;
-				/* TODO: Remove do_gettimeofday once Linux < 3.17 is no longer
-				 * supported.
-				 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-				ktime_get_real_ts64(&time);
-#else
-				do_gettimeofday(&time);
-#endif
+				XOCL_GETTIME(&time);
 				fw->err_detected_time = (u64)(time.tv_sec -
 					(sys_tz.tz_minuteswest * 60));
 			}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -3,7 +3,7 @@
  *
  *  Utility Functions for AXI firewall IP.
  *  Author: Lizhi.Hou@Xilinx.com
- *          j.stephan@hzdr.de
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -1,19 +1,19 @@
 /**
- *	Copyright (C) 2017 Xilinx, Inc. All rights reserved.
+ *  Copyright (C) 2017 Xilinx, Inc. All rights reserved.
  *
- *	Utility Functions for AXI firewall IP.
- *	Author: Lizhi.Hou@Xilinx.com
- *			j.stephan@hzdr.de
+ *  Utility Functions for AXI firewall IP.
+ *  Author: Lizhi.Hou@Xilinx.com
+ *          j.stephan@hzdr.de
  *
- *	This program is free software; you can redistribute it and/or modify
- *	it under the terms of the GNU General Public License as published by
- *	the Free Software Foundation; either version 2 of the License, or
- *	(at your option) any later version.
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
  *
- *	This program is distributed in the hope that it will be useful,
- *	but WITHOUT ANY WARRANTY; without even the implied warranty of
- *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *	GNU General Public License for more details.
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  */
 
 #include <linux/pci.h>
@@ -28,16 +28,16 @@
 #define	SOFT_CTRL				0x4
 #define	UNBLOCK_CTRL				0x8
 // Firewall error bits
-#define READ_RESPONSE_BUSY						  BIT(0)
-#define RECS_ARREADY_MAX_WAIT					  BIT(1)
-#define RECS_CONTINUOUS_RTRANSFERS_MAX_WAIT		  BIT(2)
-#define ERRS_RDATA_NUM							  BIT(3)
-#define ERRS_RID								  BIT(4)
-#define WRITE_RESPONSE_BUSY						  BIT(16)
-#define RECS_AWREADY_MAX_WAIT					  BIT(17)
-#define RECS_WREADY_MAX_WAIT					  BIT(18)
-#define RECS_WRITE_TO_BVALID_MAX_WAIT			  BIT(19)
-#define ERRS_BRESP								  BIT(20)
+#define READ_RESPONSE_BUSY                        BIT(0)
+#define RECS_ARREADY_MAX_WAIT                     BIT(1)
+#define RECS_CONTINUOUS_RTRANSFERS_MAX_WAIT       BIT(2)
+#define ERRS_RDATA_NUM                            BIT(3)
+#define ERRS_RID                                  BIT(4)
+#define WRITE_RESPONSE_BUSY                       BIT(16)
+#define RECS_AWREADY_MAX_WAIT                     BIT(17)
+#define RECS_WREADY_MAX_WAIT                      BIT(18)
+#define RECS_WRITE_TO_BVALID_MAX_WAIT             BIT(19)
+#define ERRS_BRESP                                BIT(20)
 
 // Get the timezone info from the linux kernel
 extern struct timezone sys_tz;
@@ -274,11 +274,11 @@ static const struct attribute_group firewall_attrgroup = {
 static u32 check_firewall(struct platform_device *pdev, int *level)
 {
 	struct firewall	*fw;
-	/* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported. */
+    /* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 	struct timespec64 time;
 #else
-	struct timeval time;
+    struct timeval time;
 #endif
 	int	i;
 	u32	val = 0;
@@ -296,13 +296,13 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 			if (!fw->curr_status) {
 				fw->err_detected_status = val;
 				fw->err_detected_level = i;
-				/* TODO: Remove do_gettimeofday once Linux < 3.17 is no longer
-				 * supported.
-				 */
+                /* TODO: Remove do_gettimeofday once Linux < 3.17 is no longer
+                 * supported.
+                 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-				ktime_get_real_ts64(&time);
+                ktime_get_real_ts64(&time);
 #else
-				do_gettimeofday(&time);
+                do_gettimeofday(&time);
 #endif
 				fw->err_detected_time = (u64)(time.tv_sec -
 					(sys_tz.tz_minuteswest * 60));
@@ -418,7 +418,7 @@ static struct xocl_firewall_funcs fw_ops = {
 static int firewall_remove(struct platform_device *pdev)
 {
 	struct firewall *fw;
-	int		i;
+	int     i;
 
 	fw = platform_get_drvdata(pdev);
 	if (!fw) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -158,9 +158,9 @@ static int fmgr_probe(struct platform_device *pdev)
 	struct xfpga_klass *obj = kzalloc(sizeof(struct xfpga_klass), GFP_KERNEL);
 	if (!obj)
 		return -ENOMEM;
-    /* TODO: Remove old fpga_mgr_register call as soon as Linux < 4.18 is no
-     * longer supported.
-     */
+	/* TODO: Remove old fpga_mgr_register call as soon as Linux < 4.18 is no
+	 * longer supported.
+	 */
 #if defined(FPGA_MGR_SUPPORT) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0))
 	struct fpga_manager *mgr = platform_get_drvdata(pdev);
 #endif
@@ -172,7 +172,7 @@ static int fmgr_probe(struct platform_device *pdev)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 	ret = fpga_mgr_register(mgr);
 #else
-    ret = fpga_mgr_register(&pdev->dev, obj->name, &xocl_pr_ops, obj);
+	ret = fpga_mgr_register(&pdev->dev, obj->name, &xocl_pr_ops, obj);
 #endif // LINUX_VERSION_CODE
 #else
 	platform_set_drvdata(pdev, obj);
@@ -187,13 +187,13 @@ static int fmgr_remove(struct platform_device *pdev)
 	struct xfpga_klass *obj = mgr->priv;
 
 	obj->state = FPGA_MGR_STATE_UNKNOWN;
-    /* TODO: Remove old fpga_mgr_unregister as soon as Linux < 4.18 is no
-     * longer supported.
-     */
+	/* TODO: Remove old fpga_mgr_unregister as soon as Linux < 4.18 is no
+	 * longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 	fpga_mgr_unregister(mgr);
 #else
-    fpga_mgr_unregister(&pdev->dev);
+	fpga_mgr_unregister(&pdev->dev);
 #endif // LINUX_VERSION_CODE
 #else
 	struct xfpga_klass *obj = platform_get_drvdata(pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Sonal Santan
- *			Jan Stephan <j.stephan@hzdr.de>
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -51,17 +51,17 @@ struct xfpga_klass {
 
 #if defined(FPGA_MGR_SUPPORT)
 static int xocl_pr_write_init(struct fpga_manager *mgr,
-				  struct fpga_image_info *info, const char *buf, size_t count)
+			      struct fpga_image_info *info, const char *buf, size_t count)
 {
 	struct xfpga_klass *obj = mgr->priv;
 	const struct axlf *bin = (const struct axlf *)buf;
 	if (count < sizeof(struct axlf)) {
-		obj->state = FPGA_MGR_STATE_WRITE_INIT_ERR;
+	 	obj->state = FPGA_MGR_STATE_WRITE_INIT_ERR;
 		return -EINVAL;
 	}
 
 	if (count > bin->m_header.m_length) {
-		obj->state = FPGA_MGR_STATE_WRITE_INIT_ERR;
+	 	obj->state = FPGA_MGR_STATE_WRITE_INIT_ERR;
 		return -EINVAL;
 	}
 
@@ -158,9 +158,9 @@ static int fmgr_probe(struct platform_device *pdev)
 	struct xfpga_klass *obj = kzalloc(sizeof(struct xfpga_klass), GFP_KERNEL);
 	if (!obj)
 		return -ENOMEM;
-	/* TODO: Remove old fpga_mgr_register call as soon as Linux < 4.18 is no
-	 * longer supported.
-	 */
+    /* TODO: Remove old fpga_mgr_register call as soon as Linux < 4.18 is no
+     * longer supported.
+     */
 #if defined(FPGA_MGR_SUPPORT) && (LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0))
 	struct fpga_manager *mgr = platform_get_drvdata(pdev);
 #endif
@@ -172,7 +172,7 @@ static int fmgr_probe(struct platform_device *pdev)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 	ret = fpga_mgr_register(mgr);
 #else
-	ret = fpga_mgr_register(&pdev->dev, obj->name, &xocl_pr_ops, obj);
+    ret = fpga_mgr_register(&pdev->dev, obj->name, &xocl_pr_ops, obj);
 #endif // LINUX_VERSION_CODE
 #else
 	platform_set_drvdata(pdev, obj);
@@ -187,13 +187,13 @@ static int fmgr_remove(struct platform_device *pdev)
 	struct xfpga_klass *obj = mgr->priv;
 
 	obj->state = FPGA_MGR_STATE_UNKNOWN;
-	/* TODO: Remove old fpga_mgr_unregister as soon as Linux < 4.18 is no
-	 * longer supported.
-	 */
+    /* TODO: Remove old fpga_mgr_unregister as soon as Linux < 4.18 is no
+     * longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
 	fpga_mgr_unregister(mgr);
 #else
-	fpga_mgr_unregister(&pdev->dev);
+    fpga_mgr_unregister(&pdev->dev);
 #endif // LINUX_VERSION_CODE
 #else
 	struct xfpga_klass *obj = platform_get_drvdata(pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -158,6 +158,7 @@ static int fmgr_probe(struct platform_device *pdev)
 	struct xfpga_klass *obj = kzalloc(sizeof(struct xfpga_klass), GFP_KERNEL);
 	if (!obj)
 		return -ENOMEM;
+
 	/* TODO: Remove old fpga_mgr_register call as soon as Linux < 4.18 is no
 	 * longer supported.
 	 */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -435,13 +435,13 @@ static inline void
 cmd_release_gem_object_reference(struct xocl_cmd *xcmd)
 {
 	if (xcmd->bo)
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&xcmd->bo->base);
 #else
-        drm_gem_object_unreference_unlocked(&xcmd->bo->base);
+		drm_gem_object_unreference_unlocked(&xcmd->bo->base);
 #endif
 }
 
@@ -486,13 +486,13 @@ cmd_chain_dependencies(struct xocl_cmd *xcmd)
 		struct xocl_cmd *chain_to = dbo->metadata.active;
 		// release reference created in ioctl call when dependency was looked up
 		// see comments in xocl_ioctl.c:xocl_execbuf_ioctl()
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&dbo->base);
 #else
-        drm_gem_object_unreference_unlocked(&dbo->base);
+		drm_gem_object_unreference_unlocked(&dbo->base);
 #endif
 		xcmd->deps[didx] = NULL;
 		if (!chain_to) { // command may have completed already
@@ -3083,38 +3083,38 @@ get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 	xobj = to_xocl_bo(obj);
 	if (!xobj->mm_node) {
 		/* Not a local BO */
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(obj);
 #else
-        drm_gem_object_unreference_unlocked(obj);
+		drm_gem_object_unreference_unlocked(obj);
 #endif
 		return -EADDRNOTAVAIL;
 	}
 
 	if (obj->size <= off || obj->size < off + size) {
 		userpf_err(xdev, "Failed to get paddr for BO 0x%x\n", bo_hdl);
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(obj);
 #else
-        drm_gem_object_unreference_unlocked(obj);
+		drm_gem_object_unreference_unlocked(obj);
 #endif
 		return -EINVAL;
 	}
 
 	*paddrp = xobj->mm_node->start + off;
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-     * Linux < 4.12 is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+	 * Linux < 4.12 is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(obj);
 #else
-    drm_gem_object_unreference_unlocked(obj);
+	drm_gem_object_unreference_unlocked(obj);
 #endif
 	return 0;
 }
@@ -3272,15 +3272,15 @@ client_ioctl_execbuf(struct platform_device *pdev,
 
 out:
 	for (--numdeps; numdeps >= 0; numdeps--)
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&deps[numdeps]->base);
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
-        drm_gem_object_unreference_unlocked(&deps[numdeps]->base);
-    drm_gem_object_unreference_unlocked(&xobj->base);
+		drm_gem_object_unreference_unlocked(&deps[numdeps]->base);
+	drm_gem_object_unreference_unlocked(&xobj->base);
 #endif
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -2,8 +2,8 @@
  * Copyright (C) 2018-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Soren Soe <soren.soe@xilinx.com>
- *	  Jan Stephan <j.stephan@hzdr.de>
+ *    Soren Soe <soren.soe@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -19,24 +19,24 @@
  * Kernel Driver Scheduler (KDS) for XRT
  *
  * struct xocl_cmd
- *	- wraps exec BOs create from user space
- *	- transitions through a number of states
- *	- initially added to pending command queue
- *	- consumed by scheduler which manages its execution (state transition)
+ *  - wraps exec BOs create from user space
+ *  - transitions through a number of states
+ *  - initially added to pending command queue
+ *  - consumed by scheduler which manages its execution (state transition)
  * struct xcol_cu
- *	- compute unit for executing commands
- *	- used only without embedded scheduler (ert)
- *	- talks to HW compute units
+ *  - compute unit for executing commands
+ *  - used only without embedded scheduler (ert)
+ *  - talks to HW compute units
  * struct xocl_ert
- *	- embedded scheduler for executing commands on ert
- *	- talks to HW ERT
+ *  - embedded scheduler for executing commands on ert
+ *  - talks to HW ERT
  * struct exec_core
- *	- execution core managing execution on one device
+ *  - execution core managing execution on one device
  * struct xocl_scheduler
- *	- manages execution of cmds on one or more exec cores
- *	- executed in a separate kernel thread
- *	- loops repeatedly when there is work to do
- *	- moves pending commands into a scheduler command queue
+ *  - manages execution of cmds on one or more exec cores
+ *  - executed in a separate kernel thread
+ *  - loops repeatedly when there is work to do
+ *  - moves pending commands into a scheduler command queue
  *
  * [new -> pending]. The xocl API adds exec BOs to KDS.	 The exec BOs are
  * wrapped in a xocl_cmd object and added to a pending command queue.
@@ -53,7 +53,7 @@
  * ert) or if ERT is used, then when ERT has room.
  *
  * [running -> complete]. Commands running on ERT complete by sending an
- * interrupt to scheduler.	When ERT is not used, commands are running on a
+ * interrupt to scheduler.  When ERT is not used, commands are running on a
  * compute unit and are polled for completion.
  */
 
@@ -76,7 +76,7 @@
 ({									\
 	int i;								\
 	u32 *data = (u32 *)packet;					\
-	for (i = 0; i < size; ++i)						\
+	for (i = 0; i < size; ++i)					    \
 		DRM_INFO("packet(0x%p) data[%d] = 0x%x\n", data, i, data[i]); \
 })
 
@@ -100,10 +100,10 @@
 static const unsigned int no_index = -1;
 
 /* FFA	handling */
-static const u32 AP_START	 = 0x1;
-static const u32 AP_DONE	 = 0x2;
-static const u32 AP_IDLE	 = 0x4;
-static const u32 AP_READY	 = 0x8;
+static const u32 AP_START    = 0x1;
+static const u32 AP_DONE     = 0x2;
+static const u32 AP_IDLE     = 0x4;
+static const u32 AP_READY    = 0x8;
 static const u32 AP_CONTINUE = 0x10;
 
 /* Forward declaration */
@@ -112,7 +112,7 @@ struct exec_ops;
 struct xocl_scheduler;
 
 static int validate(struct platform_device *pdev, struct client_ctx *client,
-			const struct drm_xocl_bo *bo);
+		    const struct drm_xocl_bo *bo);
 static bool exec_is_flush(struct exec_core *exec);
 static void exec_ert_clear_csr(struct exec_core *exec);
 static void scheduler_wake_up(struct xocl_scheduler *xs);
@@ -208,8 +208,8 @@ struct xocl_cmd {
 	/* command packet */
 	struct drm_xocl_bo *bo;
 	union {
-		struct ert_packet		*ert_pkt;
-		struct ert_configure_cmd	*ert_cfg;
+		struct ert_packet	    *ert_pkt;
+		struct ert_configure_cmd    *ert_cfg;
 		struct ert_start_kernel_cmd *ert_cu;
 		struct ert_start_copybo_cmd *ert_cp;
 	};
@@ -230,7 +230,7 @@ struct xocl_cmd {
 		struct drm_xocl_bo *deps[8];
 	};
 
-	unsigned long uid;	   // unique id for this command
+	unsigned long uid;     // unique id for this command
 	unsigned int cu_idx;   // index of CU running this cmd (penguin mode)
 	unsigned int slot_idx; // index in exec core submit queue
 };
@@ -435,13 +435,13 @@ static inline void
 cmd_release_gem_object_reference(struct xocl_cmd *xcmd)
 {
 	if (xcmd->bo)
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&xcmd->bo->base);
 #else
-		drm_gem_object_unreference_unlocked(&xcmd->bo->base);
+        drm_gem_object_unreference_unlocked(&xcmd->bo->base);
 #endif
 }
 
@@ -486,13 +486,13 @@ cmd_chain_dependencies(struct xocl_cmd *xcmd)
 		struct xocl_cmd *chain_to = dbo->metadata.active;
 		// release reference created in ioctl call when dependency was looked up
 		// see comments in xocl_ioctl.c:xocl_execbuf_ioctl()
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&dbo->base);
 #else
-		drm_gem_object_unreference_unlocked(&dbo->base);
+        drm_gem_object_unreference_unlocked(&dbo->base);
 #endif
 		xcmd->deps[didx] = NULL;
 		if (!chain_to) { // command may have completed already
@@ -526,7 +526,7 @@ cmd_trigger_chain(struct xocl_cmd *xcmd)
 		struct xocl_cmd *trigger = xcmd->chain[--xcmd->chain_count];
 
 		SCHED_DEBUGF("+ cmd(%lu) triggers cmd(%lu) with wait_count(%d)\n",
-				 xcmd->uid, trigger->uid, trigger->wait_count);
+			     xcmd->uid, trigger->uid, trigger->wait_count);
 		// decrement trigger wait count
 		// scheduler will submit when wait count reaches zero
 		--trigger->wait_count;
@@ -618,12 +618,12 @@ cmd_abort(struct xocl_cmd *xcmd)
  * cmd_bo_init() - Initialize a command object with an exec BO
  *
  * In penguin mode, the command object caches the CUs available
- * to execute the command.	When ERT is enabled, the CU info
+ * to execute the command.  When ERT is enabled, the CU info
  * is not used.
  */
 static void
 cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
-		int numdeps, struct drm_xocl_bo **deps, bool penguin)
+	    int numdeps, struct drm_xocl_bo **deps, bool penguin)
 {
 	SCHED_DEBUGF("%s(%lu,bo,%d,deps,%d)\n", __func__, xcmd->uid, numdeps, penguin);
 	xcmd->bo = bo;
@@ -690,17 +690,17 @@ cmd_has_cu(struct xocl_cmd *xcmd, unsigned int cuidx)
 struct xocl_cu {
 	struct list_head   running_queue;
 	struct xocl_dev    *xdev;
-	unsigned int	   idx;
-	unsigned int	   uid;
-	u32				   control;
-	void __iomem	   *base;
-	u32				   addr;
-	void __iomem	   *polladdr;
-	u32				   ap_check;
+	unsigned int       idx;
+	unsigned int       uid;
+	u32                control;
+	void __iomem       *base;
+	u32                addr;
+	void __iomem       *polladdr;
+	u32                ap_check;
 
-	u32				   ctrlreg;
-	unsigned int	   done_cnt;
-	unsigned int	   run_cnt;
+	u32                ctrlreg;
+	unsigned int       done_cnt;
+	unsigned int       run_cnt;
 };
 
 /*
@@ -718,7 +718,7 @@ cu_reset(struct xocl_cu *xcu, unsigned int idx, void __iomem *base, u32 addr, vo
 	xcu->done_cnt = 0;
 	xcu->run_cnt = 0;
 	userpf_info(xcu->xdev, "configured cu(%d) base@0x%x poll@0x%p control(%d)\n",
-			xcu->idx, xcu->addr, xcu->polladdr, xcu->control);
+		    xcu->idx, xcu->addr, xcu->polladdr, xcu->control);
 }
 
 /**
@@ -797,7 +797,7 @@ cu_continue(struct xocl_cu *xcu)
  * cu_poll() - Poll a CU for its status
  *
  * Used in penguin and ert_poll mode only. Read the CU control register and
- * update run and done count as necessary.	Acknowledge any AP_DONE received
+ * update run and done count as necessary.  Acknowledge any AP_DONE received
  * from kernel.  Check for AP_IDLE since ERT in poll mode will also read the
  * kernel control register and AP_DONE is COR.
  */
@@ -806,7 +806,7 @@ cu_poll(struct xocl_cu *xcu)
 {
 	// assert !list_empty(&running_queue)
 	SCHED_DEBUGF("-> %s cu(%d) @0x%x done(%d) run(%d)\n", __func__,
-			 xcu->idx, xcu->addr, xcu->done_cnt, xcu->run_cnt);
+		     xcu->idx, xcu->addr, xcu->done_cnt, xcu->run_cnt);
 
 	xcu->ctrlreg = ioread32(xcu->base + xcu->addr);
 
@@ -819,7 +819,7 @@ cu_poll(struct xocl_cu *xcu)
 	}
 
 	SCHED_DEBUGF("<- %s cu(%d) done(%d) run(%d)\n", __func__,
-			 xcu->idx, xcu->done_cnt, xcu->run_cnt);
+		     xcu->idx, xcu->done_cnt, xcu->run_cnt);
 }
 
 /**
@@ -837,7 +837,7 @@ cu_ready(struct xocl_cu *xcu)
 		cu_poll(xcu);
 
 	SCHED_DEBUGF("<- %s returns %d\n", __func__,
-			 cu_dataflow(xcu) ? !(xcu->ctrlreg & AP_START) : xcu->run_cnt == 0);
+		     cu_dataflow(xcu) ? !(xcu->ctrlreg & AP_START) : xcu->run_cnt == 0);
 
 	return cu_dataflow(xcu) ? !(xcu->ctrlreg & AP_START) : xcu->run_cnt == 0;
 }
@@ -878,7 +878,7 @@ cu_pop_done(struct xocl_cu *xcu)
 	--xcu->done_cnt;
 
 	SCHED_DEBUGF("%s(%d) xcmd(%lu) done(%d) run(%d)\n", __func__,
-			 xcu->idx, xcmd->uid, xcu->done_cnt, xcu->run_cnt);
+		     xcu->idx, xcmd->uid, xcu->done_cnt, xcu->run_cnt);
 }
 
 /**
@@ -958,7 +958,7 @@ cu_start(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 	++xcu->run_cnt;
 
 	SCHED_DEBUGF("<- %s cu(%d) started xcmd(%lu) done(%d) run(%d)\n",
-			 __func__, xcu->idx, xcmd->uid, xcu->done_cnt, xcu->run_cnt);
+		     __func__, xcu->idx, xcmd->uid, xcu->done_cnt, xcu->run_cnt);
 
 	return true;
 }
@@ -973,7 +973,7 @@ struct xocl_ert {
 	unsigned int uid;
 
 	unsigned int slot_size;
-	bool		 cq_intr;
+	bool         cq_intr;
 };
 
 /*
@@ -1042,7 +1042,7 @@ ert_start_cmd(struct xocl_ert *xert, struct xocl_cmd *xcmd)
 		u32 mask = 1 << slot_idx_in_mask(xcmd->slot_idx);
 
 		SCHED_DEBUGF("++ mb_submit writes slot mask 0x%x to CQ_INT register at addr 0x%x\n",
-				 mask, cq_int_addr);
+			     mask, cq_int_addr);
 		csr_write32(mask, xert->csr_base, cq_int_addr);
 	}
 	SCHED_DEBUGF("<- %s returns true\n", __func__);
@@ -1079,7 +1079,7 @@ struct exec_ops {
 	void (*process_mask)(struct exec_core *exec, u32 mask, unsigned int maskidx);
 };
 
-static struct exec_ops ert_ops;		  // ert mode
+static struct exec_ops ert_ops;       // ert mode
 static struct exec_ops ert_poll_ops;  // ert polling mode
 static struct exec_ops penguin_ops;   // kds mode (no ert)
 
@@ -1132,11 +1132,11 @@ struct exec_core {
 	unsigned int		   num_cus;
 	unsigned int		   num_cdma;
 	
-	bool				   polling_mode;
-	bool				   cq_interrupt;
-	bool				   configured;
-	bool				   stopped;
-	bool				   flush;
+	bool		           polling_mode;
+	bool		           cq_interrupt;
+	bool		           configured;
+	bool		           stopped;
+	bool		           flush;
 
 	struct xocl_cu		   *cus[MAX_CUS];
 	struct xocl_ert		   *ert;
@@ -1689,7 +1689,7 @@ exec_release_slot(struct exec_core *exec, struct xocl_cmd *xcmd)
 		return; // already released
 
 	SCHED_DEBUGF("-> %s(%d) xcmd(%lu) slotidx(%d)\n",
-			 __func__, exec->uid, xcmd->uid, xcmd->slot_idx);
+		     __func__, exec->uid, xcmd->uid, xcmd->slot_idx);
 	if (cmd_type(xcmd) == ERT_CTRL) {
 		SCHED_DEBUG("+ ctrl cmd\n");
 		exec->ctrl_busy = false;
@@ -1776,8 +1776,8 @@ exec_notify_host(struct exec_core *exec)
  * exec_cmd_mark_complete() - Move a command to complete state
  *
  * Commands are marked complete in two ways
- *	1. Through polling of CUs or polling of MB status register
- *	2. Through interrupts from MB
+ *  1. Through polling of CUs or polling of MB status register
+ *  2. Through interrupts from MB
  *
  * @xcmd: Command to mark complete
  *
@@ -1938,7 +1938,7 @@ exec_penguin_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	u32 cmdtype = cmd_type(xcmd);
 
 	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d) type(%d) slot_idx=%d\n",
-			 __func__, xcmd->uid, cmd_opcode(xcmd), cmdtype, xcmd->slot_idx);
+		     __func__, xcmd->uid, cmd_opcode(xcmd), cmdtype, xcmd->slot_idx);
 
 	if (cmdtype == ERT_KDS_LOCAL || cmdtype == ERT_CTRL)
 		exec_mark_cmd_complete(exec, xcmd);
@@ -2009,7 +2009,7 @@ exec_ert_clear_csr(struct exec_core *exec)
 
 		if (val)
 			userpf_info(exec_get_xdev(exec),
-					"csr[%d]=0x%x cleared\n", idx, val);
+				    "csr[%d]=0x%x cleared\n", idx, val);
 	}
 }
 
@@ -2043,10 +2043,10 @@ exec_ert_query_csr(struct exec_core *exec, struct xocl_cmd *xcmd, unsigned int m
 	}
 
 	if (exec->polling_mode
-		|| (mask_idx == 0 && atomic_xchg(&exec->sr0, 0))
-		|| (mask_idx == 1 && atomic_xchg(&exec->sr1, 0))
-		|| (mask_idx == 2 && atomic_xchg(&exec->sr2, 0))
-		|| (mask_idx == 3 && atomic_xchg(&exec->sr3, 0))) {
+	    || (mask_idx == 0 && atomic_xchg(&exec->sr0, 0))
+	    || (mask_idx == 1 && atomic_xchg(&exec->sr1, 0))
+	    || (mask_idx == 2 && atomic_xchg(&exec->sr2, 0))
+	    || (mask_idx == 3 && atomic_xchg(&exec->sr3, 0))) {
 		u32 csr_addr = ERT_STATUS_REGISTER_ADDR + (mask_idx<<2);
 
 		mask = csr_read32(exec->csr_base, csr_addr);
@@ -2522,9 +2522,9 @@ scheduler_iterate_cmds(struct xocl_scheduler *xs)
  * scheduler_wait_condition() - Check status of scheduler wait condition
  *
  * Scheduler must wait (sleep) if
- *	 1. there are no pending commands
- *	 2. no pending interrupt from embedded scheduler
- *	 3. no pending complete commands in polling mode
+ *   1. there are no pending commands
+ *   2. no pending interrupt from embedded scheduler
+ *   3. no pending complete commands in polling mode
  *
  * Return: 1 if scheduler must wait, 0 othewise
  */
@@ -2655,13 +2655,13 @@ add_xcmd(struct xocl_cmd *xcmd)
 	scheduler_wake_up(xcmd->xs);
 
 	SCHED_DEBUGF("<- %s ret(0) opcode(%d) type(%d) num_pending(%d)\n",
-			 __func__, cmd_opcode(xcmd), cmd_type(xcmd), atomic_read(&num_pending));
+		     __func__, cmd_opcode(xcmd), cmd_type(xcmd), atomic_read(&num_pending));
 	mutex_unlock(&exec->exec_lock);
 	return 0;
 
 err:
 	SCHED_DEBUGF("<- %s ret(1) opcode(%d) type(%d) num_pending(%d)\n",
-			 __func__, cmd_opcode(xcmd), cmd_type(xcmd), atomic_read(&num_pending));
+		     __func__, cmd_opcode(xcmd), cmd_type(xcmd), atomic_read(&num_pending));
 	mutex_unlock(&exec->exec_lock);
 	return 1;
 }
@@ -2957,7 +2957,7 @@ static uint poll_client(struct platform_device *pdev, struct file *filp,
 }
 
 static int client_ioctl_ctx(struct platform_device *pdev,
-				struct client_ctx *client, void *data)
+			    struct client_ctx *client, void *data)
 {
 	struct drm_xocl_ctx *args = data;
 	int ret = 0;
@@ -2976,7 +2976,7 @@ static int client_ioctl_ctx(struct platform_device *pdev,
 	}
 
 	if (cu_idx != XOCL_CTX_VIRT_CU_INDEX
-		&& cu_idx >= XOCL_IP_LAYOUT(xdev)->m_count) {
+	    && cu_idx >= XOCL_IP_LAYOUT(xdev)->m_count) {
 		userpf_err(xdev, "cuidx(%d) >= numcus(%d)\n",
 			cu_idx, XOCL_IP_LAYOUT(xdev)->m_count);
 		ret = -EINVAL;
@@ -2984,7 +2984,7 @@ static int client_ioctl_ctx(struct platform_device *pdev,
 	}
 
 	if (cu_idx != XOCL_CTX_VIRT_CU_INDEX
-		&& !exec_valid_cu(exec,cu_idx)) {
+	    && !exec_valid_cu(exec,cu_idx)) {
 		userpf_err(xdev, "cuidx(%d) cannot be reserved\n",cu_idx);
 		ret = -EINVAL;
 		goto out;
@@ -3068,7 +3068,7 @@ out:
 
 static int
 get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
-		 uint32_t bo_hdl, size_t off, size_t size, uint64_t *paddrp)
+	     uint32_t bo_hdl, size_t off, size_t size, uint64_t *paddrp)
 {
 	struct drm_device *ddev = filp->minor->dev;
 	struct drm_gem_object *obj;
@@ -3083,38 +3083,38 @@ get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 	xobj = to_xocl_bo(obj);
 	if (!xobj->mm_node) {
 		/* Not a local BO */
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(obj);
 #else
-		drm_gem_object_unreference_unlocked(obj);
+        drm_gem_object_unreference_unlocked(obj);
 #endif
 		return -EADDRNOTAVAIL;
 	}
 
 	if (obj->size <= off || obj->size < off + size) {
 		userpf_err(xdev, "Failed to get paddr for BO 0x%x\n", bo_hdl);
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(obj);
 #else
-		drm_gem_object_unreference_unlocked(obj);
+        drm_gem_object_unreference_unlocked(obj);
 #endif
 		return -EINVAL;
 	}
 
 	*paddrp = xobj->mm_node->start + off;
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-	 * Linux < 4.12 is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+     * Linux < 4.12 is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(obj);
 #else
-	drm_gem_object_unreference_unlocked(obj);
+    drm_gem_object_unreference_unlocked(obj);
 #endif
 	return 0;
 }
@@ -3169,8 +3169,8 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 
 	userpf_info(xdev,"checking alignment requirments for KDMA sz(%lu)",sz);
 	if ((dst_addr + dst_off) % KDMA_BLOCK_SIZE ||
-		(src_addr + src_off) % KDMA_BLOCK_SIZE ||
-		sz % KDMA_BLOCK_SIZE) {
+	    (src_addr + src_off) % KDMA_BLOCK_SIZE ||
+	    sz % KDMA_BLOCK_SIZE) {
 		userpf_info(xdev,"improper alignment, cannot use KDMA");
 		return -EINVAL;
 	}
@@ -3188,7 +3188,7 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 
 static int
 client_ioctl_execbuf(struct platform_device *pdev,
-			 struct client_ctx *client, void *data, struct drm_file *filp)
+		     struct client_ctx *client, void *data, struct drm_file *filp)
 {
 	struct drm_xocl_execbuf *args = data;
 	struct drm_xocl_bo *xobj;
@@ -3233,7 +3233,7 @@ client_ioctl_execbuf(struct platform_device *pdev,
 
 	/* Copy dependencies from user.	 It is an error if a BO handle specified
 	 * as a dependency does not exists. Lookup gem object corresponding to bo
-	 * handle.	Convert gem object to xocl_bo extension.  Note that the
+	 * handle.  Convert gem object to xocl_bo extension.  Note that the
 	 * gem lookup acquires a reference to the drm object, this reference
 	 * is passed on to the the scheduler via xocl_exec_add_buffer.
 	 */
@@ -3264,7 +3264,7 @@ client_ioctl_execbuf(struct platform_device *pdev,
 	}
 
 	/* Return here, noting that the gem objects passed to kds have
-	 * references that must be released by kds itself.	User manages
+	 * references that must be released by kds itself.  User manages
 	 * a regular reference to all BOs returned as file handles.  These
 	 * references are released with the BOs are freed.
 	 */
@@ -3272,15 +3272,15 @@ client_ioctl_execbuf(struct platform_device *pdev,
 
 out:
 	for (--numdeps; numdeps >= 0; numdeps--)
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&deps[numdeps]->base);
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
-		drm_gem_object_unreference_unlocked(&deps[numdeps]->base);
-	drm_gem_object_unreference_unlocked(&xobj->base);
+        drm_gem_object_unreference_unlocked(&deps[numdeps]->base);
+    drm_gem_object_unreference_unlocked(&xobj->base);
 #endif
 	return ret;
 }
@@ -3321,7 +3321,7 @@ int client_ioctl(struct platform_device *pdev,
  * Even though the very first client created for this device also resets the
  * exec core, it is possible that further resets are necessary.	 For example
  * in multi-process case, there can be 'n' processes that attach to the
- * device.	On first client attach the exec core is reset correctly, but now
+ * device.  On first client attach the exec core is reset correctly, but now
  * assume that 'm' of these processes finishes completely before any remaining
  * (n-m) processes start using the scheduler.  In this case, the n-m clients have
  * already been created, but icap resets AXI because the xclbin has no
@@ -3329,8 +3329,8 @@ int client_ioctl(struct platform_device *pdev,
  *
  * [Work-in-progress:]
  * Proper contract:
- *	Pre-condition: xocl_exec_stop has been called before xocl_exec_reset.
- *	Pre-condition: new bitstream has been downloaded and AXI has been reset
+ *  Pre-condition: xocl_exec_stop has been called before xocl_exec_reset.
+ *  Pre-condition: new bitstream has been downloaded and AXI has been reset
  */
 static int
 reset(struct platform_device *pdev)
@@ -3415,7 +3415,7 @@ validate(struct platform_device *pdev, struct client_ctx *client, const struct d
 		// cmd_cus must be subset of ctx_cus
 		if (cmd_cus & ~ctx_cus[maskidx]) {
 			SCHED_DEBUGF("<- %s(1), CU mismatch in mask(%d) cmd(0x%x) ctx(0x%x)\n",
-					 __func__, maskidx, cmd_cus, ctx_cus[maskidx]);
+				     __func__, maskidx, cmd_cus, ctx_cus[maskidx]);
 			err = 1;
 			goto out; /* error */
 		}
@@ -3513,8 +3513,8 @@ kds_custat_show(struct device *dev, struct device_attribute *attr, char *buf)
 
 	for (count = 0; count < exec->num_cus; ++count)
 		sz += sprintf(buf+sz, "CU[@0x%x] : %d\n",
-				  exec_cu_base_addr(exec, count),
-				  exec_cu_usage(exec, count));
+			      exec_cu_base_addr(exec, count),
+			      exec_cu_usage(exec, count));
 	if (sz)
 		buf[sz++] = 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -3271,14 +3271,15 @@ client_ioctl_execbuf(struct platform_device *pdev,
 	return ret;
 
 out:
-	for (--numdeps; numdeps >= 0; numdeps--)
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as  Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	for (--numdeps; numdeps >= 0; numdeps--)
 		drm_gem_object_put_unlocked(&deps[numdeps]->base);
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
+	for (--numdeps; numdeps >= 0; numdeps--)
 		drm_gem_object_unreference_unlocked(&deps[numdeps]->base);
 	drm_gem_object_unreference_unlocked(&xobj->base);
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -926,13 +926,13 @@ static int queue_req_complete(unsigned long priv, unsigned int done_bytes,
 			cb->queue->qconf.c2h ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
 		xocl_finish_unmgd(&cb->unmgd);
 	} else {
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&cb->xobj->base);
 #else
-        drm_gem_object_unreference_unlocked(&cb->xobj->base);
+		drm_gem_object_unreference_unlocked(&cb->xobj->base);
 #endif
 	}
 
@@ -967,13 +967,13 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 		goto out;
 	}
 
-    /* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
-     * longer supported.
-     */
+	/* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
+	 * longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_get(gem_obj);
 #else
-    drm_gem_object_reference(gem_obj);
+	drm_gem_object_reference(gem_obj);
 #endif
 	xobj = to_xocl_bo(gem_obj);
 
@@ -1022,13 +1022,13 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 
 out:
 	if (!kiocb) {
-        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-         * Linux < 4.12 is no longer supported.
-         */
+		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+		 * Linux < 4.12 is no longer supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(gem_obj);
 #else
-        drm_gem_object_unreference_unlocked(gem_obj);
+		drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 		if (io_req)
 			queue_req_free(queue, io_req, false);
@@ -1640,13 +1640,13 @@ static long stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 
 	flags = O_CLOEXEC | O_RDWR;
 
-    /* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
-     * longer supported.
-     */
+	/* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
+	 * longer supported.
+	*/
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_get(&xobj->base);
 #else
-    drm_gem_object_reference(&xobj->base);
+	drm_gem_object_reference(&xobj->base);
 #endif
 	dmabuf = drm_gem_prime_export(XOCL_DRM(xdev)->ddev,
 		       	&xobj->base, flags);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -926,14 +926,7 @@ static int queue_req_complete(unsigned long priv, unsigned int done_bytes,
 			cb->queue->qconf.c2h ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
 		xocl_finish_unmgd(&cb->unmgd);
 	} else {
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-		drm_gem_object_put_unlocked(&cb->xobj->base);
-#else
-		drm_gem_object_unreference_unlocked(&cb->xobj->base);
-#endif
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&cb->xobj->base);
 	}
 
 	spin_lock_bh(&cb->lock);
@@ -967,14 +960,7 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 		goto out;
 	}
 
-	/* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
-	 * longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_get(gem_obj);
-#else
-	drm_gem_object_reference(gem_obj);
-#endif
+	XOCL_DRM_GEM_OBJECT_GET(gem_obj);
 	xobj = to_xocl_bo(gem_obj);
 
 	io_req = queue_req_new(queue);
@@ -1022,14 +1008,7 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 
 out:
 	if (!kiocb) {
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-		drm_gem_object_put_unlocked(gem_obj);
-#else
-		drm_gem_object_unreference_unlocked(gem_obj);
-#endif
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 		if (io_req)
 			queue_req_free(queue, io_req, false);
 	} else {
@@ -1640,14 +1619,7 @@ static long stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 
 	flags = O_CLOEXEC | O_RDWR;
 
-	/* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
-	 * longer supported.
-	*/
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_get(&xobj->base);
-#else
-	drm_gem_object_reference(&xobj->base);
-#endif
+	XOCL_DRM_GEM_OBJECT_GET(&xobj->base);
 	dmabuf = drm_gem_prime_export(XOCL_DRM(xdev)->ddev,
 				&xobj->base, flags);
 	if (IS_ERR(dmabuf)) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
- *			j.stephan@hzdr.de
+ *          j.stephan@hzdr.de
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -34,7 +34,7 @@
 #include "../lib/libqdma/libqdma_export.h"
 #include "qdma_ioctl.h"
 
-#define XOCL_FILE_PAGE_OFFSET	0x100000
+#define XOCL_FILE_PAGE_OFFSET   0x100000
 #ifndef VM_RESERVED
 #define VM_RESERVED (VM_DONTEXPAND | VM_DONTDUMP)
 #endif
@@ -107,7 +107,7 @@ struct stream_queue {
 	struct device		dev;
 	struct xocl_qdma	*qdma;
 	unsigned long		queue;
-	struct qdma_queue_conf	qconf;
+	struct qdma_queue_conf  qconf;
 	u32			state;
 	int			flowid;
 	int			routeid;
@@ -119,12 +119,12 @@ struct stream_queue {
 	struct list_head	req_free_list;
 	struct stream_async_req *req_cache;
 	/* stats */
-	unsigned int		req_pend_cnt;
-	unsigned int		req_free_cnt;
-	unsigned int		req_submit_cnt;
-	unsigned int		req_cmpl_cnt;
-	unsigned int		req_cancel_cnt;
-	unsigned int		req_cancel_cmpl_cnt;
+	unsigned int 		req_pend_cnt;
+	unsigned int 		req_free_cnt;
+	unsigned int 		req_submit_cnt;
+	unsigned int 		req_cmpl_cnt;
+	unsigned int 		req_cancel_cnt;
+	unsigned int 		req_cancel_cmpl_cnt;
 };
 
 struct xocl_qdma {
@@ -360,7 +360,7 @@ static int stream_sysfs_create(struct stream_queue *queue)
 	for (i = 0; i < QDMA_QSETS_MAX * 2; i++) {
 		temp_q = queue->qdma->queues[i];
 		if (!temp_q)
-			   continue;
+		       continue;
 		if (temp_q->qconf.c2h && queue->qconf.c2h &&
 			temp_q->flowid == queue->flowid) {
 			xocl_err(&pdev->dev,
@@ -431,7 +431,7 @@ static ssize_t error_show(struct device *dev, struct device_attribute *da,
 static DEVICE_ATTR_RO(error);
 
 static ssize_t channel_stat_raw_show(struct device *dev,
-				struct device_attribute *attr, char *buf)
+		        struct device_attribute *attr, char *buf)
 {
 	u32 i;
 	ssize_t nbytes = 0;
@@ -480,7 +480,7 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 
 	dir = write ? DMA_TO_DEVICE : DMA_FROM_DEVICE; 
 	nents = pci_map_sg(XDEV(xdev)->pdev, sgt->sgl, sgt->orig_nents, dir);
-		if (!nents) {
+        if (!nents) {
 		xocl_err(&pdev->dev, "map sgl failed, sgt 0x%p.\n", sgt);
 		return -EIO;
 	}
@@ -500,7 +500,7 @@ static ssize_t qdma_migrate_bo(struct platform_device *pdev,
 
 	if (ret >= 0) {
 		chan->total_trans_bytes += ret;
-	} else	{
+	} else  {
 		xocl_err(&pdev->dev, "DMA failed, Dumping SG Page Table");
 		dump_sgtable(&pdev->dev, sgt);
 	}
@@ -516,8 +516,8 @@ static void release_channel(struct platform_device *pdev, u32 dir, u32 channel)
 
 
 	qdma = platform_get_drvdata(pdev);
-		set_bit(channel, &qdma->channel_bitmap[dir]);
-		up(&qdma->channel_sem[dir]);
+        set_bit(channel, &qdma->channel_bitmap[dir]);
+        up(&qdma->channel_sem[dir]);
 }
 
 static int acquire_channel(struct platform_device *pdev, u32 dir)
@@ -539,8 +539,8 @@ static int acquire_channel(struct platform_device *pdev, u32 dir)
 			&qdma->channel_bitmap[dir]);
 		if (result)
 			break;
-		}
-		if (!result) {
+        }
+        if (!result) {
 		// How is this possible?
 		up(&qdma->channel_sem[dir]);
 		channel = -EIO;
@@ -688,10 +688,10 @@ static u32 get_channel_count(struct platform_device *pdev)
 {
 	struct xocl_qdma *qdma;
 
-		qdma = platform_get_drvdata(pdev);
-		BUG_ON(!qdma);
+        qdma = platform_get_drvdata(pdev);
+        BUG_ON(!qdma);
 
-		return qdma->channel;
+        return qdma->channel;
 }
 
 static u64 get_channel_stat(struct platform_device *pdev, u32 channel,
@@ -699,10 +699,10 @@ static u64 get_channel_stat(struct platform_device *pdev, u32 channel,
 {
 	struct xocl_qdma *qdma;
 
-		qdma = platform_get_drvdata(pdev);
-		BUG_ON(!qdma);
+        qdma = platform_get_drvdata(pdev);
+        BUG_ON(!qdma);
 
-		return qdma->chans[write][channel].total_trans_bytes;
+        return qdma->chans[write][channel].total_trans_bytes;
 }
 
 static u64 get_str_stat(struct platform_device *pdev, u32 q_idx)
@@ -926,13 +926,13 @@ static int queue_req_complete(unsigned long priv, unsigned int done_bytes,
 			cb->queue->qconf.c2h ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
 		xocl_finish_unmgd(&cb->unmgd);
 	} else {
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(&cb->xobj->base);
 #else
-		drm_gem_object_unreference_unlocked(&cb->xobj->base);
+        drm_gem_object_unreference_unlocked(&cb->xobj->base);
 #endif
 	}
 
@@ -967,13 +967,13 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 		goto out;
 	}
 
-	/* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
-	 * longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
+     * longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_get(gem_obj);
 #else
-	drm_gem_object_reference(gem_obj);
+    drm_gem_object_reference(gem_obj);
 #endif
 	xobj = to_xocl_bo(gem_obj);
 
@@ -1022,13 +1022,13 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 
 out:
 	if (!kiocb) {
-		/* TODO: Remove drm_gem_object_unreference_unlocked as soon as
-		 * Linux < 4.12 is no longer supported.
-		 */
+        /* TODO: Remove drm_gem_object_unreference_unlocked as soon as
+         * Linux < 4.12 is no longer supported.
+         */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		drm_gem_object_put_unlocked(gem_obj);
 #else
-		drm_gem_object_unreference_unlocked(gem_obj);
+        drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 		if (io_req)
 			queue_req_free(queue, io_req, false);
@@ -1640,16 +1640,16 @@ static long stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 
 	flags = O_CLOEXEC | O_RDWR;
 
-	/* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
-	 * longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_reference as soon as Linux < 4.12 is no
+     * longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_get(&xobj->base);
 #else
-	drm_gem_object_reference(&xobj->base);
+    drm_gem_object_reference(&xobj->base);
 #endif
 	dmabuf = drm_gem_prime_export(XOCL_DRM(xdev)->ddev,
-				&xobj->base, flags);
+		       	&xobj->base, flags);
 	if (IS_ERR(dmabuf)) {
 		xocl_err(&qdma->pdev->dev, "failed to export dma_buf");
 		ret = PTR_ERR(dmabuf);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
- *          j.stephan@hzdr.de
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -1649,7 +1649,7 @@ static long stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 	drm_gem_object_reference(&xobj->base);
 #endif
 	dmabuf = drm_gem_prime_export(XOCL_DRM(xdev)->ddev,
-		       	&xobj->base, flags);
+				&xobj->base, flags);
 	if (IS_ERR(dmabuf)) {
 		xocl_err(&qdma->pdev->dev, "failed to export dma_buf");
 		ret = PTR_ERR(dmabuf);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -470,13 +470,13 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		goto out_free;
 
 	xocl_describe(xobj);
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
-    drm_gem_object_unreference_unlocked(&xobj->base);
+	drm_gem_object_unreference_unlocked(&xobj->base);
 #endif
 	return ret;
 
@@ -549,13 +549,13 @@ int xocl_userptr_bo_ioctl(struct drm_device *dev,
 
 	xobj->type |= XOCL_BO_USERPTR;
 	xocl_describe(xobj);
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
-    drm_gem_object_unreference_unlocked(&xobj->base);
+	drm_gem_object_unreference_unlocked(&xobj->base);
 #endif
 	return ret;
 
@@ -595,13 +595,13 @@ int xocl_map_bo_ioctl(struct drm_device *dev,
 	args->offset = drm_vma_node_offset_addr(&obj->vma_node);
 	xocl_describe(to_xocl_bo(obj));
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(obj);
 #else
-    drm_gem_object_unreference_unlocked(obj);
+	drm_gem_object_unreference_unlocked(obj);
 #endif
 	return ret;
 }
@@ -716,13 +716,13 @@ clear:
 		kfree(sgt);
 	}
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 	return ret;
 }
@@ -748,13 +748,13 @@ int xocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->paddr = xocl_bo_physical_addr(xobj);
 	xocl_describe(xobj);
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj)
+	drm_gem_object_unreference_unlocked(gem_obj)
 #endif
 
 	return 0;
@@ -787,9 +787,9 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -812,13 +812,13 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -856,9 +856,9 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -876,13 +876,13 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-    drm_gem_object_unreference_unlocked(gem_obj);
+	drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -1006,9 +1006,9 @@ out:
 		sg_free_table(tmp_sgt);
 		kfree(tmp_sgt);
 	}
-    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-     * is no longer supported.
-     */
+	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+	 * is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	if (src_gem_obj)
 		drm_gem_object_put_unlocked(src_gem_obj);
@@ -1016,9 +1016,9 @@ out:
 		drm_gem_object_put_unlocked(dst_gem_obj);
 #else
 	if (src_gem_obj)
-        drm_gem_object_unreference_unlocked(src_gem_obj);
+		drm_gem_object_unreference_unlocked(src_gem_obj);
 	if (dst_gem_obj)
-        drm_gem_object_unreference_unlocked(dst_gem_obj);
+		drm_gem_object_unreference_unlocked(dst_gem_obj);
 #endif
 	return ret;
 }
@@ -1124,9 +1124,9 @@ int xocl_init_unmgd(struct drm_xocl_unmgd *unmgd, uint64_t data_ptr,
 	int ret;
 	char __user *user_data = to_user_ptr(data_ptr);
 
-    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-     * supported.
-     */
+	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+	 * supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, size))
 #else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -470,14 +470,7 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		goto out_free;
 
 	xocl_describe(xobj);
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(&xobj->base);
-#else
-	drm_gem_object_unreference_unlocked(&xobj->base);
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
 	return ret;
 
 out_free:
@@ -549,14 +542,7 @@ int xocl_userptr_bo_ioctl(struct drm_device *dev,
 
 	xobj->type |= XOCL_BO_USERPTR;
 	xocl_describe(xobj);
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(&xobj->base);
-#else
-	drm_gem_object_unreference_unlocked(&xobj->base);
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
 	return ret;
 
 out0:
@@ -595,14 +581,7 @@ int xocl_map_bo_ioctl(struct drm_device *dev,
 	args->offset = drm_vma_node_offset_addr(&obj->vma_node);
 	xocl_describe(to_xocl_bo(obj));
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(obj);
-#else
-	drm_gem_object_unreference_unlocked(obj);
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 	return ret;
 }
 
@@ -716,14 +695,7 @@ clear:
 		kfree(sgt);
 	}
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(gem_obj);
-#else
-	drm_gem_object_unreference_unlocked(gem_obj);
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 	return ret;
 }
 
@@ -748,14 +720,7 @@ int xocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->paddr = xocl_bo_physical_addr(xobj);
 	xocl_describe(xobj);
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(gem_obj);
-#else
-	drm_gem_object_unreference_unlocked(gem_obj)
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return 0;
 }
@@ -787,14 +752,7 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	if (!access_ok(user_data, args->size)) {
-#else
-	if (!access_ok(VERIFY_READ, user_data, args->size)) {
-#endif
+	if (!XOCL_ACCESS_OK(VERIFY_READ, user_data, args->size)) {
 		ret = -EFAULT;
 		goto out;
 	}
@@ -812,14 +770,7 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(gem_obj);
-#else
-	drm_gem_object_unreference_unlocked(gem_obj);
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return ret;
 }
@@ -856,14 +807,7 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	if (!access_ok(user_data, args->size)) {
-#else
-	if (!access_ok(VERIFY_WRITE, user_data, args->size)) {
-#endif
+	if (!XOCL_ACCESS_OK(VERIFY_WRITE, user_data, args->size)) {
 		ret = EFAULT;
 		goto out;
 	}
@@ -876,14 +820,7 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
-	drm_gem_object_put_unlocked(gem_obj);
-#else
-	drm_gem_object_unreference_unlocked(gem_obj);
-#endif
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return ret;
 }
@@ -1006,20 +943,11 @@ out:
 		sg_free_table(tmp_sgt);
 		kfree(tmp_sgt);
 	}
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	if (src_gem_obj)
-		drm_gem_object_put_unlocked(src_gem_obj);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(src_gem_obj);
 	if (dst_gem_obj)
-		drm_gem_object_put_unlocked(dst_gem_obj);
-#else
-	if (src_gem_obj)
-		drm_gem_object_unreference_unlocked(src_gem_obj);
-	if (dst_gem_obj)
-		drm_gem_object_unreference_unlocked(dst_gem_obj);
-#endif
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(dst_gem_obj);
+
 	return ret;
 }
 
@@ -1124,14 +1052,7 @@ int xocl_init_unmgd(struct drm_xocl_unmgd *unmgd, uint64_t data_ptr,
 	int ret;
 	char __user *user_data = to_user_ptr(data_ptr);
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
-	if (!access_ok(user_data, size))
-#else
-	if (!access_ok((write == 1) ? VERIFY_READ : VERIFY_WRITE, user_data, size))
-#endif
+	if (!XOCL_ACCESS_OK((write == 1) ? VERIFY_READ : VERIFY_WRITE, user_data, size))
 		return -EFAULT;
 
 	memset(unmgd, 0, sizeof(struct drm_xocl_unmgd));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -4,9 +4,9 @@
  * Copyright (C) 2016-2017 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *	  Sonal Santan <sonal.santan@xilinx.com>
- *	  Sarabjeet Singh <sarabjeet.singh@xilinx.com>
- *	  Jan Stephan <j.stephan@hzdr.de>
+ *    Sonal Santan <sonal.santan@xilinx.com>
+ *    Sarabjeet Singh <sarabjeet.singh@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -470,13 +470,13 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		goto out_free;
 
 	xocl_describe(xobj);
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
-	drm_gem_object_unreference_unlocked(&xobj->base);
+    drm_gem_object_unreference_unlocked(&xobj->base);
 #endif
 	return ret;
 
@@ -486,8 +486,8 @@ out_free:
 }
 
 int xocl_userptr_bo_ioctl(struct drm_device *dev,
-				  void *data,
-				  struct drm_file *filp)
+			      void *data,
+			      struct drm_file *filp)
 {
 	int ret;
 	struct drm_xocl_bo *xobj;
@@ -549,13 +549,13 @@ int xocl_userptr_bo_ioctl(struct drm_device *dev,
 
 	xobj->type |= XOCL_BO_USERPTR;
 	xocl_describe(xobj);
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(&xobj->base);
 #else
-	drm_gem_object_unreference_unlocked(&xobj->base);
+    drm_gem_object_unreference_unlocked(&xobj->base);
 #endif
 	return ret;
 
@@ -570,8 +570,8 @@ out1:
 
 
 int xocl_map_bo_ioctl(struct drm_device *dev,
-			  void *data,
-			  struct drm_file *filp)
+		      void *data,
+		      struct drm_file *filp)
 {
 	int ret = 0;
 	struct drm_xocl_map_bo *args = data;
@@ -595,13 +595,13 @@ int xocl_map_bo_ioctl(struct drm_device *dev,
 	args->offset = drm_vma_node_offset_addr(&obj->vma_node);
 	xocl_describe(to_xocl_bo(obj));
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(obj);
 #else
-	drm_gem_object_unreference_unlocked(obj);
+    drm_gem_object_unreference_unlocked(obj);
 #endif
 	return ret;
 }
@@ -629,8 +629,8 @@ cleanup:
 }
 
 int xocl_sync_bo_ioctl(struct drm_device *dev,
-			   void *data,
-			   struct drm_file *filp)
+		       void *data,
+		       struct drm_file *filp)
 {
 	const struct drm_xocl_bo *xobj;
 	struct sg_table *sgt;
@@ -643,7 +643,7 @@ int xocl_sync_bo_ioctl(struct drm_device *dev,
 
 	u32 dir = (args->dir == DRM_XOCL_SYNC_BO_TO_DEVICE) ? 1 : 0;
 	struct drm_gem_object *gem_obj = xocl_gem_object_lookup(dev, filp,
-								   args->handle);
+							       args->handle);
 	if (!gem_obj) {
 		DRM_ERROR("Failed to look up GEM BO %d\n", args->handle);
 		return -ENOENT;
@@ -716,20 +716,20 @@ clear:
 		kfree(sgt);
 	}
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 	return ret;
 }
 
 int xocl_info_bo_ioctl(struct drm_device *dev,
-			   void *data,
-			   struct drm_file *filp)
+		       void *data,
+		       struct drm_file *filp)
 {
 	const struct drm_xocl_bo *xobj;
 	struct drm_xocl_info_bo *args = data;
@@ -748,13 +748,13 @@ int xocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->paddr = xocl_bo_physical_addr(xobj);
 	xocl_describe(xobj);
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj)
+    drm_gem_object_unreference_unlocked(gem_obj)
 #endif
 
 	return 0;
@@ -766,7 +766,7 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 	struct drm_xocl_bo *xobj;
 	const struct drm_xocl_pwrite_bo *args = data;
 	struct drm_gem_object *gem_obj = xocl_gem_object_lookup(dev, filp,
-								   args->handle);
+							       args->handle);
 	char __user *user_data = to_user_ptr(args->data_ptr);
 	int ret = 0;
 	void *kaddr;
@@ -777,7 +777,7 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 	}
 
 	if ((args->offset > gem_obj->size) || (args->size > gem_obj->size)
-		|| ((args->offset + args->size) > gem_obj->size)) {
+	    || ((args->offset + args->size) > gem_obj->size)) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -787,9 +787,9 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -812,13 +812,13 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -830,7 +830,7 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	struct drm_xocl_bo *xobj;
 	const struct drm_xocl_pread_bo *args = data;
 	struct drm_gem_object *gem_obj = xocl_gem_object_lookup(dev, filp,
-								   args->handle);
+							       args->handle);
 	char __user *user_data = to_user_ptr(args->data_ptr);
 	int ret = 0;
 	void *kaddr;
@@ -846,7 +846,7 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	}
 
 	if ((args->offset > gem_obj->size) || (args->size > gem_obj->size)
-		|| ((args->offset + args->size) > gem_obj->size)) {
+	    || ((args->offset + args->size) > gem_obj->size)) {
 		ret = -EINVAL;
 		goto out;
 	}
@@ -856,9 +856,9 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, args->size)) {
 #else
@@ -876,13 +876,13 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	drm_gem_object_put_unlocked(gem_obj);
 #else
-	drm_gem_object_unreference_unlocked(gem_obj);
+    drm_gem_object_unreference_unlocked(gem_obj);
 #endif
 
 	return ret;
@@ -1006,9 +1006,9 @@ out:
 		sg_free_table(tmp_sgt);
 		kfree(tmp_sgt);
 	}
-	/* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
-	 * is no longer supported.
-	 */
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	if (src_gem_obj)
 		drm_gem_object_put_unlocked(src_gem_obj);
@@ -1016,9 +1016,9 @@ out:
 		drm_gem_object_put_unlocked(dst_gem_obj);
 #else
 	if (src_gem_obj)
-		drm_gem_object_unreference_unlocked(src_gem_obj);
+        drm_gem_object_unreference_unlocked(src_gem_obj);
 	if (dst_gem_obj)
-		drm_gem_object_unreference_unlocked(dst_gem_obj);
+        drm_gem_object_unreference_unlocked(dst_gem_obj);
 #endif
 	return ret;
 }
@@ -1032,7 +1032,7 @@ struct sg_table *xocl_gem_prime_get_sg_table(struct drm_gem_object *obj)
 }
 
 struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
-	  struct dma_buf_attachment *attach, struct sg_table *sgt)
+      struct dma_buf_attachment *attach, struct sg_table *sgt)
 {
 	int ret = 0;
 	struct drm_xocl_bo *importing_xobj;
@@ -1055,7 +1055,7 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 		goto out_free;
 	}
 	ret = drm_prime_sg_to_page_addr_arrays(sgt, importing_xobj->pages,
-		   NULL, attach->dmabuf->size >> PAGE_SHIFT);
+	       NULL, attach->dmabuf->size >> PAGE_SHIFT);
 	if (ret)
 		goto out_free;
 
@@ -1074,9 +1074,9 @@ struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 	return &importing_xobj->base;
 
 out_free:
-		xocl_free_bo(&importing_xobj->base);
-		DRM_ERROR("Buffer import failed\n");
-		return ERR_PTR(ret);
+        xocl_free_bo(&importing_xobj->base);
+        DRM_ERROR("Buffer import failed\n");
+        return ERR_PTR(ret);
 }
 
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj)
@@ -1124,9 +1124,9 @@ int xocl_init_unmgd(struct drm_xocl_unmgd *unmgd, uint64_t data_ptr,
 	int ret;
 	char __user *user_data = to_user_ptr(data_ptr);
 
-	/* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
-	 * supported.
-	 */
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
 	if (!access_ok(user_data, size))
 #else
@@ -1196,7 +1196,7 @@ static bool xocl_validate_paddr(struct xocl_dev *xdev, u64 paddr, u64 size)
 }
 
 int xocl_pwrite_unmgd_ioctl(struct drm_device *dev, void *data,
-				struct drm_file *filp)
+			    struct drm_file *filp)
 {
 	int channel;
 	struct drm_xocl_unmgd unmgd;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -6,6 +6,7 @@
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
  *    Sarabjeet Singh <sarabjeet.singh@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -469,7 +470,14 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		goto out_free;
 
 	xocl_describe(xobj);
-	drm_gem_object_unreference_unlocked(&xobj->base);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(&xobj->base);
+#else
+    drm_gem_object_unreference_unlocked(&xobj->base);
+#endif
 	return ret;
 
 out_free:
@@ -541,7 +549,14 @@ int xocl_userptr_bo_ioctl(struct drm_device *dev,
 
 	xobj->type |= XOCL_BO_USERPTR;
 	xocl_describe(xobj);
-	drm_gem_object_unreference_unlocked(&xobj->base);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(&xobj->base);
+#else
+    drm_gem_object_unreference_unlocked(&xobj->base);
+#endif
 	return ret;
 
 out0:
@@ -580,7 +595,14 @@ int xocl_map_bo_ioctl(struct drm_device *dev,
 	args->offset = drm_vma_node_offset_addr(&obj->vma_node);
 	xocl_describe(to_xocl_bo(obj));
 out:
-	drm_gem_object_unreference_unlocked(obj);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(obj);
+#else
+    drm_gem_object_unreference_unlocked(obj);
+#endif
 	return ret;
 }
 
@@ -694,7 +716,14 @@ clear:
 		kfree(sgt);
 	}
 out:
-	drm_gem_object_unreference_unlocked(gem_obj);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(gem_obj);
+#else
+    drm_gem_object_unreference_unlocked(gem_obj);
+#endif
 	return ret;
 }
 
@@ -719,7 +748,14 @@ int xocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->paddr = xocl_bo_physical_addr(xobj);
 	xocl_describe(xobj);
-	drm_gem_object_unreference_unlocked(gem_obj);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(gem_obj);
+#else
+    drm_gem_object_unreference_unlocked(gem_obj)
+#endif
 
 	return 0;
 }
@@ -751,7 +787,14 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	if (!access_ok(user_data, args->size)) {
+#else
 	if (!access_ok(VERIFY_READ, user_data, args->size)) {
+#endif
 		ret = -EFAULT;
 		goto out;
 	}
@@ -769,7 +812,14 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-	drm_gem_object_unreference_unlocked(gem_obj);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(gem_obj);
+#else
+    drm_gem_object_unreference_unlocked(gem_obj);
+#endif
 
 	return ret;
 }
@@ -806,7 +856,14 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	if (!access_ok(user_data, args->size)) {
+#else
 	if (!access_ok(VERIFY_WRITE, user_data, args->size)) {
+#endif
 		ret = EFAULT;
 		goto out;
 	}
@@ -819,7 +876,14 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-	drm_gem_object_unreference_unlocked(gem_obj);
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	drm_gem_object_put_unlocked(gem_obj);
+#else
+    drm_gem_object_unreference_unlocked(gem_obj);
+#endif
 
 	return ret;
 }
@@ -942,10 +1006,20 @@ out:
 		sg_free_table(tmp_sgt);
 		kfree(tmp_sgt);
 	}
+    /* TODO: Remove drm_gem_object_unreference_unlocked as soon as Linux < 4.12
+     * is no longer supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	if (src_gem_obj)
-		drm_gem_object_unreference_unlocked(src_gem_obj);
+		drm_gem_object_put_unlocked(src_gem_obj);
 	if (dst_gem_obj)
-		drm_gem_object_unreference_unlocked(dst_gem_obj);
+		drm_gem_object_put_unlocked(dst_gem_obj);
+#else
+	if (src_gem_obj)
+        drm_gem_object_unreference_unlocked(src_gem_obj);
+	if (dst_gem_obj)
+        drm_gem_object_unreference_unlocked(dst_gem_obj);
+#endif
 	return ret;
 }
 
@@ -1050,7 +1124,14 @@ int xocl_init_unmgd(struct drm_xocl_unmgd *unmgd, uint64_t data_ptr,
 	int ret;
 	char __user *user_data = to_user_ptr(data_ptr);
 
+    /* TODO: Remove old access_ok macro as soon as Linux < 5.0 is no longer
+     * supported.
+     */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	if (!access_ok(user_data, size))
+#else
 	if (!access_ok((write == 1) ? VERIFY_READ : VERIFY_WRITE, user_data, size))
+#endif
 		return -EFAULT;
 
 	memset(unmgd, 0, sizeof(struct drm_xocl_unmgd));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -406,14 +406,7 @@ failed:
 	if (drm_registered)
 		drm_dev_unregister(ddev);
 	if (ddev)
-		/* TODO: Remove drm_dev_unref as soon as Linux < 4.15 is no longer
-		 * supported.
-		 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
-		drm_dev_put(ddev);
-#else
-		drm_dev_unref(ddev);
-#endif
+		XOCL_DRM_DEV_PUT(ddev);
 	if (drm_p)
 		xocl_drvinst_free(drm_p);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -406,13 +406,13 @@ failed:
 	if (drm_registered)
 		drm_dev_unregister(ddev);
 	if (ddev)
-        /* TODO: Remove drm_dev_unref as soon as Linux < 4.15 is no longer
-         * supported.
-         */
+		/* TODO: Remove drm_dev_unref as soon as Linux < 4.15 is no longer
+		 * supported.
+		 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 		drm_dev_put(ddev);
 #else
-        drm_dev_unref(ddev);
+		drm_dev_unref(ddev);
 #endif
 	if (drm_p)
 		xocl_drvinst_free(drm_p);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
- * Authors:
+ * Authors: Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -406,7 +406,14 @@ failed:
 	if (drm_registered)
 		drm_dev_unregister(ddev);
 	if (ddev)
-		drm_dev_unref(ddev);
+        /* TODO: Remove drm_dev_unref as soon as Linux < 4.15 is no longer
+         * supported.
+         */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+		drm_dev_put(ddev);
+#else
+        drm_dev_unref(ddev);
+#endif
 	if (drm_p)
 		xocl_drvinst_free(drm_p);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -31,6 +32,67 @@
 #include <linux/libfdt_env.h>
 #include "lib/libfdt/libfdt.h"
 
+/* The fix for the y2k38 bug was introduced with Linux 3.17 and backported to
+ * Red Hat 7.2.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+	#define XOCL_TIMESPEC struct timespec64
+	#define XOCL_GETTIME ktime_get_real_ts64
+	#define XOCL_USEC tv_nsec / NSEC_PER_USEC
+#elif defined(RHEL_RELEASE_CODE)
+	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,2)
+		#define XOCL_TIMESPEC struct timespec64
+		#define XOCL_GETTIME ktime_get_real_ts64
+		#define XOCL_USEC tv_nsec / NSEC_PER_USEC
+	#else
+		#define XOCL_TIMESPEC struct timeval
+		#define XOCL_GETTIME do_gettimeofday
+		#define XOCL_USEC tv_usec
+	#endif
+#else
+	#define XOCL_TIMESPEC struct timeval
+	#define XOCL_GETTIME do_gettimeofday
+	#define XOCL_USEC tv_usec
+#endif
+
+/* drm_gem_object_put_unlocked and drm_gem_object_get were introduced with Linux
+ * 4.12 and backported to Red Hat 7.5.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
+	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
+#elif defined(RHEL_RELEASE_CODE)
+	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,5)
+		#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
+		#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
+	#else
+		#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_unreference_unlocked
+		#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_reference
+	#endif
+#else
+	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_unreference_unlocked
+	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_reference
+#endif
+
+/* drm_dev_put was introduced with Linux 4.15 and backported to Red Hat 7.6. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+	#define XOCL_DRM_DEV_PUT drm_dev_put
+#elif defined(RHEL_RELEASE_CODE)
+	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,6)
+		#define XOCL_DRM_DEV_PUT drm_dev_put
+	#else
+		#define XOCL_DRM_DEV_PUT drm_dev_unref
+	#endif
+#else
+	#define XOCL_DRM_DEV_PUT drm_dev_unref
+#endif
+
+/* access_ok lost its first parameter with Linux 5.0. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	#define XOCL_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(ADDR, SIZE)
+#else
+	#define XOCL_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(TYPE, ADDR, SIZE)
+#endif
 
 #if defined(RHEL_RELEASE_CODE)
 #if RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7, 4)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
@@ -14,7 +14,6 @@
  */
 
 #include <linux/kthread.h>
-#include <linux/version.h>
 #include "xocl_drv.h"
 
 int xocl_test_interval = 5;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
@@ -28,12 +28,12 @@ bool xocl_test_on = true;
 static int xocl_test_thread_main(void *data)
 {
 #if 0
-    /* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported.
-     */
+	/* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported.
+	 */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 	struct timespec64 now;
 #else
-    struct timeval now;
+	struct timeval now;
 #endif
 	struct drm_xocl_dev *xdev = (struct drm_xocl_dev *)data;
 	int irq = 0;
@@ -41,11 +41,11 @@ static int xocl_test_thread_main(void *data)
 	while (!kthread_should_stop()) {
 		ssleep(xocl_test_interval);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-        ktime_get_real_ts64(&now);
+		ktime_get_real_ts64(&now);
 		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_nsec / NSEC_PER_USEC);
 #else
-        do_gettimeofday(&now);
-        DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_usec);
+		do_gettimeofday(&now);
+		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_usec);
 #endif
 		xocl_user_event(irq, xdev);
 		irq++;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
@@ -28,12 +28,12 @@ bool xocl_test_on = true;
 static int xocl_test_thread_main(void *data)
 {
 #if 0
-	/* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported.
-	 */
+    /* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported.
+     */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
 	struct timespec64 now;
 #else
-	struct timeval now;
+    struct timeval now;
 #endif
 	struct drm_xocl_dev *xdev = (struct drm_xocl_dev *)data;
 	int irq = 0;
@@ -41,11 +41,11 @@ static int xocl_test_thread_main(void *data)
 	while (!kthread_should_stop()) {
 		ssleep(xocl_test_interval);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-		ktime_get_real_ts64(&now);
+        ktime_get_real_ts64(&now);
 		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_nsec / NSEC_PER_USEC);
 #else
-		do_gettimeofday(&now);
-		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_usec);
+        do_gettimeofday(&now);
+        DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_usec);
 #endif
 		xocl_user_event(irq, xdev);
 		irq++;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_test.c
@@ -28,25 +28,14 @@ bool xocl_test_on = true;
 static int xocl_test_thread_main(void *data)
 {
 #if 0
-	/* TODO: Remove old timeval as soon as Linux < 3.17 is no longer supported.
-	 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-	struct timespec64 now;
-#else
-	struct timeval now;
-#endif
+	XOCL_TIMESPEC now;
 	struct drm_xocl_dev *xdev = (struct drm_xocl_dev *)data;
 	int irq = 0;
 	int count = 0;
 	while (!kthread_should_stop()) {
 		ssleep(xocl_test_interval);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
-		ktime_get_real_ts64(&now);
-		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_nsec / NSEC_PER_USEC);
-#else
-		do_gettimeofday(&now);
-		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_usec);
-#endif
+		XOCL_GETTIME(&now);
+		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.XOCL_USEC);
 		xocl_user_event(irq, xdev);
 		irq++;
 		irq &= 0xf;

--- a/src/runtime_src/doc/toc/index.rst
+++ b/src/runtime_src/doc/toc/index.rst
@@ -14,28 +14,70 @@ FPGA. The key user APIs are defined in ``xrt.h`` header file.
 
 .. toctree::
    :maxdepth: 1
-   :caption: Table of Contents
+   :caption: XRT Introduction
 
    platforms.rst
-   execution-model.rst
-   xrt.main.rst
-   mgmt-ioctl.main.rst
-   xocl_ioctl.main.rst
-   sysfs.rst
-   tools.rst
-   xclbintools.rst
-   ert.main.rst
-   multiprocess.rst
-   formats.rst
    system_requirements.rst
    build.rst
-   yocto.rst
    test.rst
-   newdsa-bringup.rst
-   create_platforms.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: XRT Use Model and Features
+
+   execution-model.rst
+   multiprocess.rst
    p2p.rst
    m2m.rst
-   debug-faq.rst
    xma.main.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: XRT API Library
+
+   xrt.main.rst
+   ert.main.rst
+
+
+.. toctree::
+   :caption: Kernel Driver 
+   :maxdepth: 1
+
+   sysfs.rst
+   mgmt-ioctl.main.rst
+   xocl_ioctl.main.rst
+
+
+.. toctree::
+   :caption: Tools and Utilities  
+   :maxdepth: 1
+
+   tools.rst
+   formats.rst
+   xclbintools.rst
+
+
+.. toctree::
+   :caption: Platform Building  
+   :maxdepth: 1
+
+   yocto.rst
+   newdsa-bringup.rst
+   create_platforms.rst
+
+
+.. toctree::
+   :caption: Cloud Support   
+   :maxdepth: 1
+
    mailbox.main.rst
    mailbox.proto.rst
+
+
+.. toctree::
+   :caption: Debug and Faqs  
+   :maxdepth: 1
+
+   debug-faq.rst


### PR DESCRIPTION
On newer Linux kernels the DKMS stage of compilation will fail because of renamed kernel functions (see #1384). This PR fixes these issues but of course requires testing. It should enable consistent compilation across all kernel versions from 3.10 to 5.0.