### PR TITLE
Renamed the SDX ENVs to new tool name ENVs to resolve the CR-1041912

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -528,8 +528,8 @@ namespace xclhwemhal2 {
         launcherArgs = launcherArgs + cmdLineOption.str();
         sim_path = binaryDirectory + "/behav_waveform/xsim";
         std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
-        unsetenv("SDX_LAUNCH_WAVEFORM_BATCH");
-        setenv("SDX_WAVEFORM", generatedWcfgFileName.c_str(), true);
+        unsetenv("VITIS_LAUNCH_WAVEFORM_BATCH");
+        setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
       }
 
       if (lWaveform == xclemulation::LAUNCHWAVEFORM::BATCH)
@@ -543,8 +543,8 @@ namespace xclhwemhal2 {
         launcherArgs = launcherArgs + cmdLineOption.str();
         sim_path = binaryDirectory + "/behav_waveform/xsim";
         std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
-        setenv("SDX_LAUNCH_WAVEFORM_BATCH", "1", true);
-        setenv("SDX_WAVEFORM", generatedWcfgFileName.c_str(), true);
+        setenv("VITIS_LAUNCH_WAVEFORM_BATCH", "1", true);
+        setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
       }
 
       if (userSpecifiedSimPath.empty() == false)


### PR DESCRIPTION
In process of Unified Naming PR, we modified all the SDX ENVs to new tool name ENVs in the RDI code base, and hence we have done respective changes even in the XRT code base