### PR TITLE
xbutil2: Added abstract library query functionality

### DIFF
--- a/src/runtime_src/core/common/core_device.h
+++ b/src/runtime_src/core/common/core_device.h
@@ -39,6 +39,14 @@ namespace device {
   void get_device_rom_info(uint64_t _deviceID, boost::property_tree::ptree & _pt);
   void get_device_xmc_info(uint64_t _deviceID, boost::property_tree::ptree & _pt);
   void get_device_platform_info(uint64_t _deviceID, boost::property_tree::ptree & _pt);
+  void read_device_thermal_pcb(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_thermal_fpga(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_fan_info(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_thermal_cage(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_electrical(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_power(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_firewall(uint64_t _deviceID, boost::property_tree::ptree &_pt);
+  void read_device_pcie_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt);
 }
 }
 

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -222,16 +222,17 @@ enum xclResetKind {
     XCL_USER_RESET
 };
 
+#define XCL_DEVICE_USAGE_COUNT 8
 struct xclDeviceUsage {
-    size_t h2c[8];
-    size_t c2h[8];
-    size_t ddrMemUsed[8];
-    unsigned int ddrBOAllocated[8];
+    size_t h2c[XCL_DEVICE_USAGE_COUNT];
+    size_t c2h[XCL_DEVICE_USAGE_COUNT];
+    size_t ddrMemUsed[XCL_DEVICE_USAGE_COUNT];
+    unsigned int ddrBOAllocated[XCL_DEVICE_USAGE_COUNT];
     unsigned int totalContexts;
     uint64_t xclbinId[4];
     unsigned int dma_channel_cnt;
     unsigned int mm_channel_cnt;
-    uint64_t memSize[8];
+    uint64_t memSize[XCL_DEVICE_USAGE_COUNT];
 };
 
 struct xclBOProperties {

--- a/src/runtime_src/core/pcie/linux/core_device.cpp
+++ b/src/runtime_src/core/pcie/linux/core_device.cpp
@@ -16,6 +16,8 @@
 
 
 #include "common/core_device.h"
+#include "common/utils.h"
+#include "include/xrt.h"
 #include "scan.h"
 #include <string>
 #include <iostream>
@@ -26,7 +28,7 @@ xrt_core::device::get_device_pcie_info(uint64_t _deviceID, boost::property_tree:
 {
   std::string errorMsg;
   std::string valueString;
-  uint64_t valueUInt64;
+  uint64_t valueUInt64 = 0;
 
   // Key: vendor
   pcidev::get_dev(_deviceID)->sysfs_get( "", "vendor", errorMsg, valueString);
@@ -93,7 +95,7 @@ xrt_core::device::get_device_rom_info(uint64_t _deviceID, boost::property_tree::
 {
   std::string errorMsg;
   std::string valueString;
-  uint64_t valueUInt64;
+  uint64_t valueUInt64 = 0;
 
   // Key: vbnv
   pcidev::get_dev(_deviceID)->sysfs_get("rom", "VBNV", errorMsg, valueString);
@@ -148,12 +150,12 @@ xrt_core::device::get_device_platform_info(uint64_t _deviceID, boost::property_t
 {
   std::string errorMsg;
   std::string valueString;
-  bool valueBool;
-  uint64_t valueUInt64;
+  bool valueBool = false;
+  uint64_t valueUInt64 = 0;
 
   // Key: dna
   pcidev::get_dev(_deviceID)->sysfs_get( "dna", "dna", errorMsg, valueString);
-  _pt.put("dns", valueString.c_str());
+  _pt.put("dna", valueString.c_str());
 
   // Key: clocks
   {
@@ -183,3 +185,269 @@ xrt_core::device::get_device_platform_info(uint64_t _deviceID, boost::property_t
   pcidev::get_dev(_deviceID)->sysfs_get<uint64_t>("", "p2p_enable", errorMsg, valueUInt64, 0);
   _pt.put("p2p_enabled", valueUInt64 ? "true" : "false" );
 }
+
+void 
+xrt_core::device::read_device_thermal_pcb(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  uint32_t valueUInt32 = 0;
+
+  // Key: top_front
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_se98_temp0", valueUInt32 );
+  _pt.put("top_front", std::to_string(valueUInt32).c_str());
+
+  // Key: top_rear
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_se98_temp1", valueUInt32 );
+  _pt.put("top_rear", std::to_string(valueUInt32).c_str());
+
+  // Key: top_rear
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_se98_temp2", valueUInt32 );
+  _pt.put("btm_front", std::to_string(valueUInt32).c_str());
+}
+
+void 
+xrt_core::device::read_device_thermal_fpga(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  uint32_t valueUInt32 = 0;
+
+  // Key: temp_C
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_fpga_temp", valueUInt32 );
+  _pt.put("temp_C", std::to_string(valueUInt32).c_str());
+}
+
+void 
+xrt_core::device::read_device_fan_info(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  std::string errorMsg;
+  std::string valueString;
+  uint32_t valueUInt32 = 0;
+
+  // Key: tcrit_temp
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_fan_temp",  valueUInt32 );
+  _pt.put( "tcrit_temp", std::to_string(valueUInt32).c_str());
+
+  // Key: fan_presence
+  pcidev::get_dev(_deviceID)->sysfs_get( "xmc", "fan_presence", errorMsg, valueString );
+  _pt.put( "fan_presence", valueString );
+
+  // Key: fan_speed_rpm
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_fan_rpm",  valueUInt32 );
+  _pt.put( "fan_speed_rpm", std::to_string(valueUInt32).c_str());
+}
+
+void 
+xrt_core::device::read_device_thermal_cage(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  uint32_t valueUInt32 = 0;
+
+  // Key: temp0
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_cage_temp0", valueUInt32);
+  _pt.put( "temp0", std::to_string(valueUInt32).c_str());
+
+  // Key: temp1
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_cage_temp1", valueUInt32);
+  _pt.put( "temp1", std::to_string(valueUInt32).c_str());
+
+  // Key: temp2
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_cage_temp2", valueUInt32);
+  _pt.put( "temp2", std::to_string(valueUInt32).c_str());
+
+  // Key: temp3
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_cage_temp3", valueUInt32);
+  _pt.put( "temp3", std::to_string(valueUInt32).c_str());
+}
+
+
+template <typename T>
+std::string 
+static to_string(const T _value, const int _precision = 6)
+{
+  std::ostringstream sBuffer;
+  sBuffer.precision(_precision);
+  sBuffer << std::fixed << _value;
+  return sBuffer.str();
+}
+
+void 
+xrt_core::device::read_device_electrical(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  uint32_t valueUInt32 = 0;
+
+  // Key: 12v_pex.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_12v_pex_vol",    valueUInt32);
+  _pt.put( "12v_pex.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 12v_pex.current
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_12v_pex_curr",   valueUInt32);
+  _pt.put( "12v_pex.current", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 12v_aux.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_12v_aux_vol",    valueUInt32);
+  _pt.put( "12v_aux.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 12v_aux.current
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_12v_aux_curr",   valueUInt32);
+  _pt.put( "12v_aux.current", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 3v3_pex.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_3v3_pex_vol",    valueUInt32);
+  _pt.put( "3v3_pex.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 3v3_aux.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_3v3_aux_vol",    valueUInt32); 
+  _pt.put( "3v3_aux.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: ddr_vpp_bottom.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_ddr_vpp_btm",    valueUInt32);
+  _pt.put( "ddr_vpp_bottom.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: ddr_vpp_top.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_ddr_vpp_top",    valueUInt32);
+  _pt.put( "ddr_vpp_top.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: sys_5v5.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_sys_5v5",        valueUInt32);
+  _pt.put( "sys_5v5.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 1v2_top.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_1v2_top",        valueUInt32);
+  _pt.put( "1v2_top.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 1v2_btm.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_vcc1v2_btm",     valueUInt32);
+  _pt.put( "1v2_btm.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 1v8.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_1v8",            valueUInt32);
+  _pt.put( "1v8.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 0v85.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_0v85",           valueUInt32);
+  _pt.put( "0v85.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: mgt_0v9.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_mgt0v9avcc",     valueUInt32);
+  _pt.put( "mgt_0v9.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 12v_sw.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_12v_sw",         valueUInt32);
+  _pt.put( "12v_sw.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: mgt_vtt.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_mgtavtt",        valueUInt32);
+  _pt.put( "mgt_vtt.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: vccint.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor( "xmc", "xmc_vccint_vol",     valueUInt32);
+  _pt.put( "vccint.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: vccint.current
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_vccint_curr",     valueUInt32);
+  _pt.put( "vccint.current", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 3v3_pex.current
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_3v3_pex_curr",    valueUInt32);
+  _pt.put( "3v3_pex.current", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: 0v85.current
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_0v85_curr",       valueUInt32);
+  _pt.put( "0v85.current", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: vcc3v3.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_3v3_vcc_vol",     valueUInt32);
+  _pt.put( "vcc3v3.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: hbm_1v2.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_hbm_1v2_vol",     valueUInt32);
+  _pt.put( "hbm_1v2.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: vpp2v5.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_vpp2v5_vol",      valueUInt32);
+  _pt.put( "vpp2v5.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+
+  // Key: vccint_bram.voltage
+  pcidev::get_dev(_deviceID)->sysfs_get_sensor("xmc", "xmc_vccint_bram_vol", valueUInt32);
+  _pt.put( "vccint_bram.voltage", ::to_string((float)valueUInt32 / 1000.0, 3).c_str());
+}
+
+void 
+xrt_core::device::read_device_power(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  // Key: power_watts
+  unsigned long long valueLongLong = 0;
+  std::string errMsg;
+
+  pcidev::get_dev(_deviceID)->sysfs_get<unsigned long long>( "xmc", "xmc_power",  errMsg, valueLongLong, 0);
+
+  float power = -1;
+
+  if (errMsg.empty()) {
+    power = (float) valueLongLong / 1000000;
+  }
+
+  _pt.put( "power_watts", ::to_string(power, 6).c_str());
+}
+
+
+void 
+xrt_core::device::read_device_firewall(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  std::string errorMsg;
+  uint32_t valueUInt32 = 0;
+  unsigned long long valueLongLong = 0;
+
+  // Key: level
+  pcidev::get_dev(_deviceID)->sysfs_get<unsigned int>( "firewall", "detected_level", errorMsg, valueUInt32, 0 );
+  _pt.put( "level", std::to_string(valueUInt32).c_str());
+
+  // Key: status & status_raw
+  {
+    pcidev::get_dev(_deviceID)->sysfs_get<unsigned int>( "firewall", "detected_status", errorMsg, valueUInt32, 0 ); 
+    _pt.put( "status", parseFirewallStatus(valueUInt32) );
+    std::ostringstream buf;
+    buf << std::hex << "0x" << uintptr_t(valueUInt32);
+    _pt.put("status_bits", buf.str().c_str());
+  }
+
+  // Key: time
+  pcidev::get_dev(_deviceID)->sysfs_get<unsigned long long>( "firewall", "detected_time", errorMsg, valueLongLong, 0 ); 
+  _pt.put( "time", std::to_string(valueLongLong).c_str());
+}
+
+void 
+xrt_core::device::read_device_pcie_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+// TODO: Update code to handle error messages 
+{
+  xclDeviceHandle handle = xclOpen(_deviceID, nullptr, XCL_QUIET);
+
+  if (!handle) {
+    // Unable to get a handle
+    return;
+  }
+
+  xclDeviceUsage devstat = { 0 };
+  xclGetUsageInfo(handle, &devstat);
+
+  // Clean up after ourselves
+  xclClose(handle);
+
+  boost::property_tree::ptree ptChannels;
+  for (unsigned index = 0; index < XCL_DEVICE_USAGE_COUNT; ++index) {
+      boost::property_tree::ptree ptDMA;
+      ptDMA.put( "id", std::to_string(index).c_str());
+      ptDMA.put( "h2c", unitConvert(devstat.h2c[index]) );
+      ptDMA.put( "c2h", unitConvert(devstat.c2h[index]) );
+
+      // Create our array of data
+      ptChannels.push_back(std::make_pair("", ptDMA)); 
+  }
+
+  _pt.add_child( "transfer_metrics.channels", ptChannels);
+}
+

--- a/src/runtime_src/core/pcie/linux/core_system.cpp
+++ b/src/runtime_src/core/pcie/linux/core_system.cpp
@@ -30,7 +30,6 @@
 
 #include "scan.h"
 
-
 static std::string driver_version(const std::string & _driver)
 {
   std::string line("unknown");

--- a/src/runtime_src/core/pcie/windows/core_device.cpp
+++ b/src/runtime_src/core/pcie/windows/core_device.cpp
@@ -58,3 +58,68 @@ xrt_core::device::get_device_platform_info(uint64_t _deviceID, boost::property_t
   _deviceID = _deviceID;
   _pt = _pt;
 }
+
+void 
+xrt_core::device::read_device_thermal_pcb(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_thermal_fpga(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_fan_info(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_thermal_cage(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_electrical(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_power(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_firewall(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+
+void 
+xrt_core::device::read_device_pcie_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt)
+{
+  // Dummy assignments to address compiler warning while we wait for the body to be implemented
+  _deviceID = _deviceID;
+  _pt = _pt;
+}
+

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -64,9 +64,13 @@ if(WIN32)
 else()
   target_link_libraries(
     xbutil2 -static 
-    ${Boost_LIBRARIES} 
     xrt_core_static
     xrt_coreutil_static
+    boost_filesystem
+    boost_system
+    boost_program_options 
+    uuid
+    dl
   )
 
   # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -63,8 +63,8 @@ if(WIN32)
 else()
   target_link_libraries(
     xbutil2 
-    xrt_core
-    xrt_coreutil
+    xrt_core_static
+    xrt_coreutil_static
     boost_filesystem
     boost_system
     boost_program_options 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -4,7 +4,6 @@ set(Boost_USE_STATIC_LIBS ON)               # Only find static libraries
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
 set(Boost_USE_STATIC_RUNTIME ON)            # This is how the boost libraries were build
 
-# -----------------------------------------------------------------------------
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 include_directories(${Boost_INCLUDE_DIRS})
 
@@ -63,21 +62,15 @@ if(WIN32)
   endif()
 else()
   target_link_libraries(
-    xbutil2 -static 
-    xrt_core_static
-    xrt_coreutil_static
+    xbutil2 
+    xrt_core
+    xrt_coreutil
     boost_filesystem
     boost_system
     boost_program_options 
     uuid
     dl
   )
-
-  # On Ubuntu 18.04 CMake was appending '-Wl,-Bdynamic' to the command line which 
-  # was causing the executable to reference 'linux-vdso.so.1' which would then 
-  # produce "Command not found" when running the executable.
-  #   Therefore, we direct CMake to end with static, so that it doesn't do that:
-  set_target_properties(xbutil2 PROPERTIES LINK_SEARCH_END_STATIC 1)
 endif()
 
 install (TARGETS xbutil2 RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -75,8 +75,6 @@ int subCmdQuery(const std::vector<std::string> &_options, bool _help)
   XBU::verbose(XBU::format("  Card: %ld", card));
   XBU::verbose(XBU::format("Region: %ld", region));
 
-  // Determine the number of cards and their states
-
   // Report system configuration and XRT information
   XBReport::report_system_config();
   XBReport::report_xrt_info();

--- a/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
@@ -54,25 +54,87 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
     boost::property_tree::ptree ptPlatform;
 
     // Get and add generic information
-//    {
-//      boost::property_tree::ptree ptPlatInfo;
-//      xrt_core::device::get_device_platform_info(device_id, ptPlatInfo);
-//      ptPlatform.add_child("info", ptPlatInfo);
-//    }
-
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::get_device_platform_info(device_id, pt);
+      ptPlatform.add_child("info", pt);
+    }
 
     // Get and add ROM information
     {
-      boost::property_tree::ptree ptROM;
-      xrt_core::device::get_device_rom_info(device_id, ptROM);
-      ptPlatform.add_child("rom", ptROM);
+      boost::property_tree::ptree pt;
+      xrt_core::device::get_device_rom_info(device_id, pt);
+      ptPlatform.add_child("rom", pt);
     }
 
     // Get and add XMC information
     {
-      boost::property_tree::ptree ptXMC;
-      xrt_core::device::get_device_xmc_info(device_id, ptXMC);
-      ptPlatform.add_child("xmc", ptXMC);
+      boost::property_tree::ptree pt;
+      xrt_core::device::get_device_xmc_info(device_id, pt);
+      ptPlatform.add_child("xmc", pt);
+    }
+
+    // Get and add thermal pcb information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_thermal_pcb(device_id, pt);
+      ptPlatform.add_child("physical.thermal.pcb", pt);
+    }
+
+    // Get and add thermal fpga information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_thermal_fpga(device_id, pt);
+      ptPlatform.add_child("physical.thermal.fpga", pt);
+    }
+
+    // Get and add thermal fpga information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_thermal_fpga(device_id, pt);
+      ptPlatform.add_child("physical.thermal.fpga", pt);
+    }
+
+    // Get and add fan information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_fan_info(device_id, pt);
+      ptPlatform.add_child("physical.fan", pt);
+    }
+
+    // Get and add thermal cage information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_thermal_cage(device_id, pt);
+      ptPlatform.add_child("physical.thermal.cage", pt);
+    }
+
+    // Get and add electrical information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_electrical(device_id, pt);
+      ptPlatform.add_child("physical.electrical", pt);
+    }
+
+    // Get and add power information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_power(device_id, pt);
+      ptPlatform.add_child("physical.power", pt);
+    }
+
+    // Get and add firewall information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_firewall(device_id, pt);
+      ptPlatform.add_child("firewall", pt);
+    }
+
+    // Get and add pcie dma status information
+    {
+      boost::property_tree::ptree pt;
+      xrt_core::device::read_device_pcie_dma_stats(device_id, pt);
+      ptPlatform.add_child("pcie_dma", pt);
     }
 
     // Add the platform to the device tree

--- a/src/runtime_src/core/tools/xbutil2/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBUtilities.cpp
@@ -160,4 +160,3 @@ XBUtilities::trace_print_tree(const std::string & _name,
 }
 
 
-

--- a/src/runtime_src/core/tools/xbutil2/XBUtilities.h
+++ b/src/runtime_src/core/tools/xbutil2/XBUtilities.h
@@ -28,11 +28,12 @@ namespace XBUtilities {
 template<typename ... Args>
 
 std::string format(const std::string& format, Args ... args) {
-  size_t size = 1 + snprintf(nullptr, 0, format.c_str(), args ...);
+  const static size_t NULL_CHAR_SIZE = 1;
+  size_t size = NULL_CHAR_SIZE + snprintf(nullptr, 0, format.c_str(), args ...);
   std::unique_ptr<char[]> buf(new char[size]);
   snprintf(buf.get(), size, format.c_str(), args ...);
   
-  return std::string(buf.get(), buf.get() + size);
+  return std::string(buf.get());
 }
 
   typedef enum {


### PR DESCRIPTION
Work Done
---------
+ Removed 'dead' comments
+ Added linux dependency libraries
+ Updated XBDatabase to build a system JSON database for all query values
+ Added numerous xrt_core::device::read_device* APIs
+ Implemented linux xrt_core::device::read_device* APIs
+ Stubbed out windows xrt_core::device::read_device* APIs
+ Replaced the "magic 8" for xclDeviceUsage with XCL_DEVICE_USAGE_COUNT
+ Bug fix: XBUtilities::format template was incorrectly printing a "NULL" character.