### PR TITLE
XRT-519 Check ERT major version

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -111,6 +111,11 @@ struct xocl_msix_privdata {
 	u32			total;
 };
 
+struct xocl_ert_sched_privdata {
+	char			dsa;
+	int			major;
+};
+
 #ifdef __KERNEL__
 #define XOCL_PCI_DEVID(ven, dev, subsysid, priv)	\
 	 .vendor = ven, .device=dev, .subvendor = PCI_ANY_ID, \
@@ -1426,6 +1431,11 @@ struct xocl_subdev_map {
 			}				\
 		})
 
+#define XOCL_RES_SCHEDULER_PRIV				\
+	((struct xocl_ert_sched_privdata) {		\
+		1,					\
+		1,					\
+	 })
 
 #define	XOCL_DEVINFO_SCHEDULER				\
 	{						\
@@ -1433,8 +1443,8 @@ struct xocl_subdev_map {
 		XOCL_MB_SCHEDULER,			\
 		XOCL_RES_SCHEDULER,			\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER),		\
-		&(char []){1},				\
-		1,					\
+		&XOCL_RES_SCHEDULER_PRIV,		\
+		sizeof(struct xocl_ert_sched_privdata),	\
 		.override_idx = -1,			\
 	}
 
@@ -1458,17 +1468,22 @@ struct xocl_subdev_map {
 			}				\
 		})
 
-
 #define	XOCL_DEVINFO_SCHEDULER_QDMA			\
 	{						\
 		XOCL_SUBDEV_MB_SCHEDULER,		\
 		XOCL_MB_SCHEDULER,			\
 		XOCL_RES_SCHEDULER_QDMA,		\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER_QDMA),	\
-		&(char []){1},				\
-		1,					\
+		&XOCL_RES_SCHEDULER_PRIV,		\
+		sizeof(struct xocl_ert_sched_privdata),	\
 		.override_idx = -1,			\
 	}
+
+#define XOCL_RES_SCHEDULER_PRIV_51			\
+	((struct xocl_ert_sched_privdata) {		\
+		0,					\
+		1,					\
+	 })
 
 #define	XOCL_DEVINFO_SCHEDULER_51			\
 	{						\
@@ -1476,8 +1491,8 @@ struct xocl_subdev_map {
 		XOCL_MB_SCHEDULER,			\
 		XOCL_RES_SCHEDULER,			\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER),		\
-		&(char []){0},				\
-		1,					\
+		&XOCL_RES_SCHEDULER_PRIV_51,		\
+		sizeof(struct xocl_ert_sched_privdata),	\
 		.override_idx = -1,			\
 	}
 
@@ -1514,8 +1529,8 @@ struct xocl_subdev_map {
 		XOCL_MB_SCHEDULER,			\
 		XOCL_RES_SCHEDULER_VERSAL,		\
 		ARRAY_SIZE(XOCL_RES_SCHEDULER_VERSAL),	\
-		&(char []){0},		\
-		1,					\
+		&XOCL_RES_SCHEDULER_PRIV_51,		\
+		sizeof(struct xocl_ert_sched_privdata),	\
 		.bar_idx = (char []){ 2, 2 },		\
 		.override_idx = -1,			\
 	}
@@ -2640,8 +2655,8 @@ struct xocl_subdev_map {
 		XOCL_MB_SCHEDULER,			\
 		NULL,					\
 		0,					\
-		&(char []){1},				\
-		1,					\
+		&XOCL_RES_SCHEDULER_PRIV,		\
+		sizeof(struct xocl_ert_sched_privdata),	\
 		.override_idx = -1,			\
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -508,7 +508,7 @@ int xclmgmt_update_userpf_blob(struct xclmgmt_dev *lro)
 	int ret;
 	struct FeatureRomHeader	rom_header;
 	int offset;
-	int *version;
+	const int *version;
 
 	if (!lro->core.fdt_blob)
 		return 0;
@@ -567,7 +567,7 @@ int xclmgmt_update_userpf_blob(struct xclmgmt_dev *lro)
 	offset = xocl_fdt_path_offset(lro, lro->userpf_blob,
 					"/" NODE_ENDPOINTS "/" NODE_ERT_SCHED);
 	if (offset < 0) {
-		mgmt_err(lro, "get ert firmware node failed %d", offset);
+		mgmt_err(lro, "get ert sched node failed %d", offset);
 	}
 	(void) xocl_fdt_setprop(lro, lro->userpf_blob, offset, PROP_VERSION_MAJOR,
 				version, sizeof(int));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -507,6 +507,8 @@ int xclmgmt_update_userpf_blob(struct xclmgmt_dev *lro)
 	int len, userpf_idx;
 	int ret;
 	struct FeatureRomHeader	rom_header;
+	int offset;
+	int *version;
 
 	if (!lro->core.fdt_blob)
 		return 0;
@@ -551,6 +553,24 @@ int xclmgmt_update_userpf_blob(struct xclmgmt_dev *lro)
 		mgmt_err(lro, "add vrom failed %d", ret);
 		goto failed;
 	}
+
+	/* Get ERT firmware major version from mgmtpf blob */
+	offset = xocl_fdt_path_offset(lro, lro->core.fdt_blob,
+					"/" NODE_ENDPOINTS "/" NODE_ERT_FW_MEM
+					"/" NODE_FIRMWARE);
+	if (offset < 0) {
+		mgmt_err(lro, "get ert firmware node failed %d", offset);
+	}
+	version = xocl_fdt_getprop(lro, lro->core.fdt_blob, offset, PROP_VERSION_MAJOR, NULL);
+
+	/* Add ERT firmware major version to userpf blob */
+	offset = xocl_fdt_path_offset(lro, lro->userpf_blob,
+					"/" NODE_ENDPOINTS "/" NODE_ERT_SCHED);
+	if (offset < 0) {
+		mgmt_err(lro, "get ert firmware node failed %d", offset);
+	}
+	(void) xocl_fdt_setprop(lro, lro->userpf_blob, offset, PROP_VERSION_MAJOR,
+				version, sizeof(int));
 
 	fdt_pack(lro->userpf_blob);
 	lro->userpf_blob_updated = true;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1651,7 +1651,7 @@ const struct axlf_section_header *xocl_axlf_section_header(
 	enum axlf_section_kind kind);
 int xocl_fdt_path_offset(xdev_handle_t xdev_hdl, void *blob, const char *path);
 int xocl_fdt_setprop(xdev_handle_t xdev_hdl, void *blob, int off,
-		     char *name, void *val, int size);
+		     const char *name, const void *val, int size);
 const void *xocl_fdt_getprop(xdev_handle_t xdev_hdl, void *blob, int off,
 			     char *name, int *lenp);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1649,6 +1649,11 @@ int xocl_fdt_parse_blob(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 const struct axlf_section_header *xocl_axlf_section_header(
 	xdev_handle_t xdev_hdl, const struct axlf *top,
 	enum axlf_section_kind kind);
+int xocl_fdt_path_offset(xdev_handle_t xdev_hdl, void *blob, const char *path);
+int xocl_fdt_setprop(xdev_handle_t xdev_hdl, void *blob, int off,
+		     char *name, void *val, int size);
+const void *xocl_fdt_getprop(xdev_handle_t xdev_hdl, void *blob, int off,
+			     char *name, int *lenp);
 
 
 /* init functions */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -66,7 +66,7 @@ static void *ert_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
         struct xocl_dev_core *core = XDEV(xdev_hdl);
 	void *blob;
         int node;
-	u32 *major;
+	const u32 *major;
 	struct xocl_ert_sched_privdata *priv_data;
 
         blob = core->fdt_blob;
@@ -1053,7 +1053,7 @@ int xocl_fdt_add_pair(xdev_handle_t xdev_hdl, void *blob, char *name,
 }
 
 int xocl_fdt_setprop(xdev_handle_t xdev_hdl, void *blob, int off,
-		     char *name, void *val, int size)
+		     const char *name, const void *val, int size)
 {
 	return fdt_setprop(blob, off, name, val, size);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -63,16 +63,33 @@ static void *msix_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 
 static void *ert_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 {
-	char *priv_data;
+        struct xocl_dev_core *core = XDEV(xdev_hdl);
+	void *blob;
+        int node;
+	u32 *major;
+	struct xocl_ert_sched_privdata *priv_data;
 
-	priv_data = vzalloc(1);
+        blob = core->fdt_blob;
+        if (!blob)
+                return NULL;
+
+	priv_data = vzalloc(sizeof(*priv_data));
 	if (!priv_data) {
 		*len = 0;
 		return NULL;
 	}
 
-	*priv_data = 1;
-	*len = 1;
+        node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_ERT_SCHED);
+        if (node < 0) {
+                xocl_xdev_err(xdev_hdl, "did not find ert sched node in %s", NODE_ENDPOINTS);
+                return NULL;
+        }
+
+	major = fdt_getprop(blob, node, PROP_VERSION_MAJOR, NULL);
+	priv_data->major = be32_to_cpu(*major);
+
+	priv_data->dsa = 1;
+	*len = sizeof(*priv_data);
 
 	return priv_data;
 }
@@ -1035,6 +1052,18 @@ int xocl_fdt_add_pair(xdev_handle_t xdev_hdl, void *blob, char *name,
 	return ret;
 }
 
+int xocl_fdt_setprop(xdev_handle_t xdev_hdl, void *blob, int off,
+		     char *name, void *val, int size)
+{
+	return fdt_setprop(blob, off, name, val, size);
+}
+
+const void *xocl_fdt_getprop(xdev_handle_t xdev_hdl, void *blob, int off,
+			     char *name, int *lenp)
+{
+	return fdt_getprop(blob, off, name, lenp);
+}
+
 int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 		int part_level, char *vbnv)
 {
@@ -1173,6 +1202,11 @@ int xocl_fdt_get_p2pbar(xdev_handle_t xdev_hdl, void *blob)
 		return -EINVAL;
 
 	return ntohl(*p2p_bar);
+}
+
+int xocl_fdt_path_offset(xdev_handle_t xdev_hdl, void *blob, const char *path)
+{
+	return fdt_path_offset(blob, path);
 }
 
 int xocl_fdt_build_priv_data(xdev_handle_t xdev_hdl, struct xocl_subdev *subdev,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -28,11 +28,13 @@
 #define PROP_PARTITION_INFO_BLP "blp_info"
 #define PROP_PARTITION_INFO_PLP "plp_info"
 #define PROP_PARTITION_LEVEL "partition_level"
+#define PROP_VERSION_MAJOR "firmware_version_major"
 
 #define NODE_ENDPOINTS "addressable_endpoints"
 #define INTERFACES_PATH "/interfaces"
 
 #define NODE_PROPERTIES "partition_info"
+#define NODE_FIRMWARE "firmware"
 
 #define NODE_FLASH "ep_card_flash_program_00"
 #define NODE_XVC_PUB "ep_debug_bscan_user_00"


### PR DESCRIPTION
Add ERT major version into userpf fdt blob.
For old devices based on devices.h, use ERT major version 1.

If ERT firmware version > 2, it would simply fallback to kds mode.

Test with U50/U30/U200_QDMA