### PR TITLE
XRT-458 Code clean up for unify kds

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -11,20 +11,6 @@
 
 extern int kds_echo;
 
-static void cu_hls_wait(void *core)
-{
-	struct xrt_cu_hls *cu_hls = core;
-
-	down_interruptible(&cu_hls->sem);
-}
-
-static void cu_hls_up(void *core)
-{
-	struct xrt_cu_hls *cu_hls = core;
-
-	up(&cu_hls->sem);
-}
-
 static int cu_hls_get_credit(void *core)
 {
 	struct xrt_cu_hls *cu_hls = core;
@@ -112,8 +98,6 @@ static struct xcu_funcs xrt_cu_hls_funcs = {
 	.configure	= cu_hls_configure,
 	.start		= cu_hls_start,
 	.check		= cu_hls_check,
-	.wait		= cu_hls_wait,
-	.up		= cu_hls_up,
 };
 
 int xrt_cu_hls_init(struct xrt_cu *xcu)
@@ -145,7 +129,6 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 
 	core->max_credits = 1;
 	core->credits = core->max_credits;
-	sema_init(&core->sem, core->max_credits);
 
 	xcu->core = core;
 	xcu->funcs = &xrt_cu_hls_funcs;

--- a/src/runtime_src/core/common/drv/cu_plram.c
+++ b/src/runtime_src/core/common/drv/cu_plram.c
@@ -11,20 +11,6 @@
 
 #define ECHO 0
 
-static void cu_plram_wait(void *core)
-{
-	struct xrt_cu_plram *cu_plram = core;
-
-	down_interruptible(&cu_plram->sem);
-}
-
-static void cu_plram_up(void *core)
-{
-	struct xrt_cu_plram *cu_plram = core;
-
-	up(&cu_plram->sem);
-}
-
 static int cu_plram_get_credit(void *core)
 {
 	struct xrt_cu_plram *cu_plram = core;
@@ -93,8 +79,6 @@ static struct xcu_funcs xrt_cu_plram_funcs = {
 	.configure	= cu_plram_configure,
 	.start		= cu_plram_start,
 	.check		= cu_plram_check,
-	.wait		= cu_plram_wait,
-	.up		= cu_plram_up,
 };
 
 int xrt_cu_plram_init(struct xrt_cu *xcu)
@@ -140,7 +124,6 @@ int xrt_cu_plram_init(struct xrt_cu *xcu)
 	xcu_info(xcu, "FIFO depth 0x%x", val);
 	core->max_credits = val;
 	core->credits = core->max_credits;
-	sema_init(&core->sem, core->max_credits);
 
 	/* Set plram base address, this is hard coding */
 	iowrite32(0x00, core->vaddr + 0x20);

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -10,6 +10,8 @@
 #ifndef _KDS_COMMAND_H
 #define _KDS_COMMAND_H
 
+#include "ert.h"
+
 #define REGMAP 0
 #define KEY_VAL 1
 
@@ -33,6 +35,7 @@ struct kds_command;
 
 struct kds_cmd_ops {
 	void (*notify_host)(struct kds_command *xcmd, int status);
+	void (*free)(struct kds_command *xcmd);
 };
 
 /**
@@ -60,5 +63,11 @@ struct kds_command {
 	 */
 	u32			*execbuf;
 };
+
+/* command convert */
+void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
+		   struct kds_command *xcmd);
+void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
+			  struct kds_command *xcmd);
 
 #endif

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -61,4 +61,6 @@ struct kds_command *kds_alloc_command(struct kds_client *client, u32 size);
 int kds_add_command(struct kds_command *xcmd);
 void kds_free_command(struct kds_command *xcmd);
 
+void notify_execbuf(struct kds_command *xcmd, int status);
+
 #endif

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -15,6 +15,8 @@
 #include <linux/semaphore.h>
 #include <linux/spinlock.h>
 #include <linux/io.h>
+#include <linux/kthread.h>
+#include "kds_command.h"
 
 #define MAX_CUS 128
 
@@ -136,6 +138,7 @@ struct xcu_funcs {
 struct xrt_cu_info {
 	u32	model;
 	int	cu_idx;
+	int	inst_idx;
 	u64	addr;
 	u32	protocol;
 	u32	intr_id;
@@ -150,8 +153,6 @@ struct xrt_cu {
 	struct list_head	  sq;
 	u32			  num_sq;
 	struct list_head	  rq;
-	spinlock_t		  rq_lock;
-	u32			  num_rq;
 	struct list_head	  pq;
 	spinlock_t		  pq_lock;
 	struct semaphore	  sem;
@@ -166,20 +167,65 @@ struct xrt_cu {
 	 * Compute unit functions.
 	 */
 	struct xcu_funcs          *funcs;
+	/* TODO: Maybe rethink if we should use two threads,
+	 * one for submit, one for complete
+	 */
+	struct task_struct	  *thread;
 };
 
-int  xrt_cu_get_credit(struct xrt_cu *xcu);
-void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count);
-void xrt_cu_config(struct xrt_cu *xcu, u32 *data, size_t sz, int type);
-void xrt_cu_start(struct xrt_cu *xcu);
-void xrt_cu_check(struct xrt_cu *xcu);
 void xrt_cu_reset(struct xrt_cu *xcu);
 int  xrt_cu_reset_done(struct xrt_cu *xcu);
 void xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type);
 void xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type);
 u32  xrt_cu_clear_intr(struct xrt_cu *xcu);
-void xrt_cu_wait(struct xrt_cu *xcu);
-void xrt_cu_up(struct xrt_cu *xcu);
+
+static inline void xrt_cu_config(struct xrt_cu *xcu, u32 *data, size_t sz, int type)
+{
+	xcu->funcs->configure(xcu->core, data, sz, type);
+}
+
+static inline void xrt_cu_start(struct xrt_cu *xcu)
+{
+	xcu->funcs->start(xcu->core);
+}
+
+static inline void xrt_cu_check(struct xrt_cu *xcu)
+{
+	struct xcu_status status;
+
+	xcu->funcs->check(xcu->core, &status);
+	/* XRT CU assume command finished in order
+	 */
+	xcu->done_cnt += status.num_done;
+	xcu->ready_cnt += status.num_ready;
+}
+
+static inline void xrt_cu_wait(struct xrt_cu *xcu)
+{
+	xcu->funcs->wait(xcu->core);
+}
+
+static inline void xrt_cu_up(struct xrt_cu *xcu)
+{
+	xcu->funcs->up(xcu->core);
+}
+
+static inline int xrt_cu_get_credit(struct xrt_cu *xcu)
+{
+	return xcu->funcs->get_credit(xcu->core);
+}
+
+static inline void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count)
+{
+	xcu->funcs->put_credit(xcu->core, count);
+}
+
+/* 1. Move commands from pending command queue to running queue
+ * 2. If CU is ready, submit command(Configure hardware)
+ * 3. Check if submitted command is completed or not
+ */
+int xrt_cu_thread(void *data);
+void xrt_cu_submit(struct xrt_cu *xcu, struct kds_command *xcmd);
 
 int  xrt_cu_init(struct xrt_cu *xcu);
 void xrt_cu_fini(struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -131,8 +131,6 @@ struct xcu_funcs {
 	 * Clear interrupt.
 	 */
 	u32 (*clear_intr)(void *core);
-	void (* wait)(void *core);
-	void (* up)(void *core);
 };
 
 struct xrt_cu_info {
@@ -200,16 +198,6 @@ static inline void xrt_cu_check(struct xrt_cu *xcu)
 	xcu->ready_cnt += status.num_ready;
 }
 
-static inline void xrt_cu_wait(struct xrt_cu *xcu)
-{
-	xcu->funcs->wait(xcu->core);
-}
-
-static inline void xrt_cu_up(struct xrt_cu *xcu)
-{
-	xcu->funcs->up(xcu->core);
-}
-
 static inline int xrt_cu_get_credit(struct xrt_cu *xcu)
 {
 	return xcu->funcs->get_credit(xcu->core);
@@ -235,7 +223,6 @@ struct xrt_cu_hls {
 	void __iomem		*vaddr;
 	int			 max_credits;
 	int			 credits;
-	struct semaphore	 sem;
 };
 
 int xrt_cu_hls_init(struct xrt_cu *xcu);
@@ -246,7 +233,6 @@ struct xrt_cu_plram {
 	void __iomem		*plram;
 	int			 max_credits;
 	int			 credits;
-	struct semaphore	 sem;
 };
 
 int xrt_cu_plram_init(struct xrt_cu *xcu);

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -17,6 +17,23 @@ struct zocl_cu {
 	struct platform_device	*pdev;
 };
 
+static int cu_submit(struct platform_device *pdev, struct kds_command *xcmd)
+{
+	struct zocl_cu *xcu = platform_get_drvdata(pdev);
+
+	xrt_cu_submit(&xcu->base, xcmd);
+
+	return 0;
+}
+
+static struct zocl_cu_ops cu_ops = {
+	.submit = &cu_submit,
+};
+
+static struct zocl_drv_private cu_priv = {
+	.ops = &cu_ops,
+};
+
 static int cu_probe(struct platform_device *pdev)
 {
 	struct zocl_cu *zcu;
@@ -111,7 +128,7 @@ static int cu_remove(struct platform_device *pdev)
 }
 
 static struct platform_device_id cu_id_table[] = {
-	{"CU", 0},
+	{"CU", (kernel_ulong_t)&cu_priv},
 	{ },
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -105,6 +105,10 @@ struct drm_zocl_exec_metadata {
 	unsigned int                index;
 };
 
+struct zocl_drv_private {
+	void		       *ops;
+};
+
 struct drm_zocl_bo {
 	union {
 		struct drm_gem_cma_object       cma_base;
@@ -212,5 +216,21 @@ int subdev_create_cu(struct drm_zocl_dev *zdev, struct xrt_cu_info *info);
 void subdev_destroy_cu(struct drm_zocl_dev *zdev);
 /* Sub device driver */
 extern struct platform_driver cu_driver;
+struct zocl_cu_ops {
+	int (*submit)(struct platform_device *pdev, struct kds_command *xcmd);
+};
+
+static inline int
+zocl_cu_submit_xcmd(struct drm_zocl_dev *zdev, int i, struct kds_command *xcmd)
+{
+	struct platform_device *pdev;
+	struct zocl_drv_private *priv;
+	struct zocl_cu_ops *ops;
+
+	pdev = zdev->cu_pldev[i];
+	priv = (void *)platform_get_device_id(pdev)->driver_data;
+	ops = (struct zocl_cu_ops *)priv->ops;
+	return ops->submit(pdev, xcmd);
+}
 
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -120,7 +120,6 @@ struct drm_zocl_dev {
 
 	struct kds_sched	 kds;
 	struct platform_device	*cu_pldev[MAX_CU_NUM];
-	unsigned int		 num_pldev;
 
 	/*
 	 * This RW lock is to protect the sysfs nodes exported

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
@@ -9,8 +9,6 @@
  * License version 2 or Apache License, Version 2.0.
  */
 
-#include <linux/kthread.h>
-
 #include "zocl_drv.h"
 #include "kds_core.h"
 #include "xrt_cu.h"
@@ -19,112 +17,9 @@ struct zocl_cu_ctrl {
 	struct kds_controller    core;
 	struct drm_zocl_dev	*zdev;
 	struct xrt_cu		*xcus[MAX_CUS];
-	/* TODO: Maybe rethink if we should use two threads,
-	 * one for submit, one for complete
-	 */
-	struct task_struct     **threads;
 	int			 num_cus;
 
 };
-
-static inline void process_sq_once(struct xrt_cu *xcu)
-{
-	struct list_head *q;
-	struct kds_command *done_xcmd;
-
-	/* This is the critical path, as less check as possible..
-	 * if rq and sq both are empty, please DO NOT call this function
-	 */
-
-	q = list_empty(&xcu->sq) ? &xcu->rq : &xcu->sq;
-
-	xrt_cu_check(xcu);
-	xrt_cu_put_credit(xcu, xcu->ready_cnt);
-	xcu->ready_cnt = 0;
-	if (!xcu->done_cnt)
-		return;
-
-	done_xcmd = list_first_entry_or_null(q, struct kds_command, list);
-	done_xcmd->cb.notify_host(done_xcmd, KDS_COMPLETED);
-	list_del(&done_xcmd->list);
-	kds_free_command(done_xcmd);
-	--xcu->done_cnt;
-}
-
-static inline void process_rq(struct xrt_cu *xcu)
-{
-	struct kds_command *xcmd;
-	struct kds_command *last_xcmd;
-
-	/* This function would not return until rq is empty */
-	xcmd = list_first_entry_or_null(&xcu->rq, struct kds_command, list);
-	last_xcmd = list_last_entry(&xcu->rq, struct kds_command, list);
-
-	while (xcmd) {
-		if (xrt_cu_get_credit(xcu)) {
-			/* if successfully get credit, you must start cu */
-			xrt_cu_config(xcu, (u32 *)xcmd->info, xcmd->isize, 0);
-			xrt_cu_start(xcu);
-			/* xcmd should always point to next waiting
-			 * to submit command
-			 */
-			if (xcmd != last_xcmd)
-				xcmd = list_next_entry(xcmd, list);
-			else
-				xcmd = NULL;
-		} else {
-			/* Run out of credit and still have xcmd in rq.
-			 * In this case, only do wait one more command done.
-			 */
-			process_sq_once(xcu);
-		}
-	}
-
-	/* Some commands maybe not completed
-	 * or they are completed but haven't beed processed
-	 * Do not wait, get pending command first.
-	 */
-	if (!list_empty(&xcu->rq))
-		list_splice_tail_init(&xcu->rq, &xcu->sq);
-}
-
-static int cu_ctrl_thread(void *data)
-{
-	struct xrt_cu *xcu = (struct xrt_cu *)data;
-	unsigned long flags;
-
-	/* The CU is not able to interrupt host
-	 * this thread has to poll CU status, so
-	 * let me do everything in a busy loop...
-	 */
-	while (1) {
-		spin_lock_irqsave(&xcu->pq_lock, flags);
-		if (xcu->num_pq > 0) {
-			list_splice_tail_init(&xcu->pq, &xcu->rq);
-			xcu->num_pq = 0;
-		}
-		spin_unlock_irqrestore(&xcu->pq_lock, flags);
-
-		/* Do not change the priority! */
-		if (!list_empty(&xcu->rq)) {
-			/* No matter if sq is emptey or not */
-			process_rq(xcu);
-		} else if (!list_empty(&xcu->sq)) {
-			process_sq_once(xcu);
-		} else {
-			/* TODO: looks like the timeout would impact IOPS
-			 * maybe it depends on the system?
-			 */
-			while (down_timeout(&xcu->sem, 1000) == -ETIME) {
-				if (kthread_should_stop())
-					return 0;
-			}
-			/* Something interesting happened */
-		}
-	}
-
-	return 0;
-}
 
 static int get_cu_by_addr(struct zocl_cu_ctrl *zcuc, u32 addr)
 {
@@ -145,40 +40,6 @@ static inline int cu_mask_to_cu_idx(struct kds_command *xcmd)
 
 	/* assume there is alwasy one CU */
 	return 0;
-}
-
-static inline void stop_all_threads(struct zocl_cu_ctrl *zcuc)
-{
-	int i;
-
-	for (i = 0; i < zcuc->num_cus; ++i) {
-		if (zcuc->threads[i] != NULL) {
-			kthread_stop(zcuc->threads[i]);
-			zcuc->threads[i] = NULL;
-		}
-	}
-}
-
-static inline int launch_all_threads(struct zocl_cu_ctrl *zcuc)
-{
-	int i, err = 0;
-
-	/* only launch one thread, it should be one thread per CU */
-	for (i = 0; i < 1; ++i) {
-		zcuc->threads[i] = kthread_run(cu_ctrl_thread,
-					       (void *)zcuc->xcus[i],
-					       "xcu_thread");
-		if (IS_ERR(zcuc->threads[i])) {
-			err = PTR_ERR(zcuc->threads[i]);
-			zcuc->threads[i] = NULL;
-			goto error;
-		}
-	}
-	return 0;
-
-error:
-	stop_all_threads(zcuc);
-	return err;
 }
 
 static void
@@ -208,8 +69,8 @@ cu_ctrl_config(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 		}
 		zcuc->xcus[i]->info.cu_idx = i;
 
-		/* To let aperture work. This should be remove later..
-		 * TODO: replace aperture list
+		/* TODO: replace aperture list. Before that, keep this to make
+		 * aperture work.
 		 */
 		apt_idx = get_apt_index_by_addr(zcuc->zdev, cus_addr[i]);
 		if (apt_idx < 0) {
@@ -220,43 +81,26 @@ cu_ctrl_config(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 		update_cu_idx_in_apt(zcuc->zdev, apt_idx, i);
 	}
 
-	/* TODO: Only at this time, the CU index was known.
-	 * this is why I launch threads in this place.
-	 * But really need to rethink it later...
-	 */
-	if (zcuc->threads) {
-		stop_all_threads(zcuc);
-		vfree(zcuc->threads);
-	}
-
-	zcuc->threads = vzalloc(sizeof(*zcuc->threads) * zcuc->num_cus);
-	launch_all_threads(zcuc);
-
 	/* TODO: Does it need a queue for configure commands? */
 	xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-	kds_free_command(xcmd);
+	xcmd->cb.free(xcmd);
 	return;
 
 error:
 	xcmd->cb.notify_host(xcmd, KDS_ERROR);
-	kds_free_command(xcmd);
+	xcmd->cb.free(xcmd);
 }
 
 static void
 cu_ctrl_dispatch(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 {
-	unsigned long flags;
 	int cu_idx;
+	int inst_idx;
 
 	/* Select CU */
 	cu_idx = cu_mask_to_cu_idx(xcmd);
-
-	spin_lock_irqsave(&zcuc->xcus[cu_idx]->pq_lock, flags);
-	list_add_tail(&xcmd->list, &zcuc->xcus[cu_idx]->pq);
-	if (zcuc->xcus[cu_idx]->num_pq == 0)
-		up(&zcuc->xcus[cu_idx]->sem);
-	++zcuc->xcus[cu_idx]->num_pq;
-	spin_unlock_irqrestore(&zcuc->xcus[cu_idx]->pq_lock, flags);
+	inst_idx = zcuc->xcus[cu_idx]->info.inst_idx;
+	(void) zocl_cu_submit_xcmd(zcuc->zdev, inst_idx, xcmd);
 }
 
 static void
@@ -316,12 +160,6 @@ int cu_ctrl_remove_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 		if (zcuc->xcus[i] != xcu)
 			continue;
 
-		/* Maybe the thread is running */
-		if (zcuc->threads && zcuc->threads[i]) {
-			kthread_stop(zcuc->threads[i]);
-			zcuc->threads[i] = NULL;
-		}
-
 		zcuc->xcus[i] = NULL;
 		--zcuc->num_cus;
 		break;
@@ -359,11 +197,6 @@ void cu_ctrl_fini(struct drm_zocl_dev *zdev)
 	zcuc = (struct zocl_cu_ctrl *)zocl_kds_getctrl(zdev, KDS_CU);
 	if (!zcuc)
 		return;
-
-	if (zcuc->threads) {
-		stop_all_threads(zcuc);
-		vfree(zcuc->threads);
-	}
 
 	kfree(zcuc);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -261,8 +261,7 @@ int subdev_create_cu(struct drm_zocl_dev *zdev, struct xrt_cu_info *info)
 		DRM_ERROR("Failed to probe device\n");
 		goto err1;
 	}
-	zdev->cu_pldev[zdev->num_pldev] = pldev;
-	zdev->num_pldev++;
+	zdev->cu_pldev[info->inst_idx] = pldev;
 
 	return 0;
 err1:
@@ -276,15 +275,13 @@ void subdev_destroy_cu(struct drm_zocl_dev *zdev)
 {
 	int i;
 
-	if (!zdev->num_pldev)
-		return;
-
-	for (i = 0; i < zdev->num_pldev; ++i) {
+	for (i = 0; i < MAX_CU_NUM; ++i) {
+		if (!zdev->cu_pldev[i])
+			continue;
 		platform_device_del(zdev->cu_pldev[i]);
 		platform_device_put(zdev->cu_pldev[i]);
 		zdev->cu_pldev[i] = NULL;
 	}
-	zdev->num_pldev = 0;
 }
 
 /**
@@ -916,8 +913,6 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	if (ret)
 		goto err_drm;
 	mutex_init(&zdev->zdev_xclbin_lock);
-
-	zdev->num_pldev = 0;
 
 	/* doen with zdev initialization */
 	drm->dev_private = zdev;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -24,52 +24,6 @@ module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_echo,
 		 "enable KDS echo (0 = disable (default), 1 = enable)");
 
-static void notify_execbuf(struct kds_command *xcmd, int status)
-{
-	struct kds_client *client = xcmd->client;
-	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
-
-	if (status == KDS_COMPLETED)
-		ecmd->state = ERT_CMD_STATE_COMPLETED;
-	else if (status == KDS_ERROR)
-		ecmd->state = ERT_CMD_STATE_ERROR;
-
-	atomic_inc(&client->event);
-	wake_up_interruptible(&client->waitq);
-}
-
-static inline void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
-				 struct kds_command *xcmd)
-{
-	xcmd->type = KDS_CU;
-	xcmd->opcode = OP_CONFIG_CTRL;
-
-	xcmd->cb.notify_host = notify_execbuf;
-	xcmd->execbuf = (u32 *)ecmd;
-
-	xcmd->isize = ecmd->num_cus * sizeof(u32);
-	/* Expect a ordered list of CU address */
-	memcpy(xcmd->info, ecmd->data, xcmd->isize);
-}
-
-static inline void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
-					struct kds_command *xcmd)
-{
-	xcmd->type = KDS_CU;
-	xcmd->opcode = OP_START;
-
-	xcmd->cb.notify_host = notify_execbuf;
-	xcmd->execbuf = (u32 *)ecmd;
-
-	xcmd->cu_mask[0] = ecmd->cu_mask;
-	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
-	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
-
-	/* Skip first 4 control registers */
-	xcmd->isize = (ecmd->count - xcmd->num_mask - 4) * sizeof(u32);
-	memcpy(xcmd->info, &ecmd->data[4], xcmd->isize);
-}
-
 int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp)
 {
@@ -105,6 +59,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		ret = -ENOMEM;
 		goto out;
 	}
+	xcmd->cb.free = kds_free_command;
 
 	/* TODO: one ecmd to one xcmd now. Maybe we will need
 	 * one ecmd to multiple xcmds
@@ -136,9 +91,6 @@ uint zocl_poll_client(struct file *filp, poll_table *wait)
 	if (event == -1)
 		return 0;
 
-	/* If only return POLLIN, I could get 100K IOPS more.
-	 * With above wait, the IOPS is more unstable (+/-100K).
-	 */
 	return POLLIN;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -545,6 +545,7 @@ zocl_create_cu(struct drm_zocl_dev *zdev)
 		 * driver known by configure command
 		 */
 		info.cu_idx = -1;
+		info.inst_idx = i;
 
 		/* CU sub device is a virtual device, which means there is no
 		 * device tree nodes

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -22,6 +22,15 @@ struct xocl_cu {
 	struct platform_device	*pdev;
 };
 
+static int cu_submit(struct platform_device *pdev, struct kds_command *xcmd)
+{
+	struct xocl_cu *xcu = platform_get_drvdata(pdev);
+
+	xrt_cu_submit(&xcu->base, xcmd);
+
+	return 0;
+}
+
 static int cu_probe(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -127,8 +136,16 @@ static int cu_remove(struct platform_device *pdev)
 	return 0;
 }
 
+static struct xocl_cu_funcs cu_ops = {
+	.submit	= cu_submit,
+};
+
+static struct xocl_drv_private cu_priv = {
+	.ops = &cu_ops,
+};
+
 static struct platform_device_id cu_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_CU), 0 },
+	{ XOCL_DEVNAME(XOCL_CU), (kernel_ulong_t)&cu_priv },
 	{ },
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
@@ -7,8 +7,6 @@
  * Authors: min.ma@xilinx.com
  */
 
-#include <linux/kthread.h>
-
 #include "xocl_drv.h"
 #include "kds_core.h"
 #include "xrt_cu.h"
@@ -24,264 +22,9 @@ struct xocl_cu_ctrl {
 	struct kds_controller    core;
 	struct platform_device	*pdev;
 	struct xrt_cu		*xcus[MAX_CUS];
-	/* TODO: Maybe rethink if we should use two threads,
-	 * one for submit, one for complete
-	 */
-	struct task_struct     **threads;
 	int			 num_cus;
 
 };
-
-#define Test_A_0 0
-#define Test_A_1 1
-#define Test_A_2 0
-#define Test_B 0
-
-#if Test_A_0
-static int cu_ctrl_thread(void *data)
-{
-	struct xrt_cu *xcu = (struct xrt_cu *)data;
-	struct kds_command *xcmd = NULL;
-	unsigned long flags;
-	u32 loop_cnt = 0;
-	int i;
-
-	/* The CU is not able to interrupt host
-	 * this thread has to poll CU status, so
-	 * let me do everything in a busy loop...
-	 */
-	while (!kthread_should_stop()) {
-		spin_lock_irqsave(&xcu->pq_lock, flags);
-		xcmd = list_first_entry_or_null(&xcu->pq, struct kds_command, list);
-		spin_unlock_irqrestore(&xcu->pq_lock, flags);
-
-		if (xcmd) {
-			/* submit one command */
-			if (xrt_cu_get_credit(xcu)) {
-				/* if successfully get credit, you must start cu */
-				xrt_cu_config(xcu, (u32 *)xcmd->info, xcmd->isize, 0);
-				xrt_cu_start(xcu);
-				/* Move pending command to run queue */
-				spin_lock_irqsave(&xcu->pq_lock, flags);
-				list_move_tail(&xcmd->list, &xcu->rq);
-				--xcu->num_pq;
-				spin_unlock_irqrestore(&xcu->pq_lock, flags);
-			}
-		}
-
-		if (list_empty(&xcu->rq)) {
-			/* This also impact the IOPS (about 30K) */
-			++loop_cnt;
-			if (!(loop_cnt & 0x0F))
-				schedule();
-			continue;
-		}
-
-		xrt_cu_check(xcu);
-		xrt_cu_put_credit(xcu, xcu->ready_cnt);
-		xcu->ready_cnt = 0;
-
-		if (!xcu->done_cnt)
-			continue;
-
-		for (i = 0; i < xcu->done_cnt; ++i) {
-			xcmd = list_first_entry_or_null(&xcu->rq, struct kds_command, list);
-			xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-			list_del(&xcmd->list);
-			kds_free_command(xcmd);
-		}
-
-		xcu->done_cnt = 0;
-	}
-
-	return 0;
-}
-#endif
-
-#if Test_A_1
-static inline void process_sq_once(struct xrt_cu *xcu)
-{
-	struct list_head *q;
-	struct kds_command *done_xcmd;
-
-	/* This is the critical path, as less check as possible..
-	 * if rq and sq both are empty, please DO NOT call this function
-	 */
-
-	q = list_empty(&xcu->sq) ? &xcu->rq : & xcu->sq;
-
-	xrt_cu_check(xcu);
-	xrt_cu_put_credit(xcu, xcu->ready_cnt);
-	xcu->ready_cnt = 0;
-	if (!xcu->done_cnt)
-		return;
-
-	done_xcmd = list_first_entry_or_null(q, struct kds_command, list);
-	done_xcmd->cb.notify_host(done_xcmd, KDS_COMPLETED);
-	list_del(&done_xcmd->list);
-	kds_free_command(done_xcmd);
-	--xcu->done_cnt;
-}
-
-static inline void process_rq(struct xrt_cu *xcu)
-{
-	struct kds_command *xcmd;
-	struct kds_command *last_xcmd;
-
-	/* This funtion would not return until rq is empty */
-	xcmd = list_first_entry_or_null(&xcu->rq, struct kds_command, list);
-	last_xcmd = list_last_entry(&xcu->rq, struct kds_command, list);
-
-	while (xcmd) {
-		if (xrt_cu_get_credit(xcu)) {
-			/* if successfully get credit, you must start cu */
-			xrt_cu_config(xcu, (u32 *)xcmd->info, xcmd->isize, 0);
-			xrt_cu_start(xcu);
-			/* xcmd should always point to next waiting
-			 * to submit command
-			 */
-			if (xcmd != last_xcmd)
-				xcmd = list_next_entry(xcmd, list);
-			else
-				xcmd = NULL;
-		} else {
-			/* Run out of credit and still have xcmd in rq.
-			 * In this case, only do wait one more command done.
-			 */
-			process_sq_once(xcu);
-		}
-	}
-
-	/* Some commands maybe not completed
-	 * or they are completed but haven't beed processed
-	 * Do not wait, get pending command first.
-	 */
-	if (!list_empty(&xcu->rq))
-		list_splice_tail_init(&xcu->rq, &xcu->sq);
-}
-
-static int cu_ctrl_thread(void *data)
-{
-	struct xrt_cu *xcu = (struct xrt_cu *)data;
-	unsigned long flags;
-
-	/* The CU is not able to interrupt host
-	 * this thread has to poll CU status, so
-	 * let me do everything in a busy loop...
-	 */
-	while (1) {
-		spin_lock_irqsave(&xcu->pq_lock, flags);
-		if (xcu->num_pq > 0) {
-			list_splice_tail_init(&xcu->pq, &xcu->rq);
-			xcu->num_pq = 0;
-		}
-		spin_unlock_irqrestore(&xcu->pq_lock, flags);
-
-		/* Do not change the priority! */
-		if(!list_empty(&xcu->rq)) {
-			/* No matter if sq is emptey or not */
-			process_rq(xcu);
-		} else if (!list_empty(&xcu->sq)) {
-			process_sq_once(xcu);
-		} else {
-			/* TODO: looks like the timeout would impact IOPS
-			 * maybe it depends on the system?
-			 */
-			while (down_timeout(&xcu->sem, 1000) == -ETIME) {
-				if (kthread_should_stop())
-					return 0;
-			}
-			/* Something interesting happened */
-		}
-	}
-
-	return 0;
-}
-#endif
-
-#if Test_A_2
-static int cu_ctrl_thread(void *data)
-{
-	struct xrt_cu *xcu = (struct xrt_cu *)data;
-	struct kds_command *done_xcmd;
-	unsigned long flags;
-
-	/* The CU is not able to interrupt host
-	 * this thread has to poll CU status, so
-	 * let me do everything in a busy loop...
-	 */
-	while (1) {
-		spin_lock_irqsave(&xcu->pq_lock, flags);
-		if (xcu->num_pq > 0) {
-			list_splice_tail_init(&xcu->pq, &xcu->rq);
-			xcu->num_pq = 0;
-		}
-		spin_unlock_irqrestore(&xcu->pq_lock, flags);
-
-		while (!list_empty(&xcu->rq)) {
-			done_xcmd = list_first_entry(&xcu->rq, struct kds_command, list);
-			done_xcmd->cb.notify_host(done_xcmd, KDS_COMPLETED);
-			list_del(&done_xcmd->list);
-			kds_free_command(done_xcmd);
-		}
-
-		while (down_timeout(&xcu->sem, 1000) == -ETIME) {
-			if (kthread_should_stop())
-				return 0;
-		}
-		/* Something interesting happened */
-	}
-
-	return 0;
-}
-#endif
-
-#if Test_B
-static int cu_ctrl_thread(void *data)
-{
-	struct xrt_cu *xcu = (struct xrt_cu *)data;
-	struct kds_command *xcmd;
-	unsigned long flags;
-	u32 loop_cnt = 0;
-
-	/* The CU is not able to interrupt host
-	 * this thread has to poll CU status, so
-	 * let me do everything in a busy loop...
-	 */
-	while (!kthread_should_stop()) {
-		spin_lock_irqsave(&xcu->rq_lock, flags);
-		xcmd = list_first_entry_or_null(&xcu->rq, struct kds_command, list);
-		spin_unlock_irqrestore(&xcu->rq_lock, flags);
-
-		if (xcmd != 0) {
-			xrt_cu_check(xcu);
-			xrt_cu_put_credit(xcu, xcu->ready_cnt);
-			while (xcu->ready_cnt) {
-				xrt_cu_up(xcu);
-				--xcu->ready_cnt;
-			}
-
-			if (!xcu->done_cnt)
-				continue;
-
-			/* now we have at least one command finished */
-			xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-			spin_lock_irqsave(&xcu->rq_lock, flags);
-			list_del(&xcmd->list);
-			spin_unlock_irqrestore(&xcu->rq_lock, flags);
-			kds_free_command(xcmd);
-			--xcu->done_cnt;
-		}
-
-		/* This also impact the IOPS a little bit (about 30K) */
-		++loop_cnt;
-		if (!(loop_cnt & 0x0F))
-			schedule();
-	}
-
-	return 0;
-}
-#endif
 
 static int get_cu_by_addr(struct xocl_cu_ctrl *xcuc, u32 addr)
 {
@@ -302,42 +45,6 @@ static inline int cu_mask_to_cu_idx(struct kds_command *xcmd)
 
 	/* assume there is alwasy one CU */
 	return 0;
-}
-
-static inline void stop_all_threads(struct xocl_cu_ctrl *xcuc)
-{
-	int i;
-
-	for (i = 0; i < xcuc->num_cus; ++i) {
-		if (xcuc->threads[i] != NULL) {
-			kthread_stop(xcuc->threads[i]);
-			//xcu->xcus[i]->stop = 1;
-			xcuc->threads[i] = NULL;
-		}
-	}
-}
-
-static inline int launch_all_threads(struct xocl_cu_ctrl *xcuc)
-{
-	int i, err = 0;
-
-	//for (i = 0; i < xcuc->num_cus; ++i) {
-	/* only launch one thread, it should be one thread per CU */
-	for (i = 0; i < 1; ++i) {
-		xcuc->threads[i] = kthread_run(cu_ctrl_thread,
-					       (void *)xcuc->xcus[i],
-					       "xcu_thread");
-		if (IS_ERR(xcuc->threads[i])) {
-			err = PTR_ERR(xcuc->threads[i]);
-			xcuc->threads[i] = NULL;
-			goto error;
-		}
-	}
-	return 0;
-
-error:
-	stop_all_threads(xcuc);
-	return err;
 }
 
 static void cu_ctrl_config(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
@@ -366,32 +73,21 @@ static void cu_ctrl_config(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
 		xcuc->xcus[i]->info.cu_idx = i;
 	}
 
-	/* TODO: Only at this time, the CU index was known.
-	 * this is why I launch threads in this place.
-	 * But really need to rethink it later...
-	 */
-	if (xcuc->threads) {
-		stop_all_threads(xcuc);
-		vfree(xcuc->threads);
-	}
-
-	xcuc->threads = vzalloc(sizeof(*xcuc->threads) * xcuc->num_cus);
-	launch_all_threads(xcuc);
-
 	/* TODO: Does it need a queue for configure commands? */
 	xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-	kds_free_command(xcmd);
+	xcmd->cb.free(xcmd);
 	return;
 
 error:
 	xcmd->cb.notify_host(xcmd, KDS_ERROR);
-	kds_free_command(xcmd);
+	xcmd->cb.free(xcmd);
 }
 
 static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
 {
-	unsigned long flags;
+	xdev_handle_t xdev = xocl_get_xdev(xcuc->pdev);
 	int cu_idx;
+	int inst_idx;
 
 	/* Select CU */
 	cu_idx = cu_mask_to_cu_idx(xcmd);
@@ -401,70 +97,11 @@ static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd
 	 * could produce a CU task.
 	 */
 	//xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-	//kds_free_command(xcmd);
+	//xcmd->cb.free(xcmd);
+	//return;
 
-#if 0
-	/* about 160K IOPS...
-	 * This let execbuf becomes a blocking call...
-	 * Start CU, wait CU done, return.
-	 */
-	//xrt_cu_wait(xcuc->xcus[cu_idx]);
-
-	/* start CU */
-	xrt_cu_config(xcuc->xcus[cu_idx], (u32 *)xcmd->info, xcmd->isize, 0);
-	xrt_cu_start(xcuc->xcus[cu_idx]);
-
-	while(1) {
-		xrt_cu_check(xcuc->xcus[cu_idx]);
-		if (!xcuc->xcus[cu_idx]->done_cnt)
-			continue;
-
-		xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-		kds_free_command(xcmd);
-		--xcuc->xcus[cu_idx]->done_cnt;
-		--xcuc->xcus[cu_idx]->ready_cnt;
-		//xrt_cu_up(xcu);
-		break;
-	}
-#endif
-
-#if Test_A_0
-	/* about 500K IOPS with "Test_A_0 echo" */
-	/* about 400K IOPS with "Test_A_0" */
-	spin_lock_irqsave(&xcuc->xcus[cu_idx]->pq_lock, flags);
-	list_add_tail(&xcmd->list, &xcuc->xcus[cu_idx]->pq);
-	spin_unlock_irqrestore(&xcuc->xcus[cu_idx]->pq_lock, flags);
-#endif
-
-#if Test_A_1 || Test_A_2
-	/* about 550K IOPS with "Test_A_1 echo" */
-	/* about 500K IOPS with "Test_A_1" */
-	/* about 550K IOPS with "Test_A_2" w/wo echo */
-	spin_lock_irqsave(&xcuc->xcus[cu_idx]->pq_lock, flags);
-	list_add_tail(&xcmd->list, &xcuc->xcus[cu_idx]->pq);
-	if (xcuc->xcus[cu_idx]->num_pq == 0)
-		up(&xcuc->xcus[cu_idx]->sem);
-	++xcuc->xcus[cu_idx]->num_pq;
-	spin_unlock_irqrestore(&xcuc->xcus[cu_idx]->pq_lock, flags);
-#endif
-
-#if Test_B
-	/* This approach is starting CU at this thread,
-	 * Then add xcmd to CU's run queue to wait for complete
-	 */
-
-	/* about 420K IOPS with "Test_B echo*/
-	xrt_cu_wait(xcuc->xcus[cu_idx]);
-	xrt_cu_get_credit(xcuc->xcus[cu_idx]);
-
-	/* start CU */
-	xrt_cu_config(xcuc->xcus[cu_idx], (u32 *)xcmd->info, xcmd->isize, 0);
-	xrt_cu_start(xcuc->xcus[cu_idx]);
-
-	spin_lock_irqsave(&xcuc->xcus[cu_idx]->rq_lock, flags);
-	list_add_tail(&xcmd->list, &xcuc->xcus[cu_idx]->rq);
-	spin_unlock_irqrestore(&xcuc->xcus[cu_idx]->rq_lock, flags);
-#endif
+	inst_idx = xcuc->xcus[cu_idx]->info.inst_idx;
+	(void) xocl_cu_submit_xcmd(xdev, inst_idx, xcmd);
 }
 
 static void cu_ctrl_submit(struct kds_controller *ctrl, struct kds_command *xcmd)
@@ -500,10 +137,6 @@ static int cu_ctrl_add_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 		return -ENOSPC;
 	}
 
-	/* TODO: maybe we should launch a thread when a CU was added
-	 * but at this time, we don't know how many threads will be..
-	 */
-
 	return 0;
 }
 
@@ -521,12 +154,6 @@ static int cu_ctrl_remove_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 	for (i = 0; i < MAX_CUS; i++) {
 		if (xcuc->xcus[i] != xcu)
 			continue;
-
-		/* Maybe the thread is running */
-		if (xcuc->threads && xcuc->threads[i]) {
-			ret = kthread_stop(xcuc->threads[i]);
-			xcuc->threads[i] = NULL;
-		}
 
 		xcuc->xcus[i] = NULL;
 		--xcuc->num_cus;
@@ -572,11 +199,6 @@ static int cu_ctrl_remove(struct platform_device *pdev)
 	xcuc = platform_get_drvdata(pdev);
 	if (!xcuc)
 		return -EINVAL;
-
-	if (xcuc->threads) {
-		stop_all_threads(xcuc);
-		vfree(xcuc->threads);
-	}
 
 	xocl_drvinst_release(xcuc, &hdl);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1759,6 +1759,8 @@ static int icap_create_cu(struct platform_device *pdev)
 		if (ip->m_base_address == 0xFFFFFFFF)
 			continue;
 
+		/* NOTE: Only support 64 instences in subdev framework */
+
 		/* TODO: use HLS CU as default.
 		 * don't know how to distinguish plram CU and normal CU
 		 */
@@ -1767,9 +1769,10 @@ static int icap_create_cu(struct platform_device *pdev)
 
 		/* TODO: Consider where should we determine CU index in
 		 * the driver.. Right now, user space determine it and let
-		 * driver known by configure command
+		 * driver known by configure command.
 		 */
 		info.cu_idx = -1;
+		info.inst_idx = i;
 		info.addr = ip->m_base_address;
 		info.intr_enable = ip->properties & IP_INT_ENABLE_MASK;
 		info.protocol = (ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT;
@@ -1779,6 +1782,7 @@ static int icap_create_cu(struct platform_device *pdev)
 		subdev_info.res[0].end += ip->m_base_address;
 		subdev_info.priv_data = &info;
 		subdev_info.data_len = sizeof(info);
+		subdev_info.override_idx = info.inst_idx;
 		err = xocl_subdev_create(xdev, &subdev_info);
 		if (err) {
 			//ICAP_ERR(icap, "can't create CU subdev");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1430,6 +1430,21 @@ struct xocl_kds_ctrl_funcs {
 	(CU_CTRL_CB(xdev, remove_cu)? \
 	 CU_CTRL_OPS(xdev)->remove_cu(CU_CTRL_DEV(xdev), xcu) : 0)
 
+/* CU callback */
+struct xocl_cu_funcs {
+	struct xocl_subdev_funcs common_funcs;
+	int (* submit)(struct platform_device *pdev, struct kds_command *xcmd);
+};
+#define CU_DEV(xdev, idx) \
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx).pldev
+#define CU_OPS(xdev, idx) \
+	((struct xocl_cu_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx).ops)
+#define CU_CB(xdev, idx, cb) \
+	(CU_DEV(xdev, idx) && CU_OPS(xdev, idx) && CU_OPS(xdev, idx)->cb)
+#define xocl_cu_submit_xcmd(xdev, idx, xcmd) \
+	(CU_CB(xdev, idx, submit)? \
+	 CU_OPS(xdev, idx)->submit(CU_DEV(xdev, idx), xcmd) : -ENXIO)
+
 /* helper functions */
 xdev_handle_t xocl_get_xdev(struct platform_device *pdev);
 void xocl_init_dsa_priv(xdev_handle_t xdev_hdl);


### PR DESCRIPTION
1. Move threads which directly control CU from CU controller to xrt_cu.c
    - The threads are the same on xocl/zocl, xrt_cu.c is a good place
    - A CU sub-device should provide the best way to control it
2. Add submit() API in CU subdevice on both xocl/zocl
    - Other sub-devices, like CU controller, should submit xcmd via this API
