### PR TITLE
Changed CL_DEVICE_MAX_MEM_ALLOC_SIZE from 512Mb to 4GB.

### DIFF
--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -129,7 +129,7 @@ clGetDeviceInfo(cl_device_id   device,
   case CL_DEVICE_MAX_MEM_ALLOC_SIZE:
     buffer.as<cl_ulong>() =
 #ifdef __x86_64__
-      4*1024*1024*1024; // 4GB
+      4ULL *1024*1024*1024; // 4GB
 #else
       128*1024*1024; //128 MB
 #endif

--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -129,7 +129,7 @@ clGetDeviceInfo(cl_device_id   device,
   case CL_DEVICE_MAX_MEM_ALLOC_SIZE:
     buffer.as<cl_ulong>() =
 #ifdef __x86_64__
-      512*1024*1024; //512 MB
+      4*1024*1024*1024; // 4GB
 #else
       128*1024*1024; //128 MB
 #endif


### PR DESCRIPTION
A small fix for hardcoded CL_DEVICE_MAX_MEM_ALLOC_SIZE that was hardcoded to 512 since inception. 