### PR TITLE
Support context/queue in KDS

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -279,7 +279,7 @@ get_ert_slotsize()
 inline bool
 get_cdma()
 {
-  static unsigned int value = detail::get_bool_value("Runtime.cdma",true);
+  static bool value = detail::get_bool_value("Runtime.cdma",true);
   return value;
 }
 
@@ -334,6 +334,13 @@ get_sw_em_driver()
   return value;
 }
 
-}}
+inline std::string
+get_ctx_info()
+{
+  static std::string value = detail::get_string_value("Runtime.ctx_info","");
+  return value;
+}
+
+}} // config,xrt_core
 
 #endif

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -669,11 +669,12 @@ configure_cu(addr_type cu_addr, addr_type regmap_addr, size_type regmap_size)
 inline void
 configure_cu_ooo(addr_type cu_addr, addr_type regmap_addr, size_type regmap_size)
 {
-  // write register map addr, value pairs starting at 0x10
-  for (size_type idx = 4; idx < regmap_size; idx += 2) {
+  // write register map addr, value pairs starting 
+  // past reserved 4 ctrl + 2 ctx 
+  for (size_type idx = 6; idx < regmap_size; idx += 2) {
     addr_type offset = read_reg(regmap_addr + (idx << 2));
     value_type value = read_reg(regmap_addr + ((idx + 1) << 2));
-    write_reg(offset, value);
+    write_reg(cu_addr + offset, value);
   }
 
   // start kernel at base + 0x0

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -85,7 +85,7 @@ exec_write_command(xrt_device* device)
   : command(device,ERT_EXEC_WRITE)
 {
   m_impl->ecmd->type = ERT_CU;
-  m_impl->ecmd->count = 1+4; // cumask + 4 ctrl
+  clear();
 }
 
 void
@@ -93,9 +93,19 @@ exec_write_command::
 add_cu(value_type cuidx)
 {
   if (cuidx>=32)
-    throw std::runtime_error("write_command supports at most 32 CUs");
+    throw std::runtime_error("write_exec supports at most 32 CUs");
   auto skcmd = reinterpret_cast<ert_start_kernel_cmd*>(m_impl->ecmd);
   skcmd->cu_mask |= 1<<cuidx;
+}
+
+void
+exec_write_command::
+add_ctx(uint32_t ctx)
+{
+  if (ctx >= 32)
+    throw std::runtime_error("write_exec supports at most 32 contexts numbered 0 through 31");
+  auto skcmd = reinterpret_cast<ert_start_kernel_cmd*>(m_impl->ecmd);
+  skcmd->data[0x10 >> 2] = ctx;
 }
 
 void
@@ -115,7 +125,7 @@ clear()
   skcmd->cu_mask = 0;
 
   // clear payload
-  m_impl->ecmd->count = 1+4; // cumask + 4 ctrl
+  m_impl->ecmd->count = 1 + 4 + 2; // cumask + 4 ctrl + 2 ctx
 }
 
 }} // exec,xrt

--- a/src/runtime_src/xrt/xrt++/xrtexec.hpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.hpp
@@ -104,6 +104,21 @@ public:
   add_cu(value_type cuidx);
 
   /**
+   * Add context identifier for this command.
+   *
+   * A context is value between [0..maxctx[ identifying the kernel
+   * compute unit context that should be used when executing the
+   * command.
+   *
+   * Specifying a context targeting a kernel that does not support
+   * contexts is valid but has effect on execution.
+   *
+   * @ctx: context identifier
+   */
+  void
+  add_ctx(uint32_t ctx);
+
+  /**
    * Add {addr,value} pair to the command
    *
    * @addr: the address that will be written with @value

--- a/tests/unit_test/experimental/exec_write/main.cpp
+++ b/tests/unit_test/experimental/exec_write/main.cpp
@@ -167,10 +167,11 @@ struct job_type
     while (!stop) {
       m_cmd.clear();
       for (uint32_t offset = 0x10; offset < XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA; offset += 4)
-        m_cmd.add(m_cuaddr + offset,0);
-      m_cmd.add(m_cuaddr + XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA,m_bo_dev_addr); // low
-      m_cmd.add(m_cuaddr + XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA+4,(m_bo_dev_addr >> 32) & 0xFFFFFFFF); // high part of a
+        m_cmd.add(offset,0);
+      m_cmd.add(XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA,m_bo_dev_addr); // low
+      m_cmd.add(XHELLO_HELLO_CONTROL_ADDR_ACCESS1_DATA+4,(m_bo_dev_addr >> 32) & 0xFFFFFFFF); // high part of a
       m_cmd.add_cu(m_cuidx);
+      //m_cmd.add_ctx(0);
       m_cmd.execute();
       m_cmd.wait();
       assert(m_cmd.state() == ERT_CMD_STATE_COMPLETED);


### PR DESCRIPTION
Add support for context / queue feature in KDS.

Add exec_write method to specify context.

Modify exec_write to use CU offset rather than global offset, this is
a breaking change.

Reserve exec_write payload [0..6] corresponding to 0x0..0x14 for CU
control so that addr,value pair starts at 0x18.  0x10 and 0x14 are for
context in/out and are used if and only if kernel enables context feature.