### PR TITLE
health_check_cb should check channel1 offset (0x0) instead of channel…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -450,7 +450,7 @@ static int health_check_cb(void *data)
 	bool tripped, latched = false;
 	void __iomem *shutdown_clk = xocl_iores_get_base(lro, IORES_CLKSHUTDOWN);
 	uint32_t clk_status, ucs_status;
-	struct ucs_control_ch1 *ucs_control;
+	struct ucs_control_status_ch1 *ucs_status_ch1;
 	int err;
 
 	if (!health_check)
@@ -467,22 +467,22 @@ static int health_check_cb(void *data)
 	} else {
 		/* this is R2.0 system */
 		err = xocl_iores_read32(lro, XOCL_SUBDEV_LEVEL_URP,
-		    IORES_UCS_CONTROL, 0x8, &ucs_status);
+		    IORES_UCS_CONTROL_STATUS, XOCL_RES_OFFSET_CHANNEL1, &ucs_status);
 		if (err) {
 			if (err != -ENODEV)
 				mgmt_err(lro, "Read %s error %d.",
-				    NODE_UCS_CONTROL, err);
+				    NODE_UCS_CONTROL_STATUS, err);
 		} else {
-			ucs_control = (struct ucs_control_ch1 *)&ucs_status;
-			if (ucs_control->shutdown_clocks_latched) {
+			ucs_status_ch1 = (struct ucs_control_status_ch1 *)&ucs_status;
+			if (ucs_status_ch1->shutdown_clocks_latched) {
 				mgmt_err(lro, "Critical temperature or power event, ULP kernel clocks have been stopped, reload the ULP to continue.");
 				latched = true;
-			} else if (ucs_control->clock_throttling_average > CLK_MAX_VALUE) {
+			} else if (ucs_status_ch1->clock_throttling_average > CLK_MAX_VALUE) {
 				mgmt_err(lro, "ULP kernel clocks %d exceeds expected maximum value %d.",
-				    ucs_control->clock_throttling_average, CLK_MAX_VALUE);
-			} else if (ucs_control->clock_throttling_average) {
+				    ucs_status_ch1->clock_throttling_average, CLK_MAX_VALUE);
+			} else if (ucs_status_ch1->clock_throttling_average) {
 				mgmt_err(lro, "ULP kernel clocks throttled at %d%%.",
-				    (ucs_control->clock_throttling_average / CLK_MAX_VALUE) * 100);
+				    (ucs_status_ch1->clock_throttling_average / CLK_MAX_VALUE) * 100);
 			}
 		}
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -162,7 +162,7 @@ struct icap {
 	struct bmc		bmc_header;
 
 	char			*icap_clock_freq_counters[ICAP_MAX_NUM_CLOCKS];
-	char			*icap_ucs_control;
+	char			*icap_ucs_control_status;
 
 	uint64_t		cache_expire_secs;
 	struct xcl_pr_region	cache;
@@ -2352,10 +2352,10 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 		 * With new 2RP flow, clocks are all moved to ULP.
 		 * We assume there is not any clock left in PLP in this case.
 		 */
-		if (icap->icap_ucs_control) {
+		if (icap->icap_ucs_control_status) {
 			err = icap_ocl_freqscaling(icap, true);
 			msleep(10);
-			reg_wr(icap->icap_ucs_control + 8, 1);
+			reg_wr(icap->icap_ucs_control_status + 8, 1);
 		}
 	}
 
@@ -2813,10 +2813,10 @@ static void icap_refresh_addrs(struct platform_device *pdev)
 		xocl_iores_get_base(xdev, IORES_CLKFREQ_HBM);
 	ICAP_INFO(icap, "freq_hbm @ %lx",
 			(unsigned long)icap->icap_clock_freq_counters[2]);
-	icap->icap_ucs_control =
-		xocl_iores_get_base(xdev, IORES_UCS_CONTROL);
-	ICAP_INFO(icap, "ucs_control @ %lx",
-			(unsigned long)icap->icap_ucs_control);
+	icap->icap_ucs_control_status =
+		xocl_iores_get_base(xdev, IORES_UCS_CONTROL_STATUS);
+	ICAP_INFO(icap, "ucs_control_status @ %lx",
+			(unsigned long)icap->icap_ucs_control_status);
 }
 
 static int icap_offline(struct platform_device *pdev)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -2327,7 +2327,7 @@ static int cmc_access_ops(struct platform_device *pdev, int flags)
 
 	grant = (u32)flags & 0x1;
 	err = xocl_iores_write32(xdev, XOCL_SUBDEV_LEVEL_BLD, IORES_CMC_MUTEX,
-	    0x0, grant);
+	    XOCL_RES_OFFSET_CHANNEL1, grant);
 	if (err == -ENODEV) {
 		xocl_xdev_info(xdev, "No %s resource, skip.",
 		    NODE_CMC_MUTEX);
@@ -2340,7 +2340,7 @@ static int cmc_access_ops(struct platform_device *pdev, int flags)
 
 	for (retry = 0; retry < 100; retry++) {
 		err = xocl_iores_read32(xdev, XOCL_SUBDEV_LEVEL_BLD,
-		    IORES_CMC_MUTEX, 0x8, &ack);
+		    IORES_CMC_MUTEX, XOCL_RES_OFFSET_CHANNEL2, &ack);
 		if (err) {
 			if (err == -ENODEV)
 				xocl_xdev_info(xdev, "No %s resource, skip.",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -95,6 +95,7 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	const char *flash_type;
 	void *blob;
 	int node, proplen;
+	struct xocl_flash_privdata *flash_priv;
 
 	blob = core->fdt_blob;
 	if (!blob)
@@ -115,15 +116,15 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 
 	proplen = strlen(flash_type) + 1;
 
-	priv = vzalloc(proplen);
+	flash_priv = vzalloc(sizeof(*flash_priv));
 	if (!priv)
 		return NULL;
 
-	strcpy(priv, flash_type);
+	strcpy(flash_priv->flash_type, flash_type);
 
 	*len = proplen;
 
-	return priv;
+	return flash_priv;
 
 }
 
@@ -318,7 +319,7 @@ static struct xocl_subdev_map		subdev_map[] = {
 			RESNAME_CLKFREQ_K1,
 			RESNAME_CLKFREQ_K2,
 			RESNAME_CLKFREQ_HBM,
-			RESNAME_UCS_CONTROL,
+			RESNAME_UCS_CONTROL_STATUS,
 			RESNAME_GAPPING,
 			NULL
 		},

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -73,8 +73,8 @@
 #define NODE_CLKFREQ_K1 "ep_freq_cnt_aclk_kernel_00"
 #define NODE_CLKFREQ_K2 "ep_freq_cnt_aclk_kernel_01"
 #define NODE_CLKFREQ_HBM "ep_freq_cnt_aclk_hbm_00"
-#define NODE_UCS_CONTROL "ep_ucs_control_status_00"
 #define NODE_GAPPING "ep_gapping_demand_00"
+#define NODE_UCS_CONTROL_STATUS "ep_ucs_control_status_00"
 
 enum {
 	IORES_GATEPRBLD,
@@ -89,7 +89,7 @@ enum {
 	IORES_CLKFREQ_K2,
 	IORES_KDMA,
 	IORES_CLKSHUTDOWN,
-	IORES_UCS_CONTROL,
+	IORES_UCS_CONTROL_STATUS,
 	IORES_CMC_MUTEX,
 	IORES_GAPPING,
 	IORES_MAX,
@@ -107,9 +107,9 @@ enum {
 #define RESNAME_CLKFREQ_K2	NODE_CLKFREQ_K2
 #define RESNAME_KDMA            NODE_KDMA_CTRL
 #define RESNAME_CLKSHUTDOWN	NODE_CLK_SHUTDOWN
-#define RESNAME_UCS_CONTROL     NODE_UCS_CONTROL
 #define RESNAME_CMC_MUTEX       NODE_CMC_MUTEX
 #define RESNAME_GAPPING         NODE_GAPPING
+#define RESNAME_UCS_CONTROL_STATUS     NODE_UCS_CONTROL_STATUS
 
 struct xocl_iores_map {
 	char		*res_name;
@@ -130,12 +130,18 @@ struct xocl_iores_map map[] = {                                         \
 	{ RESNAME_CLKFREQ_K2, IORES_CLKFREQ_K2},			\
 	{ RESNAME_KDMA, IORES_KDMA },                                   \
 	{ RESNAME_CLKSHUTDOWN, IORES_CLKSHUTDOWN },			\
-	{ RESNAME_UCS_CONTROL, IORES_UCS_CONTROL},			\
+	{ RESNAME_UCS_CONTROL_STATUS, IORES_UCS_CONTROL_STATUS},	\
 	{ RESNAME_CMC_MUTEX, IORES_CMC_MUTEX},				\
 	{ RESNAME_GAPPING, IORES_GAPPING},				\
 }
 
-struct ucs_control_ch1 {
+#define	XOCL_RES_OFFSET_CHANNEL1	0x0
+#define	XOCL_RES_OFFSET_CHANNEL2	0x8
+
+/*
+ * Note: please move UCS specific into UCS subdev
+*/
+struct ucs_control_status_ch1 {
 	unsigned int shutdown_clocks_latched:1;
 	unsigned int reserved1:15;
 	unsigned int clock_throttling_average:14;


### PR DESCRIPTION
fix two issues:
health monitor check channel 1 (0x0)

flash_type is truncated.

> test result

```
# /data/davidz/xbutil program -d 0 -p /data/davidz/1212/kernels/verify.xclbin
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil program succeeded.
[root@xsjhemn41 kernels]# /data/davidz/xbutil program -d 0 -p /data/davidz/1212/kernels/bandwidth.xclbin
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil program succeeded.
```
