### PR TITLE
set flags for import buffer

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -945,3 +945,19 @@ void zocl_clear_mem(struct drm_zocl_dev *zdev)
 
 	mutex_unlock(&zdev->mm_lock);
 }
+
+struct drm_gem_object *zocl_gem_import(struct drm_device *dev,
+				       struct dma_buf *dma_buf)
+{
+	struct drm_gem_object *gem_obj;
+	struct drm_zocl_bo *zocl_bo;
+
+	gem_obj = drm_gem_prime_import_dev(dev, dma_buf, dev->dev);
+	zocl_bo = to_zocl_bo(gem_obj);
+	/* gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table
+	 * The import buffer is a CMA buffer.
+	 */
+	zocl_bo->flags |= ZOCL_BO_FLAGS_CMA;
+
+	return gem_obj;
+}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.h
@@ -75,4 +75,7 @@ static inline uint32_t zocl_convert_bo_uflags(uint32_t uflags)
 	return zflags;
 }
 
+struct drm_gem_object *
+zocl_gem_import(struct drm_device *dev, struct dma_buf *dma_buf);
+
 #endif /* _ZOCL_BO_H */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -195,11 +195,11 @@ void zocl_free_bo(struct drm_gem_object *obj)
 	if (IS_ERR(obj) || !obj)
 		return;
 
+	DRM_DEBUG("Freeing BO\n");
 	zocl_obj = to_zocl_bo(obj);
 	zdev = obj->dev->dev_private;
 
 	if (!zdev->domain) {
-		DRM_INFO("Freeing BO\n");
 		zocl_describe(zocl_obj);
 		if (zocl_obj->flags & ZOCL_BO_FLAGS_USERPTR)
 			zocl_free_userptr_bo(obj);
@@ -555,7 +555,7 @@ static struct drm_driver zocl_driver = {
 	.gem_create_object         = zocl_gem_create_object,
 	.prime_handle_to_fd        = drm_gem_prime_handle_to_fd,
 	.prime_fd_to_handle        = drm_gem_prime_fd_to_handle,
-	.gem_prime_import          = drm_gem_prime_import,
+	.gem_prime_import          = zocl_gem_import,
 	.gem_prime_export          = drm_gem_prime_export,
 	.gem_prime_get_sg_table    = drm_gem_cma_prime_get_sg_table,
 	.gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table,


### PR DESCRIPTION
The flag for import DMABUF buffer was not been set.

drm_gem_prime_fd_to_handle() will call gem_prime_import() to import the DMABUF fd.
This is the best time to set flags for import buffer.

BTW,  drm_gem_prime_import_dev() will call gem_prime_import_sg_table(), which points to drm_gem_cma_prime_import_sg_table(). This function will check if buffer is physical contiguous and create CMA buffer object for the imported buffer.