### PR TITLE
XRT-499 System hits BUG() if a failure condition is hit in xocl_creat…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -413,8 +413,11 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 
 	return xobj;
 failed:
-	mutex_unlock(&drm_p->mm_lock);
-	kfree(xobj->mm_node);
+	if (xobj->mm_node) {
+		mutex_unlock(&drm_p->mm_lock);
+		kfree(xobj->mm_node);
+	}
+
 	if (xobj_inited)
 		drm_gem_object_release(&xobj->base);
 	kfree(xobj);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -743,7 +743,8 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 
 	if (topo == NULL) {
 		err = -ENODEV;
-		goto failed;
+		XOCL_PUT_MEM_TOPOLOGY(drm_p->xdev);
+		return err;
 	}
 
 	length = topo->m_count * sizeof(struct mem_data);


### PR DESCRIPTION
…e_bo()

For couple of instances the failure condition in routine was not being handled
correctly. This was causing mutex being unlocked without ever being locked and eventually
in unexpected state causing this BUG_ON() failure.