### PR TITLE
Put host_mem error message in order

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -3045,6 +3045,7 @@ static struct xocl_icap_funcs icap_ops = {
 	.get_xclbin_metadata = icap_get_xclbin_metadata,
 	.put_xclbin_metadata = icap_put_xclbin_metadata,
 	.mig_calibration = icap_calibrate_mig,
+	.clean_bitstream = icap_clean_bitstream_axlf,
 };
 
 static ssize_t clock_freqs_show(struct device *dev,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -863,8 +863,10 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 
 		if (!strncmp(mem_data->m_tag, "HOST[0]", 7)) {
 			err = xocl_set_cma_bank(drm_p, mem_data->m_base_address, ddr_bank_size);
-			if (err)
+			if (err) {
+				xocl_err(drm_p->ddev->dev, "Run host_mem to setup host memory access, request 0x%lx bytes", ddr_bank_size);
 				goto done;
+			}
 		}
 		xocl_info(drm_p->ddev->dev, "drm_mm_init called");
 	}
@@ -987,6 +989,8 @@ static int xocl_cma_mem_alloc_huge_page(struct xocl_drm *drm_p, struct drm_xocl_
 
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
 
+	if (!num)
+		return -ENODEV;
 	/* Limited by hardware, the entry number can only be power of 2
 	 * rounddown_pow_of_two 255=>>128 63=>>32
 	 */
@@ -1153,7 +1157,7 @@ static int xocl_cma_mem_alloc(struct xocl_drm *drm_p, uint64_t size)
 
 	if (!page_num) {
 		DRM_ERROR("Doesn't support CMA BANK feature");
-		return -EINVAL;		
+		return -ENODEV;		
 	}
 
 	page_sz = size/page_num;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -846,6 +846,8 @@ struct xocl_dna_funcs {
 	(ADDR_TRANSLATOR_CB(xdev, disable_remap) ? ADDR_TRANSLATOR_OPS(xdev)->disable_remap(ADDR_TRANSLATOR_DEV(xdev)) : -ENODEV)
 #define	xocl_addr_translator_clean(xdev)			\
 	(ADDR_TRANSLATOR_CB(xdev, clean) ? ADDR_TRANSLATOR_OPS(xdev)->clean(ADDR_TRANSLATOR_DEV(xdev)) : -ENODEV)
+#define	xocl_addr_translator_get_base_addr(xdev)			\
+	(ADDR_TRANSLATOR_CB(xdev, get_base_addr) ? ADDR_TRANSLATOR_OPS(xdev)->get_base_addr(ADDR_TRANSLATOR_DEV(xdev)) : 0)
 
 struct xocl_addr_translator_funcs {
 	struct xocl_subdev_funcs common_funcs;
@@ -855,6 +857,7 @@ struct xocl_addr_translator_funcs {
 	int (*enable_remap)(struct platform_device *pdev, uint64_t base_addr);
 	int (*disable_remap)(struct platform_device *pdev);
 	int (*clean)(struct platform_device *pdev);
+	u64 (*get_base_addr)(struct platform_device *pdev);
 };
 
 /**
@@ -1097,6 +1100,7 @@ struct xocl_icap_funcs {
 		enum data_kind kind, void **buf);
 	void (*put_xclbin_metadata)(struct platform_device *pdev);
 	int (*mig_calibration)(struct platform_device *pdev);
+	void (*clean_bitstream)(struct platform_device *pdev);
 };
 enum {
 	RP_DOWNLOAD_NORMAL,
@@ -1167,6 +1171,10 @@ enum {
 #define	xocl_icap_mig_calibration(xdev)				\
 	(ICAP_CB(xdev, mig_calibration) ?			\
 	ICAP_OPS(xdev)->mig_calibration(ICAP_DEV(xdev)) : 	\
+	-ENODEV)
+#define	xocl_icap_clean_bitstream(xdev)				\
+	(ICAP_CB(xdev, clean_bitstream) ?			\
+	ICAP_OPS(xdev)->clean_bitstream(ICAP_DEV(xdev)) : 	\
 	-ENODEV)
 
 #define XOCL_GET_MEM_TOPOLOGY(xdev, mem_topo)						\

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1221,6 +1221,8 @@ int shim::cmaEnable(bool enable, uint64_t size)
 
     } else {
         ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_FREE_CMA);
+        if (ret)
+                ret = -errno;
     }
 
     return ret;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1992,7 +1992,7 @@ int xcldev::xclCma(int argc, char *argv[])
         std::cout << "ERROR: Does not support HOST MEM feature"
             << std::endl; 
     } else if (ret == -EBUSY) {
-        std::cout << "ERROR: HOST MEM already enabled"
+        std::cout << "ERROR: HOST MEM already enabled or in-use"
             << std::endl;
     } else if (!ret) {
         std::cout << "xbutil host_mem done successfully" << std::endl;


### PR DESCRIPTION
1. Driver return -EBUSY if user try to disable/re-enable Host_mem feature with different size

2. Driver Return -ENODEV if user try to enable HOST_MEM w/o address translator

3. Clean all the bitstream related metadata(mem topo, uuid, etc) if xocl_read_axlf_ioctl fails