### PR TITLE
CR-1043277 xbmgmt config --device --security X gives a bad error when…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2951,7 +2951,8 @@ static ssize_t sec_level_store(struct device *dev,
 		if (!efi_enabled(EFI_SECURE_BOOT)) {
 			icap->sec_level = val;
 		} else {
-			ICAP_ERR(icap, "security level is fixed in scure boot");
+			ICAP_ERR(icap,
+				"security level is fixed in secure boot");
 			ret = -EROFS;
 		}
 #ifdef	KEY_DEBUG

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -228,8 +228,9 @@ static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
     std::string errmsg;
     dev->sysfs_put("icap", "sec_level", errmsg, lvl);
     if (!errmsg.empty()) {
-        std::cout << "can't set security level for " << dev->sysfs_name << " : "
-            << errmsg << std::endl;
+        std::cout << "Failed to set security level for " << dev->sysfs_name <<
+            << std::endl;
+        std::cout << "See dmesg log for details" << std::endl;
     }
 }
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -228,7 +228,7 @@ static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
     std::string errmsg;
     dev->sysfs_put("icap", "sec_level", errmsg, lvl);
     if (!errmsg.empty()) {
-        std::cout << "Failed to set security level for " << dev->sysfs_name <<
+        std::cout << "Failed to set security level for " << dev->sysfs_name
             << std::endl;
         std::cout << "See dmesg log for details" << std::endl;
     }


### PR DESCRIPTION
… Secure Boot is enabled