### PR TITLE
XRT-285 incorrect feature rom header for u.2

### DIFF
--- a/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
@@ -97,9 +97,9 @@ typedef union _DRIVER_VERSION
 {
     struct
     {
-        /* [Minor Version Number] Indicates the minor version is �0�. */
+        /* [Minor Version Number] Indicates the minor version is “0”. */
         USHORT MNR;
-        /* [Major Version Number] Indicates the major version is �1�. */
+        /* [Major Version Number] Indicates the major version is “1”. */
         USHORT MJR;
     };
     ULONG AsUlong;

--- a/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
@@ -97,9 +97,9 @@ typedef union _DRIVER_VERSION
 {
     struct
     {
-        /* [Minor Version Number] Indicates the minor version is “0”. */
+        /* [Minor Version Number] Indicates the minor version is ï¿½0ï¿½. */
         USHORT MNR;
-        /* [Major Version Number] Indicates the major version is “1”. */
+        /* [Major Version Number] Indicates the major version is ï¿½1ï¿½. */
         USHORT MJR;
     };
     ULONG AsUlong;
@@ -139,7 +139,7 @@ typedef struct xclmgmt_ioc_device_info {
     CHAR             vbnv[64];
     CHAR             fpga[64];
     SYSMON_INFO      sysmoninfo;
-    ULONGLONG        ocl_frequency[XCLMGMT_NUM_SUPPORTED_CLOCKS];
+    UINT32           ocl_frequency[XCLMGMT_NUM_SUPPORTED_CLOCKS];
     bool             mig_calibration[4];
     USHORT           num_clocks;
 	struct FeatureRomHeader rom_hdr;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -355,7 +355,7 @@ auto_flash(xrt_core::device_collection& deviceCollection, bool force)
   // Collect all indexes of boards need updating
   std::vector<std::pair<unsigned int , DSAInfo>> boardsToUpdate;
   for (const auto & device : deviceCollection) {
-    DSAInfo dsa(_pt.get<std::string>(std::to_string(device->get_device_id()) + ".platform.installed_shell.file"));
+    DSAInfo dsa(_pt.get<std::string>(std::to_string(device->get_device_id()) + ".platform.installed_shell.0.file"));
     //if the shell is not up-to-date and dsa has a flash image, queue the board for update
     if (!_pt.get<bool>(std::to_string(device->get_device_id()) + ".platform.shell_upto_date") ||
           !_pt.get<bool>(std::to_string(device->get_device_id()) + ".platform.sc_upto_date")) {


### PR DESCRIPTION
Output:
```
xbmgmt.exe status --report=platform
ERROR: Failed to detect XMC, bad magic number: 0
ERROR: Failed to detect XMC, bad magic number: 0
Device BDF : 0000:0e:00.0
  Flash type           : spi
Flashable partition running on FPGA
  Platform             : xilinx_samsung_u2x4_201920_2
  SC Version           : query request (21) not supported for mgmtpf on windows
  Platform ID          : 0x5e4fce30

Flashable partitions installed in system
  Platform             : xilinx_samsung_u2x4_201920_2
  SC Version           :
  Platform ID          : 0x0x5e4fce30

----------------------------------------------------
WARNING  : SC image on the device is not up-to-date.
```