### PR TITLE
Remove unused XMC out of U2

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1250,7 +1250,6 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
 			XOCL_DEVINFO_FMGR,				\
-			XOCL_DEVINFO_XMC,				\
 		})
 
 #define	XOCL_BOARD_MGMT_DEFAULT						\


### PR DESCRIPTION
http://jira.xilinx.com/browse/CR-1044306

Should just remove XMC from U.2 Platform