### PR TITLE
CR-1047791 XRT support MSI-X from ert <-> Host

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1417,8 +1417,9 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
+#define	ERT_CSR_ADDR_VERSAL		0x6040000
 #define	ERT_CQ_BASE_ADDR_VERSAL		0x4000000
-#define ERT_CSR_ADDR_VERSAL		0x6040000
+
 #define XOCL_RES_SCHEDULER_VERSAL				\
 		((struct resource []) {				\
 		/*
@@ -1435,6 +1436,11 @@ struct xocl_subdev_map {
 			.end	= ERT_CQ_BASE_ADDR_VERSAL +	\
 			ERT_CQ_SIZE - 1,			\
 			.flags	= IORESOURCE_MEM,		\
+			},					\
+			{					\
+			.start	= 0,				\
+			.end	= 0,				\
+			.flags	= IORESOURCE_IRQ,		\
 			}					\
 		})
 
@@ -1540,8 +1546,8 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XDMA,				\
 			XOCL_DEVINFO_XMC_USER,				\
 		 	XOCL_DEVINFO_SCHEDULER_VERSAL,			\
-		 	XOCL_DEVINFO_PF_MAILBOX_USER_VERSAL,		\
-		 	XOCL_DEVINFO_MAILBOX_USER_VERSAL,		\
+			XOCL_DEVINFO_PF_MAILBOX_USER_VERSAL,		\
+			XOCL_DEVINFO_MAILBOX_USER_VERSAL,		\
 		 	XOCL_DEVINFO_ICAP_USER,				\
 		})
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -95,7 +95,6 @@ static int mailbox_versal_enable_intr(struct platform_device *pdev)
 	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
 	u32 is;
 
-
 	/* set interrupt threshold for receive, 2^0=1 pkg will trigger intr */
 	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_rit, 0);
 	/* clear pending interrupt */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox_versal.c
@@ -19,6 +19,8 @@
 
 #define	MBV_ERR(mbv, fmt, arg...)    \
     xocl_err(&mbv->mbv_pdev->dev, fmt "\n", ##arg)
+#define	MBV_INFO(mbv, fmt, arg...)    \
+    xocl_info(&mbv->mbv_pdev->dev, fmt "\n", ##arg)
 
 #define	STATUS_EMPTY	(1 << 0)
 #define	STATUS_FULL	(1 << 1)
@@ -88,14 +90,63 @@ static int mailbox_versal_get(struct platform_device *pdev, u32 *data)
 	return 0;
 }
 
+static int mailbox_versal_enable_intr(struct platform_device *pdev)
+{
+	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
+	u32 is;
+
+
+	/* set interrupt threshold for receive, 2^0=1 pkg will trigger intr */
+	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_rit, 0);
+	/* clear pending interrupt */
+	is = mailbox_versal_reg_rd(mbv, &mbv->mbv_regs->mbr_is);
+	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_is, is);
+
+	/* enable receive interrupt */
+	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_ie, 2);
+
+	return 0;
+}
+
+static int mailbox_versal_disable_intr(struct platform_device *pdev)
+{
+	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
+
+	/* clear interrupt enable register */
+	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_ie, 0);
+	/* clear interrupt threshold for receive */
+	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_rit, 0);
+
+	return 0;
+}
+
+static int mailbox_versal_handle_intr(struct platform_device *pdev)
+{
+	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
+	u32 is = mailbox_versal_reg_rd(mbv, &mbv->mbv_regs->mbr_is);
+
+	/* Acknowledge all existing is in mailbox */
+	while (is) {
+		mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_is, is);
+		is = mailbox_versal_reg_rd(mbv, &mbv->mbv_regs->mbr_is);
+	}
+
+	return 0;
+}
+
 static struct xocl_mailbox_versal_funcs mailbox_versal_ops = {
 	.set		= mailbox_versal_set,
 	.get		= mailbox_versal_get,
+	.enable_intr 	= mailbox_versal_enable_intr,
+	.disable_intr 	= mailbox_versal_disable_intr,
+	.handle_intr 	= mailbox_versal_handle_intr,
 };
 
 static int mailbox_versal_remove(struct platform_device *pdev)
 {
 	struct mailbox_versal *mbv = platform_get_drvdata(pdev);
+
+	mailbox_versal_disable_intr(pdev);
 
 	platform_set_drvdata(pdev, NULL);
 	xocl_drvinst_release(mbv, NULL);
@@ -127,6 +178,8 @@ static int mailbox_versal_probe(struct platform_device *pdev)
 
 	/* Reset both RX channel and RX channel */
 	mailbox_versal_reg_wr(mbv, &mbv->mbv_regs->mbr_ctrl, 0x3);
+
+	mailbox_versal_enable_intr(pdev);
 
 	return 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1316,6 +1316,9 @@ struct xocl_mailbox_versal_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	int (*set)(struct platform_device *pdev, u32 data);
 	int (*get)(struct platform_device *pdev, u32 *data);
+	int (*enable_intr)(struct platform_device *pdev);
+	int (*disable_intr)(struct platform_device *pdev);
+	int (*handle_intr)(struct platform_device *pdev);
 };
 #define	MAILBOX_VERSAL_DEV(xdev)	\
 	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL).pldev
@@ -1333,6 +1336,15 @@ struct xocl_mailbox_versal_funcs {
 	(MAILBOX_VERSAL_READY(xdev, get)	\
 	? MAILBOX_VERSAL_OPS(xdev)->get(MAILBOX_VERSAL_DEV(xdev), \
 	data) : -ENODEV)
+#define	xocl_mailbox_versal_enable_intr(xdev)	\
+	(MAILBOX_VERSAL_READY(xdev, enable_intr)	\
+	? MAILBOX_VERSAL_OPS(xdev)->enable_intr(MAILBOX_VERSAL_DEV(xdev)) : -ENODEV)
+#define	xocl_mailbox_versal_disable_intr(xdev)	\
+	(MAILBOX_VERSAL_READY(xdev, disable_intr)	\
+	? MAILBOX_VERSAL_OPS(xdev)->disable_intr(MAILBOX_VERSAL_DEV(xdev)) : -ENODEV)
+#define	xocl_mailbox_versal_handle_intr(xdev)	\
+	(MAILBOX_VERSAL_READY(xdev, handle_intr)	\
+	? MAILBOX_VERSAL_OPS(xdev)->handle_intr(MAILBOX_VERSAL_DEV(xdev)) : -ENODEV)
 
 /* srsr callbacks */
 struct xocl_srsr_funcs {


### PR DESCRIPTION
> tested in interrupt mode

[root@xsjhemn41 ~]# xbutil validate -q
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_vck5000-es1_g3x16_201921_1
INFO: == Starting AUX power connector check:
AUX power connector not available. Skipping validation
INFO: == AUX power connector check SKIPPED
INFO: == Starting PCIE link check:
LINK ACTIVE, ATTENTION
Ensure Card is plugged in to Gen3x16, instead of Gen1x8
Lower performance may be experienced
WARN: == PCIE link check PASSED with warning
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated with warnings.

INFO: All cards validated successfully but with warnings.
[root@xsjhemn41 ~]# dmesg|grep versal
[20955.576936] xocl 0001:45:00.1:  ffff88022fdb7098 __xocl_subdev_destroy: Destroy subdev mailbox_versal, cdev           (null)
[20956.213643] xclmgmt 0001:45:00.0:  ffff88022fdb6098 __xocl_subdev_destroy: Destroy subdev ospi_versal, cdev ffff880224322900
[20956.659067] xclmgmt 0001:45:00.0:  ffff88022fdb6098 __xocl_subdev_create: creating subdev ospi_versal.m multi 0 level 0
[20956.670561] xclmgmt 0001:45:00.0:  ffff88022fdb6098 __xocl_subdev_create: Created subdev ospi_versal inst 22020096 level 0
[20956.676297] xclmgmt 0001:45:00.0:  ffff88022fdb6098 __xocl_subdev_create: subdev ospi_versal.m inst 22020096 is active
[20957.212928] xocl 0001:45:00.1:  ffff88022fdb7098 __xocl_subdev_create: creating subdev mailbox_versal.u multi 0 level 0
[20957.217614] xocl 0001:45:00.1:  ffff88022fdb7098 __xocl_subdev_create: Created subdev mailbox_versal inst 20971520 level 0
[20957.219934] xocl 0001:45:00.1:  ffff88022fdb7098 __xocl_subdev_create: subdev mailbox_versal.u inst 20971520 is active
[20977.038904] xocl 0001:45:00.1:  ffff88022fdb7098 exec_cfg_cmd: versal polling mode 0
