### PR TITLE
CR-1062783 Emulation processes are not closed

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -34,11 +34,10 @@
 namespace {
 
 static bool
-is_hw_emulation()
+is_emulation()
 {
-  static auto xem = std::getenv("XCL_EMULATION_MODE");
-  static bool hwem = xem ? (std::strcmp(xem,"hw_emu")==0) : false;
-  return hwem;
+  static bool val = (std::getenv("XCL_EMULATION_MODE") != nullptr);
+  return val;
 }
 
 }
@@ -54,7 +53,7 @@ device(std::shared_ptr<operations> ops, unsigned int idx)
 device::
 ~device()
 {
-  if (is_hw_emulation())
+  if (is_emulation())
     // xsim will not shutdown unless there is a guaranteed call to xclClose
     close();  
   

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -25,10 +25,23 @@
 #include <iostream>
 #include <cerrno>
 #include <regex>
+#include <cstdlib>
 
 #ifdef _WIN32
 # pragma warning( disable : 4267 4996 4244 4245 )
 #endif
+
+namespace {
+
+static bool
+is_hw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool hwem = xem ? (std::strcmp(xem,"hw_emu")==0) : false;
+  return hwem;
+}
+
+}
 
 namespace xrt { namespace hal2 {
 
@@ -41,10 +54,25 @@ device(std::shared_ptr<operations> ops, unsigned int idx)
 device::
 ~device()
 {
+  if (is_hw_emulation())
+    // xsim will not shutdown unless there is a guaranteed call to xclClose
+    close();  
+  
   for (auto& q : m_queue)
     q.stop();
   for (auto& t : m_workers)
     t.join();
+}
+
+void
+device::
+close()
+{
+  std::lock_guard<std::mutex> lk(m_mutex);
+  if (m_handle) {
+    m_ops->mClose(m_handle);
+    m_handle=nullptr;
+  }
 }
 
 std::ostream&
@@ -80,6 +108,7 @@ void
 device::
 setup()
 {
+  std::lock_guard<std::mutex> lk(m_mutex);
   if (!m_workers.empty())
     return;
 
@@ -576,6 +605,7 @@ void
 device::
 emplaceSVMBufferObjectMap(const BufferObjectHandle& boh, void* ptr)
 {
+  std::lock_guard<std::mutex> lk(m_mutex);
   auto itr = m_svmbomap.find(ptr);
   if (itr == m_svmbomap.end())
     m_svmbomap[ptr] = boh;
@@ -585,6 +615,7 @@ void
 device::
 eraseSVMBufferObjectMap(void* ptr)
 {
+  std::lock_guard<std::mutex> lk(m_mutex);
   auto itr = m_svmbomap.find(ptr);
   if (itr != m_svmbomap.end())
     m_svmbomap.erase(itr);
@@ -594,6 +625,7 @@ BufferObjectHandle
 device::
 svm_bo_lookup(void* ptr)
 {
+  std::lock_guard<std::mutex> lk(m_mutex);
   auto itr = m_svmbomap.find(ptr);
   if (itr != m_svmbomap.end())
     return (*itr).second;

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -30,6 +30,7 @@
 #include <memory>
 #include <map>
 #include <array>
+#include <mutex>
 
 namespace xrt { namespace hal2 {
 
@@ -68,6 +69,8 @@ class device : public xrt::hal::device
 
   hal2::device_handle m_handle;
   hal2::device_info m_devinfo;
+
+  std::mutex m_mutex;
 
   struct BufferObject : hal::buffer_object
   {
@@ -195,13 +198,7 @@ public:
   }
 
   virtual void
-  close()
-  {
-    if (m_handle) {
-      m_ops->mClose(m_handle);
-      m_handle=nullptr;
-    }
-  }
+  close();
 
   virtual hal::device_handle
   get_handle() const


### PR DESCRIPTION
Pull request #3225 for OpenCL, removed static close of devices from
platform destructor.  This was done because the platform no longer
itself opens devices found in the system.  In OpenCL only cl_context
opens devices and the context destructor closes the devices.
Unfortunately this relies on the host code properly disposing of
OpenCL objects holding on a cl_context objects, and we have lots and
lots of host code that does not do this.

For HW runs this is not a problem because the OS itself takes care of
cleaning up remaining resources, but in emulation xclClose() must be
called in order for the underlying xsim process to exit.

The pull request adds back the missign xclClose() for the HW emulation
flow only. It might be better if HW emulation could manage the xsim
processes without relying xclClose().