### PR TITLE
versal ospi support

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -141,6 +141,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/subdev/mgmt_msix.c
   xocl/subdev/flash.c
   xocl/subdev/mailbox_versal.c
+  xocl/subdev/ospi_versal.c
   xocl/Makefile
   )
 

--- a/src/runtime_src/core/common/drv/xrt_drv.h
+++ b/src/runtime_src/core/common/drv/xrt_drv.h
@@ -27,4 +27,23 @@
 #define XRT_DRV_BO_USER_ALLOC	(1 << 25)
 #define XRT_DRV_BO_CMA		(1 << 24)
 #define XRT_DRV_BO_CACHEABLE	(1 << 23)
+
+#define	XRT_PDI_PKT_STATUS_IDLE		0
+#define	XRT_PDI_PKT_STATUS_NEW		1
+#define	XRT_PDI_PKT_STATUS_DONE		2
+#define	XRT_PDI_PKT_STATUS_FAIL		3
+
+#define	XRT_PDI_PKT_FLAGS_LAST		(1 << 0)
+
+struct pdi_packet {
+	union {
+		struct {
+			u8	pkt_status;
+			u8	pkt_flags;
+			u16	pkt_size;
+		};
+		u32 header;
+	};
+} __packed;
+
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -13,6 +13,8 @@ zocl-y := \
 	zocl_dma.o \
 	zocl_cu.o \
 	zocl_mailbox.o \
+	zocl_ov_sysfs.o \
+	zocl_ospi_versal.o \
 	zocl_xclbin.o \
 	zocl_sk.o
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -865,6 +865,7 @@ static struct platform_driver zocl_drm_private_driver = {
 
 static struct platform_driver *const drivers[] = {
 	&zocl_ert_driver,
+	&zocl_ospi_versal_driver,
 };
 
 static int __init zocl_init(void)

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
@@ -31,6 +31,7 @@
 #include "zocl_ert.h"
 #include "zocl_bo.h"
 #include "zocl_dma.h"
+#include "zocl_ospi_versal.h"
 
 #if defined(CONFIG_ARM64)
 #define ZOCL_PLATFORM_ARM64   1

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
@@ -1,0 +1,301 @@
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ based
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu <yliu@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/kthread.h>
+#include <linux/platform_device.h>
+
+#include "zocl_drv.h"
+#include "xrt_drv.h"
+#include "zocl_ospi_versal.h"
+
+#define ov_err(pdev, fmt, args...)  \
+	zocl_err(&pdev->dev, fmt"\n", ##args)
+#define ov_info(pdev, fmt, args...)  \
+	zocl_info(&pdev->dev, fmt"\n", ##args)
+#define ov_dbg(pdev, fmt, args...)  \
+	zocl_dbg(&pdev->dev, fmt"\n", ##args)
+
+static inline u32 wait_for_status(struct zocl_ov_dev *ov, u8 status)
+{
+	u32 header;
+	struct pdi_packet *pkt = (struct pdi_packet *)&header;
+
+	for (;;) {
+		header = ioread32(ov->base);
+		if (pkt->pkt_status == status)
+			break;
+	}
+
+	return header;
+}
+
+static inline bool check_for_status(struct zocl_ov_dev *ov, u8 status)
+{
+	struct pdi_packet *pkt;
+	u32 header;
+
+	pkt = (struct pdi_packet *)&header;
+	header = ioread32(ov->base);
+	return (pkt->pkt_status == status);
+}
+
+static inline void set_status(struct zocl_ov_dev *ov, u8 status)
+{
+	struct pdi_packet pkt;
+
+	pkt.pkt_status = status;
+	iowrite32(pkt.header, ov->base);
+}
+
+static inline void read_data(u32 *addr, u32 *data, size_t sz)
+{
+	int i;
+
+	for (i = 0; i < sz; ++i)
+		*(data + i) = ioread32(addr + i);
+}
+
+static void zocl_ov_clean(struct zocl_ov_dev *ov)
+{
+	struct zocl_ov_pkt_node *node;
+	struct zocl_ov_pkt_node *pnode;
+
+	node = ov->head;
+	while (node != NULL) {
+		pnode = node;
+		node = pnode->zn_next;
+		vfree(pnode->zn_datap);
+		vfree(pnode);
+	}
+
+	ov->head = NULL;
+}
+
+/*
+ * This function is called once we detect there is a new PDI packet and it
+ * will communicate with host driver to collect all PDI packets and then
+ * communicate with user space daemon to flash the PDI.
+ *
+ * 1) start receiving PDI packets
+ * 2) put all pdi packets into a linked packets list
+ * 3) once got all packets, update sysfs node to indicate PDI is ready
+ * 4) wait on sysfs node on PDI flash done
+ * 5) update PDI packet status to notify host
+ */
+static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
+{
+	struct zocl_ov_pkt_node *node = ov->head;
+	u32 *base = ov->base;
+	int ret;
+
+	write_lock(&ov->att_rwlock);
+
+	/* Clear the done flag */
+	ov->pdi_done = 0;
+
+	for (;;) {
+		u32 pkt_header;
+		struct pdi_packet *pkt = (struct pdi_packet *)&pkt_header;
+		struct zocl_ov_pkt_node *new;
+
+		/* Busy wait here until we get a new packet */
+		pkt_header = wait_for_status(ov, XRT_PDI_PKT_STATUS_NEW);
+
+		new = vzalloc(sizeof(struct zocl_ov_pkt_node));
+		if (!new) {
+			set_status(ov, XRT_PDI_PKT_STATUS_FAIL);
+			ret = -ENOMEM;
+			goto fail;
+		}
+		new->zn_datap = vmalloc(ov->size);
+		if (!new->zn_datap) {
+			set_status(ov, XRT_PDI_PKT_STATUS_FAIL);
+			ret = -ENOMEM;
+			goto fail;
+		}
+		new->zn_size = pkt->pkt_size;
+
+		/* Read packet data payload on a 4 bytes base */
+		read_data(base + (sizeof(struct pdi_packet)) / 4,
+		    new->zn_datap, (ov->size - sizeof(struct pdi_packet)) / 4);
+
+		/* Notify host that the data has been read */
+		set_status(ov, XRT_PDI_PKT_STATUS_IDLE);
+
+		/* Add packet data to linked list */
+		if (node)
+			node->zn_next = new;
+		else
+			ov->head = new;
+		node = new;
+
+		/* Bail out here if this is the last packet */
+		if (pkt->pkt_flags & XRT_PDI_PKT_FLAGS_LAST)
+			break;
+	}
+
+	/* Set ready flag */
+	ov->pdi_ready = 1;
+	write_unlock(&ov->att_rwlock);
+
+	/* Wait for done */
+	read_lock(&ov->att_rwlock);
+	while (true) {
+		/*
+		 * pdi_done indicates the status of the flashing
+		 * 0: in progress
+		 * 1: completed successfully
+		 * 2: fail
+		 */
+		if (!ov->pdi_done) {
+			read_unlock(&ov->att_rwlock);
+			msleep(ZOCL_OV_TIMER_INTERVAL);
+			read_lock(&ov->att_rwlock);
+			continue;
+		}
+		if (ov->pdi_done == 1)
+			set_status(ov, XRT_PDI_PKT_STATUS_DONE);
+		else
+			set_status(ov, XRT_PDI_PKT_STATUS_FAIL);
+		break;
+	}
+	read_unlock(&ov->att_rwlock);
+
+	/* Clear ready flag */
+	write_lock(&ov->att_rwlock);
+	ov->pdi_ready = 0;
+	zocl_ov_clean(ov);
+	write_unlock(&ov->att_rwlock);
+
+	return 0;
+
+fail:
+	zocl_ov_clean(ov);
+	write_unlock(&ov->att_rwlock);
+
+	return ret;
+}
+
+/*
+ * This is the main thread in zocl ospi versal subdriver.
+ *
+ * The thread will wake up every second and check the PDI packet
+ * status. If there is a new packet ready, it will start load and
+ * flash PDI.
+ */
+static int zocl_ov_thread(void *data)
+{
+	struct zocl_ov_dev *ov = (struct zocl_ov_dev *)data;
+
+	while (1) {
+		if (kthread_should_stop())
+			break;
+
+		if (check_for_status(ov, XRT_PDI_PKT_STATUS_IDLE)) {
+			msleep(ZOCL_OV_TIMER_INTERVAL);
+			continue;
+		}
+
+		zocl_ov_get_pdi(ov);
+	}
+
+	return 0;
+}
+
+static const struct of_device_id zocl_ospi_versal_of_match[] = {
+	{ .compatible = "xlnx,ospi_versal",
+	},
+	{ /* end of table */ },
+};
+
+MODULE_DEVICE_TABLE(of, zocl_ospi_versal_of_match);
+
+static int zocl_ov_probe(struct platform_device  *pdev)
+{
+	struct zocl_ov_dev *ov;
+	const struct of_device_id *id;
+	struct resource *res;
+	void __iomem *map;
+	char thread_name[256] = "zocl-ov-thread";
+	int ret;
+
+	id = of_match_node(zocl_ospi_versal_of_match, pdev->dev.of_node);
+	ov_info(pdev, "Probing for %s", id->compatible);
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM,
+	    ZOCL_OSPI_VERSAL_BRAM_RES);
+	map = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(map)) {
+		ov_err(pdev, "Unable to map OSPI resource: %0lx.\n",
+		    PTR_ERR(map));
+		return PTR_ERR(map);
+	}
+
+	ov = devm_kzalloc(&pdev->dev, sizeof(*ov), GFP_KERNEL);
+	if (!ov)
+		return -ENOMEM;
+
+	ov->base = map;
+	ov->size = res->end - res->start + 1;
+	memset_io(ov->base, 0, ov->size);
+
+	rwlock_init(&ov->att_rwlock);
+
+	ret = zocl_ov_init_sysfs(&pdev->dev);
+	if (ret) {
+		ov_err(pdev, "Unable to create ospi versal sysfs node.\n");
+		kfree(ov);
+		return ret;
+	}
+
+	/* Start the thread. */
+	ov->timer_task = kthread_run(zocl_ov_thread, ov, thread_name);
+	if (IS_ERR(ov->timer_task)) {
+		ret = PTR_ERR(ov->timer_task);
+
+		ov_err(pdev, "Unable to create ospi versal thread.\n");
+		kfree(ov);
+		return ret;
+	}
+
+	platform_set_drvdata(pdev, ov);
+
+	return 0;
+}
+
+static int zocl_ov_remove(struct platform_device *pdev)
+{
+	struct zocl_ov_dev *ov = platform_get_drvdata(pdev);
+
+	zocl_ov_fini_sysfs(&pdev->dev);
+
+	if (ov && ov->timer_task)
+		kthread_stop(ov->timer_task);
+
+	return 0;
+}
+
+struct platform_driver zocl_ospi_versal_driver = {
+	.driver = {
+		.name = ZOCL_OSPI_VERSAL_NAME,
+		.of_match_table = zocl_ospi_versal_of_match,
+	},
+	.probe  = zocl_ov_probe,
+	.remove = zocl_ov_remove,
+};

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.h
@@ -1,0 +1,61 @@
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ based
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu <yliu@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _ZOCL_OSPI_VERSAL_H_
+#define	_ZOCL_OSPI_VERSAL_H_
+
+extern struct platform_driver zocl_ospi_versal_driver;
+
+struct zocl_ov_pkt_node {
+	size_t			zn_size;
+	u32			*zn_datap;
+	struct zocl_ov_pkt_node	*zn_next;
+};
+
+/**
+ * Main structure of ospi versal subdev.
+ * @timer_task:	main thread pointer
+ * @base:	PDI packet area base address
+ * @size:	PDI packet area size
+ * @pdi_ready:	flag to indicate PDI image is ready
+ * @pdi_done:	flag to indicate PDI flashing is done
+ * @head:	head node of PDI packet linked list
+ */
+struct zocl_ov_dev {
+	struct task_struct	*timer_task;
+	void __iomem		*base;
+	size_t			size;
+	u8			pdi_ready;
+	u8			pdi_done;
+	rwlock_t		att_rwlock;
+	struct zocl_ov_pkt_node	*head;
+};
+
+/* Timer thread wake up interval in Millisecond */
+#define	ZOCL_OV_TIMER_INTERVAL		(1000)
+
+#define	ZOCL_OSPI_VERSAL_BRAM_RES	0
+
+/* OSPI VERSAL driver name */
+#define	ZOCL_OSPI_VERSAL_NAME "zocl_ospi_versal"
+
+int zocl_ov_init_sysfs(struct device *dev);
+void zocl_ov_fini_sysfs(struct device *dev);
+
+#endif /* _ZOCL_OSPI_VERSAL_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ov_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ov_sysfs.c
@@ -1,0 +1,150 @@
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ base
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu   <yliu@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "zocl_drv.h"
+#include "zocl_ospi_versal.h"
+
+static ssize_t pdi_done_store(struct device *dev,
+		struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct zocl_ov_dev *ov = dev_get_drvdata(dev);
+	u8 val;
+
+	if (!ov)
+		return 0;
+
+	if (kstrtou8(buf, 16, &val) == -EINVAL)
+		return -EINVAL;
+
+	write_lock(&ov->att_rwlock);
+	ov->pdi_done = val;
+	write_unlock(&ov->att_rwlock);
+
+	return count;
+}
+static DEVICE_ATTR_WO(pdi_done);
+
+static ssize_t pdi_ready_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct zocl_ov_dev *ov = dev_get_drvdata(dev);
+	ssize_t size = 0;
+
+	if (!ov)
+		return 0;
+
+	read_lock(&ov->att_rwlock);
+	size += sprintf(buf, "%d\n", ov->pdi_ready);
+	read_unlock(&ov->att_rwlock);
+
+	return size;
+}
+static DEVICE_ATTR_RO(pdi_ready);
+
+static struct attribute *zocl_ov_attrs[] = {
+	&dev_attr_pdi_ready.attr,
+	&dev_attr_pdi_done.attr,
+	NULL,
+};
+
+static ssize_t read_versal_pdi(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+{
+	struct zocl_ov_dev *ov;
+	struct zocl_ov_pkt_node *node;
+	size_t pre_size = 0, size = 0, cp_size;
+	size_t rem_count = count;
+	loff_t cp_start;
+	u32 nread = 0;
+
+	ov = dev_get_drvdata(container_of(kobj, struct device, kobj));
+	if (!ov)
+		return 0;
+
+	read_lock(&ov->att_rwlock);
+	node = ov->head;
+	if (!node) {
+		read_unlock(&ov->att_rwlock);
+		return 0;
+	}
+
+	while (node) {
+		size += node->zn_size;
+		if (off > size) {
+			node = node->zn_next;
+			pre_size = size;
+			continue;
+		}
+
+		cp_start = off >= pre_size ? off - pre_size : 0;
+		if (node->zn_size - cp_start >= rem_count)
+			cp_size = rem_count;
+		else
+			cp_size = node->zn_size - cp_start;
+		rem_count -= cp_size;
+
+		memcpy(buf + nread, ((char *)node->zn_datap) + cp_start,
+		    cp_size);
+		nread += cp_size;
+		if (rem_count == 0)
+			break;
+
+		pre_size = size;
+		node = node->zn_next;
+	}
+
+	read_unlock(&ov->att_rwlock);
+	return nread;
+}
+
+static struct bin_attribute versal_pdi_attr = {
+	.attr = {
+		.name = "versal_pdi",
+		.mode = 0444
+	},
+	.read = read_versal_pdi,
+	.write = NULL,
+	.size = 0
+};
+
+static struct bin_attribute *zocl_ov_bin_attrs[] = {
+	&versal_pdi_attr,
+	NULL,
+};
+
+static struct attribute_group zocl_ov_attr_group = {
+	.attrs = zocl_ov_attrs,
+	.bin_attrs = zocl_ov_bin_attrs,
+};
+
+int zocl_ov_init_sysfs(struct device *dev)
+{
+	int ret;
+
+	ret = sysfs_create_group(&dev->kobj, &zocl_ov_attr_group);
+	if (ret)
+		DRM_ERROR("Create zocl attrs failed: %d\n", ret);
+
+	return ret;
+}
+
+void zocl_ov_fini_sysfs(struct device *dev)
+{
+	sysfs_remove_group(&dev->kobj, &zocl_ov_attr_group);
+}

--- a/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_versal_pcie.dts
+++ b/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_versal_pcie.dts
@@ -7,7 +7,7 @@
 
                 versal_buffer: buffer@0 {
                         no-map;
-                        reg = <0xc0 0x0 0x0 0x80000000>;
+                        reg = <0xc0 0x0 0x2 0x0>;
                 };
         };
 };
@@ -26,4 +26,10 @@
                 status = "okay";
                 reg = <0x203 0x30000 0x0 0x10000 0x202 0x4000000 0x0 0x10000>;
         };
+
+	ospi_versal {
+		compatible = "xlnx,ospi_versal";
+		status = "okay";
+		reg = <0x201 0x3000000 0x0 0x10000>;
+	};
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -192,6 +192,7 @@ enum {
 #define XOCL_DMA_MSIX		"dma_msix"
 #define	XOCL_MAILBOX_VERSAL	"mailbox_versal"
 #define XOCL_ERT		"ert"
+#define XOCL_OSPI_VERSAL	"ospi_versal"
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
@@ -217,6 +218,7 @@ enum subdev_id {
 	XOCL_SUBDEV_FMGR,
 	XOCL_SUBDEV_MIG_HBM,
 	XOCL_SUBDEV_MAILBOX_VERSAL,
+	XOCL_SUBDEV_OSPI_VERSAL,
 	XOCL_SUBDEV_NUM
 };
 
@@ -265,7 +267,6 @@ struct xocl_subdev_map {
 		XOCL_RES_FEATURE_ROM_VERSAL,		\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_VERSAL),	\
 	}
-
 
 #define	XOCL_RES_FEATURE_ROM_SMARTN			\
 		((struct resource []) {			\
@@ -1059,6 +1060,22 @@ struct xocl_subdev_map {
 		0,					\
 	}
 
+#define	XOCL_RES_OSPI_VERSAL				\
+		((struct resource []) {			\
+			{				\
+			.start	= 0x3000000,		\
+			.end	= 0x300FFFF,		\
+			.flags	= IORESOURCE_MEM,	\
+			}				\
+		})
+
+#define	XOCL_DEVINFO_OSPI_VERSAL			\
+	{						\
+		XOCL_SUBDEV_OSPI_VERSAL,		\
+		XOCL_OSPI_VERSAL,			\
+		XOCL_RES_OSPI_VERSAL,		\
+		ARRAY_SIZE(XOCL_RES_OSPI_VERSAL),	\
+	}
 
 /* user pf defines */
 #define	USER_RES_QDMA							\
@@ -1221,6 +1238,7 @@ struct xocl_subdev_map {
 #define	MGMT_RES_VERSAL							\
 		((struct xocl_subdev_info []) {				\
 		 	XOCL_DEVINFO_FEATURE_ROM_VERSAL,		\
+		 	XOCL_DEVINFO_OSPI_VERSAL,			\
 		})
 
 #define	MGMT_RES_DSA50							\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -39,7 +39,7 @@ xclmgmt-y := \
 	../subdev/flash.o \
 	../subdev/iores.o \
 	../subdev/axigate.o \
-	../subdev/ospi_versal.o\
+	../subdev/ospi_versal.o \
 	mgmt-core.o \
 	mgmt-cw.o \
 	mgmt-utils.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -39,6 +39,7 @@ xclmgmt-y := \
 	../subdev/flash.o \
 	../subdev/iores.o \
 	../subdev/axigate.o \
+	../subdev/ospi_versal.o\
 	mgmt-core.o \
 	mgmt-cw.o \
 	mgmt-utils.o \
@@ -52,7 +53,7 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 
 PWD	:= $(shell pwd)
 ROOT	:= $(dir $(M))
-XILINXINCLUDE := -I$(ROOT)/../include -I$(ROOT)/../../../../include
+XILINXINCLUDE := -I$(ROOT)/../include -I$(ROOT)/../../../../include -I$(ROOT)/../../../../common/drv/
 
 ccflags-y += $(XILINXINCLUDE) -DPF=MGMTPF
 ifeq ($(DEBUG),1)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1,7 +1,7 @@
 /*
  * Simple Driver for Management PF
  *
- * Copyright (C) 2017 Xilinx, Inc.
+ * Copyright (C) 2017-2019 Xilinx, Inc.
  *
  * Code borrowed from Xilinx SDAccel XDMA driver
  *
@@ -933,6 +933,7 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 
 	if (!(dev_info->flags & XOCL_DSAFLAG_DYNAMIC_IP) &&
 	    !(dev_info->flags & XOCL_DSAFLAG_SMARTN) &&
+	    !(dev_info->flags & XOCL_DSAFLAG_VERSAL) &&
 			i == dev_info->subdev_num &&
 			lro->core.intr_bar_addr != NULL) {
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_DMA_MSIX;
@@ -970,7 +971,7 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 	}
 	xocl_info(&pdev->dev, "created all sub devices");
 
-	if (!(dev_info->flags & XOCL_DSAFLAG_SMARTN))
+	if (!(dev_info->flags & (XOCL_DSAFLAG_SMARTN | XOCL_DSAFLAG_VERSAL)))
 		ret = xocl_icap_download_boot_firmware(lro);
 
 	/* return -ENODEV for 2RP platform */
@@ -1249,6 +1250,7 @@ static int (*drv_reg_funcs[])(void) __initdata = {
 	xocl_init_xmc,
 	xocl_init_dna,
 	xocl_init_fmgr,
+	xocl_init_ospi_versal,
 };
 
 static void (*drv_unreg_funcs[])(void) = {
@@ -1270,6 +1272,7 @@ static void (*drv_unreg_funcs[])(void) = {
 	xocl_fini_xmc,
 	xocl_fini_dna,
 	xocl_fini_fmgr,
+	xocl_fini_ospi_versal,
 };
 
 static int __init xclmgmt_init(void)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -1,0 +1,333 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: Larry Liu <yliu@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/*
+ * This subdriver is used to transfer Firmware Image from host memory
+ * to device memory through a dedicated BRAM. This BRAM is mapped to
+ * mgmt function and both drivers running on host and device can access
+ * this BRAM. The first 4 Bytes of the BRAM is the packet header and
+ * others are data payload.
+ *
+ *                      ------------------
+ *                     |    pkt_status    |
+ *                     |------------------|
+ *                     |    pkt_flags     |
+ *                     |------------------|
+ *                     |    pkt_size (H)  |
+ *                     |------------------|
+ *                     |    pkt_size (L)  |
+ *                     |------------------|
+ *                     |    pkt_data      |
+ *                     |      ...         |
+ *                     |      ...         |
+ *                      ------------------
+ *
+ * The pkt_status fields are used to communication between host and
+ * device driver.
+ * 1) The status will be set to IDLE initially
+ * 2) The host driver will set it to NEW after it fill the data payload
+ *    and flags
+ * 3) The device driver will read the data payload and set the status to
+ *    IDEL after data has been read so that host driver can write next
+ *    data...
+ * 4) Once the last packet is sent, host will wait for program done
+ *    status or program fail status, setting by device driver according
+ *    to the result of ospi flash.
+ * 5) Host driver will clear the status to IDLE for next ospi flash
+ *
+ * The pkt_flags fields are used to indicate the packet attributes.
+ * Currently, only one flag is used which will indicate this is the
+ * last packet of the Firmware Image.
+ *
+ * The pkt_size fields are used to indicate the data payload size
+ * in bytes.
+ *
+ * The pkt_data is the actual Firmware image data. The Firmware
+ * image data will be split to fragments into pkt_data to fit
+ * the size of BRAM.
+ */
+
+#include "../xocl_drv.h"
+#include "xrt_drv.h"
+
+#define	OSPI_VERSAL_DEV_NAME "ospi_versal" SUBDEV_SUFFIX
+
+struct ospi_versal {
+	struct platform_device	*ov_pdev;
+	void __iomem		*ov_base;
+	size_t			ov_size;
+	size_t			ov_data_size;
+	bool			ov_inuse;
+
+	struct mutex		ov_lock;
+};
+
+#define	OV_ERR(ov, fmt, arg...)    \
+	xocl_err(&ov->ov_pdev->dev, fmt "\n", ##arg)
+#define	OV_INFO(ov, fmt, arg...)    \
+	xocl_info(&ov->ov_pdev->dev, fmt "\n", ##arg)
+
+/*
+ * If return 0, we get the expected status.
+ * If return -1, the status is set to FAIL.
+ */
+static inline int wait_for_status(struct ospi_versal *ov, u8 status)
+{
+	struct pdi_packet *pkt;
+	u32 header;
+
+	pkt = (struct pdi_packet *)&header;
+	for (;;) {
+		header = ioread32(ov->ov_base);
+		if (pkt->pkt_status == status)
+			return 0;
+		if (pkt->pkt_status == XRT_PDI_PKT_STATUS_FAIL)
+			return -1;
+	}
+}
+
+static inline void set_status(struct ospi_versal *ov, u8 status)
+{
+	struct pdi_packet pkt;
+
+	pkt.pkt_status = status;
+	iowrite32(pkt.header, ov->ov_base);
+}
+
+static inline void write_data(u32 *addr, u32 *data, size_t sz)
+{
+	int i;
+
+	for (i = sz - 1; i >= 0; i--)
+		iowrite32(data[i], addr + i);
+}
+
+static ssize_t ospi_versal_write(struct file *filp, const char __user *data,
+	size_t data_len, loff_t *off)
+{
+	struct ospi_versal *ov = filp->private_data;
+	ssize_t len = 0, ret;
+	ssize_t remain = data_len;
+	u32 *pkt_data, pkt_size, tran_size;
+	u32 *base_addr = ov->ov_base;
+	struct pdi_packet pkt;
+
+	/* We don't support program partial of the ospi flash */
+	if (*off != 0) {
+		OV_ERR(ov, "OSPI offset is not 0: %lld", *off);
+		return -EINVAL;
+	}
+
+	mutex_lock(&ov->ov_lock);
+	if (ov->ov_inuse) {
+		mutex_unlock(&ov->ov_lock);
+		OV_ERR(ov, "OSPI device is busy");
+		return -EBUSY;
+	}
+
+	ov->ov_inuse = true;
+	mutex_unlock(&ov->ov_lock);
+
+	if (wait_for_status(ov, XRT_PDI_PKT_STATUS_IDLE)) {
+		OV_ERR(ov, "OSPI device is not in proper state");
+		return -EIO;
+	}
+
+	pkt_size = ov->ov_data_size;
+	pkt_data = vmalloc(pkt_size);
+
+	while (len < data_len) {
+		tran_size = (remain > pkt_size) ? pkt_size : remain;
+		ret = copy_from_user(pkt_data, data + len, tran_size);
+		if (ret) {
+			OV_ERR(ov, "copy data failed %ld", ret);
+			goto done;
+		}
+
+		write_data(base_addr + (sizeof(struct pdi_packet)) / 4,
+		    pkt_data, pkt_size / 4);
+
+		pkt.pkt_status = XRT_PDI_PKT_STATUS_NEW;
+		pkt.pkt_flags = tran_size < pkt_size ?
+		    XRT_PDI_PKT_FLAGS_LAST : 0;
+		pkt.pkt_size = tran_size;
+
+		/* Write data on 4 bytes base */
+		write_data(base_addr, &pkt.header,
+		    sizeof(struct pdi_packet) / 4);
+
+		len += tran_size;
+		remain -= tran_size;
+
+		/* wait until the data is fetched by device side */
+		if (wait_for_status(ov, XRT_PDI_PKT_STATUS_IDLE)) {
+			ret = -EIO;
+			OV_ERR(ov, "OSPI program error");
+			goto done;
+		}
+	}
+
+	/* wait until the ospi flash is done */
+	if (wait_for_status(ov, XRT_PDI_PKT_STATUS_DONE)) {
+		ret = -EIO;
+		OV_ERR(ov, "OSPI program error");
+		goto done;
+	}
+
+	OV_INFO(ov, "OSPI program is completed");
+	ret = len;
+done:
+	set_status(ov, XRT_PDI_PKT_STATUS_IDLE);
+
+	vfree(pkt_data);
+	mutex_lock(&ov->ov_lock);
+	ov->ov_inuse = false;
+	mutex_unlock(&ov->ov_lock);
+
+	return ret;
+}
+
+static int ospi_versal_open(struct inode *inode, struct file *file)
+{
+	struct ospi_versal *ov = NULL;
+
+	ov = xocl_drvinst_open(inode->i_cdev);
+	if (!ov)
+		return -ENXIO;
+
+	file->private_data = ov;
+	return 0;
+}
+
+static int ospi_versal_close(struct inode *inode, struct file *file)
+{
+	struct ospi_versal *ov = file->private_data;
+
+	xocl_drvinst_close(ov);
+	return 0;
+}
+
+static int ospi_versal_remove(struct platform_device *pdev)
+{
+	struct ospi_versal *ov = platform_get_drvdata(pdev);
+
+	if (!ov) {
+		xocl_err(&pdev->dev, "driver data is NULL");
+		return -EINVAL;
+	}
+	if (ov->ov_base)
+		iounmap(ov->ov_base);
+
+	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(ov);
+
+	return 0;
+}
+
+static int ospi_versal_probe(struct platform_device *pdev)
+{
+	struct ospi_versal *ov = NULL;
+	struct resource *res;
+	int ret;
+
+	ov = xocl_drvinst_alloc(&pdev->dev, sizeof(struct ospi_versal));
+	if (!ov)
+		return -ENOMEM;
+	platform_set_drvdata(pdev, ov);
+	ov->ov_pdev = pdev;
+
+	mutex_init(&ov->ov_lock);
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+
+	ov->ov_base = ioremap_nocache(res->start, res->end - res->start + 1);
+	if (!ov->ov_base) {
+		OV_ERR(ov, "failed to map in BRAM");
+		ret = -EIO;
+		goto failed;
+	}
+	ov->ov_size = res->end - res->start + 1;
+	ov->ov_data_size = ov->ov_size - sizeof(struct pdi_packet);
+	if (ov->ov_size % 4 || ov->ov_data_size % 4) {
+		OV_ERR(ov, "BRAM size is not 4 Bytes aligned");
+		ret = -EINVAL;
+		goto failed;
+	}
+
+	return 0;
+
+failed:
+	if (ov->ov_base) {
+		iounmap(ov->ov_base);
+		ov->ov_base = NULL;
+	}
+	ospi_versal_remove(pdev);
+
+	return ret;
+}
+
+static const struct file_operations ospi_versal_fops = {
+	.owner = THIS_MODULE,
+	.open = ospi_versal_open,
+	.release = ospi_versal_close,
+	.write = ospi_versal_write,
+};
+
+struct xocl_drv_private ospi_versal_priv = {
+	.fops = &ospi_versal_fops,
+	.dev = -1,
+};
+
+struct platform_device_id ospi_versal_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_OSPI_VERSAL),
+	    (kernel_ulong_t)&ospi_versal_priv },
+	{ },
+};
+
+static struct platform_driver	ospi_versal_driver = {
+	.probe		= ospi_versal_probe,
+	.remove		= ospi_versal_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_OSPI_VERSAL),
+	},
+	.id_table = ospi_versal_id_table,
+};
+
+int __init xocl_init_ospi_versal(void)
+{
+	int err = 0;
+
+	err = alloc_chrdev_region(&ospi_versal_priv.dev, 0, XOCL_MAX_DEVICES,
+	    OSPI_VERSAL_DEV_NAME);
+	if (err < 0)
+		return err;
+
+	err = platform_driver_register(&ospi_versal_driver);
+	if (err) {
+		unregister_chrdev_region(ospi_versal_priv.dev,
+		    XOCL_MAX_DEVICES);
+		return err;
+	}
+
+	return 0;
+}
+
+void xocl_fini_ospi_versal(void)
+{
+	unregister_chrdev_region(ospi_versal_priv.dev, XOCL_MAX_DEVICES);
+	platform_driver_unregister(&ospi_versal_driver);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1331,4 +1331,7 @@ void xocl_fini_iores(void);
 
 int __init xocl_init_mailbox_versal(void);
 void xocl_fini_mailbox_versal(void);
+
+int __init xocl_init_ospi_versal(void);
+void xocl_fini_ospi_versal(void);
 #endif

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2019 Xilinx, Inc
  * Author: Ryan Radjabi
  *
  * This is a wrapper class that does the prep work required to program a flash
@@ -57,6 +57,10 @@ Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
         // Use find() for this type of flash.
         // Since it have variations
         type = E_FlasherType::QSPIPS;
+    }
+    else if (typeStr.compare("ospi_versal") == 0)
+    {
+        type = E_FlasherType::OSPIVERSAL;
     }
     else
     {
@@ -125,6 +129,23 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         else
         {
             retVal = xqspi_ps.xclUpgradeFirmware(*primary);
+        }
+        break;
+    }
+    case OSPIVERSAL:
+    {
+        XOSPIVER_Flasher xospi_versal(mDev);
+        if (primary == nullptr)
+        {
+            std::cout << "ERROR: OSPIVERSAL mode does not support reverting to MFG." << std::endl;
+        }
+        else if(secondary != nullptr)
+        {
+            std::cout << "ERROR: OSPIVERSAL mode does not support two mcs files." << std::endl;
+        }
+        else
+        {
+            retVal = xospi_versal.xclUpgradeFirmware(*primary);
         }
         break;
     }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2019 Xilinx, Inc
  * Author: Ryan Radjabi
  *
  * This is a wrapper class that does the prep work required to program a flash
@@ -24,6 +24,7 @@
 
 #include "xspi.h"
 #include "xqspips.h"
+#include "xospiversal.h"
 #include "prom.h"
 #include "xmc.h"
 #include "firmware_image.h"
@@ -84,6 +85,7 @@ private:
         SPI,
         BPI,
         QSPIPS,
+        OSPIVERSAL,
     };
     const char *E_FlasherTypeStrings[4] = { "UNKNOWN", "SPI", "BPI", "QSPI_PS" };
     const char *getFlasherTypeText( E_FlasherType val ) { return E_FlasherTypeStrings[ val ]; }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.cpp
@@ -42,7 +42,7 @@ int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
     total_size = binStream.tellg();
     binStream.seekg(0, binStream.beg);
 
-    std::cout << "INFO: ***BOOT.BIN has " << total_size << " bytes" << std::endl;
+    std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
 
     int fd = mDev->open("ospi_versal", O_RDWR);
     if (fd == -1) {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ * Author: Larry Liu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <unistd.h>
+
+#include "xospiversal.h"
+
+/**
+ * @brief XOSPIVER_Flasher::XOSPIVER_Flasher
+ */
+XOSPIVER_Flasher::XOSPIVER_Flasher(std::shared_ptr<pcidev::pci_device> dev)
+{
+    mDev = dev;
+}
+
+/**
+ * @brief XQSPIPS_Flasher::~XQSPIPS_Flasher
+ */
+XOSPIVER_Flasher::~XOSPIVER_Flasher()
+{
+}
+
+int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
+{
+    int total_size = 0;
+
+    binStream.seekg(0, binStream.end);
+    total_size = binStream.tellg();
+    binStream.seekg(0, binStream.beg);
+
+    std::cout << "INFO: ***BOOT.BIN has " << total_size << " bytes" << std::endl;
+
+    int fd = mDev->open("ospi_versal", O_RDWR);
+    if (fd == -1) {
+        std::cout << "ERROR Cannot open ospi_versal for writing " << std::endl;
+        return -ENODEV;
+    }
+
+    std::unique_ptr<char> buffer(new char[total_size]);
+    binStream.read(buffer.get(), total_size);
+
+    ssize_t ret = write(fd, buffer.get(), total_size);
+
+    mDev->close(fd);
+
+    return ret == total_size ? 0 : -EIO;
+}

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2019 Xilinx, Inc
+ * Author: Larry Liu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XOSPIVERSAL_H_
+#define _XOSPIVERSAL_H_
+
+#include <iostream>
+#include "core/pcie/linux/scan.h"
+
+class XOSPIVER_Flasher
+{
+public:
+    XOSPIVER_Flasher(std::shared_ptr<pcidev::pci_device> dev);
+    ~XOSPIVER_Flasher();
+    int xclUpgradeFirmware(std::istream& binStream);
+
+private:
+    std::shared_ptr<pcidev::pci_device> mDev;
+};
+
+#endif


### PR DESCRIPTION
This PR added Versal OSPI support.
1. Add ospi_versal sub driver in xclmgmt
2. Add zocl_ospi_versal sub driver in zocl
3. The two sub drivers communicate through a BRAM to move Firmware image from host memory to device memory
4. xbmgmt flash is enhanced to flash the FW (PDI) to versal flash device
5. device side ospi driver will talk to user space daemon through sysfs node to flash the FW (PDI) through a user space daemon will will call flashcp to write to the flash.