### PR TITLE
xmc: Add power_temp mode for clock scaling feature

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1188,7 +1188,7 @@ static ssize_t scaling_governor_show(struct device *dev,
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
 	u32 mode;
-	char val[10];
+	char val[20];
 
 	if (!xmc->runtime_cs_enabled) {
 		xocl_warn(dev, "%s: runtime clock scaling is not supported\n",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -108,6 +108,7 @@
 #define	XMC_CLOCK_SCALING_MODE_REG	0x10
 #define	XMC_CLOCK_SCALING_MODE_POWER	0x0
 #define	XMC_CLOCK_SCALING_MODE_TEMP	0x1
+#define	XMC_CLOCK_SCALING_MODE_POWER_TEMP	0x2
 
 #define	XMC_CLOCK_SCALING_POWER_REG	0x18
 #define	XMC_CLOCK_SCALING_POWER_TARGET_MASK 0xFF
@@ -1207,6 +1208,9 @@ static ssize_t scaling_governor_show(struct device *dev,
 	case 1:
 		strcpy(val, "temp");
 		break;
+	case 2:
+		strcpy(val, "power_temp");
+		break;
 	}
 
 	return sprintf(buf, "%s\n", val);
@@ -1229,6 +1233,8 @@ static ssize_t scaling_governor_store(struct device *dev,
 		val = XMC_CLOCK_SCALING_MODE_POWER;
 	else if (strncmp(buf, "temp", strlen("temp")) == 0)
 		val = XMC_CLOCK_SCALING_MODE_TEMP;
+	else if (strncmp(buf, "power_temp", strlen("power_temp")) == 0)
+		val = XMC_CLOCK_SCALING_MODE_POWER_TEMP;
 	else {
 		xocl_err(dev, "valid modes [power, temp]\n");
 		return -EINVAL;


### PR DESCRIPTION
Enable power_temp mode for clock scaling feature.
Fix for CR-1047381

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>