### PR TITLE
Enhancement: Base name of the run_summary file is now that of the binary container name

### DIFF
--- a/src/runtime_src/xdp/profile/core/run_summary.h
+++ b/src/runtime_src/xdp/profile/core/run_summary.h
@@ -50,7 +50,7 @@ class RunSummary {
     void addFile(const std::string & fileName, FileType eFileType);
     void setProfileTree(std::shared_ptr<boost::property_tree::ptree> tree);
 
-    void extractSystemProfileMetadata(const axlf * pXclbinImage, const std::string & xclbinBaseName);
+    void extractSystemProfileMetadata(const axlf * pXclbinImage, const std::string & xclbinContainerName = "");
     void writeContent();
 
   protected:
@@ -59,7 +59,7 @@ class RunSummary {
   private:
     std::vector< std::pair< std::string, FileType> > mFiles;
     std::string mSystemMetadata;
-    std::string mXclbinBaseName;
+    std::string mXclbinContainerName;
     std::shared_ptr<boost::property_tree::ptree> mProfileTree;
 
   private:

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile_cb.cpp
@@ -588,7 +588,7 @@ void cb_reset(const axlf* xclbin)
   auto pRunSummary = pProfileMgr ? pProfileMgr->getRunSummary() : nullptr;
 
   if (pRunSummary != nullptr) {
-    pRunSummary->extractSystemProfileMetadata(xclbin, "xclbin");
+    pRunSummary->extractSystemProfileMetadata(xclbin);
   }
 
   // init flow mode


### PR DESCRIPTION
Description
-----------
If available, the base name of the run_summary file is now that of the binary container.  This name is extracted from the system_profile_metadata.  If this metadata is not available, the default base name is 'xclbin'.