### PR TITLE
fix lint warning introduced by 'add aws reclock support'

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -859,7 +859,7 @@ static int icap_ocl_update_clock_freq_topology(struct platform_device *pdev, str
 	}
 
 	for (i = 0; i < ARRAY_SIZE(freq_obj->ocl_target_freq); i++) {
-		if (!freq_obj->ocl_target_freq)
+		if (!freq_obj->ocl_target_freq[i])
 		        continue;
 		freq_max = freq_min = 0;
 		icap_get_ocl_frequency_max_min(icap, i, &freq_max, &freq_min);


### PR DESCRIPTION
one line of the PR "add aws reclock support" was not correct. Although the behavior(logic) is still fine, there is a lint warning
This PR fixes the warning