### PR TITLE
xbmgmt v2 2RP blp scan support

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -145,7 +145,10 @@ enum class key_type
   is_mfg,
   f_flash_type,
   flash_type,
-  board_name
+  board_name,
+  interface_uuids,
+  logic_uuids
+
 };
 
 class no_such_key : public std::exception
@@ -447,6 +450,40 @@ struct rom_time_since_epoch : request
   to_string(const result_type& value)
   {
     return boost::str(boost::format("0x%x") % value);
+  }
+};
+
+struct interface_uuids : request
+{
+  using result_type = std::vector<std::string>;
+  static const key_type key = key_type::interface_uuids;
+  static const char* name() { return "interface_uuids"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  // formatting of individual items for the vector
+  static std::string
+  to_string(const std::string& value)
+  {
+    return value;
+  }
+};
+
+struct logic_uuids : request
+{
+  using result_type = std::vector<std::string>;
+  static const key_type key = key_type::logic_uuids;
+  static const char* name() { return "logic_uuids"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  // formatting of individual items for the vector
+  static std::string
+  to_string(const std::string& value)
+  {
+    return value;
   }
 };
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -242,6 +242,9 @@ initialize_query_table()
   emplace_sysfs_request<query::f_flash_type>              ("flash", "flash_type");
   emplace_sysfs_request<query::flash_type>                ("", "flash_type");
   emplace_sysfs_request<query::board_name>                ("", "board_name");
+  emplace_sysfs_request<query::logic_uuids>               ("", "logic_uuids");
+  emplace_sysfs_request<query::interface_uuids>           ("", "interface_uuids");
+
   emplace_func0_request<query::pcie_bdf,                  bdf>();
 }
 

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -89,6 +89,40 @@ struct board_name
   }
 };
 
+struct logic_uuids
+{
+  using result_type = std::vector<std::string>;
+
+  static result_type
+  user(const xrt_core::device* device, key_type key)
+  {
+    return std::vector<std::string>{"TO-DO"};
+  }
+
+  static result_type
+  mgmt(const xrt_core::device* device, key_type key)
+  {
+    return std::vector<std::string>{"TO-DO"};
+  }
+};
+
+struct interface_uuids
+{
+  using result_type = std::vector<std::string>;
+
+  static result_type
+  user(const xrt_core::device* device, key_type key)
+  {
+    return std::vector<std::string>{"TO-DO"};
+  }
+
+  static result_type
+  mgmt(const xrt_core::device* device, key_type key)
+  {
+    return std::vector<std::string>{"TO-DO"};
+  }
+};
+
 struct firewall
 {
   using result_type = boost::any;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -161,7 +161,7 @@ void getUUIDFromDTB(void *blob, uint64_t &ts, std::vector<std::string> &uuids)
 
         sz = be32toh(GET_CELL(p));
         s = p_strings + be32toh(GET_CELL(p));
-        if (version < 16 && sz >= 8) {}
+        if (version < 16 && sz >= 8)
             p = PALIGN(p, 8);
 
         if (!strcmp(s, "logic_uuid"))
@@ -175,7 +175,7 @@ void getUUIDFromDTB(void *blob, uint64_t &ts, std::vector<std::string> &uuids)
         p = PALIGN(p + sz, 4);
     }
     if (uuids.size() > 0)
-        uuid2ts(uuids[0], ts);
+        uuid2ts(uuids[0], ts);  
 }
 
 DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id, const std::string& bmcV) :
@@ -430,8 +430,6 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
 	  DSAInfo dsa(start->path().string());
 	  installedDSA.push_back(dsa);
     }
-    if (!installedDSA.empty())
-        return installedDSA;
 
     // for 2RP
     p = FORMATTED_FW_DIR;


### PR DESCRIPTION
- Query for logic_uuids and interface_uuids
- Support to scan different platform package paths and determine if the platform is 1RP or 2RP
- Bug fixes
- Sample output, 1st is 2RP and 2nd card is 1RP:
```
{
    "schema_version": {
        "schema": "JSON-2020.1"
    },
    "devices": [
        {
            "platform": {
                "bdf": "0000:03:00.0",
                "flash_type": "spi",
                "hardware": {
                    "serial_num": ""
                },
                "current_shell": {
                    "vbnv": "xilinx_u250_gen3x16_base",
                    "logic-uuid": "38932b102cb9ef9ed81d66f250097e2f",
                    "interface-uuid": "2fc0b9d0d5500e2dbea94af4758726a2",
                    "id": "0x38932b102cb9ef9e",
                    "sc_version": "4.3.9"
                },
                "status": {
                    "shell": "true",
                    "sc": "true"
                },
                "available_shells": [
                    {
                        "vbnv": "xilinx_u250_gen3x16_base",
                        "sc_version": "4.3.9",
                        "id": "0x38932b102cb9ef9e",
                        "file": "\/opt\/xilinx\/firmware\/u250\/gen3x16\/base\/partition.xsabin"
                    }
                ]
            }
        },
        {
            "platform": {
                "bdf": "0000:02:00.0",
                "flash_type": "spi",
                "hardware": {
                    "serial_num": "12809621T120"
                },
                "current_shell": {
                    "vbnv": "xilinx_u200_qdma_201910_1",
                    "id": "0x5cdad62a",
                    "sc_version": "4.0.7"
                },
                "status": {
                    "shell": "true",
                    "sc": "true"
                },
                "available_shells": [
                    {
                        "vbnv": "xilinx_u200_qdma_201910_1",
                        "sc_version": "4.0.7",
                        "id": "0x5cdad62a",
                        "file": "\/lib\/firmware\/xilinx\/10ee-5010-000e-000000005cdad62a.dsabin"
                    }
                ]
            }
        }
    ]
}
```
