### PR TITLE
CR-1059689 Removing the libcommon_em dependency for both sw_emu and hw_emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions(-DXCLHAL_MAJOR_VER=1 -DXCLHAL_MINOR_VER=0)
 add_library(common_em_objects OBJECT ${COMMON_EM_SRC_FILES} ${ProtoHeaders} ${ProtoSources})
 
 set(CURR_SOURCE "")
-add_library(common_em SHARED ${CURR_SOURCE}
+add_library(common_em STATIC ${CURR_SOURCE}
   $<TARGET_OBJECTS:common_em_objects>
   )
 
@@ -48,4 +48,4 @@ target_link_libraries(common_em
   rt
   )
 
-install (TARGETS common_em LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR})
+#install (TARGETS common_em LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR})

--- a/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/common_em/CMakeLists.txt
@@ -48,4 +48,3 @@ target_link_libraries(common_em
   rt
   )
 
-#install (TARGETS common_em LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR})


### PR DESCRIPTION
Removing the libcommon_em dependency for both sw_emu and hw_emu

This change contains a fix to remove one more shard library dependency for both sw_emu and hw_emu

I have created a static library of common_em instead of shared library

Verified changes by running both emulation flows manually and running Canary
