### PR TITLE
XRT-579 Sysfs node to turn echo mode on/off

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -144,4 +144,7 @@ int kds_del_context(struct kds_client *client, struct kds_ctx_info *info);
 int kds_add_command(struct kds_command *xcmd);
 void kds_free_command(struct kds_command *xcmd);
 
+/* sysfs */
+int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
+		   int kds_mode, u32 clients, int *echo);
 #endif

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -13,6 +13,35 @@
 #include <linux/device.h>
 #include "kds_core.h"
 
+/* for sysfs */
+int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
+		   int kds_mode, u32 clients, int *echo)
+{
+	u32 enable;
+	u32 live_clients;
+
+	if (kds)
+		live_clients = kds_live_clients(kds, NULL);
+	else
+		live_clients = clients;
+
+	/* Ideally, KDS should be locked to reject new client.
+	 * But, this node is hidden for internal test purpose.
+	 * Let's refine it after new KDS is the default and
+	 * user is allow to configure it through xbutil.
+	 */
+	if (live_clients > 0)
+		return -EBUSY;
+
+	if (kstrtou32(buf, 10, &enable) == -EINVAL || enable > 1)
+		return -EINVAL;
+
+	*echo = enable;
+
+	return count;
+}
+/* sysfs end */
+
 int kds_init_sched(struct kds_sched *kds)
 {
 	INIT_LIST_HEAD(&kds->clients);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -196,6 +196,9 @@ void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size,
 void zocl_init_mem(struct drm_zocl_dev *zdev, struct mem_topology *mtopo);
 void zocl_clear_mem(struct drm_zocl_dev *zdev);
 
+/* zocl_kds.c */
+int zocl_init_sched(struct drm_zocl_dev *zdev);
+void zocl_fini_sched(struct drm_zocl_dev *zdev);
 int zocl_create_client(struct drm_zocl_dev *zdev, void **priv);
 void zocl_destroy_client(struct drm_zocl_dev *zdev, void **priv);
 uint zocl_poll_client(struct file *filp, poll_table *wait);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -927,7 +927,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		ret = cu_ctrl_init(zdev);
 		if (ret)
 			goto err_cu_ctrl;
-		ret = kds_init_sched(&zdev->kds);
+		ret = zocl_init_sched(zdev);
 		if (ret)
 			goto err_sched;
 	} else {
@@ -982,7 +982,7 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	zocl_fini_sysfs(drm->dev);
 
 	if (kds_mode == 1) {
-		kds_fini_sched(&zdev->kds);
+		zocl_fini_sched(zdev);
 		cu_ctrl_fini(zdev);
 	}
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -22,6 +22,35 @@ MODULE_PARM_DESC(kds_mode,
 
 int kds_echo = 0;
 
+/* -KDS sysfs-- */
+static ssize_t
+kds_echo_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", kds_echo);
+}
+
+static ssize_t
+kds_echo_store(struct device *dev, struct device_attribute *da,
+	       const char *buf, size_t count)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+
+	/* TODO: this should be as simple as */
+	/* return stroe_kds_echo(&zdev->kds, buf, count); */
+	return store_kds_echo(&zdev->kds, buf, count,
+			      kds_mode, 0, &kds_echo);
+}
+static DEVICE_ATTR(kds_echo, 0644, kds_echo_show, kds_echo_store);
+
+static struct attribute *kds_attrs[] = {
+	&dev_attr_kds_echo.attr,
+	NULL,
+};
+
+static struct attribute_group zocl_kds_group = {
+	.attrs = kds_attrs,
+};
+
 static inline void
 zocl_ctx_to_info(struct drm_zocl_ctx *args, struct kds_ctx_info *info)
 {
@@ -283,5 +312,25 @@ void zocl_destroy_client(struct drm_zocl_dev *zdev, void **priv)
 		vfree(client->xclbin_id);
 	kfree(client);
 	zocl_info(ddev->dev, "client exits pid(%d)\n", pid);
+}
+
+int zocl_init_sched(struct drm_zocl_dev *zdev)
+{
+	struct device *dev = zdev->ddev->dev;
+	int ret;
+
+	ret = sysfs_create_group(&dev->kobj, &zocl_kds_group);
+	if (ret)
+		zocl_err(dev, "create kds attrs failed: %d", ret);
+
+	return kds_init_sched(&zdev->kds);
+}
+
+void zocl_fini_sched(struct drm_zocl_dev *zdev)
+{
+	struct device *dev = zdev->ddev->dev;
+
+	sysfs_remove_group(&dev->kobj, &zocl_kds_group);
+	kds_fini_sched(&zdev->kds);
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -21,9 +21,6 @@ MODULE_PARM_DESC(kds_mode,
 		 "enable new KDS (0 = disable (default), 1 = enable)");
 
 int kds_echo = 0;
-module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
-MODULE_PARM_DESC(kds_echo,
-		 "enable KDS echo (0 = disable (default), 1 = enable)");
 
 static inline void
 zocl_ctx_to_info(struct drm_zocl_ctx *args, struct kds_ctx_info *info)

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -30,44 +30,6 @@ static ssize_t xclbinid_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(xclbinid);
 
-extern int kds_mode; /* This could be removed with old kds */
-extern int kds_echo;
-
-static ssize_t
-kds_echo_show(struct device *dev, struct device_attribute *attr, char *buf)
-{
-	return sprintf(buf, "%d\n", kds_echo);
-}
-
-static ssize_t
-kds_echo_store(struct device *dev, struct device_attribute *da,
-	       const char *buf, size_t count)
-{
-	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
-	u32 enable;
-	u32 clients;
-
-	if (kds_mode)
-		clients = kds_live_clients(&zdev->kds, NULL);
-	else
-		clients = sched_live_clients(zdev, NULL);
-
-	/* Ideally, KDS should be locked to reject new client.
-	 * But, this node is hidden for internal test purpose.
-	 * Let's refine it after new KDS is the default and
-	 * user is allow to configure it through xbutil.
-	 */
-	if (clients > 0)
-		return -EBUSY;
-
-	if (kstrtou32(buf, 10, &enable) == -EINVAL || enable > 1)
-		return -EINVAL;
-
-	kds_echo = enable;
-	return count;
-}
-static DEVICE_ATTR(kds_echo, 0644, kds_echo_show, kds_echo_store);
-
 static ssize_t kds_numcus_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
@@ -187,7 +149,6 @@ static DEVICE_ATTR_RO(memstat_raw);
 
 static struct attribute *zocl_attrs[] = {
 	&dev_attr_xclbinid.attr,
-	&dev_attr_kds_echo.attr,
 	&dev_attr_kds_numcus.attr,
 	&dev_attr_kds_custat.attr,
 	&dev_attr_memstat.attr,

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -30,6 +30,44 @@ static ssize_t xclbinid_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(xclbinid);
 
+extern int kds_mode; /* This could be removed with old kds */
+extern int kds_echo;
+
+static ssize_t
+kds_echo_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", kds_echo);
+}
+
+static ssize_t
+kds_echo_store(struct device *dev, struct device_attribute *da,
+	       const char *buf, size_t count)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	u32 enable;
+	u32 clients;
+
+	if (kds_mode)
+		clients = kds_live_clients(&zdev->kds, NULL);
+	else
+		clients = sched_live_clients(zdev, NULL);
+
+	/* Ideally, KDS should be locked to reject new client.
+	 * But, this node is hidden for internal test purpose.
+	 * Let's refine it after new KDS is the default and
+	 * user is allow to configure it through xbutil.
+	 */
+	if (clients > 0)
+		return -EBUSY;
+
+	if (kstrtou32(buf, 10, &enable) == -EINVAL || enable > 1)
+		return -EINVAL;
+
+	kds_echo = enable;
+	return count;
+}
+static DEVICE_ATTR(kds_echo, 0644, kds_echo_show, kds_echo_store);
+
 static ssize_t kds_numcus_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
@@ -149,6 +187,7 @@ static DEVICE_ATTR_RO(memstat_raw);
 
 static struct attribute *zocl_attrs[] = {
 	&dev_attr_xclbinid.attr,
+	&dev_attr_kds_echo.attr,
 	&dev_attr_kds_numcus.attr,
 	&dev_attr_kds_custat.attr,
 	&dev_attr_memstat.attr,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -257,6 +257,8 @@ static inline u64 xocl_pci_rebar_size_to_bytes(int size)
 }
 
 /* KDS functions */
+int xocl_init_sched(struct xocl_dev *xdev);
+void xocl_fini_sched(struct xocl_dev *xdev);
 int xocl_create_client(struct xocl_dev *xdev, void **priv);
 void xocl_destroy_client(struct xocl_dev *xdev, void **priv);
 int xocl_client_ioctl(struct xocl_dev *xdev, int op, void *data,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1362,7 +1362,7 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 
 	unmap_bar(xdev);
 
-	kds_fini_sched(&XDEV(xdev)->kds);
+	xocl_fini_sched(xdev);
 
 	xocl_subdev_fini(xdev);
 	if (xdev->ulp_blob)
@@ -1419,7 +1419,7 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 		goto failed;
 	}
 
-	(void) kds_init_sched(&XDEV(xdev)->kds);
+	(void) xocl_init_sched(xdev);
 
 	ret = xocl_config_pci(xdev);
 	if (ret)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -20,6 +20,40 @@ MODULE_PARM_DESC(kds_mode,
  */
 int kds_echo = 0;
 
+/* -KDS sysfs-- */
+static ssize_t
+kds_echo_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", kds_echo);
+}
+
+static ssize_t
+kds_echo_store(struct device *dev, struct device_attribute *da,
+	       const char *buf, size_t count)
+{
+	struct xocl_dev *xdev = dev_get_drvdata(dev);
+	u32 clients = 0;
+
+	/* TODO: this should be as simple as */
+	/* return stroe_kds_echo(&XDEV(xdev)->kds, buf, count); */
+
+	if (!kds_mode)
+		clients = get_live_clients(xdev, NULL);
+
+	return store_kds_echo(&XDEV(xdev)->kds, buf, count,
+			      kds_mode, clients, &kds_echo);
+}
+static DEVICE_ATTR(kds_echo, 0644, kds_echo_show, kds_echo_store);
+
+static struct attribute *kds_attrs[] = {
+	&dev_attr_kds_echo.attr,
+	NULL,
+};
+
+static struct attribute_group xocl_kds_group = {
+	.attrs = kds_attrs,
+};
+
 static inline void
 xocl_ctx_to_info(struct drm_xocl_ctx *args, struct kds_ctx_info *info)
 {
@@ -273,6 +307,26 @@ int xocl_client_ioctl(struct xocl_dev *xdev, int op, void *data,
 	}
 
 	return ret;
+}
+
+int xocl_init_sched(struct xocl_dev *xdev)
+{
+	struct device *dev = &xdev->core.pdev->dev;
+	int ret;
+
+	ret = sysfs_create_group(&dev->kobj, &xocl_kds_group);
+	if (ret)
+		userpf_err(dev, "create kds attrs failed: %d", ret);
+
+	return kds_init_sched(&XDEV(xdev)->kds);
+}
+
+void xocl_fini_sched(struct xocl_dev *xdev)
+{
+	struct device *dev = &xdev->core.pdev->dev;
+
+	sysfs_remove_group(&dev->kobj, &xocl_kds_group);
+	kds_fini_sched(&XDEV(xdev)->kds);
 }
 
 int xocl_kds_stop(struct xocl_dev *xdev)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -15,10 +15,10 @@ module_param(kds_mode, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_mode,
 		 "enable new KDS (0 = disable (default), 1 = enable)");
 
+/* kds_echo also impact mb_scheduler.c, keep this as global.
+ * Let's move it to struct kds_sched in the future.
+ */
 int kds_echo = 0;
-module_param(kds_echo, int, (S_IRUGO|S_IWUSR));
-MODULE_PARM_DESC(kds_echo,
-		 "enable KDS echo (0 = disable (default), 1 = enable)");
 
 static inline void
 xocl_ctx_to_info(struct drm_xocl_ctx *args, struct kds_ctx_info *info)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -58,44 +58,6 @@ static ssize_t user_pf_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(user_pf);
 
-/* -KSD sysfs-- */
-extern int kds_mode; /* This could be removed with old kds */
-extern int kds_echo;
-static ssize_t
-kds_echo_show(struct device *dev, struct device_attribute *attr, char *buf)
-{
-	return sprintf(buf, "%d\n", kds_echo);
-}
-
-static ssize_t
-kds_echo_store(struct device *dev, struct device_attribute *da,
-	       const char *buf, size_t count)
-{
-	struct xocl_dev *xdev = dev_get_drvdata(dev);
-	u32 enable;
-	u32 clients;
-
-	if (kds_mode)
-		clients = xocl_kds_live_clients(xdev, NULL);
-	else
-		clients = get_live_clients(xdev, NULL);
-
-	/* Ideally, KDS should be locked to reject new client.
-	 * But, this node is hidden for internal test purpose.
-	 * Let's refine it after new KDS is the default and
-	 * user is allow to configure it through xbutil.
-	 */
-	if (clients > 0)
-		return -EBUSY;
-
-	if (kstrtou32(buf, 10, &enable) == -EINVAL || enable > 1)
-		return -EINVAL;
-
-	kds_echo = enable;
-	return count;
-}
-static DEVICE_ATTR(kds_echo, 0644, kds_echo_show, kds_echo_store);
-
 /* -live client contexts-- */
 static ssize_t kdsstat_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
@@ -557,7 +519,6 @@ static DEVICE_ATTR_WO(mig_cache_update);
 static struct attribute *xocl_attrs[] = {
 	&dev_attr_xclbinuuid.attr,
 	&dev_attr_userbar.attr,
-	&dev_attr_kds_echo.attr,
 	&dev_attr_kdsstat.attr,
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,


### PR DESCRIPTION
A quick solution for use sysfs node to turn echo mode on/off.

Root privilege is need to write this node.
It is possible to create xbutil command to configure KDS, instead of use xrt.ini.