### PR TITLE
Changing the software emulation model to only set debug parameters wh…

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -445,8 +445,8 @@ namespace xclcpuemhal2 {
     //  files.  Also, the GUI can overwrite this by setting an
     //  environment variable
     bool debuggable = false ;
-    if (getenv("SDA_SKIP_KERNEL_DEBUG") == NULL ||
-	strcmp("true", getenv("SDA_SKIP_KERNEL_DEBUG")) != 0) 
+    if (getenv("ENABLE_KERNEL_DEBUG") != NULL &&
+	strcmp("true", getenv("ENABLE_KERNEL_DEBUG")) == 0)
     {
       char* xclbininmemory = 
         reinterpret_cast<char*>(const_cast<xclBin*>(header)) ;


### PR DESCRIPTION
…en launching the process if the environment variable ENABLE_KERNEL_DEBUG is set, as opposed to not setting when SKIP_KERNEL_DEBUG was set