### PR TITLE
Update metadata to resolve link issue

### DIFF
--- a/tests/xrt/00_hello/testinfo.yml
+++ b/tests/xrt/00_hello/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/02_simple/testinfo.yml
+++ b/tests/xrt/02_simple/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/03_loopback/testinfo.yml
+++ b/tests/xrt/03_loopback/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/04_swizzle/testinfo.yml
+++ b/tests/xrt/04_swizzle/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/07_sequence/testinfo.yml
+++ b/tests/xrt/07_sequence/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/100_ert_ncu/testinfo.yml
+++ b/tests/xrt/100_ert_ncu/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin --jobs 1024 --seconds 1 --cus 8 --ert}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/11_fp_mmult256/testinfo.yml
+++ b/tests/xrt/11_fp_mmult256/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/13_add_one/testinfo.yml
+++ b/tests/xrt/13_add_one/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/15_buffer_size/testinfo.yml
+++ b/tests/xrt/15_buffer_size/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k kernel.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:

--- a/tests/xrt/22_verify/testinfo.yml
+++ b/tests/xrt/22_verify/testinfo.yml
@@ -6,7 +6,7 @@ user:
   allowed_test_modes: [hw]
   force_makefile: "--force"
   host_args: {all: -k verify.xclbin}
-  host_cflags: ' -DDSA64 -ldl -luuid -I${HOST_SRC_PATH} '
+  host_cflags: ' -DDSA64 -ldl -luuid -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -I${HOST_SRC_PATH} '
   host_exe: host.exe
   host_src: main.cpp
   kernels:


### PR DESCRIPTION
Use link option in the common.mk to update metadata and resolve sprite link issue for xrt_core and xrt_coreutil