### PR TITLE
IBM PowerPC(PPC64le) redhat uses 4.14 as of 7.5 and 7.6

### DIFF
--- a/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
+++ b/src/runtime_src/driver/xclng/drm/xocl/xocl_drv.h
@@ -75,7 +75,7 @@
 /* drm_dev_put was introduced with Linux 4.15 and backported to Red Hat 7.6. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
 	#define XOCL_DRM_DEV_PUT drm_dev_put
-#elif defined(RHEL_RELEASE_CODE)
+#elif defined(RHEL_RELEASE_CODE) && !defined(__PPC64__)
 	#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7,6)
 		#define XOCL_DRM_DEV_PUT drm_dev_put
 	#else
@@ -207,17 +207,19 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define	XOCL_CHARDEV_REG_COUNT	16
 
 #ifdef RHEL_RELEASE_VERSION
-
-#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 6)
-#define RHEL_P2P_SUPPORT_74  0
-#define RHEL_P2P_SUPPORT_76  1
+#if defined(__PPC64__)
+	#define RHEL_P2P_SUPPORT_74  0
+	#define RHEL_P2P_SUPPORT_76  0
+#elif RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 6)
+	#define RHEL_P2P_SUPPORT_74  0
+	#define RHEL_P2P_SUPPORT_76  1
 #elif RHEL_RELEASE_CODE > RHEL_RELEASE_VERSION(7, 3) && RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 6)
-#define RHEL_P2P_SUPPORT_74  1
-#define RHEL_P2P_SUPPORT_76  0
+	#define RHEL_P2P_SUPPORT_74  1
+	#define RHEL_P2P_SUPPORT_76  0
 #endif
 #else
-#define RHEL_P2P_SUPPORT_74  0
-#define RHEL_P2P_SUPPORT_76  0
+	#define RHEL_P2P_SUPPORT_74  0
+	#define RHEL_P2P_SUPPORT_76  0
 #endif
 
 


### PR DESCRIPTION
Please review the fix for building/installing XOCL on PowerPC redhat 7.6.

Do not merge for now, need to re-verify it after code review.