### PR TITLE
qdma4: re-enable slave bridge programming

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_regs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_regs.c
@@ -235,54 +235,60 @@ int qdma4_csr_read(struct xlnx_dma_dev *xdev, struct global_csr_conf *csr)
 		return xdev->hw.qdma_get_error_code(rv);
 	}
 
-	rv = xdev->hw.qdma_global_writeback_interval_conf(xdev,
-						&csr->wb_intvl,
-						QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read write back interval, err = %d",
-					rv);
-			return xdev->hw.qdma_get_error_code(rv);
-		}
-		pr_warn("Hardware Feature not supported");
-	}
-
-	rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
+	    //(xdev->dev_cap.mm_en && xdev->dev_cap.mm_cmpt_en))
+	if (xdev->dev_cap.st_en) {
+		rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
 				QDMA_GLOBAL_CSR_ARRAY_SZ, csr->c2h_buf_sz,
 				QDMA_CSR_BUF_SZ, QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read global buffer sizes, err = %d",
-						rv);
-			return xdev->hw.qdma_get_error_code(rv);
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read global buffer sizes, %d",
+					rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
 		}
-		pr_warn("Hardware Feature not supported");
 	}
 
-	rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
+	if (xdev->dev_cap.st_en ||
+	    (xdev->dev_cap.mm_en && xdev->dev_cap.mm_cmpt_en)) {
+		rv = xdev->hw.qdma_global_writeback_interval_conf(xdev,
+						&csr->wb_intvl,
+						QDMA_HW_ACCESS_READ);
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read write back interval, %d",
+					rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
+		}
+
+		rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
 				QDMA_GLOBAL_CSR_ARRAY_SZ, csr->c2h_timer_cnt,
 				QDMA_CSR_TIMER_CNT, QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read global timer count, err = %d",
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read global timer count, %d",
 						rv);
-			return xdev->hw.qdma_get_error_code(rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
 		}
-		pr_warn("Hardware Feature not supported");
-	}
 
-	rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
+		rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
 				QDMA_GLOBAL_CSR_ARRAY_SZ, csr->c2h_cnt_th,
 				QDMA_CSR_CNT_TH, QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read global counter threshold, err = %d",
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read global counter threshold, %d",
 					rv);
-			return xdev->hw.qdma_get_error_code(rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
 		}
-		pr_warn("Hardware Feature not supported");
+		qdma_sort_c2h_cntr_th_values(xdev);
 	}
-	qdma_sort_c2h_cntr_th_values(xdev);
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -1869,15 +1869,20 @@ static int qdma4_probe(struct platform_device *pdev)
 		res;	
 		res = platform_get_resource(pdev, IORESOURCE_MEM, ++i)) {
 		if (!strncmp(res->name, NODE_QDMA4, strlen(NODE_QDMA4))) {
-			ret = xocl_ioaddr_to_baroff(xdev, res->start, &dma_bar, NULL);
+			ret = xocl_ioaddr_to_baroff(xdev, res->start, &dma_bar,
+							NULL);
 			if (ret) {
-				xocl_err(&pdev->dev, "Invalid resource %pR", res);
+				xocl_err(&pdev->dev,
+					"Invalid resource %pR", res);
 				return -EINVAL;
 			}
-		} else if (!strncmp(res->name, NODE_QDMA4_CSR, strlen(NODE_QDMA4_CSR))) {
-			ret = xocl_ioaddr_to_baroff(xdev, res->start, &csr_bar, NULL);
+		} else if (!strncmp(res->name, NODE_QDMA4_CSR,
+					strlen(NODE_QDMA4_CSR))) {
+			ret = xocl_ioaddr_to_baroff(xdev, res->start, &csr_bar,
+							NULL);
 			if (ret) {
-				xocl_err(&pdev->dev, "QDMA4_CSR: Invalid resource %pR", res);
+				xocl_err(&pdev->dev,
+					 "CSR: Invalid resource %pR", res);
 				return -EINVAL;
 			}
 
@@ -1885,9 +1890,11 @@ static int qdma4_probe(struct platform_device *pdev)
 				pci_resource_start(XDEV(xdev)->pdev, csr_bar);
 
 		} else if (!strncmp(res->name, NODE_STM4, strlen(NODE_STM4))) {
-			ret = xocl_ioaddr_to_baroff(xdev, res->start, &stm_bar, NULL);
+			ret = xocl_ioaddr_to_baroff(xdev, res->start, &stm_bar,
+							NULL);
 			if (ret) {
-				xocl_err(&pdev->dev, "Invalid resource %pR", res);
+				xocl_err(&pdev->dev,
+					"STM Invalid resource %pR", res);
 				return -EINVAL;
 			}
 			if (stm_bar == -1)
@@ -1929,6 +1936,8 @@ static int qdma4_probe(struct platform_device *pdev)
 	conf->fp_user_isr_handler = qdma_isr;
 	conf->uld = (unsigned long)qdma;
 
+	xocl_info(&pdev->dev, "dma %d, mode 0x%x.\n",
+		dma_bar, conf->qdma_drv_mode);
 	ret = qdma4_device_open(XOCL_MODULE_NAME, conf, &qdma->dma_hndl);
 	if (ret < 0) {
 		xocl_err(&pdev->dev, "QDMA Device Open failed");
@@ -1937,25 +1946,24 @@ static int qdma4_probe(struct platform_device *pdev)
 
 	if (csr_bar >= 0) {
 		xocl_info(&pdev->dev, "csr bar %d, base 0x%lx.",
-			 csr_bar, (unsigned long)csr_base);
+			csr_bar, (unsigned long)csr_base);
 
-#if 0
 		ret = qdma4_csr_prog_ta(XDEV(xdev)->pdev, csr_bar, csr_base);
 		if (ret < 0)
 			xocl_err(&pdev->dev,
-				"BDF table program failed, slave bridge may NOT work.");
+				"Slave bridge BDF program failed (%d,0x%lx).",
+				csr_bar, (unsigned long)csr_base);
 		else
 			xocl_info(&pdev->dev,
-				"BDF table program set up successful (%d,0x%lx).",
+				"Slave bridge BDF programmed (%d,0x%lx).",
 				csr_bar, (unsigned long)csr_base);
-#endif
 	}
 
 	if (stm_bar >= 0) {
 		struct stmc_dev *sdev = &qdma->stm_dev;
 
 		xocl_info(&pdev->dev, "stm bar %d, base 0x%lx.",
-			 stm_bar, (unsigned long)stm_base);
+			stm_bar, (unsigned long)stm_base);
 
 		sdev->reg_base = stm_base;
 		sdev->bar_num = stm_bar;

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -575,6 +575,8 @@ int shim::dev_init()
     mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
 
     mStreamHandle = mDev->open("dma.qdma", O_RDWR | O_SYNC);
+    if (mStreamHandle <= 0)
+       mStreamHandle = mDev->open("dma.qdma4", O_RDWR | O_SYNC);
     memset(&mAioContext, 0, sizeof(mAioContext));
     mAioEnabled = (io_setup(SHIM_QDMA_AIO_EVT_MAX, &mAioContext) == 0);
 


### PR DESCRIPTION
- re-enable slave bridge configuration programing
- add ST mode & completion enable checks to reduce warning messages for MM-only platform.
- limit each line to be max. of 80 characters.
- add dma.qdma4 in shim