### PR TITLE
should not fail for non-xmc platforms when downloading xclbin (#2574)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2298,9 +2298,7 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 	ICAP_INFO(icap, "incoming xclbin: %pUb\non device xclbin: %pUb",
 		&xclbin->m_header.uuid, &icap->icap_bitstream_uuid);
 
-	err = xocl_cmc_freeze(xdev);
-	if (err)
-		goto done;
+	xocl_cmc_freeze(xdev);
 
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 	icap_refresh_addrs(pdev);
@@ -2361,8 +2359,11 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 		}
 	}
 
-	if (ICAP_PRIVILEGED(icap))
+	if (ICAP_PRIVILEGED(icap)) {
 		err = xocl_cmc_free(xdev);
+		if (err == -ENODEV)
+			err = 0;
+	}
 
 done:
 	if (err) {


### PR DESCRIPTION
cherry pick this fix into pu1