### PR TITLE
scheduler reset after xclbin load for PR

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2785,7 +2785,7 @@ static irqreturn_t sched_cq_isr(int irq, void *arg)
 
 inline void init_exec(struct sched_exec_core *exec_core)
 {
-	unsigned int i;
+        unsigned int i;
         exec_core->scheduler = &g_sched0;
         exec_core->num_slots = 16;
         exec_core->num_cus = 0;

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2818,7 +2818,6 @@ inline void init_exec(struct sched_exec_core *exec_core)
  * 
  * This function ensures that the device exec_core state is reset to
  * same state as was when scheduler was originally probed for the device.
- * This gets called after each xclbin load. This gets called for the first time also
  *
  * @drm: Device node to initialize
  *

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -1556,7 +1556,6 @@ delete_cmd_list(void)
  * Clear stale command object associated with execution core.
  * This can occur if the HW for some reason hangs.
  */
-SCHED_UNUSED
 static void
 reset_exec(struct sched_exec_core *exec)
 {
@@ -2784,6 +2783,36 @@ static irqreturn_t sched_cq_isr(int irq, void *arg)
 	return IRQ_HANDLED;
 }
 
+inline void init_exec(struct sched_exec_core *exec_core)
+{
+	unsigned int i;
+        exec_core->scheduler = &g_sched0;
+        exec_core->num_slots = 16;
+        exec_core->num_cus = 0;
+        exec_core->cu_base_addr = 0;
+        exec_core->cu_shift_offset = 0;
+        exec_core->polling_mode = 1;
+        exec_core->cq_interrupt = 0;
+        exec_core->configured = 0;
+        exec_core->cu_isr = 0;
+        exec_core->cu_dma = 0;
+        exec_core->num_slot_masks = 1;
+        exec_core->num_cu_masks = 0;
+        exec_core->ops = &penguin_ops;
+
+        for (i = 0; i < MAX_SLOTS; ++i)
+                exec_core->submitted_cmds[i] = NULL;
+
+        for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
+                exec_core->slot_status[i] = 0;
+
+        for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
+                exec_core->cu_status[i] = 0;
+                exec_core->cu_init[i] = 0;
+                exec_core->cu_valid[i] = 0; //default value is invalid(0)
+        }
+}
+
 /**
  * zocl_exec_reset() 
  * 
@@ -2797,36 +2826,10 @@ static irqreturn_t sched_cq_isr(int irq, void *arg)
 int
 zocl_exec_reset(struct drm_device *drm)
 {
-	unsigned int i;
 	struct drm_zocl_dev *zdev = drm->dev_private;
 	struct sched_exec_core *exec_core = zdev->exec;
 
-	exec_core->scheduler = &g_sched0;
-	exec_core->num_slots = 16;
-	exec_core->num_cus = 0;
-	exec_core->cu_base_addr = 0;
-	exec_core->cu_shift_offset = 0;
-	exec_core->polling_mode = 1;
-	exec_core->cq_interrupt = 0;
-	exec_core->configured = 0;
-	exec_core->cu_isr = 0;
-	exec_core->cu_dma = 0;
-	exec_core->num_slot_masks = 1;
-	exec_core->num_cu_masks = 0;
-	exec_core->ops = &penguin_ops;
-
-	for (i = 0; i < MAX_SLOTS; ++i)
-		exec_core->submitted_cmds[i] = NULL;
-
-	for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
-		exec_core->slot_status[i] = 0;
-
-	for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
-		exec_core->cu_status[i] = 0;
-		exec_core->cu_init[i] = 0;
-		exec_core->cu_valid[i] = 0;
-	}
-
+	init_exec(exec_core);
 	reset_exec(exec_core);
 	return 0;
 }
@@ -2856,31 +2859,7 @@ sched_init_exec(struct drm_device *drm)
 	INIT_LIST_HEAD(&exec_core->ctx_list);
 	init_waitqueue_head(&exec_core->poll_wait_queue);
 
-	exec_core->scheduler = &g_sched0;
-	exec_core->num_slots = 16;
-	exec_core->num_cus = 0;
-	exec_core->cu_base_addr = 0;
-	exec_core->cu_shift_offset = 0;
-	exec_core->polling_mode = 1;
-	exec_core->cq_interrupt = 0;
-	exec_core->cu_isr = 0;
-	exec_core->cu_dma = 0;
-	exec_core->num_slot_masks = 1;
-	exec_core->num_cu_masks = 0;
-	exec_core->ops = &penguin_ops;
-
-	for (i = 0; i < MAX_SLOTS; ++i)
-		exec_core->submitted_cmds[i] = NULL;
-
-	for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
-		exec_core->slot_status[i] = 0;
-
-	for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
-		exec_core->cu_status[i] = 0;
-		exec_core->cu_init[i] = 0;
-		exec_core->cu_valid[i] = 0; //default value is invalid(0)
-	}
-
+	init_exec(exec_core);
 	init_scheduler_thread();
 
 	if (zdev->ert) {

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2785,6 +2785,53 @@ static irqreturn_t sched_cq_isr(int irq, void *arg)
 }
 
 /**
+ * zocl_exec_reset() 
+ * 
+ * This function ensures that the device exec_core state is reset to
+ * same state as was when scheduler was originally probed for the device.
+ * This gets called after each xclbin load. This gets called for the first time also
+ *
+ * @drm: Device node to initialize
+ *
+ */
+int
+zocl_exec_reset(struct drm_device *drm)
+{
+	unsigned int i;
+	struct drm_zocl_dev *zdev = drm->dev_private;
+	struct sched_exec_core *exec_core = zdev->exec;
+
+	exec_core->scheduler = &g_sched0;
+	exec_core->num_slots = 16;
+	exec_core->num_cus = 0;
+	exec_core->cu_base_addr = 0;
+	exec_core->cu_shift_offset = 0;
+	exec_core->polling_mode = 1;
+	exec_core->cq_interrupt = 0;
+	exec_core->configured = 0;
+	exec_core->cu_isr = 0;
+	exec_core->cu_dma = 0;
+	exec_core->num_slot_masks = 1;
+	exec_core->num_cu_masks = 0;
+	exec_core->ops = &penguin_ops;
+
+	for (i = 0; i < MAX_SLOTS; ++i)
+		exec_core->submitted_cmds[i] = NULL;
+
+	for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
+		exec_core->slot_status[i] = 0;
+
+	for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
+		exec_core->cu_status[i] = 0;
+		exec_core->cu_init[i] = 0;
+		exec_core->cu_valid[i] = 0;
+	}
+
+	reset_exec(exec_core);
+	return 0;
+}
+
+/**
  * sched_init_exec() - Initialize the command execution for device
  *
  * @drm: Device node to initialize

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2825,9 +2825,16 @@ inline void init_exec(struct sched_exec_core *exec_core)
 int
 zocl_exec_reset(struct drm_device *drm)
 {
+	unsigned int i;
 	struct drm_zocl_dev *zdev = drm->dev_private;
 	struct sched_exec_core *exec_core = zdev->exec;
 
+	if (!(zdev->ert || exec_core->polling_mode)) {
+		for (i = 0; i < exec_core->num_cus; i++) {
+			if (zocl_cu_is_valid(exec_core, i))
+				free_irq(zdev->irq[i], zdev);
+		}
+	}
 	init_exec(exec_core);
 	reset_exec(exec_core);
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2785,32 +2785,32 @@ static irqreturn_t sched_cq_isr(int irq, void *arg)
 
 inline void init_exec(struct sched_exec_core *exec_core)
 {
-        unsigned int i;
-        exec_core->scheduler = &g_sched0;
-        exec_core->num_slots = 16;
-        exec_core->num_cus = 0;
-        exec_core->cu_base_addr = 0;
-        exec_core->cu_shift_offset = 0;
-        exec_core->polling_mode = 1;
-        exec_core->cq_interrupt = 0;
-        exec_core->configured = 0;
-        exec_core->cu_isr = 0;
-        exec_core->cu_dma = 0;
-        exec_core->num_slot_masks = 1;
-        exec_core->num_cu_masks = 0;
-        exec_core->ops = &penguin_ops;
+	unsigned int i;
+	exec_core->scheduler = &g_sched0;
+	exec_core->num_slots = 16;
+	exec_core->num_cus = 0;
+	exec_core->cu_base_addr = 0;
+	exec_core->cu_shift_offset = 0;
+	exec_core->polling_mode = 1;
+	exec_core->cq_interrupt = 0;
+	exec_core->configured = 0;
+	exec_core->cu_isr = 0;
+	exec_core->cu_dma = 0;
+	exec_core->num_slot_masks = 1;
+	exec_core->num_cu_masks = 0;
+	exec_core->ops = &penguin_ops;
 
-        for (i = 0; i < MAX_SLOTS; ++i)
-                exec_core->submitted_cmds[i] = NULL;
+	for (i = 0; i < MAX_SLOTS; ++i)
+		exec_core->submitted_cmds[i] = NULL;
 
-        for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
-                exec_core->slot_status[i] = 0;
+	for (i = 0; i < MAX_U32_SLOT_MASKS; ++i)
+		exec_core->slot_status[i] = 0;
 
-        for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
-                exec_core->cu_status[i] = 0;
-                exec_core->cu_init[i] = 0;
-                exec_core->cu_valid[i] = 0; //default value is invalid(0)
-        }
+	for (i = 0; i < MAX_U32_CU_MASKS; ++i) {
+		exec_core->cu_status[i] = 0;
+		exec_core->cu_init[i] = 0;
+		exec_core->cu_valid[i] = 0; //default value is invalid(0)
+	}
 }
 
 /**

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.h
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.h
@@ -241,6 +241,7 @@ struct sched_ops {
 int sched_init_exec(struct drm_device *drm);
 int sched_fini_exec(struct drm_device *drm);
 
+int zocl_exec_reset(struct drm_device *dev);
 void zocl_track_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 void zocl_untrack_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -682,6 +682,7 @@ zocl_read_axlf_ioctl(struct drm_device *ddev, void *data, struct drm_file *filp)
 		goto out0;
 	}
 
+	zocl_clear_mem(zdev);
 	zocl_init_mem(zdev, zdev->topology);
 
 	zdev->unique_id_last_bitstream = axlf_head.m_uniqueId;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -686,6 +686,12 @@ zocl_read_axlf_ioctl(struct drm_device *ddev, void *data, struct drm_file *filp)
 
 	zdev->unique_id_last_bitstream = axlf_head.m_uniqueId;
 
+	/*
+	 * xclbin download changes PR region, make sure next
+	 * ERT configure cmd will go through
+	 */
+	zocl_exec_reset(ddev);
+
 out0:
 	write_unlock(&zdev->attr_rwlock);
 	if (size < 0)

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -58,10 +58,15 @@ static ssize_t kds_custat_show(struct device *dev,
 	u32 usage;
 	int i;
 
-	if (!zdev || !zdev->exec)
+	if (!zdev)
 		return 0;
 
 	read_lock(&zdev->attr_rwlock);
+
+	if (!zdev->exec) {
+		read_unlock(&zdev->attr_rwlock);
+		return 0;
+	}
 
 	for (i = 0; i < zdev->exec->num_cus; i++) {
 		paddr = zocl_cu_get_paddr(&zdev->exec->zcu[i]);
@@ -92,12 +97,18 @@ static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 	const char *raw_fmt = "%llu %d\n";
 	int i;
 
-	if (!zdev || !zdev->topology || !zdev->mem)
+	if (!zdev)
 		return 0;
+
+	read_lock(&zdev->attr_rwlock);
+
+	if (!zdev->topology || !zdev->mem) {
+		read_unlock(&zdev->attr_rwlock);
+		return 0;
+	}
 
 	memp = zdev->mem;
 	topo = zdev->topology;
-	read_lock(&zdev->attr_rwlock);
 
 	for (i = 0; i < topo->m_count; i++) {
 		if (topo->m_mem_data[i].m_type == MEM_STREAMING)
@@ -157,10 +168,15 @@ static ssize_t read_debug_ip_layout(struct file *filp, struct kobject *kobj,
 	u32 nread = 0;
 
 	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
-	if (!zdev || !zdev->debug_ip)
+	if (!zdev)
 		return 0;
 
 	read_lock(&zdev->attr_rwlock);
+
+	if (!zdev->debug_ip) {
+		read_unlock(&zdev->attr_rwlock);
+		return 0;
+	}
 
 	size = sizeof_section(zdev->debug_ip, m_debug_ip_data);
 
@@ -189,10 +205,15 @@ static ssize_t read_ip_layout(struct file *filp, struct kobject *kobj,
 	u32 nread = 0;
 
 	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
-	if (!zdev || !zdev->ip)
+	if (!zdev)
 		return 0;
 
 	read_lock(&zdev->attr_rwlock);
+
+	if (!zdev->ip) {
+		read_unlock(&zdev->attr_rwlock);
+		return 0;
+	}
 
 	size = sizeof_section(zdev->ip, m_ip_data);
 
@@ -221,10 +242,15 @@ static ssize_t read_connectivity(struct file *filp, struct kobject *kobj,
 	u32 nread = 0;
 
 	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
-	if (!zdev || !zdev->connectivity)
+	if (!zdev)
 		return 0;
 
 	read_lock(&zdev->attr_rwlock);
+
+	if (!zdev->connectivity) {
+		read_unlock(&zdev->attr_rwlock);
+		return 0;
+	}
 
 	size = sizeof_section(zdev->connectivity, m_connection);
 
@@ -253,10 +279,15 @@ static ssize_t read_mem_topology(struct file *filp, struct kobject *kobj,
 	u32 nread = 0;
 
 	zdev = dev_get_drvdata(container_of(kobj, struct device, kobj));
-	if (!zdev || !zdev->topology)
+	if (!zdev)
 		return 0;
 
 	read_lock(&zdev->attr_rwlock);
+
+	if (!zdev->topology) {
+		read_unlock(&zdev->attr_rwlock);
+		return 0;
+	}
 
 	size = sizeof_section(zdev->topology, m_mem_data);
 


### PR DESCRIPTION
* Reset scheduler state after loading new xclbin.
* This solves single process doing multiple xclbin loading issue.
* This solves the case where Applications run one after other with different xclbins
* This doesn't solve multiple threads/processes loading different xclbins at same time. This can be done using context (TODO). 