### PR TITLE
Added PL-DDR support for MPSoC

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -24,6 +24,7 @@
 #include <linux/iommu.h>
 #include <asm/io.h>
 #include "zocl_drv.h"
+#include "xclbin.h"
 
 static inline void __user *to_user_ptr(u64 address)
 {
@@ -142,12 +143,50 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 		err = drm_gem_object_init(dev, &bo->gem_base, size);
 		if (err < 0)
 			goto free;
-	} else {
+	} else if (user_flags & XCL_BO_FLAGS_CMA) {
+		/* Allocate from CMA buffer */
 		cma_obj = drm_gem_cma_create(dev, size);
 		if (IS_ERR(cma_obj))
 			return ERR_PTR(-ENOMEM);
 
 		bo = to_zocl_bo(&cma_obj->base);
+	} else {
+		/* We are allocating from a separate BANK, i.e. PL-DDR */
+		unsigned int bank = GET_MEM_BANK(user_flags);
+
+		bo = kzalloc(sizeof (struct drm_zocl_bo), GFP_KERNEL);
+		if (IS_ERR(bo))
+			return ERR_PTR(-ENOMEM);
+
+		err = drm_gem_object_init(dev, &bo->gem_base, size);
+		if (err)
+			return ERR_PTR(err);
+
+		bo->mm_node = kzalloc(sizeof(struct drm_mm_node),
+		    GFP_KERNEL);
+		if (IS_ERR(bo->mm_node)) {
+			kfree(bo);
+			return ERR_PTR(-ENOMEM);
+		}
+
+		mutex_lock(&zdev->mm_lock);
+		err = drm_mm_insert_node_generic(zdev->mem[bank].zm_mm,
+		    bo->mm_node, size, PAGE_SIZE, 0, 0);
+		if (err) {
+			DRM_ERROR("Fail to allocate BO: size %ld\n", size);
+			mutex_unlock(&zdev->mm_lock);
+			kfree(bo->mm_node);
+			kfree(bo);
+			return ERR_PTR(-ENOMEM);
+		}
+		mutex_unlock(&zdev->mm_lock);
+
+		err = drm_gem_create_mmap_offset(&bo->gem_base);
+		if (err) {
+			DRM_ERROR("Fail to create BO mmap offset.\n");
+			zocl_free_bo(&bo->gem_base);
+			return ERR_PTR(err);
+		}
 	}
 
 	if (user_flags & XCL_BO_FLAGS_EXECBUF) {
@@ -179,6 +218,7 @@ zocl_create_svm_bo(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	bo = zocl_create_bo(dev, args->size, args->flags);
 	bo->flags |= XCL_BO_FLAGS_SVM;
+	bo->bank = GET_MEM_BANK(args->flags);
 
 	if (IS_ERR(bo)) {
 		DRM_DEBUG("object creation failed\n");
@@ -215,7 +255,7 @@ zocl_create_svm_bo(struct drm_device *dev, void *data, struct drm_file *filp)
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&bo->gem_base);
 
 	/* Update memory usage statistics */
-	zocl_update_mem_stat(dev->dev_private, args->size, 1);
+	zocl_update_mem_stat(dev->dev_private, args->size, 1, bo->bank);
 
 	return ret;
 
@@ -231,20 +271,44 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	struct drm_zocl_create_bo *args = data;
 	struct drm_zocl_bo *bo;
 	struct drm_zocl_dev *zdev = dev->dev_private;
+	unsigned int bank;
 
-	/* Remove all flags, except EXECBUF and CACHEABLE. */
-	args->flags &= XCL_BO_FLAGS_EXECBUF | XCL_BO_FLAGS_CACHEABLE;
+	/*
+	 * Keep the bank index and remove all flags, except EXECBUF and
+	 * CACHEABLE.
+	 */
+	args->flags &= (XCL_BO_FLAGS_EXECBUF | XCL_BO_FLAGS_CACHEABLE | 0xFFFF);
 
 	if (zdev->domain)
 		return zocl_create_svm_bo(dev, data, filp);
 
-	/* This is not good. But force to use CMA flags here. */
-	/* Remove this only when XRT use the same flags for xocl and zocl */
-	args->flags |= XCL_BO_FLAGS_CMA;
+	bank = GET_MEM_BANK(args->flags);
 
-	/* If cacheable is not set, make sure we set COHERENT. */
-	if (!(args->flags & XCL_BO_FLAGS_CACHEABLE))
+	/* Always allocate EXECBUF from CMA */
+	if (args->flags & XCL_BO_FLAGS_EXECBUF)
+		args->flags |= XCL_BO_FLAGS_CMA;
+	else {
+		/*
+		 * For specified valid DDR bank, we only mark CMA flags
+		 * if the bank type is CMA, non-CMA type bank will use
+		 * PL-DDR; For any other cases (invalid bank index), we
+		 * allocate from CMA by default.
+		 */
+		if (bank < zdev->num_mem && zdev->mem[bank].zm_used) {
+			if (zdev->mem[bank].zm_type == ZOCL_MEM_TYPE_CMA)
+				args->flags |= XCL_BO_FLAGS_CMA;
+		} else
+			args->flags |= XCL_BO_FLAGS_CMA;
+	}
+
+	if (!(args->flags & XCL_BO_FLAGS_CACHEABLE)) {
+		/* If cacheable is not set, make sure we set COHERENT. */
 		args->flags |= XCL_BO_FLAGS_COHERENT;
+	} else if (!(args->flags & XCL_BO_FLAGS_CMA)) {
+		/* We do not support allocating cacheable BO from PL-DDR. */
+		DRM_WARN("Cache is not supported and turned off for PL-DDR.\n");
+		args->flags &= ~XCL_BO_FLAGS_CACHEABLE;
+	}
 
 	bo = zocl_create_bo(dev, args->size, args->flags);
 	if (IS_ERR(bo)) {
@@ -252,17 +316,29 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		return PTR_ERR(bo);
 	}
 
+	bo->bank = bank;
 	if (args->flags & XCL_BO_FLAGS_CACHEABLE)
 		bo->flags |= XCL_BO_FLAGS_CACHEABLE;
 	else
 		bo->flags |= XCL_BO_FLAGS_COHERENT;
-	bo->flags |= XCL_BO_FLAGS_CMA;
 
-	ret = drm_gem_handle_create(filp, &bo->cma_base.base, &args->handle);
-	if (ret) {
-		drm_gem_cma_free_object(&bo->cma_base.base);
-		DRM_DEBUG("handle creation failed\n");
-		return ret;
+	if (args->flags & XCL_BO_FLAGS_CMA) {
+		bo->flags |= XCL_BO_FLAGS_CMA;
+		ret = drm_gem_handle_create(filp, &bo->cma_base.base,
+		    &args->handle);
+		if (ret) {
+			drm_gem_cma_free_object(&bo->cma_base.base);
+			DRM_DEBUG("handle creation failed\n");
+			return ret;
+		}
+	} else {
+		ret = drm_gem_handle_create(filp, &bo->gem_base,
+		    &args->handle);
+		if (ret) {
+			zocl_free_bo(&bo->gem_base);
+			DRM_DEBUG("handle create failed\n");
+			return ret;
+		}
 	}
 
 	zocl_describe(bo);
@@ -275,7 +351,7 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	 *       the required size while gem object records the
 	 *       actual size allocated.
 	 */
-	zocl_update_mem_stat(zdev, bo->gem_base.size, 1);
+	zocl_update_mem_stat(zdev, bo->gem_base.size, 1, bo->bank);
 
 	return ret;
 }
@@ -473,8 +549,14 @@ int zocl_info_bo_ioctl(struct drm_device *dev,
 
 	bo = to_zocl_bo(gem_obj);
 
-	args->size = bo->cma_base.base.size;
-	args->paddr = bo->cma_base.paddr;
+	if (bo->flags & (XCL_BO_FLAGS_CMA | XCL_BO_FLAGS_USERPTR)) {
+		args->size = bo->cma_base.base.size;
+		args->paddr = bo->cma_base.paddr;
+	} else {
+		args->size = bo->gem_base.size;
+		args->paddr = bo->mm_node->start;
+	}
+
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return 0;
@@ -662,10 +744,112 @@ void zocl_free_host_bo(struct drm_gem_object *gem_obj)
  * allocating 'count' BOs with total size 'size'; If count < 0, we are
  * freeing 'count' BOs with total size 'size'.
  */
-void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count)
+void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count,
+		uint32_t bank)
 {
+	int i, update_bank = zdev->num_mem;
+
+	/*
+	 * If the 'bank' passed in is a valid bank and its type is
+	 * PL-DDR, we update that bank usage. Otherwise, we go
+	 * through our bank list and find the CMA bank to update
+	 * its usage.
+	 */
+	if (bank < zdev->num_mem &&
+	    zdev->mem[bank].zm_type == ZOCL_MEM_TYPE_PLDDR) {
+		update_bank = bank;
+	} else {
+		for (i = 0; i < zdev->num_mem; i++) {
+			if (zdev->mem[i].zm_used &&
+			    zdev->mem[i].zm_type == ZOCL_MEM_TYPE_CMA) {
+				update_bank = i;
+				break;
+			}
+		}
+	}
+
+	if (update_bank == zdev->num_mem)
+		return;
+
 	write_lock(&zdev->attr_rwlock);
-	zdev->mm_usage.memory_usage += (count > 0) ?  size : -size;
-	zdev->mm_usage.bo_count += count;
+	zdev->mem[update_bank].zm_stat.memory_usage +=
+	    (count > 0) ?  size : -size;
+	zdev->mem[update_bank].zm_stat.bo_count += count;
 	write_unlock(&zdev->attr_rwlock);
+}
+
+/*
+ * Initialize the memory structure in zocl driver based on the memory
+ * topology extracted from xclbin.
+ *
+ * Currently, we could have multiple memory sections but only two type
+ * of them could be marked as used. We identify the memory type by its
+ * tag. If the tag field contains "MIG", it is PL-DDR. Other tags
+ * e.g. "HP", "HPC", it is CMA memory.
+ *
+ * PL-DDR is managed by DRM MM Range Allocator;
+ * CMA is managed by DRM CMA Allocator.
+ */
+void zocl_init_mem(struct drm_zocl_dev *zdev, struct mem_topology *mtopo)
+{
+	struct zocl_mem *memp;
+	int i;
+
+	zdev->num_mem = mtopo->m_count;
+	zdev->mem = vzalloc(zdev->num_mem * sizeof(struct zocl_mem));
+
+	for (i = 0; i < zdev->num_mem; i++) {
+		struct mem_data *md = &mtopo->m_mem_data[i];
+
+		if (!md->m_used)
+			continue;
+
+		memp = &zdev->mem[i];
+		if (md->m_type == MEM_STREAMING) {
+			memp->zm_type = ZOCL_MEM_TYPE_STREAMING;
+			continue;
+		}
+
+		memp->zm_base_addr = md->m_base_address;
+		/* In mem_topology, size is in KB */
+		memp->zm_size = md->m_size * 1024;
+		memp->zm_used = 1;
+
+		if (!strstr(md->m_tag, "MIG")) {
+			memp->zm_type = ZOCL_MEM_TYPE_CMA;
+			continue;
+		}
+
+		memp->zm_mm = vzalloc(sizeof(struct drm_mm));
+		memp->zm_type = ZOCL_MEM_TYPE_PLDDR;
+
+		drm_mm_init(memp->zm_mm, memp->zm_base_addr, memp->zm_size);
+	}
+}
+
+void zocl_clear_mem(struct drm_zocl_dev *zdev)
+{
+	int i;
+
+	mutex_lock(&zdev->mm_lock);
+
+	if (!zdev->mem) {
+		mutex_unlock(&zdev->mm_lock);
+		return;
+	}
+
+	for (i = 0; i < zdev->num_mem; i++) {
+		struct zocl_mem *md = &zdev->mem[i];
+
+		if (md->zm_mm) {
+			drm_mm_takedown(md->zm_mm);
+			vfree(md->zm_mm);
+		}
+	}
+
+	vfree(zdev->mem);
+	zdev->mem = NULL;
+	zdev->num_mem = 0;
+
+	mutex_unlock(&zdev->mm_lock);
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -723,7 +723,7 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 
 	return ret;
 error:
-	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&cma_obj->base)
+	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&cma_obj->base);
 	return ret;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -162,8 +162,10 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 			return ERR_PTR(-ENOMEM);
 
 		err = drm_gem_object_init(dev, &bo->gem_base, size);
-		if (err)
+		if (err) {
+			kfree(bo);
 			return ERR_PTR(err);
+		}
 
 		bo->mm_node = kzalloc(sizeof(struct drm_mm_node),
 		    GFP_KERNEL);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -156,7 +156,7 @@ int get_apt_index(struct drm_zocl_dev *zdev, phys_addr_t addr)
 		if (apts[i].addr == addr)
 			break;
 
-	return (i == zdev->num_apts)? -EINVAL : i;
+	return (i == zdev->num_apts) ? -EINVAL : i;
 }
 
 /**
@@ -191,11 +191,23 @@ void zocl_free_bo(struct drm_gem_object *obj)
 			zocl_free_userptr_bo(obj);
 		else if (zocl_obj->flags & XCL_BO_FLAGS_HOST_BO)
 			zocl_free_host_bo(obj);
-		else {
+		else if (zocl_obj->flags & XCL_BO_FLAGS_CMA) {
 			drm_gem_cma_free_object(obj);
 
 			/* Update memory usage statistics */
-			zocl_update_mem_stat(zdev, obj->size, -1);
+			zocl_update_mem_stat(zdev, obj->size, -1,
+			    zocl_obj->bank);
+		} else {
+			if (zocl_obj->mm_node) {
+				mutex_lock(&zdev->mm_lock);
+				drm_mm_remove_node(zocl_obj->mm_node);
+				mutex_unlock(&zdev->mm_lock);
+				kfree(zocl_obj->mm_node);
+				zocl_update_mem_stat(zdev, obj->size, -1,
+				    zocl_obj->bank);
+			}
+			drm_gem_object_release(obj);
+			kfree(zocl_obj);
 		}
 
 		return;
@@ -221,7 +233,8 @@ void zocl_free_bo(struct drm_gem_object *obj)
 			drm_gem_put_pages(obj, zocl_obj->pages, false, false);
 
 			/* Update memory usage statistics */
-			zocl_update_mem_stat(zdev, obj->size, -1);
+			zocl_update_mem_stat(zdev, obj->size, -1,
+			    zocl_obj->bank);
 		}
 	}
 	if (zocl_obj->sgt)
@@ -232,11 +245,12 @@ void zocl_free_bo(struct drm_gem_object *obj)
 }
 
 static int
-zocl_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma)
+zocl_gem_mmap(struct file *filp, struct vm_area_struct *vma)
 {
-	struct drm_gem_cma_object *cma_obj;
+	struct drm_gem_cma_object *cma_obj = NULL;
 	struct drm_gem_object *gem_obj;
 	struct drm_zocl_bo *bo;
+	dma_addr_t paddr;
 	pgprot_t prot;
 	int rc;
 
@@ -248,12 +262,9 @@ zocl_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma)
 	prot = vma->vm_page_prot;
 
 	rc = drm_gem_mmap(filp, vma);
+
 	if (rc)
 		return rc;
-
-	gem_obj = vma->vm_private_data;
-	cma_obj = to_drm_gem_cma_obj(gem_obj);
-	bo = to_zocl_bo(gem_obj);
 
 	/**
 	 * Clear the VM_PFNMAP flag that was set by drm_gem_mmap(),
@@ -263,7 +274,10 @@ zocl_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma)
 	vma->vm_flags &= ~VM_PFNMAP;
 	vma->vm_pgoff = 0;
 
-	if (bo->flags & XCL_BO_FLAGS_CACHEABLE) {
+	gem_obj = vma->vm_private_data;
+	bo = to_zocl_bo(gem_obj);
+
+	if (bo->flags & XCL_BO_FLAGS_CACHEABLE)
 		/**
 		 * Resume the protection field from mmap(). Most likely
 		 * it will be cacheable. If there is a case that mmap()
@@ -272,14 +286,25 @@ zocl_gem_cma_mmap(struct file *filp, struct vm_area_struct *vma)
 		 * the cacheable BO property.
 		 */
 		vma->vm_page_prot = prot;
-		rc = remap_pfn_range(vma, vma->vm_start,
-		    cma_obj->paddr >> PAGE_SHIFT,
-		    vma->vm_end - vma->vm_start,
-		    prot);
 
+	if (bo->flags & XCL_BO_FLAGS_CMA) {
+		cma_obj = to_drm_gem_cma_obj(gem_obj);
+		paddr = cma_obj->paddr;
 	} else
+		paddr = bo->mm_node->start;
+
+	if ((!(bo->flags & XCL_BO_FLAGS_CMA)) ||
+	    (bo->flags & XCL_BO_FLAGS_CMA &&
+	    bo->flags & XCL_BO_FLAGS_CACHEABLE)) {
+		/* Map PL-DDR and cacheable CMA */
+		rc = remap_pfn_range(vma, vma->vm_start,
+		    paddr >> PAGE_SHIFT, vma->vm_end - vma->vm_start,
+		    vma->vm_page_prot);
+	} else {
+		/* Map non-cacheable CMA */
 		rc = dma_mmap_wc(cma_obj->base.dev->dev, vma, cma_obj->vaddr,
-		    cma_obj->paddr, vma->vm_end - vma->vm_start);
+		    paddr, vma->vm_end - vma->vm_start);
+	}
 
 	if (rc)
 		drm_gem_vm_close(vma);
@@ -309,7 +334,7 @@ static int zocl_mmap(struct file *filp, struct vm_area_struct *vma)
 	 */
 	if (likely(vma->vm_pgoff >= ZOCL_FILE_PAGE_OFFSET)) {
 		if (!zdev->domain)
-			return zocl_gem_cma_mmap(filp, vma);
+			return zocl_gem_mmap(filp, vma);
 
 		/* Map user's pages into his VM */
 		rc = drm_gem_mmap(filp, vma);
@@ -582,6 +607,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		zdev->host_mem = res_mem.start;
 		zdev->host_mem_len = resource_size(&res_mem);
 	}
+	mutex_init(&zdev->mm_lock);
 
 	subdev = find_pdev("80180000.ert_hw");
 	if (subdev) {
@@ -687,6 +713,8 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 #endif
 
 	sched_fini_exec(drm);
+	zocl_clear_mem(zdev);
+	mutex_destroy(&zdev->mm_lock);
 	zocl_free_sections(zdev);
 	zocl_fini_sysfs(drm->dev);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
@@ -106,7 +106,9 @@ struct drm_zocl_bo {
 			uint64_t                      uaddr;
 		};
 	};
+	struct drm_mm_node            *mm_node;
 	struct drm_zocl_exec_metadata  metadata;
+	unsigned int                   bank;
 	uint32_t                       flags;
 };
 
@@ -179,7 +181,10 @@ int zocl_init_sysfs(struct device *dev);
 void zocl_fini_sysfs(struct device *dev);
 void zocl_free_sections(struct drm_zocl_dev *zdev);
 void zocl_free_bo(struct drm_gem_object *obj);
-void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count);
+void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size,
+		int count, uint32_t bank);
+void zocl_init_mem(struct drm_zocl_dev *zdev, struct mem_topology *mtopo);
+void zocl_clear_mem(struct drm_zocl_dev *zdev);
 
 int get_apt_index(struct drm_zocl_dev *zdev, phys_addr_t addr);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -551,6 +551,8 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		goto out0;
 	}
 
+	zocl_init_mem(zdev, zdev->topology);
+
 	zdev->unique_id_last_bitstream = axlf_head.m_uniqueId;
 
 out0:


### PR DESCRIPTION
This PR added support for PL-DDR on MPSoC platform.
1) Support multiple memory bank on MPSoC, BO allocation can be from CMA or PL-DDR by specifying different bank index
        PL-DDR is managed by DRM MM Range Allocator;
        CMA is managed by DRM CMA Allocator.
2) Extract memory bank information from XCLBIN
3) Enhance sysfs node memstat to report memory usage on each bank
4) Tested XRT interface applications as well as OpenCL applications