### PR TITLE
"help" command return 0

### DIFF
--- a/src/runtime_src/core/edge/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/edge/tools/xbutil/xbutil.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 
     if (cmd == xcldev::HELP) {
         xcldev::printHelp(exe);
-        return 1;
+        return 0;
     }
 
     argv[0] = const_cast<char *>(exe);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
 
     if (cmd == xcldev::HELP) {
         xcldev::printHelp(exe);
-        return 1;
+        return 0;
     }
     if (cmd == xcldev::VERSION) {
         xrt::version::print(std::cout);

--- a/src/runtime_src/core/pcie/user_aws/awssak.cpp
+++ b/src/runtime_src/core/pcie/user_aws/awssak.cpp
@@ -59,7 +59,7 @@ int xcldev::xclAwssak(int argc, char *argv[])
 
     if (cmd == xcldev::HELP) {
         xcldev::printHelp(exe);
-        return 1;
+        return 0;
     }
 
     argv[0] = const_cast<char *>(exe.c_str());


### PR DESCRIPTION
Issuing `xbutil help` should return 0, as it is not an error. This also applies to the `awssak` utility.