### PR TITLE
CR-1054185, CR-1054186

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
@@ -87,7 +87,7 @@ private:
         QSPIPS,
         OSPIVERSAL,
     };
-    const char *E_FlasherTypeStrings[4] = { "UNKNOWN", "SPI", "BPI", "QSPI_PS" };
+    const char *E_FlasherTypeStrings[5] = { "UNKNOWN", "SPI", "BPI", "QSPI_PS", "OSPI_VERSAL"};
     const char *getFlasherTypeText( E_FlasherType val ) { return E_FlasherTypeStrings[ val ]; }
     std::shared_ptr<pcidev::pci_device> mDev;
 


### PR DESCRIPTION
CR-1054185 UNKNOWN Flash type from xbmgmt flash scan
CR-1054186 Flashable partitions None with xbmgmt flash scan

Output:
```
Card [0000:b3:00.0]
    Card type:          vck5000-es1
    Flash type:         OSPI_VERSAL
    Flashable partition running on FPGA:
        xilinx_vck5000-es1_g3x16_201921_1,[ID=0x5e51824d],[SC=4.4]
    Flashable partitions installed in system:
        xilinx_vck5000-es1_g3x16_201921_1,[ID=0x5e51824d],[SC=4.4.4]
```
