### PR TITLE
xbutil reset doesn't work after PR#2296

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -469,8 +469,8 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 
 	switch (req->req) {
 	case XCL_MAILBOX_REQ_FIREWALL:
-		userpf_info(xdev, "Card is in a BAD state, please issue xbutil reset");
-		xocl_drvinst_set_offline(xdev->core.drm, true);
+		userpf_info(xdev,
+			"Card is in a BAD state, please issue xbutil reset");
 		xocl_drvinst_kill_proc(xdev->core.drm);
 		break;
 	case XCL_MAILBOX_REQ_MGMT_STATE:


### PR DESCRIPTION
@houlz0507 @chienwei-lan , we stopped doing auto-reset after firewall trip, but if we still mark device offline, no one will put it back online and device can't even be opened for manual hot reset. You'll need to warm reboot to recover the board. Let me know if you have a better way to fix this...