### PR TITLE
adding u55n, u55c and u50lv device ID support

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2111,6 +2111,60 @@ struct xocl_subdev_map {
 		.board_name = "u50"					\
 	}
 
+#define	XOCL_BOARD_U55N_USER_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
+		.board_name = "u55n",					\
+		.subdev_info	= RES_USER_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
+	}
+
+#define	XOCL_BOARD_U55N_MGMT_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,                       \
+		.subdev_info	= RES_MGMT_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
+		.flash_type = FLASH_TYPE_SPI,				\
+		.sched_bin = "xilinx/sched_v20.bin",			\
+		.board_name = "u55n"					\
+	}
+
+#define	XOCL_BOARD_U55C_USER_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
+		.board_name = "u55c",					\
+		.subdev_info	= RES_USER_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
+	}
+
+#define	XOCL_BOARD_U55C_MGMT_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,                       \
+		.subdev_info	= RES_MGMT_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
+		.flash_type = FLASH_TYPE_SPI,				\
+		.sched_bin = "xilinx/sched_v20.bin",			\
+		.board_name = "u55c"					\
+	}
+
+#define	XOCL_BOARD_U50LV_USER_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
+		.board_name = "u50lv",					\
+		.subdev_info	= RES_USER_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
+	}
+
+#define	XOCL_BOARD_U50LV_MGMT_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP,                       \
+		.subdev_info	= RES_MGMT_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
+		.flash_type = FLASH_TYPE_SPI,				\
+		.sched_bin = "xilinx/sched_v20.bin",			\
+		.board_name = "u50lv"					\
+	}
+
 #define	XOCL_BOARD_U200_USER_RAPTOR2					\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
@@ -2445,6 +2499,33 @@ struct xocl_subdev_map {
 		.sched_bin = "xilinx/sched_u50.bin",		\
 	}
 
+#define	XOCL_BOARD_MGMT_U55N					\
+	(struct xocl_board_private){				\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
+		.subdev_info	= MGMT_RES_U50,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_U50),		\
+		.flash_type = FLASH_TYPE_SPI,			\
+		.sched_bin = "xilinx/sched_u50.bin",		\
+	}
+
+#define	XOCL_BOARD_MGMT_U55C					\
+	(struct xocl_board_private){				\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
+		.subdev_info	= MGMT_RES_U50,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_U50),		\
+		.flash_type = FLASH_TYPE_SPI,			\
+		.sched_bin = "xilinx/sched_u50.bin",		\
+	}
+
+#define	XOCL_BOARD_MGMT_U50LV					\
+	(struct xocl_board_private){				\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
+		.subdev_info	= MGMT_RES_U50,			\
+		.subdev_num = ARRAY_SIZE(MGMT_RES_U50),		\
+		.flash_type = FLASH_TYPE_SPI,			\
+		.sched_bin = "xilinx/sched_u50.bin",		\
+	}
+
 #define USER_RES_U50						\
 		((struct xocl_subdev_info []) {			\
 			XOCL_DEVINFO_FEATURE_ROM_U50,		\
@@ -2455,6 +2536,30 @@ struct xocl_subdev_map {
 		})
 
 #define	XOCL_BOARD_USER_U50					\
+	(struct xocl_board_private){				\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
+		.subdev_info	= USER_RES_U50,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_U50),		\
+		.p2p_bar_sz = 8, /* GB */			\
+	}
+
+#define	XOCL_BOARD_USER_U55N					\
+	(struct xocl_board_private){				\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
+		.subdev_info	= USER_RES_U50,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_U50),		\
+		.p2p_bar_sz = 8, /* GB */			\
+	}
+
+#define	XOCL_BOARD_USER_U55C					\
+	(struct xocl_board_private){				\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
+		.subdev_info	= USER_RES_U50,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_U50),		\
+		.p2p_bar_sz = 8, /* GB */			\
+	}
+
+#define	XOCL_BOARD_USER_U50LV					\
 	(struct xocl_board_private){				\
 		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,	\
 		.subdev_info	= USER_RES_U50,			\
@@ -2621,6 +2726,9 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5028, PCI_ANY_ID, MGMT_VERSAL) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5044, PCI_ANY_ID, MGMT_VERSAL) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5050, PCI_ANY_ID, MGMT_U25) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5058, PCI_ANY_ID, MGMT_U55N) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x505C, PCI_ANY_ID, MGMT_U55C) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5060, PCI_ANY_ID, MGMT_U50LV) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x006C, PCI_ANY_ID, MGMT_6A8F) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0078, PCI_ANY_ID, MGMT_XBB_DSA52) },  \
 	{ XOCL_PCI_DEVID(0x10EE, 0xE987, PCI_ANY_ID, XBB_MFG("samsung")) },\
@@ -2668,6 +2776,9 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x500D, PCI_ANY_ID, USER_DSA52_U280) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5021, PCI_ANY_ID, USER_U50) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5051, PCI_ANY_ID, USER_U25) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5059, PCI_ANY_ID, USER_U55N) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x505D, PCI_ANY_ID, USER_U55C) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x5061, PCI_ANY_ID, USER_U50LV) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0065, PCI_ANY_ID, USER_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0077, PCI_ANY_ID, USER_DSA52) },	\
 	{ XOCL_PCI_DEVID(0x1D0F, 0x1042, PCI_ANY_ID, USER_AWS) },	\
@@ -2728,6 +2839,31 @@ struct xocl_subdev_map {
 	{ 0x10EE, 0x5021, PCI_ANY_ID,					\
 		.vbnv = "xilinx_u50",		\
 		.priv_data = &XOCL_BOARD_U50_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 }, 				\
+	{ 0x10EE, 0x5058, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u55n",		\
+		.priv_data = &XOCL_BOARD_U55N_MGMT_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5059, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u55n",		\
+		.priv_data = &XOCL_BOARD_U55N_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x505C, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u55c",		\
+		.priv_data = &XOCL_BOARD_U55C_MGMT_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x505D, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u55c",		\
+		.priv_data = &XOCL_BOARD_U55C_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5060, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u50lv",		\
+		.priv_data = &XOCL_BOARD_U50LV_MGMT_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5061, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u50lv",		\
+		.priv_data = &XOCL_BOARD_U50LV_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 }
+
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1070,12 +1070,13 @@ xocl_fetch_dynamic_platform(struct xocl_dev_core *core,
 				strncpy(core->vbnv_cache, dsa_map[i].vbnv,
 					sizeof(core->vbnv_cache) - 1);
 				
-				// THIS NEXT PIECE OF CODE IS CRASHING THE WORKSTATION, replaced with below
-				//s = strstr(core->vbnv_cache, "_");
-				//s = strstr(s + 1, "_");
-				//strncpy(s, "_recovery",
-				//    sizeof(core->vbnv_cache) -
-				//    (s - core->vbnv_cache) - 1);
+				// THIS NEXT PIECE OF CODE IS CRASHING THE WORKSTATION, 
+				// replaced with alternate code below
+				// s = strstr(core->vbnv_cache, "_");
+				// s = strstr(s + 1, "_");
+				// strncpy(s, "_recovery",
+				//     sizeof(core->vbnv_cache) -
+				//     (s - core->vbnv_cache) - 1);
 				
 				// find end of vbnv string and append '_recovery'
 				s = strrchr(core->vbnv_cache, NULL);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1066,14 +1066,23 @@ xocl_fetch_dynamic_platform(struct xocl_dev_core *core,
 			dsa_map[i].subdevice == (u16)PCI_ANY_ID)) {
 			*in = dsa_map[i].priv_data;
 			if (ptype == XOCL_VSEC_PLAT_RECOVERY) {
+
 				strncpy(core->vbnv_cache, dsa_map[i].vbnv,
 					sizeof(core->vbnv_cache) - 1);
-				s = strstr(core->vbnv_cache, "_");
-				s = strstr(s + 1, "_");
-				strncpy(s, "_recovery",
-				    sizeof(core->vbnv_cache) -
-				    (s - core->vbnv_cache) - 1);
+				
+				// THIS NEXT PIECE OF CODE IS CRASHING THE WORKSTATION, replaced with below
+				//s = strstr(core->vbnv_cache, "_");
+				//s = strstr(s + 1, "_");
+				//strncpy(s, "_recovery",
+				//    sizeof(core->vbnv_cache) -
+				//    (s - core->vbnv_cache) - 1);
+				
+				// find end of vbnv string and append '_recovery'
+				s = strrchr(core->vbnv_cache, NULL);
+				strncpy(s, "_recovery", 9);
+
 				core->priv.vbnv = core->vbnv_cache;
+
 			} else
 				core->priv.vbnv = dsa_map[i].vbnv;
 		}


### PR DESCRIPTION
Added support for following device IDs to devices.h
u55n - 0x5058. 0x5059, no golden image, using BLP based recovery
u55c - 0x505C. 0x505D, no golden image, using BLP based recovery
u50lv - 0x5060. 0x5061, no golden image, using BLP based recovery
Change is verbose, i.e. largely replicated u50 tables. This could be condensed somewhat as all cards are raptor 2.0 and very similar to u50

Also fixed an issue in xocl_subdev.c. The code to append '_recovery' to the vbnv when VSEC platform info is XOCL_VSEC_PLAT_RECOVERY (0) was crashing the server.
