### PR TITLE
[Edge] kds state timestamp

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.h
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.h
@@ -209,10 +209,17 @@ struct sched_cmd {
 	 */
 	int check_timeout;
 
+	/*
+	 * If this flag is set, record time stamps in the user's command
+	 * package when the command state change.
+	 */
+	bool timestamp_enabled;
+
 	/* The actual cmd object representation */
 	union {
 		struct ert_packet *packet;
 		struct ert_start_copybo_cmd *ert_cp;
+		struct ert_start_kernel_cmd *ert_cu;
 	};
 
 	zocl_dma_handle_t dma_handle;


### PR DESCRIPTION
The same solution like PCIe platform.

The edge zocl driver recorded timestamps of CU start and done in the first 4 data of regmap. Keep this approach for one more release.