### PR TITLE
Creating a Linux Kernel Interface in XRT

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -61,6 +61,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/userpf/xocl_ioctl.c
   xocl/userpf/xocl_sysfs.c
   xocl/userpf/xocl_drv.c
+  xocl/userpf/xocl_kernel_api.c
   xocl/userpf/xocl.dracut.conf
   xocl/userpf/10-xocl.rules
   xocl/userpf/Makefile
@@ -158,6 +159,7 @@ SET (XRT_DKMS_DRIVER_SRCS
 # includes relative to core/pcie/driver/linux
 SET (XRT_DKMS_DRIVER_INCLUDES
   include/xocl_ioctl.h
+  include/xocl_kernel_api.h
   include/mgmt-reg.h
   include/mgmt-ioctl.h
   include/qdma_ioctl.h

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -1215,6 +1215,21 @@ size_t
 xclDebugReadIPStatus(xclDeviceHandle handle, enum xclDebugReadType type,
                      void* debugResults);
 
+/**
+ * xclStoreAppContext() - Store application context
+ *
+ * @handle:        Device handle
+ */
+XCL_DRIVER_DLLESPEC int xclStoreAppContext(xclDeviceHandle handle);
+
+/**
+ * xclDeleteAppContext() - Delete application context
+ *
+ * @handle:        Device handle
+ */
+XCL_DRIVER_DLLESPEC int xclDeleteAppContext(xclDeviceHandle handle);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -32,6 +32,7 @@ extern "C" {
 
 #define XRT_BO_FLAGS_MEMIDX_MASK	(0xFFFFFFUL)
 #define	XCL_BO_FLAGS_CACHEABLE		(1 << 24)
+#define	XCL_BO_FLAGS_KERNPTR		(1 << 25)
 #define	XCL_BO_FLAGS_SVM		(1 << 27)
 #define	XCL_BO_FLAGS_DEV_ONLY		(1 << 28)
 #define	XCL_BO_FLAGS_HOST_ONLY		(1 << 29)

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -157,6 +157,8 @@ enum drm_xocl_ops {
 	DRM_XOCL_ALLOC_CMA,
 	/* Free allocated CMA chunk through userpf*/
 	DRM_XOCL_FREE_CMA,
+	DRM_XOCL_STORE_APP_CONTEXT,
+	DRM_XOCL_DELETE_APP_CONTEXT,
 	DRM_XOCL_NUM_IOCTLS
 };
 
@@ -447,6 +449,8 @@ struct drm_xocl_execbuf {
 	uint32_t ctx_id;
 	uint32_t exec_bo_handle;
 	uint32_t deps[8];
+	uint64_t callback_fn;
+	uint64_t ctx_ptr;
 };
 
 /**
@@ -506,4 +510,6 @@ struct drm_xocl_free_cma_info {
 #define	DRM_IOCTL_XOCL_RECLOCK		XOCL_IOC_ARG(RECLOCK, reclock_info)
 #define	DRM_IOCTL_XOCL_ALLOC_CMA	XOCL_IOC_ARG(ALLOC_CMA, alloc_cma_info)
 #define	DRM_IOCTL_XOCL_FREE_CMA		XOCL_IOC_ARG(FREE_CMA, free_cma_info)
+#define	DRM_IOCTL_XOCL_STORE_APP_CONTEXT	XOCL_IOC(STORE_APP_CONTEXT)
+#define	DRM_IOCTL_XOCL_DELETE_APP_CONTEXT	XOCL_IOC(DELETE_APP_CONTEXT)
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_kernel_api.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_kernel_api.h
@@ -1,0 +1,73 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Amit Kumar <akum@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _XOCL_KERNEL_API_H
+#define	_XOCL_KERNEL_API_H
+
+#include "xocl_ioctl.h"
+
+/**
+ * struct drm_xocl_userptr_bo - Create buffer object with user's pointer
+ * used with DRM_IOCTL_XOCL_USERPTR_BO ioctl
+ *
+ * @addr:       Address of buffer allocated by user
+ * @size:       Requested size of the buffer object
+ * @handle:     bo handle returned by the driver
+ * @flags:      DRM_XOCL_BO_XXX flags
+ * @type:       The type of bo
+ */
+struct drm_xocl_kptr_bo {
+	uint64_t addr;
+	uint64_t size;
+	uint32_t handle;
+	uint32_t flags;
+	uint32_t type;
+};
+
+/**
+ * struct drm_xocl_userptr_bo - Create buffer object with user's pointer
+ * used with DRM_IOCTL_XOCL_USERPTR_BO ioctl
+ *
+ * @sgl:       Address of buffer allocated by user
+ * @size:       Requested size of the buffer object
+ * @handle:     bo handle returned by the driver
+ * @flags:      DRM_XOCL_BO_XXX flags
+ * @type:       The type of bo
+ */
+struct drm_xocl_sgl_bo {
+	uint64_t sgl;
+	uint64_t size;
+	uint32_t handle;
+	uint32_t flags;
+	uint32_t type;
+};
+
+int xocl_create_bo_ifc(struct drm_xocl_create_bo *args);
+int xocl_map_bo_ifc(struct drm_xocl_map_bo *args);
+int xocl_sync_bo_ifc(struct drm_xocl_sync_bo *args);
+int xocl_execbuf_ifc(struct drm_xocl_execbuf *args);
+int xocl_info_bo_ifc(struct drm_xocl_info_bo *args);
+int xocl_create_kmem_bo_ifc(struct drm_xocl_kptr_bo *args);
+int xocl_remap_kmem_bo_ifc(struct drm_xocl_kptr_bo *args);
+int xocl_create_sgl_bo_ifc(struct drm_xocl_sgl_bo *args);
+int xocl_remap_sgl_bo_ifc(struct drm_xocl_sgl_bo *args);
+void xocl_delete_bo_ifc(uint32_t bo_handle);
+void __iomem *xocl_get_bo_kernel_vaddr(uint32_t bo_handle);
+
+
+#endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -49,6 +49,7 @@ xocl-y := \
 	xocl_bo.o	\
 	xocl_drm.o	\
 	xocl_ioctl.o	\
+	xocl_kernel_api.o	\
 	xocl_sysfs.o
 
 xocl-y += $(libfdt-y)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -192,6 +192,11 @@ struct xocl_mm_wrapper {
   struct hlist_node node;
 };
 
+struct xocl_drm_dev_info {
+        struct drm_device *dev;
+        struct drm_file *file;
+};
+
 /* ioctl functions */
 int xocl_info_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
@@ -211,6 +216,10 @@ int xocl_alloc_cma_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_free_cma_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
+int xocl_store_app_context_ioctl(struct drm_device *dev, void *data,
+        struct drm_file *filp);
+int xocl_delete_app_context_ioctl(struct drm_device *dev, void *data,
+        struct drm_file *filp);
 
 /* sysfs functions */
 int xocl_init_sysfs(struct xocl_dev *xdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -151,6 +151,8 @@ static void xocl_free_bo(struct drm_gem_object *obj)
 		if (xocl_bo_userptr(xobj)) {
 			xocl_release_pages(xobj->pages, npages, 0);
 			drm_free_large(xobj->pages);
+		} else if (xobj->flags == XOCL_BO_KERNPTR) {
+			drm_free_large(xobj->pages);
 		} else if (xocl_bo_p2p(xobj) || xocl_bo_import(xobj)) {
 			drm_free_large(xobj->pages);
 		} else if (xocl_bo_cma(xobj)) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -41,6 +41,7 @@
 #define XOCL_BO_IMPORT		(XOCL_HOST_MEM | XOCL_DRM_IMPORT)
 #define XOCL_BO_EXECBUF		(XOCL_HOST_MEM | XOCL_DRV_ALLOC | XOCL_DRM_SHMEM)
 #define XOCL_BO_CMA		(XOCL_HOST_MEM | XOCL_CMA_MEM)
+#define XOCL_BO_KERNPTR	 	(XOCL_DEVICE_MEM | XOCL_HOST_MEM)
 
 #define XOCL_BO_DDR0 (1 << 0)
 #define XOCL_BO_DDR1 (1 << 1)
@@ -124,6 +125,9 @@ static inline unsigned xocl_bo_type(unsigned user_flags)
 		break;
 	case XCL_BO_FLAGS_HOST_ONLY:
 		bo_type = XOCL_BO_CMA;
+		break;
+	case XCL_BO_FLAGS_KERNPTR:
+		bo_type = XOCL_BO_KERNPTR;
 		break;
 	default:
 		bo_type = XOCL_BO_NORMAL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -345,6 +345,10 @@ static const struct drm_ioctl_desc xocl_ioctls[] = {
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_FREE_CMA, xocl_free_cma_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(XOCL_STORE_APP_CONTEXT, xocl_store_app_context_ioctl,
+			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(XOCL_DELETE_APP_CONTEXT, xocl_delete_app_context_ioctl,
+			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 };
 
 static long xocl_drm_ioctl(struct file *filp,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -528,3 +528,29 @@ int xocl_free_cma_ioctl(struct drm_device *dev, void *data,
 
 	return 0;
 }
+
+extern struct xocl_drm_dev_info uapp_drm_context;
+
+int xocl_store_app_context_ioctl(struct drm_device *dev, void *data,
+        struct drm_file *filp)
+{
+	if(!uapp_drm_context.dev){
+		pr_info("%s: devp %p filp %p", __func__, dev, filp);
+		uapp_drm_context.dev = dev;
+		uapp_drm_context.file = filp;
+		return 0;
+	}
+	else{
+		pr_info("%s: Device context already in use.", __func__);
+		return -1;
+	}
+}
+
+int xocl_delete_app_context_ioctl(struct drm_device *dev, void *data,
+        struct drm_file *filp)
+{
+        pr_info("%s: devp %p filp %p", __func__, dev, filp);
+        uapp_drm_context.dev = NULL;
+        uapp_drm_context.file = NULL;
+        return 0;
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kernel_api.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kernel_api.c
@@ -1,0 +1,394 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2016-2019 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Amit Kumar <akum@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/bitops.h>
+#include <linux/swap.h>
+#include <linux/dma-buf.h>
+#include <linux/pagemap.h>
+#include <linux/version.h>
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(3, 0, 0)
+#include <drm/drm_backport.h>
+#endif
+#include <drm/drmP.h>
+#include "common.h"
+#include "../xocl_drv.h"
+#include "xocl_kernel_api.h"
+
+//TO-DO: Remove these
+#ifdef _XOCL_BO_DEBUG
+#define BO_ENTER(fmt, args...)          \
+        printk(KERN_INFO "[BO] Entering %s:"fmt"\n", __func__, ##args)
+#define BO_DEBUG(fmt, args...)          \
+        printk(KERN_INFO "[BO] %s:%d:"fmt"\n", __func__, __LINE__, ##args)
+#else
+#define BO_ENTER(fmt, args...)
+#define BO_DEBUG(fmt, args...)
+#endif
+
+extern void xocl_describe(const struct drm_xocl_bo *xobj);
+
+#if defined(XOCL_DRM_FREE_MALLOC)
+static inline void drm_free_large(void *ptr)
+{
+        kvfree(ptr);
+}
+
+static inline void *drm_malloc_ab(size_t nmemb, size_t size)
+{
+        return kvmalloc_array(nmemb, size, GFP_KERNEL);
+}
+#endif
+
+struct xocl_drm_dev_info uapp_drm_context;
+
+int xocl_create_bo_ifc(struct drm_xocl_create_bo *args)
+{
+	return xocl_create_bo_ioctl(uapp_drm_context.dev, args, 
+							uapp_drm_context.file);
+}
+
+EXPORT_SYMBOL_GPL(xocl_create_bo_ifc);
+
+int xocl_map_bo_ifc(struct drm_xocl_map_bo *args)
+{
+	return xocl_map_bo_ioctl(uapp_drm_context.dev, args, 
+							uapp_drm_context.file);
+}
+EXPORT_SYMBOL_GPL(xocl_map_bo_ifc);
+
+int xocl_sync_bo_ifc(struct drm_xocl_sync_bo *args)
+{
+	return xocl_sync_bo_ioctl(uapp_drm_context.dev, args, 
+							uapp_drm_context.file);
+}
+EXPORT_SYMBOL_GPL(xocl_sync_bo_ifc);
+
+int xocl_info_bo_ifc(struct drm_xocl_info_bo *args)
+{
+	return xocl_info_bo_ioctl(uapp_drm_context.dev, args, 
+							uapp_drm_context.file);
+}
+EXPORT_SYMBOL_GPL(xocl_info_bo_ifc);
+
+int xocl_execbuf_ifc(struct drm_xocl_execbuf *args)
+{
+	return xocl_execbuf_ioctl(uapp_drm_context.dev, args, 
+							uapp_drm_context.file);
+}
+EXPORT_SYMBOL_GPL(xocl_execbuf_ifc);
+
+int xocl_create_kmem_bo_ifc(struct drm_xocl_kptr_bo *args)
+{
+	int ret, i;
+	struct drm_xocl_bo *xobj;
+	struct xocl_drm *drm_p = uapp_drm_context.dev->dev_private;
+	uint64_t page_count = 0;
+
+	if (offset_in_page(args->addr))
+		return -EINVAL;
+
+	xobj = xocl_drm_create_bo(drm_p, args->size, 
+					(args->flags | XCL_BO_FLAGS_KERNPTR));
+	BO_ENTER("xobj %p", xobj);
+
+	if (IS_ERR(xobj)) {
+		DRM_ERROR("object creation failed\n");
+		return PTR_ERR(xobj);
+	}
+
+	/* Use the page rounded size to accurately account for num of pages */
+	page_count = xobj->base.size >> PAGE_SHIFT;
+
+	xobj->pages = drm_malloc_ab(page_count, sizeof(*xobj->pages));
+	if (!xobj->pages) {
+		ret = -ENOMEM;
+		goto out1;
+	}
+
+	for (i=0; i<page_count; i++)
+	{
+		xobj->pages[i] = virt_to_page(args->addr+i*PAGE_SIZE);
+	}
+
+	xobj->sgt = drm_prime_pages_to_sg(xobj->pages, page_count);
+	if (IS_ERR(xobj->sgt)) {
+		ret = PTR_ERR(xobj->sgt);
+		goto out0;
+	}
+
+	/* TODO: resolve the cache issue */
+	xobj->vmapping = vmap(xobj->pages, page_count, VM_MAP, PAGE_KERNEL);
+
+	if (!xobj->vmapping) {
+		ret = -ENOMEM;
+		goto out1;
+	}
+
+
+	ret = drm_gem_handle_create(uapp_drm_context.file, &xobj->base, 
+								&args->handle);
+	if (ret)
+		goto out1;
+
+	xocl_describe(xobj);
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
+	return ret;
+
+out0:
+	drm_free_large(xobj->pages);
+	xobj->pages = NULL;
+out1:
+	xocl_drm_free_bo(&xobj->base);
+	DRM_DEBUG("handle creation failed\n");
+	return ret;	
+}
+EXPORT_SYMBOL_GPL(xocl_create_kmem_bo_ifc);
+
+int xocl_remap_kmem_bo_ifc(struct drm_xocl_kptr_bo *args)
+{
+	int i;
+        int ret;
+        unsigned int page_count;
+
+        struct drm_xocl_bo *xobj;
+        struct drm_gem_object *gem_obj = xocl_gem_object_lookup(
+							uapp_drm_context.dev, 
+							uapp_drm_context.file,
+                                                        args->handle);
+        if (!gem_obj) {
+                DRM_ERROR("Failed to look up GEM BO %d\n", args->handle);
+                return -ENOENT;
+        }
+
+	xobj = to_xocl_bo(gem_obj);
+
+        if (xobj->pages) {
+                drm_free_large(xobj->pages);
+                xobj->pages = NULL;
+        }
+
+        if (xobj->sgt) {
+                sg_free_table(xobj->sgt);
+                kfree(xobj->sgt);
+        }
+
+        /* Use the page rounded size so we can accurately account for number of pages */
+        page_count = xobj->base.size >> PAGE_SHIFT;
+
+        xobj->pages = drm_malloc_ab(page_count, sizeof(*xobj->pages));
+        if (!xobj->pages) {
+                ret = -ENOMEM;
+                goto out1;
+        }
+	
+	//pr_info("%s: %d %p", __func__, page_count, xobj->pages);
+
+        for (i=0; i<page_count; i++)
+        {
+                xobj->pages[i] = virt_to_page(args->addr+i*PAGE_SIZE);
+        }
+
+        xobj->sgt = drm_prime_pages_to_sg(xobj->pages, page_count);
+        if (IS_ERR(xobj->sgt)) {
+                ret = PTR_ERR(xobj->sgt);
+                goto out0;
+        }
+
+        /* TODO: resolve the cache issue */
+        xobj->vmapping = vmap(xobj->pages, page_count, VM_MAP, PAGE_KERNEL);
+
+	 if (!xobj->vmapping) {
+                ret = -ENOMEM;
+        }
+
+        return ret;
+out0:
+        drm_free_large(xobj->pages);
+        xobj->pages = NULL;
+out1:
+        return ret;
+}
+EXPORT_SYMBOL_GPL(xocl_remap_kmem_bo_ifc);
+
+int xocl_create_sgl_bo_ifc(struct drm_xocl_sgl_bo *args)
+{
+        int i;
+        int ret;
+        struct drm_xocl_bo *xobj;
+	struct xocl_drm *drm_p = uapp_drm_context.dev->dev_private;
+        unsigned int page_count;
+
+        struct scatterlist *sg;
+        int nents;
+
+	xobj = xocl_drm_create_bo(drm_p, args->size, 
+					(args->flags | XCL_BO_FLAGS_KERNPTR));
+        BO_ENTER("xobj %p", xobj);
+
+        if (IS_ERR(xobj)) {
+                DRM_DEBUG("object creation failed\n");
+                return PTR_ERR(xobj);
+        }
+
+	if (args->sgl) {
+        	nents = sg_nents((struct scatterlist *)args->sgl);
+        	/* Use the page rounded size so we can accurately account for 
+		number of pages */
+        	page_count = xobj->base.size >> PAGE_SHIFT;
+
+		/* error out if SGL being mapped is bigger than BO size*/
+		if (nents > page_count)
+			return -EINVAL;
+
+        	xobj->sgt = kmalloc(sizeof(struct sg_table), GFP_KERNEL);
+                if (!xobj->sgt)
+                        return -ENOMEM;
+
+                xobj->sgt->sgl = (struct scatterlist *)args->sgl;
+                xobj->sgt->nents = xobj->sgt->orig_nents = nents;
+
+                xobj->pages = drm_malloc_ab(page_count, sizeof(*xobj->pages));
+                if (!xobj->pages) {
+                        ret = -ENOMEM;
+                        goto out1;
+       		}
+	
+                for_each_sg((struct scatterlist *)args->sgl, sg, nents, i) {
+                        xobj->pages[i] = sg_page(sg);
+                }
+
+                /* TODO: resolve the cache issue */
+                xobj->vmapping = vmap(xobj->pages, nents, VM_MAP, PAGE_KERNEL);
+		
+		if (!xobj->vmapping) {
+                        ret = -ENOMEM;
+                        goto out0;
+        	}
+        }
+	else{
+		xobj->sgt = NULL;
+		xobj->pages = NULL;
+		xobj->vmapping = NULL;
+	}
+
+        ret = drm_gem_handle_create(uapp_drm_context.file, &xobj->base, 
+								&args->handle);
+        if (ret)
+                goto out1;
+
+        xocl_describe(xobj);
+        drm_gem_object_unreference_unlocked(&xobj->base);
+
+        return ret;
+out0:
+        drm_free_large(xobj->pages);
+        xobj->pages = NULL;
+out1:
+	xocl_drm_free_bo(&xobj->base);
+        DRM_DEBUG("handle creation failed\n");
+        return ret;
+}
+EXPORT_SYMBOL_GPL(xocl_create_sgl_bo_ifc);
+
+int xocl_remap_sgl_bo_ifc(struct drm_xocl_sgl_bo *args)
+{
+        int i;
+        int ret=0;
+	unsigned int page_count;
+	struct scatterlist *sg;
+	int nents = sg_nents((struct scatterlist *)args->sgl);
+
+	struct drm_xocl_bo *xobj;
+	struct drm_gem_object *gem_obj = xocl_gem_object_lookup(
+							uapp_drm_context.dev, 
+							uapp_drm_context.file,
+							args->handle);
+	if (!gem_obj) {
+		DRM_ERROR("Failed to look up GEM BO %d\n", args->handle);
+		return -ENOENT;
+	}
+
+	xobj = to_xocl_bo(gem_obj);
+
+        /* Use the page rounded size so we can accurately account for number of pages */
+        page_count = xobj->base.size >> PAGE_SHIFT;
+
+	/* error out if SGL being mapped is bigger than BO size*/
+	if (nents > page_count)
+		return -EINVAL;
+
+	if (!xobj->sgt) {
+		xobj->sgt = kmalloc(sizeof(struct sg_table), GFP_KERNEL);
+		if (!xobj->sgt)
+			return -ENOMEM;
+
+	}
+
+	xobj->sgt->sgl = (struct scatterlist *)args->sgl;
+	xobj->sgt->nents = xobj->sgt->orig_nents = nents;
+
+	if (!xobj->pages) {
+		page_count = nents;
+		xobj->pages = drm_malloc_ab(page_count, sizeof(*xobj->pages));
+		if (!xobj->pages)
+			return -ENOMEM;
+	}
+
+	for_each_sg((struct scatterlist *)args->sgl, sg, nents, i) {
+		xobj->pages[i] = sg_page(sg);
+	}
+
+	/* TODO: resolve the cache issue */
+	xobj->vmapping = vmap(xobj->pages, nents, VM_MAP, PAGE_KERNEL);
+
+	if (!xobj->vmapping) {
+		ret = -ENOMEM;
+                goto out0;
+	}
+
+	return ret;
+out0:
+	drm_free_large(xobj->pages);
+	xobj->pages = NULL;
+	return ret;
+}
+EXPORT_SYMBOL_GPL(xocl_remap_sgl_bo_ifc);
+
+void __iomem *xocl_get_bo_kernel_vaddr(uint32_t bo_handle)
+{
+	struct drm_gem_object *obj;
+	struct drm_xocl_bo *xobj;
+
+	obj = xocl_gem_object_lookup(uapp_drm_context.dev, 
+					uapp_drm_context.file, bo_handle);
+	xobj = to_xocl_bo(obj);
+
+	if (!obj) {
+		DRM_ERROR("Failed to look up GEM BO %d\n", bo_handle);
+		return NULL;
+	}
+
+	if (xobj->flags & XOCL_P2P_MEM)
+		return page_to_virt(xobj->pages[0]);
+	else
+		return xobj->vmapping;
+}
+EXPORT_SYMBOL_GPL(xocl_get_bo_kernel_vaddr);
+
+
+

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -22,6 +22,9 @@
 #include <linux/hashtable.h>
 #endif
 
+
+typedef void (*xocl_execbuf_callback)(void *data);
+
 /**
  * struct drm_xocl_exec_metadata - Meta data for exec bo
  *
@@ -29,8 +32,11 @@
  * @active: Reverse mapping to kds command object managed exclusively by kds
  */
 struct drm_xocl_exec_metadata {
-	        enum drm_xocl_execbuf_state state;
-		        struct xocl_cmd            *active;
+        enum drm_xocl_execbuf_state state;
+        struct xocl_cmd            *active;
+	struct work_struct          compltn_work;
+	xocl_execbuf_callback	    execbuf_cb_fn;
+	void			   *execbuf_cb_data;
 };
 
 struct xocl_cma_chunk {

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1744,6 +1744,24 @@ int shim::xclIPName2Index(const char *name, uint32_t& index)
     return 0;
 }
 
+/*
+ * xclStoreAppContext()
+ */
+int shim::xclStoreAppContext()
+{
+    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_STORE_APP_CONTEXT);
+    return ret;
+}
+
+/*
+ * xclDeleteAppContext()
+ */
+int shim::xclDeleteAppContext()
+{
+    int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_DELETE_APP_CONTEXT);
+    return ret;
+}
+
 } // namespace xocl
 
 /*******************************/
@@ -2258,3 +2276,16 @@ int xclGetSubdevPath(xclDeviceHandle handle,  const char* subdev,
     return -1;
   return drv->xclGetSubdevPath(subdev, idx, path, size);
 }
+
+int xclStoreAppContext(xclDeviceHandle handle)
+{
+    xocl::shim *drv = xocl::shim::handleCheck(handle);
+    return drv ? drv->xclStoreAppContext() : -ENODEV;
+}
+
+int xclDeleteAppContext(xclDeviceHandle handle)
+{
+    xocl::shim *drv = xocl::shim::handleCheck(handle);
+    return drv ? drv->xclDeleteAppContext() : -ENODEV;
+}
+

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -96,6 +96,8 @@ public:
     bool xclUnlockDevice();
     int xclReClock2(unsigned short region, const unsigned short *targetFreqMHz);
     int xclGetUsageInfo(xclDeviceUsage *info);
+    int xclStoreAppContext();
+    int xclDeleteAppContext();
 
     int xclTestXSpi(int device_index);
     int xclBootFPGA();


### PR DESCRIPTION
Changes to provide a linux kernel APIs/interface. These can be used by existing Linux kernel code/modules (Linux Cypto API drivers, vdo, zfs etc) to access the HW compute functions  on the Xilinx Accelerator Cards. 