### PR TITLE
when xocl and xclmgmt are not in same domain, xocl is marked as ready…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -795,6 +795,7 @@ enum data_kind {
 };
 
 enum mb_kind {
+	DAEMON_STATE,
 	CHAN_STATE,
 	CHAN_SWITCH,
 	COMM_ID,

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
@@ -14,6 +14,12 @@ include_directories(
 file(GLOB AWS_PLUGIN_FILES
   "aws_dev.h"
   "aws_dev.cpp"
+  "../common.h"
+  "../common.cpp"
+  "../sw_msg.h"
+  "../sw_msg.cpp"
+  "../pciefunc.h"
+  "../pciefunc.cpp"
   )
 
 add_library(aws_plugin OBJECT ${AWS_PLUGIN_FILES})
@@ -34,6 +40,7 @@ if(${INTERNAL_TESTING_FOR_AWS})
     boost_system
     pthread
     rt
+    dl
     )
 else()
   include_directories(${AWS_FPGA_REPO_DIR}/sdk/userspace/include/) # path to fpga_mgmt.h
@@ -47,6 +54,7 @@ else()
     boost_system
     pthread
     rt
+    dl
     ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a
     )
 endif()

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -24,6 +24,9 @@
 #include "core/pcie/driver/linux/include/mgmt-ioctl.h"
 #include "core/pcie/linux/scan.h"
 #include "../mpd_plugin.h"
+#include "../common.h"
+#include "../sw_msg.h"
+#include "../pciefunc.h"
 
 #ifdef INTERNAL_TESTING_FOR_AWS
 #include "core/pcie/driver/linux/include/xocl_ioctl.h"
@@ -88,6 +91,7 @@ private:
 };
 
 int get_remote_msd_fd(size_t index, int* fd);
+int mb_notify(size_t index, int fd, bool online);
 int awsLoadXclBin(size_t index, const axlf *xclbin, int *resp);
 int awsGetIcap(size_t index, xcl_pr_region *resp);
 int awsGetSensor(size_t index, xcl_sensor *resp);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/common.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/common.cpp
@@ -270,7 +270,7 @@ void Common::postStop()
     closelog();         
 }
 
-Common::Common(std::string &name, std::string &plugin_path, bool for_user) :
+Common::Common(const std::string &name, const std::string &plugin_path, bool for_user) :
     name(name), plugin_path(plugin_path)
 {
     total = pcidev::get_dev_total(for_user);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/common.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/common.h
@@ -75,7 +75,7 @@ class Common;
 class Common
 {
 public:
-    Common(std::string &name, std::string &plugin_path, bool for_user);
+    Common(const std::string &name, const std::string &plugin_path, bool for_user);
     ~Common();
     void *plugin_handle;
     size_t total;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
@@ -23,6 +23,7 @@
 #include "xclbin.h"
 
 typedef int (*get_remote_msd_fd_fn)(size_t index, int *fd);
+typedef int (*mb_notify_fn)(size_t index, int fd, bool online);
 typedef int (*hot_reset_fn)(size_t index, int *resp);
 typedef int (*load_xclbin_fn)(size_t index, const axlf *buf, int *resp);
 typedef int (*reclock2_fn)(size_t index, const struct xclmgmt_ioc_freqscaling *obj, int *resp);
@@ -56,6 +57,12 @@ struct mpd_plugin_callbacks {
      * have more controls on the xclbin downloading.
      */
     get_remote_msd_fd_fn get_remote_msd_fd;
+    /*
+     * Function to notify software mailbox online/offline.
+     * For those without xclmgmt driver, this hook function is used to notify
+     * the xocl that imagined mgmt is online/offline. 
+     */
+    mb_notify_fn mb_notify;
     /*
      * The following are all hook functions handling software mailbox msg
      * that initialized from xocl driver

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -59,7 +59,7 @@ int remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
 class Msd : public Common
 {
 public:
-    Msd(std::string name, std::string plugin_path, bool for_user) :
+    Msd(const std::string name, const std::string plugin_path, bool for_user) :
         Common(name, plugin_path, for_user), plugin_init(nullptr), plugin_fini(nullptr)
     {
     }

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -109,9 +109,13 @@ static void print_pci_info(std::ostream &ostr)
 
     if (pcidev::get_dev_total() != pcidev::get_dev_ready()) {
         ostr << "WARNING: "
-            << "card(s) marked by '*' are not ready, "
-            << "run xbmgmt flash --scan --verbose to further check the details."
-            << std::endl;
+            << "card(s) marked by '*' are not ready, is MPD runing? "
+            << "run 'systemctl status mpd' to check MPD details.";
+	    if (pcidev::get_dev_total(false) == 0)
+            ostr << std::endl;
+	    else
+            ostr << " please also run 'xbmgmt flash --scan --verbose' to further check card details."
+                << std::endl;
     }
 }
 


### PR DESCRIPTION
when xocl and xclmgmt are not in same domain, xocl is marked as ready only when both mailbox channel and mpd are ready.

