### PR TITLE
fix 'download xilinx xclbin file on aws crash' issue

### DIFF
--- a/src/runtime_src/driver/xclng/xrt/user_aws/shim.cpp
+++ b/src/runtime_src/driver/xclng/xrt/user_aws/shim.cpp
@@ -146,6 +146,10 @@ namespace awsbwhal {
           axlf *axlfbuffer = reinterpret_cast<axlf*>(const_cast<xclBin*> (buffer));
           fpga_mgmt_image_info orig_info;
           char* afi_id = get_afi_from_axlf(axlfbuffer);
+
+		  if (!afi_id)
+			  return -EINVAL;
+
           std::memset(&orig_info, 0, sizeof(struct fpga_mgmt_image_info));
           fpga_mgmt_describe_local_image(mBoardNumber, &orig_info, 0);
 


### PR DESCRIPTION
On aws, if we load xilinx xclbin file directly instead of the afi file with awssak, the awssak will crash.
Crash occurs in "fpga_libs/fpga_mgmt/fpga_mgmt_cmd.c"

Void fpga_mgmt_cmd_init_load()
{
strncpy(req->ids.afi_id, opt->afi_id, sizeof(req->ids.afi_id));       <<<<<<< opt->afi_id is nullptr here.
}

(gdb) bt
#0  0x000000000043c1f9 in fpga_mgmt_cmd_init_load ()
#1  0x0000000000437a74 in fpga_mgmt_load_local_image_with_options ()
#2  0x000000000043080f in awsbwhal::AwsXcl::xclLoadXclBin(axlf const*) ()
#3  0x00000000004175d8 in xcldev::device::program(std::string const&, unsigned int) ()
#4  0x00000000004158d5 in xcldev::xclAwssak(int, char**) ()
#5  0x00007ffff6be8495 in __libc_start_main () from /lib64/libc.so.6
#6  0x00000000004137f5 in _start ()

In this case, the afi_id is NULL and aws code should not assume the input afi_id is valid.

We can do a fix in our code -- when the afi_id is NULL, just return with EINVAL.