### PR TITLE
Clear cache execbufs when device is close

### DIFF
--- a/src/runtime_src/xrt/device/device.cpp
+++ b/src/runtime_src/xrt/device/device.cpp
@@ -17,6 +17,7 @@
 
 #include "xrt/util/task.h"
 #include "xrt/util/event.h"
+#include "xrt/scheduler/command.h"
 
 #include <future>
 #include <cstring> // for std::memset
@@ -28,6 +29,14 @@ device::
 printDeviceInfo(std::ostream& ostr) const
 {
   return m_hal->printDeviceInfo(ostr);
+}
+
+void
+device::
+close()
+{
+  purge_device_command_freelist(this); // command.h
+  m_hal->close();
 }
 
 } // xrt

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -17,6 +17,7 @@
 #ifndef xrt_device_device_h_
 #define xrt_device_device_h_
 
+#include "xrt/config.h"
 #include "xrt/device/hal.h"
 #include "xrt/util/range.h"
 #include "xclbin.h"
@@ -160,6 +161,7 @@ public:
     return m_hal->open();
   }
 
+  XRT_EXPORT
   void
   close();
 

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -161,10 +161,7 @@ public:
   }
 
   void
-  close()
-  {
-    m_hal->close();
-  }
+  close();
 
   device_handle
   get_handle() const

--- a/src/runtime_src/xrt/scheduler/command.cpp
+++ b/src/runtime_src/xrt/scheduler/command.cpp
@@ -86,6 +86,16 @@ purge_command_freelist()
   s_purged = true;
 }
 
+// Purge command list for specific device
+// This function is called when the device is closed
+void
+purge_device_command_freelist(xrt::device* device)
+{
+  auto itr = sx.freelist.find(device);
+  if (itr != sx.freelist.end())
+    (*itr).second.clear();
+}
+
 command::
 command(xrt::device* device, ert_cmd_opcode opcode)
   : m_device(device)

--- a/src/runtime_src/xrt/scheduler/command.h
+++ b/src/runtime_src/xrt/scheduler/command.h
@@ -272,7 +272,7 @@ command_cast(const std::shared_ptr<command>& cmd)
   return cmd->get_ert_cmd<ERT_COMMAND_TYPE>();
 }
 
-  /**
+/**
  * Clear free list of exec buffer objects
  *
  * Command exec buffer objects are recycled, the freelist
@@ -281,6 +281,14 @@ command_cast(const std::shared_ptr<command>& cmd)
 void
 purge_command_freelist();
 
-} // xrt
+/**
+ * Clear free list of exec buffer objects for device
+ *
+ * Command exec buffer objects are recycled, the freelist
+ * must be cleared when device is closed.
+ */
+void
+purge_device_command_freelist(xrt::device* device);
 
+} // xrt
 #endif


### PR DESCRIPTION
This was yet another regression from #3053, where devices are closed
by OCL when no longer in use.

For example if a cl_context is released, then the devices used by the
context are closed (if noone else have them opened).  However the
xrt::device object remains alive.

If host application constructs a new context from same devices, then
they are opened again, this time with a different xclDeviceHandle.

The execbuffer cache used by OCL caches execbuf for xrt::device
objects, so the previous cached execbufs must be purged when/if the
underlying device is closed so that new execbufs can be constructed
for proper xclDeviceHandle.