### PR TITLE
xbutil2: Add support for query|scan|dmatest sub commands

### DIFF
--- a/src/runtime_src/core/common/device_core.cpp
+++ b/src/runtime_src/core/common/device_core.cpp
@@ -395,25 +395,18 @@ device_core::read_device_firewall(uint64_t _deviceID, boost::property_tree::ptre
   query_device_and_put(_deviceID, QR_FIREWALL_TIME_SEC, _pt);
 }
 
-//TODO: dmatest
 size_t
 xrt_core::device_core::get_ddr_mem_size(uint64_t _deviceID) const
 {
-  std::string errmsg;
-  uint64_t ddr_size = 0;
-  uint64_t ddr_bank_count = 0;
   boost::property_tree::ptree _pt;
 
   query_device_and_put(_deviceID, OR_ROM_DDR_BANK_SIZE, _pt);
   query_device_and_put(_deviceID, QR_ROM_DDR_BANK_COUNT_MAX, _pt);
 
-  std::string s;
-  s = _pt.get<std::string>("ddr_size_bytes", "N/A");
-  //std::cout << "get_ddr_mem_size(): ddr_size: " << s << std::endl;
-  ddr_size = strtoull(s.c_str(), nullptr, 16);
+  auto s = _pt.get<std::string>("ddr_size_bytes", "N/A");
+  auto ddr_size = strtoull(s.c_str(), nullptr, 16);
   s = _pt.get<std::string>("widdr_countdth", "N/A");
-  //std::cout << "get_ddr_mem_size(): ddr_bank_count: " << s << std::endl;
-  ddr_bank_count = strtoull(s.c_str(), nullptr, 16);
+  auto ddr_bank_count = strtoull(s.c_str(), nullptr, 16);
 
   return (ddr_size * ddr_bank_count) / (1024 * 1024);
 }

--- a/src/runtime_src/core/common/device_core.cpp
+++ b/src/runtime_src/core/common/device_core.cpp
@@ -45,6 +45,7 @@ std::map<device_core::QueryRequest, device_core::QueryRequestEntry> device_core:
   { OR_ROM_DDR_BANK_SIZE,         { "OR_ROM_DDR_BANK_SIZE",         "ddr_size_bytes",   &typeid(uint64_t),    device_core::format_hex_base2_shiftup30 }},
   { QR_ROM_DDR_BANK_COUNT_MAX,    { "QR_ROM_DDR_BANK_COUNT_MAX",    "widdr_countdth",   &typeid(uint64_t),    device_core::format_primative }},
   { QR_ROM_FPGA_NAME,             { "QR_ROM_FPGA_NAME",             "fpga_name",        &typeid(std::string), device_core::format_primative }},
+  { QR_ROM_TIME_SINCE_EPOCH,      { "QR_ROM_TIME_SINCE_EPOCH",      "time_since_epoch", &typeid(uint64_t),    device_core::format_primative }},
   { QR_DMA_THREADS_RAW,           { "QR_DMA_THREADS_RAW",           "dma_threads",      &typeid(std::vector<std::string>),  device_core::format_primative }},
 
   { QR_XMC_VERSION,               { "QR_XMC_VERSION",               "xmc_version",      &typeid(std::string),  device_core::format_primative }},
@@ -291,6 +292,7 @@ device_core::get_device_rom_info(uint64_t _deviceID, boost::property_tree::ptree
   query_device_and_put(_deviceID, OR_ROM_DDR_BANK_SIZE, _pt);
   query_device_and_put(_deviceID, QR_ROM_DDR_BANK_COUNT_MAX, _pt);
   query_device_and_put(_deviceID, QR_ROM_FPGA_NAME, _pt);
+  query_device_and_put(_deviceID, QR_ROM_TIME_SINCE_EPOCH, _pt);
 }
 
 void

--- a/src/runtime_src/core/common/device_core.h
+++ b/src/runtime_src/core/common/device_core.h
@@ -28,7 +28,6 @@
 #include <list>
 #include <map>
 #include <boost/any.hpp>
-#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
 
 namespace xrt_core {
 
@@ -203,10 +202,10 @@ class device_core {
     } QueryRequest;
 
     virtual void query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_info & _typeInfo, boost::any &_returnValue) const = 0;
-    virtual void get_IpLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size) const = 0;
-    virtual DWORD get_IpLayoutSize(uint64_t _deviceID) const = 0;
-    virtual void get_memTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo) const = 0;
-    virtual void get_memRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw) const = 0;
+    virtual void get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size) const = 0;
+    virtual DWORD get_ip_layoutsize(uint64_t _deviceID) const = 0;
+    virtual void get_mem_topology(uint64_t _deviceID, struct mem_topology *topoInfo) const = 0;
+    virtual void get_mem_rawinfo(uint64_t _deviceID, struct mem_raw_info *memRaw) const = 0;
 
   // Helper methods
   protected:

--- a/src/runtime_src/core/common/device_core.h
+++ b/src/runtime_src/core/common/device_core.h
@@ -140,6 +140,7 @@ class device_core {
       OR_ROM_DDR_BANK_SIZE,
       QR_ROM_DDR_BANK_COUNT_MAX,
       QR_ROM_FPGA_NAME,
+      QR_ROM_TIME_SINCE_EPOCH,
 
       QR_XMC_VERSION,
       QR_XMC_SERIAL_NUM,

--- a/src/runtime_src/core/common/device_core.h
+++ b/src/runtime_src/core/common/device_core.h
@@ -203,8 +203,8 @@ class device_core {
     } QueryRequest;
 
     virtual void query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_info & _typeInfo, boost::any &_returnValue) const = 0;
-    virtual void get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size) const = 0;
-    virtual DWORD get_ip_layoutsize(uint64_t _deviceID) const = 0;
+    virtual void get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, unsigned long size) const = 0;
+    virtual unsigned long get_ip_layoutsize(uint64_t _deviceID) const = 0;
     virtual void get_mem_topology(uint64_t _deviceID, struct mem_topology *topoInfo) const = 0;
     virtual void get_mem_rawinfo(uint64_t _deviceID, struct mem_raw_info *memRaw) const = 0;
 

--- a/src/runtime_src/core/common/device_core.h
+++ b/src/runtime_src/core/common/device_core.h
@@ -28,6 +28,7 @@
 #include <list>
 #include <map>
 #include <boost/any.hpp>
+#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
 
 namespace xrt_core {
 
@@ -72,6 +73,7 @@ class device_core {
     void read_device_electrical(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
     void read_device_power(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
     void read_device_firewall(uint64_t _deviceID, boost::property_tree::ptree &_pt) const;
+    size_t get_ddr_mem_size(uint64_t _deviceID) const;
 
   public:
 
@@ -131,6 +133,7 @@ class device_core {
       QR_PCIE_SUBSYSTEM_ID,
       QR_PCIE_LINK_SPEED,
       QR_PCIE_EXPRESS_LANE_WIDTH,
+      QR_PCIE_READY_STATUS,
 
       QR_DMA_THREADS_RAW,
 
@@ -200,6 +203,10 @@ class device_core {
     } QueryRequest;
 
     virtual void query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_info & _typeInfo, boost::any &_returnValue) const = 0;
+    virtual void get_IpLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size) const = 0;
+    virtual DWORD get_IpLayoutSize(uint64_t _deviceID) const = 0;
+    virtual void get_memTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo) const = 0;
+    virtual void get_memRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw) const = 0;
 
   // Helper methods
   protected:

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -38,6 +38,8 @@
 #ifndef _XCLBIN_H_
 #define _XCLBIN_H_
 
+#define MAX_DDR_BANKS    4
+
 #ifdef _WIN32
   #include <cstdint>
   #include <algorithm>
@@ -233,8 +235,19 @@ extern "C" {
 
     struct mem_topology {
         int32_t m_count; //Number of mem_data
-        struct mem_data m_mem_data[1]; //Should be sorted on mem_type
+        struct mem_data m_mem_data[MAX_DDR_BANKS]; //Should be sorted on mem_type
     };
+
+    // XoclStatMemRaw
+	struct mem_raw {
+		uint64_t MemoryUsage;
+		uint64_t BOCount;
+	};
+
+	struct mem_raw_info {
+		unsigned long MemRawCount;
+		struct mem_raw MemRaw[MAX_DDR_BANKS];
+	};
 
     /****   CONNECTIVITY SECTION ****/
     /* Connectivity of each argument of Kernel. It will be in terms of argument

--- a/src/runtime_src/core/pcie/common/device_pcie.cpp
+++ b/src/runtime_src/core/pcie/common/device_pcie.cpp
@@ -68,6 +68,7 @@ xrt_core::device_pcie::get_device_info(uint64_t _deviceID, boost::property_tree:
   query_device_and_put(_deviceID, QR_PCIE_DEVICE, _pt);
   query_device_and_put(_deviceID, QR_PCIE_SUBSYSTEM_VENDOR, _pt);
   query_device_and_put(_deviceID, QR_PCIE_SUBSYSTEM_ID, _pt);
+  query_device_and_put(_deviceID, QR_PCIE_READY_STATUS, _pt);
   query_device_and_put(_deviceID, QR_PCIE_LINK_SPEED, _pt);
   query_device_and_put(_deviceID, QR_PCIE_EXPRESS_LANE_WIDTH, _pt);
   query_device_and_put(_deviceID, QR_DMA_THREADS_RAW, _pt);

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -54,7 +54,7 @@ namespace xcldev {
                           xclBOSyncDirection dir) const {
             int result = 0;
             while (b < e) {
-                result = xclSyncBO(mHandle, *b, dir, mSize, 0);
+                result = xclSyncBO(mHandle, UIntToPtr(*b), dir, mSize, 0);
                 if (result != 0)
                     break;
                 ++b;
@@ -85,7 +85,7 @@ namespace xcldev {
                 count = 0x40000;
 
             for (long long i = 0; i < count; i++) {
-                unsigned bo = xclAllocBO(mHandle, mSize, 0, mFlags);
+                unsigned bo = (PtrToUint)(xclAllocBO(mHandle, mSize, 0, mFlags));
                 if (bo == 0xffffffff)
                     break;
                 mBOList.push_back(bo);
@@ -98,7 +98,7 @@ namespace xcldev {
 
         ~DMARunner() {
             for (auto i : mBOList)
-                xclFreeBO(mHandle, i);
+                xclFreeBO(mHandle, UIntToPtr(i));
         }
 
         int validate(const char *buf) const {
@@ -107,7 +107,7 @@ namespace xcldev {
             for (auto i : mBOList) {
                 //Clear out the host buffer
                 std::memset(bufCmp.get(), 0, mSize);
-                result = xclReadBO(mHandle, i, bufCmp.get(), mSize, 0);
+                result = (int)xclReadBO(mHandle, UIntToPtr(i), bufCmp.get(), mSize, 0);
                 if (result < 0)
                     break;
                 if (std::memcmp(buf, bufCmp.get(), mSize)) {
@@ -125,15 +125,15 @@ namespace xcldev {
 
             int result = 0;
             for (auto i : mBOList)
-                result += xclWriteBO(mHandle, i, buf.get(), mSize, 0);
+                result += (int)xclWriteBO(mHandle, UIntToPtr(i), buf.get(), mSize, 0);
 
             if (result)
                 return result;
 
             Timer timer;
             result = runSync(XCL_BO_SYNC_BO_TO_DEVICE, true);
-            double timer_stop = timer.stop();
-            double rate = mBOList.size() * mSize;
+            double timer_stop = (double)timer.stop();
+            double rate = (double)(mBOList.size() * mSize);
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; // s
@@ -141,8 +141,8 @@ namespace xcldev {
 
             timer.reset();
             result += runSync(XCL_BO_SYNC_BO_FROM_DEVICE, true);
-            timer_stop = timer.stop();
-            rate = mBOList.size() * mSize;
+            timer_stop = (double)timer.stop();
+            rate = (double)(mBOList.size() * mSize);
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; //

--- a/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
@@ -190,6 +190,7 @@ typedef struct _XOCL_ROM_INFORMATION {
     UCHAR VBNVName[64];
     uint8_t DDRChannelCount;
     uint8_t DDRChannelSize;
+    uint64_t TimeSinceEpoch;
 } XOCL_ROM_INFORMATION, *PXOCL_ROM_INFORMATION;
 
 

--- a/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
@@ -185,6 +185,14 @@ typedef struct _XOCL_MAP_BAR_RESULT {
     ULONG       BarLength;     // OUT: Length of mapped buffer
 } XOCL_MAP_BAR_RESULT, *PXOCL_MAP_BAR_RESULT;
 
+typedef struct _XOCL_ROM_INFORMATION {
+    UCHAR FPGAPartName[64];
+    UCHAR VBNVName[64];
+    uint8_t DDRChannelCount;
+    uint8_t DDRChannelSize;
+} XOCL_ROM_INFORMATION, *PXOCL_ROM_INFORMATION;
+
+
 //
 // IOCTL_XOCL_STAT
 //
@@ -201,7 +209,7 @@ typedef enum _XOCL_STAT_CLASS {
     XoclStatIpLayout,
     XoclStatKds,
     XoclStatKdsCU,
-
+    XoclStatRomInfo
 } XOCL_STAT_CLASS, *PXOCL_STAT_CLASS;
 
 typedef struct _XOCL_STAT_CLASS_ARGS {
@@ -222,6 +230,7 @@ typedef struct _XOCL_DEVICE_INFORMATION {
     ULONG  DmaEngineVersion;
     ULONG  DriverVersion;
     ULONG  PciSlot;
+    bool ready;
 
 } XOCL_DEVICE_INFORMATION, *PXOCL_DEVICE_INFORMATION;
 #if 0

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -269,28 +269,28 @@ update_SC(uint64_t _deviceID, std::string& file) const
 }
 DWORD
 xrt_core::device_windows::
-get_IpLayoutSize(uint64_t _deviceID) const
+get_ip_layoutsize(uint64_t _deviceID) const
 {
-  return shim_getIPLayoutSize(_deviceID);
+  return shim_get_ip_layoutsize(_deviceID);
 }
 
 void
 xrt_core::device_windows::
-get_IpLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size) const
+get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size) const
 {
-  shim_getIPLayout(_deviceID, ipLayout, size);
+  shim_get_ip_layout(_deviceID, ipLayout, size);
 }
 
 void
 xrt_core::device_windows::
-get_memTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo) const
+get_mem_topology(uint64_t _deviceID, struct mem_topology *topoInfo) const
 {
-  shim_getMemTopology(_deviceID, topoInfo);
+  shim_get_mem_topology(_deviceID, topoInfo);
 }
 
 void
 xrt_core::device_windows::
-get_memRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw) const
+get_mem_rawinfo(uint64_t _deviceID, struct mem_raw_info *memRaw) const
 {
-  shim_getMemRawInfo(_deviceID, memRaw);
+  shim_get_mem_rawinfo(_deviceID, memRaw);
 }

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -164,10 +164,10 @@ std::pair<uint64_t, uint64_t>
 xrt_core::device_windows::
 get_total_devices() const
 {
-  uint64_t user_count = xclProbe();
+  auto user_count = xclProbe();
 
   //TODO: Getting ready status of devices.
-  const IOCTLEntry & entry = get_IOCTL_entry(QR_PCIE_READY_STATUS);
+  const auto& entry = get_IOCTL_entry(QR_PCIE_READY_STATUS);
   uint64_t ready_count = 0;
   boost::any anyValue;
 

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -268,7 +268,8 @@ update_SC(uint64_t _deviceID, std::string& file) const
   _deviceID = _deviceID;
   file = file;
 }
-DWORD
+
+unsigned long
 xrt_core::device_windows::
 get_ip_layoutsize(uint64_t _deviceID) const
 {
@@ -277,7 +278,7 @@ get_ip_layoutsize(uint64_t _deviceID) const
 
 void
 xrt_core::device_windows::
-get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size) const
+get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, unsigned long size) const
 {
   shim_get_ip_layout(_deviceID, ipLayout, size);
 }

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -48,6 +48,7 @@ get_IOCTL_entry( QueryRequest _eQueryRequest) const
 	{ OR_ROM_DDR_BANK_SIZE,         {rom,  ddr_bank_size}},
 	{ QR_ROM_DDR_BANK_COUNT_MAX,    {rom,  ddr_bank_count_max}},
 	{ QR_ROM_FPGA_NAME,             {rom,  FPGA}},
+	{ QR_ROM_TIME_SINCE_EPOCH,      {rom,  time_since_epoch}},
 	{ QR_XMC_VERSION,               {xmc,  version}},
 	{ QR_XMC_SERIAL_NUM,            {xmc,  serial_num}},
 	{ QR_XMC_MAX_POWER,             {xmc,  max_power}},

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -18,11 +18,14 @@
 #define INITGUID
 #include "device_windows.h"
 #include "common/utils.h"
-#include "xrt.h"
+#include "shim.h"
 #include "boost/format.hpp"
 #include <string>
 #include <iostream>
 #include <map>
+#include <fstream>
+
+#include <setupapi.h>
 
 #pragma warning(disable : 4100 4996)
 
@@ -33,69 +36,70 @@ get_IOCTL_entry( QueryRequest _eQueryRequest) const
   // Initialize our lookup table
   static const std::map<QueryRequest, IOCTLEntry> QueryRequestToIOCTLTable =
   {
-    { QR_PCIE_VENDOR,               { 0 }},
-    { QR_PCIE_DEVICE,               { 0 }},
-    { QR_PCIE_SUBSYSTEM_VENDOR,     { 0 }},
-    { QR_PCIE_SUBSYSTEM_ID,         { 0 }},
-    { QR_PCIE_LINK_SPEED,           { 0 }},
-    { QR_PCIE_EXPRESS_LANE_WIDTH,   { 0 }},
-    { QR_DMA_THREADS_RAW,           { 0 }},
-    { QR_ROM_VBNV,                  { 0 }},
-    { OR_ROM_DDR_BANK_SIZE,         { 0 }},
-    { QR_ROM_DDR_BANK_COUNT_MAX,    { 0 }},
-    { QR_ROM_FPGA_NAME,             { 0 }},
-    { QR_XMC_VERSION,               { 0 }},
-    { QR_XMC_SERIAL_NUM,            { 0 }},
-    { QR_XMC_MAX_POWER,             { 0 }},
-    { QR_XMC_BMC_VERSION,           { 0 }},
-    { QR_DNA_SERIAL_NUM,            { 0 }},
-    { QR_CLOCK_FREQS,               { 0 }},
-    { QR_IDCODE,                    { 0 }},
-    { QR_STATUS_MIG_CALIBRATED,     { 0 }},
-    { QR_STATUS_P2P_ENABLED,        { 0 }},
-    { QR_TEMP_CARD_TOP_FRONT,       { 0 }},
-    { QR_TEMP_CARD_TOP_REAR,        { 0 }},
-    { QR_TEMP_CARD_BOTTOM_FRONT,    { 0 }},
-    { QR_TEMP_FPGA,                 { 0 }},
-    { QR_FAN_TRIGGER_CRITICAL_TEMP, { 0 }},
-    { QR_FAN_FAN_PRESENCE,          { 0 }},
-    { QR_FAN_SPEED_RPM,             { 0 }},
-    { QR_CAGE_TEMP_0,               { 0 }},
-    { QR_CAGE_TEMP_1,               { 0 }},
-    { QR_CAGE_TEMP_2,               { 0 }},
-    { QR_CAGE_TEMP_3,               { 0 }},
-    { QR_12V_PEX_MILLIVOLTS,        { 0 }},
-    { QR_12V_PEX_MILLIAMPS,         { 0 }},
-    { QR_12V_AUX_MILLIVOLTS,        { 0 }},
-    { QR_12V_AUX_MILLIAMPS,         { 0 }},
-    { QR_3V3_PEX_MILLIVOLTS,        { 0 }},
-    { QR_3V3_AUX_MILLIVOLTS,        { 0 }},
-    { QR_DDR_VPP_BOTTOM_MILLIVOLTS, { 0 }},
-    { QR_DDR_VPP_TOP_MILLIVOLTS,    { 0 }},
+	{ QR_PCIE_VENDOR,               {pcie,   vendor}},
+	{ QR_PCIE_DEVICE,               {pcie,   pcie_device}},
+	{ QR_PCIE_SUBSYSTEM_VENDOR,     {pcie,   subsystem_vendor}},
+	{ QR_PCIE_SUBSYSTEM_ID,         {pcie,   subsystem_device}},
+	{ QR_PCIE_LINK_SPEED,           {pcie,   link_speed}},
+	{ QR_PCIE_EXPRESS_LANE_WIDTH,   {pcie,   link_width}},
+	{ QR_PCIE_READY_STATUS,         {pcie,   ready}},
+	{ QR_DMA_THREADS_RAW,           {dma,  channel_stat_raw_v}},
+	{ QR_ROM_VBNV,                  {rom,  VBNV}},
+	{ OR_ROM_DDR_BANK_SIZE,         {rom,  ddr_bank_size}},
+	{ QR_ROM_DDR_BANK_COUNT_MAX,    {rom,  ddr_bank_count_max}},
+	{ QR_ROM_FPGA_NAME,             {rom,  FPGA}},
+	{ QR_XMC_VERSION,               {xmc,  version}},
+	{ QR_XMC_SERIAL_NUM,            {xmc,  serial_num}},
+	{ QR_XMC_MAX_POWER,             {xmc,  max_power}},
+	{ QR_XMC_BMC_VERSION,           {xmc,  bmc_ver}},
+	{ QR_DNA_SERIAL_NUM,            {dna,  dna_v}},
+	{ QR_CLOCK_FREQS,               {icap,  clock_freqs}},
+	{ QR_IDCODE,                    {icap,  idcode}},
+	{ QR_STATUS_MIG_CALIBRATED,     {pcie,  mig_calibration}},
+	{ QR_STATUS_P2P_ENABLED,        {pcie,  p2p_enable}},
+	{ QR_TEMP_CARD_TOP_FRONT,       {xmc,  xmc_se98_temp0}},
+	{ QR_TEMP_CARD_TOP_REAR,        {xmc,  xmc_se98_temp1}},
+	{ QR_TEMP_CARD_BOTTOM_FRONT,    {xmc,  xmc_se98_temp2}},
+	{ QR_TEMP_FPGA,                 {xmc,  xmc_fpga_temp}},
+	{ QR_FAN_TRIGGER_CRITICAL_TEMP, {xmc,  xmc_fan_temp}},
+	{ QR_FAN_FAN_PRESENCE,          {xmc,  fan_presence}},
+	{ QR_FAN_SPEED_RPM,             {xmc,  xmc_fan_rpm}},
+	{ QR_CAGE_TEMP_0,               {xmc,  xmc_cage_temp0}},
+	{ QR_CAGE_TEMP_1,               {xmc,  xmc_cage_temp1}},
+	{ QR_CAGE_TEMP_2,               {xmc,  xmc_cage_temp2}},
+	{ QR_CAGE_TEMP_3,               {xmc,  xmc_cage_temp3}},
+	{ QR_12V_PEX_MILLIVOLTS,        {xmc,  xmc_12v_pex_vol}},
+	{ QR_12V_PEX_MILLIAMPS,         {xmc,  xmc_12v_pex_curr}},
+	{ QR_12V_AUX_MILLIVOLTS,        {xmc,  xmc_12v_aux_vol}},
+	{ QR_12V_AUX_MILLIAMPS,         {xmc,  xmc_12v_aux_curr}},
+	{ QR_3V3_PEX_MILLIVOLTS,        {xmc,  xmc_3v3_pex_vol}},
+	{ QR_3V3_AUX_MILLIVOLTS,        {xmc,  xmc_3v3_aux_vol}},
+	{ QR_DDR_VPP_BOTTOM_MILLIVOLTS, {xmc,  xmc_ddr_vpp_btm}},
+	{ QR_DDR_VPP_TOP_MILLIVOLTS,    {xmc,  xmc_ddr_vpp_top}},
 
-    { QR_5V5_SYSTEM_MILLIVOLTS,     { 0 }},
-    { QR_1V2_VCC_TOP_MILLIVOLTS,    { 0 }},
-    { QR_1V2_VCC_BOTTOM_MILLIVOLTS, { 0 }},
-    { QR_1V8_MILLIVOLTS,            { 0 }},
-    { QR_0V85_MILLIVOLTS,           { 0 }},
-    { QR_0V9_VCC_MILLIVOLTS,        { 0 }},
-    { QR_12V_SW_MILLIVOLTS,         { 0 }},
-    { QR_MGT_VTT_MILLIVOLTS,        { 0 }},
-    { QR_INT_VCC_MILLIVOLTS,        { 0 }},
-    { QR_INT_VCC_MILLIAMPS,         { 0 }},
+	{ QR_5V5_SYSTEM_MILLIVOLTS,     {xmc,  xmc_sys_5v5}},
+	{ QR_1V2_VCC_TOP_MILLIVOLTS,    {xmc,  xmc_1v2_top}},
+	{ QR_1V2_VCC_BOTTOM_MILLIVOLTS, {xmc,  xmc_vcc1v2_btm}},
+	{ QR_1V8_MILLIVOLTS,            {xmc,  xmc_1v8}},
+	{ QR_0V85_MILLIVOLTS,           {xmc,  xmc_0v85}},
+	{ QR_0V9_VCC_MILLIVOLTS,        {xmc,  xmc_mgt0v9avcc}},
+	{ QR_12V_SW_MILLIVOLTS,         {xmc,  xmc_12v_sw}},
+	{ QR_MGT_VTT_MILLIVOLTS,        {xmc,  xmc_mgtavtt}},
+	{ QR_INT_VCC_MILLIVOLTS,        {xmc,  xmc_vccint_vol}},
+	{ QR_INT_VCC_MILLIAMPS,         {xmc,  xmc_vccint_curr}},
 
-    { QR_3V3_PEX_MILLIAMPS,         { 0 }},
-    { QR_0V85_MILLIAMPS,            { 0 }},
-    { QR_3V3_VCC_MILLIVOLTS,        { 0 }},
-    { QR_HBM_1V2_MILLIVOLTS,        { 0 }},
-    { QR_2V5_VPP_MILLIVOLTS,        { 0 }},
-    { QR_INT_BRAM_VCC_MILLIVOLTS,   { 0 }},
+	{ QR_3V3_PEX_MILLIAMPS,         {xmc,  xmc_3v3_pex_curr}},
+	{ QR_0V85_MILLIAMPS,            {xmc,  xmc_0v85_curr}},
+	{ QR_3V3_VCC_MILLIVOLTS,        {xmc,  xmc_3v3_vcc_vol}},
+	{ QR_HBM_1V2_MILLIVOLTS,        {xmc,  xmc_hbm_1v2_vol}},
+	{ QR_2V5_VPP_MILLIVOLTS,        {xmc,  xmc_vpp2v5_vol}},
+	{ QR_INT_BRAM_VCC_MILLIVOLTS,   {xmc,  xmc_vccint_bram_vol}},
 
-    { QR_FIREWALL_DETECT_LEVEL,     { 0 }},
-    { QR_FIREWALL_STATUS,           { 0 }},
-    { QR_FIREWALL_TIME_SEC,         { 0 }},
+	{ QR_FIREWALL_DETECT_LEVEL,     {firewall, detected_level}},
+	{ QR_FIREWALL_STATUS,           {firewall, detected_status}},
+	{ QR_FIREWALL_TIME_SEC,         {firewall, detected_time}},
 
-    { QR_POWER_MICROWATTS,          { 0 }}
+	{ QR_POWER_MICROWATTS,          {xmc, xmc_power}}
 };
   // Find the translation entry
   std::map<QueryRequest, IOCTLEntry>::const_iterator it = QueryRequestToIOCTLTable.find(_eQueryRequest);
@@ -124,48 +128,13 @@ query_device(uint64_t _deviceID, QueryRequest _eQueryRequest, const std::type_in
 
   std::string sErrorMsg;
 
-  if (entry.IOCTLValue == 0) {
-    sErrorMsg = "IOCTLEntry is initialized with zeros.";
-  }
-
   // Removes compile warnings for unused variables
   _deviceID = _deviceID;
 
-  // Reference linux code:
-//  if (_typeInfo == typeid(std::string)) {
-//    // -- Typeid: std::string --
-//    _returnValue = std::string("");
-//    std::string *stringValue = boost::any_cast<std::string>(&_returnValue);
-//    pcidev::get_dev(_deviceID)->sysfs_get( entry.sSubDevice, entry.sEntry, sErrorMsg, *stringValue);
-//
-//  } else if (_typeInfo == typeid(uint64_t)) {
-//    // -- Typeid: uint64_t --
-//    _returnValue = (uint64_t) -1;
-//    std::vector<uint64_t> uint64Vector;
-//    pcidev::get_dev(_deviceID)->sysfs_get( entry.sSubDevice, entry.sEntry, sErrorMsg, uint64Vector);
-//    if (!uint64Vector.empty()) {
-//      _returnValue = uint64Vector[0];
-//    }
-//
-//  } else if (_typeInfo == typeid(bool)) {
-//    // -- Typeid: bool --
-//    _returnValue = (bool) 0;
-//    std::vector<uint64_t> uint64Vector;
-//    pcidev::get_dev(_deviceID)->sysfs_get( entry.sSubDevice, entry.sEntry, sErrorMsg, uint64Vector);
-//    if (!uint64Vector.empty()) {
-//      _returnValue = (bool) uint64Vector[0];
-//    }
-//
-//  } else if (_typeInfo == typeid(std::vector<std::string>)) {
-//    // -- Typeid: std::vector<std::string>
-//    _returnValue = std::vector<std::string>();
-//    std::vector<std::string> *stringVector = boost::any_cast<std::vector<std::string>>(&_returnValue);
-//    pcidev::get_dev(_deviceID)->sysfs_get( entry.sSubDevice, entry.sEntry, sErrorMsg, *stringVector);
-//
-//  } else {
-//  }
-
-  sErrorMsg = boost::str( boost::format("Error: Unsupported query_device return type: '%s'") % _typeInfo.name());
+  queryDeviceWithQR(_deviceID,
+		  entry.subdev,
+		  entry.variable,
+		  _returnValue);
 
   if (!sErrorMsg.empty()) {
     throw std::runtime_error(sErrorMsg);
@@ -195,8 +164,23 @@ std::pair<uint64_t, uint64_t>
 xrt_core::device_windows::
 get_total_devices() const
 {
-  auto user_count = xclProbe();
-  return std::make_pair(user_count, user_count);
+  uint64_t user_count = xclProbe();
+
+  //TODO: Getting ready status of devices.
+  const IOCTLEntry & entry = get_IOCTL_entry(QR_PCIE_READY_STATUS);
+  uint64_t ready_count = 0;
+  boost::any anyValue;
+
+  for (unsigned int i = 0; i < user_count; i++) {
+	queryDeviceWithQR(i, entry.subdev, entry.variable, anyValue);
+	bool ready = boost::any_cast<bool>(anyValue);
+	if (ready)
+	  ready_count++;
+  }
+
+  std::cout << "INFO: Found total " << user_count << " card(s), " << ready_count << " are usable.\n";
+
+  return std::make_pair(user_count, ready_count);
 }
 
 void
@@ -283,4 +267,30 @@ update_SC(uint64_t _deviceID, std::string& file) const
   _deviceID = _deviceID;
   file = file;
 }
+DWORD
+xrt_core::device_windows::
+get_IpLayoutSize(uint64_t _deviceID) const
+{
+  return shim_getIPLayoutSize(_deviceID);
+}
 
+void
+xrt_core::device_windows::
+get_IpLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size) const
+{
+  shim_getIPLayout(_deviceID, ipLayout, size);
+}
+
+void
+xrt_core::device_windows::
+get_memTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo) const
+{
+  shim_getMemTopology(_deviceID, topoInfo);
+}
+
+void
+xrt_core::device_windows::
+get_memRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw) const
+{
+  shim_getMemRawInfo(_deviceID, memRaw);
+}

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -26,8 +26,12 @@ namespace xrt_core {
 class device_windows : public device_pcie {
   public:
     struct IOCTLEntry {
-      uint64_t IOCTLValue;
+	  uint64_t subdev;
+	  uint64_t variable;
     };
+
+    uint64_t channel_stat_raw_v = 0;
+    uint64_t dna_v = 0;
 
     const IOCTLEntry & get_IOCTL_entry( QueryRequest _eQueryRequest) const;
 
@@ -43,7 +47,10 @@ class device_windows : public device_pcie {
     virtual void update_shell(uint64_t _deviceID, std::string flashType, std::string& primary, std::string& secondary) const;
     virtual void update_SC(uint64_t _deviceID, std::string& file) const;
     //end flash functions
-
+    virtual void get_IpLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size) const;
+    virtual DWORD get_IpLayoutSize(uint64_t _deviceID) const;
+    virtual void get_memTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo) const;
+    virtual void get_memRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw) const;
   public:
     device_windows();
     virtual ~device_windows();

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -47,8 +47,8 @@ class device_windows : public device_pcie {
     virtual void update_shell(uint64_t _deviceID, std::string flashType, std::string& primary, std::string& secondary) const;
     virtual void update_SC(uint64_t _deviceID, std::string& file) const;
     //end flash functions
-    virtual void get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size) const;
-    virtual DWORD get_ip_layoutsize(uint64_t _deviceID) const;
+    virtual void get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, unsigned long size) const;
+    virtual unsigned long get_ip_layoutsize(uint64_t _deviceID) const;
     virtual void get_mem_topology(uint64_t _deviceID, struct mem_topology *topoInfo) const;
     virtual void get_mem_rawinfo(uint64_t _deviceID, struct mem_raw_info *memRaw) const;
   public:

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -47,10 +47,10 @@ class device_windows : public device_pcie {
     virtual void update_shell(uint64_t _deviceID, std::string flashType, std::string& primary, std::string& secondary) const;
     virtual void update_SC(uint64_t _deviceID, std::string& file) const;
     //end flash functions
-    virtual void get_IpLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size) const;
-    virtual DWORD get_IpLayoutSize(uint64_t _deviceID) const;
-    virtual void get_memTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo) const;
-    virtual void get_memRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw) const;
+    virtual void get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size) const;
+    virtual DWORD get_ip_layoutsize(uint64_t _deviceID) const;
+    virtual void get_mem_topology(uint64_t _deviceID, struct mem_topology *topoInfo) const;
+    virtual void get_mem_rawinfo(uint64_t _deviceID, struct mem_raw_info *memRaw) const;
   public:
     device_windows();
     virtual ~device_windows();

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -337,9 +337,11 @@ done:
   size_t
   write_bo(xclBufferHandle boHandle, const void *src, size_t size, size_t seek)
   {
-	void* a = map_bo(boHandle, 1);
+	void* addr = map_bo(boHandle, 1);
 
-	memcpy(a, src, size);
+	memcpy(addr, src, size);
+
+	unmap_bo(boHandle, addr);
 
 	return 0;
 }
@@ -347,9 +349,11 @@ done:
   size_t
   read_bo(xclBufferHandle boHandle, void *dst, size_t size, size_t skip)
   {
-	void* a = map_bo(boHandle, 1);
+	void* addr = map_bo(boHandle, 1);
 
-	memcpy(dst, a, size);
+	memcpy(dst, addr, size);
+
+	unmap_bo(boHandle, addr);
 
 	return 0;
   }

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1216,6 +1216,11 @@ qr_rom_info(HANDLE handle, uint64_t variable, boost::any & _returnValue) {
 		  std::string FPGAPartName(reinterpret_cast<const char *> (romInfo.FPGAPartName), len);
 		  _returnValue = boost::any_cast<std::string>(FPGAPartName);
 	  }
+	  case time_since_epoch:
+	  {
+		  uint64_t TimeSinceEpoch = romInfo.TimeSinceEpoch;
+		  _returnValue = boost::any_cast<uint64_t>(TimeSinceEpoch);
+	  }
 	  break;
 	  default:
 		  break;

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -334,6 +334,26 @@ done:
       CloseHandle(handle);
   }
 
+  size_t
+  write_bo(xclBufferHandle boHandle, const void *src, size_t size, size_t seek)
+  {
+	void* a = map_bo(boHandle, 1);
+
+	memcpy(a, src, size);
+
+	return 0;
+}
+
+  size_t
+  read_bo(xclBufferHandle boHandle, void *dst, size_t size, size_t skip)
+  {
+	void* a = map_bo(boHandle, 1);
+
+	memcpy(dst, a, size);
+
+	return 0;
+  }
+
   int
   sync_bo(buffer_handle_type handle, xclBOSyncDirection dir, size_t size, size_t offset)
   {
@@ -965,6 +985,24 @@ xclSyncBO(xclDeviceHandle handle, xclBufferHandle boHandle, xclBOSyncDirection d
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclSyncBO()");
   auto shim = get_shim_object(handle);
   return shim->sync_bo(boHandle, dir, size, offset);
+}
+
+size_t
+xclWriteBO(xclDeviceHandle handle, xclBufferHandle boHandle, const void *src, size_t size, size_t seek)
+{
+  xrt_core::message::
+	send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclWriteBO()");
+  auto shim = get_shim_object(handle);
+  return shim->write_bo(boHandle, src, size, seek);
+}
+
+size_t
+xclReadBO(xclDeviceHandle handle, xclBufferHandle boHandle, void *dst, size_t size, size_t skip)
+{
+  xrt_core::message::
+	send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclReadBO()");
+  auto shim = get_shim_object(handle);
+  return shim->read_bo(boHandle, dst, size, skip);
 }
 
 // Compute Unit Execution Management APIs

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -25,14 +25,12 @@
 #include <setupapi.h>
 #include <strsafe.h>
 
-// To be simplified
-#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
-
 #include <cstring>
 #include <cstdio>
 #include <ctime>
 #include <iostream>
 #include <string>
+#include "boost/any.hpp"
 
 #pragma warning(disable : 4100 4996)
 #pragma comment (lib, "Setupapi.lib")
@@ -1104,4 +1102,265 @@ xclRead(xclDeviceHandle handle, enum xclAddressSpace space,
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclRead()");
   auto shim = get_shim_object(handle);
   return shim->read(space,offset,hostbuf,size) ? 0 : size;
+}
+
+void queryDeviceWithQR(uint64_t _deviceID, uint64_t subdev,
+	uint64_t variable,
+	boost::any & _returnValue)
+{
+	xclDeviceHandle handle = xclOpen((int)_deviceID, 0, XCL_INFO);
+	auto shim = get_shim_object(handle);
+	HANDLE deviceHandle = shim->m_dev;
+
+	switch (subdev)
+	{
+	case pcie: qr_pcie_info(deviceHandle, variable, _returnValue);
+		break;
+	case rom: qr_rom_info(deviceHandle, variable, _returnValue);
+		break;
+	case icap:
+		break;
+	case xmc:
+		break;
+	case firewall:
+		break;
+	case dma:
+		break;
+	case dna:
+		break;
+	default:
+		std::cout << "unknown request" << std::endl;
+	}
+}
+
+void
+qr_rom_info(HANDLE handle, uint64_t variable, boost::any & _returnValue) {
+	XOCL_ROM_INFORMATION romInfo;
+	XOCL_STAT_CLASS statClass = XoclStatRomInfo;
+	DWORD bytesWritten;
+	DWORD bytesToRead;
+	DWORD  error = ERROR_SUCCESS;
+
+	bytesToRead = sizeof(romInfo);
+
+	if (!DeviceIoControl(handle,
+		IOCTL_XOCL_STAT,
+		&statClass,
+		sizeof(statClass),
+		&romInfo,
+		sizeof(romInfo),
+		&bytesWritten,
+		nullptr)) {
+
+		error = GetLastError();
+
+		printf("DeviceIoControl failed with error 0x%x\n", error);
+		std::cout << "DeviceIoControl failed in qr_rom_info()" << std::endl;
+	} else {
+		switch (variable)
+		{
+		case VBNV:
+		{
+			size_t len = strlen((char*)romInfo.VBNVName);
+			std::string VBNVName(reinterpret_cast<const char *> (romInfo.VBNVName),len);
+			_returnValue = boost::any_cast<std::string>(VBNVName);
+		}
+			break;
+		case ddr_bank_size:
+		{
+			uint64_t DDRChannelSize = romInfo.DDRChannelSize;
+			_returnValue = boost::any_cast<uint64_t>(DDRChannelSize);
+		}
+			break;
+		case ddr_bank_count_max:
+		{
+			uint64_t DDRChannelCount = romInfo.DDRChannelCount;
+			_returnValue = boost::any_cast<uint64_t>(DDRChannelCount);
+		}
+			break;
+		case FPGA:
+		{
+			size_t len = strlen((char*)romInfo.FPGAPartName);
+			std::string FPGAPartName(reinterpret_cast<const char *> (romInfo.FPGAPartName),len);
+			_returnValue = boost::any_cast<std::string>(FPGAPartName);
+		}
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+void
+qr_pcie_info(HANDLE handle, uint64_t variable, boost::any & _returnValue) {
+	DWORD bytesRead;
+	XOCL_STAT_CLASS_ARGS statClassArgs;
+	XOCL_DEVICE_INFORMATION deviceInfo;
+
+	statClassArgs.StatClass = XoclStatDevice;
+
+	if (!DeviceIoControl(handle,
+		IOCTL_XOCL_STAT,
+		&statClassArgs,
+		sizeof(XOCL_STAT_CLASS_ARGS),
+		&deviceInfo,
+		sizeof(XOCL_DEVICE_INFORMATION),
+		&bytesRead,
+		NULL)) {
+
+		std::cout << "DeviceIoControl failed in qr_pcie_info() " << std::endl;
+	} else {
+		switch (variable)
+		{
+		case vendor:
+		{
+			uint64_t vendor = deviceInfo.Vendor;
+			_returnValue = boost::any_cast<uint64_t>(vendor);
+		}
+			break;
+		case pcie_device:
+		{
+			uint64_t Device = deviceInfo.Device;
+			_returnValue = boost::any_cast<uint64_t>(Device);
+		}
+			break;
+		case subsystem_vendor:
+		{
+			uint64_t SubsystemVendor = deviceInfo.SubsystemVendor;
+			_returnValue = boost::any_cast<uint64_t>(SubsystemVendor);
+		}
+			break;
+		case subsystem_device:
+		{
+			uint64_t SubsystemDevice = deviceInfo.SubsystemDevice;
+			_returnValue = boost::any_cast<uint64_t>(SubsystemDevice);
+		}
+			break;
+		case ready:
+		{
+			_returnValue = boost::any_cast<bool>(deviceInfo.ready);
+		}
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+DWORD shim_getIPLayoutSize(uint64_t _deviceID)
+{
+  DWORD bytesRead;
+  XOCL_STAT_CLASS_ARGS statClassArgs;
+  DWORD  error = ERROR_SUCCESS;
+  XU_IP_LAYOUT layoutHeader;
+  DWORD size = 0;
+  xclDeviceHandle handle = xclOpen((int)_deviceID, 0, XCL_INFO);
+  auto shim = get_shim_object(handle);
+  HANDLE devHandle = shim->m_dev;
+
+  statClassArgs.StatClass = XoclStatIpLayout;
+  if (!DeviceIoControl(devHandle,
+		IOCTL_XOCL_STAT,
+		&statClassArgs,
+		sizeof(XOCL_STAT_CLASS_ARGS),
+		&layoutHeader,
+		sizeof(XU_IP_LAYOUT),
+		&bytesRead,
+		NULL)) {
+	  error = GetLastError();
+	  printf("DeviceIoControl failed with error 0x%x\n", error);
+	  return 0;
+  }
+  //printf("Retrieved XU_IP_LAYOUT header (%d XU_IP_DATAs)\n", layoutHeader.m_count);
+  size = (DWORD)(sizeof(XU_IP_LAYOUT) + layoutHeader.m_count * sizeof(XU_IP_DATA));
+
+  return size;
+}
+
+void shim_getIPLayout(uint64_t _deviceID, XU_IP_LAYOUT **ip, DWORD size)
+{
+  DWORD bytesRead;
+  XOCL_STAT_CLASS_ARGS statClassArgs;
+  DWORD  error = ERROR_SUCCESS;
+  XU_IP_LAYOUT *ipLayout = *ip;
+  xclDeviceHandle handle = xclOpen((int)_deviceID, 0, XCL_INFO);
+  auto shim = get_shim_object(handle);
+  HANDLE devHandle = shim->m_dev;
+
+  statClassArgs.StatClass = XoclStatIpLayout;
+  if (!DeviceIoControl(devHandle,
+		IOCTL_XOCL_STAT,
+		&statClassArgs,
+		sizeof(XOCL_STAT_CLASS_ARGS),
+		ipLayout,
+		size,
+		&bytesRead,
+		NULL)) {
+	  error = GetLastError();
+	  printf("DeviceIoControl failed with error 0x%x\n", error);
+  } else {
+#if 0
+	  for (int i = 0; i < ipLayout->m_count; i++) {
+		  XU_IP_DATA* data = &ipLayout->m_ip_data[i];
+		  size_t len = strlen((char*)data->m_name);
+		  std::string name((const char*)data->m_name, len);
+		  printf("[shim_getIPLayout] XU_IP_DATA[%d]---\n", i);
+		  printf("\t+++m_name      = %s\n", name.c_str());
+		  printf("\t+++m_type      = 0x%lx\n", data->m_type);
+		  printf("\t+++m_index     = 0x%hx\n", data->indices.m_index);
+		  printf("\t+++m_pc_index  = 0x%hhx\n", data->indices.m_pc_index);
+		  printf("\t+++unused      = 0x%hhx\n", data->indices.unused);
+		  printf("\t+++m_base_addr = 0x%llx\n", data->m_base_address);
+		  printf("\t+++properties  = 0x%lx\n", data->properties);
+	  }
+#endif
+  }
+
+  return;
+}
+
+void shim_getMemTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo)
+{
+  xclDeviceHandle handle = xclOpen((int)_deviceID, 0, XCL_INFO);
+  auto shim = get_shim_object(handle);
+  HANDLE deviceHandle = shim->m_dev;
+  DWORD error;
+  DWORD bytesWritten;
+  XOCL_STAT_CLASS statClass = XoclStatMemTopology;
+
+  if (!DeviceIoControl(deviceHandle,
+			IOCTL_XOCL_STAT,
+			&statClass,
+			sizeof(statClass),
+			topoInfo,
+			sizeof(XOCL_MEM_TOPOLOGY_INFORMATION),
+			&bytesWritten,
+			nullptr)) {
+	  error = GetLastError();
+	  xrt_core::message::
+		  send(xrt_core::message::severity_level::XRT_ERROR, "XRT", "DeviceIoControl failed with error %d", error);
+  }
+}
+
+void shim_getMemRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw)
+{
+  xclDeviceHandle handle = xclOpen((int)_deviceID, 0, XCL_INFO);
+  auto shim = get_shim_object(handle);
+  HANDLE deviceHandle = shim->m_dev;
+  DWORD error;
+  DWORD bytesWritten;
+  XOCL_STAT_CLASS statClass = XoclStatMemRaw;
+
+  if (!DeviceIoControl(deviceHandle,
+		IOCTL_XOCL_STAT,
+		&statClass,
+		sizeof(statClass),
+		memRaw,
+		sizeof(XOCL_MEM_RAW_INFORMATION),
+		&bytesWritten,
+		nullptr)) {
+	  error = GetLastError();
+	  xrt_core::message::
+		  send(xrt_core::message::severity_level::XRT_ERROR, "XRT", "DeviceIoControl failed with error %d", error);
+  }
 }

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -19,6 +19,105 @@
 
 #include "xrt.h"
 #include "core/common/xrt_profiling.h"
+#include "boost/any.hpp"
+#include <boost/property_tree/ptree.hpp>
+#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
+
+typedef enum {
+	pcie = 0,
+	rom,
+	icap,
+	xmc,
+	firewall,
+	dma,
+	dna
+}subdev;
+
+typedef enum {
+	VBNV = 0,
+	ddr_bank_size,
+	ddr_bank_count_max,
+	FPGA
+}rom_variable;
+
+typedef enum {
+	vendor = 0,
+	pcie_device,
+	subsystem_vendor,
+	subsystem_device,
+	link_speed,
+	link_width,
+	mig_calibration,
+	p2p_enable,
+	ready
+}pcie_variable;
+
+typedef enum {
+	clock_freqs = 0,
+	idcode
+}icap_variable;
+
+typedef enum {
+	detected_level = 0,
+	detected_status,
+	detected_time
+}firewall_variable;
+
+typedef enum {
+	version = 0,
+	serial_num,
+	max_power,
+	bmc_ver,
+	xmc_se98_temp0,
+	xmc_se98_temp1,
+	xmc_se98_temp2,
+	xmc_fpga_temp,
+	xmc_fan_temp,
+	fan_presence,
+	xmc_fan_rpm,
+	xmc_cage_temp0,
+	xmc_cage_temp1,
+	xmc_cage_temp2,
+	xmc_cage_temp3,
+	xmc_12v_pex_vol,
+	xmc_12v_pex_curr,
+	xmc_12v_aux_vol,
+	xmc_12v_aux_curr,
+	xmc_3v3_pex_vol,
+	xmc_3v3_aux_vol,
+	xmc_ddr_vpp_btm,
+	xmc_ddr_vpp_top,
+	xmc_sys_5v5,
+	xmc_1v2_top,
+	xmc_vcc1v2_btm,
+	xmc_1v8,
+	xmc_0v85,
+	xmc_mgt0v9avcc,
+	xmc_12v_sw,
+	xmc_mgtavtt,
+	xmc_vccint_vol,
+	xmc_vccint_curr,
+
+	xmc_3v3_pex_curr,
+	xmc_0v85_curr,
+	xmc_3v3_vcc_vol,
+	xmc_hbm_1v2_vol,
+	xmc_vpp2v5_vol,
+	xmc_vccint_bram_vol,
+	xmc_power
+}xmc_variable;
+
+void qr_rom_info(HANDLE handle, uint64_t variable, boost::any & _returnValue);
+void qr_pcie_info(HANDLE handle, uint64_t variable, boost::any & _returnValue);
+
+__declspec(dllexport) void queryDeviceWithQR(uint64_t _deviceID, uint64_t subdev, uint64_t variable, boost::any & _returnValue);
+
+__declspec(dllexport) void shim_getIPLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size);
+
+__declspec(dllexport) DWORD shim_getIPLayoutSize(uint64_t _deviceID);
+
+__declspec(dllexport) void shim_getMemTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo);
+__declspec(dllexport) void shim_getMemRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw);
 
 namespace xocl { // shared implementation
 

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -36,7 +36,8 @@ typedef enum {
 	VBNV = 0,
 	ddr_bank_size,
 	ddr_bank_count_max,
-	FPGA
+	FPGA,
+	time_since_epoch
 }rom_variable;
 
 typedef enum {

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -21,7 +21,6 @@
 #include "core/common/xrt_profiling.h"
 #include "boost/any.hpp"
 #include <boost/property_tree/ptree.hpp>
-#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
 
 typedef enum {
 	pcie = 0,
@@ -112,12 +111,12 @@ void qr_pcie_info(HANDLE handle, uint64_t variable, boost::any & _returnValue);
 
 __declspec(dllexport) void queryDeviceWithQR(uint64_t _deviceID, uint64_t subdev, uint64_t variable, boost::any & _returnValue);
 
-__declspec(dllexport) void shim_getIPLayout(uint64_t _deviceID, XU_IP_LAYOUT **ipLayout, DWORD size);
+__declspec(dllexport) void shim_get_ip_layout(uint64_t _deviceID, struct ip_layout **ipLayout, DWORD size);
 
-__declspec(dllexport) DWORD shim_getIPLayoutSize(uint64_t _deviceID);
+__declspec(dllexport) DWORD shim_get_ip_layoutsize(uint64_t _deviceID);
 
-__declspec(dllexport) void shim_getMemTopology(uint64_t _deviceID, XOCL_MEM_TOPOLOGY_INFORMATION *topoInfo);
-__declspec(dllexport) void shim_getMemRawInfo(uint64_t _deviceID, XOCL_MEM_RAW_INFORMATION *memRaw);
+__declspec(dllexport) void shim_get_mem_topology(uint64_t _deviceID, struct mem_topology *topoInfo);
+__declspec(dllexport) void shim_get_mem_rawinfo(uint64_t _deviceID, struct mem_raw_info *memRaw);
 
 namespace xocl { // shared implementation
 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -30,6 +30,7 @@ if(WIN32)
     "SubCmdReset.cpp"
     "SubCmdScan.cpp"
     "SubCmdVersion.cpp"
+    "SubCmdDmaTest.cpp"
   )
 else()
   set(XBUTIL2_NAME "xbutil2")

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -113,10 +113,10 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
 	  return -EINVAL;
 
   std::cout << "Total DDR size: " << ddr_mem_size << " MB" << std::endl;
-  XOCL_MEM_TOPOLOGY_INFORMATION topoInfo;
-  CoreDevice.get_memTopology(card, &topoInfo);
+  struct mem_topology topoInfo;
+  CoreDevice.get_mem_topology(card, &topoInfo);
 
-  if (topoInfo.MemTopoCount == 0) {
+  if (topoInfo.m_count == 0) {
 	  std::cout << "WARNING: 'mem_topology' invalid, "
 		  << "unable to perform DMA Test. Has the bitstream been loaded? "
 		  << "See 'xbutil program' to load a specific xclbin file or run "
@@ -126,18 +126,18 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
   }
 
   printf("Got XoclStatMemTopology Data:\n");
-  printf("Memory regions: %d\n", topoInfo.MemTopoCount);
-  for (size_t i = 0; i < topoInfo.MemTopoCount; i++) {
+  printf("Memory regions: %d\n", topoInfo.m_count);
+  for (size_t i = 0; i < topoInfo.m_count; i++) {
 	  printf("\ttype: %d, tag=%s, start=0x%llx, size=0x%llx\n",
-		  topoInfo.MemTopo[i].m_type,
-		  topoInfo.MemTopo[i].m_tag,
-		  topoInfo.MemTopo[i].m_base_address,
-		  topoInfo.MemTopo[i].m_size);
-	  if (topoInfo.MemTopo[i].m_type == MEM_STREAMING)
+		  topoInfo.m_mem_data[i].m_type,
+		  topoInfo.m_mem_data[i].m_tag,
+		  topoInfo.m_mem_data[i].m_base_address,
+		  topoInfo.m_mem_data[i].m_size);
+	  if (topoInfo.m_mem_data[i].m_type == MEM_STREAMING)
 		  continue;
-	  if (topoInfo.MemTopo[i].m_used) {
+	  if (topoInfo.m_mem_data[i].m_used) {
 		  std::cout << "[TBD] Data Validity & DMA Test on "
-			  << topoInfo.MemTopo[i].m_tag << "\n";
+			  << topoInfo.m_mem_data[i].m_tag << "\n";
 		  //DMARunner runner(m_handle, blockSize, i);
 		  //result = runner.run();
 	  }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -89,12 +89,11 @@ int subCmdQuery(const std::vector<std::string> &_options)
   // Report system configuration and XRT information
   XBReport::report_system_config();
   XBReport::report_xrt_info();
-  
+  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+
   // Gather the complete system information for ALL devices
   boost::property_tree::ptree pt;
   XBDatabase::create_complete_device_tree(pt);
-
   XBU::trace_print_tree("Complete Device Tree", pt);
   return registerResult;
 }
-

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -17,6 +17,7 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "SubCmdScan.h"
+#include "XBReport.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
@@ -79,6 +80,11 @@ int subCmdScan(const std::vector<std::string> &_options)
     std::cout << scanDesc << std::endl;
     return 0;
   }
+
+  // Report system configuration and XRT information
+  XBReport::report_system_config();
+  XBReport::report_xrt_info();
+  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
 
   auto& core = xrt_core::device_core::instance();
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -99,8 +99,10 @@ int subCmdScan(const std::vector<std::string> &_options)
     throw xrt_core::error("No devices found");
 
   for (auto& device : *devices) {
-    std::cout << "[" << device.second.get<std::string>("device_id") << "] <board TBD> ...\n";
-    // populate with  same output as old xbutil
+	uint64_t device_id = device.second.get<uint64_t>("device_id", (uint64_t)-1);
+	boost::property_tree::ptree _pt;
+	core.get_device_rom_info(device_id, _pt);
+	std::cout << "[" << device_id << "]: " << _pt.get<std::string>("vbnv", "N/A") << "(ts=" << _pt.get<std::string>("time_since_epoch", "N/A") << ")" << std::endl;
   }
 
   return registerResult;

--- a/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
@@ -20,7 +20,6 @@
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 #include "common/device_core.h"
-#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
 
 // 3rd Party Library - Include Files
 
@@ -178,15 +177,15 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
 #endif
 	{
 	  //boost::property_tree::ptree pt;
-	  XU_IP_LAYOUT *ipLayout = NULL;
-	  unsigned long ipSize = CoreDevice.get_IpLayoutSize(device_id);
-	  ipLayout = (XU_IP_LAYOUT*)malloc(ipSize);
-	  CoreDevice.get_IpLayout(device_id, &ipLayout, ipSize);
+	  struct ip_layout *ipLayout = NULL;
+	  unsigned long ipSize = CoreDevice.get_ip_layoutsize(device_id);
+	  ipLayout = (struct ip_layout*)malloc(ipSize);
+	  CoreDevice.get_ip_layout(device_id, &ipLayout, ipSize);
 	  if (ipLayout != NULL) {
 		  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
 		  std::cout << "Compute Unit Status:" << std::endl;
 		  for (int i = 0; i < ipLayout->m_count; i++) {
-			  XU_IP_DATA* data = &ipLayout->m_ip_data[i];
+			  struct ip_data* data = &ipLayout->m_ip_data[i];
 			  if (data->m_type != IP_KERNEL)
 				  continue;
 			  size_t len = strlen((char*)data->m_name);
@@ -200,22 +199,22 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
 
 	{
 	  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
-	  XOCL_MEM_TOPOLOGY_INFORMATION topoInfo;
-	  CoreDevice.get_memTopology(device_id, &topoInfo);
+	  struct mem_topology topoInfo;
+	  CoreDevice.get_mem_topology(device_id, &topoInfo);
 	  printf("Got XoclStatMemTopology Data:\n");
-	  printf("Memory regions: %d\n", topoInfo.MemTopoCount);
-	  for (size_t i = 0; i < topoInfo.MemTopoCount; i++) {
+	  printf("Memory regions: %d\n", topoInfo.m_count);
+	  for (size_t i = 0; i < topoInfo.m_count; i++) {
 		  printf("\ttag=%s, start=0x%llx, size=0x%llx\n",
-			  topoInfo.MemTopo[i].m_tag,
-			  topoInfo.MemTopo[i].m_base_address,
-			  topoInfo.MemTopo[i].m_size);
+			  topoInfo.m_mem_data[i].m_tag,
+			  topoInfo.m_mem_data[i].m_base_address,
+			  topoInfo.m_mem_data[i].m_size);
 	  }
 	}
 
 	{
 		std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
-		XOCL_MEM_RAW_INFORMATION memRaw;
-		CoreDevice.get_memRawInfo(device_id, &memRaw);
+		struct mem_raw_info memRaw;
+		CoreDevice.get_mem_rawinfo(device_id, &memRaw);
 		printf("Got XoclStatMemRaw Data:\n");
 		printf("Count: %d\n", memRaw.MemRawCount);
 		for (unsigned int i = 0; i < memRaw.MemRawCount; i++) {

--- a/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBDatabase.cpp
@@ -20,17 +20,50 @@
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 #include "common/device_core.h"
-
+#include "core/pcie/driver/windows/include/XoclUser_INTF.h"
 
 // 3rd Party Library - Include Files
 
 // System - Include Files
+#include <iostream>
+#include <iomanip>
 
 // ------ N A M E S P A C E ---------------------------------------------------
 using namespace XBDatabase;
 
 
 // ------ F U N C T I O N S ---------------------------------------------------
+void
+XBDatabase::dump(boost::property_tree::ptree & _pt, std::ostream& ostr)
+{
+		std::ios::fmtflags f(ostr.flags());
+		ostr << std::left << std::endl;
+		ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+		ostr << std::setw(32) << "Shell" << std::setw(32) << "FPGA" << "IDCode" << std::endl;
+		ostr << std::setw(32) << _pt.get<std::string>("platform.rom.vbnv", "N/A")
+			<< std::setw(32) << _pt.get<std::string>("platform.rom.fpga_name", "N/A")
+			<< _pt.get<std::string>("platform.info.idcode", "N/A") << std::endl;
+		ostr << std::setw(16) << "Vendor" << std::setw(16) << "Device" << std::setw(16) << "SubDevice"
+			<< std::setw(16) << "SubVendor" << std::setw(16) << "SerNum" << std::endl;
+		ostr << std::setw(16) << _pt.get<std::string>("pcie.vendor", "N/A")
+			<< std::setw(16) << _pt.get<std::string>("pcie.device", "N/A")
+			<< std::setw(16) << _pt.get<std::string>("pcie.subsystem_id", "N/A")
+			<< std::setw(16) << _pt.get<std::string>("pcie.subsystem_vendor", "N/A")
+			<< std::setw(16) << _pt.get<std::string>("pcie.serial_number", "N/A") << std::endl;
+		ostr << std::setw(16) << "DDR size" << std::setw(16) << "DDR count" << std::setw(16)
+			<< "Clock0" << std::setw(16) << "Clock1" << std::setw(16) << "Clock2" << std::endl;
+		ostr << std::setw(16) << strtoull(_pt.get<std::string>("platform.rom.ddr_size_bytes", "N/A").c_str(), nullptr, 16) / (1024 * 1024)
+			<< std::setw(16) << _pt.get("platform.rom.widdr_countdth", -1)
+			<< std::setw(16) << _pt.get("platform.info.clock0", -1)
+			<< std::setw(16) << _pt.get("platform.info.clock1", -1)
+			<< std::setw(16) << _pt.get("platform.info.clock2", -1) << std::endl;
+
+		ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+
+		//dumpPartitionInfo(ostr);
+		ostr.flags(f);
+}
+
 void
 XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
 {
@@ -56,6 +89,7 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
     // Platform information
     boost::property_tree::ptree ptPlatform;
 
+#if 0
     // Get and add generic information
     {
       boost::property_tree::ptree pt;
@@ -63,6 +97,7 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
       ptPlatform.add_child("info", pt);
     }
 
+#endif
     // Get and add ROM information
     {
       boost::property_tree::ptree pt;
@@ -70,6 +105,7 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
       ptPlatform.add_child("rom", pt);
     }
 
+#if 0
     // Get and add XMC information
     {
       boost::property_tree::ptree pt;
@@ -139,10 +175,55 @@ XBDatabase::create_complete_device_tree(boost::property_tree::ptree & _pt)
       CoreDevice.read_device_dma_stats(device_id, pt);
       ptPlatform.add_child("pcie_dma", pt);
     }
+#endif
+	{
+	  //boost::property_tree::ptree pt;
+	  XU_IP_LAYOUT *ipLayout = NULL;
+	  unsigned long ipSize = CoreDevice.get_IpLayoutSize(device_id);
+	  ipLayout = (XU_IP_LAYOUT*)malloc(ipSize);
+	  CoreDevice.get_IpLayout(device_id, &ipLayout, ipSize);
+	  if (ipLayout != NULL) {
+		  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+		  std::cout << "Compute Unit Status:" << std::endl;
+		  for (int i = 0; i < ipLayout->m_count; i++) {
+			  XU_IP_DATA* data = &ipLayout->m_ip_data[i];
+			  if (data->m_type != IP_KERNEL)
+				  continue;
+			  size_t len = strlen((char*)data->m_name);
+			  std::string name((const char*)data->m_name, len);
 
+			  printf("[%d]: %s @0x%llx\t(TBD)\n", i, name.c_str(), data->m_base_address);
+		  }
+	  }
+		//ptPlatform.add_child("ip_layout", pt);
+	}
+
+	{
+	  std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+	  XOCL_MEM_TOPOLOGY_INFORMATION topoInfo;
+	  CoreDevice.get_memTopology(device_id, &topoInfo);
+	  printf("Got XoclStatMemTopology Data:\n");
+	  printf("Memory regions: %d\n", topoInfo.MemTopoCount);
+	  for (size_t i = 0; i < topoInfo.MemTopoCount; i++) {
+		  printf("\ttag=%s, start=0x%llx, size=0x%llx\n",
+			  topoInfo.MemTopo[i].m_tag,
+			  topoInfo.MemTopo[i].m_base_address,
+			  topoInfo.MemTopo[i].m_size);
+	  }
+	}
+
+	{
+		std::cout << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" << std::endl;
+		XOCL_MEM_RAW_INFORMATION memRaw;
+		CoreDevice.get_memRawInfo(device_id, &memRaw);
+		printf("Got XoclStatMemRaw Data:\n");
+		printf("Count: %d\n", memRaw.MemRawCount);
+		for (unsigned int i = 0; i < memRaw.MemRawCount; i++) {
+			printf("\t(%d) BOCount=%llu, MemoryUsage=0x%llx\n", i, memRaw.MemRaw[i].BOCount, memRaw.MemRaw[i].MemoryUsage);
+		}
+	}
     // Add the platform to the device tree
     ptDevice.add_child("platform", ptPlatform);
+    dump(ptDevice, std::cout);
   }
 }
-
-

--- a/src/runtime_src/core/tools/xbutil2/XBDatabase.h
+++ b/src/runtime_src/core/tools/xbutil2/XBDatabase.h
@@ -23,6 +23,7 @@
 
 namespace XBDatabase {
 void create_complete_device_tree(boost::property_tree::ptree & _pt);
+void dump(boost::property_tree::ptree & pt, std::ostream& ostr);
 };
 
 #endif


### PR DESCRIPTION
query: added changes to retrieve rom, pcie device info from
xocl user driver and printing that information in tree format.
Able to print IPLayout and memRawInfo in query output.

scan: added changes to retrieve device ready status from user driver.
>xbutil --override scan
INFO: Found total 1 card(s), 1 are usable.
[0] <board TBD> ...

dmatest: partial changes were added in SubCmdDmaTest.cpp file.
Able to read DDR size from user driver. Added changes to run
DMATest using dmatest lib APIs.
-Need to fix compile time errors and validate them.
>xbutil --override dmatest -b 1024
Total DDR size: 65536 MB
Got XoclStatMemTopology Data:
Memory regions: 4
type: 1, tag=bank0, start=0x4000000000, size=0x1000000
[TBD] Data Validity & DMA Test on bank0
type: 1, tag=bank1, start=0x5000000000, size=0x1000000
[TBD] Data Validity & DMA Test on bank1
type: 1, tag=bank2, start=0x6000000000, size=0x1000000
[TBD] Data Validity & DMA Test on bank2
type: 1, tag=bank3, start=0x7000000000, size=0x1000000
[TBD] Data Validity & DMA Test on bank3

Print IP Layout and Mem topology in query: Add changes to print
IP Layout and mem topology data in query sub command

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>