### PR TITLE
xbutil dump clock shows 0 due to idx in macro is overridden

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -281,6 +281,7 @@ static unsigned int clock_get_freq_counter_khz_impl(struct clock *clock, int idx
 	u32 freq = 0, status;
 	int times = 10;
 
+	BUG_ON(idx > CLOCK_MAX_NUM_CLOCKS);
 	BUG_ON(!mutex_is_locked(&clock->clock_lock));
 
 	if (clock->clock_freq_counter && idx < 2) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -358,12 +358,13 @@ static inline bool flash_has_err(struct xocl_flash *flash)
 static int flash_rx(struct xocl_flash *flash, u8 *buf, size_t len)
 {
 	size_t cnt;
+	u8 c;
 
 	for (cnt = 0; cnt < len; cnt++) {
-        if ((flash_get_status(flash) & QSPI_SR_RX_EMPTY) != 0)
-            return -EINVAL;
-            
-        u8 c = flash_read8(flash);
+		if ((flash_get_status(flash) & QSPI_SR_RX_EMPTY) != 0)
+			return -EINVAL;
+
+        	c = flash_read8(flash);
 
 		if (buf)
 			buf[cnt] = c;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1010,45 +1010,45 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 
 #define	xocl_clock_freqscaling(xdev, force)					\
 ({ \
-	int idx = xocl_clock_ops_level(xdev);					\
-	(CLOCK_CB(xdev, idx, freq_scaling) ?					\
-	CLOCK_OPS(xdev, idx)->freq_scaling(CLOCK_DEV(xdev, idx), force) :	\
+	int __idx = xocl_clock_ops_level(xdev);					\
+	(CLOCK_CB(xdev, __idx, freq_scaling) ?					\
+	CLOCK_OPS(xdev, __idx)->freq_scaling(CLOCK_DEV(xdev, __idx), force) :	\
 	-ENODEV); \
 })
 #define	xocl_clock_get_freq(xdev, region, freqs, num_freqs)		\
 ({ \
-	int idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, idx, get_freq) ?				\
-	CLOCK_OPS(xdev, idx)->get_freq(CLOCK_DEV(xdev, idx), region, freqs, num_freqs) : \
+	int __idx = xocl_clock_ops_level(xdev);				\
+	(CLOCK_CB(xdev, __idx, get_freq) ?				\
+	CLOCK_OPS(xdev, __idx)->get_freq(CLOCK_DEV(xdev, __idx), region, freqs, num_freqs) : \
 	-ENODEV); \
 })
 
 #define	xocl_clock_get_freq_by_id(xdev, region, freq, id)		\
 ({ \
-	int idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, idx, get_freq_by_id) ?				\
-	CLOCK_OPS(xdev, idx)->get_freq_by_id(CLOCK_DEV(xdev, idx), region, freq, id) : \
+	int __idx = xocl_clock_ops_level(xdev);				\
+	(CLOCK_CB(xdev, __idx, get_freq_by_id) ?				\
+	CLOCK_OPS(xdev, __idx)->get_freq_by_id(CLOCK_DEV(xdev, __idx), region, freq, id) : \
 	-ENODEV); \
 })
 #define	xocl_clock_get_freq_counter_khz(xdev, value, id)		\
 ({ \
-	int idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, idx, get_freq_counter_khz) ?				\
-	CLOCK_OPS(xdev, idx)->get_freq_counter_khz(CLOCK_DEV(xdev, idx), value, id) : \
+	int __idx = xocl_clock_ops_level(xdev);				\
+	(CLOCK_CB(xdev, __idx, get_freq_counter_khz) ?				\
+	CLOCK_OPS(xdev, __idx)->get_freq_counter_khz(CLOCK_DEV(xdev, __idx), value, id) : \
 	-ENODEV); \
 })
 #define	xocl_clock_update_freq(xdev, freqs, num_freqs, verify, gate_handle) \
 ({ \
-	int idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, idx, update_freq) ?					\
-	CLOCK_OPS(xdev, idx)->update_freq(CLOCK_DEV(xdev, idx), freqs, num_freqs, verify, gate_handle) : \
+	int __idx = xocl_clock_ops_level(xdev);				\
+	(CLOCK_CB(xdev, __idx, update_freq) ?					\
+	CLOCK_OPS(xdev, __idx)->update_freq(CLOCK_DEV(xdev, __idx), freqs, num_freqs, verify, gate_handle) : \
 	-ENODEV); \
 })
 #define	xocl_clock_status(xdev, latched)				\
 ({ \
-	int idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, idx, clock_status) ?					\
-	CLOCK_OPS(xdev, idx)->clock_status(CLOCK_DEV(xdev, idx), latched) : 	\
+	int __idx = xocl_clock_ops_level(xdev);				\
+	(CLOCK_CB(xdev, __idx, clock_status) ?					\
+	CLOCK_OPS(xdev, __idx)->clock_status(CLOCK_DEV(xdev, __idx), latched) : 	\
 	-ENODEV); \
 })
 


### PR DESCRIPTION
fix http://jira.xilinx.com/browse/CR-1053358

passing idx into C macro and idx overridden unfortunately 