### PR TITLE
clean up coverity warnings & remove debug printf

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -324,7 +324,6 @@ private:
     void stop_aio_worker(void)
     {
         if (qAioBatchEn) {
-            std::lock_guard<std::mutex> lk(reqLock);
             /* stop the worker thread */
             qExit = true;
             cv.notify_one();
@@ -344,7 +343,7 @@ private:
         /* to enable aio batching, the stream needs to have its own context
          * and any of the 
          */
-        if (qAioEn && (byteThresh || pktThresh)) {
+        if (qAioEn && (byteThresh || pktThresh) && !qAioBatchEn) {
             qExit = false;
             qWorker = std::thread(&queue_cb::queue_aio_worker, this);
             qAioBatchEn = true;
@@ -356,7 +355,7 @@ public:
         : qAioEn{false}, qAioBatchEn{false}, qExit{false},
           h2c{qinfo->write ? true : false}, qhndl{qinfo->handle},
           aio_max_evts{0}, byteThresh{0}, pktThresh{0}, byteCnt{0}, bufCnt{0},
-          cbSubmitCnt{0}, cbPollCnt{0}, cbErrCnt{0}
+          cbSubmitCnt{0}, cbPollCnt{0}, cbErrCnt{0}, cbErrCode{0}
     {
        memset(&qAioCtx, 0, sizeof(qAioCtx));
     }

--- a/src/runtime_src/xocl/api/xlnx/clSetStreamOpt.cpp
+++ b/src/runtime_src/xocl/api/xlnx/clSetStreamOpt.cpp
@@ -44,7 +44,6 @@ clSetStreamOpt(cl_stream           stream,
 	       cl_int*             errcode_ret)
 {
   validOrError(stream,type,val,errcode_ret);
-printf("%s: call xocl(stream 0x%p)->set_stream_opt(%d,%u).\n", __func__, stream, type, val);
   return xocl::xocl(stream)->set_stream_opt(type, val);
 }
 
@@ -58,7 +57,6 @@ clSetStreamOpt(cl_stream           stream,
 {
   try {
     PROFILE_LOG_FUNCTION_CALL;
-printf("%s: call xocl::clSetStreamOpt(0x%p,%d,%u, err).\n", __func__, stream, type, val);
     return xocl::clSetStreamOpt(stream,type,val,errcode_ret);
   }
   catch (const xrt::error& ex) {


### PR DESCRIPTION
added missing initializer and removed the lock for setting qExit as setting of it is only from clSetStreamOpt() or clReleaseStream(), assume no concurrency here.
Also removed the debug printf accidentally checked in.