### PR TITLE
CR-1032457 update

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -100,7 +100,7 @@ check_os_release(const std::vector<std::string> kernel_versions, std::ostream &o
             break;
         }
     }
-    ostr << "ERROR: Kernel verison " << release << " is not supported. " 
+    ostr << "WARNING: Kernel verison " << release << " is not officially supported. " 
         << kernel_versions.back() << " is the latest supported version" << std::endl;
     return ret;
 }
@@ -1396,7 +1396,7 @@ int xcldev::device::kernelVersionTest(void)
         return -EOPNOTSUPP;
     }
     if (!is_supported_kernel_version(std::cout)) {
-        return  -ENODEV;
+        return  1;
     }
     return 0;
 }


### PR DESCRIPTION
Sample output:
```
$ Debug/opt/xilinx/xrt/bin/xbutil validate -q
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_u200_xdma_201830_2
INFO: == Starting Kernel version check:
WARNING: Kernel verison 5.4.0-142-generic is not officially supported. 5.3.0 is the latest supported version
WARN: == Kernel version check PASSED with warning
INFO: == Starting AUX power connector check:
AUX POWER NOT CONNECTED, ATTENTION
Board not stable for heavy acceleration tasks.
WARN: == AUX power connector check PASSED with warning
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated with warnings.
```
