### PR TITLE
XRT-653 fixing bsp names for PU1 release (edge rpm creation script)

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -41,7 +41,7 @@ install_recipes()
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src\"" >> $XRT_BB
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
-        echo 'PV = "202010.2.6.0"' >> $XRT_BB
+        echo 'PV = "202010.2.7.0"' >> $XRT_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB
         echo 'LIC_FILES_CHKSUM = "file://../LICENSE;md5=da5408f748bce8a9851dac18e66f4bcf \' >> $XRT_BB
         echo '                    file://runtime_src/core/edge/drm/zocl/LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8 "' >> $XRT_BB
@@ -53,7 +53,7 @@ install_recipes()
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
         echo "EXTERNALSRC_BUILD = \"$XRT_REPO_DIR/src/runtime_src/core/edge/drm/zocl\"" >> $ZOCL_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $ZOCL_BB
-        echo 'PV = "202010.2.6.0"' >> $ZOCL_BB
+        echo 'PV = "202010.2.7.0"' >> $ZOCL_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $ZOCL_BB
         echo 'LIC_FILES_CHKSUM = "file://LICENSE;md5=7d040f51aae6ac6208de74e88a3795f8"' >> $ZOCL_BB
         echo 'pkg_postinst_ontarget_${PN}() {' >> $ZOCL_BB

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -141,13 +141,13 @@ fi
 source $PETALINUX/settings.sh 
 
 if [[ $AARCH = $aarch64_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.2-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.1-final.bsp"
     YOCTO_MACHINE="zynqmp-generic"
 elif [[ $AARCH = $aarch32_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.2-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.1-final.bsp"
     YOCTO_MACHINE="zynq-generic"
 elif [[ $AARCH = $versal_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-vck190-emmc-es1-v2020.2-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-vck190-emmc-v2020.1-final.bsp"
     YOCTO_MACHINE="versal-generic"
 else
     error "$AARCH not exist"

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,1 @@
-PETALINUX="/proj/petalinux/2020.2/petalinux-v2020.2_0615_1/tool/petalinux-v2020.2-final"
+PETALINUX="/proj/petalinux/2020.1/petalinux-v2020.1_daily_latest/tool/petalinux-v2020.1-final"


### PR DESCRIPTION
Fixing BSP names in build_edge.sh for PU1 release.
This script is consumed by DevOps to build RPMs for 2020.1_PU1 release