### PR TITLE
CR-1064446 Firewall tripped for u50 after xbutil clock test

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -711,6 +711,10 @@ static int icap_ocl_update_clock_freq_topology(struct platform_device *pdev,
 
 	err = ulp_clock_update(icap, freq_obj->ocl_target_freq,
 		ARRAY_SIZE(freq_obj->ocl_target_freq), 1);
+	if (err)
+		goto done;
+
+	err = icap_calibrate_mig(pdev);
 done:
 	mutex_unlock(&icap->icap_lock);
 	icap_xclbin_rd_unlock(icap);


### PR DESCRIPTION
For 2RP platform, we have to do mig calibration after programmed ulp clock, before anyone touch the memory bank.