### PR TITLE
should reset ulp axigate during xclbin download for vck5000

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -421,12 +421,11 @@ static int xclbin_load_axlf(struct platform_device *pdev, const void *buf)
 	}
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
-	ret = xocl_axigate_freeze(xdev, XOCL_SUBDEV_LEVEL_PRP);
-	if (ret)
-		goto done;
+	xocl_axigate_freeze(xdev, XOCL_SUBDEV_LEVEL_PRP);
 
 	/* download bitstream */
 	ret = xfer_versal_download_axlf(pdev, buf);
+
 	xocl_axigate_free(xdev, XOCL_SUBDEV_LEVEL_PRP);
 
 	if (num_dev) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -421,15 +421,20 @@ static int xclbin_load_axlf(struct platform_device *pdev, const void *buf)
 	}
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
+	ret = xocl_axigate_freeze(xdev, XOCL_SUBDEV_LEVEL_PRP);
+	if (ret)
+		goto done;
+
 	/* download bitstream */
 	ret = xfer_versal_download_axlf(pdev, buf);
+	xocl_axigate_free(xdev, XOCL_SUBDEV_LEVEL_PRP);
 
 	if (num_dev) {
 		for (i = 0; i < num_dev; i++)
 			(void) xocl_subdev_create(xdev, &urpdevs[i].info);
 		xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 	}
-
+done:
 	return ret;
 }
 


### PR DESCRIPTION
Mark requested this changes. Logically, we should reset axigate for xclbin download. 

Test Result:
```
run this script over 100+ times /proj/rdi/staff/davidzha/share/clock_stress.sh
Test(104): sleep 1 s
verify PASSED.

```