### PR TITLE
Add ImportBO and ExportBO in Windows

### DIFF
--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1421,6 +1421,20 @@ xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
   return shim->exec_wait(timeoutMilliSec);
 }
 
+int xclExportBO(xclDeviceHandle handle, unsigned int boHandle)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclExportBO() NOT IMPLEMENTED");
+  return ERROR_INVALID_FUNCTION;
+}
+
+xclBufferHandle xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclImportBO() NOT IMPLEMENTED");
+  return INVALID_HANDLE_VALUE;
+}
+
 int
 xclGetBOProperties(xclDeviceHandle handle, xclBufferHandle boHandle,
 		   struct xclBOProperties *properties)


### PR DESCRIPTION
The fix implemented for CR-1040791. The Windows XRT doesn't support these functions and returns "NON SUPPORTED" status now. 