### PR TITLE
mpd udev support

### DIFF
--- a/src/CMake/cpack.cmake
+++ b/src/CMake/cpack.cmake
@@ -45,7 +45,7 @@ if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian|pynqlinux)")
   # aws component dependencies
   SET(CPACK_DEBIAN_AWS_PACKAGE_DEPENDS "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})")
   # xrt component dependencies
-  SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-opencl-dev (>= 2.2.0), libboost-dev (>= ${Boost_VER_STR}), libboost-dev (<< ${Boost_VER_STR_ONEGREATER}), libboost-filesystem-dev (>=${Boost_VER_STR}), libboost-filesystem-dev (<<${Boost_VER_STR_ONEGREATER}), uuid-dev (>= 2.27.1), dkms (>= 2.2.0), libprotoc-dev (>=2.6.1), libssl-dev (>=1.0.2), protobuf-compiler (>=2.6.1), libncurses5-dev (>=6.0), lsb-release, libxml2-dev (>=2.9.1), libyaml-dev (>= 0.1.6), libc6 (>= ${GLIBC_VERSION}), libc6 (<< ${GLIBC_VERSION_ONEGREATER}), python (>= 2.7), python-pip ")
+  SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-opencl-dev (>= 2.2.0), libboost-dev (>= ${Boost_VER_STR}), libboost-dev (<< ${Boost_VER_STR_ONEGREATER}), libboost-filesystem-dev (>=${Boost_VER_STR}), libboost-filesystem-dev (<<${Boost_VER_STR_ONEGREATER}), uuid-dev (>= 2.27.1), dkms (>= 2.2.0), libprotoc-dev (>=2.6.1), libssl-dev (>=1.0.2), protobuf-compiler (>=2.6.1), libncurses5-dev (>=6.0), lsb-release, libxml2-dev (>=2.9.1), libyaml-dev (>= 0.1.6), libc6 (>= ${GLIBC_VERSION}), libc6 (<< ${GLIBC_VERSION_ONEGREATER}), python (>= 2.7), python-pip, libudev-dev ")
 
 elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS)")
   SET(CPACK_GENERATOR "RPM;TGZ")
@@ -66,7 +66,7 @@ elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS)")
   # aws component dependencies
   SET(CPACK_RPM_AWS_PACKAGE_REQUIRES "xrt >= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH}")
   # xrt component dependencies
-  SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd-devel >= 2.2, boost-devel >= 1.53, boost-filesystem >= 1.53, libuuid-devel >= 2.23.2, dkms >= 2.5.0, protobuf-devel >= 2.5.0, protobuf-compiler >= 2.5.0, ncurses-devel >= 5.9, redhat-lsb-core, libxml2-devel >= 2.9.1, libyaml-devel >= 0.1.4, python >= 2.7, python-pip, openssl-devel >= 1.0.2 ")
+  SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd-devel >= 2.2, boost-devel >= 1.53, boost-filesystem >= 1.53, libuuid-devel >= 2.23.2, dkms >= 2.5.0, protobuf-devel >= 2.5.0, protobuf-compiler >= 2.5.0, ncurses-devel >= 5.9, redhat-lsb-core, libxml2-devel >= 2.9.1, libyaml-devel >= 0.1.4, python >= 2.7, python-pip, openssl-devel >= 1.0.2, libudev-devel ")
 else ()
   SET (CPACK_GENERATOR "TGZ")
 endif()

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -400,6 +400,7 @@ struct mailbox {
 	uint32_t		mbx_proto_ver;
 
 	bool			mbx_peer_dead;
+	uint64_t		mbx_opened;
 };
 
 static inline const char *reg2name(struct mailbox *mbx, u32 *reg)
@@ -1868,6 +1869,9 @@ int mailbox_get(struct platform_device *pdev, enum mb_kind kind, u64 *data)
 
 	mutex_lock(&mbx->mbx_lock);
 	switch (kind) {
+	case DAEMON_STATE:
+		*data = mbx->mbx_opened;
+		break;	
 	case CHAN_STATE:
 		*data = mbx->mbx_ch_state;
 		break;
@@ -1977,6 +1981,8 @@ static int mailbox_open(struct inode *inode, struct file *file)
 	if (!mbx)
 		return -ENXIO;
 
+	/* Assume msd/mpd is the only user of the software mailbox */
+	mbx->mbx_opened = 1;
 	/* create a reference to our char device in the opened file */
 	file->private_data = mbx;
 	return 0;
@@ -1989,6 +1995,7 @@ static int mailbox_close(struct inode *inode, struct file *file)
 {
 	struct mailbox *mbx = file->private_data;
 
+	mbx->mbx_opened = 0;
 	xocl_drvinst_close(mbx);
 	return 0;
 }
@@ -2227,6 +2234,7 @@ static int mailbox_probe(struct platform_device *pdev)
 	mbx->mbx_req_cnt = 0;
 	mbx->mbx_req_sz = 0;
 	mbx->mbx_peer_dead = false;
+	mbx->mbx_opened = 0;
 	mbx->mbx_prot_ver = XCL_MB_PROTOCOL_VER;
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -343,7 +343,7 @@ static ssize_t ready_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
-	uint64_t ch_state = 0, ret = 0;
+	uint64_t ch_state = 0, ret = 0, daemon_state = 0;
 
 	/* Bypass this check for versal for now */
 	if (XOCL_DSA_IS_VERSAL(xdev))
@@ -351,7 +351,18 @@ static ssize_t ready_show(struct device *dev,
 	else {
 		xocl_mailbox_get(xdev, CHAN_STATE, &ch_state);
 
-		ret = (ch_state & XCL_MB_PEER_READY) ? 1 : 0;
+		if (ch_state & XCL_MB_PEER_SAME_DOMAIN)
+			ret = (ch_state & XCL_MB_PEER_READY) ? 1 : 0;
+		else {
+			/*
+			* If xocl and xclmgmt are not in the same daemon,
+			* mark the card as ready only when both MB channel
+			* and daemon are ready
+			*/
+			xocl_mailbox_get(xdev, DAEMON_STATE, &daemon_state);
+			ret = ((ch_state & XCL_MB_PEER_READY) && daemon_state)
+				? 1 : 0;
+		}
 	}
 
 	return sprintf(buf, "0x%llx\n", ret);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -804,6 +804,7 @@ enum data_kind {
 };
 
 enum mb_kind {
+	DAEMON_STATE,
 	CHAN_STATE,
 	CHAN_SWITCH,
 	COMM_ID,

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(mpd
   boost_system
   uuid
   dl
+  udev
   )
 install (TARGETS mpd RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
@@ -14,6 +14,12 @@ include_directories(
 file(GLOB AWS_PLUGIN_FILES
   "aws_dev.h"
   "aws_dev.cpp"
+  "../common.h"
+  "../common.cpp"
+  "../sw_msg.h"
+  "../sw_msg.cpp"
+  "../pciefunc.h"
+  "../pciefunc.cpp"
   )
 
 add_library(aws_plugin OBJECT ${AWS_PLUGIN_FILES})
@@ -34,6 +40,7 @@ if(${INTERNAL_TESTING_FOR_AWS})
     boost_system
     pthread
     rt
+    dl
     )
 else()
   include_directories(${AWS_FPGA_REPO_DIR}/sdk/userspace/include/) # path to fpga_mgmt.h
@@ -47,6 +54,7 @@ else()
     boost_system
     pthread
     rt
+    dl
     ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a
     )
 endif()

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -34,11 +34,12 @@
 #include <iostream>
 #include <fstream>
 #include <exception>
+#include <future>
 #include <uuid/uuid.h>
 #include "xclbin.h"
 #include "aws_dev.h"
 
-
+static std::map<std::string, size_t>index_map;
 /*
  * Functions each plugin needs to provide
  */
@@ -59,11 +60,15 @@ int init(mpd_plugin_callbacks *cbs)
         syslog(LOG_INFO, "aws: no device found");
         return ret;
     }
+    ret = AwsDev::init(index_map);
+    if (ret)
+        return ret;    
     if (cbs) 
     {
         // hook functions
         cbs->mpc_cookie = NULL;
         cbs->get_remote_msd_fd = get_remote_msd_fd;
+        cbs->mb_notify = mb_notify;
         cbs->mb_req.load_xclbin = awsLoadXclBin;
         cbs->mb_req.peer_data.get_icap_data = awsGetIcap;
         cbs->mb_req.peer_data.get_sensor_data = awsGetSensor;
@@ -106,6 +111,53 @@ int get_remote_msd_fd(size_t index, int* fd)
 {
     *fd = -1;
     return 0;
+}
+
+/*
+ * callback function that is used to notify xocl the imagined xclmgmt
+ * online/offline
+ * Input:
+ *        index: index of the user PF
+ *        fd: mailbox file descriptor
+ *        online: online or offline 
+ * Output:
+ *        None
+ * Return value:
+ *        0: success
+ *        others: err code
+ */
+int mb_notify(size_t index, int fd, bool online)
+{
+    std::unique_ptr<sw_msg> swmsg;
+    struct xcl_mailbox_req *mb_req = NULL;
+    struct xcl_mailbox_peer_state mb_conn = { 0 };
+    size_t data_len = sizeof(struct xcl_mailbox_peer_state) + sizeof(struct xcl_mailbox_req);
+    pcieFunc dev(index);
+   
+    std::vector<char> buf(data_len, 0);
+    mb_req = reinterpret_cast<struct xcl_mailbox_req *>(buf.data());
+
+    mb_req->req = XCL_MAILBOX_REQ_MGMT_STATE;
+    if (online)
+        mb_conn.state_flags |= XCL_MB_STATE_ONLINE;
+    else
+        mb_conn.state_flags |= XCL_MB_STATE_OFFLINE;
+    memcpy(mb_req->data, &mb_conn, sizeof(mb_conn));
+
+    try {
+        swmsg = std::make_unique<sw_msg>(mb_req, data_len, 0x1234, XCL_MB_REQ_FLAG_REQUEST);
+    } catch (std::exception &e) {
+        std::cout << "aws mb_notify: " << e.what() << std::endl;
+        throw;
+    }
+
+    struct queue_msg msg;
+    msg.localFd = fd;
+    msg.type = REMOTE_MSG;
+    msg.cb = nullptr;
+    msg.data = std::move(swmsg);
+
+    return handleMsg(dev, msg);    
 }
 
 /*
@@ -281,6 +333,18 @@ int awsGetSubdev(size_t index, char *resp, size_t resp_len)
 }
 
 /*
+ * Reset requires the mailbox msg return before the real reset
+ * happens. So we run user special reset in async thread.
+ */
+std::future<void> nouse; //so far we don't care the return value of reset
+static void awsResetDeviceAsync(size_t index)
+{
+    AwsDev d(index, nullptr);
+    if (d.isGood()) {
+        d.awsResetDevice();
+    }
+}
+/*
  * callback function that is used to handle MAILBOX_REQ_HOT_RESET msg
  * 
  * Input:
@@ -293,13 +357,9 @@ int awsGetSubdev(size_t index, char *resp, size_t resp_len)
  */
 int awsResetDevice(size_t index, int *resp)
 {
-    int ret = -1;
-    AwsDev d(index, nullptr);
-    if (d.isGood()) {
-        *resp = d.awsResetDevice();
-        ret = 0;
-    }
-    return ret;
+    *resp = -ENOTSUP;
+    nouse = std::async(std::launch::async, &awsResetDeviceAsync, index);
+    return 0;
 }
 
 /*
@@ -391,6 +451,16 @@ int awsReadP2pBarAddr(size_t index, const xcl_mailbox_p2p_bar_addr *addr, int *r
     return ret;
 }
 
+/*
+ * On AWS F1, fpga user PF without xclbin being loaded (cleared) has different
+ * device id (0x1042) than that of the user PF with xclbin being loaded (0xf010)
+ * Changint the device id needs pci node remove and rescan.
+ * fpga_pci_rescan_slot_app_pfs( mBoardNumber ) is the function used to do that.
+ * removal of the pf requires unload the xocl driver, within mpd it is impossible.
+ * So we assume the user already made the change by loading a default afi from cmdline
+ * with fpga-load-local-image.
+ * From mpd & xocl perspective, whichever device id doesn't matter.
+ */
 int AwsDev::awsLoadXclBin(const xclBin *buffer)
 {
 #ifdef INTERNAL_TESTING_FOR_AWS
@@ -519,7 +589,19 @@ bool AwsDev::isGood() {
 
 int AwsDev::awsUserProbe(xcl_mailbox_conn_resp *resp)
 {
+#ifndef INTERNAL_TESTING_FOR_AWS
+    fpga_slot_spec spec_array[16];
+    std::memset(spec_array, 0, sizeof(fpga_slot_spec) * 16);
+    if (fpga_pci_get_all_slot_specs(spec_array, 16)) {
+        std::cout << "ERROR: failed at fpga_pci_get_all_slot_specs" << std::endl;
+        return -1;
+    }
+
+    if (spec_array[mBoardNumber].map[FPGA_APP_PF].device_id != AWS_UserPF_DEVICE_ID)
+        resp->conn_flags |= XCL_MB_PEER_READY;
+#else
     resp->conn_flags |= XCL_MB_PEER_READY;
+#endif
     return 0;
 }
 
@@ -580,7 +662,7 @@ AwsDev::~AwsDev()
     }
 }
 
-AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
+AwsDev::AwsDev(size_t index, const char *logfileName)
 {
     if (logfileName != nullptr) {
         mLogStream.open(logfileName);
@@ -588,7 +670,10 @@ AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
         mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     }
 
+    std::string sysfs_name = pcidev::get_dev(index, true)->sysfs_name;
+    std::cout << "AwsDev: " << sysfs_name << "(index: " << index << ")" << std::endl;
 #ifdef INTERNAL_TESTING_FOR_AWS
+    mBoardNumber = index;
     char file_name_buf[128];
     std::fill(&file_name_buf[0], &file_name_buf[0] + 128, 0);
     std::sprintf((char *)&file_name_buf, "/dev/awsmgmt%d", mBoardNumber);
@@ -600,31 +685,13 @@ AwsDev::AwsDev(size_t index, const char *logfileName) : mBoardNumber(index)
 
 #else
     fpga_mgmt_init(); // aws-fpga version newer than 09/2019 need this
-    loadDefaultAfiIfCleared();
+    mBoardNumber = index_map[sysfs_name];
     //bar0 is mapped already. seems other 2 bars are not required.
 #endif
 }
 
 //private functions
 #ifndef INTERNAL_TESTING_FOR_AWS
-int AwsDev::loadDefaultAfiIfCleared( void )
-{
-    int array_len = 16;
-    fpga_slot_spec spec_array[ array_len ];
-    std::memset( spec_array, mBoardNumber, sizeof(fpga_slot_spec) * array_len );
-    fpga_pci_get_all_slot_specs( spec_array, array_len );
-    if( spec_array[mBoardNumber].map[FPGA_APP_PF].device_id == AWS_UserPF_DEVICE_ID ) {
-        std::string agfi = DEFAULT_GLOBAL_AFI;
-        fpga_mgmt_load_local_image( mBoardNumber, const_cast<char*>(agfi.c_str()) );
-        if( sleepUntilLoaded( agfi ) ) {
-            std::cout << "ERROR: Sleep until load failed." << std::endl;
-            return -1;
-        }
-        fpga_pci_rescan_slot_app_pfs( mBoardNumber );
-    }
-    return 0;
-}
-
 int AwsDev::sleepUntilLoaded( const std::string &afi )
 {
     for( int i = 0; i < 20; i++ ) {

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -18,12 +18,18 @@
 
 #include <fstream>
 #include <vector>
+#include <map>
+#include <sstream>
+#include <iomanip>
 #include <string>
 #include "xclhal2.h"
 #include "core/pcie/driver/linux/include/mailbox_proto.h"
 #include "core/pcie/driver/linux/include/mgmt-ioctl.h"
 #include "core/pcie/linux/scan.h"
 #include "../mpd_plugin.h"
+#include "../common.h"
+#include "../sw_msg.h"
+#include "../pciefunc.h"
 
 #ifdef INTERNAL_TESTING_FOR_AWS
 #include "core/pcie/driver/linux/include/xocl_ioctl.h"
@@ -58,6 +64,72 @@ public:
     AwsDev(size_t index, const char *logfileName);
     ~AwsDev();
 
+    static int init(std::map<std::string, size_t>& index_map)
+    {
+#ifndef INTERNAL_TESTING_FOR_AWS
+        int domain, bus, dev, func;
+        if (fpga_mgmt_init() || fpga_pci_init() ) {
+            std::cout << "ERROR: failed to initialized fpga libraries" << std::endl;
+            return -1;
+        }
+        fpga_slot_spec spec_array[16];
+        std::memset(spec_array, 0, sizeof(fpga_slot_spec) * 16);
+        if (fpga_pci_get_all_slot_specs(spec_array, 16)) {
+            std::cout << "ERROR: failed at fpga_pci_get_all_slot_specs" << std::endl;
+            return -1;
+        }
+
+        for (unsigned short i = 0; i < 16; i++) {
+            if (spec_array[i].map[FPGA_APP_PF].vendor_id == 0)
+                break;
+
+            domain = spec_array[i].map[FPGA_APP_PF].domain;
+            bus = spec_array[i].map[FPGA_APP_PF].bus;
+            dev = spec_array[i].map[FPGA_APP_PF].dev;
+            func = spec_array[i].map[FPGA_APP_PF].func;
+
+            std::stringstream domain_str;
+            std::stringstream bus_str;
+            std::stringstream dev_str;
+            //Note: Below works with stringstream only for integers and not for uint8, etc.
+            domain_str << std::setw(4) << std::setfill('0') << domain;
+            bus_str << std::setw(2) << std::setfill('0') << std::hex << bus;
+            dev_str << std::setw(2) << std::setfill('0') << std::hex << dev;
+            std::string func_str = std::to_string(func);//stringstream is giving minimum of two chars
+
+            std::string sysfs_name = domain_str.str() + ":" + bus_str.str() + ":" + dev_str.str() + "." + func_str;
+            index_map[sysfs_name] = i;
+
+            if (spec_array[i].map[FPGA_APP_PF].device_id == AWS_UserPF_DEVICE_ID) {
+                std::cout << "aws: load default afi to " << sysfs_name  << std::endl;
+                std::string agfi = DEFAULT_GLOBAL_AFI;
+                fpga_mgmt_load_local_image( i, const_cast<char*>(agfi.c_str()) );
+                int j, result = 0;
+                for (j = 0; j < 300; j++) {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    fpga_mgmt_image_info info;
+                    std::memset( &info, 0, sizeof(struct fpga_mgmt_image_info));
+                    result = fpga_mgmt_describe_local_image(i, &info, 0);
+                    if (result) {
+                        std::cout << "aws: init: load default afi failed: " << result << std::endl;
+                        break;
+                    }
+                    if( (info.status == FPGA_STATUS_LOADED) && !std::strcmp(info.ids.afi_id, const_cast<char*>(agfi.c_str())) ) {
+                        break;
+                }
+                if (j >= 300) {
+                    std::cout << "aws: init: load default afi timeout" << std::endl;
+                    break;
+                }
+                if (result)
+                    break;
+                fpga_pci_rescan_slot_app_pfs(i);
+                }
+            }
+        }
+#endif
+        return 0;
+    };
     int awsGetIcap(xcl_pr_region *resp);
     int awsGetSensor(xcl_sensor *resp);
     int awsGetBdinfo(xcl_board_info *resp);
@@ -75,19 +147,19 @@ public:
     int awsUserProbe(xcl_mailbox_conn_resp *resp);
     bool isGood();
 private:
-    const int mBoardNumber;
+    int mBoardNumber;
     std::ofstream mLogStream;
 #ifdef INTERNAL_TESTING_FOR_AWS
     int mMgtHandle;
 #else
     int sleepUntilLoaded( const std::string &afi );
     int checkAndSkipReload( char *afi_id, fpga_mgmt_image_info *info );
-    int loadDefaultAfiIfCleared( void );
     char* get_afi_from_axlf(const axlf * buffer);
 #endif
 };
 
 int get_remote_msd_fd(size_t index, int* fd);
+int mb_notify(size_t index, int fd, bool online);
 int awsLoadXclBin(size_t index, const axlf *xclbin, int *resp);
 int awsGetIcap(size_t index, xcl_pr_region *resp);
 int awsGetSensor(size_t index, xcl_sensor *resp);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/common.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/common.cpp
@@ -131,6 +131,39 @@ bool sendMsg(const pcieFunc& dev, int fd, sw_msg *swmsg)
 }
 
 /*
+ * Wait for incoming msg from udev event from all FPGA nodes.
+ * The fd with incoming msg is returned.
+ */
+int waitForMsg(int fd, long interval)
+{
+    fd_set fds;
+    int ret = 0;
+    struct timeval timeout = { interval, 0 };
+
+    FD_ZERO(&fds);
+    if (fd >= 0)
+        FD_SET(fd, &fds);
+
+    if (interval == 0) {
+        ret = select(fd + 1, &fds, NULL, NULL, NULL);
+    } else {
+        ret = select(fd + 1, &fds, NULL, NULL, &timeout);
+    }
+
+    if (ret == -1) {
+        syslog(LOG_ERR, "failed to select: %m");
+        return -EINVAL; // failed
+    }
+    if (ret == 0)
+        return -EAGAIN; // time'd tout
+
+    if (fd > 0 && FD_ISSET(fd, &fds)) {
+        syslog(LOG_INFO, "udev msg arrived on fd %d", fd);
+    }
+    return 0;
+}
+
+/*
  * Wait for incoming msg from either socket or mailbox fd.
  * The fd with incoming msg is returned.
  */
@@ -242,9 +275,9 @@ int handleMsg(const pcieFunc& dev, queue_msg &msg)
         pass = (*msg.cb)(dev, swmsg, swmsgProcessed);
     }
 
-    if (pass == FOR_LOCAL && sendMsg(dev, msg.localFd, swmsgProcessed.get()))
+    if (pass == FOR_LOCAL && msg.localFd > 0 && sendMsg(dev, msg.localFd, swmsgProcessed.get()))
         return 0;
-    if (pass == FOR_REMOTE && sendMsg(dev, msg.remoteFd, swmsgProcessed.get()))
+    if (pass == FOR_REMOTE && msg.remoteFd > 0 && sendMsg(dev, msg.remoteFd, swmsgProcessed.get()))
         return 0;
     // Error occured
     return -EINVAL;
@@ -270,7 +303,7 @@ void Common::postStop()
     closelog();         
 }
 
-Common::Common(std::string &name, std::string &plugin_path, bool for_user) :
+Common::Common(const std::string &name, const std::string &plugin_path, bool for_user) :
     name(name), plugin_path(plugin_path)
 {
     total = pcidev::get_dev_total(for_user);

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.service.in
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.service.in
@@ -1,5 +1,8 @@
 [Unit]
 Description=Xilinx Management Proxy Daemon (MPD)
+Wants=network-online.target
+After=network-online.target
+ConditionDirectoryNotEmpty=/dev/xfpga
 
 [Service]
 Type=simple

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd_plugin.h
@@ -23,6 +23,7 @@
 #include "xclbin.h"
 
 typedef int (*get_remote_msd_fd_fn)(size_t index, int *fd);
+typedef int (*mb_notify_fn)(size_t index, int fd, bool online);
 typedef int (*hot_reset_fn)(size_t index, int *resp);
 typedef int (*load_xclbin_fn)(size_t index, const axlf *buf, int *resp);
 typedef int (*reclock2_fn)(size_t index, const struct xclmgmt_ioc_freqscaling *obj, int *resp);
@@ -56,6 +57,12 @@ struct mpd_plugin_callbacks {
      * have more controls on the xclbin downloading.
      */
     get_remote_msd_fd_fn get_remote_msd_fd;
+    /*
+     * Function to notify software mailbox online/offline.
+     * For those without xclmgmt driver, this hook function is used to notify
+     * the xocl that imagined mgmt is online/offline. 
+     */
+    mb_notify_fn mb_notify;
     /*
      * The following are all hook functions handling software mailbox msg
      * that initialized from xocl driver

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.cpp
@@ -30,6 +30,7 @@
 #include <cstdlib>
 #include <csignal>
 #include <cstring>
+#include <exception>
 #include <dlfcn.h>
 
 #include "pciefunc.h"
@@ -48,18 +49,10 @@ static uint64_t chanSwitch = (1UL<<XCL_MAILBOX_REQ_TEST_READY) |
 static struct msd_plugin_callbacks plugin_cbs;
 static const std::string plugin_path("/opt/xilinx/xrt/lib/libmsd_plugin.so");
 
-static std::string getHost();
-static void createSocket(const pcieFunc& dev, int& sockfd, uint16_t& port);
-static int verifyMpd(const pcieFunc& dev, int mpdfd, int id);
-static int connectMpd(const pcieFunc& dev, int sockfd, int id, int& mpdfd);
-void msd_thread(size_t index, std::string host);
-int remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
-    std::unique_ptr<sw_msg>& processed);
-
 class Msd : public Common
 {
 public:
-    Msd(std::string name, std::string plugin_path, bool for_user) :
+    Msd(const std::string name, const std::string plugin_path, bool for_user) :
         Common(name, plugin_path, for_user), plugin_init(nullptr), plugin_fini(nullptr)
     {
     }
@@ -71,6 +64,15 @@ public:
     void start();
     void run();
     void stop();
+    static std::string getHost();
+    static void createSocket(const pcieFunc& dev, int& sockfd, uint16_t& port);
+    static int verifyMpd(const pcieFunc& dev, int mpdfd, int id);
+    static int connectMpd(const pcieFunc& dev, int sockfd, int id, int& mpdfd);
+    static void msd_thread(size_t index, std::string host);
+    static int remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
+        std::unique_ptr<sw_msg>& processed);
+    static int download_xclbin(const pcieFunc& dev, char *xclbin);
+
     init_fn plugin_init;
     fini_fn plugin_fini;
     std::vector<std::thread> threads;
@@ -107,7 +109,7 @@ void Msd::run()
     if (total == 0)
         syslog(LOG_INFO, "no device found");
     for (size_t i = 0; i < total; i++)
-        threads.emplace_back(msd_thread, i, host);
+        threads.emplace_back(Msd::msd_thread, i, host);
 }
 
 void Msd::stop()
@@ -121,7 +123,7 @@ void Msd::stop()
 }
 
 // Get host configured in config file
-static std::string getHost()
+std::string Msd::getHost()
 {
     std::ifstream cfile(configFile);
     if (!cfile.good()) {
@@ -142,7 +144,7 @@ static std::string getHost()
     return "";
 }
 
-static void createSocket(const pcieFunc& dev, int& sockfd, uint16_t& port)
+void Msd::createSocket(const pcieFunc& dev, int& sockfd, uint16_t& port)
 {
     struct sockaddr_in saddr = { 0 };
 
@@ -178,7 +180,7 @@ static void createSocket(const pcieFunc& dev, int& sockfd, uint16_t& port)
     port = ntohs(saddr.sin_port); // Retrieve allocated port by kernel
 }
 
-static int verifyMpd(const pcieFunc& dev, int mpdfd, int id)
+int Msd::verifyMpd(const pcieFunc& dev, int mpdfd, int id)
 {
     int mpdid;
 
@@ -202,7 +204,7 @@ static int verifyMpd(const pcieFunc& dev, int mpdfd, int id)
     return 0;
 }
 
-static int connectMpd(const pcieFunc& dev, int sockfd, int id, int& mpdfd)
+int Msd::connectMpd(const pcieFunc& dev, int sockfd, int id, int& mpdfd)
 {
     struct sockaddr_in mpdaddr = { 0 };
 
@@ -227,7 +229,7 @@ static int connectMpd(const pcieFunc& dev, int sockfd, int id, int& mpdfd)
     return 0;
 }
 
-int download_xclbin(const pcieFunc& dev, char *xclbin)
+int Msd::download_xclbin(const pcieFunc& dev, char *xclbin)
 {
     retrieve_xclbin_fini_fn done = nullptr;
     void *done_arg = nullptr;
@@ -261,7 +263,7 @@ int download_xclbin(const pcieFunc& dev, char *xclbin)
     return ret;
 }
 
-int remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
+int Msd::remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
     std::unique_ptr<sw_msg>& processed)
 {
     int pass = FOR_LOCAL;
@@ -303,13 +305,12 @@ int remoteMsgHandler(const pcieFunc& dev, std::unique_ptr<sw_msg>& orig,
 
 // Server serving MPD. Any error from socket fd, re-accept, don't quit.
 // Will quit on any error from local mailbox fd.
-void msd_thread(size_t index, std::string host)
+void Msd::msd_thread(size_t index, std::string host)
 {
     uint16_t port;
     int sockfd = -1, mpdfd = -1, mbxfd = -1;
     int retfd[2];
     int ret;
-    struct queue_msg msg = {0};
     const int interval = 2;
 
     pcieFunc dev(index, false);
@@ -355,25 +356,28 @@ void msd_thread(size_t index, std::string host)
             continue;
         }
 
-        msg.localFd = mbxfd;
-        msg.remoteFd = mpdfd;
-
         // Process msg.
         for (int i = 0; i < 2; i++) {
+            struct queue_msg msg = {0};
             if (retfd[i] == mbxfd) {
+                msg.localFd = mbxfd;
+                msg.remoteFd = -1;
                 msg.type = LOCAL_MSG;
                 msg.data = std::move(getLocalMsg(dev, mbxfd));
             } else if (retfd[i] == mpdfd) {
+                msg.localFd = -1;
+                msg.remoteFd = mpdfd;
                 msg.type = REMOTE_MSG;
                 msg.data = std::move(getRemoteMsg(dev, mpdfd));
-                msg.cb = remoteMsgHandler;
+                msg.cb = Msd::remoteMsgHandler;
             } else {
                 continue;
             }
 
             ret = handleMsg(dev, msg);
             if (ret) { // Socket connection was lost, retry
-                close(mpdfd);
+                if (mpdfd >= 0)
+                    close(mpdfd);
                 mpdfd = -1;
                 continue;
             }
@@ -406,11 +410,16 @@ int main(void)
     signal(SIGINT, signalHandler);
     signal(SIGTERM, signalHandler);
 
-    Msd msd("msd", plugin_path, false);
-    msd.preStart();
-    msd.start();
-    msd.run();
-    msd.stop();
-    msd.postStop();
+    try {
+	Msd msd("msd", plugin_path, false);
+	msd.preStart();
+	msd.start();
+	msd.run();
+	msd.stop();
+	msd.postStop();
+    } catch (std::exception& e) {
+        syslog(LOG_ERR, "msd: %s", e.what());
+    }
+
     return 0;
 }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/msd.service.in
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/msd.service.in
@@ -1,5 +1,8 @@
 [Unit]
 Description=Xilinx Management Service Daemon (MSD)
+Wants=network-online.target
+After=network-online.target
+ConditionDirectoryNotEmpty=/dev/xfpga
 
 [Service]
 Type=simple

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -109,9 +109,13 @@ static void print_pci_info(std::ostream &ostr)
 
     if (pcidev::get_dev_total() != pcidev::get_dev_ready()) {
         ostr << "WARNING: "
-            << "card(s) marked by '*' are not ready, "
-            << "run xbmgmt flash --scan --verbose to further check the details."
-            << std::endl;
+        << "card(s) marked by '*' are not ready, is MPD runing? "
+		<< "run 'systemctl status mpd' to check MPD details.";
+		if (pcidev::get_dev_total(false) == 0)
+		    ostr << std::endl;
+		else
+		    ostr << " please also run 'xbmgmt flash --scan --verbose' to further check card details."
+		        << std::endl;
     }
 }
 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -88,6 +88,7 @@ RH_LIST=(\
      zlib-static \
      curl-devel \
      openssl-devel \
+     libudev-devel \
 )
 
 UB_LIST=(\
@@ -136,6 +137,8 @@ UB_LIST=(\
      uuid-dev \
      libcurl4-openssl-dev \
      libssl-dev \
+     libudev-dev \
+     libsystemd-dev \
 )
 
 if [[ $docker == 0 ]]; then


### PR DESCRIPTION
backport some of the mpd new feature support and bug fix to 2019.2 for aws, the changes includes,
1. udev support
2. when xocl and xclmgmt in different domain, the card is marked as not ready when mpd doesn't get started.