### PR TITLE
Retrieve ROM header from mgmt driver

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -35,7 +35,7 @@ static std::map<device::QueryRequest, device::QueryRequestEntry> sQueryTable =
   { device::QR_PCIE_EXPRESS_LANE_WIDTH,   { "QR_PCIE_EXPRESS_LANE_WIDTH",   "width",            &typeid(uint64_t),    device::format_primative }},
 
   { device::QR_ROM_VBNV,                  { "QR_ROM_VBNV",                  "vbnv",             &typeid(std::string), device::format_primative }},
-  { device::OR_ROM_DDR_BANK_SIZE,         { "OR_ROM_DDR_BANK_SIZE",         "ddr_size_bytes",   &typeid(uint64_t),    device::format_hex_base2_shiftup30 }},
+  { device::QR_ROM_DDR_BANK_SIZE,         { "QR_ROM_DDR_BANK_SIZE",         "ddr_size_bytes",   &typeid(uint64_t),    device::format_hex_base2_shiftup30 }},
   { device::QR_ROM_DDR_BANK_COUNT_MAX,    { "QR_ROM_DDR_BANK_COUNT_MAX",    "widdr_countdth",   &typeid(uint64_t),    device::format_primative }},
   { device::QR_ROM_FPGA_NAME,             { "QR_ROM_FPGA_NAME",             "fpga_name",        &typeid(std::string), device::format_primative }},
   { device::QR_DMA_THREADS_RAW,           { "QR_DMA_THREADS_RAW",           "dma_threads",      &typeid(std::vector<std::string>),  device::format_primative }},
@@ -254,7 +254,7 @@ device::
 get_rom_info(boost::property_tree::ptree& pt) const
 {
   query_and_put(QR_ROM_VBNV, pt);
-  query_and_put(OR_ROM_DDR_BANK_SIZE, pt);
+  query_and_put(QR_ROM_DDR_BANK_SIZE, pt);
   query_and_put(QR_ROM_DDR_BANK_COUNT_MAX, pt);
   query_and_put(QR_ROM_FPGA_NAME, pt);
 }

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -59,7 +59,7 @@ public:
       QR_DMA_THREADS_RAW,
 
       QR_ROM_VBNV,
-      OR_ROM_DDR_BANK_SIZE,
+      QR_ROM_DDR_BANK_SIZE,
       QR_ROM_DDR_BANK_COUNT_MAX,
       QR_ROM_FPGA_NAME,
       QR_ROM_RAW,

--- a/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
@@ -23,7 +23,7 @@
  *
  --*/
 #pragma once
-
+#include "xclfeatures.h"
 #define XCLMGMT_NUM_SUPPORTED_CLOCKS    4
 
 //
@@ -105,7 +105,6 @@ typedef union _DRIVER_VERSION
     ULONG AsUlong;
 } DRIVER_VERSION, *PDRIVER_VERSION;
 #pragma warning(default:4201) // nameless struct/union warning
-
 typedef struct pcie_config_info {
     USHORT vendor;
     USHORT device;
@@ -143,4 +142,5 @@ typedef struct xclmgmt_ioc_device_info {
     ULONGLONG        ocl_frequency[XCLMGMT_NUM_SUPPORTED_CLOCKS];
     bool             mig_calibration[4];
     USHORT           num_clocks;
+	struct FeatureRomHeader rom_hdr;
 }XCLMGMT_IOC_DEVICE_INFO, *PXCLMGMT_IOC_DEVICE_INFO;

--- a/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
@@ -182,7 +182,7 @@ typedef struct _XOCL_MAP_BAR_ARGS {
 
 typedef struct _XOCL_MAP_BAR_RESULT {
     PVOID       Bar;           // OUT: User VA of mapped buffer
-    ULONG       BarLength;     // OUT: Length of mapped buffer
+    ULONGLONG       BarLength;     // OUT: Length of mapped buffer
 } XOCL_MAP_BAR_RESULT, *PXOCL_MAP_BAR_RESULT;
 
 //
@@ -201,6 +201,7 @@ typedef enum _XOCL_STAT_CLASS {
     XoclStatIpLayout,
     XoclStatKds,
     XoclStatKdsCU,
+    XoclStatRomInfo,
 
 } XOCL_STAT_CLASS, *PXOCL_STAT_CLASS;
 
@@ -329,6 +330,16 @@ typedef struct _XOCL_KDS_CU_INFORMATION {
     XOCL_KDS_CU CuInfo[1];
 
 } XOCL_KDS_CU_INFORMATION, *PXOCL_KDS_CU_INFORMATION;
+
+//
+// XoclStatRomInfo
+//
+typedef struct _XOCL_ROM_INFORMATION {
+	UCHAR FPGAPartName[64];
+	UCHAR VBNVName[64];
+	uint8_t DDRChannelCount;
+	uint8_t DDRChannelSize;
+} XOCL_ROM_INFORMATION, *PXOCL_ROM_INFORMATION;
 
 //
 // IOCTL_XOCL_PREAD_BO

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -40,7 +40,7 @@ device_linux::get_sysdev_entry(QueryRequest qr) const
     { QR_PCIE_EXPRESS_LANE_WIDTH,   {"",     "link_width"}},
     { QR_DMA_THREADS_RAW,           {"dma",  "channel_stat_raw"}},
     { QR_ROM_VBNV,                  {"rom",  "VBNV"}},
-    { OR_ROM_DDR_BANK_SIZE,         {"rom",  "ddr_bank_size"}},
+    { QR_ROM_DDR_BANK_SIZE,         {"rom",  "ddr_bank_size"}},
     { QR_ROM_DDR_BANK_COUNT_MAX,    {"rom",  "ddr_bank_count_max"}},
     { QR_ROM_FPGA_NAME,             {"rom",  "FPGA"}},
     { QR_ROM_RAW,                   {"rom", "raw"}},

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -17,8 +17,10 @@
 #define XCL_DRIVER_DLL_EXPORT
 #include "device_windows.h"
 #include "mgmt.h"
+#include "shim.h"
 #include "common/utils.h"
 #include "xrt.h"
+#include "xclfeatures.h"
 #include "boost/format.hpp"
 #include <string>
 #include <iostream>
@@ -28,20 +30,23 @@
 
 namespace {
 
-void
-not_implemented(xrt_core::device::QueryRequest qr, const std::type_info&, boost::any& value)
+using device_type = xrt_core::device_windows;
+using qr_type = xrt_core::device::QueryRequest;
+
+static void
+not_implemented(const device_type*, qr_type qr, const std::type_info&, boost::any& value)
 {
   throw xrt_core::no_such_query(qr, "not implemented");
 }
 
-void
-flash_type(xrt_core::device::QueryRequest qr, const std::type_info&, boost::any& value)
+static void
+flash_type(const device_type*, qr_type, const std::type_info&, boost::any& value)
 {
   value = "SPI";
 }
 
-void
-xmc(xrt_core::device::QueryRequest qr, const std::type_info&, boost::any& value)
+static void
+xmc(const device_type*, qr_type qr, const std::type_info&, boost::any& value)
 {
   if(qr == xrt_core::device::QR_XMC_STATUS)
     value = 1;
@@ -50,9 +55,46 @@ xmc(xrt_core::device::QueryRequest qr, const std::type_info&, boost::any& value)
 }
 
 void
-mfg(xrt_core::device::QueryRequest qr, const std::type_info&, boost::any& value)
+mfg(const device_type*, qr_type, const std::type_info&, boost::any& value)
 {
   value = false;
+}
+
+static void
+rom(const device_type* device, qr_type qr, const std::type_info&, boost::any& value)
+{
+  auto init_feature_rom_header = [](const device_type* dev) {
+    FeatureRomHeader hdr = {0};
+    if (auto mhdl = dev->get_mgmt_handle())
+      mgmtpf::get_rom_info(mhdl, &hdr);
+    else if (auto uhdl = dev->get_user_handle())
+      userpf::get_rom_info(uhdl, &hdr);
+    else
+      throw std::runtime_error("No device handle");
+    return hdr;
+  };
+
+  // Thread safe static initialization (magic static)
+  static auto hdr = init_feature_rom_header(device);
+
+  switch (qr) {
+  case qr_type::QR_ROM_VBNV:
+    value = std::string(reinterpret_cast<const char*>(hdr.VBNVName));
+    break;
+  case qr_type::QR_ROM_DDR_BANK_SIZE:
+    value = hdr.DDRChannelSize;
+    break;
+  case qr_type::QR_ROM_DDR_BANK_COUNT_MAX:
+    value = hdr.DDRChannelCount;
+    break;
+  case qr_type::QR_ROM_FPGA_NAME:
+    value = std::string(reinterpret_cast<const char*>(hdr.FPGAPartName));
+    break;
+  case qr_type::QR_ROM_UUID:
+    value = std::string(reinterpret_cast<const char*>(hdr.uuid),16);
+  default:
+    throw std::runtime_error("device_windows::rom() unexpected qr " + std::to_string(qr));
+  }
 }
 
 } // namespace
@@ -73,12 +115,12 @@ get_IOCTL_entry(QueryRequest qr) const
     { QR_PCIE_LINK_SPEED,           { nullptr }},
     { QR_PCIE_EXPRESS_LANE_WIDTH,   { nullptr }},
     { QR_DMA_THREADS_RAW,           { nullptr }},
-    { QR_ROM_VBNV,                  { nullptr }},
-    { OR_ROM_DDR_BANK_SIZE,         { nullptr }},
-    { QR_ROM_DDR_BANK_COUNT_MAX,    { nullptr }},
-    { QR_ROM_FPGA_NAME,             { nullptr }},
-    { QR_ROM_RAW,                   { nullptr }},
-    { QR_ROM_UUID,                  { nullptr }},
+    { QR_ROM_VBNV,                  { rom }},
+    { QR_ROM_DDR_BANK_SIZE,         { rom }},
+    { QR_ROM_DDR_BANK_COUNT_MAX,    { rom }},
+    { QR_ROM_FPGA_NAME,             { rom }},
+    { QR_ROM_RAW,                   { rom }},
+    { QR_ROM_UUID,                  { rom }},
     { QR_XMC_VERSION,               { nullptr }},
     { QR_XMC_SERIAL_NUM,            { nullptr }},
     { QR_XMC_MAX_POWER,             { nullptr }},
@@ -164,7 +206,7 @@ query(QueryRequest qr, const std::type_info & tinfo, boost::any& value) const
   if (!entry.m_fcn)
     throw std::runtime_error("Unexpected error, exception should already have been thrown");
 
-  entry.m_fcn(qr,tinfo,value);
+  entry.m_fcn(this,qr,tinfo,value);
 
 //  std::string sErrorMsg;
   // Reference linux code:
@@ -215,14 +257,14 @@ device_windows(id_type device_id, bool user)
   if (user)
     return;
 
-  m_mgmthdl = mgmt::open(device_id);
+  m_mgmthdl = mgmtpf::open(device_id);
 }
 
 device_windows::
 ~device_windows()
 {
   if (m_mgmthdl)
-    mgmt::close(m_mgmthdl);
+    mgmtpf::close(m_mgmthdl);
 }
 
 void
@@ -238,7 +280,7 @@ read(uint64_t addr, void* buf, uint64_t len) const
   if (!m_mgmthdl)
     throw std::runtime_error("");
 
-  mgmt::read_bar(m_mgmthdl, addr, buf, len);
+  mgmtpf::read_bar(m_mgmthdl, addr, buf, len);
 }
 
 void
@@ -248,7 +290,7 @@ write(uint64_t addr, const void* buf, uint64_t len) const
   if (!m_mgmthdl)
     throw std::runtime_error("");
 
-  mgmt::write_bar(m_mgmthdl, addr, buf, len);
+  mgmtpf::write_bar(m_mgmthdl, addr, buf, len);
 }
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -25,13 +25,25 @@ class device_windows : public device_pcie
 {
 public:
   struct IOCTLEntry {
-    std::function<void(QueryRequest qr, const std::type_info& tinfo, boost::any& value)> m_fcn;
+    std::function<void(const device_windows*, QueryRequest, const std::type_info&, boost::any&)> m_fcn;
   };
 
   const IOCTLEntry & get_IOCTL_entry( QueryRequest qr) const;
 
   device_windows(id_type device_id, bool user);
   ~device_windows();
+
+  xclDeviceHandle
+  get_mgmt_handle() const
+  {
+    return m_mgmthdl;
+  }
+
+  xclDeviceHandle
+  get_user_handle() const
+  {
+    return get_device_handle();
+  }
 
   // query functions
   virtual void read_dma_stats(boost::property_tree::ptree &_pt) const;

--- a/src/runtime_src/core/pcie/windows/mgmt.h
+++ b/src/runtime_src/core/pcie/windows/mgmt.h
@@ -20,7 +20,9 @@
 #include "core/pcie/windows/config.h"
 #include "xrt.h"
 
-namespace mgmt { // shared implementation
+struct FeatureRomHeader;
+
+namespace mgmtpf { // shared implementation
 
 XRT_CORE_PCIE_WINDOWS_EXPORT
 unsigned int
@@ -42,6 +44,10 @@ XRT_CORE_PCIE_WINDOWS_EXPORT
 void
 write_bar(xclDeviceHandle hdl, uint64_t offset, const void* buf, uint64_t len);
 
-} // mgmt
+XRT_CORE_PCIE_WINDOWS_EXPORT
+void
+get_rom_info(xclDeviceHandle hdl, FeatureRomHeader* value);
+
+} // mgmtpf
 
 #endif

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -15,8 +15,10 @@
  * under the License.
  */
 #define XCL_DRIVER_DLL_EXPORT
+#define XRT_CORE_PCIE_WINDOWS_SOURCE
 #include "shim.h"
 #include "xrt_mem.h"
+#include "xclfeatures.h"
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
 
@@ -812,6 +814,14 @@ done:
     return true;
   }
 
+  void
+  get_rom_info(FeatureRomHeader* value)
+  {
+    // TODO
+    value->MajorVersion = 100;
+    value->MinorVersion = 100;
+  }
+
 }; // struct shim
 
 shim*
@@ -823,7 +833,16 @@ get_shim_object(xclDeviceHandle handle)
 
 }
 
-namespace xocl {  // shared implementation
+namespace userpf {
+
+void
+get_rom_info(xclDeviceHandle hdl, FeatureRomHeader* value)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_rom_info()");
+  auto shim = get_shim_object(hdl);
+  shim->get_rom_info(value);
+}
 
 }
 

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -17,11 +17,19 @@
 #ifndef _XRT_CORE_PCIE_WINDOWS_SHIM_H
 #define _XRT_CORE_PCIE_WINDOWS_SHIM_H
 
+#include "core/pcie/windows/config.h"
 #include "xrt.h"
 #include "core/common/xrt_profiling.h"
 
-namespace xocl { // shared implementation
+struct FeatureRomHeader;
 
-} // xocl
+namespace userpf {
+
+XRT_CORE_PCIE_WINDOWS_EXPORT
+void
+get_rom_info(xclDeviceHandle hdl, FeatureRomHeader* value);
+
+} // userpf
+
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -92,8 +92,18 @@ int subCmdScan(const std::vector<std::string> &_options)
     throw xrt_core::error("No devices found");
 
   for (auto& device : *devices) {
-    std::cout << "[" << device.second.get<std::string>("device_id") << "] <board TBD> ...\n";
-    // populate with  same output as old xbutil
+    auto device_id = device.second.get<unsigned int>("device_id", std::numeric_limits<unsigned int>::max());
+    auto udev = xrt_core::get_userpf_device(device_id);
+    boost::property_tree::ptree _pt;
+    udev->get_rom_info(_pt);
+#if 0
+    dev->read_ready_status(_pt);
+    bool ready = _pt.get<bool>("ready", "false");
+    if (ready)
+      ready_count++;
+
+    std::cout << "[" << device_id << "]: " << _pt.get<std::string>("vbnv", "N/A") << "(ts=" << _pt.get<std::string>("time_since_epoch", "N/A") << ")" << std::endl;
+#endif
   }
 
   return registerResult;


### PR DESCRIPTION
Change signature of query functions on windows to accomodate calling
driver ioctls.

Update User and Mgmt driver header.  This requires systems to update
their installed drivers accordingly.

Rename struct shim in mgmt.cpp to struct mgmt to avoid shim (userpf)
confusion.

Move internal shim and mgmt APIs into namespace userpf and mgmtpf
respectively.