### PR TITLE
XRT-244 Build scripts for Edge platform

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+error()
+{
+    echo "ERROR: $1" 1>&2
+    usage_and_exit 1
+}
+
+usage()
+{
+    echo "Usage: $PROGRAM [options] "
+    echo "  options:"
+    echo "          -help                           Print this usage"
+    echo "          -aarch                          Architecture <aarch32/aarch64>"
+    echo "          -clean, clean                   Remove build directories"
+    echo ""
+}
+
+usage_and_exit()
+{
+    usage
+    exit $1
+}
+
+# --- Internal funtions ---
+install_recipes()
+{
+    META_USER_PATH=$1
+
+    SAVED_OPTIONS_LOCAL=$(set +o)
+    set +e
+    mkdir -p ${META_USER_PATH}/recipes-xrt/xrt
+    mkdir -p ${META_USER_PATH}/recipes-xrt/zocl
+    XRT_BB=${META_USER_PATH}/recipes-xrt/xrt/xrt_git.bbappend
+    ZOCL_BB=${META_USER_PATH}/recipes-xrt/zocl/zocl_git.bbappend
+    grep "inherit externalsrc" $XRT_BB
+    if [ $? != 0 ]; then
+        echo "inherit externalsrc" > $XRT_BB
+        echo "EXTERNALSRC = \"$XRT_REPO_DIR/src\"" >> $XRT_BB
+        echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
+        echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
+    fi
+
+    grep "inherit externalsrc" $ZOCL_BB
+    if [ $? != 0 ]; then
+        echo "inherit externalsrc" > $ZOCL_BB
+        echo "EXTERNALSRC = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
+        echo "EXTERNALSRC_BUILD = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
+        echo 'PACKAGE_CLASSES = "package_rpm"' >> $ZOCL_BB
+        echo 'pkg_postinst_ontarget_${PN}() {' >> $ZOCL_BB
+        echo '  #!/bin/sh' >> $ZOCL_BB
+        echo '  echo "Unloading old XRT Linux kernel modules"' >> $ZOCL_BB
+        echo '  ( rmmod zocl || true ) > /dev/null 2>&1' >> $ZOCL_BB
+        echo '  echo "Loading new XRT Linux kernel modules"' >> $ZOCL_BB
+        echo '  modprobe zocl' >> $ZOCL_BB
+        echo '}' >> $ZOCL_BB
+    fi
+    eval "$SAVED_OPTIONS_LOCAL"
+}
+
+
+
+# --- End internal functions
+
+SAVED_OPTIONS=$(set +o)
+
+# Don't print all commands
+set +x
+# Error on non-zero exit code, by default:
+set -e
+
+# Get real script by read symbol link
+THIS_SCRIPT=`readlink -f ${BASH_SOURCE[0]}`
+
+THIS_SCRIPT_DIR="$( cd "$( dirname "${THIS_SCRIPT}" )" >/dev/null 2>&1 && pwd )"
+
+PROGRAM=`basename $0`
+CONFIG_FILE=""
+PETA_BSP=""
+PROJ_NAME=""
+PLATFROM=""
+XRT_REPO_DIR=`readlink -f ${THIS_SCRIPT_DIR}/..`
+clean=0
+
+while [ $# -gt 0 ]; do
+	case $1 in
+		-help )
+			usage_and_exit 0
+			;;
+		-aarch )
+			shift
+			AARCH=$1
+			;;
+		-clean | clean )
+			clean=1
+			;;
+		--* | -* )
+			error "Unregognized option: $1"
+			;;
+		* )
+			error "Unregognized option: $1"
+			;;
+	esac
+	shift
+done
+
+aarch64_dir="aarch64"
+aarch32_dir="aarch32"
+versal_dir="versal"
+
+if [[ $clean == 1 ]]; then
+    echo $PWD
+    echo "/bin/rm -rf $aarch64_dir $aarch32_dir"
+    /bin/rm -rf $aarch64_dir $aarch32_dir
+    exit 0
+fi
+
+# we pick Petalinux BSP
+if [[ -z ${PETALINUX:+x} ]]; then
+    export PETALINUX="/proj/petalinux/2020.1/petalinux-v2020.1_0217_1/tool/petalinux-v2020.1-final"
+    export PETALINUX_VER=2020.1
+    export XSCT_TOOLCHAIN="${PETALINUX}/tools/xsct"
+fi
+
+if [[ $AARCH = $aarch64_dir ]]; then
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.1-final.bsp"
+elif [[ $AARCH = $aarch32_dir ]]; then
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.1-final.bsp"
+else
+    error "$AARCH not exist"
+fi
+
+# Sanity Check
+
+if [ ! -f $PETA_BSP ]; then
+    error "$PETA_BSP not accessible"
+fi
+
+# Sanity check done
+
+PETA_CONFIG_OPT="--silentconfig"
+ORIGINAL_DIR=`pwd`
+PETA_BIN="$PETALINUX/tools/common/petalinux/bin"
+
+echo "** START [${BASH_SOURCE[0]}] **"
+echo " PETALINUX: $PETALINUX"
+echo ""
+
+PETALINUX_NAME=$AARCH
+echo " * Create PetaLinux from BSP (-s $PETA_BSP)"
+PETA_CREATE_OPT="-s $PETA_BSP"
+
+if [ ! -d $PETALINUX_NAME ]; then
+    echo " * Create PetaLinux Project: $PETALINUX_NAME"
+    echo "[CMD]: petalinux-create -t project -n $PETALINUX_NAME $PETA_CREATE_OPT"
+    $PETA_BIN/petalinux-create -t project -n $PETALINUX_NAME $PETA_CREATE_OPT
+else
+    error " * PetaLinux Project existed: $PETALINUX_NAME."
+fi
+
+cd ${PETALINUX_NAME}/project-spec/meta-user/
+install_recipes .
+
+cd $ORIGINAL_DIR/$PETALINUX_NAME
+echo 'CONFIG_TMP_DIR_LOCATION="${PROOT}/build/tmp"' >> project-spec/configs/config
+
+# Build package
+echo " * Performing PetaLinux Build (from: ${PWD})"
+echo "[CMD]: petalinux-build -c xrt"
+$PETA_BIN/petalinux-build -c xrt
+echo "[CMD]: petalinux-build -c zocl"
+$PETA_BIN/petalinux-build -c zocl
+
+cd $ORIGINAL_DIR
+
+echo "Coping rpms in $ORIGINAL_DIR/$PETALINUX_NAME"
+cp -v ${PETALINUX_NAME}/build/tmp/deploy/rpm/${PLATFORM_NAME}*/*zocl* ${PETALINUX_NAME}/.
+cp -v ${PETALINUX_NAME}/build/tmp/deploy/rpm/*/xrt* ${PETALINUX_NAME}/.
+
+eval "$SAVED_OPTIONS"; # Restore shell options
+echo "** COMPLETE [${BASH_SOURCE[0]}] **"
+echo ""

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -12,6 +12,7 @@ usage()
     echo "  options:"
     echo "          -help                           Print this usage"
     echo "          -aarch                          Architecture <aarch32/aarch64>"
+    echo "          -cache                          path to sstate-cache"
     echo "          -clean, clean                   Remove build directories"
     echo ""
 }

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -40,6 +40,9 @@ install_recipes()
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
         echo 'PV = "202010.2.6.0"' >> $XRT_BB
+        echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB
+        echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=da5408f748bce8a9851dac18e66f4bcf \' >> $XRT_BB
+        echo '                    file://runtime_src/core/edge/drm/zocl/LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8 "' >> $XRT_BB
     fi
 
     grep "inherit externalsrc" $ZOCL_BB
@@ -49,6 +52,8 @@ install_recipes()
         echo "EXTERNALSRC_BUILD = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $ZOCL_BB
         echo 'PV = "202010.2.6.0"' >> $ZOCL_BB
+        echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $ZOCL_BB
+        echo 'LIC_FILES_CHKSUM = "file://LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8"' >> $ZOCL_BB
         echo 'pkg_postinst_ontarget_${PN}() {' >> $ZOCL_BB
         echo '  #!/bin/sh' >> $ZOCL_BB
         echo '  echo "Unloading old XRT Linux kernel modules"' >> $ZOCL_BB
@@ -126,6 +131,8 @@ if [[ $AARCH = $aarch64_dir ]]; then
     PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.1-final.bsp"
 elif [[ $AARCH = $aarch32_dir ]]; then
     PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.1-final.bsp"
+elif [[ $AARCH = $versal_dir ]]; then
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-vmk180-emmc-v2020.1-final.bsp"
 else
     error "$AARCH not exist"
 fi
@@ -155,8 +162,7 @@ if [ ! -d $PETALINUX_NAME ]; then
     echo "[CMD]: petalinux-create -t project -n $PETALINUX_NAME $PETA_CREATE_OPT"
     $PETA_BIN/petalinux-create -t project -n $PETALINUX_NAME $PETA_CREATE_OPT
 else
-    echo " * PetaLinux Project existed: $PETALINUX_NAME."
-    #error " * PetaLinux Project existed: $PETALINUX_NAME."
+    error " * PetaLinux Project existed: $PETALINUX_NAME."
 fi
 
 cd ${PETALINUX_NAME}/project-spec/meta-user/

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -88,6 +88,7 @@ PROJ_NAME=""
 PLATFROM=""
 XRT_REPO_DIR=`readlink -f ${THIS_SCRIPT_DIR}/..`
 clean=0
+SSTATECACHE=""
 
 while [ $# -gt 0 ]; do
 	case $1 in
@@ -101,6 +102,10 @@ while [ $# -gt 0 ]; do
 		-clean | clean )
 			clean=1
 			;;
+		-cache )
+                        shift
+                        SSTATECACHE=$1
+                        ;;
 		--* | -* )
 			error "Unregognized option: $1"
 			;;
@@ -143,6 +148,10 @@ if [ ! -f $PETA_BSP ]; then
     error "$PETA_BSP not accessible"
 fi
 
+if [ ! -d $SSTATECACHE ]; then
+    error "SSTATECACHE= not accessible"
+fi
+
 # Sanity check done
 
 PETA_CONFIG_OPT="--silentconfig"
@@ -169,6 +178,13 @@ cd ${PETALINUX_NAME}/project-spec/meta-user/
 install_recipes .
 
 cd $ORIGINAL_DIR/$PETALINUX_NAME
+
+if [ ! -z $SSTATECACHE ] && [ -d $SSTATECACHE ]; then
+    echo "SSTATE-CACHE:${SSTATECACHE} added"
+    echo "CONFIG_YOCTO_LOCAL_SSTATE_FEEDS_URL=\"${SSTATECACHE}\"" >> project-spec/configs/config
+else
+    echo "SSTATE-CACHE:${SSTATECACHE} not present"
+fi
 
 # Build package
 echo " * Performing PetaLinux Build (from: ${PWD})"

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,3 +1,3 @@
-export PETALINUX="/proj/petalinux/2020.1/petalinux-v2020.1_0227_1/tool/petalinux-v2020.1-final"
+export PETALINUX="/proj/petalinux/2020.1/petalinux-v2020.1_0310_1/tool/petalinux-v2020.1-final"
 export PETALINUX_VER=2020.1
 export XSCT_TOOLCHAIN="${PETALINUX}/tools/xsct"

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,0 +1,3 @@
+export PETALINUX="/proj/petalinux/2020.1/petalinux-v2020.1_0227_1/tool/petalinux-v2020.1-final"
+export PETALINUX_VER=2020.1
+export XSCT_TOOLCHAIN="${PETALINUX}/tools/xsct"


### PR DESCRIPTION
1. script to build xrt rpms for edge platform
2. usage:
              ./build_edge.sh  -aarch aarch32
              ./build_edge.sh  -aarch aarch64 
              ./build_edge.sh  -clean
              ./build_edge.sh  -aarch aarch32 -cache <path to sstate-cache>
              ./build_edge.sh  -aarch aarch64 -cache <path to sstate-cache>
3. script also generate rpm.txt contain list of rpm used for sysroot overlay
4. script also generate install_edge.sh and reinstall_edge.sh which is used to install rpms through dnf