### PR TITLE
CR-1045979 Misleading message from xbmgmt flash --update and CR-1045982 xbmgmt reset --hot and multiple cards

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -377,7 +377,7 @@ static int autoFlash(unsigned index, std::string& shell,
             bool reboot;
             std::cout << std::endl;
             if (updateShellAndSC(p.first, p.second, reboot) == 0) {
-                std::cout << "Successfully flashed Card[" << success << "]"<< std::endl;
+                std::cout << "Successfully flashed Card[" << getBDF(success) << "]"<< std::endl;
                 success++;
             }
             needreboot |= reboot;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -377,7 +377,7 @@ static int autoFlash(unsigned index, std::string& shell,
             bool reboot;
             std::cout << std::endl;
             if (updateShellAndSC(p.first, p.second, reboot) == 0) {
-                std::cout << "Successfully flashed Card[" << getBDF(success) << "]"<< std::endl;
+                std::cout << "Successfully flashed Card[" << getBDF(p.first) << "]"<< std::endl;
                 success++;
             }
             needreboot |= reboot;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_reset.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_reset.cpp
@@ -133,6 +133,9 @@ int resetHandler(int argc, char *argv[])
     int fd = dev->open("", O_RDWR);
     if (hot) {
         ret = dev->ioctl(fd, XCLMGMT_IOCHOTRESET);
+        if (ret == 0)
+            std::cout << "Successfully reset Card[" << getBDF(index)
+                      << "]"<< std::endl;
 	ret = ret ? -errno : ret;
     } else if (kernel) {
         ret = dev->ioctl(fd, XCLMGMT_IOCOCLRESET);

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
@@ -106,6 +106,15 @@ unsigned int bdf2index(const std::string& bdfStr)
     return UINT_MAX;
 }
 
+std::string getBDF(unsigned index)
+{
+    char BDF[128];
+    auto dev = pcidev::get_dev(index, false);
+    sprintf(BDF, "%.4x:%.2x:%.2x.%.1x",
+        dev->domain, dev->bus, dev->dev, dev->func);
+    return std::string(BDF);
+}
+
 static inline bool isHiddenSubcmd(const std::string& cmd)
 {
     return cmd[0] == '-';

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.h
@@ -26,6 +26,7 @@ void printSubCmdHelp(const std::string& subCmd);
 bool canProceed(void);
 void sudoOrDie(void);
 unsigned int bdf2index(const std::string& bdfStr);
+std::string getBDF(unsigned index);
 std::string driver_version(std::string driver);
 bool getenv_or_null(const char* env);
 int xrt_xbmgmt_version_cmp() ;


### PR DESCRIPTION
```
$ sudo Debug/opt/xilinx/xrt/bin/xbmgmt reset --hot
CAUTION: Performing hot reset. Please make sure xocl driver is unloaded.
Are you sure you wish to proceed? [y/n]: y
Successfully reset Card[0000:b3:00.0]


$ sudo Debug/opt/xilinx/xrt/bin/xbmgmt flash --update
sudo: unable to resolve host xsjsagarwal
[sudo] password for sagarw:
Card [0000:b3:00.0]:
         Status: shell needs updating
         Current shell: xilinx_u250_GOLDEN_2
         Shell to be flashed: xilinx_u250_xdma_201830_2
Are you sure you wish to proceed? [y/n]: y

Updating SC firmware on card[0000:b3:00.0]
INFO: found 4 sections
.....................................
INFO: Loading new firmware on SC

Updating shell on card[0000:b3:00.0]
INFO: ***Found 939 ELA Records
Idcode byte[0] ff
Idcode byte[1] 20
Idcode byte[2] bb
Idcode byte[3] 21
Idcode byte[4] 10
Enabled bitstream guard. Bitstream will not be loaded until flashing is finished.
Erasing flash..............................................
Programming flash..............................................
Cleared bitstream guard. Bitstream now active.
Successfully flashed Card[0000:b3:00.0]

1 Card(s) flashed successfully.
Cold reboot machine to load the new image on card(s).
```