### PR TITLE
CR-1055356: Provided option to reset temp and power threshold & target values using xbmgmt tool

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1454,14 +1454,14 @@ static ssize_t scaling_reset_store(struct device *dev,
 	struct device_attribute *da, const char *buf, size_t count)
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
-	u32 val = 0, val2, threshold;
+	u32 buf_val = 0, target, threshold;
 	bool cs_en;
 
 	cs_en = scaling_condition_check(xmc, dev);
 	if (!cs_en)
 		return count;
 
-	if (kstrtou32(buf, 10, &val) == -EINVAL)
+	if (kstrtou32(buf, 10, &buf_val) == -EINVAL)
 		return -EINVAL;
 
 	mutex_lock(&xmc->xmc_lock);
@@ -1469,23 +1469,23 @@ static ssize_t scaling_reset_store(struct device *dev,
 	threshold = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_THRESHOLD_REG);
 	threshold = (threshold >> XMC_CLOCK_SCALING_POWER_THRESHOLD_POS) &
 		XMC_CLOCK_SCALING_POWER_THRESHOLD_MASK;
-	val2 = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_POWER_REG);
-	val2 &= ~XMC_CLOCK_SCALING_POWER_TARGET_MASK;
-	val2 |= (threshold & XMC_CLOCK_SCALING_POWER_TARGET_MASK);
-	WRITE_RUNTIME_CS(xmc, val2, XMC_CLOCK_SCALING_POWER_REG);
+	target = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_POWER_REG);
+	target &= ~XMC_CLOCK_SCALING_POWER_TARGET_MASK;
+	target |= (threshold & XMC_CLOCK_SCALING_POWER_TARGET_MASK);
+	WRITE_RUNTIME_CS(xmc, target, XMC_CLOCK_SCALING_POWER_REG);
 
 	//Reset target temp settings to default values
 	threshold = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_THRESHOLD_REG);
 	threshold = (threshold >> XMC_CLOCK_SCALING_TEMP_THRESHOLD_POS) &
 		XMC_CLOCK_SCALING_TEMP_THRESHOLD_MASK;
-	val2 = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_TEMP_REG);
-	val2 &= ~XMC_CLOCK_SCALING_TEMP_TARGET_MASK;
-	val2 |= (threshold & XMC_CLOCK_SCALING_TEMP_TARGET_MASK);
-	WRITE_RUNTIME_CS(xmc, val2, XMC_CLOCK_SCALING_TEMP_REG);
+	target = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_TEMP_REG);
+	target &= ~XMC_CLOCK_SCALING_TEMP_TARGET_MASK;
+	target |= (threshold & XMC_CLOCK_SCALING_TEMP_TARGET_MASK);
+	WRITE_RUNTIME_CS(xmc, target, XMC_CLOCK_SCALING_TEMP_REG);
 
 	//Reset thresold override settings to default values
-	val2 = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
-	if (val2 & XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT)
+	target = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
+	if (target & XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT)
 		WRITE_REG32(xmc, 0x0, XMC_CLK_THROTTLING_PWR_MGMT_REG);
 
 	mutex_unlock(&xmc->xmc_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1450,6 +1450,48 @@ static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev)
 	return true;
 }
 
+static ssize_t scaling_reset_store(struct device *dev,
+	struct device_attribute *da, const char *buf, size_t count)
+{
+	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
+	u32 val = 0, val2, threshold;
+	bool cs_en;
+
+	cs_en = scaling_condition_check(xmc, dev);
+	if (!cs_en)
+		return count;
+
+	if (kstrtou32(buf, 10, &val) == -EINVAL)
+		return -EINVAL;
+
+	mutex_lock(&xmc->xmc_lock);
+	//Reset target power settings to default values
+	threshold = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_THRESHOLD_REG);
+	threshold = (threshold >> XMC_CLOCK_SCALING_POWER_THRESHOLD_POS) &
+		XMC_CLOCK_SCALING_POWER_THRESHOLD_MASK;
+	val2 = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_POWER_REG);
+	val2 &= ~XMC_CLOCK_SCALING_POWER_TARGET_MASK;
+	val2 |= (threshold & XMC_CLOCK_SCALING_POWER_TARGET_MASK);
+	WRITE_RUNTIME_CS(xmc, val2, XMC_CLOCK_SCALING_POWER_REG);
+
+	//Reset target temp settings to default values
+	threshold = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_THRESHOLD_REG);
+	threshold = (threshold >> XMC_CLOCK_SCALING_TEMP_THRESHOLD_POS) &
+		XMC_CLOCK_SCALING_TEMP_THRESHOLD_MASK;
+	val2 = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_TEMP_REG);
+	val2 &= ~XMC_CLOCK_SCALING_TEMP_TARGET_MASK;
+	val2 |= (threshold & XMC_CLOCK_SCALING_TEMP_TARGET_MASK);
+	WRITE_RUNTIME_CS(xmc, val2, XMC_CLOCK_SCALING_TEMP_REG);
+
+	//Reset thresold override settings to default values
+	val2 = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
+	if (val2 & XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT)
+		WRITE_REG32(xmc, 0x0, XMC_CLK_THROTTLING_PWR_MGMT_REG);
+
+	mutex_unlock(&xmc->xmc_lock);
+}
+static DEVICE_ATTR_WO(scaling_reset);
+
 static ssize_t scaling_threshold_power_override_en_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1939,6 +1939,7 @@ static struct attribute *xmc_attrs[] = {
 	&dev_attr_sensor_update_timestamp.attr,
 	&dev_attr_scaling_threshold_power_override.attr,
 	&dev_attr_scaling_threshold_power_override_en.attr,
+	&dev_attr_scaling_reset.attr,
 	SENSOR_SYSFS_NODE_ATTRS,
 	REG_SYSFS_NODE_ATTRS,
 	NULL,

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -28,7 +28,7 @@
 const char *subCmdConfigDesc = "Parse or update daemon/device configuration";
 const char *subCmdConfigUsage =
     "--daemon --host ip-or-hostname-for-peer\n"
-    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able] [--cs_threshold_power_override val]\n"
+    "--device [--card bdf] [--security level] [--runtime_clk_scale en(dis)able] [--cs_threshold_power_override val] [--cs_reset val]\n"
     "--show [--daemon | --device [--card bdf]\n"
     "--enable_retention [--ddr] [--card bdf]\n"
     "--disable_retention [--ddr] [--card bdf]";
@@ -43,6 +43,7 @@ enum configs {
     CONFIG_SECURITY = 0,
     CONFIG_CLK_SCALING,
     CONFIG_CS_THRESHOLD_POWER_OVERRIDE,
+    CONFIG_CS_RESET,
 };
 typedef configs configType;
 
@@ -293,6 +294,14 @@ static void updateDevConf(pcidev::pci_device *dev,
             std::cout << "See dmesg log for details" << std::endl;
         }
         break;
+    case CONFIG_CS_RESET:
+        dev->sysfs_put("xmc", "scaling_reset", errmsg, lvl);
+        if (!errmsg.empty()) {
+            std::cout << "Error: Failed to reset clk scaling feature for " <<
+                dev->sysfs_name << "\n";
+            std::cout << "See dmesg log for details" << std::endl;
+        }
+        break;
     }
 }
 
@@ -306,6 +315,7 @@ static int device(int argc, char *argv[])
         { "security", required_argument, nullptr, '1' },
         { "runtime_clk_scale", required_argument, nullptr, '2' },
         { "cs_threshold_power_override", required_argument, nullptr, '3' },
+        { "cs_reset", required_argument, nullptr, '4' },
         { nullptr, 0, nullptr, 0 },
     };
 
@@ -331,6 +341,10 @@ static int device(int argc, char *argv[])
         case '3':
             lvl = optarg;
             config_type = CONFIG_CS_THRESHOLD_POWER_OVERRIDE;
+            break;
+        case '4':
+            lvl = optarg;
+            config_type = CONFIG_CS_RESET;
             break;
         default:
             return -EINVAL;


### PR DESCRIPTION
Added new sysfs node "scaling_reset" under xmc to reset the power & temperature's threshold & target values to default settings.

One can reset clock scaling settings to default values using xbmgmt tool also with "--cs_reset 1"

CR-1055356

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>