### PR TITLE
xbmgmt flash msg add experts only

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -38,9 +38,10 @@ const char *subCmdFlashDesc = "Update SC firmware or shell on the device";
 const char *subCmdFlashUsage =
     "--scan [--verbose|--json]\n"
     "--update [--shell name [--id id]] [--card bdf] [--force]\n"
+    "--factory_reset [--card bdf]\n\n"
+    "Experts only:\n"
     "--shell --path file [--card bdf] [--type flash_type]\n"
-    "--sc_firmware --path file [--card bdf]\n"
-    "--factory_reset [--card bdf]";
+    "--sc_firmware --path file [--card bdf]";
 
 #define fmt_str		"    "
 


### PR DESCRIPTION
```
$ sudo Debug/opt/xilinx/xrt/bin/xbmgmt flash
'flash' sub-command usage:
--scan [--verbose|--json]
--update [--shell name [--id id]] [--card bdf] [--force]
--factory_reset [--card bdf]

Experts only:
--shell --path file [--card bdf] [--type flash_type]
--sc_firmware --path file [--card bdf]
```

added an extra space before "experts only" so that it is distinguished. 