### PR TITLE
Removing dlclose to address a race condition

### DIFF
--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.cpp
@@ -24,7 +24,7 @@ namespace xdphalinterface {
   {
     if (handle != nullptr)
     {
-      xrt_core::dlclose(handle) ;
+      //xrt_core::dlclose(handle) ;
     }
   }
 

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -106,7 +106,7 @@ namespace xdplop {
       {
 	if (handle != nullptr)
 	{
-	  xrt_core::dlclose(handle) ;
+	  //xrt_core::dlclose(handle) ;
 	}
       }
     };

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -285,7 +285,7 @@ void load_xdp_kernel_debug()
     {
       if (handle != nullptr)
       {
-	xrt_core::dlclose(handle) ;
+	//xrt_core::dlclose(handle) ;
       }
     }
   };
@@ -330,7 +330,7 @@ void load_xdp_app_debug()
     {
       if (handle != nullptr)
       {
-	xrt_core::dlclose(handle) ;
+	//xrt_core::dlclose(handle) ;
       }
     }
   };


### PR DESCRIPTION
The destruction of static objects at program end is a race condition, and on CentOS causes dlclose to unload libraries before std::function objects are destroyed, causing seg faults.