### PR TITLE
Add xclReadBO/xclWriteBO support to PL-DDR

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -328,6 +328,10 @@ void zocl_free_bo(struct drm_gem_object *obj)
 				drm_mm_remove_node(zocl_obj->mm_node);
 				mutex_unlock(&zdev->mm_lock);
 				kfree(zocl_obj->mm_node);
+				if (zocl_obj->vmapping) {
+					memunmap(zocl_obj->vmapping);
+					zocl_obj->vmapping = NULL;
+				}
 				zocl_update_mem_stat(zdev, obj->size, -1,
 				    zocl_obj->bank);
 			}


### PR DESCRIPTION
This PR fill the gap to support xclReadBO/xclWriteBO on PL-DDR.

Please note: You will need to reserve PL-DDR range in Device Tree and make sure to put no-map in it. Otherwise, you will not be able to use xclReadBO/xclWriteBO on PL-DDR. You will see linux WARN_ON