### PR TITLE
deprecation msg change

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -142,8 +142,9 @@ int main(int argc, char *argv[])
      * down to xbflash.
      */
     if(std::string( argv[ 1 ] ).compare( "flash" ) == 0) {
-        std::cout << "WARNING: flash sub-command is obsolete. "
-            << "Use xbmgmt flash instead" << std::endl;
+        std::cout << "WARNING: The xbutil sub-command flash has been deprecated. "
+                  << "Please use the xbmgmt utility with flash sub-command for equivalent functionality.\n"
+                  << std::endl;
         // get self path, launch xbflash from self path
         char buf[ PATH_MAX ] = {0};
         auto len = readlink( "/proc/self/exe", buf, PATH_MAX );


### PR DESCRIPTION
CR: Tweak xbutil flash deprecation message

Output:

```
WARNING: The xbutil sub-command flash has been deprecated. Please use the xbmgmt utility with flash sub-command for equivalent functionality.

Card [0000:b3:00.0]
        Card type:              u250
        Flash type:             SPI
        Shell running on FPGA:
                xilinx_u250_xdma_201830_2,[ID=0x000000005d14fbe6],[SC=4.2.0]
        Shell package installed in system:
                xilinx_u250_xdma_201830_2,[ID=0x000000005d14fbe6],[SC=4.2.0]
```
