### PR TITLE
xbtuil/xbmgmt CRs

### DIFF
--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -90,10 +90,6 @@ namespace xcldev {
                     break;
                 mBOList.push_back(bo);
             }
-            if (mSize < (1024*1024))
-                std::cout << "Buffer Size: " << mSize/(1024) << " KB\n";
-            else
-                std::cout << "Buffer Size: " << mSize/(1024*1024) << " MB\n";
         }
 
         ~DMARunner() {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -82,7 +82,6 @@ static int scanDevices(bool verbose, bool json)
                 sensor_tree::put(card + ".mac2", info.mMacAddr2);
                 sensor_tree::put(card + ".mac3", info.mMacAddr3);
             }
-            sensor_tree::json_dump( std::cout );
         } else {
             std::cout << "Card [" << f.sGetDBDF() << "]" << std::endl;
             std::cout << fmt_str << "Card type:\t\t" << board.board << std::endl;
@@ -128,6 +127,9 @@ static int scanDevices(bool verbose, bool json)
             std::cout << std::endl;
         }
     }
+
+    if (json)
+        sensor_tree::json_dump( std::cout );
 
     return 0;
 }

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1385,9 +1385,6 @@ public:
         if (ddr_mem_size == -EINVAL)
             return -EINVAL;
 
-        if (verbose)
-            std::cout << "Total DDR size: " << ddr_mem_size << " MB\n";
-
         bool isAREDevice = false;
 
 
@@ -1412,6 +1409,15 @@ public:
             return -EINVAL;
         }
         const mem_topology *map = (mem_topology *)buf.data();
+
+        std::string hbm_mem_size = unitConvert(map->m_count*(map->m_mem_data[0].m_size << 10));
+        if (verbose) {
+            std::cout << "INFO: DMA test on [" << m_idx << "]: "<< name() << "\n";
+            if (ddr_mem_size == 0)
+                std::cout << "Total HBM size:" << hbm_mem_size << "\n";
+            else
+                std::cout << "Total DDR size: " << ddr_mem_size << " MB\n";
+        }
 
         if(buf.empty() || map->m_count == 0) {
             std::cout << "WARNING: 'mem_topology' invalid, "

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1417,6 +1417,11 @@ public:
                 std::cout << "Total HBM size:" << hbm_mem_size << "\n";
             else
                 std::cout << "Total DDR size: " << ddr_mem_size << " MB\n";
+            
+            if (blockSize < (1024*1024))
+                std::cout << "Buffer Size: " << blockSize/(1024) << " KB\n";
+            else
+                std::cout << "Buffer Size: " << blockSize/(1024*1024) << " MB\n";
         }
 
         if(buf.empty() || map->m_count == 0) {


### PR DESCRIPTION
- CR-1051971: xbutil dma test should only report memory size for the types of memory on the card
- CR-1051887: xbmgmt flash --scan --json should only report each card once
- CR-1052204: xbutil dmatest should show the card ID being tested