### PR TITLE
Transfer Rate calculations using AXI Times instead of CU times

### DIFF
--- a/src/runtime_src/core/include/xclperf.h
+++ b/src/runtime_src/core/include/xclperf.h
@@ -382,6 +382,8 @@ typedef struct {
   unsigned long long ReadLatency[XAIM_MAX_NUMBER_SLOTS];
   unsigned short     ReadMinLatency[XAIM_MAX_NUMBER_SLOTS];
   unsigned short     ReadMaxLatency[XAIM_MAX_NUMBER_SLOTS];
+  unsigned long long ReadBusyCycles[XAIM_MAX_NUMBER_SLOTS];
+  unsigned long long WriteBusyCycles[XAIM_MAX_NUMBER_SLOTS];
   // Accelerator Monitor
   unsigned long long CuExecCount[XAM_MAX_NUMBER_SLOTS];
   unsigned long long CuExecCycles[XAM_MAX_NUMBER_SLOTS];

--- a/src/runtime_src/xdp/profile/collection/counters.cpp
+++ b/src/runtime_src/xdp/profile/collection/counters.cpp
@@ -512,13 +512,13 @@ namespace xdp {
 
   void ProfileCounters::writeKernelTransferSummary(ProfileWriterI* writer, std::string& deviceName,
       std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
-      bool isRead, uint64_t totalBytes, uint64_t totalTranx, double totalKernelTimeMsec,
-	  double totalTransferTimeMsec, double maxTransferRateMBps) const
+    bool isRead, uint64_t totalBytes, uint64_t totalTranx, double totalTxTimeMsec,
+    double totalTxLatencyMsec, double maxTransferRateMBps) const
   {
     std::string transferType = (isRead) ? "READ" : "WRITE";
 
     writer->writeKernelTransferSummary(deviceName, cuPortName, argNames, memoryName, transferType,
-    	totalBytes, totalTranx, totalKernelTimeMsec, totalTransferTimeMsec, maxTransferRateMBps);
+      totalBytes, totalTranx, totalTxTimeMsec, totalTxLatencyMsec, maxTransferRateMBps);
   }
 
   void ProfileCounters::writeTopKernelTransferSummary(

--- a/src/runtime_src/xdp/profile/collection/counters.h
+++ b/src/runtime_src/xdp/profile/collection/counters.h
@@ -113,9 +113,9 @@ namespace xdp {
         uint64_t totalTranx, double totalLatencyNsec, double totalTimeMsec,
         double maxTransferRateMBps) const;
     void writeKernelTransferSummary(ProfileWriterI* writer, std::string& deviceName,
-    	std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
-    	bool isRead, uint64_t totalBytes, uint64_t totalTranx, double totalKernelTimeMsec,
-        double totalTransferTimeMsec, double maxTransferRateMBps) const;
+      std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
+      bool isRead, uint64_t totalBytes, uint64_t totalTranx, double totalTxTimeMsec,
+      double totalTxLatencyMsec, double maxTransferRateMBps) const;
     void writeDeviceTransferSummary(ProfileWriterI* writer, bool isRead) const;
 
     void writeAcceleratorSummary(ProfileWriterI* writer) const;

--- a/src/runtime_src/xdp/profile/core/rt_util.cpp
+++ b/src/runtime_src/xdp/profile/core/rt_util.cpp
@@ -246,32 +246,4 @@ namespace xdp {
     return 8192;
   }
 
-  // Convert decimal to binary string of length bits
-  std::string RTUtil::dec2bin(uint32_t n, unsigned int bits) {
-    unsigned int index = bits;
-    std::string result(index, 0);
-
-    do result[ --index ] = '0' + (n & 1);
-    while (n >>= 1);
-
-    for (int i=index-1; i >= 0; --i)
-      result[i] = '0';
-
-    return result;
-  }
-  // Convert decimal to binary string
-  // NOTE: length of string is always sizeof(uint32_t) * 8
-  std::string RTUtil::dec2bin(uint32_t n) {
-    uint32_t index = sizeof(uint32_t) * 8;
-    std::string result(index, 0);
-
-    do result[ --index ] = '0' + (n & 1);
-    while (n >>= 1);
-
-    for (int i=index-1; i >= 0; --i)
-      result[i] = '0';
-
-    return result;
-  }
-
 } // xdp

--- a/src/runtime_src/xdp/profile/core/rt_util.h
+++ b/src/runtime_src/xdp/profile/core/rt_util.h
@@ -115,8 +115,6 @@ namespace xdp {
         long long queueAddress);
     static void getFlowModeName(e_flow_mode flowMode, std::string& str);
     static uint32_t getDevTraceBufferSize(uint32_t property);
-    static std::string dec2bin(uint32_t n);
-    static std::string dec2bin(uint32_t n, unsigned int bits);
 
   };
 

--- a/src/runtime_src/xdp/profile/core/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/core/summary_writer.cpp
@@ -310,6 +310,10 @@ namespace xdp {
 
     double totalReadTimeMsec  = 0;
     double totalWriteTimeMsec = 0;
+
+    /** Old way of calculating bandwidth is not compatible with AIM hw registers
+     * We show N/A in Summary if these registers are absent
+
     if (monitorType == RTUtil::MON_SHELL_KDMA) {
       totalReadTimeMsec  += mProfileCounters->getBufferTransferTotalTime(RTUtil::COPY_BUFFER);
       totalWriteTimeMsec += mProfileCounters->getBufferTransferTotalTime(RTUtil::COPY_BUFFER);
@@ -324,6 +328,8 @@ namespace xdp {
       totalReadTimeMsec  += mProfileCounters->getBufferTransferTotalTime(RTUtil::READ_BUFFER);
       totalWriteTimeMsec += mProfileCounters->getBufferTransferTotalTime(RTUtil::WRITE_BUFFER);
     }
+
+    */
 
     //
     // Shell monitors: KDMA/XDMA/P2P
@@ -390,13 +396,8 @@ namespace xdp {
 
       double totalReadLatencyNsec  = (1000.0 * totalReadLatency)  / tp->getDeviceClockFreqMHz();
       double totalWriteLatencyNsec = (1000.0 * totalWriteLatency) / tp->getDeviceClockFreqMHz();
-      // Use data from device if present
-      if (totalReadBusyCycles) {
-        totalReadTimeMsec = totalReadBusyCycles / (1000.0 * tp->getDeviceClockFreqMHz());
-      }
-      if (totalWriteBusyCycles) {
-        totalWriteTimeMsec = totalWriteBusyCycles / (1000.0 * tp->getDeviceClockFreqMHz());
-      }
+      totalReadTimeMsec = totalReadBusyCycles / (1000.0 * tp->getDeviceClockFreqMHz());
+      totalWriteTimeMsec = totalWriteBusyCycles / (1000.0 * tp->getDeviceClockFreqMHz());
 
       // Monitoring of KDMA/XDMA/P2P is reported on per-device basis
       // NOTE: don't show if no transfers were recorded

--- a/src/runtime_src/xdp/profile/device/aim.cpp
+++ b/src/runtime_src/xdp/profile/device/aim.cpp
@@ -51,6 +51,8 @@
 #define XAIM_SAMPLE_LAST_WRITE_DATA_OFFSET           0xA8
 #define XAIM_SAMPLE_LAST_READ_ADDRESS_OFFSET         0xAC
 #define XAIM_SAMPLE_LAST_READ_DATA_OFFSET            0xB0
+#define XAIM_SAMPLE_READ_BUSY_CYCLES_OFFSET          0xB4
+#define XAIM_SAMPLE_WRITE_BUSY_CYCLES_OFFSET         0xB8
 #define XAIM_SAMPLE_WRITE_BYTES_UPPER_OFFSET         0xC0
 #define XAIM_SAMPLE_WRITE_TRANX_UPPER_OFFSET         0xC4
 #define XAIM_SAMPLE_WRITE_LATENCY_UPPER_OFFSET       0xC8
@@ -64,6 +66,8 @@
 #define XAIM_SAMPLE_LAST_WRITE_DATA_UPPER_OFFSET     0xE8
 #define XAIM_SAMPLE_LAST_READ_ADDRESS_UPPER_OFFSET   0xEC
 #define XAIM_SAMPLE_LAST_READ_DATA_UPPER_OFFSET      0xF0
+#define XAIM_SAMPLE_READ_BUSY_CYCLES_UPPER_OFFSET    0xF4
+#define XAIM_SAMPLE_WRITE_BUSY_CYCLES_UPPER_OFFSET   0xF8
 
 /* SPM Control Register masks */
 #define XAIM_CR_RESET_ON_SAMPLE_MASK             0x00000010
@@ -163,23 +167,29 @@ size_t AIM::readCounter(xclCounterResults& counterResults, uint32_t s /*index*/)
     size += read(XAIM_SAMPLE_READ_BYTES_OFFSET, 4, &counterResults.ReadBytes[s]);
     size += read(XAIM_SAMPLE_READ_TRANX_OFFSET, 4, &counterResults.ReadTranx[s]);
     size += read(XAIM_SAMPLE_READ_LATENCY_OFFSET, 4, &counterResults.ReadLatency[s]);
+    size += read(XAIM_SAMPLE_READ_BUSY_CYCLES_OFFSET, 4, &counterResults.ReadBusyCycles[s]);
+    size += read(XAIM_SAMPLE_WRITE_BUSY_CYCLES_OFFSET, 4, &counterResults.WriteBusyCycles[s]);
 
     // Read upper 32 bits (if available)
     if(has64bit()) {
-        uint64_t upper[6] = {};
+        uint64_t upper[8] = {};
         size += read(XAIM_SAMPLE_WRITE_BYTES_UPPER_OFFSET, 4, &upper[0]);
         size += read(XAIM_SAMPLE_WRITE_TRANX_UPPER_OFFSET, 4, &upper[1]);
         size += read(XAIM_SAMPLE_WRITE_LATENCY_UPPER_OFFSET, 4, &upper[2]);
         size += read(XAIM_SAMPLE_READ_BYTES_UPPER_OFFSET, 4, &upper[3]);
         size += read(XAIM_SAMPLE_READ_TRANX_UPPER_OFFSET, 4, &upper[4]);
         size += read(XAIM_SAMPLE_READ_LATENCY_UPPER_OFFSET, 4, &upper[5]);
+        size += read(XAIM_SAMPLE_READ_BUSY_CYCLES_UPPER_OFFSET, 4, &upper[6]);
+        size += read(XAIM_SAMPLE_WRITE_BUSY_CYCLES_UPPER_OFFSET, 4, &upper[7]);
 
-        counterResults.WriteBytes[s]   += (upper[0] << 32);
-        counterResults.WriteTranx[s]   += (upper[1] << 32);
-        counterResults.WriteLatency[s] += (upper[2] << 32);
-        counterResults.ReadBytes[s]    += (upper[3] << 32);
-        counterResults.ReadTranx[s]    += (upper[4] << 32);
-        counterResults.ReadLatency[s]  += (upper[5] << 32);
+        counterResults.WriteBytes[s]      += (upper[0] << 32);
+        counterResults.WriteTranx[s]      += (upper[1] << 32);
+        counterResults.WriteLatency[s]    += (upper[2] << 32);
+        counterResults.ReadBytes[s]       += (upper[3] << 32);
+        counterResults.ReadTranx[s]       += (upper[4] << 32);
+        counterResults.ReadLatency[s]     += (upper[5] << 32);
+        counterResults.ReadBusyCycles[s]  += (upper[6] << 32);
+        counterResults.WriteBusyCycles[s] += (upper[7] << 32);
 
         if(out_stream) {
           (*out_stream) << "AXI Interface Monitor Upper 32, slot " << s << std::endl
@@ -188,7 +198,9 @@ size_t AIM::readCounter(xclCounterResults& counterResults, uint32_t s /*index*/)
                         << "  WriteLatency : " << upper[2] << std::endl
                         << "  ReadBytes : " << upper[3] << std::endl
                         << "  ReadTranx : " << upper[4] << std::endl
-                        << "  ReadLatency : " << upper[5] << std::endl;
+                        << "  ReadLatency : " << upper[5] << std::endl
+                        << "  ReadBusyCycles : " << upper[6] << std::endl
+                        << "  WriteBusyCycles : " << upper[7] << std::endl;
         }
     }
 
@@ -200,7 +212,9 @@ size_t AIM::readCounter(xclCounterResults& counterResults, uint32_t s /*index*/)
                       << "Reading AXI Interface Monitor... WriteLatency : " << counterResults.WriteLatency[s] << std::endl
                       << "Reading AXI Interface Monitor... ReadBytes : " << counterResults.ReadBytes[s] << std::endl
                       << "Reading AXI Interface Monitor... ReadTranx : " << counterResults.ReadTranx[s] << std::endl
-                      << "Reading AXI Interface Monitor... ReadLatency : " << counterResults.ReadLatency[s] << std::endl;
+                      << "Reading AXI Interface Monitor... ReadLatency : " << counterResults.ReadLatency[s] << std::endl
+                      << "Reading AXI Interface Monitor... ReadBusyCycles : " << counterResults.ReadBusyCycles[s] << std::endl
+                      << "Reading AXI Interface Monitor... WriteBusyCycles : " << counterResults.WriteBusyCycles[s] << std::endl;
     }
 
     return size;

--- a/src/runtime_src/xdp/profile/device/aim.cpp
+++ b/src/runtime_src/xdp/profile/device/aim.cpp
@@ -82,6 +82,7 @@
 
 
 #include "aim.h"
+#include <bitset>
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/device/am.cpp
+++ b/src/runtime_src/xdp/profile/device/am.cpp
@@ -52,7 +52,7 @@
 
 
 #include "am.h"
-
+#include <bitset>
 
 namespace xdp {
 
@@ -255,7 +255,7 @@ bool AM::has64bit() const
 
 bool AM::hasDataflow() const
 {
-    return ((compareVersion(1, 1) < 0) ? true : false);
+    return ((compareVersion(1, 0) <= 0) ? true : false);
 }
 
 bool AM::hasStall() const

--- a/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
@@ -41,6 +41,7 @@
 
 #include<iomanip>
 #include<cstring>
+#include <bitset>
 
 #include "core/common/memalign.h"
 #include "xdp/profile/core/rt_util.h"
@@ -330,8 +331,9 @@ void TraceFifoFull::processTraceData(xclTraceResultsVector& traceVector,uint32_t
       traceVector.mArray[i - clockWordIndex + 1] = results;   // save result
 
       if(out_stream) {
+        auto packet_dec = std::bitset<64>(currentSample).to_string();
         (*out_stream) << "  Trace sample " << std::dec << std::setw(5) << i << ": "
-                      << RTUtil::dec2bin(uint32_t(currentSample>>32)) << " " << RTUtil::dec2bin(uint32_t(currentSample&0xFFFFFFFF))
+                      <<  packet_dec.substr(0,19) << " : " << packet_dec.substr(19)
                       << std::endl
                       << " Timestamp : " << results.Timestamp << "   "
                       << "Event Type : " << results.EventType << "   "

--- a/src/runtime_src/xdp/profile/device/traceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/traceS2MM.cpp
@@ -17,6 +17,7 @@
 #include "traceS2MM.h"
 #include "tracedefs.h"
 #include "xdp/profile/core/rt_util.h"
+#include <bitset>
 
 namespace xdp {
 
@@ -163,12 +164,12 @@ inline void TraceS2MM::parsePacket(uint64_t packet, uint64_t firstTimestamp, xcl
     result.EventID = XCL_PERF_MON_HW_EVENT;
     result.EventFlags = ((packet >> 45) & 0xF) | ((packet >> 57) & 0x10);
     result.isClockTrain = false;
-
     if (out_stream) {
-    static uint64_t previousTimestamp = 0;
-    (*out_stream) << std::dec << std::setw(5)
+      static uint64_t previousTimestamp = 0;
+      auto packet_dec = std::bitset<64>(packet).to_string();
+      (*out_stream) << std::dec << std::setw(5)
         << "  Trace sample " << ": "
-        << RTUtil::dec2bin(uint32_t(packet>>32)) << " " << RTUtil::dec2bin(uint32_t(packet&0xFFFFFFFF)) << std::endl
+        <<  packet_dec.substr(0,19) << " : " << packet_dec.substr(19) << std::endl
         << " Timestamp : " << result.Timestamp << "   "
         << "Type : " << result.EventType << "   "
         << "ID : " << result.TraceID << "   "

--- a/src/runtime_src/xdp/profile/device/trace_parser.cpp
+++ b/src/runtime_src/xdp/profile/device/trace_parser.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <iomanip>
 #include <chrono>
+#include <bitset>
 
 #define getBit(word, bit) (((word) >> bit) & 0x1)
 
@@ -445,7 +446,7 @@ namespace xdp {
         s = trace.TraceID / 2;
         flags = trace.EventFlags;
         XDP_LOG("[profile_device] slot %d event flags = %s @ timestamp %d\n",
-              s, RTUtil::dec2bin(flags, 7).c_str(), timestamp);
+              s, std::bitset<8>(flags).to_string().c_str(), timestamp);
         
         // Write start
         if (getBit(flags, XAPM_WRITE_FIRST)) {

--- a/src/runtime_src/xdp/profile/writer/base_profile.cpp
+++ b/src/runtime_src/xdp/profile/writer/base_profile.cpp
@@ -295,33 +295,20 @@ namespace xdp {
   void ProfileWriterI::writeKernelTransferSummary(const std::string& deviceName,
       const std::string& cuPortName, const std::string& argNames, const std::string& memoryName,
 	  const std::string& transferType, uint64_t totalBytes, uint64_t totalTranx,
-	  double totalKernelTimeMsec, double totalTransferTimeMsec, double maxTransferRateMBps)
+	  double totalTxTimeMsec, double totalTxLatencyMsec, double maxTransferRateMBps)
   {
-    //double aveTimeMsec = stats.getAveTime();
-    double aveTimeMsec = (totalTranx == 0) ? 0.0 : totalTransferTimeMsec / totalTranx;
-
-    // Get min/average/max bytes per transaction
-    // NOTE: to remove the dependency on trace, we calculate it based on counter values
-    //       also, v1.1 of Alpha Data DSA has incorrect AXI lengths so these will always be 16K
-#if 0
-    double minBytes = (double)(stats.getMin());
-    double aveBytes = (double)(stats.getAverage());
-    double maxBytes = (double)(stats.getMax());
-#else
+    double aveLatencyMsec = (totalTranx == 0) ? 0.0 : totalTxLatencyMsec / totalTranx;
     double aveBytes = (totalTranx == 0) ? 0.0 : (double)(totalBytes) / totalTranx;
-    //double minBytes = aveBytes;
-    //double maxBytes = aveBytes;
-#endif
 
-    double transferRateMBps = (totalKernelTimeMsec == 0) ? 0.0 :
-        totalBytes / (1000.0 * totalKernelTimeMsec);
+    double transferRateMBps = (totalTxTimeMsec == 0) ? 0.0 :
+        totalBytes / (1000.0 * totalTxTimeMsec);
     double aveBWUtil = (100.0 * transferRateMBps) / maxTransferRateMBps;
     if (aveBWUtil > 100.0)
       aveBWUtil = 100.0;
 
     if (aveBWUtil > 0) {
       XDP_LOG("Kernel %s: Transfered %u bytes in %.3f msec (device: %s)\n",
-          transferType.c_str(), totalBytes, totalKernelTimeMsec, deviceName.c_str());
+          transferType.c_str(), totalBytes, totalTxTimeMsec, deviceName.c_str());
       XDP_LOG("  AveBWUtil = %.3f = %.3f / %.3f\n",
           aveBWUtil, transferRateMBps, maxTransferRateMBps);
     }
@@ -338,7 +325,7 @@ namespace xdp {
     writeTableRowStart(getStream());
     writeTableCells(getStream(), deviceName, cuPortName2, argNames, memoryName2,
     	transferType, totalTranx, transferRateMBps, aveBWUtil,
-        aveBytes/1000.0, 1.0e6*aveTimeMsec);
+        aveBytes/1000.0, 1.0e6*aveLatencyMsec);
 
     writeTableRowEnd(getStream());
   }

--- a/src/runtime_src/xdp/profile/writer/base_profile.cpp
+++ b/src/runtime_src/xdp/profile/writer/base_profile.cpp
@@ -340,8 +340,7 @@ namespace xdp {
       double totalWriteTimeMsec, double totalReadTimeMsec,
       uint32_t maxBytesPerTransfer, double maxTransferRateMBps)
   {
-    double totalTimeMsec = (totalWriteTimeMsec > totalReadTimeMsec) ?
-        totalWriteTimeMsec : totalReadTimeMsec;
+    double totalTimeMsec = totalWriteTimeMsec + totalReadTimeMsec;
 
     double transferRateMBps = (totalTimeMsec == 0) ? 0.0 :
         (double)(totalReadBytes + totalWriteBytes) / (1000.0 * totalTimeMsec);


### PR DESCRIPTION
I have chosen to not make this change compatible with previous time calculation. So if AXI times are missing, then transfer rate is **not**  calculated using CU times. This was done to avoid confusion as both transfer rates are different by a magnitude and aren't even comparable.