### PR TITLE
Update package prerm/postinst scripts to improve handling of DKMS on Ubuntu/Debian

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -23,6 +23,17 @@
 # 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm is NOT run but
 #    and postinst of 2.2.0 is run. The postinst is invoked with "2" argument.
 
+rmmodules()
+{
+    find /lib/modules -type f -name xocl.ko -delete
+    find /lib/modules -type f -name xclmgmt.ko -delete
+    find /lib/modules -type f -name xocl.ko.kz -delete
+    find /lib/modules -type f -name xclmgmt.ko.kz -delete
+    find /lib/modules -type f -name xocl.ko.xz -delete
+    find /lib/modules -type f -name xclmgmt.ko.xz -delete
+    depmod -A
+}
+
 installdir=/opt/xilinx/xrt
 systemddir=/etc/systemd/system
 
@@ -39,13 +50,21 @@ if [ "$msd_active" = "active" ]; then
 fi
 
 
-# This snippet here to clean any previous XRT DKMS. This is always true for
-# RHEL/CentOS.
+lsb_release -si | grep -Eq "^Ubuntu|^Debian"
 
-if [ -n "`dkms status -m xrt`" ]; then
+if [ $? -eq 0 ] && [ "$1" = "configure" ]; then
+    # The older modules should already have been unregistered from dkms
+    # by the prerm
+    echo "Unloading old XRT Linux kernel modules on Ubuntu/Debian"
+    rmmod xocl
+    rmmod xclmgmt
+    rmmodules
+elif [ -n "`dkms status -m xrt`" ]; then
+    # This snippet here to clean any previous XRT DKMS. This is always true for
+    # RHEL/CentOS.
     echo "Unloading old XRT Linux kernel modules"
-    modprobe -r xocl
-    modprobe -r xclmgmt
+    rmmod xocl
+    rmmod xclmgmt
 
     XRT_VERSION_STRING_OLD=`dkms status -m xrt | awk -F, '{print $2}'`
     for OLD in $XRT_VERSION_STRING_OLD; do
@@ -54,13 +73,7 @@ if [ -n "`dkms status -m xrt`" ]; then
 	break
     done
 
-    find /lib/modules -type f -name xocl.ko -delete
-    find /lib/modules -type f -name xclmgmt.ko -delete
-    find /lib/modules -type f -name xocl.ko.kz -delete
-    find /lib/modules -type f -name xclmgmt.ko.kz -delete
-    find /lib/modules -type f -name xocl.ko.xz -delete
-    find /lib/modules -type f -name xclmgmt.ko.xz -delete
-    depmod -A
+    rmmodules
 else
     echo "No previous XRT Linux kernel modules found"
 fi

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -62,7 +62,7 @@ if [ $? -eq 0 ] && [ "$1" = "configure" ]; then
 elif [ -n "`dkms status -m xrt`" ]; then
     # This snippet here to clean any previous XRT DKMS. This is always true for
     # RHEL/CentOS.
-    echo "Unloading old XRT Linux kernel modules"
+    echo "Unloading old XRT Linux kernel modules on RHEL/CentOS"
     rmmod xocl
     rmmod xclmgmt
 

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -33,8 +33,10 @@ if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
     exit 0
 fi
 
-lsb_release -si | grep -Eq "^Ubuntu"
+lsb_release -si | grep -Eq "^Ubuntu|^Debian"
 if [ $? -eq 0 ] && [ "$1" = "upgrade" ]; then
+    echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms on Ubuntu/Debian"
+    dkms remove -m xrt -v @XRT_VERSION_STRING@ --all
     echo "Cleanup is skipped for package upgrade/downgrade/re-install"
     exit 0
 fi
@@ -55,8 +57,8 @@ systemctl daemon-reload
 /opt/xilinx/xrt/bin/xbmgmt config --purge 2>&1 > /dev/null
 
 echo "Unloading old XRT Linux kernel modules"
-modprobe -r xocl
-modprobe -r xclmgmt
+rmmod xocl
+rmmod xclmgmt
 
 echo "Unregistering XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
 dkms remove -m xrt -v @XRT_VERSION_STRING@ --all

--- a/src/CMake/config/prerm.in
+++ b/src/CMake/config/prerm.in
@@ -29,7 +29,7 @@
 
 lsb_release -si | grep -Eq "^RedHat|^CentOS"
 if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
-    echo "Cleanup is skipped for package upgrade/downgrade/re-install"
+    echo "Cleanup is skipped for package upgrade/downgrade/re-install on RHEL/CentOS"
     exit 0
 fi
 
@@ -37,7 +37,7 @@ lsb_release -si | grep -Eq "^Ubuntu|^Debian"
 if [ $? -eq 0 ] && [ "$1" = "upgrade" ]; then
     echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms on Ubuntu/Debian"
     dkms remove -m xrt -v @XRT_VERSION_STRING@ --all
-    echo "Cleanup is skipped for package upgrade/downgrade/re-install"
+    echo "Cleanup is skipped for package upgrade/downgrade/re-install on Ubuntu/Debian"
     exit 0
 fi
 


### PR DESCRIPTION
1. Use rmmod instead of modprobe -r since the latter does not work after DKMS has already cleaned up the .ko binaries while the modules are still loaded in memory.
2. Unregister driver sources from DKMS in prerm for Ubuntu before package manger removes the sources all together. Otherwise dkms keeps expecting a dkms.conf file at its previously configured location, but the file including sources have been removed by package manager. This is seen in upgrade/downgrade/re-install step.  