### PR TITLE
CR-1065387 Deployment shell fails install after local XRT build and install

### DIFF
--- a/src/runtime_src/ert/CMakeLists.txt
+++ b/src/runtime_src/ert/CMakeLists.txt
@@ -4,7 +4,7 @@ set(ERT_INSTALL_FIRMWARE_PREFIX "/lib/firmware/xilinx")
 if ((EXISTS $ENV{XILINX_VITIS}/gnu/microblaze) AND (${XRT_NATIVE_BUILD} STREQUAL "yes") AND (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64"))
 
 message("-- MicroBlaze toolchain found, preparing ERT build")
-
+set(ERT_BUILD_ALL "yes")
 add_subdirectory(scheduler)
 add_subdirectory(management)
 
@@ -44,6 +44,9 @@ install(FILES
   DESTINATION ${ERT_INSTALL_FIRMWARE_PREFIX}
   )
 
+set(ERT_BUILD_ALL "no")
+add_subdirectory(scheduler)
+
 else()
 
 message(WARNING
@@ -52,5 +55,7 @@ No firmware files built or copied, resulting XRT package will be missing ERT \
 scheduler firmware.  Use build.sh -ertfw <dir> to specify path to a directory \
 with firmware to copy during XRT build.\n
 ****************************************************************")
+set(ERT_BUILD_ALL "no")
+add_subdirectory(scheduler)
 
 endif()

--- a/src/runtime_src/ert/scheduler/CMakeLists.txt
+++ b/src/runtime_src/ert/scheduler/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Build ERT under legacy and u50 directories
 
+if (${ERT_BUILD_ALL} STREQUAL "yes")
+
 add_custom_command(
  OUTPUT legacy/bsp.extracted
  COMMAND ${CMAKE_COMMAND} -E make_directory legacy/bsp
@@ -92,6 +94,11 @@ install (FILES
  RENAME sched_v20.bin
  )
 
+endif(${ERT_BUILD_ALL} STREQUAL "yes")
+
+################################################################
+# HW emulation libsched_em
+################################################################
 file(GLOB SCH_SRC_FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
   )


### PR DESCRIPTION
Do not gate building of HW emulation firmware for ERT by the
availability of XILINX_VITIS.