### PR TITLE
Add missing cmake3 on RHEL (#3437)

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-OSDIST=`lsb_release -i |awk -F: '{print tolower($2)}' | tr -d ' \t'`
+OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
 CPU=`uname -m`
 
-if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amazon" ]]; then
+if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amazon" ]] || [[ $OSDIST == "rhel" ]]; then
     CMAKE=cmake3
     if [[ ! -x "$(command -v $CMAKE)" ]]; then
         echo "$CMAKE is not installed, please run xrtdeps.sh"

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -279,6 +279,8 @@ prep_rhel()
 	yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 	yum check-update
     fi
+    echo "Installing cmake3 from EPEL repository..."
+    yum install -y cmake3
 
     if [ $MAJOR == 8 ]; then
         echo "RHEL8 not implemented yet"


### PR DESCRIPTION
* Add missing cmake3 on RHEL

* Use /etc/os-release for OS distribution
(cherry picked from commit 0c28bf9daace8305fc0b6bc44da3cd56743c77d9)