### PR TITLE
new xbutil version and bug fixes

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -61,10 +61,10 @@ instance()
 void
 get_xrt_build_info(boost::property_tree::ptree& pt)
 {
-  pt.put("version", xrt_build_version);
-  pt.put("hash",    xrt_build_version_hash);
-  pt.put("date",    xrt_build_version_date);
-  pt.put("branch",  xrt_build_version_branch);
+  pt.put("version",    xrt_build_version);
+  pt.put("hash",       xrt_build_version_hash);
+  pt.put("build_date", xrt_build_version_date);
+  pt.put("branch",     xrt_build_version_branch);
 }
 
 void

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -62,9 +62,9 @@ void
 get_xrt_build_info(boost::property_tree::ptree& pt)
 {
   pt.put("version",    xrt_build_version);
+  pt.put("branch",     xrt_build_version_branch);
   pt.put("hash",       xrt_build_version_hash);
   pt.put("build_date", xrt_build_version_date);
-  pt.put("branch",     xrt_build_version_branch);
 }
 
 void

--- a/src/runtime_src/core/common/time.cpp
+++ b/src/runtime_src/core/common/time.cpp
@@ -26,17 +26,12 @@
 # pragma warning ( disable : 4996 )
 #endif
 namespace {
-
-// thread safe time conversion to localtime  
-static std::tm
-localtime(const std::time_t& time)
+  
+static std::tm*
+get_gmtime(const std::time_t& time)
 {
-  std::tm tm;
-#ifdef _WIN32
-  localtime_s(&tm, &time);
-#else
-  localtime_r(&time, &tm); // POSIX
-#endif
+  std::tm* tm;
+  tm = gmtime(&time); 
   return tm;
 }
 
@@ -64,11 +59,10 @@ std::string
 timestamp()
 {
   auto time = std::chrono::system_clock::now();
-  auto tm = localtime(std::chrono::system_clock::to_time_t(time));
+  auto tm = get_gmtime(std::chrono::system_clock::to_time_t(time));
   char buf[64] = {0};
-  return std::strftime(buf, sizeof(buf), "%c", &tm)
-    ? buf
-    : "Time conversion failed";
+  return std::strftime(buf, sizeof(buf), "%c GMT", tm)
+    ? buf : "Time conversion failed";
 }
 
 } // xrt_core

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -179,7 +179,7 @@ unit_convert(size_t size)
 }
 
 uint16_t
-bdf2index(const std::string& bdfstr)
+bdf2index(const std::string& bdfstr, bool _inUserDomain)
 {
   auto n = std::count(bdfstr.begin(), bdfstr.end(), ':');
 
@@ -194,15 +194,15 @@ bdf2index(const std::string& bdfstr)
   if ((n != 1 && n != 2) || s.fail())
     throw std::runtime_error("Bad BDF string '" + bdfstr + "'");
 
-  auto devices = xrt_core::get_total_devices(false).first;
+  uint64_t devices = _inUserDomain ? xrt_core::get_total_devices(true).first : xrt_core::get_total_devices(false).first;
   for (uint16_t i = 0; i < devices; i++) {
-    auto device = get_mgmtpf_device(i);
+    auto device = _inUserDomain ? get_userpf_device(i) : get_mgmtpf_device(i);
     auto bdf = device_query<query::pcie_bdf>(device);
     if (b == std::get<0>(bdf) && d == std::get<1>(bdf) && f == std::get<2>(bdf))
       return i;
   }
 
-  throw std::runtime_error("No mgmt PF found for '" + bdfstr + "'");
+  throw std::runtime_error("No user or mgmt PF found for '" + bdfstr + "'");
 }
 
 }} // utils, xrt_core

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -75,7 +75,7 @@ unit_convert(size_t size);
  */
 XRT_CORE_COMMON_EXPORT
 uint16_t
-bdf2index(const std::string& bdf);
+bdf2index(const std::string& bdf, bool _inUserDomain);
 
 }} // utils, xrt_core
 

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -123,7 +123,7 @@ get_os_info(boost::property_tree::ptree &pt)
               val.erase(0, 1);
               val.erase(val.size()-1);
           }
-          pt.put("linux", val);
+          pt.put("distribution", val);
       }
       ifs.close();
   }

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -128,7 +128,7 @@ get_os_info(boost::property_tree::ptree &pt)
       ifs.close();
   }
 
-  pt.put("now", xrt_core::timestamp());
+  pt.put("creation_ts", xrt_core::timestamp());
 }
 
 std::pair<device::id_type, device::id_type>

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -23,7 +23,6 @@
 #include "system_windows.h"
 #include "device_windows.h"
 #include "gen/version.h"
-#include "core/common/time.h"
 #include "mgmt.h"
 #include <map>
 #include <memory>
@@ -69,6 +68,26 @@ getmachinename()
   return machine;
 }
 
+static std::string 
+osNameImpl()
+{
+    OSVERSIONINFO vi;
+    vi.dwOSVersionInfoSize = sizeof(vi);
+    if (GetVersionEx(&vi) == 0) 
+      throw xrt_core::error("Cannot get OS version information");
+    switch (vi.dwPlatformId)
+    {
+    case VER_PLATFORM_WIN32s:
+        return "Windows 3.x";
+    case VER_PLATFORM_WIN32_WINDOWS:
+        return vi.dwMinorVersion == 0 ? "Windows 95" : "Windows 98";
+    case VER_PLATFORM_WIN32_NT:
+        return "Windows NT";
+    default:
+        return "Unknown";
+    }
+}
+
 }
 
 namespace xrt_core {
@@ -95,8 +114,7 @@ get_os_info(boost::property_tree::ptree &pt)
   char value[128];
   DWORD BufferSize = sizeof value;
 
-  RegGetValueA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
-  pt.put("sysname", value);
+  pt.put("sysname", osNameImpl());
   //Reassign buffer size since it get override with size of value by RegGetValueA() call
   BufferSize = sizeof value;
   RegGetValueA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "BuildLab", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
@@ -106,7 +124,8 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("version", value);
 
   pt.put("machine", getmachinename());
-  pt.put("creation_ts", xrt_core::timestamp());
+  RegGetValueA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
+  pt.put("distribution", value);
 }
 
 std::pair<device::id_type, device::id_type>

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -106,7 +106,7 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("version", value);
 
   pt.put("machine", getmachinename());
-  pt.put("now", xrt_core::timestamp());
+  pt.put("creation_ts", xrt_core::timestamp());
 }
 
 std::pair<device::id_type, device::id_type>

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -124,6 +124,8 @@ get_os_info(boost::property_tree::ptree &pt)
   pt.put("version", value);
 
   pt.put("machine", getmachinename());
+
+  BufferSize = sizeof value;
   RegGetValueA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", "ProductName", RRF_RT_ANY, NULL, (PVOID)&value, &BufferSize);
   pt.put("distribution", value);
 }

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -17,6 +17,7 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "Report.h"
+#include "core/common/time.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <sstream>

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -21,6 +21,7 @@
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
+#include <boost/algorithm/string.hpp>
 
 void
 ReportHost::getPropertyTreeInternal( const xrt_core::device * _pDevice, 
@@ -63,7 +64,14 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Glibc" % _pt.get<std::string>("host.os.glibc", "N/A");
+  boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries");
+  for(auto& kl : available_libraries) {
+    boost::property_tree::ptree& lib = kl.second;
+    std::string lib_name = lib.get<std::string>("name", "N/A");
+    boost::algorithm::to_upper(lib_name);
+    _output << boost::format("  %-20s : %s\n") % lib_name 
+        % lib.get<std::string>("version", "N/A");
+  }
   _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.linux", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Now" % _pt.get<std::string>("host.os.now", "N/A");
   _output << std::endl;
@@ -71,9 +79,15 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.date", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "XOCL" % _pt.get<std::string>("host.xrt.xocl", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "XCLMGMT" % _pt.get<std::string>("host.xrt.xclmgmt", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.build_date", "N/A");
+  boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers");
+  for(auto& drv : available_drivers) {
+    boost::property_tree::ptree& driver = drv.second;
+    std::string drv_name = driver.get<std::string>("name", "N/A");
+    boost::algorithm::to_upper(drv_name);
+    _output << boost::format("  %-20s : %s\n") % drv_name 
+        % driver.get<std::string>("version", "N/A");
+  }
   _output << std::endl;
 
 }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -17,6 +17,10 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "ReportHost.h"
+#include "core/common/system.h"
+
+// 3rd Party Library - Include Files
+#include <boost/format.hpp>
 
 void
 ReportHost::getPropertyTreeInternal( const xrt_core::device * _pDevice, 
@@ -32,7 +36,14 @@ ReportHost::getPropertyTree20201( const xrt_core::device * /*_pDevice*/,
                                   boost::property_tree::ptree &_pt) const
 {
   boost::property_tree::ptree pt;
-  pt.put("Description","Host Information");
+  boost::property_tree::ptree pt_os_info;
+  boost::property_tree::ptree pt_xrt_info;
+
+  xrt_core::get_os_info(pt_os_info);
+  pt.add_child("os", pt_os_info);
+
+  xrt_core::get_xrt_info(pt_xrt_info);
+  pt.add_child("xrt", pt_xrt_info);
 
   // There can only be 1 root node
   _pt.add_child("host", pt);
@@ -40,11 +51,31 @@ ReportHost::getPropertyTree20201( const xrt_core::device * /*_pDevice*/,
 
 
 void 
-ReportHost::writeReport(const xrt_core::device * /*_pDevice*/,
+ReportHost::writeReport(const xrt_core::device * _pDevice,
                         const std::vector<std::string> & /*_elementsFilter*/, 
                         std::iostream & _output) const
 {
-  _output << "ReportHost - Hello world\n";
+  boost::property_tree::ptree _pt;
+  getPropertyTreeInternal(_pDevice, _pt);
+
+  _output << "System Configuration\n";
+  _output << boost::format("  %-20s : %s\n") % "OS Name" % _pt.get<std::string>("host.os.sysname", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Glibc" % _pt.get<std::string>("host.os.glibc", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.linux", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Now" % _pt.get<std::string>("host.os.now", "N/A");
+  _output << std::endl;
+  _output << "XRT\n";
+  _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.date", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "XOCL" % _pt.get<std::string>("host.xrt.xocl", "N/A");
+  _output << boost::format("  %-20s : %s\n") % "XCLMGMT" % _pt.get<std::string>("host.xrt.xclmgmt", "N/A");
+  _output << std::endl;
+
 }
 
 

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -61,35 +61,43 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   getPropertyTreeInternal(_pDevice, _pt);
 
   _output << "System Configuration\n";
-  _output << boost::format("  %-20s : %s\n") % "OS Name" % _pt.get<std::string>("host.os.sysname", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine", "N/A");
-  boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries", empty_ptree);
-  for(auto& kl : available_libraries) {
-    boost::property_tree::ptree& lib = kl.second;
-    std::string lib_name = lib.get<std::string>("name", "N/A");
-    boost::algorithm::to_upper(lib_name);
-    _output << boost::format("  %-20s : %s\n") % lib_name 
-        % lib.get<std::string>("version", "N/A");
+  try {
+    _output << boost::format("  %-20s : %s\n") % "OS Name" % _pt.get<std::string>("host.os.sysname");
+    _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release");
+    _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version");
+    _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine");
+    boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries", empty_ptree);
+    for(auto& kl : available_libraries) {
+      boost::property_tree::ptree& lib = kl.second;
+      std::string lib_name = lib.get<std::string>("name", "N/A");
+      boost::algorithm::to_upper(lib_name);
+      _output << boost::format("  %-20s : %s\n") % lib_name 
+          % lib.get<std::string>("version", "N/A");
+    }
+    //distribution is only available on linux
+    if(_pt.get<std::string>("host.os.sysname").compare("Linux") == 0)
+      _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.distribution");
+    _output << boost::format("  %-20s : %s\n") % "Creation Timestamp" % _pt.get<std::string>("host.os.now");
+    _output << std::endl;
+    _output << "XRT\n";
+    _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
+    _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
+    _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
+    _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.build_date", "N/A");
+    boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers", empty_ptree);
+    for(auto& drv : available_drivers) {
+      boost::property_tree::ptree& driver = drv.second;
+      std::string drv_name = driver.get<std::string>("name", "N/A");
+      boost::algorithm::to_upper(drv_name);
+      _output << boost::format("  %-20s : %s\n") % drv_name 
+          % driver.get<std::string>("version", "N/A");
+    }
+    _output << std::endl;
   }
-  _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.linux", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Now" % _pt.get<std::string>("host.os.now", "N/A");
-  _output << std::endl;
-  _output << "XRT\n";
-  _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
-  _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.build_date", "N/A");
-  boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers", empty_ptree);
-  for(auto& drv : available_drivers) {
-    boost::property_tree::ptree& driver = drv.second;
-    std::string drv_name = driver.get<std::string>("name", "N/A");
-    boost::algorithm::to_upper(drv_name);
-    _output << boost::format("  %-20s : %s\n") % drv_name 
-        % driver.get<std::string>("version", "N/A");
+  catch (const boost::property_tree::ptree_error &ex) {
+    throw xrt_core::error(boost::str(boost::format("%s. Please contact your Xilinx representative to fix the issue")
+         % ex.what()));
   }
-  _output << std::endl;
 
 }
 

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -77,7 +77,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
     //distribution is only available on linux
     if(_pt.get<std::string>("host.os.sysname").compare("Linux") == 0)
       _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.distribution");
-    _output << boost::format("  %-20s : %s\n") % "Creation Timestamp" % _pt.get<std::string>("host.os.now");
+    _output << boost::format("  %-20s : %s\n") % "Creation Timestamp" % _pt.get<std::string>("host.os.creation_ts");
     _output << std::endl;
     _output << "XRT\n";
     _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -66,6 +66,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
     _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release");
     _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version");
     _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine");
+    _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.distribution");
     boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries", empty_ptree);
     for(auto& kl : available_libraries) {
       boost::property_tree::ptree& lib = kl.second;
@@ -74,10 +75,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
       _output << boost::format("  %-20s : %s\n") % lib_name 
           % lib.get<std::string>("version", "N/A");
     }
-    //distribution is only available on linux
-    if(_pt.get<std::string>("host.os.sysname").compare("Linux") == 0)
-      _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.distribution");
-    _output << boost::format("  %-20s : %s\n") % "Creation Timestamp" % _pt.get<std::string>("host.os.creation_ts");
+    
     _output << std::endl;
     _output << "XRT\n";
     _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.xrt.version", "N/A");
@@ -89,8 +87,8 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
       boost::property_tree::ptree& driver = drv.second;
       std::string drv_name = driver.get<std::string>("name", "N/A");
       boost::algorithm::to_upper(drv_name);
-      _output << boost::format("  %-20s : %s\n") % drv_name 
-          % driver.get<std::string>("version", "N/A");
+      _output << boost::format("  %-20s : %s, %s\n") % drv_name 
+          % driver.get<std::string>("version", "N/A") % driver.get<std::string>("hash", "N/A");
     }
     _output << std::endl;
   }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -57,6 +57,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
                         std::iostream & _output) const
 {
   boost::property_tree::ptree _pt;
+  boost::property_tree::ptree empty_ptree;
   getPropertyTreeInternal(_pDevice, _pt);
 
   _output << "System Configuration\n";
@@ -64,7 +65,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   _output << boost::format("  %-20s : %s\n") % "Release" % _pt.get<std::string>("host.os.release", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Version" % _pt.get<std::string>("host.os.version", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Machine" % _pt.get<std::string>("host.os.machine", "N/A");
-  boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries");
+  boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries", empty_ptree);
   for(auto& kl : available_libraries) {
     boost::property_tree::ptree& lib = kl.second;
     std::string lib_name = lib.get<std::string>("name", "N/A");
@@ -80,7 +81,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
   _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.build_date", "N/A");
-  boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers");
+  boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers", empty_ptree);
   for(auto& drv : available_drivers) {
     boost::property_tree::ptree& driver = drv.second;
     std::string drv_name = driver.get<std::string>("name", "N/A");

--- a/src/runtime_src/core/tools/common/ReportHostInterface.h
+++ b/src/runtime_src/core/tools/common/ReportHostInterface.h
@@ -22,7 +22,7 @@
 
 class ReportHostInterface: public Report {
  public:
-  ReportHostInterface() : Report("host-inteface", "Host interface status/info", true /*deviceRequired*/) { /*empty*/ };
+  ReportHostInterface() : Report("host-interface", "Host interface status/info", true /*deviceRequired*/) { /*empty*/ };
 
  // Child methods that need to be implemented
  public:

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -18,6 +18,8 @@
 // Local - Include Files
 #include "XBHelpMenus.h"
 #include "XBUtilities.h"
+#include "core/common/time.h"
+
 namespace XBU = XBUtilities;
 
 
@@ -597,6 +599,7 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
   {
     boost::property_tree::ptree ptSchemaVersion;
     ptSchemaVersion.put("schema", Report::getSchemaDescription(_schemaVersion).optionName.c_str());
+    ptSchemaVersion.put("creation_date", xrt_core::timestamp());
 
     ptRoot.add_child("schema_version", ptSchemaVersion);
   }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -316,7 +316,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
 
   // -- Collect the devices by name
   for (const auto & deviceBDF : _deviceBDFs) {
-  	auto index = xrt_core::utils::bdf2index(deviceBDF);         // Can throw
+  	auto index = xrt_core::utils::bdf2index(deviceBDF, _inUserDomain);         // Can throw
     if(_inUserDomain)
         _deviceCollection.push_back( xrt_core::get_userpf_device(index) );
       else 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -71,7 +71,6 @@ XMC_Flasher::XMC_Flasher(unsigned int device_index)
     } catch (...) {}
     if (mRegBase == 0)
         mRegBase = XMC_REG_BASE;
-    mRegBase = XMC_REG_BASE;
 
     val = readReg(XMC_REG_OFF_MAGIC);
     if (val != XMC_MAGIC_NUM) {


### PR DESCRIPTION
- xbutil now takes userpf and not mgmtpf
- xbutil --new examine -r host
```
$ xbutil --new examine --report=host --format=json-2020.1
-----------------------------------------------------
Invoking next generation of the xbutil application
-----------------------------------------------------
{
    "schema_version": {
        "schema": "JSON-2020.1"
    },
    "system": {
        "host": {
            "os": {
                "sysname": "Linux",
                "release": "4.4.0-142-generic",
                "version": "#168-Ubuntu SMP Wed Jan 16 21:00:45 UTC 2019",
                "machine": "x86_64",
                "glibc": "2.23",
                "linux": "Ubuntu 16.04.5 LTS",
                "now": "Fri May 22 07:19:32 2020"
            },
            "xrt": {
                "version": "2.6.0",
                "hash": "0a92e2edf28ef771f952477d5b1b134c035493d7",
                "date": "2020-05-20 12:06:59",
                "branch": "xbmgmt-fixes",
                "xocl": "2.6.638,ddd5bb64ebedcab6df535d5d8525c854115b0555",
                "xclmgmt": "2.6.638,ddd5bb64ebedcab6df535d5d8525c854115b0555"
            }
        }
    }
}
```
