### PR TITLE
xbutil --override dmatest on windows

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -66,6 +66,8 @@ public:
       QR_ROM_UUID,
       QR_ROM_TIME_SINCE_EPOCH,
 
+      QR_MEM_TOPOLOGY_RAW,
+
       QR_XMC_VERSION,
       QR_XMC_SERIAL_NUM,
       QR_XMC_MAX_POWER,

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -134,7 +134,7 @@ namespace xcldev {
             Timer timer;
             result = runSync(XCL_BO_SYNC_BO_TO_DEVICE, true);
             auto timer_stop = timer.stop();
-            auto rate = mBOList.size() * mSize;
+            double rate = static_cast<double>(mBOList.size() * mSize);
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; // s
@@ -143,7 +143,7 @@ namespace xcldev {
             timer.reset();
             result += runSync(XCL_BO_SYNC_BO_FROM_DEVICE, true);
             timer_stop = timer.stop();
-            rate = mBOList.size() * mSize;
+            rate = static_cast<double>(mBOList.size() * mSize);
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; //

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -25,7 +25,7 @@
 #include <cstring>
 #include <iostream>
 
-#include "xclhal2.h"
+#include "xrt.h"
 
 namespace xcldev {
     class Timer {
@@ -44,13 +44,13 @@ namespace xcldev {
     };
 
     class DMARunner {
-        std::vector<unsigned int> mBOList;
+        std::vector<xclBufferHandle> mBOList;
         xclDeviceHandle mHandle;
         size_t mSize;
         unsigned mFlags;
 
-        int runSyncWorker(std::vector<unsigned>::const_iterator b,
-                          std::vector<unsigned>::const_iterator e,
+        int runSyncWorker(std::vector<xclBufferHandle>::const_iterator b,
+                          std::vector<xclBufferHandle>::const_iterator e,
                           xclBOSyncDirection dir) const {
             int result = 0;
             while (b < e) {
@@ -63,8 +63,8 @@ namespace xcldev {
         }
 
         int runSync(xclBOSyncDirection dir, bool mt) const {
-            const std::vector<unsigned>::const_iterator b = mBOList.begin();
-            const std::vector<unsigned>::const_iterator e = mBOList.end();
+            auto b = mBOList.begin();
+            auto e = mBOList.end();
             if (mt) {
                 auto len = e - b;
                 auto mid = b + len/2;
@@ -85,8 +85,8 @@ namespace xcldev {
                 count = 0x40000;
 
             for (long long i = 0; i < count; i++) {
-                unsigned bo = xclAllocBO(mHandle, mSize, 0, mFlags);
-                if (bo == 0xffffffff)
+                auto bo = xclAllocBO(mHandle, mSize, 0, mFlags);
+                if (bo == XRT_NULL_BO)
                     break;
                 mBOList.push_back(bo);
             }
@@ -97,13 +97,14 @@ namespace xcldev {
         }
 
         ~DMARunner() {
-            for (auto i : mBOList)
-                xclFreeBO(mHandle, i);
+            for (auto bo : mBOList)
+                xclFreeBO(mHandle, bo);
         }
 
         int validate(const char *buf) const {
             std::unique_ptr<char[]> bufCmp(new char[mSize]);
-            int result = 0;
+            int error = 0;
+            size_t result = 0;
             for (auto i : mBOList) {
                 //Clear out the host buffer
                 std::memset(bufCmp.get(), 0, mSize);
@@ -111,29 +112,29 @@ namespace xcldev {
                 if (result < 0)
                     break;
                 if (std::memcmp(buf, bufCmp.get(), mSize)) {
-                    result = -EIO;
+                    error = -EIO;
                     std::cout << "DMA Test data integrity check failed\n";
                     break;
                 }
             }
-            return result;
+            return error ? error : static_cast<int>(result);
         }
 
         int run() const {
             std::unique_ptr<char[]> buf(new char[mSize]);
             std::memset(buf.get(), 'x', mSize);
 
-            int result = 0;
+            size_t result = 0;
             for (auto i : mBOList)
                 result += xclWriteBO(mHandle, i, buf.get(), mSize, 0);
 
             if (result)
-                return result;
+                return static_cast<int>(result);
 
             Timer timer;
             result = runSync(XCL_BO_SYNC_BO_TO_DEVICE, true);
-            double timer_stop = timer.stop();
-            double rate = mBOList.size() * mSize;
+            auto timer_stop = timer.stop();
+            auto rate = mBOList.size() * mSize;
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; // s
@@ -150,7 +151,7 @@ namespace xcldev {
 
             // data integrity check: compare with initialized value 'x'
             result = validate(buf.get());
-            return result;
+            return static_cast<int>(result);
         }
     };
 }

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -35,6 +35,12 @@
 
 namespace {
 
+constexpr size_t
+operator"" _k (unsigned long long value)
+{
+  return value * 1024;
+}
+
 using device_type = xrt_core::device_windows;
 using qr_type = xrt_core::device::QueryRequest;
 
@@ -190,6 +196,23 @@ info(const device_type* device, qr_type qr, const std::type_info& tinfo, boost::
     throw std::runtime_error("No device handle");
 }
 
+static void
+xclbin_fcn(const device_type* device, qr_type qr, const std::type_info&, boost::any& value)
+{
+  auto uhdl = device->get_user_handle();
+  if (!uhdl)
+    throw std::runtime_error("Query request " + std::to_string(qr) + "requires a userpf device");
+
+  if (qr == qr_type::QR_MEM_TOPOLOGY_RAW) {
+    std::vector<char> data(4_k);
+    userpf::get_mem_topology(uhdl, data.data(), 4_k);
+    value = data;
+    return;
+  }
+
+  throw std::runtime_error("device_windows::xclbin() unexpected qr " + std::to_string(qr));
+}
+
 } // namespace
 
 namespace xrt_core {
@@ -215,6 +238,7 @@ get_IOCTL_entry(QueryRequest qr) const
     { QR_ROM_RAW,                   { rom }},
     { QR_ROM_UUID,                  { rom }},
     { QR_ROM_TIME_SINCE_EPOCH,      { rom }},
+    { QR_MEM_TOPOLOGY_RAW,          { xclbin_fcn }},
     { QR_XMC_VERSION,               { nullptr }},
     { QR_XMC_SERIAL_NUM,            { nullptr }},
     { QR_XMC_MAX_POWER,             { nullptr }},

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -95,10 +95,10 @@ rom(const device_type* device, qr_type qr, const std::type_info&, boost::any& va
     value = std::string(reinterpret_cast<const char*>(hdr.VBNVName));
     return;
   case qr_type::QR_ROM_DDR_BANK_SIZE:
-    value = hdr.DDRChannelSize;
+    value = static_cast<uint64_t>(hdr.DDRChannelSize);
     return;
   case qr_type::QR_ROM_DDR_BANK_COUNT_MAX:
-    value = hdr.DDRChannelCount;
+    value = static_cast<uint64_t>(hdr.DDRChannelCount);
     return;
   case qr_type::QR_ROM_FPGA_NAME:
     value = std::string(reinterpret_cast<const char*>(hdr.FPGAPartName));

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -913,6 +913,27 @@ done:
       throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (get_device_info) failed");
   }
 
+  void
+  get_mem_topology(char* buffer, size_t len)
+  {
+    XOCL_MEM_TOPOLOGY_INFORMATION mem_info;
+    XOCL_STAT_CLASS stat_class =  XoclStatMemTopology;
+
+    DWORD bytes = 0;
+    auto status = DeviceIoControl(m_dev,
+        IOCTL_XOCL_STAT,
+        &stat_class, sizeof(stat_class),
+        &mem_info, sizeof(XOCL_MEM_TOPOLOGY_INFORMATION),
+        &bytes,
+        nullptr);
+
+    if (!status || bytes != sizeof(XOCL_MEM_TOPOLOGY_INFORMATION) || len < sizeof(XOCL_MEM_TOPOLOGY_INFORMATION))
+      throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (get_mem_topology) failed");
+
+    std::memcpy(buffer, &mem_info, sizeof(XOCL_MEM_TOPOLOGY_INFORMATION));
+  }
+
+
 
 }; // struct shim
 
@@ -943,6 +964,15 @@ get_device_info(xclDeviceHandle hdl, XOCL_DEVICE_INFORMATION* value)
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_device_info()");
   auto shim = get_shim_object(hdl);
   shim->get_device_info(value);
+}
+
+void
+get_mem_topology(xclDeviceHandle hdl, char* buffer, size_t len)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_device_info()");
+  auto shim = get_shim_object(hdl);
+  shim->get_mem_topology(buffer, len);
 }
 
 } // userpf

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -35,6 +35,10 @@ XRT_CORE_PCIE_WINDOWS_EXPORT
 void
 get_device_info(xclDeviceHandle hdl, XOCL_DEVICE_INFORMATION* value);
 
+XRT_CORE_PCIE_WINDOWS_EXPORT
+void
+get_mem_topology(xclDeviceHandle hdl, char* buffer, size_t len);
+
 } // userpf
 
 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -78,6 +78,7 @@ else()
     boost_filesystem
     boost_system
     boost_program_options
+    pthread
     uuid
     dl
   )

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -26,6 +26,7 @@ if(WIN32)
   file(GLOB XBUTIL_V2_SUBCMD_FILES
     "SubCmdProgram.cpp"
     "SubCmdClock.cpp"
+    "SubCmdDmaTest.cpp"
     "SubCmdQuery.cpp"
     "SubCmdReset.cpp"
     "SubCmdScan.cpp"

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -31,6 +31,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <iterator>
 
 // ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
 #include "tools/common/SubCmd.h"
@@ -67,6 +68,7 @@ dmatest(const std::shared_ptr<xrt_core::device>& device, size_t block_size, bool
 
   //for (auto itrint32_t i = 0; i < map->m_count; i++) {
   for (auto& mem : boost::make_iterator_range(mem_topo->m_mem_data, mem_topo->m_mem_data + mem_topo->m_count)) {
+    auto midx = std::distance(mem_topo->m_mem_data, &mem);
     if (mem.m_type == MEM_STREAMING)
       continue;
 
@@ -86,11 +88,11 @@ dmatest(const std::shared_ptr<xrt_core::device>& device, size_t block_size, bool
         throw xrt_core::error(result, "DMATest failed mem write");
 #endif
     }
-#if 0
-    DMARunner runner( m_handle, blockSize, i);
+
+    xcldev::DMARunner runner(device->get_device_handle(), block_size, static_cast<unsigned int>(midx));
     if (int ret = runner.run())
       throw xrt_core::error(ret,"DMATest failed");
-#endif
+
   }
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -17,11 +17,16 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "SubCmdDmaTest.h"
+#include "common/system.h"
+#include "common/device.h"
+#include "core/pcie/common/dmatest.h"
+
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/range/iterator_range.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -29,15 +34,67 @@ namespace po = boost::program_options;
 
 // ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
 #include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("dmatest", 
+static const unsigned int registerResult =
+                    register_subcommand("dmatest",
                                         "Runs a DMA test on a given device",
                                         subCmdDmaTest);
 // =============================================================================
+namespace {
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+static void
+dmatest(const std::shared_ptr<xrt_core::device>& device, size_t block_size, bool verbose)
+{
+  if (block_size == 0)
+      block_size = 256 * 1024 * 1024; // Default block size
 
+  auto ddr_mem_size = xrt_core::query_device<uint64_t>(device, xrt_core::device::QR_ROM_DDR_BANK_SIZE);
 
+  if (verbose)
+    std::cout << "Total DDR size: " << ddr_mem_size << " MB\n";
+
+  // get DDR bank count from mem_topology if possible
+  auto membuf = xrt_core::query_device<std::vector<char>>(device, xrt_core::device::QR_MEM_TOPOLOGY_RAW);
+  auto mem_topo = reinterpret_cast<const mem_topology*>(membuf.data());
+  if (membuf.empty() || mem_topo->m_count == 0)
+    throw std::runtime_error
+      ("WARNING: 'mem_topology' invalid, unable to perform DMA Test. Has the "
+       "bitstream been loaded?  See 'xbutil program' to load a specific "
+       "xclbin file or run 'xbutil validate' to use the xclbins "
+       "provided with this card.");
+
+  if (verbose)
+    std::cout << "Reporting from mem_topology:" << std::endl;
+
+  //for (auto itrint32_t i = 0; i < map->m_count; i++) {
+  for (auto& mem : boost::make_iterator_range(mem_topo->m_mem_data, mem_topo->m_mem_data + mem_topo->m_count)) {
+    if (mem.m_type == MEM_STREAMING)
+      continue;
+
+    if (!mem.m_used)
+      continue;
+
+    if (verbose)
+      std::cout << "Data Validity & DMA Test on " << mem.m_tag << "\n";
+
+    for(unsigned int sz = 1; sz <= 256; sz *= 2) {
+#if 0
+      auto result = memwriteQuiet(mem.m_base_address, sz, 'J');
+      if (result < 0)
+        throw xrt_core::error(result, "DMATest failed mem write");
+      result = memreadCompare(mem.m_base_address, sz, 'J', false);
+      if (result < 0)
+        throw xrt_core::error(result, "DMATest failed mem write");
+#endif
+    }
+#if 0
+    DMARunner runner( m_handle, blockSize, i);
+    if (int ret = runner.run())
+      throw xrt_core::error(ret,"DMATest failed");
+#endif
+  }
+}
+
+} // namespace
 
 
 // ------ F U N C T I O N S ---------------------------------------------------
@@ -49,15 +106,14 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
 {
   XBU::verbose("SubCommand: dmatest");
   // -- Retrieve and parse the subcommand options -----------------------------
-  uint64_t card = 0;
-  uint64_t blockSizeKB = 0;
+  xrt_core::device::id_type card = 0;
   std::string sBlockSizeKB;
   bool help = false;
 
   po::options_description dmaTestDesc("dmatest options");
   dmaTestDesc.add_options()
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
-    (",d", boost::program_options::value<uint64_t>(&card), "Card to be examined")
+    (",d", boost::program_options::value<decltype(card)>(&card), "Card to be examined")
     (",b", boost::program_options::value<std::string>(&sBlockSizeKB), "Block Size KB")
   ;
 
@@ -82,15 +138,13 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
   }
 
   // -- Now process the subcommand --------------------------------------------
-  blockSizeKB = stoi(sBlockSizeKB, nullptr, 0);
-
-  XBU::verbose(XBU::format("      Card: %ld", card));
-  XBU::verbose(XBU::format("Block Size: 0x%lx", blockSizeKB));
-
+  auto device = xrt_core::get_userpf_device(card);
+  auto block_size = std::strtoll(sBlockSizeKB.c_str(), nullptr, 0);
+  bool verbose = true;
+  dmatest(device, block_size, verbose);
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
 
   return registerResult;
 }
-

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -145,8 +145,5 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
   bool verbose = true;
   dmatest(device, block_size, verbose);
 
-  XBU::error("COMMAND BODY NOT IMPLEMENTED.");
-  // TODO: Put working code here
-
   return registerResult;
 }


### PR DESCRIPTION
dmatest for windows with query calls to device infrastructure for mem topology and ddrs

C:\Users\soeren\git\stsoe\XRT>xbutil --override dmatest
Total DDR size: 16 MB
Reporting from mem_topology:
Data Validity & DMA Test on bank0
Buffer Size: 256 MB
Host -> PCIe -> FPGA write bandwidth = 10297.8 MB/s
Host <- PCIe <- FPGA read bandwidth = 10927.5 MB/s
Data Validity & DMA Test on bank1
Buffer Size: 256 MB
Host -> PCIe -> FPGA write bandwidth = 10395 MB/s
Host <- PCIe <- FPGA read bandwidth = 10836.8 MB/s
Data Validity & DMA Test on bank2
Buffer Size: 256 MB
Host -> PCIe -> FPGA write bandwidth = 10367.4 MB/s
Host <- PCIe <- FPGA read bandwidth = 10815.2 MB/s
Data Validity & DMA Test on bank3
Buffer Size: 256 MB
Host -> PCIe -> FPGA write bandwidth = 10253.1 MB/s
Host <- PCIe <- FPGA read bandwidth = 10860 MB/s