### PR TITLE
CR-1057132: xocl qdma: add setting of stm register base during devive probe

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/libqdma_export.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/libqdma_export.h
@@ -230,6 +230,8 @@ struct qdma_dev_conf {
 	char bar_num_bypass;
 	/** STM bar, PF only */
 	char bar_num_stm;
+	/** STM bar register base */
+	unsigned int stm_reg_base;
 	/** user bar, PF only */
 	unsigned int qsets_base;
 	/** device index */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.c
@@ -745,7 +745,8 @@ int hw_indirect_stm_prog(struct xlnx_dma_dev *xdev, unsigned int qid_hw,
 		(addr << S_STM_CMD_ADDR) | (fid << S_STM_CMD_FID);
 
 	pr_debug("ctxt_cmd reg 0x%x, qid 0x%x, op 0x%x, fid 0x%x addr 0x%x -> 0x%08x.\n",
-		 STM_REG_BASE + STM_REG_IND_CTXT_CMD, qid_hw, op, fid, addr, v);
+		 xdev->conf.stm_reg_base + STM_REG_IND_CTXT_CMD, qid_hw, op,
+		 fid, addr, v);
 	writel(v, xdev->stm_regs + STM_REG_IND_CTXT_CMD);
 
 	if (op == STM_CSR_CMD_RD) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.h
@@ -656,7 +656,6 @@ struct qdma_c2h_cmpt_cmpl_status {
 #define S_C2H_CMPT_INT_STATE	1
 #define M_C2H_CMPT_INT_STATE	0x3U
 
-#define STM_REG_BASE			0x02000000
 #define STM_REG_IND_CTXT_DATA_BASE	0x0
 #define STM_REG_IND_CTXT_DATA3		0xC
 #define STM_REG_IND_CTXT_CMD		0x14

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/xdev.c
@@ -348,8 +348,8 @@ static int xdev_map_bars(struct xlnx_dma_dev *xdev, struct pci_dev *pdev)
 		resource_size_t bar_start;
 
 		bar_start = pci_resource_start(pdev, (int)xdev->conf.bar_num_stm);
-		xdev->stm_regs = ioremap_nocache(bar_start + STM_REG_BASE,
-				4096);
+		xdev->stm_regs = ioremap_nocache(bar_start +
+			       			xdev->conf.stm_reg_base, 4096);
 		if (!xdev->stm_regs) {
 			pr_warn("%s unable to map bar %d.\n",
 				xdev->conf.name, xdev->conf.bar_num_stm);
@@ -361,9 +361,10 @@ static int xdev_map_bars(struct xlnx_dma_dev *xdev, struct pci_dev *pdev)
 		if ((((rev >> 24) & 0xFF)!= 'S') ||
 			(((rev >> 16) & 0xFF) != 'T') ||
 			(((rev >> 8) & 0xFF) != 'M')) {
-			pr_err("%s: Unknown STM 0x%x, %c%c%c.\n",
-				xdev->conf.name, rev, (rev >> 24) & 0xFF,
-				(rev >> 16) & 0xFF, (rev >> 8) & 0xFF);
+			pr_err("%s: Unknown STM 0x%x, base 0x%x, %c%c%c.\n",
+				xdev->conf.name, xdev->conf.stm_reg_base,
+			       	rev, (rev >> 24) & 0xFF, (rev >> 16) & 0xFF,
+			       	(rev >> 8) & 0xFF);
 			iounmap(xdev->stm_regs);
 			xdev->stm_regs = NULL;
 			return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -1714,6 +1714,7 @@ static int qdma_probe(struct platform_device *pdev)
 	conf->qsets_max = QDMA_QSETS_MAX;
 	conf->bar_num_config = dma_bar;
 	conf->bar_num_stm = XDEV(xdev)->bar_idx;
+	conf->stm_reg_base = 0x02000000;
 
 	conf->fp_user_isr_handler = qdma_isr;
 	conf->uld = (unsigned long)qdma;


### PR DESCRIPTION
For CR-1057132