### PR TITLE
Changing the bandwidth threshold for U2x4 as per the platform developer request

### DIFF
--- a/tests/pyopencl/23_bandwidth.py
+++ b/tests/pyopencl/23_bandwidth.py
@@ -204,3 +204,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/tests/pyopencl/23_bandwidth.py
+++ b/tests/pyopencl/23_bandwidth.py
@@ -64,6 +64,9 @@ def main():
 
     if "qdma" in str(dev):
        threshold = 30000
+    
+    if "U2x4" in str(dev):
+       threshold = 15000
 
     ctx = cl.Context(devices = [dev])
     if not ctx:

--- a/tests/pyopencl/23_bandwidth.py
+++ b/tests/pyopencl/23_bandwidth.py
@@ -204,4 +204,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Hi,

This contains a change to the threshold value for U2x4 as it can meet max 15000MBPS.
We should do it in a programmatic way in future as we should not hardcode this value for different platforms.