### PR TITLE
wireserver product version doesn't support // in uri

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -186,7 +186,7 @@ int AzureDev::azureLoadXclBin(const xclBin *&buffer)
 	std::string ret, key, value;
 	ret	= REST_Get(
 		RESTIP_ENDPOINT,
-		"/machine/plugins/?comp=FpgaController&type=StartReimaging",
+		"machine/plugins/?comp=FpgaController&type=StartReimaging",
 		fpgaSerialNumber
 	);
 	if (splitLine(ret, key, value, delim) != 0 ||
@@ -199,7 +199,7 @@ int AzureDev::azureLoadXclBin(const xclBin *&buffer)
 	do {
 		ret = REST_Get(
 			RESTIP_ENDPOINT,
-			"/machine/plugins/?comp=FpgaController&type=GetReimagingStatus",
+			"machine/plugins/?comp=FpgaController&type=GetReimagingStatus",
 			fpgaSerialNumber
 		);
 		if (splitLine(ret, key, value, delim) != 0 ||


### PR DESCRIPTION
Microsoft wireserver product version doesn't allow "//" in uri, although both the standalone version and RFC allow.

There is no difference to the standalone wireserver with or without the fix. The fix has been verified by Microsoft. 