### PR TITLE
Slight refactoring of XDP plugin structure

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -23,8 +23,6 @@
 #include "xdp/profile/writer/hal/hal_device_trace_writer.h"
 #include "xdp/profile/writer/hal/hal_summary_writer.h"
 
-#include "xdp/profile/writer/vp_base/vp_run_summary.h"
-
 #include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/device_trace_offload.h"
@@ -87,9 +85,6 @@ namespace xdp {
       (db->getStaticInfo()).addOpenedFile(fileName.c_str(), "VP_TRACE");
       ++index;
       handle = xclOpen(index, "/dev/null", XCL_INFO) ;			
-    }
-    if (db->claimRunSummaryOwnership()) {
-      writers.push_back(new VPRunSummaryWriter("hal.run_summary"));
     }
   }
 

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -16,7 +16,6 @@
 
 #include "xdp/profile/plugin/lop/lop_plugin.h"
 #include "xdp/profile/writer/lop/low_overhead_trace_writer.h"
-#include "xdp/profile/writer/vp_base/vp_run_summary.h"
 
 namespace xdp {
 
@@ -129,11 +128,6 @@ namespace xdp {
   {
     db->registerPlugin(this) ;
     writers.push_back(new LowOverheadTraceWriter("lop_trace.csv")) ;
-
-    if (db->claimRunSummaryOwnership())
-    {
-      writers.push_back(new VPRunSummaryWriter("xclbin.run_summary")) ;
-    }
 
     emulationSetup() ;
 

--- a/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
@@ -16,7 +16,6 @@
 
 #include "xdp/profile/plugin/user/user_plugin.h"
 #include "xdp/profile/writer/user/user_events_trace_writer.h"
-#include "xdp/profile/writer/vp_base/vp_run_summary.h"
 
 namespace xdp {
 
@@ -26,11 +25,6 @@ namespace xdp {
 
     writers.push_back(new UserEventsTraceWriter("user_events.csv")) ;
     (db->getStaticInfo()).addOpenedFile("user_events.csv", "VP_TRACE") ;
-    
-    if (db->claimRunSummaryOwnership())
-    {
-      writers.push_back(new VPRunSummaryWriter("xclbin.run_summary")) ;
-    }
   }
 
   UserEventsPlugin::~UserEventsPlugin()

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
-#include "xdp/profile/device/device_intf.h"
+#include "xdp/profile/writer/vp_base/vp_run_summary.h"
 
 #ifdef _WIN32
 #pragma warning(disable : 4996)
@@ -30,8 +30,11 @@ namespace xdp {
 
   XDPPlugin::XDPPlugin() : db(VPDatabase::Instance())
   {
-    // The base class should not add any devices as different plugins
-    //  should not clash with respect to the accessing the hardware.
+    // Every combination of plugins should generate a single run summary file
+    if (db->claimRunSummaryOwnership())
+    {
+      writers.push_back(new VPRunSummaryWriter("xclbin.run_summary")) ;
+    }
   }
 
   XDPPlugin::~XDPPlugin()
@@ -58,10 +61,6 @@ namespace xdp {
     }
   }
 
-  void XDPPlugin::updateDevice(void* /*device*/, const void* /*binary*/)
-  {
-  }
-
   void XDPPlugin::writeAll(bool openNewFiles)
   {
     // Base functionality is just to have all writers write.  Derived
@@ -70,12 +69,6 @@ namespace xdp {
     {
       w->write(openNewFiles) ;
     }
-  }
-
-  void XDPPlugin::readDeviceInfo(void* /*device*/)
-  {
-    // Since we can have multiple plugins, the default behavior should 
-    //  be that the plugin doesn't read any device information
   }
 
 }

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -47,17 +47,9 @@ namespace xdp {
     
     inline VPDatabase* getDatabase() { return db ; }
 
-    // Update the given device with newly loaded xclbin
-    XDP_EXPORT virtual void updateDevice(void* /*device*/, const void* /*binary*/);
-
     // When the database gets reset or at the end of execution,
     //  the plugins must make sure all of their writers dump a complete file
     XDP_EXPORT virtual void writeAll(bool openNewFiles = true) ;
-
-    // If any devices are related to this plugin, this will force
-    //  the device events to be flushed to the database for a particular 
-    //  device.
-    XDP_EXPORT virtual void readDeviceInfo(void* device) ;
   } ;
 
 }


### PR DESCRIPTION
Moving the run summary ownership claiming to the XDPPlugin base class, so any combination of plugins will always generate a run summary file.  

Also, cleaning up a few functions in the XDPPlugin base class that will be specific to a device offload plugin and are not common across all plugins.
