### PR TITLE
override_idx equals to -1 then ignore

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -272,6 +272,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM,			\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_FEATURE_ROM_VERSAL			\
@@ -289,6 +290,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM_VERSAL,		\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_VERSAL),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_FEATURE_ROM_SMARTN			\
@@ -307,6 +309,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM_SMARTN,		\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_SMARTN),\
+		.override_idx = -1,			\
 	}
 
 
@@ -325,6 +328,7 @@ struct xocl_subdev_map {
 		XOCL_SYSMON,				\
 		XOCL_RES_SYSMON,			\
 		ARRAY_SIZE(XOCL_RES_SYSMON),		\
+		.override_idx = -1,			\
 	}
 
 /* Will be populated dynamically */
@@ -345,6 +349,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_MIG),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_MIG_HBM				\
@@ -391,6 +396,7 @@ struct xocl_subdev_map {
 		XOCL_FIREWALL,				\
 		XOCL_RES_AF,				\
 		ARRAY_SIZE(XOCL_RES_AF),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_AF_USER				\
@@ -399,6 +405,7 @@ struct xocl_subdev_map {
 		XOCL_FIREWALL,				\
 		NULL,					\
 		0,					\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_AF_DSA52				\
@@ -431,6 +438,7 @@ struct xocl_subdev_map {
 		XOCL_FIREWALL,				\
 		XOCL_RES_AF_DSA52,			\
 		ARRAY_SIZE(XOCL_RES_AF_DSA52),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_XVC_PUB				\
@@ -448,6 +456,7 @@ struct xocl_subdev_map {
 		XOCL_XVC_PUB,				\
 		XOCL_RES_XVC_PUB,			\
 		ARRAY_SIZE(XOCL_RES_XVC_PUB),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_XVC_PRI				\
@@ -465,6 +474,7 @@ struct xocl_subdev_map {
 		XOCL_XVC_PRI,				\
 		XOCL_RES_XVC_PRI,			\
 		ARRAY_SIZE(XOCL_RES_XVC_PRI),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_NIFD_PRI				\
@@ -482,6 +492,7 @@ struct xocl_subdev_map {
 		XOCL_NIFD_PRI,				\
 		XOCL_RES_NIFD_PRI,			\
 		ARRAY_SIZE(XOCL_RES_NIFD_PRI),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_XIIC					\
@@ -499,6 +510,7 @@ struct xocl_subdev_map {
 		XOCL_XIIC,				\
 		XOCL_RES_XIIC,				\
 		ARRAY_SIZE(XOCL_RES_XIIC),		\
+		.override_idx = -1,			\
 	}
 
 
@@ -519,6 +531,7 @@ struct xocl_subdev_map {
 		XOCL_RES_DNA,				\
 		ARRAY_SIZE(XOCL_RES_DNA),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_AIM					\
@@ -538,6 +551,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_AIM),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_AM					\
@@ -558,6 +572,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_AM),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 
@@ -579,6 +594,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_ASM),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_TRACE_FIFO_LITE			\
@@ -599,6 +615,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_TRACE_FIFO_LITE),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_TRACE_FIFO_FULL			\
@@ -619,6 +636,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_TRACE_FIFO_FULL),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 
@@ -640,6 +658,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_TRACE_FUNNEL),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_TRACE_S2MM			\
@@ -660,6 +679,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_TRACE_S2MM),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
+		.override_idx = -1,			\
 	}
 
 /* Will be populated dynamically */
@@ -702,6 +722,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_MGMT,			\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_MGMT),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_MAILBOX_OFFSET_MGMT_VERSAL		0x6050000
@@ -725,6 +746,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_MGMT_VERSAL,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_MGMT_VERSAL),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_MAILBOX_MGMT_QDMA				\
@@ -747,6 +769,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_MGMT_QDMA,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_MGMT_QDMA),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_MAILBOX_OFFSET_USER	0x200000
@@ -770,6 +793,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_USER,			\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_USER),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_MAILBOX_USER_QDMA			\
@@ -792,6 +816,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_USER_QDMA,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_USER_QDMA),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_PF_MAILBOX_OFFSET_USER_VERSAL	0x6010000
@@ -815,6 +840,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_PF_MAILBOX_USER_VERSAL,	\
 		ARRAY_SIZE(XOCL_RES_PF_MAILBOX_USER_VERSAL),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_MAILBOX_OFFSET_USER_VERSAL	0x6040000
@@ -835,6 +861,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX_VERSAL,			\
 		XOCL_RES_MAILBOX_USER_VERSAL,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_USER_VERSAL),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_ICAP_MGMT				\
@@ -852,6 +879,7 @@ struct xocl_subdev_map {
 		XOCL_ICAP,				\
 		XOCL_RES_ICAP_MGMT,			\
 		ARRAY_SIZE(XOCL_RES_ICAP_MGMT),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_ICAP_MGMT_SMARTN				\
@@ -869,6 +897,7 @@ struct xocl_subdev_map {
 		XOCL_ICAP,				\
 		XOCL_RES_ICAP_MGMT_SMARTN,		\
 		ARRAY_SIZE(XOCL_RES_ICAP_MGMT_SMARTN),	\
+		.override_idx = -1,			\
 	}
 
 #define __RES_CLOCK_K1					\
@@ -1033,6 +1062,7 @@ struct xocl_subdev_map {
 		XOCL_ICAP,				\
 		NULL,					\
 		0,					\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_XMC					\
@@ -1076,6 +1106,7 @@ struct xocl_subdev_map {
 		XOCL_XMC,				\
 		XOCL_RES_XMC,				\
 		ARRAY_SIZE(XOCL_RES_XMC),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_XMC_USER			\
@@ -1084,6 +1115,7 @@ struct xocl_subdev_map {
 		XOCL_XMC,				\
 		NULL,					\
 		0,					\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_XMC_VERSAL				\
@@ -1101,6 +1133,7 @@ struct xocl_subdev_map {
 		XOCL_XMC,				\
 		XOCL_RES_XMC_VERSAL,			\
 		ARRAY_SIZE(XOCL_RES_XMC_VERSAL),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_MB					\
@@ -1133,6 +1166,7 @@ struct xocl_subdev_map {
 		XOCL_MB,				\
 		XOCL_RES_MB,				\
 		ARRAY_SIZE(XOCL_RES_MB),		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_PS					\
@@ -1150,6 +1184,7 @@ struct xocl_subdev_map {
 		XOCL_PS,				\
 		XOCL_RES_PS,				\
 		ARRAY_SIZE(XOCL_RES_PS),		\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_QDMA					\
@@ -1168,6 +1203,7 @@ struct xocl_subdev_map {
 		XOCL_RES_QDMA,				\
 		ARRAY_SIZE(XOCL_RES_QDMA),		\
 		.bar_idx = (char []){ 2 },		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_XDMA				\
@@ -1176,12 +1212,14 @@ struct xocl_subdev_map {
 		XOCL_XDMA,				\
 		NULL,					\
 		0,					\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_DMA_MSIX				\
 	{						\
 		.id = XOCL_SUBDEV_DMA,			\
 		.name = XOCL_DMA_MSIX,			\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_SCHEDULER				\
@@ -1216,7 +1254,8 @@ struct xocl_subdev_map {
 		XOCL_RES_SCHEDULER,			\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER),		\
 		&(char []){1},				\
-		1					\
+		1,					\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_SCHEDULER_QDMA				\
@@ -1247,7 +1286,8 @@ struct xocl_subdev_map {
 		XOCL_RES_SCHEDULER_QDMA,		\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER_QDMA),	\
 		&(char []){1},				\
-		1					\
+		1,					\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_SCHEDULER_51			\
@@ -1257,7 +1297,8 @@ struct xocl_subdev_map {
 		XOCL_RES_SCHEDULER,			\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER),		\
 		&(char []){0},				\
-		1					\
+		1,					\
+		.override_idx = -1,			\
 	}
 
 #define	ERT_CQ_BASE_ADDR_VERSAL		0x4000000
@@ -1290,6 +1331,7 @@ struct xocl_subdev_map {
 		&(char []){0},		\
 		1,					\
 		.bar_idx = (char []){ 2, 2 },		\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_FMGR				\
@@ -1298,6 +1340,7 @@ struct xocl_subdev_map {
 		XOCL_FMGR,				\
 		NULL,					\
 		0,					\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_OSPI_VERSAL				\
@@ -1315,6 +1358,7 @@ struct xocl_subdev_map {
 		XOCL_OSPI_VERSAL,			\
 		XOCL_RES_OSPI_VERSAL,			\
 		ARRAY_SIZE(XOCL_RES_OSPI_VERSAL),	\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_FLASH					\
@@ -1332,6 +1376,7 @@ struct xocl_subdev_map {
 		XOCL_FLASH,				\
 		XOCL_RES_FLASH,				\
 		ARRAY_SIZE(XOCL_RES_FLASH),		\
+		.override_idx = -1,			\
 	}
 
 /* user pf defines */
@@ -1915,6 +1960,7 @@ struct xocl_subdev_map {
 		XOCL_FLASH,				\
 		XOCL_RES_FLASH_MFG_U50,			\
 		ARRAY_SIZE(XOCL_RES_FLASH_MFG_U50),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_RES_XMC_MFG_U50				\
@@ -1932,6 +1978,7 @@ struct xocl_subdev_map {
 		XOCL_XMC,				\
 		XOCL_RES_XMC_MFG_U50,			\
 		ARRAY_SIZE(XOCL_RES_XMC_MFG_U50),	\
+		.override_idx = -1,			\
 	}
 
 /* Temporary disable XMC for U50 Golden, see CR-1052500 for more info */
@@ -1956,6 +2003,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		NULL,					\
 		0,					\
+		.override_idx = -1,			\
 	}
 
 #define RES_MGMT_VSEC							\
@@ -2046,6 +2094,7 @@ struct xocl_subdev_map {
 		XOCL_XMC,				\
 		XOCL_RES_XMC_MFG,			\
 		ARRAY_SIZE(XOCL_RES_XMC_MFG),		\
+		.override_idx = -1,			\
 	}
 
 #define MFG_RES								\
@@ -2080,6 +2129,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM_DYN,		\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_DYN),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_FEATURE_ROM_USER_DYN		\
@@ -2090,6 +2140,7 @@ struct xocl_subdev_map {
 		0,					\
 		.dyn_ip = 1,				\
 		.level = XOCL_SUBDEV_LEVEL_PRP,		\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_MAILBOX_VSEC				\
@@ -2109,6 +2160,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_MAILBOX_VSEC),	\
 		.level = XOCL_SUBDEV_LEVEL_PRP,		\
 		.bar_idx = (char []){ 0 },		\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_FLASH_BLP				\
@@ -2136,7 +2188,8 @@ struct xocl_subdev_map {
 		.level = XOCL_SUBDEV_LEVEL_BLD,		\
 		.bar_idx = (char []){ 0 },		\
 		.priv_data = &XOCL_PRIV_FLASH_BLP,	\
-		.data_len = sizeof(struct xocl_flash_privdata) \
+		.data_len = sizeof(struct xocl_flash_privdata), \
+		.override_idx = -1,			\
 	}
 
 #define XOCL_DEVINFO_FLASH_VSEC XOCL_DEVINFO_FLASH_BLP
@@ -2156,6 +2209,7 @@ struct xocl_subdev_map {
 		XOCL_XMC,				\
 		XOCL_RES_XMC_BLP,			\
 		ARRAY_SIZE(XOCL_RES_XMC_BLP),		\
+		.override_idx = -1,			\
 	}
 
 
@@ -2173,6 +2227,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_USER_DYN,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_USER_DYN),	\
+		.override_idx = -1,			\
 	}
 
 
@@ -2196,6 +2251,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		XOCL_RES_MAILBOX_USER_U50,		\
 		ARRAY_SIZE(XOCL_RES_MAILBOX_USER_U50),	\
+		.override_idx = -1,			\
 	}
 
 #define	XOCL_DEVINFO_MAILBOX_USER_SOFTWARE		\
@@ -2204,6 +2260,7 @@ struct xocl_subdev_map {
 		XOCL_MAILBOX,				\
 		NULL,		\
 		0,	\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_IORES_MGMT_DYN					\
@@ -2217,6 +2274,7 @@ struct xocl_subdev_map {
 		XOCL_IORES0,					\
 		XOCL_RES_IORES_MGMT_DYN,			\
 		ARRAY_SIZE(XOCL_RES_IORES_MGMT_DYN),		\
+		.override_idx = -1,			\
 	}
 
 #define MGMT_RES_DYNAMIC_IP					\
@@ -2243,6 +2301,7 @@ struct xocl_subdev_map {
 		0,					\
 		&(char []){1},				\
 		1,					\
+		.override_idx = -1,			\
 	}
 
 #define USER_RES_DYNAMIC_IP						\
@@ -2278,6 +2337,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM_U50,		\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_U50),	\
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_IORES_MGMT_U50					\
@@ -2292,6 +2352,7 @@ struct xocl_subdev_map {
 		XOCL_IORES0,					\
 		XOCL_RES_IORES_MGMT_U50,			\
 		ARRAY_SIZE(XOCL_RES_IORES_MGMT_U50),		\
+		.override_idx = -1,			\
 	}
 
 #define MGMT_RES_U50						\
@@ -2354,7 +2415,8 @@ struct xocl_subdev_map {
 		.level = XOCL_SUBDEV_LEVEL_BLD,		\
 		.bar_idx = (char []){ 0 },		\
 		.priv_data = &XOCL_PRIV_FLASH_BLP_U25,	\
-		.data_len = sizeof(struct xocl_flash_privdata) \
+		.data_len = sizeof(struct xocl_flash_privdata), \
+		.override_idx = -1,			\
 	}
 
 #define XOCL_RES_FEATURE_ROM_U25			\
@@ -2373,6 +2435,7 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM_U25,		\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM_U25),	\
+		.override_idx = -1,			\
 	}
 
 #define MGMT_RES_U25							\
@@ -2425,6 +2488,7 @@ struct xocl_subdev_map {
 		XOCL_FLASH,				\
 		XOCL_RES_FLASH_MFG_U25,			\
 		ARRAY_SIZE(XOCL_RES_FLASH_MFG_U25),	\
+		.override_idx = -1,			\
 	}
 
 #define MFG_RES_U25							\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -89,7 +89,7 @@ static struct xocl_subdev *xocl_subdev_reserve(xdev_handle_t xdev_hdl,
 	int max = sdev_info->multi_inst ? XOCL_SUBDEV_MAX_INST : 1;
 	int i;
 
-	if (sdev_info->override_idx) {
+	if (sdev_info->override_idx != -1) {
 		subdev = &core->subdevs[devid][sdev_info->override_idx];
 		if (subdev->state != XOCL_SUBDEV_STATE_UNINIT) {
 			xocl_xdev_info(xdev_hdl, "subdev %d index %d is in-use",


### PR DESCRIPTION
To solve override_idx = 0 bug. 

Right now, if we set override_idx to 0 then it will be ignored.

