### PR TITLE
 xclRegRead and xclRegWrite support 

### DIFF
--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -1033,7 +1033,29 @@ XCL_DRIVER_DLLESPEC int xclPollCompletion(xclDeviceHandle handle, int min_compl,
 
 XCL_DRIVER_DLLESPEC const struct axlf_section_header* wrap_get_axlf_section(const struct axlf* top, enum axlf_section_kind kind);
 
-/* XRT Stream Queue APIs */
+/**
+ * xclRegRead() - Read register in register space of a CU
+ *
+ * @handle:        Device handle
+ * @cu_index:      CU index
+ * @offset:        Offset in the register space
+ * @datap:         Pointer to where result will be saved
+ * Return:         0 or appropriate error number
+ *
+ */
+XCL_DRIVER_DLLESPEC int xclRegRead(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset, uint32_t *datap);
+
+/**
+ * xclRegWRite() - Write to register in register space of a CU
+ *
+ * @handle:        Device handle
+ * @cu_index:      CU index
+ * @offset:        Offset in the register space
+ * @datap:         Data to be written
+ * Return:         0 or appropriate error number
+ *
+ */
+XCL_DRIVER_DLLESPEC int xclRegWrite(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset, uint32_t data);
 
 /**
  * DOC: Performance Monitoring Operations

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -92,79 +92,127 @@ static int xocl_release(struct inode *inode, struct file *filp)
 	return ret;
 }
 
-static int xocl_mmap(struct file *filp, struct vm_area_struct *vma)
+static int xocl_bo_mmap(struct file *filp, struct vm_area_struct *vma)
 {
 	int ret;
-	struct drm_file *priv = filp->private_data;
-	struct drm_device *dev = priv->minor->dev;
+	struct drm_xocl_bo *xobj;
 	struct mm_struct *mm = current->mm;
-	struct xocl_drm *drm_p = dev->dev_private;
-	xdev_handle_t xdev = drm_p->xdev;
+
+	DRM_ENTER("BO map pgoff 0x%lx, size 0x%lx",
+		vma->vm_pgoff, vma->vm_end - vma->vm_start);
+
+	ret = drm_gem_mmap(filp, vma);
+	if (ret)
+		return ret;
+
+	xobj = to_xocl_bo(vma->vm_private_data);
+
+	if (!xobj->pages) {
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
+		return -EINVAL;
+	}
+	/* Clear VM_PFNMAP flag set by drm_gem_mmap()
+	 * we have "struct page" for all backing pages for bo
+	 */
+	vma->vm_flags &= ~VM_PFNMAP;
+	/* Clear VM_IO flag set by drm_gem_mmap()
+	 * it prevents gdb from accessing mapped buffers
+	 */
+	vma->vm_flags &= ~VM_IO;
+	vma->vm_flags |= VM_MIXEDMAP;
+	vma->vm_flags |= mm->def_flags;
+	vma->vm_pgoff = 0;
+
+	/* Override pgprot_writecombine() mapping setup by
+	 * drm_gem_mmap()
+	 * which results in very poor read performance
+	 */
+	if (vma->vm_flags & (VM_READ | VM_MAYREAD))
+		vma->vm_page_prot = vm_get_page_prot(vma->vm_flags);
+	else
+		vma->vm_page_prot = pgprot_writecombine(
+			vm_get_page_prot(vma->vm_flags));
+	return ret;
+}
+
+static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	int ret;
 	unsigned long vsize;
 	phys_addr_t res_start;
-	struct drm_xocl_bo *xobj;
-
-	DRM_ENTER("vm pgoff %lx", vma->vm_pgoff);
 
 	/*
-	 * If the page offset is > than 4G, then let GEM handle that and do what
-	 * it thinks is best,we will only handle page offsets less than 4G.
+	 * HACK -- We assume filp->private_data is pointing to
+	 * drm_file data structure.
 	 */
-	if (likely(vma->vm_pgoff >= XOCL_FILE_PAGE_OFFSET)) {
+	struct drm_file *priv = filp->private_data;
+	struct xocl_drm *drm_p = priv->minor->dev->dev_private;
+	xdev_handle_t xdev = drm_p->xdev;
 
-		ret = drm_gem_mmap(filp, vma);
-		if (ret)
-			return ret;
-
-		xobj = to_xocl_bo(vma->vm_private_data);
-
-		if (!xobj->pages) {
-			XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
-			return -EINVAL;
-		}
-		/* Clear VM_PFNMAP flag set by drm_gem_mmap()
-		 * we have "struct page" for all backing pages for bo
-		 */
-		vma->vm_flags &= ~VM_PFNMAP;
-		/* Clear VM_IO flag set by drm_gem_mmap()
-		 * it prevents gdb from accessing mapped buffers
-		 */
-		vma->vm_flags &= ~VM_IO;
-		vma->vm_flags |= VM_MIXEDMAP;
-		vma->vm_flags |= mm->def_flags;
-		vma->vm_pgoff = 0;
-
-		/* Override pgprot_writecombine() mapping setup by
-		 * drm_gem_mmap()
-		 * which results in very poor read performance
-		 */
-		if (vma->vm_flags & (VM_READ | VM_MAYREAD))
-			vma->vm_page_prot = vm_get_page_prot(vma->vm_flags);
-		else
-			vma->vm_page_prot = pgprot_writecombine(
-				vm_get_page_prot(vma->vm_flags));
-		return ret;
+	if (vma->vm_pgoff > MAX_CUS) {
+		userpf_err(xdev, "invalid native mmap offset: 0x%lx",
+			vma->vm_pgoff);
+		return -EINVAL;
 	}
 
-	if (vma->vm_pgoff != 0)
-		return -EINVAL;
-
 	vsize = vma->vm_end - vma->vm_start;
-	if (vsize > XDEV(xdev)->bar_size)
-		return -EINVAL;
+	res_start = pci_resource_start(XDEV(xdev)->pdev, XDEV(xdev)->bar_idx);
 
-	DRM_DBG("MAP size %ld", vsize);
+	if (vma->vm_pgoff == 0) {
+		if (vsize > XDEV(xdev)->bar_size) {
+			userpf_err(xdev,
+				"bad size (0x%lx) for native BAR mmap", vsize);
+			return -EINVAL;
+		}
+	} else {
+		int ret;
+		u32 cu_addr;
+		u32 cu_idx = vma->vm_pgoff - 1;
+
+		if (vsize > 64 * 1024) {
+			userpf_err(xdev,
+				"bad size (0x%lx) for native CU mmap", vsize);
+			return -EINVAL;
+		}
+		ret = xocl_exec_cu_map_addr(xdev, cu_idx, priv, &cu_addr);
+		if (ret != 0)
+			return ret;
+		res_start += cu_addr;
+	}
+
 	vma->vm_page_prot = pgprot_noncached(vma->vm_page_prot);
 	vma->vm_flags |= VM_IO;
 	vma->vm_flags |= VM_RESERVED;
 
-	res_start = pci_resource_start(XDEV(xdev)->pdev, XDEV(xdev)->bar_idx);
 	ret = io_remap_pfn_range(vma, vma->vm_start,
 				 res_start >> PAGE_SHIFT,
 				 vsize, vma->vm_page_prot);
-	userpf_info(xdev, "io_remap_pfn_range ret code: %d", ret);
+	if (ret != 0) {
+		userpf_err(xdev, "io_remap_pfn_range failed: %d", ret);
+		return ret;
+	}
 
+	userpf_info(xdev, "successful native mmap @0x%lx with size 0x%lx",
+		vma->vm_pgoff >> PAGE_SHIFT, vsize);
 	return ret;
+}
+
+static int xocl_mmap(struct file *filp, struct vm_area_struct *vma)
+{
+	/*
+	 * If the offset is > than 4G, then let GEM handle that and do what
+	 * it thinks is best, we will only handle offsets less than 4G.
+	 */
+	if (likely(vma->vm_pgoff >= XOCL_FILE_PAGE_OFFSET))
+		return xocl_bo_mmap(filp, vma);
+
+	/*
+	 * Native BAR or CU mmap handling.
+	 * When pgoff is 0, we perform mmap of the PCIE BAR.
+	 * When pgoff is non-zero, we treat it as CU index + 1 and perform
+	 * mmap of that particular CU register space.
+	 */
+	return xocl_native_mmap(filp, vma);
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -503,6 +503,8 @@ struct xocl_mb_scheduler_funcs {
 	int (*stop)(struct platform_device *pdev);
 	int (*reset)(struct platform_device *pdev);
 	int (*reconfig)(struct platform_device *pdev);
+	int (*cu_map_addr)(struct platform_device *pdev, u32 cu_index,
+		void *drm_filp, u32 *addrp);
 };
 #define	MB_SCHEDULER_DEV(xdev)	\
 	SUBDEV(xdev, XOCL_SUBDEV_MB_SCHEDULER).pldev
@@ -538,6 +540,11 @@ struct xocl_mb_scheduler_funcs {
 #define	xocl_exec_reconfig(xdev)		\
 	(SCHE_CB(xdev, reconfig) ?				\
 	 MB_SCHEDULER_OPS(xdev)->reconfig(MB_SCHEDULER_DEV(xdev)) : \
+	-ENODEV)
+#define	xocl_exec_cu_map_addr(xdev, cu, filep, addrp)		\
+	(SCHE_CB(xdev, cu_map_addr) ?				\
+	MB_SCHEDULER_OPS(xdev)->cu_map_addr(			\
+	MB_SCHEDULER_DEV(xdev), cu, filep, addrp) :		\
 	-ENODEV)
 
 #define XOCL_MEM_TOPOLOGY(xdev)						\


### PR DESCRIPTION
This PR introduces two new XRT APIs for accessing register space of a specific CU. Before access, application should first exclusively reserve the target CU.