### PR TITLE
CR-1033712 and skip bw testcase

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1129,8 +1129,10 @@ int xcldev::device::runTestCase(const std::string& py,
 
     if (stat(xrtTestCasePath.c_str(), &st) != 0 || stat(xclbinPath.c_str(), &st) != 0) {
         //if bandwidth xclbin isn't present, skip the test
-        if(xclbin.compare("bandwidth.xclbin") == 0)
+        if(xclbin.compare("bandwidth.xclbin") == 0) {
+            output += "Bandwidth xclbin not available. Skipping validation.";
             return -EOPNOTSUPP;
+        }
         output += "ERROR: Failed to find ";
         output += py;
         output += " or ";
@@ -1190,8 +1192,7 @@ int xcldev::device::bandwidthKernelTest(void)
         std::string("bandwidth.xclbin"), output);
 
     if (ret != 0) {
-        if(!output.empty())
-            std::cout << output << std::endl;
+        std::cout << output << std::endl;
         return ret;
     }
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1128,6 +1128,9 @@ int xcldev::device::runTestCase(const std::string& py,
     xclbinPath += xclbin;
 
     if (stat(xrtTestCasePath.c_str(), &st) != 0 || stat(xclbinPath.c_str(), &st) != 0) {
+        //if bandwidth xclbin isn't present, skip the test
+        if(xclbin.compare("bandwidth.xclbin") == 0)
+            return -EOPNOTSUPP;
         output += "ERROR: Failed to find ";
         output += py;
         output += " or ";
@@ -1187,7 +1190,8 @@ int xcldev::device::bandwidthKernelTest(void)
         std::string("bandwidth.xclbin"), output);
 
     if (ret != 0) {
-        std::cout << output << std::endl;
+        if(!output.empty())
+            std::cout << output << std::endl;
         return ret;
     }
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -916,6 +916,7 @@ public:
         sensor_tree::put( "board.physical.electrical.hbm_1v2.voltage",         hbm_1v2_vol);
         sensor_tree::put( "board.physical.electrical.vpp2v5.voltage",          vpp2v5_vol);
         sensor_tree::put( "board.physical.electrical.vccint_bram.voltage",     vccint_bram_vol);
+        sensor_tree::put( "board.physical.electrical.vcc_io.voltage",          vccint_bram_vol);
         sensor_tree::put( "board.physical.electrical.12v_aux1.current",        vol_12v_aux1);
         sensor_tree::put( "board.physical.electrical.vcc1v2_i.current",        vol_vcc1v2_i);
         sensor_tree::put( "board.physical.electrical.v12_in_i.current",        vol_v12_in_i);
@@ -1157,7 +1158,7 @@ public:
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.12v_sw.voltage"  )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.mgt_vtt.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.1v2_btm.voltage" ) << std::endl;
-        ostr << std::setw(16) << "VCCINT VOL" << std::setw(16) << "VCCINT CURR" << std::setw(16) << "VCCINT BRAM VOL" << std::setw(16) << "VCC3V3 VOL"  << std::endl;
+        ostr << std::setw(16) << "VCCINT VOL" << std::setw(16) << "VCCINT CURR" << std::setw(16) << "VCCINT IO VOL" << std::setw(16) << "VCC3V3 VOL"  << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccint.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccint.current" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccint_bram.voltage" )

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -17,7 +17,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     # Indicates that the new version of xbutil (e.g., xbutil2) should be used
     -new|--new)
-      XRT_PROG=xbutil2
+      XRT_PROG=xbmgmt2
       shift
       echo "-----------------------------------------------------"
       echo " Involking next generation of the xbmgmt application "


### PR DESCRIPTION
- [CR-1033712] U50lv CMC <-> SC: VCC_BRAM change name to VCCINT_IO for voltage and current
- skip bandwidth testcase on u30
- xbmgmt --new should run xbmgmt2 not xbutil2

Sample output for CR-1033712:
```
$xbutil query
...
VCCINT VOL      VCCINT CURR     VCCINT IO VOL   VCC3V3 VOL
N/A             N/A             N/A             N/A
...

$xbutil dump
...
"vccint_bram": {
                    "voltage": "0"
                },
"vcc_io": {
                    "voltage": "0"
                },
...
```