### PR TITLE
fix the platform scripts to take processor name instead of instance name

### DIFF
--- a/src/platform/zc702_base/zc702_base_pfm.tcl
+++ b/src/platform/zc702_base/zc702_base_pfm.tcl
@@ -2,7 +2,7 @@
 
 platform -name zc702_base -desc "Basic platform targeting the ZC702 board, which includes 1GB of DDR3, 16MB Quad-SPI Flash and an SDIO card interface. More information at https://www.xilinx.com/products/boards-and-kits/ek-z7-zc702-g.html" -hw ./zc702_base.xsa -out ./output  -prebuilt
 
-domain -name xrt -proc ps7_cortexa9_0 -os linux -image ./src/a9/xrt/image
+domain -name xrt -proc ps7_cortexa9 -os linux -image ./src/a9/xrt/image
 domain config -boot ./src/boot
 domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl

--- a/src/platform/zc706_base/zc706_base_pfm.tcl
+++ b/src/platform/zc706_base/zc706_base_pfm.tcl
@@ -3,7 +3,7 @@
 platform -name zc706_base -desc "Basic platform targeting the zc706 board, which includes 1GB of DDR3, 16MB Quad-SPI Flash and an SDIO card interface. More information at https://www.xilinx.com/products/boards-and-kits/ek-z7-zc706-g.html" -hw ./zc706_base.xsa -out ./output  -prebuilt
 
 #system -name xrt -display-name "A9 OpenCL Linux"  -boot ./src/boot  -readme ./src/generic.readme
-domain -name xrt -proc ps7_cortexa9_0 -os linux -image ./src/a9/xrt/image
+domain -name xrt -proc ps7_cortexa9 -os linux -image ./src/a9/xrt/image
 domain config -boot ./src/boot
 domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl

--- a/src/platform/zed_base/zed_base_pfm.tcl
+++ b/src/platform/zed_base/zed_base_pfm.tcl
@@ -3,7 +3,7 @@
 platform -name zed_base -desc "Basic platform targeting the zed board, which includes 1GB of DDR3, 16MB Quad-SPI Flash and an SDIO card interface. More information at https://www.xilinx.com/products/boards-and-kits/ek-z7-zed-g.html" -hw ./zed_base.xsa -out ./output  -prebuilt
 
 #system -name xrt -display-name "A9 OpenCL Linux"  -boot ./src/boot  -readme ./src/generic.readme
-domain -name xrt -proc ps7_cortexa9_0 -os linux -image ./src/a9/xrt/image
+domain -name xrt -proc ps7_cortexa9 -os linux -image ./src/a9/xrt/image
 domain config -boot ./src/boot
 domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl


### PR DESCRIPTION
Signed-off-by: Siva Rajesh Jarugula <sivaraj@xilinx.com>