### PR TITLE
Capture host CPU, memory and model information in xbutil query

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -219,7 +219,11 @@ install()
     if [ $FLAVOR == "rhel" ] || [ $FLAVOR == "centos" ] || [ $FLAVOR == "amzn" ]; then
         echo "Installing RHEL/CentOS packages..."
         ${SUDO} yum install -y "${RH_LIST[@]}"
-        ${SUDO} yum install -y devtoolset-6
+	if [ $ARCH == "ppc64le" ]; then
+            ${SUDO} yum install -y devtoolset-7
+	else
+            ${SUDO} yum install -y devtoolset-6
+	fi
     fi
 }
 


### PR DESCRIPTION
On RHEL 7.6-Alt use devtoolset-7 instead of -6