### PR TITLE
XDP Coverity fixes

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -29,7 +29,7 @@
 
 namespace xdp {
 
-  DeviceOffloadPlugin::DeviceOffloadPlugin() : XDPPlugin()
+  DeviceOffloadPlugin::DeviceOffloadPlugin() : XDPPlugin(), trace_buffer_size(0)
   {
     active = db->claimDeviceOffloadOwnership() ;
     if (!active) return ; 
@@ -42,7 +42,7 @@ namespace xdp {
     convert << tb_size ;
     convert >> trace_buffer_size ;
     
-    continuous_trace = xrt_core::config::get_continuous_trace ;
+    continuous_trace = xrt_core::config::get_continuous_trace() ;
     continuous_trace_interval_ms = 
       xrt_core::config::get_continuous_trace_interval_ms() ;
   }


### PR DESCRIPTION
Fixing uninitialized variable in constructor and the referencing of a function address instead of calling the function in the constructor.