### PR TITLE
use mrproper to validate and update the petalinux workspace

### DIFF
--- a/src/runtime_src/tools/scripts/ertbuild.sh
+++ b/src/runtime_src/tools/scripts/ertbuild.sh
@@ -207,6 +207,8 @@ else
 	echo ""
 	echo "* petalinux build (INCREMENTAL)"
 	cd $PLATFORM_NAME
+	echo "* petalinux-build mrprope"
+	petalinux-build -x mrproper
 	echo "* petalinux-build (XRT ONLY)"
 	petalinux-build -c xrt
 	echo "* petalinux-build (ZOCL Only)"


### PR DESCRIPTION
PetaLinux yocto team suggest to use 'petalinux-build -x mrproper' before incremental build.