### PR TITLE
Xbutil program

### DIFF
--- a/src/runtime_src/core/common/device_core.cpp
+++ b/src/runtime_src/core/common/device_core.cpp
@@ -14,6 +14,11 @@
  * under the License.
  */
 
+// For now device_core.cpp is delivered with core library (libxrt_core), see
+// for example core/pcie/windows/CMakeLists.txt.  To prevent compilation of
+// this file from importing symbols from libxrt_core we define this source
+// file to instead export with same macro as used in libxrt_core.
+#define XCL_DRIVER_DLL_EXPORT
 
 #include "device_core.h"
 #include "error.h"
@@ -26,33 +31,33 @@
 
 namespace xrt_core {
 
-std::map<device_core::QueryRequest, device_core::QueryRequestEntry> device_core::m_QueryTable = 
-{ 
+std::map<device_core::QueryRequest, device_core::QueryRequestEntry> device_core::m_QueryTable =
+{
   { QR_PCIE_VENDOR,               { "QR_PCIE_VENDOR",               "vendor",           &typeid(std::string), device_core::format_primative }},
   { QR_PCIE_DEVICE,               { "QR_PCIE_DEVICE",               "device",           &typeid(std::string), device_core::format_primative }},
   { QR_PCIE_SUBSYSTEM_VENDOR,     { "QR_PCIE_SUBSYSTEM_VENDOR",     "subsystem_vendor", &typeid(std::string), device_core::format_primative }},
   { QR_PCIE_SUBSYSTEM_ID,         { "QR_PCIE_SUBSYSTEM_ID",         "subsystem_id",     &typeid(std::string), device_core::format_primative }},
   { QR_PCIE_LINK_SPEED,           { "QR_PCIE_LINK_SPEED",           "link_speed",       &typeid(uint64_t),    device_core::format_primative }},
   { QR_PCIE_EXPRESS_LANE_WIDTH,   { "QR_PCIE_EXPRESS_LANE_WIDTH",   "width",            &typeid(uint64_t),    device_core::format_primative }},
-                                                                   
+
   { QR_ROM_VBNV,                  { "QR_ROM_VBNV",                  "vbnv",             &typeid(std::string), device_core::format_primative }},
   { OR_ROM_DDR_BANK_SIZE,         { "OR_ROM_DDR_BANK_SIZE",         "ddr_size_bytes",   &typeid(uint64_t),    device_core::format_hex_base2_shiftup30 }},
   { QR_ROM_DDR_BANK_COUNT_MAX,    { "QR_ROM_DDR_BANK_COUNT_MAX",    "widdr_countdth",   &typeid(uint64_t),    device_core::format_primative }},
   { QR_ROM_FPGA_NAME,             { "QR_ROM_FPGA_NAME",             "fpga_name",        &typeid(std::string), device_core::format_primative }},
   { QR_DMA_THREADS_RAW,           { "QR_DMA_THREADS_RAW",           "dma_threads",      &typeid(std::vector<std::string>),  device_core::format_primative }},
-                                                                   
+
   { QR_XMC_VERSION,               { "QR_XMC_VERSION",               "xmc_version",      &typeid(std::string),  device_core::format_primative }},
   { QR_XMC_SERIAL_NUM,            { "QR_XMC_SERIAL_NUM",            "serial_number",    &typeid(std::string),  device_core::format_primative }},
   { QR_XMC_MAX_POWER,             { "QR_XMC_MAX_POWER",             "max_power",        &typeid(std::string),  device_core::format_primative }},
   { QR_XMC_BMC_VERSION,           { "QR_XMC_BMC_VERSION",           "satellite_controller_version", &typeid(std::string),  device_core::format_primative }},
-                                                                   
+
   { QR_DNA_SERIAL_NUM,            { "QR_DNA_SERIAL_NUM",            "dna",              &typeid(std::string),  device_core::format_primative }},
   { QR_CLOCK_FREQS,               { "QR_CLOCK_FREQS",               "clocks",           &typeid(std::vector<std::string>),  device_core::format_primative }},
   { QR_IDCODE,                    { "QR_IDCODE",                    "idcode",           &typeid(std::string),  device_core::format_primative }},
-                                                                   
+
   { QR_STATUS_MIG_CALIBRATED,     { "QR_STATUS_MIG_CALIBRATED",     "mig_calibrated",   &typeid(bool),  device_core::format_primative }},
   { QR_STATUS_P2P_ENABLED,        { "QR_STATUS_P2P_ENABLED",        "p2p_enabled",      &typeid(bool),  device_core::format_primative }},
-                                                                   
+
   { QR_TEMP_CARD_TOP_FRONT,       { "QR_TEMP_CARD_TOP_FRONT",       "temp_top_front_C",    &typeid(uint64_t),  device_core::format_primative }},
   { QR_TEMP_CARD_TOP_REAR,        { "QR_TEMP_CARD_TOP_REAR",        "temp_top_rear_C",     &typeid(uint64_t),  device_core::format_primative }},
   { QR_TEMP_CARD_BOTTOM_FRONT,    { "QR_TEMP_CARD_BOTTOM_FRONT",    "temp_bottom_front_C", &typeid(uint64_t),  device_core::format_primative }},
@@ -109,7 +114,7 @@ std::map<device_core::QueryRequest, device_core::QueryRequestEntry> device_core:
 };
 
 
-const device_core::QueryRequestEntry * 
+const device_core::QueryRequestEntry *
 device_core::get_query_entry(QueryRequest _eQueryRequest) const
 {
   std::map<QueryRequest, QueryRequestEntry>::const_iterator it = m_QueryTable.find(_eQueryRequest);
@@ -140,7 +145,7 @@ device_core::instance()
 }
 
 device_core::device
-device_core::get_device(uint64_t _deviceID) const 
+device_core::get_device(uint64_t _deviceID) const
 {
   static bool device_message = true;
   if (device_message) {
@@ -173,7 +178,7 @@ device_core::format_primative(const boost::any &_data)
   return sPropertyValue;
 }
 
-std::string 
+std::string
 device_core::format_hex(const boost::any & _data)
 {
   // Can we work with this data type?
@@ -185,7 +190,7 @@ device_core::format_hex(const boost::any & _data)
 }
 
 template <typename T>
-std::string 
+std::string
 static to_string(const T _value, const int _precision = 6)
 {
   std::ostringstream sBuffer;
@@ -194,7 +199,7 @@ static to_string(const T _value, const int _precision = 6)
   return sBuffer.str();
 }
 
-std::string 
+std::string
 device_core::format_base10_shiftdown3(const boost::any &_data)
 {
   if (_data.type() != typeid(uint64_t)) {
@@ -202,11 +207,11 @@ device_core::format_base10_shiftdown3(const boost::any &_data)
   }
 
   double value = (double) boost::any_cast<uint64_t>(_data);
-  value /= (double) 1000.0;    // Shift down 3 
+  value /= (double) 1000.0;    // Shift down 3
   return to_string(value, 3 /*precision*/ );
 }
 
-std::string 
+std::string
 device_core::format_base10_shiftdown6(const boost::any &_data)
 {
   if (_data.type() != typeid(uint64_t)) {
@@ -214,11 +219,11 @@ device_core::format_base10_shiftdown6(const boost::any &_data)
   }
 
   double value = (double) boost::any_cast<uint64_t>(_data);
-  value /= (double) 1000000.0;    // Shift down 3 
+  value /= (double) 1000000.0;    // Shift down 3
   return to_string(value, 6 /*precision*/ );
 }
 
-std::string 
+std::string
 device_core::format_hex_base2_shiftup30(const boost::any &_data)
 {
   if (_data.type() != typeid(uint64_t)) {
@@ -231,9 +236,9 @@ device_core::format_hex_base2_shiftup30(const boost::any &_data)
 
 
 
-void 
-device_core::query_device_and_put(uint64_t _deviceID, 
-                                            QueryRequest _eQueryRequest, 
+void
+device_core::query_device_and_put(uint64_t _deviceID,
+                                            QueryRequest _eQueryRequest,
                                             boost::property_tree::ptree & _pt) const
 {
   const QueryRequestEntry *pQREntry = get_query_entry(_eQueryRequest);
@@ -246,10 +251,10 @@ device_core::query_device_and_put(uint64_t _deviceID,
 }
 
 void
-device_core::query_device_and_put(uint64_t _deviceID, 
-                                            QueryRequest _eQueryRequest, 
+device_core::query_device_and_put(uint64_t _deviceID,
+                                            QueryRequest _eQueryRequest,
                                             const std::type_info & _typeInfo,
-                                            boost::property_tree::ptree & _pt, 
+                                            boost::property_tree::ptree & _pt,
                                             const std::string &_sPropertyName,
                                             FORMAT_STRING_PTR stringFormat) const
 {
@@ -273,12 +278,12 @@ device_core::query_device_and_put(uint64_t _deviceID,
     } else {
       _pt.put(_sPropertyName, stringFormat(anyValue));
     }
-  } catch (const std::exception& e) { 
+  } catch (const std::exception& e) {
     _pt.put(_sPropertyName + ":error_msg", e.what());
   }
 }
 
-void 
+void
 device_core::get_device_rom_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_ROM_VBNV, _pt);
@@ -288,7 +293,7 @@ device_core::get_device_rom_info(uint64_t _deviceID, boost::property_tree::ptree
 }
 
 
-void 
+void
 device_core::get_device_xmc_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
 
@@ -298,7 +303,7 @@ device_core::get_device_xmc_info(uint64_t _deviceID, boost::property_tree::ptree
   query_device_and_put(_deviceID, QR_XMC_BMC_VERSION, _pt);
 }
 
-void 
+void
 device_core::get_device_platform_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_DNA_SERIAL_NUM, _pt);
@@ -308,7 +313,7 @@ device_core::get_device_platform_info(uint64_t _deviceID, boost::property_tree::
   query_device_and_put(_deviceID, QR_STATUS_P2P_ENABLED, _pt);
 }
 
-void 
+void
 device_core::read_device_thermal_pcb(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
 
@@ -317,13 +322,13 @@ device_core::read_device_thermal_pcb(uint64_t _deviceID, boost::property_tree::p
   query_device_and_put(_deviceID, QR_TEMP_CARD_BOTTOM_FRONT, _pt);
 }
 
-void 
+void
 device_core::read_device_thermal_fpga(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_TEMP_FPGA, _pt);
 }
 
-void 
+void
 device_core::read_device_fan_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_FAN_TRIGGER_CRITICAL_TEMP, _pt);
@@ -331,7 +336,7 @@ device_core::read_device_fan_info(uint64_t _deviceID, boost::property_tree::ptre
   query_device_and_put(_deviceID, QR_FAN_SPEED_RPM, _pt);
 }
 
-void 
+void
 device_core::read_device_thermal_cage(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_CAGE_TEMP_0, _pt);
@@ -342,7 +347,7 @@ device_core::read_device_thermal_cage(uint64_t _deviceID, boost::property_tree::
 
 
 
-void 
+void
 device_core::read_device_electrical(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_12V_PEX_MILLIVOLTS, _pt);
@@ -375,14 +380,14 @@ device_core::read_device_electrical(uint64_t _deviceID, boost::property_tree::pt
   query_device_and_put(_deviceID, QR_INT_BRAM_VCC_MILLIVOLTS, _pt);
 }
 
-void 
+void
 device_core::read_device_power(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_POWER_MICROWATTS, _pt);
 }
 
 
-void 
+void
 device_core::read_device_firewall(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_FIREWALL_DETECT_LEVEL, _pt);

--- a/src/runtime_src/core/common/device_core.h
+++ b/src/runtime_src/core/common/device_core.h
@@ -17,6 +17,9 @@
 #ifndef DEVICE_CORE_H
 #define DEVICE_CORE_H
 
+#include "error.h"
+#include "xrt.h"
+
 // Please keep eternal include file dependencies to a minimum
 #include <boost/property_tree/ptree.hpp>
 #include <cstdint>
@@ -37,13 +40,19 @@ class device_core {
      * 
      * @return The handle instance
      */
-    static const device_core & get_handle();
+   static const device_core & instance();
 
   public:
     virtual void get_devices(boost::property_tree::ptree &_pt) const = 0;
     virtual void get_device_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const = 0;
     virtual void read_device_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt) const = 0;
-    virtual uint64_t get_total_devices() const = 0;
+
+    /**
+     * get_total_devices() - Get total devices and total usable devices
+     *
+     * Return: Pair of total devices and usable devices
+     */
+    virtual std::pair<uint64_t, uint64_t> get_total_devices() const = 0;
 
     void get_device_rom_info(uint64_t _deviceID, boost::property_tree::ptree & _pt) const;
     void get_device_xmc_info(uint64_t _deviceID, boost::property_tree::ptree & _pt) const;
@@ -55,6 +64,55 @@ class device_core {
     void read_device_electrical(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
     void read_device_power(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
     void read_device_firewall(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
+
+  public:
+
+    /**
+     * class device - Encapsulate the device created from a card index
+     *
+     * @m_midx: card index
+     * @m_name: name of device
+     * @m_hdl: device handle per shim layer
+     *
+     * The device is opened immediately when constructed and closed upon
+     * destruction.  The class supports execution of shim level functions
+     * through its execute method (sample usage SubCmdProgram.cpp)
+     */
+    class device
+    {
+      uint64_t m_idx;
+      std::string m_name;
+      xclDeviceHandle m_hdl;
+
+    public:
+      explicit device(uint64_t _deviceID)
+        : m_idx(_deviceID)
+        , m_name("device[" + std::to_string(m_idx) + "]")
+        , m_hdl(xclOpen(_deviceID, nullptr, XCL_QUIET))
+      {
+        if (!m_hdl)
+          throw error("could not open " + m_name);
+      }
+
+      ~device()
+      {
+        xclClose(m_hdl);
+      }
+
+      template <typename ShimDeviceFunction, typename ...Args>
+      auto
+      execute(ShimDeviceFunction&& f, Args&&... args)
+        -> decltype(f(m_hdl, std::forward<Args>(args)...))
+      {
+        return f(m_hdl, std::forward<Args>(args)...);
+      }
+    };
+
+    /**
+     * get_device() - Construct a managed device object frok a device ID
+     */
+    device
+    get_device(uint64_t _deviceID) const;
 
   public:
     // Future TODO: Move a way from static enumeration to dynamic enumeration
@@ -171,8 +229,8 @@ class device_core {
   private:
     device_core(const device_core&) = delete;
     device_core& operator=(const device_core&) = delete;
-
- private:
+ 
+  private:
     static std::map<QueryRequest, QueryRequestEntry> m_QueryTable;
 };
 

--- a/src/runtime_src/core/common/device_core.h
+++ b/src/runtime_src/core/common/device_core.h
@@ -35,9 +35,9 @@ class device_core {
 
   public:
     /**
-     * Returns the class handle use to query the abstract 
-     * libraries 
-     * 
+     * Returns the class handle use to query the abstract
+     * libraries
+     *
      * @return The handle instance
      */
    static const device_core & instance();
@@ -88,7 +88,7 @@ class device_core {
       explicit device(uint64_t _deviceID)
         : m_idx(_deviceID)
         , m_name("device[" + std::to_string(m_idx) + "]")
-        , m_hdl(xclOpen(_deviceID, nullptr, XCL_QUIET))
+        , m_hdl(xclOpen(static_cast<unsigned int>(_deviceID), nullptr, XCL_QUIET))
       {
         if (!m_hdl)
           throw error("could not open " + m_name);
@@ -124,7 +124,7 @@ class device_core {
       QR_PCIE_LINK_SPEED,
       QR_PCIE_EXPRESS_LANE_WIDTH,
 
-      QR_DMA_THREADS_RAW,               
+      QR_DMA_THREADS_RAW,
 
       QR_ROM_VBNV,
       OR_ROM_DDR_BANK_SIZE,
@@ -202,15 +202,15 @@ class device_core {
     static std::string format_base10_shiftdown3(const boost::any &_data);
     static std::string format_base10_shiftdown6(const boost::any &_data);
 
-    void query_device_and_put(uint64_t _deviceID, 
-                              QueryRequest _eQueryRequest, 
-                              const std::type_info & _typeInfo, 
-                              boost::property_tree::ptree & _pt, 
-                              const std::string &_sPropertyName, 
+    void query_device_and_put(uint64_t _deviceID,
+                              QueryRequest _eQueryRequest,
+                              const std::type_info & _typeInfo,
+                              boost::property_tree::ptree & _pt,
+                              const std::string &_sPropertyName,
                               FORMAT_STRING_PTR stringFormat = format_primative) const;
 
     void query_device_and_put(uint64_t _deviceID, QueryRequest _eQueryRequest, boost::property_tree::ptree & _pt) const;
-    
+
   protected:
 
     struct QueryRequestEntry {
@@ -229,7 +229,7 @@ class device_core {
   private:
     device_core(const device_core&) = delete;
     device_core& operator=(const device_core&) = delete;
- 
+
   private:
     static std::map<QueryRequest, QueryRequestEntry> m_QueryTable;
 };
@@ -239,4 +239,4 @@ initialize_child_ctor();
 
 } // xrt_core
 
-#endif 
+#endif

--- a/src/runtime_src/core/common/error.h
+++ b/src/runtime_src/core/common/error.h
@@ -14,28 +14,47 @@
  * under the License.
  */
 
-#ifndef DEVICE_PCIE_H
-#define DEVICE_PCIE_H
+#ifndef xrt_util_error_h
+#define xrt_util_error_h
 
-// Please keep eternal include file dependencies to a minimum
-#include "common/device_core.h"
+#include "message.h"
+#include <stdexcept>
+#include <string>
 
 namespace xrt_core {
-class device_pcie : public xrt_core::device_core {
 
-  protected:
-    device_pcie();
-    virtual ~device_pcie();
+class error : public std::runtime_error
+{
+  int m_code;
+public:
+  error(int ec, const std::string& what = "")
+    : std::runtime_error(what), m_code(ec)
+  {}
 
-  protected:
-    virtual std::pair<uint64_t, uint64_t> get_total_devices() const = 0;
-    virtual void get_devices(boost::property_tree::ptree &_pt) const;
-    virtual void get_device_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
+  explicit
+  error(const std::string& what)
+    : std::runtime_error(what), m_code(0)
+  {}
 
-  private:
-    device_pcie(const device_pcie&);
-    device_pcie& operator=(const device_pcie&);
+  int
+  get() const
+  {
+    return m_code;
+  }
+
+  unsigned int
+  get_code() const
+  {
+    return get();
+  }
 };
+
+inline void
+send_exception_message(const char* msg)
+{
+  message::send(message::severity_level::XRT_ERROR, "XRT", msg);
 }
 
-#endif /* CORE_SYSTEM_H */
+} // xrt_core
+
+#endif

--- a/src/runtime_src/core/common/message.h
+++ b/src/runtime_src/core/common/message.h
@@ -68,6 +68,6 @@ send(severity_level l, const char* tag, const char* format, Args ... args)
   }
 }
 
-}} // message,xrt
+}} // message,xrt_core
 
 #endif

--- a/src/runtime_src/core/pcie/common/device_pcie.cpp
+++ b/src/runtime_src/core/pcie/common/device_pcie.cpp
@@ -14,6 +14,11 @@
  * under the License.
  */
 
+// For now device_core.cpp is delivered with core library (libxrt_core), see
+// for example core/pcie/windows/CMakeLists.txt.  To prevent compilation of
+// this file from importing symbols from libxrt_core we define this source
+// file to instead export with same macro as used in libxrt_core.
+#define XCL_DRIVER_DLL_EXPORT
 
 #include "device_pcie.h"
 #include "common/utils.h"
@@ -31,7 +36,7 @@ xrt_core::device_pcie::~device_pcie()
   // Do nothing
 }
 
-void 
+void
 xrt_core::device_pcie::get_devices(boost::property_tree::ptree &_pt) const
 {
   auto cards = get_total_devices();
@@ -44,19 +49,19 @@ xrt_core::device_pcie::get_devices(boost::property_tree::ptree &_pt) const
     // Key: device_id
     ptDevice.put("device_id", std::to_string(deviceID).c_str());
 
-    // Key: pcie 
+    // Key: pcie
     boost::property_tree::ptree ptPcie;
     get_device_info(deviceID, ptPcie);
     ptDevice.add_child("pcie", ptPcie);
 
     // Create our array of data
-    ptDevices.push_back(std::make_pair("", ptDevice)); 
+    ptDevices.push_back(std::make_pair("", ptDevice));
   }
 
   _pt.add_child("devices", ptDevices);
 }
 
-void 
+void
 xrt_core::device_pcie::get_device_info(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
   query_device_and_put(_deviceID, QR_PCIE_VENDOR, _pt);
@@ -67,7 +72,3 @@ xrt_core::device_pcie::get_device_info(uint64_t _deviceID, boost::property_tree:
   query_device_and_put(_deviceID, QR_PCIE_EXPRESS_LANE_WIDTH, _pt);
   query_device_and_put(_deviceID, QR_DMA_THREADS_RAW, _pt);
 }
-
-
-
-

--- a/src/runtime_src/core/pcie/common/device_pcie.cpp
+++ b/src/runtime_src/core/pcie/common/device_pcie.cpp
@@ -34,10 +34,10 @@ xrt_core::device_pcie::~device_pcie()
 void 
 xrt_core::device_pcie::get_devices(boost::property_tree::ptree &_pt) const
 {
-  size_t cardsFound = get_total_devices();
+  auto cards = get_total_devices();
 
   boost::property_tree::ptree ptDevices;
-  for (unsigned int deviceID = 0; deviceID < cardsFound; ++deviceID) {
+  for (unsigned int deviceID = 0; deviceID < cards.first; ++deviceID) {
     boost::property_tree::ptree ptDevice;
     std::string valueString;
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -178,10 +178,10 @@ xrt_core::device_linux::~device_linux() {
   // Do nothing
 }
 
-uint64_t 
+std::pair<uint64_t, uint64_t>
 xrt_core::device_linux::get_total_devices() const
 {
-  return pcidev::get_dev_total();
+  return std::make_pair(pcidev::get_dev_total(), pcidev::get_dev_ready());
 }
 
 void 

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -33,7 +33,7 @@ class device_linux : public xrt_core::device_pcie {
     const SysDevEntry & get_sysdev_entry( QueryRequest _eQueryRequest) const;
 
   protected:
-    virtual uint64_t get_total_devices() const;
+    virtual std::pair<uint64_t, uint64_t> get_total_devices() const;
     virtual void query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_info & _typeInfo, boost::any &_returnValue) const;
 
   public:

--- a/src/runtime_src/core/pcie/windows/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/windows/CMakeLists.txt
@@ -11,19 +11,28 @@ file(GLOB XRT_PCIE_WINDOWS_FILES
   "../../common/device_core.cpp"
   )
 
+file(GLOB XRT_PCIE_WINDOWS_STATIC_FILES
+  "device_windows.*"
+  "../common/device_pcie.cpp"
+  "../../common/device_core.cpp"
+  )
+
+file(GLOB XRT_PCIE_WINDOWS_SHARED_FILES
+  "core_system.*"
+  "shim.*"
+  )
+
 set(CMAKE_CXX_FLAGS "-DXCLHAL_MAJOR_VER=2 ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "-DXCLHAL_MINOR_VER=1 ${CMAKE_CXX_FLAGS}")
 
-add_library(xrt_core SHARED ${XRT_PCIE_WINDOWS_FILES})
+add_library(xrt_core SHARED ${XRT_PCIE_WINDOWS_SHARED_FILES})
+add_library(xrt_core_static STATIC ${XRT_PCIE_WINDOWS_STATIC_FILES})
 
-
-add_library(xrt_core_static STATIC ${XRT_PCIE_WINDOWS_FILES})
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   target_compile_options(xrt_core_static PRIVATE /MTd)
 else()
   target_compile_options(xrt_core_static PRIVATE /MT)
 endif()
-
 
 target_link_libraries(
   xrt_core

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -24,7 +24,7 @@
 #include <map>
 
 
-const xrt_core::device_windows::IOCTLEntry & 
+const xrt_core::device_windows::IOCTLEntry &
 xrt_core::device_windows::
 get_IOCTL_entry( QueryRequest _eQueryRequest) const
 {
@@ -108,7 +108,7 @@ get_IOCTL_entry( QueryRequest _eQueryRequest) const
 
 
 
-void 
+void
 xrt_core::device_windows::
 query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_info & _typeInfo, boost::any &_returnValue) const
 {
@@ -128,7 +128,7 @@ query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_in
 
   // Removes compile warnings for unused variables
   _deviceID = _deviceID;
- 
+
   // Reference linux code:
 //  if (_typeInfo == typeid(std::string)) {
 //    // -- Typeid: std::string --
@@ -193,12 +193,12 @@ std::pair<uint64_t, uint64_t>
 xrt_core::device_windows::
 get_total_devices() const
 {
-  // Linux reference code: 
+  // Linux reference code:
   // return pcidev::get_dev_total();
-  return 0;
+  return std::make_pair(1,1); // TODO
 }
 
-void 
+void
 xrt_core::device_windows::
 read_device_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt) const
 {
@@ -229,7 +229,7 @@ read_device_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt) cons
 //      ptDMA.put( "c2h", unitConvert(devstat.c2h[index]) );
 //
 //      // Create our array of data
-//      ptChannels.push_back(std::make_pair("", ptDMA)); 
+//      ptChannels.push_back(std::make_pair("", ptDMA));
 //  }
 //
 //  _pt.add_child( "transfer_metrics.channels", ptChannels);

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -189,7 +189,7 @@ xrt_core::device_windows::
   // Do nothing
 }
 
-uint64_t 
+std::pair<uint64_t, uint64_t>
 xrt_core::device_windows::
 get_total_devices() const
 {

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -33,7 +33,8 @@ class device_windows : public device_pcie {
 
   protected:
     virtual void read_device_dma_stats(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
-    virtual uint64_t get_total_devices() const;
+
+    virtual std::pair<uint64_t, uint64_t> get_total_devices() const;
     virtual void query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_info & _typeInfo, boost::any &_returnValue) const;
 
   public:

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -804,6 +804,14 @@ done:
 
     return m_locked = true;
   }
+
+  bool
+  unlock_device()
+  {
+    m_locked = false;
+    return true;
+  }
+
 }; // struct shim
 
 shim*
@@ -1047,6 +1055,15 @@ xclLockDevice(xclDeviceHandle handle)
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclLockDevice()");
   auto shim = get_shim_object(handle);
   return shim->lock_device() ? 0 : 1;
+}
+
+int
+xclUnlockDevice(xclDeviceHandle handle)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclUnlockDevice()");
+  auto shim = get_shim_object(handle);
+  return shim->unlock_device() ? 0 : 1;
 }
 
 ssize_t

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -58,18 +58,18 @@ set(XBUTIL_V2_SRCS ${XBUTIL_V2_FILES_SRCS})
 add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
 
 
-if(WIN32) 
+if(WIN32)
   target_link_libraries(
-    ${XBUTIL2_NAME} PRIVATE 
-    Boost::filesystem 
-    Boost::program_options 
-    Boost::system 
+    ${XBUTIL2_NAME} PRIVATE
+    Boost::filesystem
+    Boost::program_options
+    Boost::system
     xrt_core
     xrt_core_static
     xrt_coreutil_static
   )
 
-  # Use the static version of the run-time library 
+  # Use the static version of the run-time library
   # Note: Needed to link with boost
   if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     target_compile_options(${XBUTIL2_NAME} PRIVATE /MTd)
@@ -78,12 +78,12 @@ if(WIN32)
   endif()
 else()
   target_link_libraries(
-    ${XBUTIL2_NAME} 
+    ${XBUTIL2_NAME}
     xrt_core_static
     xrt_coreutil_static
     boost_filesystem
     boost_system
-    boost_program_options 
+    boost_program_options
     uuid
     dl
   )
@@ -92,4 +92,3 @@ endif()
 install (TARGETS ${XBUTIL2_NAME} RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)
 
 # -----------------------------------------------------------------------------
-

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -20,12 +20,17 @@
 #include "XBUtilities.h"
 namespace XBU = XBUtilities;
 
+#include "xrt.h"
+#include "core/common/device_core.h"
+#include "core/common/error.h"
+
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <fstream>
 
 // ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
 #include "SubCmd.h"
@@ -36,7 +41,6 @@ static const unsigned int registerResult =
 // =============================================================================
 
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
-
 
 
 
@@ -53,7 +57,7 @@ int subCmdProgram(const std::vector<std::string> &_options)
   // -- Retrieve and parse the subcommand options -----------------------------
   uint64_t card = 0;
   uint64_t region = 0;
-  std::string sXclBin;
+  std::string xclbin;
   bool help = false;
 
   po::options_description programDesc("program options");
@@ -61,7 +65,7 @@ int subCmdProgram(const std::vector<std::string> &_options)
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
     (",d", boost::program_options::value<uint64_t>(&card), "Card to be examined")
     (",r", boost::program_options::value<uint64_t>(&region), "Card region")
-    (",p", boost::program_options::value<std::string>(&sXclBin), "The xclbin image to load")
+    (",p", boost::program_options::value<std::string>(&xclbin), "The xclbin image to load")
   ;
 
   // Parse sub-command ...
@@ -87,11 +91,35 @@ int subCmdProgram(const std::vector<std::string> &_options)
   // -- Now process the subcommand --------------------------------------------
   XBU::verbose(XBU::format("  Card: %ld", card));
   XBU::verbose(XBU::format("Region: %ld", region));
-  XBU::verbose(XBU::format("XclBin: %s", sXclBin.c_str()));
+  XBU::verbose(XBU::format("XclBin: %s", xclbin.c_str()));
 
+  if (region)
+    throw xrt_core::error("region is not supported");
 
-  XBU::error("COMMAND BODY NOT IMPLEMENTED.");
-  // TODO: Put working code here
+  std::ifstream stream(xclbin, std::ios::binary);
+  if (!stream)
+    throw std::runtime_error("could not open " + xclbin + " for reading");
+
+  stream.seekg(0,stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
+
+  std::vector<char> raw(size);
+  stream.read(raw.data(),size);
+
+  std::string v(raw.data(),raw.data()+7);
+  if (v != "xclbin2")
+    throw xrt_core::error("bad binary version '" + v + "'");
+
+  auto device = xrt_core::device_core::instance().get_device(card);
+  if (auto err = device.execute(xclLockDevice))
+    throw xrt_core::error(err, "Could not lock device " + std::to_string(card));
+  if (auto err = device.execute(xclLoadXclBin, (reinterpret_cast<const axlf*>(raw.data()))))
+    throw xrt_core::error(err,"Could not program device" + std::to_string(card));
+  if (auto err = device.execute(xclUnlockDevice))
+    throw xrt_core::error(err, "Could not unlock device " + std::to_string(card));
+
+  std::cout << "INFO: xbutil2 program succeeded.\n";
 
   return registerResult;
 }

--- a/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
@@ -38,7 +38,7 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
   _pt.clear();  
 
   // Get the handle to the devices
-  const xrt_core::device_core &CoreDevice = xrt_core::device_core::get_handle();
+  const xrt_core::device_core &CoreDevice = xrt_core::device_core::instance();
 
   // Get a collection of the devices present
   CoreDevice.get_devices(_pt);

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -965,7 +965,7 @@ loadDevices(UnaryPredicate pred)
     if (pred(hal->getDriverLibraryName()))
       devices.emplace_back(std::move(hal));
   }
-  return std::move(devices);
+  return devices;
 }
 
 /**


### PR DESCRIPTION
Add support for xbutil2 program.  

- Leave implementation at subcmd level facilitated by some additions and changes  of existing support code.  

- Introduce embedded device class under xrt_core::device_core::device (aka xbutil::device) for xbutil commands that operate on a specific device. 

Some changes in this PR are WIP and TBD until more commands are implemented and functional requirements are encountered.