### PR TITLE
qdma4: backport qdma4 platform changes

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -109,6 +109,8 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/lib/libqdma/version.h
   xocl/lib/libqdma/xdev.h
   xocl/lib/libqdma/xdev.c
+  xocl/lib/libqdma4/stmc.h
+  xocl/lib/libqdma4/stmc.c
   xocl/lib/libqdma4/libqdma4_export.h
   xocl/lib/libqdma4/libqdma_config.c
   xocl/lib/libqdma4/libqdma_config.h

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -134,6 +134,11 @@ struct xocl_xmc_privdata {
 	uint16_t		flags;
 };
 
+#define XOCL_P2P_FLAG_SIBASE_NEEDED	1
+struct xocl_p2p_privdata {
+	u32			flags;
+};
+
 #ifdef __KERNEL__
 #define XOCL_PCI_DEVID(ven, dev, subsysid, priv)	\
 	 .vendor = ven, .device=dev, .subvendor = PCI_ANY_ID, \
@@ -1477,22 +1482,6 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
-#define XOCL_RES_QDMA4					\
-	((struct resource []) {				\
-		{					\
-			.start = 0x0,			\
-			.end = 0x0,			\
-	 		.name = NODE_QDMA4,		\
-			.flags = IORESOURCE_MEM,	\
-		},					\
-		{					\
-			.start = 0x2000000,			\
-			.end = 0x2001000,			\
-	 		.name = NODE_STM4,		\
-			.flags = IORESOURCE_MEM,	\
-		},					\
-	 })
-
 #define XOCL_RES_QDMA					\
 	((struct resource []) {				\
 		{					\
@@ -1508,16 +1497,6 @@ struct xocl_subdev_map {
 			.flags = IORESOURCE_MEM,	\
 		},					\
 	 })
-
-#define	XOCL_DEVINFO_QDMA4				\
-	{						\
-		XOCL_SUBDEV_DMA,			\
-		XOCL_QDMA4,				\
-		XOCL_RES_QDMA4,				\
-		ARRAY_SIZE(XOCL_RES_QDMA4),		\
-		.bar_idx = (char []){ 2, 0 },		\
-		.override_idx = -1,			\
-	}
 
 #define	XOCL_DEVINFO_QDMA				\
 	{						\
@@ -1766,26 +1745,6 @@ struct xocl_subdev_map {
 	}
 
 /* user pf defines */
-#define	USER_RES_QDMA4							\
-		((struct xocl_subdev_info []) {				\
-			XOCL_DEVINFO_FEATURE_ROM,			\
-			XOCL_DEVINFO_QDMA4,				\
-			XOCL_DEVINFO_SCHEDULER_QDMA,			\
-			XOCL_DEVINFO_XVC_PUB,				\
-			XOCL_DEVINFO_MAILBOX_USER_QDMA,			\
-			XOCL_DEVINFO_ICAP_USER,				\
-			XOCL_DEVINFO_XMC_USER,				\
-			XOCL_DEVINFO_AF_USER,				\
-			XOCL_DEVINFO_CU_CTRL,				\
-		})
-
-#define	XOCL_BOARD_USER_QDMA4						\
-	(struct xocl_board_private){					\
-		.flags		= 0,					\
-		.subdev_info	= USER_RES_QDMA4,			\
-		.subdev_num = ARRAY_SIZE(USER_RES_QDMA),		\
-	}
-
 #define	USER_RES_QDMA							\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/Makefile.in
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/Makefile.in
@@ -34,6 +34,7 @@ xocl_lib-y	+=  \
 		../lib/libqdma/xdev.o
 
 xocl_lib-y	+=  \
+		../lib/libqdma4/stmc.o	\
 		../lib/libqdma4/libqdma_config.o	\
 		../lib/libqdma4/libqdma_export.o	\
 		../lib/libqdma4/qdma_context.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/eqdma_soft_access.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/eqdma_soft_access.c
@@ -4452,6 +4452,9 @@ int eqdma_hw_error_process(void *dev_hndl)
 					err_stat);
 		else
 			continue;
+		pr_info("%s: err_stat 0x%x = 0x%x.\n", __func__,
+			eqdma_err_info[bit].stat_reg_addr, err_stat);
+
 		for (idx = bit; idx < all_eqdma_hw_errs[i]; idx++) {
 			/* call the platform specific handler */
 			if (err_stat & eqdma_err_info[idx].leaf_err_mask)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma4_export.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma4_export.h
@@ -733,6 +733,8 @@ struct qdma_queue_conf {
 			struct qdma_ul_cmpt_info *cmpt_info);
 
 	/** @note Following fileds are filled by libqdma */
+	/**  hw qid */
+	unsigned int qidx_hw;
 	/**  name of the qdma device */
 	char name[QDMA_QUEUE_NAME_MAXLEN];
 	/**  ring size of the queue */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_context.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_context.c
@@ -430,8 +430,10 @@ int qdma4_descq_context_setup(struct qdma_descq *descq)
 			else if (descq->conf.q_type)  {/* st c2h */
 				descq_conf.desc_sz = DESC_SZ_8B;
 				descq_conf.forced_en = descq->conf.fetch_credit;
-			} else /* st h2c */
+			} else { /* st h2c */
 				descq_conf.desc_sz = DESC_SZ_16B;
+				descq_conf.forced_en = descq->conf.fetch_credit;
+			}
 		}
 	}
 	descq_conf.cmpt_desc_sz = descq->conf.cmpl_desc_sz;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
@@ -116,11 +116,11 @@ static irqreturn_t user_intr_handler(int irq_index, int irq, void *dev_id)
 {
 	struct xlnx_dma_dev *xdev = dev_id;
 
-	pr_info("User IRQ fired on Funtion#%d: index=%d, vector=%d\n",
+	pr_debug("User IRQ fired on Funtion#%d: index=%d, vector=%d\n",
 		xdev->func_id, irq_index, irq);
 
 	if (xdev->conf.fp_user_isr_handler)
-		xdev->conf.fp_user_isr_handler((unsigned long)xdev, irq,
+		xdev->conf.fp_user_isr_handler((unsigned long)xdev, irq_index,
 						xdev->conf.uld);
 
 	return IRQ_HANDLED;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_regs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_regs.c
@@ -235,54 +235,60 @@ int qdma4_csr_read(struct xlnx_dma_dev *xdev, struct global_csr_conf *csr)
 		return xdev->hw.qdma_get_error_code(rv);
 	}
 
-	rv = xdev->hw.qdma_global_writeback_interval_conf(xdev,
-						&csr->wb_intvl,
-						QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read write back interval, err = %d",
-					rv);
-			return xdev->hw.qdma_get_error_code(rv);
-		}
-		pr_warn("Hardware Feature not supported");
-	}
-
-	rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
+	    //(xdev->dev_cap.mm_en && xdev->dev_cap.mm_cmpt_en))
+	if (xdev->dev_cap.st_en) {
+		rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
 				QDMA_GLOBAL_CSR_ARRAY_SZ, csr->c2h_buf_sz,
 				QDMA_CSR_BUF_SZ, QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read global buffer sizes, err = %d",
-						rv);
-			return xdev->hw.qdma_get_error_code(rv);
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read global buffer sizes, %d",
+					rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
 		}
-		pr_warn("Hardware Feature not supported");
 	}
 
-	rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
+	if (xdev->dev_cap.st_en ||
+	    (xdev->dev_cap.mm_en && xdev->dev_cap.mm_cmpt_en)) {
+		rv = xdev->hw.qdma_global_writeback_interval_conf(xdev,
+						&csr->wb_intvl,
+						QDMA_HW_ACCESS_READ);
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read write back interval, %d",
+					rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
+		}
+
+		rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
 				QDMA_GLOBAL_CSR_ARRAY_SZ, csr->c2h_timer_cnt,
 				QDMA_CSR_TIMER_CNT, QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read global timer count, err = %d",
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read global timer count, %d",
 						rv);
-			return xdev->hw.qdma_get_error_code(rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
 		}
-		pr_warn("Hardware Feature not supported");
-	}
 
-	rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
+		rv = xdev->hw.qdma_global_csr_conf(xdev, 0,
 				QDMA_GLOBAL_CSR_ARRAY_SZ, csr->c2h_cnt_th,
 				QDMA_CSR_CNT_TH, QDMA_HW_ACCESS_READ);
-	if (unlikely(rv < 0)) {
-		if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
-			pr_err("Failed to read global counter threshold, err = %d",
+		if (unlikely(rv < 0)) {
+			if (rv != -QDMA_ERR_HWACC_FEATURE_NOT_SUPPORTED) {
+				pr_err("Failed to read global counter threshold, %d",
 					rv);
-			return xdev->hw.qdma_get_error_code(rv);
+				return xdev->hw.qdma_get_error_code(rv);
+			}
+			pr_warn("Hardware Feature not supported");
 		}
-		pr_warn("Hardware Feature not supported");
+		qdma_sort_c2h_cntr_th_values(xdev);
 	}
-	qdma_sort_c2h_cntr_th_values(xdev);
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.h
@@ -55,8 +55,10 @@ struct qdma_sdesc_info {
 			u8 sop:1;
 			/** end of the packet */
 			u8 eop:1;
+			/** end of the transfer */
+			u8 eot:1;
 			/** filler for 5 bits */
-			u8 filler:5;
+			u8 filler:4;
 		} f;
 	};
 	/** reserved 3 bits */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_ul_ext.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_ul_ext.h
@@ -71,6 +71,19 @@ void qdma_update_request(void *q_hndl, struct qdma_request *req,
 
 /*****************************************************************************/
 /**
+ * qdma_q_desc_avail_count() - get available number of descriptors for the q
+ *                     specified by @q_hndl
+ *
+ * @q_hndl: handle to the q with which bypass module can request descriptors
+ *
+ * Return: # of available descriptors: success;
+ *         <0: if number of requested descriptors not available
+ *
+ *****************************************************************************/
+unsigned int qdma_q_desc_avail_count(void *q_hndl);
+
+/*****************************************************************************/
+/**
  * qdma_q_desc_get() - request @desc_cnt number of descriptors for the q
  *                     specified by @q_hndl
  *
@@ -94,6 +107,6 @@ int qdma_q_desc_get(void *q_hndl, const unsigned int desc_cnt,
  * Return: 0: success; <0: on failure
  *
  *****************************************************************************/
-int qdma_q_init_pointers(void *q_hndl);
+int qdma_q_init_pointers(unsigned long dev_hndl, unsigned long queue_hndl);
 
 #endif /* QDMA_UL_EXT_H__ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/stmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/stmc.c
@@ -1,0 +1,671 @@
+/*
+* Streaming Platform STM-C.
+* 
+* Copyright (C) 2020-  Xilinx, Inc. All rights reserved.
+*
+* Authors: Karen.Xie@Xilinx.com
+*
+* This software is licensed under the terms of the GNU General Public
+* License version 2, as published by the Free Software Foundation, and
+* may be copied, distributed, and modified under those terms.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+#include <linux/version.h>
+#include <linux/debugfs.h>
+#include <linux/types.h>
+#include <linux/pci.h>
+
+#include "stmc.h"
+#include "qdma_ul_ext.h"
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 6, 0)
+#define ioremap_nocache         ioremap
+#endif
+
+#define	STM_MAX_SUPPORTED_QID		64
+
+#define STREAM_FLOWID_MASK		0xFF
+#define STREAM_TDEST_MASK		0xFFFFFF
+
+/*
+ * STM-C v2 register map
+ */
+
+#define	STM_REG_REV			0x18
+
+#define STM_REG_CONFIG_HINT		0x28
+#define STM_REG_CONFIG_PORT_MAX		(4)
+#define		S_STM_REG_CONFIG_PORT_NUM	24
+#define		M_STM_REG_CONFIG_PORT_NUM	0xFU
+#define		L_STM_REG_CONFIG_PORT_NUM	4
+#define		V_STM_REG_CONFIG_PORT_NUM(x)	\
+		(((x) & M_STM_REG_CONFIG_PORT_NUM) << S_STM_REG_CONFIG_PORT_NUM)
+
+#define		S_STM_REG_CONFIG_PORT_MAP	16
+#define		M_STM_REG_CONFIG_PORT_MAP	0xFFU
+#define		L_STM_REG_CONFIG_PORT_MAP	8
+#define		V_STM_REG_CONFIG_PORT_MAP(x)	\
+		(((x) & M_STM_REG_CONFIG_PORT_MAP) << S_STM_REG_CONFIG_PORT_MAP)
+
+#define STM_REG_H2C_MODE		0x30
+#define		S_STM_REG_H2C_MODE_PORTMAP_H2C	24
+#define		M_STM_REG_H2C_MODE_PORTMAP_H2C	0xFFU
+#define		L_STM_REG_H2C_MODE_PORTMAP_H2C	8
+#define		V_STM_REG_H2C_MODE_PORTMAP_H2C(x) \
+		(((x) & M_STM_REG_H2C_MODE_PORTMAP_H2C) \
+		 << S_STM_REG_H2C_MODE_PORTMAP_H2C)
+
+#define		S_STM_REG_H2C_MODE_PORTMAP_C2H	16
+#define		M_STM_REG_H2C_MODE_PORTMAP_C2H	0xFFU
+#define		L_STM_REG_H2C_MODE_PORTMAP_C2H	8
+#define		V_STM_REG_H2C_MODE_PORTMAP_C2H(x) \
+		(((x) & M_STM_REG_H2C_MODE_PORTMAP_C2H) \
+		 << S_STM_REG_H2C_MODE_PORTMAP_C2H)
+#define		S_STM_EN_STMA_BKCHAN		15
+#define		F_STM_EN_STMA_BKCHAN		(1 << S_STM_EN_STMA_BKCHAN)
+
+#define STM_REG_C2H_MODE		0x38
+#define STM_REG_C2H_MODE_WEIGHT_DFLT	0x00010200
+
+#define		S_STM_REG_C2H_MODE_WEIGHT	8
+#define		M_STM_REG_C2H_MODE_WEIGHT	0xFFU
+#define		L_STM_REG_C2H_MODE_WEIGHT	8
+
+/* STM indirect cmd & data registers */
+#define STM_REG_CMD_DATA_0		0x0
+#define STM_REG_CMD_DATA_1		0x4
+#define STM_REG_CMD_DATA_2		0x8
+#define STM_REG_CMD_DATA_3		0xC
+#define STM_REG_CMD_DATA_4		0x10
+#define STM_REG_CMD_DATA_5		0x24
+#define STM_REG_CMD_DATA_C2H8		0x20
+
+#define STM_REG_CMD			0x14
+#define		STM_CMD_OP_WRITE	0x4
+#define		STM_CMD_OP_READ		0x8
+
+#define		STM_CMD_SEL_C2H_MAP	0x2
+#define		STM_CMD_SEL_CAN_DIRECT	0x8
+#define		STM_CMD_SEL_H2C_CTX	0x9
+#define		STM_CMD_SEL_H2C_MAP	0xA
+#define		STM_CMD_SEL_C2H_CTX	0xB
+
+#define S_STM_REG_CMD_QID		0
+#define M_STM_REG_CMD_QID		0x7FFU
+#define V_STM_REG_CMD_QID(x)		\
+		(((x) & M_STM_REG_CMD_QID) << S_STM_REG_CMD_QID)
+
+#define S_STM_REG_CMD_FID		12
+#define M_STM_REG_CMD_FID		0xFFFU
+#define V_STM_REG_CMD_FID(x)		\
+		(((x) & M_STM_REG_CMD_FID) << S_STM_REG_CMD_FID)
+
+#define S_STM_REG_CMD_SEL		24
+#define M_STM_REG_CMD_SEL		0xFU
+#define V_STM_REG_CMD_SEL(x)		\
+		(((x) & M_STM_REG_CMD_SEL) << S_STM_REG_CMD_SEL)
+
+#define S_STM_REG_CMD_OP		28
+#define M_STM_REG_CMD_OP		0xEU
+#define V_STM_REG_CMD_OP(x)		\
+		(((x) & M_STM_REG_CMD_OP) << S_STM_REG_CMD_OP)
+
+/* context */
+#define S_STM_CTX_W0_H2C_TDEST		0
+#define M_STM_CTX_W0_H2C_TDEST		0xFFFFFFU
+#define V_STM_CTX_W0_H2C_TDEST(x)		\
+		(((x) & M_STM_CTX_W0_H2C_TDEST) << S_STM_CTX_W0_H2C_TDEST)
+
+#define S_STM_CTX_W0_H2C_FLOW_ID	24	
+#define M_STM_CTX_W0_H2C_FLOW_ID	0xFFU
+#define V_STM_CTX_W0_H2C_FLOW_ID(x)	\
+		(((x) & M_STM_CTX_W0_H2C_FLOW_ID) << S_STM_CTX_W0_H2C_FLOW_ID)
+
+#define S_STM_CTX_W1_DPPKT		0
+#define M_STM_CTX_W1_DPPKT		0xFFU
+#define V_STM_CTX_W1_DPPKT(x)		\
+		(((x) & M_STM_CTX_W1_DPPKT) << S_STM_CTX_W1_DPPKT)
+
+#define S_STM_CTX_W1_MIN_ASK		8
+#define M_STM_CTX_W1_MIN_ASK		0xFFU
+#define V_STM_CTX_W1_MIN_ASK(x)	\
+		(((x) & M_STM_CTX_W1_MIN_ASK) << S_STM_CTX_W1_MIN_ASK)
+
+#define S_STM_CTX_W1_MAX_ASK		16	
+#define M_STM_CTX_W1_MAX_ASK		0xFFU
+#define V_STM_CTX_W1_MAX_ASK(x)	\
+		(((x) & M_STM_CTX_W1_MAX_ASK) << S_STM_CTX_W1_MAX_ASK)
+
+#define S_STM_CTX_W1_PKT_LIM		24	
+#define M_STM_CTX_W1_PKT_LIM		0xFFU
+#define V_STM_CTX_W1_PKT_LIM(x)	\
+		(((x) & M_STM_CTX_W1_PKT_LIM) << S_STM_CTX_W1_PKT_LIM)
+
+#define S_STM_CTX_W2_PKT_CDT		0	
+#define M_STM_CTX_W2_PKT_CDT		0xFFU
+#define V_STM_CTX_W2_PKT_CDT(x)	\
+		(((x) & M_STM_CTX_W2_PKT_CDT) << S_STM_CTX_W2_PKT_CDT)
+
+#define S_STM_CTX_W3_DPPKT_LOG		8
+#define M_STM_CTX_W3_DPPKT_LOG		0x3FU
+#define V_STM_CTX_W3_DPPKT_LOG(x)	\
+		(((x) & M_STM_CTX_W3_DPPKT_LOG) << S_STM_CTX_W3_DPPKT_LOG)
+
+#define S_STM_CTX_W3_F_H2C_VALID	15
+
+#define S_STM_CTX_W4_C2H_TDEST		0
+#define M_STM_CTX_W4_C2H_TDEST		0xFFFFFFU
+#define V_STM_CTX_W4_C2H_TDEST(x)	\
+		(((x) & M_STM_CTX_W4_C2H_TDEST) << S_STM_CTX_W4_C2H_TDEST)
+
+#define S_STM_CTX_W4_C2H_FLOW_ID	8
+#define M_STM_CTX_W4_C2H_FLOW_ID	0xFFFFFFU
+#define V_STM_CTX_W4_C2H_FLOW_ID(x)	\
+		(((x) & M_STM_CTX_W4_C2H_FLOW_ID) << S_STM_CTX_W4_C2H_FLOW_ID)
+
+#define S_STM_CTX_W5_F_C2H_VALID	16
+
+struct stm_queue_context {
+	u32	data[6];
+	u32	map;
+};
+
+/*
+ * STMC initialization 
+ */
+void stmc_cleanup(struct stmc_dev *sdev)
+{
+	if (sdev && sdev->regs) {
+		iounmap(sdev->regs);
+		sdev->regs = NULL;
+	}
+}
+
+int stmc_init(struct stmc_dev *sdev, struct qdma_dev_conf *conf)
+{
+	u32 v, nport, portmap;
+	resource_size_t bar_start;
+	void __iomem	*regs;
+
+	if (!sdev)
+		return -EINVAL;
+	spin_lock_init(&sdev->ctx_prog_lock);
+	sdev->name = conf->name;
+	sdev->pdev = conf->pdev;
+
+	bar_start = pci_resource_start(conf->pdev, sdev->bar_num);
+	regs = ioremap_nocache(bar_start + sdev->reg_base, 4096);
+	if (!regs) {
+		pr_warn("%s unable to map STM-C bar %u.\n",
+			conf->name, sdev->bar_num);
+		return 0;
+	}
+
+	v = readl(regs + STM_REG_REV);
+	if ((((v >> 24) & 0xFF)!= 'S') || (((v >> 16) & 0xFF) != 'T') ||
+	    (((v >> 8) & 0xFF) != 'M')) {
+		pr_warn("%s: Unknown STM bar 0x%x, base 0x%x, 0x%x(%c%c%c).\n",
+			conf->name, sdev->bar_num, sdev->reg_base, v,
+			(v >> 24) & 0xFF, (v >> 16) & 0xFF, (v >> 8) & 0xFF);
+		iounmap(regs);
+		return 0;
+	}
+	sdev->regs = regs;
+
+	pr_info("%s: STM enabled, bar %u, base 0x%x, rev 0x%x\n",
+		conf->name, sdev->bar_num, sdev->reg_base, v & 0xFF);
+
+	/* program STM port map */
+	v = readl(regs + STM_REG_CONFIG_HINT);
+	nport = (v >> S_STM_REG_CONFIG_PORT_NUM) & M_STM_REG_CONFIG_PORT_NUM;
+	portmap = (v >> S_STM_REG_CONFIG_PORT_MAP) & M_STM_REG_CONFIG_PORT_MAP;
+
+	v = V_STM_REG_H2C_MODE_PORTMAP_H2C(portmap) |
+	    V_STM_REG_H2C_MODE_PORTMAP_C2H(portmap) | F_STM_EN_STMA_BKCHAN;
+	writel(v, regs + STM_REG_H2C_MODE);
+
+	/* C2H weight */
+	v = STM_REG_C2H_MODE_WEIGHT_DFLT;
+	if (nport < STM_REG_CONFIG_PORT_MAX) {
+		int shift = (STM_REG_CONFIG_PORT_MAX - nport) *
+				L_STM_REG_C2H_MODE_WEIGHT;
+		v = (STM_REG_C2H_MODE_WEIGHT_DFLT >> shift) &
+			(~((1 << shift) - 1));
+	}
+	writel(v, regs + STM_REG_C2H_MODE);
+
+	return 0;
+}
+
+/*
+ * STM-C queue contextp
+ */
+static int stmc_indirect_prog(struct stmc_dev *sdev, unsigned int qid_hw,
+			 u8 fid, u32 op, u32 sel, struct stm_queue_context *ctx)
+{
+	void __iomem *regs = sdev->regs;
+	u32 cmd = V_STM_REG_CMD_QID(qid_hw) | V_STM_REG_CMD_FID(fid) |
+		  V_STM_REG_CMD_SEL(sel) | V_STM_REG_CMD_OP(op);
+	int rv = 0;
+
+	if ((op != STM_CMD_OP_WRITE) && (op != STM_CMD_OP_READ)) {
+		pr_err("%s: %s, qid_hw %u, op 0x%x INVALID.\n",
+			__func__, sdev->name, qid_hw, op);
+		return -EINVAL;
+	}
+
+	spin_lock(&sdev->ctx_prog_lock);
+
+	switch (sel) {
+	case STM_CMD_SEL_H2C_CTX:
+		if (op == STM_CMD_OP_WRITE) {
+			writel(ctx->data[0], regs + STM_REG_CMD_DATA_0);
+			writel(ctx->data[1], regs + STM_REG_CMD_DATA_1);
+			writel(ctx->data[2], regs + STM_REG_CMD_DATA_2);
+			writel(ctx->data[3], regs + STM_REG_CMD_DATA_3);
+			writel(cmd, regs + STM_REG_CMD);
+		} else {
+			writel(cmd, regs + STM_REG_CMD);
+			ctx->data[0] = readl(regs + STM_REG_CMD_DATA_0);
+			ctx->data[1] = readl(regs + STM_REG_CMD_DATA_1);
+			ctx->data[2] = readl(regs + STM_REG_CMD_DATA_2);
+			ctx->data[3] = readl(regs + STM_REG_CMD_DATA_3);
+			ctx->data[4] = readl(regs + STM_REG_CMD_DATA_4);
+		}
+		break;
+	case STM_CMD_SEL_C2H_CTX:
+		if (op == STM_CMD_OP_WRITE) {
+			writel(ctx->data[4], regs + STM_REG_CMD_DATA_4);
+			writel(ctx->data[5], regs + STM_REG_CMD_DATA_5);
+			writel(cmd, regs + STM_REG_CMD);
+		} else {
+			writel(cmd, regs + STM_REG_CMD);
+			ctx->data[4] = readl(regs + STM_REG_CMD_DATA_4);
+			ctx->data[5] = readl(regs + STM_REG_CMD_DATA_5);
+		}
+		break;
+	case STM_CMD_SEL_H2C_MAP:
+		if (op == STM_CMD_OP_WRITE) {
+			writel(ctx->map, regs + STM_REG_CMD_DATA_4);
+			writel(cmd, regs + STM_REG_CMD);
+		} else {
+			writel(cmd, regs + STM_REG_CMD);
+			ctx->map = readl(regs + STM_REG_CMD_DATA_4);
+		}
+		break;
+	case STM_CMD_SEL_C2H_MAP:
+		if (op == STM_CMD_OP_WRITE) {
+			writel(ctx->map, regs + STM_REG_CMD_DATA_C2H8);
+			writel(cmd, regs + STM_REG_CMD);
+		} else {
+			writel(cmd, regs + STM_REG_CMD);
+			ctx->map = readl(regs + STM_REG_CMD_DATA_C2H8);
+		}
+		break;
+	case STM_CMD_SEL_CAN_DIRECT:
+		if (op == STM_CMD_OP_WRITE) {
+			pr_err("%s: %s, STM_CMD_SEL_CAN_DIRECT is read-only.\n",
+			__func__, sdev->name);
+			rv = -EINVAL;
+		} else {
+			writel(cmd, regs + STM_REG_CMD);
+			ctx->data[0] = readl(regs + STM_REG_CMD_DATA_0);
+			ctx->data[1] = readl(regs + STM_REG_CMD_DATA_1);
+			ctx->data[2] = readl(regs + STM_REG_CMD_DATA_2);
+			ctx->data[3] = readl(regs + STM_REG_CMD_DATA_3);
+		}
+		break;
+	default:
+		pr_err("%s: %s, qid %u, fid %u, op 0x%x, sel 0x%x INVALID.\n",
+			__func__, sdev->name, qid_hw, fid, op, sel);
+		rv = -EINVAL;
+		break;
+	}
+
+	spin_unlock(&sdev->ctx_prog_lock);
+
+	return rv;
+}
+
+static void stmc_make_h2c_context(struct stmc_queue_conf *sqconf,
+				struct stm_queue_context *ctx, bool clear)
+{
+	int dppkt = 1;
+	int log2_dppkt = ilog2(dppkt);
+	int max_ask = 8;
+
+	memset(ctx, 0, sizeof(struct stm_queue_context));
+
+	if (clear)
+		return;
+
+	/* 0..31 */
+	ctx->data[0] = V_STM_CTX_W0_H2C_TDEST(sqconf->tdest) |
+		  V_STM_CTX_W0_H2C_FLOW_ID(sqconf->flow_id);
+
+	/* 32..63 */
+	ctx->data[1] = V_STM_CTX_W1_DPPKT(dppkt) |
+			V_STM_CTX_W1_MAX_ASK(max_ask);
+
+	/* 64..95 */
+	/** ?? explicitly init to 8 to workaround hw issue due to which the value
+	 * is getting initialized to zero instead of its reset value of 8
+	 */
+	ctx->data[2] = V_STM_CTX_W2_PKT_CDT(8);
+
+	/* 96..127 */
+	ctx->data[3] = V_STM_CTX_W3_DPPKT_LOG(log2_dppkt) |
+		  (1 << S_STM_CTX_W3_F_H2C_VALID);
+
+	/* 128..159 */
+
+	/* 191..160 */
+
+	/* h2c map */
+	ctx->map = sqconf->qid_hw;
+
+	pr_debug("h2c qid %u, STM ctx 0x%08x, 0x%08x, 0x%08x, 0x%08x, 0x%08x,"
+		" 0x%08x, map 0x%08x.\n",
+		 sqconf->qid_hw, ctx->data[0], ctx->data[1], ctx->data[2],
+		 ctx->data[3], ctx->data[4], ctx->data[5], ctx->map);
+}
+
+static void stmc_make_c2h_context(struct stmc_queue_conf *sqconf,
+				struct stm_queue_context *ctx, bool clear)
+{
+	memset(ctx, 0, sizeof(struct stm_queue_context));
+
+	if (clear) {
+		ctx->map = (DESC_SZ_8B << 11);
+		return;
+	} else {
+		/* c2h map */
+		ctx->map = sqconf->qid_hw | (DESC_SZ_8B << 11);
+	}
+
+	/* 0..31 */
+	/* 32..63 */
+	/* 64..95 */
+	/* 96..127 */
+	/* 128..159 */
+	ctx->data[4] = V_STM_CTX_W4_C2H_TDEST(sqconf->tdest) |
+		  V_STM_CTX_W4_C2H_FLOW_ID(sqconf->flow_id);
+	/* 191..160 */
+	ctx->data[5] = (1 << S_STM_CTX_W5_F_C2H_VALID);
+
+	pr_debug("c2h qid %u, STM ctx 0x%08x, 0x%08x, 0x%08x, 0x%08x, 0x%08x,"
+		" 0x%08x, map 0x%08x.\n",
+		 sqconf->qid_hw, ctx->data[0], ctx->data[1], ctx->data[2],
+		 ctx->data[3], ctx->data[4], ctx->data[5], ctx->map);
+}
+
+static int stmc_queue_context_program(struct stmc_dev *sdev,
+				struct stmc_queue_conf *sqconf, bool clear)
+{
+	struct stm_queue_context context;
+	int rv;
+
+	if (sqconf->c2h) {
+		stmc_make_c2h_context(sqconf, &context, clear);
+
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_WRITE, STM_CMD_SEL_C2H_CTX,
+					&context);
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_WRITE, STM_CMD_SEL_C2H_MAP,
+					&context);
+	} else {
+		stmc_make_h2c_context(sqconf, &context, clear);
+
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_WRITE, STM_CMD_SEL_H2C_CTX,
+					&context);
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_WRITE, STM_CMD_SEL_H2C_MAP,
+					&context);
+	}
+	return rv;
+}
+
+static int validate_stm_input(struct stmc_dev *sdev,
+				struct stmc_queue_conf *sqconf)
+{
+	if (!sdev || !sdev->regs) {
+		pr_info("%s: No STMC present.\n", __func__);
+		return -EINVAL;
+	}
+	if (sqconf && !sqconf->qconf) {
+		pr_info("%s: STMC context not set up.\n", __func__);
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int stmc_queue_context_cleanup(struct stmc_dev *sdev,
+				struct stmc_queue_conf *sqconf)
+{
+	int rv = validate_stm_input(sdev, sqconf);
+
+	if (rv < 0)
+		return rv;
+
+	sqconf->qconf = NULL; 
+	return stmc_queue_context_program(sdev, sqconf, true);
+}
+
+int stmc_queue_context_setup(struct stmc_dev *sdev,
+				struct qdma_queue_conf *qconf,
+				struct stmc_queue_conf *sqconf,
+				unsigned int flowid, unsigned int rid)
+{
+	int rv = validate_stm_input(sdev, NULL);
+
+	if (rv < 0)
+		return rv;
+
+	if (!qconf || !qconf->st) {
+		pr_info("%s: qconf 0x%p, %s Skipping STMC prog for MM queue.\n",
+			__func__, qconf, qconf ? qconf->name : "?") ;
+		return -EINVAL;
+	}
+
+	if (qconf->qidx_hw > STM_MAX_SUPPORTED_QID) {
+		pr_err("%s: QID for STM cannot be > %d\n",
+			qconf->name, STM_MAX_SUPPORTED_QID);
+		return -EINVAL;
+	}
+
+	sqconf->qconf = qconf;
+	sqconf->qid_hw = qconf->qidx_hw;
+	sqconf->c2h = (qconf->q_type == Q_C2H);
+        sqconf->flow_id = flowid & STREAM_FLOWID_MASK;
+	sqconf->tdest = rid & STREAM_TDEST_MASK;
+
+	pr_info("%s, %s: flowid 0x%x, rid 0x%x -> tdest %u, flow %u",
+		sdev->name, qconf->name, flowid, rid, sqconf->tdest,
+		sqconf->flow_id);
+
+	return stmc_queue_context_program(sdev, sqconf, false);
+}
+
+void stmc_queue_context_dump(struct stmc_dev *sdev,
+				struct stmc_queue_conf *sqconf)
+{
+	struct stm_queue_context ctx;
+	int rv = validate_stm_input(sdev, sqconf);
+
+	if (rv < 0)
+		return;
+
+	memset(&ctx, 0, sizeof(struct stm_queue_context));
+
+	if (sqconf->c2h) {
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_READ, STM_CMD_SEL_C2H_CTX,
+					&ctx);
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_READ, STM_CMD_SEL_C2H_MAP,
+					&ctx);
+	} else {
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_READ, STM_CMD_SEL_H2C_CTX,
+					&ctx);
+		rv = stmc_indirect_prog(sdev, sqconf->qid_hw, sqconf->flow_id,
+					STM_CMD_OP_READ, STM_CMD_SEL_H2C_MAP,
+					&ctx);
+	}
+
+	pr_info("%s qid %u, STM CTX 0x%08x, 0x%08x, 0x%08x, 0x%08x, 0x%08x,"
+		" 0x%08x, MAP 0x%08x.\n",
+		sqconf->c2h ? "C2H" : "H2C",
+		sqconf->qid_hw, ctx.data[0], ctx.data[1], ctx.data[2],
+		ctx.data[3], ctx.data[4], ctx.data[5], ctx.map);
+}
+
+/*
+ * H2C descriptor
+ */
+#define STM_MAX_PKT_SHIFT	(12)
+#define STM_MAX_PKT_SIZE	(1U << STM_MAX_PKT_SHIFT)
+
+#define stmc_get_desc_cnt(x) 	\
+	((x + STM_MAX_PKT_SIZE - 1) >> STM_MAX_PKT_SHIFT)
+
+struct stmc_h2c_desc {
+	__be16 cdh_flags;
+#define S_H2C_DESC_GL_LEN	0
+#define M_H2C_DESC_GL_LEN	0x7U
+#define V_H2C_DESC_GL_LEN(x)	((x) << S_H2C_DESC_GL_LEN)
+
+#define S_H2C_DESC_HDR_LEN	3
+#define M_H2C_DESC_HDR_LEN	0xFU
+#define V_H2C_DESC_HDR_LEN(x)	((x) << S_H2C_DESC_HDR_LEN)
+
+#define S_H2C_DESC_GL_LEN_EXT	7
+#define M_H2C_DESC_GL_LEN_EXT	0x3U
+#define V_H2C_DESC_GL_LEN_EXT(x) ((x) << S_H2C_DESC_GL_LEN_EXT)
+
+#define S_H2C_DESC_F_ZERO_CDH	13
+#define S_H2C_DESC_F_EOT	14
+#define S_H2C_DESC_F_REQ_SDI	15
+	__be16 pld_len;
+	__be16 len;
+	__be16 flags;
+#define S_H2C_DESC_F_SOP	1
+#define S_H2C_DESC_F_EOP	2
+	__be64 src_addr;
+};
+
+int stmc_req_bypass_desc_fill(void *qhndl, enum qdma_q_mode q_mode,
+			enum qdma_q_dir q_dir, struct qdma_request *req)
+{
+	struct qdma_sw_sg *sg;
+	unsigned int sg_offset;
+	unsigned int sg_max = req->sgcnt;
+	unsigned int data_cnt = 0;
+	unsigned int desc_used = 0;
+	unsigned int desc_avail;
+	int i, rv;
+
+	if ((q_mode != QDMA_Q_MODE_ST) || (q_dir != QDMA_Q_DIR_H2C)) {
+		pr_debug("%s: mode %u != %u (ST), dir %u != %u (H2C).\n",
+			__func__, q_mode, QDMA_Q_MODE_ST,
+			q_dir, QDMA_Q_DIR_H2C);
+        	return -EINVAL;
+	}
+
+	/* process the H2C request */
+	i = qdma_sgl_find_offset(req, &sg, &sg_offset);
+	if (i < 0) 
+		return -EINVAL;
+
+
+	desc_avail = qdma_q_desc_avail_count(qhndl);
+
+	for (; i < sg_max; i++, sg++) {
+		bool sop = (i == 0 && sg_offset == 0);
+		struct qdma_q_desc_list *qdesc_head = NULL;
+		struct qdma_q_desc_list *qdesc = NULL;
+		struct stmc_h2c_desc *desc;
+		unsigned int tlen = sg->len;
+		dma_addr_t addr = sg->dma_addr;
+		unsigned int desc_cnt;
+		int j;
+
+		if (sg_offset) {
+			tlen -= sg_offset;
+			addr += sg_offset;
+			sg_offset = 0;
+		}
+
+		desc_cnt = stmc_get_desc_cnt(tlen);
+                rv = qdma_q_desc_get(qhndl, desc_cnt, &qdesc_head);
+                if (rv < 0) {
+                        if (desc_used)
+                                goto update_req;
+                        else
+                                return 0;
+                }
+
+		desc = qdesc_head->desc;
+                for (j = 0, qdesc = qdesc_head; j < desc_cnt; j++,
+			qdesc = qdesc->next) {
+			unsigned int len = min_t(unsigned int, tlen,
+						STM_MAX_PKT_SIZE);
+
+                        desc = qdesc->desc;
+                        desc->flags = 0;
+
+			if (sop && j == 0)
+				desc->flags |= S_H2C_DESC_F_SOP;
+
+			desc->src_addr = addr;
+			desc->len = len;
+			desc->pld_len = len;
+			desc->cdh_flags = (1 << S_H2C_DESC_F_ZERO_CDH) |
+						V_H2C_DESC_GL_LEN(1); 
+			tlen -= len;
+			addr += len;
+			data_cnt += len;
+		}
+
+		desc_used += desc_cnt;
+		desc_avail -= desc_cnt;
+
+		/* sg not used up */
+		if (tlen) {
+			desc->cdh_flags |= 1 << S_H2C_DESC_F_REQ_SDI;
+			sg_offset = sg->len - tlen;
+			break;
+		} else if ((i + 1) == sg_max) {
+			desc->flags |= S_H2C_DESC_F_EOP;
+			desc->cdh_flags |= 1 << S_H2C_DESC_F_REQ_SDI;
+			if (req->h2c_eot)
+				desc->cdh_flags |=  1 << S_H2C_DESC_F_EOT;
+		} else if (!desc_avail) {
+			desc = qdesc_head[desc_cnt].desc;
+			desc->cdh_flags |= 1 << S_H2C_DESC_F_REQ_SDI;
+		}
+#if 0
+		/* dump out the descriptors */
+                for (j = 0, qdesc = qdesc_head; j < desc_cnt; j++,
+			qdesc = qdesc->next) {
+                        desc = qdesc->desc;
+			pr_info("%s: desc %d, cdh_flags 0x%x, pld_len 0x%x, "
+				"len 0x%x, flags 0x%x, addr 0x%x.\n",
+				__func__, j, desc->cdh_flags, desc->pld_len,
+				desc->len, desc->flags, desc->src_addr);
+		}
+#endif
+        }
+
+update_req:
+        qdma_update_request(qhndl, req, desc_used, data_cnt, sg_offset, sg);
+
+        return desc_used;
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/stmc.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/stmc.h
@@ -1,0 +1,61 @@
+/*
+* Streaming Platform STM-C.
+* 
+* Copyright (C) 2020-  Xilinx, Inc. All rights reserved.
+*
+* Authors: Karen.Xie@Xilinx.com
+*
+* This software is licensed under the terms of the GNU General Public
+* License version 2, as published by the Free Software Foundation, and
+* may be copied, distributed, and modified under those terms.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+#ifndef __STMC_H__
+#define __STMC_H__
+
+#include "libqdma4_export.h"
+
+/*
+ * STMC device
+ */
+struct stmc_dev {
+	struct pci_dev *pdev;
+	char 		*name;
+	unsigned char	bar_num;
+	unsigned int	reg_base;
+	void __iomem	*regs;
+	spinlock_t	ctx_prog_lock;
+};
+
+struct stmc_queue_conf {
+	unsigned int	qid_hw;
+	bool		c2h;
+	unsigned int	flow_id;
+	unsigned int	tdest;
+	struct qdma_queue_conf *qconf;
+};
+
+/*
+ * STM-C device
+ */
+void stmc_cleanup(struct stmc_dev *);
+int stmc_init(struct stmc_dev *, struct qdma_dev_conf *); 
+
+/*
+ * STM-C queue context
+ */
+int stmc_queue_context_cleanup(struct stmc_dev *, struct stmc_queue_conf *);
+int stmc_queue_context_setup(struct stmc_dev *, struct qdma_queue_conf *,
+				struct stmc_queue_conf *, unsigned int,
+				unsigned int);
+void stmc_queue_context_dump(struct stmc_dev *, struct stmc_queue_conf *);
+
+int stmc_req_bypass_desc_fill(void *qhndl, enum qdma_q_mode q_mode,
+                        enum qdma_q_dir q_dir, struct qdma_request *req);
+
+#endif /* __STMC_H__ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -88,6 +88,7 @@ struct p2p {
 	struct platform_device	*pdev;
 	void		__iomem	*remapper;
 	struct mutex		p2p_lock;
+	struct xocl_p2p_privdata *priv_data;
 
 	int			p2p_bar_idx;
 	ulong			p2p_bar_len;
@@ -530,8 +531,11 @@ static int p2p_mem_init(struct p2p *p2p)
 
 
 	remap_reg_wr(p2p, 0, slot_num);
-	remap_reg_wr(p2p, P2P_ADDR_LO(pa), base_addr_lo);
-	remap_reg_wr(p2p, P2P_ADDR_HI(pa), base_addr_hi);
+	if (p2p->priv_data &&
+	    p2p->priv_data->flags == XOCL_P2P_FLAG_SIBASE_NEEDED) {
+		remap_reg_wr(p2p, P2P_ADDR_LO(pa), base_addr_lo);
+		remap_reg_wr(p2p, P2P_ADDR_HI(pa), base_addr_hi);
+	}
 	remap_reg_wr(p2p, fls64(p2p->remap_range) - 1, log_range);
 
 	p2p_info(p2p, "Init remapper. range %ld, slot size %ld, num %ld",
@@ -1139,6 +1143,7 @@ static int p2p_probe(struct platform_device *pdev)
 	p2p->pdev = pdev;
 	mutex_init(&p2p->p2p_lock);
 
+	p2p->priv_data = XOCL_GET_SUBDEV_PRIV(&pdev->dev);
 	for (res = platform_get_resource(pdev, IORESOURCE_MEM, i); res;
 	    res = platform_get_resource(pdev, IORESOURCE_MEM, ++i)) {
 		if (!strncmp(res->name, NODE_REMAP_P2P,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma.c
@@ -1250,7 +1250,7 @@ static ssize_t queue_write_iter(struct kiocb *kiocb, struct iov_iter *io)
 	qdma = queue->qdma;
 
 	nr = io->nr_segs;
-	if (!iter_is_iovec(io) || nr != 2) {
+	if (!iter_is_iovec(io) || (nr & 0x1)) {
 		xocl_err(&qdma->pdev->dev, "Invalid request nr = %ld", nr);
 		return -EINVAL;
 	}
@@ -1272,7 +1272,7 @@ static ssize_t queue_read_iter(struct kiocb *kiocb, struct iov_iter *io)
 	qdma = queue->qdma;
 
 	nr = io->nr_segs;
-	if (!iter_is_iovec(io) || nr != 2) {
+	if (!iter_is_iovec(io) || (nr & 0x1)) {
 		xocl_err(&qdma->pdev->dev, "Invalid request nr = %ld", nr);
 		return -EINVAL;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020- Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>
@@ -27,6 +27,8 @@
 #include "../xocl_drv.h"
 #include "../xocl_drm.h"
 #include "../lib/libqdma4/libqdma4_export.h"
+#include "../lib/libqdma4/qdma_ul_ext.h"
+#include "../lib/libqdma4/stmc.h"
 #include "qdma_ioctl.h"
 
 #define XOCL_FILE_PAGE_OFFSET   0x100000
@@ -42,11 +44,6 @@
 
 /* streaming defines */
 #define	MINOR_NAME_MASK		0xffffffff
-
-#define	STREAM_FLOWID_MASK	0xff
-#define	STREAM_SLRID_SHIFT	16
-#define	STREAM_SLRID_MASK	0xff
-#define	STREAM_TDEST_MASK	0xffff
 
 #define	STREAM_DEFAULT_H2C_RINGSZ_IDX		0
 #define	STREAM_DEFAULT_C2H_RINGSZ_IDX		0
@@ -129,17 +126,13 @@ struct qdma_stream_queue {
 	struct xocl_qdma	*qdma;
 	unsigned long		queue;
 	struct qdma_queue_conf  qconf;
+	struct stmc_queue_conf  sqconf;
 	u32			state;
 	spinlock_t		qlock;
 	unsigned long		refcnt;
 	wait_queue_head_t 	wq;
-	int			flowid;
-	int			routeid;
-        u8			cdh_max; /** max 16. CDH length per packet */
-        u8			pipe_gl_max; /** <= 7, max # gather buf. per packet */
-        u8			 pipe_flow_id;	/** pipe flow id */
-        u8			 pipe_slr_id;	/** pipe SLR id */
-        u16			 pipe_tdest;	/** pipe route id */
+	unsigned int		flowid;
+	unsigned int		routeid;
 
 	struct file		*file;
 	int			qfd;
@@ -154,18 +147,10 @@ struct qdma_stream_queue {
 	unsigned int 		req_cancel_cmpl_cnt;
 };
 
-struct stm2_dev {
-	unsigned char		bar_num;
-	unsigned int		reg_base;
-	void __iomem		*stm_regs;
-	unsigned long		dma_hndl;
-};
-
-
 struct xocl_qdma {
 	unsigned long 		dma_hndl;
 	struct qdma_dev_conf	dev_conf;
-	struct stm2_dev		stm_dev;
+	struct stmc_dev		stm_dev;
 
 	struct platform_device	*pdev;
 	/* Number of bidirectional channels */
@@ -879,6 +864,8 @@ static void qdma_isr(unsigned long dma_handle, int irq, unsigned long arg)
 	irq_entry = &qdma->user_msix_table[irq];
 	if (irq_entry->in_use)
 		irq_entry->handler(irq, irq_entry->arg);
+	else
+		xocl_info(&qdma->pdev->dev, "user irq %d not in use", irq);
 }
 
 static struct xocl_dma_funcs qdma_ops = {
@@ -1391,6 +1378,10 @@ static int queue_flush(struct qdma_stream_queue *queue)
 			"Stop queue failed ret = %ld", ret);
 		return ret;
 	}
+
+	if (queue->qconf.st)
+		stmc_queue_context_cleanup(&qdma->stm_dev, &queue->sqconf);
+
 	ret = qdma4_queue_remove(qdma->dma_hndl, queue->queue, NULL, 0);
 	if (ret < 0) {
 		xocl_err(&qdma->pdev->dev,
@@ -1477,7 +1468,7 @@ static struct file_operations queue_fops = {
 };
 
 /* stream device file operations */
-static long qdma_stream_ioctl_create_queue(struct xocl_qdma *qdma,
+static long qdma4_stream_ioctl_create_queue(struct xocl_qdma *qdma,
 			void __user *arg)
 {
 	struct xocl_qdma_ioc_create_queue req;
@@ -1503,43 +1494,41 @@ static long qdma_stream_ioctl_create_queue(struct xocl_qdma *qdma,
 	init_waitqueue_head(&queue->wq);
 
 	qconf = &queue->qconf;
+	qconf->quld = (unsigned long)queue;
 	qconf->st = 1; /* stream queue */
 	qconf->qidx = QDMA_QUEUE_IDX_INVALID; /* request libqdma to alloc */
-	qconf->wb_status_en =1;
-	qconf->cmpl_status_acc_en=1;
-	qconf->cmpl_status_pend_chk=1;
-	qconf->fetch_credit=1;
-	qconf->cmpl_stat_en=1;
-	qconf->cmpl_trig_mode=1;
-	qconf->irq_en = (req.flags & XOCL_QDMA_QUEUE_FLAG_POLLING) ? 0 : 1;
 
 	if (!req.write) {
 		/* C2H */
+		qconf->cmpl_desc_sz = DESC_SZ_8B;
+		qconf->c2h_buf_sz_idx = 0;	/* 4K */
+		qconf->cmpl_trig_mode = TRIG_MODE_ANY;
+		qconf->cmpl_en_intr = (qdma->dev_conf.qdma_drv_mode == POLL_MODE) ?  0 : 1;
+
 		qconf->q_type = Q_C2H;
-		queue->pipe_tdest = req.rid & STREAM_TDEST_MASK;
 		qconf->desc_rng_sz_idx = qdma->c2h_ringsz_idx;
 		qconf->cmpl_rng_sz_idx = qdma->wrb_ringsz_idx;
 
-		queue->pipe_flow_id = req.flowid & STREAM_FLOWID_MASK;
-		queue->pipe_slr_id = (req.rid >> STREAM_SLRID_SHIFT) &
-		STREAM_SLRID_MASK;
+		qconf->init_pidx_dis = 1;
 	} else {
 		/* H2C */
 		qconf->q_type = Q_H2C;
 		qconf->desc_bypass = 1;
 		qconf->desc_rng_sz_idx = qdma->h2c_ringsz_idx;
-
-		queue->pipe_flow_id = req.flowid & STREAM_FLOWID_MASK;
-		queue->pipe_slr_id = (req.rid >> STREAM_SLRID_SHIFT) &
-		STREAM_SLRID_MASK;
-		queue->pipe_tdest = req.rid & STREAM_TDEST_MASK;
-		queue->pipe_gl_max = 1;
+		qconf->fp_bypass_desc_fill = stmc_req_bypass_desc_fill;
 	}
+	qconf->wb_status_en =1;
+	qconf->fetch_credit=1;
+	qconf->cmpl_status_acc_en=1;
+	qconf->cmpl_status_pend_chk=1;
+	qconf->cmpl_stat_en=1;
+	qconf->cmpl_trig_mode=1;
+	qconf->irq_en = (qdma->dev_conf.qdma_drv_mode == POLL_MODE) ?  0 : 1;
+	qconf->init_pidx_dis = 1;
+
+
 	queue->flowid = req.flowid;
 	queue->routeid = req.rid;
-	xocl_info(&qdma->pdev->dev, "Creating %s queue with tdest %d, flow %d, "
-		"slr %d", qconf->q_type == Q_C2H ? "C2H" : "H2C",
-		queue->pipe_tdest, queue->pipe_flow_id, queue->pipe_slr_id);
 
 	ret = qdma4_queue_add(qdma->dma_hndl, qconf, &queue->queue, NULL, 0);
 	if (ret < 0) {
@@ -1554,15 +1543,26 @@ static long qdma_stream_ioctl_create_queue(struct xocl_qdma *qdma,
 			ret);
 		goto failed;
 	}
-#if 0
-//	ret = qdma_queue_prog_stm(qdma->dma_hndl, queue->queue, NULL, 0);
-	ret = stm2_queue_prog(qdma->dma_hndl, queue->queue, NULL, 0);
+
+	ret = stmc_queue_context_setup(&qdma->stm_dev, qconf, &queue->sqconf,
+					req.flowid, req.rid);
 	if (ret < 0) {
-		xocl_err(&qdma->pdev->dev, "STM prog. Queue failed ret = %ld",
-			ret);
+		xocl_err(&qdma->pdev->dev, 
+			"%s STM prog. Queue failed ret = %ld",
+			qconf->name, ret);
 		goto failed;
 	}
-#endif
+
+	/* update pidx/cidx for C2H */
+	if (qconf->q_type == Q_C2H) {
+		ret = qdma_q_init_pointers(qdma->dma_hndl, queue->queue);
+		if (ret < 0) {
+			xocl_err(&qdma->pdev->dev,
+				"%s update pidx/cidx failed = %ld",
+				qconf->name, ret);
+			goto failed;
+		}
+	}
 
 	ret = qdma4_queue_get_config(qdma->dma_hndl, queue->queue, qconf, NULL, 0);
 	if (ret < 0) {
@@ -1632,13 +1632,14 @@ failed:
 	}
 
 	qdma4_queue_stop(qdma->dma_hndl, queue->queue, NULL, 0);
+	stmc_queue_context_cleanup(&qdma->stm_dev, &queue->sqconf);
 	qdma4_queue_remove(qdma->dma_hndl, queue->queue, NULL, 0);
 	queue->queue = 0UL;
 
 	return ret;
 }
 
-static long qdma_stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
+static long qdma4_stream_ioctl_alloc_buffer(struct xocl_qdma *qdma,
 			void __user *arg)
 {
 	struct xocl_qdma_ioc_alloc_buf req;
@@ -1740,7 +1741,7 @@ failed:
 	return ret;
 }
 
-static long qdma_stream_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
+static long qdma4_stream_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 {
 	struct xocl_qdma *qdma;
 	long result = 0;
@@ -1749,10 +1750,10 @@ static long qdma_stream_ioctl(struct file *filp, unsigned int cmd, unsigned long
 
 	switch (cmd) {
 	case XOCL_QDMA_IOC_CREATE_QUEUE:
-		result = qdma_stream_ioctl_create_queue(qdma, (void __user *)arg);
+		result = qdma4_stream_ioctl_create_queue(qdma, (void __user *)arg);
 		break;
 	case XOCL_QDMA_IOC_ALLOC_BUFFER:
-		result = qdma_stream_ioctl_alloc_buffer(qdma, (void __user *)arg);
+		result = qdma4_stream_ioctl_alloc_buffer(qdma, (void __user *)arg);
 		break;
 	default:
 		xocl_err(&qdma->pdev->dev, "Invalid request %u", cmd & 0xff);
@@ -1800,8 +1801,46 @@ static const struct file_operations qdma_stream_fops = {
 	.owner = THIS_MODULE,
 	.open = qdma_stream_open,
 	.release = qdma_stream_close,
-	.unlocked_ioctl = qdma_stream_ioctl,
+	.unlocked_ioctl = qdma4_stream_ioctl,
 };
+
+static int qdma4_csr_prog_ta(struct pci_dev *pdev, int bar,
+				resource_size_t base)
+{
+	resource_size_t bar_start;
+	void __iomem    *regs;
+
+	bar_start = pci_resource_start(pdev, bar);
+        regs = ioremap_nocache(bar_start + base, 0x4000);
+        if (!regs) {
+                pr_warn("%s unable to map csr bar %d, base 0x%lx.\n",
+			dev_name(&pdev->dev), bar, (unsigned long)base);
+                return -EINVAL;
+        }
+
+	/* To enable slave bridge:
+	 * First entry of the BDF table programming.
+	 * Offset	Program Value	Register info
+	 * 0x2420	0x0	Address translation value Low
+	 * 0x2424	0x0	Address translation value High
+	 * 0x2428	0x0	PASID
+	 * 0x242C	0x1	[11:0]: Function Number
+	 * 0x2430	0xC2000000	[31:30] Read/Write Access permission
+	 *				[25:0] Window Size
+	 * 				([25:0]*4K  = actual size of the window)
+	 * 0x2434	0x0	SMID
+	 */
+
+	writel(0, regs + 0x2420);
+	writel(0, regs + 0x2424);
+	writel(0, regs + 0x2428);
+	writel(1, regs + 0x242C);
+	writel(0xC2000000, regs + 0x2430);
+	writel(0, regs + 0x2434);
+
+	iounmap(regs);
+	return 0;
+}
 
 static int qdma4_probe(struct platform_device *pdev)
 {
@@ -1810,7 +1849,9 @@ static int qdma4_probe(struct platform_device *pdev)
 	xdev_handle_t	xdev;
 	struct resource *res = NULL;
 	int	i, ret = 0, dma_bar = -1, stm_bar = -1;
+	int csr_bar = -1;
 	resource_size_t stm_base = -1;
+	resource_size_t csr_base = -1;
 
 	xdev = xocl_get_xdev(pdev);
 
@@ -1828,15 +1869,32 @@ static int qdma4_probe(struct platform_device *pdev)
 		res;	
 		res = platform_get_resource(pdev, IORESOURCE_MEM, ++i)) {
 		if (!strncmp(res->name, NODE_QDMA4, strlen(NODE_QDMA4))) {
-			ret = xocl_ioaddr_to_baroff(xdev, res->start, &dma_bar, NULL);
+			ret = xocl_ioaddr_to_baroff(xdev, res->start, &dma_bar,
+							NULL);
 			if (ret) {
-				xocl_err(&pdev->dev, "Invalid resource %pR", res);
+				xocl_err(&pdev->dev,
+					"Invalid resource %pR", res);
 				return -EINVAL;
 			}
-		} else if (!strncmp(res->name, NODE_STM4, strlen(NODE_STM4))) {
-			ret = xocl_ioaddr_to_baroff(xdev, res->start, &stm_bar, NULL);
+		} else if (!strncmp(res->name, NODE_QDMA4_CSR,
+					strlen(NODE_QDMA4_CSR))) {
+			ret = xocl_ioaddr_to_baroff(xdev, res->start, &csr_bar,
+							NULL);
 			if (ret) {
-				xocl_err(&pdev->dev, "Invalid resource %pR", res);
+				xocl_err(&pdev->dev,
+					 "CSR: Invalid resource %pR", res);
+				return -EINVAL;
+			}
+
+			csr_base = res->start -
+				pci_resource_start(XDEV(xdev)->pdev, csr_bar);
+
+		} else if (!strncmp(res->name, NODE_STM4, strlen(NODE_STM4))) {
+			ret = xocl_ioaddr_to_baroff(xdev, res->start, &stm_bar,
+							NULL);
+			if (ret) {
+				xocl_err(&pdev->dev,
+					"STM Invalid resource %pR", res);
 				return -EINVAL;
 			}
 			if (stm_bar == -1)
@@ -1850,18 +1908,12 @@ static int qdma4_probe(struct platform_device *pdev)
 		}
 	}
 
-	if (dma_bar == -1 || stm_base == -1 || stm_bar == -1) {
+	if (dma_bar == -1) {
 		xocl_err(&pdev->dev,
 			"missing resource, dma_bar %d, stm_bar %d, stm_base 0x%lx.",
 			dma_bar, stm_bar, (unsigned long)stm_base);
-		//return -EINVAL;
+		return -EINVAL;
 	}
-
-	pr_info("%s: dma_bar %d, stm_bar %d, stm_base 0x%lx.\n", __func__, dma_bar, stm_bar, (unsigned long)stm_base);
-
-
-	qdma->stm_dev.bar_num = stm_bar;
-	qdma->stm_dev.reg_base = stm_base;
 
 	conf = &qdma->dev_conf;
 	memset(conf, 0, sizeof(*conf));
@@ -1884,11 +1936,42 @@ static int qdma4_probe(struct platform_device *pdev)
 	conf->fp_user_isr_handler = qdma_isr;
 	conf->uld = (unsigned long)qdma;
 
+	xocl_info(&pdev->dev, "dma %d, mode 0x%x.\n",
+		dma_bar, conf->qdma_drv_mode);
 	ret = qdma4_device_open(XOCL_MODULE_NAME, conf, &qdma->dma_hndl);
 	if (ret < 0) {
 		xocl_err(&pdev->dev, "QDMA Device Open failed");
 		goto failed;
 	}
+
+	if (csr_bar >= 0) {
+		xocl_info(&pdev->dev, "csr bar %d, base 0x%lx.",
+			csr_bar, (unsigned long)csr_base);
+
+		ret = qdma4_csr_prog_ta(XDEV(xdev)->pdev, csr_bar, csr_base);
+		if (ret < 0)
+			xocl_err(&pdev->dev,
+				"Slave bridge BDF program failed (%d,0x%lx).",
+				csr_bar, (unsigned long)csr_base);
+		else
+			xocl_info(&pdev->dev,
+				"Slave bridge BDF programmed (%d,0x%lx).",
+				csr_bar, (unsigned long)csr_base);
+	}
+
+	if (stm_bar >= 0) {
+		struct stmc_dev *sdev = &qdma->stm_dev;
+
+		xocl_info(&pdev->dev, "stm bar %d, base 0x%lx.",
+			stm_bar, (unsigned long)stm_base);
+
+		sdev->reg_base = stm_base;
+		sdev->bar_num = stm_bar;
+		ret = stmc_init(sdev, conf);
+		if (ret < 0)
+			xocl_warn(&pdev->dev, "QDMA Device STM-C failed");
+	} else
+		xocl_info(&pdev->dev, "QDMA Device STM-C not present");
 
 	if (!XOCL_DSA_IS_SMARTN(xdev)) {
 		ret = set_max_chan(qdma, qdma4_max_channel);
@@ -1925,6 +2008,8 @@ failed:
 	if (qdma) {
 		free_channels(qdma->pdev);
 
+		stmc_cleanup(&qdma->stm_dev);
+
 		if (qdma->dma_hndl)
 			qdma4_device_close(XDEV(xdev)->pdev, qdma->dma_hndl);
 
@@ -1955,6 +2040,8 @@ static int qdma4_remove(struct platform_device *pdev)
 	xdev = xocl_get_xdev(pdev);
 
 	free_channels(pdev);
+
+	stmc_cleanup(&qdma->stm_dev);
 
 	qdma4_device_close(XDEV(xdev)->pdev, qdma->dma_hndl);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -178,6 +178,31 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	return flash_priv;
 }
 
+static void *p2p_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
+{
+	struct xocl_dev_core *core = XDEV(xdev_hdl);
+	void *blob;
+	struct xocl_p2p_privdata *p2p_priv;
+	int node;
+
+	blob = core->fdt_blob;
+	if (!blob)
+		return NULL;
+
+	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_XDMA);
+	if (node < 0)
+		return NULL;
+
+	p2p_priv = vzalloc(sizeof(*p2p_priv));
+	if (!p2p_priv)
+		return NULL;
+
+	p2p_priv->flags = XOCL_P2P_FLAG_SIBASE_NEEDED;
+	*len = sizeof(*p2p_priv);
+
+	return p2p_priv;
+}
+
 static void devinfo_cb_setlevel(void *dev_hdl, void *subdevs, int num)
 {
 	struct xocl_subdev *subdev = subdevs;
@@ -261,6 +286,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		.res_array = (struct xocl_subdev_res[]) {
 			{.res_name = NODE_QDMA4},
 			{.res_name = NODE_STM4},
+			{.res_name = NODE_QDMA4_CSR},
 			{NULL},
 		},
 		.required_ip = 1,
@@ -578,7 +604,7 @@ static struct xocl_subdev_map subdev_map[] = {
 		},
 		.required_ip = 1,
 		.flags = 0,
-		.build_priv_data = NULL,
+		.build_priv_data = p2p_build_priv,
 		.devinfo_cb = NULL,
 	},
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -72,6 +72,7 @@
 #define NODE_MSIX "ep_msix_00"
 #define NODE_QDMA "ep_qdma_00"
 #define NODE_QDMA4 "ep_qdma4_00"
+#define NODE_QDMA4_CSR "ep_qdma4_csr_00"
 #define NODE_STM "ep_stream_traffic_manager_00"
 #define NODE_STM4 "ep_stream_traffic_manager4_00"
 #define NODE_CLK_SHUTDOWN "ep_aclk_shutdown_00"

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -575,6 +575,8 @@ int shim::dev_init()
     mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
 
     mStreamHandle = mDev->open("dma.qdma", O_RDWR | O_SYNC);
+    if (mStreamHandle <= 0)
+	mStreamHandle = mDev->open("dma.qdma4", O_RDWR | O_SYNC);
     memset(&mAioContext, 0, sizeof(mAioContext));
     mAioEnabled = (io_setup(SHIM_QDMA_AIO_EVT_MAX, &mAioContext) == 0);
 


### PR DESCRIPTION
backported:
-  qdma4: preconfig for slave bridge and enable ST (#3730) 
-  workaround p2p remap base issue (#3716)