### PR TITLE
CR-1028065 qdma: add per stream aio context for polling individual stream

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -316,6 +316,24 @@ clPollStreams(cl_device_id /*device*/,
 	cl_int /*timeout in ms*/,
 	cl_int * /*errcode_ret*/) CL_API_SUFFIX__VERSION_1_0;
 
+/* clPollStream - Poll a single stream on a device for completion.
+ * @stream                : The stream
+ * @completions           : Completions array
+ * @min_num_completions   : Minimum number of completions requested
+ * @max_num_completions   : Maximum number of completions requested
+ * @actual_num_completions: Actual number of completions returned.
+ * @timeout               : Timeout in milliseconds (ms)
+ * @errcode_ret :         : The return value eg CL_SUCCESS
+ * Return a cl_int.
+ */
+extern CL_API_ENTRY cl_int CL_API_CALL
+clPollStream(cl_stream             /* stream*/,
+       	cl_streams_poll_req_completions* /*completions*/,
+	cl_int  /*min_num_completion*/,
+	cl_int  /*max_num_completion*/,
+	cl_int* /*actual num_completion*/,
+	cl_int /*timeout in ms*/,
+	cl_int * /*errcode_ret*/) CL_API_SUFFIX__VERSION_1_0;
 //End QDMA APIs
 
 typedef struct _cl_mem * rte_mbuf;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -148,6 +148,7 @@ namespace xclcpuemhal2 {
       int xclFreeQDMABuf(uint64_t buf_hdl);
       ssize_t xclWriteQueue(uint64_t q_hdl, xclQueueRequest *wr);
       ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
+      int xclPollQueue(uint64_t q_hdl, int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
       int xclExecWait(int timeoutMilliSec);

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -650,6 +650,33 @@ mtx.unlock();
   xclPollCompletion_SET_PROTO_RESPONSE(vaLenMap); \
   FREE_BUFFERS();
 
+//----------xclPollQueue-------------------
+#define xclPollQueue_SET_PROTOMESSAGE(q_handle,reqcounter) \
+    c_msg.set_q_handle(q_handle); \
+    c_msg.set_req(reqcounter); \
+
+#define xclPollQueue_SET_PROTO_RESPONSE(vaLenMap) \
+  std::map<uint64_t,uint64_t>::iterator vaLenMapItr = vaLenMap.begin();\
+  if(r_msg.fullrequest_size() == (int)(vaLenMap.size()))\
+  {\
+    for(int i = 0; i < r_msg.fullrequest_size() ; i++) \
+    { \
+      const xclPollQUmpletion_response::request &oReq = r_msg.fullrequest(i); \
+      uint64_t read_size = oReq.size();\
+      numBytesProcessed  += read_size; \
+      if((*vaLenMapItr).second != 0) \
+        memcpy((void*)(*vaLenMapItr).first,oReq.dest().c_str(),read_size);\
+      vaLenMapItr++;\
+    } \
+  }\
+
+#define xclQueue_RPC_CALL(func_name,q_handle, reqcounter,vaLenMap) \
+  RPC_PROLOGUE(func_name); \
+  xclPollQueue_SET_PROTOMESSAGE(q_handle, reqcounter); \
+  SERIALIZE_AND_SEND_MSG(func_name) \
+  xclPollQueue_SET_PROTO_RESPONSE(vaLenMap); \
+  FREE_BUFFERS();
+
 //----------xclDestroyQueue-------------------
 #define xclDestroyQueue_SET_PROTOMESSAGE(q_handle) \
     c_msg.set_q_handle(q_handle);

--- a/src/runtime_src/core/include/xcl_macros.h
+++ b/src/runtime_src/core/include/xcl_macros.h
@@ -55,8 +55,9 @@
 #define xclImportBO_n 27
 #define xclSetupInstance_n 28
 #define xclPollCompletion_n 29
+#define xclPollQueue_n 30
 
-#define xclPerfMonReadCounters_Streaming_n 30
-#define xclPerfMonReadTrace_Streaming_n 31
+#define xclPerfMonReadCounters_Streaming_n 31
+#define xclPerfMonReadTrace_Streaming_n 32
 
 #endif

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -1190,6 +1190,27 @@ ssize_t
 xclReadQueue(xclDeviceHandle handle, uint64_t q_hdl, struct xclQueueRequest *rd_req);
 
 /**
+ * xclPollQueue - poll a single read/write queue completion
+ * @handle:        Device handle
+ * @q_hdl:         Queue handle
+ * @min_compl:     Unblock only when receiving min_compl completions
+ * @max_compl:     Max number of completion with one poll
+ * @comps:         Completed request array
+ * @actual_compl:  Number of requests been completed
+ * @timeout:       Timeout
+ * Return:         Number of events or appropriate error number
+ *
+ * Poll completion events of non-blocking read/write requests. Once
+ * this function returns, an array of completed requests is returned.
+ */
+XCL_DRIVER_DLLESPEC
+int
+xclPollQueue(xclDeviceHandle handle, uint64_t q_hdl, int min_compl,
+		   int max_compl, struct xclReqCompletion *comps,
+		   int* actual_compl, int timeout);
+
+
+/**
  * xclPollCompletion - poll read/write queue completion
  * @min_compl:     Unblock only when receiving min_compl completions
  * @max_compl:     Max number of completion with one poll

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -151,6 +151,7 @@ namespace xclcpuemhal2 {
       int xclFreeQDMABuf(uint64_t buf_hdl);
       ssize_t xclWriteQueue(uint64_t q_hdl, xclQueueRequest *wr);
       ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
+      int xclPollQueue(uint64_t q_hdl, int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
       int xclExecWait(int timeoutMilliSec);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -233,6 +233,7 @@ using addr_type = uint64_t;
       int xclFreeQDMABuf(uint64_t buf_hdl);
       ssize_t xclWriteQueue(uint64_t q_hdl, xclQueueRequest *wr);
       ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
+      int xclPollQueue(uint64_t q_hdl,int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       bool isImported(unsigned int _bo)
       {

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -33,6 +33,8 @@
 #include <linux/aio_abi.h>
 #include <libdrm/drm.h>
 
+#include <iostream>
+
 #include <mutex>
 #include <fstream>
 #include <list>
@@ -50,6 +52,29 @@ namespace xocl {
 
 const uint64_t mNullAddr = 0xffffffffffffffffull;
 const uint64_t mNullBO = 0xffffffff;
+
+class queue_cb {
+public:
+    queue_cb(struct xocl_qdma_ioc_create_queue *qinfo);
+    ~queue_cb();
+    int queue_poll_completion(unsigned int min_compl, unsigned int max_compl,
+		    struct xclReqCompletion *comps, unsigned int* actual,
+		    unsigned int timeout_ms);
+    ssize_t queue_submit_io(xclQueueRequest *wr, bool mAioEn, aio_context_t mAioCtx);
+
+    uint64_t queue_get_hndl() {
+        return qhndl;
+    }
+    bool queue_is_write_dir(void) {
+	return h2c;
+    }
+
+private:
+    uint64_t qhndl;
+    bool h2c; 
+    bool qAioEn;
+    aio_context_t qAioCtx;
+};
 
 class shim
 {
@@ -158,6 +183,7 @@ public:
     int xclFreeQDMABuf(uint64_t buf_hdl);
     ssize_t xclWriteQueue(uint64_t q_hdl, xclQueueRequest *wr);
     ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
+    int xclPollQueue(uint64_t q_hdl, int min_compl, int max_compl, xclReqCompletion *comps, int * actual, int timeout /*ms*/);
     int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int * actual, int timeout /*ms*/);
     int xclIPName2Index(const char *name, uint32_t& index);
 

--- a/src/runtime_src/xocl/api/clGetExtensionFunctionAddressForPlatform.cpp
+++ b/src/runtime_src/xocl/api/clGetExtensionFunctionAddressForPlatform.cpp
@@ -31,6 +31,7 @@ static const std::map<const std::string, void *> extensionFunctionTable = {
   std::pair<const std::string, void *>("clCreateStreamBuffer", (void *)clCreateStreamBuffer),
   std::pair<const std::string, void *>("clReleaseStreamBuffer", (void *)clReleaseStreamBuffer),
   std::pair<const std::string, void *>("clPollStreams", (void *)clPollStreams),
+  std::pair<const std::string, void *>("clPollStream", (void *)clPollStream),
   std::pair<const std::string, void *>("xclGetMemObjectFd", (void *)xclGetMemObjectFd),
   std::pair<const std::string, void *>("xclGetMemObjectFromFd", (void *)xclGetMemObjectFromFd),
   std::pair<const std::string, void *>("xclGetXrtDevice", (void *)xclGetXrtDevice),

--- a/src/runtime_src/xocl/api/xlnx/clPollStream.cpp
+++ b/src/runtime_src/xocl/api/xlnx/clPollStream.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2019-2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2018 Xilinx, Inc. All rights reserved.
+#include "xocl/config.h"
+#include "xocl/core/stream.h"
+#include "xocl/core/error.h"
+#include "plugin/xdp/profile.h"
+#include "xocl/core/device.h"
+#include <CL/opencl.h>
+
+namespace xocl {
+
+static void
+validOrError(cl_stream                  stream,
+	cl_streams_poll_req_completions*completions,
+	cl_int                          min_num_completion,
+	cl_int                          max_num_completion,
+	cl_int*                         actual_num_completion,
+	cl_int                          timeout,
+	cl_int*                         errcode_ret)
+
+{
+}
+
+static cl_int
+clPollStream(cl_stream                 stream,
+	cl_streams_poll_req_completions*completions,
+	cl_int                          min,
+	cl_int                          max,
+	cl_int*                         actual,
+	cl_int                          timeout,
+	cl_int*                         errcode_ret)
+{
+  validOrError(stream,completions,min,max,actual,timeout,errcode_ret);
+
+  printf("clPollStream() -> xocl(stream)->poll_stream.\n");
+
+  xocl::xocl(stream)->poll_stream(completions,min,max,actual,timeout);
+  xocl::assign(errcode_ret,CL_SUCCESS);
+  return CL_SUCCESS;
+}
+
+} //xocl
+
+CL_API_ENTRY cl_int CL_API_CALL
+clPollStream(cl_stream                  stream,
+       	cl_streams_poll_req_completions* completions,
+	cl_int                           min_num_completion,
+	cl_int                           max_num_completion,
+	cl_int*                          actual_num_completion,
+	cl_int                           timeout,
+	cl_int * errcode_ret) CL_API_SUFFIX__VERSION_1_0
+{
+  try {
+    PROFILE_LOG_FUNCTION_CALL;
+    return xocl::clPollStream
+      (stream,completions,min_num_completion,max_num_completion,actual_num_completion,timeout,errcode_ret);
+  }
+  catch (const xrt::error& ex) {
+    xocl::send_exception_message(ex.what());
+    xocl::assign(errcode_ret,ex.get_code());
+  }
+  catch (const std::exception& ex) {
+    xocl::send_exception_message(ex.what());
+    xocl::assign(errcode_ret,CL_INVALID_VALUE);
+  }
+  return CL_INVALID_VALUE;
+}

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -461,6 +461,13 @@ poll_streams(xrt::device::stream_xfer_completions* comps, int min, int max, int*
   return m_xdevice->pollStreams(comps, min,max,actual,timeout);
 }
 
+int
+device::
+poll_stream(xrt::device::stream_handle stream, xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout)
+{
+  return m_xdevice->pollStream(stream, comps, min,max,actual,timeout);
+}
+
 device::
 device(platform* pltf, xrt::device* xdevice)
   : m_uid(uid_count++), m_platform(pltf), m_xdevice(xdevice)

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -520,6 +520,9 @@ public:
   free_stream_buf(xrt::device::stream_buf_handle handle);
 
   int
+  poll_stream(xrt::device::stream_handle stream, xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout);
+
+  int
   poll_streams(xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout);
 
   /**

--- a/src/runtime_src/xocl/core/stream.cpp
+++ b/src/runtime_src/xocl/core/stream.cpp
@@ -59,6 +59,12 @@ stream::close()
   return m_device->close_stream(m_handle,m_connidx);
 }
 
+int 
+stream
+::poll_stream(xrt::device::stream_xfer_completions *comps, int min, int max, int *actual, int timeout)
+{
+  return m_device->poll_stream(m_handle, comps, min, max, actual, timeout);
+}
 
 int 
 stream_mem::

--- a/src/runtime_src/xocl/core/stream.h
+++ b/src/runtime_src/xocl/core/stream.h
@@ -45,6 +45,7 @@ private:
   int m_connidx = -1;
 public:
   int get_stream(device* device); 
+  int poll_stream(xrt::device::stream_xfer_completions *comps, int min, int max, int *actual, int timeout); 
   ssize_t read(void* ptr, size_t size, stream_xfer_req* req );
   ssize_t write(const void* ptr, size_t size, stream_xfer_req* req);
   int close();

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -555,6 +555,12 @@ public:
     return m_hal->pollStreams(comps, min,max,actual,timeout);
   };
 
+  int
+  pollStream(hal::StreamHandle stream, hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)
+  {
+    return m_hal->pollStream(stream, comps, min,max,actual,timeout);
+  };
+
 //End Streaming APIs
 #ifdef PMD_OCL
 public:

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -318,6 +318,9 @@ public:
   virtual int
   pollStreams(StreamXferCompletions* comps, int min, int max, int* actual, int timeout) = 0;
 
+  virtual int
+  pollStream(hal::StreamHandle stream, StreamXferCompletions* comps, int min, int max, int* actual, int timeout) = 0;
+
 public:
   /**
    * @returns

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -704,6 +704,14 @@ pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, in
   return m_ops->mPollQueues(m_handle,min,max,req,actual,timeout);
 }
 
+int
+device::
+pollStream(hal::StreamHandle stream, hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)
+{
+  xclReqCompletion* req = reinterpret_cast<xclReqCompletion*>(comps);
+  return m_ops->mPollQueue(m_handle,stream,min,max,req,actual,timeout);
+}
+
 #ifdef PMD_OCL
 void
 createDevices(hal::device_list& devices,

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -373,6 +373,9 @@ public:
   virtual int
   pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout);
 
+  virtual int
+  pollStream(hal::StreamHandle stream, hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout);
+
 public:
   virtual bool
   is_imported(const BufferObjectHandle& boh) const;

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -76,6 +76,7 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mFreeQDMABuf(0)
   ,mWriteQueue(0)
   ,mReadQueue(0)
+  ,mPollQueue(0)
   ,mPollQueues(0)
   ,mGetDebugIpLayout(0)
   ,mGetNumLiveProcesses(0)
@@ -123,6 +124,7 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mFreeQDMABuf = (freeQDMABufFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclFreeQDMABuf");
   mWriteQueue = (writeQueueFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclWriteQueue");
   mReadQueue = (readQueueFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclReadQueue");
+  mPollQueue = (pollQueueFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclPollQueue");
   mPollQueues = (pollQueuesFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclPollCompletion");
 
   // Profiling Functions

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -129,6 +129,7 @@ private:
   typedef int     (*freeQDMABufFuncType)(xclDeviceHandle handle,uint64_t buf_hdl);
   typedef ssize_t (*writeQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, xclQueueRequest *wr);
   typedef ssize_t (*readQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, xclQueueRequest *wr);
+  typedef int     (*pollQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, int min, int max, xclReqCompletion* completions, int* actual, int timeout);
   typedef int     (*pollQueuesFuncType)(xclDeviceHandle handle,int min, int max, xclReqCompletion* completions, int* actual, int timeout);
 //End Streaming
 
@@ -209,6 +210,7 @@ public:
   freeQDMABufFuncType mFreeQDMABuf;
   writeQueueFuncType mWriteQueue;
   readQueueFuncType mReadQueue;
+  pollQueueFuncType mPollQueue;
   pollQueuesFuncType mPollQueues;
 //End Streaming
 


### PR DESCRIPTION
Added a new API to poll individual stream: clPollStream(), and internally, added a per-queue aio context for io submission and completion polling
Tested with u200 image from 2020.1_qualified_latest.