### PR TITLE
2019.2 branch doc update with links

### DIFF
--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -11,4 +11,4 @@ This utility is used for card installation and administration, and requires sudo
 running it. The ``xbmgmt`` supported tasks include flashing the card firmware, and scanning the
 current device configuration.
 
-For more details please refer `Vitis Application Acceleration Document <https://www.xilinx.com/html_docs/xilinx2019_2/vitis_doc/utg1569948694132.html>`_
+For more details please refer `Vitis Application Acceleration Development Flow Documentation <https://www.xilinx.com/html_docs/xilinx2019_2/vitis_doc/utg1569948694132.html>`_

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -10,4 +10,4 @@ the installed accelerator card(s) along with additional card details including D
 platform name, and system information. This information can be used for both card administration 
 and application debugging.
 
-For more details please refer `Vitis Application Acceleration Document <https://www.xilinx.com/html_docs/xilinx2019_2/vitis_doc/Chunk1185163305.html>`_ 
+For more details please refer `Vitis Application Acceleration Development Flow Documentation <https://www.xilinx.com/html_docs/xilinx2019_2/vitis_doc/Chunk1377771038.html>`_ 


### PR DESCRIPTION
- fix link in xbutil to Vitis Application Acceleration Development Flow Documentation
- Change the link name to "Vitis Application Acceleration Development Flow Documentation" to match its HTML title in both xbutil and xbmgmt pages.