### PR TITLE
Added the new launcher argument qemu_qspi.bin which is passed to XSIM

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -606,10 +606,11 @@ namespace xclhwemhal2 {
 
         const char* simMode = NULL;
         if (args.m_emuData) {
-          //So far assuming that we will have only one AIR Kernel, need to 
+          //So far assuming that we will have only one AIE Kernel, need to 
           //update this logic when we have suport for multiple AIE Kernels
           launcherArgs += " -emuData " + binaryDirectory + "/" + kernels.at(0) + "/aieshim_solution.aiesol";
           launcherArgs += " -bootBH " + binaryDirectory + "/" + kernels.at(0) + "/boot_bh.bin";
+          launcherArgs += " -image " + binaryDirectory + "/" + kernels.at(0) + "/qemu_qspi.bin";
         }
 
         if (!launcherArgs.empty())


### PR DESCRIPTION
Removed to generate the generation of qemu_qspi.bin at runtime. Moved the generation of qemu_qspi.bin from the PDI at compile time and pushed the file Emulation_archive. Extracted the file from the emulation archive and passed it to the XSIM