### PR TITLE
Move loader script to unwrapped dir

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -33,7 +33,7 @@ while [ $# -gt 0 ]; do
 done
 
 # -- Find and call the loader
-XRT_LOADER="`dirname \"$0\"`/loader"
+XRT_LOADER="`dirname \"$0\"`/unwrapped/loader"
 
 if [ ! -f "$XRT_LOADER" ]; then
   echo "ERROR: Could not find 64-bit loader executable."

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.bat
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.bat
@@ -28,7 +28,7 @@ set XRTWRAP_PROG_ARGS=
   :argsParsed
 
 REM -- Find and call the loader
-set XRT_LOADER=%~dp0loader.bat
+set XRT_LOADER=%~dp0unwrapped/loader.bat
 
 if not exist %XRT_LOADER%  (
   echo ERROR: Could not find 64-bit loader executable.

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -34,7 +34,7 @@ while [ $# -gt 0 ]; do
 done
 
 # -- Find and call the loader
-XRT_LOADER="`dirname \"$0\"`/loader"
+XRT_LOADER="`dirname \"$0\"`/unwrapped/loader"
 
 if [ ! -f "$XRT_LOADER" ]; then
   echo "ERROR: Could not find 64-bit loader executable."

--- a/src/runtime_src/core/tools/xbutil2/xbutil.bat
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.bat
@@ -29,7 +29,7 @@ set XRTWRAP_PROG_ARGS=
 
 
 REM -- Find and call the loader
-set XRT_LOADER=%~dp0loader.bat
+set XRT_LOADER=%~dp0unwrapped/loader.bat
 
 if not exist %XRT_LOADER%  (
   echo ERROR: Could not find 64-bit loader executable.

--- a/src/runtime_src/tools/scripts/CMakeLists.txt
+++ b/src/runtime_src/tools/scripts/CMakeLists.txt
@@ -4,20 +4,23 @@ set(XRT_SETUP_SCRIPTS
   setup.sh
   setup.csh)
 
+set(XRT_LOADER_SCRIPTS
+  loader)
+
 set (XRT_SCRIPTS
   xrtdeps.sh
-  plp_program.sh
-  loader)
+  plp_program.sh)
 
 else()
 
 set(XRT_SETUP_SCRIPTS
   setup.bat)
 
-set (XRT_SCRIPTS
+set (XRT_LOADER_SCRIPTS
   loader.bat)
 
 endif(NOT WIN32)
 
 install (PROGRAMS ${XRT_SCRIPTS} DESTINATION ${XRT_INSTALL_BIN_DIR})
+install (PROGRAMS ${XRT_LOADER_SCRIPTS} DESTINATION ${XRT_INSTALL_UNWRAPPED_DIR})
 install (FILES ${XRT_SETUP_SCRIPTS} DESTINATION ${XRT_INSTALL_DIR})

--- a/src/runtime_src/tools/scripts/loader
+++ b/src/runtime_src/tools/scripts/loader
@@ -30,7 +30,7 @@ if [ -z "${XRT_EXEC}" ]; then
   exit 1
 fi
 
-XRT_PROG_UNWRAPPED="`dirname \"$0\"`/unwrapped/${XRT_EXEC}"
+XRT_PROG_UNWRAPPED="`dirname \"$0\"`/${XRT_EXEC}"
 if [ ! -f "${XRT_PROG_UNWRAPPED}" ]; then
   echo "ERROR: Could not find -exec program: ${XRT_EXEC}"
   echo "ERROR: ${XRT_PROG_UNWRAPPED} does not exist"
@@ -38,7 +38,7 @@ if [ ! -f "${XRT_PROG_UNWRAPPED}" ]; then
 fi
 
 # -- Find the setup script and configure environment
-XRT_SETUP_SCRIPT="`dirname \"$0\"`/../setup.sh"
+XRT_SETUP_SCRIPT="`dirname \"$0\"`/../../setup.sh"
 
 if [ ! -f "$XRT_SETUP_SCRIPT" ]; then
   echo "ERROR: Could not find XRT setup script."

--- a/src/runtime_src/tools/scripts/loader.bat
+++ b/src/runtime_src/tools/scripts/loader.bat
@@ -37,7 +37,7 @@ if [%XRT_EXEC%] == [] (
   GOTO:EOF
 )
 
-set XRT_PROG_UNWRAPPED=%~dp0unwrapped\%XRT_EXEC%.exe
+set XRT_PROG_UNWRAPPED=%~dp0\%XRT_EXEC%.exe
 if not exist %XRT_PROG_UNWRAPPED% (
   echo ERROR: Could not find -exec program: %XRT_EXEC%
   echo ERROR: %XRT_PROG_UNWRAPPED% does not exist"
@@ -45,7 +45,7 @@ if not exist %XRT_PROG_UNWRAPPED% (
 )
 
 REM -- Find the setup script and configure environment
-set XRT_SETUP_SCRIPT=%~dp0..\setup.bat
+set XRT_SETUP_SCRIPT=%~dp0..\..\setup.bat
 
 if not exist %XRT_SETUP_SCRIPT% (
   echo ERROR: Could not find XRT setup script.


### PR DESCRIPTION
This works around clash with Vivado loader script, which unfortunately
are not called with absolute path but instead picked from PATH.