### PR TITLE
XRT-533 name change from ep_ospi_cache_00 to ep_xfer_cache_00 and XRT-485 data-driven cmc should work

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -272,10 +272,12 @@ static int ospi_versal_remove(struct platform_device *pdev)
 {
 	struct ospi_versal *ov = platform_get_drvdata(pdev);
 	void *hdl;
+	int ret = 0;
 
 	if (!ov) {
 		xocl_err(&pdev->dev, "driver data is NULL");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto done;
 	}
 
 	xocl_drvinst_release(ov, &hdl);
@@ -285,14 +287,16 @@ static int ospi_versal_remove(struct platform_device *pdev)
 	platform_set_drvdata(pdev, NULL);
 	xocl_drvinst_free(hdl);
 
-	return 0;
+done:
+	OV_INFO(ov, "return: %d", ret);
+	return ret;
 }
 
 static int ospi_versal_probe(struct platform_device *pdev)
 {
 	struct ospi_versal *ov = NULL;
 	struct resource *res;
-	int ret;
+	int ret = 0;
 
 	ov = xocl_drvinst_alloc(&pdev->dev, sizeof(struct ospi_versal));
 	if (!ov)
@@ -318,6 +322,7 @@ static int ospi_versal_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
+	OV_INFO(ov, "return: %d", ret);
 	return 0;
 
 failed:
@@ -327,6 +332,7 @@ failed:
 	}
 	ospi_versal_remove(pdev);
 
+	OV_INFO(ov, "return: %d", ret);
 	return ret;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -325,10 +325,10 @@ static struct xocl_subdev_map		subdev_map[] = {
 			// 0x53000 runtime clk scaling
 			NULL
 		},
-		3,
-		0,
-		NULL,
-		NULL,
+		.required_ip = 1, /* for MPSOC, we only have the 1st resource */
+		.flags = 0,
+		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
 	},
 	{
 		XOCL_SUBDEV_MAILBOX,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -82,7 +82,7 @@
 #define NODE_DDR4_RESET_GATE "ep_ddr_mem_srsr_gate_00"
 #define NODE_ADDR_TRANSLATOR "ep_remap_data_c2h_00"
 #define NODE_MAILBOX_XRT "ep_mailbox_xrt_00"
-#define NODE_OSPI_CACHE "ep_ospi_cache_00"
+#define NODE_OSPI_CACHE "ep_xfer_cache_00"
 
 #define RESNAME_GATEPLP       NODE_GATE_PLP
 #define RESNAME_PCIEMON       NODE_PCIE_MON


### PR DESCRIPTION
minor tweak:
1) For U30/Versal MPSoc platforms, CMC only has 1 register to controll
2) we changed the name of ospi_versal's register
3) add some verbose log 