### PR TITLE
xbmgmt: add cmd to enable/disable Runtime CS feature

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
  *
  * Authors: chienwei@xilinx.com
  *
@@ -112,6 +112,7 @@
 #define	XMC_CLOCK_SCALING_MODE_REG	0x10
 #define	XMC_CLOCK_SCALING_MODE_POWER	0x0
 #define	XMC_CLOCK_SCALING_MODE_TEMP	0x1
+#define	XMC_CLOCK_SCALING_MODE_POWER_TEMP	0x2
 
 #define	XMC_CLOCK_SCALING_POWER_REG	0x18
 #define	XMC_CLOCK_SCALING_POWER_TARGET_MASK 0xFF
@@ -313,6 +314,9 @@ struct xocl_xmc {
 	ktime_t			cache_expires;
 	/* Runtime clock scaling enabled status */
 	bool			runtime_cs_enabled;
+	u32			sc_presence;
+	/* Runtime clock scaling support on platform */
+	bool			cs_on_ptfm;
 
 	/* XMC mailbox support. */
 	struct mutex		mbx_lock;
@@ -1260,7 +1264,7 @@ static ssize_t scaling_governor_show(struct device *dev,
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
 	u32 mode;
-	char val[10];
+	char val[20];
 
 	if (!xmc->runtime_cs_enabled) {
 		xocl_warn(dev, "%s: runtime clock scaling is not supported\n",
@@ -1279,6 +1283,9 @@ static ssize_t scaling_governor_show(struct device *dev,
 		break;
 	case 1:
 		strcpy(val, "temp");
+		break;
+	case 2:
+		strcpy(val, "power_temp");
 		break;
 	}
 
@@ -1302,6 +1309,8 @@ static ssize_t scaling_governor_store(struct device *dev,
 		val = XMC_CLOCK_SCALING_MODE_POWER;
 	else if (strncmp(buf, "temp", strlen("temp")) == 0)
 		val = XMC_CLOCK_SCALING_MODE_TEMP;
+	else if (strncmp(buf, "power_temp", strlen("power_temp")) == 0)
+		val = XMC_CLOCK_SCALING_MODE_POWER_TEMP;
 	else {
 		xocl_err(dev, "valid modes [power, temp]\n");
 		return -EINVAL;
@@ -1314,6 +1323,43 @@ static ssize_t scaling_governor_store(struct device *dev,
 	return count;
 }
 static DEVICE_ATTR_RW(scaling_governor);
+
+static ssize_t sc_presence_show(struct device *dev,
+	struct device_attribute *da, char *buf)
+{
+	struct xocl_xmc *xmc = dev_get_drvdata(dev);
+
+	return sprintf(buf, "%d\n", xmc->sc_presence);
+}
+static DEVICE_ATTR_RO(sc_presence);
+
+static ssize_t scaling_enabled_store(struct device *dev,
+	struct device_attribute *da, const char *buf, size_t count)
+{
+	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
+	u32 val = 0, cntrl;
+
+	/* Check if clock scaling feature enabled */
+	if (!xmc->runtime_cs_enabled) {
+		if (!XMC_PRIVILEGED(xmc))
+			xocl_warn(dev, "%s: runtime clock scaling support enabled only in privileged mode\n", __func__);
+		else if (xmc->cs_on_ptfm)
+			xocl_warn(dev, "%s: runtime clock scaling is not enabled on this platform\n", __func__);
+		else
+			xocl_warn(dev, "%s: runtime clock scaling is not supported on this platform\n", __func__);
+		return count;
+	}
+
+	if (strncmp(buf, "enable", strlen("enable")) == 0)
+		val = XMC_CLOCK_SCALING_EN;
+
+	cntrl = READ_RUNTIME_CS(xmc, XMC_CLOCK_CONTROL_REG);
+	cntrl &= ~XMC_CLOCK_SCALING_EN_MASK;
+	cntrl |= val;
+	WRITE_RUNTIME_CS(xmc, cntrl, XMC_CLOCK_CONTROL_REG);
+
+	return count;
+}
 
 static ssize_t scaling_enabled_show(struct device *dev,
 	struct device_attribute *da, char *buf)
@@ -1334,7 +1380,7 @@ static ssize_t scaling_enabled_show(struct device *dev,
 	mutex_unlock(&xmc->xmc_lock);
 	return sprintf(buf, "%d\n", val);
 }
-static DEVICE_ATTR_RO(scaling_enabled);
+static DEVICE_ATTR_RW(scaling_enabled);
 
 static ssize_t hwmon_scaling_target_power_show(struct device *dev,
 	struct device_attribute *da, char *buf)
@@ -1582,6 +1628,7 @@ static struct attribute *xmc_attrs[] = {
 	&dev_attr_max_power.attr,
 	&dev_attr_fan_presence.attr,
 	&dev_attr_config_mode.attr,
+	&dev_attr_sc_presence.attr,
 	SENSOR_SYSFS_NODE_ATTRS,
 	REG_SYSFS_NODE_ATTRS,
 	NULL,
@@ -2662,6 +2709,9 @@ static int xmc_probe(struct platform_device *pdev)
 	}
 
 	xmc->cache_expire_secs = XMC_DEFAULT_EXPIRE_SECS;
+	xmc->sc_presence = 1;
+	if (nosc_xmc(xmc->pdev))
+		xmc->sc_presence = 0;
 
 	/*
 	 * Enabling XMC clock scaling support.
@@ -2670,6 +2720,7 @@ static int xmc_probe(struct platform_device *pdev)
 	 */
 	if (XMC_PRIVILEGED(xmc) && xocl_clk_scale_on(xdev_hdl)) {
 		xmc->runtime_cs_enabled = true;
+		xmc->cs_on_ptfm = true;
 		xocl_info(&pdev->dev, "Runtime clock scaling is supported.\n");
 	}
 
@@ -2834,7 +2885,7 @@ static bool is_sc_ready(struct xocl_xmc *xmc, bool quiet)
 		return true;
 
 	if (nosc_xmc(xmc->pdev))
-		return true;
+		return false;
 
 	safe_read32(xmc, XMC_STATUS_REG, &val);
 	val >>= 28;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1312,7 +1312,7 @@ static ssize_t scaling_governor_store(struct device *dev,
 	else if (strncmp(buf, "power_temp", strlen("power_temp")) == 0)
 		val = XMC_CLOCK_SCALING_MODE_POWER_TEMP;
 	else {
-		xocl_err(dev, "valid modes [power, temp]\n");
+		xocl_err(dev, "valid modes [power, temp, power_temp]\n");
 		return -EINVAL;
 	}
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@
 const char *subCmdConfigDesc = "Parse or update daemon/device configuration";
 const char *subCmdConfigUsage =
     "--daemon --host ip-or-hostname-for-peer\n"
-    "--device [--card bdf] --security level\n"
+    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able]\n"
     "--show [--daemon | --device [--card bdf] ]";
 
 static struct config {
@@ -155,10 +155,23 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
     if (!errmsg.empty()) {
         std::cout << "can't read security level from " << dev->sysfs_name <<
             " : " << errmsg << std::endl;
-        return;
+        goto clk_scale;
     }
     std::cout << dev->sysfs_name << ":" << std::endl;
     std::cout << "\t" << "security level: " << lvl << std::endl;
+
+clk_scale:
+    lvl = 0;
+    errmsg = "";
+    dev->sysfs_get("xmc", "scaling_enabled", errmsg, lvl, 0);
+    if (!errmsg.empty()) {
+        std::cout << "can't read scaling_enabled status from " <<
+            dev->sysfs_name << " : " << errmsg << std::endl;
+        return;
+    }
+    std::cout << dev->sysfs_name << ":" << std::endl;
+    std::cout << "\t" << "Runtime clock scaling enabled status: " <<
+        lvl << std::endl;
 }
 
 static int show(int argc, char *argv[])
@@ -225,14 +238,27 @@ static int show(int argc, char *argv[])
 }
 
 static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
-    std::string lvl)
+    std::string lvl, int config_type)
 {
     std::string errmsg;
-    dev->sysfs_put("icap", "sec_level", errmsg, lvl);
-    if (!errmsg.empty()) {
-        std::cout << "Failed to set security level for " << dev->sysfs_name
-            << std::endl;
-        std::cout << "See dmesg log for details" << std::endl;
+
+    switch(config_type) {
+    case 0:
+        dev->sysfs_put("icap", "sec_level", errmsg, lvl);
+        if (!errmsg.empty()) {
+            std::cout << "Failed to set security level for " << dev->sysfs_name
+                << std::endl;
+            std::cout << "See dmesg log for details" << std::endl;
+        }
+        break;
+    case 1:
+        dev->sysfs_put("xmc", "scaling_enabled", errmsg, lvl);
+        if (!errmsg.empty()) {
+            std::cout << "Failed to update clk scaling status for " <<
+                dev->sysfs_name	<< std::endl;
+            std::cout << "See dmesg log for details" << std::endl;
+        }
+        break;
     }
 }
 
@@ -240,9 +266,11 @@ static int device(int argc, char *argv[])
 {
     unsigned int index = UINT_MAX;
     std::string lvl;
+    int config_type = -1;
     const option opts[] = {
         { "card", required_argument, nullptr, '0' },
         { "security", required_argument, nullptr, '1' },
+        { "runtime_clk_scale", required_argument, nullptr, '2' },
         { nullptr, 0, nullptr, 0 },
     };
 
@@ -259,6 +287,11 @@ static int device(int argc, char *argv[])
             break;
         case '1':
             lvl = optarg;
+            config_type = 0;
+            break;
+        case '2':
+            lvl = optarg;
+            config_type = 1;
             break;
         default:
             return -EINVAL;
@@ -270,13 +303,13 @@ static int device(int argc, char *argv[])
 
     if (index != UINT_MAX) {
         auto dev = pcidev::get_dev(index, false);
-        updateDevConf(dev, lvl);
+        updateDevConf(dev, lvl, config_type);
         return 0;
     }
 
     for (unsigned i = 0; i < pcidev::get_dev_total(false); i++) {
         auto dev = pcidev::get_dev(i, false);
-        updateDevConf(dev, lvl);
+        updateDevConf(dev, lvl, config_type);
     }
 
     return 0;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -37,10 +37,11 @@ static struct config {
 
 static const std::string configFile("/etc/msd.conf");
 
-enum configType {
+enum configs {
     CONFIG_SECURITY = 0,
     CONFIG_CLK_SCALING,
 };
+typedef configs configType;
 
 static int splitLine(std::string& line, std::string& key, std::string& value)
 {
@@ -241,8 +242,8 @@ static int show(int argc, char *argv[])
     return 0;
 }
 
-static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
-    const std::string lvl, int config_type)
+static void updateDevConf(pcidev::pci_device *dev,
+    const std::string lvl, configType config_type)
 {
     std::string errmsg;
 
@@ -270,7 +271,7 @@ static int device(int argc, char *argv[])
 {
     unsigned int index = UINT_MAX;
     std::string lvl;
-    int config_type = -1;
+    configType config_type = (configType)-1;
     const option opts[] = {
         { "card", required_argument, nullptr, '0' },
         { "security", required_argument, nullptr, '1' },
@@ -307,13 +308,13 @@ static int device(int argc, char *argv[])
 
     if (index != UINT_MAX) {
         auto dev = pcidev::get_dev(index, false);
-        updateDevConf(dev, lvl, config_type);
+        updateDevConf(dev.get(), lvl, config_type);
         return 0;
     }
 
     for (unsigned i = 0; i < pcidev::get_dev_total(false); i++) {
         auto dev = pcidev::get_dev(i, false);
-        updateDevConf(dev, lvl, config_type);
+        updateDevConf(dev.get(), lvl, config_type);
     }
 
     return 0;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -159,10 +159,10 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
     dev->sysfs_get("icap", "sec_level", errmsg, lvl, 0);
     if (!errmsg.empty()) {
         std::cout << "can't read security level from " << dev->sysfs_name <<
-            " : " << errmsg << std::endl;
+            " : " << errmsg << "\n";
     } else {
-        std::cout << dev->sysfs_name << ":" << std::endl;
-        std::cout << "\t" << "security level: " << lvl << std::endl;
+        std::cout << dev->sysfs_name << ":\n";
+        std::cout << "\t" << "security level: " << lvl << "\n";
     }
 
     lvl = 0;
@@ -172,7 +172,7 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
         std::cout << "can't read scaling_enabled status from " <<
             dev->sysfs_name << " : " << errmsg << std::endl;
     } else {
-        std::cout << dev->sysfs_name << ":" << std::endl;
+        std::cout << dev->sysfs_name << ":\n";
         std::cout << "\t" << "Runtime clock scaling enabled status: " <<
             lvl << std::endl;
     }
@@ -242,7 +242,7 @@ static int show(int argc, char *argv[])
 }
 
 static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
-    std::string lvl, int config_type)
+    const std::string lvl, int config_type)
 {
     std::string errmsg;
 
@@ -250,8 +250,8 @@ static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
     case CONFIG_SECURITY:
         dev->sysfs_put("icap", "sec_level", errmsg, lvl);
         if (!errmsg.empty()) {
-            std::cout << "Failed to set security level for " << dev->sysfs_name
-                << std::endl;
+            std::cout << "Failed to set security level for " <<
+                dev->sysfs_name << "\n";
             std::cout << "See dmesg log for details" << std::endl;
         }
         break;
@@ -259,7 +259,7 @@ static void updateDevConf(std::shared_ptr<pcidev::pci_device>& dev,
         dev->sysfs_put("xmc", "scaling_enabled", errmsg, lvl);
         if (!errmsg.empty()) {
             std::cout << "Failed to update clk scaling status for " <<
-                dev->sysfs_name << std::endl;
+                dev->sysfs_name << "\n";
             std::cout << "See dmesg log for details" << std::endl;
         }
         break;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -504,10 +504,10 @@ bool XMC_Flasher::isXMCReady()
 bool XMC_Flasher::isBMCReady(std::shared_ptr<pcidev::pci_device> dev)
 {
     bool bmcReady = true;
-    int val;
+    unsigned int val;
     std::string errmsg;
 
-    dev->sysfs_get("xmc", "sc_presence", errmsg, val);
+    dev->sysfs_get<unsigned>("xmc", "sc_presence", errmsg, val, 0);
     if (!errmsg.empty()) {
         std::cout << "can't read sc_presence node from " << dev->sysfs_name <<
             " : " << errmsg << std::endl;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -503,7 +503,6 @@ bool XMC_Flasher::isXMCReady()
 
 bool XMC_Flasher::isBMCReady()
 {
-    bool bmcReady = true;
     unsigned int val;
     std::string errmsg;
 
@@ -515,7 +514,7 @@ bool XMC_Flasher::isBMCReady()
     }
 
     if (val) {
-        bmcReady = (BMC_MODE() == 0x1);
+        bool bmcReady = (BMC_MODE() == 0x1);
         if (!bmcReady) {
             xrt_core::ios_flags_restore format(std::cout);
             std::cout << "ERROR: SC is not ready: 0x" << std::hex
@@ -524,7 +523,7 @@ bool XMC_Flasher::isBMCReady()
         return bmcReady;
     }
 
-    return bmcReady;
+    return true;
 }
 
 static void tiTxtStreamToBin(std::istream& tiTxtStream,

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -226,7 +226,7 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
     }
     std::cout << std::endl;
 
-    if (!isBMCReady(mDev)) {
+    if (!isBMCReady()) {
         std::cout << "ERROR: Time'd out waiting for SC to come back online"
             << std::endl;
         return -ETIMEDOUT;
@@ -253,7 +253,7 @@ int XMC_Flasher::xclGetBoardInfo(std::map<char, std::vector<char>>& info)
 {
     int ret = 0;
 
-    if (!isXMCReady() || !isBMCReady(mDev))
+    if (!isXMCReady() || !isBMCReady())
         return -EINVAL;
 
     mPkt = {0};
@@ -501,20 +501,19 @@ bool XMC_Flasher::isXMCReady()
     return xmcReady;
 }
 
-bool XMC_Flasher::isBMCReady(std::shared_ptr<pcidev::pci_device> dev)
+bool XMC_Flasher::isBMCReady()
 {
     bool bmcReady = true;
     unsigned int val;
     std::string errmsg;
 
-    dev->sysfs_get<unsigned>("xmc", "sc_presence", errmsg, val, 0);
+    mDev->sysfs_get<unsigned>("xmc", "sc_presence", errmsg, val, 0);
     if (!errmsg.empty()) {
-        std::cout << "can't read sc_presence node from " << dev->sysfs_name <<
+        std::cout << "can't read sc_presence node from " << mDev->sysfs_name <<
             " : " << errmsg << std::endl;
         return false;
     }
 
-    std::cout << "sc_presence: " << val << std::endl;
     if (val) {
         bmcReady = (BMC_MODE() == 0x1);
         if (!bmcReady) {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
@@ -124,7 +124,7 @@ private:
     unsigned readReg(unsigned RegOffset);
     int writeReg(unsigned RegOffset, unsigned value);
     bool isXMCReady();
-    bool isBMCReady();
+    bool isBMCReady(std::shared_ptr<pcidev::pci_device> dev);
 
     // Upgrade SC firmware via driver.
     std::FILE *mXmcDev = nullptr;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
@@ -124,7 +124,7 @@ private:
     unsigned readReg(unsigned RegOffset);
     int writeReg(unsigned RegOffset, unsigned value);
     bool isXMCReady();
-    bool isBMCReady(std::shared_ptr<pcidev::pci_device> dev);
+    bool isBMCReady();
 
     // Upgrade SC firmware via driver.
     std::FILE *mXmcDev = nullptr;


### PR DESCRIPTION
Add new sub command runtime_clk_scale under config command
in xbmgmt tool to enable/disable runtime clock scaling
feature at runtime using xbmgmt tool

Read SC ready state only when SC is present on the platform in xbmgmt.

Enable power_temp mode for clock scaling feature. Fix for CR-1047381,
and it is integrated from 19.2 branch

CRs:1051402, 1051400, 1047476 and 1044306

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>