### PR TITLE
Don't release virtual CU context with OCL subdevice (#2311)

### DIFF
--- a/src/runtime_src/xocl/core/compute_unit.h
+++ b/src/runtime_src/xocl/core/compute_unit.h
@@ -157,6 +157,10 @@ public:
 
 private:
 
+  // Shared implementation by outer locking routines
+  xclbin::memidx_bitmask_type
+  get_memidx_nolock(unsigned int arg) const;
+
   // Used by xocl::device to cache the acquire context for
   void
   set_context_type(bool shared) const
@@ -187,6 +191,7 @@ private:
   // Intersection of all argument masks
   mutable bool cached = false;
   mutable xclbin::memidx_bitmask_type m_memidx;
+  mutable std::mutex m_mutex;
 };
 
 } // xocl

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1290,8 +1290,9 @@ unload_program(const program* program)
 {
   if (m_active == program) {
     clear_cus();
-    m_xdevice->release_cu_context(-1); // release virtual CU context
     m_active = nullptr;
+    if (!m_parent.get())
+      m_xdevice->release_cu_context(-1); // release virtual CU context
   }
 }
 


### PR DESCRIPTION
Also, fix race computing memidx for  compute unit
(cherry picked from commit 7e3540d2707443d8c824669ef4272b33ce2f9ba4)