### PR TITLE
Interrupt support from Device to XRT for HW Emulation

### DIFF
--- a/src/runtime_src/core/include/xcl_macros.h
+++ b/src/runtime_src/core/include/xcl_macros.h
@@ -59,4 +59,10 @@
 #define xclPerfMonReadCounters_Streaming_n 30
 #define xclPerfMonReadTrace_Streaming_n 31
 
+#define xclQdma2HostReadMem_n 32
+#define xclQdma2HostWriteMem_n 33
+#define xclQdma2HostInterrupt_n 34
+#define xclDmaVersion_n 35
+
+
 #endif

--- a/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
+++ b/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
@@ -396,3 +396,35 @@ message xclPerfMonReadTrace_Streaming_response {
   }
   repeated events output_data = 8;
 }
+
+//Added these messages for supporting Interrupts and Slave interfaces
+message xclSlaveReadReq_call {
+     required uint64 addr = 1;
+     required uint32 size = 2;
+}
+message xclSlaveReadReq_response {
+     required bool valid = 1;
+     required bytes data = 2;
+}
+message xclSlaveWriteReq_call {
+     required uint64 addr = 1;
+     required uint32 size = 2;
+     required bytes data = 3;
+}
+message xclSlaveWriteReq_response {
+     required bool valid = 1;
+}
+message xclInterruptOccured_call {
+     required uint32 interrupt_line = 1;
+}
+message xclInterruptOccured_response {
+     required bool valid = 1;
+}
+message xclDmaVersion_call {
+     required bool valid = 1;
+}
+message xclDmaVersion_response {
+     required uint32 Major = 1;
+     required uint32 Minor = 2;
+}
+

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.cxx
@@ -19,25 +19,22 @@
 
 #include "unix_socket.h"
 
-unix_socket::unix_socket()
+unix_socket::unix_socket(std::string sock_id)
 {
   server_started = false;
   fd = -1;
-  std::string sock_id = "";
   char* cUser = getenv("USER");
-  if(cUser) {
+  if(cUser && !sock_id.compare("xcl_sock")) {
     std::string user = cUser;
     char* c_sock_id = getenv("EMULATION_SOCKETID"); 
-    if(c_sock_id) {
+    if(c_sock_id ) {
       sock_id = c_sock_id;
-    } else {
-      sock_id = "xcl_sock";
     }
     std::string pathname =  "/tmp/" + user;
     name = pathname + "/" + sock_id;
     systemUtil::makeSystemCall(pathname, systemUtil::systemOperation::CREATE);
   } else {
-    name = "/tmp/xcl_socket";
+    name = "/tmp/" + sock_id;
   }
   start_server(name);
 }

--- a/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/unix_socket.h
@@ -37,7 +37,7 @@ public:
     bool server_started;
     void set_name(std::string &sock_name) { name = sock_name;}
     std::string get_name() { return name;}
-    unix_socket();
+    unix_socket(std::string sock_id="xcl_sock");
     ~unix_socket()
     {
        server_started = false;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -21,6 +21,18 @@
 #include <unistd.h>
 
 #include "xcl_perfmon_parameters.h"
+#define SEND_RESP2QDMA()\
+    if (buf_size == 0) {\
+    	buf = malloc(ri_msg->size());\
+    } else if (buf_size < ri_msg->size()) {\
+    	buf = (void*) realloc(buf, ri_msg->size());\
+    }\
+    ri_msg->set_size(r_len);\
+    ri_msg->SerializeToArray(ri_buf,ri_len);\
+    r_msg.SerializeToArray(buf,r_len);\
+    Q2h_sock->sk_write(ri_buf,ri_len);\
+    Q2h_sock->sk_write(buf,r_len);
+
 
 namespace {
 
@@ -34,6 +46,28 @@ file_exists(const std::string& fnm)
 }
 
 namespace xclhwemhal2 {
+    //helper class for transactions from SIM_QDMA to XRT
+    class Q2H_helper {
+        private:
+        call_packet_info *ci_msg;
+        response_packet_info *ri_msg;
+	    size_t  i_len;
+	    void*   i_buf;
+	    size_t  ri_len;
+	    void*   ri_buf;
+	    size_t  buf_size;
+	    void*   buf;
+        int r;
+        unix_socket *Q2h_sock;
+        bool (*m_q2h_slavetransaction)(bool intr, int rdwr, unsigned long int, void*,unsigned long int);
+
+        public:
+        Q2H_helper();
+        ~Q2H_helper(); 
+        void poolingon_Qdma(); 
+        void select_msg(); 
+        void register_q2h_slavetransaction(bool (*q2h_slavetransaction)(bool intr, int rdwr, unsigned long int, void*,unsigned long int));
+    };
 
   namespace pt = boost::property_tree;
   std::map<unsigned int, HwEmShim*> devices;
@@ -508,6 +542,11 @@ namespace xclhwemhal2 {
     if(mMessengerThreadStarted == false) {
       mMessengerThread = std::thread(xclhwemhal2::messagesThread,this);
       mMessengerThreadStarted = true;
+    }
+    //Thread to honor the Host Memory wr/rd requests from sim_QDMA and interrupts
+    if(mHostMemAccessThreadStarted == false) {
+      mHostMemAccessThread = std::thread(xclhwemhal2::hostMemAccessThread,this);
+      mHostMemAccessThreadStarted = true;
     }
 
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
@@ -2691,4 +2730,97 @@ void HwEmShim::closemMessengerThread() {
 }
 /********************************************** QDMA APIs IMPLEMENTATION END**********************************************/
 /**********************************************HAL2 API's END HERE **********************************************/
+
+/********************************************** Q2H_helper class implementation starts **********************************************/
+bool device2xrt_trans_cb(bool, int, unsigned long int, void*,unsigned long int) {
+    std::cout << " device2xrt_trans_cb() is called...." <<std::endl;
+    return true;
+}
+Q2H_helper :: Q2H_helper() : buf_size(0),buf(NULL), r(0) {
+    std::cout << " Start of Q2H_helper()..." << std::endl;
+    ci_msg = new call_packet_info;
+    ri_msg = new response_packet_info;
+    Q2h_sock = new unix_socket("xcl_sock_K2H");
+    ci_msg->set_size(0);
+    ci_msg->set_xcl_api(0);
+    ri_msg->set_size(0);
+    ri_msg->set_xcl_api(0);
+    i_len = ci_msg->ByteSize();
+    i_buf = malloc(i_len);
+    ri_len = ri_msg->ByteSize();
+    ri_buf = malloc(i_len);
+    std::cout << " End of Q2H_helper()..." << std::endl;
+}
+Q2H_helper::~Q2H_helper() {
+    delete ci_msg;
+    delete ri_msg;
+}
+void Q2H_helper::poolingon_Qdma() {
+    //Pooling on socket for any memory or interrupt requests from SIM_QDMA
+    r = Q2h_sock->sk_read(i_buf, i_len);
+    if (r <= 0) {
+    	return;
+    }
+    assert(i_len == (uint32_t)r);
+    ci_msg->ParseFromArray(i_buf, i_len);
+    if (buf_size == 0) {
+    	buf = malloc(ci_msg->size());
+    } else if (buf_size < ci_msg->size()) {
+    	buf = (void*) realloc(buf, ci_msg->size());
+    }
+    r = Q2h_sock->sk_read(buf, ci_msg->size());
+    buf_size = ci_msg->size();
+    assert((uint32_t)r == ci_msg->size());
+    select_msg();
+}
+void Q2H_helper::select_msg() {
+    if (ci_msg->xcl_api() == xclQdma2HostReadMem_n) {
+    	xclSlaveReadReq_call c_msg;
+    	c_msg.ParseFromArray(buf, r);
+        void *data = malloc(c_msg.size());
+        bool resp = (*m_q2h_slavetransaction)(false, 0,(unsigned long int)c_msg.addr(),data,(unsigned long int)c_msg.size());
+        xclSlaveReadReq_response r_msg;
+        r_msg.set_valid(resp);
+        r_msg.set_data(data,c_msg.size());
+        int r_len = r_msg.ByteSize();
+        SEND_RESP2QDMA();
+    }        
+    if (ci_msg->xcl_api() == xclQdma2HostWriteMem_n) {
+    	xclSlaveWriteReq_call c_msg;
+    	c_msg.ParseFromArray(buf, r);
+        bool resp = (*m_q2h_slavetransaction)(false, 1,(unsigned long int)c_msg.addr(),(void*)c_msg.data().c_str(),(unsigned long int)c_msg.size());
+        xclSlaveWriteReq_response r_msg;
+        r_msg.set_valid(resp);
+        int r_len = r_msg.ByteSize();
+        SEND_RESP2QDMA();
+    }        
+    if (ci_msg->xcl_api() == xclQdma2HostInterrupt_n) {
+    	xclInterruptOccured_call c_msg;
+    	c_msg.ParseFromArray(buf, r);
+        void *interrupt_line_ptr = malloc(4);
+        *((uint32_t*)interrupt_line_ptr) = c_msg.interrupt_line();
+        bool resp = (*m_q2h_slavetransaction)(true, 1,0,interrupt_line_ptr,4);
+        xclInterruptOccured_response r_msg;
+        r_msg.set_valid(resp);
+        int r_len = r_msg.ByteSize();
+        SEND_RESP2QDMA();
+    }        
+}
+void Q2H_helper::register_q2h_slavetransaction(bool (*q2h_slavetransaction)(bool, int, unsigned long int, void*,unsigned long int)) {
+    m_q2h_slavetransaction = q2h_slavetransaction;
+}
+//Thread for which pooling for transaction from SIM_QDMA
+void hostMemAccessThread(xclhwemhal2::HwEmShim* inst) {
+    Q2H_helper *mq2h_helper_ptr = new Q2H_helper;
+    mq2h_helper_ptr->register_q2h_slavetransaction(device2xrt_trans_cb);
+    while(1){
+        if (!inst->get_simulator_started())
+            return;
+        mq2h_helper_ptr->poolingon_Qdma();
+    }
+}
+
+/********************************************** Q2H_helper class implementation Ends **********************************************/
+
+
 }  // end namespace xclhwemhal2

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -326,7 +326,9 @@ using addr_type = uint64_t;
 
       //For Emulation specific messages on host from Device
       std::thread mMessengerThread;
+      std::thread mHostMemAccessThread;
       bool mMessengerThreadStarted;
+      bool mHostMemAccessThreadStarted;
       void closemMessengerThread();
       bool mIsTraceHubAvailable;
   };


### PR DESCRIPTION
Shim.cxx/h are updated to service Interrupt coming from device through sim_qdma with creating a new socket communication between Shim.cxx(HW emu driver) and Sim_qdma