### PR TITLE
Additional cleanup. Supporting regmap upto 2048 and execbo of 4096, etc

### DIFF
--- a/src/xma/include/lib/xmahw.h
+++ b/src/xma/include/lib/xmahw.h
@@ -50,29 +50,23 @@ typedef struct XmaHwKernel
     void*       kernel_cmd_queue;
     void*       kernel_cmd_completion_queue;
     uint32_t    kernel_execbo_handle[MAX_EXECBO_POOL_SIZE];
-    char*       kernel_execbo_data[MAX_EXECBO_POOL_SIZE];
+    char*       kernel_execbo_data[MAX_EXECBO_POOL_SIZE];//execBO size is 4096 in xmahw_hal.cpp
     bool        kernel_execbo_inuse[MAX_EXECBO_POOL_SIZE];
+    uint32_t    reg_map[2048];//Max regmap 2048; execBO size is 4096 in xmahw_hal.cpp
+    pthread_mutex_t *lock;
+    bool             have_lock;
     uint32_t    reserved[16];
 } XmaHwKernel;
 
-typedef struct XmaHwContext
-{
-    uint32_t         reg_map[1024];
-    size_t           min_offset;
-    size_t           max_offset;
-    pthread_mutex_t *lock;
-    bool             have_lock;
-} XmaHwContext;
 
 typedef struct XmaHwSession
 {
     void            *dev_handle;
-    uint64_t         base_address;
-    uint32_t         ddr_bank;
+    //uint64_t         base_address;
+    //uint32_t         ddr_bank;
     //For execbo:
     uint32_t         dev_index;
     XmaHwKernel     *kernel_info;
-    XmaHwContext    *context;
     uint32_t         reserved[16];
 } XmaHwSession;
 

--- a/src/xma/src/xmaapi/xmaconnect.cpp
+++ b/src/xma/src/xmaapi/xmaconnect.cpp
@@ -172,7 +172,7 @@ is_connect_compatible(XmaEndpoint *endpt1,
            "endpt1->width   %d, endpt2->width   %d\n"
            "endpt1->height  %d, endpt2->height  %d\n",
             hw1->dev_handle, hw2->dev_handle,
-            hw1->ddr_bank,   hw2->ddr_bank,
+            hw1->kernel_info->ddr_bank,   hw2->kernel_info->ddr_bank,
             endpt1->bits_per_pixel, endpt2->bits_per_pixel,
             endpt1->width,   endpt2->width,
             endpt1->height,  endpt2->height);
@@ -180,7 +180,7 @@ is_connect_compatible(XmaEndpoint *endpt1,
     // Can't check format because of scaler plugin BUG
     //        endpt1->format         == endpt2->format         &&
     return (hw1->dev_handle        == hw2->dev_handle        &&
-            hw1->ddr_bank          == hw2->ddr_bank          &&
+            hw1->kernel_info->ddr_bank          == hw2->kernel_info->ddr_bank          &&
             endpt1->bits_per_pixel == endpt2->bits_per_pixel &&
             endpt1->width          == endpt2->width          &&
             endpt1->height         == endpt2->height);

--- a/src/xma/src/xmaapi/xmadecoder.cpp
+++ b/src/xma/src/xmaapi/xmadecoder.cpp
@@ -159,12 +159,9 @@ xma_dec_session_create(XmaDecoderProperties *dec_props)
     XmaHwHAL *hal = (XmaHwHAL*)hwcfg->devices[dev_handle].handle;
 
     dec_session->base.hw_session.dev_handle = hal->dev_handle;
-    dec_session->base.hw_session.base_address =
-        hwcfg->devices[dev_handle].kernels[kern_handle].base_address;
-    dec_session->base.hw_session.ddr_bank =
-        hwcfg->devices[dev_handle].kernels[kern_handle].ddr_bank;
     //For execbo:
     dec_session->base.hw_session.kernel_info = &hwcfg->devices[dev_handle].kernels[kern_handle];
+
     dec_session->base.hw_session.dev_index = hal->dev_index;
 
     dec_session->decoder_plugin = &g_xma_singleton->decodercfg[dec_handle];

--- a/src/xma/src/xmaapi/xmaencoder.cpp
+++ b/src/xma/src/xmaapi/xmaencoder.cpp
@@ -194,13 +194,10 @@ xma_enc_session_create(XmaEncoderProperties *enc_props)
     XmaHwHAL *hal = (XmaHwHAL*)hwcfg->devices[dev_handle].handle;
 
     enc_session->base.hw_session.dev_handle = hal->dev_handle;
-    enc_session->base.hw_session.base_address =
-        hwcfg->devices[dev_handle].kernels[kern_handle].base_address;
-    enc_session->base.hw_session.ddr_bank =
-        hwcfg->devices[dev_handle].kernels[kern_handle].ddr_bank;
 
     //For execbo:
     enc_session->base.hw_session.kernel_info = &hwcfg->devices[dev_handle].kernels[kern_handle];
+
     enc_session->base.hw_session.dev_index = hal->dev_index;
 
     enc_session->encoder_plugin = &g_xma_singleton->encodercfg[enc_handle];

--- a/src/xma/src/xmaapi/xmafilter.cpp
+++ b/src/xma/src/xmaapi/xmafilter.cpp
@@ -154,13 +154,14 @@ xma_filter_session_create(XmaFilterProperties *filter_props)
     XmaHwCfg *hwcfg = &g_xma_singleton->hwcfg;
     XmaHwHAL *hal = (XmaHwHAL*)hwcfg->devices[dev_handle].handle;
     filter_session->base.hw_session.dev_handle = hal->dev_handle;
-    filter_session->base.hw_session.base_address =
-        hwcfg->devices[dev_handle].kernels[kern_handle].base_address;
-    filter_session->base.hw_session.ddr_bank =
-        hwcfg->devices[dev_handle].kernels[kern_handle].ddr_bank;
 
     //For execbo:
     filter_session->base.hw_session.kernel_info = &hwcfg->devices[dev_handle].kernels[kern_handle];
+    filter_session->base.hw_session.kernel_info->base_address =
+        hwcfg->devices[dev_handle].kernels[kern_handle].base_address;
+    filter_session->base.hw_session.kernel_info->ddr_bank =
+        hwcfg->devices[dev_handle].kernels[kern_handle].ddr_bank;
+
     filter_session->base.hw_session.dev_index = hal->dev_index;
 
     // Assume it is the first filter plugin for now

--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -309,7 +309,7 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
                     for (int i_execbo = 0; i_execbo < MAX_EXECBO_POOL_SIZE; i_execbo++) 
                     {
                         uint32_t  bo_handle;
-                        int       execBO_size = 1024;
+                        int       execBO_size = 4096;
                         uint32_t  execBO_flags = (1<<31);
                         char     *bo_data;
                         bo_handle = xclAllocBO(hal->dev_handle, 

--- a/src/xma/src/xmaapi/xmakernel.cpp
+++ b/src/xma/src/xmaapi/xmakernel.cpp
@@ -146,13 +146,10 @@ xma_kernel_session_create(XmaKernelProperties *props)
     XmaHwHAL *hal = (XmaHwHAL*)hwcfg->devices[dev_handle].handle;
 
     session->base.hw_session.dev_handle = hal->dev_handle;
-    session->base.hw_session.base_address =
-        hwcfg->devices[dev_handle].kernels[kern_handle].base_address;
-    session->base.hw_session.ddr_bank =
-        hwcfg->devices[dev_handle].kernels[kern_handle].ddr_bank;
 
     //For execbo:
     session->base.hw_session.kernel_info = &hwcfg->devices[dev_handle].kernels[kern_handle];
+
     session->base.hw_session.dev_index = hal->dev_index;
 
     session->kernel_plugin = &g_xma_singleton->kernelcfg[k_handle];

--- a/src/xma/src/xmaapi/xmares.cpp
+++ b/src/xma/src/xmaapi/xmares.cpp
@@ -1075,9 +1075,7 @@ kern_alloc_loop:
 
     if (kern_aquired) {
         session->kern_res = (XmaKernelRes)kern_props;
-        session->hw_session.context = (XmaHwContext*) calloc(1, sizeof(XmaHwContext));
-        session->hw_session.context->lock = xma_res_obtain_kernel_mutex(session);
-        session->hw_session.context->min_offset = 0xFFFFFFFF;
+        session->hw_session.kernel_info->lock = xma_res_obtain_kernel_mutex(session);
         return XMA_SUCCESS;
     }
 

--- a/src/xma/src/xmaapi/xmascaler.cpp
+++ b/src/xma/src/xmaapi/xmascaler.cpp
@@ -237,13 +237,10 @@ xma_scaler_session_create(XmaScalerProperties *sc_props)
     XmaHwCfg *hwcfg = &g_xma_singleton->hwcfg;
     XmaHwHAL *hal = (XmaHwHAL*)hwcfg->devices[dev_handle].handle;
     sc_session->base.hw_session.dev_handle = hal->dev_handle;
-    sc_session->base.hw_session.base_address =
-        hwcfg->devices[dev_handle].kernels[kern_handle].base_address;
-    sc_session->base.hw_session.ddr_bank =
-        hwcfg->devices[dev_handle].kernels[kern_handle].ddr_bank;
 
     //For execbo:
     sc_session->base.hw_session.kernel_info = &hwcfg->devices[dev_handle].kernels[kern_handle];
+
     sc_session->base.hw_session.dev_index = hal->dev_index;
 
     // Assume it is the first scaler plugin for now

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -32,7 +32,7 @@ xma_plg_buffer_alloc(XmaHwSession s_handle, size_t size)
 {
     XmaBufferHandle handle;
     xclDeviceHandle dev_handle = s_handle.dev_handle;
-    uint32_t ddr_bank = s_handle.ddr_bank;
+    uint32_t ddr_bank = s_handle.kernel_info->ddr_bank;
 
 #if 0
     printf("xma_plg_buffer_alloc dev_handle = %p\n", dev_handle);
@@ -137,19 +137,18 @@ xma_plg_register_prep_write(XmaHwSession  s_handle,
                        size_t        offset)
 {
     uint32_t *src_array = (uint32_t*)src;
-    size_t   cur_min = offset; 
     size_t   cur_max = offset + size; 
-    int32_t  entries = size / sizeof(uint32_t);
-    int32_t  start = offset / sizeof(uint32_t);
+    uint32_t  entries = size / sizeof(uint32_t);
+    uint32_t  start = offset / sizeof(uint32_t);
 
-    for (int32_t i = 0; i < entries; i++)
-        s_handle.context->reg_map[start + i] = src_array[i];
-
-    if (cur_max > s_handle.context->max_offset)
-        s_handle.context->max_offset = cur_max;
-
-    if (cur_min < s_handle.context->min_offset)
-        s_handle.context->min_offset = cur_min;
+    //Kernel regmap only upto 2048 in xmahw.h; execBO size is 4096 in xmahw_hal.cpp
+    if (cur_max >= 2048) {
+        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Max kernel regmap size is 2048\n");
+        return XMA_ERROR;
+    }
+    for (uint32_t i = 0, tmp_idx = start; i < entries; i++, tmp_idx++) {
+        s_handle.kernel_info->reg_map[tmp_idx] = src_array[i];
+    }
 
     return 0;
 }
@@ -157,19 +156,19 @@ xma_plg_register_prep_write(XmaHwSession  s_handle,
 void xma_plg_kernel_lock(XmaHwSession s_handle)
 {
     /* Only acquire the lock if we don't already own it */
-    if (s_handle.context->have_lock)
+    if (s_handle.kernel_info->have_lock)
         return;
 
-    xma_res_kernel_lock(s_handle.context->lock);
-    s_handle.context->have_lock = true;
+    xma_res_kernel_lock(s_handle.kernel_info->lock);
+    s_handle.kernel_info->have_lock = true;
 }
 
 void xma_plg_kernel_unlock(XmaHwSession s_handle)
 {
-    if (s_handle.context->have_lock)
+    if (s_handle.kernel_info->have_lock)
     {
-        xma_res_kernel_unlock(s_handle.context->lock);
-        s_handle.context->have_lock = false;
+        xma_res_kernel_unlock(s_handle.kernel_info->lock);
+        s_handle.kernel_info->have_lock = false;
     }
 }
 
@@ -222,8 +221,9 @@ int32_t xma_plg_execbo_avail_get(XmaHwSession s_handle)
 int32_t
 xma_plg_schedule_work_item(XmaHwSession s_handle)
 {
-    uint8_t *src = (uint8_t*)s_handle.context->reg_map;
-    size_t  size = s_handle.context->max_offset;
+    uint8_t *src = (uint8_t*)s_handle.kernel_info->reg_map;
+    //size_t  size = s_handle.kernel_info->max_offset;
+    size_t  size = 2048;//Max regmap in xmahw.h is 2048; execBO size is 4096
     int32_t bo_idx;
     int32_t rc = XMA_SUCCESS;
     
@@ -310,7 +310,7 @@ xma_plg_register_write(XmaHwSession  s_handle,
                        size_t        offset)
 {
     xclDeviceHandle dev_handle = s_handle.dev_handle;
-    uint64_t        dev_offset = s_handle.base_address;
+    uint64_t        dev_offset = s_handle.kernel_info->base_address;
     //printf("xma_plg_register_write dev_handle=%p,base_addr=0x%lx,src=%p,size=%lu,offset=0x%lx\n", dev_handle, dev_offset, src, size, offset);
     return xclWrite(dev_handle, XCL_ADDR_KERNEL_CTRL, dev_offset + offset,
                     src, size);
@@ -323,7 +323,7 @@ xma_plg_register_read(XmaHwSession  s_handle,
                       size_t        offset)
 {
     xclDeviceHandle dev_handle = s_handle.dev_handle;
-    uint64_t        dev_offset = s_handle.base_address;
+    uint64_t        dev_offset = s_handle.kernel_info->base_address;
 #if 0
     printf("xma_plg_register_read dev_handle=%p,dst=%p,size=%lu,offset=%lx\n",
             dev_handle, dst, size, offset);


### PR DESCRIPTION
Additional cleanup. Supporting regmap upto 2048 and execbo of 4096 size. Added regmap size check.
@maxzhen  Please do the needful