### PR TITLE
clean up zocl 64bit lint errors

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -79,7 +79,8 @@ void zocl_free_sections(struct drm_zocl_dev *zdev)
 	}
 }
 
-static irqreturn_t zocl_h2c_isr(int irq, void *arg)
+/* Note: this function is not being used, mark it inline to make lint clean */
+static inline irqreturn_t zocl_h2c_isr(int irq, void *arg)
 {
 	void *mmio_sched = arg;
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -581,7 +581,7 @@ zocl_info_cu_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	args->apt_idx = get_apt_index(zdev, args->paddr);
 	if (args->apt_idx == -EINVAL) {
-		DRM_ERROR("Failed to find CU in aperture list 0x%lx\n", args->paddr);
+		DRM_ERROR("Failed to find CU in aperture list 0x%llx\n", args->paddr);
 		return -EINVAL;
 	}
 	return 0;


### PR DESCRIPTION
just clean some lint errors to make the 64bit compile clean.
will build a 32bit and fix that too. 