### PR TITLE
CR-1053003 XRT - xbutil clock command fails after toggling the gate

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -386,6 +386,24 @@ static unsigned short clock_get_freq_impl(struct clock *clock, int idx)
 	return freq;
 }
 
+static void clock_freq_request_load(struct clock *clock, u32 *curr_freq,
+	u32 *new_freq, int size, bool need_toggle)
+{
+	int i;
+
+	for (i = 0; i < size; i++) {
+		new_freq[i] = clock->clock_ocl_frequency[i];
+		curr_freq[i] = clock_get_freq_impl(clock, i);
+
+		/*
+		 * toggle gate will reset all clock wizard value to default,
+		 * thus we should preserve all clock wizard value before.
+		 */
+		if (need_toggle && new_freq[i] == 0)
+			new_freq[i] = curr_freq[i];
+	}
+}
+
 /*
  * Based on Clocking Wizard v5.1, section Dynamic Reconfiguration
  * through AXI4-Lite
@@ -397,7 +415,9 @@ static unsigned short clock_get_freq_impl(struct clock *clock, int idx)
 static int clock_ocl_freqscaling(struct clock *clock, bool force,
 	struct gate_handler *gate_handle)
 {
-	unsigned curr_freq[CLOCK_MAX_NUM_CLOCKS];
+	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);
+	u32 curr_freq[CLOCK_MAX_NUM_CLOCKS] = { 0 };
+	u32 new_freq[CLOCK_MAX_NUM_CLOCKS] = { 0 };
 	u32 config;
 	int i;
 	int j = 0;
@@ -408,34 +428,47 @@ static int clock_ocl_freqscaling(struct clock *clock, bool force,
 	BUG_ON(!mutex_is_locked(&clock->clock_lock));
 
 	/*
-	 * Get curr_freq before toggling the gate,
-	 * otherwise value will be reset to default.
+	 * 2RP workflow will toggle gate instead of freeze/free the gate,
+	 * after each toggle, EVERY value in clock wizard will be reset to
+	 * default value. We have to cache every clock wizard value before
+	 * toggling the gate, and ENFORCE set those value back in the clock
+	 * wizard register after toggling the gate.
 	 */
-	for (i = 0; i < CLOCK_MAX_NUM_CLOCKS; ++i) {
-		curr_freq[i] = clock_get_freq_impl(clock, i);
-	}
-	if (gate_handle && gate_handle->gate_toggle_cb)
+	if (CLOCK_DEV_LEVEL(xdev) > XOCL_SUBDEV_LEVEL_PRP &&
+	    gate_handle && gate_handle->gate_toggle_cb) {
+		force = true; /* explicitly force clock update */
+		clock_freq_request_load(clock, curr_freq, new_freq,
+		    CLOCK_MAX_NUM_CLOCKS, true);
 		gate_handle->gate_toggle_cb(gate_handle->gate_args);
+	} else {
+		clock_freq_request_load(clock, curr_freq, new_freq,
+		    CLOCK_MAX_NUM_CLOCKS, false);
+	}
 
 	for (i = 0; i < CLOCK_MAX_NUM_CLOCKS; ++i) {
 		/* A value of zero means skip scaling for this clock index */
-		if (!clock->clock_ocl_frequency[i])
+		if (!new_freq[i])
 			continue;
+
 		/* skip if the io does not exist */
 		if (!clock->clock_bases[i])
 			continue;
 
-		idx = find_matching_freq_config(clock->clock_ocl_frequency[i]);
+		idx = find_matching_freq_config(new_freq[i]);
 
-		CLOCK_INFO(clock, "Clock %d, Current %d Mhz, New %d Mhz ",
-				i, curr_freq[i], clock->clock_ocl_frequency[i]);
+		CLOCK_INFO(clock,
+		    "Clock: %d, Current: %d Mhz, New: %d Mhz, Force: %d",
+		    i, curr_freq[i], new_freq[i], force);
 
 		/*
 		 * If current frequency is in the same step as the
 		 * requested frequency then nothing to do.
 		 */
-		if (!force && (find_matching_freq_config(curr_freq[i]) == idx))
+		if (!force && (find_matching_freq_config(curr_freq[i]) == idx)) {
+			CLOCK_INFO(clock, "current freq and new freq are the "
+			    "same, skip updating.");
 			continue;
+		}
 
 		val = reg_rd(clock->clock_bases[i] +
 			OCL_CLKWIZ_STATUS_OFFSET);
@@ -495,6 +528,7 @@ static int clock_ocl_freqscaling(struct clock *clock, bool force,
 static int set_freqs(struct clock *clock, unsigned short *freqs, int num_freqs,
 	struct gate_handler *gate_handle)
 {
+	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);
 	int i;
 	int err = 0;
 	u32 val;
@@ -521,18 +555,21 @@ static int set_freqs(struct clock *clock, unsigned short *freqs, int num_freqs,
 		sizeof(*freqs) * min(CLOCK_MAX_NUM_CLOCKS, num_freqs));
 
 	/*
+	 * For ULP clock subdev, we should not freeze and free gate.
+	 * In the future, we will have separate ULP subdev to handle the request.
+	 *
 	 * When gate_handler callback funcs are present, we freeze and free the
 	 * gate. It is caller's fault if freeze and free pair has not been set
 	 * appropriately.
-	 * When ep_ucs_control_status_00 is present, clock is in ULP. The gate
-	 * handler is smart enough to do right operations.
 	 */
-	if (gate_handle && gate_handle->gate_freeze_cb)
+	if (CLOCK_DEV_LEVEL(xdev) <= XOCL_SUBDEV_LEVEL_PRP &&
+	    gate_handle && gate_handle->gate_freeze_cb)
 		gate_handle->gate_freeze_cb(gate_handle->gate_args);
 
 	err = clock_ocl_freqscaling(clock, false, gate_handle);
 
-	if (gate_handle && gate_handle->gate_free_cb)
+	if (CLOCK_DEV_LEVEL(xdev) <= XOCL_SUBDEV_LEVEL_PRP &&
+	    gate_handle && gate_handle->gate_free_cb)
 		gate_handle->gate_free_cb(gate_handle->gate_args);
 
 	/* enable kernel clocks */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -706,22 +706,14 @@ static int ulp_toggle_axi_gate(void *drvdata)
 	return 0;
 }
 
-static int ulp_freeze_axi_gate(void *drvdata)
+static inline int ulp_freeze_axi_gate(void *drvdata)
 {
-	struct icap *icap = drvdata;
-	xdev_handle_t xdev = xocl_get_xdev(icap->icap_pdev);
-
-	return (CLOCK_DEV_LEVEL(xdev) > XOCL_SUBDEV_LEVEL_PRP) ?
-	    0 : icap_freeze_axi_gate(icap);
+	return icap_freeze_axi_gate((struct icap *)drvdata);
 }
 
-static int ulp_free_axi_gate(void *drvdata)
+static inline int ulp_free_axi_gate(void *drvdata)
 {
-	struct icap *icap = drvdata;
-	xdev_handle_t xdev = xocl_get_xdev(icap->icap_pdev);
-
-	return (CLOCK_DEV_LEVEL(xdev) > XOCL_SUBDEV_LEVEL_PRP) ?
-	    0 : icap_free_axi_gate(icap);
+	return icap_free_axi_gate((struct icap *)drvdata);
 }
 
 static int ulp_clock_update(struct icap *icap, unsigned short *freqs,


### PR DESCRIPTION
This is the version of having cached freq for setting clock, tested and passed. 
Mark it as "do not merge" for now. Wait for platfrom team's feedback.

Just in case we have to do it in this way.