### PR TITLE
add version option to xbutil and xbmgmt and xbutil top -i fix

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_version.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_version.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string>
+#include <version.h>
+#include "xbmgmt.h"
+
+const char *subCmdVersionDesc = "Print out xrt build version";
+const char *subCmdVersionUsage = "(no options supported)";
+
+int versionHandler(int argc, char *argv[])
+{
+    if (argc != 1)
+        return -EINVAL;
+
+    xrt::version::print(std::cout);
+    return 0;
+}

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
@@ -35,6 +35,7 @@ struct subCmd {
 
 static const std::map<std::string, struct subCmd> subCmdList = {
     { "help", {helpHandler, subCmdHelpDesc, subCmdHelpUsage} },
+    { "version", {versionHandler, subCmdVersionDesc, subCmdVersionUsage} },
     { "scan", {scanHandler, subCmdScanDesc, subCmdScanUsage} },
     { "flash", {flashHandler, subCmdFlashDesc, subCmdFlashUsage} },
     { "reset", {resetHandler, subCmdResetDesc, subCmdResetUsage} },

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.h
@@ -33,6 +33,10 @@ int helpHandler(int argc, char *argv[]);
 extern const char *subCmdHelpDesc;
 extern const char *subCmdHelpUsage;
 
+int versionHandler(int argc, char *argv[]);
+extern const char *subCmdVersionDesc;
+extern const char *subCmdVersionUsage;
+
 int scanHandler(int argc, char *argv[]);
 extern const char *subCmdScanDesc;
 extern const char *subCmdScanUsage;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -191,6 +191,10 @@ int main(int argc, char *argv[])
         xcldev::printHelp(exe);
         return 1;
     }
+    if (cmd == xcldev::VERSION) {
+        xrt::version::print(std::cout);
+        return 1;
+    }
 
     argv[0] = const_cast<char *>(exe);
     static struct option long_options[] = {
@@ -627,6 +631,7 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "  dump\n";
     std::cout << "  help\n";
     std::cout << "  m2mtest\n";
+    std::cout << "  version\n";
     std::cout << "  mem --read [-d card] [-a [0x]start_addr] [-i size_bytes] [-o output filename]\n";
     std::cout << "  mem --write [-d card] [-a [0x]start_addr] [-i size_bytes] [-e pattern_byte]\n";
     std::cout << "  program [-d card] [-r region] -p xclbin\n";
@@ -799,6 +804,8 @@ int xcldev::xclTop(int argc, char *argv[])
         switch (c) {
         case 'i':
             interval = std::atoi(optarg);
+            if (interval < 1)
+                interval = 1;
             break;
         case 'd': {
             int ret = str2index(optarg, index);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -77,7 +77,8 @@ enum command {
     DD,
     STATUS,
     CMD_MAX,
-    M2MTEST
+    M2MTEST, 
+    VERSION
 };
 enum subcommand {
     MEM_READ = 0,
@@ -117,7 +118,8 @@ static const std::pair<std::string, command> map_pairs[] = {
     std::make_pair("mem", MEM),
     std::make_pair("dd", DD),
     std::make_pair("status", STATUS),
-    std::make_pair("m2mtest", M2MTEST)
+    std::make_pair("m2mtest", M2MTEST),
+    std::make_pair("version", VERSION)
 
 };
 


### PR DESCRIPTION
CR1:
added version option to xbutil and xbmgmt

CR2:
xbutil top doesn't crash when the interval <1. If the user gives a value <1, the interval is set to 1. 