### PR TITLE
Xrt reboot

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -358,9 +358,14 @@ static inline bool flash_has_err(struct xocl_flash *flash)
 static int flash_rx(struct xocl_flash *flash, u8 *buf, size_t len)
 {
 	size_t cnt;
+    u8 c;
 
 	for (cnt = 0; cnt < len; cnt++) {
-		u8 c = flash_read8(flash);
+        c = 0xFF;
+	
+        if ((flash_get_status(flash) & QSPI_SR_RX_EMPTY) == 0)
+            c = flash_read8(flash);
+
 		if (buf)
 			buf[cnt] = c;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -358,13 +358,12 @@ static inline bool flash_has_err(struct xocl_flash *flash)
 static int flash_rx(struct xocl_flash *flash, u8 *buf, size_t len)
 {
 	size_t cnt;
-    u8 c;
 
 	for (cnt = 0; cnt < len; cnt++) {
-        c = 0xFF;
-	
-        if ((flash_get_status(flash) & QSPI_SR_RX_EMPTY) == 0)
-            c = flash_read8(flash);
+        if ((flash_get_status(flash) & QSPI_SR_RX_EMPTY) != 0)
+            return -EINVAL;
+            
+        u8 c = flash_read8(flash);
 
 		if (buf)
 			buf[cnt] = c;
@@ -471,6 +470,9 @@ static int flash_transaction(struct xocl_flash *flash,
 		/* Needs to drain the FIFO even when the data is not wanted. */
 		ret = flash_rx(flash, NULL, len);
 	}
+
+	if (ret)
+		return ret;
 
 	/* Always need to reset slave select register after each transaction */
 	flash_activate_slave(flash, SLAVE_NONE);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -468,16 +468,13 @@ static int flash_transaction(struct xocl_flash *flash,
 		ret = flash_rx(flash, buf, len);
 	} else {
 		/* Needs to drain the FIFO even when the data is not wanted. */
-		ret = flash_rx(flash, NULL, len);
+		(void) flash_rx(flash, NULL, len);
 	}
-
-	if (ret)
-		return ret;
 
 	/* Always need to reset slave select register after each transaction */
 	flash_activate_slave(flash, SLAVE_NONE);
 
-	return 0;
+	return ret;
 }
 
 static size_t flash_get_fifo_depth(struct xocl_flash *flash)


### PR DESCRIPTION
- Flash driver is writing to tx FIFO and reading from RX FIFO, but not checking the emptiness of FIFO before reading. Flash returns Slave error if we read from empty FIFO.
-  Earlier, mgmt is in PF1, As PF1 has less capabilities/error-checks, the system is not hanging, it is just returning all F’s.  Now, mgmt is In PF0, As PF0 has more capabilities/error-checks, the System is hanging and rebooting.
- Added a check in flash driver to read FIFO whenever it is not empty which solved the reboot issue.
