### PR TITLE
    Bug Fix: The packaging of the RPM development platform

### DIFF
--- a/src/runtime_src/tools/scripts/pkg_hw_platform.sh
+++ b/src/runtime_src/tools/scripts/pkg_hw_platform.sh
@@ -815,7 +815,7 @@ chmod -R o=g %{buildroot}/opt/xilinx/platforms/$opt_xsa
 
 %files
 %defattr(-,root,root,-)
-/opt/xilinx
+/opt/xilinx/platforms/$opt_xsa/
 
 %changelog
 * $build_date Xilinx Inc - 5.1-1

--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -854,7 +854,7 @@ chmod -R o=g %{buildroot}/opt/xilinx/platforms/$opt_dsa
 
 %files
 %defattr(-,root,root,-)
-/opt/xilinx
+/opt/xilinx/platforms/$opt_dsa/
 
 %changelog
 * $build_date Xilinx Inc - 5.1-1


### PR DESCRIPTION
 Issue/Resolution
 ----------
The RPM development platform was incorrectly taking ownership of the /opt/xilinx directory instead of the /opt/xilinx/platforms/<platform_name>/ directory.