### PR TITLE
XRT-553 KDS should not crash or lead to kernel crash while application exit unexpected

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -27,6 +27,13 @@ static void cu_hls_put_credit(void *core, u32 count)
 		cu_hls->credits = cu_hls->max_credits;
 }
 
+static int cu_hls_is_zero_credit(void *core)
+{
+	struct xrt_cu_hls *cu_hls = core;
+
+	return (cu_hls->credits)? 0 : 1;
+}
+
 static void cu_hls_configure(void *core, u32 *data, size_t sz, int type)
 {
 	struct xrt_cu_hls *cu_hls = core;
@@ -105,6 +112,7 @@ static void cu_hls_check(void *core, struct xcu_status *status)
 	 */
 	if (ctrl_reg & CU_AP_DONE) {
 		done_reg = 1;
+		cu_hls->run_cnts--;
 		if (cu_hls->ctrl_chain)
 			iowrite32(CU_AP_CONTINUE, cu_hls->vaddr);
 	}
@@ -117,6 +125,7 @@ out:
 static struct xcu_funcs xrt_cu_hls_funcs = {
 	.get_credit	= cu_hls_get_credit,
 	.put_credit	= cu_hls_put_credit,
+	.is_zero_credit	= cu_hls_is_zero_credit,
 	.configure	= cu_hls_configure,
 	.start		= cu_hls_start,
 	.check		= cu_hls_check,
@@ -128,10 +137,6 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	struct resource *res;
 	size_t size;
 	int err = 0;
-
-	err = xrt_cu_init(xcu);
-	if (err)
-		return err;
 
 	core = kzalloc(sizeof(struct xrt_cu_hls), GFP_KERNEL);
 	if (!core) {
@@ -156,6 +161,10 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 
 	xcu->core = core;
 	xcu->funcs = &xrt_cu_hls_funcs;
+
+	err = xrt_cu_init(xcu);
+	if (err)
+		return err;
 
 	return 0;
 

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -33,7 +33,6 @@ struct kds_command;
 struct kds_cmd_ops {
 	void (*notify_host)(struct kds_command *xcmd, int status);
 	void (*free)(struct kds_command *xcmd);
-	int (*is_abort)(struct kds_command *xcmd);
 };
 
 /**

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -24,6 +24,8 @@ enum kds_opcode {
 enum kds_status {
 	KDS_COMPLETED	= 0,
 	KDS_ERROR	= 1,
+	KDS_ABORT,
+	KDS_TIMEOUT,
 };
 
 struct kds_command;
@@ -31,6 +33,7 @@ struct kds_command;
 struct kds_cmd_ops {
 	void (*notify_host)(struct kds_command *xcmd, int status);
 	void (*free)(struct kds_command *xcmd);
+	int (*is_abort)(struct kds_command *xcmd);
 };
 
 /**
@@ -52,11 +55,13 @@ struct kds_command {
 	u32			 cu_mask[4];
 	u32			 num_mask;
 	u32			 payload_type;
+	u64			 start;
 	struct kds_cmd_ops	 cb;
 	/* execbuf is used to update the header
 	 * of execbuf when notifying host
 	 */
 	u32			*execbuf;
+	void			*gem_obj;
 };
 
 /* execbuf command related funtions */

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -74,6 +74,7 @@ struct kds_client {
 	int			  num_ctx;
 	int			  virt_cu_ref;
 	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
+	int			  abort;
 #if PRE_ALLOC
 	u32			  max_xcmd;
 	u32			  xcmd_idx;
@@ -89,6 +90,7 @@ struct kds_client {
 	u64			  padding[16];
 	wait_queue_head_t	  waitq;
 	atomic_t		  event;
+	atomic_t		  outstanding_cmds;
 };
 
 /* the MSB of cu_refs is used for exclusive flag */
@@ -115,6 +117,7 @@ struct kds_sched {
 	struct list_head	clients;
 	int			num_client;
 	struct mutex		lock;
+	bool			bad_state;
 	struct kds_cu_mgmt	cu_mgmt;
 };
 
@@ -122,6 +125,8 @@ int kds_init_sched(struct kds_sched *kds);
 int kds_init_client(struct kds_sched *kds, struct kds_client *client);
 void kds_fini_sched(struct kds_sched *kds);
 void kds_fini_client(struct kds_sched *kds, struct kds_client *client);
+void kds_reset(struct kds_sched *kds);
+int is_bad_state(struct kds_sched *kds);
 u32 kds_live_clients(struct kds_sched *kds, pid_t **plist);
 int kds_add_cu(struct kds_sched *kds, struct xrt_cu *xcu);
 int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -74,7 +74,6 @@ struct kds_client {
 	int			  num_ctx;
 	int			  virt_cu_ref;
 	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
-	int			  abort;
 #if PRE_ALLOC
 	u32			  max_xcmd;
 	u32			  xcmd_idx;

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -90,7 +90,6 @@ struct kds_client {
 	u64			  padding[16];
 	wait_queue_head_t	  waitq;
 	atomic_t		  event;
-	atomic_t		  outstanding_cmds;
 };
 
 /* the MSB of cu_refs is used for exclusive flag */

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -77,6 +77,13 @@ struct xcu_funcs {
 	void (*put_credit)(void *core, u32 count);
 
 	/**
+	 * @is_zero_credit:
+	 *
+	 * Check if CU core has zero credit.
+	 */
+	int (*is_zero_credit)(void *core);
+
+	/**
 	 * @configure:
 	 *
 	 * Congifure CU arguments.
@@ -185,8 +192,11 @@ struct xrt_cu {
 	struct semaphore	  sem;
 	void                     *core;
 	u32			  stop;
+	bool			  timeout;
 	u32			  done_cnt;
 	u32			  ready_cnt;
+	u64			  run_timeout;
+	struct kds_command	 *old_cmd;
 	/**
 	 * @funcs:
 	 *
@@ -231,6 +241,11 @@ static inline int xrt_cu_get_credit(struct xrt_cu *xcu)
 	return xcu->funcs->get_credit(xcu->core);
 }
 
+static inline int is_zero_credit(struct xrt_cu *xcu)
+{
+	return xcu->funcs->is_zero_credit(xcu->core);
+}
+
 static inline void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count)
 {
 	xcu->funcs->put_credit(xcu->core, count);
@@ -242,6 +257,7 @@ static inline void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count)
  */
 int xrt_cu_thread(void *data);
 void xrt_cu_submit(struct xrt_cu *xcu, struct kds_command *xcmd);
+int xrt_cu_status(struct xrt_cu *xcu);
 
 int  xrt_cu_init(struct xrt_cu *xcu);
 void xrt_cu_fini(struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -164,6 +164,14 @@ struct xrt_cu_info {
 	bool	intr_enable;
 };
 
+#define CU_STATE_GOOD  0x1
+#define CU_STATE_BAD   0x2
+struct xrt_cu_event {
+	struct mutex		  lock;
+	void			 *client;
+	int			  state;
+};
+
 struct xrt_cu {
 	struct device		 *dev;
 	struct xrt_cu_info	  info;
@@ -192,11 +200,12 @@ struct xrt_cu {
 	struct semaphore	  sem;
 	void                     *core;
 	u32			  stop;
-	bool			  timeout;
+	bool			  bad_state;
 	u32			  done_cnt;
 	u32			  ready_cnt;
 	u64			  run_timeout;
 	struct kds_command	 *old_cmd;
+	struct xrt_cu_event	  ev;
 	/**
 	 * @funcs:
 	 *
@@ -257,7 +266,9 @@ static inline void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count)
  */
 int xrt_cu_thread(void *data);
 void xrt_cu_submit(struct xrt_cu *xcu, struct kds_command *xcmd);
-int xrt_cu_status(struct xrt_cu *xcu);
+int xrt_cu_abort(struct xrt_cu *xcu, void *client);
+int xrt_cu_abort_done(struct xrt_cu *xcu);
+void xrt_cu_set_bad_state(struct xrt_cu *xcu);
 
 int  xrt_cu_init(struct xrt_cu *xcu);
 void xrt_cu_fini(struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -7,6 +7,7 @@
  * Authors: min.ma@xilinx.com
  */
 
+#include <linux/delay.h>
 #include "xrt_cu.h"
 
 /**
@@ -35,8 +36,13 @@ static inline void process_cq(struct xrt_cu *xcu)
 static inline void process_sq(struct xrt_cu *xcu)
 {
 	struct kds_command *xcmd;
+	u64 time;
 
-	if (!xcu->num_sq)
+	/* A submitted command might be done but the CU is still
+	 * not ready for next command. In this case, check CU status
+	 * to get ready count.
+	 */
+	if (!xcu->num_sq && !is_zero_credit(xcu))
 		return;
 
 	/* If no command is running on the hardware,
@@ -49,6 +55,19 @@ static inline void process_sq(struct xrt_cu *xcu)
 	if (xcu->ready_cnt) {
 		xrt_cu_put_credit(xcu, xcu->ready_cnt);
 		xcu->ready_cnt = 0;
+	}
+
+	if (!xcu->done_cnt && xcu->num_sq) {
+		xcmd = list_first_entry(&xcu->sq, struct kds_command, list);
+		if (!xcu->old_cmd || xcu->old_cmd != xcmd) {
+			xcu->old_cmd = xcmd;
+			return;
+		}
+
+		time = ktime_get_raw_fast_ns();
+		if (time - xcmd->start > xcu->run_timeout)
+			xcu->timeout = 1;
+		return;
 	}
 
 	/* Move all of the completed commands to completed queue */
@@ -77,6 +96,17 @@ static inline int process_rq(struct xrt_cu *xcu)
 
 	xcmd = list_first_entry(&xcu->rq, struct kds_command, list);
 
+	/* No lock here. Abort would only be set while destroy the client.
+	 * If we got old data, just run one more command. No harm.
+	 */
+	if (xcmd->cb.is_abort(xcmd)) {
+		xcmd->cb.notify_host(xcmd, KDS_ABORT);
+		list_del(&xcmd->list);
+		xcmd->cb.free(xcmd);
+		--xcu->num_rq;
+		return 1;
+	}
+
 	if (!xrt_cu_get_credit(xcu))
 		return 0;
 
@@ -85,11 +115,26 @@ static inline int process_rq(struct xrt_cu *xcu)
 	xrt_cu_start(xcu);
 
 	/* Move xcmd to submmited queue */
+	xcmd->start = ktime_get_raw_fast_ns();
 	list_move_tail(&xcmd->list, &xcu->sq);
 	--xcu->num_rq;
 	++xcu->num_sq;
 
 	return 1;
+}
+
+/* Use for flush queue when timeout */
+static inline void flush_queue(struct list_head *q, u32 *len, int status)
+{
+	struct kds_command *xcmd;
+
+	while (*len) {
+		xcmd = list_first_entry(q, struct kds_command, list);
+		xcmd->cb.notify_host(xcmd, status);
+		list_del(&xcmd->list);
+		xcmd->cb.free(xcmd);
+		--(*len);
+	}
 }
 
 int xrt_cu_thread(void *data)
@@ -99,8 +144,9 @@ int xrt_cu_thread(void *data)
 	int ret = 0;
 
 	while (!xcu->stop) {
-		/* process run queue would return 1 if submit a command to CU
-		 * Let's try submit another command
+		/* Make sure to submit as many commands as possible.
+		 * This is why we call continue here. This is important to make
+		 * CU busy, especially CU has hardware queue.
 		 */
 		if (process_rq(xcu))
 			continue;
@@ -113,7 +159,10 @@ int xrt_cu_thread(void *data)
 		process_cq(xcu);
 		process_sq(xcu);
 
-		/* Continue until run queue emtpy */
+		if (xcu->timeout)
+			break;
+
+		/* Continue until run queue empty */
 		if (xcu->num_rq)
 			continue;
 
@@ -127,6 +176,30 @@ int xrt_cu_thread(void *data)
 		 */
 		if (!xcu->num_pq)
 			continue;
+		spin_lock_irqsave(&xcu->pq_lock, flags);
+		if (xcu->num_pq) {
+			list_splice_tail_init(&xcu->pq, &xcu->rq);
+			xcu->num_rq = xcu->num_pq;
+			xcu->num_pq = 0;
+		}
+		spin_unlock_irqrestore(&xcu->pq_lock, flags);
+	}
+
+	if (!xcu->timeout)
+		return ret;
+
+	/* CU timeout detected, maybe CU is hang/deadlock. Or maybe the command
+	 * needs more time to execute.
+	 */
+	xcu_err(xcu, "CU(%d) timeout, please reset device", xcu->info.cu_idx);
+	flush_queue(&xcu->sq, &xcu->num_sq, KDS_TIMEOUT);
+	flush_queue(&xcu->cq, &xcu->num_cq, KDS_TIMEOUT);
+	while (!xcu->stop) {
+		flush_queue(&xcu->rq, &xcu->num_rq, KDS_TIMEOUT);
+
+		if (down_interruptible(&xcu->sem))
+			ret = -ERESTARTSYS;
+
 		spin_lock_irqsave(&xcu->pq_lock, flags);
 		if (xcu->num_pq) {
 			list_splice_tail_init(&xcu->pq, &xcu->rq);
@@ -156,6 +229,11 @@ void xrt_cu_submit(struct xrt_cu *xcu, struct kds_command *xcmd)
 		up(&xcu->sem);
 }
 
+int xrt_cu_status(struct xrt_cu *xcu)
+{
+	return (xcu->timeout)? -1 : 0;
+}
+
 int xrt_cu_init(struct xrt_cu *xcu)
 {
 	int err = 0;
@@ -174,6 +252,8 @@ int xrt_cu_init(struct xrt_cu *xcu)
 	/* Initialize completed queue */
 	INIT_LIST_HEAD(&xcu->cq);
 
+	/* default timeout 10ms */
+	xcu->run_timeout = 10000000;
 	sema_init(&xcu->sem, 0);
 	xcu->thread = kthread_run(xrt_cu_thread, xcu, "xrt_thread");
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -119,11 +119,12 @@ int
 zocl_execbuf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 {
 	struct drm_zocl_dev *zdev = dev->dev_private;
+	int ret = 0;
 
 	if (kds_mode == 1)
-		zocl_command_ioctl(zdev, data, filp);
+		ret = zocl_command_ioctl(zdev, data, filp);
 	else
-		zocl_execbuf_exec(dev, data, filp);
+		ret = zocl_execbuf_exec(dev, data, filp);
 
-	return 0;
+	return ret;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -213,6 +213,8 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 		ecmd->state = ERT_CMD_STATE_ERROR;
 	else if (status == KDS_TIMEOUT)
 		ecmd->state = ERT_CMD_STATE_TIMEOUT;
+	else if (status == KDS_ABORT)
+		ecmd->state = ERT_CMD_STATE_ABORT;
 
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -202,6 +202,25 @@ int zocl_context_ioctl(struct drm_zocl_dev *zdev, void *data,
 	return ret;
 }
 
+static void notify_execbuf(struct kds_command *xcmd, int status)
+{
+	struct kds_client *client = xcmd->client;
+	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+
+	if (status == KDS_COMPLETED)
+		ecmd->state = ERT_CMD_STATE_COMPLETED;
+	else if (status == KDS_ERROR)
+		ecmd->state = ERT_CMD_STATE_ERROR;
+	else if (status == KDS_TIMEOUT)
+		ecmd->state = ERT_CMD_STATE_TIMEOUT;
+
+	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
+
+	atomic_inc(&client->event);
+	atomic_dec(&client->outstanding_cmds);
+	wake_up_interruptible(&client->waitq);
+}
+
 int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		       struct drm_file *filp)
 {
@@ -217,6 +236,11 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 	if (!client->xclbin_id) {
 		DRM_ERROR("The client has no opening context\n");
 		return -EINVAL;
+	}
+
+	if (zdev->kds.bad_state) {
+		DRM_ERROR("KDS is in bad state\n");
+		return -EDEADLK;
 	}
 
 	gem_obj = zocl_gem_object_lookup(dev, filp, args->exec_bo_handle);
@@ -252,6 +276,8 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		cfg_ecmd2xcmd(to_cfg_pkg(ecmd), xcmd);
 	else if (ecmd->opcode == ERT_START_CU)
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+	xcmd->cb.notify_host = notify_execbuf;
+	xcmd->gem_obj = gem_obj;
 
 	/* Now, we could forget execbuf */
 	ret = kds_add_command(&zdev->kds, xcmd);
@@ -259,7 +285,6 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		kds_free_command(xcmd);
 
 out:
-	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&zocl_bo->cma_base.base);
 	return ret;
 }
 
@@ -317,9 +342,16 @@ void zocl_destroy_client(struct drm_zocl_dev *zdev, void **priv)
 	ddev = zdev->ddev;
 
 	kds = &zdev->kds;
+	/* kds_fini_client should released resources hold by the client.
+	 * release xclbin_id and unlock bitstream if needed.
+	 */
 	kds_fini_client(kds, client);
-	if (client->xclbin_id)
+	if (client->xclbin_id) {
+		(void) zocl_unlock_bitstream(zdev, client->xclbin_id);
 		vfree(client->xclbin_id);
+	}
+
+	/* Make sure all resources of the client are released */
 	kfree(client);
 	zocl_info(ddev->dev, "client exits pid(%d)\n", pid);
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -217,7 +217,6 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 
 	atomic_inc(&client->event);
-	atomic_dec(&client->outstanding_cmds);
 	wake_up_interruptible(&client->waitq);
 }
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -594,6 +594,8 @@ xclExecBuf(unsigned int cmdBO)
   drm_zocl_execbuf exec = {0, cmdBO};
   int result = ioctl(mKernelFD, DRM_IOCTL_ZOCL_EXECBUF, &exec);
   xclLog(XRT_DEBUG, "XRT", "%s: cmdBO handle %d, ioctl return %d", __func__, cmdBO, result);
+  if (result == -EDEADLK)
+      xclLog(XRT_ERROR, "XRT", "CU might hang, please reset device");
   return result;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -42,7 +42,6 @@ static ssize_t debug_store(struct device *dev,
 	struct xocl_cu *cu = platform_get_drvdata(pdev);
 	struct xrt_cu *xcu = &cu->base;
 #endif
-
 	/* Place holder for now. */
 	return count;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -343,7 +343,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 			goto done;
 		}
 	} else {
-		if (atomic_read(&xdev->outstanding_execs)) {
+		if (list_is_singular(&xdev->ctx_list) && atomic_read(&xdev->outstanding_execs)) {
 			err = -EDEADLK;
 			goto done;
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -337,6 +337,18 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		return -EINVAL;
 	}
 
+	if (kds_mode) {
+		if (is_bad_state(&XDEV(xdev)->kds)) {
+			err = -EDEADLK;
+			goto done;
+		}
+	} else {
+		if (atomic_read(&xdev->outstanding_execs)) {
+			err = -EDEADLK;
+			goto done;
+		}
+	}
+
 	if (xclbin_downloaded(xdev, &bin_obj.m_header.uuid))
 		goto done;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -191,6 +191,8 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 		ecmd->state = ERT_CMD_STATE_ERROR;
 	else if (status == KDS_TIMEOUT)
 		ecmd->state = ERT_CMD_STATE_TIMEOUT;
+	else if (status == KDS_ABORT)
+		ecmd->state = ERT_CMD_STATE_ABORT;
 
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -195,7 +195,6 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 
 	atomic_inc(&client->event);
-	atomic_dec(&client->outstanding_cmds);
 	wake_up_interruptible(&client->waitq);
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -180,6 +180,25 @@ static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,
 	return ret;
 }
 
+static void notify_execbuf(struct kds_command *xcmd, int status)
+{
+	struct kds_client *client = xcmd->client;
+	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+
+	if (status == KDS_COMPLETED)
+		ecmd->state = ERT_CMD_STATE_COMPLETED;
+	else if (status == KDS_ERROR)
+		ecmd->state = ERT_CMD_STATE_ERROR;
+	else if (status == KDS_TIMEOUT)
+		ecmd->state = ERT_CMD_STATE_TIMEOUT;
+
+	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
+
+	atomic_inc(&client->event);
+	atomic_dec(&client->outstanding_cmds);
+	wake_up_interruptible(&client->waitq);
+}
+
 static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 			      struct drm_file *filp)
 {
@@ -193,8 +212,13 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	int ret = 0;
 
 	if (!client->xclbin_id) {
-		DRM_ERROR("The client has no opening context\n");
+		userpf_err(xdev, "The client has no opening context\n");
 		return -EINVAL;
+	}
+
+	if (XDEV(xdev)->kds.bad_state) {
+		userpf_err(xdev, "KDS is in bad state\n");
+		return -EDEADLK;
 	}
 
 	obj = xocl_gem_object_lookup(ddev, filp, args->exec_bo_handle);
@@ -231,6 +255,8 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		cfg_ecmd2xcmd(to_cfg_pkg(ecmd), xcmd);
 	} else if (ecmd->opcode == ERT_START_CU)
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+	xcmd->cb.notify_host = notify_execbuf;
+	xcmd->gem_obj = obj;
 
 	/* Now, we could forget execbuf */
 	ret = kds_add_command(&XDEV(xdev)->kds, xcmd);
@@ -238,8 +264,6 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		kds_free_command(xcmd);
 
 out:
-	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&xobj->base);
-
 	return ret;
 }
 
@@ -277,8 +301,10 @@ void xocl_destroy_client(struct xocl_dev *xdev, void **priv)
 
 	kds = &XDEV(xdev)->kds;
 	kds_fini_client(kds, client);
-	if (client->xclbin_id)
+	if (client->xclbin_id) {
+		(void) xocl_icap_unlock_bitstream(xdev, client->xclbin_id);
 		vfree(client->xclbin_id);
+	}
 	kfree(client);
 	userpf_info(xdev, "client exits pid(%d)\n", pid);
 }
@@ -326,7 +352,7 @@ int xocl_init_sched(struct xocl_dev *xdev)
 
 	ret = sysfs_create_group(&dev->kobj, &xocl_kds_group);
 	if (ret)
-		userpf_err(dev, "create kds attrs failed: %d", ret);
+		userpf_err(xdev, "create kds attrs failed: %d", ret);
 
 	return kds_init_sched(&XDEV(xdev)->kds);
 }
@@ -347,7 +373,7 @@ int xocl_kds_stop(struct xocl_dev *xdev)
 
 int xocl_kds_reset(struct xocl_dev *xdev, const xuid_t *xclbin_id)
 {
-	/* plact holder */
+	kds_reset(&XDEV(xdev)->kds);
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1332,6 +1332,10 @@ int shim::xclLoadXclBin(const xclBin *buffer)
         xrt_logmsg(XRT_ERROR,
                    "Is xclmgmt driver loaded? Or is MSD/MPD running?");
       }
+      else if (ret == -EDEADLK) {
+        xrt_logmsg(XRT_ERROR, "CU was deadlocked? Hardware is not stable");
+        xrt_logmsg(XRT_ERROR, "Please reset device with 'xbutil reset'");
+      }
       xrt_logmsg(XRT_ERROR, "See dmesg log for details. err=%d", ret);
     }
 


### PR DESCRIPTION
This PR is to let new KDS be able to handle exceptions. For example,
1. User application exit without close context or even without waiting for all commands finish. 
2. CU hangs then commands are not able to complete.

For 1), while destroy client, driver would release all resources and other applications could still run without issue.
For 2), CU subdevice would detect if a command is timeout. Once timeout happened, the CU subdevice would mark all commands as TIMEOUT. While a client close the context of this CU, it would mark the whole KDS as bad state. The next new client would see error when download xclbin. In the case, XRT would hint the device needs reset to recover.