### PR TITLE
CR-1041924 Adding timeout support for clPollStream in emulation

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -77,6 +77,7 @@ namespace xclemulation{
     mLegacyErt = ERTMODE::NONE;
     mCuBaseAddrForce=-1;
     mIsSharedFmodel=true;
+    mTimeOutScale=TIMEOUT_SCALE::NA;
   }
 
   static bool getBoolValue(std::string& value,bool defaultValue)
@@ -276,6 +277,16 @@ namespace xclemulation{
           setLegacyErt(ERTMODE::LEGACY);
       } else if (name=="cu_base_addr_force") {
           mCuBaseAddrForce= strtoll(value.c_str(),NULL,0);
+      } else if (name == "timeout_scale") {
+      	  if (boost::iequals(value,"ms")) {
+      		mTimeOutScale=TIMEOUT_SCALE::MS;
+      	  } else if (boost::iequals(value,"sec")) {
+    		  mTimeOutScale=TIMEOUT_SCALE::SEC;
+    	  } else if (boost::iequals(value,"min")) {
+    		  mTimeOutScale=TIMEOUT_SCALE::MIN;
+    	  } else {
+    		  mTimeOutScale=TIMEOUT_SCALE::NA;
+    	  }
       }
       else if(name.find("Debug.") == std::string::npos)
       {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2838,16 +2838,10 @@ int HwEmShim::xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *
   {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << " , "<< max_compl <<", "<<min_compl<<" ," << *actual <<" ," << timeout << std::endl;
   }
-//  struct timespec time, *ptime = NULL;
-//
-//  if (timeout > 0) 
-//  {
-//    memset(&time, 0, sizeof(time));
-//    time.tv_sec = timeout / 1000;
-//    time.tv_nsec = (timeout % 1000) * 1000000;
-//    ptime = &time;
-//  }
+  xclemulation::TIMEOUT_SCALE timeout_scale=xclemulation::config::getInstance()->getTimeOutScale();
 
+  xclemulation::ApiWatchdog watch(timeout_scale,timeout);
+  watch.reset();
   *actual = 0;
   while(*actual < min_compl)
   {
@@ -2870,6 +2864,11 @@ int HwEmShim::xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *
       {
         it++;
       }
+      if(watch.isTimeout()) {
+    	 PRINTENDFUNC;
+    	 return -1;
+     }
+
     }
   }
   PRINTENDFUNC;


### PR DESCRIPTION
Adding timeout support for clPollStream API in emulation which will be enabled through a ini switch
[Emulation]
timeout_scale=na/ms/sec/min
na -> timeout disabled (default)
ms- > timeout scale is milliseconds
sec -> timeout scale is second
min -> timeout scale is minutes

Scaling is needed as HW based timeout will not work for emulation which is usually millisec 