### PR TITLE
xclbinutil: Enhanced the PARTITION_METADATA to support 'interrupt_alias' JSON syntax

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -52,6 +52,7 @@ const FDTProperty::PropertyNameFormat SectionPartitionMetadata::m_propertyNameFo
   { "firmware_version_major", FDTProperty::DF_u32 },
   { "firmware_version_minor", FDTProperty::DF_u32 },
   { "firmware_version_revision", FDTProperty::DF_u32 },
+  { "interrupt_alias", FDTProperty::DF_asz },
   { "__INFO", FDTProperty::DF_sz }
 };
 
@@ -331,6 +332,10 @@ SchemaTransformToDTC_addressable_endpoint( const std::string _sEndPointName,
 
   // -- Get the 'pcie_base_address_register' if it exists
   SchemaTransform_nameValue("pcie_base_address_register", "pcie_bar_mapping", false  /*required*/, _ptOriginal, _ptTransformed);
+
+  // -- Get the 'interrupt_alias' if it exists
+  if (_ptOriginal.find("interrupt_alias") != _ptOriginal.not_found()) 
+      _ptTransformed.add_child("interrupt_alias", _ptOriginal.get_child("interrupt_alias"));
 }
 
 /**
@@ -480,6 +485,10 @@ SchemaTransformToPM_addressable_endpoint( const std::string _sEndPointName,
 
   // -- Get the 'pcie_base_address_register' if it exists
   SchemaTransform_nameValue("pcie_bar_mapping", "pcie_base_address_register", false  /*required*/, _ptOriginal, _ptTransformed);
+
+  // -- Get the 'interrupt_alias' if it exists
+  if (_ptOriginal.find("interrupt_alias") != _ptOriginal.not_found()) 
+      _ptTransformed.add_child("interrupt_alias", _ptOriginal.get_child("interrupt_alias"));
 }
 
 /**


### PR DESCRIPTION
xclbinutil's PARTITION_METADATA parser has been updated to support the 'interrupt_alias" JSON syntax.  For example:
```
        "addressable_endpoints": {
            "ep_blp_rom_00": {
                "offset": "0x0000000001e03000",
                "range": "0x0000000000001000",
                "pcie_physical_function": "0x0",
                "register_abstraction_name": "xilinx.com:reg_abs:axi_intc:1.0",
                "pcie_base_address_register": "0x0",
                "interrupt_alias": [
                    "interrupt_cmc_00",
                    "interrupt_cmc_01",
                    "interrupt_cmc_02",
                    "interrupt_cmc_03"
                ]
            }
```
This support includes:
1. Recognizing the JSON syntax and converting it to a DTB format.
2. Converting the DTB format back to JSON.