### PR TITLE
update versal device tree with BRAM partition

### DIFF
--- a/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_versal_pcie.dts
+++ b/src/runtime_src/core/edge/fragments/xlnk_dts_fragment_versal_pcie.dts
@@ -30,6 +30,6 @@
 	ospi_versal {
 		compatible = "xlnx,ospi_versal";
 		status = "okay";
-		reg = <0x201 0x3000000 0x0 0x10000>;
+		reg = <0x201 0x3008000 0x0 0x8000>;
 	};
 };


### PR DESCRIPTION
Update device tree to use higher 32K of BRAM for versal ospi. The lower 32K is used by CMC.