### PR TITLE
skip 6 data in ACCEL adapter configure

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -366,7 +366,7 @@ zocl_acc_configure(void *core, u32 *data, size_t sz, int type)
 	 * Same open issue like HLS adapter
 	 * Skip 6 data,this is how user layer construct the command.
 	 */
-	for (i = 4; i < sz - 1; i += 2) {
+	for (i = 6; i < sz - 1; i += 2) {
 		offset = *(data + i) - cu_core->paddr;
 		val = *(data + i + 1);
 


### PR DESCRIPTION
OpenCL will skip the first 6 data. Follow the same rule.