### PR TITLE
display buffer size in dmatest

### DIFF
--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -90,6 +90,7 @@ namespace xcldev {
                     break;
                 mBOList.push_back(bo);
             }
+            std::cout << "Buffer Size: " << mSize/(1024*1024) << " MB\n";
         }
 
         ~DMARunner() {


### PR DESCRIPTION
```
INFO: Found total 1 card(s), 1 are usable
Total DDR size: 65536 MB
Reporting from mem_topology:
Data Validity & DMA Test on bank0
Buffer Size: 256 MB
Host -> PCIe -> FPGA write bandwidth = 9584.11 MB/s
Host <- PCIe <- FPGA read bandwidth = 11957.8 MB/s
INFO: xbutil dmatest succeeded.
```
