### PR TITLE
fix softkernel command type

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4091,10 +4091,10 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	switch (scmd->opcode) {
 	case ERT_START_CU:
 	case ERT_EXEC_WRITE:
+	case ERT_SK_START:
 		scmd->type = ERT_CU;
 		break;
 	case ERT_SK_CONFIG:
-	case ERT_SK_START:
 	case ERT_SK_UNCONFIG:
 		scmd->type = ERT_CTRL;
 		break;


### PR DESCRIPTION
This PR fixes two issues
1) For download XCLBIN (by using config soft kernel command) on versal, we should bail out after the downloading and do not config any soft kernel
2) We treat ERT_SK_START as ERT_CU command type instead of ERT_CTRL type. Otherwise, there will be only one outstanding CTRL command, which will be very slow for dispatching soft kernel.