### PR TITLE
CR-1046863 Without optional card argument, xbmgmt flash -shell for 1 card...

### DIFF
--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -378,7 +378,7 @@ pcidev::pci_device::pci_device(const std::string& sysfs) : sysfs_name(sysfs)
     bus = b;
     dev = d;
     func = f;
-    sysfs_get<int>("", "userbar", err, user_bar, -1);
+    sysfs_get<int>("", "userbar", err, user_bar, 0);
     user_bar_size = bar_size(dir, user_bar);
     is_mgmt = mgmt;
     instance = inst;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -38,9 +38,10 @@ const char *subCmdFlashDesc = "Update SC firmware or shell on the device";
 const char *subCmdFlashUsage =
     "--scan [--verbose|--json]\n"
     "--update [--shell name [--id id]] [--card bdf] [--force]\n"
-    "--shell --path file [--card bdf] [--type flash_type]\n"
-    "--sc_firmware --path file [--card bdf]\n"
-    "--factory_reset [--card bdf]";
+    "--factory_reset [--card bdf]\n\n"
+    "Experts only:\n"
+    "--shell --path file --card bdf [--type flash_type]\n"
+    "--sc_firmware --path file --card bdf";
 
 #define fmt_str		"    "
 
@@ -628,11 +629,10 @@ static int shell(int argc, char *argv[])
         }
     }
 
-    if (file.empty())
+    if (file.empty() || index == UINT_MAX)
         return -EINVAL;
 
-    int ret = updateShell(index == UINT_MAX ? 0 : index, type, file.c_str(),
-        nullptr);
+    int ret = updateShell(index, type, file.c_str(), nullptr);
     if (ret)
         return ret;
 
@@ -669,10 +669,10 @@ static int sc(int argc, char *argv[])
         }
     }
 
-    if (file.empty())
+    if (file.empty() || index == UINT_MAX)
         return -EINVAL;
 
-    int ret = updateSC(index == UINT_MAX ? 0 : index, file.c_str());
+    int ret = updateSC(index, file.c_str());
     if (ret)
         return ret;
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -118,8 +118,13 @@ static void print_pci_info(std::ostream &ostr)
 static int xrt_xbutil_version_cmp() 
 {
     /*check xbutil tools and xrt versions*/
-    std::string xrt = sensor_tree::get<std::string>( "runtime.build.version", "N/A" ) + ","
+    std::string xrt = "";
+    try {
+        xrt = sensor_tree::get<std::string>( "runtime.build.version", "N/A" ) + ","
         + sensor_tree::get<std::string>( "runtime.build.hash", "N/A" );
+    } catch (std::exception const& e) {
+        std::cout << e.what() << std::endl;
+    }
     if ( xcldev::driver_version("xocl") != "unknown" &&
         xrt.compare(xcldev::driver_version("xocl") ) != 0 ) {
         std::cout << "\nERROR: Mixed versions of XRT and xbutil are not supported. \


### PR DESCRIPTION
...messes other card type on system and coverity fixes

- For the CR: enforced --card for --sc_firmware and --shell and added "Experts only" to flash help msg
- Coverity: userbar default should be 0 (defined in scan.h)
- Coverity: exception handling in xbutil.cpp