### PR TITLE
sched_exec should use zocl_xclbin to interact with xclbin.h

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -27,12 +27,6 @@
 #include "zocl_sk.h"
 #include "zocl_xclbin.h"
 
-/*
- * The get_cu_support_intr needs this but we will move it to zocl_xclbin.c
- * in next code change.
- */
-#include "xclbin.h"
-
 /* #define SCHED_VERBOSE */
 
 #if defined(__GNUC__)
@@ -670,26 +664,6 @@ done:
 		DRM_INFO("CU can only be initialized once.\n");
 }
 
-/*
- * returns false if any of the cu doesnt support interrupt
- */
-bool
-get_cus_support_intr(struct drm_zocl_dev *zdev)
-{
-	struct ip_data *ip;
-        int i;
-        if (!zdev->ip)
-                return false;
-
-        for (i = 0; i < zdev->ip->m_count; ++i) {
-                ip = &zdev->ip->m_ip_data[i];
-                if(!(ip->properties & 0x1)) {
-                        return false;
-                }
-        }
-        return true;
-}
-
 /**
  * configure() - Configure the scheduler from user space command
  *
@@ -755,7 +729,7 @@ configure(struct sched_cmd *cmd)
 		 * Interrupt may not be enabled for some of the kernel,
 		 * Need to use polling mode in that case
 		 */
-		if (!get_cus_support_intr(zdev)) {
+		if (!zocl_xclbin_cus_support_intr(zdev)) {
 			DRM_WARN("Interrupt is not enabled for at least one "
 			    "kernel. Fall back to polling mode.");
 			exec->polling_mode = 1;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -942,3 +942,26 @@ zocl_xclbin_accel_adapter(int kds_mask)
 {
 	return kds_mask == ACCEL_ADAPTER;
 }
+
+/*
+ * returns false if any of the cu doesnt support interrupt
+ */
+bool
+zocl_xclbin_cus_support_intr(struct drm_zocl_dev *zdev)
+{
+	struct ip_data *ip;
+	int i;
+
+	if (!zdev->ip)
+		return false;
+
+	for (i = 0; i < zdev->ip->m_count; ++i) {
+		ip = &zdev->ip->m_ip_data[i];
+		if (!(ip->properties & 0x1)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.h
@@ -38,5 +38,6 @@ int zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev,
 int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data);
 
 bool zocl_xclbin_accel_adapter(int kds_mask);
+bool zocl_xclbin_cus_support_intr(struct drm_zocl_dev *zdev);
 
 #endif /* _ZOCL_XCLBIN_H_ */


### PR DESCRIPTION
as we discussed before, move xclbin related code outside of scheduler. In the future, we should make the scheduler code only for scheduling. 