### PR TITLE
2019.1

### DIFF
--- a/src/xma/src/xmaapi/xmacfg.c
+++ b/src/xma/src/xmaapi/xmacfg.c
@@ -81,7 +81,7 @@ static XmaSystemCfgSM systemcfg_sm[] = {
 { "SystemCfg",     &check_systemcfg,   true },
 { "logfile",       &set_logfile,       false },
 { "loglevel",      &set_loglevel,      false },
-{ "dsa",           &set_dsa,           true },
+{ "dsa",           &set_dsa,           false },
 { "pluginpath",    &set_pluginpath,    true },
 { "xclbinpath",    &set_xclbinpath,    true },
 { "ImageCfg",      &check_imagecfg,    true },

--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -162,7 +162,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
 {
     int32_t num_devices_requested = 0;
     int32_t i;
-    int32_t j;
+    //int32_t j;
     int32_t max_dev_id;
 
     max_dev_id = get_max_dev_id(systemcfg);
@@ -181,6 +181,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
         return false;
     }
 
+#if 0
     for (i = 0; i < systemcfg->num_images; i++)
     {
         for (j = 0; j < systemcfg->imagecfg[i].num_devices; j++)
@@ -193,6 +194,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
             }
         }
     }
+#endif
 
     return true;
 }

--- a/src/xma/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/src/xmaapi/xmahw_hal.cpp
@@ -181,21 +181,6 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
         return false;
     }
 
-#if 0
-    for (i = 0; i < systemcfg->num_images; i++)
-    {
-        for (j = 0; j < systemcfg->imagecfg[i].num_devices; j++)
-        {
-            if (strcmp(systemcfg->dsa, hwcfg->devices[systemcfg->imagecfg[i].device_id_map[j]].dsa) != 0)
-            {
-                xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "DSA mismatch: requested %s found %s\n",
-                systemcfg->dsa, hwcfg->devices[systemcfg->imagecfg[i].device_id_map[j]].dsa);
-                return false;
-            }
-        }
-    }
-#endif
-
     return true;
 }
 


### PR DESCRIPTION
Remove compatibility check of DSA in YAML configuration against DSA loaded on accelerator.  This check is superfluous since the xclbin will not be loaded if there is a mismatch.  More importantly, this change allows multiple cards types to be supported on the same server.