### PR TITLE
adding gtest support for xclbinutil for windows

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -21,6 +21,7 @@ endif(GIT_FOUND)
 #set(Boost_DEBUG 1)
 
 INCLUDE (FindBoost)
+INCLUDE (FindGTest)
 
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/xrt")

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -184,7 +184,7 @@ install (TARGETS xclbinutil RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)
 # -----------------------------------------------------------------------------
 
 if (WIN32)
-  set(GTEST_ROOT "C:/XRT/libs/gtest")
+  set(GTEST_ROOT "C:/Xilinx/XRT/ext")
 endif()
 
 find_package(GTest)


### PR DESCRIPTION
Hi,

This PR contains following changes
>updated xrtdeps-win.py script which downloads, builds and links gtest libraries to make xclbin unit tests work for windows
>Changed path of GTest_Root so that find_package gets the path for .lib files

Thanks 