### PR TITLE
CR-1052500 XRT - Don't display SC information or update SC flash when…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1786,8 +1786,8 @@ struct xocl_subdev_map {
 #define XOCL_RES_XMC_MFG				\
 	((struct resource []) {				\
 		{					\
-			.start	= 0x140000,		\
-			.end	= 0x141fff,		\
+			.start	= 0x120000,		\
+			.end 	= 0x121FFF,		\
 			.flags  = IORESOURCE_MEM,	\
 		},					\
 	})

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1690,7 +1690,7 @@ struct xocl_subdev_map {
 #define MFG_RES_U50							\
 	((struct xocl_subdev_info []) {					\
 	 	XOCL_DEVINFO_FLASH_MFG_U50,				\
-	 	XOCL_DEVINFO_XMC_MFG_U50,				\
+		/* XOCL_DEVINFO_XMC_U50, */				\
 	 })
 
 #define	XOCL_BOARD_XBB_MFG_U50						\
@@ -1783,9 +1783,27 @@ struct xocl_subdev_map {
 		.board_name = "u250"					\
 	}
 
+#define XOCL_RES_XMC_MFG				\
+	((struct resource []) {				\
+		{					\
+			.start	= 0x140000,		\
+			.end	= 0x141fff,		\
+			.flags  = IORESOURCE_MEM,	\
+		},					\
+	})
+
+#define XOCL_DEVINFO_XMC_MFG				\
+	{						\
+		XOCL_SUBDEV_MB,				\
+		XOCL_XMC,				\
+		XOCL_RES_XMC_MFG,			\
+		ARRAY_SIZE(XOCL_RES_XMC_MFG),		\
+	}
+
 #define MFG_RES								\
 	((struct xocl_subdev_info []) {					\
 		XOCL_DEVINFO_FLASH,					\
+		XOCL_DEVINFO_XMC_MFG,					\
 	})
 
 #define	XOCL_BOARD_XBB_MFG(board)					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1687,6 +1687,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_XMC_MFG_U50),	\
 	}
 
+/* Temporary disable XMC for U50 Golden, see CR-1052500 for more info */
 #define MFG_RES_U50							\
 	((struct xocl_subdev_info []) {					\
 	 	XOCL_DEVINFO_FLASH_MFG_U50,				\

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -293,6 +293,19 @@ static int resetShell(unsigned index)
     return flasher.upgradeFirmware("", nullptr, nullptr);
 }
 
+/* We do not take the risk to flash any bmc marked as UNKNOWN */
+static void isSameShellOrSC(DSAInfo& candidate, DSAInfo& current,
+	bool *same_dsa, bool *same_bmc)
+{
+    if (!current.name.empty()) {
+        *same_dsa = (candidate.name == current.name &&
+            candidate.matchId(current));
+        *same_bmc = (current.bmcVer.empty() ||
+            current.bmcVer.compare(DSAInfo::UNKNOWN) == 0 ||
+            candidate.bmcVer == current.bmcVer);
+    }
+}
+
 static int updateShellAndSC(unsigned boardIdx, DSAInfo& candidate, bool& reboot)
 {
     reboot = false;
@@ -306,12 +319,8 @@ static int updateShellAndSC(unsigned boardIdx, DSAInfo& candidate, bool& reboot)
     bool same_dsa = false;
     bool same_bmc = false;
     DSAInfo current = flasher.getOnBoardDSA();
-    if (!current.name.empty()) {
-        same_dsa = (candidate.name == current.name &&
-            candidate.matchId(current));
-        same_bmc = (current.bmcVer.empty() ||
-            candidate.bmcVer == current.bmcVer);
-    }
+    isSameShellOrSC(candidate, current, &same_dsa, &same_bmc);
+
     if (same_dsa && same_bmc)
         std::cout << "update not needed" << std::endl;
 
@@ -392,19 +401,23 @@ static DSAInfo selectShell(unsigned idx, std::string& dsa, std::string& id)
     bool same_dsa = false;
     bool same_bmc = false;
     DSAInfo currentDSA = flasher.getOnBoardDSA();
-    if (!currentDSA.name.empty()) {
-        same_dsa = (candidate.name == currentDSA.name &&
-            candidate.matchId(currentDSA));
-        same_bmc = (currentDSA.bmcVer.empty() ||
-            candidate.bmcVer == currentDSA.bmcVer);
-    }
+    isSameShellOrSC(candidate, currentDSA, &same_dsa, &same_bmc);
+ 
     if (same_dsa && same_bmc) {
         std::cout << "\t Status: shell is up-to-date" << std::endl;
         return DSAInfo("");
     }
-    std::cout << "\t Status: shell needs updating" << std::endl;
-    std::cout << "\t Current shell: " << currentDSA.name << std::endl;
-    std::cout << "\t Shell to be flashed: " << candidate.name << std::endl;
+
+    if (!same_bmc) {
+        std::cout << "\t Status: SC needs updating" << std::endl;
+        std::cout << "\t Current SC: " << currentDSA.bmcVer<< std::endl;
+        std::cout << "\t SC to be flashed: " << candidate.bmcVer << std::endl;
+    }
+    if (!same_dsa) {
+        std::cout << "\t Status: shell needs updating" << std::endl;
+        std::cout << "\t Current shell: " << currentDSA.name << std::endl;
+        std::cout << "\t Shell to be flashed: " << candidate.name << std::endl;
+    }
     return candidate;
 }
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -34,6 +34,9 @@
 #define hex_digit "([0-9a-fA-F]+)"
 
 using namespace boost::filesystem;
+
+const std::string DSAInfo::UNKNOWN = "UNKNOWN";
+
 /*
  * Helper to parse DSA name string and retrieve all tokens
  * The DSA name string is passed in by value since it'll be modified inside.

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -55,6 +55,7 @@ public:
     std::string partition_family_name;
     std::string partition_name;
     std::string build_ident;
+    static const std::string UNKNOWN;
 
     DSAInfo(const std::string& filename, uint64_t ts, const std::string& id, const std::string& bmc);
     DSAInfo(const std::string& filename);

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -391,7 +391,7 @@ DSAInfo Flasher::getOnBoardDSA()
     else if (rc == -EOPNOTSUPP)
         bmc.clear(); // BMC is not supported on DSA
     else
-        bmc = "UNKNOWN"; // BMC not ready, set it to an invalid version string
+        bmc = DSAInfo::UNKNOWN; // BMC not ready, set it to an invalid version string
 
     return DSAInfo(vbnv, ts, uuid, bmc);
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -38,7 +38,7 @@ XMC_Flasher::XMC_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     bool is_mfg = false;
     mDev->sysfs_get<bool>("", "mfg", err, is_mfg, false);
     if (!is_mfg) {
-         if (!hasXMC())
+        if (!hasXMC())
             goto nosup;
 
         mDev->sysfs_get<unsigned>("xmc", "status", err, val, 0);


### PR DESCRIPTION
… golden/recovery image loaded

1) Temporary disable XMC for U50 Golden;
2) Enable XMC for all other legacy Golden;
3) Test Results:

>1) flash SC only

[root@xsjhemn41 ~]# xbmgmt flash --scan
Card [0001:58:00.0]
    Card type:          u50
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u50_gen3x16-xdma_blp_1,[ID=0xf465b0a3ae8c64f6],[SC=5.0.22]
    Flashable partitions installed in system:
        xilinx_u50_xdma_201920_2,[ID=0x5e155197],[SC=5.0.26]
         #xilinx_u50_gen3x16-xdma_blp_1,[ID=0xf465b0a3ae8c64f6],[SC=5.0.26]

xbmgmt flash --update --shell xilinx_u50_gen3x16-xdma_blp_1
         Status: SC needs updating
         Current SC: 5.0.22
         SC to be flashed: 5.0.26
Are you sure you wish to proceed? [y/n]: y

Updating SC firmware on card[0001:58:00.0]
Stopping user function...
INFO: found 5 sections
..............................
INFO: Loading new firmware on SC
................
Successfully flashed Card[0001:58:00.0]

1 Card(s) flashed successfully.


> 2 flash u50 Golden

xbmgmt flash --scan
Card [0000:d9:00.0]
    Card type:          u50
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u50_GOLDEN_9
    Flashable partitions installed in system:
        xilinx_u50_gen3x16-xdma_blp_1,[ID=0xf465b0a3ae8c64f6],[SC=5.0.26]


xbmgmt flash --update --shell xilinx_u50_gen3x16-xdma_blp_1 --card 0000:d9:00.0
         Status: shell needs updating
         Current shell: xilinx_u50_GOLDEN_9
         Shell to be flashed: xilinx_u50_gen3x16-xdma_blp_1
Are you sure you wish to proceed? [y/n]: y

Updating shell on card[0000:d9:00.0]
INFO: ***Found 353 ELA Records
Enabled bitstream guard. Bitstream will not be loaded until flashing is finished.
Preparing flash chip 0
Erasing flash.................
Programming flash.................
Cleared bitstream guard. Bitstream now active.
Successfully flashed Card[0000:d9:00.0]

1 Card(s) flashed successfully.
Cold reboot machine to load the new image on card(s).

 > 3) I will need a good most recent golden which can work with a shell, so we can display the sc version correctly. It seems that all recent SC won't work with golden any more. 