### PR TITLE
xclbinutil: Added automated memory bank grouping support.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -32,22 +32,6 @@
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
 
-template <typename T>
-std::vector<T> as_vector(boost::property_tree::ptree const& pt, 
-                         boost::property_tree::ptree::key_type const& key)
-{
-    std::vector<T> r;
-
-    boost::property_tree::ptree::const_assoc_iterator it = pt.find(key);
-
-    if( it != pt.not_found()) {
-      for (auto& item : pt.get_child(key)) {
-        r.push_back(item.second);
-      }
-    }
-    return r;
-}
-
 std::string
 FormattedOutput::getTimeStampAsString(const axlf &_xclBinHeader) {
   return XUtil::format("%ld", _xclBinHeader.m_header.m_timeStamp);
@@ -193,13 +177,13 @@ FormattedOutput::getKernelDDRMemory(const std::string _sKernelInstanceName,
   XUtil::TRACE_PrintTree("Top", ptSections);
 
   boost::property_tree::ptree& ptMemTopology = ptSections.get_child("mem_topology");
-  std::vector<boost::property_tree::ptree> memTopology = as_vector<boost::property_tree::ptree>(ptMemTopology, "m_mem_data");
+  std::vector<boost::property_tree::ptree> memTopology = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology, "m_mem_data");
 
   boost::property_tree::ptree& ptConnectivity = ptSections.get_child("connectivity");
-  std::vector<boost::property_tree::ptree> connectivity = as_vector<boost::property_tree::ptree>(ptConnectivity, "m_connection");
+  std::vector<boost::property_tree::ptree> connectivity = XUtil::as_vector<boost::property_tree::ptree>(ptConnectivity, "m_connection");
 
   boost::property_tree::ptree& ptIPLayout = ptSections.get_child("ip_layout");
-  std::vector<boost::property_tree::ptree> ipLayout = as_vector<boost::property_tree::ptree>(ptIPLayout, "m_ip_data");
+  std::vector<boost::property_tree::ptree> ipLayout = XUtil::as_vector<boost::property_tree::ptree>(ptIPLayout, "m_ip_data");
 
   // 3) Establish the connections
   std::set<int> addedIndex;
@@ -306,9 +290,9 @@ reportXclbinInfo( std::ostream & _ostream,
     std::string sKernels;
     if (!_ptMetaData.empty()) {
       boost::property_tree::ptree &ptXclBin = _ptMetaData.get_child("xclbin");
-      std::vector<boost::property_tree::ptree> userRegions = as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
+      std::vector<boost::property_tree::ptree> userRegions = XUtil::as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
       for (auto & userRegion : userRegions) {
-        std::vector<boost::property_tree::ptree> kernels = as_vector<boost::property_tree::ptree>(userRegion,"kernels");
+        std::vector<boost::property_tree::ptree> kernels = XUtil::as_vector<boost::property_tree::ptree>(userRegion,"kernels");
         for (auto & kernel : kernels) {
            std::string sKernel = kernel.get<std::string>("name", "");
            if (sKernel.empty()) {
@@ -609,7 +593,7 @@ reportClocks( std::ostream & _ostream,
     return;
   }
 
-  std::vector<boost::property_tree::ptree> clockFreqs = as_vector<boost::property_tree::ptree>(ptClockFreqTopology,"m_clock_freq");
+  std::vector<boost::property_tree::ptree> clockFreqs = XUtil::as_vector<boost::property_tree::ptree>(ptClockFreqTopology,"m_clock_freq");
   for (unsigned int index = 0; index < clockFreqs.size(); ++index) {
     boost::property_tree::ptree &ptClockFreq = clockFreqs[index];
     std::string sName = ptClockFreq.get<std::string>("m_name");
@@ -651,7 +635,7 @@ reportMemoryConfiguration( std::ostream & _ostream,
     return;
   }
 
-  std::vector<boost::property_tree::ptree> memDatas = as_vector<boost::property_tree::ptree>(ptMemTopology,"m_mem_data");
+  std::vector<boost::property_tree::ptree> memDatas = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology,"m_mem_data");
   for (unsigned int index = 0; index < memDatas.size(); ++index) {
     boost::property_tree::ptree & ptMemData = memDatas[index];
 
@@ -700,20 +684,20 @@ reportKernels( std::ostream & _ostream,
     boost::property_tree::ptree pt;
     if (MEM_TOPOLOGY == pSection->getSectionKind() ) {
       pSection->getPayload(pt);
-      memTopology = as_vector<boost::property_tree::ptree>(pt.get_child("mem_topology"), "m_mem_data");
+      memTopology = XUtil::as_vector<boost::property_tree::ptree>(pt.get_child("mem_topology"), "m_mem_data");
     } else if (CONNECTIVITY == pSection->getSectionKind() ) {
       pSection->getPayload(pt);
-      connectivity = as_vector<boost::property_tree::ptree>(pt.get_child("connectivity"), "m_connection");
+      connectivity = XUtil::as_vector<boost::property_tree::ptree>(pt.get_child("connectivity"), "m_connection");
     } else if (IP_LAYOUT == pSection->getSectionKind() ) {
       pSection->getPayload(pt);
-      ipLayout = as_vector<boost::property_tree::ptree>(pt.get_child("ip_layout"), "m_ip_data");
+      ipLayout = XUtil::as_vector<boost::property_tree::ptree>(pt.get_child("ip_layout"), "m_ip_data");
     }
   }
 
   boost::property_tree::ptree &ptXclBin = _ptMetaData.get_child("xclbin");
-  std::vector<boost::property_tree::ptree> userRegions = as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
+  std::vector<boost::property_tree::ptree> userRegions = XUtil::as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
   for (auto & userRegion : userRegions) {
-    std::vector<boost::property_tree::ptree> kernels = as_vector<boost::property_tree::ptree>(userRegion,"kernels");
+    std::vector<boost::property_tree::ptree> kernels = XUtil::as_vector<boost::property_tree::ptree>(userRegion,"kernels");
     if (kernels.size() == 0) 
       _ostream << "Kernel(s): <None Found>" << std::endl;
 
@@ -723,9 +707,9 @@ reportKernels( std::ostream & _ostream,
       std::string sKernel = ptKernel.get<std::string>("name");
       _ostream << XUtil::format("%s %s", "Kernel:", sKernel.c_str()).c_str() << std::endl;
 
-      std::vector<boost::property_tree::ptree> ports = as_vector<boost::property_tree::ptree>(ptKernel,"ports");
-      std::vector<boost::property_tree::ptree> arguments = as_vector<boost::property_tree::ptree>(ptKernel,"arguments");
-      std::vector<boost::property_tree::ptree> instances = as_vector<boost::property_tree::ptree>(ptKernel,"instances");
+      std::vector<boost::property_tree::ptree> ports = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"ports");
+      std::vector<boost::property_tree::ptree> arguments = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"arguments");
+      std::vector<boost::property_tree::ptree> instances = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"instances");
 
       _ostream << std::endl;
 
@@ -944,7 +928,7 @@ reportKeyValuePairs( std::ostream & _ostream,
     if (pSection->getSectionKind() == KEYVALUE_METADATA) {
       boost::property_tree::ptree pt;
       pSection->getPayload(pt);
-      keyValues = as_vector<boost::property_tree::ptree>(pt.get_child("keyvalue_metadata"), "key_values");
+      keyValues = XUtil::as_vector<boost::property_tree::ptree>(pt.get_child("keyvalue_metadata"), "key_values");
       break;
     }
   }

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -36,17 +36,6 @@ namespace XUtil = XclBinUtilities;
 static const std::string MIRROR_DATA_START = "XCLBIN_MIRROR_DATA_START";
 static const std::string MIRROR_DATA_END = "XCLBIN_MIRROR_DATA_END";
 
-template <typename T>
-std::vector<T> as_vector(boost::property_tree::ptree const& pt, 
-                         boost::property_tree::ptree::key_type const& key)
-{
-    std::vector<T> r;
-    for (auto& item : pt.get_child(key))
-        r.push_back(item.second);
-    return r;
-}
-
-
 static
 bool getVersionMajorMinorPath(const char * _pVersion, uint8_t & _major, uint8_t & _minor, uint16_t & _patch)
 {
@@ -753,7 +742,7 @@ XclBin::updateHeaderFromSection(Section *_pSection)
     boost::property_tree::ptree ptDsa;
     ptDsa = pt.get_child("build_metadata.dsa");
 
-    std::vector<boost::property_tree::ptree> feature_roms = as_vector<boost::property_tree::ptree>(ptDsa, "feature_roms");
+    std::vector<boost::property_tree::ptree> feature_roms = XUtil::as_vector<boost::property_tree::ptree>(ptDsa, "feature_roms");
 
     boost::property_tree::ptree featureRom;
     if (!feature_roms.empty()) {
@@ -1434,7 +1423,7 @@ XclBin::setKeyValue(const std::string & _keyValue)
 
     XUtil::TRACE_PrintTree("KEYVALUE:", ptKeyValueMetadata);
     boost::property_tree::ptree ptKeyValues = ptKeyValueMetadata.get_child("keyvalue_metadata");
-    std::vector<boost::property_tree::ptree> keyValues = as_vector<boost::property_tree::ptree>(ptKeyValues, "key_values");
+    std::vector<boost::property_tree::ptree> keyValues = XUtil::as_vector<boost::property_tree::ptree>(ptKeyValues, "key_values");
 
     // Update existing key
     bool bKeyFound = false;
@@ -1494,7 +1483,7 @@ XclBin::removeKey(const std::string & _sKey)
 
    XUtil::TRACE_PrintTree("KEYVALUE:", ptKeyValueMetadata);
    boost::property_tree::ptree ptKeyValues = ptKeyValueMetadata.get_child("keyvalue_metadata");
-   std::vector<boost::property_tree::ptree> keyValues = as_vector<boost::property_tree::ptree>(ptKeyValues, "key_values");
+   std::vector<boost::property_tree::ptree> keyValues = XUtil::as_vector<boost::property_tree::ptree>(ptKeyValues, "key_values");
 
    // Update existing key
    bool bKeyFound = false;

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -54,6 +54,7 @@ class XclBin {
   void dumpSections(ParameterSectionData &_PSD);
   void setKeyValue(const std::string & _keyValue);
   void removeKey(const std::string & _keyValue);
+  void addSection(Section* _pSection);
 
   public:
     // Helper method to take given encoded keyValue and break it down to its individual values (e.g., domain, key, and value)
@@ -75,7 +76,6 @@ class XclBin {
 
   void addHeaderMirrorData(boost::property_tree::ptree& _pt_header);
 
-  void addSection(Section* _pSection);
   void addSubSection(ParameterSectionData &_PSD);
   void dumpSubSection(ParameterSectionData &_PSD);
 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -25,9 +25,11 @@
 #include <fstream>
 #include <boost/property_tree/ptree.hpp>
 
-
 #include <iostream>
 #include <stdint.h>
+#include <vector>
+
+class XclBin;
 
 // Custom exception with payloads
 typedef enum {
@@ -35,9 +37,8 @@ typedef enum {
   XET_MISSING_SECTION = 100, // Section is missing
 } XclBinExceptionType;
 
-
 namespace XclBinUtilities {
-//
+
 template<typename ... Args>
 
 std::string format(const std::string& format, Args ... args) {
@@ -47,6 +48,23 @@ std::string format(const std::string& format, Args ... args) {
 
   return std::string(buf.get(), buf.get() + size);
 }
+
+template <typename T>
+std::vector<T> as_vector(boost::property_tree::ptree const& pt, 
+                         boost::property_tree::ptree::key_type const& key)
+{
+    std::vector<T> r;
+
+    boost::property_tree::ptree::const_assoc_iterator it = pt.find(key);
+
+    if( it != pt.not_found()) {
+      for (auto& item : pt.get_child(key)) {
+        r.push_back(item.second);
+      }
+    }
+    return r;
+}
+
 
 class XclBinUtilException : public std::runtime_error {
   private:
@@ -130,6 +148,8 @@ void printKinds();
 std::string getUUIDAsString( const unsigned char (&_uuid)[16] );
 
 void write_htonl(std::ostream & _buf, uint32_t _word32);
+
+void createMemoryBankGrouping(XclBin & xclbin);
 };
 
 #endif


### PR DESCRIPTION
Added support in xclbinutil to create the GROUP_TOPOLOGY and GROUP_CONNECTIVITY from the MEM_TOPOLOGY and CONNECTIVITY sections if the GROUP sections don't exist.

Note: To disable this automation, the --skip-bank-grouping option can be used.

**Work Done**
+ Created the algorithm that determines which memories can be grouped together for a given connectivity entry.
+ Added an option to "disable" this automation (e.g., --skip-bank-grouping option)
+ Refactored the "duplicate" as_vector templates to one common template.
+ Added various DRCs to validate that the MEM_TOPOLOGY and CONNECTIVITY sections are correct prior to operating on them.
+ Updated various copyright dates
