### PR TITLE
CR-1055623 22_verify.py core dump when doing stress test

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1412,13 +1412,24 @@ xclProbe()
 xclDeviceHandle
 xclOpen(unsigned deviceIndex, const char *logFileName, xclVerbosityLevel level)
 {
-  //std::cout << "xclOpen called" << std::endl;
-  ZYNQ::shim *handle = new ZYNQ::shim(deviceIndex, logFileName, level);
-  if (!ZYNQ::shim::handleCheck(handle)) {
-    delete handle;
-    handle = 0;
+  try {
+    //std::cout << "xclOpen called" << std::endl;
+    auto handle = new ZYNQ::shim(deviceIndex, logFileName, level);
+    if (!ZYNQ::shim::handleCheck(handle)) {
+      delete handle;
+      handle = XRT_NULL_HANDLE;
+    }
+    return handle;
   }
-  return (xclDeviceHandle) handle;
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+
+  return XRT_NULL_HANDLE;
+
 }
 
 void

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1293,16 +1293,19 @@ xclProbe()
 xclDeviceHandle
 xclOpen(unsigned int deviceIndex, const char *logFileName, xclVerbosityLevel level)
 {
-  xrt_core::message::
-    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclOpen()");
   try {
+    xrt_core::message::
+      send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclOpen()");
     return new shim(deviceIndex);
   }
-  catch (const std::exception& ex) {
-    xrt_core::message::
-      send(xrt_core::message::severity_level::XRT_ERROR, "XRT", "xclOpen failed with `%s`", ex.what());
-    return nullptr;
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
   }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+
+  return nullptr;
 }
 
 void
@@ -1441,14 +1444,24 @@ xclGetBOProperties(xclDeviceHandle handle, xclBufferHandle boHandle,
 int
 xclLoadXclBin(xclDeviceHandle handle, const struct axlf *buffer)
 {
-  xrt_core::message::
-    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclLoadXclbin()");
-  auto shim = get_shim_object(handle);
-  if (auto ret =shim->load_xclbin(buffer))
-    return ret;
-  auto core_device = xrt_core::get_userpf_device(shim);
-  core_device->register_axlf(buffer);
-  return 0;
+  try {
+    xrt_core::message::
+      send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclLoadXclbin()");
+    auto shim = get_shim_object(handle);
+    if (auto ret =shim->load_xclbin(buffer))
+      return ret;
+    auto core_device = xrt_core::get_userpf_device(shim);
+    core_device->register_axlf(buffer);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -EINVAL;
+  }
 }
 
 unsigned int


### PR DESCRIPTION
Catch exceptions before returning

This is a general problem with all shim APIs.  Need to revisit as new
style APIs are added.