### PR TITLE
Metadata update to exclude versal device for unsupported tests

### DIFF
--- a/tests/unit_test/cdma/testinfo.yml
+++ b/tests/unit_test/cdma/testinfo.yml
@@ -4,6 +4,7 @@ level: 6
 owner: soeren
 user:
   allowed_test_modes: [hw]
+  excl_platforms: [xilinx_v350-es1_xdma_201920_1]
   force_makefile: "--force"
   host_args: {all: addone.xclbin}
   host_cflags: ' -DDSA64'

--- a/tests/unit_test/cuselect/testinfo.yml
+++ b/tests/unit_test/cuselect/testinfo.yml
@@ -4,6 +4,7 @@ level: 6
 owner: soeren
 user:
   allowed_test_modes: [hw]
+  excl_platforms: [xilinx_v350-es1_xdma_201920_1]
   force_makefile: "--force"
   host_args: {all: cuselect.xclbin}
   host_cflags: ' -DDSA64'

--- a/tests/unit_test/subdevice/testinfo.yml
+++ b/tests/unit_test/subdevice/testinfo.yml
@@ -4,6 +4,7 @@ level: 6
 owner: soeren
 user:
   allowed_test_modes: [hw]
+  excl_platforms: [xilinx_v350-es1_xdma_201920_1]
   force_makefile: "--force"
   host_args: {all: addone.xclbin}
   host_cflags: ' -DDSA64'


### PR DESCRIPTION
DDR banks won't work with versal. So, update metadata to exclude unsupported tests 