### PR TITLE
CR-1056045 hotplug does not work on SuSE linux

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -561,6 +561,7 @@ static int feature_rom_probe(struct platform_device *pdev)
 		return -ENOMEM;
 
 	rom->pdev =  pdev;
+	platform_set_drvdata(pdev, rom);
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (res == NULL) {
@@ -628,13 +629,12 @@ static int feature_rom_probe(struct platform_device *pdev)
 		rom->header.TimeSinceEpoch);
 	xocl_info(&pdev->dev, "FeatureBitMap: %llx", rom->header.FeatureBitMap);
 
-	platform_set_drvdata(pdev, rom);
-
 	return 0;
 
 failed:
 	if (rom->base)
 		iounmap(rom->base);
+	platform_set_drvdata(pdev, NULL);
 	devm_kfree(&pdev->dev, rom);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -1693,6 +1693,7 @@ static int qdma_probe(struct platform_device *pdev)
 	}
 
 	qdma->pdev = pdev;
+	platform_set_drvdata(pdev, qdma);
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
 	if (!res) {
@@ -1753,8 +1754,6 @@ static int qdma_probe(struct platform_device *pdev)
 	qdma->user_msix_mask = QDMA_USER_INTR_MASK;
 
 	spin_lock_init(&qdma->user_msix_table_lock);
-
-	platform_set_drvdata(pdev, qdma);
 
 	return 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -398,6 +398,7 @@ static int xdma_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
+	platform_set_drvdata(pdev, xdma);
 	ret = sysfs_create_group(&pdev->dev.kobj, &xdma_attr_group);
 	if (ret) {
 		xocl_err(&pdev->dev, "create attrs failed: %d", ret);
@@ -406,8 +407,6 @@ static int xdma_probe(struct platform_device *pdev)
 
 	mutex_init(&xdma->stat_lock);
 	mutex_init(&xdma->user_msix_table_lock);
-
-	platform_set_drvdata(pdev, xdma);
 
 	return 0;
 


### PR DESCRIPTION
platform_set_drvdata() should be called before sysfs entries are created, otherwise it is potential to have NULL pointer reference when sysfs is being accessed.