### PR TITLE
Fix some syntax warnings in xrt_bindings.py for Python>=3.8

### DIFF
--- a/src/python/xrt_binding.py
+++ b/src/python/xrt_binding.py
@@ -490,15 +490,15 @@ def xclMapBO(handle, boHandle, write, buf_type='char', buf_size=1):
     Return type void pointer doesn't get correctly binded in ctypes
     To map the buffer, explicitly specify the type and size of data
     """
-    if buf_type is 'char':
+    if buf_type == 'char':
         prop = xclBOProperties()
         xclGetBOProperties(handle, boHandle, prop)
         libc.xclMapBO.restype = ctypes.POINTER(ctypes.c_char * prop.size)
 
-    elif buf_size is 1 and buf_type is 'int':
+    elif buf_size == 1 and buf_type == 'int':
         libc.xclMapBO.restype = ctypes.POINTER(ctypes.c_int)
 
-    elif buf_type is 'int':
+    elif buf_type == 'int':
         libc.xclMapBO.restype = ctypes.POINTER(ctypes.c_int * buf_size)
     else:
         print("ERROR: This data type is not supported ")


### PR DESCRIPTION
This PR fixes some syntax warnings for using 'is' instead of '==' for string and numerical literals. From Python 3.8, doing so will produce a SyntaxWarning, and in general, it is incorrect (see [here](https://bugs.python.org/issue34850)).

The PR is done against master, but the syntax issue should be really fixed across all branches.