### PR TITLE
CR-1065044 terminate called after throwing an instance of 'std::invalid_argument'...

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -600,7 +600,11 @@ static void tiTxtStreamToBin(std::istream& tiTxtStream,
         switch (line[0]) {
         case '@':
             // Address line
-            currentAddr = std::stoi(line.substr(1), NULL , 16);
+            try {
+                currentAddr = std::stoi(line.substr(1), NULL, 16);
+            } catch (...){
+                return;
+            }
             break;
         case 'q':
         case 'Q':
@@ -617,8 +621,15 @@ static void tiTxtStreamToBin(std::istream& tiTxtStream,
             // Data line
             std::stringstream ss(line);
             std::string token;
-            while (std::getline(ss, token, ' '))
-                buf.push_back(std::stoi(token, NULL, 16));
+            unsigned char int_token;
+            while (std::getline(ss, token, ' ')) {
+                try {
+                    int_token = std::stoi(token, NULL, 16);
+                } catch (...) {
+                    return;
+                }
+                buf.push_back(int_token);
+            }
             break;
         }
     }

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -603,6 +603,7 @@ static void tiTxtStreamToBin(std::istream& tiTxtStream,
             try {
                 currentAddr = std::stoi(line.substr(1), NULL, 16);
             } catch (...){
+                std::cout << "ERROR: Invalid address " << line.substr(1) << ". No action taken" << std::endl;
                 return;
             }
             break;
@@ -626,6 +627,7 @@ static void tiTxtStreamToBin(std::istream& tiTxtStream,
                 try {
                     int_token = std::stoi(token, NULL, 16);
                 } catch (...) {
+                    std::cout << "ERROR: Invalid address " << token << ". No action taken" << std::endl;
                     return;
                 }
                 buf.push_back(int_token);


### PR DESCRIPTION
...what(): stoi

Catch the error cleanly. Now if the SC is not able to update, it shows:
```
[root@xsjhemn41 xbmgmt]# ./xbmgmt flash --update
...
Updating SC firmware on card[0000:18:00.0]
Stopping user function...
...................................
ERROR: Failed to update SC firmware, err=-1
ERROR: Please refer to dmesg for more details
WARNING: Failed to update SC firmware on card [0000:18:00.0]
...
```