### PR TITLE
mbreq.req misaligned

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -446,13 +446,14 @@ static void check_sensor(struct xclmgmt_dev *lro)
 static int health_check_cb(void *data)
 {
 	struct xclmgmt_dev *lro = (struct xclmgmt_dev *)data;
-	struct mailbox_req mbreq = { MAILBOX_REQ_FIREWALL, };
+	struct mailbox_req mbreq = { 0 };
 	bool tripped;
 
 	if (!health_check)
 		return 0;
 
 	tripped = xocl_af_check(lro, NULL);
+	mbreq.req = MAILBOX_REQ_FIREWALL;
 
 	if (!tripped) {
 		check_sensor(lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1514,10 +1514,8 @@ static int icap_download_rp(struct platform_device *pdev, int level, bool force)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
-	struct mailbox_req mbreq = { MAILBOX_REQ_CHG_SHELL, };
+	struct mailbox_req mbreq = { 0 };
 	int ret = 0;
-
-
 
 	mutex_lock(&icap->icap_lock);
 	if (!icap->rp_bit || !icap->rp_fdt) {
@@ -1526,6 +1524,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, bool force)
 		goto failed;
 	}
 	if (!force) {
+		mbreq.req = MAILBOX_REQ_CHG_SHELL;
 		(void) xocl_peer_notify(xocl_get_xdev(icap->icap_pdev), &mbreq,
 				sizeof(struct mailbox_req));
 		ICAP_INFO(icap, "Notified userpf to program rp");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -109,7 +109,7 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare)
 int xocl_program_shell(struct xocl_dev *xdev, bool force)
 {
 	int ret = 0, mbret = 0;
-	struct mailbox_req mbreq = { MAILBOX_REQ_PROGRAM_SHELL, };
+	struct mailbox_req mbreq = { 0 };
 	size_t resplen = sizeof(ret);
 	int i;
 
@@ -153,6 +153,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 		goto failed;
 
 	userpf_info(xdev, "request mgmtpf to program prp");
+	mbreq.req = MAILBOX_REQ_PROGRAM_SHELL;
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct mailbox_req),
 		&ret, &resplen, NULL, NULL, 0);
 	if (mbret)
@@ -177,7 +178,7 @@ failed:
 int xocl_hot_reset(struct xocl_dev *xdev, bool force)
 {
 	int ret = 0, mbret = 0;
-	struct mailbox_req mbreq = { MAILBOX_REQ_HOT_RESET, };
+	struct mailbox_req mbreq = { 0 };
 	size_t resplen = sizeof(ret);
 
 	mutex_lock(&xdev->dev_lock);
@@ -199,6 +200,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, bool force)
 	xocl_reset_notify(xdev->core.pdev, true);
 
 	/* Reset mgmt */
+	mbreq.req = MAILBOX_REQ_HOT_RESET;
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct mailbox_req),
 		&ret, &resplen, NULL, NULL, 0);
 	if (mbret)


### PR DESCRIPTION
struct mailbox_req {
	uint64_t flags;
	enum mailbox_request req;
	char data[1]; /* variable length of payload */
};


struct mailbox_req mbreq = { MAILBOX_REQ_FIREWALL, };

equals to

mbreq.flags = MAILBOX_REQ_FIREWALL, not mbreq.req = MAILBOX_REQ_FIREWALL