### PR TITLE
CR-1062492 subdevice test cases crash intermittently on sprite

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -527,6 +527,10 @@ lock()
   if (m_locks)
     return ++m_locks;
 
+  // sub-device should lock parent as well
+  if (m_parent.get())
+    m_parent->lock();
+
   // Open the underlying device if not sub device
   if (!m_parent.get())
     m_xdevice->open();
@@ -557,6 +561,10 @@ unlock()
     if (rv.valid() && rv.get())
       throw  xocl::error(CL_DEVICE_NOT_AVAILABLE,"could not unlock device");
   }
+
+  // sub-device should unlock the parent
+  if (m_parent.get())
+    m_parent->unlock();
 
   // Close the underlying device
   if (!m_parent.get())


### PR DESCRIPTION
More fallout from #3053

Ensure that sub-devices lock parent device as well as sub-device.  The
parent devices will close the device when lock count becomes 0.
Sub-device, while different OCL cl_device object, share same
underlying device with parent, so parent should only close device
after sub-devices are disposed of.