### PR TITLE
CR-1064750 XRT WINDOWS : Timestamp mismatch not reported

### DIFF
--- a/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
@@ -35,6 +35,10 @@ DEFINE_GUID(GUID_DEVINTERFACE_XOCL_USER,
 #define XOCL_USER_DEVICE_BUFFER_OBJECT_NAMESPACE L"\\Buffer"
 #define XOCL_USER_DEVICE_DEVICE_NAMESPACE        L"\\Device"
 
+// Windows kernel return status values. The values is equal to definitions in <ntstatus.h>
+#define NTSTATUS_REVISION_MISMATCH   0xC0000059
+#define NTSTATUS_STATUS_SUCCESS      0x00000000
+
 //
 // IOCTL Codes and structures supported by XoclUser
 // 

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -24,6 +24,7 @@
 
 struct FeatureRomHeader;
 
+// Windows kernel return status values. The values is equal to definitions in <ntstatus.h>
 #define NTSTATUS_REVISION_MISMATCH   0xC0000059
 #define NTSTATUS_STATUS_SUCCESS      0x00000000
 

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -24,6 +24,9 @@
 
 struct FeatureRomHeader;
 
+#define NTSTATUS_REVISION_MISMATCH   0xC0000059
+#define NTSTATUS_STATUS_SUCCESS      0x00000000
+
 namespace userpf {
 
 XRT_CORE_PCIE_WINDOWS_EXPORT

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -24,9 +24,7 @@
 
 struct FeatureRomHeader;
 
-// Windows kernel return status values. The values is equal to definitions in <ntstatus.h>
-#define NTSTATUS_REVISION_MISMATCH   0xC0000059
-#define NTSTATUS_STATUS_SUCCESS      0x00000000
+
 
 namespace userpf {
 


### PR DESCRIPTION
CR-1064750. Because there is mismatch between the kernel return errors (NTSTATUS) and Win32 error codes the driver returns errors in the output parameters. 