### PR TITLE
enable cmc mutex handshake for ulp new feature resources

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -547,6 +547,18 @@ int xclmgmt_program_shell(struct xclmgmt_dev *lro)
 
 	xocl_thread_stop(lro);
 
+	/*
+	 * cmc has its own freeze operation, once ert is also enabled, we need
+	 * refactor code to a register design pattern, the freeze operation
+	 * will loop all registerred module and freeze them one by one, for
+	 * example: cmc, ert, etc.
+	 */
+	ret = xocl_cmc_freeze(lro);
+	if (ret) {
+		mgmt_err(lro, "release CMC access failed %d", ret);
+		goto failed;
+	}
+
 	xocl_mb_stop(lro);
 
 	ret = xocl_subdev_destroy_prp(lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -547,18 +547,6 @@ int xclmgmt_program_shell(struct xclmgmt_dev *lro)
 
 	xocl_thread_stop(lro);
 
-	/*
-	 * cmc has its own freeze operation, once ert is also enabled, we need
-	 * refactor code to a register design pattern, the freeze operation
-	 * will loop all registerred module and freeze them one by one, for
-	 * example: cmc, ert, etc.
-	 */
-	ret = xocl_cmc_freeze(lro);
-	if (ret) {
-		mgmt_err(lro, "release CMC access failed %d", ret);
-		goto failed;
-	}
-
 	xocl_mb_stop(lro);
 
 	ret = xocl_subdev_destroy_prp(lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2298,6 +2298,10 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 	ICAP_INFO(icap, "incoming xclbin: %pUb\non device xclbin: %pUb",
 		&xclbin->m_header.uuid, &icap->icap_bitstream_uuid);
 
+	err = xocl_cmc_freeze(xdev);
+	if (err)
+		goto done;
+
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 	icap_refresh_addrs(pdev);
 
@@ -2356,6 +2360,9 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 			reg_wr(icap->icap_ucs_control + 8, 1);
 		}
 	}
+
+	if (ICAP_PRIVILEGED(icap))
+		err = xocl_cmc_free(xdev);
 
 done:
 	if (err) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -89,6 +89,7 @@
 #define	XMC_HOST_MSG_OFFSET_REG		0x300
 #define	XMC_HOST_MSG_ERROR_REG		0x304
 #define	XMC_HOST_MSG_HEADER_REG		0x308
+#define	XMC_HOST_NEW_FEATURE_REG1	0xB20
 
 #define	VALID_ID			0x74736574
 
@@ -2260,6 +2261,93 @@ static void xmc_clk_scale_config(struct platform_device *pdev)
 static int xmc_dynamic_region_free(struct platform_device *pdev);
 static int xmc_dynamic_region_freeze(struct platform_device *pdev);
 
+/*
+ * flags can be 1: Grant access (free)
+ *              0: Release access (freeze)
+ */
+static int cmc_access_ops(struct platform_device *pdev, int flags)
+{
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	struct xocl_xmc *xmc = platform_get_drvdata(pdev);
+	u32 val, grant, ack;
+	int retry;
+	int err = 0;
+
+	if (flags == 1) {
+#if 1
+		/*
+		 * for grant access (flags = 1), we are looking for new
+		 * features, if no new features, skip the grant operation
+		 */
+		err = xocl_iores_read32(xdev, XOCL_SUBDEV_LEVEL_URP,
+		    IORES_GAPPING, 0x0, &val);
+		if (err) {
+			if (err == -ENODEV) {
+				xocl_xdev_info(xdev, "No %s resource, skip.",
+				    NODE_GAPPING);
+				return 0;
+			}
+			return err;
+		}
+#else
+		/* test only before xclbin has correct metadata */
+		val = 0x1001000; //hard code ep_gapping_demand_00
+#endif
+		/*
+		 * Dancing with CMC here:
+		 * 0-24 bit is address read from xclbin
+		 * 28 is flag for enable
+		 * 29 is flag for present
+		 */
+		WRITE_REG32(xmc, val & 0x01FFFFFF, XMC_HOST_NEW_FEATURE_REG1);
+		WRITE_REG32(xmc,
+		    (1<<28) | (1<<29), XMC_HOST_NEW_FEATURE_REG1);
+	}
+
+	grant = (u32)flags & 0x1;
+	err = xocl_iores_write32(xdev, XOCL_SUBDEV_LEVEL_BLD, IORES_CMC_MUTEX,
+	    0x0, grant);
+	if (err) {
+		if (err == -ENODEV) {
+			xocl_xdev_info(xdev, "No %s resource, skip.",
+			    NODE_CMC_MUTEX);
+			return 0;
+		}
+		return err;
+	}
+
+	for (retry = 0; retry < 100; retry++) {
+		err = xocl_iores_read32(xdev, XOCL_SUBDEV_LEVEL_BLD,
+		    IORES_CMC_MUTEX, 0x8, &ack);
+		if (err) {
+			if (err == -ENODEV)
+				xocl_xdev_info(xdev, "No %s resource, skip.",
+				    NODE_CMC_MUTEX);
+			else
+				xocl_xdev_err(xdev, "Read ack from %s failed",
+				    NODE_CMC_MUTEX);
+			goto fail;
+		}
+
+		if ((grant & 0x1) == (ack & 0x1))
+			break;
+
+		msleep(100);
+	}
+
+	if ((grant & 0x1) != (ack & 0x1)) {
+		xocl_xdev_err(xdev,
+		    "Grant falied. The bit 0 in Ack (0x%x) is not the same "
+		    "in grant (0x%x)", ack, grant);
+		err = -EBUSY;
+		goto fail;
+	}
+
+	xocl_xdev_info(xdev, "%s CMC succeeded.", flags ? "Grant" : "Release");
+fail:
+	return err;
+}
+
 static struct xocl_mb_funcs xmc_ops = {
 	.load_mgmt_image	= load_mgmt_image,
 	.load_sche_image	= load_sche_image,
@@ -2268,6 +2356,7 @@ static struct xocl_mb_funcs xmc_ops = {
 	.get_data		= xmc_get_data,
 	.dr_freeze          	= xmc_dynamic_region_freeze,
 	.dr_free         	= xmc_dynamic_region_free,
+	.cmc_access              = cmc_access_ops,
 };
 
 static void xmc_unload_board_info(struct xocl_xmc *xmc)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -704,6 +704,7 @@ struct xocl_mb_funcs {
 	int (*get_data)(struct platform_device *pdev, enum xcl_group_kind kind, void *buf);
 	int (*dr_freeze)(struct platform_device *pdev);
 	int (*dr_free)(struct platform_device *pdev);
+	int (*cmc_access)(struct platform_device *pdev, int flags);
 };
 
 #define	MB_DEV(xdev)		\
@@ -733,6 +734,12 @@ struct xocl_mb_funcs {
 	(MB_CB(xdev, dr_freeze) ? MB_OPS(xdev)->dr_freeze(MB_DEV(xdev)) : -ENODEV)
 #define xocl_xmc_dr_free(xdev)		\
 	(MB_CB(xdev, dr_free) ? MB_OPS(xdev)->dr_free(MB_DEV(xdev)) : -ENODEV)
+
+#define xocl_cmc_free(xdev) 		\
+	(MB_CB(xdev, cmc_access) ? MB_OPS(xdev)->cmc_access(MB_DEV(xdev), 1) : -ENODEV)
+#define xocl_cmc_freeze(xdev)		\
+	(MB_CB(xdev, cmc_access) ? MB_OPS(xdev)->cmc_access(MB_DEV(xdev), 0) : -ENODEV)
+
 
 /* processor system callbacks */
 struct xocl_ps_funcs {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -322,6 +322,7 @@ static struct xocl_subdev_map		subdev_map[] = {
 			RESNAME_CLKFREQ_K2,
 			RESNAME_CLKFREQ_HBM,
 			RESNAME_UCS_CONTROL,
+			RESNAME_GAPPING,
 			NULL
 		},
 		1,
@@ -340,6 +341,7 @@ static struct xocl_subdev_map		subdev_map[] = {
 			RESNAME_CLKWIZKERNEL3,
 			RESNAME_KDMA,
 			RESNAME_CLKSHUTDOWN,
+			RESNAME_CMC_MUTEX,
 			NULL
 		},
 		1,
@@ -837,6 +839,9 @@ int xocl_fdt_check_uuids(xdev_handle_t xdev_hdl, const void *blob,
 	const char *subset_int_uuid = NULL;
 	const char *int_uuid = NULL;
 	int offset, subset_offset;
+
+	// comment this out for debugging xclbin download only
+	//return 0;
 
 	if (!blob || !subset_blob) {
 		xocl_xdev_err(xdev_hdl, "blob is NULL");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -49,6 +49,7 @@
 #define NODE_AF_DATA_H2C "ep_firewall_data_h2c_00"
 #define NODE_CMC_REG "ep_cmc_regmap_00"
 #define NODE_CMC_RESET "ep_cmc_reset_00"
+#define NODE_CMC_MUTEX "ep_cmc_mutex_00"
 #define NODE_CMC_FW_MEM "ep_cmc_firmware_mem_00"
 #define NODE_ERT_FW_MEM "ep_ert_firmware_mem_00"
 #define NODE_ERT_CQ_MGMT "ep_ert_command_queue_mgmt_00"
@@ -73,6 +74,7 @@
 #define NODE_CLKFREQ_K2 "ep_freq_cnt_aclk_kernel_01"
 #define NODE_CLKFREQ_HBM "ep_freq_cnt_aclk_hbm_00"
 #define NODE_UCS_CONTROL "ep_ucs_control_status_00"
+#define NODE_GAPPING "ep_gapping_demand_00"
 
 enum {
 	IORES_GATEPRBLD,
@@ -88,6 +90,8 @@ enum {
 	IORES_KDMA,
 	IORES_CLKSHUTDOWN,
 	IORES_UCS_CONTROL,
+	IORES_CMC_MUTEX,
+	IORES_GAPPING,
 	IORES_MAX,
 };
 
@@ -104,6 +108,8 @@ enum {
 #define RESNAME_KDMA            NODE_KDMA_CTRL
 #define RESNAME_CLKSHUTDOWN	NODE_CLK_SHUTDOWN
 #define RESNAME_UCS_CONTROL     NODE_UCS_CONTROL
+#define RESNAME_CMC_MUTEX       NODE_CMC_MUTEX
+#define RESNAME_GAPPING         NODE_GAPPING
 
 struct xocl_iores_map {
 	char		*res_name;
@@ -125,6 +131,8 @@ struct xocl_iores_map map[] = {                                         \
 	{ RESNAME_KDMA, IORES_KDMA },                                   \
 	{ RESNAME_CLKSHUTDOWN, IORES_CLKSHUTDOWN },			\
 	{ RESNAME_UCS_CONTROL, IORES_UCS_CONTROL},			\
+	{ RESNAME_CMC_MUTEX, IORES_CMC_MUTEX},				\
+	{ RESNAME_GAPPING, IORES_GAPPING},				\
 }
 
 #endif


### PR DESCRIPTION
This is the effort for enabling extra handshake for u50 1rp blp, we will need to interact with CMC by extra operations, say CMC Release and CMC Grant.
The CMC Release is needed prior to download BLP/PLP/ULP, it will set and then get response from CMC so that CMC is in status for downloading new dsabin or xsabin.

The CMC Grant is needed after download ULP only. It will tell CMC if there is new features bring up after the xclbin download, CMC should acknowledge by setting ack.

Unit Test:
1) factory reset, flash for regular xdma u50 shell and new 1rp_blp u50 shell;
2) verified xbmgmt program on both xdma u50 (download successfully) and 1rp_blp_u50 (CR http://jira.xilinx.com/browse/CR-1049207).