### PR TITLE
XRT-270: Acquire CU context when creating kernel

### DIFF
--- a/src/runtime_src/core/common/exec/kernel.cpp
+++ b/src/runtime_src/core/common/exec/kernel.cpp
@@ -62,6 +62,10 @@ struct device_type
     , exec_buffer_cache(dhdl, 128)
   {}
 
+  ~device_type()
+  try {}
+  catch (const std::exception&) {}
+
   template <typename CommandType>
   xrt_core::bo_cache::cmd_bo<CommandType>
   create_exec_buf()
@@ -74,6 +78,62 @@ struct device_type
   {
     return core_device.get();
   }
+};
+
+
+// struct ip_context - Manages process access to CUs
+//
+// Constructing a kernel object opens a context on the CUs associated
+// with the kernel object.  The context is reference counted such that
+// multiple kernel objects can open a context on the same CU provided
+// the access type is shared.
+//
+// A CU context is released when the last kernel object referencing it
+// is closed.  If the process closes without having released on kernel
+// then behavior is undefined.
+class ip_context
+{
+public:
+  enum class access_mode : bool { exclusive = false, shared = true };
+  
+  static std::shared_ptr<ip_context>
+  open(xrt_core::device* device, xuid_t xclbin_id, unsigned int ipidx, access_mode am)
+  {
+    static std::vector<std::weak_ptr<ip_context>> ips(128);
+    auto ip = ips[ipidx].lock();
+    if (!ip) {
+      ip = std::shared_ptr<ip_context>(new ip_context(device, xclbin_id, ipidx, am));
+      ips[ipidx] = ip;
+    }
+
+    if (ip->access != am)
+      throw std::runtime_error("Conflicting access mode for IP(" + std::to_string(ipidx) + ")");
+
+    return ip;
+  }
+
+  // For symmetry
+  void
+  close()
+  {}
+
+  ~ip_context()
+  {
+    device->close_context(xid, idx);
+  }
+
+private:
+  ip_context(xrt_core::device* dev, xuid_t xclbin_id, unsigned int ipidx, access_mode am)
+    : device(dev), idx(ipidx), access(am)
+  {
+    uuid_copy(xid, xclbin_id);
+    device->open_context(xid, idx, std::underlying_type<access_mode>::type(am));
+  }
+
+  xrt_core::device* device;
+  unsigned int idx;
+  access_mode access;
+  xuid_t xid;
 };
 
 // class kernel_command - Immplements command API expected by schedulers
@@ -257,13 +317,15 @@ private:
 struct kernel_type
 {
   using argument = xrt_core::xclbin::kernel_argument;
+  using ipctx = std::shared_ptr<ip_context>;
 
   std::shared_ptr<device_type> device;   // shared ownership
   std::string name;                      // kernel name
   const axlf* top = nullptr;             // xclbin
-  std::vector<const ip_data*> ips;       // compute units
   std::vector<argument> args;            // kernel args sorted by argument index
+  std::vector<ipctx> ipctxs;             // CU context locks
   std::bitset<128> cumask;               // cumask for command execution
+  xuid_t xclbin_id;                      // xclbin uuid
   size_t regmap_size = 0;                // CU register map size
   size_t num_cumasks = 1;                // Required number of command cu masks TODO: compute
 
@@ -272,22 +334,28 @@ struct kernel_type
   // @dev:     device associated with this kernel object
   // @xclbin:  xclbin to mine for kernel meta data
   // @nm:      name identifying kernel and/or kernel and instances
-  kernel_type(std::shared_ptr<device_type> dev, const char* xclbin, const std::string& nm)
+  // @am:      access mode for underlying compute units
+  kernel_type(std::shared_ptr<device_type> dev, const char* xclbin, const std::string& nm, ip_context::access_mode am)
     : device(std::move(dev))                                   // share ownership
     , name(nm.substr(0,nm.find(":")))                          // filter instance names
     , top(reinterpret_cast<const axlf*>(xclbin))               // convert to axlf
-    , ips(xrt_core::xclbin::get_cus(top, nm))                  // CUs matching nm
     , args(xrt_core::xclbin::get_kernel_arguments(top, name))  // kernel argument meta data
   {
+    uuid_copy(xclbin_id, top->m_header.uuid);
+    
     // Compare the matching CUs against the CU sort order to create cumask
+    auto ips = xrt_core::xclbin::get_cus(top, nm);
     if (ips.empty())
       throw std::runtime_error("No compute units matching '" + nm + "'");
+
     auto cus = xrt_core::xclbin::get_cus(top);  // sort order
     for (const ip_data* cu : ips) {
       auto itr = std::find(cus.begin(), cus.end(), cu->m_base_address);
       if (itr == cus.end())
         throw std::runtime_error("unexpected error");
-      cumask.set(std::distance(cus.begin(), itr));
+      auto idx = std::distance(cus.begin(), itr);
+      ipctxs.emplace_back(ip_context::open(device->get_core_device(), xclbin_id, idx, am));
+      cumask.set(idx);
     }
 
     // Compute register map size for a kernel invocation
@@ -491,10 +559,10 @@ get_run(xrtRunHandle rhdl)
 namespace api {
 
 xrtKernelHandle
-xrtKernelOpen(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
+xrtKernelOpen(xrtDeviceHandle dhdl, const char* xclbin, const char *name, ip_context::access_mode am)
 {
   auto device = get_device(dhdl, xclbin);
-  auto kernel = std::make_shared<kernel_type>(device, xclbin, name);
+  auto kernel = std::make_shared<kernel_type>(device, xclbin, name, am);
   auto handle = kernel.get();
   kernels.emplace(std::make_pair(handle,std::move(kernel)));
   return handle;
@@ -577,7 +645,19 @@ xrtKernelHandle
 xrtKernelOpen(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
 {
   try {
-    return api::xrtKernelOpen(dhdl, xclbin, name);
+    return api::xrtKernelOpen(dhdl, xclbin, name, ip_context::access_mode::shared);
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return XRT_NULL_HANDLE;
+  }
+}
+
+xrtKernelHandle
+xrtKernelOpenExclusive(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
+{
+  try {
+    return api::xrtKernelOpen(dhdl, xclbin, name, ip_context::access_mode::exclusive);
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());

--- a/src/runtime_src/core/common/exec/kernel.cpp
+++ b/src/runtime_src/core/common/exec/kernel.cpp
@@ -62,10 +62,6 @@ struct device_type
     , exec_buffer_cache(dhdl, 128)
   {}
 
-  ~device_type()
-  try {}
-  catch (const std::exception&) {}
-
   template <typename CommandType>
   xrt_core::bo_cache::cmd_bo<CommandType>
   create_exec_buf()
@@ -95,7 +91,7 @@ class ip_context
 {
 public:
   enum class access_mode : bool { exclusive = false, shared = true };
-  
+
   static std::shared_ptr<ip_context>
   open(xrt_core::device* device, xuid_t xclbin_id, unsigned int ipidx, access_mode am)
   {
@@ -342,7 +338,7 @@ struct kernel_type
     , args(xrt_core::xclbin::get_kernel_arguments(top, name))  // kernel argument meta data
   {
     uuid_copy(xclbin_id, top->m_header.uuid);
-    
+
     // Compare the matching CUs against the CU sort order to create cumask
     auto ips = xrt_core::xclbin::get_cus(top, nm);
     if (ips.empty())

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -60,6 +60,10 @@ typedef void * xrtRunHandle;
  * The kernel name must uniquely identify compatible kernel instances
  * (compute units).  Optionally specify which kernel instance(s) to
  * open using "kernelname:{instancename1,instancename2,...}" syntax.
+ * The compute units are opened with shared access, meaning that 
+ * other kernels and other process will have shared access to same
+ * compute units.  If exclusive access is needed then open the 
+ * kernel using @xrtKernelOpenExclusve().
  *
  * An xclbin with the specified kernel must have been loaded prior
  * to calling this function. An XRT_NULL_HANDLE is returned on error
@@ -70,6 +74,17 @@ typedef void * xrtRunHandle;
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
 xrtKernelOpen(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
+
+/**
+ * xrtKernelOpenExclusive() - Open a kernel and obtain its handle.
+ *
+ * Same as @xrtKernelOpen(), but opens compute units with exclusive
+ * access.  Fails if any compute unit is already opened with either
+ * exclusive or shared access.
+ */
+XCL_DRIVER_DLLESPEC
+xrtKernelHandle
+xrtKernelOpenExclusive(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
 
 /**
  * xrtKernelClose() - Close an opened kernel


### PR DESCRIPTION
Support opening kernel in shared or exclusive access mode, such that
underlying compute units are opened accordingly for the lifetime of
the kernel object.