### PR TITLE
[Edge] downgrade user pointer error to warnning

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -430,7 +430,7 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	/* Physical address must be continuous */
 	if (sg_count != 1) {
-		DRM_ERROR("User buffer is not physical contiguous\n");
+		DRM_WARN("User buffer is not physical contiguous\n");
 		ret = -EINVAL;
 		goto out0;
 	}


### PR DESCRIPTION
Downgrade "User buffer is not physical contiguous" error to warning. Base on below two facts:
1.	This is not a “system about to crash” error.
2.	User's application could handle it if this ioctl failed.
So, this is not have to be a driver error message.
