### PR TITLE
CR-1055001 program ULP Clock should wait for HBM Calibration

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -642,6 +642,7 @@ static int clock_update_freq(struct platform_device *pdev,
 	struct gate_handler *gate_handle)
 {
 	struct clock *clock = platform_get_drvdata(pdev);
+	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);
 	int err = 0;
 
 	if (gate_handle == NULL) {
@@ -654,6 +655,12 @@ static int clock_update_freq(struct platform_device *pdev,
 	    set_and_verify_freqs(clock, freqs, num_freqs, gate_handle) :
 	    set_freqs(clock, freqs, num_freqs, gate_handle);
 	mutex_unlock(&clock->clock_lock);
+
+	/* Done clock programming, wait for HBM Calibration */
+	if (CLOCK_DEV_LEVEL(xdev) > XOCL_SUBDEV_LEVEL_PRP &&
+	    gate_handle && gate_handle->gate_hbm_calibration_cb) {
+		gate_handle->gate_hbm_calibration_cb(gate_handle->gate_args);
+	}
 
 	CLOCK_INFO(clock, "verify: %d ret: %d.", verify, err);
 	return err;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -983,6 +983,7 @@ struct gate_handler {
 	int (*gate_freeze_cb)(void *drvdata);
 	int (*gate_free_cb)(void *drvdata);
 	int (*gate_toggle_cb)(void *drvdata);
+	int (*gate_hbm_calibration_cb)(void *drvdata);
 	void *gate_args;
 };
 


### PR DESCRIPTION
I kept the original code path 'unchanged' for user pf.
For mgmt pf, new code will create clock first (fatal error if not clock dev created),
then enforce HBM calibrate for all level 3 clock subdevs!

Without this enforcement, we saw firewall trips everywhere.
See CR: http://jira.xilinx.com/browse/CR-1055001 for more info.

Tested by: /proj/rdi/staff/davidzha/share/hbm.sh
U50 works, U200 seems not affected, but please carefully review the code.