### PR TITLE
linux-driver: Fix mmap and build error

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_debugfs.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_debugfs.h
@@ -23,7 +23,7 @@
 #include <linux/pci.h>
 #include <linux/debugfs.h>
 #include <linux/fs.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <linux/mutex.h>
 #include <linux/slab.h>
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -28,7 +28,6 @@
 #include "../lib/libqdma/libqdma_export.h"
 #include "qdma_ioctl.h"
 
-#define XOCL_FILE_PAGE_OFFSET   0x100000
 #ifndef VM_RESERVED
 #define VM_RESERVED (VM_DONTEXPAND | VM_DONTDUMP)
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -23,7 +23,6 @@
 #include "../xocl_drm.h"
 #include "../lib/libxdma_api.h"
 
-#define XOCL_FILE_PAGE_OFFSET   0x100000
 #ifndef VM_RESERVED
 #define VM_RESERVED (VM_DONTEXPAND | VM_DONTDUMP)
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -31,11 +31,11 @@
 #include "../lib/libxdma_api.h"
 #include "common.h"
 
-#if defined(__PPC64__)
-#define XOCL_FILE_PAGE_OFFSET	0x10000
-#else
-#define XOCL_FILE_PAGE_OFFSET	0x100000
+#ifndef SZ_4G
+#define SZ_4G	_AC(0x100000000, ULL)
 #endif
+
+#define XOCL_FILE_PAGE_OFFSET	(SZ_4G / PAGE_SIZE)
 
 #ifndef VM_RESERVED
 #define VM_RESERVED (VM_DONTEXPAND | VM_DONTDUMP)


### PR DESCRIPTION
1)Should use the linux/uaccess.h, it include all arches.

2)Make XOCL_FILE_PAGE_OFFSET be more applicable

static int xocl_mmap(struct file *filp, struct vm_area_struct *vma)
{
        /*
         * If the offset is > than 4G, then let GEM handle that and do what
         * it thinks is best, we will only handle offsets less than 4G.
         */
        if (likely(vma->vm_pgoff >= XOCL_FILE_PAGE_OFFSET))
                return xocl_bo_mmap(filp, vma);

Different architectrues have different page size, and can be choosed,
PPC64 support 4/16/64/256KB, MIPS support 4/8/16/32/64KB to choose.

So set XOCL_FILE_PAGE_OFFSET = (SZ_4G / PAGE_SIZE) is more applicable.