### PR TITLE
[Edeg] data-driven interrupt handling(PR-15981)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.h
@@ -158,6 +158,7 @@ struct zocl_cu {
 	u32			  ready_cnt;
 	u32                       run_timeout;
 	u32                       reset_timeout;
+	u32			  irq;
 	/**
 	 * @funcs:
 	 *

--- a/src/runtime_src/core/edge/drm/zocl/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_util.h
@@ -60,6 +60,7 @@ struct drm_zocl_mm_stat {
 struct addr_aperture {
 	phys_addr_t	addr;
 	size_t		size;
+	u32		prop;
 };
 
 enum zocl_mem_type {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -464,6 +464,7 @@ zocl_update_apertures(struct drm_zocl_dev *zdev)
 			ip = &zdev->ip->m_ip_data[i];
 			apt[zdev->num_apts].addr = ip->m_base_address;
 			apt[zdev->num_apts].size = CU_SIZE;
+			apt[zdev->num_apts].prop = ip->properties;
 			zdev->num_apts++;
 		}
 	}
@@ -936,6 +937,27 @@ bool
 zocl_xclbin_accel_adapter(int kds_mask)
 {
 	return kds_mask == ACCEL_ADAPTER;
+}
+
+bool
+zocl_xclbin_legacy_intr(struct drm_zocl_dev *zdev)
+{
+	u32 prop = zdev->apertures[0].prop;
+
+	/* The first aperture is special.
+	 * If the interrupt ID is zero, this is the legacy
+	 * interrupt xclbin.
+	 */
+	return (prop & IP_INTERRUPT_ID_MASK) == 0;
+}
+
+u32
+zocl_xclbin_intr_id(struct drm_zocl_dev *zdev, u32 idx)
+{
+	u32 prop = zdev->apertures[idx].prop;
+	u32 intr_id = prop & IP_INTERRUPT_ID_MASK;
+
+	return intr_id >> IP_INTERRUPT_ID_SHIFT;
 }
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.h
@@ -38,6 +38,8 @@ int zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev,
 int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data);
 
 bool zocl_xclbin_accel_adapter(int kds_mask);
+bool zocl_xclbin_legacy_intr(struct drm_zocl_dev *zdev);
+u32  zocl_xclbin_intr_id(struct drm_zocl_dev *zdev, u32 idx);
 bool zocl_xclbin_cus_support_intr(struct drm_zocl_dev *zdev);
 
 #endif /* _ZOCL_XCLBIN_H_ */


### PR DESCRIPTION
The legacy interrupt xclbin support would be remove in the future when system linker doesn't support legacy platforms.