### PR TITLE
XRT-608 update edge compilation script to use latest bsps

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -139,13 +139,13 @@ source $SETTINGS_FILE
 source $PETALINUX/settings.sh 
 
 if [[ $AARCH = $aarch64_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.1-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.2-final.bsp"
     YOCTO_MACHINE="zynqmp-generic"
 elif [[ $AARCH = $aarch32_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.1-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.2-final.bsp"
     YOCTO_MACHINE="zynq-generic"
 elif [[ $AARCH = $versal_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-vck190-emmc-v2020.1-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-vck190-emmc-v2020.2-final.bsp"
     YOCTO_MACHINE="versal-generic"
 else
     error "$AARCH not exist"

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,1 @@
-PETALINUX="/proj/petalinux/2020.1/petalinux-v2020.1_0327_3/tool/petalinux-v2020.1-final"
+PETALINUX="/proj/petalinux/2020.2/petalinux-v2020.2_0612_1/tool/petalinux-v2020.2-final"


### PR DESCRIPTION
Updating bsp paths for 2020.2 for edge platforms