### PR TITLE
Change_Windows_ExportBO_input_Param

### DIFF
--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1414,11 +1414,11 @@ xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
   return shim->exec_wait(timeoutMilliSec);
 }
 
-int xclExportBO(xclDeviceHandle handle, unsigned int boHandle)
+int xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclExportBO() NOT IMPLEMENTED");
-  return ERROR_INVALID_FUNCTION;
+  return EDOM;
 }
 
 xclBufferHandle xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1418,7 +1418,7 @@ int xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclExportBO() NOT IMPLEMENTED");
-  return EDOM;
+  return ENOSYS;
 }
 
 xclBufferHandle xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)


### PR DESCRIPTION
CR-1040791. ExportBO was missed as an Export DLL function. Needed to correct an input parameter. XRT build is passed. Tested by Sid's 30vadd_c application.