### PR TITLE
Updated Mapping of Alveo BMC for both Gen4 and Gen5

### DIFF
--- a/src/runtime_src/tools/scripts/pkg_hw_platform.sh
+++ b/src/runtime_src/tools/scripts/pkg_hw_platform.sh
@@ -369,16 +369,8 @@ initBMCVar()
 {
     prefix=""
     if [ "${SatelliteControllerFamily}" != "" ]; then
-      if [ "${SatelliteControllerFamily}" == "Alveo-Gen1" ]; then
-         prefix="AlveoGen1-"
-      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen2" ]; then
-         prefix="AlveoGen2-"
-      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen3" ]; then
-         prefix="AlveoGen3-"
-      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen4" ]; then
-         prefix="AlveoGen4-"
-      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen5" ]; then
-         prefix="AlveoGen5-"
+      if [[ "${SatelliteControllerFamily}" == Alveo-Gen* ]]; then
+         prefix="${SatelliteControllerFamily/Alveo-Gen/AlveoGen}-"
       else
          echo "ERROR: Unknown satellite controller family: ${SatelliteControllerFamily}"
          exit 1
@@ -423,6 +415,9 @@ initBMCVar()
       # We only go through this loop once
       return
     done
+
+    echo "ERROR: Could not find satellite controller firmmware image for the family: ${SatelliteControllerFamily}"
+    exit 1
 }
 
 initXsaBinEnvAndVars()

--- a/src/runtime_src/tools/scripts/pkg_hw_platform.sh
+++ b/src/runtime_src/tools/scripts/pkg_hw_platform.sh
@@ -375,6 +375,10 @@ initBMCVar()
          prefix="AlveoGen2-"
       elif [ "${SatelliteControllerFamily}" == "Alveo-Gen3" ]; then
          prefix="AlveoGen3-"
+      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen4" ]; then
+         prefix="AlveoGen4-"
+      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen5" ]; then
+         prefix="AlveoGen5-"
       else
          echo "ERROR: Unknown satellite controller family: ${SatelliteControllerFamily}"
          exit 1

--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -340,6 +340,8 @@ initBMCVar()
          prefix="AlveoGen3-"
       elif [ "${SatelliteControllerFamily}" == "Alveo-Gen4" ]; then
          prefix="AlveoGen4-"
+      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen5" ]; then
+         prefix="AlveoGen5-"
       else
          echo "ERROR: Unknown satellite controller family: ${SatelliteControllerFamily}"
          exit 1


### PR DESCRIPTION
Issue: The mapping for both Gen4 and Gen5 FW images were missing in the packaging scripts preventing deployment platforms that use these images from being created.