### PR TITLE
adding a flat shell support

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2394,11 +2394,17 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin)
 			goto out;
 		}
 	}
-
-
-	err = icap_download_bitstream(icap, xclbin);
-	if (err)
-		goto out;
+// dont need to program the bitstream for flat shell
+	if(xclbin->m_header.m_mode != XCLBIN_FLAT)
+	{
+    err = icap_download_bitstream(icap, xclbin);
+    if (err)
+      goto out;
+  }
+  else
+  {
+		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to load bitstream ");
+	}
 
 	/* calibrate hbm and ddr should be performed when resources are ready */
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2394,21 +2394,15 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin)
 			goto out;
 		}
 	}
-    /* dont need to program the bitstream for flat shell
-       get uuid from board and compare with xclbin uuid 
-       if both are same no need to program the board otherwise return with error */ 
+    /* dont need to program the bitstream for flat shell */
 
     if(xclbin->m_header.m_mode != XCLBIN_FLAT) {
         err = icap_download_bitstream(icap, xclbin);
         if (err)
             goto out;
-    } else if (!uuid_equal(&xclbin->m_header.uuid, (xuid_t *) xocl_rom_get_uuid(xdev))) {
-        ICAP_ERR(icap, "Provided xclbin and on board bitstream are different, please reprogram the board with xclbin ");
-        err = -EINVAL;
-        goto out;
     } else {
         uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
-        ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to load bitstream ");
+        ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
     }
 
 	/* calibrate hbm and ddr should be performed when resources are ready */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2394,8 +2394,11 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin)
 			goto out;
 		}
 	}
-    /* dont need to program the bitstream for flat shell */
-
+    /* xclbin generated for the flat shell contains MCS files which includes the accelerator
+     * these MCS files should have been already flashed into the device using xbmgmt tool
+     * we dont need to reprogram the xclbin for the FLAT shells.
+     * TODO Currently , There is no way to check whether the programmed xclbin matches with this xclbin or not
+     */
     if(xclbin->m_header.m_mode != XCLBIN_FLAT) {
         err = icap_download_bitstream(icap, xclbin);
         if (err)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2394,12 +2394,20 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin)
 			goto out;
 		}
 	}
-// dont need to program the bitstream for flat shell
-	if(xclbin->m_header.m_mode != XCLBIN_FLAT) {
+    /* dont need to program the bitstream for flat shell
+       get uuid from board and compare with xclbin uuid 
+       if both are same no need to program the board otherwise return with error */ 
+
+    if(xclbin->m_header.m_mode != XCLBIN_FLAT) {
         err = icap_download_bitstream(icap, xclbin);
         if (err)
             goto out;
+    } else if (!uuid_equal(&xclbin->m_header.uuid, (xuid_t *) xocl_rom_get_uuid(xdev))) {
+        ICAP_ERR(icap, "Provided xclbin and on board bitstream are different, please reprogram the board with xclbin ");
+        err = -EINVAL;
+        goto out;
     } else {
+        uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
         ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to load bitstream ");
     }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2395,16 +2395,13 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin)
 		}
 	}
 // dont need to program the bitstream for flat shell
-	if(xclbin->m_header.m_mode != XCLBIN_FLAT)
-	{
-    err = icap_download_bitstream(icap, xclbin);
-    if (err)
-      goto out;
-  }
-  else
-  {
-		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to load bitstream ");
-	}
+	if(xclbin->m_header.m_mode != XCLBIN_FLAT) {
+        err = icap_download_bitstream(icap, xclbin);
+        if (err)
+            goto out;
+    } else {
+        ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to load bitstream ");
+    }
 
 	/* calibrate hbm and ddr should be performed when resources are ready */
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -640,102 +640,89 @@ static int update(int argc, char *argv[])
             break;
 
         switch (opt) {
-        case '0':
-            index = bdf2index(optarg);
-            if (index == UINT_MAX)
-                return -ENOENT;
-            break;
-        case '1':
-            shell = std::string(optarg);
-            break;
-        case '2':
-	    id = std::string(optarg);
-            break;
-        case '3':
-            force = true;
-            break;
-        case '4':
-            xclbin = std::string(optarg);
-            break;
-        default:
-            return -EINVAL;
+            case '0':
+                index = bdf2index(optarg);
+                if (index == UINT_MAX)
+                    return -ENOENT;
+                break;
+            case '1':
+                shell = std::string(optarg);
+                break;
+            case '2':
+                id = std::string(optarg);
+                break;
+            case '3':
+                force = true;
+                break;
+            case '4':
+                xclbin = std::string(optarg);
+                break;
+            default:
+                return -EINVAL;
         }
     }
 
     if (shell.empty() && !id.empty())
         return -EINVAL;
 
-    if(!xclbin.empty())
-    {
-
-      std::ifstream in(xclbin);
-      if (!in.is_open())
-      {
-        std::cout << "Can't open " << xclbin <<std::endl;
-        return -EINVAL;
-      }
-
-      axlf a1;
-      size_t sz = sizeof (axlf);
-      in.read(reinterpret_cast<char *>(&a1), sz);
-      if (!in.good())
-      {
-        std::cout << "Can't read axlf from "<< xclbin << std::endl;
-        return -EINVAL;
-      }
-
-      if (a1.m_header.m_numSections > 10000)
-        return -EINVAL;
-
-      sz = sizeof (axlf) + sizeof (axlf_section_header) *(a1.m_header.m_numSections - 1);
-      std::vector<char> top(sz);
-      in.seekg(0);
-      in.read(top.data(), sz);
-      if (!in.good())
-      {
-        std::cout << "Can't read axlf and section headers from	 "<< xclbin<< std::endl;
-        return -EINVAL;
-      }
-      bool matched = false;
-      // TODO... get Following fields to  verify with installedDSAs
-      //currently his information not present in the xclbin
-      //std::string vendor_id;
-      //std::string device_id;
-
-      uint64_t timestamp;
-
-      const axlf *ap = reinterpret_cast<const axlf *>(top.data());
-      timestamp = ap->m_header.m_featureRomTimeStamp;
-
-      auto installedDSAs = firmwareImage::getIntalledDSAs();
-      bool multiDSA = false;
-      for (DSAInfo& dsa: installedDSAs)
-      {
-        if ((shell == dsa.name) &&
-            (id.empty() || dsa.matchId(id)) &&
-            (timestamp == dsa.timestamp)) {
-          if(!matched)
-            matched = true;
-          else
-            multiDSA =true;
+    if (!xclbin.empty()) {
+        std::ifstream in(xclbin);
+        if (!in.is_open()) {
+            std::cout << "Can't open " << xclbin <<std::endl;
+            return -EINVAL;
         }
-      }
 
-      if(multiDSA)
-      {
-        std::cout << "Specified xclbin matched multiple installed shells" << std::endl;
-        return -ENOTUNIQ;
-      }
+        axlf a1;
+        size_t sz = sizeof (axlf);
+        in.read(reinterpret_cast<char *>(&a1), sz);
+        if (!in.good()) {
+            std::cout << "Can't read axlf from "<< xclbin << std::endl;
+            return -EINVAL;
+        }
 
-      if(matched)
-      {
-        //remove the already installedDSAs from the firmwareImage and add xclbin
-        std::cout << "Specified xclbin matched with installed shell" << std::endl;
-        firmwareImage::clearInstalledDSAs();
-        DSAInfo dInfo(xclbin);
-        firmwareImage::addToInstalledDSAs(dInfo);
-      }
+        if (a1.m_header.m_numSections > 10000)
+            return -EINVAL;
 
+        sz = sizeof (axlf) + sizeof (axlf_section_header) *(a1.m_header.m_numSections - 1);
+        std::vector<char> top(sz);
+        in.seekg(0);
+        in.read(top.data(), sz);
+        if (!in.good()) {
+            std::cout << "Can't read axlf and section headers from	 "<< xclbin<< std::endl;
+            return -EINVAL;
+        }
+        // TODO... get Following fields to  verify with installedDSAs
+        //currently his information not present in the xclbin
+        //std::string vendor_id;
+        //std::string device_id;
+        const axlf *ap = reinterpret_cast<const axlf *>(top.data());
+        uint64_t timestamp = ap->m_header.m_featureRomTimeStamp;
+
+        auto installedDSAs = firmwareImage::getIntalledDSAs();
+        bool multiDSA = false;
+        bool matched = false;
+        for (DSAInfo& dsa: installedDSAs) {
+            if ((shell == dsa.name) &&
+                (id.empty() || dsa.matchId(id)) &&
+                (timestamp == dsa.timestamp)) {
+                if(!matched)
+                    matched = true;
+                else
+                    multiDSA =true;
+            }
+        }
+        if (multiDSA) {
+            std::cout << "Specified xclbin matched multiple installed shells" << std::endl;
+            return -ENOTUNIQ;
+        }
+
+        if (matched) {
+            //remove the already installedDSAs from the firmwareImage and add xclbin
+            std::cout << "Specified xclbin matched with installed shell" << std::endl;
+            firmwareImage::clearInstalledDSAs();
+            DSAInfo dInfo(xclbin);
+            firmwareImage::addToInstalledDSAs(dInfo);
+        }
     }
     return autoFlash(index, shell, id, force);
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -624,7 +624,6 @@ static int update(int argc, char *argv[])
     unsigned index = UINT_MAX;
     std::string shell;
     std::string id;
-    std::string xclbin;
     const option opts[] = {
         { "card", required_argument, nullptr, '0' },
         { "shell", required_argument, nullptr, '1' },
@@ -652,9 +651,6 @@ static int update(int argc, char *argv[])
                 break;
             case '3':
                 force = true;
-                break;
-            case '4':
-                xclbin = std::string(optarg);
                 break;
             default:
                 return -EINVAL;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -666,7 +666,7 @@ static int update(int argc, char *argv[])
         return -EINVAL;
 
     if (!xclbin.empty()) {
-        std::ifstream in(xclbin);
+        std::ifstream in(xclbin, std::ios::binary);
         if (!in.is_open()) {
             std::cout << "Can't open " << xclbin <<std::endl;
             return -EINVAL;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -206,8 +206,7 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id
     }
     // DSABIN file path.
     else if ((suffix.compare(XSABIN_FILE_SUFFIX) == 0) ||
-             (suffix.compare(DSABIN_FILE_SUFFIX) == 0) ||
-             (suffix.compare(XCLBIN_FILE_SUFFIX) == 0 ))
+            (suffix.compare(DSABIN_FILE_SUFFIX) == 0))
     {
         std::ifstream in(file);
         if (!in.is_open())
@@ -254,12 +253,6 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id
         getVendorBoardFromDSAName(name, vendor, board);
         parseDSAFilename(filename, vendor_id, device_id, subsystem_id, timestamp);
         
-        //get the timestamp from xclbin
-        if( suffix.compare(XCLBIN_FILE_SUFFIX) == 0 && timestamp == NULL_TIMESTAMP)
-        {
-             const axlf *ap = reinterpret_cast<const axlf *>(top.data());
-             timestamp = ap->m_header.m_featureRomTimeStamp;
-        }	
         // Assume there is only 1 interface UUID is provided for BLP,
         // Show it as ID for flashing
         const axlf_section_header* dtbSection = xclbin::get_axlf_section(ap, PARTITION_METADATA);
@@ -370,16 +363,6 @@ bool DSAInfo::matchId(DSAInfo& dsa)
 }
 
 std::vector<DSAInfo> firmwareImage::installedDSA;
-
-void firmwareImage::clearInstalledDSAs()
-{
-    installedDSA.clear();
-}
-
-void firmwareImage::addToInstalledDSAs(DSAInfo& dInfo)
-{
-    installedDSA.push_back(dInfo);
-}
 
 std::vector<DSAInfo>& firmwareImage::getIntalledDSAs()
 {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -373,12 +373,12 @@ std::vector<DSAInfo> firmwareImage::installedDSA;
 
 void firmwareImage::clearInstalledDSAs()
 {
-  installedDSA.clear();
+    installedDSA.clear();
 }
 
 void firmwareImage::addToInstalledDSAs(DSAInfo& dInfo)
 {
-  installedDSA.push_back(dInfo);
+    installedDSA.push_back(dInfo);
 }
 
 std::vector<DSAInfo>& firmwareImage::getIntalledDSAs()

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -84,8 +84,6 @@ public:
     firmwareImage(const char *file, imageType type);
     ~firmwareImage();
     static std::vector<DSAInfo>& getIntalledDSAs();
-    static void clearInstalledDSAs();
-    static void addToInstalledDSAs(DSAInfo& dInfo);
 private:
     static std::vector<DSAInfo> installedDSA;
     int mType;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -34,6 +34,7 @@
 #define DSA_FILE_SUFFIX     "mcs"
 #define DSABIN_FILE_SUFFIX  "dsabin"
 #define XSABIN_FILE_SUFFIX  "xsabin"
+#define XCLBIN_FILE_SUFFIX  "xclbin"
 #define NULL_TIMESTAMP      0
 
 class DSAInfo
@@ -83,6 +84,8 @@ public:
     firmwareImage(const char *file, imageType type);
     ~firmwareImage();
     static std::vector<DSAInfo>& getIntalledDSAs();
+    static void clearInstalledDSAs();
+    static void addToInstalledDSAs(DSAInfo& dInfo);
 private:
     static std::vector<DSAInfo> installedDSA;
     int mType;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -342,8 +342,15 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
 	else if (!dsa.name.empty() && (vendor_id == dsa.vendor_id) && (device_id == dsa.device_id))
         {
             DSAs.push_back(dsa);
-        } else if (onBoard.name.empty())
+        } 
+  else if (onBoard.name.empty())
+        {
             DSAs.push_back(dsa);
+        } 
+  else if (dsa.file.find(XCLBIN_FILE_SUFFIX) != std::string::npos)
+        {
+            DSAs.push_back(dsa);
+        }
 
     }
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -339,15 +339,15 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
         {
             DSAs.push_back(dsa);
         }
-	else if (!dsa.name.empty() && (vendor_id == dsa.vendor_id) && (device_id == dsa.device_id))
+        else if (!dsa.name.empty() && (vendor_id == dsa.vendor_id) && (device_id == dsa.device_id))
         {
             DSAs.push_back(dsa);
         } 
-  else if (onBoard.name.empty())
+        else if (onBoard.name.empty())
         {
             DSAs.push_back(dsa);
         } 
-  else if (dsa.file.find(XCLBIN_FILE_SUFFIX) != std::string::npos)
+        else if (dsa.file.find(XCLBIN_FILE_SUFFIX) != std::string::npos)
         {
             DSAs.push_back(dsa);
         }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -331,7 +331,7 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
     {
         // std::cout << "DSA " << dsa.name << ": " << dsa.vendor << " " << dsa.board << " " << dsa.vendor_id << " " << dsa.device_id << "TS: " << dsa.timestamp << std::endl;
         if (!dsa.hasFlashImage || dsa.timestamp == NULL_TIMESTAMP)
-            continue;
+	       continue;
 
         if (!onBoard.vendor.empty() && !onBoard.board.empty() &&
             (onBoard.vendor == dsa.vendor) &&
@@ -339,14 +339,11 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
         {
             DSAs.push_back(dsa);
         }
-        else if (!dsa.name.empty() && (vendor_id == dsa.vendor_id) && (device_id == dsa.device_id))
+	else if (!dsa.name.empty() && (vendor_id == dsa.vendor_id) && (device_id == dsa.device_id))
         {
             DSAs.push_back(dsa);
-        } 
-        else if (onBoard.name.empty())
-        {
+        } else if (onBoard.name.empty())
             DSAs.push_back(dsa);
-        }
 
     }
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -331,7 +331,7 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
     {
         // std::cout << "DSA " << dsa.name << ": " << dsa.vendor << " " << dsa.board << " " << dsa.vendor_id << " " << dsa.device_id << "TS: " << dsa.timestamp << std::endl;
         if (!dsa.hasFlashImage || dsa.timestamp == NULL_TIMESTAMP)
-	       continue;
+            continue;
 
         if (!onBoard.vendor.empty() && !onBoard.board.empty() &&
             (onBoard.vendor == dsa.vendor) &&

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -346,10 +346,6 @@ std::vector<DSAInfo> Flasher::getInstalledDSA()
         else if (onBoard.name.empty())
         {
             DSAs.push_back(dsa);
-        } 
-        else if (dsa.file.find(XCLBIN_FILE_SUFFIX) != std::string::npos)
-        {
-            DSAs.push_back(dsa);
         }
 
     }


### PR DESCRIPTION
Added flat shell support  Implementation details are captured in following confluence page
https://confluence.xilinx.com/pages/viewpage.action?pageId=157601379#SupportforFlatshell(non-DFX)inXRT(PR-15989)-Development:


Overview:
- xbmgmt is updated to support xclbin flash

- Added a extra option --xclbin to xbmgmt

- Stopped loading bitstream in xclLoadXclbin if generated for flat shell
