### PR TITLE
xbmgmt: Add sub command to override threshold power in clk scaling feature

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -353,7 +353,7 @@ static int stop_xmc(struct platform_device *pdev);
 static void xmc_clk_scale_config(struct platform_device *pdev);
 static int xmc_load_board_info(struct xocl_xmc *xmc);
 static int cmc_access_ops(struct platform_device *pdev, int flags);
-static bool scaling_condition_check(struct xocl_xmc *xmc);
+static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev);
 
 static void set_sensors_data(struct xocl_xmc *xmc, struct xcl_sensor *sensors)
 {
@@ -1303,7 +1303,7 @@ static int get_temp_by_m_tag(struct xocl_xmc *xmc, char *m_tag)
 }
 
 /* Runtime clock scaling sysfs node */
-static bool scaling_condition_check(struct xocl_xmc *xmc)
+static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev)
 {
 	if (!xmc->runtime_cs_enabled) {
 		if (!XMC_PRIVILEGED(xmc))
@@ -1324,7 +1324,7 @@ static ssize_t scaling_threshold_power_override_en_show(struct device *dev,
 	u32 val = 0;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
@@ -1344,7 +1344,7 @@ static ssize_t scaling_threshold_power_override_show(struct device *dev,
 	u32 val = 0;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
@@ -1363,7 +1363,7 @@ static ssize_t scaling_threshold_power_override_store(struct device *dev,
 	u32 val, val2, val3;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return count;
 
@@ -1401,7 +1401,7 @@ static ssize_t scaling_governor_show(struct device *dev,
 	char val[20];
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en) {
 		strcpy(val, "NULL");
 		return sprintf(buf, "%s\n", val);
@@ -1434,7 +1434,7 @@ static ssize_t scaling_governor_store(struct device *dev,
 	bool cs_en;
 
 	/* Check if clock scaling feature enabled */
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return count;
 
@@ -1473,7 +1473,7 @@ static ssize_t scaling_enabled_store(struct device *dev,
 	bool cs_en;
 
 	/* Check if clock scaling feature enabled */
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return count;
 
@@ -1492,7 +1492,7 @@ static ssize_t scaling_enabled_show(struct device *dev,
 	u32 val = 0;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
@@ -1515,7 +1515,7 @@ static ssize_t hwmon_scaling_target_power_show(struct device *dev,
 	u32 val = 0;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
@@ -1535,7 +1535,7 @@ static ssize_t hwmon_scaling_target_power_store(struct device *dev,
 	u32 val, val2, threshold;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return count;
 
@@ -1571,7 +1571,7 @@ static ssize_t hwmon_scaling_target_temp_show(struct device *dev,
 	u32 val = 0;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
@@ -1592,7 +1592,7 @@ static ssize_t hwmon_scaling_target_temp_store(struct device *dev,
 	bool cs_en;
 
 	/* Check if clock scaling feature enabled */
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return count;
 
@@ -1626,7 +1626,7 @@ static ssize_t hwmon_scaling_threshold_temp_show(struct device *dev,
 	u32 val = 0;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
@@ -1647,7 +1647,7 @@ static ssize_t hwmon_scaling_threshold_power_show(struct device *dev,
 	u32 val = 0, val2;
 	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc);
+	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -2886,10 +2886,21 @@ static int xmc_probe(struct platform_device *pdev)
 	 * clk scaling can only be enabled on mgmt side, why do we set
 	 * the enabled bit in feature ROM on user side at all?
 	 */
-	if (XMC_PRIVILEGED(xmc) && xocl_clk_scale_on(xdev_hdl)) {
-		xmc->runtime_cs_enabled = true;
-		xmc->cs_on_ptfm = true;
-		xocl_info(&pdev->dev, "Runtime clock scaling is supported.\n");
+	if (XMC_PRIVILEGED(xmc)) {
+		if (!xmc->sc_presence) {
+			if (xocl_clk_scale_on(xdev_hdl)) {
+				xmc->runtime_cs_enabled = true;
+				xmc->cs_on_ptfm = true;
+			}
+		} else {
+			u32 reg = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
+			if (reg & (1 << 29)) {
+				xmc->runtime_cs_enabled = true;
+				xmc->cs_on_ptfm = true;
+			}
+		}
+		if (xmc->runtime_cs_enabled)
+			xocl_info(&pdev->dev, "Runtime clock scaling is supported.\n");
 	}
 
 	return 0;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -28,7 +28,7 @@
 const char *subCmdConfigDesc = "Parse or update daemon/device configuration";
 const char *subCmdConfigUsage =
     "--daemon --host ip-or-hostname-for-peer\n"
-    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able] [--csThresholdPowerOverride val]\n"
+    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able] [--cs_threshold_power_override val]\n"
     "--show [--daemon | --device [--card bdf] ]";
 
 static struct config {
@@ -129,7 +129,7 @@ static int daemon(int argc, char *argv[])
     // Write it back.
     std::ofstream cfile(configFile);
     if (!cfile.good()) {
-        std::cout << "Can't open config file for writing" << std::endl;
+        std::cout << "Error: Can't open config file for writing" << std::endl;
         return -EINVAL;
     }
 
@@ -160,8 +160,8 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
 
     dev->sysfs_get("icap", "sec_level", errmsg, lvl, 0);
     if (!errmsg.empty()) {
-        std::cout << "can't read security level from " << dev->sysfs_name <<
-            " : " << errmsg << "\n";
+        std::cout << "Error: can't read security level from " << dev->sysfs_name
+			<< " : " << errmsg << "\n";
     } else {
         std::cout << dev->sysfs_name << ":\n";
         std::cout << "\t" << "security level: " << lvl << "\n";
@@ -171,7 +171,7 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
     errmsg = "";
     dev->sysfs_get("xmc", "scaling_enabled", errmsg, lvl, 0);
     if (!errmsg.empty()) {
-        std::cout << "can't read scaling_enabled status from " <<
+        std::cout << "Error: can't read scaling_enabled status from " <<
             dev->sysfs_name << " : " << errmsg << std::endl;
     } else {
         std::cout << dev->sysfs_name << ":\n";
@@ -182,8 +182,8 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
     errmsg = "";
     dev->sysfs_get("xmc", "scaling_threshold_power_override", errmsg, svl);
     if (!errmsg.empty()) {
-        std::cout << "can't read scaling_threshold_power_override from " <<
-            dev->sysfs_name << " : " << errmsg << std::endl;
+        std::cout << "Error: can't read scaling_threshold_power_override from "
+			<< dev->sysfs_name << " : " << errmsg << std::endl;
     } else {
         std::cout << dev->sysfs_name << ":\n";
         std::cout << "\t" << "scaling_threshold_power_override: " <<
@@ -263,7 +263,7 @@ static void updateDevConf(pcidev::pci_device *dev,
     case CONFIG_SECURITY:
         dev->sysfs_put("icap", "sec_level", errmsg, lvl);
         if (!errmsg.empty()) {
-            std::cout << "Failed to set security level for " <<
+            std::cout << "Error: Failed to set security level for " <<
                 dev->sysfs_name << "\n";
             std::cout << "See dmesg log for details" << std::endl;
         }
@@ -271,7 +271,7 @@ static void updateDevConf(pcidev::pci_device *dev,
     case CONFIG_CLK_SCALING:
         dev->sysfs_put("xmc", "scaling_enabled", errmsg, lvl);
         if (!errmsg.empty()) {
-            std::cout << "Failed to update clk scaling status for " <<
+            std::cout << "Error: Failed to update clk scaling status for " <<
                 dev->sysfs_name << "\n";
             std::cout << "See dmesg log for details" << std::endl;
         }
@@ -279,7 +279,7 @@ static void updateDevConf(pcidev::pci_device *dev,
     case CONFIG_CS_THRESHOLD_POWER_OVERRIDE:
         dev->sysfs_put("xmc", "scaling_threshold_power_override", errmsg, lvl);
         if (!errmsg.empty()) {
-            std::cout << "Failed to update clk scaling power threshold for " <<
+            std::cout << "Error: Failed to update clk scaling power threshold for " <<
                 dev->sysfs_name << "\n";
             std::cout << "See dmesg log for details" << std::endl;
         }
@@ -296,7 +296,7 @@ static int device(int argc, char *argv[])
         { "card", required_argument, nullptr, '0' },
         { "security", required_argument, nullptr, '1' },
         { "runtime_clk_scale", required_argument, nullptr, '2' },
-        { "csThresholdPowerOverride", required_argument, nullptr, '3' },
+        { "cs_threshold_power_override", required_argument, nullptr, '3' },
         { nullptr, 0, nullptr, 0 },
     };
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -28,7 +28,7 @@
 const char *subCmdConfigDesc = "Parse or update daemon/device configuration";
 const char *subCmdConfigUsage =
     "--daemon --host ip-or-hostname-for-peer\n"
-    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able]\n"
+    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able] [--csThresholdPowerOverride val]\n"
     "--show [--daemon | --device [--card bdf] ]";
 
 static struct config {
@@ -40,6 +40,7 @@ static const std::string configFile("/etc/msd.conf");
 enum configs {
     CONFIG_SECURITY = 0,
     CONFIG_CLK_SCALING,
+    CONFIG_CS_THRESHOLD_POWER_OVERRIDE,
 };
 typedef configs configType;
 
@@ -154,7 +155,7 @@ static void showDaemonConf(void)
 
 static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
 {
-    std::string errmsg;
+    std::string errmsg, svl;
     int lvl = 0;
 
     dev->sysfs_get("icap", "sec_level", errmsg, lvl, 0);
@@ -176,6 +177,17 @@ static void showDevConf(std::shared_ptr<pcidev::pci_device>& dev)
         std::cout << dev->sysfs_name << ":\n";
         std::cout << "\t" << "Runtime clock scaling enabled status: " <<
             lvl << std::endl;
+    }
+
+    errmsg = "";
+    dev->sysfs_get("xmc", "scaling_threshold_power_override", errmsg, svl);
+    if (!errmsg.empty()) {
+        std::cout << "can't read scaling_threshold_power_override from " <<
+            dev->sysfs_name << " : " << errmsg << std::endl;
+    } else {
+        std::cout << dev->sysfs_name << ":\n";
+        std::cout << "\t" << "scaling_threshold_power_override: " <<
+            svl << std::endl;
     }
 }
 
@@ -264,6 +276,14 @@ static void updateDevConf(pcidev::pci_device *dev,
             std::cout << "See dmesg log for details" << std::endl;
         }
         break;
+    case CONFIG_CS_THRESHOLD_POWER_OVERRIDE:
+        dev->sysfs_put("xmc", "scaling_threshold_power_override", errmsg, lvl);
+        if (!errmsg.empty()) {
+            std::cout << "Failed to update clk scaling power threshold for " <<
+                dev->sysfs_name << "\n";
+            std::cout << "See dmesg log for details" << std::endl;
+        }
+        break;
     }
 }
 
@@ -276,6 +296,7 @@ static int device(int argc, char *argv[])
         { "card", required_argument, nullptr, '0' },
         { "security", required_argument, nullptr, '1' },
         { "runtime_clk_scale", required_argument, nullptr, '2' },
+        { "csThresholdPowerOverride", required_argument, nullptr, '3' },
         { nullptr, 0, nullptr, 0 },
     };
 
@@ -297,6 +318,10 @@ static int device(int argc, char *argv[])
         case '2':
             lvl = optarg;
             config_type = CONFIG_CLK_SCALING;
+            break;
+        case '3':
+            lvl = optarg;
+            config_type = CONFIG_CS_THRESHOLD_POWER_OVERRIDE;
             break;
         default:
             return -EINVAL;


### PR DESCRIPTION
Added sub command --csThresholdPowerOverride to override
threshold power value in clock scaling feature.
  Complete command looks like:
  $xbmgmt config --device --csThresholdPowerOverride 55

  And, command to disable override threshold power value:
  $xbmgmt config --device --csThresholdPowerOverride 0

Added required changes in xmc driver to support this.

CR-1051402

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>