### PR TITLE
XRT-290 Enable clock subdev for versal

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -842,9 +842,9 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			break;
 		}
 
-		ret = xocl_has_icap(lro) ?
-		    xocl_icap_ocl_update_clock_freq_topology(lro, clk) :
-		    xocl_clock_update_freq(lro, clk->ocl_target_freq,
+		ret = xocl_icap_ocl_update_clock_freq_topology(lro, clk);
+		if (ret == -ENODEV)
+		    ret = xocl_clock_update_freq(lro, clk->ocl_target_freq,
 		        ARRAY_SIZE(clk->ocl_target_freq), 1);
 
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -544,7 +544,7 @@ struct xocl_pci_funcs xclmgmt_pci_ops = {
 	.reset = xclmgmt_reset,
 };
 
-static void xclmgmt_icap_get_data_impl(struct xclmgmt_dev *lro, void *buf)
+static int xclmgmt_icap_get_data_impl(struct xclmgmt_dev *lro, void *buf)
 {
 	struct xcl_pr_region *hwicap = NULL;
 	int err = 0;
@@ -552,7 +552,7 @@ static void xclmgmt_icap_get_data_impl(struct xclmgmt_dev *lro, void *buf)
 
 	err = XOCL_GET_XCLBIN_ID(lro, xclbin_id);
 	if (err)
-		return;
+		return err;
 
 	hwicap = (struct xcl_pr_region *)buf;
 	hwicap->idcode = xocl_icap_get_data(lro, IDCODE);
@@ -585,7 +585,7 @@ static void xclmgmt_clock_get_data_impl(struct xclmgmt_dev *lro, void *buf)
 
 static void xclmgmt_icap_get_data(struct xclmgmt_dev *lro, void *buf)
 {
-	return xocl_has_icap(lro) ? xclmgmt_icap_get_data_impl(lro, buf) :
+	if (xclmgmt_icap_get_data_impl(lro, buf) == -ENODEV)
 		xclmgmt_clock_get_data_impl(lro, buf);
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -544,7 +544,7 @@ struct xocl_pci_funcs xclmgmt_pci_ops = {
 	.reset = xclmgmt_reset,
 };
 
-static void xclmgmt_icap_get_data(struct xclmgmt_dev *lro, void *buf)
+static void xclmgmt_icap_get_data_impl(struct xclmgmt_dev *lro, void *buf)
 {
 	struct xcl_pr_region *hwicap = NULL;
 	int err = 0;
@@ -568,6 +568,25 @@ static void xclmgmt_icap_get_data(struct xclmgmt_dev *lro, void *buf)
 	hwicap->data_retention = xocl_icap_get_data(lro, DATA_RETAIN);
 
 	XOCL_PUT_XCLBIN_ID(lro);
+}
+
+static void xclmgmt_clock_get_data_impl(struct xclmgmt_dev *lro, void *buf)
+{
+	struct xcl_pr_region *hwicap = NULL;
+
+	hwicap = (struct xcl_pr_region *)buf;
+	hwicap->freq_0 = xocl_clock_get_data(lro, CLOCK_FREQ_0);
+	hwicap->freq_1 = xocl_clock_get_data(lro, CLOCK_FREQ_1);
+	hwicap->freq_2 = xocl_clock_get_data(lro, CLOCK_FREQ_2);
+	hwicap->freq_cntr_0 = xocl_clock_get_data(lro, FREQ_COUNTER_0);
+	hwicap->freq_cntr_1 = xocl_clock_get_data(lro, FREQ_COUNTER_1);
+	hwicap->freq_cntr_2 = xocl_clock_get_data(lro, FREQ_COUNTER_2);
+}
+
+static void xclmgmt_icap_get_data(struct xclmgmt_dev *lro, void *buf)
+{
+	return xocl_has_icap(lro) ? xclmgmt_icap_get_data_impl(lro, buf) :
+		xclmgmt_clock_get_data_impl(lro, buf);
 }
 
 static void xclmgmt_mig_get_data(struct xclmgmt_dev *lro, void *mig_ecc, size_t entry_sz)
@@ -638,7 +657,7 @@ static void xclmgmt_subdev_get_data(struct xclmgmt_dev *lro, size_t offset,
 
 static int xclmgmt_read_subdev_req(struct xclmgmt_dev *lro, char *data_ptr, void **resp, size_t *sz)
 {
-	size_t resp_sz = 0, current_sz;
+	size_t resp_sz = 0, current_sz = 0;
 	struct xcl_mailbox_subdev_peer *subdev_req = (struct xcl_mailbox_subdev_peer *)data_ptr;
 
 	BUG_ON(!lro);
@@ -822,7 +841,12 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			mgmt_err(lro, "peer request dropped, wrong size\n");
 			break;
 		}
-		ret = xocl_icap_ocl_update_clock_freq_topology(lro, clk);
+
+		ret = xocl_has_icap(lro) ?
+		    xocl_icap_ocl_update_clock_freq_topology(lro, clk) :
+		    xocl_clock_update_freq(lro, clk->ocl_target_freq,
+		        ARRAY_SIZE(clk->ocl_target_freq), 1);
+
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,
 			sizeof(ret));
 		break;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1025,6 +1025,7 @@ struct xocl_clock_funcs {
 	int (*update_freq)(struct platform_device *pdev,
 		unsigned short *freqs, int num_freqs, int verify);
 	int (*clock_status)(struct platform_device *pdev, bool *latched);
+	uint64_t (*get_data)(struct platform_device *pdev, enum data_kind kind);
 };
 #define CLOCK_DEV_INFO(xdev, idx)					\
 	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK, idx).info
@@ -1069,31 +1070,38 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 #define	xocl_clock_get_freq_by_id(xdev, region, freq, id)		\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, __idx, get_freq_by_id) ?				\
+	(CLOCK_CB(xdev, __idx, get_freq_by_id) ?			\
 	CLOCK_OPS(xdev, __idx)->get_freq_by_id(CLOCK_DEV(xdev, __idx), region, freq, id) : \
 	-ENODEV); \
 })
 #define	xocl_clock_get_freq_counter_khz(xdev, value, id)		\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, __idx, get_freq_counter_khz) ?				\
+	(CLOCK_CB(xdev, __idx, get_freq_counter_khz) ?			\
 	CLOCK_OPS(xdev, __idx)->get_freq_counter_khz(CLOCK_DEV(xdev, __idx), value, id) : \
 	-ENODEV); \
 })
 #define	xocl_clock_update_freq(xdev, freqs, num_freqs, verify) \
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, __idx, update_freq) ?					\
+	(CLOCK_CB(xdev, __idx, update_freq) ?				\
 	CLOCK_OPS(xdev, __idx)->update_freq(CLOCK_DEV(xdev, __idx), freqs, num_freqs, verify) : \
 	-ENODEV); \
 })
 #define	xocl_clock_status(xdev, latched)				\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);				\
-	(CLOCK_CB(xdev, __idx, clock_status) ?					\
+	(CLOCK_CB(xdev, __idx, clock_status) ?				\
 	CLOCK_OPS(xdev, __idx)->clock_status(CLOCK_DEV(xdev, __idx), latched) : 	\
 	-ENODEV); \
 })
+#define	xocl_clock_get_data(xdev, kind)					\
+({ \
+	int __idx = xocl_clock_ops_level(xdev);				\
+	(CLOCK_CB(xdev, __idx, get_data) ?				\
+	CLOCK_OPS(xdev, __idx)->get_data(CLOCK_DEV(xdev, __idx), kind) : 0); 	\
+})
+
 
 struct xocl_icap_funcs {
 	struct xocl_subdev_funcs common_funcs;
@@ -1132,6 +1140,8 @@ enum {
 	((struct xocl_icap_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ICAP).ops)
 #define ICAP_CB(xdev, cb)						\
 	(ICAP_DEV(xdev) && ICAP_OPS(xdev) && ICAP_OPS(xdev)->cb)
+#define xocl_has_icap(xdev)						\
+	(ICAP_DEV(xdev) && ICAP_OPS(xdev) ? true : false)
 #define	xocl_icap_reset_axi_gate(xdev)					\
 	(ICAP_CB(xdev, reset_axi_gate) ?				\
 	ICAP_OPS(xdev)->reset_axi_gate(ICAP_DEV(xdev)) :		\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1140,8 +1140,6 @@ enum {
 	((struct xocl_icap_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ICAP).ops)
 #define ICAP_CB(xdev, cb)						\
 	(ICAP_DEV(xdev) && ICAP_OPS(xdev) && ICAP_OPS(xdev)->cb)
-#define xocl_has_icap(xdev)						\
-	(ICAP_DEV(xdev) && ICAP_OPS(xdev) ? true : false)
 #define	xocl_icap_reset_axi_gate(xdev)					\
 	(ICAP_CB(xdev, reset_axi_gate) ?				\
 	ICAP_OPS(xdev)->reset_axi_gate(ICAP_DEV(xdev)) :		\
@@ -1192,7 +1190,7 @@ enum {
 #define	xocl_icap_get_xclbin_metadata(xdev, kind, buf)			\
 	(ICAP_CB(xdev, get_xclbin_metadata) ?				\
 	ICAP_OPS(xdev)->get_xclbin_metadata(ICAP_DEV(xdev), kind, buf) :	\
-	0)
+	-ENODEV)
 #define	xocl_icap_put_xclbin_metadata(xdev)			\
 	(ICAP_CB(xdev, put_xclbin_metadata) ?			\
 	ICAP_OPS(xdev)->put_xclbin_metadata(ICAP_DEV(xdev)) : 	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -196,7 +196,7 @@ static void devinfo_cb_plp_gate(void *dev_hdl, void *subdevs, int num)
 {
 	struct xocl_subdev *subdev = subdevs;
 
-	subdev->info.level = XOCL_SUBDEV_LEVEL_BLD;
+	subdev->info.level = XOCL_SUBDEV_LEVEL_PRP;
 	subdev->info.override_idx = subdev->info.level;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -196,7 +196,7 @@ static void devinfo_cb_plp_gate(void *dev_hdl, void *subdevs, int num)
 {
 	struct xocl_subdev *subdev = subdevs;
 
-	subdev->info.level = XOCL_SUBDEV_LEVEL_PRP;
+	subdev->info.level = XOCL_SUBDEV_LEVEL_BLD;
 	subdev->info.override_idx = subdev->info.level;
 }
 


### PR DESCRIPTION
This is the initial support for displaying clock for xbutil. So that user can check the frequency of clock now.

We are waiting for platform team to provide clock configuration guide, that's sightly different than existing clock config. For now, xbutil clock -f will just fail. No hardware hung or panic, but it won't work. This will take longer time to fix.