### PR TITLE
For user host pointer

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -133,6 +133,9 @@ static void
 sync_to_ubuf(xocl::memory* buffer, size_t offset, size_t size,
              xrt::device* xdevice, const xrt::device::BufferObjectHandle& boh)
 {
+  if (!buffer->need_extra_sync())
+      return;
+
   auto ubuf = buffer->get_host_ptr();
   if (ubuf) {
     auto hbuf = xdevice->map(boh);
@@ -150,6 +153,9 @@ static void
 sync_to_hbuf(xocl::memory* buffer, size_t offset, size_t size,
              xrt::device* xdevice, const xrt::device::BufferObjectHandle& boh)
 {
+  if (!buffer->need_extra_sync())
+      return;
+
   auto ubuf = buffer->get_host_ptr();
   if (ubuf) {
     auto hbuf = xdevice->map(boh);
@@ -289,12 +295,14 @@ alloc(memory* mem, memidx_type memidx)
   auto boh = m_xdevice->alloc(sz,domain,memidx,nullptr);
   track(mem);
 
-  // Handle unaligned user ptr
+  // Handle unaligned user ptr or bad alloc host_ptr
   if (host_ptr) {
     if (!aligned_flag)
       unaligned_message(host_ptr);
 
+    mem->set_extra_sync();
     auto bo_host_ptr = m_xdevice->map(boh);
+    // No need to copy data to a CL_MEM_WRITE_ONLY buffer
     if (!(mem->get_flags() & CL_MEM_WRITE_ONLY))
         memcpy(bo_host_ptr, host_ptr, sz);
 
@@ -324,12 +332,14 @@ alloc(memory* mem)
   }
 
   auto boh = m_xdevice->alloc(sz);
-  // Handle unaligned user ptr
+  // Handle unaligned user ptr or bad alloc host_ptr
   if (host_ptr) {
     if (!aligned_flag)
       unaligned_message(host_ptr);
 
+    mem->set_extra_sync();
     auto bo_host_ptr = m_xdevice->map(boh);
+    // No need to copy data to a CL_MEM_WRITE_ONLY buffer
     if (!(mem->get_flags() & CL_MEM_WRITE_ONLY))
         memcpy(bo_host_ptr, host_ptr, sz);
 
@@ -924,7 +934,7 @@ write_buffer(memory* buffer, size_t offset, size_t size, const void* ptr)
   // Write data to buffer object at offset
   xdevice->write(boh,ptr,size,offset,false);
 
-  // Update unaligned ubuf or bad alloc ubuf if necessary
+  // Update ubuf if necessary
   sync_to_ubuf(buffer,offset,size,xdevice,boh);
 
   if (buffer->is_resident(this))
@@ -948,7 +958,7 @@ read_buffer(memory* buffer, size_t offset, size_t size, void* ptr)
   // Read data from buffer object at offset
   xdevice->read(boh,ptr,size,offset,false);
 
-  // Update unaligned ubuf or bad alloc ubuf if necessary
+  // Update ubuf if necessary
   sync_to_ubuf(buffer,offset,size,xdevice,boh);
 }
 

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -134,7 +134,7 @@ sync_to_ubuf(xocl::memory* buffer, size_t offset, size_t size,
              xrt::device* xdevice, const xrt::device::BufferObjectHandle& boh)
 {
   if (!buffer->need_extra_sync())
-      return;
+    return;
 
   auto ubuf = buffer->get_host_ptr();
   if (ubuf) {
@@ -154,7 +154,7 @@ sync_to_hbuf(xocl::memory* buffer, size_t offset, size_t size,
              xrt::device* xdevice, const xrt::device::BufferObjectHandle& boh)
 {
   if (!buffer->need_extra_sync())
-      return;
+    return;
 
   auto ubuf = buffer->get_host_ptr();
   if (ubuf) {

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -174,6 +174,18 @@ public:
     throw std::runtime_error("is_aligned called on bad object");
   }
 
+  virtual bool
+  need_extra_sync() const
+  {
+    throw std::runtime_error("need_extra_sync called on bad object");
+  }
+
+  virtual void
+  set_extra_sync()
+  {
+    throw std::runtime_error("set_extra_sync called on bad object");
+  }
+
   virtual cl_mem_object_type
   get_type() const = 0;
 
@@ -537,7 +549,20 @@ public:
     return m_size;
   }
 
+  virtual void
+  set_extra_sync()
+  {
+    m_extra_sync = true;
+  }
+
+  virtual bool
+  need_extra_sync() const
+  {
+    return m_extra_sync;
+  }
+
 private:
+  bool m_extra_sync = false;
   bool m_aligned = false;
   size_t m_size = 0;
   void* m_host_ptr = nullptr;


### PR DESCRIPTION
1. Remove aligned check in sync_to_ubuf() and sync_to_hbuf(). Either buffer is non-aligned or bad alloc by xclAllocUserPtrBO, sync buffer should happen. The ubuf and hbuf check is good enough.

2. If buffer is CL_MEM_WRITE_ONLY, we don't need to do memcpy() on this buffer. In this case, the only sync direction, which make sense, is from device to host. Since this buffer is wrote by kernel and read by host application.