### PR TITLE
Coverity fixes

### DIFF
--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -35,7 +35,7 @@ namespace xrt_core {
 
     private:
         std::ostream& ios;
-        std::ios::fmtflags f;
+        std::ios_base::fmtflags f;
     };
 } //xrt_core
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
@@ -231,12 +231,12 @@ XQSPIPS_Flasher::XQSPIPS_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     // By default, it is 'perallel'
     mConnectMode = 0;
     // U30 Rev.A use single
-    if (typeStr.find("single")) {
+    if (typeStr.find("single") != std::string::npos) {
         mConnectMode = 1;
     }
 
     mBusWidth = 4;
-    if (typeStr.find("x2")) {
+    if (typeStr.find("x2") != std::string::npos) {
         // U30 Rev.B use x2
         mBusWidth = 2;
     }

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -931,23 +931,9 @@ void testCaseProgressReporter(bool *quit)
     }
 }
 
-//coverity[ +tainted_string_sanitize_content : arg-0 ]
-inline bool sanitize_getenv(const char* path) 
+inline const char* getenv_or_empty(const char* path)
 {
-    std::string str_path(path);
-    std::string blacklist = "?\"<>|";
-    for (char const &c: str_path) {
-        if(blacklist.find(c) != std::string::npos) {
-            return false;
-        }
-    }
-    return true;
-}
-
-inline const char* getenv_or_empty(const char* env_var)
-{
-    const char* path(getenv(env_var));
-    return (path != NULL && sanitize_getenv(path)) ? path : "";
+    return getenv(path) ? getenv(path) : "";
 }
 
 static void set_shell_path_env(const std::string& var_name,

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -931,9 +931,23 @@ void testCaseProgressReporter(bool *quit)
     }
 }
 
-inline const char* getenv_or_empty(const char* path)
+//coverity[ +tainted_string_sanitize_content : arg-0 ]
+inline bool sanitize_getenv(const char* path) 
 {
-    return getenv(path) ? getenv(path) : "";
+    std::string str_path(path);
+    std::string blacklist = "?\"<>|";
+    for (char const &c: str_path) {
+        if(blacklist.find(c) != std::string::npos) {
+            return false;
+        }
+    }
+    return true;
+}
+
+inline const char* getenv_or_empty(const char* env_var)
+{
+    const char* path(getenv(env_var));
+    return (path != NULL && sanitize_getenv(path)) ? path : "";
 }
 
 static void set_shell_path_env(const std::string& var_name,

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -138,6 +138,7 @@ XmaBufferObj xma_plg_buffer_alloc_arg_num(XmaSession s_handle, size_t size, bool
     b_obj_error.dev_index = -1;
     b_obj_error.device_only_buffer = false;
     b_obj_error.private_do_not_touch = NULL;
+    b_obj_error.user_ptr = NULL;
     b_obj.data = NULL;
     b_obj.ref_cnt = 0;
     b_obj.user_ptr = NULL;
@@ -230,6 +231,7 @@ xma_plg_buffer_alloc_ddr(XmaSession s_handle, size_t size, bool device_only_buff
     b_obj_error.dev_index = -1;
     b_obj_error.device_only_buffer = false;
     b_obj_error.private_do_not_touch = NULL;
+    b_obj_error.user_ptr = NULL;
     b_obj.data = NULL;
     b_obj.ref_cnt = 0;
     b_obj.user_ptr = NULL;


### PR DESCRIPTION
- ios -> ios_base: seems like ios_flags_restore class wasn't really fixing the coverity issue. Not sure if this change will help

- getenv needs to be sanitized before being used. Coverity requires an annotation to be added for custom sanitization functions. This change should fix that issue

- fixing a couple of other coverity issues as well