### PR TITLE
qdma4: disable slave bridge bdf programming for now

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/stmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/stmc.c
@@ -566,7 +566,6 @@ int stmc_req_bypass_desc_fill(void *qhndl, enum qdma_q_mode q_mode,
 	unsigned int data_cnt = 0;
 	unsigned int desc_used = 0;
 	unsigned int desc_avail;
-	bool sop;
 	int i, rv;
 
 	if ((q_mode != QDMA_Q_MODE_ST) || (q_dir != QDMA_Q_DIR_H2C)) {
@@ -581,11 +580,11 @@ int stmc_req_bypass_desc_fill(void *qhndl, enum qdma_q_mode q_mode,
 	if (i < 0) 
 		return -EINVAL;
 
-	sop = (i == 0 && sg_offset == 0);
 
 	desc_avail = qdma_q_desc_avail_count(qhndl);
 
 	for (; i < sg_max; i++, sg++) {
+		bool sop = (i == 0 && sg_offset == 0);
 		struct qdma_q_desc_list *qdesc_head = NULL;
 		struct qdma_q_desc_list *qdesc = NULL;
 		struct stmc_h2c_desc *desc;
@@ -609,6 +608,7 @@ int stmc_req_bypass_desc_fill(void *qhndl, enum qdma_q_mode q_mode,
                                 return 0;
                 }
 
+		desc = qdesc_head->desc;
                 for (j = 0, qdesc = qdesc_head; j < desc_cnt; j++,
 			qdesc = qdesc->next) {
 			unsigned int len = min_t(unsigned int, tlen,
@@ -617,7 +617,7 @@ int stmc_req_bypass_desc_fill(void *qhndl, enum qdma_q_mode q_mode,
                         desc = qdesc->desc;
                         desc->flags = 0;
 
-			if (!desc_cnt && sop)
+			if (sop && j == 0)
 				desc->flags |= S_H2C_DESC_F_SOP;
 
 			desc->src_addr = addr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -1908,17 +1908,6 @@ static int qdma4_probe(struct platform_device *pdev)
 		return -EINVAL;
 	}
 
-	if (csr_bar >= 0) {
-		ret = qdma4_csr_prog_ta(XDEV(xdev)->pdev, csr_bar, csr_base);
-		if (ret < 0)
-			xocl_err(&pdev->dev,
-				"BDF table program failed, slave bridge may NOT work.");
-		else
-			xocl_info(&pdev->dev,
-				"BDF table program set up successful (%d,0x%lx).",
-				csr_bar, (unsigned long)csr_base);
-	}
-
 	conf = &qdma->dev_conf;
 	memset(conf, 0, sizeof(*conf));
 	conf->pdev = XDEV(xdev)->pdev;
@@ -1946,8 +1935,27 @@ static int qdma4_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
+	if (csr_bar >= 0) {
+		xocl_info(&pdev->dev, "csr bar %d, base 0x%lx.",
+			 csr_bar, (unsigned long)csr_base);
+
+#if 0
+		ret = qdma4_csr_prog_ta(XDEV(xdev)->pdev, csr_bar, csr_base);
+		if (ret < 0)
+			xocl_err(&pdev->dev,
+				"BDF table program failed, slave bridge may NOT work.");
+		else
+			xocl_info(&pdev->dev,
+				"BDF table program set up successful (%d,0x%lx).",
+				csr_bar, (unsigned long)csr_base);
+#endif
+	}
+
 	if (stm_bar >= 0) {
 		struct stmc_dev *sdev = &qdma->stm_dev;
+
+		xocl_info(&pdev->dev, "stm bar %d, base 0x%lx.",
+			 stm_bar, (unsigned long)stm_base);
 
 		sdev->reg_base = stm_base;
 		sdev->bar_num = stm_bar;


### PR DESCRIPTION
disable the feature until it is verified working with MM-only platform.