### PR TITLE
misc fixes for flashing shell and SC firmware through driver

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -250,6 +250,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	 */
 	if (!XOCL_DSA_PCI_RESET_OFF(lro)) {
 		xocl_subdev_destroy_by_level(lro, XOCL_SUBDEV_LEVEL_URP);
+		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_FLASH);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_ICAP);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_MAILBOX);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_AF);
@@ -261,6 +262,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_AF);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_MAILBOX);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_ICAP);
+		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_FLASH);
 	} else {
 		mgmt_warn(lro, "PCI Hot reset is not supported on this board.");
 	}

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.h
@@ -42,7 +42,7 @@
 #define XMC_BASE_VERSION                    2018201
 
 #define XMC_CTRL_ERR_CLR                    (1 << 1)
-#define XMC_PKT_SUPPORT_MASK                (1 << 3)
+#define XMC_NO_MAILBOX_MASK                 (1 << 3)
 #define XMC_PKT_OWNER_MASK                  (1 << 5)
 #define XMC_PKT_ERR_MASK                    (1 << 26)
 


### PR DESCRIPTION
Issues fixed:
1. not able to flash SC firmware through when board is running golden image
2. failed to wait long enough for SC firmware erase to finish
3. can't flash shell after hot reset
Also did some code cleanup.

Tested with xbmgmt flash command to flash shell and SC firmware when board is in golden or non-golden image.