### PR TITLE
Soft kernel command should have ERT_CTRL command type.

### DIFF
--- a/src/runtime_src/core/common/scheduler.cpp
+++ b/src/runtime_src/core/common/scheduler.cpp
@@ -180,6 +180,7 @@ init(xclDeviceHandle handle, const axlf* top)
       std::memset(scmd, 0, 0x1000);
       scmd->state = ERT_CMD_STATE_NEW;
       scmd->opcode = ERT_SK_CONFIG;
+      ecmd->type = ERT_CTRL;
       scmd->count = sizeof (ert_configure_sk_cmd) / 4 - 1;
       scmd->start_cuidx = start_cuidx;
       scmd->num_cus = sk.ninst;
@@ -219,6 +220,7 @@ loadXclbinToPS(xclDeviceHandle handle, const axlf* top)
   auto ecmd = reinterpret_cast<ert_configure_sk_cmd*>(execbo->data);
   ecmd->state = ERT_CMD_STATE_NEW;
   ecmd->opcode = ERT_SK_CONFIG;
+  ecmd->type = ERT_CTRL;
   ecmd->count = 13;
   ecmd->start_cuidx = 0;
   ecmd->sk_type = SOFTKERNEL_TYPE_XCLBIN;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4038,9 +4038,23 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	uint64_t dst_addr;
 	struct ert_start_copybo_cmd *scmd = (struct ert_start_copybo_cmd *)xobj->vmapping;
 
-	/* CU style commands must specify CU type */
-	if (scmd->opcode == ERT_START_CU || scmd->opcode == ERT_EXEC_WRITE)
+	/*
+	 * CU style commands must specify CU type
+	 * Softkernel commands should use CTRL type
+	 */
+	switch (scmd->opcode) {
+	case ERT_START_CU:
+	case ERT_EXEC_WRITE:
 		scmd->type = ERT_CU;
+		break;
+	case ERT_SK_CONFIG:
+	case ERT_SK_START:
+	case ERT_SK_UNCONFIG:
+		scmd->type = ERT_CTRL;
+		break;
+	default:
+		break;
+	}
 
 	/* Only convert COPYBO cmd for now. */
 	if (scmd->opcode != ERT_START_COPYBO)


### PR DESCRIPTION
Softkernel should set ERT_CTRL command type. Otherwise, the command will fail to execute with unknonw command type.