### PR TITLE
CR-1052598 XRT - Health thread - Check PCIe Link Status Monitor and r…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -438,6 +438,39 @@ static void check_sensor(struct xclmgmt_dev *lro)
 	vfree(s);
 }
 
+static void check_pcie_link_toggle(struct xclmgmt_dev *lro, int clear)
+{
+	u32 sts;
+	int err;
+
+
+	err = xocl_iores_read32(lro, XOCL_SUBDEV_LEVEL_BLD,
+			IORES_PCIE_MON, 0x8, &sts);
+	if (err)
+		return;
+
+	if (sts && !clear) {
+		mgmt_err(lro, "PCI link toggle was detected\n");
+		clear = 1;
+	}
+
+	if (clear) {
+		
+		xocl_iores_write32(lro,XOCL_SUBDEV_LEVEL_BLD ,
+				IORES_PCIE_MON, 0, 1);
+
+		xocl_iores_read32(lro, XOCL_SUBDEV_LEVEL_BLD,
+				IORES_PCIE_MON, 0, &sts);
+
+		xocl_iores_write32(lro, XOCL_SUBDEV_LEVEL_BLD,
+				IORES_PCIE_MON, 0, 0);
+	}
+
+		
+
+}
+
+
 static int health_check_cb(void *data)
 {
 	struct xclmgmt_dev *lro = (struct xclmgmt_dev *)data;
@@ -451,6 +484,9 @@ static int health_check_cb(void *data)
 	(void) xocl_clock_status(lro, &latched);
 
 	check_sensor(lro);
+
+	/* Check PCIe Link Toggle */
+	check_pcie_link_toggle(lro, 0);
 
 	/*
 	 * Checking firewall should be the last thing to do.
@@ -975,6 +1011,10 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 
 	/* return -ENODEV for 2RP platform */
 	if (!ret) {
+
+		/* Reset PCI link monitor */
+		check_pcie_link_toggle(lro, 1);
+
 		xocl_thread_start(lro);
 
 		/* Launch the mailbox server. */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1011,10 +1011,6 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 
 	/* return -ENODEV for 2RP platform */
 	if (!ret) {
-
-		/* Reset PCI link monitor */
-		check_pcie_link_toggle(lro, 1);
-
 		xocl_thread_start(lro);
 
 		/* Launch the mailbox server. */
@@ -1028,6 +1024,9 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 			goto fail_all_subdev;
 	} else
 		goto fail_all_subdev;
+
+	/* Reset PCI link monitor */
+	check_pcie_link_toggle(lro, 1);
 
 	/* Notify our peer that we're listening. */
 	xclmgmt_connect_notify(lro, true);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/iores.c
@@ -33,7 +33,8 @@ static struct xocl_iores_map res_map[] = {
 	{ RESNAME_GAPPING, IORES_GAPPING},
 	{ RESNAME_CLKFREQ_K1_K2, IORES_CLKFREQ_K1_K2},
 	{ RESNAME_CLKFREQ_HBM, IORES_CLKFREQ_HBM },
-	{ RESNAME_DDR4_RESET_GATE, IORES_DDR4_RESET_GATE}
+	{ RESNAME_DDR4_RESET_GATE, IORES_DDR4_RESET_GATE},
+	{ RESNAME_PCIEMON, IORES_PCIE_MON}
 };
 
 static int read32(struct platform_device *pdev, u32 id, u32 off, u32 *val)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -391,6 +391,7 @@ static struct xocl_subdev_map		subdev_map[] = {
 			RESNAME_MEMCALIB,
 			RESNAME_KDMA,
 			RESNAME_DDR4_RESET_GATE,
+			RESNAME_PCIEMON,
 			NULL
 		},
 		1,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -57,6 +57,7 @@
 #define NODE_MAILBOX_USER "ep_mailbox_user_00"
 #define NODE_GATE_PLP "ep_pr_isolate_plp_00"
 #define NODE_GATE_ULP "ep_pr_isolate_ulp_00"
+#define NODE_PCIE_MON "ep_pcie_link_mon_00"
 #define NODE_DDR_CALIB "ep_ddr_mem_calib_00"
 #define NODE_CLK_KERNEL1 "ep_aclk_kernel_00"
 #define NODE_CLK_KERNEL2 "ep_aclk_kernel_01"
@@ -80,6 +81,7 @@
 #define NODE_DDR4_RESET_GATE "ep_ddr4_reset_gate_00"
 
 #define RESNAME_GATEPLP       NODE_GATE_PLP
+#define RESNAME_PCIEMON       NODE_PCIE_MON
 #define RESNAME_MEMCALIB        NODE_DDR_CALIB
 #define RESNAME_GATEULP       NODE_GATE_ULP
 #define RESNAME_CLKWIZKERNEL1   NODE_CLK_KERNEL1
@@ -111,6 +113,7 @@ enum {
 	IORES_CLKFREQ_K1_K2, /* static res config exposed to iores subdev */
 	IORES_CLKFREQ_HBM, /* static res config exposed to iores subdev */
 	IORES_DDR4_RESET_GATE,
+	IORES_PCIE_MON,
 	IORES_MAX,
 };
 


### PR DESCRIPTION
…eport if link down condition detected

Add support for HIF peripheral "PCIe Link Status Monitor". This IP
will monitor pci link status and indicate if there were any
unexpected pci link toggle. If a link toggle is detected a message
will be logged in dmesg.

*Tested on 2RP u250 shell. 