### PR TITLE
CR-1066711 VCK5000 Download of XCLBIN fails in latest XRT build

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -821,20 +821,13 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 			ret = -ENOMEM;
 		} else {
 			memcpy(buf, xclbin, xclbin_len);
-			if (XOCL_DSA_IS_VERSAL(lro)) {
-				xocl_subdev_destroy_by_id(lro, XOCL_SUBDEV_CLOCK);
-				ret = xocl_xfer_versal_download_axlf(lro, buf);
-				/*
-				 *Note: this is a workaround for enabling ULP
-				 * level clock after xclbin download. We will
-				 * have new-code to replace this api. For fast
-				 * fix, just enable it temporarily.
-				 */
-				xocl_subdev_create_by_id(lro, XOCL_SUBDEV_CLOCK);
 
-			} else {
+			/* Note: future xclbin library to load axlf */
+			if (XOCL_DSA_IS_VERSAL(lro))
+				ret = xocl_xclbin_load_axlf(lro, buf);
+			else
 				ret = xocl_icap_download_axlf(lro, buf);
-			}
+
 			vfree(buf);
 		}
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -349,9 +349,94 @@ done:
 	return ret;
 }
 
+static const struct axlf_section_header *get_axlf_section_hdr(
+	struct xfer_versal *xv, const struct axlf *top, enum axlf_section_kind kind)
+{
+	int i;
+	const struct axlf_section_header *hdr = NULL;
+
+	for (i = 0; i < top->m_header.m_numSections; i++) {
+		if (top->m_sections[i].m_sectionKind == kind) {
+			hdr = &top->m_sections[i];
+			break;
+		}
+	}
+
+	if (hdr) {
+		if ((hdr->m_sectionOffset + hdr->m_sectionSize) >
+			top->m_header.m_length) {
+			XV_ERR(xv, "found section %d is invalid", kind);
+			hdr = NULL;
+		} else {
+			XV_INFO(xv, "section %d offset: %llu, size: %llu",
+				kind, hdr->m_sectionOffset, hdr->m_sectionSize);
+		}
+	} else {
+		XV_INFO(xv, "could not find section header %d", kind);
+	}
+
+	return hdr;
+}
+
+static void parse_partition_metadata(struct xfer_versal *xv,
+	const struct axlf *top, void **addr, uint64_t *size)
+{
+	void *section = NULL;
+	const struct axlf_section_header *hdr =
+		get_axlf_section_hdr(xv, top, PARTITION_METADATA);
+
+	if (hdr == NULL)
+		return;
+
+	section = vmalloc(hdr->m_sectionSize);
+	if (section == NULL)
+		return;
+
+	memcpy(section, ((const char *)top) + hdr->m_sectionOffset,
+		hdr->m_sectionSize);
+
+	*addr = section;
+	*size = hdr->m_sectionSize;
+}
+
+/* Note: this is a workaround for enabling ULP level clock after xclbin
+ * download. We will have new-code to replace this api. For fast fix, just
+ * enable it temporarily.
+ */
+static int xclbin_load_axlf(struct platform_device *pdev, const void *buf)
+{
+	struct xfer_versal *xv = platform_get_drvdata(pdev);
+	struct axlf *xclbin = (struct axlf *)buf;
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	void *metadata = NULL;	
+	uint64_t size;
+	struct xocl_subdev *urpdevs;
+	int i, ret = 0, num_dev = 0;
+	
+	parse_partition_metadata(xv, xclbin, &metadata, &size);
+	if (metadata) {
+		num_dev = xocl_fdt_parse_blob(xdev, metadata,
+		    size, &urpdevs);
+		vfree(metadata);
+	}
+	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+
+	/* download bitstream */
+	ret = xfer_versal_download_axlf(pdev, buf);
+
+	if (num_dev) {
+		for (i = 0; i < num_dev; i++)
+			(void) xocl_subdev_create(xdev, &urpdevs[i].info);
+		xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+	}
+
+	return ret;
+}
+
 /* Kernel APIs exported from this sub-device driver */
 static struct xocl_xfer_versal_funcs xfer_versal_ops = {
 	.download_axlf = xfer_versal_download_axlf,
+	.xclbin_load_axlf = xclbin_load_axlf,
 };
 
 static int xfer_versal_open(struct inode *inode, struct file *file)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1539,6 +1539,8 @@ struct xocl_flash_funcs {
 struct xocl_xfer_versal_funcs {
 	int (*download_axlf)(struct platform_device *pdev,
 		const void __user *arg);
+	int (*xclbin_load_axlf)(struct platform_device *pdev,
+		const void __user *arg);
 };
 
 #define	XFER_VERSAL_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL).pldev
@@ -1548,7 +1550,10 @@ struct xocl_xfer_versal_funcs {
 #define	xocl_xfer_versal_download_axlf(xdev, xclbin)	\
 	(XFER_VERSAL_CB(xdev) ?					\
 	XFER_VERSAL_OPS(xdev)->download_axlf(XFER_VERSAL_DEV(xdev), xclbin) : -ENODEV)
-
+/* Note: this API is a workaround, will be relocated into xclbin lib */
+#define	xocl_xclbin_load_axlf(xdev, xclbin)	\
+	(XFER_VERSAL_CB(xdev) ?					\
+	XFER_VERSAL_OPS(xdev)->xclbin_load_axlf(XFER_VERSAL_DEV(xdev), xclbin) : -ENODEV)
 
 /* subdev mbx messages */
 #define XOCL_MSG_SUBDEV_VER	1


### PR DESCRIPTION
This is the temporary fix (should be relocated to xclbin lib within a week). 
I will also document a CR for this workaround (no write on freq_cnt).
```
Test Result:
1) Stress test, run 55+ times, no issue found;
root@xsjyliu50:~# /proj/rdi/staff/davidzha/share/clock_stress.sh
Test(55): sleep 1 s
bandwidth PASSED.
Test(56): ^C

2) Unit test;
root@xsjyliu50:~# xbutil clock -g 120
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil clock succeeded.
root@xsjyliu50:~# xbutil clock -f 140
INFO: Found total 1 card(s), 1 are usable
INFO: xbutil clock succeeded.
root@xsjyliu50:~# xbutil dump|grep clock
            "clock0": "140",
            "clock1": "119",
            "clock2": "0",
```