### PR TITLE
XRT-502 vsec bar id should be 15:13 3bits

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1206,8 +1206,9 @@ xocl_subdev_vsec(xdev_handle_t xdev, u32 type,
 		found = true;
 		off_high = ioread32(bar_addr + i + 4);
 		off = ((u64)off_high << 16) | (off_low & 0xffff0000) >> 16;
+		/* Note: 15:13 is bar, 12:8 is rev, 7:0 is type */
 		if (bar_idx)
-			*bar_idx = (off_low >> 12) & 0xf;
+			*bar_idx = (off_low >> 13) & 0x7;
 		if (offset)
 			*offset = off;
 	}


### PR DESCRIPTION
Please take a look at the description, it is actually 3 bits 15:13.

http://jira.xilinx.com/browse/XRT-502
