### PR TITLE
CID 210272 (#1 of 1): Dereference after null check (FORWARD_NULL)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -276,8 +276,7 @@ static int ospi_versal_remove(struct platform_device *pdev)
 
 	if (!ov) {
 		xocl_err(&pdev->dev, "driver data is NULL");
-		ret = -EINVAL;
-		goto done;
+		return -EINVAL;
 	}
 
 	xocl_drvinst_release(ov, &hdl);
@@ -287,7 +286,6 @@ static int ospi_versal_remove(struct platform_device *pdev)
 	platform_set_drvdata(pdev, NULL);
 	xocl_drvinst_free(hdl);
 
-done:
 	OV_INFO(ov, "return: %d", ret);
 	return ret;
 }


### PR DESCRIPTION
ov should not be null now.