### PR TITLE
NSPR-6216 XRT support on RHEL/CentOs 8.2

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -344,7 +344,8 @@ static int p2p_mem_chunk_reserve(struct p2p *p2p, struct p2p_mem_chunk *chk)
 	} else {
 		chk->xpmc_pgmap.res = res;
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0) && \
+	RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 2)
 		chk->xpmc_pgmap.ref = pref;
 		chk->xpmc_pgmap.altmap_valid = false;
 #else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -223,7 +223,11 @@ int xocl_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #ifdef RHEL_RELEASE_VERSION
 		pfn_t pfn;
 		pfn = phys_to_pfn_t(page_to_phys(xobj->pages[page_offset]), PFN_MAP|PFN_DEV);
+#if RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 2)
 		ret = vm_insert_mixed(vma, vmf_address, pfn);
+#else
+		ret = vmf_insert_mixed(vma, vmf_address, pfn);
+#endif
 #else
 		ret = vm_insert_page(vma, vmf_address, xobj->pages[page_offset]);
 #endif
@@ -234,7 +238,7 @@ int xocl_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) || defined(RHEL_RELEASE_VERSION)
 		pfn_t pfn;
 		pfn = phys_to_pfn_t(page_to_phys(xobj->pages[page_offset]), PFN_MAP);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 2)
 		ret = vmf_insert_mixed(vma, vmf_address, pfn);
 #else
 		ret = vm_insert_mixed(vma, vmf_address, pfn);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -110,7 +110,7 @@ is_supported_kernel_version(std::ostream &ostr)
     std::vector<std::string> ubuntu_kernel_versions =
         { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0", "5.4.0" };
     std::vector<std::string> centos_rh_kernel_versions =
-        { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.18.0-147" };
+        { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.18.0-147", "4.18.0-193" };
     const std::string os = sensor_tree::get<std::string>("system.linux", "N/A");
 
     if(os.find("Ubuntu") != std::string::npos)


### PR DESCRIPTION
> Made changes to build userspace and kernel code.
> Added kernel version of Rhel/Centos 8.2 in supported kernel version list.