### PR TITLE
CR-1046975: XMA failed to handle device mismatch condition

### DIFF
--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -162,6 +162,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
 {
     int32_t num_devices_requested = 0;
     int32_t i;
+    int32_t j;
     int32_t max_dev_id;
 
     max_dev_id = get_max_dev_id(systemcfg);
@@ -180,14 +181,16 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
         return false;
     }
 
-    /* For each of the requested devices, check that the DSA name matches */
-    for (i = 0; i < num_devices_requested; i++)
+    for (i = 0; i < systemcfg->num_images; i++)
     {
-        if (strcmp(systemcfg->dsa, hwcfg->devices[i].dsa) != 0)
+        for (j = 0; j < systemcfg->imagecfg[i].num_devices; j++)
         {
-            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "DSA mismatch: requested %s found %s\n",
-                       systemcfg->dsa, hwcfg->devices[i].dsa);
-            return false;
+            if (strcmp(systemcfg->dsa, hwcfg->devices[systemcfg->imagecfg[i].device_id_map[j]].dsa) != 0)
+            {
+                xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "DSA mismatch: requested %s found %s\n",
+                systemcfg->dsa, hwcfg->devices[systemcfg->imagecfg[i].device_id_map[j]].dsa);
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
Providing fix for XMA, as currently XMA is unable to handle use case of heterogeneous system (System having different DSAs). 
Link of CR - http://jira.xilinx.com/browse/CR-1046975