### PR TITLE
enable timestamp for exec buf in kds

### DIFF
--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -580,11 +580,14 @@ ert_copybo_size(struct ert_start_copybo_cmd *pkt)
   return pkt->size;
 }
 
+#define P2ROUNDUP(x, align)     (-(-(x) & -(align)))
 static inline struct cu_cmd_state_timestamps *
 ert_start_kernel_timestamps(struct ert_start_kernel_cmd *pkt)
 {
+  size_t offset = pkt->count * sizeof(uint32_t) + sizeof(pkt->header);
+  /* Make sure the offset of timestamps are properly aligned. */
   return (struct cu_cmd_state_timestamps *)
-    ((char *)pkt + pkt->count * sizeof(uint32_t) + sizeof(pkt->header));
+    ((char *)pkt + P2ROUNDUP(offset, sizeof(uint64_t)));
 }
 
 #endif

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -584,7 +584,7 @@ ert_copybo_size(struct ert_start_copybo_cmd *pkt)
 static inline struct cu_cmd_state_timestamps *
 ert_start_kernel_timestamps(struct ert_start_kernel_cmd *pkt)
 {
-  size_t offset = pkt->count * sizeof(uint32_t) + sizeof(pkt->header);
+  uint64_t offset = pkt->count * sizeof(uint32_t) + sizeof(pkt->header);
   /* Make sure the offset of timestamps are properly aligned. */
   return (struct cu_cmd_state_timestamps *)
     ((char *)pkt + P2ROUNDUP(offset, sizeof(uint64_t)));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -61,6 +61,7 @@
 #include <linux/list.h>
 #include <linux/eventfd.h>
 #include <linux/kthread.h>
+#include <linux/ktime.h>
 #include <ert.h>
 #include "../xocl_drv.h"
 #include "../userpf/common.h"
@@ -242,6 +243,8 @@ struct xocl_cmd {
 	unsigned long uid;      // unique id for this command
 	unsigned int  cu_idx;   // index of CU running this cmd (penguin mode)
 	unsigned int  slot_idx; // index in exec core submit queue
+
+	bool timestamp_enabled;
 };
 
 /*
@@ -340,12 +343,13 @@ cmd_payload_size(struct xocl_cmd *xcmd)
  * cmd_packet_size() - Command packet size
  *
  * @xcmd: Command object
- * Return: Size in number of words of command packet
+ * Return: Size in number of uint32_t of command packet
  */
 static inline unsigned int
 cmd_packet_size(struct xocl_cmd *xcmd)
 {
-	return cmd_payload_size(xcmd) + 1;
+	return cmd_payload_size(xcmd) +
+		sizeof(xcmd->ert_pkt->header) / sizeof(uint32_t);
 }
 
 /**
@@ -388,6 +392,16 @@ cmd_regmap(struct xocl_cmd *xcmd)
 	return xcmd->ert_cu->data + xcmd->ert_cu->extra_cu_masks;
 }
 
+static inline void
+cmd_record_timestamp(struct xocl_cmd *xcmd, enum ert_cmd_state state)
+{
+	if (!xcmd->timestamp_enabled)
+		return;
+
+	ert_start_kernel_timestamps(xcmd->ert_cu)->
+		skc_timestamps[state] = ktime_to_ns(ktime_get());
+}
+
 /**
  * cmd_set_int_state() - Set internal command state used by scheduler only
  *
@@ -398,6 +412,7 @@ static inline void
 cmd_set_int_state(struct xocl_cmd *xcmd, enum ert_cmd_state state)
 {
 	SCHED_DEBUGF("-> %s(%lu,%d)\n", __func__, xcmd->uid, state);
+	cmd_record_timestamp(xcmd, state);
 	xcmd->state = state;
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
@@ -415,6 +430,7 @@ static inline void
 cmd_set_state(struct xocl_cmd *xcmd, enum ert_cmd_state state)
 {
 	SCHED_DEBUGF("->%s(%lu,%d)\n", __func__, xcmd->uid, state);
+	cmd_record_timestamp(xcmd, state);
 	xcmd->state = state;
 	xcmd->ert_pkt->state = state;
 	SCHED_DEBUGF("<-%s\n", __func__);
@@ -568,6 +584,7 @@ cmd_get(struct xocl_scheduler *xs, struct exec_core *exec, struct client_ctx *cl
 	xcmd->ert_pkt = NULL;
 	xcmd->chain_count = 0;
 	xcmd->wait_count = 0;
+	xcmd->timestamp_enabled = false;
 	atomic_inc(&client->outstanding_execs);
 	SCHED_DEBUGF("xcmd(%lu) xcmd(%p) [-> new ]\n", xcmd->uid, xcmd);
 	return xcmd;
@@ -628,6 +645,17 @@ cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
 	SCHED_DEBUGF("%s(%lu,bo,%d,deps,%d)\n", __func__, xcmd->uid, numdeps, penguin);
 	xcmd->bo = bo;
 	xcmd->ert_pkt = (struct ert_packet *)bo->vmapping;
+
+	// Check if we need to enable timestamp recording
+	if (cmd_type(xcmd) == ERT_CU && xcmd->ert_cu->stat_enabled) {
+		if (sizeof(struct cu_cmd_state_timestamps) +
+			cmd_packet_size(xcmd) * sizeof(u32) > bo->base.size) {
+			userpf_err(xcmd->xdev,
+				"not enough space for timestamps in exec buf");
+		} else {
+			xcmd->timestamp_enabled = true;
+		}
+	}
 
 	// in kds mode copy pkt cus to command object cu bitmap
 	if (penguin && cmd_type(xcmd) == ERT_CU) {
@@ -3682,8 +3710,16 @@ validate(struct platform_device *pdev, struct client_ctx *client, const struct d
 	u32 ctx_cus[4] = {0};
 	u32 cumasks = 0;
 	int err = 0;
+	u64 bo_size = bo->base.size;
 
 	SCHED_DEBUGF("-> %s opcode(%d)\n", __func__, ecmd->opcode);
+
+	// Before accessing content of exec buf, make sure the size makes sense
+	if (bo_size < sizeof(*ecmd) ||
+		bo_size < sizeof(ecmd->header) + ecmd->count * sizeof(u32)) {
+		userpf_err(xocl_get_xdev(pdev), "exec buf is too small\n");
+		return 1;
+	}
 
 	// cus for start kernel commands only
 	if (ecmd->type != ERT_CU)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -632,7 +632,7 @@ cmd_abort(struct xocl_cmd *xcmd)
 }
 
 static inline bool
-can_enable_timestamps(struct xocl_cmd *xcmd)
+cmd_can_enable_timestamps(struct xocl_cmd *xcmd)
 {
 	struct ert_start_kernel_cmd *pkt = xcmd->ert_cu;
 
@@ -663,7 +663,7 @@ cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
 	xcmd->bo = bo;
 	xcmd->ert_pkt = (struct ert_packet *)bo->vmapping;
 
-	xcmd->timestamp_enabled = can_enable_timestamps(xcmd);
+	xcmd->timestamp_enabled = cmd_can_enable_timestamps(xcmd);
 
 	// in kds mode copy pkt cus to command object cu bitmap
 	if (penguin && cmd_type(xcmd) == ERT_CU) {


### PR DESCRIPTION
Enable KDS to record timestamp of various state when exec buf is being executed. Useful for performance analysis.