### PR TITLE
Removing the usages of unused xclAllBO() argument

### DIFF
--- a/tests/xrt/00_hello/main.cpp
+++ b/tests/xrt/00_hello/main.cpp
@@ -154,8 +154,8 @@ int main(int argc, char** argv)
         if (xclOpenContext(handle, xclbinId, cu_index, true))
             throw std::runtime_error("Cannot create context");
 
-        unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem);
-        unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem);
+        unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, 0, first_mem);
+        unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, 0, first_mem);
         char* bo1 = (char*)xclMapBO(handle, boHandle1, true);
         memset(bo1, 0, DATA_SIZE);
         std::string testVector =  "hello\nthis is Xilinx OpenCL memory read write test\n:-)\n";
@@ -173,7 +173,7 @@ int main(int argc, char** argv)
             return 1;
 
         //Allocate the exec_bo
-        unsigned execHandle = xclAllocBO(handle, DATA_SIZE, xclBOKind(0), (1<<31));
+        unsigned execHandle = xclAllocBO(handle, DATA_SIZE, 0, (1<<31));
         //void* execData = xclMapBO(handle, execHandle, true);
 
         //Get the output;

--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -75,8 +75,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
 
     const size_t DATA_SIZE = count * sizeof(int);
 
-    unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem); //output s1
-    unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem); // input s2
+    unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, 0, first_mem); //output s1
+    unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, 0, first_mem); // input s2
     int *bo2 = (int*)xclMapBO(handle, boHandle2, true);
     int *bo1 = (int*)xclMapBO(handle, boHandle1, true);
     
@@ -108,7 +108,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
     if( (bo2devAddr == (uint64_t)(-1)) || (bo1devAddr == (uint64_t)(-1)))
         return 1;
     //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, DATA_SIZE, xclBOKind(0), (1<<31));
+    unsigned execHandle = xclAllocBO(handle, DATA_SIZE, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
     std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv)
         if (xclOpenContext(handle, xclbinId, cu_index, true))
             throw std::runtime_error("Cannot create context");
 
-        unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem);
+        unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, 0, first_mem);
         char* bo2 = (char*)xclMapBO(handle, boHandle2, true);
         memset(bo2, 0, DATA_SIZE);
         std::string testVector =  "hello\nthis is Xilinx OpenCL memory read write test\n:-)\n";
@@ -174,11 +174,11 @@ int main(int argc, char** argv)
         if(xclSyncBO(handle, boHandle2, XCL_BO_SYNC_BO_TO_DEVICE , DATA_SIZE,0))
             return 1;
 
-        unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem);
+        unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, 0, first_mem);
 
 
         //Allocate the exec_bo
-        unsigned execHandle = xclAllocBO(handle, DATA_SIZE, xclBOKind(0), (1<<31));
+        unsigned execHandle = xclAllocBO(handle, DATA_SIZE, 0, (1<<31));
         void* execData = xclMapBO(handle, execHandle, true);
 
         //construct the exec buffer cmd to configure.

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -162,7 +162,7 @@ int main(int argc, char** argv)
         if (xclOpenContext(handle, xclbinId, cu_index, true))
             throw std::runtime_error("Cannot create context");
 
-        unsigned boHandle = xclAllocBO(handle, DATA_SIZE*sizeof(int), XCL_BO_DEVICE_RAM, first_mem);
+        unsigned boHandle = xclAllocBO(handle, DATA_SIZE*sizeof(int), 0, first_mem);
         int* bo = (int*)xclMapBO(handle, boHandle, true);
         memset(bo, 0, DATA_SIZE*sizeof(int));
 
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
             return 1;
 
         //Allocate the exec_bo
-        unsigned execHandle = xclAllocBO(handle, DATA_SIZE*4, xclBOKind(0), (1<<31));
+        unsigned execHandle = xclAllocBO(handle, DATA_SIZE*4, 0, (1<<31));
         void* execData = xclMapBO(handle, execHandle, true);
 
         //construct the exec buffer cmd to configure.

--- a/tests/xrt/07_sequence/main.cpp
+++ b/tests/xrt/07_sequence/main.cpp
@@ -103,7 +103,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
     if(xclOpenContext(handle, xclbinId, cu_index, true))
         throw std::runtime_error("Cannot create context");
 
-    unsigned boHandle = xclAllocBO(handle, DATA_SIZE*sizeof(unsigned), XCL_BO_DEVICE_RAM, first_mem);
+    unsigned boHandle = xclAllocBO(handle, DATA_SIZE*sizeof(unsigned), 0, first_mem);
     unsigned* bo = (unsigned*)xclMapBO(handle, boHandle, true);
     
     memset(bo, 0, DATA_SIZE*sizeof(unsigned));
@@ -118,7 +118,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         return 1;
 
     //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, DATA_SIZE*sizeof(unsigned), xclBOKind(0), (1<<31));
+    unsigned execHandle = xclAllocBO(handle, DATA_SIZE*sizeof(unsigned), 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
     std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;

--- a/tests/xrt/102_multiproc_verify/main.cpp
+++ b/tests/xrt/102_multiproc_verify/main.cpp
@@ -83,7 +83,7 @@ static int runKernel(xclDeviceHandle handle, uint64_t cu_base_addr, bool verbose
 
     try {
         for (auto &bo : dataBO) {
-            bo.first = xclAllocBO(handle, size, XCL_BO_DEVICE_RAM, 0x1);
+            bo.first = xclAllocBO(handle, size, 0, 0x1);
             bo.second = xclMapBO(handle, bo.first, true);
             std::memset(bo.second, 0, size);
             if (xclSyncBO(handle, bo.first, XCL_BO_SYNC_BO_TO_DEVICE, size, 0))
@@ -92,7 +92,7 @@ static int runKernel(xclDeviceHandle handle, uint64_t cu_base_addr, bool verbose
 
         auto dbo = dataBO.begin();
         for (auto &cbo : cmdBO) {
-            cbo.first = xclAllocBO(handle, 4096, xclBOKind(0), (1<<31));
+            cbo.first = xclAllocBO(handle, 4096, 0, (1<<31));
             cbo.second = xclMapBO(handle, cbo.first, true);
             std::memset(cbo.second, 0, 4096);
             ert_start_kernel_cmd *ecmd = reinterpret_cast<ert_start_kernel_cmd*>(cbo.second);
@@ -166,7 +166,7 @@ static int runKernelLoop(xclDeviceHandle handle, uint64_t cu_base_addr, bool ver
         throw std::runtime_error("Cannot create context");
 
     //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, 1024, xclBOKind(0), (1<<31));
+    unsigned execHandle = xclAllocBO(handle, 1024, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
     //construct the exec buffer cmd to configure.

--- a/tests/xrt/103_multiproc/main.cpp
+++ b/tests/xrt/103_multiproc/main.cpp
@@ -81,7 +81,7 @@ static int runKernel(xclDeviceHandle handle, uint64_t cu_base_addr, bool verbose
     try {
         int result = 0;
         for (auto &bo : dataBO) {
-            bo.first = xclAllocBO(handle, size, XCL_BO_DEVICE_RAM, 0x0);
+            bo.first = xclAllocBO(handle, size, 0, 0x0);
             bo.second = xclMapBO(handle, bo.first, true);
             std::memset(bo.second, 0, size);
             result += xclSyncBO(handle, bo.first, XCL_BO_SYNC_BO_TO_DEVICE, size, 0);
@@ -93,7 +93,7 @@ static int runKernel(xclDeviceHandle handle, uint64_t cu_base_addr, bool verbose
 
 
         for (auto &bo : cmdBO) {
-            bo.first = xclAllocBO(handle, 4096, xclBOKind(0), (1<<31));
+            bo.first = xclAllocBO(handle, 4096, 0, (1<<31));
             bo.second = xclMapBO(handle, bo.first, true);
             std::memset(bo.second, 0, 4096);
             ert_start_kernel_cmd *ecmd = reinterpret_cast<ert_start_kernel_cmd*>(bo.second);
@@ -149,7 +149,7 @@ static int runKernelLoop(xclDeviceHandle handle, uint64_t cu_base_addr, bool ver
     xclOpenContext(handle, xclbinId, 0, true);
 
     //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, 1024, xclBOKind(0), (1<<31));
+    unsigned execHandle = xclAllocBO(handle, 1024, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
     std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;

--- a/tests/xrt/11_fp_mmult256/main.cpp
+++ b/tests/xrt/11_fp_mmult256/main.cpp
@@ -85,8 +85,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
             throw std::runtime_error("Cannot create context");
 
         // Allocate the device memory
-        unsigned boHandle1 = xclAllocBO(handle, 2*DATA_SIZE*sizeof(float), XCL_BO_DEVICE_RAM, first_mem); // input a and b
-        unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE*sizeof(float), XCL_BO_DEVICE_RAM, first_mem);   // output
+        unsigned boHandle1 = xclAllocBO(handle, 2*DATA_SIZE*sizeof(float), 0, first_mem); // input a and b
+        unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE*sizeof(float), 0, first_mem);   // output
 
         // Create the mapping to the host memory
         float *bo1 = (float*)xclMapBO(handle, boHandle1, true);
@@ -135,7 +135,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         }
 
         // Create an execution buffer to configure the FPGA (ERT)
-        unsigned execHandle = xclAllocBO(handle, DATA_SIZE*sizeof(float), xclBOKind(0), (1<<31));
+        unsigned execHandle = xclAllocBO(handle, DATA_SIZE*sizeof(float), 0, (1<<31));
         void* execData = xclMapBO(handle, execHandle, true);
         
         std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;

--- a/tests/xrt/13_add_one/main.cpp
+++ b/tests/xrt/13_add_one/main.cpp
@@ -104,8 +104,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
 
     const size_t DATA_SIZE = n_elements * ARRAY_SIZE;
 
-    unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem); //input a
-    unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem); // output b
+    unsigned boHandle1 = xclAllocBO(handle, DATA_SIZE, 0, first_mem); //input a
+    unsigned boHandle2 = xclAllocBO(handle, DATA_SIZE, 0, first_mem); // output b
     unsigned long *bo1 = (unsigned long*)xclMapBO(handle, boHandle1, true);
     memset(bo1, 0, DATA_SIZE);
     unsigned long *bo2 = (unsigned long*)xclMapBO(handle, boHandle2, false);
@@ -123,7 +123,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
 
 
     //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, DATA_SIZE, xclBOKind(0), (1<<31));
+    unsigned execHandle = xclAllocBO(handle, DATA_SIZE, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
     // Fill our data sets with pattern

--- a/tests/xrt/15_buffer_size/main.cpp
+++ b/tests/xrt/15_buffer_size/main.cpp
@@ -116,8 +116,8 @@ static int transferSizeTest1(xclDeviceHandle &handle, size_t alignment, unsigned
 
     std::cout << "transferSizeTest1 start\n";
     std::cout << "Allocate two buffers with size: " << maxSize/1024 << " KBytes ...\n";
-    unsigned int boHandle1 = xclAllocBO(handle, maxSize, XCL_BO_DEVICE_RAM, first_mem); //buf1
-    unsigned int boHandle2 = xclAllocBO(handle, maxSize, XCL_BO_DEVICE_RAM, first_mem); // buf2
+    unsigned int boHandle1 = xclAllocBO(handle, maxSize, 0, first_mem); //buf1
+    unsigned int boHandle2 = xclAllocBO(handle, maxSize, 0, first_mem); // buf2
     unsigned *writeBuffer = (unsigned *)xclMapBO(handle, boHandle1, true);
     memset(writeBuffer, 0, maxSize);
     std::list<uint64_t> deviceHandleList;
@@ -150,7 +150,7 @@ static int transferSizeTest1(xclDeviceHandle &handle, size_t alignment, unsigned
             return 1;
 
         //Allocate the exec_bo
-        //unsigned execHandle = xclAllocBO(handle, maxSize, xclBOKind(0), (1<<31));
+        //unsigned execHandle = xclAllocBO(handle, maxSize, 0, (1<<31));
         //void* execData = xclMapBO(handle, execHandle, true);
 
         //Get the output;
@@ -190,8 +190,8 @@ static int transferSizeTest2(xclDeviceHandle &handle, size_t alignment, unsigned
 
     std::cout << "transferSizeTest2 start\n";
     std::cout << "Allocate two buffers with size: " << maxSize/1024 << " KBytes ...\n";
-    unsigned boHandle1 = xclAllocBO(handle, maxSize, XCL_BO_DEVICE_RAM, first_mem); //buf1
-    unsigned boHandle2 = xclAllocBO(handle, maxSize, XCL_BO_DEVICE_RAM, first_mem); // buf2
+    unsigned boHandle1 = xclAllocBO(handle, maxSize, 0, first_mem); //buf1
+    unsigned boHandle2 = xclAllocBO(handle, maxSize, 0, first_mem); // buf2
     unsigned *writeBuffer = (unsigned *)xclMapBO(handle, boHandle1, true);
     memset(writeBuffer, 0, maxSize);
     std::list<uint64_t> deviceHandleList;
@@ -219,7 +219,7 @@ static int transferSizeTest2(xclDeviceHandle &handle, size_t alignment, unsigned
             return 1;
 
         //Allocate the exec_bo
-        //unsigned execHandle = xclAllocBO(handle, maxSize, xclBOKind(0), (1<<31));
+        //unsigned execHandle = xclAllocBO(handle, maxSize, 0, (1<<31));
         //void* execData = xclMapBO(handle, execHandle, true);
         //Get the output;
         if(xclSyncBO(handle, boHandle1, XCL_BO_SYNC_BO_FROM_DEVICE, size, 0)) {
@@ -257,7 +257,7 @@ static int bufferSizeTest(xclDeviceHandle &handle, uint64_t totalSize, int first
     // Fill the DDR with random size buffers and measure the utilization
     while (totalAllocationSize < totalSize) {
         size_t size = dis(generator);
-        unsigned pos = xclAllocBO(handle, size, XCL_BO_DEVICE_RAM, first_mem); //buf1
+        unsigned pos = xclAllocBO(handle, size, 0, first_mem); //buf1
         xclBOProperties p;
         uint64_t bodevAddr = !xclGetBOProperties(handle, pos, &p) ? p.paddr : -1;
         if (bodevAddr == (uint64_t)(-1)) {

--- a/tests/xrt/22_verify/main.cpp
+++ b/tests/xrt/22_verify/main.cpp
@@ -80,7 +80,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
     if(xclOpenContext(handle, xclbinId, cu_index, true))
         throw std::runtime_error("Cannot create context");
 
-    unsigned boHandle = xclAllocBO(handle, 1024, XCL_BO_DEVICE_RAM, first_mem);//buf1
+    unsigned boHandle = xclAllocBO(handle, 1024, 0, first_mem);//buf1
     char* bo = (char*)xclMapBO(handle, boHandle, true);
 
     memset(bo, 0, 1024);
@@ -95,7 +95,7 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         return 1;
 
     //Allocate the exec_bo
-    unsigned execHandle = xclAllocBO(handle, 1024, xclBOKind(0), (1<<31));
+    unsigned execHandle = xclAllocBO(handle, 1024, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
     std::cout << "Construct the exe buf cmd to configure FPGA" << std::endl;

--- a/tests/xrt/host_src/utils.hpp
+++ b/tests/xrt/host_src/utils.hpp
@@ -210,8 +210,8 @@ create_bo(const device& device, size_t sz, int bank=-1)
   auto ubo = std::make_unique<buffer_object>();
   ubo->dev = device->handle;
   ubo->bo = bank>=0
-    ? xclAllocBO(ubo->dev,sz,XCL_BO_DEVICE_RAM, bank)
-    : xclAllocBO(ubo->dev,sz,XCL_BO_DEVICE_RAM,0);
+    ? xclAllocBO(ubo->dev,sz,0, bank)
+    : xclAllocBO(ubo->dev,sz,0,0);
   ubo->data = xclMapBO(ubo->dev,ubo->bo,true /*write*/);
   ubo->size = sz;
   return buffer(ubo.release(),delBO);


### PR DESCRIPTION
@maxzhen I have removed all the usages of "int unused" argument of xclAllocBO() for all the xrt testcases.
Can you check this out?

If my changes are good to go, then you can go ahead and restore the changes in https://github.com/Xilinx/XRT/pull/1584/
