### PR TITLE
disable zcu102ng platform specific dtsi

### DIFF
--- a/src/platform/zcu102ng/config.sh
+++ b/src/platform/zcu102ng/config.sh
@@ -68,9 +68,11 @@ config_dts()
 	GLOB_DTS=${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts
 	echo "cat ${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts >> recipes-bsp/device-tree/files/system-user.dtsi"
 	cat ${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts >> recipes-bsp/device-tree/files/system-user.dtsi
+
 	# Attach platform special device tree node
-	echo "cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_fragment.dts >> $DTS_FILE"
-	cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_fragment.dts >> $DTS_FILE
+	# If you wants to add device tree node for your platform. This is the recommented way.
+	#echo "cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_fragment.dts >> $DTS_FILE"
+	#cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_fragment.dts >> $DTS_FILE
 }
 
 # The first argument is the rootfs configure file


### PR DESCRIPTION
This  zcu102ng platform specific dts file has conflict with BSP flow.
Keep this as comment since it could hint someone who wants to use template flow and add his own device tree node.

NOTE: After this change, if you use template flow to build zcu102ng platform, the ethernet and SD card slot would not work.