### PR TITLE
refine graph rtp metadata

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -87,16 +87,14 @@ get_tiles(const pt::ptree& aie_meta, const std::string& graph_name)
 }
 
 std::vector<rtp_type>
-get_rtp(const pt::ptree& aie_meta, const std::string& port_name)
+get_rtp(const pt::ptree& aie_meta)
 {
   std::vector<rtp_type> rtps;
 
   for (auto& rtp_node : aie_meta.get_child("aie_metadata.RTPs")) {
-    if (rtp_node.second.get<std::string>("port_name") != port_name)
-      continue;
-
     rtp_type rtp;
-    rtp.name = port_name;
+
+    rtp.name = rtp_node.second.get<std::string>("port_name");
     rtp.selector_row = rtp_node.second.get<uint16_t>("selector_row");
     rtp.selector_col = rtp_node.second.get<uint16_t>("selector_column");
     rtp.selector_lock_id = rtp_node.second.get<uint16_t>("selector_lock_id");
@@ -141,7 +139,7 @@ get_tiles(const xrt_core::device* device, const std::string& graph_name)
 }
 
 std::vector<rtp_type>
-get_rtp(const xrt_core::device* device, const std::string& port_name)
+get_rtp(const xrt_core::device* device)
 {
   auto data = device->get_axlf_section(AIE_METADATA);
   if (!data.first || !data.second)
@@ -149,7 +147,7 @@ get_rtp(const xrt_core::device* device, const std::string& port_name)
 
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
-  return ::get_rtp(aie_meta, port_name);
+  return ::get_rtp(aie_meta);
 }
 
 }}} // aie, edge, xrt_core

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -78,7 +78,7 @@ struct rtp_type
  * @port_name: name of port to get data from
  */
 std::vector<rtp_type>
-get_rtp(const xrt_core::device* device, const std::string& port_name);
+get_rtp(const xrt_core::device* device);
 
 }}} // aie, edge, xrt_core
 

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -49,36 +49,8 @@ graph_type(std::shared_ptr<xrt_core::device> dev, uuid_t, const std::string& gra
     for (auto& tile : xrt_core::edge::aie::get_tiles(device.get(), name))
       tiles.emplace_back(std::move(tile));
 
-    // to be removed once TBD decided
-    tiles.emplace_back(tile_type{2, 4, 2, 4, 0x17e4});
-
-    /* TODO
-     * get RTP port from xclbin. Will need some interfaces like
-     * xrt_core::xclbin::get_rtpports(const axlf *top, char *graphName);
-     * just hard code for now.
-     */
-    rtps.emplace_back(rtp_type{"mygraph.k1.in[0]",
-
-                               1,
-                               0,
-                               0,
-                               0x4000,
-
-                               2,
-                               0,
-                               0,
-                               0,
-
-                               2,
-                               0,
-                               1,
-                               0x2000,
-
-                               false,
-                               true,
-                               false,
-                               false,
-                               true});
+    for (auto &rtp : xrt_core::edge::aie::get_rtp(device.get()))
+      rtps.emplace_back(std::move(rtp));
 
     state = graph_state::stop;
 }


### PR DESCRIPTION
1) Remove the hard coded graph tile and rtp metadata
2) Change get_rtp to get all rtp ports' metadata instead of a given port name