### PR TITLE
zocl changes to handle ap_ctrl_chain

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -26,6 +26,7 @@
 #include "sched_exec.h"
 #include "zocl_sk.h"
 #include "zocl_xclbin.h"
+#include "xclbin.h"
 
 /* #define SCHED_VERBOSE */
 
@@ -528,6 +529,9 @@ static irqreturn_t sched_exec_isr(int irq, void *arg)
 		return IRQ_NONE;
 	}
 
+	if(zocl_cu_get_control(&zdev->exec->zcu[cu_idx]) == AP_CTRL_CHAIN)
+		zocl_cu_check(&zdev->exec->zcu[cu_idx]);
+	
 	/* This function returns the value of the interrupt status register
 	 * No need to check the interrupt type for now.
 	 */
@@ -702,6 +706,7 @@ configure(struct sched_cmd *cmd)
 	int apt_idx, irq_id;
 	bool is_legacy_intr = true;
 	int ret;
+	u32 control;
 
 	if (sched_error_on(exec, opcode(cmd) != ERT_CONFIGURE))
 		return 1;
@@ -801,6 +806,7 @@ configure(struct sched_cmd *cmd)
 				has_acc_cu = 1;
 		}
 
+		control = cfg->data[i] & 0x7; //bit [2:0]
 		/* CU address should be masked by encoded handshake for KDS. */
 		cu_addr = cfg->data[i] & ZOCL_KDS_MASK;
 		if (cu_addr == ZOCL_CU_FREE_RUNNING) {
@@ -846,7 +852,7 @@ configure(struct sched_cmd *cmd)
 		cu_addr = zdev->res_start + cu_addr;
 
 		if (!acc_cu)
-			zocl_cu_init(&exec->zcu[i], MODEL_HLS, cu_addr);
+			zocl_cu_init(&exec->zcu[i], MODEL_HLS, cu_addr|control);
 		else {
 			zocl_cu_init(&exec->zcu[i], MODEL_ACC, cu_addr);
 			/* ACCEL adapter CU initial finished.

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -529,7 +529,8 @@ static irqreturn_t sched_exec_isr(int irq, void *arg)
 		return IRQ_NONE;
 	}
 
-	if(zocl_cu_get_control(&zdev->exec->zcu[cu_idx]) == AP_CTRL_CHAIN)
+	/* Check for done and write ap_continue to stop redundent interrupts */
+	if (zocl_cu_get_control(&zdev->exec->zcu[cu_idx]) == AP_CTRL_CHAIN)
 		zocl_cu_check(&zdev->exec->zcu[cu_idx]);
 	
 	/* This function returns the value of the interrupt status register

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -343,7 +343,7 @@ zocl_hls_cu_init(struct zocl_cu *cu, phys_addr_t paddr)
 	}
 
 	core->control = paddr & 0x7;
-	paddr = paddr & ZOCL_KDS_MASK; 
+	paddr = paddr & ZOCL_KDS_MASK;
 	core->paddr = paddr;
 	core->vaddr = ioremap(paddr, CU_SIZE);
 	if (!core->vaddr) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -108,6 +108,14 @@ zocl_cu_status_print(struct zocl_cu *cu)
 	    (u64)cu_core->paddr, ioread32(cu_core->vaddr));
 }
 
+u32
+zocl_cu_get_control(struct zocl_cu *cu)
+{
+	struct zcu_core *cu_core = cu->core;
+
+	return cu_core->control;
+}
+
 /* -- HLS adapter start -- */
 /* HLS adapter implementation realted code. */
 static void
@@ -334,6 +342,8 @@ zocl_hls_cu_init(struct zocl_cu *cu, phys_addr_t paddr)
 		return -ENOMEM;
 	}
 
+	core->control = paddr & 0x7;
+	paddr = paddr & ZOCL_KDS_MASK; 
 	core->paddr = paddr;
 	core->vaddr = ioremap(paddr, CU_SIZE);
 	if (!core->vaddr) {
@@ -471,6 +481,7 @@ zocl_acc_cu_init(struct zocl_cu *cu, phys_addr_t paddr)
 	core->credits = core->max_credits;
 
 	core->intr_type = 0;
+	core->control = 0;
 
 	cu->done_cnt = 0;
 	cu->ready_cnt = 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.h
@@ -68,6 +68,7 @@ struct zcu_core {
 	u32			 intr_type;
 	u32			 pending_intr;
 	u32			 running;
+	u32			 control;
 };
 
 struct zcu_funcs {
@@ -184,5 +185,6 @@ u32  zocl_cu_clear_intr(struct zocl_cu *cu);
 
 phys_addr_t zocl_cu_get_paddr(struct zocl_cu *cu);
 void zocl_cu_status_print(struct zocl_cu *cu);
+u32 zocl_cu_get_control(struct zocl_cu *cu);
 
 #endif /* _ZOCL_CU_H_ */


### PR DESCRIPTION
* current implementation of zocl doesnot handle ap_ctrl_chain in which xrt need to write on ap_continue in isr else it will generate infinite interrupts