### PR TITLE
Use CMake variables when linking with Boost

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -70,11 +70,11 @@ if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} VERSION_GREATER 17.1
 endif()
 
 find_package(Boost REQUIRED COMPONENTS system filesystem )
+include_directories(${Boost_INCLUDE_DIRS})
 
 # -- Cursers ---
 INCLUDE (FindCurses)
 find_package(Curses REQUIRED)
-
 
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR           "${CMAKE_INSTALL_PREFIX}/xrt")

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -71,6 +71,7 @@ endif()
 
 find_package(Boost REQUIRED COMPONENTS system filesystem )
 include_directories(${Boost_INCLUDE_DIRS})
+add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")
 
 # -- Cursers ---
 INCLUDE (FindCurses)

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -22,6 +22,7 @@ endif(GIT_FOUND)
 
 INCLUDE (FindBoost)
 INCLUDE (FindGTest)
+include_directories(${Boost_INCLUDE_DIRS})
 
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR "xrt")

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -23,6 +23,7 @@ endif(GIT_FOUND)
 INCLUDE (FindBoost)
 INCLUDE (FindGTest)
 include_directories(${Boost_INCLUDE_DIRS})
+add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")
 
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR "xrt")

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -7,11 +7,8 @@ if(${CMAKE_BUILD_TYPE} STREQUAL "Release" AND ${XRT_NATIVE_BUILD} STREQUAL "yes"
   add_subdirectory(doc)
 endif()
 
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${BOOST_FILESYSTEM_INCLUDE_DIRS}
-  ${BOOST_SYSTEM_INCLUDE_DIRS}
-  )
+# Default include search path starts at runtime_src
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 option(XOCL_VERBOSE "Enable xocl verbosity" OFF)
 option(XRT_VERBOSE "Enable xrt verbosity" OFF)

--- a/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
@@ -13,10 +13,10 @@ add_executable(xbutil ${XRT_EDGE_TOOLS_XBUTIL_FILES})
 target_link_libraries(xbutil
   xrt_core_static
   xrt_coreutil_static
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
-  boost_filesystem
-  boost_system
   uuid
   ${CURSES_LIBRARIES}
   )

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -45,8 +45,8 @@ if (DEFINED XRT_AIE_BUILD)
     rt
     dl
     uuid
-    boost_filesystem
-    boost_system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     metal
     xaiengine
     )
@@ -57,8 +57,8 @@ else()
     rt
     dl
     uuid
-    boost_filesystem
-    boost_system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     )
 endif()
 

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -43,11 +43,11 @@ set_target_properties(xrt_core PROPERTIES
 
 target_link_libraries(xrt_core
   xrt_coreutil
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
   dl
-  boost_filesystem
-  boost_system
   uuid
   )
 

--- a/src/runtime_src/core/pcie/tools/awssak/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/awssak/CMakeLists.txt
@@ -19,8 +19,8 @@ if(${INTERNAL_TESTING})
     xrt_aws_static
     xrt_coreutil_static
     uuid
-    boost_filesystem
-    boost_system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
     )
@@ -32,8 +32,8 @@ else()
     xrt_aws_static
     xrt_coreutil_static
     uuid
-    boost_filesystem
-    boost_system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
     ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/CMakeLists.txt
@@ -18,8 +18,8 @@ target_link_libraries(mpd
   xrt_core_static
   xrt_coreutil_static
   pthread
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   uuid
   dl
   udev
@@ -42,8 +42,8 @@ target_link_libraries(msd
   xrt_core_static
   xrt_coreutil_static
   pthread
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   uuid
   dl
   )

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/CMakeLists.txt
@@ -33,11 +33,11 @@ add_compile_options("-fPIC")
 if(${INTERNAL_TESTING_FOR_AWS})
   add_definitions(-DINTERNAL_TESTING_FOR_AWS)
   target_link_libraries(aws_mpd_plugin
-	xrt_core_static
-	xrt_coreutil_static
+    xrt_core_static
+    xrt_coreutil_static
     uuid
-    boost_filesystem
-    boost_system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
     dl
@@ -47,11 +47,11 @@ else()
   set(AWS_FPGA_MGMT_LIB_DIR ${AWS_FPGA_REPO_DIR}/sdk/userspace/lib)
 
   target_link_libraries(aws_mpd_plugin
-	xrt_core_static
-	xrt_coreutil_static
+    xrt_core_static
+    xrt_coreutil_static
     uuid
-    boost_filesystem
-    boost_system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
     pthread
     rt
     dl

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/CMakeLists.txt
@@ -27,8 +27,8 @@ target_link_libraries(azure_mpd_plugin
   xrt_core_static
   xrt_coreutil_static
   uuid
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
   dl

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/container/CMakeLists.txt
@@ -21,8 +21,8 @@ target_link_libraries(container_mpd_plugin
   xrt_core_static
   xrt_coreutil_static
   uuid
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   pthread
   rt
   crypto

--- a/src/runtime_src/core/pcie/tools/xbmgmt/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/CMakeLists.txt
@@ -15,8 +15,8 @@ target_link_libraries(xbmgmt
   xrt_core_static
   xrt_coreutil_static
   pthread
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   uuid
   )
 

--- a/src/runtime_src/core/pcie/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/xbutil/CMakeLists.txt
@@ -18,8 +18,8 @@ target_link_libraries(xbutil
   pthread
   rt
   dl
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   uuid
   ${CURSES_LIBRARIES}
   )

--- a/src/runtime_src/core/pcie/user_aws/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/user_aws/CMakeLists.txt
@@ -46,8 +46,8 @@ if (${INTERNAL_TESTING})
   xrt_coreutil
   pthread
   rt
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   uuid
   )
 else ()
@@ -56,8 +56,8 @@ else ()
   xrt_coreutil
   pthread
   rt
-  boost_filesystem
-  boost_system
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
   uuid
   ${AWS_FPGA_MGMT_LIB_DIR}/libfpga_mgmt.a
 )

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -64,6 +64,9 @@ endif()
 if(WIN32)
 target_link_libraries(
     ${XBMGMT2_NAME} PRIVATE
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     Boost::filesystem
     Boost::program_options
     Boost::system
@@ -79,9 +82,9 @@ else()
     xrt_core
     xrt_core_static
     xrt_coreutil_static
-    boost_filesystem
-    boost_system
-    boost_program_options
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     uuid
     dl
   )

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -69,9 +69,9 @@ endif()
 if(WIN32)
   target_link_libraries(
     ${XBUTIL2_NAME} PRIVATE
-    Boost::filesystem
-    Boost::program_options
-    Boost::system
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     xrt_core
     xrt_coreutil
   )
@@ -82,9 +82,9 @@ else()
     xrt_core
     xrt_core_static
     xrt_coreutil_static
-    boost_filesystem
-    boost_system
-    boost_program_options
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
     pthread
     uuid
     dl


### PR DESCRIPTION
Do not link with system installed library by default.  We use CMake to
find the location of the boost install, which is the system install by
default, but could be a local version.