### PR TITLE
Xclbin Signing

### DIFF
--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -18,6 +18,9 @@ find_library(Z_LIB libz.a REQUIRED)
 find_library(DL_LIB libdl.a REQUIRED)
 
 find_library(PTHREAD_LIB libpthread.a)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 endif()
 
 # -----------------------------------------------------------------------------
@@ -136,19 +139,43 @@ if(WIN32)
   # when BOOST was released
   target_compile_options(xclbinutil PRIVATE /DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
 else()
-  target_link_libraries(xclbinutil -static ${Boost_LIBRARIES})
-  # False warning: /usr/lib/x86_64-linux-gnu/libcrypto.a(dso_dlfcn.o): In function `dlfcn_globallookup':
-  #                (.text+0x11): warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
-  target_link_libraries(xclbinutil ${CRYPTO_LIB})
-  target_link_libraries(xclbinutil ${Z_LIB})       # OpenSSL supporting library
-  target_link_libraries(xclbinutil ${DL_LIB})      # OpenSSL supporting library
-  target_link_libraries(xclbinutil ${PTHREAD_LIB})      # OpenSSL supporting library
-  
-  # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 
-  # was causing the executable to reference 'linux-vdso.so.1' which would then 
-  # produce "Command not found" when running the executable.
-  #   Therefore, we direct CMake to end with static, so that it doesn't do that:
-  set_target_properties(xclbinutil PROPERTIES LINK_SEARCH_END_STATIC 1)
+
+  # For Ubuntu 18.04 we must link dynamic libraries.  This is because the static
+  # openssl library is linked to a dynamic library :-(
+  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STREQUAL 18.04))
+    # Note: The following Ubuntu 18.04 target results in a execution Segmentation Fault
+    #       due to dynamic library dependencies in the openssl static library.
+    #       
+    #       The offending library is: libdl.so.2
+    #
+    #   target_link_libraries(xclbinutil -static ${Boost_LIBRARIES})
+    #   target_link_libraries(xclbinutil ${CRYPTO_LIB})
+    #   target_link_libraries(xclbinutil ${Z_LIB})       # OpenSSL supporting library
+    #   target_link_libraries(xclbinutil ${DL_LIB})      # OpenSSL supporting library
+    #   target_link_libraries(xclbinutil ${PTHREAD_LIB})      # OpenSSL supporting library
+    #   target_link_libraries(xclbinutil -static-libgcc -static-libstdc++)
+    #   set_target_properties(xclbinutil PROPERTIES LINK_SEARCH_END_STATIC 1)
+
+    # Create an xclbinutil executable that is dependent on shared libraries
+    # Used the linux command 'ldd' to show the shared libraries used by the executable
+    target_link_libraries(xclbinutil ${Boost_LIBRARIES})
+    target_link_libraries(xclbinutil OpenSSL::Crypto)
+    target_link_libraries(xclbinutil -Bstatic ${PTHREAD_LIB})
+    target_link_libraries(xclbinutil ${CMAKE_DL_LIBS})   # Needs to be shared library
+    target_link_libraries(xclbinutil -static-libgcc -static-libstdc++)
+  else()
+    target_link_libraries(xclbinutil -static ${Boost_LIBRARIES})
+    target_link_libraries(xclbinutil ${CRYPTO_LIB})
+    target_link_libraries(xclbinutil ${Z_LIB})            # OpenSSL supporting library
+    target_link_libraries(xclbinutil ${DL_LIB})           # OpenSSL supporting library
+    target_link_libraries(xclbinutil ${PTHREAD_LIB})      # OpenSSL supporting library
+    
+    # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 
+    # was causing the executable to reference 'linux-vdso.so.1' which would then 
+    # produce "Command not found" when running the executable.
+    #   Therefore, we direct CMake to end with static, so that it doesn't do that:
+    set_target_properties(xclbinutil PROPERTIES LINK_SEARCH_END_STATIC 1)
+  endif()
 endif()
 
 install (TARGETS xclbinutil RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)

--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -17,6 +17,7 @@
 #include "FormattedOutput.h"
 #include "Section.h"
 #include "SectionBitstream.h"
+#include "XclBinSignature.h"
 #include  <set>
 
 #include <iostream>
@@ -247,10 +248,25 @@ reportXclbinInfo( std::ostream & _ostream,
                   boost::property_tree::ptree &_ptMetaData,
                   const std::vector<Section*> _sections)
 {
+  std::string sSignatureState;
+
+  // Look for the PKCS signature first
+  if (!_sInputFile.empty()) {
+    try {
+      XclBinPKCSImageStats xclBinPKCSStats = {0};
+      getXclBinPKCSStats(_sInputFile, xclBinPKCSStats);
+  
+      if (xclBinPKCSStats.is_PKCS_signed) {
+        sSignatureState = XUtil::format("Present - Signed PKCS - Offset: 0x%lx, Size: 0x%lx", xclBinPKCSStats.signature_offset, xclBinPKCSStats.signature_size);
+      }
+    } catch (...) {
+      // Do nothing
+    }
+  }
+
   // Calculate if the signature is present or not because this is a slow
-  std::string sSignatureState = "Not Present";
   {
-    if (!_sInputFile.empty()) {
+    if (!_sInputFile.empty() && sSignatureState.empty()) {
       std::fstream inputStream;
       inputStream.open(_sInputFile, std::ifstream::in | std::ifstream::binary);
       if (inputStream.is_open()) {

--- a/src/runtime_src/tools/xclbin/XclBinSignature.h
+++ b/src/runtime_src/tools/xclbin/XclBinSignature.h
@@ -28,7 +28,20 @@
 
 // ---------------------- F U N C T I O N S ----------------------------------
 
-void signXclBinImage(const std::string & _fileOnDisk, const std::string & _sPrivateKey, const std::string & _sCertificate);
-void verifyXclBinImage(const std::string & _fileOnDisk, const std::string & _sCertificate);
+void signXclBinImage(const std::string & _fileOnDisk, const std::string & _sPrivateKey, const std::string & _sCertificate, const std::string & _sDigestAlgorithm, bool _bEnableDebugOutput);
+void verifyXclBinImage(const std::string & _fileOnDisk, const std::string & _sCertificate, bool _bEnableDebugOutput);
+void dumpSignatureFile(const std::string & _fileOnDisk, const std::string & _signatureFile);
+
+// Status structure
+typedef struct {
+  bool is_valid_xclbin_image;
+  bool is_PKCS_signed;
+  uint64_t file_size;
+  uint64_t image_size;
+  uint64_t signature_size;
+  uint64_t signature_offset;
+} XclBinPKCSImageStats;
+
+void getXclBinPKCSStats( const std::string& _xclBinFile, XclBinPKCSImageStats& _xclBinPKCSImageStats);
 
 #endif


### PR DESCRIPTION
Work Done
---------
+ Ubuntu 18.04 - Updated the cmake scripts to enable xclbinutil to use shared libraries.  This was needed since the static library libcrypt.a is dynamically linked to libdl.so.2
+ Updated the signing algorithm to have axlf.m_header.m_length to include the length of the signature.
+ Enhancement: Updated --info to recognize a signed PKCS xclbin archive
+ Enhancement: Added support use to select differ digest algorithms (--digest-algorithm)
+ Debug Enhancement: Added signing debugging support to dump the intermidate images during signing and validating xclbin images (hidden option: --signature-debug)
+ Debug Enhancement: Added support to dump just the binary signature file to disk (hidden option: --dump-signature)
+ Enhancement: Added lots of DRC checks to validate length and process to sign and validate a signature
+ Enhancement: Added DRC checks to prevent the user signing and PKCS options from colliding (only one type will be support at a time)
+ Debug Enhancement: Added more trace support.