### PR TITLE
Fixing multiple issues in U.2. Removing MB subdevice from U2 MGMT

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1288,7 +1288,6 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_CLOCK_LEGACY,			\
 			XOCL_DEVINFO_SYSMON,				\
 			XOCL_DEVINFO_AF,				\
-			XOCL_DEVINFO_MB,				\
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_XIIC,				\
 			XOCL_DEVINFO_MAILBOX_MGMT,			\


### PR DESCRIPTION
Below issues are fixed with this change
-Firewall tripped error message when unloading and loading xocl/xclmgmt
drivers
-sensors is not showing the FPGA Temp
-xmc.m sub device is not getting called/created in xclmgmt driver.

U.2 platform has to use XMC subdevice

XMC sub device already handles loading of mgmt|sched firmwares on microblaze.
So, MB subdev entry in RES_U2 not required.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>