### PR TITLE
xclbinutil: Added EoU support to better define xclbin types.

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -121,6 +121,7 @@ extern "C" {
         XCLBIN_TANDEM_STAGE2_WITH_PR,
         XCLBIN_HW_EMU,
         XCLBIN_SW_EMU,
+        XCLBIN_HW_EMU_PR,
         XCLBIN_MODE_MAX
     };
 

--- a/src/runtime_src/tools/xclbin/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbin/CMakeLists.txt
@@ -74,7 +74,8 @@ file(GLOB XCLBINUTIL_FILES
   "FDT*.cxx"
   "FormattedOutput.cxx"
   "ParameterSectionData.cxx"
-  "Section*.cxx"
+  "Section.cxx"     # Note: Due to linking dependency issue, this entry needs to be before the other sections
+  "Section*.cxx"  
   "XclBinClass.cxx"
   "XclBinSignature.cxx"
   "XclBinUtilities.cxx"

--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1290,10 +1290,37 @@ XclBin::dumpSections(ParameterSectionData &_PSD)
                                           _PSD.getFormatTypeAsStr().c_str(), sDumpFileName.c_str()).c_str() << std::endl;
 }
 
+std::string 
+XclBin::findKeyAndGetValue(const std::string & _searchDomain, 
+                           const std::string & _searchKey, 
+                           std::vector<std::string> _keyValues)
+{
+  std::string sDomain;
+  std::string sKey;
+  std::string sValue;
+
+  for (auto const & keyValue : _keyValues) {
+    getKeyValueComponents(keyValue, sDomain, sKey, sValue);
+    if ((_searchDomain == sDomain) &&
+        (_searchKey == sKey)) {
+      return sValue;
+    }
+  }
+  return std::string("");
+}
+
 
 void 
-XclBin::setKeyValue(const std::string & _keyValue)
+XclBin::getKeyValueComponents( const std::string & _keyValue, 
+                               std::string & _domain, 
+                               std::string & _key,
+                               std::string & _value)
 {
+  // Reset output arguments
+  _domain.clear();
+  _key.clear();
+  _value.clear();
+
   const std::string& delimiters = ":";      // Our delimiter
 
   // Working variables
@@ -1323,10 +1350,17 @@ XclBin::setKeyValue(const std::string & _keyValue)
   }
 
   boost::to_upper(tokens[0]);
-  std::string sDomain = tokens[0];
-  std::string sKey = tokens[1];
-  std::string sValue = tokens[2];
-  
+  _domain = tokens[0];
+  _key = tokens[1];
+  _value = tokens[2];
+}
+
+void 
+XclBin::setKeyValue(const std::string & _keyValue)
+{
+  std::string sDomain, sKey, sValue;
+  getKeyValueComponents(_keyValue, sDomain, sKey, sValue);
+
   XUtil::TRACE(XUtil::format("Setting key-value pair \"%s\":  domain:'%s', key:'%s', value:'%s'", 
                              _keyValue.c_str(), sDomain.c_str(), sKey.c_str(), sValue.c_str()));
 
@@ -1344,6 +1378,8 @@ XclBin::setKeyValue(const std::string & _keyValue)
         m_xclBinHeader.m_header.m_mode = XCLBIN_HW_EMU;
       } else if (sValue == "sw_emu") {
         m_xclBinHeader.m_header.m_mode = XCLBIN_SW_EMU;
+      } else if (sValue == "hw_emu_pr") {
+        m_xclBinHeader.m_header.m_mode = XCLBIN_HW_EMU_PR;
       } else {
         std::string errMsg = XUtil::format("ERROR: Unknown value '%s' for key '%s'. Key-value pair: '%s'.", sValue.c_str(), sKey.c_str(), _keyValue.c_str());
         throw std::runtime_error(errMsg);

--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -619,7 +619,7 @@ XclBin::removeSection(const Section* _pSection)
 
 Section *
 XclBin::findSection(enum axlf_section_kind _eKind, 
-                    const std::string _indexName)
+                    const std::string & _indexName) const
 {
   for (unsigned int index = 0; index < m_sections.size(); ++index) {
     if (m_sections[index]->getSectionKind() == _eKind) {

--- a/src/runtime_src/tools/xclbin/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbin/XclBinClass.cxx
@@ -1290,10 +1290,10 @@ XclBin::dumpSections(ParameterSectionData &_PSD)
                                           _PSD.getFormatTypeAsStr().c_str(), sDumpFileName.c_str()).c_str() << std::endl;
 }
 
-std::string 
+std::string
 XclBin::findKeyAndGetValue(const std::string & _searchDomain, 
                            const std::string & _searchKey, 
-                           std::vector<std::string> _keyValues)
+                           const std::vector<std::string> & _keyValues)
 {
   std::string sDomain;
   std::string sKey;

--- a/src/runtime_src/tools/xclbin/XclBinClass.h
+++ b/src/runtime_src/tools/xclbin/XclBinClass.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -54,6 +54,10 @@ class XclBin {
   void dumpSections(ParameterSectionData &_PSD);
   void setKeyValue(const std::string & _keyValue);
   void removeKey(const std::string & _keyValue);
+
+  public:
+    static void getKeyValueComponents(const std::string & _keyValue, std::string & _domain, std::string & _key,std::string & _value);
+    static std::string findKeyAndGetValue(const std::string & _searchDomain, const std::string & _searchKey, std::vector<std::string> _keyValues);
 
  public:
   Section *findSection(enum axlf_section_kind _eKind, const std::string _indexName = "");

--- a/src/runtime_src/tools/xclbin/XclBinClass.h
+++ b/src/runtime_src/tools/xclbin/XclBinClass.h
@@ -56,8 +56,9 @@ class XclBin {
   void removeKey(const std::string & _keyValue);
 
   public:
-    static void getKeyValueComponents(const std::string & _keyValue, std::string & _domain, std::string & _key,std::string & _value);
-    static std::string findKeyAndGetValue(const std::string & _searchDomain, const std::string & _searchKey, std::vector<std::string> _keyValues);
+    // Helper method to take given encoded keyValue and break it down to its individual values (e.g., domain, key, and value)
+    static void getKeyValueComponents(const std::string & _keyValue, std::string & _domain, std::string & _key, std::string & _value);
+    static std::string findKeyAndGetValue(const std::string & _searchDomain, const std::string & _searchKey, const std::vector<std::string> & _keyValues);
 
  public:
   Section *findSection(enum axlf_section_kind _eKind, const std::string _indexName = "");

--- a/src/runtime_src/tools/xclbin/XclBinClass.h
+++ b/src/runtime_src/tools/xclbin/XclBinClass.h
@@ -61,7 +61,7 @@ class XclBin {
     static std::string findKeyAndGetValue(const std::string & _searchDomain, const std::string & _searchKey, const std::vector<std::string> & _keyValues);
 
  public:
-  Section *findSection(enum axlf_section_kind _eKind, const std::string _indexName = "");
+  Section *findSection(enum axlf_section_kind _eKind, const std::string & _indexName = "") const;
 
  private:
   void updateHeaderFromSection(Section *_pSection);


### PR DESCRIPTION
A new option '--target' and key-value 'SYS:dfx_enable' was added to assist the clients of xclbinutil to better define the type of xclbin being created.

Syntax: --target hw|hw_emu|sw_emu [--key-value SYS:dfx_enable:true|false]

Work Done
---------
+ Added new '--target' option
+ Added new key-value 'SYS:dfx_enable' value
+ Updated new enum XCLBIN_MODE value: XCLBIN_HW_EMU_PR
+ Added DRC checks that check for correct 'target" and 'SYS:dfx_enable" combinations
+ Added pre-processing support to correctly set the m_mode value.
+ Compile bug fix: Updated CMakeList.txt file to always build Section.cxx prior to previous sections.  Failure to do so causes a runtime exception.