### PR TITLE
For 2019.1: CentOS fix for header include. CR# 1023034 and 1034439

### DIFF
--- a/src/xma/include/lib/xmacfg.h
+++ b/src/xma/include/lib/xmacfg.h
@@ -24,6 +24,11 @@
 
 #include "lib/xmalimits.h"
 
+#if !defined (PATH_MAX) || !defined (NAME_MAX)
+#include <linux/limits.h>
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/xma/include/lib/xmaxclbin.h
+++ b/src/xma/include/lib/xmaxclbin.h
@@ -24,6 +24,10 @@
 #include "xclbin.h"
 #include "mgmt-ioctl.h"
 
+#if !defined (PATH_MAX) || !defined (NAME_MAX)
+#include <linux/limits.h>
+#endif
+
 
 typedef struct XmaIpLayout
 {


### PR DESCRIPTION
CentOs fix for header include. CR# 1023034 and 1034439