### PR TITLE
change help msgs for xbutil/xbmgmt

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
@@ -113,13 +113,23 @@ static inline bool isHiddenSubcmd(const std::string& cmd)
 
 static void printHelp(void)
 {
+    std::vector<std::string> expert_subCmd =
+        { "reset", "clock", "partition", "config", "nifd" };
+    std::stringstream expert_ostr;
     std::cout << "Supported sub-commands are:" << std::endl;
     for (auto& c : subCmdList) {
         if (isHiddenSubcmd(c.first))
             continue;
+        if(std::find(std::begin(expert_subCmd),
+            std::end(expert_subCmd), c.first) != expert_subCmd.end()) {
+            expert_ostr << "\t" << c.first << " - " << c.second.description
+                << std::endl;
+            continue;
+        }
         std::cout << "\t" << c.first << " - " << c.second.description <<
             std::endl;
     }
+    std::cout << "Experts only:\n" << expert_ostr.str();
     std::cout <<
         "Run xbmgmt help <subcommand> for detailed help of each subcommand" <<
         std::endl;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
@@ -50,6 +50,9 @@ static const std::map<std::string, struct subCmd> subCmdList = {
     { "nifd", {nifdHandler, subCmdNifdDesc, subCmdNifdUsage} },
 };
 
+const static std::vector<std::string> basic_subCmd =
+    { "flash", "help", "scan", "version" };
+
 void sudoOrDie()
 {
     const char* SudoMessage = "ERROR: root privileges required.";
@@ -113,8 +116,6 @@ static inline bool isHiddenSubcmd(const std::string& cmd)
 
 static void printHelp(void)
 {
-    const static std::vector<std::string> basic_subCmd =
-        { "flash", "help", "scan", "version" };
     std::stringstream expert_ostr;
     std::cout << "Supported sub-commands are:" << std::endl;
     for (auto& c : subCmdList) {
@@ -142,6 +143,9 @@ void printSubCmdHelp(const std::string& subCmd)
     if (cmd == subCmdList.end()) {
         std::cout << "Unknown sub-command: " << subCmd << std::endl;
     } else {
+        if (std::find(std::begin(basic_subCmd),
+            std::end(basic_subCmd), subCmd) == basic_subCmd.end())
+                std::cout << "Experts only sub-command, use at your own risk." << std::endl;
         if (!isHiddenSubcmd(subCmd))
             std::cout << "'" << subCmd << "' sub-command usage:" << std::endl;
         std::cout << cmd->second.usage << std::endl;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
@@ -113,15 +113,15 @@ static inline bool isHiddenSubcmd(const std::string& cmd)
 
 static void printHelp(void)
 {
-    std::vector<std::string> expert_subCmd =
-        { "reset", "clock", "partition", "config", "nifd" };
+    const static std::vector<std::string> basic_subCmd =
+        { "flash", "help", "scan", "version" };
     std::stringstream expert_ostr;
     std::cout << "Supported sub-commands are:" << std::endl;
     for (auto& c : subCmdList) {
         if (isHiddenSubcmd(c.first))
             continue;
-        if(std::find(std::begin(expert_subCmd),
-            std::end(expert_subCmd), c.first) != expert_subCmd.end()) {
+        if(std::find(std::begin(basic_subCmd),
+            std::end(basic_subCmd), c.first) == basic_subCmd.end()) {
             expert_ostr << "\t" << c.first << " - " << c.second.description
                 << std::endl;
             continue;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -700,6 +700,7 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "  flash   [-d card] -a <all | shell> [-t timestamp]\n";
     std::cout << "  flash   [-d card] -p msp432_firmware\n";
     std::cout << "  flash   scan [-v]\n";
+    std::cout << "\nNOTE: card for -d option can either be id or bdf\n";
     std::cout << "\nExamples:\n";
     std::cout << "Print JSON file to stdout\n";
     std::cout << "  " << exe << " dump\n";
@@ -724,7 +725,7 @@ void xcldev::printHelp(const std::string& exe)
     std::cout << "List the debug IPs available on the platform\n";
     std::cout << "  " << exe << " status \n";
     std::cout << "Validate installation on card 1\n";
-    std::cout << "  " << exe << " validate -d 1\n";
+    std::cout << "  " << exe << " validate -d 0000:02:00.0\n";
 }
 
 std::unique_ptr<xcldev::device> xcldev::xclGetDevice(unsigned index)


### PR DESCRIPTION
```
$ Debug/opt/xilinx/xrt/bin/xbutil help
Running xbutil for 4.0+ shell's

Usage: Debug/opt/xilinx/xrt/bin/xbutil <command> [options]

Command and option summary:
  clock   [-d card] [-r region] [-f clock1_freq_MHz] [-g clock2_freq_MHz] [-h clock3_freq_MHz]
  dmatest [-d card] [-b [0x]block_size_KB]
  dump
  help
  m2mtest
  version
  mem --read [-d card] [-a [0x]start_addr] [-i size_bytes] [-o output filename]
  mem --write [-d card] [-a [0x]start_addr] [-i size_bytes] [-e pattern_byte]
  program [-d card] [-r region] -p xclbin
  query   [-d card [-r region]]
  status [-d card] [--debug_ip_name]
  scan
  top [-d card] [-i seconds]
  validate [-d card]
  reset  [-d card]
 Requires root privileges:
  p2p    [-d card] --enable
  p2p    [-d card] --disable
  p2p    [-d card] --validate
  flash   [-d card] -m primary_mcs [-n secondary_mcs] [-o bpi|spi]
  flash   [-d card] -a <all | shell> [-t timestamp]
  flash   [-d card] -p msp432_firmware
  flash   scan [-v]

NOTE: card for -d option can either be id or bdf

Examples:
Print JSON file to stdout
  Debug/opt/xilinx/xrt/bin/xbutil dump
List all cards
  Debug/opt/xilinx/xrt/bin/xbutil list
Scan for Xilinx PCIe card(s) & associated drivers (if any) and relevant system information
  Debug/opt/xilinx/xrt/bin/xbutil scan
Change the clock frequency of region 0 in card 0 to 100 MHz
  Debug/opt/xilinx/xrt/bin/xbutil clock -f 100
For card 0 which supports multiple clocks, change the clock 1 to 200MHz and clock 2 to 250MHz
  Debug/opt/xilinx/xrt/bin/xbutil clock -f 200 -g 250
Download the accelerator program for card 2
  Debug/opt/xilinx/xrt/bin/xbutil program -d 2 -p a.xclbin
Run DMA test on card 1 with 32 KB blocks of buffer
  Debug/opt/xilinx/xrt/bin/xbutil dmatest -d 1 -b 0x20
Read 256 bytes from DDR/HBM/PLRAM starting at 0x1000 into file read.out
  Debug/opt/xilinx/xrt/bin/xbutil mem --read -a 0x1000 -i 256 -o read.out
  Default values for address is 0x0, size is DDR size and file is memread.out
Write 256 bytes to DDR/HBM/PLRAM starting at 0x1000 with byte 0xaa
  Debug/opt/xilinx/xrt/bin/xbutil mem --write -a 0x1000 -i 256 -e 0xaa
  Default values for address is 0x0, size is DDR size and pattern is 0x0
List the debug IPs available on the platform
  Debug/opt/xilinx/xrt/bin/xbutil status
Validate installation on card 1
  Debug/opt/xilinx/xrt/bin/xbutil validate -d 0000:02:00.0


$ Debug/opt/xilinx/xrt/bin/xbmgmt help
Supported sub-commands are:
        flash - Update SC firmware or shell on the device
        help - Print out help message for a sub-command
        scan - List all detected mgmt PCIE functions
        version - Print out xrt build version
Experts only:
        clock - Change various clock frequency on the device
        config - Parse or update daemon/device configuration
        nifd - Access the NIFD debug IP to readback frames and offsets
        partition - Show and download partition onto the device
        reset - Perform various flavors of reset on the device
Run xbmgmt help <subcommand> for detailed help of each subcommand
```
