### PR TITLE
Enable icap to cache xclbin metadata on versal

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1138,6 +1138,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XDMA,				\
 		 	XOCL_DEVINFO_SCHEDULER_VERSAL,			\
 		 	XOCL_DEVINFO_MAILBOX_USER_VERSAL,		\
+		 	XOCL_DEVINFO_ICAP_USER,				\
 		})
 
 #define USER_RES_AWS							\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2017 Xilinx, Inc. All rights reserved.
+ *  Copyright (C) 2017-2019 Xilinx, Inc. All rights reserved.
  *  Author: Sonal Santan
  *  Code copied verbatim from SDAccel xcldma kernel mode driver
  *
@@ -2329,7 +2329,9 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 		if (err)
 			goto done;
 	} else {
-		err = __icap_peer_xclbin_download(icap, xclbin);
+		if (!XOCL_DSA_IS_VERSAL(xdev))
+			err = __icap_peer_xclbin_download(icap, xclbin);
+
 		/*
 		 * xclbin download changes PR region, make sure next
 		 * ERT configure cmd will go through
@@ -2342,8 +2344,14 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 		icap_parse_bitstream_axlf_section(pdev, xclbin,
 			DEBUG_IP_LAYOUT);
 		icap_setup_clock_freq_topology(icap, xclbin);
-		/* not really doing verification, but just create subdevs */
-		(void) icap_verify_bitstream_axlf(pdev, xclbin);
+
+		if (!XOCL_DSA_IS_VERSAL(xdev)) {
+			/*
+			 * not really doing verification, but
+			 * just create subdevs
+			 */
+			(void) icap_verify_bitstream_axlf(pdev, xclbin);
+		}
 	}
 
 	icap_parse_bitstream_axlf_section(pdev, xclbin, PARTITION_METADATA);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -162,8 +162,6 @@ struct xocl_dev	{
 
 	uint64_t		mig_cache_expire_secs;
 	ktime_t			mig_cache_expires;
-
-	struct mem_topology	*mem_topo;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1165,8 +1165,6 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 		vfree(xdev->core.dyn_subdev_store);
 	if (xdev->ulp_blob)
 		vfree(xdev->ulp_blob);
-	if (xdev->mem_topo)
-		vfree(xdev->mem_topo);
 	mutex_destroy(&xdev->core.lock);
 	mutex_destroy(&xdev->dev_lock);
 	mutex_destroy(&xdev->wq_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -582,15 +582,8 @@ struct xocl_mb_scheduler_funcs {
 	MB_SCHEDULER_DEV(xdev), cu, filep, addrp) :		\
 	-ENODEV)
 
-
-#define XOCL_GET_MEM_TOPOLOGY(xdev, topo)						\
-({ \
-	int ret = 0; \
-	if (XOCL_DSA_IS_VERSAL(xdev)) 							\
-		topo = (struct mem_topology *)(((struct xocl_dev *)(xdev))->mem_topo); 	\
-	ret = xocl_icap_get_xclbin_metadata(xdev, MEMTOPO_AXLF, (void **)&topo); \
-	(ret);\
-})
+#define XOCL_GET_MEM_TOPOLOGY(xdev, mem_topo)						\
+	(xocl_icap_get_xclbin_metadata(xdev, MEMTOPO_AXLF, (void **)&mem_topo))
 
 #define XOCL_GET_IP_LAYOUT(xdev, ip_layout)						\
 	(xocl_icap_get_xclbin_metadata(xdev, IPLAYOUT_AXLF, (void **)&ip_layout))
@@ -599,9 +592,7 @@ struct xocl_mb_scheduler_funcs {
 
 
 #define XOCL_PUT_MEM_TOPOLOGY(xdev)						\
-	(XOCL_DSA_IS_VERSAL(xdev) ?						\
-	-ENODEV : \
-	xocl_icap_put_xclbin_metadata(xdev))
+	xocl_icap_put_xclbin_metadata(xdev)
 #define XOCL_PUT_IP_LAYOUT(xdev)						\
 	xocl_icap_put_xclbin_metadata(xdev)
 #define XOCL_PUT_XCLBIN_ID(xdev)						\


### PR DESCRIPTION
This PR solve the following problem
1. Enable user icap sub driver to cache xclbin meta data without download bitstream. The xclbin metadata was not cached before so that we can not run quite a few xbutil sub fucntions.
2. Get rid of some Versal DSA check in that we have icap and feature rom sub drivers enabled
3. Get rid of mem_topo in xocl_dev structure. The mem_topo is now cached in icap