### PR TITLE
xbmgmt2/xbutil2: Added support for hidden options.

### DIFF
--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -26,10 +26,12 @@ namespace XBU = XBUtilities;
 namespace po = boost::program_options;
 
 OptionOptions::OptionOptions( const std::string & _longName,
+                              bool _isHidden,
                               const std::string & _description)
   : m_executable("<unknown>")
   , m_command("<unknown>")
   , m_longName(_longName)
+  , m_isHidden(_isHidden)
   , m_description(_description)
   , m_extendedHelp("")
 {
@@ -39,6 +41,9 @@ OptionOptions::OptionOptions( const std::string & _longName,
 void 
 OptionOptions::printHelp() const
 {
-  XBU::report_subcommand_help(m_executable, m_command + " --" + m_longName, m_description, m_extendedHelp, m_optionsDescription, m_positionalOptions);
+  XBU::report_subcommand_help( m_executable, 
+                               m_command + " --" + m_longName, 
+                               m_description, m_extendedHelp, 
+                               m_optionsDescription, m_optionsHidden, m_positionalOptions);
 }
 

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -32,6 +32,8 @@ class OptionOptions {
   const std::string &longName() const { return m_longName; };
   const std::string &description() const {return m_description; };
   const std::string &extendedHelp() const { return m_extendedHelp; };
+  bool isHidden() const { return m_isHidden; };
+
   void setExecutable( const std::string &_executable) {m_executable = _executable; };
   void setCommand( const std::string & _command) {m_command = _command; };
 
@@ -45,7 +47,7 @@ class OptionOptions {
 
  // Child class Helper methods
  protected:
-  OptionOptions(const std::string & _longName, const std::string & _description);
+  OptionOptions(const std::string & _longName, bool _isHidden, const std::string & _description);
   void setExtendedHelp(const std::string &_extendedHelp) { m_extendedHelp = _extendedHelp; };
   void printHelp() const;
 
@@ -55,12 +57,14 @@ class OptionOptions {
  // Variables
  protected:
   boost::program_options::options_description m_optionsDescription;
+  boost::program_options::options_description m_optionsHidden;
   boost::program_options::positional_options_description m_positionalOptions;
 
  private:
   std::string m_executable;
   std::string m_command;
   std::string m_longName;
+  bool m_isHidden;
   std::string m_description;
   std::string m_extendedHelp;
 };

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -39,17 +39,19 @@ SubCmd::SubCmd(const std::string & _name,
 }
 
 void
-SubCmd::printHelp( const boost::program_options::options_description & _optionDescription) const
+SubCmd::printHelp( const boost::program_options::options_description & _optionDescription,
+                   const boost::program_options::options_description & _optionHidden) const
 {
   boost::program_options::positional_options_description emptyPOD;
-  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, emptyPOD);
+  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, emptyPOD);
 }
 
 void
 SubCmd::printHelp( const boost::program_options::options_description & _optionDescription,
+                   const boost::program_options::options_description & _optionHidden,
                    const SubOptionOptions & _subOptionOptions) const
 {
- XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _subOptionOptions);
+ XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions);
 }
 
 

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -57,8 +57,10 @@ public:
   void setIsPreliminary(bool _isPreliminary) { m_isPreliminary = _isPreliminary; };
   void setLongDescription(const std::string &_longDescription) {m_longDescription = _longDescription; };
   void setExampleSyntax(const std::string &_exampleSyntax) {m_exampleSyntax = _exampleSyntax; };
-  void printHelp(const boost::program_options::options_description & _optionDescription) const;
   void printHelp(const boost::program_options::options_description & _optionDescription,
+                 const boost::program_options::options_description & _optionHidden) const;
+  void printHelp( const boost::program_options::options_description & _optionDescription,
+                  const boost::program_options::options_description & _optionHidden,
                   const SubOptionOptions & _subOptionOptions) const;
   void conflictingOptions( const boost::program_options::variables_map& _vm, 
                            const std::string &_opt1, const std::string &_opt2) const;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -35,6 +35,7 @@ namespace XBUtilities {
     report_commands_help( const std::string &_executable, 
                           const std::string &_description,
                           const boost::program_options::options_description& _optionDescription,
+                          const boost::program_options::options_description& _optionHidden,
                           const SubCmdsCollection &_subCmds );
   void 
     report_subcommand_help( const std::string &_executableName,
@@ -42,6 +43,7 @@ namespace XBUtilities {
                             const std::string &_description, 
                             const std::string &_extendedHelp,
                             const boost::program_options::options_description & _optionDescription,
+                            const boost::program_options::options_description &_optionHidden,
                             const boost::program_options::positional_options_description & _positionalDescription );
 
   void 
@@ -50,6 +52,7 @@ namespace XBUtilities {
                             const std::string &_description, 
                             const std::string &_extendedHelp,
                             const boost::program_options::options_description &_optionDescription,
+                            const boost::program_options::options_description &_optionHidden,
                             const SubCmd::SubOptionOptions & _subOptionOptions);
 
   void 

--- a/src/runtime_src/core/tools/common/XBMain.h
+++ b/src/runtime_src/core/tools/common/XBMain.h
@@ -18,12 +18,14 @@
 #define __XBMgmtMain_h_
 
 // Include files
+
 // Please keep these to the bare minimum
 #include "XBHelpMenus.h"
 #include <string>
     
 // ---------------------- F U N C T I O N S ----------------------------------
 void main_(int argc, char** argv, 
+           const std::string & _executable,
            const std::string & _description,
            const SubCmdsCollection & _SubCmds);
 #endif

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -38,6 +38,7 @@ using namespace XBUtilities;
 static bool m_bVerbose = false;
 static bool m_bTrace = false;
 static bool m_disableEscapeCodes = false;
+static bool m_bShowHidden = false;
 
 
 // ------ F U N C T I O N S ---------------------------------------------------
@@ -46,27 +47,42 @@ XBUtilities::setVerbose(bool _bVerbose)
 {
   bool prevVerbose = m_bVerbose;
 
-  if ((prevVerbose == true) && (_bVerbose == false)) {
+  if ((prevVerbose == true) && (_bVerbose == false)) 
     verbose("Disabling Verbosity");
-  }
 
   m_bVerbose = _bVerbose;
 
-  if ((prevVerbose == false) && (_bVerbose == true)) {
+  if ((prevVerbose == false) && (_bVerbose == true)) 
     verbose("Enabling Verbosity");
-  }
 }
 
 void 
 XBUtilities::setTrace(bool _bTrace)
 {
-  if (_bTrace) {
+  if (_bTrace) 
     trace("Enabling Tracing");
-  } else {
+  else 
     trace("Disabling Tracing");
-  }
 
   m_bTrace = _bTrace;
+}
+
+
+void 
+XBUtilities::setShowHidden(bool _bShowHidden)
+{
+  if (_bShowHidden) 
+    trace("Hidden commands and options will be shown.");
+  else 
+    trace("Hidden commands and options will be hidden");
+
+  m_bShowHidden = _bShowHidden;
+}
+
+bool
+XBUtilities::getShowHidden()
+{
+  return m_bShowHidden;
 }
 
 void 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -47,6 +47,10 @@ namespace XBUtilities {
    */
   void setVerbose(bool _bVerbose);
   void setTrace(bool _bVerbose);
+
+  void setShowHidden(bool _bShowHidden);
+  bool getShowHidden();
+
   void disable_escape_codes( bool _disable );
   bool is_esc_enabled();  
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Clock.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Clock.cpp
@@ -26,8 +26,8 @@ namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_Clock::OO_Clock( const std::string &_longName)
-    : OptionOptions(_longName, "Set the frequency on the named clock")
+OO_Clock::OO_Clock( const std::string &_longName, bool _isHidden)
+    : OptionOptions(_longName, _isHidden, "Set the frequency on the named clock")
     , m_device("")
     , m_clockName("")
     , m_clockFreq("")

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Clock.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Clock.h
@@ -24,7 +24,7 @@ class OO_Clock : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_Clock(const std::string &_longName);
+  OO_Clock(const std::string &_longName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -117,8 +117,8 @@ memory_retention(std::shared_ptr<xrt_core::device>& dev,
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_Config::OO_Config( const std::string &_longName)
-    : OptionOptions(_longName, "<Add description>")
+OO_Config::OO_Config( const std::string &_longName, bool _isHidden)
+    : OptionOptions(_longName, _isHidden, "<Add description>")
     , m_device({})
     , m_help(false)
     , m_daemon(false)
@@ -135,17 +135,20 @@ OO_Config::OO_Config( const std::string &_longName)
 {
   m_optionsDescription.add_options()
     ("device,d", boost::program_options::value<decltype(m_device)>(&m_device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("enable_retention", boost::program_options::bool_switch(&m_enable_retention), "<add description>")
+    ("disable_retention", boost::program_options::bool_switch(&m_disable_retention), "<add description>")
+    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+  ;
+
+  m_optionsHidden.add_options()
     ("daemon", boost::program_options::bool_switch(&m_daemon), "<add description>")
     ("host", boost::program_options::value<decltype(m_host)>(&m_host), "ip or hostname for peer")
     ("security", boost::program_options::value<decltype(m_security)>(&m_security), "<add description>")
     ("runtime_clk_scale", boost::program_options::value<decltype(m_clk_scale)>(&m_clk_scale), "<add description>")
     ("cs_threshold_power_override", boost::program_options::value<decltype(m_power_override)>(&m_power_override), "<add description>")
     ("show", boost::program_options::bool_switch(&m_show), "<add description>")
-    ("enable_retention", boost::program_options::bool_switch(&m_enable_retention), "<add description>")
-    ("disable_retention", boost::program_options::bool_switch(&m_disable_retention), "<add description>")
     ("ddr", boost::program_options::bool_switch(&m_ddr), "<add description>")
     ("hbm", boost::program_options::bool_switch(&m_hbm), "<add description>")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
@@ -26,7 +26,7 @@ class OO_Config : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_Config(const std::string &_longName);
+  OO_Config(const std::string &_longName, bool _isHidden = false);
 
  private:
   std::vector<std::string> m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_NIFD.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_NIFD.cpp
@@ -26,8 +26,8 @@ namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_NIFD::OO_NIFD( const std::string &_longName)
-    : OptionOptions(_longName, "<add description>")
+OO_NIFD::OO_NIFD( const std::string &_longName, bool _isHidden)
+    : OptionOptions(_longName, _isHidden, "<add description>")
     , m_device("")
     , m_help(false)
 {

--- a/src/runtime_src/core/tools/xbmgmt2/OO_NIFD.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_NIFD.h
@@ -24,7 +24,7 @@ class OO_NIFD : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_NIFD(const std::string &_longName);
+  OO_NIFD(const std::string &_longName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -432,8 +432,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   bool help = false;
   bool force = false;
 
-  po::options_description queryDesc("Options");  // Note: Boost will add the colon.
-  queryDesc.add_options()
+  po::options_description commonOptions("Common Options");  
+  commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' indicates that every found device should be examined.")
     ("plp", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
                                                                 "  Name (and path) of the partiaion.\n"
@@ -454,21 +454,29 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");  
+
+  po::options_description allOptions("All Options");  
+
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(queryDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
     throw; // Re-throw exception
   }
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 
@@ -562,5 +570,5 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   }
 
   std::cout << "\nERROR: Missing flash operation.  No action taken.\n\n";
-  printHelp(queryDesc);
+  printHelp(commonOptions, hiddenOptions);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -139,8 +139,8 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   bool help = false;
   bool force = false; //TO-DO: remove this when the global force is implemented
 
-  po::options_description resetDesc("Options");
-  resetDesc.add_options()
+  po::options_description commonOptions("Common Options");
+  commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("type,r", boost::program_options::value<decltype(type)>(&type)->implicit_value("hot"), "The type of reset to perform. Types resets available:\n"
                                                                         "  hot          - Hot reset (default)\n"
@@ -151,15 +151,21 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");
+
+  po::options_description allOptions("All Options");
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(resetDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(resetDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -167,7 +173,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(resetDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdStatus.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdStatus.cpp
@@ -77,8 +77,8 @@ SubCmdStatus::execute(const SubCmdOptions& _options) const
   bool bHelp = false;
 
   // -- Retrieve and parse the subcommand options -----------------------------
-  po::options_description queryDesc("Options");  // Note: Boost will add the colon.
-  queryDesc.add_options()
+  po::options_description commonOptions("Common Options");  
+  commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
@@ -87,21 +87,27 @@ SubCmdStatus::execute(const SubCmdOptions& _options) const
     ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");  
+
+  po::options_description allOptions("All Options");  
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(queryDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
     throw; // Re-throw exception
   }
 
   // Check to see if help was requested 
   if (bHelp == true)  {
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 
@@ -146,7 +152,7 @@ SubCmdStatus::execute(const SubCmdOptions& _options) const
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -53,9 +53,8 @@ int main( int argc, char** argv )
 
   const std::string executable = "xbmgmt";
 
-  for (auto & subCommand : subCommands) {
+  for (auto & subCommand : subCommands) 
     subCommand->setExecutableName(executable);
-  }
 
   // -- Program Description
   const std::string description = 
@@ -64,7 +63,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_(argc, argv, description, subCommands);
+    main_(argc, argv, executable, description, subCommands);
     return 0;
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());

--- a/src/runtime_src/core/tools/xbutil2/OO_Clock.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_Clock.cpp
@@ -26,8 +26,8 @@ namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_Clock::OO_Clock( const std::string &_longName)
-    : OptionOptions(_longName, "Set the frequency on the named clock")
+OO_Clock::OO_Clock( const std::string &_longName, bool _isHidden)
+    : OptionOptions(_longName, _isHidden, "Set the frequency on the named clock")
     , m_device("")
     , m_clockName("")
     , m_clockFreq("")

--- a/src/runtime_src/core/tools/xbutil2/OO_Clock.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_Clock.h
@@ -24,7 +24,7 @@ class OO_Clock : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_Clock(const std::string &_longName);
+  OO_Clock(const std::string &_longName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -26,8 +26,8 @@ namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_MemRead::OO_MemRead( const std::string &_longName )
-    : OptionOptions(_longName,  "Read from the given memory address" )
+OO_MemRead::OO_MemRead( const std::string &_longName, bool _isHidden )
+    : OptionOptions(_longName, _isHidden, "Read from the given memory address" )
     , m_device("")
     , m_baseAddress("")
     , m_sizeBytes("")

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.h
@@ -24,7 +24,7 @@ class OO_MemRead : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_MemRead( const std::string &_longName );
+  OO_MemRead( const std::string &_longName, bool _isHidden = false );
 
  private:
    std::string m_device;

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -26,8 +26,8 @@ namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_MemWrite::OO_MemWrite( const std::string &_longName)
-    : OptionOptions(_longName, "Write to a given memory address")
+OO_MemWrite::OO_MemWrite( const std::string &_longName, bool _isHidden)
+    : OptionOptions(_longName, _isHidden, "Write to a given memory address")
     , m_device("")
     , m_baseAddress("")
     , m_sizeBytes("")

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.h
@@ -24,7 +24,7 @@ class OO_MemWrite : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_MemWrite( const std::string &_longName);
+  OO_MemWrite( const std::string &_longName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -26,8 +26,8 @@ namespace XBU = XBUtilities;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-OO_P2P::OO_P2P( const std::string &_longName )
-    : OptionOptions(_longName, "Controls P2P functionality")
+OO_P2P::OO_P2P( const std::string &_longName, bool _isHidden )
+    : OptionOptions(_longName, _isHidden, "Controls P2P functionality")
     , m_device("")
     , m_action("")
     , m_help(false)

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.h
@@ -24,7 +24,7 @@ class OO_P2P : public OptionOptions {
   virtual void execute( const SubCmdOptions &_options ) const;
 
  public:
-  OO_P2P( const std::string &_longName);
+  OO_P2P( const std::string &_longName, bool _isHidden = false);
 
  private:
   std::string m_device;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -63,17 +63,15 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: advanced");
 
-  // ============= Define all of the options =================================
-  po::options_description allDesc;
-
   // -- Common top level options ---
   bool help = false;
 
-  po::options_description commonTopDesc("Common Options"); 
-  commonTopDesc.add_options()
+  po::options_description commonOptions("Common Options"); 
+  commonOptions.add_options()
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
-  allDesc.add(commonTopDesc);
+
+  po::options_description hiddenOptions("Hidden Options"); 
 
   // -- Define the supporting option options ----
   SubOptionOptions subOptionOptions;
@@ -83,17 +81,24 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
   subOptionOptions.emplace_back(std::make_shared<OO_P2P>("p2p"));
 
   for (auto & subOO : subOptionOptions) {
-    allDesc.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+    if (subOO->isHidden()) 
+      hiddenOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
+    else
+      commonOptions.add_options()(subOO->longName().c_str(), subOO->description().c_str());
     subOO->setExecutable(getExecutableName());
     subOO->setCommand(getName());
   }
+
+  po::options_description allOptions("All Options");
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
 
   // =========== Process the options ========================================
 
   // 1) Process the common top level options 
   po::parsed_options parsedCommonTop = 
     po::command_line_parser(_options).
-    options(allDesc).          
+    options(allOptions).          
     allow_unregistered().           // Allow for unregistered options
     run();                          // Parse the options
 
@@ -111,7 +116,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
     }
   } catch (const std::exception & e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
-    printHelp(allDesc, subOptionOptions);
+    printHelp(commonOptions, hiddenOptions, subOptionOptions);
     return;
   }
 
@@ -126,7 +131,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
-    printHelp(allDesc, subOptionOptions);
+    printHelp(commonOptions, hiddenOptions, subOptionOptions);
     return;
   }
 
@@ -137,11 +142,4 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
   }
 
   optionOption->execute(topOptions);
-
-  // Process the commands
-  // 2) Look for mutually exclusive options.  Error if found.
-  // 3) Look for sub-options and process them.  Process them, if none-found error.
-
-  // -- Now process the subcommand --------------------------------------------
-  // Is valid BDF value valid
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -120,22 +120,28 @@ SubCmdDmaTest::execute(const SubCmdOptions& _options) const
   std::string sBlockSizeKB;
   bool help = false;
 
-  po::options_description dmaTestDesc("dmatest options");
-  dmaTestDesc.add_options()
+  po::options_description commonOptions("Common Options");
+  commonOptions.add_options()
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
     (",d", boost::program_options::value<decltype(card)>(&card), "Card to be examined")
     (",b", boost::program_options::value<std::string>(&sBlockSizeKB), "Block Size KB")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");
+
+  po::options_description allOptions("All Options");  
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(dmaTestDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(dmaTestDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -143,7 +149,7 @@ SubCmdDmaTest::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(dmaTestDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -61,23 +61,29 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   std::string xclbin;
   bool help = false;
 
-  po::options_description programDesc("program options");
-  programDesc.add_options()
+  po::options_description commonOptions("Common Options");
+  commonOptions.add_options()
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
     (",d", boost::program_options::value<unsigned int>(&card), "Card to be examined")
     (",r", boost::program_options::value<uint64_t>(&region), "Card region")
     (",p", boost::program_options::value<std::string>(&xclbin), "The xclbin image to load")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");
+
+  po::options_description allOptions("All Options");  
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(programDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(programDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -85,7 +91,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(programDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 
@@ -122,5 +128,5 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
   std::cout << "\nERROR: Missing program operation. No action taken.\n\n";
-  printHelp(programDesc);
+  printHelp(commonOptions, hiddenOptions);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdQuery.cpp
@@ -169,21 +169,27 @@ SubCmdQuery::execute(const SubCmdOptions& _options) const
   xrt_core::device::id_type card = 0;
   bool help = false;
 
-  po::options_description queryDesc("query options");
-  queryDesc.add_options()
+  po::options_description commonOptions("Common options");
+  commonOptions.add_options()
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
     (",d", boost::program_options::value<decltype(card)>(&card), "Card to be examined.")
   ;
+
+  po::options_description hiddenOptions("Hidden options");
+
+  po::options_description allOptions("All options");
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
 
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(queryDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -191,7 +197,7 @@ SubCmdQuery::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(queryDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -52,8 +52,8 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   std::string reset = "all";
   bool help = false;
 
-  po::options_description resetDesc("Options");
-  resetDesc.add_options()
+  po::options_description commonOptions("Common Options");
+  commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("type,r", boost::program_options::value<decltype(reset)>(&reset), "The type of reset to perform. Types resets available:\n"
                                                                        "  all          - Perform al lknown resets (default)\n"
@@ -65,15 +65,21 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");
+
+  po::options_description allOptions("All Options");
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(resetDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(resetDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -81,7 +87,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(resetDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdScan.cpp
@@ -56,22 +56,28 @@ SubCmdScan::execute(const SubCmdOptions& _options) const
   bool help = false;
   uint64_t card = 0;
 
-  po::options_description scanDesc("scan options");
+  po::options_description commonOptions("Common Options");
 
-  scanDesc.add_options()
+  commonOptions.add_options()
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
     (",d", boost::program_options::value<uint64_t>(&card), "Card to be examined")
   ;
+
+  po::options_description hiddenOptions("Hidden Options");
+
+  po::options_description allOptions("All Options");
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
 
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(scanDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     xrt_core::send_exception_message(e.what(), "XBUTIL");
-    printHelp(scanDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -79,7 +85,7 @@ SubCmdScan::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(scanDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -51,8 +51,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   std::string device = "all";
   bool help = false;
 
-  po::options_description validateDesc("Options");
-  validateDesc.add_options()
+  po::options_description commonOptions("Commmon Options");
+  commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device), "The device of interest. This is specified as follows:\n"
                                                                            "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)\n"
                                                                            "  all   - Examines all known devices (default)")
@@ -60,15 +60,21 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
+  po::options_description hiddenOptions("Hidden Options");
+
+  po::options_description allOptions("All Options");
+  allOptions.add(commonOptions);
+  allOptions.add(hiddenOptions);
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(validateDesc).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
-    printHelp(validateDesc);
+    printHelp(commonOptions, hiddenOptions);
 
     // Re-throw exception
     throw;
@@ -76,7 +82,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 
   // Check to see if help was requested or no command was found
   if (help == true)  {
-    printHelp(validateDesc);
+    printHelp(commonOptions, hiddenOptions);
     return;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -77,7 +77,7 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_( argc, argv, description, subCommands);
+    main_( argc, argv, executable, description, subCommands);
     return 0;
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());


### PR DESCRIPTION
Work Done
---------
+ Added hidden option '--show-hidden' that will show hidden options in the various help menues
+ Added support to hide commands, sub-commands, and their options.
+ Added menu help support to display commands, sub-commands, and their options if the '--show-hidden' option is used.
+ Bug Fix: Fixed issue where usage command name was getting truncated.