### PR TITLE
static xfer

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1275,7 +1275,7 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (XOCL_DSA_IS_VERSAL(lro)) {
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XFER_MGMT_VERSAL;
 		xocl_info(&pdev->dev,
-			"Should be in VSEC, but now probe static Start 0x%llx",
+			"probe xfer_versal Start 0x%llx",
 			subdev_info.res[0].start);
 		rc = xocl_subdev_create(lro, &subdev_info);
 		if (rc)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1272,6 +1272,16 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	(void) xocl_subdev_create_by_level(lro, XOCL_SUBDEV_LEVEL_BLD);
 	(void) xocl_subdev_create_vsec_devs(lro);
 
+	if (XOCL_DSA_IS_VERSAL(lro)) {
+		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XFER_MGMT_VERSAL;
+		xocl_info(&pdev->dev,
+			"Should be in VSEC, but now probe static Start 0x%llx",
+			subdev_info.res[0].start);
+		rc = xocl_subdev_create(lro, &subdev_info);
+		if (rc)
+			goto err_init_sysfs;
+	}
+
 	xocl_pmc_enable_reset(lro);
 
 	return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -519,6 +519,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.build_priv_data = NULL,
 		.devinfo_cb = NULL,
 	},
+	/* temporary disable dynamic probe, this should be probed from VSEC in the future
 	{
 		.id = XOCL_SUBDEV_XFER_VERSAL,
 		.dev_name = XOCL_XFER_VERSAL,
@@ -531,7 +532,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.build_priv_data = NULL,
 		.devinfo_cb = NULL,
 	},
-
+	*/
 	{
 		.id = XOCL_SUBDEV_ICAP,
 		.dev_name = XOCL_ICAP,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -519,7 +519,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.build_priv_data = NULL,
 		.devinfo_cb = NULL,
 	},
-	/* temporary disable dynamic probe, this should be probed from VSEC in the future
+#if 0
 	{
 		.id = XOCL_SUBDEV_XFER_VERSAL,
 		.dev_name = XOCL_XFER_VERSAL,
@@ -532,7 +532,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.build_priv_data = NULL,
 		.devinfo_cb = NULL,
 	},
-	*/
+#endif
 	{
 		.id = XOCL_SUBDEV_ICAP,
 		.dev_name = XOCL_ICAP,


### PR DESCRIPTION
Long term goal, having this in VSEC.
Short term goal, just hard-code for 2020.1_web release.

I have been helping devop to recover a VCK5000 which is not able to pass the xbutil validate test. I think this is what happend
He had a package whose uuid is 6fbef5f2d3107ef92b38d3a283717547 and flashed to the device
Install the latest package whose uuid is 174e4435e0d934c1ed1323770c6780bb
Then somehow, before update the shell, board was rebooted
Then the old shell can not find the metadata whose uuid is 6fbef5f2d3107ef92b38d3a283717547
The problem is there is no 6fbef5f2d3107ef92b38d3a283717547  package on his system any more. And he can not find that package anywhere. So the xfer_cache sub driver can not be probed.
Current solution is to install 2019.2 XRT where we use static ospi_versal resource. Then use xbmgmt flash --shell to force flash partition.pdi. Then reinstall the 2020.2 xrt back, cold reboot, and everything is back.

https://confluence.xilinx.com/pages/viewpage.action?spaceKey=DCG&title=Shell+Subsystem+-+Xilinx+VSEC+HW+Discovery For Alevo board, the OSPI_Controler res is flashed in VSEC.