### PR TITLE
Addressed Windows Compiling Warnings

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -28,17 +28,6 @@
 
 namespace XBUtilities {
 
-template<typename ... Args>
-
-std::string format(const std::string& format, Args ... args) {
-  const static size_t NULL_CHAR_SIZE = 1;
-  size_t size = NULL_CHAR_SIZE + snprintf(nullptr, 0, format.c_str(), args ...);
-  std::unique_ptr<char[]> buf(new char[size]);
-  snprintf(buf.get(), size, format.c_str(), args ...);
-  
-  return std::string(buf.get());
-}
-
   typedef enum {
     MT_MESSAGE,
     MT_INFO,

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdFlash.cpp
@@ -487,11 +487,11 @@ SubCmdFlash::execute(const SubCmdOptions& _options) const
   std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format("  Scan: %ld", scan));
-  XBU::verbose(XBU::format("  Shell: %ld", shell));
-  XBU::verbose(XBU::format("  sc_firmware: %ld", sc_firmware));
-  XBU::verbose(XBU::format("  Reset: %ld", reset));
-  XBU::verbose(XBU::format("  Update: %ld", update));
+  XBU::verbose(boost::str(boost::format("  Scan: %ld") % scan));
+  XBU::verbose(boost::str(boost::format("  Shell: %ld") % shell));
+  XBU::verbose(boost::str(boost::format("  sc_firmware: %ld") % sc_firmware));
+  XBU::verbose(boost::str(boost::format("  Reset: %ld") % reset));
+  XBU::verbose(boost::str(boost::format("  Update: %ld") % update));
 
   if (scan) {
     bool verbose;
@@ -516,8 +516,7 @@ SubCmdFlash::execute(const SubCmdOptions& _options) const
     }
 
     // -- Now process the subcommand option-------------------------------
-    XBU::verbose(XBU::format("  Verbose: %ld", verbose));
-    //XBU::verbose(XBU::format("  Json: %ld", json));
+    XBU::verbose(boost::str(boost::format("  Verbose: %ld") % verbose));
 
     if (verbose && json) {
       XBU::error("Please specify only one option");
@@ -558,10 +557,10 @@ SubCmdFlash::execute(const SubCmdOptions& _options) const
     }
 
     // -- Now process the subcommand option-------------------------------
-    XBU::verbose(XBU::format("  Force: %ld", force));
-    XBU::verbose(XBU::format("  Card: %s", bdf.c_str()));
-    XBU::verbose(XBU::format("  Shell_name: %s", name.c_str()));
-    XBU::verbose(XBU::format("  Card id: %s", id.c_str()));
+    XBU::verbose(boost::str(boost::format("  Force: %ld") % force));
+    XBU::verbose(boost::str(boost::format("  Card: %s") % bdf.c_str()));
+    XBU::verbose(boost::str(boost::format("  Shell_name: %s") % name.c_str()));
+    XBU::verbose(boost::str(boost::format("  Card id: %s") % id.c_str()));
 
     if (name.empty() && !id.empty()){
       XBU::error("Please specify the shell");
@@ -597,7 +596,7 @@ SubCmdFlash::execute(const SubCmdOptions& _options) const
     }
 
     // -- Now process the subcommand option-------------------------------
-    XBU::verbose(XBU::format("  Card: %s", bdf.c_str()));
+    XBU::verbose(boost::str(boost::format("  Card: %s") % bdf.c_str()));
 
     uint16_t idx = 0;
     if (!bdf.empty())
@@ -635,9 +634,8 @@ SubCmdFlash::execute(const SubCmdOptions& _options) const
     }
 
     // -- Now process the subcommand option-------------------------------
-    XBU::verbose(XBU::format("  Card: %s", bdf.c_str()));
-    XBU::verbose(XBU::format("  File: %s", file.c_str()));
-    // XBU::verbose(XBU::format("  Flash_type: %s", flash_type.c_str()));
+    XBU::verbose(boost::str(boost::format("  Card: %s") % bdf.c_str()));
+    XBU::verbose(boost::str(boost::format("  File: %s") % file.c_str()));
 
     if (file.empty() || bdf.empty()) {
       XBU::error("Please specify the shell file path and the device bdf");
@@ -675,8 +673,8 @@ SubCmdFlash::execute(const SubCmdOptions& _options) const
     }
 
     // -- Now process the subcommand option-------------------------------
-    XBU::verbose(XBU::format("  Card: %s", bdf.c_str()));
-    XBU::verbose(XBU::format("  Sc_file: %s", file.c_str()));
+    XBU::verbose(boost::str(boost::format("  Card: %s") % bdf.c_str()));
+    XBU::verbose(boost::str(boost::format("  Sc_file: %s") % file.c_str()));
     if (file.empty() || bdf.empty()) {
       XBU::error("Please specify the sc file path and the device bdf");
       std::cerr << scDesc <<  "\n";

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -31,10 +31,11 @@ namespace XBU = XBUtilities;
 #include "flash/flasher.h"
 
 // 3rd Party Library - Include Files
-#include "boost/format.hpp"
-#include "boost/tokenizer.hpp"
-#include "boost/filesystem.hpp"
-#include "boost/program_options.hpp"
+#include <boost/format.hpp>
+#include <boost/tokenizer.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <boost/algorithm/string.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -43,6 +44,7 @@ namespace po = boost::program_options;
 #include <thread>
 #include <chrono>
 #include <ctime>
+#include <locale>
 
 #ifdef _WIN32
 #pragma warning(disable : 4996) //std::asctime
@@ -261,12 +263,17 @@ selectShell(uint16_t idx, const std::string& dsa, const std::string& id)
 static bool 
 canProceed()
 {
-  std::string input;
   bool proceed = false;
+  std::string input;
 
   std::cout << "Are you sure you wish to proceed? [Y/n]: ";
   std::getline( std::cin, input );
-  std::transform( input.begin(), input.end(), input.begin(), ::tolower );
+
+  // Ugh, the std::transform() produces windows compiler warnings due to 
+  // conversions from 'int' to 'char' in the algorithm header file
+  boost::algorithm::to_lower(input);
+  //std::transform( input.begin(), input.end(), input.begin(), [](unsigned char c){ return std::tolower(c); });
+  //std::transform( input.begin(), input.end(), input.begin(), ::tolower);
 
   // proceeds for "y", "Y" and no input
   proceed = ((input.compare("y") == 0) || input.empty());
@@ -518,8 +525,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format("  Card: %s", device));
-  XBU::verbose(XBU::format("  Update: %s", update));
+  XBU::verbose(boost::str(boost::format("  Card: %s") % device));
+  XBU::verbose(boost::str(boost::format("  Update: %s") % update));
   // Is valid BDF value valid
 
   if (test_mode) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdClock.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdClock.cpp
@@ -21,6 +21,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -87,11 +88,11 @@ SubCmdClock::execute(const SubCmdOptions& _options) const
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format("  Card: %ld", card));
-  XBU::verbose(XBU::format("Region: %ld", region));
-  XBU::verbose(XBU::format("Clock1: %ld", clock1FreqMhz));
-  XBU::verbose(XBU::format("Clock2: %ld", clock2FreqMhz));
-  XBU::verbose(XBU::format("Clock3: %ld", clock3FreqMhz));
+  XBU::verbose(boost::str(boost::format("  Card: %ld") % card));
+  XBU::verbose(boost::str(boost::format("Region: %ld") % region));
+  XBU::verbose(boost::str(boost::format("Clock1: %ld") % clock1FreqMhz));
+  XBU::verbose(boost::str(boost::format("Clock2: %ld") % clock2FreqMhz));
+  XBU::verbose(boost::str(boost::format("Clock3: %ld") % clock3FreqMhz));
 
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDD.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDD.cpp
@@ -22,6 +22,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -106,12 +107,12 @@ SubCmdDD::execute(const SubCmdOptions& _options) const
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format(" InputFile: %s", sInputFile.c_str()));
-  XBU::verbose(XBU::format("OutputFile: %s", sOutputFile.c_str()));
-  XBU::verbose(XBU::format(" BlockSize: %s", sBlockSize.c_str()));
-  XBU::verbose(XBU::format("     Count: %s", sCount.c_str()));
-  XBU::verbose(XBU::format("      Skip: %s", sSkip.c_str()));
-  XBU::verbose(XBU::format("      Seek: %s", sSeek.c_str()));
+  XBU::verbose(boost::str(boost::format(" InputFile: %s") % sInputFile.c_str()));
+  XBU::verbose(boost::str(boost::format("OutputFile: %s") % sOutputFile.c_str()));
+  XBU::verbose(boost::str(boost::format(" BlockSize: %s") % sBlockSize.c_str()));
+  XBU::verbose(boost::str(boost::format("     Count: %s") % sCount.c_str()));
+  XBU::verbose(boost::str(boost::format("      Skip: %s") % sSkip.c_str()));
+  XBU::verbose(boost::str(boost::format("      Seek: %s") % sSeek.c_str()));
 
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdMem.cpp
@@ -22,6 +22,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -100,13 +101,13 @@ SubCmdMem::execute(const SubCmdOptions& _options) const
   // -- Do some DRC checks here --------------------------------------------
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format(" Read Operation: %d", bRead));
-  XBU::verbose(XBU::format("Write Operation: %d", bWrite));
-  XBU::verbose(XBU::format("           Card: %ld", card));
-  XBU::verbose(XBU::format("  Start Address: %s", sStartAddr.c_str()));
-  XBU::verbose(XBU::format("     Size Bytes: %s", sSizeBytes.c_str()));
-  XBU::verbose(XBU::format("    Output File: %s", sOutputFile.c_str()));
-  XBU::verbose(XBU::format("        Pattern: %s", sPatternBytes.c_str()));
+  XBU::verbose(boost::str(boost::format(" Read Operation: %d") % bRead));
+  XBU::verbose(boost::str(boost::format("Write Operation: %d") % bWrite));
+  XBU::verbose(boost::str(boost::format("           Card: %ld") % card));
+  XBU::verbose(boost::str(boost::format("  Start Address: %s") % sStartAddr.c_str()));
+  XBU::verbose(boost::str(boost::format("     Size Bytes: %s") % sSizeBytes.c_str()));
+  XBU::verbose(boost::str(boost::format("    Output File: %s") % sOutputFile.c_str()));
+  XBU::verbose(boost::str(boost::format("        Pattern: %s") % sPatternBytes.c_str()));
 
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdP2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdP2P.cpp
@@ -22,6 +22,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -87,10 +88,10 @@ SubCmdP2P::execute(const SubCmdOptions& _options) const
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format("    Card: %ld", card));
-  XBU::verbose(XBU::format("  Enable: %d", bEnable));
-  XBU::verbose(XBU::format(" Disable: %d", bDisable));
-  XBU::verbose(XBU::format("Validate: %d", bValidate));
+  XBU::verbose(boost::str(boost::format("    Card: %ld") % card));
+  XBU::verbose(boost::str(boost::format("  Enable: %d") % bEnable));
+  XBU::verbose(boost::str(boost::format(" Disable: %d") % bDisable));
+  XBU::verbose(boost::str(boost::format("Validate: %d") % bValidate));
 
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -27,6 +27,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -92,9 +93,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     throw xrt_core::error("Please specify xclbin file with '-p' switch");
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format("  Card: %ld", card));
-  XBU::verbose(XBU::format("Region: %ld", region));
-  XBU::verbose(XBU::format("XclBin: %s", xclbin.c_str()));
+  XBU::verbose(boost::str(boost::format("  Card: %ld") % card));
+  XBU::verbose(boost::str(boost::format("Region: %ld") % region));
+  XBU::verbose(boost::str(boost::format("XclBin: %s") % xclbin.c_str()));
 
   if (region)
     throw xrt_core::error("region is not supported");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdTop.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdTop.cpp
@@ -22,6 +22,7 @@ namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
 #include <boost/program_options.hpp>
+#include <boost/format.hpp>
 namespace po = boost::program_options;
 
 // System - Include Files
@@ -81,7 +82,7 @@ SubCmdTop::execute(const SubCmdOptions& _options) const
   }
 
   // -- Now process the subcommand --------------------------------------------
-  XBU::verbose(XBU::format("Seconds: %ld", seconds));
+  XBU::verbose(boost::str(boost::format("Seconds: %ld") % seconds));
 
   XBU::error("COMMAND BODY NOT IMPLEMENTED.");
   // TODO: Put working code here

--- a/src/runtime_src/core/tools/xbutil2/XBReport.cpp
+++ b/src/runtime_src/core/tools/xbutil2/XBReport.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,6 +20,7 @@
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 #include "common/system.h"
+#include <boost/format.hpp>
 
 // 3rd Party Library - Include Files
 
@@ -40,13 +41,13 @@ XBReport::report_system_config()
 
   XBU::message("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
   XBU::message("System Configuration");
-  XBU::message(XBU::format("%-14s: %s", "OS Name",      pt.get<std::string>("sysname","N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Release",      pt.get<std::string>("release", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Version",      pt.get<std::string>("version", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Machine",      pt.get<std::string>("machine", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Glibc",        pt.get<std::string>("glibc", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Distribution", pt.get<std::string>("linux", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Now",          pt.get<std::string>("now", "N/A").c_str()));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "OS Name" %      pt.get<std::string>("sysname","N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Release" %      pt.get<std::string>("release", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Version" %      pt.get<std::string>("version", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Machine" %      pt.get<std::string>("machine", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Glibc" %        pt.get<std::string>("glibc", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Distribution" % pt.get<std::string>("linux", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Now" %          pt.get<std::string>("now", "N/A")));
 }
 
 void
@@ -59,10 +60,10 @@ XBReport::report_xrt_info()
 
   XBU::message("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
   XBU::message("XRT Information");
-  XBU::message(XBU::format("%-14s: %s", "Version",    pt.get<std::string>("build.version", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Git Hash",   pt.get<std::string>("build.hash", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Git Branch", pt.get<std::string>("build.branch", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "Build Date", pt.get<std::string>("build.date", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "XOCL",       pt.get<std::string>("xocl", "N/A").c_str()));
-  XBU::message(XBU::format("%-14s: %s", "XCLMGMT",    pt.get<std::string>("xclmgmt", "N/A").c_str()));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Version" %    pt.get<std::string>("build.version", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Git Hash" %   pt.get<std::string>("build.hash", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Git Branch" % pt.get<std::string>("build.branch", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "Build Date" % pt.get<std::string>("build.date", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "XOCL" %       pt.get<std::string>("xocl", "N/A")));
+  XBU::message(boost::str(boost::format("%-14s: %s") % "XCLMGMT" %    pt.get<std::string>("xclmgmt", "N/A")));
 }


### PR DESCRIPTION
Work Done
---------
+ Replaced XBUtilities::format template with boost::format.  The
XBUtilities::format used a "depricated" method was was deemed to be
unsafe.
+ Refactored SubCmdProgram::canProceed to use boost::to_lower() instead
of std::transform, which causes a windows compiling warning.