### PR TITLE
XRT-423 Get 2020.1 lenet work with XRT Graph API

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -29,6 +29,7 @@ namespace {
 namespace pt = boost::property_tree;
 using tile_type = xrt_core::edge::aie::tile_type;
 using rtp_type = xrt_core::edge::aie::rtp_type;
+using gmio_type = xrt_core::edge::aie::gmio_type;
 
 inline void
 throw_if_error(bool err, const char* msg)
@@ -122,6 +123,24 @@ get_rtp(const pt::ptree& aie_meta)
   return rtps;
 }
 
+std::vector<gmio_type>
+get_gmio(const pt::ptree& aie_meta)
+{
+  std::vector<gmio_type> gmios;
+
+  for (auto& gmio_node : aie_meta.get_child("aie_metadata.GMIOs")) {
+    gmio_type gmio;
+
+    gmio.id = gmio_node.second.get<std::string>("id");
+    gmio.name = gmio_node.second.get<std::string>("name");
+    gmio.type = gmio_node.second.get<uint16_t>("type");
+    gmio.shim_col = gmio_node.second.get<uint16_t>("shim_column");
+    gmio.burst_len = gmio_node.second.get<uint16_t>("burst_length_in_16byte");
+  }
+
+  return gmios;
+}
+
 } // namespace
 
 namespace xrt_core { namespace edge { namespace aie {
@@ -149,6 +168,19 @@ get_rtp(const xrt_core::device* device)
   read_aie_metadata(data.first, data.second, aie_meta);
   return ::get_rtp(aie_meta);
 }
+
+std::vector<gmio_type>
+get_gmios(const xrt_core::device* device)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return std::vector<gmio_type>();
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_gmio(aie_meta);
+}
+
 
 }}} // aie, edge, xrt_core
 

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -136,6 +136,8 @@ get_gmio(const pt::ptree& aie_meta)
     gmio.type = gmio_node.second.get<uint16_t>("type");
     gmio.shim_col = gmio_node.second.get<uint16_t>("shim_column");
     gmio.burst_len = gmio_node.second.get<uint16_t>("burst_length_in_16byte");
+
+    gmios.emplace_back(std::move(gmio));
   }
 
   return gmios;

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -70,12 +70,10 @@ struct rtp_type
   bool            require_lock;
 };
 
- 
 /**
- * get_rtp() - get rtp data for a port from xclbin AIE metadata
+ * get_rtp() - get rtp data from xclbin AIE metadata
  *
  * @device: device with loaded meta data
- * @port_name: name of port to get data from
  */
 std::vector<rtp_type>
 get_rtp(const xrt_core::device* device);
@@ -90,6 +88,14 @@ struct gmio_type
   uint16_t        channel_number;
   uint16_t        burst_len;
 };
+
+/**
+ * get_gmios() - get gmio data from xclbin AIE metadata
+ *
+ * @device: device with loaded meta data
+ */
+std::vector<gmio_type>
+get_gmios(const xrt_core::device* device);
 
 }}} // aie, edge, xrt_core
 

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -22,18 +22,13 @@
 #include <vector>
 #include <queue>
 
+#include "core/common/device.h"
 #include "core/edge/common/aie_parser.h"
 extern "C" {
 #include <xaiengine.h>
 }
 
 namespace zynqaie {
-
-#define BD_HIGH_ADDR_MASK               0xFF00000000L
-#define BD_LOW_ADDR_MASK                0xFFFFFFFF
-
-#define GET_BD_HIGH_ADDR(addr)          (((addr) & BD_HIGH_ADDR_MASK) >> 32)
-#define GET_BD_LOW_ADDR(addr)           ((addr) & BD_LOW_ADDR_MASK)
 
 struct BD {
     uint16_t bd_num;
@@ -58,7 +53,7 @@ public:
     using gmio_type = xrt_core::edge::aie::gmio_type;
 
     ~Aie();
-    Aie();
+    Aie(std::shared_ptr<xrt_core::device> device);
 
     std::vector<XAieGbl_Tile> tileArray;  // Tile Array
     std::vector<ShimDMA> shim_dma;   // shim DMA

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -32,6 +32,20 @@ extern "C"
 
 namespace zynqaie {
 
+static inline uint64_t
+get_bd_high_addr(uint64_t addr)
+{
+  constexpr uint64_t hi_mask = 0xFFFF00000000L;
+  return ((addr & hi_mask) >> 32);
+}
+
+static inline uint64_t
+get_bd_low_addr(uint64_t addr)
+{
+  constexpr uint32_t low_mask = 0xFFFFFFFFL;
+  return (addr & low_mask);
+}
+
 graph_type::
 graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t, const std::string& graph_name)
   : device(std::move(dev)), name(graph_name)
@@ -42,43 +56,32 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t, const std::strin
     auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
     aieArray = drv->getAieArray();
     if (!aieArray) {
-      aieArray = new Aie();
+      aieArray = new Aie(device);
       drv->setAieArray(aieArray);
     }
 
     /* Initialize graph tile metadata */
-    for (auto& tile : xrt_core::edge::aie::get_tiles(device.get(), name))
+    for (auto& tile : xrt_core::edge::aie::get_tiles(device.get(), name)) {
+      /*
+       * Since row 0 is shim row, according to Cardano, row data in
+       * xclbin is off-by-one. To talk to AIE driver, we need to add
+       * shim row back.
+       */ 
+      tile.row += 1;
+      tile.itr_mem_row += 1;
       tiles.emplace_back(std::move(tile));
+    }
 
     /* Initialize graph rtp metadata */
     for (auto &rtp : xrt_core::edge::aie::get_rtp(device.get()))
       rtps.emplace_back(std::move(rtp));
 
     state = graph_state::stop;
-
-    auto aie_inst = aieArray->getAieInst();
-    std::vector<XAie_LocType> locs(tiles.size());
-    for (auto& tile : tiles) {
-      XAie_LocType loc = {tile.row, tile.col};
-      locs.emplace_back(loc);
-    }
-
-    /* Register all AIE events */
-    XAieTile_EventRegisterNotification(aie_inst, locs.data(), locs.size(), XAIEGBL_MODULE_ALL, XAIETILE_EVENT_CORE_PERF_CNT0, event_cb, NULL);
 }
 
 graph_type::
 ~graph_type()
 {
-    auto aie_inst = aieArray->getAieInst();
-    std::vector<XAie_LocType> locs(tiles.size());
-    for (auto& tile : tiles) {
-      XAie_LocType loc = {tile.row, tile.col};
-      locs.emplace_back(loc);
-    }
-
-    XAieTile_EventUnregisterNotification(aie_inst, locs.data(), locs.size(), XAIEGBL_MODULE_ALL, XAIETILE_EVENTS_ALL);
-
     /* TODO move this to ZYNQShim destructor or use smart pointer */
     if (aieArray)
         delete aieArray;
@@ -376,8 +379,8 @@ sync_bo(unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size
 
   BD bd = dmap->dma_chan[chan].idle_bds.front();
   dmap->dma_chan[chan].idle_bds.pop();
-  bd.addr_high = GET_BD_HIGH_ADDR(paddr);
-  bd.addr_low = GET_BD_LOW_ADDR(paddr);
+  bd.addr_high = get_bd_high_addr(paddr);
+  bd.addr_low = get_bd_low_addr(paddr);
 
   XAieDma_ShimBdSetAddr(&(dmap->handle), bd.bd_num, bd.addr_high, bd.addr_low, size);
 
@@ -529,7 +532,7 @@ xrtGraphUpdateRTP(xrtGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 void
-xrtSyncBOAIE(xrtGraphHandle ghdl, unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xrtSyncBOAIE(xrtGraphHandle ghdl, unsigned int bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   auto graph = get_graph(ghdl);
   graph->sync_bo(bo, dmaID, dir, size, offset);
@@ -714,7 +717,7 @@ xrtGraphUpdateRTP(xrtGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 int
-xrtSyncBOAIE(xrtGraphHandle ghdl, unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xrtSyncBOAIE(xrtGraphHandle ghdl, unsigned int bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
     api::xrtSyncBOAIE(ghdl, bo, dmaID, dir, size, offset);

--- a/src/runtime_src/core/include/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/experimental/xrt_aie.h
@@ -164,6 +164,6 @@ xrtGraphUpdateRTP(xrtGraphHandle gh, const char *hierPathPort, const char *buffe
  * Note: Upon return, the synchronization is done or error out
  */
 int
-xrtSyncBOAIE(xrtGraphHandle gh, unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xrtSyncBOAIE(xrtGraphHandle gh, unsigned int bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 #endif


### PR DESCRIPTION
This PR addressed the following issues:
1) Fix a few bugs to make lenet work with native XRT Graph API
   a) AIE driver does not support unregister all errors and register/unregister all events
   b) tile.row should be added by one to include shim tile
2) Implement getting GMIO metadata from Xclbin
3) Address some comments from after last PR (https://github.com/Xilinx/XRT/pull/3103)