### PR TITLE
CR-1051238 Getting deadfa11 during xbtest stress on r730 in DC (#2646)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4690,6 +4690,7 @@ static int mb_scheduler_remove(struct platform_device *pdev)
 
 	user_sysfs_destroy_kds(pdev);
 	exec_destroy(exec);
+	atomic_set(&xdev->outstanding_execs, 0);
 	platform_set_drvdata(pdev, NULL);
 
 	SCHED_DEBUGF("<- %s\n", __func__);


### PR DESCRIPTION
A clean cherry-pick for PU1.

Thanks,
David