### PR TITLE
XDP: refactoring run summary ownership

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.cpp
+++ b/src/runtime_src/xdp/profile/database/database.cpp
@@ -80,23 +80,6 @@ namespace xdp {
 
   // This function should return true the first time any plugin calls it.
   //  The plugin that has ownership is the only one that should be responsible
-  //  for writing the run summary.
-  bool VPDatabase::claimRunSummaryOwnership()
-  {
-    static std::mutex runSummaryLock ;
-    static bool claimed = false ;
-
-    std::lock_guard<std::mutex> lock(runSummaryLock) ;
-    if (claimed)
-    {
-      return false ;
-    }
-    claimed = true ;
-    return true ;
-  }
-
-  // This function should return true the first time any plugin calls it.
-  //  The plugin that has ownership is the only one that should be responsible
   //  for offloading information from the devices.  This is necessary for
   //  hardware OpenCL flows which will end up loading two offload plugins
   bool VPDatabase::claimDeviceOffloadOwnership()

--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -40,7 +40,7 @@ namespace xdp {
   {
   public:
     // For messages sent to specific plugins
-    enum MessageType { DUMP_RUN_SUMMARY } ;
+    enum MessageType { } ;
 
   private:
     // The information stored in the database will be separated into 
@@ -86,7 +86,6 @@ namespace xdp {
     // Functions that provide arbitration between multiple plugins
     //  for resources that should only exist once regardless of 
     //  the number of plugins
-    XDP_EXPORT bool claimRunSummaryOwnership() ;
     XDP_EXPORT bool claimDeviceOffloadOwnership() ;
 
     // Functions that send messages to registered plugins

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -33,6 +33,7 @@
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/device/hal_device/xdp_hal_device.h"
 #include "core/include/xclbin.h"
+#include "xdp/profile/writer/vp_base/vp_run_summary.h"
 
 #define XAM_STALL_PROPERTY_MASK        0x4
 
@@ -79,7 +80,7 @@ namespace xdp {
     connections[argIdx].push_back(memIdx);
   }
 
-  VPStaticDatabase::VPStaticDatabase(VPDatabase* d) : db(d)
+  VPStaticDatabase::VPStaticDatabase(VPDatabase* d) : db(d), runSummary(nullptr)
   {
 #ifdef _WIN32
     pid = _getpid() ;
@@ -90,6 +91,11 @@ namespace xdp {
 
   VPStaticDatabase::~VPStaticDatabase()
   {
+    if (runSummary != nullptr)
+    {
+      runSummary->write() ;
+      delete runSummary ;
+    }
   }
 
   // This function is called whenever a device is loaded with an 
@@ -323,7 +329,10 @@ namespace xdp {
 
     openedFiles.push_back(std::make_pair(name, type)) ;
 
-    db->broadcast(VPDatabase::DUMP_RUN_SUMMARY, nullptr) ;
+    if (runSummary == nullptr)
+    {
+      runSummary = new VPRunSummaryWriter("xclbin.run_summary") ;
+    }
   }
 
 }

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -93,7 +93,7 @@ namespace xdp {
   {
     if (runSummary != nullptr)
     {
-      runSummary->write() ;
+      runSummary->write(false) ;
       delete runSummary ;
     }
   }
@@ -333,6 +333,7 @@ namespace xdp {
     {
       runSummary = new VPRunSummaryWriter("xclbin.run_summary") ;
     }
+    runSummary->write(false) ;
   }
 
 }

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -30,6 +30,7 @@ namespace xdp {
 
   // Forward declarations
   class VPDatabase ;
+  class VPWriter ;
 
   struct Monitor {
     uint8_t     type;
@@ -137,7 +138,10 @@ namespace xdp {
   class VPStaticDatabase
   {
   private:
+    // Parent pointer to database so we can issue broadcasts
     VPDatabase* db ;
+    // The static database handles the single instance of the run summary
+    VPWriter* runSummary ;
 
   private:
     // ********* Information specific to each host execution **********

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -67,13 +67,15 @@ namespace xdp {
     }
   }
 
-  void XDPPlugin::broadcast(VPDatabase::MessageType msg, void* /*blob*/)
+  void XDPPlugin::broadcast(VPDatabase::MessageType /*msg*/, void* /*blob*/)
   {
+    /*
     switch(msg)
     {
     default:
       break ;
     }
+    */
   }
 
 }

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -31,11 +31,6 @@ namespace xdp {
 
   XDPPlugin::XDPPlugin() : db(VPDatabase::Instance())
   {
-    // Every combination of plugins should generate a single run summary file
-    if (db->claimRunSummaryOwnership())
-    {
-      writers.push_back(new VPRunSummaryWriter("xclbin.run_summary")) ;
-    }
   }
 
   XDPPlugin::~XDPPlugin()
@@ -76,15 +71,6 @@ namespace xdp {
   {
     switch(msg)
     {
-    case VPDatabase::DUMP_RUN_SUMMARY:
-      for (auto w : writers)
-      {
-	if (w->isRunSummaryWriter())
-	{
-	  w->write(false) ;
-	}
-      }
-      break ;
     default:
       break ;
     }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -50,9 +50,6 @@ namespace xdp {
     //  we dump
     refreshFile() ;
 
-    // There might be more than one run summary writer if multiple
-    //  plugins are instantitated.  In that case, only one will
-    //  be able to write.
     if (!fout) return ;
 
     // Collect all the files that have been created in this host execution


### PR DESCRIPTION
Moving the ownership of the run summary generation from the plugins to the database.  With this change, there will always be one and only one run summary that gets updated every time a file is added.