### PR TITLE
Enhance clGetDeviceInfo to return BDF for a device

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -473,7 +473,10 @@ xclGetComputeUnitInfo(cl_kernel             kernel,
 #define CL_MEM_BANK                     0x1109
 
 // cl_program_build_info (CR962714)
-#define CL_PROGRAM_TARGET_TYPE          0x1190
+#define CL_PROGRAM_TARGET_TYPE          0x1110
+
+// cl_device_info
+#define CL_DEVICE_PCIE_BDF              0x1120
 
 // valid target types (CR962714)
 typedef cl_uint cl_program_target_type;

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -24,12 +24,6 @@ namespace xrt_core {
 class device_linux : public device_pcie
 {
 public:
-  struct SysDevEntry {
-    const std::string sSubDevice;
-    const std::string sEntry;
-  };
-  const SysDevEntry & get_sysdev_entry(QueryRequest qr) const;
-
   device_linux(id_type device_id, bool user);
 
   // query functions

--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -301,8 +301,11 @@ clGetDeviceInfo(cl_device_id   device,
   case CL_DEVICE_SVM_CAPABILITIES:
     buffer.as<cl_device_svm_capabilities>() = CL_DEVICE_SVM_COARSE_GRAIN_BUFFER;
     break;
+  case CL_DEVICE_PCIE_BDF:
+    buffer.as<char>() = xdevice->get_bdf();
+    break;
   default:
-    return CL_INVALID_VALUE;
+    throw error(CL_INVALID_VALUE,"clGetDeviceInfo: invalid param_name");
     break;
   }
   return CL_SUCCESS;

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -234,6 +234,15 @@ init_scheduler(xocl::device* device)
 
 namespace xocl {
 
+std::string
+device::
+get_bdf() const 
+{
+  if (m_xdevice)
+    return m_xdevice->get_bdf();
+  throw xocl::error(CL_INVALID_DEVICE, "No BDF");
+}
+
 void
 device::
 track(const memory* mem)

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -167,6 +167,14 @@ public:
   }
 
   /**
+   * Get the BDF of the device
+   *
+   * Throws on error
+   */
+  std::string
+  get_bdf() const;
+
+  /**
    * Get the number of DDR memory banks on the current device
    *
    * @return
@@ -707,7 +715,8 @@ public:
   size_t
   get_num_cdmas() const;
 
-  void clear_connection(connidx_type conn);
+  void
+  clear_connection(connidx_type conn);
 
 private:
 

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -101,6 +101,12 @@ public:
     return m_hal->getName();
   }
 
+  std::string
+  get_bdf() const
+  {
+    return m_hal->get_bdf();
+  }
+
   unsigned int
   getBankCount() const
   {
@@ -631,22 +637,6 @@ public:
     m_uuid = xclbin->m_header.uuid;
     return m_hal->loadXclBin(xclbin);
   }
-
-  /**
-   * Load a bistream from a file
-   *
-   * @param fnm
-   *   Full path to bitsream file
-   * @returns
-   *   A pair <int,bool> where bool is set to true if
-   *   and only if the return int value is valid. The
-   *   return value is implementation dependent.
-   */
-//  hal::operations_result<int>
-//  loadBitstream(const char* fnm)
-//  {
-//    return m_hal->loadBitstream(fnm);
-//  }
 
   bool
   hasBankAlloc() const

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -174,6 +174,9 @@ public:
   virtual device_handle
   get_handle() const = 0;
 
+  virtual std::string
+  get_bdf() const = 0;
+
   virtual void
   acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared) {}
 

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -219,6 +219,9 @@ public:
     return m_handle;
   }
 
+  virtual std::string
+  get_bdf() const;
+
   virtual void
   acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared);
 


### PR DESCRIPTION
This is applicable only for HW flow, emulation defaults to unknown.

Current implementation is not clean, it uses a sysfs path to parse for
BDF.  In future this should go through device classes used by xbutil
and xbmgmt, but more restructuring is needed in order to do this.

Prepare device_linux for accessing more than sysfs data in query
function.