### PR TITLE
do not erase the whole flash, golden image starting from 64MB offset

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
@@ -382,8 +382,8 @@ int XQSPIPS_Flasher::xclUpgradeFirmware(std::istream& binStream)
 
     // Sectoer size is defined by SECTOR_SIZE
     std::cout << "Erasing flash" << std::flush;
-    //eraseSector(0, total_size);
-    eraseBulk();
+    eraseSector(0, total_size);
+    //eraseBulk();
     std::cout << std::endl;
 
     pages = total_size / PAGE_SIZE;


### PR DESCRIPTION
As for the storage team's requirement, do not erase the whole flash. This change would make the erase time become longer. The higher 64MB is for golden image.