### PR TITLE
Resolve the mismatch of the cu name between the host code and the metadata

### DIFF
--- a/tests/xrt/22_verify/testinfo.yml
+++ b/tests/xrt/22_verify/testinfo.yml
@@ -15,7 +15,7 @@ user:
   xclbins:
   - files: 'hello.xo '
     kernels:
-    - cus: [hello]
+    - cus: [hello_1]
       name: hello
       num_cus: 1
     name: verify.xclbin


### PR DESCRIPTION
Resolve the mismatch of the cu name between the host code and the metadata
Both the host code and metadata will use hello:hello_1