### PR TITLE
CR-1049369 Probe platform/device time quite long

### DIFF
--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  * Author(s): Hem C. Neema, Ryan Radjabi
  * PCIe HAL Driver layered on top of XOCL GEM kernel driver
  *
@@ -45,425 +45,122 @@
 #define RENDER_NM       "renderD"
 #define DEV_TIMEOUT	90 // seconds
 
-static const std::string sysfs_root = "/sys/bus/pci/devices/";
+namespace {
 
-static std::string get_name(const std::string& dir, const std::string& subdir)
+namespace bfs = boost::filesystem;
+
+
+static std::string
+get_name(const std::string& dir, const std::string& subdir)
 {
-    std::string line;
-    std::ifstream ifs(dir + "/" + subdir + "/name");
+  std::string line;
+  std::ifstream ifs(dir + "/" + subdir + "/name");
 
-    if (ifs.is_open())
-        std::getline(ifs, line);
+  if (ifs.is_open())
+    std::getline(ifs, line);
 
-    return line;
+  return line;
 }
 
 // Helper to find subdevice directory name
 // Assumption: all subdevice's sysfs directory name starts with subdevice name!!
-static int get_subdev_dir_name(const std::string& dir,
-    const std::string& subDevName, std::string& subdir)
+static int
+get_subdev_dir_name(const std::string& dir, const std::string& subDevName, std::string& subdir)
 {
-    DIR *dp;
-    size_t sub_nm_sz = subDevName.size();
+  DIR *dp;
+  size_t sub_nm_sz = subDevName.size();
 
-    subdir = "";
-    if (subDevName.empty())
-        return 0;
+  subdir = "";
+  if (subDevName.empty())
+    return 0;
 
-    int ret = -ENOENT;
-    dp = opendir(dir.c_str());
-    if (dp) {
-        struct dirent *entry;
-        while ((entry = readdir(dp))) {
-            std::string nm = get_name(dir, entry->d_name);
-            if (!nm.empty()) {
-                if (nm != subDevName)
-                    continue;
-            } else if(strncmp(entry->d_name, subDevName.c_str(), sub_nm_sz) ||
-                entry->d_name[sub_nm_sz] != '.') {
-                continue;
-            }
-            // found it
-            subdir = entry->d_name;
-            ret = 0;
-            break;
-        }
-        closedir(dp);
-    }
-
-    return ret;
-}
-
-std::string pcidev::pci_device::get_sysfs_path(const std::string& subdev,
-    const std::string& entry)
-{
-    std::string subdir;
-    if (get_subdev_dir_name(sysfs_root + sysfs_name, subdev, subdir) != 0)
-        return "";
-
-    std::string path = sysfs_root;
-    path += sysfs_name;
-    path += "/";
-    path += subdir;
-    path += "/";
-    path += entry;
-    return path;
-}
-
-std::string pcidev::pci_device::get_subdev_path(const std::string& subdev,
-    uint idx)
-{
-    std::string path("/dev/xfpga/");
-
-    path += subdev;
-    path += is_mgmt ? ".m" : ".u";
-    path += std::to_string((domain<<16) + (bus<<8) + (dev<<3) + func);
-    path += "." + std::to_string(idx);
-    return path;
-}
-
-static std::fstream sysfs_open_path(const std::string& path, std::string& err,
-    bool write, bool binary)
-{
-    std::fstream fs;
-    std::ios::openmode mode = write ? std::ios::out : std::ios::in;
-
-    if (binary)
-        mode |= std::ios::binary;
-
-    err.clear();
-    fs.open(path, mode);
-    if (!fs.is_open()) {
-        std::stringstream ss;
-        ss << "Failed to open " << path << " for "
-            << (binary ? "binary " : "")
-            << (write ? "writing" : "reading") << ": "
-            << strerror(errno) << std::endl;
-        err = ss.str();
-    }
-    return fs;
-}
-
-std::fstream pcidev::pci_device::sysfs_open(const std::string& subdev,
-    const std::string& entry, std::string& err, bool write, bool binary)
-{
-    std::fstream fs;
-    const std::string path = get_sysfs_path(subdev, entry);
-
-    if (path.empty()) {
-        std::stringstream ss;
-        ss << "Failed to find subdirectory for " << subdev
-            << " under " << sysfs_root + sysfs_name << std::endl;
-        err = ss.str();
-    } else {
-        fs = sysfs_open_path(path, err, write, binary);
-    }
-
-    return fs;
-}
-
-void pcidev::pci_device::sysfs_put(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, const std::string& input)
-{
-    std::fstream fs = sysfs_open(subdev, entry, err_msg, true, false);
-    if (!err_msg.empty())
-        return;
-    fs << input;
-    fs.flush();
-    if (!fs.good()) {
-        std::stringstream ss;
-        ss << "Failed to write " << get_sysfs_path(subdev, entry) << ": "
-            << strerror(errno) << std::endl;
-        err_msg = ss.str();
-    }
-}
-
-void pcidev::pci_device::sysfs_put(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, const std::vector<char>& buf)
-{
-    std::fstream fs = sysfs_open(subdev, entry, err_msg, true, true);
-    if (!err_msg.empty())
-        return;
-
-    fs.write(buf.data(), buf.size());
-    fs.flush();
-    if (!fs.good()) {
-        std::stringstream ss;
-        ss << "Failed to write " << get_sysfs_path(subdev, entry) << ": "
-            << strerror(errno) << std::endl;
-        err_msg = ss.str();
-    }
-}
-
-void pcidev::pci_device::sysfs_put(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, const unsigned int& input)
-{
-    std::fstream fs = sysfs_open(subdev, entry, err_msg, true, false);
-    if (!err_msg.empty())
-        return;
-    fs << input;
-    fs.flush();
-    if (!fs.good()) {
-        std::stringstream ss;
-        ss << "Failed to write " << get_sysfs_path(subdev, entry) << ": "
-            << strerror(errno) << std::endl;
-        err_msg = ss.str();
-    }
-}
-
-void pcidev::pci_device::sysfs_get(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, std::vector<char>& buf)
-{
-    std::fstream fs = sysfs_open(subdev, entry, err_msg, false, true);
-    if (!err_msg.empty())
-        return;
-
-    buf.insert(std::end(buf),std::istreambuf_iterator<char>(fs),
-        std::istreambuf_iterator<char>());
-}
-
-void pcidev::pci_device::sysfs_get(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, std::vector<std::string>& sv)
-{
-    std::fstream fs = sysfs_open(subdev, entry, err_msg, false, false);
-    if (!err_msg.empty())
-        return;
-
-    sv.clear();
-    std::string line;
-    while (std::getline(fs, line))
-        sv.push_back(line);
-}
-
-void pcidev::pci_device::sysfs_get(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, std::vector<uint64_t>& iv)
-{
-    uint64_t n;
-    std::vector<std::string> sv;
-
-    iv.clear();
-
-    sysfs_get(subdev, entry, err_msg, sv);
-    if (!err_msg.empty())
-        return;
-
-    char *end;
-    for (auto& s : sv) {
-        std::stringstream ss;
-
-        if (s.empty()) {
-            ss << "Reading " << get_sysfs_path(subdev, entry) << ", ";
-            ss << "can't convert empty string to integer" << std::endl;
-            err_msg = ss.str();
-            break;
-        }
-        n = std::strtoull(s.c_str(), &end, 0);
-        if (*end != '\0') {
-            ss << "Reading " << get_sysfs_path(subdev, entry) << ", ";
-            ss << "failed to convert string to integer: " << s << std::endl;
-            err_msg = ss.str();
-            break;
-        }
-        iv.push_back(n);
-    }
-}
-
-void pcidev::pci_device::sysfs_get(
-    const std::string& subdev, const std::string& entry,
-    std::string& err_msg, std::string& s)
-{
-    std::vector<std::string> sv;
-
-    sysfs_get(subdev, entry, err_msg, sv);
-    if (!sv.empty())
-        s = sv[0];
-    else
-        s = ""; // default value
-}
-
-static std::string get_devfs_path(bool is_mgmt, uint32_t instance)
-{
-    std::string prefixStr = is_mgmt ? "/dev/xclmgmt" : "/dev/dri/" RENDER_NM;
-    std::string instStr = std::to_string(instance);
-
-    return prefixStr + instStr;
-}
-
-static bool is_admin()
-{     
-    return (getuid() == 0) || (geteuid() == 0);
-}
-
-int pcidev::pci_device::open(const std::string& subdev, uint32_t idx, int flag)
-{
-    if (is_mgmt && !::is_admin())
-        throw std::runtime_error("Root privileges required");
-    // Open xclmgmt/xocl node
-    if (subdev.empty()) {
-        std::string devfs = get_devfs_path(is_mgmt, instance);
-        return ::open(devfs.c_str(), flag);
-    }
-
-    // Open subdevice node
-    std::string file("/dev/xfpga/");
-    file += subdev;
-    file += is_mgmt ? ".m" : ".u";
-    file += std::to_string((uint32_t)(domain<<16) + (bus<<8) + (dev<<3) + func);
-    file += "." + std::to_string(idx);
-    return ::open(file.c_str(), flag);
-}
-
-int pcidev::pci_device::open(const std::string& subdev, int flag)
-{
-    return open(subdev, 0, flag);
-}
-
-static size_t bar_size(const std::string &dir, unsigned bar)
-{
-    std::ifstream ifs(dir + "/resource");
-    if (!ifs.good())
-        return 0;
-    std::string line;
-    for (unsigned i = 0; i <= bar; i++) {
-        line.clear();
-        std::getline(ifs, line);
-    }
-    long long start, end, meta;
-    if (sscanf(line.c_str(), "0x%llx 0x%llx 0x%llx", &start, &end, &meta) != 3)
-        return 0;
-    return end - start + 1;
-}
-
-static int get_render_value(const std::string& dir)
-{
+  int ret = -ENOENT;
+  dp = opendir(dir.c_str());
+  if (dp) {
     struct dirent *entry;
-    DIR *dp;
-    int instance_num = INVALID_ID;
-
-    dp = opendir(dir.c_str());
-    if (dp == NULL)
-        return instance_num;
-
     while ((entry = readdir(dp))) {
-        if(strncmp(entry->d_name, RENDER_NM, sizeof (RENDER_NM) - 1) == 0) {
-            sscanf(entry->d_name, RENDER_NM "%d", &instance_num);
-            break;
-        }
+      std::string nm = get_name(dir, entry->d_name);
+      if (!nm.empty()) {
+        if (nm != subDevName)
+          continue;
+      } else if(strncmp(entry->d_name, subDevName.c_str(), sub_nm_sz) ||
+                entry->d_name[sub_nm_sz] != '.') {
+        continue;
+      }
+      // found it
+      subdir = entry->d_name;
+      ret = 0;
+      break;
     }
-
     closedir(dp);
+  }
 
+  return ret;
+}
+
+
+static std::string
+get_devfs_path(bool is_mgmt, uint32_t instance)
+{
+  std::string prefixStr = is_mgmt ? "/dev/xclmgmt" : "/dev/dri/" RENDER_NM;
+  std::string instStr = std::to_string(instance);
+
+  return prefixStr + instStr;
+}
+
+static bool
+is_admin()
+{     
+  return (getuid() == 0) || (geteuid() == 0);
+}
+
+static size_t
+bar_size(const std::string &dir, unsigned bar)
+{
+  std::ifstream ifs(dir + "/resource");
+  if (!ifs.good())
+    return 0;
+  std::string line;
+  for (unsigned i = 0; i <= bar; i++) {
+    line.clear();
+    std::getline(ifs, line);
+  }
+  long long start, end, meta;
+  if (sscanf(line.c_str(), "0x%llx 0x%llx 0x%llx", &start, &end, &meta) != 3)
+    return 0;
+  return end - start + 1;
+}
+
+static int
+get_render_value(const std::string& dir)
+{
+  struct dirent *entry;
+  DIR *dp;
+  int instance_num = INVALID_ID;
+
+  dp = opendir(dir.c_str());
+  if (dp == NULL)
     return instance_num;
-}
 
-static bool devfs_exists(bool is_mgmt, uint32_t instance)
-{
-    struct stat buf;
-    std::string devfs = get_devfs_path(is_mgmt, instance);
-
-    return (stat(devfs.c_str(), &buf) == 0);
-}
-
-pcidev::pci_device::pci_device(const std::string& sysfs) : sysfs_name(sysfs)
-{
-    const std::string dir = sysfs_root + sysfs;
-    std::string err;
-    std::vector<pci_device> mgmt_devices;
-    std::vector<pci_device> user_devices;
-    uint16_t dom, b, d, f, vendor;
-    bool mgmt = false;
-
-    if((sysfs.c_str())[0] == '.')
-        return;
-
-    if(sscanf(sysfs.c_str(), "%hx:%hx:%hx.%hx", &dom, &b, &d, &f) < 4) {
-        std::cout << "Couldn't parse entry name " << sysfs << std::endl;
-        return;
+  while ((entry = readdir(dp))) {
+    if(strncmp(entry->d_name, RENDER_NM, sizeof (RENDER_NM) - 1) == 0) {
+      sscanf(entry->d_name, RENDER_NM "%d", &instance_num);
+      break;
     }
+  }
 
-    // Determine if device is of supported vendor
-    sysfs_get<uint16_t>("", "vendor", err, vendor, static_cast<uint16_t>(-1));
-    if (!err.empty()) {
-        std::cout << err << std::endl;
-        return;
-    }
-    if((vendor != XILINX_ID) && (vendor != ADVANTECH_ID) && (vendor != AWS_ID))
-        return;
+  closedir(dp);
 
-    // Determine if the device is mgmt or user pf.
-    std::string tmp;
-    sysfs_get("", "mgmt_pf", err, tmp);
-    if (err.empty()) {
-        mgmt = true;
-    } else {
-        mgmt = false;
-        sysfs_get("", "user_pf", err, tmp);
-        if (!err.empty()) {
-            return; // device not recognized
-        }
-    }
-
-    uint32_t inst = INVALID_ID;
-    if (mgmt)
-        sysfs_get<uint32_t>("", "instance", err, inst, static_cast<uint32_t>(-1));
-    else
-        inst = get_render_value(dir + "/drm");
-    if (!devfs_exists(mgmt, inst))
-        return; // device node is not available
-
-    // Found a supported PCIE function.
-    domain = dom;
-    bus = b;
-    dev = d;
-    func = f;
-
-    sysfs_get<int>("", "userbar", err, user_bar, 0);
-    user_bar_size = bar_size(dir, user_bar);
-    is_mgmt = mgmt;
-    instance = inst;
-    sysfs_get<bool>("", "ready", err, is_ready, false);
+  return instance_num;
 }
 
-pcidev::pci_device::~pci_device()
+static bool
+devfs_exists(bool is_mgmt, uint32_t instance)
 {
-    if (user_bar_map != MAP_FAILED)
-      ::munmap(user_bar_map, user_bar_size);
-}
+  struct stat buf;
+  std::string devfs = get_devfs_path(is_mgmt, instance);
 
-int pcidev::pci_device::map_usr_bar()
-{
-        std::lock_guard<std::mutex> l(lock);
-
-        if (user_bar_map != MAP_FAILED)
-            return 0;
-
-        int dev_handle = open("", O_RDWR);
-        if (dev_handle < 0)
-            return -errno;
-
-        user_bar_map = (char *)::mmap(0, user_bar_size,
-            PROT_READ | PROT_WRITE, MAP_SHARED, dev_handle, 0);
-
-        // Mapping should stay valid after handle is closed
-        // (according to man page)
-        (void)close(dev_handle);
-
-        if (user_bar_map == MAP_FAILED)
-            return -errno;
-
-        return 0;
-}
-
-void pcidev::pci_device::close(int dev_handle)
-{
-    if (dev_handle != -1)
-        (void)::close(dev_handle);
+  return (stat(devfs.c_str(), &buf) == 0);
 }
 
 /*
@@ -473,613 +170,999 @@ void pcidev::pci_device::close(int dev_handle)
  * Neither memcpy, nor std::copy work as they become byte copying
  * on some platforms.
  */
-inline void* wordcopy(void *dst, const void* src, size_t bytes)
+inline void*
+wordcopy(void *dst, const void* src, size_t bytes)
 {
-    // assert dest is 4 byte aligned
-    assert((reinterpret_cast<intptr_t>(dst) % 4) == 0);
+  // assert dest is 4 byte aligned
+  assert((reinterpret_cast<intptr_t>(dst) % 4) == 0);
 
-    using word = uint32_t;
-    volatile auto d = reinterpret_cast<word*>(dst);
-    auto s = reinterpret_cast<const word*>(src);
-    auto w = bytes/sizeof(word);
+  using word = uint32_t;
+  volatile auto d = reinterpret_cast<word*>(dst);
+  auto s = reinterpret_cast<const word*>(src);
+  auto w = bytes/sizeof(word);
 
-    for (size_t i=0; i<w; ++i)
-        d[i] = s[i];
+  for (size_t i=0; i<w; ++i)
+    d[i] = s[i];
 
-    return dst;
+  return dst;
 }
 
-int pcidev::pci_device::pcieBarRead(uint64_t offset, void* buf, uint64_t len)
+} // namespace
+
+namespace pcidev {
+
+namespace sysfs {
+
+static const std::string root = "/sys/bus/pci/devices/";
+
+static std::string
+get_path(const std::string& name, const std::string& subdev, const std::string& entry)
 {
-    if (user_bar_map == MAP_FAILED) {
-        int ret = map_usr_bar();
-        if (ret)
-            return ret;
+  std::string subdir;
+  if (get_subdev_dir_name(root + name, subdev, subdir) != 0)
+    return "";
+
+  auto path = root;
+  path += name;
+  path += "/";
+  path += subdir;
+  path += "/";
+  path += entry;
+  return path;
+}
+
+static std::fstream
+open_path(const std::string& path, std::string& err, bool write, bool binary)
+{
+  std::fstream fs;
+  std::ios::openmode mode = write ? std::ios::out : std::ios::in;
+
+  if (binary)
+    mode |= std::ios::binary;
+
+  err.clear();
+  fs.open(path, mode);
+  if (!fs.is_open()) {
+    std::stringstream ss;
+    ss << "Failed to open " << path << " for "
+       << (binary ? "binary " : "")
+       << (write ? "writing" : "reading") << ": "
+       << strerror(errno) << std::endl;
+    err = ss.str();
+  }
+  return fs;
+}
+
+static std::fstream
+open(const std::string& name,
+     const std::string& subdev, const std::string& entry,
+     std::string& err, bool write, bool binary)
+{
+  std::fstream fs;
+  auto path = get_path(name, subdev, entry);
+
+  if (path.empty()) {
+    std::stringstream ss;
+    ss << "Failed to find subdirectory for " << subdev
+       << " under " << root + name << std::endl;
+    err = ss.str();
+  } else {
+    fs = open_path(path, err, write, binary);
+  }
+
+  return fs;
+}
+
+static void
+get(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, std::vector<std::string>& sv)
+{
+  std::fstream fs = open(name, subdev, entry, err, false, false);
+  if (!err.empty())
+    return;
+
+  sv.clear();
+  std::string line;
+  while (std::getline(fs, line))
+    sv.push_back(line);
+}
+
+static void
+get(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, std::vector<uint64_t>& iv)
+{
+  iv.clear();
+
+  std::vector<std::string> sv;
+  get(name, subdev, entry, err, sv);
+  if (!err.empty())
+    return;
+
+  for (auto& s : sv) {
+    if (s.empty()) {
+      std::stringstream ss;
+      ss << "Reading " << get_path(name, subdev, entry) << ", ";
+      ss << "can't convert empty string to integer" << std::endl;
+      err = ss.str();
+      break;
     }
-    (void) wordcopy(buf, user_bar_map + offset, len);
+    char* end = nullptr;
+    auto n = std::strtoull(s.c_str(), &end, 0);
+    if (*end != '\0') {
+      std::stringstream ss;
+      ss << "Reading " << get_path(name, subdev, entry) << ", ";
+      ss << "failed to convert string to integer: " << s << std::endl;
+      err = ss.str();
+      break;
+    }
+    iv.push_back(n);
+  }
+}
+
+static void
+get(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, std::string& s)
+{
+  std::vector<std::string> sv;
+  get(name, subdev, entry, err, sv);
+  if (!sv.empty())
+    s = sv[0];
+  else
+    s = ""; // default value
+}
+
+static void
+get(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, std::vector<char>& buf)
+{
+  std::fstream fs = open(name, subdev, entry, err, false, true);
+  if (!err.empty())
+    return;
+
+  buf.insert(std::end(buf),std::istreambuf_iterator<char>(fs),
+             std::istreambuf_iterator<char>());
+}
+
+static void
+put(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, const std::string& input)
+{
+  std::fstream fs = open(name, subdev, entry, err, true, false);
+  if (!err.empty())
+    return;
+  fs << input;
+  fs.flush();
+  if (!fs.good()) {
+    std::stringstream ss;
+    ss << "Failed to write " << get_path(name, subdev, entry) << ": "
+       << strerror(errno) << std::endl;
+    err = ss.str();
+  }
+}
+
+static void
+put(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, const std::vector<char>& buf)
+{
+  std::fstream fs = open(name, subdev, entry, err, true, true);
+  if (!err.empty())
+    return;
+
+  fs.write(buf.data(), buf.size());
+  fs.flush();
+  if (!fs.good()) {
+    std::stringstream ss;
+    ss << "Failed to write " << get_path(name, subdev, entry) << ": "
+       << strerror(errno) << std::endl;
+    err = ss.str();
+  }
+}
+
+static void
+put(const std::string& name,
+    const std::string& subdev, const std::string& entry,
+    std::string& err, const unsigned int& input)
+{
+  std::fstream fs = open(name, subdev, entry, err, true, false);
+  if (!err.empty())
+    return;
+  fs << input;
+  fs.flush();
+  if (!fs.good()) {
+    std::stringstream ss;
+    ss << "Failed to write " << get_path(name, subdev, entry) << ": "
+       << strerror(errno) << std::endl;
+    err = ss.str();
+  }
+}
+
+} // sysfs
+
+static bool
+is_in_use(std::vector<std::shared_ptr<pci_device>>& vec)
+{
+  for (auto& d : vec)
+    if (d.use_count() > 1)
+      return true;
+  return false;
+}
+
+void
+pci_device::
+sysfs_get(const std::string& subdev, const std::string& entry,
+          std::string& err, std::vector<std::string>& ret)
+{
+  sysfs::get(sysfs_name, subdev, entry, err, ret);
+}
+
+void
+pci_device::
+sysfs_get(const std::string& subdev, const std::string& entry,
+          std::string& err, std::vector<uint64_t>& ret)
+{
+  sysfs::get(sysfs_name, subdev, entry, err, ret);
+}
+
+void
+pci_device::
+sysfs_get(const std::string& subdev, const std::string& entry,
+          std::string& err, std::vector<char>& ret)
+{
+  sysfs::get(sysfs_name, subdev, entry, err, ret);
+}
+
+void
+pci_device::
+sysfs_get(const std::string& subdev, const std::string& entry,
+          std::string& err, std::string& s)
+{
+  sysfs::get(sysfs_name, subdev, entry, err, s);
+}
+
+
+void
+pci_device::
+sysfs_put(const std::string& subdev, const std::string& entry,
+          std::string& err, const std::string& input)
+{
+  sysfs::put(sysfs_name, subdev, entry, err, input);
+}
+
+void
+pci_device::
+sysfs_put(const std::string& subdev, const std::string& entry,
+          std::string& err, const std::vector<char>& buf)
+{
+  sysfs::put(sysfs_name, subdev, entry, err, buf);
+}
+
+void
+pci_device::
+sysfs_put(const std::string& subdev, const std::string& entry,
+          std::string& err, const unsigned int& buf)
+{
+  sysfs::put(sysfs_name, subdev, entry, err, buf);
+}
+  
+std::string
+pci_device::
+get_sysfs_path(const std::string& subdev, const std::string& entry)
+{
+  return sysfs::get_path(sysfs_name, subdev, entry);
+}
+
+std::string
+pci_device::
+get_subdev_path(const std::string& subdev, uint idx)
+{
+  std::string path("/dev/xfpga/");
+
+  path += subdev;
+  path += is_mgmt ? ".m" : ".u";
+  path += std::to_string((domain<<16) + (bus<<8) + (dev<<3) + func);
+  path += "." + std::to_string(idx);
+  return path;
+}
+
+int
+pci_device::
+open(const std::string& subdev, uint32_t idx, int flag)
+{
+  if (is_mgmt && !::is_admin())
+    throw std::runtime_error("Root privileges required");
+  // Open xclmgmt/xocl node
+  if (subdev.empty()) {
+    std::string devfs = get_devfs_path(is_mgmt, instance);
+    return ::open(devfs.c_str(), flag);
+  }
+
+  // Open subdevice node
+  std::string file("/dev/xfpga/");
+  file += subdev;
+  file += is_mgmt ? ".m" : ".u";
+  file += std::to_string((uint32_t)(domain<<16) + (bus<<8) + (dev<<3) + func);
+  file += "." + std::to_string(idx);
+  return ::open(file.c_str(), flag);
+}
+
+int
+pci_device::
+open(const std::string& subdev, int flag)
+{
+  return open(subdev, 0, flag);
+}
+
+pci_device::
+pci_device(const std::string& sysfs)
+  : sysfs_name(sysfs)
+{
+  if((sysfs.c_str())[0] == '.')
+    return;
+
+  uint16_t dom, b, d, f;
+  if(sscanf(sysfs.c_str(), "%hx:%hx:%hx.%hx", &dom, &b, &d, &f) < 4) {
+    std::cout << "Couldn't parse entry name " << sysfs << std::endl;
+    return;
+  }
+
+  // Determine if device is of supported vendor
+  uint16_t vendor;
+  std::string err;
+  sysfs_get("", "vendor", err, vendor, static_cast<uint16_t>(-1));
+  if (!err.empty()) {
+    std::cout << err << std::endl;
+    return;
+  }
+  if((vendor != XILINX_ID) && (vendor != ADVANTECH_ID) && (vendor != AWS_ID))
+    return;
+
+  // Determine if the device is mgmt or user pf.
+  bool mgmt = false;
+  std::string tmp;
+  sysfs_get("", "mgmt_pf", err, tmp);
+  if (err.empty()) {
+    mgmt = true;
+  } else {
+    mgmt = false;
+    sysfs_get("", "user_pf", err, tmp);
+    if (!err.empty()) {
+      return; // device not recognized
+    }
+  }
+
+  const std::string dir = sysfs::root + sysfs;
+  uint32_t inst = INVALID_ID;
+  if (mgmt)
+    sysfs_get("", "instance", err, inst, static_cast<uint32_t>(-1));
+  else
+    inst = get_render_value(dir + "/drm");
+  if (!devfs_exists(mgmt, inst))
+    return; // device node is not available
+
+  domain = dom;
+  bus = b;
+  dev = d;
+  func = f;
+
+  sysfs_get<int>("", "userbar", err, user_bar, 0);
+  user_bar_size = bar_size(dir, user_bar);
+  is_mgmt = mgmt;
+  instance = inst;
+  sysfs_get<bool>("", "ready", err, is_ready, false);
+}
+
+pci_device::
+~pci_device()
+{
+  if (user_bar_map != MAP_FAILED)
+    ::munmap(user_bar_map, user_bar_size);
+}
+
+int
+pci_device::
+map_usr_bar()
+{
+  std::lock_guard<std::mutex> l(lock);
+
+  if (user_bar_map != MAP_FAILED)
     return 0;
+
+  int dev_handle = open("", O_RDWR);
+  if (dev_handle < 0)
+    return -errno;
+
+  user_bar_map = (char *)::mmap(0, user_bar_size,
+                                PROT_READ | PROT_WRITE, MAP_SHARED, dev_handle, 0);
+
+  // Mapping should stay valid after handle is closed
+  // (according to man page)
+  (void)close(dev_handle);
+
+  if (user_bar_map == MAP_FAILED)
+    return -errno;
+
+  return 0;
 }
 
-int pcidev::pci_device::pcieBarWrite(uint64_t offset,
-    const void* buf, uint64_t len)
+void
+pci_device::
+close(int dev_handle)
 {
-    if (user_bar_map == MAP_FAILED) {
-        int ret = map_usr_bar();
-        if (ret)
-            return ret;
-    }
-    (void) wordcopy(user_bar_map + offset, buf, len);
-    return 0;
+  if (dev_handle != -1)
+    (void)::close(dev_handle);
 }
 
-int pcidev::pci_device::ioctl(int dev_handle, unsigned long cmd, void *arg)
+
+int
+pci_device::
+pcieBarRead(uint64_t offset, void* buf, uint64_t len)
 {
-    if (dev_handle == -1) {
-        errno = -EINVAL;
-        return -1;
-    }
-    return ::ioctl(dev_handle, cmd, arg);
+  if (user_bar_map == MAP_FAILED) {
+    int ret = map_usr_bar();
+    if (ret)
+      return ret;
+  }
+  (void) wordcopy(buf, user_bar_map + offset, len);
+  return 0;
 }
 
-int pcidev::pci_device::poll(int dev_handle, short events, int timeoutMilliSec)
+int
+pci_device::
+pcieBarWrite(uint64_t offset, const void* buf, uint64_t len)
 {
-    pollfd info = {dev_handle, events, 0};
-    return ::poll(&info, 1, timeoutMilliSec);
+  if (user_bar_map == MAP_FAILED) {
+    int ret = map_usr_bar();
+    if (ret)
+      return ret;
+  }
+  (void) wordcopy(user_bar_map + offset, buf, len);
+  return 0;
 }
 
-void *pcidev::pci_device::mmap(int dev_handle,
-    size_t len, int prot, int flags, off_t offset)
+int
+pci_device::
+ioctl(int dev_handle, unsigned long cmd, void *arg)
 {
-    if (dev_handle == -1) {
-        errno = -EINVAL;
-        return MAP_FAILED;
-    }
-    return ::mmap(0, len, prot, flags, dev_handle, offset);
+  if (dev_handle == -1) {
+    errno = -EINVAL;
+    return -1;
+  }
+  return ::ioctl(dev_handle, cmd, arg);
 }
 
-int pcidev::pci_device::munmap(int dev_handle, void* addr, size_t len)
+int
+pci_device::
+poll(int dev_handle, short events, int timeoutMilliSec)
 {
-    if (dev_handle == -1) {
-       errno = -EINVAL;
-       return -1;
-    }
-    return ::munmap(addr, len);
+  pollfd info = {dev_handle, events, 0};
+  return ::poll(&info, 1, timeoutMilliSec);
 }
 
-int pcidev::pci_device::get_partinfo(std::vector<std::string>& info, void *blob)
+void*
+pci_device::
+mmap(int dev_handle, size_t len, int prot, int flags, off_t offset)
 {
+  if (dev_handle == -1) {
+    errno = -EINVAL;
+    return MAP_FAILED;
+  }
+  return ::mmap(0, len, prot, flags, dev_handle, offset);
+}
+
+int
+pci_device::
+munmap(int dev_handle, void* addr, size_t len)
+{
+  if (dev_handle == -1) {
+    errno = -EINVAL;
+    return -1;
+  }
+  return ::munmap(addr, len);
+}
+
+int
+pci_device::
+get_partinfo(std::vector<std::string>& info, void *blob)
+{
+  if (!blob) {
     std::vector<char> buf;
     std::string err;
+    sysfs_get("", "fdt_blob", err, buf);
+    if (!buf.size())
+      return -ENOENT;
 
-    if (!blob)
-    {
-        sysfs_get("", "fdt_blob", err, buf);
-        if (!buf.size())
-            return -ENOENT;
+    blob = &buf[0];
+  }
 
-        blob = &buf[0];
+  struct fdt_header *bph = (struct fdt_header *)blob;
+  uint32_t version = be32toh(bph->version);
+  uint32_t off_dt = be32toh(bph->off_dt_struct);
+  const char *p_struct = (const char *)blob + off_dt;
+  uint32_t off_str = be32toh(bph->off_dt_strings);
+  const char *p_strings = (const char *)blob + off_str;
+  const char *p, *s;
+  uint32_t tag;
+  uint32_t level = 0;
+
+  p = p_struct;
+  while ((tag = be32toh(GET_CELL(p))) != FDT_END) {
+    if (tag == FDT_BEGIN_NODE) {
+      s = p;
+      p = PALIGN(p + strlen(s) + 1, 4);
+      std::regex e("partition_info_([0-9]+)");
+      std::cmatch cm;
+      std::regex_match(s, cm, e);
+      if (cm.size())
+        level = std::stoul(cm.str(1));
+      continue;
     }
 
-    struct fdt_header *bph = (struct fdt_header *)blob;
-    uint32_t version = be32toh(bph->version);
-    uint32_t off_dt = be32toh(bph->off_dt_struct);
-    const char *p_struct = (const char *)blob + off_dt;
-    uint32_t off_str = be32toh(bph->off_dt_strings);
-    const char *p_strings = (const char *)blob + off_str;
-    const char *p, *s;
-    uint32_t tag;
-    int sz;
-    uint32_t level = 0;
+    if (tag != FDT_PROP)
+      continue;
 
-    p = p_struct;
-    while ((tag = be32toh(GET_CELL(p))) != FDT_END)
-    {
-        if (tag == FDT_BEGIN_NODE)
-        {
-            s = p;
-            p = PALIGN(p + strlen(s) + 1, 4);
-            std::regex e("partition_info_([0-9]+)");
-            std::cmatch cm;
-            std::regex_match(s, cm, e);
-            if (cm.size())
-            {
-                level = std::stoul(cm.str(1));
-            }
-            continue;
-        }
-
-        if (tag != FDT_PROP)
-            continue;
-
-
-        sz = be32toh(GET_CELL(p));
-        s = p_strings + be32toh(GET_CELL(p));
-        if (version < 16 && sz >= 8)
-            p = PALIGN(p, 8);
-
-        if (strcmp(s, "__INFO"))
-        {
-            p = PALIGN(p + sz, 4);
-            continue;
-        }
-
-        if (info.size() <= level)
-        {
-            info.resize(level + 1);
-        }
-
-        info[level] = std::string(p);
-
-        p = PALIGN(p + sz, 4);
+    int sz = be32toh(GET_CELL(p));
+    s = p_strings + be32toh(GET_CELL(p));
+    if (version < 16 && sz >= 8)
+      p = PALIGN(p, 8);
+    
+    if (strcmp(s, "__INFO")) {
+      p = PALIGN(p + sz, 4);
+      continue;
     }
-    return 0;
+
+    if (info.size() <= level)
+      info.resize(level + 1);
+
+    info[level] = std::string(p);
+
+    p = PALIGN(p + sz, 4);
+  }
+  return 0;
 }
 
-int pcidev::pci_device::flock(int dev_handle, int op)
+int
+pci_device::
+flock(int dev_handle, int op)
 {
-    if (dev_handle == -1) {
-        errno = -EINVAL;
-        return -1;
-    }
-    return ::flock(dev_handle, op);
+  if (dev_handle == -1) {
+    errno = -EINVAL;
+    return -1;
+  }
+  return ::flock(dev_handle, op);
 }
 
-std::shared_ptr<pcidev::pci_device> pcidev::pci_device::lookup_peer_dev()
+std::shared_ptr<pci_device>
+pci_device::
+lookup_peer_dev()
 {
-    int i = 0;
-    std::shared_ptr<pcidev::pci_device> udev;
+  if (!is_mgmt)
+    return nullptr;
 
-    if (!is_mgmt)
-        return NULL;
+  int i = 0;
+  for (auto udev = get_dev(i, true); udev; udev = get_dev(i, true), ++i)
+    if (udev->domain == domain && udev->bus == bus && udev->dev == dev)
+      return udev;
 
-    for (udev = pcidev::get_dev(i, true); udev; udev = pcidev::get_dev(i, true)) {
-        if (udev->domain == domain && udev->bus == bus && udev->dev == dev) {
-                break;
-        }
-        i++;
-    }
-
-    return udev;
+  return nullptr;
 }
 
-class pci_device_scanner {
+class pci_device_scanner
+{
 public:
+  static pci_device_scanner*
+  get_scanner()
+  {
+    static pci_device_scanner scanner;
+    return &scanner;
+  }
 
-    static pci_device_scanner *get_scanner()
-    {
-        static pci_device_scanner scanner;
-        return &scanner;
-    }
+  void
+  rescan()
+  {
+    std::lock_guard<std::mutex> l(lock);
+    rescan_nolock();
+  }
 
-    void rescan()
-    {
-        std::lock_guard<std::mutex> l(lock);
-        rescan_nolock();
-    }
+  size_t
+  get_num_ready(bool is_user)
+  {
+    std::lock_guard<std::mutex> l(lock);
+    return is_user ? num_user_ready : num_mgmt_ready;
+  }
 
-    size_t get_num_ready(bool is_user)
-    {
-        std::lock_guard<std::mutex> l(lock);
-        return is_user ? num_user_ready : num_mgmt_ready;
-    }
+  size_t
+  get_num_total(bool is_user)
+  {
+    std::lock_guard<std::mutex> l(lock);
+    return is_user ? user_list.size() : mgmt_list.size();
+  }
 
-    size_t get_num_total(bool is_user)
-    {
-        std::lock_guard<std::mutex> l(lock);
-        return is_user ? user_list.size() : mgmt_list.size();
-    }
-
-    const std::shared_ptr<pcidev::pci_device> get_dev(unsigned index,bool user)
-    {
-        std::lock_guard<std::mutex> l(lock);
-        auto list = user ? &user_list : &mgmt_list;
-        if (index >= list->size())
-            return nullptr;
-        return (*list)[index];
-    }
+  const std::shared_ptr<pci_device>
+  get_dev(unsigned index,bool user)
+  {
+    std::lock_guard<std::mutex> l(lock);
+    auto list = user ? &user_list : &mgmt_list;
+    if (index >= list->size())
+      return nullptr;
+    return (*list)[index];
+  }
 
 private:
-
-    // Full list of discovered user devices. Index 0 ~ (num_user_ready - 1) are
-    // boards ready for use. The rest, if any, are not ready, according to what
-    // is indicated by driver's "ready" sysfs entry. The applications only see
-    // ready-for-use boards since xclProbe returns num_user_ready, not the size
-    // of the full list.
-    std::vector<std::shared_ptr<pcidev::pci_device>> user_list;
-    size_t num_user_ready;
-
-    // Full list of discovered mgmt devices. Index 0 ~ (num_mgmt_ready - 1) are
-    // boards ready for use. The rest, if any, are not ready, according to what
-    // is indicated by driver's "ready" sysfs entry. Application does not see
-    // mgmt devices.
-    std::vector<std::shared_ptr<pcidev::pci_device>> mgmt_list;
-    size_t num_mgmt_ready;
-
-    std::mutex lock;
-    void rescan_nolock();
-    pci_device_scanner() {
-        rescan_nolock();
-    }
-    pci_device_scanner(const pci_device_scanner& s);
-    pci_device_scanner& operator=(const pci_device_scanner& s);
-};
-
-static bool is_in_use(std::vector<std::shared_ptr<pcidev::pci_device>>& vec)
-{
-    for (auto& d : vec)
-        if (d.use_count() > 1)
-            return true;
-    return false;
-}
-
-void pci_device_scanner::pci_device_scanner::rescan_nolock()
-{
-    std::vector<boost::filesystem::path> vec;
-
+  void rescan_nolock()
+  {
     if (is_in_use(user_list) || is_in_use(mgmt_list)) {
-        std::cout << "Device list is in use, can't rescan" << std::endl;
-        return;
+      std::cout << "Device list is in use, can't rescan" << std::endl;
+      return;
     }
 
     user_list.clear();
     mgmt_list.clear();
-    
-    if(!boost::filesystem::exists(sysfs_root)) {
-        std::cout << "File does not exist : " << sysfs_root << std::endl;
-        return;
+  
+    if(!bfs::exists(sysfs::root)) {
+      std::cout << "File does not exist : " << sysfs::root << std::endl;
+      return;
     }
 
-    copy(boost::filesystem::directory_iterator(sysfs_root), boost::filesystem::directory_iterator(),
-            std::back_inserter(vec));
+    // Gather all sysfs directory and sort
+    std::vector<bfs::path> vec{bfs::directory_iterator(sysfs::root), bfs::directory_iterator()};
+    std::sort(vec.begin(), vec.end());
 
-    /* sort, since directory iteration is not ordered on some file systems */
-    sort(vec.begin(), vec.end());
+    for (auto& path : vec) {
+      auto pf = std::make_shared<pcidev::pci_device>(path.filename().string());
+      if(!pf || pf->domain == INVALID_ID)
+        continue;
 
-    for (std::vector<boost::filesystem::path>::const_iterator it(vec.begin()), it_end(vec.end());
-            it != it_end; ++it)
-    {
-        auto pf = std::make_shared<pcidev::pci_device>(
-                std::string(it->filename().c_str()));
-        if(pf->domain == INVALID_ID)
-            continue;
-
-        auto list = pf->is_mgmt ? &mgmt_list : &user_list;
-        auto num_ready = pf->is_mgmt ? &num_mgmt_ready : &num_user_ready;
-        if (pf->is_ready) {
-            list->insert(list->begin(), pf);
-            ++(*num_ready);
-        } else {
-            list->push_back(pf);
-        }
+      auto& list = pf->is_mgmt ? mgmt_list : user_list;
+      auto& num_ready = pf->is_mgmt ? num_mgmt_ready : num_user_ready;
+      if (pf->is_ready) {
+        list.insert(list.begin(), pf);
+        ++num_ready;
+      } else {
+        list.push_back(pf);
+      }
     }
+  }
 
+  pci_device_scanner()
+  {
+    rescan_nolock();
+  }
+
+  std::mutex lock;
+
+  // Full list of discovered user devices. Index 0 ~ (num_user_ready - 1) are
+  // boards ready for use. The rest, if any, are not ready, according to what
+  // is indicated by driver's "ready" sysfs entry. The applications only see
+  // ready-for-use boards since xclProbe returns num_user_ready, not the size
+  // of the full list.
+  std::vector<std::shared_ptr<pci_device>> user_list;
+  size_t num_user_ready;
+
+  // Full list of discovered mgmt devices. Index 0 ~ (num_mgmt_ready - 1) are
+  // boards ready for use. The rest, if any, are not ready, according to what
+  // is indicated by driver's "ready" sysfs entry. Application does not see
+  // mgmt devices.
+  std::vector<std::shared_ptr<pci_device>> mgmt_list;
+  size_t num_mgmt_ready;
+
+};
+
+void
+rescan(void)
+{
+  pci_device_scanner::get_scanner()->rescan();
 }
 
-
-void pcidev::rescan(void)
+size_t
+get_dev_ready(bool user)
 {
-    pci_device_scanner::get_scanner()->rescan();
+  return pci_device_scanner::get_scanner()->get_num_ready(user);
 }
 
-size_t pcidev::get_dev_ready(bool user)
+size_t
+get_dev_total(bool user)
 {
-    return pci_device_scanner::get_scanner()->get_num_ready(user);
+  return pci_device_scanner::get_scanner()->get_num_total(user);
 }
 
-size_t pcidev::get_dev_total(bool user)
+std::shared_ptr<pci_device>
+get_dev(unsigned index, bool user)
 {
-    return pci_device_scanner::get_scanner()->get_num_total(user);
+  return pci_device_scanner::get_scanner()->get_dev(index, user);
 }
 
-std::shared_ptr<pcidev::pci_device> pcidev::get_dev(unsigned index, bool user)
+int
+get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char>& buf)
 {
-    return pci_device_scanner::get_scanner()->get_dev(index, user);
+  std::ifstream in(filename);
+  if (!in.is_open()) {
+    std::cout << "Can't open " << filename << std::endl;
+    return -ENOENT;
+  }
+
+  // Read axlf from dsabin file to find out number of sections in total.
+  axlf a;
+  size_t sz = sizeof (axlf);
+  in.read(reinterpret_cast<char *>(&a), sz);
+  if (!in.good()) {
+      std::cout << "Can't read axlf from "<< filename << std::endl;
+      return -EINVAL;
+  }
+  // Reread axlf from dsabin file, including all sections headers.
+  // Sanity check for number of sections coming from user input file
+  if (a.m_header.m_numSections > 10000)
+    return -EINVAL;
+
+  sz = sizeof (axlf) + sizeof (axlf_section_header) * (a.m_header.m_numSections - 1);
+
+  std::vector<char> top(sz);
+  in.seekg(0);
+  in.read(top.data(), sz);
+  if (!in.good()) {
+    std::cout << "Can't read axlf and section headers from "<< filename << std::endl;
+    return -EINVAL;
+  }
+  const axlf *ap = reinterpret_cast<const axlf *>(top.data());
+
+  const axlf_section_header* section = xclbin::get_axlf_section(ap, (enum axlf_section_kind)kind);
+  if (!section)
+    return -EINVAL;
+
+  buf = std::shared_ptr<char>(new char[section->m_sectionSize]);
+  in.seekg(section->m_sectionOffset);
+  in.read(buf.get(), section->m_sectionSize);
+
+  return 0;
 }
 
-std::ostream& operator<<(std::ostream& stream,
-    const std::shared_ptr<pcidev::pci_device>& dev)
+int
+get_uuids(std::shared_ptr<char>& dtbbuf, std::vector<std::string>& uuids)
 {
-    std::ios_base::fmtflags f(stream.flags());
+  struct fdt_header *bph = (struct fdt_header *)dtbbuf.get();
+  uint32_t version = be32toh(bph->version);
+  uint32_t off_dt = be32toh(bph->off_dt_struct);
+  const char *p_struct = (const char *)bph + off_dt;
+  uint32_t off_str = be32toh(bph->off_dt_strings);
+  const char *p_strings = (const char *)bph + off_str;
+  const char *p, *s;
+  uint32_t tag;
+  int sz;
 
-    stream << std::hex << std::right << std::setfill('0');
-
-    // [dddd:bb:dd.f]
-    stream << std::setw(4) << dev->domain << ":"
-        << std::setw(2) << dev->bus << ":"
-        << std::setw(2) << dev->dev << "."
-        << std::setw(1) << dev->func;
-
-    // board/shell name
-    std::string shell_name;
-    std::string err;
-    bool is_mfg = false;
-    uint64_t ts = 0;
-    dev->sysfs_get<bool>("", "mfg", err, is_mfg, false);
-    if (is_mfg) {
-        unsigned ver = 0;
-        std::string nm;
-
-        dev->sysfs_get("", "board_name", err, nm);
-        dev->pcieBarRead(MFG_REV_OFFSET, &ver, sizeof(ver));
-        shell_name += "xilinx_";
-        shell_name += nm;
-        shell_name += "_GOLDEN_";
-        shell_name += std::to_string(ver);
-    } else {
-        dev->sysfs_get("rom", "VBNV", err, shell_name);
-        dev->sysfs_get<uint64_t>("rom", "timestamp", err, ts, static_cast<uint64_t>(-1));
+  p = p_struct;
+  uuids.clear();
+  while ((tag = be32toh(GET_CELL(p))) != FDT_END) {
+    if (tag == FDT_BEGIN_NODE) {
+      s = p;
+      p = PALIGN(p + strlen(s) + 1, 4);
+      continue;
     }
-    stream << " " << shell_name;
-    if (ts != 0)
-        stream << "(ID=0x" << std::hex << ts << ")";
+    if (tag != FDT_PROP)
+      continue;
 
-    // instance number
-    if (dev->is_mgmt)
-        stream << " mgmt(inst=";
-    else
-        stream << " user(inst=";
-    stream << std::dec << dev->instance << ")";
+    sz = be32toh(GET_CELL(p));
+    s = p_strings + be32toh(GET_CELL(p));
+    if (version < 16 && sz >= 8)
+      p = PALIGN(p, 8);
 
-    stream.flags(f);
-    return stream;
+    if (!strcmp(s, "logic_uuid"))
+      uuids.insert(uuids.begin(), std::string(p));
+    else if (!strcmp(s, "interface_uuid"))
+      uuids.push_back(std::string(p));
+
+    p = PALIGN(p + sz, 4);
+  }
+
+  return uuids.size() ? 0 : -EINVAL;
 }
 
-int pcidev::get_axlf_section(std::string filename, int kind, std::shared_ptr<char>& buf)
+int
+shutdown(std::shared_ptr<pci_device> mgmt_dev, bool remove_user, bool remove_mgmt)
 {
-    std::ifstream in(filename);
-    if (!in.is_open())
-    {
-        std::cout << "Can't open " << filename << std::endl;
-	return -ENOENT;
-    }
-    // Read axlf from dsabin file to find out number of sections in total.
-    axlf a;
-    size_t sz = sizeof (axlf);
-    in.read(reinterpret_cast<char *>(&a), sz);
-    if (!in.good())
-    {
-        std::cout << "Can't read axlf from "<< filename << std::endl;
-        return -EINVAL;
-    }
-    // Reread axlf from dsabin file, including all sections headers.
-    // Sanity check for number of sections coming from user input file
-    if (a.m_header.m_numSections > 10000)
-        return -EINVAL;
+  if (!mgmt_dev->is_mgmt)
+    return -EINVAL;
 
-    sz = sizeof (axlf) + sizeof (axlf_section_header) * (a.m_header.m_numSections - 1);
+  auto udev = mgmt_dev->lookup_peer_dev();
+  if (!udev) {
+    std::cout << "ERROR: User function is not found. " <<
+      "This is probably due to user function is running in virtual machine or user driver is not loaded. " << std::endl;
+    return -ECANCELED;
+  }
 
-    std::vector<char> top(sz);
-    in.seekg(0);
-    in.read(top.data(), sz);
-    if (!in.good())
-    {
-        std::cout << "Can't read axlf and section headers from "<< filename << std::endl;
-        return -EINVAL;
-    }
-    const axlf *ap = reinterpret_cast<const axlf *>(top.data());
+  std::cout << "Stopping user function..." << std::endl;
+  // This will trigger hot reset on device.
+  std::string errmsg;
+  udev->sysfs_put("", "shutdown", errmsg, "1\n");
+  if (!errmsg.empty()) {
+    std::cout << "ERROR: Shutdown user function failed." << std::endl;
+    return -EINVAL;
+  }
 
-    const axlf_section_header* section = xclbin::get_axlf_section(ap, (enum axlf_section_kind)kind);
-    if (!section)
-    {
-        return -EINVAL;
-    }
+  // Poll till shutdown is done.
+  int userShutdownStatus = 0;
+  int mgmtOfflineStatus = 1;
+  for (int wait = 0; wait < DEV_TIMEOUT; wait++) {
+    sleep(1);
 
-    buf = std::shared_ptr<char>(new char[section->m_sectionSize]);
-    in.seekg(section->m_sectionOffset);
-    in.read(buf.get(), section->m_sectionSize);
+    udev->sysfs_get<int>("", "shutdown", errmsg, userShutdownStatus, EINVAL);
+    if (!errmsg.empty())
+      // Ignore the error since sysfs nodes will be removed during hot reset.
+      continue;
 
-    return 0;
-}
+    if (userShutdownStatus != 1)
+      continue;
 
-int pcidev::get_uuids(std::shared_ptr<char>& dtbbuf, std::vector<std::string>& uuids)
-{
-    struct fdt_header *bph = (struct fdt_header *)dtbbuf.get();
-    uint32_t version = be32toh(bph->version);
-    uint32_t off_dt = be32toh(bph->off_dt_struct);
-    const char *p_struct = (const char *)bph + off_dt;
-    uint32_t off_str = be32toh(bph->off_dt_strings);
-    const char *p_strings = (const char *)bph + off_str;
-    const char *p, *s;
-    uint32_t tag;
-    int sz;
-
-    p = p_struct;
-    uuids.clear();
-    while ((tag = be32toh(GET_CELL(p))) != FDT_END)
-    {
-        if (tag == FDT_BEGIN_NODE)
-        {
-            s = p;
-            p = PALIGN(p + strlen(s) + 1, 4);
-            continue;
-        }
-        if (tag != FDT_PROP)
-            continue;
-
-        sz = be32toh(GET_CELL(p));
-        s = p_strings + be32toh(GET_CELL(p));
-        if (version < 16 && sz >= 8)
-            p = PALIGN(p, 8);
-
-        if (!strcmp(s, "logic_uuid"))
-        {
-            uuids.insert(uuids.begin(), std::string(p));
-        }
-        else if (!strcmp(s, "interface_uuid"))
-        {
-            uuids.push_back(std::string(p));
-        }
-        p = PALIGN(p + sz, 4);
-    }
-
-    if (!uuids.size())
-        return -EINVAL;
-
-    return 0;
-}
-
-int pcidev::shutdown(std::shared_ptr<pcidev::pci_device> mgmt_dev, bool remove_user, bool remove_mgmt)
-{
-    std::shared_ptr<pcidev::pci_device> udev;
-    std::string errmsg;
-    if (!mgmt_dev->is_mgmt) {
-        return -EINVAL;
-    }
-
-    udev = mgmt_dev->lookup_peer_dev();
-    if (!udev) {
-        std::cout << "ERROR: User function is not found. " <<
-            "This is probably due to user function is running in virtual machine or user driver is not loaded. " << std::endl;
-        return -ECANCELED;
-    }
-
-    std::cout << "Stopping user function..." << std::endl;
-    // This will trigger hot reset on device.
-    udev->sysfs_put("", "shutdown", errmsg, "1\n");
+    // User shutdown is done successfully. Now needs to wait for mgmt
+    // to finish reset. By the time we got here mgmt pf should be offline.
+    // We just need to wait for it to be online again.
+    mgmt_dev->sysfs_get<int>("", "dev_offline", errmsg, mgmtOfflineStatus, EINVAL);
     if (!errmsg.empty()) {
-        std::cout << "ERROR: Shutdown user function failed." << std::endl;
-        return -EINVAL;
+      std::cout << "ERROR: Can't read mgmt dev_offline: " << errmsg << std::endl;
+      break;
     }
+    if (mgmtOfflineStatus == 0)
+      break; // Shutdown is completed
+  }
 
-    // Poll till shutdown is done.
-    int userShutdownStatus = 0;
-    int mgmtOfflineStatus = 1;
-    for (int wait = 0; wait < DEV_TIMEOUT; wait++) {
-        sleep(1);
-
-        udev->sysfs_get<int>("", "shutdown", errmsg, userShutdownStatus, EINVAL);
-        if (!errmsg.empty()) {
-            // Ignore the error since sysfs nodes will be removed during hot reset.
-            continue;
-        }
-        if (userShutdownStatus != 1)
-            continue;
-
-        /*
-         * User shutdown is done successfully. Now needs to wait for mgmt
-         * to finish reset. By the time we got here mgmt pf should be offline.
-         * We just need to wait for it to be online again.
-         */
-        mgmt_dev->sysfs_get<int>("", "dev_offline", errmsg, mgmtOfflineStatus, EINVAL);
-        if (!errmsg.empty()) {
-            std::cout << "ERROR: Can't read mgmt dev_offline: " << errmsg << std::endl;
-            break;
-        }
-        if (mgmtOfflineStatus == 0)
-            break; // Shutdown is completed
-    }
-
-    if (userShutdownStatus != 1 || mgmtOfflineStatus != 0) {
-        std::cout << "ERROR: Shutdown user function timeout." << std::endl;
-        return -ETIMEDOUT;
-    }
-
-    if (!remove_user && !remove_mgmt) {
-        return 0;
-    }
-
-    int rem_dev_cnt = 0;
-    int active_dev_num;
-    std::string parent_path;
-
-    mgmt_dev->sysfs_get<int>("", "dparent/power/runtime_active_kids", errmsg, active_dev_num, EINVAL);
-
-    if (!errmsg.empty()) {
-        std::cout << "ERROR: can not read active device number" << std::endl;
-        return -ENOENT;
-    }
-
-    /* Cache the parent sysfs path before remove the PF */
-    parent_path = mgmt_dev->get_sysfs_path("", "dparent/power/runtime_active_kids");
-    /* Get the absolute path from the symbolic link */
-    parent_path = (boost::filesystem::canonical(parent_path)).c_str();
-
-    if (remove_user) {
-        udev->sysfs_put("", "remove", errmsg, "1\n");
-        if (!errmsg.empty()) {
-            std::cout << "ERROR: removing user function failed" << std::endl;
-            return -EINVAL;
-        }
-        rem_dev_cnt++;
-    }
-
-    if (remove_mgmt) {
-        mgmt_dev->sysfs_put("", "remove", errmsg, "1\n");
-        if (!errmsg.empty()) {
-            std::cout << "ERROR: removing mgmt function failed" << std::endl;
-            return -EINVAL;
-        }
-        rem_dev_cnt++;
-    }
-
-    if (!rem_dev_cnt) {
-        return 0;
-    }
-
-    for (int wait = 0; wait < DEV_TIMEOUT; wait++) {
-        int curr_act_dev;
-        boost::filesystem::ifstream file(parent_path);
-        file >> curr_act_dev;
-        
-        if (curr_act_dev + rem_dev_cnt == active_dev_num)
-            return 0;
-       
-        sleep(1);
-    }
-
-    std::cout << "ERROR: removing device node timed out" << std::endl;
-
+  if (userShutdownStatus != 1 || mgmtOfflineStatus != 0) {
+    std::cout << "ERROR: Shutdown user function timeout." << std::endl;
     return -ETIMEDOUT;
+  }
+
+  if (!remove_user && !remove_mgmt)
+    return 0;
+
+  int active_dev_num;
+  mgmt_dev->sysfs_get<int>("", "dparent/power/runtime_active_kids", errmsg, active_dev_num, EINVAL);
+  if (!errmsg.empty()) {
+    std::cout << "ERROR: can not read active device number" << std::endl;
+    return -ENOENT;
+  }
+
+  /* Cache the parent sysfs path before remove the PF */
+  std::string parent_path = mgmt_dev->get_sysfs_path("", "dparent/power/runtime_active_kids");
+  /* Get the absolute path from the symbolic link */
+  parent_path = (bfs::canonical(parent_path)).c_str();
+
+  int rem_dev_cnt = 0;
+  if (remove_user) {
+    udev->sysfs_put("", "remove", errmsg, "1\n");
+    if (!errmsg.empty()) {
+      std::cout << "ERROR: removing user function failed" << std::endl;
+      return -EINVAL;
+    }
+    rem_dev_cnt++;
+  }
+
+  if (remove_mgmt) {
+    mgmt_dev->sysfs_put("", "remove", errmsg, "1\n");
+    if (!errmsg.empty()) {
+      std::cout << "ERROR: removing mgmt function failed" << std::endl;
+      return -EINVAL;
+    }
+    rem_dev_cnt++;
+  }
+
+  if (!rem_dev_cnt)
+    return 0;
+
+  for (int wait = 0; wait < DEV_TIMEOUT; wait++) {
+    int curr_act_dev;
+    bfs::ifstream file(parent_path);
+    file >> curr_act_dev;
+      
+    if (curr_act_dev + rem_dev_cnt == active_dev_num)
+      return 0;
+     
+    sleep(1);
+  }
+
+  std::cout << "ERROR: removing device node timed out" << std::endl;
+
+  return -ETIMEDOUT;
 }
 
-int pcidev::check_p2p_config(std::shared_ptr<pcidev::pci_device> dev, std::string &err)
+int
+check_p2p_config(const std::shared_ptr<pci_device>& dev, std::string &err)
 {
-    std::string errmsg;
-    int ret = P2P_CONFIG_DISABLED;
+  std::string errmsg;
+  int ret = P2P_CONFIG_DISABLED;
 
-    if (dev->is_mgmt) {
-        return -EINVAL;
+  if (dev->is_mgmt) {
+    return -EINVAL;
+  }
+  err.clear();
+
+  std::vector<std::string> p2p_cfg;
+  dev->sysfs_get("p2p", "config", errmsg, p2p_cfg);
+  if (errmsg.empty()) {
+    long long bar = -1;
+    long long rbar = -1;
+    long long remap = -1;
+    long long exp_bar = -1;
+
+    for (unsigned int i = 0; i < p2p_cfg.size(); i++) {
+        const char *str = p2p_cfg[i].c_str();
+        std::sscanf(str, "bar:%lld", &bar);
+        std::sscanf(str, "exp_bar:%lld", &exp_bar);
+        std::sscanf(str, "rbar:%lld", &rbar);
+        std::sscanf(str, "remap:%lld", &remap);
     }
-    err.clear();
-
-    std::vector<std::string> p2p_cfg;
-    dev->sysfs_get("p2p", "config", errmsg, p2p_cfg);
-    if (errmsg.empty()) {
-        long long bar = -1;
-        long long rbar = -1;
-        long long remap = -1;
-        long long exp_bar = -1;
-
-        for (unsigned int i = 0; i < p2p_cfg.size(); i++)
-        {
-            const char *str = p2p_cfg[i].c_str();
-            std::sscanf(str, "bar:%lld", &bar);
-            std::sscanf(str, "exp_bar:%lld", &exp_bar);
-            std::sscanf(str, "rbar:%lld", &rbar);
-            std::sscanf(str, "remap:%lld", &remap);
-        }
-        if (bar == -1)
-        {
-            ret = P2P_CONFIG_NOT_SUPP;
-            err = "ERROR: P2P is not supported. Cann't find P2P BAR.";
-        }
-        else if (rbar != -1 && rbar > bar)
-        {
-            ret = P2P_CONFIG_REBOOT;
-            err = "Please WARM reboot to enable p2p now.";
-        }
-        else if (remap > 0 && remap != bar)
-        {
-            ret = P2P_CONFIG_ERROR;
-            err = "ERROR: P2P remapper is not set correctly";
-        }
-        else if (bar == exp_bar)
-        {
-            ret = P2P_CONFIG_ENABLED;
-        }
-
-        return ret;
+    if (bar == -1) {
+      ret = P2P_CONFIG_NOT_SUPP;
+      err = "ERROR: P2P is not supported. Cann't find P2P BAR.";
+    }
+    else if (rbar != -1 && rbar > bar) {
+      ret = P2P_CONFIG_REBOOT;
+      err = "Please WARM reboot to enable p2p now.";
+    }
+    else if (remap > 0 && remap != bar) {
+      ret = P2P_CONFIG_ERROR;
+      err = "ERROR: P2P remapper is not set correctly";
+    }
+    else if (bar == exp_bar) {
+      ret = P2P_CONFIG_ENABLED;
     }
 
-    return P2P_CONFIG_NOT_SUPP;
+    return ret;
+  }
+
+  return P2P_CONFIG_NOT_SUPP;
 }
+
+} // namespace pcidev
+
+std::ostream&
+operator<<(std::ostream& stream, const std::shared_ptr<pcidev::pci_device>& dev)
+{
+  std::ios_base::fmtflags f(stream.flags());
+
+  stream << std::hex << std::right << std::setfill('0');
+
+  // [dddd:bb:dd.f]
+  stream << std::setw(4) << dev->domain << ":"
+         << std::setw(2) << dev->bus << ":"
+         << std::setw(2) << dev->dev << "."
+         << std::setw(1) << dev->func;
+
+  // board/shell name
+  std::string shell_name;
+  std::string err;
+  bool is_mfg = false;
+  uint64_t ts = 0;
+  dev->sysfs_get<bool>("", "mfg", err, is_mfg, false);
+  if (is_mfg) {
+    unsigned ver = 0;
+    std::string nm;
+
+    dev->sysfs_get("", "board_name", err, nm);
+    dev->pcieBarRead(MFG_REV_OFFSET, &ver, sizeof(ver));
+    shell_name += "xilinx_";
+    shell_name += nm;
+    shell_name += "_GOLDEN_";
+    shell_name += std::to_string(ver);
+  }
+  else {
+    dev->sysfs_get("rom", "VBNV", err, shell_name);
+    dev->sysfs_get<uint64_t>("rom", "timestamp", err, ts, static_cast<uint64_t>(-1));
+  }
+  stream << " " << shell_name;
+  if (ts != 0)
+    stream << "(ID=0x" << std::hex << ts << ")";
+
+  // instance number
+  if (dev->is_mgmt)
+    stream << " mgmt(inst=";
+  else
+    stream << " user(inst=";
+  stream << std::dec << dev->instance << ")";
+
+  stream.flags(f);
+  return stream;
+}
+

--- a/src/runtime_src/core/pcie/linux/scan.h
+++ b/src/runtime_src/core/pcie/linux/scan.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  * Author: Hem Neema, Ryan Radjabi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -64,83 +64,97 @@ struct fdt_header {
 namespace pcidev {
 
 // One PCIE function on FPGA board
-class pci_device {
+class pci_device
+{
 public:
-    // Fundamental and static information for this device are defined as class
-    // members and initialized during object construction.
-    //
-    // The rest of information related to the device shall be obtained
-    // dynamically via sysfs APIs below.
+  // Fundamental and static information for this device are defined as class
+  // members and initialized during object construction.
+  //
+  // The rest of information related to the device shall be obtained
+  // dynamically via sysfs APIs below.
 
-    uint16_t domain =           INVALID_ID;
-    uint16_t bus =              INVALID_ID;
-    uint16_t dev =              INVALID_ID;
-    uint16_t func =             INVALID_ID;
-    uint32_t instance =         INVALID_ID;
-    std::string sysfs_name =    ""; // dir name under /sys/bus/pci/devices
-    int user_bar =              0;  // BAR mapped in by tools, default is BAR0
-    size_t user_bar_size =      0;
-    bool is_mgmt =              false;
-    bool is_ready =             false;
+  uint16_t domain =           INVALID_ID;
+  uint16_t bus =              INVALID_ID;
+  uint16_t dev =              INVALID_ID;
+  uint16_t func =             INVALID_ID;
+  uint32_t instance =         INVALID_ID;
+  std::string sysfs_name =    ""; // dir name under /sys/bus/pci/devices
+  int user_bar =              0;  // BAR mapped in by tools, default is BAR0
+  size_t user_bar_size =      0;
+  bool is_mgmt =              false;
+  bool is_ready =             false;
 
-    pci_device(const std::string& sysfs_name);
-    ~pci_device();
+  pci_device(const std::string& sysfs_name);
+  ~pci_device();
 
-    void sysfs_get(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, std::vector<std::string>& sv);
-    void sysfs_get(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, std::vector<uint64_t>& iv);
-    void sysfs_get(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, std::string& s);
-    void sysfs_get(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, std::vector<char>& buf);
-    template <typename T>
-    void sysfs_get(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, T& i, const T& default_val) {
-        std::vector<uint64_t> iv;
+  void
+  sysfs_get(const std::string& subdev, const std::string& entry,
+            std::string& err, std::vector<std::string>& sv);
+  void
+  sysfs_get(const std::string& subdev, const std::string& entry,
+            std::string& err, std::vector<uint64_t>& iv);
+  void
+  sysfs_get(const std::string& subdev, const std::string& entry,
+            std::string& err, std::string& s);
+  void
+  sysfs_get(const std::string& subdev, const std::string& entry,
+            std::string& err, std::vector<char>& buf);
+  template <typename T>
+  void
+  sysfs_get(const std::string& subdev, const std::string& entry,
+            std::string& err, T& i, const T& default_val)
+  {
+    std::vector<uint64_t> iv;
+    sysfs_get(subdev, entry, err, iv);
+    if (!iv.empty())
+      i = static_cast<T>(iv[0]);
+    else
+      i = static_cast<T>(default_val); // default value
+  }
 
-        sysfs_get(subdev, entry, err_msg, iv);
-        if (!iv.empty())
-            i = static_cast<T>(iv[0]);
-        else
-            i = static_cast<T>(default_val); // default value
-    }
-    void sysfs_get_sensor(const std::string& subdev, const std::string& entry,
-        uint32_t& i) {
-        std::string err;
-        sysfs_get<uint32_t>(subdev, entry, err, i, 0);
-    }
-    void sysfs_put(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, const std::string& input);
-    void sysfs_put(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, const std::vector<char>& buf);
-    void sysfs_put(const std::string& subdev, const std::string& entry,
-        std::string& err_msg, const unsigned int& buf);
-    std::string get_sysfs_path(const std::string& subdev,
-        const std::string& entry);
-    std::string get_subdev_path(const std::string& subdev, uint32_t idx);
-    int pcieBarRead(uint64_t offset, void *buf, uint64_t len);
-    int pcieBarWrite(uint64_t offset, const void *buf, uint64_t len);
+  void
+  sysfs_get_sensor(const std::string& subdev, const std::string& entry, uint32_t& i)
+  {
+    std::string err;
+    sysfs_get<uint32_t>(subdev, entry, err, i, 0);
+  }
 
-    int open(const std::string& subdev, int flag);
-    int open(const std::string& subdev, uint32_t idx, int flag);
-    void close(int devhdl);
-    int ioctl(int devhdl, unsigned long cmd, void *arg = nullptr);
-    int poll(int devhdl, short events, int timeoutMilliSec);
-    void *mmap(int devhdl, size_t len, int prot, int flags, off_t offset);
-    int munmap(int devhdl, void* addr, size_t len);
-    int flock(int devhdl, int op);
-    int get_partinfo(std::vector<std::string>& info, void *blob = nullptr);
-    std::shared_ptr<pcidev::pci_device> lookup_peer_dev();
+  void
+  sysfs_put(const std::string& subdev, const std::string& entry,
+            std::string& err, const std::string& input);
+  void
+  sysfs_put(const std::string& subdev, const std::string& entry,
+            std::string& err, const std::vector<char>& buf);
+
+  void
+  sysfs_put(const std::string& subdev, const std::string& entry,
+            std::string& err, const unsigned int& buf);
+
+  std::string
+  get_sysfs_path(const std::string& subdev, const std::string& entry);
+
+  std::string
+  get_subdev_path(const std::string& subdev, uint32_t idx);
+
+  int pcieBarRead(uint64_t offset, void *buf, uint64_t len);
+  int pcieBarWrite(uint64_t offset, const void *buf, uint64_t len);
+
+  int open(const std::string& subdev, int flag);
+  int open(const std::string& subdev, uint32_t idx, int flag);
+  void close(int devhdl);
+  int ioctl(int devhdl, unsigned long cmd, void *arg = nullptr);
+  int poll(int devhdl, short events, int timeoutMilliSec);
+  void *mmap(int devhdl, size_t len, int prot, int flags, off_t offset);
+  int munmap(int devhdl, void* addr, size_t len);
+  int flock(int devhdl, int op);
+  int get_partinfo(std::vector<std::string>& info, void *blob = nullptr);
+  std::shared_ptr<pcidev::pci_device> lookup_peer_dev();
 
 private:
-    std::fstream sysfs_open(const std::string& subdev,
-        const std::string& entry, std::string& err,
-        bool write = false, bool binary = false);
-    int map_usr_bar(void);
+  int map_usr_bar(void);
 
-    std::mutex lock;
-    char *user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
+  std::mutex lock;
+  char *user_bar_map = reinterpret_cast<char *>(MAP_FAILED);
 };
 
 void rescan(void);
@@ -148,15 +162,16 @@ size_t get_dev_total(bool user = true);
 size_t get_dev_ready(bool user = true);
 std::shared_ptr<pci_device> get_dev(unsigned index, bool user = true);
 
-int get_axlf_section(std::string filename, int kind, std::shared_ptr<char>& buf);
+int get_axlf_section(const std::string& filename, int kind, std::shared_ptr<char>& buf);
 int get_uuids(std::shared_ptr<char>& dtbbuf, std::vector<std::string>& uuids);
 std::shared_ptr<pcidev::pci_device> lookup_user_dev(std::shared_ptr<pcidev::pci_device> mgmt_dev);
 int shutdown(std::shared_ptr<pcidev::pci_device> mgmt_dev, bool remove_user = false, bool remove_mgmt = false);
-int check_p2p_config(std::shared_ptr<pcidev::pci_device> dev, std::string &err);
-} /* pcidev */
+int check_p2p_config(const std::shared_ptr<pcidev::pci_device>& dev, std::string &err);
+
+} // namespace pcidev
 
 // For print out per device info
-std::ostream& operator<<(std::ostream& stream,
-    const std::shared_ptr<pcidev::pci_device>& dev);
+std::ostream&
+operator<< (std::ostream& stream, const std::shared_ptr<pcidev::pci_device>& dev);
 
 #endif

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -475,11 +475,6 @@ device(platform* pltf, xrt::device* xdevice)
   : m_uid(uid_count++), m_platform(pltf), m_xdevice(xdevice)
 {
   XOCL_DEBUG(std::cout,"xocl::device::device(",m_uid,")\n");
-
-  // lock/open the device once to ensure that device info data
-  // for this device is cached.  There are device level APIs
-  // that access data from low level device info.
-  (void) lock_guard();
 }
 
 device::

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -153,7 +153,9 @@ public:
    * @param level
    *   Verbosity level for logging
    * @returns
-   *   If open succeeds then true, false otherwise
+   *   If open was opened then true, false if device was already open
+   *
+   * Throws if device could not be opened
    */
   bool
   open()

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -160,6 +160,13 @@ public:
     ,XRT_HOST_ONLY_MEM
   };
 
+  /**
+   * Open the device.
+   *
+   * @return True if device was opened, false if already open
+   *
+   * Throws if device could not be opened
+   */
   virtual bool
   open() = 0;
 

--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -19,6 +19,7 @@
 #include "core/common/device.h"
 #include "core/common/query_requests.h"
 #include "core/common/thread.h"
+#include "core/common/scope_guard.h"
 
 #include <boost/format.hpp>
 #include <cstring> // for std::memcpy
@@ -63,15 +64,45 @@ device::
     t.join();
 }
 
+bool
+device::
+open_nolock()
+{
+  if (m_handle)
+    return false;
+
+  m_handle=m_ops->mOpen(m_idx, nullptr, XCL_QUIET);
+
+  if (!m_handle)
+    throw std::runtime_error("Could not open device");
+
+  return true;
+}
+
+bool
+device::
+open()
+{
+  std::lock_guard<std::mutex> lk(m_mutex);
+  return open_nolock();
+}
+
+void
+device::
+close_nolock()
+{
+  if (m_handle) {
+    m_ops->mClose(m_handle);
+    m_handle=nullptr;
+  }
+}
+
 void
 device::
 close()
 {
   std::lock_guard<std::mutex> lk(m_mutex);
-  if (m_handle) {
-    m_ops->mClose(m_handle);
-    m_handle=nullptr;
-  }
+  close_nolock();
 }
 
 std::ostream&
@@ -80,26 +111,27 @@ printDeviceInfo(std::ostream& ostr) const
 {
   if (!m_handle)
     throw std::runtime_error("Can't print device info, device is not open");
-  ostr << "Name: " << m_devinfo.mName << "\n";
-  ostr << "HAL v" << m_devinfo.mHALMajorVersion << "." << m_devinfo.mHALMinorVersion << "\n";
-  ostr << "HAL vendor id: " << std::hex << m_devinfo.mVendorId << std::dec << "\n";
-  ostr << "HAL device id: " << std::hex << m_devinfo.mDeviceId << std::dec << "\n";
-  ostr << "HAL device v" << m_devinfo.mDeviceVersion << "\n";
-  ostr << "HAL subsystem id: " << std::hex << m_devinfo.mSubsystemId << std::dec << "\n";
-  ostr << "HAL subsystem vendor id: " << std::hex << m_devinfo.mSubsystemVendorId << std::dec << "\n";
-  ostr << "HAL DDR size: " << std::hex << m_devinfo.mDDRSize << std::dec << "\n";
-  ostr << "HAL Data alignment: " << m_devinfo.mDataAlignment << "\n";
-  ostr << "HAL DDR free size: " << std::hex << m_devinfo.mDDRFreeSize << std::dec << "\n";
-  ostr << "HAL Min transfer size: " << m_devinfo.mMinTransferSize << "\n";
-  ostr << "HAL OnChip Temp: " << m_devinfo.mOnChipTemp << "\n";
-  ostr << "HAL Fan Temp: " << m_devinfo.mFanTemp << "\n";
-  ostr << "HAL Voltage: " << m_devinfo.mVInt << "\n";
-  ostr << "HAL Current: " << m_devinfo.mCurrent << "\n";
-  ostr << "HAL DDR count: " << m_devinfo.mDDRBankCount << "\n";
-  ostr << "HAL OCL freq: " << m_devinfo.mOCLFrequency[0] << "\n";
-  ostr << "HAL PCIe width: " << m_devinfo.mPCIeLinkWidth << "\n";
-  ostr << "HAL PCIe speed: " << m_devinfo.mPCIeLinkSpeed << "\n";
-  ostr << "HAL DMA threads: " << m_devinfo.mDMAThreads << "\n";
+  auto dinfo = get_device_info();
+  ostr << "Name: " << dinfo->mName << "\n";
+  ostr << "HAL v" << dinfo->mHALMajorVersion << "." << dinfo->mHALMinorVersion << "\n";
+  ostr << "HAL vendor id: " << std::hex << dinfo->mVendorId << std::dec << "\n";
+  ostr << "HAL device id: " << std::hex << dinfo->mDeviceId << std::dec << "\n";
+  ostr << "HAL device v" << dinfo->mDeviceVersion << "\n";
+  ostr << "HAL subsystem id: " << std::hex << dinfo->mSubsystemId << std::dec << "\n";
+  ostr << "HAL subsystem vendor id: " << std::hex << dinfo->mSubsystemVendorId << std::dec << "\n";
+  ostr << "HAL DDR size: " << std::hex << dinfo->mDDRSize << std::dec << "\n";
+  ostr << "HAL Data alignment: " << dinfo->mDataAlignment << "\n";
+  ostr << "HAL DDR free size: " << std::hex << dinfo->mDDRFreeSize << std::dec << "\n";
+  ostr << "HAL Min transfer size: " << dinfo->mMinTransferSize << "\n";
+  ostr << "HAL OnChip Temp: " << dinfo->mOnChipTemp << "\n";
+  ostr << "HAL Fan Temp: " << dinfo->mFanTemp << "\n";
+  ostr << "HAL Voltage: " << dinfo->mVInt << "\n";
+  ostr << "HAL Current: " << dinfo->mCurrent << "\n";
+  ostr << "HAL DDR count: " << dinfo->mDDRBankCount << "\n";
+  ostr << "HAL OCL freq: " << dinfo->mOCLFrequency[0] << "\n";
+  ostr << "HAL PCIe width: " << dinfo->mPCIeLinkWidth << "\n";
+  ostr << "HAL PCIe speed: " << dinfo->mPCIeLinkSpeed << "\n";
+  ostr << "HAL DMA threads: " << dinfo->mDMAThreads << "\n";
   return ostr;
 }
 
@@ -111,13 +143,15 @@ setup()
   if (!m_workers.empty())
     return;
 
-  openOrError();
+  open_nolock();
+
+  auto dinfo = get_device_info_nolock();
 
   auto threads = config::get_dma_threads(); // number of bidirectional channels
   if (!threads)
-    threads = m_devinfo.mDMAThreads;
+    threads = dinfo->mDMAThreads;
   else
-    threads = std::min(static_cast<unsigned short>(threads),m_devinfo.mDMAThreads);
+    threads = std::min(static_cast<unsigned short>(threads),dinfo->mDMAThreads);
   if (!threads) // Guard against drivers who do not set m_devinfo.mDMAThreads
     threads = 2;
 
@@ -149,6 +183,38 @@ getExecBufferObject(const ExecBufferObjectHandle& boh) const
   if (bo->owner != m_handle)
     throw std::runtime_error("bad exec buffer object");
   return bo;
+}
+
+hal2::device_info*
+device::
+get_device_info_nolock() const
+{
+  hal2::device_info* dinfo = m_devinfo.get_ptr();
+  if (dinfo)
+    return dinfo;
+
+  // Gather device info, open device if necessary
+  // This is a logically const operation
+  auto dev = const_cast<device*>(this);
+  dinfo = (m_devinfo = hal2::device_info()).get_ptr();
+
+  // Scope guard for closing device again if opened
+  auto at_exit = [] (device* d, bool close) { if (close) d->close_nolock(); };
+  xrt_core::scope_guard<std::function<void()>> g(std::bind(at_exit, dev, dev->open_nolock()));
+
+  std::memset(dinfo,0,sizeof(hal2::device_info));
+  if (m_ops->mGetDeviceInfo(m_handle,dinfo))
+    throw std::runtime_error("device info not available");
+
+  return dinfo;
+}
+
+hal2::device_info*
+device::
+get_device_info() const
+{
+  std::lock_guard<std::mutex> lk(m_mutex);
+  return get_device_info_nolock();
 }
 
 std::string
@@ -186,6 +252,24 @@ release_cu_context(const uuid& uuid,size_t cuidx)
                                + std::strerror(errno)
                                + "'");
   }
+}
+
+hal::operations_result<int>
+device::
+loadXclBin(const xclBin* xclbin)
+{
+  if (!m_ops->mLoadXclBin)
+    return hal::operations_result<int>();
+
+  hal::operations_result<int> ret = m_ops->mLoadXclBin(m_handle,xclbin);
+
+  // refresh device info on successful load
+  if (!ret.get()) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    m_devinfo = boost::none;
+  }
+
+  return ret;
 }
 
 ExecBufferObjectHandle


### PR DESCRIPTION
OpenCL device creation no longer opens device up front for device info.
Instead device info is gathered on demand first time it is needed.

Factor out sysfs access from pci_device class.