### PR TITLE
Clean up xrt_core::device construction

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -18,6 +18,7 @@
 #include "device.h"
 #include "error.h"
 #include "utils.h"
+#include "debug.h"
 #include "query_requests.h"
 #include "xclbin_parser.h"
 #include "core/include/xrt.h"
@@ -34,12 +35,14 @@ device::
 device(id_type device_id)
   : m_device_id(device_id)
 {
+  XRT_DEBUGF("xrt_core::device::device(0x%x) idx(%d)\n", this, device_id);
 }
 
 device::
 ~device()
 {
   // virtual must be declared and defined
+  XRT_DEBUGF("xrt_core::device::~device(0x%x) idx(%d)\n", this, m_device_id);
 }
 
 std::string

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -32,6 +32,9 @@ namespace xrt_core {
 struct ishim
 {
   virtual void
+  close_device() = 0;
+  
+  virtual void
   open_context(xuid_t xclbin_uuid, unsigned int ip_index, bool shared) = 0;
 
   virtual void
@@ -89,6 +92,12 @@ struct shim : public DeviceType
   shim(Args&&... args)
     : DeviceType(std::forward<Args>(args)...)
   {}
+
+  virtual void
+  close_device()
+  {
+    xclClose(DeviceType::get_device_handle());
+  }
 
   virtual void
   open_context(xuid_t xclbin_uuid , unsigned int ip_index, bool shared)

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -39,7 +39,7 @@ namespace xrt_core {
 // Singleton is initialized when libxrt_core is loaded
 // A concrete system object is constructed during static
 // global initialization.  Lifetime is until core library
-// is unloaded. 
+// is unloaded.
 system* singleton = nullptr;
 
 system::
@@ -99,7 +99,7 @@ get_userpf_device(device::id_type id)
   // Repackage raw ptr in new shared ptr with deleter that calls xclClose,
   // but leaves device object alone. The returned device is managed in that
   // it calls xclClose when going out of scope.
-  auto close = [] (auto d) { d->close_device(); };
+  auto close = [] (xrt_core::device* d) { d->close_device(); };
   return {device.get(), close};
 }
 
@@ -131,7 +131,7 @@ get_userpf_device(device::handle_type handle, device::id_type id)
   userpf_device_map[handle] = device;  // create or replace
   return device;
 }
-  
+
 std::shared_ptr<device>
 get_mgmtpf_device(device::id_type id)
 {

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -57,16 +57,29 @@ public:
   get_total_devices(bool is_user = true) const = 0;
 
   /**
-   * get_userpf_device() - construct from device id
+   * get_userpf_device() - Open a new device specified by index
+   *
+   * This function calls xclOpen to create a new shim handle from
+   * which a core device is constructed.
+   *
+   * The returned device is managed, such that xclClose is called
+   * when device is no longer referenced.
    */
   virtual std::shared_ptr<device>
   get_userpf_device(device::id_type id) const = 0;
 
   /**
-   * get_userpf_device() - construct from existing handle and id
+   * get_userpf_device() - Get previous opened device from handle
    *
    * @hdl:  Handle for device
    * @id:   Device index
+   *
+   * The returned device is a pointer to the device opened previously
+   * by a call to xclOpen.  This call could be explicit xclOpen in
+   * host code, which must be followed by xclClose also in host code.
+   *
+   * The returned device is unmanaged, in other words xclClose is 
+   * not called when device goes out of scope.
    */
   virtual std::shared_ptr<device>
   get_userpf_device(device::handle_type hdl, device::id_type) const = 0;
@@ -129,11 +142,11 @@ std::pair<uint64_t, uint64_t>
 get_total_devices(bool is_user);
 
 /**
- * get_userpf_device() - construct from device id
+ * get_userpf_device() - Open and create device specified by index
  *
- * This API is ambiguous in multi-threaded applications that
- * open a device in each thread. In these cases only the device
- * handle can be used to locate correspoding device object
+ * This function calls xclOpen to create a new shim handle
+ * The returned device is managed, such that xclClose is called
+ * when device is deleted.
  */
 XRT_CORE_COMMON_EXPORT
 std::shared_ptr<device>
@@ -145,22 +158,28 @@ get_userpf_device(device::id_type id);
  * @hdl:  Handle for device.  The handle is from xclOpen().
  *
  * This is a cached lookup to allow retrieving device associated
- * with device handle obtained from xclOpen()
+ * with device handle obtained from xclOpen().
+ *
+ * The returned device is unmanaged, meaning that the underlying
+ * shim object is not closed when the device is deleted.
  */
 XRT_CORE_COMMON_EXPORT
 std::shared_ptr<device>
 get_userpf_device(device::handle_type handle);
 
 /**
- * get_userpf_device() - get userpf mdevice from existing handle and id
+ * get_userpf_device() - construct from existing handle and id
  *
  * @hdl:  Handle for device
  * @id:   Device index
  *
+ * The returned device is unmanaged, meaning that the underlying
+ * shim object is not closed when the device goes out of scope.
+ *
  * This is used by shim level implementations to construct and
  * cache a device object as part of constructing shim level handle.
  * The function is called from shim constructors (xclOpen()).  After
- * registration the xrt_core::device object can at all times be
+ * registration, the xrt_core::device object can at all times be
  * retrived from just an hdl (xclDeviceHandle)
  */
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/common/uuid.h
+++ b/src/runtime_src/core/common/uuid.h
@@ -17,93 +17,13 @@
 #ifndef xrt_core_uuid_h_
 #define xrt_core_uuid_h_
 
-#ifdef _WIN32
-# include "core/include/windows/uuid.h"
-#else
-# include <uuid/uuid.h>
-using xuid_t = uuid_t;
-#endif
+#include "core/include/experimental/xrt_uuid.h"
 
 namespace xrt_core {
 
-/**
- * uuid wrapper to treat uuid_t as a value type
- * supports copying
- */
-struct uuid
-{
-  xuid_t m_uuid;
+using uuid = xrt::uuid;
 
-  uuid()
-  {
-    uuid_clear(m_uuid);
-  }
-
-  uuid(const xuid_t val)
-  {
-    uuid_copy(m_uuid,val);
-  }
-
-  uuid(const uuid& rhs)
-  {
-    uuid_copy(m_uuid,rhs.m_uuid);
-  }
-
-  uuid(uuid&&) = default;
-  uuid& operator=(uuid&&) = default;
-
-  uuid& operator=(const uuid& rhs)
-  {
-    uuid source(rhs);
-    std::swap(*this,source);
-    return *this;
-  }
-
-  const xuid_t& get() const
-  {
-    return m_uuid;
-  }
-
-  std::string
-  to_string() const
-  {
-    char str[40] = {0};
-    uuid_unparse_lower(m_uuid,str);
-    return str;
-  }
-
-  bool
-  operator == (const xuid_t& xuid) const
-  {
-    return uuid_compare(m_uuid, xuid) == 0;
-  }
-
-  bool
-  operator != (const xuid_t& xuid) const
-  {
-    return uuid_compare(m_uuid, xuid) != 0;
-  }
-
-  bool
-  operator == (const uuid& rhs) const
-  {
-    return uuid_compare(m_uuid, rhs.m_uuid) == 0;
-  }
-
-  bool
-  operator != (const uuid& rhs) const
-  {
-    return uuid_compare(m_uuid, rhs.m_uuid) != 0;
-  }
-
-  bool
-  operator < (const uuid& rhs) const
-  {
-    return uuid_compare(m_uuid, rhs.m_uuid) < 0;
-  }
-};
-
-} // xrt
+} // xrt_core
 
 
 #endif

--- a/src/runtime_src/core/common/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/xrt_xclbin.cpp
@@ -37,7 +37,7 @@ namespace {
 namespace api {
 
 void
-xrtXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
+xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out)
 {
   auto device = xrt_core::get_userpf_device(dhdl);
   auto uuid_str = device->get_xclbin_uuid();
@@ -58,7 +58,7 @@ send_exception_message(const char* msg)
 // xrt_xclbin API implmentations (xrt_xclbin.h)
 ////////////////////////////////////////////////////////////////
 int
-xrtXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
+xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out)
 {
   try {
    api::xrtXclbinUUID(dhdl, out);

--- a/src/runtime_src/core/edge/common/device_edge.cpp
+++ b/src/runtime_src/core/edge/common/device_edge.cpp
@@ -23,24 +23,9 @@
 namespace xrt_core {
 
 device_edge::
-device_edge(id_type device_id, bool user)
-  : device(device_id), m_userpf(user), m_managed(true)
+device_edge(handle_type device_handle, id_type device_id, bool user)
+  : device(device_id), m_handle(device_handle), m_userpf(user)
 {
-  if (m_userpf)
-    m_handle = xclOpen(device_id, nullptr, XCL_QUIET);
-}
-
-device_edge::
-device_edge(handle_type device_handle, id_type device_id)
-  : device(device_id), m_handle(device_handle), m_userpf(true), m_managed(false)
-{
-}
-
-device_edge::
-~device_edge()
-{
-  if (m_userpf && m_handle && m_managed)
-    xclClose(m_handle);
 }
 
 xclDeviceHandle

--- a/src/runtime_src/core/edge/common/device_edge.h
+++ b/src/runtime_src/core/edge/common/device_edge.h
@@ -25,18 +25,9 @@ class device_edge : public device
 {
 public:
   /**
-   * device_edge() - Construct and open a device
+   * device_edge() - Construct from a device_handle, device_id
    */
-  device_edge(id_type device_id, bool user);
-
-  /**
-   * device_edge() - Construct from a device_handle
-   *
-   * Bypasses call to xclOpen
-   */
-  device_edge(handle_type device_handle, id_type device_id);
-
-  ~device_edge();
+  device_edge(handle_type device_handle, id_type device_id, bool user);
 
   virtual void
   get_info(boost::property_tree::ptree& pt) const;
@@ -52,7 +43,6 @@ public:
 private:
   xclDeviceHandle m_handle = XRT_NULL_HANDLE;
   bool m_userpf;
-  bool m_managed;
 };
 
 } // xrt_core

--- a/src/runtime_src/core/edge/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/edge/tools/xbutil/xbutil.h
@@ -522,12 +522,7 @@ public:
         std::vector<char> buffer(length);
         stream.read(buffer.data(), length);
         const xclBin *header = (const xclBin *)buffer.data();
-        int result = xclLockDevice(m_handle);
-        if (result == 0)
-            result = xclLoadXclBin(m_handle, header);
-        (void) xclUnlockDevice(m_handle);
-
-        return result;
+        return xclLoadXclBin(m_handle, header);
     }
 
     int boot() { std::cout << "Unsupported API " << std::endl; return -1; }

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -204,16 +204,8 @@ lookup_query(query::key_type query_key) const
 }
 
 device_linux::
-device_linux(id_type device_id, bool user)
-  : shim<device_edge>(device_id, user)
-{
-  handle = get_device_handle();
-  xclGetDeviceInfo2(handle, &deviceInfo);
-}
-
-device_linux::
-device_linux(handle_type device_handle, id_type device_id)
-  : shim<device_edge>(device_handle, device_id)
+device_linux(handle_type device_handle, id_type device_id, bool user)
+  : shim<device_edge>(device_handle, device_id, user)
 {
 }
 

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -27,10 +27,7 @@ namespace xrt_core {
 class device_linux : public shim<device_edge>
 {
 public:
-  device_linux(id_type device_id, bool user);
-
-  // Open an unmanged device.  This ctor is called by xclOpen
-  device_linux(handle_type device_handle, id_type device_id);
+  device_linux(handle_type device_handle, id_type device_id, bool user);
 
   // query functions
   virtual void read_dma_stats(boost::property_tree::ptree& pt) const;

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -111,8 +111,7 @@ std::shared_ptr<device>
 system_linux::
 get_userpf_device(device::id_type id) const
 {
-  // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_linux>(new device_linux(id,true));
+  return xrt_core::get_userpf_device(xclOpen(id, nullptr, XCL_QUIET));
 }
 
 std::shared_ptr<device>
@@ -120,7 +119,7 @@ system_linux::
 get_userpf_device(device::handle_type handle, device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_linux>(new device_linux(handle, id));
+  return std::shared_ptr<device_linux>(new device_linux(handle, id, true));
 }  
 
 std::shared_ptr<device>
@@ -128,7 +127,7 @@ system_linux::
 get_mgmtpf_device(device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_linux>(new device_linux(id,false));
+  return std::shared_ptr<device_linux>(new device_linux(nullptr, id, false));
 }
 
 namespace edge_linux {

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -4,6 +4,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_bo.h
   xrt_device.h
   xrt_kernel.h
+  xrt_uuid.h
   xrt_xclbin.h
   xclbin_util.h
   xclbin-util.h)

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -19,6 +19,7 @@
 #define _XRT_DEVICE_H_
 
 #include "xrt.h"
+#include "experimental/xrt_uuid.h"
 
 #ifdef __cplusplus
 # include <memory>
@@ -52,8 +53,8 @@ public:
    * @didx:     Device index
    */
   XCL_DRIVER_DLLESPEC
+  explicit
   device(unsigned int didx);
-
 
   /**
    * device() - Copy ctor
@@ -83,26 +84,47 @@ public:
    * load_xclbin() - Load an xclbin 
    *
    * @xclbin:     Pointer to xclbin in memory image
+   * Return:      UUID of argument xclbin
    *
    * The xclbin image can safely be deleted after calling
    * this funciton.
    */
   XCL_DRIVER_DLLESPEC
-  void
+  uuid
   load_xclbin(const struct axlf* xclbin);
 
   /**
    * load_xclbin() - Read and load an xclbin file
    *
    * @xclbin_fnm:  Full path to xclbin file
+   * Return:       UUID of argument xclbin
    *
    * This function read the file from disk and loads
    * the xclbin.   Using this function allows one time
    * allocation of data that needs to be kept in memory.
    */
   XCL_DRIVER_DLLESPEC
-  void
+  uuid
   load_xclbin(const std::string& xclbin_filename);
+
+  /**
+   * get_xclbin_uuid() - Get UUID of xclbin image loaded on device
+   *
+   * Return:       UUID of currently loaded xclbin
+   *
+   * Note that current UUID can be different from the UUID of 
+   * the xclbin loaded by this process using @load_xclbin()
+   */
+  XCL_DRIVER_DLLESPEC
+  uuid
+  get_xclbin_uuid() const;
+
+public:
+  /**
+   * Undocumented temporary interface during porting
+   */
+  XCL_DRIVER_DLLESPEC
+  operator xclDeviceHandle () const;
 
 private:
   std::shared_ptr<xrt_core::device> handle;
@@ -159,6 +181,20 @@ xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const struct axlf* xclbin);
 XCL_DRIVER_DLLESPEC
 int
 xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* xclbin_filename);
+
+/**
+ * xrtDeviceGetXclbinUUID() - Get UUID of xclbin image loaded on device
+ *
+ * @handle: Device handle
+ * @out:    Return xclbin id in this uuid_t struct
+ * Return:  0 on success or appropriate error number
+ *
+ * Note that current UUID can be different from the UUID of 
+ * the xclbin loaded by this process using @load_xclbin()
+ */
+XCL_DRIVER_DLLESPEC
+void
+xrtDeviceGetXclbinUUID(xrtDeviceHandle dhld, xuid_t out);
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/core/include/experimental/xrt_uuid.h
+++ b/src/runtime_src/core/include/experimental/xrt_uuid.h
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2016-2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef xrt_uuid_h_
+#define xrt_uuid_h_
+
+#ifdef _WIN32
+# include "windows/uuid.h"
+#else
+# include <uuid/uuid.h>
+using xuid_t = uuid_t;
+#endif
+
+namespace xrt {
+
+/**
+ * uuid wrapper to treat uuid_t as a value type
+ * supports copying
+ */
+class uuid
+{
+  xuid_t m_uuid;
+public:
+  uuid()
+  {
+    uuid_clear(m_uuid);
+  }
+
+  uuid(const xuid_t val)
+  {
+    uuid_copy(m_uuid,val);
+  }
+
+  uuid(const uuid& rhs)
+  {
+    uuid_copy(m_uuid,rhs.m_uuid);
+  }
+
+  uuid(uuid&&) = default;
+  uuid& operator=(uuid&&) = default;
+
+  uuid& operator=(const uuid& rhs)
+  {
+    uuid source(rhs);
+    std::swap(*this,source);
+    return *this;
+  }
+
+  const xuid_t& get() const
+  {
+    return m_uuid;
+  }
+
+  std::string
+  to_string() const
+  {
+    char str[40] = {0};
+    uuid_unparse_lower(m_uuid,str);
+    return str;
+  }
+
+  bool
+  operator == (const xuid_t& xuid) const
+  {
+    return uuid_compare(m_uuid, xuid) == 0;
+  }
+
+  bool
+  operator != (const xuid_t& xuid) const
+  {
+    return uuid_compare(m_uuid, xuid) != 0;
+  }
+
+  bool
+  operator == (const uuid& rhs) const
+  {
+    return uuid_compare(m_uuid, rhs.m_uuid) == 0;
+  }
+
+  bool
+  operator != (const uuid& rhs) const
+  {
+    return uuid_compare(m_uuid, rhs.m_uuid) != 0;
+  }
+
+  bool
+  operator < (const uuid& rhs) const
+  {
+    return uuid_compare(m_uuid, rhs.m_uuid) < 0;
+  }
+};
+
+} // xrt
+
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_uuid.h
+++ b/src/runtime_src/core/include/experimental/xrt_uuid.h
@@ -17,6 +17,8 @@
 #ifndef xrt_uuid_h_
 #define xrt_uuid_h_
 
+#include <string>
+
 #ifdef _WIN32
 # include "windows/uuid.h"
 #else

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -25,13 +25,6 @@ extern "C" {
 #endif
 
 /**
- * typedef xrtDeviceHandle - opaque device handle
- *
- * Typedef alias from xrt.h
- */
-typedef xclDeviceHandle xrtDeviceHandle;
-
-/**
  * xrtGetXclbinUUID() - Get UUID of xclbin image running on device
  *
  * @handle: Device handle
@@ -40,7 +33,7 @@ typedef xclDeviceHandle xrtDeviceHandle;
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinUUID(xrtDeviceHandle handle, xuid_t out);
+xrtXclbinUUID(xclDeviceHandle handle, xuid_t out);
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/core/pcie/common/device_pcie.cpp
+++ b/src/runtime_src/core/pcie/common/device_pcie.cpp
@@ -27,24 +27,9 @@
 namespace xrt_core {
 
 device_pcie::
-device_pcie(id_type device_id, bool user)
-  : device(device_id), m_userpf(user), m_managed(true)
+device_pcie(handle_type device_handle, id_type device_id, bool user)
+  : device(device_id), m_handle(device_handle), m_userpf(user)
 {
-  if (m_userpf)
-    m_handle = xclOpen(device_id, nullptr, XCL_QUIET);
-}
-
-device_pcie::
-device_pcie(handle_type device_handle, id_type device_id)
-  : device(device_id), m_handle(device_handle), m_userpf(true), m_managed(false)
-{
-}
-
-device_pcie::
-~device_pcie()
-{
-  if (m_userpf && m_handle && m_managed)
-    xclClose(m_handle);
 }
 
 xclDeviceHandle

--- a/src/runtime_src/core/pcie/common/device_pcie.h
+++ b/src/runtime_src/core/pcie/common/device_pcie.h
@@ -25,23 +25,9 @@ class device_pcie : public device
 {
 public:
   /**
-   * device_pcie() - Construct and open a device
-   */
-  device_pcie(id_type device_id, bool user);
-
-  /**
    * device_pcie() - Construct from a device_handle
-   *
-   * Bypasses call to xclOpen
    */
-  device_pcie(handle_type device_handle, id_type device_id);
-
-  /**
-   * Dtor - 
-   *
-   * Closes the device if and only if the device is managed
-   */
-  ~device_pcie();
+  device_pcie(handle_type device_handle, id_type device_id, bool user);
 
   virtual void
   get_info(boost::property_tree::ptree& pt) const;
@@ -66,7 +52,6 @@ public:
 private:
   xclDeviceHandle m_handle = XRT_NULL_HANDLE;
   bool m_userpf;
-  bool m_managed;
 };
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/common/system_pcie.cpp
+++ b/src/runtime_src/core/pcie/common/system_pcie.cpp
@@ -36,7 +36,7 @@ get_devices(boost::property_tree::ptree& pt) const
     pt_device.put("device_id", std::to_string(device_id));
 
     // Key: pcie
-    auto device = get_userpf_device(device_id);
+    auto device = xrt_core::get_userpf_device(device_id);
     boost::property_tree::ptree pt_pcie;
     device->get_info(pt_pcie);
     pt_device.add_child("pcie", pt_pcie);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/device_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/device_swemu.cxx
@@ -53,14 +53,8 @@ lookup_query(query::key_type query_key) const
 }
 
 device::
-device(id_type device_id, bool user)
-  : shim<device_pcie>(device_id, user)
-{
-}
-
-device::
-device(handle_type device_handle, id_type device_id)
-  : shim<device_pcie>(device_handle, device_id)
+device(handle_type device_handle, id_type device_id, bool user)
+  : shim<device_pcie>(device_handle, device_id, user)
 {
 }
 

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/device_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/device_swemu.h
@@ -27,10 +27,7 @@ namespace xrt_core { namespace swemu {
 class device : public shim<device_pcie>
 {
 public:
-  device(id_type device_id, bool user);
-
-  // Open an unmanged device.  This ctor is called by xclOpen
-  device(handle_type device_handle, id_type device_id);
+  device(handle_type device_handle, id_type device_id, bool user);
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
@@ -53,8 +53,7 @@ std::shared_ptr<xrt_core::device>
 system::
 get_userpf_device(device::id_type id) const
 {
-  // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<xrt_core::swemu::device>(new xrt_core::swemu::device(id,true));
+  return xrt_core::get_userpf_device(xclOpen(id, nullptr, XCL_QUIET));
 }
 
 std::shared_ptr<xrt_core::device>
@@ -62,7 +61,7 @@ system::
 get_userpf_device(device::handle_type handle, device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<xrt_core::swemu::device>(new xrt_core::swemu::device(handle, id));
+  return std::shared_ptr<xrt_core::swemu::device>(new xrt_core::swemu::device(handle, id, true));
 }
 
 std::shared_ptr<xrt_core::device>
@@ -70,7 +69,7 @@ system::
 get_mgmtpf_device(device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<xrt_core::swemu::device>(new xrt_core::swemu::device(id,false));
+  return std::shared_ptr<xrt_core::swemu::device>(new xrt_core::swemu::device(nullptr, id, false));
 }
 
 std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/device_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/device_hwemu.cxx
@@ -46,14 +46,8 @@ lookup_query(query::key_type query_key) const
 }
 
 device::
-device(id_type device_id, bool user)
-  : shim<device_pcie>(device_id, user)
-{
-}
-
-device::
-device(handle_type device_handle, id_type device_id)
-  : shim<device_pcie>(device_handle, device_id)
+device(handle_type device_handle, id_type device_id, bool user)
+  : shim<device_pcie>(device_handle, device_id, user)
 {
 }
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/device_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/device_hwemu.h
@@ -27,10 +27,7 @@ namespace xrt_core { namespace hwemu {
 class device : public shim<device_pcie>
 {
 public:
-  device(id_type device_id, bool user);
-
-  // Open an unmanged device.  This ctor is called by xclOpen
-  device(handle_type device_handle, id_type device_id);
+  device(handle_type device_handle, id_type device_id, bool user);
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1372,6 +1372,11 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     }
     mFdToFileNameMap.clear();
 
+    // Shim object is not deleted as part of closing device.
+    // The core device must correspond to open and close, so
+    // reset here rather than in destructor
+    mCoreDevice.reset();
+
     if (!sock) 
     {
       if( xclemulation::config::getInstance()->isKeepRunDirEnabled() == false)
@@ -1641,8 +1646,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
   }
 
   HwEmShim::HwEmShim( unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool _unified, bool _xpr, FeatureRomHeader &fRomHeader)
-    :mCoreDevice(xrt_core::hwemu::get_userpf_device(this, deviceIndex))
-    ,mRAMSize(info.mDDRSize)
+    :mRAMSize(info.mDDRSize)
     ,mCoalesceThreshold(4)
     ,mDSAMajorVersion(DSA_MAJOR_VERSION)
     ,mDSAMinorVersion(DSA_MINOR_VERSION)
@@ -1986,6 +1990,11 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       mGlobalInMemStream.open("global_in.mem");
       mGlobalOutMemStream.open("global_out.mem");
     }
+
+    // Shim object creation doesn't follow xclOpen/xclClose.
+    // The core device must correspond to open and close, so
+    // create here rather than in constructor
+    mCoreDevice = xrt_core::hwemu::get_userpf_device(this, mDeviceIndex);
   }
 
 /**********************************************HAL2 API's START HERE **********************************************/

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
@@ -53,8 +53,7 @@ std::shared_ptr<xrt_core::device>
 system::
 get_userpf_device(device::id_type id) const
 {
-  // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<xrt_core::hwemu::device>(new xrt_core::hwemu::device(id,true));
+  return xrt_core::get_userpf_device(xclOpen(id, nullptr, XCL_QUIET));
 }
 
 std::shared_ptr<xrt_core::device>
@@ -62,7 +61,7 @@ system::
 get_userpf_device(device::handle_type handle, device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<xrt_core::hwemu::device>(new xrt_core::hwemu::device(handle, id));
+  return std::shared_ptr<xrt_core::hwemu::device>(new xrt_core::hwemu::device(handle, id, true));
 }
 
 std::shared_ptr<xrt_core::device>
@@ -70,7 +69,7 @@ system::
 get_mgmtpf_device(device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<xrt_core::hwemu::device>(new xrt_core::hwemu::device(id,false));
+  return std::shared_ptr<xrt_core::hwemu::device>(new xrt_core::hwemu::device(nullptr, id, false));
 }
 
 std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -268,14 +268,8 @@ lookup_query(query::key_type query_key) const
 }
 
 device_linux::
-device_linux(id_type device_id, bool user)
-  : shim<device_pcie>(device_id, user)
-{
-}
-
-device_linux::
-device_linux(handle_type device_handle, id_type device_id)
-  : shim<device_pcie>(device_handle, device_id)
+device_linux(handle_type device_handle, id_type device_id, bool user)
+  : shim<device_pcie>(device_handle, device_id, user)
 {
 }
 

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -27,10 +27,7 @@ namespace xrt_core {
 class device_linux : public shim<device_pcie>
 {
 public:
-  device_linux(id_type device_id, bool user);
-
-  // Open an unmanged device.  This ctor is called by xclOpen
-  device_linux(handle_type device_handle, id_type device_id);
+  device_linux(handle_type device_handle, id_type device_id, bool user);
 
   // query functions
   virtual void read_dma_stats(boost::property_tree::ptree& pt) const;

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -155,8 +155,7 @@ std::shared_ptr<device>
 system_linux::
 get_userpf_device(device::id_type id) const
 {
-  // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_linux>(new device_linux(id,true));
+  return xrt_core::get_userpf_device(xclOpen(id, nullptr, XCL_QUIET));
 }
 
 std::shared_ptr<device>
@@ -164,7 +163,7 @@ system_linux::
 get_userpf_device(device::handle_type handle, device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_linux>(new device_linux(handle, id));
+  return std::shared_ptr<device_linux>(new device_linux(handle, id, true));
 }
 
 std::shared_ptr<device>
@@ -172,7 +171,7 @@ system_linux::
 get_mgmtpf_device(device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_linux>(new device_linux(id,false));
+  return std::shared_ptr<device_linux>(new device_linux(nullptr, id, false));
 }
 
 namespace pcie_linux {

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -910,20 +910,10 @@ lookup_query(query::key_type query_key) const
 }
 
 device_windows::
-device_windows(id_type device_id, bool user)
-  : shim<device_pcie>(device_id, user)
-{
-  if (user)
-    return;
-
-  m_mgmthdl = mgmtpf::open(device_id);
-}
-
-device_windows::
-device_windows(handle_type device_handle, id_type device_id)
-  : shim<device_pcie>(device_handle, device_id)
-{
-}
+device_windows(handle_type device_handle, id_type device_id, bool user)
+  : shim<device_pcie>(user ? device_handle : nullptr, device_id, user)
+  , m_mgmthdl(user ? nullptr : device_handle)
+{}
 
 device_windows::
 ~device_windows()

--- a/src/runtime_src/core/pcie/windows/device_windows.h
+++ b/src/runtime_src/core/pcie/windows/device_windows.h
@@ -27,10 +27,8 @@ namespace xrt_core {
 class device_windows : public shim<device_pcie>
 {
 public:
-  device_windows(id_type device_id, bool user);
-
   // Open an unmanged device.  This ctor is called by xclOpen
-  device_windows(handle_type device_handle, id_type device_id);
+  device_windows(handle_type device_handle, id_type device_id, bool user);
 
   ~device_windows();
 

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -151,8 +151,7 @@ std::shared_ptr<device>
 system_windows::
 get_userpf_device(device::id_type id) const
 {
-  // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_windows>(new device_windows(id,true));
+  return xrt_core::get_userpf_device(xclOpen(id, nullptr, XCL_QUIET));
 }
 
 std::shared_ptr<device>
@@ -160,7 +159,7 @@ system_windows::
 get_userpf_device(device::handle_type handle, device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_windows>(new device_windows(handle, id));
+  return std::shared_ptr<device_windows>(new device_windows(handle, id, true));
 }
 
 std::shared_ptr<device>
@@ -168,7 +167,7 @@ system_windows::
 get_mgmtpf_device(device::id_type id) const
 {
   // deliberately not using std::make_shared (used with weak_ptr)
-  return std::shared_ptr<device_windows>(new device_windows(id,false));
+  return std::shared_ptr<device_windows>(new device_windows(mgmtpf::open(id), id, false));
 }
 
 } // xrt_core

--- a/src/runtime_src/xrt/util/uuid.h
+++ b/src/runtime_src/xrt/util/uuid.h
@@ -14,16 +14,9 @@
  * under the License.
  */
 
-#ifndef xrt_uuid_h_
-#define xrt_uuid_h_
+#ifndef xrtx_uuid_h_
+#define xrtx_uuid_h_
 
-#include "core/common/uuid.h"
-
-namespace xrt {
-
-using uuid = xrt_core::uuid;
-
-} // xrt
-
+#include "core/include/experimental/xrt_uuid.h"
 
 #endif

--- a/tests/xrt/common.mk
+++ b/tests/xrt/common.mk
@@ -104,7 +104,7 @@ xclbin : $(CL_XCLBIN)
 exe : $(ODIR)/$(EXENAME)
 
 $(ODIR)/$(EXENAME): $(OBJS)
-	$(CXX) $(LDFLAGS) $(MYLDFLAGS) -o $@ $(OBJS)  -I${XILINX_XRT}/include  -L${XILINX_XRT}/lib -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_core -lxrt_coreutil -ldl -luuid -pthread
+	$(CXX) $(LDFLAGS) $(MYLDFLAGS) -o $@ $(OBJS)  -I${XILINX_XRT}/include  -L${XILINX_XRT}/lib -Wl,-rpath-link,${XILINX_XRT}/lib -lxrt_hwemu -lxrt_coreutil -ldl -luuid -pthread
 
 endif
 


### PR DESCRIPTION
Ensure that only one xrt_core::device is created per xclOpen() call.

Manage lifetime of device object to ensure that xclClose() is called
when xrt_core::device is constructed from device index.