### PR TITLE
xbmgmt2 control flow fixes

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -284,7 +284,8 @@ XBUtilities::wrap_paragraphs( const std::string & _unformattedString,
 void
 XBUtilities::parse_device_indices(std::vector<uint16_t> &device_indices, const std::string &device)
 {
-  if(boost::iequals(device, "all")) {
+  //if no device is passed or "all" is specified, parse all devices
+  if(boost::iequals(device, "all") || device.empty()) {
     ::verbose("Sub command : --device");
     //get all devices
     auto total = xrt_core::get_total_devices(false).first;
@@ -294,7 +295,7 @@ XBUtilities::parse_device_indices(std::vector<uint16_t> &device_indices, const s
     for(uint16_t i = 0; i < total; i++) {
       device_indices.push_back(i);
     }
-  } else if (!device.empty()) {
+  } else {
     ::verbose("Sub command : --device");
     using tokenizer = boost::tokenizer< boost::char_separator<char> >;
     boost::char_separator<char> sep(", ");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -491,7 +491,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 //                     Download the accelerator program for card 2
 //                       xbutil program -d 2 -p a.xclbin
 {
-  XBU::verbose("SubCommand: examine");
+  XBU::verbose("SubCommand: program");
 
   XBU::verbose("Option(s):");
   for (auto & aString : _options) {
@@ -589,7 +589,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   // get all device IDs to be processed
-  std::vector<uint16_t> device_indices; //instead of saving this, can we save Flasher objects?
+  if(device.empty())
+    throw xrt_core::error("Please specify a device using --device option");
+  std::vector<uint16_t> device_indices;
   XBU::parse_device_indices(device_indices, device);
 
   if (!update.empty()) {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -40,36 +40,38 @@ Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
 {
     std::string err;
     E_FlasherType type = E_FlasherType::UNKNOWN;
-    if (typeStr.empty())
-      typeStr = xrt_core::device_query<xrt_core::query::f_flash_type>(m_device);
-    if (typeStr.empty())
-      typeStr = xrt_core::device_query<xrt_core::query::flash_type>(m_device);
 
-    if (typeStr.empty())
-    {
-        getProgrammingTypeFromDeviceName(mFRHeader.VBNVName, type);
-    }
-    else if (typeStr.compare("spi") == 0)
-    {
+    // check various locations for flash_type 
+    try {
+        if (typeStr.empty())
+            typeStr = xrt_core::device_query<xrt_core::query::f_flash_type>(m_device);
+    } catch (...) {}
+    try {
+        if (typeStr.empty())
+          typeStr = xrt_core::device_query<xrt_core::query::flash_type>(m_device);
+    } catch (...) {}
+    try {
+        if (typeStr.empty())
+            getProgrammingTypeFromDeviceName(mFRHeader.VBNVName, type);
+    } catch (...) {}
+    
+    //map flash_tyoe str to E_FlasherType
+    if (typeStr.compare("spi") == 0) {
         type = E_FlasherType::SPI;
     }
-    else if (typeStr.compare("bpi") == 0)
-    {
+    else if (typeStr.compare("bpi") == 0) {
         type = E_FlasherType::BPI;
     }
-    else if (typeStr.find("qspi_ps") == 0)
-    {
+    else if (typeStr.find("qspi_ps") == 0) {
         // Use find() for this type of flash.
         // Since it have variations
         type = E_FlasherType::QSPIPS;
     }
-    else if (typeStr.compare("ospi_versal") == 0)
-    {
+    else if (typeStr.compare("ospi_versal") == 0) {
         type = E_FlasherType::OSPIVERSAL;
     }
-    else
-    {
-        std::cout << "Unknown flash type: " << typeStr << std::endl;
+    else {
+        throw xrt_core::error(boost::str(boost::format("Unknown flash type: %s") % typeStr));
     }
 
     return type;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -39,8 +39,9 @@
 /* 
  * map flash_tyoe str to E_FlasherType
  */
-void Flasher::typeStr_to_E_FlasherType(const std::string& typeStr, E_FlasherType &type)
+Flasher::E_FlasherType Flasher::typeStr_to_E_FlasherType(const std::string& typeStr)
 {    
+    E_FlasherType type = E_FlasherType::UNKNOWN;
     if (typeStr.compare("spi") == 0) {
         type = E_FlasherType::SPI;
     }
@@ -55,9 +56,7 @@ void Flasher::typeStr_to_E_FlasherType(const std::string& typeStr, E_FlasherType
     else if (typeStr.compare("ospi_versal") == 0) {
         type = E_FlasherType::OSPIVERSAL;
     }
-    else {
-        throw xrt_core::error(boost::str(boost::format("Unknown flash type: %s") % typeStr));
-    }
+    return type;
 }
 
 Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
@@ -81,7 +80,9 @@ Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
             getProgrammingTypeFromDeviceName(mFRHeader.VBNVName, type);
     } catch (...) {}
     
-    typeStr_to_E_FlasherType(typeStr, type);
+    type = typeStr_to_E_FlasherType(typeStr);
+    if(type == E_FlasherType::UNKNOWN)
+        throw xrt_core::error(boost::str(boost::format("Unknown flash type: %s") % typeStr));
 
    return type;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -209,14 +209,22 @@ int Flasher::getBoardInfo(BoardInfo& board)
     if (ret != 0)
         return ret;
 
+    std::string unassigned_mac = "FF:FF:FF:FF:FF:FF";
     board.mBMCVer = std::move(charVec2String(info[BDINFO_BMC_VER]));
-    board.mConfigMode = info[BDINFO_CONFIG_MODE][0];
-    board.mFanPresence = info[BDINFO_FAN_PRESENCE][0];
-    board.mMacAddr0 = std::move(charVec2String(info[BDINFO_MAC0]));
-    board.mMacAddr1 = std::move(charVec2String(info[BDINFO_MAC1]));
-    board.mMacAddr2 = std::move(charVec2String(info[BDINFO_MAC2]));
-    board.mMacAddr3 = std::move(charVec2String(info[BDINFO_MAC3]));
-    board.mMaxPower = int2PowerString(info[BDINFO_MAX_PWR][0]);
+    board.mConfigMode = info.find(BDINFO_CONFIG_MODE) != info.end() ?
+        info[BDINFO_CONFIG_MODE][0] : '\0';
+    board.mFanPresence = info.find(BDINFO_FAN_PRESENCE) != info.end() ?
+        info[BDINFO_FAN_PRESENCE][0] : '\0';
+    board.mMacAddr0 = charVec2String(info[BDINFO_MAC0]).compare(unassigned_mac) ? 
+        std::move(charVec2String(info[BDINFO_MAC0])) : std::move(std::string("Unassigned"));
+    board.mMacAddr1 = charVec2String(info[BDINFO_MAC1]).compare(unassigned_mac) ? 
+        std::move(charVec2String(info[BDINFO_MAC1])) : std::move(std::string("Unassigned"));
+    board.mMacAddr2 = charVec2String(info[BDINFO_MAC2]).compare(unassigned_mac) ? 
+        std::move(charVec2String(info[BDINFO_MAC2])) : std::move(std::string("Unassigned"));
+    board.mMacAddr3 = charVec2String(info[BDINFO_MAC3]).compare(unassigned_mac) ? 
+        std::move(charVec2String(info[BDINFO_MAC3])) : std::move(std::string("Unassigned"));
+    board.mMaxPower = info.find(BDINFO_MAX_PWR) != info.end() ?
+        int2PowerString(info[BDINFO_MAX_PWR][0]) : "N/A";
     board.mName = std::move(charVec2String(info[BDINFO_NAME]));
     board.mRev = std::move(charVec2String(info[BDINFO_REV]));
     board.mSerialNum = std::move(charVec2String(info[BDINFO_SN]));

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
@@ -87,6 +87,7 @@ private:
     };
     const char *E_FlasherTypeStrings[4] = { "UNKNOWN", "SPI", "BPI", "QSPI_PS" };
     const char *getFlasherTypeText( E_FlasherType val ) { return E_FlasherTypeStrings[ val ]; }
+    void typeStr_to_E_FlasherType(const std::string& typeStr, E_FlasherType &type); 
     std::shared_ptr<xrt_core::device> m_device;
 
     int getProgrammingTypeFromDeviceName(unsigned char name[], E_FlasherType &type );

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
@@ -87,7 +87,7 @@ private:
     };
     const char *E_FlasherTypeStrings[4] = { "UNKNOWN", "SPI", "BPI", "QSPI_PS" };
     const char *getFlasherTypeText( E_FlasherType val ) { return E_FlasherTypeStrings[ val ]; }
-    void typeStr_to_E_FlasherType(const std::string& typeStr, E_FlasherType &type); 
+    E_FlasherType typeStr_to_E_FlasherType(const std::string& typeStr); 
     std::shared_ptr<xrt_core::device> m_device;
 
     int getProgrammingTypeFromDeviceName(unsigned char name[], E_FlasherType &type );


### PR DESCRIPTION
- enforce device specification for xbmgmt2 program but not for xbmgmt2 scan (default is "all")

Eg:
   xbmgmt2 status --report=scan --device=all _[works]_
   xbmgmt2 status --report=scan _[works: reports for all devices]_
   xbmgmt2 program --update --device=all _[works]_
   xbmgmt2 program --update _[throws an error]_

- flash_type is present in many locations, so don't fail when not found. Look check all locations before throwing an error