### PR TITLE
Support CentOs 8.1

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -98,16 +98,9 @@ rh_package_list()
          systemd-devel \
          python3 \
          python3-pip \
+         kernel-devel-$(uname -r) \
+         kernel-headers-$(uname -r) \
         )
-
-	if [ $FLAVOR == "rhel" ]; then
-  
-            RH_LIST+=(\
-             kernel-devel-$(uname -r) \
-             kernel-headers-$(uname -r) \
-            )
-  
-        fi
 
     else
 


### PR DESCRIPTION
Updated xrtdeps.sh with the missing kernel-headers and kernel-devel packages for CentOs 8 and above versions