### PR TITLE
awsmgmt doesn't need to be installed on F1

### DIFF
--- a/src/CMake/config/postinst-aws.in
+++ b/src/CMake/config/postinst-aws.in
@@ -1,36 +1,39 @@
 #!/bin/sh
 
-if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
-    echo "Unloading old XRT Linux kernel modules"
-    modprobe -r awsmgmt
+nm /opt/xilinx/xrt/lib/libaws_mpd_plugin.so |grep 'fpga_mgmt' > /dev/null 2>&1
+if [ $? -eq 1 ]; then
+    if [ -n "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@`" ]; then
+        echo "Unloading old XRT Linux kernel modules"
+        modprobe -r awsmgmt
+        
+        echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
+        dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
+        find /lib/modules -type f -name awsmgmt.ko -delete
+        find /lib/modules -type f -name awsmgmt.ko.kz -delete
+        find /lib/modules -type f -name awsmgmt.ko.xz -delete
+        depmod -A
+    fi
 
-    echo "Unregistering old XRT Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-    dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
-    find /lib/modules -type f -name awsmgmt.ko -delete
-    find /lib/modules -type f -name awsmgmt.ko.kz -delete
-    find /lib/modules -type f -name awsmgmt.ko.xz -delete
-    depmod -A
-fi
+    echo "Invoking xrt-aws common.postinst"
+    /usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
+    if [ $? -eq 0 ]; then
+        echo "Finished xrt-aws common.postinst"
+        install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/mgmt/10-awsmgmt.rules /etc/udev/rules.d
+        
+        echo "Loading new XRT AWS Linux kernel modules"
+        udevadm control --reload-rules
+        modprobe awsmgmt
+        udevadm trigger
+    fi
 
-echo "Invoking xrt-aws common.postinst"
-/usr/lib/dkms/common.postinst xrt-aws @XRT_VERSION_STRING@ "" "" $2
-if [ $? -eq 0 ]; then
-    echo "Finished xrt-aws common.postinst"
-    install -m 644 /usr/src/xrt-aws-@XRT_VERSION_STRING@/driver/aws/mgmt/10-awsmgmt.rules /etc/udev/rules.d
-
-    echo "Loading new XRT AWS Linux kernel modules"
-    udevadm control --reload-rules
-    modprobe awsmgmt
-    udevadm trigger
-fi
-
-if [ -z "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@ |grep installed`" ]; then
-    echo "****************************************************************"
-    echo "* DKMS failed to install AWS drivers."
-    echo "* Please check if kernel development headers are installed for OS variant used."
-    echo "* "
-    echo "* Check build logs in /var/lib/dkms/xrt-aws/@XRT_VERSION_STRING@"
-    echo "****************************************************************"
+    if [ -z "`dkms status -m xrt-aws -v @XRT_VERSION_STRING@ |grep installed`" ]; then
+        echo "****************************************************************"
+        echo "* DKMS failed to install AWS drivers."
+        echo "* Please check if kernel development headers are installed for OS variant used."
+        echo "* "
+        echo "* Check build logs in /var/lib/dkms/xrt-aws/@XRT_VERSION_STRING@"
+        echo "****************************************************************"
+    fi
 fi
 
 #create sym link to /opt/xilinx/xrt/lib/libmpd_plugin and restart mpd service

--- a/src/CMake/config/prerm-aws.in
+++ b/src/CMake/config/prerm-aws.in
@@ -27,16 +27,19 @@
 # configuration of the components and hence we want to handle the configuration
 # in postinst script.
 
-echo "Unloading old AWS Linux kernel modules"
-modprobe -r awsmgmt
+nm /opt/xilinx/xrt/lib/libaws_mpd_plugin.so |grep 'fpga_mgmt' > /dev/null 2>&1
+if [ $? -eq 1 ]; then
+    echo "Unloading old AWS Linux kernel modules"
+    modprobe -r awsmgmt
 
-echo "Unregistering AWS Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
-dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
-find /lib/modules -type f -name awsmgmt.ko -delete
-find /lib/modules -type f -name awsmgmt.ko.kz -delete
-depmod -A
+    echo "Unregistering AWS Linux kernel module sources @XRT_VERSION_STRING@ from dkms"
+    dkms remove -m xrt-aws -v @XRT_VERSION_STRING@ --all
+    find /lib/modules -type f -name awsmgmt.ko -delete
+    find /lib/modules -type f -name awsmgmt.ko.kz -delete
+    depmod -A
 
-rm -f /etc/udev/rules.d/10-awsmgmt.rules
+    rm -f /etc/udev/rules.d/10-awsmgmt.rules
+fi
 
 #In case prerm is called after postinst on centos, make sure not to stop mpd
 lsb_release -si | grep -Eq "^RedHat|^CentOS"
@@ -47,7 +50,7 @@ fi
 
 echo "Remove mpd plugin"
 rm -rf /opt/xilinx/xrt/lib/libmpd_plugin.so > /dev/null 2>&1
-systemctl disable mpd /dev/null 2>&1
-systemctl stop mpd /dev/null 2>&1
+systemctl disable mpd > /dev/null 2>&1
+systemctl stop mpd > /dev/null 2>&1
 
 exit 0


### PR DESCRIPTION
awsmgmt driver is only for internal test on pegasus. It doesn't need (shouldn't) be installed on F1.

Installing awsmgmt on F1 not only takes unnecessary time but also prints some error/warning msgs which are just false alarming (awsmgmt install failed etc...)