### PR TITLE
CR-1059082 host to global bandwidth numbers are incorrect

### DIFF
--- a/src/runtime_src/core/pcie/windows/perf.cpp
+++ b/src/runtime_src/core/pcie/windows/perf.cpp
@@ -47,15 +47,15 @@ xclGetDeviceTimestamp(xclDeviceHandle handle)
 
 double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-   return 0.0;
+  return 9600.0;
 }
-
-#if 0
-
 
 double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
+  return 9600.0;
 }
+
+#if 0
 
 void xclSetProfilingNumberSlots(xclDeviceHandle handle, enum xclPerfMonType type,
                                 uint32_t numSlots)

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -683,4 +683,14 @@ DeviceIntf::~DeviceIntf()
       traceDMA->parseTraceBuf(traceData, bytes, traceVector);
   }
 
+  void DeviceIntf::setMaxBwRead()
+  {
+    m_bw_read = mDevice->getMaxBwRead();
+  }
+
+  void DeviceIntf::setMaxBwWrite()
+  {
+    m_bw_read = mDevice->getMaxBwWrite();
+  }
+
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -149,6 +149,13 @@ class DeviceIntf {
     XDP_EXPORT
     void parseTraceData(void* traceData, uint64_t bytes, xclTraceResultsVector& traceVector);
 
+    double getMaxBwRead() const {return m_bw_read;}
+    double getMaxBwWrite() const {return m_bw_write;}
+    XDP_EXPORT
+    void setMaxBwRead();
+    XDP_EXPORT
+    void setMaxBwWrite();
+
     inline xdp::Device* getAbstractDevice() { return mDevice ; }
 
   private:
@@ -172,8 +179,17 @@ class DeviceIntf {
 
     TraceS2MM* traceDMA = nullptr;
 
-// lapc ip data holder
-//
+    /*
+     * Set bandwidth number to a reasonable default
+     * For PCIE Device:
+     *   bw_per_lane = 985 MB/s (Wikipedia on PCIE 3.0)
+     *   num_lanes = 16/8/4 depending on host system
+     *   total bw = bw_per_lane * num_lanes
+     * For Edge Device:
+     *  total bw = DDR4 memory bandwidth
+     */
+    double m_bw_read = 9600.0;
+    double m_bw_write = 9600.0;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -153,5 +153,15 @@ uint64_t HalDevice::getDeviceAddr(size_t id)
   return (!xclGetBOProperties(mHalDevice, mBOHandles[boIndex], &p)) ? p.paddr : ((uint64_t)-1);
 }
 
+double HalDevice::getMaxBwRead()
+{
+  return xclGetReadMaxBandwidthMBps(mHalDevice);
+}
+
+double HalDevice::getMaxBwWrite()
+{
+  return xclGetWriteMaxBandwidthMBps(mHalDevice);
+}
+
 }
 

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -55,6 +55,9 @@ public:
   virtual void sync(size_t xdpBoHandle, size_t sz, size_t offset, direction dir, bool async=false);
   virtual uint64_t getDeviceAddr(size_t xdpBoHandle);
   virtual void* getRawDevice() { return mHalDevice ; }
+
+  virtual double getMaxBwRead();
+  virtual double getMaxBwWrite();
 };
 }
 

--- a/src/runtime_src/xdp/profile/device/xdp_base_device.h
+++ b/src/runtime_src/xdp/profile/device/xdp_base_device.h
@@ -58,6 +58,9 @@ public:
   virtual int getTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz) = 0;
   virtual int readTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample) = 0;
 
+  virtual double getMaxBwRead() = 0;
+  virtual double getMaxBwWrite() = 0;
+
   virtual void* getRawDevice() = 0 ;
 
 };

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
@@ -140,5 +140,15 @@ uint64_t XrtDevice::getDeviceAddr(size_t xdpBoHandle)
   return mXrtDevice->getDeviceAddr(m_bos[idx]);
 }
 
+double XrtDevice::getMaxBwRead()
+{
+  return mXrtDevice->getDeviceMaxRead().get();
+}
+
+double XrtDevice::getMaxBwWrite()
+{
+  return mXrtDevice->getDeviceMaxWrite().get();
+}
+
 }
 

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
@@ -60,6 +60,9 @@ public:
   virtual void sync(size_t xdpBoHandle, size_t sz, size_t offset, direction dir, bool async=false);
   virtual uint64_t getDeviceAddr(size_t xdpBoHandle);
   virtual void* getRawDevice() { return mXrtDevice ; } 
+
+  virtual double getMaxBwRead();
+  virtual double getMaxBwWrite();
 };
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ocl/ocl_profiler.h
+++ b/src/runtime_src/xdp/profile/plugin/ocl/ocl_profiler.h
@@ -29,6 +29,8 @@
 
 namespace xdp {
 
+  using oclDeviceData = xoclp::platform::device::data;
+
   class OCLProfiler {
   public:
     static OCLProfiler* Instance();
@@ -94,6 +96,8 @@ namespace xdp {
                              std::chrono::steady_clock::time_point end);
 
     uint64_t getDeviceDDRBufferSize(DeviceIntf* dInt, xocl::device* device);
+
+    oclDeviceData* initializeDeviceInterface(xocl::device* device);
 
   private:
     // Flags

--- a/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/xocl_profile.cpp
@@ -634,6 +634,9 @@ double
 getMaxRead(key k)
 {
   auto device = k;
+  auto device_interface = get_device_interface(device);
+  if (device_interface)
+    return device_interface->getMaxBwRead();
   return device->get_xrt_device()->getDeviceMaxRead().get();
 }
 
@@ -641,6 +644,9 @@ double
 getMaxWrite(key k)
 {
   auto device = k;
+  auto device_interface = get_device_interface(device);
+  if (device_interface)
+    return device_interface->getMaxBwRead();
   return device->get_xrt_device()->getDeviceMaxWrite().get();
 }
 


### PR DESCRIPTION
Reason: xrtcore:: device gets destroyed before profiling can query it
Solution: use device interface to manage these values and read them in advance