### PR TITLE
XRT-518 FreeBuffer call is hanging in hw_emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -154,7 +154,7 @@ using addr_type = uint64_t;
       uint64_t xclAllocDeviceBuffer2(size_t& size, xclMemoryDomains domain, unsigned flags,bool p2pBuffer, std::string &sFileName);
 
       void xclOpen(const char* logfileName);
-      void xclFreeDeviceBuffer(uint64_t buf);
+      void xclFreeDeviceBuffer(uint64_t buf,bool sendtosim);
       size_t xclCopyBufferHost2Device(uint64_t dest, const void *src, size_t size, size_t seek, uint32_t topology);
       size_t xclCopyBufferDevice2Host(void *dest, uint64_t src, size_t size, size_t skip, uint32_t topology);
       void xclClose();


### PR DESCRIPTION
There is an issue in sending the free buffer calls to simulation process in hw_emu.
We shouldnt send the execBo handles to simulation process. 

Fix reviewed by: Pratyush
Testing: Canary