### PR TITLE
XRT-293 move xclbin parsing code to a lib from icap

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2438,7 +2438,7 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
-	/* TODO: link this comment to specific fuction in xocl_ioctl.c */
+	/* TODO: link this comment to specific function in xocl_ioctl.c */
 	/* has to create mem topology even with failure case
 	 * please refer the comment in xocl_ioctl.c
 	 * without creating mem topo, memory corruption could happen
@@ -2480,7 +2480,7 @@ done:
 	if (err) {
 		uuid_copy(&icap->icap_bitstream_uuid, &uuid_null);
 	} else {
-		/* Remember "this" bitstream, so avoid redownload next time. */
+		/* Remember "this" bitstream, so avoid re-download next time. */
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 	}
 	return err;
@@ -2491,13 +2491,13 @@ done:
  *    1) after xclbin validation, freeze(isolate) xmc;
  *    2) save calib;
  *    3) remove all URP subdevs;
- *    4) save retation flag before caching mem_topology and ip_layout;
+ *    4) save retention flag before caching mem_topology and ip_layout;
  *    5) verify signed signature;
- *    6) reconfig clock;
+ *    6) re-config clock;
  *    7) reset ddr pin for retention only;
  *    8) perform icap download for non-flat design;
  *    9) create SRSR subdev;
- *    10) create CLOCK subdev, reconfig clock;
+ *    10) create CLOCK subdev, re-config clock;
  *    11) perform mig calibration;
  *    12) create subdev ip_layout;
  *    13) create subdev dna;
@@ -2524,7 +2524,7 @@ static int __icap_download_bitstream_mgmt(struct platform_device *pdev,
 	/* remove any URP subdev before downloading xclbin */
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
-	/* Check the incoming mem topoloy with the current one before overwrite */
+	/* Check the incoming mem topology with the current one before overwrite */
 	sref = check_mem_topo_and_data_retention(icap, xclbin);
 	icap_cache_bitstream_axlf_section(pdev, xclbin, MEM_TOPOLOGY);
 	icap_cache_bitstream_axlf_section(pdev, xclbin, IP_LAYOUT);
@@ -2556,7 +2556,7 @@ done:
 	if (err) {
 		uuid_copy(&icap->icap_bitstream_uuid, &uuid_null);
 	} else {
-		/* Remember "this" bitstream, so avoid redownload next time. */
+		/* Remember "this" bitstream, so avoid re-download next time. */
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 	}
 	return err;
@@ -2884,9 +2884,11 @@ done:
 		}
 		ICAP_INFO(icap, "skip kind %d(%s), return code %ld", kind,
 			xrt_xclbin_kind_to_string(kind), err);
-	} else
+	} else {
 		ICAP_INFO(icap, "found kind %d(%s)", kind,
 			xrt_xclbin_kind_to_string(kind));
+	}
+
 	return err;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -340,7 +340,7 @@ const static struct xclmgmt_ocl_clockwiz {
 	{/*1462.500*/   650.000,        0x02710E01,     0x0000FA02}
 };
 
-static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
+static int icap_cache_bitstream_axlf_section(struct platform_device *pdev,
 	const struct axlf *xclbin, enum axlf_section_kind kind);
 static void icap_set_data(struct icap *icap, struct xcl_pr_region *hwicap);
 static uint64_t icap_get_data_nolock(struct platform_device *pdev, enum data_kind kind);
@@ -818,7 +818,7 @@ static void xclbin_write_clock_freq(struct clock_freq *dst, struct clock_freq *s
 }
 
 
-static int xclbin_setup_clock_freq_topology(struct icap *icap,
+static int icap_cache_clock_freq_topology(struct icap *icap,
 	const struct axlf *xclbin)
 {
 	int i;
@@ -1625,7 +1625,7 @@ static int icap_create_subdev_debugip(struct platform_device *pdev)
 	return err;
 }
 
-static int icap_create_cu(struct platform_device *pdev)
+static int icap_create_subdev_cu(struct platform_device *pdev)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
@@ -1678,7 +1678,21 @@ static int icap_create_cu(struct platform_device *pdev)
 	return err;
 }
 
-static int icap_create_subdev(struct platform_device *pdev)
+/*
+ * TODO: clear the comments, it seems that different subdev has different
+ *    flow during creation. Using specific function to create specific subdev
+ *    gives us flexibility to adjust the download procedure.
+ *
+ * Add sub device dynamically.
+ * restrict any dynamically added sub-device and 1 base address,
+ * Has pre-defined length
+ *  Ex:    "ip_data": {
+ *         "m_type": "IP_DNASC",
+ *         "properties": "0x0",
+ *         "m_base_address": "0x1100000", <--  base address
+ *         "m_name": "slr0\/dna_self_check_0"
+ */
+static int icap_create_subdev_ip_layout(struct platform_device *pdev)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
 	int err = 0, i = 0;
@@ -1803,11 +1817,6 @@ static int icap_create_subdev(struct platform_device *pdev)
 		}
 	}
 
-	if (!ICAP_PRIVILEGED(icap))
-		err = icap_create_cu(pdev);
-
-	if (!ICAP_PRIVILEGED(icap))
-		err = icap_create_subdev_debugip(pdev);
 done:
 	return err;
 }
@@ -1876,7 +1885,7 @@ done:
 	return err;
 }
 
-static int icap_verify_bitstream_axlf(struct platform_device *pdev,
+static int icap_create_subdev_dna(struct platform_device *pdev,
 	struct axlf *xclbin)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
@@ -1884,26 +1893,6 @@ static int icap_verify_bitstream_axlf(struct platform_device *pdev,
 	int err = 0;
 	uint64_t section_size = 0;
 	u32 capability;
-
-	/*
-	 * Add sub device dynamically.
-	 * restrict any dynamically added sub-device and 1 base address,
-	 * Has pre-defined length
-	 *  Ex:    "ip_data": {
-	 *         "m_type": "IP_DNASC",
-	 *         "properties": "0x0",
-	 *         "m_base_address": "0x1100000", <--  base address
-	 *         "m_name": "slr0\/dna_self_check_0"
-	 */
-
-	err = icap_create_subdev(pdev);
-	if (err)
-		goto done;
-
-
-	/* Skip dna validation in userpf*/
-	if (!ICAP_PRIVILEGED(icap))
-		goto done;
 
 	/* capability BIT8 as DRM IP enable, BIT0 as AXI mode
 	 * We only check if anyone of them is set.
@@ -2068,9 +2057,10 @@ static int icap_refresh_clock_freq(struct icap *icap, struct axlf *xclbin)
 	int err = 0;
 
 	if (ICAP_PRIVILEGED(icap) && !XOCL_DSA_IS_SMARTN(xdev)) {
-		err = xclbin_setup_clock_freq_topology(icap, xclbin);
+		err = icap_cache_clock_freq_topology(icap, xclbin);
 		if (!err) {
 			err = axlf_set_freqscaling(icap);
+			/* No clock subdev is ok? */
 			err = err == -ENODEV ? 0 : err;
 		}
 	}
@@ -2186,16 +2176,9 @@ static int icap_calib_and_check(struct platform_device *pdev)
 	return icap_calibrate_mig(pdev);
 }
 
-static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool sref)
+static int icap_verify_signed_signature(struct icap *icap, struct axlf *xclbin)
 {
-	xdev_handle_t xdev = xocl_get_xdev(icap->icap_pdev);
-	int i = 0, err = 0, num_dev = 0;
-	bool retention = ((icap->data_retention & 0x1) == 0x1) && sref;
-	struct xocl_subdev *subdevs = NULL;
-	bool has_ulp_clock = false;
-
-	BUG_ON(!mutex_is_locked(&icap->icap_lock));
-	icap_probe_urpdev(icap->icap_pdev, xclbin, &num_dev, &subdevs);
+	int err = 0;
 
 	if (xclbin->m_signature_length != -1) {
 		int siglen = xclbin->m_signature_length;
@@ -2219,6 +2202,67 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 		goto out;
 	}
 
+out:
+	return err;
+}
+
+/* Create all urp subdevs */
+static void icap_probe_urpdev_all(struct platform_device *pdev,
+	struct axlf *xclbin)
+{
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	int i, num_dev = 0;
+	struct xocl_subdev *subdevs = NULL;
+
+	/* create the rest of subdevs for both mgmt and user pf */
+	icap_probe_urpdev(pdev, xclbin, &num_dev, &subdevs);
+	if (num_dev > 0) {
+		for (i = 0; i < num_dev; i++)
+			(void) xocl_subdev_create(xdev, &subdevs[i].info);
+	}
+
+	if (subdevs)
+		vfree(subdevs);
+}
+
+/* Create specific subdev */
+static int icap_probe_urpdev_by_id(struct platform_device *pdev,
+	struct axlf *xclbin, enum subdev_id devid)
+{
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	int i, err = 0, num_dev = 0;
+	struct xocl_subdev *subdevs = NULL;
+	bool found = false;
+
+	/* create specific subdev for both mgmt and user pf */
+	icap_probe_urpdev(pdev, xclbin, &num_dev, &subdevs);
+	if (num_dev > 0) {
+		for (i = 0; i < num_dev; i++) {
+			if (subdevs[i].info.id != devid)
+				continue;
+			err = xocl_subdev_create(xdev, &subdevs[i].info);
+			found = true;
+			break;
+		}
+	}
+
+	if (subdevs)
+		vfree(subdevs);
+
+	return found ? err : -ENODATA;
+}
+
+static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool sref)
+{
+	int err = 0;
+	bool retention = ((icap->data_retention & 0x1) == 0x1) && sref;
+
+	BUG_ON(!mutex_is_locked(&icap->icap_lock));
+
+	err = icap_verify_signed_signature(icap, xclbin);
+	if (err)
+		goto out;
+
 	err = icap_refresh_clock_freq(icap, xclbin);
 	if (err)
 		goto out;
@@ -2232,10 +2276,13 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 			goto out;
 		}
 	}
-	/* xclbin generated for the flat shell contains MCS files which includes the accelerator
-	 * these MCS files should have been already flashed into the device using xbmgmt tool
-	 * we dont need to reprogram the xclbin for the FLAT shells.
-	 * TODO Currently , There is no way to check whether the programmed xclbin matches with this xclbin or not
+
+	/* xclbin generated for the flat shell contains MCS files which
+	 * includes the accelerator these MCS files should have been already
+	 * flashed into the device using xbmgmt tool we dont need to reprogram
+	 * the xclbin for the FLAT shells.
+	 * TODO: Currently , There is no way to check whether the programmed
+	 * xclbin matches with this xclbin or not
 	 */
 	if (xclbin->m_header.m_mode != XCLBIN_FLAT) {
 		err = icap_download_bitstream(icap, xclbin);
@@ -2251,30 +2298,16 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 	if (err)
 		goto out;
 
-	/* For 2RP, the majority of ULP IP can only be touched after ucs control bit set to 0x1
-	 * which is done in icap_refresh_clock_freq. Move so logics(create clock devices and set ucs control bit)
-	 * to xclbin download function as workaround to solve interleaving issue.
-	 * DDR SRSR IP and MIG need to wait until ucs control bit set to 0x1, 
-	 * and icap mig calibration needs to wait until DDR SRSR calibration finish
+	/*
+	 * Perform the following exact sequence to avoid firewall trip.
+	 *    1) ucs_control set to 0x1
+	 *    2) DDR SRSR IP and MIG
+	 *    3) MIG calibration
 	 */
-	if (num_dev > 0) {
-		/* if has clock, create clock subdev first */
-		for (i = 0; i < num_dev; i++) {
-			if (subdevs[i].info.id != XOCL_SUBDEV_CLOCK)
-				continue;
-			err = xocl_subdev_create(xdev, &subdevs[i].info);
-			if (err)
-				goto out;
-
-			has_ulp_clock = true;
-			break;
-		}
-
-		icap_refresh_addrs(icap->icap_pdev);
+	/* If xclbin has clock metadata, refresh all clock freq */
+	err = icap_probe_urpdev_by_id(icap->icap_pdev, xclbin, XOCL_SUBDEV_CLOCK);
+	if (!err)
 		err = icap_refresh_clock_freq(icap, xclbin);
-		if (err)
-			goto out;
-	}
 
 	icap_calib(icap, retention);
 
@@ -2291,8 +2324,6 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 out:
 	if (err && retention)
 		icap_release_ddr_gate_pin(icap);
-	if (subdevs)
-		vfree(subdevs);
 	ICAP_INFO(icap, "ret: %d", (int)err);
 	return err;
 }
@@ -2303,7 +2334,7 @@ static void icap_probe_urpdev(struct platform_device *pdev, struct axlf *xclbin,
 	struct icap *icap = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(icap->icap_pdev);
 
-	icap_parse_bitstream_axlf_section(pdev, xclbin, PARTITION_METADATA);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, PARTITION_METADATA);
 	if (icap->partition_metadata) {
 		*num_urpdev = xocl_fdt_parse_blob(xdev, icap->partition_metadata,
 			icap_get_section_size(icap, PARTITION_METADATA),
@@ -2369,7 +2400,7 @@ static bool check_mem_topo_and_data_retention(struct icap *icap,
 	return true;
 }
 
-static void icap_get_max_host_mem_aperture(struct icap *icap)
+static void icap_cache_max_host_mem_aperture(struct icap *icap)
 {
 	int i = 0;
 	struct mem_topology *mem_topo = icap->mem_topo;
@@ -2389,98 +2420,133 @@ static void icap_get_max_host_mem_aperture(struct icap *icap)
 	return;
 }
 
-static int __icap_download_bitstream_axlf(struct platform_device *pdev,
+/*
+ * Axlf xclbin download flow on user pf:
+ *   1) after xclbin validation, remove all URP subdevs;
+ *   2) cache mem_topology first (see comments);
+ *   3) request peer(aka. mgmt pf to do real download);
+ *   4) cache and create subdevs, including URP subdevs;
+ *   5) if fail, set uuid to NULL to allow next download;
+ * TODO: ignoring errors for 4) now, need more justification.
+ */
+static int __icap_download_bitstream_user(struct platform_device *pdev,
 	struct axlf *xclbin)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
-	int err = 0, i = 0, num_dev = 0;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
-	struct xocl_subdev *subdevs = NULL;
+	int err = 0;
+
+	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+
+	/* TODO: link this comment to specific fuction in xocl_ioctl.c */
+	/* has to create mem topology even with failure case
+	 * please refer the comment in xocl_ioctl.c
+	 * without creating mem topo, memory corruption could happen
+	 */
+	icap_cache_bitstream_axlf_section(pdev, xclbin, MEM_TOPOLOGY);
+
+	err = __icap_peer_xclbin_download(icap, xclbin);
+
+	/* TODO: Remove this after new KDS replace the legacy one */
+	/*
+	 * xclbin download changes PR region, make sure next
+	 * ERT configure cmd will go through
+	 */
+	if (!kds_mode)
+		(void) xocl_exec_reconfig(xdev);
+	if (err)
+		goto done;
+
+	/* TODO: ignoring any return value or just -ENODEV? */
+	icap_cache_bitstream_axlf_section(pdev, xclbin, IP_LAYOUT);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, CONNECTIVITY);
+	icap_cache_bitstream_axlf_section(pdev, xclbin,
+		DEBUG_IP_LAYOUT);
+	icap_cache_clock_freq_topology(icap, xclbin);
+
+	icap_create_subdev_ip_layout(pdev);
+	icap_create_subdev_cu(pdev);
+	icap_create_subdev_debugip(pdev);
+
+	icap_cache_max_host_mem_aperture(icap);
+
+	/* Initialize Group Topology and Group Connectivity */
+	icap_cache_bitstream_axlf_section(pdev, xclbin, ASK_GROUP_TOPOLOGY);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, ASK_GROUP_CONNECTIVITY);
+
+	icap_probe_urpdev_all(pdev, xclbin);
+	xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
+done:
+	if (err) {
+		uuid_copy(&icap->icap_bitstream_uuid, &uuid_null);
+	} else {
+		/* Remember "this" bitstream, so avoid redownload next time. */
+		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
+	}
+	return err;
+}
+
+/*
+ * Axlf xclbin download flow on mgmt pf:
+ *    1) after xclbin validation, freeze(isolate) xmc;
+ *    2) save calib;
+ *    3) remove all URP subdevs;
+ *    4) save retation flag before caching mem_topology and ip_layout;
+ *    5) verify signed signature;
+ *    6) reconfig clock;
+ *    7) reset ddr pin for retention only;
+ *    8) perform icap download for non-flat design;
+ *    9) create SRSR subdev;
+ *    10) create CLOCK subdev, reconfig clock;
+ *    11) perform mig calibration;
+ *    12) create subdev ip_layout;
+ *    13) create subdev dna;
+ *    14) create subdev from xclbin;
+ *    15) create URP subdevs;
+ *    16) free xmc;
+ * NOTE: any steps above can fail, return err and set uuid to NULL.
+ */
+static int __icap_download_bitstream_mgmt(struct platform_device *pdev,
+	struct axlf *xclbin)
+{
+	struct icap *icap = platform_get_drvdata(pdev);
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	bool sref = false;
+	int err = 0;
 
-	BUG_ON(!mutex_is_locked(&icap->icap_lock));
-
-	ICAP_INFO(icap, "incoming xclbin: %pUb\non device xclbin: %pUb",
-		&xclbin->m_header.uuid, &icap->icap_bitstream_uuid);
-
-	/* NOTE: xmc freeze -> xclbin download -> xmc free */
 	err = icap_xmc_freeze(icap);
 	if (err)
 		return err;
 
+	/* TODO: why void, ignoring any errors */
 	icap_save_calib(icap);
 
+	/* remove any URP subdev before downloading xclbin */
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
-	icap_refresh_addrs(pdev);
 
-	icap_probe_urpdev(pdev, xclbin, &num_dev, &subdevs);
+	/* Check the incoming mem topoloy with the current one before overwrite */
+	sref = check_mem_topo_and_data_retention(icap, xclbin);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, MEM_TOPOLOGY);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, IP_LAYOUT);
 
-	if (ICAP_PRIVILEGED(icap)) {
-		if (XOCL_DSA_IS_VERSAL(xdev))
-			return 0;
+	err = __icap_xclbin_download(icap, xclbin, sref);
+	if (err)
+		goto done;
 
-		/* Check the incoming mem topoloy with the current one before overwrite */
-		sref = check_mem_topo_and_data_retention(icap, xclbin);
+	err = icap_create_subdev_ip_layout(pdev);
+	if (err)
+		goto done;
 
-		icap_parse_bitstream_axlf_section(pdev, xclbin, MEM_TOPOLOGY);
-		icap_parse_bitstream_axlf_section(pdev, xclbin, IP_LAYOUT);
-
-		err = __icap_xclbin_download(icap, xclbin, sref);
-		if (err)
-			goto done;
-
-		/* reconfig mig and dna after calibrate_mig */
-		err = icap_verify_bitstream_axlf(pdev, xclbin);
-		if (err)
-			goto done;
-	} else {
-		/* has to create mem topology even with failure case
-		 * please refer the comment in xocl_ioctl.c
-		 * without creating mem topo, memory corruption could happen
-		 */
-		icap_parse_bitstream_axlf_section(pdev, xclbin, MEM_TOPOLOGY);
-
-		err = __icap_peer_xclbin_download(icap, xclbin);
-
-		/* TODO: Remove this after new KDS replace the legacy one */
-		/*
-		 * xclbin download changes PR region, make sure next
-		 * ERT configure cmd will go through
-		 */
-		if (!kds_mode)
-			(void) xocl_exec_reconfig(xdev);
-		if (err)
-			goto done;
-
-		icap_parse_bitstream_axlf_section(pdev, xclbin, IP_LAYOUT);
-		icap_parse_bitstream_axlf_section(pdev, xclbin, CONNECTIVITY);
-		icap_parse_bitstream_axlf_section(pdev, xclbin,
-			DEBUG_IP_LAYOUT);
-		xclbin_setup_clock_freq_topology(icap, xclbin);
-
-		if (!XOCL_DSA_IS_VERSAL(xdev)) {
-			/*
-			 * not really doing verification, but
-			 * just create subdevs
-			 */
-			(void) icap_verify_bitstream_axlf(pdev, xclbin);
-		}
-
-		icap_get_max_host_mem_aperture(icap);
-
-	}
+	err = icap_create_subdev_dna(pdev, xclbin);
+	if (err)
+		goto done;
 
 	/* Initialize Group Topology and Group Connectivity */
-	icap_parse_bitstream_axlf_section(pdev, xclbin, ASK_GROUP_TOPOLOGY);
-	icap_parse_bitstream_axlf_section(pdev, xclbin, ASK_GROUP_CONNECTIVITY);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, ASK_GROUP_TOPOLOGY);
+	icap_cache_bitstream_axlf_section(pdev, xclbin, ASK_GROUP_CONNECTIVITY);
 
-	/* create the rest of subdevs for both mgmt and user pf */
-	if (num_dev > 0) {
-		for (i = 0; i < num_dev; i++)
-			(void) xocl_subdev_create(xdev, &subdevs[i].info);
-
-		xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
-	}
+	icap_probe_urpdev_all(pdev, xclbin);
+	xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
 	/* Only when everything has been successfully setup, then enable xmc */
 	if (!err)
@@ -2494,8 +2560,29 @@ done:
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 	}
 	return err;
+
 }
 
+static int __icap_download_bitstream_axlf(struct platform_device *pdev,
+	struct axlf *xclbin)
+{
+	struct icap *icap = platform_get_drvdata(pdev);
+
+	BUG_ON(!mutex_is_locked(&icap->icap_lock));
+
+	ICAP_INFO(icap, "incoming xclbin: %pUb\non device xclbin: %pUb",
+		&xclbin->m_header.uuid, &icap->icap_bitstream_uuid);
+
+	return ICAP_PRIVILEGED(icap) ?
+		__icap_download_bitstream_mgmt(pdev, xclbin) :
+		__icap_download_bitstream_user(pdev, xclbin);
+}
+
+/*
+ * Both icap user and mgmt subdev call into this function, it should
+ * only perform common validation, then call into different function
+ * for user icap or mgmt icap.
+ */
 static int icap_download_bitstream_axlf(struct platform_device *pdev,
 	const void *u_xclbin)
 {
@@ -2571,7 +2658,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 done:
 	mutex_unlock(&icap->icap_lock);
 	icap_xclbin_wr_unlock(icap);
-	ICAP_INFO(icap, "%s err: %d", __func__, err);
+	ICAP_INFO(icap, "err: %d", err);
 	return err;
 }
 
@@ -2723,7 +2810,7 @@ done:
 	return 0;
 }
 
-static int icap_parse_bitstream_axlf_section(struct platform_device *pdev,
+static int icap_cache_bitstream_axlf_section(struct platform_device *pdev,
 	const struct axlf *xclbin, enum axlf_section_kind kind)
 {
 	struct icap *icap = platform_get_drvdata(pdev);
@@ -2795,9 +2882,11 @@ done:
 			vfree(*target);
 			*target = NULL;
 		}
-		ICAP_INFO(icap, "skip kind %d, return code %ld", kind, err);
+		ICAP_INFO(icap, "skip kind %d(%s), return code %ld", kind,
+			xrt_xclbin_kind_to_string(kind), err);
 	} else
-		ICAP_INFO(icap, "found kind %d", kind);
+		ICAP_INFO(icap, "found kind %d(%s)", kind,
+			xrt_xclbin_kind_to_string(kind));
 	return err;
 }
 


### PR DESCRIPTION
> Design:
I would request this code clean up effort for now. Tested on U200, U50 and versal. 
The final goal is a little ambiguity (having icap user subdev for 2.0 shell only).
I have code changed, but facing clean design for handling:
    1) where do we put the sysfs nodes;
    2) mailbox between new icap_user and icap_mgmt;
    3) compatible with legacy icap subdevs (non-2.0 vs. 2.0);
I could take longer time to clean up all those items. But I feel that the current icap code could be cleaned up a little bit,
after chatting with Lizhi and Max, Chienwei. I would first just split axlf download procedure for user and mgmt. 

> Testing: 
Need to borrow a U250 env 
