### PR TITLE
Changing the build of the XDP plugins to MODULE

### DIFF
--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_api_interface.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_api_interface.cpp
@@ -120,6 +120,8 @@ namespace xdphalinterface {
       exit(EXIT_FAILURE);
     }
     bfs::path p(xrt / "lib");
+    p /= "xrt" ;
+    p /= "module" ;
     if(directoryOrError(p)) {
       exit(EXIT_FAILURE);
     }

--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.cpp
@@ -232,6 +232,8 @@ void load_xdp_plugin_library(HalPluginConfig* )
       exit(EXIT_FAILURE);
     }
     bfs::path p(xrt / "lib");
+    p /= "xrt" ;
+    p /= "module" ;
     if(directoryOrError(p)) {
       exit(EXIT_FAILURE);
     }

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_api_interface.cpp
@@ -135,6 +135,8 @@ namespace xdphalinterface {
       exit(EXIT_FAILURE);
     }
     bfs::path p(xrt / "lib");
+    p /= "xrt" ;
+    p /= "module" ;
     if(directoryOrError(p)) {
       exit(EXIT_FAILURE);
     }

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
@@ -410,7 +410,7 @@ void load_xdp_plugin_library(HalPluginConfig* )
     if (xrt.empty()) {
       throw std::runtime_error("Library xdp_hal_plugin not found! XILINX_XRT not set");
     }
-    bfs::path xrtlib(xrt / "lib");
+    bfs::path xrtlib(xrt / "lib" / "xrt" / "module");
     directoryOrError(xrtlib);
     auto libname = modulepath(xrt, "xdp_hal_plugin");
     if (!isDLL(libname)) {

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
@@ -33,12 +33,12 @@ inline bool isDLL(const bfs::path& path) {
 }
 
 boost::filesystem::path
-dllpath(const boost::filesystem::path& root, const std::string& libnm)
+modulepath(const boost::filesystem::path& root, const std::string& libnm)
 {
 #ifdef _WIN32
   return root / "bin" / (libnm + ".dll");
 #else
-  return root / "lib" / ("lib" + libnm + ".so");
+  return root / "lib" / "xrt" / "module" / ("lib" + libnm + ".so");
 #endif
 }
 
@@ -412,7 +412,7 @@ void load_xdp_plugin_library(HalPluginConfig* )
     }
     bfs::path xrtlib(xrt / "lib");
     directoryOrError(xrtlib);
-    auto libname = dllpath(xrt, "xdp_hal_plugin");
+    auto libname = modulepath(xrt, "xdp_hal_plugin");
     if (!isDLL(libname)) {
       throw std::runtime_error("Library " + libname.string() + " not found!");
     }

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -143,11 +143,13 @@ if (NOT WIN32)
 add_library(xdp_core SHARED ${XRT_NEW_XDP_CORE_FILES})
 add_library(xdp SHARED ${XRT_XDP_ALL_SRC})
 add_library(oclxdp SHARED ${XRT_XDP_PROFILE_OCL_PLUGIN_FILES})
-add_library(xdp_hal_plugin SHARED ${XRT_XDP_PROFILE_HAL_PLUGIN_FILES})
-add_library(xdp_hal_api_interface_plugin SHARED ${XRT_XDP_PROFILE_HAL_INTERFACE_PLUGIN_FILES})
-add_library(xdp_debug_plugin SHARED ${XRT_XDP_DEBUG_FILES})
-add_library(xdp_appdebug_plugin SHARED ${XRT_XDP_APPDEBUG_FILES})
-add_library(xdp_lop_plugin SHARED ${XRT_XDP_PROFILE_LOP_PLUGIN_FILES})
+
+# Plugin modules
+add_library(xdp_hal_plugin MODULE ${XRT_XDP_PROFILE_HAL_PLUGIN_FILES})
+add_library(xdp_hal_api_interface_plugin MODULE ${XRT_XDP_PROFILE_HAL_INTERFACE_PLUGIN_FILES})
+add_library(xdp_debug_plugin MODULE ${XRT_XDP_DEBUG_FILES})
+add_library(xdp_appdebug_plugin MODULE ${XRT_XDP_APPDEBUG_FILES})
+add_library(xdp_lop_plugin MODULE ${XRT_XDP_PROFILE_LOP_PLUGIN_FILES})
 
 add_dependencies(xdp xrt_coreutil)
 add_dependencies(oclxdp xilinxopencl xdp)
@@ -178,7 +180,9 @@ set_target_properties(xdp_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} 
 set_target_properties(xdp_appdebug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 set_target_properties(xdp_lop_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
-install (TARGETS xdp oclxdp xdp_core xdp_hal_plugin xdp_hal_api_interface_plugin xdp_debug_plugin xdp_appdebug_plugin xdp_lop_plugin LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR})
+install (TARGETS xdp oclxdp xdp_core LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR})
+
+install (TARGETS xdp_hal_plugin xdp_hal_api_interface_plugin xdp_debug_plugin xdp_appdebug_plugin xdp_lop_plugin LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR}/xrt/module)
 
 install (FILES "${XRT_XDP_PROFILE_XMA_PLUGIN_DIR}/xma_profile.h" DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
 
@@ -232,8 +236,10 @@ file(GLOB XRT_XDP_ALL_SRC_WIN
 
 add_library(xdp SHARED ${XRT_XDP_ALL_SRC_WIN})
 add_library(oclxdp SHARED ${XRT_XDP_PROFILE_OCL_PLUGIN_FILES})
-add_library(xdp_hal_plugin SHARED ${XRT_XDP_PROFILE_HAL_PLUGIN_FILES})
-add_library(xdp_hal_api_interface_plugin SHARED ${XRT_XDP_PROFILE_HAL_INTERFACE_PLUGIN_FILES})
+
+# Plugin modules
+add_library(xdp_hal_plugin MODULE ${XRT_XDP_PROFILE_HAL_PLUGIN_FILES})
+add_library(xdp_hal_api_interface_plugin MODULE ${XRT_XDP_PROFILE_HAL_INTERFACE_PLUGIN_FILES})
 
 add_dependencies(xdp xrt_core xilinxopencl)
 add_dependencies(oclxdp xdp xilinxopencl)

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -81,7 +81,7 @@ namespace xdplop {
 	if (xrt.empty()) 
 	  throw std::runtime_error("XILINX_XRT not set");
 	
-	bfs::path xrtlib(xrt / "lib");
+	bfs::path xrtlib(xrt / "lib" / "xrt" / "module");
 	if (!bfs::is_directory(xrtlib))
 	  throw std::runtime_error("No such directory '"+xrtlib.string()+"'");
 

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -58,7 +58,7 @@ namespace {
 #ifdef _WIN32
     return root / "bin" / (libnm + ".dll");
 #else
-    return root / "lib" / ("lib" + libnm + ".so");
+    return root / "lib" / "xrt" / "module" / ("lib" + libnm + ".so");
 #endif
   }
 } // end anonymous namespace

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -86,6 +86,16 @@ dllpath(const boost::filesystem::path& root, const std::string& libnm)
 #endif
 }
 
+boost::filesystem::path
+modulepath(const boost::filesystem::path& root, const std::string& libnm)
+{
+#ifdef _WIN32
+  return root / "bin" / (libnm + ".dll") ;
+#else
+  return root / "lib" / "xrt" / "module" / ("lib" + libnm + ".so") ;
+#endif
+}
+
 static bool
 is_emulation()
 {
@@ -264,7 +274,7 @@ void load_xdp_kernel_debug()
       }
       bfs::path xrtlib(xrt / "lib") ;
       directoryOrError(xrtlib) ;
-      auto libpath = dllpath(xrt, "xdp_debug_plugin") ;
+      auto libpath = modulepath(xrt, "xdp_debug_plugin") ;
       if (!isDLL(libpath)) {
         throw std::runtime_error("Library " + libpath.string() + " not found!");
       }
@@ -307,8 +317,10 @@ void load_xdp_app_debug()
         throw std::runtime_error("XILINX_XRT not set");
       }
       bfs::path xrtlib(xrt / "lib");
+      xrtlib /= "xrt" ;
+      xrtlib /= "module" ;
       directoryOrError(xrtlib);
-      auto libpath = dllpath(xrt, "xdp_appdebug_plugin");
+      auto libpath = modulepath(xrt, "xdp_appdebug_plugin");
 
       if (!isDLL(libpath)) {
         throw std::runtime_error("Library " + libpath.string() + " not found!");

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -272,7 +272,7 @@ void load_xdp_kernel_debug()
       if (xrt.empty()) {
         throw std::runtime_error("XILINX_XRT not set");
       }
-      bfs::path xrtlib(xrt / "lib") ;
+      bfs::path xrtlib(xrt / "lib" / "xrt" / "module" ) ;
       directoryOrError(xrtlib) ;
       auto libpath = modulepath(xrt, "xdp_debug_plugin") ;
       if (!isDLL(libpath)) {
@@ -316,9 +316,7 @@ void load_xdp_app_debug()
       if (xrt.empty()) {
         throw std::runtime_error("XILINX_XRT not set");
       }
-      bfs::path xrtlib(xrt / "lib");
-      xrtlib /= "xrt" ;
-      xrtlib /= "module" ;
+      bfs::path xrtlib(xrt / "lib" / "xrt" / "module");
       directoryOrError(xrtlib);
       auto libpath = modulepath(xrt, "xdp_appdebug_plugin");
 


### PR DESCRIPTION
XDP plugins (xdp_debug_plugin, xdp_appdebug_plugin, xdp_hal_api_interface_plugin, xdp_lop_plugin, and xdp_hal_plugin) that are loaded at runtime and linked via dlopen and dlsyms are changed to be MODULE in the CMakeList files instead of shared libraries on Linux for edge and pcie.

Also, moving the install location to lib/xrt/module on Linux and changing the loading of the plugins in XRT code.

The elimination of duplicate code and consolidation of a single way to load the plugins will be addressed in a future pull request.