### PR TITLE
Rename xrtKernelOpen to xrtPLKernelOpen

### DIFF
--- a/src/runtime_src/core/common/exec/kernel.cpp
+++ b/src/runtime_src/core/common/exec/kernel.cpp
@@ -638,7 +638,7 @@ send_exception_message(const char* msg)
 // xrt_kernel API implmentations (xrt_kernel.h)
 ////////////////////////////////////////////////////////////////
 xrtKernelHandle
-xrtKernelOpen(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
+xrtPLKernelOpen(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
 {
   try {
     return api::xrtKernelOpen(dhdl, xclbin, name, ip_context::access_mode::shared);
@@ -650,7 +650,7 @@ xrtKernelOpen(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
 }
 
 xrtKernelHandle
-xrtKernelOpenExclusive(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
+xrtPLKernelOpenExclusive(xrtDeviceHandle dhdl, const char* xclbin, const char *name)
 {
   try {
     return api::xrtKernelOpen(dhdl, xclbin, name, ip_context::access_mode::exclusive);

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -50,7 +50,7 @@ typedef void * xrtKernelHandle;
 typedef void * xrtRunHandle;
 
 /**
- * xrtKernelOpen() - Open a kernel and obtain its handle.
+ * xrtPLKernelOpen() - Open a PL kernel and obtain its handle.
  *
  * @deviceHandle:  Handle to the device with the kernel
  * @xclbin:        The xclbin with the specified kernel.
@@ -63,7 +63,7 @@ typedef void * xrtRunHandle;
  * The compute units are opened with shared access, meaning that 
  * other kernels and other process will have shared access to same
  * compute units.  If exclusive access is needed then open the 
- * kernel using @xrtKernelOpenExclusve().
+ * kernel using @xrtPLKernelOpenExclusve().
  *
  * An xclbin with the specified kernel must have been loaded prior
  * to calling this function. An XRT_NULL_HANDLE is returned on error
@@ -73,18 +73,18 @@ typedef void * xrtRunHandle;
  */
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
-xrtKernelOpen(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
+xrtPLKernelOpen(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
 
 /**
- * xrtKernelOpenExclusive() - Open a kernel and obtain its handle.
+ * xrtPLKernelOpenExclusive() - Open a PL kernel and obtain its handle.
  *
- * Same as @xrtKernelOpen(), but opens compute units with exclusive
+ * Same as @xrtPLKernelOpen(), but opens compute units with exclusive
  * access.  Fails if any compute unit is already opened with either
  * exclusive or shared access.
  */
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
-xrtKernelOpenExclusive(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
+xrtPLKernelOpenExclusive(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
 
 /**
  * xrtKernelClose() - Close an opened kernel

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -296,7 +296,7 @@ int run(int argc, char** argv)
 
   compute_units = cus = std::min(cus, compute_units);
   std::string kname = get_kernel_name(cus);
-  auto kernel = xrtKernelOpen(device, header.data(), kname.c_str());
+  auto kernel = xrtPLKernelOpen(device, header.data(), kname.c_str());
 
   run(device,kernel,jobs,secs,first_used_mem);
 


### PR DESCRIPTION
Prepare for different types of kernel to open.
Handle and runs remain unchanged, alas no other APIs need change.