### PR TITLE
Fixed CR 1028205

### DIFF
--- a/src/runtime_src/core/edge/common_em/config.cxx
+++ b/src/runtime_src/core/edge/common_em/config.cxx
@@ -205,7 +205,11 @@ namespace xclemulation{
       {
         //Nothing to do
       }
-      else if(name.find("Debug.") == std::string::npos &&  name.find("alive") == std::string::npos)
+      else if(name == "aliveness_message_interval")
+      {
+        //Nothing to do
+      }
+      else if(name.find("Debug.") == std::string::npos)
       {
         std::cout<<"WARNING: [HW-EM 08] Invalid option '"<<name<<"` specified in sdaccel.ini"<<std::endl;
       }

--- a/src/runtime_src/core/edge/common_em/config.cxx
+++ b/src/runtime_src/core/edge/common_em/config.cxx
@@ -205,9 +205,9 @@ namespace xclemulation{
       {
         //Nothing to do
       }
-      else if(name.find("Debug.") == std::string::npos)
+      else if(name.find("Debug.") == std::string::npos &&  name.find("alive") == std::string::npos)
       {
-        std::cout<<"WARNING: [SDx-EM 08] Invalid option '"<<name<<"` specified in sdaccel.ini"<<std::endl;
+        std::cout<<"WARNING: [HW-EM 08] Invalid option '"<<name<<"` specified in sdaccel.ini"<<std::endl;
       }
     }
     //this code has to be removed once gui generates ini file by adding launch_waveform property

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -206,11 +206,15 @@ namespace xclemulation{
       {
         //Nothing to do
       }
+      else if(name == "aliveness_message_interval")
+      {
+        //Nothing to do
+      }
       else if(name == "system_dpa")
       {
         setSystemDPA(getBoolValue(value,true));
       }
-      else if(name.find("Debug.") == std::string::npos && name.find("alive") == std::string::npos)
+      else if(name.find("Debug.") == std::string::npos)
       {
         std::cout<<"WARNING: [HW-EM 08] Invalid option '"<<name<<"` specified in sdaccel.ini"<<std::endl;
       }

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -210,9 +210,9 @@ namespace xclemulation{
       {
         setSystemDPA(getBoolValue(value,true));
       }
-      else if(name.find("Debug.") == std::string::npos)
+      else if(name.find("Debug.") == std::string::npos && name.find("alive") == std::string::npos)
       {
-        std::cout<<"WARNING: [SDx-EM 08] Invalid option '"<<name<<"` specified in sdaccel.ini"<<std::endl;
+        std::cout<<"WARNING: [HW-EM 08] Invalid option '"<<name<<"` specified in sdaccel.ini"<<std::endl;
       }
     }
     //this code has to be removed once gui generates ini file by adding launch_waveform property


### PR DESCRIPTION
Since 'aliveness_message_interval' is a valid option in sdaccel.ini, removed giving error when it is set.