### PR TITLE
CR-1058034,  CR-1061337 . Provide a warning, when behav_gdb dir doesn’t exist and continue with behav_waveform

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -586,11 +586,15 @@ namespace xclhwemhal2 {
         // NOTE: proto inst filename must match name in HPIKernelCompilerHwEmu.cpp
         std::string protoFileName = "./" + bdName + "_behav.protoinst";
         std::stringstream cmdLineOption;
-        cmdLineOption << " -g --wdb " << wdbFileName << ".wdb"
-          << " --protoinst " << protoFileName;
 
-        launcherArgs = launcherArgs + cmdLineOption.str();
         sim_path = binaryDirectory + "/behav_waveform/xsim";
+
+        if (boost::filesystem::exists(sim_path) != false) {
+          cmdLineOption << " -g --wdb " << wdbFileName << ".wdb"
+            << " --protoinst " << protoFileName;
+
+          launcherArgs = launcherArgs + cmdLineOption.str();
+        }
         std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
         unsetenv("VITIS_LAUNCH_WAVEFORM_BATCH");
         setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
@@ -616,6 +620,10 @@ namespace xclhwemhal2 {
         setenv("VITIS_KERNEL_PROFILE_FILENAME", kernelProfileFileName.c_str(), true);
         setenv("VITIS_KERNEL_TRACE_FILENAME", kernelTraceFileName.c_str(), true);
       }
+      if (lWaveform == xclemulation::LAUNCHWAVEFORM::OFF)
+      {
+        sim_path = binaryDirectory + "/behav_gdb/xsim";
+      }
 
       if (userSpecifiedSimPath.empty() == false)
       {
@@ -629,9 +637,35 @@ namespace xclhwemhal2 {
         }
         if (boost::filesystem::exists(sim_path) == false)
         {
-          std::string dMsg = "WARNING: [HW-EM 07] None of the kernels is compiled in debug mode. Compile kernels in debug mode to launch waveform";
-          logMessage(dMsg, 0);
-          sim_path = binaryDirectory + "/behav_gdb/xsim";
+          if (lWaveform == xclemulation::LAUNCHWAVEFORM::OFF) {
+            sim_path = binaryDirectory + "/behav_waveform/xsim";
+            std::string dMsg = "WARNING: [HW-EM 07] Launch Waveform is set to OFF in ini file. Could not find an axsim binary. Running simulation using xsim. Using " + sim_path + " as simulation directory.";
+            logMessage(dMsg, 0);
+            std::string protoFileName = "./" + bdName + "_behav.protoinst";
+            std::stringstream cmdLineOption;
+            cmdLineOption << " --wdb " << wdbFileName << ".wdb"
+              << " --protoinst " << protoFileName;
+
+            launcherArgs = launcherArgs + cmdLineOption.str();
+            std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
+            setenv("VITIS_LAUNCH_WAVEFORM_BATCH", "1", true);
+            setenv("VITIS_WAVEFORM", generatedWcfgFileName.c_str(), true);
+            setenv("VITIS_WAVEFORM_WDB_FILENAME", std::string(wdbFileName + ".wdb").c_str(), true);
+            setenv("VITIS_KERNEL_PROFILE_FILENAME", kernelProfileFileName.c_str(), true);
+            setenv("VITIS_KERNEL_TRACE_FILENAME", kernelTraceFileName.c_str(), true);
+
+          }
+          else {
+            std::string dMsg;
+            sim_path = binaryDirectory + "/behav_gdb/xsim";
+            if (lWaveform == xclemulation::LAUNCHWAVEFORM::GUI) {
+              dMsg = "WARNING: [HW-EM 07] Launch Waveform is set to GUI in ini file. Could not find a xsim binary. Running simulation using axsim. Cannot enable simulator GUI in this mode. Using " + sim_path + " as simulation directory.";
+            }
+            else {
+              dMsg = "WARNING: [HW-EM 07] Launch Waveform is set to BATCH in ini file (or) considered by default. Could not find a xsim binary. Running simulation using axsim. Using " + sim_path + " as simulation directory.";
+            }
+            logMessage(dMsg, 0);
+          }
         }
       }
       std::stringstream socket_id;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -621,9 +621,7 @@ namespace xclhwemhal2 {
         setenv("VITIS_KERNEL_TRACE_FILENAME", kernelTraceFileName.c_str(), true);
       }
       if (lWaveform == xclemulation::LAUNCHWAVEFORM::OFF)
-      {
         sim_path = binaryDirectory + "/behav_gdb/xsim";
-      }
 
       if (userSpecifiedSimPath.empty() == false)
       {
@@ -658,12 +656,10 @@ namespace xclhwemhal2 {
           else {
             std::string dMsg;
             sim_path = binaryDirectory + "/behav_gdb/xsim";
-            if (lWaveform == xclemulation::LAUNCHWAVEFORM::GUI) {
+            if (lWaveform == xclemulation::LAUNCHWAVEFORM::GUI) 
               dMsg = "WARNING: [HW-EM 07] Launch Waveform is set to GUI in ini file. Could not find a xsim binary. Running simulation using axsim. Cannot enable simulator GUI in this mode. Using " + sim_path + " as simulation directory.";
-            }
-            else {
+            else 
               dMsg = "WARNING: [HW-EM 07] Launch Waveform is set to BATCH in ini file (or) considered by default. Could not find a xsim binary. Running simulation using axsim. Using " + sim_path + " as simulation directory.";
-            }
             logMessage(dMsg, 0);
           }
         }


### PR DESCRIPTION
•  Fix for CR 1058034, 1061337.
•  CR-1058034 Provide a warning, behav_gdb directory doesn’t exist when launch_waveform=off is selected. 
• CR-1061337 Continue with simulation, by changing the sim_path to behav_waveform, when behav_gdb directory is not found with launch_waveform=off (Amit's recommendation)
• Tests done :  Manully verified hello_world case in launchwaveform=gui/batch/off modes with default v++  and v++ -g -xp param:hw_emu.debugMode=gdb. Canary run. Results look good.
• Code Reviewer : venkatp
