### PR TITLE
Return fail when XMC is not present.

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2020 Xilinx, Inc
  * Author(s): Max Zhen
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -38,8 +38,10 @@ XMC_Flasher::XMC_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     bool is_mfg = false;
     mDev->sysfs_get<bool>("", "mfg", err, is_mfg, false);
     if (!is_mfg) {
-        if (mDev->get_sysfs_path("xmc", "").empty())
+        if (mDev->get_sysfs_path("xmc", "").empty()) {
+            mProbingErrMsg << "Failed to detect XMC"; 
             goto nosup;
+	}
 
         mDev->sysfs_get<unsigned>("xmc", "status", err, val, 0);
 	if (!err.empty() || !(val & 1)) {


### PR DESCRIPTION
When there is no CMC node, we should log a error message in XMC_Flasher constructor so that the caller knows the constructor fails. This will avoid the further access to XMC register.