### PR TITLE
Add support for caching CMD BO objects used in xclCopyBO() for both P…

### DIFF
--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef core_common_bo_cache_h_
+#define core_common_bo_cache_h_
+
+#include <vector>
+#include <utility>
+
+#include "xrt.h"
+#include "ert.h"
+
+namespace xrt_core {
+    // Create a cache of CMD BO objects -- for now only used for M2M -- to reduce
+    // the overhead of BO life cycle management.
+    class bo_cache {
+        // Helper typedef for std::pair. Note the elements are const so that the
+        // pair is immutable. The clients should not change the contents of cmd_bo.
+        typedef std::pair<const unsigned int, void *const> cmd_bo;
+
+        static const size_t mBOSize = 4096;
+        xclDeviceHandle mDevice;
+        // Maximum number of BOs that can be cached in the pool
+        const unsigned int mCacheMaxSize;
+        std::vector<cmd_bo> mCmdBOCache;
+        std::mutex mCacheMutex;
+
+    public:
+        bo_cache(xclDeviceHandle handle, unsigned max_size) : mDevice(handle),
+                                                              mCacheMaxSize(max_size) {}
+        ~bo_cache() {
+            std::lock_guard<std::mutex> lock(mCacheMutex);
+            for (cmd_bo bo : mCmdBOCache)
+                destroy(bo);
+        }
+        template<typename T> std::pair<unsigned int, T *const> alloc() {
+            cmd_bo bo = allocImpl();
+            return std::make_pair(bo.first, static_cast<T *>(bo.second));
+        }
+        template<typename T> void release(std::pair<unsigned int, T *const> bo) {
+            releaseImpl(std::make_pair(bo.first, static_cast<void *>(bo.second)));
+        }
+    private:
+        cmd_bo allocImpl() {
+            if (mCacheMaxSize) {
+                // If caching is enabled first look up in the BO cache
+                std::lock_guard<std::mutex> lock(mCacheMutex);
+                if (!mCmdBOCache.empty()) {
+                    cmd_bo bo = mCmdBOCache.back();
+                    mCmdBOCache.pop_back();
+                    return bo;
+                }
+            }
+
+            unsigned execHandle = xclAllocBO(mDevice, mBOSize,
+                                             0, XCL_BO_FLAGS_EXECBUF);
+            return std::make_pair(execHandle, xclMapBO(mDevice, execHandle, true));
+        }
+        void releaseImpl(cmd_bo bo) {
+            if (mCacheMaxSize) {
+                // If caching is enabled send this back to the BO cache if the cache is not
+                // fully populated
+                std::lock_guard<std::mutex> lock(mCacheMutex);
+                if (mCmdBOCache.size() < mCacheMaxSize) {
+                    mCmdBOCache.push_back(bo);
+                    return;
+                }
+            }
+            destroy(bo);
+        }
+
+    private:
+        void destroy(cmd_bo bo) {
+            (void)munmap(bo.second, mBOSize);
+            xclFreeBO(mDevice, bo.first);
+        }
+    };
+}
+
+#endif

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -303,6 +303,16 @@ get_feature_toggle(const std::string& feature)
   return detail::get_bool_value(feature.c_str(),false);
 }
 
+/**
+ * Set CMD BO cache size. CUrrently it is only used in xclCopyBO()
+ */
+inline unsigned int
+get_cmdbo_cache()
+{
+  static unsigned int value = detail::get_uint_value("Runtime.cmdbo_cache",0x4);
+  return value;
+}
+
 inline std::string
 get_hw_em_driver()
 {

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -391,8 +391,7 @@ int ZYNQShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
                         src_offset, dst_offset, size);
 
     int ret = xclExecBuf(bo.first);
-    if (ret == 0)
-        while (xclExecWait(1000) == 0);   if (ret) {
+    if (ret) {
         mCmdBOCache->release(bo);
         return ret;
     }

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -386,7 +386,7 @@ int ZYNQShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
 {
   int ret = -EOPNOTSUPP;
 #ifdef __aarch64__
-    std::pair<unsigned int, ert_start_copybo_cmd *const> bo = mCmdBOCache->alloc<ert_start_copybo_cmd>();
+    std::pair<const unsigned int, ert_start_copybo_cmd *const> bo = mCmdBOCache->alloc<ert_start_copybo_cmd>();
     ert_fill_copybo_cmd(bo.second, src_boHandle, dst_boHandle,
                         src_offset, dst_offset, size);
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2019 Xilinx, Inc
  * Author(s): Hem C. Neema
  *          : Min Ma
- * ZNYQ HAL Driver layered on top of ZYNQ kernel driver
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -35,7 +35,8 @@
 #include "core/common/message.h"
 #include "core/common/scheduler.h"
 #include "core/common/xclbin_parser.h"
-//#include "xclbin.h"
+#include "core/common/bo_cache.h"
+#include "core/common/config_reader.h"
 #include <assert.h>
 
 #define GB(x)   ((size_t) (x) << 30)
@@ -117,12 +118,14 @@ ZYNQShim::ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel ve
     mLogStream << "FUNCTION, THREAD ID, ARG..." << std::endl;
     mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
   }
+  mCmdBOCache = new xrt_core::bo_cache(this, xrt_core::config::get_cmdbo_cache());
 }
 
 #ifndef __HWEM__
 ZYNQShim::~ZYNQShim()
 {
-  if (profiling != nullptr) delete profiling;
+  delete mCmdBOCache;
+  delete profiling;
   //TODO
   if (mKernelFD > 0) {
     close(mKernelFD);
@@ -378,6 +381,38 @@ int ZYNQShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t si
   return ioctl(mKernelFD, DRM_IOCTL_ZOCL_SYNC_BO, &syncInfo);
 }
 
+int ZYNQShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                        size_t dst_offset, size_t src_offset)
+{
+  int ret = -EOPNOTSUPP;
+#ifdef __aarch64__
+    std::pair<unsigned int, ert_start_copybo_cmd *const> bo = mCmdBOCache->alloc<ert_start_copybo_cmd>();
+    ert_fill_copybo_cmd(bo.second, src_boHandle, dst_boHandle,
+                        src_offset, dst_offset, size);
+
+    int ret = xclExecBuf(bo.first);
+    if (ret == 0)
+        while (xclExecWait(1000) == 0);   if (ret) {
+        mCmdBOCache->release(bo);
+        return ret;
+    }
+
+    do {
+        ret = xclExecWait(1000);
+        if (ret == -1)
+            break;
+    }
+    while (bo.second->state < ERT_CMD_STATE_COMPLETED);
+
+    ret = (ret == -1) ? -errno : 0;
+    if (!ret && (bo.second->state != ERT_CMD_STATE_COMPLETED))
+        ret = -EINVAL;
+    mCmdBOCache->release<ert_start_copybo_cmd>(bo);
+#endif
+  return ret;
+}
+
+
 #ifndef __HWEM__
 int ZYNQShim::xclLoadXclBin(const xclBin *buffer)
 {
@@ -530,14 +565,14 @@ uint ZYNQShim::xclGetNumLiveProcesses()
 int ZYNQShim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)
 {
   // Until we have a programmatic way to determine what this directory
-  //  is on Zynq platforms, this is hard-coded so we can test out 
+  //  is on Zynq platforms, this is hard-coded so we can test out
   //  debug and profile features.
   std::string path = "/sys/devices/platform/amba/amba:zyxclmm_drm/";
   path += entry ;
 
   if (path.length() >= size) return -1 ;
 
-  // Since path.length() < size, we are sure to copy over the null 
+  // Since path.length() < size, we are sure to copy over the null
   //  terminating byte.
   strncpy(sysfsPath, path.c_str(), size) ;
   return 0 ;
@@ -586,7 +621,7 @@ int ZYNQShim::xclSKReport(uint32_t cu_idx, xrt_scu_state state)
   }
 
   scmd.cu_idx = cu_idx;
-  
+
   ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_SK_REPORT, &scmd);
 
   return ret;
@@ -835,7 +870,7 @@ uint xclGetNumLiveProcesses(xclDeviceHandle handle)
   return drv->xclGetNumLiveProcesses();
 }
 
-int xclGetSysfsPath(xclDeviceHandle handle, const char* subdev, 
+int xclGetSysfsPath(xclDeviceHandle handle, const char* subdev,
 		    const char* entry, char* sysfsPath, size_t size)
 {
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -27,6 +27,11 @@
 #include <map>
 #include <vector>
 
+// Forward declaration
+namespace xrt_core {
+    class bo_cache;
+}
+
 namespace ZYNQ {
 
 // Forward declaration
@@ -81,6 +86,8 @@ public:
 
   int xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size,
                 size_t offset);
+  int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                size_t dst_offset, size_t src_offset);
 
   int xclGetDeviceInfo2(xclDeviceInfo2 *info);
 
@@ -96,6 +103,7 @@ private:
   xclVerbosityLevel mVerbosity;
   int mKernelFD;
   std::map<uint64_t, uint32_t *> mKernelControl;
+  xrt_core::bo_cache *mCmdBOCache;
 };
 };
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -440,7 +440,6 @@ int shim::xclCopyBO(unsigned int dst_boHandle,
                         src_offset, dst_offset, size);
 
     int ret = xclExecBuf(bo.first);
-
     if (ret) {
         mCmdBOCache->release(bo);
         return ret;

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1,9 +1,10 @@
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
  * Author(s): Umang Parekh
  *          : Sonal Santan
  *          : Ryan Radjabi
- * PCIe HAL Driver layered on top of XOCL GEM kernel driver
+ *
+ * XRT PCIe library layered on top of xocl kernel driver
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,6 +22,8 @@
 #include "scan.h"
 #include "core/common/message.h"
 #include "core/common/scheduler.h"
+#include "core/common/bo_cache.h"
+#include "core/common/config_reader.h"
 #include "xclbin.h"
 #include "ert.h"
 
@@ -113,7 +116,8 @@ shim::shim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity)
     mMemoryProfilingNumberSlots(0),
     mAccelProfilingNumberSlots(0),
     mStallProfilingNumberSlots(0),
-    mStreamProfilingNumberSlots(0)
+    mStreamProfilingNumberSlots(0),
+    mCmdBOCache(nullptr)
 {
     init(index, logfileName, verbosity);
 }
@@ -144,12 +148,12 @@ int shim::dev_init()
 
     // We're good now.
     mDev = dev;
+    (void) xclGetDeviceInfo2(&mDeviceInfo);
+    mCmdBOCache = new xrt_core::bo_cache(this, xrt_core::config::get_cmdbo_cache());
 
     mStreamHandle = mDev->devfs_open("dma.qdma", O_RDWR | O_SYNC);
     if (mStreamHandle == -1)
 	    return -errno;
-
-    (void) xclGetDeviceInfo2(&mDeviceInfo);
 
     memset(&mAioContext, 0, sizeof(mAioContext));
     mAioEnabled = (io_setup(SHIM_QDMA_AIO_EVT_MAX, &mAioContext) == 0);
@@ -168,6 +172,9 @@ void shim::dev_fini()
         io_destroy(mAioContext);
             mAioEnabled = false;
     }
+
+    delete mCmdBOCache;
+    mCmdBOCache = nullptr;
 }
 
 /*
@@ -422,29 +429,34 @@ int shim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, 
 }
 
 /*
- * xclCopyBO() - TO BE REMOVED
+ * xclCopyBO()
  */
 int shim::xclCopyBO(unsigned int dst_boHandle,
     unsigned int src_boHandle, size_t size, size_t dst_offset,
     size_t src_offset)
 {
-    int ret;
-    unsigned execHandle = xclAllocBO(sizeof (ert_start_copybo_cmd),
-        0, XCL_BO_FLAGS_EXECBUF);
-    struct ert_start_copybo_cmd *execData =
-        reinterpret_cast<struct ert_start_copybo_cmd *>(
-        xclMapBO(execHandle, true));
+    std::pair<unsigned int, ert_start_copybo_cmd *const> bo = mCmdBOCache->alloc<ert_start_copybo_cmd>();
+    ert_fill_copybo_cmd(bo.second, src_boHandle, dst_boHandle,
+                        src_offset, dst_offset, size);
 
-    ert_fill_copybo_cmd(execData, src_boHandle, dst_boHandle,
-        src_offset, dst_offset, size);
+    int ret = xclExecBuf(bo.first);
 
-    ret = xclExecBuf(execHandle);
-    if (ret == 0)
-        while (xclExecWait(1000) == 0);
+    if (ret) {
+        mCmdBOCache->release(bo);
+        return ret;
+    }
 
-    (void) munmap(execData, sizeof (ert_start_copybo_cmd));
-    xclFreeBO(execHandle);
+    do {
+        ret = xclExecWait(1000);
+        if (ret == -1)
+            break;
+    }
+    while (bo.second->state < ERT_CMD_STATE_COMPLETED);
 
+    ret = (ret == -1) ? -errno : 0;
+    if (!ret && (bo.second->state != ERT_CMD_STATE_COMPLETED))
+        ret = -EINVAL;
+    mCmdBOCache->release<ert_start_copybo_cmd>(bo);
     return ret;
 }
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -435,7 +435,7 @@ int shim::xclCopyBO(unsigned int dst_boHandle,
     unsigned int src_boHandle, size_t size, size_t dst_offset,
     size_t src_offset)
 {
-    std::pair<unsigned int, ert_start_copybo_cmd *const> bo = mCmdBOCache->alloc<ert_start_copybo_cmd>();
+    std::pair<const unsigned int, ert_start_copybo_cmd *const> bo = mCmdBOCache->alloc<ert_start_copybo_cmd>();
     ert_fill_copybo_cmd(bo.second, src_boHandle, dst_boHandle,
                         src_offset, dst_offset, size);
 

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -2,12 +2,13 @@
 #define _XOCL_GEM_SHIM_H_
 
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
 
  * Author(s): Umang Parekh
  *          : Sonal Santan
  *          : Ryan Radjabi
- * XOCL GEM HAL Driver layered on top of XOCL kernel driver
+ *
+ * XRT PCIe library layered on top of xocl kernel driver
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,6 +37,11 @@
 #include <map>
 #include <cassert>
 #include <vector>
+
+// Forward declaration
+namespace xrt_core {
+    class bo_cache;
+}
 
 namespace xocl {
 
@@ -169,6 +175,7 @@ private:
     uint32_t mStallProfilingNumberSlots;
     uint32_t mStreamProfilingNumberSlots;
     std::string mDevUserName;
+    xrt_core::bo_cache *mCmdBOCache;
 
     bool zeroOutDDR();
     bool isXPR() const {


### PR DESCRIPTION
…CIe and edge platforms.

Update xbutil to use xclCopyBO() for M2M test. The size of the cache is determined by Runtime.cmdbo_cache
key in ert.ini and defaults to 4.

xclCopyBO() with BO Cache improves the throughput by hiding the CMD BO management
overhead. See the xbutil m2mtest metrics below for 256 KB buffers:
After change
------------
dx4300:~/git/XRT/build>/home/sonals/git/XRT/build/Release/opt/xilinx/xrt/bin/xbutil m2mtest
INFO: Found total 1 card(s), 1 are usable
bank0 -> bank1 M2M bandwidth: 833.333 MB/s
bank0 -> bank2 M2M bandwidth: 3086.42 MB/s
bank0 -> bank3 M2M bandwidth: 3623.19 MB/s
bank1 -> bank2 M2M bandwidth: 3787.88 MB/s
bank1 -> bank3 M2M bandwidth: 3731.34 MB/s
bank2 -> bank3 M2M bandwidth: 3787.88 MB/s
INFO: xbutil m2mtest succeeded.
dx4300:~/git/XRT/build>

Before change
-------------
dx4300:~/git/XRT/build>/home/sonals/git/XRT/build/Release/opt/xilinx/xrt/bin/xbutil m2mtest
INFO: Found total 1 card(s), 1 are usable
bank0 -> bank1 M2M bandwidth: 868.056 MB/s
bank0 -> bank2 M2M bandwidth: 1201.92 MB/s
bank0 -> bank3 M2M bandwidth: 1552.8 MB/s
bank1 -> bank2 M2M bandwidth: 1724.14 MB/s
bank1 -> bank3 M2M bandwidth: 1436.78 MB/s
bank2 -> bank3 M2M bandwidth: 696.379 MB/s
INFO: xbutil m2mtest succeeded.
dx4300:~/git/XRT/build>