### PR TITLE
Host mem check for allocBo in sw emu

### DIFF
--- a/src/runtime_src/core/edge/common_em/em_defines.h
+++ b/src/runtime_src/core/edge/common_em/em_defines.h
@@ -150,6 +150,11 @@ namespace xclemulation {
     return (bo->flags & XCL_BO_FLAGS_DEV_ONLY);
   }
 
+  static inline bool xocl_bo_host_only(const struct drm_xocl_bo *bo)
+  {
+    return (bo->flags & XCL_BO_FLAGS_HOST_ONLY);
+  }  
+
   static inline bool no_host_memory(const struct drm_xocl_bo *bo)
   {
     return xocl_bo_dev_only(bo) || xocl_bo_p2p(bo) ;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -1174,7 +1174,7 @@ uint64_t CpuemShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
   auto xobj = std::make_unique<xclemulation::drm_xocl_bo>();
   xobj->flags=info->flags;
   /* check whether buffer is p2p or not*/
-  bool noHostMemory = xclemulation::no_host_memory(xobj.get());
+  bool noHostMemory = xclemulation::no_host_memory(xobj.get()) || xclemulation::xocl_bo_host_only(xobj.get()); 
   std::string sFileName("");
   xobj->base = xclAllocDeviceBuffer2(size,XCL_MEM_DEVICE_RAM,ddr,noHostMemory,sFileName);
   xobj->filename = sFileName;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/swscheduler.cxx
@@ -1,6 +1,6 @@
 #include "shim.h"
 #include <algorithm>
-#define EM_DEBUG_KDS
+//#define EM_DEBUG_KDS
 #define PRINTSTARTFUNC
 //#define PRINTSTARTFUNC std::cout <<"swscheduler: " <<__func__ << " begin " << std::endl;
 namespace xclcpuemhal2 {

--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -150,6 +150,11 @@ namespace xclemulation {
     return (bo->flags & XCL_BO_FLAGS_DEV_ONLY);
   }
 
+  static inline bool xocl_bo_host_only(const struct drm_xocl_bo *bo)
+  {
+    return (bo->flags & XCL_BO_FLAGS_HOST_ONLY);
+  }  
+
   static inline bool no_host_memory(const struct drm_xocl_bo *bo)
   {
     return xocl_bo_dev_only(bo) || xocl_bo_p2p(bo) ;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1178,7 +1178,7 @@ uint64_t CpuemShim::xoclCreateBo(xclemulation::xocl_create_bo* info)
   auto xobj = std::make_unique<xclemulation::drm_xocl_bo>();
   xobj->flags=info->flags;
   /* check whether buffer is p2p or not*/
-  bool noHostMemory = xclemulation::no_host_memory(xobj.get());
+  bool noHostMemory = xclemulation::no_host_memory(xobj.get()) || xclemulation::xocl_bo_host_only(xobj.get()); 
   std::string sFileName("");
   xobj->base = xclAllocDeviceBuffer2(size,XCL_MEM_DEVICE_RAM,ddr,noHostMemory,sFileName);
   xobj->filename = sFileName;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
@@ -1,6 +1,6 @@
 #include "shim.h"
 #include <algorithm>
-#define EM_DEBUG_KDS
+//#define EM_DEBUG_KDS
 #define PRINTSTARTFUNC
 //#define PRINTSTARTFUNC std::cout <<"swscheduler: " <<__func__ << " begin " << std::endl;
 namespace xclcpuemhal2 {


### PR DESCRIPTION
Host mem check for allocBo in sw emu. Ran vitis canary with this change, all tests are passing and could not seen any issue with this change.
