### PR TITLE
save mpd.conf for azure during pkg reinstall

### DIFF
--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -35,6 +35,7 @@ fi
 
 #create sym link to /opt/xilinx/xrt/lib/libmpd_plugin and restart mpd service
 echo "Install aws mpd plugin"
+rm -rf /opt/xilinx/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
 ln -s /opt/xilinx/xrt/lib/libaws_mpd_plugin.so /opt/xilinx/xrt/lib/libmpd_plugin.so
 #make sure mpd automatically gets starts across reboot if plugin is installed
 systemctl enable mpd

--- a/src/CMake/config/postinst-azure.in
+++ b/src/CMake/config/postinst-azure.in
@@ -1,8 +1,10 @@
 #!/bin/sh
 
+DIR=/opt/xilinx/xrt/
 #create sym link to /opt/xilinx/xrt/lib/libmpd_plugin and restart mpd service
 echo "Install azure mpd plugin"
-ln -s /opt/xilinx/xrt/lib/libazure_mpd_plugin.so /opt/xilinx/xrt/lib/libmpd_plugin.so
+rm -rf $DIR/lib/libmpd_plugin.so > /dev/null 2>&1
+ln -s $DIR/lib/libazure_mpd_plugin.so $DIR/lib/libmpd_plugin.so
 #make sure mpd automatically gets starts across reboot if plugin is installed
 systemctl enable mpd
 echo "Restart mpd service"

--- a/src/CMake/config/postinst-container.in
+++ b/src/CMake/config/postinst-container.in
@@ -4,6 +4,7 @@
 #stop msd service anyway
 systemctl stop msd > /dev/null 2>&1
 echo "Install container mpd plugin"
+rm -rf /opt/xilinx/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
 ln -s /opt/xilinx/xrt/lib/libcontainer_mpd_plugin.so /opt/xilinx/xrt/lib/libmpd_plugin.so
 #make sure mpd automatically gets starts across reboot if plugin is installed
 systemctl enable mpd

--- a/src/CMake/config/prerm-aws.in
+++ b/src/CMake/config/prerm-aws.in
@@ -1,5 +1,32 @@
 #!/bin/sh
 
+#
+# UBUNTU NOTE
+# -----------
+# 1. When downgrading (say from 2.3.0 to 2.2.0) then prerm of 2.3.0 is run
+#    but postinst of 2.2.0 is run. The prerm is invoked with "upgrade 2.2.0"
+#    argument and postinst is invoked with "configure 2.3.0" argument.
+# 2. When upgrading (say from 2.2.0 to 2.3.0) then prerm of 2.2.0 is run
+#    but postinst of 2.3.0 is run. The prerm is invoked with "upgrade 2.3.0"
+#    argument and postinst is invoked with "configure 2.2.0" argument.
+# 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm of 2.2.0 is run
+#    and postinst of 2.2.0 is run. The prerm is invoked with "upgrade 2.2.0"
+#    argument and postinst is invoked with "configure 2.2.0" argument.
+#
+# RHEL/CentOS NOTE
+# ----------------
+# 1. When downgrading (say from 2.3.0 to 2.2.0) then oddly postinst of 2.2.0
+#    is run first followed by prerm of 2.3.0 run. The postinst is invoked with
+#    "2" and prerm is invoked with "1".
+# 2. When upgrading (say from 2.2.0 to 2.3.0) then prerm of 2.2.0 is NOT run
+#    but postinst of 2.3.0 is run. The postinst is invoked with "2" argument.
+# 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm is NOT run but
+#    and postinst of 2.2.0 is run. The postinst is invoked with "2" argument.
+
+# In the case of upgrade, downgrade or re-install we would like to preserve the
+# configuration of the components and hence we want to handle the configuration
+# in postinst script.
+
 echo "Unloading old AWS Linux kernel modules"
 modprobe -r awsmgmt
 
@@ -10,6 +37,13 @@ find /lib/modules -type f -name awsmgmt.ko.kz -delete
 depmod -A
 
 rm -f /etc/udev/rules.d/10-awsmgmt.rules
+
+#In case prerm is called after postinst on centos, make sure not to stop mpd
+lsb_release -si | grep -Eq "^RedHat|^CentOS"
+if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
+    echo "Cleanup is skipped for package upgrade/downgrade/re-install on RHEL/CentOS"
+    exit 0
+fi
 
 echo "Remove mpd plugin"
 rm -rf /opt/xilinx/xrt/lib/libmpd_plugin.so > /dev/null 2>&1

--- a/src/CMake/config/prerm-azure.in
+++ b/src/CMake/config/prerm-azure.in
@@ -1,8 +1,43 @@
 #!/bin/sh
 
+#
+# UBUNTU NOTE
+# -----------
+# 1. When downgrading (say from 2.3.0 to 2.2.0) then prerm of 2.3.0 is run
+#    but postinst of 2.2.0 is run. The prerm is invoked with "upgrade 2.2.0"
+#    argument and postinst is invoked with "configure 2.3.0" argument.
+# 2. When upgrading (say from 2.2.0 to 2.3.0) then prerm of 2.2.0 is run
+#    but postinst of 2.3.0 is run. The prerm is invoked with "upgrade 2.3.0"
+#    argument and postinst is invoked with "configure 2.2.0" argument.
+# 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm of 2.2.0 is run
+#    and postinst of 2.2.0 is run. The prerm is invoked with "upgrade 2.2.0"
+#    argument and postinst is invoked with "configure 2.2.0" argument.
+#
+# RHEL/CentOS NOTE
+# ----------------
+# 1. When downgrading (say from 2.3.0 to 2.2.0) then oddly postinst of 2.2.0
+#    is run first followed by prerm of 2.3.0 run. The postinst is invoked with
+#    "2" and prerm is invoked with "1".
+# 2. When upgrading (say from 2.2.0 to 2.3.0) then prerm of 2.2.0 is NOT run
+#    but postinst of 2.3.0 is run. The postinst is invoked with "2" argument.
+# 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm is NOT run but
+#    and postinst of 2.2.0 is run. The postinst is invoked with "2" argument.
+
+# In the case of upgrade, downgrade or re-install we would like to preserve the
+# configuration of the components and hence we want to handle the configuration
+# in postinst script.
+
+DIR=/opt/xilinx/xrt
+
+#In case prerm is called after postinst on centos, make sure not to stop mpd
+lsb_release -si | grep -Eq "^RedHat|^CentOS"
+if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
+    echo "Cleanup is skipped for package upgrade/downgrade/re-install on RHEL/CentOS"
+    exit 0
+fi
+
 echo "Remove mpd plugin"
-rm -rf /opt/xilinx/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
-rm -rf /opt/xilinx/xrt/etc/mpd.conf > /dev/null 2>&1
+rm -rf $DIR/lib/libmpd_plugin.so > /dev/null 2>&1
 systemctl disable mpd > /dev/null 2>&1
 systemctl stop mpd > /dev/null 2>&1
 

--- a/src/CMake/config/prerm-container.in
+++ b/src/CMake/config/prerm-container.in
@@ -1,5 +1,39 @@
 #!/bin/sh
 
+#
+# UBUNTU NOTE
+# -----------
+# 1. When downgrading (say from 2.3.0 to 2.2.0) then prerm of 2.3.0 is run
+#    but postinst of 2.2.0 is run. The prerm is invoked with "upgrade 2.2.0"
+#    argument and postinst is invoked with "configure 2.3.0" argument.
+# 2. When upgrading (say from 2.2.0 to 2.3.0) then prerm of 2.2.0 is run
+#    but postinst of 2.3.0 is run. The prerm is invoked with "upgrade 2.3.0"
+#    argument and postinst is invoked with "configure 2.2.0" argument.
+# 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm of 2.2.0 is run
+#    and postinst of 2.2.0 is run. The prerm is invoked with "upgrade 2.2.0"
+#    argument and postinst is invoked with "configure 2.2.0" argument.
+#
+# RHEL/CentOS NOTE
+# ----------------
+# 1. When downgrading (say from 2.3.0 to 2.2.0) then oddly postinst of 2.2.0
+#    is run first followed by prerm of 2.3.0 run. The postinst is invoked with
+#    "2" and prerm is invoked with "1".
+# 2. When upgrading (say from 2.2.0 to 2.3.0) then prerm of 2.2.0 is NOT run
+#    but postinst of 2.3.0 is run. The postinst is invoked with "2" argument.
+# 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm is NOT run but
+#    and postinst of 2.2.0 is run. The postinst is invoked with "2" argument.
+
+# In the case of upgrade, downgrade or re-install we would like to preserve the
+# configuration of the components and hence we want to handle the configuration
+# in postinst script.
+
+#In case prerm is called after postinst on centos, make sure not to stop mpd
+lsb_release -si | grep -Eq "^RedHat|^CentOS"
+if [ $? -eq 0 ] && [ $1 -ge 1 ]; then
+    echo "Cleanup is skipped for package upgrade/downgrade/re-install on RHEL/CentOS"
+    exit 0
+fi
+
 echo "Remove mpd plugin"
 rm -rf /opt/xilinx/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
 systemctl disable mpd > /dev/null 2>&1

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
@@ -42,12 +42,4 @@ install(TARGETS azure_mpd_plugin
   COMPONENT azure
   )
 
-set (MPD_CONFIG_FILE "mpd.conf")
-
-install (
-  FILES ${MPD_CONFIG_FILE}
-  DESTINATION ${XRT_INSTALL_DIR}/etc
-  COMPONENT azure
-  )
-
 endif (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -48,7 +48,13 @@ int init(mpd_plugin_callbacks *cbs);
 void fini(void *mpc_cookie);
 }
 
-static std::string RESTIP_ENDPOINT;
+/*
+ * This is the default Azure cloud wireserver IP.
+ * Users debugging with a standalone server needs to edit /etc/mpd.conf to
+ * specify its own IP, with format, eg
+ * restip = 1.1.1.1
+ */
+static std::string RESTIP_ENDPOINT = "168.63.129.16";
 /*
  * Init function of the plugin that is used to hook the required functions.
  * The cookie is used by fini (see below). Can be NULL if not required.
@@ -63,7 +69,9 @@ int init(mpd_plugin_callbacks *cbs)
     }
     if (cbs) 
     {
-        RESTIP_ENDPOINT = AzureDev::get_wireserver_ip();
+        std::string private_ip = AzureDev::get_wireserver_ip();
+        if (!private_ip.empty())
+            RESTIP_ENDPOINT = private_ip;
         syslog(LOG_INFO, "azure restserver ip: %s\n", RESTIP_ENDPOINT.c_str());
         // hook functions
         cbs->mpc_cookie = NULL;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
@@ -46,7 +46,7 @@ public:
     int azureLoadXclBin(const xclBin *&buffer);
     static std::string get_wireserver_ip()
     {
-        const std::string config("/opt/xilinx/xrt/etc/mpd.conf");
+        const std::string config("/etc/mpd.conf");
         //just check ip address format, not validity
         std::regex ip("^([0-9]{1,3}\\.){3}[0-9]{1,3}$");
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/mpd.conf
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/mpd.conf
@@ -1,6 +1,0 @@
-# This file is used to specify the wireserver IP address of Azure
-# The IP address is specified as key = value pair, with key as "restip"
-# and value having ipv4 format.
-# The file is installed at /opt/xilinx/opt/etc/ of the VM
-#eg,
-restip = 168.63.129.16


### PR DESCRIPTION
azure pkg has a conf file saving the ip of the wireserver. User may edit this file saving its own IP address.

For pkg upgrade/downgrade/re-install, the content of the file need to be kept.