### PR TITLE
    Added support to xclbinutil to support mulitple unique sections

### DIFF
--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -360,6 +360,10 @@ reportXclbinInfo( std::ostream & _ostream,
       }
 
       sSections += sKindStr;
+
+      if (!pSection->getSectionIndexName().empty()) {
+        sSections += "[" + pSection->getSectionIndexName() + "]";
+      }
     }
 
     std::vector<std::string> sections;

--- a/src/runtime_src/tools/xclbin/ParameterSectionData.h
+++ b/src/runtime_src/tools/xclbin/ParameterSectionData.h
@@ -45,6 +45,7 @@ class ParameterSectionData {
   const std::string &getFormatTypeAsStr();
   const std::string &getSectionName();
   const std::string &getSubSectionName();
+  const std::string &getSectionIndexName();
   enum axlf_section_kind &getSectionKind();
   const std::string &getOriginalFormattedString();
 
@@ -54,6 +55,7 @@ class ParameterSectionData {
    std::string m_file;
    std::string m_section;
    std::string m_subSection;
+   std::string m_sectionIndex;
    enum axlf_section_kind m_eKind;
    std::string m_originalString;
 

--- a/src/runtime_src/tools/xclbin/Section.cxx
+++ b/src/runtime_src/tools/xclbin/Section.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018 - 2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -38,10 +38,12 @@ std::map<std::string, enum axlf_section_kind> Section::m_mapNameToId;
 std::map<enum axlf_section_kind, Section::Section_factory> Section::m_mapIdToCtor;
 std::map<std::string, enum axlf_section_kind> Section::m_mapJSONNameToKind;
 std::map<enum axlf_section_kind, bool> Section::m_mapIdToSubSectionSupport;
+std::map<enum axlf_section_kind, bool> Section::m_mapIdToSectionIndexSupport;
 
 Section::Section()
     : m_eKind(BITSTREAM)
     , m_sKindName("")
+    , m_sIndexName("")
     , m_pBuffer(nullptr)
     , m_bufferSize(0)
     , m_name("") {
@@ -80,6 +82,7 @@ Section::registerSectionCtor(enum axlf_section_kind _eKind,
                              const std::string& _sKindStr,
                              const std::string& _sHeaderJSONName,
                              bool _bSupportsSubSections,
+                             bool _bSupportsIndexing,
                              Section_factory _Section_factory) {
   // Some error checking
   if (_sKindStr.empty()) {
@@ -116,6 +119,7 @@ Section::registerSectionCtor(enum axlf_section_kind _eKind,
   m_mapNameToId[_sKindStr] = _eKind;
   m_mapIdToCtor[_eKind] = _Section_factory;
   m_mapIdToSubSectionSupport[_eKind] = _bSupportsSubSections;
+  m_mapIdToSectionIndexSupport[_eKind] = _bSupportsIndexing;
 }
 
 bool
@@ -135,6 +139,23 @@ Section::supportsSubSections(enum axlf_section_kind &_eKind)
     return false;   
   }
   return m_mapIdToSubSectionSupport[_eKind];
+}
+
+bool
+Section::supportsSectionIndex(enum axlf_section_kind &_eKind)
+{
+  if (m_mapIdToSectionIndexSupport.find(_eKind) == m_mapIdToSectionIndexSupport.end()) {
+    return false;   
+  }
+  return m_mapIdToSectionIndexSupport[_eKind];
+}
+
+// -------------------------------------------------------------------------
+
+const std::string & 
+Section::getSectionIndexName() const
+{
+  return m_sIndexName;
 }
 
 enum Section::FormatType 
@@ -166,7 +187,8 @@ Section::getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eK
 
 
 Section*
-Section::createSectionObjectOfKind(enum axlf_section_kind _eKind) {
+Section::createSectionObjectOfKind( enum axlf_section_kind _eKind, 
+                                    const std::string _sIndexName) {
   Section* pSection = nullptr;
 
   if (m_mapIdToCtor.find(_eKind) == m_mapIdToCtor.end()) {
@@ -177,10 +199,12 @@ Section::createSectionObjectOfKind(enum axlf_section_kind _eKind) {
   pSection = m_mapIdToCtor[_eKind]();
   pSection->m_eKind = _eKind;
   pSection->m_sKindName = m_mapIdToName[_eKind];
+  pSection->m_sIndexName = _sIndexName;
 
-  XUtil::TRACE(XUtil::format("Created segment: %s (%d)",
+  XUtil::TRACE(XUtil::format("Created segment: %s (%d), index: '%s'",
                              pSection->getSectionKindAsString().c_str(),
-                             (unsigned int)pSection->getSectionKind()));
+                             (unsigned int)pSection->getSectionKind(),
+                             pSection->getSectionIndexName().c_str()));
   return pSection;
 }
 

--- a/src/runtime_src/tools/xclbin/Section.h
+++ b/src/runtime_src/tools/xclbin/Section.h
@@ -53,12 +53,12 @@ class Section {
 
  public:
   static void getKinds(std::vector< std::string > & kinds);
-  static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind);
+  static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind, const std::string _sIndexName = "");
   static bool translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind);
   static bool getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind);
   static enum FormatType getFormatType(const std::string _sFormatType);
   static bool supportsSubSections(enum axlf_section_kind &_eKind);
-
+  static bool supportsSectionIndex(enum axlf_section_kind &_eKind);
 
  public:
   virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
@@ -71,6 +71,7 @@ class Section {
   const std::string& getSectionKindAsString() const;
   std::string getName() const;
   unsigned int getSize() const;
+  const std::string & getSectionIndexName() const;
 
  public:
   // Xclbin Binary helper methods - child classes can override them if they choose
@@ -106,11 +107,12 @@ class Section {
 
  protected:
   typedef std::function<Section*()> Section_factory;
-  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, bool _bSupportsSubSections, Section_factory _Section_factory);
+  static void registerSectionCtor(enum axlf_section_kind _eKind, const std::string& _sKindStr, const std::string& _sHeaderJSONName, bool _bSupportsSubSections, bool _bSupportsIndexing, Section_factory _Section_factory);
 
  protected:
   enum axlf_section_kind m_eKind;
   std::string m_sKindName;
+  std::string m_sIndexName;
 
   char* m_pBuffer;
   unsigned int m_bufferSize;
@@ -122,6 +124,7 @@ class Section {
   static std::map<enum axlf_section_kind, Section_factory> m_mapIdToCtor;
   static std::map<std::string, enum axlf_section_kind> m_mapJSONNameToKind;
   static std::map<enum axlf_section_kind, bool> m_mapIdToSubSectionSupport;
+  static std::map<enum axlf_section_kind, bool> m_mapIdToSectionIndexSupport;
 
  private:
   // Purposefully private and undefined ctors...

--- a/src/runtime_src/tools/xclbin/SectionBMC.h
+++ b/src/runtime_src/tools/xclbin/SectionBMC.h
@@ -65,7 +65,7 @@ public:
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BMC, "BMC", "", true, boost::factory<SectionBMC*>()); }
+    _init() { registerSectionCtor(BMC, "BMC", "", true, false, boost::factory<SectionBMC*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstream.h
@@ -45,7 +45,7 @@ class SectionBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", false, boost::factory<SectionBitstream*>()); }
+    _init() { registerSectionCtor(BITSTREAM, "BITSTREAM", "", false, false, boost::factory<SectionBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBitstreamPartialPDI.h
+++ b/src/runtime_src/tools/xclbin/SectionBitstreamPartialPDI.h
@@ -42,7 +42,7 @@ class SectionBitstreamPartialPDI : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", "", false, boost::factory<SectionBitstreamPartialPDI*>()); }
+    _init() { registerSectionCtor(BITSTREAM_PARTIAL_PDI, "BITSTREAM_PARTIAL_PDI", "", false, false, boost::factory<SectionBitstreamPartialPDI*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionBuildMetadata.h
@@ -51,7 +51,7 @@ class SectionBuildMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", false, boost::factory<SectionBuildMetadata*>()); }
+    _init() { registerSectionCtor(BUILD_METADATA, "BUILD_METADATA", "build_metadata", false, false, boost::factory<SectionBuildMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClearBitstream.h
+++ b/src/runtime_src/tools/xclbin/SectionClearBitstream.h
@@ -42,7 +42,7 @@ class SectionClearBitstream : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", false, boost::factory<SectionClearBitstream*>()); }
+    _init() { registerSectionCtor(CLEARING_BITSTREAM, "CLEARING_BITSTREAM", "", false, false, boost::factory<SectionClearBitstream*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionClockFrequencyTopology.h
@@ -55,7 +55,7 @@ class SectionClockFrequencyTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", false, boost::factory<SectionClockFrequencyTopology*>()); }
+    _init() { registerSectionCtor(CLOCK_FREQ_TOPOLOGY, "CLOCK_FREQ_TOPOLOGY", "clock_freq_topology", false, false, boost::factory<SectionClockFrequencyTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionConnectivity.h
+++ b/src/runtime_src/tools/xclbin/SectionConnectivity.h
@@ -53,7 +53,7 @@ public:
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", false, boost::factory<SectionConnectivity*>()); }
+    _init() { registerSectionCtor(CONNECTIVITY, "CONNECTIVITY", "connectivity", false, false, boost::factory<SectionConnectivity*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDNACertificate.h
+++ b/src/runtime_src/tools/xclbin/SectionDNACertificate.h
@@ -48,7 +48,7 @@ class SectionDNACertificate : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DNA_CERTIFICATE, "DNA_CERTIFICATE", "", false, boost::factory<SectionDNACertificate*>()); }
+    _init() { registerSectionCtor(DNA_CERTIFICATE, "DNA_CERTIFICATE", "", false, false, boost::factory<SectionDNACertificate*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugData.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugData.h
@@ -42,7 +42,7 @@ class SectionDebugData : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", false, boost::factory<SectionDebugData*>()); }
+    _init() { registerSectionCtor(DEBUG_DATA, "DEBUG_DATA", "", false, false, boost::factory<SectionDebugData*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionDebugIPLayout.h
@@ -54,7 +54,7 @@ class SectionDebugIPLayout : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", false, boost::factory<SectionDebugIPLayout*>()); }
+    _init() { registerSectionCtor(DEBUG_IP_LAYOUT, "DEBUG_IP_LAYOUT", "debug_ip_layout", false, false, boost::factory<SectionDebugIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
+++ b/src/runtime_src/tools/xclbin/SectionDesignCheckPoint.h
@@ -42,7 +42,7 @@ class SectionDesignCheckPoint : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", false, boost::factory<SectionDesignCheckPoint*>()); }
+    _init() { registerSectionCtor(DESIGN_CHECK_POINT, "DESIGN_CHECKPOINT", "", false, false, boost::factory<SectionDesignCheckPoint*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionEmbeddedMetadata.h
@@ -42,7 +42,7 @@ class SectionEmbeddedMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", false, boost::factory<SectionEmbeddedMetadata*>()); }
+    _init() { registerSectionCtor(EMBEDDED_METADATA, "EMBEDDED_METADATA", "", false, false, boost::factory<SectionEmbeddedMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionEmulationData.h
+++ b/src/runtime_src/tools/xclbin/SectionEmulationData.h
@@ -42,7 +42,7 @@ class SectionEmulationData : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(EMULATION_DATA, "EMULATION_DATA", "", false, boost::factory<SectionEmulationData*>()); }
+    _init() { registerSectionCtor(EMULATION_DATA, "EMULATION_DATA", "", false, false, boost::factory<SectionEmulationData*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionIPLayout.h
+++ b/src/runtime_src/tools/xclbin/SectionIPLayout.h
@@ -57,7 +57,7 @@ public:
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", false, boost::factory<SectionIPLayout*>()); }
+    _init() { registerSectionCtor(IP_LAYOUT, "IP_LAYOUT", "ip_layout", false, false, boost::factory<SectionIPLayout*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionKeyValueMetadata.h
@@ -50,7 +50,7 @@ class SectionKeyValueMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", false, boost::factory<SectionKeyValueMetadata*>()); }
+    _init() { registerSectionCtor(KEYVALUE_METADATA, "KEYVALUE_METADATA", "keyvalue_metadata", false, false, boost::factory<SectionKeyValueMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMCS.h
+++ b/src/runtime_src/tools/xclbin/SectionMCS.h
@@ -60,7 +60,7 @@ class SectionMCS : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MCS, "MCS", "", true, boost::factory<SectionMCS*>()); }
+    _init() { registerSectionCtor(MCS, "MCS", "", true, false, boost::factory<SectionMCS*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionManagementFW.h
+++ b/src/runtime_src/tools/xclbin/SectionManagementFW.h
@@ -42,7 +42,7 @@ class SectionManagementFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", false, boost::factory<SectionManagementFW*>()); }
+    _init() { registerSectionCtor(FIRMWARE, "FIRMWARE", "", false, false, boost::factory<SectionManagementFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionMemTopology.h
+++ b/src/runtime_src/tools/xclbin/SectionMemTopology.h
@@ -54,7 +54,7 @@ class SectionMemTopology : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", false, boost::factory<SectionMemTopology*>()); }
+    _init() { registerSectionCtor(MEM_TOPOLOGY, "MEM_TOPOLOGY", "mem_topology", false, false, boost::factory<SectionMemTopology*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionPDI.h
+++ b/src/runtime_src/tools/xclbin/SectionPDI.h
@@ -42,7 +42,7 @@ class SectionPDI : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(PDI, "PDI", "", false, boost::factory<SectionPDI*>()); }
+    _init() { registerSectionCtor(PDI, "PDI", "", false, false, boost::factory<SectionPDI*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionPartitionMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionPartitionMetadata.h
@@ -56,7 +56,7 @@ class SectionPartitionMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-      _init() { registerSectionCtor(PARTITION_METADATA, "PARTITION_METADATA", "partition_metadata", false, boost::factory<SectionPartitionMetadata *>()); }
+      _init() { registerSectionCtor(PARTITION_METADATA, "PARTITION_METADATA", "partition_metadata", false, false, boost::factory<SectionPartitionMetadata *>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
+++ b/src/runtime_src/tools/xclbin/SectionSchedulerFW.h
@@ -42,7 +42,7 @@ class SectionSchedulerFW : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", false, boost::factory<SectionSchedulerFW*>()); }
+    _init() { registerSectionCtor(SCHED_FIRMWARE, "SCHED_FIRMWARE", "", false, false, boost::factory<SectionSchedulerFW*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionSoftKernel.h
+++ b/src/runtime_src/tools/xclbin/SectionSoftKernel.h
@@ -44,6 +44,8 @@ public:
   virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
   virtual bool supportsSubSection(const std::string &_sSubSectionName) const;
   virtual bool subSectionExists(const std::string &_sSubSectionName) const;
+  virtual void readXclBinBinary(std::fstream& _istream, const struct axlf_section_header& _sectionHeader);
+
 
  protected:
   virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::fstream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream &_buffer) const;
@@ -65,7 +67,7 @@ public:
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(SOFT_KERNEL, "SOFT_KERNEL", "", true, boost::factory<SectionSoftKernel*>()); }
+    _init() { registerSectionCtor(SOFT_KERNEL, "SOFT_KERNEL", "", true, true, boost::factory<SectionSoftKernel*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionSystemMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionSystemMetadata.h
@@ -42,7 +42,7 @@ class SectionSystemMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(SYSTEM_METADATA, "SYSTEM_METADATA", "", false, boost::factory<SectionSystemMetadata*>()); }
+    _init() { registerSectionCtor(SYSTEM_METADATA, "SYSTEM_METADATA", "", false, false, boost::factory<SectionSystemMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/SectionUserMetadata.h
+++ b/src/runtime_src/tools/xclbin/SectionUserMetadata.h
@@ -42,7 +42,7 @@ class SectionUserMetadata : public Section {
   // Static initializer helper class
   static class _init {
    public:
-    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", false, boost::factory<SectionUserMetadata*>()); }
+    _init() { registerSectionCtor(USER_METADATA, "USER_METADATA", "", false, false, boost::factory<SectionUserMetadata*>()); }
   } _initializer;
 };
 

--- a/src/runtime_src/tools/xclbin/XclBinClass.h
+++ b/src/runtime_src/tools/xclbin/XclBinClass.h
@@ -56,7 +56,7 @@ class XclBin {
   void removeKey(const std::string & _keyValue);
 
  public:
-  Section *findSection(enum axlf_section_kind _eKind);
+  Section *findSection(enum axlf_section_kind _eKind, const std::string _indexName = "");
 
  private:
   void updateHeaderFromSection(Section *_pSection);

--- a/src/runtime_src/tools/xclbin/unittests/TestMetaData.cxx
+++ b/src/runtime_src/tools/xclbin/unittests/TestMetaData.cxx
@@ -8,7 +8,7 @@ using std::string;
 
 TEST(MetaData, AddingMissingFile) {
   XclBin xclBin;
-  const std::string formattedString = "BUILD_METADATA:junk.json:json";
+  const std::string formattedString = "BUILD_METADATA:JSON:junk.json";
   ParameterSectionData psd(formattedString);
 
   ASSERT_THROW (xclBin.addSection(psd), std::runtime_error);

--- a/src/runtime_src/tools/xclbin/unittests/UnitParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbin/unittests/UnitParameterSectionData.cxx
@@ -2,7 +2,7 @@
 #include "ParameterSectionData.h"
 
 TEST(ParameterSectionData, ValidTuple) {
-   const std::string sOption = "BUILD_METADATA:json:myfile.json";
+   const std::string sOption = "BUILD_METADATA:JSON:myfile.json";
 
    ParameterSectionData *pPSD = new ParameterSectionData(sOption);
 
@@ -12,13 +12,13 @@ TEST(ParameterSectionData, ValidTuple) {
 }
 
 TEST(ParameterSectionData, FileColon) {
-   const std::string sOption = "BUILD_METADATA:json:my:file.json";
+   const std::string sOption = "BUILD_METADATA:JSON:C:\\file.json";
 
    ParameterSectionData *pPSD = new ParameterSectionData(sOption);
 
    EXPECT_STREQ("BUILD_METADATA", pPSD->getSectionName().c_str());
    EXPECT_EQ(Section::FT_JSON, pPSD->getFormatType());
-   EXPECT_STREQ("my:file.json", pPSD->getFile().c_str());
+   EXPECT_STREQ("C:\\file.json", pPSD->getFile().c_str());
 }
 
 TEST(ParameterSectionData, EmptySectionWithJSON) {


### PR DESCRIPTION
    Work Done
    ---------
    + Updated Section class to support unique name multiple section kinds
    + Updated all Section classes to indicate if they support multiple sections
    + Update the --info option to report the section index along with the section name
    + Updated XclBin::findSection() to find sections with index values
    + Updated --remove-section to be index aware
    + Updated --add-section to be index aware
    + Updated --dump-section to be index aware
    + Updated reading in xclbin images to be index aware
    + Added support to SectionSoftKernel support multiple sections
    + Updated the parser in ParameterSectionData to parse index values
    + Updated ParameterSectionData unit test to test for Window path names
    + Updated incorrectly build option add-section string test.