### PR TITLE
Backport CR1068638 

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -943,18 +943,20 @@ static int p2p_release_resource(struct platform_device *pdev,
 	struct resource *res)
 {
 	struct p2p *p2p = platform_get_drvdata(pdev);
+	ulong bar_off;
 
 	if (res->start < p2p->p2p_bar_start ||
 	    res->start >= p2p->p2p_bar_start + p2p->p2p_bar_len)
 		return 0;
 
+	bar_off = res->start - p2p->p2p_bar_start;
 	if (!p2p->remapper) {
 		p2p_err(p2p, "remap does not exist");
 		return -EINVAL;
 	}
 
-	p2p_info(p2p, "Remap release resource %pR", res);
-	p2p_bar_unmap(p2p, res->start);
+	p2p_info(p2p, "Remap release resource %lx", bar_off);
+	p2p_bar_unmap(p2p, bar_off);
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1343,7 +1343,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			    (subdev_info.priv_data))->flash_type,
 			    FLASH_TYPE_QSPIPS, strlen(FLASH_TYPE_QSPIPS));
 			/* default is FLASH_TYPE_SPI, thus pass through. */
-			__attribute__ ((fallthrough));
+			/* fall through */
 		case XOCL_VSEC_FLASH_TYPE_SPI_IP:
 		case XOCL_VSEC_FLASH_TYPE_SPI_REG:
 			xocl_xdev_info(xdev,


### PR DESCRIPTION
this is back porting firewall 1.1 to PU1. Note, without this, XRT will not be able to detect C2H firewall trip