### PR TITLE
Bug Fix: The option "--info" output file wasn't checking for an existing file.

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
@@ -323,6 +323,12 @@ int main_(int argc, char** argv) {
       outputFiles.push_back(sOutputFile);
     }
 
+    if (!sInfoFile.empty()) {
+      if (sInfoFile != "<console>") {
+        outputFiles.push_back(sInfoFile);
+      }
+    }
+
     for (auto section : sectionsToDump ) {
       ParameterSectionData psd(section);
       outputFiles.push_back(psd.getFile());


### PR DESCRIPTION
When using the "--info" option for an output file, it wasn't checking for an already existing file.   This pull request adds functionality to check if the file exists and if it does to not write out the file, unless of course the "--force" option is used.