### PR TITLE
aarch64 warning on alignas

### DIFF
--- a/src/runtime_src/core/pcie/user_aws/shim.cpp
+++ b/src/runtime_src/core/pcie/user_aws/shim.cpp
@@ -204,7 +204,8 @@ namespace awsbwhal {
             mLogStream << __func__ << ", " << std::this_thread::get_id() << ", "
                        << offset << ", " << hostBuf << ", " << size << std::endl;
         }
-#if ((GCC_VERSION >= 40800) && !defined(__PPC64__))
+
+#if ((GCC_VERSION >= 40800) && !defined(__PPC64__) && !defined(__aarch64__))
         alignas(DDR_BUFFER_ALIGNMENT) char buffer[DDR_BUFFER_ALIGNMENT];
 #else
         AlignedAllocator<char> alignedBuffer(DDR_BUFFER_ALIGNMENT, DDR_BUFFER_ALIGNMENT);


### PR DESCRIPTION
When I was compiling the XRT on native ARM64 system, this was the only warning. It seems that some aarch64-g++ doesn't support the alignas c++11 api. Either we disable the warning or we don't use the alignas api on ARM64. I think disabling the warning may cause some potential performance issue.