### PR TITLE
Support added to profiling to create a run_summary file

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -120,7 +120,7 @@ XclBin::readXclBinBinaryHeader(std::fstream& _istream) {
   _istream.read((char*)&m_xclBinHeader, sizeof(axlf));
 
   if (_istream.gcount() != expectBufferSize) {
-    std::string errMsg = "ERROR: Input stream is smaller then the expected header size.";
+    std::string errMsg = "ERROR: Input stream is smaller than the expected header size.";
     throw std::runtime_error(errMsg);
   }
 
@@ -148,7 +148,7 @@ XclBin::readXclBinBinarySections(std::fstream& _istream) {
     _istream.read((char*)&sectionHeader, sizeof(axlf_section_header));
 
     if (_istream.gcount() != expectBufferSize) {
-      std::string errMsg = "ERROR: Input stream is smaller then the expected section header size.";
+      std::string errMsg = "ERROR: Input stream is smaller than the expected section header size.";
       throw std::runtime_error(errMsg);
     }
 

--- a/src/runtime_src/xdp/profile/core/rt_profile.cpp
+++ b/src/runtime_src/xdp/profile/core/rt_profile.cpp
@@ -197,7 +197,7 @@ namespace xdp {
     mWriter->attach(writer);
 
     // Gather data for RunSummary
-    if ((mProfileFlags && xdp::RTUtil::FILE_SUMMARY) && (writer != nullptr)) {
+    if ((mProfileFlags & RTUtil::FILE_SUMMARY) && (writer != nullptr)) {
       mRunSummary->addFile(writer->getFileName(), RunSummary::FT_PROFILE);
     }
   }
@@ -207,7 +207,7 @@ namespace xdp {
     mLogger->attach(writer);
 
     // Gather data for TimingSummary
-    if ((mProfileFlags && xdp::RTUtil::FILE_TIMELINE_TRACE) && (writer != nullptr)) {
+    if ((mProfileFlags & RTUtil::FILE_TIMELINE_TRACE) && (writer != nullptr)) {
       mRunSummary->addFile(writer->getFileName(), RunSummary::FT_TIMING);
     }
   }

--- a/src/runtime_src/xdp/profile/core/rt_profile.cpp
+++ b/src/runtime_src/xdp/profile/core/rt_profile.cpp
@@ -208,7 +208,7 @@ namespace xdp {
 
     // Gather data for TimingSummary
     if ((mProfileFlags & RTUtil::FILE_TIMELINE_TRACE) && (writer != nullptr)) {
-      mRunSummary->addFile(writer->getFileName(), RunSummary::FT_TIMING);
+      mRunSummary->addFile(writer->getFileName(), RunSummary::FT_TRACE);
     }
   }
 

--- a/src/runtime_src/xdp/profile/core/rt_profile.cpp
+++ b/src/runtime_src/xdp/profile/core/rt_profile.cpp
@@ -51,6 +51,9 @@ namespace xdp {
     // Logger & writer
     mLogger = new TraceLogger(mProfileCounters, mTraceParser, mPluginHandle.get());
     mWriter = new SummaryWriter(mProfileCounters, mTraceParser, mPluginHandle.get());
+
+    // Run Summary
+    mRunSummary = new RunSummary();
   }
 
   RTProfile::~RTProfile()
@@ -58,10 +61,14 @@ namespace xdp {
     if (mProfileFlags)
       writeProfileSummary();
 
+    // Write out the run summary file (if there is data to write)
+    mRunSummary->writeContent();    
+
     delete mWriter;
     delete mLogger;
     delete mTraceParser;
     delete mProfileCounters;
+    delete mRunSummary;
   }
 
   // ***************************************************************************
@@ -188,11 +195,21 @@ namespace xdp {
   void RTProfile::attach(ProfileWriterI* writer)
   {
     mWriter->attach(writer);
+
+    // Gather data for RunSummary
+    if ((mProfileFlags && xdp::RTUtil::FILE_SUMMARY) && (writer != nullptr)) {
+      mRunSummary->addFile(writer->getFileName(), RunSummary::FT_PROFILE);
+    }
   }
 
   void RTProfile::attach(TraceWriterI* writer)
   {
     mLogger->attach(writer);
+
+    // Gather data for TimingSummary
+    if ((mProfileFlags && xdp::RTUtil::FILE_TIMELINE_TRACE) && (writer != nullptr)) {
+      mRunSummary->addFile(writer->getFileName(), RunSummary::FT_TIMING);
+    }
   }
 
   void RTProfile::detach(ProfileWriterI* writer)

--- a/src/runtime_src/xdp/profile/core/rt_profile.h
+++ b/src/runtime_src/xdp/profile/core/rt_profile.h
@@ -19,6 +19,7 @@
 
 #include "rt_util.h"
 #include "xclperf.h"
+#include "run_summary.h"           // Used to create the run_summary file
 #include "xdp/profile/plugin/base_plugin.h"
 
 #include <set>
@@ -58,6 +59,7 @@ namespace xdp {
     void setStallTrace(const std::string traceStr);
     RTUtil::e_device_trace getTransferTrace() { return mDeviceTraceOption; }
     RTUtil::e_stall_trace getStallTrace() { return mStallTraceOption; }
+    RunSummary * getRunSummary() { return mRunSummary; }
 
   public:
     // Attach or detach observer writers
@@ -161,6 +163,7 @@ namespace xdp {
     SummaryWriter* mWriter;
     std::vector<std::string> mDeviceNames;
     std::shared_ptr<XDPPluginI> mPluginHandle;
+    RunSummary* mRunSummary;
   };
 
 } // xdp

--- a/src/runtime_src/xdp/profile/core/run_summary.cpp
+++ b/src/runtime_src/xdp/profile/core/run_summary.cpp
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "run_summary.h"
+
+#include <iostream>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+RunSummary::RunSummary()
+    : mSystemMetadata("")
+    , mXclbinBaseName("")
+{
+  // Empty
+}
+
+RunSummary::~RunSummary() 
+{
+  // Empty
+}
+
+void RunSummary::addFile(const std::string & fileName, RunSummary::FileType eFileType )
+{
+  // Validate the input parameters
+  if (fileName.empty() || (eFileType == FT_UNKNOWN)) {
+    return;  
+  }
+
+  mFiles.emplace_back(fileName, eFileType);
+}
+
+
+const std::string  
+RunSummary::getFileTypeAsStr(enum RunSummary::FileType eFileType)
+{
+  switch (eFileType) {
+    case FT_UNKNOWN: return "UNKNOWN";
+    case FT_PROFILE: return "PROFILE";
+    case FT_TIMING: return "TIMING";
+  }
+
+  // Yeah, the code will never get here, but it makes for a clean flow
+  return "UNKNOWN";
+}
+
+void RunSummary::extractSystemProfileMetadata(const axlf * pXclbinImage, 
+                                              const std::string & xclbinBaseName)
+{
+  mXclbinBaseName = xclbinBaseName;
+  mSystemMetadata.clear();
+
+  // Make sure we have something to work with
+  if (pXclbinImage == nullptr) {
+    return;
+  }
+
+  // Find the System Metadata section
+  const struct axlf_section_header *pSectionHeader = xclbin::get_axlf_section((const axlf*) pXclbinImage, SYSTEM_METADATA);
+  if (pSectionHeader == nullptr) {
+    return;  
+  }
+
+  // Point to the payload
+  const unsigned char *pBuffer = (const unsigned char *) pXclbinImage + pSectionHeader->m_sectionOffset;
+
+  // Convert the payload from 1 byte binary format to 2 byte hex ascii string representation
+  std::ostringstream buf;
+
+  for (unsigned int index = 0; index < pSectionHeader->m_sectionSize; ++index) {
+    buf << std::hex << std::setw(2) << std::setfill('0') << (unsigned int) pBuffer[index];
+  }
+
+  mSystemMetadata = buf.str();
+}
+
+
+void RunSummary::writeContent()
+{
+  //  Determine if there are files, if not then exit
+  if (mFiles.empty()) {
+    return;
+  }
+
+  boost::property_tree::ptree ptRunSummary;
+
+  // -- Create and add the schema version
+  {
+    boost::property_tree::ptree ptSchema;
+    ptSchema.put("major", "1");
+    ptSchema.put("minor", "0");
+    ptSchema.put("patch", "0");
+    ptRunSummary.add_child("schema_version", ptSchema);
+  }
+
+  // -- Add the files
+  {
+    boost::property_tree::ptree ptFiles;
+
+    // Add each files
+    for (auto file : mFiles) {
+      boost::property_tree::ptree ptFile;
+      ptFile.put("name", file.first.c_str());
+      ptFile.put("type", getFileTypeAsStr(file.second).c_str());
+      ptFiles.push_back(std::make_pair("", ptFile));
+    }
+
+    // Add the files array to the run summary
+    ptRunSummary.add_child("files", ptFiles);
+    boost::property_tree::ptree ptFile;
+  }
+
+  // Add the payload
+  if (!mSystemMetadata.empty()) {
+    boost::property_tree::ptree ptSystemDiagram;
+    ptSystemDiagram.put("payload_16bitEnc", mSystemMetadata.c_str());
+    ptRunSummary.add_child("system_diagram", ptSystemDiagram);
+  }
+   
+  // Open output file
+  std::string outputFile = mXclbinBaseName + ".run_summary";
+
+
+  std::fstream outputStream;
+  outputStream.open(outputFile, std::ifstream::out | std::ifstream::binary);
+  if (!outputStream.is_open()) {
+    std::string errMsg = "ERROR: Unable to open the file for writing: " + outputFile;
+    // std::cerr << errMsg << std::endl;
+    return;
+  }
+
+  boost::property_tree::write_json(outputStream, ptRunSummary, true /*Pretty print*/);
+  outputStream.close();
+}
+

--- a/src/runtime_src/xdp/profile/core/run_summary.cpp
+++ b/src/runtime_src/xdp/profile/core/run_summary.cpp
@@ -49,7 +49,7 @@ RunSummary::getFileTypeAsStr(enum RunSummary::FileType eFileType)
   switch (eFileType) {
     case FT_UNKNOWN: return "UNKNOWN";
     case FT_PROFILE: return "PROFILE";
-    case FT_TIMING: return "TIMING";
+    case FT_TRACE: return "TRACE";
   }
 
   // Yeah, the code will never get here, but it makes for a clean flow

--- a/src/runtime_src/xdp/profile/core/run_summary.h
+++ b/src/runtime_src/xdp/profile/core/run_summary.h
@@ -37,7 +37,7 @@ class RunSummary {
     enum FileType {
       FT_UNKNOWN,
       FT_PROFILE,
-      FT_TIMING
+      FT_TRACE
     };
 
   public:

--- a/src/runtime_src/xdp/profile/core/run_summary.h
+++ b/src/runtime_src/xdp/profile/core/run_summary.h
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __XDP_CORE_RUN_SUMMARY_H
+#define __XDP_CORE_RUN_SUMMARY_H
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+#include "xclbin.h"
+
+#include <string>
+#include <fstream>
+#include <vector>
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+// Forward declarations - use these instead whenever possible...
+
+// --------------- C L A S S :   R u n S u m m a r y -------------------------
+
+class RunSummary {
+  public:
+    // File types supported in the run_summary file
+    enum FileType {
+      FT_UNKNOWN,
+      FT_PROFILE,
+      FT_TIMING
+    };
+
+  public:
+    RunSummary();
+    ~RunSummary();
+
+  public:
+    void addFile(const std::string & fileName, FileType eFileType );
+
+    void extractSystemProfileMetadata(const axlf * pXclbinImage, const std::string & xclbinBaseName);
+    void writeContent();
+
+  protected:
+    const std::string getFileTypeAsStr(FileType eFileType);
+
+  private:
+    std::vector< std::pair< std::string, FileType> > mFiles;
+    std::string mSystemMetadata;
+    std::string mXclbinBaseName;
+
+  private:
+    // Purposefully private and undefined ctors...
+    RunSummary(const RunSummary& obj);
+    RunSummary& operator=(const RunSummary& obj); 
+};
+
+
+
+#endif

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile_cb.cpp
@@ -579,6 +579,14 @@ void cb_reset(const axlf* xclbin)
 {
   auto profiler = OCLProfiler::Instance();
 
+  // Extract and store the system profile metatdata
+  auto pProfileMgr = profiler ? profiler->getProfileManager() : nullptr;
+  auto pRunSummary = pProfileMgr ? pProfileMgr->getRunSummary() : nullptr;
+
+  if (pRunSummary != nullptr) {
+    pRunSummary->extractSystemProfileMetadata(xclbin, "xclbin");
+  }
+
   // init flow mode
   if (!is_emulation_mode()) {
     auto dsa = std::string(reinterpret_cast<const char*>(xclbin->m_header.m_platformVBNV),64);

--- a/src/runtime_src/xdp/profile/writer/base_profile.h
+++ b/src/runtime_src/xdp/profile/writer/base_profile.h
@@ -52,6 +52,10 @@ namespace xdp {
       inline void enableStallTable() { mEnStallTable = true; }
       inline void enableStreamTable() { mEnStreamTable = true; }
       inline void enableShellTables() { mEnShellTables = true; }
+
+      // Returns the output file name for the writer
+      virtual const std::string getFileName() { return ""; }
+
       // Functions for Summary
       // Write Kernel Execution Time stats
       virtual void writeTimeStats(const std::string& name, const TimeStats& stats);

--- a/src/runtime_src/xdp/profile/writer/base_trace.h
+++ b/src/runtime_src/xdp/profile/writer/base_trace.h
@@ -43,6 +43,10 @@ namespace xdp {
 	  virtual ~TraceWriterI() {};
 
     public:
+            // Returns the output file name for the writer
+            virtual const std::string getFileName() { return ""; }
+
+
 	    // Functions for timeline trace log
 	    // Write timeline trace of a function call such as cl API call
 	    void writeFunction(double time, const std::string& functionName,

--- a/src/runtime_src/xdp/profile/writer/csv_profile.h
+++ b/src/runtime_src/xdp/profile/writer/csv_profile.h
@@ -23,14 +23,15 @@ namespace xdp {
 
     class CSVProfileWriter: public ProfileWriterI {
 
-	public:
+    public:
       CSVProfileWriter(const std::string& summaryFileName, const std::string& platformName, XDPPluginI* Plugin);
       ~CSVProfileWriter();
 
       virtual void writeSummary(RTProfile* profile);
+      virtual const std::string getFileName() { return SummaryFileName; }
 
-	protected:
-     void writeDocumentHeader(std::ofstream& ofs, const std::string& docName) override;
+    protected:
+      void writeDocumentHeader(std::ofstream& ofs, const std::string& docName) override;
       void writeDocumentSubHeader(std::ofstream& ofs, RTProfile* profile) override;
       void writeTableHeader(std::ofstream& ofs, const std::string& caption,
           const std::vector<std::string>& columnLabels) override;
@@ -46,7 +47,7 @@ namespace xdp {
       const char* rowEnd() override { return ""; }
       const char* newLine() override { return "\n"; }
 
-	private:
+    private:
       std::string SummaryFileName;
       std::string PlatformName;
       const std::string FileExtension = ".csv";

--- a/src/runtime_src/xdp/profile/writer/csv_trace.h
+++ b/src/runtime_src/xdp/profile/writer/csv_trace.h
@@ -23,14 +23,16 @@ namespace xdp {
 
     class CSVTraceWriter: public TraceWriterI {
 
-	public:
+    public:
       CSVTraceWriter(const std::string& traceFileName, const std::string& platformName, XDPPluginI* Plugin);
       ~CSVTraceWriter();
 
-	protected:
+      virtual const std::string getFileName() { return TraceFileName; }
+
+    protected:
       void writeDocumentHeader(std::ofstream& ofs, const std::string& docName) override;
       void writeTableHeader(std::ofstream& ofs, const std::string& caption,
-	      const std::vector<std::string>& columnLabels) override;
+      const std::vector<std::string>& columnLabels) override;
       void writeTableRowStart(std::ofstream& ofs) override { ofs << "";}
       void writeTableRowEnd(std::ofstream& ofs) override { ofs << "\n";}
       void writeDocumentFooter(std::ofstream& ofs) override;
@@ -38,7 +40,7 @@ namespace xdp {
       // Rest of the cell and row parameters are default in base class
       const char* cellEnd() override { return ","; } 
 
-	private:
+    private:
       std::string TraceFileName;
       std::string PlatformName;
       const std::string FileExtension = ".csv";


### PR DESCRIPTION
The run_summary file has a file index to the profile and timing
files on disk and contains the system profile metadata.
Work Done
---------
1) When the RTProfile class destructor is called, the run_summary file is produced.
2) Added a RunSummary class that is used to store file and metadata that is later marshed to disk.
   + Extracts the System Diagram metadata from the in memory xclbin archive image
   + Encodes the System Diagram metadata as a hex representation when storing to disk
   + Stores the contents of the run_summary file produced on disk in the JSON format
3) Update RTProfile to create the RunSummary class and to add the files and xclbin image to the RunSummary class.
4) Updated the trace and profile classes with a method that exposes the filename produced on disk.
5) Fixed some spelling mistakes