### PR TITLE
deprecated more xcl APIs

### DIFF
--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -300,7 +300,7 @@ xclClose(xclDeviceHandle handle);
  * NOTE: Only implemeted Reset kind through user pf is XCL_USER_RESET
  *
  * This API is deprecated and will be removed in future release.
- * New clients should run xbutil reset instead
+ * New clients should use xbutil utility to reset device instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -450,7 +450,7 @@ xclCloseContext(xclDeviceHandle handle, xuid_t xclbinId, unsigned int ipIndex);
  * Update the device BPI PROM with new image, deprecated
  *
  * This API is deprecated and will be removed in future release.
- * New clients should run xbmgmt flash instead
+ * New clients should use xbmgmt utility to flash device instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -461,7 +461,7 @@ xclUpgradeFirmware(xclDeviceHandle handle, const char *fileName);
  * Update the device PROM with new image with clearing bitstream, deprecated
  *
  * This API is deprecated and will be removed in future release.
- * New clients should run xbmgmt flash instead
+ * New clients should use xbmgmt utility to flash device instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -472,7 +472,7 @@ xclUpgradeFirmware2(xclDeviceHandle handle, const char *file1, const char* file2
  * Update the device SPI PROM with new image, deprecated
  *
  * This API is deprecated and will be removed in future release.
- * New clients should run xbmgmt flash instead
+ * New clients should use xbmgmt utility to flash device instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -298,6 +298,9 @@ xclClose(xclDeviceHandle handle);
  * purged. A device may be reset if a user's application dies without waiting for
  * running kernel(s) to finish.
  * NOTE: Only implemeted Reset kind through user pf is XCL_USER_RESET
+ *
+ * This API is deprecated and will be removed in future release.
+ * New clients should run xbutil reset instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -445,6 +448,9 @@ xclCloseContext(xclDeviceHandle handle, xuid_t xclbinId, unsigned int ipIndex);
 
 /*
  * Update the device BPI PROM with new image, deprecated
+ *
+ * This API is deprecated and will be removed in future release.
+ * New clients should run xbmgmt flash instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -453,6 +459,9 @@ xclUpgradeFirmware(xclDeviceHandle handle, const char *fileName);
 
 /*
  * Update the device PROM with new image with clearing bitstream, deprecated
+ *
+ * This API is deprecated and will be removed in future release.
+ * New clients should run xbmgmt flash instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -461,6 +470,9 @@ xclUpgradeFirmware2(xclDeviceHandle handle, const char *file1, const char* file2
 
 /*
  * Update the device SPI PROM with new image, deprecated
+ *
+ * This API is deprecated and will be removed in future release.
+ * New clients should run xbmgmt flash instead
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -474,6 +486,9 @@ xclUpgradeFirmwareXSpi(xclDeviceHandle handle, const char *fileName, int index);
  * Return:         0 on success or appropriate error number
  *
  * This should only be called when there are no other clients. It will cause PCIe bus re-enumeration
+ *
+ * This API is deprecated and will be removed in future release.
+ * This functionality is no longer supported.
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
@@ -483,6 +498,9 @@ xclBootFPGA(xclDeviceHandle handle);
 /*
  * Write to /sys/bus/pci/devices/<deviceHandle>/remove and initiate a pci rescan by
  * writing to /sys/bus/pci/rescan, deprecated
+ *
+ * This API is deprecated and will be removed in future release.
+ * This functionality is no longer supported.
  */
 XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -288,7 +288,7 @@ void
 xclClose(xclDeviceHandle handle);
 
 /**
- * xclResetDevice() - Reset a device or its CL
+ * xclResetDevice() - Reset a device, deprecated
  *
  * @handle:        Device handle
  * @kind:          Reset kind
@@ -299,6 +299,7 @@ xclClose(xclDeviceHandle handle);
  * running kernel(s) to finish.
  * NOTE: Only implemeted Reset kind through user pf is XCL_USER_RESET
  */
+XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
 int
 xclResetDevice(xclDeviceHandle handle, enum xclResetKind kind);
@@ -443,42 +444,47 @@ int
 xclCloseContext(xclDeviceHandle handle, xuid_t xclbinId, unsigned int ipIndex);
 
 /*
- * Update the device BPI PROM with new image
+ * Update the device BPI PROM with new image, deprecated
  */
+XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
 int
 xclUpgradeFirmware(xclDeviceHandle handle, const char *fileName);
 
 /*
- * Update the device PROM with new image with clearing bitstream
+ * Update the device PROM with new image with clearing bitstream, deprecated
  */
+XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
 int
 xclUpgradeFirmware2(xclDeviceHandle handle, const char *file1, const char* file2);
 
 /*
- * Update the device SPI PROM with new image
+ * Update the device SPI PROM with new image, deprecated
  */
+XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
 int
 xclUpgradeFirmwareXSpi(xclDeviceHandle handle, const char *fileName, int index);
 
 /**
- * xclBootFPGA() - Boot the FPGA from PROM
+ * xclBootFPGA() - Boot the FPGA from PROM, deprecated
  *
  * @handle:        Device handle
  * Return:         0 on success or appropriate error number
  *
  * This should only be called when there are no other clients. It will cause PCIe bus re-enumeration
  */
+XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
 int
 xclBootFPGA(xclDeviceHandle handle);
 
 /*
  * Write to /sys/bus/pci/devices/<deviceHandle>/remove and initiate a pci rescan by
- * writing to /sys/bus/pci/rescan.
+ * writing to /sys/bus/pci/rescan, deprecated
  */
+XRT_DEPRECATED
 XCL_DRIVER_DLLESPEC
 int
 xclRemoveAndScanFPGA();
@@ -705,7 +711,7 @@ xclGetBOProperties(xclDeviceHandle handle, xclBufferHandle boHandle,
                    struct xclBOProperties *properties);
 
 /*
- * xclGetBOSize() - Retrieve size of a BO
+ * xclGetBOSize() - Retrieve size of a BO, deprecated
  *
  * @handle:        Device handle
  * @boHandle:      BO handle
@@ -723,7 +729,7 @@ xclGetBOSize(xclDeviceHandle handle, xclBufferHandle boHandle)
 }
 
 /*
- * Get the physical address on the device
+ * Get the physical address on the device, deprecated
  *
  * This API is deprecated and will be removed in future release.
  * New clients should use xclGetBOProperties() instead.

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1507,7 +1507,15 @@ int xcldev::xclValidate(int argc, char *argv[])
 
 int xcldev::device::reset(xclResetKind kind)
 {
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     return xclResetDevice(m_handle, kind);
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
+    
 }
 
 static bool canProceed()

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1454,7 +1454,14 @@ public:
             return -EACCES;
         } else {
             int retVal = -1;
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
             retVal = xclBootFPGA(m_handle);
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
             if( retVal == 0 )
             {
                 m_handle = xclOpen( m_idx, nullptr, XCL_QUIET );

--- a/src/runtime_src/core/pcie/user_aws/awssak.h
+++ b/src/runtime_src/core/pcie/user_aws/awssak.h
@@ -47,6 +47,11 @@
 #include "core/common/utils.h"
 #include "core/pcie/common/dd.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #define TO_STRING(x) #x
 //#define AXI_FIREWALL Not supported for AWS
 
@@ -659,5 +664,9 @@ void printHelp(const std::string& exe);
 int xclAwssak(int argc, char *argv[]);
 
 } // end namespace xcldev
+
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #endif /* AWSSAK_H */

--- a/src/runtime_src/core/pcie/user_aws/shim.cpp
+++ b/src/runtime_src/core/pcie/user_aws/shim.cpp
@@ -38,6 +38,11 @@
 #define MMAP_SIZE_USER         0x400000
 #endif
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /* Aligning access to FPGA DRAM space to 4096 Byte */
 //TODO : Should this be pagesize too ?
 #define DDR_BUFFER_ALIGNMENT   0x1000
@@ -1687,3 +1692,6 @@ int xclGetDebugProfileDeviceInfo(xclDeviceHandle handle, xclDebugProfileDeviceIn
   return 0;
 }
 
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Obsoleting the following XRT public APIs from xrt.h. These instead should be private hooks for our tools xbutil/xbmgmt as we do not want any application call these:
a.	xclUpgradeFirmware()
b.	xclUpgradeFirmware2()
c.	xclUpgradeFirmwareXSpi()
d.	xclBootFPGA()
e.	xclRemoveAndScanFPGA()
f.      xclResetDevice()
