### PR TITLE
fixing bvt_issue of emulation. u50_20192_1 also uses legacy scheduler

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1563,6 +1563,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
         || vbnv.find("u280_xdma_201920_2")        != std::string::npos
         || vbnv.find("u280_xdma_201920_3")        != std::string::npos
         || vbnv.find("u50_xdma_201910_1")         != std::string::npos
+        || vbnv.find("u50_xdma_201920_1")         != std::string::npos
         || vbnv.find("u50_xdma_201920_2")         != std::string::npos))
       return true;
 


### PR DESCRIPTION
fixing bvt issue by adding u50_20192_1 in legacy scheduler list