### PR TITLE
Add DEBUG_IP_LAYOUT information

### DIFF
--- a/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
@@ -203,6 +203,7 @@ typedef enum _XOCL_STAT_CLASS {
     XoclStatKds,
     XoclStatKdsCU,
     XoclStatRomInfo,
+    XoclStatDebugIpLayout
 
 } XOCL_STAT_CLASS, *PXOCL_STAT_CLASS;
 

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -950,6 +950,59 @@ done:
       throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (get_ip_layout) failed");
   }
 
+
+  void
+      get_debug_ip_layout(char* buffer, size_t size, size_t* size_ret)
+  {
+      struct debug_ip_layout debug_iplayout_hdr;
+      XOCL_STAT_CLASS_ARGS statargs;
+
+      statargs.StatClass = XoclStatDebugIpLayout;
+
+      DWORD bytes = 0;
+      auto status = DeviceIoControl(m_dev,
+          IOCTL_XOCL_STAT,
+          &statargs, sizeof(XOCL_STAT_CLASS_ARGS),
+          &debug_iplayout_hdr, sizeof(struct debug_ip_layout),
+          &bytes,
+          nullptr);
+
+      if (!status || bytes != sizeof(struct debug_ip_layout))
+          throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (get_debug_ip_layout hdr) failed");
+
+      if (debug_iplayout_hdr.m_count == 0)
+      {
+          *size_ret = 0; //there is not any debug_ip_layout info
+          return;
+      }
+      
+      DWORD debug_ip_layout_size = sizeof(struct debug_ip_layout) + ((debug_iplayout_hdr.m_count - 1) * sizeof(struct debug_ip_data));
+
+      if (size_ret)
+          *size_ret = debug_ip_layout_size;
+
+      if (!buffer)
+          return;  // size_ret has the required size
+
+      if (size < debug_ip_layout_size)
+          throw std::runtime_error
+          ("DeviceIoControl IOCTL_XOCL_STAT (get_debug_ip_layout) failed "
+              "size (" + std::to_string(size) + ") of buffer too small, "
+              "required size (" + std::to_string(debug_ip_layout_size) + ")");
+
+      auto debug_iplayout = reinterpret_cast<struct debug_ip_layout*>(buffer);
+
+      status = DeviceIoControl(m_dev,
+          IOCTL_XOCL_STAT,
+          &statargs, sizeof(XOCL_STAT_CLASS_ARGS),
+          debug_iplayout, debug_ip_layout_size,
+          &bytes,
+          nullptr);
+
+      if (!status || bytes != debug_ip_layout_size)
+          throw std::runtime_error("DeviceIoControl IOCTL_XOCL_STAT (get_debug_ip_layout) failed");
+  }
+
   void
   get_sensor_info(xcl_sensor* value)
   {
@@ -1106,6 +1159,15 @@ get_ip_layout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret)
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_ip_layout()");
   auto shim = get_shim_object(hdl);
   shim->get_ip_layout(buffer, size, size_ret);
+}
+
+void
+get_debug_ip_layout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret)
+{
+    xrt_core::message::
+        send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_debug_ip_layout()");
+    auto shim = get_shim_object(hdl);
+    shim->get_debug_ip_layout(buffer, size, size_ret);
 }
 
 void

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -59,6 +59,19 @@ XRT_CORE_PCIE_WINDOWS_EXPORT
 void
 get_ip_layout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
 
+/**
+ * get_debug_ip_layout() - Get xclbin debug ip layout  from driver
+ *
+ * @hdl: device handle
+ * @buffer: buffer to hold the debug iplayout section, ignored if nullptr
+ * @size: size of buffer
+ * @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
+ */
+XRT_CORE_PCIE_WINDOWS_EXPORT
+void
+get_debug_ip_layout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
+
+
 XRT_CORE_PCIE_WINDOWS_EXPORT
 void
 get_bdf_info(xclDeviceHandle hdl, uint16_t bdf[3]);


### PR DESCRIPTION
Already implemented in the Windows XoclUser driver. Changes tested by a special xclbin image which has debug ip layout section. 