### PR TITLE
Get compute unit status from sysfs

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -116,13 +116,10 @@ get_first_used_mem(const axlf* top)
 }
 
 std::vector<uint64_t>
-get_cus(const axlf* top, bool encode)
+get_cus(const ip_layout* ip_layout, bool encode)
 {
   std::vector<uint64_t> cus;
-  auto ip_layout = axlf_section_type<const ::ip_layout*>::get(top,axlf_section_kind::IP_LAYOUT);
-  if (!ip_layout)
-   return cus;
-
+  
   for (int32_t count=0; count <ip_layout->m_count; ++count) {
     const auto& ip_data = ip_layout->m_ip_data[count];
     if (is_valid_cu(ip_data)) {
@@ -140,6 +137,13 @@ get_cus(const axlf* top, bool encode)
   }
   std::sort(cus.begin(),cus.end());
   return cus;
+}
+
+std::vector<uint64_t>
+get_cus(const axlf* top, bool encode)
+{
+  auto ip_layout = axlf_section_type<const ::ip_layout*>::get(top,axlf_section_kind::IP_LAYOUT);
+  return ip_layout ? get_cus(ip_layout,encode) : std::vector<uint64_t>(0);
 }
 
 std::vector<std::pair<uint64_t, size_t>>

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -79,6 +79,9 @@ get_first_used_mem(const axlf* top);
  * @encode: If true encode control protocol in lower address bit
  */
 std::vector<uint64_t>
+get_cus(const ip_layout* ip_layout, bool encode=false);
+
+std::vector<uint64_t>
 get_cus(const axlf* top, bool encode=false);
 
 std::vector<std::pair<uint64_t, size_t>>

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -693,15 +693,6 @@ cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
 }
 
 /*
- */
-static void
-cmd_packet_init(struct xocl_cmd *xcmd, struct ert_packet *packet)
-{
-	SCHED_DEBUGF("%s(%lu,packet)\n", __func__, xcmd->uid);
-	xcmd->ert_pkt = packet;
-}
-
-/*
  * cmd_has_cu() - Check if this command object can execute on CU
  *
  * @cuidx: the index of the CU.	 Note that CU indicies start from 0.
@@ -1052,6 +1043,13 @@ cu_continue(struct xocl_cu *xcu)
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
+static inline u32
+cu_status(struct xocl_cu *xcu)
+{
+	SCHED_DEBUGF("%s cu(%d) @0x%x\n", __func__, xcu->idx, xcu->addr);
+	return ioread32(xcu->base + xcu->addr);
+}
+
 /**
  * cu_poll() - Poll a CU for its status
  *
@@ -1067,7 +1065,7 @@ cu_poll(struct xocl_cu *xcu)
 	SCHED_DEBUGF("-> %s cu(%d) @0x%x done(%d) run(%d)\n", __func__,
 		     xcu->idx, xcu->addr, xcu->done_cnt, xcu->run_cnt);
 
-	xcu->ctrlreg = ioread32(xcu->base + xcu->addr);
+	xcu->ctrlreg = cu_status(xcu);
 
 	SCHED_DEBUGF("+ ctrlreg(0x%x)\n", xcu->ctrlreg);
 
@@ -1360,9 +1358,9 @@ static struct exec_ops penguin_ops;   // kds mode (no ert)
  * @stopped: Flag to indicate that the core data structure cannot be used
  * @flush: Flag to indicate that commands for this device should be flushed
  * @cu_usage: Usage count since last reset
+ * @cu_status: AP_CTRL status of CU, updated by ERT_CU_STAT
  * @slot_status: Bitmap to track status (busy(1)/free(0)) slots in command queue
  * @ctrl_busy: Flag to indicate that slot 0 (ctrl commands) is busy
- * @cu_status: Bitmap to track status (busy(1)/free(0)) of CUs. Unused in ERT mode.
  * @sr0: If set, then status register [0..31] is pending with completed commands (ERT only).
  * @sr1: If set, then status register [32..63] is pending with completed commands (ERT only).
  * @sr2: If set, then status register [64..95] is pending with completed commands (ERT only).
@@ -1402,6 +1400,7 @@ struct exec_core {
 	struct xocl_ert		   *ert;
 
 	u32			   cu_usage[MAX_CUS];
+	u32			   cu_status[MAX_CUS];
 
 	// Bitmap tracks busy(1)/free(0) slots in cmd_slots
 	struct xocl_cmd		   *submitted_cmds[MAX_SLOTS];
@@ -1505,6 +1504,12 @@ static inline u32
 exec_cu_usage(struct exec_core *exec, unsigned int cuidx)
 {
 	return exec->cu_usage[cuidx];
+}
+
+static inline u32
+exec_cu_status(struct exec_core *exec, unsigned int cuidx)
+{
+	return exec->cu_status[cuidx];
 }
 
 static bool
@@ -1984,14 +1989,30 @@ exec_submit_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	return true;
 }
 
+static void
+exec_update_custatus(struct exec_core *exec)
+{
+	unsigned int cuidx;
+	for (cuidx = 0; cuidx < exec->num_cus; ++cuidx) {
+		struct xocl_cu *xcu = exec->cus[cuidx];
+		exec->cu_status[cuidx] = cu_status(xcu);
+	}
+}
+
 /*
  * finish_cmd() - Special post processing of commands after execution
  */
 static int
 exec_finish_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
-	if (cmd_opcode(xcmd) == ERT_CU_STAT && exec_is_ert(exec))
+	if (cmd_opcode(xcmd) != ERT_CU_STAT)
+		return 0;
+	
+	if (exec_is_ert(exec)) 
 		ert_read_custat(exec->ert, exec->num_cus, exec->cu_usage, xcmd);
+
+	exec_update_custatus(exec);
+
 	return 0;
 }
 
@@ -3059,30 +3080,6 @@ err:
 	return 1;
 }
 
-static int
-add_ctrl_cmd(struct exec_core *exec, struct client_ctx *client, struct ert_packet *packet)
-{
-	struct xocl_cmd *xcmd = cmd_get(exec_scheduler(exec), exec, client);
-
-	if (!xcmd)
-		return 1;
-
-	SCHED_DEBUGF("-> %s cmd(%lu)\n", __func__, xcmd->uid);
-
-	cmd_packet_init(xcmd, packet);
-
-	if (add_xcmd(xcmd))
-		goto err;
-
-	SCHED_DEBUGF("<- %s ret(0) opcode(%d) type(%d)\n", __func__, cmd_opcode(xcmd), cmd_type(xcmd));
-	return 0;
-err:
-	cmd_abort(xcmd);
-	SCHED_DEBUGF("<- %s ret(1) opcode(%d) type(%d)\n", __func__, cmd_opcode(xcmd), cmd_type(xcmd));
-	return 1;
-}
-
-
 /**
  * init_scheduler_thread() - Initialize scheduler thread if necessary
  *
@@ -3930,40 +3927,23 @@ static ssize_t
 kds_custat_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct exec_core *exec = dev_get_exec(dev);
-	struct xocl_dev *xdev = exec_get_xdev(exec);
-	struct client_ctx client;
-	struct ert_packet packet;
 	unsigned int count = 0;
 	ssize_t sz = 0;
 
-	// minimum required initialization of client
-	client.abort = false;
-	client.xdev = xdev;
-	atomic_set(&client.outstanding_execs, 0);
+	SCHED_DEBUGF("-> %s\n",__func__);
 
-	packet.opcode = ERT_CU_STAT;
-	packet.type = ERT_CTRL;
-	packet.count = 1;  // data[1]
-
-	if (add_ctrl_cmd(exec, &client, &packet) == 0) {
-		int retry = 5;
-
-		SCHED_DEBUGF("-> custat waiting for command to finish\n");
-		// wait for command completion
-		while (--retry && atomic_read(&client.outstanding_execs))
-			msleep(100);
-		if (retry == 0 && atomic_read(&client.outstanding_execs))
-			userpf_info(xdev, "custat unexpected timeout\n");
-		SCHED_DEBUGF("<- custat retry(%d)\n", retry);
-	}
-
+	// No need to lock exec, cu stats are computed and cached.
+	// Even if xclbin is swapped, the data reflects the xclbin on
+	// which is was computed above.
 	for (count = 0; count < exec->num_cus; ++count)
-		sz += sprintf(buf+sz, "CU[@0x%x] : %d\n",
+		sz += sprintf(buf+sz, "CU[@0x%x] : %d status : %d\n",
 			      exec_cu_base_addr(exec, count),
-			      exec_cu_usage(exec, count));
+			      exec_cu_usage(exec, count),
+			      exec_cu_status(exec, count));
 	if (sz)
 		buf[sz++] = 0;
 
+	SCHED_DEBUGF("<- %s sz=%ld\n",__func__,sz);
 	return sz;
 }
 static DEVICE_ATTR_RO(kds_custat);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1046,6 +1046,7 @@ cu_continue(struct xocl_cu *xcu)
 static inline u32
 cu_status(struct xocl_cu *xcu)
 {
+	SCHED_PRINTF("%s cu(%d) @0x%x base(%p) addr(%p)\n", __func__, xcu->idx, xcu->addr,xcu->base,xcu->base + xcu->addr);
 	SCHED_DEBUGF("%s cu(%d) @0x%x\n", __func__, xcu->idx, xcu->addr);
 	return ioread32(xcu->base + xcu->addr);
 }

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -76,6 +76,8 @@ public:
     int xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
                   size_t dst_offset, size_t src_offset);
 
+    int xclUpdateSchedulerStat();
+
     int xclExportBO(unsigned int boHandle);
     unsigned int xclImportBO(int fd, unsigned flags);
     int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -35,7 +35,7 @@
 
 const size_t m2mBoSize = 256L * 1024 * 1024;
 
-int bdf2index(std::string& bdfStr, unsigned& index)
+static int bdf2index(std::string& bdfStr, unsigned& index)
 {
     // Extract bdf from bdfStr.
     int dom = 0, b, d, f;
@@ -64,7 +64,7 @@ int bdf2index(std::string& bdfStr, unsigned& index)
     return -ENOENT;
 }
 
-int str2index(const char *arg, unsigned& index)
+static int str2index(const char *arg, unsigned& index)
 {
     std::string devStr(arg);
 
@@ -90,7 +90,7 @@ int str2index(const char *arg, unsigned& index)
 }
 
 
-void print_pci_info(std::ostream &ostr)
+static void print_pci_info(std::ostream &ostr)
 {
     ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
     if (pcidev::get_dev_total() == 0) {
@@ -115,7 +115,7 @@ void print_pci_info(std::ostream &ostr)
     }
 }
 
-int xrt_xbutil_version_cmp()
+static int xrt_xbutil_version_cmp() 
 {
     /*check xbutil tools and xrt versions*/
     std::string xrt = sensor_tree::get<std::string>( "runtime.build.version", "N/A" ) + ","


### PR DESCRIPTION
The backdoor sysfs execution of ctrl commands was unsafe and is
removed in this PR. The sysfs node could add ctrl cmd to kds, but
regular flow could immediately unload xclbin and call exec_stop which
in turn would prevent scheduler from draining the outstanding ctrl
command (see #1705).

Now scheduler stats is updated explicitly through xbutil top and query
through regular command execution.

Fixes CR: 1027416