### PR TITLE
fixing an issue when compiling application with lOpenCL.

### DIFF
--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -72,6 +72,10 @@ add_library(xilinxopencl SHARED
   $<TARGET_OBJECTS:xclbin>
   )
 
+# Attach to the user's linker flags
+set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
+set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
+
 set_target_properties(xilinxopencl
   PROPERTIES LINKER_LANGUAGE CXX
   )


### PR DESCRIPTION
All the applications are now hanging before this fix. Any API landed on
XRT shouldnt call any function which is in OpenCL. It should only call
APIs which are in libxilinxopencl.so
