### PR TITLE
XRT-281 Slave bridge address translation IP framework

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -472,7 +472,7 @@ struct drm_xocl_reclock_info {
 struct drm_xocl_alloc_cma_info {
 	uint64_t	total_size;
 	uint64_t	entry_num;
-	uint64_t	user_addr[1];
+	uint64_t	*user_addr;
 };
 /*
  * Core ioctls numbers

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -265,7 +265,7 @@ static int xocl_cma_bo_alloc(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj, u
 	if (!xobj->cma_mm_node)
 		return -ENOMEM;
 
-	err = drm_mm_insert_node_generic(drm_p->cma_bank->mm, xobj->cma_mm_node, size, PAGE_SIZE,
+	err = drm_mm_insert_node_generic(&drm_p->cma_bank->mm, xobj->cma_mm_node, size, PAGE_SIZE,
 #if defined(XOCL_DRM_FREE_MALLOC)
 		0, 0);
 #else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -256,35 +256,30 @@ static int xocl_cma_bo_alloc(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj, u
 {
 	int err = 0;
 
-	if (drm_p->cma_chunk[idx]) {
+	if (!drm_p->cma_bank)
+		return -ENOMEM;
 
-		xobj->cma_mm_node = kzalloc(sizeof(*xobj->cma_mm_node), GFP_KERNEL);
 
-		if (!xobj->cma_mm_node)
-			return -ENOMEM;
+	xobj->cma_mm_node = kzalloc(sizeof(*xobj->cma_mm_node), GFP_KERNEL);
 
-		err = drm_mm_insert_node_generic(drm_p->cma_chunk[idx]->mm, xobj->cma_mm_node, size, PAGE_SIZE,
+	if (!xobj->cma_mm_node)
+		return -ENOMEM;
+
+	err = drm_mm_insert_node_generic(drm_p->cma_bank->mm, xobj->cma_mm_node, size, PAGE_SIZE,
 #if defined(XOCL_DRM_FREE_MALLOC)
-			0, 0);
+		0, 0);
 #else
-			0, 0, 0);
+		0, 0, 0);
 #endif
-		if (err) {
-			kfree(xobj->cma_mm_node);
-			xobj->cma_mm_node = NULL;
-			return err;
-		}
-
-		DRM_DEBUG("xobj->cma_mm_node.start 0x%llx, xobj->cma_mm_node.size %llx", xobj->cma_mm_node->start,
-			xobj->cma_mm_node->size);
-	} else {
-		xobj->cma_addr = alloc_pages_exact(size, GFP_KERNEL | __GFP_ZERO);
-
-		if (!xobj->cma_addr) {
-			DRM_ERROR("Unable to alloc %llx bytes CMA buffer", size);
-			return -ENOMEM;
-		}
+	if (err) {
+		kfree(xobj->cma_mm_node);
+		xobj->cma_mm_node = NULL;
+		return err;
 	}
+
+	DRM_DEBUG("xobj->cma_mm_node.start 0x%llx, xobj->cma_mm_node.size %llx", xobj->cma_mm_node->start,
+		xobj->cma_mm_node->size);
+
 	return err;
 }
 
@@ -421,31 +416,6 @@ fail:
 	return ERR_CAST(p);
 }
 
-static struct page **xocl_cma_pool_get_pages(struct xocl_drm *drm_p, uint32_t idx, uint64_t offset, size_t nr_pages)
-{
-	uint64_t page_offset = 0;
-	struct page **pages = NULL;
-
-	if (idx >= DRM_XOCL_CMA_CHUNK_MAX)
-		return ERR_PTR(-EINVAL);
-
-	if (!drm_p->cma_chunk[idx])
-		return ERR_PTR(-ENOMEM);
-
-	if (offset < drm_p->cma_chunk[idx]->start_addr)
-		return ERR_PTR(-EINVAL);
-
-	page_offset = (offset - drm_p->cma_chunk[idx]->start_addr) >> PAGE_SHIFT;
-
-	pages = drm_malloc_ab(nr_pages, sizeof(struct page *));
-	if (pages == NULL)
-		return ERR_PTR(-ENOMEM);
-
-	memcpy(pages, drm_p->cma_chunk[idx]->pages+page_offset, nr_pages*sizeof(struct page *));
-
-	return pages;
-}
-
 static struct page **xocl_virt_addr_get_pages(void *vaddr, int npages)
 
 {
@@ -554,9 +524,6 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		else if (xobj->flags & XOCL_CMA_MEM) {
 			if (xobj->cma_addr)
 				xobj->pages = xocl_virt_addr_get_pages(xobj->cma_addr, xobj->base.size >> PAGE_SHIFT);
-			else
-				xobj->pages = xocl_cma_pool_get_pages(drm_p,
-					0, xobj->cma_mm_node->start, xobj->base.size >> PAGE_SHIFT);
 		}
 		if (IS_ERR(xobj->pages)) {
 			ret = PTR_ERR(xobj->pages);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -24,6 +24,7 @@
 #include <linux/pfn_t.h>
 #endif
 #include <linux/pagemap.h>
+#include <linux/log2.h>
 
 #include <drm/drmP.h>
 #include <drm/drm_gem.h>
@@ -54,7 +55,8 @@
 
 static char driver_date[9];
 
-static void xocl_cma_chunks_free_all(struct xocl_drm *drm_p);
+static void xocl_cma_mem_free(struct xocl_drm *drm_p, uint32_t idx);
+static int __xocl_cma_bank_alloc(struct xocl_drm *drm_p, uint32_t num, uint64_t entry_sz);
 
 static void xocl_free_object(struct drm_gem_object *obj)
 {
@@ -482,7 +484,7 @@ void xocl_drm_fini(struct xocl_drm *drm_p)
 	xocl_drvinst_release(drm_p, &hdl);
 
 	xocl_cleanup_mem(drm_p);
-	xocl_cma_chunks_free_all(drm_p);
+	xocl_cma_bank_free(drm_p);
 	drm_put_dev(drm_p->ddev);
 	mutex_destroy(&drm_p->mm_lock);
 
@@ -505,6 +507,28 @@ void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 
 	drm_p->mm_usage_stat[ddr]->memory_usage += (count > 0) ? size : -size;
 	drm_p->mm_usage_stat[ddr]->bo_count += count;
+}
+
+void xocl_cma_mm_get_usage_stat(struct xocl_drm *drm_p,
+	struct drm_xocl_mm_stat *pstat)
+{
+	if(!drm_p->cma_bank)
+		return;
+
+	pstat->memory_usage = drm_p->cma_bank->mm_usage_stat ?
+		drm_p->cma_bank->mm_usage_stat->memory_usage : 0;
+	pstat->bo_count = drm_p->cma_bank->mm_usage_stat ?
+		drm_p->cma_bank->mm_usage_stat->bo_count : 0;
+}
+
+void xocl_cma_mm_update_usage_stat(struct xocl_drm *drm_p,
+	u64 size, int count)
+{
+	if(!drm_p->cma_bank->mm_usage_stat)
+		return;
+
+	drm_p->cma_bank->mm_usage_stat->memory_usage += (count > 0) ? size : -size;
+	drm_p->cma_bank->mm_usage_stat->bo_count += count;
 }
 
 int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 ddr,
@@ -577,38 +601,44 @@ uint32_t xocl_get_shared_ddr(struct xocl_drm *drm_p, struct mem_data *m_data)
 	return 0xffffffff;
 }
 
-static void xocl_cma_chunk_free(struct xocl_drm *drm_p, uint32_t idx)
+static void xocl_cma_mem_free(struct xocl_drm *drm_p, uint32_t idx)
 {
-	if (drm_p->cma_chunk[idx]) {
+	struct xocl_cma_memory *cma_mem = drm_p->cma_bank->cma_mem[idx];
 
-		if (drm_p->cma_chunk[idx]->mm) {
-			drm_mm_takedown(drm_p->cma_chunk[idx]->mm);
-			vfree(drm_p->cma_chunk[idx]->mm);
-		}
+	if (!cma_mem)
+		return;
+
+	if (cma_mem->vaddr) {
+		dma_free_coherent(&drm_p->ddev->pdev->dev, cma_mem->size, cma_mem->vaddr, cma_mem->paddr);
+	} else if (cma_mem->pages) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-		release_pages(drm_p->cma_chunk[idx]->pages, drm_p->cma_chunk[idx]->page_count);
+		release_pages(cma_mem->pages, cma_mem->size >> PAGE_SHIFT);
 #else
-		release_pages(drm_p->cma_chunk[idx]->pages, drm_p->cma_chunk[idx]->page_count, 0);
+		release_pages(cma_mem->pages, cma_mem->size >> PAGE_SHIFT, 0);
 #endif
-
-		if (drm_p->cma_chunk[idx]->pages)
-			vfree(drm_p->cma_chunk[idx]->pages);
-
-		vfree(drm_p->cma_chunk[idx]);
-		drm_p->cma_chunk[idx] = NULL;
-
 	}
+
+	if (cma_mem->pages)
+		vfree(cma_mem->pages);
+
+	vfree(drm_p->cma_bank->cma_mem[idx]);
+	drm_p->cma_bank->cma_mem[idx] = NULL;
+
 }
 
-static void xocl_cma_chunks_free_all(struct xocl_drm *drm_p)
+static void xocl_cma_mem_free_all(struct xocl_drm *drm_p)
 {
 	int i = 0;
+	uint64_t num = 0;
 
-	mutex_lock(&drm_p->mm_lock);
-	for (i = 0; i < DRM_XOCL_CMA_CHUNK_MAX; ++i) {
-		xocl_cma_chunk_free(drm_p, i);
-	}
-	mutex_unlock(&drm_p->mm_lock);
+	if (!drm_p->cma_bank)
+		return;
+
+	num = drm_p->cma_bank->entry_num;
+
+	for (i = 0; i < num; ++i)
+		xocl_cma_mem_free(drm_p, i);
+
 	xocl_info(drm_p->ddev->dev, "%s done", __func__);
 }
 
@@ -821,10 +851,11 @@ failed:
 	return err;
 }
 
-static int is_chunk_cma(struct page **pages, uint64_t page_count, size_t sz)
+static int is_chunk_cma(struct page **pages, uint64_t page_count)
 {
 	int err = 0;
 	struct sg_table *sgt = NULL;
+	uint64_t sz = page_count << PAGE_SHIFT;
 
 	sgt = kmalloc(sizeof(struct sg_table), GFP_KERNEL);
 	if (!sgt) {
@@ -848,85 +879,346 @@ out:
 	return err;
 }
 
-static int xocl_cma_chunk_reserve(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info)
+static int xocl_cma_mem_alloc_huge_page_by_idx(struct xocl_drm *drm_p, uint32_t idx, uint64_t user_addr, uint64_t page_sz)
 {
-	int ret = 0, idx = 0;
-	uint64_t nr, page_count;
-	struct page **pages = NULL;
+	uint64_t page_count = 0, nr = 0;
 	struct device *dev = drm_p->ddev->dev;
-	uint64_t user_addr = 0x0; // remove it next commit, bypass coverity check
-	size_t page_sz = cma_info->total_size/cma_info->entry_num;
-
-	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
+	int ret = 0;
+	struct xocl_cma_memory *cma_mem;
 
 	if (!(XOCL_ACCESS_OK(VERIFY_WRITE, user_addr, page_sz))) {
 		xocl_err(dev, "Invalid huge page user pointer\n");
 		ret = -ENOMEM;
-		goto out;
+		goto done;
 	}
+	drm_p->cma_bank->cma_mem[idx] = vzalloc(sizeof(struct xocl_cma_memory));
 
-	for (idx = 0; idx < DRM_XOCL_CMA_CHUNK_MAX; ++idx) {
-		if (!drm_p->cma_chunk[idx])
-			break;
+	cma_mem = drm_p->cma_bank->cma_mem[idx];
+	if (!cma_mem) {
+		ret = -ENOMEM;
+		goto done;
 	}
-
-	if (idx >= DRM_XOCL_CMA_CHUNK_MAX) {
-		ret = -EBUSY;
-		return ret;
-	}
-
-	drm_p->cma_chunk[idx] =  vzalloc(sizeof(struct xocl_cma_chunk));
 
 	page_count = (page_sz) >> PAGE_SHIFT;
-
-	pages = vzalloc(page_count*sizeof(struct page *));
-	if (!pages) {
+	cma_mem->pages = vzalloc(page_count*sizeof(struct page *));
+	if (!cma_mem->pages) {
 		ret = -ENOMEM;
-		goto out;
+		goto done;
 	}
-	drm_p->cma_chunk[idx]->pages = pages;
 
-	nr = get_user_pages_fast(user_addr, page_count, 1, drm_p->cma_chunk[idx]->pages);
+	nr = get_user_pages_fast(user_addr, page_count, 1, cma_mem->pages);
 	if (nr != page_count) {
 		xocl_err(dev, "Can't pin down enough page_nr %llx\n", nr);
 		ret = -EINVAL;
-		goto out;
+		goto done;
 	}
-	drm_p->cma_chunk[idx]->page_count = page_count;
 
-
-	ret = is_chunk_cma(drm_p->cma_chunk[idx]->pages, page_count, page_sz);
+	ret = is_chunk_cma(cma_mem->pages, page_count);
 	if (ret) {
 		xocl_err(dev, "not a cma chunk\n");
-		goto out;
+		goto done;
 	}
 
-	drm_p->cma_chunk[idx]->start_addr = page_to_phys(drm_p->cma_chunk[idx]->pages[0]);
+	cma_mem->size = page_sz;
 
-	xocl_info(dev, "Alloc CMA chunk, phys_addr %llx, size %lx", drm_p->cma_chunk[idx]->start_addr, page_sz);
+done:
+	if (ret) {
+		vfree(drm_p->cma_bank->cma_mem[idx]->pages);
+		vfree(drm_p->cma_bank->cma_mem[idx]);
+		drm_p->cma_bank->cma_mem[idx] = NULL;
+	}
 
-	drm_p->cma_chunk[idx]->mm = vzalloc(sizeof(struct drm_mm));
-
-	drm_mm_init(drm_p->cma_chunk[idx]->mm, drm_p->cma_chunk[idx]->start_addr, page_sz);
-
-out:
-	xocl_info(dev, "%s ret %d", __func__, ret);
 	return ret;
 }
 
-int xocl_cma_chunk_alloc_helper(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info)
+static int xocl_cma_mem_alloc_huge_page(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info)
 {
-	int err = 0;
+	int ret = 0;
+	xdev_handle_t xdev = drm_p->xdev;
+	size_t page_sz = cma_info->total_size/cma_info->entry_num;
+	uint32_t i, num = xocl_addr_translator_get_entries_num(xdev);
+	uint64_t *user_addr = NULL;
+	uint64_t rounddown_num = rounddown_pow_of_two(cma_info->entry_num);
 
-	mutex_lock(&drm_p->mm_lock);
-	err = xocl_cma_chunk_reserve(drm_p, cma_info);
-	mutex_unlock(&drm_p->mm_lock);
-	return err;
+	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
+
+	if (page_sz != ADDR_TRANSLATOR_ENTRY_1G)
+		return -EINVAL;
+
+	/* Limited by hardware, the entry number can only be power of 2
+	 * rounddown_pow_of_two 255=>>128 63=>>32
+	 */
+	if (rounddown_num != cma_info->entry_num) {
+		DRM_ERROR("Request %lld, round down to power of 2 %lld\n", 
+				cma_info->entry_num, rounddown_num);
+		return -EINVAL;
+	}
+
+	if (rounddown_num > num)
+		return -EINVAL;
+
+	user_addr = vzalloc(sizeof(uint64_t)*rounddown_num);
+	if (!user_addr)
+		return -ENOMEM;
+
+	ret = copy_from_user(user_addr, cma_info->user_addr, sizeof(uint64_t *)*rounddown_num);
+	if (ret) {
+		ret = -EFAULT;
+		goto done;
+	}
+
+	for (i = 0; i < rounddown_num; ++i) {
+		ret = xocl_cma_mem_alloc_huge_page_by_idx(drm_p, i, user_addr[i], ADDR_TRANSLATOR_ENTRY_1G);
+		if (ret)
+			break;
+	}
+	if (ret)
+		goto done;
+
+	ret = __xocl_cma_bank_alloc(drm_p, rounddown_num, ADDR_TRANSLATOR_ENTRY_1G);
+
+done:
+	vfree(user_addr);
+	return ret;
 }
 
-void xocl_cma_chunk_free_helper(struct xocl_drm *drm_p)
+static struct page **xocl_virt_addr_get_pages(void *vaddr, int npages)
+
+{
+	struct page *p, **pages;
+	int i;
+	uint64_t offset = 0;
+
+	pages = vzalloc(npages*sizeof(struct page *));
+	if (pages == NULL)
+		return ERR_PTR(-ENOMEM);
+
+	for (i = 0; i < npages; i++) {
+		p = virt_to_page(vaddr + offset);
+		pages[i] = p;
+		if (IS_ERR(p))
+			goto fail;
+		offset += PAGE_SIZE;
+	}
+
+	return pages;
+fail:
+	vfree(pages);
+	return ERR_CAST(p);
+}
+
+static int xocl_cma_mem_alloc_by_idx(struct xocl_drm *drm_p, uint32_t idx)
+{
+	int ret = 0;
+	uint64_t page_count, size = ADDR_TRANSLATOR_ENTRY_4M;
+	struct xocl_cma_memory *cma_mem = NULL;
+	struct page **pages = NULL;
+	dma_addr_t phys_addrs;
+
+
+	if (drm_p->cma_bank->cma_mem[idx]) {
+		DRM_ERROR("CMA memory exist!!");
+		ret = -EEXIST;
+		goto done;		
+	}
+
+	drm_p->cma_bank->cma_mem[idx] = vzalloc(sizeof(struct xocl_cma_memory));
+	cma_mem = drm_p->cma_bank->cma_mem[idx];
+
+	if (!cma_mem) {
+		ret = -ENOMEM;
+		goto done;		
+	}
+
+	page_count = (size) >> PAGE_SHIFT;
+
+	cma_mem->vaddr = dma_alloc_coherent(&drm_p->ddev->pdev->dev, size, &phys_addrs, GFP_KERNEL);
+
+	if (!cma_mem->vaddr) {
+		DRM_ERROR("Unable to alloc %llx bytes CMA buffer", size);
+		ret = -ENOMEM;
+		goto done;
+	}
+
+	pages = xocl_virt_addr_get_pages(cma_mem->vaddr, size >> PAGE_SHIFT);
+	if (IS_ERR(pages)) {
+		ret = PTR_ERR(pages);
+		goto done;
+	}
+
+	cma_mem->pages = pages;
+	cma_mem->paddr = phys_addrs;
+	cma_mem->size = size;
+
+done:
+	if (ret)
+		xocl_cma_mem_free(drm_p, idx);
+
+	return ret;
+}
+
+static void __xocl_cma_bank_free(struct xocl_drm *drm_p)
+{
+	if (!drm_p->cma_bank)
+		return;
+
+	xocl_cma_mem_free_all(drm_p);
+	if (drm_p->cma_bank->mm)
+		drm_mm_takedown(drm_p->cma_bank->mm);
+	vfree(drm_p->cma_bank->mm);
+	vfree(drm_p->cma_bank->mm_usage_stat);
+	vfree(drm_p->cma_bank->cma_mem);
+	vfree(drm_p->cma_bank);
+	drm_p->cma_bank = NULL;
+}
+
+static int __xocl_cma_bank_alloc(struct xocl_drm *drm_p, uint32_t num, uint64_t entry_sz)
+{
+	xdev_handle_t xdev = drm_p->xdev;
+	int ret = 0;
+	uint32_t i = 0, rounddown_num = rounddown_pow_of_two(num);
+	uint64_t *phys_addrs = NULL, cma_mem_size = 0;
+
+	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
+
+	if (num != rounddown_num) {
+		DRM_ERROR("num %d is not order of 2", num);
+		ret = -EINVAL;
+		goto done;
+	}
+
+	phys_addrs = vzalloc(num*sizeof(uint64_t));
+	if (!phys_addrs) {
+		ret = -ENOMEM;
+		goto done;		
+	}
+
+	for (; i < num; ++i) {
+		struct xocl_cma_memory *cma_mem = drm_p->cma_bank->cma_mem[i];
+
+		if (!cma_mem) {
+			ret = -ENOMEM;
+			break;
+		}
+
+		/* All the cma mem should have the same size,
+		 * find the black sheep
+		 */
+		if (cma_mem_size && cma_mem_size != cma_mem->size) {
+			DRM_ERROR("CMA memory mixmatch");
+			ret = -EINVAL;
+			break;
+		}
+
+		phys_addrs[i] = cma_mem->paddr;
+		cma_mem_size = cma_mem->size;
+	}
+
+	if (ret)
+		goto done;
+
+	/* Limited by hardware, the entry number can only be power of 2
+	 * rounddown_pow_of_two 255=>>128 63=>>32
+	 */
+
+	drm_p->cma_bank->mm = vzalloc(sizeof(struct drm_mm));
+	if (!drm_p->cma_bank->mm) {
+		ret = -ENOMEM;
+		goto done;
+	}
+
+	drm_p->cma_bank->start_addr = ADDR_TRANSLATOR_OFFSET;
+	/* Remember how many cma mem we allocate*/
+	drm_p->cma_bank->entry_num = num;
+	drm_p->cma_bank->entry_sz = entry_sz;
+
+	drm_mm_init(drm_p->cma_bank->mm, ADDR_TRANSLATOR_OFFSET, entry_sz*num);
+
+	drm_p->cma_bank->mm_usage_stat = vzalloc(sizeof(struct drm_xocl_mm_stat));
+	if (!drm_p->cma_bank->mm_usage_stat) {
+		ret = -ENOMEM;
+		goto done;
+	}
+
+	ret = xocl_addr_translator_set_page_table(xdev, phys_addrs, drm_p->cma_bank->start_addr,
+							entry_sz, num);
+done:
+	if (ret)
+		__xocl_cma_bank_free(drm_p);
+
+	vfree(phys_addrs);
+	DRM_INFO("%s ret %d", __func__, ret);
+	return ret;
+
+}
+
+static uint32_t xocl_cma_mem_alloc(struct xocl_drm *drm_p, uint64_t size)
+{
+	xdev_handle_t xdev = drm_p->xdev;
+	int ret = 0;
+	uint64_t i = 0, page_num = size / ADDR_TRANSLATOR_ENTRY_4M;
+	uint64_t rounddown_num =  rounddown_pow_of_two(page_num);
+	uint32_t max_num = xocl_addr_translator_get_entries_num(xdev);
+
+	if (rounddown_num > max_num)
+		return -EINVAL;
+
+	for (; i < rounddown_num; ++i) {
+		ret = xocl_cma_mem_alloc_by_idx(drm_p, i);
+		if (ret)
+			break;
+	}
+
+	ret = __xocl_cma_bank_alloc(drm_p, rounddown_num, ADDR_TRANSLATOR_ENTRY_4M);
+
+	return ret;
+}
+
+void xocl_cma_bank_free(struct xocl_drm *drm_p)
 {
 	mutex_lock(&drm_p->mm_lock);
-	xocl_cma_chunks_free_all(drm_p);
+	__xocl_cma_bank_free(drm_p);
 	mutex_unlock(&drm_p->mm_lock);
+}
+
+int xocl_cma_bank_alloc(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info)
+{
+	int err = 0;
+	xdev_handle_t xdev = drm_p->xdev;
+	int num = xocl_addr_translator_get_entries_num(xdev);
+
+	mutex_lock(&drm_p->mm_lock);
+
+	if (drm_p->cma_bank) {
+		err = -EINVAL;
+		DRM_ERROR("CMA BANK already allocated");
+		goto done;
+	}
+
+	drm_p->cma_bank = vzalloc(sizeof(struct xocl_cma_bank));
+	if (!drm_p->cma_bank) {
+		err = -ENOMEM;
+		goto done;
+	}
+	drm_p->cma_bank->cma_mem = vzalloc(num *sizeof(struct xocl_cma_mem*));
+	if (!drm_p->cma_bank->cma_mem) {
+		err = -ENOMEM;
+		goto done;
+	}
+
+	if (cma_info->entry_num)
+		err = xocl_cma_mem_alloc_huge_page(drm_p, cma_info);
+	else {
+		/* Cast all err as E2BIG */
+		err = xocl_cma_mem_alloc(drm_p, cma_info->total_size);
+		if (err)
+			err = -E2BIG;
+	}
+done:
+	if (err)
+		__xocl_cma_bank_free(drm_p);
+
+	mutex_unlock(&drm_p->mm_lock);
+	DRM_INFO("%s, %d", __func__, err);
+	return err;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -510,7 +510,7 @@ int xocl_alloc_cma_ioctl(struct drm_device *dev, void *data,
 	int err = 0;
 
 	mutex_lock(&xdev->dev_lock);
-	err = xocl_cma_chunk_alloc_helper(drm_p, cma_info);
+	err = xocl_cma_bank_alloc(drm_p, cma_info);
 	mutex_unlock(&xdev->dev_lock);
 	return err;
 }
@@ -522,7 +522,7 @@ int xocl_free_cma_ioctl(struct drm_device *dev, void *data,
 	struct xocl_dev *xdev = drm_p->xdev;
 
 	mutex_lock(&xdev->dev_lock);
-	xocl_cma_chunk_free_helper(drm_p);
+	xocl_cma_bank_free(drm_p);
 	mutex_unlock(&xdev->dev_lock);
 
 	return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -44,9 +44,11 @@ struct xocl_cma_bank {
 	uint64_t		start_addr;
 	uint64_t		entry_sz;
 	uint64_t		entry_num;
-	struct xocl_cma_memory	**cma_mem;
-	struct drm_mm		*mm;
-	struct drm_xocl_mm_stat	*mm_usage_stat;
+	struct drm_mm		mm;
+	struct drm_xocl_mm_stat	mm_usage_stat;
+	bool			mm_inited;
+	struct xocl_cma_memory	cma_mem[1];
+
 };
 
 struct xocl_drm {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -29,15 +29,24 @@
  * @active: Reverse mapping to kds command object managed exclusively by kds
  */
 struct drm_xocl_exec_metadata {
-	        enum drm_xocl_execbuf_state state;
-		        struct xocl_cmd            *active;
+	enum drm_xocl_execbuf_state state;
+	struct xocl_cmd            *active;
 };
 
-struct xocl_cma_chunk {
-	uint64_t		start_addr;
+struct xocl_cma_memory {
+	uint64_t		paddr;
 	struct page		**pages;
-	uint64_t		page_count;
-	struct drm_mm 		*mm;
+	void 			*vaddr;
+	uint64_t		size;
+};
+
+struct xocl_cma_bank {
+	uint64_t		start_addr;
+	uint64_t		entry_sz;
+	uint64_t		entry_num;
+	struct xocl_cma_memory	**cma_mem;
+	struct drm_mm		*mm;
+	struct drm_xocl_mm_stat	*mm_usage_stat;
 };
 
 struct xocl_drm {
@@ -53,7 +62,7 @@ struct xocl_drm {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
 	DECLARE_HASHTABLE(mm_range, 6);
 #endif
-	struct xocl_cma_chunk  *cma_chunk[DRM_XOCL_CMA_CHUNK_MAX];
+	struct xocl_cma_bank  *cma_bank;
 };
 
 struct drm_xocl_bo {
@@ -90,6 +99,11 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         struct drm_xocl_mm_stat *pstat);
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
+void xocl_cma_mm_get_usage_stat(struct xocl_drm *drm_p,
+        struct drm_xocl_mm_stat *pstat);
+void xocl_cma_mm_update_usage_stat(struct xocl_drm *drm_p,
+        u64 size, int count);
+
 int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 ddr,
                 struct drm_mm_node *node, u64 size);
 void *xocl_drm_init(xdev_handle_t xdev);
@@ -98,8 +112,8 @@ uint32_t xocl_get_shared_ddr(struct xocl_drm *drm_p, struct mem_data *m_data);
 int xocl_init_mem(struct xocl_drm *drm_p);
 int xocl_cleanup_mem(struct xocl_drm *drm_p);
 
-int xocl_cma_chunk_alloc_helper(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info);
-void xocl_cma_chunk_free_helper(struct xocl_drm *drm_p);
+int xocl_cma_bank_alloc(struct xocl_drm *drm_p, struct drm_xocl_alloc_cma_info *cma_info);
+void xocl_cma_bank_free(struct xocl_drm *drm_p);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 vm_fault_t xocl_gem_fault(struct vm_fault *vmf);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -830,10 +830,7 @@ struct xocl_dna_funcs {
 #define	xocl_addr_translator_set_page_table(xdev, addrs, base_addr, sz, num)			\
 	(ADDR_TRANSLATOR_CB(xdev, get_entries_num) ? ADDR_TRANSLATOR_OPS(xdev)->set_page_table(ADDR_TRANSLATOR_DEV(xdev), addrs, base_addr, sz, num) : -ENODEV)
 
-#define ADDR_TRANSLATOR_OFFSET			0x10000000000
-#define ADDR_TRANSLATOR_ENTRY_4M		0x400000
-#define ADDR_TRANSLATOR_ENTRY_1G		0x40000000
-
+#define ADDR_TRANSLATOR_OFFSET		0x10000000000
 
 struct xocl_addr_translator_funcs {
 	struct xocl_subdev_funcs common_funcs;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -821,7 +821,7 @@ struct xocl_dna_funcs {
 #define	ADDR_TRANSLATOR_DEV(xdev)		\
 	SUBDEV(xdev, XOCL_SUBDEV_ADDR_TRANSLATOR).pldev
 #define	ADDR_TRANSLATOR_OPS(xdev)		\
-	((struct xocl_slbr_funcs *)SUBDEV(xdev,	\
+	((struct xocl_addr_translator_funcs *)SUBDEV(xdev,	\
 	XOCL_SUBDEV_ADDR_TRANSLATOR).ops)
 #define ADDR_TRANSLATOR_CB(xdev, cb)	\
 	(ADDR_TRANSLATOR_DEV(xdev) && ADDR_TRANSLATOR_OPS(xdev) && ADDR_TRANSLATOR_OPS(xdev)->cb)
@@ -830,7 +830,7 @@ struct xocl_dna_funcs {
 #define	xocl_addr_translator_set_page_table(xdev, addrs, base_addr, sz, num)			\
 	(ADDR_TRANSLATOR_CB(xdev, get_entries_num) ? ADDR_TRANSLATOR_OPS(xdev)->set_page_table(ADDR_TRANSLATOR_DEV(xdev), addrs, base_addr, sz, num) : -ENODEV)
 
-#define ADDR_TRANSLATOR_OFFSET 			0x10000000000
+#define ADDR_TRANSLATOR_OFFSET			0x10000000000
 #define ADDR_TRANSLATOR_ENTRY_4M		0x400000
 #define ADDR_TRANSLATOR_ENTRY_1G		0x40000000
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -751,14 +751,15 @@ int shim::cmaEnable(bool enable, uint64_t size)
     int ret = 0;
 
     if (enable) {
+        uint64_t page_sz = 1 << 30;
         uint32_t page_num = size >> 30;
-        uint32_t cma_info_sz = sizeof(drm_xocl_alloc_cma_info)+sizeof(uint64_t)*page_num;
-        drm_xocl_alloc_cma_info *cma_info = (drm_xocl_alloc_cma_info *)alloca(cma_info_sz);
+        drm_xocl_alloc_cma_info cma_info = {0};
         int err_code = 0;
 
-        cma_info->total_size = size;
+        cma_info.total_size = size;
+        cma_info.entry_num = 0;
 
-        ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_ALLOC_CMA, cma_info);
+        ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_ALLOC_CMA, &cma_info);
 
         err_code = -errno;
         if (ret && err_code != -E2BIG)
@@ -769,12 +770,13 @@ int shim::cmaEnable(bool enable, uint64_t size)
              * 21 = 0x15
              * Let's find how many 1GB huge page we have to allocate
              */
-            uint64_t hugepage_flag = 0x1e;
-            uint32_t page_num = size >> 30; 
-            uint64_t page_sz = 1 << 30;
-            std::string err;
+            uint64_t hugepage_flag = 0x1e; 
+            cma_info.entry_num = page_num;
 
-            cma_info->total_size = size;
+            cma_info.user_addr = (uint64_t *)alloca(sizeof(uint64_t)*page_num);
+            ret = 0;
+
+
 
             for (uint32_t i = 0; i < page_num; ++i) {
                 void *addr_local = mmap(0x0, page_sz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | hugepage_flag << MAP_HUGE_SHIFT, 0, 0);
@@ -784,21 +786,21 @@ int shim::cmaEnable(bool enable, uint64_t size)
                     ret = -ENOMEM;
                     break;
                 } else {
-                    cma_info->user_addr[i] = (uint64_t)addr_local;
+                    cma_info.user_addr[i] = (uint64_t)addr_local;
                 }
             }
 
             if (!ret) {
-                ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_ALLOC_CMA, cma_info);
+                ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_ALLOC_CMA, &cma_info);
                 if (ret)
                         ret = -errno;
             }
 
             for (uint32_t i = 0; i < page_num; ++i) {
-                if (!cma_info->user_addr[i])
+                if (!cma_info.user_addr[i])
                     continue;
 
-                 munmap((void*)cma_info->user_addr[i], page_sz);
+                 munmap((void*)cma_info.user_addr[i], page_sz);
             }
 
         }

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1819,8 +1819,6 @@ int xcldev::xclP2p(int argc, char *argv[])
     return ret;
 }
 
-
-
 int xcldev::device::setCma(bool enable, uint64_t total_size)
 {
     return xclCmaEnable(m_handle, enable, total_size);
@@ -1859,7 +1857,7 @@ int xcldev::xclCma(int argc, char *argv[])
             cma_enable = 0;
             break;
         case xcldev::CMA_SIZE:
-            total_size = std::stoi(optarg);
+            total_size = std::stoll(optarg);
             break;
         default:
             xcldev::printHelp(exe);
@@ -1872,6 +1870,11 @@ int xcldev::xclCma(int argc, char *argv[])
         return -EINVAL;
 
     if (cma_enable == -1) {
+        std::cerr << usage << std::endl;
+        return -EINVAL;
+    }
+
+    if (cma_enable && !total_size) {
         std::cerr << usage << std::endl;
         return -EINVAL;
     }


### PR DESCRIPTION
1. Change user_addr[1] to *user_addr:

ioctl via DRM framework, it'll do a copy_from_user with given struct size and pass a kernel buffer to the ioctl function , so we'll lose the user_addr pointer at that point.

2. CMA bank contains a specific number of CMA memory(256 in this case):

Read the maximum number from address_translator IP, convert the given size into page count and check the page count to see it's power of 2 or not.(power of 2 comes from hardware limitation)
Allocate CMA memory, set translation table, initiate struct drm_mm as range allocator.
