### PR TITLE
support hot reset on PPC

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -691,9 +691,23 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 
 	switch (req->req) {
 	case XCL_MAILBOX_REQ_HOT_RESET:
+#if defined(__PPC64__)
+		/* Reply before doing reset to release peer from waiting
+		 * for response and move to timer based wait stage.
+		 */
+		(void) xocl_peer_response(lro, req->req, msgid, &ret,
+			sizeof(ret));
+		msleep(2000);
+		/* Peer should be msleeping and waiting now. Do reset now
+		 * before peer wakes up and start touching the PCIE BAR,
+		 * which is not allowed during reset.
+		 */
+		ret = (int) reset_hot_ioctl(lro);
+#else
 		ret = (int) reset_hot_ioctl(lro);
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,
 			sizeof(ret));
+#endif
 		break;
 	case XCL_MAILBOX_REQ_LOAD_XCLBIN_KADDR: {
 		void *buf = NULL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -179,11 +179,6 @@ long reset_hot_ioctl(struct xclmgmt_dev *lro)
 	}
 
 	ep_name = pdev->bus->name;
-#if defined(__PPC64__)
-	mgmt_info(lro, "Ignore reset operation for card %d in slot %s:%02x:%1x",
-		lro->instance, ep_name,
-		PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
-#else
 	mgmt_info(lro, "Trying to reset card %d in slot %s:%02x:%1x",
 		lro->instance, ep_name,
 		PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
@@ -202,7 +197,11 @@ long reset_hot_ioctl(struct xclmgmt_dev *lro)
 	if (!XOCL_DSA_PCI_RESET_OFF(lro)) {
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_ICAP);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_MAILBOX);
+#if defined(__PPC64__)
+		pci_fundamental_reset(lro);
+#else
 		xclmgmt_reset_pci(lro);
+#endif
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_MAILBOX);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_ICAP);
 	} else {
@@ -242,7 +241,6 @@ long reset_hot_ioctl(struct xclmgmt_dev *lro)
 
 	xocl_thread_start(lro);
 
-#endif
 done:
 	return err;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -429,7 +429,7 @@ int mailbox_post_notify(struct platform_device *, void *, size_t);
 int mailbox_get(struct platform_device *pdev, enum mb_kind kind, u64 *data);
 
 static int mailbox_enable_intr_mode(struct mailbox *mbx);
-static void mailbox_disable_intr_mode(struct mailbox *mbx);
+static void mailbox_disable_intr_mode(struct mailbox *mbx, bool timer_on);
 
 static inline u32 mailbox_reg_rd(struct mailbox *mbx, u32 *reg)
 {
@@ -1491,7 +1491,7 @@ static ssize_t intr_mode_store(struct device *dev,
 	if (enable)
 		mailbox_enable_intr_mode(mbx);
 	else
-		mailbox_disable_intr_mode(mbx);
+		mailbox_disable_intr_mode(mbx, true);
 
 	return count;
 }
@@ -1827,19 +1827,22 @@ static int mailbox_enable_intr_mode(struct mailbox *mbx)
 	return 0;
 }
 
-static void mailbox_disable_intr_mode(struct mailbox *mbx)
+static void mailbox_disable_intr_mode(struct mailbox *mbx, bool timer_on)
 {
 	struct platform_device *pdev = mbx->mbx_pdev;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 
 	if (MB_SW_ONLY(mbx))
 		return;
+
 	/*
 	 * No need to turn on polling mode for TX, which has
 	 * a channel stall checking timer always on when there is
 	 * outstanding TX packet.
 	 */
-	set_bit(MBXCS_BIT_POLL_MODE, &mbx->mbx_rx.mbc_state);
+	if (timer_on)
+		set_bit(MBXCS_BIT_POLL_MODE, &mbx->mbx_rx.mbc_state);
+
 	chan_config_timer(&mbx->mbx_rx);
 
 	/* Disable both TX / RX intrs. */
@@ -1934,7 +1937,14 @@ static int mailbox_offline(struct platform_device *pdev)
 	struct mailbox *mbx;
 
 	mbx = platform_get_drvdata(pdev);
-	mailbox_disable_intr_mode(mbx);
+#if defined(__PPC64__)
+	/* Offline is called during reset. We can't poll mailbox registers
+	 * during reset on PPC.
+	 */
+	mailbox_disable_intr_mode(mbx, false);
+#else
+	mailbox_disable_intr_mode(mbx, true);
+#endif
 	return 0;
 }
 
@@ -2180,7 +2190,7 @@ static int mailbox_remove(struct platform_device *pdev)
 	sysfs_remove_group(&pdev->dev.kobj, &mailbox_attrgroup);
 
 	/* Stop interrupt. */
-	mailbox_disable_intr_mode(mbx);
+	mailbox_disable_intr_mode(mbx, false);
 	/* Tear down all threads. */
 	chan_fini(&mbx->mbx_tx);
 	chan_fini(&mbx->mbx_rx);
@@ -2257,13 +2267,13 @@ static int mailbox_probe(struct platform_device *pdev)
 	/* Enable interrupt. */
 	if (mailbox_no_intr) {
 		MBX_INFO(mbx, "Enabled timer-driven mode");
-		mailbox_disable_intr_mode(mbx);
+		mailbox_disable_intr_mode(mbx, true);
 	} else {
 		ret = mailbox_enable_intr_mode(mbx);
 		if (ret != 0) {
 			MBX_INFO(mbx, "failed to enable intr mode");
 			/* Ignore error, fall back to timer driven mode */
-			mailbox_disable_intr_mode(mbx);
+			mailbox_disable_intr_mode(mbx, true);
 		}
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -329,6 +329,14 @@ int xocl_hot_reset(struct xocl_dev *xdev, bool force)
 	if (mbret)
 		ret = mbret;
 
+#if defined(__PPC64__)
+	/* During reset we can't poll mailbox registers to get notified when
+	 * peer finishes reset. Just do a timer based wait for 20 seconds,
+	 * which is long enough for reset to be done.
+	 */
+	msleep(20 * 1000);
+#endif
+
 	xocl_reset_notify(xdev->core.pdev, false);
 
 	xocl_drvinst_set_offline(xdev->core.drm, false);


### PR DESCRIPTION
In order to support hot reset on PPC, we:
1. perform PCIE fundamental reset, instead of PCIE secondary bus reset (the latter does not seem to work on PPC, maybe we did not sleep long enough after toggling the reset bit)
2. make sure no one touches PCIE BAR on both mgmt and user pf during reset, or we may trigger PCIE fatal error.

This change is tested on a PPC and seems to be working fine. Also tested hot reset on X86 system to make sure there is no regression.

@houlz0507 @sonals , please take a look ASAP.