### PR TITLE
CR-1048231 checking xclbin uuid before checking scheduler busy status

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -695,19 +695,19 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj)
 
 	write_lock(&zdev->attr_rwlock);
 
-	if (kds_mode == 0) {
-		if (sched_live_clients(zdev, NULL) || sched_is_busy(zdev)) {
-			DRM_ERROR("Current xclbin is in-use, can't change");
-			ret = -EBUSY;
-			goto out0;
-		}
-	}
-
 	/* Check unique ID */
 	if (zocl_xclbin_same_uuid(zdev, &axlf_head.m_header.uuid)) {
 		DRM_INFO("%s The XCLBIN already loaded, uuid: %pUb. "
 		     "Don't need to reload.", __func__, &axlf_head.m_header.uuid);
 		goto out0;
+	}
+
+	if (kds_mode == 0) {
+		if (sched_live_clients(zdev, NULL) || sched_is_busy(zdev)) {
+			DRM_ERROR("Current xclbin is in-use, can't change, try again.");
+			ret = -EBUSY;
+			goto out0;
+		}
 	}
 
 	/* uuid is null means first time load xclbin */


### PR DESCRIPTION
Should validate xclbin uuid match check before checking the scheduler busy status to avoid unnecessary checks in the uuid matching cases.