### PR TITLE
CR-1041924 Adding a warning message for timeouts not enabled by default in emulation

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2850,6 +2850,10 @@ int HwEmShim::xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *
     mLogStream << __func__ << ", " << std::this_thread::get_id() << " , "<< max_compl <<", "<<min_compl<<" ," << *actual <<" ," << timeout << std::endl;
   }
   xclemulation::TIMEOUT_SCALE timeout_scale=xclemulation::config::getInstance()->getTimeOutScale();
+  if(timeout_scale==xclemulation::TIMEOUT_SCALE::NA) {
+      std::string dMsg = "WARNING: [HW-EMU 10] xclPollCompletion : Timeout is not enabled in enulation by default. Please use xrt.ini to enable";
+      logMessage(dMsg, 0); 
+  }
 
   xclemulation::ApiWatchdog watch(timeout_scale,timeout);
   watch.reset();


### PR DESCRIPTION
xclPollStream in emulation will not enable timeouts in emulation and a warning message will be printed to let the user know that that timeout is ignored