### PR TITLE
[edge] allow user map dma-buf

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -440,8 +440,14 @@ int ZYNQShim::xclLoadAxlf(const axlf *buffer)
 
 int ZYNQShim::xclExportBO(unsigned int boHandle)
 {
-  drm_prime_handle info = {boHandle, 0, -1};
+  drm_prime_handle info = {boHandle, DRM_RDWR, -1};
+  // Since Linux 4.6, drm_prime_handle_to_fd_ioctl respects O_RDWR.
   int result = ioctl(mKernelFD, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
+  if (result) {
+    std::cout << "WARNING: DRM prime handle to fd faied with DRM_RDWR. Try default flags." << std::endl;
+    info.flags = 0;
+    result = ioctl(mKernelFD, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
+  }
   if (mVerbosity == XCL_INFO) {
     mLogStream << "xclExportBO result = " << result << std::endl;
   }


### PR DESCRIPTION
Before below Linux patch. DRM prime_handle_to_fd() only allow (DRM|O)_CLOEXEC.
https://lists.freedesktop.org/archives/intel-gfx/2015-August/073593.html
The user space is not allow to mmap() a dma-buf that created by this API.

Try DRM_RDWR flags in DRM_IOCTL_PRIME_HANDLE_TO_FD, if it failed, fall back to default flags(0x00).