### PR TITLE
CR-1053217 XRT - Firewall wait settings not re-initialized after hot …

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -199,11 +199,13 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro)
 	if (!XOCL_DSA_PCI_RESET_OFF(lro)) {
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_ICAP);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_MAILBOX);
+		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_AF);
 #if defined(__PPC64__)
 		pci_fundamental_reset(lro);
 #else
 		xclmgmt_reset_pci(lro);
 #endif
+		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_AF);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_MAILBOX);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_ICAP);
 	} else {


### PR DESCRIPTION
We don't offline/online firewall.m, it's safe to offline/online it without touching any IPs.
We offline it at the last time and online it before every other subdevs.

[root@xsjhemn41 ~]# xbutil reset
All existing processes will be killed.
Are you sure you wish to proceed? [y/n]: y
[root@xsjhemn41 ~]# /proj/rdi/staff/davidzha/share/firewall.sh
      e0002000-e0002fff : ep_firewall_ctrl_mgmt_00 1 0 1
      e0003000-e0003fff : ep_firewall_ctrl_user_00 1 0 1
      e0004000-e0004fff : ep_firewall_ctrl_debug_00 1 0 1
e0002000
0x00000000e0002030 = 0x00002000
0x00000000e0002034 = 0x00002000
0x00000000e0002038 = 0x00002000
0x00000000e000203c = 0x00002000
0x00000000e0002040 = 0x00002000
e0003000
0x00000000e0003030 = 0x00002000
0x00000000e0003034 = 0x00002000
0x00000000e0003038 = 0x00002000
0x00000000e000303c = 0x00002000
0x00000000e0003040 = 0x00002000
e0004000
0x00000000e0004030 = 0x00002000
0x00000000e0004034 = 0x00002000
0x00000000e0004038 = 0x00002000
0x00000000e000403c = 0x00002000
0x00000000e0004040 = 0x00002000
      e0005000-e0005fff : ep_firewall_data_h2c_00 1 0 1
      e1f02000-e1f02fff : ep_firewall_blp_ctrl_mgmt_00 1 0 1
      e1f03000-e1f03fff : ep_firewall_blp_ctrl_user_00 1 0 1
e0005000
0x00000000e0005030 = 0x0000ffff
0x00000000e0005034 = 0x0000ffff
0x00000000e0005038 = 0x0000ffff
0x00000000e000503c = 0x0000ffff
0x00000000e0005040 = 0x0000ffff
e1f02000
0x00000000e1f02030 = 0x0000ffff
0x00000000e1f02034 = 0x0000ffff
0x00000000e1f02038 = 0x0000ffff
0x00000000e1f0203c = 0x0000ffff
0x00000000e1f02040 = 0x0000ffff
e1f03000
0x00000000e1f03030 = 0x0000ffff
0x00000000e1f03034 = 0x0000ffff
0x00000000e1f03038 = 0x0000ffff
0x00000000e1f0303c = 0x0000ffff
0x00000000e1f03040 = 0x0000ffff