### PR TITLE
CR-1062290 : xrt::device dtor should not call xclClose

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -41,7 +41,6 @@ device(std::shared_ptr<operations> ops, unsigned int idx)
 device::
 ~device()
 {
-  close();
   for (auto& q : m_queue)
     q.stop();
   for (auto& t : m_workers)


### PR DESCRIPTION
The device open/close is managed by OCL context, the device is closed
when a context with the device is deleted.

This fixes a race that could happen when static global destruction
deletes the global platform, which in turn deletes all xrt::devices.
At the same time a separate worker thread may be in the process of
release a up a completed event.  The event dtor release a reference
count on a context, which when 0, is deleted.  Context deletion then
attempts to close the device which the platform dtor is in process of
closing.

This bug was a result of PR #3053, where open/close of device was moved
to OCL context.