### PR TITLE
XDP: Initial implementation of power profiling as a HAL level plugin.

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -160,6 +160,13 @@ get_power_profile()
   return value;
 }
 
+inline unsigned int
+get_power_profile_interval_ms()
+{
+  static unsigned int value = detail::get_uint_value("Debug.power_profile_interval_ms", 20) ;
+  return value ;
+}
+
 inline std::string
 get_stall_trace()
 {

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -156,7 +156,7 @@ get_data_transfer_trace()
 inline bool
 get_power_profile()
 {
-  static bool value = get_profile() && detail::get_bool_value("Debug.power_profile",false);
+  static bool value = detail::get_bool_value("Debug.power_profile",false);
   return value;
 }
 

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
@@ -1,5 +1,6 @@
 #include "plugin/xdp/hal_profile.h"
 #include "plugin/xdp/hal_device_offload.h"
+#include "plugin/xdp/power_profile.h"
 #include "core/common/module_loader.h"
 #include "core/common/utils.h"
 #include "core/common/config_reader.h"
@@ -23,7 +24,8 @@ CallLogger::CallLogger(uint64_t id)
 {
   if (hal_plugins_loaded) return ;
   hal_plugins_loaded = true ;
-  
+
+  // This hook is responsible for loading all of the HAL level plugins
   if (xrt_core::config::get_xrt_profile())
   {
     load_xdp_plugin_library(nullptr) ;
@@ -31,6 +33,10 @@ CallLogger::CallLogger(uint64_t id)
   if (xrt_core::config::get_data_transfer_trace() != "off")
   {
     xdphaldeviceoffload::load_xdp_hal_device_offload() ;
+  }
+  if (xrt_core::config::get_power_profile())
+  {
+    xdppowerprofile::load_xdp_power_plugin() ;
   }
 }
 

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/power_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/power_profile.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "plugin/xdp/power_profile.h"
+#include "core/common/module_loader.h"
+
+namespace xdppowerprofile {
+
+  void load_xdp_power_plugin()
+  {
+    static xrt_core::module_loader xdp_power_loader("xdp_power_plugin",
+						    register_power_callbacks,
+						    warning_power_callbacks) ;
+  }
+
+  void register_power_callbacks(void* /*handle*/)
+  {
+    // No callbacks in power profiling.  The plugin is always active
+  }
+
+  void warning_power_callbacks()
+  {
+    // No warnings for power profiling
+  }
+
+} // end namespace xdppowerprofile

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/power_profile.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/power_profile.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef POWER_PROFILE_DOT_H
+#define POWER_PROFILE_DOT_H
+
+namespace xdppowerprofile {
+
+  void load_xdp_power_plugin() ;
+  void register_power_callbacks(void* handle) ;
+  void warning_power_callbacks() ;
+
+} // end namespace xdppowerprofile
+
+#endif

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -44,6 +44,8 @@ set(XRT_XDP_PROFILE_DEVICE_OFFLOAD_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profi
 set(XRT_XDP_PROFILE_DEVICE_OFFLOAD_WRITER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/writer/device_trace")
 set(XRT_XDP_PROFILE_OPENCL_DEVICE_OFFLOAD_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/device_offload/opencl")
 set(XRT_XDP_PROFILE_HAL_DEVICE_OFFLOAD_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/device_offload/hal")
+set(XRT_XDP_POWER_PROFILE_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/power")
+set(XRT_XDP_POWER_PROFILE_WRITER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/writer/power")
 
 # Files for the new xdp core
 set(XRT_XDP_PROFILE_BASE_PLUGIN_DIR    "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/vp_base")
@@ -177,6 +179,13 @@ file(GLOB XRT_XDP_HAL_PROFILE_DEVICE_OFFLOAD_PLUGIN_FILES
   "${XRT_XDP_PROFILE_HAL_DEVICE_DIR}/*.cpp"
   )
 
+file(GLOB XRT_XDP_POWER_PROFILE_PLUGIN_FILES
+  "${XRT_XDP_POWER_PROFILE_PLUGIN_DIR}/*.h"
+  "${XRT_XDP_POWER_PROFILE_PLUGIN_DIR}/*.cpp"
+  "${XRT_XDP_POWER_PROFILE_WRITER_DIR}/*.h"
+  "${XRT_XDP_POWER_PROFILE_WRITER_DIR}/*.cpp"
+  )
+
 set(XRT_XDP_ALL_SRC
   ${XRT_XDP_PROFILE_FILES}
   ${XRT_XDP_FILES}
@@ -198,6 +207,7 @@ add_library(xdp_lop_plugin MODULE ${XRT_XDP_PROFILE_LOP_PLUGIN_FILES})
 add_library(xdp_user_plugin MODULE ${XRT_XDP_PROFILE_USER_PLUGIN_FILES})
 add_library(xdp_device_offload_plugin MODULE ${XRT_XDP_OPENCL_PROFILE_DEVICE_OFFLOAD_PLUGIN_FILES})
 add_library(xdp_hal_device_offload_plugin MODULE ${XRT_XDP_HAL_PROFILE_DEVICE_OFFLOAD_PLUGIN_FILES})
+add_library(xdp_power_plugin MODULE ${XRT_XDP_POWER_PROFILE_PLUGIN_FILES})
 
 add_dependencies(xdp xrt_coreutil)
 add_dependencies(oclxdp xilinxopencl xdp)
@@ -210,6 +220,7 @@ add_dependencies(xdp_lop_plugin xdp_core)
 add_dependencies(xdp_user_plugin xdp_core)
 add_dependencies(xdp_device_offload_plugin xdp_core xilinxopencl)
 add_dependencies(xdp_hal_device_offload_plugin xdp_core xrt_core)
+add_dependencies(xdp_power_plugin xdp_core xrt_core)
 
 target_link_libraries(xdp xrt_coreutil)
 target_link_libraries(oclxdp xilinxopencl xdp)
@@ -222,6 +233,7 @@ target_link_libraries(xdp_lop_plugin xdp_core)
 target_link_libraries(xdp_user_plugin xdp_core)
 target_link_libraries(xdp_device_offload_plugin xdp_core xilinxopencl)
 target_link_libraries(xdp_hal_device_offload_plugin xdp_core xrt_core)
+target_link_libraries(xdp_power_plugin xdp_core xrt_core)
 
 # ====== Linux Specifics =======
 
@@ -236,10 +248,11 @@ set_target_properties(xdp_lop_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SO
 set_target_properties(xdp_user_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 set_target_properties(xdp_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 set_target_properties(xdp_hal_device_offload_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+set_target_properties(xdp_power_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 install (TARGETS xdp oclxdp xdp_core LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR})
 
-install (TARGETS xdp_hal_plugin xdp_hal_api_interface_plugin xdp_debug_plugin xdp_appdebug_plugin xdp_lop_plugin xdp_user_plugin xdp_device_offload_plugin xdp_hal_device_offload_plugin LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR}/xrt/module)
+install (TARGETS xdp_hal_plugin xdp_hal_api_interface_plugin xdp_debug_plugin xdp_appdebug_plugin xdp_lop_plugin xdp_user_plugin xdp_device_offload_plugin xdp_hal_device_offload_plugin xdp_power_plugin LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR}/xrt/module)
 
 install (FILES "${XRT_XDP_PROFILE_XMA_PLUGIN_DIR}/xma_profile.h" DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -171,4 +171,26 @@ namespace xdp {
       fout << s.second << "," << s.first.c_str() << std::endl ;
     }
   }
+
+  void VPDynamicDatabase::addPowerSample(uint64_t deviceId, double timestamp,
+					 const std::vector<int>& values)
+  {
+    std::lock_guard<std::mutex> lock(dbLock) ;
+
+    if (powerSamples.find(deviceId) == powerSamples.end())
+    {
+      std::vector<CounterSample> blank ;
+      powerSamples[deviceId] = blank ;
+    }
+
+    powerSamples[deviceId].push_back(std::make_pair(timestamp, values)) ;
+  }
+
+  std::vector<VPDynamicDatabase::CounterSample>
+  VPDynamicDatabase::getPowerSamples(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(dbLock) ;
+
+    return powerSamples[deviceId] ;
+  }
 }

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -173,7 +173,7 @@ namespace xdp {
   }
 
   void VPDynamicDatabase::addPowerSample(uint64_t deviceId, double timestamp,
-					 const std::vector<int>& values)
+					 const std::vector<uint64_t>& values)
   {
     std::lock_guard<std::mutex> lock(dbLock) ;
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -43,7 +43,7 @@ namespace xdp {
   public:
     // Define a public typedef for all plugins that get information
     //  from counters
-    typedef std::pair<double, std::vector<int>> CounterSample ;
+    typedef std::pair<double, std::vector<uint64_t>> CounterSample ;
 
   private:
     // For host events, we are guaranteed that all of the timestamps
@@ -117,7 +117,7 @@ namespace xdp {
 
     // Functions that are used by counter-based plugins
     XDP_EXPORT void addPowerSample(uint64_t deviceId, double timestamp,
-				   const std::vector<int>& values) ;
+				   const std::vector<uint64_t>& values) ;
     XDP_EXPORT std::vector<CounterSample> getPowerSamples(uint64_t deviceId) ;
   } ;
   

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -40,6 +40,11 @@ namespace xdp {
   private:
     VPDatabase* db ;
 
+  public:
+    // Define a public typedef for all plugins that get information
+    //  from counters
+    typedef std::pair<double, std::vector<int>> CounterSample ;
+
   private:
     // For host events, we are guaranteed that all of the timestamps
     //  will come in sequential order.  For this, we can use 
@@ -51,6 +56,10 @@ namespace xdp {
     //  hardware might shuffle the order of events we have to make sure
     //  that this set of events is ordered based on timestamp.
     std::map<uint64_t, std::multimap<double, VTFEvent*>> deviceEvents;
+
+    // For all plugins that read counters, we will store that information
+    //  here.
+    std::map<uint64_t, std::vector<CounterSample>> powerSamples ;
 
     // A unique event id for every event added to the database.
     //  It starts with 1 so we can use 0 as an indicator of NULL
@@ -105,6 +114,11 @@ namespace xdp {
 
     // Functions that dump large portions of the database
     XDP_EXPORT void dumpStringTable(std::ofstream& fout) ;
+
+    // Functions that are used by counter-based plugins
+    XDP_EXPORT void addPowerSample(uint64_t deviceId, double timestamp,
+				   const std::vector<int>& values) ;
+    XDP_EXPORT std::vector<CounterSample> getPowerSamples(uint64_t deviceId) ;
   } ;
   
 }

--- a/src/runtime_src/xdp/profile/plugin/ocl/ocl_power_profile.cpp
+++ b/src/runtime_src/xdp/profile/plugin/ocl/ocl_power_profile.cpp
@@ -23,6 +23,7 @@ OclPowerProfile::OclPowerProfile(xrt::device* xrt_device,
                                 std::string unique_name) 
                                 : status(PowerProfileStatus::IDLE) {
     power_profile_en = xrt::config::get_power_profile();
+    power_profile_interval_ms = xrt::config::get_power_profile_interval_ms();
     target_device = xrt_device;
     target_xocl_plugin = xocl_plugin;
     target_unique_name = unique_name;
@@ -109,7 +110,7 @@ void OclPowerProfile::poll_power() {
         }
 
         // TODO: step 3 pause the thread for certain time
-        std::this_thread::sleep_for (std::chrono::milliseconds(20));
+        std::this_thread::sleep_for (std::chrono::milliseconds(power_profile_interval_ms));
     }
 }
 

--- a/src/runtime_src/xdp/profile/plugin/ocl/ocl_power_profile.h
+++ b/src/runtime_src/xdp/profile/plugin/ocl/ocl_power_profile.h
@@ -57,6 +57,7 @@ private:
     PowerProfileStatus status;
     std::thread polling_thread;
     bool power_profile_en;
+    unsigned int power_profile_interval_ms ;
     xrt::device* target_device;
     std::shared_ptr<XoclPlugin> target_xocl_plugin;
     std::vector<PowerStat> power_trace;

--- a/src/runtime_src/xdp/profile/plugin/power/power_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_cb.cpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "xdp/profile/plugin/power/power_plugin.h"
+
+namespace xdp {
+
+  // The power profiling plugin doesn't have any callbacks.  Instead, it
+  //  only has a single static instance of the plugin object
+
+  static PowerProfilingPlugin powerPluginInstance ;
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_SOURCE
+
+#include "xdp/profile/plugin/power/power_plugin.h"
+#include "xdp/profile/writer/power/power_writer.h"
+#include "core/common/system.h"
+#include "core/common/time.h"
+#include "core/include/experimental/xrt-next.h"
+
+namespace xdp {
+
+  const char* PowerProfilingPlugin::powerFiles[] = 
+    {
+      "xmc_12v_aux_curr",
+      "xmc_12v_aux_vol",
+      "xmc_12v_pex_curr",
+      "xmc_12v_pex_vol",
+      "xmc_vccint_curr",
+      "xmc_vccint_vol",
+      "xmc_3v3_pex_curr",
+      "xmc_3v3_pex_vol",
+      "xmc_cage_temp0",
+      "xmc_cage_temp1",
+      "xmc_cage_temp2",
+      "xmc_cage_temp3",
+      "xmc_dimm_temp0",
+      "xmc_dimm_temp1",
+      "xmc_dimm_temp2",
+      "xmc_dimm_temp3",
+      "xmc_fan_temp",
+      "xmc_fpga_temp",
+      "xmc_hbm_temp",
+      "xmc_se98_temp0",
+      "xmc_se98_temp1",
+      "xmc_se98_temp2",
+      "xmc_vccint_temp",
+      "xmc_fan_rpm"      
+    } ;
+
+  PowerProfilingPlugin::PowerProfilingPlugin() : XDPPlugin(), keepPolling(true)
+  {
+    db->registerPlugin(this) ;
+   
+    // Just like HAL level device profiling, go through the devices 
+    //  that exist in order to find all of the sysfs paths
+    uint64_t index = 0 ;
+    void* handle = xclOpen(index, "/dev/null", XCL_INFO) ;
+    while (handle != nullptr)
+    {
+      // For each device, keep track of the paths to the sysfs files
+      std::vector<std::string> paths ;
+      for (auto f : powerFiles)
+      {
+	char sysfsPath[512] ;
+	xclGetSysfsPath(handle, "xmc", f, sysfsPath, 512) ;
+	paths.push_back(sysfsPath) ;
+      }
+      filePaths.push_back(paths) ;
+
+      // Determine the name of the device
+      struct xclDeviceInfo2 info ;
+      xclGetDeviceInfo2(handle, &info) ;
+      std::string deviceName = std::string(info.mName) ;
+      std::string outputFile = "power_profile_" + deviceName + ".csv" ; 
+
+      writers.push_back(new PowerProfilingWriter(outputFile.c_str(),
+						 deviceName.c_str(),
+					         index)) ;
+      (db->getStaticInfo()).addOpenedFile(outputFile.c_str(), 
+					  "XRT_POWER_PROFILE") ;
+
+      // Move on to the next device
+      xclClose(handle) ;
+      ++index ;
+      handle = xclOpen(index, "/dev/null", XCL_INFO) ;
+    }
+
+    // Start the power profiling thread
+    pollingThread = std::thread(&PowerProfilingPlugin::pollPower, this) ;
+  }
+
+  PowerProfilingPlugin::~PowerProfilingPlugin()
+  {
+    // Stop the polling thread
+    keepPolling = false ;
+    pollingThread.join() ;
+
+    if (VPDatabase::alive())
+    {
+      for (auto w : writers)
+      {
+	w->write(false) ;
+      }
+
+      db->unregisterPlugin(this) ;
+    }
+  }
+
+  void PowerProfilingPlugin::pollPower()
+  {
+    while(keepPolling)
+    {
+      // Get timestamp in milliseconds
+      double timestamp = xrt_core::time_ns() / 1.0e6 ;
+      uint64_t index = 0 ;
+      for (auto device : filePaths)
+      {
+	std::vector<int> values ;
+	for (auto file : device)
+	{
+	  std::ifstream fs(file) ;
+	  std::string data ;
+	  std::getline(fs, data) ;
+	  int dp = data.empty() ? 0 : std::stoi(data) ;
+	  values.push_back(dp) ;
+	  fs.close() ;
+	}
+	(db->getDynamicInfo()).addPowerSample(index, timestamp, values) ;
+	++index ;	
+      }
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(20)) ;
+    }
+  }
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -124,13 +124,22 @@ namespace xdp {
       uint64_t index = 0 ;
       for (auto device : filePaths)
       {
-	std::vector<int> values ;
+	std::vector<uint64_t> values ;
 	for (auto file : device)
 	{
 	  std::ifstream fs(file) ;
+	  if (!fs)
+	  {
+	    // When we tried to get the path to this file, we got a bad
+	    //  result (like empty string).  So all devices are aligned and
+	    //  have the same amount of information we'll just record this
+	    //  data element as 0.
+	    values.push_back(0) ;
+	    continue ;
+	  }
 	  std::string data ;
 	  std::getline(fs, data) ;
-	  int dp = data.empty() ? 0 : std::stoi(data) ;
+	  uint64_t dp = data.empty() ? 0 : std::stoul(data) ;
 	  values.push_back(dp) ;
 	  fs.close() ;
 	}

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -20,6 +20,7 @@
 #include "xdp/profile/writer/power/power_writer.h"
 #include "core/common/system.h"
 #include "core/common/time.h"
+#include "core/common/config_reader.h"
 #include "core/include/experimental/xrt-next.h"
 
 namespace xdp {
@@ -52,9 +53,12 @@ namespace xdp {
       "xmc_fan_rpm"      
     } ;
 
-  PowerProfilingPlugin::PowerProfilingPlugin() : XDPPlugin(), keepPolling(true)
+  PowerProfilingPlugin::PowerProfilingPlugin() :
+    XDPPlugin(), keepPolling(true), pollingInterval(20)
   {
     db->registerPlugin(this) ;
+
+    pollingInterval = xrt_core::config::get_power_profile_interval_ms() ;
    
     // Just like HAL level device profiling, go through the devices 
     //  that exist in order to find all of the sysfs paths
@@ -134,7 +138,7 @@ namespace xdp {
 	++index ;	
       }
 
-      std::this_thread::sleep_for(std::chrono::milliseconds(20)) ;
+      std::this_thread::sleep_for(std::chrono::milliseconds(pollingInterval)) ;
     }
   }
 

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef POWER_PROFILING_DOT_H
+#define POWER_PROFILING_DOT_H
+
+#include <vector>
+#include <string>
+#include <thread>
+
+#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+#include "xdp/config.h"
+
+namespace xdp {
+
+  class PowerProfilingPlugin : public XDPPlugin
+  {
+  private:
+    // These are the files that will be opened and read
+    static const char* powerFiles[] ;
+
+  private:
+    std::vector<std::vector<std::string>> filePaths ;
+
+    // Power profiling requires its own thread
+    bool keepPolling ;
+    std::thread pollingThread ;
+    void pollPower() ;
+  public:
+    PowerProfilingPlugin() ;
+    ~PowerProfilingPlugin() ;
+
+    XDP_EXPORT void addDevice(void* handle) ;
+  } ;
+
+} // end namespace xdp
+
+#endif

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.h
@@ -38,6 +38,7 @@ namespace xdp {
     // Power profiling requires its own thread
     bool keepPolling ;
     std::thread pollingThread ;
+    unsigned int pollingInterval ;
     void pollPower() ;
   public:
     PowerProfilingPlugin() ;

--- a/src/runtime_src/xdp/profile/writer/power/power_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/power/power_writer.cpp
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <vector>
+
+#include "xdp/profile/writer/power/power_writer.h"
+#include "xdp/profile/database/database.h"
+
+namespace xdp {
+
+  PowerProfilingWriter::PowerProfilingWriter(const char* filename,
+					     const char* d,
+					     uint64_t index) :
+    VPWriter(filename), deviceName(d), deviceIndex(index)
+  {
+  }
+
+  PowerProfilingWriter::~PowerProfilingWriter()
+  {    
+  }
+
+  void PowerProfilingWriter::write(bool openNewFile)
+  {
+    // Write header
+    fout << "Target device: " << deviceName << std::endl ;
+    fout << "timestamp"    << ","
+	 << "12v_aux_curr" << ","
+	 << "12v_aux_vol"  << ","
+	 << "12v_pex_curr" << ","
+	 << "12v_pex_vol"  << ","
+	 << "vccint_curr"  << ","
+	 << "vccint_vol"   << ","
+	 << "3v3_pex_curr" << ","
+	 << "3v3_pex_vol"  << ","
+	 << "cage_temp0"   << ","
+	 << "cage_temp1"   << ","
+	 << "cage_temp2"   << ","
+	 << "cage_temp3"   << ","
+	 << "dimm_temp0"   << ","
+	 << "dimm_temp1"   << ","
+	 << "dimm_temp2"   << ","
+	 << "dimm_temp3"   << ","
+	 << "fan_temp"     << ","
+	 << "fpga_temp"    << ","
+	 << "hbm_temp"     << ","
+	 << "se98_temp0"   << ","
+	 << "se98_temp1"   << ","
+	 << "se98_temp2"   << ","
+	 << "vccint_temp"  << ","
+	 << "fan_rpm"
+	 << std::endl;
+
+    // Write all of the data elements
+    std::vector<VPDynamicDatabase::CounterSample> samples = 
+      (db->getDynamicInfo()).getPowerSamples(deviceIndex) ;
+
+    for (auto sample : samples)
+    {
+      fout << sample.first << "," ; // Timestamp
+      for (auto value : sample.second)
+      {
+	fout << value << "," ;
+      }
+      fout << std::endl ;
+    }
+  }
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/power/power_writer.h
+++ b/src/runtime_src/xdp/profile/writer/power/power_writer.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef POWER_WRITER_DOT_H
+#define POWER_WRITER_DOT_H
+
+#include <string>
+
+#include "xdp/profile/writer/vp_base/vp_writer.h"
+
+namespace xdp {
+
+  class PowerProfilingWriter : public VPWriter
+  {
+  private:
+    std::string deviceName ;
+    uint64_t deviceIndex ;
+  public:
+    PowerProfilingWriter(const char* filename, const char* d, uint64_t index) ;
+    ~PowerProfilingWriter() ;
+
+    virtual void write(bool openNewFile) ;
+  } ;
+
+} // end namespace xdp
+
+#endif


### PR DESCRIPTION
This loading of this plugin module is still protected by the compile time guard, so by default there should be no change to any current applications.  This check-in does not remove the current OpenCL level power profiling.  When HAL level profiling is enabled, the OpenCL level power profiling should be removed in the same check-in.