### PR TITLE
Refactored XDMA library code to support asynchronous IOs.

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -20,6 +20,7 @@
 #include <linux/mm.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
+#include <linux/delay.h>
 #include <linux/vmalloc.h>
 
 #include "libxdma.h"
@@ -43,6 +44,9 @@ MODULE_VERSION(DRV_MODULE_VERSION);
 MODULE_LICENSE("GPL v2");
 #endif
 
+extern unsigned int desc_blen_max;
+
+
 /* Module Parameters */
 static unsigned int poll_mode;
 module_param(poll_mode, uint, 0644);
@@ -52,9 +56,20 @@ static unsigned int interrupt_mode;
 module_param(interrupt_mode, uint, 0644);
 MODULE_PARM_DESC(interrupt_mode, "0 - MSI-x , 1 - MSI, 2 - Legacy");
 
-static unsigned int enable_credit_mp;
+static unsigned int enable_credit_mp = 1;
 module_param(enable_credit_mp, uint, 0644);
 MODULE_PARM_DESC(enable_credit_mp, "Set 1 to enable creidt feature, default is 0 (no credit control)");
+
+static unsigned int desc_set_depth = 16;
+module_param(desc_set_depth, uint, 0644);
+MODULE_PARM_DESC(desc_set_depth, "Supported Values 16, 32, 64, 128, default is 32");
+
+unsigned int desc_blen_max = XDMA_DESC_BLEN_MAX;
+module_param(desc_blen_max, uint, 0644);
+MODULE_PARM_DESC(desc_blen_max,
+		 "per descriptor max. buffer length, default is (1 << 28) - 1");
+
+
 
 /*
  * xdma device management
@@ -70,6 +85,17 @@ static DEFINE_SPINLOCK(xdev_rcu_lock);
 #define list_last_entry(ptr, type, member) \
 		list_entry((ptr)->prev, type, member)
 #endif
+
+static inline unsigned int incr_ptr_idx(unsigned int cur, unsigned int incr,
+			     unsigned int max)
+{
+	cur += incr;
+	if (cur > (max - 1))
+		cur -= max;
+
+	return cur;
+}
+
 
 static inline void xdev_list_add(struct xdma_dev *xdev)
 {
@@ -154,12 +180,12 @@ inline void __write_register(const char *fn, u32 value, void *iomem, unsigned lo
 }
 #define write_register(v,mem,off) __write_register(__func__, v, mem, off)
 #else
-#define write_register(v,mem,off) iowrite32(v, mem)
+#define write_register(v,mem,off) writel(v, mem)
 #endif
 
 inline u32 read_register(void *iomem)
 {
-	return ioread32(iomem);
+	return readl(iomem);
 }
 
 static inline u32 build_u32(u32 hi, u32 lo)
@@ -469,12 +495,16 @@ static u32 engine_status_read(struct xdma_engine *engine, bool clear, bool dump)
  * xdma_engine_stop() - stop an SG DMA engine
  *
  */
-static void xdma_engine_stop(struct xdma_engine *engine)
+static int xdma_engine_stop(struct xdma_engine *engine)
 {
 	u32 w;
 
-	BUG_ON(!engine);
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
 	dbg_tfr("xdma_engine_stop(engine=%p)\n", engine);
+
 
 	w = 0;
 	w |= (u32)XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
@@ -483,80 +513,245 @@ static void xdma_engine_stop(struct xdma_engine *engine)
 	w |= (u32)XDMA_CTRL_IE_DESC_ERROR;
 
 	if (poll_mode) {
-		w |= (u32) XDMA_CTRL_POLL_MODE_WB;
-	} else {
-		w |= (u32)XDMA_CTRL_IE_DESC_STOPPED;
-		w |= (u32)XDMA_CTRL_IE_DESC_COMPLETED;
-
-		/* Disable IDLE STOPPED for MM */
-		if ((engine->streaming && (engine->dir == DMA_FROM_DEVICE)) ||
-		    (engine->xdma_perf))
-			w |= (u32)XDMA_CTRL_IE_IDLE_STOPPED;
-	}
-
-	dbg_tfr("Stopping SG DMA %s engine; writing 0x%08x to 0x%p.\n",
-			engine->name, w, (u32 *)&engine->regs->control);
-	write_register(w, &engine->regs->control,
-			(unsigned long)(&engine->regs->control) -
-			(unsigned long)(&engine->regs));
-	/* dummy read of status register to flush all previous writes */
-	dbg_tfr("xdma_engine_stop(%s) done\n", engine->name);
-}
-
-static void engine_start_mode_config(struct xdma_engine *engine)
-{
-	u32 w;
-
-	BUG_ON(!engine);
-
-	/* If a perf test is running, enable the engine interrupts */
-	if (engine->xdma_perf) {
-		w = XDMA_CTRL_IE_DESC_STOPPED;
-		w |= XDMA_CTRL_IE_DESC_COMPLETED;
-		w |= XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
-		w |= XDMA_CTRL_IE_MAGIC_STOPPED;
-		w |= XDMA_CTRL_IE_IDLE_STOPPED;
-		w |= XDMA_CTRL_IE_READ_ERROR;
-		w |= XDMA_CTRL_IE_DESC_ERROR;
-
-		write_register(w, &engine->regs->interrupt_enable_mask,
-			(unsigned long)(&engine->regs->interrupt_enable_mask) -
-			(unsigned long)(&engine->regs));
-	}
-
-	/* write control register of SG DMA engine */
-	w = (u32)XDMA_CTRL_RUN_STOP;
-	w |= (u32)XDMA_CTRL_IE_READ_ERROR;
-	w |= (u32)XDMA_CTRL_IE_DESC_ERROR;
-	w |= (u32)XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
-	w |= (u32)XDMA_CTRL_IE_MAGIC_STOPPED;
-
-	if (poll_mode) {
 		w |= (u32)XDMA_CTRL_POLL_MODE_WB;
 	} else {
 		w |= (u32)XDMA_CTRL_IE_DESC_STOPPED;
 		w |= (u32)XDMA_CTRL_IE_DESC_COMPLETED;
 
-		if ((engine->streaming && (engine->dir == DMA_FROM_DEVICE)) ||
-		    (engine->xdma_perf))
-			w |= (u32)XDMA_CTRL_IE_IDLE_STOPPED;
-
-		/* set non-incremental addressing mode */
-		if (engine->non_incr_addr)
-			w |= (u32)XDMA_CTRL_NON_INCR_ADDR;
 	}
 
-	dbg_tfr("iowrite32(0x%08x to 0x%p) (control)\n", w,
-			(void *)&engine->regs->control);
-	/* start the engine */
+	dbg_tfr("Stopping SG DMA %s engine; writing 0x%08x to 0x%p.\n",
+			engine->name, w, (u32 *)&engine->regs->control);
 	write_register(w, &engine->regs->control,
-			(unsigned long)(&engine->regs->control) -
+		       (unsigned long)(&engine->regs->control) -
+		       (unsigned long)(&engine->regs));
+	/* dummy read of status register to flush all previous writes */
+	dbg_tfr("xdma_engine_stop(%s) done\n", engine->name);
+	return 0;
+}
+
+
+static int engine_start_mode_config(struct xdma_engine *engine)
+{
+	u32 wr;
+
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
+
+	/* If a perf test is running, enable the engine interrupts */
+	if (engine->xdma_perf) {
+		wr = XDMA_CTRL_IE_DESC_STOPPED;
+		wr |= XDMA_CTRL_IE_DESC_COMPLETED;
+		wr |= XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
+		wr |= XDMA_CTRL_IE_MAGIC_STOPPED;
+		wr |= XDMA_CTRL_IE_IDLE_STOPPED;
+		wr |= XDMA_CTRL_IE_READ_ERROR;
+		wr |= XDMA_CTRL_IE_DESC_ERROR;
+
+		write_register(
+			wr, &engine->regs->interrupt_enable_mask,
+			(unsigned long)(&engine->regs->interrupt_enable_mask) -
 			(unsigned long)(&engine->regs));
+	}
+
+	/* write control register of SG DMA engine */
+	wr = (u32)XDMA_CTRL_RUN_STOP;
+	wr |= (u32)XDMA_CTRL_IE_READ_ERROR;
+	wr |= (u32)XDMA_CTRL_IE_DESC_ERROR;
+	wr |= (u32)XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
+	wr |= (u32)XDMA_CTRL_IE_MAGIC_STOPPED;
+
+	if (poll_mode) {
+		wr |= (u32)XDMA_CTRL_POLL_MODE_WB;
+	} else {
+		wr |= (u32)XDMA_CTRL_IE_DESC_STOPPED;
+		wr |= (u32)XDMA_CTRL_IE_DESC_COMPLETED;
+		/* set non-incremental addressing mode */
+		if (engine->non_incr_addr)
+			wr |= (u32)XDMA_CTRL_NON_INCR_ADDR;
+	}
+
+	/* start the engine */
+	write_register(wr, &engine->regs->control,
+		       (unsigned long)(&engine->regs->control) -
+		       (unsigned long)(&engine->regs));
 
 	/* dummy read of status register to flush all previous writes */
-	w = read_register(&engine->regs->status);
 	dbg_tfr("ioread32(0x%p) = 0x%08x (dummy read flushes writes).\n",
-			&engine->regs->status, w);
+		&engine->regs->status, rd);
+	dbg_tfr("iowrite32(0x%08x to 0x%p) (control)\n", wr,
+		(void *)&engine->regs->control);
+
+	return 0;
+}
+
+
+/**
+ * engine_service_shutdown() - stop servicing an SG DMA engine
+ *
+ * must be called with engine->lock already acquired
+ *
+ * @engine pointer to struct xdma_engine
+ *
+ */
+static int engine_service_shutdown(struct xdma_engine *engine)
+{
+	int rv;
+	/* if the engine stopped with RUN still asserted, de-assert RUN now */
+	dbg_tfr("engine just went idle, resetting RUN_STOP.\n");
+	rv = xdma_engine_stop(engine);
+	if (rv < 0) {
+		pr_err("Failed to stop engine\n");
+		return rv;
+	}
+	engine->running = 0;
+	engine->desc_dequeued = 0;
+
+	/* awake task on engine's shutdown wait queue */
+	wake_up_interruptible(&engine->shutdown_wq);
+	return 0;
+}
+
+/* xdma_desc_link() - Link two descriptors
+ *
+ * Link the first descriptor to a second descriptor, or terminate the first.
+ *
+ * @first first descriptor
+ * @second second descriptor, or NULL if first descriptor must be set as last.
+ * @second_bus bus address of second descriptor
+ */
+static void xdma_desc_link(struct xdma_desc *first, struct xdma_desc *second,
+			   dma_addr_t second_bus)
+{
+	/*
+	 * remember reserved control in first descriptor, but zero
+	 * extra_adjacent!
+	 */
+
+	/* Clear adjacent count for last descriptor in first block
+	 * also clear out STOPPED bit. But Let the COMPLETION bit
+	 * be set.
+	 * TODO - Need to improve this algorithm for setting COMPLETION BIT.
+	 */
+	u32 control = le32_to_cpu(first->control) & 0xffffc0feUL;
+	/* second descriptor given? */
+	if (second) {
+		/*
+		 * link last descriptor of 1st array to first descriptor of
+		 * 2nd array
+		 */
+		first->next_lo = cpu_to_le32(PCI_DMA_L(second_bus));
+		first->next_hi = cpu_to_le32(PCI_DMA_H(second_bus));
+		WARN_ON(first->next_hi);
+		/* no second descriptor given */
+	} else {
+		/* first descriptor is the last */
+		first->next_lo = 0;
+		first->next_hi = 0;
+	}
+
+	/* write bytes and next_num */
+	first->control = cpu_to_le32(control);
+}
+
+/* xdma_desc_adjacent -- Set how many descriptors are adjacent to this one */
+static void xdma_desc_adjacent(struct xdma_desc *desc, int next_adjacent)
+{
+	u32 max_extra_adj = 0x3F;
+	/* remember reserved and control bits */
+	u32 control = le32_to_cpu(desc->control) & 0xffffc0ffUL;
+
+	if (next_adjacent)
+		next_adjacent = next_adjacent - 1;
+
+	if (next_adjacent >= desc_set_depth)
+		next_adjacent = desc_set_depth - 1;
+	if (next_adjacent > max_extra_adj)
+		next_adjacent = max_extra_adj;
+
+	control |= (next_adjacent << 8);
+	/* write control and next_adjacent */
+	desc->control = cpu_to_le32(control);
+}
+
+/* xdma_desc_control -- Set complete control field of a descriptor. */
+static int xdma_desc_control_set(struct xdma_desc *first, u32 control_field)
+{
+	/* remember magic and adjacent number */
+	u32 control = le32_to_cpu(first->control) & ~(LS_BYTE_MASK);
+
+	if (control_field & ~(LS_BYTE_MASK)) {
+		pr_err("Invalid control field\n");
+		return -EINVAL;
+	}
+	/* merge adjacent and control field */
+	control |= control_field;
+	/* write control and next_adjacent */
+	first->control = cpu_to_le32(control);
+	return 0;
+}
+
+
+/* xdma_desc_done - recycle cache-coherent linked list of descriptors.
+ *
+ * @dev Pointer to pci_dev
+ * @number Number of descriptors to be allocated
+ * @desc_virt Pointer to (i.e. virtual address of) first descriptor in list
+ * @desc_bus Bus address of first descriptor in list
+ */
+static inline void xdma_desc_done(struct xdma_desc *desc_virt, int count)
+{
+	memset(desc_virt, 0, count * sizeof(struct xdma_desc));
+}
+
+/* xdma_desc() - Fill a descriptor with the transfer details
+ *
+ * @desc pointer to descriptor to be filled
+ * @addr root complex address
+ * @ep_addr end point address
+ * @len number of bytes, must be a (non-negative) multiple of 4.
+ * @dir, dma direction
+ * is the end point address. If zero, vice versa.
+ *
+ * Does not modify the next pointer
+ */
+static void xdma_desc_set(struct xdma_desc *desc, dma_addr_t rc_bus_addr,
+			  u64 ep_addr, int len, int dir)
+{
+	/* transfer length */
+	desc->bytes = cpu_to_le32(len);
+	desc->control = DESC_MAGIC;
+	if (dir == DMA_TO_DEVICE) {
+		/* read from root complex memory (source address) */
+		desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(rc_bus_addr));
+		desc->src_addr_hi = cpu_to_le32(PCI_DMA_H(rc_bus_addr));
+		/* write to end point address (destination address) */
+		desc->dst_addr_lo = cpu_to_le32(PCI_DMA_L(ep_addr));
+		desc->dst_addr_hi = cpu_to_le32(PCI_DMA_H(ep_addr));
+	} else {
+		/* read from end point address (source address) */
+		desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(ep_addr));
+		desc->src_addr_hi = cpu_to_le32(PCI_DMA_H(ep_addr));
+		/* write to root complex memory (destination address) */
+		desc->dst_addr_lo = cpu_to_le32(PCI_DMA_L(rc_bus_addr));
+		desc->dst_addr_hi = cpu_to_le32(PCI_DMA_H(rc_bus_addr));
+	}
+}
+
+static inline void enable_interrupts(struct xdma_engine *engine)
+{
+	/* re-enable interrupts for this engine */
+	if (engine->xdev->msix_enabled) {
+		write_register(
+				engine->interrupt_enable_mask_value,
+				&engine->regs->interrupt_enable_mask_w1s,
+				(unsigned long)(&engine->regs
+					->interrupt_enable_mask_w1s) -
+				(unsigned long)(&engine->regs));
+	} else
+		channel_interrupts_enable(engine->xdev, engine->irq_bitmask);
 }
 
 /**
@@ -575,504 +770,773 @@ static void engine_start_mode_config(struct xdma_engine *engine)
  * taken.
  *
  */
-static struct xdma_transfer *engine_start(struct xdma_engine *engine)
+static int engine_start(struct xdma_engine *engine,
+		dma_addr_t desc_bus, unsigned int desc_adjacent)
 {
-	struct xdma_transfer *transfer;
 	u32 w;
-	int extra_adj = 0;
+	int extra_adj = desc_adjacent - 1;
+	u32 max_extra_adj = 0x3F;
+	int rv;
 
-	/* engine must be idle */
-	BUG_ON(engine->running);
-	/* engine transfer queue must not be empty */
-	BUG_ON(list_empty(&engine->transfer_list));
-	/* inspect first transfer queued on the engine */
-	transfer = list_entry(engine->transfer_list.next, struct xdma_transfer,
-				entry);
-	BUG_ON(!transfer);
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
+
+	/* remember the engine is running */
+	engine->running = 1;
+	engine->desc_dequeued = 0;
 
 	/* engine is no longer shutdown */
 	engine->shutdown = ENGINE_SHUTDOWN_NONE;
-
-	dbg_tfr("engine_start(%s): transfer=0x%p.\n", engine->name, transfer);
-
-	/* initialize number of descriptors of dequeued transfers */
-	engine->desc_dequeued = 0;
+	if (engine->streaming && (engine->dir == DMA_FROM_DEVICE) &&
+			enable_credit_mp) {
+		write_register(desc_set_depth,
+			       &engine->sgdma_regs->credits, 0);
+	}
 
 	/* write lower 32-bit of bus address of transfer first descriptor */
-	w = cpu_to_le32(PCI_DMA_L(transfer->desc_bus));
+	w = cpu_to_le32(PCI_DMA_L(desc_bus));
 	dbg_tfr("iowrite32(0x%08x to 0x%p) (first_desc_lo)\n", w,
-			(void *)&engine->sgdma_regs->first_desc_lo);
+		(void *)&engine->sgdma_regs->first_desc_lo);
 	write_register(w, &engine->sgdma_regs->first_desc_lo,
-			(unsigned long)(&engine->sgdma_regs->first_desc_lo) -
-			(unsigned long)(&engine->sgdma_regs));
+		       (unsigned long)(&engine->sgdma_regs->first_desc_lo) -
+			       (unsigned long)(&engine->sgdma_regs));
 	/* write upper 32-bit of bus address of transfer first descriptor */
-	w = cpu_to_le32(PCI_DMA_H(transfer->desc_bus));
+	w = cpu_to_le32(PCI_DMA_H(desc_bus));
 	dbg_tfr("iowrite32(0x%08x to 0x%p) (first_desc_hi)\n", w,
-			(void *)&engine->sgdma_regs->first_desc_hi);
+		(void *)&engine->sgdma_regs->first_desc_hi);
 	write_register(w, &engine->sgdma_regs->first_desc_hi,
-			(unsigned long)(&engine->sgdma_regs->first_desc_hi) -
-			(unsigned long)(&engine->sgdma_regs));
+		       (unsigned long)(&engine->sgdma_regs->first_desc_hi) -
+			       (unsigned long)(&engine->sgdma_regs));
 
-	if (transfer->desc_adjacent > 0) {
-		extra_adj = transfer->desc_adjacent - 1;
-		if (extra_adj > MAX_EXTRA_ADJ)
-			extra_adj = MAX_EXTRA_ADJ;
-	}
-	dbg_tfr("iowrite32(0x%08x to 0x%p) (first_desc_adjacent)\n",
-		extra_adj, (void *)&engine->sgdma_regs->first_desc_adjacent);
-	write_register(extra_adj, &engine->sgdma_regs->first_desc_adjacent,
-			(unsigned long)(&engine->sgdma_regs->first_desc_adjacent) -
+	if (extra_adj >= desc_set_depth)
+		extra_adj = desc_set_depth - 1;
+	if (extra_adj > max_extra_adj)
+		extra_adj = max_extra_adj;
+	dbg_tfr("iowrite32(0x%08x to 0x%p) (first_desc_adjacent)\n", extra_adj,
+		(void *)&engine->sgdma_regs->first_desc_adjacent);
+	write_register(
+		extra_adj, &engine->sgdma_regs->first_desc_adjacent,
+		(unsigned long)(&engine->sgdma_regs->first_desc_adjacent) -
 			(unsigned long)(&engine->sgdma_regs));
 
 	dbg_tfr("ioread32(0x%p) (dummy read flushes writes).\n",
 		&engine->regs->status);
 	mmiowb();
 
-	engine_start_mode_config(engine);
+	rv = engine_start_mode_config(engine);
 
-	engine_status_read(engine, 0, 0);
+	if (rv < 0) {
+		pr_err("Failed to start engine mode config\n");
+		return -EINVAL;
+	}
 
 	dbg_tfr("%s engine 0x%p now running\n", engine->name, engine);
-	/* remember the engine is running */
-	engine->running = 1;
-	return transfer;
-}
-
-/**
- * engine_service() - service an SG DMA engine
- *
- * must be called with engine->lock already acquired
- *
- * @engine pointer to struct xdma_engine
- *
- */
-static void engine_service_shutdown(struct xdma_engine *engine)
-{
-	/* if the engine stopped with RUN still asserted, de-assert RUN now */
-	dbg_tfr("engine just went idle, resetting RUN_STOP.\n");
-	xdma_engine_stop(engine);
-	engine->running = 0;
-
-	/* awake task on engine's shutdown wait queue */
-	wake_up(&engine->shutdown_wq);
-}
-
-struct xdma_transfer *engine_transfer_completion(struct xdma_engine *engine,
-		struct xdma_transfer *transfer)
-{
-	BUG_ON(!engine);
-	BUG_ON(!transfer);
-
-	/* synchronous I/O? */
-	/* awake task on transfer's wait queue */
-	wake_up(&transfer->wq);
-
-	return transfer;
-}
-
-struct xdma_transfer *engine_service_transfer_list(struct xdma_engine *engine,
-		struct xdma_transfer *transfer, u32 *pdesc_completed)
-{
-	BUG_ON(!engine);
-	BUG_ON(!pdesc_completed);
-
-	if (!transfer) {
-		pr_info("%s xfer empty, pdesc completed %u.\n",
-			engine->name, *pdesc_completed);
-		return NULL;
-	}
-
-	/*
-	 * iterate over all the transfers completed by the engine,
-	 * except for the last (i.e. use > instead of >=).
-	 */
-	while (transfer && (!transfer->cyclic) &&
-		(*pdesc_completed > transfer->desc_num)) {
-		/* remove this transfer from pdesc_completed */
-		*pdesc_completed -= transfer->desc_num;
-		dbg_tfr("%s engine completed non-cyclic xfer 0x%p (%d desc)\n",
-			engine->name, transfer, transfer->desc_num);
-		/* remove completed transfer from list */
-		list_del(engine->transfer_list.next);
-		/* add to dequeued number of descriptors during this run */
-		engine->desc_dequeued += transfer->desc_num;
-		/* mark transfer as succesfully completed */
-		transfer->state = TRANSFER_STATE_COMPLETED;
-
-		/* Complete transfer - sets transfer to NULL if an async
-		 * transfer has completed */
-		transfer = engine_transfer_completion(engine, transfer);
-
-		/* if exists, get the next transfer on the list */
-		if (!list_empty(&engine->transfer_list)) {
-			transfer = list_entry(engine->transfer_list.next,
-					struct xdma_transfer, entry);
-			dbg_tfr("Non-completed transfer %p\n", transfer);
-		} else {
-			/* no further transfers? */
-			transfer = NULL;
-		}
-	}
-
-	return transfer;
-}
-
-static void engine_err_handle(struct xdma_engine *engine,
-		struct xdma_transfer *transfer, u32 desc_completed)
-{
-	u32 value;
-
-	/*
-	 * The BUSY bit is expected to be clear now but older HW has a race
-	 * condition which could cause it to be still set.  If it's set, re-read
-	 * and check again.  If it's still set, log the issue.
-	 */
-	if (engine->status & XDMA_STAT_BUSY) {
-		value = read_register(&engine->regs->status);
-		if ((value & XDMA_STAT_BUSY) && printk_ratelimit())
-			pr_info("%s has errors but is still BUSY\n",
-				engine->name);
-	}
-
-	if (printk_ratelimit()) {
-		pr_info("%s, s 0x%x, aborted xfer 0x%p, cmpl %d/%d\n",
-			engine->name, engine->status, transfer, desc_completed,
-			transfer->desc_num);
-	}
-
-	/* mark transfer as failed */
-	transfer->state = TRANSFER_STATE_FAILED;
-	xdma_engine_stop(engine);
-}
-
-struct xdma_transfer *engine_service_final_transfer(struct xdma_engine *engine,
-			struct xdma_transfer *transfer, u32 *pdesc_completed)
-{
-	BUG_ON(!engine);
-	BUG_ON(!transfer);
-	BUG_ON(!pdesc_completed);
-
-	/* inspect the current transfer */
-	if (transfer) {
-		if (((engine->dir == DMA_FROM_DEVICE) &&
-		     (engine->status & XDMA_STAT_C2H_ERR_MASK)) ||
-		    ((engine->dir == DMA_TO_DEVICE) &&
-		     (engine->status & XDMA_STAT_H2C_ERR_MASK))) {
-			pr_info("engine %s, status error 0x%x.\n",
-				engine->name, engine->status);
-			engine_status_dump(engine);
-			engine_err_handle(engine, transfer, *pdesc_completed);
-			goto transfer_del;
-		}
-
-		if (engine->status & XDMA_STAT_BUSY)
-			dbg_tfr("Engine %s is unexpectedly busy - ignoring\n",
-				engine->name);
-
-		/* the engine stopped on current transfer? */
-		if (*pdesc_completed < transfer->desc_num) {
-			transfer->state = TRANSFER_STATE_FAILED;
-			pr_info("%s, xfer 0x%p, stopped half-way, %d/%d.\n",
-				engine->name, transfer, *pdesc_completed,
-				transfer->desc_num);
-		} else {
-			dbg_tfr("engine %s completed transfer\n", engine->name);
-			dbg_tfr("Completed transfer ID = 0x%p\n", transfer);
-			dbg_tfr("*pdesc_completed=%d, transfer->desc_num=%d",
-				*pdesc_completed, transfer->desc_num);
-
-			if (!transfer->cyclic) {
-				/*
-				 * if the engine stopped on this transfer,
-				 * it should be the last
-				 */
-				WARN_ON(*pdesc_completed > transfer->desc_num);
-			}
-			/* mark transfer as succesfully completed */
-			transfer->state = TRANSFER_STATE_COMPLETED;
-		}
-
-transfer_del:
-		/* remove completed transfer from list */
-		list_del(engine->transfer_list.next);
-		/* add to dequeued number of descriptors during this run */
-		engine->desc_dequeued += transfer->desc_num;
-
-		/*
-		 * Complete transfer - sets transfer to NULL if an asynchronous
-		 * transfer has completed
-		 */
-		transfer = engine_transfer_completion(engine, transfer);
-	}
-
-	return transfer;
-}
-
-static void engine_service_perf(struct xdma_engine *engine, u32 desc_completed)
-{
-	BUG_ON(!engine);
-
-	/* performance measurement is running? */
-	if (engine->xdma_perf) {
-		/* a descriptor was completed? */
-		if (engine->status & XDMA_STAT_DESC_COMPLETED) {
-			engine->xdma_perf->iterations = desc_completed;
-			dbg_perf("transfer->xdma_perf->iterations=%d\n",
-				engine->xdma_perf->iterations);
-		}
-
-		/* a descriptor stopped the engine? */
-		if (engine->status & XDMA_STAT_DESC_STOPPED) {
-			engine->xdma_perf->stopped = 1;
-			/*
-			 * wake any XDMA_PERF_IOCTL_STOP waiting for
-			 * the performance run to finish
-			 */
-			wake_up(&engine->xdma_perf_wq);
-			dbg_perf("transfer->xdma_perf stopped\n");
-		}
-	}
-}
-
-static void engine_transfer_dequeue(struct xdma_engine *engine)
-{
-	struct xdma_transfer *transfer;
-
-	BUG_ON(!engine);
-
-	/* pick first transfer on the queue (was submitted to the engine) */
-	transfer = list_entry(engine->transfer_list.next, struct xdma_transfer,
-		entry);
-	BUG_ON(!transfer);
-	BUG_ON(transfer != &engine->cyclic_req->xfer);
-	dbg_tfr("%s engine completed cyclic transfer 0x%p (%d desc).\n",
-		engine->name, transfer, transfer->desc_num);
-	/* remove completed transfer from list */
-	list_del(engine->transfer_list.next);
-}
-
-static int engine_ring_process(struct xdma_engine *engine)
-{
-	struct xdma_result *result;
-	int start;
-	int eop_count = 0;
-
-	BUG_ON(!engine);
-	result = engine->cyclic_result;
-	BUG_ON(!result);
-
-	/* where we start receiving in the ring buffer */
-	start = engine->rx_tail;
-
-	/* iterate through all newly received RX result descriptors */
-	dbg_tfr("%s, result %d, 0x%x, len 0x%x.\n",
-		engine->name, engine->rx_tail, result[engine->rx_tail].status,
-		result[engine->rx_tail].length);
-	while (result[engine->rx_tail].status && !engine->rx_overrun) {
-		/* EOP bit set in result? */
-		if (result[engine->rx_tail].status & RX_STATUS_EOP){
-			eop_count++;
-		}
-
-		/* increment tail pointer */
-		engine->rx_tail = (engine->rx_tail + 1) % CYCLIC_RX_PAGES_MAX;
-
-		dbg_tfr("%s, head %d, tail %d, 0x%x, len 0x%x.\n",
-			engine->name, engine->rx_head, engine->rx_tail,
-			result[engine->rx_tail].status,
-			result[engine->rx_tail].length);
-
-		/* overrun? */
-		if (engine->rx_tail == engine->rx_head) {
-			dbg_tfr("%s: overrun\n", engine->name);
-			/* flag to user space that overrun has occurred */
-			engine->rx_overrun = 1;
-		}
-	}
-
-	return eop_count;
-}
-
-static int engine_service_cyclic_polled(struct xdma_engine *engine)
-{
-	int eop_count = 0;
-	int rc = 0;
-	struct xdma_poll_wb *writeback_data;
-	u32 sched_limit = 0;
-
-	BUG_ON(!engine);
-	BUG_ON(engine->magic != MAGIC_ENGINE);
-
-	writeback_data = (struct xdma_poll_wb *)engine->poll_mode_addr_virt;
-
-	while (eop_count == 0) {
-		if (sched_limit != 0) {
-			if ((sched_limit % NUM_POLLS_PER_SCHED) == 0)
-				schedule();
-		}
-		sched_limit++;
-
-		/* Monitor descriptor writeback address for errors */
-		if ((writeback_data->completed_desc_count) & WB_ERR_MASK) {
-			rc = -EINVAL;
-			break;
-		}
-
-		eop_count = engine_ring_process(engine);
-	}
-
-	if (eop_count == 0) {
-		engine_status_read(engine, 1, 0);
-		if ((engine->running) && !(engine->status & XDMA_STAT_BUSY)) {
-			/* transfers on queue? */
-			if (!list_empty(&engine->transfer_list))
-				engine_transfer_dequeue(engine);
-
-			engine_service_shutdown(engine);
-		}
-	}
-
-	return rc;
-}
-
-static int engine_service_cyclic_interrupt(struct xdma_engine *engine)
-{
-	int eop_count = 0;
-	struct xdma_transfer *xfer;
-
-	BUG_ON(!engine);
-	BUG_ON(engine->magic != MAGIC_ENGINE);
-
-	engine_status_read(engine, 1, 0);
-
-	eop_count = engine_ring_process(engine);
-	/*
-	 * wake any reader on EOP, as one or more packets are now in
-	 * the RX buffer
-	 */
-	xfer = &engine->cyclic_req->xfer;
-	if(enable_credit_mp){
-		if (eop_count > 0) {
-			//engine->eop_found = 1;
-		}
-		wake_up(&xfer->wq);
-	}else{
-		if (eop_count > 0) {
-			/* awake task on transfer's wait queue */
-			dbg_tfr("wake_up() due to %d EOP's\n", eop_count);
-			engine->eop_found = 1;
-			wake_up(&xfer->wq);
-		}
-	}
-
-	/* engine was running but is no longer busy? */
-	if ((engine->running) && !(engine->status & XDMA_STAT_BUSY)) {
-		/* transfers on queue? */
-		if (!list_empty(&engine->transfer_list))
-			engine_transfer_dequeue(engine);
-
-		engine_service_shutdown(engine);
-	}
 
 	return 0;
 }
 
-/* must be called with engine->lock already acquired */
-static int engine_service_cyclic(struct xdma_engine *engine)
+static void xdma_request_free(struct xdma_request_cb *req)
 {
-	int rc = 0;
-
-	dbg_tfr("engine_service_cyclic()");
-
-	BUG_ON(!engine);
-	BUG_ON(engine->magic != MAGIC_ENGINE);
-
-	if (poll_mode)
-		rc = engine_service_cyclic_polled(engine);
+	if (((unsigned long)req) >= VMALLOC_START &&
+	    ((unsigned long)req) < VMALLOC_END)
+		vfree(req);
 	else
-		rc = engine_service_cyclic_interrupt(engine);
-
-	return rc;
+		kfree(req);
 }
 
-
-static void engine_service_resume(struct xdma_engine *engine)
+static void xdma_request_release(struct xdma_dev *xdev,
+			struct xdma_request_cb *req)
 {
-	struct xdma_transfer *transfer_started;
+	struct sg_table *sgt = req->sgt;
+	if (!req->dma_mapped) {
+		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
+			     req->dir);
+		sgt->nents = 0;
+	}
 
-	BUG_ON(!engine);
+	xdma_request_free(req);
+}
 
-	/* engine stopped? */
-	if (!engine->running) {
-		/* in the case of shutdown, let it finish what's in the Q */
-		if (!list_empty(&engine->transfer_list)) {
-			/* (re)start engine */
-			transfer_started = engine_start(engine);
-			dbg_tfr("re-started %s engine with pending xfer 0x%p\n",
-				engine->name, transfer_started);
-		/* engine was requested to be shutdown? */
-		} else if (engine->shutdown & ENGINE_SHUTDOWN_REQUEST) {
-			engine->shutdown |= ENGINE_SHUTDOWN_IDLE;
-			/* awake task on engine's shutdown wait queue */
-			wake_up(&engine->shutdown_wq);
-		} else {
-			dbg_tfr("no pending transfers, %s engine stays idle.\n",
-				engine->name);
+static int free_desc_set(struct xdma_engine *engine,
+		unsigned int desc_dequeued) {
+	struct desc_sets *s;
+	unsigned int desc_cnt = 0;
+	unsigned int prev_cidx;
+	unsigned int avail_sets = 0;
+	int ret = -EBUSY;
+
+	spin_lock(&engine->desc_lock);
+	while (desc_dequeued) {
+		prev_cidx = engine->cidx;
+		s = &engine->sets[prev_cidx];
+
+		desc_cnt = min_t(unsigned int, desc_dequeued,
+				 s->desc_set_offset);
+		if (!desc_cnt)
+			break;
+		s->desc_set_offset -= desc_cnt;
+		desc_dequeued -= desc_cnt;
+		if (s->desc_set_offset == 0) {
+			engine->cidx = incr_ptr_idx(prev_cidx, 1,
+						       XDMA_DESC_SETS_MAX);
+			engine->avail_sets++;
+			s->last_set = 0;
+			ret = 0;
+			dbg_tfr("free desc set cidx = %u/%u/%u/%u",
+				s->desc_set_offset, engine->cidx,
+				engine->pidx, desc_dequeued);
 		}
-	} else {
-		/* engine is still running? */
-		if (list_empty(&engine->transfer_list)) {
-			pr_warn("no queued transfers but %s engine running!\n",
-				engine->name);
-			WARN_ON(1);
+		avail_sets = engine->avail_sets;
+		if (avail_sets > XDMA_DESC_SETS_AVAIL_MAX)
+			break;
+	}
+	spin_unlock(&engine->desc_lock);
+
+	return ret;
+}
+
+static int process_completions(struct xdma_engine *engine,
+		unsigned int desc_dequeued)
+{
+	unsigned int desc_count;
+	struct xdma_request_cb *req;
+	struct list_head *req_list_head = &engine->pend_list;
+	unsigned int released_desc = desc_dequeued;
+	int i, ret;
+
+	spin_lock(&engine->req_list_lock);
+	if (list_empty(&engine->pend_list) && list_empty(&engine->work_list)) {
+		spin_unlock(&engine->req_list_lock);
+		 /* requests expired */
+		return free_desc_set(engine, released_desc);
+	}
+	spin_unlock(&engine->req_list_lock);
+	while (desc_dequeued) {
+		req_list_head = &engine->pend_list;
+		spin_lock(&engine->req_list_lock);
+		if (list_empty(&engine->pend_list)) {
+			req_list_head = &engine->work_list;
+			if (list_empty(req_list_head)) {
+				spin_unlock(&engine->req_list_lock);
+				break;
+			}
 		}
+		req = list_first_entry(req_list_head,
+				struct xdma_request_cb,	entry);
+		desc_count = min_t(unsigned int,
+				req->sw_desc_idx - req->desc_completed,
+				desc_dequeued);
+		if (!desc_count) {
+			/*these release descriptors are from some expired
+			 * requests*/
+			spin_unlock(&engine->req_list_lock);
+			break;
+		}
+
+		/* Update completed transfer length */
+		for (i = req->desc_completed;
+				i <(desc_count + req->desc_completed); i++)
+			req->done  += req->sdesc[i].len;
+
+		req->desc_completed += desc_count;
+		desc_dequeued -= desc_count;
+
+		if (req->sw_desc_cnt == req->desc_completed) {
+			list_del(&req->entry);
+			if (req->cb && req->cb->io_done) {
+				struct xdma_io_cb *cb = req->cb;
+
+				cb->io_done((unsigned long)cb->private, 0);
+				xdma_request_release(engine->xdev, req);
+			} else
+				wake_up_interruptible(&req->arbtr_wait);
+		}
+		spin_unlock(&engine->req_list_lock);
+	}
+	/* at any pint of time only one desc set is given for processing,
+	 * so only descriptors related to only 1 desc set can be released */
+	ret = free_desc_set(engine, released_desc);
+
+	return ret;
+}
+
+static struct xdma_request_cb *xdma_request_alloc(unsigned int sdesc_nr)
+{
+	struct xdma_request_cb *req;
+	unsigned int size = sizeof(struct xdma_request_cb) +
+			    sdesc_nr * sizeof(struct sw_desc);
+
+	req = kzalloc(size, GFP_KERNEL);
+	if (!req) {
+		req = vmalloc(size);
+		if (req)
+			memset(req, 0, size);
+	}
+	if (!req) {
+		pr_info("OOM, %u sw_desc, %u.\n", sdesc_nr, size);
+		return NULL;
+	}
+
+	req->sw_desc_cnt = sdesc_nr;
+
+	return req;
+}
+
+static int xdma_init_request(struct xdma_request_cb *req)
+{
+	struct sg_table *sgt = req->sgt;
+	struct scatterlist *sg = sgt->sgl;
+	int i;
+
+	for (i = 0, sg = sgt->sgl; i < sgt->nents; i++, sg = sg_next(sg)) {
+		unsigned int tlen = sg_dma_len(sg);
+		dma_addr_t addr = sg_dma_address(sg);
+
+		if (tlen >= desc_blen_max)
+			return -EINVAL;
+		req->total_len += tlen;
+		req->sdesc[i].addr = addr;
+		req->sdesc[i].len = tlen;
+	}
+
+#ifdef __LIBXDMA_DEBUG__
+	xdma_request_cb_dump(req);
+#endif
+	return 0;
+}
+
+static void xdma_add_request(struct xdma_engine *engine,
+		struct xdma_request_cb *req)
+{
+	init_waitqueue_head(&req->arbtr_wait);
+	spin_lock(&engine->req_list_lock);
+	list_add_tail(&req->entry, &engine->work_list);
+	spin_unlock(&engine->req_list_lock);
+}
+
+/* returns Num of Descriptors filled for DMA transfer */
+/* Fill proper virt and bus address before calling this func */
+static void request_build(struct xdma_engine *engine,
+			  struct xdma_desc *desc_virt,
+			  struct xdma_request_cb *req, unsigned int desc_max)
+{
+	struct sw_desc *sdesc;
+	struct xdma_result *result_virt;
+	int i;
+	unsigned int result_pidx = engine->result_pidx;
+	dma_addr_t result_addr;
+
+	sdesc = &(req->sdesc[req->sw_desc_idx]);
+
+	for (i = 0; i < desc_max; i++, sdesc++) {
+		/* fill in descriptor entry j with transfer details */
+		xdma_desc_set(desc_virt + i, sdesc->addr, req->ep_addr,
+			      sdesc->len, engine->dir);
+		if (engine->streaming && engine->dir == DMA_FROM_DEVICE) {
+			result_addr = engine->cyclic_result_bus +
+					(result_pidx *
+						sizeof(struct xdma_result));
+			result_virt = engine->cyclic_result + result_pidx;
+			result_virt->length = 0;
+			result_virt->status = 0;
+			desc_virt[i].src_addr_hi =
+					cpu_to_le32(PCI_DMA_H(result_addr));
+			desc_virt[i].src_addr_lo =
+					cpu_to_le32(PCI_DMA_L(result_addr));
+			result_pidx = incr_ptr_idx(result_pidx, 1,
+						      (XDMA_DESC_SETS_MAX *
+						      desc_set_depth));
+		}
+
+
+		/* for non-inc-add mode don't increment ep_addr */
+		if (!engine->non_incr_addr)
+			req->ep_addr += sdesc->len;
+	}
+	engine->result_pidx = result_pidx;
+	req->sw_desc_idx += desc_max;
+}
+
+static void request_desc_init(struct xdma_desc *desc_virt,
+		dma_addr_t desc_bus, unsigned int count)
+{
+	int i;
+
+	if (!count)
+		return;
+	/* create singly-linked list for SG DMA controller */
+	for (i = 0; i < count; i++) {
+		/* increment bus address to next in array */
+		desc_bus += sizeof(struct xdma_desc);
+
+		desc_virt[i].next_lo = cpu_to_le32(PCI_DMA_L(desc_bus));
+		desc_virt[i].next_hi = cpu_to_le32(PCI_DMA_H(desc_bus));
 	}
 }
 
-/**
- * engine_service() - service an SG DMA engine
- *
- * must be called with engine->lock already acquired
- *
- * @engine pointer to struct xdma_engine
- *
- */
-static int engine_service(struct xdma_engine *engine, int desc_writeback)
+static int queue_request(struct xdma_engine *engine,
+		dma_addr_t desc_bus, unsigned int desc_count)
 {
-	struct xdma_transfer *transfer = NULL;
+	int rv = 0;
+	struct xdma_dev *xdev;
+
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
+
+	if (!engine->xdev) {
+		pr_err("Invalid xdev\n");
+		return -EINVAL;
+	}
+
+	xdev = engine->xdev;
+	if (xdma_device_flag_check(xdev, XDEV_FLAG_OFFLINE)) {
+		pr_info("dev 0x%p offline\n", xdev);
+		return -EBUSY;
+	}
+
+	engine->prev_cpu = get_cpu();
+	put_cpu();
+
+	/* engine is being shutdown; do not accept new transfers */
+	if (engine->shutdown & ENGINE_SHUTDOWN_REQUEST) {
+		pr_info("engine %s offline\n", engine->name);
+		rv = -EBUSY;
+		goto shutdown;
+	}
+
+	if (!poll_mode)
+		enable_interrupts(engine);
+
+	/* start engine */
+	rv = engine_start(engine, desc_bus, desc_count);
+	if (rv < 0)
+		goto shutdown;
+
+	if (poll_mode)
+		schedule_work_on(engine->cpu_idx, &engine->poll);
+
+	return rv;
+shutdown:
+	engine->running = 0;
+	dbg_tfr("engine->running = %d\n", engine->running);
+	return rv;
+}
+
+static inline int xdma_get_desc_set(struct xdma_engine *engine)
+{
+	int pidx = -EBUSY;
+
+	if (engine->avail_sets)
+		pidx = engine->pidx;
+
+	return pidx;
+}
+/*
+ * Fetch the First PENDING REQUEST from running list OR
+ * Fetch the First REQUEST FROM waiting list
+ */
+static struct xdma_request_cb *xdma_fetch_request(struct xdma_engine *engine)
+{
+	struct xdma_request_cb *req = NULL;
+
+	spin_lock(&engine->req_list_lock);
+	req = list_first_entry_or_null(&engine->work_list,
+			struct xdma_request_cb,	entry);
+	spin_unlock(&engine->req_list_lock);
+
+	return req;
+}
+
+static void config_last_desc(struct xdma_engine *engine, struct desc_sets *s,
+		struct xdma_desc *last_desc)
+{
+	if (!s->last_set) {
+		last_desc->control |= cpu_to_le32(XDMA_DESC_STOPPED |
+				XDMA_DESC_COMPLETED);
+		last_desc->next_lo = cpu_to_le32(0);
+		last_desc->next_hi = cpu_to_le32(0);
+		engine->sets_ready++;
+		s->last_set = 1;
+	}
+
+	dbg_tfr("%s", __func__);
+}
+
+/*
+ * Create chained descriptor list by linking two descriptor sets in READY state.
+ * Also update COMPLETION bit and STOPPED bit accordingly.
+ */
+static void xdma_link_sets(struct xdma_engine *engine,
+				struct desc_sets *first,
+				struct desc_sets *second,
+				unsigned int cidx_submit)
+{
+	struct xdma_desc *last_desc;
+	struct xdma_desc *desc_virt;
+	dma_addr_t desc_bus;
+	unsigned int s_cidx;
+
+	desc_virt = engine->desc + (cidx_submit * desc_set_depth);
+	last_desc = &desc_virt[first->desc_set_offset - 1];
+	s_cidx = engine->sw_cidx;
+	desc_virt = engine->desc + (s_cidx * desc_set_depth);
+	desc_bus = engine->desc_bus + ((s_cidx * desc_set_depth) *
+				sizeof(struct xdma_desc));
+
+	xdma_desc_link(last_desc, desc_virt, desc_bus);
+
+	return;
+}
+
+static int xdma_request_desc_init(struct xdma_engine *engine,
+				  unsigned char req_submit)
+{
+	struct xdma_request_cb *req = NULL;
+	struct xdma_desc *desc_virt;
+	struct desc_sets *s;
+	struct desc_sets *first, *second;
+	dma_addr_t desc_bus;
+	unsigned int count;
+	unsigned int desc_set_offset;
+	int pidx = -EBUSY;
+	int rv;
+	int old_pidx = 0;
+	unsigned char desc_setup_yield = req_submit;
+	int i;
+	unsigned int desc_cnt_submit = 0, submit_cnt = 0;
+	unsigned int cidx_submit = 0, cidx_link = 0;
+	unsigned char eop = 0;
+
+	/* Loop Runs until REQ are none or Desc Sets consumed */
+	req = NULL;
+	desc_set_offset = 0;
+	do {
+		req = xdma_fetch_request(engine);
+		if (req == NULL) {
+			if (desc_set_offset || req_submit) {
+				dbg_tfr("going to submit for pidx = %d", pidx);
+				goto submit_req;
+			}
+			return 0;
+		}
+		spin_lock(&engine->desc_lock);
+		if (!desc_set_offset) {
+			pidx = xdma_get_desc_set(engine);
+			if (pidx == -EBUSY) {
+				spin_unlock(&engine->desc_lock);
+				if (req_submit)
+					goto submit_req;
+				return 0;
+			}
+			s = &engine->sets[pidx];
+			if (s->desc_set_offset) {
+				 /* someone already using this desc set,
+				  * dont jump the gun, go and wait */
+				spin_unlock(&engine->desc_lock);
+				if (req_submit)
+					goto submit_req;
+				return 0;
+			}
+			 /* if repeatedly same pidx, not going anywhere,
+			  * yield */
+			if (old_pidx == pidx)
+				desc_setup_yield = 1;
+			else
+				old_pidx = pidx;
+		}
+		if (req->sw_desc_cnt == req->sw_desc_idx) {
+			/* req already setup, do no redo */
+			spin_unlock(&engine->desc_lock);
+			desc_setup_yield = 1;
+			goto submit_req;
+		}
+		dbg_tfr("%u-%u: req desc proced = %u/%u - %u", 
+			pidx, desc_set_offset,	req->sw_desc_idx, 
+			req->sw_desc_cnt, engine->avail_sets);
+
+		s = &engine->sets[pidx];
+		desc_virt = engine->desc + (pidx * desc_set_depth);
+		desc_bus = engine->desc_bus + ((pidx * desc_set_depth) *
+				sizeof(struct xdma_desc));
+		/* index is to track partially completed desc set */
+		count = min_t(unsigned int, req->sw_desc_cnt - req->sw_desc_idx,
+			      desc_set_depth - desc_set_offset);
+		BUG_ON(!count);
+		/* Updates Bus Address of DATA SEGMENTS from SW DESC */
+		request_build(engine, desc_virt + desc_set_offset, req, count);
+		eop = (req->sw_desc_cnt == req->sw_desc_idx) ? 1 : 0;
+		/* Keep Track of Consumed Descriptors per Req */
+		request_desc_init(desc_virt + desc_set_offset, desc_bus +
+				  (desc_set_offset * sizeof(struct xdma_desc)),
+				  count);
+		desc_set_offset += count;
+		s->desc_set_offset = desc_set_offset;
+		if (eop)
+			desc_virt[desc_set_offset - 1].control |=
+					cpu_to_le32(XDMA_DESC_EOP);
+
+		spin_unlock(&engine->desc_lock);
+		if (eop) {
+			dbg_tfr("EOP desc control = %x", 
+				desc_virt[s->desc_set_offset - 1].control);
+			/* whole request processed */
+			spin_lock(&engine->req_list_lock);
+			list_del(&req->entry);
+			list_add_tail(&req->entry, &engine->pend_list);
+			spin_unlock(&engine->req_list_lock);
+		} else {
+			/* Submit partial request */
+			goto submit_req;
+		}
+		if (desc_set_offset < desc_set_depth) {
+			schedule(); /* time for other threads to do something */
+			continue; /* get new request to fill desc set */
+		}
+submit_req:
+		spin_lock(&engine->desc_lock);
+		dbg_tfr("pidx = %u, cidx = %u %u - %u", pidx,
+			engine->cidx, desc_set_offset, engine->avail_sets);
+		if ((pidx >= 0) && desc_set_offset) { /* something new is setup */
+			s = &engine->sets[pidx];
+			desc_virt = engine->desc + (pidx * desc_set_depth);
+			config_last_desc(engine, s,
+					 &desc_virt[s->desc_set_offset - 1]);
+			dbg_tfr("last desc control = %x/%u/0x%x",
+				desc_virt[s->desc_set_offset - 1].control,
+				s->desc_set_offset, desc_virt[s->desc_set_offset - 1].next_lo);
+			for (i = 0; i < s->desc_set_offset; i++) {
+				xdma_desc_adjacent(desc_virt + i,
+						   s->desc_set_offset -
+						   i - 1);
+				dbg_tfr("%s:[%d]desc->control = 0x%x pidx=%u next=0x%x",
+					engine->name, i,
+					desc_virt[i].control, pidx,
+					desc_virt[i].next_lo);
+			}
+			for (i = s->desc_set_offset; i < desc_set_depth; i++)
+				desc_virt[i].control = 0;
+			/* fill in adjacent numbers */
+			if (engine->avail_sets) {
+				engine->pidx = incr_ptr_idx(pidx, 1,
+							    XDMA_DESC_SETS_MAX);
+				engine->avail_sets--;
+			}
+			desc_set_offset = 0; /* going for next set */
+		}
+		if (engine->avail_sets >= XDMA_DESC_SETS_AVAIL_MAX) {
+			/* Nothing to submit */
+			spin_unlock(&engine->desc_lock);
+			break;
+		}
+		spin_unlock(&engine->desc_lock);
+
+		spin_lock(&engine->lock);
+		/* if engine is not free, cannot progress further */
+		if (engine->running) {
+			spin_unlock(&engine->lock);
+			if (desc_setup_yield)
+				break;
+			else
+				continue;
+		}
+		/* we submit 1 set at a time, the base of set is always 0.
+		 * Also, we have produced a set, but submission should always
+		 * happen from cidx */
+		spin_lock(&engine->desc_lock);
+		if (!engine->sets_ready) {
+			spin_unlock(&engine->desc_lock);
+			spin_unlock(&engine->lock);
+			if (desc_setup_yield)
+				break;
+			else
+				continue;
+			break;
+		}
+		cidx_submit = engine->sw_cidx;
+		s = &engine->sets[cidx_submit];
+		desc_cnt_submit = s->desc_set_offset;
+		engine->sets_ready--;
+		engine->sw_cidx = incr_ptr_idx(cidx_submit, 1,
+						       XDMA_DESC_SETS_MAX);
+		cidx_link = cidx_submit;
+		submit_cnt = desc_cnt_submit;
+
+		/*
+		 * Chain multiple descriptor sets which are ready
+		 * to be submitted. Chain as much as possible
+		 * for now.
+		 * TODO: Make change to increase completion frequency
+		 * by using configurable parameter to set COMPLETION bit.
+		 */
+		while (engine->sets_ready) {
+			first = s;
+			second = &engine->sets[engine->sw_cidx];
+			xdma_link_sets(engine, first, second , cidx_link);
+			s = second;
+			cidx_link = engine->sw_cidx;
+			engine->sw_cidx = incr_ptr_idx(engine->sw_cidx, 1,
+						       XDMA_DESC_SETS_MAX);
+			submit_cnt += s->desc_set_offset;
+			engine->sets_ready--;
+
+		}
+
+		/* TODO: this keeps track of submitted descritors.
+		 * Used while processing completions to see if more
+		 * completions are expected or not.
+		 */
+		engine->desc_queued = submit_cnt;
+
+
+		spin_unlock(&engine->desc_lock);
+
+		rv = queue_request(engine, engine->desc_bus +
+				   (cidx_submit * desc_set_depth *
+						   sizeof(struct xdma_desc)),
+						   desc_cnt_submit);
+		desc_cnt_submit = 0;
+		spin_unlock(&engine->lock);
+		if (rv < 0) {
+			spin_lock(&engine->desc_lock);
+			engine->sets_ready++;
+			spin_unlock(&engine->desc_lock);
+		}
+		/* (rv < 0) we can still setup descriptors if resources
+		 * available */
+		if ((rv < 0) && desc_setup_yield)
+			break; /* lingered long enough */
+		else
+			schedule(); /* time for other threads to do something */
+	} while (1);
+
+	return 0;
+}
+static int xdma_process_requests(struct xdma_engine *engine,
+		struct xdma_request_cb *req)
+{
+	int rv;
+	long int timeout;
+
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
+
+	if (!req) {
+		pr_err("engine %s request NULL\n", engine->name);
+		return -EINVAL;
+	}
+
+	rv = xdma_request_desc_init(engine, 0);
+	if (rv < 0) {
+		pr_err("Failed to perform descriptor init\n");
+		return rv;
+	}
+	if ((!req->cb || !req->cb->io_done) && (rv == 0)) {
+		timeout = wait_event_interruptible_timeout(req->arbtr_wait,
+				req->sw_desc_cnt == req->desc_completed,
+				msecs_to_jiffies(10000)); /* 10sec timeout */
+		if (timeout == 0) {
+			pr_err("Request completion timeout\n");
+			engine_reg_dump(engine);
+			rv = -EIO;
+		}
+	}
+	if (req->cb && req->cb->io_done) {
+		req->expiry = jiffies + msecs_to_jiffies(10000);
+		schedule_work_on(engine->cpu_idx, &engine->aio_mon);
+	}
+
+	return rv;
+}
+
+static int engine_service_requests(struct xdma_engine *engine,
+				   int desc_writeback)
+{
 	u32 desc_count = desc_writeback & WB_COUNT_MASK;
 	u32 err_flag = desc_writeback & WB_ERR_MASK;
 	int rv = 0;
-	struct xdma_poll_wb *wb_data;
 
-	BUG_ON(!engine);
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
+	dbg_tfr("Interrupt raised for %s-%s", engine->streaming ? "ST":"MM",
+			(engine->dir == DMA_FROM_DEVICE) ? "C2H":"H2C");
 
 	/* If polling detected an error, signal to the caller */
 	if (err_flag)
-		rv = -EINVAL;
-
-	/* Service the engine */
-	if (!engine->running) {
-		dbg_tfr("Engine was not running!!! Clearing status\n");
-		engine_status_read(engine, 1, 0);
-		return 0;
-	}
+		rv = -1;
 
 	/*
 	 * If called by the ISR or polling detected an error, read and clear
 	 * engine status. For polled mode descriptor completion, this read is
 	 * unnecessary and is skipped to reduce latency
 	 */
-	if ((desc_count == 0) || (err_flag != 0))
-		engine_status_read(engine, 1, 0);
+	if ((desc_count == 0) || (err_flag != 0)) {
+		rv = engine_status_read(engine, 1, 0);
+		if (rv < 0) {
+			pr_err("Failed to read engine status\n");
+			return rv;
+		}
+	}
 
-	/*
-	 * engine was running but is no longer busy, or writeback occurred,
-	 * shut down
-	 */
-	if ((engine->running && !(engine->status & XDMA_STAT_BUSY)) ||
-		(desc_count != 0))
-		engine_service_shutdown(engine);
+	if (((engine->dir == DMA_FROM_DEVICE) &&
+				(engine->status & XDMA_STAT_C2H_ERR_MASK)) ||
+			((engine->dir == DMA_TO_DEVICE) &&
+			 (engine->status & XDMA_STAT_H2C_ERR_MASK))) {
+
+		pr_err("engine %s, status error 0x%x.\n", engine->name,
+				engine->status);
+		engine_status_dump(engine);
+		engine_reg_dump(engine);
+	}
+
+	if (engine->streaming && (engine->dir == DMA_FROM_DEVICE)) {
+		unsigned int result_cidx;
+		struct xdma_result *result_virt;
+		struct desc_sets *s;
+		unsigned long timeout;
+		unsigned int desc_max;
+
+		timeout = jiffies + (POLL_TIMEOUT_SECONDS * HZ);
+		spin_lock(&engine->desc_lock);
+		s = &engine->sets[engine->cidx];
+		desc_max = s->desc_set_offset;
+		spin_unlock(&engine->desc_lock);
+loop_again:
+		spin_lock(&engine->desc_lock);
+		result_cidx = engine->result_cidx;
+		result_virt = engine->cyclic_result + result_cidx;
+		while ((result_virt->status & 0xFFFF0000) == 0x52B40000) {
+			pr_info("received packet of length = %u/0x%x",
+				result_virt->length, result_virt->status);
+			desc_count += (result_virt->length + PAGE_SIZE -1) >>
+					PAGE_SHIFT;
+			result_cidx = incr_ptr_idx(result_cidx, 1,
+						      (XDMA_DESC_SETS_MAX *
+						      desc_set_depth));
+			result_virt = engine->cyclic_result + result_cidx;
+		}
+		engine->result_cidx = result_cidx;
+		spin_unlock(&engine->desc_lock);
+		if ((poll_mode) && (desc_max > desc_count)) {
+			if (time_after(jiffies, timeout)) {
+				pr_err("Polling timed out");
+				pr_err("expected wb = %u, actual = %u",
+					 desc_max, desc_count);
+			} else {
+				schedule();
+				goto loop_again;
+			}
+		}
+	}
+	
+	spin_lock(&engine->lock);
 
 	/*
 	 * If called from the ISR, or if an error occurred, the descriptor
@@ -1082,104 +1546,197 @@ static int engine_service(struct xdma_engine *engine, int desc_writeback)
 	 */
 	if (!desc_count)
 		desc_count = read_register(&engine->regs->completed_desc_count);
-	dbg_tfr("desc_count = %d\n", desc_count);
 
-	/* transfers on queue? */
-	if (!list_empty(&engine->transfer_list)) {
-		/* pick first transfer on queue (was submitted to the engine) */
-		transfer = list_entry(engine->transfer_list.next,
-				struct xdma_transfer, entry);
-
-		dbg_tfr("head of queue transfer 0x%p has %d descriptors\n",
-			transfer, (int)transfer->desc_num);
-
-		dbg_tfr("Engine completed %d desc, %d not yet dequeued\n",
-			(int)desc_count,
-			(int)desc_count - engine->desc_dequeued);
-
-		engine_service_perf(engine, desc_count);
+	if (!desc_count) {
+		pr_err("desc count is zero\n");
+		spin_unlock(&engine->lock);
+		goto shutdown_engine;
 	}
 
-	if (transfer) {
-		/*
-		 * account for already dequeued transfers during this engine
-		 * run
-		 */
-		desc_count -= engine->desc_dequeued;
+	desc_count = desc_count - engine->desc_dequeued;
+	engine->desc_dequeued += desc_count;
+	engine->desc_queued -= desc_count;
+	spin_unlock(&engine->lock);
 
-		/* Process all but the last transfer */
-		transfer = engine_service_transfer_list(engine, transfer,
-			&desc_count);
+	/* completions need to be processed before engine shutdown */
+	rv = process_completions(engine, desc_count);
 
-		/*
-		 * Process final transfer - includes checks of number of
-		 * descriptors to detect faulty completion
-		 */
-		transfer = engine_service_final_transfer(engine, transfer,
-			&desc_count);
+	/* Continue waiting for more completions if not all are dequeued */
+	if (rv < 0 || engine->desc_queued) {
+		if (poll_mode)
+			schedule_work_on(engine->cpu_idx, &engine->poll);
+		else {
+			enable_interrupts(engine);
+		}
+		return 0; /* more descriptors need to be freed*/
+	}
+shutdown_engine:
+	/*
+	 * engine was running but is no longer busy, or writeback occurred,
+	 * shut down
+	 */
+	if (!(engine->status & XDMA_STAT_BUSY) ||
+			(desc_count != 0)) {
+		spin_lock(&engine->lock);
+		rv = engine_service_shutdown(engine);
+		if (rv < 0) {
+			spin_unlock(&engine->lock);
+			pr_err("Failed to shutdown engine\n");
+			return rv;
+		}
+		spin_unlock(&engine->lock);
+	} else {
+		if (engine->status & XDMA_STAT_BUSY)
+			pr_warn("engine %s is unexpectedly busy - ignoring\n",
+					engine->name);
+		if (engine->status & XDMA_STAT_BUSY) {
+			u32 value = read_register(&engine->regs->status);
+			if ((value & XDMA_STAT_BUSY))
+				pr_err("%s has errors but is still BUSY\n",
+						engine->name);
+			return -EIO;
+		}
 	}
 
-	/* Before starting engine again, clear the writeback data */
-        if (poll_mode) {
-		wb_data = (struct xdma_poll_wb *)engine->poll_mode_addr_virt;
-		wb_data->completed_desc_count = 0;
+	spin_lock(&engine->desc_lock);
+	if ((engine->avail_sets < XDMA_DESC_SETS_AVAIL_MAX) ||
+			!list_empty(&engine->work_list)) {
+		spin_unlock(&engine->desc_lock);
+		/* something is pending */
+		rv = xdma_request_desc_init(engine, 1);
+		if (rv < 0)
+			pr_err("Failed to perform descriptor init\n");
+		return rv;
 	}
+	spin_unlock(&engine->desc_lock);
 
-	/* Restart the engine following the servicing */
-	engine_service_resume(engine);
-
-	return 0;
+	return rv;
 }
 
-/* engine_service_work */
+
+static void aio_request_monitor(struct work_struct *work)
+{
+	struct xdma_engine *engine;
+	struct list_head *tmp, *entry;
+	unsigned char reschedule = 0;
+	unsigned char timedout = 0;
+
+	engine = container_of(work, struct xdma_engine, req_proc);
+	if (engine->magic != MAGIC_ENGINE) {
+		pr_err("%s has invalid magic number %lx\n", engine->name,
+		       engine->magic);
+		return;
+	}
+
+	spin_lock(&engine->req_list_lock);
+	list_for_each_safe(entry, tmp, &engine->pend_list) {
+		struct xdma_request_cb *req = (struct xdma_request_cb *)entry;
+		struct xdma_io_cb *cb = req->cb;
+
+		if (cb && cb->io_done) {
+			if (time_after(jiffies, req->expiry)) {
+				list_del(&req->entry);
+				xdma_request_release(engine->xdev, req);
+				cb->io_done((unsigned long)engine->xdev,
+						 -EIO);
+				timedout = 1;
+			} else
+				reschedule = 1;
+		}
+	}
+	list_for_each_safe(entry, tmp, &engine->work_list) {
+		struct xdma_request_cb *req = (struct xdma_request_cb *)entry;
+		struct xdma_io_cb *cb = req->cb;
+
+		if (cb && cb->io_done) {
+			if (time_after(jiffies, req->expiry)) {
+				list_del(&req->entry);
+				xdma_request_release(engine->xdev, req);
+				cb->io_done((unsigned long)engine->xdev,
+						 -EIO);
+				timedout = 1;
+			} else
+				reschedule = 1;
+		}
+	}
+	spin_lock(&engine->req_list_lock);
+	if (timedout) {
+		pr_err("AIO reqs timedout");
+		engine_status_dump(engine);
+		engine_reg_dump(engine);
+	}
+	if (reschedule) {
+		msleep(100);
+		schedule_work_on(engine->cpu_idx, &engine->aio_mon);
+	}
+}
+
+static void engine_process_requests(struct work_struct *work)
+{
+	struct xdma_engine *engine;
+	int rv;
+
+	engine = container_of(work, struct xdma_engine, req_proc);
+	if (engine->magic != MAGIC_ENGINE) {
+		pr_err("%s has invalid magic number %lx\n", engine->name,
+		       engine->magic);
+		return;
+	}
+
+	rv = xdma_request_desc_init(engine, 0);
+	if (rv < 0)
+		pr_err("Failed to perform descriptor init\n");
+		return;
+}
+
+
+/**
+ * engine_service() - service an SG DMA engine
+ *
+ * must be called with engine->lock already acquired
+ *
+ * @engine pointer to struct xdma_engine
+ *
+ */
 static void engine_service_work(struct work_struct *work)
 {
 	struct xdma_engine *engine;
-	unsigned long flags;
+	int rv;
 
 	engine = container_of(work, struct xdma_engine, work);
-	BUG_ON(engine->magic != MAGIC_ENGINE);
+	if (engine->magic != MAGIC_ENGINE) {
+		pr_err("%s has invalid magic number %lx\n", engine->name,
+		       engine->magic);
+		return;
+	}
 
-	/* lock the engine */
-	spin_lock_irqsave(&engine->lock, flags);
-
-	dbg_tfr("engine_service() for %s engine %p\n",
-		engine->name, engine);
-	if (engine->cyclic_req)
-                engine_service_cyclic(engine);
-	else
-		engine_service(engine, 0);
-
-	/* re-enable interrupts for this engine */
-	if (engine->xdev->msix_enabled){
-		write_register(engine->interrupt_enable_mask_value,
-			       &engine->regs->interrupt_enable_mask_w1s,
-			(unsigned long)(&engine->regs->interrupt_enable_mask_w1s) -
-			(unsigned long)(&engine->regs));
-	} else
-		channel_interrupts_enable(engine->xdev, engine->irq_bitmask);
-
-	/* unlock the engine */
-	spin_unlock_irqrestore(&engine->lock, flags);
+	engine->wq_serviced++;
+	dbg_tfr("engine_service() for %s engine %p\n", engine->name, engine);
+		rv = engine_service_requests(engine, 0);
+		if (rv < 0)
+			pr_err("Failed to service engine\n");
 }
 
 static u32 engine_service_wb_monitor(struct xdma_engine *engine,
-	u32 expected_wb)
+				     u32 expected_wb)
 {
 	struct xdma_poll_wb *wb_data;
 	u32 desc_wb = 0;
 	u32 sched_limit = 0;
 	unsigned long timeout;
 
-	BUG_ON(!engine);
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
 	wb_data = (struct xdma_poll_wb *)engine->poll_mode_addr_virt;
 
 	/*
- 	 * Poll the writeback location for the expected number of
- 	 * descriptors / error events This loop is skipped for cyclic mode,
- 	 * where the expected_desc_count passed in is zero, since it cannot be
- 	 * determined before the function is called
- 	 */
+	 * Poll the writeback location for the expected number of
+	 * descriptors / error events This loop is skipped for cyclic mode,
+	 * where the expected_desc_count passed in is zero, since it cannot be
+	 * determined before the function is called
+	 */
 
 	timeout = jiffies + (POLL_TIMEOUT_SECONDS * HZ);
 	while (expected_wb != 0) {
@@ -1187,13 +1744,13 @@ static u32 engine_service_wb_monitor(struct xdma_engine *engine,
 
 		if (desc_wb & WB_ERR_MASK)
 			break;
-		else if (desc_wb == expected_wb)
+		else if (desc_wb >= expected_wb)
 			break;
 
 		/* RTO - prevent system from hanging in polled mode */
 		if (time_after(jiffies, timeout)) {
-			dbg_tfr("Polling timeout occurred");
-			dbg_tfr("desc_wb = 0x%08x, expected 0x%08x\n", desc_wb,
+			pr_err("Polling timeout occurred");
+			pr_err("desc_wb = 0x%08x, expected 0x%08x\n", desc_wb,
 				expected_wb);
 			if ((desc_wb & WB_COUNT_MASK) > expected_wb)
 				desc_wb = expected_wb | WB_ERR_MASK;
@@ -1202,9 +1759,9 @@ static u32 engine_service_wb_monitor(struct xdma_engine *engine,
 		}
 
 		/*
- 		 * Define NUM_POLLS_PER_SCHED to limit how much time is spent
- 		 * in the scheduler
- 		 */
+		 * Define NUM_POLLS_PER_SCHED to limit how much time is spent
+		 * in the scheduler
+		 */
 
 		if (sched_limit != 0) {
 			if ((sched_limit % NUM_POLLS_PER_SCHED) == 0)
@@ -1216,50 +1773,57 @@ static u32 engine_service_wb_monitor(struct xdma_engine *engine,
 	return desc_wb;
 }
 
-static int engine_service_poll(struct xdma_engine *engine,
-                u32 expected_desc_count)
+static void engine_service_req_poll(struct work_struct *poll)
 {
+	struct xdma_engine *engine;
 	struct xdma_poll_wb *writeback_data;
+	struct desc_sets *s;
+	unsigned int expected_desc_count;
 	u32 desc_wb = 0;
-	unsigned long flags;
-	int rv = 0;
+	unsigned int mon_cidx;
 
-	BUG_ON(!engine);
-	BUG_ON(engine->magic != MAGIC_ENGINE);
-
+	engine = container_of(poll, struct xdma_engine, poll);
+	if (engine->magic != MAGIC_ENGINE) {
+		pr_err("%s has invalid magic number %lx\n", engine->name,
+				engine->magic);
+		return;
+	}
+	if (engine->streaming && (engine->dir == DMA_FROM_DEVICE))
+		goto service_wb;
 	writeback_data = (struct xdma_poll_wb *)engine->poll_mode_addr_virt;
+	/* only one desc set on ply, so addressing the current cidx is good
+	 * enough*/
+	spin_lock(&engine->desc_lock);
+	mon_cidx = engine->cidx;
+	s = &engine->sets[mon_cidx];
+	expected_desc_count = s->desc_set_offset;
+	spin_unlock(&engine->desc_lock);
 
-	if ((expected_desc_count & WB_COUNT_MASK) != expected_desc_count) {
-		dbg_tfr("Queued descriptor count is larger than supported\n");
-		return -EINVAL;
+
+	if (!expected_desc_count)
+		return;
+
+	if ((expected_desc_count & WB_COUNT_MASK) !=
+			expected_desc_count) {
+		pr_err("Queued descriptor count is larger than supported\n");
+		return;
 	}
-
-	/*
- 	 * Poll the writeback location for the expected number of
- 	 * descriptors / error events This loop is skipped for cyclic mode,
- 	 * where the expected_desc_count passed in is zero, since it cannot be
- 	 * determined before the function is called
- 	 */
-
-	desc_wb = engine_service_wb_monitor(engine, expected_desc_count);
-
-	spin_lock_irqsave(&engine->lock, flags);
-	dbg_tfr("%s service.\n", engine->name);
-	if (engine->cyclic_req) {
-		rv = engine_service_cyclic(engine);
-	} else {
-		rv = engine_service(engine, desc_wb);
-	}
-	spin_unlock_irqrestore(&engine->lock, flags);
-
-	return rv;
+	desc_wb = engine_service_wb_monitor(engine,
+					    expected_desc_count);
+	writeback_data->completed_desc_count = 0;
+service_wb:
+	engine_service_requests(engine, desc_wb);
 }
+
 
 static irqreturn_t user_irq_service(int irq, struct xdma_user_irq *user_irq)
 {
 	unsigned long flags;
 
-	BUG_ON(!user_irq);
+	if (!user_irq) {
+		pr_err("Invalid user_irq\n");
+		return IRQ_NONE;
+	}
 
 	if (user_irq->handler)
 		return user_irq->handler(user_irq->user_idx, user_irq->dev);
@@ -1267,7 +1831,7 @@ static irqreturn_t user_irq_service(int irq, struct xdma_user_irq *user_irq)
 	spin_lock_irqsave(&(user_irq->events_lock), flags);
 	if (!user_irq->events_irq) {
 		user_irq->events_irq = 1;
-		wake_up(&(user_irq->events_wq));
+		wake_up_interruptible(&(user_irq->events_wq));
 	}
 	spin_unlock_irqrestore(&(user_irq->events_lock), flags);
 
@@ -1286,23 +1850,28 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 	u32 mask;
 	struct xdma_dev *xdev;
 	struct interrupt_regs *irq_regs;
+	unsigned long flags;
 
 	dbg_irq("(irq=%d, dev 0x%p) <<<< ISR.\n", irq, dev_id);
-	BUG_ON(!dev_id);
+	if (!dev_id) {
+		pr_err("Invalid dev_id on irq line %d\n", irq);
+		return -IRQ_NONE;
+	}
 	xdev = (struct xdma_dev *)dev_id;
 
 	if (!xdev) {
 		WARN_ON(!xdev);
-		dbg_irq("xdma_isr(irq=%d) xdev=%p ??\n", irq, xdev);
+		dbg_irq("%s(irq=%d) xdev=%p ??\n", __func__, irq, xdev);
 		return IRQ_NONE;
 	}
 
+	spin_lock_irqsave(&xdev->lock, flags);
 	irq_regs = (struct interrupt_regs *)(xdev->bar[xdev->config_bar_idx] +
-			XDMA_OFS_INT_CTRL);
+					     XDMA_OFS_INT_CTRL);
 
 	/* read channel interrupt requests */
 	ch_irq = read_register(&irq_regs->channel_int_request);
-	dbg_irq("ch_irq = 0x%08x\n", ch_irq);
+	dbg_irq("ch_irq = 0x%08x - mode %u\n", ch_irq, interrupt_mode);
 
 	/*
 	 * disable all interrupts that fired; these are re-enabled individually
@@ -1317,7 +1886,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 
 	if (user_irq) {
 		int user = 0;
-                u32 mask = 1;
+		u32 mask = 1;
 		int max = xdev->h2c_channel_max;
 
 		for (; user < max && user_irq; user++, mask <<= 1) {
@@ -1338,11 +1907,11 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 			struct xdma_engine *engine = &xdev->engine_h2c[channel];
 
 			/* engine present and its interrupt fired? */
-			if((engine->irq_bitmask & mask) &&
-			   (engine->magic == MAGIC_ENGINE)) {
+			if ((engine->irq_bitmask & mask) &&
+			    (engine->magic == MAGIC_ENGINE)) {
 				mask &= ~engine->irq_bitmask;
 				dbg_tfr("schedule_work, %s.\n", engine->name);
-				schedule_work(&engine->work);
+				schedule_work_on(engine->cpu_idx, &engine->work);
 			}
 		}
 	}
@@ -1357,16 +1926,17 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 			struct xdma_engine *engine = &xdev->engine_c2h[channel];
 
 			/* engine present and its interrupt fired? */
-			if((engine->irq_bitmask & mask) &&
-			   (engine->magic == MAGIC_ENGINE)) {
+			if ((engine->irq_bitmask & mask) &&
+			    (engine->magic == MAGIC_ENGINE)) {
 				mask &= ~engine->irq_bitmask;
 				dbg_tfr("schedule_work, %s.\n", engine->name);
-				schedule_work(&engine->work);
+				schedule_work_on(engine->cpu_idx, &engine->work);
 			}
 		}
 	}
 
 	xdev->irq_count++;
+	spin_unlock_irqrestore(&xdev->lock, flags);
 	return IRQ_HANDLED;
 }
 
@@ -1381,10 +1951,13 @@ static irqreturn_t xdma_user_irq(int irq, void *dev_id)
 
 	dbg_irq("(irq=%d) <<<< INTERRUPT SERVICE ROUTINE\n", irq);
 
-	BUG_ON(!dev_id);
+	if (!dev_id) {
+		pr_err("Invalid dev_id on irq line %d\n", irq);
+		return IRQ_NONE;
+	}
 	user_irq = (struct xdma_user_irq *)dev_id;
 
-	return  user_irq_service(irq, user_irq);
+	return user_irq_service(irq, user_irq);
 }
 
 /*
@@ -1399,30 +1972,33 @@ static irqreturn_t xdma_channel_irq(int irq, void *dev_id)
 	struct interrupt_regs *irq_regs;
 
 	dbg_irq("(irq=%d) <<<< INTERRUPT service ROUTINE\n", irq);
-	BUG_ON(!dev_id);
+	if (!dev_id) {
+		pr_err("Invalid dev_id on irq line %d\n", irq);
+		return IRQ_NONE;
+	}
 
 	engine = (struct xdma_engine *)dev_id;
 	xdev = engine->xdev;
 
 	if (!xdev) {
 		WARN_ON(!xdev);
-		dbg_irq("xdma_channel_irq(irq=%d) xdev=%p ??\n", irq, xdev);
+		dbg_irq("%s(irq=%d) xdev=%p ??\n", __func__, irq, xdev);
 		return IRQ_NONE;
 	}
 
 	irq_regs = (struct interrupt_regs *)(xdev->bar[xdev->config_bar_idx] +
-			XDMA_OFS_INT_CTRL);
-
+					     XDMA_OFS_INT_CTRL);
 	/* Disable the interrupt for this engine */
-	write_register(engine->interrupt_enable_mask_value,
-			&engine->regs->interrupt_enable_mask_w1c,
-			(unsigned long)
-			(&engine->regs->interrupt_enable_mask_w1c) -
-			(unsigned long)(&engine->regs));
-	/* Dummy read to flush the above write */
-	read_register(&irq_regs->channel_int_pending);
+	/* TODO: Need to see if this can be removed.
+	 */
+	write_register(
+		engine->interrupt_enable_mask_value,
+		&engine->regs->interrupt_enable_mask_w1c,
+		(unsigned long)(&engine->regs->interrupt_enable_mask_w1c) -
+		(unsigned long)(&engine->regs));
+
 	/* Schedule the bottom half */
-	schedule_work(&engine->work);
+	schedule_work_on(engine->cpu_idx, &engine->work);
 
 	/*
 	 * RTO - need to protect access here if multiple MSI-X are used for
@@ -1431,6 +2007,7 @@ static irqreturn_t xdma_channel_irq(int irq, void *dev_id)
 	xdev->irq_count++;
 	return IRQ_HANDLED;
 }
+
 
 /*
  * Unmap the BAR regions that had been mapped earlier using map_bars()
@@ -1451,7 +2028,7 @@ static void unmap_bars(struct xdma_dev *xdev, struct pci_dev *dev)
 }
 
 static resource_size_t map_single_bar(struct xdma_dev *xdev,
-	       	struct pci_dev *dev, int idx)
+					struct pci_dev *dev, int idx)
 {
 	resource_size_t bar_start;
 	resource_size_t bar_len;
@@ -1469,7 +2046,11 @@ static resource_size_t map_single_bar(struct xdma_dev *xdev,
 	 * P2P bar (size >= 256M)
 	 */
 	pr_info("map bar %d, len %lld\n", idx, bar_len);
+
+
+	/* do not map BARs with length 0. Note that start MAY be 0! */
 	if (!bar_len || bar_len >= (1 << 28)) {
+		pr_info("BAR #%d is not present - skipping\n", idx);
 		return 0;
 	}
 
@@ -1480,6 +2061,7 @@ static resource_size_t map_single_bar(struct xdma_dev *xdev,
 		return 0;
 
 	release_mem_region(bar_start, bar_len);
+
 	/* BAR size exceeds maximum desired mapping? */
 	if (bar_len > INT_MAX) {
 		pr_info("Limit BAR %d mapping from %llu to %d bytes\n", idx,
@@ -1491,12 +2073,11 @@ static resource_size_t map_single_bar(struct xdma_dev *xdev,
 	 * address space
 	 */
 	dbg_init("BAR%d: %llu bytes to be mapped.\n", idx, (u64)map_len);
-	xdev->bar[idx] = ioremap_nocache(pci_resource_start(dev, idx),
-			 map_len);
+	xdev->bar[idx] = pci_iomap(dev, idx, map_len);
 
 	if (!xdev->bar[idx]) {
 		pr_info("Could not map BAR %d.\n", idx);
-		return 0;
+		return -1;
 	}
 
 	pr_info("BAR%d at 0x%llx mapped at 0x%p, length=%llu(/%llu)\n", idx,
@@ -1504,6 +2085,7 @@ static resource_size_t map_single_bar(struct xdma_dev *xdev,
 
 	return (resource_size_t)map_len;
 }
+
 
 static int is_config_bar(struct xdma_dev *xdev, int idx)
 {
@@ -2089,316 +2671,9 @@ static void dump_desc(struct xdma_desc *desc_virt)
 	pr_info("\n");
 }
 
-static void transfer_dump(struct xdma_transfer *transfer)
-{
-	int i;
-	struct xdma_desc *desc_virt = transfer->desc_virt;
-
-	pr_info("xfer 0x%p, state 0x%x, f 0x%x, dir %d, len %u, last %d.\n",
-		transfer, transfer->state, transfer->flags, transfer->dir,
-		transfer->len, transfer->last_in_request);
-
-	pr_info("transfer 0x%p, desc %d, bus 0x%llx, adj %d.\n",
-		transfer, transfer->desc_num, (u64)transfer->desc_bus,
-		transfer->desc_adjacent);
-	for (i = 0; i < transfer->desc_num; i += 1)
-		dump_desc(desc_virt + i);
-}
 #endif /* __LIBXDMA_DEBUG__ */
 
-/* xdma_desc_alloc() - Allocate cache-coherent array of N descriptors.
- *
- * Allocates an array of 'number' descriptors in contiguous PCI bus addressable
- * memory. Chains the descriptors as a singly-linked list; the descriptor's
- * next * pointer specifies the bus address of the next descriptor.
- *
- *
- * @dev Pointer to pci_dev
- * @number Number of descriptors to be allocated
- * @desc_bus_p Pointer where to store the first descriptor bus address
- *
- * @return Virtual address of the first descriptor
- *
- */
-static void transfer_desc_init(struct xdma_transfer *transfer, int count)
-{
-	struct xdma_desc *desc_virt = transfer->desc_virt;
-	dma_addr_t desc_bus = transfer->desc_bus;
-	int i;
-	int adj = count - 1;
-	int extra_adj;
-	u32 temp_control;
 
-	BUG_ON(count > XDMA_TRANSFER_MAX_DESC);
-
-	/* create singly-linked list for SG DMA controller */
-	for (i = 0; i < count - 1; i++) {
-		/* increment bus address to next in array */
-		desc_bus += sizeof(struct xdma_desc);
-
-		/* singly-linked list uses bus addresses */
-		desc_virt[i].next_lo = cpu_to_le32(PCI_DMA_L(desc_bus));
-		desc_virt[i].next_hi = cpu_to_le32(PCI_DMA_H(desc_bus));
-		desc_virt[i].bytes = cpu_to_le32(0);
-
-		/* any adjacent descriptors? */
-		if (adj > 0) {
-			extra_adj = adj - 1;
-			if (extra_adj > MAX_EXTRA_ADJ)
-				extra_adj = MAX_EXTRA_ADJ;
-
-			adj--;
-		} else {
-			extra_adj = 0;
-		}
-
-		temp_control = DESC_MAGIC | (extra_adj << 8);
-
-		desc_virt[i].control = cpu_to_le32(temp_control);
-	}
-	/* { i = number - 1 } */
-	/* zero the last descriptor next pointer */
-	desc_virt[i].next_lo = cpu_to_le32(0);
-	desc_virt[i].next_hi = cpu_to_le32(0);
-	desc_virt[i].bytes = cpu_to_le32(0);
-
-	temp_control = DESC_MAGIC;
-
-	desc_virt[i].control = cpu_to_le32(temp_control);
-}
-
-/* xdma_desc_link() - Link two descriptors
- *
- * Link the first descriptor to a second descriptor, or terminate the first.
- *
- * @first first descriptor
- * @second second descriptor, or NULL if first descriptor must be set as last.
- * @second_bus bus address of second descriptor
- */
-static void xdma_desc_link(struct xdma_desc *first, struct xdma_desc *second,
-		dma_addr_t second_bus)
-{
-	/*
-	 * remember reserved control in first descriptor, but zero
-	 * extra_adjacent!
-	 */
-	 /* RTO - what's this about?  Shouldn't it be 0x0000c0ffUL? */
-	u32 control = le32_to_cpu(first->control) & 0x0000f0ffUL;
-	/* second descriptor given? */
-	if (second) {
-		/*
-		 * link last descriptor of 1st array to first descriptor of
-		 * 2nd array
-		 */
-		first->next_lo = cpu_to_le32(PCI_DMA_L(second_bus));
-		first->next_hi = cpu_to_le32(PCI_DMA_H(second_bus));
-		WARN_ON(first->next_hi);
-		/* no second descriptor given */
-	} else {
-		/* first descriptor is the last */
-		first->next_lo = 0;
-		first->next_hi = 0;
-	}
-	/* merge magic, extra_adjacent and control field */
-	control |= DESC_MAGIC;
-
-	/* write bytes and next_num */
-	first->control = cpu_to_le32(control);
-}
-
-/* xdma_desc_adjacent -- Set how many descriptors are adjacent to this one */
-static void xdma_desc_adjacent(struct xdma_desc *desc, int next_adjacent)
-{
-	int extra_adj = 0;
-	/* remember reserved and control bits */
-	u32 control = le32_to_cpu(desc->control) & 0x0000f0ffUL;
-	u32 max_adj_4k = 0;
-
-	if (next_adjacent > 0) {
-		extra_adj =  next_adjacent - 1;
-		if (extra_adj > MAX_EXTRA_ADJ){
-			extra_adj = MAX_EXTRA_ADJ;
-		}
-		max_adj_4k = (0x1000 - ((le32_to_cpu(desc->next_lo))&0xFFF))/32 - 1;
-		if (extra_adj>max_adj_4k) {
-			extra_adj = max_adj_4k;
-		}
-		if(extra_adj<0){
-			printk("Warning: extra_adj<0, converting it to 0\n");
-			extra_adj = 0;
-		}
-	}
-	/* merge adjacent and control field */
-	control |= 0xAD4B0000UL | (extra_adj << 8);
-	/* write control and next_adjacent */
-	desc->control = cpu_to_le32(control);
-}
-
-/* xdma_desc_control -- Set complete control field of a descriptor. */
-static void xdma_desc_control_set(struct xdma_desc *first, u32 control_field)
-{
-	/* remember magic and adjacent number */
-	u32 control = le32_to_cpu(first->control) & ~(LS_BYTE_MASK);
-
-	BUG_ON(control_field & ~(LS_BYTE_MASK));
-	/* merge adjacent and control field */
-	control |= control_field;
-	/* write control and next_adjacent */
-	first->control = cpu_to_le32(control);
-}
-
-/* xdma_desc_clear -- Clear bits in control field of a descriptor. */
-static void xdma_desc_control_clear(struct xdma_desc *first, u32 clear_mask)
-{
-	/* remember magic and adjacent number */
-	u32 control = le32_to_cpu(first->control);
-
-	BUG_ON(clear_mask & ~(LS_BYTE_MASK));
-
-	/* merge adjacent and control field */
-	control &= (~clear_mask);
-	/* write control and next_adjacent */
-	first->control = cpu_to_le32(control);
-}
-
-/* xdma_desc_done - recycle cache-coherent linked list of descriptors.
- *
- * @dev Pointer to pci_dev
- * @number Number of descriptors to be allocated
- * @desc_virt Pointer to (i.e. virtual address of) first descriptor in list
- * @desc_bus Bus address of first descriptor in list
- */
-static inline void xdma_desc_done(struct xdma_desc *desc_virt)
-{
-	memset(desc_virt, 0, XDMA_TRANSFER_MAX_DESC * sizeof(struct xdma_desc));
-}
-
-/* xdma_desc() - Fill a descriptor with the transfer details
- *
- * @desc pointer to descriptor to be filled
- * @addr root complex address
- * @ep_addr end point address
- * @len number of bytes, must be a (non-negative) multiple of 4.
- * @dir, dma direction
- * is the end point address. If zero, vice versa.
- *
- * Does not modify the next pointer
- */
-static void xdma_desc_set(struct xdma_desc *desc, dma_addr_t rc_bus_addr,
-		u64 ep_addr, int len, int dir)
-{
-	/* transfer length */
-	desc->bytes = cpu_to_le32(len);
-	if (dir == DMA_TO_DEVICE) {
-		/* read from root complex memory (source address) */
-		desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(rc_bus_addr));
-		desc->src_addr_hi = cpu_to_le32(PCI_DMA_H(rc_bus_addr));
-		/* write to end point address (destination address) */
-		desc->dst_addr_lo = cpu_to_le32(PCI_DMA_L(ep_addr));
-		desc->dst_addr_hi = cpu_to_le32(PCI_DMA_H(ep_addr));
-	} else {
-		/* read from end point address (source address) */
-		desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(ep_addr));
-		desc->src_addr_hi = cpu_to_le32(PCI_DMA_H(ep_addr));
-		/* write to root complex memory (destination address) */
-		desc->dst_addr_lo = cpu_to_le32(PCI_DMA_L(rc_bus_addr));
-		desc->dst_addr_hi = cpu_to_le32(PCI_DMA_H(rc_bus_addr));
-	}
-}
-
-/*
- * should hold the engine->lock;
- */
-static void transfer_abort(struct xdma_engine *engine,
-			struct xdma_transfer *transfer)
-{
-	struct xdma_transfer *head;
-
-	BUG_ON(!engine);
-	BUG_ON(!transfer);
-	BUG_ON(transfer->desc_num == 0);
-
-	pr_info("abort transfer 0x%p, desc %d, engine desc queued %d.\n",
-		transfer, transfer->desc_num, engine->desc_dequeued);
-
-	head = list_entry(engine->transfer_list.next, struct xdma_transfer,
-			entry);
-	if (head == transfer)
-		list_del(engine->transfer_list.next);
-        else
-		pr_info("engine %s, transfer 0x%p NOT found, 0x%p.\n",
-			engine->name, transfer, head);
-
-	if (transfer->state == TRANSFER_STATE_SUBMITTED)
-		transfer->state = TRANSFER_STATE_ABORTED;
-}
-
-/* transfer_queue() - Queue a DMA transfer on the engine
- *
- * @engine DMA engine doing the transfer
- * @transfer DMA transfer submitted to the engine
- *
- * Takes and releases the engine spinlock
- */
-static int transfer_queue(struct xdma_engine *engine,
-		struct xdma_transfer *transfer)
-{
-	int rv = 0;
-	struct xdma_transfer *transfer_started;
-	struct xdma_dev *xdev;
-	unsigned long flags;
-
-	BUG_ON(!engine);
-	BUG_ON(!engine->xdev);
-	BUG_ON(!transfer);
-	BUG_ON(transfer->desc_num == 0);
-	dbg_tfr("transfer_queue(transfer=0x%p).\n", transfer);
-
-	xdev = engine->xdev;
-	if (xdma_device_flag_check(xdev, XDEV_FLAG_OFFLINE)) {
-		pr_info("dev 0x%p offline, transfer 0x%p not queued.\n",
-			xdev, transfer);
-		return -EBUSY;
-	}
-
-	/* lock the engine state */
-	spin_lock_irqsave(&engine->lock, flags);
-
-	engine->prev_cpu = get_cpu();
-	put_cpu();
-
-	/* engine is being shutdown; do not accept new transfers */
-	if (engine->shutdown & ENGINE_SHUTDOWN_REQUEST) {
-		pr_info("engine %s offline, transfer 0x%p not queued.\n",
-			engine->name, transfer);
-		rv = -EBUSY;
-		goto shutdown;
-	}
-
-	/* mark the transfer as submitted */
-	transfer->state = TRANSFER_STATE_SUBMITTED;
-	/* add transfer to the tail of the engine transfer queue */
-	list_add_tail(&transfer->entry, &engine->transfer_list);
-
-	/* engine is idle? */
-	if (!engine->running) {
-		/* start engine */
-		dbg_tfr("transfer_queue(): starting %s engine.\n",
-			engine->name);
-		transfer_started = engine_start(engine);
-		dbg_tfr("transfer=0x%p started %s engine with transfer 0x%p.\n",
-			transfer, engine->name, transfer_started);
-	} else {
-		dbg_tfr("transfer=0x%p queued, with %s engine running.\n",
-			transfer, engine->name);
-	}
-
-shutdown:
-	/* unlock the engine state */
-	dbg_tfr("engine->running = %d\n", engine->running);
-	spin_unlock_irqrestore(&engine->lock, flags);
-	return rv;
-}
 
 static void engine_alignments(struct xdma_engine *engine)
 {
@@ -2408,8 +2683,8 @@ static void engine_alignments(struct xdma_engine *engine)
 	u32 address_bits;
 
 	w = read_register(&engine->regs->alignments);
-	dbg_init("engine %p name %s alignments=0x%08x\n", engine,
-		engine->name, (int)w);
+	dbg_init("engine %p name %s alignments=0x%08x\n", engine, engine->name,
+		 (int)w);
 
 	/* RTO  - add some macros to extract these fields */
 	align_bytes = (w & 0x00ff0000U) >> 16;
@@ -2439,50 +2714,78 @@ static void engine_free_resource(struct xdma_engine *engine)
 	/* Release memory use for descriptor writebacks */
 	if (engine->poll_mode_addr_virt) {
 		dbg_sg("Releasing memory for descriptor writeback\n");
-		dma_free_coherent(&xdev->pdev->dev,
-				sizeof(struct xdma_poll_wb),
-				engine->poll_mode_addr_virt,
-				engine->poll_mode_bus);
+		dma_free_coherent(&xdev->pdev->dev, sizeof(struct xdma_poll_wb),
+				  engine->poll_mode_addr_virt,
+				  engine->poll_mode_bus);
 		dbg_sg("Released memory for descriptor writeback\n");
 		engine->poll_mode_addr_virt = NULL;
 	}
 
 	if (engine->desc) {
 		dbg_init("device %s, engine %s pre-alloc desc 0x%p,0x%llx.\n",
-			dev_name(&xdev->pdev->dev), engine->name,
-			engine->desc, engine->desc_bus);
+			 dev_name(&xdev->pdev->dev), engine->name, engine->desc,
+			 engine->desc_bus);
 		dma_free_coherent(&xdev->pdev->dev,
-			XDMA_TRANSFER_MAX_DESC * sizeof(struct xdma_desc),
-			engine->desc, engine->desc_bus);
+					  XDMA_DESC_SETS_MAX *
+					  desc_set_depth *
+					  sizeof(struct xdma_desc),
+				  engine->desc, engine->desc_bus);
 		engine->desc = NULL;
 	}
 
 	if (engine->cyclic_result) {
-		dma_free_coherent(&xdev->pdev->dev,
-			CYCLIC_RX_PAGES_MAX * sizeof(struct xdma_result),
+		dma_free_coherent(
+			&xdev->pdev->dev,
+			XDMA_TRANSFER_MAX_DESC * sizeof(struct xdma_result),
 			engine->cyclic_result, engine->cyclic_result_bus);
 		engine->cyclic_result = NULL;
 	}
 }
 
-static void engine_destroy(struct xdma_dev *xdev, struct xdma_engine *engine)
+static int engine_destroy(struct xdma_dev *xdev, struct xdma_engine *engine)
 {
-	BUG_ON(!xdev);
-	BUG_ON(!engine);
+	struct list_head *entry, *tmp;
+
+	if (!xdev) {
+		pr_err("Invalid xdev\n");
+		return -EINVAL;
+	}
+
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
 
 	dbg_sg("Shutting down engine %s%d", engine->name, engine->channel);
 
 	/* Disable interrupts to stop processing new events during shutdown */
 	write_register(0x0, &engine->regs->interrupt_enable_mask,
-			(unsigned long)(&engine->regs->interrupt_enable_mask) -
-			(unsigned long)(&engine->regs));
+		       (unsigned long)(&engine->regs->interrupt_enable_mask) -
+			       (unsigned long)(&engine->regs));
 
+	spin_lock(&engine->desc_lock);
+	list_for_each_safe(entry, tmp, &engine->pend_list) {
+		struct xdma_request_cb *req = (struct xdma_request_cb *)entry;
+
+		list_del(&req->entry);
+		if (req->cb && req->cb->io_done)
+			req->cb->io_done((unsigned long)engine->xdev, -EIO);
+	}
+	list_for_each_safe(entry, tmp, &engine->work_list) {
+		struct xdma_request_cb *req = (struct xdma_request_cb *)entry;
+
+		list_del(&req->entry);
+		if (req->cb && req->cb->io_done)
+			req->cb->io_done((unsigned long)engine->xdev, -EIO);
+	}
+	spin_unlock(&engine->desc_lock);
 	if (enable_credit_mp && engine->streaming &&
-		engine->dir == DMA_FROM_DEVICE) {
+	    engine->dir == DMA_FROM_DEVICE) {
 		u32 reg_value = (0x1 << engine->channel) << 16;
-		struct sgdma_common_regs *reg = (struct sgdma_common_regs *)
-				(xdev->bar[xdev->config_bar_idx] +
-				 (0x6*TARGET_SPACING));
+		struct sgdma_common_regs *reg =
+			(struct sgdma_common_regs
+				 *)(xdev->bar[xdev->config_bar_idx] +
+				    (0x6 * TARGET_SPACING));
 		write_register(reg_value, &reg->credit_mode_enable_w1c, 0);
 	}
 
@@ -2492,6 +2795,7 @@ static void engine_destroy(struct xdma_dev *xdev, struct xdma_engine *engine)
 	memset(engine, 0, sizeof(struct xdma_engine));
 	/* Decrement the number of engines available */
 	xdev->engines_num--;
+	return 0;
 }
 
 /**
@@ -2499,43 +2803,26 @@ static void engine_destroy(struct xdma_dev *xdev, struct xdma_engine *engine)
  *
  *engine->lock must be taken
  */
-struct xdma_transfer *engine_cyclic_stop(struct xdma_engine *engine)
+int engine_cyclic_stop(struct xdma_engine *engine)
 {
-	struct xdma_transfer *transfer = 0;
+	int rv;
 
-	/* transfers on queue? */
-	if (!list_empty(&engine->transfer_list)) {
-		/* pick first transfer on the queue (was submitted to engine) */
-		transfer = list_entry(engine->transfer_list.next,
-					struct xdma_transfer, entry);
-		BUG_ON(!transfer);
-
-		xdma_engine_stop(engine);
-
-		if (transfer->cyclic) {
-			if (engine->xdma_perf)
-				dbg_perf("Stopping perf transfer on %s\n",
-					engine->name);
-			else
-				dbg_perf("Stopping cyclic transfer on %s\n",
-					engine->name);
-			/* make sure the handler sees correct transfer state */
-			transfer->cyclic = 1;
-			/*
-			* set STOP flag and interrupt on completion, on the
-			* last descriptor
-			*/
-			xdma_desc_control_set(
-				transfer->desc_virt + transfer->desc_num - 1,
-				XDMA_DESC_COMPLETED | XDMA_DESC_STOPPED);
-		} else {
-			dbg_sg("(engine=%p) running transfer is not cyclic\n",
-				engine);
-		}
-	} else {
-		dbg_sg("(engine=%p) found not running transfer.\n", engine);
+	if (engine->xdma_perf)
+		dbg_perf("Stopping perf transfer on %s\n",
+				engine->name);
+	else {
+		pr_warn("Performance is not running on engine %s\n",
+				engine->name);
+		return -EINVAL;
 	}
-	return transfer;
+
+	rv = xdma_engine_stop(engine);
+	if (rv < 0)
+		pr_err("Failed to stop engine\n");
+	engine->running = 0;
+	rv = engine_status_read(engine, 1, 0);
+
+	return rv;
 }
 EXPORT_SYMBOL_GPL(engine_cyclic_stop);
 
@@ -2545,9 +2832,16 @@ static int engine_writeback_setup(struct xdma_engine *engine)
 	struct xdma_dev *xdev;
 	struct xdma_poll_wb *writeback;
 
-	BUG_ON(!engine);
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return -EINVAL;
+	}
+
 	xdev = engine->xdev;
-	BUG_ON(!xdev);
+	if (!xdev) {
+		pr_err("Invalid xdev\n");
+		return -EINVAL;
+	}
 
 	/*
 	 * RTO - doing the allocation per engine is wasteful since a full page
@@ -2558,19 +2852,18 @@ static int engine_writeback_setup(struct xdma_engine *engine)
 	writeback->completed_desc_count = 0;
 
 	dbg_init("Setting writeback location to 0x%llx for engine %p",
-		engine->poll_mode_bus, engine);
+		 engine->poll_mode_bus, engine);
 	w = cpu_to_le32(PCI_DMA_L(engine->poll_mode_bus));
 	write_register(w, &engine->regs->poll_mode_wb_lo,
-			(unsigned long)(&engine->regs->poll_mode_wb_lo) -
-			(unsigned long)(&engine->regs));
+		       (unsigned long)(&engine->regs->poll_mode_wb_lo) -
+			       (unsigned long)(&engine->regs));
 	w = cpu_to_le32(PCI_DMA_H(engine->poll_mode_bus));
 	write_register(w, &engine->regs->poll_mode_wb_hi,
-			(unsigned long)(&engine->regs->poll_mode_wb_hi) -
-			(unsigned long)(&engine->regs));
+		       (unsigned long)(&engine->regs->poll_mode_wb_hi) -
+			       (unsigned long)(&engine->regs));
 
 	return 0;
 }
-
 
 /* engine_create() - Create an SG DMA engine bookkeeping data structure
  *
@@ -2589,51 +2882,49 @@ static int engine_init_regs(struct xdma_engine *engine)
 	int rv = 0;
 
 	write_register(XDMA_CTRL_NON_INCR_ADDR, &engine->regs->control_w1c,
-			(unsigned long)(&engine->regs->control_w1c) -
-			(unsigned long)(&engine->regs));
+		       (unsigned long)(&engine->regs->control_w1c) -
+			       (unsigned long)(&engine->regs));
 
 	engine_alignments(engine);
 
 	/* Configure error interrupts by default */
 	reg_value = XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
-	reg_value |= XDMA_CTRL_IE_MAGIC_STOPPED;
+	reg_value |= XDMA_CTRL_RUN_STOP;
 	reg_value |= XDMA_CTRL_IE_MAGIC_STOPPED;
 	reg_value |= XDMA_CTRL_IE_READ_ERROR;
 	reg_value |= XDMA_CTRL_IE_DESC_ERROR;
 
 	/* if using polled mode, configure writeback address */
 	if (poll_mode) {
+
 		rv = engine_writeback_setup(engine);
 		if (rv) {
 			dbg_init("%s descr writeback setup failed.\n",
-				engine->name);
+				 engine->name);
 			goto fail_wb;
 		}
 	} else {
 		/* enable the relevant completion interrupts */
 		reg_value |= XDMA_CTRL_IE_DESC_STOPPED;
 		reg_value |= XDMA_CTRL_IE_DESC_COMPLETED;
-
-		if (engine->streaming && engine->dir == DMA_FROM_DEVICE)
-			reg_value |= XDMA_CTRL_IE_IDLE_STOPPED;
 	}
 
 	/* Apply engine configurations */
 	write_register(reg_value, &engine->regs->interrupt_enable_mask,
-			(unsigned long)(&engine->regs->interrupt_enable_mask) -
-			(unsigned long)(&engine->regs));
+		       (unsigned long)(&engine->regs->interrupt_enable_mask) -
+			       (unsigned long)(&engine->regs));
 
 	engine->interrupt_enable_mask_value = reg_value;
 
 	/* only enable credit mode for AXI-ST C2H */
 	if (enable_credit_mp && engine->streaming &&
-		engine->dir == DMA_FROM_DEVICE) {
-
+	    engine->dir == DMA_FROM_DEVICE) {
 		struct xdma_dev *xdev = engine->xdev;
 		u32 reg_value = (0x1 << engine->channel) << 16;
-		struct sgdma_common_regs *reg = (struct sgdma_common_regs *)
-				(xdev->bar[xdev->config_bar_idx] +
-				 (0x6*TARGET_SPACING));
+		struct sgdma_common_regs *reg =
+			(struct sgdma_common_regs
+				 *)(xdev->bar[xdev->config_bar_idx] +
+				    (0x6 * TARGET_SPACING));
 
 		write_register(reg_value, &reg->credit_mode_enable_w1s, 0);
 	}
@@ -2647,38 +2938,61 @@ fail_wb:
 static int engine_alloc_resource(struct xdma_engine *engine)
 {
 	struct xdma_dev *xdev = engine->xdev;
+	int i;
+	unsigned int temp_control = DESC_MAGIC;
+	struct xdma_desc *desc_virt;
+	dma_addr_t desc_bus;
 
 	engine->desc = dma_alloc_coherent(&xdev->pdev->dev,
-			XDMA_TRANSFER_MAX_DESC * sizeof(struct xdma_desc),
-			&engine->desc_bus, GFP_KERNEL);
+					  XDMA_DESC_SETS_MAX *
+					  desc_set_depth *
+					  sizeof(struct xdma_desc),
+					  &engine->desc_bus, GFP_KERNEL);
 	if (!engine->desc) {
 		pr_warn("dev %s, %s pre-alloc desc OOM.\n",
 			dev_name(&xdev->pdev->dev), engine->name);
 		goto err_out;
 	}
+	desc_virt = engine->desc;
+	desc_bus = engine->desc_bus;
+	for (i = 0; i < (XDMA_DESC_SETS_MAX * desc_set_depth); i++) {
+		/* increment bus address to next in array */
+		desc_bus += sizeof(struct xdma_desc);
+
+		desc_virt[i].next_lo = cpu_to_le32(PCI_DMA_L(desc_bus));
+		desc_virt[i].next_hi = cpu_to_le32(PCI_DMA_H(desc_bus));
+		desc_virt[i].control = cpu_to_le32(temp_control);
+	}
+	desc_virt[i - 1].next_lo = cpu_to_le32(0);
+	desc_virt[i - 1].next_hi = cpu_to_le32(0);
 
 	if (poll_mode) {
-		engine->poll_mode_addr_virt = dma_alloc_coherent(
-					&xdev->pdev->dev,
-					sizeof(struct xdma_poll_wb),
-					&engine->poll_mode_bus, GFP_KERNEL);
+
+		engine->poll_mode_addr_virt =
+			dma_alloc_coherent(&xdev->pdev->dev,
+					   sizeof(struct xdma_poll_wb),
+					   &engine->poll_mode_bus, GFP_KERNEL);
 		if (!engine->poll_mode_addr_virt) {
-                        pr_warn("%s, %s poll pre-alloc writeback OOM.\n",
+			pr_warn("%s, %s poll pre-alloc writeback OOM.\n",
 				dev_name(&xdev->pdev->dev), engine->name);
 			goto err_out;
 		}
 	}
 
 	if (engine->streaming && engine->dir == DMA_FROM_DEVICE) {
-		engine->cyclic_result = dma_alloc_coherent(&xdev->pdev->dev,
-			CYCLIC_RX_PAGES_MAX * sizeof(struct xdma_result),
+		engine->cyclic_result = dma_alloc_coherent(
+			&xdev->pdev->dev,
+			((XDMA_DESC_SETS_MAX * desc_set_depth) *
+			sizeof(struct xdma_result)),
 			&engine->cyclic_result_bus, GFP_KERNEL);
 
 		if (!engine->cyclic_result) {
-                        pr_warn("%s, %s pre-alloc result OOM.\n",
+			pr_warn("%s, %s pre-alloc result OOM.\n",
 				dev_name(&xdev->pdev->dev), engine->name);
 			goto err_out;
 		}
+		engine->result_pidx = 0;
+		engine->result_cidx = 0;
 	}
 
 	return 0;
@@ -2689,7 +3003,7 @@ err_out:
 }
 
 static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
-			int offset, enum dma_data_direction dir, int channel)
+		       int offset, enum dma_data_direction dir, int channel)
 {
 	int rv;
 	u32 val;
@@ -2701,6 +3015,9 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 
 	engine->channel = channel;
 
+	/* set cpu for engine */
+	engine->cpu_idx = channel;
+
 	/* engine interrupt request bit */
 	engine->irq_bitmask = (1 << XDMA_ENG_IRQ_NUM) - 1;
 	engine->irq_bitmask <<= (xdev->engines_num * XDMA_ENG_IRQ_NUM);
@@ -2711,9 +3028,9 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 	/* register address */
 	engine->regs = (xdev->bar[xdev->config_bar_idx] + offset);
 	engine->sgdma_regs = xdev->bar[xdev->config_bar_idx] + offset +
-				SGDMA_OFFSET_FROM_CHANNEL;
+			     	SGDMA_OFFSET_FROM_CHANNEL;
 	val = read_register(&engine->regs->identifier);
-        if (val & 0x8000U)
+	if (val & 0x8000U)
 		engine->streaming = 1;
 
 	/* remember SG DMA direction */
@@ -2723,16 +3040,23 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 		engine->streaming ? "ST" : "MM");
 
 	dbg_init("engine %p name %s irq_bitmask=0x%08x\n", engine, engine->name,
-		(int)engine->irq_bitmask);
+		 (int)engine->irq_bitmask);
 
-	/* initialize the deferred work for transfer completion */
-	INIT_WORK(&engine->work, engine_service_work);
+	/* initialize the deferred work for request/transfer completion */
+	if (poll_mode)
+		INIT_WORK(&engine->poll, engine_service_req_poll);
+	else
+		INIT_WORK(&engine->work, engine_service_work);
+	INIT_WORK(&engine->aio_mon, aio_request_monitor);
+	INIT_WORK(&engine->req_proc, engine_process_requests);
 
 	if (dir == DMA_TO_DEVICE)
 		xdev->mask_irq_h2c |= engine->irq_bitmask;
 	else
 		xdev->mask_irq_c2h |= engine->irq_bitmask;
 	xdev->engines_num++;
+
+	engine->wq_serviced = 0;
 
 	rv = engine_alloc_resource(engine);
 	if (rv)
@@ -2745,94 +3069,7 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 	return 0;
 }
 
-/* transfer_destroy() - free transfer */
-static void transfer_destroy(struct xdma_dev *xdev, struct xdma_transfer *xfer)
-{
-	/* free descriptors */
-	xdma_desc_done(xfer->desc_virt);
 
-	if (xfer->last_in_request && (xfer->flags & XFER_FLAG_NEED_UNMAP)) {
-        	struct sg_table *sgt = xfer->sgt;
-
-		if (sgt->nents) {
-			pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents,
-				xfer->dir);
-			sgt->nents = 0;
-		}
-	}
-}
-
-static int transfer_build(struct xdma_engine *engine,
-			struct xdma_request_cb *req, unsigned int desc_max)
-{
-	struct xdma_transfer *xfer = &req->xfer;
-	struct sw_desc *sdesc = &(req->sdesc[req->sw_desc_idx]);
-	int i = 0;
-	int j = 0;
-
-	for (; i < desc_max; i++, j++, sdesc++) {
-		dbg_desc("sw desc %d/%u: 0x%llx, 0x%x, ep 0x%llx.\n",
-			i + req->sw_desc_idx, req->sw_desc_cnt,
-			sdesc->addr, sdesc->len, req->ep_addr);
-
-		/* fill in descriptor entry j with transfer details */
-		xdma_desc_set(xfer->desc_virt + j, sdesc->addr, req->ep_addr,
-				 sdesc->len, xfer->dir);
-		xfer->len += sdesc->len;
-
-		/* for non-inc-add mode don't increment ep_addr */
-		if (!engine->non_incr_addr)
-			req->ep_addr += sdesc->len;
-	}
-	req->sw_desc_idx += desc_max;
-	return 0;
-}
-
-static int transfer_init(struct xdma_engine *engine, struct xdma_request_cb *req)
-{
-	struct xdma_transfer *xfer = &req->xfer;
-	unsigned int desc_max = min_t(unsigned int,
-				req->sw_desc_cnt - req->sw_desc_idx,
-				XDMA_TRANSFER_MAX_DESC);
-	int i = 0;
-	int last = 0;
-	u32 control;
-
-	memset(xfer, 0, sizeof(*xfer));
-
-	/* initialize wait queue */
-	init_waitqueue_head(&xfer->wq);
-
-	/* remember direction of transfer */
-	xfer->dir = engine->dir;
-
-	xfer->desc_virt = engine->desc;
-	xfer->desc_bus = engine->desc_bus;
-
-	transfer_desc_init(xfer, desc_max);
-
-	dbg_sg("transfer->desc_bus = 0x%llx.\n", (u64)xfer->desc_bus);
-
-	transfer_build(engine, req, desc_max);
-
-	/* terminate last descriptor */
-	last = desc_max - 1;
-	xdma_desc_link(xfer->desc_virt + last, 0, 0);
-	/* stop engine, EOP for AXI ST, req IRQ on last descriptor */
-	control = XDMA_DESC_STOPPED;
-	control |= XDMA_DESC_EOP;
-	control |= XDMA_DESC_COMPLETED;
-	xdma_desc_control_set(xfer->desc_virt + last, control);
-
-	xfer->desc_num = xfer->desc_adjacent = desc_max;
-
-	dbg_sg("transfer 0x%p has %d descriptors\n", xfer, xfer->desc_num);
-	/* fill in adjacent numbers */
-	for (i = 0; i < xfer->desc_num; i++)
-		xdma_desc_adjacent(xfer->desc_virt + i, xfer->desc_num - i - 1);
-
-	return 0;
-}
 
 #ifdef __LIBXDMA_DEBUG__
 static void sgt_dump(struct sg_table *sgt)
@@ -2863,90 +3100,10 @@ static void xdma_request_cb_dump(struct xdma_request_cb *req)
 }
 #endif
 
-static void xdma_request_free(struct xdma_request_cb *req)
-{
-	if (((unsigned long)req) >= VMALLOC_START &&
-	    ((unsigned long)req) < VMALLOC_END)
-		vfree(req);
-	else
-		kfree(req);
-}
-
-static struct xdma_request_cb * xdma_request_alloc(unsigned int sdesc_nr)
-{
-	struct xdma_request_cb *req;
-	unsigned int size = sizeof(struct xdma_request_cb) +
-				sdesc_nr * sizeof(struct sw_desc);
-
-	req = kzalloc(size, GFP_KERNEL);
-	if (!req) {
-		req = vmalloc(size);
-		if (req)
-			memset(req, 0, size);
-	}
-	if (!req) {
-		pr_info("OOM, %u sw_desc, %u.\n", sdesc_nr, size);
-		return NULL;
-	}
-
-	return req;
-}
-
-static struct xdma_request_cb * xdma_init_request(struct sg_table *sgt,
-						u64 ep_addr)
-{
-	struct xdma_request_cb *req;
-	struct scatterlist *sg = sgt->sgl;
-	int max = sgt->nents;
-	int extra = 0;
-	int i, j = 0;
-
-	for (i = 0;  i < max; i++, sg = sg_next(sg)) {
-		unsigned int len = sg_dma_len(sg);
-
-		if (unlikely(len > XDMA_DESC_BLEN_MAX))
-			extra += len >> XDMA_DESC_BLEN_BITS;
-	}
-
-	//pr_info("ep 0x%llx, desc %u+%u.\n", ep_addr, max, extra);
-
-	max += extra;
-	req = xdma_request_alloc(max);
-	if (!req)
-		return NULL;
-
-	req->sgt = sgt;
-	req->ep_addr = ep_addr;
-
-	for (i = 0, sg = sgt->sgl;  i < sgt->nents; i++, sg = sg_next(sg)) {
-		unsigned int tlen = sg_dma_len(sg);
-		dma_addr_t addr = sg_dma_address(sg);
-
-		req->total_len += tlen;
-		while (tlen) {
-			req->sdesc[j].addr = addr;
-			if (tlen > XDMA_DESC_BLEN_MAX) {
-				req->sdesc[j].len = XDMA_DESC_BLEN_MAX;
-				addr += XDMA_DESC_BLEN_MAX;
-				tlen -= XDMA_DESC_BLEN_MAX;
-			} else {
-				req->sdesc[j].len = tlen;
-				tlen = 0;
-			}
-			j++;
-		}
-	}
-	BUG_ON(j > max);
-
-	req->sw_desc_cnt = j;
-#ifdef __LIBXDMA_DEBUG__
-	xdma_request_cb_dump(req);
-#endif
-	return req;
-}
 
 ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
-			struct sg_table *sgt, bool dma_mapped, int timeout_ms)
+			 struct sg_table *sgt, bool dma_mapped, int timeout_ms,
+			 struct xdma_io_cb *cb)
 {
 	struct xdma_dev *xdev = (struct xdma_dev *)dev_hndl;
 	struct xdma_engine *engine;
@@ -2963,38 +3120,44 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	if (debug_check_dev_hndl(__func__, xdev->pdev, dev_hndl) < 0)
 		return -EINVAL;
 
+
 	if (write == 1) {
 		if (channel >= xdev->h2c_channel_max) {
-			pr_warn("H2C channel %d >= %d.\n",
-				channel, xdev->h2c_channel_max);
+			pr_err("H2C channel %d >= %d.\n", channel,
+				xdev->h2c_channel_max);
 			return -EINVAL;
 		}
 		engine = &xdev->engine_h2c[channel];
 	} else if (write == 0) {
 		if (channel >= xdev->c2h_channel_max) {
-			pr_warn("C2H channel %d >= %d.\n",
-				channel, xdev->c2h_channel_max);
+			pr_err("C2H channel %d >= %d.\n", channel,
+				xdev->c2h_channel_max);
 			return -EINVAL;
 		}
 		engine = &xdev->engine_c2h[channel];
-	} else {
-		pr_warn("write %d, exp. 0|1.\n", write);
+	}
+
+	if (!engine) {
+		pr_err("dma engine NULL\n");
 		return -EINVAL;
 	}
 
-        BUG_ON(!engine);
-        BUG_ON(engine->magic != MAGIC_ENGINE);
+	if (engine->magic != MAGIC_ENGINE) {
+		pr_err("%s has invalid magic number %lx\n", engine->name,
+		       engine->magic);
+		return -EINVAL;
+	}
 
 	xdev = engine->xdev;
 	if (xdma_device_flag_check(xdev, XDEV_FLAG_OFFLINE)) {
-		pr_info("xdev 0x%p, offline.\n", xdev);
+		pr_err("xdev 0x%p, offline.\n", xdev);
 		return -EBUSY;
 	}
 
 	/* check the direction */
 	if (engine->dir != dir) {
-		pr_info("0x%p, %s, %d, W %d, 0x%x/0x%x mismatch.\n",
-			engine, engine->name, channel, write, engine->dir, dir);
+		pr_err("0x%p, %s, %d, W %d, 0x%x/0x%x mismatch.\n", engine,
+			engine->name, channel, write, engine->dir, dir);
 		return -EINVAL;
 	}
 
@@ -3002,167 +3165,62 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
-			return -EIO;
+			goto unmap_sgl;
 		}
 		sgt->nents = nents;
 	} else {
-		BUG_ON(!sgt->nents);
+		if (!sgt->nents) {
+			pr_err("sg table has invalid number of entries 0x%p.\n",
+			       sgt);
+			goto unmap_sgl;
+		}
 	}
 
-	req = xdma_init_request(sgt, ep_addr);
-	if (!req) {
-		rv = -ENOMEM;
+
+	req = xdma_request_alloc(sgt->nents);
+	if (!req)
+		return -ENOMEM;
+	req->dma_mapped = dma_mapped;
+	req->cb = cb; 
+	req->dir = dir;
+	req->sgt = sgt;
+	req->ep_addr = ep_addr;
+
+
+	rv = xdma_init_request(req);
+	if (rv < 0)
+		goto unmap_sgl;
+	xdma_add_request(engine, req);
+
+	dbg_tfr("%s, len %u sg cnt %u.\n", engine->name, req->total_len,
+		req->sw_desc_cnt);
+
+	/* If this is async request return immediately. */
+	if (req->cb && req->cb->io_done)
+	{
+		/* Kickoff processing of asynchronous IOs */
+		schedule_work_on(engine->cpu_idx, &engine->req_proc);
+		return 0;
+
+	}
+	rv = xdma_process_requests(engine, req);
+
+	/* Read length of completed transfer */
+	done = req->done;
+	if (rv < 0) {
+		spin_lock(&engine->req_list_lock);
+
+
+		if (req->sw_desc_cnt > req->desc_completed)
+			list_del(&req->entry);
+		spin_unlock(&engine->req_list_lock);
+		pr_err("Request Processing failed, :%u/%u/%u\n",
+		       req->sw_desc_cnt, req->sw_desc_idx, req->desc_completed);
 		goto unmap_sgl;
 	}
 
-	dbg_tfr("%s, len %u sg cnt %u.\n",
-		engine->name, req->total_len, req->sw_desc_cnt);
-
-	sg = sgt->sgl;
-	nents = req->sw_desc_cnt;
-	while (nents) {
-		unsigned long flags;
-		struct xdma_transfer *xfer;
-
-		/* one transfer at a time */
-#ifndef CONFIG_PREEMPT_COUNT
-		spin_lock(&engine->desc_lock);
-#else
-		mutex_lock(&engine->desc_mutex);
-#endif
-
-		/* build transfer */
-		rv = transfer_init(engine, req);
-		if (rv < 0) {
-#ifndef CONFIG_PREEMPT_COUNT
-			spin_unlock(&engine->desc_lock);
-#else
-			mutex_unlock(&engine->desc_mutex);
-#endif
-			goto unmap_sgl;
-		}
-		xfer = &req->xfer;
-
-		if (!dma_mapped)
-			xfer->flags = XFER_FLAG_NEED_UNMAP;
-
-		/* last transfer for the given request? */
-		nents -= xfer->desc_num;
-		if (!nents) {
-			xfer->last_in_request = 1;
-			xfer->sgt = sgt;
-		}
-
-		dbg_tfr("xfer, %llu, ep 0x%llx, done %lu, sg %u/%u.\n",
-			xfer->len, req->ep_addr, done, req->sw_desc_idx,
-			req->sw_desc_cnt);
-
-#ifdef __LIBXDMA_DEBUG__
-		transfer_dump(xfer);
-#endif
-
-		rv = transfer_queue(engine, xfer);
-		if (rv < 0) {
-#ifndef CONFIG_PREEMPT_COUNT
-			spin_unlock(&engine->desc_lock);
-#else
-			mutex_unlock(&engine->desc_mutex);
-#endif
-			pr_info("unable to submit %s, %d.\n", engine->name, rv);
-			goto unmap_sgl;
-		}
-
-		/*
-		 * When polling, determine how many descriptors have been queued		 * on the engine to determine the writeback value expected
-		 */
-		if (poll_mode) {
-			unsigned int desc_count;
-
-			spin_lock_irqsave(&engine->lock, flags);
-                        desc_count = xfer->desc_num;
-			spin_unlock_irqrestore(&engine->lock, flags);
-
-                        dbg_tfr("%s poll desc_count=%d\n",
-				engine->name, desc_count);
-			rv = engine_service_poll(engine, desc_count);
-
-		} else {
-			rv = wait_event_timeout(xfer->wq,
-                	        (xfer->state != TRANSFER_STATE_SUBMITTED),
-				msecs_to_jiffies(timeout_ms));
-		}
-
-		spin_lock_irqsave(&engine->lock, flags);
-
-		switch(xfer->state) {
-		case TRANSFER_STATE_COMPLETED:
-			spin_unlock_irqrestore(&engine->lock, flags);
-
-			dbg_tfr("transfer %p, %llu, ep 0x%llx compl, +%lu.\n",
-				xfer, xfer->len, req->ep_addr - xfer->len, done);
-			done += xfer->len;
-			rv = 0;
-			break;
-		case TRANSFER_STATE_FAILED:
-			pr_info("xfer 0x%p,%llu, failed, ep 0x%llx.\n",
-				 xfer, xfer->len, req->ep_addr - xfer->len);
-			spin_unlock_irqrestore(&engine->lock, flags);
-
-#ifdef __LIBXDMA_DEBUG__
-			transfer_dump(xfer);
-			sgt_dump(sgt);
-#endif
-			rv = -EIO;
-			break;
-		default:
-			if (!poll_mode && rv == -ERESTARTSYS) {
-				pr_info("xfer 0x%p,%llu, canceled, ep 0x%llx.\n",
-					xfer, xfer->len,
-					req->ep_addr - xfer->len);
-				spin_unlock_irqrestore(&engine->lock, flags);
-				wait_event_timeout(xfer->wq, (xfer->state !=
-					TRANSFER_STATE_SUBMITTED),
-					msecs_to_jiffies(timeout_ms));
-				xdma_engine_stop(engine);
-				break;
-			}
-			/* transfer can still be in-flight */
-			pr_info("xfer 0x%p,%llu, s 0x%x timed out, ep 0x%llx.\n",
-				 xfer, xfer->len, xfer->state, req->ep_addr - xfer->len);
-			engine_status_read(engine, 0, 1);
-			//engine_status_dump(engine);
-			transfer_abort(engine, xfer);
-
-			xdma_engine_stop(engine);
-			spin_unlock_irqrestore(&engine->lock, flags);
-
-#ifdef __LIBXDMA_DEBUG__
-			transfer_dump(xfer);
-			sgt_dump(sgt);
-#endif
-			rv = -ERESTARTSYS;
-			break;
-		}
-		transfer_destroy(xdev, xfer);
-#ifndef CONFIG_PREEMPT_COUNT
-			spin_unlock(&engine->desc_lock);
-#else
-			mutex_unlock(&engine->desc_mutex);
-#endif
-
-		if (rv < 0)
-			goto unmap_sgl;
-	} /* while (sg) */
-
 unmap_sgl:
-	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
-		sgt->nents = 0;
-	}
-
-	if (req)
-		xdma_request_free(req);
-
+	xdma_request_release(engine->xdev, req);
 	if (rv < 0)
 		return rv;
 
@@ -3170,82 +3228,153 @@ unmap_sgl:
 }
 EXPORT_SYMBOL_GPL(xdma_xfer_submit);
 
+void xdma_proc_aio_requests(void *dev_hndl, int channel, bool write)
+{
+	struct xdma_dev *xdev = (struct xdma_dev *)dev_hndl;
+	struct xdma_engine *engine;
+
+	if (write) {
+		if (channel >= xdev->h2c_channel_max) {
+			pr_err("H2C channel %d >= %d.\n", channel,
+				xdev->h2c_channel_max);
+			return;
+		}
+		engine = &xdev->engine_h2c[channel];
+	} else {
+		if (channel >= xdev->c2h_channel_max) {
+			pr_err("C2H channel %d >= %d.\n", channel,
+				xdev->c2h_channel_max);
+			return;
+		}
+		engine = &xdev->engine_c2h[channel];
+	}
+	if (!engine) {
+		pr_err("dma engine NULL\n");
+		return;
+	}
+
+	if (engine->magic != MAGIC_ENGINE) {
+		pr_err("%s has invalid magic number %lx\n", engine->name,
+		       engine->magic);
+		return;
+	}
+
+	if (xdma_device_flag_check(xdev, XDEV_FLAG_OFFLINE)) {
+		pr_err("xdev 0x%p, offline.\n", xdev);
+		return;
+	}
+
+	schedule_work_on(engine->cpu_idx, &engine->req_proc);
+}
+EXPORT_SYMBOL_GPL(xdma_proc_aio_requests);
+
 int xdma_performance_submit(struct xdma_dev *xdev, struct xdma_engine *engine)
 {
 	u8 *buffer_virt;
 	u32 max_consistent_size = 128 * 32 * 1024; /* 1024 pages, 4MB */
-	dma_addr_t buffer_bus;	/* bus address */
-	struct xdma_transfer *transfer;
+	dma_addr_t buffer_bus; /* bus address */
+	dma_addr_t rc_bus_addr;
+	struct xdma_request_cb *req;
+	struct xdma_desc *desc_virt;
+	dma_addr_t desc_bus;
 	u64 ep_addr = 0;
 	int num_desc_in_a_loop = 128;
 	int size_in_desc = engine->xdma_perf->transfer_size;
 	int size = size_in_desc * num_desc_in_a_loop;
 	int i;
+	int rv = -ENOMEM;
 
-	BUG_ON(size_in_desc > max_consistent_size);
+
+	if (size_in_desc > max_consistent_size) {
+		pr_err("%s max consistent size %d is more than supported %d\n",
+		       engine->name, size_in_desc, max_consistent_size);
+		return -EINVAL;
+	}
 
 	if (size > max_consistent_size) {
 		size = max_consistent_size;
 		num_desc_in_a_loop = size / size_in_desc;
 	}
 
-	buffer_virt = dma_alloc_coherent(&xdev->pdev->dev, size,
-					&buffer_bus, GFP_KERNEL);
-
-	/* allocate transfer data structure */
-	transfer = kzalloc(sizeof(struct xdma_transfer), GFP_KERNEL);
-	BUG_ON(!transfer);
-
-	/* 0 = write engine (to_dev=0) , 1 = read engine (to_dev=1) */
-	transfer->dir = engine->dir;
-	/* set number of descriptors */
-	transfer->desc_num = num_desc_in_a_loop;
-
-	/* allocate descriptor list */
 	if (!engine->desc) {
-		engine->desc = dma_alloc_coherent(&xdev->pdev->dev,
-			num_desc_in_a_loop * sizeof(struct xdma_desc),
-			&engine->desc_bus, GFP_KERNEL);
-		BUG_ON(!engine->desc);
-		dbg_init("device %s, engine %s pre-alloc desc 0x%p,0x%llx.\n",
-			dev_name(&xdev->pdev->dev), engine->name,
-			engine->desc, engine->desc_bus);
+		pr_err("DMA engine %s has void descriptor buffers\n",
+			     engine->name);
+		return -EINVAL;
 	}
-	transfer->desc_virt = engine->desc;
-	transfer->desc_bus = engine->desc_bus;
 
-	transfer_desc_init(transfer, transfer->desc_num);
 
-	dbg_sg("transfer->desc_bus = 0x%llx.\n", (u64)transfer->desc_bus);
+	buffer_virt = NULL;
+	/* allocates request without sgt entries */
+	req = xdma_request_alloc(0);
+	if (!req)
+		return -ENOMEM;
+	spin_lock(&engine->lock);
+	if (engine->running) {
+		pr_warn("Dma Engine is busy\n");
+		rv = -EBUSY;
+		goto err_dma_desc;
+	}
+	//xdma_add_request(engine, req);
+	req->desc_virt = engine->desc;
+	req->desc_bus = engine->desc_bus;
 
-	for (i = 0; i < transfer->desc_num; i++) {
-		struct xdma_desc *desc = transfer->desc_virt + i;
-		dma_addr_t rc_bus_addr = buffer_bus + size_in_desc * i;
+	buffer_virt = dma_alloc_coherent(&xdev->pdev->dev, size, &buffer_bus,
+					 GFP_KERNEL);
+	if (!buffer_virt) {
+		pr_err("dev %s, %s DMA allocation OOM.\n",
+		       dev_name(&xdev->pdev->dev), engine->name);
+		return rv;
+	}
+
+	engine->perf_buffer = buffer_virt;
+	engine->perf_bus = buffer_bus;
+	engine->perf_size = size;
+
+	desc_bus = req->desc_bus;
+	for (i = 0; i < num_desc_in_a_loop; i++) {
+		desc_virt = req->desc_virt + i;
+		desc_bus += sizeof(struct xdma_desc);
+		/* Actual Data to perform DMA */
+		rc_bus_addr = buffer_bus + size_in_desc * i;
 
 		/* fill in descriptor entry with transfer details */
-		xdma_desc_set(desc, rc_bus_addr, ep_addr, size_in_desc,
-			engine->dir);
+		xdma_desc_set(desc_virt, rc_bus_addr, ep_addr, size_in_desc,
+			      engine->dir);
+		desc_virt[i].next_lo = cpu_to_le32(PCI_DMA_L(desc_bus));
+		desc_virt[i].next_hi = cpu_to_le32(PCI_DMA_H(desc_bus));
 	}
 
 	/* stop engine and request interrupt on last descriptor */
-	xdma_desc_control_set(transfer->desc_virt, 0);
+	rv = xdma_desc_control_set(req->desc_virt, 0);
+	if (rv < 0) {
+		pr_err("Failed to set desc control\n");
+		goto err_dma_desc;
+	}
 	/* create a linked loop */
-	xdma_desc_link(transfer->desc_virt + transfer->desc_num - 1,
-		transfer->desc_virt, transfer->desc_bus);
-
-	transfer->cyclic = 1;
-
-	/* initialize wait queue */
-	init_waitqueue_head(&transfer->wq);
-
-	//printk("=== Descriptor print for PERF \n");
-	//transfer_dump(transfer);
+	xdma_desc_link(req->desc_virt + num_desc_in_a_loop - 1,
+		       req->desc_virt, req->desc_bus);
 
 	dbg_perf("Queueing XDMA I/O %s request for performance measurement.\n",
-		engine->dir ? "write (to dev)" : "read (from dev)");
-	transfer_queue(engine, transfer);
+		 engine->dir ? "write (to dev)" : "read (from dev)");
+	rv = engine_start(engine, req->desc_bus, num_desc_in_a_loop);
+	if (rv < 0) {
+		pr_err("Failed to queue transfer\n");
+		goto err_dma_desc;
+	}
+	engine->running = 1;
+	spin_unlock(&engine->lock);
+	kfree(req);
 	return 0;
 
+err_dma_desc:
+	spin_unlock(&engine->lock);
+	kfree(req);
+	req = NULL;
+	if (buffer_virt)
+		dma_free_coherent(&xdev->pdev->dev, size, buffer_virt,
+				  buffer_bus);
+	buffer_virt = NULL;
+	return rv;
 }
 EXPORT_SYMBOL_GPL(xdma_performance_submit);
 
@@ -3255,7 +3384,10 @@ static struct xdma_dev *alloc_dev_instance(struct pci_dev *pdev)
 	struct xdma_dev *xdev;
 	struct xdma_engine *engine;
 
-	BUG_ON(!pdev);
+	if (!pdev) {
+		pr_err("Invalid pdev\n");
+		return NULL;
+	}
 
 	/* allocate zeroed device book keeping structure */
 	xdev = kzalloc(sizeof(struct xdma_dev), GFP_KERNEL);
@@ -3288,10 +3420,11 @@ static struct xdma_dev *alloc_dev_instance(struct pci_dev *pdev)
 	for (i = 0; i < XDMA_CHANNEL_NUM_MAX; i++, engine++) {
 		spin_lock_init(&engine->lock);
 		spin_lock_init(&engine->desc_lock);
-#ifdef CONFIG_PREEMPT_COUNT
-		mutex_init(&engine->desc_mutex);
-#endif
-		INIT_LIST_HEAD(&engine->transfer_list);
+		spin_lock_init(&engine->req_list_lock);
+		INIT_LIST_HEAD(&engine->work_list);
+		INIT_LIST_HEAD(&engine->pend_list);
+		engine->avail_sets = XDMA_DESC_SETS_AVAIL_MAX;
+	//	INIT_LIST_HEAD(&engine->transfer_list);
 		init_waitqueue_head(&engine->shutdown_wq);
 		init_waitqueue_head(&engine->xdma_perf_wq);
 	}
@@ -3300,16 +3433,18 @@ static struct xdma_dev *alloc_dev_instance(struct pci_dev *pdev)
 	for (i = 0; i < XDMA_CHANNEL_NUM_MAX; i++, engine++) {
 		spin_lock_init(&engine->lock);
 		spin_lock_init(&engine->desc_lock);
-#ifdef CONFIG_PREEMPT_COUNT
-		mutex_init(&engine->desc_mutex);
-#endif
-		INIT_LIST_HEAD(&engine->transfer_list);
+		spin_lock_init(&engine->req_list_lock);
+		INIT_LIST_HEAD(&engine->work_list);
+		INIT_LIST_HEAD(&engine->pend_list);
+		engine->avail_sets = XDMA_DESC_SETS_AVAIL_MAX;
+	//	INIT_LIST_HEAD(&engine->transfer_list);
 		init_waitqueue_head(&engine->shutdown_wq);
 		init_waitqueue_head(&engine->xdma_perf_wq);
 	}
 
 	return xdev;
 }
+
 
 static int set_dma_mask(struct pci_dev *pdev)
 {
@@ -3616,7 +3751,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 
 	/* re-determine user_max */
 	xdev->user_max = min(xdev->user_max, pci_msix_vec_count(pdev) -
-			xdev->c2h_channel_max - xdev->h2c_channel_max);
+				xdev->c2h_channel_max - xdev->h2c_channel_max);
 	if (xdev->user_max < 0) {
 		rv = -EINVAL;
 		pr_err("Invalid number of interrupts. "
@@ -3625,7 +3760,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 			xdev->c2h_channel_max);
 		goto err_enable_msix;
 	}
-
+	
 	rv = enable_msi_msix(xdev, pdev);
 	if (rv < 0)
 		goto err_enable_msix;
@@ -3639,6 +3774,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 
 	/* Flush writes */
 	read_interrupts(xdev);
+
 
 	*user_max = xdev->user_max;
 	*h2c_channel_max = xdev->h2c_channel_max;
@@ -3788,7 +3924,7 @@ pr_info("pdev 0x%p, xdev 0x%p.\n", pdev, xdev);
 	}
 
 	/* re-write the interrupt table */
-	if (!poll_mode ) {
+	if (!poll_mode) {
 		irq_setup(xdev, pdev);
 
 		channel_interrupts_enable(xdev, ~0);
@@ -3927,61 +4063,6 @@ static void __exit xdma_base_exit(void)
 module_init(xdma_base_init);
 module_exit(xdma_base_exit);
 #endif
-/* makes an existing transfer cyclic */
-static void xdma_transfer_cyclic(struct xdma_transfer *transfer)
-{
-	/* link last descriptor to first descriptor */
-	xdma_desc_link(transfer->desc_virt + transfer->desc_num - 1,
-			transfer->desc_virt, transfer->desc_bus);
-	/* remember transfer is cyclic */
-	transfer->cyclic = 1;
-}
-
-static int transfer_monitor_cyclic(struct xdma_engine *engine,
-			struct xdma_transfer *transfer, int timeout_ms)
-{
-	struct xdma_result *result;
-	int rc = 0;
-
-	BUG_ON(!engine);
-	BUG_ON(!transfer);
-
-	result = engine->cyclic_result;
-	BUG_ON(!result);
-
-	if (poll_mode) {
-		int i ;
-		for (i = 0; i < 5; i++) {
-			rc = engine_service_poll(engine, 0);
-			if (rc) {
-				pr_info("%s service_poll failed %d.\n",
-					engine->name, rc);
-			}
-			if (result[engine->rx_head].status)
-				return 0;
-		}
-	} else {
-		if (enable_credit_mp){
-			dbg_tfr("%s: rx_head=%d,rx_tail=%d, wait ...\n",
-				engine->name, engine->rx_head, engine->rx_tail);
-			rc = wait_event_timeout( transfer->wq,
-					(engine->rx_head!=engine->rx_tail ||
-					 engine->rx_overrun),
-					msecs_to_jiffies(timeout_ms));
-			dbg_tfr("%s: wait returns %d, rx %d/%d, overrun %d.\n",
-				 engine->name, rc, engine->rx_head,
-				engine->rx_tail, engine->rx_overrun);
-		} else {
-			rc = wait_event_timeout( transfer->wq,
-					engine->eop_found,
-					msecs_to_jiffies(timeout_ms));
-			dbg_tfr("%s: wait returns %d, eop_found %d.\n",
-				engine->name, rc, engine->eop_found);
-		}
-	}
-
-	return 0;
-}
 
 struct scatterlist *sglist_index(struct sg_table *sgt, unsigned int idx)
 {
@@ -4000,456 +4081,5 @@ struct scatterlist *sglist_index(struct sg_table *sgt, unsigned int idx)
 	return sg;
 }
 
-static int copy_cyclic_to_user(struct xdma_engine *engine, int pkt_length,
-				int head, char __user *buf, size_t count)
-{
-	struct scatterlist *sg;
-	int more = pkt_length;
+/* ********************* static function definitions ************************ */
 
-	BUG_ON(!engine);
-	BUG_ON(!buf);
-
-	dbg_tfr("%s, pkt_len %d, head %d, user buf idx %u.\n",
-		engine->name, pkt_length, head, engine->user_buffer_index);
-
-	sg = sglist_index(&engine->cyclic_sgt, head);
-	if (!sg) {
-		pr_info("%s, head %d OOR, sgl %u.\n",
-			engine->name, head, engine->cyclic_sgt.orig_nents);
-		return -EIO;
-	}
-
-	/* EOP found? Transfer anything from head to EOP */
-	while (more) {
-		unsigned int copy = more > PAGE_SIZE ? PAGE_SIZE : more;
-		unsigned int blen = count - engine->user_buffer_index;
-		int rv;
-
-		if (copy > blen)
-			copy = blen;
-
-		dbg_tfr("%s sg %d, 0x%p, copy %u to user %u.\n",
-			engine->name, head, sg, copy,
-			engine->user_buffer_index);
-
-		rv = copy_to_user(&buf[engine->user_buffer_index],
-			page_address(sg_page(sg)), copy);
-		if (rv) {
-			pr_info("%s copy_to_user %u failed %d\n",
-				engine->name, copy, rv);
-			return -EIO;
-		}
-
-		more -= copy;
-		engine->user_buffer_index += copy;
-
-		if (engine->user_buffer_index == count) {
-			/* user buffer used up */
-			break;
-		}
-
-		head++;
-		if (head >= CYCLIC_RX_PAGES_MAX) {
-			head = 0;
-			sg = engine->cyclic_sgt.sgl;
-		} else
-			sg = sg_next(sg);
-	}
-
-	return pkt_length;
-}
-
-static int complete_cyclic(struct xdma_engine *engine, char __user *buf,
-			   size_t count)
-{
-	struct xdma_result *result;
-	int pkt_length = 0;
-	int fault = 0;
-	int eop = 0;
-	int head;
-	int rc = 0;
-	int num_credit = 0;
-	unsigned long flags;
-
-	BUG_ON(!engine);
-	result = engine->cyclic_result;
-	BUG_ON(!result);
-
-	spin_lock_irqsave(&engine->lock, flags);
-
-	/* where the host currently is in the ring buffer */
-	head = engine->rx_head;
-
-	/* iterate over newly received results */
-	while (engine->rx_head != engine->rx_tail||engine->rx_overrun) {
-
-		WARN_ON(result[engine->rx_head].status==0);
-
-		dbg_tfr("%s, result[%d].status = 0x%x length = 0x%x.\n",
-			engine->name, engine->rx_head,
-			result[engine->rx_head].status,
-			result[engine->rx_head].length);
-
-		if ((result[engine->rx_head].status >> 16) != C2H_WB) {
-			pr_info("%s, result[%d].status 0x%x, no magic.\n",
-				engine->name, engine->rx_head,
-				result[engine->rx_head].status);
-			fault = 1;
-		} else if (result[engine->rx_head].length > PAGE_SIZE) {
-			pr_info("%s, result[%d].len 0x%x, > PAGE_SIZE 0x%lx.\n",
-				engine->name, engine->rx_head,
-				result[engine->rx_head].length, PAGE_SIZE);
-			fault = 1;
-		} else if (result[engine->rx_head].length == 0) {
-			pr_info("%s, result[%d].length 0x%x.\n",
-				engine->name, engine->rx_head,
-				result[engine->rx_head].length);
-			fault = 1;
-			/* valid result */
-		} else {
-			pkt_length += result[engine->rx_head].length;
-			num_credit++;
-			/* seen eop? */
-			//if (result[engine->rx_head].status & RX_STATUS_EOP)
-			if (result[engine->rx_head].status & RX_STATUS_EOP){
-				eop = 1;
-				engine->eop_found = 1;
-			}
-
-			dbg_tfr("%s, pkt_length=%d (%s)\n",
-				engine->name, pkt_length,
-				eop ? "with EOP" : "no EOP yet");
-		}
-		/* clear result */
-		result[engine->rx_head].status = 0;
-		result[engine->rx_head].length = 0;
-		/* proceed head pointer so we make progress, even when fault */
-		engine->rx_head = (engine->rx_head + 1) % CYCLIC_RX_PAGES_MAX;
-
-		/* stop processing if a fault/eop was detected */
-		if (fault || eop){
-			break;
-		}
-	}
-
-	spin_unlock_irqrestore(&engine->lock, flags);
-
-	if (fault)
-		return -EIO;
-
-	rc = copy_cyclic_to_user(engine, pkt_length, head, buf, count);
-	engine->rx_overrun = 0;
-	/* if copy is successful, release credits */
-	if(rc > 0)
-		write_register(num_credit,&engine->sgdma_regs->credits, 0);
-
-	return rc;
-}
-
-ssize_t xdma_engine_read_cyclic(struct xdma_engine *engine, char __user *buf,
-				size_t count, int timeout_ms)
-{
-	int i = 0;
-	int rc = 0;
-	int rc_len = 0;
-	struct xdma_transfer *transfer;
-
-	BUG_ON(!engine);
-	BUG_ON(engine->magic != MAGIC_ENGINE);
-
-	transfer = &engine->cyclic_req->xfer;
-	BUG_ON(!transfer);
-
-        engine->user_buffer_index = 0;
-
-	do {
-		rc = transfer_monitor_cyclic(engine, transfer, timeout_ms);
-		if (rc < 0)
-			return rc;
-		rc = complete_cyclic(engine, buf, count);
-		if (rc < 0)
-			return rc;
-		rc_len += rc;
-
-		i++;
-		if (i > 10)
-			break;
-	} while (!engine->eop_found);
-
-	if(enable_credit_mp)
-		engine->eop_found = 0;
-
-	return rc_len;
-}
-
-static void sgt_free_with_pages(struct sg_table *sgt, int dir,
-				struct pci_dev *pdev)
-{
-	struct scatterlist *sg = sgt->sgl;
-	int npages = sgt->orig_nents;
-	int i;
-
-	for (i = 0; i < npages; i++, sg = sg_next(sg)) {
-		struct page *pg = sg_page(sg);
-		dma_addr_t bus = sg_dma_address(sg);
-
-		if (pg) {
-			if (pdev)
-				pci_unmap_page(pdev, bus, PAGE_SIZE, dir);
-			__free_page(pg);
-		} else
-			break;
-	}
-	sg_free_table(sgt);
-	memset(sgt, 0, sizeof(struct sg_table));
-}
-
-static int sgt_alloc_with_pages(struct sg_table *sgt, unsigned int npages,
-				int dir, struct pci_dev *pdev)
-{
-	struct scatterlist *sg;
-	int i;
-
-	if (sg_alloc_table(sgt, npages, GFP_KERNEL)) {
-		pr_info("sgt OOM.\n");
-		return -ENOMEM;
-	}
-
-	sg = sgt->sgl;
-	for (i = 0; i < npages; i++, sg = sg_next(sg)) {
-		struct page *pg = alloc_page(GFP_KERNEL);
-
-        	if (!pg) {
-			pr_info("%d/%u, page OOM.\n", i, npages);
-			goto err_out;
-		}
-
-		if (pdev) {
-			dma_addr_t bus = pci_map_page(pdev, pg, 0, PAGE_SIZE,
-							dir);
-                	if (unlikely(pci_dma_mapping_error(pdev, bus))) {
-				pr_info("%d/%u, page 0x%p map err.\n",
-					 i, npages, pg);
-				__free_page(pg);
-				goto err_out;
-			}
-			sg_dma_address(sg) = bus;
-			sg_dma_len(sg) = PAGE_SIZE;
-		}
-		sg_set_page(sg, pg, PAGE_SIZE, 0);
-	}
-
-	sgt->orig_nents = sgt->nents = npages;
-
-	return 0;
-
-err_out:
-	sgt_free_with_pages(sgt, dir, pdev);
-	return -ENOMEM;
-}
-
-int xdma_cyclic_transfer_setup(struct xdma_engine *engine)
-{
-	struct xdma_dev *xdev;
-	struct xdma_transfer *xfer;
-	dma_addr_t bus;
-	unsigned long flags;
-	int i;
-	int rc;
-
-	BUG_ON(!engine);
-	xdev = engine->xdev;
-	BUG_ON(!xdev);
-
-	if (engine->cyclic_req) {
-		pr_info("%s: exclusive access already taken.\n",
-			engine->name);
-		return -EBUSY;
-	}
-
-	spin_lock_irqsave(&engine->lock, flags);
-
-	engine->rx_tail = 0;
-	engine->rx_head = 0;
-	engine->rx_overrun = 0;
-	engine->eop_found = 0;
-
-	rc = sgt_alloc_with_pages(&engine->cyclic_sgt, CYCLIC_RX_PAGES_MAX,
-				engine->dir, xdev->pdev);
-	if (rc < 0) {
-		pr_info("%s cyclic pages %u OOM.\n",
-			engine->name, CYCLIC_RX_PAGES_MAX);
-		goto err_out;
-	}
-
-	engine->cyclic_req = xdma_init_request(&engine->cyclic_sgt, 0);
-	if (!engine->cyclic_req) {
-		pr_info("%s cyclic request OOM.\n", engine->name);
-		rc = -ENOMEM;
-		goto err_out;
-	}
-
-#ifdef __LIBXDMA_DEBUG__
-	xdma_request_cb_dump(engine->cyclic_req);
-#endif
-
-	rc = transfer_init(engine, engine->cyclic_req);
-	if (rc < 0)
-		goto err_out;
-
-	xfer = &engine->cyclic_req->xfer;
-
-	/* replace source addresses with result write-back addresses */
-	memset(engine->cyclic_result, 0,
-		CYCLIC_RX_PAGES_MAX * sizeof(struct xdma_result));
-	bus = engine->cyclic_result_bus;
-        for (i = 0; i < xfer->desc_num; i++) {
-		xfer->desc_virt[i].src_addr_lo = cpu_to_le32(PCI_DMA_L(bus));
-        	xfer->desc_virt[i].src_addr_hi = cpu_to_le32(PCI_DMA_H(bus));
-                bus += sizeof(struct xdma_result);
-        }
-	/* set control of all descriptors */
-        for (i = 0; i < xfer->desc_num; i++) {
-                xdma_desc_control_clear(xfer->desc_virt + i, LS_BYTE_MASK);
-                xdma_desc_control_set(xfer->desc_virt + i,
-				 XDMA_DESC_EOP | XDMA_DESC_COMPLETED);
-        }
-
-	/* make this a cyclic transfer */
-	xdma_transfer_cyclic(xfer);
-
-#ifdef __LIBXDMA_DEBUG__
-	transfer_dump(xfer);
-#endif
-
-	if(enable_credit_mp){
-		//write_register(RX_BUF_PAGES,&engine->sgdma_regs->credits);
-		write_register(128, &engine->sgdma_regs->credits, 0);
-	}
-
-	spin_unlock_irqrestore(&engine->lock, flags);
-
-	/* start cyclic transfer */
-	transfer_queue(engine, xfer);
-
-	return 0;
-
-	/* unwind on errors */
-err_out:
-	if (engine->cyclic_req) {
-		xdma_request_free(engine->cyclic_req);
-		engine->cyclic_req = NULL;
-	}
-
-	if (engine->cyclic_sgt.orig_nents) {
-		sgt_free_with_pages(&engine->cyclic_sgt, engine->dir,
-				xdev->pdev);
-		engine->cyclic_sgt.orig_nents = 0;
-		engine->cyclic_sgt.nents = 0;
-		engine->cyclic_sgt.sgl = NULL;
-	}
-
-	spin_unlock_irqrestore(&engine->lock, flags);
-
-	return rc;
-}
-
-
-static int cyclic_shutdown_polled(struct xdma_engine *engine)
-{
-	BUG_ON(!engine);
-
-	spin_lock(&engine->lock);
-
-	dbg_tfr("Polling for shutdown completion\n");
-	do {
-		engine_status_read(engine, 1, 0);
-		schedule();
-	} while (engine->status & XDMA_STAT_BUSY);
-
-	if ((engine->running) && !(engine->status & XDMA_STAT_BUSY)) {
-		dbg_tfr("Engine has stopped\n");
-
-		if (!list_empty(&engine->transfer_list))
-			engine_transfer_dequeue(engine);
-
-		engine_service_shutdown(engine);
-	}
-
-	dbg_tfr("Shutdown completion polling done\n");
-	spin_unlock(&engine->lock);
-
-	return 0;
-}
-
-static int cyclic_shutdown_interrupt(struct xdma_engine *engine)
-{
-	int rc;
-
-	BUG_ON(!engine);
-
-	rc = wait_event_timeout(engine->shutdown_wq,
-				!engine->running, msecs_to_jiffies(10000));
-
-#if 0
-	if (rc) {
-		dbg_tfr("wait_event_timeout=%d\n", rc);
-		return rc;
-	}
-#endif
-
-	if (engine->running) {
-		pr_info("%s still running?!, %d\n", engine->name, rc);
-		return -EINVAL;
-	}
-
-	return rc;
-}
-
-int xdma_cyclic_transfer_teardown(struct xdma_engine *engine)
-{
-	int rc;
-	struct xdma_dev *xdev = engine->xdev;
-	struct xdma_transfer *transfer;
-	unsigned long flags;
-
-	transfer = engine_cyclic_stop(engine);
-
-	spin_lock_irqsave(&engine->lock, flags);
-	if (transfer) {
-		dbg_tfr("%s: stop transfer 0x%p.\n", engine->name, transfer);
-		if (transfer != &engine->cyclic_req->xfer) {
-			pr_info("%s unexpected transfer 0x%p/0x%p\n",
-				engine->name, transfer,
-				&engine->cyclic_req->xfer);
-		}
-	}
-	/* allow engine to be serviced after stop request */
-	spin_unlock_irqrestore(&engine->lock, flags);
-
-	/* wait for engine to be no longer running */
-	if (poll_mode)
-		rc = cyclic_shutdown_polled(engine);
-	else
-		rc = cyclic_shutdown_interrupt(engine);
-
-	/* obtain spin lock to atomically remove resources */
-	spin_lock_irqsave(&engine->lock, flags);
-
-	if (engine->cyclic_req) {
-		xdma_request_free(engine->cyclic_req);
-		engine->cyclic_req = NULL;
-	}
-
-	if (engine->cyclic_sgt.orig_nents) {
-		sgt_free_with_pages(&engine->cyclic_sgt, engine->dir,
-				xdev->pdev);
-		engine->cyclic_sgt.orig_nents = 0;
-		engine->cyclic_sgt.nents = 0;
-		engine->cyclic_sgt.sgl = NULL;
-	}
-
-	spin_unlock_irqrestore(&engine->lock, flags);
-
-	return 0;
-}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma_api.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma_api.h
@@ -57,6 +57,24 @@ typedef struct {
 	u64 msix_trigger;
 } xdma_statistics;
 
+struct xdma_io_cb {
+	void __user *buf;
+	size_t len;
+	void *private;
+	unsigned int pages_nr;
+	struct sg_table *sgt;
+	struct page **pages;
+	/** total data size */
+	unsigned int count;
+	/** MM only, DDR/BRAM memory addr */
+	u64 ep_addr;
+	/** write: if write to the device */
+	struct xdma_request_cb *req;
+	u8 write:1;
+	void (*io_done)(unsigned long cb_hndl, int err);
+};
+
+
 /*
  * This struct should be constantly updated by XMDA using u64_stats_* APIs
  * The front end will read the structure without locking (That's why updating atomically is a must)
@@ -149,7 +167,8 @@ int xdma_user_isr_disable(void *dev_hndl, unsigned int mask);
  * TODO: exact error code will be defined later
  */
 ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
-			struct sg_table *sgt, bool dma_mapped, int timeout_ms);
+			struct sg_table *sgt, bool dma_mapped, int timeout_ms,
+		       	struct xdma_io_cb *cb);
 			
 /*
  * xdma_device_online - bring device offline

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -80,7 +80,7 @@ static ssize_t xdma_migrate_bo(struct platform_device *pdev,
 	xocl_dbg(&pdev->dev, "TID %d, Channel:%d, Offset: 0x%llx, Dir: %d",
 		pid, channel, paddr, dir);
 	ret = xdma_xfer_submit(xdma->dma_handle, channel, dir,
-		paddr, sgt, false, 10000);
+		paddr, sgt, false, 10000, NULL);
 	if (ret >= 0) {
 		xdma->channel_usage[dir][channel] += ret;
 		return ret;


### PR DESCRIPTION
* Implemented queuing mechanism to enqueue IO requests without waiting for completions.
* When request are asynchronous the xdma driver takes callback routine and callback context as input and executes the callback on receiving completions.
* Driver batches as many requests as possible before submitting to DMA engine.


Current changes does not alter any XRT mechanism for DMA transfers. Further changes will follow to make use of this asynchronous mechanism within XRT stack. 