### PR TITLE
factory_reset --force should perform reset without checking

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -248,7 +248,7 @@ static int resetShell(unsigned index, bool force)
 
     std::cout << "CAUTION: Resetting Card [" << flasher.sGetDBDF() <<
         "] back to factory mode." << std::endl;
-    if(force || !canProceed())
+    if(!force && !canProceed())
         return -ECANCELED;
 
     return flasher.upgradeFirmware("", nullptr, nullptr, nullptr);


### PR DESCRIPTION
factory_reset --force actually returns -ECANCELED without resetting the shell to golden.
we expect:

root@xsjyliu50:/scratch/davidz# ./xbmgmt flash --factory_reset --card 0000:3b:00.0
CAUTION: Resetting Card [0000:3b:00.0] back to factory mode.
Are you sure you wish to proceed? [y/n]: ^C

root@xsjyliu50:/scratch/davidz# ./xbmgmt flash --factory_reset --card 0000:3b:00.0 --force
CAUTION: Resetting Card [0000:3b:00.0] back to factory mode.
Bitstream guard installed on flash @0x1002000
Shell is reset successfully
Cold reboot machine to load new shell on card

root@xsjyliu50:/scratch/davidz# ./xbmgmt flash --factory_reset --card 0000:3b:00.0
CAUTION: Resetting Card [0000:3b:00.0] back to factory mode.
Are you sure you wish to proceed? [y/n]: y
Bitstream guard installed on flash @0x1002000
Shell is reset successfully
Cold reboot machine to load new shell on card
