### PR TITLE
XRT-575 IOPS test shows unusual result

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -197,6 +197,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 
 	ecmd = (struct ert_packet *)zocl_bo->cma_base.vaddr;
 
+	ecmd->state = ERT_CMD_STATE_NEW;
 	/* only the user command knows the real size of the payload.
 	 * count is more than enough!
 	 */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -168,6 +168,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 
 	ecmd = (struct ert_packet *)xobj->vmapping;
 
+	ecmd->state = ERT_CMD_STATE_NEW;
 	/* only the user command knows the real size of the payload.
 	 * count is more than enough!
 	 */


### PR DESCRIPTION
Fixed.

Remove num_execs. Instead, wait all of the submitted commands finished then calculate duration and verify.
Execute 5 times then calculate average duration.
