### PR TITLE
Flip the default value of Runtime.xrt_bo to true

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -393,14 +393,14 @@ get_multiprocess()
 }
 
 /**
- * Set to true if host code uses post 2020.1 XRT BO APIs.
- * This affects how the kernel APIs treat C-style variadic args for 
- * global memory arguments.
+ * Set to false if host code uses post xcl style buffer handles with
+ * new kernel API variadic arguments.  This affects how the kernel
+ * APIs treat C-style variadic args for global memory arguments.
  */
 inline bool
 get_xrt_bo()
 {
-  static bool value = detail::get_bool_value("Runtime.xrt_bo", false);
+  static bool value = detail::get_bool_value("Runtime.xrt_bo", true);
   return value;
 }
 

--- a/tests/python/02_simple/main.py
+++ b/tests/python/02_simple/main.py
@@ -18,6 +18,7 @@
  under the License.
 """
 
+import os
 import sys
 
 # Following found in PYTHONPATH setup by XRT
@@ -100,4 +101,5 @@ def main(args):
         xclClose(opt.handle)
 
 if __name__ == "__main__":
+    os.environ["Runtime.xrt_bo"] = "false"
     main(sys.argv)

--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -16,6 +16,7 @@
  under the License.
 """
 
+import os
 import sys
 import uuid
 import re
@@ -103,4 +104,5 @@ def main(args):
         xclClose(opt.handle)
 
 if __name__ == "__main__":
+    os.environ["Runtime.xrt_bo"] = "false"
     main(sys.argv)

--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -162,7 +162,6 @@ def runKernel(opt):
         raise RuntimeError("ERROR: Throughput is less than expected value of %d GB/sec" %(threshold/1000))
 
 def main(args):
-    os.environ["Runtime.xrt_bo"] = "true"
     opt = Options()
     Options.getOptions(opt, args)
 

--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -154,7 +154,6 @@ def runKernel(opt):
 
 
 def main(args):
-    os.environ["Runtime.xrt_bo"] = "true"
     opt = Options()
     Options.getOptions(opt, args)
 

--- a/tests/python/23_bandwidth/versal_23_bandwidth.py
+++ b/tests/python/23_bandwidth/versal_23_bandwidth.py
@@ -170,7 +170,6 @@ def runKernel(opt):
         raise RuntimeError("ERROR: Throughput is less than expected value of %d GB/sec" %(threshold/1000))
 
 def main(args):
-    os.environ["Runtime.xrt_bo"] = "true"
     opt = Options()
     Options.getOptions(opt, args)
 

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <iostream>
 #include <vector>
+#include <cstdlib>
 
 #ifdef _WIN32
 # pragma warning ( disable : 4267 )
@@ -320,6 +321,12 @@ int
 main(int argc, char* argv[])
 {
   try {
+    // This test uses old style xclBufferHandles with new Kernel APIs
+#ifdef __GNUC__
+    setenv("Runtime.xrt_bo", "false", 1);
+#else
+# warning "Make sure Runtime.xrt_bo=false"
+#endif
     run(argc,argv);
     return 0;
   }


### PR DESCRIPTION
Set to false if using old style xclBufferHandles with kernel C-APIs.
This is necessary for the C-style variadic args to infer the type.  By
default it is assume that host code use XRT Native APIs for BOs as
well as kernel, in which case the default value is required.