### PR TITLE
xmc: remove warn message for clk scaling not enabled case

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1354,7 +1354,7 @@ static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev)
 		if (!XMC_PRIVILEGED(xmc)) {
 			xocl_dbg(dev, "runtime clock scaling is not supported in non privileged mode\n");
 		} else if (xmc->cs_on_ptfm) {
-			xocl_warn(dev, "runtime clock scaling is not enabled\n");
+			xocl_dbg(dev, "runtime clock scaling is not enabled\n");
 			return true;
 		} else {
 			xocl_warn(dev, "runtime clock scaling is not supported\n");


### PR DESCRIPTION
Removing warning message and make it debug print. Otherwise,
it is creating confusion to the user in certain test cases.

CR-1053867

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>