### PR TITLE
CR-1070070 : Increased XRT driver max device support to 24 from 16 

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -179,7 +179,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define	ICAP_XCLBIN_V2		"xclbin2"
 #define XOCL_CDEV_DIR		"xfpga"
 
-#define XOCL_MAX_DEVICES	16
+#define XOCL_MAX_DEVICES	24
 #define XOCL_EBUF_LEN           512
 #define xocl_sysfs_error(xdev, fmt, args...)     \
 		snprintf(((struct xocl_dev_core *)xdev)->ebuf, XOCL_EBUF_LEN,	\


### PR DESCRIPTION
Current Driver support max 16 device. i.e. XOCL_MAX_DEVICES       16
Changed it to 24 devices as Samsung will be verifying with 24 devices. 