### PR TITLE
make mpd_plugin.h C style & fix some lint warnings

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -58,20 +58,23 @@ public:
     AwsDev(size_t index, const char *logfileName);
     ~AwsDev();
 
-    int awsGetIcap(std::unique_ptr<xcl_pr_region> &resp);
-    int awsGetSensor(std::unique_ptr<xcl_sensor> &resp);
-    int awsGetBdinfo(std::unique_ptr<xcl_board_info> &resp);
-    int awsGetMig(std::unique_ptr<std::vector<char>> &resp, size_t &resp_len);
-    int awsGetFirewall(std::unique_ptr<xcl_mig_ecc> &resp);
-    int awsGetDna(std::unique_ptr<xcl_dna> &resp);
-    int awsGetSubdev(std::unique_ptr<std::vector<char>> &resp, size_t &resp_len);
+    int awsGetIcap(xcl_pr_region *resp);
+    int awsGetSensor(xcl_sensor *resp);
+    int awsGetBdinfo(xcl_board_info *resp);
+    int awsGetMig(char *resp, size_t resp_len);
+    int awsGetFirewall(xcl_mig_ecc *resp);
+    int awsGetDna(xcl_dna *resp);
+    int awsGetSubdev(char *resp, size_t resp_len);
     // Bitstreams
-    int awsLoadXclBin(const xclBin *&buffer);
+    int awsLoadXclBin(const xclBin *buffer);
     //int xclBootFPGA();
     int awsResetDevice();
-    int awsReClock2(xclmgmt_ioc_freqscaling *&obj);
+    int awsReClock2(const xclmgmt_ioc_freqscaling *obj);
     int awsLockDevice();
     int awsUnlockDevice();
+    int awsProgramShell();
+    int awsReadP2pBarAddr(const xcl_mailbox_p2p_bar_addr *addr);
+    int awsUserProbe(xcl_mailbox_conn_resp *resp);
     bool isGood();
 private:
     const int mBoardNumber;
@@ -87,17 +90,20 @@ private:
 #endif
 };
 
-int get_remote_msd_fd(size_t index, int& fd);
-int awsLoadXclBin(size_t index, const axlf *&xclbin);
-int awsGetIcap(size_t index, std::unique_ptr<xcl_pr_region> &resp);
-int awsGetSensor(size_t index, std::unique_ptr<xcl_sensor> &resp);
-int awsGetBdinfo(size_t index, std::unique_ptr<xcl_board_info> &resp);
-int awsGetMig(size_t index, std::unique_ptr<std::vector<char>> &resp, size_t &resp_len);
-int awsGetFirewall(size_t index, std::unique_ptr<xcl_mig_ecc> &resp);
-int awsGetDna(size_t index, std::unique_ptr<xcl_dna> &resp);
-int awsGetSubdev(size_t index, std::unique_ptr<std::vector<char>> &resp, size_t &resp_len);
-int awsLockDevice(size_t index);
-int awsUnlockDevice(size_t index);
-int awsResetDevice(size_t index);
-int awsReClock2(size_t index, struct xclmgmt_ioc_freqscaling *&obj);
+int get_remote_msd_fd(size_t index, int* fd);
+int awsLoadXclBin(size_t index, const axlf *xclbin, int *resp);
+int awsGetIcap(size_t index, xcl_pr_region *resp);
+int awsGetSensor(size_t index, xcl_sensor *resp);
+int awsGetBdinfo(size_t index, xcl_board_info *resp);
+int awsGetMig(size_t index, char *resp, size_t resp_len);
+int awsGetFirewall(size_t index, xcl_mig_ecc *resp);
+int awsGetDna(size_t index, xcl_dna *resp);
+int awsGetSubdev(size_t index, char *resp, size_t resp_len);
+int awsLockDevice(size_t index, int *resp);
+int awsUnlockDevice(size_t index, int *resp);
+int awsResetDevice(size_t index, int *resp);
+int awsReClock2(size_t index, const xclmgmt_ioc_freqscaling *obj, int *resp);
+int awsUserProbe(size_t index, xcl_mailbox_conn_resp *resp);
+int awsProgramShell(size_t index, int *resp);
+int awsReadP2pBarAddr(size_t index, const xcl_mailbox_p2p_bar_addr *addr, int *resp);
 #endif

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
@@ -43,7 +43,7 @@ public:
     ~AzureDev();
 
     // Bitstreams
-    int azureLoadXclBin(const xclBin *&buffer);
+    int azureLoadXclBin(const xclBin *buffer);
     static std::string get_wireserver_ip()
     {
         const std::string config("/opt/xilinx/xrt/etc/mpd.conf");
@@ -100,8 +100,8 @@ struct write_unit {
     const char *uptr;
     size_t  sizeleft;
 };
-int get_remote_msd_fd(size_t index, int& fd);
-int azureLoadXclBin(size_t index, const axlf *&xclbin);
+int get_remote_msd_fd(size_t index, int* fd);
+int azureLoadXclBin(size_t index, const axlf *xclbin, int *resp);
 static size_t read_callback(void *contents, size_t size,
        size_t nmemb, void *userp);
 static size_t WriteCallback(void *contents, size_t size,

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/common.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/common.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <queue>
+#include <functional>
 #include "pciefunc.h"
 #include "sw_msg.h"
 #include "core/pcie/driver/linux/include/mailbox_proto.h"
@@ -74,7 +75,7 @@ class Common;
 class Common
 {
 public:
-    Common(std::string &name, std::string &plugin_path);
+    Common(std::string &name, std::string &plugin_path, bool for_user);
     ~Common();
     void *plugin_handle;
     size_t total;
@@ -87,5 +88,18 @@ public:
 private:
     std::string name;
     std::string plugin_path;
+};
+
+class Sw_mb_container
+{
+public:
+    Sw_mb_container(size_t respLen, uint64_t respID);
+    ~Sw_mb_container();
+    std::unique_ptr<sw_msg> get_response();
+    char* get_payload_buf();
+    void set_hook(std::function<void()> hook);
+private:
+    std::unique_ptr<sw_msg> processed_;
+    std::function<void()> hook_;
 };
 #endif // COMMON_H

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/container.h
@@ -45,7 +45,7 @@ public:
     ~Container();
 
     // Bitstreams
-    int xclLoadXclBin(const xclBin *&buffer);
+    int xclLoadXclBin(const xclBin *buffer);
     bool isGood();
 private:
 /*
@@ -57,6 +57,6 @@ private:
     std::vector<char> read_file(const char *filename);
 };
 
-int get_remote_msd_fd(size_t index, int& fd);
-int xclLoadXclBin(size_t index, const axlf *&xclbin);
+int get_remote_msd_fd(size_t index, int* fd);
+int xclLoadXclBin(size_t index, const axlf *xclbin, int *resp);
 #endif

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -59,8 +59,8 @@ int remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
 class Msd : public Common
 {
 public:
-    Msd(std::string name, std::string plugin_path) :
-        Common(name, plugin_path)
+    Msd(std::string name, std::string plugin_path, bool for_user) :
+        Common(name, plugin_path, for_user), plugin_init(nullptr), plugin_fini(nullptr)
     {
     }
 
@@ -383,8 +383,10 @@ void msd_thread(size_t index, std::string host)
 
 done:
     dev.updateConf("", 0, 0); // Restore default config.
-    close(mpdfd);
-    close(sockfd);
+    if (mpdfd >= 0)
+    	close(mpdfd);
+    if (sockfd >= 0)
+    	close(sockfd);
 }
 
 /*
@@ -405,7 +407,7 @@ int main(void)
     signal(SIGINT, signalHandler);
     signal(SIGTERM, signalHandler);
 
-    Msd msd("msd", plugin_path);
+    Msd msd("msd", plugin_path, false);
     msd.preStart();
     msd.start();
     msd.run();

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/pciefunc.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/pciefunc.cpp
@@ -19,6 +19,7 @@
 #include <stdarg.h>
 #include <sstream>
 #include <cstring>
+#include <random>
 #include "pciefunc.h"
 #include "common.h"
 
@@ -113,7 +114,7 @@ bool pcieFunc::loadConf()
         else if (key.compare("port") == 0)
             port = stoi(value, nullptr, 0);
         else if (key.compare("id") == 0)
-            devId = stoi(value, nullptr, 0);
+            devId = stol(value, nullptr, 0);
         else // ignore unknown key, but don't fail
             log(LOG_WARNING, "unknown config key %s", key.c_str());
     }
@@ -162,7 +163,9 @@ int pcieFunc::updateConf(std::string hostname, uint16_t hostport, uint64_t swch)
     std::lock_guard<std::mutex> l(lock);
     std::string config;
     std::string err;
-    int id = rand();
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    int id = gen();
 
     config += "host=" + hostname + "\n";
     config += "port=" + std::to_string(hostport) + "\n";

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/sw_msg.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/sw_msg.cpp
@@ -23,31 +23,39 @@ sw_msg::~sw_msg()
 {
 }
 
-sw_msg::sw_msg(const void *payload, size_t len, uint64_t id, uint64_t flags)
+sw_msg::sw_msg(const void *payload, size_t len, uint64_t id, uint64_t flags) :
+    buf(sizeof(xcl_sw_chan) + len, 0)
 {
-    buf = std::make_unique<std::vector<char>>(sizeof(xcl_sw_chan) + len, 0);
-    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf->data());
+    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
     sc->sz = len;
     sc->flags = flags;
     sc->id = id;
     std::memcpy(sc->data, payload, len);
 }
 
-sw_msg::sw_msg(size_t len)
+sw_msg::sw_msg(size_t len, uint64_t id, uint64_t flags) :
+    buf(sizeof(xcl_sw_chan) + len, 0)
 {
-    buf = std::make_unique<std::vector<char>>(sizeof(xcl_sw_chan) + len, 0);
-    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf->data());
+    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
+    sc->sz = len;
+    sc->flags = flags;
+    sc->id = id;
+}
+
+sw_msg::sw_msg(size_t len) : buf(sizeof(xcl_sw_chan) + len, 0)
+{
+    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
     sc->sz = len;
 }
 
 size_t sw_msg::size()
 {
-    return buf->size();
+    return buf.size();
 }
 
 size_t sw_msg::payloadSize()
 {
-    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf->data());
+    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
     return sc->sz;
 }
 
@@ -58,17 +66,17 @@ bool sw_msg::valid()
 
 char *sw_msg::data()
 {
-    return buf->data();
+    return buf.data();
 }
 
 char *sw_msg::payloadData()
 {
-    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf->data());
+    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
     return sc->data;
 }
 
 uint64_t sw_msg::id()
 {
-    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf->data());
+    xcl_sw_chan *sc = reinterpret_cast<xcl_sw_chan *>(buf.data());
     return sc->id;
 }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/sw_msg.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/sw_msg.h
@@ -26,6 +26,8 @@ class sw_msg {
 public:
     // Init a buffer ready to be sent out.
     sw_msg(const void *payload, size_t len, uint64_t id, uint64_t flags);
+    // Init a buffer to be sent without payload being filled yet.
+    sw_msg(size_t len, uint64_t id, uint64_t flags);
     // Init a buffer ready to receive data.
     sw_msg(size_t len);
     ~sw_msg();
@@ -39,7 +41,7 @@ public:
     uint64_t id();
 
 private:
-    std::unique_ptr<std::vector<char>> buf;
+    std::vector<char> buf;
 };
 
 #endif // SW_MSG_H


### PR DESCRIPTION
This PR includes,
1. change mpd_plugin.h from c++ to c
2. avoid some 2 heap allocations 
3. clear some code using smart pointer & raw pointers
4. fix msd/mpd crash bug
5. fix some lint warnings

The PR doesn't include,
1. Some comments Soren gave, such as, put cv, mutex, queue, in a class, favor exception than return, etc
2. Some comments which require big change to the code
3. fix to the issues about upgrade/downgrade/reinstall of plugin pkg(this will be in a separate PR later)