### PR TITLE
Update package prerm/postinst scripts to improve handling of DKMS on Ubuntu/Debian

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -23,22 +23,8 @@
 # 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm is NOT run but
 #    and postinst of 2.2.0 is run. The postinst is invoked with "2" argument.
 
-
-# This snippet here to clean any previous XRT DKMS. This is always true for
-# RHEL/CentOS.
-
-if [ -n "`dkms status -m xrt`" ]; then
-    echo "Unloading old XRT Linux kernel modules"
-    modprobe -r xocl
-    modprobe -r xclmgmt
-
-    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
-    for OLD in $XRT_VERSION_STRING_OLD; do
-	echo "Unregistering old XRT Linux kernel module sources $OLD from dkms"
-	dkms remove -m xrt -v $OLD --all
-	break
-    done
-
+rmmodules()
+{
     find /lib/modules -type f -name xocl.ko -delete
     find /lib/modules -type f -name xclmgmt.ko -delete
     find /lib/modules -type f -name xocl.ko.kz -delete
@@ -46,6 +32,31 @@ if [ -n "`dkms status -m xrt`" ]; then
     find /lib/modules -type f -name xocl.ko.xz -delete
     find /lib/modules -type f -name xclmgmt.ko.xz -delete
     depmod -A
+}
+
+lsb_release -si | grep -Eq "^Ubuntu|^Debian"
+
+if [ $? -eq 0 ] && [ "$1" = "configure" ]; then
+    # The older modules should already have been unregistered from dkms
+    # by the prerm
+    echo "Unloading old XRT Linux kernel modules on Ubuntu/Debian"
+    rmmod xocl
+    rmmod xclmgmt
+    rmmodules
+elif [ -n "`dkms status -m xrt`" ]; then
+    # This snippet here to clean any previous XRT DKMS. This is always true for
+    # RHEL/CentOS.
+    echo "Unloading old XRT Linux kernel modules on RHEL/CentOS"
+    rmmod xocl
+    rmmod xclmgmt
+
+    XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
+    for OLD in $XRT_VERSION_STRING_OLD; do
+	echo "Unregistering old XRT Linux kernel module sources $OLD from dkms"
+	dkms remove -m xrt -v $OLD --all
+	break
+    done
+    rmmodules
 else
     echo "No previous XRT Linux kernel modules found"
 fi

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -29,7 +29,7 @@ if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
 	exit 0
 fi
 
-lsb_release -si | grep -Eq "^Ubuntu|Debian"
+lsb_release -si | grep -Eq "^Ubuntu|^Debian"
 if [ $? -eq 0 ] && [ "$1" = "upgrade" ]; then
     echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms on Ubuntu/Debian"
     dkms remove -m xrt -v @XRT_VERSION_STRING@ --all

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -29,13 +29,21 @@ if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
 	exit 0
 fi
 
+lsb_release -si | grep -Eq "^Ubuntu|Debian"
+if [ $? -eq 0 ] && [ "$1" = "upgrade" ]; then
+    echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms on Ubuntu/Debian"
+    dkms remove -m xrt -v @XRT_VERSION_STRING@ --all
+    echo "Cleanup is skipped for package upgrade/downgrade/re-install"
+    exit 0
+fi
+
 # If we are here then
 # a. either the user is trying to remove xrt package on Ubuntu or RHEL/CentOS
 # b. or we are executing install (ubgrade), re-install or downgrade on Ubuntu
 
 echo "Unloading old XRT Linux kernel modules"
-modprobe -r xocl
-modprobe -r xclmgmt
+rmmod xocl
+rmmod xclmgmt
 
 echo "Unregistering XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
 dkms remove -m xrt -v @XRT_VERSION_STRING@ --all


### PR DESCRIPTION
This resolves issues when during upgrade/reinstall DKMS will get confused about previous version of package and we would end up with older version of drivers with userspace from new version of XRT.