### PR TITLE
CR-1067079 reduce Over Temp limit to 110c from 125c on SmartSSD U2 board

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -53,7 +53,11 @@ enum {
 	XOCL_DSAFLAG_VERSAL			= (1 << 11),
 	XOCL_DSAFLAG_MPSOC			= (1 << 12),
 	XOCL_DSAFLAG_NOSC			= (1 << 13),
-	XOCL_DSAFLAG_OT_OVERRIDE		= (1 << 14),
+};
+
+/* sysmon flags */
+enum {
+	XOCL_SYSMON_OT_OVERRIDE		= (1 << 0),
 };
 
 #define	FLASH_TYPE_SPI	"spi"
@@ -115,6 +119,10 @@ struct xocl_msix_privdata {
 struct xocl_ert_sched_privdata {
 	char			dsa;
 	int			major;
+};
+
+struct xocl_sysmon_privdata {
+	uint16_t		flags;
 };
 
 #ifdef __KERNEL__
@@ -352,6 +360,22 @@ struct xocl_subdev_map {
 		XOCL_RES_SYSMON,			\
 		ARRAY_SIZE(XOCL_RES_SYSMON),		\
 		.override_idx = -1,			\
+	}
+
+#define XOCL_PRIV_SYSMON_U2				\
+	((struct xocl_sysmon_privdata){			\
+		XOCL_SYSMON_OT_OVERRIDE,		\
+	 })
+
+#define	XOCL_DEVINFO_SYSMON_U2		\
+	{						\
+		XOCL_SUBDEV_SYSMON,			\
+		XOCL_SYSMON,				\
+		XOCL_RES_SYSMON,			\
+		ARRAY_SIZE(XOCL_RES_SYSMON),		\
+		.override_idx = -1,			\
+		.priv_data = &XOCL_PRIV_SYSMON_U2,	\
+		.data_len = sizeof(struct xocl_sysmon_privdata), \
 	}
 
 /* Will be populated dynamically */
@@ -1874,9 +1898,9 @@ struct xocl_subdev_map {
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
 			XOCL_DEVINFO_PRP_IORES_MGMT,			\
-		 	XOCL_DEVINFO_AXIGATE_ULP,			\
+			XOCL_DEVINFO_AXIGATE_ULP,			\
 			XOCL_DEVINFO_CLOCK_LEGACY,			\
-			XOCL_DEVINFO_SYSMON,				\
+			XOCL_DEVINFO_SYSMON_U2,			\
 			XOCL_DEVINFO_AF,				\
 			XOCL_DEVINFO_XVC_PUB,				\
 			XOCL_DEVINFO_XIIC,				\
@@ -1905,8 +1929,7 @@ struct xocl_subdev_map {
 
 #define	XOCL_BOARD_MGMT_U2						\
 	(struct xocl_board_private){					\
-		.flags		= XOCL_DSAFLAG_NOSC |			\
-			XOCL_DSAFLAG_OT_OVERRIDE,			\
+		.flags		= XOCL_DSAFLAG_NOSC,			\
 		.subdev_info	= MGMT_RES_U2,				\
 		.subdev_num = ARRAY_SIZE(MGMT_RES_U2),			\
 		.flash_type = FLASH_TYPE_SPI,				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -53,6 +53,7 @@ enum {
 	XOCL_DSAFLAG_VERSAL			= (1 << 11),
 	XOCL_DSAFLAG_MPSOC			= (1 << 12),
 	XOCL_DSAFLAG_NOSC			= (1 << 13),
+	XOCL_DSAFLAG_OT_OVERRIDE		= (1 << 14),
 };
 
 #define	FLASH_TYPE_SPI	"spi"
@@ -1904,7 +1905,8 @@ struct xocl_subdev_map {
 
 #define	XOCL_BOARD_MGMT_U2						\
 	(struct xocl_board_private){					\
-		.flags		= XOCL_DSAFLAG_NOSC,			\
+		.flags		= XOCL_DSAFLAG_NOSC |			\
+			XOCL_DSAFLAG_OT_OVERRIDE,			\
 		.subdev_info	= MGMT_RES_U2,				\
 		.subdev_num = ARRAY_SIZE(MGMT_RES_U2),			\
 		.flash_type = FLASH_TYPE_SPI,				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/sysmon.c
@@ -342,8 +342,8 @@ static int sysmon_probe(struct platform_device *pdev)
 	}
 
 	if (ot_override(pdev)) {
-		xocl_info(&pdev->dev, "Over temperature threshold override is enabled");
-		WRITE_REG32(sysmon, (ADC_CODE_TEMP_110 << 1) |
+		xocl_info(&pdev->dev, "Over temperature threshold override is set");
+		WRITE_REG32(sysmon, (ADC_CODE_TEMP_110 << 4) |
 			OT_UPPER_ALARM_REG_OVERRIDE, OT_UPPER_ALARM_REG);
 	}
 


### PR DESCRIPTION
Reducing over temperature threshold value from 125c to 110c for SmartSSD U2 board.
12 bit ADC code which has to be programmed in over temp upper reg (53h), needs to be calculated using temperature sensor transfer functions defined at equation 4-2 from UG580 document.

The default OT threshold is only overridden to a custom OT upper alarm threshold value when the OT upper alarm threshold register (53h) ends with 0011b (DI[3:0]).
 