### PR TITLE
Fix for CR-1060521 Added the newer INI options user_pre_sim_script, enable_debug

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -59,6 +59,7 @@ namespace xclemulation{
     mLaunchWaveform = LAUNCHWAVEFORM::BATCH;
     mDontRun = false;
     mSimDir = "";
+    mUserPreSimScript = "";
     mPacketSize = 0x800000;
     mMaxTraceCount = 1;
     mPaddingFactor = 1;
@@ -144,6 +145,9 @@ namespace xclemulation{
       else if(name == "dont_run")
       {
         setDontRun(getBoolValue(value,false));
+      }
+      else if (name == "user_pre_sim_script") {
+        setUserPreSimScript(value);
       }
       else if (name == "ENABLE_GMEM_LATENCY" || name == "enable_gmem_latency") {
         //This is then new INI option that sets the ENV HW_EM_DISABLE_LATENCY to appropriate value before 

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -120,6 +120,7 @@ namespace xclemulation{
       inline void setMaxTraceCount( unsigned int maxTraceCount) { mMaxTraceCount    = maxTraceCount; }
       inline void setPaddingFactor( unsigned int paddingFactor) { mPaddingFactor    = paddingFactor; }
       inline void setSimDir( std::string& simDir)               { mSimDir           = simDir;        }
+      inline void setUserPreSimScript( std::string& userPreSimScript) {mUserPreSimScript = userPreSimScript; }
       inline void setLaunchWaveform( LAUNCHWAVEFORM lWaveform)  { mLaunchWaveform   = lWaveform;     }
       inline void suppressInfo( bool suppress)                  { mSuppressInfo     = suppress;      }
       inline void suppressWarnings( bool suppress)              { mSuppressWarnings = suppress;      }
@@ -143,6 +144,7 @@ namespace xclemulation{
       inline unsigned int getMaxTraceCount()    const { return mMaxTraceCount;  }
       inline unsigned int getPaddingFactor()    const { if(!mOOBChecks) return 0; return mPaddingFactor;  }
       inline std::string getSimDir()            const { return mSimDir;         }
+      inline std::string getUserPreSimScript()  const { return mUserPreSimScript;}
       inline LAUNCHWAVEFORM getLaunchWaveform() const { return mLaunchWaveform; }
       inline bool isInfoSuppressed()            const { return mSuppressInfo;    }
       inline bool isWarningsuppressed()         const { return mSuppressWarnings;}
@@ -169,6 +171,7 @@ namespace xclemulation{
       bool mDontRun;
       LAUNCHWAVEFORM mLaunchWaveform;
       std::string mSimDir;
+      std::string mUserPreSimScript;
       unsigned int mPacketSize;
       unsigned int mMaxTraceCount;
       unsigned int mPaddingFactor;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -666,7 +666,7 @@ namespace xclhwemhal2 {
       setenv("SYSTEMC_DISABLE_COPYRIGHT_MESSAGE", "1", true);
       pid_t pid = fork();
       assert(pid >= 0);
-      if (pid == 0){ //I am child
+      if (pid == 0) { //I am child
         //Redirecting the XSIM log to a file
         FILE* nP = freopen("/dev/null", "w", stdout);
         if (!nP) { std::cerr << "FATAR ERROR : Unable to redirect simulation output " << std::endl; exit(1); }
@@ -699,11 +699,11 @@ namespace xclhwemhal2 {
             launcherArgs += " -boot-bh " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/BOOT_bh.bin";
             launcherArgs += " -ospi-image " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/qemu_ospi.bin";
             launcherArgs += " -qemu-args-file " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/qemu_args.txt";
-           
-            if (boost::filesystem::exists(binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmc_args.txt") ) {
+
+            if (boost::filesystem::exists(binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmc_args.txt")) {
               launcherArgs += " -pmc-args-file " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmc_args.txt";
             }
-            else if (boost::filesystem::exists(binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmu_args.txt" ) ) {
+            else if (boost::filesystem::exists(binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmu_args.txt")) {
               launcherArgs += " -pmc-args-file " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmu_args.txt";
             }
             else {
@@ -717,8 +717,14 @@ namespace xclhwemhal2 {
             if (aie_sim_options != "") {
               launcherArgs += " -aie-sim-options " + aie_sim_options;
             }
+
+            std::string userSpecifiedPreSimScript = xclemulation::config::getInstance()->getUserPreSimScript();
+
+            if (userSpecifiedPreSimScript != "") {
+              launcherArgs += " -user-pre-sim-script " + userSpecifiedPreSimScript;
+            }
           }
-          else { 
+          else {
             // Added to be compatible for older flows, will remove this once the prep_target aka pack flow is stabilized and obsorbed by the DSV
             launcherArgs += " -emuData " + binaryDirectory + "/" + kernels.at(0) + "/aieshim_solution.aiesol";
             launcherArgs += " -emu-data " + binaryDirectory + "/" + kernels.at(0) + "/aieshim_solution.aiesol";


### PR DESCRIPTION
Fix for CR-1060521; Added the newer INI options user_pre_sim_script, enable_debug to improve the debuggability of the emulation. With this one can add the add_wave, log_wave xsim commands and can create the wdb file from the batch mode

Reviewer: @vboggara-xilinx 
Verification: Ran required test cases, able to see desired output. These option cannot be verified with canary runs