### PR TITLE
xrt-next.h: Fix typo in function declaration of xclGetNumLiveProcesses()

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt-next.h
+++ b/src/runtime_src/core/include/experimental/xrt-next.h
@@ -43,7 +43,7 @@ XCL_DRIVER_DLLESPEC int xclP2pEnable(xclDeviceHandle handle, bool enable, bool f
  * This uses kdsstat information in sysfs.
  */
 
-XCL_DRIVER_DLLESPEC uint xclGetNumLiveProcesses(xclDeviceHandle handle);
+XCL_DRIVER_DLLESPEC uint32_t xclGetNumLiveProcesses(xclDeviceHandle handle);
 
 /**
  * xclGetSysfsPath() - Helper function to build a sysfs node full path


### PR DESCRIPTION
In XRT/master commit e04c194 fixes this issue through PR #2294.
This needs to make its way to XRT/2019.2 to allow pure C applications
that using a configure or Cmake.

Typically, the build system compiles a test compile when a pkg-config
dependancy is added, which fails for the FFmpeg being used for the U30.

Fixes: fcadc99 Fix xclLogMsg va_list processing -- cannot call va_start()
	   twice on the same va_list

Signed-off-by: Rohit Athavale <rohit.athavale@xilinx.com>