### PR TITLE
CR-1034331 xbutil dmatest crashes if not enough system memory available

### DIFF
--- a/src/runtime_src/core/pcie/common/memaccess.h
+++ b/src/runtime_src/core/pcie/common/memaccess.h
@@ -216,11 +216,13 @@ namespace xcldev {
             result = readCompare(itr.m_base_address, itr.m_size, aPattern, false);
             if(result < 0)
                 return result;
-            DMARunner runner(mHandle, blocksize, 1 << itr.m_index);
-            result = runner.run();
-            if( result < 0 )
-                return result;
-
+            try {
+                DMARunner runner(mHandle, blocksize, 1 << itr.m_index);
+                result = runner.run();
+            } catch (const xrt_core::error &ex) {
+                std::cout << "ERROR: " << ex.what() << std::endl;
+                return ex.get();
+            }
         }
 
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -119,7 +119,7 @@ static void print_pci_info(std::ostream &ostr)
     }
 }
 
-static int xrt_xbutil_version_cmp() 
+static int xrt_xbutil_version_cmp()
 {
     /*check xbutil tools and xrt versions*/
     std::string xrt = "";
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
             }
 
             if (blockSize > 0x100000) {
-                std::cout << "ERROR: block size cannot be greater than 0x100000 MB\n";
+                std::cout << "ERROR: block size cannot be greater than 0x100000 KB\n";
                 return -1;
             }
             blockSize *= 1024; // convert kilo bytes to bytes
@@ -1261,7 +1261,7 @@ int xcldev::device::pcieLinkTest(void)
     return 0;
 }
 
-int xcldev::device::auxConnectionTest(void) 
+int xcldev::device::auxConnectionTest(void)
 {
     std::string name, errmsg;
     unsigned short max_power = 0;
@@ -1715,7 +1715,7 @@ int xcldev::device::testP2p()
         //p2p is not supported for DDR on u280
         if(vbnv.find("_u280_") == std::string::npos)
             supList.push_back("DDR");
-        
+
         const std::string name(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag));
         bool find = false;
         for (auto s : supList) {
@@ -1889,7 +1889,7 @@ int xcldev::xclCma(int argc, char *argv[])
 
     /* At this moment, we have two way to collect CMA memory chunk
      * 1. Call Kernel API
-     * 2. Huge Page MMAP 
+     * 2. Huge Page MMAP
      */
     ret = d->setCma(cma_enable, total_size);
     if (ret == -ENOMEM) {
@@ -2012,7 +2012,7 @@ int xcldev::device::testM2m()
 
     dev->sysfs_get<int>("mb_scheduler", "kds_numcdmas", errmsg, m2m_enabled, 0);
     // Workaround:
-    // u250_xdma_201830_1 falsely shows that m2m is available 
+    // u250_xdma_201830_1 falsely shows that m2m is available
     // which causes a hang. Skip m2mtest if this platform is installed
     dev->sysfs_get( "rom", "VBNV", errmsg, vbnv );
     if (m2m_enabled == 0 || strstr( vbnv.c_str(), "_u250_xdma_201830_1")) {
@@ -2065,8 +2065,8 @@ struct exec_struct {
     unsigned int exec_size;
 };
 
-static int 
-get_first_used_mem(unsigned int idx) 
+static int
+get_first_used_mem(unsigned int idx)
 {
     std::string errmsg;
     std::vector<char> buf;
@@ -2075,7 +2075,7 @@ get_first_used_mem(unsigned int idx)
 
     if (dev == nullptr)
         return -EINVAL;
-    
+
     dev->sysfs_get("icap", "mem_topology", errmsg, buf);
 
     const mem_topology *map = (mem_topology *)buf.data();
@@ -2094,7 +2094,7 @@ get_first_used_mem(unsigned int idx)
     return first_used_mem;
 }
 
-static void 
+static void
 iops_free_unmap_bo(xclDeviceHandle handle, unsigned boh,
     void * boptr, size_t boSize)
 {
@@ -2104,7 +2104,7 @@ iops_free_unmap_bo(xclDeviceHandle handle, unsigned boh,
         xclFreeBO(handle, boh);
 }
 
-static void 
+static void
 iops_alloc_init_bo(xclDeviceHandle handle, int bank, exec_struct* info)
 {
     info->out_size = 20;
@@ -2151,7 +2151,7 @@ iops_alloc_init_bo(xclDeviceHandle handle, int bank, exec_struct* info)
 }
 
 static void
-execute_cmds(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& cmds, 
+execute_cmds(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& cmds,
     unsigned int num_execs, double& duration)
 {
     unsigned int num_issued = 0;
@@ -2187,7 +2187,7 @@ execute_cmds(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& 
 }
 
 static void
-run_iops_test(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& cmds, 
+run_iops_test(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& cmds,
     std::vector<double>& iops_list, int first_used_mem, unsigned int cmd_per_batch, unsigned int num_execs)
 {
     double duration = 0;
@@ -2209,27 +2209,27 @@ run_iops_test(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>&
             throw std::runtime_error("Bad output result after CU execution");
     }
     iops_list.push_back(num_execs * 1000 * 1000 / duration);
-    // std::cout << "Combos: b: " << b << " t: " << t << " iops: " << (t * 1000 * 1000 / duration) << std::endl;  
+    // std::cout << "Combos: b: " << b << " t: " << t << " iops: " << (t * 1000 * 1000 / duration) << std::endl;
 }
 
-int 
+int
 xcldev::device::iopsTest()
 {
 
     xclbin_lock xclbin_lock(m_handle, m_idx);
     int first_used_mem = get_first_used_mem(m_idx);
-    
+
     if(first_used_mem == -1)
         return -EINVAL;
 
     std::vector<std::shared_ptr<exec_struct>> cmds;
     std::vector<unsigned int> cmd_per_batch = { 8,16,32,64,128,256,1024,2048 }; //b
     std::vector<unsigned int> num_execs = { 8,16,32,64,128,256,1024,2048 }; //t
-    std::vector<double> iops_list; 
-    
+    std::vector<double> iops_list;
+
     if(xclOpenContext(m_handle, xclbin_lock.m_uuid, 0, true))
             throw std::runtime_error("Cannot create context");
-    
+
     //run different combinations
     for(const auto& b : cmd_per_batch) {
         for(const auto& t : num_execs) {
@@ -2239,7 +2239,7 @@ xcldev::device::iopsTest()
     }
 
     std::cout << "\nIOPS: " << static_cast<int>(*max_element(iops_list.begin(), iops_list.end())) << std::endl;
-    
+
     // release all BOs
     for(auto& c : cmds) {
         iops_free_unmap_bo(m_handle, c->out_bo_handle, c->output_bo_ptr, c->out_size);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -88,7 +88,7 @@ enum command {
     DD,
     STATUS,
     CMD_MAX,
-    M2MTEST, 
+    M2MTEST,
     VERSION
 };
 enum subcommand {
@@ -356,7 +356,7 @@ public:
         std::vector<std::string> custat;
         std::string errmsg;
         pcidev::get_dev(m_idx)->sysfs_get("mb_scheduler", "kds_custat", errmsg, custat);
-          
+
         for (unsigned int i = 0; i < computeUnits.size(); ++i) {
             const auto& ip = computeUnits[i];
             if (ip.m_type != IP_KERNEL)
@@ -386,7 +386,7 @@ public:
     }
 
     void sysfs_stringize_power(std::vector<std::string> &lines) const
-    { 
+    {
         std::stringstream ss;
         ss << std::left << "\n";
         ss << std::setw(16) << "Power" << "\n";
@@ -435,7 +435,7 @@ public:
               std::string str = std::to_string(percentage).substr(0, 4) + "%";
 
               ss << " [" << index << "] "
-                 << std::setw(16 - (std::to_string(index).length()) - 4) 
+                 << std::setw(16 - (std::to_string(index).length()) - 4)
                  << std::left << tag
                  << "[ " << std::right << std::setw(nums_fiftieth)
                  << std::setfill('|') << (nums_fiftieth ? " ":"")
@@ -582,7 +582,7 @@ public:
             sensor_tree::add_child( std::string("board.memory.mem." + std::to_string(m)), ptMem );
             m++;
         }
- 
+
         boost::property_tree::ptree ptMem;
 
         std::string str = "MEM_HOST";
@@ -726,7 +726,7 @@ public:
         std::vector<std::string> dma_threads;
         std::vector<std::string> mac_addrs;
         bool mig_calibration;
-        
+
         clock_freqs.resize(3);
         mac_addrs.resize(4);
         pcidev::get_dev(m_idx)->sysfs_get( "", "vendor",                     errmsg, vendor );
@@ -744,8 +744,8 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "mac_addr3",               errmsg, mac_addrs[3] );
         pcidev::get_dev(m_idx)->sysfs_get<int>("rom", "ddr_bank_size",       errmsg, ddr_size,  0 );
         pcidev::get_dev(m_idx)->sysfs_get<int>( "rom", "ddr_bank_count_max", errmsg, ddr_count, 0 );
-        pcidev::get_dev(m_idx)->sysfs_get( "icap", "clock_freqs",            errmsg, clock_freqs ); 
-        pcidev::get_dev(m_idx)->sysfs_get( "dma", "channel_stat_raw",        errmsg, dma_threads ); 
+        pcidev::get_dev(m_idx)->sysfs_get( "icap", "clock_freqs",            errmsg, clock_freqs );
+        pcidev::get_dev(m_idx)->sysfs_get( "dma", "channel_stat_raw",        errmsg, dma_threads );
         pcidev::get_dev(m_idx)->sysfs_get<int>( "", "link_speed",            errmsg, pcie_speed, 0 );
         pcidev::get_dev(m_idx)->sysfs_get<int>( "", "link_width",            errmsg, pcie_width, 0 );
         pcidev::get_dev(m_idx)->sysfs_get<bool>( "", "mig_calibration",      errmsg, mig_calibration, false );
@@ -811,7 +811,7 @@ public:
         // physical.thermal
         unsigned int fan_rpm, xmc_fpga_temp, xmc_fan_temp, vccint_temp, xmc_hbm_temp;
         std::string fan_presence;
-        
+
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_fpga_temp", xmc_fpga_temp );
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_fan_temp",  xmc_fan_temp );
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "fan_presence",         errmsg, fan_presence );
@@ -837,8 +837,8 @@ public:
         sensor_tree::put( "board.physical.thermal.cage.temp3", temp3);
 
         //electrical
-        unsigned int m3v3_pex_vol, m3v3_aux_vol, ddr_vpp_btm, ddr_vpp_top, sys_5v5, m1v2_top, m1v2_btm, m1v8, 
-                     m0v85, mgt0v9avcc, m12v_sw, mgtavtt, vccint_vol, vccint_curr, m3v3_pex_curr, m0v85_curr, m3v3_vcc_vol, 
+        unsigned int m3v3_pex_vol, m3v3_aux_vol, ddr_vpp_btm, ddr_vpp_top, sys_5v5, m1v2_top, m1v2_btm, m1v8,
+                     m0v85, mgt0v9avcc, m12v_sw, mgtavtt, vccint_vol, vccint_curr, m3v3_pex_curr, m0v85_curr, m3v3_vcc_vol,
                      hbm_1v2_vol, vpp2v5_vol, vccint_bram_vol, m12v_pex_vol, m12v_aux_curr, m12v_pex_curr, m12v_aux_vol,
                      vol_12v_aux1, vol_vcc1v2_i, vol_v12_in_i, vol_v12_in_aux0_i, vol_v12_in_aux1_i, vol_vccaux,
                      vol_vccaux_pmc, vol_vccram;
@@ -847,7 +847,7 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_12v_aux_vol",    m12v_aux_vol);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_12v_aux_curr",   m12v_aux_curr);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_3v3_pex_vol",    m3v3_pex_vol);
-        pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_3v3_aux_vol",    m3v3_aux_vol); 
+        pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_3v3_aux_vol",    m3v3_aux_vol);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_ddr_vpp_btm",    ddr_vpp_btm);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_ddr_vpp_top",    ddr_vpp_top);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_sys_5v5",        sys_5v5);
@@ -908,19 +908,19 @@ public:
         sensor_tree::put( "board.physical.electrical.vccram.current",          vol_vccram);
 
         // physical.power
-        sensor_tree::put( "board.physical.power", static_cast<unsigned>(sysfs_power())); 
+        sensor_tree::put( "board.physical.power", static_cast<unsigned>(sysfs_power()));
 
         // firewall
         unsigned int level = 0, status = 0;
         unsigned long long time = 0;
         pcidev::get_dev(m_idx)->sysfs_get<unsigned int>( "firewall", "detected_level",      errmsg, level, 0 );
-        pcidev::get_dev(m_idx)->sysfs_get<unsigned int>( "firewall", "detected_status",     errmsg, status, 0 ); 
-        pcidev::get_dev(m_idx)->sysfs_get<unsigned long long>( "firewall", "detected_time", errmsg, time, 0 ); 
+        pcidev::get_dev(m_idx)->sysfs_get<unsigned int>( "firewall", "detected_status",     errmsg, status, 0 );
+        pcidev::get_dev(m_idx)->sysfs_get<unsigned long long>( "firewall", "detected_time", errmsg, time, 0 );
         sensor_tree::put( "board.error.firewall.firewall_level", level );
         sensor_tree::put( "board.error.firewall.firewall_status", status );
         sensor_tree::put( "board.error.firewall.firewall_time", time );
         sensor_tree::put( "board.error.firewall.status", xrt_core::utils::parse_firewall_status(status) );
-        
+
         // memory
         xclDeviceUsage devstat = { 0 };
         (void) xclGetUsageInfo(m_handle, &devstat);
@@ -930,7 +930,7 @@ public:
             pt_dma.put( "c2h", xrt_core::utils::unit_convert(devstat.c2h[i]) );
             sensor_tree::add_child( std::string("board.pcie_dma.transfer_metrics.chan." + std::to_string(i)), pt_dma );
         }
-        
+
         getMemTopology( devstat );
 
         // xclbin
@@ -979,7 +979,7 @@ public:
             ostr << ": " << pt.data() << std::endl;
         } else {
             if (level > 0)
-                ostr << std::endl; 
+                ostr << std::endl;
             for (auto pos = pt.begin(); pos != pt.end();) {
                 std::cout << indent(level+1) << pos->first;
                 printTree(ostr, pos->second, level + 1);
@@ -1026,14 +1026,14 @@ public:
         ostr << std::setw(32) << sensor_tree::get<std::string>( "board.info.dsa_name",  "N/A" )
              << std::setw(32) << sensor_tree::get<std::string>( "board.info.fpga_name", "N/A" )
              << sensor_tree::get<std::string>( "board.info.idcode",    "N/A" ) << std::endl;
-        ostr << std::setw(16) << "Vendor" << std::setw(16) << "Device" << std::setw(16) << "SubDevice" 
+        ostr << std::setw(16) << "Vendor" << std::setw(16) << "Device" << std::setw(16) << "SubDevice"
              << std::setw(16) << "SubVendor" << std::setw(16) << "SerNum" << std::endl;
         ostr << std::setw(16) << sensor_tree::get<std::string>( "board.info.vendor",    "N/A" )
              << std::setw(16) << sensor_tree::get<std::string>( "board.info.device",    "N/A" )
              << std::setw(16) << sensor_tree::get<std::string>( "board.info.subdevice", "N/A" )
-             << std::setw(16) << sensor_tree::get<std::string>( "board.info.subvendor", "N/A" ) 
+             << std::setw(16) << sensor_tree::get<std::string>( "board.info.subvendor", "N/A" )
              << std::setw(16) << sensor_tree::get<std::string>( "board.info.serial_number", "N/A" ) << std::endl;
-        ostr << std::setw(16) << "DDR size" << std::setw(16) << "DDR count" << std::setw(16) 
+        ostr << std::setw(16) << "DDR size" << std::setw(16) << "DDR count" << std::setw(16)
              << "Clock0" << std::setw(16) << "Clock1" << std::setw(16) << "Clock2" << std::endl;
         ostr << std::setw(16) << xrt_core::utils::unit_convert(sensor_tree::get<long long>( "board.info.ddr_size", -1 ))
              << std::setw(16) << sensor_tree::get( "board.info.ddr_count", -1 )
@@ -1045,7 +1045,7 @@ public:
              << std::setw(16) << "MIG Calibrated"
              << std::setw(16) << "P2P Enabled"
 	     << std::setw(16) << "OEM ID" << std::endl;
-        ostr << "GEN " << sensor_tree::get( "board.info.pcie_speed", -1 ) << "x" << std::setw(10) 
+        ostr << "GEN " << sensor_tree::get( "board.info.pcie_speed", -1 ) << "x" << std::setw(10)
              << sensor_tree::get( "board.info.pcie_width", -1 ) << std::setw(16) << sensor_tree::get( "board.info.dma_threads", -1 )
              << std::setw(16) << sensor_tree::get<std::string>( "board.info.mig_calibrated", "N/A" );
              switch(sensor_tree::get( "board.info.p2p_enabled", -1)) {
@@ -1099,13 +1099,13 @@ public:
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.pcb.top_rear"  )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.pcb.btm_front" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.vccint_temp" ) << std::endl;
-        ostr << std::setw(16) << "FPGA TEMP" << std::setw(16) << "TCRIT Temp" << std::setw(16) << "FAN Presence" 
+        ostr << std::setw(16) << "FPGA TEMP" << std::setw(16) << "TCRIT Temp" << std::setw(16) << "FAN Presence"
              << std::setw(16) << "FAN Speed(RPM)" << std::endl;
-        ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.fpga_temp") 
+        ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.fpga_temp")
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.tcrit_temp")
              << std::setw(16) << sensor_tree::get<std::string>( "board.physical.thermal.fan_presence")
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.fan_speed" ) << std::endl;
-        ostr << std::setw(16) << "QSFP 0" << std::setw(16) << "QSFP 1" << std::setw(16) << "QSFP 2" << std::setw(16) << "QSFP 3" 
+        ostr << std::setw(16) << "QSFP 0" << std::setw(16) << "QSFP 1" << std::setw(16) << "QSFP 2" << std::setw(16) << "QSFP 3"
              << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp0" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.cage.temp1" )
@@ -1115,25 +1115,25 @@ public:
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.thermal.hbm_temp") << std::endl;
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
         ostr << "Electrical(mV|mA)\n";
-        ostr << std::setw(16) << "12V PEX" << std::setw(16) << "12V AUX" << std::setw(16) << "12V PEX Current" << std::setw(16) 
+        ostr << std::setw(16) << "12V PEX" << std::setw(16) << "12V AUX" << std::setw(16) << "12V PEX Current" << std::setw(16)
              << "12V AUX Current" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.12v_pex.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.12v_aux.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.12v_pex.current" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.12v_aux.current" ) << std::endl;
-        ostr << std::setw(16) << "3V3 PEX" << std::setw(16) << "3V3 AUX" << std::setw(16) << "DDR VPP BOTTOM" << std::setw(16) 
+        ostr << std::setw(16) << "3V3 PEX" << std::setw(16) << "3V3 AUX" << std::setw(16) << "DDR VPP BOTTOM" << std::setw(16)
              << "DDR VPP TOP" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.3v3_pex.voltage"        )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.3v3_aux.voltage"        )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.ddr_vpp_bottom.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.ddr_vpp_top.voltage"    ) << std::endl;
-        ostr << std::setw(16) << "SYS 5V5" << std::setw(16) << "1V2 TOP" << std::setw(16) << "1V8 TOP" << std::setw(16) 
+        ostr << std::setw(16) << "SYS 5V5" << std::setw(16) << "1V2 TOP" << std::setw(16) << "1V8 TOP" << std::setw(16)
              << "0V85" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.sys_5v5.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.1v2_top.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.1v8.voltage"     )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.0v85.voltage"    ) << std::endl;
-        ostr << std::setw(16) << "MGT 0V9" << std::setw(16) << "12V SW" << std::setw(16) << "MGT VTT" 
+        ostr << std::setw(16) << "MGT 0V9" << std::setw(16) << "12V SW" << std::setw(16) << "MGT VTT"
              << std::setw(16) << "1V2 BTM" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.mgt_0v9.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.12v_sw.voltage"  )
@@ -1466,7 +1466,7 @@ public:
 
         if (blockSize == 0)
             blockSize = 256 * 1024 * 1024; // Default block size
-        
+
         int ddr_mem_size = get_ddr_mem_size();
         if (ddr_mem_size == -EINVAL)
             return -EINVAL;
@@ -1495,7 +1495,7 @@ public:
                 std::cout << "Total HBM size: " << hbm_mem_size << "\n";
             if (ddr_mem_size != 0)
                 std::cout << "Total DDR size: " << ddr_mem_size << " MB\n";
-            
+
             if (blockSize < (1024*1024))
                 std::cout << "Buffer Size: " << blockSize/(1024) << " KB\n";
             else
@@ -1532,8 +1532,13 @@ public:
                     if( result < 0 )
                         return result;
                 }
-                DMARunner runner( m_handle, blockSize, i);
-                result = runner.run();
+                try {
+                    DMARunner runner( m_handle, blockSize, i);
+                    result = runner.run();
+                } catch (const xrt_core::error &ex) {
+                    std::cout << "ERROR: " << ex.what() << std::endl;
+                    return ex.get();
+                }
             }
         }
 

--- a/src/runtime_src/core/pcie/user_aws/awssak.h
+++ b/src/runtime_src/core/pcie/user_aws/awssak.h
@@ -238,7 +238,7 @@ public:
             if (!((buf[0] == 0x0) || (buf[0] == 0x4) || (buf[0] == 0x6))) {
                 return -EBUSY;
             }
-        }        
+        }
         return 0;
     }
 
@@ -298,8 +298,8 @@ public:
         if (!buf.empty())
              ostr << "\nXclbin ID:  0x" << buf << "\n";
         else
-            ostr << "WARNING: 'xclbinuuid' invalid, unable to report xclbinuuid. Has the bitstream been loaded? See 'awssak program'.\n"; 
- 
+            ostr << "WARNING: 'xclbinuuid' invalid, unable to report xclbinuuid. Has the bitstream been loaded? See 'awssak program'.\n";
+
         std::vector<char> mem_topo;
         xcldev::sysfs_get(dev_name, "icap", "mem_topology", errmsg, mem_topo);
 
@@ -502,8 +502,13 @@ public:
                                 break;
                         }
                         if( result >= 0 ) {
-                            DMARunner runner( m_handle, blockSize, i );
-                            result = runner.run();
+                            try {
+                                DMARunner runner( m_handle, blockSize, i );
+                                result = runner.run();
+                            } catch (const xrt_core::error &ex) {
+                                std::cout << "ERROR: " << ex.what() << std::endl;
+                                result = ex.get();
+                            }
                         }
 
                         if( result < 0 ) {
@@ -531,10 +536,13 @@ public:
                         return result;
                 }
 
-                DMARunner runner( m_handle, blockSize );//, xcl_bank[i] );
-                result = runner.run();
-                if( result < 0 )
-                    return result;
+                try {
+                    DMARunner runner( m_handle, blockSize );//, xcl_bank[i] );
+                    result = runner.run();
+                } catch (const xrt_core::error &ex) {
+                    std::cout << "ERROR: " << ex.what() << std::endl;
+                    return ex.get();
+                }
             }
         }
 

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -149,7 +149,7 @@ def initXRT(opt):
                 continue
             opt.cu_base_addr = ip[i].ip_u1.m_base_address
             opt.kernels.append(ctypes.cast(ip[i].m_name, ctypes.c_char_p).value)
-            print("CU[%d] %s @0x%x" % (i, opt.kernels[len(opt.kernels)-1], opt.cu_base_addr))
+            print("CU[%d] %s @0x%x" % (i, opt.kernels[-1], opt.cu_base_addr))
 
         head = wrap_get_axlf_section(blob, AXLF_SECTION_KIND.MEM_TOPOLOGY)
         topo = mem_topology.from_buffer(data, head.contents.m_sectionOffset)


### PR DESCRIPTION
* Use xclAllocUserPtrBO() to allocate buffers for dmatest which is more robust than xclAllocBO()
* DMARunner now throws exceptions which are supposed to be caught by the callers