### PR TITLE
add xrt index to aws index mapping

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -38,6 +38,7 @@
 #include "xclbin.h"
 #include "aws_dev.h"
 
+static std::map<std::string, size_t>index_map;
 
 /*
  * Functions each plugin needs to provide
@@ -59,6 +60,9 @@ int init(mpd_plugin_callbacks *cbs)
         syslog(LOG_INFO, "aws: no device found");
         return ret;
     }
+    ret = AwsDev::init(index_map);
+    if (ret)
+        return ret;    
     if (cbs) 
     {
         // hook functions
@@ -638,7 +642,7 @@ AwsDev::~AwsDev()
     }
 }
 
-AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
+AwsDev::AwsDev(size_t index, const char *logfileName)
 {
     if (logfileName != nullptr) {
         mLogStream.open(logfileName);
@@ -646,7 +650,10 @@ AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
         mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     }
 
+    std::string sysfs_name = pcidev::get_dev(index, true)->sysfs_name;
+    std::cout << "AwsDev: " << sysfs_name << "(index: " << index << ")" << std::endl;
 #ifdef INTERNAL_TESTING_FOR_AWS
+    mBoardNumber = index;
     char file_name_buf[128];
     std::fill(&file_name_buf[0], &file_name_buf[0] + 128, 0);
     std::sprintf((char *)&file_name_buf, "/dev/awsmgmt%d", mBoardNumber);
@@ -658,6 +665,7 @@ AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
 
 #else
     fpga_mgmt_init(); // aws-fpga version newer than 09/2019 need this
+    mBoardNumber = index_map[sysfs_name];
     //bar0 is mapped already. seems other 2 bars are not required.
 #endif
 }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -18,6 +18,9 @@
 
 #include <fstream>
 #include <vector>
+#include <map>
+#include <sstream>
+#include <iomanip>
 #include <string>
 #include "xclhal2.h"
 #include "core/pcie/driver/linux/include/mailbox_proto.h"
@@ -61,6 +64,44 @@ public:
     AwsDev(size_t index, const char *logfileName);
     ~AwsDev();
 
+    static int init(std::map<std::string, size_t>& index_map)
+    {
+#ifndef INTERNAL_TESTING_FOR_AWS
+        int domain, bus, dev, func;	
+        if (fpga_mgmt_init() || fpga_pci_init() ) {
+            std::cout << "ERROR: failed to initialized fpga libraries" << std::endl;
+            return -1;
+        }
+        fpga_slot_spec spec_array[16];
+        std::memset(spec_array, 0, sizeof(fpga_slot_spec) * 16);
+        if (fpga_pci_get_all_slot_specs(spec_array, 16)) {
+            std::cout << "ERROR: failed at fpga_pci_get_all_slot_specs" << std::endl;
+            return -1;
+        }
+
+        for (unsigned short i = 0; i < 16; i++) {
+            if (spec_array[i].map[FPGA_APP_PF].vendor_id == 0)
+                break;
+
+            domain = spec_array[i].map[FPGA_APP_PF].domain;
+            bus = spec_array[i].map[FPGA_APP_PF].bus;
+            dev = spec_array[i].map[FPGA_APP_PF].dev;
+            func = spec_array[i].map[FPGA_APP_PF].func;
+
+            std::stringstream domain_str;
+            std::stringstream bus_str;
+            std::stringstream dev_str;
+            //Note: Below works with stringstream only for integers and not for uint8, etc.
+            domain_str << std::setw(4) << std::setfill('0') << domain;
+            bus_str << std::setw(2) << std::setfill('0') << std::hex << bus;
+            dev_str << std::setw(2) << std::setfill('0') << std::hex << dev;
+            std::string func_str = std::to_string(func);//stringstream is giving minimum of two chars
+
+            index_map[domain_str.str() + ":" + bus_str.str() + ":" + dev_str.str() + "." + func_str] = i;
+        }
+#endif
+        return 0;
+    };
     int awsGetIcap(xcl_pr_region *resp);
     int awsGetSensor(xcl_sensor *resp);
     int awsGetBdinfo(xcl_board_info *resp);
@@ -78,7 +119,7 @@ public:
     int awsUserProbe(xcl_mailbox_conn_resp *resp);
     bool isGood();
 private:
-    const int mBoardNumber;
+    int mBoardNumber;
     std::ofstream mLogStream;
 #ifdef INTERNAL_TESTING_FOR_AWS
     int mMgtHandle;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -165,7 +165,7 @@ void Mpd::run()
             hotreset_msg req_msg;
             int ret = hotreset_q_req->getMsg(1, req_msg);
             if (ret) //timeout
-                    continue;
+                continue;
 
             if (req_msg.type == REMOVE_REQ) {
                 syslog(LOG_INFO, "receive req to close mailbox: %s", req_msg.sysfs_name.c_str());
@@ -195,7 +195,6 @@ void Mpd::stop()
         syslog(LOG_INFO, "%s getMsg thread exit", t.first.c_str());
         t.second.join();
     }
-
 
     if (plugin_fini)
         (*plugin_fini)(plugin_cbs.mpc_cookie);
@@ -527,6 +526,8 @@ void Mpd::mpd_getMsg(size_t index)
             syslog(LOG_ERR, "failed to mark mgmt as online");
     }
 
+    add_done[sysfs_name] = true;
+
     struct queue_msg msg = {
         .localFd = mbxfd,
         .remoteFd = msdfd,
@@ -585,7 +586,8 @@ void Mpd::mpd_getMsg(size_t index)
 
     if (msdfd > 0)     
         close(msdfd);
-    dev.log(LOG_INFO, "mpd_getMsg thread %d exit!!", index);
+    dev.log(LOG_INFO, "mpd_getMsg thread for %s exit!!",
+	pcidev::get_dev(index)->sysfs_name.c_str());
 }
 
 // Client of MPD handling msg. Will quit on any error from either local mailbox or socket fd.
@@ -608,11 +610,11 @@ void Mpd::mpd_handleMsg(size_t index)
             break;
     }
     threads_handling[sysfs_name] = false;
-    dev.log(LOG_INFO, "mpd_handleMsg thread %d exit!!", index);
+    dev.log(LOG_INFO, "mpd_handleMsg thread for %s exit!!",
+	pcidev::get_dev(index)->sysfs_name.c_str());
 }
 
 /*
- * daemon will gracefully exit(eg notify mailbox driver) when
  * 'kill -15' is sent. or 'crtl c' on the terminal for debug.
  * so far 'kill -9' is not handled.
  */


### PR DESCRIPTION
card index xrt see and aws mgmt see may be different. A mapping should be setup and convert index if necessary.
card index mpd see and xbutil see are different. This is not an issue since both identify the card based on bdf. In order not to confuse users, mpd log should info of bdf instead of index.