### PR TITLE
Updated Mapping of Alveo BMC for both Gen4 and Gen5

### DIFF
--- a/src/runtime_src/tools/scripts/pkg_hw_platform.sh
+++ b/src/runtime_src/tools/scripts/pkg_hw_platform.sh
@@ -162,6 +162,7 @@ echo "================================================================"
 xsaFile=""
 mcsPrimary=""
 mcsSecondary=""
+pdiFile=""
 fullBitFile=""
 clearBitstreamFile=""
 metaDataJSONFile=""
@@ -242,6 +243,11 @@ recordXsaFiles()
    # MCS Secondary
    if [ "${ENTITY_ATTRIBUTES_ARRAY[Type]}" == "SECONDARY_MCS" ]; then
      mcsSecondary="firmware/${ENTITY_ATTRIBUTES_ARRAY[Name]}"
+   fi
+
+   # PDI Image
+   if [ "${ENTITY_ATTRIBUTES_ARRAY[Type]}" == "PDI" ]; then
+     pdiFile="${ENTITY_ATTRIBUTES_ARRAY[Name]}"
    fi
 
    # Clear Bitstream
@@ -449,6 +455,12 @@ initXsaBinEnvAndVars()
        unzip -q -d . "${xsaFile}" "${mcsSecondary}"
     fi
 
+    # -- Extract the PDI File --
+    if [ "${pdiFile}" != "" ]; then
+       echo "Info: Extracting PDI Primary file: ${pdiFile}"
+       unzip -q -d . "${xsaFile}" "${pdiFile}"
+    fi
+
     # -- Extract the bitstreams --
     if [ "${fullBitFile}" != "" ]; then
        echo "Info: Extracting Full Bitstream file: ${fullBitFile}"
@@ -577,6 +589,11 @@ doxsabin()
     # -- MCS_SECONDARY image --
     if [ "$mcsSecondary" != "" ]; then
        xclbinOpts+=" --add-section MCS-SECONDARY:RAW:${mcsSecondary}"
+    fi
+    
+    # -- PDI image --
+    if [ "$pdiFile" != "" ]; then
+       xclbinOpts+=" --add-section PDI:RAW:${pdiFile}"
     fi
     
     # -- Firmware: Scheduler --

--- a/src/runtime_src/tools/scripts/pkg_hw_platform.sh
+++ b/src/runtime_src/tools/scripts/pkg_hw_platform.sh
@@ -369,6 +369,10 @@ initBMCVar()
          prefix="AlveoGen2-"
       elif [ "${SatelliteControllerFamily}" == "Alveo-Gen3" ]; then
          prefix="AlveoGen3-"
+      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen4" ]; then
+         prefix="AlveoGen4-"
+      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen5" ]; then
+         prefix="AlveoGen5-"
       else
          echo "ERROR: Unknown satellite controller family: ${SatelliteControllerFamily}"
          exit 1

--- a/src/runtime_src/tools/scripts/pkgdsa.sh
+++ b/src/runtime_src/tools/scripts/pkgdsa.sh
@@ -340,6 +340,8 @@ initBMCVar()
          prefix="AlveoGen3-"
       elif [ "${SatelliteControllerFamily}" == "Alveo-Gen4" ]; then
          prefix="AlveoGen4-"
+      elif [ "${SatelliteControllerFamily}" == "Alveo-Gen5" ]; then
+         prefix="AlveoGen5-"
       else
          echo "ERROR: Unknown satellite controller family: ${SatelliteControllerFamily}"
          exit 1


### PR DESCRIPTION
Issue: The mapping for both Gen4 and Gen5 FW images were missing in the packaging scripts preventing deployment platforms that use these images from being created.