### PR TITLE
data structure members used in threads submitting CU cmds and complet…

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -39,15 +39,23 @@ struct kds_client {
 	struct list_head	  link;
 	struct device	         *dev;
 	struct pid	         *pid;
-	struct kds_controller   **ctrl;
-	wait_queue_head_t	  waitq;
-	atomic_t		  event;
 #if PRE_ALLOC
 	u32			  max_xcmd;
 	u32			  xcmd_idx;
 	void			 *xcmds;
 	void			 *infos;
 #endif
+	/*
+	 * "ctrl" is used in thread that is submitting CU cmds.
+	 * "waitq" and "event" are modified in thread that is completing them.
+	 * In order to prevent false sharing, they need to be in different
+	 * cache lines. Hence we add a "padding" in between (assuming 128-byte
+	 * is big enough for most CPU architectures).
+	 */
+	struct kds_controller   **ctrl;
+	u64			  padding[16];
+	wait_queue_head_t	  waitq;
+	atomic_t		  event;
 };
 #define	CLIENT_NUM_CU(client) (0)
 

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -152,6 +152,14 @@ struct xrt_cu {
 	struct list_head	  pq;
 	spinlock_t		  pq_lock;
 	u32			  num_pq;
+	/*
+	 * Pending Q is used in thread that is submitting CU cmds.
+	 * Other Qs are used in thread that is completing them.
+	 * In order to prevent false sharing, they need to be in different
+	 * cache lines. Hence we add a "padding" in between (assuming 128-byte
+	 * is big enough for most CPU architectures).
+	 */
+	u64			  padding[16];
 	/* run queue */
 	struct list_head	  rq;
 	u32			  num_rq;

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -104,7 +104,8 @@ int xrt_cu_thread(void *data)
 		 */
 		if (process_rq(xcu))
 			continue;
-		/* process completed queue before submitted queue, for two reasons
+		/* process completed queue before submitted queue, for
+		 * two reasons:
 		 * - The last submitted command may be still running
 		 * - while handling completed queue, running command might done
 		 * - process_sq will check CU status, which is thru slow bus
@@ -141,7 +142,7 @@ int xrt_cu_thread(void *data)
 void xrt_cu_submit(struct xrt_cu *xcu, struct kds_command *xcmd)
 {
 	unsigned long flags;
-	bool first_command;
+	bool first_command = false;
 
 	/* Add command to pending queue
 	 * wakeup CU thread if it is the first command
@@ -172,13 +173,8 @@ int xrt_cu_init(struct xrt_cu *xcu)
 	INIT_LIST_HEAD(&xcu->sq);
 	/* Initialize completed queue */
 	INIT_LIST_HEAD(&xcu->cq);
-	xcu->num_pq = 0;
-	xcu->num_rq = 0;
-	xcu->num_sq = 0;
-	xcu->num_cq = 0;
 
 	sema_init(&xcu->sem, 0);
-	xcu->stop = 0;
 	xcu->thread = kthread_run(xrt_cu_thread, xcu, "xrt_thread");
 
 	return err;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -31,6 +31,42 @@ static int cu_submit(struct platform_device *pdev, struct kds_command *xcmd)
 	return 0;
 }
 
+static ssize_t debug_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+#if 0
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+	struct xrt_cu *xcu = &cu->base;
+#endif
+	/* Place holder for now. */
+	return 0;
+}
+
+static ssize_t debug_store(struct device *dev,
+	struct device_attribute *da, const char *buf, size_t count)
+{
+#if 0
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+	struct xrt_cu *xcu = &cu->base;
+#endif
+
+	/* Place holder for now. */
+	return count;
+}
+
+static DEVICE_ATTR_RW(debug);
+
+static struct attribute *cu_attrs[] = {
+	&dev_attr_debug.attr,
+	NULL,
+};
+
+static const struct attribute_group cu_attrgroup = {
+	.attrs = cu_attrs,
+};
+
 static int cu_probe(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -88,6 +124,9 @@ static int cu_probe(struct platform_device *pdev)
 		goto err2;
 	}
 
+	if (sysfs_create_group(&pdev->dev.kobj, &cu_attrgroup))
+		XCU_ERR(xcu, "Not able to create CU sysfs group");
+
 	platform_set_drvdata(pdev, xcu);
 
 	return 0;
@@ -112,6 +151,8 @@ static int cu_remove(struct platform_device *pdev)
 	xcu = platform_get_drvdata(pdev);
 	if (!xcu)
 		return -EINVAL;
+
+	(void) sysfs_remove_group(&pdev->dev.kobj, &cu_attrgroup);
 
 	info = &xcu->base.info;
 	switch (info->model) {


### PR DESCRIPTION
…ing them should be in different CU cache line for better performance

False sharing is hurting new KDS performance. After separate data structure members in different CPU cache line, I can see ~20% performance improvement in echo mode.

Also added a sysfs node place holder for debug purpose.