### PR TITLE
get_header_from_dtb can fail due to[C ioread8 may return -1(ff)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -410,8 +410,11 @@ static int get_header_from_dtb(struct feature_rom *rom)
 	const char *vbnv;
 	int i, j = 0;
 
-	for (i = 31; i >= 0; i--, j+=2) {
-		sprintf(&rom->uuid[j], "%02x", *((uint8_t *)rom->base + i));
+	/* uuid string should be 64 + '\0' */
+	BUG_ON(sizeof(rom->uuid) <= 64);
+
+	for (i = 28; i >= 0 && j < 64; i -= 4, j += 8) {
+		sprintf(&rom->uuid[j], "%08x", ioread32(rom->base + i));
 	}
 	xocl_info(&rom->pdev->dev, "UUID %s", rom->uuid);
 


### PR DESCRIPTION
without the fix:
[root@xsjhemn41 ~]# xbmgmt flash --scan --verbose
Card [0001:45:00.0]
    Card type:          u200
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u200_xdma_201920_1,[ID=0xffffff9fffffff5e]
            Logic UUID:
            ffffff9fffffff5effffff40ffffffb5ffffffceffffffd1ffffffc8ffffffac
    Flashable partitions installed in system:
        xilinx_u200_gen3x16-ea_blp,[ID=0x272eb49f3c9fb05e]
            Logic UUID:
            272eb49f3c9fb05e27db9f40f01419b5f8c245ce1cba59d11f8b97c8787e96ac

with the fix:
[root@xsjhemn41 ~]# xbmgmt flash --scan --verbose
Card [0001:45:00.0]
    Card type:          u200
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u200_gen3x16-ea_blp,[ID=0x272eb49f3c9fb05e]
            Logic UUID:
            272eb49f3c9fb05e27db9f40f01419b5f8c245ce1cba59d11f8b97c8787e96ac
    Flashable partitions installed in system:
        xilinx_u200_gen3x16-ea_blp,[ID=0x272eb49f3c9fb05e]
            Logic UUID:
            272eb49f3c9fb05e27db9f40f01419b5f8c245ce1cba59d11f8b97c8787e96ac


