### PR TITLE
Zynq compilation issue

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -690,8 +690,7 @@ configure(struct sched_cmd *cmd)
 	}
 	write_unlock(&zdev->attr_rwlock);
 
-	if(zdev->ert)
-	{
+	if(zdev->ert) {
 	  /* Enable interrupt from host to PS when new commands are ready */
 	  if (exec->cq_interrupt) {
 	    /* Stop CQ check thread */

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -689,25 +689,28 @@ configure(struct sched_cmd *cmd)
 	}
 	write_unlock(&zdev->attr_rwlock);
 
-	/* Enable interrupt from host to PS when new commands are ready */
-	if (exec->cq_interrupt) {
-		/* Stop CQ check thread */
-		if (zdev->exec->cq_thread)
-			kthread_stop(zdev->exec->cq_thread);
+	if(zdev->ert)
+	{
+	  /* Enable interrupt from host to PS when new commands are ready */
+	  if (exec->cq_interrupt) {
+	    /* Stop CQ check thread */
+	    if (zdev->exec->cq_thread)
+	      kthread_stop(zdev->exec->cq_thread);
 
-		/* At this point we are good. No one is polling CQ */
-		cq_irq = zdev->ert->irq[ERT_CQ_IRQ];
-		ret = request_irq(cq_irq, sched_cq_isr, 0, "zocl_cq", zdev);
-		if (ret) {
-			DRM_WARN("Failed to initial CQ interrupt. "
-				 "Fall back to polling\n");
-			exec->cq_interrupt = 0;
-			exec->cq_thread = kthread_run(cq_check, zdev, name);
-		}
-	} else {
-		/* In CQ polling mode now */
-		if (!zdev->exec->cq_thread)
-			exec->cq_thread = kthread_run(cq_check, zdev, name);
+	    /* At this point we are good. No one is polling CQ */
+	    cq_irq = zdev->ert->irq[ERT_CQ_IRQ];
+	    ret = request_irq(cq_irq, sched_cq_isr, 0, "zocl_cq", zdev);
+	    if (ret) {
+	      DRM_WARN("Failed to initial CQ interrupt. "
+		  "Fall back to polling\n");
+	      exec->cq_interrupt = 0;
+	      exec->cq_thread = kthread_run(cq_check, zdev, name);
+	    }
+	  } else {
+	    /* In CQ polling mode now */
+	    if (!zdev->exec->cq_thread)
+	      exec->cq_thread = kthread_run(cq_check, zdev, name);
+	  }
 	}
 
 	exec->zcu = vzalloc(sizeof(struct zocl_cu) * exec->num_cus);

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -707,10 +707,6 @@ configure(struct sched_cmd *cmd)
 	      exec->cq_interrupt = 0;
 	      exec->cq_thread = kthread_run(cq_check, zdev, name);
 	    }
-	  } else {
-	    /* In CQ polling mode now */
-	    if (!zdev->exec->cq_thread)
-	      exec->cq_thread = kthread_run(cq_check, zdev, name);
 	  }
 	}
 	/* TODO: let's consider how to support reconfigurable KDS/ERT later.

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ert.c
@@ -89,6 +89,7 @@ ert_mpsoc_next(struct zocl_ert_dev *ert, struct ert_packet *pkg, int *idx_ret)
 	int slot_idx, mask_idx, slot_tmp;
 	int slot_sz;
 	int i, found;
+	u64 slot_info;
 
 	slot_sz = ioread32(ert_hw + ERT_CQ_SLOT_SIZE_REG) * 4;
 	/* Calculate current slot index */
@@ -104,7 +105,9 @@ ert_mpsoc_next(struct zocl_ert_dev *ert, struct ert_packet *pkg, int *idx_ret)
 		cq_status[3] = ioread32(ert_hw + ERT_CQ_STATUS_REG3);
 	} else {
 		/* ERT mode is only for 64 bits system */
-		slot_idx = ((u64)pkg - (u64)ert->cq_ioremap) / slot_sz;
+	  	slot_info = ((u64)pkg - (u64)ert->cq_ioremap) ;
+		do_div(slot_info,slot_sz);
+		slot_idx = slot_info;
 	}
 
 	/* Get mask index and local slot index for the next commmand */


### PR DESCRIPTION
Hi,

This change contains a fix for 32bit system compilation issue along with crash when ert-thread started when ERT is not enabled.
