### PR TITLE
CR-1061236 : added LD_LIBRARY_PATH for sw emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -402,7 +402,8 @@ namespace xclcpuemhal2 {
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "fpo_v7_0" + ":";
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "dds_v6_0" + ":";
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "opencv"   + ":";
-          sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "lib"   + DS + "csim";
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "lib" + DS + "csim" + ":";
+          sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS;         
           setenv("LD_LIBRARY_PATH",sLdLibs.c_str(),true);
         }
 


### PR DESCRIPTION
added $XILINX_VIVADO/lib/lnx64.o/Default/ to LD_LIBRARY_PATH for sw emulation.