### PR TITLE
lift restriction of mismatch SC version

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -394,20 +394,16 @@ static ssize_t ready_show(struct device *dev,
 			goto bail;
 		xocl_xmc_get_data(xdev, XCL_BDINFO, board_info);
 		/*
-		 * Note:
-		 * bmc_ver can be cut into 5.0 instead of 5.0.6
-		 * a temporary workaround is to compare first 5.0 part,
-		 * platform should make sure bmc_ver is intact.
-		 *
-		 * with legacy mgmtpf driver, exp_bmc_ver will be NULL.
-		 * And we have to mark ready in this case
+		 * Lift the restriction of mis-matching SC version for
+		 * experienced user to manually update SC firmware than
+		 * installed xsabin may contain.
 		 */
-		if (!strncmp(board_info->bmc_ver, board_info->exp_bmc_ver,
-			strlen(board_info->bmc_ver)) ||
-			board_info->exp_bmc_ver[0] == 0)
-			ret = 1;
-		else
-			ret = 0;
+		if (strcmp(board_info->bmc_ver, board_info->exp_bmc_ver)) {
+			xocl_warn(dev, "installed XSABIN has SC version: "
+			    "(%s) mismatch with loaded SC version: (%s).",
+			    board_info->exp_bmc_ver, board_info->bmc_ver);
+		}
+		ret = 1;
 	}
 
 bail:

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1250,7 +1250,9 @@ int xcldev::device::scVersionTest(void)
     pcidev::get_dev(m_idx)->sysfs_get("xmc", "exp_bmc_ver", errmsg, exp_sc_ver);
     if (!exp_sc_ver.empty() && sc_ver.compare(exp_sc_ver) != 0)
     {
-        std::cout << "SC firmware version is not expected. SC firmware running on board: " << sc_ver << ". Expected SC firmware: " << exp_sc_ver << std::endl; 
+        std::cout << "SC FIRMWARE MISMATCH, ATTENTION" << std::endl;
+        std::cout << "SC firmware running on board: " << sc_ver << ". Expected SC firmware from installed Shell: " << exp_sc_ver << std::endl;
+	std::cout << "Please use \"xbmgmt flash --scan\" to check installed Shell." << std::endl;
 	return 1;
     }
 


### PR DESCRIPTION
I finally got it tested on one of the machine. Is the xclbin valid warning message too much?


>SC firmware mismatch, ATTENTION
>SC firmware running on board: 4.0.7. Expected SC firmware from installed Shell: 4.2.0
>Using: xbmgmt flash --update --shell <xsabin file> to sync on board SC firmware
>WARN: == SC firmware version check PASSED with warning

dmesg:
ready_show: installed XSABIN has SC version: (4.2.0) mismatch with loaded SC version: (4.0.7).
