### PR TITLE
read msg on tcp socket should block until the full request is statisfied

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/common.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/common.cpp
@@ -61,7 +61,7 @@ size_t getSockMsgSize(const pcieFunc& dev, int sockfd)
 {
     std::unique_ptr<sw_msg> swmsg = std::make_unique<sw_msg>(0);
 
-    if (recv(sockfd, swmsg->data(), swmsg->size(), MSG_PEEK) !=
+    if (recv(sockfd, swmsg->data(), swmsg->size(), MSG_PEEK|MSG_WAITALL) !=
         static_cast<ssize_t>(swmsg->size())) {
         dev.log(LOG_ERR, "can't receive sw_chan from socket, %m");
         return 0;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -177,7 +177,7 @@ static int connectMsd(const pcieFunc& dev, std::string &ip, uint16_t port, int i
     }
 
     int ret = 0;
-    if (read(msdfd, &ret, sizeof(ret)) != sizeof(ret) || ret) {
+    if (recv(msdfd, &ret, sizeof(ret), MSG_WAITALL) != sizeof(ret) || ret) {
         dev.log(LOG_ERR, "id not recognized by msd");
         close(msdfd);
         return -1;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -182,7 +182,7 @@ static int verifyMpd(const pcieFunc& dev, int mpdfd, int id)
 {
     int mpdid;
 
-    if (read(mpdfd, &mpdid, sizeof(mpdid)) != sizeof(mpdid)) {
+    if (recv(mpdfd, &mpdid, sizeof(mpdid), MSG_WAITALL) != sizeof(mpdid)) {
         dev.log(LOG_ERR, "short read mpd id");
         return -EINVAL;
     }


### PR DESCRIPTION
msd/mpd read 'communication id', "verify status', 'sw mailbox msg length' should block until the full request is satisfied. 
It is possible a write()/send() of even a 4 bytes msg  in one side of a TCP connection results in arriving the other side in multiple packets. 