### PR TITLE
xbmgmt: read sc present state before issuing any SC related packets

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -106,6 +106,11 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
     int retries = 5;
     int ret = 0;
 
+    if (!hasSC()) {
+        std::cout << "ERROR: SC is not present on platform" << std::endl;
+        return -EINVAL;
+    }
+
     if (!isXMCReady())
         return -EINVAL;
 
@@ -253,7 +258,7 @@ int XMC_Flasher::xclGetBoardInfo(std::map<char, std::vector<char>>& info)
 {
     int ret = 0;
 
-    if (!isXMCReady() || !isBMCReady())
+    if (!hasSC() || !isXMCReady() || !isBMCReady())
         return -EINVAL;
 
     mPkt = {0};
@@ -503,6 +508,24 @@ bool XMC_Flasher::isXMCReady()
 
 bool XMC_Flasher::isBMCReady()
 {
+    bool bmcReady = (BMC_MODE() == 0x1);
+
+    if (!bmcReady) {
+        xrt_core::ios_flags_restore format(std::cout);
+        std::cout << "ERROR: SC is not ready: 0x" << std::hex
+                << BMC_MODE() << std::endl;
+    }
+
+    return bmcReady;
+}
+
+bool XMC_Flasher::hasXMC()
+{
+        return !mDev->get_sysfs_path("xmc", "").empty();
+}
+
+bool XMC_Flasher::hasSC()
+{
     unsigned int val;
     std::string errmsg;
 
@@ -516,22 +539,7 @@ bool XMC_Flasher::isBMCReady()
         return false;
     }
 
-    if (val) {
-        bool bmcReady = (BMC_MODE() == 0x1);
-        if (!bmcReady) {
-            xrt_core::ios_flags_restore format(std::cout);
-            std::cout << "ERROR: SC is not ready: 0x" << std::hex
-                << BMC_MODE() << std::endl;
-        }
-        return bmcReady;
-    }
-
-    return true;
-}
-
-bool XMC_Flasher::hasXMC()
-{
-        return !mDev->get_sysfs_path("xmc", "").empty();
+    return (val != 0);
 }
 
 static void tiTxtStreamToBin(std::istream& tiTxtStream,

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
@@ -126,6 +126,7 @@ private:
     int writeReg(unsigned RegOffset, unsigned value);
     bool isXMCReady();
     bool isBMCReady();
+    bool hasSC();
 
     // Upgrade SC firmware via driver.
     std::FILE *mXmcDev = nullptr;


### PR DESCRIPTION
Integrated from PU2 branch (https://github.com/Xilinx/XRT/pull/2881). 
CR-1054786


Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>