### PR TITLE
Trace Enhancements and Race Condition Fixes

### DIFF
--- a/src/runtime_src/xdp/profile/core/trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/core/trace_logger.cpp
@@ -74,7 +74,10 @@ namespace xdp {
   // Attach new trace writer
   void TraceLogger::attach(TraceWriterI* writer)
   {
-    std::lock_guard < std::mutex > lock(mLogMutex);
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
+
     auto itr = std::find(mTraceWriters.begin(), mTraceWriters.end(), writer);
     if (itr == mTraceWriters.end())
       mTraceWriters.push_back(writer);
@@ -83,7 +86,10 @@ namespace xdp {
   // Detach new trace writer
   void TraceLogger::detach(TraceWriterI* writer)
   {
-    std::lock_guard < std::mutex > lock(mLogMutex);
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
+
     auto itr = std::find(mTraceWriters.begin(), mTraceWriters.end(), writer);
     if (itr != mTraceWriters.end())
       mTraceWriters.erase(itr);
@@ -178,7 +184,11 @@ namespace xdp {
       name += "|General";
     else
       (name += "|") +=std::to_string(queueAddress);
-    std::lock_guard<std::mutex> lock(mLogMutex);
+
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
+
     mProfileCounters->logFunctionCallStart(functionName, timeStamp);
     writeTimelineTrace(timeStamp, name.c_str(), "START", functionID);
     mFunctionStartLogged = true;
@@ -199,7 +209,10 @@ namespace xdp {
     else
       (name += "|") +=std::to_string(queueAddress);
 
-    std::lock_guard<std::mutex> lock(mLogMutex);
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
+
     mProfileCounters->logFunctionCallEnd(functionName, timeStamp);
     writeTimelineTrace(timeStamp, name.c_str(), "END", functionID);
   }
@@ -220,7 +233,11 @@ namespace xdp {
 
     std::string commandString;
     std::string stageString;
-    std::lock_guard < std::mutex > lock(mLogMutex);
+
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
+
     RTUtil::commandKindToString(objKind, commandString);
     RTUtil::commandStageToString(objStage, stageString);
 
@@ -310,7 +327,9 @@ namespace xdp {
       tp->setLastKernelEndTimeMsec(timeStamp);
     }
 
-    std::lock_guard<std::mutex> lock(mLogMutex);
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
 
     // TODO: create unique name for device since currently all devices are called fpga0
     // NOTE: see also logCounters for corresponding device name for counters
@@ -481,7 +500,11 @@ namespace xdp {
       const std::string& eventString, const std::string& dependString)
   {
     std::string commandString;
-    std::lock_guard < std::mutex > lock(mLogMutex);
+
+    std::unique_lock<std::mutex> next(mLogNext);
+    std::unique_lock<std::mutex> lock(mLogMutex);
+    next.unlock();
+
     RTUtil::commandKindToString(objKind, commandString);
 
     double traceTime = mPluginHandle->getTraceTime();
@@ -498,7 +521,6 @@ namespace xdp {
     if (tp == NULL || (traceVector.mLength == 0 && endLog == false))
       return;
 
-    std::lock_guard<std::mutex> lock(mLogMutex);
     TraceParser::TraceResultVector resultVector;
     tp->logTrace(deviceName, type, traceVector, resultVector);
     if (endLog)
@@ -540,12 +562,22 @@ namespace xdp {
       mProfileCounters->pushToSortedTopUsage(tr, isRead, isKernelTransfer);
     }
 
-    // Write trace results vector to files
-    //if (this->isTimelineTraceFileOn()) {
-      for (auto w : mTraceWriters) {
-        w->writeDeviceTrace(resultVector, deviceName, binaryName);
+    /*
+     * Device Trace offload is low priority
+     * Write one packet and yield locks
+     */
+    std::unique_lock<std::mutex> next(mLogNext, std::defer_lock);
+    std::unique_lock<std::mutex> lock(mLogMutex, std::defer_lock);
+
+    for (auto w : mTraceWriters) {
+      for (auto& tr: resultVector) {
+        next.lock();
+        lock.lock();
+        next.unlock();
+        w->writeDeviceTrace(tr, deviceName, binaryName);
+        lock.unlock();
       }
-    //}
+    }
 
     resultVector.clear();
   }

--- a/src/runtime_src/xdp/profile/core/trace_logger.h
+++ b/src/runtime_src/xdp/profile/core/trace_logger.h
@@ -129,6 +129,7 @@ namespace xdp {
     std::string mCurrentDeviceName;
     std::string mCurrentBinaryName;
     std::mutex mLogMutex;
+    std::mutex mLogNext;
 
     std::map<uint64_t, KernelTrace*> mKernelTraceMap;
     std::map<uint64_t, BufferTrace*> mBufferTraceMap;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -55,7 +55,7 @@ DeviceTraceOffload::~DeviceTraceOffload()
 
 void DeviceTraceOffload::offload_device_continuous()
 {
-  if (!read_trace_init())
+  if (!m_initialized && !read_trace_init())
     return;
 
   while (should_continue()) {
@@ -144,11 +144,13 @@ bool DeviceTraceOffload::read_trace_init()
   m_trbuf_full = false;
 
   if (has_ts2mm()) {
-    return init_s2mm();
+    m_initialized = init_s2mm();
   } else if (has_fifo()) {
-    return true;
+    m_initialized = true;
+  } else {
+    m_initialized = false;
   }
-  return false;
+  return m_initialized;
 }
 
 void DeviceTraceOffload::read_trace_end()
@@ -159,6 +161,7 @@ void DeviceTraceOffload::read_trace_end()
   deviceTraceLogger->endProcessTraceData(m_trace_vector);
   if (dev_intf->hasTs2mm()) {
     reset_s2mm();
+    m_initialized = false;
   }
 }
 

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -65,6 +65,8 @@ public:
     bool read_trace_init();
     XDP_EXPORT
     void read_trace_end();
+    XDP_EXPORT
+    void train_clock();
 
 public:
     void set_trbuf_alloc_sz(uint64_t sz) {
@@ -82,8 +84,9 @@ public:
     void read_trace() {
         m_read_trace();
     };
-
-    DeviceTraceLogger* getDeviceTraceLogger() { return deviceTraceLogger; }
+    DeviceTraceLogger* getDeviceTraceLogger() {
+        return deviceTraceLogger;
+    };
 
 private:
     std::mutex status_lock;
@@ -102,7 +105,6 @@ private:
     uint64_t m_trbuf_offset = 0;
     uint64_t m_trbuf_chunk_sz = 0;
 
-    void train_clock();
     void read_trace_fifo();
     void read_trace_s2mm();
     void* sync_trace_buf(uint64_t offset, uint64_t bytes);
@@ -116,6 +118,7 @@ private:
 
     bool m_trbuf_full = false;
     bool m_debug = false; /* Enable Output stream for log */
+    bool m_initialized = false;
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
@@ -99,6 +99,7 @@ void TraceFifoFull::processTraceData(xclTraceResultsVector& traceVector,uint32_t
     xclTraceResults results = {};
     int mod = 0;
     unsigned int clockWordIndex = 7;
+    unsigned int idx = 0;
     for (uint32_t i = 0; i < numSamples; i++) {
 
       // Old method has issues with emulation trace
@@ -146,7 +147,7 @@ void TraceFifoFull::processTraceData(xclTraceResultsVector& traceVector,uint32_t
                           << " Host Timestamp : " << std::hex << results.HostTimestamp << std::endl;
           }
           results.isClockTrain = 1 ;
-          traceVector.mArray[static_cast<int>(i/4)] = results;    // save result
+          traceVector.mArray[idx++] = results;    // save result
           memset(&results, 0, sizeof(xclTraceResults));
         }
         mod = (mod == 3) ? 0 : mod + 1;
@@ -165,10 +166,7 @@ void TraceFifoFull::processTraceData(xclTraceResultsVector& traceVector,uint32_t
       results.EventFlags = ((currentSample >> 45) & 0xF) | ((currentSample >> 57) & 0x10) ;
       results.isClockTrain = 0 ;
 
-      int idx = mclockTrainingdone ? i : i - clockWordIndex + 1;
-      if (idx < 0)
-        continue;
-      traceVector.mArray[idx] = results;   // save result
+      traceVector.mArray[idx++] = results;   // save result
 
       if(out_stream) {
         uint64_t previousTimestamp = 0;
@@ -189,6 +187,7 @@ void TraceFifoFull::processTraceData(xclTraceResultsVector& traceVector,uint32_t
       }
       memset(&results, 0, sizeof(xclTraceResults));
     }
+    traceVector.mLength = idx;
     mclockTrainingdone = true;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ocl/ocl_profiler.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/ocl_profiler.cpp
@@ -349,23 +349,19 @@ namespace xdp {
 
         DeviceTraceLogger* deviceTraceLogger = new TraceLoggerUsingProfileMngr(getProfileManager(), device->get_unique_name(), binaryName);
         auto offloader = std::make_unique<DeviceTraceOffload>(dInt, deviceTraceLogger,
-                                                         mTraceReadIntMs, traceBufSz, mTraceThreadEn);
-        bool init_done = true;
-        if (!mTraceThreadEn) {
-          init_done = offloader->read_trace_init();
-          if (init_done) {
-            /* Trace FIFO is usually very small (8k,16k etc)
-             *  Hence enable Continuous clock training by default
-             *  ONLY for Trace Offload to DDR Memory
-             */
-            if (dInt->hasTs2mm())
-              offloader->start_offload(OffloadThreadType::CLOCK_TRAIN);
-            else
-              dInt->clockTraining();
-          }
-        }
-
+                                                         mTraceReadIntMs, traceBufSz, false);
+        bool init_done = offloader->read_trace_init();
         if (init_done) {
+          offloader->train_clock();
+          /* Trace FIFO is usually very small (8k,16k etc)
+           *  Hence enable Continuous clock training by default
+           *  ONLY for Trace Offload to DDR Memory
+           */
+          if (mTraceThreadEn)
+            offloader->start_offload(OffloadThreadType::TRACE);
+          else if (dInt->hasTs2mm())
+            offloader->start_offload(OffloadThreadType::CLOCK_TRAIN);
+
           DeviceTraceLoggers.push_back(deviceTraceLogger);
           DeviceTraceOffloadList.push_back(std::move(offloader));
         } else {

--- a/src/runtime_src/xdp/profile/writer/base_trace.cpp
+++ b/src/runtime_src/xdp/profile/writer/base_trace.cpp
@@ -266,18 +266,15 @@ namespace xdp {
   }
 
   // Functions for device trace
-  void TraceWriterI::writeDeviceTrace(const TraceParser::TraceResultVector &resultVector,
+  void TraceWriterI::writeDeviceTrace(const DeviceTrace &tr,
       std::string deviceName, std::string binaryName)
   {
     if (!Trace_ofs.is_open())
       return;
 
-    for (auto it = resultVector.begin(); it != resultVector.end(); it++) {
-      DeviceTrace tr = *it;
-
 #ifndef XDP_VERBOSE
       if (tr.Kind == DeviceTrace::DEVICE_BUFFER)
-        continue;
+        return;
 #endif
 
       double deviceClockDurationUsec = (1.0 / (mPluginHandle->getKernelClockFreqMHz(deviceName)));
@@ -362,7 +359,7 @@ namespace xdp {
       if (tr.Type == "Kernel") {
         std::string workGroupSize;
         mPluginHandle->getTraceStringFromComputeUnit(deviceName, cuName, traceName);
-        if (traceName.empty()) continue;
+        if (traceName.empty()) return;
         size_t pos = traceName.find_last_of("|");
         workGroupSize = traceName.substr(pos + 1);
         traceName = traceName.substr(0, pos);
@@ -374,7 +371,7 @@ namespace xdp {
         writeTableRowStart(getStream());
         writeTableCells(getStream(), endStr.str(), traceName, "END", "", workGroupSize, tr.EventID);
         writeTableRowEnd(getStream());
-        continue;
+        return;
       }
 
       double deviceDuration = 1000.0*(tr.End - tr.Start);
@@ -385,7 +382,6 @@ namespace xdp {
           tr.StartTime, tr.EndTime, deviceDuration,
           startStr.str(), endStr.str());
       writeTableRowEnd(getStream());
-    }
   }
 
 } // xdp

--- a/src/runtime_src/xdp/profile/writer/base_trace.h
+++ b/src/runtime_src/xdp/profile/writer/base_trace.h
@@ -72,7 +72,7 @@ namespace xdp {
 	    void writeDeviceCounters(xclPerfMonType type, xclCounterResults& results,
 		      double timestamp, uint32_t sampleNum, bool firstReadAfterProgram);
 	    // Write device trace
-	    void writeDeviceTrace(const TraceParser::TraceResultVector &resultVector,
+	    void writeDeviceTrace(const DeviceTrace &tr,
 	          std::string deviceName, std::string binaryName);
 
     protected:
@@ -80,7 +80,7 @@ namespace xdp {
       // stream it to a file
       // TODO: Windows doesn't support variadic functions till VS 2013.
       template<typename T>
-      void writeTableCells(std::ofstream& ofs, T value)
+      void writeTableCells(std::ofstream& ofs, const T& value)
       {
         ofs << cellStart();
         ofs << value;
@@ -88,7 +88,7 @@ namespace xdp {
       }
 
       template<typename T, typename... Args>
-      void writeTableCells(std::ofstream& ofs, T first, Args... args)
+      void writeTableCells(std::ofstream& ofs, const T& first, const Args& ... args)
       {
         writeTableCells(ofs, first);
         writeTableCells(ofs, args...);


### PR DESCRIPTION
1. Use double locking to make device trace lower priority offload. This means host events can still get logged while device data is being dumped.
2. Fix Race condition where big trace buffer allocation lead to delay in trace offload start.
3. Fix FIFO trace vector indexing.
4. Use references in trace writer to eliminate string copy.