### PR TITLE
xrt aie interface

### DIFF
--- a/src/runtime_src/core/edge/include/CMakeLists.txt
+++ b/src/runtime_src/core/edge/include/CMakeLists.txt
@@ -7,3 +7,5 @@ install (FILES ${MPSOC_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
 message("-- XRT header files for MPSoC only")
 message("-- xclhal2_mpsoc.h")
 message("-- sk_types.h")
+
+add_subdirectory(experimental)

--- a/src/runtime_src/core/edge/include/CMakeLists.txt
+++ b/src/runtime_src/core/edge/include/CMakeLists.txt
@@ -8,4 +8,6 @@ message("-- XRT header files for MPSoC only")
 message("-- xclhal2_mpsoc.h")
 message("-- sk_types.h")
 
-add_subdirectory(experimental)
+if (DEFINED XRT_AIE_BUILD)
+  add_subdirectory(experimental)
+endif()

--- a/src/runtime_src/core/edge/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/edge/include/experimental/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(XRT_EDGE_EXPERIMENTAL_HEADER_SRC
+  xrt_aie.h)
+
+install (FILES ${XRT_EDGE_EXPERIMENTAL_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/experimental)
+
+message("-- XRT experimental header files")
+foreach (header ${XRT_EDGE_EXPERIMENTAL_HEADER_SRC})
+  message("-- ${header}")
+endforeach()

--- a/src/runtime_src/core/edge/include/experimental/xrt_aie.h
+++ b/src/runtime_src/core/edge/include/experimental/xrt_aie.h
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XRT_AIE_H_
+#define _XRT_AIE_H_
+
+#include "xclhal2.h"
+
+typedef void *xrtGraphHandle;
+
+/**
+ * xrtGraphOpen() - Open a graph and obtain its handle.
+ *
+ * @deviceHandle: Handle to the device with the graph.
+ * @xclbUUID:     UUID of the xclbin with the specified graph.
+ * @graphNmae:    The name of graph to be open.
+ * Return:        Handle to representing the graph. NULL for error.
+ *
+ * An xclbin with the specified graph must have been loaded prior
+ * to calling this function.
+ */
+xrtGraphHandle xrtGraphOpen(xclDeviceHandle handle, uuid_t xclbinUUID, const char *graphName);
+
+/**
+ * xrtGraphClose() - Close an open graph.
+ *
+ * @gh:            Handle to graph previously opened with xrtGraphOpen.
+ *
+ */
+void xrtGraphClose(xrtGraphHandle gh);
+
+/**
+ * xrtGraphReset() - Reset a graph.
+ *
+ * @gh:            Handle to graph previously opened with xrtGraphOpen.
+ * Return:         0 on success, -1 on error
+ *
+ * Note: Reset by disable tiles and enable tile reset
+ */
+int xrtGraphReset(xrtGraphHandle gh);
+
+/**
+ * xrtGraphTimeStamp() - Get timestamp of a graph. The unit of timestamp is
+ *                       AIE Cycle.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          Timestamp in AIE cycle.
+ */
+uint64_t xrtGraphTimeStamp(xrtGraphHandle gh);
+
+/**
+ * xrtGraphUpdateIter() - Update graph run iteration.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * @iterations:     The run iteration to update to graph. -1 for infinite.
+ * Return:          0 on success, -1 on error
+ */
+int xrtGraphUpdateIter(xrtGraphHandle gh, int iterations);
+
+/**
+ * xrtGraphRun() - Start a graph execution
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          0 on success, -1 on error
+ *
+ * Note: Run by enable tiles and disable tile reset
+ */
+int xrtGraphRun(xrtGraphHandle gh);
+
+/**
+ * xrtGraphWaitDone() - Wait for graph to stop.
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @timeoutMilliSec: Timeout value to wait for graph done.
+ *
+ * Return:          0 on success, -1 on timeout.
+ *
+ * Note: Wait for done status of ALL the tiles
+ */
+int xrtGraphWaitDone(xrtGraphHandle gh, int timeoutMilliSec);
+
+/**
+ * xrtGraphSuspend() - Suspend a running graph.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          0 on success, -1 on error.
+ */
+int xrtGraphSuspend(xrtGraphHandle gh);
+
+/**
+ * xrtGraphResume() - Resume a suspended graph.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          0 on success, -1 on error.
+ */
+int xrtGraphResume(xrtGraphHandle gh);
+
+/**
+ * xrtGraphStop() - Stop a running graph if not done within a given time
+ *                  interval.
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @timeoutMilliSec: Timeout value before force to stop graph.
+ *
+ * Return:          0 on success, -1 on timeout.
+ *
+ * Note: Wait for done status of ALL the tiles
+ */
+int xrtGraphStop(xrtGraphHandle gh, int timeoutMilliSec);
+
+#endif

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -5,6 +5,8 @@ include_directories(
   ${CMAKE_BINARY_DIR} # includes version.h
   )
 
+add_subdirectory(aie)
+
 file(GLOB XRT_EDGE_USER_PLUGIN_XDP_FILES
   "plugin/xdp/*.h"
   "plugin/xdp/*.cpp"
@@ -35,6 +37,7 @@ add_library(core_edgeuser_objects OBJECT ${XRT_USER_FILES})
 add_library(xrt_core SHARED ${XRT_SRC}
   $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_objects>
   $<TARGET_OBJECTS:core_common_objects>
+  $<TARGET_OBJECTS:xrt_aie_object>
   #$<TARGET_OBJECTS:core_edgecommon_objects>
   )
 
@@ -56,6 +59,8 @@ target_link_libraries(xrt_core
   uuid
   boost_filesystem
   boost_system
+  metal
+  xaiengine
   )
 
 install (TARGETS xrt_core LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -5,7 +5,9 @@ include_directories(
   ${CMAKE_BINARY_DIR} # includes version.h
   )
 
-add_subdirectory(aie)
+if (DEFINED XRT_AIE_BUILD)
+  add_subdirectory(aie)
+endif()
 
 file(GLOB XRT_EDGE_USER_PLUGIN_XDP_FILES
   "plugin/xdp/*.h"
@@ -34,12 +36,20 @@ add_library(core_edgeuser_plugin_xdp_objects OBJECT ${XRT_EDGE_USER_PLUGIN_XDP_F
 
 add_library(core_edgeuser_objects OBJECT ${XRT_USER_FILES})
 
-add_library(xrt_core SHARED ${XRT_SRC}
-  $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_objects>
-  $<TARGET_OBJECTS:core_common_objects>
-  $<TARGET_OBJECTS:xrt_aie_object>
-  #$<TARGET_OBJECTS:core_edgecommon_objects>
-  )
+if (DEFINED XRT_AIE_BUILD)
+  add_library(xrt_core SHARED ${XRT_SRC}
+    $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_objects>
+    $<TARGET_OBJECTS:core_common_objects>
+    $<TARGET_OBJECTS:xrt_aie_object>
+    #$<TARGET_OBJECTS:core_edgecommon_objects>
+    )
+else()
+  add_library(xrt_core SHARED ${XRT_SRC}
+    $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_objects>
+    $<TARGET_OBJECTS:core_common_objects>
+    #$<TARGET_OBJECTS:core_edgecommon_objects>
+    )
+endif()
 
 add_library(xrt_core_static STATIC ""
   $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_no_dl_load_objects>
@@ -51,16 +61,28 @@ add_library(xrt_core_static STATIC ""
 set_target_properties(xrt_core PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
-target_link_libraries(xrt_core
-  xrt_coreutil
-  pthread
-  rt
-  dl
-  uuid
-  boost_filesystem
-  boost_system
-  metal
-  xaiengine
-  )
+if (DEFINED XRT_AIE_BUILD)
+  target_link_libraries(xrt_core
+    xrt_coreutil
+    pthread
+    rt
+    dl
+    uuid
+    boost_filesystem
+    boost_system
+    metal
+    xaiengine
+    )
+else()
+  target_link_libraries(xrt_core
+    xrt_coreutil
+    pthread
+    rt
+    dl
+    uuid
+    boost_filesystem
+    boost_system
+    )
+endif()
 
 install (TARGETS xrt_core LIBRARY DESTINATION ${XRT_INSTALL_DIR}/lib)

--- a/src/runtime_src/core/edge/user/aie/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/aie/CMakeLists.txt
@@ -1,0 +1,20 @@
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../include/experimental
+  ${CMAKE_CURRENT_SOURCE_DIR}/..
+  )
+
+file(GLOB XRT_AIE_FILES
+  "*.h"
+  "*.cpp"
+  "*.c"
+  )
+
+set(AIE_SRC
+  ${XRT_AIE_FILES}
+  )
+
+set(CMAKE_CXX_FLAGS "-DXAIE_DEBUG ${CMAKE_CXX_FLAGS}")
+
+add_library(xrt_aie_object OBJECT ${AIE_SRC})

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "xrt_aie.h"
+#include "aie.h"
+
+#include <iostream>
+#include <errno.h>
+
+namespace zynqaie {
+
+Aie::Aie()
+{
+    /* TODO where are these number from */
+    numRows = 8;
+    numCols = 50;
+    aieAddrArrayOff = 0x800;
+
+    XAIEGBL_HWCFG_SET_CONFIG((&aieConfig), numRows, numCols, aieAddrArrayOff);
+    XAieGbl_HwInit(&aieConfig);
+    aieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+
+    int tileArraySize = numCols * (numRows + 1);
+    tileArray.resize(tileArraySize);
+
+    /* TODO is void good here? */
+    (void) XAieGbl_CfgInitialize(&aieInst, tileArray.data(), aieConfigPtr);
+
+#if 0
+    /* TODO Register Event, Error XRT handler here ? */
+    xaie_register_event_handler(event, module, xrtAieEventCallBack);
+    xaie_register_error_notification(error, module, xrtAieErrorCallBack, arg);
+#endif
+}
+
+Aie::~Aie()
+{
+#if 0
+    /* TODO Unregister AIE Event, Error XRT handler. */
+    xaie_unregister_events_notification();
+    xaie_unregister_error_notification();
+#endif
+}
+
+int Aie::getTilePos(int col, int row)
+{
+    return col * (numRows + 1) + row;
+}
+
+}
+
+

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _ZYNQ_AIE_H
+#define _ZYNQ_AIE_H
+
+extern "C"
+{
+#include <xaiengine.h>
+}
+
+#include <vector>
+
+typedef xclDeviceHandle xrtDeviceHandle;
+
+namespace zynqaie {
+
+class Aie {
+public:
+    ~Aie();
+    Aie();
+
+    std::vector<XAieGbl_Tile> tileArray;  // Tile Array
+
+    int getTilePos(int col, int row);
+
+private:
+    int numRows;
+    int numCols;
+    uint64_t aieAddrArrayOff;
+
+    XAieGbl_Config *aieConfigPtr; // AIE configuration pointer
+    XAieGbl aieInst;              // AIE global instance
+    XAieGbl_HwCfg aieConfig;      // AIE configuration pointer
+};
+
+}
+
+#endif

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -1,0 +1,375 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+extern "C"
+{
+#include <xaiengine.h>
+}
+#include "xrt_aie.h"
+#include "shim.h"
+#include "tile.h"
+#include "graph.h"
+
+#include <iostream>
+#include <errno.h>
+#include <chrono>
+
+namespace zynqaie {
+
+Graph::Graph(xclDeviceHandle handle, const char *graphName)
+{
+    ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+    devHandle = handle;
+
+    name = graphName;
+
+    /*
+     * TODO
+     * this is not the right place for creating Aie instance. Should
+     * we move this to loadXclbin when detect Aie Array?
+     */
+    aieArray = drv->getAieArray();
+    if (!aieArray) {
+        aieArray = new Aie();
+        drv->setAieArray(aieArray);
+    }
+
+    /* TODO
+     * get tiles from xclbin. Will need some interfaces like
+     * xrt_core::xclbin::get_tiles(const axlf *top, char *graphName);
+     * just hard code for now.
+     */
+    tiles.push_back(new Tile(2, 4, 2, 4, 0x17e4));
+
+    state = GRAPH_STATE_STOP;
+}
+
+Graph::~Graph()
+{
+    /* TODO move this to ZYNQShim destructor or use smart pointer */
+    if (aieArray)
+        delete aieArray;
+}
+
+Graph *Graph::graphHandleCheck(void *gHandle)
+{
+    if (!gHandle)
+        return 0;
+
+    return (Graph *) gHandle;
+}
+
+int Graph::xrtGraphReset()
+{
+    for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+        auto col = (*iter)->graphCol;
+        auto row = (*iter)->graphRow;
+        auto pos = aieArray->getTilePos(col, row);
+
+        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_ENABLE);
+    }
+
+    state = GRAPH_STATE_RESET;
+
+    return 0;
+}
+
+uint64_t Graph::xrtGraphTimeStamp()
+{
+    /* TODO just use the first tile to get the timestamp? */
+    auto col = (*tiles.begin())->graphCol;
+    auto row = (*tiles.begin())->graphRow;
+
+    auto pos = aieArray->getTilePos(col, row);
+
+    uint64_t timeStamp = XAieTile_CoreReadTimer(&(aieArray->tileArray.at(pos)));
+
+    return timeStamp;
+}
+
+int Graph::xrtGraphRun()
+{
+    if (state != GRAPH_STATE_STOP && state != GRAPH_STATE_RESET) {
+        std::cout << "Error: xrtGraphRun graph fail, already running" << std::endl;
+	return -EINVAL;
+    }
+
+    if (state != GRAPH_STATE_RESET) {
+        /* Reset the graph first */
+        xrtGraphReset();
+    }
+
+    for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+        auto col = (*iter)->graphCol;
+        auto row = (*iter)->graphRow;
+        auto pos = aieArray->getTilePos(col, row);
+        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_ENABLE, XAIE_DISABLE);
+    }
+
+    state = GRAPH_STATE_RUNNING;
+ 
+    return 0;
+}
+
+int Graph::xrtGraphUpdateIter(int iterations)
+{
+    for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+        auto col = (*iter)->iterCol;
+        auto row = (*iter)->iterRow;
+        auto pos = aieArray->getTilePos(col, row);
+        uint32_t addr = (*iter)->iterMemAddr;
+        XAieTile_DmWriteWord(&(aieArray->tileArray.at(pos)), addr, iterations);
+    }
+
+    return 0;
+}
+
+int Graph::xrtGraphWaitDone(int timeoutMilliSec)
+{
+    if (state != GRAPH_STATE_RUNNING)
+        return -EINVAL;
+
+    auto begin = std::chrono::high_resolution_clock::now();
+
+    /*
+     * We are using busy waiting here. Until every tile in the graph
+     * is done, we keep polling each tile.
+     *
+     * TODO Will register AIE event for tile done.
+     */
+    while (1) {
+        uint8_t done;
+        for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+            auto col = (*iter)->iterCol;
+            auto row = (*iter)->iterRow;
+            auto pos = aieArray->getTilePos(col, row);
+            uint32_t addr = (*iter)->iterMemAddr;
+            done = XAieTile_CoreReadStatusDone(&(aieArray->tileArray.at(pos)));
+            if (!done)
+                break;
+        }
+
+        if (done)
+            return 0;
+
+        auto current = std::chrono::high_resolution_clock::now();
+        auto dur = current - begin;
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+        if (timeoutMilliSec >= 0 && timeoutMilliSec < ms) {
+            std::cout << "Wait Graph " << name << " timeout." << std::endl;
+            return -ETIME;
+        }
+    }
+
+    state = GRAPH_STATE_STOP;
+
+    return 0;
+}
+
+int Graph::xrtGraphSuspend()
+{
+    if (state != GRAPH_STATE_RUNNING) {
+        std::cout << "Error: xrtGraphDisable graph fail, not running" << std::endl;
+	return -EINVAL;
+    }
+
+    for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+        auto col = (*iter)->graphCol;
+        auto row = (*iter)->graphRow;
+        auto pos = aieArray->getTilePos(col, row);
+        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+    }
+
+    state = GRAPH_STATE_SUSPEND;
+
+    return 0;
+}
+
+int Graph::xrtGraphResume()
+{
+    if (state != GRAPH_STATE_SUSPEND) {
+        std::cout << "Error: xrtGraphEnable graph fail, not suspending" << std::endl;
+        return -EINVAL;
+    }
+
+    for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+        auto col = (*iter)->graphCol;
+        auto row = (*iter)->graphRow;
+        auto pos = aieArray->getTilePos(col, row);
+        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_ENABLE, XAIE_DISABLE);
+    }
+
+    state = GRAPH_STATE_RUNNING;
+
+    return 0;
+}
+
+int Graph::xrtGraphStop(int timeoutMilliSec)
+{
+    if (state != GRAPH_STATE_RUNNING)
+        return -EINVAL;
+
+    auto begin = std::chrono::high_resolution_clock::now();
+
+    /*
+     * We are using busy waiting here. Until every tile in the graph
+     * is done, we keep polling each tile.
+     *
+     * TODO Will register AIE event for tile done.
+     */
+    while (1) {
+        uint8_t done;
+        for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+            auto col = (*iter)->iterCol;
+            auto row = (*iter)->iterRow;
+            auto pos = aieArray->getTilePos(col, row);
+            done = XAieTile_CoreReadStatusDone(&(aieArray->tileArray.at(pos)));
+            if (!done)
+                break;
+        }
+
+        if (done)
+            return 0;
+
+        auto current = std::chrono::high_resolution_clock::now();
+        auto dur = current - begin;
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+        if (timeoutMilliSec >= 0 && timeoutMilliSec < ms) {
+            std::cout << "Wait Graph " << name << " timeout. Force stop" << std::endl;
+            for (auto iter = tiles.begin(); iter != tiles.end(); ++iter) {
+                auto col = (*iter)->iterCol;
+                auto row = (*iter)->iterRow;
+                auto pos = aieArray->getTilePos(col, row);
+                XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+
+               /* TODO any extra action needed to end a graph? */
+            }
+
+            break;
+        }
+    }
+
+    state = GRAPH_STATE_STOP;
+
+    return 0;
+}
+
+
+}
+
+xrtGraphHandle xrtGraphOpen(xclDeviceHandle handle, uuid_t xclbinUUID, const    char *graphName)
+{
+    ZYNQ::ZYNQShim *drv = ZYNQ::ZYNQShim::handleCheck(handle);
+    if (!drv)
+        return NULL;
+
+    zynqaie::Graph *gHandle = new zynqaie::Graph(handle, graphName);
+    if (!zynqaie::Graph::graphHandleCheck(gHandle)) {
+        delete gHandle;
+        gHandle = 0;
+    }
+
+    return (xrtGraphHandle) gHandle;
+}
+
+void xrtGraphClose(xrtGraphHandle gh)
+{
+    if (zynqaie::Graph::graphHandleCheck(gh))
+        delete ((zynqaie::Graph *) gh);
+}
+
+int xrtGraphReset(xrtGraphHandle gh)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphReset();
+}
+
+/**
+ * Get a timestamp
+ */
+uint64_t xrtGraphTimeStamp(xrtGraphHandle gh)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphTimeStamp();
+}
+
+/**
+ * Enable tiles and disable tile reset
+ */
+int xrtGraphRun(xrtGraphHandle gh)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphRun();
+}
+
+/**
+ * Update iter variable locations for all the tiles
+ */
+int xrtGraphUpdateIter(xrtGraphHandle gh, int iterations)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphUpdateIter(iterations);
+}
+
+int xrtGraphWaitDone(xrtGraphHandle gh, int timeoutMilliSec)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphWaitDone(timeoutMilliSec);
+}
+
+int xrtGraphSuspend(xrtGraphHandle gh)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphSuspend();
+}
+
+int xrtGraphResume(xrtGraphHandle gh)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphResume();
+}
+
+int xrtGraphStop(xrtGraphHandle gh, int timeoutMilliSec)
+{
+    zynqaie::Graph *graph = zynqaie::Graph::graphHandleCheck(gh);
+    if (!graph)
+        return -EINVAL;
+
+    return graph->xrtGraphStop(timeoutMilliSec);
+}

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _ZYNQ_GRAPH_H
+#define _ZYNQ_GRAPH_H
+
+#include "tile.h"
+
+typedef xclDeviceHandle xrtDeviceHandle;
+
+namespace zynqaie {
+
+class Graph {
+
+public:
+    ~Graph();
+    Graph(xrtDeviceHandle handle, const char *graphName);
+
+    static Graph *graphHandleCheck(void *gHandle);
+
+    int xrtGraphReset();
+    uint64_t xrtGraphTimeStamp();
+    int xrtGraphUpdateIter(int iterations);
+    int xrtGraphRun();
+    int xrtGraphWaitDone(int timeoutMilliSec);
+    int xrtGraphSuspend();
+    int xrtGraphResume();
+    int xrtGraphStop(int timeoutMilliSec);
+
+private:
+
+    enum graphState {
+        GRAPH_STATE_STOP = 0,
+        GRAPH_STATE_RESET = 1,
+        GRAPH_STATE_RUNNING = 2,
+        GRAPH_STATE_SUSPEND = 3,
+    };
+
+    graphState state;
+
+    std::string name;
+
+    /**
+     * This is the XRT device handle that the graph belongs to.
+     * To operate on a graph, XRT device has to be opened first.'
+     */
+    xrtDeviceHandle devHandle;
+
+    /**
+     * This is the pointer to the AIE array where the AIE part of
+     * the graph resides. The Aie is an obect that holds the whole
+     * AIE resources, configurations etc.
+     * TODO it should be initialized when we load XCLBIN?
+     */
+    Aie *aieArray;
+
+    /**
+     * This is the collections of tiles that this graph uses.
+     * TODO A tile is represented by a pair of number <col, row>?
+     * It represents the tile position in the AIE array.
+     */
+    std::vector<Tile *> tiles;
+
+};
+
+}
+
+#endif

--- a/src/runtime_src/core/edge/user/aie/tile.cpp
+++ b/src/runtime_src/core/edge/user/aie/tile.cpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "tile.h"
+
+namespace zynqaie {
+
+Tile::Tile(int gRow, int gCol, int iRow, int iCol, uint32_t iMemAddr)
+    :graphRow(gRow), graphCol(gCol), iterRow(iRow), iterCol(iCol), iterMemAddr(iMemAddr)
+{
+}
+
+Tile::~Tile()
+{
+}
+
+}
+

--- a/src/runtime_src/core/edge/user/aie/tile.h
+++ b/src/runtime_src/core/edge/user/aie/tile.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _TILE_H_
+#define _TILE_H_
+
+#include "xclhal2.h"
+
+namespace zynqaie {
+
+class Tile {
+public:
+    ~Tile();
+    Tile(int gRow, int gCol, int iRow, int iCol, uint32_t iMemAddr);
+
+    int graphRow;
+    int graphCol;
+    int iterRow;
+    int iterCol;
+
+    uint32_t iterMemAddr;
+};
+
+}
+
+
+#endif

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -92,6 +92,9 @@ ZYNQShim::ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel ve
   }
   mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
   mDev = zynq_device::get_dev();
+
+  /* TODO is this necessary? We may want to initialize it when loading xclbin */
+  aieArray = NULL; 
 }
 
 #ifndef __HWEM__
@@ -1240,7 +1243,15 @@ int ZYNQShim::xclLogMsg(xrtLogMsgLevel level, const char* tag,
     return (double)clockFreq;
   }
 
+  zynqaie::Aie * ZYNQShim::getAieArray()
+  {
+    return aieArray; 
+  }
 
+  void ZYNQShim::setAieArray(zynqaie::Aie *aie)
+  {
+    aieArray = aieArray;
+  }
 }
 ;
 //end namespace ZYNQ

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -93,8 +93,10 @@ ZYNQShim::ZYNQShim(unsigned index, const char *logfileName, xclVerbosityLevel ve
   mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
   mDev = zynq_device::get_dev();
 
+#ifdef XRT_ENABLE_AIE
   /* TODO is this necessary? We may want to initialize it when loading xclbin */
   aieArray = NULL; 
+#endif
 }
 
 #ifndef __HWEM__
@@ -1243,6 +1245,7 @@ int ZYNQShim::xclLogMsg(xrtLogMsgLevel level, const char* tag,
     return (double)clockFreq;
   }
 
+#ifdef XRT_ENABLE_AIE
   zynqaie::Aie * ZYNQShim::getAieArray()
   {
     return aieArray; 
@@ -1252,6 +1255,8 @@ int ZYNQShim::xclLogMsg(xrtLogMsgLevel level, const char* tag,
   {
     aieArray = aieArray;
   }
+#endif
+
 }
 ;
 //end namespace ZYNQ

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -28,13 +28,16 @@
 #include "core/common/bo_cache.h"
 #include "core/common/xrt_profiling.h"
 #include "core/include/xcl_app_debug.h"
-#include "core/edge/user/aie/aie.h"
 #include <cstdint>
 #include <fstream>
 #include <map>
 #include <vector>
 #include <mutex>
 #include <memory>
+
+#ifdef XRT_ENABLE_AIE
+#include "core/edge/user/aie/aie.h"
+#endif
 
 namespace ZYNQ {
 
@@ -124,8 +127,10 @@ public:
   int cmpMonVersions(unsigned int major1, unsigned int minor1, 
 		     unsigned int major2, unsigned int minor2);
 
+#ifdef XRT_ENABLE_AIE
   zynqaie::Aie *getAieArray();
   void setAieArray(zynqaie::Aie *aie);
+#endif
 
 private:
   const int mBoardNumber = -1;
@@ -149,7 +154,9 @@ private:
   int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
   int xclLog(xrtLogMsgLevel level, const char* tag, const char* format, ...);
 
+#ifdef XRT_ENABLE_AIE
   zynqaie::Aie *aieArray;
+#endif
 };
 
 } // namespace ZYNQ

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -28,6 +28,7 @@
 #include "core/common/bo_cache.h"
 #include "core/common/xrt_profiling.h"
 #include "core/include/xcl_app_debug.h"
+#include "core/edge/user/aie/aie.h"
 #include <cstdint>
 #include <fstream>
 #include <map>
@@ -123,6 +124,8 @@ public:
   int cmpMonVersions(unsigned int major1, unsigned int minor1, 
 		     unsigned int major2, unsigned int minor2);
 
+  zynqaie::Aie *getAieArray();
+  void setAieArray(zynqaie::Aie *aie);
 
 private:
   const int mBoardNumber = -1;
@@ -145,6 +148,8 @@ private:
   std::mutex mCuMapLock;
   int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
   int xclLog(xrtLogMsgLevel level, const char* tag, const char* format, ...);
+
+  zynqaie::Aie *aieArray;
 };
 
 } // namespace ZYNQ


### PR DESCRIPTION
This Pull Request introduce XRT AIE graph APIs including open, close, reset, run, suspend, resume, stop, etc. an AIE graph.

The APIs are exposed within libxrt_core.
The API header files are put into /usr/include/xrt/experimental/xrt_aie.h
This Pull Request is for edge only.

This add a new dependencies for building libxrt_core on edge that libxrt_core will now depend on libaiengien and libmetal