### PR TITLE
Using zocl ert to handle dataflow CU on versal

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1641,9 +1641,17 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	userpf_info(xdev, "ert per feature rom = %d", ert);
 	userpf_info(xdev, "dsa52 = %d", dsa);
 
-	if (XOCL_DSA_IS_VERSAL(xdev) && !cfg->polling) {
+	if (XOCL_DSA_IS_VERSAL(xdev)) {
 		userpf_info(xdev, "force polling mode for versal");
 		cfg->polling = true;
+
+		/*
+		 * For versal device, we will use ert_full if we are
+		 * configured as ert mode even dataflow is configured.
+		 * And we do not support ert_poll.
+		 */
+		ert_full = cfg->ert;
+		ert_poll = false;
 	}
 
 	/* Mark command as control command to force slot 0 execution */


### PR DESCRIPTION
On versal device, if we have dataflow CU, we need to use ert_full mode to send CU control command to zocl ert. This PR force ert_full mode on versal if ert is configured and disable ert_poll regardless dataflow is configured or not.