### PR TITLE
no lock on mgmt pf for xclbin lockdown on user pf

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -46,8 +46,6 @@
  * @MAILBOX_REQ_UNKNOWN: invalid OP code
  * @MAILBOX_REQ_TEST_READY: test msg is ready (post only, internal test only)
  * @MAILBOX_REQ_TEST_READ: fetch test msg from peer (internal test only)
- * @MAILBOX_REQ_LOCK_BITSTREAM: lock down xclbin on mgmt pf
- * @MAILBOX_REQ_UNLOCK_BITSTREAM: unlock xclbin on mgmt pf
  * @MAILBOX_REQ_HOT_RESET: request mgmt pf driver to reset the board
  * @MAILBOX_REQ_FIREWALL: firewall trip detected on mgmt pf (post only)
  * @MAILBOX_REQ_LOAD_XCLBIN_KADDR: download xclbin (pointed to by a pointer)
@@ -64,8 +62,6 @@ enum xcl_mailbox_request {
 	XCL_MAILBOX_REQ_UNKNOWN =		0,
 	XCL_MAILBOX_REQ_TEST_READY =		1,
 	XCL_MAILBOX_REQ_TEST_READ =		2,
-	XCL_MAILBOX_REQ_LOCK_BITSTREAM =	3,
-	XCL_MAILBOX_REQ_UNLOCK_BITSTREAM =	4,
 	XCL_MAILBOX_REQ_HOT_RESET =		5,
 	XCL_MAILBOX_REQ_FIREWALL =		6,
 	XCL_MAILBOX_REQ_LOAD_XCLBIN_KADDR =	7,
@@ -78,16 +74,6 @@ enum xcl_mailbox_request {
 	XCL_MAILBOX_REQ_PROGRAM_SHELL =		14,
 	XCL_MAILBOX_REQ_READ_P2P_BAR_ADDR =	15,
 	/* Version 0 OP code ends */
-};
-
-/**
- * struct mailbox_req_bitstream_lock - MAILBOX_REQ_LOCK_BITSTREAM and
- * 				       MAILBOX_REQ_UNLOCK_BITSTREAM payload type
- * @uuid: uuid of the xclbin
- */
-struct xcl_mailbox_req_bitstream_lock {
-	uint64_t reserved;
-	uint8_t uuid[XCL_UUID_SZ];
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -46,6 +46,8 @@
  * @MAILBOX_REQ_UNKNOWN: invalid OP code
  * @MAILBOX_REQ_TEST_READY: test msg is ready (post only, internal test only)
  * @MAILBOX_REQ_TEST_READ: fetch test msg from peer (internal test only)
+ * @MAILBOX_REQ_LOCK_BITSTREAM: lock down xclbin on mgmt pf (not implemented)
+ * @MAILBOX_REQ_UNLOCK_BITSTREAM: unlock xclbin on mgmt pf (not implemented)
  * @MAILBOX_REQ_HOT_RESET: request mgmt pf driver to reset the board
  * @MAILBOX_REQ_FIREWALL: firewall trip detected on mgmt pf (post only)
  * @MAILBOX_REQ_LOAD_XCLBIN_KADDR: download xclbin (pointed to by a pointer)
@@ -62,6 +64,8 @@ enum xcl_mailbox_request {
 	XCL_MAILBOX_REQ_UNKNOWN =		0,
 	XCL_MAILBOX_REQ_TEST_READY =		1,
 	XCL_MAILBOX_REQ_TEST_READ =		2,
+	XCL_MAILBOX_REQ_LOCK_BITSTREAM =	3,
+	XCL_MAILBOX_REQ_UNLOCK_BITSTREAM =	4,
 	XCL_MAILBOX_REQ_HOT_RESET =		5,
 	XCL_MAILBOX_REQ_FIREWALL =		6,
 	XCL_MAILBOX_REQ_LOAD_XCLBIN_KADDR =	7,
@@ -74,6 +78,16 @@ enum xcl_mailbox_request {
 	XCL_MAILBOX_REQ_PROGRAM_SHELL =		14,
 	XCL_MAILBOX_REQ_READ_P2P_BAR_ADDR =	15,
 	/* Version 0 OP code ends */
+};
+
+/**
+ * struct mailbox_req_bitstream_lock - MAILBOX_REQ_LOCK_BITSTREAM and
+ * 				       MAILBOX_REQ_UNLOCK_BITSTREAM payload type
+ * @uuid: uuid of the xclbin
+ */
+struct xcl_mailbox_req_bitstream_lock {
+	uint64_t reserved;
+	uint8_t uuid[XCL_UUID_SZ];
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -690,32 +690,6 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 	}
 
 	switch (req->req) {
-	case XCL_MAILBOX_REQ_LOCK_BITSTREAM: {
-		struct xcl_mailbox_req_bitstream_lock *bitstm_lock =
-			(struct xcl_mailbox_req_bitstream_lock *)req->data;
-		if (payload_len < sizeof(*bitstm_lock)) {
-			mgmt_err(lro, "peer request dropped, wrong size\n");
-			break;
-		}
-		ret = xocl_icap_lock_bitstream(lro,
-			(xuid_t *)bitstm_lock->uuid);
-		(void) xocl_peer_response(lro, req->req, msgid,
-			&ret, sizeof(ret));
-		break;
-	}
-	case XCL_MAILBOX_REQ_UNLOCK_BITSTREAM: {
-		struct xcl_mailbox_req_bitstream_lock *bitstm_lock =
-			(struct xcl_mailbox_req_bitstream_lock *)req->data;
-		if (payload_len < sizeof(*bitstm_lock)) {
-			mgmt_err(lro, "peer request dropped, wrong size\n");
-			break;
-		}
-		ret = xocl_icap_unlock_bitstream(lro,
-			(xuid_t *)bitstm_lock->uuid);
-		(void) xocl_peer_response(lro, req->req, msgid, &ret,
-			sizeof(ret));
-		break;
-	}
 	case XCL_MAILBOX_REQ_HOT_RESET:
 		ret = (int) reset_hot_ioctl(lro);
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1783,36 +1783,6 @@ free_buffers:
 	return err;
 }
 
-
-static int __icap_peer_lock(struct platform_device *pdev,
-	const xuid_t *id, bool lock)
-{
-	int err = 0;
-	int resp = 0;
-	size_t resplen = sizeof(resp);
-	struct xcl_mailbox_req_bitstream_lock bitstream_lock = {0};
-	size_t data_len = sizeof(struct xcl_mailbox_req_bitstream_lock);
-	struct xcl_mailbox_req *mb_req = NULL;
-	size_t reqlen = sizeof(struct xcl_mailbox_req) + data_len;
-	xdev_handle_t xdev = xocl_get_xdev(pdev);
-
-	mb_req = vmalloc(reqlen);
-	if (!mb_req)
-		return -ENOMEM;
-
-	mb_req->req = lock ?
-		XCL_MAILBOX_REQ_LOCK_BITSTREAM : XCL_MAILBOX_REQ_UNLOCK_BITSTREAM;
-	uuid_copy((xuid_t *)bitstream_lock.uuid, id);
-	memcpy(mb_req->data, &bitstream_lock, data_len);
-	err = xocl_peer_request(xdev,
-		mb_req, reqlen, &resp, &resplen, NULL, NULL, 0);
-	if (!err)
-		err = resp;
-
-	vfree(mb_req);
-	return err;
-}
-
 static void icap_clean_axlf_section(struct icap *icap,
 	enum axlf_section_kind kind)
 {
@@ -2458,17 +2428,6 @@ static int icap_lock_bitstream(struct platform_device *pdev, const xuid_t *id)
 		return -EBUSY;
 	}
 
-	if (icap->icap_bitstream_ref == 0 && !ICAP_PRIVILEGED(icap)) {
-		int err = __icap_peer_lock(pdev, id, true);
-
-		if (err < 0) {
-			ICAP_ERR(icap, "can't lock bitstream %pUb on peer: %d",
-				id, err);
-			mutex_unlock(&icap->icap_lock);
-			return err;
-		}
-	}
-
 	ref = icap->icap_bitstream_ref;
 	icap->icap_bitstream_ref++;
 	ICAP_INFO(icap, "bitstream %pUb locked, ref=%d", id,
@@ -2480,7 +2439,6 @@ static int icap_lock_bitstream(struct platform_device *pdev, const xuid_t *id)
 	}
 
 	mutex_unlock(&icap->icap_lock);
-
 	return 0;
 }
 
@@ -2508,11 +2466,6 @@ static int icap_unlock_bitstream(struct platform_device *pdev, const xuid_t *id)
 			id, &icap->icap_bitstream_uuid);
 		mutex_unlock(&icap->icap_lock);
 		return err;
-	}
-
-	if (icap->icap_bitstream_ref == 0 && !ICAP_PRIVILEGED(icap)) {
-		(void) __icap_peer_lock(pdev, id, false);
-		(void) xocl_exec_stop(xocl_get_xdev(pdev));
 	}
 
 	mutex_unlock(&icap->icap_lock);
@@ -3448,7 +3401,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 		size_t data_len, loff_t *off)
 {
 	struct icap *icap = filp->private_data;
-	struct axlf axlf_header = { 0 };
+	struct axlf axlf_header = { {0} };
 	struct axlf *axlf = NULL;
 	const struct axlf_section_header *section;
 	void *header;
@@ -3476,13 +3429,14 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 		}
 
 		if (memcmp(axlf_header.m_magic, ICAP_XCLBIN_V2,
-					sizeof(ICAP_XCLBIN_V2))) {
+			sizeof(ICAP_XCLBIN_V2))) {
 			ICAP_ERR(icap, "Incorrect magic string");
 			ret = -EINVAL;
 			goto failed;
 		}
 
-		if (!axlf_header.m_header.m_length || axlf_header.m_header.m_length >= GB(1)) {
+		if (!axlf_header.m_header.m_length ||
+			axlf_header.m_header.m_length >= GB(1)) {
 			ICAP_ERR(icap, "Invalid xclbin size");
 			ret = -EINVAL;
 			goto failed;			

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2468,7 +2468,11 @@ static int icap_unlock_bitstream(struct platform_device *pdev, const xuid_t *id)
 		return err;
 	}
 
+	if (icap->icap_bitstream_ref == 0 && !ICAP_PRIVILEGED(icap))
+		(void) xocl_exec_stop(xocl_get_xdev(pdev));
+
 	mutex_unlock(&icap->icap_lock);
+
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -72,8 +72,6 @@ int init(mpd_plugin_callbacks *cbs)
         cbs->mb_req.peer_data.get_firewall_data = awsGetFirewall;
         cbs->mb_req.peer_data.get_dna_data = awsGetDna;
         cbs->mb_req.peer_data.get_subdev_data = awsGetSubdev;
-        cbs->mb_req.lock_bitstream = awsLockDevice;
-        cbs->mb_req.unlock_bitstream = awsUnlockDevice;
         cbs->mb_req.hot_reset = awsResetDevice;
         cbs->mb_req.reclock2 = awsReClock2;
         cbs->mb_req.user_probe = awsUserProbe;
@@ -279,50 +277,6 @@ int awsGetSubdev(size_t index, char *resp, size_t resp_len)
     AwsDev d(index, nullptr);
     if (d.isGood())
         ret = d.awsGetSubdev(resp, resp_len);
-    return ret;
-}
-
-/*
- * callback function that is used to handle MAILBOX_REQ_LOCK_BITSTREAM msg 
- *
- * Input:
- *        index: index of the FPGA device
- * Output:
- *        resp: int as response msg
- * Return value:
- *        0: success
- *        others: err code
- */
-int awsLockDevice(size_t index, int *resp)
-{
-    int ret = -1;
-    AwsDev d(index, nullptr);
-    if (d.isGood()) {
-        *resp = d.awsLockDevice();
-        ret = 0;
-    }
-    return ret;
-}
-
-/*
- * callback function that is used to handle MAILBOX_REQ_UNLOCK_BITSTREAM msg
- * 
- * Input:
- *        index: index of the FPGA device
- * Output:
- *        resp: int as response msg
- * Return value:
- *        0: success
- *        others: err code
- */
-int awsUnlockDevice(size_t index, int *resp)
-{
-    int ret = -1;
-    AwsDev d(index, nullptr);
-    if (d.isGood()) {
-        *resp = d.awsUnlockDevice();
-        ret = 0;
-    }
     return ret;
 }
 
@@ -569,20 +523,6 @@ int AwsDev::awsUserProbe(xcl_mailbox_conn_resp *resp)
     return 0;
 }
 
-int AwsDev::awsLockDevice()
-{
-    // AWS FIXME - add lockDevice
-    mLocked = true;
-    return 0;
-}
-
-int AwsDev::awsUnlockDevice()
-{
-    // AWS FIXME - add unlockDevice
-    mLocked = false;
-    return 0;
-}
-
 int AwsDev::awsResetDevice() {
     // AWS FIXME - add reset
     return 0;
@@ -622,7 +562,7 @@ AwsDev::~AwsDev()
     }
 }
 
-AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index), mLocked(false)
+AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
 {
     if (logfileName != nullptr) {
         mLogStream.open(logfileName);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -70,15 +70,12 @@ public:
     //int xclBootFPGA();
     int awsResetDevice();
     int awsReClock2(const xclmgmt_ioc_freqscaling *obj);
-    int awsLockDevice();
-    int awsUnlockDevice();
     int awsProgramShell();
     int awsReadP2pBarAddr(const xcl_mailbox_p2p_bar_addr *addr);
     int awsUserProbe(xcl_mailbox_conn_resp *resp);
     bool isGood();
 private:
     const int mBoardNumber;
-    bool mLocked;
     std::ofstream mLogStream;
 #ifdef INTERNAL_TESTING_FOR_AWS
     int mMgtHandle;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -96,8 +96,6 @@ int awsGetMig(size_t index, char *resp, size_t resp_len);
 int awsGetFirewall(size_t index, xcl_mig_ecc *resp);
 int awsGetDna(size_t index, xcl_dna *resp);
 int awsGetSubdev(size_t index, char *resp, size_t resp_len);
-int awsLockDevice(size_t index, int *resp);
-int awsUnlockDevice(size_t index, int *resp);
 int awsResetDevice(size_t index, int *resp);
 int awsReClock2(size_t index, const xclmgmt_ioc_freqscaling *obj, int *resp);
 int awsUserProbe(size_t index, xcl_mailbox_conn_resp *resp);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -314,24 +314,6 @@ static int localMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
         processed = c.get_response();
         break;
     }
-    case XCL_MAILBOX_REQ_LOCK_BITSTREAM: {//optional
-        Sw_mb_container c(sizeof(int), orig->id());
-        if (plugin_cbs.mb_req.lock_bitstream) {
-            int *resp = reinterpret_cast<int *>(c.get_payload_buf());
-            c.set_hook(std::bind(plugin_cbs.mb_req.lock_bitstream, dev.getIndex(), resp));
-        }
-        processed = c.get_response();
-        break;
-    }
-    case XCL_MAILBOX_REQ_UNLOCK_BITSTREAM: { //optional
-        Sw_mb_container c(sizeof(int), orig->id());
-        if (plugin_cbs.mb_req.unlock_bitstream) {
-            int *resp = reinterpret_cast<int *>(c.get_payload_buf());
-            c.set_hook(std::bind(plugin_cbs.mb_req.unlock_bitstream, dev.getIndex(), resp));
-        }
-        processed = c.get_response();
-        break;
-    }
     case XCL_MAILBOX_REQ_HOT_RESET: {//optional
         Sw_mb_container c(sizeof(int), orig->id());
         if (plugin_cbs.mb_req.hot_reset) {

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
@@ -23,8 +23,6 @@
 #include "xclbin.h"
 
 typedef int (*get_remote_msd_fd_fn)(size_t index, int *fd);
-typedef int (*lock_bitstream_fn)(size_t index, int *resp);
-typedef int (*unlock_bitstream_fn)(size_t index, int *resp);
 typedef int (*hot_reset_fn)(size_t index, int *resp);
 typedef int (*load_xclbin_fn)(size_t index, const axlf *buf, int *resp);
 typedef int (*reclock2_fn)(size_t index, const struct xclmgmt_ioc_freqscaling *obj, int *resp);
@@ -69,8 +67,6 @@ struct mpd_plugin_callbacks {
      * on how many features their own HW have.
      */
     struct {
-        lock_bitstream_fn lock_bitstream; //3 optional
-        unlock_bitstream_fn unlock_bitstream; //4 optional
         hot_reset_fn hot_reset; //5 optional
         load_xclbin_fn load_xclbin; //8 mandatory
         reclock2_fn reclock2; //9 optional


### PR DESCRIPTION
Xocl will try to bump up ref count on mgmt pf on first xclbin user lockdown and release ref count on last user unlocking the xclbin. However, there is no clean solution to reset ref count on mgmt side when things go wrong.

If we remove ref count on mgmt pf side and make it stateless, we don't need to solve the mgmt ref count reset issue. The question is: is ref count on mgmt side really needed? 

@sonals , let's have a discussion.