### PR TITLE
regression introduced due to #3622, name typo of XVC_PRI and XVC_PUB

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -335,7 +335,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.id = XOCL_SUBDEV_XVC_PRI,
 		.dev_name = XOCL_XVC_PRI,
 		.res_array = (struct xocl_subdev_res[]) {
-			{.res_name = NODE_XVC_PUB},
+			{.res_name = NODE_XVC_PRI},
 			{NULL},
 		},
 		.required_ip = 1,
@@ -347,7 +347,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.id = XOCL_SUBDEV_SYSMON,
 		.dev_name = XOCL_SYSMON,
 		.res_array = (struct xocl_subdev_res[]) {
-			{.res_name = NODE_XVC_PUB},
+			{.res_name = NODE_SYSMON},
 			{NULL},
 		},
 		.required_ip = 1,


### PR DESCRIPTION
Thanks to Pranjal, he found that there are two name error which might cause the subdevs not being created.

https://github.com/Xilinx/XRT/pull/3622

