### PR TITLE
CR-1050747 health thread for xilinx_u50_xdma_201920_2 and xilinx_u50_…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -480,7 +480,7 @@ static int health_check_cb(void *data)
 				/* clock throttle is at bit 29:16, maximum is 6400 */
 				clk_status = CLK_THROTTLED(ucs_status, 29, 16);
 				if (clk_status > CLK_MAX_VALUE)
-					mgmt_err(lro, "ULP kernel clocks %d exceeds expected maximized value %d.", clk_status, CLK_MAX_VALUE);
+					mgmt_err(lro, "ULP kernel clocks %d exceeds expected maximum value %d.", clk_status, CLK_MAX_VALUE);
 				else if (clk_status)
 					mgmt_err(lro, "ULP kernel clocks throttled at %d%%.", (clk_status / CLK_MAX_VALUE) * 100);
 			}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -59,6 +59,7 @@ MODULE_PARM_DESC(minimum_initialization,
 
 #define	MAX_DYN_SUBDEV		1024
 
+#define	CLK_MAX_VALUE		6400
 #define	CLK_SHUTDOWN_BIT	0x1
 #define	DEBUG_CLK_SHUTDOWN_BIT	0x2
 #define	VALID_CLKSHUTDOWN_BITS	(CLK_SHUTDOWN_BIT|DEBUG_CLK_SHUTDOWN_BIT)
@@ -478,8 +479,10 @@ static int health_check_cb(void *data)
 			} else {
 				/* clock throttle is at bit 29:16, maximum is 6400 */
 				clk_status = CLK_THROTTLED(ucs_status, 29, 16);
-				if (clk_status)
-					mgmt_err(lro, "ULP kernel clocks throttled at %d%%.", clk_status / 64);
+				if (clk_status > CLK_MAX_VALUE)
+					mgmt_err(lro, "ULP kernel clocks %d exceeds expected maximized value %d.", clk_status, CLK_MAX_VALUE);
+				else if (clk_status)
+					mgmt_err(lro, "ULP kernel clocks throttled at %d%%.", (clk_status / CLK_MAX_VALUE) * 100);
 			}
 		}
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -425,10 +425,10 @@ static void platform_type_append(char *prefix, u32 platform_type)
 		type = "_Recovery BLP";
 		break;
 	case XOCL_VSEC_PLAT_1RP:
-		type = "_xdma_201920_2";
+		type = "_xdma_gen3x4_201920_3";
 		break;
 	case XOCL_VSEC_PLAT_2RP:
-		type = "_xdma_201920_2";
+		type = "_xdma_gen3x4_201920_3";
 		break;
 	default:
 		type = "_Unknown";

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -422,7 +422,7 @@ static void platform_type_append(char *prefix, u32 platform_type)
 
 	switch (platform_type) {
 	case XOCL_VSEC_PLAT_RECOVERY:
-		type = "_Recovery BLP";
+		type = "_Recovery";
 		break;
 	case XOCL_VSEC_PLAT_1RP:
 		type = "_xdma_gen3x4_201920_3";

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -135,4 +135,11 @@ struct xocl_iores_map map[] = {                                         \
 	{ RESNAME_GAPPING, IORES_GAPPING},				\
 }
 
+struct ucs_control_ch1 {
+	unsigned int shutdown_clocks_latched:1;
+	unsigned int reserved1:15;
+	unsigned int clock_throttling_average:14;
+	unsigned int reserved2:2;
+};
+
 #endif


### PR DESCRIPTION
this is for CR CR-1050747

also address the name change for vbnv as xilinx_u50_xdma_gen3x4_201920_3 