### PR TITLE
CR-1049331 HBM temp missing from xbutil query Temperature section

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -767,7 +767,7 @@ public:
         sensor_tree::put( "board.physical.thermal.pcb.btm_front", xmc_se98_temp2);
 
         // physical.thermal
-        unsigned int fan_rpm, xmc_fpga_temp, xmc_fan_temp, vccint_temp;
+        unsigned int fan_rpm, xmc_fpga_temp, xmc_fan_temp, vccint_temp, xmc_hbm_temp;
         std::string fan_presence;
         
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_fpga_temp", xmc_fpga_temp );
@@ -775,11 +775,13 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "fan_presence",         errmsg, fan_presence );
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_fan_rpm",   fan_rpm );
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_vccint_temp",  vccint_temp);
+        pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_hbm_temp",  xmc_hbm_temp);
         sensor_tree::put( "board.physical.thermal.fpga_temp",    xmc_fpga_temp );
         sensor_tree::put( "board.physical.thermal.tcrit_temp",   xmc_fan_temp );
         sensor_tree::put( "board.physical.thermal.fan_presence", fan_presence );
         sensor_tree::put( "board.physical.thermal.fan_speed",    fan_rpm );
-        sensor_tree::put( "board.physical.thermal.vccint_temp",     vccint_temp);
+        sensor_tree::put( "board.physical.thermal.vccint_temp",  vccint_temp);
+        sensor_tree::put( "board.physical.thermal.hbm_temp",     xmc_hbm_temp);
 
         // physical.thermal.cage
         unsigned int temp0, temp1, temp2, temp3;
@@ -1051,6 +1053,8 @@ public:
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp1" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp2" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp3" ) << std::endl;
+        ostr << std::setw(16) << "HBM TEMP" << std::endl;
+        ostr << std::setw(16) << sensor_tree::get<std::string>( "board.physical.thermal.hbm_temp") << std::endl;
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         ostr << "Electrical(mV|mA)\n";
         ostr << std::setw(16) << "12V PEX" << std::setw(16) << "12V AUX" << std::setw(16) << "12V PEX Current" << std::setw(16) 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1054,7 +1054,7 @@ public:
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp2" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp3" ) << std::endl;
         ostr << std::setw(16) << "HBM TEMP" << std::endl;
-        ostr << std::setw(16) << sensor_tree::get<std::string>( "board.physical.thermal.hbm_temp") << std::endl;
+        ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.hbm_temp") << std::endl;
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         ostr << "Electrical(mV|mA)\n";
         ostr << std::setw(16) << "12V PEX" << std::setw(16) << "12V AUX" << std::setw(16) << "12V PEX Current" << std::setw(16) 


### PR DESCRIPTION
requested by marking, just simply add temp[0] as hbm temp. 

Test Results:
```
xbutil query
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Temperature(C)                                                                  
PCB TOP FRONT   PCB TOP REAR    PCB BTM FRONT   VCCINT TEMP                     
36              31              N/A             41                              
FPGA TEMP       TCRIT Temp      FAN Presence    FAN Speed(RPM)                  
39              35              P               N/A                             
QSFP 0          QSFP 1          QSFP 2          QSFP 3                          
N/A             N/A             N/A             N/A                             
HBM TEMP                                                                        
34  

xbutil dump
        "physical":                                                      
        {                                                                
            "thermal":                                                   
            {                                                            
                "pcb":                                                   
                {                                                        
                    "top_front": "36",                                   
                    "top_rear": "31",                                    
                    "btm_front": "0"                                     
                },                                                       
                "fpga_temp": "39",                                       
                "tcrit_temp": "35",                                      
                "fan_presence": "P",                                     
                "fan_speed": "0",                                        
                "vccint_temp": "41",                                     
                "cage":                                                  
                {                                                        
                    "temp0": "0",                                        
                    "temp1": "0",                                        
                    "temp2": "0",                                        
                    "temp3": "0"                                         
                },                                                       
                "hbm_temp": "34"                                         
            },
```