### PR TITLE
Fixed Regmap size. Max regmap check of 4032 Bytes.

### DIFF
--- a/src/xma/include/lib/xmahw_lib.h
+++ b/src/xma/include/lib/xmahw_lib.h
@@ -25,6 +25,9 @@
 #include "app/xmahw.h"
 
 #define MAX_EXECBO_POOL_SIZE      16
+#define MAX_EXECBO_BUFF_SIZE      4096// 4KB
+#define MAX_KERNEL_REGMAP_SIZE    4032//Some space used by ert pkt
+#define MAX_REGMAP_ENTRIES        1024//Int32 entries; So 4B x 1024 = 4K Bytes
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +56,7 @@ typedef struct XmaHwKernel
     uint32_t    kernel_execbo_handle[MAX_EXECBO_POOL_SIZE];
     char*       kernel_execbo_data[MAX_EXECBO_POOL_SIZE];//execBO size is 4096 in xmahw_hal.cpp
     bool        kernel_execbo_inuse[MAX_EXECBO_POOL_SIZE];
-    uint32_t    reg_map[2048];//Max regmap 2048; execBO size is 4096 in xmahw_hal.cpp
+    uint32_t    reg_map[MAX_REGMAP_ENTRIES];//4KB = 4B x 1024; Supported Max regmap of 4032 Bytes only in xmaplugin.cpp; execBO size is 4096 = 4KB in xmahw_hal.cpp
     pthread_mutex_t *lock;
     bool             have_lock;
     uint32_t    reserved[16];

--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -309,7 +309,7 @@ bool hal_configure(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg, bool hw_configured)
                     for (int i_execbo = 0; i_execbo < MAX_EXECBO_POOL_SIZE; i_execbo++) 
                     {
                         uint32_t  bo_handle;
-                        int       execBO_size = 4096;
+                        int       execBO_size = MAX_EXECBO_BUFF_SIZE;
                         uint32_t  execBO_flags = (1<<31);
                         char     *bo_data;
                         bo_handle = xclAllocBO(hal->dev_handle, 

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -143,9 +143,9 @@ xma_plg_register_prep_write(XmaHwSession  s_handle,
     uint32_t  entries = size / sizeof(uint32_t);
     uint32_t  start = offset / sizeof(uint32_t);
 
-    //Kernel regmap only upto 2048 in xmahw.h; execBO size is 4096 in xmahw_hal.cpp
-    if (cur_max >= 2048) {
-        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Max kernel regmap size is 2048\n");
+    //Kernel regmap 4KB in xmahw.h; execBO size is 4096 = 4KB in xmahw_hal.cpp; But ERT uses some space for ert pkt so allow max of 4032 Bytes for regmap
+    if (cur_max > MAX_KERNEL_REGMAP_SIZE) {
+        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Max kernel regmap size is 4032 Bytes\n");
         return XMA_ERROR;
     }
     for (uint32_t i = 0, tmp_idx = start; i < entries; i++, tmp_idx++) {
@@ -225,7 +225,7 @@ xma_plg_schedule_work_item(XmaHwSession s_handle)
 {
     uint8_t *src = (uint8_t*)s_handle.kernel_info->reg_map;
     //size_t  size = s_handle.kernel_info->max_offset;
-    size_t  size = 2048;//Max regmap in xmahw.h is 2048; execBO size is 4096
+    size_t  size = MAX_KERNEL_REGMAP_SIZE;//Max regmap in xmahw.h is 4KB; execBO size is 4096; Supported max regmap size is 4032 Bytes only
     int32_t bo_idx;
     int32_t rc = XMA_SUCCESS;
     


### PR DESCRIPTION
Fixed Regmap size. Max regmap check of 4032 Bytes.