### PR TITLE
Check for local network access

### DIFF
--- a/src/runtime_src/ert/CMakeLists.txt
+++ b/src/runtime_src/ert/CMakeLists.txt
@@ -7,8 +7,14 @@ message("-- MicroBlaze toolchain found, preparing ERT build")
 
 add_subdirectory(scheduler)
 add_subdirectory(management)
+
+# CMC and BMC require gitenterprise access, disable if no access
+# Improve this test to check for url access to gitenterprise.xilinx.com
+if (EXISTS /tools/batonroot/rodin/devkits)
+message("-- Preparing cmc and bmc legacy")
 add_subdirectory(cmc)
 add_subdirectory(bmc)
+endif()
 
 add_custom_target(ert ALL
  DEPENDS scheduler management cmc bmc


### PR DESCRIPTION
This is to prevent URL timeouts when it is known that
gitenterprise.xilinx.com cannot be accessed.  The test
itself should be improved; as is, it is a quick stopgap.