### PR TITLE
fix versal DFX (#2404)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -974,7 +974,7 @@ configure_soft_kernel(struct sched_cmd *cmd)
 
 		/* remap device physical addr to kernel virtual addr */
 		xclbin_buffer =
-		    memremap(cfg->sk_addr, cfg->sk_size, MEMREMAP_WB);
+		    memremap(cfg->sk_addr, cfg->sk_size, MEMREMAP_WC);
 		if (xclbin_buffer == NULL) {
 			ret = -ENOMEM;
 			goto fail;


### PR DESCRIPTION
Cherry-pick this to support Versal DFX in 2019.2. 
Test done:
Build two xclbin with different kernel.cl and switch them. Without the fix, the second download will fail. And with the fix, the two xclbin can be switched many times without issue.

This is a very low risk backport because it is only on the softkernel configuration (download xclbin) data path, which is only used by Versal.