### PR TITLE
CR-1047488 xrt deb is trying to install pyopencl even though its installed

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -117,11 +117,11 @@ if [ `uname -m` = "ppc64le" ]; then
     exit 0
 fi
 #get major version of pyopencl
-version=$(python -m pip list 2>&1 | grep -Po '(?<=pyopencl )(.+)' | grep -Po '[0-9][0-9][0-9][0-9]')
+VERSION=$(python -m pip list 2>&1 | grep -Po '(?<=pyopencl )(.+)' | grep -Po '[0-9][0-9][0-9][0-9]')
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}'`
 FLAVOR=`echo $FLAVOR | tr -d '"'`
 
-if [ -z $version ] || [ $version -lt 2019 ]; then
+if [ -z $VERSION ] ; then
     echo "Installing pyopencl..."
     #need to force install numpy version 1.8 for centos
     if [ $FLAVOR = "centos" ] || [ $FLAVOR = "rhel" ] ; then
@@ -129,10 +129,19 @@ if [ -z $version ] || [ $version -lt 2019 ]; then
         pip install --ignore-installed numpy==1.8
     fi
     pip install pyopencl
+elif [ $VERSION -lt 2019 ]; then
+    
+    echo "***********************************************************************"
+    echo "* Pyopencl ($VERSION) is installed on the system but pyopencl >= 2019.1"
+    echo "* is required. Please uninstall the current pyopencl by running"
+    echo "* 'apt remove python-pyopencl' and then reinstall the xrt package"
+    echo "***********************************************************************"
+    exit 0
 else
     echo "Skipping pyopencl installation..."
     exit 0
 fi
+
 if python -c "import pyopencl"; then
     echo "Successfully installed pyopencl"
 else


### PR DESCRIPTION
If older version of pyopencl is installed:

```
***********************************************************************
* Pyopencl (2015) is installed on the system but pyopencl >= 2019.1
* is required. Please uninstall the current pyopencl by running
* 'apt remove python-pyopencl' and then reinstall the xrt package
***********************************************************************
```
