### PR TITLE
Update covbuild.sh script for local coverity build

### DIFF
--- a/build/covbuild.sh
+++ b/build/covbuild.sh
@@ -2,11 +2,30 @@
 
 set -e
 
+# Prepare a Coverity Scan build of XRT for manual upload to
+# the XRT project on scan.coverity.com
+#
+# Usage:
+#  # Configure the compilers, only needed when building from clean slate
+#  % covbuild.sh --configure
+#
+#  # Build XRT
+#  % covbuild.sh
+#  ...
+#  Coverity build completed, make sure it was successful, then upload xrt.tgz to scan.coverity.com
+#  file: /proj/xsjhdstaff3/soeren/git/stsoe/XRT.coverity/build/coverity/xrt.tgz
+#  Project Version: 2.7.0.c
+#  Description/tag: 6e449a961eda6efa705f3480337b4e4347e3f27b
+#
+# Update to scan.coverity.com using the version and description per covbuild.sh output
+# Make sure to upload from a host with direct access to xrt.tgz (342M)
+
 OSDIST=`lsb_release -i |awk -F: '{print tolower($2)}' | tr -d ' \t'`
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
-COVBIN=/home/soeren/tools/coverity/cov-analysis-linux64-2017.07/bin
+#COVBIN=/home/soeren/tools/coverity/cov-analysis-linux64-2017.07/bin
+COVBIN=/home/soeren/tools/coverity/cov-analysis-linux64-2019.03/bin
 
 if [[ $OSDIST == "centos" ]]; then
     CMAKE=cmake3
@@ -16,11 +35,11 @@ if [[ $OSDIST == "centos" ]]; then
     fi
 fi
 
-if [[ $(git branch | grep '*' | cut -d ' ' -f2) != "2018.3" ]]; then
-    echo "Currently only analyzing 2018.3"
-    echo "covbuild.sh must be run on branch 2018.3"
-    exit
-fi
+#if [[ $(git branch | grep '*' | cut -d ' ' -f2) != "2018.3" ]]; then
+#    echo "Currently only analyzing 2018.3"
+#    echo "covbuild.sh must be run on branch 2018.3"
+#    exit
+#fi
 
 usage()
 {
@@ -33,6 +52,7 @@ usage()
 
 clean=0
 ccache=1
+configure=0
 while [ $# -gt 0 ]; do
     case "$1" in
         -help)
@@ -40,6 +60,10 @@ while [ $# -gt 0 ]; do
             ;;
         clean|-clean)
             clean=1
+            shift
+            ;;
+        -configure|--configure)
+            configure=1
             shift
             ;;
         *)
@@ -59,15 +83,21 @@ if [ $clean == 1 ]; then
     exit 0
 fi
 
+if [ $configure == 1 ]; then
+    $COVBIN/cov-configure --template --config $BUILDDIR/coverity/config/conf.xml --compiler c++
+    $COVBIN/cov-configure --template --config $BUILDDIR/coverity/config/conf.xml --compiler gcc
+    exit 0
+fi
+
 mkdir -p coverity
 cd coverity
 /bin/rm -f xrt.tgz
 imed=$PWD/cov-int
 $CMAKE -DCMAKE_BUILD_TYPE=Release ../../src
-$COVBIN/cov-build --dir $imed make -j4
+$COVBIN/cov-build --config $BUILDDIR/coverity/config/conf.xml --dir $imed make -j4
 make DESTDIR=$PWD install
-cd usr/src/xrt-2.1.0/driver/xclng/drm/xocl
-$COVBIN/cov-build --dir $imed make
+cd usr/src/xrt-2.7.0/driver/xocl
+$COVBIN/cov-build --config $BUILDDIR/coverity/config/conf.xml --dir $imed make
 cd $BUILDDIR/coverity
 tar czvf xrt.tgz cov-int
 cd $here
@@ -75,6 +105,6 @@ cd $here
 if [[ -e $BUILDDIR/coverity/xrt.tgz ]]; then
     echo "Coverity build completed, make sure it was successful, then upload xrt.tgz to scan.coverity.com"
     echo "file: $BUILDDIR/coverity/xrt.tgz"
-    echo "Project Version: 2.1.0"
+    echo "Project Version: 2.7.0.c"
     echo "Description/tag: $(git rev-parse HEAD)"
 fi


### PR DESCRIPTION
The build artifacts (xrt.tgz) should be uploaded to scan.coverity.com
where it will be analyzed.