### PR TITLE
XRT-400 CMA BO management

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -43,6 +43,10 @@
 
 static struct sg_table *alloc_onetime_sg_table(struct page **pages, uint64_t offset, uint64_t size);
 
+static void xocl_cma_bo_free(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj);
+
+static int xocl_cma_bo_alloc(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj, uint64_t size);
+
 #if defined(XOCL_DRM_FREE_MALLOC)
 static inline void drm_free_large(void *ptr)
 {
@@ -128,12 +132,6 @@ static void xocl_free_bo(struct drm_gem_object *obj)
 			xobj->p2p_bar_offset, obj->size, false);
 	}
 
-	if (xocl_bo_cma(xobj) && xobj->cma_mm_node) {
-		drm_mm_remove_node(xobj->cma_mm_node);
-		kfree(xobj->cma_mm_node);
-		xobj->cma_mm_node = NULL;
-	}
-
 	if (xobj->vmapping)
 		vunmap(xobj->vmapping);
 	xobj->vmapping = NULL;
@@ -154,8 +152,7 @@ static void xocl_free_bo(struct drm_gem_object *obj)
 		} else if (xocl_bo_p2p(xobj) || xocl_bo_import(xobj)) {
 			drm_free_large(xobj->pages);
 		} else if (xocl_bo_cma(xobj)) {
-			if (xobj->cma_addr)
-				free_pages_exact(xobj->cma_addr, npages << PAGE_SHIFT);
+			xocl_cma_bo_free(drm_p, xobj);
 			drm_free_large(xobj->pages);
 		} else {
 			drm_gem_put_pages(obj, xobj->pages, false, false);
@@ -217,15 +214,16 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 	struct mem_topology *topo = NULL;
 	int err = 0;
 
-	if (type == XOCL_BO_EXECBUF || type == XOCL_BO_IMPORT)
+	if (type == XOCL_BO_EXECBUF || type == XOCL_BO_IMPORT || 
+	    type == XOCL_BO_CMA)
 		return 0;
-
 	//From "mem_topology" or "feature rom" depending on
 	//unified or non-unified dsa
 	ddr_count = XOCL_DDR_COUNT(xdev);
 
 	if (ddr_count == 0)
 		return -EINVAL;
+
 	ddr = xocl_bo_ddr_idx(flags);
 	if (ddr >= ddr_count)
 		return -EINVAL;
@@ -252,13 +250,59 @@ done:
 	return err;
 }
 
-static int xocl_cma_bo_alloc(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj, uint64_t size, unsigned idx)
+static void xocl_cma_bo_free(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj)
+{
+	if (xobj->cma_mm_node) {
+		xocl_cma_mm_update_usage_stat(drm_p, xobj->base.size, -1);
+		drm_mm_remove_node(xobj->cma_mm_node);
+		kfree(xobj->cma_mm_node);
+		xobj->cma_mm_node = NULL;
+	}
+}
+
+static struct page **xocl_cma_collect_pages(struct xocl_drm *drm_p, uint64_t start, uint64_t size)
+{
+	uint64_t entry_sz = drm_p->cma_bank->entry_sz;
+	uint64_t chunk_offset, page_copied = 0, page_offset_start, page_offset_end;
+	int64_t addr_offset = 0;
+	struct page **pages = NULL;
+	uint64_t pages_per_chunk = entry_sz >> PAGE_SHIFT;
+
+	addr_offset = start - drm_p->cma_bank->start_addr;
+
+	if (addr_offset < 0)
+		return ERR_PTR(-EINVAL);
+
+	page_offset_start = addr_offset >> PAGE_SHIFT;
+	page_offset_end = (addr_offset + size) >> PAGE_SHIFT;
+
+	pages = vzalloc((size >> PAGE_SHIFT) * sizeof(struct page*));
+
+
+	while (page_offset_start < page_offset_end) {
+		uint64_t nr = min(page_offset_end - page_offset_start, (pages_per_chunk - page_offset_start % pages_per_chunk));
+		
+		chunk_offset = page_offset_start / pages_per_chunk;
+		DRM_DEBUG("chunk_offset %lld start 0x%llx, end 0x%llx\n", chunk_offset, page_offset_start, page_offset_end);
+
+		memcpy(pages+page_copied, drm_p->cma_bank->cma_mem[chunk_offset].pages+(page_offset_start%pages_per_chunk), nr*sizeof(struct page*));
+		page_offset_start += nr;
+		page_copied += nr;
+	}
+
+	if (page_copied != size >> PAGE_SHIFT)
+		return ERR_PTR(-ENOMEM);
+
+
+	return pages;
+}
+
+static int xocl_cma_bo_alloc(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj, uint64_t size)
 {
 	int err = 0;
 
 	if (!drm_p->cma_bank)
 		return -ENOMEM;
-
 
 	xobj->cma_mm_node = kzalloc(sizeof(*xobj->cma_mm_node), GFP_KERNEL);
 
@@ -271,15 +315,17 @@ static int xocl_cma_bo_alloc(struct xocl_drm *drm_p, struct drm_xocl_bo *xobj, u
 #else
 		0, 0, 0);
 #endif
-	if (err) {
-		kfree(xobj->cma_mm_node);
-		xobj->cma_mm_node = NULL;
-		return err;
-	}
 
-	DRM_DEBUG("xobj->cma_mm_node.start 0x%llx, xobj->cma_mm_node.size %llx", xobj->cma_mm_node->start,
+	if (err)
+		goto failed;
+
+	xocl_cma_mm_update_usage_stat(drm_p, size, 1);
+	DRM_INFO("xobj->cma_mm_node.start 0x%llx, xobj->cma_mm_node.size %llx\n", xobj->cma_mm_node->start,
 		xobj->cma_mm_node->size);
 
+	return 0;
+failed:
+	xocl_cma_bo_free(drm_p, xobj);
 	return err;
 }
 
@@ -316,7 +362,6 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	if (xobj->flags == XOCL_BO_EXECBUF)
 		xobj->metadata.state = DRM_XOCL_EXECBUF_STATE_ABORT;
 
-
 	if (xobj->flags & XOCL_DRM_SHMEM) {
 		err = drm_gem_object_init(dev, &xobj->base, size);
 		if (err)
@@ -326,7 +371,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	}
 
 	if (xobj->flags & XOCL_CMA_MEM) {
-		err = xocl_cma_bo_alloc(drm_p, xobj, size, ddr);
+		err = xocl_cma_bo_alloc(drm_p, xobj, size);
 		if (err)
 			goto failed;
 	}
@@ -364,13 +409,6 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	return xobj;
 failed:
 	mutex_unlock(&drm_p->mm_lock);
-	if (xobj->cma_mm_node) {
-		drm_mm_remove_node(xobj->cma_mm_node);
-		kfree(xobj->cma_mm_node);
-		xobj->cma_mm_node = NULL;
-	}
-	if (xobj->cma_addr)
-		free_pages_exact(xobj->cma_addr, size);
 	kfree(xobj->mm_node);
 	if (xobj_inited)
 		drm_gem_object_release(&xobj->base);
@@ -416,31 +454,6 @@ fail:
 	return ERR_CAST(p);
 }
 
-static struct page **xocl_virt_addr_get_pages(void *vaddr, int npages)
-
-{
-	struct page *p, **pages;
-	int i;
-	uint64_t offset = 0;
-
-	pages = drm_malloc_ab(npages, sizeof(struct page *));
-	if (pages == NULL)
-		return ERR_PTR(-ENOMEM);
-
-	for (i = 0; i < npages; i++) {
-		p = virt_to_page(vaddr + offset);
-		pages[i] = p;
-		if (IS_ERR(p))
-			goto fail;
-		offset += PAGE_SIZE;
-	}
-
-	return pages;
-fail:
-	drm_free_large(pages);
-	return ERR_CAST(p);
-}
-
 static struct sg_table *alloc_onetime_sg_table(struct page **pages, uint64_t offset, uint64_t size)
 {
 	int ret;
@@ -457,6 +470,7 @@ static struct sg_table *alloc_onetime_sg_table(struct page **pages, uint64_t off
 	ret = sg_alloc_table_from_pages(sgt, pages, nr_pages, offset, size, GFP_KERNEL);
 	if (ret)
 		goto cleanup;
+
 	return sgt;
 
 cleanup:
@@ -521,10 +535,9 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 				xobj->p2p_bar_offset, xobj->base.size);
 		else if (xobj->flags & XOCL_DRM_SHMEM)
 			xobj->pages = drm_gem_get_pages(&xobj->base);
-		else if (xobj->flags & XOCL_CMA_MEM) {
-			if (xobj->cma_addr)
-				xobj->pages = xocl_virt_addr_get_pages(xobj->cma_addr, xobj->base.size >> PAGE_SHIFT);
-		}
+		else if (xobj->flags & XOCL_CMA_MEM)
+			xobj->pages = xocl_cma_collect_pages(drm_p, xobj->cma_mm_node->start, xobj->cma_mm_node->size);
+
 		if (IS_ERR(xobj->pages)) {
 			ret = PTR_ERR(xobj->pages);
 			xobj->pages = NULL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -944,7 +944,7 @@ static int xocl_cma_mem_alloc_huge_page(struct xocl_drm *drm_p, struct drm_xocl_
 	if (!user_addr)
 		return -ENOMEM;
 
-	ret = copy_from_user(user_addr, cma_info->user_addr, sizeof(uint64_t *)*rounddown_num);
+	ret = copy_from_user(user_addr, cma_info->user_addr, sizeof(uint64_t)*rounddown_num);
 	if (ret) {
 		ret = -EFAULT;
 		goto done;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -100,7 +100,7 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 	size_t memory_usage = 0;
 	unsigned int bo_count = 0;
 	const char *txt_fmt = "[%s] %s@0x%012llx (%lluMB): %lluKB %dBOs\n";
-	const char *raw_fmt = "%llu %d\n";
+	const char *raw_fmt = "%llu %d %llu\n";
 	struct mem_topology *topo = NULL;
 	struct drm_xocl_mm_stat stat;
 
@@ -128,7 +128,7 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 
 			count = sprintf(buf, raw_fmt,
 				memory_usage,
-				bo_count);
+				bo_count, 0);
 		} else {
 			count = sprintf(buf, txt_fmt,
 				topo->m_mem_data[i].m_used ?
@@ -142,6 +142,29 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 		buf += count;
 		size += count;
 	}
+
+	for (i = 0; i < 1; i++) {
+		struct drm_xocl_mm_stat cma_stat = {0};
+		struct xocl_drm *drm_p = xdev->core.drm;
+		size_t cma_bank_sz = drm_p->cma_bank ? drm_p->cma_bank->entry_sz * drm_p->cma_bank->entry_num : 0;
+
+		xocl_cma_mm_get_usage_stat(XOCL_DRM(xdev), &cma_stat);
+
+		if (raw) {
+			memory_usage = 0;
+			bo_count = 0;
+			memory_usage = cma_stat.memory_usage;
+			bo_count = cma_stat.bo_count;
+
+			count = sprintf(buf, raw_fmt,
+				memory_usage,
+				bo_count, cma_bank_sz);
+		}
+		buf += count;
+		size += count;
+	}
+
+
 done:
 	XOCL_PUT_MEM_TOPOLOGY(xdev);
 	mutex_unlock(&xdev->dev_lock);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1889,13 +1889,16 @@ int xcldev::xclCma(int argc, char *argv[])
      * 2. Huge Page MMAP 
      */
     ret = d->setCma(cma_enable, total_size);
-    if (ret == ENOMEM) {
-        std::cout << "ERROR: No enough huge page." << std::endl;
+    if (ret == -ENOMEM) {
+        std::cout << "ERROR: No enough CMA." << std::endl;
         std::cout << "Please check grub settings" << std::endl;
-    } else if (ret == EINVAL) {
-        std::cout << "ERROR: Invalid huge page." << std::endl;
-    } else if (ret == ENXIO) {
+    } else if (ret == -EINVAL) {
+        std::cout << "ERROR: Invalid cma size." << std::endl;
+    } else if (ret == -ENXIO) {
         std::cout << "ERROR: Huge page is not supported on this platform"
+            << std::endl;
+    } else if (ret == -ENODEV) {
+        std::cout << "ERROR: Does not support CMA feature"
             << std::endl;
     } else if (!ret) {
         std::cout << "xbutil cma done successfully" << std::endl;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -509,7 +509,7 @@ public:
         std::string errmsg;
         std::vector<char> buf, temp_buf;
         std::vector<std::string> mm_buf, stream_stat;
-        uint64_t memoryUsage, boCount;
+        uint64_t memoryUsage, boCount, memBankSize;
         auto dev = pcidev::get_dev(m_idx);
 
         dev->sysfs_get("icap", "mem_topology", errmsg, buf);
@@ -605,6 +605,23 @@ public:
             sensor_tree::add_child( std::string("board.memory.mem." + std::to_string(m)), ptMem );
             m++;
         }
+ 
+        boost::property_tree::ptree ptMem;
+
+        std::string str = "**UNUSED**";
+
+        std::stringstream ss(mm_buf[m]);
+        ss >> memoryUsage >> boCount >> memBankSize;
+
+        ptMem.put( "type",      str );
+        ptMem.put( "temp",      XCL_NO_SENSOR_DEV);
+        ptMem.put( "tag",       "CMA_BANK" );
+        ptMem.put( "enabled",   false);
+        ptMem.put( "size",      xrt_core::utils::unit_convert(memBankSize));
+        ptMem.put( "mem_usage", xrt_core::utils::unit_convert(memoryUsage));
+        ptMem.put( "bo_count",  boCount);
+        sensor_tree::add_child( std::string("board.memory.mem." + std::to_string(m)), ptMem );
+
     }
 
     void m_mem_usage_stringize_dynamics(xclDeviceUsage &devstat, std::vector<std::string> &lines) const


### PR DESCRIPTION
Allocate/free CMA by getting/releasing pages from CMA bank.

CMA BO only has host memory and the host memory must be physical contiguous. 

Allocate: setup the page table with given size, and update mm_stat

Free: Free the page table, and update mm_stat



Test goal: create CMA BO, do mmap, memset the whole BO, and see the page_fault works properly.

Test 1: 1G CMA bank, 256 *4M CMA BO => good

Test 2: 1G CMA bank, 1 * 1G CMA BO => good

Test 3: 2G CMA bank, 1 * 2G CMA BO => good

Test 4: 4G CMA bank, 1 * 2G CMA BO => good
