### PR TITLE
Memory Leak Fix

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -3453,11 +3453,6 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 			ret = -ENOMEM;
 			goto failed;
 		}
-		axlf = vmalloc(sizeof(struct axlf));
-		if (!axlf) {
-			ret = -ENOMEM;
-			goto failed;
-		}
 
 		ret = copy_from_user(&axlf_header, data, sizeof(struct axlf));
 		if (ret) {


### PR DESCRIPTION
Use local variable axlf_header instead of pointer *axlf.


Remove axlf malloc because we are not using it at this moment.