### PR TITLE
Skip b/w test for ppc+rhel

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -118,7 +118,7 @@ FLAVOR=`echo $FLAVOR | tr -d '"'`
 
 #ppc+rhel
 # skip pyopencl installation
-if [ `uname -m` = "ppc64le" ] && [ $FLAVOR = "ubuntu" ]; then
+if [ `uname -m` = "ppc64le" ] && [ $FLAVOR = "rhel" ]; then
     exit 0
 fi
 #ppc+ubuntu

--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -116,6 +116,11 @@ version=$(python -m pip list 2>&1 | grep -Po '(?<=pyopencl )(.+)' | grep -Po '[0
 FLAVOR=`grep '^ID=' /etc/os-release | awk -F= '{print $2}'`
 FLAVOR=`echo $FLAVOR | tr -d '"'`
 
+#ppc+rhel
+# skip pyopencl installation
+if [ `uname -m` = "ppc64le" ] && [ $FLAVOR = "ubuntu" ]; then
+    exit 0
+fi
 #ppc+ubuntu
 #need to manually install python3 and pyhont3-pip
 if [ `uname -m` = "ppc64le" ] && [ $FLAVOR = "ubuntu" ]; then

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1305,12 +1305,6 @@ int xcldev::device::bandwidthKernelXbtest(void)
 {
     std::string output;
 
-    if (sensor_tree::get<std::string>("system.linux", "N/A").find("Red Hat") != std::string::npos) {
-        std::cout << "Testcase not supported on Red Hat. Skipping validation"
-                  << std::endl;
-        return -EOPNOTSUPP;
-    }
-
     int ret = runXbTestCase(std::string("memory.json"), output);
 
     if (ret != 0) {

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1207,6 +1207,12 @@ int xcldev::device::bandwidthKernelTest(void)
 {
     std::string output;
 
+    if (sensor_tree::get<std::string>("system.linux", "N/A").find("Red Hat") != std::string::npos) {
+        std::cout << "Testcase not supported on Red Hat. Skipping validation"
+                  << std::endl;
+        return -EOPNOTSUPP;
+    }
+
     int ret = runTestCase(std::string("23_bandwidth.py"),
         std::string("bandwidth.xclbin"), output);
 
@@ -1298,6 +1304,12 @@ int xcldev::device::auxConnectionTest(void)
 int xcldev::device::bandwidthKernelXbtest(void)
 {
     std::string output;
+
+    if (sensor_tree::get<std::string>("system.linux", "N/A").find("Red Hat") != std::string::npos) {
+        std::cout << "Testcase not supported on Red Hat. Skipping validation"
+                  << std::endl;
+        return -EOPNOTSUPP;
+    }
 
     int ret = runXbTestCase(std::string("memory.json"), output);
 


### PR DESCRIPTION
output on rhel:
```
# xbutil validate -d 0
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_u200_xdma_201830_1
INFO: == Starting AUX power connector check:
INFO: == AUX power connector check PASSED
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: == Starting DMA test:
Buffer Size: 256 MB
Host -> PCIe -> FPGA write bandwidth = 7518.24 MB/s
Host <- PCIe <- FPGA read bandwidth = 13164.8 MB/s
INFO: == DMA test PASSED
INFO: == Starting device memory bandwidth test:
Testcase not supported on Red Hat. Skipping validation
INFO: == device memory bandwidth test SKIPPED
INFO: == Starting PCIE peer-to-peer test:
P2P BAR is not enabled. Skipping validation
INFO: == PCIE peer-to-peer test SKIPPED
INFO: == Starting memory-to-memory DMA test:
Only one bank available. Skipping validation
INFO: == memory-to-memory DMA test PASSED
INFO: Card[0] validated successfully.

INFO: All cards validated successfully.
```