### PR TITLE
add platform specific device tree file

### DIFF
--- a/src/platform/zcu102ng/config.sh
+++ b/src/platform/zcu102ng/config.sh
@@ -65,14 +65,14 @@ TEMPLATE=zynqMP
 config_dts()
 {
 	DTS_FILE=$1
-	GLOB_DTS=${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts
-	echo "cat ${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts >> recipes-bsp/device-tree/files/system-user.dtsi"
-	cat ${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts >> recipes-bsp/device-tree/files/system-user.dtsi
+	#GLOB_DTS=${XRT_REPO_DIR}/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_mpsoc.dts
+	#echo "cat $GLOB_DTS >> recipes-bsp/device-tree/files/system-user.dtsi"
+	#cat $GLOB_DTS >> recipes-bsp/device-tree/files/system-user.dtsi
 
 	# Attach platform special device tree node
 	# If you wants to add device tree node for your platform. This is the recommented way.
-	#echo "cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_fragment.dts >> $DTS_FILE"
-	#cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_fragment.dts >> $DTS_FILE
+	echo "cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_cu.dts >> $DTS_FILE"
+	cat ${THIS_CONFIG_SCRIPT_DIR}/zcu102ng_cu.dts >> $DTS_FILE
 }
 
 # The first argument is the rootfs configure file

--- a/src/platform/zcu102ng/zcu102ng_cu.dts
+++ b/src/platform/zcu102ng/zcu102ng_cu.dts
@@ -1,0 +1,27 @@
+
+&amba {
+	axi_intc_0: axi-interrupt-ctrl {
+		#interrupt-cells = <2>;
+		compatible = "xlnx,xps-intc-1.00.a";
+		interrupt-controller;
+		reg = <0x0 0xA8000000 0x0 0x1000>;
+		xlnx,kind-of-intr = <0x0>;
+		xlnx,num-intr-inputs = <0x20>;
+		interrupt-parent = <&gic>;
+		interrupts = <0 89 4>;
+	};
+
+	zyxclmm_drm {
+		compatible = "xlnx,zocl";
+		status = "okay";
+		interrupt-parent = <&axi_intc_0>;
+		interrupts = <0  4>, <1  4>, <2  4>, <3  4>,
+			     <4  4>, <5  4>, <6  4>, <7  4>,
+			     <8  4>, <9  4>, <10 4>, <11 4>,
+			     <12 4>, <13 4>, <14 4>, <15 4>,
+			     <16 4>, <17 4>, <18 4>, <19 4>,
+			     <20 4>, <21 4>, <22 4>, <23 4>,
+			     <24 4>, <25 4>, <26 4>, <27 4>,
+			     <28 4>, <29 4>, <30 4>, <31 4>;
+	};
+};

--- a/src/platform/zcu102ng/zcu102ng_xsa.tcl
+++ b/src/platform/zcu102ng/zcu102ng_xsa.tcl
@@ -89,6 +89,7 @@ set_property PFM.IRQ $intVar [get_bd_cells /xlconcat_1]
 ##spit out a XSA
 generate_target all [get_files ./zcu102ng_vivado/zcu102ng.srcs/sources_1/bd/zcu102ng/zcu102ng.bd]
 set_property platform.post_sys_link_tcl_hook        ./dynamic_postlink.tcl       [current_project]
+set_property platform.default_output_type "sd_card" [current_project]
 write_hw_platform -force ./zcu102ng.xsa
 
 #generate hdf


### PR DESCRIPTION
The address of interrupt controller in the global MPSoC device tree changed. Because the interrupt controller was move to the static region.
The zcu102ng platform should use specify device tree file.