### PR TITLE
CR: Change xbmgmt flash --reset to xbmgmt flash --factory_reset to revert card to golden

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -40,7 +40,7 @@ const char *subCmdFlashUsage =
     "--update [--shell name [--id id]] [--card bdf] [--force]\n"
     "--shell --path file [--card bdf] [--type flash_type]\n"
     "--sc_firmware --path file [--card bdf]\n"
-    "--reset [--card bdf]";
+    "--factory_reset [--card bdf]";
 
 #define fmt_str		"    "
 
@@ -717,7 +717,7 @@ static const std::map<std::string, std::function<int(int, char **)>> optList = {
     { "--update", update },
     { "--shell", shell },
     { "--sc_firmware", sc },
-    { "--reset", reset },
+    { "--factory_reset", reset },
 };
 
 int flashHandler(int argc, char *argv[])


### PR DESCRIPTION
```
$ sudo Debug/opt/xilinx/xrt/bin/xbmgmt flash --factory_reset
[sudo] password for sagarw:
CAUTION: Resetting Card [0000:b3:00.0] back to factory mode.
Are you sure you wish to proceed? [y/n]: n
Action canceled.

$ sudo Debug/opt/xilinx/xrt/bin/xbmgmt flash
'flash' sub-command usage:
--scan [--verbose|--json]
--update [--shell name [--id id]] [--card bdf] [--force]
--shell --path file [--card bdf] [--type flash_type]
--sc_firmware --path file [--card bdf]
--factory_reset [--card bdf]
```