### PR TITLE
Add hidden scheduler subcommand

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1745,6 +1745,7 @@ int xclValidate(int argc, char *argv[]);
 std::unique_ptr<xcldev::device> xclGetDevice(unsigned index);
 int xclP2p(int argc, char *argv[]);
 int xclCma(int argc, char *argv[]);
+int xclScheduler(int argc, char *argv[]);
 } // end namespace xcldev
 
 #endif /* XBUTIL_H */


### PR DESCRIPTION
Add 'scheduler' sub-command and root privileges is required.

How to run
Turn off kds_echo:
xbutil scheduler -e 0
Turn on kds_echo:
xbutil scheduler -e 1

Use -d to select device. 