### PR TITLE
Enhancement: Change JSON output format from a multiset to an array.

### DIFF
--- a/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.cxx
+++ b/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.cxx
@@ -119,7 +119,7 @@ SectionClockFrequencyTopology::marshalToJSON(char* _pDataSection,
     clock_freq.put("m_type", getClockTypeStr((enum CLOCK_TYPE)pHdr->m_clock_freq[index].m_type).c_str());
     clock_freq.put("m_name", XUtil::format("%s", pHdr->m_clock_freq[index].m_name).c_str());
 
-    m_clock_freq.add_child("clock_freq", clock_freq);
+    m_clock_freq.push_back(std::make_pair("", clock_freq));   // Used to make an array of objects
   }
 
   clock_freq_topology.add_child("m_clock_freq", m_clock_freq);

--- a/src/runtime_src/tools/xclbin/SectionConnectivity.cxx
+++ b/src/runtime_src/tools/xclbin/SectionConnectivity.cxx
@@ -79,7 +79,7 @@ SectionConnectivity::marshalToJSON(char* _pDataSection,
     connection.put("m_ip_layout_index", XUtil::format("%d", (unsigned int)pHdr->m_connection[index].m_ip_layout_index).c_str());
     connection.put("mem_data_index", XUtil::format("%d", (unsigned int)pHdr->m_connection[index].mem_data_index).c_str());
 
-    m_connection.add_child("connection", connection);
+    m_connection.push_back(std::make_pair("", connection));   // Used to make an array of objects
   }
 
   connectivity.add_child("m_connection", m_connection);

--- a/src/runtime_src/tools/xclbin/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbin/SectionDebugIPLayout.cxx
@@ -174,7 +174,7 @@ SectionDebugIPLayout::marshalToJSON(char* _pDataSection,
     debug_ip_data.put("m_base_address", XUtil::format("0x%lx",  pHdr->m_debug_ip_data[index].m_base_address).c_str());
     debug_ip_data.put("m_name", XUtil::format("%s", pHdr->m_debug_ip_data[index].m_name).c_str());
 
-    m_debug_ip_data.add_child("debug_ip_data", debug_ip_data);
+    m_debug_ip_data.push_back(std::make_pair("", debug_ip_data));   // Used to make an array of objects
   }
 
   debug_ip_layout.add_child("m_debug_ip_data", m_debug_ip_data);

--- a/src/runtime_src/tools/xclbin/SectionIPLayout.cxx
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.cxx
@@ -186,7 +186,7 @@ SectionIPLayout::marshalToJSON(char* _pDataSection,
     }
     ip_data.put("m_name", XUtil::format("%s", pHdr->m_ip_data[index].m_name).c_str());
 
-    m_ip_data.add_child("ip_data", ip_data);
+    m_ip_data.push_back(std::make_pair("", ip_data));   // Used to make an array of objects
   }
 
   ip_layout.add_child("m_ip_data", m_ip_data);

--- a/src/runtime_src/tools/xclbin/SectionMemTopology.cxx
+++ b/src/runtime_src/tools/xclbin/SectionMemTopology.cxx
@@ -148,7 +148,7 @@ SectionMemTopology::marshalToJSON(char* _pDataSection,
     mem_data.put("m_tag", XUtil::format("%s", pHdr->m_mem_data[index].m_tag).c_str());
     mem_data.put("m_base_address", XUtil::format("0x%lx", pHdr->m_mem_data[index].m_base_address).c_str());
 
-    m_mem_data.add_child("mem_data", mem_data);
+    m_mem_data.push_back(std::make_pair("", mem_data));   // Used to make an array of objects
   }
 
   mem_topology.add_child("m_mem_data", m_mem_data);


### PR DESCRIPTION
Description
----------
The current JSON output of "collections" is represented as a list.  Being that each list object has a key and the keys are duplicates of each other, this was causing issues with various JSON parser for this data was being placed into a set as opposed to a multset.

To help address this issue, instead of creating a list of objects, xclbinutil will now create an array of objects.

Note
----
When reading in the JSON file, both lists and arrays are supported.