### PR TITLE
use dma_addr_t instead of uint64_t so its compatible with both 32bit and 64 bit system

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -44,7 +44,7 @@ void zocl_describe(const struct drm_zocl_bo *obj)
 }
 
 static inline void
-zocl_bo_describe(const struct drm_zocl_bo *bo, uint64_t *size, uint64_t *paddr)
+zocl_bo_describe(const struct drm_zocl_bo *bo, uint64_t *size, dma_addr_t *paddr)
 {
 	if (bo->flags & (ZOCL_BO_FLAGS_CMA | ZOCL_BO_FLAGS_USERPTR)) {
 		*size = bo->cma_base.base.size;

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -27,6 +27,12 @@
 #include <uapi/drm/drm_mode.h>
 #endif /* !__KERNEL__ */
 
+#if defined(CONFIG_ARM64)
+typedef uint64_t addr_t;
+#else
+typedef uint32_t addr_t;
+#endif
+
 //#define XCLBIN_DOWNLOAD
 
 enum {
@@ -102,7 +108,7 @@ struct drm_zocl_sync_bo {
 struct drm_zocl_info_bo {
 	uint32_t	handle;
 	uint64_t	size;
-	uint64_t	paddr;
+	addr_t	paddr;
 };
 
 /**

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -108,7 +108,7 @@ struct drm_zocl_sync_bo {
 struct drm_zocl_info_bo {
 	uint32_t	handle;
 	uint64_t	size;
-	addr_t	paddr;
+	addr_t		paddr;
 };
 
 /**


### PR DESCRIPTION
use dma_addr_t instead of uint64_t so its compatible with both 32bit and 64 bit system