### PR TITLE
xrt-next.h: Add typedef to profiling related struct declaration 

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt-next.h
+++ b/src/runtime_src/core/include/experimental/xrt-next.h
@@ -133,13 +133,13 @@ struct ProfileResults
   char* deviceName;
 
   uint64_t numAIM;
-  KernelTransferData* kernelTransferData;
+  struct KernelTransferData *kernelTransferData;
 
   uint64_t numAM;
-  CuExecData* cuExecData;
+  struct CuExecData *cuExecData;
 
   uint64_t numASM;
-  StreamTransferData* streamData;
+  struct StreamTransferData  *streamData;
 };
 
 /**
@@ -153,7 +153,7 @@ struct ProfileResults
  *                     This argument remains unchanged if xclCreateProfileResults fails.
  *
  */
-XCL_DRIVER_DLLESPEC int xclCreateProfileResults(xclDeviceHandle, ProfileResults**);
+XCL_DRIVER_DLLESPEC int xclCreateProfileResults(xclDeviceHandle, struct ProfileResults**);
 
 /**
  * int xclGetProfileResults(xclDeviceHandle, ProfileResults*)
@@ -166,7 +166,7 @@ XCL_DRIVER_DLLESPEC int xclCreateProfileResults(xclDeviceHandle, ProfileResults*
  *                    This buffer should be created using previous call to "xclCreateProfileResults"
  *
  */
-XCL_DRIVER_DLLESPEC int xclGetProfileResults(xclDeviceHandle, ProfileResults*);
+XCL_DRIVER_DLLESPEC int xclGetProfileResults(xclDeviceHandle, struct ProfileResults*);
 
 /**
  * int xclDestroyProfileResults(xclDeviceHandle, ProfileResults*)
@@ -178,7 +178,7 @@ XCL_DRIVER_DLLESPEC int xclGetProfileResults(xclDeviceHandle, ProfileResults*);
  * @ProfileResults* : Pointer to buffer to be deleted
  *
  */
-XCL_DRIVER_DLLESPEC int xclDestroyProfileResults(xclDeviceHandle, ProfileResults*);
+XCL_DRIVER_DLLESPEC int xclDestroyProfileResults(xclDeviceHandle, struct ProfileResults*);
 
 /**
  * xclRegRead() - Read register in register space of a CU


### PR DESCRIPTION
Add typedef to struct declaration to make visible in the namespace

Several routines in this header refer to ProfileResults, however it was declared as
a simple struct. Without the typedef specifier it will not be resolved when using
an application that eventually needs compile with xclhal2.h

ProfileResults is invoked in the following functions xclCreateProfileResults,
xclGetProfileResults, and xclDestroyProfileResults

Typedef needs to be added to the definitions of KernelTransferData, CuExecData, and
StreamTransferData as they are used without the struct * being used in the
definition of ProfileResults.

Fixes: 9b40ccb HAL level profiling with counters for PCIe and Zynq (#1936)

Signed-off-by: Rohit Athavale <rohit.athavale@xilinx.com>