### PR TITLE
iops test in xbutil validate

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1704,7 +1704,7 @@ public:
         return xclGetDeviceInfo2(m_handle, &devinfo);
     }
 
-    int validate(bool quick);
+    int validate(bool quick, bool hidden);
 
     int reset(xclResetKind kind);
     int setP2p(bool enable, bool force);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -29,6 +29,7 @@
 #include <boost/property_tree/json_parser.hpp>
 
 #include "xrt.h"
+#include "ert.h"
 #include "xclperf.h"
 #include "xcl_axi_checker_codes.h"
 #include "core/pcie/common/dmatest.h"
@@ -1710,6 +1711,7 @@ public:
     int setCma(bool enable, uint64_t sz);
     int testP2p(void);
     int testM2m(void);
+    int iopsTest(void);
 
 private:
     // Run a test case as <exe> <xclbin> [-d index] on this device and collect


### PR DESCRIPTION
- added "-h" (hidden) option to run iops test
- running all combinations of  cmd_per_batch = { 8,16,32,64,128,256,1024,2048 } and num_execs = { 8,16,32,64,128,256,1024,2048 } and printing out the highest IOPS
- takes 7-8 seconds to run
Output:
```
sagarw@xsjsagarwal:/proj/xsjhdstaff1/sagarw/XRT/build$ xbutil validate -hq
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_u200_xdma_201830_2
INFO: == Starting AUX power connector check:
AUX POWER NOT CONNECTED, ATTENTION
Board not stable for heavy acceleration tasks.
WARN: == AUX power connector check PASSED with warning
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: == Starting IOPS test:
........
IOPS: 98253
INFO: == IOPS test PASSED
INFO: Card[0] validated with warnings.

INFO: All cards validated successfully but with warnings.
```
