### PR TITLE
CR1068638 Illegal memory access attempt through the slave bridge does…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -928,18 +928,20 @@ static int p2p_release_resource(struct platform_device *pdev,
 	struct resource *res)
 {
 	struct p2p *p2p = platform_get_drvdata(pdev);
+	ulong bar_off;
 
 	if (res->start < p2p->p2p_bar_start ||
 	    res->start >= p2p->p2p_bar_start + p2p->p2p_bar_len)
 		return 0;
 
+	bar_off = res->start - p2p->p2p_bar_start;
 	if (!p2p->remapper) {
 		p2p_err(p2p, "remap does not exist");
 		return -EINVAL;
 	}
 
-	p2p_info(p2p, "Remap release resource %pR", res);
-	p2p_bar_unmap(p2p, res->start);
+	p2p_info(p2p, "Remap release resource %lx", bar_off);
+	p2p_bar_unmap(p2p, bar_off);
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1343,7 +1343,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			    (subdev_info.priv_data))->flash_type,
 			    FLASH_TYPE_QSPIPS, strlen(FLASH_TYPE_QSPIPS));
 			/* default is FLASH_TYPE_SPI, thus pass through. */
-			__attribute__ ((fallthrough));
+			/* fall through */
 		case XOCL_VSEC_FLASH_TYPE_SPI_IP:
 		case XOCL_VSEC_FLASH_TYPE_SPI_REG:
 			xocl_xdev_info(xdev,


### PR DESCRIPTION
[34660.634745] xclmgmt 0000:65:00.0: firewall.m.11534336 ffff898cbadbbc10 check_firewall: AXI Firewall 2 tripped, status: 0x2, bar offset 0x102000, resource ep_firewall_ctrl_mgmt_00 1 1 2 axi_firewall
[34660.634757] xclmgmt 0000:65:00.0: firewall.m.11534336 ffff898cbadbbc10 check_firewall: ARADDR 0x972000, AWADDR 0x0, ARUSER 0x0, AWUSER 0x0

command # cat /sys/bus/pci/devices/0000\:65\:00.0/firewall.m.11534336/detected_trip 
status_bit1:RECS_ARREADY_MAX_WAIT
araddr:0x972000
awaddr:0x0
aruser:0x0
awuser:0x0
