### PR TITLE
CR-1063652 System crash on multi-threaded host accessing multiple eng…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -3423,11 +3423,19 @@ static struct xocl_scheduler scheduler0;
 static void
 scheduler_reset(struct xocl_scheduler *xs)
 {
+	struct list_head *pos, *next;
+
 	xs->error = false;
 	xs->stop = false;
 	xs->reset = false;
 	xs->poll = 0;
 	xs->intc = 0;
+
+	list_for_each_safe(pos, next, &xs->cores) {
+		struct exec_core *exec =
+			list_entry(pos, struct exec_core, core_list);
+		exec_reset_cmds(exec);
+	}
 }
 
 static void


### PR DESCRIPTION
…ines in same device (part 1)

This change fixes the crash described in CR-1063652.

KDS does not release exec buf BOs after application is killed. In the very next hot reset the system will crash when KDS is freeing left over exec buf BOs due to that it's torn down after DRM is gone.

Note that those left over BOs are not for CU cmds that are stuck on device. They are BOs for CU cmds that have not submitted to device yet. CU cmds that are on device is aborted and freed properly when application is killed.

The fix is simply freeing all stale CU cmds when KDS is being reset, no matter what stage they are on.

Tested with steps described in the CR and the crash is not seen. After hot reset, board can be recovered properly. Tested with full xbutil validate and it worked fine.