### PR TITLE
Revert ERT_CQ_SIZE back to 64k

### DIFF
--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -410,13 +410,12 @@ enum softkernel_type {
 /**
  * Address constants per spec
  */
-#define ERT_WORD_SIZE                     4          /* 4 bytes */
+#define ERT_WORD_SIZE                      4          /* 4 bytes */
+#define ERT_CQ_SIZE                        0x10000    /* 64K */
 #ifndef ERT_BUILD_U50
-# define ERT_CQ_SIZE                       0x10000    /* 64K */
 # define ERT_CQ_BASE_ADDR                  0x190000
 # define ERT_CSR_ADDR                      0x180000
 #else
-# define ERT_CQ_SIZE                       0x4000    /* 16K */
 # define ERT_CQ_BASE_ADDR                  0x340000
 # define ERT_CSR_ADDR                      0x360000
 #endif


### PR DESCRIPTION
2RP platforms are back at 64K CQ size.
With this change, KDS and ERT are now using same CQ size.