### PR TITLE
Add support for Kernels 5.4+ with drm API changes

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -1627,8 +1627,12 @@ static long qdma_stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 	flags = O_CLOEXEC | O_RDWR;
 
 	XOCL_DRM_GEM_OBJECT_GET(&xobj->base);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
 	dmabuf = drm_gem_prime_export(XOCL_DRM(xdev)->ddev,
-				&xobj->base, flags);
+                               &xobj->base, flags);
+#else
+	dmabuf = drm_gem_prime_export(&xobj->base, flags);
+#endif
 	if (IS_ERR(dmabuf)) {
 		xocl_err(&qdma->pdev->dev, "failed to export dma_buf");
 		ret = PTR_ERR(dmabuf);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -370,8 +370,12 @@ static const struct vm_operations_struct xocl_vm_ops = {
 };
 
 static struct drm_driver mm_drm_driver = {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
 	.driver_features		= DRIVER_GEM | DRIVER_PRIME |
 						DRIVER_RENDER,
+#else
+	.driver_features		= DRIVER_GEM | DRIVER_RENDER,
+#endif
 
 	.postclose			= xocl_client_release,
 	.open				= xocl_client_open,


### PR DESCRIPTION
Build on test on Ubuntu 20.04 LTS (beta) kernel 5.4.0-12

Initializes U250 
[drm] Initialized xocl 2.5.0 20200212 for 0000:09:00.1 on minor 1
..
xocl 0000:09:00.1: hwmon_device_register() is deprecated. Please convert the driver to use hwmon_device_register_with_info().

http://lkml.iu.edu/hypermail/linux/kernel/1909.2/03913.html