### PR TITLE
Refine behavior on CL_MEM_WRITE_ONLY buffer

### DIFF
--- a/src/runtime_src/xocl/api/clEnqueueMapBuffer.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueMapBuffer.cpp
@@ -45,6 +45,9 @@ validOrError(cl_command_queue command_queue,
   detail::memory::validOrError(buffer,map_flags,offset,size);
   detail::event::validOrError(command_queue,num_events_in_wait_list,event_wait_list);
 
+  if ((xocl(buffer)->get_flags() & CL_MEM_WRITE_ONLY) && map_flags == CL_MAP_WRITE)
+    throw error(CL_MAP_FAILURE,"Map CL_MEM_WRITE_ONLY buffer for write is undefined");
+
   auto ctx1 = xocl(command_queue)->get_context();
   if (ctx1 != xocl(buffer)->get_context())
     throw error(CL_INVALID_CONTEXT,"context of objects do not match");

--- a/src/runtime_src/xocl/api/enqueue.cpp
+++ b/src/runtime_src/xocl/api/enqueue.cpp
@@ -519,6 +519,13 @@ action_migrate_memobjects(size_t num, const cl_mem* memobjs, cl_mem_migration_fl
         continue;
       }
 
+      // do not migrate if argument is write only, but trick the code
+      // into assuming that the argument is resident
+      if (xocl::xocl(mem)->get_flags() & (CL_MEM_WRITE_ONLY|CL_MEM_HOST_NO_ACCESS)) {
+          xocl::xocl(mem)->set_resident(device);
+          continue;
+      }
+
       auto at = (flags & CL_MIGRATE_MEM_OBJECT_HOST) ? async_type::read : async_type::write;
       xdevice->schedule(migrate_buffer,at,ec,device,mem,flags);
     }


### PR DESCRIPTION
1. Do not map CL_MEM_WRITE_ONLY buffer for write.
2. No need to sync data to CL_MEM_WRITE_ONLY buffer.