### PR TITLE
Refactoring xrt build information out of get_xrt_info

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -16,6 +16,7 @@
 #define XRT_CORE_COMMON_SOURCE
 #include "core/common/system.h"
 #include "core/common/device.h"
+#include "gen/version.h"
 
 #include <vector>
 #include <map>
@@ -51,6 +52,15 @@ instance()
   if (singleton)
     return *singleton;
   throw std::runtime_error("system singleton is not loaded");
+}
+
+void
+get_xrt_build_info(boost::property_tree::ptree& pt)
+{
+  pt.put("version", xrt_build_version);
+  pt.put("hash",    xrt_build_version_hash);
+  pt.put("date",    xrt_build_version_date);
+  pt.put("branch",  xrt_build_version_branch);
 }
 
 void

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -66,6 +66,7 @@ get_xrt_build_info(boost::property_tree::ptree& pt)
 void
 get_xrt_info(boost::property_tree::ptree &pt)
 {
+  get_xrt_build_info(pt);
   instance().get_xrt_info(pt);
 }
 

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -83,6 +83,12 @@ public:
  */
 XRT_CORE_COMMON_EXPORT
 void
+get_xrt_build_info(boost::property_tree::ptree& pt);
+
+/**
+ */
+XRT_CORE_COMMON_EXPORT
+void
 get_xrt_info(boost::property_tree::ptree& pt);
 
 /**

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -69,11 +69,8 @@ void
 system_linux::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  pt.put("version",   xrt_build_version);
-  pt.put("hash",      xrt_build_version_hash);
-  pt.put("date",      xrt_build_version_date);
-  pt.put("branch",    xrt_build_version_branch);
-  pt.put("zocl",      driver_version("zocl"));
+  xrt_core::get_xrt_build_info(pt);
+  pt.put("zocl", driver_version("zocl"));
 }
 
 

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -69,7 +69,6 @@ void
 system_linux::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  xrt_core::get_xrt_build_info(pt);
   pt.put("zocl", driver_version("zocl"));
 }
 

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -77,10 +77,7 @@ void
 system_linux::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  pt.put("version",   xrt_build_version);
-  pt.put("hash",      xrt_build_version_hash);
-  pt.put("date",      xrt_build_version_date);
-  pt.put("branch",    xrt_build_version_branch);
+  xrt_core::get_xrt_build_info(pt);
   pt.put("xocl",      driver_version("xocl"));
   pt.put("xclmgmt",   driver_version("xclmgmt"));
 }

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -77,7 +77,6 @@ void
 system_linux::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  xrt_core::get_xrt_build_info(pt);
   pt.put("xocl",      driver_version("xocl"));
   pt.put("xclmgmt",   driver_version("xclmgmt"));
 }

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -81,10 +81,8 @@ system_child_ctor()
 }
 void
 system_windows::
-get_xrt_info(boost::property_tree::ptree &pt)
+get_xrt_info(boost::property_tree::ptree& /*pt*/)
 {
-  xrt_core::get_xrt_build_info(pt);
-
   //TODO
   // _pt.put("xocl",      driver_version("xocl"));
   // _pt.put("xclmgmt",   driver_version("xclmgmt"));

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -83,10 +83,7 @@ void
 system_windows::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  pt.put("version",   xrt_build_version);
-  pt.put("hash",      xrt_build_version_hash);
-  pt.put("date",      xrt_build_version_date);
-  pt.put("branch",    xrt_build_version_branch);
+  xrt_core::get_xrt_build_info(pt);
 
   //TODO
   // _pt.put("xocl",      driver_version("xocl"));

--- a/src/runtime_src/xdp/profile/writer/json_profile.cpp
+++ b/src/runtime_src/xdp/profile/writer/json_profile.cpp
@@ -150,7 +150,7 @@ void JSONProfileWriter::writeDocumentHeader(std::ofstream& /*ofs*/,
   header.put("toolVersion", xdp::WriterI::getToolVersion());
 
   boost::property_tree::ptree xrtInfo;
-  xrt_core::get_xrt_info(xrtInfo);
+  xrt_core::get_xrt_build_info(xrtInfo);
   header.put("XRT build version", xrtInfo.get<std::string>("version", "N/A"));
   header.put("Build version branch", xrtInfo.get<std::string>("branch", "N/A"));
   header.put("Build version hash", xrtInfo.get<std::string>("hash", "N/A"));

--- a/src/runtime_src/xdp/profile/writer/util.cpp
+++ b/src/runtime_src/xdp/profile/writer/util.cpp
@@ -38,7 +38,7 @@ namespace xdp {
     std::string xrtVersion;
 
     boost::property_tree::ptree xrtInfo;
-    xrt_core::get_xrt_info(xrtInfo);
+    xrt_core::get_xrt_build_info(xrtInfo);
     xrtVersion = "XRT build version: "  + xrtInfo.get<std::string>("version", "N/A") + "\n"
                + "Build version branch: " + xrtInfo.get<std::string>("branch", "N/A") + "\n"
                + "Build version hash: " + xrtInfo.get<std::string>("hash", "N/A") + "\n"


### PR DESCRIPTION
This allows XDP to get the information it needs before a singleton is created