### PR TITLE
CR-1065562 ASTeR TC 18.01 - xbutil dmatest returns Read bandwidth val…

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1473,7 +1473,7 @@ public:
         xclbin_lock xclbin_lock(m_handle, m_idx);
 
         if (blockSize == 0)
-            blockSize = 256 * 1024 * 1024; // Default block size
+            blockSize = 16 * 1024 * 1024; // Default block size 16MB
 
         int ddr_mem_size = get_ddr_mem_size();
         if (ddr_mem_size == -EINVAL)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdDmaTest.cpp
@@ -41,7 +41,7 @@ static void
 dmatest(const std::shared_ptr<xrt_core::device>& device, size_t block_size, bool verbose)
 {
   if (block_size == 0)
-      block_size = 256 * 1024 * 1024; // Default block size
+      block_size = 16 * 1024 * 1024; // Default block size 16MB
 
   auto ddr_mem_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
 


### PR DESCRIPTION
…ues out of expected range.


on u50 HBM bank size is 256MB causing dmatest to only create 1 BO. DMA bandwidth test results will not be accurate because we will be measuring transfer for 1 BO over 2 xdma hannels.  16MB seems to be fair IO size for measure BW on different platforms. 