### PR TITLE
CR-1066124: Improper waveform on edge when using trace fifo

### DIFF
--- a/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
@@ -88,7 +88,7 @@ uint32_t TraceFifoFull::readTrace(xclTraceResultsVector& traceVector, uint32_t n
     uint32_t wordsPerSample = 1;
     getDevice()->readTraceData(traceBuf, traceBufSz, numSamples/* use numSamples */, getBaseAddress(), wordsPerSample);
 
-    processTraceData(traceVector, numSamples, traceBuf, wordsPerSample); 
+    processTraceData(traceVector, traceSamples, traceBuf, wordsPerSample); 
 
     delete [] traceBuf;
     return 0;


### PR DESCRIPTION
Since the width of the trace FIFO is different on edge and PCIe, the number of 64-bit elements processed in software must account for those differences.  This pull request fixes an issue where, after correctly calculating the number of trace samples to process, we instead processed a number of samples based off the wrong value.  This led to us interpreting extra garbage sometimes as extra events on edge and producing a bad visualization.
