### PR TITLE
Refine edge XRT print

### DIFF
--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -64,7 +64,6 @@ public:
   unsigned int xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags);
   unsigned int xclGetHostBO(uint64_t paddr, size_t size);
   void xclFreeBO(unsigned int boHandle);
-  int xclGetBOInfo(uint64_t handle);
   int xclWriteBO(unsigned int boHandle, const void *src, size_t size,
                  size_t seek);
   int xclReadBO(unsigned int boHandle, void *dst, size_t size, size_t skip);
@@ -97,8 +96,6 @@ public:
                 size_t dst_offset, size_t src_offset);
 
   int xclGetDeviceInfo2(xclDeviceInfo2 *info);
-
-  void xclWriteHostEvent(xclPerfMonEventType type, xclPerfMonEventID id);
 
   bool isGood() const;
   static ZYNQShim *handleCheck(void *handle);

--- a/src/runtime_src/tools/scripts/peta_build.sh
+++ b/src/runtime_src/tools/scripts/peta_build.sh
@@ -49,7 +49,8 @@ config_kernel()
 	KERN_CONFIG_FILE=$1
 	# *** Enable or disable Linux kernel features as you need ***
 	# AR# 69143 -- To avoid PetaLinux hang when JTAG connected.
-	echo '# CONFIG_CPU_IDLE is not set' >> $KERN_CONFIG_FILE
+	echo '# CONFIG_CPU_IDLE is not set'      >> $KERN_CONFIG_FILE
+	echo 'CONFIG_CONSOLE_LOGLEVEL_DEFAULT=1' >> $KERN_CONFIG_FILE
 }
 
 config_rootfs()


### PR DESCRIPTION
1. Linux console loglevel should be 1. Only print critical error on console.
2. Shim should use xclLog(), keep the same format like PCIe shim.

To enable different log level, add this in to Runtime section of xrt.ini.
For XRT_WARNING: verbosity = 4
For XRT_INFO: verbosity = 6
For XRT_DEBUG: verbosity = 7  