### PR TITLE
Updated compile macros for XclBinUtilException()

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.h
@@ -57,19 +57,11 @@ class XclBinUtilException : public std::runtime_error {
     XclBinExceptionType m_eExceptionType;
 
 public:
-#ifndef _WIN32
     XclBinUtilException(XclBinExceptionType _eExceptionType,
                         const std::string & _msg,
                         const char * _file = __FILE__,
                         int _line = __LINE__,
                         const char * _function = __FUNCTION__)
-#else
-    XclBinUtilException(XclBinExceptionType _eExceptionType,
-                        const std::string & _msg,
-                        const char * _file = "fix me",
-                        int _line = 0,
-                        const char * _function = "fix me")
-#endif
     : std::runtime_error(_msg)
     , m_msg(_msg)
     , m_file(_file)


### PR DESCRIPTION
Validated that the compiler macros used for Windows and Linux are the same and are valid, by:

1. Compiling the code both on Windows and Linux
2. Referring to the C++ documentation for:
gcc: [gcc 3.7.1 Standard Predefined Macros](https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html)
Windows: [Windows C++ Predefined macros](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=vs-2019)