### PR TITLE
add kds_echo param for test purpose

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -19,6 +19,11 @@ module_param(kds_mode, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_mode,
 		 "enable new KDS (0 = disable (default), 1 = enable)");
 
+int kds_echo = 0;
+module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
+MODULE_PARM_DESC(kds_echo,
+		 "enable KDS echo (0 = disable (default), 1 = enable)");
+
 static void notify_execbuf(struct kds_command *xcmd, int status)
 {
 	struct kds_client *client = xcmd->client;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -16,6 +16,11 @@ module_param(kds_mode, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_mode,
 		 "enable new KDS (0 = disable (default), 1 = enable)");
 
+int kds_echo = 0;
+module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
+MODULE_PARM_DESC(kds_echo,
+		 "enable KDS echo (0 = disable (default), 1 = enable)");
+
 static void notify_execbuf(struct kds_command *xcmd, int status)
 {
 	struct kds_client *client = xcmd->client;


### PR DESCRIPTION
As per Max's request, add kds_echo parameter to make KDS doesn't touch hardware. With this, it is easier to measure the software overhead in scheduling.

This is only for test purpose. It is not a product level support.