### PR TITLE
xbmgmt2 flash [factory_reset and scan]

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -142,7 +142,8 @@ public:
       QR_FLASH_BAR_OFFSET,
       QR_IS_MFG,
       QR_F_FLASH_TYPE,
-      QR_FLASH_TYPE
+      QR_FLASH_TYPE,
+      QR_BOARD_NAME
   };
 public:
 

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -45,12 +45,6 @@ get_devices(boost::property_tree::ptree& pt)
   instance().get_devices(pt);
 }
 
-void
-scan_devices(bool verbose, bool json)
-{
-  instance().scan_devices(verbose, json);
-}
-
 std::shared_ptr<device>
 get_userpf_device(device::id_type id)
 {
@@ -64,9 +58,9 @@ get_mgmtpf_device(device::id_type id)
 }
 
 std::pair<uint64_t, uint64_t>
-get_total_devices()
+get_total_devices(bool is_user)
 {
-  return instance().get_total_devices();
+  return instance().get_total_devices(is_user);
 }
 
 uint16_t

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -36,8 +36,7 @@ public:
   virtual void get_xrt_info(boost::property_tree::ptree &pt) = 0;
   virtual void get_os_info(boost::property_tree::ptree &pt) = 0;
   virtual void get_devices(boost::property_tree::ptree &pt) const = 0;
-  virtual std::pair<device::id_type, device::id_type> get_total_devices() const = 0;
-  virtual void scan_devices(bool verbose, bool json) const = 0;
+  virtual std::pair<device::id_type, device::id_type> get_total_devices(bool is_user = true) const = 0;
   virtual uint16_t bdf2index(const std::string& bdfStr) const = 0;
 
 
@@ -70,11 +69,7 @@ get_devices(boost::property_tree::ptree& pt);
  */
 XRT_CORE_COMMON_EXPORT
 std::pair<uint64_t, uint64_t>
-get_total_devices();
-
-XRT_CORE_COMMON_EXPORT
-void
-scan_devices(bool verbose, bool json);
+get_total_devices(bool is_user);
 
 XRT_CORE_COMMON_EXPORT
 std::shared_ptr<device>

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -89,7 +89,7 @@ get_os_info(boost::property_tree::ptree &pt)
 
 std::pair<device::id_type, device::id_type>
 system_linux::
-get_total_devices() const
+get_total_devices(bool is_user) const
 {
   return std::make_pair(0,0);
 }

--- a/src/runtime_src/core/edge/user/system_linux.h
+++ b/src/runtime_src/core/edge/user/system_linux.h
@@ -31,7 +31,7 @@ public:
   get_os_info(boost::property_tree::ptree &pt);
 
   std::pair<device::id_type, device::id_type>
-  get_total_devices() const;
+  get_total_devices(bool is_user) const;
 
   void
   scan_devices(bool verbose, bool json) const;

--- a/src/runtime_src/core/pcie/common/system_pcie.cpp
+++ b/src/runtime_src/core/pcie/common/system_pcie.cpp
@@ -64,7 +64,7 @@ bdf2index(const std::string& bdfStr) const
     throw error(errMsg);
 	}
 
-  for (uint16_t i = 0; i < get_total_devices().first; i++) {
+  for (uint16_t i = 0; i < get_total_devices(false).first; i++) {
     auto device = get_mgmtpf_device(i);
     boost::any bus, dev, func;
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -40,7 +40,7 @@ struct query_entry
 static void
 bdf(const device_type* device, qr_type qr, const std::type_info&, boost::any& value)
 {
-  auto pdev = pcidev::get_dev(device->get_device_id());
+  auto pdev = pcidev::get_dev(device->get_device_id(), false);
 
   switch (qr) {
   case qr_type::QR_PCIE_BDF_BUS:
@@ -60,23 +60,26 @@ bdf(const device_type* device, qr_type qr, const std::type_info&, boost::any& va
 // Sysfs accessor
 static void
 sysfs(const device_type* device, const std::type_info& tinfo, boost::any& value,
-      const std::string& subdev, const std::string& entry)
+      const std::string& subdev, const std::string& entry, bool is_user)
 {
   auto device_id = device->get_device_id();
   std::string errmsg;
+  // ignore the errmsg from sysfs_get. Some nodes do not exist but we don't
+  // want to throw an error. this function handles invalid queries nicely
+  std::string ignore_err;
 
   if (tinfo == typeid(std::string)) {
     // -- Typeid: std::string --
     value = std::string("");
     auto p_str = boost::any_cast<std::string>(&value);
-    pcidev::get_dev(device_id)->sysfs_get(subdev, entry, errmsg, *p_str);
+    pcidev::get_dev(device_id, is_user)->sysfs_get(subdev, entry, ignore_err, *p_str);
 
   }
   else if (tinfo == typeid(uint64_t)) {
     // -- Typeid: uint64_t --
     value = (uint64_t) -1;
     std::vector<uint64_t> uint64Vector;
-    pcidev::get_dev(device_id)->sysfs_get(subdev, entry, errmsg, uint64Vector);
+    pcidev::get_dev(device_id, is_user)->sysfs_get(subdev, entry, ignore_err, uint64Vector);
     if (!uint64Vector.empty()) {
       value = uint64Vector[0];
     }
@@ -86,7 +89,7 @@ sysfs(const device_type* device, const std::type_info& tinfo, boost::any& value,
     // -- Typeid: bool --
     value = (bool) 0;
     std::vector<uint64_t> uint64Vector;
-    pcidev::get_dev(device_id)->sysfs_get(subdev, entry, errmsg, uint64Vector);
+    pcidev::get_dev(device_id, is_user)->sysfs_get(subdev, entry, ignore_err, uint64Vector);
     if (!uint64Vector.empty()) {
       value = (bool) uint64Vector[0];
     }
@@ -96,7 +99,7 @@ sysfs(const device_type* device, const std::type_info& tinfo, boost::any& value,
     // -- Typeid: std::vector<std::string>
     value = std::vector<std::string>();
     auto p_strvec = boost::any_cast<std::vector<std::string>>(&value);
-    pcidev::get_dev(device_id)->sysfs_get(subdev, entry, errmsg, *p_strvec);
+    pcidev::get_dev(device_id, is_user)->sysfs_get(subdev, entry, ignore_err, *p_strvec);
 
   }
   else {
@@ -108,88 +111,106 @@ sysfs(const device_type* device, const std::type_info& tinfo, boost::any& value,
   }
 }
 
+//sysfs mgmt wrapper
+static void
+sysfs_mgmt(const device_type* device, const std::type_info& tinfo, boost::any& value, 
+      const std::string& subdev, const std::string& entry)
+{
+  sysfs(device, tinfo, value, subdev, entry, false);
+}
+
+//sysfs mgmt wrapper
+static void
+sysfs_user(const device_type* device, const std::type_info& tinfo, boost::any& value, 
+      const std::string& subdev, const std::string& entry)
+{
+  sysfs(device, tinfo, value, subdev, entry, true);
+}
+
 namespace sp = std::placeholders;
 static std::map<qr_type, query_entry> query_table = {
-  { qr_type::QR_PCIE_VENDOR,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "vendor")}},
-  { qr_type::QR_PCIE_DEVICE,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "device")}},
-  { qr_type::QR_PCIE_SUBSYSTEM_VENDOR,     {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "subsystem_vendor")}},
-  { qr_type::QR_PCIE_SUBSYSTEM_ID,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "subsystem_device")}},
-  { qr_type::QR_PCIE_LINK_SPEED,           {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "link_speed")}},
-  { qr_type::QR_PCIE_EXPRESS_LANE_WIDTH,   {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "link_width")}},
+  { qr_type::QR_PCIE_VENDOR,               {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "", "vendor")}},
+  { qr_type::QR_PCIE_DEVICE,               {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "", "device")}},
+  { qr_type::QR_PCIE_SUBSYSTEM_VENDOR,     {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "", "subsystem_vendor")}},
+  { qr_type::QR_PCIE_SUBSYSTEM_ID,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "", "subsystem_device")}},
+  { qr_type::QR_PCIE_LINK_SPEED,           {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "", "link_speed")}},
+  { qr_type::QR_PCIE_EXPRESS_LANE_WIDTH,   {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "", "link_width")}},
   { qr_type::QR_PCIE_BDF_BUS,              {std::bind(bdf, sp::_1, qr_type::QR_PCIE_BDF_BUS, sp::_2, sp::_3)}},
   { qr_type::QR_PCIE_BDF_DEVICE,           {std::bind(bdf, sp::_1, qr_type::QR_PCIE_BDF_DEVICE, sp::_2, sp::_3)}},
   { qr_type::QR_PCIE_BDF_FUNCTION,         {std::bind(bdf, sp::_1, qr_type::QR_PCIE_BDF_FUNCTION, sp::_2, sp::_3)}},
-  { qr_type::QR_DMA_THREADS_RAW,           {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "dma", "channel_stat_raw")}},
-  { qr_type::QR_ROM_VBNV,                  {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "rom", "VBNV")}},
-  { qr_type::QR_ROM_DDR_BANK_SIZE,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "rom", "ddr_bank_size")}},
-  { qr_type::QR_ROM_DDR_BANK_COUNT_MAX,    {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "rom", "ddr_bank_count_max")}},
-  { qr_type::QR_ROM_FPGA_NAME,             {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "rom", "FPGA")}},
-  { qr_type::QR_ROM_RAW,                   {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "rom", "raw")}},
-  { qr_type::QR_ROM_UUID,                  {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "rom", "uuid")}},
-  { qr_type::QR_XMC_VERSION,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "version")}},
-  { qr_type::QR_XMC_SERIAL_NUM,            {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "serial_num")}},
-  { qr_type::QR_XMC_MAX_POWER,             {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "max_power")}},
-  { qr_type::QR_XMC_BMC_VERSION,           {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "bmc_ver")}},
-  { qr_type::QR_XMC_STATUS,                {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "status")}},
-  { qr_type::QR_XMC_REG_BASE,              {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "reg_base")}},
-  { qr_type::QR_DNA_SERIAL_NUM,            {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "dna", "dna")}},
-  { qr_type::QR_CLOCK_FREQS,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "icap", "clock_freqs")}},
-  { qr_type::QR_IDCODE,                    {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "icap", "idcode")}},
-  { qr_type::QR_STATUS_MIG_CALIBRATED,     {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "mig_calibration")}},
-  { qr_type::QR_STATUS_P2P_ENABLED,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "p2p_enable")}},
-  { qr_type::QR_TEMP_CARD_TOP_FRONT,       {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_se98_temp0")}},
-  { qr_type::QR_TEMP_CARD_TOP_REAR,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_se98_temp1")}},
-  { qr_type::QR_TEMP_CARD_BOTTOM_FRONT,    {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_se98_temp2")}},
-  { qr_type::QR_TEMP_FPGA,                 {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_fpga_temp")}},
-  { qr_type::QR_FAN_TRIGGER_CRITICAL_TEMP, {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_fan_temp")}},
-  { qr_type::QR_FAN_FAN_PRESENCE,          {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "fan_presence")}},
-  { qr_type::QR_FAN_SPEED_RPM,             {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_fan_rpm")}},
-  { qr_type::QR_DDR_TEMP_0,                {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp0")}},
-  { qr_type::QR_DDR_TEMP_1,                {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp1")}},
-  { qr_type::QR_DDR_TEMP_2,                {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp2")}},
-  { qr_type::QR_DDR_TEMP_3,                {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp3")}},
-  { qr_type::QR_HBM_TEMP,                  {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_hbm_temp")}},
-  { qr_type::QR_CAGE_TEMP_0,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp0")}},
-  { qr_type::QR_CAGE_TEMP_1,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp1")}},
-  { qr_type::QR_CAGE_TEMP_2,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp2")}},
-  { qr_type::QR_CAGE_TEMP_3,               {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp3")}},
-  { qr_type::QR_12V_PEX_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_pex_vol")}},
-  { qr_type::QR_12V_PEX_MILLIAMPS,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_pex_curr")}},
-  { qr_type::QR_12V_AUX_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_aux_vol")}},
-  { qr_type::QR_12V_AUX_MILLIAMPS,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_aux_curr")}},
-  { qr_type::QR_3V3_PEX_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_pex_vol")}},
-  { qr_type::QR_3V3_AUX_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_aux_vol")}},
-  { qr_type::QR_DDR_VPP_BOTTOM_MILLIVOLTS, {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_vpp_btm")}},
-  { qr_type::QR_DDR_VPP_TOP_MILLIVOLTS,    {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_vpp_top")}},
+  { qr_type::QR_DMA_THREADS_RAW,           {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "dma", "channel_stat_raw")}},
+  { qr_type::QR_ROM_VBNV,                  {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "VBNV")}},
+  { qr_type::QR_ROM_DDR_BANK_SIZE,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "ddr_bank_size")}},
+  { qr_type::QR_ROM_DDR_BANK_COUNT_MAX,    {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "ddr_bank_count_max")}},
+  { qr_type::QR_ROM_FPGA_NAME,             {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "FPGA")}},
+  { qr_type::QR_ROM_RAW,                   {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "raw")}},
+  { qr_type::QR_ROM_UUID,                  {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "uuid")}},
+  { qr_type::QR_ROM_TIME_SINCE_EPOCH,      {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "rom", "timestamp")}},
+  { qr_type::QR_XMC_VERSION,               {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "version")}},
+  { qr_type::QR_XMC_SERIAL_NUM,            {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "serial_num")}},
+  { qr_type::QR_XMC_MAX_POWER,             {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "max_power")}},
+  { qr_type::QR_XMC_BMC_VERSION,           {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "bmc_ver")}},
+  { qr_type::QR_XMC_STATUS,                {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "xmc", "status")}},
+  { qr_type::QR_XMC_REG_BASE,              {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "xmc", "reg_base")}},
+  { qr_type::QR_DNA_SERIAL_NUM,            {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "dna", "dna")}},
+  { qr_type::QR_CLOCK_FREQS,               {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "icap", "clock_freqs")}},
+  { qr_type::QR_IDCODE,                    {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "icap", "idcode")}},
+  { qr_type::QR_STATUS_MIG_CALIBRATED,     {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "", "mig_calibration")}},
+  { qr_type::QR_STATUS_P2P_ENABLED,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "", "p2p_enable")}},
+  { qr_type::QR_TEMP_CARD_TOP_FRONT,       {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_se98_temp0")}},
+  { qr_type::QR_TEMP_CARD_TOP_REAR,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_se98_temp1")}},
+  { qr_type::QR_TEMP_CARD_BOTTOM_FRONT,    {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_se98_temp2")}},
+  { qr_type::QR_TEMP_FPGA,                 {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_fpga_temp")}},
+  { qr_type::QR_FAN_TRIGGER_CRITICAL_TEMP, {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_fan_temp")}},
+  { qr_type::QR_FAN_FAN_PRESENCE,          {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "fan_presence")}},
+  { qr_type::QR_FAN_SPEED_RPM,             {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_fan_rpm")}},
+  { qr_type::QR_DDR_TEMP_0,                {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp0")}},
+  { qr_type::QR_DDR_TEMP_1,                {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp1")}},
+  { qr_type::QR_DDR_TEMP_2,                {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp2")}},
+  { qr_type::QR_DDR_TEMP_3,                {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_temp3")}},
+  { qr_type::QR_HBM_TEMP,                  {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_hbm_temp")}},
+  { qr_type::QR_CAGE_TEMP_0,               {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp0")}},
+  { qr_type::QR_CAGE_TEMP_1,               {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp1")}},
+  { qr_type::QR_CAGE_TEMP_2,               {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp2")}},
+  { qr_type::QR_CAGE_TEMP_3,               {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_cage_temp3")}},
+  { qr_type::QR_12V_PEX_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_pex_vol")}},
+  { qr_type::QR_12V_PEX_MILLIAMPS,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_pex_curr")}},
+  { qr_type::QR_12V_AUX_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_aux_vol")}},
+  { qr_type::QR_12V_AUX_MILLIAMPS,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_aux_curr")}},
+  { qr_type::QR_3V3_PEX_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_pex_vol")}},
+  { qr_type::QR_3V3_AUX_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_aux_vol")}},
+  { qr_type::QR_DDR_VPP_BOTTOM_MILLIVOLTS, {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_vpp_btm")}},
+  { qr_type::QR_DDR_VPP_TOP_MILLIVOLTS,    {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_ddr_vpp_top")}},
 
-  { qr_type::QR_5V5_SYSTEM_MILLIVOLTS,     {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_sys_5v5")}},
-  { qr_type::QR_1V2_VCC_TOP_MILLIVOLTS,    {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_1v2_top")}},
-  { qr_type::QR_1V2_VCC_BOTTOM_MILLIVOLTS, {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vcc1v2_btm")}},
-  { qr_type::QR_1V8_MILLIVOLTS,            {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_1v8")}},
-  { qr_type::QR_0V85_MILLIVOLTS,           {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_0v85")}},
-  { qr_type::QR_0V9_VCC_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_mgt0v9avcc")}},
-  { qr_type::QR_12V_SW_MILLIVOLTS,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_sw")}},
-  { qr_type::QR_MGT_VTT_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_mgtavtt")}},
-  { qr_type::QR_INT_VCC_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vccint_vol")}},
-  { qr_type::QR_INT_VCC_MILLIAMPS,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vccint_curr")}},
+  { qr_type::QR_5V5_SYSTEM_MILLIVOLTS,     {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_sys_5v5")}},
+  { qr_type::QR_1V2_VCC_TOP_MILLIVOLTS,    {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_1v2_top")}},
+  { qr_type::QR_1V2_VCC_BOTTOM_MILLIVOLTS, {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vcc1v2_btm")}},
+  { qr_type::QR_1V8_MILLIVOLTS,            {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_1v8")}},
+  { qr_type::QR_0V85_MILLIVOLTS,           {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_0v85")}},
+  { qr_type::QR_0V9_VCC_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_mgt0v9avcc")}},
+  { qr_type::QR_12V_SW_MILLIVOLTS,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_12v_sw")}},
+  { qr_type::QR_MGT_VTT_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_mgtavtt")}},
+  { qr_type::QR_INT_VCC_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vccint_vol")}},
+  { qr_type::QR_INT_VCC_MILLIAMPS,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vccint_curr")}},
 
-  { qr_type::QR_3V3_PEX_MILLIAMPS,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_pex_curr")}},
-  { qr_type::QR_0V85_MILLIAMPS,            {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_0v85_curr")}},
-  { qr_type::QR_3V3_VCC_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_vcc_vol")}},
-  { qr_type::QR_HBM_1V2_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_hbm_1v2_vol")}},
-  { qr_type::QR_2V5_VPP_MILLIVOLTS,        {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vpp2v5_vol")}},
-  { qr_type::QR_INT_BRAM_VCC_MILLIVOLTS,   {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vccint_bram_vol")}},
+  { qr_type::QR_3V3_PEX_MILLIAMPS,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_pex_curr")}},
+  { qr_type::QR_0V85_MILLIAMPS,            {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_0v85_curr")}},
+  { qr_type::QR_3V3_VCC_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_3v3_vcc_vol")}},
+  { qr_type::QR_HBM_1V2_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_hbm_1v2_vol")}},
+  { qr_type::QR_2V5_VPP_MILLIVOLTS,        {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vpp2v5_vol")}},
+  { qr_type::QR_INT_BRAM_VCC_MILLIVOLTS,   {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_vccint_bram_vol")}},
 
-  { qr_type::QR_FIREWALL_DETECT_LEVEL,     {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "firewall", "detected_level")}},
-  { qr_type::QR_FIREWALL_STATUS,           {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "firewall", "detected_status")}},
-  { qr_type::QR_FIREWALL_TIME_SEC,         {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "firewall", "detected_time")}},
+  { qr_type::QR_FIREWALL_DETECT_LEVEL,     {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "firewall", "detected_level")}},
+  { qr_type::QR_FIREWALL_STATUS,           {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "firewall", "detected_status")}},
+  { qr_type::QR_FIREWALL_TIME_SEC,         {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "firewall", "detected_time")}},
 
-  { qr_type::QR_POWER_MICROWATTS,          {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "xmc", "xmc_power")}},
+  { qr_type::QR_POWER_MICROWATTS,          {std::bind(sysfs_user, sp::_1, sp::_2, sp::_3, "xmc", "xmc_power")}},
 
-  { qr_type::QR_FLASH_BAR_OFFSET,          {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "flash", "bar_off")}},
-  { qr_type::QR_IS_MFG,                    {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "mfg")}},
-  { qr_type::QR_F_FLASH_TYPE,              {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "flash", "flash_type" )}},
-  { qr_type::QR_FLASH_TYPE,                {std::bind(sysfs, sp::_1, sp::_2, sp::_3, "", "flash_type" )}}
+  { qr_type::QR_FLASH_BAR_OFFSET,          {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "flash", "bar_off")}},
+  { qr_type::QR_IS_MFG,                    {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "", "mfg")}},
+  { qr_type::QR_F_FLASH_TYPE,              {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "flash", "flash_type" )}},
+  { qr_type::QR_FLASH_TYPE,                {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "", "flash_type" )}},
+  { qr_type::QR_BOARD_NAME,                {std::bind(sysfs_mgmt, sp::_1, sp::_2, sp::_3, "", "board_name" )}}
 };
 
 const query_entry&
@@ -260,7 +281,7 @@ void
 device_linux::
 read(uint64_t offset, void* buf, uint64_t len) const
 {
-  if (auto err = pcidev::get_dev(get_device_id())->pcieBarRead(offset, buf, len))
+  if (auto err = pcidev::get_dev(get_device_id(), false)->pcieBarRead(offset, buf, len))
     throw error(err, "read failed");
 }
 
@@ -268,7 +289,7 @@ void
 device_linux::
 write(uint64_t offset, const void* buf, uint64_t len) const
 {
-  if (auto err = pcidev::get_dev(get_device_id())->pcieBarWrite(offset, buf, len))
+  if (auto err = pcidev::get_dev(get_device_id(), false)->pcieBarWrite(offset, buf, len))
     throw error(err, "write failed");
 }
 

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -108,9 +108,9 @@ get_os_info(boost::property_tree::ptree &pt)
 
 std::pair<device::id_type, device::id_type>
 system_linux::
-get_total_devices() const
+get_total_devices(bool is_user) const
 {
-  return std::make_pair(pcidev::get_dev_total(), pcidev::get_dev_ready());
+  return std::make_pair(pcidev::get_dev_total(is_user), pcidev::get_dev_ready(is_user));
 }
 
 void

--- a/src/runtime_src/core/pcie/linux/system_linux.h
+++ b/src/runtime_src/core/pcie/linux/system_linux.h
@@ -31,7 +31,7 @@ public:
   get_os_info(boost::property_tree::ptree &pt);
 
   std::pair<device::id_type, device::id_type>
-  get_total_devices() const;
+  get_total_devices(bool is_user) const;
 
   void
   scan_devices(bool verbose, bool json) const;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1472,7 +1472,7 @@ public:
             //addr = 0xC00000000;//48GB = 3 hops
             addr = 0x400000000;//16GB = one hop
             sz = 0x20000;//128KB
-            long numHops = addr / ddr_mem_size;
+            long numHops = addr / get_ddr_mem_size();
             auto t1 = Clock::now();
             for (unsigned i = 0; i < numIteration; i++) {
                 memwriteQuiet(addr, sz, pattern);

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -65,6 +65,12 @@ mfg(const device_type*, qr_type, const std::type_info&, boost::any& value)
   value = false;
 }
 
+void
+board_name(const device_type*, qr_type, const std::type_info&, boost::any& value)
+{
+  value = std::string("TO-DO");
+}
+
 static void
 rom(const device_type* device, qr_type qr, const std::type_info&, boost::any& value)
 {
@@ -182,16 +188,16 @@ info_mgmt(const device_type* device, qr_type qr, const std::type_info&, boost::a
 
   switch (qr) {
   case qr_type::QR_PCIE_VENDOR:
-    value = info.pcie_info.vendor;
+    value = static_cast<uint64_t>(info.pcie_info.vendor);
     return;
   case qr_type::QR_PCIE_DEVICE:
-    value = info.pcie_info.device;
+    value = static_cast<uint64_t>(info.pcie_info.device);
     return;
   case qr_type::QR_PCIE_SUBSYSTEM_VENDOR:
-    value = info.pcie_info.subsystem_vendor;
+    value = static_cast<uint64_t>(info.pcie_info.subsystem_vendor);
     return;
   case qr_type::QR_PCIE_SUBSYSTEM_ID:
-    value = info.pcie_info.subsystem_device;
+    value = static_cast<uint64_t>(info.pcie_info.subsystem_device);
     return;
   default:
     throw std::runtime_error("device_windows::info_mgmt() unexpected qr " + std::to_string(qr));
@@ -522,6 +528,7 @@ get_IOCTL_entry(QueryRequest qr) const
     { QR_IS_MFG,                    { mfg }},
     { QR_F_FLASH_TYPE,              { flash_type }},
     { QR_FLASH_TYPE,                { flash_type }},
+    { QR_BOARD_NAME,                { board_name }}
   };
   // Find the translation entry
   std::map<QueryRequest, IOCTLEntry>::const_iterator it = QueryRequestToIOCTLTable.find(qr);

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -113,10 +113,14 @@ get_os_info(boost::property_tree::ptree &pt)
 
 std::pair<device::id_type, device::id_type>
 system_windows::
-get_total_devices() const
+get_total_devices(bool is_user) const
 {
-  auto user_count = xclProbe();
-  return std::make_pair(user_count, user_count);
+  uisigned int count = 0;
+  if (is_user)
+    count = xclProbe();
+  else
+    count = mgmtpf::probe();
+  return std::make_pair(count, count);
 }
 
 void

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -24,6 +24,7 @@
 #include "device_windows.h"
 #include "gen/version.h"
 #include "core/common/time.h"
+#include "mgmt.h"
 #include <memory>
 #include <ctime>
 #include <windows.h>
@@ -115,7 +116,7 @@ std::pair<device::id_type, device::id_type>
 system_windows::
 get_total_devices(bool is_user) const
 {
-  uisigned int count = 0;
+  unsigned int count = 0;
   if (is_user)
     count = xclProbe();
   else

--- a/src/runtime_src/core/pcie/windows/system_windows.h
+++ b/src/runtime_src/core/pcie/windows/system_windows.h
@@ -31,7 +31,7 @@ public:
   get_os_info(boost::property_tree::ptree &pt);
 
   std::pair<device::id_type, device::id_type>
-  get_total_devices() const;
+  get_total_devices(bool is_user) const;
 
   void
   scan_devices(bool verbose, bool json) const;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -291,7 +291,7 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id
 		
         // get filename without the path
         using tokenizer = boost::tokenizer< boost::char_separator<char> >;
-        boost::char_separator<char> sep("\\");
+        boost::char_separator<char> sep("\\/");
         tokenizer tokens(filename, sep);
         std::string dsafile = "";
         for (auto tok_iter = tokens.begin(); tok_iter != tokens.end(); ++tok_iter) {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.h
@@ -31,7 +31,7 @@
 
 // directory where all MCS files are saved
 #define FIRMWARE_WIN_DIR    "C:\\Xilinx"
-#define FIRMWARE_DIR        "/lib/xilinx/firmware"
+#define FIRMWARE_DIR        "/lib/firmware/xilinx"
 #define FORMATTED_FW_DIR    "/opt/xilinx/firmware"
 #define DSA_FILE_SUFFIX     "mcs"
 #define DSABIN_FILE_SUFFIX  "dsabin"


### PR DESCRIPTION
- separated get_total_devices for user and mgmt pf
- factory_reset works on linux and windows
- flash --scan works on linux and windows
- flash --scan on windows doesn't work when in the golden state. Might is a driver issue, will look into it next week
- a Coverity fix