### PR TITLE
Removed the use of __FUNCTION__ macro as a default argument value  

### DIFF
--- a/src/runtime_src/tools/xclbin/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbin/XclBinUtilities.h
@@ -57,11 +57,12 @@ class XclBinUtilException : public std::runtime_error {
     XclBinExceptionType m_eExceptionType;
 
 public:
+  
     XclBinUtilException(XclBinExceptionType _eExceptionType,
                         const std::string & _msg,
+                        const char * _function = "<not_defined>", 
                         const char * _file = __FILE__,
-                        int _line = __LINE__,
-                        const char * _function = __FUNCTION__)
+                        int _line = __LINE__)
     : std::runtime_error(_msg)
     , m_msg(_msg)
     , m_file(_file)


### PR DESCRIPTION
The XclBinUtilException exception class was using the __FUNCTION__ macro to set the default value for the variable **_file** in the class' constructor.  Unfortunately, doing so caused the Windows compiler to fail.  The code was refactored to no longer depend on this macro.
Note
----
If the user wishes to have the function name to be part of the thrown exception, they would need to add this value during the exception class creation.