### PR TITLE
xocl: fix coverity warning

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/libqdma_export.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/libqdma_export.c
@@ -288,7 +288,7 @@ static ssize_t qdma_request_submit_st_c2h(struct xlnx_dma_dev *xdev,
 		return -EINVAL;
 	}
 
-	if (!work_pending(&descq->req_work))
+	if (!work_pending((&(descq->req_work))))
 		schedule_work(&descq->req_work);
 
 	/** if there is a completion thread associated,


### PR DESCRIPTION
libqdma_export.c: fix CID 209911: Out-of-bounds access (ARRAY_VS_SINGLETON).
libxdma.c: fix for CID 208715: Value not atomically updated (ATOMICITY)