### PR TITLE
CR-1045886: Add XCL_STREAM flags for consistency with CL_MEM flags

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -190,13 +190,42 @@ xclGetMemObjectFromFd(cl_context context,
  */
 
 /**
- * cl_stream_flags. Type of the stream , eg set to CL_STREAM_READ_ONLY for
+ * cl_stream_flags. Type of the stream , eg set to XCL_STREAM_READ_ONLY for
  * read only. Used in clCreateStream()
+ *
+ * This flag specifies that the stream object is a read-only stream
+ * object when used inside a kernel.  Writing to a buffer or image object
+ * created with CL_STREAM_READ_ONLY inside a kernel is undefined.
  */
 typedef uint64_t cl_stream_flags;
-#define CL_STREAM_READ_ONLY			    (1 << 0)
-#define CL_STREAM_WRITE_ONLY                        (1 << 1)
-#define CL_STREAM_POLLING                           (1 << 2)
+#ifdef __GNUC__
+# define CL_STREAM_READ_ONLY                        _Pragma ("GCC warning \"CL_STREAM_READ_ONLY deprecated, please use XCL_STREAM_WRITE_ONLY\"") (1 << 0)
+# define CL_STREAM_WRITE_ONLY                       _Pragma ("GCC warning \"CL_STREAM_WRITE_ONLY deprecated, please use XCL_STREAM_READ_ONLY\"") (1 << 1)
+# define CL_STREAM_POLLING                          _Pragma ("GCC warning \"CL_STREAM_POLLING deprecated, please use XCL_STREAM_POLLING\"") (1 << 2)
+#else
+# define CL_STREAM_READ_ONLY                        (1 << 0)
+# define CL_STREAM_WRITE_ONLY                       (1 << 1)
+# define CL_STREAM_POLLING                          (1 << 2)
+#endif
+
+/**
+ * This flag specifies that the stream object is a read-only stream
+ * object when used inside a kernel.  Writing to a stream
+ * created with CL_STREAM_READ_ONLY inside a kernel is undefined.
+ */
+#define XCL_STREAM_READ_ONLY                        (1 << 1)
+
+/**
+ * This flag specifies that the stream object will be written but not
+ * read by a kernel.  Reading from a stream object created with
+ * CL_STREAM_WRITE_ONLY inside a kernel is undefined.
+ */
+#define XCL_STREAM_WRITE_ONLY                       (1 << 0)
+
+/**
+ * Unused
+ */
+#define XCL_STREAM_POLLING                          (1 << 2)
 
 /**
  * cl_stream_attributes. eg set it to CL_STREAM for stream mode. Used

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -36,6 +36,7 @@
 #pragma warning ( disable : 4244 4245 4267 4996 4505 )
 #endif
 
+
 namespace {
 
 static unsigned int uid_count = 0;
@@ -386,11 +387,11 @@ get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, con
 
     //TODO: Put an assert/throw if both read and write are not set, but currently that check will break as full m_tag not yet available
 
-    if(read && !(flags & CL_STREAM_READ_ONLY))
-      throw xocl::error(CL_INVALID_OPERATION,"Connecting a read stream to non-read stream, argument " + ext->flags);
+    if(read && !(flags & XCL_STREAM_WRITE_ONLY))
+      throw xocl::error(CL_INVALID_OPERATION,"Connecting a kernel write only stream to non-user-read stream, argument " + ext->flags);
 
-    if(write &&  !(flags & CL_STREAM_WRITE_ONLY))
-      throw xocl::error(CL_INVALID_OPERATION,"Connecting a write stream to non-write stream, argument " + ext->flags);
+    if(write &&  !(flags & XCL_STREAM_READ_ONLY))
+      throw xocl::error(CL_INVALID_OPERATION,"Connecting a kernel read stream to non-user-write stream, argument " + ext->flags);
 
     if(mem.m_type != MEM_STREAMING)
       throw xocl::error(CL_INVALID_OPERATION,"Connecting a streaming argument to non-streaming bank");
@@ -398,9 +399,9 @@ get_stream(xrt::device::stream_flags flags, xrt::device::stream_attrs attrs, con
     xocl(kernel)->set_argument(ext->flags,sizeof(cl_mem),nullptr);
   }
 
-  if (flags & CL_STREAM_READ_ONLY)
+  if (flags & XCL_STREAM_WRITE_ONLY)  // kernel writes, user reads
     rc = m_xdevice->createReadStream(flags, attrs, route, flow, stream);
-  else if (flags & CL_STREAM_WRITE_ONLY)
+  else if (flags & XCL_STREAM_READ_ONLY) // kernel reads, user writes
     rc = m_xdevice->createWriteStream(flags, attrs, route, flow, stream);
   else
     throw xocl::error(CL_INVALID_OPERATION,"Unknown stream type specified");


### PR DESCRIPTION
XCL_STREAM flags are kernel centric to match CL_MEM flags.