### PR TITLE
Migrating pull request 2942 changes from master into PU2 branch

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -15,6 +15,7 @@
  */
 #define XRT_CORE_COMMON_SOURCE
 #include "core/common/system.h"
+#include "gen/version.h"
 
 namespace xrt_core {
 
@@ -41,8 +42,18 @@ instance()
 }
 
 void
+get_xrt_build_info(boost::property_tree::ptree& pt)
+{
+  pt.put("version", xrt_build_version);
+  pt.put("hash",    xrt_build_version_hash);
+  pt.put("date",    xrt_build_version_date);
+  pt.put("branch",  xrt_build_version_branch);
+}
+
+void
 get_xrt_info(boost::property_tree::ptree &pt)
 {
+  get_xrt_build_info(pt);
   instance().get_xrt_info(pt);
 }
 

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -51,6 +51,12 @@ public:
  */
 XRT_CORE_COMMON_EXPORT
 void
+get_xrt_build_info(boost::property_tree::ptree& pt);
+
+/**
+ */
+XRT_CORE_COMMON_EXPORT
+void
 get_xrt_info(boost::property_tree::ptree& pt);
 
 /**

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -66,11 +66,7 @@ void
 system_linux::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  pt.put("version",   xrt_build_version);
-  pt.put("hash",      xrt_build_version_hash);
-  pt.put("date",      xrt_build_version_date);
-  pt.put("branch",    xrt_build_version_branch);
-  pt.put("zocl",      driver_version("zocl"));
+  pt.put("zocl", driver_version("zocl"));
 }
 
 

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -67,10 +67,6 @@ void
 system_linux::
 get_xrt_info(boost::property_tree::ptree &pt)
 {
-  pt.put("version",   xrt_build_version);
-  pt.put("hash",      xrt_build_version_hash);
-  pt.put("date",      xrt_build_version_date);
-  pt.put("branch",    xrt_build_version_branch);
   pt.put("xocl",      driver_version("xocl"));
   pt.put("xclmgmt",   driver_version("xclmgmt"));
 }

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -83,13 +83,8 @@ system_child_ctor()
 }
 void
 system_windows::
-get_xrt_info(boost::property_tree::ptree &pt)
+get_xrt_info(boost::property_tree::ptree& /*pt*/)
 {
-  pt.put("version",   xrt_build_version);
-  pt.put("hash",      xrt_build_version_hash);
-  pt.put("date",      xrt_build_version_date);
-  pt.put("branch",    xrt_build_version_branch);
-
   //TODO
   // _pt.put("xocl",      driver_version("xocl"));
   // _pt.put("xclmgmt",   driver_version("xclmgmt"));

--- a/src/runtime_src/xdp/profile/writer/json_profile.cpp
+++ b/src/runtime_src/xdp/profile/writer/json_profile.cpp
@@ -150,7 +150,7 @@ void JSONProfileWriter::writeDocumentHeader(std::ofstream& /*ofs*/,
   header.put("toolVersion", xdp::WriterI::getToolVersion());
 
   boost::property_tree::ptree xrtInfo;
-  xrt_core::get_xrt_info(xrtInfo);
+  xrt_core::get_xrt_build_info(xrtInfo);
   header.put("XRT build version", xrtInfo.get<std::string>("version", "N/A"));
   header.put("Build version branch", xrtInfo.get<std::string>("branch", "N/A"));
   header.put("Build version hash", xrtInfo.get<std::string>("hash", "N/A"));

--- a/src/runtime_src/xdp/profile/writer/util.cpp
+++ b/src/runtime_src/xdp/profile/writer/util.cpp
@@ -38,7 +38,7 @@ namespace xdp {
     std::string xrtVersion;
 
     boost::property_tree::ptree xrtInfo;
-    xrt_core::get_xrt_info(xrtInfo);
+    xrt_core::get_xrt_build_info(xrtInfo);
     xrtVersion = "XRT build version: "  + xrtInfo.get<std::string>("version", "N/A") + "\n"
                + "Build version branch: " + xrtInfo.get<std::string>("branch", "N/A") + "\n"
                + "Build version hash: " + xrtInfo.get<std::string>("hash", "N/A") + "\n"


### PR DESCRIPTION
CR-1060525: Fixing "system singleton is not loaded" error when profiling is enabled in emulation flows.
The error occurred when profiling tried to call "get_xrt_info" before the system singleton was created.  Since the only information profiling required was static information about the XRT build, this pull request refactors out that portion to be independent of the system singleton and has profiling call the new get_xrt_build_info function instead.