### PR TITLE
add flag for MPSoC devices like U30/SmartSSD

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -51,6 +51,7 @@ enum {
 	XOCL_DSAFLAG_DYNAMIC_IP			= (1 << 9),
 	XOCL_DSAFLAG_SMARTN			= (1 << 10),
 	XOCL_DSAFLAG_VERSAL			= (1 << 11),
+	XOCL_DSAFLAG_MPSOC			= (1 << 12),
 };
 
 #define	FLASH_TYPE_SPI	"spi"
@@ -91,7 +92,6 @@ struct xocl_board_private {
 	bool			xpr;
 	char			*flash_type; /* used by xbflash */
 	char			*board_name; /* used by xbflash */
-	bool			mpsoc;
 	uint64_t		p2p_bar_sz;
 	const char		*vbnv;
 	const char		*sched_bin;
@@ -1626,30 +1626,27 @@ struct xocl_subdev_map {
 
 #define	XOCL_BOARD_MGMT_MPSOC						\
 	(struct xocl_board_private){					\
-		.flags		= 0,					\
+		.flags		= XOCL_DSAFLAG_MPSOC,			\
 		.subdev_info	= MGMT_RES_MPSOC,			\
 		.subdev_num = ARRAY_SIZE(MGMT_RES_MPSOC),		\
-		.mpsoc = true,						\
 		.board_name = "samsung",				\
 		.flash_type = FLASH_TYPE_QSPIPS,			\
 	}
 
 #define	XOCL_BOARD_MGMT_U30						\
 	(struct xocl_board_private){					\
-		.flags		= 0,					\
+		.flags		= XOCL_DSAFLAG_MPSOC,			\
 		.subdev_info	= MGMT_RES_MPSOC_U30,			\
 		.subdev_num = ARRAY_SIZE(MGMT_RES_MPSOC_U30),		\
-		.mpsoc = true,						\
 		.board_name = "u30",					\
 		.flash_type = "qspi_ps_x2_single",				\
 	}
 
 #define	XOCL_BOARD_USER_XDMA_MPSOC					\
 	(struct xocl_board_private){					\
-		.flags		= 0,					\
+		.flags		= XOCL_DSAFLAG_MPSOC,			\
 		.subdev_info	= USER_RES_XDMA,			\
 		.subdev_num = ARRAY_SIZE(USER_RES_XDMA),		\
-		.mpsoc = true,						\
 	}
 
 #define XOCL_RES_FLASH_MFG_U50				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -995,7 +995,7 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 	}
 	xocl_info(&pdev->dev, "created all sub devices");
 
-	if (!(dev_info->flags & (XOCL_DSAFLAG_SMARTN | XOCL_DSAFLAG_VERSAL)))
+	if (!(dev_info->flags & (XOCL_DSAFLAG_SMARTN | XOCL_DSAFLAG_VERSAL | XOCL_DSAFLAG_MPSOC)))
 		ret = xocl_icap_download_boot_firmware(lro);
 
 	/* return -ENODEV for 2RP platform */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -213,7 +213,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 	(XDEV(xdev)->priv.dsa_ver)
 
 #define XOCL_DSA_IS_MPSOC(xdev)                \
-	(XDEV(xdev)->priv.mpsoc)
+	(XDEV(xdev)->priv.flags & XOCL_DSAFLAG_MPSOC)
 
 #define XOCL_DSA_IS_SMARTN(xdev)                \
 	(XDEV(xdev)->priv.flags & XOCL_DSAFLAG_SMARTN)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1204,7 +1204,6 @@ void xocl_fill_dsa_priv(xdev_handle_t xdev_hdl, struct xocl_board_private *in)
 	core->priv.flags = in->flags;
 	core->priv.flash_type = in->flash_type;
 	core->priv.board_name = in->board_name;
-	core->priv.mpsoc = in->mpsoc;
 	core->priv.p2p_bar_sz = in->p2p_bar_sz;
 	if (in->flags & XOCL_DSAFLAG_SET_DSA_VER)
 		core->priv.dsa_ver = in->dsa_ver;


### PR DESCRIPTION
Without this fix on U30, xocl_icap_download_boot_firmware(lro) will return -2. Then sub devices will be destroyed.