### PR TITLE
xclCopyBO enhancements

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2201,11 +2201,7 @@ fini_scheduler_thread(void)
 static inline int
 dma_done(struct sched_cmd *cmd)
 {
-	if (cmd->dma_handle.dma_flags & ZOCL_DMA_DONE) {
-		cmd->dma_handle.dma_flags &= ~ZOCL_DMA_DONE;
-		return true;
-	}
-	return false;
+	return (cmd->dma_handle.dma_flags & ZOCL_DMA_DONE) != 0;
 }
 
 static inline bool

--- a/src/runtime_src/core/edge/drm/zocl/zocl_dma.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_dma.h
@@ -22,9 +22,10 @@
 #include <linux/dmaengine.h>
 #include <linux/dma-mapping.h>
 
-#define ZOCL_DMA_DONE (1 << 0)
+#define ZOCL_DMA_DONE 	(1 << 0)
+#define ZOCL_DMA_ERROR 	(1 << 1)
 
-typedef void (*zocl_dma_complete_cb)(void *arg);
+typedef void (*zocl_dma_complete_cb)(void *arg, int ret);
 
 typedef struct zocl_dma_handle {
 	int		 	dma_flags;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_dma.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_dma.h
@@ -22,8 +22,8 @@
 #include <linux/dmaengine.h>
 #include <linux/dma-mapping.h>
 
-#define ZOCL_DMA_DONE 	(1 << 0)
-#define ZOCL_DMA_ERROR 	(1 << 1)
+#define ZOCL_DMA_DONE	(1 << 0)
+#define ZOCL_DMA_ERROR	(1 << 1)
 
 typedef void (*zocl_dma_complete_cb)(void *arg, int ret);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -199,7 +199,7 @@ static int zocl_pcap_download(struct drm_zocl_dev *zdev,
 {
 	struct fpga_manager *fpga_mgr = zdev->fpga_mgr;
 	XHwIcap_Bit_Header bit_header;
-	struct fpga_image_info *info;
+	struct fpga_image_info *info = NULL;
 	char *buffer = NULL;
 	char *data = NULL;
 	unsigned int i;

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -843,6 +843,15 @@ int xclSyncBO(xclDeviceHandle handle, unsigned int boHandle, xclBOSyncDirection 
   return drv->xclSyncBO(boHandle, dir, size, offset);
 }
 
+int xclCopyBO(xclDeviceHandle handle, unsigned int dst_boHandle,
+            unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)
+{
+  ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+  if (!drv)
+    return -EINVAL;
+  return drv->xclCopyBO(dst_boHandle, src_boHandle, size, dst_offset, src_offset);
+}
+
 int xclExportBO(xclDeviceHandle handle, unsigned int boHandle) {
   //std::cout << "xclExportBO called.. " << handle << std::endl;
   ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);


### PR DESCRIPTION
While I am doing documentation of zocl dma, I think we'd better make the code even clearer for the future linux kernel 5.0x. I think we should handle all possible status and most importantly handle error conditions and return appropriate error. 

Also found that the xclCopyBO needs to be enabled for client.

Found a lint error.