### PR TITLE
Revert to PCIe bar based access to profiling monitors. 

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -132,13 +132,6 @@ get_profile()
 }
 
 inline bool
-get_container()
-{
-  static bool value = detail::get_bool_value("Debug.container",false);
-  return value;
-}
-
-inline bool
 get_device_profile()
 {
   static bool value = get_profile() && detail::get_bool_value("Debug.device_profile",false);

--- a/src/runtime_src/core/pcie/linux/system_linux.h
+++ b/src/runtime_src/core/pcie/linux/system_linux.h
@@ -48,7 +48,12 @@ public:
   monitor_access_type
   get_monitor_access_type() const
   {
-    return monitor_access_type::ioctl;
+    /* User space cannot access profiling subdevices while running inside container.
+     * So, revert to access to profiling IPs via PCIe bar (using xclRead/Write) 
+     * for PCIe Linux flow.
+     */
+    return monitor_access_type::bar;
+    //return monitor_access_type::ioctl;
   }
 };
 

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -570,10 +570,8 @@ DeviceIntf::~DeviceIntf()
       xrt_core::system::monitor_access_type accessType = xrt_core::get_monitor_access_type();
       /* Currently, only PCIeLinux Device flow uses open+ioctl and hence specialized monitors are instantiated.
        * All other flows(including PCIe Windows) use the older mechanism and should use old monitor abstraction.
-       * Also, user space cannot access profiling subdvices while running inside containers, so use xclRead/Write
-       * based flow.
        */
-      if(xrt_core::system::monitor_access_type::bar == accessType || true == xrt_core::config::get_container()) {
+      if(xrt_core::system::monitor_access_type::bar == accessType) {
         for(uint64_t i = 0; i < map->m_count; i++ ) {
           switch(map->m_debug_ip_data[i].m_type) {
             case AXI_MM_MONITOR :        aimList.push_back(new AIM(mDevice, i, &(map->m_debug_ip_data[i])));


### PR DESCRIPTION
Revert to PCIe bar based access to profiling monitors. . This is because user space applications cannot access profile subdevices when running inside containers.