### PR TITLE
CR-1071496 Addition of PCIe IDs for U26Z

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2580,6 +2580,24 @@ struct xocl_subdev_map {
 		.board_name = "u25"                                     \
 	}
 
+#define XOCL_BOARD_U26Z_USER_RAPTOR2                          \
+	(struct xocl_board_private){                               \
+		.flags       = XOCL_DSAFLAG_DYNAMIC_IP,                 \
+		.board_name  = "u26z",                                  \
+		.subdev_info = RES_USER_VSEC,                           \
+		.subdev_num  = ARRAY_SIZE(RES_USER_VSEC)                \
+	}
+
+#define XOCL_BOARD_U26Z_MGMT_RAPTOR2                          \
+	(struct xocl_board_private){                               \
+		.flags       = XOCL_DSAFLAG_DYNAMIC_IP,                 \
+		.subdev_info = RES_MGMT_VSEC,                           \
+		.subdev_num  = ARRAY_SIZE(RES_MGMT_VSEC),               \
+		.flash_type  = FLASH_TYPE_SPI,                          \
+		.sched_bin   = "xilinx/sched_v20.bin",                  \
+		.board_name  = "u26z"                                   \
+	}
+
 #define XOCL_BOARD_U30_USER_RAPTOR2                                     \
         (struct xocl_board_private){                                    \
                 .flags = XOCL_DSAFLAG_DYNAMIC_IP |                      \
@@ -3188,6 +3206,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5044, PCI_ANY_ID, MGMT_VERSAL) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5048, PCI_ANY_ID, VERSAL_MGMT_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5050, PCI_ANY_ID, MGMT_U25) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x504E, PCI_ANY_ID, U26Z_MGMT_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5058, PCI_ANY_ID, U55N_MGMT_RAPTOR2) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x505C, PCI_ANY_ID, U55C_MGMT_RAPTOR2) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5060, PCI_ANY_ID, U50LV_MGMT_RAPTOR2) },\
@@ -3239,6 +3258,7 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x500D, PCI_ANY_ID, USER_DSA52_U280) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5021, PCI_ANY_ID, USER_U50) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5051, PCI_ANY_ID, USER_U25) },	\
+	{ XOCL_PCI_DEVID(0x10EE, 0x504F, PCI_ANY_ID, U26Z_USER_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x513D, PCI_ANY_ID, U30_USER_RAPTOR2) },       \
 	{ XOCL_PCI_DEVID(0x10EE, 0x5059, PCI_ANY_ID, U55N_USER_RAPTOR2) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x505D, PCI_ANY_ID, U55C_USER_RAPTOR2) },\
@@ -3321,5 +3341,5 @@ struct xocl_subdev_map {
 		.vbnv = "xilinx_u25",					\
 		.priv_data = &XOCL_BOARD_U25_USER_RAPTOR2,              \
 		.type = XOCL_DSAMAP_RAPTOR2 }
-	
+
 #endif


### PR DESCRIPTION
Addition of PCIe IDs for U26Z.
Smoke-tested by rebuilding and running through xbutil validate on known-good U250 card.