### PR TITLE
edge: Fix drm_mode.h include

### DIFF
--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -74,7 +74,7 @@
 #ifndef __KERNEL__
 #include <stdint.h>
 #include <libdrm/drm.h>
-#include <drm/drm_mode.h>
+#include <libdrm/drm_mode.h>
 #else
 #include <uapi/drm/drm_mode.h>
 #endif /* !__KERNEL__ */


### PR DESCRIPTION
Original commit

    01178203434a ("[Edge] Remove drm.h and drm_mode.h (#2614)")

says that drm_mode.h has to come from libdrm, so change the path
accordingly to fix the build.