### PR TITLE
fix for awsmgmt building failed on Pegasus

### DIFF
--- a/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.h
@@ -15,6 +15,7 @@
 #define _AWS_MGT_PF_H_
 
 #include <linux/cdev.h>
+#include <linux/version.h>
 #include <asm/io.h>
 
 #define DRV_NAME "awsmgmt"


### PR DESCRIPTION
Just tested on xsjpegasus3 -- awsmgmt can be built and xrt-aws pkg can be installed