### PR TITLE
CR-1056667 support batching of asynch i/o on stream queues

### DIFF
--- a/src/runtime_src/core/include/xstream.h
+++ b/src/runtime_src/core/include/xstream.h
@@ -48,16 +48,11 @@ typedef uint32_t stream_xfer_req_type;
  * -  STREAM_OPT_AIO_BATCH_THRESH_PKTS,   io_batching threshold: # request
  *    Keep accumulating the i/o request, until the total # of r/w request
  *    reaches the threshold of "opt_value" of requests
- *
- * -  STREAM_OPT_AIO_BATCH_THRESH_TIMER,  io_batching threshold: # request
- *    Keep accumulating the i/o request, until the timer pops.
- *    The timer duration is "opt_value" milisecond.
  */
 typedef enum stream_opt_type {
     STREAM_OPT_AIO_MAX_EVENT = 1,       /* maximum # aio event */
     STREAM_OPT_AIO_BATCH_THRESH_BYTES,  /* io batching threshold: # bytes */
     STREAM_OPT_AIO_BATCH_THRESH_PKTS,   /* io_batching threshold: # request */
-    STREAM_OPT_AIO_BATCH_THRESH_TIMER,  /* io batching threshold: timer in ms */
 
     STREAM_OPT_MAX
 } stream_opt_type;


### PR DESCRIPTION
During stream performance testing, we found that syscall io_submit() is a bottleneck, this patch adds the support to allow accumulating then submitting multiple stream i/o in a single io_submit() call.

To enable asynchronous i/o batching, the host app needs to configure the batching threshold via clSetStreamOpt(). There are two thresholds, they can be used individually or combined:

1. timer - accumulating the request until the timer pops.
2. total buffer count: total # of buffers in all of the i/o requests

When either of the above condition is met, all of the accumulated i/o submitted to the kernel.