### PR TITLE
Build on Ubuntu 20.04

### DIFF
--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -49,7 +49,12 @@ if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
   SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS "OFF")
   SET(CPACK_DEBIAN_AWS_PACKAGE_DEPENDS "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})")
   SET(CPACK_DEBIAN_XBTEST_PACKAGE_DEPENDS "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH}), libjson-glib-dev")
-  SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-opencl-dev (>= 2.2.0), libboost-dev (>= ${Boost_VER_STR}), libboost-dev (<< ${Boost_VER_STR_ONEGREATER}), libboost-filesystem-dev (>=${Boost_VER_STR}), libboost-filesystem-dev (<<${Boost_VER_STR_ONEGREATER}), libboost-program-options-dev (>=${Boost_VER_STR}), libboost-program-options-dev (<<${Boost_VER_STR_ONEGREATER}), uuid-dev (>= 2.27.1), dkms (>= 2.2.0), libprotoc-dev (>=2.6.1), libssl-dev (>=1.0.2), protobuf-compiler (>=2.6.1), libncurses5-dev (>=6.0), lsb-release, libxml2-dev (>=2.9.1), libyaml-dev (>= 0.1.6), libc6 (>= ${GLIBC_VERSION}), libc6 (<< ${GLIBC_VERSION_ONEGREATER}), python (>= 2.7), python-pip, libudev-dev ")
+  SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-opencl-dev (>= 2.2.0), libboost-dev (>= ${Boost_VER_STR}), libboost-dev (<< ${Boost_VER_STR_ONEGREATER}), libboost-filesystem-dev (>=${Boost_VER_STR}), libboost-filesystem-dev (<<${Boost_VER_STR_ONEGREATER}), libboost-program-options-dev (>=${Boost_VER_STR}), libboost-program-options-dev (<<${Boost_VER_STR_ONEGREATER}), uuid-dev (>= 2.27.1), dkms (>= 2.2.0), libprotoc-dev (>=2.6.1), libssl-dev (>=1.0.2), protobuf-compiler (>=2.6.1), libncurses5-dev (>=6.0), lsb-release, libxml2-dev (>=2.9.1), libyaml-dev (>= 0.1.6), libc6 (>= ${GLIBC_VERSION}), libc6 (<< ${GLIBC_VERSION_ONEGREATER}), libudev-dev")
+  if (${LINUX_VERSION} VERSION_LESS "20.04")
+    STRING(APPEND CPACK_DEBIAN_XRT_PACKAGE_DEPENDS ", python (>= 2.7), python-pip")
+  else()
+    STRING(APPEND CPACK_DEBIAN_XRT_PACKAGE_DEPENDS ", python3, python3-pip")
+  endif()
 
 elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS|Amazon)")
   execute_process(

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -68,8 +68,8 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
 else()
   # On older systems libboost_system.a is not compiled with -fPIC which leads to
   # link errors when XRT shared objects try to link with it.
-  # Static linking with Boost is enabled on Ubuntu 18.04 and later versions.
-  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} VERSION_GREATER 17.10))
+  # Static linking with Boost is enabled on Ubuntu 18.04 but not 20.04
+  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STREQUAL 18.04))
     set(Boost_USE_STATIC_LIBS  ON)
   endif()
   find_package(Boost 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -158,8 +158,6 @@ ub_package_list()
      opencl-headers \
      ocl-icd-opencl-dev \
      perl \
-     python \
-     python-pip \
      pciutils \
      pkg-config \
      protobuf-compiler \
@@ -177,6 +175,12 @@ ub_package_list()
 
     if [[ $docker == 0 ]]; then
         UB_LIST+=(linux-headers-$(uname -r))
+    fi
+
+    if [[ $VERSION == 20.04 ]]; then
+        UB_LIST+=(python3 python3-pip)
+    else
+        UB_LIST+=(python python-pip)
     fi
 
     #dmidecode is only applicable for x86_64


### PR DESCRIPTION
These are quick fixes to build XRT on Ubuntu 20.04. Python is a bit of a mess and needs to be cleaned up in xrtdeps.sh, cpackLin.cmake, and postinst.in.