### PR TITLE
2019.2

### DIFF
--- a/src/xma/xma_legacy/src/xmaapi/xmacfg.c
+++ b/src/xma/xma_legacy/src/xmaapi/xmacfg.c
@@ -81,7 +81,7 @@ static XmaSystemCfgSM systemcfg_sm[] = {
 { "SystemCfg",     &check_systemcfg,   true },
 { "logfile",       &set_logfile,       false },
 { "loglevel",      &set_loglevel,      false },
-{ "dsa",           &set_dsa,           true },
+{ "dsa",           &set_dsa,           false },
 { "pluginpath",    &set_pluginpath,    true },
 { "xclbinpath",    &set_xclbinpath,    true },
 { "ImageCfg",      &check_imagecfg,    true },

--- a/src/xma/xma_legacy/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/xma_legacy/src/xmaapi/xmahw_hal.cpp
@@ -180,19 +180,6 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
         return false;
     }
 
-#if 0
-    /* For each of the requested devices, check that the DSA name matches */
-    for (i = 0; i < num_devices_requested; i++)
-    {
-        if (strcmp(systemcfg->dsa, hwcfg->devices[i].dsa) != 0)
-        {
-            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "DSA mismatch: requested %s found %s\n",
-                       systemcfg->dsa, hwcfg->devices[i].dsa);
-            return false;
-        }
-    }
-#endif
-
     return true;
 }
 

--- a/src/xma/xma_legacy/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/xma_legacy/src/xmaapi/xmahw_hal.cpp
@@ -180,6 +180,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
         return false;
     }
 
+#if 0
     /* For each of the requested devices, check that the DSA name matches */
     for (i = 0; i < num_devices_requested; i++)
     {
@@ -190,6 +191,7 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
             return false;
         }
     }
+#endif
 
     return true;
 }


### PR DESCRIPTION
Remove compatibility check of DSA in YAML configuration against DSA loaded on accelerator. This check is superfluous since the xclbin will not be loaded if there is a mismatch. More importantly, this change allows multiple cards types to be supported on the same server.