### PR TITLE
[XRT-90] xbmgmt2 reset

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -227,13 +227,15 @@ public:
   /**
    * read() - maps pcie bar and copy bytes word (32bit) by word
    * THIS FUNCTION DOES NOT BELONG HERE
-   */
+   */ 
   virtual void read(uint64_t, void*, uint64_t) const {}
   /**
    * write() - maps pcie bar and copy bytes word (32bit) by word
    * THIS FUNCTION DOES NOT BELONG HERE
    */
   virtual void write(uint64_t, const void*, uint64_t) const {}
+
+  virtual void reset(const char*, const char*, const char*) const {}
 
   /**
    * file_open() - Opens a scoped fd

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -315,6 +315,16 @@ write(uint64_t offset, const void* buf, uint64_t len) const
     throw error(err, "write failed");
 }
 
+void 
+device_linux::
+reset(const char* subdev, const char* key, const char* value) const 
+{
+  std::string err;
+  pcidev::get_dev(get_device_id(), false)->sysfs_put(subdev, key, err, value);
+  if (!err.empty())
+    throw error("reset failed");
+}
+
 int 
 device_linux::
 open(const std::string& subdev, int flag) const

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -39,6 +39,7 @@ public:
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
   virtual int  open(const std::string& subdev, int flag) const;
   virtual void close(int dev_handle) const;
+  virtual void reset(const char*, const char*, const char*) const;
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -928,6 +928,7 @@ void
 device_windows::
 reset(const char*, const char*, const char*) const 
 {
+  throw std::runtime_error("Reset is not supported on Windows.");
 }
 
 /* TODO: after 2020.1

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -924,6 +924,12 @@ write(uint64_t addr, const void* buf, uint64_t len) const
   mgmtpf::write_bar(m_mgmthdl, addr, buf, len);
 }
 
+void 
+device_windows::
+reset(const char*, const char*, const char*) const 
+{
+}
+
 /* TODO: after 2020.1
  * Adding open/close stubs for compilation purposes.
  * We currently don't use these functions but we'll

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -53,6 +53,7 @@ public:
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
   virtual int  open(const std::string& subdev, int flag) const;
   virtual void close(int dev_handle) const;
+  virtual void reset(const char*, const char*, const char*) const;
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -324,4 +324,24 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   }
 }
 
+bool 
+XBUtilities::can_proceed()
+{
+  bool proceed = false;
+  std::string input;
 
+  std::cout << "Are you sure you wish to proceed? [Y/n]: ";
+  std::getline( std::cin, input );
+
+  // Ugh, the std::transform() produces windows compiler warnings due to 
+  // conversions from 'int' to 'char' in the algorithm header file
+  boost::algorithm::to_lower(input);
+  //std::transform( input.begin(), input.end(), input.begin(), [](unsigned char c){ return std::tolower(c); });
+  //std::transform( input.begin(), input.end(), input.begin(), ::tolower);
+
+  // proceeds for "y", "Y" and no input
+  proceed = ((input.compare("y") == 0) || input.empty());
+  if (!proceed)
+    std::cout << "Action canceled." << std::endl;
+  return proceed;
+}

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -63,6 +63,7 @@ namespace XBUtilities {
   void trace_print_tree(const std::string & _name, 
                         const boost::property_tree::ptree & _pt);
 
+  bool can_proceed();
   // ---------
   void wrap_paragraph( const std::string & _unformattedString, 
                        unsigned int _indentWidth, 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -255,32 +255,6 @@ report_status(xrt_core::device_collection& deviceCollection, boost::property_tre
 }
 
 /* 
- * Confirm with the user
- * Helper method for auto_flash
- */
-static bool 
-canProceed()
-{
-  bool proceed = false;
-  std::string input;
-
-  std::cout << "Are you sure you wish to proceed? [Y/n]: ";
-  std::getline( std::cin, input );
-
-  // Ugh, the std::transform() produces windows compiler warnings due to 
-  // conversions from 'int' to 'char' in the algorithm header file
-  boost::algorithm::to_lower(input);
-  //std::transform( input.begin(), input.end(), input.begin(), [](unsigned char c){ return std::tolower(c); });
-  //std::transform( input.begin(), input.end(), input.begin(), ::tolower);
-
-  // proceeds for "y", "Y" and no input
-  proceed = ((input.compare("y") == 0) || input.empty());
-  if (!proceed)
-    std::cout << "Action canceled." << std::endl;
-  return proceed;
-}
-
-/* 
  * Flash shell and sc firmware
  * Helper method for auto_flash
  */
@@ -372,7 +346,7 @@ auto_flash(xrt_core::device_collection& deviceCollection, bool force)
   if (!boardsToUpdate.empty()) {
 
     // Prompt user about what boards will be updated and ask for permission.
-    if(!force && !canProceed())
+    if(!force && !XBU::can_proceed())
       return;
 
     // Perform DSA and BMC updating
@@ -564,7 +538,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     }
     
     //ask user's permission
-    if(!canProceed())
+    if(!XBU::can_proceed())
       return;
     
     for(auto& f : flasher_list) {

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -81,7 +81,7 @@ reset_ecc(std::shared_ptr<xrt_core::device> dev)
     for(int32_t i = 0; i < map->m_count; i++) {
       if(!map->m_mem_data[i].m_used)
         continue;
-        dev->reset(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag), "ecc_reset", "1");
+      dev->reset(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag), "ecc_reset", "1");
       std::cout << boost::format("Successfully reset Device[%s]\n") 
         % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
     }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -20,7 +20,11 @@
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
+#include "core/common/query_requests.h"
+
 // 3rd Party Library - Include Files
+#include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
 
@@ -28,6 +32,88 @@ namespace po = boost::program_options;
 #include <iostream>
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
+
+static void
+pretty_print_action_list(xrt_core::device_collection& deviceCollection, const std::string& reset)
+{
+  if(reset.compare("hot") == 0) {
+    std::cout << "Performing 'hot' reset on " << std::endl;
+  } 
+  else if(reset.compare("kernel") == 0) {
+    std::cout << "Performing DFX region reset on " << std::endl;
+  } 
+  else if(reset.compare("ert") == 0) {
+    std::cout << "Performing PS ERT reset on" << std::endl;
+  } 
+  else if(reset.compare("ecc") == 0) {
+    std::cout << "Resetting all ECC counters on " << std::endl;
+  } 
+  else if(reset.compare("soft-kernel") == 0) {
+    std::cout << "Performing Soft Kernel reset on " << std::endl;
+  } 
+  else 
+    throw xrt_core::error("Please specify a valid value");
+  
+  for(const auto & device: deviceCollection) {
+      std::cout << boost::format("  -[%s]\n") % 
+        xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  }
+
+  if(reset.compare("hot") == 0)
+    std::cout << "WARNING: Please make sure xocl driver is unloaded." << std::endl;
+  else if(reset.compare("kernel") == 0)
+    std::cout << "WARNING: Please make sure no application is currently running." << std::endl;
+  std::cout << std::endl; 
+}
+
+static void 
+reset_ecc(std::shared_ptr<xrt_core::device> dev)
+{
+  auto raw_mem = xrt_core::device_query<xrt_core::query::mem_topology_raw>(dev);
+  const mem_topology *map = (mem_topology *)raw_mem.data();
+    if(raw_mem.empty() || map->m_count == 0) {
+      std::cout << "WARNING: 'mem_topology' not found, "
+        << "unable to query ECC info. Has the xclbin been loaded? "
+        << "See 'xbmgmt status'." << std::endl;
+      return;
+    }
+
+    for(int32_t i = 0; i < map->m_count; i++) {
+      if(!map->m_mem_data[i].m_used)
+        continue;
+        dev->reset(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag), "ecc_reset", "1");
+      std::cout << boost::format("Successfully reset Device[%s]\n") 
+        % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
+    }
+}
+
+static void
+reset_device(std::shared_ptr<xrt_core::device> dev, const std::string& type)
+{
+  if(type.compare("hot") == 0) {
+    dev->reset("", "mgmt_reset", "1");
+    std::cout << boost::format("Successfully reset Device[%s]\n") 
+      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
+  } 
+  else if(type.compare("kernel") == 0) {
+    dev->reset("", "mgmt_reset", "2");
+    std::cout << boost::format("Successfully reset Device[%s]\n") 
+      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
+  } 
+  else if(type.compare("ert") == 0) {
+    dev->reset("", "mgmt_reset", "3");
+    std::cout << boost::format("Successfully reset Device[%s]\n") 
+      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
+  }  
+  else if(type.compare("soft-kernel") == 0) {
+    dev->reset("", "mgmt_reset", "4");
+    std::cout << boost::format("Successfully reset Device[%s]\n") 
+      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
+  }
+  else if(type.compare("ecc") == 0) {
+    reset_ecc(dev);
+  }
+}
 
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("reset", 
@@ -48,20 +134,20 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: reset");
   // -- Retrieve and parse the subcommand options -----------------------------
-  std::string device = "all";
-  std::string reset = "all";
+  std::vector<std::string> devices;
+  std::string type = "";
   bool help = false;
+  bool force = false; //TO-DO: remove this when the global force is implemented
 
   po::options_description resetDesc("Options");
   resetDesc.add_options()
-    ("device,d", boost::program_options::value<decltype(device)>(&device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
-    ("type,r", boost::program_options::value<decltype(reset)>(&reset), "The type of reset to perform. Types resets available:\n"
-                                                                        "  all | hot    - Perform all known resets (default)\n"
-                                                                        "  kernel       - Kernel communication links\n"
-                                                                        "  scheduler    - Scheduler\n"
-                                                                        "  clear-fabric - Clears the accleration fabric with the\n"
-                                                                        "                 shells verify.xclbin image\n"
-                                                                        "  memory       - Clears the memory block")
+    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
+    ("type,r", boost::program_options::value<decltype(type)>(&type)->implicit_value("all"), "The type of reset to perform. Types resets available:\n"
+                                                                        "  hot          - Hot reset (default)\n"
+                                                                        "  kernel       - Kernel communication links\n" 
+                                                                        "  ert          - Reset management processor\n"
+                                                                        "  ecc          - Reset ecc memory\n"
+                                                                        "  soft-kernel  - Reset soft kernel")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
@@ -86,10 +172,28 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   }
 
   // -- Now process the subcommand --------------------------------------------
+  XBU::verbose(boost::str(boost::format("  Reset: %s") % type));
 
-  XBU::error("COMMAND BODY NOT IMPLEMENTED.");
-  // TODO: Put working code here
+  // -- process "device" option -----------------------------------------------
+  // enforce device specification
+  if(devices.empty())
+    throw xrt_core::error("Please specify a device using --device option");
 
-  return;
+  // Collect all of the devices of interest
+  std::set<std::string> deviceNames;
+  xrt_core::device_collection deviceCollection;  // The collection of devices to examine
+  for (const auto & deviceName : devices) 
+    deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
+
+  XBU::collect_devices(deviceNames, false /*inUserDomain*/, deviceCollection);
+  pretty_print_action_list(deviceCollection, type);
+
+  // Ask user for permission
+  if(!force && !XBU::can_proceed())
+    return;
+
+  //perform reset actions
+  for (const auto & dev : deviceCollection) {
+    reset_device(dev, type);
+  }
 }
-


### PR DESCRIPTION
- created reset function in  device.h which calls sysfs_put() on Linux and throws an error on Windows
- moved can_proceed() to XBUtilities since it is being used in SubCmdProgram and SubCmdReset
- Sample outputs:
```
# ./xbmgmt2 reset --device=0000:b3:00.0 0000:65:00.0 --type=hot
Performing 'hot' reset on
  -[0000:65:00.0]
  -[0000:b3:00.0]
WARNING: Please make sure xocl driver is unloaded.
 
Are you sure you wish to proceed? [Y/n]:
Successfully reset Card[0000:65:00.0]
Successfully reset Card[0000:b3:00.0]
```

On windows:
```
>xbmgmt.exe reset --device=0000:0e:00.0 --type=hot
Performing 'hot' reset on
  -[0000:0e:00.0]
WARNING: Please make sure xocl driver is unloaded.

Are you sure you wish to proceed? [Y/n]:
XRT build version: 2.6.0
Build hash: 4bac721f66694e3a422e09298dc5c9845950b8fd
Build date: 2020-04-22 11:49:10
Git branch: HEAD
PID: 4608
UID: 0
[Wed Apr 22 11:51:12 2020]
HOST:
EXE:
[xbmgmt] ERROR: Reset is not supported on Windows.
```