### PR TITLE
CR-1058962: LOP Trace Missing Events

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.cpp
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.cpp
@@ -31,7 +31,7 @@ namespace xdp {
   {
   }
 
-  void OpenCLAPICall::dump(std::ofstream& fout, int bucket)
+  void OpenCLAPICall::dump(std::ofstream& fout, uint32_t bucket)
   {
     VTFEvent::dump(fout, bucket) ;
     fout << "," << functionName << std::endl ;

--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
@@ -36,7 +36,7 @@ namespace xdp {
     inline uint64_t getQueueAddress() { return queueAddress ; } 
 
     virtual bool isOpenCLAPI() { return true ; } 
-    XDP_EXPORT virtual void dump(std::ofstream& fout, int bucket) ;
+    XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
@@ -35,7 +35,7 @@ namespace xdp {
 
     inline uint64_t getQueueAddress() { return queueAddress ; } 
 
-    virtual bool isOpenCLAPI() { return true ; } 
+    virtual bool isOpenCLAPI() { return true ; }
     XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 


### PR DESCRIPTION
This pull request changes the signature and definition of the "dump" function in the OpenCLAPI event class used in low overhead profiling.  The mismatch resulted in the base class function being called instead of the derived class on certain operating systems where int and uint32_t were different types, resulting in incorrect CSV files being generated which could not be successfully parsed.