### PR TITLE
check xmc first to avoid "failed to find subdirectory for xmc"

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1796,7 +1796,6 @@ static struct attribute *xmc_attrs[] = {
 	&dev_attr_max_power.attr,
 	&dev_attr_fan_presence.attr,
 	&dev_attr_config_mode.attr,
-	&dev_attr_sc_presence.attr,
 	&dev_attr_sensor_update_timestamp.attr,
 	&dev_attr_scaling_threshold_power_override.attr,
 	&dev_attr_scaling_threshold_power_override_en.attr,
@@ -1808,6 +1807,7 @@ static struct attribute *xmc_attrs[] = {
 static struct attribute *xmc_mini_attrs[] = {
 	&dev_attr_reg_base.attr,
 	&dev_attr_status.attr,
+	&dev_attr_sc_presence.attr,
 	NULL,
 };
 
@@ -2852,6 +2852,8 @@ static int xmc_probe(struct platform_device *pdev)
 			break;
 	}
 
+	xmc->sc_presence = nosc_xmc(xmc->pdev) ? 0 : 1;
+
 	if (XMC_PRIVILEGED(xmc)) {
 		if (xmc->base_addrs[IO_REG]) {
 			err = mgmt_sysfs_create_xmc_mini(pdev);
@@ -2899,9 +2901,6 @@ static int xmc_probe(struct platform_device *pdev)
 	}
 
 	xmc->cache_expire_secs = XMC_DEFAULT_EXPIRE_SECS;
-	xmc->sc_presence = 1;
-	if (nosc_xmc(xmc->pdev))
-		xmc->sc_presence = 0;
 
 	/*
 	 * Enabling XMC clock scaling support.

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -156,8 +156,11 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
 int Flasher::upgradeBMCFirmware(firmwareImage* bmc)
 {
     XMC_Flasher flasher(mDev);
-    const std::string e = flasher.probingErrMsg();
 
+    if (!flasher.hasXMC())
+        return -EOPNOTSUPP;
+
+    const std::string e = flasher.probingErrMsg();
     if (!e.empty())
     {
         std::cout << "ERROR: " << e << std::endl;
@@ -193,6 +196,9 @@ int Flasher::getBoardInfo(BoardInfo& board)
     std::string unassigned_mac = "FF:FF:FF:FF:FF:FF";
     std::map<char, std::vector<char>> info;
     XMC_Flasher flasher(mDev);
+
+    if (!flasher.hasXMC())
+        return -EOPNOTSUPP;
 
     if (!flasher.probingErrMsg().empty())
     {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -38,10 +38,8 @@ XMC_Flasher::XMC_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     bool is_mfg = false;
     mDev->sysfs_get<bool>("", "mfg", err, is_mfg, false);
     if (!is_mfg) {
-        if (mDev->get_sysfs_path("xmc", "").empty()) {
-            mProbingErrMsg << "Failed to detect XMC"; 
+         if (!hasXMC())
             goto nosup;
-	}
 
         mDev->sysfs_get<unsigned>("xmc", "status", err, val, 0);
 	if (!err.empty() || !(val & 1)) {
@@ -508,6 +506,9 @@ bool XMC_Flasher::isBMCReady()
     unsigned int val;
     std::string errmsg;
 
+    if (!hasXMC())
+	    return false;
+
     mDev->sysfs_get<unsigned>("xmc", "sc_presence", errmsg, val, 0);
     if (!errmsg.empty()) {
         std::cout << "can't read sc_presence node from " << mDev->sysfs_name <<
@@ -526,6 +527,11 @@ bool XMC_Flasher::isBMCReady()
     }
 
     return true;
+}
+
+bool XMC_Flasher::hasXMC()
+{
+        return !mDev->get_sysfs_path("xmc", "").empty();
 }
 
 static void tiTxtStreamToBin(std::istream& tiTxtStream,

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
@@ -109,6 +109,7 @@ public:
     int xclUpgradeFirmware(std::istream& tiTxtStream);
     int xclGetBoardInfo(std::map<char, std::vector<char>>& info);
     const std::string probingErrMsg() { return mProbingErrMsg.str(); }
+    bool hasXMC();
 
 private:
     std::shared_ptr<pcidev::pci_device> mDev;


### PR DESCRIPTION
@larry9523 @houlz0507 rethink the solution, now we add the sc_presence into golden sysfs too.
The logic is simple, if has xmc, then check, otherwise skip.

Note: u50 Recovery BLP doesn't have xmc, so we should not print errors to early.