### PR TITLE
implement zocl_cu_get_paddr()

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -91,6 +91,14 @@ zocl_cu_reset_done(struct zocl_cu *cu)
 	return cu->funcs->reset_done(cu->core);
 }
 
+phys_addr_t
+zocl_cu_get_paddr(struct zocl_cu *cu)
+{
+	struct zcu_core *cu_core = cu->core;
+
+	return cu_core->paddr;
+}
+
 /* -- HLS adapter start -- */
 /* HLS adapter implementation realted code. */
 static void


### PR DESCRIPTION
The zocl_cu_get_paddr() has no implementation. This should lead to error when load module. Not sure why I didn't catch this error on my test. Anyway, this is a quick fix.