### PR TITLE
CR-1053117 XRT - Add VCCINT VRM Temperature to list reported by xbuti…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -171,6 +171,7 @@ struct xcl_sensor {
 	uint32_t vccint_bram;
 	uint32_t version;
 	uint32_t oem_id;
+	uint32_t vccint_temp;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -89,6 +89,7 @@
 #define	XMC_VCCINT_BRAM_REG		0x2A8
 #define	XMC_HBM_TEMP2_REG		0x2B4
 #define	XMC_OEM_ID_REG                  0x2C0
+#define	XMC_VCCINT_TEMP_REG             0x2CC
 #define	XMC_HOST_MSG_OFFSET_REG		0x300
 #define	XMC_HOST_MSG_ERROR_REG		0x304
 #define	XMC_HOST_MSG_HEADER_REG		0x308
@@ -567,6 +568,9 @@ static void xmc_sensor(struct platform_device *pdev, enum data_kind kind,
 		case XMC_OEM_ID:
 			safe_read32(xmc, XMC_OEM_ID_REG, val);
 			break;
+		case XMC_VCCINT_TEMP:
+			safe_read32(xmc, XMC_VCCINT_TEMP_REG, val);
+			break;
 		default:
 			break;
 		}
@@ -696,6 +700,9 @@ static void xmc_sensor(struct platform_device *pdev, enum data_kind kind,
 			break;
 		case XMC_OEM_ID:
 			*val = xmc->cache->oem_id;
+			break;
+		case XMC_VCCINT_TEMP:
+			*val = xmc->cache->vccint_temp;
 			break;
 		default:
 			break;
@@ -915,6 +922,7 @@ static int xmc_get_data(struct platform_device *pdev, enum xcl_group_kind kind,
 		xmc_sensor(pdev, VOL_VCCINT_BRAM, &sensors->vccint_bram, SENSOR_INS);
 		xmc_sensor(pdev, XMC_VER, &sensors->version, SENSOR_INS);
 		xmc_sensor(pdev, XMC_OEM_ID, &sensors->oem_id, SENSOR_INS);
+		xmc_sensor(pdev, XMC_VCCINT_TEMP, &sensors->vccint_temp, SENSOR_INS);
 		break;
 	case XCL_BDINFO:
 		mutex_lock(&xmc->mbx_lock);
@@ -1041,6 +1049,7 @@ SENSOR_SYSFS_NODE(xmc_vccint_bram_vol, VOL_VCCINT_BRAM);
 SENSOR_SYSFS_NODE(xmc_hbm_temp, HBM_TEMP);
 SENSOR_SYSFS_NODE(version, XMC_VER);
 SENSOR_SYSFS_NODE_FORMAT(xmc_oem_id, XMC_OEM_ID, "0x%x\n");
+SENSOR_SYSFS_NODE(xmc_vccint_temp, XMC_VCCINT_TEMP);
 
 static ssize_t xmc_power_show(struct device *dev,
 	struct device_attribute *da, char *buf)
@@ -1104,7 +1113,8 @@ static DEVICE_ATTR_RO(status);
 	&dev_attr_xmc_hbm_temp.attr,					\
 	&dev_attr_xmc_power.attr,					\
 	&dev_attr_version.attr,						\
-	&dev_attr_xmc_oem_id.attr
+	&dev_attr_xmc_oem_id.attr,					\
+	&dev_attr_xmc_vccint_temp.attr
 
 /*
  * Defining sysfs nodes for reading some of xmc regisers.

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -921,6 +921,7 @@ enum data_kind {
 	XMC_VER,
 	EXP_BMC_VER,
 	XMC_OEM_ID,
+	XMC_VCCINT_TEMP,
 };
 
 enum mb_kind {

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -767,9 +767,12 @@ public:
         sensor_tree::put( "board.physical.thermal.pcb.btm_front", xmc_se98_temp2);
 
         // physical.thermal
-        unsigned int fan_rpm, xmc_fpga_temp, xmc_fan_temp;
+        unsigned int fan_rpm, xmc_fpga_temp, xmc_fan_temp, vccint_temp;
         std::string fan_presence;
         
+        pcidev::get_dev(m_idx)->sysfs_get_sensor("xmc", "xmc_vccint_temp",  vccint_temp);
+        sensor_tree::put( "board.physical.thermal.vccint_temp.current",     vccint_temp);
+
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_fpga_temp", xmc_fpga_temp );
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_fan_temp",  xmc_fan_temp );
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "fan_presence",         errmsg, fan_presence );
@@ -1032,10 +1035,11 @@ public:
 
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         ostr << "Temperature(C)\n";
-        ostr << std::setw(16) << "PCB TOP FRONT" << std::setw(16) << "PCB TOP REAR" << std::setw(16) << "PCB BTM FRONT" << std::endl;
+        ostr << std::setw(16) << "PCB TOP FRONT" << std::setw(16) << "PCB TOP REAR" << std::setw(16) << "PCB BTM FRONT" << std::setw(16) << "VCCINT TEMP" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.pcb.top_front" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.pcb.top_rear"  )
-             << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.pcb.btm_front" ) << std::endl;
+             << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.pcb.btm_front" )
+             << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.vccint_temp.current" ) << std::endl;
         ostr << std::setw(16) << "FPGA TEMP" << std::setw(16) << "TCRIT Temp" << std::setw(16) << "FAN Presence" 
              << std::setw(16) << "FAN Speed(RPM)" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.fpga_temp") 


### PR DESCRIPTION
See CR for the requirements.
Test results:

> ./xbutil query|grep -A1 "VCCINT TEMP"
```
PCB TOP FRONT   PCB TOP REAR    PCB BTM FRONT   VCCINT TEMP
38              34              N/A             43
```

> ./xbutil dump|grep -A13 physical
```

        "physical":
        {
            "thermal":
            {
                "pcb":
                {
                    "top_front": "38",
                    "top_rear": "34",
                    "btm_front": "0"
                },
                "vccint_temp":
                {
                    "current": "43"
                },
```