### PR TITLE
Fix for zynq7000 platform creation scripts

### DIFF
--- a/src/platform/zc702_base/zc702_base_pfm.tcl
+++ b/src/platform/zc702_base/zc702_base_pfm.tcl
@@ -8,7 +8,7 @@ domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl
 domain -qemu-args ./src/qemu/lnx/qemu_args.txt
 domain -qemu-data ./src/boot
-domain -sysroot ./src/arm-xilinx-linux
+#domain -sysroot ./src/arm-xilinx-linux
 
 platform -generate
 

--- a/src/platform/zc702_base/zc702_base_pfm.tcl
+++ b/src/platform/zc702_base/zc702_base_pfm.tcl
@@ -2,7 +2,7 @@
 
 platform -name zc702_base -desc "Basic platform targeting the ZC702 board, which includes 1GB of DDR3, 16MB Quad-SPI Flash and an SDIO card interface. More information at https://www.xilinx.com/products/boards-and-kits/ek-z7-zc702-g.html" -hw ./zc702_base.xsa -out ./output  -prebuilt
 
-domain -name xrt -proc ps7_cortexa9_0 -os linux -image ./src/a9/xrt/image
+domain -name xrt -proc ps7_cortexa9 -os linux -image ./src/a9/xrt/image
 domain config -boot ./src/boot
 domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl

--- a/src/platform/zc706_base/zc706_base_pfm.tcl
+++ b/src/platform/zc706_base/zc706_base_pfm.tcl
@@ -9,7 +9,7 @@ domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl
 domain -qemu-args ./src/qemu/lnx/qemu_args.txt
 domain -qemu-data ./src/boot
-domain -sysroot ./src/arm-xilinx-linux
+#domain -sysroot ./src/arm-xilinx-linux
 
 platform -generate
 

--- a/src/platform/zc706_base/zc706_base_pfm.tcl
+++ b/src/platform/zc706_base/zc706_base_pfm.tcl
@@ -3,7 +3,7 @@
 platform -name zc706_base -desc "Basic platform targeting the zc706 board, which includes 1GB of DDR3, 16MB Quad-SPI Flash and an SDIO card interface. More information at https://www.xilinx.com/products/boards-and-kits/ek-z7-zc706-g.html" -hw ./zc706_base.xsa -out ./output  -prebuilt
 
 #system -name xrt -display-name "A9 OpenCL Linux"  -boot ./src/boot  -readme ./src/generic.readme
-domain -name xrt -proc ps7_cortexa9_0 -os linux -image ./src/a9/xrt/image
+domain -name xrt -proc ps7_cortexa9 -os linux -image ./src/a9/xrt/image
 domain config -boot ./src/boot
 domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl

--- a/src/platform/zed_base/zed_base_pfm.tcl
+++ b/src/platform/zed_base/zed_base_pfm.tcl
@@ -3,7 +3,7 @@
 platform -name zed_base -desc "Basic platform targeting the zed board, which includes 1GB of DDR3, 16MB Quad-SPI Flash and an SDIO card interface. More information at https://www.xilinx.com/products/boards-and-kits/ek-z7-zed-g.html" -hw ./zed_base.xsa -out ./output  -prebuilt
 
 #system -name xrt -display-name "A9 OpenCL Linux"  -boot ./src/boot  -readme ./src/generic.readme
-domain -name xrt -proc ps7_cortexa9_0 -os linux -image ./src/a9/xrt/image
+domain -name xrt -proc ps7_cortexa9 -os linux -image ./src/a9/xrt/image
 domain config -boot ./src/boot
 domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl

--- a/src/platform/zed_base/zed_base_pfm.tcl
+++ b/src/platform/zed_base/zed_base_pfm.tcl
@@ -9,7 +9,7 @@ domain config -bif ./src/a9/xrt/linux.bif
 domain -runtime opencl
 domain -qemu-args ./src/qemu/lnx/qemu_args.txt
 domain -qemu-data ./src/boot
-domain -sysroot ./src/arm-xilinx-linux
+#domain -sysroot ./src/arm-xilinx-linux
 
 platform -generate
 


### PR DESCRIPTION
comment out the redundant sysroot generations step, fix the cputype metadata for platform