### PR TITLE
CR-1064013 ZCU102 DFx platform: fails with [drm:zocl_load_partial [zocl]] *ERROR* FPGA manager is not found

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -859,7 +859,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	 * For PR platform, the FPGA manager is required. No good way to
 	 * determin if it is a PR platform at probe.
 	 */
-	fnode = of_get_child_by_name(of_root,
+	fnode = of_find_node_by_name(of_root,
 	    zdev->zdev_data_info->fpga_driver_name);
 	if (fnode) {
 		zdev->fpga_mgr = of_fpga_mgr_get(fnode);


### PR DESCRIPTION
This change contains a fix to find out the pcap node from entire device tree instead of just checking in childrens of top node. Please go thru the CR for more details. Old and new DTS files are attached in the CR.

PCAP node generated from latest petalinux tools is part of the firmware node, thatswhy we need to check entire tree instead of checking only children of top node.

Fix reviewed/verified by : SivaRajesh