### PR TITLE
CR-1066010 CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE not working on VCK5000

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -2763,7 +2763,7 @@ exec_ert_query_mailbox(struct exec_core *exec, struct xocl_cmd *xcmd)
 			continue;
 		}
 
-		mask = 1 << (slots[i] % sizeof (u32));
+		mask = 1 << (slots[i] % 32);
 		mask_idx = slots[i] >> 5;
 
 		exec->ops->process_mask(exec, mask, mask_idx);


### PR DESCRIPTION
Fix a bug of coverting slot # to mask/mask_idx