### PR TITLE
timeout increased for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
       name: "Xilinx/XRT"
       description: "Xilinx Runtime"
     notification_email: sagarw@xilinx.com
-    build_command: "./build.sh -dbg"
+    build_command: "./build.sh"
     branch_pattern: master
 
 script: if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then ./build.sh ; fi


### PR DESCRIPTION
The support increased the timeout limit to 180 minutes. Let's see if we can do a full build for Coverity Scan in that much time