### PR TITLE
XRT-647 Add interrupt controller sub-device

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -224,6 +224,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/subdev/cu.c
   xocl/subdev/p2p.c
   xocl/subdev/pmc.c
+  xocl/subdev/intc.c
   xocl/Makefile
   )
 

--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -11,14 +11,14 @@
 
 extern int kds_echo;
 
-static int cu_hls_get_credit(void *core)
+static int cu_hls_alloc_credit(void *core)
 {
 	struct xrt_cu_hls *cu_hls = core;
 
 	return (cu_hls->credits) ? cu_hls->credits-- : 0;
 }
 
-static void cu_hls_put_credit(void *core, u32 count)
+static void cu_hls_free_credit(void *core, u32 count)
 {
 	struct xrt_cu_hls *cu_hls = core;
 
@@ -27,11 +27,11 @@ static void cu_hls_put_credit(void *core, u32 count)
 		cu_hls->credits = cu_hls->max_credits;
 }
 
-static int cu_hls_is_zero_credit(void *core)
+static int cu_hls_peek_credit(void *core)
 {
 	struct xrt_cu_hls *cu_hls = core;
 
-	return (cu_hls->credits)? 0 : 1;
+	return cu_hls->credits;
 }
 
 static void cu_hls_configure(void *core, u32 *data, size_t sz, int type)
@@ -123,9 +123,9 @@ out:
 }
 
 static struct xcu_funcs xrt_cu_hls_funcs = {
-	.get_credit	= cu_hls_get_credit,
-	.put_credit	= cu_hls_put_credit,
-	.is_zero_credit	= cu_hls_is_zero_credit,
+	.alloc_credit	= cu_hls_alloc_credit,
+	.free_credit	= cu_hls_free_credit,
+	.peek_credit	= cu_hls_peek_credit,
 	.configure	= cu_hls_configure,
 	.start		= cu_hls_start,
 	.check		= cu_hls_check,

--- a/src/runtime_src/core/common/drv/cu_plram.c
+++ b/src/runtime_src/core/common/drv/cu_plram.c
@@ -11,14 +11,14 @@
 
 extern int kds_echo;
 
-static int cu_plram_get_credit(void *core)
+static int cu_plram_alloc_credit(void *core)
 {
 	struct xrt_cu_plram *cu_plram = core;
 
 	return (cu_plram->credits) ? cu_plram->credits-- : 0;
 }
 
-static void cu_plram_put_credit(void *core, u32 count)
+static void cu_plram_free_credit(void *core, u32 count)
 {
 	struct xrt_cu_plram *cu_plram = core;
 
@@ -27,11 +27,11 @@ static void cu_plram_put_credit(void *core, u32 count)
 		cu_plram->credits = cu_plram->max_credits;
 }
 
-static int cu_plram_is_zero_credit(void *core)
+static int cu_plram_peek_credit(void *core)
 {
 	struct xrt_cu_plram *cu_plram = core;
 
-	return (cu_plram->credits)? 0 : 1;
+	return cu_plram->credits;
 }
 
 static void cu_plram_configure(void *core, u32 *data, size_t sz, int type)
@@ -81,9 +81,9 @@ out:
 }
 
 static struct xcu_funcs xrt_cu_plram_funcs = {
-	.get_credit	= cu_plram_get_credit,
-	.put_credit	= cu_plram_put_credit,
-	.is_zero_credit = cu_plram_is_zero_credit,
+	.alloc_credit	= cu_plram_alloc_credit,
+	.free_credit	= cu_plram_free_credit,
+	.peek_credit	= cu_plram_peek_credit,
 	.configure	= cu_plram_configure,
 	.start		= cu_plram_start,
 	.check		= cu_plram_check,

--- a/src/runtime_src/core/common/drv/cu_plram.c
+++ b/src/runtime_src/core/common/drv/cu_plram.c
@@ -9,7 +9,7 @@
 
 #include "xrt_cu.h"
 
-#define ECHO 0
+extern int kds_echo;
 
 static int cu_plram_get_credit(void *core)
 {
@@ -27,28 +27,33 @@ static void cu_plram_put_credit(void *core, u32 count)
 		cu_plram->credits = cu_plram->max_credits;
 }
 
+static int cu_plram_is_zero_credit(void *core)
+{
+	struct xrt_cu_plram *cu_plram = core;
+
+	return (cu_plram->credits)? 0 : 1;
+}
+
 static void cu_plram_configure(void *core, u32 *data, size_t sz, int type)
 {
-#if ECHO
-	return;
-#else
 	struct xrt_cu_plram *cu_plram = core;
+
+	if (kds_echo)
+		return;
 
 	/* TODO: Configure in specific slot */
 	memcpy(cu_plram->plram, data, sz);
-#endif
 }
 
 static void cu_plram_start(void *core)
 {
-#if ECHO
-	return;
-#else
 	struct xrt_cu_plram *cu_plram = core;
+
+	if (kds_echo)
+		return;
 
 	/* TODO: Start CU in specific slot */
 	iowrite32(0x0, cu_plram->vaddr + 0x10);
-#endif
 }
 
 static void cu_plram_check(void *core, struct xcu_status *status)
@@ -56,9 +61,11 @@ static void cu_plram_check(void *core, struct xcu_status *status)
 	struct xrt_cu_plram *cu_plram = core;
 	u32 done_reg = 0;
 
-#if ECHO
-	done_reg = 1;
-#else
+	if (kds_echo) {
+		done_reg = 1;
+		goto out;
+	}
+
 	/* There is only one done commands counter in the plram CU
 	 * It tells how many commands are done and how many FIFO slots
 	 * are ready for more commands.
@@ -68,7 +75,7 @@ static void cu_plram_check(void *core, struct xcu_status *status)
 	 */
 	if (cu_plram->credits != cu_plram->max_credits)
 		done_reg = ioread32(cu_plram->vaddr + 0x1C);
-#endif
+out:
 	status->num_done = done_reg;
 	status->num_ready = done_reg;
 }
@@ -76,6 +83,7 @@ static void cu_plram_check(void *core, struct xcu_status *status)
 static struct xcu_funcs xrt_cu_plram_funcs = {
 	.get_credit	= cu_plram_get_credit,
 	.put_credit	= cu_plram_put_credit,
+	.is_zero_credit = cu_plram_is_zero_credit,
 	.configure	= cu_plram_configure,
 	.start		= cu_plram_start,
 	.check		= cu_plram_check,
@@ -95,10 +103,6 @@ int xrt_cu_plram_init(struct xrt_cu *xcu)
 		return -EINVAL;
 	}
 
-	err = xrt_cu_init(xcu);
-	if (err)
-		return err;
-
 	core = kzalloc(sizeof(struct xrt_cu_plram), GFP_KERNEL);
 	if (!core)
 		return -ENOMEM;
@@ -116,11 +120,11 @@ int xrt_cu_plram_init(struct xrt_cu *xcu)
 	/* NOTE: Dummy read needed on kernel 0x18 and 0x1c register because
 	 * of some bug in kernel, first read will give some garbage data
 	 */
-	val = ioread32(core->vaddr + 0x18);
 	val = ioread32(core->vaddr + 0x1C);
+	val = ioread32(core->vaddr + 0x18);
 
-	val = ioread32(core->vaddr + 0x18);
 	val = ioread32(core->vaddr + 0x1C);
+	val = ioread32(core->vaddr + 0x18);
 	xcu_info(xcu, "FIFO depth 0x%x", val);
 	core->max_credits = val;
 	core->credits = core->max_credits;
@@ -143,6 +147,10 @@ int xrt_cu_plram_init(struct xrt_cu *xcu)
 
 	xcu->core = core;
 	xcu->funcs = &xrt_cu_plram_funcs;
+
+	err = xrt_cu_init(xcu);
+	if (err)
+		return err;
 
 	return 0;
 err1:

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -60,28 +60,28 @@ struct xcu_status {
 
 struct xcu_funcs {
 	/**
-	 * @get_credit:
+	 * @alloc_credit:
 	 *
-	 * Try to get one credit from the CU. A credit is required before
+	 * Try to alloc one credit on the CU. A credit is required before
 	 * submit a task to the CU. Otherwise, it would lead to unknown CU
 	 * behaviour.
 	 * Return: the number of remaining credit.
 	 */
-	int (*get_credit)(void *core);
+	int (*alloc_credit)(void *core);
 
 	/**
-	 * @refund_credit:
+	 * @free_credit:
 	 *
-	 * refund credit to the CU.
+	 * free credits.
 	 */
-	void (*put_credit)(void *core, u32 count);
+	void (*free_credit)(void *core, u32 count);
 
 	/**
-	 * @is_zero_credit:
+	 * @peek_credit:
 	 *
-	 * Check if CU core has zero credit.
+	 * Check how many credits the CU could provide with side effect.
 	 */
-	int (*is_zero_credit)(void *core);
+	int (*peek_credit)(void *core);
 
 	/**
 	 * @configure:
@@ -247,17 +247,17 @@ static inline void xrt_cu_check(struct xrt_cu *xcu)
 
 static inline int xrt_cu_get_credit(struct xrt_cu *xcu)
 {
-	return xcu->funcs->get_credit(xcu->core);
+	return xcu->funcs->alloc_credit(xcu->core);
 }
 
 static inline int is_zero_credit(struct xrt_cu *xcu)
 {
-	return xcu->funcs->is_zero_credit(xcu->core);
+	return (xcu->funcs->peek_credit(xcu->core) == 0);
 }
 
 static inline void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count)
 {
-	xcu->funcs->put_credit(xcu->core, count);
+	xcu->funcs->free_credit(xcu->core, count);
 }
 
 /* 1. Move commands from pending command queue to running queue

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -240,6 +240,7 @@ enum {
 #define	XOCL_CU			"cu"
 #define	XOCL_P2P		"p2p"
 #define	XOCL_PMC		"pmc"
+#define	XOCL_INTC		"intc"
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
@@ -283,6 +284,7 @@ enum subdev_id {
 	XOCL_SUBDEV_LAPC,
 	XOCL_SUBDEV_SPC,
 	XOCL_SUBDEV_PMC,
+	XOCL_SUBDEV_INTC,
 	XOCL_SUBDEV_NUM
 };
 
@@ -1560,6 +1562,29 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_UARTLITE),		\
 	}
 
+#define XOCL_RES_INTC					\
+	((struct resource []) {				\
+		{					\
+		.start  = ERT_CSR_ADDR,			\
+		.end    = ERT_CSR_ADDR + 0xfff,		\
+		.flags  = IORESOURCE_MEM,		\
+		},					\
+		{					\
+		.start  = 0,				\
+		.end    = 3,				\
+		.flags  = IORESOURCE_IRQ,		\
+		}					\
+	})
+
+#define XOCL_DEVINFO_INTC				\
+	{						\
+		XOCL_SUBDEV_INTC,			\
+		XOCL_INTC,				\
+		XOCL_RES_INTC,				\
+		ARRAY_SIZE(XOCL_RES_INTC),		\
+		.override_idx = -1,			\
+	}
+
 #define XOCL_RES_SCHEDULER				\
 		((struct resource []) {			\
 		/*
@@ -1598,6 +1623,29 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_SCHEDULER),		\
 		&XOCL_RES_SCHEDULER_PRIV,		\
 		sizeof(struct xocl_ert_sched_privdata),	\
+		.override_idx = -1,			\
+	}
+
+#define XOCL_RES_INTC_QDMA				\
+	((struct resource []) {				\
+		{					\
+		.start  = ERT_CSR_ADDR,			\
+		.end    = ERT_CSR_ADDR + 0xfff,		\
+		.flags  = IORESOURCE_MEM,		\
+		},					\
+		{					\
+		.start  = 2,				\
+		.end    = 5,				\
+		.flags  = IORESOURCE_IRQ,		\
+		}					\
+	})
+
+#define XOCL_DEVINFO_INTC_QDMA				\
+	{						\
+		XOCL_SUBDEV_INTC,			\
+		XOCL_INTC,				\
+		XOCL_RES_INTC_QDMA,			\
+		ARRAY_SIZE(XOCL_RES_INTC_QDMA),		\
 		.override_idx = -1,			\
 	}
 
@@ -1651,6 +1699,30 @@ struct xocl_subdev_map {
 
 #define	ERT_CSR_ADDR_VERSAL		0x6040000
 #define	ERT_CQ_BASE_ADDR_VERSAL		0x4000000
+
+#define XOCL_RES_INTC_VERSAL				\
+	((struct resource []) {				\
+		{					\
+		.start  = ERT_CSR_ADDR_VERSAL,		\
+		.end    = ERT_CSR_ADDR_VERSAL + 0xfff,	\
+		.flags  = IORESOURCE_MEM,		\
+		},					\
+		{					\
+		.start  = 0,				\
+		.end    = 0,				\
+		.flags  = IORESOURCE_IRQ,		\
+		}					\
+	})
+
+#define XOCL_DEVINFO_INTC_VERSAL			\
+	{						\
+		XOCL_SUBDEV_INTC,			\
+		XOCL_INTC,				\
+		XOCL_RES_INTC_VERSAL,			\
+		ARRAY_SIZE(XOCL_RES_INTC_VERSAL),	\
+		.override_idx = -1,			\
+		.bar_idx = (char []){ 2 },		\
+	}
 
 #define XOCL_RES_SCHEDULER_VERSAL				\
 		((struct resource []) {				\
@@ -1745,6 +1817,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XMC_USER,				\
 			XOCL_DEVINFO_AF_USER,				\
 			XOCL_DEVINFO_CU_CTRL,				\
+			XOCL_DEVINFO_INTC_QDMA,				\
 		})
 
 #define	XOCL_BOARD_USER_QDMA4						\
@@ -1764,6 +1837,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_ICAP_USER,				\
 			XOCL_DEVINFO_XMC_USER,				\
 			XOCL_DEVINFO_AF_USER,				\
+			XOCL_DEVINFO_INTC_QDMA,				\
 		})
 
 #define	XOCL_BOARD_USER_QDMA						\
@@ -1779,6 +1853,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XDMA,				\
 			XOCL_DEVINFO_SCHEDULER_51,			\
 			XOCL_DEVINFO_ICAP_USER,				\
+			XOCL_DEVINFO_INTC,				\
 		})
 
 #define	USER_RES_XDMA							\
@@ -1790,6 +1865,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_ICAP_USER,				\
 			XOCL_DEVINFO_XMC_USER,				\
 			XOCL_DEVINFO_AF_USER,				\
+			XOCL_DEVINFO_INTC,				\
 		})
 
 #define	USER_RES_XDMA_VERSAL						\
@@ -1801,6 +1877,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_PF_MAILBOX_USER_VERSAL,		\
 			XOCL_DEVINFO_MAILBOX_USER_VERSAL,		\
 		 	XOCL_DEVINFO_ICAP_USER,				\
+			XOCL_DEVINFO_INTC_VERSAL,				\
 		})
 
 #define USER_RES_AWS							\
@@ -1810,6 +1887,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_SCHEDULER_51,			\
 			XOCL_DEVINFO_MAILBOX_USER_SOFTWARE,		\
 			XOCL_DEVINFO_ICAP_USER,				\
+			XOCL_DEVINFO_INTC,				\
 		})
 
 #define	USER_RES_DSA52							\
@@ -1822,6 +1900,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_ICAP_USER,				\
 			XOCL_DEVINFO_XMC_USER,				\
 			XOCL_DEVINFO_AF_USER,				\
+			XOCL_DEVINFO_INTC,				\
 		})
 
 #define	USER_RES_DSA52_U2						\
@@ -1834,6 +1913,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_ICAP_USER,				\
 			XOCL_DEVINFO_XMC_USER_U2,			\
 			XOCL_DEVINFO_AF_USER,				\
+			XOCL_DEVINFO_INTC,				\
 		})
 
 #define USER_RES_SMARTN							\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -153,7 +153,6 @@ static int request_intr(struct platform_device *pdev, int intr_id,
 static int config_intr(struct platform_device *pdev, int intr_id, bool en)
 {
 	struct xocl_intc *intc = platform_get_drvdata(pdev);
-	xdev_handle_t xdev = xocl_get_xdev(intc->pdev);
 	struct intr_metadata *data;
 	struct intr_info *info;
 	int data_idx = intr_id / INTR_SRCS;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: Min Ma <minm@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "../xocl_drv.h"
+/* To get register address of CSR */
+#include "ert.h"
+
+#define INTC_INFO(intc, fmt, arg...)	\
+	xocl_info(&intc->pdev->dev, fmt "\n", ##arg)
+#define INTC_ERR(intc, fmt, arg...)	\
+	xocl_err(&intc->pdev->dev, fmt "\n", ##arg)
+#define INTC_DBG(intc, fmt, arg...)	\
+	xocl_dbg(&intc->pdev->dev, fmt "\n", ##arg)
+
+/* The purpose of this driver is to manage the CU/ERT interrupts on an Alveo
+ * board. It provides:
+ *	interrupt register function for CU and ERT sub-devices.
+ *	interrupt to ERT function
+ *
+ * Based on current hardware implementation, the driver supports 4 PCIe MSI-x
+ * interrupts. For each interrupt, there are 32 different sources.
+ * If current interrupt mode is ERT.
+ * To determine the interrupt sources, read ERT_STATUS_REGISTER_ADDR and check
+ * which bit is set.
+ *
+ * If current interrupt mode is CU.
+ * (TBD)...
+ */
+
+extern int kds_mode;
+
+#define INTR_NUM  4
+#define INTR_SRCS 32
+
+/* ERT Interrupt Status Register offsets */
+static u32 eisr[4] = {
+	ERT_STATUS_REGISTER_ADDR0 - ERT_STATUS_REGISTER_ADDR,
+	ERT_STATUS_REGISTER_ADDR1 - ERT_STATUS_REGISTER_ADDR,
+	ERT_STATUS_REGISTER_ADDR2 - ERT_STATUS_REGISTER_ADDR,
+	ERT_STATUS_REGISTER_ADDR3 - ERT_STATUS_REGISTER_ADDR
+};
+
+struct intr_info {
+	irqreturn_t (*handler)(int irq, void *arg);
+	void *arg;
+	bool  enabled;
+};
+
+/* A metadata contains details of a MSI-X interrupt
+ * intr: MSI-x irq number
+ * isr:  Interrupt status register
+ * info: Information of each interrupt source
+ */
+struct intr_metadata {
+	u32			 intr;
+	u32 __iomem		*isr;
+	struct intr_info	*info[INTR_SRCS];
+};
+
+/* The details for intc sub-device.
+ * It holds all resources and understand hardware.
+ */
+struct xocl_intc {
+	struct platform_device	*pdev;
+	struct intr_metadata	 data[INTR_NUM];
+	u32			 data_num;
+	void __iomem		*csr_base;
+	u32			 csr_size;
+	/* TODO: support CU to host interrupt after we got hardware spec */
+};
+
+/**
+ * intc_csr_isr() - Handler of ERT to host interrupts
+ */
+irqreturn_t intc_csr_isr(int irq, void *arg)
+{
+	struct intr_metadata *data = arg;
+	u32 pending;
+	u32 index;
+
+	/* EISR is clear on read */
+	pending = ioread32(data->isr);
+
+	/* Iterate all interrupt sources. If it is set, handle it */
+	for (index = 0; pending != 0; index++) {
+		struct intr_info *info;
+
+		if (!(pending & (1 << index)))
+			continue;
+
+		info = data->info[index];
+		/* If a bit is set but without handler, it probably is
+		 * a bug on hardware or ERT firmware.
+		 */
+		if (info && info->enabled && info->handler)
+			info->handler(index, info->arg);
+
+		pending ^= 1 << index;
+	};
+
+	return IRQ_HANDLED;
+}
+
+static int request_intr(struct platform_device *pdev, int intr_id,
+			irqreturn_t (*handler)(int irq, void *arg),
+			void *arg)
+{
+	struct xocl_intc *intc = platform_get_drvdata(pdev);
+	struct intr_metadata *data;
+	struct intr_info *info;
+	int data_idx = intr_id / INTR_SRCS;
+	int intr_src = intr_id % INTR_SRCS;
+
+	if (data_idx >= intc->data_num) {
+		INTC_ERR(intc, "Interrupt ID out-of-range");
+		return -EINVAL;
+	}
+
+	data = &intc->data[data_idx];
+
+	if (data->info[intr_src] && handler)
+		return -EBUSY;
+
+	if (handler) {
+		info = vzalloc(sizeof(struct intr_info));
+		info->handler = handler;
+		info->arg = arg;
+		info->enabled = false;
+		data->info[intr_src] = info;
+		return 0;
+	}
+
+	if (data->info[intr_src]) {
+		vfree(data->info[intr_src]);
+		data->info[intr_src] = NULL;
+	}
+
+	return 0;
+}
+
+static int config_intr(struct platform_device *pdev, int intr_id, bool en)
+{
+	struct xocl_intc *intc = platform_get_drvdata(pdev);
+	xdev_handle_t xdev = xocl_get_xdev(intc->pdev);
+	struct intr_metadata *data;
+	struct intr_info *info;
+	int data_idx = intr_id / INTR_SRCS;
+	int intr_src = intr_id % INTR_SRCS;
+
+	if (data_idx >= intc->data_num) {
+		INTC_ERR(intc, "Interrupt ID out-of-range");
+		return -EINVAL;
+	}
+
+	data = &intc->data[data_idx];
+	info = data->info[intr_src];
+
+	if (!info)
+		return -EINVAL;
+
+	info->enabled = en;
+
+	return 0;
+}
+
+static int intc_probe(struct platform_device *pdev)
+{
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	struct xocl_intc *intc = NULL;
+	struct resource *res;
+	struct intr_metadata *data;
+	void *hdl;
+	u32 irq;
+	int ret;
+	int i;
+
+	if (!kds_mode)
+		goto out;
+
+	intc = xocl_drvinst_alloc(&pdev->dev, sizeof(*intc));
+	if (!intc)
+		return -ENOMEM;
+
+	platform_set_drvdata(pdev, intc);
+	intc->pdev = pdev;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (!res) {
+		INTC_ERR(intc, "Did not get CSR resource");
+		ret = -EINVAL;
+		goto err;
+	}
+	intc->csr_size = res->end - res->start + 1;
+	intc->csr_base = ioremap_nocache(res->start, intc->csr_size);
+
+	res = platform_get_resource(pdev, IORESOURCE_IRQ, 0);
+	if (!res) {
+		INTC_ERR(intc, "Did not get IRQ resource");
+		ret = -EINVAL;
+		goto err1;
+	}
+	/* For all PCIe platform, CU/ERT interrupts are contiguous */
+	intc->data_num = res->end - res->start + 1;
+	if (intc->data_num > INTR_NUM) {
+		INTC_ERR(intc, "Too many interrupts in the resource");
+		return -EINVAL;
+	}
+
+	for (i = 0; i < intc->data_num; i++) {
+		irq = res->start + i;
+		data = &intc->data[i];
+		data->intr = irq;
+		data->isr = intc->csr_base + eisr[i];
+		xocl_user_interrupt_reg(xdev, irq, intc_csr_isr, data);
+		/* enable interrupt */
+		xocl_user_interrupt_config(xdev, irq, true);
+	}
+out:
+	return 0;
+
+err1:
+	iounmap(intc->csr_base);
+err:
+	xocl_drvinst_release(intc, &hdl);
+	xocl_drvinst_free(hdl);
+	return ret;
+}
+
+static int intc_remove(struct platform_device *pdev)
+{
+	struct xocl_intc *intc = platform_get_drvdata(pdev);
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	void *hdl;
+	int i;
+
+	if (!kds_mode)
+		goto out;
+
+	for (i = 0; i < intc->data_num; i++) {
+		/* disable interrupt */
+		xocl_user_interrupt_config(xdev, intc->data[i].intr, false);
+		xocl_user_interrupt_reg(xdev, intc->data[i].intr, NULL, NULL);
+	}
+
+	xocl_drvinst_release(intc, &hdl);
+	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(hdl);
+out:
+	return 0;
+}
+
+static struct xocl_intc_funcs intc_ops = {
+	.request_intr = request_intr,
+	.config_intr  = config_intr,
+	/* TODO: add CU/ERT mode switch op */
+};
+
+struct xocl_drv_private intc_priv = {
+	.ops = &intc_ops,
+};
+
+struct platform_device_id intc_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_INTC), (kernel_ulong_t)&intc_priv },
+	{ },
+};
+
+static struct platform_driver intc_driver = {
+	.probe		= intc_probe,
+	.remove		= intc_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_INTC),
+	},
+	.id_table = intc_id_table,
+};
+
+int __init xocl_init_intc(void)
+{
+	return platform_driver_register(&intc_driver);
+}
+
+void xocl_fini_intc(void)
+{
+	platform_driver_unregister(&intc_driver);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -81,6 +81,7 @@ xocl-y := \
 	../subdev/address_translator.o \
 	../subdev/cu.o \
 	../subdev/p2p.o \
+	../subdev/intc.o \
 	$(xocl_lib-y)	\
 	$(drv_common-y) \
 	xocl_drv.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1531,6 +1531,8 @@ static int (*xocl_drv_reg_funcs[])(void) __initdata = {
 	xocl_init_trace_funnel,
 	xocl_init_trace_s2mm,
 	xocl_init_mem_hbm,
+	/* Initial intc sub-device before CU/ERT sub-devices */
+	xocl_init_intc,
 	xocl_init_cu,
 	xocl_init_addr_translator,
 	xocl_init_p2p,
@@ -1563,6 +1565,8 @@ static void (*xocl_drv_unreg_funcs[])(void) = {
 	xocl_fini_trace_s2mm,
 	xocl_fini_mem_hbm,
 	xocl_fini_cu,
+	/* Remove intc sub-device after CU/ERT sub-devices */
+	xocl_fini_intc,
 	xocl_fini_addr_translator,
 	xocl_fini_p2p,
 	xocl_fini_spc,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1492,6 +1492,28 @@ struct xocl_cu_funcs {
 #define CU_CB(xdev, idx, cb) \
 	(CU_DEV(xdev, idx) && CU_OPS(xdev, idx) && CU_OPS(xdev, idx)->cb)
 
+/* INTC call back */
+struct xocl_intc_funcs {
+	struct xocl_subdev_funcs common_funcs;
+	int (* request_intr)(struct platform_device *pdev, int intr_id,
+			     irqreturn_t (*handler)(int irq, void *arg),
+			     void *arg);
+	int (* config_intr)(struct platform_device *pdev, int intr_id, bool en);
+};
+#define	INTC_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_INTC).pldev
+#define INTC_OPS(xdev)  \
+	((struct xocl_intc_funcs *)SUBDEV(xdev, XOCL_SUBDEV_INTC).ops)
+#define INTC_CB(xdev, cb) \
+	(INTC_DEV(xdev) && INTC_OPS(xdev) && INTC_OPS(xdev)->cb)
+#define xocl_intc_request(xdev, id, handler, arg) \
+	(INTC_CB(xdev, request_intr) ? \
+	 INTC_OPS(xdev)->request_intr(INTC_DEV(xdev), id, handler, arg) : \
+	 -ENODEV)
+#define xocl_intc_config(xdev, id, en) \
+	(INTC_CB(xdev, config_intr) ? \
+	 INTC_OPS(xdev)->config_intr(INTC_DEV(xdev), id, en) : \
+	 -ENODEV)
+
 /* helper functions */
 xdev_handle_t xocl_get_xdev(struct platform_device *pdev);
 void xocl_init_dsa_priv(xdev_handle_t xdev_hdl);
@@ -1916,4 +1938,7 @@ void xocl_fini_lapc(void);
 
 int __init xocl_init_pmc(void);
 void xocl_fini_pmc(void);
+
+int __init xocl_init_intc(void);
+void xocl_fini_intc(void);
 #endif


### PR DESCRIPTION
Basic INTC sub-device, the idea is to create a sub-device to manage the ERT/CU interrupts. This could decoupling interrupt handling logic from KDS and be able to support CU to host interrupt.

I'd like to highlight devices.h change. I'm trying to split XOCL_RES_SCHEDULRE into two resources. One is XOCL_RES_INTC, which is for this new INTC sub-device. The other is for command queue (no include in this PR). Later on, the ERT sub-device would need the command queue resource.
@larry9523 , I would need your help to check if this change work on Versal (no runtime error).

The ERT/CU sub-device could register an interrupt handler through xocl_intc_request(xdev, id, handler, arg).
    The id is the interrupt ID, from 0 to 127.
    The handler is the same the standard interrupt handler function.
    The arg is the argument that will pass to the handler.

Supported:
    Legacy platforms (Tested on U.2 and U200)
Unsupported:
    SSv2 platform (waiting on U50 board)
    SSv3 platform (waiting on U50 board and new interrupt mapping support)
       - The INTC sub-device would support CU to host interrupts

The other commit is to update plram CU, which is a minor change. Please let me know if I should create an other PR.