### PR TITLE
xbutil2: Clean up build environment and added reporting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build/Debug*
+build/WDebug*
 build/Release*
+build/WRelease*
 docs/.buildinfo
 docs/.doctrees
 tests/xrt/build

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -35,6 +35,7 @@ file(GLOB XBUTIL_V2_FILES
   "SubCmdReset.cpp"
   "SubCmdP2P.cpp"
   "SubCmdVersion.cpp"
+  "XBReport.cpp"
 )
 set(XBUTIL_V2_FILES_SRCS ${XBUTIL_V2_FILES})
 set(XBUTIL_V2_SRCS ${XBUTIL_V2_FILES_SRCS})

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -41,8 +41,8 @@ int subCmdQuery(const std::vector<std::string> &_options, bool _help)
 {
   XBU::verbose("SubCommand: query");
   // -- Retrieve and parse the subcommand options -----------------------------
-  uint64_t card = -1;
-  uint64_t region = -1;
+  uint64_t card = 0;
+  uint64_t region = 0;
 
   po::options_description queryDesc("query options");
   queryDesc.add_options()

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -17,6 +17,8 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "SubCmdQuery.h"
+#include "XBReport.h"
+
 #include "XBUtilities.h"
 namespace XBU = XBUtilities;
 
@@ -39,8 +41,8 @@ int subCmdQuery(const std::vector<std::string> &_options, bool _help)
 {
   XBU::verbose("SubCommand: query");
   // -- Retrieve and parse the subcommand options -----------------------------
-  uint64_t card = 0;
-  uint64_t region = 0;
+  uint64_t card = -1;
+  uint64_t region = -1;
 
   po::options_description queryDesc("query options");
   queryDesc.add_options()
@@ -72,10 +74,12 @@ int subCmdQuery(const std::vector<std::string> &_options, bool _help)
   XBU::verbose(XBU::format("  Card: %ld", card));
   XBU::verbose(XBU::format("Region: %ld", region));
 
+  // Determine the number of cards and their states
 
-  XBU::error("COMMAND BODY NOT IMPLEMENTED.");
-  // TODO: Put working code here
-
+  // Report system configuration and XRT information
+  XBReport::report_system_config();
+  XBReport::report_xrt_info();
+  
   return 0;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/XBReport.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBReport.cpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "XBReport.h"
+#include "XBUtilities.h"
+namespace XBU = XBUtilities;
+#include "common/core_system.h"
+
+// 3rd Party Library - Include Files
+
+// System - Include Files
+
+// ------ N A M E S P A C E ---------------------------------------------------
+using namespace XBReport;
+
+
+// ------ F U N C T I O N S ---------------------------------------------------
+void
+XBReport::report_system_config()
+{
+  // -- Get the property tree 
+  boost::property_tree::ptree _ptSystem;
+  xrt_core::system::get_os_info(_ptSystem);
+  XBU::trace_print_tree("System", _ptSystem);
+
+  XBU::message("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+  XBU::message("System Configuration");
+  XBU::message(XBU::format("%-14s: %s", "OS Name",      _ptSystem.get<std::string>("sysname","N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Release",      _ptSystem.get<std::string>("release", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Version",      _ptSystem.get<std::string>("version", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Machine",      _ptSystem.get<std::string>("machine", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Glibc",        _ptSystem.get<std::string>("glibc", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Distribution", _ptSystem.get<std::string>("linux", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Now",          _ptSystem.get<std::string>("now", "N/A").c_str()));
+}
+
+void
+XBReport::report_xrt_info()
+{
+  // -- Get the property tree 
+  boost::property_tree::ptree _ptXRT;
+  xrt_core::system::get_xrt_info(_ptXRT);
+  XBU::trace_print_tree("XRT", _ptXRT);
+
+  XBU::message("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+  XBU::message("XRT Information");
+	XBU::message(XBU::format("%-14s: %s", "Version",    _ptXRT.get<std::string>("version", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Git Hash",   _ptXRT.get<std::string>("hash", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Git Branch", _ptXRT.get<std::string>("branch", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "Build Date", _ptXRT.get<std::string>("date", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "XOCL",       _ptXRT.get<std::string>("xocl", "N/A").c_str()));
+  XBU::message(XBU::format("%-14s: %s", "XCLMGMT",    _ptXRT.get<std::string>("xclmgmt", "N/A").c_str()));
+}

--- a/src/runtime_src/core/tools/xbutil2/XBReport.h
+++ b/src/runtime_src/core/tools/xbutil2/XBReport.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __XBReport_h_
+#define __XBReport_h_
+
+// Include files
+// Please keep these to the bare minimum
+
+namespace XBReport {
+  void report_system_config();
+  void report_xrt_info();
+};
+
+#endif
+

--- a/src/runtime_src/core/tools/xbutil2/XBUtilMain.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBUtilMain.cpp
@@ -127,13 +127,17 @@ ReturnCodes main_(int argc, char** argv) {
 
   // Global options
   bool bVerbose = false;
+  bool bTrace = false;
   bool bHelp = false;
+  bool bOverride = false;
 
   // Build our global options
   po::options_description globalOptions("Global options");
   globalOptions.add_options()
     ("help", boost::program_options::bool_switch(&bHelp), "Help to use this program")
     ("verbose", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
+    ("trace", boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
+    ("override", boost::program_options::bool_switch(&bOverride), "Bypasses the development check for this executable")
     ("command", po::value<std::string>(), "command to execute")
     ("subArguments", po::value<std::vector<std::string> >(), "Arguments for command")
   ;
@@ -162,9 +166,23 @@ ReturnCodes main_(int argc, char** argv) {
     return RC_ERROR_IN_COMMAND_LINE;
   }
 
+  if (bOverride == false) {
+    std::cout << std::endl;
+    std::cout << "===========================================================" << std::endl;
+    std::cout << "xbutil2 is currently under development and currently is    " << std::endl;
+    std::cout << "not ready to be used in examining XRT drivers or platforms." << std::endl;
+    std::cout << "===========================================================" << std::endl;
+    exit(0);
+  }
+
   // Set the verbosity if enabled
   if (bVerbose == true) {
     XBU::setVerbose( true );
+  }
+
+  // Set the tracing if enabled
+  if (bTrace == true) {
+    XBU::setTrace( true );
   }
 
   // Check to see if help was requested or no command was found

--- a/src/runtime_src/core/tools/xbutil2/XBUtilities.h
+++ b/src/runtime_src/core/tools/xbutil2/XBUtilities.h
@@ -21,6 +21,7 @@
 // Please keep these to the bare minimum
 #include <string>
 #include <memory>
+#include <boost/property_tree/ptree.hpp>
 
 namespace XBUtilities {
 
@@ -34,6 +35,16 @@ std::string format(const std::string& format, Args ... args) {
   return std::string(buf.get(), buf.get() + size);
 }
 
+  typedef enum {
+    MT_MESSAGE,
+    MT_INFO,
+    MT_WARNING,
+    MT_ERROR,
+    MT_VERBOSE,
+    MT_FATAL,
+    MT_TRACE,
+    MT_UNKNOWN, 
+  } MessageType;
 
   /**
    * Enables / Disables verbosity
@@ -42,11 +53,24 @@ std::string format(const std::string& format, Args ... args) {
    *                  false - disable verbosity (default)
    */
   void setVerbose(bool _bVerbose);
+  void setTrace(bool _bVerbose);
 
-  void message(const std::string& _msg, bool _endl = true);
-  void error(const std::string& _msg, bool _endl = true);
+  void message_(MessageType _eMT, const std::string& _msg, bool _endl = true);
+
+  void message(const std::string& _msg, bool _endl = true); 
+  void info(const std::string& _msg, bool _endl = true);
   void warning(const std::string& _msg, bool _endl = true);
+  void error(const std::string& _msg, bool _endl = true);
   void verbose(const std::string& _msg, bool _endl = true);
+  void fatal(const std::string& _msg, bool _endl = true);
+  void trace(const std::string& _msg, bool _endl = true);
+
+  void trace_print_tree(const std::string & _name, const boost::property_tree::ptree & _pt);
+
+// ===========================================================================
+void get_system_info(boost::property_tree::ptree & _pt);
+
+
 };
 
 #endif


### PR DESCRIPTION
Work Done
---------
+ gitignore: build/WDebug & build/WRelease
+ Added XBReport for to format and write info status to std::out
+ Updated sub-command query to report system and xrt information
+ Added trace support
+ Added helper methods to write messages (e.g., info, warning, error, etc.)
+ Added friendly message that xbutil2 should not be used by non-developers