### PR TITLE
fix softkernel validate

### DIFF
--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019, Xilinx Inc
+ *  Copyright (C) 2019-2020, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -399,6 +399,7 @@ enum ert_cmd_type {
   ERT_KDS_LOCAL = 1,
   ERT_CTRL = 2,
   ERT_CU = 3,
+  ERT_SCU = 4,
 };
 
 /**


### PR DESCRIPTION
This PR fix the following issue

1) skip cu validate for soft kernel
2) add a new ERT command type ERT_SCU so that ERT_START_SCU can be scheduled deprately.
3) remove two more XOCL_DSA_IS_VERSAL. 