### PR TITLE
firewall trip on 2019.1 u50 shell

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -801,7 +801,7 @@ static int clock_freeze_axi_gate(struct clock *clock, int level)
 	BUG_ON(!mutex_is_locked(&clock->clock_lock));
 
 	if (level <= XOCL_SUBDEV_LEVEL_PRP)
-		err = xocl_axigate_freeze(xdev, level);
+		err = xocl_axigate_freeze(xdev, XOCL_SUBDEV_LEVEL_PRP);
 	else
 		err = xocl_axigate_reset(xdev, XOCL_SUBDEV_LEVEL_PRP);
 
@@ -817,7 +817,7 @@ static int clock_free_axi_gate(struct clock *clock, int level)
 	BUG_ON(!mutex_is_locked(&clock->clock_lock));
 
 	if (level <= XOCL_SUBDEV_LEVEL_PRP) {
-		xocl_axigate_free(xdev, level);
+		xocl_axigate_free(xdev, XOCL_SUBDEV_LEVEL_PRP);
 	} else {
 		if (!clock->clock_ucs_control_status) {
 			CLOCK_ERR(clock, "URP clock has no %s\n",


### PR DESCRIPTION
Your concern is true, actually my code break the u50 legacy code. We should always use PRP level axigate. 

For versal clock, we will need more new code in ULP level. 