### PR TITLE
xmares: Add xma_shm_lock to xma_client_mp_alloc

### DIFF
--- a/src/xma/src/xmaapi/xmares.cpp
+++ b/src/xma/src/xmaapi/xmares.cpp
@@ -1153,6 +1153,10 @@ static int32_t xma_client_mp_alloc(XmaResources shm_cfg,
     uint8_t j;
     int ret;
 
+    xma_logmsg(XMA_DEBUG_LOG, XMA_RES_MOD, "%s()\n", __func__);
+    if (xma_shm_lock(xma_shm))
+        return XMA_ERROR;
+
     for (j = 0;
          kernel_inst->channels[j].client_id &&
          j < MAX_KERNEL_CHANS               &&


### PR DESCRIPTION
xma_shm_lock() is not called in xma_client_mp_alloc. If you read
xma_client_sp_alloc, the correct behaviour needs xma_client_mp_alloc
to be called initially.

CC: Neel Mani <neelmani@xilinx.com>
CC: Jeffrey Mouroux <jmouroux@xilinx.com>

Reported-by: Neel Mani <neelmani@xilinx.com>
Suggested-by: Jeffrey Mouroux <jmouroux@xilinx.com>
Signed-off-by: Rohit Athavale <rohit.athavale@xilinx.com>