### PR TITLE
Cleanup deprecated xocl_dev offline

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -3796,24 +3796,16 @@ create_client(struct platform_device *pdev, void **priv)
 	if (!client)
 		return -ENOMEM;
 
+	client->pid = get_pid(task_pid(current));
+	client->abort = false;
+	atomic_set(&client->trigger, 0);
+	atomic_set(&client->outstanding_execs, 0);
+	client->num_cus = 0;
+	client->xdev = xocl_get_xdev(pdev);
 	mutex_lock(&xdev->dev_lock);
-
-	if (!xdev->offline) {
-		client->pid = get_pid(task_pid(current));
-		client->abort = false;
-		atomic_set(&client->trigger, 0);
-		atomic_set(&client->outstanding_execs, 0);
-		client->num_cus = 0;
-		client->xdev = xocl_get_xdev(pdev);
-		list_add_tail(&client->link, &xdev->ctx_list);
-		*priv =	client;
-	} else {
-		/* Do not allow new client to come in while being offline. */
-		devm_kfree(XDEV2DEV(xdev), client);
-		ret = -EBUSY;
-	}
-
+	list_add_tail(&client->link, &xdev->ctx_list);
 	mutex_unlock(&xdev->dev_lock);
+	*priv =	client;
 
 	DRM_INFO("creating scheduler client for pid(%d), ret: %d\n",
 		 pid_nr(task_tgid(current)), ret);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -123,8 +123,6 @@ enum {
 struct xocl_dev	{
 	struct xocl_dev_core	core;
 
-	bool			offline;
-
 	int			p2p_bar_idx;
 	u64			p2p_bar_sz_cached;
 	resource_size_t		p2p_bar_len;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -771,11 +771,6 @@ int xocl_sync_bo_ioctl(struct drm_device *dev,
 	if (paddr == 0xffffffffffffffffull)
 		return -EINVAL;
 
-	/* If device is offline (due to error), reject all DMA requests */
-	if (xdev->offline)
-		return -ENODEV;
-
-
 	if ((args->offset + args->size) > gem_obj->size) {
 		ret = -EINVAL;
 		goto out;
@@ -1056,13 +1051,6 @@ int xocl_copy_import_bo(struct drm_device *dev, struct drm_file *filp,
 		DRM_ERROR("invalid src or dst BO type, copy_bo aborted");
 		DRM_ERROR("expecting one local and one imported BO");
 		ret = -EINVAL;
-		goto out;
-	}
-
-	/* If device is offline (due to error), reject all DMA requests */
-	if (xdev->offline) {
-		DRM_ERROR("DMA engine is offline, copy_bo aborted");
-		ret = -ENODEV;
 		goto out;
 	}
 


### PR DESCRIPTION
xocl_dev offline is deprecated. All drivers should use offline in struct xocl_drvinst.
No where would set xdev->offline to true.

This PR removes xdev->offline in mb_scheduler.c and xocl_bo.c.

**xocl_bo.c:** If xdma is offline, xocl_acquire_channel() would return -ENODEV.
**mb_scheduler.c:** This is to avoid create client while the device is resetting. But now, this is protect by xocl_drvinst_open() in xocl_client_open().

Base on above, just simply remove the deprecated logic.