### PR TITLE
XRT-514 refactor icap.c phase1: migrate axlf parse among xocl and zocl

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -250,6 +250,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV
   common/drv/xrt_cu.c
   common/drv/cu_hls.c
   common/drv/cu_plram.c
+  common/drv/xrt_xclbin.c
   )
 
 SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
@@ -257,6 +258,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
   common/drv/include/kds_core.h
   common/drv/include/kds_command.h
   common/drv/include/xrt_cu.h
+  common/drv/include/xrt_xclbin.h
   )
 
 SET (XRT_DKMS_ABS_SRCS)

--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -53,6 +53,8 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/xocl_thread.c
   xocl/xocl_fdt.c
   xocl/xocl_fdt.h
+  xocl/xocl_xclbin.c
+  xocl/xocl_xclbin.h
   xocl/xocl_test.c
   xocl/userpf/common.h
   xocl/userpf/xocl_bo.c

--- a/src/runtime_src/core/common/drv/include/xrt_xclbin.h
+++ b/src/runtime_src/core/common/drv/include/xrt_xclbin.h
@@ -1,18 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * A GEM style device manager for PCIe based OpenCL accelerators.
+ * Xilinx Kernel Driver XCLBIN parser
  *
- * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020 Xilinx, Inc.
  *
  * Authors: David Zhang <davidzha@xilinx.com>
- *
- * This software is licensed under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation, and
- * may be copied, distributed, and modified under those terms.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
  */
 
 #ifndef _XRT_XCLBIN_H

--- a/src/runtime_src/core/common/drv/include/xrt_xclbin.h
+++ b/src/runtime_src/core/common/drv/include/xrt_xclbin.h
@@ -1,0 +1,78 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: David Zhang <davidzha@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _XRT_XCLBIN_H
+#define _XRT_XCLBIN_H
+
+#include <linux/types.h>
+
+/* Used for parsing bitstream header */
+#define XHI_EVEN_MAGIC_BYTE     0x0f
+#define XHI_ODD_MAGIC_BYTE      0xf0
+
+/* Extra mode for IDLE */
+#define XHI_OP_IDLE  -1
+#define XHI_BIT_HEADER_FAILURE -1
+
+/* The imaginary module length register */
+#define XHI_MLR                  15
+
+#define DMA_HWICAP_BITFILE_BUFFER_SIZE 1024
+
+enum axlf_section_kind;
+struct axlf_section_header;
+struct axlf;
+
+/**
+ * Bitstream header information.
+ */
+struct XHwIcap_Bit_Header {
+	unsigned int HeaderLength;     /* Length of header in 32 bit words */
+	unsigned int BitstreamLength;  /* Length of bitstream to read in bytes*/
+	unsigned char *DesignName;     /* Design name get from bitstream */
+	unsigned char *PartName;       /* Part name read from bitstream */
+	unsigned char *Date;           /* Date read from bitstream header */
+	unsigned char *Time;           /* Bitstream creation time*/
+	unsigned int MagicLength;      /* Length of the magic numbers*/
+};
+
+int
+xrt_xclbin_parse_header(const unsigned char *data,
+	unsigned int size, struct XHwIcap_Bit_Header *header);
+
+void
+xrt_xclbin_free_header(struct XHwIcap_Bit_Header *header);
+
+char *
+xrt_xclbin_kind_to_string(enum axlf_section_kind kind);
+
+const struct axlf_section_header *
+xrt_xclbin_get_section_hdr(const struct axlf *xclbin, enum axlf_section_kind kind);
+
+int
+xrt_xclbin_check_section_hdr(const struct axlf_section_header *header,
+	uint64_t xclbin_len);
+
+int
+xrt_xclbin_section_info(const struct axlf *xclbin, enum axlf_section_kind kind,
+	uint64_t *offset, uint64_t *size);
+
+int
+xrt_xclbin_get_section(const struct axlf *xclbin,
+	enum axlf_section_kind kind, void **data, uint64_t *len);
+
+#endif

--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -1,19 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * A GEM style device manager for PCIe based OpenCL accelerators.
+ * Xilinx Kernel Driver XCLBIN parser
  *
- * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020 Xilinx, Inc.
  *
  * Authors: David Zhang <davidzha@xilinx.com>
- *
- * This software is licensed under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation, and
- * may be copied, distributed, and modified under those terms.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
  */
+
 #include <asm/errno.h>
 #include <linux/vmalloc.h>
 #include "xclbin.h"
@@ -242,6 +235,7 @@ xrt_xclbin_section_info(const struct axlf *xclbin, enum axlf_section_kind kind,
 	return 0;
 }
 
+/* caller should free the allocated memory for **data */
 int xrt_xclbin_get_section(const struct axlf *xclbin,
 	enum axlf_section_kind kind, void **data, uint64_t *len)
 {

--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -1,0 +1,267 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: David Zhang <davidzha@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include <asm/errno.h>
+#include <linux/vmalloc.h>
+#include "xclbin.h"
+#include "xrt_xclbin.h"
+
+int xrt_xclbin_parse_header(const unsigned char *data,
+	unsigned int size, struct XHwIcap_Bit_Header *header)
+{
+	unsigned int i;
+	unsigned int len;
+	unsigned int tmp;
+	unsigned int index;
+
+	/* Start Index at start of bitstream */
+	index = 0;
+
+	/* Initialize HeaderLength.  If header returned early inidicates
+	 * failure.
+	 */
+	header->HeaderLength = XHI_BIT_HEADER_FAILURE;
+
+	/* Get "Magic" length */
+	header->MagicLength = data[index++];
+	header->MagicLength = (header->MagicLength << 8) | data[index++];
+
+	/* Read in "magic" */
+	for (i = 0; i < header->MagicLength - 1; i++) {
+		tmp = data[index++];
+		if (i%2 == 0 && tmp != XHI_EVEN_MAGIC_BYTE)
+			return -1;   /* INVALID_FILE_HEADER_ERROR */
+
+		if (i%2 == 1 && tmp != XHI_ODD_MAGIC_BYTE)
+			return -1;   /* INVALID_FILE_HEADER_ERROR */
+
+	}
+
+	/* Read null end of magic data. */
+	tmp = data[index++];
+
+	/* Read 0x01 (short) */
+	tmp = data[index++];
+	tmp = (tmp << 8) | data[index++];
+
+	/* Check the "0x01" half word */
+	if (tmp != 0x01)
+		return -1;	 /* INVALID_FILE_HEADER_ERROR */
+
+	/* Read 'a' */
+	tmp = data[index++];
+	if (tmp != 'a')
+		return -1;	  /* INVALID_FILE_HEADER_ERROR	*/
+
+	/* Get Design Name length */
+	len = data[index++];
+	len = (len << 8) | data[index++];
+
+	/* allocate space for design name and final null character. */
+	header->DesignName = vmalloc(len);
+
+	/* Read in Design Name */
+	for (i = 0; i < len; i++)
+		header->DesignName[i] = data[index++];
+
+
+	if (header->DesignName[len-1] != '\0')
+		return -1;
+
+	/* Read 'b' */
+	tmp = data[index++];
+	if (tmp != 'b')
+		return -1;	/* INVALID_FILE_HEADER_ERROR */
+
+	/* Get Part Name length */
+	len = data[index++];
+	len = (len << 8) | data[index++];
+
+	/* allocate space for part name and final null character. */
+	header->PartName = vmalloc(len);
+
+	/* Read in part name */
+	for (i = 0; i < len; i++)
+		header->PartName[i] = data[index++];
+
+	if (header->PartName[len-1] != '\0')
+		return -1;
+
+	/* Read 'c' */
+	tmp = data[index++];
+	if (tmp != 'c')
+		return -1;	/* INVALID_FILE_HEADER_ERROR */
+
+	/* Get date length */
+	len = data[index++];
+	len = (len << 8) | data[index++];
+
+	/* allocate space for date and final null character. */
+	header->Date = vmalloc(len);
+
+	/* Read in date name */
+	for (i = 0; i < len; i++)
+		header->Date[i] = data[index++];
+
+	if (header->Date[len - 1] != '\0')
+		return -1;
+
+	/* Read 'd' */
+	tmp = data[index++];
+	if (tmp != 'd')
+		return -1;	/* INVALID_FILE_HEADER_ERROR  */
+
+	/* Get time length */
+	len = data[index++];
+	len = (len << 8) | data[index++];
+
+	/* allocate space for time and final null character. */
+	header->Time = vmalloc(len);
+
+	/* Read in time name */
+	for (i = 0; i < len; i++)
+		header->Time[i] = data[index++];
+
+	if (header->Time[len - 1] != '\0')
+		return -1;
+
+	/* Read 'e' */
+	tmp = data[index++];
+	if (tmp != 'e')
+		return -1;	/* INVALID_FILE_HEADER_ERROR */
+
+	/* Get byte length of bitstream */
+	header->BitstreamLength = data[index++];
+	header->BitstreamLength = (header->BitstreamLength << 8) | data[index++];
+	header->BitstreamLength = (header->BitstreamLength << 8) | data[index++];
+	header->BitstreamLength = (header->BitstreamLength << 8) | data[index++];
+	header->HeaderLength = index;
+
+	return 0;
+}
+
+void
+xrt_xclbin_free_header(struct XHwIcap_Bit_Header *header)
+{
+	vfree(header->DesignName);
+	vfree(header->PartName);
+	vfree(header->Date);
+	vfree(header->Time);
+}
+
+char *
+xrt_xclbin_kind_to_string(enum axlf_section_kind kind)
+{
+	switch (kind) {
+	case 0:  return "BITSTREAM";
+	case 1:  return "CLEARING_BITSTREAM";
+	case 2:  return "EMBEDDED_METADATA";
+	case 3:  return "FIRMWARE";
+	case 4:  return "DEBUG_DATA";
+	case 5:  return "SCHED_FIRMWARE";
+	case 6:  return "MEM_TOPOLOGY";
+	case 7:  return "CONNECTIVITY";
+	case 8:  return "IP_LAYOUT";
+	case 9:  return "DEBUG_IP_LAYOUT";
+	case 10: return "DESIGN_CHECK_POINT";
+	case 11: return "CLOCK_FREQ_TOPOLOGY";
+	case 12: return "MCS";
+	case 13: return "BMC";
+	case 14: return "BUILD_METADATA";
+	case 15: return "KEYVALUE_METADATA";
+	case 16: return "USER_METADATA";
+	case 17: return "DNA_CERTIFICATE";
+	case 18: return "PDI";
+	case 19: return "BITSTREAM_PARTIAL_PDI";
+	case 20: return "DTC";
+	case 21: return "EMULATION_DATA";
+	case 22: return "SYSTEM_METADATA";
+	case 23: return "SOFT_KERNEL";
+	case 24: return "ASK_FLASH";
+	case 25: return "AIE_METADATA";
+	case 26: return "ASK_GROUP_TOPOLOGY";
+	case 27: return "ASK_GROUP_CONNECTIVITY";
+	default: return "UNKNOWN";
+	}
+}
+
+const struct axlf_section_header *
+xrt_xclbin_get_section_hdr(const struct axlf *xclbin, enum axlf_section_kind kind)
+{
+	int i = 0;
+
+	for (i = 0; i < xclbin->m_header.m_numSections; i++) {
+		if (xclbin->m_sections[i].m_sectionKind == kind)
+			return &xclbin->m_sections[i];
+	}
+
+	return NULL;
+}
+
+int
+xrt_xclbin_check_section_hdr(const struct axlf_section_header *header,
+	uint64_t xclbin_len)
+{
+	return (header->m_sectionOffset + header->m_sectionSize) > xclbin_len ?
+		-EINVAL : 0;
+}
+
+int
+xrt_xclbin_section_info(const struct axlf *xclbin, enum axlf_section_kind kind,
+	uint64_t *offset, uint64_t *size)
+{
+	const struct axlf_section_header *memHeader = NULL;
+	uint64_t xclbin_len;
+	int err = 0;
+
+	memHeader = xrt_xclbin_get_section_hdr(xclbin, kind);
+	if (!memHeader)
+		return -EINVAL;
+
+	xclbin_len = xclbin->m_header.m_length;
+	err = xrt_xclbin_check_section_hdr(memHeader, xclbin_len);
+	if (err)
+		return err;
+
+	*offset = memHeader->m_sectionOffset;
+	*size = memHeader->m_sectionSize;
+
+	return 0;
+}
+
+int xrt_xclbin_get_section(const struct axlf *xclbin,
+	enum axlf_section_kind kind, void **data, uint64_t *len)
+{
+	void *section = NULL;
+	int err = 0;
+	uint64_t offset = 0;
+	uint64_t size = 0;
+
+	err = xrt_xclbin_section_info(xclbin, kind, &offset, &size);
+	if (err)
+		return err;
+
+	section = vmalloc(size);
+	if (section == NULL)
+		return -ENOMEM;
+
+	memcpy(section, ((const char *)xclbin) + offset, size);
+
+	*data = section;
+	*len = size;
+
+	return 0;
+}

--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -159,35 +159,35 @@ char *
 xrt_xclbin_kind_to_string(enum axlf_section_kind kind)
 {
 	switch (kind) {
-	case 0:  return "BITSTREAM";
-	case 1:  return "CLEARING_BITSTREAM";
-	case 2:  return "EMBEDDED_METADATA";
-	case 3:  return "FIRMWARE";
-	case 4:  return "DEBUG_DATA";
-	case 5:  return "SCHED_FIRMWARE";
-	case 6:  return "MEM_TOPOLOGY";
-	case 7:  return "CONNECTIVITY";
-	case 8:  return "IP_LAYOUT";
-	case 9:  return "DEBUG_IP_LAYOUT";
-	case 10: return "DESIGN_CHECK_POINT";
-	case 11: return "CLOCK_FREQ_TOPOLOGY";
-	case 12: return "MCS";
-	case 13: return "BMC";
-	case 14: return "BUILD_METADATA";
-	case 15: return "KEYVALUE_METADATA";
-	case 16: return "USER_METADATA";
-	case 17: return "DNA_CERTIFICATE";
-	case 18: return "PDI";
-	case 19: return "BITSTREAM_PARTIAL_PDI";
-	case 20: return "DTC";
-	case 21: return "EMULATION_DATA";
-	case 22: return "SYSTEM_METADATA";
-	case 23: return "SOFT_KERNEL";
-	case 24: return "ASK_FLASH";
-	case 25: return "AIE_METADATA";
-	case 26: return "ASK_GROUP_TOPOLOGY";
-	case 27: return "ASK_GROUP_CONNECTIVITY";
-	default: return "UNKNOWN";
+	case BITSTREAM:  		return "BITSTREAM";
+	case CLEARING_BITSTREAM:  	return "CLEARING_BITSTREAM";
+	case EMBEDDED_METADATA:  	return "EMBEDDED_METADATA";
+	case FIRMWARE:  		return "FIRMWARE";
+	case DEBUG_DATA:  		return "DEBUG_DATA";
+	case SCHED_FIRMWARE:  		return "SCHED_FIRMWARE";
+	case MEM_TOPOLOGY:  		return "MEM_TOPOLOGY";
+	case CONNECTIVITY:  		return "CONNECTIVITY";
+	case IP_LAYOUT:  		return "IP_LAYOUT";
+	case DEBUG_IP_LAYOUT:  		return "DEBUG_IP_LAYOUT";
+	case DESIGN_CHECK_POINT: 	return "DESIGN_CHECK_POINT";
+	case CLOCK_FREQ_TOPOLOGY: 	return "CLOCK_FREQ_TOPOLOGY";
+	case MCS: 			return "MCS";
+	case BMC: 			return "BMC";
+	case BUILD_METADATA: 		return "BUILD_METADATA";
+	case KEYVALUE_METADATA: 	return "KEYVALUE_METADATA";
+	case USER_METADATA: 		return "USER_METADATA";
+	case DNA_CERTIFICATE: 		return "DNA_CERTIFICATE";
+	case PDI: 			return "PDI";
+	case BITSTREAM_PARTIAL_PDI: 	return "BITSTREAM_PARTIAL_PDI";
+	case PARTITION_METADATA: 	return "PARTITION_METADATA";
+	case EMULATION_DATA: 		return "EMULATION_DATA";
+	case SYSTEM_METADATA: 		return "SYSTEM_METADATA";
+	case SOFT_KERNEL: 		return "SOFT_KERNEL";
+	case ASK_FLASH: 		return "ASK_FLASH";
+	case AIE_METADATA: 		return "AIE_METADATA";
+	case ASK_GROUP_TOPOLOGY: 	return "ASK_GROUP_TOPOLOGY";
+	case ASK_GROUP_CONNECTIVITY: 	return "ASK_GROUP_CONNECTIVITY";
+	default: 			return "UNKNOWN";
 	}
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -7,7 +7,8 @@ ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -
 
 drv_common-y   := ../../../common/drv/kds_core.o \
 		  ../../../common/drv/cu_hls.o \
-		  ../../../common/drv/xrt_cu.o
+		  ../../../common/drv/xrt_cu.o \
+		  ../../../common/drv/xrt_xclbin.o
 
 zocl-y := \
 	$(drv_common-y) \

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -14,207 +14,12 @@
 #include <linux/fpga/fpga-mgr.h>
 #include "sched_exec.h"
 #include "zocl_xclbin.h"
+#include "xrt_xclbin.h"
 #include "xclbin.h"
-
-/* Used for parsing bitstream header */
-#define XHI_EVEN_MAGIC_BYTE     0x0f
-#define XHI_ODD_MAGIC_BYTE      0xf0
-
-/* Extra mode for IDLE */
-#define XHI_OP_IDLE  -1
-#define XHI_BIT_HEADER_FAILURE -1
-
-/* The imaginary module length register */
-#define XHI_MLR                  15
-
-#define DMA_HWICAP_BITFILE_BUFFER_SIZE 1024
-#define BITFILE_BUFFER_SIZE DMA_HWICAP_BITFILE_BUFFER_SIZE
 
 #define VIRTUAL_CU(id) (id == (u32)-1)
 
 extern int kds_mode;
-/**
- * Bitstream header information.
- */
-struct XHwIcap_Bit_Header {
-	unsigned int HeaderLength;     /* Length of header in 32 bit words */
-	unsigned int BitstreamLength;  /* Length of bitstream to read in bytes*/
-	unsigned char *DesignName;     /* Design name get from bitstream */
-	unsigned char *PartName;       /* Part name read from bitstream */
-	unsigned char *Date;           /* Date read from bitstream header */
-	unsigned char *Time;           /* Bitstream creation time*/
-	unsigned int MagicLength;      /* Length of the magic numbers*/
-};
-
-static char *
-kind_to_string(enum axlf_section_kind kind)
-{
-	switch (kind) {
-	case 0:  return "BITSTREAM";
-	case 1:  return "CLEARING_BITSTREAM";
-	case 2:  return "EMBEDDED_METADATA";
-	case 3:  return "FIRMWARE";
-	case 4:  return "DEBUG_DATA";
-	case 5:  return "SCHED_FIRMWARE";
-	case 6:  return "MEM_TOPOLOGY";
-	case 7:  return "CONNECTIVITY";
-	case 8:  return "IP_LAYOUT";
-	case 9:  return "DEBUG_IP_LAYOUT";
-	case 10: return "DESIGN_CHECK_POINT";
-	case 11: return "CLOCK_FREQ_TOPOLOGY";
-	case 12: return "MCS";
-	case 13: return "BMC";
-	case 14: return "BUILD_METADATA";
-	case 15: return "KEYVALUE_METADATA";
-	case 16: return "USER_METADATA";
-	case 17: return "DNA_CERTIFICATE";
-	case 18: return "PDI";
-	case 19: return "BITSTREAM_PARTIAL_PDI";
-	case 20: return "DTC";
-	case 21: return "EMULATION_DATA";
-	case 22: return "SYSTEM_METADATA";
-	default: return "UNKNOWN";
-	}
-}
-
-static int bitstream_parse_header(const unsigned char *Data, unsigned int Size,
-				  struct XHwIcap_Bit_Header *Header)
-{
-	unsigned int i;
-	unsigned int len;
-	unsigned int tmp;
-	unsigned int idx;
-
-	/* Start Index at start of bitstream */
-	idx = 0;
-
-	/* Initialize HeaderLength.  If header returned early inidicates
-	 * failure.
-	 */
-	Header->HeaderLength = XHI_BIT_HEADER_FAILURE;
-
-	/* Get "Magic" length */
-	Header->MagicLength = Data[idx++];
-	Header->MagicLength = (Header->MagicLength << 8) | Data[idx++];
-
-	/* Read in "magic" */
-	for (i = 0; i < Header->MagicLength - 1; i++) {
-		tmp = Data[idx++];
-		if (i%2 == 0 && tmp != XHI_EVEN_MAGIC_BYTE)
-			return -1;   /* INVALID_FILE_HEADER_ERROR */
-
-		if (i%2 == 1 && tmp != XHI_ODD_MAGIC_BYTE)
-			return -1;   /* INVALID_FILE_HEADER_ERROR */
-
-	}
-
-	/* Read null end of magic data. */
-	tmp = Data[idx++];
-
-	/* Read 0x01 (short) */
-	tmp = Data[idx++];
-	tmp = (tmp << 8) | Data[idx++];
-
-	/* Check the "0x01" half word */
-	if (tmp != 0x01)
-		return -1;	 /* INVALID_FILE_HEADER_ERROR */
-
-	/* Read 'a' */
-	tmp = Data[idx++];
-	if (tmp != 'a')
-		return -1;	  /* INVALID_FILE_HEADER_ERROR	*/
-
-	/* Get Design Name length */
-	len = Data[idx++];
-	len = (len << 8) | Data[idx++];
-
-	/* allocate space for design name and final null character. */
-	Header->DesignName = kmalloc(len, GFP_KERNEL);
-
-	/* Read in Design Name */
-	for (i = 0; i < len; i++)
-		Header->DesignName[i] = Data[idx++];
-
-	if (Header->DesignName[len-1] != '\0')
-		return -1;
-
-	/* Read 'b' */
-	tmp = Data[idx++];
-	if (tmp != 'b')
-		return -1;	/* INVALID_FILE_HEADER_ERROR */
-
-
-	/* Get Part Name length */
-	len = Data[idx++];
-	len = (len << 8) | Data[idx++];
-
-	/* allocate space for part name and final null character. */
-	Header->PartName = kmalloc(len, GFP_KERNEL);
-
-	/* Read in part name */
-	for (i = 0; i < len; i++)
-		Header->PartName[i] = Data[idx++];
-
-	if (Header->PartName[len-1] != '\0')
-		return -1;
-
-	/* Read 'c' */
-	tmp = Data[idx++];
-	if (tmp != 'c')
-		return -1;	/* INVALID_FILE_HEADER_ERROR */
-
-
-	/* Get date length */
-	len = Data[idx++];
-	len = (len << 8) | Data[idx++];
-
-	/* allocate space for date and final null character. */
-	Header->Date = kmalloc(len, GFP_KERNEL);
-
-	/* Read in date name */
-	for (i = 0; i < len; i++)
-		Header->Date[i] = Data[idx++];
-
-	if (Header->Date[len - 1] != '\0')
-		return -1;
-
-	/* Read 'd' */
-	tmp = Data[idx++];
-	if (tmp != 'd')
-		return -1;	/* INVALID_FILE_HEADER_ERROR  */
-
-	/* Get time length */
-	len = Data[idx++];
-	len = (len << 8) | Data[idx++];
-
-	/* allocate space for time and final null character. */
-	Header->Time = kmalloc(len, GFP_KERNEL);
-
-	/* Read in time name */
-	for (i = 0; i < len; i++)
-		Header->Time[i] = Data[idx++];
-
-	if (Header->Time[len - 1] != '\0')
-		return -1;
-
-	/* Read 'e' */
-	tmp = Data[idx++];
-	if (tmp != 'e')
-		return -1;	/* INVALID_FILE_HEADER_ERROR */
-
-	/* Get byte length of bitstream */
-	Header->BitstreamLength = Data[idx++];
-	Header->BitstreamLength = (Header->BitstreamLength << 8) | Data[idx++];
-	Header->BitstreamLength = (Header->BitstreamLength << 8) | Data[idx++];
-	Header->BitstreamLength = (Header->BitstreamLength << 8) | Data[idx++];
-	Header->HeaderLength = idx;
-
-	DRM_INFO("Design %s: Part %s: Timestamp %s %s: Raw data size 0x%x\n",
-			Header->DesignName, Header->PartName, Header->Time,
-			Header->Date, Header->BitstreamLength);
-
-	return 0;
-}
 
 static int
 zocl_fpga_mgr_load(struct drm_zocl_dev *zdev, const char *data, int size)
@@ -289,7 +94,7 @@ zocl_load_bitstream(struct drm_zocl_dev *zdev, char *buffer, int length)
 	char temp;
 
 	memset(&bit_header, 0, sizeof(bit_header));
-	if (bitstream_parse_header(buffer, BITFILE_BUFFER_SIZE, &bit_header)) {
+	if (xrt_xclbin_parse_header(buffer, BITFILE_BUFFER_SIZE, &bit_header)) {
 		DRM_ERROR("bitstream header parse failed");
 		return -EINVAL;
 	}
@@ -316,65 +121,6 @@ zocl_load_bitstream(struct drm_zocl_dev *zdev, char *buffer, int length)
 	return zocl_load_partial(zdev, data, bit_header.BitstreamLength);
 }
 
-/* should be obsoleted after mailbox implememted */
-static struct axlf_section_header *
-get_axlf_section(struct axlf *top, enum axlf_section_kind kind)
-{
-	int i = 0;
-
-	DRM_INFO("Finding %s section header", kind_to_string(kind));
-	for (i = 0; i < top->m_header.m_numSections; i++) {
-		if (top->m_sections[i].m_sectionKind == kind)
-			return &top->m_sections[i];
-	}
-	DRM_INFO("AXLF section %s header not found", kind_to_string(kind));
-	return NULL;
-}
-
-static int
-zocl_check_section(struct axlf_section_header *header, uint64_t xclbin_len,
-		enum axlf_section_kind kind)
-{
-	uint64_t offset;
-	uint64_t size;
-
-	DRM_INFO("Section %s details:", kind_to_string(kind));
-	DRM_INFO("  offset = 0x%llx", header->m_sectionOffset);
-	DRM_INFO("  size = 0x%llx", header->m_sectionSize);
-
-	offset = header->m_sectionOffset;
-	size = header->m_sectionSize;
-	if (offset + size > xclbin_len) {
-		DRM_ERROR("Section %s extends beyond xclbin boundary 0x%llx\n",
-				kind_to_string(kind), xclbin_len);
-		return -EINVAL;
-	}
-	return 0;
-}
-
-static int
-zocl_section_info(enum axlf_section_kind kind, struct axlf *axlf_full,
-	uint64_t *offset, uint64_t *size)
-{
-	struct axlf_section_header *memHeader = NULL;
-	uint64_t xclbin_len;
-	int err = 0;
-
-	memHeader = get_axlf_section(axlf_full, kind);
-	if (!memHeader)
-		return -ENODEV;
-
-	xclbin_len = axlf_full->m_header.m_length;
-	err = zocl_check_section(memHeader, xclbin_len, kind);
-	if (err)
-		return err;
-
-	*offset = memHeader->m_sectionOffset;
-	*size = memHeader->m_sectionSize;
-
-	return 0;
-}
-
 static int
 zocl_offsetof_sect(enum axlf_section_kind kind, void *sect,
 		struct axlf *axlf_full, char __user *xclbin_ptr)
@@ -384,9 +130,12 @@ zocl_offsetof_sect(enum axlf_section_kind kind, void *sect,
 	void **sect_tmp = (void *)sect;
 	int err = 0;
 
-	err = zocl_section_info(kind, axlf_full, &offset, &size);
-	if (err)
+	err = xrt_xclbin_section_info(axlf_full, kind, &offset, &size);
+	if (err) {
+		DRM_WARN("get section %s err: %d ",
+		    xrt_xclbin_kind_to_string(kind), err);
 		return 0;
+	}
 
 	*sect_tmp = &xclbin_ptr[offset];
 
@@ -403,13 +152,18 @@ zocl_read_sect(enum axlf_section_kind kind, void *sect,
 	void **sect_tmp = (void *)sect;
 	int err = 0;
 
-	err = zocl_section_info(kind, axlf_full, &offset, &size);
-	if (err)
+	err = xrt_xclbin_section_info(axlf_full, kind, &offset, &size);
+	if (err) {
+		DRM_WARN("get section %s err: %d ",
+		    xrt_xclbin_kind_to_string(kind), err);
 		return 0;
+	}
 
 	*sect_tmp = vmalloc(size);
 	err = copy_from_user(*sect_tmp, &xclbin_ptr[offset], size);
 	if (err) {
+		DRM_WARN("copy_from_user for section %s err: %d ",
+		    xrt_xclbin_kind_to_string(kind), err);
 		vfree(*sect_tmp);
 		sect = NULL;
 		return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -94,7 +94,8 @@ zocl_load_bitstream(struct drm_zocl_dev *zdev, char *buffer, int length)
 	char temp;
 
 	memset(&bit_header, 0, sizeof(bit_header));
-	if (xrt_xclbin_parse_header(buffer, BITFILE_BUFFER_SIZE, &bit_header)) {
+	if (xrt_xclbin_parse_header(buffer, DMA_HWICAP_BITFILE_BUFFER_SIZE,
+	    &bit_header)) {
 		DRM_ERROR("bitstream header parse failed");
 		return -EINVAL;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -16,11 +16,36 @@
 obj-m	+= xclmgmt.o
 include $(PWD)/../lib/Makefile.in
 
+# Base on Linux Documentation/kbuild/modules.txt.
+# $(src) provides the absolute path by pointing to the directory
+# where the currently executing kbuild file is located.
+ifneq ($(src),)
+# building modules
+ifneq ($(wildcard $(src)/../../common),)
+# dpms dir
+common_dir = ../../common
+else
+# build from source code
+common_dir = ../../../../../common/drv
+endif
+
+else
+# clean
+common_dir = ../../../../../common/drv
+ifeq ($(wildcard ../../../../../common/drv),)
+common_dir = ../../common
+endif
+
+endif
+
+drv_common-y   := $(common_dir)/xrt_xclbin.o
+
 xclmgmt-y := \
 	../xocl_subdev.o \
 	../xocl_ctx.o \
 	../xocl_thread.o \
 	../xocl_fdt.o \
+	../xocl_xclbin.o \
 	../subdev/sysmon.o \
 	../subdev/feature_rom.o \
 	../subdev/microblaze.o \
@@ -47,6 +72,7 @@ xclmgmt-y := \
 	../subdev/ulite.o \
 	../subdev/calib_storage.o \
 	../subdev/pmc.o \
+	$(drv_common-y) \
 	mgmt-core.o \
 	mgmt-cw.o \
 	mgmt-utils.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -30,6 +30,7 @@
 #include "../xocl_drv.h"
 #include "version.h"
 #include "xclbin.h"
+#include "../xocl_xclbin.h"
 
 static const struct pci_device_id pci_ids[] = {
 	XOCL_MGMT_PCI_IDS,
@@ -822,11 +823,7 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 		} else {
 			memcpy(buf, xclbin, xclbin_len);
 
-			/* Note: future xclbin library to load axlf */
-			if (XOCL_DSA_IS_VERSAL(lro))
-				ret = xocl_xclbin_load_axlf(lro, buf);
-			else
-				ret = xocl_icap_download_axlf(lro, buf);
+			ret = xocl_xclbin_download(lro, buf);
 
 			vfree(buf);
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -26,6 +26,7 @@
 #include <linux/verification.h>
 #endif
 #include "xclbin.h"
+#include "xrt_xclbin.h"
 #include "../xocl_drv.h"
 #include "../xocl_drm.h"
 #include "mgmt-ioctl.h"
@@ -52,12 +53,13 @@ static struct key *icap_keys = NULL;
 	xocl_dbg(&(icap)->icap_pdev->dev, fmt "\n", ##arg)
 
 #define	ICAP_PRIVILEGED(icap)	((icap)->icap_regs != NULL)
-#define DMA_HWICAP_BITFILE_BUFFER_SIZE 1024
 
 /*
  * Block comment for spliting old icap into subdevs (icap, clock, xclbin, etc.)
+ *
  * Current design: all-in-one icap
  * Future design: multiple subdevs with their own territory
+ *
  * Phase1 design:
  *    - The clock subdev would only handle clock specific logic.
  *    - Before we are able to take xclbin subdev out of icap, we can keep
@@ -68,6 +70,13 @@ static struct key *icap_keys = NULL;
  *    Callers still call APIs through icap in phase1, eventually those APIs
  *    will be moved to xclbin subdev, and icap will redirect requests to clock
  *    subdev.
+ *
+ * Phase2 design:
+ *    - The clock is already a stand alone subdev on mgmt pf only.
+ *    - The xclbin is a library and cache data in pdev. Legacy icap interfaces
+ *      are relocated from icap to xclbin library. Since xclbin is splitted
+ *      from icap, icap subdev can be offline/online without lossing loaded
+ *      xclbin info.
  */
 
 /*
@@ -78,26 +87,6 @@ static struct key *icap_keys = NULL;
 #define ICAP_DEFAULT_EXPIRE_SECS	1
 
 #define INVALID_MEM_IDX			0xFFFF
-/*
- * Bitstream header information.
- */
-typedef struct {
-	unsigned int HeaderLength;     /* Length of header in 32 bit words */
-	unsigned int BitstreamLength;  /* Length of bitstream to read in bytes*/
-	unsigned char *DesignName;     /* Design name read from bitstream header */
-	unsigned char *PartName;       /* Part name read from bitstream header */
-	unsigned char *Date;           /* Date read from bitstream header */
-	unsigned char *Time;           /* Bitstream creation time read from header */
-	unsigned int MagicLength;      /* Length of the magic numbers in header */
-} XHwIcap_Bit_Header;
-#define XHI_BIT_HEADER_FAILURE	-1
-/* Used for parsing bitstream header */
-#define XHI_EVEN_MAGIC_BYTE	0x0f
-#define XHI_ODD_MAGIC_BYTE	0xf0
-/* Extra mode for IDLE */
-#define XHI_OP_IDLE		-1
-/* The imaginary module length register */
-#define XHI_MLR			15
 
 static struct attribute_group icap_attr_group;
 
@@ -354,8 +343,6 @@ static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
 static void icap_set_data(struct icap *icap, struct xcl_pr_region *hwicap);
 static uint64_t icap_get_data_nolock(struct platform_device *pdev, enum data_kind kind);
 static uint64_t icap_get_data(struct platform_device *pdev, enum data_kind kind);
-static const struct axlf_section_header *get_axlf_section_hdr(
-	struct icap *icap, const struct axlf *top, enum axlf_section_kind kind);
 static void icap_refresh_addrs(struct platform_device *pdev);
 static inline int icap_calibrate_mig(struct platform_device *pdev);
 static void icap_probe_urpdev(struct platform_device *pdev, struct axlf *xclbin,
@@ -655,7 +642,7 @@ static void xclbin_get_ocl_frequency_max_min(struct icap *icap,
 			*freq_max = topology->m_clock_freq[idx].m_freq_Mhz;
 
 		if (freq_min)
-			*freq_min = frequency_table[0].ocl;
+			*freq_min = 10;
 	}
 }
 
@@ -836,7 +823,7 @@ static int xclbin_setup_clock_freq_topology(struct icap *icap,
 	struct clock_freq_topology *topology;
 	struct clock_freq *clk_freq = NULL;
 	const struct axlf_section_header *hdr =
-		get_axlf_section_hdr(icap, xclbin, CLOCK_FREQ_TOPOLOGY);
+		xrt_xclbin_get_section_hdr(xclbin, CLOCK_FREQ_TOPOLOGY);
 
 	/* Can't find CLOCK_FREQ_TOPOLOGY, just return*/
 	if (!hdr)
@@ -947,144 +934,6 @@ static uint64_t icap_get_section_size(struct icap *icap, enum axlf_section_kind 
 	return size;
 }
 
-static int bitstream_parse_header(struct icap *icap, const unsigned char *data,
-	unsigned int size, XHwIcap_Bit_Header *header)
-{
-	unsigned int i;
-	unsigned int len;
-	unsigned int tmp;
-	unsigned int index;
-
-	/* Start Index at start of bitstream */
-	index = 0;
-
-	/* Initialize HeaderLength.  If header returned early inidicates
-	 * failure.
-	 */
-	header->HeaderLength = XHI_BIT_HEADER_FAILURE;
-
-	/* Get "Magic" length */
-	header->MagicLength = data[index++];
-	header->MagicLength = (header->MagicLength << 8) | data[index++];
-
-	/* Read in "magic" */
-	for (i = 0; i < header->MagicLength - 1; i++) {
-		tmp = data[index++];
-		if (i%2 == 0 && tmp != XHI_EVEN_MAGIC_BYTE)
-			return -1;   /* INVALID_FILE_HEADER_ERROR */
-
-		if (i%2 == 1 && tmp != XHI_ODD_MAGIC_BYTE)
-			return -1;   /* INVALID_FILE_HEADER_ERROR */
-
-	}
-
-	/* Read null end of magic data. */
-	tmp = data[index++];
-
-	/* Read 0x01 (short) */
-	tmp = data[index++];
-	tmp = (tmp << 8) | data[index++];
-
-	/* Check the "0x01" half word */
-	if (tmp != 0x01)
-		return -1;	 /* INVALID_FILE_HEADER_ERROR */
-
-	/* Read 'a' */
-	tmp = data[index++];
-	if (tmp != 'a')
-		return -1;	  /* INVALID_FILE_HEADER_ERROR	*/
-
-	/* Get Design Name length */
-	len = data[index++];
-	len = (len << 8) | data[index++];
-
-	/* allocate space for design name and final null character. */
-	header->DesignName = kmalloc(len, GFP_KERNEL);
-
-	/* Read in Design Name */
-	for (i = 0; i < len; i++)
-		header->DesignName[i] = data[index++];
-
-
-	if (header->DesignName[len-1] != '\0')
-		return -1;
-
-	/* Read 'b' */
-	tmp = data[index++];
-	if (tmp != 'b')
-		return -1;	/* INVALID_FILE_HEADER_ERROR */
-
-	/* Get Part Name length */
-	len = data[index++];
-	len = (len << 8) | data[index++];
-
-	/* allocate space for part name and final null character. */
-	header->PartName = kmalloc(len, GFP_KERNEL);
-
-	/* Read in part name */
-	for (i = 0; i < len; i++)
-		header->PartName[i] = data[index++];
-
-	if (header->PartName[len-1] != '\0')
-		return -1;
-
-	/* Read 'c' */
-	tmp = data[index++];
-	if (tmp != 'c')
-		return -1;	/* INVALID_FILE_HEADER_ERROR */
-
-	/* Get date length */
-	len = data[index++];
-	len = (len << 8) | data[index++];
-
-	/* allocate space for date and final null character. */
-	header->Date = kmalloc(len, GFP_KERNEL);
-
-	/* Read in date name */
-	for (i = 0; i < len; i++)
-		header->Date[i] = data[index++];
-
-	if (header->Date[len - 1] != '\0')
-		return -1;
-
-	/* Read 'd' */
-	tmp = data[index++];
-	if (tmp != 'd')
-		return -1;	/* INVALID_FILE_HEADER_ERROR  */
-
-	/* Get time length */
-	len = data[index++];
-	len = (len << 8) | data[index++];
-
-	/* allocate space for time and final null character. */
-	header->Time = kmalloc(len, GFP_KERNEL);
-
-	/* Read in time name */
-	for (i = 0; i < len; i++)
-		header->Time[i] = data[index++];
-
-	if (header->Time[len - 1] != '\0')
-		return -1;
-
-	/* Read 'e' */
-	tmp = data[index++];
-	if (tmp != 'e')
-		return -1;	/* INVALID_FILE_HEADER_ERROR */
-
-	/* Get byte length of bitstream */
-	header->BitstreamLength = data[index++];
-	header->BitstreamLength = (header->BitstreamLength << 8) | data[index++];
-	header->BitstreamLength = (header->BitstreamLength << 8) | data[index++];
-	header->BitstreamLength = (header->BitstreamLength << 8) | data[index++];
-	header->HeaderLength = index;
-
-	ICAP_INFO(icap, "Design \"%s\"", header->DesignName);
-	ICAP_INFO(icap, "Part \"%s\"", header->PartName);
-	ICAP_INFO(icap, "Timestamp \"%s %s\"", header->Time, header->Date);
-	ICAP_INFO(icap, "Raw data size 0x%x", header->BitstreamLength);
-	return 0;
-}
-
 static int bitstream_helper(struct icap *icap, const u32 *word_buffer,
 	unsigned word_count)
 {
@@ -1119,14 +968,14 @@ static long icap_download(struct icap *icap, const char *buffer,
 	unsigned long length)
 {
 	long err = 0;
-	XHwIcap_Bit_Header bit_header = { 0 };
+	struct XHwIcap_Bit_Header bit_header = { 0 };
 	unsigned numCharsRead = DMA_HWICAP_BITFILE_BUFFER_SIZE;
 	unsigned byte_read;
 
 	BUG_ON(!buffer);
 	BUG_ON(!length);
 
-	if (bitstream_parse_header(icap, buffer,
+	if (xrt_xclbin_parse_header(buffer,
 		DMA_HWICAP_BITFILE_BUFFER_SIZE, &bit_header)) {
 		err = -EINVAL;
 		goto free_buffers;
@@ -1155,65 +1004,9 @@ static long icap_download(struct icap *icap, const char *buffer,
 	err = wait_for_done(icap);
 
 free_buffers:
-	kfree(bit_header.DesignName);
-	kfree(bit_header.PartName);
-	kfree(bit_header.Date);
-	kfree(bit_header.Time);
+	xrt_xclbin_free_header(&bit_header);
 	return err;
 }
-
-static const struct axlf_section_header *get_axlf_section_hdr(
-	struct icap *icap, const struct axlf *top, enum axlf_section_kind kind)
-{
-	int i;
-	const struct axlf_section_header *hdr = NULL;
-
-	for (i = 0; i < top->m_header.m_numSections; i++) {
-		if (top->m_sections[i].m_sectionKind == kind) {
-			hdr = &top->m_sections[i];
-			break;
-		}
-	}
-
-	if (hdr) {
-		if ((hdr->m_sectionOffset + hdr->m_sectionSize) >
-			top->m_header.m_length) {
-			ICAP_ERR(icap, "found section %d is invalid", kind);
-			hdr = NULL;
-		} else {
-			ICAP_INFO(icap, "section %d offset: %llu, size: %llu",
-				kind, hdr->m_sectionOffset, hdr->m_sectionSize);
-		}
-	} else {
-		ICAP_WARN(icap, "could not find section header %d", kind);
-	}
-
-	return hdr;
-}
-
-static int alloc_and_get_axlf_section(struct icap *icap,
-	const struct axlf *top, enum axlf_section_kind kind,
-	void **addr, uint64_t *size)
-{
-	void *section = NULL;
-	const struct axlf_section_header *hdr =
-		get_axlf_section_hdr(icap, top, kind);
-
-	if (hdr == NULL)
-		return -EINVAL;
-
-	section = vmalloc(hdr->m_sectionSize);
-	if (section == NULL)
-		return -ENOMEM;
-
-	memcpy(section, ((const char *)top) + hdr->m_sectionOffset,
-		hdr->m_sectionSize);
-
-	*addr = section;
-	*size = hdr->m_sectionSize;
-	return 0;
-}
-
 
 static int icap_download_hw(struct icap *icap, const struct axlf *axlf)
 {
@@ -1231,7 +1024,7 @@ static int icap_download_hw(struct icap *icap, const struct axlf *axlf)
 
 	length = axlf->m_header.m_length;
 
-	primaryHeader = get_axlf_section_hdr(icap, axlf, BITSTREAM);
+	primaryHeader = xrt_xclbin_get_section_hdr(axlf, BITSTREAM);
 
 	if (primaryHeader) {
 		primaryFirmwareOffset = primaryHeader->m_sectionOffset;
@@ -1300,7 +1093,7 @@ static int icap_download_boot_firmware(struct platform_device *pdev)
 			}
 		}
 		if (!load_sched) {
-			mbHeader = get_axlf_section_hdr(icap, bin_obj_axlf,
+			mbHeader = xrt_xclbin_get_section_hdr(bin_obj_axlf,
 					SCHED_FIRMWARE);
 			if (mbHeader) {
 				mbBinaryOffset = mbHeader->m_sectionOffset;
@@ -1319,7 +1112,7 @@ static int icap_download_boot_firmware(struct platform_device *pdev)
 
 	if (xocl_mb_mgmt_on(xdev)) {
 		/* Try locating the board mgmt binary. */
-		mbHeader = get_axlf_section_hdr(icap, bin_obj_axlf, FIRMWARE);
+		mbHeader = xrt_xclbin_get_section_hdr(bin_obj_axlf, FIRMWARE);
 		if (mbHeader) {
 			mbBinaryOffset = mbHeader->m_sectionOffset;
 			mbBinaryLength = mbHeader->m_sectionSize;
@@ -1335,7 +1128,7 @@ static int icap_download_boot_firmware(struct platform_device *pdev)
 		xocl_mb_reset(xdev);
 
 	/* save BMC version */
-	mbHeader = get_axlf_section_hdr(icap, bin_obj_axlf, BMC);
+	mbHeader = xrt_xclbin_get_section_hdr(bin_obj_axlf, BMC);
 	if (mbHeader) {
 		if (mbHeader->m_sectionSize < sizeof(struct bmc)) {
 			err = -EINVAL;
@@ -2114,8 +1907,7 @@ static int icap_verify_bitstream_axlf(struct platform_device *pdev,
 
 		ICAP_INFO(icap, "DNA version: %s", (capability & 0x1) ? "AXI" : "BRAM");
 
-		if (alloc_and_get_axlf_section(icap, xclbin,
-			DNA_CERTIFICATE,
+		if (xrt_xclbin_get_section(xclbin, DNA_CERTIFICATE,
 			(void **)&cert, &section_size) != 0) {
 
 			/* We keep dna sub device if IP_DNASC presents */
@@ -2523,7 +2315,8 @@ static bool check_mem_topo_and_data_retention(struct icap *icap,
 	struct axlf *xclbin)
 {
 	struct mem_topology *mem_topo = icap->mem_topo;
-	const struct axlf_section_header *hdr = get_axlf_section_hdr(icap, xclbin, MEM_TOPOLOGY);
+	const struct axlf_section_header *hdr =
+		xrt_xclbin_get_section_hdr(xclbin, MEM_TOPOLOGY);
 	uint64_t size = 0, offset = 0;
 
 	if (!hdr || !mem_topo || !icap->data_retention)
@@ -2690,7 +2483,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 		goto done;
 	}
 
-	header = get_axlf_section_hdr(icap, xclbin, PARTITION_METADATA);
+	header = xrt_xclbin_get_section_hdr(xclbin, PARTITION_METADATA);
 	if (header) {
 		ICAP_INFO(icap, "check interface uuid");
 		if (!XDEV(xdev)->fdt_blob) {
@@ -2714,7 +2507,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 	 * bitstream it may damage the hardware!
 	 * If no clock freq, must return without touching the hardware.
 	 */
-	header = get_axlf_section_hdr(icap, xclbin, CLOCK_FREQ_TOPOLOGY);
+	header = xrt_xclbin_get_section_hdr(xclbin, CLOCK_FREQ_TOPOLOGY);
 	if (!header) {
 		err = -EINVAL;
 		goto done;
@@ -2932,10 +2725,11 @@ static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
 		*target = NULL;
 	}
 
-	err = alloc_and_get_axlf_section(icap, xclbin, kind,
-		target, &section_size);
-	if (err != 0)
+	err = xrt_xclbin_get_section(xclbin, kind, target, &section_size);
+	if (err != 0) {
+		ICAP_ERR(icap, "get section err: %ld", err);
 		goto done;
+	}
 	sect_sz = icap_get_section_size(icap, kind);
 	if (sect_sz > section_size) {
 		err = -EINVAL;
@@ -2949,7 +2743,7 @@ done:
 			*target = NULL;
 		}
 	}
-	ICAP_INFO(icap, "%s kind %d, err: %ld", __func__, kind, err);
+	ICAP_INFO(icap, "kind %d, err: %ld", kind, err);
 	return err;
 }
 
@@ -3936,7 +3730,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 	struct axlf *axlf = NULL;
 	const struct axlf_section_header *section;
 	void *header;
-	XHwIcap_Bit_Header bit_header = { 0 };
+	struct XHwIcap_Bit_Header bit_header = { 0 };
 	const struct firmware *sche_fw = NULL;
 	ssize_t ret, len;
 	int err;
@@ -4027,7 +3821,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 
 	strncpy(icap->rp_vbnv, axlf->m_header.m_platformVBNV,
 			sizeof(icap->rp_vbnv) - 1);
-	section = get_axlf_section_hdr(icap, axlf, PARTITION_METADATA);
+	section = xrt_xclbin_get_section_hdr(axlf, PARTITION_METADATA);
 	if (!section) {
 		ICAP_ERR(icap, "did not find PARTITION_METADATA section");
 		ret = -EINVAL;
@@ -4051,7 +3845,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 	icap->rp_fdt_len = fdt_totalsize(header);
 	memcpy(icap->rp_fdt, header, fdt_totalsize(header));
 
-	section = get_axlf_section_hdr(icap, axlf, BITSTREAM);
+	section = xrt_xclbin_get_section_hdr(axlf, BITSTREAM);
 	if (!section) {
 		ICAP_ERR(icap, "did not find BITSTREAM section");
 		ret = -EINVAL;
@@ -4065,7 +3859,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 	}
 
 	header = (char *)axlf + section->m_sectionOffset;
-	if (bitstream_parse_header(icap, header,
+	if (xrt_xclbin_parse_header(header,
 			DMA_HWICAP_BITFILE_BUFFER_SIZE, &bit_header)) {
 		ICAP_ERR(icap, "parse header failed");
 		ret = -EINVAL;
@@ -4089,7 +3883,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 	memcpy(icap->rp_bit, header, icap->rp_bit_len);
 
 	/* Try locating the board mgmt binary. */
-	section = get_axlf_section_hdr(icap, axlf, FIRMWARE);
+	section = xrt_xclbin_get_section_hdr(axlf, FIRMWARE);
 	if (section) {
 		header = (char *)axlf + section->m_sectionOffset;
 		icap->rp_mgmt_bin = vmalloc(section->m_sectionSize);
@@ -4120,7 +3914,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 	}
 
 
-	section = get_axlf_section_hdr(icap, axlf, SCHED_FIRMWARE);
+	section = xrt_xclbin_get_section_hdr(axlf, SCHED_FIRMWARE);
 	if (section && !icap->rp_sche_bin) {
 		header = (char *)axlf + section->m_sectionOffset;
 		icap->rp_sche_bin = vmalloc(section->m_sectionSize);
@@ -4142,6 +3936,7 @@ static ssize_t icap_write_rp(struct file *filp, const char __user *data,
 	return len;
 
 failed:
+	xrt_xclbin_free_header(&bit_header);
 	icap_free_bins(icap);
 	if (sche_fw)
 		release_firmware(sche_fw);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -2578,6 +2578,7 @@ static int stop_xmc_nolock(struct platform_device *pdev)
 	void *xdev_hdl;
 	u32 magic = 0;
 	int ret;
+	bool skip_xmc = false;
 
 	xmc = platform_get_drvdata(pdev);
 	if (!xmc)
@@ -2600,7 +2601,7 @@ static int stop_xmc_nolock(struct platform_device *pdev)
 
 	reg_val = READ_GPIO(xmc, 0);
 
-	bool skip_xmc = xmc_in_bitfile(xmc->pdev);
+	skip_xmc = xmc_in_bitfile(xmc->pdev);
 	if (skip_xmc)
 		xocl_info(&xmc->pdev->dev, "MB Reset GPIO 0x%x (ert), 0x%x (xmc)", reg_val,
 			  READ_XMC_GPIO(xmc, 0));
@@ -2711,6 +2712,7 @@ static int load_xmc(struct xocl_xmc *xmc)
 	u32 reg_val = 0, reg_map_ready;
 	int ret = 0;
 	void *xdev_hdl;
+	bool skip_xmc = false;
 
 	if (!xmc->enabled)
 		return -ENODEV;
@@ -2729,7 +2731,7 @@ static int load_xmc(struct xocl_xmc *xmc)
 	reg_val = READ_GPIO(xmc, 0);
 
 	xdev_hdl = xocl_get_xdev(xmc->pdev);
-	bool skip_xmc = xmc_in_bitfile(xmc->pdev);
+	skip_xmc = xmc_in_bitfile(xmc->pdev);
 	if (skip_xmc) {
 		xocl_info(&xmc->pdev->dev, "MB Reset GPIO 0x%x (ert), 0x%x (xmc)", reg_val,
 			  READ_XMC_GPIO(xmc, 0));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -43,13 +43,15 @@ endif
 drv_common-y   := $(common_dir)/kds_core.o \
 		  $(common_dir)/xrt_cu.o \
 		  $(common_dir)/cu_hls.o \
-		  $(common_dir)/cu_plram.o
+		  $(common_dir)/cu_plram.o \
+		  $(common_dir)/xrt_xclbin.o
 
 xocl-y := \
 	../xocl_subdev.o \
 	../xocl_ctx.o \
 	../xocl_thread.o \
 	../xocl_fdt.o \
+	../xocl_xclbin.o \
 	../subdev/xdma.o \
 	../subdev/qdma.o \
 	../subdev/qdma4.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -40,6 +40,7 @@
 #include <linux/moduleparam.h>
 #include <linux/cdev.h>
 #include "xclbin.h"
+#include "xrt_xclbin.h"
 #include "xrt_mem.h"
 #include "devices.h"
 #include "xocl_ioctl.h"
@@ -444,6 +445,8 @@ struct xocl_dev_core {
 	spinlock_t		api_lock;
 	struct completion	api_comp;
 	int			api_call_cnt;
+
+	struct xocl_xclbin 	*xdev_xclbin;
 };
 
 #define XOCL_DRM(xdev_hdl)					\
@@ -1539,8 +1542,6 @@ struct xocl_flash_funcs {
 struct xocl_xfer_versal_funcs {
 	int (*download_axlf)(struct platform_device *pdev,
 		const void __user *arg);
-	int (*xclbin_load_axlf)(struct platform_device *pdev,
-		const void __user *arg);
 };
 #define	XFER_VERSAL_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL).pldev
 #define	XFER_VERSAL_OPS(xdev)					\
@@ -1549,10 +1550,6 @@ struct xocl_xfer_versal_funcs {
 #define	xocl_xfer_versal_download_axlf(xdev, xclbin)	\
 	(XFER_VERSAL_CB(xdev) ?					\
 	XFER_VERSAL_OPS(xdev)->download_axlf(XFER_VERSAL_DEV(xdev), xclbin) : -ENODEV)
-/* Note: this API is a workaround, will be relocated into xclbin lib */
-#define	xocl_xclbin_load_axlf(xdev, xclbin)	\
-	(XFER_VERSAL_CB(xdev) ?					\
-	XFER_VERSAL_OPS(xdev)->xclbin_load_axlf(XFER_VERSAL_DEV(xdev), xclbin) : -ENODEV)
 
 struct xocl_pmc_funcs {
 	int (*enable_reset)(struct platform_device *pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2018-2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    David Zhang <davidzha@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "xrt_xclbin.h"
+#include "xocl_drv.h"
+
+struct xocl_xclbin_ops {
+	int (*xclbin_pre_download)(xdev_handle_t xdev, void *args);
+	int (*xclbin_download)(xdev_handle_t xdev, void *args);
+	int (*xclbin_post_download)(xdev_handle_t xdev, void *args);
+};
+
+struct xclbin_arg {
+	xdev_handle_t 		xdev;
+	struct axlf 		*xclbin;
+	struct xocl_subdev 	*urpdevs;
+	int 			num_dev;
+};
+
+static int versal_xclbin_pre_download(xdev_handle_t xdev, void *args)
+{
+	struct xclbin_arg *arg = (struct xclbin_arg *)args;
+	struct axlf *xclbin = arg->xclbin;
+	void *metadata = NULL;	
+	uint64_t size;
+	int ret = 0;
+
+	ret = xrt_xclbin_get_section(xclbin, PARTITION_METADATA, &metadata, &size);
+	if (ret)
+		return ret;
+
+	if (metadata) {
+		arg->num_dev = xocl_fdt_parse_blob(xdev, metadata,
+		    size, &(arg->urpdevs));
+		vfree(metadata);
+	}
+	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+
+	return ret;
+}
+
+static int versal_xclbin_download(xdev_handle_t xdev, void *args)
+{
+	struct xclbin_arg *arg = (struct xclbin_arg *)args;
+	int ret = 0;
+
+	BUG_ON(!arg->xclbin);
+
+	xocl_axigate_freeze(xdev, XOCL_SUBDEV_LEVEL_PRP);
+
+	/* download bitstream */
+	ret = xocl_xfer_versal_download_axlf(xdev, arg->xclbin);
+
+	xocl_axigate_free(xdev, XOCL_SUBDEV_LEVEL_PRP);
+
+	return ret;
+}
+
+static int versal_xclbin_post_download(xdev_handle_t xdev, void *args)
+{
+	struct xclbin_arg *arg = (struct xclbin_arg *)args;
+	int i, ret = 0;
+
+	if (arg->num_dev) {
+		for (i = 0; i < arg->num_dev; i++)
+			(void) xocl_subdev_create(xdev, &(arg->urpdevs[i].info));
+		xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+	}
+
+	return ret;
+
+}
+
+static struct xocl_xclbin_ops versal_ops = {
+	.xclbin_pre_download 	= versal_xclbin_pre_download,
+	.xclbin_download 	= versal_xclbin_download,
+	.xclbin_post_download 	= versal_xclbin_post_download,
+};
+
+#if 0
+/* Place holder for icap callbacks */
+static int icap_xclbin_pre_download(xdev_handle_t xdev, void *args)
+{ return 0; }
+static int icap_xclbin_download(xdev_handle_t xdev, void *args)
+{ return 0; }
+static int icap_xclbin_post_download(xdev_handle_t xdev, void *args)
+{ return 0; }
+
+static struct xocl_xclbin_ops icap_ops = {
+	.xclbin_pre_download 	= icap_xclbin_pre_download,
+	.xclbin_download 	= icap_xclbin_download,
+	.xclbin_post_download 	= icap_xclbin_post_download,
+};
+
+/*
+ *Future enhancement for binding info table to of_device_id with
+ *device-tree compatible
+ */
+static const struct xocl_xclbin_info icap_info = {
+	.ops = &icap_ops;
+};
+
+static const struct xocl_xclbin_info versal_info = {
+	.ops = &versal_ops;
+};
+#endif
+
+static int xocl_xclbin_download_impl(xdev_handle_t xdev, const void *xclbin,
+	struct xocl_xclbin_ops *ops)
+{
+	/* args are simular, thus using the same pattern among all ops*/
+	struct xclbin_arg args = {
+		.xdev = xdev,
+		.xclbin = (struct axlf *)xclbin,
+		.num_dev = 0,
+	};
+	int ret = 0;	
+
+	/* Step1: call pre download callback */
+	if (ops->xclbin_pre_download) {
+		ret = ops->xclbin_pre_download(xdev, &args);
+		if (ret)
+			goto done;
+	}
+
+	/* Step2: there must be a download callback */
+	if (!ops->xclbin_download) {
+		ret = -EINVAL;
+		goto done;
+	}
+	ret = ops->xclbin_download(xdev, &args);
+	if (ret)
+		goto done;
+
+	/* Step3: call post download callback */
+	if (ops->xclbin_post_download) {
+		ret = ops->xclbin_post_download(xdev, &args);
+	}
+
+done:	
+	return ret;
+}
+
+int xocl_xclbin_download(xdev_handle_t xdev, const void *xclbin)
+{
+	if (XOCL_DSA_IS_VERSAL(xdev))
+		return xocl_xclbin_download_impl(xdev, xclbin, &versal_ops);
+	else
+		/* TODO: return xocl_xclbin_download_impl(xdev, xclbin, &icap_ops); */
+		return xocl_icap_download_axlf(xdev, xclbin);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -1,17 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * Copyright (C) 2018-2020 Xilinx, Inc. All rights reserved.
+ * Xilinx Kernel Driver XCLBIN parser
  *
- * Authors:
- *    David Zhang <davidzha@xilinx.com>
+ * Copyright (C) 2020 Xilinx, Inc.
  *
- * This software is licensed under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation, and
- * may be copied, distributed, and modified under those terms.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * Authors: David Zhang <davidzha@xilinx.com>
  */
 
 #include "xrt_xclbin.h"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.h
@@ -1,0 +1,43 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    David Zhang <davidzha@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _XOCL_XCLBIN_H
+#define	_XOCL_XCLBIN_H
+
+#if 0
+/* for icap user to preserve xclbin data */
+struct xocl_xclbin {
+	xuid_t				xclbin_uuid;
+	int				xclbin_refcnt;
+	usigned long			xclbin_clock_freq_topology_len;
+	struct clock_freq_topology	*xclbin_clock_freq_topology;
+	struct mem_topology		*xclbin_mem_topology;
+	struct ip_layout		*xclbin_ip_layout;
+	struct debug_ip_layout		*xclbin_debug_layout;
+	struct connectivity		*xclbin_connectivity;
+	void				*xclbin_partition_metadata;
+	uint64_t			xclbin_max_host_mem_aperture;
+}
+
+init xocl_xclbin_init(xdev_handle_t xdev);
+void xocl_xclbin_fini(xdev_handle_t xdev);
+#endif
+
+int xocl_xclbin_download(xdev_handle_t xdev, const void *xclbin);
+
+#endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.h
@@ -1,19 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
- * A GEM style device manager for PCIe based OpenCL accelerators.
+ * Xilinx Kernel Driver XCLBIN parser
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020 Xilinx, Inc.
  *
- * Authors:
- *    David Zhang <davidzha@xilinx.com>
- *
- * This software is licensed under the terms of the GNU General Public
- * License version 2, as published by the Free Software Foundation, and
- * may be copied, distributed, and modified under those terms.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * Authors: David Zhang <davidzha@xilinx.com>
  */
 
 #ifndef _XOCL_XCLBIN_H


### PR DESCRIPTION
This is the effort to make xclbin code in common library and separate logic between xclbin download protocol and xclbin download logic. This phase will not change icap's existing behavior to minimize the risk of too much code changes, and only moved xclbin code outside of ospi_versal. The ops callbacks will be enhanced for icap in phase2.

The changes have been documented here: https://confluence.xilinx.com/display/~davidzha/icap.c+2.0#icap.c2.0-3.22020version

Tested on vck5000. Will post all test results here.