### PR TITLE
Manage ownership of command objects in native APIs

### DIFF
--- a/src/runtime_src/core/common/api/command.h
+++ b/src/runtime_src/core/common/api/command.h
@@ -26,7 +26,7 @@
  */
 namespace xrt_core {
 
-class command
+class command : public std::enable_shared_from_this<command>
 {
 public:
   /**


### PR DESCRIPTION
Fixes race in command::notify() where notification can end up
triggering delete of the run object that holds on to the command
object.

Run object now shares ownership of the command object through
a shared pointer and callers of notify retains ownership of the
command object before calling notify().  That way the run object
can be safely deleted without destruction of the command object.