### PR TITLE
CR-1061709 fixing hw_emu crash which got introuduced in latest preptarget change

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -11,7 +11,7 @@ usage()
     echo "Usage: $PROGRAM [options] "
     echo "  options:"
     echo "          -help                           Print this usage"
-    echo "          -aarch                          Architecture <aarch32/aarch64>"
+    echo "          -aarch                          Architecture <aarch32/aarch64/versal>"
     echo "          -cache                          path to sstate-cache"
     echo "          -clean, clean                   Remove build directories"
     echo ""

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -531,9 +531,14 @@ namespace xclhwemhal2 {
     //Creating the Kernel Directory and dumping the emulation data into Kernel Dir
     //For timebeing having this under is_prep_target condition, will remove this
     //condition once this flow is obsorbed by the Sprite and Canary Verification
+    std::string xclbinName("xclbin");
+    if(kernels.size() > 0) {
+      xclbinName = kernels.at(0);
+    }
+
     if (is_prep_target) {
       std::stringstream ks;
-      ks << binaryDirectory << "/" << kernels.at(0);
+      ks << binaryDirectory << "/" << xclbinName;
       std::string kernelDir = ks.str();
       systemUtil::makeSystemCall(kernelDir, systemUtil::systemOperation::CREATE);
 
@@ -724,17 +729,17 @@ namespace xclhwemhal2 {
           //For timebeing having this under is_prep_target condition, will remove this
           //condition once this flow is obsorbed by the Sprite and Canary Verification
           if (is_prep_target) {
-            launcherArgs += " -emuData " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/libsdf/cfg/aie.sim.config.txt";
-            launcherArgs += " -aie-sim-config " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/libsdf/cfg/aie.sim.config.txt";
-            launcherArgs += " -boot-bh " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/BOOT_bh.bin";
-            launcherArgs += " -ospi-image " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/qemu_ospi.bin";
-            launcherArgs += " -qemu-args-file " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/qemu_args.txt";
+            launcherArgs += " -emuData " + binaryDirectory + "/" + xclbinName + "/emulation_data/libsdf/cfg/aie.sim.config.txt";
+            launcherArgs += " -aie-sim-config " + binaryDirectory + "/" + xclbinName + "/emulation_data/libsdf/cfg/aie.sim.config.txt";
+            launcherArgs += " -boot-bh " + binaryDirectory + "/" + xclbinName + "/emulation_data/BOOT_bh.bin";
+            launcherArgs += " -ospi-image " + binaryDirectory + "/" + xclbinName + "/emulation_data/qemu_ospi.bin";
+            launcherArgs += " -qemu-args-file " + binaryDirectory + "/" + xclbinName + "/emulation_data/qemu_args.txt";
 
-            if (boost::filesystem::exists(binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmc_args.txt")) {
-              launcherArgs += " -pmc-args-file " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmc_args.txt";
+            if (boost::filesystem::exists(binaryDirectory + "/" + xclbinName + "/emulation_data/pmc_args.txt")) {
+              launcherArgs += " -pmc-args-file " + binaryDirectory + "/" + xclbinName + "/emulation_data/pmc_args.txt";
             }
-            else if (boost::filesystem::exists(binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmu_args.txt")) {
-              launcherArgs += " -pmc-args-file " + binaryDirectory + "/" + kernels.at(0) + "/emulation_data/pmu_args.txt";
+            else if (boost::filesystem::exists(binaryDirectory + "/" + xclbinName + "/emulation_data/pmu_args.txt")) {
+              launcherArgs += " -pmc-args-file " + binaryDirectory + "/" + xclbinName + "/emulation_data/pmu_args.txt";
             }
             else {
               std::cout << "ERROR: [HW-EMU] Unable to find either PMU/PMC args which are required to launch the emulation." << std::endl;
@@ -756,11 +761,11 @@ namespace xclhwemhal2 {
           }
           else {
             // Added to be compatible for older flows, will remove this once the prep_target aka pack flow is stabilized and obsorbed by the DSV
-            launcherArgs += " -emuData " + binaryDirectory + "/" + kernels.at(0) + "/aieshim_solution.aiesol";
-            launcherArgs += " -emu-data " + binaryDirectory + "/" + kernels.at(0) + "/aieshim_solution.aiesol";
-            launcherArgs += " -bootBH " + binaryDirectory + "/" + kernels.at(0) + "/boot_bh.bin";
-            launcherArgs += " -boot-bh " + binaryDirectory + "/" + kernels.at(0) + "/boot_bh.bin";
-            launcherArgs += " -image " + binaryDirectory + "/" + kernels.at(0) + "/qemu_qspi.bin";
+            launcherArgs += " -emuData " + binaryDirectory + "/" + xclbinName + "/aieshim_solution.aiesol";
+            launcherArgs += " -emu-data " + binaryDirectory + "/" + xclbinName + "/aieshim_solution.aiesol";
+            launcherArgs += " -bootBH " + binaryDirectory + "/" + xclbinName + "/boot_bh.bin";
+            launcherArgs += " -boot-bh " + binaryDirectory + "/" + xclbinName + "/boot_bh.bin";
+            launcherArgs += " -image " + binaryDirectory + "/" + xclbinName + "/qemu_qspi.bin";
 
             if (is_enable_debug) {
               launcherArgs += " -enable-debug ";


### PR DESCRIPTION
Hi,

This change contains a fix to the crash which got introduced in latest prepTarget change.

There were no checks before accessing a vector.

Also updated help message of build_edge.sh

Thanks
