### PR TITLE
CR-1047439 multi_process example fails for zcu102_base_dfx hardware board run

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2930,8 +2930,10 @@ sched_init_exec(struct drm_device *drm)
 	SCHED_DEBUG("-> %s\n", __func__);
 
 	exec_core = devm_kzalloc(drm->dev, sizeof(*exec_core), GFP_KERNEL);
-	if (!exec_core)
+	if (!exec_core) {
+		DRM_ERROR("Alloc exec_core failed: no memory\n");
 		return -ENOMEM;
+	}
 
 	zdev->exec = exec_core;
 	spin_lock_init(&exec_core->ctx_list_lock);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -919,8 +919,10 @@ int
 zocl_xclbin_init(struct drm_zocl_dev *zdev)
 {
 	zdev->zdev_xclbin = vmalloc(sizeof(struct zocl_xclbin));
-	if (!zdev->zdev_xclbin)
+	if (!zdev->zdev_xclbin) {
+		DRM_ERROR("Alloc zdev_xclbin failed: no memory\n");
 		return -ENOMEM;
+	}
 
 	zdev->zdev_xclbin->zx_last_bitstream = 0;
 	zdev->zdev_xclbin->zx_refcnt = 0;


### PR DESCRIPTION
multi_process example fails for zcu102_base_dfx hardware board run

somehow, the mutex_init is lost during code migration from other development branches.