### PR TITLE
Support devtoolset-9 on CentOs

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -337,7 +337,10 @@ install()
     if [ $FLAVOR == "rhel" ] || [ $FLAVOR == "centos" ] || [ $FLAVOR == "amzn" ]; then
         echo "Installing RHEL/CentOS packages..."
         yum install -y "${RH_LIST[@]}"
-	if [ $ARCH == "ppc64le" ]; then
+        OSREL=`lsb_release -r | awk -F: '{print tolower($2)}' |tr -d ' \t' | awk -F. '{print $1*100+$2}'`
+        if [ $FLAVOR == "centos" ] && [ $OSREL -gt 706 ]; then
+          yum install -y devtoolset-9
+	elif [ $ARCH == "ppc64le" ]; then
             yum install -y devtoolset-7
 	elif [ $MAJOR -lt "8" ]; then
             yum install -y devtoolset-6

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -338,9 +338,9 @@ install()
         echo "Installing RHEL/CentOS packages..."
         yum install -y "${RH_LIST[@]}"
         OSREL=`lsb_release -r | awk -F: '{print tolower($2)}' |tr -d ' \t' | awk -F. '{print $1*100+$2}'`
-        if [ $FLAVOR == "centos" ] && [ $OSREL -gt 706 ]; then
+        if [ $FLAVOR == "centos" ] && [ $OSREL -gt 706 ] && [ $OSREL -lt 800 ]; then
           yum install -y devtoolset-9
-	elif [ $ARCH == "ppc64le" ]; then
+        elif [ $ARCH == "ppc64le" ]  || [[ $FLAVOR == "centos" && $OSREL -eq 704 ]]; then
             yum install -y devtoolset-7
 	elif [ $MAJOR -lt "8" ]; then
             yum install -y devtoolset-6


### PR DESCRIPTION
> Updated xrtdeps.sh to install devtoolset-9 for CentOs with version
greater than 7.6.
> CentOs 7.7 and 7.8 doesnot support devtoolset-6 package.