### PR TITLE
add polling throttle option to contorl sws

### DIFF
--- a/src/runtime_src/xrt/scheduler/sws.cpp
+++ b/src/runtime_src/xrt/scheduler/sws.cpp
@@ -769,6 +769,11 @@ class xocl_scheduler
   {
     wait();
     queue_cmds();
+
+    // throttle polling for cu completion
+    if (auto us = xrt::config::get_polling_throttle())
+      std::this_thread::sleep_for(std::chrono::microseconds(us));
+
     iterate_cmds();
   }
 


### PR DESCRIPTION
One customer is using polling_throttle option since 2017.2. Just take it back here.
This only impact 'sws' but has no effect on 'kds'.