### PR TITLE
CR-1049976 ERROR: Card index 0 is out of range: xbutil query issue wi…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -394,10 +394,16 @@ static ssize_t ready_show(struct device *dev,
 			goto bail;
 		xocl_xmc_get_data(xdev, XCL_BDINFO, board_info);
 		/*
+		 * Note:
+		 * bmc_ver can be cut into 5.0 instead of 5.0.6
+		 * a temporary workaround is to compare first 5.0 part,
+		 * platform should make sure bmc_ver is intact.
+		 *
 		 * with legacy mgmtpf driver, exp_bmc_ver will be NULL.
 		 * And we have to mark ready in this case
 		 */
-		if (!strcmp(board_info->bmc_ver, board_info->exp_bmc_ver) ||
+		if (!strncmp(board_info->bmc_ver, board_info->exp_bmc_ver,
+			strlen(board_info->bmc_ver)) ||
 			board_info->exp_bmc_ver[0] == 0)
 			ret = 1;
 		else


### PR DESCRIPTION
…th latest XRT and released 201920_1 u50 platform

SC version is cut into 5.0 instead of 5.0.16, then sysfs of xocl cannot mark ready to 0x1.

[root@xsjhemn41 davidz]# /proj/xsjhdstaff2/davidzha/XRT_zocl/build/Debug/runtime_src/core/pcie/tools/xbmgmt/xbmgmt flash --scan
Card [0001:45:00.0]
    Card type:          u50
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u50_xdma_201920_2,[ts=0x5de2bfd3],[SC=5.0]
    Flashable partitions installed in system:
        xilinx_u50_xdma_201920_2,[ts=0x5de2bfd3],[SC=5.0.16]
        xilinx_u50_gen3x4-1rp_blp,[ts=0xb3f5a36427acdcda]

