### PR TITLE
Revert “KDS reconfig after reset softkernel or ert”

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -77,7 +77,6 @@ enum xcl_mailbox_request {
 	XCL_MAILBOX_REQ_CHG_SHELL =		13,
 	XCL_MAILBOX_REQ_PROGRAM_SHELL =		14,
 	XCL_MAILBOX_REQ_READ_P2P_BAR_ADDR =	15,
-	XCL_MAILBOX_REQ_ERT_RESET =		16,
 	/* Version 0 OP code ends */
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -728,18 +728,12 @@ void xclmgmt_ocl_reset(struct xclmgmt_dev *lro)
 
 void xclmgmt_ert_reset(struct xclmgmt_dev *lro)
 {
-	struct xcl_mailbox_req mbreq = { 0 };
 	/* This is for reset PS ERT */
 	xocl_ps_reset(lro);
 	xocl_ps_wait(lro);
-	mbreq.req = XCL_MAILBOX_REQ_ERT_RESET;
-	(void) xocl_peer_notify(lro, &mbreq, sizeof(mbreq));
 }
 
 void xclmgmt_softkernel_reset(struct xclmgmt_dev *lro)
 {
-	struct xcl_mailbox_req mbreq = { 0 };
 	xocl_ps_sk_reset(lro);
-	mbreq.req = XCL_MAILBOX_REQ_ERT_RESET;
-	(void) xocl_peer_notify(lro, &mbreq, sizeof(mbreq));
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -602,10 +602,6 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 		xocl_queue_work(xdev, XOCL_WORK_PROGRAM_SHELL,
 				XOCL_PROGRAM_SHELL_DELAY);
 		break;
-	case XCL_MAILBOX_REQ_ERT_RESET:
-		userpf_info(xdev, "ERT was reset.");
-		(void) xocl_exec_reconfig(xdev);
-		break;
 	default:
 		userpf_err(xdev, "dropped bad request (%d)\n", req->req);
 		break;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_reset.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_reset.cpp
@@ -141,9 +141,11 @@ int resetHandler(int argc, char *argv[])
         } else if (ecc) {
             std::cout << "CAUTION: resetting all ECC counters. " << std::endl;
         } else if (sk) {
-            std::cout << "CAUTION: Performing Soft Kernel reset. " << std::endl;
+            std::cout << "CAUTION: Performing Soft Kernel reset. " <<
+                "Please make sure xocl driver is unloaded." << std::endl;
         } else if (ert) {
-            std::cout << "CAUTION: Performing PS ERT reset. " << std::endl;
+            std::cout << "CAUTION: Performing PS ERT reset. " <<
+                "Please make sure xocl driver is unloaded." << std::endl;
         }
         if(!canProceed())
             return -ECANCELED;


### PR DESCRIPTION
* Revert #3150 
* Guide user to unload xocl driver before reset softkernel or ert