### PR TITLE
Fix xclbinutil for Ubuntu 19.04

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -65,7 +65,7 @@ INCLUDE (FindBoost)
 # link errors when XRT shared objects try to link with it.
 
 # Static linking with Boost is enabled on Ubuntu 18.04 and later versions.
-if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STRGREATER_EQUAL 18.04))
+if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} VERSION_GREATER 17.10))
    set(Boost_USE_STATIC_LIBS  ON)
 endif()
 

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -65,7 +65,7 @@ INCLUDE (FindBoost)
 # link errors when XRT shared objects try to link with it.
 
 # Static linking with Boost is enabled on Ubuntu 18.04 and later versions.
-if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND ((${LINUX_VERSION} STREQUAL 18.04) OR (${LINUX_VERSION} STREQUAL 19.04)))
+if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STRGREATER_EQUAL 18.04))
    set(Boost_USE_STATIC_LIBS  ON)
 endif()
 

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -64,8 +64,8 @@ INCLUDE (FindBoost)
 # On older systems libboost_system.a is not compiled with -fPIC which leads to
 # link errors when XRT shared objects try to link with it.
 
-# Static linking with Boost is enabled on Ubuntu 18.04.
-if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STREQUAL 18.04))
+# Static linking with Boost is enabled on Ubuntu 18.04 and later versions.
+if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND ((${LINUX_VERSION} STREQUAL 18.04) OR (${LINUX_VERSION} STREQUAL 19.04)))
    set(Boost_USE_STATIC_LIBS  ON)
 endif()
 

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -143,7 +143,7 @@ else()
 
   # For Ubuntu 18.04 and later versions we must link dynamic libraries.  This is because the static
   # openssl library is linked to a dynamic library :-(
-  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STRGREATER_EQUAL 18.04))
+  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} VERSION_GREATER 17.10))
     # Note: The following Ubuntu 18.04 target results in a execution Segmentation Fault
     #       due to dynamic library dependencies in the openssl static library.
     #       

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -143,7 +143,7 @@ else()
 
   # For Ubuntu 18.04 and later versions we must link dynamic libraries.  This is because the static
   # openssl library is linked to a dynamic library :-(
-  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND ((${LINUX_VERSION} STREQUAL 18.04) OR (${LINUX_VERSION} STREQUAL 19.04)))
+  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STRGREATER_EQUAL 18.04))
     # Note: The following Ubuntu 18.04 target results in a execution Segmentation Fault
     #       due to dynamic library dependencies in the openssl static library.
     #       

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -141,9 +141,9 @@ if(WIN32)
   target_compile_options(xclbinutil PRIVATE /DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
 else()
 
-  # For Ubuntu 18.04 we must link dynamic libraries.  This is because the static
+  # For Ubuntu 18.04 and later versions we must link dynamic libraries.  This is because the static
   # openssl library is linked to a dynamic library :-(
-  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STREQUAL 18.04))
+  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND ((${LINUX_VERSION} STREQUAL 18.04) OR (${LINUX_VERSION} STREQUAL 19.04)))
     # Note: The following Ubuntu 18.04 target results in a execution Segmentation Fault
     #       due to dynamic library dependencies in the openssl static library.
     #       


### PR DESCRIPTION
The compilation changes introduced for Ubuntu 18.04 need to be applied to Ubuntu 19.04 as well, otherwise `xclbinutil` will fail with a segmentation fault. I didn't include Ubuntu 18.10 since that version is no longer supported by Canonical.