### PR TITLE
Undo explicitly migrate change

### DIFF
--- a/src/runtime_src/xocl/api/enqueue.cpp
+++ b/src/runtime_src/xocl/api/enqueue.cpp
@@ -519,13 +519,6 @@ action_migrate_memobjects(size_t num, const cl_mem* memobjs, cl_mem_migration_fl
         continue;
       }
 
-      // do not migrate if argument is write only, but trick the code
-      // into assuming that the argument is resident
-      if (xocl::xocl(mem)->get_flags() & (CL_MEM_WRITE_ONLY|CL_MEM_HOST_NO_ACCESS)) {
-          xocl::xocl(mem)->set_resident(device);
-          continue;
-      }
-
       auto at = (flags & CL_MIGRATE_MEM_OBJECT_HOST) ? async_type::read : async_type::write;
       xdevice->schedule(migrate_buffer,at,ec,device,mem,flags);
     }


### PR DESCRIPTION
Failure when trying to migrate write_only buffer back from device to
host.  Need more testing before commiting changes to avoid unncessary
migrate.