### PR TITLE
CR-1052598 Fix PCIe Link monitoring for u50.

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -416,12 +416,16 @@ static struct xocl_subdev_map		subdev_map[] = {
 		0,
 		NULL,
 		devinfo_cb_setlevel,
+		.min_level = XOCL_SUBDEV_LEVEL_PRP,
 	},
 	{
 		XOCL_SUBDEV_IORES,
 		XOCL_IORES1,
 		{
 			RESNAME_PCIEMON,
+			RESNAME_MEMCALIB,
+			RESNAME_KDMA,
+			RESNAME_DDR4_RESET_GATE,
 			NULL
 		},
 		1,


### PR DESCRIPTION
for 1RP SSv2 platforms like u50 certain subdev IPs are in BLP level vs PLP on other platforms. Adding support for such IPs in iores1