### PR TITLE
xclbinutil : Corrected DRC seg fault

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1149,7 +1149,7 @@ XclBin::dumpSubSection(ParameterSectionData &_PSD)
   // Determine if the section exists
   Section *pSection = findSection(eKind, _PSD.getSectionIndexName());
   if (pSection == nullptr) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' does not exist.", pSection->getSectionKindAsString().c_str());
+    std::string errMsg = XUtil::format("ERROR: Section %s[%s] does not exist.", _PSD.getSectionName().c_str(), _PSD.getSectionIndexName().c_str());
     throw std::runtime_error(errMsg);
   }
 


### PR DESCRIPTION
Issue
-----
A seg fault would occur if an invalidate section index value was used.  This was the result of the DRC error message attempting to reference a null pointer.

Resolution
----------
The DRC error message was refactored to not use pointers that are of null value.