### PR TITLE
CR-1054254 ,CR-1061059 mmap on file descriptor causing kernel hang

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -27,6 +27,7 @@
 #include <drm/drm_backport.h>
 #endif
 #include <drm/drmP.h>
+#include <drm/drm_gem.h>
 #include "common.h"
 
 #ifdef _XOCL_BO_DEBUG

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1219,12 +1219,16 @@ int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
 	drm_gem_object_get(obj);
 
 	fput(vma->vm_file);
-	if (!IS_ERR_OR_NULL(xobj->base.dma_buf->file) && !IS_ERR_OR_NULL(xobj->base.dev->driver->gem_vm_ops)) {
+	if(!IS_ERR_OR_NULL(xobj->dmabuf) && !IS_ERR_OR_NULL(xobj->dmabuf->file)) {
+		vma->vm_file = get_file(xobj->dmabuf->file);
+		vma->vm_ops = xobj->dmabuf_vm_ops;
+	} else if (!IS_ERR_OR_NULL(xobj->base.dma_buf) && !IS_ERR_OR_NULL(xobj->base.dma_buf->file)) {
 		vma->vm_file = get_file(xobj->base.dma_buf->file);
 		vma->vm_ops = xobj->base.dev->driver->gem_vm_ops;
-		vma->vm_private_data = obj;
-		vma->vm_flags |= VM_MIXEDMAP;
 	}
+	
+	vma->vm_private_data = obj;
+	vma->vm_flags |= VM_MIXEDMAP;
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -27,7 +27,6 @@
 #include <drm/drm_backport.h>
 #endif
 #include <drm/drmP.h>
-#include <drm/drm_gem.h>
 #include "common.h"
 
 #ifdef _XOCL_BO_DEBUG
@@ -1217,7 +1216,7 @@ int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
 	ret = obj->filp->f_op->mmap(obj->filp, vma);
 	if (ret)
 		return ret;
-	drm_gem_object_get(obj);
+	XOCL_DRM_GEM_OBJECT_GET(obj);
 
 	fput(vma->vm_file);
 	if(!IS_ERR_OR_NULL(xobj->dmabuf) && !IS_ERR_OR_NULL(xobj->dmabuf->file)) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1210,13 +1210,13 @@ int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
 	if (!obj->filp)
 		return -ENODEV;
 
-  /* Add the fake offset */
-  vma->vm_pgoff += drm_vma_node_start(&obj->vma_node);
+	/* Add the fake offset */
+	vma->vm_pgoff += drm_vma_node_start(&obj->vma_node);
 
 	ret = obj->filp->f_op->mmap(obj->filp, vma);
 	if (ret)
 		return ret;
-  drm_gem_object_get(obj);
+	drm_gem_object_get(obj);
 
 	fput(vma->vm_file);
 	if (!IS_ERR_OR_NULL(xobj->base.dma_buf->file) && !IS_ERR_OR_NULL(xobj->base.dev->driver->gem_vm_ops)) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1210,14 +1210,18 @@ int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma)
 	if (!obj->filp)
 		return -ENODEV;
 
+  /* Add the fake offset */
+  vma->vm_pgoff += drm_vma_node_start(&obj->vma_node);
+
 	ret = obj->filp->f_op->mmap(obj->filp, vma);
 	if (ret)
 		return ret;
+  drm_gem_object_get(obj);
 
 	fput(vma->vm_file);
-	if (!IS_ERR(xobj->dmabuf)) {
-		vma->vm_file = get_file(xobj->dmabuf->file);
-		vma->vm_ops = xobj->dmabuf_vm_ops;
+	if (!IS_ERR_OR_NULL(xobj->base.dma_buf->file) && !IS_ERR_OR_NULL(xobj->base.dev->driver->gem_vm_ops)) {
+		vma->vm_file = get_file(xobj->base.dma_buf->file);
+		vma->vm_ops = xobj->base.dev->driver->gem_vm_ops;
 		vma->vm_private_data = obj;
 		vma->vm_flags |= VM_MIXEDMAP;
 	}

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1085,7 +1085,7 @@ int shim::xclExportBO(unsigned int boHandle)
         result = ioctl(mUserHandle, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
     }
 
-    xrt_logmsg(XRT_INFO, "XRT", "%s: boHandle %d, ioctl return %ld, fd %d", __func__, boHandle, result, info.fd);
+    xrt_logmsg(XRT_DEBUG, "XRT", "%s: boHandle %d, ioctl return %ld, fd %d", __func__, boHandle, result, info.fd);
     return !result ? info.fd : result;
 }
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1080,12 +1080,12 @@ int shim::xclExportBO(unsigned int boHandle)
     drm_prime_handle info = {boHandle, DRM_RDWR, -1};
     int result = mDev->ioctl(mUserHandle, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
     if (result) {
-        xclLog(XRT_WARNING, "XRT", "%s: DRM prime handle to fd failed with DRM_RDWR. Trying default flags.", __func__);
+        xrt_logmsg(XRT_WARNING, "XRT", "%s: DRM prime handle to fd failed with DRM_RDWR. Trying default flags.", __func__);
         info.flags = 0;
-        result = ioctl(mKernelFD, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
+        result = ioctl(mUserHandle, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
     }
 
-    xclLog(XRT_INFO, "XRT", "%s: boHandle %d, ioctl return %ld, fd %d", __func__, boHandle, result, info.fd);
+    xrt_logmsg(XRT_INFO, "XRT", "%s: boHandle %d, ioctl return %ld, fd %d", __func__, boHandle, result, info.fd);
     return !result ? info.fd : result;
 }
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1077,8 +1077,15 @@ int shim::xclLoadAxlf(const axlf *buffer)
  */
 int shim::xclExportBO(unsigned int boHandle)
 {
-    drm_prime_handle info = {boHandle, 0, -1};
+    drm_prime_handle info = {boHandle, DRM_RDWR, -1};
     int result = mDev->ioctl(mUserHandle, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
+    if (result) {
+        xclLog(XRT_WARNING, "XRT", "%s: DRM prime handle to fd failed with DRM_RDWR. Trying default flags.", __func__);
+        info.flags = 0;
+        result = ioctl(mKernelFD, DRM_IOCTL_PRIME_HANDLE_TO_FD, &info);
+    }
+
+    xclLog(XRT_INFO, "XRT", "%s: boHandle %d, ioctl return %ld, fd %d", __func__, boHandle, result, info.fd);
     return !result ? info.fd : result;
 }
 


### PR DESCRIPTION
This fix is done for http://jira.xilinx.com/browse/CR-1054254.
It also fixes http://jira.xilinx.com/browse/CR-1061059
-> Kernel hang is caused because of accessing nullptrs in function xocl_gem_prime_mmap.
-> xobj->dmabuf and xobj->dmabuf_vm_ops are both nullptrs here.
-> After this fix mmap supports both read and write.