### PR TITLE
CR-1053481, CR-1053358 enable clock subdev for icap

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -521,7 +521,7 @@ static int set_freqs(struct clock *clock, unsigned short *freqs, int num_freqs,
 		gate_handle->gate_free_cb(gate_handle->gate_args);
 
 done:
-	CLOCK_ERR(clock, "returns %d", err);
+	CLOCK_INFO(clock, "returns %d", err);
 	return err;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -643,7 +643,6 @@ static unsigned int icap_get_clock_frequency_counter_khz(const struct icap *icap
 	if (ICAP_PRIVILEGED(icap)) {
 		if (uuid_is_null(&icap->icap_bitstream_uuid))
 			return freq;
-
 		err = xocl_clock_get_freq_counter_khz(xdev, &freq, idx);
 		if (err)
 			ICAP_WARN(icap, "clock subdev returns %d.", err);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1315,12 +1315,14 @@ static int get_temp_by_m_tag(struct xocl_xmc *xmc, char *m_tag)
 static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev)
 {
 	if (xmc->sc_presence) {
+		u32 reg;
+
 		//Feature present bit may configured each time an xclbin is downloaded,
 		//or following a reset of the CMC Subsystem. So, check for latest
 		//status every time.
 		xmc->cs_on_ptfm = false;
 		xmc->runtime_cs_enabled = false;
-		u32 reg = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
+		reg = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
 		if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT) {
 			xmc->cs_on_ptfm = true;
 			if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_ENABLE)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -326,7 +326,8 @@ static int __xocl_subdev_create(xdev_handle_t xdev_hdl,
 	else
 		snprintf(devname, sizeof(devname) - 1, "%s%s",
 				sdev_info->name, SUBDEV_SUFFIX);
-	xocl_xdev_info(xdev_hdl, "creating subdev %s", devname);
+	xocl_xdev_info(xdev_hdl, "creating subdev %s multi %d level %d",
+		devname, sdev_info->multi_inst, sdev_info->level);
 
 	subdev = xocl_subdev_reserve(xdev_hdl, sdev_info);
 	if (!subdev) {
@@ -443,8 +444,8 @@ static int __xocl_subdev_create(xdev_handle_t xdev_hdl,
 
 	subdev->state = XOCL_SUBDEV_STATE_ADDED;
 
-	xocl_xdev_info(xdev_hdl, "Created subdev %s inst %d",
-			sdev_info->name, subdev->inst);
+	xocl_xdev_info(xdev_hdl, "Created subdev %s inst %d level %d",
+			sdev_info->name, subdev->inst, sdev_info->level);
 
 	if (XOCL_GET_DRV_PRI(subdev->pldev) &&
 			XOCL_GET_DRV_PRI(subdev->pldev)->ops)


### PR DESCRIPTION
Root cause of clock is that on U200, clock's level is 2 and icap is 0. Therefor, we should use how the iores subdev multi level mechanism to find clock xdev_handle_t and all apis.

Fix a lint issue during compile too.