### PR TITLE
CR-1046516 xbutil and xbmgmt use different formats for time stamp

### DIFF
--- a/src/runtime_src/core/common/config_reader.cpp
+++ b/src/runtime_src/core/common/config_reader.cpp
@@ -180,12 +180,17 @@ get_bool_value(const char* key, bool default_value)
 std::string
 get_string_value(const char* key, const std::string& default_value)
 {
-  std::string val = s_tree.m_tree.get<std::string>(key,default_value);
-  // Although INI file entries are not supposed to have quotes around strings
-  // but we want to be cautious
-  if (!val.empty() && (val.front() == '"') && (val.back() == '"')) {
-    val.erase(0, 1);
-    val.erase(val.size()-1);
+  std::string val = default_value;
+  try {
+    val = s_tree.m_tree.get<std::string>(key,default_value);
+    // Although INI file entries are not supposed to have quotes around strings
+    // but we want to be cautious
+    if (!val.empty() && (val.front() == '"') && (val.back() == '"')) {
+      val.erase(0, 1);
+      val.erase(val.size()-1);
+      } 
+    }catch( std::exception const&) {
+    // eat the exception, probably bad path
   }
   return val;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -448,8 +448,7 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
     stream << dsa.name;
     if (dsa.timestamp != NULL_TIMESTAMP)
     {
-        stream << ",[ID=0x" << std::hex << std::setw(16) << std::setfill('0')
-            << dsa.timestamp << "]";
+        stream << ",[ts=0x" << std::hex << dsa.timestamp << "]";
     }
     if (!dsa.bmcVer.empty())
     {


### PR DESCRIPTION
and coverity fix

Output for timestamp:
```
$ xbmgmt flash --scan
ERROR: root privileges required.
sagarw@xsjsagarwal:/proj/xsjhdstaff1/sagarw/XRT/build$ sudo Debug/opt/xilinx/xrt/bin/xbmgmt flash --scan
Card [0000:b3:00.0]
    Card type:          u200
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u200_qdma_201910_1,[ts=0x5cdad62a],[SC=4.0.7]
    Flashable partitions installed in system:
        xilinx_u200_qdma_201910_1,[ts=0x5cdad62a],[SC=4.0.7]


$ xbutil list
INFO: Found total 1 card(s), 1 are usable
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
System Configuration
OS name:        Linux
Release:        4.4.0-142-generic
Version:        #168-Ubuntu SMP Wed Jan 16 21:00:45 UTC 2019
Machine:        x86_64
Glibc:          2.23
Distribution:   Ubuntu 16.04.5 LTS
Now:            Tue Oct 22 09:09:44 2019
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
XRT Information
Version:        2.3.0
Git Hash:       70fbe070faa64b9589e25f6a634918eb84a24cf6
Git Branch:     timestamp
Build Date:     2019-10-22 09:07:07
XOCL:           2.3.0,73edaf2387044eac334851435ed003eed55fd11e
XCLMGMT:        2.3.0,73edaf2387044eac334851435ed003eed55fd11e
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [0] 0000:b3:00.1 xilinx_u200_qdma_201910_1(ts=0x5cdad62a) user(inst=128)
```
