### PR TITLE
CR-1062816 ASTeR - Validate fails on an IBM server with Redhat 7.6 for a u50 and u50lv

### DIFF
--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -33,7 +33,6 @@ def runKernel(opt):
 
     rule = re.compile("hello*")
     name = list(filter(lambda val: rule.match, opt.kernels))[0]
-    # import pdb; pdb.set_trace()
     khandle = xrtPLKernelOpen(opt.handle, opt.xuuid, name)
 
     boHandle1 = xclAllocBO(opt.handle, opt.DATA_SIZE, 0, opt.first_mem)

--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -32,7 +32,8 @@ from utils_binding import *
 def runKernel(opt):
 
     rule = re.compile("hello*")
-    name = filter(rule.match, opt.kernels)[0]
+    name = list(filter(lambda val: rule.match, opt.kernels))[0]
+    # import pdb; pdb.set_trace()
     khandle = xrtPLKernelOpen(opt.handle, opt.xuuid, name)
 
     boHandle1 = xclAllocBO(opt.handle, opt.DATA_SIZE, 0, opt.first_mem)
@@ -64,9 +65,8 @@ def runKernel(opt):
     result2 = bo2[:len("Hello World")]
     print("Result string = [%s]" % result1.decode("utf-8"))
     print("Result string = [%s]" % result2.decode("utf-8"))
-
-    assert(result1 == "Hello World"), "Incorrect output from kernel"
-    assert(result2 == "Hello World"), "Incorrect output from kernel"
+    assert(result1.decode("utf-8") == "Hello World"), "Incorrect output from kernel"
+    assert(result2.decode("utf-8") == "Hello World"), "Incorrect output from kernel"
 
     xrtRunClose(rhandle2)
     xrtRunClose(rhandle1)

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -99,7 +99,7 @@ def initXRT(opt):
     if opt.index >= xclProbe():
         raise RuntimeError("Incorrect device index")
 
-    opt.handle = xclOpen(opt.index, "", xclVerbosityLevel.XCL_INFO)
+    opt.handle = xclOpen(opt.index, None, xclVerbosityLevel.XCL_INFO)
 
     xclGetDeviceInfo2(opt.handle, ctypes.byref(deviceInfo))
 


### PR DESCRIPTION
validate now works with python2 and python3