### PR TITLE
CR-1059337 add subdev icap_controller

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -224,6 +224,8 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/subdev/cu.c
   xocl/subdev/p2p.c
   xocl/subdev/pmc.c
+  xocl/subdev/icap_cntrl.c
+  xocl/subdev/version_ctrl.c
   xocl/Makefile
   )
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -240,11 +240,14 @@ enum {
 #define	XOCL_CU			"cu"
 #define	XOCL_P2P		"p2p"
 #define	XOCL_PMC		"pmc"
+#define	XOCL_ICAP_CNTRL		"icap_controller"
+#define	XOCL_VERSION_CTRL	"version_control"
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
 enum subdev_id {
 	XOCL_SUBDEV_FEATURE_ROM,
+	XOCL_SUBDEV_VERSION_CTRL,
 	XOCL_SUBDEV_AXIGATE,
 	XOCL_SUBDEV_DMA,
 	XOCL_SUBDEV_IORES,
@@ -283,6 +286,7 @@ enum subdev_id {
 	XOCL_SUBDEV_LAPC,
 	XOCL_SUBDEV_SPC,
 	XOCL_SUBDEV_PMC,
+	XOCL_SUBDEV_ICAP_CNTRL,
 	XOCL_SUBDEV_NUM
 };
 
@@ -319,6 +323,24 @@ struct xocl_subdev_map {
 		XOCL_FEATURE_ROM,			\
 		XOCL_RES_FEATURE_ROM,			\
 		ARRAY_SIZE(XOCL_RES_FEATURE_ROM),	\
+		.override_idx = -1,			\
+	}
+
+#define	XOCL_RES_VERSION_CTRL			\
+		((struct resource []) {			\
+			{				\
+			.start	= 0x0330000,		\
+			.end	= 0x0330010,		\
+			.flags	= IORESOURCE_MEM,	\
+			}				\
+		})
+
+#define	XOCL_DEVINFO_VERSION_CTRL		\
+	{						\
+		XOCL_SUBDEV_VERSION_CTRL,		\
+		XOCL_VERSION_CTRL,			\
+		XOCL_RES_VERSION_CTRL,		\
+		ARRAY_SIZE(XOCL_RES_VERSION_CTRL),	\
 		.override_idx = -1,			\
 	}
 
@@ -1312,13 +1334,6 @@ struct xocl_subdev_map {
 	.flags	= IORESOURCE_MEM,	\
 	}				\
 
-#define __RES_VERSION_CTRL		\
-	{				\
-	.start	= 0x0330000,		\
-	.end	= 0x03300ff,		\
-	.flags	= IORESOURCE_MEM,	\
-	}				\
-
 #define __RES_XMC_GPIO			\
 	{				\
 	.start	= 0x0132000,		\
@@ -1359,7 +1374,6 @@ struct xocl_subdev_map {
 		((struct resource []) {			\
 			__RES_XMC,			\
 			__RES_XMC_SCALING,		\
-			__RES_VERSION_CTRL,		\
 			__RES_XMC_GPIO,			\
 		})
 
@@ -1535,6 +1549,24 @@ struct xocl_subdev_map {
 	{						\
 		.id = XOCL_SUBDEV_P2P,			\
 		.name = XOCL_P2P,			\
+		.override_idx = -1,			\
+	}
+
+#define XOCL_RES_ICAP_CNTRL				\
+	((struct resource []) {				\
+		{					\
+			.start = 0x380000,		\
+			.end = 0x38000F,		\
+			.flags = IORESOURCE_MEM,	\
+		},					\
+	 })
+
+#define	XOCL_DEVINFO_ICAP_CNTRL			\
+	{						\
+		XOCL_SUBDEV_ICAP_CNTRL,			\
+		XOCL_ICAP_CNTRL,			\
+		XOCL_RES_ICAP_CNTRL,			\
+		ARRAY_SIZE(XOCL_RES_ICAP_CNTRL),	\
 		.override_idx = -1,			\
 	}
 
@@ -1827,6 +1859,7 @@ struct xocl_subdev_map {
 #define	USER_RES_DSA52_U2						\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
+			XOCL_DEVINFO_VERSION_CTRL,			\
 			XOCL_DEVINFO_XDMA,				\
 			XOCL_DEVINFO_SCHEDULER,				\
 			XOCL_DEVINFO_MAILBOX_USER,			\
@@ -1963,6 +1996,7 @@ struct xocl_subdev_map {
 #define	MGMT_RES_U2						\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
+			XOCL_DEVINFO_VERSION_CTRL,			\
 			XOCL_DEVINFO_PRP_IORES_MGMT,			\
 			XOCL_DEVINFO_AXIGATE_ULP,			\
 			XOCL_DEVINFO_CLOCK_LEGACY,			\
@@ -1975,6 +2009,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_FMGR,				\
 			XOCL_DEVINFO_XMC_SCALING_U2,			\
 			XOCL_DEVINFO_FLASH,				\
+			XOCL_DEVINFO_ICAP_CNTRL,			\
 		})
 
 #define	XOCL_BOARD_MGMT_DEFAULT						\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
 #
 # Authors:
 #
@@ -72,6 +72,8 @@ xclmgmt-y := \
 	../subdev/ulite.o \
 	../subdev/calib_storage.o \
 	../subdev/pmc.o \
+	../subdev/icap_cntrl.o \
+	../subdev/version_ctrl.o \
 	$(drv_common-y) \
 	mgmt-core.o \
 	mgmt-cw.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1385,6 +1385,7 @@ static struct pci_driver xclmgmt_driver = {
 
 static int (*drv_reg_funcs[])(void) __initdata = {
 	xocl_init_feature_rom,
+	xocl_init_version_control,
 	xocl_init_iores,
 	xocl_init_flash,
 	xocl_init_mgmt_msix,
@@ -1410,10 +1411,12 @@ static int (*drv_reg_funcs[])(void) __initdata = {
 	xocl_init_ulite,
 	xocl_init_calib_storage,
 	xocl_init_pmc,
+	xocl_init_icap_controller,
 };
 
 static void (*drv_unreg_funcs[])(void) = {
 	xocl_fini_feature_rom,
+	xocl_fini_version_control,
 	xocl_fini_iores,
 	xocl_fini_flash,
 	xocl_fini_mgmt_msix,
@@ -1439,6 +1442,7 @@ static void (*drv_unreg_funcs[])(void) = {
 	xocl_fini_ulite,
 	xocl_fini_calib_storage,
 	xocl_fini_pmc,
+	xocl_fini_icap_controller,
 };
 
 static int __init xclmgmt_init(void)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap_cntrl.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: Rajkumar Rampelli <rajkumar@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "../xocl_drv.h"
+#include <linux/iommu.h>
+
+#define ICAP_PROGRAMMING_REG		0x0
+#define ICAP_PROGRAMMING_REG_ENABLE	0x1
+
+#define	READ_REG32(icap_cntrl, off)			\
+	(icap_cntrl->base_addr ?		\
+	XOCL_READ_REG32(icap_cntrl->base_addr + off) : 0)
+#define	WRITE_REG32(icap_cntrl, val, off)		\
+	(icap_cntrl->base_addr ?		\
+	XOCL_WRITE_REG32(val, icap_cntrl->base_addr + off) : ((void)0))
+
+struct icap_cntrl {
+	struct platform_device *pdev;
+	void __iomem *base_addr;
+	struct xocl_icap_cntrl_privdata *priv_data;
+	struct mutex icap_cntrl_lock;
+	bool sysfs_created;
+	bool support_enabled;
+};
+
+static ssize_t load_flash_addr_store(struct device *dev,
+                                     struct device_attribute *da,
+                                     const char *buf, size_t count)
+{
+	struct icap_cntrl *ic =	platform_get_drvdata(to_platform_device(dev));
+	long addr;
+
+	if (!ic->support_enabled) {
+		xocl_dbg(dev, "Icap controller programming is not supported\n");
+		return -EINVAL;
+	}
+
+	if (kstrtol(buf, 10, &addr)) {
+		xocl_err(dev, "invalid input");
+		return -EINVAL;
+	}
+
+	mutex_lock(&ic->icap_cntrl_lock);
+	WRITE_REG32(ic, addr, ICAP_PROGRAMMING_REG);
+	mutex_unlock(&ic->icap_cntrl_lock);
+
+	return count;
+}
+
+static ssize_t load_flash_addr_show(struct device *dev,
+                                    struct device_attribute *da, char *buf)
+{
+	struct icap_cntrl *ic = platform_get_drvdata(to_platform_device(dev));
+	u32 val;
+
+	if (!ic->support_enabled) {
+		xocl_dbg(dev, "Icap controller programming is not supported\n");
+		return -EINVAL;
+	}
+
+	val = READ_REG32(ic, ICAP_PROGRAMMING_REG);
+	val = val >> 4;
+
+	return sprintf(buf, "0x%x\n", val);
+}
+static DEVICE_ATTR(load_flash_addr, 0644, load_flash_addr_show,
+                   load_flash_addr_store);
+
+static ssize_t enable_store(struct device *dev, struct device_attribute *da,
+                            const char *buf, size_t count)
+{
+	struct icap_cntrl *ic = platform_get_drvdata(to_platform_device(dev));
+	long enable;
+	u32 reg = 0;
+
+	if (!ic->support_enabled) {
+		xocl_dbg(dev, "Icap controller programming is not supported\n");
+		return -EINVAL;
+	}
+
+	if (kstrtol(buf, 10, &enable)) {
+		xocl_err(dev, "invalid input");
+		return -EINVAL;
+	}
+
+	mutex_lock(&ic->icap_cntrl_lock);
+
+	reg = READ_REG32(ic, ICAP_PROGRAMMING_REG);
+	if (enable)
+		reg |= ICAP_PROGRAMMING_REG_ENABLE;
+	else
+		reg &= ~ICAP_PROGRAMMING_REG_ENABLE;
+	WRITE_REG32(ic, reg, ICAP_PROGRAMMING_REG);
+
+	mutex_unlock(&ic->icap_cntrl_lock);
+
+	return count;
+}
+
+static ssize_t enable_show(struct device *dev,
+                           struct device_attribute *da, char *buf)
+{
+	struct icap_cntrl *ic = platform_get_drvdata(to_platform_device(dev));
+	u32 val;
+
+	if (!ic->support_enabled) {
+		xocl_dbg(dev, "Icap controller programming is not supported\n");
+		return -EINVAL;
+	}
+
+	val = READ_REG32(ic, ICAP_PROGRAMMING_REG);
+	val = val & ICAP_PROGRAMMING_REG_ENABLE;
+
+	return sprintf(buf, "%d\n", val);
+}
+static DEVICE_ATTR(enable, 0644, enable_show, enable_store);
+
+static struct attribute *icap_cntrl_attrs[] = {
+	&dev_attr_enable.attr,
+	&dev_attr_load_flash_addr.attr,
+	NULL,
+};
+
+static struct attribute_group icap_cntrl_attr_group = {
+	.attrs = icap_cntrl_attrs,
+};
+
+static void icap_cntrl_sysfs_destroy(struct icap_cntrl *icap_cntrl)
+{
+	if (!icap_cntrl->sysfs_created)
+		return;
+
+	sysfs_remove_group(&icap_cntrl->pdev->dev.kobj, &icap_cntrl_attr_group);
+	icap_cntrl->sysfs_created = false;
+}
+
+static int icap_cntrl_sysfs_create(struct icap_cntrl *ic)
+{
+	int ret;
+
+	if (ic->sysfs_created)
+		return 0;
+
+	ret = sysfs_create_group(&ic->pdev->dev.kobj, &icap_cntrl_attr_group);
+	if (ret) {
+		xocl_err(&ic->pdev->dev, "create icap_cntrl attrs failed: 0x%x", ret);
+		return ret;
+	}
+
+	ic->sysfs_created = true;
+
+	return 0;
+}
+
+static int icap_cntrl_remove(struct platform_device *pdev)
+{
+	struct icap_cntrl *icap_cntrl;
+	void *hdl;
+
+	icap_cntrl = platform_get_drvdata(pdev);
+	if (!icap_cntrl) {
+		xocl_err(&pdev->dev, "driver data is NULL");
+		return -EINVAL;
+	}
+	xocl_drvinst_release(icap_cntrl, &hdl);
+
+	icap_cntrl_sysfs_destroy(icap_cntrl);
+
+	if (icap_cntrl->base_addr)
+		iounmap(icap_cntrl->base_addr);
+
+	mutex_destroy(&icap_cntrl->icap_cntrl_lock);
+	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(hdl);
+
+	return 0;
+}
+
+static int icap_cntrl_probe(struct platform_device *pdev)
+{
+	void *xdev_hdl = xocl_get_xdev(pdev);
+	struct icap_cntrl *icap_cntrl;
+	struct resource *res;
+	int ret = 0;
+
+	icap_cntrl = xocl_drvinst_alloc(&pdev->dev, sizeof(*icap_cntrl));
+	if (!icap_cntrl) {
+		xocl_err(&pdev->dev, "failed to alloc data");
+		return -ENOMEM;
+	}
+
+	icap_cntrl->support_enabled = xocl_flat_shell_check(xdev_hdl);
+
+	if (icap_cntrl->support_enabled)
+		xocl_info(&pdev->dev, "ICAP Controller Programming is Supported");
+
+	platform_set_drvdata(pdev, icap_cntrl);
+	icap_cntrl->pdev = pdev;
+	mutex_init(&icap_cntrl->icap_cntrl_lock);
+
+	icap_cntrl->priv_data = XOCL_GET_SUBDEV_PRIV(&pdev->dev);
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	icap_cntrl->base_addr = ioremap_nocache(res->start,
+                                res->end - res->start + 1);
+	if (!icap_cntrl->base_addr) {
+		ret = -EIO;
+		xocl_err(&pdev->dev, "Map iomem failed");
+		goto failed;
+	}
+
+	ret = icap_cntrl_sysfs_create(icap_cntrl);
+	if (ret)
+		goto failed;
+
+	return 0;
+
+failed:
+	icap_cntrl_remove(pdev);
+	return ret;
+}
+
+struct platform_device_id icap_cntrl_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_ICAP_CNTRL), 0 },
+	{ },
+};
+
+static struct platform_driver	icap_cntrl_driver = {
+	.probe		= icap_cntrl_probe,
+	.remove		= icap_cntrl_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_ICAP_CNTRL),
+	},
+	.id_table = icap_cntrl_id_table,
+};
+
+int __init xocl_init_icap_controller(void)
+{
+	return platform_driver_register(&icap_cntrl_driver);
+}
+
+void xocl_fini_icap_controller(void)
+{
+	platform_driver_unregister(&icap_cntrl_driver);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/version_ctrl.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: Rajkumar Rampelli <rajkumar@xilinx.com>
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "../xocl_drv.h"
+#include <linux/iommu.h>
+
+//Version control registers
+#define VERSION_CTRL_REG                       0x0
+#define VERSION_CTRL_REG_FLAT_SHELL_MASK       0x80000000
+
+#define VERSION_CTRL_MISC_REG                  0xC
+#define VERSION_CTRL_MISC_REG_CMC_IN_BITFILE   0x2
+
+#define	READ_REG32(vc, off)		\
+	(vc->base ?		\
+	XOCL_READ_REG32(vc->base + off) : 0)
+
+struct version_ctrl {
+	struct platform_device *pdev;
+	void __iomem *base;
+	struct xocl_version_ctrl_privdata *priv_data;
+	bool sysfs_created;
+	bool			flat_shell;
+	bool			cmc_in_bitfile;
+};
+
+static bool flat_shell_check(struct platform_device *pdev)
+{
+	struct version_ctrl *vc;
+
+	vc = platform_get_drvdata(pdev);
+	BUG_ON(!vc);
+
+	return vc->flat_shell;
+}
+
+static bool cmc_in_bitfile(struct platform_device *pdev)
+{
+	struct version_ctrl *vc;
+
+	vc = platform_get_drvdata(pdev);
+	BUG_ON(!vc);
+
+	return vc->cmc_in_bitfile;
+}
+
+static ssize_t version_show(struct device *dev,
+                            struct device_attribute *da, char *buf)
+{
+	struct version_ctrl *vc = platform_get_drvdata(to_platform_device(dev));
+	u32 val;
+
+	val = READ_REG32(vc, VERSION_CTRL_REG);
+
+	return sprintf(buf, "0x%x\n", val);
+}
+static DEVICE_ATTR_RO(version);
+
+static ssize_t cmc_in_bitfile_show(struct device *dev,
+                           struct device_attribute *da, char *buf)
+{
+	struct version_ctrl *vc = platform_get_drvdata(to_platform_device(dev));
+	u32 val;
+
+	val = READ_REG32(vc, VERSION_CTRL_MISC_REG);
+
+	return sprintf(buf, "%d\n", (val & VERSION_CTRL_MISC_REG_CMC_IN_BITFILE));
+}
+static DEVICE_ATTR_RO(cmc_in_bitfile);
+
+static struct attribute *version_ctrl_attrs[] = {
+	&dev_attr_version.attr,
+	&dev_attr_cmc_in_bitfile.attr,
+	NULL,
+};
+
+static struct attribute_group version_ctrl_attr_group = {
+	.attrs = version_ctrl_attrs,
+};
+
+static void version_ctrl_sysfs_destroy(struct version_ctrl *version_ctrl)
+{
+	if (!version_ctrl->sysfs_created)
+		return;
+
+	sysfs_remove_group(&version_ctrl->pdev->dev.kobj, &version_ctrl_attr_group);
+	version_ctrl->sysfs_created = false;
+}
+
+static int version_ctrl_sysfs_create(struct version_ctrl *vc)
+{
+	int ret;
+
+	if (vc->sysfs_created)
+		return 0;
+
+	ret = sysfs_create_group(&vc->pdev->dev.kobj, &version_ctrl_attr_group);
+	if (ret) {
+		xocl_err(&vc->pdev->dev, "create version_ctrl attrs failed: 0x%x", ret);
+		return ret;
+	}
+
+	vc->sysfs_created = true;
+
+	return 0;
+}
+
+static int version_ctrl_remove(struct platform_device *pdev)
+{
+	struct version_ctrl *version_ctrl;
+	void *hdl;
+
+	version_ctrl = platform_get_drvdata(pdev);
+	if (!version_ctrl) {
+		xocl_err(&pdev->dev, "driver data is NULL");
+		return -EINVAL;
+	}
+	xocl_drvinst_release(version_ctrl, &hdl);
+
+	version_ctrl_sysfs_destroy(version_ctrl);
+
+	if (version_ctrl->base)
+		iounmap(version_ctrl->base);
+
+	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_free(hdl);
+
+	return 0;
+}
+
+static struct xocl_version_ctrl_funcs vc_ops = {
+	.flat_shell_check = flat_shell_check,
+	.cmc_in_bitfile = cmc_in_bitfile,
+};
+
+static int version_ctrl_probe(struct platform_device *pdev)
+{
+	struct version_ctrl *version_ctrl;
+	struct resource *res;
+	u32 reg;
+	int ret = 0;
+
+	version_ctrl = xocl_drvinst_alloc(&pdev->dev, sizeof(*version_ctrl));
+	if (!version_ctrl) {
+		xocl_err(&pdev->dev, "failed to alloc data");
+		return -ENOMEM;
+	}
+
+	platform_set_drvdata(pdev, version_ctrl);
+	version_ctrl->pdev = pdev;
+
+	version_ctrl->priv_data = XOCL_GET_SUBDEV_PRIV(&pdev->dev);
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	version_ctrl->base = ioremap_nocache(res->start,
+                                res->end - res->start + 1);
+	if (!version_ctrl->base) {
+		ret = -EIO;
+		xocl_err(&pdev->dev, "Map iomem failed");
+		goto failed;
+	}
+
+	reg = READ_REG32(version_ctrl, VERSION_CTRL_REG);
+	if (reg & VERSION_CTRL_REG_FLAT_SHELL_MASK)
+		version_ctrl->flat_shell = true;
+
+	reg = READ_REG32(version_ctrl, VERSION_CTRL_MISC_REG);
+	if (reg & VERSION_CTRL_MISC_REG_CMC_IN_BITFILE)
+		version_ctrl->cmc_in_bitfile = true;
+
+	ret = version_ctrl_sysfs_create(version_ctrl);
+	if (ret)
+		goto failed;
+
+	return 0;
+
+failed:
+	version_ctrl_remove(pdev);
+	return ret;
+}
+
+struct xocl_drv_private version_ctrl_priv = {
+	.ops = &vc_ops,
+};
+
+struct platform_device_id version_ctrl_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_VERSION_CTRL), (kernel_ulong_t)&version_ctrl_priv },
+	{ },
+};
+
+static struct platform_driver	version_ctrl_driver = {
+	.probe		= version_ctrl_probe,
+	.remove		= version_ctrl_remove,
+	.driver		= {
+		.name = XOCL_DEVNAME(XOCL_VERSION_CTRL),
+	},
+	.id_table = version_ctrl_id_table,
+};
+
+int __init xocl_init_version_control(void)
+{
+	return platform_driver_register(&version_ctrl_driver);
+}
+
+void xocl_fini_version_control(void)
+{
+	platform_driver_unregister(&version_ctrl_driver);
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -81,6 +81,7 @@ xocl-y := \
 	../subdev/address_translator.o \
 	../subdev/cu.o \
 	../subdev/p2p.o \
+	../subdev/version_ctrl.o \
 	$(xocl_lib-y)	\
 	$(drv_common-y) \
 	xocl_drv.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1509,6 +1509,7 @@ static struct pci_driver userpf_driver = {
 /* INIT */
 static int (*xocl_drv_reg_funcs[])(void) __initdata = {
 	xocl_init_feature_rom,
+	xocl_init_version_control,
 	xocl_init_iores,
 	xocl_init_xdma,
 	xocl_init_qdma,
@@ -1540,6 +1541,7 @@ static int (*xocl_drv_reg_funcs[])(void) __initdata = {
 
 static void (*xocl_drv_unreg_funcs[])(void) = {
 	xocl_fini_feature_rom,
+	xocl_fini_version_control,
 	xocl_fini_iores,
 	xocl_fini_xdma,
 	xocl_fini_qdma,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -551,6 +551,23 @@ struct xocl_rom_funcs {
 #define xocl_rom_get_uuid(xdev)				\
 	(ROM_CB(xdev, get_uuid) ? ROM_OPS(xdev)->get_uuid(ROM_DEV(xdev)) : NULL)
 
+/* version_ctrl callbacks */
+struct xocl_version_ctrl_funcs {
+	bool (*flat_shell_check)(struct platform_device *pdev);
+	bool (*cmc_in_bitfile)(struct platform_device *pdev);
+};
+
+#define VC_DEV(xdev)	\
+	SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL).pldev
+#define	VC_OPS(xdev)	\
+	((struct xocl_version_ctrl_funcs *)SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL).ops)
+#define VC_CB(xdev, cb)	\
+	(VC_DEV(xdev) && VC_OPS(xdev) && VC_OPS(xdev)->cb)
+#define	xocl_flat_shell_check(xdev)		\
+	(VC_CB(xdev, flat_shell_check) ? VC_OPS(xdev)->flat_shell_check(VC_DEV(xdev)) : false)
+#define	xocl_cmc_in_bitfile(xdev)		\
+	(VC_CB(xdev, cmc_in_bitfile) ? VC_OPS(xdev)->cmc_in_bitfile(VC_DEV(xdev)) : false)
+
 /* dma callbacks */
 struct xocl_dma_funcs {
 	struct xocl_subdev_funcs common_funcs;
@@ -1916,4 +1933,10 @@ void xocl_fini_lapc(void);
 
 int __init xocl_init_pmc(void);
 void xocl_fini_pmc(void);
+
+int __init xocl_init_icap_controller(void);
+void xocl_fini_icap_controller(void);
+
+int __init xocl_init_version_control(void);
+void xocl_fini_version_control(void);
 #endif

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -96,6 +96,14 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         {
             retVal = xspi.xclUpgradeFirmware2(*primary, *secondary, stripped);
         }
+
+        auto dev = mDev.get();
+        std::string errmsg;
+        std::string lvl = std::to_string(1);
+        dev->sysfs_put("icap_controller", "enable", errmsg, lvl);
+        if (errmsg.empty())
+            std::cout << "Successfully enabled icap_controller" << std::endl;
+
         break;
     }
     case BPI:


### PR DESCRIPTION
Adding icap controller subdev to program & enable flash address
in icap controller ip registers to eliminate reboot after flashing image on card.
This feature will only be enabled on Samsung U2 flat shells.
Added new subdev called version control to read the shell stats and other
information which are needed for enabling features.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>