### PR TITLE
Update metadata to exclude unsupported platform

### DIFF
--- a/tests/unit_test/cuselect/testinfo.yml
+++ b/tests/unit_test/cuselect/testinfo.yml
@@ -4,7 +4,7 @@ level: 6
 owner: soeren
 user:
   allowed_test_modes: [hw]
-  excl_platforms: [xilinx_v350-es1_xdma_201920_1, xilinx_u200_qdma_201910_1, xilinx_u200_qdma_201920_1, xilinx_u250_qdma_201910_1, xilinx_u250_qdma_201920_1, xilinx_u280_xdma_201920_1, xilinx_u50_xdma_201920_1, xilinx_u50_xdma_201920_2, xilinx_samsung_U2x4_201920_1, xilinx_samsung_u2x4_201920_2, xilinx_u250_qep_201910_1, xilinx_u50_xdma_gen3x16_201920_3, xilinx_u280_xdma_201920_3]
+  excl_platforms: [xilinx_v350-es1_xdma_201920_1, xilinx_u200_qdma_201910_1, xilinx_u200_qdma_201920_1, xilinx_u250_qdma_201910_1, xilinx_u250_qdma_201920_1, xilinx_u280_xdma_201920_1, xilinx_u50_xdma_201920_1, xilinx_u50_xdma_201920_2, xilinx_samsung_U2x4_201920_1, xilinx_samsung_u2x4_201920_2, xilinx_u250_qep_201910_1, xilinx_u50_xdma_gen3x16_201920_3, xilinx_u280_xdma_201920_3, xilinx_u200_xdma_201920_1, xilinx_u200_xdma_201830_2]
   force_makefile: "--force"
   host_args: {all: cuselect.xclbin}
   host_cflags: ' -DDSA64'


### PR DESCRIPTION
Update metadata to exclude unsupported platform: xilinx_u200_xdma_201920_1, xilinx_u200_xdma_201830_2