### PR TITLE
Add import / export xrt::bo

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -49,6 +49,12 @@ struct ishim
   virtual void
   free_bo(xclBufferHandle boh) = 0;
 
+  virtual xclBufferExportHandle
+  export_bo(xclBufferHandle boh) = 0;
+
+  virtual xclBufferHandle
+  import_bo(xclBufferExportHandle ehdl) = 0;
+
   virtual void
   copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset) = 0;
 
@@ -134,6 +140,23 @@ struct shim : public DeviceType
   free_bo(xclBufferHandle bo)
   {
     xclFreeBO(DeviceType::get_device_handle(), bo);
+  }
+
+  virtual xclBufferExportHandle
+  export_bo(xclBufferHandle bo)
+  {
+    auto ehdl = xclExportBO(DeviceType::get_device_handle(), bo);
+    if (ehdl < 0)
+      throw std::runtime_error("Unable to export BO");
+    return ehdl;
+  }
+
+  virtual xclBufferHandle
+  import_bo(xclBufferExportHandle ehdl)
+  {
+    if (auto bo = xclImportBO(DeviceType::get_device_handle(), ehdl, 0))
+      return bo;
+    throw std::runtime_error("unable to import BO");
   }
 
   virtual void

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -33,7 +33,7 @@ struct ishim
 {
   virtual void
   close_device() = 0;
-  
+
   virtual void
   open_context(xuid_t xclbin_uuid, unsigned int ip_index, bool shared) = 0;
 
@@ -146,7 +146,7 @@ struct shim : public DeviceType
   export_bo(xclBufferHandle bo)
   {
     auto ehdl = xclExportBO(DeviceType::get_device_handle(), bo);
-    if (ehdl < 0)
+    if (ehdl == XRT_NULL_BO_EXPORT)
       throw std::runtime_error("Unable to export BO");
     return ehdl;
   }

--- a/src/runtime_src/core/include/experimental/xrt_bo.h
+++ b/src/runtime_src/core/include/experimental/xrt_bo.h
@@ -90,6 +90,18 @@ public:
   bo(xclDeviceHandle dhdl, size_t size, buffer_flags flags, memory_group grp);
 
   /**
+   * bo() - Constructor to import an exported buffer
+   *
+   * @dhdl:     Device that imports the exported buffer
+   * @ehdl:     Exported buffer handle, implementation specific type
+   * 
+   * The exported buffer handle is acquired by using the export() method
+   * and can be passed to another process.  
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(xclDeviceHandle dhdl, xclBufferExportHandle ehdl);
+
+  /**
    * bo() - Constructor for sub-buffer
    *
    * @parent:   Parent buffer
@@ -122,6 +134,27 @@ public:
     handle = std::move(rhs.handle);
     return *this;
   }
+
+  /**
+   * size() - Get the size of this buffer
+   *
+   * Return: size of buffer in bytes
+   */
+  XCL_DRIVER_DLLESPEC
+  size_t
+  size() const;
+
+  /**
+   * buffer_export() - Export this buffer
+   *
+   * Return:  exported buffer handle
+   *
+   * An exported buffer can be imported on another device by this
+   * process or another process.
+   */
+  XCL_DRIVER_DLLESPEC
+  xclBufferExportHandle
+  export_buffer();
 
   /**
    * sync() - Synchronize buffer content with device side 
@@ -219,7 +252,7 @@ xrtBufferHandle
 xrtBOAllocUserPtr(xclDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp);
 
 /**
- * xclBOAlloc() - Allocate a BO of requested size with appropriate flags
+ * xrtBOAlloc() - Allocate a BO of requested size with appropriate flags
  *
  * @handle:        Device handle
  * @size:          Size of buffer
@@ -232,7 +265,32 @@ xrtBufferHandle
 xrtBOAlloc(xclDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp);
 
 /**
- * xclBOSubAlloc() - Allocate a sub buffer from a parent buffer
+ * xrtBOImport() - Allocate a BO imported from another device
+ *
+ * @dhdl:     Device that imports the exported buffer
+ * @ehdl:     Exported buffer handle, implementation specific type
+ * 
+ * The exported buffer handle is acquired by using the export() method
+ * and can be passed to another process.  
+ */  
+XCL_DRIVER_DLLESPEC
+xrtBufferHandle
+xrtBOImport(xclDeviceHandle dhdl, xclBufferExportHandle ehdl);
+
+/**
+ * xrtBOExport() - Export this buffer
+ *
+ * Return:  exported buffer handle
+ *
+ * An exported buffer can be imported on another device by this
+ * process or another process.
+ */
+XCL_DRIVER_DLLESPEC
+xclBufferExportHandle
+xrtBOExport(xrtBufferHandle bhdl);
+
+/**
+ * xrtBOSubAlloc() - Allocate a sub buffer from a parent buffer
  *
  * @parent:        Parent buffer handle
  * @size:          Size of sub buffer 
@@ -252,6 +310,16 @@ xrtBOSubAlloc(xrtBufferHandle parent, size_t size, size_t offset);
 XCL_DRIVER_DLLESPEC
 int
 xrtBOFree(xrtBufferHandle handle);
+
+/**
+ * xrtBOSize() - Get the size of this buffer
+ *
+ * @handle:       Buffer handle
+ * Return:        Size of buffer in bytes
+ */
+XCL_DRIVER_DLLESPEC
+size_t
+xrtBOSize(xrtBufferHandle handle);
 
 /**
  * xrtBOSync() - Synchronize buffer contents in requested direction

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -87,6 +87,21 @@ typedef unsigned int xclBufferHandle;
 #endif
 #define XRT_NULL_BO NULLBO
 
+/*
+ * typedef xclBufferExportHandle
+ *
+ * Implementation specific type representing an exported buffer handle
+ * that can be passed between processes.
+ */
+#ifdef _WIN32
+typedef void* xclBufferExportHandle;  // TBD
+#define NULLBOEXPORT INVALID_HANDLE_VALUE
+#else
+typedef int32_t xclBufferExportHandle;
+#define NULLBOEXPORT -1;
+#endif
+#define XRT_NULL_BO_EXPORT NULLBOEXPORT
+
 struct axlf;
 
 /**
@@ -585,7 +600,7 @@ xclCopyBO(xclDeviceHandle handle, xclBufferHandle dstBoHandle,
  * framework
  */
 XCL_DRIVER_DLLESPEC
-int
+xclBufferExportHandle
 xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle);
 
 /**
@@ -601,7 +616,7 @@ xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle);
  */
 XCL_DRIVER_DLLESPEC
 xclBufferHandle
-xclImportBO(xclDeviceHandle handle, int fd, unsigned int flags);
+xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned int flags);
 
 /**
  * xclGetBOProperties() - Obtain xclBOProperties struct for a BO

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -98,7 +98,7 @@ typedef void* xclBufferExportHandle;  // TBD
 #define NULLBOEXPORT INVALID_HANDLE_VALUE
 #else
 typedef int32_t xclBufferExportHandle;
-#define NULLBOEXPORT -1;
+#define NULLBOEXPORT -1
 #endif
 #define XRT_NULL_BO_EXPORT NULLBOEXPORT
 

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1454,7 +1454,7 @@ xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclExportBO() NOT IMPLEMENTED");
-  return -ENOSYS;
+  return INVALID_HANDLE_VALUE;
 }
 
 xclBufferHandle

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1449,14 +1449,16 @@ xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
   return shim->exec_wait(timeoutMilliSec);
 }
 
-int xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
+xclBufferExportHandle
+xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclExportBO() NOT IMPLEMENTED");
-  return ENOSYS;
+  return -ENOSYS;
 }
 
-xclBufferHandle xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
+xclBufferHandle
+xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned flags)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "xclImportBO() NOT IMPLEMENTED");


### PR DESCRIPTION
An buffer object can be exported from one process and imported by
another.

This change exposes xclExportBO and xclImportBO to the XRT Native API
level. It uses an opaque implementation define xclBufferExportHandle
type, which on Linux is a dmabuf file descriptor and is TBD on
Windows.

Also add size() method to xrt::bo.