### PR TITLE
Explicitly specify python3

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -109,4 +109,8 @@ if [ "$mpd_active" = "active" ]; then
     echo "Starting MPD daemon"
     systemctl start mpd > /dev/null 2>&1
 fi
+
+# xbutil validate depends on numpy
+pip3 install numpy
+
 exit 0

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1192,7 +1192,7 @@ int xcldev::device::runTestCase(const std::string& py,
         return -EINVAL;
     }
 
-    std::string cmd = "/usr/bin/python " + xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx);
+    std::string cmd = "/usr/bin/python3 " + xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx);
     return runShellCmd(cmd, output);
 }
 


### PR DESCRIPTION
python->python2 symlink is created by default, but python->python3 linking is not supported and won’t be in foreseeable future according to PEP. 
We have no other choice but to explicitly specify 'python3' in xbutil code. We won’t be moving to a newer version of python anytime soon so this should be safe for now.

