### PR TITLE
Coverity boundary check: Check if index >=4 

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -426,7 +426,7 @@ static struct page **xocl_cma_pool_get_pages(struct xocl_drm *drm_p, uint32_t id
 	uint64_t page_offset = 0;
 	struct page **pages = NULL;
 
-	if (idx > DRM_XOCL_CMA_CHUNK_MAX)
+	if (idx >= DRM_XOCL_CMA_CHUNK_MAX)
 		return ERR_PTR(-EINVAL);
 
 	if (!drm_p->cma_chunk[idx])

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -785,7 +785,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
 
     } else {
         drm_xocl_free_cma_info cma_info = {0};
-        mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_FREE_CMA, &cma_info);
+        ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_FREE_CMA, &cma_info);
     }
 
     return ret;


### PR DESCRIPTION
out of boundary if index = 4

&

get ioctl return value
