### PR TITLE
reverted page alignment for hw emulation in xclMapbo

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2121,7 +2121,8 @@ void *HwEmShim::xclMapBO(unsigned int boHandle, bool write)
   }
 
   void *pBuf=nullptr;
-  if (posix_memalign(&pBuf, getpagesize(), bo->size))
+  //if (posix_memalign(&pBuf, getpagesize(), bo->size))
+  if(posix_memalign(&pBuf, sizeof(double)*16, bo->size)) 
   {
     if (mLogStream.is_open()) mLogStream << "posix_memalign failed" << std::endl;
     pBuf=nullptr;
@@ -2678,7 +2679,8 @@ void * HwEmShim::xclAllocQDMABuf(size_t size, uint64_t *buf_hdl)
     mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
   }
   void *pBuf=nullptr;
-  if (posix_memalign(&pBuf, getpagesize(), size))
+  //if (posix_memalign(&pBuf, getpagesize(), size))
+  if(posix_memalign(&pBuf, sizeof(double)*16, size))   
   {
     if (mLogStream.is_open()) mLogStream << "posix_memalign failed" << std::endl;
     pBuf=nullptr;


### PR DESCRIPTION
reverted page alignment for hw emulation in xclMapbo