### PR TITLE
Cr1051362 Clock is not set due to IO addresses are missing

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -230,6 +230,7 @@ struct xocl_subdev_map {
 	u32	flags;
 	void	*(*build_priv_data)(void *dev_hdl, void *subdev, size_t *len);
 	void	(*devinfo_cb)(void *dev_hdl, void *subdevs, int num);
+	u32	min_level;
 };
 
 #define	XOCL_RES_FEATURE_ROM				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2365,10 +2365,6 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 	}
 
 	if (num_dev > 0) {
-		for (i = 0; i < ICAP_MAX_NUM_CLOCKS; i++) {
-			if (icap->icap_clock_bases[i])
-				break;
-		}
 		xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 		icap_refresh_addrs(pdev);
 		/*

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -327,6 +327,7 @@ static struct xocl_subdev_map		subdev_map[] = {
 		0,
 		NULL,
 		devinfo_cb_setlevel,
+		.min_level = XOCL_SUBDEV_LEVEL_URP,
 	},
 	{
 		XOCL_SUBDEV_IORES,
@@ -636,14 +637,15 @@ found:
 }
 
 static int xocl_fdt_res_lookup(xdev_handle_t xdev_hdl, char *blob,
-		const char *ipname, struct xocl_subdev *subdev,
+		const char *ipname, u32 min_level, struct xocl_subdev *subdev,
 		struct ip_node *ip, int ip_num)
 {
 	int i, ret;
 
 	for (i = 0; i < ip_num; i++) {
 		if (ip->name && strlen(ipname) > 0 && !ip->used &&
-			       !strncmp(ip->name, ipname, strlen(ipname)))
+				ip->level >= min_level &&
+				!strncmp(ip->name, ipname, strlen(ipname)))
 			break;
 		ip++;
 	}
@@ -695,8 +697,8 @@ static int xocl_fdt_get_devinfo(xdev_handle_t xdev_hdl, char *blob,
 
 	for (res_name = map_p->res_names[0]; res_name;
 			res_name = map_p->res_names[++i]) {
-		ret = xocl_fdt_res_lookup(xdev_hdl, blob, res_name, subdev,
-				ip, ip_num);
+		ret = xocl_fdt_res_lookup(xdev_hdl, blob, res_name,
+				map_p->min_level, subdev, ip, ip_num);
 		if (ret) {
 			xocl_xdev_err(xdev_hdl, "lookup dev %s, ip %s failed",
 					map_p->dev_name, res_name);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -325,7 +325,7 @@ static struct xocl_subdev_map		subdev_map[] = {
 			RESNAME_GAPPING,
 			NULL
 		},
-		6,
+		1,
 		0,
 		NULL,
 		devinfo_cb_setlevel,


### PR DESCRIPTION
Changing minimum ipnum from 1 to 6 for clocks in xocl_fdt.c is a simplest workaround for pu1. It should allow less than 6 for ulp clock devices. Instead, adding a member min_level to resolve this.