### PR TITLE
Fixing ert issue in emulation

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -67,6 +67,7 @@ namespace xclemulation{
     mKeepRunDir=false;
     mLauncherArgs = "";
     mSystemDPA = true;
+    mLegacyErt = ERTMODE::NONE;
   }
 
   static bool getBoolValue(std::string& value,bool defaultValue)
@@ -217,6 +218,13 @@ namespace xclemulation{
       else if(name == "system_dpa")
       {
         setSystemDPA(getBoolValue(value,true));
+      }
+      else if(name == "legacy_ert")
+      {
+        if (boost::iequals(value,"false" ))
+          setLegacyErt(ERTMODE::UPDATED);
+        else if(boost::iequals(value,"true"))
+          setLegacyErt(ERTMODE::LEGACY);
       }
       else if(name.find("Debug.") == std::string::npos)
       {

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -94,6 +94,12 @@ namespace xclemulation{
     BATCH,
     GUI
   };
+  
+  enum ERTMODE {
+    NONE,
+    LEGACY,
+    UPDATED 
+  };
 
   class config 
   {
@@ -121,7 +127,8 @@ namespace xclemulation{
       inline void setServerPort(unsigned int serverPort)        { mServerPort       = serverPort;    }
       inline void setKeepRunDir(bool _mKeepRundir)              { mKeepRunDir = _mKeepRundir;        }    
       inline void setLauncherArgs(std::string & _mLauncherArgs) { mLauncherArgs = _mLauncherArgs;    }
-      inline void setSystemDPA(bool _isDPAEnabled)              { mSystemDPA    = _isDPAEnabled;      }
+      inline void setSystemDPA(bool _isDPAEnabled)              { mSystemDPA    = _isDPAEnabled;     }
+      inline void setLegacyErt(ERTMODE _legacyErt)              { mLegacyErt    = _legacyErt;        }
       
       inline bool isDiagnosticsEnabled()        const { return mDiagnostics;    }
       inline bool isUMRChecksEnabled()          const { return mUMRChecks;      }
@@ -143,7 +150,8 @@ namespace xclemulation{
       inline bool isErrorsToBePrintedOnConsole()   const { return mPrintErrorsInConsole;  }
       inline bool isWarningsToBePrintedOnConsole() const { return mPrintWarningsInConsole;}
       inline std::string getLauncherArgs() const { return mLauncherArgs;}
-      inline bool isSystemDPAEnabled() const     {return mSystemDPA;              }
+      inline bool isSystemDPAEnabled() const     { return mSystemDPA;              }
+      inline ERTMODE getLegacyErt() const         { return mLegacyErt;              }
       
       void populateEnvironmentSetup(std::map<std::string,std::string>& mEnvironmentNameValueMap);
 
@@ -170,6 +178,7 @@ namespace xclemulation{
       bool mKeepRunDir;
       std::string mLauncherArgs;
       bool mSystemDPA;
+      ERTMODE mLegacyErt;
       
      
       config();

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mbscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mbscheduler.cxx
@@ -517,11 +517,33 @@ namespace xclhwemhal2 {
     }
 
     slot_addr = ERT_CQ_BASE_ADDR + xcmd->slot_idx*slot_size(xcmd->exec);
+    
+    if (type(xcmd) == ERT_CU && mParent->isDynamicallyLoadingErt())
+    {
+      //now KDS is sending the cu_idx to ERT
+      struct exec_core *exec = xcmd->exec;
+      for (unsigned int cuidx = 0; cuidx < exec->num_cus; ++cuidx)
+      {
+        xocl_cu *xcu = exec->cus[cuidx];
 
-    /* TODO write packet minus header */
-    mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4, xcmd->packet->data,(packet_size(xcmd)-1)*sizeof(uint32_t));
-    //memcpy_toio(xcmd->exec->base + slot_addr + 4,xcmd->packet->data,(packet_size(xcmd)-1)*sizeof(uint32_t));
+        if (cmd_has_cu(xcmd, cuidx) && cu_ready(xcu))
+        {
+          xcmd->cu_idx = cuidx;
+          break;
+        }
+      }
+      
+      if (xcmd->cu_idx < 0) {
+        return false;
+      }
 
+      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4,(void*) &(xcmd->cu_idx)  ,4);
+      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 8, xcmd->packet->data + 1 ,(packet_size(xcmd)-2)*sizeof(uint32_t));
+    }
+    else
+    {
+      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4, xcmd->packet->data  ,(packet_size(xcmd)-1)*sizeof(uint32_t));
+    }
     /* TODO write header */
     mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr, (void*)(&xcmd->packet->header) ,4);
     //iowrite32(xcmd->packet->header,xcmd->exec->base + slot_addr);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mbscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mbscheduler.cxx
@@ -518,27 +518,34 @@ namespace xclhwemhal2 {
 
     slot_addr = ERT_CQ_BASE_ADDR + xcmd->slot_idx*slot_size(xcmd->exec);
     
-    if (type(xcmd) == ERT_CU && mParent->isDynamicallyLoadingErt())
+    if(!mParent->isLegacyErt())
     {
-      //now KDS is sending the cu_idx to ERT
-      struct exec_core *exec = xcmd->exec;
-      for (unsigned int cuidx = 0; cuidx < exec->num_cus; ++cuidx)
+      if (type(xcmd) == ERT_CU)
       {
-        xocl_cu *xcu = exec->cus[cuidx];
-
-        if (cmd_has_cu(xcmd, cuidx) && cu_ready(xcu))
+        //now KDS is sending the cu_idx to ERT
+        struct exec_core *exec = xcmd->exec;
+        for (unsigned int cuidx = 0; cuidx < exec->num_cus; ++cuidx)
         {
-          xcmd->cu_idx = cuidx;
-          break;
-        }
-      }
-      
-      if (xcmd->cu_idx < 0) {
-        return false;
-      }
+          xocl_cu *xcu = exec->cus[cuidx];
 
-      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4,(void*) &(xcmd->cu_idx)  ,4);
-      mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 8, xcmd->packet->data + 1 ,(packet_size(xcmd)-2)*sizeof(uint32_t));
+          if (cmd_has_cu(xcmd, cuidx) && cu_ready(xcu))
+          {
+            xcmd->cu_idx = cuidx;
+            break;
+          }
+        }
+
+        if (xcmd->cu_idx < 0) {
+          return false;
+        }
+
+        mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4,(void*) &(xcmd->cu_idx)  ,4);
+        mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 8, xcmd->packet->data + 1 ,(packet_size(xcmd)-2)*sizeof(uint32_t));
+      }
+      else
+      {
+        mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcmd->exec->base + slot_addr + 4, xcmd->packet->data  ,(packet_size(xcmd)-1)*sizeof(uint32_t));
+      }
     }
     else
     {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1562,6 +1562,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
         || vbnv.find("u280_xdma_201920_1")        != std::string::npos
         || vbnv.find("u280_xdma_201920_2")        != std::string::npos
         || vbnv.find("u280_xdma_201920_3")        != std::string::npos
+        || vbnv.find("u50_xdma_201910_1")         != std::string::npos
         || vbnv.find("u50_xdma_201920_2")         != std::string::npos))
       return true;
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1540,6 +1540,17 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     bool QDMAPlatform = (getDsaVersion() == 60)? true: false;
     return mbSchEnabled && !QDMAPlatform;
   }
+  
+
+  bool HwEmShim::isDynamicallyLoadingErt()
+  {
+    //Currently returning true for samsung platform. This should return true by default in 2020.1
+    //Emulation team needs to add more platform names here which are dynamically loading ERT
+    std::string vbnv  = mDeviceInfo.mName;
+    if(!vbnv.empty() && vbnv.find("u2x4") != std::string::npos)
+      return true;
+    return false;
+  }
 
   bool HwEmShim::isCdmaEnabled()
   {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1542,13 +1542,29 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
   }
   
 
-  bool HwEmShim::isDynamicallyLoadingErt()
+  bool HwEmShim::isLegacyErt()
   {
-    //Currently returning true for samsung platform. This should return true by default in 2020.1
-    //Emulation team needs to add more platform names here which are dynamically loading ERT
-    std::string vbnv  = mDeviceInfo.mName;
-    if(!vbnv.empty() && vbnv.find("u2x4") != std::string::npos)
+    if(xclemulation::config::getInstance()->getLegacyErt() == xclemulation::ERTMODE::LEGACY)
       return true;
+    else if(xclemulation::config::getInstance()->getLegacyErt() == xclemulation::ERTMODE::UPDATED)
+      return false;
+
+    //Following platforms uses legacyErt As per Emulation team. 
+    //There is no other way to get whether platform uses legacy ERT or not
+    std::string vbnv  = mDeviceInfo.mName;
+    if(!vbnv.empty() && 
+        (  vbnv.find("u200_xdma-gen3x4_201830_2") != std::string::npos 
+        || vbnv.find("u200_xdma_201830_1")        != std::string::npos 
+        || vbnv.find("u200_xdma_201830_2")        != std::string::npos 
+        || vbnv.find("u250_qep_201910_1")         != std::string::npos
+        || vbnv.find("u250_xdma_201830_1")        != std::string::npos 
+        || vbnv.find("u250_xdma_201830_2")        != std::string::npos 
+        || vbnv.find("u280_xdma_201920_1")        != std::string::npos
+        || vbnv.find("u280_xdma_201920_2")        != std::string::npos
+        || vbnv.find("u280_xdma_201920_3")        != std::string::npos
+        || vbnv.find("u50_xdma_201920_2")         != std::string::npos))
+      return true;
+
     return false;
   }
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -210,7 +210,7 @@ using addr_type = uint64_t;
       void setUnified(bool _unified) { bUnified = _unified; }
 
       bool isMBSchedulerEnabled();
-      bool isDynamicallyLoadingErt();
+      bool isLegacyErt();
       unsigned int getDsaVersion();
       bool isCdmaEnabled();
       uint64_t getCdmaBaseAddress(unsigned int index);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -210,6 +210,7 @@ using addr_type = uint64_t;
       void setUnified(bool _unified) { bUnified = _unified; }
 
       bool isMBSchedulerEnabled();
+      bool isDynamicallyLoadingErt();
       unsigned int getDsaVersion();
       bool isCdmaEnabled();
       uint64_t getCdmaBaseAddress(unsigned int index);


### PR DESCRIPTION
This change contains a fix to ERT in emulation. ERT scheduler is now expecting KDS to provide the cu_idx