### PR TITLE
NSRP-1387 Use GROUP_TOPOLOGY and GROUP_CONNECTIVITY

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -756,7 +756,7 @@ public:
     auto ip_layout = reinterpret_cast<const ::ip_layout*>(ip_section.first);
 
     // connectivity section for CU memory connectivity, permissible for section to not exist
-    auto connectivity_section = device->core_device->get_axlf_section(CONNECTIVITY, xclbin_id);
+    auto connectivity_section = device->core_device->get_axlf_section(ASK_GROUP_CONNECTIVITY, xclbin_id);
     auto connectivity = reinterpret_cast<const ::connectivity*>(connectivity_section.first);
 
     // xml section for kernel arguments

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -20,8 +20,22 @@
 
 #include "shim.h"
 #include "system_swemu.h"
+#include "xclbin.h"
 #include <errno.h>
 #include <unistd.h>
+
+namespace {
+
+static auto
+get_mem_topology(const axlf* top)
+{
+  if (auto sec = xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
+    return sec;
+  return xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+}
+  
+}
+
 namespace xclcpuemhal2 {
 
   std::map<unsigned int, CpuemShim*> devices;
@@ -528,7 +542,7 @@ namespace xclcpuemhal2 {
           sharedlib = xclbininmemory + sec->m_sectionOffset;
           sharedliblength = sec->m_sectionSize;
         }
-        if (auto sec = xclbin::get_axlf_section(top,MEM_TOPOLOGY)) {
+        if (auto sec = get_mem_topology(top)) {
           memTopologySize = sec->m_sectionSize;
           memTopology = new char[memTopologySize];
           memcpy(memTopology, xclbininmemory + sec->m_sectionOffset, memTopologySize);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -20,8 +20,22 @@
 
 #include "shim.h"
 #include "system_swemu.h"
+#include "xclbin.h"
 #include <errno.h>
 #include <unistd.h>
+
+namespace {
+
+static auto
+get_mem_topology(const axlf* top)
+{
+  if (auto sec = xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
+    return sec;
+  return xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+}
+  
+}
+
 namespace xclcpuemhal2 {
 
   std::map<unsigned int, CpuemShim*> devices;
@@ -528,7 +542,7 @@ namespace xclcpuemhal2 {
           sharedlib = xclbininmemory + sec->m_sectionOffset;
           sharedliblength = sec->m_sectionSize;
         }
-        if (auto sec = xclbin::get_axlf_section(top,MEM_TOPOLOGY)) {
+        if (auto sec = get_mem_topology(top)) {
           memTopologySize = sec->m_sectionSize;
           memTopology = new char[memTopologySize];
           memcpy(memTopology, xclbininmemory + sec->m_sectionOffset, memTopologySize);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -16,6 +16,7 @@
 
 #include "shim.h"
 #include "system_hwemu.h"
+#include "xclbin.h"
 #include <string.h>
 #include <boost/property_tree/xml_parser.hpp>
 #include <errno.h>
@@ -33,6 +34,14 @@ file_exists(const std::string& fnm)
   return stat(fnm.c_str(), &statBuf) == 0;
 }
   
+static auto
+get_mem_topology(const axlf* top)
+{
+  if (auto sec = xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
+    return sec;
+  return xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+}
+
 }
 
 namespace xclhwemhal2 {
@@ -198,7 +207,7 @@ namespace xclhwemhal2 {
       debugFile = new char[debugFileSize];
       memcpy(debugFile, bitstreambin + sec->m_sectionOffset, debugFileSize);
     }
-    if (auto sec = xclbin::get_axlf_section(top, MEM_TOPOLOGY)) {
+    if (auto sec = get_mem_topology(top)) {
       memTopologySize = sec->m_sectionSize;
       memTopology = new char[memTopologySize];
       memcpy(memTopology, bitstreambin + sec->m_sectionOffset, memTopologySize);

--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -401,7 +401,7 @@ validate_cus(const device* device, unsigned long argidx, int memidx) const
     auto cu = (*itr);
     auto cuconn = cu->get_memidx(argidx);
     if ((cuconn & connections).none()) {
-      auto mem = device->get_axlf_section<const mem_topology*>(MEM_TOPOLOGY);
+      auto mem = device->get_axlf_section<const mem_topology*>(ASK_GROUP_TOPOLOGY);
       xrt::message::send
         (xrt::message::severity_level::XRT_WARNING
          , "Argument '" + std::to_string(argidx)

--- a/src/runtime_src/xocl/xclbin/xclbin.cpp
+++ b/src/runtime_src/xocl/xclbin/xclbin.cpp
@@ -689,8 +689,8 @@ class xclbin_data_sections
 
 public:
   xclbin_data_sections(const xrt_core::device* device, const xrt_core::uuid& uuid)
-    : m_con(get_xclbin_section<const ::connectivity*>(device, CONNECTIVITY, uuid))
-    , m_mem(get_xclbin_section<const ::mem_topology*>(device, MEM_TOPOLOGY, uuid))
+    : m_con(get_xclbin_section<const ::connectivity*>(device, ASK_GROUP_CONNECTIVITY, uuid))
+    , m_mem(get_xclbin_section<const ::mem_topology*>(device, ASK_GROUP_TOPOLOGY, uuid))
     , m_ip (get_xclbin_section<const ::ip_layout*>(device, IP_LAYOUT, uuid))
   {
     // populate mem bank


### PR DESCRIPTION
Use new sections for checking connectivity and acquiring group bank
index.  For legacy xclbins, or xclbins without grouping, the group
sections are same as MEM_TOPOLOGY and CONNECTIVITY.

This PR requires #3700