### PR TITLE
CR-1056313 XRT - xbmgmt config --show not reporting clock scaling ena…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1727,12 +1727,7 @@ static ssize_t scaling_enabled_show(struct device *dev,
 		return sprintf(buf, "%d\n", val);
 
 	mutex_lock(&xmc->xmc_lock);
-	val = READ_RUNTIME_CS(xmc, XMC_CLOCK_CONTROL_REG);
-	if (val & XMC_CLOCK_SCALING_EN)
-		val = 1;
-	else
-		val = 0;
-
+	val =  xmc->runtime_cs_enabled;
 	mutex_unlock(&xmc->xmc_lock);
 	return sprintf(buf, "%d\n", val);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1726,9 +1726,7 @@ static ssize_t scaling_enabled_show(struct device *dev,
 	if (!cs_en)
 		return sprintf(buf, "%d\n", val);
 
-	mutex_lock(&xmc->xmc_lock);
 	val =  xmc->runtime_cs_enabled;
-	mutex_unlock(&xmc->xmc_lock);
 	return sprintf(buf, "%d\n", val);
 }
 static DEVICE_ATTR_RW(scaling_enabled);


### PR DESCRIPTION
…bled

SSv2 platform uses XMC subdevice registers to configure and enable clock scaling.
Use correct indictor for showing if clock scaling is enabled or not.