### PR TITLE
XRT-317 add retry when calling wireserver APIs in azure mpd plugin

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -227,7 +227,7 @@ MODULE_PARM_DESC(mailbox_no_intr,
 
 #define	MAILBOX_TIMER		(HZ / 50) /* in jiffies */
 #define	MAILBOX_SEC2TIMER(s)	((s) * HZ / MAILBOX_TIMER)
-#define	MSG_RX_DEFAULT_TTL	20UL	/* in seconds */
+#define	MSG_RX_DEFAULT_TTL	60UL	/* in seconds */
 #define	MSG_TX_DEFAULT_TTL	2UL	/* in seconds */
 #define	MSG_TX_PER_MB_TTL	1UL	/* in seconds */
 #define	MSG_MAX_TTL		0xFFFFFFFF /* used to disable timer */

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -89,8 +89,9 @@ public:
     }
 private:
     // 4 MB buffer to truncate and send
-    static const int TRANSFER_SEGMENT_SIZE { 1024 * 4096 };
-    static const int REIMAGE_TIMEOUT { 20 }; //in second
+    static const int transfer_segment_size { 1024 * 4096 };
+    static const int rest_timeout { 20 }; //in second
+    static const int upload_retry { 15 }; //in second
     std::shared_ptr<pcidev::pci_device> dev;
     size_t index;
     int UploadToWireServer(


### PR DESCRIPTION
in azure production environment, retry when calling wireserver APIs are required since  there is no guarantee networking is available.
And when xclbin is downloaded, azure wireserver takes extra steps to verify the xclbin in one of the API -- that step usually takes 12-18s, so the default 20s mailbox rx timeout is not enough. change the default to 60s. 