### PR TITLE
Fix for the unit_tests

### DIFF
--- a/tests/unit_test/002_bitonic_sort/testinfo.yml
+++ b/tests/unit_test/002_bitonic_sort/testinfo.yml
@@ -8,7 +8,7 @@ user:
   host_args: {all: -k kernel.xclbin}
   host_cflags: ' -DDSA64 -DFLOW_HLS_CSIM'
   host_exe: host.exe
-  host_src: test-cl.cpp
+  host_src: utils.cpp test-cl.cpp
   kernels:
   - {cflags: {all: ' -I.'}, file: bitonicsort.xo, ksrc: kernel.cl, name: bitonicsort, type: C}
   name: 002_bitonic_sort

--- a/tests/unit_test/003_bringup0/kernel.cl
+++ b/tests/unit_test/003_bringup0/kernel.cl
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2016-2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifdef __xilinx__
+__attribute__ ((reqd_work_group_size(1, 1, 1)))
+#endif
+kernel void loopback (global char * restrict s1,
+                      global const char *s2,
+                      int length)
+{
+#ifdef __xilinx__
+    __attribute__((xcl_pipeline_loop))
+#endif
+    for (int i = 0; i < length; i++) {
+        s1[i] = s2[i];
+    }
+}

--- a/tests/unit_test/003_bringup0/main.cpp
+++ b/tests/unit_test/003_bringup0/main.cpp
@@ -208,15 +208,32 @@ int main(int argc, char** argv)
 
     KernelHostData hostData(length);
 
+    oclSoftware software;
+    std::memset(&software, 0, sizeof(oclSoftware));
+    std::strcpy(software.mKernelName, "loopback");
+    std::strcpy(software.mFileName, kernelFile.c_str());
+    std::sprintf(software.mCompileOptions, "");
+    
+    getOclSoftware(software, hardware);
+
     try {
         KernelDeviceData deviceData(hostData, hardware.mContext);
         cl_mem seq1 = deviceData.getSequence1();
         cl_mem seq2 = deviceData.getSequence2();
 
+        cl_int err = clSetKernelArg(software.mKernel, 0, sizeof(cl_mem), &seq1);
+        checkStatus(err);
+
+        err = clSetKernelArg(software.mKernel, 1, sizeof(cl_mem), &seq2);
+        checkStatus(err);
+
+        err = clSetKernelArg(software.mKernel, 2, 4, &length);
+        checkStatus(err);
+
         std::cout << "Sequence1: " << hostData.getSequence1() << "\n";
         std::cout << "Sequence2: " << hostData.getSequence2() << "\n";
 
-        cl_int err = clEnqueueCopyBuffer(hardware.mQueue, seq2, seq1, 0, 0, hostData.getLength(), 0, NULL, NULL);
+        err = clEnqueueCopyBuffer(hardware.mQueue, seq2, seq1, 0, 0, hostData.getLength(), 0, NULL, NULL);
         checkStatus(err);
 
         err = clFinish(hardware.mQueue);

--- a/tests/unit_test/003_bringup0/testinfo.yml
+++ b/tests/unit_test/003_bringup0/testinfo.yml
@@ -5,12 +5,20 @@ owner: sonals
 user:
   allowed_test_modes: [sw_emu, hw_emu, hw]
   force_makefile: "--force"
-  host_args: {all: -d acc}
+  host_args: {all: -k kernel.xclbin -d acc}
   host_cflags: ' -DDSA64'
   host_exe: host.exe
   host_src: main.cpp oclErrorCodes.cpp oclHelper.cpp
   name: 003_bringup0
-  only_host_code: 1 
+  kernels:
+  - {cflags: {all: ' -I.'}, file: loopback.xo, ksrc: kernel.cl, name: loopback, type: C}
+  xclbins:
+  - files: 'loopback.xo '
+    kernels:
+    - cus: [loopback_cu0]
+      name: loopback
+      num_cus: 1
+    name: kernel.xclbin
   labels:
     test_type: ['regression']
   sdx_type: [sdx_fast]

--- a/tests/unit_test/005_bringup2/kernel.cl
+++ b/tests/unit_test/005_bringup2/kernel.cl
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2016-2018 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifdef __xilinx__
+__attribute__ ((reqd_work_group_size(1, 1, 1)))
+#endif
+kernel void loopback (global char * restrict s1,
+                      global const char *s2,
+                      int length)
+{
+#ifdef __xilinx__
+    __attribute__((xcl_pipeline_loop))
+#endif
+    for (int i = 0; i < length; i++) {
+        s1[i] = s2[i];
+    }
+}

--- a/tests/unit_test/005_bringup2/main.cpp
+++ b/tests/unit_test/005_bringup2/main.cpp
@@ -208,11 +208,29 @@ int main(int argc, char** argv)
 
     KernelHostData hostData(length);
 
+    oclSoftware software;
+    std::memset(&software, 0, sizeof(oclSoftware));
+    std::strcpy(software.mKernelName, "loopback");
+    std::strcpy(software.mFileName, kernelFile.c_str());
+    std::sprintf(software.mCompileOptions, "");
+    
+    getOclSoftware(software, hardware);
+
     try {
         std::cout << "Sequence1: " << hostData.getSequence1() << "\n";
         std::cout << "Sequence2: " << hostData.getSequence2() << "\n";
         cl_int err = CL_SUCCESS;
         cl_mem mSequence = clCreateBuffer(hardware.mContext, CL_MEM_READ_WRITE, hostData.getLength(), NULL, &err);
+
+        err = clSetKernelArg(software.mKernel, 0, sizeof(cl_mem), &mSequence);
+        checkStatus(err);
+
+        //err = clSetKernelArg(software.mKernel, 1, sizeof(cl_mem), &seq2);
+        //checkStatus(err);
+
+        //err = clSetKernelArg(software.mKernel, 2, 4, &length);
+        //checkStatus(err);
+
         err = clEnqueueWriteBuffer(hardware.mQueue, mSequence, CL_FALSE, 0, hostData.getLength(), hostData.getSequence2(), 0, NULL, NULL);
         checkStatus(err);
         if ((hardware.mMajorVersion >= 1) && (hardware.mMinorVersion > 1)) {

--- a/tests/unit_test/005_bringup2/testinfo.yml
+++ b/tests/unit_test/005_bringup2/testinfo.yml
@@ -5,12 +5,20 @@ owner: sonals
 user:
   allowed_test_modes: [sw_emu, hw_emu, hw]
   force_makefile: "--force"
-  host_args: {all: -d acc}
+  host_args: {all: -k kernel.xclbin -d acc}
   host_cflags: ' -DDSA64'
   host_exe: host.exe
   host_src: main.cpp oclErrorCodes.cpp oclHelper.cpp
   name: 005_bringup2
-  only_host_code: 1
+  kernels:
+  - {cflags: {all: ' -I.'}, file: loopback.xo, ksrc: kernel.cl, name: loopback, type: C}
+  xclbins:
+  - files: 'loopback.xo '
+    kernels:
+    - cus: [loopback_cu0]
+      name: loopback
+      num_cus: 1
+    name: kernel.xclbin
   labels:
     test_type: ['regression']
   sdx_type: [sdx_fast]

--- a/tests/unit_test/hostsrc/utils.hpp
+++ b/tests/unit_test/hostsrc/utils.hpp
@@ -20,7 +20,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <chrono>
-#include <boost/align/aligned_allocator.hpp>
+//#include <boost/align/aligned_allocator.hpp>
 
 #define CL_TARGET_OPENCL_VERSION 120
 #define CL_HPP_MINIMUM_OPENCL_VERSION 120
@@ -40,8 +40,8 @@
 
 namespace utils {
 
-template <typename T>
-using aligned_allocator = boost::alignment::aligned_allocator<T, 4096>;
+//template <typename T>
+//using aligned_allocator = boost::alignment::aligned_allocator<T, 4096>;
   
 /**
  * @return


### PR DESCRIPTION
Fix for the these unit_tests:
- 000_verify: hostsrc fix for removing unused code
- 002_bitonic_sort: metadata fix to include utils.cpp properly
- 003_bringup0: Host code fix to download xclbin properly
- 005_bringup2: Host code fix to download xclbin properly