### PR TITLE
Rewire xbutil scan to new query methods

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -64,6 +64,7 @@ public:
       QR_ROM_FPGA_NAME,
       QR_ROM_RAW,
       QR_ROM_UUID,
+      QR_ROM_TIME_SINCE_EPOCH,
 
       QR_XMC_VERSION,
       QR_XMC_SERIAL_NUM,

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -99,8 +99,20 @@ rom(const device_type* device, qr_type qr, const std::type_info&, boost::any& va
   case qr_type::QR_ROM_FPGA_NAME:
     value = std::string(reinterpret_cast<const char*>(hdr.FPGAPartName));
     break;
+  }
+
+  if (device->get_user_handle())
+    throw std::runtime_error("device_windows::rom() unexpected qr("
+                             + std::to_string(qr)
+                             + ") for userpf");
+
+  switch (qr) {
   case qr_type::QR_ROM_UUID:
     value = std::string(reinterpret_cast<const char*>(hdr.uuid),16);
+    break;
+  case qr_type::QR_ROM_TIME_SINCE_EPOCH:
+    value = hdr.TimeSinceEpoch;
+    break;
   default:
     throw std::runtime_error("device_windows::rom() unexpected qr " + std::to_string(qr));
   }
@@ -130,6 +142,7 @@ get_IOCTL_entry(QueryRequest qr) const
     { QR_ROM_FPGA_NAME,             { rom }},
     { QR_ROM_RAW,                   { rom }},
     { QR_ROM_UUID,                  { rom }},
+    { QR_ROM_TIME_SINCE_EPOCH,      { rom }},
     { QR_XMC_VERSION,               { nullptr }},
     { QR_XMC_SERIAL_NUM,            { nullptr }},
     { QR_XMC_MAX_POWER,             { nullptr }},

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -89,16 +89,16 @@ rom(const device_type* device, qr_type qr, const std::type_info&, boost::any& va
   switch (qr) {
   case qr_type::QR_ROM_VBNV:
     value = std::string(reinterpret_cast<const char*>(hdr.VBNVName));
-    break;
+    return;
   case qr_type::QR_ROM_DDR_BANK_SIZE:
     value = hdr.DDRChannelSize;
-    break;
+    return;
   case qr_type::QR_ROM_DDR_BANK_COUNT_MAX:
     value = hdr.DDRChannelCount;
-    break;
+    return;
   case qr_type::QR_ROM_FPGA_NAME:
     value = std::string(reinterpret_cast<const char*>(hdr.FPGAPartName));
-    break;
+    return;
   }
 
   if (device->get_user_handle())
@@ -109,10 +109,10 @@ rom(const device_type* device, qr_type qr, const std::type_info&, boost::any& va
   switch (qr) {
   case qr_type::QR_ROM_UUID:
     value = std::string(reinterpret_cast<const char*>(hdr.uuid),16);
-    break;
+    return;
   case qr_type::QR_ROM_TIME_SINCE_EPOCH:
     value = hdr.TimeSinceEpoch;
-    break;
+    return;
   default:
     throw std::runtime_error("device_windows::rom() unexpected qr " + std::to_string(qr));
   }

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -817,9 +817,24 @@ done:
   void
   get_rom_info(FeatureRomHeader* value)
   {
-    // TODO
-    value->MajorVersion = 100;
-    value->MinorVersion = 100;
+    XOCL_STAT_CLASS stat_class =  XoclStatRomInfo;
+    XOCL_ROM_INFORMATION device_info;
+
+    DWORD bytes = 0;
+    auto status = DeviceIoControl(m_dev,
+        IOCTL_XOCL_STAT,
+        &stat_class, sizeof(stat_class),
+        &device_info, sizeof(device_info),
+        &bytes,
+        nullptr);
+
+    if (!status || bytes != sizeof(device_info))
+      throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (rom_info) failed");
+
+    std::memcpy(value->FPGAPartName, device_info.FPGAPartName, sizeof(device_info.FPGAPartName));
+    std::memcpy(value->VBNVName, device_info.VBNVName, sizeof(device_info.VBNVName));
+    value->DDRChannelCount = device_info.DDRChannelCount;
+    value->DDRChannelSize = device_info.DDRChannelSize;
   }
 
 }; // struct shim

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -91,11 +91,11 @@ int subCmdScan(const std::vector<std::string> &_options)
   if (!devices || (*devices).size()==0)
     throw xrt_core::error("No devices found");
 
+  using query_request = xrt_core::device::QueryRequest;
   for (auto& device : *devices) {
     auto device_id = device.second.get<unsigned int>("device_id", std::numeric_limits<unsigned int>::max());
     auto udev = xrt_core::get_userpf_device(device_id);
-    boost::property_tree::ptree _pt;
-    udev->get_rom_info(_pt);
+    auto vbnv = xrt_core::query_device<std::string>(udev, query_request::QR_ROM_VBNV);
 #if 0
     dev->read_ready_status(_pt);
     bool ready = _pt.get<bool>("ready", "false");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -92,11 +92,12 @@ int subCmdScan(const std::vector<std::string> &_options)
     throw xrt_core::error("No devices found");
 
   using query_request = xrt_core::device::QueryRequest;
+  std::cout << "INFO: Found total " << (*devices).size() << " card(s), " << "TBD" << " are usable.\n";
   for (auto& device : *devices) {
     auto device_id = device.second.get<unsigned int>("device_id", std::numeric_limits<unsigned int>::max());
     auto udev = xrt_core::get_userpf_device(device_id);
     auto vbnv = xrt_core::query_device<std::string>(udev, query_request::QR_ROM_VBNV);
-	std::cout << "[" << device_id << "]: " << vbnv << "\n";
+    std::cout << "[" << device_id << "]: " << vbnv << "\n";
 #if 0
     dev->read_ready_status(_pt);
     bool ready = _pt.get<bool>("ready", "false");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -96,6 +96,7 @@ int subCmdScan(const std::vector<std::string> &_options)
     auto device_id = device.second.get<unsigned int>("device_id", std::numeric_limits<unsigned int>::max());
     auto udev = xrt_core::get_userpf_device(device_id);
     auto vbnv = xrt_core::query_device<std::string>(udev, query_request::QR_ROM_VBNV);
+	std::cout << "[" << device_id << "]: " << vbnv << "\n";
 #if 0
     dev->read_ready_status(_pt);
     bool ready = _pt.get<bool>("ready", "false");


### PR DESCRIPTION
Preview xbutil scan on windows without ready card status and timestamp