### PR TITLE
NSPR-7258 Streamline PDI download from host to VCK5000 via mgmt only PF

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -416,13 +416,6 @@ inline std::string
 get_sw_em_driver()
 {
   static std::string value = detail::get_string_value("Runtime.sw_em_driver","null");
-  return value;
-}
-
-inline bool
-get_pdi_load()
-{
-  static bool value = detail::get_bool_value("Runtime.pdi_load",true);
   return value;
 }
 

--- a/src/runtime_src/core/common/drv/include/xrt_drv.h
+++ b/src/runtime_src/core/common/drv/include/xrt_drv.h
@@ -28,12 +28,34 @@
 #define XRT_DRV_BO_CMA		(1 << 24)
 #define XRT_DRV_BO_CACHEABLE	(1 << 23)
 
-#define	XRT_PDI_PKT_STATUS_IDLE		0
-#define	XRT_PDI_PKT_STATUS_NEW		1
-#define	XRT_PDI_PKT_STATUS_DONE		2
-#define	XRT_PDI_PKT_STATUS_FAIL		3
+/* Versal transfer cache packet definition */
 
-#define	XRT_PDI_PKT_FLAGS_LAST		(1 << 0)
+#define	XRT_XFR_VER			1
+
+/*
+ * Note: we should keep the existing PKT status and flags
+ *       stable to not breaking the old versal platform
+ */
+#define	XRT_XFR_PKT_STATUS_IDLE		0
+#define	XRT_XFR_PKT_STATUS_NEW		1
+#define	XRT_XFR_PKT_STATUS_DONE		2
+#define	XRT_XFR_PKT_STATUS_FAIL		3
+
+#define	XRT_XFR_PKT_TYPE_SHIFT		1
+#define	XRT_XFR_PKT_TYPE_MASK		7
+
+#define	XRT_XFR_PKT_VER_SHIFT		4
+#define	XRT_XFR_PKT_VER_MASK		3
+
+#define	XRT_XFR_PKT_TYPE_PDI		0
+#define	XRT_XFR_PKT_TYPE_XCLBIN		1
+
+#define	XRT_XFR_PKT_FLAGS_LAST		(1 << 0)
+#define	XRT_XFR_PKT_FLAGS_PDI		(XRT_XFR_PKT_TYPE_PDI << \
+	XRT_XFR_PKT_TYPE_SHIFT)
+#define	XRT_XFR_PKT_FLAGS_XCLBIN	(XRT_XFR_PKT_TYPE_XCLBIN << \
+	XRT_XFR_PKT_TYPE_SHIFT)
+#define	XRT_XFR_PKT_FLAGS_VER		(XRT_XFR_VER << XRT_XFR_PKT_VER_SHIFT)
 
 struct pdi_packet {
 	union {

--- a/src/runtime_src/core/edge/drm/zocl/include/sched_exec.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/sched_exec.h
@@ -267,6 +267,7 @@ struct sched_ops {
 int sched_init_exec(struct drm_device *drm);
 int sched_fini_exec(struct drm_device *drm);
 int sched_reset_exec(struct drm_device *drm);
+int sched_reset_scheduler(struct drm_device *drm);
 
 void zocl_track_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 void zocl_untrack_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_cu.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_cu.h
@@ -2,7 +2,7 @@
 /*
  * Compute unit structures.
  *
- * Copyright (C) 2019 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Min Ma <min.ma@xilinx.com>
@@ -43,9 +43,7 @@ struct zocl_cu;
 /* Supported CU models */
 enum zcu_model {
 	MODEL_ACC,
-	MODEL_HLS_SOFT,
-	MODEL_HLS_HARD,
-	MODEL_HLS_FULL,
+	MODEL_HLS,
 };
 
 enum zcu_configure_type {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -206,6 +206,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp);
 int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp);
+struct platform_device *zocl_find_pdev(char *name);
 
 /* CU controller */
 int cu_ctrl_init(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert.h
@@ -191,11 +191,6 @@ struct zocl_ert_ops {
 	 */
 	void (*update_cmd)(struct zocl_ert_dev *ert, int idx,
 			    void *data, int sz);
-
-	/**
-	 * if this platform is static or dynamic
-	 */
-	int (*static_xclbin)(void);
 };
 
 struct zocl_ert_info {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ospi_versal.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ospi_versal.h
@@ -30,7 +30,7 @@ struct zocl_ov_pkt_node {
  * @size:	PDI packet area size
  * @pdi_ready:	flag to indicate PDI image is ready
  * @pdi_done:	flag to indicate PDI flashing is done
- * @pdev: 	platform_device
+ * @pdev:	platform_device
  * @head:	head node of PDI packet linked list
  */
 struct zocl_ov_dev {
@@ -40,7 +40,13 @@ struct zocl_ov_dev {
 	u8			pdi_ready;
 	u8			pdi_done;
 	rwlock_t		att_rwlock;
+
+	/* platform device */
 	struct platform_device  *pdev;
+
+	/* parent platform device */
+	struct platform_device	*ppdev;
+
 	struct zocl_ov_pkt_node	*head;
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -52,7 +52,6 @@
 
 static int cq_check(void *data);
 static irqreturn_t sched_cq_isr(int irq, void *arg);
-static void zocl_cu_reclaim(struct drm_zocl_dev *zdev);
 
 /* Scheduler call schedule() every MAX_SCHED_LOOP loop*/
 #define MAX_SCHED_LOOP 8
@@ -751,7 +750,6 @@ configure(struct sched_cmd *cmd)
 	int cq_irq;
 	int acc_cu = 0;
 	int has_acc_cu = 0;
-	int has_dynamic_region = 0;
 	int apt_idx, irq_id;
 	bool is_legacy_intr = true;
 	int ret;
@@ -799,26 +797,6 @@ configure(struct sched_cmd *cmd)
 	} else {
 		SCHED_DEBUG("++ configuring PS ERT mode\n");
 
-		/*
-		 * Block comment for the big picture of ert with static or
-		 * dynamic xclbins.
-		 *   - versal ERT defer dynamic region xclbin download, so we
-		 *     call init_cu_soft in configure and defer the
-		 *     init_cu_hard till pdi is downloaded via softkernel.
-		 *   - other ERT will load xclbin first then call configure, so
-		 *     that we call init_cu_full in configure.
-		 */
-		if (zdev->ert->ops->static_xclbin()) {
-			exec->configured = 1;
-		} else {
-			/*
-			 * dynamic xclbin like versal, the procedure is:
-			 * loalxclbin->scheduler:init->configure->load_pdi.
-			 */
-			zocl_cu_reclaim(zdev);
-			has_dynamic_region = 1;
-		}
-
 		exec->ops = &ps_ert_ops;
 		exec->polling_mode = cfg->polling;
 		exec->cq_interrupt = cfg->cq_int;
@@ -830,9 +808,13 @@ configure(struct sched_cmd *cmd)
 		DRM_INFO("  host_polling_mode(%d)", exec->polling_mode);
 		DRM_INFO("  cq_interrupt(%d)", exec->cq_interrupt);
 		zdev->ert->ops->config(zdev->ert, cfg);
+		exec->configured = 1;
 	}
 
-	/* Note: for current design: the slot_size can be not 4k, but cq_size is always 64k. */
+	/*
+	 * Note: for current design: the slot_size can be not 4k,
+	 * but cq_size is always 64k.
+	 */
 	exec->num_slots       = CQ_SIZE / cfg->slot_size;
 	exec->num_cus         = cfg->num_cus;
 	exec->cu_shift_offset = cfg->cu_shift;
@@ -927,17 +909,8 @@ configure(struct sched_cmd *cmd)
 		    i, (uint64_t)zdev->res_start, (uint64_t)cu_addr);
 		cu_addr = zdev->res_start + cu_addr;
 
-		/*
-		 * has_dynamic_region is a flag for ERT only. If it is set, the
-		 * cu_init should not touch any hardware during configure
-		 * because the dynamic region has not been configured by later
-		 * softkernel command yet. After softkernel command has been
-		 * done with dynamic region downloaed, making sure cu_init_hard
-		 * will be called.
-		 */
 		if (!acc_cu)
-			zocl_cu_init(&exec->zcu[i], has_dynamic_region ?
-			    MODEL_HLS_SOFT : MODEL_HLS_FULL, cu_addr|control);
+			zocl_cu_init(&exec->zcu[i], MODEL_HLS, cu_addr|control);
 		else {
 			zocl_cu_init(&exec->zcu[i], MODEL_ACC, cu_addr);
 			/* ACCEL adapter CU initial finished.
@@ -1099,26 +1072,6 @@ zocl_cu_reclaim(struct drm_zocl_dev *zdev)
 	vfree(zdev->exec->zcu);
 }
 
-/*
- * Probe any deferred cu initiation due to dynamic region has not been enabled
- * yet by early prevision time. After dynamic region is enabled, we should
- * continue to accessing cu hardware address safely.
- */
-static void
-zocl_cu_probe(struct sched_cmd *cmd)
-{
-	struct drm_zocl_dev *zdev = cmd->ddev->dev_private;
-	struct sched_exec_core *exec = zdev->exec;
-	int i;
-
-	for (i = 0; i < exec->num_cus; i++) {
-		if (zocl_cu_is_valid(exec, i) &&
-		    exec->zcu[i].model == MODEL_HLS_SOFT) {
-			zocl_cu_init(&exec->zcu[i], MODEL_HLS_HARD, (phys_addr_t)NULL);
-		}
-	}
-}
-
 static int
 configure_soft_kernel(struct sched_cmd *cmd)
 {
@@ -1132,30 +1085,6 @@ configure_soft_kernel(struct sched_cmd *cmd)
 	SCHED_DEBUG("-> %s", __func__);
 
 	cfg = (struct ert_configure_sk_cmd *)(cmd->packet);
-
-	if (cfg->sk_type == SOFTKERNEL_TYPE_XCLBIN_STATIC) {
-		zocl_cu_probe(cmd);
-		return 0;
-	}
-	if (cfg->sk_type == SOFTKERNEL_TYPE_XCLBIN_DYNAMIC) {
-		void *xclbin_buffer = NULL;
-
-		/* remap device physical addr to kernel virtual addr */
-		xclbin_buffer =
-		    memremap(cfg->sk_addr, cfg->sk_size, MEMREMAP_WC);
-		if (xclbin_buffer == NULL) {
-			ret = -ENOMEM;
-			goto fail;
-		}
-		mutex_lock(&zdev->zdev_xclbin_lock);
-		ret = zocl_xclbin_load_pdi(zdev, xclbin_buffer);
-		mutex_unlock(&zdev->zdev_xclbin_lock);
-		memunmap(xclbin_buffer);
-		if (!ret)
-			zocl_cu_probe(cmd);
-		return ret;
-	}
-
 
 	mutex_lock(&sk->sk_lock);
 
@@ -2874,7 +2803,7 @@ zocl_execbuf_to_ert(struct drm_zocl_bo *bo, struct drm_file *filp)
  * @dev: Device node calling execbuf
  * @bo: buffer objects from user space from which new command is created
  *
-*/
+ */
 static bool
 zocl_dma_check(struct drm_device *dev, struct drm_zocl_bo *bo)
 {
@@ -3332,6 +3261,31 @@ int sched_fini_exec(struct drm_device *drm)
 	fini_scheduler_thread();
 	zocl_cleanup_cu_timer(zdev);
 	SCHED_DEBUG("<- %s\n", __func__);
+
+	return 0;
+}
+
+/*
+ * A simplified version of reset scheduler. This is to support DFX on
+ * Hybrid-platform which is running in ert mode. All the context and
+ * command draining are managed by host side XRT.
+ */
+int
+sched_reset_scheduler(struct drm_device *drm)
+{
+	struct drm_zocl_dev *zdev = drm->dev_private;
+	struct sched_exec_core *exec = zdev->exec;
+
+	DRM_INFO("%s: stop scheduler", __func__);
+
+	/* Once stopped, keep this status until reset done */
+	atomic_set(&exec->exec_status, ZOCL_EXEC_STOP);
+
+	fini_configure(drm);
+	init_exec(exec);
+
+	/* start receiving cmds */
+	atomic_set(&exec->exec_status, ZOCL_EXEC_NORMAL);
 
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -96,27 +96,6 @@ match_name(struct device *dev, void *data)
 }
 
 /**
- * find_pdev - Find platform device by name
- *
- * @name: device name
- *
- * Returns a platform device. Returns NULL if not found.
- */
-static struct platform_device *find_pdev(char *name)
-{
-	struct device *dev;
-	struct platform_device *pdev;
-
-	dev = bus_find_device(&platform_bus_type, NULL, (void *)name,
-	    match_name);
-	if (!dev)
-		return NULL;
-
-	pdev = container_of(dev, struct platform_device, dev);
-	return pdev;
-}
-
-/**
  * get_reserved_mem_region - Get reserved memory region
  *
  * @dev: device struct
@@ -139,6 +118,27 @@ static int get_reserved_mem_region(struct device *dev, struct resource *res)
 		return -EINVAL;
 
 	return 0;
+}
+
+/**
+ * zocl_find_pdev - Find platform device by name
+ *
+ * @name: device name
+ *
+ * Returns a platform device. Returns NULL if not found.
+ */
+struct platform_device *zocl_find_pdev(char *name)
+{
+	struct device *dev;
+	struct platform_device *pdev;
+
+	dev = bus_find_device(&platform_bus_type, NULL, (void *)name,
+	    match_name);
+	if (!dev)
+		return NULL;
+
+	pdev = container_of(dev, struct platform_device, dev);
+	return pdev;
 }
 
 /**
@@ -837,7 +837,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	}
 	mutex_init(&zdev->mm_lock);
 
-	subdev = find_pdev("ert_hw");
+	subdev = zocl_find_pdev("ert_hw");
 	if (subdev) {
 		DRM_INFO("ert_hw found: 0x%llx\n", (uint64_t)(uintptr_t)subdev);
 		/* Trust device tree for now, but a better place should be

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ert.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Min Ma <min.ma@xilinx.com>
@@ -102,7 +102,7 @@ ert_mpsoc_next(struct zocl_ert_dev *ert, struct ert_packet *pkg, int *idx_ret)
 	} else {
 		/* ERT mode is only for 64 bits system */
 		slot_info = ((u64)pkg - (u64)ert->cq_ioremap);
-		do_div(slot_info,slot_sz);
+		do_div(slot_info, slot_sz);
 		slot_idx = slot_info;
 	}
 
@@ -205,18 +205,6 @@ update_cmd(struct zocl_ert_dev *ert, int idx, void *data, int sz)
 	memcpy_toio(pkg->data, data, sz);
 }
 
-static int
-ert_mpsoc_xclbin(void)
-{
-	return 1;
-}
-
-static int
-ert_versal_xclbin(void)
-{
-	return 0;
-}
-
 static struct zocl_ert_ops mpsoc_ops = {
 	.init         = ert_mpsoc_init,
 	.fini         = ert_mpsoc_fini,
@@ -224,7 +212,6 @@ static struct zocl_ert_ops mpsoc_ops = {
 	.get_next_cmd = ert_mpsoc_next,
 	.notify_host  = ert_mpsoc_notify_host,
 	.update_cmd   = update_cmd,
-	.static_xclbin	= ert_mpsoc_xclbin,
 };
 
 static struct zocl_ert_ops versal_ops = {
@@ -234,7 +221,6 @@ static struct zocl_ert_ops versal_ops = {
 	.get_next_cmd = ert_versal_next,
 	.notify_host  = ert_versal_notify_host,
 	.update_cmd   = update_cmd,
-	.static_xclbin	= ert_versal_xclbin,
 };
 
 static const struct zocl_ert_info mpsoc_ert_info = {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
@@ -18,6 +18,8 @@
 
 #include "zocl_drv.h"
 #include "xrt_drv.h"
+#include "sched_exec.h"
+#include "zocl_xclbin.h"
 #include "zocl_ospi_versal.h"
 
 #define ov_err(pdev, fmt, args...)  \
@@ -41,6 +43,16 @@ static inline u32 wait_for_status(struct zocl_ov_dev *ov, u8 status)
 	return header;
 }
 
+static inline u8 get_pkt_flags(struct zocl_ov_dev *ov)
+{
+	struct pdi_packet *pkt;
+	u32 header;
+
+	pkt = (struct pdi_packet *)&header;
+	header = ioread32(ov->base);
+	return pkt->pkt_flags;
+}
+
 static inline bool check_for_status(struct zocl_ov_dev *ov, u8 status)
 {
 	struct pdi_packet *pkt;
@@ -51,12 +63,33 @@ static inline bool check_for_status(struct zocl_ov_dev *ov, u8 status)
 	return (pkt->pkt_status == status);
 }
 
+static inline void set_flags(struct zocl_ov_dev *ov, u8 flags)
+{
+	struct pdi_packet *pkt;
+	u32 header;
+
+	pkt = (struct pdi_packet *)&header;
+	header = ioread32(ov->base);
+	pkt->pkt_flags = flags;
+
+	iowrite32(pkt->header, ov->base);
+}
+
+static inline void set_version(struct zocl_ov_dev *ov)
+{
+	set_flags(ov, XRT_XFR_VER <<  XRT_XFR_PKT_VER_SHIFT);
+}
+
 static inline void set_status(struct zocl_ov_dev *ov, u8 status)
 {
-	struct pdi_packet pkt;
+	struct pdi_packet *pkt;
+	u32 header;
 
-	pkt.pkt_status = status;
-	iowrite32(pkt.header, ov->base);
+	pkt = (struct pdi_packet *)&header;
+	header = ioread32(ov->base);
+	pkt->pkt_status = status;
+
+	iowrite32(pkt->header, ov->base);
 }
 
 static inline void read_data(u32 *addr, u32 *data, size_t sz)
@@ -83,30 +116,63 @@ static void zocl_ov_clean(struct zocl_ov_dev *ov)
 	ov->head = NULL;
 }
 
-/*
- * This function is called once we detect there is a new PDI packet and it
- * will communicate with host driver to collect all PDI packets and then
- * communicate with user space daemon to flash the PDI.
- *
- * 1) start receiving PDI packets
- * 2) put all pdi packets into a linked packets list
- * 3) once got all packets, update sysfs node to indicate PDI is ready
- * 4) wait on sysfs node on PDI flash done
- * 5) update PDI packet status to notify host
- */
-static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
+static int zocl_ov_find_parent_dev(struct zocl_ov_dev *ov)
+{
+	struct platform_device *parent_dev;
+
+	parent_dev = zocl_find_pdev("zyxclmm_drm");
+	if (parent_dev) {
+		ov_info(ov->pdev, "Found parent pdev zyxclmm_drv: 0x%llx",
+		    (uint64_t)(uintptr_t)parent_dev);
+		ov->ppdev = parent_dev;
+		return 0;
+	}
+
+	ov_err(ov->pdev, "Can NOT find parent pdev zyxclmm_drv");
+
+	ov->ppdev = NULL;
+	return -ENXIO;
+}
+
+static int zocl_ov_copy_xclbin(struct zocl_ov_dev *ov, struct axlf **xclbin)
+{
+	struct zocl_ov_pkt_node *node = ov->head;
+	char *xp;
+	size_t len = 0;
+
+	while (node) {
+		len += node->zn_size;
+		node = node->zn_next;
+	}
+
+	if (len == 0) {
+		ov_err(ov->pdev, "Load xclbin failed: size is 0");
+		return -EINVAL;
+	}
+
+	*xclbin = vmalloc(len);
+	if (!(*xclbin)) {
+		ov_err(ov->pdev, "Load xclbin failed to allocate buf");
+		return -ENOMEM;
+	}
+
+	xp = (char *)*xclbin;
+	node = ov->head;
+	while (node) {
+		memcpy(xp, node->zn_datap, node->zn_size);
+		xp += node->zn_size;
+		node = node->zn_next;
+	}
+
+	return 0;
+}
+
+static int zocl_ov_recieve(struct zocl_ov_dev *ov)
 {
 	struct zocl_ov_pkt_node *node = ov->head;
 	u32 *base = ov->base;
-	int ret;
 	int len = 0, next = 0;
-
-	/* Clear the done flag */
-	write_lock(&ov->att_rwlock);
-	ov->pdi_done = 0;
-	write_unlock(&ov->att_rwlock);
-
-	ov_info(ov->pdev, "pdi is being downloaded...");
+	int ret;
 
 	for (;;) {
 		u32 pkt_header;
@@ -114,19 +180,17 @@ static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
 		struct zocl_ov_pkt_node *new;
 
 		/* Busy wait here until we get a new packet */
-		pkt_header = wait_for_status(ov, XRT_PDI_PKT_STATUS_NEW);
+		pkt_header = wait_for_status(ov, XRT_XFR_PKT_STATUS_NEW);
 
 		new = vzalloc(sizeof(struct zocl_ov_pkt_node));
 		if (!new) {
-			set_status(ov, XRT_PDI_PKT_STATUS_FAIL);
 			ret = -ENOMEM;
-			goto fail;
+			break;
 		}
 		new->zn_datap = vmalloc(ov->size);
 		if (!new->zn_datap) {
-			set_status(ov, XRT_PDI_PKT_STATUS_FAIL);
 			ret = -ENOMEM;
-			goto fail;
+			break;
 		}
 		new->zn_size = pkt->pkt_size;
 
@@ -135,7 +199,7 @@ static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
 		    new->zn_datap, (ov->size - sizeof(struct pdi_packet)) / 4);
 
 		/* Notify host that the data has been read */
-		set_status(ov, XRT_PDI_PKT_STATUS_IDLE);
+		set_status(ov, XRT_XFR_PKT_STATUS_IDLE);
 
 		len += ov->size;
 		if ((len / 1000000) > next) {
@@ -151,14 +215,122 @@ static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
 		node = new;
 
 		/* Bail out here if this is the last packet */
-		if (pkt->pkt_flags & XRT_PDI_PKT_FLAGS_LAST)
+		if (pkt->pkt_flags & XRT_XFR_PKT_FLAGS_LAST) {
+			ret = 0;
 			break;
+		}
+	}
+
+	return ret;
+}
+
+/*
+ * This function is called once we detect there is a new XCLBIN packet and it
+ * will communicate with host driver to collect all XCLBIN packets and then
+ * call zocl driver service to load this xclbin.
+ *
+ * 1) start receiving XCLBIN packets
+ * 2) put all XCLBIN packets into a linked packets list
+ * 3) once got all packets, copy XCLBIN packets to a XCLBIN buffer
+ * 4) call zocl driver service to load XCLBIN
+ * 5) update XCLBIN packet status to notify host
+ */
+static int zocl_ov_get_xclbin(struct zocl_ov_dev *ov)
+{
+	struct axlf *xclbin = NULL;
+	void *pdrv;
+	int ret = 0;
+
+	ov_info(ov->pdev, "xclbin is being downloaded...");
+
+	write_lock(&ov->att_rwlock);
+
+	ret = zocl_ov_recieve(ov);
+	if (ret) {
+		set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
+		ov_err(ov->pdev, "Fail to recieve XCLBIN file %d", ret);
+		goto out;
+	}
+
+	ov_info(ov->pdev, "XCLBIN is transfered");
+
+	ret = zocl_ov_copy_xclbin(ov, &xclbin);
+	if (ret) {
+		set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
+		goto out;
+	}
+
+	if (!ov->ppdev) {
+		ret = zocl_ov_find_parent_dev(ov);
+		if (ret) {
+			set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
+			goto out;
+		}
+	}
+
+	pdrv = platform_get_drvdata(ov->ppdev);
+	if (!pdrv) {
+		ov_err(ov->pdev, "Fail to get parent dev driver data");
+		set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
+		ret = -ENXIO;
+		goto out;
+	}
+
+	write_unlock(&ov->att_rwlock);
+	ret = zocl_xclbin_load_pdi(pdrv, xclbin);
+	if (ret) {
+		set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
+		goto out;
+	}
+	write_lock(&ov->att_rwlock);
+
+	ov_info(ov->pdev, "xclbin_done: %d", ov->pdi_done);
+
+	set_status(ov, XRT_XFR_PKT_STATUS_DONE);
+
+out:
+	zocl_ov_clean(ov);
+	write_unlock(&ov->att_rwlock);
+	vfree(xclbin);
+
+	wait_for_status(ov, XRT_XFR_PKT_STATUS_IDLE);
+	set_version(ov);
+
+	return ret;
+}
+
+/*
+ * This function is called once we detect there is a new PDI packet and it
+ * will communicate with host driver to collect all PDI packets and then
+ * communicate with user space daemon to flash the PDI.
+ *
+ * 1) start receiving PDI packets
+ * 2) put all pdi packets into a linked packets list
+ * 3) once got all packets, update sysfs node to indicate PDI is ready
+ * 4) wait on sysfs node on PDI flash done
+ * 5) update PDI packet status to notify host
+ */
+static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
+{
+	int ret;
+
+	ov_info(ov->pdev, "pdi is being downloaded...");
+
+	/* Clear the done flag */
+	write_lock(&ov->att_rwlock);
+	ov->pdi_done = 0;
+
+	ret = zocl_ov_recieve(ov);
+	if (ret) {
+		write_unlock(&ov->att_rwlock);
+		set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
+		ov_err(ov->pdev, "Fail to recieve PDI file %d", ret);
+		goto fail;
 	}
 
 	ov_info(ov->pdev, "pdi is ready for ospi_daemon");
 
 	/* Set ready flag */
-	write_lock(&ov->att_rwlock);
 	ov->pdi_ready = 1;
 	write_unlock(&ov->att_rwlock);
 
@@ -178,9 +350,9 @@ static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
 			continue;
 		}
 		if (ov->pdi_done == 1)
-			set_status(ov, XRT_PDI_PKT_STATUS_DONE);
+			set_status(ov, XRT_XFR_PKT_STATUS_DONE);
 		else
-			set_status(ov, XRT_PDI_PKT_STATUS_FAIL);
+			set_status(ov, XRT_XFR_PKT_STATUS_FAIL);
 		break;
 	}
 	read_unlock(&ov->att_rwlock);
@@ -193,13 +365,18 @@ static int zocl_ov_get_pdi(struct zocl_ov_dev *ov)
 	zocl_ov_clean(ov);
 	write_unlock(&ov->att_rwlock);
 
-	wait_for_status(ov, XRT_PDI_PKT_STATUS_IDLE);
+	wait_for_status(ov, XRT_XFR_PKT_STATUS_IDLE);
+	set_version(ov);
 
 	return 0;
 
 fail:
+	write_lock(&ov->att_rwlock);
 	zocl_ov_clean(ov);
 	write_unlock(&ov->att_rwlock);
+
+	wait_for_status(ov, XRT_XFR_PKT_STATUS_IDLE);
+	set_version(ov);
 
 	return ret;
 }
@@ -207,26 +384,40 @@ fail:
 /*
  * This is the main thread in zocl ospi versal subdriver.
  *
- * The thread will wake up every second and check the PDI packet
+ * The thread will wake up every second and check the packet
  * status. If there is a new packet ready, it will start load and
- * flash PDI.
+ * handle the packets.
  */
 static int zocl_ov_thread(void *data)
 {
 	struct zocl_ov_dev *ov = (struct zocl_ov_dev *)data;
+	u8 pkt_flags, pkt_type;
 
-	set_status(ov, XRT_PDI_PKT_STATUS_IDLE);
+	set_status(ov, XRT_XFR_PKT_STATUS_IDLE);
 
 	while (1) {
 		if (kthread_should_stop())
 			break;
 
-		if (check_for_status(ov, XRT_PDI_PKT_STATUS_IDLE)) {
+		if (check_for_status(ov, XRT_XFR_PKT_STATUS_IDLE)) {
 			msleep(ZOCL_OV_TIMER_INTERVAL);
 			continue;
 		}
 
-		zocl_ov_get_pdi(ov);
+		pkt_flags = get_pkt_flags(ov);
+		pkt_type = pkt_flags >> XRT_XFR_PKT_TYPE_SHIFT &
+		    XRT_XFR_PKT_TYPE_MASK;
+		switch (pkt_type) {
+		case XRT_XFR_PKT_TYPE_PDI:
+			zocl_ov_get_pdi(ov);
+			break;
+		case XRT_XFR_PKT_TYPE_XCLBIN:
+			zocl_ov_get_xclbin(ov);
+			break;
+		default:
+			ov_err(ov->pdev, "Unknow packet type: %d", pkt_type);
+			break;
+		}
 	}
 
 	return 0;
@@ -256,7 +447,7 @@ static int zocl_ov_probe(struct platform_device  *pdev)
 	    ZOCL_OSPI_VERSAL_BRAM_RES);
 	map = devm_ioremap_resource(&pdev->dev, res);
 	if (IS_ERR(map)) {
-		ov_err(pdev, "Unable to map OSPI resource: %0lx.\n",
+		ov_err(pdev, "Unable to map OSPI resource: %0lx",
 		    PTR_ERR(map));
 		return PTR_ERR(map);
 	}
@@ -274,17 +465,19 @@ static int zocl_ov_probe(struct platform_device  *pdev)
 
 	ret = zocl_ov_init_sysfs(&pdev->dev);
 	if (ret) {
-		ov_err(pdev, "Unable to create ospi versal sysfs node.\n");
+		ov_err(pdev, "Unable to create ospi versal sysfs node");
 		kfree(ov);
 		return ret;
 	}
+
+	set_version(ov);
 
 	/* Start the thread. */
 	ov->timer_task = kthread_run(zocl_ov_thread, ov, thread_name);
 	if (IS_ERR(ov->timer_task)) {
 		ret = PTR_ERR(ov->timer_task);
 
-		ov_err(pdev, "Unable to create ospi versal thread.\n");
+		ov_err(pdev, "Unable to create ospi versal thread");
 		kfree(ov);
 		return ret;
 	}

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -413,12 +413,9 @@ enum ert_cmd_type {
  * Soft kernel types
  *
  * @SOFTKERNEL_TYPE_EXEC:       executable
- * @SOFTKERNEL_TYPE_XCLBIN:     XCLBIN data file
  */
 enum softkernel_type {
   SOFTKERNEL_TYPE_EXEC = 0,
-  SOFTKERNEL_TYPE_XCLBIN_STATIC = 1,
-  SOFTKERNEL_TYPE_XCLBIN_DYNAMIC = 2,
 };
 
 /*

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -203,7 +203,7 @@ enum {
 #define	XOCL_DMA_MSIX		"dma_msix"
 #define	XOCL_MAILBOX_VERSAL	"mailbox_versal"
 #define	XOCL_ERT		"ert"
-#define	XOCL_OSPI_VERSAL	"ospi_versal"
+#define	XOCL_XFER_VERSAL	"xfer_versal"
 #define	XOCL_AIM		"aximm_mon"
 #define	XOCL_AM			"accel_mon"
 #define	XOCL_ASM		"axistream_mon"
@@ -243,7 +243,7 @@ enum subdev_id {
 	XOCL_SUBDEV_FMGR,
 	XOCL_SUBDEV_MIG_HBM,
 	XOCL_SUBDEV_MAILBOX_VERSAL,
-	XOCL_SUBDEV_OSPI_VERSAL,
+	XOCL_SUBDEV_XFER_VERSAL,
 	XOCL_SUBDEV_CLOCK,
 	XOCL_SUBDEV_AIM,
 	XOCL_SUBDEV_AM,
@@ -1544,7 +1544,7 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
-#define	XOCL_RES_OSPI_VERSAL				\
+#define	XOCL_RES_XFER_MGMT_VERSAL				\
 		((struct resource []) {			\
 			{				\
 			.start	= 0x3008000,		\
@@ -1553,12 +1553,12 @@ struct xocl_subdev_map {
 			}				\
 		})
 
-#define	XOCL_DEVINFO_OSPI_VERSAL			\
+#define	XOCL_DEVINFO_XFER_MGMT_VERSAL			\
 	{						\
-		XOCL_SUBDEV_OSPI_VERSAL,		\
-		XOCL_OSPI_VERSAL,			\
-		XOCL_RES_OSPI_VERSAL,			\
-		ARRAY_SIZE(XOCL_RES_OSPI_VERSAL),	\
+		XOCL_SUBDEV_XFER_VERSAL,		\
+		XOCL_XFER_VERSAL,			\
+		XOCL_RES_XFER_MGMT_VERSAL,			\
+		ARRAY_SIZE(XOCL_RES_XFER_MGMT_VERSAL),	\
 		.override_idx = -1,			\
 	}
 
@@ -1775,7 +1775,7 @@ struct xocl_subdev_map {
 		 	XOCL_DEVINFO_FEATURE_ROM_VERSAL,		\
 			XOCL_DEVINFO_MAILBOX_MGMT_VERSAL,		\
 		 	XOCL_DEVINFO_XMC_VERSAL,			\
-		 	XOCL_DEVINFO_OSPI_VERSAL,			\
+		 	XOCL_DEVINFO_XFER_MGMT_VERSAL,			\
 		 	XOCL_DEVINFO_UARTLITE,				\
 		})
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -805,6 +805,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 		uint64_t xclbin_len = 0;
 		struct xcl_mailbox_bitstream_kaddr *mb_kaddr =
 			(struct xcl_mailbox_bitstream_kaddr *)req->data;
+
 		if (payload_len < sizeof(*mb_kaddr)) {
 			mgmt_err(lro, "peer request dropped, wrong size\n");
 			break;
@@ -820,7 +821,10 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			ret = -ENOMEM;
 		} else {
 			memcpy(buf, xclbin, xclbin_len);
-			ret = xocl_icap_download_axlf(lro, buf);
+			if (XOCL_DSA_IS_VERSAL(lro))
+				ret = xocl_xfer_versal_download_axlf(lro, buf);
+			else
+				ret = xocl_icap_download_axlf(lro, buf);
 			vfree(buf);
 		}
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,
@@ -1396,7 +1400,7 @@ static int (*drv_reg_funcs[])(void) __initdata = {
 	xocl_init_xmc,
 	xocl_init_dna,
 	xocl_init_fmgr,
-	xocl_init_ospi_versal,
+	xocl_init_xfer_versal,
 	xocl_init_srsr,
 	xocl_init_mem_hbm,
 	xocl_init_ulite,
@@ -1424,7 +1428,7 @@ static void (*drv_unreg_funcs[])(void) = {
 	xocl_fini_xmc,
 	xocl_fini_dna,
 	xocl_fini_fmgr,
-	xocl_fini_ospi_versal,
+	xocl_fini_xfer_versal,
 	xocl_fini_srsr,
 	xocl_fini_mem_hbm,
 	xocl_fini_ulite,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -16,11 +16,11 @@
  */
 
 /*
- * This subdriver is used to transfer Firmware Image from host memory
- * to device memory through a dedicated BRAM. This BRAM is mapped to
- * mgmt function and both drivers running on host and device can access
- * this BRAM. The first 4 Bytes of the BRAM is the packet header and
- * others are data payload.
+ * This subdriver is used to transfer data, e.g. firmware image, XCLBIN
+ * from host memory to device memory through a dedicated BRAM. This BRAM
+ * is mapped to mgmt function and both drivers running on host and device
+ * can access this BRAM. The first 4 Bytes of the BRAM is the packet
+ * header and others are data payload.
  *
  *                      ------------------
  *                     |    pkt_status    |
@@ -36,6 +36,17 @@
  *                     |      ...         |
  *                      ------------------
  *
+ *
+ * Layout of packet header
+ * 31 - 16   15 - 14   13 - 12   11 - 9    8    7 - 0
+ * -----------------------------------------------------
+ * |    |    |    |    |    |    |    |    |    |----| pkt_status
+ * |    |    |    |    |    |    |    |    |---------- pkt_flags: last packet
+ * |    |    |    |    |    |    |----|--------------- pkt_flags: pkt type
+ * |    |    |    |    |----|------------------------- pkt_flags: version
+ * |    |    |----|----------------------------------- pkt_flags: reserved
+ * |----|--------------------------------------------- pkt_size
+ *
  * The pkt_status fields are used to communication between host and
  * device driver.
  * 1) The status will be set to IDLE initially
@@ -44,73 +55,79 @@
  * 3) The device driver will read the data payload and set the status to
  *    IDEL after data has been read so that host driver can write next
  *    data...
- * 4) Once the last packet is sent, host will wait for program done
- *    status or program fail status, setting by device driver according
- *    to the result of ospi flash.
- * 5) Host driver will clear the status to IDLE for next ospi flash
+ * 4) Once the last packet is sent, host will wait for the done
+ *    status or fail status, setting by device driver according
+ *    to the result of whole package handling, where PDI image will
+ *    be handled by ospi_flash daemon; XCLBIN image will be handled
+ *    by zocl driver xclbin service.
+ * 5) Host driver will clear the status to IDLE for next data transfer
  *
  * The pkt_flags fields are used to indicate the packet attributes.
- * Currently, only one flag is used which will indicate this is the
- * last packet of the Firmware Image.
+ *	last packet flag : set if the last packet of the Data Image.
+ *	type flag        : we currently support load PDI and XCLBIN
+ *	version flag     : set by zocl to indicate the protocol version.
+ *	                   the current version is set to 1. we need this
+ *	                   field to support old shell (including golden
+ *	                   image) where there is no version field and thus
+ *	                   these fields were set to 0.
  *
  * The pkt_size fields are used to indicate the data payload size
  * in bytes.
  *
- * The pkt_data is the actual Firmware image data. The Firmware
- * image data will be split to fragments into pkt_data to fit
- * the size of BRAM.
+ * The pkt_data is the actual data image. The data image will be split
+ * to fragments into pkt_data to fit the size of BRAM.
  */
 
 #include "../xocl_drv.h"
 #include "xrt_drv.h"
 
-#define	OSPI_VERSAL_DEV_NAME "ospi_versal" SUBDEV_SUFFIX
+#define	XFER_VERSAL_DEV_NAME "xfer_versal" SUBDEV_SUFFIX
 
 /* Timer interval of checking OSPI done */
-#define OSPI_VERSAL_TIMER_INTERVAL	(1000)
+#define XFER_VERSAL_TIMER_INTERVAL	(1000)
 
-struct ospi_versal {
-	struct platform_device	*ov_pdev;
-	void __iomem		*ov_base;
-	size_t			ov_size;
-	size_t			ov_data_size;
-	bool			ov_inuse;
+struct xfer_versal {
+	struct platform_device	*xv_pdev;
+	void __iomem		*xv_base;
+	size_t			xv_size;
+	size_t			xv_data_size;
+	bool			xv_inuse;
 
-	struct mutex		ov_lock;
+	struct mutex		xv_lock;
 };
 
-#define	OV_ERR(ov, fmt, arg...)    \
-	xocl_err(&ov->ov_pdev->dev, fmt "\n", ##arg)
-#define	OV_INFO(ov, fmt, arg...)    \
-	xocl_info(&ov->ov_pdev->dev, fmt "\n", ##arg)
-#define	OV_DEBUG(ov, fmt, arg...)    \
-	xocl_dbg(&ov->ov_pdev->dev, fmt "\n", ##arg)
+#define	XV_ERR(xv, fmt, arg...)    \
+	xocl_err(&xv->xv_pdev->dev, fmt "\n", ##arg)
+#define	XV_INFO(xv, fmt, arg...)    \
+	xocl_info(&xv->xv_pdev->dev, fmt "\n", ##arg)
+#define	XV_DEBUG(xv, fmt, arg...)    \
+	xocl_dbg(&xv->xv_pdev->dev, fmt "\n", ##arg)
 
 /*
  * If return 0, we get the expected status.
  * If return -1, the status is set to FAIL.
  */
-static inline int wait_for_status(struct ospi_versal *ov, u8 status)
+static inline int wait_for_status(struct xfer_versal *xv, u8 status)
 {
 	struct pdi_packet *pkt;
 	u32 header;
 
 	pkt = (struct pdi_packet *)&header;
 	for (;;) {
-		header = ioread32(ov->ov_base);
+		header = ioread32(xv->xv_base);
 		if (pkt->pkt_status == status)
 			return 0;
-		if (pkt->pkt_status == XRT_PDI_PKT_STATUS_FAIL)
+		if (pkt->pkt_status == XRT_XFR_PKT_STATUS_FAIL)
 			return -1;
 	}
 }
 
-static inline void set_status(struct ospi_versal *ov, u8 status)
+static inline void set_status(struct xfer_versal *xv, u8 status)
 {
 	struct pdi_packet pkt;
 
 	pkt.pkt_status = status;
-	iowrite32(pkt.header, ov->ov_base);
+	iowrite32(pkt.header, xv->xv_base);
 }
 
 /*
@@ -118,18 +135,28 @@ static inline void set_status(struct ospi_versal *ov, u8 status)
  * If return 1, current status is not FAIL and 'status'
  * If return -1, the status is set to FAIL.
  */
-static inline int check_for_status(struct ospi_versal *ov, u8 status)
+static inline int check_for_status(struct xfer_versal *xv, u8 status)
 {
 	struct pdi_packet *pkt;
 	u32 header;
 
 	pkt = (struct pdi_packet *)&header;
-	header = ioread32(ov->ov_base);
+	header = ioread32(xv->xv_base);
 	if (pkt->pkt_status == status)
 		return 0;
-	if (pkt->pkt_status == XRT_PDI_PKT_STATUS_FAIL)
+	if (pkt->pkt_status == XRT_XFR_PKT_STATUS_FAIL)
 		return -1;
 	return 1;
+}
+
+static inline u8 get_pkt_flags(struct xfer_versal *xv)
+{
+	struct pdi_packet *pkt;
+	u32 header;
+
+	pkt = (struct pdi_packet *)&header;
+	header = ioread32(xv->xv_base);
+	return pkt->pkt_flags;
 }
 
 static inline void write_data(u32 *addr, u32 *data, size_t sz)
@@ -140,57 +167,42 @@ static inline void write_data(u32 *addr, u32 *data, size_t sz)
 		iowrite32(data[i], addr + i);
 }
 
-static ssize_t ospi_versal_write(struct file *filp, const char __user *data,
-	size_t data_len, loff_t *off)
+static ssize_t xfer_versal_transfer(struct xfer_versal *xv, const char *data,
+		size_t data_len, u8 flags)
 {
-	struct ospi_versal *ov = filp->private_data;
 	ssize_t len = 0, ret;
 	ssize_t remain = data_len;
 	u32 *pkt_data, pkt_size, tran_size;
-	u32 *base_addr = ov->ov_base;
+	u32 *base_addr = xv->xv_base;
 	struct pdi_packet pkt;
+	int mod;
 	int next = 0;
 
-	/* We don't support program partial of the ospi flash */
-	if (*off != 0) {
-		OV_ERR(ov, "OSPI offset is not 0: %lld", *off);
-		return -EINVAL;
-	}
+	pkt_size = xv->xv_data_size;
 
-	mutex_lock(&ov->ov_lock);
-	if (ov->ov_inuse) {
-		mutex_unlock(&ov->ov_lock);
-		OV_ERR(ov, "OSPI device is busy");
-		return -EBUSY;
-	}
-
-	ov->ov_inuse = true;
-	mutex_unlock(&ov->ov_lock);
-
-	if (wait_for_status(ov, XRT_PDI_PKT_STATUS_IDLE)) {
-		OV_ERR(ov, "OSPI device is not in proper state");
-		return -EIO;
-	}
-
-	pkt_size = ov->ov_data_size;
-	pkt_data = vmalloc(pkt_size);
-
-	OV_INFO(ov, "start writting data_len: %lu", data_len);
+	XV_INFO(xv, "start writting data_len: %lu", data_len);
 
 	while (len < data_len) {
 		tran_size = (remain > pkt_size) ? pkt_size : remain;
-		ret = copy_from_user(pkt_data, data + len, tran_size);
-		if (ret) {
-			OV_ERR(ov, "copy data failed %ld", ret);
-			goto done;
+		pkt_data = (u32 *)(data + len);
+		mod = tran_size % 4;
+
+		if (mod == 0) {
+			write_data(base_addr + (sizeof(struct pdi_packet)) / 4,
+			    pkt_data, tran_size / 4);
+		} else {
+			u32 resid;
+
+			write_data(base_addr + (sizeof(struct pdi_packet)) / 4,
+			    pkt_data, (tran_size - mod) / 4);
+			memcpy(&resid, data + data_len - mod, mod);
+			write_data(base_addr + (sizeof(struct pdi_packet)) / 4 +
+			    (tran_size / 4), &resid, 1);
 		}
 
-		write_data(base_addr + (sizeof(struct pdi_packet)) / 4,
-		    pkt_data, pkt_size / 4);
-
-		pkt.pkt_status = XRT_PDI_PKT_STATUS_NEW;
-		pkt.pkt_flags = tran_size < pkt_size ?
-		    XRT_PDI_PKT_FLAGS_LAST : 0;
+		pkt.pkt_status = XRT_XFR_PKT_STATUS_NEW;
+		pkt.pkt_flags = (tran_size < pkt_size ?
+		    XRT_XFR_PKT_FLAGS_LAST : 0) | flags;
 		pkt.pkt_size = tran_size;
 
 		/* Write data on 4 bytes base */
@@ -201,7 +213,7 @@ static ssize_t ospi_versal_write(struct file *filp, const char __user *data,
 		remain -= tran_size;
 
 		if ((len / 1000000) > next) {
-			OV_DEBUG(ov, "%lu M write %lu, remain %lu",
+			XV_INFO(xv, "%lu M write %lu, remain %lu",
 			    (len / 1000000), len, remain);
 			next++;
 		}
@@ -210,21 +222,22 @@ static ssize_t ospi_versal_write(struct file *filp, const char __user *data,
 		schedule();
 
 		/* wait until the data is fetched by device side */
-		if (wait_for_status(ov, XRT_PDI_PKT_STATUS_IDLE)) {
+		if (wait_for_status(xv, XRT_XFR_PKT_STATUS_IDLE)) {
 			ret = -EIO;
-			OV_ERR(ov, "OSPI program error");
+			XV_ERR(xv, "Data transfer error");
 			goto done;
 		}
 	}
 
-	OV_INFO(ov, "copy file to device done");
+	XV_INFO(xv, "copy file to device done");
 
-	/* wait until the ospi flash is done */
+	/* wait until the data is done */
 	while (true) {
 		int status;
-		status = check_for_status(ov, XRT_PDI_PKT_STATUS_DONE);
+
+		status = check_for_status(xv, XRT_XFR_PKT_STATUS_DONE);
 		if (status == -1) {
-			OV_ERR(ov, "OSPI program error");
+			XV_ERR(xv, "Data handle error");
 			ret = -EIO;
 			goto done;
 		}
@@ -232,147 +245,245 @@ static ssize_t ospi_versal_write(struct file *filp, const char __user *data,
 		if (status == 0)
 			break;
 
-		msleep(OSPI_VERSAL_TIMER_INTERVAL);
+		msleep(XFER_VERSAL_TIMER_INTERVAL);
 	}
 
-	OV_INFO(ov, "OSPI program is completed");
+	XV_INFO(xv, "Data transfer is completed");
 	ret = len;
-done:
-	set_status(ov, XRT_PDI_PKT_STATUS_IDLE);
 
-	vfree(pkt_data);
-	mutex_lock(&ov->ov_lock);
-	ov->ov_inuse = false;
-	mutex_unlock(&ov->ov_lock);
+done:
+	set_status(xv, XRT_XFR_PKT_STATUS_IDLE);
 
 	return ret;
 }
 
-static int ospi_versal_open(struct inode *inode, struct file *file)
+static ssize_t xfer_versal_write(struct file *filp, const char __user *udata,
+	size_t data_len, loff_t *off)
 {
-	struct ospi_versal *ov = NULL;
+	struct xfer_versal *xv = filp->private_data;
+	ssize_t ret;
+	char *kdata;
 
-	ov = xocl_drvinst_open(inode->i_cdev);
-	if (!ov)
+	/* We don't support program partial of the ospi flash */
+	if (*off != 0) {
+		XV_ERR(xv, "OSPI offset is not 0: %lld", *off);
+		return -EINVAL;
+	}
+
+	mutex_lock(&xv->xv_lock);
+	if (xv->xv_inuse) {
+		mutex_unlock(&xv->xv_lock);
+		XV_ERR(xv, "OSPI device is busy");
+		return -EBUSY;
+	}
+
+	xv->xv_inuse = true;
+	mutex_unlock(&xv->xv_lock);
+
+	if (wait_for_status(xv, XRT_XFR_PKT_STATUS_IDLE)) {
+		XV_ERR(xv, "OSPI device is not in proper state");
+		ret = -EIO;
+		goto done;
+	}
+
+	kdata = vmalloc(data_len);
+	if (!kdata) {
+		XV_ERR(xv, "Can't create xfer buffer");
+		ret = -ENOMEM;
+		goto done;
+	}
+
+	ret = copy_from_user(kdata, udata, data_len);
+	if (ret) {
+		XV_ERR(xv, "copy data failed %ld", ret);
+		goto done;
+	}
+
+	ret = xfer_versal_transfer(xv, kdata, data_len, XRT_XFR_PKT_FLAGS_PDI);
+
+done:
+	mutex_lock(&xv->xv_lock);
+	xv->xv_inuse = false;
+	mutex_unlock(&xv->xv_lock);
+	vfree(kdata);
+
+	return ret;
+}
+
+static int xfer_versal_download_axlf(struct platform_device *pdev,
+		const void *u_xclbin)
+{
+	struct xfer_versal *xv = platform_get_drvdata(pdev);
+	struct axlf *xclbin = (struct axlf *)u_xclbin;
+	uint64_t xclbin_len = xclbin->m_header.m_length;
+	u8 pkt_flags, pkt_ver;
+	int ret;
+
+	mutex_lock(&xv->xv_lock);
+	if (xv->xv_inuse) {
+		mutex_unlock(&xv->xv_lock);
+		XV_ERR(xv, "XFER device is busy");
+		return -EBUSY;
+	}
+
+	xv->xv_inuse = true;
+	mutex_unlock(&xv->xv_lock);
+
+	pkt_flags = get_pkt_flags(xv);
+	pkt_ver = pkt_flags >> XRT_XFR_PKT_VER_SHIFT & XRT_XFR_PKT_VER_MASK;
+	if (pkt_ver != XRT_XFR_VER) {
+		XV_ERR(xv, "Platform does not support load xclbin");
+		ret = -ENOTSUPP;
+		goto done;
+	}
+
+	ret = xfer_versal_transfer(xv, u_xclbin, xclbin_len,
+	    XRT_XFR_PKT_FLAGS_XCLBIN);
+	ret = ret == xclbin_len ? 0 : -EIO;
+
+done:
+	mutex_lock(&xv->xv_lock);
+	xv->xv_inuse = false;
+	mutex_unlock(&xv->xv_lock);
+
+	return ret;
+}
+
+/* Kernel APIs exported from this sub-device driver */
+static struct xocl_xfer_versal_funcs xfer_versal_ops = {
+	.download_axlf = xfer_versal_download_axlf,
+};
+
+static int xfer_versal_open(struct inode *inode, struct file *file)
+{
+	struct xfer_versal *xv = NULL;
+
+	xv = xocl_drvinst_open(inode->i_cdev);
+	if (!xv)
 		return -ENXIO;
 
-	file->private_data = ov;
+	file->private_data = xv;
 	return 0;
 }
 
-static int ospi_versal_close(struct inode *inode, struct file *file)
+static int xfer_versal_close(struct inode *inode, struct file *file)
 {
-	struct ospi_versal *ov = file->private_data;
+	struct xfer_versal *xv = file->private_data;
 
-	xocl_drvinst_close(ov);
+	xocl_drvinst_close(xv);
 	return 0;
 }
 
-static int ospi_versal_remove(struct platform_device *pdev)
+static int xfer_versal_remove(struct platform_device *pdev)
 {
-	struct ospi_versal *ov = platform_get_drvdata(pdev);
+	struct xfer_versal *xv = platform_get_drvdata(pdev);
 	void *hdl;
 	int ret = 0;
 
-	if (!ov) {
+	if (!xv) {
 		xocl_err(&pdev->dev, "driver data is NULL");
 		return -EINVAL;
 	}
 
-	xocl_drvinst_release(ov, &hdl);
-	if (ov->ov_base)
-		iounmap(ov->ov_base);
+	xocl_drvinst_release(xv, &hdl);
+	if (xv->xv_base)
+		iounmap(xv->xv_base);
 
 	platform_set_drvdata(pdev, NULL);
 	xocl_drvinst_free(hdl);
 
-	OV_INFO(ov, "return: %d", ret);
+	XV_INFO(xv, "return: %d", ret);
 	return ret;
 }
 
-static int ospi_versal_probe(struct platform_device *pdev)
+static int xfer_versal_probe(struct platform_device *pdev)
 {
-	struct ospi_versal *ov = NULL;
+	struct xfer_versal *xv = NULL;
 	struct resource *res;
 	int ret = 0;
 
-	ov = xocl_drvinst_alloc(&pdev->dev, sizeof(struct ospi_versal));
-	if (!ov)
+	xv = xocl_drvinst_alloc(&pdev->dev, sizeof(struct xfer_versal));
+	if (!xv)
 		return -ENOMEM;
-	platform_set_drvdata(pdev, ov);
-	ov->ov_pdev = pdev;
+	platform_set_drvdata(pdev, xv);
+	xv->xv_pdev = pdev;
 
-	mutex_init(&ov->ov_lock);
+	mutex_init(&xv->xv_lock);
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (!res) {
+		XV_ERR(xv, "failed to get resource");
+		return ret;
+	}
 
-	ov->ov_base = ioremap_nocache(res->start, res->end - res->start + 1);
-	if (!ov->ov_base) {
-		OV_ERR(ov, "failed to map in BRAM");
+	xv->xv_base = ioremap_nocache(res->start, res->end - res->start + 1);
+	if (!xv->xv_base) {
+		XV_ERR(xv, "failed to map in BRAM");
 		ret = -EIO;
 		goto failed;
 	}
-	ov->ov_size = res->end - res->start + 1;
-	ov->ov_data_size = ov->ov_size - sizeof(struct pdi_packet);
-	if (ov->ov_size % 4 || ov->ov_data_size % 4) {
-		OV_ERR(ov, "BRAM size is not 4 Bytes aligned");
+	xv->xv_size = res->end - res->start + 1;
+	xv->xv_data_size = xv->xv_size - sizeof(struct pdi_packet);
+	if (xv->xv_size % 4 || xv->xv_data_size % 4) {
+		XV_ERR(xv, "BRAM size is not 4 Bytes aligned");
 		ret = -EINVAL;
 		goto failed;
 	}
 
-	OV_INFO(ov, "return: %d", ret);
+	XV_INFO(xv, "return: %d", ret);
 	return 0;
 
 failed:
-	if (ov->ov_base) {
-		iounmap(ov->ov_base);
-		ov->ov_base = NULL;
+	if (xv->xv_base) {
+		iounmap(xv->xv_base);
+		xv->xv_base = NULL;
 	}
-	ospi_versal_remove(pdev);
+	xfer_versal_remove(pdev);
 
-	OV_INFO(ov, "return: %d", ret);
+	XV_INFO(xv, "return: %d", ret);
 	return ret;
 }
 
-static const struct file_operations ospi_versal_fops = {
+static const struct file_operations xfer_versal_fops = {
 	.owner = THIS_MODULE,
-	.open = ospi_versal_open,
-	.release = ospi_versal_close,
-	.write = ospi_versal_write,
+	.open = xfer_versal_open,
+	.release = xfer_versal_close,
+	.write = xfer_versal_write,
 };
 
-struct xocl_drv_private ospi_versal_priv = {
-	.fops = &ospi_versal_fops,
+struct xocl_drv_private xfer_versal_priv = {
+	.ops = &xfer_versal_ops,
+	.fops = &xfer_versal_fops,
 	.dev = -1,
 };
 
-struct platform_device_id ospi_versal_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_OSPI_VERSAL),
-	    (kernel_ulong_t)&ospi_versal_priv },
+struct platform_device_id xfer_versal_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_XFER_VERSAL),
+	    (kernel_ulong_t)&xfer_versal_priv },
 	{ },
 };
 
-static struct platform_driver	ospi_versal_driver = {
-	.probe		= ospi_versal_probe,
-	.remove		= ospi_versal_remove,
+static struct platform_driver	xfer_versal_driver = {
+	.probe		= xfer_versal_probe,
+	.remove		= xfer_versal_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_OSPI_VERSAL),
+		.name = XOCL_DEVNAME(XOCL_XFER_VERSAL),
 	},
-	.id_table = ospi_versal_id_table,
+	.id_table = xfer_versal_id_table,
 };
 
-int __init xocl_init_ospi_versal(void)
+int __init xocl_init_xfer_versal(void)
 {
 	int err = 0;
 
-	err = alloc_chrdev_region(&ospi_versal_priv.dev, 0, XOCL_MAX_DEVICES,
-	    OSPI_VERSAL_DEV_NAME);
+	err = alloc_chrdev_region(&xfer_versal_priv.dev, 0, XOCL_MAX_DEVICES,
+	    XFER_VERSAL_DEV_NAME);
 	if (err < 0)
 		return err;
 
-	err = platform_driver_register(&ospi_versal_driver);
+	err = platform_driver_register(&xfer_versal_driver);
 	if (err) {
-		unregister_chrdev_region(ospi_versal_priv.dev,
+		unregister_chrdev_region(xfer_versal_priv.dev,
 		    XOCL_MAX_DEVICES);
 		return err;
 	}
@@ -380,8 +491,8 @@ int __init xocl_init_ospi_versal(void)
 	return 0;
 }
 
-void xocl_fini_ospi_versal(void)
+void xocl_fini_xfer_versal(void)
 {
-	unregister_chrdev_region(ospi_versal_priv.dev, XOCL_MAX_DEVICES);
-	platform_driver_unregister(&ospi_versal_driver);
+	unregister_chrdev_region(xfer_versal_priv.dev, XOCL_MAX_DEVICES);
+	platform_driver_unregister(&xfer_versal_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -77,6 +77,7 @@ xocl-y := \
 	../subdev/address_translator.o \
 	../subdev/cu_ctrl.o \
 	../subdev/cu.o \
+	../subdev/ospi_versal.o \
 	$(xocl_lib-y)	\
 	$(drv_common-y) \
 	xocl_drv.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -77,7 +77,6 @@ xocl-y := \
 	../subdev/address_translator.o \
 	../subdev/cu_ctrl.o \
 	../subdev/cu.o \
-	../subdev/ospi_versal.o \
 	$(xocl_lib-y)	\
 	$(drv_common-y) \
 	xocl_drv.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1552,6 +1552,20 @@ struct xocl_flash_funcs {
 	(FLASH_CB(xdev) ?			\
 	FLASH_OPS(xdev)->get_size(FLASH_DEV(xdev), size) : -ENODEV)
 
+struct xocl_xfer_versal_funcs {
+	int (*download_axlf)(struct platform_device *pdev,
+		const void __user *arg);
+};
+
+#define	XFER_VERSAL_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL).pldev
+#define	XFER_VERSAL_OPS(xdev)					\
+	((struct xocl_xfer_versal_funcs *)SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL).ops)
+#define	XFER_VERSAL_CB(xdev)	(XFER_VERSAL_DEV(xdev) && XFER_VERSAL_OPS(xdev))
+#define	xocl_xfer_versal_download_axlf(xdev, xclbin)	\
+	(XFER_VERSAL_CB(xdev) ?					\
+	XFER_VERSAL_OPS(xdev)->download_axlf(XFER_VERSAL_DEV(xdev), xclbin) : -ENODEV)
+
+
 /* subdev mbx messages */
 #define XOCL_MSG_SUBDEV_VER	1
 #define XOCL_MSG_SUBDEV_DATA_LEN	(512 * 1024)
@@ -1775,8 +1789,8 @@ void xocl_fini_iores(void);
 int __init xocl_init_mailbox_versal(void);
 void xocl_fini_mailbox_versal(void);
 
-int __init xocl_init_ospi_versal(void);
-void xocl_fini_ospi_versal(void);
+int __init xocl_init_xfer_versal(void);
+void xocl_fini_xfer_versal(void);
 
 int __init xocl_init_aim(void);
 void xocl_fini_aim(void);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2018-2020 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *
@@ -466,10 +466,10 @@ static struct xocl_subdev_map		subdev_map[] = {
 		.devinfo_cb = NULL,
 	},
 	{
-		.id = XOCL_SUBDEV_OSPI_VERSAL,
-		.dev_name = XOCL_OSPI_VERSAL,
+		.id = XOCL_SUBDEV_XFER_VERSAL,
+		.dev_name = XOCL_XFER_VERSAL,
 		.res_names = {
-			NODE_OSPI_CACHE,
+			NODE_XFER_CACHE,
 			NULL
 		},
 		.required_ip = 1,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *
@@ -84,7 +84,7 @@
 #define NODE_DDR4_RESET_GATE "ep_ddr_mem_srsr_gate_00"
 #define NODE_ADDR_TRANSLATOR "ep_remap_data_c2h_00"
 #define NODE_MAILBOX_XRT "ep_mailbox_xrt_00"
-#define NODE_OSPI_CACHE "ep_xfer_cache_00"
+#define NODE_XFER_CACHE "ep_xfer_cache_00"
 
 #define RESNAME_GATEPLP       NODE_GATE_PLP
 #define RESNAME_PCIEMON       NODE_PCIE_MON

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2212,12 +2212,6 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
       START_DEVICE_PROFILING_CB(handle);
 #endif
     }
-    if (!ret && xrt_core::config::get_ert() &&
-        (xclbin::get_axlf_section(buffer, PDI) ||
-         xclbin::get_axlf_section(buffer, BITSTREAM_PARTIAL_PDI))) {
-      ret = xrt_core::scheduler::
-        loadXclbinToPS(handle, buffer,xrt_core::config::get_pdi_load());
-    }
     return ret;
   }
   catch (const xrt_core::error& ex) {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xospiversal.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  * Author: Larry Liu
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -43,7 +43,7 @@ int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
     binStream.seekg(0, binStream.beg);
 
     std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
-    int fd = mDev->open("ospi_versal", O_RDWR);
+    int fd = mDev->open("xfer_versal", O_RDWR);
 
     if (fd == -1) {
         std::cout << "ERROR Cannot open ospi_versal for writing " << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -37,7 +37,7 @@ int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
     
     xrt_core::scope_value_guard<int, std::function<void()>> fd { 0, nullptr };
     try {
-        fd = m_device->file_open("ospi_versal", O_RDWR); 
+        fd = m_device->file_open("xfer_versal", O_RDWR); 
     } catch (const std::exception& e) {
         xrt_core::send_exception_message(e.what(), "XBMGMT");
     }


### PR DESCRIPTION
-------------To XRT developers--------------
This PR enable loading PDI, which is packed into xclbin, via mgmt PF on VCK5000.
1) Remove the current mechanism of transferring XCLBIN through userpf by XDMA
2) Remove loadXclbinToPS and combine it into xclLoadXclbin
3) Remove supporting the "pdi_load" key in xrt.ini
4) Remove the softkernel xclbin type
5) Remove "static_xclbin" operation on MPSOC in zocl driver
6) XCLBIN will be transferred from host memory to device memory through a 32K BRAM on mgmt function. This BRAM will be shared by transferring OSPI image and XCLBIN.


-------------To VCK5000 platform team--------------
Once merged, VCK5000 platform team will need to respin a platform including device side XRT.


-------------To VCK5000 users--------------
This PR will be an incompatible change for the old platform (including golden image). You will need to update to the new platform once install host XRT with this PR.

If new host XRT operates on old platform (including golden image):
1) You will NOT be able to load your PDI. xclLoadXclbin() will return fail with -ENOTSUPP
2) You will need to use "xbmgmt flash" to update your platform

After host XRT and device platform are all up-to-date,
1) You will NOT be able to use ”pdi_load=false" to prevend XRT from load PDI. Instead, make sure your XCLBIN_MODE in your XCLBIN header is set to XCLBIN_FLAT to prevent XRT loading PDI
2) PDI load time could be a little bit longer because we use PCIe PIO to replace XDMA when transfering XCLBIN to device memory. But this will only be observed on the first time you load XCLBIN. Once loaded, same XCLBIN will not be transferred any more.
3) You will NOT be able to load XCLBIN (first time) while you are updating your OSPI image

Please report bug if you see any issue or regression.