### PR TITLE
XRT-132 CMA enable User Interface

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -470,9 +470,9 @@ struct drm_xocl_reclock_info {
 
 
 struct drm_xocl_alloc_cma_info {
-	uint64_t	page_sz;
-	uint64_t	user_addr;
-	bool		end;
+	uint64_t	total_size;
+	uint64_t	entry_num;
+	uint64_t	*user_addr;
 };
 /*
  * Core ioctls numbers

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -470,13 +470,9 @@ struct drm_xocl_reclock_info {
 
 
 struct drm_xocl_alloc_cma_info {
-	uint64_t page_sz;
-	uint64_t user_addr;
-	uint64_t chunk_id;
-};
-
-struct drm_xocl_free_cma_info {
-	uint64_t chunk_id;
+	uint64_t	page_sz;
+	uint64_t	user_addr;
+	bool		end;
 };
 /*
  * Core ioctls numbers
@@ -505,5 +501,5 @@ struct drm_xocl_free_cma_info {
 #define	DRM_IOCTL_XOCL_HOT_RESET	XOCL_IOC(HOT_RESET)
 #define	DRM_IOCTL_XOCL_RECLOCK		XOCL_IOC_ARG(RECLOCK, reclock_info)
 #define	DRM_IOCTL_XOCL_ALLOC_CMA	XOCL_IOC_ARG(ALLOC_CMA, alloc_cma_info)
-#define	DRM_IOCTL_XOCL_FREE_CMA		XOCL_IOC_ARG(FREE_CMA, free_cma_info)
+#define	DRM_IOCTL_XOCL_FREE_CMA		XOCL_IOC(FREE_CMA)
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -472,7 +472,7 @@ struct drm_xocl_reclock_info {
 struct drm_xocl_alloc_cma_info {
 	uint64_t	total_size;
 	uint64_t	entry_num;
-	uint64_t	*user_addr;
+	uint64_t	user_addr[1];
 };
 /*
  * Core ioctls numbers

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/address_translator.c
@@ -61,36 +61,17 @@ struct addr_translator {
 	bool			online;
 };
 
-static ssize_t status_show(struct device *dev, struct device_attribute *attr,
-	char *buf)
-{
-	u32 status = 1;
-
-	return sprintf(buf, "0x%x\n", status);
-}
-static DEVICE_ATTR_RO(status);
-
-static struct attribute *addr_translator_attributes[] = {
-	&dev_attr_status.attr,
-	NULL
-};
-
-static const struct attribute_group addr_translator_attrgroup = {
-	.attrs = addr_translator_attributes,
-};
-
 static uint32_t addr_translator_get_entries_num(struct platform_device *pdev)
 {
 	struct addr_translator *addr_translator = platform_get_drvdata(pdev);
 	struct trans_regs *regs = (struct trans_regs *)addr_translator->base;
 	xdev_handle_t xdev = ADDR_TRANSLATOR_DEV2XDEV(pdev);
-	uint32_t num;
+	uint32_t num = 0;
 
 	mutex_lock(&addr_translator->lock);
 
 	num = (xocl_dr_reg_read32(xdev, &regs->cap)>>6 & 0x1f) << 8;
 
-	num = 256;
 	mutex_unlock(&addr_translator->lock);
 	return num;
 }
@@ -152,6 +133,26 @@ done:
 static struct xocl_addr_translator_funcs addr_translator_ops = {
 	.get_entries_num = addr_translator_get_entries_num,
 	.set_page_table = addr_translator_set_page_table,
+};
+
+static ssize_t num_show(struct device *dev, struct device_attribute *attr,
+	char *buf)
+{
+	u32 num = 0;
+
+	num = addr_translator_get_entries_num(to_platform_device(dev));
+
+	return sprintf(buf, "0x%x\n", num);
+}
+static DEVICE_ATTR_RO(num);
+
+static struct attribute *addr_translator_attributes[] = {
+	&dev_attr_num.attr,
+	NULL
+};
+
+static const struct attribute_group addr_translator_attrgroup = {
+	.attrs = addr_translator_attributes,
 };
 
 static int addr_translator_probe(struct platform_device *pdev)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -854,8 +854,8 @@ static int xocl_cma_chunk_reserve(struct xocl_drm *drm_p, struct drm_xocl_alloc_
 	uint64_t nr, page_count;
 	struct page **pages = NULL;
 	struct device *dev = drm_p->ddev->dev;
-	uint64_t user_addr = cma_info->user_addr;
-	size_t page_sz = cma_info->page_sz;
+	uint64_t user_addr = 0x0; // remove it next commit, bypass coverity check
+	size_t page_sz = cma_info->total_size/cma_info->entry_num;
 
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -909,8 +909,6 @@ static int xocl_cma_chunk_reserve(struct xocl_drm *drm_p, struct drm_xocl_alloc_
 
 	drm_mm_init(drm_p->cma_chunk[idx]->mm, drm_p->cma_chunk[idx]->start_addr, page_sz);
 
-	cma_info->chunk_id = idx;
-
 out:
 	xocl_info(dev, "%s ret %d", __func__, ret);
 	return ret;
@@ -926,11 +924,9 @@ int xocl_cma_chunk_alloc_helper(struct xocl_drm *drm_p, struct drm_xocl_alloc_cm
 	return err;
 }
 
-void xocl_cma_chunk_free_helper(struct xocl_drm *drm_p, struct drm_xocl_free_cma_info *cma_info)
+void xocl_cma_chunk_free_helper(struct xocl_drm *drm_p)
 {
-	uint64_t chunk_id = cma_info->chunk_id;
-
 	mutex_lock(&drm_p->mm_lock);
-	xocl_cma_chunk_free(drm_p, chunk_id);
+	xocl_cma_chunks_free_all(drm_p);
 	mutex_unlock(&drm_p->mm_lock);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -518,12 +518,11 @@ int xocl_alloc_cma_ioctl(struct drm_device *dev, void *data,
 int xocl_free_cma_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp)
 {
-	struct drm_xocl_free_cma_info *cma_info = data;
 	struct xocl_drm *drm_p = dev->dev_private;
 	struct xocl_dev *xdev = drm_p->xdev;
 
 	mutex_lock(&xdev->dev_lock);
-	xocl_cma_chunk_free_helper(drm_p, cma_info);
+	xocl_cma_chunk_free_helper(drm_p);
 	mutex_unlock(&xdev->dev_lock);
 
 	return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -99,7 +99,7 @@ int xocl_init_mem(struct xocl_drm *drm_p);
 int xocl_cleanup_mem(struct xocl_drm *drm_p);
 
 int xocl_cma_chunk_alloc_helper(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info);
-void xocl_cma_chunk_free_helper(struct xocl_drm *drm_p, struct drm_xocl_free_cma_info *cma_info);
+void xocl_cma_chunk_free_helper(struct xocl_drm *drm_p);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 vm_fault_t xocl_gem_fault(struct vm_fault *vmf);

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -91,7 +91,7 @@ public:
     static shim *handleCheck(void * handle);
     int resetDevice(xclResetKind kind);
     int p2pEnable(bool enable, bool force);
-    int cmaEnable(bool enable, uint64_t size);
+    int cmaEnable(bool enable, bool hugepage, uint64_t size);
     bool xclLockDevice();
     bool xclUnlockDevice();
     int xclReClock2(unsigned short region, const unsigned short *targetFreqMHz);
@@ -128,7 +128,7 @@ public:
      * e.g. enable = true, sz = 0x100000 (2M): add 2M CMA chunk
      *      enable = false: remove CMA chunk
      */
-    int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t sz);
+    int xclCmaEnable(xclDeviceHandle handle, bool enable, bool hugepage, uint64_t page_sz);
 
     int xclGetDebugIPlayoutPath(char* layoutPath, size_t size);
     int xclGetSubdevPath(const char* subdev, uint32_t idx, char* path, size_t size);

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -91,7 +91,7 @@ public:
     static shim *handleCheck(void * handle);
     int resetDevice(xclResetKind kind);
     int p2pEnable(bool enable, bool force);
-    int cmaEnable(bool enable, bool hugepage, uint64_t size);
+    int cmaEnable(bool enable, uint64_t size);
     bool xclLockDevice();
     bool xclUnlockDevice();
     int xclReClock2(unsigned short region, const unsigned short *targetFreqMHz);
@@ -128,7 +128,7 @@ public:
      * e.g. enable = true, sz = 0x100000 (2M): add 2M CMA chunk
      *      enable = false: remove CMA chunk
      */
-    int xclCmaEnable(xclDeviceHandle handle, bool enable, bool hugepage, uint64_t page_sz);
+    int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
 
     int xclGetDebugIPlayoutPath(char* layoutPath, size_t size);
     int xclGetSubdevPath(const char* subdev, uint32_t idx, char* path, size_t size);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1821,9 +1821,9 @@ int xcldev::xclP2p(int argc, char *argv[])
 
 
 
-int xcldev::device::setCma(bool enable, bool hugepage, uint64_t page_sz)
+int xcldev::device::setCma(bool enable, uint64_t total_size)
 {
-    return xclCmaEnable(m_handle, enable, hugepage, page_sz);
+    return xclCmaEnable(m_handle, enable, total_size);
 }
 
 int xcldev::xclCma(int argc, char *argv[])
@@ -1831,16 +1831,15 @@ int xcldev::xclCma(int argc, char *argv[])
     int c;
     unsigned int index = 0;
     int cma_enable = -1;
-    bool huge_page = false;
-    uint64_t page_sz = 0x40000000;
+    uint64_t total_size = 0;
     bool root = ((getuid() == 0) || (geteuid() == 0));
-    const std::string usage("Options: [-d index] --[enable|disable]");
+    const std::string usage("Options: [-d index] --[enable|disable] --size [size]");
     static struct option long_options[] = {
         {"enable", no_argument, 0, xcldev::CMA_ENABLE},
         {"disable", no_argument, 0, xcldev::CMA_DISABLE},
-        {"hugepage", no_argument, 0, xcldev::CMA_HUGEPAGE},
-        {0, 0, 0, 0}
+        {"size", required_argument, nullptr, xcldev::CMA_SIZE},
     };
+
     int long_index, ret;
     const char* short_options = "d"; //don't add numbers
     const char* exe = argv[ 0 ];
@@ -1859,8 +1858,8 @@ int xcldev::xclCma(int argc, char *argv[])
         case xcldev::CMA_DISABLE:
             cma_enable = 0;
             break;
-        case xcldev::CMA_HUGEPAGE:
-            huge_page = true;
+        case xcldev::CMA_SIZE:
+            total_size = std::stoi(optarg);
             break;
         default:
             xcldev::printHelp(exe);
@@ -1886,7 +1885,7 @@ int xcldev::xclCma(int argc, char *argv[])
      * 1. Call Kernel API
      * 2. Huge Page MMAP 
      */
-    ret = d->setCma(cma_enable, huge_page, page_sz);
+    ret = d->setCma(cma_enable, total_size);
     if (ret == ENOMEM) {
         std::cout << "ERROR: No enough huge page." << std::endl;
         std::cout << "Please check grub settings" << std::endl;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -49,7 +49,7 @@ using Clock = std::chrono::high_resolution_clock;
 
 /* exposed by shim */
 int xclUpdateSchedulerStat(xclDeviceHandle);
-int xclCmaEnable(xclDeviceHandle handle, bool enable, bool hugepage, uint64_t sz);
+int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
 int xclGetDebugProfileDeviceInfo(xclDeviceHandle handle, xclDebugProfileDeviceInfo* info);
 
 #define TO_STRING(x) #x
@@ -119,7 +119,7 @@ enum cmacommand {
     CMA_ENABLE = 0x0,
     CMA_DISABLE,
     CMA_VALIDATE,
-    CMA_HUGEPAGE,
+    CMA_SIZE,
 };
 
 static const std::pair<std::string, command> map_pairs[] = {
@@ -1793,7 +1793,7 @@ public:
 
     int reset(xclResetKind kind);
     int setP2p(bool enable, bool force);
-    int setCma(bool enable, bool hugepage, uint64_t sz);
+    int setCma(bool enable, uint64_t total_size);
     int testP2p(void);
     int testM2m(void);
     int iopsTest(void);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -49,7 +49,7 @@ using Clock = std::chrono::high_resolution_clock;
 
 /* exposed by shim */
 int xclUpdateSchedulerStat(xclDeviceHandle);
-int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t sz);
+int xclCmaEnable(xclDeviceHandle handle, bool enable, bool hugepage, uint64_t sz);
 int xclGetDebugProfileDeviceInfo(xclDeviceHandle handle, xclDebugProfileDeviceInfo* info);
 
 #define TO_STRING(x) #x
@@ -119,8 +119,7 @@ enum cmacommand {
     CMA_ENABLE = 0x0,
     CMA_DISABLE,
     CMA_VALIDATE,
-    CMA_SIZE_1G,
-    CMA_SIZE_2M,
+    CMA_HUGEPAGE,
 };
 
 static const std::pair<std::string, command> map_pairs[] = {
@@ -1794,7 +1793,7 @@ public:
 
     int reset(xclResetKind kind);
     int setP2p(bool enable, bool force);
-    int setCma(bool enable, uint64_t sz);
+    int setCma(bool enable, bool hugepage, uint64_t sz);
     int testP2p(void);
     int testM2m(void);
     int iopsTest(void);


### PR DESCRIPTION
Modify xbutil cma --enable user interface.

1. remove --1G sub command.

2. allocate the CMA chunk by  A. allocate huge page and pass them to driver, 
                                                 B. call kernel API to collect CMA memory

