### PR TITLE
fast workaround for enabling versal validate with clock config

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -821,10 +821,20 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			ret = -ENOMEM;
 		} else {
 			memcpy(buf, xclbin, xclbin_len);
-			if (XOCL_DSA_IS_VERSAL(lro))
+			if (XOCL_DSA_IS_VERSAL(lro)) {
+				xocl_subdev_destroy_by_id(lro, XOCL_SUBDEV_CLOCK);
 				ret = xocl_xfer_versal_download_axlf(lro, buf);
-			else
+				/*
+				 *Note: this is a workaround for enabling ULP
+				 * level clock after xclbin download. We will
+				 * have new-code to replace this api. For fast
+				 * fix, just enable it temporarily.
+				 */
+				xocl_subdev_create_by_id(lro, XOCL_SUBDEV_CLOCK);
+
+			} else {
 				ret = xocl_icap_download_axlf(lro, buf);
+			}
 			vfree(buf);
 		}
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -477,6 +477,8 @@ static unsigned short clock_get_freq_impl(struct clock *clock, int idx)
 {
 	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);
 
+	BUG_ON(!mutex_is_locked(&clock->clock_lock));
+
 	return XOCL_DSA_IS_VERSAL(xdev) ?
 	    clock_get_freq_acap(clock, idx) :
 	    clock_get_freq_ultrascale(clock, idx);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1107,7 +1107,6 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 	CLOCK_OPS(xdev, __idx)->get_data(CLOCK_DEV(xdev, __idx), kind) : 0); 	\
 })
 
-
 struct xocl_icap_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	void (*reset_axi_gate)(struct platform_device *pdev);


### PR DESCRIPTION
This is a quick fix to enable versal clock, but we will need a better design later to replace this quick fix.

>xclbin download test
```
root@xsjyliu50:~# ./xbutil program -p /opt/xilinx/firmware/vck5000-es1/gen3x16/base/test/verify.xclbin
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil program succeeded.
root@xsjyliu50:~# ./xbutil program -p /opt/xilinx/firmware/vck5000-es1/gen3x16/base/test/bandwidth.xclbin
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil program succeeded.
```

>clock test
```
root@xsjyliu50:~# ./xbutil clock -f 102 -g 203
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil clock succeeded.
root@xsjyliu50:~# ./xbutil dump|grep clock
            "branch": "xocl_clock",
            "clock0": "102",
            "clock1": "202",
            "clock2": "0",
```