### PR TITLE
fixing an issue of p2p buffer. Shouldnt call migrate buffer for p2p

### DIFF
--- a/src/runtime_src/xocl/api/enqueue.cpp
+++ b/src/runtime_src/xocl/api/enqueue.cpp
@@ -369,7 +369,7 @@ action_ndrange_migrate(cl_event event,cl_kernel kernel)
     for (auto mem : kernel_args) {
       // do not migrate if argument is write only, but trick the code
       // into assuming that the argument is resident
-      if (mem->get_flags() & (CL_MEM_WRITE_ONLY|CL_MEM_HOST_NO_ACCESS)) {
+      if ((mem->get_flags() & CL_MEM_WRITE_ONLY) | (xocl(mem)->no_host_memory())) {
         mem->set_resident(device);
         continue;
       }


### PR DESCRIPTION
There is a check added recently in migrate_buffer to errorout if p2p buffer is getting migrated. This makes sense of host is using this. But EnqueuNdRangeKernel also migrates all the READ_ONLY/READ_WRITE buffers. We should not call migrate from this function aswell