### PR TITLE
Fix Linux 5.0 compilation errors (#1530)

### DIFF
--- a/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.c
+++ b/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.c
@@ -7,6 +7,7 @@
  *
  * Author(s):
  * Sonal Santan <sonal.santan@xilinx.com>
+ * Jan Stephan  <j.stephan@hzdr.de>
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
@@ -268,9 +269,9 @@ static long char_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		return -ENOTTY;
 
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
-	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		result =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		result = !AWSMGMT_ACCESS_OK(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+	else if(_IOC_DIR(cmd) & _IOC_WRITE)
+		result = !AWSMGMT_ACCESS_OK(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 
 	if (result)
 		return -EFAULT;

--- a/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.h
@@ -23,6 +23,14 @@
 #define AWSMGMT_DRIVER_MINOR 2
 #define AWSMGMT_DRIVER_PATCHLEVEL 1
 
+/* Ensure compatibility with newer Linux kernels. */
+/* access_ok lost its first parameter with Linux 5.0. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	#define AWSMGMT_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(ADDR, SIZE)
+#else
+	#define AWSMGMT_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(TYPE, ADDR, SIZE)
+#endif
+
 enum AWSMGMT_BARS {
     AWSMGMT_MAIN_BAR = 0,
     AWSMGMT_MAILBOX_BAR,

--- a/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_compat.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/lib/libqdma/qdma_compat.h
@@ -45,17 +45,6 @@
 
 #endif
 
-/* use simple wait queue (swaitq) with newer kernels */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)
-#include <linux/swait.h>
-
-#define qdma_wait_queue			struct swait_queue_head
-#define qdma_waitq_init			init_swait_queue_head
-#define qdma_waitq_wakeup		swake_up
-#define qdma_waitq_wait_event		swait_event_interruptible
-#define qdma_waitq_wait_event_timeout	swait_event_interruptible_timeout
-
-#else
 #include <linux/wait.h>
 
 #define qdma_wait_queue			wait_queue_head_t
@@ -63,8 +52,6 @@
 #define qdma_waitq_wakeup		wake_up_interruptible
 #define qdma_waitq_wait_event		wait_event_interruptible
 #define qdma_waitq_wait_event_timeout	wait_event_interruptible_timeout
-
-#endif	/* swaitq */
 
 /* timer */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)

--- a/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-ioctl.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/mgmtpf/mgmt-ioctl.c
@@ -1,6 +1,7 @@
 /**
  *  Copyright (C) 2017 Xilinx, Inc. All rights reserved.
- *  Author: Sonal Santan
+ *  Authors: Sonal Santan
+ *           Jan Stephan <j.stephan@hzdr.de>
  *  Code copied verbatim from SDAccel xcldma kernel mode driver
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -113,9 +114,9 @@ long mgmt_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		return -ENOTTY;
 
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		result = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		result = !XOCL_ACCESS_OK(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		result =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		result = !XOCL_ACCESS_OK(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 
 	if (result)
 		return -EFAULT;

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/firewall.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/firewall.c
@@ -3,6 +3,7 @@
  *
  *  Utility Functions for AXI firewall IP.
  *  Author: Lizhi.Hou@Xilinx.com
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -191,7 +192,7 @@ static const struct attribute_group firewall_attrgroup = {
 static u32 check_firewall(struct platform_device *pdev, int *level)
 {
 	struct firewall	*fw;
-	struct timeval	time;
+	XOCL_TIMESPEC time;
 	int	i;
 	u32	val = 0;
 
@@ -206,7 +207,7 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 			if (!fw->curr_status) {
 				fw->err_detected_status = val;
 				fw->err_detected_level = i;
-				do_gettimeofday(&time);
+				XOCL_GETTIME(&time);
 				fw->err_detected_time = (u64)(time.tv_sec -
 					(sys_tz.tz_minuteswest * 60));
 			}

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/fmgr.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/fmgr.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Sonal Santan
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -161,12 +162,34 @@ static int fmgr_probe(struct platform_device *pdev)
 	obj->xdev = xocl_get_xdev(pdev);
 	snprintf(obj->name, sizeof(obj->name), "Xilinx PCIe FPGA Manager");
 
+	/* TODO: Remove old fpga_mgr_register call as soon as Linux < 4.18 is no
+	 * longer supported.
+	 */
 #if defined(FPGA_MGR_SUPPORT)
 	obj->state = FPGA_MGR_STATE_UNKNOWN;
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+	struct fpga_manager *mgr = fpga_mgr_create(&pdev->dev,
+											   obj->name,
+											   &xocl_pr_ops,
+											   obj);
+	if (!mgr)
+		return -ENOMEM;
+
+	/* Historically this was internally called by fpga_mgr_register (in the form
+	 * of drv_set_drvdata) but is expected to be called here since Linux 4.18.
+	 */
+	platform_set_drvdata(pdev, mgr);
+
+	ret = fpga_mgr_register(mgr);
+	if (ret)
+		fpga_mgr_free(mgr);
+	#else
 	ret = fpga_mgr_register(&pdev->dev, obj->name, &xocl_pr_ops, obj);
+	#endif
 #else
 	platform_set_drvdata(pdev, obj);
 #endif
+
 	return ret;
 }
 
@@ -177,7 +200,14 @@ static int fmgr_remove(struct platform_device *pdev)
 	struct xfpga_klass *obj = mgr->priv;
 
 	obj->state = FPGA_MGR_STATE_UNKNOWN;
+	/* TODO: Remove old fpga_mgr_unregister as soon as Linux < 4.18 is no
+	 * longer supported.
+	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+	fpga_mgr_unregister(mgr);
+#else
 	fpga_mgr_unregister(&pdev->dev);
+#endif // LINUX_VERSION_CODE
 #else
 	struct xfpga_klass *obj = platform_get_drvdata(pdev);
 #endif

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/mb_scheduler.c
@@ -3,6 +3,7 @@
  *
  * Authors:
  *    Soren Soe <soren.soe@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -429,7 +430,7 @@ static inline void
 cmd_release_gem_object_reference(struct xocl_cmd *xcmd)
 {
 	if (xcmd->bo)
-		drm_gem_object_unreference_unlocked(&xcmd->bo->base);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xcmd->bo->base);
 }
 
 /*
@@ -473,7 +474,7 @@ cmd_chain_dependencies(struct xocl_cmd *xcmd)
 		struct xocl_cmd *chain_to = dbo->metadata.active;
 		// release reference created in ioctl call when dependency was looked up
 		// see comments in xocl_ioctl.c:xocl_execbuf_ioctl()
-		drm_gem_object_unreference_unlocked(&dbo->base);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&dbo->base);
 		xcmd->deps[didx] = NULL;
 		if (!chain_to) { // command may have completed already
 			--xcmd->wait_count;
@@ -3014,18 +3015,18 @@ get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 	xobj = to_xocl_bo(obj);
 	if (!xobj->mm_node) {
 		/* Not a local BO */
-		drm_gem_object_unreference_unlocked(obj);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 		return -EADDRNOTAVAIL;
 	}
 
 	if (obj->size <= off || obj->size < off + size) {
 		userpf_err(xdev, "Failed to get paddr for BO 0x%x\n", bo_hdl);
-		drm_gem_object_unreference_unlocked(obj);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 		return -EINVAL;
 	}
 
 	*paddrp = xobj->mm_node->start + off;
-	drm_gem_object_unreference_unlocked(obj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 	return 0;
 }
 
@@ -3181,8 +3182,9 @@ client_ioctl_execbuf(struct platform_device *pdev,
 
 out:
 	for (--numdeps; numdeps >= 0; numdeps--)
-		drm_gem_object_unreference_unlocked(&deps[numdeps]->base);
-	drm_gem_object_unreference_unlocked(&xobj->base);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&deps[numdeps]->base);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
+
 	return ret;
 }
 

--- a/src/runtime_src/driver/xclng/drm/xocl/subdev/qdma.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/subdev/qdma.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -928,7 +929,7 @@ static int queue_req_complete(unsigned long priv, unsigned int done_bytes,
 			cb->queue->qconf.c2h ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
 		xocl_finish_unmgd(&cb->unmgd);
 	} else {
-		drm_gem_object_unreference_unlocked(&cb->xobj->base);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&cb->xobj->base);
 	}
 
 	spin_lock_bh(&cb->lock);
@@ -962,7 +963,7 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 		goto out;
 	}
 
-	drm_gem_object_reference(gem_obj);
+	XOCL_DRM_GEM_OBJECT_GET(gem_obj);
 	xobj = to_xocl_bo(gem_obj);
 
 	io_req = queue_req_new(queue);
@@ -1010,7 +1011,7 @@ static ssize_t stream_post_bo(struct xocl_qdma *qdma,
 
 out:
 	if (!kiocb) {
-		drm_gem_object_unreference_unlocked(gem_obj);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 		if (io_req)
 			queue_req_free(queue, io_req, false);
 	} else {
@@ -1621,9 +1622,9 @@ static long stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 
 	flags = O_CLOEXEC | O_RDWR;
 
-	drm_gem_object_reference(&xobj->base);
+	XOCL_DRM_GEM_OBJECT_GET(&xobj->base);
 	dmabuf = drm_gem_prime_export(XOCL_DRM(xdev)->ddev,
-		       	&xobj->base, flags);
+				&xobj->base, flags);
 	if (IS_ERR(dmabuf)) {
 		xocl_err(&qdma->pdev->dev, "failed to export dma_buf");
 		ret = PTR_ERR(dmabuf);

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_bo.c
@@ -6,6 +6,7 @@
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
  *    Sarabjeet Singh <sarabjeet.singh@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -469,7 +470,7 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		goto out_free;
 
 	xocl_describe(xobj);
-	drm_gem_object_unreference_unlocked(&xobj->base);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
 	return ret;
 
 out_free:
@@ -541,7 +542,7 @@ int xocl_userptr_bo_ioctl(struct drm_device *dev,
 
 	xobj->type |= XOCL_BO_USERPTR;
 	xocl_describe(xobj);
-	drm_gem_object_unreference_unlocked(&xobj->base);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
 	return ret;
 
 out0:
@@ -580,7 +581,7 @@ int xocl_map_bo_ioctl(struct drm_device *dev,
 	args->offset = drm_vma_node_offset_addr(&obj->vma_node);
 	xocl_describe(to_xocl_bo(obj));
 out:
-	drm_gem_object_unreference_unlocked(obj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 	return ret;
 }
 
@@ -694,7 +695,7 @@ clear:
 		kfree(sgt);
 	}
 out:
-	drm_gem_object_unreference_unlocked(gem_obj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 	return ret;
 }
 
@@ -719,7 +720,7 @@ int xocl_info_bo_ioctl(struct drm_device *dev,
 
 	args->paddr = xocl_bo_physical_addr(xobj);
 	xocl_describe(xobj);
-	drm_gem_object_unreference_unlocked(gem_obj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return 0;
 }
@@ -751,7 +752,7 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	if (!access_ok(VERIFY_READ, user_data, args->size)) {
+	if (!XOCL_ACCESS_OK(VERIFY_READ, user_data, args->size)) {
 		ret = -EFAULT;
 		goto out;
 	}
@@ -769,7 +770,7 @@ int xocl_pwrite_bo_ioctl(struct drm_device *dev, void *data,
 
 	ret = copy_from_user(kaddr, user_data, args->size);
 out:
-	drm_gem_object_unreference_unlocked(gem_obj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return ret;
 }
@@ -806,7 +807,7 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 		goto out;
 	}
 
-	if (!access_ok(VERIFY_WRITE, user_data, args->size)) {
+	if (!XOCL_ACCESS_OK(VERIFY_WRITE, user_data, args->size)) {
 		ret = EFAULT;
 		goto out;
 	}
@@ -819,7 +820,7 @@ int xocl_pread_bo_ioctl(struct drm_device *dev, void *data,
 	ret = copy_to_user(user_data, kaddr, args->size);
 
 out:
-	drm_gem_object_unreference_unlocked(gem_obj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return ret;
 }
@@ -943,9 +944,10 @@ out:
 		kfree(tmp_sgt);
 	}
 	if (src_gem_obj)
-		drm_gem_object_unreference_unlocked(src_gem_obj);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(src_gem_obj);
 	if (dst_gem_obj)
-		drm_gem_object_unreference_unlocked(dst_gem_obj);
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(dst_gem_obj);
+
 	return ret;
 }
 
@@ -1050,7 +1052,7 @@ int xocl_init_unmgd(struct drm_xocl_unmgd *unmgd, uint64_t data_ptr,
 	int ret;
 	char __user *user_data = to_user_ptr(data_ptr);
 
-	if (!access_ok((write == 1) ? VERIFY_READ : VERIFY_WRITE, user_data, size))
+	if (!XOCL_ACCESS_OK((write == 1) ? VERIFY_READ : VERIFY_WRITE, user_data, size))
 		return -EFAULT;
 
 	memset(unmgd, 0, sizeof(struct drm_xocl_unmgd));

--- a/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/userpf/xocl_drm.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
- * Authors:
+ * Authors: Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -406,7 +406,7 @@ failed:
 	if (drm_registered)
 		drm_dev_unregister(ddev);
 	if (ddev)
-		drm_dev_unref(ddev);
+		XOCL_DRM_DEV_PUT(ddev);
 	if (drm_p)
 		xocl_drvinst_free(drm_p);
 

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -2,6 +2,7 @@
  * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
+ *          Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -29,6 +30,67 @@
 #include "mgmt-ioctl.h"
 #include "mailbox_proto.h"
 
+/* The fix for the y2k38 bug was introduced with Linux 3.17 and backported to
+ * Red Hat 7.2.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0)
+	#define XOCL_TIMESPEC struct timespec64
+	#define XOCL_GETTIME ktime_get_real_ts64
+	#define XOCL_USEC tv_nsec / NSEC_PER_USEC
+#elif defined(RHEL_RELEASE_CODE)
+	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,2)
+		#define XOCL_TIMESPEC struct timespec64
+		#define XOCL_GETTIME ktime_get_real_ts64
+		#define XOCL_USEC tv_nsec / NSEC_PER_USEC
+	#else
+		#define XOCL_TIMESPEC struct timeval
+		#define XOCL_GETTIME do_gettimeofday
+		#define XOCL_USEC tv_usec
+	#endif
+#else
+	#define XOCL_TIMESPEC struct timeval
+	#define XOCL_GETTIME do_gettimeofday
+	#define XOCL_USEC tv_usec
+#endif
+
+/* drm_gem_object_put_unlocked and drm_gem_object_get were introduced with Linux
+ * 4.12 and backported to Red Hat 7.5.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
+	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
+#elif defined(RHEL_RELEASE_CODE)
+	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,5)
+		#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
+		#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
+	#else
+		#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_unreference_unlocked
+		#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_reference
+	#endif
+#else
+	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_unreference_unlocked
+	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_reference
+#endif
+
+/* drm_dev_put was introduced with Linux 4.15 and backported to Red Hat 7.6. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+	#define XOCL_DRM_DEV_PUT drm_dev_put
+#elif defined(RHEL_RELEASE_CODE)
+	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,6)
+		#define XOCL_DRM_DEV_PUT drm_dev_put
+	#else
+		#define XOCL_DRM_DEV_PUT drm_dev_unref
+	#endif
+#else
+	#define XOCL_DRM_DEV_PUT drm_dev_unref
+#endif
+
+/* access_ok lost its first parameter with Linux 5.0. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+	#define XOCL_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(ADDR, SIZE)
+#else
+	#define XOCL_ACCESS_OK(TYPE, ADDR, SIZE) access_ok(TYPE, ADDR, SIZE)
+#endif
 
 #if defined(RHEL_RELEASE_CODE)
 #if RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7, 4)

--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_test.c
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_test.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2018 Xilinx, Inc. All rights reserved.
  *
- * Authors:
+ * Authors: Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -27,14 +27,14 @@ bool xocl_test_on = true;
 static int xocl_test_thread_main(void *data)
 {
 #if 0
-	struct timeval now;
+	XOCL_TIMESPEC now;
 	struct drm_xocl_dev *xdev = (struct drm_xocl_dev *)data;
 	int irq = 0;
 	int count = 0;
 	while (!kthread_should_stop()) {
 		ssleep(xocl_test_interval);
-		do_gettimeofday(&now);
-		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.tv_usec);
+		XOCL_GETTIME(&now);
+		DRM_INFO("irq[%d] tv_sec[%ld]tv_usec[%ld]\n", irq, now.tv_sec, now.XOCL_USEC);
 		xocl_user_event(irq, xdev);
 		irq++;
 		irq &= 0xf;

--- a/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/sched_exec.c
@@ -4,8 +4,9 @@
  * Copyright (C) 2017-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
- *    Soren Soe <soren.soe@xilinx.com>
- *    Min Ma <min.ma@xilinx.com>
+ *    Soren Soe   <soren.soe@xilinx.com>
+ *    Min Ma      <min.ma@xilinx.com>
+ *    Jan Stephan <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -792,8 +793,10 @@ static inline void
 set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 {
 	u32 opc = opcode(cmd);
-	struct timeval tv;
-	struct start_kernel_cmd *sk = (struct start_kernel_cmd *)cmd->packet;
+	ZOCL_TIMESPEC tv;
+	struct ert_start_kernel_cmd *sk;
+
+	sk = (struct ert_start_kernel_cmd *)cmd->packet;
 
 	/* Simply skip if it is not start CU command */
 	if (opc != OP_START_CU)
@@ -806,13 +809,13 @@ set_cmd_ext_timestamp(struct sched_cmd *cmd, enum zocl_ts_type ts)
 	 * The fourth 32 bits - CU done  microseconds
 	 * Use 32 bits timestamp is good enough for this purpose for now.
 	 */
-	do_gettimeofday(&tv);
+	ZOCL_GETTIME(&tv);
 	if (ts == CU_START_TIME) {
 		*(sk->data + sk->extra_cu_masks) = (u32)tv.tv_sec;
-		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.tv_usec;
+		*(sk->data + sk->extra_cu_masks + 1) = (u32)tv.ZOCL_USEC;
 	} else if (ts == CU_DONE_TIME) {
 		*(sk->data + sk->extra_cu_masks + 2) = (u32)tv.tv_sec;
-		*(sk->data + sk->extra_cu_masks + 3) = (u32)tv.tv_usec;
+		*(sk->data + sk->extra_cu_masks + 3) = (u32)tv.ZOCL_USEC;
 	}
 }
 
@@ -1095,9 +1098,9 @@ void zocl_gem_object_unref(struct sched_cmd *cmd)
 	struct drm_zocl_bo *bo = cmd->buffer;
 
 	if (zdev->domain)
-		drm_gem_object_unreference_unlocked(&bo->gem_base);
+		ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&bo->gem_base);
 	else
-		drm_gem_object_unreference_unlocked(&bo->cma_base.base);
+		ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&bo->cma_base.base);
 }
 
 /*

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_drv.c
@@ -8,6 +8,7 @@
  *    Sonal Santan <sonal.santan@xilinx.com>
  *    Umang Parekh <umang.parekh@xilinx.com>
  *    Min Ma       <min.ma@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -666,7 +667,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 err1:
 	zocl_fini_sysfs(drm->dev);
 err0:
-	drm_dev_unref(drm);
+	ZOCL_DRM_DEV_PUT(drm);
 	return ret;
 }
 
@@ -693,7 +694,7 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 
 	if (drm) {
 		drm_dev_unregister(drm);
-		drm_dev_unref(drm);
+		ZOCL_DRM_DEV_PUT(drm);
 	}
 
 	return 0;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_ioctl.c
@@ -6,6 +6,7 @@
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
+ *    Jan Stephan  <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -288,7 +289,7 @@ int zocl_pcap_download_ioctl(struct drm_device *dev, void *data,
 
 	buffer = (char __user *)args->xclbin;
 
-	if (!access_ok(VERIFY_READ, buffer, bin_obj.m_length))
+	if (!ZOCL_ACCESS_OK(VERIFY_READ, buffer, bin_obj.m_length))
 		return -EFAULT;
 
 	buffer += primary_fw_off;
@@ -499,7 +500,7 @@ zocl_read_axlf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	}
 
 	xclbin = (char __user *)axlf_obj->xclbin;
-	ret = !access_ok(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
+	ret = !ZOCL_ACCESS_OK(VERIFY_READ, xclbin, axlf_head.m_header.m_length);
 	if (ret) {
 		ret = -EFAULT;
 		goto out0;

--- a/src/runtime_src/driver/zynq/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/driver/zynq/drm/zocl/zocl_sk.c
@@ -6,6 +6,7 @@
  *
  * Authors:
  *    Larry Liu       <yliu@xilinx.com>
+ *    Jan Stephan     <j.stephan@hzdr.de>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -108,7 +109,7 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	sk->sk_cu[cu_idx]->sc_vregs = bo->cma_base.vaddr;
 	sema_init(&sk->sk_cu[cu_idx]->sc_sem, 0);
 
-	drm_gem_object_unreference_unlocked(gem_obj);
+	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 
 	return 0;
 }


### PR DESCRIPTION
Teach XRT 2019.1 about more modern Linux 5.0 so it can work with modern Debian & Ubuntu for example.

This is a cherry pick from master.