### PR TITLE
fix zocl memory leak in zocl_can_dma_performed and code style, and gc…

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -166,11 +166,12 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 	} else {
 		/* We are allocating from a separate BANK, i.e. PL-DDR */
 		unsigned int bank = GET_MEM_BANK(user_flags);
+
 		if (bank >= zdev->num_mem || !zdev->mem[bank].zm_used ||
 		    zdev->mem[bank].zm_type != ZOCL_MEM_TYPE_PLDDR)
 			return ERR_PTR(-EINVAL);
 
-		bo = kzalloc(sizeof (struct drm_zocl_bo), GFP_KERNEL);
+		bo = kzalloc(sizeof(struct drm_zocl_bo), GFP_KERNEL);
 		if (IS_ERR(bo))
 			return ERR_PTR(-ENOMEM);
 
@@ -191,7 +192,8 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 		err = drm_mm_insert_node_generic(zdev->mem[bank].zm_mm,
 		    bo->mm_node, size, PAGE_SIZE, 0, 0);
 		if (err) {
-			DRM_ERROR("Fail to allocate BO: size %ld\n", (long)size);
+			DRM_ERROR("Fail to allocate BO: size %ld\n",
+			    (long)size);
 			mutex_unlock(&zdev->mm_lock);
 			kfree(bo->mm_node);
 			kfree(bo);
@@ -547,18 +549,16 @@ out:
 	return rc;
 }
 
-bool 
-zocl_can_dma_performed(struct drm_device *dev, 
-    			struct drm_file *filp,
-			struct drm_zocl_copy_bo *args,
-			uint64_t *dst_paddr,
-			uint64_t *src_paddr)
+bool
+zocl_can_dma_performed(struct drm_device *dev, struct drm_file *filp,
+	struct drm_zocl_copy_bo *args, uint64_t *dst_paddr, uint64_t *src_paddr)
 {
-	struct drm_gem_object 		*dst_gem_obj, *src_gem_obj;
-	struct drm_zocl_bo 		*dst_bo, *src_bo;
-	uint64_t		        dst_size, src_size;
-	int 				unsupported_flags = 0;
-	bool				rc = true;
+	struct drm_gem_object  *dst_gem_obj, *src_gem_obj;
+	struct drm_zocl_bo     *dst_bo, *src_bo;
+	uint64_t               dst_size, src_size;
+	int                    unsupported_flags = 0;
+	bool                   rc = true;
+
 	dst_gem_obj = zocl_gem_object_lookup(dev, filp, args->dst_handle);
 	if (!dst_gem_obj) {
 		DRM_ERROR("Failed to look up GEM dst handle %d\n",
@@ -609,7 +609,7 @@ zocl_can_dma_performed(struct drm_device *dev,
 		rc = false;
 		goto out;
 	}
-	return rc;
+
 out:
 	if (dst_gem_obj)
 		ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(dst_gem_obj);
@@ -625,16 +625,17 @@ int zocl_copy_bo_async(struct drm_device *dev,
 		zocl_dma_handle_t *dma_handle,
 		struct drm_zocl_copy_bo *args)
 {
-	uint64_t 			dst_paddr, src_paddr;
-	int 				rc = 0;
+	uint64_t dst_paddr, src_paddr;
+	int rc = 0;
+	bool ret = false;
 
 	if (dma_handle->dma_func == NULL) {
 		DRM_ERROR("Failed: no callback dma_func for async dma");
 		return -EINVAL;
 	}
 
-	bool ret = zocl_can_dma_performed(dev, filp, args, &dst_paddr, &src_paddr);
-	if(!ret) {
+	ret = zocl_can_dma_performed(dev, filp, args, &dst_paddr, &src_paddr);
+	if (!ret) {
 		DRM_ERROR("Failed: Cannot perform DMA due to previous Errors");
 		return -EINVAL;
 	}


### PR DESCRIPTION
Sorry this is urgent too. Not for the code style but one line issue which cause the memory leak.

in zocl_can_dma_performed, we should free the drm object before return.
otherwise, we see panic info:
[   60.774786] Hardware name: ZynqMP ZCU104 RevC (DT)
[   60.774790] pstate: 40000005 (nZcv daif -PAN -UAO)
[   60.774794] pc : drm_mm_takedown+0x24/0x30
[   60.774798] lr : drm_mm_takedown+0x24/0x30
[   60.774800] sp : ffffff800e6d3c50
[   60.774802] x29: ffffff800e6d3c50 x28: ffffffc07da8c480
[   60.774807] x27: 0000000000000000 x26: 0000000000000000
[   60.774812] x25: 0000000056000000 x24: 0000000000000015
[   60.774816] x23: ffffffc07daf1070 x22: ffffff8000b89568
[   60.774821] x21: ffffffc07daf1010 x20: ffffffc07844e000
[   60.774826] x19: ffffffc07da92b00 x18: 00000000fffffff0
[   60.774830] x17: 0000000000000001 x16: 0000000000000007
[   60.774835] x15: ffffff800913af18 x14: ffffff80091c7350
[   60.774840] x13: 0000000000000000 x12: ffffff80091c6000
[   60.774844] x11: ffffff800913a000 x10: ffffff80091c69a8
[   60.774849] x9 : 0000000000000000 x8 : 0000000000000001
[   60.774854] x7 : ffffff80091c6000 x6 : 00000000000001b5
[   60.774858] x5 : 0000000000000001 x4 : ffffffc07fe86990
[   60.774863] x3 : ffffffc07fe86990 x2 : 0000000000000007
[   60.774867] x1 : bbee8b47d5111a00 x0 : 0000000000000000
[   60.774872] Call trace:
[   60.774877]  drm_mm_takedown+0x24/0x30
[   60.774882]  drm_vma_offset_manager_destroy+0x38/0x50
[   60.774886]  drm_gem_destroy+0x18/0x30
[   60.774889]  drm_dev_fini+0x84/0x88
[   60.774892]  drm_dev_put.part.0+0x50/0x60
[   60.774896]  drm_dev_put+0x10/0x20
[   60.774907]  zocl_drm_platform_remove+0x84/0x98 [zocl]
[   60.774912]  platform_drv_remove+0x28/0x48
[   60.774917]  device_release_driver_internal+0x1a8/0x240
[   60.774921]  driver_detach+0x48/0xb8
[   60.774925]  bus_remove_driver+0x54/0xa8
[   60.774930]  driver_unregister+0x2c/0x58
[   60.774933]  platform_driver_unregister+0x10/0x18
[   60.774941]  zocl_exit+0x18/0x850 [zocl]
[   60.774946]  __arm64_sys_delete_module+0x16c/0x1f8
[   60.774952]  el0_svc_common+0x84/0xd8
[   60.774956]  el0_svc_handler+0x68/0x80
[   60.774960]  el0_svc+0x8/0xc
[   60.774963] ---[ end trace bf1ea442d6ef16c2 ]---
