### PR TITLE
CR-1057070 Support VCK5000 shell Raptor 2.0 methodology

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2271,6 +2271,15 @@ struct xocl_subdev_map {
 		XOCL_DEVINFO_AF_USER,					\
 	 })
 
+/* need static scheduler for a little while, and no AF user for now */
+#define RES_USER_VERSAL_VSEC						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM_USER_DYN,			\
+		XOCL_DEVINFO_SCHEDULER_VERSAL,				\
+		XOCL_DEVINFO_ICAP_USER,					\
+		XOCL_DEVINFO_XMC_USER,					\
+	 })
+
 #define	XOCL_BOARD_U50_USER_RAPTOR2					\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP,			\
@@ -2383,6 +2392,27 @@ struct xocl_subdev_map {
 		.sched_bin = "xilinx/sched_v20.bin",			\
 		.board_name = "u250"					\
 	}
+
+#define	XOCL_BOARD_VERSAL_USER_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
+			XOCL_DSAFLAG_VERSAL,				\
+		.subdev_info = RES_USER_VERSAL_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
+		.board_name = "vck5000"					\
+	}
+
+#define	XOCL_BOARD_VERSAL_MGMT_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_VERSAL |				\
+			XOCL_DSAFLAG_FIXED_INTR |			\
+			XOCL_DSAFLAG_DYNAMIC_IP,	 		\
+		.subdev_info = RES_MGMT_VSEC,				\
+		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
+		.flash_type = FLASH_TYPE_OSPI_VERSAL,			\
+		.board_name = "vck5000"					\
+	}
+
 
 #define XOCL_RES_XMC_MFG				\
 	((struct resource []) {				\
@@ -2951,7 +2981,13 @@ struct xocl_subdev_map {
 	{ 0x10EE, 0x5021, PCI_ANY_ID,					\
 		.vbnv = "xilinx_u50",		\
 		.priv_data = &XOCL_BOARD_U50_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5044, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u50",					\
+		.priv_data = &XOCL_BOARD_VERSAL_MGMT_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5045, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u50",					\
+		.priv_data = &XOCL_BOARD_VERSAL_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 }
-
-
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1009,7 +1009,17 @@ static void xclmgmt_extended_probe(struct xclmgmt_dev *lro)
 	if (!(dev_info->flags & (XOCL_DSAFLAG_SMARTN | XOCL_DSAFLAG_VERSAL | XOCL_DSAFLAG_MPSOC)))
 		ret = xocl_icap_download_boot_firmware(lro);
 
-	/* return -ENODEV for 2RP platform */
+	/*
+	 * All 2.0 shell will not have icap for mgmt at this moment, thus we will
+	 * get ENODEV (see RES_MGMT_VSEC).
+	 * If we don't want to break the existing rule but still apply the rule
+	 * like if versal has vesc, then it is a 2.0 shell. We can add the following
+	 * condition.
+	 */
+	if ((dev_info->flags & XOCL_DSAFLAG_VERSAL) &&
+	    xocl_subdev_is_vsec(lro))
+		ret = -ENODEV;
+
 	if (!ret) {
 		xocl_thread_start(lro);
 
@@ -1210,8 +1220,6 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	 */
 	(void) xocl_subdev_create_by_level(lro, XOCL_SUBDEV_LEVEL_BLD);
 	(void) xocl_subdev_create_vsec_devs(lro);
-
-
 
 	return 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -646,6 +646,7 @@ static bool xocl_subdev_vsec_is_golden(xdev_handle_t xdev_hdl)
 
 int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 {
+	struct xocl_board_private *dev_info = &lro->core.priv;
 	const struct axlf_section_header	*dtc_header;
 	struct axlf				*bin_axlf;
 	int					ret;
@@ -701,7 +702,10 @@ int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 	if (ret)
 		goto failed;
 
-	ret = xocl_icap_download_boot_firmware(lro);
+	/* VERSAL doesn't have icap to download, will need to refactor the code */
+	if (!(dev_info->flags & XOCL_DSAFLAG_VERSAL))
+		ret = xocl_icap_download_boot_firmware(lro);
+
 	if (ret)
 		goto failed;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1958,6 +1958,12 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	cfg->type = ERT_CTRL;
 
 	SCHED_DEBUGF("configuring scheduler cq_size(%d)\n", exec->cq_size);
+	if (exec->cq_size == 0 || cfg->slot_size == 0) {
+		userpf_err(xdev, "should not have zeroed value of cq_size=%d, slot_size=%d",
+		    exec->cq_size, cfg->slot_size);
+		return 1;
+	}
+
 	ert_num_slots = exec->cq_size / cfg->slot_size;
 	exec->num_cus = cfg->num_cus;
 	exec->num_cdma = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1538,6 +1538,7 @@ int xocl_subdev_create_prp(xdev_handle_t xdev);
 int xocl_subdev_vsec(xdev_handle_t xdev, u32 type, int *bar_idx, u64 *offset);
 u32 xocl_subdev_vsec_read32(xdev_handle_t xdev, int bar, u64 offset);
 int xocl_subdev_create_vsec_devs(xdev_handle_t xdev);
+bool xocl_subdev_is_vsec(xdev_handle_t xdev);
 int xocl_subdev_get_level(struct platform_device *pdev);
 
 void xocl_subdev_register(struct platform_device *pldev, void *ops);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -431,6 +431,30 @@ static struct xocl_subdev_map		subdev_map[] = {
 		.devinfo_cb = NULL,
 	},
 	{
+		.id = XOCL_SUBDEV_MAILBOX_VERSAL,
+		.dev_name = XOCL_MAILBOX_VERSAL,
+		.res_names = {
+			NODE_MAILBOX_XRT,
+			NULL
+		},
+		.required_ip = 1,
+		.flags = 0,
+		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
+	},
+	{
+		.id = XOCL_SUBDEV_OSPI_VERSAL,
+		.dev_name = XOCL_OSPI_VERSAL,
+		.res_names = {
+			NODE_OSPI_CACHE,
+			NULL
+		},
+		.required_ip = 1,
+		.flags = 0,
+		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
+	},
+	{
 		XOCL_SUBDEV_ICAP,
 		XOCL_ICAP,
 		{

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -80,6 +80,8 @@
 #define NODE_P2P "ep_p2p_00"
 #define NODE_DDR4_RESET_GATE "ep_ddr_mem_srsr_gate_00"
 #define NODE_ADDR_TRANSLATOR "ep_remap_data_c2h_00"
+#define NODE_MAILBOX_XRT "ep_mailbox_xrt_00"
+#define NODE_OSPI_CACHE "ep_ospi_cache_00"
 
 #define RESNAME_GATEPLP       NODE_GATE_PLP
 #define RESNAME_PCIEMON       NODE_PCIE_MON

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1220,6 +1220,15 @@ xocl_subdev_vsec(xdev_handle_t xdev, u32 type,
 	return found ? 0 : -ENOENT;
 }
 
+bool xocl_subdev_is_vsec(xdev_handle_t xdev)
+{
+	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev;
+	struct pci_dev *pdev = core->pdev;
+	int cap;
+
+	return pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VNDR) != 0;
+}
+
 int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 {
 	u64 offset;
@@ -1230,7 +1239,8 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_FLASH_VSEC;
 
 		xocl_xdev_info(xdev,
-			"Vendor Specific FLASH RES Start 0x%llx", offset);
+			"Vendor Specific FLASH RES Start 0x%llx, bar %d",
+			 offset, bar);
 		subdev_info.res[0].start = offset;
 		subdev_info.res[0].end = offset + 0xfff;
 		subdev_info.bar_idx[0] = bar;
@@ -1245,7 +1255,8 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_MAILBOX_VSEC;
 
 		xocl_xdev_info(xdev,
-			"Vendor Specific MAILBOX RES Start 0x%llx", offset);
+			"Vendor Specific MAILBOX RES Start 0x%llx, bar %d",
+			 offset, bar);
 		subdev_info.res[0].start = offset;
 		subdev_info.res[0].end = offset + 0xfff;
 		subdev_info.bar_idx[0] = bar;


### PR DESCRIPTION
shell 2.0 support for versal.

This is the first drop, scheduler is still static configured. However, we can allow other users to switch their test against 2.0 shell earlier.

I will be working on refactoring the mb_scheduler and versal_mailbox code, move about dependencies before 2020.1 released.