### PR TITLE
Revert to xbtest in xbutil validate for xilinx_u50_xdma_201920_1 (#2678)

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1158,6 +1158,43 @@ int xcldev::device::runTestCase(const std::string& py,
     return runShellCmd(cmd, output);
 }
 
+int xcldev::device::runXbTestCase(const std::string& test, std::string& output)
+{
+    struct stat st;
+    int retVal;
+
+    std::string name, errmsg;
+    pcidev::get_dev(m_idx)->sysfs_get( "rom", "VBNV", errmsg, name );
+    if (!errmsg.empty()) {
+        std::cout << errmsg << std::endl;
+        return -EINVAL;
+    }
+
+    std::string devInfoPath = name + "/test/";
+    std::string xsaTestPath = xsaPath + devInfoPath;
+    std::string dsaTestPath = dsaPath + devInfoPath;
+
+    output.clear();
+
+    std::string testPath;
+    searchXsaAndDsa(m_idx, xsaTestPath, dsaTestPath, testPath, output);
+    std::string exePath = testPath + "xbtest";
+    testPath += test;
+
+    if (stat(testPath.c_str(), &st) != 0) {
+        std::cout << output << std::endl;
+        std::cout << "ERROR: Failed to find ";
+        std::cout << test;
+        std::cout << ", Shell package not installed properly.";
+        return -ENOENT;
+    }
+
+    std::string cmd = exePath + " -j " + testPath + " -d " + std::to_string(m_idx);
+    retVal = runShellCmd(cmd, output);
+
+    return retVal;
+}
+
 int xcldev::device::verifyKernelTest(void)
 {
     std::string output;
@@ -1298,6 +1335,93 @@ int xcldev::device::auxConnectionTest(void)
     return 0;
 }
 
+int xcldev::device::bandwidthKernelXbtest(void)
+{
+    std::string output;
+
+    int ret = runXbTestCase(std::string("memory.json"), output);
+
+    if (ret != 0) {
+        std::cout << output << std::endl;
+        return ret;
+    }
+
+    if (output.find("RESULT: ALL TESTS PASSED") == std::string::npos) {
+        std::cout << output << std::endl;
+        return -EINVAL;
+    }
+
+    // Print out average thruput
+    size_t st = output.find("FPGA <- HBM ");
+    if (st != std::string::npos) {
+        size_t end = output.find("\n", st);
+        std::cout << std::endl << output.substr(st, end - st) << std::endl;
+    }
+    st = output.find("FPGA -> HBM ");
+    if (st != std::string::npos) {
+        size_t end = output.find("\n", st);
+        std::cout << output.substr(st, end - st) << std::endl;
+    }
+
+    return 0;
+}
+
+int xcldev::device::verifyKernelXbtest(void)
+{
+    std::string output;
+
+    int ret = runXbTestCase(std::string("verify.json"), output);
+
+    if (ret != 0) {
+        std::cout << output << std::endl;
+        return ret;
+    }
+
+    if (output.find("RESULT: ALL TESTS PASSED") == std::string::npos) {
+        std::cout << output << std::endl;
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+int xcldev::device::dmaXbtest(void)
+{
+    std::string output;
+
+    int ret = runXbTestCase(std::string("dma.json"), output);
+
+    if (ret != 0) {
+        std::cout << output << std::endl;
+        return ret;
+    }
+
+    if (output.find("RESULT: ALL TESTS PASSED") == std::string::npos) {
+        std::cout << output << std::endl;
+        return -EINVAL;
+    }
+
+    // Print out average thruput
+    size_t st = output.find("Host -> PCIe -> FPGA");
+    if (st != std::string::npos) {
+        size_t end = output.find("\n", st);
+        std::cout << std::endl << output.substr(st, end - st);
+        st = output.find("Average", end);
+        end = output.find("\n", st);
+        std::cout << output.substr(st, end - st) << std::endl;
+    }
+    st = output.find("Host <- PCIe <- FPGA");
+    if (st != std::string::npos) {
+        size_t end = output.find("\n", st);
+        std::cout << output.substr(st, end - st);
+        st = output.find("Average", end);
+        end = output.find("\n", st);
+        std::cout << output.substr(st, end - st) << std::endl;
+    }
+
+    return 0;
+}
+
 int xcldev::device::runOneTest(std::string testName,
     std::function<int(void)> testFunc)
 {
@@ -1366,6 +1490,31 @@ int xcldev::device::validate(bool quick)
     withWarning = withWarning || (retVal == 1);
     if (retVal < 0)
         return retVal;
+
+    if (isXbTestPlatform()) {
+        retVal = runOneTest("verify kernel test",
+                std::bind(&xcldev::device::verifyKernelXbtest, this));
+        withWarning = withWarning || (retVal == 1);
+        if (retVal < 0)
+            return retVal;
+
+        // Skip the rest of test cases for quicker turn around.
+        if (quick)
+            return withWarning ? 1 : 0;
+
+        retVal = runOneTest("DMA test",
+                std::bind(&xcldev::device::dmaXbtest, this));
+        withWarning = withWarning || (retVal == 1);
+        if (retVal < 0)
+            return retVal;
+
+        retVal = runOneTest("device memory bandwidth test",
+                std::bind(&xcldev::device::bandwidthKernelXbtest, this));
+        withWarning = withWarning || (retVal == 1);
+        if (retVal < 0)
+            return retVal;
+        return withWarning ? 1 : 0;
+    }
 
     // Test verify kernel
     retVal = runOneTest("verify kernel test",

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1720,6 +1720,22 @@ public:
         return xclGetDeviceInfo2(m_handle, &devinfo);
     }
 
+    // Currently only u50 uses xbtest
+    bool isXbTestPlatform(void) {
+        std::string name, errmsg;
+        pcidev::get_dev(m_idx)->sysfs_get( "rom", "VBNV", errmsg, name );
+
+        if (!errmsg.empty()) {
+            std::cout << errmsg << std::endl;
+            return false;
+        }
+
+        if( strstr( name.c_str(), "_u50_xdma_201920_1" ) ) { //This is U50 device
+            return true;
+        }
+        return false;
+    }
+
     int validate(bool quick);
 
     int reset(xclResetKind kind);
@@ -1733,6 +1749,15 @@ private:
     // all output from the run into "output"
     // Note: exe should assume index to be 0 without -d
     int runTestCase(const std::string& exe, const std::string& xclbin, std::string& output);
+
+    // Run a test case using the xbtest external program and collect
+    // all output from the run into "output"
+    // Note: test is the name of a json file containing the test description
+    int runXbTestCase(const std::string& test, std::string& output);
+
+    int bandwidthKernelXbtest(void);
+    int verifyKernelXbtest(void);
+    int dmaXbtest(void);
 
     int scVersionTest(void);
     int pcieLinkTest(void);


### PR DESCRIPTION
* Revert "CR-1049198 U50 3x16x 201920_2 - xbulti changes to revert to using hello_world and kernel_bw (#2557)"

This reverts commit 25f9957e1e13620a1999c7e8bc15a3c52ebfbbd1.

* xbtest changes for xdma_2019_1

(cherry picked from commit c1cd79f7f0cd49c364131a5e9b0e64910d3ccb3f)