### PR TITLE
Adjust command queue size

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1941,6 +1941,7 @@ exec_create(struct platform_device *pdev, struct xocl_scheduler *xs)
 		xocl_info(&pdev->dev, "did not get CQ resource");
 	} else {
 		exec->cq_size = res->end - res->start + 1;
+		exec->cq_size = min(exec->cq_size, (unsigned int)ERT_CQ_SIZE);
 		exec->cq_base = ioremap_nocache(res->start, exec->cq_size);
 		if (!exec->cq_base) {
 			if (exec->csr_base)


### PR DESCRIPTION
This is a temporary change to get 2RP running again after upping CQ size from 16K to 64K.  
XRT relies on cq size from meta data, but ERT uses a constant.  After 2RP change they are out-of-sync.  Use the minimum of hard-coded constant and meta data advertised size.