### PR TITLE
XRT-186 data retention new flow

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -713,7 +713,7 @@ struct xocl_subdev_map {
 	((struct resource []) {				\
 		{					\
 			.start	= 0x0,			\
-			.end	= 0x4FFF,		\
+			.end	= 0x7FFF,		\
 			.flags  = IORESOURCE_MEM,	\
 		}					\
 	})

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
@@ -49,6 +49,9 @@ static int axigate_freeze(struct platform_device *pdev)
 	if (!freeze)
 		goto done; /* Already freeze */
 
+	reg_wr(gate, 0x1, iag_wr);
+	ndelay(500);
+
 	reg_wr(gate, 0, iag_wr);
 	ndelay(500);
 	(void) reg_rd(gate, iag_rd);
@@ -73,7 +76,7 @@ static int axigate_free(struct platform_device *pdev)
 	if (freeze)
 		goto done; /* Already free */
 
-	reg_wr(gate, 0x2, iag_wr);
+	reg_wr(gate, 0x1, iag_wr);
 	ndelay(500);
 	(void) reg_rd(gate, iag_rd);
 	reg_wr(gate, 0x3, iag_wr);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -598,7 +598,7 @@ done:
  */
 static int clock_ocl_freqscaling(struct clock *clock, bool force, int level)
 {
-	int i, err;
+	int i, err = 0;
 	u32 curr[CLOCK_MAX_NUM_CLOCKS] = { 0 };
 
 	/* Read current clock freq before freeze/toggle axi gate */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ddr_srsr.c
@@ -25,14 +25,6 @@
 #define	REG_CALIB_OFFSET		0x00000008
 #define	REG_XSDB_RAM_BASE		0x00004000
 
-#define	XSDB_RAM_MAX_IN_WORDS		2902
-#define XOCL_CALIB_CACHE_SIZE		XSDB_RAM_MAX_IN_WORDS*4
-
-/* Calibration cache size may up to XSDB_RAM_MAX_IN_WORDS*4 = ~12kB
- * And XSDB_RAM_SIZE is 4kB, need to read the cache from XSDB_RAM at least 3 times.
- */
-#define	TIMES_TO_READ_XSDB_RAM		3
-
 #define	FULL_CALIB_TIMEOUT		100
 #define	FAST_CALIB_TIMEOUT		15
 
@@ -53,6 +45,7 @@ struct xocl_ddr_srsr {
 	struct device		*dev;
 	struct mutex		lock;
 	uint32_t		*calib_cache;
+	uint32_t		cache_size;
 	bool			restored;
 };
 
@@ -103,13 +96,11 @@ static int srsr_save_calib(struct platform_device *pdev)
 	xdev_handle_t xdev = SRSR_DEV2XDEV(xocl_ddr_srsr->dev);
 	int i = 0, err = -ETIMEDOUT;
 	u32 val = 0;
+	u32 cache_size_in_words = xocl_ddr_srsr->cache_size/sizeof(uint32_t);
+
+	BUG_ON(!xocl_ddr_srsr->calib_cache);
 
 	mutex_lock(&xocl_ddr_srsr->lock);
-	if (!xocl_ddr_srsr->calib_cache) {
-		err = -EINVAL;
-		goto done;
-	}
-
 	xocl_dr_reg_write32(xdev, CTRL_BIT_SREF_REQ, xocl_ddr_srsr->base+REG_CTRL_OFFSET);
 	for ( ; i < 20; ++i) {
 		val = xocl_dr_reg_read32(xdev, xocl_ddr_srsr->base+REG_STATUS_OFFSET);
@@ -122,12 +113,11 @@ static int srsr_save_calib(struct platform_device *pdev)
 
 	xocl_dr_reg_write32(xdev, CTRL_BIT_SREF_REQ | CTRL_BIT_XSDB_SELECT, xocl_ddr_srsr->base+REG_CTRL_OFFSET);
 
-	for (i = 0; i < XSDB_RAM_MAX_IN_WORDS; ++i) {
+	for (i = 0; i < cache_size_in_words; ++i) {
 		val = xocl_dr_reg_read32(xdev, xocl_ddr_srsr->base+REG_XSDB_RAM_BASE+i*4);
 		*(xocl_ddr_srsr->calib_cache+i) = val;
 	}
 
-done:
 	mutex_unlock(&xocl_ddr_srsr->lock);
 	return err;
 }
@@ -138,6 +128,7 @@ static int srsr_fast_calib(struct platform_device *pdev, bool retention)
 	xdev_handle_t xdev = SRSR_DEV2XDEV(xocl_ddr_srsr->dev);
 	int i = 0, err = -ETIMEDOUT;
 	u32 val, write_val = CTRL_BIT_RESTORE_EN | CTRL_BIT_XSDB_SELECT;
+	u32 cache_size_in_words = xocl_ddr_srsr->cache_size/sizeof(uint32_t);
 
 	BUG_ON(!xocl_ddr_srsr->calib_cache);
 
@@ -147,7 +138,7 @@ static int srsr_fast_calib(struct platform_device *pdev, bool retention)
 	xocl_dr_reg_write32(xdev, write_val, xocl_ddr_srsr->base+REG_CTRL_OFFSET);
 
 	msleep(20);
-	for (i = 0; i < XSDB_RAM_MAX_IN_WORDS; ++i) {
+	for (i = 0; i < cache_size_in_words; ++i) {
 		val = *(xocl_ddr_srsr->calib_cache+i);
 		xocl_dr_reg_write32(xdev, val, xocl_ddr_srsr->base+REG_XSDB_RAM_BASE+i*4);
 	}
@@ -176,7 +167,9 @@ static int srsr_fast_calib(struct platform_device *pdev, bool retention)
 static int srsr_calib(struct platform_device *pdev, bool retention)
 {
 	struct xocl_ddr_srsr *xocl_ddr_srsr = platform_get_drvdata(pdev);
+	xdev_handle_t xdev = SRSR_DEV2XDEV(xocl_ddr_srsr->dev);
 	int err = -1;
+	uint32_t addr0, addr1;
 
 	mutex_lock(&xocl_ddr_srsr->lock);
 
@@ -187,13 +180,34 @@ static int srsr_calib(struct platform_device *pdev, bool retention)
 	 * Wipe out calibration cache before full calibration
 	 */
 	if (err) {
+		err = srsr_full_calibration(pdev);
+		if (err)
+			goto done;
+
+		/* END_ADDR0/1 provides the end address for a given memory configuration
+		 * END_ADDR 0 is lower 9 bits, the other one is higher 9 bits
+		 * E.g. addr0 = 0x155,     0'b 1 0101 0101
+		 *      addr1 = 0x5    0'b 0101
+		 *                     0'b 01011 0101 0101
+		 *                   =  0xB55
+		 * and the total size is 0xB55+1
+		 * Check the value, it should not excess predefined XSDB range
+		 */
+		addr0 = xocl_dr_reg_read32(xdev, xocl_ddr_srsr->base+REG_XSDB_RAM_BASE+4);
+		addr1 = xocl_dr_reg_read32(xdev, xocl_ddr_srsr->base+REG_XSDB_RAM_BASE+8);
+
+		xocl_ddr_srsr->cache_size = (((addr1 << 9) | addr0)+1)*sizeof(uint32_t);
+
+		if (xocl_ddr_srsr->cache_size >= 0x4000) {
+			err = -ENOMEM;
+			goto done;
+		}
 		vfree(xocl_ddr_srsr->calib_cache);
-		xocl_ddr_srsr->calib_cache = vzalloc(XOCL_CALIB_CACHE_SIZE);
+		xocl_ddr_srsr->calib_cache = vzalloc(xocl_ddr_srsr->cache_size);
 		if (!xocl_ddr_srsr->calib_cache) {
 			err = -ENOMEM;
 			goto done;
 		}
-		err = srsr_full_calibration(pdev);
 	}
 done:
 	mutex_unlock(&xocl_ddr_srsr->lock);
@@ -207,31 +221,46 @@ static int srsr_read_calib(struct platform_device *pdev, void *calib_cache, uint
 
 	BUG_ON(!xocl_ddr_srsr->calib_cache);
 	BUG_ON(!calib_cache);
-	BUG_ON(size != XOCL_CALIB_CACHE_SIZE);
+	BUG_ON(size != xocl_ddr_srsr->cache_size);
 
+	mutex_lock(&xocl_ddr_srsr->lock);
 	memcpy(calib_cache, xocl_ddr_srsr->calib_cache, size);
-
+	mutex_unlock(&xocl_ddr_srsr->lock);
 	return ret;
 }
 
 static int srsr_write_calib(struct platform_device *pdev, const void *calib_cache, uint32_t size)
 {
-	int ret = 0;
+	int ret = 0, err = 0;
 	struct xocl_ddr_srsr *xocl_ddr_srsr = platform_get_drvdata(pdev);
 
-	BUG_ON(!xocl_ddr_srsr->calib_cache);
 	BUG_ON(!calib_cache);
-	BUG_ON(size != XOCL_CALIB_CACHE_SIZE);
+
+	mutex_lock(&xocl_ddr_srsr->lock);
+	xocl_ddr_srsr->cache_size = size;
+
+	vfree(xocl_ddr_srsr->calib_cache);
+	xocl_ddr_srsr->calib_cache = vzalloc(xocl_ddr_srsr->cache_size);
+	if (!xocl_ddr_srsr->calib_cache) {
+		err = -ENOMEM;
+		goto done;
+	}
 
 	memcpy(xocl_ddr_srsr->calib_cache, calib_cache, size);
 
 	xocl_ddr_srsr->restored = true;
+done:
+	mutex_unlock(&xocl_ddr_srsr->lock);
 	return ret;
 }
 
 static uint32_t srsr_cache_size(struct platform_device *pdev)
 {
-	return XOCL_CALIB_CACHE_SIZE;
+	struct xocl_ddr_srsr *xocl_ddr_srsr = platform_get_drvdata(pdev);
+
+	BUG_ON(!xocl_ddr_srsr->calib_cache);
+
+	return xocl_ddr_srsr->cache_size;
 }
 
 
@@ -270,12 +299,6 @@ static int xocl_ddr_srsr_probe(struct platform_device *pdev)
 	}
 	mutex_init(&xocl_ddr_srsr->lock);
 	platform_set_drvdata(pdev, xocl_ddr_srsr);
-
-	xocl_ddr_srsr->calib_cache = vzalloc(XOCL_CALIB_CACHE_SIZE);
-	if (!xocl_ddr_srsr->calib_cache) {
-		err = -ENOMEM;
-		goto create_xocl_ddr_srsr_failed;
-	}
 
 	err = sysfs_create_group(&pdev->dev.kobj, &xocl_ddr_srsr_attrgroup);
 	if (err)

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1897,7 +1897,7 @@ int xcldev::xclCma(int argc, char *argv[])
     } else if (!ret) {
         std::cout << "xbutil cma done successfully" << std::endl;
     } else if (ret) {
-        std::cout << "ERROR: " << strerror(std::abs(ret)) << std::endl;
+        std::cout << "ERROR: " << strerror(ret) << std::endl;
     }
 
     return ret;


### PR DESCRIPTION
Data Retention new flow.

1. ulp isolate sequence (0x3 => 0x1 => 0x0), undo (0x0 => 0x1 => 0x3)

2. word-addressing XSDB

3. move icap_save_calib before destroy ULP level sub-devices
          