### PR TITLE
XRT-431 New KDS driver has NULL pointer when there are 2 CUs in a xclbin

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -660,7 +660,7 @@ struct xocl_subdev_map {
 	((struct resource []) {				\
 		{					\
 			.start	= 0x0,			\
-			.end	= 0x7FFFFF,		\
+			.end	= 0x0FFFF,		\
 			.flags	= IORESOURCE_MEM,	\
 		},					\
 		{					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
@@ -523,7 +523,7 @@ static int cu_ctrl_remove_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 			continue;
 
 		/* Maybe the thread is running */
-		if (xcuc->threads[i] != NULL) {
+		if (xcuc->threads && xcuc->threads[i]) {
 			ret = kthread_stop(xcuc->threads[i]);
 			xcuc->threads[i] = NULL;
 		}


### PR DESCRIPTION
The CU size should be 64KB.
When it is failed to create a CU, the CU controller need to check if CU threads are allocated.