### PR TITLE
Add filtering metadata for new infra 

### DIFF
--- a/tests/unit_test/000_verify/testinfo.yml
+++ b/tests/unit_test/000_verify/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: hello
       num_cus: 1
     name: verify.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/001_basic_sincos/testinfo.yml
+++ b/tests/unit_test/001_basic_sincos/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: test_sincos
       num_cus: 1
     name: sincos.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/002_bitonic_sort/testinfo.yml
+++ b/tests/unit_test/002_bitonic_sort/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: bitonicsort
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/003_bringup0/testinfo.yml
+++ b/tests/unit_test/003_bringup0/testinfo.yml
@@ -11,3 +11,5 @@ user:
   host_src: main.cpp oclErrorCodes.cpp oclHelper.cpp
   name: 003_bringup0
   only_host_code: 1 
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/004_bringup1/testinfo.yml
+++ b/tests/unit_test/004_bringup1/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: loopback
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/005_bringup2/testinfo.yml
+++ b/tests/unit_test/005_bringup2/testinfo.yml
@@ -11,3 +11,5 @@ user:
   host_src: main.cpp oclErrorCodes.cpp oclHelper.cpp
   name: 005_bringup2
   only_host_code: 1
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/006_copy/testinfo.yml
+++ b/tests/unit_test/006_copy/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: myCopy
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/007_copy_loop/testinfo.yml
+++ b/tests/unit_test/007_copy_loop/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: myCopy
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/008_globalbandwidth/testinfo.yml
+++ b/tests/unit_test/008_globalbandwidth/testinfo.yml
@@ -20,3 +20,5 @@ user:
       name: globalbandwidth
       num_cus: 1
     name: globalbandwidth.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/009_mmult1/testinfo.yml
+++ b/tests/unit_test/009_mmult1/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 1
     name: mmult1.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/010_mmult2/testinfo.yml
+++ b/tests/unit_test/010_mmult2/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 1
     name: mmult2.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/011_mmult3/testinfo.yml
+++ b/tests/unit_test/011_mmult3/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 1
     name: mmult3.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/012_mmult4/testinfo.yml
+++ b/tests/unit_test/012_mmult4/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 1
     name: mmult4.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/013_montecarlo/testinfo.yml
+++ b/tests/unit_test/013_montecarlo/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: montecarlo
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/014_multikernel/testinfo.yml
+++ b/tests/unit_test/014_multikernel/testinfo.yml
@@ -27,3 +27,5 @@ user:
       name: adder_stage
       num_cus: 1
     name: kernels.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/015_outoforderqueue/testinfo.yml
+++ b/tests/unit_test/015_outoforderqueue/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 1
     name: mmult1.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/016_parkernels/testinfo.yml
+++ b/tests/unit_test/016_parkernels/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 2
     name: mmult1.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/017_vectorswizzle/testinfo.yml
+++ b/tests/unit_test/017_vectorswizzle/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: vectorswizzle
       num_cus: 1
     name: vectorswizzle.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/018_bringup3/testinfo.yml
+++ b/tests/unit_test/018_bringup3/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: loopback
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/019_bringup4/testinfo.yml
+++ b/tests/unit_test/019_bringup4/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: loopback
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/036_hello/testinfo.yml
+++ b/tests/unit_test/036_hello/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: hello
       num_cus: 1
     name: bin_hello.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/2kernelglobal_002_rw_4ddr_512/testinfo.yml
+++ b/tests/unit_test/2kernelglobal_002_rw_4ddr_512/testinfo.yml
@@ -23,3 +23,5 @@ user:
       name: bandwidth1
       num_cus: 1
     name: bandwidth.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/cdma/testinfo.yml
+++ b/tests/unit_test/cdma/testinfo.yml
@@ -33,3 +33,5 @@ user:
     lflags: {all: ' --sp add00.m_axi_gmem:DDR[0] --sp add10.m_axi_gmem:DDR[1] --sp add20.m_axi_gmem:DDR[2]
       --sp add30.m_axi_gmem:DDR[3]'}
     name: addone.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/cuselect/testinfo.yml
+++ b/tests/unit_test/cuselect/testinfo.yml
@@ -28,3 +28,5 @@ user:
       --sp vadd_7.D:DDR[2] --sp vadd_8.A:DDR[3] --sp vadd_8.B:DDR[0] --sp vadd_8.C:DDR[1]
       --sp vadd_8.D:DDR[2]'}
     name: cuselect.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/unit_test/subdevice/testinfo.yml
+++ b/tests/unit_test/subdevice/testinfo.yml
@@ -22,3 +22,5 @@ user:
       --sp addone_2.b:DDR[2] --sp addone_3.a:DDR[2] --sp addone_3.b:DDR[3] --sp addone_4.a:DDR[3]
       --sp addone_4.b:DDR[0]'}
     name: addone.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/00_hello/testinfo.yml
+++ b/tests/xrt/00_hello/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: dummy
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/02_simple/testinfo.yml
+++ b/tests/xrt/02_simple/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: simple
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/03_loopback/testinfo.yml
+++ b/tests/xrt/03_loopback/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: loopback
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/04_swizzle/testinfo.yml
+++ b/tests/xrt/04_swizzle/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: vectorswizzle
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/07_sequence/testinfo.yml
+++ b/tests/xrt/07_sequence/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mysequence
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/100_ert_ncu/testinfo.yml
+++ b/tests/xrt/100_ert_ncu/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: addone
       num_cus: 8
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/11_fp_mmult256/testinfo.yml
+++ b/tests/xrt/11_fp_mmult256/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: mmult
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/13_add_one/testinfo.yml
+++ b/tests/xrt/13_add_one/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: addone
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/15_buffer_size/testinfo.yml
+++ b/tests/xrt/15_buffer_size/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: dummy
       num_cus: 1
     name: kernel.xclbin
+  labels:
+    test_type: ['regression']

--- a/tests/xrt/22_verify/testinfo.yml
+++ b/tests/xrt/22_verify/testinfo.yml
@@ -19,3 +19,5 @@ user:
       name: hello
       num_cus: 1
     name: verify.xclbin
+  labels:
+    test_type: ['regression']


### PR DESCRIPTION
New infra requires 'regression' metadata for filtering.
So, updated all the testinfo.yml files to have the filtering metadata