### PR TITLE
Work-around indirect loading of libxrt_core during profiling

### DIFF
--- a/src/runtime_src/core/edge/hw_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/hw_em/CMakeLists.txt
@@ -19,10 +19,6 @@ file(GLOB EM_SRC_FILES
   "${EM_SRC_DIR}/*.cpp"
   "${COMMON_SRC_DIR}/common/*.h"
   "${COMMON_SRC_DIR}/common/*.cpp"
-  "${COMMON_SRC_DIR}/../common/system.h"
-  "${COMMON_SRC_DIR}/../common/system.cpp"
-  "${COMMON_SRC_DIR}/../common/device.cpp"
-  "${COMMON_SRC_DIR}/../common/device.h"
   )
 
 add_definitions(-DXCLHAL_MAJOR_VER=1 -DXCLHAL_MINOR_VER=0 -D__HWEM__)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
@@ -30,6 +30,8 @@ namespace {
 static xrt_core::hwemu::system*
 singleton_instance()
 {
+  if (xrt_core::config::get_profile())
+    return nullptr; // waiting for fix to CR1056184
   static xrt_core::hwemu::system singleton;
   return &singleton;
 }


### PR DESCRIPTION
CR1056184 triggers a problem during emulation with profiling enabled.
PR #2949 enabled emulation with native XRT kernel APIs, but that
triggered a conflict with profiling which incorrectly and
uncoditionally loads libxrt_core.  Having two shim libraries loaded
with same symbols is not cool to begin with, but with the reference PR
it falt out doesn't work since shim libraries intialize a singleton
xrt_core::system variable.

This PR also fixes the historical weirdness where both libxrt_swemu
and libxrt_hwemu were loaded when emulation was specified.  Now only
one library is loaded depending on the value of XCL_EMULATION_MODE.