### PR TITLE
CR-1051957 Unknown flash type reported - prevents factory_reset

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -115,7 +115,8 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 		return NULL;
 	}
 
-	proplen = strlen(flash_type) + 1;
+	BUG_ON(strlen(flash_type) + 1 > sizeof(flash_priv->flash_type));
+	proplen = sizeof(struct xocl_flash_privdata);
 
 	flash_priv = vzalloc(sizeof(*flash_priv));
 	if (!flash_priv)
@@ -126,7 +127,6 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	*len = proplen;
 
 	return flash_priv;
-
 }
 
 static void devinfo_cb_setlevel(void *dev_hdl, void *subdevs, int num)


### PR DESCRIPTION
typically, platform_device_add_data should add sizeof(struct ...) as the length, for example: 
https://elixir.bootlin.com/linux/v4.7/source/arch/arm/mach-davinci/board-dm644x-evm.c#L316

Also add a bug_on to prevent overflow.