### PR TITLE
Add feature ROM and mgmt function on versal

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -248,6 +248,23 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM),	\
 	}
 
+#define	XOCL_RES_FEATURE_ROM_VERSAL			\
+		((struct resource []) {			\
+			{				\
+			.start	= 0x6000000,		\
+			.end	= 0x600FFFF,		\
+			.flags	= IORESOURCE_MEM,	\
+			}				\
+		})
+
+#define	XOCL_DEVINFO_FEATURE_ROM_VERSAL			\
+	{						\
+		XOCL_SUBDEV_FEATURE_ROM,		\
+		XOCL_FEATURE_ROM,			\
+		XOCL_RES_FEATURE_ROM_VERSAL,		\
+		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_VERSAL),	\
+	}
+
 
 #define	XOCL_RES_FEATURE_ROM_SMARTN			\
 		((struct resource []) {			\
@@ -1083,6 +1100,7 @@ struct xocl_subdev_map {
 
 #define	USER_RES_XDMA_VERSAL						\
 		((struct xocl_subdev_info []) {				\
+		 	XOCL_DEVINFO_FEATURE_ROM_VERSAL,		\
 			XOCL_DEVINFO_XDMA,				\
 		 	XOCL_DEVINFO_SCHEDULER_VERSAL,			\
 		 	XOCL_DEVINFO_MAILBOX_USER_VERSAL,		\
@@ -1199,6 +1217,11 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_FMGR,		        	\
 		})
 
+#define	MGMT_RES_VERSAL							\
+		((struct xocl_subdev_info []) {				\
+		 	XOCL_DEVINFO_FEATURE_ROM_VERSAL,		\
+		})
+
 #define	MGMT_RES_DSA50							\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
@@ -1251,6 +1274,13 @@ struct xocl_subdev_map {
 		.subdev_info	= MGMT_RES_U2,				\
 		.subdev_num = ARRAY_SIZE(MGMT_RES_U2),			\
 		.flash_type = FLASH_TYPE_SPI,				\
+	}
+
+#define	XOCL_BOARD_MGMT_VERSAL						\
+	(struct xocl_board_private){					\
+		.flags		= XOCL_DSAFLAG_VERSAL,			\
+		.subdev_info	= MGMT_RES_VERSAL,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_VERSAL),		\
 	}
 
 #define	MGMT_RES_6A8F							\
@@ -2013,6 +2043,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5008, PCI_ANY_ID, MGMT_XBB_DSA52_U280) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x500C, PCI_ANY_ID, MGMT_XBB_DSA52_U280) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5020, PCI_ANY_ID, MGMT_U50) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5028, PCI_ANY_ID, MGMT_VERSAL) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x006C, PCI_ANY_ID, MGMT_6A8F) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0078, PCI_ANY_ID, MGMT_XBB_DSA52) },  \
 	{ XOCL_PCI_DEVID(0x10EE, 0xD000, PCI_ANY_ID, XBB_MFG("u200")) },\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -3629,15 +3629,18 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 	rv = probe_engines(xdev);
 	if (rv)
 		goto err_engines;
-	/* re-determine user_max */
-	xdev->user_max = min(xdev->user_max, pci_msix_vec_count(pdev) -
-			xdev->c2h_channel_max - xdev->h2c_channel_max);
-	if (xdev->user_max < 0) {
-		rv = -EINVAL;
-		pr_err("Invalid number of interrupts. pci %d, h2c %d, c2h %d",
-			pci_msix_vec_count(pdev), xdev->h2c_channel_max,
-			xdev->c2h_channel_max);
-		goto err_enable_msix;
+	if (!(XOCL_DSA_IS_VERSAL(xcldev))) {
+		/* re-determine user_max */
+		xdev->user_max = min(xdev->user_max, pci_msix_vec_count(pdev) -
+				xdev->c2h_channel_max - xdev->h2c_channel_max);
+		if (xdev->user_max < 0) {
+			rv = -EINVAL;
+			pr_err("Invalid number of interrupts. "
+				"pci %d, h2c %d, c2h %d",
+				pci_msix_vec_count(pdev), xdev->h2c_channel_max,
+				xdev->c2h_channel_max);
+			goto err_enable_msix;
+		}
 	}
 
 	rv = enable_msi_msix(xdev, pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -211,10 +211,6 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 	if (type == XOCL_BO_EXECBUF || type == XOCL_BO_IMPORT)
 		return 0;
 
-	if (XOCL_DSA_IS_VERSAL(xdev))
-		/* Bypass checking bo user reqs for now */
-		return 0;
-
 	//From "mem_topology" or "feature rom" depending on
 	//unified or non-unified dsa
 	ddr_count = XOCL_DDR_COUNT(xdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -300,7 +300,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	void *ulp_blob;
 	int rc;
 
-	if (!XOCL_DSA_IS_VERSAL(xdev) && !xocl_is_unified(xdev)) {
+	if (!xocl_is_unified(xdev)) {
 		userpf_err(xdev, "XOCL: not unified Shell\n");
 		return -EINVAL;
 	}


### PR DESCRIPTION
This PR included the following enahncement and bug fixes on versal
1. Add xclmgmt driver 
2. Add featuro ROM subdriver
3. fix an xdma issue on versal, where interrupt is not supported yet.