### PR TITLE
add subdev register functions to update/remove operations

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1353,3 +1353,29 @@ int xocl_subdev_create_prp(xdev_handle_t xdev)
 failed:
 	return ret;
 }
+
+void xocl_subdev_register(struct platform_device *pldev, void *ops)
+{
+	struct xocl_subdev *subdev;
+
+	subdev = xocl_subdev_lookup(pldev);
+	if (!subdev) {
+		xocl_err(&pldev->dev, "did not find subdev");
+		return;
+	}
+
+	subdev->ops = ops;
+}
+
+void xocl_subdev_unregister(struct platform_device *pldev)
+{
+	struct xocl_subdev *subdev;
+
+	subdev = xocl_subdev_lookup(pldev);
+	if (!subdev) {
+		xocl_err(&pldev->dev, "did not find subdev");
+		return;
+	}
+
+	subdev->ops = NULL;
+}


### PR DESCRIPTION
Add register functions. In case to driver_override another driver for a device, the sub driver could call these register functions while probe/remove to update the subdev ops.