### PR TITLE
XDP: Adding broadcast mechanism for active plugins

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.cpp
+++ b/src/runtime_src/xdp/profile/database/database.cpp
@@ -25,8 +25,8 @@ namespace xdp {
 
   bool VPDatabase::live ;
 
-  VPDatabase::VPDatabase()
-            : numDevices(0)
+  VPDatabase::VPDatabase() :
+    stats(this), staticdb(this), dyndb(this), numDevices(0)
   {
     VPDatabase::live = true ;
   }
@@ -111,4 +111,11 @@ namespace xdp {
     return true ;
   }
 
+  void VPDatabase::broadcast(MessageType msg, void* blob)
+  {
+    for (auto p : plugins)
+    {
+      p->broadcast(msg, blob) ;
+    }
+  }
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -38,6 +38,10 @@ namespace xdp {
   //  singleton pattern.
   class VPDatabase
   {
+  public:
+    // For messages sent to specific plugins
+    enum MessageType { DUMP_RUN_SUMMARY } ;
+
   private:
     // The information stored in the database will be separated into 
     //  three sections:
@@ -84,6 +88,9 @@ namespace xdp {
     //  the number of plugins
     XDP_EXPORT bool claimRunSummaryOwnership() ;
     XDP_EXPORT bool claimDeviceOffloadOwnership() ;
+
+    // Functions that send messages to registered plugins
+    XDP_EXPORT void broadcast(MessageType msg, void* blob = nullptr);
   } ;
 }
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -21,8 +21,8 @@
 
 namespace xdp {
   
-  VPDynamicDatabase::VPDynamicDatabase() : 
-    eventId(1), stringId(1)
+  VPDynamicDatabase::VPDynamicDatabase(VPDatabase* d) :
+    db(d), eventId(1), stringId(1)
   {
     // For low overhead profiling, we will reserve space for 
     //  a set number of events.  This won't change HAL or OpenCL 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -30,10 +30,16 @@
 
 namespace xdp {
 
+  // Forward declarations
+  class VPDatabase ;
+
   // The Dynamic Database will own all VTFEvents and is responsible
   //  for cleaning up this memory.
   class VPDynamicDatabase
   {
+  private:
+    VPDatabase* db ;
+
   private:
     // For host events, we are guaranteed that all of the timestamps
     //  will come in sequential order.  For this, we can use 
@@ -73,7 +79,7 @@ namespace xdp {
     void addDeviceEvent(uint64_t deviceId, VTFEvent* event) ;
 
   public:
-    XDP_EXPORT VPDynamicDatabase() ;
+    XDP_EXPORT VPDynamicDatabase(VPDatabase* d) ;
     XDP_EXPORT ~VPDynamicDatabase() ;
 
     // Add an event in sorted order in the database

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -30,6 +30,7 @@
 #define XDP_SOURCE
 
 #include "xdp/profile/database/static_info_database.h"
+#include "xdp/profile/database/database.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #include "core/include/xclbin.h"
 
@@ -78,7 +79,7 @@ namespace xdp {
     connections[argIdx].push_back(memIdx);
   }
 
-  VPStaticDatabase::VPStaticDatabase()
+  VPStaticDatabase::VPStaticDatabase(VPDatabase* d) : db(d)
   {
 #ifdef _WIN32
     pid = _getpid() ;
@@ -321,6 +322,8 @@ namespace xdp {
     std::lock_guard<std::mutex> lock(dbLock) ;
 
     openedFiles.push_back(std::make_pair(name, type)) ;
+
+    db->broadcast(VPDatabase::DUMP_RUN_SUMMARY, nullptr) ;
   }
 
 }

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -28,6 +28,9 @@
 
 namespace xdp {
 
+  // Forward declarations
+  class VPDatabase ;
+
   struct Monitor {
     uint8_t     type;
     uint64_t    index;
@@ -134,6 +137,9 @@ namespace xdp {
   class VPStaticDatabase
   {
   private:
+    VPDatabase* db ;
+
+  private:
     // ********* Information specific to each host execution **********
     int pid ;
     
@@ -168,7 +174,7 @@ namespace xdp {
     bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
 
   public:
-    VPStaticDatabase() ;
+    VPStaticDatabase(VPDatabase* d) ;
     ~VPStaticDatabase() ;
 
     // Getters and setters

--- a/src/runtime_src/xdp/profile/database/statistics_database.cpp
+++ b/src/runtime_src/xdp/profile/database/statistics_database.cpp
@@ -23,8 +23,8 @@
 
 namespace xdp {
 
-  VPStatisticsDatabase::VPStatisticsDatabase() : 
-    firstKernelStartTime(0.0)
+  VPStatisticsDatabase::VPStatisticsDatabase(VPDatabase* d) :
+    db(d), firstKernelStartTime(0.0)
   {
   }
 

--- a/src/runtime_src/xdp/profile/database/statistics_database.h
+++ b/src/runtime_src/xdp/profile/database/statistics_database.h
@@ -31,6 +31,9 @@
 
 namespace xdp {
 
+  // Forward declarations
+  class VPDatabase ;
+
   // All of the statistics in this database will be used in 
   //  summary files.  Different plugins might use different
   //  information.  This information accumulates throughout 
@@ -81,6 +84,9 @@ namespace xdp {
   class VPStatisticsDatabase 
   {
   private:
+    VPDatabase* db ;
+
+  private:
     // Statistics on API calls (OpenCL and HAL) have to be thread specific
     std::map<std::pair<std::string, std::thread::id>,
              std::vector<std::pair<double, double>>> callCount ;
@@ -103,7 +109,7 @@ namespace xdp {
     std::mutex dbLock ;
 
   public:
-    XDP_EXPORT VPStatisticsDatabase() ;
+    XDP_EXPORT VPStatisticsDatabase(VPDatabase* d) ;
     XDP_EXPORT ~VPStatisticsDatabase() ;
 
     // Getters and setters

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -31,6 +31,7 @@
 #include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/xrt_device/xdp_xrt_device.h"
+#include "xdp/profile/writer/vp_base/vp_writer.h"
 
 namespace xdp {
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -20,6 +20,7 @@
 
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
 #include "xdp/profile/writer/vp_base/vp_run_summary.h"
+#include "xdp/profile/database/database.h"
 
 #ifdef _WIN32
 #pragma warning(disable : 4996)
@@ -68,6 +69,24 @@ namespace xdp {
     for (auto w : writers)
     {
       w->write(openNewFiles) ;
+    }
+  }
+
+  void XDPPlugin::broadcast(VPDatabase::MessageType msg, void* /*blob*/)
+  {
+    switch(msg)
+    {
+    case VPDatabase::DUMP_RUN_SUMMARY:
+      for (auto w : writers)
+      {
+	if (w->isRunSummaryWriter())
+	{
+	  w->write(false) ;
+	}
+      }
+      break ;
+    default:
+      break ;
     }
   }
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -20,15 +20,15 @@
 #include <vector>
 
 #include "xdp/profile/database/database.h"
-#include "xdp/profile/writer/vp_base/vp_writer.h"
-
 #include "xdp/config.h"
 
 namespace xdp {
 
+  // Forward declarations
+  class VPWriter ;
+
   class XDPPlugin
   {
-  private:
   protected:
     // A link to the single instance of the database that all plugins
     //  refer to.
@@ -50,6 +50,11 @@ namespace xdp {
     // When the database gets reset or at the end of execution,
     //  the plugins must make sure all of their writers dump a complete file
     XDP_EXPORT virtual void writeAll(bool openNewFiles = true) ;
+
+    // Messages may be broadcast from the database to all plugins using
+    //  this function
+    XDP_EXPORT void broadcast(VPDatabase::MessageType msg,
+			      void* blob = nullptr) ;
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -46,6 +46,10 @@ namespace xdp {
   {
     // Ignore openNewFile
     
+    // We could be called to write multiple times, so refresh before
+    //  we dump
+    refreshFile() ;
+
     // There might be more than one run summary writer if multiple
     //  plugins are instantitated.  In that case, only one will
     //  be able to write.

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
@@ -38,6 +38,8 @@ namespace xdp {
 
     XDP_EXPORT
     virtual void write(bool openNewFile) ;
+
+    virtual bool isRunSummaryWriter() { return true ; }
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -22,7 +22,7 @@
 namespace xdp {
 
   VPWriter::VPWriter(const char* filename) : 
-    basename(filename), fileNum(1),
+    basename(filename), currentFileName(filename), fileNum(1),
     db(VPDatabase::Instance()), fout(filename)
   {
   }
@@ -39,9 +39,19 @@ namespace xdp {
     fout.clear() ;
 
     ++fileNum ;
-    std::string newFileName = std::to_string(fileNum) + std::string("-") + basename ;
+    currentFileName = std::to_string(fileNum) + std::string("-") + basename ;
 
-    fout.open(newFileName.c_str()) ;
+    fout.open(currentFileName.c_str()) ;
+  }
+
+  // If we are overwriting a file that was previously written (but not
+  //  switching files), then this function resets the output stream
+  void VPWriter::refreshFile()
+  {
+    fout.close() ;
+    fout.clear() ;
+
+    fout.open(currentFileName.c_str()) ;
   }
 
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -36,6 +36,9 @@ namespace xdp {
     // The base name of all files created by this writer
     std::string basename ;
 
+    // The current name of the open file
+    std::string currentFileName ;
+
     // The number of files created by this writer (in continuous offload)
     uint32_t fileNum ;
 
@@ -50,10 +53,12 @@ namespace xdp {
 
     inline const char* getRawBasename() { return basename.c_str() ; } 
     XDP_EXPORT virtual void switchFiles() ;
+    XDP_EXPORT virtual void refreshFile() ;
   public:
     XDP_EXPORT VPWriter(const char* filename) ;
     XDP_EXPORT virtual ~VPWriter() ;
 
+    virtual bool isRunSummaryWriter() { return false ; }
     virtual void write(bool openNewFile = true) = 0 ;
     virtual bool isDeviceWriter() { return false ; } 
     virtual DeviceIntf* device() { return nullptr ; } 


### PR DESCRIPTION
Adding ability for the database to broadcast messages to all of the registered plugins.  This is used first to update and dump the run_summary file whenever a new file to keep track of is added to the static info database.