### PR TITLE
Bug Fix: Added a command argument preprocessor implicit arguments

### DIFF
--- a/src/runtime_src/tools/xclbin/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbin/FormattedOutput.cxx
@@ -27,7 +27,7 @@
 #include <boost/property_tree/json_parser.hpp>
 
 // Generated include files
-#include <version.h>
+#include "version.h"
 
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
@@ -226,7 +226,7 @@ FormattedOutput::getKernelDDRMemory(const std::string _sKernelInstanceName,
 void
 reportBuildVersion( std::ostream & _ostream)
 {
-  _ostream << XUtil::format("%17s: %s", "XRT Build Version", xrt_build_version).c_str() << std::endl;
+  _ostream << XUtil::format("%17s: %s (%s)", "XRT Build Version", xrt_build_version, xrt_build_version_branch).c_str() << std::endl;
   _ostream << XUtil::format("%17s: %s", "Build Date", xrt_build_version_date).c_str() << std::endl;
   _ostream << XUtil::format("%17s: %s", "Hash ID", xrt_build_version_hash).c_str() << std::endl;
 }

--- a/src/runtime_src/tools/xclbin/Section.cxx
+++ b/src/runtime_src/tools/xclbin/Section.cxx
@@ -604,7 +604,7 @@ Section::getSubPayload(std::ostringstream &_buf,
   // All is good now get the data from the section
   getSubPayload(m_pBuffer, m_bufferSize, _buf, _sSubSection, _eFormatType);
 
-  if (_buf.tellp() == 0) {
+  if ((long) _buf.tellp() == 0) {
     return false;
   }
 

--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -32,7 +32,7 @@ namespace XUtil = XclBinUtilities;
 
 #include "FormattedOutput.h"
 // Generated include files
-#include <version.h>
+#include "version.h"
 static const std::string MIRROR_DATA_START = "XCLBIN_MIRROR_DATA_START";
 static const std::string MIRROR_DATA_END = "XCLBIN_MIRROR_DATA_END";
 

--- a/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinUtilMain.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -89,7 +89,7 @@ void QUIET(const std::string _msg){
 }
 
 // Program entry point
-int main_(int argc, char** argv) {
+int main_(int argc, const char** argv) {
   bool bVerbose = false;
   bool bTrace = false;
   bool bMigrateForward = false;

--- a/src/runtime_src/tools/xclbin/XclBinUtilMain.h
+++ b/src/runtime_src/tools/xclbin/XclBinUtilMain.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,6 +17,6 @@
 #ifndef __XclBinUtilMain_h_
 #define __XclBinUtilMain_h_
 
-int main_(int argc, char** argv);
+int main_(int argc, const char** argv);
 
 #endif

--- a/src/runtime_src/tools/xclbin/xclbinutil.cxx
+++ b/src/runtime_src/tools/xclbin/xclbinutil.cxx
@@ -28,7 +28,7 @@ int main( int argc, char** argv )
   // and adjacent key value pairs.  In other words, depending on which version
   // of boost you are using, the syntax:
   //     --info myfile
-  // may or maynot be value.  What is value across all versions is:
+  // may or maynot be valued.  What is valued across all versions is:
   //     --info=myfile
 
   std::vector<std::string> implicitOptions = {"--info"};

--- a/src/runtime_src/tools/xclbin/xclbinutil.cxx
+++ b/src/runtime_src/tools/xclbin/xclbinutil.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,11 +20,55 @@
 #include <string>
 #include <iostream>
 #include <exception>
+#include <vector>
 
 int main( int argc, char** argv )
 {
+  // A kludge fix around changes in boost with regards to implicit values
+  // and adjacent key value pairs.  In other words, depending on which version
+  // of boost you are using, the syntax:
+  //     --info myfile
+  // may or maynot be value.  What is value across all versions is:
+  //     --info=myfile
+
+  std::vector<std::string> implicitOptions = {"--info"};
+
+  // A simply way of managing memory.  No need for a new or delete.
+  std::vector<std::string> newOptions;    // Collection of strings (used instead of new/deletes)
+  std::vector<const char *> argv_vector;  // Collection of string pointers
+
+  // Examine the options
+  for (int index = 0; index < argc; ++index) {
+    bool optionProcessed = false;
+
+    // Examine the current entry to determine if it is implicit
+    for (const auto & option: implicitOptions) {
+      if (option.compare(argv[index]) == 0) {
+
+        // Look ahead one option to see if we need merge the two
+        int peekIndex = index + 1;
+        if ((peekIndex < argc) && (argv[peekIndex][0] != '-')) {
+          std::string newOption = option + "=" + argv[peekIndex];
+          newOptions.push_back(newOption);
+          argv_vector.push_back(newOptions.back().c_str());
+          index = peekIndex;
+          optionProcessed = true;
+          break;
+        }
+      }
+    }
+    if (optionProcessed)
+      continue;
+
+    argv_vector.push_back(argv[index]);
+  }
+
+  // We are now ready to parse the options
+  const char** new_argv = argv_vector.data();
+  int new_argc = (int) argv_vector.size();
+
   try {
-    return main_( argc, argv );
+    return main_(new_argc, new_argv );
   } catch( XclBinUtilities::XclBinUtilException &e) {
     std::cerr << e.what() << std::endl;
     return (int) e.exceptionType();
@@ -40,3 +84,4 @@ int main( int argc, char** argv )
   }
   return -1;
 }
+


### PR DESCRIPTION
This is a kludge fix to address changes in boost with regards on how it process implicit values.  In the past, adjacent key value pairs need not have an equal '=' value.  Going forward it now requires it.
For example:
--info myfile
was valued with some versions of boost.  With new versions of the boot libraries only the syntax:
--info=myfile
is valued.