### PR TITLE
CR-1028065 qdma: add per stream aio context

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -217,6 +217,7 @@ typedef uint32_t cl_stream_attributes;
 #define CL_STREAM_NONBLOCKING                       (1 << 2)
 #define CL_STREAM_SILENT                            (1 << 3)
 
+typedef stream_opt_type              cl_stream_opt_type;
 typedef stream_xfer_req_type         cl_stream_xfer_req_type;
 typedef streams_poll_req_completions cl_streams_poll_req_completions;
 typedef stream_xfer_req              cl_stream_xfer_req;
@@ -316,6 +317,37 @@ clPollStreams(cl_device_id /*device*/,
 	cl_int /*timeout in ms*/,
 	cl_int * /*errcode_ret*/) CL_API_SUFFIX__VERSION_1_0;
 
+/* clPollStream - Poll a single stream on a device for completion.
+ * @stream                : The stream
+ * @completions           : Completions array
+ * @min_num_completions   : Minimum number of completions requested
+ * @max_num_completions   : Maximum number of completions requested
+ * @actual_num_completions: Actual number of completions returned.
+ * @timeout               : Timeout in milliseconds (ms)
+ * @errcode_ret :         : The return value eg CL_SUCCESS
+ * Return a cl_int.
+ */
+extern CL_API_ENTRY cl_int CL_API_CALL
+clPollStream(cl_stream             /* stream*/,
+       	cl_streams_poll_req_completions* /*completions*/,
+	cl_int  /*min_num_completion*/,
+	cl_int  /*max_num_completion*/,
+	cl_int* /*actual num_completion*/,
+	cl_int /*timeout in ms*/,
+	cl_int * /*errcode_ret*/) CL_API_SUFFIX__VERSION_1_0;
+
+/* clSetStreamOpt -Set stream options.
+ * @stream                : The stream
+ * @option                : the option type
+ * @val                   : the option value
+ * @errcode_ret :         : The return value eg CL_SUCCESS
+ * Return a cl_int.
+ */
+extern CL_API_ENTRY cl_int CL_API_CALL
+clSetStreamOpt(cl_stream             /* stream*/,
+	cl_stream_opt_type  /*option_type*/,
+	cl_int  /*option_value*/,
+	cl_int * /*errcode_ret*/) CL_API_SUFFIX__VERSION_1_0;
 //End QDMA APIs
 
 typedef struct _cl_mem * rte_mbuf;

--- a/src/runtime_src/core/include/stream.h
+++ b/src/runtime_src/core/include/stream.h
@@ -24,15 +24,6 @@
 extern "C" {
 #endif
 
-typedef enum stream_opt_type {
-    STREAM_OPT_AIO_MAX_EVENT = 1,	/* maximum # aio event */
-    STREAM_OPT_AIO_BATCH_THRESH_BYTES,	/* io batching threshold: # bytes */
-    STREAM_OPT_AIO_BATCH_THRESH_PKTS,	/* io_batching threshold: # request */
-    STREAM_OPT_AIO_BATCH_THRESH_TIMER,	/* io batching threshold: timer */
-
-    STREAM_OPT_MAX
-} stream_opt_type;
-
 /**
  * cl_stream_xfer_req.
  * For each read or write request, this extra data needs to be sent.

--- a/src/runtime_src/core/include/stream.h
+++ b/src/runtime_src/core/include/stream.h
@@ -24,7 +24,14 @@
 extern "C" {
 #endif
 
-typedef uint32_t stream_xfer_req_type;
+typedef enum stream_opt_type {
+    STREAM_OPT_AIO_MAX_EVENT = 1,	/* maximum # aio event */
+    STREAM_OPT_AIO_BATCH_THRESH_BYTES,	/* io batching threshold: # bytes */
+    STREAM_OPT_AIO_BATCH_THRESH_PKTS,	/* io_batching threshold: # request */
+    STREAM_OPT_AIO_BATCH_THRESH_TIMER,	/* io batching threshold: timer */
+
+    STREAM_OPT_MAX
+} stream_opt_type;
 
 /**
  * cl_stream_xfer_req.

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -650,6 +650,49 @@ mtx.unlock();
   xclPollCompletion_SET_PROTO_RESPONSE(vaLenMap); \
   FREE_BUFFERS();
 
+//----------xclPollQueue-------------------
+#define xclPollQueue_SET_PROTOMESSAGE(q_handle,reqcounter) \
+    c_msg.set_q_handle(q_handle); \
+    c_msg.set_req(reqcounter); \
+
+#define xclPollQueue_SET_PROTO_RESPONSE(vaLenMap) \
+  std::map<uint64_t,uint64_t>::iterator vaLenMapItr = vaLenMap.begin();\
+  if(r_msg.fullrequest_size() == (int)(vaLenMap.size()))\
+  {\
+    for(int i = 0; i < r_msg.fullrequest_size() ; i++) \
+    { \
+      const xclPollQueue_response::request &oReq = r_msg.fullrequest(i); \
+      uint64_t read_size = oReq.size();\
+      numBytesProcessed  += read_size; \
+      if((*vaLenMapItr).second != 0) \
+        memcpy((void*)(*vaLenMapItr).first,oReq.dest().c_str(),read_size);\
+      vaLenMapItr++;\
+    } \
+  }\
+
+#define xclPollQueue_RPC_CALL(func_name,q_handle, reqcounter,vaLenMap) \
+  RPC_PROLOGUE(func_name); \
+  xclPollQueue_SET_PROTOMESSAGE(q_handle, reqcounter); \
+  SERIALIZE_AND_SEND_MSG(func_name) \
+  xclPollQueue_SET_PROTO_RESPONSE(vaLenMap); \
+  FREE_BUFFERS();
+
+//----------xclSetQueueOpt-------------------
+#define xclSetQueueOpt_SET_PROTOMESSAGE(q_handle,type,val) \
+    c_msg.set_q_handle(q_handle); \
+    c_msg.set_type(type); \
+    c_msg.set_val(val);
+
+#define xclSetQueueOpt_SET_PROTO_RESPONSE() \
+  success = r_msg.success();
+
+#define xclSetQueueOpt_RPC_CALL(func_name,q_handle,type,val) \
+  RPC_PROLOGUE(func_name); \
+  xclSetQueueOpt_SET_PROTOMESSAGE(q_handle,type,val); \
+  SERIALIZE_AND_SEND_MSG(func_name) \
+  xclSetQueueOpt_SET_PROTO_RESPONSE(); \
+  FREE_BUFFERS();
+
 //----------xclDestroyQueue-------------------
 #define xclDestroyQueue_SET_PROTOMESSAGE(q_handle) \
     c_msg.set_q_handle(q_handle);

--- a/src/runtime_src/core/include/xcl_macros.h
+++ b/src/runtime_src/core/include/xcl_macros.h
@@ -55,8 +55,10 @@
 #define xclImportBO_n 27
 #define xclSetupInstance_n 28
 #define xclPollCompletion_n 29
+#define xclPollQueue_n 30
+#define xclSetQueueOpt_n 31
 
-#define xclPerfMonReadCounters_Streaming_n 30
-#define xclPerfMonReadTrace_Streaming_n 31
+#define xclPerfMonReadCounters_Streaming_n 32
+#define xclPerfMonReadTrace_Streaming_n 33
 
 #endif

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -1103,6 +1103,15 @@ struct xclReqBuffer {
     uint64_t  buf_hdl;   // NULL when first field is buffer pointer
 };
 
+enum xclQueueOptions {
+    XCL_QOPT_AIO_MAX_EVENT = 1,      /* maximum # aio event */
+    XCL_QOPT_AIO_BATCH_THRESH_BYTES, /* io batching threshold: # bytes */
+    XCL_QOPT_AIO_BATCH_THRESH_PKTS,  /* io_batching threshold: # request */
+    XCL_QOPT_AIO_BATCH_THRESH_TIMER, /* io batching threshold: timer */
+
+    XCL_QOPT_MAX
+};
+
 /*
  * enum xclQueueRequestKind - request type.
  */
@@ -1190,6 +1199,41 @@ xclWriteQueue(xclDeviceHandle handle, uint64_t q_hdl, struct xclQueueRequest *wr
 XCL_DRIVER_DLLESPEC
 ssize_t
 xclReadQueue(xclDeviceHandle handle, uint64_t q_hdl, struct xclQueueRequest *rd_req);
+
+/**
+ * xclPollQueue - poll a single read/write queue completion
+ * @handle:        Device handle
+ * @q_hdl:         Queue handle
+ * @min_compl:     Unblock only when receiving min_compl completions
+ * @max_compl:     Max number of completion with one poll
+ * @comps:         Completed request array
+ * @actual_compl:  Number of requests been completed
+ * @timeout:       Timeout
+ * Return:         Number of events or appropriate error number
+ *
+ * Poll completion events of non-blocking read/write requests. Once
+ * this function returns, an array of completed requests is returned.
+ */
+XCL_DRIVER_DLLESPEC
+int
+xclPollQueue(xclDeviceHandle handle, uint64_t q_hdl, int min_compl,
+		   int max_compl, struct xclReqCompletion *comps,
+		   int* actual_compl, int timeout);
+
+/**
+ * xclSetQueueOpt - Set a single read/write queue's option
+ * @handle:        Device handle
+ * @q_hdl:         Queue handle
+ * @type:          option type
+ * @val:           option value
+ * Return:         Number of events or appropriate error number
+ *
+ * Set option of a read or write queue. 
+ */
+XCL_DRIVER_DLLESPEC
+int
+xclSetQueueOpt(xclDeviceHandle handle, uint64_t q_hdl, int type, uint32_t val);
+
 
 /**
  * xclPollCompletion - poll read/write queue completion

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -1103,15 +1103,6 @@ struct xclReqBuffer {
     uint64_t  buf_hdl;   // NULL when first field is buffer pointer
 };
 
-enum xclQueueOptions {
-    XCL_QOPT_AIO_MAX_EVENT = 1,      /* maximum # aio event */
-    XCL_QOPT_AIO_BATCH_THRESH_BYTES, /* io batching threshold: # bytes */
-    XCL_QOPT_AIO_BATCH_THRESH_PKTS,  /* io_batching threshold: # request */
-    XCL_QOPT_AIO_BATCH_THRESH_TIMER, /* io batching threshold: timer */
-
-    XCL_QOPT_MAX
-};
-
 /*
  * enum xclQueueRequestKind - request type.
  */

--- a/src/runtime_src/core/include/xstream.h
+++ b/src/runtime_src/core/include/xstream.h
@@ -26,11 +26,38 @@ extern "C" {
 
 typedef uint32_t stream_xfer_req_type;
 
+/**
+ * stream_opt_type
+ *
+ * For streaming queues, additional control can be set on a per-queue basis via
+ * clSetStreamOpt(opt_type, opt_value)
+ *
+ * The following options are available:
+ * - STREAM_OPT_AIO_MAX_EVENT: maximum # aio event
+ *   this option creates a per-queue asynchronous i/o context with
+ *   the "opt_value" as the maximum # concurrently i/o operations.
+ *
+ * The next 3 options will allow accumulation of the io requests before 
+ * submitting to the kernel for processing. This accumulation will increase
+ * the latency but may increase throughput.
+ *
+ * -  STREAM_OPT_AIO_BATCH_THRESH_BYTES,  io batching threshold: # bytes
+ *    Keep accumulating the i/o request, until the total # of r/w bytes reaches
+ *    the threshold of "opt_value" of bytes
+ *
+ * -  STREAM_OPT_AIO_BATCH_THRESH_PKTS,   io_batching threshold: # request
+ *    Keep accumulating the i/o request, until the total # of r/w request
+ *    reaches the threshold of "opt_value" of requests
+ *
+ * -  STREAM_OPT_AIO_BATCH_THRESH_TIMER,  io_batching threshold: # request
+ *    Keep accumulating the i/o request, until the timer pops.
+ *    The timer duration is "opt_value" milisecond.
+ */
 typedef enum stream_opt_type {
     STREAM_OPT_AIO_MAX_EVENT = 1,       /* maximum # aio event */
     STREAM_OPT_AIO_BATCH_THRESH_BYTES,  /* io batching threshold: # bytes */
     STREAM_OPT_AIO_BATCH_THRESH_PKTS,   /* io_batching threshold: # request */
-    STREAM_OPT_AIO_BATCH_THRESH_TIMER,  /* io batching threshold: timer */
+    STREAM_OPT_AIO_BATCH_THRESH_TIMER,  /* io batching threshold: timer in ms */
 
     STREAM_OPT_MAX
 } stream_opt_type;

--- a/src/runtime_src/core/include/xstream.h
+++ b/src/runtime_src/core/include/xstream.h
@@ -26,6 +26,15 @@ extern "C" {
 
 typedef uint32_t stream_xfer_req_type;
 
+typedef enum stream_opt_type {
+    STREAM_OPT_AIO_MAX_EVENT = 1,       /* maximum # aio event */
+    STREAM_OPT_AIO_BATCH_THRESH_BYTES,  /* io batching threshold: # bytes */
+    STREAM_OPT_AIO_BATCH_THRESH_PKTS,   /* io_batching threshold: # request */
+    STREAM_OPT_AIO_BATCH_THRESH_TIMER,  /* io batching threshold: timer */
+
+    STREAM_OPT_MAX
+} stream_opt_type;
+
 /**
  * cl_stream_xfer_req.
  * For each read or write request, this extra data needs to be sent.

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -29,6 +29,7 @@
 #include "core/pcie/driver/linux/include/xocl_ioctl.h"
 #include "core/pcie/driver/linux/include/qdma_ioctl.h"
 #include "core/common/xrt_profiling.h"
+#include "core/include/xstream.h" /* for stream_opt_type */
 
 #include <linux/aio_abi.h>
 #include <libdrm/drm.h>

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -156,6 +156,8 @@ public:
     int xclFreeQDMABuf(uint64_t buf_hdl);
     ssize_t xclWriteQueue(uint64_t q_hdl, xclQueueRequest *wr);
     ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
+    int xclPollQueue(uint64_t q_hdl, int min_compl, int max_compl, xclReqCompletion *comps, int * actual, int timeout /*ms*/);
+    int xclSetQueueOpt(uint64_t q_hdl, int type, uint32_t val);
     int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int * actual, int timeout /*ms*/);
     int xclIPName2Index(const char *name, uint32_t& index);
 

--- a/src/runtime_src/xocl/api/clGetExtensionFunctionAddressForPlatform.cpp
+++ b/src/runtime_src/xocl/api/clGetExtensionFunctionAddressForPlatform.cpp
@@ -31,6 +31,8 @@ static const std::map<const std::string, void *> extensionFunctionTable = {
   std::pair<const std::string, void *>("clCreateStreamBuffer", (void *)clCreateStreamBuffer),
   std::pair<const std::string, void *>("clReleaseStreamBuffer", (void *)clReleaseStreamBuffer),
   std::pair<const std::string, void *>("clPollStreams", (void *)clPollStreams),
+  std::pair<const std::string, void *>("clPollStream", (void *)clPollStream),
+  std::pair<const std::string, void *>("clSetStreamOpt", (void *)clSetStreamOpt),
   std::pair<const std::string, void *>("xclGetMemObjectFd", (void *)xclGetMemObjectFd),
   std::pair<const std::string, void *>("xclGetMemObjectFromFd", (void *)xclGetMemObjectFromFd),
   std::pair<const std::string, void *>("xclGetXrtDevice", (void *)xclGetXrtDevice),

--- a/src/runtime_src/xocl/api/xlnx/clPollStream.cpp
+++ b/src/runtime_src/xocl/api/xlnx/clPollStream.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2019-2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2018 Xilinx, Inc. All rights reserved.
+#include "xocl/config.h"
+#include "xocl/core/stream.h"
+#include "xocl/core/error.h"
+#include "plugin/xdp/profile.h"
+#include "xocl/core/device.h"
+#include <CL/opencl.h>
+
+namespace xocl {
+
+static void
+validOrError(cl_stream                  stream,
+	cl_streams_poll_req_completions*completions,
+	cl_int                          min_num_completion,
+	cl_int                          max_num_completion,
+	cl_int*                         actual_num_completion,
+	cl_int                          timeout,
+	cl_int*                         errcode_ret)
+
+{
+}
+
+static cl_int
+clPollStream(cl_stream                 stream,
+	cl_streams_poll_req_completions*completions,
+	cl_int                          min,
+	cl_int                          max,
+	cl_int*                         actual,
+	cl_int                          timeout,
+	cl_int*                         errcode_ret)
+{
+  validOrError(stream,completions,min,max,actual,timeout,errcode_ret);
+
+  printf("clPollStream() -> xocl(stream)->poll_stream.\n");
+
+  xocl::xocl(stream)->poll_stream(completions,min,max,actual,timeout);
+  xocl::assign(errcode_ret,CL_SUCCESS);
+  return CL_SUCCESS;
+}
+
+} //xocl
+
+CL_API_ENTRY cl_int CL_API_CALL
+clPollStream(cl_stream                  stream,
+       	cl_streams_poll_req_completions* completions,
+	cl_int                           min_num_completion,
+	cl_int                           max_num_completion,
+	cl_int*                          actual_num_completion,
+	cl_int                           timeout,
+	cl_int * errcode_ret) CL_API_SUFFIX__VERSION_1_0
+{
+  try {
+    PROFILE_LOG_FUNCTION_CALL;
+    return xocl::clPollStream
+      (stream,completions,min_num_completion,max_num_completion,actual_num_completion,timeout,errcode_ret);
+  }
+  catch (const xrt::error& ex) {
+    xocl::send_exception_message(ex.what());
+    xocl::assign(errcode_ret,ex.get_code());
+  }
+  catch (const std::exception& ex) {
+    xocl::send_exception_message(ex.what());
+    xocl::assign(errcode_ret,CL_INVALID_VALUE);
+  }
+  return CL_INVALID_VALUE;
+}

--- a/src/runtime_src/xocl/api/xlnx/clSetStreamOpt.cpp
+++ b/src/runtime_src/xocl/api/xlnx/clSetStreamOpt.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2019-2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright 2018 Xilinx, Inc. All rights reserved.
+#include "xocl/config.h"
+#include "xocl/core/stream.h"
+#include "xocl/core/error.h"
+#include "plugin/xdp/profile.h"
+#include "xocl/core/device.h"
+#include <CL/opencl.h>
+
+#ifdef _WIN32
+#pragma warning ( disable : 4267 )
+#endif
+
+namespace xocl {
+
+static void
+validOrError(cl_stream           stream,
+	     cl_stream_opt_type  type,
+	     cl_int              val,
+	     cl_int*             errcode_ret)
+
+{
+}
+
+static cl_int
+clSetStreamOpt(cl_stream           stream,
+	       cl_stream_opt_type  type,
+	       cl_int              val,
+	       cl_int*             errcode_ret)
+{
+  validOrError(stream,type,val,errcode_ret);
+printf("%s: call xocl(stream 0x%p)->set_stream_opt(%d,%u).\n", __func__, stream, type, val);
+  return xocl::xocl(stream)->set_stream_opt(type, val);
+}
+
+} //xocl
+
+CL_API_ENTRY cl_int CL_API_CALL
+clSetStreamOpt(cl_stream           stream,
+	       cl_stream_opt_type  type,
+	       cl_int              val,
+	       cl_int*             errcode_ret) CL_API_SUFFIX__VERSION_1_0
+{
+  try {
+    PROFILE_LOG_FUNCTION_CALL;
+printf("%s: call xocl::clSetStreamOpt(0x%p,%d,%u, err).\n", __func__, stream, type, val);
+    return xocl::clSetStreamOpt(stream,type,val,errcode_ret);
+  }
+  catch (const xrt::error& ex) {
+    xocl::send_exception_message(ex.what());
+    xocl::assign(errcode_ret,ex.get_code());
+  }
+  catch (const std::exception& ex) {
+    xocl::send_exception_message(ex.what());
+    xocl::assign(errcode_ret,CL_INVALID_VALUE);
+  }
+  return CL_INVALID_VALUE;
+}

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -454,6 +454,20 @@ poll_streams(xrt::device::stream_xfer_completions* comps, int min, int max, int*
   return m_xdevice->pollStreams(comps, min,max,actual,timeout);
 }
 
+int
+device::
+poll_stream(xrt::device::stream_handle stream, xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout)
+{
+  return m_xdevice->pollStream(stream, comps, min,max,actual,timeout);
+}
+
+int
+device::
+set_stream_opt(xrt::device::stream_handle stream, int type, uint32_t val)
+{
+  return m_xdevice->setStreamOpt(stream, type, val);
+}
+
 device::
 device(platform* pltf, xrt::device* xdevice)
   : m_uid(uid_count++), m_platform(pltf), m_xdevice(xdevice)

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -501,6 +501,12 @@ public:
   free_stream_buf(xrt::device::stream_buf_handle handle);
 
   int
+  set_stream_opt(xrt::device::stream_handle stream, int type, uint32_t val);
+
+  int
+  poll_stream(xrt::device::stream_handle stream, xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout);
+
+  int
   poll_streams(xrt::device::stream_xfer_completions* comps, int min, int max, int* actual, int timeout);
 
   /**

--- a/src/runtime_src/xocl/core/stream.cpp
+++ b/src/runtime_src/xocl/core/stream.cpp
@@ -59,6 +59,19 @@ stream::close()
   return m_device->close_stream(m_handle,m_connidx);
 }
 
+int 
+stream
+::poll_stream(xrt::device::stream_xfer_completions *comps, int min, int max, int *actual, int timeout)
+{
+  return m_device->poll_stream(m_handle, comps, min, max, actual, timeout);
+}
+
+int 
+stream
+::set_stream_opt(int type, uint32_t val)
+{
+  return m_device->set_stream_opt(m_handle, type, val);
+}
 
 int 
 stream_mem::

--- a/src/runtime_src/xocl/core/stream.h
+++ b/src/runtime_src/xocl/core/stream.h
@@ -27,12 +27,14 @@ namespace xocl {
 //class stream for qdma and other streaming purposes.
 class stream : public _cl_stream // TODO: public refcount
 {  
+  using stream_opt_type = xrt::hal::StreamOptType;
   using stream_flags_type = property_object<cl_stream_flags>;
   using stream_attributes_type = property_object<cl_stream_attributes>;
 protected:
   using stream_handle = xrt::hal::StreamHandle;
   using stream_xfer_flags = xrt::hal::StreamXferFlags;
   using stream_xfer_req = xrt::hal::StreamXferReq;
+
 public:
   stream(stream_flags_type flags, stream_attributes_type attr, cl_mem_ext_ptr_t* ext);
 private:
@@ -45,6 +47,8 @@ private:
   int m_connidx = -1;
 public:
   int get_stream(device* device); 
+  int poll_stream(xrt::device::stream_xfer_completions *comps, int min, int max, int *actual, int timeout); 
+  int set_stream_opt(int type, uint32_t val);
   ssize_t read(void* ptr, size_t size, stream_xfer_req* req );
   ssize_t write(const void* ptr, size_t size, stream_xfer_req* req);
   int close();

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -515,6 +515,18 @@ public:
     return m_hal->closeStream(stream);
   };
 
+  int
+  setStreamOpt(hal::StreamHandle stream, int type, uint32_t val)
+  {
+    return m_hal->setStreamOpt(stream, type, val);
+  }
+
+  int
+  pollStream(hal::StreamHandle stream, hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)
+  {
+    return m_hal->pollStream(stream, comps, min,max,actual,timeout);
+  };
+
   hal::StreamBuf
   allocStreamBuf(size_t size, hal::StreamBufHandle *buf)
   {

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -81,6 +81,7 @@ typedef uint64_t StreamFlags;
 
 using StreamXferReq = stream_xfer_req;
 using StreamXferCompletions = streams_poll_req_completions;
+using StreamOptType = stream_opt_type;
 /**
  * Helper class to encapsulate return values from HAL operations.
  *
@@ -308,6 +309,13 @@ public:
 
   virtual int
   pollStreams(StreamXferCompletions* comps, int min, int max, int* actual, int timeout) = 0;
+
+  virtual int
+  pollStream(hal::StreamHandle stream, StreamXferCompletions* comps, int min, int max, int* actual, int timeout) = 0;
+
+  virtual int
+  setStreamOpt(hal::StreamHandle stream, int type, uint32_t val) = 0;
+
 
 public:
   /**

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -702,6 +702,21 @@ pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, in
   return m_ops->mPollQueues(m_handle,min,max,req,actual,timeout);
 }
 
+int
+device::
+pollStream(hal::StreamHandle stream, hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout)
+{
+  xclReqCompletion* req = reinterpret_cast<xclReqCompletion*>(comps);
+  return m_ops->mPollQueue(m_handle,stream,min,max,req,actual,timeout);
+}
+
+int
+device::
+setStreamOpt(hal::StreamHandle stream, int type, uint32_t val)
+{
+  return m_ops->mSetQueueOpt(m_handle,stream,type,val);
+}
+
 void
 createDevices(hal::device_list& devices,
               const std::string& dll, void* driverHandle, unsigned int deviceCount)

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -362,6 +362,12 @@ public:
   virtual int
   pollStreams(hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout);
 
+  virtual int
+  pollStream(hal::StreamHandle stream, hal::StreamXferCompletions* comps, int min, int max, int* actual, int timeout);
+
+  virtual int
+  setStreamOpt(hal::StreamHandle stream, int type, uint32_t val);
+
 public:
   virtual bool
   is_imported(const BufferObjectHandle& boh) const;

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -77,6 +77,8 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mWriteQueue(0)
   ,mReadQueue(0)
   ,mPollQueues(0)
+  ,mPollQueue(0)
+  ,mSetQueueOpt(0)
   ,mGetDebugIpLayout(0)
   ,mGetNumLiveProcesses(0)
   ,mGetSysfsPath(0)
@@ -124,6 +126,8 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   mWriteQueue = (writeQueueFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclWriteQueue");
   mReadQueue = (readQueueFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclReadQueue");
   mPollQueues = (pollQueuesFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclPollCompletion");
+  mPollQueue = (pollQueueFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclPollQueue");
+  mSetQueueOpt = (setQueueOptFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclSetQueueOpt");
 
   // Profiling Functions
   mGetDeviceTime = (getDeviceTimeFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetDeviceTimestamp");

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -129,6 +129,8 @@ private:
   typedef int     (*freeQDMABufFuncType)(xclDeviceHandle handle,uint64_t buf_hdl);
   typedef ssize_t (*writeQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, xclQueueRequest *wr);
   typedef ssize_t (*readQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, xclQueueRequest *wr);
+  typedef int     (*setQueueOptFuncType)(xclDeviceHandle handle,uint64_t q_hdl, int type, uint32_t val);
+  typedef int     (*pollQueueFuncType)(xclDeviceHandle handle,uint64_t q_hdl, int min, int max, xclReqCompletion* completions, int* actual, int timeout);
   typedef int     (*pollQueuesFuncType)(xclDeviceHandle handle,int min, int max, xclReqCompletion* completions, int* actual, int timeout);
 //End Streaming
 
@@ -210,6 +212,8 @@ public:
   writeQueueFuncType mWriteQueue;
   readQueueFuncType mReadQueue;
   pollQueuesFuncType mPollQueues;
+  pollQueueFuncType mPollQueue;
+  setQueueOptFuncType mSetQueueOpt;
 //End Streaming
 
   getDebugIpLayoutType mGetDebugIpLayout;


### PR DESCRIPTION
The current qdma streaming asynchronous i/o uses a single aio context "mAioContext" per device. When we have multiple streaming queues configured, the completion events of all the queues are mingled. The host application cannot selectively query for completion on a particular stream.

This patch added a per-stream (i.e., queue) aio context and a new API "clPollStream()". so the completion events are queued on a per-queue based and the host can query on a per-stream basis.

To maintain backward compatibility, a new API clSetStreamOpt() is added to enabled the per-stream aio context. 

The existing API flows with per-device aio context still works:
clCreateStream() -> clReadStream() or clWriteStream(), -> clPollStreams()

To use the per-stream aio context, the new  API clSetStreamOpt() needs to be called to enable first:
clCreateStream() -> clSetStreamOpt() -> clReadStream() or clWriteStream(), -> clPollStream().

Tested with u200 image from 2020.1_qualified_latest.