### PR TITLE
Xmc mb offset

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -2623,6 +2623,9 @@ static int xmc_load_board_info(struct xocl_xmc *xmc)
 	if (xmc->bdinfo_loaded)
 		return 0;
 
+	if (!xmc->mbx_offset)
+		return 0;
+
 	if (XMC_PRIVILEGED(xmc)) {
 
 		if ((!is_xmc_ready(xmc) || !is_sc_ready(xmc)))


### PR DESCRIPTION
[ 2488.868207] xmc.m xmc.m.11534336: load_xmc: XMC info, version 0x1ed23d, status 0x13018801, id 0x74736574
[ 2488.868215] xmc.m xmc.m.11534336: load_xmc: XMC mailbox offset: **0x1000**.
[ 2488.976328] xmc.m xmc.m.11534336: xmc_load_board_info: board info reloaded
[ 2488.976337] xclmgmt 0000:65:00.0: xocl_thread_start: init xclmgmt health thread


root@alveo:/opt/xilinx/xrt-2.3.1301/driver/xocl/mgmtpf# xbutil validate -q
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_u200_xdma_201920_1
**INFO: == Starting AUX power connector check:**
AUX power connector not available. Skipping validation
INFO: == AUX power connector check SKIPPED
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated successfully.

INFO: All cards validated successfully.
