### PR TITLE
xclbinutil: Updated the mirror parsing code to treat the uniqueID as a hex string

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -513,7 +513,7 @@ XclBin::readXclBinHeader(const boost::property_tree::ptree& _ptHeader,
   _axlfHeader.m_signature_length = _ptHeader.get<int32_t>("SignatureLength", -1);
   std::string sKeyBlock = _ptHeader.get<std::string>("KeyBlock");
   XUtil::hexStringToBinaryBuffer(sKeyBlock, (unsigned char*)&_axlfHeader.m_keyBlock, sizeof(axlf::m_keyBlock));
-  _axlfHeader.m_uniqueId = XUtil::stringToUInt64(_ptHeader.get<std::string>("UniqueID"));
+  _axlfHeader.m_uniqueId = XUtil::stringToUInt64(_ptHeader.get<std::string>("UniqueID"), true /*forceHex*/);
 
   _axlfHeader.m_header.m_timeStamp = XUtil::stringToUInt64(_ptHeader.get<std::string>("TimeStamp"));
   _axlfHeader.m_header.m_featureRomTimeStamp = XUtil::stringToUInt64(_ptHeader.get<std::string>("FeatureRomTimeStamp"));

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -292,13 +292,13 @@ XclBinUtilities::hexStringToBinaryBuffer(const std::string& _inputString,
 
 #ifdef _WIN32
 uint64_t
-XclBinUtilities::stringToUInt64(const std::string& _sInteger) {
+XclBinUtilities::stringToUInt64(const std::string& _sInteger, bool _bForceHex) {
   uint64_t value = 0;
 
   // Is it a hex value
-  if ((_sInteger.length() > 2) &&
-      (_sInteger[0] == '0') &&
-      (_sInteger[1] == 'x')) {
+  if ( _bForceHex || 
+       ((_sInteger.length() > 2) &&
+        (_sInteger[0] == '0') && (_sInteger[1] == 'x'))) {
     if (1 == sscanf_s(_sInteger.c_str(), "%" PRIx64 "", &value)) {
       return value;
     }
@@ -313,13 +313,13 @@ XclBinUtilities::stringToUInt64(const std::string& _sInteger) {
 }
 #else
 uint64_t
-XclBinUtilities::stringToUInt64(const std::string& _sInteger) {
+XclBinUtilities::stringToUInt64(const std::string& _sInteger, bool _bForceHex) {
   uint64_t value = 0;
 
   // Is it a hex value
-  if ((_sInteger.length() > 2) &&
-      (_sInteger[0] == '0') &&
-      (_sInteger[1] == 'x')) {
+  if (_bForceHex || 
+      ((_sInteger.length() > 2) &&
+       (_sInteger[0] == '0') && (_sInteger[1] == 'x'))) {
     if (1 == sscanf(_sInteger.c_str(), "%" PRIx64 "", &value)) {
       return value;
     }

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -125,7 +125,7 @@ unsigned int alignBytes(std::ostream & _buf, unsigned int _byteBoundary);
 
 void binaryBufferToHexString(const unsigned char* _binBuf, uint64_t _size, std::string& _outputString);
 void hexStringToBinaryBuffer(const std::string& _inputString, unsigned char* _destBuf, unsigned int _bufferSize);
-uint64_t stringToUInt64(const std::string& _sInteger);
+uint64_t stringToUInt64(const std::string& _sInteger, bool _bForceHex = false);
 void printKinds();
 std::string getUUIDAsString( const unsigned char (&_uuid)[16] );
 


### PR DESCRIPTION
Issue
-----
The hex value being written into the mirrorData section did not pre-append an '0x' value prior to the hex string.  This unfortunately resulted in a bad parse.

Resolution
----------
Since the mirror data writing algorithm cannot be changed, the parsing algorithm was instead updated to treat this value as a hex string.

Work Done
--------
+ Updated XclBinUtilities::stringToUInt64() to support a 'force hex' parsing option.
+ Updated XclBin::readXclBinHeader() to tree the uniqueID as a hex string