### PR TITLE
zocl: Fix build for Linux kernel 5.6

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -12,7 +12,7 @@
  */
 
 
-#include <drm/drmP.h>
+#include <drm/drm_print.h>
 #include <linux/io.h>
 
 #include "zocl_cu.h"

--- a/src/runtime_src/core/edge/drm/zocl/zocl_dma.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_dma.c
@@ -15,7 +15,7 @@
  */
 
 #include "zocl_dma.h"
-#include <drm/drmP.h>
+#include <drm/drm_print.h>
 
 static void zocl_dma_irq_done(void *data)
 {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -15,6 +15,7 @@
  * License version 2 or Apache License, Version 2.0.
  */
 
+#include <linux/delay.h>
 #include <linux/dma-buf.h>
 #include <linux/module.h>
 #include <linux/fpga/fpga-mgr.h>
@@ -24,6 +25,7 @@
 #include <linux/kernel.h>
 #include <linux/of_address.h>
 #include <linux/of_irq.h>
+#include <linux/poll.h>
 #include <linux/spinlock.h>
 #include "zocl_drv.h"
 #include "zocl_sk.h"

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
@@ -16,7 +16,8 @@
 
 #ifndef _ZOCL_DRV_H_
 #define _ZOCL_DRV_H_
-#include <drm/drmP.h>
+#include <drm/drm_device.h>
+#include <drm/drm_drv.h>
 #include <drm/drm_gem.h>
 #include <drm/drm_mm.h>
 #include <drm/drm_gem_cma_helper.h>

--- a/src/runtime_src/core/edge/drm/zocl/zocl_generic_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_generic_cu.c
@@ -11,8 +11,9 @@
  * License version 2 or Apache License, Version 2.0.
  */
 
-#include <drm/drmP.h>
+#include <drm/drm_print.h>
 #include <linux/anon_inodes.h>
+#include <linux/poll.h>
 #include "zocl_util.h"
 #include "sched_exec.h"
 #include "zocl_generic_cu.h"

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
@@ -12,6 +12,7 @@
  * License version 2 or Apache License, Version 2.0.
  */
 
+#include <linux/delay.h>
 #include <linux/kthread.h>
 #include <linux/platform_device.h>
 


### PR DESCRIPTION
drm/drmP.h header has been dropped from Linux kernel 5.5+ in favour of
including really required headers.

Fix #3113 

Reference: https://github.com/torvalds/linux/commit/4e98f871bcffa322850c73d22c66bbd7af2a0374 ("drm: delete drmP.h + drm_os_linux.h")
