### PR TITLE
xbmgmt flash --scan --invlaid-opt can trigger segmentfault

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -529,6 +529,7 @@ static int scan(int argc, char *argv[])
     const option opts[] = {
         { "verbose", no_argument, nullptr, '0' },
         { "json", no_argument, nullptr, '1' },
+        {0,0,0,0},
     };
 
     while (true) {


### PR DESCRIPTION
build/XDebug/opt/xilinx/xrt/bin/xbmgmt flash --scan --invalid-ops
Segmentation fault (core dumped)

expected:
uild/XDebug/opt/xilinx/xrt/bin/xbmgmt flash --scan --invalid-ops
flashHandler--scanhere1!
flashHandler--scanhere2!
--scan: unrecognized option '--invalid-ops'
'flash' sub-command usage:
--scan [--verbose|--json]
--update [--shell name [--id id]] [--card bdf] [--force]
--factory_reset [--card bdf]

Experts only:
--shell --path file --card bdf [--type flash_type]
--sc_firmware --path file --card bdf

