### PR TITLE
qdma4: enable interrupt

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
@@ -262,9 +262,6 @@ static void data_intr_direct(struct xlnx_dma_dev *xdev, int vidx, int irq,
 	list_for_each_safe(entry, tmp, descq_list) {
 		descq = container_of(entry, struct qdma_descq, intr_list);
 
-		if (!descq)
-			continue;
-
 		if (descq->conf.ping_pong_en &&
 				descq->conf.q_type == Q_C2H && descq->conf.st)
 			descq->ping_pong_rx_time = timestamp;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
@@ -32,13 +32,14 @@
 #endif
 #include "qdma_access_common.h"
 
+#define MBOX_INTERRUPT_DISABLE
+
 #ifndef __QDMA_VF__
 static LIST_HEAD(legacy_intr_q_list);
 static spinlock_t legacy_intr_lock;
 static spinlock_t legacy_q_add_lock;
 static unsigned long legacy_intr_flags = IRQF_SHARED;
 #endif
-
 
 #ifndef __QDMA_VF__
 #ifdef DUMP_ON_ERROR_INTERRUPT
@@ -500,16 +501,15 @@ static int intr_vector_setup(struct xlnx_dma_dev *xdev, int idx,
 					  irq_bottom, 0,
 				  xdev->dev_intr_info_list[idx].msix_name,
 				  xdev);
-
-	pr_debug("%s requesting IRQ vector #%d: vec %d, type %d, %s.\n",
-			xdev->conf.name, idx, xdev->msix[idx].vector,
-			type, xdev->dev_intr_info_list[idx].msix_name);
-
 	if (rv) {
 		pr_err("%s requesting IRQ vector #%d: vec %d failed %d.\n",
 			xdev->conf.name, idx, xdev->msix[idx].vector, rv);
 		return rv;
 	}
+
+	pr_info("%s IRQ #%d: vec %d, %s.\n",
+		xdev->conf.name, idx, xdev->msix[idx].vector,
+		xdev->dev_intr_info_list[idx].msix_name);
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
@@ -729,7 +729,8 @@ int qdma4_device_offline(struct pci_dev *pdev, unsigned long dev_hndl,
 
 	qdma4_device_cleanup(xdev);
 	qdma_device_interrupt_cleanup(xdev);
-	qdma_mbox_stop(xdev);
+	if (xdev->dev_cap.mailbox_en && !xdev->conf.no_mailbox)
+		qdma_mbox_stop(xdev);
 	qdma4_intr_teardown(xdev);
 	xdev->flags &= ~(XDEV_FLAG_IRQ);
 
@@ -739,7 +740,8 @@ int qdma4_device_offline(struct pci_dev *pdev, unsigned long dev_hndl,
 	 * interrupt state of the VF goes bad. That's why switching
 	 * from mbox's interrupt mode to poll mode
 	 */
-	qdma_mbox_poll_start(xdev);
+	if (xdev->dev_cap.mailbox_en && !xdev->conf.no_mailbox)
+		qdma_mbox_poll_start(xdev);
 #ifdef __QDMA_VF__
 	if (reset) {
 		if (xdev->reset_state == RESET_STATE_RECV_PF_RESET_REQ) {
@@ -768,14 +770,16 @@ int qdma4_device_offline(struct pci_dev *pdev, unsigned long dev_hndl,
 			xdev->workq = NULL;
 		}
 	}
-	qdma_mbox_stop(xdev);
+	if (xdev->dev_cap.mailbox_en && !xdev->conf.no_mailbox)
+		qdma_mbox_stop(xdev);
 #elif defined(CONFIG_PCI_IOV)
 	if (!reset) {
 		qdma_pf_trigger_vf_offline((unsigned long)xdev);
 		xdev_sriov_disable(xdev);
 	} else if (xdev->vf_count_online != 0) {
 		qdma_pf_trigger_vf_reset((unsigned long)xdev);
-		qdma_mbox_stop(xdev);
+		if (xdev->dev_cap.mailbox_en && !xdev->conf.no_mailbox)
+			qdma_mbox_stop(xdev);
 	}
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -71,6 +71,11 @@ unsigned int qdma4_max_channel = 16;
 module_param(qdma4_max_channel, uint, 0644);
 MODULE_PARM_DESC(qdma4_max_channel, "Set number of channels for qdma, default is 16");
 
+static unsigned int qdma4_poll_mode;
+module_param(qdma4_poll_mode, uint, 0644);
+MODULE_PARM_DESC(poll_mode, "Set 1 for hw polling, default is 0 (interrupts)");
+
+
 struct dentry *qdma4_debugfs_root;
 
 static dev_t	str_dev;
@@ -1875,7 +1880,12 @@ static int qdma4_probe(struct platform_device *pdev)
 	conf->bar_num_config = dma_bar;
 	conf->bar_num_user = -1;
 	conf->bar_num_bypass = -1;
-	conf->qdma_drv_mode = POLL_MODE;
+	conf->no_mailbox = 1;
+	//conf->qdma_drv_mode = POLL_MODE;
+	conf->data_msix_qvec_max = 1;
+	conf->user_msix_qvec_max = 8;
+	conf->msix_qvec_max = 16;
+	conf->qdma_drv_mode = qdma4_poll_mode ? POLL_MODE : AUTO_MODE;
 
 	conf->fp_user_isr_handler = qdma_isr;
 	conf->uld = (unsigned long)qdma;


### PR DESCRIPTION
CID 211019 (#1 of 1): Logically dead code (DEADCODE)