### PR TITLE
XRT-362: Use uuid for kernelopen APIs

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -61,7 +61,7 @@ device::
 register_axlf(const axlf* top)
 {
   uuid_copy(m_xclbin_uuid, top->m_header.uuid);
-  axlf_section_kind kinds[] = {EMBEDDED_METADATA, AIE_METADATA};
+  axlf_section_kind kinds[] = {EMBEDDED_METADATA, AIE_METADATA, IP_LAYOUT};
   for (auto kind : kinds) {
     auto hdr = xclbin::get_axlf_section(top, kind);
     if (!hdr)
@@ -80,6 +80,15 @@ get_axlf_section(axlf_section_kind section) const
   return itr != m_axlf_sections.end()
     ? std::make_pair((*itr).second.data(), (*itr).second.size())
     : std::make_pair(nullptr, 0);
+}
+
+std::pair<const char*, size_t>
+device::
+get_axlf_section(axlf_section_kind section, const xuid_t xclbin_id) const
+{
+  if (uuid_compare(xclbin_id, m_xclbin_uuid))
+    throw std::runtime_error("xclbin id mismatch");
+  return get_axlf_section(section);
 }
 
 std::string

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -199,6 +199,16 @@ public:
   std::pair<const char*, size_t>
   get_axlf_section(axlf_section_kind section) const;
 
+  /**
+   * get_axlf_section() - Get section from currently loaded axlf
+   * 
+   * xclbin_id:  Check that xclbin_id matches currently cached
+   *
+   * Same behavior as other get_axlf_section()
+   */
+  std::pair<const char*, size_t>
+  get_axlf_section(axlf_section_kind section, const xuid_t xclbin_id) const;
+
   // Move all these 'pt' functions out the class interface
   virtual void get_info(boost::property_tree::ptree&) const {}
   virtual void read_dma_stats(boost::property_tree::ptree&) const {}

--- a/src/runtime_src/core/common/exec/exec.cpp
+++ b/src/runtime_src/core/common/exec/exec.cpp
@@ -106,7 +106,7 @@ schedule(command* cmd)
 }
 
 void
-init(xrt_core::device* device, const axlf* top)
+init(xrt_core::device* device)
 {
   struct X {
     ~X() { try { stop(); } catch (...) { } } // coverity
@@ -120,11 +120,11 @@ init(xrt_core::device* device, const axlf* top)
   }
 
   if (pts_enabled())
-    pts::init(device,top);
+    pts::init(device);
   if (kds_enabled())
-    kds::init(device,top);
+    kds::init(device);
   else
-    sws::init(device,top);
+    sws::init(device);
 }
 
 }} // exec, xrt_core

--- a/src/runtime_src/core/common/exec/exec.h
+++ b/src/runtime_src/core/common/exec/exec.h
@@ -20,8 +20,6 @@
 #include <vector>
 #include <memory>
 
-struct axlf;
-
 namespace xrt_core {
 
 class device;
@@ -42,7 +40,7 @@ void
 stop();
 
 void
-init(xrt_core::device* device, const axlf* top);
+init(xrt_core::device* device);
 
 void
 init(xrt_core::device* device, const std::vector<uint64_t>& cu_addr_map);
@@ -66,12 +64,6 @@ stop();
 void
 init(xrt_core::device* device);
 
-inline void
-init(xrt_core::device* device, const axlf*)
-{
-  init(device);
-}
-
 } // kds
 
 /**
@@ -91,12 +83,6 @@ stop();
 void
 init(xrt_core::device* device);
 
-inline void
-init(xrt_core::device* device, const axlf*)
-{
-  init(device);
-}
-
 } // pts
 
 namespace exec {
@@ -113,7 +99,7 @@ void
 stop();
 
 void
-init(xrt_core::device* device, const axlf* top);
+init(xrt_core::device* device);
 
 } // scheduler
 

--- a/src/runtime_src/core/common/exec/sws.cpp
+++ b/src/runtime_src/core/common/exec/sws.cpp
@@ -909,12 +909,17 @@ init(xrt_core::device* xdev, const std::vector<uint64_t>& cu_addr_map)
 }
 
 void
-init(xrt_core::device* xdev, const axlf* top)
+init(xrt_core::device* xdev)
 {
+  auto ip_section = xdev->get_axlf_section(IP_LAYOUT);
+  auto ip_layout = reinterpret_cast<const ::ip_layout*>(ip_section.first);
+  if (!ip_layout)
+    throw std::runtime_error("No ip layout available to initialize sws, make sure xclbin is loaded");
+  
   // create execution core for this device
   auto slots = ERT_CQ_SIZE / xrt_core::config::get_ert_slotsize();
   cu_trace_enabled = xrt_core::config::get_profile();
-  auto cuaddrs = xrt_core::xclbin::get_cus(top);
+  auto cuaddrs = xrt_core::xclbin::get_cus(ip_layout);
   std::vector<addr_type> amap(cuaddrs.begin(),cuaddrs.end());
   s_device_exec_core.erase(xdev);
   s_device_exec_core.insert

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -442,17 +442,9 @@ get_kernel_freq(const axlf* top)
 }
 
 std::vector<kernel_argument>
-get_kernel_arguments(const axlf* top, const std::string& kname)
+get_kernel_arguments(const char* xml_data, size_t xml_size, const std::string& kname)
 {
   std::vector<kernel_argument> args;
-  const axlf_section_header *xml_hdr = ::xclbin::get_axlf_section(top, EMBEDDED_METADATA);
-
-  if (!xml_hdr)
-    throw std::runtime_error("No meta data in xclbin");
-
-  auto begin = reinterpret_cast<const char*>(top) + xml_hdr->m_sectionOffset;
-  const char *xml_data = reinterpret_cast<const char*>(begin);
-  uint64_t xml_size = xml_hdr->m_sectionSize;
 
   pt::ptree xml_project;
   std::stringstream xml_stream;
@@ -487,6 +479,21 @@ get_kernel_arguments(const axlf* top, const std::string& kname)
     break;
   }
   return args;
+}
+
+std::vector<kernel_argument>
+get_kernel_arguments(const axlf* top, const std::string& kname)
+{
+  const axlf_section_header *xml_hdr = ::xclbin::get_axlf_section(top, EMBEDDED_METADATA);
+
+  if (!xml_hdr)
+    throw std::runtime_error("No meta data in xclbin");
+
+  auto begin = reinterpret_cast<const char*>(top) + xml_hdr->m_sectionOffset;
+  auto xml_data = reinterpret_cast<const char*>(begin);
+  auto xml_size = xml_hdr->m_sectionSize;
+
+  return get_kernel_arguments(xml_data, xml_size, kname);
 }
 
 //This function will be removed once IP_LAYOUT section is available in sw emu rtd.

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -194,6 +194,18 @@ get_kernel_freq(const axlf* top);
 /**
  * get_kernel_arguments() - Get argument meta data for a kernel
  *
+ * @xml_data: XML metadata from xclbin
+ * @xml_size: Size of XML metadata from xclbin
+ * @kname : Name of kernel
+ * Return: List of argument per struct kernel_argument
+ */
+XRT_CORE_COMMON_EXPORT
+std::vector<kernel_argument>
+get_kernel_arguments(const char* xml_data, size_t xml_size, const std::string& kname);
+
+/**
+ * get_kernel_arguments() - Get argument meta data for a kernel
+ *
  * @kname : Name of kernel
  * Return: List of argument per struct kernel_argument
  */

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -53,7 +53,7 @@ typedef void * xrtRunHandle;
  * xrtPLKernelOpen() - Open a PL kernel and obtain its handle.
  *
  * @deviceHandle:  Handle to the device with the kernel
- * @xclbin:        The xclbin with the specified kernel.
+ * @xclbinId:      The uuid of the xclbin with the specified kernel.
  * @name:          Name of kernel to open.
  * Return:         Handle representing the opened kernel.
  *
@@ -73,7 +73,7 @@ typedef void * xrtRunHandle;
  */
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
-xrtPLKernelOpen(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
+xrtPLKernelOpen(xrtDeviceHandle deviceHandle, const xuid_t xclbinId, const char *name);
 
 /**
  * xrtPLKernelOpenExclusive() - Open a PL kernel and obtain its handle.
@@ -84,7 +84,7 @@ xrtPLKernelOpen(xrtDeviceHandle deviceHandle, const char* xclbin, const char *na
  */
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
-xrtPLKernelOpenExclusive(xrtDeviceHandle deviceHandle, const char* xclbin, const char *name);
+xrtPLKernelOpenExclusive(xrtDeviceHandle deviceHandle, const xuid_t xclbinId, const char *name);
 
 /**
  * xrtKernelClose() - Close an opened kernel

--- a/src/runtime_src/core/include/windows/uuid.h
+++ b/src/runtime_src/core/include/windows/uuid.h
@@ -38,6 +38,12 @@ uuid_clear(xuid_t uuid)
   std::memset(uuid, 0, sizeof(xuid_t));
 }
 
+inline int
+uuid_compare(const xuid_t uuid1, const xuid_t uuid2)
+{
+  return memcmp(uuid1, uuid2, sizeof(xuid_t));
+}
+
 inline void
 uuid_unparse_lower(const xuid_t uuid, char* str)
 {

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -190,9 +190,8 @@ int main(int argc, char** argv)
        if (first_mem < 0)
            return 1;
 
-
        std::string kname = "loopback";
-       auto kernel = xrtPLKernelOpen(handle, header.data(), kname.c_str());
+       auto kernel = xrtPLKernelOpen(handle, top->m_header.uuid, kname.c_str());
 
        auto boHandle2 = xclAllocBO(handle, DATA_SIZE, XCL_BO_DEVICE_RAM, first_mem);
        char* bo2 = (char*)xclMapBO(handle, boHandle2, true);

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -279,19 +279,19 @@ int run(int argc, char** argv)
 
   auto header = load_xclbin(device, xclbin_fnm);
   auto top = reinterpret_cast<const axlf*>(header.data());
-  auto ip = xclbin::get_axlf_section(top, IP_LAYOUT);
-  auto layout = reinterpret_cast<ip_layout*>(header.data() + ip->m_sectionOffset);
   auto topo = xclbin::get_axlf_section(top, MEM_TOPOLOGY);
   auto topology = reinterpret_cast<mem_topology*>(header.data() + topo->m_sectionOffset);
 
-  uuid_t xclbin_id;
-  uuid_copy(xclbin_id, top->m_header.uuid);
+  {
+    // Demo xrt_xclbin API retrieving uuid from kernel if applicable
+    uuid_t xclbin_id;
+    uuid_copy(xclbin_id, top->m_header.uuid);
 
-  uuid_t xid;
-  xrtXclbinUUID(device, xid);
-
-  if (uuid_compare(xclbin_id, xid) != 0)
-    throw std::runtime_error("xid mismatch");
+    uuid_t xid;
+    xrtXclbinUUID(device, xid);
+    if (uuid_compare(xclbin_id, xid) != 0)
+      throw std::runtime_error("xid mismatch");
+  }
 
   int first_used_mem = 0;
   for (int i=0; i<topology->m_count; ++i) {
@@ -303,7 +303,7 @@ int run(int argc, char** argv)
 
   compute_units = cus = std::min(cus, compute_units);
   std::string kname = get_kernel_name(cus);
-  auto kernel = xrtPLKernelOpen(device, header.data(), kname.c_str());
+  auto kernel = xrtPLKernelOpen(device, top->m_header.uuid, kname.c_str());
 
   run(device,kernel,jobs,secs,first_used_mem);
 


### PR DESCRIPTION
XCL_DRIVER_DLLESPEC
xrtKernelHandle
xrtPLKernelOpen(xrtDeviceHandle deviceHandle, **const xuid_t xclbinId**, const char *name);