### PR TITLE
bug fix aws plugin & azure plugin

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -266,6 +266,10 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		userpf_err(xdev, "invalid xclbin magic string\n");
 		return -EINVAL;
 	}
+	if (uuid_is_null(&bin_obj.m_header.uuid)) {
+		userpf_err(xdev, "invalid xclbin uuid\n");
+		return -EINVAL;
+	}
 
 	xclbin_id = XOCL_XCLBIN_ID(xdev);
 	if (xclbin_id && uuid_equal(xclbin_id, &bin_obj.m_header.uuid)) {

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -514,6 +514,8 @@ AwsDev::~AwsDev()
 #ifdef INTERNAL_TESTING_FOR_AWS
     if (mMgtHandle > 0)
         close(mMgtHandle);
+#else
+    fpga_mgmt_close(); // aws-fpga version newer than 09/2019 need this
 #endif
     if (mLogStream.is_open()) {
         mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
@@ -540,6 +542,7 @@ AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index), mLo
         throw std::runtime_error("Can't open /dev/awsmgmt");
 
 #else
+    fpga_mgmt_init(); // aws-fpga version newer than 09/2019 need this
     loadDefaultAfiIfCleared();
     //bar0 is mapped already. seems other 2 bars are not required.
 #endif

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -186,7 +186,7 @@ int AzureDev::azureLoadXclBin(const xclBin *&buffer)
     std::string ret, key, value;
     ret = REST_Get(
         RESTIP_ENDPOINT,
-        "/machine/plugins/?comp=FpgaController&type=StartReimaging",
+        "machine/plugins/?comp=FpgaController&type=StartReimaging",
         fpgaSerialNumber
     );
     if (splitLine(ret, key, value, delim) != 0 ||
@@ -199,7 +199,7 @@ int AzureDev::azureLoadXclBin(const xclBin *&buffer)
     do {
         ret = REST_Get(
             RESTIP_ENDPOINT,
-            "/machine/plugins/?comp=FpgaController&type=GetReimagingStatus",
+            "machine/plugins/?comp=FpgaController&type=GetReimagingStatus",
             fpgaSerialNumber
         );
         if (splitLine(ret, key, value, delim) != 0 ||

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -746,7 +746,7 @@ public:
         sensor_tree::put( "board.info.subvendor",      subvendor );
         sensor_tree::put( "board.info.xmcversion",     xmc_ver );
         sensor_tree::put( "board.info.serial_number",  ser_num );
-        sensor_tree::put( "board.info.max_power",      lvl2PowerStr(stoi(max_power)) );
+        sensor_tree::put( "board.info.max_power",      lvl2PowerStr(max_power.empty() ? UINT_MAX : stoi(max_power)) );
         sensor_tree::put( "board.info.sc_version",     bmc_ver );
         sensor_tree::put( "board.info.ddr_size",       GB(ddr_size)*ddr_count );
         sensor_tree::put( "board.info.ddr_count",      ddr_count );

--- a/src/runtime_src/core/pcie/user_aws/shim.h
+++ b/src/runtime_src/core/pcie/user_aws/shim.h
@@ -94,7 +94,7 @@ public:
 
 
   // Bitstreams
-  int xclGetXclBinIdFromSysfs(uint64_t &xclbinid);
+  int xclGetXclBinIdFromSysfs(uuid_t &xclbinid);
   int xclLoadXclBin(const xclBin *buffer);
   int xclLoadAxlf(const axlf *buffer);
   int xclUpgradeFirmware(const char *fileName);


### PR DESCRIPTION
This PR contains several bugfixs:

1. azure wireserver production version doesn't support URI with "//", so the plugin need to make sure when URI is created, only '/' is being used.
2. aws new aws-fpga library has recent update, so the aws plugin need to change accordingly
3. aws load old version of xclbin where the uuid is empty will result in crash in icap.c
    2426 BUG_ON(uuid_is_null(id));
4. awssak crash fixes forward-port to 2019.2 in case sometimes one wants to use awssak before it is removed