### PR TITLE
Initial versal support (host)

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -139,6 +139,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/subdev/fmgr.c
   xocl/subdev/mgmt_msix.c
   xocl/subdev/flash.c
+  xocl/subdev/mailbox_versal.c
   xocl/Makefile
   )
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -348,6 +348,13 @@ get_sw_em_driver()
   return value;
 }
 
+inline bool
+get_pdi_load()
+{
+  static bool value = detail::get_bool_value("Runtime.pdi_load",true);
+  return value;
+}
+
 /* Indicate whether Block automation based Emulation Models are used. By default, it is turned off.
  * This is used to turn on xclRead/Write based counter and trace data collection flow in ProfileIP objects in XDP.
  * Otherwise, fall back on old HwEmuShim layer based RPC call mechanism.

--- a/src/runtime_src/core/common/scheduler.h
+++ b/src/runtime_src/core/common/scheduler.h
@@ -35,6 +35,9 @@ namespace xrt_core { namespace scheduler {
 int
 init(xclDeviceHandle handle, const axlf* top);
 
+int
+loadXclbinToPS(xclDeviceHandle handle, const axlf* top);
+
 }} // utils,xrt
 
 #endif

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -247,6 +247,7 @@ struct ert_configure_cmd {
  * @type:            [31-27] 0, type of configure
  *
  * @start_cuidx:     start index of compute units
+ * @sk_type:         type of soft kernel.
  * @num_cus:         number of compute units in program
  * @sk_size:         size in bytes of soft kernel image
  * @sk_name:         symbol name of soft kernel
@@ -265,7 +266,8 @@ struct ert_configure_sk_cmd {
   };
 
   /* payload */
-  uint32_t start_cuidx;
+  uint32_t start_cuidx:16;
+  uint32_t sk_type:16;
   uint32_t num_cus;
   uint32_t sk_size;		/* soft kernel size */
   uint32_t sk_name[8];		/* soft kernel name */
@@ -392,6 +394,17 @@ enum ert_cmd_type {
   ERT_KDS_LOCAL = 1,
   ERT_CTRL = 2,
   ERT_CU = 3,
+};
+
+/**
+ * Soft kernel types
+ *
+ * @SOFTKERNEL_TYPE_EXEC:       executable
+ * @SOFTKERNEL_TYPE_XCLBIN:     XCLBIN data file
+ */
+enum softkernel_type {
+  SOFTKERNEL_TYPE_EXEC = 0,
+  SOFTKERNEL_TYPE_XCLBIN = 1,
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019, Xilinx Inc
+ *  Copyright (C) 2018-2019, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -1854,7 +1854,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5019, PCI_ANY_ID, USER_QDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x501D, PCI_ANY_ID, USER_QDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5031, PCI_ANY_ID, USER_SMARTN) },	\
-	{ XOCL_PCI_DEVID(0x10EE, 0x5028, PCI_ANY_ID, USER_XDMA_VERSAL) }
+	{ XOCL_PCI_DEVID(0x10EE, 0x5029, PCI_ANY_ID, USER_XDMA_VERSAL) }
 #define XOCL_DSA_VBNV_MAP						\
 	{ 0x10EE, 0x5001, PCI_ANY_ID, "xilinx_u200_xdma_201820_1",	\
 		&XOCL_BOARD_USER_XDMA },				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018, Xilinx Inc
+ *  Copyright (C) 2019, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -50,6 +50,7 @@ enum {
 	XOCL_DSAFLAG_CUDMA_OFF			= 0x100,
 	XOCL_DSAFLAG_DYNAMIC_IP			= 0x200,
 	XOCL_DSAFLAG_SMARTN			= 0x400,
+	XOCL_DSAFLAG_VERSAL			= 0x800,
 };
 
 #define	FLASH_TYPE_SPI	"spi"
@@ -179,6 +180,7 @@ enum {
 #define	XOCL_FMGR		"fmgr"
 #define	XOCL_FLASH		"flash"
 #define XOCL_DMA_MSIX		"dma_msix"
+#define	XOCL_MAILBOX_VERSAL	"mailbox_versal"
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
@@ -202,6 +204,7 @@ enum subdev_id {
 	XOCL_SUBDEV_DNA,
 	XOCL_SUBDEV_FMGR,
 	XOCL_SUBDEV_MIG_HBM,
+	XOCL_SUBDEV_MAILBOX_VERSAL,
 	XOCL_SUBDEV_NUM
 };
 
@@ -553,6 +556,26 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_USER_QDMA,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_USER_QDMA),	\
+	}
+
+#define	XOCL_MAILBOX_OFFSET_USER_VERSAL	0x6040000
+#define	XOCL_MAILBOX_USER_VERSAL_SIZE	0x2f
+#define	XOCL_RES_MAILBOX_USER_VERSAL			\
+	((struct resource []) {				\
+		{					\
+			.start	= XOCL_MAILBOX_OFFSET_USER_VERSAL, \
+			.end	= XOCL_MAILBOX_OFFSET_USER_VERSAL +	\
+	 			XOCL_MAILBOX_USER_VERSAL_SIZE,		\
+			.flags  = IORESOURCE_MEM,	\
+		},					\
+	})
+
+#define	XOCL_DEVINFO_MAILBOX_USER_VERSAL		\
+	{						\
+		XOCL_SUBDEV_MAILBOX_VERSAL,		\
+		XOCL_MAILBOX_VERSAL,			\
+		XOCL_RES_MAILBOX_USER_VERSAL,		\
+		ARRAY_SIZE(XOCL_RES_MAILBOX_USER_VERSAL),	\
 	}
 
 #define	XOCL_RES_ICAP_MGMT				\
@@ -926,6 +949,38 @@ struct xocl_subdev_map {
 		1					\
 	}
 
+#define	ERT_CQ_BASE_ADDR_VERSAL            0x4000000
+#define ERT_CSR_ADDR_VERSAL                0x6040000
+#define XOCL_RES_SCHEDULER_VERSAL			\
+		((struct resource []) {			\
+		/*
+ 		 * map entire bar for now because scheduler directly
+		 * programs CUs
+		 */					\
+			{				\
+			.start	= ERT_CSR_ADDR_VERSAL,		\
+			.end	= ERT_CSR_ADDR_VERSAL + 0xffff,	\
+			.flags	= IORESOURCE_MEM,	\
+			},				\
+			{				\
+			.start	= ERT_CQ_BASE_ADDR_VERSAL,	\
+			.end	= ERT_CQ_BASE_ADDR_VERSAL +	\
+		       		ERT_CQ_SIZE - 1,		\
+			.flags	= IORESOURCE_MEM,	\
+			}				\
+		})
+
+#define	XOCL_DEVINFO_SCHEDULER_VERSAL			\
+	{						\
+		XOCL_SUBDEV_MB_SCHEDULER,		\
+		XOCL_MB_SCHEDULER,			\
+		XOCL_RES_SCHEDULER_VERSAL,			\
+		ARRAY_SIZE(XOCL_RES_SCHEDULER_VERSAL),		\
+		&(char []){0},		\
+		1,					\
+		.bar_idx = (char []){ 2, 2 },		\
+	}
+
 #define	XOCL_DEVINFO_FMGR				\
 	{						\
 		XOCL_SUBDEV_FMGR,			\
@@ -974,6 +1029,13 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_AF_USER,				\
 		})
 
+#define	USER_RES_XDMA_VERSAL						\
+		((struct xocl_subdev_info []) {				\
+			XOCL_DEVINFO_XDMA,				\
+		 	XOCL_DEVINFO_SCHEDULER_VERSAL,			\
+		 	XOCL_DEVINFO_MAILBOX_USER_VERSAL,		\
+		})
+
 #define USER_RES_AWS							\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
@@ -1016,6 +1078,13 @@ struct xocl_subdev_map {
 		.flags		= 0,					\
 		.subdev_info	= USER_RES_XDMA,			\
 		.subdev_num = ARRAY_SIZE(USER_RES_XDMA),		\
+	}
+
+#define	XOCL_BOARD_USER_XDMA_VERSAL					\
+	(struct xocl_board_private){					\
+		.flags		= XOCL_DSAFLAG_VERSAL,			\
+		.subdev_info	= USER_RES_XDMA_VERSAL,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_XDMA_VERSAL),		\
 	}
 
 #define	XOCL_BOARD_USER_XDMA_ERT_OFF					\
@@ -1784,7 +1853,8 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5015, PCI_ANY_ID, USER_QDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5019, PCI_ANY_ID, USER_QDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x501D, PCI_ANY_ID, USER_QDMA) },	\
-	{ XOCL_PCI_DEVID(0x10EE, 0x5031, PCI_ANY_ID, USER_SMARTN) }
+	{ XOCL_PCI_DEVID(0x10EE, 0x5031, PCI_ANY_ID, USER_SMARTN) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5028, PCI_ANY_ID, USER_XDMA_VERSAL) }
 #define XOCL_DSA_VBNV_MAP						\
 	{ 0x10EE, 0x5001, PCI_ANY_ID, "xilinx_u200_xdma_201820_1",	\
 		&XOCL_BOARD_USER_XDMA },				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 Xilinx, Inc. All rights reserved.
+ *  Copyright (C) 2017-2019 Xilinx, Inc. All rights reserved.
  *  Author: Karen Xie <karen.xie@xilinx.com>
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -471,6 +471,7 @@ static u32 engine_status_read(struct xdma_engine *engine, bool clear, bool dump)
  */
 static void xdma_engine_stop(struct xdma_engine *engine)
 {
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 	u32 w;
 
 	BUG_ON(!engine);
@@ -482,7 +483,7 @@ static void xdma_engine_stop(struct xdma_engine *engine)
 	w |= (u32)XDMA_CTRL_IE_READ_ERROR;
 	w |= (u32)XDMA_CTRL_IE_DESC_ERROR;
 
-	if (poll_mode) {
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 		w |= (u32) XDMA_CTRL_POLL_MODE_WB;
 	} else {
 		w |= (u32)XDMA_CTRL_IE_DESC_STOPPED;
@@ -505,6 +506,7 @@ static void xdma_engine_stop(struct xdma_engine *engine)
 
 static void engine_start_mode_config(struct xdma_engine *engine)
 {
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 	u32 w;
 
 	BUG_ON(!engine);
@@ -531,7 +533,7 @@ static void engine_start_mode_config(struct xdma_engine *engine)
 	w |= (u32)XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
 	w |= (u32)XDMA_CTRL_IE_MAGIC_STOPPED;
 
-	if (poll_mode) {
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 		w |= (u32)XDMA_CTRL_POLL_MODE_WB;
 	} else {
 		w |= (u32)XDMA_CTRL_IE_DESC_STOPPED;
@@ -980,6 +982,7 @@ static int engine_service_cyclic_interrupt(struct xdma_engine *engine)
 /* must be called with engine->lock already acquired */
 static int engine_service_cyclic(struct xdma_engine *engine)
 {
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 	int rc = 0;
 
 	dbg_tfr("engine_service_cyclic()");
@@ -987,7 +990,7 @@ static int engine_service_cyclic(struct xdma_engine *engine)
 	BUG_ON(!engine);
 	BUG_ON(engine->magic != MAGIC_ENGINE);
 
-	if (poll_mode)
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev))
 		rc = engine_service_cyclic_polled(engine);
 	else
 		rc = engine_service_cyclic_interrupt(engine);
@@ -1044,6 +1047,7 @@ static int engine_service(struct xdma_engine *engine, int desc_writeback)
 	u32 err_flag = desc_writeback & WB_ERR_MASK;
 	int rv = 0;
 	struct xdma_poll_wb *wb_data;
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 
 	BUG_ON(!engine);
 
@@ -1120,7 +1124,7 @@ static int engine_service(struct xdma_engine *engine, int desc_writeback)
 	}
 
 	/* Before starting engine again, clear the writeback data */
-        if (poll_mode) {
+        if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 		wb_data = (struct xdma_poll_wb *)engine->poll_mode_addr_virt;
 		wb_data->completed_desc_count = 0;
 	}
@@ -1711,9 +1715,14 @@ static void disable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 static int enable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 {
 	int rv = 0;
+	struct xocl_dev *xcldev = XOCL_PCI_DEV_TO_XDEV(pdev);
 
 	BUG_ON(!xdev);
 	BUG_ON(!pdev);
+
+	/* Do not set up interrupt on versal for now. */
+	if (XOCL_DSA_IS_VERSAL(xcldev))
+		return rv;
 
 	if (!interrupt_mode && msi_msix_capable(pdev, PCI_CAP_ID_MSIX)) {
 		int req_nvec = xdev->c2h_channel_max + xdev->h2c_channel_max +
@@ -2587,6 +2596,7 @@ static int engine_init_regs(struct xdma_engine *engine)
 {
 	u32 reg_value;
 	int rv = 0;
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 
 	write_register(XDMA_CTRL_NON_INCR_ADDR, &engine->regs->control_w1c,
 			(unsigned long)(&engine->regs->control_w1c) -
@@ -2602,7 +2612,7 @@ static int engine_init_regs(struct xdma_engine *engine)
 	reg_value |= XDMA_CTRL_IE_DESC_ERROR;
 
 	/* if using polled mode, configure writeback address */
-	if (poll_mode) {
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 		rv = engine_writeback_setup(engine);
 		if (rv) {
 			dbg_init("%s descr writeback setup failed.\n",
@@ -2647,6 +2657,7 @@ fail_wb:
 static int engine_alloc_resource(struct xdma_engine *engine)
 {
 	struct xdma_dev *xdev = engine->xdev;
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 
 	engine->desc = dma_alloc_coherent(&xdev->pdev->dev,
 			XDMA_TRANSFER_MAX_DESC * sizeof(struct xdma_desc),
@@ -2657,7 +2668,7 @@ static int engine_alloc_resource(struct xdma_engine *engine)
 		goto err_out;
 	}
 
-	if (poll_mode) {
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 		engine->poll_mode_addr_virt = dma_alloc_coherent(
 					&xdev->pdev->dev,
 					sizeof(struct xdma_poll_wb),
@@ -2956,6 +2967,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	int nents;
 	enum dma_data_direction dir = write ? DMA_TO_DEVICE : DMA_FROM_DEVICE;
 	struct xdma_request_cb *req = NULL;
+	struct xocl_dev *xcldev;
 
 	if (!dev_hndl)
 		return -EINVAL;
@@ -2990,6 +3002,8 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 		pr_info("xdev 0x%p, offline.\n", xdev);
 		return -EBUSY;
 	}
+
+	xcldev = XDMA_ENGINE_TO_XDEV(engine);
 
 	/* check the direction */
 	if (engine->dir != dir) {
@@ -3075,7 +3089,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 		/*
 		 * When polling, determine how many descriptors have been queued		 * on the engine to determine the writeback value expected
 		 */
-		if (poll_mode) {
+		if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 			unsigned int desc_count;
 
 			spin_lock_irqsave(&engine->lock, flags);
@@ -3115,7 +3129,8 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			rv = -EIO;
 			break;
 		default:
-			if (!poll_mode && rv == -ERESTARTSYS) {
+			if (!poll_mode && rv == -ERESTARTSYS &&
+			    !XOCL_DSA_IS_VERSAL(xcldev)) {
 				pr_info("xfer 0x%p,%llu, canceled, ep 0x%llx.\n",
 					xfer, xfer->len,
 					req->ep_addr - xfer->len);
@@ -3543,6 +3558,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 {
 	struct xdma_dev *xdev = NULL;
 	int rv = 0;
+	struct xocl_dev *xcldev = XOCL_PCI_DEV_TO_XDEV(pdev);
 
 	pr_info("%s device %s, 0x%p.\n", mname, dev_name(&pdev->dev), pdev);
 
@@ -3622,7 +3638,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 	if (rv < 0)
 		goto err_interrupts;
 
-	if (!poll_mode)
+	if (!poll_mode && !(XOCL_DSA_IS_VERSAL(xcldev)))
 		channel_interrupts_enable(xdev, ~0);
 
 	/* Flush writes */
@@ -3744,6 +3760,7 @@ void xdma_device_online(struct pci_dev *pdev, void *dev_hndl)
 {
 	struct xdma_dev *xdev = (struct xdma_dev *)dev_hndl;
 	struct xdma_engine *engine;
+	struct xocl_dev *xcldev = XOCL_PCI_DEV_TO_XDEV(pdev);
 	unsigned long flags;
 	int i;
 
@@ -3776,7 +3793,7 @@ pr_info("pdev 0x%p, xdev 0x%p.\n", pdev, xdev);
 	}
 
 	/* re-write the interrupt table */
-	if (!poll_mode) {
+	if (!poll_mode && !(XOCL_DSA_IS_VERSAL(xcldev))) {
 		irq_setup(xdev, pdev);
 
 		channel_interrupts_enable(xdev, ~0);
@@ -3929,6 +3946,7 @@ static int transfer_monitor_cyclic(struct xdma_engine *engine,
 			struct xdma_transfer *transfer, int timeout_ms)
 {
 	struct xdma_result *result;
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 	int rc = 0;
 
 	BUG_ON(!engine);
@@ -3937,7 +3955,7 @@ static int transfer_monitor_cyclic(struct xdma_engine *engine,
 	result = engine->cyclic_result;
 	BUG_ON(!result);
 
-	if (poll_mode) {
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev)) {
 		int i ;
 		for (i = 0; i < 5; i++) {
 			rc = engine_service_poll(engine, 0);
@@ -4400,6 +4418,7 @@ int xdma_cyclic_transfer_teardown(struct xdma_engine *engine)
 	int rc;
 	struct xdma_dev *xdev = engine->xdev;
 	struct xdma_transfer *transfer;
+	struct xocl_dev *xcldev = XDMA_ENGINE_TO_XDEV(engine);
 	unsigned long flags;
 
 	transfer = engine_cyclic_stop(engine);
@@ -4417,7 +4436,7 @@ int xdma_cyclic_transfer_teardown(struct xdma_engine *engine)
 	spin_unlock_irqrestore(&engine->lock, flags);
 
 	/* wait for engine to be no longer running */
-	if (poll_mode)
+	if (poll_mode || XOCL_DSA_IS_VERSAL(xcldev))
 		rc = cyclic_shutdown_polled(engine);
 	else
 		rc = cyclic_shutdown_interrupt(engine);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *
  * Xilinx XDMA IP Core Linux Driver
- * Copyright(c) 2015 - 2017 Xilinx, Inc.
+ * Copyright(c) 2015 - 2019 Xilinx, Inc.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -35,6 +35,8 @@
 #include <linux/kernel.h>
 #include <linux/pci.h>
 #include <linux/workqueue.h>
+
+#include "../xocl_drv.h"
 
 /* Switch debug printing on/off */
 #define XDMA_DEBUG 0
@@ -218,6 +220,9 @@
 #define dbg_init(...)
 #define dbg_desc(...)
 #endif
+
+#define XDMA_ENGINE_TO_XDEV(engine)	\
+	XOCL_PCI_DEV_TO_XDEV(engine->xdev->pdev)
 
 /* SECTION: Enum definitions */
 enum transfer_state {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -1,0 +1,166 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: Larry Liu <yliu@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "../xocl_drv.h"
+
+#define	MBV_ERR(mbv, fmt, arg...)    \
+    xocl_err(&mbv->mbv_pdev->dev, fmt "\n", ##arg)
+
+#define	STATUS_EMPTY	(1 << 0)
+#define	STATUS_FULL	(1 << 1)
+#define	STATUS_STA	(1 << 2)
+#define	STATUS_RTA	(1 << 3)
+
+/*
+ * Mailbox IP register layout
+ */
+struct mailbox_reg {
+	u32			mbr_wrdata;
+	u32			mbr_resv1;
+	u32			mbr_rddata;
+	u32			mbr_resv2;
+	u32			mbr_status;
+	u32			mbr_error;
+	u32			mbr_sit;
+	u32			mbr_rit;
+	u32			mbr_is;
+	u32			mbr_ie;
+	u32			mbr_ip;
+	u32			mbr_ctrl;
+} __attribute__((packed));
+
+struct mailbox_versal {
+	struct platform_device	*mbv_pdev;
+	struct mailbox_reg	*mbv_regs;
+
+	struct mutex		mbv_lock;
+};
+
+static inline void mailbox_versal_reg_wr(struct mailbox_versal *mbv,
+		u32 *reg, u32 val)
+{
+	iowrite32(val, reg);
+}
+
+static inline u32 mailbox_versal_reg_rd(struct mailbox_versal *mbv, u32 *reg)
+{
+	u32 val = ioread32(reg);
+
+	return val;
+}
+
+static int mailbox_versal_set(struct platform_device *pdev, u32 data)
+{
+	return 0;
+}
+
+static int mailbox_versal_get(struct platform_device *pdev, u32 *data)
+{
+	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
+	u32 st;
+
+	mutex_lock(&mbv->mbv_lock);
+
+	st = mailbox_versal_reg_rd(mbv, &mbv->mbv_regs->mbr_status);
+	if (st & STATUS_EMPTY) {
+		mutex_unlock(&mbv->mbv_lock);
+		return -ENOMSG;
+	}
+
+	*data = mailbox_versal_reg_rd(mbv, &mbv->mbv_regs->mbr_rddata);
+
+	mutex_unlock(&mbv->mbv_lock);
+
+	return 0;
+}
+
+static struct xocl_mailbox_versal_funcs mailbox_versal_ops = {
+	.set		= mailbox_versal_set,
+	.get		= mailbox_versal_get,
+};
+
+static int mailbox_versal_remove(struct platform_device *pdev)
+{
+	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
+
+	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(mbv);
+
+	return 0;
+}
+
+static int mailbox_versal_probe(struct platform_device *pdev)
+{
+	struct mailbox_versal *mbv = NULL;
+	struct resource *res;
+	int ret;
+
+	mbv = xocl_drvinst_alloc(&pdev->dev, sizeof(struct mailbox_versal));
+	if (!mbv)
+		return -ENOMEM;
+	platform_set_drvdata(pdev, mbv);
+	mbv->mbv_pdev = pdev;
+
+	mutex_init(&mbv->mbv_lock);
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+
+	mbv->mbv_regs = ioremap_nocache(res->start, res->end - res->start + 1);
+	if (!mbv->mbv_regs) {
+		MBV_ERR(mbv, "failed to map in registers");
+		ret = -EIO;
+		goto failed;
+	}
+
+	/* Reset both RX channel and RX channel */
+	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_ctrl, 0x3);
+
+	return 0;
+
+failed:
+	mailbox_versal_remove(pdev);
+	return ret;
+}
+
+struct xocl_drv_private mailbox_versal_priv = {
+	.ops = &mailbox_versal_ops,
+	.dev = -1,
+};
+
+struct platform_device_id mailbox_versal_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_MAILBOX_VERSAL),
+	    (kernel_ulong_t)&mailbox_versal_priv },
+	{ },
+};
+
+static struct platform_driver	mailbox_versal_driver = {
+	.probe		= mailbox_versal_probe,
+	.remove		= mailbox_versal_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_MAILBOX_VERSAL),
+	},
+	.id_table = mailbox_versal_id_table,
+};
+
+int __init xocl_init_mailbox_versal(void)
+{
+	return platform_driver_register(&mailbox_versal_driver);
+}
+
+void xocl_fini_mailbox_versal(void)
+{
+	platform_driver_unregister(&mailbox_versal_driver);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
 #
 # Authors:
 #
@@ -34,6 +34,7 @@ xocl-y := \
 	../subdev/mig.o \
 	../subdev/dna.o \
 	../subdev/iores.o \
+	../subdev/mailbox_versal.o\
 	$(xocl_lib-y)	\
 	xocl_drv.o	\
 	xocl_bo.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2017 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -200,6 +200,10 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 	if (type == XOCL_BO_EXECBUF || type == XOCL_BO_IMPORT)
 		return 0;
 
+	if (XOCL_DSA_IS_VERSAL(xdev))
+		/* Bypass checking bo user reqs for now */
+		return 0;
+
 	//From "mem_topology" or "feature rom" depending on
 	//unified or non-unified dsa
 	ddr_count = XOCL_DDR_COUNT(xdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Jan Stephan <j.stephan@hzdr.de>
  *
@@ -595,7 +595,7 @@ int xocl_cleanup_mem(struct xocl_drm *drm_p)
 	return 0;
 }
 
-int xocl_init_mem(struct xocl_drm *drm_p)
+int xocl_init_mem(struct xocl_drm *drm_p, struct mem_topology *new_topo)
 {
 	size_t length = 0;
 	size_t mm_size = 0, mm_stat_size = 0;
@@ -618,7 +618,11 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 		reserved2 = 0x1000000;
 	}
 
-	topo = XOCL_MEM_TOPOLOGY(drm_p->xdev);
+	if (XOCL_DSA_IS_VERSAL(drm_p->xdev))
+		topo = new_topo;
+	else
+		topo = XOCL_MEM_TOPOLOGY(drm_p->xdev);
+
 	if (topo == NULL)
 		return 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@xilinx.com
  *
@@ -1085,6 +1085,7 @@ static int (*xocl_drv_reg_funcs[])(void) __initdata = {
 	xocl_init_firewall,
 	xocl_init_mig,
 	xocl_init_dna,
+	xocl_init_mailbox_versal,
 };
 
 static void (*xocl_drv_unreg_funcs[])(void) = {
@@ -1100,6 +1101,7 @@ static void (*xocl_drv_unreg_funcs[])(void) = {
 	xocl_fini_firewall,
 	xocl_fini_mig,
 	xocl_fini_dna,
+	xocl_fini_mailbox_versal,
 };
 
 static int __init xocl_init(void)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1000,6 +1000,10 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 		goto failed;
 	}
 
+	/* Don't check mailbox on versal for now. */
+	if (XOCL_DSA_IS_VERSAL(xdev))
+		return 0;
+
 	/* Launch the mailbox server. */
 	ret = xocl_peer_listen(xdev, xocl_mailbox_srv, (void *)xdev);
 	if (ret) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@xilinx.com
  *
@@ -344,9 +344,14 @@ static ssize_t ready_show(struct device *dev,
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 	uint64_t ch_state, ret;
 
-	xocl_mailbox_get(xdev, CHAN_STATE, &ch_state);
+	/* Bypass this check for versal for now */
+	if (XOCL_DSA_IS_VERSAL(xdev))
+		ret = 1;
+	else {
+		xocl_mailbox_get(xdev, CHAN_STATE, &ch_state);
 
-	ret = (ch_state & MB_PEER_READY) ? 1 : 0;
+		ret = (ch_state & MB_PEER_READY) ? 1 : 0;
+	}
 
 	return sprintf(buf, "0x%llx\n", ret);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *
@@ -86,7 +86,7 @@ int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 ddr,
 void *xocl_drm_init(xdev_handle_t xdev);
 void xocl_drm_fini(struct xocl_drm *drm_p);
 uint32_t xocl_get_shared_ddr(struct xocl_drm *drm_p, struct mem_data *m_data);
-int xocl_init_mem(struct xocl_drm *drm_p);
+int xocl_init_mem(struct xocl_drm *drm_p, struct mem_topology *topo);
 int xocl_cleanup_mem(struct xocl_drm *drm_p);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -196,6 +196,9 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_PL_DEV_TO_XDEV(pldev) \
 	pci_get_drvdata(XOCL_PL_TO_PCI_DEV(pldev))
 
+#define XOCL_PCI_DEV_TO_XDEV(pcidev) \
+	pci_get_drvdata(pcidev)
+
 #define XOCL_PCI_FUNC(xdev_hdl)		\
 	PCI_FUNC(XDEV(xdev_hdl)->pdev->devfn)
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>
@@ -208,6 +208,9 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 
 #define XOCL_DSA_IS_SMARTN(xdev)                \
 	(XDEV(xdev)->priv.flags & XOCL_DSAFLAG_SMARTN)
+
+#define XOCL_DSA_IS_VERSAL(xdev)                \
+	(XDEV(xdev)->priv.flags & XOCL_DSAFLAG_VERSAL)
 
 #define	XOCL_DEV_ID(pdev)			\
 	((pci_domain_nr(pdev->bus) << 16) |	\
@@ -1010,6 +1013,28 @@ struct xocl_axigate_funcs {
 	AXIGATE_OPS(xdev, level)->free(AXIGATE_DEV(xdev, level)) :	\
 	-ENODEV)
 
+struct xocl_mailbox_versal_funcs {
+	struct xocl_subdev_funcs common_funcs;
+	int (*set)(struct platform_device *pdev, u32 data);
+	int (*get)(struct platform_device *pdev, u32 *data);
+};
+#define	MAILBOX_VERSAL_DEV(xdev)	\
+	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL).pldev
+#define	MAILBOX_VERSAL_OPS(xdev)	\
+	((struct xocl_mailbox_versal_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_MAILBOX_VERSAL).ops)
+#define MAILBOX_VERSAL_READY(xdev, cb)	\
+	(MAILBOX_VERSAL_DEV(xdev) && MAILBOX_VERSAL_OPS(xdev) &&	\
+	 MAILBOX_VERSAL_OPS(xdev)->cb)
+#define	xocl_mailbox_versal_set(xdev, data)	\
+	(MAILBOX_VERSAL_READY(xdev, set) ?	\
+	MAILBOX_VERSAL_OPS(xdev)->set(MAILBOX_VERSAL_DEV(xdev), \
+	data) : -ENODEV)
+#define	xocl_mailbox_versal_get(xdev, data)	\
+	(MAILBOX_VERSAL_READY(xdev, get)	\
+	? MAILBOX_VERSAL_OPS(xdev)->get(MAILBOX_VERSAL_DEV(xdev), \
+	data) : -ENODEV)
+
 static inline void __iomem *xocl_cdma_addr(xdev_handle_t xdev)
 {
 	void	__iomem *ioaddr;
@@ -1198,4 +1223,7 @@ void xocl_fini_axigate(void);
 
 int __init xocl_init_iores(void);
 void xocl_fini_iores(void);
+
+int __init xocl_init_mailbox_versal(void);
+void xocl_fini_mailbox_versal(void);
 #endif

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1536,6 +1536,79 @@ int shim::xclCuName2Index(const char *name, uint32_t& index)
     return -ENOENT;
 }
 
+int shim::xclLoadXclBinPS(const xclBin *buffer)
+{
+    int ret;
+    int first_mem;
+    uuid_t uuid;
+
+    auto axlfHeader = xclbin::get_axlf_section(buffer, PDI);
+    if (axlfHeader == nullptr)
+        return 0;
+
+    auto topo = xclbin::get_axlf_section(buffer, MEM_TOPOLOGY);
+    if (topo == nullptr) {
+        xclLog(XRT_ERROR, "XRT", "Load PDI fail, no mem topology.");
+        return -ENOMEM; 
+    }
+    struct mem_topology *topology =
+        (mem_topology *)((char *)buffer + topo->m_sectionOffset);
+    for (first_mem = 0; first_mem < topology->m_count; ++first_mem)
+        if (topology->m_mem_data[first_mem].m_used)
+            break;
+    if (first_mem == topology->m_count) {
+	xclLog(XRT_ERROR, "XRT", "Load PDI fail, no usable memory bank.");
+        return -ENOMEM;
+    }
+
+    uint64_t len = buffer->m_header.m_length;
+    unsigned int xclbinBoHdl = xclAllocBO(len, 0, first_mem); 
+    char *xclbinBo = (char *)xclMapBO(xclbinBoHdl, true);
+    xclBOProperties xclbinBoProp;
+    ret = xclGetBOProperties(xclbinBoHdl, &xclbinBoProp);
+    if (ret)
+        return ret;
+    uint64_t xBoAddr = xclbinBoProp.paddr;
+    uint64_t xBoSize = xclbinBoProp.size;
+    std::memcpy(xclbinBo, buffer, len); 
+    ret = xclSyncBO(xclbinBoHdl, XCL_BO_SYNC_BO_TO_DEVICE, len, 0);
+    if (ret)
+        return ret;
+
+    unsigned execHandle = xclAllocBO(sizeof (ert_configure_sk_cmd),
+        0, (1<<31));
+    struct ert_configure_sk_cmd *ecmd =
+        reinterpret_cast<ert_configure_sk_cmd *>(
+	xclMapBO(execHandle, true));
+
+    ecmd->state = ERT_CMD_STATE_NEW;
+    ecmd->opcode = ERT_SK_CONFIG;
+    ecmd->count = 13;
+    ecmd->start_cuidx = 0;
+    ecmd->sk_type = SOFTKERNEL_TYPE_XCLBIN;
+    ecmd->num_cus = 0;
+    ecmd->sk_size = xBoSize;
+    ecmd->sk_addr = xBoAddr;
+
+    uuid_copy(uuid, buffer->m_header.uuid);
+    ret = xclOpenContext(uuid, -1, true);
+    if (ret) {
+        std::cout << "unable to reserve virtual CU." << std::endl;
+	goto done;
+    }
+
+    ret = xclExecBuf(execHandle);
+    if (ret == 0)
+        while (xclExecWait(1000) == 0);
+
+done:
+    (void) xclCloseContext(uuid, -1);
+    (void) munmap(ecmd, sizeof (ert_configure_sk_cmd));
+    xclFreeBO(execHandle);
+
+    return ret;
+}
+
 } // namespace xocl
 
 /*******************************/
@@ -1576,6 +1649,8 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
       ret = xrt_core::scheduler::init(handle, buffer);
       START_DEVICE_PROFILING_CB(handle);
     }
+    if (!ret && xrt_core::config::get_ert() && xrt_core::config::get_pdi_load())
+      ret = drv->xclLoadXclBinPS(buffer);
     return ret;
 }
 

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -82,6 +82,7 @@ public:
 
     // Bitstream/bin download
     int xclLoadXclBin(const xclBin *buffer);
+    int xclLoadXclBinPS(const xclBin *buffer);
     int xclGetErrorStatus(xclErrorStatus *info);
     int xclGetDeviceInfo2(xclDeviceInfo2 *info);
     bool isGood() const;

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -82,7 +82,6 @@ public:
 
     // Bitstream/bin download
     int xclLoadXclBin(const xclBin *buffer);
-    int xclLoadXclBinPS(const xclBin *buffer);
     int xclGetErrorStatus(xclErrorStatus *info);
     int xclGetDeviceInfo2(xclDeviceInfo2 *info);
     bool isGood() const;


### PR DESCRIPTION
This PR is the initial support for versal.

It added new PCIe device ID 0x5028 (will be changed to 0x5029 when we have PF swap done)
We have userpf and the following subdev driver
1) XDMA
2) mb_scheduler
3) mailbox_versal

With this initial PR, we can download XCLBIN/PDI, schedule PL and AIE kernel to run.