### PR TITLE
CR-1062456 xbutil validate core dump for u280

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
@@ -49,9 +49,6 @@ static int axigate_freeze(struct platform_device *pdev)
 	if (!freeze)
 		goto done; /* Already freeze */
 
-	reg_wr(gate, 0x1, iag_wr);
-	ndelay(500);
-
 	reg_wr(gate, 0, iag_wr);
 	ndelay(500);
 	(void) reg_rd(gate, iag_rd);
@@ -76,7 +73,7 @@ static int axigate_free(struct platform_device *pdev)
 	if (freeze)
 		goto done; /* Already free */
 
-	reg_wr(gate, 0x1, iag_wr);
+	reg_wr(gate, 0x2, iag_wr);
 	ndelay(500);
 	(void) reg_rd(gate, iag_rd);
 	reg_wr(gate, 0x3, iag_wr);


### PR DESCRIPTION
The new AXI gate freeze / free sequence introduced by https://github.com/Xilinx/XRT/pull/3117 does not work well on U280. Revert it back to original sequence.