### PR TITLE
XRT Windows - EoU and simple bug fix

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -59,7 +59,7 @@ ReturnCodes main_(int argc, char** argv) {
     ("help", boost::program_options::bool_switch(&bHelp), "Help to use this program")
     ("verbose", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
     ("trace", boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
-    ("command", po::value<std::string>(), "command to execute")
+    ("command", po::value<std::string>(), "Subcommand to execute")
     ("subArguments", po::value<std::vector<std::string> >(), "Arguments for command")
   ;
 
@@ -97,8 +97,9 @@ ReturnCodes main_(int argc, char** argv) {
     XBU::setTrace( true );
   }
 
-  // Check to see if help was requested and no command was found
-  if ((bHelp == true) && (vm.count("command") == 0)) {
+  // Produce a help output if no command is given
+  // Note: In this case, --help is assumed
+  if (vm.count("command") == 0) {
     ::printHelp(globalOptions);
     return RC_SUCCESS;
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.cpp
@@ -46,20 +46,20 @@ void reportVersions()
   xrt::version::print(std::cout);
 
   // Get and report XOCL build information
-  boost::property_tree::ptree xrt_pt;
-  xrt_core::get_xrt_info(xrt_pt);
-
-  std::cout.width(26);
-  std::cout << std::internal
-            << "XOCL: "
-            << xrt_pt.get<std::string>( "xocl", "---Not Defined--")
-            << std::endl;
-
-  std::cout.width(26);
-  std::cout << std::internal
-            << "XCLMGMT: "
-            << xrt_pt.get<std::string>( "xclmgmt", "---Not Defined--")
-            << std::endl;
+//  boost::property_tree::ptree xrt_pt;
+//  xrt_core::get_xrt_info(xrt_pt);
+//
+//  std::cout.width(26);
+//  std::cout << std::internal
+//            << "XOCL: "
+//            << xrt_pt.get<std::string>( "xocl", "---Not Defined--")
+//            << std::endl;
+//
+//  std::cout.width(26);
+//  std::cout << std::internal
+//            << "XCLMGMT: "
+//            << xrt_pt.get<std::string>( "xclmgmt", "---Not Defined--")
+//            << std::endl;
 }
 
 // ------ F U N C T I O N S ---------------------------------------------------

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -25,10 +25,8 @@ if(WIN32)
   set(XBUTIL2_NAME "xbutil")     # Yes, on windows the file name will be xbutil
   file(GLOB XBUTIL_V2_SUBCMD_FILES
     "SubCmdProgram.cpp"
-    "SubCmdClock.cpp"
     "SubCmdDmaTest.cpp"
     "SubCmdQuery.cpp"
-    "SubCmdReset.cpp"
     "SubCmdScan.cpp"
     "SubCmdVersion.cpp"
   )


### PR DESCRIPTION
Work Done
---------
+ Bug Fix: xbutil and xbmgmt use to throw and exception if no subcommand is given
+ Remove xbutil un implemented subcommands: reset and clock
+ Remove unsupported functionality around reporting the driver version.