### PR TITLE
No need to lock device in clGetDeviceInfo

### DIFF
--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -56,9 +56,6 @@ clGetDeviceInfo(cl_device_id   device,
   xocl::param_buffer buffer { param_value, param_value_size, param_value_size_ret };
   auto xdevice = xocl::xocl(device);
 
-  // lock the device to ensure that it is opened if necessary
-  auto lock = xdevice->lock_guard();
-
   switch(param_name) {
   case CL_DEVICE_TYPE:
     buffer.as<cl_device_type>() = CL_DEVICE_TYPE_ACCELERATOR;


### PR DESCRIPTION
Related to #3053.  Device info is cache when the platform is created
and all devices are probed.