### PR TITLE
NSPR-1387 : Xrt hbm support

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -196,6 +196,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
   common/drv/include/kds_core.h
   common/drv/include/kds_command.h
   common/drv/include/xrt_cu.h
+  common/drv/include/mem_group.h
   )
 
 SET (XRT_DKMS_ABS_SRCS)

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -78,6 +78,53 @@ register_axlf(const axlf* top)
 
   // Build modified CONNECTIVITY and MEM_TOPOLOGY section based on memory group ids
   // Base groups off data from driver
+  auto m_itr = m_axlf_sections.find(MEM_TOPOLOGY);
+  int g_count = (int)m_grp_info.size();
+  if (g_count && (m_itr != m_axlf_sections.end())) {
+    auto m_mem = reinterpret_cast<::mem_topology*>((*m_itr).second.data());
+    
+    /* Store the original memory topology before modify */
+    size_t size = (*m_itr).second.size();
+    char *buf = new char[size];
+    memcpy(buf, m_mem, size);
+    
+    auto m_topo = reinterpret_cast<::mem_topology*>(buf);
+    for (auto i=0; i<g_count; ++i) {
+      auto& mem = m_mem->m_mem_data[i];
+      auto it = m_grp_info.find(i);
+      if (it != m_grp_info.end()) {
+        auto l_idx = (*it).second.first;
+        auto h_idx = (*it).second.second;
+	mem.m_base_address = m_topo->m_mem_data[l_idx].m_base_address;
+        mem.m_size = (m_topo->m_mem_data[h_idx].m_base_address + m_topo->m_mem_data[h_idx].m_size) -
+			m_topo->m_mem_data[l_idx].m_base_address;
+        mem.m_type = m_topo->m_mem_data[l_idx].m_type;
+        memcpy(&mem.m_tag, m_topo->m_mem_data[l_idx].m_tag, sizeof(m_topo->m_mem_data[l_idx].m_tag));
+        mem.m_used = 1;
+      }
+    }
+    // Update remaing entries as un-used
+    for (auto i=g_count; i<m_mem->m_count; ++i) {
+	    auto& mem = m_mem->m_mem_data[i];
+	    mem.m_used = 0;
+    }
+    // Update the new memory topology count 
+    m_mem->m_count = g_count;
+    delete []buf;
+  }
+
+  auto c_itr = m_axlf_sections.find(CONNECTIVITY);
+  if (c_itr != m_axlf_sections.end()) {
+    auto m_con = reinterpret_cast<::connectivity*>((*c_itr).second.data());
+    for (auto i=0; i<m_con->m_count; ++i) {
+      auto& con = m_con->m_connection[i];
+      auto it = m_grp_map.find(std::make_pair(con.m_ip_layout_index,
+                                              con.arg_index));
+      if (it != m_grp_map.end()) {
+        con.mem_data_index = (*it).second;
+      }
+    }
+  }
 }
 
 std::pair<const char*, size_t>
@@ -148,6 +195,48 @@ get_ert_slots() const
   if (!xml.first)
     throw std::runtime_error("No xml metadata in xclbin");
   return get_ert_slots(xml.first, xml.second);
+}
+
+void
+device::
+populate_mem_group_info(const char *infoBuff)  
+{
+  struct xcl_mem_connectivity   grpInfoMap;
+  struct xcl_mem_group_info     *m_grp = NULL;
+  struct xcl_mem_map_info       *m_map = NULL;
+
+  if (!infoBuff) 
+    throw std::runtime_error("Failed to get memory information");
+
+  grpInfoMap.mem_group = (struct xcl_mem_group *)infoBuff;
+  if (!grpInfoMap.mem_group) 
+    throw std::runtime_error("Failed to get memory group information");
+ 
+  infoBuff += sizeof(grpInfoMap.mem_group->g_count); 
+  for (int i = 0; i < grpInfoMap.mem_group->g_count; i++)
+  {
+    m_grp = (struct xcl_mem_group_info *)infoBuff;
+    if(!m_grp)
+      throw std::runtime_error("Failed to get memory mapping information");
+
+    m_grp_info.emplace(i, std::make_pair(m_grp->l_bank_idx, m_grp->h_bank_idx));
+    infoBuff += sizeof(*m_grp);
+  }
+
+  grpInfoMap.mem_map = (struct xcl_mem_map *)infoBuff;
+  if (!grpInfoMap.mem_map) 
+    throw std::runtime_error("Failed to get memory mapping information");
+ 
+  infoBuff += sizeof(grpInfoMap.mem_map->m_count); 
+  for (int i = 0; i < grpInfoMap.mem_map->m_count; i++)
+  {
+    m_map = (struct xcl_mem_map_info *)infoBuff;
+    if(!m_map)
+      throw std::runtime_error("Failed to get memory mapping information");
+    
+    m_grp_map.emplace(std::make_pair(m_map->cu_id, m_map->arg_id), m_map->grp_id);
+    infoBuff += sizeof(*m_map);
+  }
 }
 
 std::string

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -24,7 +24,6 @@
 #include "scope_guard.h"
 #include "uuid.h"
 #include "core/include/xrt.h"
-#include "core/common/drv/include/mem_group.h"
 
 // Please keep eternal include file dependencies to a minimum
 #include <cstdint>
@@ -178,7 +177,7 @@ public:
    */
   XRT_CORE_COMMON_EXPORT
   void
-  register_axlf(const axlf*);
+  register_axlf(const axlf*, const char *info_buff = nullptr);
 
   /**
    * get_xclbin_uuid() - Get uuid of currently loaded xclbin
@@ -315,12 +314,6 @@ public:
   // cache xclbin meta data loaded by this process
   uuid m_xclbin_uuid;
   std::map<axlf_section_kind, std::vector<char>> m_axlf_sections;
-
-  // Store memory mapping information <<cuIdx, argIdx>, grpIdx>
-  std::map<std::pair<uint32_t, uint32_t>, uint32_t> m_grp_map;
-
-  // Store memory group information <grpIdx, <startAddr, size>>
-  std::map<uint32_t, std::pair<uint64_t, uint64_t>> m_grp_info;
 };
 
 /**

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -24,6 +24,7 @@
 #include "scope_guard.h"
 #include "uuid.h"
 #include "core/include/xrt.h"
+#include "core/common/drv/include/mem_group.h"
 
 // Please keep eternal include file dependencies to a minimum
 #include <cstdint>
@@ -235,6 +236,13 @@ public:
   std::pair<size_t, size_t>
   get_ert_slots() const;
 
+  /**
+   * populate_mem_group_info() - Store the memory group information
+   *
+   */
+  void
+  populate_mem_group_info(const char *infoBuff);
+
   // Move all these 'pt' functions out the class interface
   virtual void get_info(boost::property_tree::ptree&) const {}
   virtual void read_dma_stats(boost::property_tree::ptree&) const {}
@@ -307,6 +315,12 @@ public:
   // cache xclbin meta data loaded by this process
   uuid m_xclbin_uuid;
   std::map<axlf_section_kind, std::vector<char>> m_axlf_sections;
+
+  // Store memory mapping information <<cuIdx, argIdx>, grpIdx>
+  std::map<std::pair<uint32_t, uint32_t>, uint32_t> m_grp_map;
+
+  // Store memory group information <grpIdx, <startAddr, size>>
+  std::map<uint32_t, std::pair<uint64_t, uint64_t>> m_grp_info;
 };
 
 /**

--- a/src/runtime_src/core/common/drv/include/mem_group.h
+++ b/src/runtime_src/core/common/drv/include/mem_group.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef XRT_CORE_MEM_GROUP_H
+#define XRT_CORE_MEM_GROUP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * WARNING: This structure has been shared between userspace and driver.
+ * Any modification to this will affect both parties. Please update
+ * with extra caution.
+ */
+
+/****   MEMORY GROUP SECTION ****/
+#define XCL_MEM_GROUP_MAX 128
+
+/* Stores each groups information */
+struct xcl_mem_group_info {
+    uint32_t l_bank_idx;	/* Low memory Bank index */
+    uint64_t l_start_addr;
+    uint32_t h_bank_idx;	/* High memory Bank index */
+    uint64_t h_end_addr;
+};
+
+struct xcl_mem_group {
+    int32_t g_count;
+    struct xcl_mem_group_info *m_group[XCL_MEM_GROUP_MAX];
+};
+
+/* memory mapping information for groups */
+struct xcl_mem_map_info {
+    uint32_t cu_id;
+    uint32_t arg_id;
+    uint32_t grp_id;
+};
+
+struct xcl_mem_map {
+    int32_t m_count;
+    struct xcl_mem_map_info *m_map[XCL_MEM_GROUP_MAX];
+};
+
+struct xcl_mem_connectivity {
+    struct xcl_mem_map     *mem_map;
+    struct xcl_mem_group   *mem_group;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/runtime_src/core/common/drv/include/mem_group.h
+++ b/src/runtime_src/core/common/drv/include/mem_group.h
@@ -45,9 +45,9 @@ struct xcl_mem_group {
 
 /* memory mapping information for groups */
 struct xcl_mem_map_info {
-    uint32_t cu_id;
-    uint32_t arg_id;
-    uint32_t grp_id;
+    int32_t cu_id;
+    int32_t arg_id;
+    int32_t grp_id;
 };
 
 struct xcl_mem_map {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -199,6 +199,7 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 {
 	struct xocl_drm *drm_p = dev->dev_private;
 	struct xocl_dev *xdev = drm_p->xdev;
+	struct xcl_mem_group *mem_grp = NULL;
 	u16 ddr_count;
 	unsigned ddr;
 	struct mem_topology *topo = NULL;
@@ -209,7 +210,11 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 		return 0;
 	//From "mem_topology" or "feature rom" depending on
 	//unified or non-unified dsa
-	ddr_count = XOCL_DDR_COUNT(xdev);
+	mem_grp = drm_p->m_connect->mem_group;
+	if (!mem_grp)
+		return -EINVAL;
+
+	ddr_count = mem_grp->g_count;
 
 	if (ddr_count == 0)
 		return -EINVAL;
@@ -225,12 +230,6 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 	if (topo) {
 		if (XOCL_IS_STREAM(topo, ddr)) {
 			userpf_err(xdev, "Bank %d is Stream", ddr);
-			err = -EINVAL;
-			goto done;
-		}
-		if (!XOCL_IS_DDR_USED(topo, ddr)) {
-			userpf_err(xdev,
-				"Bank %d is marked as unused in axlf", ddr);
 			err = -EINVAL;
 			goto done;
 		}
@@ -334,7 +333,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 
 	mutex_lock(&drm_p->mm_lock);
 	/* Attempt to allocate buffer on the requested DDR */
-	xocl_xdev_dbg(xdev, "alloc bo from bank%u", memidx);
+	xocl_xdev_dbg(xdev, "alloc bo from group%u", memidx);
 
 	/* Check the mem index to see if it's MEM_HOST */
 	if ((xobj->flags & XOCL_CMA_MEM) && !is_cma_bank(drm_p, memidx)) {
@@ -342,13 +341,13 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 		goto failed;
 	}
 
-	err = xocl_mm_insert_node(drm_p, memidx, xobj->mm_node,
+	err = xocl_mm_insert_node_range(drm_p, memidx, xobj->mm_node,
 		xobj->base.size);
+	if (err)
+		goto failed;
 	BO_DEBUG("insert mm_node:%p, start:%llx size: %llx",
 		xobj->mm_node, xobj->mm_node->start,
 		xobj->mm_node->size);
-	if (err)
-		goto failed;
 
 	xocl_mm_update_usage_stat(drm_p, memidx, xobj->base.size, 1);
 	mutex_unlock(&drm_p->mm_lock);
@@ -434,18 +433,19 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 	struct xocl_drm *drm_p = dev->dev_private;
 	struct xocl_dev *xdev = drm_p->xdev;
 	struct drm_xocl_create_bo *args = data;
-	unsigned ddr = xocl_bo_ddr_idx(args->flags);
+	unsigned mem_id = xocl_bo_ddr_idx(args->flags);
 	unsigned bo_type = xocl_bo_type(args->flags);
 	struct mem_topology *topo = NULL;
+	struct xcl_mem_group_info *xocl_mem = NULL;
 
 	xobj = xocl_create_bo(dev, args->size, args->flags, bo_type);
 
-	BO_ENTER("xobj %p, mm_node %p", xobj, xobj->mm_node);
 	if (IS_ERR(xobj)) {
-		DRM_ERROR("object creation failed idx %d, size 0x%llx\n", ddr, args->size);
+		DRM_ERROR("object creation failed idx %d, size 0x%llx\n", mem_id, args->size);
 		return PTR_ERR(xobj);
 	}
 
+	BO_ENTER("xobj %p, mm_node %p", xobj, xobj->mm_node);
 	if (xobj->flags == XOCL_BO_P2P) {
 		/*
 		 * DRM allocate contiguous pages, shift the vmapping with
@@ -458,12 +458,17 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		if (topo) {
 			int ret;
 			ulong bar_off;
+                        xocl_mem = drm_p->m_connect->mem_group->m_group[mem_id];
+                        if (xocl_mem == NULL) {
+                                ret = -EINVAL;
+                                goto out_free;
+                        }
 
 			ret = xocl_p2p_mem_map(xdev,
-				topo->m_mem_data[ddr].m_base_address,
-				topo->m_mem_data[ddr].m_size * 1024,
+			       topo->m_mem_data[xocl_mem->l_bank_idx].m_base_address,
+			       topo->m_mem_data[xocl_mem->l_bank_idx].m_size * 1024,
 				xobj->mm_node->start -
-				topo->m_mem_data[ddr].m_base_address,
+			       topo->m_mem_data[xocl_mem->l_bank_idx].m_base_address,
 				xobj->base.size,
 				&bar_off);
 			if (ret) {
@@ -485,7 +490,7 @@ int xocl_create_bo_ioctl(struct drm_device *dev,
 		else if (xobj->flags & XOCL_DRM_SHMEM)
 			xobj->pages = drm_gem_get_pages(&xobj->base);
 		else if (xobj->flags & XOCL_CMA_MEM){
-			uint64_t start_addr = drm_p->mm[ddr]->head_node.start + drm_p->mm[ddr]->head_node.size;
+			uint64_t start_addr = drm_p->mm->head_node.start + drm_p->mm->head_node.size;
 
 			xobj->pages = xocl_cma_collect_pages(drm_p, start_addr, xobj->mm_node->start, xobj->base.size);
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -92,18 +92,66 @@ static ssize_t kdsstat_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(kdsstat);
 
-/* -live memory usage-- */
-static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
+static ssize_t mem_group_info_show(struct device *dev,
+                struct device_attribute *attr, char *buf)
+{
+        struct xocl_dev 		*xdev = dev_get_drvdata(dev);
+        struct xocl_drm 		*drm_p = XOCL_DRM(xdev);
+        struct xcl_mem_group 		*mem_group = NULL;
+        struct xcl_mem_group_info 	*m_grp = NULL;
+        struct xcl_mem_map 		*mem_map = NULL;
+        struct xcl_mem_map_info 	*m_map = NULL;
+        ssize_t size = 0;
+        int i;
+
+        if (!drm_p || !drm_p->m_connect)
+                return 0;
+
+	 mem_group = drm_p->m_connect->mem_group;
+        if (!mem_group)
+                return 0;
+
+        /* Copy the group info size first */
+        memcpy((void *)buf, (void *)&mem_group->g_count, sizeof(mem_group->g_count));
+        buf += sizeof(mem_group->g_count);
+        size += sizeof(mem_group->g_count);
+
+        /* Copy Group Information */
+        for (i = 0; i < mem_group->g_count; i++) {
+                m_grp = mem_group->m_group[i];
+                memcpy((void *)buf, (void *)m_grp, sizeof(*m_grp));
+                buf += sizeof(*m_grp);
+                size += sizeof(*m_grp);
+        }
+
+        mem_map = drm_p->m_connect->mem_map;
+        if (!mem_map)
+                return 0;
+
+        /* Copy group mapping size  */
+        memcpy((void *)buf, (void *)&mem_map->m_count, sizeof(mem_map->m_count));
+        buf += sizeof(mem_map->m_count);
+        size += sizeof(mem_map->m_count);
+
+        /* Copy group mapping information  */
+        for (i = 0; i < mem_map->m_count; i++) {
+                m_map = mem_map->m_map[i];
+                memcpy((void *)buf, (void *)m_map, sizeof(*m_map));
+                buf += sizeof(*m_map);
+                size += sizeof(*m_map);
+        }
+
+        return size;
+}
+static DEVICE_ATTR_RO(mem_group_info);
+
+static ssize_t xocl_mm_info(struct xocl_dev *xdev, char *buf)
 {
 	int i, err;
 	ssize_t count = 0;
 	ssize_t size = 0;
-	size_t memory_usage = 0;
-	unsigned int bo_count = 0;
-	const char *txt_fmt = "[%s] %s@0x%012llx (%lluMB): %lluKB %dBOs\n";
-	const char *raw_fmt = "%llu %d %llu\n";
+	const char *txt_fmt = "[%s] %s@0x%012llx (%lluMB)\n";
 	struct mem_topology *topo = NULL;
-	struct drm_xocl_mm_stat stat;
 
 	mutex_lock(&xdev->dev_lock);
 
@@ -119,6 +167,44 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 	}
 
 	for (i = 0; i < topo->m_count; i++) {
+		count = sprintf(buf, txt_fmt,
+				topo->m_mem_data[i].m_used ?
+				"IN-USE" : "UNUSED",
+				topo->m_mem_data[i].m_tag,
+				topo->m_mem_data[i].m_base_address,
+				topo->m_mem_data[i].m_size / 1024);
+		buf += count;
+		size += count;
+	}
+
+done:
+	XOCL_PUT_MEM_TOPOLOGY(xdev);
+	mutex_unlock(&xdev->dev_lock);
+	return size;
+}
+
+static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
+{
+	int i;
+	ssize_t count = 0;
+	ssize_t size = 0;
+	size_t memory_usage = 0;
+	unsigned int bo_count = 0;
+	const char *txt_fmt = "[GROUP-%d] : %lluKB %dBOs\n";
+	const char *raw_fmt = "%llu %d %llu\n";
+	struct drm_xocl_mm_stat stat;
+        struct xcl_mem_group *mem_group = NULL;
+        struct xocl_drm *drm_p = XOCL_DRM(xdev);
+
+
+        if (!drm_p || !drm_p->m_connect)
+                return 0;
+
+        mem_group = drm_p->m_connect->mem_group;
+        if (!mem_group)
+                return 0;
+
+        for (i = 0; i < mem_group->g_count; i++) {
 		xocl_mm_get_usage_stat(XOCL_DRM(xdev), i, &stat);
 
 		if (raw) {
@@ -131,12 +217,7 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 				memory_usage,
 				bo_count, 0);
 		} else {
-			count = sprintf(buf, txt_fmt,
-				topo->m_mem_data[i].m_used ?
-				"IN-USE" : "UNUSED",
-				topo->m_mem_data[i].m_tag,
-				topo->m_mem_data[i].m_base_address,
-				topo->m_mem_data[i].m_size / 1024,
+			count = sprintf(buf, txt_fmt, i,
 				stat.memory_usage / 1024,
 				stat.bo_count);
 		}
@@ -144,11 +225,17 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 		size += count;
 	}
 
-done:
-	XOCL_PUT_MEM_TOPOLOGY(xdev);
-	mutex_unlock(&xdev->dev_lock);
 	return size;
 }
+
+static ssize_t mem_info_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_dev *xdev = dev_get_drvdata(dev);
+
+	return xocl_mm_info(xdev, buf);
+}
+static DEVICE_ATTR_RO(mem_info);
 
 static ssize_t memstat_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
@@ -429,6 +516,8 @@ static struct attribute *xocl_attrs[] = {
 	&dev_attr_userbar.attr,
 	&dev_attr_kdsstat.attr,
 	&dev_attr_memstat.attr,
+	&dev_attr_mem_info.attr,
+	&dev_attr_mem_group_info.attr,
 	&dev_attr_memstat_raw.attr,
 	&dev_attr_dev_offline.attr,
 	&dev_attr_mig_calibration.attr,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -21,6 +21,7 @@
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
 #include <linux/hashtable.h>
 #endif
+#include "mem_group.h"
 
 
 #define IS_HOST_MEM(m_tag)	(!strncmp(m_tag, "HOST[0]", 7))
@@ -54,7 +55,7 @@ struct xocl_drm {
 	/* memory management */
 	struct drm_device       *ddev;
 	/* Memory manager array, one per DDR channel, protected by mm_lock */
-	struct drm_mm           **mm;
+	struct drm_mm           *mm;
 	struct mutex            mm_lock;
 	struct drm_xocl_mm_stat **mm_usage_stat;
 
@@ -62,6 +63,7 @@ struct xocl_drm {
 	DECLARE_HASHTABLE(mm_range, 6);
 #endif
 	struct xocl_cma_bank  *cma_bank;
+	struct xcl_mem_connectivity *m_connect;
 };
 
 struct drm_xocl_bo {
@@ -97,6 +99,8 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
+int xocl_mm_insert_node_range(struct xocl_drm *drm_p, u32 mem_id,
+                    struct drm_mm_node *node, u64 size);
 int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 ddr,
                 struct drm_mm_node *node, u64 size);
 void *xocl_drm_init(xdev_handle_t xdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1214,7 +1214,8 @@ enum {
 
 #define XOCL_GET_MEM_TOPOLOGY(xdev, mem_topo)						\
 	(xocl_icap_get_xclbin_metadata(xdev, MEMTOPO_AXLF, (void **)&mem_topo))
-
+#define XOCL_GET_CONNECTIVITY(xdev, connectivity)                                       \
+        (xocl_icap_get_xclbin_metadata(xdev, CONNECTIVITY_AXLF, (void **)&connectivity))
 #define XOCL_GET_IP_LAYOUT(xdev, ip_layout)						\
 	(xocl_icap_get_xclbin_metadata(xdev, IPLAYOUT_AXLF, (void **)&ip_layout))
 #define XOCL_GET_XCLBIN_ID(xdev, xclbin_id)						\
@@ -1222,6 +1223,8 @@ enum {
 
 
 #define XOCL_PUT_MEM_TOPOLOGY(xdev)						\
+	xocl_icap_put_xclbin_metadata(xdev)
+#define XOCL_PUT_CONNECTIVITY(xdev)                                             \
 	xocl_icap_put_xclbin_metadata(xdev)
 #define XOCL_PUT_IP_LAYOUT(xdev)						\
 	xocl_icap_put_xclbin_metadata(xdev)

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1396,6 +1396,31 @@ unsigned int shim::xclImportBO(int fd, unsigned flags)
 }
 
 /*
+ * xclGetMemGroupInfo()
+ */
+int shim::xclGetMemGroupInfo(char **grpMapInfo)
+{
+    std::string errmsg;
+    size_t size = 0;
+    std::vector<char> memGroupInfo;
+
+    mDev->sysfs_get("", "mem_group_info", errmsg, memGroupInfo);
+    if (memGroupInfo.empty()) 
+        return -EINVAL;
+ 
+    size = memGroupInfo.size() * sizeof(char); 
+    /* Allocate memory for *grpMapInfo */
+    *grpMapInfo =  (char *)malloc(size);
+    if (!*grpMapInfo)
+	return -ENOMEM; 
+
+    memset((void *)*grpMapInfo, 0, size);
+    memcpy((void *)*grpMapInfo, memGroupInfo.data(), size);
+     
+    return size;
+}
+
+/*
  * xclGetBOProperties()
  */
 int shim::xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties)
@@ -2224,7 +2249,20 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
 #endif
 
     if (!ret) {
+      char *pGrpInfo = NULL;
+      int grp_info_size = 0;
       auto core_device = xrt_core::get_userpf_device(drv);
+      
+      /* Get memory group mapping info from sysfs */
+      grp_info_size = drv->xclGetMemGroupInfo(&pGrpInfo);
+      if (grp_info_size > 0) {
+          /* Populate the retrive info into device class */
+          core_device->populate_mem_group_info(pGrpInfo);
+	  
+	  /* Free the allocated memory */
+	  if (pGrpInfo)
+              free(pGrpInfo); 	
+      }
       core_device->register_axlf(buffer);
 #ifdef ENABLE_HAL_PROFILING
     LOAD_XCLBIN_CB ;

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2257,13 +2257,12 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
       grp_info_size = drv->xclGetMemGroupInfo(&pGrpInfo);
       if (grp_info_size > 0) {
           /* Populate the retrive info into device class */
-          core_device->populate_mem_group_info(pGrpInfo);
+          core_device->register_axlf(buffer, pGrpInfo);
 	  
 	  /* Free the allocated memory */
 	  if (pGrpInfo)
               free(pGrpInfo); 	
       }
-      core_device->register_axlf(buffer);
 #ifdef ENABLE_HAL_PROFILING
     LOAD_XCLBIN_CB ;
 #endif

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -82,6 +82,7 @@ public:
 
     int xclExportBO(unsigned int boHandle);
     unsigned int xclImportBO(int fd, unsigned flags);
+    int xclGetMemGroupInfo(char **grpMapInfo);
     int xclGetBOProperties(unsigned int boHandle, xclBOProperties *properties);
 
     // Bitstream/bin download

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -32,6 +32,7 @@
 #include "ert.h"
 #include "xclperf.h"
 #include "xcl_axi_checker_codes.h"
+#include "core/common/drv/include/mem_group.h"
 #include "core/pcie/common/dmatest.h"
 #include "core/pcie/common/memaccess.h"
 #include "core/pcie/common/dd.h"
@@ -418,31 +419,21 @@ public:
         ss << "Device Memory Usage\n";
 
         try {
-          for (auto& v : sensor_tree::get_child("board.memory.mem")) {
+          for (auto& v : sensor_tree::get_child("board.memory.grp")) {
             int index = std::stoi(v.first);
             if( index >= 0 ) {
               uint64_t size = 0, mem_usage = 0;
               std::string tag, type, temp;
-              bool enabled = false;
 
               for (auto& subv : v.second) {
-                  if( subv.first == "type" ) {
-                      type = subv.second.get_value<std::string>();
-                  } else if( subv.first == "tag" ) {
+                  if( subv.first == "tag" ) {
                       tag = subv.second.get_value<std::string>();
-                  } else if( subv.first == "temp" ) {
-                      unsigned int t = subv.second.get_value<unsigned int>();
-                      temp = sensor_tree::pretty<unsigned int>(t == XCL_INVALID_SENSOR_VAL ? XCL_NO_SENSOR_DEV : t, "N/A");
                   } else if( subv.first == "mem_usage_raw" ) {
                       mem_usage = subv.second.get_value<uint64_t>();
                   } else if( subv.first == "size_raw" ) {
                       size = subv.second.get_value<uint64_t>();
-                  } else if( subv.first == "enabled" ) {
-                      enabled = subv.second.get_value<bool>();
                   }
               }
-              if (!enabled || !size)
-                continue;
 
               float percentage = (float)mem_usage * 100 / size;
               int nums_fiftieth = (int)percentage / 2;
@@ -496,19 +487,19 @@ public:
     void getMemTopology( const xclDeviceUsage &devstat ) const
     {
         std::string errmsg;
-        std::vector<char> buf, temp_buf;
+        std::vector<char> buf, temp_buf, grp_buf;
         std::vector<std::string> mm_buf, stream_stat;
-        uint64_t memoryUsage, boCount;
         auto dev = pcidev::get_dev(m_idx);
 
         dev->sysfs_get("icap", "mem_topology", errmsg, buf);
         dev->sysfs_get("", "memstat_raw", errmsg, mm_buf);
+        dev->sysfs_get("", "mem_group_info", errmsg, grp_buf);
         dev->sysfs_get("xmc", "temp_by_mem_topology", errmsg, temp_buf);
 
         const mem_topology *map = (mem_topology *)buf.data();
         const uint32_t *temp = (uint32_t *)temp_buf.data();
 
-        if(buf.empty() || mm_buf.empty())
+	if(buf.empty())
             return;
 
         int j = 0; // stream index
@@ -581,8 +572,6 @@ public:
                     ptMem.put("ecc_ue_ffa", ue_ffa);
                 }
             }
-            std::stringstream ss(mm_buf[i]);
-            ss >> memoryUsage >> boCount;
 
             ptMem.put( "type",      str );
             ptMem.put( "temp",      temp_buf.empty() ? XCL_NO_SENSOR_DEV : temp[i]);
@@ -590,11 +579,54 @@ public:
             ptMem.put( "enabled",   map->m_mem_data[i].m_used ? true : false );
             ptMem.put( "size",      xrt_core::utils::unit_convert(map->m_mem_data[i].m_size << 10) );
             ptMem.put( "size_raw",  map->m_mem_data[i].m_size << 10 );
-            ptMem.put( "mem_usage", xrt_core::utils::unit_convert(memoryUsage));
-            ptMem.put( "mem_usage_raw", memoryUsage);
-            ptMem.put( "bo_count",  boCount);
             sensor_tree::add_child( std::string("board.memory.mem." + std::to_string(m)), ptMem );
             m++;
+        }
+
+        if (!grp_buf.empty() && !mm_buf.empty()) {
+            struct xcl_mem_connectivity	grpInfoMap;
+            struct xcl_mem_group_info   *m_grp = NULL;
+            const char					*infoBuff = (const char*)grp_buf.data();
+
+            grpInfoMap.mem_group = (struct xcl_mem_group *)infoBuff;
+
+            infoBuff += sizeof(grpInfoMap.mem_group->g_count);
+            for (auto i = 0; i < grpInfoMap.mem_group->g_count; i++)
+            {
+                uint64_t memoryUsage, boCount;
+                boost::property_tree::ptree ptGrp;
+
+                m_grp = (struct xcl_mem_group_info *)infoBuff;
+                if(!m_grp)
+                    return;
+
+                int l_idx = m_grp->l_bank_idx;
+                int h_idx = m_grp->h_bank_idx;
+
+                std::stringstream ss(mm_buf[i]);
+                ss >> memoryUsage >> boCount;
+
+                std::stringstream g_tag;
+                g_tag << "Group-" << i;
+
+                std::stringstream ss_bank_map;
+                ss_bank_map << std::left << std::setw(8) << map->m_mem_data[l_idx].m_tag << "- " <<
+                    std::setw(8) << map->m_mem_data[h_idx].m_tag;
+
+                auto size = ((map->m_mem_data[h_idx].m_base_address +
+                            map->m_mem_data[h_idx].m_size)) -
+                    map->m_mem_data[l_idx].m_base_address;
+
+                ptGrp.put( "tag",		g_tag.str());
+                ptGrp.put( "bank_mapping",	ss_bank_map.str());
+                ptGrp.put( "size",              xrt_core::utils::unit_convert(size) );
+                ptGrp.put( "size_raw",		size);
+                ptGrp.put( "mem_usage",		xrt_core::utils::unit_convert(memoryUsage));
+                ptGrp.put( "mem_usage_raw",	memoryUsage);
+                ptGrp.put( "bo_count",		boCount);
+                sensor_tree::add_child( std::string("board.memory.grp." + std::to_string(i)), ptGrp);
+                infoBuff += sizeof(*m_grp);
+            }
         }
     }
 
@@ -602,8 +634,45 @@ public:
     {
         std::stringstream ss;
 
-        ss << std::left << std::setw(48) << "Mem Topology"
-            << std::setw(32) << "Device Memory Usage" << "\n";
+        ss << std::left << std::setw(48) << "Device Memory Usage" << "\n";
+        try {
+            ss << std::left << std::setw(17) << "     Group"  << std::setw(20)
+                << "Bank Mapping" << std::setw(12)  << "Size" << std::setw(16)
+                << "Mem Usage";
+            ss << std::setw(8)  << "BO count" << std::endl;
+            for (auto& v : sensor_tree::get_child("board.memory.grp")) {
+                int index = std::stoi(v.first);
+                if( index >= 0 ) {
+                    std::string mem_usage, bank_mapping, size, tag;
+                    unsigned bo_count = 0;
+                    for (auto& subv : v.second) {
+                        if( subv.first == "bank_mapping" ) {
+                            bank_mapping = subv.second.get_value<std::string>();
+                        } else if( subv.first == "tag" ) {
+                            tag = subv.second.get_value<std::string>();
+                        } else if( subv.first == "size" ) {
+                            size = subv.second.get_value<std::string>();
+                        } else if( subv.first == "bo_count" ) {
+                            bo_count = subv.second.get_value<unsigned>();
+                        } else if( subv.first == "mem_usage" ) {
+                            mem_usage = subv.second.get_value<std::string>();
+                        }
+                    }
+                    ss << std::left
+                        << "[" << std::right << std::setw(2) << index << "] " << std::left
+                        << std::setw(12) << tag 
+                        << std::setw(20) << bank_mapping
+                        << std::setw(12) << size << std::setw(16) << mem_usage
+                        << std::setw(8) << bo_count << std::endl;
+                }
+            }
+        }
+        catch( std::exception const& e) {
+            ss << "WARNING: Unable to report memory stats. "
+                << "Has the bitstream been loaded? See 'xbutil program'.";
+        }
+
+        ss << std::left << std::setw(48) << "\nMem Topology" << "\n";
         auto dev = pcidev::get_dev(m_idx);
         if(!dev){
             ss << "xocl driver is not loaded, skipped" << std::endl;
@@ -612,50 +681,41 @@ public:
         }
 
         try {
-           ss << std::setw(17) << "Tag"  << std::setw(12) << "Type"
-              << std::setw(9) << "Temp" << std::setw(10) << "Size";
-           ss << std::setw(16) << "Mem Usage" << std::setw(8) << "BO nums"
-              << "\n";
-          for (auto& v : sensor_tree::get_child("board.memory.mem")) {
-            int index = std::stoi(v.first);
-            if( index >= 0 ) {
-              std::string mem_usage, tag, size, type, temp;
-              unsigned bo_count = 0;
-              bool enabled = false;
-              for (auto& subv : v.second) {
-                  if( subv.first == "type" ) {
-                      type = subv.second.get_value<std::string>();
-                  } else if( subv.first == "tag" ) {
-                      tag = subv.second.get_value<std::string>();
-                  } else if( subv.first == "temp" ) {
-                      unsigned int t = subv.second.get_value<unsigned int>();
-                      temp = sensor_tree::pretty<unsigned int>(t == XCL_INVALID_SENSOR_VAL ? XCL_NO_SENSOR_DEV : t, "N/A");
-                  } else if( subv.first == "bo_count" ) {
-                      bo_count = subv.second.get_value<unsigned>();
-                  } else if( subv.first == "mem_usage" ) {
-                      mem_usage = subv.second.get_value<std::string>();
-                  } else if( subv.first == "size" ) {
-                      size = subv.second.get_value<std::string>();
-                  } else if( subv.first == "enabled" ) {
-                      enabled = subv.second.get_value<bool>();
+            ss << std::setw(17) << "Tag"  << std::setw(12) << "Type"
+                << std::setw(9) << "Temp" << std::setw(10) << "Size" << "\n";
+            for (auto& v : sensor_tree::get_child("board.memory.mem")) {
+                int index = std::stoi(v.first);
+                if( index >= 0 ) {
+                    std::string tag, size, type, temp;
+                    bool enabled = false;
+                    for (auto& subv : v.second) {
+                        if( subv.first == "type" ) {
+                            type = subv.second.get_value<std::string>();
+                        } else if( subv.first == "tag" ) {
+                            tag = subv.second.get_value<std::string>();
+                        } else if( subv.first == "temp" ) {
+                            unsigned int t = subv.second.get_value<unsigned int>();
+                            temp = sensor_tree::pretty<unsigned int>(t == XCL_INVALID_SENSOR_VAL ? XCL_NO_SENSOR_DEV : t, "N/A");
+                        } else if( subv.first == "size" ) {
+                            size = subv.second.get_value<std::string>();
+                        } else if( subv.first == "enabled" ) {
+                            enabled = subv.second.get_value<bool>();
                   }
               }
               if (!enabled)
                 continue;
 
               ss   << " [" << std::right << index << "] "
-                   << std::setw(17 - (std::to_string(index).length()) - 4)
-                   << std::left << tag
-                   << std::setw(12) << type
-                   << std::setw(9) << temp
-                   << std::setw(10) << size
-                   << std::setw(16) << mem_usage
-                   << std::setw(8) << bo_count << std::endl;
+                        << std::setw(17 - (std::to_string(index).length()) - 4)
+                        << std::left << tag
+                        << std::setw(12) << type
+                        << std::setw(9) << temp
+                        << std::setw(10) << size << std::endl;
+                }
             }
-          }
         } catch( std::exception const& e) {
-            ss << "WARNING: Unable to report memory stats. "
-               << "Has the bitstream been loaded? See 'xbutil program'.";
+            ss << "WARNING: Unable to report memory information. "
+                << "Has the bitstream been loaded? See 'xbutil program'.";
         }
 
         ss << "\nTotal DMA Transfer Metrics:" << "\n";
@@ -719,7 +779,6 @@ public:
         std::string vendor, device, subsystem, subvendor, xmc_ver, xmc_oem_id,
             ser_num, bmc_ver, idcode, fpga, dna, errmsg, max_power, cpu_affinity;
         int ddr_size = 0, ddr_count = 0, pcie_speed = 0, pcie_width = 0, p2p_enabled = 0;
-        uint64_t host_mem_size = 0, max_host_mem_aperture = 0;
         std::vector<std::string> clock_freqs;
         std::vector<std::string> dma_threads;
         std::vector<std::string> mac_addrs;
@@ -751,10 +810,6 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get( "icap", "idcode",                 errmsg, idcode );
         pcidev::get_dev(m_idx)->sysfs_get( "dna", "dna",                     errmsg, dna );
         pcidev::get_dev(m_idx)->sysfs_get("", "local_cpulist",               errmsg, cpu_affinity);
-        pcidev::get_dev(m_idx)->sysfs_get<uint64_t>("address_translator", "host_mem_size",  
-                                                                             errmsg, host_mem_size, 0);
-        pcidev::get_dev(m_idx)->sysfs_get<uint64_t>("icap", "max_host_mem_aperture",  
-                                                                             errmsg, max_host_mem_aperture, 0);
 
         p2p_enabled = pcidev::check_p2p_config(pcidev::get_dev(m_idx), errmsg);
 
@@ -782,8 +837,6 @@ public:
         sensor_tree::put( "board.info.dna",            dna );
         sensor_tree::put( "board.info.p2p_enabled",    p2p_enabled );
         sensor_tree::put( "board.info.cpu_affinity",   cpu_affinity );
-        sensor_tree::put( "board.info.host_mem_size",   xrt_core::utils::unit_convert(host_mem_size) );
-        sensor_tree::put( "board.info.max_host_mem_aperture",   xrt_core::utils::unit_convert(max_host_mem_aperture) );
 
         for (uint32_t i = 0; i < mac_addrs.size(); ++i) {
             std::string entry_name = "board.info.mac_addr."+std::to_string(i);
@@ -1102,14 +1155,9 @@ public:
             ostr << std::endl;
         }
         ostr << std::setw(32) << "DNA"
-             << std::setw(16) << "CPU_AFFINITY"
-             << std::setw(16) << "HOST_MEM size"
-             << std::setw(16) << "Max HOST_MEM" << std::endl;
+             << std::setw(16) << "CPU_AFFINITY" << std::endl;
         ostr << std::setw(32) << sensor_tree::get<std::string>( "board.info.dna", "N/A" )
-             << std::setw(16) << sensor_tree::get<std::string>( "board.info.cpu_affinity", "N/A" )
-             << std::setw(16) << sensor_tree::get<std::string>( "board.info.host_mem_size", "N/A" )
-             << std::setw(16) << sensor_tree::get<std::string>( "board.info.max_host_mem_aperture", "N/A" )
-             << std::endl;
+             << std::setw(16) << sensor_tree::get<std::string>( "board.info.cpu_affinity", "N/A" ) << std::endl;
 
 
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
@@ -1238,17 +1286,16 @@ public:
         }
 
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
-        ostr << std::left << "Memory Status" << std::endl;
+        ostr << std::left << "Memory Information" << std::endl;
         ostr << std::setw(17) << "     Tag"  << std::setw(12) << "Type"
-             << std::setw(9)  << "Temp(C)"   << std::setw(8)  << "Size";
-        ostr << std::setw(16) << "Mem Usage" << std::setw(8)  << "BO count" << std::endl;
+             << std::setw(9)  << "Temp(C)"   << std::setw(8)  << "Size"
+	     << std::endl;
 
         try {
           for (auto& v : sensor_tree::get_child("board.memory.mem")) {
             int index = std::stoi(v.first);
             if( index >= 0 ) {
-              std::string mem_usage, tag, size, type, temp;
-              unsigned bo_count = 0;
+              std::string tag, size, type, temp;
               for (auto& subv : v.second) {
                   if( subv.first == "type" ) {
                       type = subv.second.get_value<std::string>();
@@ -1257,10 +1304,6 @@ public:
                   } else if( subv.first == "temp" ) {
                       unsigned int t = subv.second.get_value<unsigned int>();
                       temp = sensor_tree::pretty<unsigned int>(t == XCL_INVALID_SENSOR_VAL ? XCL_NO_SENSOR_DEV : t, "N/A");
-                  } else if( subv.first == "bo_count" ) {
-                      bo_count = subv.second.get_value<unsigned>();
-                  } else if( subv.first == "mem_usage" ) {
-                      mem_usage = subv.second.get_value<std::string>();
                   } else if( subv.first == "size" ) {
                       size = subv.second.get_value<std::string>();
                   }
@@ -1270,8 +1313,43 @@ public:
                    << std::setw(12) << tag
                    << std::setw(12) << type
                    << std::setw(9) << temp
-                   << std::setw(8) << size
-                   << std::setw(16) << mem_usage
+                   << std::setw(8) << size << std::endl;
+            }
+          }
+        }
+        catch( std::exception const& e) {
+          // eat the exception, probably bad path
+        }
+
+	ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+        ostr << std::left << "Memory Status" << std::endl;
+        ostr << std::left << std::setw(17) << "     Group"  << std::setw(20) << "Bank Mapping"
+             << std::setw(12)  << "Size" << std::setw(16) << "Mem Usage";
+        ostr << std::setw(8)  << "BO count" << std::endl;
+        try {
+          for (auto& v : sensor_tree::get_child("board.memory.grp")) {
+            int index = std::stoi(v.first);
+            if( index >= 0 ) {
+              std::string mem_usage, bank_mapping, size, tag;
+              unsigned bo_count = 0;
+              for (auto& subv : v.second) {
+                  if( subv.first == "bank_mapping" ) {
+                      bank_mapping = subv.second.get_value<std::string>();
+		  } else if( subv.first == "tag" ) {
+                      tag = subv.second.get_value<std::string>();
+		  } else if( subv.first == "size" ) {
+                      size = subv.second.get_value<std::string>();
+		  } else if( subv.first == "bo_count" ) {
+                      bo_count = subv.second.get_value<unsigned>();
+                  } else if( subv.first == "mem_usage" ) {
+                      mem_usage = subv.second.get_value<std::string>();
+                  }
+              }
+              ostr << std::left
+                   << "[" << std::right << std::setw(2) << index << "] " << std::left
+                   << std::setw(12) << tag 
+                   << std::setw(20) << bank_mapping
+                   << std::setw(12) << size << std::setw(16) << mem_usage
                    << std::setw(8) << bo_count << std::endl;
             }
           }

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -153,7 +153,7 @@ def initXRT(opt):
             print("[%d] %s @0x%x" % (i, ctypes.cast(mem[i].m_tag, ctypes.c_char_p).value, mem[i].mem_u2.m_base_address))
             if (mem[i].m_used == 0):
                 continue
-            opt.first_mem = i
+            opt.first_mem = 0
             break
 
     return 0


### PR DESCRIPTION
Hi,
Creating this PR for review this HBM changes.
Please review the changes follows:

Userspace changes for XRT layer
User_PF Driver changes for HBM support
New changes support the following functionality:

User can specify a range of HBM banks in the v++ connectivity section, Example:
-sp CU_0.in1:HBM[0:3] . The user needs to specify bank-id information in his host application
as well using Extension Pointer.
If the user doesn't specify anything through the Extension pointer, Then XRT should automatically
detect the HBM banks using the connectivity section present in rtd file.