### PR TITLE
Including linux/version.h for builds with new kernel

### DIFF
--- a/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.h
+++ b/src/runtime_src/driver/aws/kernel/mgmt/mgmt-core.h
@@ -15,6 +15,7 @@
 #define _AWS_MGT_PF_H_
 
 #include <linux/cdev.h>
+#include <linux/version.h>
 #include <asm/io.h>
 
 #define DRV_NAME "awsmgmt"


### PR DESCRIPTION
This is to fix dkms build issues with new Centos 3.10.0-1062.4.1.el7.x86_64 kernel.

Fixes the following build error:
```
In file included from /var/lib/dkms/xrt-aws/2.2.0/build/driver/aws/kernel/mgmt/mgmt-core.c:25:0:
/var/lib/dkms/xrt-aws/2.2.0/build/driver/aws/kernel/mgmt/mgmt-core.h:28:5: warning: "LINUX_VERSION_CODE" is not defined [-Wundef]
...
/var/lib/dkms/xrt-aws/2.2.0/build/driver/aws/kernel/mgmt/mgmt-core.h:28:27: warning: "KERNEL_VERSION" is not defined [-Wundef]
...
/var/lib/dkms/xrt-aws/2.2.0/build/driver/aws/kernel/mgmt/mgmt-core.h:28:41: error: missing binary operator before token "(
```