### PR TITLE
[EDGE] support xclRegRead and xclRegWrite

### DIFF
--- a/src/runtime_src/core/common/bo_cache.h
+++ b/src/runtime_src/core/common/bo_cache.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <utility>
 #include <mutex>
+#include <sys/mman.h>
 
 #include "xrt.h"
 #include "ert.h"

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -41,6 +41,12 @@
 
 #define GB(x)   ((size_t) (x) << 30)
 
+static inline void errlog(std::string& errstr)
+{
+    xrt_core::message::send(xrt_core::message::severity_level::XRT_ERROR,
+        "XRT", errstr.c_str());
+}
+
 static std::string parseCUStatus(unsigned val) {
   char delim = '(';
   std::string status;
@@ -105,7 +111,8 @@ namespace ZYNQ {
 ZYNQShim::ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity) :
     profiling(nullptr),
     mBoardNumber(index),
-    mVerbosity(verbosity)
+    mVerbosity(verbosity),
+    mCuMaps(128, nullptr)
 {
   profiling = std::make_unique<ZYNQShimProfiling>(this);
   //TODO: Use board number
@@ -132,6 +139,11 @@ ZYNQShim::~ZYNQShim()
   if (mLogStream.is_open()) {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     mLogStream.close();
+  }
+
+  for (auto p : mCuMaps) {
+    if (p)
+      (void) munmap(p, mCuMapSize);
   }
 }
 #endif
@@ -624,6 +636,56 @@ int ZYNQShim::xclSKReport(uint32_t cu_idx, xrt_scu_state state)
   return ret;
 }
 
+int ZYNQShim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset,
+  uint32_t *datap)
+{
+  std::lock_guard<std::mutex> l(mCuMapLock);
+
+  if (cu_index >= mCuMaps.size()) {
+    std::string err = "xclRegRW: invalid CU index: ";
+    err += std::to_string(cu_index);
+    errlog(err);
+    return -EINVAL;
+  }
+  if (offset >= mCuMapSize || (offset & (sizeof(uint32_t) - 1)) != 0) {
+    std::string err = "xclRegRW: invalid CU offset: ";
+    err += std::to_string(offset);
+    errlog(err);
+    return -EINVAL;
+  }
+
+  if (mCuMaps[cu_index] == nullptr) {
+    void *p = mmap(0, mCuMapSize, PROT_READ | PROT_WRITE, MAP_SHARED,
+      mKernelFD, cu_index * getpagesize());
+    if (p != MAP_FAILED)
+        mCuMaps[cu_index] = (uint32_t *)p;
+  }
+
+  uint32_t *cumap = mCuMaps[cu_index];
+  if (cumap == nullptr) {
+    std::string err = "xclRegRW: can't map CU ";
+    err += std::to_string(cu_index);
+    errlog(err);
+    return -EINVAL;
+  }
+
+  if (rd)
+    *datap = cumap[offset / sizeof(uint32_t)];
+  else
+    cumap[offset / sizeof(uint32_t)] = *datap;
+  return 0;
+}
+
+int ZYNQShim::xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap)
+{
+  return xclRegRW(true, cu_index, offset, datap);
+}
+
+int ZYNQShim::xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data)
+{
+  return xclRegRW(false, cu_index, offset, &data);
+}
+
 }
 ;
 //end namespace ZYNQ
@@ -797,7 +859,6 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
 
 size_t xclWrite(xclDeviceHandle handle, xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
 {
-  //std::cout << "xclWrite called" << std::endl;
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
   if (!drv)
     return -EINVAL;
@@ -806,7 +867,6 @@ size_t xclWrite(xclDeviceHandle handle, xclAddressSpace space, uint64_t offset, 
 
 size_t xclRead(xclDeviceHandle handle, xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
 {
-//  //std::cout << "xclRead called" << std::endl;
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
   if (!drv)
     return -EINVAL;
@@ -815,7 +875,6 @@ size_t xclRead(xclDeviceHandle handle, xclAddressSpace space, uint64_t offset, v
 
 int xclGetDeviceInfo2(xclDeviceHandle handle, xclDeviceInfo2 *info)
 {
-  //std::cout << "xclGetDeviceInfo2 called" << std::endl;
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
   if (!drv)
     return -EINVAL;
@@ -1145,4 +1204,18 @@ ssize_t xclWriteQueue(xclDeviceHandle handle, void *q_hdl, xclQueueRequest *wr_r
 ssize_t xclReadQueue(xclDeviceHandle handle, void *q_hdl, xclQueueRequest *wr_req)
 {
   return -ENOSYS;
+}
+
+int xclRegWrite(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset,
+  uint32_t data)
+{
+  ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+  return drv ? drv->xclRegWrite(cu_index, offset, data) : -ENODEV;
+}
+
+int xclRegRead(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset,
+  uint32_t *datap)
+{
+  ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+  return drv ? drv->xclRegRead(cu_index, offset, datap) : -ENODEV;
 }


### PR DESCRIPTION
This PR is mostly ported from DC platform and was tested on zcu102ng platform.

There is one difference in behavior b/w edge and DC. Since we don't have real CU reservation support on edge, we do not require user to exclusively reserve a CU before it can access the reg space using xclRegRead() and xclRegWrite().