### PR TITLE
CR-1065849 opmode ERT_EXEC_WRITE does not set kernel arguments correctly

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2003,12 +2003,17 @@ ert_configure_cu(struct sched_cmd *cmd, int cu_idx)
 	u32 size = regmap_size(cmd);
 	struct ert_start_kernel_cmd *sk;
 	struct zocl_cu *cu = &cmd->exec->zcu[cu_idx];
-	int type = CONSECUTIVE;
+	int type;
 
 	SCHED_DEBUG("-> %s cu_idx=%d, regmap_size=%d\n",
 	    __func__, cu_idx, size);
 
 	sk = (struct ert_start_kernel_cmd *)cmd->packet;
+
+	if (opcode(cmd) == ERT_EXEC_WRITE)
+		type = PAIRS;
+	else
+		type = CONSECUTIVE;
 
 	zocl_cu_configure(cu, sk->data + sk->extra_cu_masks, size, type);
 


### PR DESCRIPTION
This for 2020.1 branch. #3435 