### PR TITLE
CR-1064295 Stop Buffer deallocation emulation calls for versal

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -328,7 +328,7 @@ using addr_type = uint64_t;
       FeatureRomHeader mFeatureRom;
       std::set<unsigned int > mImportedBOs;
       uint64_t mCuBaseAddress;
-
+      bool     mVersalPlatform;
       //For Emulation specific messages on host from Device
       std::thread mMessengerThread;
       bool mMessengerThreadStarted;


### PR DESCRIPTION
Versal emulation does not support P2P buffer allocation/deallocation