### PR TITLE
missing leading --type is actually --flash_type

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -40,7 +40,7 @@ const char *subCmdFlashUsage =
     "--update [--shell name [--id id]] [--card bdf] [--force]\n"
     "--factory_reset [--card bdf] [--force]\n\n"
     "Experts only:\n"
-    "--shell --primary primary_file [--secondary secondary_file] --card bdf [--type flash_type]\n"
+    "--shell --primary primary_file [--secondary secondary_file] --card bdf [--flash_type flash_type]\n"
     "--sc_firmware --path file --card bdf";
 
 #define fmt_str        "    "


### PR DESCRIPTION
it is actually xbmgmt flash --shell --path --flash_type flash_type instead of
xbmgmt flash --shell --path --type. Given there are many existing scripts or tools have been using the --flash_type, we just adjust the output instead of changing the subcommand.

[root@xsjhemn41 davidz]# ./xbmgmt flash --shell --path ./vck5000_linux.pdi --card 0001:45:00.0 --type ospi_versal
--shell: unrecognized option '--type'
'flash' sub-command usage:
--scan [--verbose|--json]
--update [--shell name [--id id]] [--card bdf] [--force]
--factory_reset [--card bdf]

Experts only:
--shell --path file --card bdf [--type flash_type]
--sc_firmware --path file --card bdf
[root@xsjhemn41 davidz]# ./xbmgmt flash --shell --path ./vck5000_linux.pdi --card 0001:45:00.0 --flash_type ospi_versal
CAUTION: Overriding flash mode is not recommended. You may damage your card with this option.
Are you sure you wish to proceed? [y/n]: y
INFO: ***PDI has 83475888 bytes

