### PR TITLE
xclCopyBO() now leverages newly added CMD BO caching framework to improve M2M throughput.

### DIFF
--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef core_common_bo_cache_h_
+#define core_common_bo_cache_h_
+
+#include <stack>
+#include <utility>
+
+#include "xrt.h"
+#include "ert.h"
+
+namespace xrt_core {
+    typedef std::pair<const unsigned, struct ert_start_copybo_cmd * const> cmd_bo;
+    class bo_cache {
+        xclDeviceHandle device_handle;
+        unsigned cmd_bo_cache_max_size;
+        std::stack<cmd_bo> cmd_bo_cache;
+        std::mutex cmd_bo_cache_lock;
+
+    public:
+        bo_cache(xclDeviceHandle handle, unsigned max_size) : device_handle(handle),
+                                                              cmd_bo_cache_max_size(max_size) {}
+        ~bo_cache() {
+            std::lock_guard<std::mutex> lock(cmd_bo_cache_lock);
+            while (!cmd_bo_cache.empty()) {
+                cmd_bo bo = cmd_bo_cache.top();
+                destroy(bo);
+                cmd_bo_cache.pop();
+            }
+        }
+
+        cmd_bo alloc() {
+            {
+                std::lock_guard<std::mutex> lock(cmd_bo_cache_lock);
+                if (!cmd_bo_cache.empty()) {
+                    cmd_bo bo = cmd_bo_cache.top();
+                    cmd_bo_cache.pop();
+                    return bo;
+                }
+            }
+            unsigned execHandle = xclAllocBO(device_handle, sizeof(ert_start_copybo_cmd),
+                                             0, XCL_BO_FLAGS_EXECBUF);
+            struct ert_start_copybo_cmd *execData =
+                reinterpret_cast<struct ert_start_copybo_cmd *>(
+                    xclMapBO(device_handle, execHandle, true));
+            return std::make_pair(execHandle, execData);
+        }
+        void release(cmd_bo bo) {
+            {
+                std::lock_guard<std::mutex> lock(cmd_bo_cache_lock);
+                if (cmd_bo_cache.size() < cmd_bo_cache_max_size)
+                    cmd_bo_cache.push(bo);
+            }
+            destroy(bo);
+        }
+
+    private:
+        void destroy(cmd_bo bo) {
+            (void)munmap(bo.second, sizeof(ert_start_copybo_cmd));
+            xclFreeBO(device_handle, bo.first);
+        }
+    };
+}
+
+#endif

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -27,6 +27,11 @@
 #include <map>
 #include <vector>
 
+// Forward declaration
+namespace xrt_core {
+    class bo_cache;
+}
+
 namespace ZYNQ {
 
 // Forward declaration
@@ -81,6 +86,8 @@ public:
 
   int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size,
                 size_t offset);
+  int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                size_t dst_offset, size_t src_offset);
 
   int xclGetDeviceInfo2(xclDeviceInfo2 *info);
 
@@ -96,6 +103,7 @@ private:
   xclVerbosityLevel mVerbosity;
   int mKernelFD;
   std::map<uint64_t, uint32_t *> mKernelControl;
+  xrt_core::bo_cache *mCmdBOCache;
 };
 };
 

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -2,7 +2,7 @@
 #define _XOCL_GEM_SHIM_H_
 
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
 
  * Author(s): Umang Parekh
  *          : Sonal Santan
@@ -36,6 +36,11 @@
 #include <map>
 #include <cassert>
 #include <vector>
+
+// Forward declaration
+namespace xrt_core {
+    class bo_cache;
+}
 
 namespace xocl {
 
@@ -169,6 +174,7 @@ private:
     uint32_t mStallProfilingNumberSlots;
     uint32_t mStreamProfilingNumberSlots;
     std::string mDevUserName;
+    xrt_core::bo_cache *mCmdBOCache;
 
     bool zeroOutDDR();
     bool isXPR() const {

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -27,7 +27,6 @@
 
 #include "xbutil.h"
 #include "base.h"
-#include "ert.h"
 #include "core/pcie/linux/shim.h"
 #include "core/common/memalign.h"
 
@@ -1531,41 +1530,15 @@ static int m2mtest_bank(xclDeviceHandle handle, uuid_t uuid, int bank_a, int ban
         xclCloseContext(handle, uuid, -1);
         return -EINVAL;
     }
-#if 0
-    //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, sizeof (ert_start_copybo_cmd),
-        0, XCL_BO_FLAGS_EXECBUF);
-    struct ert_start_copybo_cmd *execData =
-        reinterpret_cast<struct ert_start_copybo_cmd *>(
-        xclMapBO(handle, execHandle, true));
-    ert_fill_copybo_cmd(execData, boSrc, boTgt, 0, 0, boSize);
 
-    xcldev::Timer timer;
-    if(xclExecBuf(handle, execHandle)) {
-        m2m_free_unmap_bo(handle, boSrc, boSrcPtr, boSize);
-        m2m_free_unmap_bo(handle, boTgt, boTgtPtr, boSize);
-        m2m_free_unmap_bo(handle, execHandle, execData, sizeof (ert_start_copybo_cmd));
-        xclCloseContext(handle, uuid, -1);
-        std::cout << "ERROR: Unable to issue xclExecBuf" << std::endl;
-        return -EINVAL;
-    }
-
-    while (execData->state < ERT_CMD_STATE_COMPLETED){
-        while (xclExecWait(handle, 1000) == 0) {
-            std::cout << "reentering wait...\n";
-        };
-    }
-    double timer_stop = timer.stop();
-#else
     xcldev::Timer timer;
     if ((ret = xclCopyBO(handle, boTgt, boSrc, boSize, 0, 0)))
         return ret;
     double timer_stop = timer.stop();
-#endif
+
     if(xclSyncBO(handle, boTgt, XCL_BO_SYNC_BO_FROM_DEVICE, boSize, 0)) {
         m2m_free_unmap_bo(handle, boSrc, boSrcPtr, boSize);
         m2m_free_unmap_bo(handle, boTgt, boTgtPtr, boSize);
-//        m2m_free_unmap_bo(handle, execHandle, execData, sizeof (ert_start_copybo_cmd));
         xclCloseContext(handle, uuid, -1);
         std::cout << "ERROR: Unable to sync target BO" << std::endl;
         return -EINVAL;
@@ -1576,7 +1549,6 @@ static int m2mtest_bank(xclDeviceHandle handle, uuid_t uuid, int bank_a, int ban
     // Clean up
     m2m_free_unmap_bo(handle, boSrc, boSrcPtr, boSize);
     m2m_free_unmap_bo(handle, boTgt, boTgtPtr, boSize);
-//    m2m_free_unmap_bo(handle, execHandle, execData, sizeof (ert_start_copybo_cmd));
 
     xclCloseContext(handle, uuid, -1);
 


### PR DESCRIPTION
Only tested on PCIe platform.