### PR TITLE
Adding Ubuntu 20.04 kernel version to remove warning

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -108,7 +108,7 @@ static bool
 is_supported_kernel_version(std::ostream &ostr)
 {
     std::vector<std::string> ubuntu_kernel_versions =
-        { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0" };
+        { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0", "5.4.0" };
     std::vector<std::string> centos_rh_kernel_versions =
         { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.18.0-147" };
     const std::string os = sensor_tree::get<std::string>("system.linux", "N/A");


### PR DESCRIPTION
> Added linux kernel version 5.4 to remove warning message in xbutil commands