### PR TITLE
Removing ERT configuration code which is not necessary anymore

### DIFF
--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -107,46 +107,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
 
     if( (bo2devAddr == (uint64_t)(-1)) || (bo1devAddr == (uint64_t)(-1)))
         return 1;
-    //Allocate the exec_bo
     unsigned execHandle = xclAllocBO(handle, DATA_SIZE, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
-
-    std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;
-    //construct the exec buffer cmd to configure.
-    {
-        auto ecmd = reinterpret_cast<ert_configure_cmd*>(execData);
-
-        std::memset(ecmd, 0, DATA_SIZE);
-        ecmd->state = ERT_CMD_STATE_NEW;
-        ecmd->opcode = ERT_CONFIGURE;
-
-        ecmd->slot_size = 1024;
-        ecmd->num_cus = 1;
-        ecmd->cu_shift = 16;
-        ecmd->cu_base_addr = cu_base_addr;
-
-        ecmd->ert = ert;
-        if (ert) {
-            ecmd->cu_dma = 1;
-            ecmd->cu_isr = 1;
-        }
-
-        // CU -> base address mapping
-        ecmd->data[0] = cu_base_addr;
-        ecmd->count = 5 + ecmd->num_cus;
-    }
-
-    std::cout << "Send the exec command and configure FPGA (ERT)" << std::endl;
-    //Send the command.
-    if(xclExecBuf(handle, execHandle)) {
-        std::cout << "Unable to issue xclExecBuf" << std::endl;
-        return 1;
-    }
-
-    std::cout << "Wait until the command finish" << std::endl;
-    //Wait on the command finish
-    while (xclExecWait(handle,1000) == 0);
-
 
     std::cout << "Construct the exec command to run the kernel on FPGA" << std::endl;
     std::cout << "Due to the 1D OpenCL group size, the kernel must be launched ("<< count << ") times" << std::endl;

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -191,42 +191,8 @@ int main(int argc, char** argv)
         unsigned execHandle = xclAllocBO(handle, DATA_SIZE*4, 0, (1<<31));
         void* execData = xclMapBO(handle, execHandle, true);
 
-        //construct the exec buffer cmd to configure.
-        {
-            auto ecmd = reinterpret_cast<ert_configure_cmd*>(execData);
-
-            std::memset(ecmd, 0, DATA_SIZE);
-            ecmd->state = ERT_CMD_STATE_NEW;
-            ecmd->opcode = ERT_CONFIGURE;
-
-            ecmd->slot_size = 1024;
-            ecmd->num_cus = 1;
-            ecmd->cu_shift = 16;
-            ecmd->cu_base_addr = cu_base_addr;
-
-            ecmd->ert = ert;
-            if (ert) {
-                ecmd->cu_dma = 1;
-                ecmd->cu_isr = 1;
-            }
-
-            // CU -> base address mapping
-            ecmd->data[0] = cu_base_addr;
-            ecmd->count = 5 + ecmd->num_cus;
-        }
-
-        //Send the command.
-        if(xclExecBuf(handle, execHandle)) {
-            std::cout << "Unable to issue xclExecBuf" << std::endl;
-            return 1;
-        }
-
-        //Wait on the command finish
-        while (xclExecWait(handle,1000) == 0);
-
         std::cout << "Construct the exec command to run the kernel on FPGA" << std::endl;
 
-        //--
         //construct the exec buffer cmd to start the kernel.
         {
             auto ecmd = reinterpret_cast<ert_start_kernel_cmd*>(execData);

--- a/tests/xrt/07_sequence/main.cpp
+++ b/tests/xrt/07_sequence/main.cpp
@@ -121,45 +121,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
     unsigned execHandle = xclAllocBO(handle, DATA_SIZE*sizeof(unsigned), 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
-    std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;
-    //construct the exec buffer cmd to configure.
-    {
-        auto ecmd = reinterpret_cast<ert_configure_cmd*>(execData);
-
-        std::memset(ecmd, 0, DATA_SIZE);
-        ecmd->state = ERT_CMD_STATE_NEW;
-        ecmd->opcode = ERT_CONFIGURE;
-
-        ecmd->slot_size = 1024;
-        ecmd->num_cus = 1;
-        ecmd->cu_shift = 16;
-        ecmd->cu_base_addr = cu_base_addr;
-
-        ecmd->ert = ert;
-        if (ert) {
-            ecmd->cu_dma = 1;
-            ecmd->cu_isr = 1;
-        }
-
-        // CU -> base address mapping
-        ecmd->data[0] = cu_base_addr;
-        ecmd->count = 5 + ecmd->num_cus;
-    }
-
-    std::cout << "Send the exec command and configure FPGA (ERT)" << std::endl;
-    //Send the command.
-    if(xclExecBuf(handle, execHandle)) {
-        std::cout << "Unable to issue xclExecBuf" << std::endl;
-        return 1;
-    }
-
-    std::cout << "Wait until the command finish" << std::endl;
-    //Wait on the command finish
-    while (xclExecWait(handle,1000) == 0);
-
-
     std::cout << "Construct the exec command to run the kernel on FPGA" << std::endl;
-    //--
+    
     //construct the exec buffer cmd to start the kernel.
     {
         auto ecmd = reinterpret_cast<ert_start_kernel_cmd*>(execData);

--- a/tests/xrt/11_fp_mmult256/main.cpp
+++ b/tests/xrt/11_fp_mmult256/main.cpp
@@ -138,47 +138,9 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         unsigned execHandle = xclAllocBO(handle, DATA_SIZE*sizeof(float), 0, (1<<31));
         void* execData = xclMapBO(handle, execHandle, true);
         
-        std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;
-        //construct the exec buffer cmd to configure.
-        {
-            auto ecmd = reinterpret_cast<ert_configure_cmd*>(execData);
-            
-            std::memset(ecmd, 0, DATA_SIZE*sizeof(float));
-            ecmd->state = ERT_CMD_STATE_NEW;
-            ecmd->opcode = ERT_CONFIGURE;
-            
-            ecmd->slot_size = 1024;
-            ecmd->num_cus = 1;
-            ecmd->cu_shift = 16;
-            ecmd->cu_base_addr = cu_base_addr;
-            
-            ecmd->ert = ert;
-            if (ert) {
-                ecmd->cu_dma = 1;
-                ecmd->cu_isr = 1;
-            }
-            
-            // CU -> base address mapping
-            ecmd->data[0] = cu_base_addr;
-            ecmd->count = 5 + ecmd->num_cus;
-        }
-
-        std::cout << "Send the exec command and configure FPGA (ERT)" << std::endl;
-        //Send the command.
-        if(xclExecBuf(handle, execHandle)) {
-            std::cout << "Unable to issue xclExecBuf" << std::endl;
-            return 1;
-        }
-
-        std::cout << "Wait until the command finish" << std::endl;
-        //Wait on the command finish
-        while (xclExecWait(handle,1000) == 0);
-
-
         std::cout << "Construct the exec command to run the kernel on FPGA" << std::endl;
-        //--
-        //construct the exec buffer cmd to start the kernel.
 
+        //construct the exec buffer cmd to start the kernel.
         {
             auto ecmd = reinterpret_cast<ert_start_kernel_cmd*>(execData);
 

--- a/tests/xrt/13_add_one/main.cpp
+++ b/tests/xrt/13_add_one/main.cpp
@@ -135,45 +135,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
         //bo2[i] = 0x55;
     }
 
-    std::cout << "Construct the exe buf cmd to confire FPGA" << std::endl;
-    //construct the exec buffer cmd to configure.
-    {
-        auto ecmd = reinterpret_cast<ert_configure_cmd*>(execData);
-
-        std::memset(ecmd, 0, DATA_SIZE);
-        ecmd->state = ERT_CMD_STATE_NEW;
-        ecmd->opcode = ERT_CONFIGURE;
-
-        ecmd->slot_size = 1024;
-        ecmd->num_cus = 1;
-        ecmd->cu_shift = 16;
-        ecmd->cu_base_addr = cu_base_addr;
-
-        ecmd->ert = ert;
-        if (ert) {
-            ecmd->cu_dma = 1;
-            ecmd->cu_isr = 1;
-        }
-
-        // CU -> base address mapping
-        ecmd->data[0] = cu_base_addr;
-        ecmd->count = 5 + ecmd->num_cus;
-    }
-
-    std::cout << "Send the exec command and configure FPGA (ERT)" << std::endl;
-    //Send the command.
-    if(xclExecBuf(handle, execHandle)) {
-        std::cout << "Unable to issue xclExecBuf" << std::endl;
-        return 1;
-    }
-
-    std::cout << "Wait until the command finish" << std::endl;
-    //Wait on the command finish
-    while (xclExecWait(handle,1000) == 0);
-
-
     std::cout << "Construct the exec command to run the kernel on FPGA" << std::endl;
-    //--
+
     //construct the exec buffer cmd to start the kernel.
     {
         auto ecmd = reinterpret_cast<ert_start_kernel_cmd*>(execData);

--- a/tests/xrt/22_verify/main.cpp
+++ b/tests/xrt/22_verify/main.cpp
@@ -98,46 +98,8 @@ static int runKernel(xclDeviceHandle &handle, uint64_t cu_base_addr, size_t alig
     unsigned execHandle = xclAllocBO(handle, 1024, 0, (1<<31));
     void* execData = xclMapBO(handle, execHandle, true);
 
-    std::cout << "Construct the exe buf cmd to configure FPGA" << std::endl;
-    //construct the exec buffer cmd to configure.
-    {
-        auto ecmd = reinterpret_cast<ert_configure_cmd*>(execData);
-
-        std::memset(ecmd, 0, 1024);
-        ecmd->state = ERT_CMD_STATE_NEW;
-        ecmd->opcode = ERT_CONFIGURE;
-
-        ecmd->slot_size = 1024;
-        ecmd->num_cus = 1;
-        ecmd->cu_shift = 16;
-        ecmd->cu_base_addr = cu_base_addr;
-
-        ecmd->ert = ert;
-        if (ert) {
-            ecmd->cu_dma = 1;
-            ecmd->cu_isr = 1;
-        }
-
-        // CU -> base address mapping
-        ecmd->data[0] = cu_base_addr;
-        ecmd->count = 5 + ecmd->num_cus;
-    }
-
-    std::cout << "Send the exec command and configure FPGA (ERT)" << std::endl;
-    //Send the command.
-    if(xclExecBuf(handle, execHandle)) {
-        std::cout << "Unable to issue xclExecBuf" << std::endl;
-        return 1;
-    }
-
-    std::cout << "Wait until the command finish" << std::endl;
-    //Wait on the command finish
-    while (xclExecWait(handle,1000) == 0);
-
-
     std::cout << "Construct the exec command to run the kernel on FPGA" << std::endl;
 
-    //--
     //construct the exec buffer cmd to start the kernel.
     {
         auto ecmd = reinterpret_cast<ert_start_kernel_cmd*>(execData);


### PR DESCRIPTION
Since we don't have to send a exec buffer to configure the ERT, corresponding code is removed from the HAL API testcases. 