### PR TITLE
Add hook to direct OpenCL to acquire exclusive CU access

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -479,7 +479,8 @@ xclGetComputeUnitInfo(cl_kernel             kernel,
 #define CL_PROGRAM_TARGET_TYPE          0x1110
 
 // cl_device_info
-#define CL_DEVICE_PCIE_BDF              0x1120
+#define CL_DEVICE_PCIE_BDF              0x1120  // BUS/DEVICE/FUNCTION
+#define CL_DEVICE_HANDLE                0x1121  // XRT device handle
 
 // valid target types (CR962714)
 typedef cl_uint cl_program_target_type;

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -400,6 +400,16 @@ get_kernel_channel_info()
   return value;
 }
 
+/**
+ * Direct OpenCL kernel execution to acquire exclusive context on CU
+ */
+inline bool
+get_exclusive_cu_context()
+{
+  static bool value = detail::get_bool_value("Runtime.exclusive_cu_context", false);
+  return value;
+}
+
 }} // config,xrt_core
 
 #endif

--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -304,6 +304,9 @@ clGetDeviceInfo(cl_device_id   device,
   case CL_DEVICE_PCIE_BDF:
     buffer.as<char>() = xdevice->get_bdf();
     break;
+  case CL_DEVICE_HANDLE:
+    buffer.as<void*>() = xdevice->get_handle();
+    break;
   default:
     throw error(CL_INVALID_VALUE,"clGetDeviceInfo: invalid param_name");
     break;

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -243,6 +243,15 @@ get_bdf() const
   throw xocl::error(CL_INVALID_DEVICE, "No BDF");
 }
 
+void*
+device::
+get_handle() const
+{
+  if (m_xdevice)
+    return m_xdevice->get_handle();
+  throw xocl::error(CL_INVALID_DEVICE, "No device handle");
+}
+
 void
 device::
 track(const memory* mem)
@@ -1308,8 +1317,10 @@ unload_program(const program* program)
 
 bool
 device::
-acquire_context(const compute_unit* cu, bool shared) const
+acquire_context(const compute_unit* cu) const
 {
+  static bool shared = xrt::config::get_exclusive_cu_context() ? false : true;
+
   std::lock_guard<std::mutex> lk(m_mutex);
   if (cu->m_context_type != compute_unit::context_type::none)
     return true;

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -175,6 +175,12 @@ public:
   get_bdf() const;
 
   /**
+   * Get underlying driver device handle
+   */
+  void*
+  get_handle() const;
+
+  /**
    * Get the number of DDR memory banks on the current device
    *
    * @return
@@ -687,15 +693,16 @@ public:
   }
 
   /**
-   * Acquire a context for a given compute unit on this device
+   * Acquire a context for a given compute unit on this device.
    *
-   * Throws exception if context cannot be acquired on device
+   * By default the context is acquired as shared.
+   * Throws exception if context cannot be acquired on device.
    *
    * @return
    *   @true on success, @false if no program loaded.
    */
   bool
-  acquire_context(const compute_unit* cu, bool shared=true) const;
+  acquire_context(const compute_unit* cu) const;
 
   /**
    * Release a context for a given compute unit on this device


### PR DESCRIPTION
This allows host application to use OpenCL with native XRT xclRegRead(2).

```
% cat xrt.ini
[Runtime]
exclusive_cu_context=true
```
or
`% env Runtime.exclusive_cu_context=true ./host.exe ...`

Add CL_DEVICE_HANDLE to get shim device handle from cl_device

```
void* handle = nullptr;
clGetDeviceInfo(device.get(),CL_DEVICE_HANDLE,sizeof(void*),&handle,nullptr);
```

```
uint32_t above_limit_hw;
xclRegRead(handle, 0, REG_OFFSET_ABOVE_LIMIT, &above_limit_hw);
```