### PR TITLE
Have to use relative path. WORKDIR didn't compatible with EXTERNAL_SRC

### DIFF
--- a/src/platform/recipes-xrt/xrt/xrt_git.bb
+++ b/src/platform/recipes-xrt/xrt/xrt_git.bb
@@ -2,7 +2,7 @@ SUMMARY  = "Xilinx Runtime(XRT) libraries"
 DESCRIPTION = "Xilinx Runtime User Space Libraries and headers"
 
 LICENSE = "GPLv2 & Apache-2.0"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=fa343562af4b9b922b8d7fe7b0b6d000 \
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=fa343562af4b9b922b8d7fe7b0b6d000 \
                     file://runtime_src/core/pcie/driver/linux/xocl/LICENSE;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://runtime_src/core/pcie/linux/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
                     file://runtime_src/core/pcie/tools/xbutil/LICENSE;md5=d273d63619c9aeaf15cdaf76422c4f87"


### PR DESCRIPTION
Revert this change #1750. Because ${WORKDIR} didn't compatible with EXTERNALSRC. We rely on EXTERNALSRC to build from local source code.
The XRT recipe in meta-xilinx repo, for PetaLinux team, would use ${WORKDIR}. Since PetaLinux Yocto hate relative path in a recipe.

Note: The recipe in the XRT repo is the latest. Sometime, when we update the recipe in meta-xilinx repo, we need to take care of this difference.  