### PR TITLE
Partition BRAM to be shared by versal ospi and cmc

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2018-2019, Xilinx Inc
+ *  Copyright (C) 2018-2020, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -1066,7 +1066,7 @@ struct xocl_subdev_map {
 #define	XOCL_RES_OSPI_VERSAL				\
 		((struct resource []) {			\
 			{				\
-			.start	= 0x3000000,		\
+			.start	= 0x3008000,		\
 			.end	= 0x300FFFF,		\
 			.flags	= IORESOURCE_MEM,	\
 			}				\


### PR DESCRIPTION
The 64K BRAM which was used by versal ospi should be partioned and shared with cmc. Cmc will use the first 32K and versal OSPI will use the rest.

This PR addresses the partition as well as fixing some soft lockup cause by shrinking the size of BRAM.