### PR TITLE
fix versal DFX

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -958,7 +958,7 @@ configure_soft_kernel(struct sched_cmd *cmd)
 
 		/* remap device physical addr to kernel virtual addr */
 		xclbin_buffer =
-		    memremap(cfg->sk_addr, cfg->sk_size, MEMREMAP_WB);
+		    memremap(cfg->sk_addr, cfg->sk_size, MEMREMAP_WC);
 		if (xclbin_buffer == NULL) {
 			ret = -ENOMEM;
 			goto fail;


### PR DESCRIPTION
The xclbin_buffer is PS memory that is reserved for host application. These memory can NOT be mapped as cacheable because no cache coherence is guaranteed when host DMA from/to these memory.