### PR TITLE
XRT-310 Introduce calibration storage sub device

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -154,6 +154,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/subdev/memory_hbm.c
   xocl/subdev/ddr_srsr.c
   xocl/subdev/ulite.c
+  xocl/subdev/calib_storage.c
   xocl/Makefile
   )
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -208,6 +208,7 @@ enum {
 #define	XOCL_MIG_HBM		"mig.hbm"
 #define	XOCL_SRSR		"srsr"
 #define	XOCL_UARTLITE		"ulite"
+#define	XOCL_CALIB_STORAGE      "calib_storage"
 
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
@@ -245,6 +246,7 @@ enum subdev_id {
 	XOCL_SUBDEV_TRACE_S2MM,
 	XOCL_SUBDEV_SRSR,
 	XOCL_SUBDEV_UARTLITE,
+	XOCL_SUBDEV_CALIB_STORAGE,
 	XOCL_SUBDEV_NUM
 };
 
@@ -704,7 +706,20 @@ struct xocl_subdev_map {
 		XOCL_RES_SRSR,				\
 		ARRAY_SIZE(XOCL_RES_SRSR),		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
+		.override_idx = -1,			\
 	}
+
+
+#define	XOCL_DEVINFO_CALIB_STORAGE			\
+	{						\
+		XOCL_SUBDEV_CALIB_STORAGE,		\
+		XOCL_CALIB_STORAGE,			\
+		NULL,					\
+		0,					\
+		.level = XOCL_SUBDEV_LEVEL_PRP,		\
+		.override_idx = -1,			\
+	}
+
 
 #define	XOCL_MAILBOX_OFFSET_MGMT	0x210000
 #define	XOCL_RES_MAILBOX_MGMT				\
@@ -2412,6 +2427,7 @@ struct xocl_subdev_map {
 		XOCL_DEVINFO_IORES_MGMT_DYN,			\
 	 	XOCL_DEVINFO_FLASH_BLP,				\
 		XOCL_DEVINFO_FMGR,				\
+		XOCL_DEVINFO_CALIB_STORAGE,			\
 	})
 
 #define	XOCL_BOARD_MGMT_DYNAMIC_IP					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -45,6 +45,7 @@ xclmgmt-y := \
 	../subdev/ddr_srsr.o \
 	../subdev/memory_hbm.o \
 	../subdev/ulite.o \
+	../subdev/calib_storage.o \
 	mgmt-core.o \
 	mgmt-cw.o \
 	mgmt-utils.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1309,6 +1309,7 @@ static int (*drv_reg_funcs[])(void) __initdata = {
 	xocl_init_srsr,
 	xocl_init_mem_hbm,
 	xocl_init_ulite,
+	xocl_init_calib_storage,
 };
 
 static void (*drv_unreg_funcs[])(void) = {
@@ -1336,6 +1337,7 @@ static void (*drv_unreg_funcs[])(void) = {
 	xocl_fini_srsr,
 	xocl_fini_mem_hbm,
 	xocl_fini_ulite,
+	xocl_fini_calib_storage,
 };
 
 static int __init xclmgmt_init(void)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/calib_storage.c
@@ -1,0 +1,201 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: Chien-Wei Lan <chienwei@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <linux/vmalloc.h>
+#include "../xocl_drv.h"
+#include "mgmt-ioctl.h"
+
+struct calib_cache {
+	uint64_t	mem_id;
+	char		*data;
+};
+
+struct calib_storage {
+	struct device		*dev;
+	struct mutex		lock;
+	struct calib_cache	**cache;
+	uint32_t		cache_num;
+};
+
+static int calib_storage_save_by_idx(struct platform_device *pdev, uint32_t idx)
+{
+	struct calib_storage *calib_storage = platform_get_drvdata(pdev);
+	int err = 0;
+
+	BUG_ON(!calib_storage->cache);
+
+	calib_storage->cache[idx] = vzalloc(sizeof(struct calib_cache));
+	if (!calib_storage->cache[idx]) {
+		err = -ENOMEM;
+		goto done;
+	}
+
+	calib_storage->cache[idx]->data = vzalloc(XOCL_CALIB_CACHE_SIZE);
+	if (!calib_storage->cache[idx]->data) {
+		err = -ENOMEM;
+		goto done;
+	}
+
+done:
+	if (err) {
+		vfree(calib_storage->cache[idx]->data);
+		vfree(calib_storage->cache[idx]);
+		calib_storage->cache[idx] = NULL;
+	}
+	return err;
+}
+
+static void calib_cache_clean(struct platform_device *pdev)
+{
+	int i = 0;
+	struct calib_storage *calib_storage = platform_get_drvdata(pdev);
+
+	if (!calib_storage)
+		return;
+
+	mutex_lock(&calib_storage->lock);
+
+	if (!calib_storage->cache)
+		goto done;
+
+	for (; i < calib_storage->cache_num; ++i) {
+		if (!calib_storage->cache[i])
+			continue;
+
+		vfree(calib_storage->cache[i]->data);
+		vfree(calib_storage->cache[i]);
+		calib_storage->cache[i] = NULL;
+	}
+done:
+	mutex_unlock(&calib_storage->lock);
+}
+
+static int calib_storage_save(struct platform_device *pdev)
+{
+	struct calib_storage *calib_storage = platform_get_drvdata(pdev);
+	int err = 0;
+	uint32_t i = 0;
+
+	if (err)
+		return err;
+
+	calib_cache_clean(pdev);
+
+	mutex_lock(&calib_storage->lock);
+
+	for (; i < calib_storage->cache_num; ++i)
+		err = calib_storage_save_by_idx(pdev, i);
+
+	mutex_unlock(&calib_storage->lock);
+	return err;
+}
+
+static int calib_storage_restore(struct platform_device *pdev)
+{
+	struct calib_storage *calib_storage = platform_get_drvdata(pdev);
+	int err = 0;
+	uint32_t i = 0;
+
+	mutex_lock(&calib_storage->lock);
+
+	BUG_ON(!calib_storage->cache);
+	BUG_ON(!calib_storage->cache_num);
+
+	for (; i < calib_storage->cache_num; ++i) {
+		if (!calib_storage->cache[i])
+			continue;
+	}
+
+	mutex_unlock(&calib_storage->lock);
+	return err;
+}
+
+
+static struct calib_storage_funcs calib_storage_ops = {
+	.save = calib_storage_save,
+	.restore = calib_storage_restore,
+};
+
+static int calib_storage_probe(struct platform_device *pdev)
+{
+	struct calib_storage *calib_storage;
+	int err = 0;
+
+	calib_storage = devm_kzalloc(&pdev->dev, sizeof(*calib_storage), GFP_KERNEL);
+	if (!calib_storage)
+		return -ENOMEM;
+	
+	calib_storage->cache = vzalloc(MAX_M_COUNT*sizeof(struct calib_cache *));
+	if (!calib_storage->cache) {
+		return -ENOMEM;
+	}
+
+	calib_storage->cache_num = MAX_M_COUNT;
+
+	calib_storage->dev = &pdev->dev;
+
+	mutex_init(&calib_storage->lock);
+	platform_set_drvdata(pdev, calib_storage);
+
+	return err;
+}
+
+
+static int calib_storage_remove(struct platform_device *pdev)
+{
+	struct calib_storage *calib_storage = platform_get_drvdata(pdev);
+
+	if (!calib_storage) {
+		xocl_err(&pdev->dev, "driver data is NULL");
+		return -EINVAL;
+	}
+	calib_cache_clean(pdev);
+	vfree(calib_storage->cache);
+
+	platform_set_drvdata(pdev, NULL);
+	devm_kfree(&pdev->dev, calib_storage);
+
+	return 0;
+}
+
+struct xocl_drv_private calib_storage_priv = {
+	.ops = &calib_storage_ops,
+};
+
+struct platform_device_id calib_storage_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_CALIB_STORAGE), (kernel_ulong_t)&calib_storage_priv },
+	{ },
+};
+
+static struct platform_driver	calib_storage_driver = {
+	.probe		= calib_storage_probe,
+	.remove		= calib_storage_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_CALIB_STORAGE),
+	},
+	.id_table = calib_storage_id_table,
+};
+
+int __init xocl_init_calib_storage(void)
+{
+	return platform_driver_register(&calib_storage_driver);
+}
+
+void xocl_fini_calib_storage(void)
+{
+	platform_driver_unregister(&calib_storage_driver);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1956,10 +1956,9 @@ static int icap_create_post_download_subdevs(struct platform_device *pdev, struc
 
 		if (ip->m_type == IP_DDR4_CONTROLLER && !strncasecmp(ip->m_name, "SRSR", 4)) {
 			struct xocl_subdev_info subdev_info = XOCL_DEVINFO_SRSR;
-			uint32_t target_m_type = MEM_DDR4;
 
 			/* hardcoded, to find a global*/
-			memidx = icap_get_memidx(mem_topo, target_m_type, ip->properties-4);
+			memidx = icap_get_memidx(mem_topo, ip->m_type, ip->properties-4);
 			if (memidx == INVALID_MEM_IDX) {
 				ICAP_ERR(icap, "INVALID_MEM_IDX: %u",
 					ip->properties);
@@ -2091,6 +2090,7 @@ static int __icap_peer_xclbin_download(struct icap *icap, struct axlf *xclbin)
 		ICAP_INFO(icap, "xclbin already on peer, skip downloading");
 		return 0;
 	}
+
 	xocl_mailbox_get(xdev, CHAN_STATE, &ch_state);
 	if ((ch_state & XCL_MB_PEER_SAME_DOMAIN) != 0) {
 		data_len = sizeof(struct xcl_mailbox_req) +
@@ -2205,6 +2205,7 @@ static void icap_save_calib(struct icap *icap)
 		if (err)
 			ICAP_DBG(icap, "Not able to save mem %d calibration data.", i);
 	}
+	err = xocl_calib_storage_save(xdev);
 }
 
 static void icap_calib(struct icap *icap, bool retain)
@@ -2214,6 +2215,8 @@ static void icap_calib(struct icap *icap, bool retain)
 	struct mem_topology *mem_topo = icap->mem_topo;
 
 	BUG_ON(!mem_topo);
+
+	err = xocl_calib_storage_restore(xdev);
 
 	for (; i < mem_topo->m_count; ++i) {
 		err = xocl_srsr_calib(xdev, i, retain);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -255,6 +255,8 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_XLAT_GPA_BASE_UPPER_REG_ADDR  0x190
 #define XOCL_VSEC_XLAT_GPA_LIMIT_UPPER_REG_ADDR 0x194
 
+#define XOCL_CALIB_CACHE_SIZE	    0x4000
+
 struct xocl_vsec_header {
 	u32		format;
 	u32		length;
@@ -1296,8 +1298,6 @@ struct xocl_mailbox_versal_funcs {
 	? MAILBOX_VERSAL_OPS(xdev)->get(MAILBOX_VERSAL_DEV(xdev), \
 	data) : -ENODEV)
 
-
-
 /* srsr callbacks */
 struct xocl_srsr_funcs {
 	struct xocl_subdev_funcs common_funcs;
@@ -1322,6 +1322,25 @@ struct xocl_srsr_funcs {
 	SRSR_OPS(xdev, idx)->calib(SRSR_DEV(xdev, idx), retain) : \
 	-ENODEV)
 
+struct calib_storage_funcs {
+	struct xocl_subdev_funcs common_funcs;
+	int (*save)(struct platform_device *pdev);
+	int (*restore)(struct platform_device *pdev);
+};
+
+#define	CALIB_STORAGE_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE).pldev
+#define	CALIB_STORAGE_OPS(xdev)							\
+	((struct calib_storage_funcs *)SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE).ops)
+#define	CALIB_STORAGE_CB(xdev)	\
+	(CALIB_STORAGE_DEV(xdev) && CALIB_STORAGE_OPS(xdev))
+#define	xocl_calib_storage_save(xdev)				\
+	(CALIB_STORAGE_CB(xdev) ?						\
+	CALIB_STORAGE_OPS(xdev)->save(CALIB_STORAGE_DEV(xdev)) : \
+	-ENODEV)
+#define	xocl_calib_storage_restore(xdev)				\
+	(CALIB_STORAGE_CB(xdev) ?						\
+	CALIB_STORAGE_OPS(xdev)->restore(CALIB_STORAGE_DEV(xdev)) : \
+	-ENODEV)
 /* helper functions */
 xdev_handle_t xocl_get_xdev(struct platform_device *pdev);
 void xocl_init_dsa_priv(xdev_handle_t xdev_hdl);
@@ -1597,5 +1616,8 @@ void xocl_fini_srsr(void);
 
 int __init xocl_init_ulite(void);
 void xocl_fini_ulite(void);
+
+int __init xocl_init_calib_storage(void);
+void xocl_fini_calib_storage(void);
 
 #endif


### PR DESCRIPTION
Here we introduce calibration storage sub-device to save/restore the calibration cache from SRSR IP.

SRSR IP is an ULP level sub-device which will be removed every time we download a xclbin.

So we need somewhere to save the calibration cache after mig calibration finished then restore it back before we ask SRSR IP to perform fast calibration.