### PR TITLE
flashing shell and update SC firmware via driver by default

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -82,7 +82,7 @@ XMC_Flasher::XMC_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     mPktBufOffset = readReg(XMC_REG_OFF_PKT_OFFSET);
 
     mXmcDev = nullptr;
-    if (std::getenv("FLASH_VIA_DRIVER")) {
+    if (std::getenv("FLASH_VIA_USER") == NULL) {
         int fd = mDev->open("xmc", O_RDWR);
         if (fd >= 0)
             mXmcDev = fdopen(fd, "r+");

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -293,7 +293,7 @@ XSPI_Flasher::XSPI_Flasher(std::shared_ptr<pcidev::pci_device> dev)
         flash_base = FLASH_BASE;
 
     mFlashDev = nullptr;
-    if (std::getenv("FLASH_VIA_DRIVER")) {
+    if (std::getenv("FLASH_VIA_USER") == NULL) {
         int fd = mDev->open("flash", O_RDWR);
         if (fd >= 0)
             mFlashDev = fdopen(fd, "r+");

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -308,7 +308,7 @@ XSPI_Flasher::XSPI_Flasher(std::shared_ptr<xrt_core::device> dev)
 
     mFlashDev = nullptr;
 #ifdef __GNUC__
-    if (std::getenv("FLASH_VIA_DRIVER")) {
+    if (std::getenv("FLASH_VIA_USER") == NULL) {
         auto fd = mDev->file_open("flash", O_RDWR);
         if (fd.get() >= 0)
             mFlashDev = fdopen(fd.get(), "r+");


### PR DESCRIPTION
By default, shell and sc firmware update will go through driver. Setting FLASH_VIA_USER environment variable could switch to old code path which will go through mapped PCIE BAR on mgmt PF.