### PR TITLE
Feature Added: Signing xclbin archives

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -197,7 +197,9 @@ extern "C" {
 
     struct axlf {
         char m_magic[8];                            /* Should be "xclbin2\0"  */
-        unsigned char m_cipher[32];                 /* Hmac output digest */
+        int32_t m_signature_length;                 /* Length of the signature. -1 indicates no signature */
+        unsigned char reserved[28];                 /* Note: Initialized to 0xFFs */
+
         unsigned char m_keyBlock[256];              /* Signature for validation of binary */
         uint64_t m_uniqueId;                        /* axlf's uniqueId, use it to skip redownload etc */
         struct axlf_header m_header;                /* Inline header */

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -72,6 +72,7 @@ RH_LIST=(\
      opencl-headers \
      opencv \
      openssl-devel \
+     openssl-static \
      pciutils \
      perl \
      pkgconfig \
@@ -84,6 +85,7 @@ RH_LIST=(\
      rpm-build \
      strace \
      unzip \
+     zlib-static \
 )
 
 UB_LIST=(\

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(ZLIB REQUIRED)
 find_library(Z_LIB libz.a REQUIRED)
 
 find_library(DL_LIB libdl.a REQUIRED)
+
+find_library(PTHREAD_LIB libpthread.a)
 endif()
 
 # -----------------------------------------------------------------------------
@@ -140,6 +142,7 @@ else()
   target_link_libraries(xclbinutil ${CRYPTO_LIB})
   target_link_libraries(xclbinutil ${Z_LIB})       # OpenSSL supporting library
   target_link_libraries(xclbinutil ${DL_LIB})      # OpenSSL supporting library
+  target_link_libraries(xclbinutil ${PTHREAD_LIB})      # OpenSSL supporting library
   
   # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 
   # was causing the executable to reference 'linux-vdso.so.1' which would then 

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -10,6 +10,10 @@ include_directories(${Boost_INCLUDE_DIRS})
 if(NOT WIN32) 
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
+find_library(CRYPTO_LIB libcrypto.a REQUIRED)
+
+find_package(ZLIB REQUIRED)
+find_library(Z_LIB libz.a REQUIRED)
 
 find_library(DL_LIB libdl.a REQUIRED)
 endif()
@@ -133,10 +137,10 @@ else()
   target_link_libraries(xclbinutil -static ${Boost_LIBRARIES})
   # False warning: /usr/lib/x86_64-linux-gnu/libcrypto.a(dso_dlfcn.o): In function `dlfcn_globallookup':
   #                (.text+0x11): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
-  target_link_libraries(xclbinutil -static OpenSSL::Crypto)
-  target_link_libraries(xclbinutil -static libdl.a)
-
-
+  target_link_libraries(xclbinutil ${CRYPTO_LIB})
+  target_link_libraries(xclbinutil ${Z_LIB})       # OpenSSL supporting library
+  target_link_libraries(xclbinutil ${DL_LIB})      # OpenSSL supporting library
+  
   # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 
   # was causing the executable to reference 'linux-vdso.so.1' which would then 
   # produce "Command not found" when running the executable.
@@ -168,7 +172,8 @@ if (GTEST_FOUND)
   message (STATUS "GTest libraries: '${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread'")
   target_link_libraries(xclbintest ${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread )
   target_link_libraries(xclbintest OpenSSL::Crypto)
-  target_link_libraries(xclbintest ${CMAKE_DL_LIBS})
+  target_link_libraries(xclbintest ${ZLIB_LIBRARIES})     # OpenSSL supporting library
+  target_link_libraries(xclbintest ${CMAKE_DL_LIBS})      # OpenSSL supporting library
 
   message(STATUS "Configuring CMake to run unit test after building")
   set(UNIT_TEST_XCLBINUTIL xclbintest)

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -7,6 +7,13 @@ set(Boost_USE_STATIC_RUNTIME ON)            # This is how the boost libraries we
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
+if(NOT WIN32) 
+set(OPENSSL_USE_STATIC_LIBS TRUE)
+find_package(OpenSSL REQUIRED)
+
+find_library(DL_LIB libdl.a REQUIRED)
+endif()
+
 # -----------------------------------------------------------------------------
 
 include_directories(${CMAKE_BINARY_DIR}/gen)
@@ -96,6 +103,7 @@ file(GLOB XCLBINUTIL_FILES
   "DTCStringsBlock.cxx"
   "FDTNode.cxx"
   "FDTProperty.cxx"
+  "XclBinSignature.cxx"
 )
 set(XCLBINUTIL_FILES_SRCS ${XCLBINUTIL_FILES})
 
@@ -123,6 +131,11 @@ if(WIN32)
   target_compile_options(xclbinutil PRIVATE /DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
 else()
   target_link_libraries(xclbinutil -static ${Boost_LIBRARIES})
+  # False warning: /usr/lib/x86_64-linux-gnu/libcrypto.a(dso_dlfcn.o): In function `dlfcn_globallookup':
+  #                (.text+0x11): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
+  target_link_libraries(xclbinutil -static OpenSSL::Crypto)
+  target_link_libraries(xclbinutil -static libdl.a)
+
 
   # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 
   # was causing the executable to reference 'linux-vdso.so.1' which would then 
@@ -154,6 +167,8 @@ if (GTEST_FOUND)
 
   message (STATUS "GTest libraries: '${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread'")
   target_link_libraries(xclbintest ${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread )
+  target_link_libraries(xclbintest OpenSSL::Crypto)
+  target_link_libraries(xclbintest ${CMAKE_DL_LIBS})
 
   message(STATUS "Configuring CMake to run unit test after building")
   set(UNIT_TEST_XCLBINUTIL xclbintest)

--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -69,9 +69,9 @@ FormattedOutput::getMagicAsString(const axlf &_xclBinHeader) {
 }
 
 std::string 
-FormattedOutput::getCipherAsString(const axlf &_xclBinHeader) { 
+FormattedOutput::getSignatureLengthAsString(const axlf &_xclBinHeader) { 
   std::string sTemp("");
-  XUtil::binaryBufferToHexString((unsigned char*)&_xclBinHeader.m_cipher, sizeof(_xclBinHeader.m_cipher), sTemp);
+  XUtil::binaryBufferToHexString((unsigned char*)&_xclBinHeader.m_signature_length, sizeof(_xclBinHeader.m_signature_length), sTemp);
   return sTemp; // TBD: "0x" + sTemp; ? do the others too...
 }
 

--- a/src/runtime_src/tools/xclbin/FormattedOutput.h
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.h
@@ -41,7 +41,7 @@ namespace FormattedOutput {
   std::string getFeatureRomTimeStampAsString(const axlf &_xclBinHeader);
   std::string getVersionAsString(const axlf &_xclBinHeader);
   std::string getMagicAsString(const axlf &_xclBinHeader);
-  std::string getCipherAsString(const axlf &_xclBinHeader);
+  std::string getSignatureLengthAsString(const axlf &_xclBinHeader);
   std::string getKeyBlockAsString(const axlf &_xclBinHeader);
   std::string getUniqueIdAsString(const axlf &_xclBinHeader);
   std::string getModeAsString(const axlf &_xclBinHeader);

--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -91,7 +91,8 @@ XclBin::initializeHeader(axlf &_xclBinHeader)
 
   std::string sMagic = "xclbin2";
   XUtil::safeStringCopy(_xclBinHeader.m_magic, sMagic, sizeof(_xclBinHeader.m_magic));
-  memset( _xclBinHeader.m_cipher, 0xFF, sizeof(_xclBinHeader.m_cipher) );
+  _xclBinHeader.m_signature_length = -1;  // Initialize to 0xFFs
+  memset( _xclBinHeader.reserved, 0xFF, sizeof(_xclBinHeader.reserved) );
   memset( _xclBinHeader.m_keyBlock, 0xFF, sizeof(_xclBinHeader.m_keyBlock) );
   _xclBinHeader.m_uniqueId = time( nullptr );
   _xclBinHeader.m_header.m_timeStamp = time( nullptr );
@@ -204,7 +205,7 @@ XclBin::addHeaderMirrorData(boost::property_tree::ptree& _pt_header) {
   // Axlf structure
   {
     _pt_header.put("Magic", FormattedOutput::getMagicAsString(m_xclBinHeader).c_str());
-    _pt_header.put("Cipher", FormattedOutput::getCipherAsString(m_xclBinHeader).c_str());
+    _pt_header.put("SignatureLength", FormattedOutput::getSignatureLengthAsString(m_xclBinHeader).c_str());
     _pt_header.put("KeyBlock", FormattedOutput::getKeyBlockAsString(m_xclBinHeader).c_str());
     _pt_header.put("UniqueID", FormattedOutput::getUniqueIdAsString(m_xclBinHeader).c_str());
   }
@@ -506,8 +507,7 @@ XclBin::readXclBinHeader(const boost::property_tree::ptree& _ptHeader,
 
   std::string sMagic = _ptHeader.get<std::string>("Magic");
   XUtil::safeStringCopy((char*)&_axlfHeader.m_magic, sMagic, sizeof(axlf::m_magic));
-  std::string sCipher = _ptHeader.get<std::string>("Cipher");
-  XUtil::hexStringToBinaryBuffer(sCipher, (unsigned char*)&_axlfHeader.m_cipher, sizeof(axlf::m_cipher));
+  _axlfHeader.m_signature_length = _ptHeader.get<int32_t>("SignatureLength", -1);
   std::string sKeyBlock = _ptHeader.get<std::string>("KeyBlock");
   XUtil::hexStringToBinaryBuffer(sKeyBlock, (unsigned char*)&_axlfHeader.m_keyBlock, sizeof(axlf::m_keyBlock));
   _axlfHeader.m_uniqueId = XUtil::stringToUInt64(_ptHeader.get<std::string>("UniqueID"));

--- a/src/runtime_src/tools/xclbin/XclBinSignature.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinSignature.cxx
@@ -17,6 +17,7 @@
 #include "XclBinSignature.h"
 
 #include <iostream>
+#include <vector>
 
 #ifndef _WIN32
   #include <openssl/cms.h>

--- a/src/runtime_src/tools/xclbin/XclBinSignature.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinSignature.cxx
@@ -1,0 +1,344 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "XclBinSignature.h"
+
+#include <iostream>
+
+#ifndef _WIN32
+  #include <openssl/cms.h>
+  #include <openssl/pem.h>
+#endif
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+// Status structure
+typedef struct {
+  bool bIsXclImage;
+  bool bIsSigned;
+  uint64_t actualFileSize;
+  uint64_t headerFileLength;
+  int32_t signatureLength;
+} XclBinImageStats;
+
+
+static void
+getXclBinStats(const std::string& _xclBinFile,
+               XclBinImageStats& _xclBinImageStats) {
+  // Initialize return values
+  _xclBinImageStats = { 0 };
+
+  // Error checks
+  if (_xclBinFile.empty()) {
+    std::string errMsg = "ERROR: Missing xclbin file name to read from.";
+    throw std::runtime_error(errMsg);
+  }
+
+  // Open the file for consumption
+  XUtil::TRACE("Reading xclbin binary file: " + _xclBinFile);
+  std::fstream ifXclBin;
+  ifXclBin.open(_xclBinFile, std::ifstream::in | std::ifstream::binary);
+  if (!ifXclBin.is_open()) {
+    std::string errMsg = "ERROR: Unable to open the file for reading: " + _xclBinFile;
+    throw std::runtime_error(errMsg);
+  }
+
+  // Determine File Size
+  ifXclBin.seekg(0, ifXclBin.end);
+  _xclBinImageStats.actualFileSize = ifXclBin.tellg();
+
+  // Read in the header buffer
+  axlf xclBinHeader;
+  const unsigned int expectBufferSize = sizeof(axlf);
+
+  ifXclBin.seekg(0);
+  ifXclBin.read((char*)&xclBinHeader, sizeof(axlf));
+
+  if (ifXclBin.gcount() != expectBufferSize) {
+    std::string errMsg = "ERROR: xclbin file is smaller than the header size.";
+    throw std::runtime_error(errMsg);
+  }
+
+  std::string sMagicValue = XUtil::format("%s", xclBinHeader.m_magic).c_str();
+  if (sMagicValue.compare("xclbin2") != 0) {
+    std::string errMsg = XUtil::format("ERROR: The XCLBIN appears to be corrupted.  Expected magic value: 'xclbin2', actual: '%s'", sMagicValue.c_str());
+    throw std::runtime_error(errMsg);
+  }
+
+  // We know it is an xclbin archive
+  _xclBinImageStats.bIsXclImage = true;
+
+  // Get signature information
+  if (xclBinHeader.m_signature_length != -1) {
+    _xclBinImageStats.bIsSigned = true;
+    _xclBinImageStats.signatureLength = xclBinHeader.m_signature_length;
+
+    if (xclBinHeader.m_signature_length < -1) {
+      throw std::runtime_error("ERROR: xclbin recorded signature length is corrupted.");
+    }
+  }
+
+  // Get header file length
+  _xclBinImageStats.headerFileLength = xclBinHeader.m_header.m_length;
+
+  // Now do some simple DRC checks
+  uint64_t expectedFileSize = _xclBinImageStats.headerFileLength;
+
+  if (_xclBinImageStats.bIsSigned) {
+    expectedFileSize += _xclBinImageStats.signatureLength;
+  }
+
+  if (expectedFileSize != _xclBinImageStats.actualFileSize) {
+    std::string errMsg = XUtil::format("ERROR: Expected files size (0x%lx) does not match actual (0x%lx)", expectedFileSize, _xclBinImageStats.actualFileSize);
+    throw std::runtime_error(errMsg);
+  }
+
+  // We are done
+  ifXclBin.close();
+}
+
+
+void signXclBinImage(const std::string& _fileOnDisk,
+                     const std::string& _sPrivateKey,
+                     const std::string& _sCertificate)
+// Equivalent openssl command:
+//   openssl cms -md sha512 -nocerts -noattr -sign -signer certificate.cer -inkey private.key -binary -in u50.dts -outform der -out signature.openssl
+#ifdef _WIN32
+{
+  throw std::runtime_error("ERROR: signXclBinImage not implemented on windows");
+}
+#else
+{
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+  std::cout << "Signing the archive file: '" + _fileOnDisk + "'" << std::endl;
+  std::cout << "        Private key file: '" + _sPrivateKey + "'" << std::endl;
+  std::cout << "        Certificate file: '" + _sCertificate + "'" << std::endl;
+
+
+  XUtil::TRACE("SignXclBinImage");
+  XUtil::TRACE("File On Disk: '" + _fileOnDisk + "'");
+  XUtil::TRACE("Private Key: '" + _sPrivateKey + "'");
+  XUtil::TRACE("Certificate: '" + _sCertificate + "'");
+
+  // -- Do some DRC checks on the image
+  // Is the image on disk
+  XclBinImageStats xclBinStats = { 0 };
+  getXclBinStats(_fileOnDisk, xclBinStats);
+
+  if (xclBinStats.bIsSigned == true) {
+    throw std::runtime_error("ERROR: Xclbin image is already signed. File: '" + _fileOnDisk + "'");
+  }
+
+  // *** Calculate the signature **
+
+  std::cout << "Calculating signature..." << std::endl;
+
+  // -- Have openssl point to the xclbin image on disk
+  BIO* bmRead = BIO_new_file(_fileOnDisk.c_str(), "rb");
+
+  if (bmRead == nullptr) {
+    throw std::runtime_error("ERROR: File missing: '" + _fileOnDisk + "'");
+  }
+
+  // -- Read the private key --
+  BIO* bmPrivateKey = BIO_new_file(_sPrivateKey.c_str(), "rb");
+  if (bmPrivateKey == nullptr) {
+    throw std::runtime_error("ERROR: File missing: '" + _sPrivateKey + "'");
+  }
+
+  EVP_PKEY* privateKey = PEM_read_bio_PrivateKey(bmPrivateKey, NULL, NULL, NULL);
+  if (privateKey == nullptr) {
+    throw std::runtime_error("ERROR: Can create private key object.");
+  }
+
+  BIO_free(bmPrivateKey);
+
+  // -- Read the certificate --
+  BIO* bmCertificate = BIO_new_file(_sCertificate.c_str(), "rb");
+  if (bmCertificate == nullptr) {
+    throw std::runtime_error("ERROR: File missing: '" + _sCertificate + "'");
+  }
+
+  X509* x509 = PEM_read_bio_X509(bmCertificate, NULL, NULL, NULL);
+  if (bmCertificate == nullptr) {
+    throw std::runtime_error("ERROR: Can create certificate key object.");
+  }
+
+  BIO_free(bmCertificate);
+
+  // -- Obtain the digest algorithm --
+  OpenSSL_add_all_digests();
+  const EVP_MD* digestAlgorithm = EVP_get_digestbyname("sha512");
+
+  if (digestAlgorithm == nullptr) {
+    throw std::runtime_error("ERROR: Could not obtain the digest algorithm for 'sha512'");
+  }
+
+  // -- Prepare CMS content and signer info --
+  CMS_ContentInfo* cmsContentInfo = CMS_sign(NULL, NULL, NULL, NULL,
+                                             CMS_NOCERTS | CMS_PARTIAL | CMS_BINARY |
+                                             CMS_DETACHED | CMS_STREAM);
+  if (cmsContentInfo == nullptr) {
+    throw std::runtime_error("ERROR: Could not obtain CMS content info");
+  }
+
+  CMS_SignerInfo* cmsSignerInfo = CMS_add1_signer(cmsContentInfo, x509, privateKey, digestAlgorithm,
+                                                  CMS_NOCERTS | CMS_BINARY |
+                                                  CMS_NOSMIMECAP | CMS_NOATTR);
+
+  if (cmsSignerInfo == nullptr) {
+    throw std::runtime_error("ERROR: Could not obtain CMS signer info");
+  }
+
+  // -- We are ready to tie it all together --
+  if (CMS_final(cmsContentInfo, bmRead, NULL, CMS_NOCERTS | CMS_BINARY) < 0) {
+    throw std::runtime_error("ERROR: In finalizing the CMS content.");
+  }
+
+  // We are done close the handles
+  BIO_free(bmRead);
+
+  // -- Get the signature --
+  BIO* bmMem = BIO_new(BIO_s_mem());
+  if (i2d_CMS_bio_stream(bmMem, cmsContentInfo, NULL, 0) < 0) {
+    throw std::runtime_error("ERROR: Writing to the signature.bin to the in-memory buffer");
+  }
+
+  BUF_MEM *bufMem = nullptr;
+  BIO_get_mem_ptr(bmMem, &bufMem);
+  XUtil::TRACE_BUF("Signature", bufMem->data, bufMem->length);
+
+  // ** Now update the xclbin archive image **
+
+  XUtil::TRACE(XUtil::format("Setting the signature length to: 0x%x", bufMem->length).c_str());
+  std::fstream iofXclBin;
+  iofXclBin.open(_fileOnDisk, std::ios::in | std::ios::out | std::ios::binary);
+  if (!iofXclBin.is_open()) {
+    std::string errMsg = "ERROR: Unable to open the file for reading / writing: " + _fileOnDisk;
+    throw std::runtime_error(errMsg);
+  }
+
+  // First the file signature length
+  axlf xclBinHeader = {0};
+  iofXclBin.seekg(0);
+  iofXclBin.read((char*)&xclBinHeader, sizeof(axlf));
+  xclBinHeader.m_signature_length = bufMem->length;
+
+  iofXclBin.seekg(0);
+  iofXclBin.write((char*)&xclBinHeader, sizeof(axlf));
+  
+  // Now add the signature
+  iofXclBin.seekg(0, iofXclBin.end);
+  iofXclBin.write(bufMem->data, bufMem->length);
+
+  // And we are done
+  iofXclBin.close();
+
+  std::cout << "Signature calculated and added successfully to the archive." << std::endl;
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+}
+#endif
+
+
+void verifyXclBinImage(const std::string& _fileOnDisk,
+                       const std::string& _sCertificate)
+
+// Equivalent openssl command:
+// openssl smime -verify -in signature.openssl.small -inform DER -content u50.dts -noverify -certfile certificate.cer -binary > /dev/null
+#ifdef _WIN32
+{
+  throw std::runtime_error("ERROR: verifyXclBinImage not implemented on windows");
+}
+#else
+{
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+  std::cout << "Verifying signature for archive file: '" + _fileOnDisk + "'" << std::endl;
+  std::cout << "                    Certificate file: '" + _sCertificate + "'" << std::endl;
+
+  XUtil::TRACE("SignXclBinImage");
+  XUtil::TRACE("File On Disk: '" + _fileOnDisk + "'");
+  XUtil::TRACE("Certificate: '" + _sCertificate + "'");
+
+  // -- Do some DRC checks on the image
+  // Is the image on disk
+  XclBinImageStats xclBinStats = { 0 };
+  getXclBinStats(_fileOnDisk, xclBinStats);
+
+  if (xclBinStats.bIsSigned == false) {
+    throw std::runtime_error("ERROR: Xclbin image is not signed. File: '" + _fileOnDisk + "'");
+  }
+
+  // ** Read in the memory image **
+  std::cout << "Reading archive file..." << std::endl;
+
+  std::ifstream ifs(_fileOnDisk, std::ios::binary | std::ios::ate);
+  std::ifstream::pos_type pos = ifs.tellg();
+  std::vector<char> memImage(pos);
+  ifs.seekg(0, std::ios::beg);
+  ifs.read(memImage.data(), pos);
+
+  // -- Change the signature length to -1 (since this was its signed value)
+  axlf *pXclBinHeader = (axlf *) memImage.data();
+  pXclBinHeader->m_signature_length = -1;
+
+  // ** Calculate the signature
+
+  std::cout << "Validating signature..." << std::endl;
+
+  BIO *bmImage = BIO_new_mem_buf(memImage.data(), xclBinStats.headerFileLength);
+  BIO *bmSignature = BIO_new_mem_buf((char *)(memImage.data() + xclBinStats.headerFileLength), xclBinStats.signatureLength);
+  
+  // -- Obtain the digest algorithm --
+  OpenSSL_add_all_digests();
+
+  // -- Read the certificate --
+  BIO* bmCertificate = BIO_new_file(_sCertificate.c_str(), "rb");
+  if (bmCertificate == nullptr) {
+    throw std::runtime_error("ERROR: File missing: '" + _sCertificate + "'");
+  }
+
+  X509* x509 = PEM_read_bio_X509(bmCertificate, NULL, NULL, NULL);
+  if (x509 == nullptr) {
+    throw std::runtime_error("ERROR: Can create certificate key object.");
+  }
+
+  BIO_free(bmCertificate);
+
+  // -- Set up trusted CA certificate store --
+  X509_STORE* store = X509_STORE_new();
+
+  if (!X509_STORE_add_cert(store, x509)) {
+    throw std::runtime_error("ERROR: Can't add certificate.");
+  }
+
+  // -- Read in signature --
+  PKCS7* p7 = d2i_PKCS7_bio(bmSignature, NULL);
+  if (p7 == NULL) {
+    throw std::runtime_error("ERROR: P7 is null.");
+  }
+
+  STACK_OF(X509) * ca_stack = sk_X509_new_null();
+  sk_X509_push(ca_stack, x509);
+
+  if (!PKCS7_verify(p7, ca_stack, store, bmImage, NULL, PKCS7_DETACHED |  PKCS7_BINARY | PKCS7_NOINTERN)) {
+    std::cout << "Signed xclbin archive verification failed" << std::endl;
+  } else {
+    std::cout << "Signed xclbin archive verification successful" << std::endl;
+  }
+  std::cout << "----------------------------------------------------------------------" << std::endl;
+}
+#endif

--- a/src/runtime_src/tools/xclbin/XclBinSignature.h
+++ b/src/runtime_src/tools/xclbin/XclBinSignature.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __XclBinSignature_h_
+#define __XclBinSignature_h_
+
+#include <string>
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+
+// ---------------------- F U N C T I O N S ----------------------------------
+
+void signXclBinImage(const std::string & _fileOnDisk, const std::string & _sPrivateKey, const std::string & _sCertificate);
+void verifyXclBinImage(const std::string & _fileOnDisk, const std::string & _sCertificate);
+
+#endif

--- a/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
@@ -21,6 +21,7 @@
 #include "XclBinClass.h"
 #include "ParameterSectionData.h"
 #include "FormattedOutput.h"
+#include "XclBinSignature.h"
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
@@ -102,6 +103,10 @@ int main_(int argc, char** argv) {
   std::string sSignature;
   bool bGetSignature = false;
 
+  std::string sPrivateKey;
+  std::string sCertificate;
+  bool bValidateSignature = false;
+
   std::string sInputFile;
   std::string sOutputFile;
 
@@ -122,6 +127,10 @@ int main_(int argc, char** argv) {
       ("help,h", "Print help messages")
       ("input,i", boost::program_options::value<std::string>(&sInputFile), "Input file name. Reads xclbin into memory.")
       ("output,o", boost::program_options::value<std::string>(&sOutputFile), "Output file name. Writes in memory xclbin image to a file.")
+
+      ("private-key", boost::program_options::value<std::string>(&sPrivateKey), "Private key used in signing the xclbin image.")
+      ("certificate", boost::program_options::value<std::string>(&sCertificate), "Certificate used in signing and validating the xclbin image.")
+      ("validate-signature", boost::program_options::bool_switch(&bValidateSignature), "Validates the signature for the given xclbin archive.")
 
       ("verbose,v", boost::program_options::bool_switch(&bVerbose), "Display verbose/debug information.")
       ("quiet,q", boost::program_options::bool_switch(&bQuiet),     "Minimize reporting information.")
@@ -145,21 +154,6 @@ int main_(int argc, char** argv) {
       ("version", boost::program_options::bool_switch(&bVersion), "Version of this executable.")
       ("force", boost::program_options::bool_switch(&bForce), "Forces a file overwrite.")
  ;
-
-// --remove-section=section
-//    Remove the section matching the section name. Note that using this option inappropriately may make the output file unusable.
-//
-// --dump-section sectionname=filename
-//    Place the contents of section named sectionname into the file filename, overwriting any contents that may have been there previously.
-//    This option is the inverse of --add-section. This option is similar to the --only-section option except that it does not create a formatted file,
-//    it just dumps the contents as raw binary data, without applying any relocations. The option can be specified more than once.
-//
-// --add-section sectionname=filename
-//    Add a new section named sectionname while copying the file. The contents of the new section are taken from the file filename.
-//    The size of the section will be the size of the file. This option only works on file formats which can support sections with arbitrary names.
-//
-// --migrate-forward
-//    Migrates the xclbin forward to the new binary structure using the backup mirror metadata.
 
   // hidden options
   std::vector<std::string> badOptions;
@@ -235,8 +229,6 @@ int main_(int argc, char** argv) {
   }
 
   // Examine the options
-  // TODO: Clean up this flow.  Currently, its flow is that of testing features
-  //       and not how the customer would use it.
   XUtil::setVerbose(bTrace);
 
   if (bVersion) {
@@ -249,7 +241,6 @@ int main_(int argc, char** argv) {
   }
 
   // Actions not requiring --input
-
   if (bListNames) {
     if (argc != 2) {
       std::string errMsg = "ERROR: The '--list-names' argument is a stand alone option.  No other options can be specified with it.";
@@ -259,6 +250,25 @@ int main_(int argc, char** argv) {
     return RC_SUCCESS;
   }
 
+  // Signing DRCs
+  if (bValidateSignature == true) {
+    if (sCertificate.empty()) {
+      throw std::runtime_error("ERROR: Validate signature specified with no certificate defined.");
+    }
+
+    if (sInputFile.empty()) {
+      throw std::runtime_error("ERROR: Validate signature specified with no input file defined.");
+    }
+  }
+
+  if (!sPrivateKey.empty() && sOutputFile.empty()) {
+    throw std::runtime_error("ERROR: Private key specified, but no output file defined.");
+  }
+
+  if (sCertificate.empty() && !sOutputFile.empty() && !sPrivateKey.empty()) {
+    throw std::runtime_error("ERROR: Private key specified, but no certificate defined.");
+  }
+
   // Actions requiring --input
   
   // Check to see if there any file conflicts
@@ -266,6 +276,14 @@ int main_(int argc, char** argv) {
   {
     if (!sInputFile.empty()) {
        inputFiles.push_back(sInputFile);
+    }
+
+    if (!sCertificate.empty()) {
+       inputFiles.push_back(sCertificate);
+    }
+
+    if (!sPrivateKey.empty()) {
+       inputFiles.push_back(sPrivateKey);
     }
 
     for (auto section : sectionsToAdd) {
@@ -298,6 +316,17 @@ int main_(int argc, char** argv) {
 
   drcCheckFiles(inputFiles, outputFiles, bForce);
 
+  if (sOutputFile.empty()) {
+    QUIET("------------------------------------------------------------------------------");
+    QUIET("Warning: The option '--output' has not been specified. All operations will    ");
+    QUIET("         be done in memory with the exception of the '--dump-section' command.");
+    QUIET("------------------------------------------------------------------------------");
+  }
+
+  // Validate signature for the input file
+  if (bValidateSignature == true) {
+    verifyXclBinImage(sInputFile, sCertificate);
+  }
 
   if (!sSignature.empty()) {
     if (sInputFile.empty()) {
@@ -335,13 +364,6 @@ int main_(int argc, char** argv) {
     XUtil::removeSignature(sInputFile, sOutputFile);
     QUIET("Exiting");
     return RC_SUCCESS;
-  }
-
-  if (sOutputFile.empty()) {
-    QUIET("------------------------------------------------------------------------------");
-    QUIET("Warning: The option '--output' has not been specified. All operations will    ");
-    QUIET("         be done in memory with the exception of the '--dump-section' command.");
-    QUIET("------------------------------------------------------------------------------");
   }
 
   XclBin xclBin;
@@ -402,6 +424,10 @@ int main_(int argc, char** argv) {
 
   if (!sOutputFile.empty()) {
     xclBin.writeXclBinBinary(sOutputFile, bSkipUUIDInsertion);
+
+    if (!sPrivateKey.empty() && !sCertificate.empty()) {
+      signXclBinImage(sOutputFile, sPrivateKey, sCertificate);
+    }
   }
 
   if (!sInfoFile.empty()) {

--- a/src/runtime_src/tools/xclbin/xclbincat1.cxx
+++ b/src/runtime_src/tools/xclbin/xclbincat1.cxx
@@ -567,7 +567,8 @@ namespace xclbincat1 {
   {
     const char* magic = "xclbin2\0";
     memcpy( data.getHead().m_magic, magic, sizeof(data.getHead().m_magic) );
-    memset( data.getHead().m_cipher, 0xFF, sizeof(data.getHead().m_cipher) );
+    data.getHead().m_signature_length = -1;
+    memset( data.getHead().reserved, 0xFF, sizeof(data.getHead().reserved) );
     memset( data.getHead().m_keyBlock, 0xFF, sizeof(data.getHead().m_keyBlock) );
     data.getHead().m_uniqueId = time( nullptr );
     data.getHead().m_header.m_timeStamp = time( nullptr );
@@ -683,10 +684,10 @@ namespace xclbincat1 {
       ss.str("");
       ss.clear();
       XclBinUtil::hex2data( ss, (const unsigned char*)value.c_str(), value.size() ); 
-      if ( strcmp( key.c_str(), "cipher" ) == 0 ) {
-        memset( _data.getHead().m_cipher, 0, sizeof(_data.getHead().m_cipher) );
-        ss >> std::hex >> _data.getHead().m_cipher;
-      } else if ( strcmp( key.c_str(), "keyBlock" ) == 0 ) {
+//      if ( strcmp( key.c_str(), "cipher" ) == 0 ) {
+//        memset( _data.getHead().m_cipher, 0, sizeof(_data.getHead().m_cipher) );
+//        ss >> std::hex >> _data.getHead().m_cipher;
+      if ( strcmp( key.c_str(), "keyBlock" ) == 0 ) {
         memset( _data.getHead().m_keyBlock, 0, sizeof(_data.getHead().m_keyBlock) );
         ss >> std::hex >> _data.getHead().m_keyBlock;
       } else if ( strcmp( key.c_str(), "uniqueId" ) == 0 ) {

--- a/src/runtime_src/tools/xclbin/xclbindata.cxx
+++ b/src/runtime_src/tools/xclbin/xclbindata.cxx
@@ -460,9 +460,9 @@ bool
 XclBinData::reportHead() 
 {
   std::cout << "Magic: " << m_xclBinHead.m_magic << "\n";
-  std::cout << "Cipher: ";
-  XclBinUtil::data2hex( std::cout, (const unsigned char*)&m_xclBinHead.m_cipher, sizeof(m_xclBinHead.m_cipher) );
-  std::cout << "\n";
+//  std::cout << "Cipher: ";
+//  XclBinUtil::data2hex( std::cout, (const unsigned char*)&m_xclBinHead.m_cipher, sizeof(m_xclBinHead.m_cipher) );
+//  std::cout << "\n";
   std::cout << "Key Block: ";
   XclBinUtil::data2hex( std::cout, (const unsigned char*)&m_xclBinHead.m_keyBlock, sizeof(m_xclBinHead.m_keyBlock) );
   std::cout << "\n";


### PR DESCRIPTION
Work Done
---------
+ Created C functions to sign and verify the signatures of an xclbin archive using the openssl library
+ Updated xclbinutil to support passing in the private and certificate keys
+ Updated xclbintuil to support verifying a signed xclbin archive
+ Updated cmake scripts to be aware of the openssl library
  - Disabled use of openssl libraries for window builds
+ Replaced unsigned variable 'char axlf.m_cipher[28]' with 'int32_t m_signature_length' and 'char reserved[28]'
+ Updated depricated xclbincat to no longer support setting the axlf.m_cipher value
+ Updated FormattedOutput and XclBinClass classes to be signature aware