### PR TITLE
AIE error and event handling

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -67,6 +67,11 @@ public:
     std::vector<gmio_type> gmios;
 
     int getTilePos(int col, int row);
+
+    XAieGbl *getAieInst();
+
+    static XAieGbl_ErrorHandleStatus
+    error_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 error, void *arg);
     
 private:
     int numRows;

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -37,7 +37,7 @@ public:
     using rtp_type = xrt_core::edge::aie::rtp_type;
     using gmio_type = xrt_core::edge::aie::gmio_type;
 
-    graph_type(std::shared_ptr<xrt_core::device> device, uuid_t xclbin_uuid, const std::string& name);
+    graph_type(std::shared_ptr<xrt_core::device> device, const uuid_t xclbin_uuid, const std::string& name);
     ~graph_type();
 
     void
@@ -69,6 +69,9 @@ public:
 
     void
     sync_bo(unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+    static void
+    event_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 event, void *arg);
 
 private:
     // Core device to which the graph belongs.  The core device

--- a/src/runtime_src/core/include/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/experimental/xrt_aie.h
@@ -35,7 +35,7 @@ typedef void *xrtGraphHandle;
  * to calling this function.
  */
 xrtGraphHandle
-xrtGraphOpen(xclDeviceHandle handle, uuid_t xclbinUUID, const char *graphName);
+xrtGraphOpen(xclDeviceHandle handle, const uuid_t xclbinUUID, const char *graphName);
 
 /**
  * xrtGraphClose() - Close an open graph.


### PR DESCRIPTION
This PR implement the XRT AIE error/event handler.
1. Error handler is registered during AIE initialization.
2. Event handler is registerer during graph initializtion because event is reported on tiles based.
3. The current error/event handler will log message using existing XRT logging framework. 
4. Errors are classified according to its severity.
5. Events are logged as NOTICE