### PR TITLE
CR-1065621 fix qdma batch iocb contruction for io_submit()

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -278,12 +278,11 @@ private:
         auto end = reqList.end();
         for (auto it = reqList.begin(); it != end && cb_cnt < cb_max;
              ++it, cb_cnt++) {
-            auto qio = (*it);
 
-            qio.header.flags = qio.flags;
-            prepare_io(&qio.cb, qio.iov, &qio.header, qio.buf_va, qio.len,
-			qio.priv_data);
-            cbpp[cb_cnt] = &qio.cb;
+            it->header.flags = it->flags;
+            prepare_io(&it->cb, it->iov, &it->header, it->buf_va, it->len,
+			it->priv_data);
+            cbpp[cb_cnt] = &it->cb;
         }
 
         int submitted = io_submit(qAioCtx, cb_cnt, cbpp.data());


### PR DESCRIPTION
Fixed the iocb construction when batching is enabled, the bug was that the iocb was constructed locally inside for loop which become invalid for io_submit() call outside of the for loop.

The bug has been approved for merging into 2020.1 branch.