### PR TITLE
Amend earlier changes to memory bank limit

### DIFF
--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -949,7 +949,7 @@ public:
     // 30,20,10,0
     xocl::xclbin::memidx_bitmask_type bitmask = 0;
     for (auto& mb : m_membanks) {
-      if (mb.index > 63)
+      if (mb.index >= xocl::xclbin::max_banks)
         throw std::runtime_error("bad mem_data index '" + std::to_string(mb.index) + "'");
       if (!m_mem->m_mem_data[mb.index].m_used)
         continue;
@@ -966,7 +966,7 @@ public:
     // 30,20,10,0
     int bankidx = -1;
     for (auto& mb : m_membanks) {
-      if (mb.index > 63)
+      if (mb.index >= xocl::xclbin::max_banks)
         throw std::runtime_error("bad mem_data index '" + std::to_string(mb.index) + "'");
       if (!m_mem->m_mem_data[mb.index].m_used)
         continue;

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -63,9 +63,10 @@ public:
   // Max 256 memory indicies for now. This number must be >= to number
   // of mem_topology.m_count.  Unfortunately it is a compile time constant.
   // A better solution must be found (boost::dynamic_bitset<>???)
-  using memidx_bitmask_type = std::bitset<256>;
   using memidx_type = int32_t;
   using connidx_type = int32_t;
+  static constexpr memidx_type max_banks = 256;
+  using memidx_bitmask_type = std::bitset<max_banks>;
 
   enum class target_type{ bin,x86,zynqps7,csim,cosim,hwem,invalid};
 


### PR DESCRIPTION
Amend #2763 and #2844 and make bank limit a symbolic constant.  Fix
hardwired usage of original old limit (63).