### PR TITLE
xclbinutil: Fixed xclbinutil.bat wrapper script to correctly find the loader.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/xclbinutil.bat
+++ b/src/runtime_src/tools/xclbinutil/xclbinutil.bat
@@ -4,6 +4,9 @@ setlocal
 REM Working variables
 set XRT_PROG=xclbinutil
 
+REM -- Find and call the loader
+set XRT_LOADER=%~dp0unwrapped/loader.bat
+
 REM -- Examine the options
 set XRTWRAP_PROG_ARGS=
   :parseArgs
@@ -24,9 +27,6 @@ set XRTWRAP_PROG_ARGS=
     )
     goto parseArgs
   :argsParsed
-
-REM -- Find and call the loader
-set XRT_LOADER=%~dp0unwrapped/loader.bat
 
 if not exist %XRT_LOADER%  (
   echo ERROR: Could not find 64-bit loader executable.


### PR DESCRIPTION
Issue
-----
The xclbinutil.bat script 'sometimes' doesn't find the loarder.bat file.  This 'seems' to be the result of the batch commandline interpreter getting confused when 'shifting' through the elements.

Resolution
----------
The XRT_LOADER directory value is calculated prior to examining of the arguments.