### PR TITLE
[Edge] if timeout is 0, no timeout check

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -350,6 +350,9 @@ cu_idx_to_timeout(struct drm_device *dev, unsigned int cu_idx)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
 
+	if (!zdev->exec->zcu[cu_idx].run_timeout)
+		return 0;
+
 	return zdev->exec->zcu[cu_idx].run_timeout /
 	    (ZOCL_CU_TIMER_INTERVAL * 1000) + 1;
 }


### PR DESCRIPTION
If zcu->run_timeout is 0, it means do not need to check timeout.