### PR TITLE
xbutil p2p --enable does not report failure

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -645,10 +645,8 @@ int shim::p2pEnable(bool enable, bool force)
 
     int p2p_enable = EINVAL;
     mDev->sysfs_get("", "p2p_enable", err, p2p_enable);
-    if (p2p_enable < 0)
-        return p2p_enable;
 
-    return 0;
+    return p2p_enable;
 }
 
 /*

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1483,6 +1483,8 @@ int xcldev::xclP2p(int argc, char *argv[])
         std::cout << "Please check BIOS settings" << std::endl;
     } else if (ret == EBUSY) {
         std::cout << "ERROR: P2P is enabled. But there is not enough iomem space, please warm reboot." << std::endl;
+    } else if (ret == ENXIO) {
+        std::cout << "ERROR: P2P is not supported on this platform" << std::endl;
     } else if (ret)
         std::cout << "ERROR: " << strerror(ret) << std::endl;
 


### PR DESCRIPTION
xbutil p2p --enable
ERROR: P2P is enabled. But there is not enough iomem space, please warm reboot.
xbutil p2p --enable
ERROR: P2P is enabled. But there is not enough iomem space, please warm reboot.
reboot
xbutil p2p --enable
xbutil query
....
PCIe DMA chan(bidir) MIG Calibrated P2P Enabled 
GEN 3x16 2 true true 
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~