### PR TITLE
CR-1069847 mgmt probe fail with static xfer on 2019 shell

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1269,16 +1269,6 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	(void) xocl_subdev_create_by_level(lro, XOCL_SUBDEV_LEVEL_BLD);
 	(void) xocl_subdev_create_vsec_devs(lro);
 
-	if (XOCL_DSA_IS_VERSAL(lro)) {
-		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XFER_MGMT_VERSAL;
-		xocl_info(&pdev->dev,
-			"probe xfer_versal Start 0x%llx",
-			subdev_info.res[0].start);
-		rc = xocl_subdev_create(lro, &subdev_info);
-		if (rc)
-			goto err_init_sysfs;
-	}
-
 	xocl_pmc_enable_reset(lro);
 
 	return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -271,9 +271,15 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_PLATFORM_INFO     0x52
 #define XOCL_VSEC_MAILBOX           0x53
 
+#define XOCL_VSEC_FLASH_TYPE_SPI_IP	0x0
+#define XOCL_VSEC_FLASH_TYPE_SPI_REG	0x1
+#define XOCL_VSEC_FLASH_TYPE_QSPI	0x2
+#define XOCL_VSEC_FLASH_TYPE_VERSAL	0x3
+
 #define XOCL_VSEC_PLAT_RECOVERY     0x0
 #define XOCL_VSEC_PLAT_1RP          0x1
 #define XOCL_VSEC_PLAT_2RP          0x2
+
 
 #define XOCL_MAXNAMELEN	64
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1292,6 +1292,16 @@ bool xocl_subdev_is_vsec(xdev_handle_t xdev)
 	return pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VNDR) != 0;
 }
 
+static inline int xocl_subdev_create_vsec_impl(xdev_handle_t xdev,
+	struct xocl_subdev_info *info, u64 offset, int bar)
+{
+	info->res[0].start = offset;
+	info->res[0].end = offset + 0xfff;
+	info->bar_idx[0] = bar;
+
+	return xocl_subdev_create(xdev, info);
+}
+
 int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 {
 	u64 offset;
@@ -1301,22 +1311,49 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_FLASH_CONTROLER, &bar, &offset,
 		&vtype);
 	if (!ret) {
-		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_FLASH_VSEC;
+		struct xocl_subdev_info subdev_info =
+		    XOCL_DEVINFO_FLASH_VSEC;
 
-		xocl_xdev_info(xdev,
-			"Vendor Specific FLASH RES Start 0x%llx, bar %d",
-			 offset, bar);
-		subdev_info.res[0].start = offset;
-		subdev_info.res[0].end = offset + 0xfff;
-		subdev_info.bar_idx[0] = bar;
-		if (vtype == 0x2)
-                        memcpy(((struct xocl_flash_privdata *)
-				(subdev_info.priv_data))->flash_type,
-				FLASH_TYPE_QSPIPS, strlen(FLASH_TYPE_QSPIPS));
+		switch (vtype) {
+		case XOCL_VSEC_FLASH_TYPE_QSPI:
+			memcpy(((struct xocl_flash_privdata *)
+			    (subdev_info.priv_data))->flash_type,
+			    FLASH_TYPE_QSPIPS, strlen(FLASH_TYPE_QSPIPS));
+			/* default is FLASH_TYPE_SPI, thus pass through. */
+		case XOCL_VSEC_FLASH_TYPE_SPI_IP:
+		case XOCL_VSEC_FLASH_TYPE_SPI_REG:
+			xocl_xdev_info(xdev,
+			    "VSEC FLASH RES Start 0x%llx, bar %d, type 0x%x",
+			    offset, bar, vtype);
 
-		ret = xocl_subdev_create(xdev, &subdev_info);
-		if (ret)
-			return ret;
+			ret = xocl_subdev_create_vsec_impl(xdev, &subdev_info,
+			    offset, bar);
+
+			if (ret)
+				return ret;
+			break;
+		case XOCL_VSEC_FLASH_TYPE_VERSAL:
+			xocl_xdev_info(xdev,
+			    "VSEC VERSAL FLASH RES Start 0x%llx, bar %d",
+			    offset, bar);
+
+			/* set devinfo to xfer versal */
+			subdev_info.id = XOCL_SUBDEV_XFER_VERSAL;
+			subdev_info.name = XOCL_XFER_VERSAL;
+			subdev_info.res[0].name = XOCL_XFER_VERSAL;
+			memcpy(((struct xocl_flash_privdata *)
+			    (subdev_info.priv_data))->flash_type,
+			    FLASH_TYPE_OSPI_VERSAL, strlen(FLASH_TYPE_OSPI_VERSAL));
+
+			ret = xocl_subdev_create_vsec_impl(xdev, &subdev_info,
+				offset, bar);
+
+			if (ret)
+				return ret;
+			break;
+		default:
+			xocl_xdev_info(xdev, "Unsupport flash type 0x%x", vtype);
+		}
 	}
 
 	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_MAILBOX, &bar, &offset, NULL);
@@ -1324,13 +1361,11 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_MAILBOX_VSEC;
 
 		xocl_xdev_info(xdev,
-			"Vendor Specific MAILBOX RES Start 0x%llx, bar %d",
+			"VSEC MAILBOX RES Start 0x%llx, bar %d",
 			 offset, bar);
-		subdev_info.res[0].start = offset;
-		subdev_info.res[0].end = offset + 0xfff;
-		subdev_info.bar_idx[0] = bar;
 
-		ret = xocl_subdev_create(xdev, &subdev_info);
+		ret = xocl_subdev_create_vsec_impl(xdev, &subdev_info,
+			offset, bar);
 		if (ret)
 			return ret;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1320,6 +1320,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			    (subdev_info.priv_data))->flash_type,
 			    FLASH_TYPE_QSPIPS, strlen(FLASH_TYPE_QSPIPS));
 			/* default is FLASH_TYPE_SPI, thus pass through. */
+			__attribute__ ((fallthrough));
 		case XOCL_VSEC_FLASH_TYPE_SPI_IP:
 		case XOCL_VSEC_FLASH_TYPE_SPI_REG:
 			xocl_xdev_info(xdev,
@@ -1353,6 +1354,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			break;
 		default:
 			xocl_xdev_info(xdev, "Unsupport flash type 0x%x", vtype);
+			break;
 		}
 	}
 


### PR DESCRIPTION
Tested on vck5000 2020.1 shell.

RCA:

xfer subdev can fail which causes OS panic. 

Solution:

2020.1_web shell has xfer resource in VSEC, reading from VSEC.

for 2019.2 shell, there is no VSEC, xfer will be loaded from static config.

for 2020.1_web shell, xfer will be loaded from VSEC config