### PR TITLE
CR-1071207 Fix XRT/ZOCL build fail for versal platforms

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -18,6 +18,7 @@
 
 #include "aie.h"
 #include "core/common/error.h"
+#include "core/common/message.h"
 
 #include <iostream>
 #include <cerrno>

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -20,6 +20,7 @@
 #include "core/edge/user/shim.h"
 #include "core/include/experimental/xrt_aie.h"
 #include "core/common/error.h"
+#include "core/common/message.h"
 
 #include <iostream>
 #include <chrono>


### PR DESCRIPTION
> Added the missing include file in aie.cpp and graph.cpp