### PR TITLE
CR-1057699 Check for Errors while waiting for completions

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -1437,7 +1437,9 @@ static int xdma_process_requests(struct xdma_engine *engine,
 		timeout = wait_event_interruptible_timeout(req->arbtr_wait,
 				req->sw_desc_cnt == req->desc_completed,
 				msecs_to_jiffies(10000)); /* 10sec timeout */
-		if (timeout == 0) {
+
+		/* Check for timeouts or errors */
+		if (timeout == 0 || timeout < 0) {
 			pr_err("Request completion timeout\n");
 			engine_reg_dump(engine);
 			rv = -EIO;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -1439,11 +1439,16 @@ static int xdma_process_requests(struct xdma_engine *engine,
 				msecs_to_jiffies(10000)); /* 10sec timeout */
 
 		/* Check for timeouts or errors */
-		if (timeout == 0 || timeout < 0) {
+		if (timeout == 0) {
 			pr_err("Request completion timeout\n");
 			engine_reg_dump(engine);
 			rv = -EIO;
+		} else if (timeout < 0) {
+			pr_err("Request aborted with error = %d\n", timeout);
+			engine_reg_dump(engine);
+			rv = -EIO;
 		}
+	
 	}
 	if (req->cb && req->cb->io_done) {
 		req->expiry = jiffies + msecs_to_jiffies(10000);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -948,7 +948,7 @@ static int process_completions(struct xdma_engine *engine,
 				cb->io_done((unsigned long)cb->private, 0);
 				xdma_request_release(engine->xdev, req);
 			} else
-				wake_up_interruptible(&req->arbtr_wait);
+				wake_up(&req->arbtr_wait);
 		}
 		spin_unlock(&engine->req_list_lock);
 	}
@@ -1434,17 +1434,13 @@ static int xdma_process_requests(struct xdma_engine *engine,
 		return rv;
 	}
 	if ((!req->cb || !req->cb->io_done) && (rv == 0)) {
-		timeout = wait_event_interruptible_timeout(req->arbtr_wait,
+		timeout = wait_event_timeout(req->arbtr_wait,
 				req->sw_desc_cnt == req->desc_completed,
 				msecs_to_jiffies(10000)); /* 10sec timeout */
 
-		/* Check for timeouts or errors */
+		/* Check for timeouts*/
 		if (timeout == 0) {
 			pr_err("Request completion timeout\n");
-			engine_reg_dump(engine);
-			rv = -EIO;
-		} else if (timeout < 0) {
-			pr_err("Request aborted with error = %d\n", timeout);
 			engine_reg_dump(engine);
 			rv = -EIO;
 		}


### PR DESCRIPTION
XRT-296 Hit xdma panic when debugging u250 2RP
CR-1057699 Check for Errors while waiting for completions

Look for error being returned by wait_event_interruptible_timeout() in addition to timeout. Not checking for error was causing requests to be freed before being removed for list causing panic.

