### PR TITLE
Fix GMIO interfaces

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -140,7 +140,7 @@ get_gmio(const pt::ptree& aie_meta)
   for (auto& gmio_node : aie_meta.get_child("aie_metadata.GMIOs")) {
     gmio_type gmio;
 
-    gmio.id = gmio_node.second.get<std::string>("id");
+    gmio.id = gmio_node.second.get<uint32_t>("id");
     gmio.name = gmio_node.second.get<std::string>("name");
     gmio.type = gmio_node.second.get<uint16_t>("type");
     gmio.shim_col = gmio_node.second.get<uint16_t>("shim_column");

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -16,9 +16,7 @@
 
 #include "aie_parser.h"
 #include "core/common/device.h"
-#ifndef __AIESIM__
 #include "core/include/xclbin.h"
-#endif
 
 #include <sstream>
 #include <string>

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -82,9 +82,9 @@ get_rtp(const xrt_core::device* device);
 
 struct gmio_type
 {
-  std::string     id;
   std::string     name;
 
+  uint32_t        id;
   uint16_t        type;
   uint16_t        shim_col;
   uint16_t        channel_number;

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -41,7 +41,7 @@ get_bd_low_addr(uint64_t addr)
   return (addr & low_mask);
 }
 
-Aie::Aie(std::shared_ptr<xrt_core::device> device)
+Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
 {
     /* TODO where are these number from */
     numRows = 8;
@@ -258,7 +258,7 @@ sync_bo_nb(uint64_t paddr, const char *gmioName, enum xclBOSyncDirection dir, si
 
 void
 Aie::
-wait_gmio(const char *gmioName)
+wait_gmio(const std::string& gmioName)
 {
   auto gmio = std::find_if(gmios.begin(), gmios.end(),
             [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
@@ -273,7 +273,7 @@ wait_gmio(const char *gmioName)
 
 void
 Aie::
-submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator gmio, enum xclBOSyncDirection dir, size_t size)
+submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size)
 {
   switch (dir) {
   case XCL_BO_SYNC_BO_GMIO_TO_AIE:
@@ -330,7 +330,7 @@ submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator gmio, enum xclBO
 
 void
 Aie::
-wait_sync_bo(ShimDMA *dmap, uint32_t chan, uint32_t timeout)
+wait_sync_bo(ShimDMA* const dmap, uint32_t chan, uint32_t timeout)
 {
   while ((XAieDma_ShimWaitDone(&(dmap->handle), chan, timeout) != XAIEGBL_NOC_DMASTA_STA_IDLE));
 

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -18,12 +18,28 @@
 
 #include "aie.h"
 #include "core/common/error.h"
+#ifndef __AIESIM__
 #include "core/common/message.h"
+#endif
 
 #include <iostream>
 #include <cerrno>
 
 namespace zynqaie {
+
+static inline uint64_t
+get_bd_high_addr(uint64_t addr)
+{
+  constexpr uint64_t hi_mask = 0xFFFF00000000L;
+  return ((addr & hi_mask) >> 32);
+}
+
+static inline uint64_t
+get_bd_low_addr(uint64_t addr)
+{
+  constexpr uint32_t low_mask = 0xFFFFFFFFL;
+  return (addr & low_mask);
+}
 
 Aie::Aie(std::shared_ptr<xrt_core::device> device)
 {
@@ -208,6 +224,121 @@ Aie::error_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 error, v
 #endif
 
     return XAIETILE_ERROR_HANDLED;
+}
+
+void
+Aie::
+sync_bo(uint64_t paddr, const char *gmioName, enum xclBOSyncDirection dir, size_t size)
+{
+  auto gmio = std::find_if(gmios.begin(), gmios.end(),
+            [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
+
+  if (gmio == gmios.end())
+    throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
+
+  submit_sync_bo(paddr, gmio, dir, size);
+
+  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
+  auto chan = gmio->channel_number;
+  wait_sync_bo(dmap, chan, 0);
+}
+
+void
+Aie::
+sync_bo_nb(uint64_t paddr, const char *gmioName, enum xclBOSyncDirection dir, size_t size)
+{
+  auto gmio = std::find_if(gmios.begin(), gmios.end(),
+            [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
+
+  if (gmio == gmios.end())
+    throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
+
+  submit_sync_bo(paddr, gmio, dir, size);
+}
+
+void
+Aie::
+wait_gmio(const char *gmioName)
+{
+  auto gmio = std::find_if(gmios.begin(), gmios.end(),
+            [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
+
+  if (gmio == gmios.end())
+    throw xrt_core::error(-EINVAL, "Can't wait GMIO: GMIO name not found");
+
+  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
+  auto chan = gmio->channel_number;
+  wait_sync_bo(dmap, chan, 0);
+}
+
+void
+Aie::
+submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator gmio, enum xclBOSyncDirection dir, size_t size)
+{
+  switch (dir) {
+  case XCL_BO_SYNC_BO_GMIO_TO_AIE:
+    if (gmio->type != 0)
+      throw xrt_core::error(-EINVAL, "Sync BO direction does not match GMIO type");
+    break;
+  case XCL_BO_SYNC_BO_AIE_TO_GMIO:
+    if (gmio->type != 1)
+      throw xrt_core::error(-EINVAL, "Sync BO direction does not match GMIO type");
+    break;
+  default:
+    throw xrt_core::error(-EINVAL, "Can't sync BO: unknown direction.");
+  }
+
+  if (size & XAIEDMA_SHIM_TXFER_LEN32_MASK != 0)
+    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: size is not 32 bits aligned.");
+
+  if (paddr & XAIEDMA_SHIM_ADDRLOW_ALIGN_MASK != 0)
+    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: address is not 128 bits aligned.");
+
+  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
+  auto chan = gmio->channel_number;
+
+  /* Find a free BD. Busy wait until we get one. */
+  while (dmap->dma_chan[chan].idle_bds.empty()) {
+    uint8_t npend = XAieDma_ShimPendingBdCount(&(dmap->handle), chan);
+    int num_comp = XAIEGBL_NOC_DMASTA_STARTQ_MAX - npend;
+
+    /* Pending BD is completed by order per Shim DMA spec. */
+    for (int i = 0; i < num_comp; ++i) {
+      BD bd = dmap->dma_chan[chan].pend_bds.front();
+      dmap->dma_chan[chan].pend_bds.pop();
+      dmap->dma_chan[chan].idle_bds.push(bd);
+    }
+  }
+
+  BD bd = dmap->dma_chan[chan].idle_bds.front();
+  dmap->dma_chan[chan].idle_bds.pop();
+  bd.addr_high = get_bd_high_addr(paddr);
+  bd.addr_low = get_bd_low_addr(paddr);
+
+  XAieDma_ShimBdSetAddr(&(dmap->handle), bd.bd_num, bd.addr_high, bd.addr_low, size);
+
+  /* Set BD lock */
+  XAieDma_ShimBdSetLock(&(dmap->handle), bd.bd_num, bd.bd_num, 1, XAIEDMA_SHIM_LKACQRELVAL_INVALID, 1, XAIEDMA_SHIM_LKACQRELVAL_INVALID);
+
+  /* Write BD */
+  XAieDma_ShimBdWrite(&(dmap->handle), bd.bd_num);
+
+  /* Enqueue BD */
+  XAieDma_ShimSetStartBd((&(dmap->handle)), chan, bd.bd_num);
+  dmap->dma_chan[chan].pend_bds.push(bd);
+}
+
+void
+Aie::
+wait_sync_bo(ShimDMA *dmap, uint32_t chan, uint32_t timeout)
+{
+  while ((XAieDma_ShimWaitDone(&(dmap->handle), chan, timeout) != XAIEGBL_NOC_DMASTA_STA_IDLE));
+
+  while (!dmap->dma_chan[chan].pend_bds.empty()) {
+    BD bd = dmap->dma_chan[chan].pend_bds.front();
+    dmap->dma_chan[chan].pend_bds.pop();
+    dmap->dma_chan[chan].idle_bds.push(bd);
+  }
 }
 
 

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -25,6 +25,7 @@
 
 #include "core/common/device.h"
 #include "core/edge/common/aie_parser.h"
+#include "experimental/xrt_bo.h"
 extern "C" {
 #include <xaiengine.h>
 }
@@ -66,6 +67,15 @@ public:
 
     XAieGbl *getAieInst();
 
+    void
+    sync_bo(uint64_t paddr, const char *dmaID, enum xclBOSyncDirection dir, size_t size);
+
+    void
+    sync_bo_nb(uint64_t paddr, const char *gmioName, enum xclBOSyncDirection dir, size_t size);
+
+    void
+    wait_gmio(const char *gmioName);
+
     static XAieGbl_ErrorHandleStatus
     error_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 error, void *arg);
 
@@ -77,8 +87,16 @@ private:
     XAieGbl_Config *aieConfigPtr; // AIE configuration pointer
     XAieGbl aieInst;              // AIE global instance
     XAieGbl_HwCfg aieConfig;      // AIE configuration pointer
+
+    void
+    submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator gmio, enum xclBOSyncDirection dir, size_t size);
+
+    /* Wait for all the BD trasters for a given channel */
+    void
+    wait_sync_bo(ShimDMA *dmap, uint32_t chan, uint32_t timeout);
 };
 
 }
 
+uint64_t xrtBOAddress(xrtBufferHandle bhdl);
 #endif

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -91,7 +91,7 @@ private:
     void
     submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size);
 
-    /* Wait for all the BD trasters for a given channel */
+    /* Wait for all the BD transfers for a given channel */
     void
     wait_sync_bo(ShimDMA* const dmap, uint32_t chan, uint32_t timeout);
 };

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -55,7 +55,7 @@ public:
     using gmio_type = xrt_core::edge::aie::gmio_type;
 
     ~Aie();
-    Aie(std::shared_ptr<xrt_core::device> device);
+    Aie(const std::shared_ptr<xrt_core::device>& device);
 
     std::vector<XAieGbl_Tile> tileArray;  // Tile Array
     std::vector<ShimDMA> shim_dma;   // shim DMA
@@ -74,7 +74,7 @@ public:
     sync_bo_nb(uint64_t paddr, const char *gmioName, enum xclBOSyncDirection dir, size_t size);
 
     void
-    wait_gmio(const char *gmioName);
+    wait_gmio(const std::string& gmioName);
 
     static XAieGbl_ErrorHandleStatus
     error_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 error, void *arg);
@@ -89,11 +89,11 @@ private:
     XAieGbl_HwCfg aieConfig;      // AIE configuration pointer
 
     void
-    submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator gmio, enum xclBOSyncDirection dir, size_t size);
+    submit_sync_bo(uint64_t paddr, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size);
 
     /* Wait for all the BD trasters for a given channel */
     void
-    wait_sync_bo(ShimDMA *dmap, uint32_t chan, uint32_t timeout);
+    wait_sync_bo(ShimDMA* const dmap, uint32_t chan, uint32_t timeout);
 };
 
 }

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -36,11 +36,10 @@ extern "C"
 }
 
 #ifdef __AIESIM__
-static zynqaie::Aie* sp_aie = nullptr;
-zynqaie::Aie* getAieArray() {
-  if (sp_aie == nullptr)
-    sp_aie = new zynqaie::Aie(xrt_core::get_userpf_device(0));
-  return sp_aie;
+zynqaie::Aie* getAieArray()
+{
+  static zynqaie::Aie s_aie(xrt_core::get_userpf_device(0));
+  return &s_aie;
 }
 #endif
 
@@ -372,7 +371,7 @@ end(uint64_t cycle)
 
 void
 graph_type::
-update_rtp(const char* port, const char* buffer, size_t size)
+update_rtp(const std::string& port, const char* buffer, size_t size)
 {
     auto rtp = std::find_if(rtps.begin(), rtps.end(),
             [port](rtp_type it) { return it.name.compare(port) == 0; });
@@ -466,7 +465,7 @@ update_rtp(const char* port, const char* buffer, size_t size)
 
 void
 graph_type::
-read_rtp(const char* port, char* buffer, size_t size)
+read_rtp(const std::string& port, char* buffer, size_t size)
 {
     auto rtp = std::find_if(rtps.begin(), rtps.end(),
             [port](rtp_type it) { return it.name.compare(port) == 0; });

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -19,10 +19,10 @@
 #include "graph.h"
 #ifndef __AIESIM__
 #include "core/edge/user/shim.h"
+#include "core/common/message.h"
 #endif
 #include "core/include/experimental/xrt_aie.h"
 #include "core/common/error.h"
-#include "core/common/message.h"
 
 #include <cstring>
 #include <map>
@@ -36,24 +36,15 @@ extern "C"
 }
 
 #ifdef __AIESIM__
-static zynqaie::Aie s_aie(xrt_core::get_userpf_device(0));
+static zynqaie::Aie* sp_aie = nullptr;
+zynqaie::Aie* getAieArray() {
+  if (sp_aie == nullptr)
+    sp_aie = new zynqaie::Aie(xrt_core::get_userpf_device(0));
+  return sp_aie;
+}
 #endif
 
 namespace zynqaie {
-
-static inline uint64_t
-get_bd_high_addr(uint64_t addr)
-{
-  constexpr uint64_t hi_mask = 0xFFFF00000000L;
-  return ((addr & hi_mask) >> 32);
-}
-
-static inline uint64_t
-get_bd_low_addr(uint64_t addr)
-{
-  constexpr uint32_t low_mask = 0xFFFFFFFFL;
-  return (addr & low_mask);
-}
 
 graph_type::
 graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t, const std::string& graph_name)
@@ -71,7 +62,7 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t, const std::strin
       drv->setAieArray(aieArray);
     }
 #else
-    aieArray = &s_aie;
+    aieArray = getAieArray();
 #endif
 
     /* Initialize graph tile metadata */
@@ -156,7 +147,7 @@ run()
 
 void
 graph_type::
-run(uint32_t iterations)
+run(int iterations)
 {
     if (state != graph_state::stop && state != graph_state::reset)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is already running or has ended");
@@ -165,7 +156,6 @@ run(uint32_t iterations)
         auto pos = aieArray->getTilePos(tile.itr_mem_col, tile.itr_mem_row);
         XAieTile_DmWriteWord(&(aieArray->tileArray.at(pos)), tile.itr_mem_addr, iterations);
     }
-
 
     /* Record a snapshot of graph start time */
     if (!tiles.empty()) {
@@ -561,101 +551,6 @@ read_rtp(const char* port, char* buffer, size_t size)
 
 void
 graph_type::
-sync_bo(unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
-{
-  int ret;
-  drm_zocl_info_bo info;
-
-  auto gmio = std::find_if(aieArray->gmios.begin(), aieArray->gmios.end(),
-            [dmaID](gmio_type it) { return it.id.compare(dmaID) == 0; });
-
-  if (gmio == aieArray->gmios.end())
-    throw xrt_core::error(-EINVAL, "Can't sync BO: DMA ID not found");
-
-  switch (dir) {
-  case XCL_BO_SYNC_BO_GMIO_TO_AIE:
-    if (gmio->type != 0)
-      throw xrt_core::error(-EINVAL, "Sync BO direction does not match GMIO type");
-    break;
-  case XCL_BO_SYNC_BO_AIE_TO_GMIO:
-    if (gmio->type != 1)
-      throw xrt_core::error(-EINVAL, "Sync BO direction does not match GMIO type");
-    break;
-  default:
-    throw xrt_core::error(-EINVAL, "Can't sync BO: unknown direction.");
-  }
-
-  auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
-  info.handle = bo;
-  ret = drv->getBOInfo(info);
-  if (ret)
-    throw xrt_core::error(ret, "Sync AIE Bo fails: can not get BO info.");
-
-  if (size & XAIEDMA_SHIM_TXFER_LEN32_MASK != 0)
-    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: size is not 32 bits aligned.");
-
-  if (offset + size > info.size)
-    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
-
-  uint64_t paddr = info.paddr + offset;
-  if (paddr & XAIEDMA_SHIM_ADDRLOW_ALIGN_MASK != 0)
-    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: address is not 128 bits aligned.");
-
-  ShimDMA *dmap = &aieArray->shim_dma.at(gmio->shim_col);
-  auto chan = gmio->channel_number;
-
-  /* Find a free BD. Busy wait until we get one. */
-  while (dmap->dma_chan[chan].idle_bds.empty()) {
-    uint8_t npend = XAieDma_ShimPendingBdCount(&(dmap->handle), chan);
-    int num_comp = XAIEGBL_NOC_DMASTA_STARTQ_MAX - npend;
-
-    /* Pending BD is completed by order per Shim DMA spec. */
-    for (int i = 0; i < num_comp; ++i) {
-      BD bd = dmap->dma_chan[chan].pend_bds.front();
-      dmap->dma_chan[chan].pend_bds.pop();
-      dmap->dma_chan[chan].idle_bds.push(bd);
-    }
-  }
-
-  BD bd = dmap->dma_chan[chan].idle_bds.front();
-  dmap->dma_chan[chan].idle_bds.pop();
-  bd.addr_high = get_bd_high_addr(paddr);
-  bd.addr_low = get_bd_low_addr(paddr);
-
-  XAieDma_ShimBdSetAddr(&(dmap->handle), bd.bd_num, bd.addr_high, bd.addr_low, size);
-
-  /* Set BD lock */
-  XAieDma_ShimBdSetLock(&(dmap->handle), bd.bd_num, bd.bd_num, 1, XAIEDMA_SHIM_LKACQRELVAL_INVALID, 1, XAIEDMA_SHIM_LKACQRELVAL_INVALID);
-
-  /* Write BD */
-  XAieDma_ShimBdWrite(&(dmap->handle), bd.bd_num);
-
-  /* Enqueue BD */
-  XAieDma_ShimSetStartBd((&(dmap->handle)), chan, bd.bd_num);
-  dmap->dma_chan[chan].pend_bds.push(bd);
-
-  /*
-   * Wait for transfer to be completed
-   * TODO Set a timeout value when we have error handling/reset
-   */
-  wait_sync_bo(dmap, chan, 0);
-}
-
-void
-graph_type::
-wait_sync_bo(ShimDMA *dmap, uint32_t chan, uint32_t timeout)
-{
-  while ((XAieDma_ShimWaitDone(&(dmap->handle), chan, timeout) != XAIEGBL_NOC_DMASTA_STA_IDLE));
-
-  while (!dmap->dma_chan[chan].pend_bds.empty()) {
-    BD bd = dmap->dma_chan[chan].pend_bds.front();
-    dmap->dma_chan[chan].pend_bds.pop();
-    dmap->dma_chan[chan].idle_bds.push(bd);
-  }
-}
-
-void
-graph_type::
 event_cb(struct XAieGbl *aie_inst, XAie_LocType Loc, u8 module, u8 event, void *arg)
 {
 #ifndef __AIESIM__
@@ -725,7 +620,7 @@ xrtGraphTimeStamp(xrtGraphHandle ghdl)
 }
 
 void
-xrtGraphRun(xrtGraphHandle ghdl, uint32_t iterations)
+xrtGraphRun(xrtGraphHandle ghdl, int iterations)
 {
   auto graph = get_graph(ghdl);
   if (iterations == 0)
@@ -790,10 +685,66 @@ xrtGraphReadRTP(xrtGraphHandle ghdl, const char* port, char* buffer, size_t size
 }
 
 void
-xrtSyncBOAIE(xrtGraphHandle ghdl, unsigned int bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
-  auto graph = get_graph(ghdl);
-  graph->sync_bo(bo, dmaID, dir, size, offset);
+  zynqaie::Aie *aieArray = nullptr;
+
+#ifndef __AIESIM__
+  auto device = xrt_core::get_userpf_device(handle);
+  auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+
+  aieArray = drv->getAieArray();
+#else
+  aieArray = getAieArray();
+#endif
+
+  auto paddr = xrtBOAddress(bohdl);
+  auto bosize = xrtBOSize(bohdl);
+
+  if (offset + size > bosize)
+    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
+
+  aieArray->sync_bo(paddr + offset, gmioName, dir, size);
+}
+
+void
+xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  zynqaie::Aie *aieArray = nullptr;
+
+#ifndef __AIESIM__
+  auto device = xrt_core::get_userpf_device(handle);
+  auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+
+  aieArray = drv->getAieArray();
+#else
+  aieArray = getAieArray();
+#endif
+
+  auto paddr = xrtBOAddress(bohdl);
+  auto bosize = xrtBOSize(bohdl);
+
+  if (offset + size > bosize)
+    throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
+
+  aieArray->sync_bo_nb(paddr + offset, gmioName, dir, size);
+}
+
+void
+xrtGMIOWait(xclDeviceHandle handle, const char *gmioName)
+{
+  zynqaie::Aie *aieArray = nullptr;
+
+#ifndef __AIESIM__
+  auto device = xrt_core::get_userpf_device(handle);
+  auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+
+  aieArray = drv->getAieArray();
+#else
+  aieArray = getAieArray();
+#endif
+
+  aieArray->wait_gmio(gmioName);
 }
 
 void
@@ -865,7 +816,7 @@ xrtGraphTimeStamp(xrtGraphHandle ghdl)
 }
 
 int
-xrtGraphRun(xrtGraphHandle ghdl, uint32_t iterations)
+xrtGraphRun(xrtGraphHandle ghdl, int iterations)
 {
   try {
     api::xrtGraphRun(ghdl, iterations);
@@ -1001,10 +952,10 @@ xrtGraphReadRTP(xrtGraphHandle ghdl, const char *port, char *buffer, size_t size
 }
 
 int
-xrtSyncBOAIE(xrtGraphHandle ghdl, unsigned int bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
-    api::xrtSyncBOAIE(ghdl, bo, dmaID, dir, size, offset);
+    api::xrtSyncBOAIE(handle, bohdl, gmioName, dir, size, offset);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -1023,6 +974,66 @@ xrtResetAIEArray(xclDeviceHandle handle)
   try {
     api::xrtResetAieArray(handle);
     return 0;
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -1;
+  }
+}
+
+////////////////////////////////////////////////////////////////
+// Exposed for Cardano as extensions to xrt_aie.h
+////////////////////////////////////////////////////////////////
+/**
+ * xrtSyncBOAIENB() - Transfer data between DDR and Shim DMA channel
+ *
+ * @handle:          Handle to the device
+ * @bohdl:           BO handle.
+ * @gmioName:        GMIO port name
+ * @dir:             GM to AIE or AIE to GM
+ * @size:            Size of data to synchronize
+ * @offset:          Offset within the BO
+ *
+ * Return:          0 on success, -1 on error.
+ *
+ * Synchronize the buffer contents between GMIO and AIE.
+ * Note: Upon return, the synchronization is submitted or error out
+ */
+int
+xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  try {
+    api::xrtSyncBOAIENB(handle, bohdl, gmioName, dir, size, offset);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -1;
+  }
+}
+
+/**
+ * xrtGMIOWait() - Wait a shim DMA channel to be idle for a given GMIO port
+ *
+ * @handle:          Handle to the device
+ * @gmioName:        GMIO port name
+ *
+ * Return:          0 on success, -1 on error.
+ */
+int
+xrtGMIOWait(xclDeviceHandle handle, const char *gmioName)
+{
+  try {
+    api::xrtGMIOWait(handle, gmioName);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -35,7 +35,6 @@ class graph_type
 public:
     using tile_type = xrt_core::edge::aie::tile_type;
     using rtp_type = xrt_core::edge::aie::rtp_type;
-    using gmio_type = xrt_core::edge::aie::gmio_type;
 
     graph_type(std::shared_ptr<xrt_core::device> device, const uuid_t xclbin_uuid, const std::string& name);
     ~graph_type();
@@ -50,7 +49,7 @@ public:
     run();
 
     void
-    run(uint32_t iterations);
+    run(int iterations);
 
     void
     wait_done(int timeout_ms);
@@ -78,9 +77,6 @@ public:
 
     void
     read_rtp(const char* path, char* buffer, size_t size);
-
-    void
-    sync_bo(unsigned bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     static void
     event_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 event, void *arg);
@@ -121,9 +117,6 @@ private:
 
     /* This is the collections of rtps that are used. */
     std::vector<rtp_type> rtps;
-
-    /* Wait for all the BD trasters for a given channel */
-    void wait_sync_bo(ShimDMA *dmap, uint32_t chan, uint32_t timeout);
 };
 
 }

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -73,10 +73,10 @@ public:
     end(uint64_t cycle);
 
     void
-    update_rtp(const char* path, const char* buffer, size_t size);
+    update_rtp(const std::string& path, const char* buffer, size_t size);
 
     void
-    read_rtp(const char* path, char* buffer, size_t size);
+    read_rtp(const std::string& path, char* buffer, size_t size);
 
     static void
     event_cb(struct XAieGbl *aie_inst, XAie_LocType loc, u8 module, u8 event, void *arg);

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1368,16 +1368,6 @@ setAieArray(zynqaie::Aie *aie)
   aieArray = aie;
 }
 
-int
-shim::getBOInfo(drm_zocl_info_bo &info)
-{
-  int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_INFO_BO, &info);
-  if (ret)
-    return -errno;
-
-  return 0;
-}
-
 #endif
 
 } // end namespace ZYNQ

--- a/src/runtime_src/core/include/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/experimental/xrt_aie.h
@@ -20,6 +20,7 @@
 #define _XRT_AIE_H_
 
 #include "xrt.h"
+#include "experimental/xrt_bo.h"
 
 typedef void *xrtGraphHandle;
 
@@ -71,13 +72,15 @@ xrtGraphTimeStamp(xrtGraphHandle gh);
  * xrtGraphRun() - Start a graph execution
  *
  * @gh:             Handle to graph previously opened with xrtGraphOpen.
- * @iterations:     The run iteration to update to graph. 0 for infinite.
+ * @iterations:     The run iteration to update to graph.
+ *                  0 for default or previous set iterations
+ *                  -1 for run forever
  * Return:          0 on success, -1 on error
  *
  * Note: Run by enable tiles and disable tile reset
  */
 int
-xrtGraphRun(xrtGraphHandle gh, uint32_t iterations);
+xrtGraphRun(xrtGraphHandle gh, int iterations);
 
 /**
  * xrtGraphWaitDone() - Wait for graph to be done. If the graph is not
@@ -177,12 +180,12 @@ int
 xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_t size);
 
 /**
- * xrtSyncBOAIE() - Transfer data between DDR and AIE tiles using Shim DMA
+ * xrtSyncBOAIE() - Transfer data between DDR and Shim DMA channel
  *
- * @gh:              Handle to graph previously opened with xrtGraphOpen.
- * @bo:              BO handle.
- * @dmaID:           GMIO DMA ID
- * @dir:             GMIO to AIE or AIE to GMIO
+ * @handle:          Handle to the device
+ * @bohdl:           BO handle.
+ * @gmioName:        GMIO name
+ * @dir:             GM to AIE or AIE to GM
  * @size:            Size of data to synchronize
  * @offset:          Offset within the BO
  *
@@ -192,7 +195,7 @@ xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_
  * Note: Upon return, the synchronization is done or error out
  */
 int
-xrtSyncBOAIE(xrtGraphHandle gh, unsigned int bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 /**
  * xrtResetAIEArray() - Reset the AIE array


### PR DESCRIPTION
This PR made the following changes
1) Change data type of xrtGraphRun from uint32_t to int32_t to match Cardano context (0 for default and -1 for run forever)
2) Fix xrtSyncBOAIE interfaces
    a) Use device handle other than graph handle
    b) Use xrtBufferHandle other than integer BO handle
    c) Use GMIO name other than GMIO id
3) Move xrtSyncBO implementation from graph class to AIE class which is a device level class
4) Added non block GMIO and GMIO wait (xrtSycnBONB and xrtGMIOWait) for internal uses. Will revisit the non block syncbo later with AIO framework.
5) Small fixes for AIESIM