### PR TITLE
display warning when aux cable is not connected 

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1350,6 +1350,9 @@ int xcldev::device::validate(bool quick)
     bool withWarning = false;
     int retVal = 0;
 
+    if (!isAuxConnected())
+        std::cout << "WARNING: No aux cable connected." << std::endl;
+
     // Check pcie training
     retVal = runOneTest("PCIE link check",
             std::bind(&xcldev::device::pcieLinkTest, this));

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1214,13 +1214,6 @@ int xcldev::device::pcieLinkTest(void)
     return 0;
 }
 
-bool isU2xxBoard(std::string& bd_name)
-{
-    if (strstr( bd_name.c_str(), "U200" ) || strstr( bd_name.c_str(), "U250" ) || strstr( bd_name.c_str(), "U280" ))
-        return true;
-    return false;
-}
-
 int xcldev::device::auxConnectionTest(void) 
 {
     std::string name, errmsg;
@@ -1235,8 +1228,10 @@ int xcldev::device::auxConnectionTest(void)
     pcidev::get_dev(m_idx)->sysfs_get( "xmc", "max_power",  errmsg, max_power );
 
     //check aux cable if board u200, u250, u280
-    if(isU2xxBoard(name) && max_power == 0 ) {
-        std::cout << "WARN: == No AUX power connected." << std::endl;
+    if((strstr( name.c_str(), "U200" ) || strstr( name.c_str(), "U250" ) || 
+        strstr( name.c_str(), "U280" )) && max_power == 0 ) {
+        std::cout << "AUX POWER NOT CONNECTED, ATTENTION" << std::endl;
+        std::cout << "Board not stable for heavy acceleration tasks." << std::endl;
         return 1;
     }
     return 0;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1716,6 +1716,21 @@ public:
         return false;
     }
 
+    bool isAuxConnected(void) {
+        std::string name, errmsg;
+        unsigned short m12v_aux_vol = 0, m3v3_aux_vol = 0;
+
+        pcidev::get_dev(m_idx)->sysfs_get( "rom", "VBNV", errmsg, name );
+        pcidev::get_dev(m_idx)->sysfs_get( "xmc", "xmc_12v_aux_vol",  errmsg, m12v_aux_vol );
+        pcidev::get_dev(m_idx)->sysfs_get( "xmc", "xmc_3v3_aux_vol",  errmsg, m3v3_aux_vol );
+
+        //check aux cable if not u2xx
+        if(strstr( name.c_str(), "_u2" ) && m12v_aux_vol == 0 && m3v3_aux_vol == 0 ) {
+            return false;
+        }
+        return true;
+    }
+
     int validate(bool quick);
 
     int reset(xclResetKind kind);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1716,21 +1716,6 @@ public:
         return false;
     }
 
-    bool isAuxConnected(void) {
-        std::string name, errmsg;
-        unsigned short m12v_aux_vol = 0, m3v3_aux_vol = 0;
-
-        pcidev::get_dev(m_idx)->sysfs_get( "rom", "VBNV", errmsg, name );
-        pcidev::get_dev(m_idx)->sysfs_get( "xmc", "xmc_12v_aux_vol",  errmsg, m12v_aux_vol );
-        pcidev::get_dev(m_idx)->sysfs_get( "xmc", "xmc_3v3_aux_vol",  errmsg, m3v3_aux_vol );
-
-        //check aux cable if not u2xx
-        if(strstr( name.c_str(), "_u2" ) && m12v_aux_vol == 0 && m3v3_aux_vol == 0 ) {
-            return false;
-        }
-        return true;
-    }
-
     int validate(bool quick);
 
     int reset(xclResetKind kind);
@@ -1754,6 +1739,7 @@ private:
     int dmaXbtest(void);
 
     int pcieLinkTest(void);
+    int auxConnectionTest(void);
     int verifyKernelTest(void);
     int bandwidthKernelTest(void);
     // testFunc must return 0 for success, 1 for warning, and < 0 for error


### PR DESCRIPTION
- check aux cable (xmc_12v_aux_vol and xmc_3v3_aux_vol) only for u2xx boards
- When an aux is connected:
```
$xbutil validate -q
INFO: Found 2 cards

INFO: Validating card[0]: xilinx_u250_xdma_201830_2
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated successfully.

INFO: Validating card[1]: xilinx_u50_xdma_201920_1
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[1] validated successfully.

INFO: All cards validated successfully.
```

- When an aux is not connected:
```
$xbutil validate -q
INFO: Found 2 cards

INFO: Validating card[0]: xilinx_u250_xdma_201830_2
WARNING: No aux cable connected.
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated successfully.

INFO: Validating card[1]: xilinx_u50_xdma_201920_1
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[1] validated successfully.

INFO: All cards validated successfully.
```
