### PR TITLE
clean up 32bit lint errors of zocl

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -191,7 +191,7 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 		err = drm_mm_insert_node_generic(zdev->mem[bank].zm_mm,
 		    bo->mm_node, size, PAGE_SIZE, 0, 0);
 		if (err) {
-			DRM_ERROR("Fail to allocate BO: size %ld\n", size);
+			DRM_ERROR("Fail to allocate BO: size %ld\n", (long)size);
 			mutex_unlock(&zdev->mm_lock);
 			kfree(bo->mm_node);
 			kfree(bo);
@@ -435,7 +435,7 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		goto out0;
 	}
 
-	bo->cma_base.vaddr = (void *)args->addr;
+	bo->cma_base.vaddr = (void *)(uintptr_t)args->addr;
 
 	ret = drm_gem_handle_create(filp, &bo->cma_base.base, &args->handle);
 	if (ret) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -602,13 +602,14 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	}
 	zdev->cu_num = index;
 
-	zdev->host_mem = 0xFFFFFFFFFFFFFFFF;
+	/* set to 0xFFFFFFFF(32bit) or 0xFFFFFFFFFFFFFFFF(64bit) */
+	zdev->host_mem = (phys_addr_t) -1;
 	zdev->host_mem_len = 0;
 	/* If reserved memory region are not found, just keep going */
 	ret = get_reserved_mem_region(&pdev->dev, &res_mem);
 	if (!ret) {
-		DRM_INFO("Reserved memory for host at 0x%llx, size 0x%llx\n",
-			 res_mem.start, resource_size(&res_mem));
+		DRM_INFO("Reserved memory for host at 0x%lx, size 0x%lx\n",
+			 (unsigned long)res_mem.start, (unsigned long)resource_size(&res_mem));
 		zdev->host_mem = res_mem.start;
 		zdev->host_mem_len = resource_size(&res_mem);
 	}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ert.c
@@ -60,8 +60,8 @@ static int zocl_ert_probe(struct platform_device *pdev)
 		return PTR_ERR(map);
 	}
 	ert->hw_ioremap = map;
-	ert_info(pdev, "IP(embedded_scheduler_hw) IO start %llx, end %llx",
-			      res->start, res->end);
+	ert_info(pdev, "IP(embedded_scheduler_hw) IO start %lx, end %lx",
+	      (unsigned long)res->start, (unsigned long)res->end);
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, ZOCL_ERT_CQ_RES);
 	map = devm_ioremap_resource(&pdev->dev, res);
@@ -71,8 +71,8 @@ static int zocl_ert_probe(struct platform_device *pdev)
 		return PTR_ERR(map);
 	}
 	ert->cq_ioremap = map;
-	ert_info(pdev, "Command Queue IO start %llx, end %llx",
-			res->start, res->end);
+	ert_info(pdev, "Command Queue IO start %lx, end %lx",
+		(unsigned long)res->start, (unsigned long)res->end);
 
 	ert->irq[ZOCL_ERT_CQ_IRQ] = platform_get_irq(pdev, ZOCL_ERT_CQ_IRQ);
 	ert->irq[ZOCL_ERT_CU_IRQ] = platform_get_irq(pdev, ZOCL_ERT_CU_IRQ);


### PR DESCRIPTION
seems that's the only lint issues in 32bit zocl code. Verified both on 32 and 64 platforms.