### PR TITLE
AIE Support: Updated the xclbin header to support an action mask

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2015-2018, Xilinx Inc
+ *  Copyright (C) 2015-2020, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -192,6 +192,10 @@ extern "C" {
         IP_MEM_HBM
     };
 
+    enum ACTION_MASK {
+      AM_LOAD_AIE = 0x1                     /* Indicates to the driver to load the AIE PID section */
+    };
+
     struct axlf_section_header {
         uint32_t m_sectionKind;             /* Section type */
         char m_sectionName[16];             /* Examples: "stage2", "clear1", "clear2", "ocl1", "ocl2, "ublaze", "sched" */
@@ -207,7 +211,8 @@ extern "C" {
         uint16_t m_versionPatch;            /* Patch Version */
         uint8_t m_versionMajor;             /* Major Version - Version: 2.1.0*/
         uint8_t m_versionMinor;             /* Minor Version */
-        uint32_t m_mode;                    /* XCLBIN_MODE */
+        uint16_t m_mode;                    /* XCLBIN_MODE */
+        uint16_t m_actionMask;              /* Bit Mask */
 	union {
 	    struct {
 		uint64_t m_platformId;      /* 64 bit platform ID: vendor-device-subvendor-subdev */

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -331,6 +331,18 @@ reportXclbinInfo( std::ostream & _ostream,
     _ostream << XUtil::format("   %-23s %s", "Signature:", sSignatureState.c_str()).c_str() << std::endl;
   }
 
+  // Action Masks
+  {
+    // Are there any masks set
+    if (_xclBinHeader.m_header.m_actionMask) {
+      _ostream << XUtil::format("   %-23s ", "Action Mask(s):");
+      if (_xclBinHeader.m_header.m_actionMask & AM_LOAD_AIE) {
+        _ostream << "LOAD_AIE ";
+      }
+      _ostream << std::endl;
+    }
+  }
+
   // Content
   {
     std::string sContent;

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1387,6 +1387,21 @@ XclBin::setKeyValue(const std::string & _keyValue)
       return; // Key processed 
     }
 
+    if (sKey == "action_mask") {
+      std::vector<std::string> masks;
+      boost::split(masks, sValue, boost::is_any_of("|"));
+      m_xclBinHeader.m_header.m_actionMask = 0;
+      for (const auto & mask : masks) {
+        if (mask == "LOAD_AIE") {
+          m_xclBinHeader.m_header.m_actionMask |= AM_LOAD_AIE;
+        } else {
+          std::string errMsg = XUtil::format("ERROR: Unknown bit mask '%s' for the key '%s'. Key-value pair: '%s'.", mask.c_str(), sKey.c_str(), _keyValue.c_str());
+          throw std::runtime_error(errMsg);
+        }
+      }
+      return; // Key processed
+    }
+
     if (sKey == "FeatureRomTimestamp") {
       m_xclBinHeader.m_header.m_featureRomTimeStamp = XUtil::stringToUInt64(sValue);
       return; // Key processed 

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -523,7 +523,7 @@ XclBin::readXclBinHeader(const boost::property_tree::ptree& _ptHeader,
                            _axlfHeader.m_header.m_versionMinor, 
                            _axlfHeader.m_header.m_versionPatch);
 
-  _axlfHeader.m_header.m_mode = _ptHeader.get<uint32_t>("Mode");
+  _axlfHeader.m_header.m_mode = _ptHeader.get<uint16_t>("Mode");
 
   std::string sFeatureRomUUID = _ptHeader.get<std::string>("FeatureRomUUID");
   XUtil::hexStringToBinaryBuffer(sFeatureRomUUID, (unsigned char*)&_axlfHeader.m_header.rom_uuid, sizeof(axlf_header::rom_uuid));


### PR DESCRIPTION
Updated the xclbin header to support an action mask value.  This value represents a collection of bits used to indicate an action that the drivers should perform.  In this case, LOAD_AIE pid image.
Work Done
---------
+ Reduced the size of the m_mode value from an unit32_t to uintt16_t.
+ Added a new variable "m_actionMask" after m_mode
+ Verified via a hex editor that the m_mode value placement in the xclbin didn't regress
+ Added a new SYS parameter to xclbinutil (e.g., action_mask) that supports setting the LOAD_AIE bit
+ Update the --info report to report any "set" bit values in the action_mask variable.