### PR TITLE
XRT-289 Need to flash XSABIN file onto flash

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/flash.c
@@ -676,6 +676,9 @@ static int qspi_probe(struct xocl_flash *flash)
 {
 	int ret;
 
+	/* Probing on first flash only. */
+	flash->qspi_curr_slave = 0;
+
 	flash_set_ctrl(flash, QSPI_CR_INIT_STATE);
 
 	/* Find out fifo depth before any read/write operations. */
@@ -903,7 +906,7 @@ static bool is_valid_offset(struct xocl_flash *flash, loff_t off)
 	/* Assuming all flash are of the same size, we use
 	 * offset into flash 0 to perform boundary check. */
 	faddr.slave = 0;
-	return flash_faddr2offset(&faddr) < flash->flash_size;
+	return flash_faddr2offset(&faddr) <= flash->flash_size;
 }
 
 /*
@@ -920,10 +923,14 @@ flash_read(struct file *file, char __user *buf, size_t n, loff_t *off)
 
 	FLASH_INFO(flash, "reading 0x%lx bytes @0x%llx", n, *off);
 
-	if (n == 0 || !is_valid_offset(flash, *off + n)) {
+	if (!is_valid_offset(flash, *off)) {
 		FLASH_ERR(flash, "Can't read: out of boundary");
 		return -EINVAL;
 	}
+
+	if (n == 0 || *off == flash->flash_size)
+		return 0;
+	n = min(n, flash->flash_size - (size_t)*off);
 
 	page = vmalloc(FLASH_PAGE_SIZE);
 	if (page == NULL)
@@ -1223,10 +1230,22 @@ static ssize_t properties_show(struct device *dev,
 
 static DEVICE_ATTR_RO(properties);
 
+/* Show size of one chip. Double it for total size for dual chip platforms. */
+static ssize_t size_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_flash *flash = dev_get_drvdata(dev);
+
+	return sprintf(buf, "%ld\n", flash->flash_size);
+}
+
+static DEVICE_ATTR_RO(size);
+
 static struct attribute *flash_attrs[] = {
 	&dev_attr_bar_off.attr,
 	&dev_attr_flash_type.attr,
 	&dev_attr_properties.attr,
+	&dev_attr_size.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -43,8 +43,8 @@ const char *subCmdFlashUsage =
     "--shell --path file --card bdf [--type flash_type]\n"
     "--sc_firmware --path file --card bdf";
 
-#define fmt_str		"    "
-#define DEV_TIMEOUT	60
+#define fmt_str        "    "
+#define DEV_TIMEOUT    60
 
 static int scanDevices(bool verbose, bool json)
 {
@@ -179,7 +179,7 @@ static int updateSC(unsigned index, const char *file)
     dev->sysfs_put("", "shutdown", errmsg, "0\n");
     if (!errmsg.empty()) {
         std::cout << "ERROR: online userpf failed. Please warm reboot." << std::endl;
-	return ret;
+    return ret;
     }
 
     int wait = 0;
@@ -204,6 +204,7 @@ static int updateShell(unsigned index, std::string flashType,
 {
     std::shared_ptr<firmwareImage> pri;
     std::shared_ptr<firmwareImage> sec;
+    std::shared_ptr<firmwareImage> stripped;
 
     if (!flashType.empty()) {
         std::cout << "CAUTION: Overriding flash mode is not recommended. " <<
@@ -223,14 +224,19 @@ static int updateShell(unsigned index, std::string flashType,
     if (pri->fail())
         return -EINVAL;
 
+    stripped = std::make_shared<firmwareImage>(primary, STRIPPED_FIRMWARE);
+    if (stripped->fail())
+        stripped = nullptr;
+
     if (secondary != nullptr) {
         sec = std::make_shared<firmwareImage>(secondary,
             MCS_FIRMWARE_SECONDARY);
         if (sec->fail())
             sec = nullptr;
     }
-
-    return flasher.upgradeFirmware(flashType, pri.get(), sec.get());
+ 
+    return flasher.upgradeFirmware(flashType, pri.get(), sec.get(),
+        stripped.get());
 }
 
 // Reset shell to factory mode.
@@ -245,12 +251,12 @@ static int resetShell(unsigned index)
     if(!canProceed())
         return -ECANCELED;
 
-    return flasher.upgradeFirmware("", nullptr, nullptr);
+    return flasher.upgradeFirmware("", nullptr, nullptr, nullptr);
 }
 
 /* We do not take the risk to flash any bmc marked as UNKNOWN */
 static void isSameShellOrSC(DSAInfo& candidate, DSAInfo& current,
-	bool *same_dsa, bool *same_bmc)
+    bool *same_dsa, bool *same_bmc)
 {
     if (!current.name.empty()) {
         *same_dsa = (candidate.name == current.name &&
@@ -544,7 +550,7 @@ int flashXbutilFlashHandler(int argc, char *argv[])
             bmc = optarg;
             break;
         case 't':
-	    id = optarg;
+        id = optarg;
             break;
         case 'r':
             reset = true;
@@ -782,12 +788,90 @@ static int reset(int argc, char *argv[])
     return 0;
 }
 
+static int file(int argc, char *argv[])
+{
+    unsigned index = UINT_MAX;
+    const option opts[] = {
+        { "card", required_argument, nullptr, '0' },
+        { "input", required_argument, nullptr, '1' },
+        { "output", required_argument, nullptr, '2' },
+        { nullptr, 0, nullptr, 0 },
+    };
+    char *input_path = nullptr;
+    char *output_path = nullptr;
+
+    while (true) {
+        const auto opt = getopt_long(argc, argv, "", opts, nullptr);
+        if (opt == -1)
+            break;
+
+        switch (opt) {
+        case '0':
+            index = bdf2index(optarg);
+            if (index == UINT_MAX)
+                return -ENOENT;
+            break;
+        case '1':
+            input_path = optarg;
+            break;
+        case '2':
+            output_path = optarg;
+            break;
+        default:
+            return -EINVAL;
+        }
+    }
+
+    if ((input_path == nullptr) == (output_path == nullptr)) {
+        std::cout << "Specify input or output file path" << std::endl;
+        return -EINVAL;
+    }
+
+    Flasher flasher(index);
+    if(!flasher.isValid())
+        return -EINVAL;
+
+    if (input_path) {
+        std::ifstream ifs(input_path, std::ifstream::binary);
+        if (!ifs.good()) {
+            std::cout << "invalid input path: " << input_path << std::endl;
+            return -EINVAL;
+        }
+        ifs.seekg(0, ifs.end);
+        size_t len = ifs.tellg();
+        ifs.seekg(0, ifs.beg);
+        std::vector<unsigned char> data(len);
+        ifs.read(reinterpret_cast<char *>(data.data()), len);
+        return flasher.writeData(data);
+    }
+
+    if (output_path) {
+        std::ofstream ofs(output_path,
+            std::ofstream::binary | std::ofstream::trunc);
+        if (!ofs.good()) {
+            std::cout << "invalid output path: " << output_path << std::endl;
+            return -EINVAL;
+        }
+        std::vector<unsigned char> data;
+        int ret = flasher.readData(data);
+        if (ret) {
+            std::cout << "failed to read data from flash: " << std::endl;
+            return ret;
+        }
+        ofs.write(reinterpret_cast<char *>(data.data()), data.size());
+        return 0;
+    }
+
+    return 0;
+}
+
 static const std::map<std::string, std::function<int(int, char **)>> optList = {
     { "--scan", scan },
     { "--update", update },
     { "--shell", shell },
     { "--sc_firmware", sc },
     { "--factory_reset", reset },
+    { "--file", file },
 };
 
 int flashHandler(int argc, char *argv[])

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -76,6 +76,7 @@ enum imageType
     BMC_FIRMWARE,
     MCS_FIRMWARE_PRIMARY,
     MCS_FIRMWARE_SECONDARY,
+    STRIPPED_FIRMWARE,
 };
 
 class firmwareImage : public std::istringstream

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -74,7 +74,7 @@ Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
  * upgradeFirmware
  */
 int Flasher::upgradeFirmware(const std::string& flasherType,
-    firmwareImage *primary, firmwareImage *secondary)
+    firmwareImage *primary, firmwareImage *secondary, firmwareImage *stripped)
 {
     int retVal = -EINVAL;
     E_FlasherType type = getFlashType(flasherType);
@@ -90,11 +90,11 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         }
         else if(secondary == nullptr)
         {
-            retVal = xspi.xclUpgradeFirmware1(*primary);
+            retVal = xspi.xclUpgradeFirmware1(*primary, stripped);
         }
         else
         {
-            retVal = xspi.xclUpgradeFirmware2(*primary, *secondary);
+            retVal = xspi.xclUpgradeFirmware2(*primary, *secondary, stripped);
         }
         break;
     }
@@ -399,4 +399,16 @@ std::string Flasher::sGetDBDF()
     sprintf(cDBDF, "%.4x:%.2x:%.2x.%.1x",
         mDev->domain, mDev->bus, mDev->dev, mDev->func);
     return std::string(cDBDF);
+}
+
+int Flasher::readData(std::vector<unsigned char>& data)
+{
+    XSPI_Flasher xspi(mDev);
+    return xspi.xclReadData(data);
+}
+
+int Flasher::writeData(std::vector<unsigned char>& data)
+{
+    XSPI_Flasher xspi(mDev);
+    return xspi.xclWriteData(data);
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
@@ -69,7 +69,7 @@ class Flasher
 {
 public:
     Flasher(unsigned int index);
-    int upgradeFirmware(const std::string& typeStr, firmwareImage* primary, firmwareImage* secondary);
+    int upgradeFirmware(const std::string& typeStr, firmwareImage* primary, firmwareImage* secondary, firmwareImage* stripped);
     int upgradeBMCFirmware(firmwareImage* bmc);
     bool isValid(void) { return mDev != nullptr; }
 
@@ -78,6 +78,9 @@ public:
     DSAInfo getOnBoardDSA();
     std::vector<DSAInfo> getInstalledDSA();
     int getBoardInfo(BoardInfo& board);
+
+    int readData(std::vector<unsigned char>& data);
+    int writeData(std::vector<unsigned char>& data);
 
 private:
     enum E_FlasherType {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -518,12 +518,13 @@ int XSPI_Flasher::xclTestXSpi(int index)
 }
 
 //Method for updating QSPI (expects 1 MCS files)
-int XSPI_Flasher::xclUpgradeFirmware1(std::istream& mcsStream1) {
+int XSPI_Flasher::xclUpgradeFirmware1(std::istream& mcsStream1,
+    std::istream* stripped) {
     int status = 0;
     uint32_t bitstream_start_loc = 0, bitstream_shift_addr = 0;
 
     if (mFlashDev)
-        return upgradeFirmware1Drv(mcsStream1);
+        return upgradeFirmware1Drv(mcsStream1, stripped);
     
     //Parse MCS file for first flash device 
     status = parseMCS(mcsStream1);
@@ -571,7 +572,8 @@ int XSPI_Flasher::xclUpgradeFirmware1(std::istream& mcsStream1) {
 
 
 //Method for updating dual QSPI (expects 2 MCS files)
-int XSPI_Flasher::xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mcsStream2) {
+int XSPI_Flasher::xclUpgradeFirmware2(std::istream& mcsStream1,
+    std::istream& mcsStream2, std::istream* stripped) {
     int status = 0;
     uint32_t bitstream_start_loc = 0, bitstream_shift_addr = 0;
 
@@ -581,7 +583,7 @@ int XSPI_Flasher::xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mc
     }
 
     if (mFlashDev)
-        return upgradeFirmware2Drv(mcsStream1, mcsStream2);
+        return upgradeFirmware2Drv(mcsStream1, mcsStream2, stripped);
 
     //Parse MCS file for first flash device 
     status = parseMCS(mcsStream1);
@@ -1818,6 +1820,23 @@ static int writeToFlash(std::FILE *flashDev, int slave,
     return ret;
 }
 
+static int readFromFlash(std::FILE *flashDev, int slave,
+    const unsigned int address, unsigned char *buf, size_t len)
+{
+    int ret = 0;
+    long addr = toAddr(slave, address);
+
+    ret = std::fseek(flashDev, addr, SEEK_SET);
+    if (ret)
+        return ret;
+
+    std::fread(buf, 1, len, flashDev);
+    if (ferror(flashDev))
+        ret = -errno;
+
+    return ret;
+}
+
 static int installBitstreamGuard(pcidev::pci_device *dev, std::FILE *flashDev,
     uint32_t address)
 {
@@ -2121,7 +2140,8 @@ static int programXSpiDrv(std::FILE *mFlashDev, std::istream& mcsStream,
     return 0;
 }
 
-int XSPI_Flasher::upgradeFirmware1Drv(std::istream& mcsStream)
+int XSPI_Flasher::upgradeFirmware1Drv(std::istream& mcsStream,
+    std::istream* stripped)
 {
     int ret = 0;
     uint32_t bsGuardAddr;
@@ -2138,6 +2158,17 @@ int XSPI_Flasher::upgradeFirmware1Drv(std::istream& mcsStream)
     if (ret)
         return ret;
 
+    // Persist non-bitstream part of firmware, should happen before we
+    // start writing bitstream, so that we don't corrupt bitstream.
+    if (stripped) {
+        std::vector<unsigned char> data{
+            std::istreambuf_iterator<char>(*stripped),
+            std::istreambuf_iterator<char>()};
+        ret = xclWriteData(data);
+        if (ret)
+            return ret;
+    }
+
     // Write MCS
     ret = programXSpiDrv(mFlashDev, mcsStream, 0, bitstreamGuardSize);
     if (ret)
@@ -2148,7 +2179,7 @@ int XSPI_Flasher::upgradeFirmware1Drv(std::istream& mcsStream)
 }
 
 int XSPI_Flasher::upgradeFirmware2Drv(std::istream& mcsStream0,
-    std::istream& mcsStream1)
+    std::istream& mcsStream1, std::istream* stripped)
 {
     int ret = 0;
     uint32_t bsGuardAddr;
@@ -2169,6 +2200,17 @@ int XSPI_Flasher::upgradeFirmware2Drv(std::istream& mcsStream0,
     if (ret)
         return ret;
 
+    // Persist non-bitstream part of firmware, should happen before we
+    // start writing bitstream, so that we don't corrupt bitstream.
+    if (stripped) {
+        std::vector<unsigned char> data{
+            std::istreambuf_iterator<char>(*stripped),
+            std::istreambuf_iterator<char>()};
+        ret = xclWriteData(data);
+        if (ret)
+            return ret;
+    }
+
     // Write MCS
     ret = programXSpiDrv(mFlashDev, mcsStream0, 0, bitstreamGuardSize);
     if (ret)
@@ -2179,4 +2221,128 @@ int XSPI_Flasher::upgradeFirmware2Drv(std::istream& mcsStream0,
 
     // Disable bitstream guard.
     return removeBitstreamGuard(mDev.get(), mFlashDev, bsGuardAddr);
+}
+
+const std::string magic = "XRTDATA";
+struct flash_data_header {
+    char magic[7] = "";
+    char ver = 0;
+    uint32_t data_len = 0;
+    uint32_t parity = 0;
+};
+// Max file data length can be saved on flash
+static const size_t xrt_max_data_len = 1024 * 1024;
+
+static size_t getFlashSize(pcidev::pci_device* dev)
+{
+    std::string err;
+    size_t size;
+
+    dev->sysfs_get<size_t>("flash", "size", err, size, 0);
+    if (size == 0)
+        std::cout << "can't detect flash size: " << err << std::endl;
+    return size;
+}
+
+static uint32_t getParity32(std::vector<unsigned char>& data)
+{
+    uint32_t parity = 0;
+
+    for (size_t len = 0; len < data.size(); len += 4) {
+        uint32_t tmp;
+        std::memcpy(&tmp, data.data() + len, std::min(4ul, data.size() - len));
+        parity ^= tmp;
+    }
+    return parity;
+}
+
+int XSPI_Flasher::xclWriteData(std::vector<unsigned char>& data)
+{
+    const int flash_index = 0;
+
+    if (mFlashDev == nullptr)
+        return -EINVAL;
+
+    if (data.size() > xrt_max_data_len) {
+        std::cout << "meta data is too big (" << data.size() << "B) to flash: "
+            << std::endl;
+        return -EINVAL;
+    }
+
+    size_t size = getFlashSize(mDev.get());
+    if (size == 0)
+        return -EINVAL;
+
+    // Write file data onto flash
+    unsigned int addr = size - sizeof(flash_data_header) - data.size();
+    int ret = writeToFlash(mFlashDev, flash_index, addr,
+        data.data(), data.size());
+    if (ret) {
+        std::cout << "failed to write meta data to flash: " << ret << std::endl;
+        return ret;
+    }
+
+    // Write meta data onto flash
+    flash_data_header header;
+    std::memcpy(header.magic, magic.c_str(), magic.size());
+    header.ver = 0;
+    header.data_len = data.size();
+    header.parity = getParity32(data);
+    addr += data.size();
+    ret = writeToFlash(mFlashDev, flash_index, addr,
+        reinterpret_cast<unsigned char *>(&header), sizeof(header));
+    if (ret) {
+        std::cout << "failed to write meata data header to flash: " << ret
+            << std::endl;
+        return ret;
+    }
+
+    std::cout << "Persisted " << data.size() << " bytes of meta data to flash "
+        << flash_index << " @0x" << std::hex << addr << std::dec << std::endl;
+    return 0;
+}
+
+int XSPI_Flasher::xclReadData(std::vector<unsigned char>& data)
+{
+    const int flash_index = 0;
+
+    if (mFlashDev == nullptr)
+        return -EINVAL;
+
+    size_t size = getFlashSize(mDev.get());
+    if (size == 0)
+        return -EINVAL;
+
+    // Read meta data from flash
+    flash_data_header header;
+    unsigned int addr = size - sizeof(header);
+    std::cout << "reading " << sizeof(header) << " bytes of header from flash "
+        << flash_index << " @0x" << std::hex << addr << std::dec << std::endl;
+    int ret = readFromFlash(mFlashDev, flash_index, addr,
+        reinterpret_cast<unsigned char *>(&header), sizeof(header));
+    if (ret) {
+        std::cout << "failed to read header from flash: " << ret << std::endl;
+        return ret;
+    }
+    if (std::memcmp(header.magic, magic.c_str(), magic.size())) {
+        std::cout << "bad header magic: " << header.magic << std::endl;
+        return -EINVAL;
+    }
+
+    // Read file data from flash
+    data.resize(header.data_len);
+    addr -= header.data_len;
+    std::cout << "reading " << header.data_len << " bytes of data from flash "
+        << flash_index << " @0x" << std::hex << addr << std::dec << std::endl;
+    ret = readFromFlash(mFlashDev, flash_index, addr, data.data(), data.size());
+    if (ret) {
+        std::cout << "failed to read data from flash: " << ret << std::endl;
+        return ret;
+    }
+    if (header.parity ^ getParity32(data)) {
+        std::cout << "data is corrupted" << std::endl;
+        return -EINVAL;
+    }
+
+    return 0;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -1830,9 +1830,11 @@ static int readFromFlash(std::FILE *flashDev, int slave,
     if (ret)
         return ret;
 
-    std::fread(buf, 1, len, flashDev);
+    size_t read = std::fread(buf, 1, len, flashDev);
     if (ferror(flashDev))
         ret = -errno;
+    if (read != len)
+        ret = -EIO;
 
     return ret;
 }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.h
@@ -41,9 +41,13 @@ class XSPI_Flasher
 public:
     XSPI_Flasher(std::shared_ptr<pcidev::pci_device> dev);
     ~XSPI_Flasher();
-    int xclUpgradeFirmware1(std::istream& mcsStream1);
-    int xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mcsStream2);
+    int xclUpgradeFirmware1(std::istream& mcsStream1, std::istream* stripped);
+    int xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mcsStream2,
+        std::istream* stripped);
     int revertToMFG(void);
+
+    int xclReadData(std::vector<unsigned char>& data);
+    int xclWriteData(std::vector<unsigned char>& data);
 
 private:
     std::shared_ptr<pcidev::pci_device> mDev;
@@ -75,8 +79,9 @@ private:
     unsigned getSector(unsigned address);
 
     // Upgrade firmware via driver.
-    int upgradeFirmware1Drv(std::istream& mcsStream1);
-    int upgradeFirmware2Drv(std::istream& mcsStream1, std::istream& mcsStream2);
+    int upgradeFirmware1Drv(std::istream& mcsStream1, std::istream* stripped);
+    int upgradeFirmware2Drv(std::istream& mcsStream1, std::istream& mcsStream2,
+        std::istream* stripped);
 };
 
 #endif


### PR DESCRIPTION
This change set implement the feature to flash a stripped version of dsabin onto flash together with the MCS bitstream.

In order to test this code path, xbmgmt flash --file option is added to be able to write content of a file onto flash and read it back. Note that this option is for developer use. There is no guarantee that it will not corrupt the bitstream on the flash if it's used to write data.

The data (stripped version of dsabin or content of a plain file) is saved on flash at the very end (of the first chip). There should be some tens of MB of free space in this area based on today's shell size and flash size. This implementation limited the data size to be at most 1MB anyway just to be safe. If the data is corrupted by bitstream, it should be easy to detect since we have parity and magic words in meta data on the flash.