### PR TITLE
XmaEncoder Properties: Updates need for Custom Rate Control integration with Look Ahead

### DIFF
--- a/src/xma/include/app/xmaencoder.h
+++ b/src/xma/include/app/xmaencoder.h
@@ -118,6 +118,8 @@ typedef struct XmaEncoderProperties
     /** aq_mode  */
     int32_t         aq_mode;
     int32_t         minQP;
+    /** Rate Control Mode for Custom Rate Control **/
+    int32_t 	    rc_mode;
     /** force property values to be accepted by encoder plugin */
     int32_t         force_param;
     /** array of kernel-specific custom initialization parameters */

--- a/src/xma/include/app/xmaencoder.h
+++ b/src/xma/include/app/xmaencoder.h
@@ -120,6 +120,8 @@ typedef struct XmaEncoderProperties
     int32_t         minQP;
     /** Rate Control Mode for Custom Rate Control **/
     int32_t 	    rc_mode;
+    /** Look Ahead Depth  needed to count number of Custom RC Params **/
+    int32_t        la_depth;
     /** force property values to be accepted by encoder plugin */
     int32_t         force_param;
     /** array of kernel-specific custom initialization parameters */

--- a/src/xma/xma_legacy/include/app/xmaencoder.h
+++ b/src/xma/xma_legacy/include/app/xmaencoder.h
@@ -255,6 +255,8 @@ typedef struct XmaEncoderProperties
     int32_t         minQP;
     /** force property values to be accepted by encoder plugin */
     int32_t         force_param;
+    /** Rate Control Mode for Custom Rate Control **/
+    int32_t        rc_mode;
     /** array of kernel-specific custom initialization parameters */
     XmaParameter    *params;
     /** count of custom parameters for port */

--- a/src/xma/xma_legacy/include/app/xmaencoder.h
+++ b/src/xma/xma_legacy/include/app/xmaencoder.h
@@ -257,6 +257,8 @@ typedef struct XmaEncoderProperties
     int32_t         force_param;
     /** Rate Control Mode for Custom Rate Control **/
     int32_t        rc_mode;
+    /** Look Ahead Depth  needed to count number of Custom RC Params **/
+    int32_t        la_depth;
     /** array of kernel-specific custom initialization parameters */
     XmaParameter    *params;
     /** count of custom parameters for port */


### PR DESCRIPTION
This pull-request contains updates to both xma and xma_legacy XmaEncoder properties to absorb lookahead depth and custom-rate-control flags.

- The Lookahead IP collects statistics about the next N frames (N could be between 1 and 30).
- Custom Rate Control utilizes this statistics, sends Frame SAD &Frame Activity to the U30 soft-kernels
- For low latency use-cases the Look Ahead Depth could be 1 frame
- For regular latency use-case the Look-Ahead Depth could be 16, 18 or 20 frames.
-  Custom RC = 1 (Enabled), XMA Plugins need to send this enable/disable flag to U30 soft-kernels

Such details come from the FFmpeg command line arguments, and need to be captured and made a part of the Encoder Properties for the plugins to consume and take appropriate action.