### PR TITLE
CR-1049630 only show expert-only subcommand usage with hidden help option

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_expert.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_expert.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <string>
+#include "xbmgmt.h"
+#include <iostream>
+
+const char *subCmdExpertDesc = "Print out expert help message for a sub-command";
+const char *subCmdExpertUsage = "expert-help [sub-command]";
+
+int expertHandler(int argc, char *argv[])
+{
+    if (argc == 1) {
+        printHelp(true);
+        return 0;
+    }
+
+    std::string subCmd(argv[1]);
+    printSubCmdHelp(subCmd, true);//to-do
+    return 0;
+}

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_help.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_help.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 #include "xbmgmt.h"
+#include <iostream>
 
 const char *subCmdHelpDesc = "Print out help message for a sub-command";
 const char *subCmdHelpUsage = "help [sub-command]";
@@ -23,14 +24,11 @@ const char *subCmdHelpUsage = "help [sub-command]";
 int helpHandler(int argc, char *argv[])
 {
     if (argc == 1) {
-        printHelp();
+        printHelp(false);
         return 0;
     }
 
-    if (argc != 2)
-        return -EINVAL;
-
     std::string subCmd(argv[1]);
-    printSubCmdHelp(subCmd);
+    printSubCmdHelp(subCmd, false);
     return 0;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -448,7 +448,7 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
     stream << dsa.name;
     if (dsa.timestamp != NULL_TIMESTAMP)
     {
-        stream << ",[ts=0x" << std::hex << dsa.timestamp << "]";
+        stream << ",[ID=0x" << std::hex << dsa.timestamp << "]";
     }
     if (!dsa.bmcVer.empty())
     {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.h
@@ -22,8 +22,8 @@
 
 // Helper functions that can be used by all command handlers
 //
-void printHelp(void);
-void printSubCmdHelp(const std::string& subCmd);
+void printHelp(bool printExpHelp);
+void printSubCmdHelp(const std::string& subCmd, bool printExpHelp);
 bool canProceed(void);
 void sudoOrDie(void);
 unsigned int bdf2index(const std::string& bdfStr);
@@ -36,6 +36,10 @@ int xrt_xbmgmt_version_cmp() ;
 int helpHandler(int argc, char *argv[]);
 extern const char *subCmdHelpDesc;
 extern const char *subCmdHelpUsage;
+
+int expertHandler(int argc, char *argv[]);
+extern const char *subCmdExpertDesc;
+extern const char *subCmdExpertUsage;
 
 int versionHandler(int argc, char *argv[]);
 extern const char *subCmdVersionDesc;


### PR DESCRIPTION
```
$xbmgmt -expert-help
$ xbmgmt -expert
```
show expert sub commands as well

`$xbmgmt -expert-help clock`

shows the usage of clock (or any other expert) subcmd. I mostly added this option to be able to print flash user and experts-only options, but I haven't done that yet. 

*changed ts to ID in xbmgmt flash --scan