### PR TITLE
CR-1056085 Creating 2 programs in single process throws error

### DIFF
--- a/src/runtime_src/core/common/uuid.h
+++ b/src/runtime_src/core/common/uuid.h
@@ -72,7 +72,32 @@ struct uuid
     return str;
   }
 
-  bool operator < (const uuid& rhs) const
+  bool
+  operator == (const xuid_t& xuid) const
+  {
+    return uuid_compare(m_uuid, xuid) == 0;
+  }
+
+  bool
+  operator != (const xuid_t& xuid) const
+  {
+    return uuid_compare(m_uuid, xuid) != 0;
+  }
+
+  bool
+  operator == (const uuid& rhs) const
+  {
+    return uuid_compare(m_uuid, rhs.m_uuid) == 0;
+  }
+
+  bool
+  operator != (const uuid& rhs) const
+  {
+    return uuid_compare(m_uuid, rhs.m_uuid) != 0;
+  }
+
+  bool
+  operator < (const uuid& rhs) const
   {
     return uuid_compare(m_uuid, rhs.m_uuid) < 0;
   }

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -171,6 +171,14 @@ get_xclbin(const device* d) const
   return m_binaries.begin()->second;
 }
 
+xrt_core::uuid
+program::
+get_xclbin_uuid(const device* d) const
+{
+  auto xclbin = get_xclbin(d);
+  return xclbin.uuid();
+}
+
 std::pair<const char*, const char*>
 program::
 get_xclbin_binary(const device* d) const

--- a/src/runtime_src/xocl/core/program.h
+++ b/src/runtime_src/xocl/core/program.h
@@ -146,6 +146,13 @@ public:
   get_xclbin(const device* d) const;
 
   /**
+   * @return
+   *   The uuid of xclbin for argument device
+   */
+  xrt_core::uuid
+  get_xclbin_uuid(const device* d) const;
+
+  /**
    * Return the xclbin binary for argument device
    *
    * @param d


### PR DESCRIPTION
Allow clCreateProgramWithBinary to be called twice with same list
of devices and binaries.   Check that the xclbin uuid of currently
programmed binaries match those passed to second call to API.