### PR TITLE
CR1060218: Fix issue with reporting kernel enqueues incorrectly in LOP

### DIFF
--- a/src/runtime_src/xocl/api/clEnqueueNDRangeKernel.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueNDRangeKernel.cpp
@@ -421,6 +421,10 @@ clEnqueueNDRangeKernel(cl_command_queue command_queue,
   xocl::profile::set_event_action(umEvent.get(),xocl::profile::action_ndrange_migrate,mEvent,kernel);
   xocl::appdebug::set_event_action(umEvent.get(),xocl::appdebug::action_ndrange_migrate,mEvent,kernel);
 
+#ifndef _WIN32
+  xocl::lop::set_event_action(umEvent.get(),xocl::lop::action_ndrange_migrate,kernel);
+#endif
+
   // Schedule migration
   umEvent->queue();
 

--- a/src/runtime_src/xocl/api/clEnqueueNDRangeKernel.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueNDRangeKernel.cpp
@@ -420,9 +420,6 @@ clEnqueueNDRangeKernel(cl_command_queue command_queue,
   xocl::enqueue::set_event_action(umEvent.get(),xocl::enqueue::action_ndrange_migrate,mEvent,kernel);
   xocl::profile::set_event_action(umEvent.get(),xocl::profile::action_ndrange_migrate,mEvent,kernel);
   xocl::appdebug::set_event_action(umEvent.get(),xocl::appdebug::action_ndrange_migrate,mEvent,kernel);
-#ifndef _WIN32
-  xocl::lop::set_event_action(umEvent.get(), xocl::lop::action_ndrange) ;
-#endif
 
   // Schedule migration
   umEvent->queue();
@@ -440,6 +437,10 @@ clEnqueueNDRangeKernel(cl_command_queue command_queue,
 
   xocl::profile::set_event_action(ueEvent.get(),xocl::profile::action_ndrange,eEvent,kernel);
   xocl::appdebug::set_event_action(ueEvent.get(),xocl::appdebug::action_ndrange,eEvent,kernel);
+
+#ifndef _WIN32
+  xocl::lop::set_event_action(ueEvent.get(), xocl::lop::action_ndrange) ;
+#endif
 
   // Schedule execution
   ueEvent->queue();

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -249,7 +249,7 @@ namespace xocl {
 	{
 	  if (!xdplop::enqueue_cb) return ;
 
-	  if (status == CL_RUNNING || status == CL_SUBMITTED)
+	  if (status == CL_RUNNING)
 	    xdplop::enqueue_cb(e->get_uid(), true) ;
 	  else if (status == CL_COMPLETE)
 	    xdplop::enqueue_cb(e->get_uid(), false) ;

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -256,6 +256,43 @@ namespace xocl {
 	} ;
     }
 
+    std::function<void (xocl::event*, cl_int)>
+    action_ndrange_migrate(cl_kernel kernel)
+    {
+      // Only check to see if any of the memory objects are going
+      //  to move.
+      bool writeWillHappen = false ;
+      for (auto& arg : xocl::xocl(kernel)->get_argument_range())
+      {
+	auto mem = arg->get_memory_object() ;
+	if (mem != nullptr && !(arg->is_progvar()) && !(mem->is_resident()))
+	{
+	  writeWillHappen = true ;
+	  break ;
+	}
+      }
+      
+      if (writeWillHappen)
+      {
+	return [](xocl::event* e, cl_int status)
+	{
+	  if (!xdplop::write_cb) return ;
+	  
+	  if (status == CL_RUNNING)
+	    xdplop::write_cb(e->get_uid(), true) ;
+	  else if (status == CL_COMPLETE)
+	    xdplop::write_cb(e->get_uid(), false) ;
+	} ;	
+      }
+      else
+      {
+	return [](xocl::event* e, cl_int status)
+	  {
+	    return ;
+	  } ;
+      }
+    }
+
   } // end namespace lop
 } // end namespace xocl
 

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.h
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.h
@@ -74,9 +74,9 @@ namespace xocl {
     std::function<void (xocl::event*, cl_int)> action_write() ;
     std::function<void (xocl::event*, cl_int)> action_migrate(cl_mem_migration_flags flags) ;
     std::function<void (xocl::event*, cl_int)> action_ndrange() ;
+    std::function<void (xocl::event*, cl_int)> action_ndrange_migrate(cl_kernel kernel) ;
     //std::function<void (xocl::event*)> action_map() ;
     //std::function<void (xocl::event*)> action_unmap() ;
-    //std::function<void (xocl::event*)> action_ndrange_migrate() ;
     //std::function<void (xocl::event*)> action_copy() ;
     
   } // end namespace lop


### PR DESCRIPTION
Now tracing the correct event and only marking the start when CL_RUNNING occurs