### PR TITLE
support U30 flash

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1488,6 +1488,16 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_QSPIPS,			\
 	}
 
+#define	XOCL_BOARD_MGMT_U30						\
+	(struct xocl_board_private){					\
+		.flags		= 0,					\
+		.subdev_info	= MGMT_RES_MPSOC,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_MPSOC),		\
+		.mpsoc = true,						\
+		.board_name = "u30",					\
+		.flash_type = "qspi_ps_x4_single",				\
+	}
+
 #define	XOCL_BOARD_USER_XDMA_MPSOC					\
 	(struct xocl_board_private){					\
 		.flags		= 0,					\
@@ -1825,6 +1835,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x684F, PCI_ANY_ID, MGMT_DEFAULT) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0xA883, 0x1351, MGMT_MPSOC) },		\
 	{ XOCL_PCI_DEVID(0x10EE, 0xA983, 0x1351, MGMT_MPSOC) },		\
+	{ XOCL_PCI_DEVID(0x10EE, 0x503C, PCI_ANY_ID, MGMT_U30) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x688F, PCI_ANY_ID, MGMT_DEFAULT) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x694F, PCI_ANY_ID, MGMT_DEFAULT) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x6987, PCI_ANY_ID, MGMT_U2) },	\
@@ -1879,6 +1890,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5035, PCI_ANY_ID, USER_DSA52_U2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0xA884, 0x1351, USER_XDMA_MPSOC) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0xA984, 0x1351, USER_XDMA_MPSOC) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x503D, PCI_ANY_ID, USER_XDMA_MPSOC) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x6990, PCI_ANY_ID, USER_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x6A50, PCI_ANY_ID, USER_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x6A90, 0x4350, USER_XDMA_DSA50) },	\

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -52,8 +52,10 @@ Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
     {
         type = E_FlasherType::BPI;
     }
-    else if (typeStr.compare("qspi_ps") == 0)
+    else if (typeStr.find("qspi_ps") == 0)
     {
+        // Use find() for this type of flash.
+        // Since it have variations
         type = E_FlasherType::QSPIPS;
     }
     else

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.h
@@ -58,7 +58,10 @@ private:
     uint8_t mReadBuffer[PAGE_8K];
     uint32_t mTxBytes;
     uint32_t mRxBytes;
-    uint32_t mMaxNumSectors;
+
+    /* QSPI configure */
+    uint32_t mConnectMode; //Single, Stacked and Parallel mode
+    uint32_t mBusWidth; // x1, x2, x4
 
     void clearReadBuffer(unsigned size);
     void clearWriteBuffer(unsigned size);


### PR DESCRIPTION
Add U30 Device ID: MGMT pf 503C, USER pf 503D.

Support qspi single and parallel mode.

Some know issue. If petalinux boot, JTAG and "xbutil flash" would not able to program the flash. We don't know why. This is not the case for SmartSSD device which also use the same solution.