### PR TITLE
CR-1054276 XRT no longer shows SC version for golden image cards. Reg…

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -256,6 +256,7 @@ static void isSameShellOrSC(DSAInfo& candidate, DSAInfo& current,
             candidate.matchId(current));
         *same_bmc = (current.bmcVer.empty() ||
             current.bmcVer.compare(DSAInfo::UNKNOWN) == 0 ||
+            current.bmcVer.compare(DSAInfo::INACTIVE) == 0 ||
             candidate.bmcVer == current.bmcVer);
     }
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -36,6 +36,7 @@
 using namespace boost::filesystem;
 
 const std::string DSAInfo::UNKNOWN = "UNKNOWN";
+const std::string DSAInfo::INACTIVE = "INACTIVE";
 
 /*
  * Helper to parse DSA name string and retrieve all tokens

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -56,6 +56,7 @@ public:
     std::string partition_name;
     std::string build_ident;
     static const std::string UNKNOWN;
+    static const std::string INACTIVE;
 
     DSAInfo(const std::string& filename, uint64_t ts, const std::string& id, const std::string& bmc);
     DSAInfo(const std::string& filename);

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -385,7 +385,7 @@ DSAInfo Flasher::getOnBoardDSA()
     if (rc == 0)
         bmc = info.mBMCVer; // Successfully read BMC version
     else if (rc == -EOPNOTSUPP)
-        bmc.clear(); // BMC is not supported on DSA
+        bmc = DSAInfo::INACTIVE; // BMC is not supported on DSA, state is inactive
     else
         bmc = DSAInfo::UNKNOWN; // BMC not ready, set it to an invalid version string
 


### PR DESCRIPTION
…ression from 2019.2 release

Test Results:
On U50
```

Card [0000:d9:00.0]
    Card type:          u50
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u50_GOLDEN_9,[SC=INACTIVE]
    Flashable partitions installed in system:
        xilinx_u50_gen3x16-xdma_blp_1,[ID=0xf465b0a3ae8c64f6],[SC=5.0.27]

xbmgmt flash --update --shell xilinx_u50_gen3x16-xdma_blp_1 --card 0000:d9:00.0
         Status: shell needs updating
         Current shell: xilinx_u50_GOLDEN_9
         Shell to be flashed: xilinx_u50_gen3x16-xdma_blp_1
Are you sure you wish to proceed? [y/n]: y

Updating shell on card[0000:d9:00.0]
INFO: ***Found 353 ELA Records
Enabled bitstream guard. Bitstream will not be loaded until flashing is finished.
Preparing flash chip 0
Erasing flash.................
Programming flash.................
Cleared bitstream guard. Bitstream now active.
Successfully flashed Card[0000:d9:00.0]

1 Card(s) flashed successfully.
Cold reboot machine to load the new image on card(s).
```

On U200
```
Card [0000:5e:00.0]
    Card type:          u200
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u200_GOLDEN_5,[SC=4.2]
    Flashable partitions installed in system:
        xilinx_u200_xdma_201830_2,[ID=0x5d1211e8],[SC=4.2.0]
        xilinx_u200_qdma_201920_1,[ID=0x5dccb0ca],[SC=4.3.7]

root@xsjyliu50:~# xbmgmt flash --update --shell xilinx_u200_qdma_201920_1 --card 0000:5e:00.0
         Status: SC needs updating
         Current SC: 4.2
         SC to be flashed: 4.3.7
         Status: shell needs updating
         Current shell: xilinx_u200_GOLDEN_5
         Shell to be flashed: xilinx_u200_qdma_201920_1
Are you sure you wish to proceed? [y/n]: y

Updating SC firmware on card[0000:5e:00.0]
INFO: found 4 sections
......................................
INFO: Loading new firmware on SC

Updating shell on card[0000:5e:00.0]
INFO: ***Found 783 ELA Records
Enabled bitstream guard. Bitstream will not be loaded until flashing is finished.
Preparing flash chip 0
Erasing flash.......................................
Programming flash............
```