### PR TITLE
XRT-486 data-driven msix interrupt for versal

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -227,6 +227,7 @@ enum subdev_id {
 	XOCL_SUBDEV_DMA,
 	XOCL_SUBDEV_IORES,
 	XOCL_SUBDEV_FLASH,
+	XOCL_SUBDEV_MAILBOX_VERSAL,
 	XOCL_SUBDEV_MB_SCHEDULER,
 	XOCL_SUBDEV_XVC_PUB,
 	XOCL_SUBDEV_XVC_PRI,
@@ -242,7 +243,6 @@ enum subdev_id {
 	XOCL_SUBDEV_DNA,
 	XOCL_SUBDEV_FMGR,
 	XOCL_SUBDEV_MIG_HBM,
-	XOCL_SUBDEV_MAILBOX_VERSAL,
 	XOCL_SUBDEV_OSPI_VERSAL,
 	XOCL_SUBDEV_CLOCK,
 	XOCL_SUBDEV_AIM,
@@ -2292,11 +2292,11 @@ struct xocl_subdev_map {
 		XOCL_DEVINFO_CU_CTRL,					\
 	 })
 
-/* need static scheduler for a little while, and no AF user for now */
+/* versal has not been enabled of AF and CU_CTRL yet */
 #define RES_USER_VERSAL_VSEC						\
 	((struct xocl_subdev_info []) {					\
 		XOCL_DEVINFO_FEATURE_ROM_USER_DYN,			\
-		XOCL_DEVINFO_SCHEDULER_VERSAL,				\
+		XOCL_DEVINFO_SCHEDULER_DYN,				\
 		XOCL_DEVINFO_ICAP_USER,					\
 		XOCL_DEVINFO_XMC_USER,					\
 	 })

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1336,6 +1336,7 @@ struct xocl_mailbox_versal_funcs {
 	int (*enable_intr)(struct platform_device *pdev);
 	int (*disable_intr)(struct platform_device *pdev);
 	int (*handle_intr)(struct platform_device *pdev);
+	int (*intr_res)(struct platform_device *pdev, struct resource **res);
 };
 #define	MAILBOX_VERSAL_DEV(xdev)	\
 	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL).pldev
@@ -1362,6 +1363,9 @@ struct xocl_mailbox_versal_funcs {
 #define	xocl_mailbox_versal_handle_intr(xdev)	\
 	(MAILBOX_VERSAL_READY(xdev, handle_intr)	\
 	? MAILBOX_VERSAL_OPS(xdev)->handle_intr(MAILBOX_VERSAL_DEV(xdev)) : -ENODEV)
+#define	xocl_mailbox_versal_intr_res(xdev, res)	\
+	(MAILBOX_VERSAL_READY(xdev, intr_res)	\
+	? MAILBOX_VERSAL_OPS(xdev)->intr_res(MAILBOX_VERSAL_DEV(xdev), res) : -ENODEV)
 
 /* srsr callbacks */
 struct xocl_srsr_funcs {


### PR DESCRIPTION
Please take your time and carefully review this for me. We want to make mb_scheduler data-driven by the name of the resources. 

The special case for vck5000 is that:
1) the resource of IRQ0 interrupt base is also the resource of versal mailbox.
2) versal doen'st have mb ERT (u30 doesn't have mb ERT too).

