### PR TITLE
CR-1051238 after PCI reset, mb_scheduler should have clean command buffer

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -354,6 +354,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, bool force)
 
 	xocl_drvinst_set_offline(xdev->core.drm, false);
 
+
 	return ret;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -332,7 +332,10 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	 * used to lock down xclbin on mgmt pf side.
 	 */
 	if (live_clients(xdev, NULL) || atomic_read(&xdev->outstanding_execs)) {
-		userpf_err(xdev, " Current xclbin is in-use, can't change\n");
+		userpf_err(xdev, " Current xclbin is in-use, clients(%d) "
+		    " outstanding cmds(%d), can't change\n",
+		    live_clients(xdev, NULL),
+		    atomic_read(&xdev->outstanding_execs));
 		err = -EBUSY;
 		goto done;
 	}


### PR DESCRIPTION
Summary of RCA of xclbin download issue and suggested solutions:

Root Cause Analysis:

cmds running on CU is marked as running_cmds in XRT scheduler, when firewall trip (causes xrt reset), XRT will set those running cmds as ABORTED. The PU1's scheduler will free any commands (status >= COMPLETE, including ABORTED), but forget to update the global value outstanding_execs. Thus, xclbin cannot be swapped due to this outstanding_exec is not ZERO.

Solutions:

1) mini tweak: enforce outstanding_exec to zero after reset. Pro: simple; Con: please see No.2;

2) more sophisticated solution:

     2.1) running cmds on CU cannot be freed unless we can reset the hardware (CU), but we don't reset CU today, so we should not free aborted running cmd before any hardware reset.

     2.2) after reset whole PCI devices, hardware are considered reset, we should clean up any pending cmds now. 

     2.3) after reset, we reclaim aborted cmds, reinitialize pci interrupts, etc. 