### PR TITLE
Core based scheduling

### DIFF
--- a/src/runtime_src/core/common/scheduler.cpp
+++ b/src/runtime_src/core/common/scheduler.cpp
@@ -132,6 +132,7 @@ init(xclDeviceHandle handle, const axlf* top)
   auto ecmd = reinterpret_cast<ert_configure_cmd*>(execbo->data);
   ecmd->state = ERT_CMD_STATE_NEW;
   ecmd->opcode = ERT_CONFIGURE;
+  ecmd->type = ERT_CTRL;
 
   auto cus = xclbin::get_cus(top, true);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -131,6 +131,7 @@ static void exec_ert_clear_csr(struct exec_core *exec);
 static void scheduler_wake_up(struct xocl_scheduler *xs);
 static void scheduler_intr(struct xocl_scheduler *xs);
 static void scheduler_decr_poll(struct xocl_scheduler *xs);
+static void scheduler_incr_poll(struct xocl_scheduler *xs);
 
 /*
  */
@@ -170,27 +171,27 @@ xocl_bitmap_from_arr32(unsigned long *bitmap, const u32 *buf, unsigned int nbits
 
 
 /**
- * slot_mask_idx() - Slot mask idx index for a given slot_idx
+ * mask_idx32() - Slot mask idx index for a given slot_idx
  *
  * @slot_idx: Global [0..127] index of a CQ slot
  * Return: Index of the slot mask containing the slot_idx
  */
 static inline unsigned int
-slot_mask_idx(unsigned int slot_idx)
+mask_idx32(unsigned int idx)
 {
-	return slot_idx >> 5;
+	return idx >> 5;
 }
 
 /**
- * slot_idx_in_mask() - Index of command queue slot within the mask that contains it
+ * idx_in_mask32() - Index of command queue slot within the mask that contains it
  *
  * @slot_idx: Global [0..127] index of a CQ slot
  * Return: Index of slot within the mask that contains it
  */
 static inline unsigned int
-slot_idx_in_mask(unsigned int slot_idx)
+idx_in_mask32(unsigned int idx, unsigned int mask_idx)
 {
-	return slot_idx - (slot_mask_idx(slot_idx) << 5);
+	return idx - (mask_idx << 5);
 }
 
 /**
@@ -245,8 +246,8 @@ struct xocl_cmd {
 
 	bool          aborted;  // set to true if CU aborts the command 
 	unsigned long uid;      // unique id for this command
-	unsigned int  cu_idx;   // index of CU running this cmd (penguin mode)
-	unsigned int  slot_idx; // index in exec core submit queue
+	unsigned int  cu_idx;   // index of CU running this cmd
+	unsigned int  slot_idx; // index in exec core running queue
 
 	bool timestamp_enabled;
 };
@@ -433,11 +434,11 @@ cmd_set_int_state(struct xocl_cmd *xcmd, enum ert_cmd_state state)
 static inline void
 cmd_set_state(struct xocl_cmd *xcmd, enum ert_cmd_state state)
 {
-	SCHED_DEBUGF("->%s(%lu,%d)\n", __func__, xcmd->uid, state);
+	SCHED_DEBUGF("-> %s(%lu,%d)\n", __func__, xcmd->uid, state);
 	cmd_record_timestamp(xcmd, state);
 	xcmd->state = state;
 	xcmd->ert_pkt->state = state;
-	SCHED_DEBUGF("<-%s\n", __func__);
+	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
 /*
@@ -517,10 +518,13 @@ cmd_chain_dependencies(struct xocl_cmd *xcmd)
 			continue;
 		}
 		if (chain_to->chain_count >= MAX_DEPS) {
-			DRM_INFO("chain count exceeded");
+			userpf_err(xcmd->xdev,
+				   "cmd (%lu) chain count (%d) exceeds maximum allowed (%d)",
+				   chain_to->uid, chain_to->chain_count, MAX_DEPS);
 			return 1;
 		}
-		SCHED_DEBUGF("+ xcmd(%lu)->chain[%d]=xcmd(%lu)", chain_to->uid, chain_to->chain_count, xcmd->uid);
+		SCHED_DEBUGF("+ xcmd(%lu)->chain[%d]=xcmd(%lu)",
+			     chain_to->uid, chain_to->chain_count, xcmd->uid);
 		chain_to->chain[chain_to->chain_count++] = xcmd;
 	}
 	SCHED_DEBUG("<- chain_dependencies\n");
@@ -598,12 +602,12 @@ cmd_get(struct xocl_scheduler *xs, struct exec_core *exec, struct client_ctx *cl
  * cmd_free() - free a command object
  *
  * @xcmd: command object to free (move to freelist)
- *
- * The command *is* in some current list (scheduler command queue)
  */
 static void
 cmd_free(struct xocl_cmd *xcmd)
 {
+	SCHED_DEBUGF("-> %s xcmd(%lu)\n", __func__, xcmd->uid);
+
 	cmd_release_gem_object_reference(xcmd);
 
 	mutex_lock(&free_cmds_mutex);
@@ -612,7 +616,8 @@ cmd_free(struct xocl_cmd *xcmd)
 
 	atomic_dec(&xcmd->xdev->outstanding_execs);
 	atomic_dec(&xcmd->client->outstanding_execs);
-	SCHED_DEBUGF("xcmd(%lu) [-> free]\n", xcmd->uid);
+
+	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
 /**
@@ -669,8 +674,8 @@ cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
 
 	xcmd->timestamp_enabled = cmd_can_enable_timestamps(xcmd);
 
-	// in kds mode copy pkt cus to command object cu bitmap
-	if (penguin && cmd_type(xcmd) == ERT_CU) {
+	// copy pkt cus to command object cu bitmap
+	if (cmd_type(xcmd) == ERT_CU) {
 		unsigned int i = 0;
 		u32 cumasks[4] = {0};
 
@@ -692,20 +697,71 @@ cmd_bo_init(struct xocl_cmd *xcmd, struct drm_xocl_bo *bo,
 	xcmd->chain_count = 0;
 }
 
-/*
+/**
  * cmd_has_cu() - Check if this command object can execute on CU
  *
  * @cuidx: the index of the CU.	 Note that CU indicies start from 0.
  */
-static int
+static inline bool
 cmd_has_cu(struct xocl_cmd *xcmd, unsigned int cuidx)
 {
 	SCHED_DEBUGF("%s(%lu,%d) = %d\n", __func__, xcmd->uid, cuidx, test_bit(cuidx, xcmd->cu_bitmap));
 	return test_bit(cuidx, xcmd->cu_bitmap);
 }
 
+/**
+ * cmd_first_cu() - Get index of first CU this command can use
+ */
+static inline unsigned int
+cmd_first_cu(struct xocl_cmd *xcmd)
+{
+	return find_first_bit(xcmd->cu_bitmap, MAX_CUS);
+}
 
-/*
+/**
+ * cmd_next_cu() - Get index of CU after @prev this command can use
+ *
+ * @prev: index of previous CU
+ */
+static inline unsigned int
+cmd_next_cu(struct xocl_cmd *xcmd, unsigned int prev)
+{
+	return find_next_bit(xcmd->cu_bitmap, MAX_CUS, prev + 1);
+}
+
+/**
+ * cmd_set_cu() - Lock command to one specific CU
+ *
+ * @cuidx: Selected specific CU that this command can use
+ */
+static inline void
+cmd_set_cu(struct xocl_cmd *xcmd, unsigned int cuidx)
+{
+	unsigned int midx = 0;
+
+	SCHED_DEBUGF("-> %s cmd(%lu) cuidx(%d)\n", __func__, xcmd->uid, cuidx);
+
+	xcmd->cu_idx = cuidx;
+	bitmap_zero(xcmd->cu_bitmap, MAX_CUS);
+	set_bit(cuidx, xcmd->cu_bitmap);
+
+	// TODO, change ERT to get exact idx of selected CU
+	// rather than bitmap which now has just one bit set
+	xcmd->ert_cu->cu_mask = 0;  // cuidx per TODO
+	for (midx = 0; midx < xcmd->ert_cu->extra_cu_masks; ++midx)
+		xcmd->ert_cu->data[midx] = 0;
+
+	midx = mask_idx32(cuidx);
+	SCHED_DEBUGF("+ midx(%d) = 0x%x\n", midx, 1 << idx_in_mask32(cuidx, midx));
+	if (midx == 0)
+		xcmd->ert_cu->cu_mask = (1 << idx_in_mask32(cuidx, midx));
+	else
+		xcmd->ert_cu->data[midx - 1] = (1 << idx_in_mask32(cuidx, midx));
+
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+/**
  * cmd_ctx_in() - Get the context/queue ID from the command
  *
  * Applicable only for ERT_CU commands when the command targets a CU
@@ -1046,8 +1102,6 @@ cu_continue(struct xocl_cu *xcu)
 static inline u32
 cu_status(struct xocl_cu *xcu)
 {
-	SCHED_DEBUGF("%s(%p) cu(%d) @0x%x\n", __func__, xcu->base + xcu->addr,
-		     xcu->idx, xcu->addr);
 	return ioread32(xcu->base + xcu->addr);
 }
 
@@ -1195,11 +1249,10 @@ cu_start(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 	// past header, past cumasks
 	SCHED_DEBUG_PACKET(cmd_regmap(xcmd), cmd_regmap_size(xcmd));
 
-	/* write register map, starting at base + 0x10
-	 * 0x0 used for control register
-	 * 0x4, 0x8 used for interrupt, which is initialized in setup of ERT
-	 * 0xC used for interrupt status, which is set by hardware
-	 */
+	// write register map, starting at base + 0x10
+	// 0x0 used for control register
+	// 0x4, 0x8 used for interrupt, which is initialized in setup of ERT
+	// 0xC used for interrupt status, which is set by hardware
 	if (cmd_opcode(xcmd) == ERT_EXEC_WRITE)
 		cu_configure_ooo(xcu, xcmd);
 	else
@@ -1224,34 +1277,60 @@ cu_start(struct xocl_cu *xcu, struct xocl_cmd *xcmd)
 
 
 /**
- * sruct xocl_ert: Represents embedded scheduler in ert mode
+ * struct xocl_ert: Represents embedded scheduler in ert mode
+ *
+ * @cq_size: Size of HW command queue
+ * @num_slots: Number of slot in CQ
+ * @slot_size: Size of a CQ slot
+ * @cq_intr: Enable interrupts host -> MB for new commands
+ * @command_queue: Command queue with commands that have been sent to ERT
+ * @slot_status: Bitmap to track status (busy(1)/free(0)) slots in command queue
+ * @ctrl_busy: Flag to indicate that slot 0 (ctrl commands) is busy
+ * @version: Version per HW ERT
+ * @cu_usage: CU usage count per ERT FW (since last reset)
+ * @cu_status: CU status per ERT FW
+ * @cq_slot_status: CQ (command_queue) slot status per ERT FW
+ * @cq_slot_usage: CQ (command_queue) usage count since last reset
  */
 struct xocl_ert {
-	void __iomem *csr_base;
-	void __iomem *cq_base;
-	unsigned int uid;
+	struct xocl_dev * xdev;
+	void __iomem *    csr_base;
+	void __iomem *    cq_base;
+	unsigned int      uid;
 
-	unsigned int slot_size;
-	bool         cq_intr;
+	unsigned int      cq_size;
+	unsigned int      num_slots;
+
+	unsigned int      slot_size;
+	bool              cq_intr;
+	
+	struct xocl_cmd * command_queue[MAX_SLOTS];
+
+	// Bitmap tracks busy(1)/free(0) slots in command_queue
+	DECLARE_BITMAP(slot_status, MAX_SLOTS);
+	unsigned int	  ctrl_busy;
 
 	// stats
-	u32          version;
-	u32          cu_usage[MAX_CUS];
-	u32          cu_status[MAX_CUS];
-	u32          cq_slot_status[MAX_SLOTS];
+	u32               version;
+	u32               cu_usage[MAX_CUS];
+	u32               cu_status[MAX_CUS];
+	u32               cq_slot_status[MAX_SLOTS];
+	unsigned int      cq_slot_usage[MAX_SLOTS];
 };
 
 /*
  */
 struct xocl_ert *
-ert_create(void __iomem *csr_base, void __iomem *cq_base)
+ert_create(struct xocl_dev * xdev, void __iomem *csr_base, void __iomem *cq_base)
 {
 	struct xocl_ert *xert = kmalloc(sizeof(struct xocl_ert), GFP_KERNEL);
 	static unsigned int uid;
 
+	xert->xdev = xdev;
 	xert->csr_base = csr_base;
 	xert->cq_base = cq_base;
 	xert->uid = uid++;
+	xert->num_slots = 0;
 	xert->slot_size = 0;
 	xert->cq_intr = false;
 	SCHED_DEBUGF("%s(%d,0x%p)\n", __func__, xert->uid, xert->cq_base);
@@ -1270,11 +1349,112 @@ ert_destroy(struct xocl_ert *xert)
 /**
  */
 static void
-ert_cfg(struct xocl_ert *xert, unsigned int slot_size, bool cq_intr)
+ert_cfg(struct xocl_ert *xert, unsigned int cq_size, unsigned int num_slots, bool cq_intr)
 {
-	SCHED_DEBUGF("%s(%d) slot_size(%d) cq_intr(%d)\n", __func__, xert->uid, slot_size, cq_intr);
-	xert->slot_size = slot_size;
+	unsigned int idx;
+
+	SCHED_DEBUGF("%s ert(%d) cq_size(%d) slots(num_slots) slot_size(%d) cq_intr(%d)\n",
+		     __func__, xert->uid, cq_size, num_slots, cq_size / num_slots, cq_intr);
+	xert->cq_size = cq_size;
+	xert->num_slots = num_slots;
+	xert->slot_size = cq_size / num_slots;
 	xert->cq_intr = cq_intr;
+	xert->version = 0;
+
+	for (idx = 0; idx < MAX_CUS; ++idx) {
+		xert->cu_usage[idx] = 0;
+		xert->cu_status[idx] = 0;
+	}
+
+	for (idx = 0; idx < MAX_SLOTS; ++idx) {
+		xert->command_queue[idx] = NULL;
+		xert->cq_slot_status[idx] = 0;
+		xert->cq_slot_usage[idx] = 0;
+	}
+
+	bitmap_zero(xert->slot_status, MAX_SLOTS);
+	set_bit(0, xert->slot_status); // reserve for control command
+	xert->ctrl_busy = false;
+}
+
+/*
+ * acquire_slot_idx() - First available slot index
+ */
+static unsigned int
+ert_acquire_slot_idx(struct xocl_ert *xert)
+{
+	unsigned int idx = find_first_zero_bit(xert->slot_status, MAX_SLOTS);
+
+	SCHED_DEBUGF("%s(%d) returns %d\n", __func__, xert->uid, idx < xert->num_slots ? idx : no_index);
+	if (idx < xert->num_slots) {
+		set_bit(idx, xert->slot_status);
+		return idx;
+	}
+	return no_index;
+}
+
+
+/**
+ * acquire_slot() - Acquire a slot index for a command
+ *
+ * This function makes a special case for control commands which
+ * must always dispatch to slot 0, otherwise normal acquisition
+ */
+static int
+ert_acquire_slot(struct xocl_ert *xert, struct xocl_cmd *xcmd)
+{
+	// slot 0 is reserved for ctrl commands
+	if (cmd_type(xcmd) == ERT_CTRL) {
+		SCHED_DEBUGF("%s ctrl cmd(%lu)\n", __func__, xcmd->uid);
+		if (xert->ctrl_busy) {
+			userpf_info(xert->xdev, "ctrl slot is busy\n");
+			return -1;
+		}
+		xert->ctrl_busy = true;
+		return (xcmd->slot_idx = 0);
+	}
+
+	return (xcmd->slot_idx = ert_acquire_slot_idx(xert));
+}
+
+/*
+ * release_slot_idx() - Release specified slot idx
+ */
+static void
+ert_release_slot_idx(struct xocl_ert *xert, unsigned int slot_idx)
+{
+	clear_bit(slot_idx, xert->slot_status);
+}
+
+/**
+ * release_slot() - Release a slot index for a command
+ *
+ * Special case for control commands that execute in slot 0.  This
+ * slot cannot be marked free ever.
+ */
+static void
+ert_release_slot(struct xocl_ert *xert, struct xocl_cmd *xcmd)
+{
+	if (xcmd->slot_idx == no_index)
+		return; // already released
+
+	SCHED_DEBUGF("-> %s(%d) xcmd(%lu) slotidx(%d)\n",
+		     __func__, exec->uid, xcmd->uid, xcmd->slot_idx);
+	if (cmd_type(xcmd) == ERT_CTRL) {
+		SCHED_DEBUG("+ ctrl cmd\n");
+		xert->ctrl_busy = false;
+	} else {
+		ert_release_slot_idx(xert, xcmd->slot_idx);
+	}
+	xert->command_queue[xcmd->slot_idx] = NULL;
+	xcmd->slot_idx = no_index;
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static inline struct xocl_cmd *
+ert_get_cmd(struct xocl_ert *xert, unsigned int slotidx)
+{
+	return xert->command_queue[slotidx];
 }
 
 /**
@@ -1287,12 +1467,19 @@ ert_cfg(struct xocl_ert *xert, unsigned int slot_size, bool cq_intr)
 static bool
 ert_start_cmd(struct xocl_ert *xert, struct xocl_cmd *xcmd)
 {
-	u32 slot_addr = xcmd->slot_idx * xert->slot_size;
+	u32 slot_addr = 0;
 	struct ert_packet *ecmd = cmd_packet(xcmd);
 
-	SCHED_DEBUG_PACKET(ecmd, cmd_packet_size(xcmd));
-
 	SCHED_DEBUGF("-> %s ert(%d) cmd(%lu)\n", __func__, xert->uid, xcmd->uid);
+
+	if (ert_acquire_slot(xert, xcmd) == no_index) {
+		SCHED_DEBUGF("<- %s returns false (noindex)\n", __func__);
+		return false;
+	}
+
+	slot_addr = xcmd->slot_idx * xert->slot_size;
+
+	SCHED_DEBUG_PACKET(ecmd, cmd_packet_size(xcmd));
 
 	// write packet minus header
 	SCHED_DEBUGF("++ slot_idx=%d, slot_addr=0x%x\n", xcmd->slot_idx, slot_addr);
@@ -1303,13 +1490,19 @@ ert_start_cmd(struct xocl_ert *xert, struct xocl_cmd *xcmd)
 
 	// trigger interrupt to embedded scheduler if feature is enabled
 	if (xert->cq_intr) {
-		u32 cq_int_addr = ERT_CQ_STATUS_REGISTER_ADDR + (slot_mask_idx(xcmd->slot_idx) << 2);
-		u32 mask = 1 << slot_idx_in_mask(xcmd->slot_idx);
+		u32 mask_idx = mask_idx32(xcmd->slot_idx);
+		u32 cq_int_addr = ERT_CQ_STATUS_REGISTER_ADDR + (mask_idx << 2);
+		u32 mask = 1 << idx_in_mask32(xcmd->slot_idx, mask_idx);
 
 		SCHED_DEBUGF("++ mb_submit writes slot mask 0x%x to CQ_INT register at addr 0x%x\n",
 			     mask, cq_int_addr);
 		csr_write32(mask, xert->csr_base, cq_int_addr);
 	}
+
+	// success
+	++xert->cq_slot_usage[xcmd->slot_idx];
+	xert->command_queue[xcmd->slot_idx] = xcmd;
+	
 	SCHED_DEBUGF("<- %s returns true\n", __func__);
 	return true;
 }
@@ -1345,9 +1538,11 @@ ert_read_custat(struct xocl_ert *xert, struct xocl_cmd *xcmd, unsigned int num_c
 	// New command style from ERT firmware
 	if (custat_version == 0x51a10000) {
 		unsigned int idx = 2; // packet word index past header and version
+		unsigned int max_idx = (xert->slot_size >> 2);
 		u32 git = ioread32(xert->cq_base + slot_addr + (idx++ << 2));
 		u32 ert_num_cq_slots = ioread32(xert->cq_base + slot_addr + (idx++ << 2));
 		u32 ert_num_cus = ioread32(xert->cq_base + slot_addr + (idx++ << 2));
+		unsigned int words = 0; 
 
 		xert->version = git;
 
@@ -1356,18 +1551,22 @@ ert_read_custat(struct xocl_ert *xert, struct xocl_cmd *xcmd, unsigned int num_c
 			return;
 
 		// cu execution stat
+		words = min(ert_num_cus, max_idx - idx);
 		xocl_memcpy_fromio(xert->cu_usage, xert->cq_base + slot_addr + (idx << 2),
-			      ert_num_cus * sizeof(u32));
-		idx += ert_num_cus;
+			      words * sizeof(u32));
+		idx += words;
 
 		// ert cu status
+		words = min(ert_num_cus, max_idx - idx);
 		xocl_memcpy_fromio(xert->cu_status, xert->cq_base + slot_addr + (idx << 2),
-			      ert_num_cus * sizeof(u32));
-		idx += ert_num_cus;
+			      words * sizeof(u32));
+		idx += words;
 
 		// ert cq status
+		words = min(ert_num_cq_slots, max_idx - idx);
 		xocl_memcpy_fromio(xert->cq_slot_status, xert->cq_base + slot_addr + (idx << 2),
-			      ert_num_cq_slots * sizeof(u32));
+			      words * sizeof(u32));
+		idx += words;
 	}
 	else {
 		// Old ERT command style populates only cu usage past header
@@ -1402,10 +1601,24 @@ ert_cu_status(struct xocl_ert *xert, unsigned int cuidx)
 
 /**
  */
+static inline bool
+ert_cq_slot_busy(struct xocl_ert *xert, unsigned int slotidx)
+{
+	return xert->command_queue[slotidx] != NULL;
+}
+
+/**
+ */
 static inline u32
-ert_cq_status(struct xocl_ert *xert, unsigned int slotidx)
+ert_cq_slot_status(struct xocl_ert *xert, unsigned int slotidx)
 {
 	return xert->cq_slot_status[slotidx];
+}
+
+static inline u32
+ert_cq_slot_usage(struct xocl_ert *xert, unsigned int slotidx)
+{
+	return xert->cq_slot_usage[slotidx];
 }
 
 /**
@@ -1435,12 +1648,18 @@ static struct exec_ops penguin_ops;   // kds mode (no ert)
 /**
  * struct exec_core: Core data structure for command execution on a device
  *
- * @ctx_list: Context list populated with device context
+ * @pdev: Platform device associated with this execution core
  * @exec_lock: Lock for synchronizing external access
+ * @base: BAR address
+ * @csr_base: Status register base address
+ * @cq_base: CQ base address
+ * @intr_base:
+ * @intr_num:
+ * @ert_cfg_priv: Private data for scheduler subdevice
  * @poll_wait_queue: Wait queue for device polling
  * @scheduler: Command queue scheduler
- * @submitted_cmds: Tracking of command submitted for execution on this device
- * @num_slots: Number of command queue slots
+ * @core_list: List head for storing in scheduler
+ * @xclbin_id: UUID of current loaded xclbin
  * @num_cus: Number of CUs in loaded program
  * @num_cdma: Number of CDMAs in hardware
  * @polling_mode: If set then poll for command completion
@@ -1448,25 +1667,38 @@ static struct exec_ops penguin_ops;   // kds mode (no ert)
  * @configured: Flag to indicate that the core data structure has been initialized
  * @stopped: Flag to indicate that the core data structure cannot be used
  * @flush: Flag to indicate that commands for this device should be flushed
- * @cu_usage: Usage count since last reset
+ * @pending_cu_queue: num_cus array of commands submitted but pending execution on a CU
+ * @cu_load_count: num_cus array of number of pending + running (submitted) commands for a CU
+ * @pending_ctrl_queue: Pending control commands
+ * @pending_kds_queue: Pending kds (local) commands
+ * @pending_cmd_queue: Staging queue for commands that are queued but not yet submitted
+ * @cu_usage: CU usage count since last reset
  * @cu_status: AP_CTRL status of CU, updated by ERT_CU_STAT
- * @slot_status: Bitmap to track status (busy(1)/free(0)) slots in command queue
- * @ctrl_busy: Flag to indicate that slot 0 (ctrl commands) is busy
  * @sr0: If set, then status register [0..31] is pending with completed commands (ERT only).
  * @sr1: If set, then status register [32..63] is pending with completed commands (ERT only).
  * @sr2: If set, then status register [64..95] is pending with completed commands (ERT only).
  * @sr3: If set, then status register [96..127] is pending with completed commands (ERT only).
  * @ops: Scheduler operations vtable
+ *
+ * The execution core receives commands from scheduler when it transfers
+ * execbuf command objects to execution cores where they are queued.  When the
+ * scheduler services an execution core, the queued commands are submitted to
+ * matching pending queue depending on command type.  A CU command is
+ * submitted to the matching CU queue with fewest entries.  Pending CU
+ * commands are started when the CU is available (kds mode) or when there is
+ * room in the running command queue (ert mode).  When checking command
+ * completion only the commands in the running queue need to be checked.
  */
 struct exec_core {
-	struct platform_device	   *pdev;
+	struct platform_device *   pdev;
 
 	struct mutex		   exec_lock;
 
-	void __iomem		   *base;
-	void __iomem		   *csr_base;
-	void __iomem		   *cq_base;
+	void __iomem *		   base;
+	void __iomem *		   csr_base;
+	void __iomem *		   cq_base;
 	unsigned int               cq_size;
+
 	u32			   intr_base;
 	u32			   intr_num;
 	char			   ert_cfg_priv;
@@ -1474,11 +1706,11 @@ struct exec_core {
 
 	wait_queue_head_t	   poll_wait_queue;
 
-	struct xocl_scheduler	   *scheduler;
+	struct xocl_scheduler *    scheduler;
+	struct list_head           core_list;
 
 	xuid_t			   xclbin_id;
 
-	unsigned int		   num_slots;
 	unsigned int		   num_cus;
 	unsigned int		   num_cdma;
 	
@@ -1488,16 +1720,22 @@ struct exec_core {
 	bool		           stopped;
 	bool		           flush;
 
-	struct xocl_cu		   *cus[MAX_CUS];
-	struct xocl_ert		   *ert;
+	struct list_head           pending_cu_queue[MAX_CUS];
+	struct list_head           pending_ctrl_queue;
+	struct list_head           pending_kds_queue;
+
+	struct list_head           running_cmd_queue;
+	struct list_head           pending_cmd_queue;
+
+	unsigned int               num_running_cmds;
+	unsigned int               num_pending_cmds;
+	unsigned int               cu_load_count[MAX_CUS];
+
+	struct xocl_cu *	   cus[MAX_CUS];
+	struct xocl_ert	*	   ert;
 
 	u32			   cu_usage[MAX_CUS];
 	u32			   cu_status[MAX_CUS];
-
-	// Bitmap tracks busy(1)/free(0) slots in cmd_slots
-	struct xocl_cmd		   *submitted_cmds[MAX_SLOTS];
-	DECLARE_BITMAP(slot_status, MAX_SLOTS);
-	unsigned int		   ctrl_busy;
 
 	// Status register pending complete.  Written by ISR, cleared by
 	// scheduler
@@ -1508,7 +1746,7 @@ struct exec_core {
 
 	// Operations for dynamic indirection dependt on MB or kernel
 	// scheduler
-	struct exec_ops		   *ops;
+	struct exec_ops *	   ops;
 
 	unsigned int		   uid;
 
@@ -1604,6 +1842,18 @@ exec_cu_status(struct exec_core *exec, unsigned int cuidx)
 	return exec->cu_status[cuidx];
 }
 
+static inline unsigned int
+exec_num_running(struct exec_core *exec)
+{
+	return exec->num_running_cmds;
+}
+
+static inline unsigned int
+exec_num_pending(struct exec_core *exec)
+{
+	return exec->num_pending_cmds;
+}
+
 static bool
 exec_valid_cu(struct exec_core *exec, unsigned int cuidx)
 {
@@ -1618,6 +1868,7 @@ exec_cfg(struct exec_core *exec)
 {
 }
 
+
 /*
  * to be automated
  */
@@ -1631,7 +1882,13 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	bool ert = XOCL_DSA_IS_VERSAL(xdev) ? 1 : xocl_mb_sched_on(xdev);
 	bool ert_full = (ert && cfg->ert && !cfg->dataflow);
 	bool ert_poll = (ert && cfg->ert && cfg->dataflow);
+	unsigned int ert_num_slots = 0;
 	int cuidx = 0;
+
+	// If exec_cfg_cmd is called on new xclbin then by default
+	// polling is true.  If configuration turns off polling, then
+	// scheduler poll count must be decremented.
+	bool exec_polling_save = exec->polling_mode;
 
 	/* Only allow configuration with one live ctx */
 	if (exec->configured) {
@@ -1665,13 +1922,20 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	}
 
 	SCHED_DEBUGF("configuring scheduler cq_size(%d)\n", exec->cq_size);
-	exec->num_slots = exec->cq_size / cfg->slot_size;
+	ert_num_slots = exec->cq_size / cfg->slot_size;
 	exec->num_cus = cfg->num_cus;
 	exec->num_cdma = 0;
 
 	if (ert_poll)
 		// Adjust slot size for ert poll mode
 		cfg->slot_size = exec->cq_size / MAX_CUS;
+
+	if (ert_full && cfg->cu_dma && ert_num_slots > 32) {
+		// Max slot size is 32 because of cudma bug
+		userpf_info(xdev, "Limitting CQ size to 32 due to ERT CUDMA bug\n");
+		ert_num_slots = 32;
+		cfg->slot_size = exec->cq_size / ert_num_slots;
+	}
 
 	// Create CUs for regular CUs
 	for (cuidx = 0; cuidx < exec->num_cus; ++cuidx) {
@@ -1711,19 +1975,19 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	}
 
 	if ((ert_full || ert_poll) && !exec->ert)
-		exec->ert = ert_create(exec->csr_base, exec->cq_base);
+		exec->ert = ert_create(exec_get_xdev(exec), exec->csr_base, exec->cq_base);
 
 	if (ert_poll) {
 		userpf_info(xdev, "configuring dataflow mode with ert polling\n");
 		cfg->slot_size = exec->cq_size / MAX_CUS;
 		cfg->cu_isr = 0;
 		cfg->cu_dma = 0;
-		ert_cfg(exec->ert, cfg->slot_size, cfg->cq_int);
+		ert_cfg(exec->ert, exec->cq_size, MAX_CUS, cfg->cq_int);
 		exec->ops = &ert_poll_ops;
 		exec->polling_mode = cfg->polling;
 	} else if (ert_full) {
 		userpf_info(xdev, "configuring embedded scheduler mode\n");
-		ert_cfg(exec->ert, cfg->slot_size, cfg->cq_int);
+		ert_cfg(exec->ert, exec->cq_size, ert_num_slots, cfg->cq_int);
 		exec->ops = &ert_ops;
 		exec->polling_mode = cfg->polling;
 		exec->cq_interrupt = cfg->cq_int;
@@ -1735,16 +1999,18 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 		exec->polling_mode = true;
 	}
 
+	// Polling may have toggled, correct scheduler count
+	if (!exec->polling_mode && exec_polling_save)
+		scheduler_decr_poll(exec->scheduler);
+
 	if (XDEV(xdev)->priv.flags & XOCL_DSAFLAG_CUDMA_OFF)
 		cfg->cu_dma = 0;
 
-	// reserve slot 0 for control commands
-	set_bit(0, exec->slot_status);
 
 	userpf_info(xdev, "scheduler config ert(%d), dataflow(%d), slots(%d), cudma(%d), cuisr(%d), cdma(%d), cus(%d)\n"
 		 , ert_poll | ert_full
 		 , cfg->dataflow
-		 , exec->num_slots
+		 , ert_num_slots
 		 , cfg->cu_dma ? 1 : 0
 		 , cfg->cu_isr ? 1 : 0
 		 , exec->num_cdma
@@ -1765,6 +2031,7 @@ static void
 exec_reset(struct exec_core *exec, const xuid_t *xclbin_id)
 {
 	struct xocl_dev *xdev = exec_get_xdev(exec);
+	unsigned int idx;
 
 	mutex_lock(&exec->exec_lock);
 
@@ -1778,12 +2045,10 @@ exec_reset(struct exec_core *exec, const xuid_t *xclbin_id)
 
 	userpf_info(xdev, "%s resets", __func__);
 	userpf_info(xdev, "exec->xclbin(%pUb),xclbin(%pUb)\n", &exec->xclbin_id, xclbin_id);
-	memset(exec->cu_usage, 0, MAX_CUS * sizeof(u32));
 	uuid_copy(&exec->xclbin_id, xclbin_id);
 	exec->num_cus = 0;
 	exec->num_cdma = 0;
 
-	exec->num_slots = 16;
 	exec->polling_mode = true;
 	exec->cq_interrupt = false;
 	exec->configured = false;
@@ -1791,9 +2056,19 @@ exec_reset(struct exec_core *exec, const xuid_t *xclbin_id)
 	exec->flush = false;
 	exec->ops = &penguin_ops;
 
-	bitmap_zero(exec->slot_status, MAX_SLOTS);
-	set_bit(0, exec->slot_status); // reserve for control command
-	exec->ctrl_busy = false;
+	for (idx = 0; idx < MAX_CUS; ++idx) {
+		INIT_LIST_HEAD(&exec->pending_cu_queue[idx]);
+		exec->cu_load_count[idx] = 0;
+		exec->cu_usage[idx] = 0;
+	}
+
+	exec->num_running_cmds = 0;
+	exec->num_pending_cmds = 0;
+
+	INIT_LIST_HEAD(&exec->pending_ctrl_queue);
+	INIT_LIST_HEAD(&exec->pending_kds_queue);
+	INIT_LIST_HEAD(&exec->pending_cmd_queue);
+	INIT_LIST_HEAD(&exec->running_cmd_queue);
 
 	atomic_set(&exec->sr0, 0);
 	atomic_set(&exec->sr1, 0);
@@ -1820,7 +2095,6 @@ out:
 static void
 exec_stop(struct exec_core *exec)
 {
-	int idx;
 	struct xocl_dev *xdev = exec_get_xdev(exec);
 	unsigned int outstanding = 0;
 	unsigned int wait_ms = 100;
@@ -1845,9 +2119,9 @@ exec_stop(struct exec_core *exec)
 	// prior to exec_stop being called (per contract), this implies that
 	// all regular client commands have been flushed.
 	if (outstanding) {
+		exec->flush = true;
 		// Wake up the scheduler to force one iteration flushing stale
 		// commands for this device
-		exec->flush = true;
 		scheduler_intr(exec->scheduler);
 
 		// Wait a second
@@ -1857,14 +2131,6 @@ exec_stop(struct exec_core *exec)
 	outstanding = atomic_read(&xdev->outstanding_execs);
 	if (outstanding)
 		userpf_err(xdev, "unexpected outstanding commands %d after flush", outstanding);
-
-	// stale commands were flushed, reset submitted command state
-	for (idx = 0; idx < MAX_SLOTS; ++idx)
-		exec->submitted_cmds[idx] = NULL;
-
-	bitmap_zero(exec->slot_status, MAX_SLOTS);
-	set_bit(0, exec->slot_status); // reserve for control command
-	exec->ctrl_busy = false;
 }
 
 /*
@@ -1990,6 +2256,8 @@ exec_destroy(struct exec_core *exec)
 	if (exec->cq_base)
 		iounmap(exec->cq_base);
 
+	list_del(&exec->core_list);
+
 	devm_kfree(&exec->pdev->dev, exec);
 }
 
@@ -2001,98 +2269,6 @@ exec_scheduler(struct exec_core *exec)
 	return exec->scheduler;
 }
 
-/*
- * acquire_slot_idx() - First available slot index
- */
-static unsigned int
-exec_acquire_slot_idx(struct exec_core *exec)
-{
-	unsigned int idx = find_first_zero_bit(exec->slot_status, MAX_SLOTS);
-
-	SCHED_DEBUGF("%s exec(%d) returns %d\n", __func__, exec->uid, idx < exec->num_slots ? idx : no_index);
-	if (idx < exec->num_slots) {
-		set_bit(idx, exec->slot_status);
-		return idx;
-	}
-	return no_index;
-}
-
-
-/**
- * acquire_slot() - Acquire a slot index for a command
- *
- * This function makes a special case for control commands which
- * must always dispatch to slot 0, otherwise normal acquisition
- */
-static int
-exec_acquire_slot(struct exec_core *exec, struct xocl_cmd *xcmd)
-{
-	// slot 0 is reserved for ctrl commands
-	if (cmd_type(xcmd) == ERT_CTRL) {
-		SCHED_DEBUGF("%s ctrl cmd(%lu)\n", __func__, xcmd->uid);
-		if (exec->ctrl_busy) {
-			userpf_info(exec_get_xdev(exec),
-				    "cmd(%lu) opcode(%d) ctrl slot is busy\n",
-				    xcmd->uid, cmd_opcode(xcmd));
-			return -1;
-		}
-		exec->ctrl_busy = true;
-		return (xcmd->slot_idx = 0);
-	}
-
-	return (xcmd->slot_idx = exec_acquire_slot_idx(exec));
-}
-
-/*
- * release_slot_idx() - Release specified slot idx
- */
-static void
-exec_release_slot_idx(struct exec_core *exec, unsigned int slot_idx)
-{
-	clear_bit(slot_idx, exec->slot_status);
-}
-
-/**
- * release_slot() - Release a slot index for a command
- *
- * Special case for control commands that execute in slot 0.  This
- * slot cannot be marked free ever.
- */
-static void
-exec_release_slot(struct exec_core *exec, struct xocl_cmd *xcmd)
-{
-	if (xcmd->slot_idx == no_index)
-		return; // already released
-
-	SCHED_DEBUGF("-> %s(%d) xcmd(%lu) slotidx(%d)\n",
-		     __func__, exec->uid, xcmd->uid, xcmd->slot_idx);
-	if (cmd_type(xcmd) == ERT_CTRL) {
-		SCHED_DEBUG("+ ctrl cmd\n");
-		exec->ctrl_busy = false;
-	} else {
-		exec_release_slot_idx(exec, xcmd->slot_idx);
-	}
-	xcmd->slot_idx = no_index;
-	SCHED_DEBUGF("<- %s\n", __func__);
-}
-
-/*
- * submit_cmd() - Submit command for execution on this core
- *
- * Return: true on success, false if command could not be submitted
- */
-static bool
-exec_submit_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
-{
-	unsigned int slotidx = exec_acquire_slot(exec, xcmd);
-
-	if (slotidx == no_index)
-		return false;
-	SCHED_DEBUGF("%s cmd(%lu) slotidx(%d)\n", __func__, xcmd->uid, slotidx);
-	exec->submitted_cmds[slotidx] = xcmd;
-	cmd_set_int_state(xcmd, ERT_CMD_STATE_SUBMITTED);
-	return true;
-}
 
 static void
 exec_update_custatus(struct exec_core *exec)
@@ -2115,7 +2291,7 @@ exec_update_custatus(struct exec_core *exec)
 		exec->cu_status[cuidx] = 0;
 }
 
-/*
+/**
  * finish_cmd() - Special post processing of commands after execution
  */
 static int
@@ -2180,17 +2356,18 @@ exec_notify_host(struct exec_core *exec)
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
-/*
+/**
  * exec_cmd_mark_complete() - Move a command to complete state
  *
  * Commands are marked complete in two ways
- *  1. Through polling of CUs or polling of MB status register
+ *  1. Through polling (of CUs or of MB status register)
  *  2. Through interrupts from MB
  *
  * @xcmd: Command to mark complete
  *
  * The external command state is changed to complete and the host
- * is notified that some command has completed.
+ * is notified that some command has completed.  The command is 
+ * removed from the running queue and freed for reuse.
  */
 static void
 exec_mark_cmd_state(struct exec_core *exec, struct xocl_cmd *xcmd, enum ert_cmd_state state)
@@ -2200,12 +2377,16 @@ exec_mark_cmd_state(struct exec_core *exec, struct xocl_cmd *xcmd, enum ert_cmd_
 	if (cmd_type(xcmd) == ERT_CTRL)
 		exec_finish_cmd(exec, xcmd);
 
+	if (xcmd->cu_idx != no_index)
+		--exec->cu_load_count[xcmd->cu_idx];
+
 	cmd_set_state(xcmd, state);
 
 	if (exec->polling_mode)
 		scheduler_decr_poll(exec->scheduler);
 
-	exec_release_slot(exec, xcmd);
+	if (exec->ert)
+		ert_release_slot(exec->ert, xcmd);
 
 	// This notification is problematic because it occurs before internal
 	// bookkeeping (outstanding cmds) is updated. Client could trigger exit
@@ -2223,18 +2404,18 @@ exec_mark_cmd_state(struct exec_core *exec, struct xocl_cmd *xcmd, enum ert_cmd_
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
-inline static void
+static inline void
 exec_mark_cmd_complete(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
 	exec_mark_cmd_state(exec, xcmd,
 			    xcmd->aborted ? ERT_CMD_STATE_ABORT : ERT_CMD_STATE_COMPLETED);
 }
 
-inline static void
-exec_mark_cmd_abort(struct exec_core *exec, struct xocl_cmd *xcmd)
+static inline void
+exec_mark_cmd_error(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
 	exec_mark_cmd_state(exec, xcmd,
-			    ERT_CMD_STATE_ABORT);
+			    xcmd->aborted ? ERT_CMD_STATE_ABORT : ERT_CMD_STATE_ERROR);
 }
 
 /**
@@ -2253,17 +2434,17 @@ exec_process_cmd_mask(struct exec_core *exec, u32 mask, unsigned int mask_idx)
 {
 	int bit_idx = 0, cmd_idx = 0;
 
-	// assert(mask)
 	SCHED_DEBUGF("-> %s(0x%x,%d)\n", __func__, mask, mask_idx);
 
 	for (bit_idx = 0, cmd_idx = mask_idx<<5; bit_idx < 32; mask >>= 1, ++bit_idx, ++cmd_idx) {
 		struct xocl_cmd *xcmd = (mask & 0x1)
-			? exec->submitted_cmds[cmd_idx]
+			? ert_get_cmd(exec->ert, cmd_idx)
 			: NULL;
 
 		if (xcmd)
 			exec_mark_cmd_complete(exec, xcmd);
 	}
+
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
@@ -2286,7 +2467,7 @@ exec_process_cu_mask(struct exec_core *exec, u32 mask, unsigned int mask_idx)
 {
 	int bit_idx = 0, cu_idx = 0;
 
-	// assert(mask > 0x1); // 0x1 is ctrl commands not cus
+	// assert(mask_idx > 0 || mask > 0x1); // 0x1 is ctrl commands not cus
 	SCHED_DEBUGF("-> %s(0x%x,%d)\n", __func__, mask, mask_idx);
 	for (bit_idx = 0, cu_idx = mask_idx<<5; bit_idx < 32; mask >>= 1, ++bit_idx, ++cu_idx) {
 		struct xocl_cu *xcu;
@@ -2308,49 +2489,57 @@ exec_process_cu_mask(struct exec_core *exec, u32 mask, unsigned int mask_idx)
 }
 
 /**
- * penguin_start_cmd() - Start a command in penguin mode
+ * exec_penguin_start_cu_cmd() - Callback in penguin and dataflow mode
  *
- * @exec: device
  * @xcmd: command to start
  *
- * scheduler_ops penguin and ert poll callback function
+ * scheduler_ops penguin and ert poll callback function for CU type commands
  *
  * Used in penguin and ert poll mode where KDS schedules and starts
  * compute units.
  */
 static bool
-exec_penguin_start_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+exec_penguin_start_cu_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
-	unsigned int cuidx;
-	u32 opcode = cmd_opcode(xcmd);
+	struct xocl_cu *xcu = NULL;
 
-	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d)\n", __func__, xcmd->uid, opcode);
+	SCHED_DEBUGF("-> %s cmd(%lu)\n", __func__, xcmd->uid);
 
-	if (opcode == ERT_START_COPYBO && exec_execute_copybo_cmd(exec, xcmd)) {
-		cmd_set_state(xcmd, ERT_CMD_STATE_ERROR);
-		return false;
-	}
-
-	if (cmd_type(xcmd) != ERT_CU) {
-		SCHED_DEBUGF("<- %s not a CU style command -> true\n", __func__);
+	// CU was selected when command was submitted
+	xcu = exec->cus[xcmd->cu_idx];
+	if (cu_ready(xcu) && cu_start(xcu, xcmd)) {
+		cmd_set_int_state(xcmd, ERT_CMD_STATE_RUNNING);
+		list_move_tail(&xcmd->cq_list, &exec->running_cmd_queue);
+		++exec->num_running_cmds;
+		++exec->cu_usage[xcmd->cu_idx];
+		SCHED_DEBUGF("<- %s -> true\n", __func__);
 		return true;
 	}
-
-	// Find a ready CU
-	for (cuidx = 0; cuidx < exec->num_cus; ++cuidx) {
-		struct xocl_cu *xcu = exec->cus[cuidx];
-
-		if (cmd_has_cu(xcmd, cuidx) && cu_ready(xcu) && cu_start(xcu, xcmd)) {
-			exec->submitted_cmds[xcmd->slot_idx] = NULL;
-			++exec->cu_usage[cuidx];
-			exec_release_slot(exec, xcmd);
-			xcmd->cu_idx = cuidx;
-			SCHED_DEBUGF("<- %s -> true\n", __func__);
-			return true;
-		}
-	}
+	
 	SCHED_DEBUGF("<- %s -> false\n", __func__);
 	return false;
+}
+
+/**
+ * exec_penguin_start_ctrl_cmd() - Callback in penguin mode for ctrl commands
+ * 
+ * In penguin mode ctrl commands run synchronously, so mark them complete when
+ * done, e.g. there is nothihng to poll for completion as there is nothing
+ * left running
+ */
+static bool
+exec_penguin_start_ctrl_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+
+	// Nothting to do for currently supported ctrl commands
+	// Just mark the command as complete and free it.
+	exec_mark_cmd_complete(exec, xcmd);
+	cmd_free(xcmd);
+
+	SCHED_DEBUGF("<- %s returns true\n", __func__);
+
+	return true;
 }
 
 /**
@@ -2371,9 +2560,7 @@ exec_penguin_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d) type(%d) slot_idx=%d\n",
 		     __func__, xcmd->uid, cmd_opcode(xcmd), cmdtype, xcmd->slot_idx);
 
-	if (cmdtype == ERT_KDS_LOCAL || cmdtype == ERT_CTRL)
-		exec_mark_cmd_complete(exec, xcmd);
-	else if (cmdtype == ERT_CU) {
+	if (cmdtype == ERT_CU) {
 		struct xocl_cu *xcu = exec->cus[xcmd->cu_idx];
 
 		 if (cu_first_done(xcu) == xcmd) {
@@ -2398,25 +2585,48 @@ exec_penguin_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 static bool
 exec_ert_start_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
-	if (cmd_type(xcmd) == ERT_KDS_LOCAL)
-		return exec_penguin_start_cmd(exec, xcmd);
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu) opcode(%d)\n", __func__,
+		     exec->uid, xcmd->uid, cmd_opcode(xcmd));
+	
+	if (ert_start_cmd(exec->ert, xcmd)) {
+		cmd_set_int_state(xcmd, ERT_CMD_STATE_RUNNING);
+		list_move_tail(&xcmd->cq_list, &exec->running_cmd_queue);
+		++exec->num_running_cmds;
+		SCHED_DEBUGF("<- %s returns true\n", __func__);
+		return true;
+	}
 
-	return ert_start_cmd(exec->ert, xcmd);
+	// start failed
+	SCHED_DEBUGF("<- %s returns false\n", __func__);
+	return false;
 }
 
 /**
- * ert_start_ctrl() - Start a control command in ERT mode
+ * exec_ert_start_ctrl_cmd() - Callback in ERT mode for ctrl commands
  *
  * In ERT poll mode cu stats are managed by kds itself, nothing
  * to retrieve from ERT.
  */
 static bool
-exec_ert_start_ctrl(struct exec_core *exec, struct xocl_cmd *xcmd)
+exec_ert_start_ctrl_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
-	if (cmd_opcode(xcmd) == ERT_CU_STAT && exec_is_ert_poll(exec))
-		return exec_penguin_start_cmd(exec, xcmd);
+	SCHED_DEBUGF("-> %s exec(%d) xcmd(%lu)\n", __func__, exec->uid, xcmd->uid);
 
-	return ert_start_cmd(exec->ert, xcmd);
+	// For CU_STAT in ert polling mode (dataflow assisted polling) there
+	// is nothing to do, mark complete immediately
+	if (cmd_opcode(xcmd) == ERT_CU_STAT && exec_is_ert_poll(exec)) {
+		exec_mark_cmd_complete(exec, xcmd);
+		return true;
+	}
+
+	// Pass all other control commands to ERT
+	if (exec_ert_start_cmd(exec, xcmd)) {
+		SCHED_DEBUGF("<- %s returns true\n", __func__);
+		return true;
+	}
+		
+	SCHED_DEBUGF("<- %s returns false\n", __func__);
+	return false;
 }
 
 /**
@@ -2469,12 +2679,6 @@ exec_ert_query_mailbox(struct exec_core *exec, struct xocl_cmd *xcmd)
 
 	SCHED_DEBUGF("-> %s cmd(%lu)\n", __func__, xcmd->uid);
 
-	if (cmdtype == ERT_KDS_LOCAL) {
-		exec_mark_cmd_complete(exec, xcmd);
-		SCHED_DEBUGF("<- %s local command\n", __func__);
-		return;
-	}
-
 	while (!(xocl_mailbox_versal_get(xcmd->xdev, &slot)))
 		slots[cnt++] = slot;
 
@@ -2521,12 +2725,6 @@ exec_ert_query_csr(struct exec_core *exec, struct xocl_cmd *xcmd, unsigned int m
 
 	SCHED_DEBUGF("-> %s cmd(%lu), mask_idx(%d)\n", __func__, xcmd->uid, mask_idx);
 
-	if (cmdtype == ERT_KDS_LOCAL) {
-		exec_mark_cmd_complete(exec, xcmd);
-		SCHED_DEBUGF("<- %s local command\n", __func__);
-		return;
-	}
-
 	if (exec->polling_mode
 	    || (mask_idx == 0 && atomic_xchg(&exec->sr0, 0))
 	    || (mask_idx == 1 && atomic_xchg(&exec->sr1, 0))
@@ -2557,13 +2755,11 @@ exec_ert_query_csr(struct exec_core *exec, struct xocl_cmd *xcmd, unsigned int m
 
 
 /**
- * ert_query_cu() - Check command completion based on ERT CQ completion register
+ * exec_ert_query_cu() - Callback for ERT poll mode
  *
- * @exec: device
  * @xcmd: command to check
- * @maskidx:
  *
- * scheduler_ops ERT poll mode callback function
+ * ERT assisted polling in dataflow mode
  *
  * NOTE: in ERT poll mode the CQ slot indices are offset by 1 for cu indices,
  * this is done so as to reserve slot 0 for control commands.
@@ -2582,18 +2778,16 @@ static void
 exec_ert_query_cu(struct exec_core *exec, struct xocl_cmd *xcmd)
 {
 	SCHED_DEBUGF("-> %s cmd(%lu), cu_idx(%d)\n", __func__, xcmd->uid, xcmd->cu_idx);
-	exec_ert_query_csr(exec, xcmd, slot_mask_idx(xcmd->cu_idx+1)); // note offset
+	exec_ert_query_csr(exec, xcmd, mask_idx32(xcmd->cu_idx+1)); // note offset
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
 /**
- * ert_query_cu() - Check command completion based on ERT CQ completion register
+ * exec_ert_query_cmd() - Callback for cmd completion when ERT mode
  *
- * @exec: device
  * @xcmd: command to check
- * @maskidx:
  *
- * scheduler_ops ERT mode callback function
+ * ERT CU scheduling mode
  *
  * In ERT mode, the command completion register corresponds to ERT commands,
  * which KDS wrote to the ERT command queue when a command was started.
@@ -2619,58 +2813,9 @@ exec_ert_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	if (XOCL_DSA_IS_VERSAL(xdev)) {
 		exec_ert_query_mailbox(exec, xcmd);
 	} else
-		exec_ert_query_csr(exec, xcmd, slot_mask_idx(xcmd->slot_idx));
+		exec_ert_query_csr(exec, xcmd, mask_idx32(xcmd->slot_idx));
 
 	SCHED_DEBUGF("<- %s\n", __func__);
-}
-
-/**
- * ert_query_ctrl() - Check command completion for control command
- *
- * In ERT poll mode cu stats are managed by kds itself, nothing
- * to retrieve from ERT.
- */
-static void
-exec_ert_query_ctrl(struct exec_core *exec, struct xocl_cmd *xcmd)
-{
-	SCHED_DEBUGF("-> %s cmd(%lu), slot_idx(%d)\n", __func__, xcmd->uid, xcmd->slot_idx);
-	if (cmd_opcode(xcmd) == ERT_CU_STAT && exec_is_ert_poll(exec))
-		exec_penguin_query_cmd(exec, xcmd);
-	else
-		exec_ert_query_cmd(exec, xcmd);
-	SCHED_DEBUGF("<- %s\n", __func__);
-}
-
-/**
- * start_cmd() - Start execution of a command
- *
- * Return: true if succesfully started, false otherwise
- *
- * Function dispatches based on penguin vs ert mode
- */
-static bool
-exec_start_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
-{
-	u32 cmdtype = cmd_type(xcmd);
-
-	// assert cmd had been submitted
-	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d)\n", __func__, xcmd->uid, cmd_opcode(xcmd));
-
-	// ctrl commands may need special attention
-	if (cmdtype == ERT_CTRL && exec->ops->start_ctrl(exec, xcmd)) {
-		cmd_set_int_state(xcmd, ERT_CMD_STATE_RUNNING);
-		SCHED_DEBUGF("<- %s returns true for cmd type(%d)\n", __func__, cmdtype);
-		return true;
-	}
-
-	if (cmdtype != ERT_CTRL && exec->ops->start_cmd(exec, xcmd)) {
-		cmd_set_int_state(xcmd, ERT_CMD_STATE_RUNNING);
-		SCHED_DEBUGF("<- %s returns true for cmd type(%d)\n", __func__, cmdtype);
-		return true;
-	}
-
-	SCHED_DEBUGF("<- %s returns false\n", __func__);
-	return false;
 }
 
 /**
@@ -2695,36 +2840,387 @@ exec_query_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
+static void
+exec_abort_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	// book keeping before notification.  client could potentially exit
+	// immediately after notification otherwise leaving outstanding cmds
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, exec->uid, xcmd->uid);
+	cmd_free(xcmd);
+	exec_notify_host(exec);
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
 /**
- * ert_ops: operations for ERT scheduling
+ * start_cmd() - Start execution of a command
+ *
+ * Return: true if succesfully started, false otherwise
+ *
+ * Function dispatches based on penguin vs ert mode
+ */
+static inline bool
+exec_start_cu_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu) opcode(%d)\n", __func__,
+		     exec->uid, xcmd->uid, cmd_opcode(xcmd));
+
+	if (exec->ops->start_cmd(exec, xcmd)) {
+		SCHED_DEBUGF("<- %s returns true\n", __func__);
+		return true;
+	}
+
+	SCHED_DEBUGF("<- %s returns false\n", __func__);
+	return false;
+}
+
+/**
+ * start_start_ctrl_cmd() - Start execution of a command
+ *
+ * Return: true if succesfully started, false otherwise
+ *
+ * Function dispatches based on penguin vs ert mode
+ */
+static bool
+exec_start_ctrl_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu) opcode(%d)\n", __func__,
+		     exec->uid, xcmd->uid, cmd_opcode(xcmd));
+
+	// On configure, must configure KDS at a minimum
+	if (cmd_opcode(xcmd) == ERT_CONFIGURE && exec_cfg_cmd(exec, xcmd)) {
+		exec_mark_cmd_error(exec, xcmd);
+		--exec->num_pending_cmds;
+		cmd_free(xcmd);
+		SCHED_DEBUGF("<- %s returns false for exec_cfg_cmd\n", __func__);
+		return false;
+	}
+
+	// Let scheduler mode determine additional processing
+        if (exec->ops->start_ctrl(exec, xcmd)) {
+		SCHED_DEBUGF("<- %s returns true\n", __func__);
+		return true;
+	}
+	
+	SCHED_DEBUGF("<- %s returns false\n", __func__);
+	return false;
+}
+
+
+
+/**
+ * exec_start_kds_cmd() - KDS commands run synchronously
+ */
+static inline bool
+exec_start_kds_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	if (cmd_opcode(xcmd) == ERT_START_COPYBO && exec_execute_copybo_cmd(exec, xcmd)) {
+		exec_mark_cmd_error(exec, xcmd);
+		--exec->num_pending_cmds;
+		cmd_free(xcmd);
+		return false;
+	}
+
+	exec_mark_cmd_complete(exec, xcmd);
+	cmd_free(xcmd);
+	return true;
+}
+
+static int
+exec_start_cu_range(struct exec_core *exec, unsigned int start, unsigned int end)
+{
+	unsigned int started = 0;
+	unsigned int cuidx;
+
+	for (cuidx = start; cuidx < end; ++cuidx) {
+		struct list_head *cu_queue = &exec->pending_cu_queue[cuidx];
+		struct xocl_cmd *xcmd = list_first_entry_or_null(cu_queue, struct xocl_cmd, cq_list);
+		if (!xcmd || !exec_start_cu_cmd(exec, xcmd))
+			continue;
+		++started;
+	}
+
+	return started;
+}
+
+static int
+exec_start_cus(struct exec_core *exec)
+{
+	static unsigned int first_cu = -1;
+	unsigned int start_cu = (first_cu < exec->num_cus) ? ++first_cu : (first_cu = 0);
+
+	unsigned int total = 0;
+	unsigned int prev = 0;
+
+	//SCHED_PRINTF("-> %s first_cu(%d) start_cu(%d)\n", __func__, first_cu, start_cu);
+
+	do {
+		prev = total;
+		total += exec_start_cu_range(exec, start_cu, exec->num_cus);
+		total += exec_start_cu_range(exec, 0, start_cu);
+	} while (total > prev);
+
+	return total;
+}
+
+static int
+exec_start_ctrl(struct exec_core *exec)
+{
+	struct list_head *ctrl_queue = &exec->pending_ctrl_queue;
+	struct xocl_cmd *xcmd = list_first_entry_or_null(ctrl_queue, struct xocl_cmd, cq_list);
+	return (xcmd && exec_start_ctrl_cmd(exec, xcmd)) ? 1 : 0;
+}
+
+static int
+exec_start_kds(struct exec_core *exec)
+{
+	struct list_head *local_queue = &exec->pending_kds_queue;
+	struct xocl_cmd *xcmd = list_first_entry_or_null(local_queue, struct xocl_cmd, cq_list);
+	return (xcmd && exec_start_kds_cmd(exec, xcmd)) ? 1 : 0;
+}
+
+static bool
+exec_submit_cu_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	// Append cmd to end of shortest CU list
+	unsigned int min_load_count = -1;
+	unsigned int cuidx = -1;
+	unsigned int bit;
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, exec->uid, xcmd->uid);
+	for (bit = cmd_first_cu(xcmd); bit < exec->num_cus; bit = cmd_next_cu(xcmd, bit)) {
+		unsigned int load_count = exec->cu_load_count[bit];
+		if (load_count >= min_load_count)
+			continue;
+		cuidx = bit;
+		if ((min_load_count = load_count) == 0)
+			break;
+	}
+
+	list_move_tail(&xcmd->cq_list, &exec->pending_cu_queue[cuidx]);
+	cmd_set_cu(xcmd, cuidx);
+	++exec->cu_load_count[cuidx];
+	SCHED_DEBUGF("<- %s cuidx(%d) load(%d)\n", __func__, cuidx, exec->cu_load_count[cuidx]);
+	return true;
+}
+
+static inline bool
+exec_submit_ctrl_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, exec->uid, xcmd->uid);
+	list_move_tail(&xcmd->cq_list, &exec->pending_ctrl_queue);
+	SCHED_DEBUGF("<- %s\n", __func__);
+	return true;
+}
+
+static inline bool
+exec_submit_kds_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, exec->uid, xcmd->uid);
+	list_move_tail(&xcmd->cq_list, &exec->pending_kds_queue);
+	SCHED_DEBUGF("<- %s\n", __func__);
+	return true;
+}
+
+static bool
+exec_submit_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	bool ret = false;
+
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, exec->uid, xcmd->uid);
+	if (cmd_update_state(xcmd) == ERT_CMD_STATE_ABORT)
+		exec_abort_cmd(exec, xcmd);
+	else if (cmd_type(xcmd) == ERT_CU)
+		ret = exec_submit_cu_cmd(exec, xcmd);
+	else if (cmd_type(xcmd) == ERT_KDS_LOCAL)
+		ret = exec_submit_kds_cmd(exec, xcmd);
+	else if (cmd_type(xcmd) == ERT_CTRL)
+		ret = exec_submit_ctrl_cmd(exec, xcmd);
+	else
+		userpf_err(xcmd->xdev,"Unknown command type %d\n",cmd_type(xcmd));
+
+	if (ret && exec->polling_mode)
+		scheduler_incr_poll(exec->scheduler);
+
+	if (ret)
+		++exec->num_pending_cmds;
+	
+	SCHED_DEBUGF("<- %s ret(%d)\n", __func__, ret);
+	return ret;
+}
+
+static void
+exec_error_to_free(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	// book keeping before notification.  client could potentially exit
+	// immediately after notification otherwise leaving outstanding cmds
+	cmd_free(xcmd);
+	exec_notify_host(exec);
+}
+
+static inline void
+exec_new_to_queued(struct exec_core *exec, struct xocl_cmd *xcmd)
+{
+	SCHED_DEBUGF("-> %s exec(%d) cmd(%lu)\n", __func__, exec->uid, xcmd->uid);
+	if (cmd_update_state(xcmd) == ERT_CMD_STATE_ABORT) {
+		exec_abort_cmd(exec, xcmd);
+		SCHED_DEBUGF("<- %s aborting\n", __func__);
+		return;
+	}
+
+	// add to core command queue
+	list_move_tail(&xcmd->cq_list, &exec->pending_cmd_queue);
+	cmd_set_int_state(xcmd, ERT_CMD_STATE_QUEUED);
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_queued_to_submitted(struct exec_core *exec)
+{
+	struct list_head *pos, *next;
+
+	list_for_each_safe(pos, next, &exec->pending_cmd_queue) {
+		struct xocl_cmd *xcmd = list_entry(pos, struct xocl_cmd, cq_list);
+		exec_submit_cmd(exec, xcmd);
+	}
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_submitted_to_running(struct exec_core *exec)
+{
+	unsigned int started = 0;
+	
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	started += exec_start_ctrl(exec);
+	started += exec_start_cus(exec);
+	started += exec_start_kds(exec);
+	exec->num_pending_cmds -= started;
+	SCHED_DEBUGF("<- %s started(%d)\n", __func__, started);
+}
+
+static void
+exec_running_to_complete(struct exec_core *exec)
+{
+	struct list_head *pos, *next;
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	list_for_each_safe(pos, next, &exec->running_cmd_queue) {
+		struct xocl_cmd *xcmd = list_entry(pos, struct xocl_cmd, cq_list);
+		cmd_update_state(xcmd);
+
+		// guard against exec_query_cmd completing multiple commands
+		// in one call when ert is enabled.
+		if (xcmd->state == ERT_CMD_STATE_RUNNING)
+			exec_query_cmd(exec, xcmd);
+
+		if (xcmd->state >= ERT_CMD_STATE_COMPLETED) {
+			--exec->num_running_cmds;
+			cmd_free(xcmd);
+		}
+	}
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_reset_cmd_queue(struct exec_core *exec, struct list_head *cmd_queue)
+{
+	struct list_head *pos, *next;
+	list_for_each_safe(pos, next, cmd_queue) {
+		struct xocl_cmd *xcmd = list_entry(pos, struct xocl_cmd, cq_list);
+		cmd_set_state(xcmd, ERT_CMD_STATE_ABORT);
+		exec_error_to_free(exec, xcmd);
+	}
+}
+
+static void
+exec_reset_pending_cu_cmds(struct exec_core *exec)
+{
+	unsigned int cuidx;
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	for (cuidx = 0; cuidx < exec->num_cus; ++cuidx) {
+		SCHED_DEBUGF("+ %s cu_queue(%d)\n", __func__, cuidx);
+		exec_reset_cmd_queue(exec, &exec->pending_cu_queue[cuidx]);
+	}
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_reset_pending_ctrl_cmds(struct exec_core *exec)
+{
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	exec_reset_cmd_queue(exec, &exec->pending_ctrl_queue);
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_reset_pending_kds_cmds(struct exec_core *exec)
+{
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	exec_reset_cmd_queue(exec, &exec->pending_kds_queue);
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_reset_cmds(struct exec_core *exec)
+{
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	exec_reset_pending_cu_cmds(exec);
+	exec_reset_pending_ctrl_cmds(exec);
+	exec_reset_pending_kds_cmds(exec);
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+static void
+exec_service_cmds(struct exec_core *exec)
+{
+	SCHED_DEBUGF("-> %s exec(%d)\n", __func__, exec->uid);
+	// Baby sit running commands
+	exec_running_to_complete(exec);
+
+	// Submit new commands for execution
+	exec_queued_to_submitted(exec);
+
+	// Start commands
+	exec_submitted_to_running(exec);
+	SCHED_DEBUGF("<- %s\n", __func__);
+}
+
+
+/**
+ * struct ert_ops: ERT scheduling
+ *
+ * Callback functions used in regular (no dataflow) ERT mode
  */
 static struct exec_ops ert_ops = {
 	.start_cmd = exec_ert_start_cmd,
-	.start_ctrl = exec_ert_start_cmd,
+	.start_ctrl = exec_ert_start_ctrl_cmd,
 	.query_cmd = exec_ert_query_cmd,
 	.query_ctrl = exec_ert_query_cmd,
 	.process_mask = exec_process_cmd_mask,
 };
 
 /**
- * penguin_ops: operations for kernel mode scheduling
+ * struct penguin_ops: kernel mode scheduling (penguin)
+ *
+ * Callback functions used in regular (no dataflow) penguin mode
  */
 static struct exec_ops penguin_ops = {
-	.start_cmd = exec_penguin_start_cmd,
-	.start_ctrl = exec_penguin_start_cmd,
+	.start_cmd = exec_penguin_start_cu_cmd,
+	.start_ctrl = exec_penguin_start_ctrl_cmd,
 	.query_cmd = exec_penguin_query_cmd,
 	.query_ctrl = exec_penguin_query_cmd,
 	.process_mask = NULL,
 };
 
 /**
- * dataflow_ops: operations for kernel mode scheduling
+ * struct dataflow_ops: kernel mode scheduling with ert polling
+ *
+ * Callback functions used in dataflow mode only when ERT is 
+ * assisting in polling for CU completion.
  */
 static struct exec_ops ert_poll_ops = {
-	.start_cmd = exec_penguin_start_cmd,
-	.start_ctrl = exec_ert_start_ctrl,
+	.start_cmd = exec_penguin_start_cu_cmd,
+	.start_ctrl = exec_ert_start_ctrl_cmd,
 	.query_cmd = exec_ert_query_cu,
-	.query_ctrl = exec_ert_query_ctrl,
+	.query_ctrl = exec_ert_query_cmd,
 	.process_mask = exec_process_cu_mask,
 };
 
@@ -2771,7 +3267,8 @@ static atomic_t num_pending = ATOMIC_INIT(0);
 static void
 pending_cmds_reset(void)
 {
-	/* clear stale command objects if any */
+	SCHED_DEBUGF("-> %s\n", __func__);
+	// clear stale command objects if any
 	while (!list_empty(&pending_cmds)) {
 		struct xocl_cmd *xcmd = list_first_entry(&pending_cmds, struct xocl_cmd, cq_list);
 
@@ -2779,6 +3276,7 @@ pending_cmds_reset(void)
 		cmd_free(xcmd);
 	}
 	atomic_set(&num_pending, 0);
+	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
 /**
@@ -2790,7 +3288,7 @@ pending_cmds_reset(void)
  * @error: set to 1 to indicate scheduler error
  * @stop: set to 1 to indicate scheduler should stop
  * @reset: set to 1 to reset the scheduler
- * @command_queue: list of command objects managed by scheduler
+ * @cores: list of execution cores (devices)
  * @intc: boolean flag set when there is a pending interrupt for command completion
  * @poll: number of running commands in polling mode
  */
@@ -2799,11 +3297,11 @@ struct xocl_scheduler {
 	unsigned int		   use_count;
 
 	wait_queue_head_t	   wait_queue;
-	unsigned int		   error;
-	unsigned int		   stop;
-	unsigned int		   reset;
+	bool  		           error;
+	bool 		           stop;
+	bool		           reset;
 
-	struct list_head	   command_queue;
+	struct list_head           cores; // executuion cores
 
 	unsigned int		   intc; /* pending intr shared with isr, word aligned atomic */
 	unsigned int		   poll; /* number of cmds to poll */
@@ -2814,23 +3312,27 @@ static struct xocl_scheduler scheduler0;
 static void
 scheduler_reset(struct xocl_scheduler *xs)
 {
-	xs->error = 0;
-	xs->stop = 0;
-	xs->poll = 0;
+	xs->error = false;
+	xs->stop = false;
 	xs->reset = false;
+	xs->poll = 0;
 	xs->intc = 0;
 }
 
+#if 0
 static void
-scheduler_cq_reset(struct xocl_scheduler *xs)
+scheduler_core_reset(struct xocl_scheduler *xs)
 {
-	while (!list_empty(&xs->command_queue)) {
-		struct xocl_cmd *xcmd = list_first_entry(&xs->command_queue, struct xocl_cmd, cq_list);
+	struct list_head *pos, *next;
 
-		DRM_INFO("deleting stale scheduler cmd\n");
-		cmd_free(xcmd);
+	SCHED_DEBUGF("-> %s\n", __func__);
+	list_for_each_safe(pos, next, &xs->cores) {
+		struct exec_core *exec = list_entry(pos, struct exec_core, core_list);
+		exec_reset_cmds(exec);
 	}
+	SCHED_DEBUGF("<- %s\n", __func__);
 }
+#endif
 
 static void
 scheduler_wake_up(struct xocl_scheduler *xs)
@@ -2851,36 +3353,38 @@ scheduler_decr_poll(struct xocl_scheduler *xs)
 	--xs->poll;
 }
 
+static inline void
+scheduler_incr_poll(struct xocl_scheduler *xs)
+{
+	++xs->poll;
+}
 
 /**
- * scheduler_queue_cmds() - Queue any pending commands
- *
- * The scheduler copies pending commands to its internal command queue where
- * is is now in queued state.
+ * scheduler_queue_cmds() - Dispatch pending commands to cores
  */
 static void
 scheduler_queue_cmds(struct xocl_scheduler *xs)
 {
-	struct xocl_cmd *xcmd;
 	struct list_head *pos, *next;
 
 	SCHED_DEBUGF("-> %s\n", __func__);
 	mutex_lock(&pending_cmds_mutex);
 	list_for_each_safe(pos, next, &pending_cmds) {
-		xcmd = list_entry(pos, struct xocl_cmd, cq_list);
+		struct xocl_cmd *xcmd = list_entry(pos, struct xocl_cmd, cq_list);
 		if (xcmd->xs != xs)
 			continue;
-		SCHED_DEBUGF("+ queueing cmd(%lu)\n", xcmd->uid);
-		list_del(&xcmd->cq_list);
-		list_add_tail(&xcmd->cq_list, &xs->command_queue);
+		SCHED_DEBUGF("+ dispatching cmd(%lu)\n", xcmd->uid);
 
-		/* chain active dependencies if any to this command object */
+		// chain active dependencies if any to this command object
 		if (cmd_wait_count(xcmd) && cmd_chain_dependencies(xcmd))
 			cmd_set_state(xcmd, ERT_CMD_STATE_ERROR);
 		else
 			cmd_set_int_state(xcmd, ERT_CMD_STATE_QUEUED);
 
-		/* this command is now active and can chain other commands */
+		// move command to proper execution core
+		exec_new_to_queued(xcmd->exec, xcmd);
+
+		// this command is now active and can chain other commands
 		cmd_mark_active(xcmd);
 		atomic_dec(&num_pending);
 	}
@@ -2888,129 +3392,19 @@ scheduler_queue_cmds(struct xocl_scheduler *xs)
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
 
-/**
- * queued_to_running() - Move a command from queued to running state if possible
- *
- * @xcmd: Command to start
- *
- * Upon success, the command is not necessarily running. In ert mode the
- * command will have been submitted to the embedded scheduler, whereas in
- * penguin mode the command has been started on a CU.
- *
- * Return: %true if command was submitted to device, %false otherwise
- */
-static bool
-scheduler_queued_to_submitted(struct xocl_scheduler *xs, struct xocl_cmd *xcmd)
-{
-	struct exec_core *exec = cmd_exec(xcmd);
-	bool retval = false;
-
-	if (cmd_wait_count(xcmd))
-		return false;
-
-	SCHED_DEBUGF("-> %s cmd(%lu) opcode(%d)\n", __func__, xcmd->uid, cmd_opcode(xcmd));
-
-	// configure prior to using the core
-	if (cmd_opcode(xcmd) == ERT_CONFIGURE && exec_cfg_cmd(exec, xcmd)) {
-		cmd_set_state(xcmd, ERT_CMD_STATE_ERROR);
-		return false;
-	}
-
-	// submit the command
-	if (exec_submit_cmd(exec, xcmd)) {
-		if (exec->polling_mode)
-			++xs->poll;
-		retval = true;
-	}
-
-	SCHED_DEBUGF("<- queued_to_submitted returns %d\n", retval);
-
-	return retval;
-}
-
-static bool
-scheduler_submitted_to_running(struct xocl_scheduler *xs, struct xocl_cmd *xcmd)
-{
-	return exec_start_cmd(cmd_exec(xcmd), xcmd);
-}
 
 /**
- * running_to_complete() - Check status of running commands
- *
- * @xcmd: Command is in running state
- *
- * When ERT is enabled this function may mark more than just argument
- * command as complete based on content of command completion register.
- * Without ERT, only argument command is checked for completion.
+ * scheduler_service_cores() - Iterate all devices
  */
 static void
-scheduler_running_to_complete(struct xocl_scheduler *xs, struct xocl_cmd *xcmd)
-{
-	exec_query_cmd(cmd_exec(xcmd), xcmd);
-}
-
-/**
- * complete_to_free() - Recycle a complete command objects
- *
- * @xcmd: Command is in complete state
- */
-static void
-scheduler_complete_to_free(struct xocl_scheduler *xs, struct xocl_cmd *xcmd)
-{
-	SCHED_DEBUGF("-> %s cmd(%lu)\n", __func__, xcmd->uid);
-	cmd_free(xcmd);
-	SCHED_DEBUGF("<- %s\n", __func__);
-}
-
-static void
-scheduler_error_to_free(struct xocl_scheduler *xs, struct xocl_cmd *xcmd)
-{
-	struct exec_core *exec = cmd_exec(xcmd);
-	SCHED_DEBUGF("-> %s cmd(%lu)\n", __func__, xcmd->uid);
-
-	// book keeping before notification.  client could potentially exit
-	// immediately after notification otherwise leaving outstanding cmds
-	scheduler_complete_to_free(xs, xcmd);
-	exec_notify_host(exec);
-
-	SCHED_DEBUGF("<- %s\n", __func__);
-}
-
-static void
-scheduler_abort_to_free(struct xocl_scheduler *xs, struct xocl_cmd *xcmd)
-{
-	SCHED_DEBUGF("-> %s cmd(%lu)\n", __func__, xcmd->uid);
-	scheduler_error_to_free(xs, xcmd);
-	SCHED_DEBUGF("<- %s\n", __func__);
-}
-
-/**
- * scheduler_iterator_cmds() - Iterate all commands in scheduler command queue
- */
-static void
-scheduler_iterate_cmds(struct xocl_scheduler *xs)
+scheduler_service_cores(struct xocl_scheduler *xs)
 {
 	struct list_head *pos, *next;
 
 	SCHED_DEBUGF("-> %s\n", __func__);
-	list_for_each_safe(pos, next, &xs->command_queue) {
-		struct xocl_cmd *xcmd = list_entry(pos, struct xocl_cmd, cq_list);
-
-		cmd_update_state(xcmd);
-		SCHED_DEBUGF("+ processing cmd(%lu)\n", xcmd->uid);
-
-		if (xcmd->state == ERT_CMD_STATE_QUEUED)
-			scheduler_queued_to_submitted(xs, xcmd);
-		if (xcmd->state == ERT_CMD_STATE_SUBMITTED)
-			scheduler_submitted_to_running(xs, xcmd);
-		if (xcmd->state == ERT_CMD_STATE_RUNNING)
-			scheduler_running_to_complete(xs, xcmd);
-		if (xcmd->state == ERT_CMD_STATE_COMPLETED)
-			scheduler_complete_to_free(xs, xcmd);
-		if (xcmd->state == ERT_CMD_STATE_ERROR)
-			scheduler_error_to_free(xs, xcmd);
-		if (xcmd->state == ERT_CMD_STATE_ABORT)
-			scheduler_abort_to_free(xs, xcmd);
+	list_for_each_safe(pos, next, &xs->cores) {
+		struct exec_core *exec = list_entry(pos, struct exec_core, core_list);
+		exec_service_cmds(exec);
 	}
 	SCHED_DEBUGF("<- %s\n", __func__);
 }
@@ -3029,7 +3423,7 @@ static int
 scheduler_wait_condition(struct xocl_scheduler *xs)
 {
 	if (kthread_should_stop()) {
-		xs->stop = 1;
+		xs->stop = true;
 		SCHED_DEBUG("scheduler wakes kthread_should_stop\n");
 		return 0;
 	}
@@ -3087,11 +3481,11 @@ scheduler_loop(struct xocl_scheduler *xs)
 		scheduler_reset(xs);
 	}
 
-	/* queue new pending commands */
+	// queue new pending commands
 	scheduler_queue_cmds(xs);
 
-	/* iterate all commands */
-	scheduler_iterate_cmds(xs);
+	// iterate all execution cores
+	scheduler_service_cores(xs);
 
 	// loop 8 times before explicitly yielding
 	if (++loop_cnt == 8) {
@@ -3111,7 +3505,7 @@ scheduler(void *data)
 	while (!xs->stop)
 		scheduler_loop(xs);
 	DRM_INFO("%s:%d %s thread exits with value %d\n", __FILE__, __LINE__, __func__, xs->error);
-	return xs->error;
+	return xs->error ? 1 : 0;
 }
 
 
@@ -3217,7 +3611,7 @@ init_scheduler_thread(struct xocl_scheduler *xs)
 		return 0;
 
 	init_waitqueue_head(&xs->wait_queue);
-	INIT_LIST_HEAD(&xs->command_queue);
+	INIT_LIST_HEAD(&xs->cores);
 	scheduler_reset(xs);
 
 	xs->scheduler_thread = kthread_run(scheduler, (void *)xs, "xocl-scheduler-thread0");
@@ -3246,11 +3640,10 @@ fini_scheduler_thread(struct xocl_scheduler *xs)
 
 	retval = kthread_stop(xs->scheduler_thread);
 
-	/* clear stale command objects if any */
+	// clear stale command objects if any
 	pending_cmds_reset();
-	scheduler_cq_reset(xs);
 
-	/* reclaim memory for allocate command objects */
+	// reclaim memory for allocate command objects
 	cmd_list_delete();
 
 	return retval;
@@ -3269,8 +3662,8 @@ static void client_release_implicit_cus(struct exec_core *exec,
 	SCHED_DEBUGF("<- %s", __func__);
 }
 
-static void client_reserve_implicit_cus(struct exec_core *exec,
-	struct client_ctx *client)
+static void
+client_reserve_implicit_cus(struct exec_core *exec, struct client_ctx *client)
 {
 	int i;
 
@@ -3392,7 +3785,8 @@ static int rem_ip_ref(struct xocl_dev *xdev, struct exec_core *exec, u32 ip_idx)
 	return 0;
 }
 
-static void destroy_client(struct platform_device *pdev, void **priv)
+static void 
+destroy_client(struct platform_device *pdev, void **priv)
 {
 	struct client_ctx *client = (struct client_ctx *)(*priv);
 	struct exec_core *exec = platform_get_drvdata(pdev);
@@ -3408,6 +3802,7 @@ static void destroy_client(struct platform_device *pdev, void **priv)
 
 	// force scheduler to abort execs for this client
 	client->abort = true;
+
 	// wait for outstanding execs to finish
 	outstanding = atomic_read(&client->outstanding_execs);
 	while (outstanding) {
@@ -4065,10 +4460,30 @@ kds_custat_show(struct device *dev, struct device_attribute *attr, char *buf)
 			      xert ? ert_cu_usage(xert, idx) : exec_cu_usage(exec, idx),
 			      exec_cu_status(exec, idx));
 
-	if (!xert)
+	sz += sprintf(buf+sz, "KDS number of pending commands: %d\n", exec_num_pending(exec));
+
+	if (!xert) {
+		sz += sprintf(buf+sz, "KDS number of running commands: %d\n", exec_num_running(exec));
 		goto out;
+	}
+
+	sz += sprintf(buf+sz, "CQ usage : {");
+	for (idx = 0; idx < xert->num_slots; ++idx)
+		sz += sprintf(buf+sz, "%s%d", (idx > 0 ? "," : ""), ert_cq_slot_usage(xert, idx));
+	sz += sprintf(buf+sz, "}\n");
+
+	sz += sprintf(buf+sz, "CQ mirror state : {");
+	for (idx = 0; idx < xert->num_slots; ++idx) {
+		if (idx == 0) { // ctrl slot should be ignored
+			sz += sprintf(buf+sz, "-");
+			continue;
+		}
+		sz += sprintf(buf+sz, ",%d", ert_cq_slot_busy(xert, idx));
+	}
+	sz += sprintf(buf+sz, "}\n");
 
 	sz += sprintf(buf+sz, "ERT scheduler version : 0x%x\n", ert_version(xert));
+	sz += sprintf(buf+sz, "ERT number of submitted commands: %d\n", exec_num_running(exec));
 	sz += sprintf(buf+sz, "ERT scheduler CU state : {");
 	for (idx = 0; idx < exec->num_cus; ++idx) {
 		if (idx > 0)
@@ -4077,12 +4492,12 @@ kds_custat_show(struct device *dev, struct device_attribute *attr, char *buf)
 	}
 		
 	sz += sprintf(buf+sz, "}\nERT scheduler CQ state : {");
-	for (idx = 0; idx < exec->num_slots; ++idx) {
+	for (idx = 0; idx < xert->num_slots; ++idx) {
 		if (idx == 0) { // ctrl slot should be ignored
 			sz += sprintf(buf+sz, "-");
 			continue;
 		}
-		sz += sprintf(buf+sz, ",%d", ert_cq_status(xert, idx));
+		sz += sprintf(buf+sz, ",%d", ert_cq_slot_status(xert, idx));
 	}
 	sz += sprintf(buf+sz, "}\n");
 
@@ -4136,6 +4551,7 @@ static int mb_scheduler_probe(struct platform_device *pdev)
 		goto err;
 
 	init_scheduler_thread(&scheduler0);
+	list_add_tail(&exec->core_list, &scheduler0.cores);
 	platform_set_drvdata(pdev, exec);
 
 	DRM_INFO("command scheduler started\n");
@@ -4152,14 +4568,14 @@ err:
  */
 static int mb_scheduler_remove(struct platform_device *pdev)
 {
-	struct xocl_dev *xdev;
-	int i;
+	struct xocl_dev *xdev = xocl_get_xdev(pdev);
 	struct exec_core *exec = platform_get_drvdata(pdev);
+	unsigned int i;
 
 	SCHED_DEBUGF("-> %s\n", __func__);
+	exec_reset_cmds(exec);
 	fini_scheduler_thread(exec_scheduler(exec));
 
-	xdev = xocl_get_xdev(pdev);
 	for (i = 0; i < exec->intr_num; i++) {
 		xocl_user_interrupt_config(xdev, i + exec->intr_base, false);
 		xocl_user_interrupt_reg(xdev, i + exec->intr_base,

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -32,6 +32,7 @@
 #endif
 #include <stdlib.h>
 #include <limits>
+#include <bitset>
 
 // version is a git hash passed in from build script
 // default for builds that bypass build script
@@ -156,117 +157,16 @@ const addr_type CQ_STATUS_REGISTER_ADDR[4] =
  ,ERT_CQ_STATUS_REGISTER_ADDR3
 };
 
+
 /**
  * Simple bitset type supporting 128 bits
  *
  * ERT supports a max of 128 CUs and 128 slots, this bitset class
  * is added to simplify managing 4 32bit bitmasks.
+ *
+ * Using std::bitset non-throwing functions only
  */
-struct bitset_type
-{
-  bitmask_type bitmasks[4] = {0};
-  size_type masks;
-
-  /**
-   * Default construct with 4 masks.
-   *
-   * Use reset once number of positions are known
-   */
-  bitset_type()
-    : masks(4)
-  {}
-
-  /**
-   * Reset a bitset such that it supports specified number of bits
-   *
-   * @maxpos: The index of the highest order bit
-   */
-  void
-  reset(size_type maxpos)
-  {
-    clear();
-    masks = (maxpos >> 5)+1;
-  }
-
-  void
-  set(size_type pos)
-  {
-    auto mask = pos >> 5;
-    bitmasks[mask] |= 1<<(pos - (mask << 5));
-  }
-
-  void
-  clear(size_type pos)
-  {
-    auto mask = pos >> 5;
-    bitmasks[mask] &= ~(1<<(pos - (mask << 5)));
-  }
-
-  void
-  clear_and_set(size_type pos)
-  {
-    clear();
-    set(pos);
-  }
-
-  void
-  set_mask(size_type mask_idx, bitmask_type bm)
-  {
-    bitmasks[mask_idx] = bm;
-  }
-
-  bitmask_type
-  get_mask(size_type mask_idx) const
-  {
-    return bitmasks[mask_idx];
-  }
-
-  void
-  toggle(size_type pos)
-  {
-    auto mask = pos >> 5;
-    bitmasks[mask] ^= 1<<(pos - (mask << 5));
-  }
-
-  bool
-  test(size_type pos) const
-  {
-    auto mask = pos >> 5;
-    return bitmasks[mask] & (1<<(pos - (mask << 5)));
-  }
-
-  size_type
-  count() const
-  {
-    size_type count = 0;
-    for (auto itr=bitmasks; itr!=bitmasks+masks; ++itr)
-      for (bitmask_type bm = *itr; bm; count += (bm & 0x1), bm>>=1);
-    return count;
-  }
-
-  // Return: true if no bits are set
-  bool
-  none() const
-  {
-    for (auto itr=bitmasks; itr!=bitmasks+masks; ++itr)
-      if (*itr)
-        return false;
-    return true;
-  }
-
-  void
-  clear()
-  {
-    for (auto itr=bitmasks; itr!=bitmasks+masks; ++itr)
-      (*itr)=0;
-  }
-
-  const char*
-  string()
-  {
-    return "? not implemented";
-  }
-};
+using bitset_type = std::bitset<128>;
 
 // If this assert fails, then ert_parameters is out of sync with
 // the board support package header files.
@@ -532,7 +432,7 @@ setup()
     auto& slot = command_slots[i];
     slot.slot_addr = ERT_CQ_BASE_ADDR + (slot_size * i);
     slot.header_value = 0x4; // free
-    slot.cus.reset(num_cus);
+    slot.cus.reset();
     slot.regmap_addr = 0;
     slot.regmap_size = 0;
 
@@ -544,7 +444,7 @@ setup()
   for (size_type i=0; i<4; ++i)
     ERT_UNUSED volatile auto val = read_reg(STATUS_REGISTER_ADDR[i]);
 
-  cu_status.reset(num_cus);
+  cu_status.reset();
 
   // Initialize cu_slot_usage
   for (size_type i=0; i<num_cus; ++i) {
@@ -598,13 +498,13 @@ setup()
   bool enable_master_interrupts = false;
 
   // Enable cu interupts (cu -> cu_isr -> mb interrupts)
-  cu_interrupt_mask.reset(num_cus);
+  cu_interrupt_mask.reset();
   bitmask_type intc_ier_mask = 0;
   if (cu_interrupt_enabled) {
     for (size_type cu=0; cu<num_cus; ++cu) {
       write_reg(cu_idx_to_addr(cu) + 0x04,1);
       write_reg(cu_idx_to_addr(cu) + 0x08,1);
-      cu_interrupt_mask.set(cu);
+      cu_interrupt_mask[cu] = 1;
     }
     write_reg(ERT_CU_ISR_HANDLER_ENABLE_ADDR,1); // enable CU ISR handler
     intc_ier_mask |= 0x2;                        // acccept cu interrupts on bit 1 of the ier of intc
@@ -621,7 +521,7 @@ setup()
     write_reg(ERT_INTC_IER_ADDR,read_reg(ERT_INTC_IER_ADDR) & ~0x6);  // disable interrupts on bit 1 & 2 (0x2|0x4)
     write_reg(ERT_CU_ISR_HANDLER_ENABLE_ADDR,0); // disable CU ISR handler
   }
-  CTRL_DEBUGF("cu interrupt mask : %s\n",cu_interrupt_mask.string());
+  CTRL_DEBUGF("cu interrupt mask : %s\n", "cannot convert"); // to_string throws
 
   // Enable interrupts from host to MB when new commands are ready
   // When enabled, MB will read CQ_STATUS_REGISTER(s) to determine new
@@ -676,10 +576,11 @@ notify_host(size_type cmd_idx)
   auto mask_idx = cmd_idx>>5;
   auto mask = idx_to_mask(cmd_idx,mask_idx);
   write_reg(STATUS_REGISTER_ADDR[mask_idx],mask);
-#endif
+#else
   // this relies on 1<<n == 1<<(n%32), safe?  no, not safe, to be fixed
   // once 128 slots work so I can check the actual behavior
   write_reg(STATUS_REGISTER_ADDR[cmd_idx>>5],1<<cmd_idx);
+#endif
 }
 
 /**
@@ -782,7 +683,7 @@ start_cu(size_type slot_idx)
 
   // Check all CUs against argument cus mask and against cu_status
   for (size_type cu_idx=0; cu_idx<num_cus; ++cu_idx) {
-    if (cus.test(cu_idx) && !cu_status.test(cu_idx)) {
+    if (cus[cu_idx] && !cu_status[cu_idx]) {
       ERT_DEBUGF("start_cu cu(%d) for slot_idx(%d)\n",cu_idx,slot_idx);
       ERT_ASSERT(read_reg(cu_idx_to_addr(cu_idx))==AP_IDLE,"cu not ready");
 
@@ -797,7 +698,7 @@ start_cu(size_type slot_idx)
         // manually configure and start cu
         configure_cu(cu_idx_to_addr(cu_idx),slot.regmap_addr,slot.regmap_size);
 
-      cu_status.toggle(cu_idx);     // toggle cu status bit, it is now busy
+      cu_status[cu_idx] = !cu_status[cu_idx];     // toggle cu status bit, it is now busy
       set_cu_info(cu_idx,slot_idx); // record which slot cu associated with
       return cu_idx;
     }
@@ -821,9 +722,9 @@ static void
 check_command(size_type slot_idx, size_type cu_idx)
 {
   auto& slot = command_slots[slot_idx];
-  ERT_ASSERT(slot.cus.test(cu_idx),"cu is not used by slot");
+  ERT_ASSERT(slot.cus[cu_idx],"cu is not used by slot");
   // toggle cu mask in slot
-  slot.cus.toggle(cu_idx);
+  slot.cus[cu_idx] = !slot.cus[cu_idx];
   if (slot.cus.none()) {
     notify_host(slot_idx);
     slot.header_value = (slot.header_value & ~0xF) | 0x4; // free
@@ -854,18 +755,18 @@ static bool
 check_cu(size_type cu_idx, bool wait=false)
 {
   // cu interrupt enabled, then managed by interrupt handler
-  if (cu_interrupt_mask.test(cu_idx))
+  if (cu_interrupt_mask[cu_idx])
     return false;
 
   // no interrupt for cu, check cu status register manually
-  ERT_ASSERT(cu_status.test(cu_idx),"cu wasn't started");
+  ERT_ASSERT(cu_status[cu_idx],"cu wasn't started");
   auto cu_addr = cu_idx_to_addr(cu_idx);
 
   // check if done
   do {
     if (read_reg(cu_addr) & AP_DONE) {
       // toogle cu status bit, it is now free
-      cu_status.toggle(cu_idx);
+      cu_status[cu_idx] = !cu_status[cu_idx];
       cu_slot_usage[cu_idx] = no_index; // reset slot index
       return true;
     }
@@ -988,6 +889,7 @@ cu_stat(size_type slot_idx)
 
   // write stats to command package after header
   size_type pkt_idx = 1; // after header
+  size_type max_idx = slot_size >> 2; 
 
   // custat version, update when changing layout of packet
   write_reg(slot.slot_addr + (pkt_idx++ << 2),0x51a10000);
@@ -1002,19 +904,19 @@ cu_stat(size_type slot_idx)
   write_reg(slot.slot_addr + (pkt_idx++ << 2),num_cus);
   
   // individual cu execution stat
-  for (size_type i=0; i<num_cus; ++i) {
+  for (size_type i=0; pkt_idx<max_idx && i<num_cus; ++i) {
     CTRL_DEBUGF("cu_usage[0x%x]=%d\n",cu_idx_to_addr(i),cu_usage[i]);
     write_reg(slot.slot_addr + (pkt_idx++ << 2),cu_usage[i]);
   }
 
   // individual cu status
-  for (size_type i=0; i<num_cus; ++i) {
-    CTRL_DEBUGF("cu_staus[0x%x]=%d\n",cu_idx_to_addr(i),cu_status.test(i));
-    write_reg(slot.slot_addr + (pkt_idx++ << 2),cu_status.test(i));
+  for (size_type i=0; pkt_idx<max_idx && i<num_cus; ++i) {
+    CTRL_DEBUGF("cu_staus[0x%x]=%d\n",cu_idx_to_addr(i),cu_status[i]);
+    write_reg(slot.slot_addr + (pkt_idx++ << 2),cu_status[i]);
   }
 
   // command slot status
-  for (size_type i=0; i<num_slots; ++i) {
+  for (size_type i=0; pkt_idx<max_idx && i<num_slots; ++i) {
     auto& s = command_slots[i];
     CTRL_DEBUGF("slot_status[%d]=%d\n",i,s.header_value & 0XF);
     write_reg(slot.slot_addr + (pkt_idx++ << 2),s.header_value & 0XF);
@@ -1049,10 +951,10 @@ abort_mb(size_type slot_idx)
   if ((s.header_value & 0xF)!=0x3)
     return true; // bail if not running
   for (size_type cu_idx=0; cu_idx<num_cus; ++cu_idx) {
-    if (s.cus.test(cu_idx)) {
+    if (s.cus[cu_idx]) {
       check_command(sidx,cu_idx);
       cu_slot_usage[cu_idx] = no_index;
-      cu_status.toggle(cu_idx);
+      cu_status[cu_idx] = !cu_status[cu_idx];
     }
   }
 
@@ -1129,8 +1031,11 @@ new_to_queued(size_type slot_idx)
 
   // new command, gather slot info
   addr_type addr = cu_section_addr(slot.slot_addr);
+  slot.cus.reset();
   for (size_type idx=0; idx<num_cu_masks; ++idx) {
-    slot.cus.set_mask(idx,read_reg(addr + (idx<<2)));
+    bitset_type reg(read_reg(addr + (idx<<2)));
+    slot.cus <<= 32;
+    slot.cus |= reg;
   }
   slot.regmap_addr = regmap_section_addr(slot.header_value,slot.slot_addr);
   slot.regmap_size = regmap_size(slot.header_value);
@@ -1162,7 +1067,7 @@ queued_to_running(size_type slot_idx)
   // queued command, start if any of cus is ready
   auto cu_idx = start_cu(slot_idx);
   if (cu_idx != no_index) {
-    slot.cus.clear_and_set(cu_idx); // bitmask now reflects running cu
+    slot.cus.reset(); slot.cus[cu_idx] = 1; // bitmask now reflects running cu
     slot.header_value |= 0x1;       // running (0x2->0x3)
     ERT_DEBUGF("slot(%d) [queued -> running]\n",slot_idx);
 
@@ -1187,10 +1092,10 @@ running_to_free(size_type slot_idx)
   auto& slot = command_slots[slot_idx];
   ERT_ASSERT((slot.header_value & 0xF)==0x3,"slot is not running\n");
   // running command, check its cu status
+  bitset_type cus = slot.cus;
   for (size_type w=0,offset=0; w<num_cu_masks; ++w,offset+=32) {
-    auto cu_mask = slot.cus.get_mask(w);
-    for (size_type cu_idx=offset; cu_mask; cu_mask >>=1, ++cu_idx) {
-      if ((cu_mask & 0x1) && check_cu(cu_idx,false)) {
+    for (size_type cu_idx=offset; cus.any(); cus >>= 1, ++cu_idx) {
+      if (cus[0] && check_cu(cu_idx,false)) {
         notify_host(slot_idx);
         slot.header_value = (slot.header_value & ~0xF) | 0x4; // free
         ERT_DEBUGF("slot(%d) [running -> free]\n",slot_idx);
@@ -1243,23 +1148,23 @@ scheduler_loop()
         size_type cuidx = slot_idx-1;  // compensate for reserved slot (0)
 
         // Check if host has started or continued this CU
-        if (!cu_status.test(cuidx)) {
+        if (!cu_status[cuidx]) {
           auto cqvalue = read_reg(slot.slot_addr);
           if (cqvalue & (AP_START|AP_CONTINUE)) {
             write_reg(slot.slot_addr,0x0); // clear
             ERT_DEBUGF("enable cu(%d) cqvalue(0x%x)\n",cuidx,cqvalue);
-            cu_status.toggle(cuidx); // enable polling of this CU
+            cu_status[cuidx] = !cu_status[cuidx]; // enable polling of this CU
           }
         }
 
-        if (!cu_status.test(cuidx))
+        if (!cu_status[cuidx])
           continue; // CU is not used
 
         auto cuvalue = read_reg(cu_idx_to_addr(cuidx));
         if (!(cuvalue & AP_DONE))
           continue;
 
-        cu_status.toggle(cuidx); // disable polling until host re-enables
+        cu_status[cuidx] = !cu_status[cuidx]; // disable polling until host re-enables
         ERT_DEBUGF("polled cu(%d) cuvalue(0x%x)\n",cuidx,cuvalue);
 
         // wake up host
@@ -1306,15 +1211,19 @@ cu_interrupt_handler()
 
   if (intc_mask & 0x2) { // cuisr interrupt
     for (size_type w=0,offset=0; w<num_cu_masks; ++w,offset+=32) {
-      auto cu_mask = read_reg(CU_STATUS_REGISTER_ADDR[w]) & cu_interrupt_mask.get_mask(w);
+      auto cu_mask = read_reg(CU_STATUS_REGISTER_ADDR[w]);
       for (size_type cu_idx=offset; cu_mask; cu_mask >>= 1, ++cu_idx) {
-        if (cu_mask & 0x1) {
+        if ((cu_mask & 0x1) && cu_interrupt_mask[cu_idx]) {
           ERT_DEBUGF("cu(%d) is interrupting\n",cu_idx);
-          ERT_ASSERT(cu_status.test(cu_idx),"cu wasn't started");
+          //ERT_ASSERT(cu_status[cu_idx],"cu wasn't started");
+          if (!cu_status[cu_idx]) {
+            ERT_PRINTF("cu(%d) wasn't started\n",cu_idx);
+            continue;
+          }
           // check if command is done
           check_command(cu_slot_usage[cu_idx],cu_idx);
           cu_slot_usage[cu_idx] = no_index; // reset slot index
-          cu_status.toggle(cu_idx); // toggle status of completed cus
+          cu_status[cu_idx] = !cu_status[cu_idx]; // toggle status of completed cus
         }
       }
     }
@@ -1334,10 +1243,10 @@ cu_interrupt_handler()
   if (intc_mask & 0x4) { // cdma interrupt
     auto cu_idx = num_cus-1; // cdma is last cu
     ERT_DEBUGF("cdma cu(%d) interrupts\n",cu_idx);
-    ERT_ASSERT(cu_status.test(cu_idx),"cdma cu wasn't started");
+    ERT_ASSERT(cu_status[cu_idx],"cdma cu wasn't started");
     check_command(cu_slot_usage[cu_idx],cu_idx);
     cu_slot_usage[cu_idx] = no_index; // reset slot index;
-    cu_status.toggle(cu_idx); // toggle status of completed cus
+    cu_status[cu_idx] = !cu_status[cu_idx]; // toggle status of completed cus
 
     // Reset cdma (1) read status to clear it, (2) reset isr at base + 0xC
     ERT_UNUSED volatile auto val = read_reg(cu_idx_to_addr(cu_idx));

--- a/src/runtime_src/ert/scheduler/scheduler.mk
+++ b/src/runtime_src/ert/scheduler/scheduler.mk
@@ -14,8 +14,10 @@ ifndef SCHED_VERSION
  export SCHED_VERSION := 0x$(shell git rev-list -1 HEAD $(SRC) | cut -c1-8)
 endif
 
-MYCFLAGS := -I$(BSP)/include -I$(RTS) $(DEFINES) -DERT_VERSION=$(SCHED_VERSION) -DERT_SVERSION=\"$(SCHED_VERSION)\"
-MYLFLAGS :=  -Wl,-T,$(BLDDIR)/lscript.ld
+MYCFLAGS := -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti
+MYCFLAGS += -I$(BSP)/include -I$(RTS) $(DEFINES) -DERT_VERSION=$(SCHED_VERSION) -DERT_SVERSION=\"$(SCHED_VERSION)\"
+MYLFLAGS := -Wl,--defsym=_HEAP_SIZE=0x0 -Wl,--gc-sections
+MYLFLAGS += -Wl,-T,$(BLDDIR)/lscript.ld
 
 $(OBJ): $(SRC) $(BSP).extracted $(RTS)/core/include/ert.h
 	$(CPP) $(MYCFLAGS) -c -o $@ $<


### PR DESCRIPTION
Change KDS to managing execution cores (devices) rather than commands.
Each core manages commands but only iterates running commands to check
for completion.

Also use std::bitset in ERT firmware, but avoid throwing std::bitset
member functions (thanks to Stefan).