### PR TITLE
CR-1070987 xrt 2.7.76 xbmgmt flash attempts to download SC even thoug…

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -251,7 +251,7 @@ static int resetShell(unsigned index, bool force)
 }
 
 /*
- * bmcVer (shown as [SC=version]) can be 3 status:
+ * bmcVer (shown as [SC=version]) can be the following status:
  *   1) regular SC version;
  *        example: [SC=4.1.7]
  *   2) INACTIVE;
@@ -271,6 +271,7 @@ static void isSameShellOrSC(DSAInfo& candidate, DSAInfo& current,
         *same_dsa = ((candidate.name == current.name) &&
             candidate.matchId(current));
         *same_bmc = (current.bmcVerIsFixed() ||
+            candidate.bmcVer.empty() ||
             (current.bmcVer.compare(DSAInfo::INACTIVE) == 0) ||
             (candidate.bmcVer == current.bmcVer));
     }


### PR DESCRIPTION
tested on U25:
```
Card [0000:66:00.0]
    Card type:          u25
    Flash type:         QSPI_PS
    Flashable partition running on FPGA:
        xilinx_u25_gen3x8_xdma_base_1,[ID=0xc27f347aa668d2f9],[SC=7.8.0]
    Flashable partitions installed in system:
        xilinx_u25_gen3x8_xdma_base_1,[ID=0xc27f347aa668d2f9]
```
> Fixed version:
```
/proj/xsjhdstaff2/davidzha/XRT_zocl/build/Debug/runtime_src/core/pcie/tools/xbmgmt/xbmgmt flash --update --shell xilinx_u25_gen3x8_xdma_base_1 --card 0000:66:00.0
         Status: shell is up-to-date

Card(s) up-to-date and do not need to be flashed.
```

> without the fix:
```
/proj/xsjhdstaff2/davidzha/XRT_zocl/build/Debug/runtime_src/core/pcie/tools/xbmgmt/xbmgmt flash --update --shell xilinx_u25_gen3x8_xdma_base_1 --card 0000:66:00.0
         Status: SC needs updating
         Current SC: 7.8.0
         SC to be flashed:
Are you sure you wish to proceed? [y/n]: n
Action canceled.

```