### PR TITLE
CR-1062847 ignore fifo_full base address while claim resource

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -631,22 +631,12 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
-#define	XOCL_RES_TRACE_FIFO_FULL			\
-	((struct resource []) {				\
-		{					\
-			.name   = "TRACE_FIFO_FULL",	\
-			.start	= 0x0,			\
-			.end	= 0xFFF,		\
-			.flags  = IORESOURCE_MEM,	\
-		},					\
-	})
-
 #define	XOCL_DEVINFO_TRACE_FIFO_FULL				\
 	{						\
 		XOCL_SUBDEV_TRACE_FIFO_FULL,			\
 		XOCL_TRACE_FIFO_FULL,				\
-		XOCL_RES_TRACE_FIFO_FULL,			\
-		ARRAY_SIZE(XOCL_RES_TRACE_FIFO_FULL),		\
+		NULL,			\
+		0,		\
 		.level = XOCL_SUBDEV_LEVEL_URP,		\
 		.multi_inst = true,			\
 		.override_idx = -1,			\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1710,8 +1710,6 @@ static int icap_create_subdev_debugip(struct platform_device *pdev)
 		} else if (ip->m_type == AXI_MONITOR_FIFO_FULL) {
 			struct xocl_subdev_info subdev_info = XOCL_DEVINFO_TRACE_FIFO_FULL;
 
-			subdev_info.res[0].start += ip->m_base_address;
-			subdev_info.res[0].end += ip->m_base_address;
 			err = xocl_subdev_create(xdev, &subdev_info);
 			if (err) {
 				ICAP_ERR(icap, "can't create AXI_MONITOR_FIFO_FULL subdev");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/trace_fifo_full.c
@@ -19,8 +19,6 @@
 
 struct trace_fifo_full {
 	struct device		*dev;
-	uint64_t		start_paddr;
-	uint64_t		range;
 	struct mutex 		lock;
 };
 
@@ -47,8 +45,6 @@ static int trace_fifo_full_remove(struct platform_device *pdev)
 static int trace_fifo_full_probe(struct platform_device *pdev)
 {
 	struct trace_fifo_full *trace_fifo_full;
-	struct resource *res;
-	int err = 0;
 
 	trace_fifo_full = xocl_drvinst_alloc(&pdev->dev, sizeof(struct trace_fifo_full));
 	if (!trace_fifo_full)
@@ -59,24 +55,6 @@ static int trace_fifo_full_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, trace_fifo_full);
 	mutex_init(&trace_fifo_full->lock);
 
-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	if (!res) {
-		err = -ENOMEM;
-		goto done;
-	}
-		
-
-	xocl_info(&pdev->dev, "IO start: 0x%llx, end: 0x%llx",
-		res->start, res->end);
-
-	trace_fifo_full->start_paddr = res->start;
-	trace_fifo_full->range = res->end - res->start + 1;
-
-done:
-	if (err) {
-		trace_fifo_full_remove(pdev);
-		return err;
-	}
 	return 0;
 }
 


### PR DESCRIPTION
The TRACE_FIFO_FULL ip_m_address in debug_ip_layout is one of the exception which does not map to PCI BAR.