### PR TITLE
add option allowing users to use cmake toolchain

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -42,6 +42,7 @@ usage()
     echo "[-nocmake]                 Skip CMake call"
     echo "[-j <n>]                   Compile parallel (default: system cores)"
     echo "[-ccache]                  Build using RDI's compile cache"
+    echo "[-toolchain <file>]        Extra toolchain file to configure CMake"
     echo "[-driver]                  Include building driver code"
     echo "[-checkpatch]              Run checkpatch.pl on driver code"
     echo "[-verbose]                 Turn on verbosity when compiling"
@@ -69,6 +70,7 @@ dbg=1
 edge=0
 nocmake=0
 ertfw=""
+extratoolchain=0
 while [ $# -gt 0 ]; do
     case "$1" in
         -help)
@@ -110,6 +112,12 @@ while [ $# -gt 0 ]; do
             ;;
         -ccache)
             ccache=1
+            shift
+            ;;
+        -toolchain)
+            extratoolchain=1
+            shift
+            toolchain=$1
             shift
             ;;
         -checkpatch)
@@ -180,8 +188,27 @@ if [[ $dbg == 1 ]]; then
   mkdir -p $debug_dir
   cd $debug_dir
   if [[ $nocmake == 0 ]]; then
-    echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src"
-    time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src
+	if [[ $extratoolchain == 0 ]]; then
+		echo "$CMAKE -DRDI_CCACHE=$ccache"
+		echo "	-DCMAKE_BUILD_TYPE=Debug"
+		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+		echo "	../../src"
+		time $CMAKE -DRDI_CCACHE=$ccache \
+			-DCMAKE_BUILD_TYPE=Debug \
+			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+			../../src
+	else
+		echo "$CMAKE -DRDI_CCACHE=$ccache"
+		echo "	-DCMAKE_BUILD_TYPE=Debug"
+		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+		echo "	-DCMAKE_TOOLCHAIN_FILE=$toolchain"
+		echo "	../../src"
+		time $CMAKE -DRDI_CCACHE=$ccache \
+			-DCMAKE_BUILD_TYPE=Debug \
+			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+			-DCMAKE_TOOLCHAIN_FILE=$toolchain \
+			../../src
+	fi
   fi
   echo "make -j $jcore $verbose DESTDIR=$PWD install"
   time make -j $jcore $verbose DESTDIR=$PWD install
@@ -193,8 +220,27 @@ if [[ $opt == 1 ]]; then
   mkdir -p $release_dir
   cd $release_dir
   if [[ $nocmake == 0 ]]; then
-    echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src"
-    time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../../src
+	if [[ $extratoolchain == 0 ]]; then
+		echo "$CMAKE -DRDI_CCACHE=$ccache"
+		echo "	-DCMAKE_BUILD_TYPE=Release"
+		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+		echo "	../../src"
+		time $CMAKE -DRDI_CCACHE=$ccache \
+			-DCMAKE_BUILD_TYPE=Release \
+			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+			../../src
+	else
+		echo "$CMAKE -DRDI_CCACHE=$ccache"
+		echo "	-DCMAKE_BUILD_TYPE=Release"
+		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+		echo "	-DCMAKE_TOOLCHAIN_FILE=$toolchain"
+		echo "../../src"
+        time $CMAKE -DRDI_CCACHE=$ccache \
+			-DCMAKE_BUILD_TYPE=Release \
+			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+			-DCMAKE_TOOLCHAIN_FILE=$toolchain \
+			../../src
+	fi
   fi
 
   if [[ $docs == 1 ]]; then

--- a/build/build.sh
+++ b/build/build.sh
@@ -70,7 +70,6 @@ dbg=1
 edge=0
 nocmake=0
 ertfw=""
-extratoolchain=0
 while [ $# -gt 0 ]; do
     case "$1" in
         -help)
@@ -115,7 +114,6 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         -toolchain)
-            extratoolchain=1
             shift
             toolchain=$1
             shift
@@ -188,27 +186,8 @@ if [[ $dbg == 1 ]]; then
   mkdir -p $debug_dir
   cd $debug_dir
   if [[ $nocmake == 0 ]]; then
-	if [[ $extratoolchain == 0 ]]; then
-		echo "$CMAKE -DRDI_CCACHE=$ccache"
-		echo "	-DCMAKE_BUILD_TYPE=Debug"
-		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-		echo "	../../src"
-		time $CMAKE -DRDI_CCACHE=$ccache \
-			-DCMAKE_BUILD_TYPE=Debug \
-			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-			../../src
-	else
-		echo "$CMAKE -DRDI_CCACHE=$ccache"
-		echo "	-DCMAKE_BUILD_TYPE=Debug"
-		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-		echo "	-DCMAKE_TOOLCHAIN_FILE=$toolchain"
-		echo "	../../src"
-		time $CMAKE -DRDI_CCACHE=$ccache \
-			-DCMAKE_BUILD_TYPE=Debug \
-			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-			-DCMAKE_TOOLCHAIN_FILE=$toolchain \
-			../../src
-	fi
+	echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src"
+	time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src
   fi
   echo "make -j $jcore $verbose DESTDIR=$PWD install"
   time make -j $jcore $verbose DESTDIR=$PWD install
@@ -220,27 +199,8 @@ if [[ $opt == 1 ]]; then
   mkdir -p $release_dir
   cd $release_dir
   if [[ $nocmake == 0 ]]; then
-	if [[ $extratoolchain == 0 ]]; then
-		echo "$CMAKE -DRDI_CCACHE=$ccache"
-		echo "	-DCMAKE_BUILD_TYPE=Release"
-		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-		echo "	../../src"
-		time $CMAKE -DRDI_CCACHE=$ccache \
-			-DCMAKE_BUILD_TYPE=Release \
-			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-			../../src
-	else
-		echo "$CMAKE -DRDI_CCACHE=$ccache"
-		echo "	-DCMAKE_BUILD_TYPE=Release"
-		echo "	-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-		echo "	-DCMAKE_TOOLCHAIN_FILE=$toolchain"
-		echo "../../src"
-        time $CMAKE -DRDI_CCACHE=$ccache \
-			-DCMAKE_BUILD_TYPE=Release \
-			-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-			-DCMAKE_TOOLCHAIN_FILE=$toolchain \
-			../../src
-	fi
+	echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src"
+	time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src
   fi
 
   if [[ $docs == 1 ]]; then

--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -30,7 +30,7 @@ SET(Boost_VER_STR "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}")
 SET(Boost_VER_STR_ONEGREATER "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION_ONEGREATER}")
 
 SET(PACKAGE_KIND "TGZ")
-if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian|pynqlinux)")
+if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
   execute_process(
     COMMAND dpkg --print-architecture
     OUTPUT_VARIABLE CPACK_ARCH

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -69,10 +69,6 @@ if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} VERSION_GREATER 17.1
    set(Boost_USE_STATIC_LIBS  ON)
 endif()
 
-if (${LINUX_FLAVOR} STREQUAL pynqlinux)
-   set(Boost_USE_STATIC_LIBS  ON)
-endif()
-
 find_package(Boost REQUIRED COMPONENTS system filesystem )
 
 # -- Cursers ---

--- a/src/CMake/pkgconfig.cmake
+++ b/src/CMake/pkgconfig.cmake
@@ -1,6 +1,6 @@
 message("-- Preparing XRT pkg-config")
 
-if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|pynqlinux)")
+if (${LINUX_FLAVOR} MATCHES "^(Ubuntu)")
   set(XRT_PKG_CONFIG_DIR "/usr/lib/pkgconfig")
 elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS)")
   set(XRT_PKG_CONFIG_DIR "/usr/lib64/pkgconfig")


### PR DESCRIPTION
Removed pynqlinux from native build, since pynq is going through the non-native build for now. In the future we probably need better ways to decide which kind of platform users are building upon.

Add extra toolchain option, so users can provide an external toolchain file (toolchain.cmake). This option, if ignored (by default), will not take any effect.