### PR TITLE
New xbmgmt/xbutil cleanup

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -42,7 +42,9 @@ void  main_(int argc, char** argv,
   }
   // Determine the executable name for this application
   boost::filesystem::path pathAndFile(argv[0]);
-  const std::string executable = pathAndFile.filename().string();
+  std::string executable = pathAndFile.filename().string();
+  executable.pop_back();
+
   // Global options
   bool bVerbose = false;
   bool bTrace = false;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -441,9 +441,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
                                                                 "  Name (and path) of the partiaion.\n"
                                                                 "  Parition's UUID")
     ("update", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images.  Value values:\n"
-                                                                         "  ALL   - All images will be updated\n"
-                                                                         "  FLASH - Flash image\n"
-                                                                         "  SC    - Satellite controller\n")
+                                                                         "  ALL   - All images will be updated"
+                                                                     /*  "  FLASH - Flash image\n"
+                                                                         "  SC    - Satellite controller"*/)
     ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(), "Specifies an image to use used to update the persistent device(s).  Value values:\n"
                                                                       "  Name (and path) to the mcs image on disk\n"
                                                                       "  Name (and path) to the xsabin image on disk\n"
@@ -451,7 +451,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     ("force,f", boost::program_options::bool_switch(&force), "Force update the flash image")
     ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType), "Overrides the flash mode. Use with caution.  Value values:\n"
                                                                       "  ospi\n"
-                                                                      "  ospi_versal\n")
+                                                                      "  ospi_versal")
     ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image.  Note: This currently only applies to the flash image.")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
@@ -522,9 +522,9 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     if(update.compare("all") == 0)
       auto_flash(deviceCollection, force);
     else if(update.compare("flash") == 0)
-      std::cout << "TODO: implement platform only update\n";
+      throw xrt_core::error("Platform only update is not supported");
     else if(update.compare("sc") == 0)
-      std::cout << "TODO: implement SC only update\n";
+      throw xrt_core::error("SC only update is not supported");
     else 
       throw xrt_core::error("Please specify a valid value");
     return;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -142,7 +142,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   po::options_description resetDesc("Options");
   resetDesc.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
-    ("type,r", boost::program_options::value<decltype(type)>(&type)->implicit_value("all"), "The type of reset to perform. Types resets available:\n"
+    ("type,r", boost::program_options::value<decltype(type)>(&type)->implicit_value("hot"), "The type of reset to perform. Types resets available:\n"
                                                                         "  hot          - Hot reset (default)\n"
                                                                         "  kernel       - Kernel communication links\n" 
                                                                         "  ert          - Reset management processor\n"

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -47,13 +47,11 @@ int main( int argc, char** argv )
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
     subCommands.emplace_back(std::make_shared<   SubCmdProgram  >(false, false, false));
     subCommands.emplace_back(std::make_shared<     SubCmdReset  >(false, false, false));
-    subCommands.emplace_back(std::make_shared<  SubCmdAdvanced  >(false, false,  true));
-    subCommands.emplace_back(std::make_shared<     SubCmdStatus >(false, false, false));
+    subCommands.emplace_back(std::make_shared<  SubCmdAdvanced  >(true,  false,  true));
+    subCommands.emplace_back(std::make_shared<    SubCmdStatus  >(false, false, false));
   }
 
-  // -- Determine and set the executable name for each subcommand
-  boost::filesystem::path pathAndFile(argv[0]);
-  const std::string executable = pathAndFile.stem().string();
+  const std::string executable = "xbmgmt";
 
   for (auto & subCommand : subCommands) {
     subCommand->setExecutableName(executable);
@@ -66,7 +64,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_( argc, argv, description, subCommands);
+    main_(argc, argv, description, subCommands);
     return 0;
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -45,9 +45,9 @@ int main( int argc, char** argv )
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
     subCommands.emplace_back(std::make_shared<  SubCmdExamine >(false, false, false));
     subCommands.emplace_back(std::make_shared<  SubCmdProgram >(false, false, false));
-    subCommands.emplace_back(std::make_shared< SubCmdValidate >(false, false, false));
-    subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(false, false, true ));
-    subCommands.emplace_back(std::make_shared<    SubCmdReset >(false, false, false));
+    subCommands.emplace_back(std::make_shared< SubCmdValidate >(true,  false, false));
+    subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(true,  false, true ));
+    subCommands.emplace_back(std::make_shared<    SubCmdReset >(true,  false, false));
   }
 
   // Add depricated commands
@@ -60,9 +60,7 @@ int main( int argc, char** argv )
   }
   #endif
 
-  // -- Determine and set the executable name for each subcommand
-  boost::filesystem::path pathAndFile(argv[0]);
-  const std::string executable = pathAndFile.stem().string();
+  const std::string executable = "xbutil";
 
   for (auto & subCommand : subCommands) {
     subCommand->setExecutableName(executable);
@@ -72,7 +70,7 @@ int main( int argc, char** argv )
   const std::string description = 
   "The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that"
   " is included with the Xilinx Run Time (XRT) installation package. It includes"
-  " multiple commands to validate and identifythe installed card(s) along with"
+  " multiple commands to validate and identify the installed card(s) along with"
   " additional card details including DDR, PCIe (R), shell name (DSA), and system"
   " information.\n\nThis information can be used for both card administration and"
   " application debugging.";


### PR DESCRIPTION
- remove "2" xbmgmt and xbutil in help
- hide/comment out commands/values that are not implemented
- clean up command flows and throw errors and print help appropriately 