### PR TITLE
fix multi-thread application

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2450,12 +2450,13 @@ static int icap_lock_bitstream(struct platform_device *pdev, const xuid_t *id)
 	ICAP_INFO(icap, "bitstream %pUb locked, ref=%d", id,
 		icap->icap_bitstream_ref);
 
-	mutex_unlock(&icap->icap_lock);
-
 	if (ref == 0) {
 		/* reset on first reference */
-		xocl_exec_reset(xocl_get_xdev(pdev));
+		xocl_exec_reset(xocl_get_xdev(pdev), id);
 	}
+
+	mutex_unlock(&icap->icap_lock);
+
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -105,6 +105,10 @@
 #define	CU_ADDR_HANDSHAKE_MASK	(0xff)
 #define	CU_ADDR_VALID(addr)	(((addr) | CU_ADDR_HANDSHAKE_MASK) != -1)
 
+#if defined(XOCL_UUID)
+static xuid_t uuid_null = NULL_UUID_LE;
+#endif
+
 /* constants */
 static const unsigned int no_index = -1;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1654,14 +1654,11 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
  *	 rather than relying of cfg command
  */
 static void
-exec_reset(struct exec_core *exec)
+exec_reset(struct exec_core *exec, const xuid_t *xclbin_id)
 {
 	struct xocl_dev *xdev = exec_get_xdev(exec);
-	xuid_t *xclbin_id;
 
 	mutex_lock(&exec->exec_lock);
-
-	xclbin_id = XOCL_XCLBIN_ID(xdev);
 
 	userpf_info(xdev, "%s(%d) cfg(%d)\n", __func__, exec->uid, exec->configured);
 
@@ -1858,7 +1855,7 @@ exec_create(struct platform_device *pdev, struct xocl_scheduler *xs)
 		xocl_user_interrupt_config(xdev, i + exec->intr_base, true);
 	}
 
-	exec_reset(exec);
+	exec_reset(exec, &uuid_null);
 	platform_set_drvdata(pdev, exec);
 
 	SCHED_DEBUGF("%s(%d)\n", __func__, exec->uid);
@@ -3736,11 +3733,11 @@ int client_ioctl(struct platform_device *pdev,
  *  Pre-condition: new bitstream has been downloaded and AXI has been reset
  */
 static int
-reset(struct platform_device *pdev)
+reset(struct platform_device *pdev, const xuid_t *xclbin_id)
 {
 	struct exec_core *exec = platform_get_drvdata(pdev);
 
-	exec_reset(exec);
+	exec_reset(exec, xclbin_id);
 	exec->needs_reset = false;
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -136,7 +136,7 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare)
 		if (ret)
 			xocl_err(&pdev->dev, "Online subdevs failed %d", ret);
 		(void) xocl_peer_listen(xdev, xocl_mailbox_srv, (void *)xdev);
-		xocl_exec_reset(xdev);
+		xocl_exec_reset(xdev, XOCL_XCLBIN_ID(xdev));
 	}
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -394,7 +394,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 			 * We have to clear uuid cached in scheduler here if
 			 * download xclbin failed
 			 */
-			(void) xocl_exec_reset(xdev);
+			(void) xocl_exec_reset(xdev, &uuid_null);
 			/*
 			 * Don't just bail out here, always recreate drm mem
 			 * since we have cleaned it up before download.

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -524,7 +524,7 @@ struct xocl_mb_scheduler_funcs {
 	int (*client_ioctl)(struct platform_device *pdev, int op,
 		void *data, void *drm_filp);
 	int (*stop)(struct platform_device *pdev);
-	int (*reset)(struct platform_device *pdev);
+	int (*reset)(struct platform_device *pdev, const xuid_t *xclbin_id);
 	int (*reconfig)(struct platform_device *pdev);
 	int (*cu_map_addr)(struct platform_device *pdev, u32 cu_index,
 		void *drm_filp, u32 *addrp);
@@ -556,9 +556,9 @@ struct xocl_mb_scheduler_funcs {
 	(SCHE_CB(xdev, stop) ?				\
 	 MB_SCHEDULER_OPS(xdev)->stop(MB_SCHEDULER_DEV(xdev)) : \
 	-ENODEV)
-#define	xocl_exec_reset(xdev)		\
+#define	xocl_exec_reset(xdev, xclbin_id)		\
 	(SCHE_CB(xdev, reset) ?				\
-	 MB_SCHEDULER_OPS(xdev)->reset(MB_SCHEDULER_DEV(xdev)) : \
+	 MB_SCHEDULER_OPS(xdev)->reset(MB_SCHEDULER_DEV(xdev), xclbin_id) : \
 	-ENODEV)
 #define	xocl_exec_reconfig(xdev)		\
 	(SCHE_CB(xdev, reconfig) ?				\

--- a/src/runtime_src/core/pcie/linux/debug.cpp
+++ b/src/runtime_src/core/pcie/linux/debug.cpp
@@ -38,10 +38,6 @@
 #include "xclbin.h"
 #include "core/common/message.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
 #include <iostream>
 #include <cstdio>
 #include <cstring>

--- a/src/runtime_src/core/pcie/linux/perf.cpp
+++ b/src/runtime_src/core/pcie/linux/perf.cpp
@@ -973,7 +973,7 @@ namespace xocl {
 
           drm_xocl_pread_unmgd unmgd = {0, 0, fifoReadAddress[0], chunkSizeBytes,
             reinterpret_cast<uint64_t>((void *)(hostbuf + words))};
-          if (mDev->ioctl(DRM_IOCTL_XOCL_PREAD_UNMGD, &unmgd) < 0)
+          if (mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_PREAD_UNMGD, &unmgd) < 0)
             return 0;
 
           size += chunkSizeBytes;
@@ -992,7 +992,7 @@ namespace xocl {
 
         drm_xocl_pread_unmgd unmgd = {0, 0, fifoReadAddress[0], chunkSizeBytes,
           reinterpret_cast<uint64_t>((void *)(hostbuf + words))};
-        if (mDev->ioctl(DRM_IOCTL_XOCL_PREAD_UNMGD, &unmgd) < 0)
+        if (mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_PREAD_UNMGD, &unmgd) < 0)
           return 0;
 
         size += chunkSizeBytes;

--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -33,9 +33,11 @@
 #include "scan.h"
 
 // Supported vendors
-#define XILINX_ID    0x10ee
-#define ADVANTECH_ID 0x13fe
-#define AWS_ID    0x1d0f
+#define XILINX_ID       0x10ee
+#define ADVANTECH_ID    0x13fe
+#define AWS_ID          0x1d0f
+
+#define RENDER_NM       "renderD"
 
 static const std::string sysfs_root = "/sys/bus/pci/devices/";
 
@@ -249,17 +251,28 @@ void pcidev::pci_device::sysfs_get(
         b = false; // default value
 }
 
-int pcidev::pci_device::devfs_open(const std::string& subdev, int flag)
+static std::string get_devfs_path(bool is_mgmt, uint32_t instance)
 {
-    std::string file("/dev/xfpga/");
+    std::string prefixStr = is_mgmt ? "/dev/xclmgmt" : "/dev/dri/" RENDER_NM;
+    std::string instStr = std::to_string(instance);
 
+    return prefixStr + instStr;
+}
+
+int pcidev::pci_device::open(const std::string& subdev, int flag)
+{
+    // Open xclmgmt/xocl node
+    if (subdev.empty()) {
+        std::string devfs = get_devfs_path(is_mgmt, instance);
+        return ::open(devfs.c_str(), flag);
+    }
+
+    // Open subdevice node
+    std::string file("/dev/xfpga/");
     file += subdev;
     file += is_mgmt ? ".m" : ".u";
     file += std::to_string((domain<<16) + (bus<<8) + (dev<<3) + func);
-
-    const int fd = open(file.c_str(), flag);
-
-    return fd;
+    return ::open(file.c_str(), flag);
 }
 
 static size_t bar_size(const std::string &dir, unsigned bar)
@@ -280,7 +293,6 @@ static size_t bar_size(const std::string &dir, unsigned bar)
 
 static int get_render_value(const std::string& dir)
 {
-#define RENDER_NM   "renderD"
     struct dirent *entry;
     DIR *dp;
     int instance_num = INVALID_ID;
@@ -299,14 +311,6 @@ static int get_render_value(const std::string& dir)
     closedir(dp);
 
     return instance_num;
-}
-
-static std::string get_devfs_path(bool is_mgmt, uint32_t instance)
-{
-    std::string prefixStr = is_mgmt ? "/dev/xclmgmt" : "/dev/dri/renderD";
-    std::string instStr = std::to_string(instance);
-
-    return prefixStr + instStr;
 }
 
 static bool devfs_exists(bool is_mgmt, uint32_t instance)
@@ -379,26 +383,28 @@ pcidev::pci_device::pci_device(const std::string& sysfs) : sysfs_name(sysfs)
 
 pcidev::pci_device::~pci_device()
 {
-    devfs_close();
+    if (user_bar_map != MAP_FAILED)
+        munmap(user_bar_map, user_bar_size);
 }
 
-int pcidev::pci_device::devfs_open_and_map()
+int pcidev::pci_device::map_usr_bar()
 {
         std::lock_guard<std::mutex> l(lock);
 
         if (user_bar_map != MAP_FAILED)
             return 0;
 
-        std::string devfs = get_devfs_path(is_mgmt, instance);
-
-        dev_handle = open(devfs.c_str(), O_RDWR);
+        int dev_handle = open("", O_RDWR);
         if (dev_handle < 0)
             return -errno;
 
         user_bar_map = (char *)::mmap(0, user_bar_size,
             PROT_READ | PROT_WRITE, MAP_SHARED, dev_handle, 0);
+        // Mapping should stay valid after handle is closed
+        // (according to man page)
+        (void)close(dev_handle);
+
         if (user_bar_map == MAP_FAILED) {
-            (void) close(dev_handle);
             dev_handle = -1;
             return -errno;
         }
@@ -406,12 +412,10 @@ int pcidev::pci_device::devfs_open_and_map()
         return 0;
 }
 
-void pcidev::pci_device::devfs_close(void)
+void pcidev::pci_device::close(int dev_handle)
 {
-    if (user_bar_map != MAP_FAILED)
-        munmap(user_bar_map, user_bar_size);
     if (dev_handle != -1)
-        (void) close(dev_handle);
+        (void)::close(dev_handle);
 }
 
 /*
@@ -440,7 +444,7 @@ inline void* wordcopy(void *dst, const void* src, size_t bytes)
 int pcidev::pci_device::pcieBarRead(uint64_t offset, void* buf, uint64_t len)
 {
     if (user_bar_map == MAP_FAILED) {
-        int ret = devfs_open_and_map();
+        int ret = map_usr_bar();
         if (ret)
             return ret;
     }
@@ -452,7 +456,7 @@ int pcidev::pci_device::pcieBarWrite(uint64_t offset,
     const void* buf, uint64_t len)
 {
     if (user_bar_map == MAP_FAILED) {
-        int ret = devfs_open_and_map();
+        int ret = map_usr_bar();
         if (ret)
             return ret;
     }
@@ -460,45 +464,31 @@ int pcidev::pci_device::pcieBarWrite(uint64_t offset,
     return 0;
 }
 
-int pcidev::pci_device::ioctl(unsigned long cmd, void *arg)
+int pcidev::pci_device::ioctl(int dev_handle, unsigned long cmd, void *arg)
 {
-    if (dev_handle == -1) {
-        int ret = devfs_open_and_map();
-        if (ret)
-            return ret;
-    }
+    if (dev_handle == -1)
+        return -EINVAL;
     return ::ioctl(dev_handle, cmd, arg);
 }
 
-int pcidev::pci_device::poll(short events, int timeoutMilliSec)
+int pcidev::pci_device::poll(int dev_handle, short events, int timeoutMilliSec)
 {
-    if (dev_handle == -1) {
-        int ret = devfs_open_and_map();
-        if (ret)
-            return ret;
-    }
-
     pollfd info = {dev_handle, events, 0};
     return ::poll(&info, 1, timeoutMilliSec);
 }
 
-void *pcidev::pci_device::mmap(size_t len, int prot, int flags, off_t offset)
+void *pcidev::pci_device::mmap(int dev_handle,
+    size_t len, int prot, int flags, off_t offset)
 {
-    if (dev_handle == -1) {
-        int ret = devfs_open_and_map();
-        if (ret)
-            return MAP_FAILED;
-    }
+    if (dev_handle == -1)
+        return MAP_FAILED;
     return ::mmap(0, len, prot, flags, dev_handle, offset);
 }
 
-int pcidev::pci_device::flock(int op)
+int pcidev::pci_device::flock(int dev_handle, int op)
 {
-    if (dev_handle == -1) {
-        int ret = devfs_open_and_map();
-        if (ret)
-            return ret;
-    }
+    if (dev_handle == -1)
+        return -EINVAL;
     return ::flock(dev_handle, op);
 }
 

--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -400,14 +400,13 @@ int pcidev::pci_device::map_usr_bar()
 
         user_bar_map = (char *)::mmap(0, user_bar_size,
             PROT_READ | PROT_WRITE, MAP_SHARED, dev_handle, 0);
+
         // Mapping should stay valid after handle is closed
         // (according to man page)
         (void)close(dev_handle);
 
-        if (user_bar_map == MAP_FAILED) {
-            dev_handle = -1;
+        if (user_bar_map == MAP_FAILED)
             return -errno;
-        }
 
         return 0;
 }
@@ -466,8 +465,10 @@ int pcidev::pci_device::pcieBarWrite(uint64_t offset,
 
 int pcidev::pci_device::ioctl(int dev_handle, unsigned long cmd, void *arg)
 {
-    if (dev_handle == -1)
-        return -EINVAL;
+    if (dev_handle == -1) {
+        errno = -EINVAL;
+        return -1;
+    }
     return ::ioctl(dev_handle, cmd, arg);
 }
 
@@ -480,15 +481,19 @@ int pcidev::pci_device::poll(int dev_handle, short events, int timeoutMilliSec)
 void *pcidev::pci_device::mmap(int dev_handle,
     size_t len, int prot, int flags, off_t offset)
 {
-    if (dev_handle == -1)
+    if (dev_handle == -1) {
+        errno = -EINVAL;
         return MAP_FAILED;
+    }
     return ::mmap(0, len, prot, flags, dev_handle, offset);
 }
 
 int pcidev::pci_device::flock(int dev_handle, int op)
 {
-    if (dev_handle == -1)
-        return -EINVAL;
+    if (dev_handle == -1) {
+        errno = -EINVAL;
+        return -1;
+    }
     return ::flock(dev_handle, op);
 }
 

--- a/src/runtime_src/core/pcie/linux/scan.h
+++ b/src/runtime_src/core/pcie/linux/scan.h
@@ -86,22 +86,20 @@ public:
     int pcieBarRead(uint64_t offset, void *buf, uint64_t len);
     int pcieBarWrite(uint64_t offset, const void *buf, uint64_t len);
 
-    int ioctl(unsigned long cmd, void *arg = nullptr);
-    int poll(short events, int timeoutMilliSec);
-    void *mmap(size_t len, int prot, int flags, off_t offset);
-    int flock(int op);
-
-    void devfs_close(void);
-    int devfs_open(const std::string& subdev, int flag);
+    int open(const std::string& subdev, int flag);
+    void close(int devhdl);
+    int ioctl(int devhdl, unsigned long cmd, void *arg = nullptr);
+    int poll(int devhdl, short events, int timeoutMilliSec);
+    void *mmap(int devhdl, size_t len, int prot, int flags, off_t offset);
+    int flock(int devhdl, int op);
 
 private:
     std::fstream sysfs_open(const std::string& subdev,
         const std::string& entry, std::string& err,
         bool write = false, bool binary = false);
-    int devfs_open_and_map(void);
+    int map_usr_bar(void);
 
     std::mutex lock;
-    int dev_handle = -1;
     char *user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
 };
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -144,7 +144,7 @@ int shim::dev_init()
         xclLog(XRT_ERROR, "XRT", "%s: Card [%d] not found", __func__, mBoardNumber);
         return -ENOENT;
     }
- 
+
     drm_version version;
     const std::unique_ptr<char[]> name(new char[128]);
     const std::unique_ptr<char[]> desc(new char[512]);

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -121,6 +121,7 @@ namespace xocl {
  */
 shim::shim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity)
   : mVerbosity(verbosity),
+    mUserHandle(-1),
     mStreamHandle(-1),
     mBoardNumber(index),
     mLocked(false),
@@ -143,7 +144,7 @@ int shim::dev_init()
         xclLog(XRT_ERROR, "XRT", "%s: Card [%d] not found", __func__, mBoardNumber);
         return -ENOENT;
     }
-
+ 
     drm_version version;
     const std::unique_ptr<char[]> name(new char[128]);
     const std::unique_ptr<char[]> desc(new char[512]);
@@ -156,18 +157,26 @@ int shim::dev_init()
     version.date = date.get();
     version.date_len = 128;
 
-    int result = dev->ioctl(DRM_IOCTL_VERSION, &version);
-    if (result)
+    mUserHandle = dev->open("", O_RDWR);
+    if (mUserHandle == -1)
         return -errno;
+
+    int result = dev->ioctl(mUserHandle, DRM_IOCTL_VERSION, &version);
+    if (result) {
+        dev->close(mUserHandle);
+        return -errno;
+    }
 
     // We're good now.
     mDev = dev;
     (void) xclGetDeviceInfo2(&mDeviceInfo);
     mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
 
-    mStreamHandle = mDev->devfs_open("dma.qdma", O_RDWR | O_SYNC);
-    if (mStreamHandle == -1)
+    mStreamHandle = mDev->open("dma.qdma", O_RDWR | O_SYNC);
+    if (mStreamHandle == -1) {
+        dev->close(mUserHandle);
 	    return -errno;
+    }
 
     memset(&mAioContext, 0, sizeof(mAioContext));
     mAioEnabled = (io_setup(SHIM_QDMA_AIO_EVT_MAX, &mAioContext) == 0);
@@ -196,6 +205,9 @@ void shim::dev_fini()
         io_destroy(mAioContext);
             mAioEnabled = false;
     }
+
+    if (mUserHandle != -1)
+        mDev->close(mUserHandle);
 }
 
 /*
@@ -361,7 +373,7 @@ size_t shim::xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size
 unsigned int shim::xclAllocBO(size_t size, int unused, unsigned flags)
 {
     drm_xocl_create_bo info = {size, mNullBO, flags};
-    int result = mDev->ioctl(DRM_IOCTL_XOCL_CREATE_BO, &info);
+    int result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_CREATE_BO, &info);
     return result ? mNullBO : info.handle;
 }
 
@@ -372,7 +384,7 @@ unsigned int shim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
 {
     drm_xocl_userptr_bo user =
         {reinterpret_cast<uint64_t>(userptr), size, mNullBO, flags};
-    int result = mDev->ioctl(DRM_IOCTL_XOCL_USERPTR_BO, &user);
+    int result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_USERPTR_BO, &user);
     return result ? mNullBO : user.handle;
 }
 
@@ -382,7 +394,7 @@ unsigned int shim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
 void shim::xclFreeBO(unsigned int boHandle)
 {
     drm_gem_close closeInfo = {boHandle, 0};
-    (void) mDev->ioctl(DRM_IOCTL_GEM_CLOSE, &closeInfo);
+    (void) mDev->ioctl(mUserHandle, DRM_IOCTL_GEM_CLOSE, &closeInfo);
 }
 
 /*
@@ -392,7 +404,7 @@ int shim::xclWriteBO(unsigned int boHandle, const void *src, size_t size, size_t
 {
     int ret;
     drm_xocl_pwrite_bo pwriteInfo = { boHandle, 0, seek, size, reinterpret_cast<uint64_t>(src) };
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_PWRITE_BO, &pwriteInfo);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_PWRITE_BO, &pwriteInfo);
     return ret ? -errno : ret;
 }
 
@@ -403,7 +415,7 @@ int shim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip)
 {
     int ret;
     drm_xocl_pread_bo preadInfo = { boHandle, 0, skip, size, reinterpret_cast<uint64_t>(dst) };
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_PREAD_BO, &preadInfo);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_PREAD_BO, &preadInfo);
     return ret ? -errno : ret;
 }
 
@@ -413,19 +425,20 @@ int shim::xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip)
 void *shim::xclMapBO(unsigned int boHandle, bool write)
 {
     drm_xocl_info_bo info = { boHandle, 0, 0 };
-    int result = mDev->ioctl(DRM_IOCTL_XOCL_INFO_BO, &info);
+    int result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_INFO_BO, &info);
     if (result) {
         return nullptr;
     }
 
     drm_xocl_map_bo mapInfo = { boHandle, 0, 0 };
-    result = mDev->ioctl(DRM_IOCTL_XOCL_MAP_BO, &mapInfo);
+    result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_MAP_BO, &mapInfo);
     if (result) {
         return nullptr;
     }
 
-    return mDev->mmap(info.size, (write ? (PROT_READ|PROT_WRITE) : PROT_READ),
-              MAP_SHARED, mapInfo.offset);
+    return mDev->mmap(mUserHandle, info.size,
+        (write ? (PROT_READ | PROT_WRITE) : PROT_READ), MAP_SHARED,
+        mapInfo.offset);
 }
 
 /*
@@ -438,7 +451,7 @@ int shim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t size, 
             DRM_XOCL_SYNC_BO_TO_DEVICE :
             DRM_XOCL_SYNC_BO_FROM_DEVICE;
     drm_xocl_sync_bo syncInfo = {boHandle, 0, size, offset, drm_dir};
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_SYNC_BO, &syncInfo);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_SYNC_BO, &syncInfo);
     return ret ? -errno : ret;
 }
 
@@ -605,11 +618,10 @@ int shim::resetDevice(xclResetKind kind)
 
     std::string err;
     int dev_offline = 1;
-    int ret = mDev->ioctl(DRM_IOCTL_XOCL_HOT_RESET);
+    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_HOT_RESET);
     if (ret)
         return -errno;
 
-    mDev->devfs_close();
     dev_fini();
 
     while (dev_offline) {
@@ -635,7 +647,6 @@ int shim::p2pEnable(bool enable, bool force)
 
     if (force) {
         dev_fini();
-        mDev->devfs_close();
         /* remove root bus and rescan */
         mDev->sysfs_put("", "root_dev/remove", err, input);
 
@@ -661,7 +672,8 @@ int shim::p2pEnable(bool enable, bool force)
  */
 bool shim::xclLockDevice()
 {
-    if (!is_multiprocess_mode() && mDev->flock(LOCK_EX | LOCK_NB) == -1)
+    if (!is_multiprocess_mode() &&
+        mDev->flock(mUserHandle, LOCK_EX | LOCK_NB) == -1)
         return false;
 
     mLocked = true;
@@ -674,7 +686,7 @@ bool shim::xclLockDevice()
 bool shim::xclUnlockDevice()
 {
     if (!is_multiprocess_mode())
-      mDev->flock(LOCK_UN);
+      mDev->flock(mUserHandle, LOCK_UN);
 
     mLocked = false;
     return true;
@@ -692,7 +704,7 @@ int shim::xclReClock2(unsigned short region, const unsigned short *targetFreqMHz
     reClockInfo.ocl_target_freq[0] = targetFreqMHz[0];
     reClockInfo.ocl_target_freq[1] = targetFreqMHz[1];
     reClockInfo.ocl_target_freq[2] = targetFreqMHz[2];
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_RECLOCK, &reClockInfo);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_RECLOCK, &reClockInfo);
     return ret ? -errno : ret;
 }
 
@@ -736,7 +748,7 @@ int shim::xclLoadXclBin(const xclBin *buffer)
             xclLog(XRT_ERROR, "XRT", "Xclbin on card is in use, can't change.");
         } else if (ret == -EKEYREJECTED) {
             xclLog(XRT_ERROR, "XRT", "Xclbin isn't signed properly");
-	}
+        }
         xclLog(XRT_ERROR, "XRT", "Refer to dmesg log for details. err=%d", ret);
     }
 
@@ -758,7 +770,7 @@ int shim::xclLoadAxlf(const axlf *buffer)
     }
 
     drm_xocl_axlf axlf_obj = {const_cast<axlf *>(buffer)};
-    int ret = mDev->ioctl(DRM_IOCTL_XOCL_READ_AXLF, &axlf_obj);
+    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_READ_AXLF, &axlf_obj);
     if(ret)
         return -errno;
 
@@ -783,7 +795,7 @@ int shim::xclLoadAxlf(const axlf *buffer)
 int shim::xclExportBO(unsigned int boHandle)
 {
     drm_prime_handle info = {boHandle, 0, -1};
-    int result = mDev->ioctl(DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
+    int result = mDev->ioctl(mUserHandle, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
     return !result ? info.fd : result;
 }
 
@@ -793,7 +805,7 @@ int shim::xclExportBO(unsigned int boHandle)
 unsigned int shim::xclImportBO(int fd, unsigned flags)
 {
     drm_prime_handle info = {mNullBO, flags, fd};
-    int result = mDev->ioctl(DRM_IOCTL_PRIME_FD_TO_HANDLE, &info);
+    int result = mDev->ioctl(mUserHandle, DRM_IOCTL_PRIME_FD_TO_HANDLE, &info);
     if (result) {
         xclLog(XRT_ERROR, "XRT", "%s: FD to handle IOCTL failed", __func__);
     }
@@ -806,7 +818,7 @@ unsigned int shim::xclImportBO(int fd, unsigned flags)
 int shim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties)
 {
     drm_xocl_info_bo info = {boHandle, 0, mNullBO, mNullAddr};
-    int result = mDev->ioctl(DRM_IOCTL_XOCL_INFO_BO, &info);
+    int result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_INFO_BO, &info);
     properties->handle = info.handle;
     properties->flags  = info.flags;
     properties->size   = info.size;
@@ -951,7 +963,7 @@ ssize_t shim::xclUnmgdPwrite(unsigned flags, const void *buf, size_t count, uint
         return -EINVAL;
     }
     drm_xocl_pwrite_unmgd unmgd = {0, 0, offset, count, reinterpret_cast<uint64_t>(buf)};
-    return mDev->ioctl(DRM_IOCTL_XOCL_PWRITE_UNMGD, &unmgd);
+    return mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_PWRITE_UNMGD, &unmgd);
 }
 
 /*
@@ -963,7 +975,7 @@ ssize_t shim::xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t of
         return -EINVAL;
     }
     drm_xocl_pread_unmgd unmgd = {0, 0, offset, count, reinterpret_cast<uint64_t>(buf)};
-    return mDev->ioctl(DRM_IOCTL_XOCL_PREAD_UNMGD, &unmgd);
+    return mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_PREAD_UNMGD, &unmgd);
 }
 
 /*
@@ -974,7 +986,7 @@ int shim::xclExecBuf(unsigned int cmdBO)
     int ret;
     xclLog(XRT_INFO, "XRT", "%s, cmdBO: %d", __func__, cmdBO);
     drm_xocl_execbuf exec = {0, cmdBO, 0,0,0,0,0,0,0,0};
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_EXECBUF, &exec);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_EXECBUF, &exec);
     return ret ? -errno : ret;
 }
 
@@ -989,7 +1001,7 @@ int shim::xclExecBuf(unsigned int cmdBO, size_t num_bo_in_wait_list, unsigned in
     unsigned int bwl[8] = {0};
     std::memcpy(bwl,bo_wait_list,num_bo_in_wait_list*sizeof(unsigned int));
     drm_xocl_execbuf exec = {0, cmdBO, bwl[0],bwl[1],bwl[2],bwl[3],bwl[4],bwl[5],bwl[6],bwl[7]};
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_EXECBUF, &exec);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_EXECBUF, &exec);
     return ret ? -errno : ret;
 }
 
@@ -1000,7 +1012,7 @@ int shim::xclRegisterEventNotify(unsigned int userInterrupt, int fd)
 {
     int ret ;
     drm_xocl_user_intr userIntr = {0, fd, (int)userInterrupt};
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_USER_INTR, &userIntr);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_USER_INTR, &userIntr);
     return ret ? -errno : ret;
 }
 
@@ -1009,7 +1021,7 @@ int shim::xclRegisterEventNotify(unsigned int userInterrupt, int fd)
  */
 int shim::xclExecWait(int timeoutMilliSec)
 {
-    return mDev->poll(POLLIN, timeoutMilliSec);
+    return mDev->poll(mUserHandle, POLLIN, timeoutMilliSec);
 }
 
 /*
@@ -1023,7 +1035,7 @@ int shim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool share
     std::memcpy(ctx.xclbin_id, xclbinId, sizeof(uuid_t));
     ctx.cu_index = ipIndex;
     ctx.flags = flags;
-    ret = mDev->ioctl(DRM_IOCTL_XOCL_CTX, &ctx);
+    ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_CTX, &ctx);
     return ret ? -errno : ret;
 }
 
@@ -1046,7 +1058,7 @@ int shim::xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex)
     drm_xocl_ctx ctx = {XOCL_CTX_OP_FREE_CTX};
     std::memcpy(ctx.xclbin_id, xclbinId, sizeof(uuid_t));
     ctx.cu_index = ipIndex;
-    int ret = mDev->ioctl(DRM_IOCTL_XOCL_CTX, &ctx);
+    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_CTX, &ctx);
     return ret ? -errno : ret;
 }
 
@@ -1447,7 +1459,7 @@ int shim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap)
     }
 
     if (mCuMaps[cu_index] == nullptr) {
-        void *p = mDev->mmap(mCuMapSize,
+        void *p = mDev->mmap(mUserHandle, mCuMapSize,
             PROT_READ | PROT_WRITE, MAP_SHARED, (cu_index + 1) * getpagesize());
         if (p != MAP_FAILED)
             mCuMaps[cu_index] = (uint32_t *)p;

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -176,6 +176,7 @@ private:
     std::shared_ptr<pcidev::pci_device> mDev;
     xclVerbosityLevel mVerbosity;
     std::ofstream mLogStream;
+    int mUserHandle;
     int mStreamHandle;
     int mBoardNumber;
     bool mLocked;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.cpp
@@ -139,7 +139,10 @@ int Container::xclLoadXclBin(const xclBin *&buffer)
         return -EINVAL;
     xclmgmt_ioc_bitstream_axlf obj = {reinterpret_cast<axlf *>(real_xclbin.data())};    
 #endif
-    return mgmtDev->ioctl(XCLMGMT_IOCICAPDOWNLOAD_AXLF, &obj);
+    int fd = mgmtDev->open("", O_RDWR);
+    int ret = mgmtDev->ioctl(fd, XCLMGMT_IOCICAPDOWNLOAD_AXLF, &obj);
+    mgmtDev->close(fd);
+    return ret;
 }
 
 bool Container::isGood()

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -251,7 +251,9 @@ int download_xclbin(const pcieFunc& dev, char *xclbin)
         return -EINVAL;
 
     xclmgmt_ioc_bitstream_axlf obj = {reinterpret_cast<axlf *>(newxclbin)};
-    ret = dev.getDev()->ioctl(XCLMGMT_IOCICAPDOWNLOAD_AXLF, &obj);
+    int fd = dev.getDev()->open("", O_RDWR);
+    ret = dev.getDev()->ioctl(fd, XCLMGMT_IOCICAPDOWNLOAD_AXLF, &obj);
+    dev.getDev()->close(fd);
 
     if (done)
         (*done)(done_arg, newxclbin, newlen);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd_plugin_example.c
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd_plugin_example.c
@@ -38,9 +38,6 @@
 #include <stdlib.h> 
 #include <string.h> 
 #include <syslog.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <openssl/md5.h>
 #include <unistd.h>
 #include "msd_plugin.h"

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/pciefunc.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/pciefunc.cpp
@@ -152,9 +152,8 @@ pcieFunc::pcieFunc(size_t index, bool user) : index(index)
 
 pcieFunc::~pcieFunc()
 {
-    dev->devfs_close();
     clearConf();
-    close(mbxfd);
+    dev->close(mbxfd);
     mbxfd = -1;
 }
 
@@ -193,7 +192,7 @@ int pcieFunc::updateConf(std::string hostname, uint16_t hostport, uint64_t swch)
 
 int pcieFunc::mailboxOpen()
 {
-    const int fd = dev->devfs_open("mailbox", O_RDWR);
+    const int fd = dev->open("mailbox", O_RDWR);
     if (fd == -1) {
         log(LOG_ERR, "failed to open mailbox: %m");
         return -1;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_clock.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_clock.cpp
@@ -102,7 +102,9 @@ int clockHandler(int argc, char *argv[])
     obj.ocl_target_freq[KERNEL_CLK] = kernel;
     obj.ocl_target_freq[SYSTEM_CLK] = system;
     auto dev = pcidev::get_dev(index, false);
-    int ret = dev->ioctl(XCLMGMT_IOCFREQSCALE, &obj);
+    int hdl = dev->open("", O_RDWR);
+    int ret = dev->ioctl(hdl, XCLMGMT_IOCFREQSCALE, &obj);
+    dev->close(hdl);
 
     return ret ? -errno : ret;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_part.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_part.cpp
@@ -47,7 +47,7 @@ int program_prp(unsigned index, const std::string& xclbin, bool force)
     }
 
     auto dev = pcidev::get_dev(index, false);
-    int fd = dev->devfs_open("icap", O_WRONLY);
+    int fd = dev->open("icap", O_WRONLY);
 
     if (fd == -1) {
         std::cout << "ERROR: Cannot open icap for writing." << std::endl;
@@ -77,10 +77,10 @@ int program_prp(unsigned index, const std::string& xclbin, bool force)
 
     if (ret <= 0) {
         std::cout << "ERROR: Write prp to icap subdev failed." << std::endl;
-        close(fd);
+        dev->close(fd);
         return -errno;
     }
-    close(fd);
+    dev->close(fd);
 
     if (force)
     {
@@ -127,7 +127,9 @@ int program_urp(unsigned index, const std::string& xclbin)
     stream.read(buffer, length);
     xclmgmt_ioc_bitstream_axlf obj = { reinterpret_cast<axlf *>(buffer) };
     auto dev = pcidev::get_dev(index, false);
-    int ret = dev->ioctl(XCLMGMT_IOCICAPDOWNLOAD_AXLF, &obj);
+    int fd = dev->open("", O_RDWR);
+    int ret = dev->ioctl(fd, XCLMGMT_IOCICAPDOWNLOAD_AXLF, &obj);
+    dev->close(fd);
     delete [] buffer;
 
     return ret ? -errno : ret;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_reset.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_reset.cpp
@@ -130,15 +130,17 @@ int resetHandler(int argc, char *argv[])
 
     int ret = 0;
     auto dev = pcidev::get_dev(index, false);
+    int fd = dev->open("", O_RDWR);
     if (hot) {
-        ret = dev->ioctl(XCLMGMT_IOCHOTRESET);
+        ret = dev->ioctl(fd, XCLMGMT_IOCHOTRESET);
 	ret = ret ? -errno : ret;
     } else if (kernel) {
-        ret = dev->ioctl(XCLMGMT_IOCOCLRESET);
+        ret = dev->ioctl(fd, XCLMGMT_IOCOCLRESET);
 	ret = ret ? -errno : ret;
     } else if (ecc) {
         ret = resetEcc(dev);
     }
+    dev->close(fd);
 
     return ret;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -21,7 +21,6 @@
 #include <memory>
 #include <regex>
 #include <sstream>
-#include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <stdint.h>

--- a/src/runtime_src/core/pcie/tools/xbmgmt/prom.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/prom.cpp
@@ -24,8 +24,6 @@
 #include <cassert>
 #include <thread>
 #include <cstring>
-#include <sys/ioctl.h>
-#include <fcntl.h>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <sys/types.h>

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil_debug.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil_debug.cpp
@@ -22,8 +22,6 @@
 #include <fstream>
 #include <vector>
 #include <iomanip>
-#include <fcntl.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <cstring>
 #include <unistd.h>


### PR DESCRIPTION
Mistakenly forced all threads to use device handle in pci_device. It's now fixed.
Pass in xclbin_id to exec_reset() so that it does not need to call into icap to get it. This may avoid dead lock when icap is calling exec_reset(). @stsoe @larry9523 , please take a look.
Touched cloud daemon and NIFD due to the API change in pci_device, @xuhz @jvillarre , please take a look.

Tested with a process with 200 threads, each doing xclOpen/xclOpenContext/xclExecBuf/xclExecWait. It's working now.