### PR TITLE
EoU XRT: Re-architected xbutil2 & xbmgmt2 help subsystems.

### DIFF
--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -23,8 +23,8 @@
 #include "XBUtilities.h"
 namespace XBU = XBUtilities;
 
-SubCmd::SubCmd(const std::string _name, 
-               const std::string _shortDescription)
+SubCmd::SubCmd(const std::string & _name, 
+               const std::string & _shortDescription)
   : m_executableName("")
   , m_subCmdName(_name)
   , m_shortDescription(_shortDescription)

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -23,35 +23,22 @@
 #include "XBUtilities.h"
 namespace XBU = XBUtilities;
 
-static SubCmdTable cmdTable;
-
-unsigned int 
-register_subcommand(const std::string &_subCmdName, 
-                    const std::string & _description, 
-                    t_subcommand _pSubCommand,
-                    bool _isHidden)
+SubCmd::SubCmd(const std::string _name, 
+               const std::string _shortDescription)
+  : m_executableName("")
+  , m_subCmdName(_name)
+  , m_shortDescription(_shortDescription)
+  , m_longDescription("")
+  , m_isHidden(false)
+  , m_isDeprecated(false)
+  , m_isPreliminary(false)
 {
-  if (cmdTable.find(_subCmdName) != cmdTable.end()) {
-    XBU::fatal(boost::str(boost::format("Sub-command '%s' already registered.") % _subCmdName));
-    exit(1);
-  }
-
-  cmdTable[_subCmdName] = SubCmdEntry{_subCmdName, _description, _pSubCommand, _isHidden};
-  return 0;
+  // Empty
 }
 
-const SubCmdEntry *
-getSubCmdEntry(const std::string &_sSubCmdName)
+void
+SubCmd::printHelp(const boost::program_options::options_description & _optionDescription) const
 {
-  if (cmdTable.find(_sSubCmdName) == cmdTable.end()) {
-    return nullptr;
-  }
-
-  return &cmdTable[_sSubCmdName];
+  XBU::subcommand_help(m_executableName, m_subCmdName, m_longDescription, _optionDescription, m_exampleSyntax);
 }
 
-const std::map<const std::string, SubCmdEntry> &
-getSubCmdsTable()
-{
-  return cmdTable;
-}

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -45,7 +45,7 @@ class SubCmd {
 
  // Child class Helper methods
  protected:
-  SubCmd(const std::string _name, const std::string _shortDescription);
+  SubCmd(const std::string & _name, const std::string & _shortDescription);
   void setIsHidden(bool _isHidden) { m_isHidden = _isHidden; };
   void setIsDeprecated(bool _isDeprecated) { m_isDeprecated = _isDeprecated; };
   void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,22 +20,56 @@
 // Please keep eternal include file dependencies to a minimum
 #include <vector>
 #include <string>
-#include <map>
+#include <boost/program_options.hpp>
   
-typedef int (*t_subcommand)(const std::vector<std::string> &);
+class SubCmd {
+ public:
+   typedef std::vector<std::string> SubCmdOptions;
+
+ public:
+   virtual void execute(const SubCmdOptions &_options) const = 0;
+
+ public:
+   const std::string &getName() const { return m_subCmdName; };
+   const std::string &getShortDescription() const { return m_shortDescription; };
+   bool isHidden() const { return m_isHidden; };
+   bool isDeprecated() const { return m_isDeprecated; };
+   bool isPreliminary() const { return m_isPreliminary; };
+
+ public:
+   void setExecutableName(const std::string & _name) { m_executableName = _name; };
+   const std::string & getExectuableName() const {return m_executableName; };
+
+ public:
+   virtual ~SubCmd() {};
+
+ // Child class Helper methods
+ protected:
+  SubCmd(const std::string _name, const std::string _shortDescription);
+  void setIsHidden(bool _isHidden) { m_isHidden = _isHidden; };
+  void setIsDeprecated(bool _isDeprecated) { m_isDeprecated = _isDeprecated; };
+  void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };
+  void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
+  void setExampleSyntax(const std::string &_exampleSyntax) {m_exampleSyntax = _exampleSyntax; };
+  void printHelp(const boost::program_options::options_description & _optionDescription) const;
+
+ // Methods not supported
+ private:
+  SubCmd() = delete;
+  SubCmd(const SubCmd& obj) = delete;
+  SubCmd& operator=(const SubCmd& obj) = delete;
+
+ // Variables
+ private:
+  std::string m_executableName;
+  std::string m_subCmdName;
+  std::string m_shortDescription;
+  std::string m_longDescription;
+  std::string m_exampleSyntax;
+
+  bool m_isHidden;
+  bool m_isDeprecated;
+  bool m_isPreliminary;
+};
   
-typedef struct {
-  std::string sSubCmd;
-  std::string sDescription;
-  t_subcommand callBackFunction;
-  bool isHidden;
-} SubCmdEntry;
-
-typedef std::map<const std::string, SubCmdEntry> SubCmdTable;
-
-unsigned int register_subcommand(const std::string &_subCommandName, const std::string &_description, t_subcommand _pSubCommand, bool _isHidden = false);
-const SubCmdEntry *getSubCmdEntry(const std::string &_sSubCmdName);
-const SubCmdTable &getSubCmdsTable();
-
-
 #endif

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -53,11 +53,8 @@ class SubCmd {
   void setExampleSyntax(const std::string &_exampleSyntax) {m_exampleSyntax = _exampleSyntax; };
   void printHelp(const boost::program_options::options_description & _optionDescription) const;
 
- // Methods not supported
  private:
   SubCmd() = delete;
-  SubCmd(const SubCmd& obj) = delete;
-  SubCmd& operator=(const SubCmd& obj) = delete;
 
  // Variables
  private:

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -98,9 +98,9 @@ static void print_help( const std::string &_executable,
 }
 
 // ------ Program entry point -------------------------------------------------
-ReturnCodes main_(int argc, char** argv, 
-                  const std::string & _description,
-                  const SubCmdsCollection &_subCmds) 
+void  main_(int argc, char** argv, 
+            const std::string & _description,
+            const SubCmdsCollection &_subCmds) 
 {
   if (_subCmds.size() == 0) {
     // do nothing
@@ -152,7 +152,7 @@ ReturnCodes main_(int argc, char** argv,
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     ::print_help(executable, _description, globalOptions, _subCmds);
-    return RC_ERROR_IN_COMMAND_LINE;
+    return;
   }
 
   // Set the verbosity if enabled
@@ -168,7 +168,7 @@ ReturnCodes main_(int argc, char** argv,
   // Check to see if help was requested and no command was found
   if ((bHelp == true) && (vm.count("subCmd") == 0)) {
     ::print_help(executable, _description, globalOptions, _subCmds);
-    return RC_SUCCESS;
+    return;
   }
 
   // Now see if there is a command to work with
@@ -177,7 +177,7 @@ ReturnCodes main_(int argc, char** argv,
 
   if (sCommand == "help") {
     ::print_help(executable, _description, globalOptions, _subCmds);
-    return RC_SUCCESS;
+    return;
   }
 
   // Search for the subcommand (case sensitive)
@@ -192,7 +192,7 @@ ReturnCodes main_(int argc, char** argv,
   if ( !subCommand) {
     std::cerr << "ERROR: " << "Unknown sub-command: '" << sCommand << "'" << std::endl;
     ::print_help(executable, _description, globalOptions, _subCmds);
-    return RC_ERROR_IN_COMMAND_LINE;
+    return;
   }
 
   // Prepare the data
@@ -206,7 +206,7 @@ ReturnCodes main_(int argc, char** argv,
   // Execute the sub-command
   subCommand->execute(opts);
 
-  return RC_SUCCESS;
+  return;
 }
 
 

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -182,7 +182,7 @@ void  main_(int argc, char** argv,
 
   // Search for the subcommand (case sensitive)
   std::shared_ptr<SubCmd> subCommand;
-  for (auto subCmdEntry :  _subCmds) {
+  for (auto & subCmdEntry :  _subCmds) {
     if (sCommand.compare(subCmdEntry->getName()) == 0) {
       subCommand = subCmdEntry;
       break;

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -25,53 +25,121 @@ namespace XBU = XBUtilities;
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
-#include "boost/format.hpp"
+#include <boost/format.hpp>
+#include <boost/filesystem.hpp>
 
 // System - Include Files
 #include <iostream>
 
 
-static void printHelp(const po::options_description& _optionDescription)
-{
-  std::cout << "\nSyntax: xbmgmt <subcommand> <options>\n\n";
-  std::cout << "Sub Commands:\n";
-  const SubCmdTable & cmdTable = getSubCmdsTable();
-  for (auto& subCmdEntry : cmdTable) {
-    if (subCmdEntry.second.isHidden == true) {
+static void print_help( const std::string &_executable, 
+                        const std::string &_description,
+                        const po::options_description& _optionDescription,
+                        const SubCmdsCollection &_subCmds)
+{ 
+  // -- Command description
+  std::string formatted;
+  XBU::wrap_paragraphs(_description, 13, 80, false, formatted);
+  if ( !formatted.empty() ) 
+    std::cout << boost::format("\nDescription: %s\n") % formatted;
+
+  // -- Command usage
+  std::string usage = XBU::create_usage_string(_executable,"", _optionDescription);
+  usage += " [subCmd [subCmdArgs]]";
+  std::cout << boost::format("\nUsage: %s\n") % usage;
+
+  // -- Sort the SubCommands
+  SubCmdsCollection subCmdsReleased;
+  SubCmdsCollection subCmdsDepricated;
+  SubCmdsCollection subCmdsPreliminary;
+
+  for (auto& subCmdEntry : _subCmds) {
+    // Filter out hidden subcommand
+    if (subCmdEntry->isHidden()) 
+      continue;
+
+    // Depricated sub-command
+    if (subCmdEntry->isDeprecated()) {
+      subCmdsDepricated.push_back(subCmdEntry);
       continue;
     }
-    std::cout << boost::format("  %-10s - %s") % subCmdEntry.second.sSubCmd % subCmdEntry.second.sDescription << "\n";
+
+    // Preliminary sub-command
+    if (subCmdEntry->isPreliminary()) {
+      subCmdsPreliminary.push_back(subCmdEntry);
+      continue;
+    }
+
+    // Released sub-command
+    subCmdsReleased.push_back(subCmdEntry);
   }
+
+  // -- Report the SubCommands
+  if (!subCmdsReleased.empty()) {
+    std::cout << boost::format("\nAvailable SubCommands:\n");
+    for (auto & subCmdEntry : subCmdsReleased)
+      std::cout << boost::format("  %-10s - %s\n") % subCmdEntry->getName() % subCmdEntry->getShortDescription();
+  }
+
+  if (!subCmdsPreliminary.empty()) {
+    std::cout << boost::format("\nPreliminary SubCommands:\n");
+    for (auto & subCmdEntry : subCmdsPreliminary)
+      std::cout << boost::format("  %-10s - %s\n") % subCmdEntry->getName() % subCmdEntry->getShortDescription();
+  }
+
+  if (!subCmdsDepricated.empty()) {
+    std::cout << boost::format("\nDeprecated SubCommands:\n");
+    for (auto & subCmdEntry : subCmdsDepricated)
+      std::cout << boost::format("  %-10s - %s\n") % subCmdEntry->getName() % subCmdEntry->getShortDescription();
+  }
+
+  // Global Options
   std::cout << "\n" << _optionDescription << std::endl;
 }
 
 // ------ Program entry point -------------------------------------------------
-ReturnCodes main_(int argc, char** argv) {
-
+ReturnCodes main_(int argc, char** argv, 
+                  const std::string & _description,
+                  const SubCmdsCollection &_subCmds) 
+{
+  if (_subCmds.size() == 0) {
+    // do nothing
+  }
+  // Determine the executable name for this application
+  boost::filesystem::path pathAndFile(argv[0]);
+  const std::string executable = pathAndFile.filename().string();
   // Global options
   bool bVerbose = false;
   bool bTrace = false;
   bool bHelp = false;
 
-  // Build our global options
-  po::options_description globalOptions("Global options");
+  // Build our options
+  po::options_description globalOptions("Global Options");
   globalOptions.add_options()
     ("help", boost::program_options::bool_switch(&bHelp), "Help to use this program")
     ("verbose", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
     ("trace", boost::program_options::bool_switch(&bTrace), "Enables code flow tracing")
-    ("command", po::value<std::string>(), "command to execute")
-    ("subArguments", po::value<std::vector<std::string> >(), "Arguments for command")
   ;
+
+  po::options_description hiddenOptions("Hidden Options");
+  hiddenOptions.add_options()
+    ("subCmd", po::value<std::string>(), "command to execute")
+    ("subCmdArgs", po::value<std::vector<std::string> >(), "Arguments for command")
+  ;
+
+  // Merge the options to one common collection
+  po::options_description allOptions("Allowed Options");
+  allOptions.add(globalOptions).add(hiddenOptions);
 
   // Create a sub-option command and arguments
   po::positional_options_description positionalCommand;
   positionalCommand.
-    add("command", 1 /* max_count */).
-    add("subArguments", 1 /* Unlimited max_count */);
+    add("subCmd", 1 /* max_count */).
+    add("subCmdArgs", 1 /* Unlimited max_count */);
 
   // Parse the command line
   po::parsed_options parsed = po::command_line_parser(argc, argv).
-    options(globalOptions).         // Global options
+    options(allOptions).            // Global options
     positional(positionalCommand).  // Our commands
     allow_unregistered().           // Allow for unregistered options (needed for sub obtions)
     run();                          // Parse the options
@@ -83,7 +151,7 @@ ReturnCodes main_(int argc, char** argv) {
     po::notify(vm);                 // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << globalOptions << std::endl;
+    ::print_help(executable, _description, globalOptions, _subCmds);
     return RC_ERROR_IN_COMMAND_LINE;
   }
 
@@ -98,24 +166,32 @@ ReturnCodes main_(int argc, char** argv) {
   }
 
   // Check to see if help was requested and no command was found
-  if ((bHelp == true) && (vm.count("command") == 0)) {
-    ::printHelp(globalOptions);
+  if ((bHelp == true) && (vm.count("subCmd") == 0)) {
+    ::print_help(executable, _description, globalOptions, _subCmds);
     return RC_SUCCESS;
   }
 
   // Now see if there is a command to work with
   // Get the command of choice
-  std::string sCommand = vm["command"].as<std::string>();
+  std::string sCommand = vm["subCmd"].as<std::string>();
 
   if (sCommand == "help") {
-    ::printHelp(globalOptions);
+    ::print_help(executable, _description, globalOptions, _subCmds);
     return RC_SUCCESS;
   }
 
-  const SubCmdEntry *pSubCmdEntry = getSubCmdEntry(sCommand);
-  if (pSubCmdEntry == nullptr) {
+  // Search for the subcommand (case sensitive)
+  std::shared_ptr<SubCmd> subCommand;
+  for (auto subCmdEntry :  _subCmds) {
+    if (sCommand.compare(subCmdEntry->getName()) == 0) {
+      subCommand = subCmdEntry;
+      break;
+    }
+  }
+
+  if ( !subCommand) {
     std::cerr << "ERROR: " << "Unknown sub-command: '" << sCommand << "'" << std::endl;
-    ::printHelp(globalOptions);
+    ::print_help(executable, _description, globalOptions, _subCmds);
     return RC_ERROR_IN_COMMAND_LINE;
   }
 
@@ -127,10 +203,8 @@ ReturnCodes main_(int argc, char** argv) {
       opts.push_back("--help");
   }
 
-  // Call the registered function for this command
-  if (pSubCmdEntry->callBackFunction != nullptr) {
-    pSubCmdEntry->callBackFunction(opts);
-  }
+  // Execute the sub-command
+  subCommand->execute(opts);
 
   return RC_SUCCESS;
 }

--- a/src/runtime_src/core/tools/common/XBMain.h
+++ b/src/runtime_src/core/tools/common/XBMain.h
@@ -24,21 +24,12 @@
 // ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
 // Forward declarations - use these instead whenever possible...
 class SubCmd;
-  
-// --------- E N U M E R A T I O N S   /   T Y P E D E F S--------------------
-typedef enum {
-  RC_SUCCESS = 0,
-  RC_ERROR_IN_COMMAND_LINE = 1,
-  RC_ERROR_UNHANDLED_EXCEPTION = 2
-} ReturnCodes;
-    
+
+// ----------------------- T Y P E D E F S -----------------------------------
 typedef std::vector<std::shared_ptr<SubCmd>> SubCmdsCollection;
     
-// ---------------------- F U N C T I O N S ---------------------------------
-
-ReturnCodes main_(int argc, char** argv, 
-                  const std::string & _description,
-                  const SubCmdsCollection & _SubCmds);
-
-
+// ---------------------- F U N C T I O N S ----------------------------------
+void main_(int argc, char** argv, 
+           const std::string & _description,
+           const SubCmdsCollection & _SubCmds);
 #endif

--- a/src/runtime_src/core/tools/common/XBMain.h
+++ b/src/runtime_src/core/tools/common/XBMain.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -19,13 +19,26 @@
 
 #include <string>
 #include <vector>
+#include <memory>
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+// Forward declarations - use these instead whenever possible...
+class SubCmd;
   
-  typedef enum {
-    RC_SUCCESS = 0,
-    RC_ERROR_IN_COMMAND_LINE = 1,
-    RC_ERROR_UNHANDLED_EXCEPTION = 2
-  } ReturnCodes;
+// --------- E N U M E R A T I O N S   /   T Y P E D E F S--------------------
+typedef enum {
+  RC_SUCCESS = 0,
+  RC_ERROR_IN_COMMAND_LINE = 1,
+  RC_ERROR_UNHANDLED_EXCEPTION = 2
+} ReturnCodes;
     
-ReturnCodes main_(int argc, char** argv);
+typedef std::vector<std::shared_ptr<SubCmd>> SubCmdsCollection;
+    
+// ---------------------- F U N C T I O N S ---------------------------------
+
+ReturnCodes main_(int argc, char** argv, 
+                  const std::string & _description,
+                  const SubCmdsCollection & _SubCmds);
+
 
 #endif

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -21,6 +21,9 @@
 // 3rd Party Library - Include Files
 #include "common/core_system.h"
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/format.hpp>
+namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
@@ -159,4 +162,229 @@ XBUtilities::trace_print_tree(const std::string & _name,
   XBUtilities::message(buf.str());
 }
 
+std::string 
+XBUtilities::create_usage_string(const std::string &_executableName,
+                                 const std::string &_subCommand,
+                                 const po::options_description &_od)
+{
+  const static int SHORT_OPTION_STRING_SIZE = 2;
+    std::stringstream buffer;
+
+    // Define the basic first
+    buffer << _executableName << " " << _subCommand;
+
+    const std::vector<boost::shared_ptr<po::option_description>> options = _od.options();
+
+    // Gather up the short simple flags
+    {
+      bool firstShortFlagFound = false;
+      for (auto option : options) {
+        // Get the option name
+        std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+
+        // See if we have a long flag
+        if (optionDisplayName.size() != SHORT_OPTION_STRING_SIZE)
+          continue;
+
+        // We are not interested in any arguments
+        if (option->semantic()->max_tokens() > 0)
+          continue;
+
+        // This option shouldn't be required
+        if (option->semantic()->is_required() == true) 
+          continue;
+
+        if (!firstShortFlagFound) {
+          buffer << " [-";
+          firstShortFlagFound = true;
+        }
+
+        buffer << optionDisplayName[1];
+      }
+
+      if (firstShortFlagFound == true) 
+        buffer << "]";
+    }
+
+     
+    // Gather up the long simple flags (flags with no short versions)
+    {
+      for (auto option : options) {
+        // Get the option name
+        std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+
+        // See if we have a short flag
+        if (optionDisplayName.size() == SHORT_OPTION_STRING_SIZE)
+          continue;
+
+        // We are not interested in any arguments
+        if (option->semantic()->max_tokens() > 0)
+          continue;
+
+        // This option shouldn't be required
+        if (option->semantic()->is_required() == true) 
+          continue;
+
+        std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_long);
+        buffer << " [" << completeOptionName << "]";
+      }
+    }
+
+    // Gather up the options with arguments
+    for (auto option : options) {
+      // Skip if there are no arguments
+      if (option->semantic()->max_tokens() == 0)
+        continue;
+
+      // This option shouldn't be required
+      if (option->semantic()->is_required() == true) 
+        continue;
+
+      
+      std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+      buffer << " [" << completeOptionName << " arg]";
+    }
+
+    // Gather up the required options with arguments
+    for (auto option : options) {
+      // Skip if there are no arguments
+      if (option->semantic()->max_tokens() == 0)
+        continue;
+
+      // This option is required
+      if (option->semantic()->is_required() == false) 
+        continue;
+
+      std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
+      buffer << " " << completeOptionName << " arg";
+    }
+
+  return buffer.str();
+}
+
+void 
+XBUtilities::wrap_paragraph( const std::string _unformattedString, 
+                             unsigned int _indentWidth, 
+                             unsigned int _columnWidth, 
+                             bool _indentFirstLine,
+                             std::string &_formattedString)
+{
+  // Set return variables to a now state
+  _formattedString.clear();
+
+  if (_indentWidth >= _columnWidth) {
+    std::string errMsg = boost::str(boost::format("Internal Error: %s paragraph indent (%d) is greater than or equal to the column width (%d) ") % __FUNCTION__ % _indentWidth % _columnWidth);
+    throw std::runtime_error(errMsg);
+  }
+
+  const unsigned int paragraphWidth = _columnWidth - _indentWidth;
+
+  std::string::const_iterator lineBeginIter = _unformattedString.begin();
+  const std::string::const_iterator paragraphEndIter = _unformattedString.end();
+
+  unsigned int linesProcessed = 0;
+
+  while (lineBeginIter < paragraphEndIter)  
+  {
+    // Remove leading spaces
+    if ((linesProcessed > 0) && 
+        (*lineBeginIter == ' ')) {
+      lineBeginIter++;
+      continue;
+    }
+
+    // Determine the end-of-the line to be examined
+    std::string::const_iterator lineEndIter = lineBeginIter;
+    int64_t remainingChars = std::distance(lineBeginIter, paragraphEndIter);
+    if (remainingChars < paragraphWidth)
+      lineEndIter += remainingChars;
+    else
+      lineEndIter += paragraphWidth;
+
+    // Not last line
+    if (lineEndIter != paragraphEndIter) {
+      // Find a break between the words
+      std::string::const_iterator lastSpaceIter = find(std::reverse_iterator<std::string::const_iterator>(lineEndIter),
+                                                       std::reverse_iterator<std::string::const_iterator>(lineBeginIter), ' ').base();
+
+      // See if we have gone to the beginning, if not then break the line
+      if (lastSpaceIter != lineBeginIter) {
+        lineEndIter = lastSpaceIter;
+      }
+    }
+    
+    // Add new line
+    if (linesProcessed > 0)
+      _formattedString += "\n";
+
+    // Indent the line
+    if ((linesProcessed > 0) || 
+        (_indentFirstLine == true)) {
+      for (size_t index = _indentWidth; index > 0; index--)
+      _formattedString += " ";
+    }
+
+    // Write out the line
+    _formattedString.append(lineBeginIter, lineEndIter);
+
+    lineBeginIter = lineEndIter;              
+    linesProcessed++;
+  }
+}   
+
+void 
+XBUtilities::wrap_paragraphs( const std::string _unformattedString, 
+                            unsigned int _indentWidth, 
+                            unsigned int _columnWidth, 
+                            bool _indentFirstLine,
+                            std::string &_formattedString) 
+{
+  // Set return variables to a now state
+  _formattedString.clear();
+
+  if (_indentWidth >= _columnWidth) {
+    std::string errMsg = boost::str(boost::format("Internal Error: %s paragraph indent (%d) is greater than or equal to the column width (%d) ") % __FUNCTION__ % _indentWidth % _columnWidth);
+    throw std::runtime_error(errMsg);
+  }
+
+  typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+  boost::char_separator<char> sep{"\n", "", boost::keep_empty_tokens};
+  tokenizer paragraphs{_unformattedString, sep};
+
+  tokenizer::const_iterator iter = paragraphs.begin();
+  while (iter != paragraphs.end()) {
+    std::string formattedParagraph;
+    wrap_paragraph(*iter, _indentWidth, _columnWidth, _indentFirstLine, formattedParagraph);
+    _formattedString += formattedParagraph;
+    _indentFirstLine = true; // We wish to indent all lines following the first
+
+    ++iter;
+
+    // Determine if a '\n' should be added
+    if (iter != paragraphs.end()) 
+      _formattedString += "\n";
+  }
+}
+
+void 
+XBUtilities::subcommand_help( const std::string &_executableName,
+                              const std::string &_subCommand,
+                              const std::string &_description, 
+                              const po::options_description &_od, 
+                              const std::string &_examples)
+{
+  std::cout << boost::format("SubCommand:  %s\n\n") % _subCommand;
+ 
+  std::string formattedDescription;
+  wrap_paragraphs(_description, 13, 80, false, formattedDescription);
+  std::cout << boost::format("Description: %s\n\n") % formattedDescription;
+
+  std::string usage = create_usage_string(_executableName, _subCommand, _od);
+  std::cout << boost::format("Usage: %s \n\n") % usage;
+
+  std::cout << _od << std::endl;
+  if (!_examples.empty() ) {
+    std::cout << "Example Syntax: " << _examples << std::endl;
+  }
+}
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -263,7 +263,7 @@ XBUtilities::create_usage_string(const std::string &_executableName,
 }
 
 void 
-XBUtilities::wrap_paragraph( const std::string _unformattedString, 
+XBUtilities::wrap_paragraph( const std::string & _unformattedString, 
                              unsigned int _indentWidth, 
                              unsigned int _columnWidth, 
                              bool _indentFirstLine,
@@ -295,7 +295,7 @@ XBUtilities::wrap_paragraph( const std::string _unformattedString,
 
     // Determine the end-of-the line to be examined
     std::string::const_iterator lineEndIter = lineBeginIter;
-    int64_t remainingChars = std::distance(lineBeginIter, paragraphEndIter);
+    auto remainingChars = std::distance(lineBeginIter, paragraphEndIter);
     if (remainingChars < paragraphWidth)
       lineEndIter += remainingChars;
     else
@@ -333,11 +333,11 @@ XBUtilities::wrap_paragraph( const std::string _unformattedString,
 }   
 
 void 
-XBUtilities::wrap_paragraphs( const std::string _unformattedString, 
-                            unsigned int _indentWidth, 
-                            unsigned int _columnWidth, 
-                            bool _indentFirstLine,
-                            std::string &_formattedString) 
+XBUtilities::wrap_paragraphs( const std::string & _unformattedString, 
+                              unsigned int _indentWidth, 
+                              unsigned int _columnWidth, 
+                              bool _indentFirstLine,
+                              std::string &_formattedString) 
 {
   // Set return variables to a now state
   _formattedString.clear();

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -178,7 +178,7 @@ XBUtilities::create_usage_string(const std::string &_executableName,
     // Gather up the short simple flags
     {
       bool firstShortFlagFound = false;
-      for (auto option : options) {
+      for (auto & option : options) {
         // Get the option name
         std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
 
@@ -209,7 +209,7 @@ XBUtilities::create_usage_string(const std::string &_executableName,
      
     // Gather up the long simple flags (flags with no short versions)
     {
-      for (auto option : options) {
+      for (auto & option : options) {
         // Get the option name
         std::string optionDisplayName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
 
@@ -231,7 +231,7 @@ XBUtilities::create_usage_string(const std::string &_executableName,
     }
 
     // Gather up the options with arguments
-    for (auto option : options) {
+    for (auto & option : options) {
       // Skip if there are no arguments
       if (option->semantic()->max_tokens() == 0)
         continue;
@@ -246,7 +246,7 @@ XBUtilities::create_usage_string(const std::string &_executableName,
     }
 
     // Gather up the required options with arguments
-    for (auto option : options) {
+    for (auto & option : options) {
       // Skip if there are no arguments
       if (option->semantic()->max_tokens() == 0)
         continue;

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -22,6 +22,9 @@
 #include <string>
 #include <memory>
 #include <boost/property_tree/ptree.hpp>
+#include <boost/program_options.hpp>
+
+
 
 namespace XBUtilities {
 
@@ -66,7 +69,28 @@ std::string format(const std::string& format, Args ... args) {
   void fatal(const std::string& _msg, bool _endl = true);
   void trace(const std::string& _msg, bool _endl = true);
 
-  void trace_print_tree(const std::string & _name, const boost::property_tree::ptree & _pt);
+  void trace_print_tree(const std::string & _name, 
+                        const boost::property_tree::ptree & _pt);
+
+  // ---------
+  std::string create_usage_string( const std::string &_executableName,
+                                   const std::string &_subCommand,
+                                   const boost::program_options::options_description &_od);
+  void wrap_paragraph( const std::string _unformattedString, 
+                       unsigned int _indentWidth, 
+                       unsigned int _columnWidth, 
+                       bool _indentFirstLine,
+                       std::string &_formattedString);
+  void wrap_paragraphs( const std::string _unformattedString, 
+                        unsigned int _indentWidth, 
+                        unsigned int _columnWidth, 
+                        bool _indentFirstLine,
+                        std::string &_formattedString);
+  void subcommand_help( const std::string &_executableName,
+                        const std::string &_subCommand,
+                        const std::string &_description, 
+                        const boost::program_options::options_description &_od, 
+                        const std::string &_examples);
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -76,12 +76,12 @@ std::string format(const std::string& format, Args ... args) {
   std::string create_usage_string( const std::string &_executableName,
                                    const std::string &_subCommand,
                                    const boost::program_options::options_description &_od);
-  void wrap_paragraph( const std::string _unformattedString, 
+  void wrap_paragraph( const std::string & _unformattedString, 
                        unsigned int _indentWidth, 
                        unsigned int _columnWidth, 
                        bool _indentFirstLine,
                        std::string &_formattedString);
-  void wrap_paragraphs( const std::string _unformattedString, 
+  void wrap_paragraphs( const std::string & _unformattedString, 
                         unsigned int _indentWidth, 
                         unsigned int _columnWidth, 
                         bool _indentFirstLine,

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(${CMAKE_BINARY_DIR})
 
 # -----------------------------------------------------------------------------
 
+# Collect files outside of this directory
 file(GLOB XBMGMT_V2_BASE_FILES
   "xbmgmt.cpp"
   "../common/XBMain.cpp"
@@ -19,36 +20,40 @@ file(GLOB XBMGMT_V2_BASE_FILES
   "../common/SubCmd.cpp"
 )
 
-if(WIN32)
-  set(XBMGMT2_NAME "xbmgmt")     # Yes, on windows the file name will be xbmgmt
-  file(GLOB XBMGMT_V2_SUBCMD_FILES
-    "SubCmdFlash.cpp"
-    "SubCmdVersion.cpp"
-    "flash/firmware_image.cpp"
-    "flash/xmc.cpp"
-    "flash/xspi.cpp"
-    "flash/flasher.cpp"
-  )
-else()
-  set(XBMGMT2_NAME "xbmgmt2")
-  file(GLOB XBMGMT_V2_SUBCMD_FILES
-    "SubCmdFlash.cpp"
-    "SubCmdVersion.cpp"
-    "flash/firmware_image.cpp"
-    "flash/xmc.cpp"
-    "flash/xspi.cpp"
-    "flash/flasher.cpp"
-  )
-endif()
+# Collect local directory files
+file(GLOB XBMGMT_V2_SUBCMD_FILES
+  "flash/firmware_image.cpp"
+  "flash/flasher.cpp"
+  "flash/xmc.cpp"
+  "flash/xspi.cpp"
+  "SubCmdFlash.cpp"
+  "SubCmdVersion.cpp"
+)
 
+# Merge the files into one collection
 set(XBMGMT_V2_FILES_SRCS ${XBMGMT_V2_BASE_FILES} ${XBMGMT_V2_SUBCMD_FILES})
 set(XBMGMT_V2_SRCS ${XBMGMT_V2_FILES_SRCS})
 
+
+# Determine the name of the executable
+if(WIN32)
+set(XBMGMT2_NAME "xbmgmt")     # Yes, on windows the file name will be xbmgmt
+else()
+  set(XBMGMT2_NAME "xbmgmt2")
+endif()
+
 add_executable(${XBMGMT2_NAME} ${XBMGMT_V2_SRCS})
 
-
+# Determine what functionality should be added
 if(WIN32)
-  target_link_libraries(
+  target_compile_definitions(${XBMGMT2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
+else()
+  target_compile_definitions(${XBMGMT2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
+endif()
+
+# Add the supporting libraries
+if(WIN32)
+target_link_libraries(
     ${XBMGMT2_NAME} PRIVATE
     Boost::filesystem
     Boost::program_options

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -33,12 +33,6 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("flash",
-                                        "Update SC firmware or shell on the device",
-                                        subCmdFlash);
 // =============================================================================
 
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
@@ -162,9 +156,22 @@ reset_shell(uint16_t index)
 } // unnamed namespace
 
 
-// ------ F U N C T I O N S ---------------------------------------------------
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-int subCmdFlash(const std::vector<std::string> &_options)
+SubCmdFlash::SubCmdFlash(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("flash", 
+             "Update SC firmware or shell on the device")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
+
+void
+SubCmdFlash::execute(const SubCmdOptions& _options) const
 // Reference Command:   'flash' sub-command usage:
 //                      --scan [--verbose|--json]
 //                      --update [--shell name [--id id]] [--card bdf] [--force]
@@ -218,15 +225,15 @@ int subCmdFlash(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     xrt_core::send_exception_message(e.what(), "XBMGMT");
-    std::cerr << allOptions << std::endl;
+    printHelp(allOptions);
 
     // Re-throw exception
     throw;
   }
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << allOptions << std::endl;
-    return 0;
+    printHelp(allOptions);
+    return;
   }
 
   //prep data
@@ -267,11 +274,11 @@ int subCmdFlash(const std::vector<std::string> &_options)
 
     if (verbose && json) {
       XBU::error("Please specify only one option");
-      return 1;
+      return;
     }
 
     scan_devices(verbose, json);
-    return registerResult;
+    return;
   }
 
   if (update) {
@@ -311,12 +318,12 @@ int subCmdFlash(const std::vector<std::string> &_options)
 
     if (name.empty() && !id.empty()){
       XBU::error("Please specify the shell");
-      return 1;
+      return;
     }
 
     uint16_t idx = xrt_core::bdf2index(bdf);
     auto_flash(idx, name, id, force);
-    return registerResult;
+    return;
   }
 
   if (reset) {
@@ -345,7 +352,7 @@ int subCmdFlash(const std::vector<std::string> &_options)
 
     uint16_t idx = xrt_core::bdf2index(bdf);
     reset_shell(idx);
-    return registerResult;
+    return;
   }
 
   if (shell) {
@@ -385,11 +392,11 @@ int subCmdFlash(const std::vector<std::string> &_options)
       XBU::error("Please specify the shell file path and the device bdf");
       std::cerr << shellDesc << "\n";
       std::cerr << "Example: xbmgmt.exe flash --shell --path='path\\to\\dsabin\\file' --card=0000:04:00.0" << std::endl;
-      return 1;
+      return;
     }
 	  uint16_t idx = xrt_core::bdf2index(bdf);
     update_shell(idx, flash_type, file, secondary);
-    return registerResult;
+    return;
   }
 
   if (sc_firmware) {
@@ -423,13 +430,10 @@ int subCmdFlash(const std::vector<std::string> &_options)
       XBU::error("Please specify the sc file path and the device bdf");
       std::cerr << scDesc <<  "\n";
       std::cerr << "Example: xbmgmt.exe flash --sc_firmware --path='path\\to\\dsabin\\file' --card=0000:04:00.0" << std::endl;
-      return 1;
+      return;
     }
 
     uint16_t idx = xrt_core::bdf2index(bdf);
     update_SC(idx, file);
-    return registerResult;
   }
-
-  return registerResult;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
@@ -26,11 +26,8 @@ class SubCmdFlash : public SubCmd {
  public:
   SubCmdFlash(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdFlash() = delete;
-  SubCmdFlash(const SubCmdFlash& obj) = delete;
-  SubCmdFlash& operator=(const SubCmdFlash& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
@@ -25,9 +25,6 @@ class SubCmdFlash : public SubCmd {
 
  public:
   SubCmdFlash(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdFlash() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdFlash_h_
 #define __SubCmdFlash_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdFlash(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdFlash : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdFlash(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdFlash() {};
+
+ // Methods not supported
+ private:
+  SubCmdFlash() = delete;
+  SubCmdFlash(const SubCmdFlash& obj) = delete;
+  SubCmdFlash& operator=(const SubCmdFlash& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.h
@@ -21,11 +21,10 @@
 
 class SubCmdFlash : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdFlash(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdFlash() {};
+  SubCmdFlash(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -29,15 +29,6 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("version",
-                                        "Reports the version of the build, OS, and drivers (if present)",
-                                        subCmdVersion);
-// =============================================================================
-
-
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
 
 void reportVersions()
@@ -62,9 +53,22 @@ void reportVersions()
             << std::endl;
 }
 
-// ------ F U N C T I O N S ---------------------------------------------------
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-int subCmdVersion(const std::vector<std::string> &_options)
+SubCmdVersion::SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("version", 
+             "Reports the version of the build, OS, and drivers (if present)")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
+
+void
+SubCmdVersion::execute(const SubCmdOptions& _options) const
 // Reference Command:  version
 
 {
@@ -86,7 +90,7 @@ int subCmdVersion(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << versionDesc << std::endl;
+    printHelp(versionDesc);
 
     // Re-throw exception
     throw;
@@ -94,12 +98,10 @@ int subCmdVersion(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << versionDesc << std::endl;
-    return 0;
+    printHelp(versionDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
   reportVersions();
-
-  return registerResult;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
@@ -26,11 +26,8 @@ class SubCmdVersion : public SubCmd {
  public:
   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdVersion() = delete;
-  SubCmdVersion(const SubCmdVersion& obj) = delete;
-  SubCmdVersion& operator=(const SubCmdVersion& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
@@ -25,9 +25,6 @@ class SubCmdVersion : public SubCmd {
 
  public:
   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdVersion() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdVersion_h_
 #define __SubCmdVersion_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdVersion(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdVersion : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdVersion() {};
+
+ // Methods not supported
+ private:
+  SubCmdVersion() = delete;
+  SubCmdVersion(const SubCmdVersion& obj) = delete;
+  SubCmdVersion& operator=(const SubCmdVersion& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdVersion.h
@@ -21,11 +21,10 @@
 
 class SubCmdVersion : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdVersion() {};
+  SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -43,8 +43,8 @@ int main( int argc, char** argv )
   #ifdef ENABLE_DEPRECATED_2020_1_SUBCMDS
   {
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
-    subCommands.emplace_back(new   SubCmdFlash(false, true, false));
-    subCommands.emplace_back(new SubCmdVersion(false, true, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdFlash >(false, true, false));
+    subCommands.emplace_back(std::make_shared< SubCmdVersion >(false, true, false));
   }
   #endif
 
@@ -52,7 +52,7 @@ int main( int argc, char** argv )
   boost::filesystem::path pathAndFile(argv[0]);
   const std::string executable = pathAndFile.filename().string();
 
-  for (auto subCommand : subCommands) {
+  for (auto & subCommand : subCommands) {
     subCommand->setExecutableName(executable);
   }
 
@@ -63,7 +63,8 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    return main_( argc, argv, description, subCommands);
+    main_( argc, argv, description, subCommands);
+    return 0;
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (...) {

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -14,21 +14,60 @@
  * under the License.
  */
 
+// Sub Commands
+#include "SubCmdFlash.h"
+#include "SubCmdVersion.h"
+
+// Supporint tools
 #include "tools/common/XBMain.h"
+#include "tools/common/SubCmd.h"
 #include "common/error.h"
 
+// System include files
+#include <boost/filesystem.hpp>
 #include <string>
 #include <iostream>
 #include <exception>
 
+// Program entry
 int main( int argc, char** argv )
 {
+  // -- Build the supported subcommands
+  SubCmdsCollection subCommands;
+
+  {
+    // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
+  }
+
+  // Add depricated commands
+  #ifdef ENABLE_DEPRECATED_2020_1_SUBCMDS
+  {
+    // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
+    subCommands.emplace_back(new   SubCmdFlash(false, true, false));
+    subCommands.emplace_back(new SubCmdVersion(false, true, false));
+  }
+  #endif
+
+  // -- Determine and set the executable name for each subcommand
+  boost::filesystem::path pathAndFile(argv[0]);
+  const std::string executable = pathAndFile.filename().string();
+
+  for (auto subCommand : subCommands) {
+    subCommand->setExecutableName(executable);
+  }
+
+  // -- Program Description
+  const std::string description = 
+  "The Xilinx (R) Board Management (xbmgmt) is a standalone command line utility that"
+  " is included with the Xilinx Run Time (XRT) installation package.";
+
+  // -- Ready to execute the code
   try {
-    return main_( argc, argv );
+    return main_( argc, argv, description, subCommands);
   } catch (const std::exception &e) {
-    xrt_core::send_exception_message(e.what(), "XBMGMT");
+    xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (...) {
-    xrt_core::send_exception_message("Unknown error", "XBMGMT");
+    xrt_core::send_exception_message("Unknown error", executable.c_str());
   }
   return 1;
 }

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(${CMAKE_BINARY_DIR})
 
 # -----------------------------------------------------------------------------
 
+# Collect files outside of this directory
 file(GLOB XBUTIL_V2_BASE_FILES
   "xbutil.cpp"
   "../common/XBMain.cpp"
@@ -21,44 +22,48 @@ file(GLOB XBUTIL_V2_BASE_FILES
   "../common/SubCmd.cpp"
 )
 
-if(WIN32)
-  set(XBUTIL2_NAME "xbutil")     # Yes, on windows the file name will be xbutil
-  file(GLOB XBUTIL_V2_SUBCMD_FILES
-    "SubCmdProgram.cpp"
-    "SubCmdClock.cpp"
-    "SubCmdDmaTest.cpp"
-    "SubCmdQuery.cpp"
-    "SubCmdReset.cpp"
-    "SubCmdScan.cpp"
-    "SubCmdVersion.cpp"
-  )
-else()
-  set(XBUTIL2_NAME "xbutil2")
-  file(GLOB XBUTIL_V2_SUBCMD_FILES
-    "SubCmdQuery.cpp"
-    "SubCmdClock.cpp"
-    "SubCmdDmaTest.cpp"
-    "SubCmdDump.cpp"
-    "SubCmdM2MTest.cpp"
-    "SubCmdScan.cpp"
-    "SubCmdProgram.cpp"
-    "SubCmdList.cpp"
-    "SubCmdMem.cpp"
-    "SubCmdDD.cpp"
-    "SubCmdTop.cpp"
-    "SubCmdValidate.cpp"
-    "SubCmdReset.cpp"
-    "SubCmdP2P.cpp"
-    "SubCmdVersion.cpp"
-  )
-endif()
+# Collect local directory files
+file(GLOB XBUTIL_V2_SUBCMD_FILES
+  "SubCmdClock.cpp"
+  "SubCmdDD.cpp"
+  "SubCmdDmaTest.cpp"
+  "SubCmdDump.cpp"
+  "SubCmdExamine.cpp"
+  "SubCmdList.cpp"
+  "SubCmdM2MTest.cpp"
+  "SubCmdMem.cpp"
+  "SubCmdP2P.cpp"
+  "SubCmdProgram.cpp"
+  "SubCmdQuery.cpp"
+  "SubCmdReset.cpp"
+  "SubCmdScan.cpp"
+  "SubCmdTop.cpp"
+  "SubCmdValidate.cpp"
+  "SubCmdVersion.cpp"
+)
 
+# Merge the files into one collection
 set(XBUTIL_V2_FILES_SRCS ${XBUTIL_V2_BASE_FILES} ${XBUTIL_V2_SUBCMD_FILES})
 set(XBUTIL_V2_SRCS ${XBUTIL_V2_FILES_SRCS})
 
+# Determine the name of the executable
+if(WIN32)
+  set(XBUTIL2_NAME "xbutil")     # Yes, on windows the file name will be xbutil
+else()
+  set(XBUTIL2_NAME "xbutil2")
+endif()
+
 add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
 
+# Determine what functionality should be added
+if(WIN32)
+  target_compile_definitions(${XBUTIL2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
+else()
+  target_compile_definitions(${XBUTIL2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
+endif()
 
+
+# Add the supporting libraries
 if(WIN32)
   target_link_libraries(
     ${XBUTIL2_NAME} PRIVATE
@@ -84,6 +89,7 @@ else()
   )
 endif()
 
+# Install our built executable
 install (TARGETS ${XBUTIL2_NAME} RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)
 
 # -----------------------------------------------------------------------------

--- a/src/runtime_src/core/tools/xbutil2/SubCmdClock.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdClock.cpp
@@ -1,6 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
- *
+ * Copyright (C) 2019-2020
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
  * License is located at
@@ -27,23 +26,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("clock", 
-                                        "Change a given clock frequency",
-                                        subCmdClock);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
+SubCmdClock::SubCmdClock(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("clock", 
+             "Change a given clock frequency")
+{
+  const std::string longDescription = "Change a given clock frequecy.";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
-
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdClock(const std::vector<std::string> &_options)
+void
+SubCmdClock::execute(const SubCmdOptions& _options) const
 // Reference Command:  clock   [-d card] [-r region] [-f clock1_freq_MHz] [-g clock2_freq_MHz] [-h clock3_freq_MHz]
 //                     Change the clock frequency of region 0 in card 0 to 100 MHz\n";
 //                         xbutil clock -f 100
@@ -78,16 +76,14 @@ int subCmdClock(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << clockDesc << std::endl;
-
-    // Re-throw exception
+    printHelp(clockDesc);
     throw;
   }
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << clockDesc << std::endl;
-    return 0;
+    printHelp(clockDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -100,7 +96,5 @@ int subCmdClock(const std::vector<std::string> &_options)
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
@@ -26,11 +26,8 @@ class SubCmdClock : public SubCmd {
  public:
   SubCmdClock(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdClock() = delete;
-  SubCmdClock(const SubCmdClock& obj) = delete;
-  SubCmdClock& operator=(const SubCmdClock& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
@@ -25,9 +25,6 @@ class SubCmdClock : public SubCmd {
 
  public:
   SubCmdClock(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdClock() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
@@ -21,11 +21,10 @@
 
 class SubCmdClock : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdClock(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdClock() {};
+  SubCmdClock(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdClock.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdClock_h_
 #define __SubCmdClock_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdClock(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdClock : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdClock(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdClock() {};
+
+ // Methods not supported
+ private:
+  SubCmdClock() = delete;
+  SubCmdClock(const SubCmdClock& obj) = delete;
+  SubCmdClock& operator=(const SubCmdClock& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDD.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDD.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,23 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("dd", 
-                                        "<add description>",
-                                        subCmdDD);
-// =============================================================================
+SubCmdDD::SubCmdDD(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("dd", 
+             "<add short description>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
-
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdDD(const std::vector<std::string> &_options)
+void
+SubCmdDD::execute(const SubCmdOptions& _options) const
 // Reference Command:  dd -i inputFile -o outputFile -b blockSize -c count -p blocksToSkip -e seek
 
 {
@@ -76,16 +75,15 @@ int subCmdDD(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << ddDesc << std::endl;
-
+    printHelp(ddDesc);
     // Re-throw exception
     throw;
   }
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << ddDesc << std::endl;
-    return 0;
+    printHelp(ddDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -99,7 +97,5 @@ int subCmdDD(const std::vector<std::string> &_options)
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
@@ -25,9 +25,6 @@ class SubCmdDD : public SubCmd {
 
  public:
   SubCmdDD(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdDD() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdDD_h_
 #define __SubCmdDD_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdDD(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdDD : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdDD(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdDD() {};
+
+ // Methods not supported
+ private:
+  SubCmdDD() = delete;
+  SubCmdDD(const SubCmdDD& obj) = delete;
+  SubCmdDD& operator=(const SubCmdDD& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
@@ -26,11 +26,8 @@ class SubCmdDD : public SubCmd {
  public:
   SubCmdDD(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdDD() = delete;
-  SubCmdDD(const SubCmdDD& obj) = delete;
-  SubCmdDD& operator=(const SubCmdDD& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDD.h
@@ -21,11 +21,10 @@
 
 class SubCmdDD : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdDD(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdDD() {};
+  SubCmdDD(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -33,12 +33,6 @@ namespace po = boost::program_options;
 #include <iostream>
 #include <iterator>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("dmatest",
-                                        "Runs a DMA test on a given device",
-                                        subCmdDmaTest);
 // =============================================================================
 namespace {
 
@@ -99,9 +93,22 @@ dmatest(const std::shared_ptr<xrt_core::device>& device, size_t block_size, bool
 } // namespace
 
 
-// ------ F U N C T I O N S ---------------------------------------------------
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-int subCmdDmaTest(const std::vector<std::string> &_options)
+SubCmdDmaTest::SubCmdDmaTest(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("dmatest", 
+             "Runs a DMA test on a given device")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
+
+void
+SubCmdDmaTest::execute(const SubCmdOptions& _options) const
 // References: dmatest [-d card] [-b [0x]block_size_KB]
 //             Run DMA test on card 1 with 32 KB blocks of buffer
 //               xbutil dmatest -d 1 -b 0x2000
@@ -127,7 +134,7 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << dmaTestDesc << std::endl;
+    printHelp(dmaTestDesc);
 
     // Re-throw exception
     throw;
@@ -135,8 +142,8 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << dmaTestDesc << std::endl;
-    return 0;
+    printHelp(dmaTestDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -144,6 +151,4 @@ int subCmdDmaTest(const std::vector<std::string> &_options)
   auto block_size = std::strtoll(sBlockSizeKB.c_str(), nullptr, 0);
   bool verbose = true;
   dmatest(device, block_size, verbose);
-
-  return registerResult;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
@@ -25,9 +25,6 @@ class SubCmdDmaTest : public SubCmd {
 
  public:
   SubCmdDmaTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdDmaTest() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
@@ -21,11 +21,10 @@
 
 class SubCmdDmaTest : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdDmaTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdDmaTest() {};
+  SubCmdDmaTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
@@ -26,11 +26,8 @@ class SubCmdDmaTest : public SubCmd {
  public:
   SubCmdDmaTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdDmaTest() = delete;
-  SubCmdDmaTest(const SubCmdDmaTest& obj) = delete;
-  SubCmdDmaTest& operator=(const SubCmdDmaTest& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdDmaTest_h_
 #define __SubCmdDmaTest_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdDmaTest(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdDmaTest : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdDmaTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdDmaTest() {};
+
+ // Methods not supported
+ private:
+  SubCmdDmaTest() = delete;
+  SubCmdDmaTest(const SubCmdDmaTest& obj) = delete;
+  SubCmdDmaTest& operator=(const SubCmdDmaTest& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDump.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                          register_subcommand("dump", 
-                                              "<add description>",
-                                              subCmdDump);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("dump", 
+             "<add short description>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdDump(const std::vector<std::string> &_options)
+void
+SubCmdDump::execute(const SubCmdOptions& _options) const
 // Reference Command:  dump
 
 {
@@ -64,7 +64,7 @@ int subCmdDump(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << dumpDesc << std::endl;
+    printHelp(dumpDesc);
 
     // Re-throw exception
     throw;
@@ -72,15 +72,13 @@ int subCmdDump(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << dumpDesc << std::endl;
-    return 0;
+    printHelp(dumpDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
@@ -25,9 +25,6 @@ class SubCmdDump : public SubCmd {
 
  public:
   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdDump() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdDump_h_
 #define __SubCmdDump_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdDump(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdDump : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdDump() {};
+
+ // Methods not supported
+ private:
+  SubCmdDump() = delete;
+  SubCmdDump(const SubCmdDump& obj) = delete;
+  SubCmdDump& operator=(const SubCmdDump& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
@@ -21,11 +21,10 @@
 
 class SubCmdDump : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdDump() {};
+  SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDump.h
@@ -26,11 +26,8 @@ class SubCmdDump : public SubCmd {
  public:
   SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdDump() = delete;
-  SubCmdDump(const SubCmdDump& obj) = delete;
-  SubCmdDump& operator=(const SubCmdDump& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -59,7 +59,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   XBU::verbose("SubCommand: examine");
 
   XBU::verbose("Option(s):");
-  for (auto aString : _options) {
+  for (auto & aString : _options) {
     std::string msg = "   ";
     msg += aString;
     XBU::verbose(msg);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "SubCmdExamine.h"
+#include "XBReport.h"
+#include "XBDatabase.h"
+
+#include "common/system.h"
+#include "common/device.h"
+#include "common/xclbin_parser.h"
+
+#include "tools/common/XBUtilities.h"
+namespace XBU = XBUtilities;
+
+// 3rd Party Library - Include Files
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
+
+// System - Include Files
+#include <iostream> 
+
+#include "common/system.h"
+#include "common/device.h"
+#include <boost/format.hpp>
+
+// ----- C L A S S   M E T H O D S -------------------------------------------
+
+SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("examine", 
+             "Status of the system and device(s)")
+{
+  const std::string longDescription = "This command will 'examine' the state of the system/device and will"
+                                      " generate a report of interest in a text or JSON format.";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
+
+void
+SubCmdExamine::execute(const SubCmdOptions& _options) const
+{
+  XBU::verbose("SubCommand: examine");
+
+  XBU::verbose("Option(s):");
+  for (auto aString : _options) {
+    std::string msg = "   ";
+    msg += aString;
+    XBU::verbose(msg);
+  }
+
+  // -- Retrieve and parse the subcommand options -----------------------------
+  std::string device = "all";
+  std::string report = "scan";
+  std::string format = "text";
+  std::string output;
+  bool help = false;
+
+  po::options_description queryDesc("Options");  // Note: Boost will add the colon.
+  queryDesc.add_options()
+    ("device,d", boost::program_options::value<decltype(device)>(&device), "The device of interest. This is specified as follows:\n"
+                                                                           "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)\n"
+                                                                           "  all   - Examines all known devices (default)")
+    ("report,r", boost::program_options::value<decltype(report)>(&report), "The type of report to be produced. Reports currently available are:\n"
+                                                                           "  all         - All know reports are produced\n"
+                                                                           "  scan        - Terse report of found devices (default)\n"
+                                                                           "  electrical  - Voltages, currents, and power\n"
+                                                                           "                consumption on the device\n"
+                                                                           "  temperature - Temperatures across the device\n"
+                                                                           "  os-info     - Information relating to the operating\n"
+                                                                           "                system and drivers\n"
+                                                                           "  debug-ip-status - Debug IP Status\n"
+                                                                           "  fans        - Fan status")
+    ("format,f", boost::program_options::value<decltype(format)>(&format), "Report output format. Valid values are:\n"
+                                                                           "  text        - Human readable report (default)\n"
+                                                                           "  json-2020.1 - JSON 2020.1 schema")
+    ("output,o", boost::program_options::value<decltype(output)>(&output), "Direct the output to the given file.")
+    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+  ;
+
+  // Parse sub-command ...
+  po::variables_map vm;
+
+  try {
+    po::store(po::command_line_parser(_options).options(queryDesc).run(), vm);
+    po::notify(vm); // Can throw
+  } catch (po::error& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
+    printHelp(queryDesc);
+    throw; // Re-throw exception
+  }
+
+  // Check to see if help was requested or no command was found
+  if (help == true)  {
+    printHelp(queryDesc);
+    return;
+  }
+
+  // -- Now process the subcommand --------------------------------------------
+  // Is valid BDF value valid
+}

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -26,11 +26,8 @@ class SubCmdExamine : public SubCmd {
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdExamine() = delete;
-  SubCmdExamine(const SubCmdExamine& obj) = delete;
-  SubCmdExamine& operator=(const SubCmdExamine& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,24 +14,24 @@
  * under the License.
  */
 
-#ifndef __SubCmdM2MTest_h_
-#define __SubCmdM2MTest_h_
+#ifndef __SubCmdExamine_h_
+#define __SubCmdExamine_h_
 
 #include "tools/common/SubCmd.h"
 
-class SubCmdM2MTest : public SubCmd {
+class SubCmdExamine : public SubCmd {
  public:
    virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdM2MTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdM2MTest() {};
+   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdExamine() {};
 
  // Methods not supported
  private:
-  SubCmdM2MTest() = delete;
-  SubCmdM2MTest(const SubCmdM2MTest& obj) = delete;
-  SubCmdM2MTest& operator=(const SubCmdM2MTest& obj) = delete;
+  SubCmdExamine() = delete;
+  SubCmdExamine(const SubCmdExamine& obj) = delete;
+  SubCmdExamine& operator=(const SubCmdExamine& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -21,11 +21,10 @@
 
 class SubCmdExamine : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdExamine() {};
+  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.h
@@ -25,9 +25,6 @@ class SubCmdExamine : public SubCmd {
 
  public:
   SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdExamine() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdList.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdList.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("list", 
-                                        "List all devices",
-                                        subCmdList);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdList::SubCmdList(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("list", 
+             "List all devices")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdList(const std::vector<std::string> &_options)
+void
+SubCmdList::execute(const SubCmdOptions& _options) const
 // Reference Command:  list
 //                     List all cards
 //                       xbutil list
@@ -65,7 +65,7 @@ int subCmdList(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << listDesc << std::endl;
+    printHelp(listDesc);
 
     // Re-throw exception
     throw;
@@ -73,15 +73,13 @@ int subCmdList(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << listDesc << std::endl;
-    return 0;
+    printHelp(listDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdList.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdList.h
@@ -25,9 +25,6 @@ class SubCmdList : public SubCmd {
 
  public:
   SubCmdList(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdList() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdList.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdList.h
@@ -26,11 +26,8 @@ class SubCmdList : public SubCmd {
  public:
   SubCmdList(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdList() = delete;
-  SubCmdList(const SubCmdList& obj) = delete;
-  SubCmdList& operator=(const SubCmdList& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdList.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdList.h
@@ -21,11 +21,10 @@
 
 class SubCmdList : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdList(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdList() {};
+  SubCmdList(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdList.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdList.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdList_h_
 #define __SubCmdList_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdList(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdList : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdList(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdList() {};
+
+ // Methods not supported
+ private:
+  SubCmdList() = delete;
+  SubCmdList(const SubCmdList& obj) = delete;
+  SubCmdList& operator=(const SubCmdList& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("m2mtest", 
-                                        "<add description>",
-                                        subCmdM2MTest);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdM2MTest::SubCmdM2MTest(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("m2mtest", 
+             "<add short description>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdM2MTest(const std::vector<std::string> &_options)
+void
+SubCmdM2MTest::execute(const SubCmdOptions& _options) const
 // Reference Command:  m2mtest
 
 {
@@ -64,7 +64,7 @@ int subCmdM2MTest(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << m2mtestDesc << std::endl;
+    printHelp(m2mtestDesc);
 
     // Re-throw exception
     throw;
@@ -72,8 +72,8 @@ int subCmdM2MTest(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << m2mtestDesc << std::endl;
-    return 0;
+    printHelp(m2mtestDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -81,6 +81,5 @@ int subCmdM2MTest(const std::vector<std::string> &_options)
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
 
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.h
@@ -21,11 +21,10 @@
 
 class SubCmdM2MTest : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdM2MTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdM2MTest() {};
+  SubCmdM2MTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.h
@@ -25,9 +25,6 @@ class SubCmdM2MTest : public SubCmd {
 
  public:
   SubCmdM2MTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdM2MTest() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdM2MTest.h
@@ -26,11 +26,8 @@ class SubCmdM2MTest : public SubCmd {
  public:
   SubCmdM2MTest(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdM2MTest() = delete;
-  SubCmdM2MTest(const SubCmdM2MTest& obj) = delete;
-  SubCmdM2MTest& operator=(const SubCmdM2MTest& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdMem.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,23 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("mem", 
-                                        "Memory write tests.",
-                                        subCmdMem);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdMem::SubCmdMem(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("mem", 
+             "Memory write tests.")
+{
+  const std::string longDescription = "<add long discription>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
 
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdMem(const std::vector<std::string> &_options)
+void
+SubCmdMem::execute(const SubCmdOptions& _options) const
 // Reference Command: mem --read [-d card] [-a [0x]start_addr] [-i size_bytes] [-o output filename]
 //                    mem --write [-d card] [-a [0x]start_addr] [-i size_bytes] [-e pattern_byte]
 //                    Read 256 bytes from DDR starting at 0x1000 into file read.out\n";
@@ -84,7 +85,7 @@ int subCmdMem(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << memDesc << std::endl;
+    printHelp(memDesc);
 
     // Re-throw exception
     throw;
@@ -92,8 +93,8 @@ int subCmdMem(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << memDesc << std::endl;
-    return 0;
+    printHelp(memDesc);
+    return;
   }
 
   // -- Do some DRC checks here --------------------------------------------
@@ -110,7 +111,5 @@ int subCmdMem(const std::vector<std::string> &_options)
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
@@ -21,11 +21,10 @@
 
 class SubCmdMem : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdMem(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdMem() {};
+  SubCmdMem(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
@@ -25,9 +25,6 @@ class SubCmdMem : public SubCmd {
 
  public:
   SubCmdMem(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdMem() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdMem_h_
 #define __SubCmdMem_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdMem(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdMem : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdMem(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdMem() {};
+
+ // Methods not supported
+ private:
+  SubCmdMem() = delete;
+  SubCmdMem(const SubCmdMem& obj) = delete;
+  SubCmdMem& operator=(const SubCmdMem& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdMem.h
@@ -26,11 +26,8 @@ class SubCmdMem : public SubCmd {
  public:
   SubCmdMem(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdMem() = delete;
-  SubCmdMem(const SubCmdMem& obj) = delete;
-  SubCmdMem& operator=(const SubCmdMem& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdP2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdP2P.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("p2p", 
-                                        "<add description>",
-                                        subCmdP2P);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdP2P::SubCmdP2P(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("p2p", 
+             "<add short discription>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdP2P(const std::vector<std::string> &_options)
+void
+SubCmdP2P::execute(const SubCmdOptions& _options) const
 // Reference Command:  
 //                      p2p  [-d card] --enable
 //                      p2p  [-d card] --disable
@@ -74,7 +74,7 @@ int subCmdP2P(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << p2pDesc << std::endl;
+    printHelp(p2pDesc);
 
     // Re-throw exception
     throw;
@@ -82,8 +82,8 @@ int subCmdP2P(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << p2pDesc << std::endl;
-    return 0;
+    printHelp(p2pDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -95,7 +95,5 @@ int subCmdP2P(const std::vector<std::string> &_options)
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
@@ -21,11 +21,10 @@
 
 class SubCmdP2P : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdP2P(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdP2P() {};
+  SubCmdP2P(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
@@ -26,11 +26,8 @@ class SubCmdP2P : public SubCmd {
  public:
   SubCmdP2P(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdP2P() = delete;
-  SubCmdP2P(const SubCmdP2P& obj) = delete;
-  SubCmdP2P& operator=(const SubCmdP2P& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdP2P_h_
 #define __SubCmdP2P_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdP2P(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdP2P : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdP2P(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdP2P() {};
+
+ // Methods not supported
+ private:
+  SubCmdP2P() = delete;
+  SubCmdP2P(const SubCmdP2P& obj) = delete;
+  SubCmdP2P& operator=(const SubCmdP2P& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdP2P.h
@@ -25,9 +25,6 @@ class SubCmdP2P : public SubCmd {
 
  public:
   SubCmdP2P(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdP2P() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -33,26 +33,25 @@ namespace po = boost::program_options;
 #include <iostream>
 #include <fstream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("program",
-                                        "Download the acceleration program to a given device",
-                                        subCmdProgram);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdProgram::SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("program", 
+             "Download the acceleration program to a given device")
+{
+  const std::string longDescription = "<add long discription>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdProgram(const std::vector<std::string> &_options)
+void
+SubCmdProgram::execute(const SubCmdOptions& _options) const
 // Reference Command:  [-d card] [-r region] -p xclbin
 //                     Download the accelerator program for card 2
 //                       xbutil program -d 2 -p a.xclbin
-
-
 {
   XBU::verbose("SubCommand: program");
   // -- Retrieve and parse the subcommand options -----------------------------
@@ -77,7 +76,7 @@ int subCmdProgram(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     xrt_core::send_exception_message(e.what(), "XBUTIL");
-    std::cerr << programDesc << std::endl;
+    printHelp(programDesc);
 
     // Re-throw exception
     throw;
@@ -85,8 +84,8 @@ int subCmdProgram(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << programDesc << std::endl;
-    return 0;
+    printHelp(programDesc);
+    return;
   }
 
   if (xclbin.empty())
@@ -125,6 +124,4 @@ int subCmdProgram(const std::vector<std::string> &_options)
     throw xrt_core::error(err, "Could not unlock device " + std::to_string(card));
 
   std::cout << "INFO: xbutil2 program succeeded.\n";
-
-  return registerResult;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
@@ -25,9 +25,6 @@ class SubCmdProgram : public SubCmd {
 
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdProgram() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
@@ -26,11 +26,8 @@ class SubCmdProgram : public SubCmd {
  public:
   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdProgram() = delete;
-  SubCmdProgram(const SubCmdProgram& obj) = delete;
-  SubCmdProgram& operator=(const SubCmdProgram& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdProgram_h_
 #define __SubCmdProgram_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdProgram(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdProgram : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdProgram() {};
+
+ // Methods not supported
+ private:
+  SubCmdProgram() = delete;
+  SubCmdProgram(const SubCmdProgram& obj) = delete;
+  SubCmdProgram& operator=(const SubCmdProgram& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.h
@@ -21,11 +21,10 @@
 
 class SubCmdProgram : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdProgram() {};
+  SubCmdProgram(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -34,21 +34,12 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("query",
-                                        "Status of the system and device(s)",
-                                        subCmdQuery);
-// =============================================================================
 #include "common/system.h"
 #include "common/device.h"
 #include <boost/format.hpp>
 
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
 
-
-// ------ F U N C T I O N S ---------------------------------------------------
 template <typename T>
 std::vector<T>
 as_vector(boost::property_tree::ptree const& pt,
@@ -150,8 +141,23 @@ pu1_query_report()
   }
 }
 
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-int subCmdQuery(const std::vector<std::string> &_options)
+SubCmdQuery::SubCmdQuery(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("query", 
+             "Status of the system and device(s)")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
+
+
+void
+SubCmdQuery::execute(const SubCmdOptions& _options) const
 // Reference Command:  query [-d card [-r region]
 {
   for (auto aString : _options) {
@@ -176,7 +182,7 @@ int subCmdQuery(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << queryDesc << std::endl;
+    printHelp(queryDesc);
 
     // Re-throw exception
     throw;
@@ -184,8 +190,8 @@ int subCmdQuery(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << queryDesc << std::endl;
-    return 0;
+    printHelp(queryDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -200,6 +206,4 @@ int subCmdQuery(const std::vector<std::string> &_options)
   boost::property_tree::ptree pt;
   XBDatabase::create_complete_device_tree(pt);
   XBU::trace_print_tree("Complete Device Tree", pt);
-
-  return registerResult;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -114,7 +114,7 @@ pu1_query_report()
       std::cout << "    No compute units found." << std::endl;
     } else {
       int index = 0;
-      for (auto cu : cus) {
+      for (auto & cu : cus) {
         std::string nm = xrt_core::xclbin::get_ip_name(iplayout, cu);
         std::cout << boost::format("    CU[%d]: %s - Base Address : 0x%x") % index++ % nm.c_str() % cu << std::endl;
       }
@@ -160,7 +160,7 @@ void
 SubCmdQuery::execute(const SubCmdOptions& _options) const
 // Reference Command:  query [-d card [-r region]
 {
-  for (auto aString : _options) {
+  for (auto & aString : _options) {
     std::cout << "Option: '" << aString << "'" << std::endl;
   }
   XBU::verbose("SubCommand: query");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
@@ -21,11 +21,10 @@
 
 class SubCmdQuery : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdQuery(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdQuery() {};
+  SubCmdQuery(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
@@ -25,9 +25,6 @@ class SubCmdQuery : public SubCmd {
 
  public:
   SubCmdQuery(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdQuery() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdQuery_h_
 #define __SubCmdQuery_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdQuery(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdQuery : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdQuery(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdQuery() {};
+
+ // Methods not supported
+ private:
+  SubCmdQuery() = delete;
+  SubCmdQuery(const SubCmdQuery& obj) = delete;
+  SubCmdQuery& operator=(const SubCmdQuery& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.h
@@ -26,11 +26,8 @@ class SubCmdQuery : public SubCmd {
  public:
   SubCmdQuery(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdQuery() = delete;
-  SubCmdQuery(const SubCmdQuery& obj) = delete;
-  SubCmdQuery& operator=(const SubCmdQuery& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("reset", 
-                                        "<add description>",
-                                        subCmdReset);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("reset", 
+             "<add short description>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdReset(const std::vector<std::string> &_options)
+void
+SubCmdReset::execute(const SubCmdOptions& _options) const
 // Reference Command:  reset [-d card]
 
 {
@@ -65,7 +65,7 @@ int subCmdReset(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << resetDesc << std::endl;
+    printHelp(resetDesc);
 
     // Re-throw exception
     throw;
@@ -73,8 +73,8 @@ int subCmdReset(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << resetDesc << std::endl;
-    return 0;
+    printHelp(resetDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -83,6 +83,6 @@ int subCmdReset(const std::vector<std::string> &_options)
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
 
-  return registerResult;
+  return;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
@@ -26,11 +26,8 @@ class SubCmdReset : public SubCmd {
  public:
   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdReset() = delete;
-  SubCmdReset(const SubCmdReset& obj) = delete;
-  SubCmdReset& operator=(const SubCmdReset& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdReset_h_
 #define __SubCmdReset_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdReset(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdReset : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdReset() {};
+
+ // Methods not supported
+ private:
+  SubCmdReset() = delete;
+  SubCmdReset(const SubCmdReset& obj) = delete;
+  SubCmdReset& operator=(const SubCmdReset& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
@@ -21,11 +21,10 @@
 
 class SubCmdReset : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdReset() {};
+  SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.h
@@ -25,9 +25,6 @@ class SubCmdReset : public SubCmd {
 
  public:
   SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdReset() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,22 +30,22 @@ namespace po = boost::program_options;
 #include "common/system.h"
 #include "common/device.h"
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("scan",
-                                        "<add description>",
-                                        subCmdScan);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdScan::SubCmdScan(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("scan", 
+             "<add short description>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdScan(const std::vector<std::string> &_options)
+void
+SubCmdScan::execute(const SubCmdOptions& _options) const
 // Reference Command:  scan
 
 {
@@ -69,7 +69,7 @@ int subCmdScan(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     xrt_core::send_exception_message(e.what(), "XBUTIL");
-    std::cerr << scanDesc << std::endl;
+    printHelp(scanDesc);
 
     // Re-throw exception
     throw;
@@ -77,8 +77,8 @@ int subCmdScan(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << scanDesc << std::endl;
-    return 0;
+    printHelp(scanDesc);
+    return;
   }
 
   // Collect
@@ -107,6 +107,4 @@ int subCmdScan(const std::vector<std::string> &_options)
     std::cout << "[" << device_id << "]: " << _pt.get<std::string>("vbnv", "N/A") << "(ts=" << _pt.get<std::string>("time_since_epoch", "N/A") << ")" << std::endl;
 #endif
   }
-
-  return registerResult;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdScan_h_
 #define __SubCmdScan_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdScan(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdScan : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdScan(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdScan() {};
+
+ // Methods not supported
+ private:
+  SubCmdScan() = delete;
+  SubCmdScan(const SubCmdScan& obj) = delete;
+  SubCmdScan& operator=(const SubCmdScan& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
@@ -25,9 +25,6 @@ class SubCmdScan : public SubCmd {
 
  public:
   SubCmdScan(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdScan() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
@@ -21,11 +21,10 @@
 
 class SubCmdScan : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdScan(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdScan() {};
+  SubCmdScan(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.h
@@ -26,11 +26,8 @@ class SubCmdScan : public SubCmd {
  public:
   SubCmdScan(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdScan() = delete;
-  SubCmdScan(const SubCmdScan& obj) = delete;
-  SubCmdScan& operator=(const SubCmdScan& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdTop.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdTop.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,22 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("top", 
-                                        "<add description>",
-                                        subCmdTop);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdTop::SubCmdTop(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("top", 
+             "<add short description>")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdTop(const std::vector<std::string> &_options)
+void
+SubCmdTop::execute(const SubCmdOptions& _options) const
 // Reference Command:  top  [-i seconds]
 
 {
@@ -65,7 +65,7 @@ int subCmdTop(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << topDesc << std::endl;
+    printHelp(topDesc);
 
     // Re-throw exception
     throw;
@@ -73,8 +73,8 @@ int subCmdTop(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << topDesc << std::endl;
-    return 0;
+    printHelp(topDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -82,7 +82,5 @@ int subCmdTop(const std::vector<std::string> &_options)
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
@@ -26,11 +26,8 @@ class SubCmdTop : public SubCmd {
  public:
   SubCmdTop(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdTop() = delete;
-  SubCmdTop(const SubCmdTop& obj) = delete;
-  SubCmdTop& operator=(const SubCmdTop& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
@@ -25,9 +25,6 @@ class SubCmdTop : public SubCmd {
 
  public:
   SubCmdTop(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdTop() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdTop_h_
 #define __SubCmdTop_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdTop(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdTop : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdTop(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdTop() {};
+
+ // Methods not supported
+ private:
+  SubCmdTop() = delete;
+  SubCmdTop(const SubCmdTop& obj) = delete;
+  SubCmdTop& operator=(const SubCmdTop& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdTop.h
@@ -21,11 +21,10 @@
 
 class SubCmdTop : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdTop(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdTop() {};
+  SubCmdTop(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,22 +27,23 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult = 
-                    register_subcommand("validate", 
-                                        "<add description>",
-                                        subCmdValidate);
-// =============================================================================
+// ----- C L A S S   M E T H O D S -------------------------------------------
 
-// ------ L O C A L   F U N C T I O N S ---------------------------------------
+SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("validate", 
+             "<add short description")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
 
-
-
-// ------ F U N C T I O N S ---------------------------------------------------
-
-int subCmdValidate(const std::vector<std::string> &_options)
+void
+SubCmdValidate::execute(const SubCmdOptions& _options) const
 
 {
   XBU::verbose("SubCommand: validate");
@@ -64,7 +65,7 @@ int subCmdValidate(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << validateDesc << std::endl;
+    printHelp(validateDesc);
 
     // Re-throw exception
     throw;
@@ -72,8 +73,8 @@ int subCmdValidate(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    std::cout << validateDesc << std::endl;
-    return 0;
+    printHelp(validateDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
@@ -81,7 +82,5 @@ int subCmdValidate(const std::vector<std::string> &_options)
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here
-
-  return registerResult;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdValidate_h_
 #define __SubCmdValidate_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdValidate(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdValidate : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdValidate() {};
+
+ // Methods not supported
+ private:
+  SubCmdValidate() = delete;
+  SubCmdValidate(const SubCmdValidate& obj) = delete;
+  SubCmdValidate& operator=(const SubCmdValidate& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -25,9 +25,6 @@ class SubCmdValidate : public SubCmd {
 
  public:
   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdValidate() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -26,11 +26,8 @@ class SubCmdValidate : public SubCmd {
  public:
   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdValidate() = delete;
-  SubCmdValidate(const SubCmdValidate& obj) = delete;
-  SubCmdValidate& operator=(const SubCmdValidate& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.h
@@ -21,11 +21,10 @@
 
 class SubCmdValidate : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdValidate() {};
+  SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/SubCmdVersion.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdVersion.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -29,15 +29,6 @@ namespace po = boost::program_options;
 // System - Include Files
 #include <iostream>
 
-// ======= R E G I S T E R   T H E   S U B C O M M A N D ======================
-#include "tools/common/SubCmd.h"
-static const unsigned int registerResult =
-                    register_subcommand("version",
-                                        "Reports the version of the build, OS, and drivers (if present)",
-                                        subCmdVersion);
-// =============================================================================
-
-
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
 
 void reportVersions()
@@ -62,11 +53,22 @@ void reportVersions()
             << std::endl;
 }
 
-// ------ F U N C T I O N S ---------------------------------------------------
+// ----- C L A S S   M E T H O D S -------------------------------------------
+SubCmdVersion::SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("version", 
+             "Reports the version of the build, OS, and drivers (if present)")
+{
+  const std::string longDescription = "<add long description>";
+  setLongDescription(longDescription);
+  setExampleSyntax("");
+  setIsHidden(_isHidden);
+  setIsDeprecated(_isDepricated);
+  setIsPreliminary(_isPreliminary);
+}
 
-int subCmdVersion(const std::vector<std::string> &_options)
+void
+SubCmdVersion::execute(const SubCmdOptions& _options) const
 // Reference Command:  version
-
 {
   XBU::verbose("SubCommand: version");
   // -- Retrieve and parse the subcommand options -----------------------------
@@ -86,7 +88,7 @@ int subCmdVersion(const std::vector<std::string> &_options)
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    std::cerr << versionDesc << std::endl;
+    printHelp(versionDesc);
 
     // Re-throw exception
     throw;
@@ -94,12 +96,12 @@ int subCmdVersion(const std::vector<std::string> &_options)
 
   // Check to see if help was requested or no command was found
   if (bHelp == true)  {
-    std::cout << versionDesc << std::endl;
-    return 0;
+    printHelp(versionDesc);
+    return;
   }
 
   // -- Now process the subcommand --------------------------------------------
   reportVersions();
 
-  return registerResult;
+  return;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
@@ -26,11 +26,8 @@ class SubCmdVersion : public SubCmd {
  public:
   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
- // Methods not supported
  private:
   SubCmdVersion() = delete;
-  SubCmdVersion(const SubCmdVersion& obj) = delete;
-  SubCmdVersion& operator=(const SubCmdVersion& obj) = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
@@ -25,9 +25,6 @@ class SubCmdVersion : public SubCmd {
 
  public:
   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-
- private:
-  SubCmdVersion() = delete;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,10 +17,21 @@
 #ifndef __SubCmdVersion_h_
 #define __SubCmdVersion_h_
 
-// Please keep eternal include file dependencies to a minimum
-#include <vector>
-#include <string>
-  
-int subCmdVersion(const std::vector<std::string> &_options);
+#include "tools/common/SubCmd.h"
+
+class SubCmdVersion : public SubCmd {
+ public:
+   virtual void execute(const SubCmdOptions &_options) const;
+
+ public:
+   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+   virtual ~SubCmdVersion() {};
+
+ // Methods not supported
+ private:
+  SubCmdVersion() = delete;
+  SubCmdVersion(const SubCmdVersion& obj) = delete;
+  SubCmdVersion& operator=(const SubCmdVersion& obj) = delete;
+};
 
 #endif

--- a/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdVersion.h
@@ -21,11 +21,10 @@
 
 class SubCmdVersion : public SubCmd {
  public:
-   virtual void execute(const SubCmdOptions &_options) const;
+  virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-   SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
-   virtual ~SubCmdVersion() {};
+  SubCmdVersion(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 
  // Methods not supported
  private:

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,21 +14,92 @@
  * under the License.
  */
 
+// Sub Commands
+#include "SubCmdExamine.h"
+#include "SubCmdClock.h"
+#include "SubCmdDD.h"
+#include "SubCmdDump.h"
+#include "SubCmdDmaTest.h"
+#include "SubCmdList.h"
+#include "SubCmdMem.h"
+#include "SubCmdM2MTest.h"
+#include "SubCmdP2P.h"
+#include "SubCmdProgram.h"
+#include "SubCmdQuery.h"
+#include "SubCmdReset.h"
+#include "SubCmdScan.h"
+#include "SubCmdTop.h"
+#include "SubCmdVersion.h"
+#include "SubCmdValidate.h"
+
+// Supporting tools
 #include "tools/common/XBMain.h"
+#include "tools/common/SubCmd.h"
 #include "common/error.h"
 
+// System include files
+#include <boost/filesystem.hpp>
 #include <string>
 #include <iostream>
 #include <exception>
 
+// Program entry
 int main( int argc, char** argv )
 {
+  // -- Build the supported subcommands
+  SubCmdsCollection subCommands;
+
+  {
+    // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
+    subCommands.emplace_back(new  SubCmdExamine(false, false, false));
+    subCommands.emplace_back(new  SubCmdProgram(false, false, false));
+    subCommands.emplace_back(new SubCmdValidate(false, false, false));
+  }
+
+  // Add depricated commands
+  #ifdef ENABLE_DEPRECATED_2020_1_SUBCMDS
+  {
+    // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
+    subCommands.emplace_back(new   SubCmdClock(false, true, false));
+    subCommands.emplace_back(new      SubCmdDD(false, true, false));
+    subCommands.emplace_back(new    SubCmdDump(false, true, false));
+    subCommands.emplace_back(new SubCmdDmaTest(false, true, false));
+    subCommands.emplace_back(new    SubCmdList(false, true, false));
+    subCommands.emplace_back(new SubCmdM2MTest(false, true, false));
+    subCommands.emplace_back(new     SubCmdMem(false, true, false));
+    subCommands.emplace_back(new     SubCmdP2P(false, true, false));
+    subCommands.emplace_back(new   SubCmdQuery(false, true, false));
+    subCommands.emplace_back(new   SubCmdReset(false, true, false));
+    subCommands.emplace_back(new    SubCmdScan(false, true, false));
+    subCommands.emplace_back(new     SubCmdTop(false, true, false));
+    subCommands.emplace_back(new SubCmdVersion(false, true, false));
+  }
+  #endif
+
+  // -- Determine and set the executable name for each subcommand
+  boost::filesystem::path pathAndFile(argv[0]);
+  const std::string executable = pathAndFile.filename().string();
+
+  for (auto subCommand : subCommands) {
+    subCommand->setExecutableName(executable);
+  }
+
+  // -- Program Description
+  const std::string description = 
+  "The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that"
+  " is included with the Xilinx Run Time (XRT) installation package. It includes"
+  " multiple commands to validate and identifythe installed card(s) along with"
+  " additional card details including DDR, PCIe (R), shell name (DSA), and system"
+  " information.\n\nThis information can be used for both card administration and"
+  " application debugging.";
+
+  // -- Ready to execute the code
   try {
-    return main_( argc, argv );
+    return main_( argc, argv, description, subCommands);
   } catch (const std::exception &e) {
-    xrt_core::send_exception_message(e.what(), "XBUTIL");
+    xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (...) {
-    xrt_core::send_exception_message("Unknown error", "XBUTIL");
+    xrt_core::send_exception_message("Unknown error", executable.c_str());
   }
   return 1;
 }

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -51,28 +51,28 @@ int main( int argc, char** argv )
 
   {
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
-    subCommands.emplace_back(new  SubCmdExamine(false, false, false));
-    subCommands.emplace_back(new  SubCmdProgram(false, false, false));
-    subCommands.emplace_back(new SubCmdValidate(false, false, false));
+    subCommands.emplace_back(std::make_shared<  SubCmdExamine >(false, false, false));
+    subCommands.emplace_back(std::make_shared<  SubCmdProgram >(false, false, false));
+    subCommands.emplace_back(std::make_shared< SubCmdValidate >(false, false, false));
   }
 
   // Add depricated commands
   #ifdef ENABLE_DEPRECATED_2020_1_SUBCMDS
   {
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
-    subCommands.emplace_back(new   SubCmdClock(false, true, false));
-    subCommands.emplace_back(new      SubCmdDD(false, true, false));
-    subCommands.emplace_back(new    SubCmdDump(false, true, false));
-    subCommands.emplace_back(new SubCmdDmaTest(false, true, false));
-    subCommands.emplace_back(new    SubCmdList(false, true, false));
-    subCommands.emplace_back(new SubCmdM2MTest(false, true, false));
-    subCommands.emplace_back(new     SubCmdMem(false, true, false));
-    subCommands.emplace_back(new     SubCmdP2P(false, true, false));
-    subCommands.emplace_back(new   SubCmdQuery(false, true, false));
-    subCommands.emplace_back(new   SubCmdReset(false, true, false));
-    subCommands.emplace_back(new    SubCmdScan(false, true, false));
-    subCommands.emplace_back(new     SubCmdTop(false, true, false));
-    subCommands.emplace_back(new SubCmdVersion(false, true, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdClock >(false, true, false));
+    subCommands.emplace_back(std::make_shared<      SubCmdDD >(false, true, false));
+    subCommands.emplace_back(std::make_shared<    SubCmdDump >(false, true, false));
+    subCommands.emplace_back(std::make_shared< SubCmdDmaTest >(false, true, false));
+    subCommands.emplace_back(std::make_shared<    SubCmdList >(false, true, false));
+    subCommands.emplace_back(std::make_shared< SubCmdM2MTest >(false, true, false));
+    subCommands.emplace_back(std::make_shared<     SubCmdMem >(false, true, false));
+    subCommands.emplace_back(std::make_shared<     SubCmdP2P >(false, true, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdQuery >(false, true, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdReset >(false, true, false));
+    subCommands.emplace_back(std::make_shared<    SubCmdScan >(false, true, false));
+    subCommands.emplace_back(std::make_shared<     SubCmdTop >(false, true, false));
+    subCommands.emplace_back(std::make_shared< SubCmdVersion >(false, true, false));
   }
   #endif
 
@@ -80,7 +80,7 @@ int main( int argc, char** argv )
   boost::filesystem::path pathAndFile(argv[0]);
   const std::string executable = pathAndFile.filename().string();
 
-  for (auto subCommand : subCommands) {
+  for (auto & subCommand : subCommands) {
     subCommand->setExecutableName(executable);
   }
 
@@ -95,7 +95,8 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    return main_( argc, argv, description, subCommands);
+    main_( argc, argv, description, subCommands);
+    return 0;
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (...) {


### PR DESCRIPTION
Re-architected xbutil2 & xbmgmt2 help subsystem
Work Done
-------------
1. All sub-commands are now contained in their own class.
2. Sub-commands now can be designated as hidden, deprecated, preliminary, etc.
3. New pretty print help created for both sub-command and top level parser.
4. Remove "self registration" of sub-command and replaced it with a more data-driven approached.
5. Cleaned-up CMakelist.txt build scripts
6. Added new xbutil 'examine' sub-command
