### PR TITLE
zcu102_base: Add BOOT.bin to platform

### DIFF
--- a/src/platform/zcu102_base/config.sh
+++ b/src/platform/zcu102_base/config.sh
@@ -117,19 +117,12 @@ post_build_hook()
 {
 	PETA_DIR=$1
 	PLATFORM_NAME=`basename ${PETA_DIR}`
-	ORIGINAL_DIR=`pwd`
-
-	mkdir ${PETA_DIR}/tmp
-	unzip -q ${XRT_REPO_DIR}/src/runtime_src/tools/scripts/xsa_build/${PLATFORM_NAME}/${PLATFORM_NAME}.xsa -d ${PETA_DIR}/tmp
-
-	cd $PETA_DIR
 	echo "create boot.bin in `pwd`"
 
-	petalinux-package --boot --fsbl ${PETA_DIR}/images/linux/zynqmp_fsbl.elf --fpga ${PETA_DIR}/tmp/${PLATFORM_NAME}.bit --u-boot ${PETA_DIR}/images/linux/u-boot.elf --pmufw ${PETA_DIR}/images/linux/pmufw.elf --atf ${PETA_DIR}/images/linux/bl31.elf
-	cd $ORIGINAL_DIR
+	cd $PETA_DIR
 
-	rm -rf ${PETA_DIR}/tmp
+	petalinux-package --boot --fsbl ${PETA_DIR}/images/linux/zynqmp_fsbl.elf --fpga ${PETA_DIR}/project-spec/hw-description/${PLATFORM_NAME}.bit --u-boot ${PETA_DIR}/images/linux/u-boot.elf --pmufw ${PETA_DIR}/images/linux/pmufw.elf --atf ${PETA_DIR}/images/linux/bl31.elf
 
-	cp -f ${PETA_DIR}/images/linux/BOOT.BIN ${XRT_REPO_DIR}/src/runtime_src/tools/scripts/xsa_build/${PLATFORM_NAME}/src/${CPU_ARCH}//xrt/image/
+	cp -f ${PETA_DIR}/images/linux/BOOT.BIN ${THIS_CONFIG_SCRIPT_DIR}/src/${CPU_ARCH}/xrt/image/
 }
 

--- a/src/platform/zcu102_base/config.sh
+++ b/src/platform/zcu102_base/config.sh
@@ -113,9 +113,23 @@ pre_build_hook()
 # The first argument is the petalinux project path
 #  post_build_hook <PETALINUX_PROJECT_DIR>
 #
-#post_build_hook()
-#{
-#	PETA_DIR=$1
-#	# Nothing needs to do
-#}
+post_build_hook()
+{
+	PETA_DIR=$1
+	PLATFORM_NAME=`basename ${PETA_DIR}`
+	ORIGINAL_DIR=`pwd`
+
+	mkdir ${PETA_DIR}/tmp
+	unzip -q ${XRT_REPO_DIR}/src/runtime_src/tools/scripts/xsa_build/${PLATFORM_NAME}/${PLATFORM_NAME}.xsa -d ${PETA_DIR}/tmp
+
+	cd $PETA_DIR
+	echo "create boot.bin in `pwd`"
+
+	petalinux-package --boot --fsbl ${PETA_DIR}/images/linux/zynqmp_fsbl.elf --fpga ${PETA_DIR}/tmp/${PLATFORM_NAME}.bit --u-boot ${PETA_DIR}/images/linux/u-boot.elf --pmufw ${PETA_DIR}/images/linux/pmufw.elf --atf ${PETA_DIR}/images/linux/bl31.elf
+	cd $ORIGINAL_DIR
+
+	rm -rf ${PETA_DIR}/tmp
+
+	cp -f ${PETA_DIR}/images/linux/BOOT.BIN ${XRT_REPO_DIR}/src/runtime_src/tools/scripts/xsa_build/${PLATFORM_NAME}/src/${CPU_ARCH}//xrt/image/
+}
 


### PR DESCRIPTION
Enable post_build_hook to generate BOOT.bin and add to platform

Signed-off-by: Subhransu S. Prusty <subhransu.sekhar.prusty@xilinx.com>