### PR TITLE
better /proc/iomem output for ep_ names

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -771,9 +771,9 @@ static int xocl_fdt_parse_ip(xdev_handle_t xdev_hdl, char *blob,
 		subdev->res[idx].flags = IORESOURCE_MEM;
 		snprintf(subdev->res_name[idx],
 			XOCL_SUBDEV_RES_NAME_LEN,
-			"%s %d %d %d",
+			"%s %d %d %d %s",
 			ip->name, ip->major, ip->minor,
-			ip->level);
+			ip->level, ip->regmap_name ? ip->regmap_name : "");
 		subdev->res[idx].name = subdev->res_name[idx];
 
 		subdev->bar_idx[idx] = bar_idx ? ntohl(*bar_idx) : 0;
@@ -791,9 +791,9 @@ static int xocl_fdt_parse_ip(xdev_handle_t xdev_hdl, char *blob,
 		subdev->res[idx].flags = IORESOURCE_IRQ;
 		snprintf(subdev->res_name[idx],
 			XOCL_SUBDEV_RES_NAME_LEN,
-			"%s %d %d %d",
+			"%s %d %d %d %s",
 			ip->name, ip->major, ip->minor,
-			ip->level);
+			ip->level, ip->regmap_name ? ip->regmap_name : "");
 		subdev->res[idx].name = subdev->res_name[idx];
 		subdev->info.num_res++;
 		sz -= sizeof(*irq_off) * 2;


### PR DESCRIPTION
print NULL as %s is an undefined behavior, so better to conservatively check if it is NULL.

Test Result:
```
root@xsjyliu50:~# cat /proc/iomem|grep ep_
      d4030000-d403000b : ep_pr_isolate_ulp_00
      d4032000-d4032003 : ep_ddr_mem_calib_00
      d4050000-d4050fff : ep_aclk_kernel_00
      d4051000-d4051fff : ep_aclk_kernel_01
      da030000-da03000b : ep_pr_isolate_ulp_00
      da032000-da032003 : ep_ddr_mem_calib_00
      da050000-da050fff : ep_aclk_kernel_00
      da051000-da051fff : ep_aclk_kernel_01
      382fee010000-382fee01ffff : ep_mailbox_user_00 1 0 1 mailbox
      382fee040000-382fee04ffff : ep_mailbox_user_to_ert_00 1 0 1 mailbox
      382ff3000000-382ff3007fff : ep_cmc_regmap_00 1 0 1 axi_bram_ctrl
      382ff3008000-382ff300ffff : ep_fpga_configuration_00 1 0 1 pdi_config_mem
      382ff5130000-382ff5130fff : ep_pmc_intr_00 1 0 1 axi_gpio
      382ff6010000-382ff6010fff : ep_pmc_mux_00 1 0 1 axi_gpio
      382ff6050000-382ff605ffff : ep_mailbox_mgmt_00 1 0 1 mailbox
      382ff6070000-382ff6070fff : ep_pr_isolate_ulp_00 1 0 1 axi_gpio
      382ff8000000-382ff800ffff : ep_qdma4_00 1 0 1 qdma

```