### PR TITLE
XRT-363 driver should be able to read xsabin from flash

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -166,6 +166,7 @@ SET (XRT_DKMS_DRIVER_INCLUDES
   include/mgmt-ioctl.h
   include/qdma_ioctl.h
   include/mailbox_proto.h
+  include/flash_xrt_data.h
   )
 
 # includes relative to core

--- a/src/runtime_src/core/pcie/driver/linux/include/flash_xrt_data.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/flash_xrt_data.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2019 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *		 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _FLASH_XRT_DATA_H_
+#define _FLASH_XRT_DATA_H_
+
+#define XRT_DATA_MAGIC	"XRTDATA"
+
+/*
+ * This header file contains data structure for xrt meta data on flash. This
+ * file is included in user space utilities and kernel drivers. The data
+ * structure is used to describe on-flash xrt data which is written by utility
+ * and read by driver. Any change of the data structure should either be
+ * backward compatible or cause version to be bumped up.
+ */
+
+struct flash_data_ident {
+	char fdi_magic[7];
+	char fdi_version;
+};
+
+/*
+ * On-flash meta data describing XRT data on flash. Either fdh_id_begin or
+ * fdh_id_end should be at well-known location on flash so that the reader
+ * can easily pick up fdi_version from flash before it tries to interpret
+ * the whole data structure.
+ * E.g., you align header in the end of the flash so that fdh_id_end is at well
+ * known location or align header at the beginning of the flash so that
+ * fdh_id_begin is at well known location.
+ */
+struct flash_data_header {
+	struct flash_data_ident fdh_id_begin;
+	uint32_t fdh_data_offset;
+	uint32_t fdh_data_len;
+	uint32_t fdh_data_parity;
+	uint8_t fdh_reserved[16];
+	struct flash_data_ident fdh_id_end;
+};
+
+static inline uint32_t flash_xrt_data_get_parity32(unsigned char *buf, size_t n)
+{
+	char *p;
+	size_t i;
+	size_t len;
+	uint32_t parity = 0;
+
+	for (len = 0; len < n; len += 4) {
+		uint32_t tmp = 0;
+		size_t thislen = n - len;
+
+		/* One word at a time. */
+		if (thislen > 4)
+			thislen = 4;
+
+		for (i = 0, p = (char *)&tmp; i < thislen; i++)
+			p[i] = buf[len + i];
+		parity ^= tmp;
+	}
+	return parity;
+}
+
+#endif

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -892,7 +892,6 @@ static int file(int argc, char *argv[])
             return ret;
         }
         ofs.write(reinterpret_cast<char *>(data.data()), data.size());
-        return 0;
     }
 
     return 0;


### PR DESCRIPTION
This change enables driver to fetching dsabin file directly from flash, which is saved when shell is flashed on the board.

Without this change, when shell pkg is removed，we get:
root@xsjmaxz50:/lib/firmware/xilinx# xbmgmt flash --scan
Can't open /opt/xilinx/firmware/u50/gen3x16-xdma/blp/partition.xsabin
Card [0000:65:00.0]
    Card type:		u50
    Flash type:		SPI
    Flashable partition running on FPGA:
        xilinx_u50,[ID=0xf465b0a3ae8c64f6],[SC=INACTIVE]
    Flashable partitions installed in system:	(None)

Card [0000:b3:00.0]
    Card type:		u200
    Flash type:		SPI
    Flashable partition running on FPGA:
        xilinx_u200_qdma_201920_1,[ID=0x5dccb0ca],[SC=INACTIVE]
    Flashable partitions installed in system:	(None)

After the change, we get:
root@xsjmaxz50:/lib/firmware/xilinx# xbmgmt flash --scan
Can't open /opt/xilinx/firmware/u50/gen3x16-xdma/blp/partition.xsabin
Card [0000:b3:00.0]
    Card type:		u200
    Flash type:		SPI
    Flashable partition running on FPGA:
        xilinx_u200_qdma_201920_1,[ID=0x5dccb0ca],[SC=4.3.7]
    Flashable partitions installed in system:	(None)

Card [0000:65:00.0]
    Card type:		u50
    Flash type:		SPI
    Flashable partition running on FPGA:
        xilinx_u50_gen3x16_xdma_201920_3,[ID=0xf465b0a3ae8c64f6],[SC=5.0.27]
    Flashable partitions installed in system:	(None)
