### PR TITLE
HBM ECC disable/enable feature

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -332,7 +332,7 @@ struct xocl_subdev_map {
 #define	XOCL_RES_MIG_HBM				\
 		((struct resource []) {			\
 			{				\
-			.start	= 0x5800,		\
+			.start	= 0x3C00,		\
 			.end 	= 0x58FF,		\
 			.flags  = IORESOURCE_MEM,	\
 			}				\


### PR DESCRIPTION
http://jira.xilinx.com/browse/CR-1051483

"Change XRT such that it does not set ECC_CORRECTION_EN - if ECC_CORRECTION_EN == 0 then simply ignore the memory in terms of ECC
Change XRT such that it is easily possible to disable/enable ECC dynamically
This requires 4 registers to be adjusted (1/0) based on whether ECC is being enabled or disabled."