### PR TITLE
CR-1064505 Moved the emulation_data section to xsim area and that helps us to construct the proper relative path and help us to have the portable XCLBIN even for the Versal DC platforms

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/system_utils.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/system_utils.cxx
@@ -6,7 +6,7 @@ namespace systemUtil {
   {
     if(!status)// no error
       return;
-    std::cout<<"ERROR: [SDx 60-600] "<< command <<" failed with the error code "<< status<< ". PLEASE CHECK YOUR PERMISSIONS "<<std::endl;
+    std::cout << "ERROR: [EMU 60-600] " << command << " failed with the error code " << status << ". PLEASE CHECK YOUR PERMISSIONS " << std::endl;
   }
   
   void makeSystemCall (std::string &operand1, systemOperation operation, std::string operand2 )

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -185,6 +185,7 @@ using addr_type = uint64_t;
       bool get_simulator_started() {return simulator_started;}
       void fillDeviceInfo(xclDeviceInfo2* dest, xclDeviceInfo2* src);
       void saveWaveDataBase();
+      void extractEmuData(const std::string& simPath, const std::string& binaryDirectory, int binaryCounter, bitStreamArg args);
 
       // Sanity checks
       static HwEmShim *handleCheck(void *handle);


### PR DESCRIPTION
Moved the emulation_data section to xsim area and that helps us to construct the proper relative path and help us to have the portable XCLBIN even for the Versal DC platforms

Reviewer: @ramyam-xilinx 
CR: 1064505