### PR TITLE
after PCI reset, mb_scheduler should have clean command buffer

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -227,7 +227,7 @@ int xocl_p2p_reserve_release_range(struct xocl_dev *xdev,
 int xocl_get_p2p_bar(struct xocl_dev *xdev, u64 *bar_size);
 int xocl_pci_resize_resource(struct pci_dev *dev, int resno, int size);
 int xocl_pci_rbar_refresh(struct pci_dev *dev, int resno);
-void xocl_reset_notify(struct pci_dev *pdev, bool prepare);
+void xocl_reset_notify(struct pci_dev *pdev, bool prepare, bool hot_reset);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
 void user_pci_reset_prepare(struct pci_dev *pdev);
 void user_pci_reset_done(struct pci_dev *pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -332,7 +332,10 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	 * used to lock down xclbin on mgmt pf side.
 	 */
 	if (live_clients(xdev, NULL) || atomic_read(&xdev->outstanding_execs)) {
-		userpf_err(xdev, " Current xclbin is in-use, can't change\n");
+		userpf_err(xdev, " Current xclbin is in-use, clients(%d) "
+		    " outstanding cmds(%d), can't change\n",
+		    live_clients(xdev, NULL),
+		    atomic_read(&xdev->outstanding_execs));
 		err = -EBUSY;
 		goto done;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -540,6 +540,7 @@ struct xocl_mb_scheduler_funcs {
 	int (*reconfig)(struct platform_device *pdev);
 	int (*cu_map_addr)(struct platform_device *pdev, u32 cu_index,
 		void *drm_filp, u32 *addrp);
+	int (*hot_reset)(struct platform_device *pdev);
 };
 #define	MB_SCHEDULER_DEV(xdev)	\
 	SUBDEV(xdev, XOCL_SUBDEV_MB_SCHEDULER).pldev
@@ -580,6 +581,10 @@ struct xocl_mb_scheduler_funcs {
 	(SCHE_CB(xdev, cu_map_addr) ?				\
 	MB_SCHEDULER_OPS(xdev)->cu_map_addr(			\
 	MB_SCHEDULER_DEV(xdev), cu, filep, addrp) :		\
+	-ENODEV)
+#define	xocl_exec_hot_reset(xdev)					\
+	(SCHE_CB(xdev, hot_reset) ?					\
+	 MB_SCHEDULER_OPS(xdev)->hot_reset(MB_SCHEDULER_DEV(xdev)) : 	\
 	-ENODEV)
 
 #define XOCL_GET_MEM_TOPOLOGY(xdev, mem_topo)						\


### PR DESCRIPTION
This is the idea to fix the issue in PU1 compare to 2019.1.

When firewall tripped, the health monitor thread will start issuing PCI reset. After the tripped is resolved for some reason, in 2019.1, we can restart. But in PU1, we cannot restart because of the xdev->outstanding_execs is not zero. Since we have done a hot reset, we should just reclaim all buffers and reset the outstanding_execs back to zero.