### PR TITLE
msg cleanup

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -191,6 +191,9 @@ void shim::dev_fini()
 void shim::init(unsigned index, const char *logfileName,
     xclVerbosityLevel verbosity)
 {
+    if(logfileName != nullptr) {
+        xclLog(XRT_WARNING, "XRT", "%s: logfileName is no longer supported", __func__);
+    }
     xclLog(XRT_INFO, "XRT", "%s", __func__);
     dev_init();
 

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -56,7 +56,8 @@ public:
     shim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity);
     void init(unsigned index, const char *logfileName, xclVerbosityLevel verbosity);
     void readDebugIpLayout();
-    static int xclLogMsg(xclDeviceHandle handle, xrtLogMsgLevel level, const char* tag, const char* format, va_list args1);
+    static int xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* format, va_list args1);
+    int xclLog(xrtLogMsgLevel level, const char* tag, const char* format, ...);
     // Raw unmanaged read/write on the entire PCIE user BAR
     size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);
     size_t xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size);

--- a/tests/message-mgmt/mssg.cpp
+++ b/tests/message-mgmt/mssg.cpp
@@ -8,7 +8,7 @@
 
 void foo(int num, xclDeviceHandle handle)
 {
-    xclLogMsg(handle, NOTICE, "XRT", "(5) Running Thread number %d", num);
+    xclLogMsg(handle, XRT_NOTICE, "XRT", "(5) Running Thread number %d", num);
 }
 
 int main(int argc, char** argv) {
@@ -37,19 +37,19 @@ int main(int argc, char** argv) {
 
     handle = xclOpen(devIndex, "", XCL_INFO);
     if(!handle)
-        xclLogMsg(handle, EMERGENCY, "XRT", "(0) Unable to open device %d", devIndex);
+        xclLogMsg(handle, XRT_EMERGENCY, "XRT", "(0) Unable to open device %d", devIndex);
 
-    xclLogMsg(handle, INFO, "XRT", "(6) %s was passed in as an argument", bitFile);
+    xclLogMsg(handle, XRT_INFO, "XRT", "(6) %s was passed in as an argument", bitFile);
 
     if(debug_flag)
-        xclLogMsg(handle, DEBUG, "XRT","(7) Debug flag was set");
+        xclLogMsg(handle, XRT_DEBUG, "XRT","(7) Debug flag was set");
 
     if(xclGetDeviceInfo2(handle, &deviceInfo))
-        xclLogMsg(handle, ALERT,"XRT", "(1) Unable to obtain device information");
+        xclLogMsg(handle, XRT_ALERT,"XRT", "(1) Unable to obtain device information");
 
     const xclBin *blob =(const xclBin *) new char [1];
     if(xclLoadXclBin(handle, blob))
-        xclLogMsg(handle, CRITICAL, "XRT", "(2) Unable to load xclbin");
+        xclLogMsg(handle, XRT_CRITICAL, "XRT", "(2) Unable to load xclbin");
 
     std::cout << "~~~Multi threading~~~" <<  std::endl;
     std:: thread t1(foo, 1, handle);
@@ -59,8 +59,8 @@ int main(int argc, char** argv) {
     std::cout << "~~~~~~~~~~~~~~~~~~~~~" << std:: endl;
 
     std::cout << "Other messages: \n";
-    xclLogMsg(handle, ERROR,"XRT", "(3) Display when verbosity 3");
-    xclLogMsg(handle, WARNING, "XRT", "(4) Display when verbosity 2");
+    xclLogMsg(handle, XRT_ERROR,"XRT", "(3) Display when verbosity 3");
+    xclLogMsg(handle, XRT_WARNING, "XRT", "(4) Display when verbosity 2");
 
     return 0;
 }


### PR DESCRIPTION
- fix mssg example
- use xclLogMsg for logging in shim.cpp and removing any use of the passed in logfile

Example output:

```
XRT build version: 2.3.0
Build hash: 53d69f43e5059fb7ec9c88958316c8cb800de4b1
Build date: 2019-07-24 11:38:22
Git branch: xcllog
[Wed Jul 24 11:48:17 2019]
PID: 302325
UID: 31939
HOST: xsjsagarwal
EXE: /scratch/sagarw/XRT/tests/xrt/build/opt/22_verify/22_verify.exe
[Wed Jul 24 11:48:17 2019] [XRT] Tid: 140542701299584,  INFO: Read /scratch/sagarw/XRT/tests/xrt/build/opt/22_verify/xrt.ini
[Wed Jul 24 11:48:17 2019] [XRT] Tid: 140542701299584,  INFO: init
[Wed Jul 24 11:48:17 2019] [XRT] Tid: 140542701299584,  INFO: xclLoadAxlf, buffer: xclbin2
[Wed Jul 24 11:48:17 2019] [XRT] Tid: 140542701299584,  ERROR: Xclbin does not match Shell on card or xrt version.                         
Please install compatible xrt or run xbutil flash -a all to flash card.
```