### PR TITLE
More test clean up and migration to PL APIs

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -122,8 +122,8 @@ namespace xocl {
  * handles the actual interaction with the kernel on the i/o data path.
  *
  * Configuration:
- * - qAioEn:		per queue aio context enabled or not 
- * - qAioCtx:		per queue aio context, valid only if qAioEn = true 
+ * - qAioEn:		per queue aio context enabled or not
+ * - qAioCtx:		per queue aio context, valid only if qAioEn = true
  * - set_option():	optional configurations for aio context and batching
  *
  * i/o data path:
@@ -156,7 +156,7 @@ public:
     const int queue_get_handle(void) { return (int)qhndl; }
 
     // optional configurations
-    int set_option(int type, uint32_t val) 
+    int set_option(int type, uint32_t val)
     {
         switch(type) {
         case STREAM_OPT_AIO_MAX_EVENT:
@@ -523,8 +523,13 @@ size_t shim::xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size
 unsigned int shim::xclAllocBO(size_t size, int unused, unsigned flags)
 {
     drm_xocl_create_bo info = {size, mNullBO, flags};
+    unsigned int bo = mNullBO;
     int result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_CREATE_BO, &info);
-    return result ? mNullBO : info.handle;
+    if (result)
+        errno = result;
+    else
+        bo = info.handle;
+    return bo;
 }
 
 /*
@@ -534,8 +539,13 @@ unsigned int shim::xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
 {
     drm_xocl_userptr_bo user =
         {reinterpret_cast<uint64_t>(userptr), size, mNullBO, flags};
+    unsigned int bo = mNullBO;
     int result = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_USERPTR_BO, &user);
-    return result ? mNullBO : user.handle;
+    if (result)
+        errno = result;
+    else
+        bo = user.handle;
+    return bo;
 }
 
 /*
@@ -916,7 +926,7 @@ int shim::cmaEnable(bool enable, uint64_t size)
              * 21 = 0x15
              * Let's find how many 1GB huge page we have to allocate
              */
-            uint64_t hugepage_flag = 0x1e; 
+            uint64_t hugepage_flag = 0x1e;
             cma_info.entry_num = page_num;
 
             cma_info.user_addr = (uint64_t *)alloca(sizeof(uint64_t)*page_num);
@@ -2220,7 +2230,7 @@ int xclCloseContext(xclDeviceHandle handle, uuid_t xclbinId, unsigned ipIndex)
 #ifdef DISABLE_DOWNLOAD_XCLBIN
   return 0;
 #endif
-  
+
   xocl::shim *drv = xocl::shim::handleCheck(handle);
   return drv ? drv->xclCloseContext(xclbinId, ipIndex) : -ENODEV;
 }
@@ -2421,7 +2431,7 @@ int xclGetSubdevPath(xclDeviceHandle handle,  const char* subdev,
 void
 xclGetDebugIpLayout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret)
 {
-  if(size_ret) 
+  if(size_ret)
     *size_ret = 0;
   return;
 }

--- a/tests/python/02_simple/main.py
+++ b/tests/python/02_simple/main.py
@@ -6,8 +6,8 @@ sys.path.append('../')
 from utils_binding import *
 
 def runKernel(opt):
-    count = 1024
-    DATA_SIZE = ctypes.sizeof(ctypes.c_int32) * count
+    COUNT = 1024
+    DATA_SIZE = ctypes.sizeof(ctypes.c_int32) * COUNT
 
     khandle = xrtPLKernelOpen(opt.handle, opt.xuuid, "simple")
 
@@ -21,10 +21,10 @@ def runKernel(opt):
     ctypes.memset(bo2, 0, DATA_SIZE)
 
     for i in range(len(bo1.contents)):
-        bo1.contents[i] = i * i
+        bo2.contents[i] = i
 
     # bufReference
-    bufReference = [i*i + i*16 for i in range(count)]
+    bufReference = [i + i*16 for i in range(COUNT)]
 
     xclSyncBO(opt.handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, DATA_SIZE, 0)
     xclSyncBO(opt.handle, boHandle2, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, DATA_SIZE, 0)
@@ -42,7 +42,7 @@ def runKernel(opt):
     xrtRunClose(rhandle1)
     xrtKernelClose(khandle)
 
-    assert (bufReference[:count] == bo1.contents[:count]), "Computed value does not match reference"
+    assert (bufReference[:COUNT] == bo1.contents[:COUNT]), "Computed value does not match reference"
     xclUnmapBO(opt.handle, boHandle2, bo2)
     xclFreeBO(opt.handle, boHandle2)
     xclUnmapBO(opt.handle, boHandle1, bo1)

--- a/tests/xrt/02_simple/kernel.cl
+++ b/tests/xrt/02_simple/kernel.cl
@@ -16,11 +16,11 @@
 
 // Copyright 2017 Xilinx, Inc. All rights reserved.
 
-__attribute__ ((reqd_work_group_size(1, 1, 1)))
+__attribute__ ((reqd_work_group_size(1024, 1, 1)))
 kernel void simple(global int *restrict s1,
                    global const int *s2,
                    int foo)
 {
-    const int id = get_global_id(0);
+    const int id = get_local_id(0);
     s1[id] = s2[id] + id * foo;
 }

--- a/tests/xrt/host_src/utils.h
+++ b/tests/xrt/host_src/utils.h
@@ -29,6 +29,7 @@
 #include <ctime>
 #include <map>
 #include <chrono>
+#include <system_error>
 
 #include <sys/mman.h>
 #include <sys/types.h>
@@ -132,7 +133,7 @@ static int initXRT( const char*bit,
             break;
         }
     }
-    
+
     uuid_copy(xclbinId, top->m_header.uuid);
 
     delete [] header;
@@ -148,4 +149,15 @@ static inline std::ostream& stamp(std::ostream& os) {
     os << '[' << getpid() << "] (" << st << "): ";
     return os;
 }
+
+static inline void validHandleOrError(unsigned int handle)
+{
+    if (handle == XRT_NULL_BO) throw std::system_error(errno, std::generic_category(), "buffer object allocation");
+}
+
+static inline void validOrError(int res, const char *what)
+{
+    if (res) throw std::system_error(-res, std::generic_category(), what);
+}
+
 #endif


### PR DESCRIPTION
*Update xrt/02_simple/kernel.cl to use workgroup size of 1024 for iteration which removes dependency on host application passing group ids to kernel
*Update 02_simple host code for both python and xrt test case
*Update 22_verify xrt test case host code to use new PL APIs
*Capture errno for XRT allocation APIs