### PR TITLE
CR-1062480: Kernel enqueue time on edge emulation reported as 0

### DIFF
--- a/src/runtime_src/xdp/profile/core/trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/core/trace_logger.cpp
@@ -65,6 +65,9 @@ namespace xdp {
     // In HW emulation, use estimated host timestamp based on device clock cycles (in psec from HAL)
     if (mPluginHandle->getFlowMode() == xdp::RTUtil::HW_EM) {
       size_t dts = mPluginHandle->getDeviceTimestamp(deviceName);
+      // On edge, emulation and hardware shims return 0 always, so 
+      //  use host time instead
+      if (dts == 0) return deviceTimeStamp ;
       deviceTimeStamp = dts / 1000000.0;
     }
 


### PR DESCRIPTION
Adding a check if the shim xclDeviceTimestamp function returns 0, as is the case on edge hardware and edge emulation.  In that case, we use host timestamps as in hardware.