### PR TITLE
CR-1067817 add new condition check for runtime clock scaling feature config

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1455,6 +1455,7 @@ static int get_temp_by_m_tag(struct xocl_xmc *xmc, char *m_tag)
 /* Runtime clock scaling sysfs node */
 static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev)
 {
+	void *xdev_hdl = xocl_get_xdev(xmc->pdev);
 	u32 reg;
 	bool cs_on_ptfm = false;
 	bool runtime_cs_enabled = false;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1730,8 +1730,22 @@ static ssize_t scaling_enabled_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
+	bool cs_ptfm;
+	bool runtime_cs_enabled = false;
 
-	return sprintf(buf, "%d\n", scaling_condition_check(xmc, dev));
+	cs_ptfm = scaling_condition_check(xmc, dev);
+	if (!cs_ptfm)
+		return sprintf(buf, "%d\n", runtime_cs_enabled);
+
+	u32 reg = READ_RUNTIME_CS(xmc, XMC_CLOCK_CONTROL_REG);
+	if (reg & XMC_CLOCK_SCALING_EN)
+		runtime_cs_enabled = true;
+
+	reg = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
+	if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_ENABLE)
+		runtime_cs_enabled = true;
+
+	return sprintf(buf, "%d\n", runtime_cs_enabled);
 }
 static DEVICE_ATTR_RW(scaling_enabled);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -370,13 +370,7 @@ struct xocl_xmc {
 	u64			cache_expire_secs;
 	struct xcl_sensor	*cache;
 	ktime_t			cache_expires;
-	/* Runtime clock scaling enabled status */
-	bool			runtime_cs_enabled;
 	u32			sc_presence;
-	/* Runtime clock scaling support on platform */
-	bool			cs_on_ptfm;
-	/* Indicates the currently loaded SC firmware does not support clock throttling.*/
-	bool			sc_no_cs;
 
 	/* XMC mailbox support. */
 	struct mutex		mbx_lock;
@@ -1096,7 +1090,6 @@ static void runtime_clk_scale_disable(struct xocl_xmc *xmc)
 	cntrl &= ~XMC_HOST_NEW_FEATURE_REG1_FEATURE_ENABLE;
 	WRITE_REG32(xmc, cntrl, XMC_HOST_NEW_FEATURE_REG1);
 
-	xmc->runtime_cs_enabled = false;
 	xocl_info(&xmc->pdev->dev, "runtime clock scaling is disabled\n");
 }
 
@@ -1112,7 +1105,6 @@ static void runtime_clk_scale_enable(struct xocl_xmc *xmc)
 	cntrl |= XMC_HOST_NEW_FEATURE_REG1_FEATURE_ENABLE;
 	WRITE_REG32(xmc, cntrl, XMC_HOST_NEW_FEATURE_REG1);
 
-	xmc->runtime_cs_enabled = true;
 	xocl_info(&xmc->pdev->dev, "runtime clock scaling is enabled\n");
 }
 
@@ -1463,32 +1455,42 @@ static int get_temp_by_m_tag(struct xocl_xmc *xmc, char *m_tag)
 /* Runtime clock scaling sysfs node */
 static bool scaling_condition_check(struct xocl_xmc *xmc, struct device *dev)
 {
-	if (xmc->sc_presence) {
-		u32 reg;
+	u32 reg;
+	bool cs_on_ptfm = false;
+	bool runtime_cs_enabled = false;
+	bool sc_no_cs = false;
 
+	if (!xmc->sc_presence) {
+		if (xocl_clk_scale_on(xdev_hdl)) {
+			reg = READ_RUNTIME_CS(xmc, XMC_CLOCK_CONTROL_REG);
+			if (reg & XMC_CLOCK_SCALING_EN)
+				runtime_cs_enabled = true;
+			cs_on_ptfm = true;
+		}
+	} else {
 		//Feature present bit may configured each time an xclbin is downloaded,
 		//or following a reset of the CMC Subsystem. So, check for latest
 		//status every time.
-		xmc->cs_on_ptfm = false;
-		xmc->runtime_cs_enabled = false;
+		cs_on_ptfm = false;
+		runtime_cs_enabled = false;
 		reg = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
 		if (reg & XMC_HOST_NEW_FEATURE_REG1_SC_NO_CS) {
-			xmc->sc_no_cs = true;
+			sc_no_cs = true;
 		} else {
 			if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT)
-				xmc->cs_on_ptfm = true;
+				cs_on_ptfm = true;
 			if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_ENABLE)
-				xmc->runtime_cs_enabled = true;
+				runtime_cs_enabled = true;
 		}
 	}
 
-	if (!xmc->runtime_cs_enabled) {
+	if (!runtime_cs_enabled) {
 		if (!XMC_PRIVILEGED(xmc)) {
 			xocl_dbg(dev, "runtime clock scaling is not supported in non privileged mode\n");
-		} else if (xmc->sc_no_cs) {
+		} else if (sc_no_cs) {
 			xocl_dbg(dev, "currently loaded SC firmware does not support runtime clock scalling\n");
 			return false;
-		} else if (xmc->cs_on_ptfm) {
+		} else if (cs_on_ptfm) {
 			xocl_dbg(dev, "runtime clock scaling is not enabled\n");
 			return true;
 		} else {
@@ -1728,15 +1730,8 @@ static ssize_t scaling_enabled_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
-	u32 val = 0;
-	bool cs_en;
 
-	cs_en = scaling_condition_check(xmc, dev);
-	if (!cs_en)
-		return sprintf(buf, "%d\n", val);
-
-	val =  xmc->runtime_cs_enabled;
-	return sprintf(buf, "%d\n", val);
+	return sprintf(buf, "%d\n", scaling_condition_check(xmc, dev));
 }
 static DEVICE_ATTR_RW(scaling_enabled);
 
@@ -3242,27 +3237,30 @@ static int xmc_probe(struct platform_device *pdev)
 	 * the enabled bit in feature ROM on user side at all?
 	 */
 	if (XMC_PRIVILEGED(xmc)) {
+		bool cs_on_ptfm = false;
+		bool runtime_cs_enabled = false;
+		bool sc_no_cs = false;
 		if (!xmc->sc_presence) {
 			if (xocl_clk_scale_on(xdev_hdl)) {
+				cs_on_ptfm = true;
 				u32 reg = READ_RUNTIME_CS(xmc, XMC_CLOCK_CONTROL_REG);
 				if (reg & XMC_CLOCK_SCALING_EN)
-					xmc->runtime_cs_enabled = true;
-				xmc->cs_on_ptfm = true;
+					runtime_cs_enabled = true;
 			}
 		} else {
 			u32 reg = READ_REG32(xmc, XMC_HOST_NEW_FEATURE_REG1);
 			if (reg & XMC_HOST_NEW_FEATURE_REG1_SC_NO_CS) {
-				xmc->sc_no_cs = true;
+				sc_no_cs = true;
 			} else {
 				if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT)
-					xmc->cs_on_ptfm = true;
+					cs_on_ptfm = true;
 				if (reg & XMC_HOST_NEW_FEATURE_REG1_FEATURE_ENABLE)
-					xmc->runtime_cs_enabled = true;
+					runtime_cs_enabled = true;
 			}
 		}
-		if (xmc->sc_no_cs)
+		if (sc_no_cs)
 			xocl_info(&pdev->dev, "Loaded SC firmware does not support Runtime clock scaling.\n");
-		else if (xmc->cs_on_ptfm)
+		else if (cs_on_ptfm)
 			xocl_info(&pdev->dev, "Runtime clock scaling is supported.\n");
 	}
 


### PR DESCRIPTION
The new bit 30 (in 0xB20 reg) set to '1' indicates that the currently
loaded SC firmware does not support clock throttling.
XRT can set bit 29 (Feature present) if the ULP metadata indicates that
hardware support for throttling is loaded, but should not set bit 28
(Feature enabled) if the new bit 30 is set to '1'.
A dmesg report should be generated to indicate that runtime clock
throttling is not supported if the user tries to enable clock throttling
when bit 30 is set to '1'.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>