### PR TITLE
XRT-459 Add context support in KDS

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -183,6 +183,7 @@ SET (XRT_DKMS_CORE_INCLUDES
 
 SET (XRT_DKMS_COMMON_XRT_DRV
   common/drv/kds_core.c
+  common/drv/kds_cu_ctrl.c
   common/drv/xrt_cu.c
   common/drv/cu_hls.c
   common/drv/cu_plram.c
@@ -191,6 +192,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV
 SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
   common/drv/include/xrt_drv.h
   common/drv/include/kds_core.h
+  common/drv/include/kds_cu_ctrl.h
   common/drv/include/kds_command.h
   common/drv/include/xrt_cu.h
   )

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -10,15 +10,11 @@
 #ifndef _KDS_COMMAND_H
 #define _KDS_COMMAND_H
 
+/* Userspace command format */
 #include "ert.h"
 
 #define REGMAP 0
 #define KEY_VAL 1
-
-enum kds_type {
-	KDS_CU		= 0,
-	KDS_MAX_TYPE, // always the last one
-};
 
 enum kds_opcode {
 	OP_CONFIG_CTRL	= 0,

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -60,10 +60,11 @@ struct kds_command {
 	u32			*execbuf;
 };
 
-/* command convert */
+/* execbuf command related funtions */
 void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 		   struct kds_command *xcmd);
 void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			  struct kds_command *xcmd);
+int cu_mask_to_cu_idx(struct kds_command *xcmd);
 
 #endif

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -107,7 +107,6 @@ struct kds_client {
 	wait_queue_head_t	  waitq;
 	atomic_t		  event;
 };
-#define	CLIENT_NUM_CU(client) (0)
 
 /**
  * struct kds_sched: KDS scheduler manage controllers and client list.

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -32,13 +32,21 @@ enum kds_type {
 	KDS_MAX_TYPE, // always the last one
 };
 
+/* Context properties */
+#define	CU_CTX_PROP_MASK	0x0F
 #define	CU_CTX_SHARED		0x00
 #define	CU_CTX_EXCLUSIVE	0x01
+
+/* Context operation bits indicated that what operation to perform */
 #define	CU_CTX_OP_MASK		0xF0
 #define	CU_CTX_OP_INIT		0x10
 #define	CU_CTX_OP_FINI		0x20
 #define	CU_CTX_OP_ADD		0x30
 #define	CU_CTX_OP_DEL		0x40
+/* Virtual CU index
+ * This is useful when there is no need to open a context on hardware CU,
+ * but still need to lockdown the xclbin.
+ */
 #define	CU_CTX_VIRT_CU		0xffffffff
 struct kds_ctx_info {
 	u32		  cu_idx;

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -14,10 +14,9 @@
 #include <linux/mutex.h>
 #include <linux/pid.h>
 #include <linux/device.h>
+#include <linux/uuid.h>
 
 #include "kds_command.h"
-
-struct kds_controller;
 
 #define kds_info(client, fmt, args...)			\
 	dev_info(client->dev, " %llx %s: "fmt, (u64)client->dev, __func__, ##args)
@@ -28,17 +27,68 @@ struct kds_controller;
 
 #define PRE_ALLOC 0
 
+enum kds_type {
+	KDS_CU		= 0,
+	KDS_MAX_TYPE, // always the last one
+};
+
+#define	CU_CTX_SHARED		0x00
+#define	CU_CTX_EXCLUSIVE	0x01
+#define	CU_CTX_OP_MASK		0xF0
+#define	CU_CTX_OP_INIT		0x10
+#define	CU_CTX_OP_FINI		0x20
+#define	CU_CTX_OP_ADD		0x30
+#define	CU_CTX_OP_DEL		0x40
+#define	CU_CTX_VIRT_CU		0xffffffff
+struct kds_ctx_info {
+	u32		  cu_idx;
+	u32		  flags;
+};
+
+#define TO_KDS_CTRL(core) ((struct kds_ctrl *)(core))
+
 /**
- * struct kds_client: Manage user space client context attached to device
+ * struct kds_ctrl: KDS controller core.
+ * This is the basic controller that KDS should understand.
+ * This should be the first member of a controller implementation.
+ * Any members added here should be shared by all controllers.
  *
- * @link: Client context is added to list in device
+ * @control_ctx: Delete context from a client
+ * @submit: Submit command to controller
+ */
+struct kds_ctrl {
+	int (* control_ctx)(struct kds_ctrl *ctrl, struct kds_client *client,
+			    struct kds_ctx_info *info);
+	void (* submit)(struct kds_ctrl *ctrl, struct kds_command *xcmd);
+};
+
+/**
+ * struct kds_client: Manage user client
+ * Whenever user applciation open the device, a client would be created.
+ * A client will keep alive util application close the device or being killed.
+ * The client could open multiple contexts to access compute resources.
+ *
+ * @link: Client is added to list in KDS scheduler
  * @dev:  Device
  * @pid:  Client process ID
+ * @lock: Mutex to protext context related members
+ * @ctrl_priv: Private data of controller
+ * @xclbin_id: UUID of xclbin cache
+ * @num_ctx: Number of context that opened
+ * @virt_cu_ref: Reference count of virtual CU
+ * @ctrl: Pointer to controllers array
+ * @waitq: Wait queue for poll client
+ * @event: Events to notify user client
  */
 struct kds_client {
 	struct list_head	  link;
 	struct device	         *dev;
 	struct pid	         *pid;
+	struct mutex		  lock;
+	void			 *ctrl_priv[KDS_MAX_TYPE];
+	void			 *xclbin_id;
+	int			  num_ctx;
+	int			  virt_cu_ref;
 #if PRE_ALLOC
 	u32			  max_xcmd;
 	u32			  xcmd_idx;
@@ -52,23 +102,39 @@ struct kds_client {
 	 * cache lines. Hence we add a "padding" in between (assuming 128-byte
 	 * is big enough for most CPU architectures).
 	 */
-	struct kds_controller   **ctrl;
+	struct kds_ctrl		**ctrl;
 	u64			  padding[16];
 	wait_queue_head_t	  waitq;
 	atomic_t		  event;
 };
 #define	CLIENT_NUM_CU(client) (0)
 
-struct kds_controller {
-	void (* submit)(struct kds_controller *ctrl, struct kds_command *xcmd);
+/**
+ * struct kds_sched: KDS scheduler manage controllers and client list.
+ *		     There should be only one KDS on a device.
+ *
+ * @ctrl: Controllers array only one per KDS
+ * @list_head: Client list
+ * @num_client: Number of clients
+ * @lock: Mutex to protect client list
+ */
+struct kds_sched {
+	struct kds_ctrl	       *ctrl[KDS_MAX_TYPE];
+	struct list_head	clients;
+	int			num_client;
+	struct mutex		lock;
 };
 
-int kds_init_client(struct kds_client *client);
-void kds_fini_client(struct kds_client *client);
+int kds_init_sched(struct kds_sched *kds);
+void kds_fini_sched(struct kds_sched *kds);
+int kds_init_client(struct kds_sched *kds, struct kds_client *client);
+void kds_fini_client(struct kds_sched *kds, struct kds_client *client);
+u32 kds_live_clients(struct kds_sched *kds, pid_t **plist);
 struct kds_command *kds_alloc_command(struct kds_client *client, u32 size);
+int kds_add_context(struct kds_client *client, struct kds_ctx_info *info);
+int kds_del_context(struct kds_client *client, struct kds_ctx_info *info);
+
 int kds_add_command(struct kds_command *xcmd);
 void kds_free_command(struct kds_command *xcmd);
-
-void notify_execbuf(struct kds_command *xcmd, int status);
 
 #endif

--- a/src/runtime_src/core/common/drv/include/kds_cu_ctrl.h
+++ b/src/runtime_src/core/common/drv/include/kds_cu_ctrl.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Xilinx Kernel Driver Scheduler
+ *
+ * Copyright (C) 2020 Xilinx, Inc.
+ *
+ * Authors: min.ma@xilinx.com
+ */
+
+#ifndef _KDS_CU_CTRL_H
+#define _KDS_CU_CTRL_H
+
+#include "kds_core.h"
+#include "xrt_cu.h"
+
+#define CU_EXCLU_MASK		0x80000000
+
+struct kds_cu_ctrl {
+	struct kds_ctrl		  core;
+	struct xrt_cu		 *xcus[MAX_CUS];
+	struct mutex		  lock;
+	u32			  cu_refs[MAX_CUS];
+	int			  num_cus;
+	int			  num_clients;
+	int			  configured;
+};
+
+#define TO_CU_CTRL(core) ((struct kds_cu_ctrl *)(core))
+
+struct client_cu_priv {
+	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
+};
+
+int config_ctrl(struct kds_cu_ctrl *kcuc, struct kds_command *xcmd);
+int acquire_cu_inst_idx(struct kds_cu_ctrl *kcuc, struct kds_command *xcmd);
+int control_ctx(struct kds_cu_ctrl *kcuc, struct kds_client *client,
+		struct kds_ctx_info *info);
+int add_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu);
+int remove_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu);
+
+ssize_t show_cu_ctx(struct kds_cu_ctrl *kcuc, char *buf);
+
+#endif

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -278,9 +278,9 @@ u32 kds_live_clients(struct kds_sched *kds, pid_t **plist)
 			i++;
 		}
 	}
-	mutex_unlock(&kds->lock);
 
 out:
+	mutex_unlock(&kds->lock);
 	return count;
 }
 

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -260,7 +260,7 @@ u32 kds_live_clients(struct kds_sched *kds, pid_t **plist)
 	/* Find out number of active client */
 	list_for_each(ptr, &kds->clients) {
 		client = list_entry(ptr, struct kds_client, link);
-		if (CLIENT_NUM_CU(client) > 0)
+		if (client->num_ctx > 0)
 			count++;
 	}
 	if (count == 0 || plist == NULL)
@@ -273,7 +273,7 @@ u32 kds_live_clients(struct kds_sched *kds, pid_t **plist)
 
 	list_for_each(ptr, &kds->clients) {
 		client = list_entry(ptr, struct kds_client, link);
-		if (CLIENT_NUM_CU(client) > 0) {
+		if (client->num_ctx > 0) {
 			pl[i] = pid_nr(client->pid);
 			i++;
 		}
@@ -299,6 +299,7 @@ void notify_execbuf(struct kds_command *xcmd, int status)
 	wake_up_interruptible(&client->waitq);
 }
 
+/* User space execbuf command related functions below */
 void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 		   struct kds_command *xcmd)
 {
@@ -339,3 +340,10 @@ void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	memcpy(xcmd->info, &ecmd->data[4], xcmd->isize);
 }
 
+inline int cu_mask_to_cu_idx(struct kds_command *xcmd)
+{
+	/* TODO: balance the CU usage if multiple bits are set */
+
+	/* assume there is alwasy one CU */
+	return 0;
+}

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -7,11 +7,25 @@
  * Authors: min.ma@xilinx.com
  */
 
-#include <linux/device.h>
 #include <linux/slab.h>
 #include <linux/sched.h>
 #include <linux/vmalloc.h>
+#include <linux/device.h>
 #include "kds_core.h"
+
+int kds_init_sched(struct kds_sched *kds)
+{
+	INIT_LIST_HEAD(&kds->clients);
+	mutex_init(&kds->lock);
+	kds->num_client = 0;
+
+	return 0;
+}
+
+void kds_fini_sched(struct kds_sched *kds)
+{
+	mutex_destroy(&kds->lock);
+}
 
 struct kds_command *kds_alloc_command(struct kds_client *client, u32 size)
 {
@@ -65,7 +79,7 @@ void kds_free_command(struct kds_command *xcmd)
 int kds_submit_cu(struct kds_command *xcmd)
 {
 	struct kds_client *client = xcmd->client;
-	struct kds_controller *ctrl = client->ctrl[KDS_CU];
+	struct kds_ctrl *ctrl = client->ctrl[KDS_CU];
 
 	if (ctrl) {
 		/* NOTE: If still has errors, the controller
@@ -108,10 +122,29 @@ int kds_add_command(struct kds_command *xcmd)
 	return err;
 }
 
-int kds_init_client(struct kds_client *client)
+int kds_init_client(struct kds_sched *kds, struct kds_client *client)
 {
+	struct kds_ctx_info info;
+	struct kds_ctrl *ctrl;
+
+	client->pid = get_pid(task_pid(current));
+	client->ctrl = kds->ctrl;
+	mutex_init(&client->lock);
+
+	/* Initial controller context private data */
+	ctrl = client->ctrl[KDS_CU];
+	info.flags = CU_CTX_OP_INIT;
+	if (ctrl)
+		ctrl->control_ctx(ctrl, client, &info);
+
 	init_waitqueue_head(&client->waitq);
 	atomic_set(&client->event, 0);
+
+	mutex_lock(&kds->lock);
+	list_add_tail(&client->link, &kds->clients);
+	kds->num_client++;
+	mutex_unlock(&kds->lock);
+
 #if PRE_ALLOC
 	client->max_xcmd = 0x8000;
 	client->xcmd_idx = 0;
@@ -130,13 +163,125 @@ int kds_init_client(struct kds_client *client)
 	return 0;
 }
 
-void kds_fini_client(struct kds_client *client)
+void kds_fini_client(struct kds_sched *kds, struct kds_client *client)
 {
+	struct kds_ctx_info info;
+	struct kds_ctrl *ctrl;
+
 #if PRE_ALLOC
 	vfree(client->xcmds);
 	vfree(client->infos);
 #endif
-	return;
+	ctrl = client->ctrl[KDS_CU];
+	info.flags = CU_CTX_OP_FINI;
+	if (ctrl)
+		ctrl->control_ctx(ctrl, client, &info);
+
+	put_pid(client->pid);
+	mutex_destroy(&client->lock);
+
+	mutex_lock(&kds->lock);
+	list_del(&client->link);
+	kds->num_client--;
+	mutex_unlock(&kds->lock);
+}
+
+int kds_add_context(struct kds_client *client, struct kds_ctx_info *info)
+{
+	u32 cu_idx = info->cu_idx;
+	bool shared = (info->flags != CU_CTX_EXCLUSIVE);
+	struct kds_ctrl *ctrl = client->ctrl[KDS_CU];
+
+	BUG_ON(!mutex_is_locked(&client->lock));
+
+	/* TODO: In lagcy KDS, there is a concept of implicit CUs.
+	 * It looks like that part is related to cdma. But it use the same
+	 * cu bit map and it relies on to how user open context.
+	 * Let's consider that kind of CUs later.
+	 */
+	if (cu_idx == CU_CTX_VIRT_CU) {
+		if (!shared) {
+			kds_err(client, "Only allow share virtual CU");
+			return -EINVAL;
+		}
+		++client->virt_cu_ref;
+	} else {
+		if (!ctrl)
+			return -ENODEV;
+		info->flags &= ~CU_CTX_OP_MASK;
+		info->flags |= CU_CTX_OP_ADD;
+		if (ctrl->control_ctx(ctrl, client, info))
+			return -EINVAL;
+	}
+
+	++client->num_ctx;
+	kds_info(client, "Client pid(%d) add context CU(0x%x) shared(%s)",
+		 pid_nr(client->pid), cu_idx, shared? "true" : "false");
+	return 0;
+}
+
+int kds_del_context(struct kds_client *client, struct kds_ctx_info *info)
+{
+	u32 cu_idx = info->cu_idx;
+	struct kds_ctrl *ctrl = client->ctrl[KDS_CU];
+
+	BUG_ON(!mutex_is_locked(&client->lock));
+
+	if (cu_idx == CU_CTX_VIRT_CU) {
+		if (!client->virt_cu_ref) {
+			kds_err(client, "No opening virtual CU");
+			return -EINVAL;
+		}
+		--client->virt_cu_ref;
+	} else {
+		if (!ctrl)
+			return -ENODEV;
+		info->flags &= ~CU_CTX_OP_MASK;
+		info->flags |= CU_CTX_OP_DEL;
+		if (ctrl->control_ctx(ctrl, client, info))
+			return -EINVAL;
+	}
+
+	--client->num_ctx;
+	kds_info(client, "Client pid(%d) del context CU(0x%x)",
+		 pid_nr(client->pid), cu_idx);
+	return 0;
+}
+
+u32 kds_live_clients(struct kds_sched *kds, pid_t **plist)
+{
+	const struct list_head *ptr;
+	struct kds_client *client;
+	pid_t *pl = NULL;
+	u32 count = 0;
+	u32 i = 0;
+
+	mutex_lock(&kds->lock);
+	/* Find out number of active client */
+	list_for_each(ptr, &kds->clients) {
+		client = list_entry(ptr, struct kds_client, link);
+		if (CLIENT_NUM_CU(client) > 0)
+			count++;
+	}
+	if (count == 0 || plist == NULL)
+		goto out;
+
+	/* Collect list of PIDs of active client */
+	pl = (pid_t *)vmalloc(sizeof(pid_t) * count);
+	if (pl == NULL)
+		goto out;
+
+	list_for_each(ptr, &kds->clients) {
+		client = list_entry(ptr, struct kds_client, link);
+		if (CLIENT_NUM_CU(client) > 0) {
+			pl[i] = pid_nr(client->pid);
+			i++;
+		}
+	}
+	mutex_unlock(&kds->lock);
+
+out:
+	return count;
 }
 
 /* General notify client function */
@@ -157,6 +302,8 @@ void notify_execbuf(struct kds_command *xcmd, int status)
 void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 		   struct kds_command *xcmd)
 {
+	int i;
+
 	xcmd->type = KDS_CU;
 	xcmd->opcode = OP_CONFIG_CTRL;
 
@@ -164,6 +311,12 @@ void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 	xcmd->execbuf = (u32 *)ecmd;
 
 	xcmd->isize = ecmd->num_cus * sizeof(u32);
+	/* Remove encoding at the low bits
+	 * The same information is stored in CU already.
+	 */
+	for (i = 0; i < ecmd->num_cus; i++)
+		ecmd->data[i] &= ~0x000000FF;
+
 	/* Expect a ordered list of CU address */
 	memcpy(xcmd->info, ecmd->data, xcmd->isize);
 }

--- a/src/runtime_src/core/common/drv/kds_cu_ctrl.c
+++ b/src/runtime_src/core/common/drv/kds_cu_ctrl.c
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Xilinx Kernel Driver Scheduler
+ *
+ * Copyright (C) 2020 Xilinx, Inc.
+ *
+ * Authors: min.ma@xilinx.com
+ */
+
+#include "kds_cu_ctrl.h"
+
+static int
+get_cu_by_addr(struct kds_cu_ctrl *kcuc, u32 addr)
+{
+	int i;
+
+	/* Do not use this search in critical path */
+	for (i = 0; i < kcuc->num_cus; ++i) {
+		if (kcuc->xcus[i]->info.addr == addr)
+			break;
+	}
+
+	return i;
+}
+
+static int
+add_ctx(struct kds_cu_ctrl *kcuc, struct kds_client *client,
+	struct kds_ctx_info *info)
+{
+	struct client_cu_priv *cu_priv;
+	int cu_idx = info->cu_idx;
+	bool shared;
+	int ret = 0;
+
+	if (cu_idx >= kcuc->num_cus) {
+		kds_err(client, "CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
+
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (test_and_set_bit(cu_idx, cu_priv->cu_bitmap)) {
+		kds_err(client, "CU(%d) has been added", cu_idx);
+		return -EINVAL;
+	}
+
+	/* Remove OPs from flag */
+	info->flags &= ~CU_CTX_OP_MASK;
+	shared = (info->flags != CU_CTX_EXCLUSIVE);
+
+	mutex_lock(&kcuc->lock);
+	/* Must check exclusive bit is set first */
+	if (kcuc->cu_refs[cu_idx] & CU_EXCLU_MASK) {
+		kds_err(client, "CU(%d) has been exclusively reserved", cu_idx);
+		ret = -EBUSY;
+		goto err;
+	}
+
+	/* Not allow exclusively reserved if CU is shared */
+	if (!shared && kcuc->cu_refs[cu_idx]) {
+		kds_err(client, "CU(%d) has been shared", cu_idx);
+		ret = -EBUSY;
+		goto err;
+	}
+
+	/* CU is not shared and not exclusively reserved */
+	if (!shared)
+		kcuc->cu_refs[cu_idx] |= CU_EXCLU_MASK;
+	else
+		++kcuc->cu_refs[cu_idx];
+	mutex_unlock(&kcuc->lock);
+
+	return 0;
+err:
+	mutex_unlock(&kcuc->lock);
+	clear_bit(cu_idx, cu_priv->cu_bitmap);
+	return ret;
+}
+
+static int
+del_ctx(struct kds_cu_ctrl *kcuc, struct kds_client *client,
+	struct kds_ctx_info *info)
+{
+	struct client_cu_priv *cu_priv;
+	int cu_idx = info->cu_idx;
+
+	if (cu_idx >= kcuc->num_cus) {
+		kds_err(client, "CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
+
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (!test_and_clear_bit(cu_idx, cu_priv->cu_bitmap)) {
+		kds_err(client, "CU(%d) has never been reserved", cu_idx);
+		return -EINVAL;
+	}
+
+	mutex_lock(&kcuc->lock);
+	if (kcuc->cu_refs[cu_idx] & CU_EXCLU_MASK)
+		kcuc->cu_refs[cu_idx] = 0;
+	else
+		--kcuc->cu_refs[cu_idx];
+	mutex_unlock(&kcuc->lock);
+
+	return 0;
+}
+
+int config_ctrl(struct kds_cu_ctrl *kcuc, struct kds_command *xcmd)
+{
+	struct kds_client *client = xcmd->client;
+	u32 *cus_addr = (u32 *)xcmd->info;
+	size_t num_cus = xcmd->isize / sizeof(u32);
+	struct xrt_cu *tmp;
+	int i, j;
+
+	mutex_lock(&kcuc->lock);
+	/* I don't care if the configure command claim less number of cus */
+	if (unlikely(num_cus > kcuc->num_cus))
+		goto error;
+
+	/* If the configure command is sent by xclLoadXclbin(), the command
+	 * content should be the same and it is okay to let it go through.
+	 *
+	 * But it still has chance that user would manually construct a config
+	 * command, which could be wrong.
+	 *
+	 * So, do not allow reconfigure. This is still not totally safe, since
+	 * configure command and load xclbin are not atomic.
+	 *
+	 * The configured flag would be reset once the last one client finished.
+	 */
+	if (kcuc->configured) {
+		kds_info(client, "CU controller already configured\n");
+		goto done;
+	}
+
+	/* Now we need to make CU index right */
+	for (i = 0; i < num_cus; i++) {
+		j = get_cu_by_addr(kcuc, cus_addr[i]);
+		if (j == kcuc->num_cus)
+			goto error;
+
+		/* Ordering CU index */
+		if (j != i) {
+			tmp = kcuc->xcus[i];
+			kcuc->xcus[i] = kcuc->xcus[j];
+			kcuc->xcus[j] = tmp;
+		}
+		kcuc->xcus[i]->info.cu_idx = i;
+	}
+	kcuc->configured = 1;
+
+done:
+	mutex_unlock(&kcuc->lock);
+	xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
+	xcmd->cb.free(xcmd);
+	return 0;
+
+error:
+	mutex_unlock(&kcuc->lock);
+	xcmd->cb.notify_host(xcmd, KDS_ERROR);
+	xcmd->cb.free(xcmd);
+	return -EINVAL;
+}
+
+int acquire_cu_inst_idx(struct kds_cu_ctrl *kcuc, struct kds_command *xcmd)
+{
+	struct kds_client *client = xcmd->client;
+	struct client_cu_priv *cu_priv;
+	int cu_idx;
+
+	/* Select CU */
+	cu_idx = cu_mask_to_cu_idx(xcmd);
+
+	/* Check if selected CU is in the context */
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (!test_bit(cu_idx, cu_priv->cu_bitmap)) {
+		xcmd->cb.notify_host(xcmd, KDS_ERROR);
+		xcmd->cb.free(xcmd);
+		return -EINVAL;
+	}
+
+	return kcuc->xcus[cu_idx]->info.inst_idx;
+}
+
+int control_ctx(struct kds_cu_ctrl *kcuc, struct kds_client *client,
+		struct kds_ctx_info *info)
+{
+	struct client_cu_priv *cu_priv;
+	u32 op;
+
+	/* TODO: Still has space to improve configured flag.
+	 * Since not all of the clients would need to use CU controller.
+	 *
+	 * But right now, the scope of a configuration is unclear.
+	 * Maybe the configuration could be per client?
+	 * Maybe config command would be removed?
+	 *
+	 * Anyway, for now, allow reconfigure when the last client exit.
+	 */
+	op = info->flags & CU_CTX_OP_MASK;
+	switch (op) {
+	case CU_CTX_OP_INIT:
+		cu_priv = vzalloc(sizeof(*cu_priv));
+		if (!cu_priv)
+			return -ENOMEM;
+		client->ctrl_priv[KDS_CU] = cu_priv;
+		mutex_lock(&kcuc->lock);
+		++kcuc->num_clients;
+		mutex_unlock(&kcuc->lock);
+		break;
+	case CU_CTX_OP_FINI:
+		vfree(client->ctrl_priv[KDS_CU]);
+		client->ctrl_priv[KDS_CU] = NULL;
+		mutex_lock(&kcuc->lock);
+		--kcuc->num_clients;
+		if (!kcuc->num_clients)
+			kcuc->configured = 0;
+		mutex_unlock(&kcuc->lock);
+		break;
+	case CU_CTX_OP_ADD:
+		return add_ctx(kcuc, client, info);
+	case CU_CTX_OP_DEL:
+		return del_ctx(kcuc, client, info);
+	}
+
+	return 0;
+}
+
+int add_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu)
+{
+	int i;
+
+	if (!kcuc)
+		return -EINVAL;
+
+	if (kcuc->num_cus >= MAX_CUS)
+		return -ENOMEM;
+
+	/* Find a slot xcus[] */
+	for (i = 0; i < MAX_CUS; i++) {
+		if (kcuc->xcus[i] != NULL)
+			continue;
+
+		kcuc->xcus[i] = xcu;
+		++kcuc->num_cus;
+		break;
+	}
+
+	return i;
+}
+
+int remove_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu)
+{
+	int i;
+
+	if (!kcuc)
+		return -EINVAL;
+
+	if (kcuc->num_cus == 0)
+		return -EINVAL;
+
+	for (i = 0; i < MAX_CUS; i++) {
+		if (kcuc->xcus[i] != xcu)
+			continue;
+
+		kcuc->xcus[i] = NULL;
+		--kcuc->num_cus;
+		break;
+	}
+
+	return i;
+}
+
+ssize_t show_cu_ctx(struct kds_cu_ctrl *kcuc, char *buf)
+{
+	bool shared;
+	ssize_t sz = 0;
+	int ref;
+	u32 i = 0;
+
+	mutex_lock(&kcuc->lock);
+	for (i = 0; i < kcuc->num_cus; ++i) {
+		shared = !(kcuc->cu_refs[i] & CU_EXCLU_MASK);
+		ref = kcuc->cu_refs[i] & ~CU_EXCLU_MASK;
+		sz += sprintf(buf+sz, "CU[%d] shared(%d) refcount(%d)\n",
+			      i, shared, ref);
+	}
+	mutex_unlock(&kcuc->lock);
+
+	if (sz)
+		buf[sz++] = 0;
+
+	return sz;
+}

--- a/src/runtime_src/core/common/drv/kds_cu_ctrl.c
+++ b/src/runtime_src/core/common/drv/kds_cu_ctrl.c
@@ -9,6 +9,14 @@
 
 #include "kds_cu_ctrl.h"
 
+/**
+ * get_cu_by_addr -Get CU index by address
+ *
+ * @kcuc: KDS CU controller
+ * @addr: The address of the target CU
+ *
+ * Returns CU index if found. Returns an out of range number if not found.
+ */
 static int
 get_cu_by_addr(struct kds_cu_ctrl *kcuc, u32 addr)
 {
@@ -243,10 +251,10 @@ int add_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu)
 
 		kcuc->xcus[i] = xcu;
 		++kcuc->num_cus;
-		break;
+		return 0;
 	}
 
-	return i;
+	return -ENOSPC;
 }
 
 int remove_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu)
@@ -265,10 +273,10 @@ int remove_cu(struct kds_cu_ctrl *kcuc, struct xrt_cu *xcu)
 
 		kcuc->xcus[i] = NULL;
 		--kcuc->num_cus;
-		break;
+		return 0;
 	}
 
-	return i;
+	return -ENODEV;
 }
 
 ssize_t show_cu_ctx(struct kds_cu_ctrl *kcuc, char *buf)

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -6,6 +6,7 @@ KERNEL_SRC ?= /lib/modules/$(shell uname -r)/build
 ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include
 
 drv_common-y   := ../../../common/drv/kds_core.o \
+		  ../../../common/drv/kds_cu_ctrl.o \
 		  ../../../common/drv/cu_hls.o \
 		  ../../../common/drv/xrt_cu.o
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -162,12 +162,12 @@ zocl_bo_execbuf(const struct drm_zocl_bo *bo)
 
 static inline void
 zocl_kds_setctrl(struct drm_zocl_dev *zdev, int type,
-		 struct kds_controller *ctrl)
+		 struct kds_ctrl *ctrl)
 {
 	zdev->kds.ctrl[type] = ctrl;
 }
 
-static inline struct kds_controller *
+static inline struct kds_ctrl *
 zocl_kds_getctrl(struct drm_zocl_dev *zdev, int type)
 {
 	return zdev->kds.ctrl[type];
@@ -200,6 +200,8 @@ int zocl_create_client(struct drm_zocl_dev *zdev, void **priv);
 void zocl_destroy_client(struct drm_zocl_dev *zdev, void **priv);
 uint zocl_poll_client(struct file *filp, poll_table *wait);
 int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
+		       struct drm_file *filp);
+int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp);
 
 /* CU controller */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -89,10 +89,6 @@ struct zdev_data {
 	char fpga_driver_name[64];
 };
 
-struct kds_sched {
-	struct kds_controller *ctrl[KDS_MAX_TYPE];
-};
-
 struct drm_zocl_dev {
 	struct drm_device       *ddev;
 	struct fpga_manager     *fpga_mgr;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -12,6 +12,8 @@
 #ifndef _ZOCL_XCLBIN_H_
 #define _ZOCL_XCLBIN_H_
 
+#include <linux/uuid.h>
+
 struct zocl_xclbin {
 	int		zx_refcnt;
 	void		*zx_uuid;
@@ -22,9 +24,8 @@ void zocl_xclbin_fini(struct drm_zocl_dev *zdev);
 
 int zocl_xclbin_set_uuid(struct drm_zocl_dev *zdev, void *uuid);
 void *zocl_xclbin_get_uuid(struct drm_zocl_dev *zdev);
-int zocl_xclbin_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_ctx *ctx,
-	struct sched_client_ctx *client);
-int zocl_xclbin_release(struct drm_zocl_dev *zdev);
+int zocl_lock_bitstream(struct drm_zocl_dev *zdev, const uuid_t *id);
+int zocl_unlock_bitstream(struct drm_zocl_dev *zdev, const uuid_t *id);
 
 int zocl_xclbin_refcount(struct drm_zocl_dev *zdev);
 int zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev,

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -32,7 +32,7 @@ void zocl_describe(const struct drm_zocl_bo *obj)
 	size_t size_in_kb = obj->cma_base.base.size / 1024;
 	size_t physical_addr = obj->cma_base.paddr;
 
-	DRM_DEBUG("%p: H[0x%zxKB] D[0x%zx]\n",
+	DRM_DEBUG("%px: H[0x%zxKB] D[0x%zx]\n",
 			obj,
 			size_in_kb,
 			physical_addr);
@@ -834,7 +834,7 @@ void zocl_free_host_bo(struct drm_gem_object *gem_obj)
 {
 	struct drm_zocl_bo *zocl_bo = to_zocl_bo(gem_obj);
 
-	DRM_INFO("%s: obj 0x%p", __func__, zocl_bo);
+	DRM_DEBUG("%s: obj 0x%px", __func__, zocl_bo);
 
 	memunmap(zocl_bo->cma_base.vaddr);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
@@ -10,145 +10,84 @@
  */
 
 #include "zocl_drv.h"
-#include "kds_core.h"
+#include "kds_cu_ctrl.h"
 #include "xrt_cu.h"
 
-#define CU_EXCLU_MASK		0x80000000
+#define TO_ZOCL_CU_CTRL(c) ((struct zocl_cu_ctrl *)(c))
 
 struct zocl_cu_ctrl {
-	struct kds_ctrl		 core;
+	struct kds_cu_ctrl	 core;
 	struct drm_zocl_dev	*zdev;
-	struct xrt_cu		*xcus[MAX_CUS];
-	struct mutex		 lock;
-	u32			 cu_refs[MAX_CUS];
-	int			 num_cus;
-	int			 num_clients;
-	int			 configured;
 };
 
-struct client_cu_priv {
-	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
+/* sysfs nods */
+static ssize_t
+cu_ctx_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+
+	return show_cu_ctx(TO_CU_CTRL(zocl_kds_getctrl(zdev, KDS_CU)), buf);
+}
+static DEVICE_ATTR_RO(cu_ctx);
+
+static struct attribute *cu_ctrl_attrs[] = {
+	&dev_attr_cu_ctx.attr,
+	NULL,
 };
 
-static int get_cu_by_addr(struct zocl_cu_ctrl *zcuc, u32 addr)
-{
-	int i;
-
-	/* Do not use this search in critical path */
-	for (i = 0; i < zcuc->num_cus; ++i) {
-		if (zcuc->xcus[i]->info.addr == addr)
-			break;
-	}
-
-	return i;
-}
-
-static inline int cu_mask_to_cu_idx(struct kds_command *xcmd)
-{
-	/* TODO: balance the CU usage if multiple bits are set */
-
-	/* assume there is alwasy one CU */
-	return 0;
-}
+static struct attribute_group cu_ctrl_attr_group = {
+	.attrs = cu_ctrl_attrs,
+};
+/* sysfs nods end */
 
 static void
 cu_ctrl_config(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 {
 	u32 *cus_addr = (u32 *)xcmd->info;
 	size_t num_cus = xcmd->isize / sizeof(u32);
-	struct xrt_cu *tmp;
-	int i, j;
 	int apt_idx;
+	int i;
 
-	mutex_lock(&zcuc->lock);
-	/* I don't care if the configure command claim less number of cus */
-	if (num_cus > zcuc->num_cus)
-		goto error;
+	if (config_ctrl(TO_CU_CTRL(zcuc), xcmd))
+		return;
 
-	/* If the configure command is sent by xclLoadXclbin(), the command
-	 * content should be the same and it is okay to let it go through.
-	 *
-	 * But it still has chance that user would manually construct a config
-	 * command, which could be wrong.
-	 *
-	 * So, do not allow reconfigure. This is still not totally safe, since
-	 * configure command and load xclbin are not atomic.
-	 *
-	 * The configured flag would be reset once the last one client finished.
+	/* TODO: replace aperture list.
+	 * Before that, keep this to make aperture work.
 	 */
-	if (zcuc->configured) {
-		DRM_INFO("CU controller already configured\n");
-		goto done;
-	}
-
-	/* Now we need to make CU index right */
 	for (i = 0; i < num_cus; i++) {
-		j = get_cu_by_addr(zcuc, cus_addr[i]);
-		if (j == zcuc->num_cus)
-			goto error;
-
-		/* Ordering CU index */
-		if (j != i) {
-			tmp = zcuc->xcus[i];
-			zcuc->xcus[i] = zcuc->xcus[j];
-			zcuc->xcus[j] = tmp;
-		}
-		zcuc->xcus[i]->info.cu_idx = i;
-
-		/* TODO: replace aperture list. Before that, keep this to make
-		 * aperture work.
-		 */
 		apt_idx = get_apt_index_by_addr(zcuc->zdev, cus_addr[i]);
-		if (apt_idx < 0) {
-			DRM_ERROR("CU address %x is not found in XCLBIN\n",
-				  cus_addr[i]);
-			goto error;
-		}
+		WARN_ON(apt_idx < 0);
 		update_cu_idx_in_apt(zcuc->zdev, apt_idx, i);
 	}
+}
 
-	zcuc->configured = 1;
+static inline void
+cu_ctrl_dispatch(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
+{
+	int inst_idx;
 
-done:
-	mutex_unlock(&zcuc->lock);
-	/* TODO: Does it need a queue for configure commands? */
+	/* This is call echo type 1.
+	 * The echo type 2 could be enabled by module param 'kds_echo=1'
+	 */
+#if 0
 	xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
 	xcmd->cb.free(xcmd);
 	return;
+#endif
 
-error:
-	mutex_unlock(&zcuc->lock);
-	xcmd->cb.notify_host(xcmd, KDS_ERROR);
-	xcmd->cb.free(xcmd);
-}
-
-static void
-cu_ctrl_dispatch(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
-{
-	struct kds_client *client = xcmd->client;
-	struct client_cu_priv *cu_priv;
-	int cu_idx;
-	int inst_idx;
-
-	/* Select CU */
-	cu_idx = cu_mask_to_cu_idx(xcmd);
-
-	/* Check if selected CU is in the context */
-	cu_priv = client->ctrl_priv[KDS_CU];
-	if (!test_bit(cu_idx, cu_priv->cu_bitmap)) {
-		xcmd->cb.notify_host(xcmd, KDS_ERROR);
-		xcmd->cb.free(xcmd);
-		return;
-	}
-
-	inst_idx = zcuc->xcus[cu_idx]->info.inst_idx;
-	(void) zocl_cu_submit_xcmd(zcuc->zdev, inst_idx, xcmd);
+	/* In here we needs to know the CU subdevice instance id,
+	 * which is determined at load xclbin.
+	 * It is different from the CU index defined by config command.
+	 */
+	inst_idx = acquire_cu_inst_idx(TO_CU_CTRL(zcuc), xcmd);
+	if (inst_idx >= 0)
+		(void) zocl_cu_submit_xcmd(zcuc->zdev, inst_idx, xcmd);
 }
 
 static void
 cu_ctrl_submit(struct kds_ctrl *ctrl, struct kds_command *xcmd)
 {
-	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
+	struct zocl_cu_ctrl *zcuc = TO_ZOCL_CU_CTRL(ctrl);
 
 	/* Priority from hight to low */
 	if (xcmd->opcode != OP_CONFIG_CTRL)
@@ -158,157 +97,22 @@ cu_ctrl_submit(struct kds_ctrl *ctrl, struct kds_command *xcmd)
 }
 
 static int
-cu_ctrl_add_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
-		struct kds_ctx_info *info)
-{
-	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
-	struct client_cu_priv *cu_priv;
-	int cu_idx = info->cu_idx;
-	bool shared;
-	int ret = 0;
-
-	if (cu_idx >= zcuc->num_cus) {
-		DRM_ERROR("CU(%d) not found", cu_idx);
-		return -EINVAL;
-	}
-
-	cu_priv = client->ctrl_priv[KDS_CU];
-	if (test_and_set_bit(cu_idx, cu_priv->cu_bitmap)) {
-		DRM_ERROR("CU(%d) has been added", cu_idx);
-		return -EINVAL;
-	}
-
-	info->flags &= ~CU_CTX_OP_MASK;
-	shared = (info->flags != CU_CTX_EXCLUSIVE);
-
-	mutex_lock(&zcuc->lock);
-
-	if (zcuc->cu_refs[cu_idx] & CU_EXCLU_MASK) {
-		DRM_ERROR("CU(%d) has been exclusively reserved", cu_idx);
-		ret = -EBUSY;
-		goto err;
-	}
-
-	if (!shared && zcuc->cu_refs[cu_idx]) {
-		DRM_ERROR("CU(%d) has been shared", cu_idx);
-		ret = -EBUSY;
-		goto err;
-	}
-
-	if (!shared)
-		zcuc->cu_refs[cu_idx] |= CU_EXCLU_MASK;
-	else
-		++zcuc->cu_refs[cu_idx];
-
-	mutex_unlock(&zcuc->lock);
-
-	return 0;
-err:
-	clear_bit(cu_idx, cu_priv->cu_bitmap);
-	return ret;
-}
-
-static int
-cu_ctrl_del_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
-		struct kds_ctx_info *info)
-{
-	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
-	struct client_cu_priv *cu_priv;
-	int cu_idx = info->cu_idx;
-
-	if (cu_idx >= zcuc->num_cus) {
-		DRM_ERROR("CU(%d) not found", cu_idx);
-		return -EINVAL;
-	}
-
-	cu_priv = client->ctrl_priv[KDS_CU];
-	if (!test_and_clear_bit(cu_idx, cu_priv->cu_bitmap)) {
-		DRM_ERROR("CU(%d) has never been reserved", cu_idx);
-		return -EINVAL;
-	}
-
-	mutex_lock(&zcuc->lock);
-	if (zcuc->cu_refs[cu_idx] & CU_EXCLU_MASK)
-		zcuc->cu_refs[cu_idx] = 0;
-	else
-		--zcuc->cu_refs[cu_idx];
-	mutex_unlock(&zcuc->lock);
-
-	return 0;
-}
-
-static int
 cu_ctrl_control_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
 		    struct kds_ctx_info *info)
 {
-	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
-	struct client_cu_priv *cu_priv;
-	u32 op;
-
-	op = info->flags & CU_CTX_OP_MASK;
-	switch (op) {
-	case CU_CTX_OP_INIT:
-		cu_priv = kzalloc(sizeof(*cu_priv), GFP_KERNEL);
-		if (!cu_priv)
-			return -ENOMEM;
-		client->ctrl_priv[KDS_CU] = cu_priv;
-		mutex_lock(&zcuc->lock);
-		++zcuc->num_clients;
-		mutex_unlock(&zcuc->lock);
-		break;
-	case CU_CTX_OP_FINI:
-		kfree(client->ctrl_priv[KDS_CU]);
-		client->ctrl_priv[KDS_CU] = NULL;
-		mutex_lock(&zcuc->lock);
-		--zcuc->num_clients;
-		mutex_unlock(&zcuc->lock);
-		break;
-	case CU_CTX_OP_ADD:
-		return cu_ctrl_add_ctx(ctrl, client, info);
-	case CU_CTX_OP_DEL:
-		return cu_ctrl_del_ctx(ctrl, client, info);
-	}
-
-	/* TODO: Still has space to improve. Since not all of the clients would
-	 * need to use CU controller.
-	 *
-	 * But right now, the scope of a configuration is unclear.
-	 * Or maybe the configuration could be per client?
-	 * Or maybe config command would be removed?
-	 *
-	 * Anyway, for now, allow reconfigure when the last client exit.
-	 */
-	mutex_lock(&zcuc->lock);
-	if (!zcuc->num_clients)
-		zcuc->configured = 0;
-	mutex_unlock(&zcuc->lock);
-
-	return 0;
+	return control_ctx(TO_CU_CTRL(ctrl), client, info);
 }
 
 int cu_ctrl_add_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 {
-	struct zocl_cu_ctrl *zcuc;
-	int i;
+	int ret;
 
-	zcuc = (struct zocl_cu_ctrl *)zocl_kds_getctrl(zdev, KDS_CU);
-	if (!zcuc)
-		return -EINVAL;
+	ret = add_cu(TO_CU_CTRL(zocl_kds_getctrl(zdev, KDS_CU)), xcu);
+	if (ret < 0)
+		return ret;
 
-	if (zcuc->num_cus >= MAX_CUS)
-		return -ENOMEM;
-
-	for (i = 0; i < MAX_CUS; i++) {
-		if (zcuc->xcus[i] != NULL)
-			continue;
-
-		zcuc->xcus[i] = xcu;
-		++zcuc->num_cus;
-		break;
-	}
-
-	if (i == MAX_CUS) {
-		DRM_ERROR("Could not find a slot for CU %p\n", xcu);
+	if (ret == MAX_CUS) {
+		DRM_ERROR("Could not find a slot for CU %px\n", xcu);
 		return -ENOSPC;
 	}
 
@@ -317,27 +121,14 @@ int cu_ctrl_add_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 
 int cu_ctrl_remove_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 {
-	struct zocl_cu_ctrl *zcuc;
-	int i;
+	int ret;
 
-	zcuc = (struct zocl_cu_ctrl *)zocl_kds_getctrl(zdev, KDS_CU);
-	if (!zcuc)
-		return -EINVAL;
+	ret = remove_cu(TO_CU_CTRL(zocl_kds_getctrl(zdev, KDS_CU)), xcu);
+	if (ret < 0)
+		return ret;
 
-	if (zcuc->num_cus == 0)
-		return -EINVAL;
-
-	for (i = 0; i < MAX_CUS; i++) {
-		if (zcuc->xcus[i] != xcu)
-			continue;
-
-		zcuc->xcus[i] = NULL;
-		--zcuc->num_cus;
-		break;
-	}
-
-	if (i == MAX_CUS) {
-		DRM_ERROR("Could not find CU %p\n", xcu);
+	if (ret == MAX_CUS) {
+		DRM_ERROR("Could not find CU %px\n", xcu);
 		return -EINVAL;
 	}
 
@@ -347,20 +138,32 @@ int cu_ctrl_remove_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 int cu_ctrl_init(struct drm_zocl_dev *zdev)
 {
 	struct zocl_cu_ctrl *zcuc;
+	struct kds_ctrl *core;
+	int ret = 0;
 
 	zcuc = kzalloc(sizeof(*zcuc), GFP_KERNEL);
 	if (!zcuc)
 		return -ENOMEM;
 
-	mutex_init(&zcuc->lock);
+	mutex_init(&zcuc->core.lock);
 	zcuc->zdev = zdev;
 
-	zcuc->core.control_ctx = cu_ctrl_control_ctx;
-	zcuc->core.submit = cu_ctrl_submit;
+	core = TO_KDS_CTRL(&zcuc->core);
+	core->control_ctx = cu_ctrl_control_ctx;
+	core->submit = cu_ctrl_submit;
 
-	zocl_kds_setctrl(zdev, KDS_CU, (struct kds_ctrl *)zcuc);
+	ret = sysfs_create_group(&zdev->ddev->dev->kobj, &cu_ctrl_attr_group);
+	if (ret) {
+		DRM_ERROR("create cu_ctrl attrs failed: 0x%x", ret);
+		goto err;
+	}
 
+	zocl_kds_setctrl(zdev, KDS_CU, core);
 	return 0;
+
+err:
+	kfree(zcuc);
+	return ret;
 }
 
 void cu_ctrl_fini(struct drm_zocl_dev *zdev)
@@ -368,11 +171,12 @@ void cu_ctrl_fini(struct drm_zocl_dev *zdev)
 	struct zocl_cu_ctrl *zcuc;
 
 	zcuc = (struct zocl_cu_ctrl *)zocl_kds_getctrl(zdev, KDS_CU);
-	if (!zcuc)
-		return;
+	BUG_ON(zcuc == NULL);
 
-	mutex_destroy(&zcuc->lock);
+	mutex_destroy(&zcuc->core.lock);
 	kfree(zcuc);
 
 	zocl_kds_setctrl(zdev, KDS_CU, NULL);
+
+	sysfs_remove_group(&zdev->ddev->dev->kobj, &cu_ctrl_attr_group);
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
@@ -13,12 +13,21 @@
 #include "kds_core.h"
 #include "xrt_cu.h"
 
+#define CU_EXCLU_MASK		0x80000000
+
 struct zocl_cu_ctrl {
-	struct kds_controller    core;
+	struct kds_ctrl		 core;
 	struct drm_zocl_dev	*zdev;
 	struct xrt_cu		*xcus[MAX_CUS];
+	struct mutex		 lock;
+	u32			 cu_refs[MAX_CUS];
 	int			 num_cus;
+	int			 num_clients;
+	int			 configured;
+};
 
+struct client_cu_priv {
+	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
 };
 
 static int get_cu_by_addr(struct zocl_cu_ctrl *zcuc, u32 addr)
@@ -51,9 +60,26 @@ cu_ctrl_config(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 	int i, j;
 	int apt_idx;
 
+	mutex_lock(&zcuc->lock);
 	/* I don't care if the configure command claim less number of cus */
 	if (num_cus > zcuc->num_cus)
 		goto error;
+
+	/* If the configure command is sent by xclLoadXclbin(), the command
+	 * content should be the same and it is okay to let it go through.
+	 *
+	 * But it still has chance that user would manually construct a config
+	 * command, which could be wrong.
+	 *
+	 * So, do not allow reconfigure. This is still not totally safe, since
+	 * configure command and load xclbin are not atomic.
+	 *
+	 * The configured flag would be reset once the last one client finished.
+	 */
+	if (zcuc->configured) {
+		DRM_INFO("CU controller already configured\n");
+		goto done;
+	}
 
 	/* Now we need to make CU index right */
 	for (i = 0; i < num_cus; i++) {
@@ -81,12 +107,17 @@ cu_ctrl_config(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 		update_cu_idx_in_apt(zcuc->zdev, apt_idx, i);
 	}
 
+	zcuc->configured = 1;
+
+done:
+	mutex_unlock(&zcuc->lock);
 	/* TODO: Does it need a queue for configure commands? */
 	xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
 	xcmd->cb.free(xcmd);
 	return;
 
 error:
+	mutex_unlock(&zcuc->lock);
 	xcmd->cb.notify_host(xcmd, KDS_ERROR);
 	xcmd->cb.free(xcmd);
 }
@@ -94,17 +125,28 @@ error:
 static void
 cu_ctrl_dispatch(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 {
+	struct kds_client *client = xcmd->client;
+	struct client_cu_priv *cu_priv;
 	int cu_idx;
 	int inst_idx;
 
 	/* Select CU */
 	cu_idx = cu_mask_to_cu_idx(xcmd);
+
+	/* Check if selected CU is in the context */
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (!test_bit(cu_idx, cu_priv->cu_bitmap)) {
+		xcmd->cb.notify_host(xcmd, KDS_ERROR);
+		xcmd->cb.free(xcmd);
+		return;
+	}
+
 	inst_idx = zcuc->xcus[cu_idx]->info.inst_idx;
 	(void) zocl_cu_submit_xcmd(zcuc->zdev, inst_idx, xcmd);
 }
 
 static void
-cu_ctrl_submit(struct kds_controller *ctrl, struct kds_command *xcmd)
+cu_ctrl_submit(struct kds_ctrl *ctrl, struct kds_command *xcmd)
 {
 	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
 
@@ -113,6 +155,135 @@ cu_ctrl_submit(struct kds_controller *ctrl, struct kds_command *xcmd)
 		cu_ctrl_dispatch(zcuc, xcmd);
 	else
 		cu_ctrl_config(zcuc, xcmd);
+}
+
+static int
+cu_ctrl_add_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
+		struct kds_ctx_info *info)
+{
+	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
+	struct client_cu_priv *cu_priv;
+	int cu_idx = info->cu_idx;
+	bool shared;
+	int ret = 0;
+
+	if (cu_idx >= zcuc->num_cus) {
+		DRM_ERROR("CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
+
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (test_and_set_bit(cu_idx, cu_priv->cu_bitmap)) {
+		DRM_ERROR("CU(%d) has been added", cu_idx);
+		return -EINVAL;
+	}
+
+	info->flags &= ~CU_CTX_OP_MASK;
+	shared = (info->flags != CU_CTX_EXCLUSIVE);
+
+	mutex_lock(&zcuc->lock);
+
+	if (zcuc->cu_refs[cu_idx] & CU_EXCLU_MASK) {
+		DRM_ERROR("CU(%d) has been exclusively reserved", cu_idx);
+		ret = -EBUSY;
+		goto err;
+	}
+
+	if (!shared && zcuc->cu_refs[cu_idx]) {
+		DRM_ERROR("CU(%d) has been shared", cu_idx);
+		ret = -EBUSY;
+		goto err;
+	}
+
+	if (!shared)
+		zcuc->cu_refs[cu_idx] |= CU_EXCLU_MASK;
+	else
+		++zcuc->cu_refs[cu_idx];
+
+	mutex_unlock(&zcuc->lock);
+
+	return 0;
+err:
+	clear_bit(cu_idx, cu_priv->cu_bitmap);
+	return ret;
+}
+
+static int
+cu_ctrl_del_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
+		struct kds_ctx_info *info)
+{
+	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
+	struct client_cu_priv *cu_priv;
+	int cu_idx = info->cu_idx;
+
+	if (cu_idx >= zcuc->num_cus) {
+		DRM_ERROR("CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
+
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (!test_and_clear_bit(cu_idx, cu_priv->cu_bitmap)) {
+		DRM_ERROR("CU(%d) has never been reserved", cu_idx);
+		return -EINVAL;
+	}
+
+	mutex_lock(&zcuc->lock);
+	if (zcuc->cu_refs[cu_idx] & CU_EXCLU_MASK)
+		zcuc->cu_refs[cu_idx] = 0;
+	else
+		--zcuc->cu_refs[cu_idx];
+	mutex_unlock(&zcuc->lock);
+
+	return 0;
+}
+
+static int
+cu_ctrl_control_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
+		    struct kds_ctx_info *info)
+{
+	struct zocl_cu_ctrl *zcuc = (struct zocl_cu_ctrl *)ctrl;
+	struct client_cu_priv *cu_priv;
+	u32 op;
+
+	op = info->flags & CU_CTX_OP_MASK;
+	switch (op) {
+	case CU_CTX_OP_INIT:
+		cu_priv = kzalloc(sizeof(*cu_priv), GFP_KERNEL);
+		if (!cu_priv)
+			return -ENOMEM;
+		client->ctrl_priv[KDS_CU] = cu_priv;
+		mutex_lock(&zcuc->lock);
+		++zcuc->num_clients;
+		mutex_unlock(&zcuc->lock);
+		break;
+	case CU_CTX_OP_FINI:
+		kfree(client->ctrl_priv[KDS_CU]);
+		client->ctrl_priv[KDS_CU] = NULL;
+		mutex_lock(&zcuc->lock);
+		--zcuc->num_clients;
+		mutex_unlock(&zcuc->lock);
+		break;
+	case CU_CTX_OP_ADD:
+		return cu_ctrl_add_ctx(ctrl, client, info);
+	case CU_CTX_OP_DEL:
+		return cu_ctrl_del_ctx(ctrl, client, info);
+	}
+
+	/* TODO: Still has space to improve. Since not all of the clients would
+	 * need to use CU controller.
+	 *
+	 * But right now, the scope of a configuration is unclear.
+	 * Or maybe the configuration could be per client?
+	 * Or maybe config command would be removed?
+	 *
+	 * Anyway, for now, allow reconfigure when the last client exit.
+	 */
+	mutex_lock(&zcuc->lock);
+	if (!zcuc->num_clients)
+		zcuc->configured = 0;
+	mutex_unlock(&zcuc->lock);
+
+	return 0;
 }
 
 int cu_ctrl_add_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
@@ -181,11 +352,13 @@ int cu_ctrl_init(struct drm_zocl_dev *zdev)
 	if (!zcuc)
 		return -ENOMEM;
 
+	mutex_init(&zcuc->lock);
 	zcuc->zdev = zdev;
 
+	zcuc->core.control_ctx = cu_ctrl_control_ctx;
 	zcuc->core.submit = cu_ctrl_submit;
 
-	zocl_kds_setctrl(zdev, KDS_CU, (struct kds_controller *)zcuc);
+	zocl_kds_setctrl(zdev, KDS_CU, (struct kds_ctrl *)zcuc);
 
 	return 0;
 }
@@ -198,6 +371,7 @@ void cu_ctrl_fini(struct drm_zocl_dev *zdev)
 	if (!zcuc)
 		return;
 
+	mutex_destroy(&zcuc->lock);
 	kfree(zcuc);
 
 	zocl_kds_setctrl(zdev, KDS_CU, NULL);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_ctrl.c
@@ -75,7 +75,7 @@ cu_ctrl_dispatch(struct zocl_cu_ctrl *zcuc, struct kds_command *xcmd)
 	return;
 #endif
 
-	/* In here we needs to know the CU subdevice instance id,
+	/* In here we need to know the CU subdevice instance id,
 	 * which is determined at load xclbin.
 	 * It is different from the CU index defined by config command.
 	 */
@@ -108,12 +108,9 @@ int cu_ctrl_add_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 	int ret;
 
 	ret = add_cu(TO_CU_CTRL(zocl_kds_getctrl(zdev, KDS_CU)), xcu);
-	if (ret < 0)
+	if (ret < 0) {
+		DRM_ERROR("Could not find a slot for CU, ret %d\n", ret);
 		return ret;
-
-	if (ret == MAX_CUS) {
-		DRM_ERROR("Could not find a slot for CU %px\n", xcu);
-		return -ENOSPC;
 	}
 
 	return 0;
@@ -124,12 +121,9 @@ int cu_ctrl_remove_cu(struct drm_zocl_dev *zdev, struct xrt_cu *xcu)
 	int ret;
 
 	ret = remove_cu(TO_CU_CTRL(zocl_kds_getctrl(zdev, KDS_CU)), xcu);
-	if (ret < 0)
+	if (ret < 0) {
+		DRM_ERROR("Could not find CU, ret %d\n", ret);
 		return ret;
-
-	if (ret == MAX_CUS) {
-		DRM_ERROR("Could not find CU %px\n", xcu);
-		return -EINVAL;
 	}
 
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -18,6 +18,11 @@
 #include "zocl_generic_cu.h"
 
 extern int kds_mode;
+
+/* TODO: remove this once new KDS is ready */
+int zocl_xclbin_ctx(struct drm_zocl_dev *zdev, struct drm_zocl_ctx *ctx,
+		    struct sched_client_ctx *client);
+
 /*
  * read_axlf and ctx should be protected by zdev_xclbin_lock exclusively.
  */
@@ -57,7 +62,7 @@ zocl_ctx_ioctl(struct drm_device *ddev, void *data, struct drm_file *filp)
 	int ret = 0;
 
 	if (kds_mode == 1) {
-		return ret;
+		return zocl_context_ioctl(zdev, data, filp);
 	}
 
 	if (args->op == ZOCL_CTX_OP_OPEN_GCU_FD) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -108,7 +108,6 @@ zocl_del_context(struct drm_zocl_dev *zdev, struct kds_client *client,
 	}
 
 	mutex_lock(&client->lock);
-
 	uuid = client->xclbin_id;
 	/* xclCloseContext() would send xclbin_id and cu_idx.
 	 * Be more cautious while delete. Do sanity check

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -54,8 +54,10 @@ zocl_add_context(struct drm_zocl_dev *zdev, struct kds_client *client,
 		return -ENOMEM;
 
 	ret = copy_from_user(id, uuid_ptr, sizeof(uuid_t));
-	if (ret)
-		goto out;
+	if (ret) {
+		vfree(id);
+		return ret;
+	}
 
 	mutex_lock(&client->lock);
 	if (!client->num_ctx) {
@@ -82,8 +84,8 @@ out:
 		client->xclbin_id = NULL;
 		(void) zocl_unlock_bitstream(zdev, id);
 	}
-	vfree(id);
 	mutex_unlock(&client->lock);
+	vfree(id);
 	return ret;
 }
 
@@ -137,8 +139,8 @@ zocl_del_context(struct drm_zocl_dev *zdev, struct kds_client *client,
 	}
 
 out:
-	vfree(id);
 	mutex_unlock(&client->lock);
+	vfree(id);
 	return ret;
 }
 
@@ -158,6 +160,7 @@ int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
 		break;
 	default:
 		ret = -EINVAL;
+		break;
 	}
 
 	return ret;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -12,6 +12,7 @@
 #include <linux/sched/signal.h>
 #include "zocl_drv.h"
 #include "zocl_util.h"
+#include "zocl_xclbin.h"
 #include "kds_core.h"
 
 int kds_mode = 0;
@@ -24,6 +25,145 @@ module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_echo,
 		 "enable KDS echo (0 = disable (default), 1 = enable)");
 
+static inline void
+zocl_ctx_to_info(struct drm_zocl_ctx *args, struct kds_ctx_info *info)
+{
+	if (args->cu_index == ZOCL_CTX_VIRT_CU_INDEX)
+		info->cu_idx = CU_CTX_VIRT_CU;
+	else
+		info->cu_idx = args->cu_index;
+
+	/* Ignore ZOCL_CTX_SHARED bit if ZOCL_CTX_EXCLUSIVE bit is set */
+	if (args->flags & ZOCL_CTX_EXCLUSIVE)
+		info->flags = CU_CTX_EXCLUSIVE;
+	else
+		info->flags = CU_CTX_SHARED;
+}
+
+static int
+zocl_add_context(struct drm_zocl_dev *zdev, struct kds_client *client,
+		 struct drm_zocl_ctx *args)
+{
+	struct kds_ctx_info info;
+	void *uuid_ptr = (void *)(uintptr_t)args->uuid_ptr;
+	uuid_t *id;
+	int ret;
+
+	id = vmalloc(sizeof(uuid_t));
+	if (!id)
+		return -ENOMEM;
+
+	ret = copy_from_user(id, uuid_ptr, sizeof(uuid_t));
+	if (ret)
+		goto out;
+
+	mutex_lock(&client->lock);
+	if (!client->num_ctx) {
+		ret = zocl_lock_bitstream(zdev, id);
+		if (ret)
+			goto out;
+		client->xclbin_id = vzalloc(sizeof(*id));
+		if (!client->xclbin_id) {
+			ret = -ENOMEM;
+			goto out;
+		}
+		uuid_copy(client->xclbin_id, id);
+	}
+
+	/* Bitstream is locked. No one could load a new one
+	 * until this client close all of the contexts.
+	 */
+	zocl_ctx_to_info(args, &info);
+	ret = kds_add_context(client, &info);
+
+out:
+	if (!client->num_ctx) {
+		vfree(client->xclbin_id);
+		client->xclbin_id = NULL;
+		(void) zocl_unlock_bitstream(zdev, id);
+	}
+	vfree(id);
+	mutex_unlock(&client->lock);
+	return ret;
+}
+
+static int
+zocl_del_context(struct drm_zocl_dev *zdev, struct kds_client *client,
+		 struct drm_zocl_ctx *args)
+{
+	struct kds_ctx_info info;
+	void *uuid_ptr = (void *)(uintptr_t)args->uuid_ptr;
+	uuid_t *id;
+	uuid_t *uuid;
+	int ret;
+
+	id = vmalloc(sizeof(uuid_t));
+	if (!id)
+		return -ENOMEM;
+
+	ret = copy_from_user(id, uuid_ptr, sizeof(uuid_t));
+	if (ret) {
+		vfree(id);
+		return ret;
+	}
+
+	mutex_lock(&client->lock);
+
+	uuid = client->xclbin_id;
+	/* xclCloseContext() would send xclbin_id and cu_idx.
+	 * Be more cautious while delete. Do sanity check
+	 */
+	if (!uuid) {
+		DRM_ERROR("No context was opened");
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* If xclbin id looks good, unlock bitstream should not fail. */
+	if (!uuid_equal(uuid, id)) {
+		DRM_ERROR("Try to delete CTX on wrong xclbin");
+		ret = -EBUSY;
+		goto out;
+	}
+
+	zocl_ctx_to_info(args, &info);
+	ret = kds_del_context(client, &info);
+	if (ret)
+		goto out;
+
+	if (!client->num_ctx) {
+		vfree(client->xclbin_id);
+		client->xclbin_id = NULL;
+		(void) zocl_unlock_bitstream(zdev, id);
+	}
+
+out:
+	vfree(id);
+	mutex_unlock(&client->lock);
+	return ret;
+}
+
+int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
+		       struct drm_file *filp)
+{
+	struct drm_zocl_ctx *args = data;
+	struct kds_client *client = filp->driver_priv;
+	int ret = 0;
+
+	switch (args->op) {
+	case ZOCL_CTX_OP_ALLOC_CTX:
+		ret = zocl_add_context(zdev, client, args);
+		break;
+	case ZOCL_CTX_OP_FREE_CTX:
+		ret = zocl_del_context(zdev, client, args);
+		break;
+	default:
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
 int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp)
 {
@@ -35,6 +175,11 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 	struct ert_packet *ecmd;
 	struct kds_command *xcmd;
 	int ret = 0;
+
+	if (!client->xclbin_id) {
+		DRM_ERROR("The client has no opening context\n");
+		return -EINVAL;
+	}
 
 	gem_obj = zocl_gem_object_lookup(dev, filp, args->exec_bo_handle);
 	if (!gem_obj) {
@@ -55,7 +200,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 	 */
 	xcmd = kds_alloc_command(client, ecmd->count * sizeof(u32));
 	if (!xcmd) {
-		DRM_INFO("Failed to alloc xcmd\n");
+		DRM_ERROR("Failed to alloc xcmd\n");
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -97,6 +242,7 @@ uint zocl_poll_client(struct file *filp, poll_table *wait)
 int zocl_create_client(struct drm_zocl_dev *zdev, void **priv)
 {
 	struct kds_client *client;
+	struct kds_sched  *kds;
 	struct drm_device *ddev;
 	int ret = 0;
 
@@ -106,15 +252,13 @@ int zocl_create_client(struct drm_zocl_dev *zdev, void **priv)
 
 	ddev = zdev->ddev;
 
-	client->dev  = ddev->dev;
-	client->pid  = get_pid(task_pid(current));
-	client->ctrl = zdev->kds.ctrl;
-	ret = kds_init_client(client);
+	kds = &zdev->kds;
+	client->dev = ddev->dev;
+	ret = kds_init_client(kds, client);
 	if (ret) {
 		kfree(client);
 		goto out;
 	}
-	list_add_tail(&client->link, &zdev->ctx_list);
 	*priv = client;
 
 out:
@@ -127,13 +271,16 @@ out:
 void zocl_destroy_client(struct drm_zocl_dev *zdev, void **priv)
 {
 	struct kds_client *client = *priv;
+	struct kds_sched  *kds;
 	struct drm_device *ddev;
 	int pid = pid_nr(client->pid);
 
 	ddev = zdev->ddev;
 
-	list_del(&client->link);
-	kds_fini_client(client);
+	kds = &zdev->kds;
+	kds_fini_client(kds, client);
+	if (client->xclbin_id)
+		vfree(client->xclbin_id);
 	kfree(client);
 	zocl_info(ddev->dev, "client exits pid(%d)\n", pid);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
@@ -18,13 +18,59 @@
 #define XCUC_DBG(xcuc, fmt, arg...) \
 	xocl_dbg(&xcuc->pdev->dev, fmt "\n", ##arg)
 
+#define CU_EXCLU_MASK		0x80000000
+
 struct xocl_cu_ctrl {
-	struct kds_controller    core;
+	struct kds_ctrl		 core;
 	struct platform_device	*pdev;
 	struct xrt_cu		*xcus[MAX_CUS];
+	struct mutex		 lock;
+	u32			 cu_refs[MAX_CUS];
 	int			 num_cus;
-
+	int			 num_clients;
+	int			 configured;
 };
+
+struct client_cu_priv {
+	DECLARE_BITMAP		(cu_bitmap, MAX_CUS);
+};
+
+/* sysfs nods */
+static ssize_t
+cu_ctx_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu_ctrl *xcuc = platform_get_drvdata(pdev);
+	ssize_t sz = 0;
+	bool shared;
+	int ref;
+	u32 i = 0;
+
+	mutex_lock(&xcuc->lock);
+	for (i = 0; i < xcuc->num_cus; ++i) {
+		shared = !(xcuc->cu_refs[i] & CU_EXCLU_MASK);
+		ref = xcuc->cu_refs[i] & ~CU_EXCLU_MASK;
+		sz += sprintf(buf+sz, "CU[%d] shared(%d) refcount(%d)\n",
+			      i, shared, ref);
+	}
+	mutex_unlock(&xcuc->lock);
+
+	if (sz)
+		buf[sz++] = 0;
+
+	return sz;
+}
+static DEVICE_ATTR_RO(cu_ctx);
+
+static struct attribute *cu_ctrl_attrs[] = {
+	&dev_attr_cu_ctx.attr,
+	NULL,
+};
+
+static struct attribute_group cu_ctrl_attr_group = {
+	.attrs = cu_ctrl_attrs,
+};
+/* sysfs nods end */
 
 static int get_cu_by_addr(struct xocl_cu_ctrl *xcuc, u32 addr)
 {
@@ -86,15 +132,24 @@ error:
 static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
 {
 	xdev_handle_t xdev = xocl_get_xdev(xcuc->pdev);
+	struct kds_client *client = xcmd->client;
+	struct client_cu_priv *cu_priv;
 	int cu_idx;
 	int inst_idx;
 
 	/* Select CU */
 	cu_idx = cu_mask_to_cu_idx(xcmd);
 
-	/* about 850K IOPS, if only do below two lines
-	 * The purpose is to show how fast a single user thread
-	 * could produce a CU task.
+	/* Check if selected CU is in the context */
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (!test_bit(cu_idx, cu_priv->cu_bitmap)) {
+		xcmd->cb.notify_host(xcmd, KDS_ERROR);
+		xcmd->cb.free(xcmd);
+		return;
+	}
+
+	/* This is call echo type 1.
+	 * The echo type 2 could be enabled by module param 'kds_echo=1'
 	 */
 	//xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
 	//xcmd->cb.free(xcmd);
@@ -104,7 +159,7 @@ static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd
 	(void) xocl_cu_submit_xcmd(xdev, inst_idx, xcmd);
 }
 
-static void cu_ctrl_submit(struct kds_controller *ctrl, struct kds_command *xcmd)
+static void cu_ctrl_submit(struct kds_ctrl *ctrl, struct kds_command *xcmd)
 {
 	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
 
@@ -113,6 +168,137 @@ static void cu_ctrl_submit(struct kds_controller *ctrl, struct kds_command *xcmd
 		cu_ctrl_dispatch(xcuc, xcmd);
 	else
 		cu_ctrl_config(xcuc, xcmd);
+}
+
+static int
+cu_ctrl_add_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
+		struct kds_ctx_info *info)
+{
+	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
+	struct client_cu_priv *cu_priv;
+	int cu_idx = info->cu_idx;
+	bool shared;
+	int ret = 0;
+
+	if (cu_idx >= xcuc->num_cus) {
+		XCUC_ERR(xcuc, "CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
+
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (test_and_set_bit(cu_idx, cu_priv->cu_bitmap)) {
+		XCUC_ERR(xcuc, "CU(%d) has been added", cu_idx);
+		return -EINVAL;
+	}
+
+	info->flags &= ~CU_CTX_OP_MASK;
+	shared = (info->flags != CU_CTX_EXCLUSIVE);
+
+	mutex_lock(&xcuc->lock);
+
+	if (xcuc->cu_refs[cu_idx] & CU_EXCLU_MASK) {
+		XCUC_ERR(xcuc, "CU(%d) has been exclusively reserved", cu_idx);
+		ret = -EBUSY;
+		goto err;
+	}
+
+	if (!shared && xcuc->cu_refs[cu_idx]) {
+		XCUC_ERR(xcuc, "CU(%d) has been shared", cu_idx);
+		ret = -EBUSY;
+		goto err;
+	}
+
+	if (!shared)
+		xcuc->cu_refs[cu_idx] |= CU_EXCLU_MASK;
+	else
+		++xcuc->cu_refs[cu_idx];
+
+	mutex_unlock(&xcuc->lock);
+
+	return 0;
+err:
+	clear_bit(cu_idx, cu_priv->cu_bitmap);
+	return ret;
+}
+
+static int
+cu_ctrl_del_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
+		struct kds_ctx_info *info)
+{
+	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
+	struct client_cu_priv *cu_priv;
+	int cu_idx = info->cu_idx;
+
+	if (cu_idx >= xcuc->num_cus) {
+		XCUC_ERR(xcuc, "CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
+
+	cu_priv = client->ctrl_priv[KDS_CU];
+	if (!test_and_clear_bit(cu_idx, cu_priv->cu_bitmap)) {
+		XCUC_ERR(xcuc, "CU(%d) has never been reserved", cu_idx);
+		return -EINVAL;
+	}
+
+	mutex_lock(&xcuc->lock);
+
+	if (xcuc->cu_refs[cu_idx] & CU_EXCLU_MASK)
+		xcuc->cu_refs[cu_idx] = 0;
+	else
+		--xcuc->cu_refs[cu_idx];
+
+	mutex_unlock(&xcuc->lock);
+
+	return 0;
+}
+
+static int
+cu_ctrl_control_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
+		    struct kds_ctx_info *info)
+{
+	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
+	struct client_cu_priv *cu_priv;
+	u32 op;
+
+	op = info->flags & CU_CTX_OP_MASK;
+	switch (op) {
+	case CU_CTX_OP_INIT:
+		cu_priv = kzalloc(sizeof(*cu_priv), GFP_KERNEL);
+		if (!cu_priv)
+			return -ENOMEM;
+		client->ctrl_priv[KDS_CU] = cu_priv;
+		mutex_lock(&xcuc->lock);
+		++xcuc->num_clients;
+		mutex_unlock(&xcuc->lock);
+		break;
+	case CU_CTX_OP_FINI:
+		kfree(client->ctrl_priv[KDS_CU]);
+		client->ctrl_priv[KDS_CU] = NULL;
+		mutex_lock(&xcuc->lock);
+		--xcuc->num_clients;
+		mutex_unlock(&xcuc->lock);
+		break;
+	case CU_CTX_OP_ADD:
+		return cu_ctrl_add_ctx(ctrl, client, info);
+	case CU_CTX_OP_DEL:
+		return cu_ctrl_del_ctx(ctrl, client, info);
+	}
+
+	/* TODO: Still has space to improve. Since not all of the clients would
+	 * need to use CU controller.
+	 *
+	 * But right now, the scope of a configuration is unclear.
+	 * Or maybe the configuration could be per client?
+	 * Or maybe config command would be removed?
+	 *
+	 * Anyway, for now, allow reconfigure when the last client exit.
+	 */
+	mutex_lock(&xcuc->lock);
+	if (!xcuc->num_clients)
+		xcuc->configured = 0;
+	mutex_unlock(&xcuc->lock);
+
+	return 0;
 }
 
 static int cu_ctrl_add_cu(struct platform_device *pdev, struct xrt_cu *xcu)
@@ -172,22 +358,29 @@ static int cu_ctrl_probe(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xocl_cu_ctrl *xcuc;
+	int ret = 0;
 
 	xcuc = xocl_drvinst_alloc(&pdev->dev, sizeof(struct xocl_cu_ctrl));
 	if (!xcuc)
 		return -ENOMEM;
 
+	mutex_init(&xcuc->lock);
 	xcuc->pdev = pdev;
 
 	/* TODO: handle irq resource when we support CU interrupt to host */
 
 	platform_set_drvdata(pdev, xcuc);
 
+	xcuc->core.control_ctx = cu_ctrl_control_ctx;
 	xcuc->core.submit = cu_ctrl_submit;
 
-	xocl_kds_setctrl(xdev, KDS_CU, (struct kds_controller *)xcuc);
+	xocl_kds_setctrl(xdev, KDS_CU, (struct kds_ctrl *)xcuc);
+	ret = sysfs_create_group(&pdev->dev.kobj, &cu_ctrl_attr_group);
+	if (ret) {
+		XCUC_ERR(xcuc, "create cu_ctrl attrs failed: 0x%x", ret);
+	}
 
-	return 0;
+	return ret;
 }
 
 static int cu_ctrl_remove(struct platform_device *pdev)
@@ -200,12 +393,16 @@ static int cu_ctrl_remove(struct platform_device *pdev)
 	if (!xcuc)
 		return -EINVAL;
 
+	mutex_destroy(&xcuc->lock);
+
 	xocl_drvinst_release(xcuc, &hdl);
 
 	platform_set_drvdata(pdev, NULL);
 	xocl_drvinst_free(hdl);
 
 	xocl_kds_setctrl(xdev, KDS_CU, NULL);
+
+	sysfs_remove_group(&pdev->dev.kobj, &cu_ctrl_attr_group);
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
@@ -64,7 +64,7 @@ static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd
 	//xcmd->cb.free(xcmd);
 	//return;
 
-	/* In here we needs to know the CU subdevice instance id,
+	/* In here we need to know the CU subdevice instance id,
 	 * which is determined at load xclbin.
 	 * It is different from the CU index defined by config command.
 	 */
@@ -97,12 +97,9 @@ static int cu_ctrl_add_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 	int ret;
 
 	ret = add_cu(TO_CU_CTRL(platform_get_drvdata(pdev)), xcu);
-	if (ret < 0)
+	if (ret < 0) {
+		XCUC_ERR(xcuc, "Could not find a slot for CU, ret %d", ret);
 		return ret;
-
-	if (ret == MAX_CUS) {
-		XCUC_ERR(xcuc, "Could not find a slot for CU %p", xcu);
-		return -ENOSPC;
 	}
 
 	return 0;
@@ -114,15 +111,12 @@ static int cu_ctrl_remove_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 	int ret;
 
 	ret = remove_cu(TO_CU_CTRL(platform_get_drvdata(pdev)), xcu);
-	if (ret < 0)
+	if (ret < 0) {
+		XCUC_ERR(xcuc, "Could not find CU, ret %d", ret);
 		return ret;
-
-	if (ret == MAX_CUS) {
-		XCUC_ERR(xcuc, "Could not find CU %p", xcu);
-		return -EINVAL;
 	}
 
-	return ret;
+	return 0;
 }
 
 static int cu_ctrl_remove(struct platform_device *pdev)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu_ctrl.c
@@ -8,7 +8,7 @@
  */
 
 #include "xocl_drv.h"
-#include "kds_core.h"
+#include "kds_cu_ctrl.h"
 #include "xrt_cu.h"
 
 #define XCUC_INFO(xcuc, fmt, arg...) \
@@ -18,21 +18,11 @@
 #define XCUC_DBG(xcuc, fmt, arg...) \
 	xocl_dbg(&xcuc->pdev->dev, fmt "\n", ##arg)
 
-#define CU_EXCLU_MASK		0x80000000
+#define TO_XOCL_CU_CTRL(c) ((struct xocl_cu_ctrl *)(c))
 
 struct xocl_cu_ctrl {
-	struct kds_ctrl		 core;
+	struct kds_cu_ctrl	 core;
 	struct platform_device	*pdev;
-	struct xrt_cu		*xcus[MAX_CUS];
-	struct mutex		 lock;
-	u32			 cu_refs[MAX_CUS];
-	int			 num_cus;
-	int			 num_clients;
-	int			 configured;
-};
-
-struct client_cu_priv {
-	DECLARE_BITMAP		(cu_bitmap, MAX_CUS);
 };
 
 /* sysfs nods */
@@ -41,24 +31,8 @@ cu_ctx_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct platform_device *pdev = to_platform_device(dev);
 	struct xocl_cu_ctrl *xcuc = platform_get_drvdata(pdev);
-	ssize_t sz = 0;
-	bool shared;
-	int ref;
-	u32 i = 0;
 
-	mutex_lock(&xcuc->lock);
-	for (i = 0; i < xcuc->num_cus; ++i) {
-		shared = !(xcuc->cu_refs[i] & CU_EXCLU_MASK);
-		ref = xcuc->cu_refs[i] & ~CU_EXCLU_MASK;
-		sz += sprintf(buf+sz, "CU[%d] shared(%d) refcount(%d)\n",
-			      i, shared, ref);
-	}
-	mutex_unlock(&xcuc->lock);
-
-	if (sz)
-		buf[sz++] = 0;
-
-	return sz;
+	return show_cu_ctx(TO_CU_CTRL(xcuc), buf);
 }
 static DEVICE_ATTR_RO(cu_ctx);
 
@@ -72,81 +46,16 @@ static struct attribute_group cu_ctrl_attr_group = {
 };
 /* sysfs nods end */
 
-static int get_cu_by_addr(struct xocl_cu_ctrl *xcuc, u32 addr)
+static void
+cu_ctrl_config(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
 {
-	int i;
-
-	/* Do not use this search in critical path */
-	for (i = 0; i < xcuc->num_cus; ++i) {
-		if (xcuc->xcus[i]->info.addr == addr)
-			break;
-	}
-
-	return i;
-}
-
-static inline int cu_mask_to_cu_idx(struct kds_command *xcmd)
-{
-	/* TODO: balance the CU usage if multiple bits are set */
-
-	/* assume there is alwasy one CU */
-	return 0;
-}
-
-static void cu_ctrl_config(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
-{
-	u32 *cus_addr = (u32 *)xcmd->info;
-	size_t num_cus = xcmd->isize / sizeof(u32);
-	struct xrt_cu *tmp;
-	int i, j;
-
-	/* I don't care if the configure command claim less number of cus */
-	if (num_cus > xcuc->num_cus)
-		goto error;
-
-	/* Now we need to make CU index right */
-	for (i = 0; i < num_cus; i++) {
-		j = get_cu_by_addr(xcuc, cus_addr[i]);
-		if (j == xcuc->num_cus)
-			goto error;
-
-		/* Ordering CU index */
-		if (j != i) {
-			tmp = xcuc->xcus[i];
-			xcuc->xcus[i] = xcuc->xcus[j];
-			xcuc->xcus[j] = tmp;
-		}
-		xcuc->xcus[i]->info.cu_idx = i;
-	}
-
-	/* TODO: Does it need a queue for configure commands? */
-	xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
-	xcmd->cb.free(xcmd);
-	return;
-
-error:
-	xcmd->cb.notify_host(xcmd, KDS_ERROR);
-	xcmd->cb.free(xcmd);
+	(void) config_ctrl(TO_CU_CTRL(xcuc), xcmd);
 }
 
 static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd)
 {
 	xdev_handle_t xdev = xocl_get_xdev(xcuc->pdev);
-	struct kds_client *client = xcmd->client;
-	struct client_cu_priv *cu_priv;
-	int cu_idx;
 	int inst_idx;
-
-	/* Select CU */
-	cu_idx = cu_mask_to_cu_idx(xcmd);
-
-	/* Check if selected CU is in the context */
-	cu_priv = client->ctrl_priv[KDS_CU];
-	if (!test_bit(cu_idx, cu_priv->cu_bitmap)) {
-		xcmd->cb.notify_host(xcmd, KDS_ERROR);
-		xcmd->cb.free(xcmd);
-		return;
-	}
 
 	/* This is call echo type 1.
 	 * The echo type 2 could be enabled by module param 'kds_echo=1'
@@ -155,8 +64,13 @@ static void cu_ctrl_dispatch(struct xocl_cu_ctrl *xcuc, struct kds_command *xcmd
 	//xcmd->cb.free(xcmd);
 	//return;
 
-	inst_idx = xcuc->xcus[cu_idx]->info.inst_idx;
-	(void) xocl_cu_submit_xcmd(xdev, inst_idx, xcmd);
+	/* In here we needs to know the CU subdevice instance id,
+	 * which is determined at load xclbin.
+	 * It is different from the CU index defined by config command.
+	 */
+	inst_idx = acquire_cu_inst_idx(TO_CU_CTRL(xcuc), xcmd);
+	if (inst_idx >= 0)
+		(void) xocl_cu_submit_xcmd(xdev, inst_idx, xcmd);
 }
 
 static void cu_ctrl_submit(struct kds_ctrl *ctrl, struct kds_command *xcmd)
@@ -171,154 +85,22 @@ static void cu_ctrl_submit(struct kds_ctrl *ctrl, struct kds_command *xcmd)
 }
 
 static int
-cu_ctrl_add_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
-		struct kds_ctx_info *info)
-{
-	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
-	struct client_cu_priv *cu_priv;
-	int cu_idx = info->cu_idx;
-	bool shared;
-	int ret = 0;
-
-	if (cu_idx >= xcuc->num_cus) {
-		XCUC_ERR(xcuc, "CU(%d) not found", cu_idx);
-		return -EINVAL;
-	}
-
-	cu_priv = client->ctrl_priv[KDS_CU];
-	if (test_and_set_bit(cu_idx, cu_priv->cu_bitmap)) {
-		XCUC_ERR(xcuc, "CU(%d) has been added", cu_idx);
-		return -EINVAL;
-	}
-
-	info->flags &= ~CU_CTX_OP_MASK;
-	shared = (info->flags != CU_CTX_EXCLUSIVE);
-
-	mutex_lock(&xcuc->lock);
-
-	if (xcuc->cu_refs[cu_idx] & CU_EXCLU_MASK) {
-		XCUC_ERR(xcuc, "CU(%d) has been exclusively reserved", cu_idx);
-		ret = -EBUSY;
-		goto err;
-	}
-
-	if (!shared && xcuc->cu_refs[cu_idx]) {
-		XCUC_ERR(xcuc, "CU(%d) has been shared", cu_idx);
-		ret = -EBUSY;
-		goto err;
-	}
-
-	if (!shared)
-		xcuc->cu_refs[cu_idx] |= CU_EXCLU_MASK;
-	else
-		++xcuc->cu_refs[cu_idx];
-
-	mutex_unlock(&xcuc->lock);
-
-	return 0;
-err:
-	clear_bit(cu_idx, cu_priv->cu_bitmap);
-	return ret;
-}
-
-static int
-cu_ctrl_del_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
-		struct kds_ctx_info *info)
-{
-	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
-	struct client_cu_priv *cu_priv;
-	int cu_idx = info->cu_idx;
-
-	if (cu_idx >= xcuc->num_cus) {
-		XCUC_ERR(xcuc, "CU(%d) not found", cu_idx);
-		return -EINVAL;
-	}
-
-	cu_priv = client->ctrl_priv[KDS_CU];
-	if (!test_and_clear_bit(cu_idx, cu_priv->cu_bitmap)) {
-		XCUC_ERR(xcuc, "CU(%d) has never been reserved", cu_idx);
-		return -EINVAL;
-	}
-
-	mutex_lock(&xcuc->lock);
-
-	if (xcuc->cu_refs[cu_idx] & CU_EXCLU_MASK)
-		xcuc->cu_refs[cu_idx] = 0;
-	else
-		--xcuc->cu_refs[cu_idx];
-
-	mutex_unlock(&xcuc->lock);
-
-	return 0;
-}
-
-static int
 cu_ctrl_control_ctx(struct kds_ctrl *ctrl, struct kds_client *client,
 		    struct kds_ctx_info *info)
 {
-	struct xocl_cu_ctrl *xcuc = (struct xocl_cu_ctrl *)ctrl;
-	struct client_cu_priv *cu_priv;
-	u32 op;
-
-	op = info->flags & CU_CTX_OP_MASK;
-	switch (op) {
-	case CU_CTX_OP_INIT:
-		cu_priv = kzalloc(sizeof(*cu_priv), GFP_KERNEL);
-		if (!cu_priv)
-			return -ENOMEM;
-		client->ctrl_priv[KDS_CU] = cu_priv;
-		mutex_lock(&xcuc->lock);
-		++xcuc->num_clients;
-		mutex_unlock(&xcuc->lock);
-		break;
-	case CU_CTX_OP_FINI:
-		kfree(client->ctrl_priv[KDS_CU]);
-		client->ctrl_priv[KDS_CU] = NULL;
-		mutex_lock(&xcuc->lock);
-		--xcuc->num_clients;
-		mutex_unlock(&xcuc->lock);
-		break;
-	case CU_CTX_OP_ADD:
-		return cu_ctrl_add_ctx(ctrl, client, info);
-	case CU_CTX_OP_DEL:
-		return cu_ctrl_del_ctx(ctrl, client, info);
-	}
-
-	/* TODO: Still has space to improve. Since not all of the clients would
-	 * need to use CU controller.
-	 *
-	 * But right now, the scope of a configuration is unclear.
-	 * Or maybe the configuration could be per client?
-	 * Or maybe config command would be removed?
-	 *
-	 * Anyway, for now, allow reconfigure when the last client exit.
-	 */
-	mutex_lock(&xcuc->lock);
-	if (!xcuc->num_clients)
-		xcuc->configured = 0;
-	mutex_unlock(&xcuc->lock);
-
-	return 0;
+	return control_ctx(TO_CU_CTRL(ctrl), client, info);
 }
 
 static int cu_ctrl_add_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 {
-	struct xocl_cu_ctrl *xcuc = platform_get_drvdata(pdev);
-	int i;
+	struct xocl_cu_ctrl *xcuc = TO_XOCL_CU_CTRL(platform_get_drvdata(pdev));
+	int ret;
 
-	if (xcuc->num_cus >= MAX_CUS)
-		return -ENOMEM;
+	ret = add_cu(TO_CU_CTRL(platform_get_drvdata(pdev)), xcu);
+	if (ret < 0)
+		return ret;
 
-	for (i = 0; i < MAX_CUS; i++) {
-		if (xcuc->xcus[i] != NULL)
-			continue;
-
-		xcuc->xcus[i] = xcu;
-		++xcuc->num_cus;
-		break;
-	}
-
-	if (i == MAX_CUS) {
+	if (ret == MAX_CUS) {
 		XCUC_ERR(xcuc, "Could not find a slot for CU %p", xcu);
 		return -ENOSPC;
 	}
@@ -328,56 +110,16 @@ static int cu_ctrl_add_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 
 static int cu_ctrl_remove_cu(struct platform_device *pdev, struct xrt_cu *xcu)
 {
-	struct xocl_cu_ctrl *xcuc = platform_get_drvdata(pdev);
-	int i, ret = 0;
+	struct xocl_cu_ctrl *xcuc = TO_XOCL_CU_CTRL(platform_get_drvdata(pdev));
+	int ret;
 
-	if (xcuc->num_cus == 0)
-		return -EINVAL;
+	ret = remove_cu(TO_CU_CTRL(platform_get_drvdata(pdev)), xcu);
+	if (ret < 0)
+		return ret;
 
-	/* The xcus list is not the same as when a CU was added
-	 * search the CU..
-	 */
-	for (i = 0; i < MAX_CUS; i++) {
-		if (xcuc->xcus[i] != xcu)
-			continue;
-
-		xcuc->xcus[i] = NULL;
-		--xcuc->num_cus;
-		break;
-	}
-
-	if (i == MAX_CUS) {
+	if (ret == MAX_CUS) {
 		XCUC_ERR(xcuc, "Could not find CU %p", xcu);
 		return -EINVAL;
-	}
-
-	return ret;
-}
-
-static int cu_ctrl_probe(struct platform_device *pdev)
-{
-	xdev_handle_t xdev = xocl_get_xdev(pdev);
-	struct xocl_cu_ctrl *xcuc;
-	int ret = 0;
-
-	xcuc = xocl_drvinst_alloc(&pdev->dev, sizeof(struct xocl_cu_ctrl));
-	if (!xcuc)
-		return -ENOMEM;
-
-	mutex_init(&xcuc->lock);
-	xcuc->pdev = pdev;
-
-	/* TODO: handle irq resource when we support CU interrupt to host */
-
-	platform_set_drvdata(pdev, xcuc);
-
-	xcuc->core.control_ctx = cu_ctrl_control_ctx;
-	xcuc->core.submit = cu_ctrl_submit;
-
-	xocl_kds_setctrl(xdev, KDS_CU, (struct kds_ctrl *)xcuc);
-	ret = sysfs_create_group(&pdev->dev.kobj, &cu_ctrl_attr_group);
-	if (ret) {
-		XCUC_ERR(xcuc, "create cu_ctrl attrs failed: 0x%x", ret);
 	}
 
 	return ret;
@@ -390,21 +132,56 @@ static int cu_ctrl_remove(struct platform_device *pdev)
 	void *hdl;
 
 	xcuc = platform_get_drvdata(pdev);
-	if (!xcuc)
-		return -EINVAL;
+	BUG_ON(xcuc == NULL);
 
-	mutex_destroy(&xcuc->lock);
-
+	mutex_destroy(&xcuc->core.lock);
 	xocl_drvinst_release(xcuc, &hdl);
-
-	platform_set_drvdata(pdev, NULL);
-	xocl_drvinst_free(hdl);
 
 	xocl_kds_setctrl(xdev, KDS_CU, NULL);
 
 	sysfs_remove_group(&pdev->dev.kobj, &cu_ctrl_attr_group);
 
+	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(hdl);
+
 	return 0;
+}
+
+static int cu_ctrl_probe(struct platform_device *pdev)
+{
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	struct xocl_cu_ctrl *xcuc;
+	struct kds_ctrl *core;
+	int ret = 0;
+
+	xcuc = xocl_drvinst_alloc(&pdev->dev, sizeof(struct xocl_cu_ctrl));
+	if (!xcuc)
+		return -ENOMEM;
+
+	mutex_init(&xcuc->core.lock);
+	xcuc->pdev = pdev;
+
+	/* TODO: handle irq resource when we support CU interrupt to host */
+
+	platform_set_drvdata(pdev, xcuc);
+
+	core = TO_KDS_CTRL(&xcuc->core);
+	core->control_ctx = cu_ctrl_control_ctx;
+	core->submit = cu_ctrl_submit;
+
+	xocl_kds_setctrl(xdev, KDS_CU, core);
+
+	ret = sysfs_create_group(&pdev->dev.kobj, &cu_ctrl_attr_group);
+	if (ret) {
+		XCUC_ERR(xcuc, "create cu_ctrl attrs failed: 0x%x", ret);
+		goto err;
+	}
+
+	return 0;
+
+err:
+	cu_ctrl_remove(pdev);
+	return ret;
 }
 
 static struct xocl_kds_ctrl_funcs cu_ctrl_ops = {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -30,6 +30,12 @@
 #include "../xocl_drm.h"
 #include "mgmt-ioctl.h"
 
+#if PF == MGMTPF
+int kds_mode = 0;
+#else
+extern int kds_mode;
+#endif
+
 #if defined(XOCL_UUID)
 static xuid_t uuid_null = NULL_UUID_LE;
 #endif
@@ -2537,11 +2543,13 @@ static int __icap_download_bitstream_axlf(struct platform_device *pdev,
 		if (!XOCL_DSA_IS_VERSAL(xdev))
 			err = __icap_peer_xclbin_download(icap, xclbin);
 
+		/* TODO: Remove this after new KDS replace the legacy one */
 		/*
 		 * xclbin download changes PR region, make sure next
 		 * ERT configure cmd will go through
 		 */
-		(void) xocl_exec_reconfig(xdev);
+		if (!kds_mode)
+			(void) xocl_exec_reconfig(xdev);
 		if (err)
 			goto done;
 
@@ -2733,7 +2741,8 @@ static int icap_lock_bitstream(struct platform_device *pdev, const xuid_t *id)
 	ICAP_INFO(icap, "bitstream %pUb locked, ref=%d", id,
 		icap->icap_bitstream_ref);
 
-	if (ref == 0) {
+	/* TODO: Remove this after new KDS replace the legacy one */
+	if (!kds_mode && ref == 0) {
 		/* reset on first reference */
 		xocl_exec_reset(xocl_get_xdev(pdev), id);
 	}
@@ -2779,7 +2788,8 @@ static int icap_unlock_bitstream(struct platform_device *pdev, const xuid_t *id)
 		goto done;
 	}
 
-	if (icap->icap_bitstream_ref == 0 && !ICAP_PRIVILEGED(icap))
+	/* TODO: Remove this after new KDS replace the legacy one */
+	if (!kds_mode && icap->icap_bitstream_ref == 0 && !ICAP_PRIVILEGED(icap))
 		(void) xocl_exec_stop(xocl_get_xdev(pdev));
 
 done:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -41,6 +41,7 @@ endif
 endif
 
 drv_common-y   := $(common_dir)/kds_core.o \
+		  $(common_dir)/kds_cu_ctrl.o \
 		  $(common_dir)/xrt_cu.o \
 		  $(common_dir)/cu_hls.o \
 		  $(common_dir)/cu_plram.o

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -259,14 +259,14 @@ static inline u64 xocl_pci_rebar_size_to_bytes(int size)
 /* KDS functions */
 int xocl_create_client(struct xocl_dev *xdev, void **priv);
 void xocl_destroy_client(struct xocl_dev *xdev, void **priv);
-int xocl_poll_client(struct xocl_dev *xdev, struct file *filp,
-		     poll_table *wait, void *priv);
 int xocl_client_ioctl(struct xocl_dev *xdev, int op, void *data,
 		      struct drm_file *filp);
+int xocl_poll_client(struct file *filp, poll_table *wait, void *priv);
 int xocl_kds_stop(struct xocl_dev *xdev);
 int xocl_kds_reset(struct xocl_dev *xdev, const xuid_t *xclbin_id);
 int xocl_kds_reconfig(struct xocl_dev *xdev);
 int xocl_cu_map_addr(struct xocl_dev *xdev, u32 cu_idx,
 		     void *drm_filp, u32 *addrp);
+u32 xocl_kds_live_clients(struct xocl_dev *xdev, pid_t **plist);
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -312,7 +312,7 @@ static uint xocl_poll(struct file *filp, poll_table *wait)
 
 	DRM_ENTER("");
 	if (kds_mode == 1)
-		return xocl_poll_client(drm_p->xdev, filp, wait, priv->driver_priv);
+		return xocl_poll_client(filp, wait, priv->driver_priv);
 	else
 		return xocl_exec_poll_client(drm_p->xdev, filp, wait, priv->driver_priv);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1321,6 +1321,8 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 
 	unmap_bar(xdev);
 
+	kds_fini_sched(&XDEV(xdev)->kds);
+
 	xocl_subdev_fini(xdev);
 	if (xdev->ulp_blob)
 		vfree(xdev->ulp_blob);
@@ -1375,6 +1377,8 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 		xocl_err(&pdev->dev, "failed to failed to init subdev");
 		goto failed;
 	}
+
+	(void) kds_init_sched(&XDEV(xdev)->kds);
 
 	ret = xocl_config_pci(xdev);
 	if (ret)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -332,9 +332,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	/*
 	 * Coupling scheduler(context, exec BOs) at this place is a bad idea.
 	 *
-	 * Ideally, after successfully loaded xclbin, it should be locked.
-	 * But since there is no API to undo load xclbin. So we are not able to
-	 * lock xclbin here.
+	 * The load xclbin and lock xclbin operation are separated.
 	 * The xclbin was locked until a context was opened and unlocked until
 	 * all of the contexts were closed.
 	 * If some processes are downloading the same xclbin. Only the first

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -201,54 +201,29 @@ static uint live_clients(struct xocl_dev *xdev, pid_t **plist)
 	uint count = 0;
 	uint i = 0;
 	pid_t *pl = NULL;
+	const struct client_ctx *entry;
 
 	BUG_ON(!mutex_is_locked(&xdev->dev_lock));
 
-	if (kds_mode) {
-		const struct kds_client *entry;
-		/* Find out number of active client */
-		list_for_each(ptr, &xdev->ctx_list) {
-			entry = list_entry(ptr, struct kds_client, link);
-			if (CLIENT_NUM_CU(entry) > 0)
-				count++;
-		}
-		if (count == 0 || plist == NULL)
-			goto out;
+	/* Find out number of active client */
+	list_for_each(ptr, &xdev->ctx_list) {
+		entry = list_entry(ptr, struct client_ctx, link);
+		if (CLIENT_NUM_CU_CTX(entry) > 0)
+			count++;
+	}
+	if (count == 0 || plist == NULL)
+		goto out;
 
-		/* Collect list of PIDs of active client */
-		pl = (pid_t *)vmalloc(sizeof(pid_t) * count);
-		if (pl == NULL)
-			goto out;
+	/* Collect list of PIDs of active client */
+	pl = (pid_t *)vmalloc(sizeof(pid_t) * count);
+	if (pl == NULL)
+		goto out;
 
-		list_for_each(ptr, &xdev->ctx_list) {
-			entry = list_entry(ptr, struct kds_client, link);
-			if (CLIENT_NUM_CU(entry) > 0) {
-				pl[i] = pid_nr(entry->pid);
-				i++;
-			}
-		}
-	} else {
-		const struct client_ctx *entry;
-		/* Find out number of active client */
-		list_for_each(ptr, &xdev->ctx_list) {
-			entry = list_entry(ptr, struct client_ctx, link);
-			if (CLIENT_NUM_CU_CTX(entry) > 0)
-				count++;
-		}
-		if (count == 0 || plist == NULL)
-			goto out;
-
-		/* Collect list of PIDs of active client */
-		pl = (pid_t *)vmalloc(sizeof(pid_t) * count);
-		if (pl == NULL)
-			goto out;
-
-		list_for_each(ptr, &xdev->ctx_list) {
-			entry = list_entry(ptr, struct client_ctx, link);
-			if (CLIENT_NUM_CU_CTX(entry) > 0) {
-				pl[i] = pid_nr(entry->pid);
-				i++;
-			}
+	list_for_each(ptr, &xdev->ctx_list) {
+		entry = list_entry(ptr, struct client_ctx, link);
+		if (CLIENT_NUM_CU_CTX(entry) > 0) {
+			pl[i] = pid_nr(entry->pid);
+			i++;
 		}
 	}
 
@@ -258,13 +233,18 @@ out:
 	return count;
 }
 
+/* TODO: Move to xocl_kds.c, when start to create sysfs nodes for new kds. */
 u32 get_live_clients(struct xocl_dev *xdev, pid_t **plist)
 {
 	u32 c;
 
-	mutex_lock(&xdev->dev_lock);
-	c = live_clients(xdev, plist);
-	mutex_unlock(&xdev->dev_lock);
+	if (kds_mode) {
+		c = xocl_kds_live_clients(xdev, plist);
+	} else {
+		mutex_lock(&xdev->dev_lock);
+		c = live_clients(xdev, plist);
+		mutex_unlock(&xdev->dev_lock);
+	}
 
 	return c;
 }
@@ -350,6 +330,39 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		goto done;
 
 	/*
+	 * Coupling scheduler(context, exec BOs) at this place is a bad idea.
+	 *
+	 * Ideally, after successfully loaded xclbin, it should be locked.
+	 * But since there is no API to undo load xclbin. So we are not able to
+	 * lock xclbin here.
+	 * The xclbin was locked until a context was opened and unlocked until
+	 * all of the contexts were closed.
+	 * If some processes are downloading the same xclbin. Only the first
+	 * one could reach below lines.
+	 * If some processes are downloading different xclbins. The second one
+	 * got dev_lock could go here.  Let's see if ICAP could protect the
+	 * sequence of download xclbin and open context on downloaded xclbin.
+	 *
+	 * If open context locked bitstream, xocl_icap_download_axlf() would
+	 * failed later on, since the bitstream is busy.
+	 * If xocl_icap_download_axlf() successed, open context on prev xclbin
+	 * would fail. This is the same as current implementation. This is the
+	 * cost that we have to pay if we are not able to lock xclbin after
+	 * loaded it.
+	 *
+	 * After all, ICAP subdevice does everything to protect xclbin. If
+	 * scheduler is ready to work on a new xclbin, like all of contexts are
+	 * closed, it should only notice ICAP not here.
+	 *
+	 * "Note that icap subdevice also maintains xclbin ref count, which is
+	 * used to lock down xclbin on mgmt pf side."
+	 * I found this statement is not correct anymore. The ref count is using
+	 * on user pf side.
+	 */
+	if (!kds_mode)
+		goto skip1;
+
+	/*
 	 * Support for multiple processes
 	 * 1. We lock &xdev->dev_lock so no new contexts can be opened and no
 	 *    live contexts can be closed
@@ -367,6 +380,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		goto done;
 	}
 
+skip1:
 	/* Really need to download, sanity check xclbin, first. */
 	if (xocl_xrt_version_check(xdev, &bin_obj, true)) {
 		userpf_err(xdev, "Xclbin isn't supported by current XRT\n");
@@ -452,6 +466,8 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 
 	err = xocl_icap_download_axlf(xdev, axlf);
 	if (err) {
+		/* TODO: remove this. Coupling scheduler is a bad idea.
+		 */
 		/*
 		 * We have to clear uuid cached in scheduler here if
 		 * download xclbin failed

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -20,11 +20,119 @@ module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_echo,
 		 "enable KDS echo (0 = disable (default), 1 = enable)");
 
+static inline void
+xocl_ctx_to_info(struct drm_xocl_ctx *args, struct kds_ctx_info *info)
+{
+	if (args->cu_index == XOCL_CTX_VIRT_CU_INDEX)
+		info->cu_idx = CU_CTX_VIRT_CU;
+	else
+		info->cu_idx = args->cu_index;
+
+	if (args->flags == XOCL_CTX_EXCLUSIVE)
+		info->flags = CU_CTX_EXCLUSIVE;
+	else
+		info->flags = CU_CTX_SHARED;
+}
+
+static int xocl_add_context(struct xocl_dev *xdev, struct kds_client *client,
+			    struct drm_xocl_ctx *args)
+{
+	struct kds_ctx_info info;
+	xuid_t *uuid;
+	int ret;
+
+	mutex_lock(&client->lock);
+	/* If this client has no opened context, lock bitstream */
+	if (!client->num_ctx) {
+		ret = xocl_icap_lock_bitstream(xdev, &args->xclbin_id);
+		if (ret)
+			goto out;
+		uuid = vzalloc(sizeof(*uuid));
+		if (!uuid) {
+			ret = -ENOMEM;
+			goto out;
+		}
+		uuid_copy(uuid, &args->xclbin_id);
+		client->xclbin_id = uuid;
+	}
+
+	/* Bitstream is locked. No one could load a new one
+	 * until this client close all of the contexts.
+	 */
+	xocl_ctx_to_info(args, &info);
+	ret = kds_add_context(client, &info);
+
+out:
+	if (!client->num_ctx) {
+		vfree(client->xclbin_id);
+		client->xclbin_id = NULL;
+		(void) xocl_icap_unlock_bitstream(xdev, &args->xclbin_id);
+	}
+	mutex_unlock(&client->lock);
+	return ret;
+}
+
+static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
+			    struct drm_xocl_ctx *args)
+{
+	struct kds_ctx_info info;
+	xuid_t *uuid;
+	int ret = 0;
+
+	mutex_lock(&client->lock);
+
+	uuid = client->xclbin_id;
+	/* xclCloseContext() would send xclbin_id and cu_idx.
+	 * Be more cautious while delete. Do sanity check */
+	if (!uuid) {
+		userpf_err(xdev, "No context was opened");
+		ret = -EINVAL;
+		goto out;
+	}
+
+	/* If xclbin id looks good, unlock bitstream should not fail. */
+	if (!uuid_equal(uuid, &args->xclbin_id)) {
+		userpf_err(xdev, "Try to delete CTX on wrong xclbin");
+		ret = -EBUSY;
+		goto out;
+	}
+
+	xocl_ctx_to_info(args, &info);
+	ret = kds_del_context(client, &info);
+	if (ret)
+		goto out;
+
+	/* unlock bitstream if there is no opening context */
+	if (!client->num_ctx) {
+		vfree(client->xclbin_id);
+		client->xclbin_id = NULL;
+		(void) xocl_icap_unlock_bitstream(xdev, &args->xclbin_id);
+	}
+
+out:
+	mutex_unlock(&client->lock);
+	return ret;
+}
+
 static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,
 			      struct drm_file *filp)
 {
-	/* TODO: implement this */
-	return 0;
+	struct drm_xocl_ctx *args = data;
+	struct kds_client *client = filp->driver_priv;
+	int ret = 0;
+
+	switch(args->op) {
+	case XOCL_CTX_OP_ALLOC_CTX:
+		ret = xocl_add_context(xdev, client, args);
+		break;
+	case XOCL_CTX_OP_FREE_CTX:
+		ret = xocl_del_context(xdev, client, args);
+		break;
+	default:
+		ret = -EINVAL;
+	}
+
+	return ret;
 }
 
 static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
@@ -38,6 +146,11 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	struct ert_packet *ecmd;
 	struct kds_command *xcmd;
 	int ret = 0;
+
+	if (!client->xclbin_id) {
+		DRM_ERROR("The client has no opening context\n");
+		return -EINVAL;
+	}
 
 	obj = xocl_gem_object_lookup(ddev, filp, args->exec_bo_handle);
 	if (!obj) {
@@ -87,23 +200,21 @@ out:
 int xocl_create_client(struct xocl_dev *xdev, void **priv)
 {
 	struct	kds_client	*client;
+	struct  kds_sched	*kds;
 	int	ret = 0;
 
 	client = kzalloc(sizeof(*client), GFP_KERNEL);
 	if (!client)
 		return -ENOMEM;
 
+	kds = &XDEV(xdev)->kds;
 	client->dev = XDEV2DEV(xdev);
-	client->pid = get_pid(task_pid(current));
-	client->ctrl = XDEV(xdev)->kds.ctrl;
-	ret = kds_init_client(client);
+	ret = kds_init_client(kds, client);
 	if (ret) {
 		kfree(client);
 		goto out;
 	}
-	mutex_lock(&xdev->dev_lock);
-	list_add_tail(&client->link, &xdev->ctx_list);
-	mutex_unlock(&xdev->dev_lock);
+
 	*priv = client;
 
 out:
@@ -115,16 +226,18 @@ out:
 void xocl_destroy_client(struct xocl_dev *xdev, void **priv)
 {
 	struct kds_client *client = *priv;
+	struct kds_sched  *kds;
 	int pid = pid_nr(client->pid);
 
-	list_del(&client->link);
-	kds_fini_client(client);
+	kds = &XDEV(xdev)->kds;
+	kds_fini_client(kds, client);
+	if (client->xclbin_id)
+		vfree(client->xclbin_id);
 	kfree(client);
 	userpf_info(xdev, "client exits pid(%d)\n", pid);
 }
 
-int xocl_poll_client(struct xocl_dev *xdev, struct file *filp,
-	    poll_table *wait, void *priv)
+int xocl_poll_client(struct file *filp, poll_table *wait, void *priv)
 {
 	struct kds_client *client = (struct kds_client *)priv;
 	int event;
@@ -185,3 +298,7 @@ int xocl_cu_map_addr(struct xocl_dev *xdev, u32 cu_idx,
 	return 0;
 }
 
+u32 xocl_kds_live_clients(struct xocl_dev *xdev, pid_t **plist)
+{
+	return kds_live_clients(&XDEV(xdev)->kds, plist);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -130,6 +130,7 @@ static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,
 		break;
 	default:
 		ret = -EINVAL;
+		break;
 	}
 
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -395,10 +395,6 @@ struct xocl_work {
 	int			op;
 };
 
-struct kds_sched {
-	struct kds_controller *ctrl[KDS_MAX_TYPE];
-};
-
 struct xocl_dev_core {
 	struct pci_dev		*pdev;
 	int			dev_minor;
@@ -1636,7 +1632,7 @@ static inline void xocl_dr_reg_write32(xdev_handle_t xdev, u32 value, void __iom
 	read_unlock(&XDEV(xdev)->rwlock);
 }
 
-static inline void xocl_kds_setctrl(xdev_handle_t xdev, int type, struct kds_controller *ctrl)
+static inline void xocl_kds_setctrl(xdev_handle_t xdev, int type, struct kds_ctrl *ctrl)
 {
 	XDEV(xdev)->kds.ctrl[type] = ctrl;
 }


### PR DESCRIPTION
1. Support xclOpenContext() and xclCloseContext at unify KDS.
- The first client open context would lock the bitstream. Others who try to change bitstream will fail.
- Other clients could open context with the same bitstream (bump up the ref count).
- Only when the ref count return to 0, the bitstream is unlocked.
2. Unify CU controller code for xocl and zocl. The logic is almost the same.

After this, zocl scheduler would fully support multi processes. (In before, exclusive reserved CU was not support).