### PR TITLE
5.3 and older linux need include drm.h

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -12,6 +12,7 @@
  */
 
 
+#include <drm/drm.h>
 #include <drm/drm_print.h>
 #include <linux/io.h>
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.h
@@ -16,6 +16,7 @@
 
 #ifndef _ZOCL_DRV_H_
 #define _ZOCL_DRV_H_
+#include <drm/drm.h>
 #include <drm/drm_device.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_gem.h>


### PR DESCRIPTION
#3119 remove drmP.h from zocl source code because it was removed from Linux 5.5+. The replace header files was added since Linux 4.19.
The master XRT support PetaLinux 2019.x (Linux 4.19) and PetaLinux 2020.x (Linux 5.4).

The drm_print.h relies on drm.h, but it didn't include drm.h in Linux 4.19.
This was fixed by Linux since Linux 5.3.

This PR is just simply add drm.h to fix compile issue with Linux 4.19. 

:( It seems like pipeline doesn't build zocl.ko with petalinux 2019.x sysroot. So, the compile error was not caught.