### PR TITLE
Add missing std vector header to fix xrt test 03_loopback host compilation issue

### DIFF
--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -18,6 +18,7 @@
 
 #include <getopt.h>
 #include <iostream>
+#include <vector>
 #include <stdexcept>
 #include <string>
 #include <cstring>


### PR DESCRIPTION
Add missing std vector header to fix xrt test 03_loopback host compilation issue