### PR TITLE
should not fail for non-xmc platforms when downloading xclbin

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2298,9 +2298,7 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 	ICAP_INFO(icap, "incoming xclbin: %pUb\non device xclbin: %pUb",
 		&xclbin->m_header.uuid, &icap->icap_bitstream_uuid);
 
-	err = xocl_cmc_freeze(xdev);
-	if (err)
-		goto done;
+	xocl_cmc_freeze(xdev);
 
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 	icap_refresh_addrs(pdev);
@@ -2361,8 +2359,11 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 		}
 	}
 
-	if (ICAP_PRIVILEGED(icap))
+	if (ICAP_PRIVILEGED(icap)) {
 		err = xocl_cmc_free(xdev);
+		if (err == -ENODEV)
+			err = 0;
+	}
 
 done:
 	if (err) {


### PR DESCRIPTION
there is only one chance to get EBUSY during xocl_cmc_free, so ignore errors for xocl_cmc_freeze and treat ENODEV for xocl_cmc_free as err = 0, aka not a failure.

In the future, we could refactor the download code and isolate pre-download, download, post-downlod . The pre-download and post-download can be done by a (Observer pattern: http://www.adampetersen.se/Patterns%20in%20C%204,%20OBSERVER.pdf).