### PR TITLE
support flashing through driver

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -71,15 +71,15 @@ struct xocl_subdev_info {
 	uint32_t		id;
 	const char		*name;
 	struct resource	*res;
-	int				num_res;
+	int			num_res;
 	void			*priv_data;
-	int				data_len;
+	int			data_len;
 	bool			multi_inst;
-	int				level;
+	int			level;
 	char			*bar_idx;
-	int				dyn_ip;
+	int			dyn_ip;
 	const char		*override_name;
-	int				override_idx;
+	int			override_idx;
 };
 
 struct xocl_board_private {
@@ -97,9 +97,8 @@ struct xocl_board_private {
 };
 
 struct xocl_flash_privdata {
-	u32			flash_type;
 	u32			properties;
-	char			data[128];
+	char			flash_type[128];
 };
 
 struct xocl_msix_privdata {
@@ -108,10 +107,10 @@ struct xocl_msix_privdata {
 };
 
 #ifdef __KERNEL__
-#define XOCL_PCI_DEVID(ven, dev, subsysid, priv)        \
-         .vendor = ven, .device=dev, .subvendor = PCI_ANY_ID, \
-         .subdevice = subsysid, .driver_data =          \
-         (kernel_ulong_t) &XOCL_BOARD_##priv
+#define XOCL_PCI_DEVID(ven, dev, subsysid, priv)	\
+	 .vendor = ven, .device=dev, .subvendor = PCI_ANY_ID, \
+	 .subdevice = subsysid, .driver_data =	  \
+	 (kernel_ulong_t) &XOCL_BOARD_##priv
 
 enum {
 	XOCL_DSAMAP_VBNV,
@@ -135,9 +134,9 @@ struct xocl_board_info {
 	struct xocl_board_private	*priv_data;
 };
 
-#define XOCL_PCI_DEVID(ven, dev, subsysid, priv)        \
-         .vendor = ven, .device=dev, \
-         .subdevice = subsysid, .priv_data = &XOCL_BOARD_##priv
+#define XOCL_PCI_DEVID(ven, dev, subsysid, priv)	\
+	 .vendor = ven, .device=dev, \
+	 .subdevice = subsysid, .priv_data = &XOCL_BOARD_##priv
 
 struct resource {
 	size_t		start;
@@ -698,27 +697,27 @@ struct xocl_subdev_map {
 		.override_idx = XOCL_SUBDEV_LEVEL_PRP,	\
 	}
 
-#define XOCL_RES_PRP_IORES_MGMT_QEP            \
-    ((struct resource []) {             \
-        __RES_PRP_IORES_MGMT,           \
-        /* OCL_CLKWIZ2_BASE */          \
-        {                   \
-            .name   = RESNAME_CLKWIZKERNEL3,\
-            .start  = 0x053000,     \
-            .end    = 0x053fff,     \
-            .flags  = IORESOURCE_MEM,   \
-         },                  \
+#define XOCL_RES_PRP_IORES_MGMT_QEP	    \
+    ((struct resource []) {	     \
+	__RES_PRP_IORES_MGMT,	   \
+	/* OCL_CLKWIZ2_BASE */	  \
+	{		   \
+	    .name   = RESNAME_CLKWIZKERNEL3,\
+	    .start  = 0x053000,     \
+	    .end    = 0x053fff,     \
+	    .flags  = IORESOURCE_MEM,   \
+	 },		  \
      })
 
 
-#define XOCL_DEVINFO_PRP_IORES_MGMT_QEP         \
-     {                       \
-         XOCL_SUBDEV_IORES,          \
-         XOCL_IORES2,                \
-         XOCL_RES_PRP_IORES_MGMT_QEP,        \
-         ARRAY_SIZE(XOCL_RES_PRP_IORES_MGMT_QEP),    \
-         .level = XOCL_SUBDEV_LEVEL_PRP,     \
-         .override_idx = XOCL_SUBDEV_LEVEL_PRP,  \
+#define XOCL_DEVINFO_PRP_IORES_MGMT_QEP	 \
+     {		       \
+	 XOCL_SUBDEV_IORES,	  \
+	 XOCL_IORES2,		\
+	 XOCL_RES_PRP_IORES_MGMT_QEP,	\
+	 ARRAY_SIZE(XOCL_RES_PRP_IORES_MGMT_QEP),    \
+	 .level = XOCL_SUBDEV_LEVEL_PRP,     \
+	 .override_idx = XOCL_SUBDEV_LEVEL_PRP,  \
      }
 
 
@@ -847,7 +846,7 @@ struct xocl_subdev_map {
 			},				\
 		})
 
-#define	XOCL_DEVINFO_XMC					\
+#define	XOCL_DEVINFO_XMC				\
 	{						\
 		XOCL_SUBDEV_MB,				\
 		XOCL_XMC,				\
@@ -958,7 +957,7 @@ struct xocl_subdev_map {
 			{				\
 			.start	= ERT_CQ_BASE_ADDR,	\
 			.end	= ERT_CQ_BASE_ADDR +	\
-		       		ERT_CQ_SIZE - 1,	\
+			ERT_CQ_SIZE - 1,	\
 			.flags	= IORESOURCE_MEM,	\
 			},				\
 			{				\
@@ -989,7 +988,7 @@ struct xocl_subdev_map {
 			{				\
 			.start	= ERT_CQ_BASE_ADDR,	\
 			.end	= ERT_CQ_BASE_ADDR +	\
-		       		ERT_CQ_SIZE - 1,	\
+			ERT_CQ_SIZE - 1,	\
 			.flags	= IORESOURCE_MEM,	\
 			},				\
 			{				\
@@ -1000,17 +999,17 @@ struct xocl_subdev_map {
 		})
 
 
-#define	XOCL_DEVINFO_SCHEDULER_QDMA				\
+#define	XOCL_DEVINFO_SCHEDULER_QDMA			\
 	{						\
 		XOCL_SUBDEV_MB_SCHEDULER,		\
 		XOCL_MB_SCHEDULER,			\
-		XOCL_RES_SCHEDULER_QDMA,			\
-		ARRAY_SIZE(XOCL_RES_SCHEDULER_QDMA),		\
+		XOCL_RES_SCHEDULER_QDMA,		\
+		ARRAY_SIZE(XOCL_RES_SCHEDULER_QDMA),	\
 		&(char []){1},				\
 		1					\
 	}
 
-#define	XOCL_DEVINFO_SCHEDULER_51				\
+#define	XOCL_DEVINFO_SCHEDULER_51			\
 	{						\
 		XOCL_SUBDEV_MB_SCHEDULER,		\
 		XOCL_MB_SCHEDULER,			\
@@ -1020,33 +1019,33 @@ struct xocl_subdev_map {
 		1					\
 	}
 
-#define	ERT_CQ_BASE_ADDR_VERSAL            0x4000000
-#define ERT_CSR_ADDR_VERSAL                0x6040000
-#define XOCL_RES_SCHEDULER_VERSAL			\
-		((struct resource []) {			\
+#define	ERT_CQ_BASE_ADDR_VERSAL		0x4000000
+#define ERT_CSR_ADDR_VERSAL		0x6040000
+#define XOCL_RES_SCHEDULER_VERSAL				\
+		((struct resource []) {				\
 		/*
  		 * map entire bar for now because scheduler directly
 		 * programs CUs
-		 */					\
-			{				\
+		 */						\
+			{					\
 			.start	= ERT_CSR_ADDR_VERSAL,		\
 			.end	= ERT_CSR_ADDR_VERSAL + 0xffff,	\
-			.flags	= IORESOURCE_MEM,	\
-			},				\
-			{				\
+			.flags	= IORESOURCE_MEM,		\
+			},					\
+			{					\
 			.start	= ERT_CQ_BASE_ADDR_VERSAL,	\
 			.end	= ERT_CQ_BASE_ADDR_VERSAL +	\
-		       		ERT_CQ_SIZE - 1,		\
-			.flags	= IORESOURCE_MEM,	\
-			}				\
+			ERT_CQ_SIZE - 1,			\
+			.flags	= IORESOURCE_MEM,		\
+			}					\
 		})
 
 #define	XOCL_DEVINFO_SCHEDULER_VERSAL			\
 	{						\
 		XOCL_SUBDEV_MB_SCHEDULER,		\
 		XOCL_MB_SCHEDULER,			\
-		XOCL_RES_SCHEDULER_VERSAL,			\
-		ARRAY_SIZE(XOCL_RES_SCHEDULER_VERSAL),		\
+		XOCL_RES_SCHEDULER_VERSAL,		\
+		ARRAY_SIZE(XOCL_RES_SCHEDULER_VERSAL),	\
 		&(char []){0},		\
 		1,					\
 		.bar_idx = (char []){ 2, 2 },		\
@@ -1073,8 +1072,25 @@ struct xocl_subdev_map {
 	{						\
 		XOCL_SUBDEV_OSPI_VERSAL,		\
 		XOCL_OSPI_VERSAL,			\
-		XOCL_RES_OSPI_VERSAL,		\
+		XOCL_RES_OSPI_VERSAL,			\
 		ARRAY_SIZE(XOCL_RES_OSPI_VERSAL),	\
+	}
+
+#define XOCL_RES_FLASH					\
+	((struct resource []) {				\
+		{					\
+			.start = 0x40000,		\
+			.end = 0x4007b,			\
+			.flags = IORESOURCE_MEM,	\
+		},					\
+	 })
+
+#define XOCL_DEVINFO_FLASH				\
+	{						\
+		XOCL_SUBDEV_FLASH,			\
+		XOCL_FLASH,				\
+		XOCL_RES_FLASH,				\
+		ARRAY_SIZE(XOCL_RES_FLASH),		\
 	}
 
 /* user pf defines */
@@ -1082,9 +1098,9 @@ struct xocl_subdev_map {
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
 			XOCL_DEVINFO_QDMA,				\
-			XOCL_DEVINFO_SCHEDULER_QDMA, 			\
+			XOCL_DEVINFO_SCHEDULER_QDMA,			\
 			XOCL_DEVINFO_XVC_PUB,				\
-		 	XOCL_DEVINFO_MAILBOX_USER_QDMA,			\
+			XOCL_DEVINFO_MAILBOX_USER_QDMA,			\
 			XOCL_DEVINFO_ICAP_USER,				\
 			XOCL_DEVINFO_XMC_USER,				\
 			XOCL_DEVINFO_AF_USER,				\
@@ -1183,12 +1199,12 @@ struct xocl_subdev_map {
 		.subdev_num = ARRAY_SIZE(USER_RES_XDMA),		\
 	}
 
-#define XOCL_BOARD_USER_AWS                         \
-   (struct xocl_board_private){                    \
-       .flags      = 0,                    \
-       .subdev_info    = USER_RES_AWS,         \
-       .subdev_num = ARRAY_SIZE(USER_RES_AWS),     \
-   }
+#define XOCL_BOARD_USER_AWS						\
+	(struct xocl_board_private){					\
+		.flags		= 0,					\
+		.subdev_info	= USER_RES_AWS,				\
+		.subdev_num = ARRAY_SIZE(USER_RES_AWS),			\
+	}
 
 #define	XOCL_BOARD_USER_DSA52						\
 	(struct xocl_board_private){					\
@@ -1197,7 +1213,7 @@ struct xocl_subdev_map {
 		.subdev_num = ARRAY_SIZE(USER_RES_DSA52),		\
 	}
 
-#define	XOCL_BOARD_USER_DSA52_U280						\
+#define	XOCL_BOARD_USER_DSA52_U280					\
 	(struct xocl_board_private){					\
 		.flags		= 0,					\
 		.subdev_info	= USER_RES_DSA52,			\
@@ -1232,7 +1248,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XIIC,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,		        	\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	MGMT_RES_VERSAL							\
@@ -1253,9 +1270,10 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XIIC,				\
 			XOCL_DEVINFO_ICAP_MGMT,				\
 			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
-#define	MGMT_RES_U2						\
+#define	MGMT_RES_U2							\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
 			XOCL_DEVINFO_IORES_MGMT,			\
@@ -1269,6 +1287,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_ICAP_MGMT,				\
 			XOCL_DEVINFO_FMGR,				\
 			XOCL_DEVINFO_XMC,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	XOCL_BOARD_MGMT_DEFAULT						\
@@ -1313,7 +1332,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	MGMT_RES_6A8F_DSA50						\
@@ -1326,7 +1346,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_MB,				\
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	MGMT_RES_XBB_DSA51						\
@@ -1339,7 +1360,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	XOCL_BOARD_MGMT_6A8F						\
@@ -1349,7 +1371,7 @@ struct xocl_subdev_map {
 		.subdev_num = ARRAY_SIZE(MGMT_RES_6A8F),		\
 	}
 
-#define	XOCL_BOARD_MGMT_XBB_DSA51						\
+#define	XOCL_BOARD_MGMT_XBB_DSA51					\
 	(struct xocl_board_private){					\
 		.flags		= 0,					\
 		.subdev_info	= MGMT_RES_XBB_DSA51,			\
@@ -1379,11 +1401,12 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XVC_PRI,				\
 			XOCL_DEVINFO_MAILBOX_MGMT_QDMA,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 
-#define	XOCL_BOARD_MGMT_QDMA					\
+#define	XOCL_BOARD_MGMT_QDMA						\
 	(struct xocl_board_private){					\
 		.flags		= 0,					\
 		.subdev_info	= MGMT_RES_QDMA,			\
@@ -1391,51 +1414,52 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_SPI				\
 	}
 
-#define MGMT_RES_XBB_QDMA                                               \
-	((struct xocl_subdev_info []) {                         \
-		XOCL_DEVINFO_FEATURE_ROM,                       \
-		XOCL_DEVINFO_IORES_MGMT,			\
-		XOCL_DEVINFO_PRP_IORES_MGMT,			\
-		XOCL_DEVINFO_AF_DSA52,                          \
-		XOCL_DEVINFO_XMC,                               \
-		XOCL_DEVINFO_XVC_PRI,                           \
-		XOCL_DEVINFO_NIFD_PRI,				\
-		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,			\
-		XOCL_DEVINFO_ICAP_MGMT,                         \
-		XOCL_DEVINFO_FMGR,      			\
+#define MGMT_RES_XBB_QDMA						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM,				\
+		XOCL_DEVINFO_IORES_MGMT,				\
+		XOCL_DEVINFO_PRP_IORES_MGMT,				\
+		XOCL_DEVINFO_AF_DSA52,					\
+		XOCL_DEVINFO_XMC,					\
+		XOCL_DEVINFO_XVC_PRI,					\
+		XOCL_DEVINFO_NIFD_PRI,					\
+		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,				\
+		XOCL_DEVINFO_ICAP_MGMT,					\
+		XOCL_DEVINFO_FMGR,					\
+		XOCL_DEVINFO_FLASH,					\
+	})
+
+#define MGMT_RES_XBB_QEP						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM,				\
+		XOCL_DEVINFO_IORES_MGMT,				\
+		XOCL_DEVINFO_PRP_IORES_MGMT_QEP,			\
+		XOCL_DEVINFO_AF_DSA52,			 		\
+		XOCL_DEVINFO_XMC,					\
+		XOCL_DEVINFO_XVC_PRI,					\
+		XOCL_DEVINFO_NIFD_PRI,					\
+		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,				\
+		XOCL_DEVINFO_ICAP_MGMT,					\
+		XOCL_DEVINFO_FMGR,					\
+		XOCL_DEVINFO_FLASH,					\
 	})
 
 
-#define MGMT_RES_XBB_QEP                                               \
-    ((struct xocl_subdev_info []) {                         \
-        XOCL_DEVINFO_FEATURE_ROM,                       \
-        XOCL_DEVINFO_IORES_MGMT,            \
-        XOCL_DEVINFO_PRP_IORES_MGMT_QEP,            \
-        XOCL_DEVINFO_AF_DSA52,                          \
-        XOCL_DEVINFO_XMC,                               \
-        XOCL_DEVINFO_XVC_PRI,                           \
-        XOCL_DEVINFO_NIFD_PRI,              \
-        XOCL_DEVINFO_MAILBOX_MGMT_QDMA,         \
-        XOCL_DEVINFO_ICAP_MGMT,                         \
-        XOCL_DEVINFO_FMGR,                  \
-    })
-
-
-#define XOCL_BOARD_MGMT_XBB_QDMA                                        \
-	(struct xocl_board_private){                                    \
-		.flags          = XOCL_DSAFLAG_FIXED_INTR,		\
-		.subdev_info    = MGMT_RES_XBB_QDMA,                    \
-		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_QDMA),            \
+#define XOCL_BOARD_MGMT_XBB_QDMA					\
+	(struct xocl_board_private){					\
+		.flags	  = XOCL_DSAFLAG_FIXED_INTR,			\
+		.subdev_info    = MGMT_RES_XBB_QDMA,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_QDMA),		\
 		.flash_type = FLASH_TYPE_SPI				\
 	}
 
-#define XOCL_BOARD_MGMT_U250_QEP                                \
-   (struct xocl_board_private){                                    \
-       .flags          = XOCL_DSAFLAG_FIXED_INTR,      \
-       .subdev_info    = MGMT_RES_XBB_QEP,                    \
-       .subdev_num = ARRAY_SIZE(MGMT_RES_XBB_QEP),            \
-      .flash_type = FLASH_TYPE_SPI                         \
-    }
+#define XOCL_BOARD_MGMT_U250_QEP					\
+	(struct xocl_board_private){					\
+		.flags	  = XOCL_DSAFLAG_FIXED_INTR,			\
+		.subdev_info    = MGMT_RES_XBB_QEP,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_QEP),		\
+		.flash_type = FLASH_TYPE_SPI				\
+	}
 
 
 #define	XOCL_BOARD_MGMT_6B0F		XOCL_BOARD_MGMT_6A8F
@@ -1451,7 +1475,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XVC_PRI,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	XOCL_BOARD_MGMT_6A8F_DSA52					\
@@ -1472,7 +1497,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_NIFD_PRI,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	XOCL_BOARD_MGMT_XBB_DSA52					\
@@ -1493,8 +1519,9 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XMC,				\
 			XOCL_DEVINFO_XVC_PRI,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
-			XOCL_DEVINFO_ICAP_MGMT,			\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_ICAP_MGMT,				\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	XOCL_BOARD_MGMT_XBB_DSA52_U280					\
@@ -1505,42 +1532,44 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_SPI,				\
 	}
 
-#define MGMT_RES_XBB_QDMA_U280                                               \
-	((struct xocl_subdev_info []) {                         \
-		XOCL_DEVINFO_FEATURE_ROM,                       \
-		XOCL_DEVINFO_IORES_MGMT_U280,			\
-		XOCL_DEVINFO_PRP_IORES_MGMT_U280,		\
-		XOCL_DEVINFO_AF_DSA52,                          \
-		XOCL_DEVINFO_XMC,                               \
-		XOCL_DEVINFO_XVC_PRI,                           \
-		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,			\
-		XOCL_DEVINFO_ICAP_MGMT,                    \
-		XOCL_DEVINFO_FMGR,      			\
+#define MGMT_RES_XBB_QDMA_U280						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM,				\
+		XOCL_DEVINFO_IORES_MGMT_U280,				\
+		XOCL_DEVINFO_PRP_IORES_MGMT_U280,			\
+		XOCL_DEVINFO_AF_DSA52,					\
+		XOCL_DEVINFO_XMC,					\
+		XOCL_DEVINFO_XVC_PRI,					\
+		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,				\
+		XOCL_DEVINFO_ICAP_MGMT,					\
+		XOCL_DEVINFO_FMGR,					\
+		XOCL_DEVINFO_FLASH,					\
 	})
 
-#define XOCL_BOARD_MGMT_XBB_QDMA_U280                                   \
-	(struct xocl_board_private){                                    \
-		.flags          = XOCL_DSAFLAG_FIXED_INTR,		\
-		.subdev_info    = MGMT_RES_XBB_QDMA_U280,               \
-		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_QDMA_U280),       \
-		.flash_type = FLASH_TYPE_SPI				\
+#define XOCL_BOARD_MGMT_XBB_QDMA_U280					\
+	(struct xocl_board_private){					\
+		.flags	  = XOCL_DSAFLAG_FIXED_INTR,			\
+		.subdev_info    = MGMT_RES_XBB_QDMA_U280,		\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_QDMA_U280),	\
+		.flash_type = FLASH_TYPE_SPI,				\
 	}
 
-#define MGMT_RES_XBB_SMARTN                                     \
-	((struct xocl_subdev_info []) {                         \
-		XOCL_DEVINFO_FEATURE_ROM_SMARTN,		\
-		XOCL_DEVINFO_PRP_IORES_MGMT_SMARTN,		\
-		XOCL_DEVINFO_XMC,                               \
-		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,			\
-		XOCL_DEVINFO_ICAP_MGMT_SMARTN,                  \
-		XOCL_DEVINFO_FMGR,      			\
+#define MGMT_RES_XBB_SMARTN						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM_SMARTN,			\
+		XOCL_DEVINFO_PRP_IORES_MGMT_SMARTN,			\
+		XOCL_DEVINFO_XMC,					\
+		XOCL_DEVINFO_MAILBOX_MGMT_QDMA,				\
+		XOCL_DEVINFO_ICAP_MGMT_SMARTN,				\
+		XOCL_DEVINFO_FMGR,					\
+		XOCL_DEVINFO_FLASH,					\
 	})
 
-#define XOCL_BOARD_MGMT_XBB_SMARTN                                  	\
-	(struct xocl_board_private){                                    \
-		.flags          = XOCL_DSAFLAG_SMARTN,		\
-		.subdev_info    = MGMT_RES_XBB_SMARTN,               \
-		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_SMARTN),       \
+#define XOCL_BOARD_MGMT_XBB_SMARTN					\
+	(struct xocl_board_private){					\
+		.flags	  = XOCL_DSAFLAG_SMARTN,			\
+		.subdev_info    = MGMT_RES_XBB_SMARTN,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_XBB_SMARTN),		\
 		.flash_type = FLASH_TYPE_SPI				\
 	}
 
@@ -1556,7 +1585,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XIIC,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
+			XOCL_DEVINFO_FLASH,				\
 		})
 
 #define	XOCL_BOARD_MGMT_6E8F_DSA52					\
@@ -1575,10 +1605,10 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
 		})
 
-#define MGMT_RES_MPSOC_U30							\
+#define MGMT_RES_MPSOC_U30						\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
 			XOCL_DEVINFO_IORES_MGMT,			\
@@ -1588,7 +1618,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\
 			XOCL_DEVINFO_ICAP_MGMT,				\
-			XOCL_DEVINFO_FMGR,      			\
+			XOCL_DEVINFO_FMGR,				\
 		})
 
 #define	XOCL_BOARD_MGMT_MPSOC						\
@@ -1710,11 +1740,18 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_SPI,				\
 	}
 
+#define MFG_RES								\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FLASH,					\
+	})
+
 #define	XOCL_BOARD_XBB_MFG(board)					\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_MFG,				\
 		.board_name = board,					\
 		.flash_type = FLASH_TYPE_SPI,				\
+		.subdev_info	= MFG_RES,				\
+		.subdev_num = ARRAY_SIZE(MFG_RES),			\
 	}
 
 #define XOCL_RES_FEATURE_ROM_DYN			\
@@ -1776,9 +1813,8 @@ struct xocl_subdev_map {
 
 #define XOCL_PRIV_FLASH_BLP				\
 	((struct xocl_flash_privdata) {			\
-		offsetof(struct xocl_flash_privdata, data), \
-		0,	\
-		FLASH_TYPE_SPI,\
+		0,					\
+		FLASH_TYPE_SPI,				\
 	 })
 
 #define XOCL_DEVINFO_FLASH_BLP				\
@@ -1865,7 +1901,7 @@ struct xocl_subdev_map {
 	 	XOCL_DEVINFO_FEATURE_ROM_DYN,			\
 	 	XOCL_DEVINFO_IORES_MGMT,			\
 	 	XOCL_DEVINFO_FLASH_BLP,				\
-		XOCL_DEVINFO_FMGR,      			\
+		XOCL_DEVINFO_FMGR,				\
 	})
 
 #define	XOCL_BOARD_MGMT_DYNAMIC_IP					\
@@ -1876,7 +1912,7 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_SPI,				\
 	}
 
-#define	XOCL_DEVINFO_SCHEDULER_DYN				\
+#define	XOCL_DEVINFO_SCHEDULER_DYN			\
 	{						\
 		XOCL_SUBDEV_MB_SCHEDULER,		\
 		XOCL_MB_SCHEDULER,			\
@@ -1884,7 +1920,7 @@ struct xocl_subdev_map {
 		0,					\
 		&(char []){1},				\
 		1,					\
-		.level = XOCL_SUBDEV_LEVEL_PRP,         \
+		.level = XOCL_SUBDEV_LEVEL_PRP,	 \
 	}
 
 #define USER_RES_DYNAMIC_IP						\
@@ -1955,7 +1991,7 @@ struct xocl_subdev_map {
 	 	XOCL_DEVINFO_IORES_MGMT_U50,				\
 	 	XOCL_DEVINFO_FLASH_BLP,					\
 	 	XOCL_DEVINFO_XMC_BLP,					\
-		XOCL_DEVINFO_FMGR,      				\
+		XOCL_DEVINFO_FMGR,					\
 	})
 
 #define	XOCL_BOARD_MGMT_U50						\
@@ -2088,8 +2124,8 @@ struct xocl_subdev_map {
 	{ 0x10EE, 0x5000, PCI_ANY_ID, "xilinx_u200_xdma_201820_1",	\
 		&XOCL_BOARD_MGMT_XBB_DSA51 },				\
 	{ 0x10EE, 0x5005, PCI_ANY_ID, "xilinx_u250_xdma_201830_1",	\
-		&XOCL_BOARD_USER_DSA_U250_NO_KDMA },                     \
-	{0x10EE, 0x5014, PCI_ANY_ID, "xilinx_u250_qep_201910_1",  \
+		&XOCL_BOARD_USER_DSA_U250_NO_KDMA },			\
+	{0x10EE, 0x5014, PCI_ANY_ID, "xilinx_u250_qep_201910_1",  	\
 		&XOCL_BOARD_MGMT_U250_QEP }
 
 #define XOCL_DSA_DYNAMIC_MAP						\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -1,9 +1,10 @@
 /*
- * A GEM style device manager for PCIe based OpenCL accelerators.
+ * Platform driver for flash controllers on Xilinx's Alveo cards.
  *
- * Copyright (C) 2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi Hou <lizhih@xilinx.com>
+ *          Max Zhen <maxz@xilinx.com>
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -18,12 +19,1108 @@
 #include "../xocl_drv.h"
 #include "mgmt-ioctl.h"
 
+/* Status write command */
+#define QSPI_CMD_STATUSREG_WRITE		0x01
+/* Page Program command */
+#define QSPI_CMD_PAGE_PROGRAM			0x02
+/* Random read command */
+#define QSPI_CMD_RANDOM_READ			0x03
+/* Status read command */
+#define QSPI_CMD_STATUSREG_READ			0x05
+/* Enable flash write */
+#define QSPI_CMD_WRITE_ENABLE			0x06
+/* 4KB Subsector Erase command */
+#define QSPI_CMD_4KB_SUBSECTOR_ERASE		0x20
+/* Quad Input Fast Program */
+#define QSPI_CMD_QUAD_WRITE			0x32
+/* Extended quad input fast program */
+#define QSPI_CMD_EXT_QUAD_WRITE			0x38
+/* Dual Output Fast Read */
+#define QSPI_CMD_DUAL_READ			0x3B
+/* Clear flag register */
+#define QSPI_CMD_CLEAR_FLAG_REGISTER		0x50
+/* 32KB Subsector Erase command */
+#define QSPI_CMD_32KB_SUBSECTOR_ERASE		0x52
+/* Enhanced volatile configuration register write command */
+#define QSPI_CMD_ENH_VOLATILE_CFGREG_WRITE	0x61
+/* Enhanced volatile configuration register read command */
+#define QSPI_CMD_ENH_VOLATILE_CFGREG_READ	0x65
+/* Quad Output Fast Read */
+#define QSPI_CMD_QUAD_READ			0x6B
+/* Status flag read command */
+#define QSPI_CMD_FLAG_STATUSREG_READ		0x70
+/* Volatile configuration register write command */
+#define QSPI_CMD_VOLATILE_CFGREG_WRITE		0x81
+/* Volatile configuration register read command */
+#define QSPI_CMD_VOLATILE_CFGREG_READ		0x85
+/* Read ID Code */
+#define QSPI_CMD_IDCODE_READ			0x9F
+/* Non volatile configuration register write command */
+#define QSPI_CMD_NON_VOLATILE_CFGREG_WRITE	0xB1
+/* Non volatile configuration register read command */
+#define QSPI_CMD_NON_VOLATILE_CFGREG_READ	0xB5
+/* Dual IO Fast Read */
+#define QSPI_CMD_DUAL_IO_READ			0xBB
+/* Enhanced volatile configuration register write command */
+#define QSPI_CMD_EXTENDED_ADDRESS_REG_WRITE	0xC5
+/* Bulk Erase command */
+#define QSPI_CMD_BULK_ERASE			0xC7
+/* Enhanced volatile configuration register read command */
+#define QSPI_CMD_EXTENDED_ADDRESS_REG_READ	0xC8
+/* Sector Erase command */
+#define QSPI_CMD_SECTOR_ERASE			0xD8
+/* Quad IO Fast Read */
+#define QSPI_CMD_QUAD_IO_READ			0xEB
+
+#define	FLASH_ERR(flash, fmt, arg...)	\
+	xocl_err(&flash->pdev->dev, fmt "\n", ##arg)
+#define	FLASH_WARN(flash, fmt, arg...)	\
+	xocl_warn(&flash->pdev->dev, fmt "\n", ##arg)
+#define	FLASH_INFO(flash, fmt, arg...)	\
+	xocl_info(&flash->pdev->dev, fmt "\n", ##arg)
+#define	FLASH_DBG(flash, fmt, arg...)	\
+	xocl_dbg(&flash->pdev->dev, fmt "\n", ##arg)
+
+/*
+ * QSPI control reg bits.
+ */
+#define QSPI_CR_LOOPBACK		(1 << 0)
+#define QSPI_CR_ENABLED			(1 << 1)
+#define QSPI_CR_MASTER_MODE		(1 << 2)
+#define QSPI_CR_CLK_POLARITY		(1 << 3)
+#define QSPI_CR_CLK_PHASE		(1 << 4)
+#define QSPI_CR_TXFIFO_RESET		(1 << 5)
+#define QSPI_CR_RXFIFO_RESET		(1 << 6)
+#define QSPI_CR_MANUAL_SLAVE_SEL	(1 << 7)
+#define QSPI_CR_TRANS_INHIBIT		(1 << 8)
+#define QSPI_CR_LSB_FIRST		(1 << 9)
+#define QSPI_CR_INIT_STATE		(QSPI_CR_TRANS_INHIBIT		| \
+					QSPI_CR_MANUAL_SLAVE_SEL	| \
+					QSPI_CR_RXFIFO_RESET		| \
+					QSPI_CR_TXFIFO_RESET		| \
+					QSPI_CR_ENABLED			| \
+					QSPI_CR_MASTER_MODE)
+
+/*
+ * QSPI status reg bits.
+ */
+#define QSPI_SR_RX_EMPTY		(1 << 0)
+#define QSPI_SR_RX_FULL			(1 << 1)
+#define QSPI_SR_TX_EMPTY		(1 << 2)
+#define QSPI_SR_TX_FULL			(1 << 3)
+#define QSPI_SR_MODE_ERR		(1 << 4)
+#define QSPI_SR_SLAVE_MODE		(1 << 5)
+#define QSPI_SR_CPOL_CPHA_ERR		(1 << 6)
+#define QSPI_SR_SLAVE_MODE_ERR		(1 << 7)
+#define QSPI_SR_MSB_ERR			(1 << 8)
+#define QSPI_SR_LOOPBACK_ERR		(1 << 9)
+#define QSPI_SR_CMD_ERR			(1 << 10)
+#define QSPI_SR_ERRS			(QSPI_SR_CMD_ERR	| 	\
+					QSPI_SR_LOOPBACK_ERR	| 	\
+					QSPI_SR_MSB_ERR		| 	\
+					QSPI_SR_SLAVE_MODE_ERR	| 	\
+					QSPI_SR_CPOL_CPHA_ERR	| 	\
+					QSPI_SR_MODE_ERR)
+
+#define	MAX_NUM_OF_SLAVES	2
+#define	SLAVE_NONE		(-1)
+#define SLAVE_SELECT_NONE	((1 << MAX_NUM_OF_SLAVES) -1)
+
+/*
+ * We support erasing flash memory at three page unit. Page read-modify-write
+ * is done at smallest page unit.
+ */
+#define	FLASH_LARGE_PAGE_SIZE	(32UL * 1024)
+#define	FLASH_HUGE_PAGE_SIZE	(64UL * 1024)
+#define	FLASH_PAGE_SIZE		(4UL * 1024)
+#define	FLASH_PAGE_MASK		(FLASH_PAGE_SIZE - 1)
+#define	FLASH_PAGE_ALIGN(off)	((off) & ~FLASH_PAGE_MASK)
+#define	FLASH_PAGE_OFFSET(off)	((off) & FLASH_PAGE_MASK)
+static inline size_t FLASH_PAGE_ROUNDUP(loff_t offset)
+{
+	if (FLASH_PAGE_OFFSET(offset))
+		return round_up(offset, FLASH_PAGE_SIZE);
+	return offset + FLASH_PAGE_SIZE;
+}
+
+/*
+ * Wait for condition to be true for at most 1 second.
+ * Return true, if time'd out, false otherwise.
+ */
+#define FLASH_BUSY_WAIT(condition)					\
+({									\
+	const int interval = 5; /* in microsec */			\
+	int retry = 1000 * 1000 / interval; /* wait for 1 second */	\
+	while (retry && !(condition)) {					\
+		udelay(interval);					\
+		retry--;						\
+	}								\
+	(retry == 0);							\
+})
+
+static size_t micron_code2sectors(u8 code)
+{
+	size_t max_sectors = 0;
+
+	switch (code) {
+	case 0x17:
+		max_sectors = 1;
+		break;
+	case 0x18:
+		max_sectors = 1;
+		break;
+	case 0x19:
+		max_sectors = 2;
+		break;
+	case 0x20:
+		max_sectors = 4;
+		break;
+	case 0x21:
+		max_sectors = 8;
+		break;
+	case 0x22:
+		max_sectors = 16;
+		break;
+	default:
+		break;
+	}
+	return max_sectors;
+}
+
+static size_t macronix_code2sectors(u8 code)
+{
+	if (code < 0x38 || code > 0x3c)
+		return 0;
+	return (1 << (code - 0x38));
+}
+
+static u8 macronix_write_cmd(void)
+{
+	return QSPI_CMD_PAGE_PROGRAM;
+}
+
+static u8 micron_write_cmd(void)
+{
+	return QSPI_CMD_QUAD_WRITE;
+}
+
+/*
+ * Flash memory vendor specific operations.
+ */
+static struct qspi_flash_vendor {
+	u8 vendor_id;
+	const char *vendor_name;
+	size_t (*code2sectors)(u8 code);
+	u8 (*write_cmd)(void);
+} vendors[] = {
+	{ 0x20, "micron", micron_code2sectors, micron_write_cmd },
+	{ 0xc2, "macronix", macronix_code2sectors, macronix_write_cmd },
+};
+
+struct qspi_flash_addr {
+	u8 slave;
+	u8 sector;
+	u8 addr_lo;
+	u8 addr_mid;
+	u8 addr_hi;
+};
+
+/*
+ * QSPI flash controller IP register layout
+ */
+struct qspi_reg {
+	u32	qspi_padding1[16];
+	u32	qspi_reset;
+	u32	qspi_padding2[7];
+	u32	qspi_ctrl;
+	u32	qspi_status;
+	u32	qspi_tx;
+	u32	qspi_rx;
+	u32	qspi_slave;
+	u32	qspi_tx_fifo;
+	u32	qspi_rx_fifo;
+} __attribute__((packed));
+
 struct xocl_flash {
 	struct platform_device	*pdev;
 
 	struct resource *res;
 	struct xocl_flash_privdata *priv_data;
+	struct mutex io_lock;
+	bool sysfs_created;
+	bool busy;
+	bool io_debug;
+	size_t flash_size;
+	u8 *io_buf;
+
+	/* For now, only support QSPI */
+	struct qspi_reg *qspi_regs;
+	size_t qspi_fifo_depth;
+	u8 qspi_curr_sector;
+	struct qspi_flash_vendor *vendor;
 };
+
+static inline const char *reg2name(struct xocl_flash *flash, u32 *reg)
+{
+	const char *reg_names[] = {
+		"qspi_ctrl",
+		"qspi_status",
+		"qspi_tx",
+		"qspi_rx",
+		"qspi_slave",
+		"qspi_tx_fifo",
+		"qspi_rx_fifo",
+	};
+	size_t off = (uintptr_t)reg - (uintptr_t)flash->qspi_regs;
+
+	if (off == offsetof(struct qspi_reg, qspi_reset))
+		return "qspi_reset";
+	if (off < offsetof(struct qspi_reg, qspi_ctrl))
+		return "padding";
+	off -= offsetof(struct qspi_reg, qspi_ctrl);
+	return reg_names[off / sizeof(u32)];
+}
+
+static inline u32 flash_reg_rd(struct xocl_flash *flash, u32 *reg)
+{
+	u32 val = ioread32(reg);
+	if (flash->io_debug)
+		FLASH_INFO(flash, "REG_RD(%s)=0x%x", reg2name(flash, reg), val);
+	return val;
+}
+
+static inline void flash_reg_wr(struct xocl_flash *flash, u32 *reg, u32 val)
+{
+	if (flash->io_debug)
+		FLASH_INFO(flash, "REG_WR(%s,0x%x)", reg2name(flash, reg), val);
+	iowrite32(val, reg);
+}
+
+static inline u32 flash_get_status(struct xocl_flash *flash)
+{
+	return flash_reg_rd(flash, &flash->qspi_regs->qspi_status);
+}
+
+static inline u32 flash_get_ctrl(struct xocl_flash *flash)
+{
+	return flash_reg_rd(flash, &flash->qspi_regs->qspi_ctrl);
+}
+
+static inline void flash_set_ctrl(struct xocl_flash *flash, u32 ctrl)
+{
+	flash_reg_wr(flash, &flash->qspi_regs->qspi_ctrl, ctrl);
+}
+
+static inline void flash_set_slave(struct xocl_flash *flash, int index)
+{
+	u32 slave_reg;
+
+	if (index == SLAVE_NONE)
+		slave_reg = SLAVE_SELECT_NONE;
+	else
+		slave_reg = ~(1 << index);
+	flash_reg_wr(flash, &flash->qspi_regs->qspi_slave, slave_reg);
+}
+
+/*
+ * Pull one byte from flash RX fifo.
+ * So far, only 8-bit data width is supported.
+ */
+static inline u8 flash_read8(struct xocl_flash *flash)
+{
+	return (u8)flash_reg_rd(flash, &flash->qspi_regs->qspi_rx);
+}
+
+/*
+ * Push one byte to flash TX fifo.
+ * So far, only 8-bit data width is supported.
+ */
+static inline void flash_send8(struct xocl_flash *flash, u8 val)
+{
+	flash_reg_wr(flash, &flash->qspi_regs->qspi_tx, val);
+}
+
+static inline bool flash_has_err(struct xocl_flash *flash)
+{
+	u32 status = flash_get_status(flash);
+	if (!(status & QSPI_SR_ERRS))
+		return false;
+
+	FLASH_ERR(flash, "QSPI error status: 0x%x", status);
+	return true;
+}
+
+/*
+ * Caller should make sure the flash controller has exactly
+ * len bytes in the fifo. It's an error if we pull out less.
+ */
+static int flash_rx(struct xocl_flash *flash, u8 *buf, size_t len)
+{
+	size_t cnt;
+
+	for (cnt = 0; cnt < len; cnt++) {
+		u8 c = flash_read8(flash);
+		if (buf)
+			buf[cnt] = c;
+	}
+
+	if ((flash_get_status(flash) & QSPI_SR_RX_EMPTY) == 0) {
+		FLASH_ERR(flash, "failed to drain RX fifo");
+		return -EINVAL;
+	}
+
+	if (flash_has_err(flash))
+		return -EINVAL;
+
+	return 0;
+}
+
+/*
+ * Caller should make sure the fifo is large enough to host len bytes.
+ */
+static int flash_tx(struct xocl_flash *flash, u8 *buf, size_t len)
+{
+	u32 ctrl = flash_get_ctrl(flash);
+	int i;
+
+	BUG_ON(len > flash->qspi_fifo_depth);
+
+	/* Stop transfering to the flash. */
+	flash_set_ctrl(flash, ctrl | QSPI_CR_TRANS_INHIBIT);
+
+	/* Fill out the FIFO. */
+	for (i = 0; i < len; i++)
+		flash_send8(flash, buf[i]);
+
+	/* Start transfering to the flash. */
+	flash_set_ctrl(flash, ctrl & ~QSPI_CR_TRANS_INHIBIT);
+
+	/* Waiting for FIFO to become empty again. */
+	if (FLASH_BUSY_WAIT(flash_get_status(flash) &
+		(QSPI_SR_TX_EMPTY | QSPI_SR_ERRS))) {
+		if (flash_has_err(flash)) {
+			FLASH_ERR(flash, "QSPI write failed");
+		} else {
+			FLASH_ERR(flash, "QSPI write timeout, status: 0x%x",
+				flash_get_status(flash));
+		}
+		return -ETIMEDOUT;
+	}
+
+	/* Always stop transfering to the flash after we finish. */
+	flash_set_ctrl(flash, ctrl | QSPI_CR_TRANS_INHIBIT);
+
+	if (flash_has_err(flash))
+		return -EINVAL;
+
+	return 0;
+}
+
+/*
+ * Reset both RX and TX FIFO.
+ */
+static int flash_reset_fifo(struct xocl_flash *flash)
+{
+	const u32 status_fifo_mask = QSPI_SR_TX_FULL | QSPI_SR_RX_FULL |
+		QSPI_SR_TX_EMPTY | QSPI_SR_RX_EMPTY;
+	u32 fifo_status = flash_get_status(flash) & status_fifo_mask;
+
+	if (fifo_status == (QSPI_SR_TX_EMPTY | QSPI_SR_RX_EMPTY))
+		return 0;
+
+	flash_set_ctrl(flash, flash_get_ctrl(flash) | QSPI_CR_TXFIFO_RESET |
+		QSPI_CR_RXFIFO_RESET);
+
+	if (FLASH_BUSY_WAIT((flash_get_status(flash) & status_fifo_mask)) ==
+		(QSPI_SR_TX_EMPTY | QSPI_SR_RX_EMPTY)) {
+		FLASH_ERR(flash, "failed to reset FIFO, status: 0x%x",
+			flash_get_status(flash));
+		return -ETIMEDOUT;
+	}
+	return 0;
+}
+
+static int flash_transaction(struct xocl_flash *flash,
+	u8 *buf, size_t len, int slave, bool need_output)
+{
+	int ret = 0;
+
+	/* Reset both the TX and RX fifo before starting transaction. */
+	ret = flash_reset_fifo(flash);
+	if (ret)
+		return ret;
+
+	/* The slave index should be within range. */
+	if (slave >= MAX_NUM_OF_SLAVES)
+		return -EINVAL;
+	flash_set_slave(flash, slave);
+
+	ret = flash_tx(flash, buf, len);
+	if (ret)
+		return ret;
+
+	if (need_output) {
+		ret = flash_rx(flash, buf, len);
+	} else {
+		/* Needs to drain the FIFO even when the data is not wanted. */
+		ret = flash_rx(flash, NULL, len);
+	}
+
+	/* Always need to reset slave select register after each transaction */
+	flash_set_slave(flash, SLAVE_NONE);
+
+	return 0;
+}
+
+static size_t flash_get_fifo_depth(struct xocl_flash *flash)
+{
+	size_t depth = 0;
+	u32 ctrl;
+
+	/* Reset TX fifo. */
+	if (flash_reset_fifo(flash))
+		return depth;
+
+	/* Stop transfering to flash. */
+	ctrl = flash_get_ctrl(flash);
+	flash_set_ctrl(flash, ctrl | QSPI_CR_TRANS_INHIBIT);
+
+	/*
+	 * Find out fifo depth by keep pushing data to QSPI until
+	 * the fifo is full. We can choose to send any data. But
+	 * sending 0 seems to cause error, so pick a non-zero one.
+	 */
+	while (!(flash_get_status(flash) & (QSPI_SR_TX_FULL | QSPI_SR_ERRS))) {
+		flash_send8(flash, 1);
+		depth++;
+	}
+
+	/* Make sure flash is still in good shape. */
+	if (flash_has_err(flash))
+		return 0;
+
+	/* Reset RX/TX fifo and restore ctrl since we just touched them. */
+	flash_set_ctrl(flash, ctrl);
+	(void) flash_reset_fifo(flash);
+
+	return depth;
+}
+
+/*
+ * Exec flash IO command on specified slave.
+ */
+static inline int flash_exec_io_cmd(struct xocl_flash *flash,
+	size_t len, int slave, bool output_needed)
+{
+	char *buf = flash->io_buf;
+
+	return flash_transaction(flash, buf, len, slave, output_needed);
+}
+
+/* Test if flash memory is ready. */
+static bool flash_is_ready(struct xocl_flash *flash)
+{
+	/*
+	 * Reading flash device status input needs a dummy byte
+	 * after cmd byte. The output is in the 2nd byte.
+	 */
+	u8 cmd[2] = { QSPI_CMD_STATUSREG_READ, };
+	int ret = flash_transaction(flash, cmd, sizeof(cmd), 0, true);
+
+	if (ret || (cmd[1] & 0x1)) // flash device is busy
+		return false;
+
+	return true;
+}
+
+static int flash_get_ID(struct xocl_flash *flash)
+{
+	int i;
+	struct qspi_flash_vendor *vendor = NULL;
+	/*
+	 * Reading flash device vendor ID. Vendor ID is in cmd[1], max vector
+	 * number is in cmd[3] from output.
+	 */
+	u8 cmd[5] = { QSPI_CMD_IDCODE_READ, };
+	int ret = flash_transaction(flash, cmd, sizeof(cmd), 0, true);
+
+	if (ret) {
+		FLASH_ERR(flash, "Can't get flash memory ID, err: %d", ret);
+		return -EINVAL;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(vendors); i++) {
+		if (cmd[1] == vendors[i].vendor_id) {
+			vendor = &vendors[i];
+			break;
+		}
+	}
+
+	/* Find out flash vendor and size. */
+	if (vendor == NULL) {
+		FLASH_ERR(flash, "Unknown flash vendor: %d", cmd[1]);
+		return -EINVAL;
+	} else {
+		FLASH_INFO(flash, "Flash vendor: %s", vendor->vendor_name);
+		flash->vendor = vendor;
+	}
+
+	flash->flash_size = vendor->code2sectors(cmd[3]) * (16 * 1024 * 1024);
+	if (flash->flash_size == 0) {
+		FLASH_ERR(flash, "Unknown flash memory size code: %d", cmd[3]);
+		return -EINVAL;
+	} else {
+		FLASH_INFO(flash, "Flash size: %ldMB",
+			flash->flash_size / 1024 / 1024);
+	}
+
+	return 0;
+}
+
+static int flash_enable_write(struct xocl_flash *flash)
+{
+	u8 cmd = QSPI_CMD_WRITE_ENABLE;
+	int ret = flash_transaction(flash, &cmd, 1, 0, false);
+
+	if (ret)
+		FLASH_ERR(flash, "Failed to enable flash write: %d", ret);
+	return ret;
+}
+
+static int flash_set_sector(struct xocl_flash *flash, u8 sector)
+{
+	int ret = 0;
+	u8 cmd[] = { QSPI_CMD_EXTENDED_ADDRESS_REG_WRITE, sector };
+
+	if (sector == flash->qspi_curr_sector)
+		return 0;
+
+	FLASH_DBG(flash, "setting sector to %d", sector);
+
+	ret = flash_enable_write(flash);
+	if (ret)
+		return ret;
+
+	ret = flash_transaction(flash, cmd, sizeof(cmd), 0, false);
+	if (ret) {
+		FLASH_ERR(flash, "Failed to set sector %d: %d", sector, ret);
+		return ret;
+	}
+
+	flash->qspi_curr_sector = sector;
+	return ret;
+}
+
+/* For 24 bit addressing. */
+static inline void flash_offset2faddr(loff_t addr,
+	struct qspi_flash_addr *faddr)
+{
+	faddr->slave = (u8)(addr >> 56);
+	faddr->sector = (u8)(addr >> 24);
+	faddr->addr_lo = (u8)(addr);
+	faddr->addr_mid = (u8)(addr >> 8);
+	faddr->addr_hi = (u8)(addr >> 16);
+}
+
+/* IO cmd starts with op code followed by address. */
+static inline int
+flash_setup_io_cmd_header(struct xocl_flash *flash,
+	u8 op, struct qspi_flash_addr *faddr, size_t *header_len)
+{
+	int ret = 0;
+
+	/* Set sector (the high byte of a 32-bit address), if needed. */
+	ret = flash_set_sector(flash, faddr->sector);
+	if (ret == 0) {
+		/* The rest of address bytes are in cmd. */
+		flash->io_buf[0] = op;
+		flash->io_buf[1] = faddr->addr_hi;
+		flash->io_buf[2] = faddr->addr_mid;
+		flash->io_buf[3] = faddr->addr_lo;
+		*header_len = 4;
+	}
+	return ret;
+}
+
+static bool flash_wait_till_ready(struct xocl_flash *flash)
+{
+	if (FLASH_BUSY_WAIT(flash_is_ready(flash))) {
+		FLASH_ERR(flash, "QSPI flash device is not ready");
+		return false;
+	}
+	return true;
+}
+
+static int qspi_probe(struct xocl_flash *flash)
+{
+	int ret;
+
+	flash_set_ctrl(flash, QSPI_CR_INIT_STATE);
+
+	/* Find out fifo depth before any read/write operations. */
+	flash->qspi_fifo_depth = flash_get_fifo_depth(flash);
+	if (flash->qspi_fifo_depth == 0)
+		return -EINVAL;
+	FLASH_INFO(flash, "QSPI FIFO depth is: %ld", flash->qspi_fifo_depth);
+
+	if (!flash_wait_till_ready(flash))
+		return -EINVAL;
+
+	/* Update flash vendor. */
+	ret = flash_get_ID(flash);
+	if (ret)
+		return ret;
+
+	flash->qspi_curr_sector = 0xff;
+
+	return 0;
+}
+
+/*
+ * Do one FIFO read from flash.
+ * @cnt contains bytes actually read on successful return.
+ */
+static int flash_fifo_rd(struct xocl_flash *flash,
+	loff_t off, u8 *buf, size_t *cnt)
+{
+	/* For read cmd, we need to exclude a few more dummy bytes in FIFO. */
+	const size_t read_dummy_len = 4;
+
+	int ret;
+	struct qspi_flash_addr faddr;
+	size_t header_len, total_len, payload_len;
+
+	/* Should not cross page bundary. */
+	BUG_ON(off + *cnt > FLASH_PAGE_ROUNDUP(off));
+	flash_offset2faddr(off, &faddr);
+
+	ret = flash_setup_io_cmd_header(flash,
+		QSPI_CMD_QUAD_READ, &faddr, &header_len);
+	if (ret)
+		return ret;
+
+	/* Figure out length of IO for this read. */
+
+	/*
+	 * One read should not be more than one fifo depth, so that we don't
+	 * overrun flash->io_buf.
+	 * The first header_len + read_dummy_len bytes in output buffer are
+	 * always garbage, need to make room for them. What a wonderful memory
+	 * controller!!
+	 */
+	payload_len = min(*cnt,
+		flash->qspi_fifo_depth - header_len - read_dummy_len);
+	total_len = payload_len + header_len + read_dummy_len;
+
+	FLASH_DBG(flash, "reading %ld bytes @0x%llx", payload_len, off);
+
+	/* Now do the read. */
+
+	/*
+	 * You tell the memory controller how many bytes you want to read
+	 * by writing that many bytes to it. How hard would it be to just
+	 * add one more integer to specify the length in the input cmd?!
+	 */
+	ret = flash_exec_io_cmd(flash, total_len, faddr.slave, true);
+	if (ret)
+		return ret;
+
+	/* Copy out the output. Skip the garbage part. */
+	memcpy(buf, &flash->io_buf[header_len + read_dummy_len], payload_len);
+	*cnt = payload_len;
+	return 0;
+}
+
+/*
+ * Do one FIFO write to flash. Assuming erase is already done.
+ * @cnt contains bytes actually written on successful return.
+ */
+static int flash_fifo_wr(struct xocl_flash *flash,
+	loff_t off, u8 *buf, size_t *cnt)
+{
+	/*
+	 * For write cmd, we can't write more than write_max_len bytes in one
+	 * IO request even though we have larger fifo. Otherwise, writes will
+	 * randomly fail.
+	 */
+	const size_t write_max_len = 128UL;
+
+	int ret;
+	struct qspi_flash_addr faddr;
+	size_t header_len, total_len, payload_len;
+
+	flash_offset2faddr(off, &faddr);
+
+	ret = flash_setup_io_cmd_header(flash,
+		flash->vendor->write_cmd(), &faddr, &header_len);
+	if (ret)
+		return ret;
+
+	/* Figure out length of IO for this write. */
+
+	/*
+	 * One IO should not be more than one fifo depth, so that we don't
+	 * overrun flash->io_buf. And we don't go beyond the write_max_len;
+	 */
+	payload_len = min(*cnt, flash->qspi_fifo_depth - header_len);
+	payload_len = min(payload_len, write_max_len);
+	total_len = payload_len + header_len;
+
+	FLASH_DBG(flash, "writing %ld bytes @0x%llx", payload_len, off);
+
+	/* Copy in payload after header. */
+	memcpy(&flash->io_buf[header_len], buf, payload_len);
+
+	/* Now do the write. */
+
+	ret = flash_enable_write(flash);
+	if (ret)
+		return ret;
+	ret = flash_exec_io_cmd(flash, total_len, faddr.slave, false);
+	if (ret)
+		return ret;
+	if (!flash_wait_till_ready(flash))
+		return -EINVAL;
+
+	*cnt = payload_len;
+	return 0;
+}
+
+/*
+ * Load/store the whole buf of data from/to flash memory.
+ */
+static int flash_buf_rdwr(struct xocl_flash *flash,
+	u8 *buf, loff_t off, size_t len, bool write)
+{
+	int ret = 0;
+	size_t n, curlen;
+
+	for (n = 0; ret == 0 && n < len; n += curlen) {
+		curlen = len - n;
+		if (write)
+			ret = flash_fifo_wr(flash, off + n, &buf[n], &curlen);
+		else
+			ret = flash_fifo_rd(flash, off + n, &buf[n], &curlen);
+	}
+
+	/*
+	 * Yield CPU after every buf IO so that Linux does not complain
+	 * about CPU soft lockup.
+	 */
+	schedule();
+	return ret;
+}
+
+static u8 flash_erase_cmd(size_t pagesz)
+{
+	u8 cmd = 0;
+	const size_t onek = 1024;
+
+	BUG_ON(!IS_ALIGNED(pagesz, onek));
+	switch (pagesz / onek) {
+	case 4:
+		cmd = QSPI_CMD_4KB_SUBSECTOR_ERASE;
+		break;
+	case 32:
+		cmd = QSPI_CMD_32KB_SUBSECTOR_ERASE;
+		break;
+	case 64:
+		cmd = QSPI_CMD_SECTOR_ERASE;
+		break;
+	default:
+		BUG_ON(1);
+		break;
+	}
+	return cmd;
+}
+
+/*
+ * Erase one flash page.
+ */
+static int flash_page_erase(struct xocl_flash *flash, loff_t off, size_t pagesz)
+{
+	int ret = 0;
+	struct qspi_flash_addr faddr;
+	size_t cmdlen;
+	u8 cmd = flash_erase_cmd(pagesz);
+
+	FLASH_DBG(flash, "Erasing 0x%lx bytes @0x%llx with cmd=0x%x",
+		pagesz, off, (u32)cmd);
+
+	BUG_ON(!IS_ALIGNED(off, pagesz));
+	flash_offset2faddr(off, &faddr);
+
+	if (!flash_wait_till_ready(flash))
+		return -EINVAL;
+
+	ret = flash_setup_io_cmd_header(flash, cmd, &faddr, &cmdlen);
+	if (ret)
+		return ret;
+
+	ret = flash_enable_write(flash);
+	if (ret)
+		return ret;
+
+	ret = flash_exec_io_cmd(flash, cmdlen, faddr.slave, false);
+	if (ret) {
+		FLASH_ERR(flash, "Failed to erase 0x%lx bytes @0x%llx",
+			pagesz, off);
+		return ret;
+	}
+
+	if (!flash_wait_till_ready(flash))
+		return -EINVAL;
+
+	return 0;
+}
+
+/*
+ * Read flash memory page by page into user buf.
+ */
+static ssize_t
+flash_read(struct file *file, char __user *buf, size_t n, loff_t *off)
+{
+	struct xocl_flash *flash = file->private_data;
+	u8 *page = NULL;
+	size_t cnt = 0;
+	int ret = 0;
+
+	if (n == 0 || *off + n >= flash->flash_size)
+		return -EINVAL;
+
+	page = vmalloc(FLASH_PAGE_SIZE);
+	if (page == NULL)
+		return -ENOMEM;
+
+	mutex_lock(&flash->io_lock);
+
+	if (!flash_wait_till_ready(flash))
+		ret = -EINVAL;
+
+	while (cnt < n) {
+		loff_t thisoff = *off + cnt;
+		size_t thislen = min(n - cnt,
+			FLASH_PAGE_ROUNDUP(thisoff) - (size_t)thisoff);
+		char *thisbuf = &page[FLASH_PAGE_OFFSET(thisoff)];
+
+		ret = flash_buf_rdwr(flash, thisbuf, thisoff, thislen, false);
+		if (ret)
+			break;
+
+		if (copy_to_user(&buf[cnt], thisbuf, thislen) != 0) {
+			ret = -EFAULT;
+			break;
+		}
+
+		cnt += thislen;
+	}
+
+	mutex_unlock(&flash->io_lock);
+
+	vfree(page);
+	if (ret)
+		return ret;
+
+	*off += n;
+	return n;
+}
+
+/*
+ * Write a page. Perform read-modify-write as needed.
+ * @cnt contains actual bytes copied from user on successful return.
+ */
+static int flash_page_rmw(struct xocl_flash *flash,
+	const char __user *ubuf, u8 *kbuf, loff_t off, size_t *cnt)
+{
+	loff_t thisoff = FLASH_PAGE_ALIGN(off);
+	size_t front = FLASH_PAGE_OFFSET(off);
+	size_t mid = min(*cnt, FLASH_PAGE_SIZE - front);
+	size_t last = FLASH_PAGE_SIZE - front - mid;
+	u8 *thiskbuf = kbuf;
+	int ret;
+
+	if (front) {
+		ret = flash_buf_rdwr(flash, thiskbuf, thisoff, front, false);
+		if (ret)
+			return ret;
+	}
+	thisoff += front;
+	thiskbuf += front;
+	if (copy_from_user(thiskbuf, ubuf, mid) != 0)
+		return -EFAULT;
+	*cnt = mid;
+	thisoff += mid;
+	thiskbuf += mid;
+	if (last) {
+		ret = flash_buf_rdwr(flash, thiskbuf, thisoff, last, false);
+		if (ret)
+			return ret;
+	}
+
+	ret = flash_page_erase(flash, FLASH_PAGE_ALIGN(off), FLASH_PAGE_SIZE);
+	if (ret == 0) {
+		ret = flash_buf_rdwr(flash, kbuf, FLASH_PAGE_ALIGN(off),
+			FLASH_PAGE_SIZE, true);
+	}
+	return ret;
+}
+
+static inline size_t flash_get_page_io_size(loff_t off, size_t sz)
+{
+	if (IS_ALIGNED(off, FLASH_HUGE_PAGE_SIZE) &&
+		sz >= FLASH_HUGE_PAGE_SIZE)
+		return FLASH_HUGE_PAGE_SIZE;
+	if (IS_ALIGNED(off, FLASH_LARGE_PAGE_SIZE) &&
+		sz >= FLASH_LARGE_PAGE_SIZE)
+		return FLASH_LARGE_PAGE_SIZE;
+	if (IS_ALIGNED(off, FLASH_PAGE_SIZE) &&
+		sz >= FLASH_PAGE_SIZE)
+		return FLASH_PAGE_SIZE;
+
+	return 0; // can't do full page IO
+}
+
+/*
+ * Try to erase and write full (large/huge) page.
+ * @cnt contains actual bytes copied from user on successful return.
+ * Needs to fallback to RMW, if not possible.
+ */
+static int flash_page_wr(struct xocl_flash *flash,
+	const char __user *ubuf, u8 *kbuf, loff_t off, size_t *cnt)
+{
+	int ret;
+	size_t thislen = flash_get_page_io_size(off, *cnt);
+
+	if (thislen == 0)
+		return -EOPNOTSUPP;
+
+	*cnt = thislen;
+
+	if (copy_from_user(kbuf, ubuf, thislen) != 0)
+		return -EFAULT;
+
+	ret = flash_page_erase(flash, off, thislen);
+	if (ret == 0)
+		ret = flash_buf_rdwr(flash, kbuf, off, thislen, true);
+	return ret;
+}
+
+/*
+ * Write to flash memory page by page from user buf.
+ */
+static ssize_t
+flash_write(struct file *file, const char __user *buf, size_t n, loff_t *off)
+{
+	struct xocl_flash *flash = file->private_data;
+	u8 *page = NULL;
+	size_t cnt = 0;
+	int ret = 0;
+
+	if (n == 0 || *off + n >= flash->flash_size)
+		return -EINVAL;
+
+	page = vmalloc(FLASH_HUGE_PAGE_SIZE);
+	if (page == NULL)
+		return -ENOMEM;
+
+	mutex_lock(&flash->io_lock);
+
+	if (!flash_wait_till_ready(flash))
+		ret = -EINVAL;
+
+	while (ret == 0 && cnt < n) {
+		loff_t thisoff = *off + cnt;
+		const char *thisbuf = buf + cnt;
+		size_t thislen = n - cnt;
+
+		/* Try write full page. */
+		ret = flash_page_wr(flash, thisbuf, page, thisoff, &thislen);
+		if (ret) {
+			/* Fallback to RMW. */
+			if (ret == -EOPNOTSUPP) {
+				ret = flash_page_rmw(flash, thisbuf, page,
+					thisoff, &thislen);
+			}
+			if (ret)
+				break;
+		}
+		cnt += thislen;
+	}
+
+	mutex_unlock(&flash->io_lock);
+
+	vfree(page);
+	if (ret)
+		return ret;
+
+	*off += n;
+	return n;
+}
+
+static loff_t
+flash_llseek(struct file *filp, loff_t off, int whence)
+{
+	loff_t npos;
+
+	switch(whence) {
+	case 0: /* SEEK_SET */
+		npos = off;
+		break;
+	case 1: /* SEEK_CUR */
+		npos = filp->f_pos + off;
+		break;
+	case 2: /* SEEK_END: no need to support */
+		return -EINVAL;
+	default: /* should not happen */
+		return -EINVAL;
+	}
+	if (npos < 0)
+		return -EINVAL;
+
+	filp->f_pos = npos;
+	return npos;
+}
+
+/*
+ * Only allow one client at a time.
+ */
+static int flash_open(struct inode *inode, struct file *file)
+{
+	int ret = 0;
+	struct xocl_flash *flash = xocl_drvinst_open(inode->i_cdev);
+
+	if (!flash)
+		return -ENXIO;
+
+	mutex_lock(&flash->io_lock);
+	if (flash->busy) {
+		ret = -EBUSY;
+	} else {
+		file->private_data = flash;
+		flash->busy = true;
+	}
+	mutex_unlock(&flash->io_lock);
+
+	if (ret)
+		xocl_drvinst_close(flash);
+	return ret;
+}
+
+static int flash_close(struct inode *inode, struct file *file)
+{
+	struct xocl_flash *flash = file->private_data;
+
+	if (!flash)
+		return -EINVAL;
+
+	mutex_lock(&flash->io_lock);
+	flash->busy = false;
+	file->private_data = NULL;
+	mutex_unlock(&flash->io_lock);
+
+	xocl_drvinst_close(flash);
+	return 0;
+}
 
 static ssize_t bar_off_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
@@ -54,11 +1151,11 @@ static ssize_t flash_type_show(struct device *dev,
 	xdev_handle_t xdev = xocl_get_xdev(flash->pdev);
 	ssize_t ret;
 
-	if (flash->priv_data)
-		ret = sprintf(buf, "%s\n", (char *)flash->priv_data +
-			flash->priv_data->flash_type);
-	else
+	if (flash->priv_data) {
+		ret = sprintf(buf, "%s\n", flash->priv_data->flash_type);
+	} else {
 		ret = sprintf(buf, "%s\n", XDEV(xdev)->priv.flash_type);
+	}
 
 	return ret;
 }
@@ -93,19 +1190,40 @@ static int sysfs_create_flash(struct xocl_flash *flash)
 {
 	int ret;
 
-	ret  = sysfs_create_group(&flash->pdev->dev.kobj, 
-			&flash_attr_group);
+	ret  = sysfs_create_group(&flash->pdev->dev.kobj, &flash_attr_group);
 	if (ret)
-		xocl_err(&flash->pdev->dev, "create sysfs failed %d", ret);
-
+		FLASH_ERR(flash, "create sysfs failed %d", ret);
+	else
+		flash->sysfs_created = true;
 
 	return ret;
 }
 
 static void sysfs_destroy_flash(struct xocl_flash *flash)
 {
-	sysfs_remove_group(&flash->pdev->dev.kobj,
-			&flash_attr_group);
+	if (flash->sysfs_created)
+		sysfs_remove_group(&flash->pdev->dev.kobj, &flash_attr_group);
+}
+
+static int flash_remove(struct platform_device *pdev)
+{
+	struct xocl_flash *flash;
+
+	flash = platform_get_drvdata(pdev);
+	if (!flash)
+		return -EINVAL;
+
+	platform_set_drvdata(pdev, NULL);
+
+	sysfs_destroy_flash(flash);
+	vfree(flash->io_buf);
+
+	if (flash->qspi_regs)
+		iounmap(flash->qspi_regs);
+
+	mutex_destroy(&flash->io_lock);
+	xocl_drvinst_free(flash);
+	return 0;
 }
 
 static int flash_probe(struct platform_device *pdev)
@@ -113,52 +1231,69 @@ static int flash_probe(struct platform_device *pdev)
 	struct xocl_flash *flash;
 	int ret;
 
-	flash = devm_kzalloc(&pdev->dev, sizeof(*flash), GFP_KERNEL);
+	flash = xocl_drvinst_alloc(&pdev->dev, sizeof(*flash));
 	if (!flash)
 		return -ENOMEM;
 
+	platform_set_drvdata(pdev, flash);
 	flash->pdev = pdev;
+
+	mutex_init(&flash->io_lock);
+	flash->priv_data = XOCL_GET_SUBDEV_PRIV(&pdev->dev);
 
 	flash->res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (!flash->res) {
-		xocl_err(&pdev->dev, "Empty resource");
-		return -EINVAL;
+		ret = -EINVAL;
+		FLASH_ERR(flash, "empty resource");
+		goto error;
+	}
+	flash->qspi_regs = ioremap_nocache(flash->res->start,
+		flash->res->end - flash->res->start + 1);
+	if (!flash->qspi_regs) {
+		ret = -ENOMEM;
+		FLASH_ERR(flash, "failed to map resource");
+		goto error;
 	}
 
-	flash->priv_data = XOCL_GET_SUBDEV_PRIV(&pdev->dev);
+	ret = qspi_probe(flash);
+	if (ret)
+		goto error;
 
-	xocl_info(&pdev->dev, "Flash IO start: 0x%llx, end: 0x%llx",
-		flash->res->start, flash->res->end);
+	flash->io_buf = vmalloc(flash->qspi_fifo_depth);
+	if (flash->io_buf == NULL) {
+		ret = -ENOMEM;
+		goto error;
+	}
 
 	ret = sysfs_create_flash(flash);
 	if (ret)
-		return ret;
-
-	platform_set_drvdata(pdev, flash);
+		goto error;
 
 	return 0;
+
+error:
+	FLASH_ERR(flash, "probing failed");
+	flash_remove(pdev);
+	return ret;
 }
 
+static const struct file_operations flash_fops = {
+	.owner = THIS_MODULE,
+	.open = flash_open,
+	.release = flash_close,
+	.llseek = flash_llseek,
+	.read = flash_read,
+	.write = flash_write,
+};
 
-static int flash_remove(struct platform_device *pdev)
-{
-	struct xocl_flash	*flash;
-
-	flash = platform_get_drvdata(pdev);
-	if (!flash) {
-		xocl_err(&pdev->dev, "driver data is NULL");
-		return -EINVAL;
-	}
-	sysfs_destroy_flash(flash);
-	platform_set_drvdata(pdev, NULL);
-
-	devm_kfree(&pdev->dev, flash);
-
-	return 0;
-}
+struct xocl_drv_private flash_priv = {
+	.ops = NULL,
+	.fops = &flash_fops,
+	.dev = -1,
+};
 
 struct platform_device_id flash_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_FLASH), 0 },
+	{ XOCL_DEVNAME(XOCL_FLASH), (kernel_ulong_t)&flash_priv },
 	{ },
 };
 
@@ -173,10 +1308,21 @@ static struct platform_driver	flash_driver = {
 
 int __init xocl_init_flash(void)
 {
-	return platform_driver_register(&flash_driver);
+	int err = alloc_chrdev_region(&flash_priv.dev, 0, XOCL_MAX_DEVICES,
+			XOCL_FLASH);
+	if (err)
+		return err;
+
+	err = platform_driver_register(&flash_driver);
+	if (err == 0)
+		return 0;
+
+	unregister_chrdev_region(flash_priv.dev, XOCL_MAX_DEVICES);
+	return err;
 }
 
 void xocl_fini_flash(void)
 {
+	unregister_chrdev_region(flash_priv.dev, XOCL_MAX_DEVICES);
 	platform_driver_unregister(&flash_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -642,7 +642,7 @@ flash_setup_io_cmd_header(struct xocl_flash *flash,
 	return ret;
 }
 
-static bool flash_wait_till_ready(struct xocl_flash *flash)
+static bool flash_wait_until_ready(struct xocl_flash *flash)
 {
 	if (FLASH_BUSY_WAIT(flash_is_ready(flash))) {
 		FLASH_ERR(flash, "QSPI flash device is not ready");
@@ -663,7 +663,7 @@ static int qspi_probe(struct xocl_flash *flash)
 		return -EINVAL;
 	FLASH_INFO(flash, "QSPI FIFO depth is: %ld", flash->qspi_fifo_depth);
 
-	if (!flash_wait_till_ready(flash))
+	if (!flash_wait_until_ready(flash))
 		return -EINVAL;
 
 	/* Update flash vendor. */
@@ -779,7 +779,7 @@ static int flash_fifo_wr(struct xocl_flash *flash,
 	ret = flash_exec_io_cmd(flash, total_len, faddr.slave, false);
 	if (ret)
 		return ret;
-	if (!flash_wait_till_ready(flash))
+	if (!flash_wait_until_ready(flash))
 		return -EINVAL;
 
 	*cnt = payload_len;
@@ -850,7 +850,7 @@ static int flash_page_erase(struct xocl_flash *flash, loff_t off, size_t pagesz)
 	BUG_ON(!IS_ALIGNED(off, pagesz));
 	flash_offset2faddr(off, &faddr);
 
-	if (!flash_wait_till_ready(flash))
+	if (!flash_wait_until_ready(flash))
 		return -EINVAL;
 
 	ret = flash_setup_io_cmd_header(flash, cmd, &faddr, &cmdlen);
@@ -868,7 +868,7 @@ static int flash_page_erase(struct xocl_flash *flash, loff_t off, size_t pagesz)
 		return ret;
 	}
 
-	if (!flash_wait_till_ready(flash))
+	if (!flash_wait_until_ready(flash))
 		return -EINVAL;
 
 	return 0;
@@ -894,7 +894,7 @@ flash_read(struct file *file, char __user *buf, size_t n, loff_t *off)
 
 	mutex_lock(&flash->io_lock);
 
-	if (!flash_wait_till_ready(flash))
+	if (!flash_wait_until_ready(flash))
 		ret = -EINVAL;
 
 	while (cnt < n) {
@@ -1025,7 +1025,7 @@ flash_write(struct file *file, const char __user *buf, size_t n, loff_t *off)
 
 	mutex_lock(&flash->io_lock);
 
-	if (!flash_wait_till_ready(flash))
+	if (!flash_wait_until_ready(flash))
 		ret = -EINVAL;
 
 	while (ret == 0 && cnt < n) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -2340,7 +2340,7 @@ int __init xocl_init_mailbox(void)
 
 	return 0;
 err_driver_reg:
-	unregister_chrdev_region(mailbox_priv.dev, 1);
+	unregister_chrdev_region(mailbox_priv.dev, XOCL_MAX_DEVICES);
 err_chrdev_reg:
 	return err;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -91,7 +91,7 @@ failed:
 static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 {
 	struct xocl_dev_core *core = XDEV(xdev_hdl);
-	struct xocl_flash_privdata *priv = NULL;
+	char *priv = NULL;
 	const char *flash_type;
 	void *blob;
 	int node, proplen;
@@ -100,8 +100,7 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	if (!blob)
 		return NULL;
 
-	node = fdt_path_offset(blob, LEVEL0_DEV_PATH
-			"/" NODE_FLASH);
+	node = fdt_path_offset(blob, LEVEL0_DEV_PATH "/" NODE_FLASH);
 	if (node < 0) {
 		xocl_xdev_err(xdev_hdl, "did not find flash node");
 		return NULL;
@@ -114,15 +113,13 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 		return NULL;
 	}
 
-	proplen = sizeof(*priv) + strlen(flash_type);
+	proplen = strlen(flash_type) + 1;
 
 	priv = vzalloc(proplen);
 	if (!priv)
 		return NULL;
 
-	priv->flash_type = offsetof(struct xocl_flash_privdata, data);
-	priv->properties = priv->flash_type + strlen(flash_type) + 1;
-	strcpy((char *)priv + priv->flash_type, flash_type);
+	strcpy(priv, flash_type);
 
 	*len = proplen;
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -493,7 +493,7 @@ int flashXbutilFlashHandler(int argc, char *argv[])
         int ret = resetShell(devIdx == UINT_MAX ? 0 : devIdx);
         if (ret)
             return ret;
-        std::cout << "Shell is reset succesfully" << std::endl;
+        std::cout << "Shell is reset successfully" << std::endl;
         std::cout << "Cold reboot machine to load new shell on card" <<
             std::endl;
         return 0;
@@ -507,7 +507,7 @@ int flashXbutilFlashHandler(int argc, char *argv[])
             primary, secondary);
         if (ret)
             return ret;
-        std::cout << "Shell is updated succesfully" << std::endl;
+        std::cout << "Shell is updated successfully" << std::endl;
         std::cout << "Cold reboot machine to load new shell on card" <<
             std::endl;
         return 0;
@@ -639,7 +639,7 @@ static int shell(int argc, char *argv[])
     if (ret)
         return ret;
 
-    std::cout << "Shell is updated succesfully" << std::endl;
+    std::cout << "Shell is updated successfully" << std::endl;
     std::cout << "Cold reboot machine to load new shell on card" << std::endl;
     return 0;
 }
@@ -680,7 +680,7 @@ static int sc(int argc, char *argv[])
     if (ret)
         return ret;
 
-    std::cout << "SC firmware is updated succesfully" << std::endl;
+    std::cout << "SC firmware is updated successfully" << std::endl;
     return 0;
 }
 
@@ -712,7 +712,7 @@ static int reset(int argc, char *argv[])
     if (ret)
         return ret;
 
-    std::cout << "Shell is reset succesfully" << std::endl;
+    std::cout << "Shell is reset successfully" << std::endl;
     std::cout << "Cold reboot machine to load new shell on card" << std::endl;
     return 0;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2019 Xilinx, Inc
  * Author(s) : Sonal Santan
  *           : Hem Neema
  *           : Ryan Radjabi
@@ -26,7 +26,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <errno.h>
-#include <stdio.h>
+#include <cstdio>
 #include <stddef.h>
 #include "xspi.h"
 #include "core/pcie/driver/linux/include/mgmt-reg.h"
@@ -266,6 +266,12 @@ static void clearBuffers() {
     clearWriteBuffer(PAGE_SIZE + READ_WRITE_EXTRA_BYTES);
 }
 
+XSPI_Flasher::~XSPI_Flasher()
+{
+    if (mFlashDev)
+        std::fclose(mFlashDev);
+}
+
 XSPI_Flasher::XSPI_Flasher(std::shared_ptr<pcidev::pci_device> dev)
 {
     mDev = dev;
@@ -275,6 +281,11 @@ XSPI_Flasher::XSPI_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     if (!err.empty())
         flash_base = FLASH_BASE;
 
+    if (std::getenv("FLASH_VIA_DRIVER")) {
+        mFlashDev = fdopen(mDev->open("flash", O_RDWR), "r+");
+        if (mFlashDev == NULL)
+            std::cout << "Failed to open flash device on card" << std::endl;
+    }
 }
 
 unsigned XSPI_Flasher::getSector(unsigned address) {
@@ -493,6 +504,9 @@ int XSPI_Flasher::xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mc
 }
 
 int XSPI_Flasher::xclUpgradeFirmwareXSpi(std::istream& mcsStream, int index) {
+    if (mFlashDev)
+        return upgradeFirmwareXSpiDrv(mcsStream, index);
+
     clearBuffers();
     recordList.clear();
 
@@ -593,7 +607,7 @@ unsigned XSPI_Flasher::readReg(unsigned RegOffset) {
     unsigned value;
     if( mDev->pcieBarRead( flash_base + RegOffset, &value, 4 ) != 0 ) {
         assert(0);
-	throw std::runtime_error("read reg ERROR");
+        throw std::runtime_error("read reg ERROR");
     }
     return value;
 }
@@ -602,7 +616,7 @@ int XSPI_Flasher::writeReg(unsigned RegOffset, unsigned value) {
     int status = mDev->pcieBarWrite(flash_base + RegOffset, &value, 4);
     if(status != 0) {
         assert(0);
-        std::cout << "write reg ERROR " << std::endl;
+        throw std::runtime_error("write reg ERROR");
     }
     return 0;
 }
@@ -1593,8 +1607,79 @@ bool XSPI_Flasher::writeRegister(unsigned commandCode, unsigned value, unsigned 
     return Status;
 }
 
+// The bitstream guard location is fixed for now for all platforms.
+const unsigned int bitstreamGuardAddress = 0x01002000;
+const unsigned int bitstreamGuardSize = 4096;
+// Print out "." for each pagesz bytes of data processed.
+const size_t pagesz = 1024 * 1024ul;
+
+static inline long toAddr(const int slave, const unsigned int offset)
+{
+    long addr = slave;
+
+    // Slave index is the MSB of the address.
+    addr <<= 56;
+    addr |= offset;
+    return addr;
+}
+
+static int writeToFlash(std::FILE *flashDev, int slave,
+    const unsigned int address, const unsigned char *buf, size_t len)
+{
+    int ret = 0;
+    long addr = toAddr(slave, address);
+
+    ret = std::fseek(flashDev, addr, SEEK_SET);
+    if (ret)
+        return ret;
+
+    std::size_t s = std::fwrite(buf, 1, len, flashDev);
+    if (s != len)
+        ret = -ferror(flashDev);
+    return ret;
+}
+
+static int installBitstreamGuard(std::FILE *flashDev)
+{
+    const size_t bitstream_guard_offset = 128;
+    unsigned char buf[4096];
+
+    memset(buf, 0xff, sizeof(buf));
+    memcpy(buf + bitstream_guard_offset,
+        BITSTREAM_GUARD, sizeof(BITSTREAM_GUARD));
+
+    int ret = writeToFlash(flashDev, 0,
+        bitstreamGuardAddress, buf, sizeof(buf));
+    if (ret) {
+        std::cout << "Failed to activate bitstream guard: " << ret << std::endl;
+    } else {
+        std::cout << "Bitstream guard activated on flash @0x"
+            << std::hex << bitstreamGuardAddress << std::dec << std::endl;
+    }
+
+    return ret;
+}
+
+static int removeBitstreamGuard(std::FILE *flashDev)
+{
+    unsigned char buf[4096];
+
+    memset(buf, 0xff, sizeof(buf));
+    int ret = writeToFlash(flashDev, 0,
+        bitstreamGuardAddress, buf, sizeof(buf));
+    if (ret)
+        std::cout << "Failed to remove bitstream guard: " << ret << std::endl;
+    else
+        std::cout << "Bitstream guard deactivated on flash" << std::endl;
+
+    return ret;
+}
+
 int XSPI_Flasher::revertToMFG(void)
 {
+    if (mFlashDev)
+        return installBitstreamGuard(mFlashDev);
+
     if (!prepareXSpi()) {
         std::cout << "ERROR: Unable to prepare the XSpi\n";
         return -EINVAL;
@@ -1604,6 +1689,193 @@ int XSPI_Flasher::revertToMFG(void)
         std::cout << "ERROR: Unable to set bitstream guard!" << std::endl;
         return -EINVAL;
     }
+    return 0;
+}
+
+static int splitMcsLine(std::string& line,
+    unsigned int& type, unsigned int& address, std::vector<unsigned char>& data)
+{
+    int ret = 0;
+
+    // Every line should start with ":"
+    if (line[0] != ':')
+        return -EINVAL;
+
+    unsigned int len = std::stoi(line.substr(1, 2), NULL , 16);
+    type = std::stoi(line.substr(7, 2), NULL , 16);
+    address = std::stoi(line.substr(3, 4), NULL, 16);
+    data.clear();
+
+    switch (type) {
+    case 0:
+        if (len > 16) {
+            // For xilinx mcs files data length should be 16 for all records
+            // except for the last one which can be smaller
+            ret = -EINVAL;
+        } else {
+            unsigned int l = len * 2;
+            std::string d = line.substr(9, len * 2);
+            for (unsigned int i = 0; i < l; i += 2)
+                data.push_back(std::stoi(d.substr(i, 2), NULL, 16));
+        }
+        break;
+    case 1:
+        break;
+    case 4:
+        if (len != 2) {
+            // For xilinx mcs files extended address can only be 2 bytes
+            ret = -EINVAL;
+        }
+        address = std::stoi(line.substr(9, len * 2), NULL, 16);
+        break;
+    default:
+        // Xilinx mcs files should not contain other types
+        ret = -EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+static inline unsigned int pageOffset(unsigned int addr)
+{
+    return (addr & 0xffff);
+}
+
+static int mcsStreamToBin(std::istream& mcsStream, unsigned int& currentAddr,
+    std::vector<unsigned char>& buf, unsigned int& nextAddr)
+{
+    bool done = false;
+    size_t cnt = 0;
+
+    buf.clear();
+
+    while (!mcsStream.eof() && !done) {
+        std::string line;
+        unsigned int type;
+        unsigned int addr;
+        std::vector<unsigned char> data;
+
+        std::getline(mcsStream, line);
+        if (line.size() == 0)
+            continue;
+
+        if (splitMcsLine(line, type, addr, data) != 0) {
+            std::cout << "Found invalid MCS line: " << line << std::endl;
+            return -EINVAL;
+        }
+
+        switch (type) {
+        case 0:
+            if (currentAddr == UINT_MAX) {
+                std::cout << "MCS missing page starting address" << std::endl;
+                return -EINVAL;
+            } else if (buf.size() == 0) {
+                // we're the 1st data in this page, updating the current addr
+                assert(pageOffset(currentAddr) == 0);
+                currentAddr |= addr;
+            } else if (pageOffset(currentAddr + buf.size()) != addr) {
+                std::cout << "MCS page offset is not contiguous, expecting 0x"
+                    << std::hex << pageOffset(currentAddr) + buf.size()
+                    << ", but, got 0x" << addr << std::dec << std::endl;
+                return -EINVAL;
+            }
+            // keep adding data to existing buffer
+            buf.insert(buf.end(), data.begin(), data.end());
+            cnt += data.size();
+            break;
+        case 1:
+            // end current buffer and no more
+            nextAddr = UINT_MAX;
+            done = true;
+            break;
+        case 4:
+            addr <<= 16;
+            if (currentAddr == UINT_MAX) {
+                currentAddr = addr; // addr of the very first page
+            } else if (currentAddr + buf.size() != addr) {
+                nextAddr = addr; // start new page
+                done = true;
+            }
+            // otherwise, continue to next page since page is still contiguous
+            break;
+        default:
+            assert(1); // shouldn't be here
+            break;
+        }
+
+        if (cnt >= pagesz) {
+            std::cout << "." << std::flush;
+            cnt = 0;
+        }
+    }
+    if (cnt) // print the last "."
+            std::cout << "." << std::flush;
+    std::cout << std::endl;
+
+    if (buf.size() > UINT_MAX) {
+        std::cout << "MCS bitstream is too large: 0x" << std::hex << buf.size()
+            << std::dec << " bytes" << std::endl;
+        return -EINVAL;
+    }
 
     return 0;
+}
+
+static int writeBitstream(std::FILE *flashDev, int index, unsigned int addr,
+    std::vector<unsigned char>& buf)
+{
+    int ret = 0;
+    size_t len = 0;
+
+    // Write to flash page by page and print '.' for each write
+    // as progress indicator
+    for (size_t i = 0; ret == 0 && i < buf.size(); i += len) {
+        len = pagesz - ((addr + i) % pagesz);
+        len = std::min(len, buf.size() - i);
+
+        std::cout << "." << std::flush;
+        ret = writeToFlash(flashDev, index, addr + i, buf.data() + i, len);
+    }
+    std::cout << std::endl;
+    return ret;
+}
+
+int XSPI_Flasher::upgradeFirmwareXSpiDrv(std::istream& mcsStream, int index)
+{
+    int ret = 0;
+
+    // Enable bitstream guard.
+    ret = installBitstreamGuard(mFlashDev);
+    if (ret)
+        return ret;
+
+    // Parse MCS data and write each contiguous chunk to flash.
+    std::vector<unsigned char> buf;
+    unsigned int curAddr = UINT_MAX;
+    unsigned int nextAddr = 0;
+    while (nextAddr != UINT_MAX) {
+        std::cout << "Extracting bitstream from MCS data:" << std::endl;
+        ret = mcsStreamToBin(mcsStream, curAddr, buf, nextAddr);
+        if (ret)
+            return ret;
+        assert(nextAddr == UINT_MAX || pageOffset(nextAddr) == 0);
+        // Address from MCS does not take bitstream guard into consideration.
+        // We have to push out the Entire MCS by bitstreamGuardSize bytes on
+        // the flash memory to make room for bitstream guard
+        assert(curAddr >= bitstreamGuardAddress); 
+        curAddr += bitstreamGuardSize;
+        std::cout << "Extracted " << buf.size() << "B bitstream @0x"
+            << std::hex << curAddr << std::dec << std::endl;
+
+        std::cout << "Writing bitstream to flash:" << std::endl;
+        ret = writeBitstream(mFlashDev, index, curAddr, buf);
+        if (ret)
+            return ret;
+    }
+
+    // Disable bitstream guard.
+    ret = removeBitstreamGuard(mFlashDev);
+
+    return ret;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -814,24 +814,24 @@ bool XSPI_Flasher::getFlashId()
         return false;
     else {
         switch(ReadBuffer[3]) {
-	case 0x38:
+        case 0x38:
         case 0x17:
         case 0x18:
             MAX_NUM_SECTORS = 1;
             break;
-	case 0x39:
+        case 0x39:
         case 0x19:
             MAX_NUM_SECTORS = 2;
             break;
-	case 0x3A:
+        case 0x3A:
         case 0x20:
             MAX_NUM_SECTORS = 4;
             break;
-	case 0x3B:
+        case 0x3B:
         case 0x21:
             MAX_NUM_SECTORS = 8;
             break;
-	case 0x3C:
+        case 0x3C:
         case 0x22:
             MAX_NUM_SECTORS = 16;
             break;
@@ -931,7 +931,7 @@ bool XSPI_Flasher::finalTransfer(uint8_t *SendBufPtr, uint8_t *RecvBufPtr, int B
             Data = *(uint32_t *)SendBufferPtr;
         }
 
-	if (writeReg(XSP_DTR_OFFSET, Data) != 0) {
+        if (writeReg(XSP_DTR_OFFSET, Data) != 0) {
             return false;
         }
         SendBufferPtr += (DataWidth >> 3);
@@ -1022,7 +1022,7 @@ bool XSPI_Flasher::finalTransfer(uint8_t *SendBufPtr, uint8_t *RecvBufPtr, int B
                 //read the data.
                 try {
                     Data = readReg(XSP_DRR_OFFSET);
-		} catch (const std::exception& ex) {
+                } catch (const std::exception& ex) {
                     return false;
                 }
 
@@ -1077,7 +1077,7 @@ bool XSPI_Flasher::finalTransfer(uint8_t *SendBufPtr, uint8_t *RecvBufPtr, int B
                         Data = *(uint32_t *)SendBufferPtr;
                     }
 
-		    if(writeReg(XSP_DTR_OFFSET, Data) != 0) {
+                    if(writeReg(XSP_DTR_OFFSET, Data) != 0) {
                         return false;
                     }
 
@@ -1627,6 +1627,7 @@ static int writeToFlash(std::FILE *flashDev, int slave,
     const unsigned int address, const unsigned char *buf, size_t len)
 {
     int ret = 0;
+#if 0
     long addr = toAddr(slave, address);
 
     ret = std::fseek(flashDev, addr, SEEK_SET);
@@ -1636,6 +1637,7 @@ static int writeToFlash(std::FILE *flashDev, int slave,
     std::size_t s = std::fwrite(buf, 1, len, flashDev);
     if (s != len)
         ret = -ferror(flashDev);
+#endif
     return ret;
 }
 
@@ -1861,18 +1863,18 @@ int XSPI_Flasher::upgradeFirmwareXSpiDrv(std::istream& mcsStream, int index)
         if (ret)
             return ret;
         assert(nextAddr == UINT_MAX || pageOffset(nextAddr) == 0);
-	if (curAddr == 0) {
-		// This is a golden image, don't shift for bitstream guard
-		noShift = true;
-	}
-	if (!noShift) {
-		// Address from MCS does not take bitstream guard into
-		// consideration. We have to push out the Entire MCS by
-		// bitstreamGuardSize bytes on the flash memory to make
-		// room for bitstream guard
-		assert(curAddr >= bitstreamGuardAddress); 
-		curAddr += bitstreamGuardSize;
-	}
+        if (curAddr == 0) {
+            // This is a golden image, don't shift for bitstream guard
+            noShift = true;
+        }
+        if (!noShift) {
+            // Address from MCS does not take bitstream guard into
+            // consideration. We have to push out the Entire MCS by
+            // bitstreamGuardSize bytes on the flash memory to make
+            // room for bitstream guard
+            assert(curAddr >= bitstreamGuardAddress); 
+            curAddr += bitstreamGuardSize;
+        }
         std::cout << "Extracted " << buf.size() << "B bitstream @0x"
             << std::hex << curAddr << std::dec << std::endl;
 
@@ -1880,7 +1882,7 @@ int XSPI_Flasher::upgradeFirmwareXSpiDrv(std::istream& mcsStream, int index)
         ret = writeBitstream(mFlashDev, index, curAddr, buf);
         if (ret)
             return ret;
-	curAddr = nextAddr;
+        curAddr = nextAddr;
     }
 
     // Disable bitstream guard.

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -1627,7 +1627,6 @@ static int writeToFlash(std::FILE *flashDev, int slave,
     const unsigned int address, const unsigned char *buf, size_t len)
 {
     int ret = 0;
-#if 0
     long addr = toAddr(slave, address);
 
     ret = std::fseek(flashDev, addr, SEEK_SET);
@@ -1637,7 +1636,7 @@ static int writeToFlash(std::FILE *flashDev, int slave,
     std::size_t s = std::fwrite(buf, 1, len, flashDev);
     if (s != len)
         ret = -ferror(flashDev);
-#endif
+
     return ret;
 }
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.h
@@ -40,12 +40,14 @@ class XSPI_Flasher
 
 public:
     XSPI_Flasher(std::shared_ptr<pcidev::pci_device> dev);
+    ~XSPI_Flasher();
     int xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mcsStream2);
     int xclUpgradeFirmwareXSpi(std::istream& mcsStream, int device_index=0);
     int revertToMFG(void);
 
 private:
     std::shared_ptr<pcidev::pci_device> mDev;
+    std::FILE *mFlashDev;
 
     unsigned long long flash_base;
     int xclTestXSpi(int device_index);
@@ -69,6 +71,9 @@ private:
     bool writeRegister(unsigned commandCode, unsigned value, unsigned bytes);
     bool setSector(unsigned address);
     unsigned getSector(unsigned address);
+
+    // Upgrade firmware via driver.
+    int upgradeFirmwareXSpiDrv(std::istream& mcsStream, int device_index);
 };
 
 #endif


### PR DESCRIPTION
This PR contains changes to support shell flashing through driver, instead of mapping xclmgmt's user BAR into xbmgmt to flash.

The PR replicated functionality found in xspi.cpp in flash sub-device driver. However, the implementation is a complete rewrite and:
1. Removed unnecessary interactions with device during flashing.
2. Enabled large page (32K/64K) erasing support besides 4K page used in today's code.
3. Added flash content read back support.

Due to the above enhancement/cleanup, flashing via driver is 2X faster.

The flash sub-device driver presents a standard char device to user land by supporting open/close/read/write/lseek callbacks. Users with root privilege can directly read/write from/to the flash memory on card by talking to the dev node found under /dev/xfpga/flash.xxx without going through xclmgmt or using xbmgmt. Note that when writing to the flash memory, driver will need to break down the IO into smaller erasable pages and even do read-modify-write at smallest page level (4K), if the IO is not page aligned or does not cover the entire page (4K/32K/64K). So, it'll be very inefficient if you write big chunk of data to the flash in small non-flash-page-aligned IOs. It'll work, but slow.

Limitations in this PR that needs addressing in follow-up PRs:
1. Only QSPI is supported in the driver. The QSPI_PS (for U25/30) and OSPI (for Versal) are not supported for now.
2. The existing QSPI code path in xbmgmt is still in use by default even after this change. User needs to set FLASH_VIA_DRIVER environment variable to switch to driver flashing code path explicitly. We'll completely remove userland flashing code path and make permanent switch when this change is tested more widely on all platforms applicable.

The QSPI HW interface is, again, proven to be very difficult to work with and took me quite some time to clean up QSPI code and move it down to driver. But, it worth the time for:
1. now we have an easier to maintain implementation in long term
2. 2X faster flash operation
3. can read back what's flashed on the device (a long desired feature)
4. one big step toward getting rid of supporting mmap user bar from xclmgmt, so it’ll be less frowned upon when we upstream the driver source code

What's more, it also enables flash memory access by xclmgmt as well. On today's platforms we supported, there should still be ~50MB space on flash even after a normal shell is flashed. Potentially, we can save DTB/CMC/ERT/SC images to the flash right after xbmgmt flashes the MCS from the same .dsabin file for xclmgmt to load them during attach. Thus, we'll always have a self-contained board with matching shell and firmware without relying on some data saved on hard drive. The shell package will only be needed when someone wants to update the content on the flash, not when user just want to run applications. More work/thoughts are needed in regarding to this.

