### PR TITLE
Declared missing "padding" in the mem_data struct.

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -232,7 +232,9 @@ extern "C" {
         };
         unsigned char m_tag[16]; // DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
     };
-    static_assert (sizeof(mem_data) == 40, "mem_data structure no longer is 40 bytes in size"); 
+    #ifdef __cplusplus
+      static_assert (sizeof(mem_data) == 40, "mem_data structure no longer is 40 bytes in size"); 
+    #endif
 
     struct mem_topology {
         int32_t m_count; //Number of mem_data

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -219,18 +219,20 @@ extern "C" {
 
     /****   MEMORY TOPOLOGY SECTION ****/
     struct mem_data {
-        uint8_t m_type; //enum corresponding to mem_type.
-        uint8_t m_used; //if 0 this bank is not present
+        uint8_t m_type;          // enum corresponding to mem_type.
+        uint8_t m_used;          // if 0 this bank is not present
+        uint8_t padding[6];      // 8 Byte alignment padding (initialized to zeros)
         union {
-            uint64_t m_size; //if mem_type DDR, then size in KB;
-            uint64_t route_id; //if streaming then "route_id"
+            uint64_t m_size;     // if mem_type DDR, then size in KB;
+            uint64_t route_id;   // if streaming then "route_id"
         };
         union {
-            uint64_t m_base_address;//if DDR then the base address;
-            uint64_t flow_id; //if streaming then "flow id"
+            uint64_t m_base_address; // if DDR then the base address;
+            uint64_t flow_id;        // if streaming then "flow id"
         };
-        unsigned char m_tag[16]; //DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
+        unsigned char m_tag[16]; // DDR: BANK0,1,2,3, has to be null terminated; if streaming then stream0, 1 etc
     };
+    static_assert (sizeof(mem_data) == 40, "mem_data structure no longer is 40 bytes in size"); 
 
     struct mem_topology {
         int32_t m_count; //Number of mem_data


### PR DESCRIPTION
In the mem_data struct, the compiler is performing 8 byte aligning of uint64_t types.  To assure "binary" compatibility between various compilers, instead of relying of the compiler to insert the padding bytes, the structure was updated to reflect them. 

Because this structure is used to communicate binary information among a wide range of OSs and platforms, additional testing was was and added to the xclbin.h data structure, which included:
1) Adding a static_assert that validated the size of the mem_data structure.
Note: This static_assert was first added and validated, then the padding was added with no compiler issues.
2) Examine the binary content of the xclbin images produced.