### PR TITLE
Updated ERT firmware to support Emulation shared library creation

### DIFF
--- a/src/runtime_src/ert/scheduler/CMakeLists.txt
+++ b/src/runtime_src/ert/scheduler/CMakeLists.txt
@@ -50,3 +50,21 @@ install (FILES
  DESTINATION ${ERT_INSTALL_PREFIX}
  RENAME sched_u50.bin
 )
+
+
+file(GLOB SCH_SRC_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
+  )
+
+add_definitions(-DERT_HW_EMU -DXCLHAL_MAJOR_VER=1 -DXCLHAL_MINOR_VER=0)
+add_library(sch_objects OBJECT ${SCH_SRC_FILES})
+
+set(CURR_SOURCE "")
+add_library(sched_em SHARED ${CURR_SOURCE}
+  $<TARGET_OBJECTS:sch_objects>
+  )
+
+set_target_properties(sched_em PROPERTIES VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION})
+
+install (TARGETS sched_em LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -18,11 +18,7 @@
  * Embedded runtime scheduler
  */
 
-#ifndef ERT_HW_EMU
 #include "core/include/ert.h"
-#else
-#include "ert.h"
-#endif
 // includes from bsp
 #ifndef ERT_HW_EMU
 #include <xil_printf.h>
@@ -31,8 +27,10 @@
 #else
 #define xil_printf printf
 #define print printf
+#define u32 uint32_t
 #endif
 #include <stdlib.h>
+#include <stdio.h>
 #include <limits>
 
 #define ERT_UNUSED __attribute__((unused))
@@ -46,7 +44,7 @@ ERT_UNUSED
 static void
 ert_assert(const char* file, long line, const char* function, const char* expr, const char* msg)
 {
-  xil_printf("Assert failed: %s:%d:%s:%s %s\n",file,line,function,expr,msg);
+  xil_printf("Assert failed: %s:%ld:%s:%s %s\n",file,line,function,expr,msg);
   exit(1);
 }
 
@@ -71,6 +69,17 @@ ert_assert(const char* file, long line, const char* function, const char* expr, 
 #else
 # define CTRL_DEBUG(msg)
 # define CTRL_DEBUGF(format,...)
+#endif
+
+#ifdef ERT_HW_EMU
+using addr_type = uint32_t;
+using value_type = uint32_t;
+
+extern value_type read_reg(addr_type addr);
+extern void write_reg(addr_type addr, value_type val);
+extern void microblaze_enable_interrupts();
+extern void microblaze_disable_interrupts();
+extern void reg_access_wait();
 #endif
 
 namespace ert {
@@ -886,7 +895,10 @@ configure_mb(size_type slot_idx)
   cdma_enabled = (features & 0x20)!=0;
   dataflow_enabled = (features & 0x40)!=0;
   cu_dma_52 = (features & 0x80000000)!=0;
-
+#ifdef ERT_HW_EMU
+  //Force new mechanism for latest emulation platforms
+  cu_dma_52 = 1;
+#endif
   // CU base address
   for (size_type i=0; i<num_cus; ++i) {
     u32 addr = read_reg(slot.slot_addr + 0x18 + (i<<2));
@@ -1153,13 +1165,7 @@ scheduler_loop()
       auto& slot = command_slots[slot_idx];
 
 #ifdef ERT_HW_EMU
-      if(sim_embedded_scheduler_sw_imp::getSchedularPtr()!=nullptr) {
-      sim_embedded_scheduler_sw_imp* sch=sim_embedded_scheduler_sw_imp::getSchedularPtr();
-        wait(sch->maxi_lite_mb_aclk.posedge_event());
-      } else {
-        sc_time t(1,SC_NS);
-        wait(t);
-      }
+      reg_access_wait();
 #endif
 
       // In dataflow mode ERT is polling CUs for completion after
@@ -1221,7 +1227,9 @@ scheduler_loop()
 /**
  * CU interrupt service routine
  */
+#ifndef ERT_HW_EMU
 void cu_interrupt_handler() __attribute__((interrupt_handler));
+#endif
 void
 cu_interrupt_handler()
 {
@@ -1273,6 +1281,23 @@ cu_interrupt_handler()
 }
 
 } // ert
+#ifdef ERT_HW_EMU
+#ifdef __cplusplus
+extern "C" {
+#endif
+void scheduler_loop() {
+    ert::scheduler_loop();
+}
+
+void cu_interrupt_handler() {
+    ert::cu_interrupt_handler();
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+
 #ifndef ERT_HW_EMU
 int main()
 {

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -25,12 +25,12 @@
 #include <mb_interface.h>
 #include <xparameters.h>
 #else
+#include <stdio.h>
 #define xil_printf printf
 #define print printf
 #define u32 uint32_t
 #endif
 #include <stdlib.h>
-#include <stdio.h>
 #include <limits>
 
 #define ERT_UNUSED __attribute__((unused))


### PR DESCRIPTION
Hi 

This is a pull request to create a shared library for ERT code so that Emulation can use latest ERT firmware instead of keeping a copy of it in the Emulation model.
