### PR TITLE
qdma4: fix error interrupt enable mask for MM only and ST updates

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/eqdma_soft_access.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/eqdma_soft_access.c
@@ -1,29 +1,5 @@
 /*
  * Copyright(c) 2019-2020 Xilinx, Inc. All rights reserved.
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
  */
 
 #include "qdma_access_common.h"
@@ -4398,6 +4374,25 @@ int eqdma_get_user_bar(void *dev_hndl, uint8_t is_vf,
 
 /*****************************************************************************/
 /**
+ * eqdma_hw_get_error_name() - Function to get the error in string format
+ *
+ * @err_idx: error index
+ *
+ * Return: string - success and NULL on failure
+ *****************************************************************************/
+const char *eqdma_hw_get_error_name(uint32_t err_idx)
+{
+	if (err_idx >= EQDMA_ERRS_ALL) {
+		qdma_log_error("%s: err_idx=%d is invalid, returning NULL\n",
+				__func__, (enum eqdma_error_idx)err_idx);
+		return NULL;
+	}
+
+	return eqdma_err_info[(enum eqdma_error_idx)err_idx].err_name;
+}
+
+/*****************************************************************************/
+/**
  * eqdma_hw_error_process() - Function to find the error that got
  * triggered and call the handler qdma_hw_error_handler of that
  * particular error.
@@ -4452,6 +4447,7 @@ int eqdma_hw_error_process(void *dev_hndl)
 					err_stat);
 		else
 			continue;
+
 		pr_info("%s: err_stat 0x%x = 0x%x.\n", __func__,
 			eqdma_err_info[bit].stat_reg_addr, err_stat);
 
@@ -4471,21 +4467,85 @@ int eqdma_hw_error_process(void *dev_hndl)
 
 /*****************************************************************************/
 /**
- * eqdma_hw_get_error_name() - Function to get the error in string format
+ * qdma_hw_error_enable() - Function to enable all or a specific error
  *
+ * @dev_hndl: device handle
  * @err_idx: error index
  *
- * Return: string - success and NULL on failure
+ * Return:	0   - success and < 0 - failure
  *****************************************************************************/
-const char *eqdma_hw_get_error_name(enum qdma_error_idx err_idx)
+int eqdma_hw_error_enable(void *dev_hndl, uint32_t err_idx)
 {
-	if ((enum eqdma_error_idx)err_idx >= EQDMA_ERRS_ALL) {
-		qdma_log_error("%s: err_idx=%d is invalid, returning NULL\n",
-				__func__, (enum eqdma_error_idx)err_idx);
-		return NULL;
+	uint32_t idx = 0, i = 0;
+	uint32_t reg_val = 0;
+	struct qdma_dev_attributes *dev_cap;
+
+	if (!dev_hndl) {
+		qdma_log_error("%s: dev_handle is NULL, err:%d\n",
+				__func__, -QDMA_ERR_INV_PARAM);
+		return -QDMA_ERR_INV_PARAM;
 	}
 
-	return eqdma_err_info[(enum eqdma_error_idx)err_idx].err_name;
+	if (err_idx > EQDMA_ERRS_ALL) {
+		qdma_log_error("%s: err_idx=%d is invalid, err:%d\n",
+				__func__, (enum eqdma_error_idx)err_idx,
+				-QDMA_ERR_INV_PARAM);
+		return -QDMA_ERR_INV_PARAM;
+	}
+
+	qdma_get_device_attr(dev_hndl, &dev_cap);
+
+	if (err_idx == EQDMA_ERRS_ALL) {
+		for (i = 0; i < TOTAL_LEAF_ERROR_AGGREGATORS; i++) {
+
+			idx = all_eqdma_hw_errs[i];
+
+			/* Don't access streaming registers in
+			 * MM only bitstreams
+			 */
+			if (!dev_cap->st_en) {
+				if (idx == EQDMA_ST_C2H_ERR_ALL ||
+					idx == EQDMA_ST_FATAL_ERR_ALL ||
+					idx == EQDMA_ST_H2C_ERR_ALL)
+					continue;
+			}
+
+			reg_val = eqdma_err_info[idx].leaf_err_mask;
+			qdma_reg_write(dev_hndl,
+				eqdma_err_info[idx].mask_reg_addr, reg_val);
+
+			reg_val = qdma_reg_read(dev_hndl,
+					EQDMA_OFFSET_GLBL_ERR_MASK);
+			reg_val |= FIELD_SET(
+				eqdma_err_info[idx].global_err_mask, 1);
+			qdma_reg_write(dev_hndl, EQDMA_OFFSET_GLBL_ERR_MASK,
+					reg_val);
+		}
+
+	} else {
+		/* Don't access streaming registers in MM only bitstreams
+		 *  QDMA_C2H_ERR_MTY_MISMATCH to QDMA_H2C_ERR_ALL are all
+		 *  ST errors
+		 */
+		if (!dev_cap->st_en) {
+			if (err_idx >= EQDMA_ST_C2H_ERR_MTY_MISMATCH &&
+					err_idx <= EQDMA_ST_H2C_ERR_ALL)
+				return QDMA_SUCCESS;
+		}
+
+		reg_val = qdma_reg_read(dev_hndl,
+				eqdma_err_info[err_idx].mask_reg_addr);
+		reg_val |= FIELD_SET(eqdma_err_info[err_idx].leaf_err_mask, 1);
+		qdma_reg_write(dev_hndl,
+				eqdma_err_info[err_idx].mask_reg_addr, reg_val);
+
+		reg_val = qdma_reg_read(dev_hndl, EQDMA_OFFSET_GLBL_ERR_MASK);
+		reg_val |=
+			FIELD_SET(eqdma_err_info[err_idx].global_err_mask, 1);
+		qdma_reg_write(dev_hndl, EQDMA_OFFSET_GLBL_ERR_MASK, reg_val);
+	}
+
+	return QDMA_SUCCESS;
 }
 
 /*****************************************************************************/

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/eqdma_soft_access.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/eqdma_soft_access.h
@@ -1,29 +1,5 @@
 /*
  * Copyright(c) 2019-2020 Xilinx, Inc. All rights reserved.
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
  */
 
 #ifndef EQDMA_ACCESS_H_
@@ -255,7 +231,8 @@ int eqdma_context_buf_len(uint8_t st,
 		enum qdma_dev_q_type q_type, uint32_t *buflen);
 
 int eqdma_hw_error_process(void *dev_hndl);
-const char *eqdma_hw_get_error_name(enum qdma_error_idx err_idx);
+const char *eqdma_hw_get_error_name(uint32_t err_idx);
+int eqdma_hw_error_enable(void *dev_hndl, uint32_t err_idx);
 
 int eqdma_read_dump_queue_context(void *dev_hndl,
 		uint16_t qid_hw,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma4_export.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma4_export.h
@@ -1566,8 +1566,10 @@ int qdma4_queue_packet_write(unsigned long dev_hndl, unsigned long qhndl,
  * @param budget	ST C2H only, max number of completions to be processed.
  * @param c2h_upd_cmpl	flag to update the completion
  *
+ * Return:		0 for success or <0 for error
+ *
  *****************************************************************************/
-void qdma4_queue_service(unsigned long dev_hndl, unsigned long qhndl,
+int qdma4_queue_service(unsigned long dev_hndl, unsigned long qhndl,
 			int budget, bool c2h_upd_cmpl);
 
 /*****************************************************************************/
@@ -1577,8 +1579,10 @@ void qdma4_queue_service(unsigned long dev_hndl, unsigned long qhndl,
  * @param dev_hndl	dev_hndl returned from qdma_device_open()
  * @param qhndl		hndl returned from qdma_queue_add()
  *
+ * Return:		0 for success or <0 for error
+ *
  *****************************************************************************/
-void qdma4_queue_update_pointers(unsigned long dev_hndl, unsigned long qhndl);
+int qdma4_queue_update_pointers(unsigned long dev_hndl, unsigned long qhndl);
 
 /*****************************************************************************/
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
@@ -1236,34 +1236,52 @@ static int is_usable_queue(struct xlnx_dma_dev *xdev, int qidx,
 		reqmask |= Q_MODE_MASK;
 	if (q_type == Q_CMPT) {
 		cmptq_chkmask |= (Q_PRESENT_CMPT_MASK | Q_MODE_MASK);
-		if (refmask & cmptq_chkmask)
+		if (refmask & cmptq_chkmask) {
+			pr_err("Q_CMPT: refmask not valid.\n");
 			goto q_reject;
+		}
 	} else if (q_type == Q_H2C) {
 		c2hq_chkmask = (Q_PRESENT_C2H_MASK | Q_MODE_MASK);
-		if (st && (refmask & Q_PRESENT_CMPT_MASK))
+		if (st && (refmask & Q_PRESENT_CMPT_MASK)) {
+			pr_err("Q_H2C: CMPT q given to MM.\n");
 			goto q_reject; /* CMPT q given to MM */
+		}
 		if (st && (refmask & Q_PRESENT_C2H_MASK)
 				&& (refmask & c2hq_chkmask)
-						== Q_PRESENT_C2H_MASK)
+					 == Q_PRESENT_C2H_MASK) {
+			pr_err("Q_H2C: MM mode c2h q present.\n");
 			goto q_reject; /* MM mode c2h q present*/
+		}
 		if (!st && (refmask & Q_PRESENT_C2H_MASK)
-				&& (refmask & c2hq_chkmask) == c2hq_chkmask)
+				&& (refmask & c2hq_chkmask) == c2hq_chkmask) {
+			pr_err("Q_H2C: ST mode c2h q present.\n");
 			goto q_reject; /* ST mode c2h q present*/
-		if (refmask & Q_PRESENT_H2C_MASK)
+		}
+		if (refmask & Q_PRESENT_H2C_MASK) {
+			pr_err("Q_H2C: h2c q already present.\n");
 			goto q_reject; /* h2c q already present */
+		}
 	} else {
 		h2cq_chkmask |= (Q_PRESENT_H2C_MASK | Q_MODE_MASK);
-		if (st && (refmask & Q_PRESENT_CMPT_MASK))
+		if (st && (refmask & Q_PRESENT_CMPT_MASK)) {
+			pr_err("!Q_H2C: CMPT q given to MM.\n");
 			goto q_reject; /* CMPT q given to MM */
+		}
 		if (st && (refmask & Q_PRESENT_H2C_MASK)
 				&& (refmask & h2cq_chkmask)
-						== Q_PRESENT_H2C_MASK)
+						== Q_PRESENT_H2C_MASK) {
+			pr_err("!Q_H2C: MM mode h2c q present.\n");
 			goto q_reject; /* MM mode h2c q present*/
+		}
 		if (!st && (refmask & Q_PRESENT_H2C_MASK)
-				&& (refmask & h2cq_chkmask) == h2cq_chkmask)
+				&& (refmask & h2cq_chkmask) == h2cq_chkmask) {
+			pr_err("!Q_H2C: ST mode h2c q present.\n");
 			goto q_reject; /* ST mode h2c q present*/
-		if (refmask & Q_PRESENT_C2H_MASK)
+		}
+		if (refmask & Q_PRESENT_C2H_MASK) {
+			pr_err("!Q_H2C: c2h q already present.\n");
 			goto q_reject; /* c2h q already present */
+		}
 	}
 	return 0;
 q_reject:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_access_common.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_access_common.c
@@ -1,17 +1,5 @@
 /*
  * Copyright(c) 2019-2020 Xilinx, Inc. All rights reserved.
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
  */
 
 #include "qdma_access_common.h"
@@ -1703,6 +1691,7 @@ int qdma_hw_access_init(void *dev_hndl, uint8_t is_vf,
 				&eqdma_indirect_intr_ctx_conf;
 		hw_access->qdma_dump_config_regs = &eqdma_dump_config_regs;
 		hw_access->qdma_dump_intr_context = &eqdma_dump_intr_context;
+		hw_access->qdma_hw_error_enable = &eqdma_hw_error_enable;
 		hw_access->qdma_hw_error_process = &eqdma_hw_error_process;
 		hw_access->qdma_hw_get_error_name = &eqdma_hw_get_error_name;
 		hw_access->qdma_hw_ctx_conf = &eqdma_hw_ctx_conf;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_access_common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_access_common.h
@@ -1,17 +1,5 @@
 /*
  * Copyright(c) 2019-2020 Xilinx, Inc. All rights reserved.
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
  */
 
 #ifndef QDMA4_ACCESS_COMMON_H_
@@ -587,8 +575,8 @@ struct qdma_hw_access {
 					uint8_t err_intr_index);
 	int (*qdma_hw_error_intr_rearm)(void *dev_hndl);
 	int (*qdma_hw_error_enable)(void *dev_hndl,
-					enum qdma_error_idx err_idx);
-	const char *(*qdma_hw_get_error_name)(enum qdma_error_idx err_idx);
+			uint32_t err_idx);
+	const char *(*qdma_hw_get_error_name)(uint32_t err_idx);
 	int (*qdma_hw_error_process)(void *dev_hndl);
 	int (*qdma_dump_config_regs)(void *dev_hndl, uint8_t is_vf, char *buf,
 					uint32_t buflen);
@@ -755,4 +743,4 @@ void qdma_fetch_version_details(uint8_t is_vf, uint32_t version_reg_val,
 }
 #endif
 
-#endif /* QDMA_ACCESS_COMMON_H_ */
+#endif /* QDMA4_ACCESS_COMMON_H_ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_context.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_context.c
@@ -207,7 +207,7 @@ static int make_cmpt_context(struct qdma_descq *descq,
 
 	cmpt_ctxt->bs_addr = descq->desc_cmpt_bus;
 	cmpt_ctxt->desc_sz = descq->conf.cmpl_desc_sz;
-	cmpt_ctxt->full_upd = descq->xdev->conf.intr_moderation;
+	cmpt_ctxt->full_upd = descq->conf.adaptive_rx;
 
 	cmpt_ctxt->valid = 1;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.c
@@ -763,8 +763,7 @@ static int descq_mm_n_h2c_cmpl_status(struct qdma_descq *descq)
 	 * dma transfer by resuming the thread here.
 	 */
 
-
-	return 1;
+	return 0;
 }
 
 /* ************** public function definitions ******************************* */
@@ -806,6 +805,16 @@ int qdma_q_desc_get(void *q_hndl, const unsigned int desc_cnt,
 		pr_err("Invalid desc queue index");
 		return -EINVAL; /* not possible to give so many desc */
 	}
+
+	 /*
+	  * it is very unlikely that below condition hits in MM or ST H2C as
+	  * one packet is submitted at once. But It is ibserved that HW is not
+	  * giving writeback and sometimes its corresponding interrupt. For this
+	  * reason a polling logic is introduced as below
+	  **/
+	if (descq->avail < desc_cnt)
+		descq_mm_n_h2c_cmpl_status(descq);
+
 	if (descq->avail < desc_cnt) {
 		pr_err("No entries available to read");
 		return -EBUSY; /* curently not available */
@@ -881,36 +890,61 @@ int qdma_q_init_pointers(unsigned long dev_hndl, unsigned long id)
 	return 0;
 }
 
-void qdma4_queue_update_pointers(unsigned long dev_hndl, unsigned long qhndl)
+int qdma4_queue_update_pointers(unsigned long dev_hndl, unsigned long qhndl)
 {
 	struct xlnx_dma_dev *xdev = (struct xlnx_dma_dev *)dev_hndl;
 	struct qdma_descq *descq = qdma4_device_get_descq_by_id(xdev, qhndl,
 							NULL, 0, 0);
-	int ret;
+	int ret = 0;
 
-	if (descq) {
-		if (descq->conf.st && (descq->conf.q_type == Q_C2H)) {
+	if (!descq) {
+		pr_err("%s descq is null\n", __func__);
+		return -EINVAL;
+	}
+	if (descq->conf.st && (descq->conf.q_type == Q_C2H)) {
+		lock_descq(descq);
+		if (descq->q_state == Q_STATE_ONLINE) {
 			ret = queue_cmpt_cidx_update(descq->xdev,
 					descq->conf.qidx,
 					&descq->cmpt_cidx_info);
 			if (ret < 0) {
 				pr_err("%s: Failed to update cmpt cidx\n",
-						descq->conf.name);
-				return;
+					descq->conf.name);
+				ret = -EBUSY;
+				goto func_exit;
 			}
+		
 			ret = queue_pidx_update(descq->xdev,
 					descq->conf.qidx,
 					descq->conf.q_type,
 					&descq->pidx_info);
 			if (ret < 0) {
 				pr_err("%s: Failed to update pidx\n",
-						descq->conf.name);
-				return;
+					descq->conf.name);
+				ret = -EBUSY;
+				goto func_exit;
 			}
+			/*
+			 * Memory barrier in update pointers
+			 */
+			wmb();
+		} else {
+			pr_debug("Pointer update for offline queue for %s\n",
+				descq->conf.name);
+			ret = -ENODEV;
 		}
+	} else {
+		pr_debug("Pointer update for invalid queue for %s\n",
+			descq->conf.name);
+		
+		ret = -EINVAL;
 	}
 
+func_exit:
+	unlock_descq(descq);
+	return ret;
 }
+
 int qdma4_descq_alloc_resource(struct qdma_descq *descq)
 {
 	struct xlnx_dma_dev *xdev = descq->xdev;
@@ -942,16 +976,21 @@ int qdma4_descq_alloc_resource(struct qdma_descq *descq)
 
 		flq->desc = (struct qdma_c2h_desc *)descq->desc;
 		flq->size = descq->conf.rngsz;
-		flq->pg_shift = fls(descq->conf.c2h_bufsz) - 1;
+		flq->buf_pg_shift = fls(descq->conf.c2h_bufsz) - 1;
+		flq->buf_pg_mask = (1 << flq->buf_pg_shift) - 1;
+
+		flq->desc_buf_size = get_next_powof2(descq->conf.c2h_bufsz);
+		flq->desc_pg_shift = fls(flq->desc_buf_size) - 1;
 
 		/* These code changes are to accomodate buf_sz
 		 *  of less than 4096
 		 */
-		if (flq->pg_shift < PAGE_SHIFT)
-			flq->pg_order = 0;
+		if (flq->buf_pg_shift < PAGE_SHIFT)
+			flq->desc_pg_order = 0;
 		else
-			flq->pg_order = flq->pg_shift - PAGE_SHIFT;
+			flq->desc_pg_order = flq->buf_pg_shift - PAGE_SHIFT;
 
+		flq->max_pg_offset = (PAGE_SIZE << flq->desc_pg_order);
 		/* freelist / rx buffers */
 		rv = qdma4_descq_flq_alloc_resource(descq);
 		if (rv < 0)
@@ -1042,7 +1081,7 @@ void qdma4_descq_free_resource(struct qdma_descq *descq)
 			descq->conf.name, descq->desc, descq->desc_cmpt);
 
 		if (descq->conf.st && (descq->conf.q_type == Q_C2H))
-			qdma4_descq_flq_free_resource(descq);
+			descq_flq_free_page_resource(descq);
 		else
 			kfree(descq->desc_list);
 
@@ -1275,35 +1314,39 @@ int qdma4_descq_prog_hw(struct qdma_descq *descq)
 	return rv;
 }
 
-void qdma4_descq_service_cmpl_update(struct qdma_descq *descq, int budget,
+int qdma4_descq_service_cmpl_update(struct qdma_descq *descq, int budget,
 				bool c2h_upd_cmpl)
 {
+	int rv = 0;
+
 	if (descq->conf.st && (descq->conf.q_type == Q_C2H)) {
 		lock_descq(descq);
-		if (descq->q_state == Q_STATE_ONLINE)
-			qdma4_descq_process_completion_st_c2h(descq, budget,
-						c2h_upd_cmpl);
+		if (descq->q_state == Q_STATE_ONLINE) {
+			rv = qdma4_descq_process_completion_st_c2h(descq,
+						budget, c2h_upd_cmpl);
+			if (rv && (rv != -ENODATA))
+				pr_err("Error detected in %s.\n",
+					descq->conf.name);
+		} else {
+			pr_debug("Invalid q state of %s.\n", descq->conf.name);
+			rv = -EINVAL;
+		}
 		unlock_descq(descq);
 	} else if ((descq->xdev->conf.qdma_drv_mode == POLL_MODE) ||
 			(descq->xdev->conf.qdma_drv_mode == AUTO_MODE)) {
-		lock_descq(descq);
-		if (!descq->proc_req_running) {
-			unlock_descq(descq);
-			qdma4_descq_proc_sgt_request(descq);
-		} else {
-			pr_err("Processing previous request\n");
-			unlock_descq(descq);
-		}
+		if (!descq->proc_req_running)
+			rv = qdma4_descq_proc_sgt_request(descq);
 	} else {
 		lock_descq(descq);
 		descq_mm_n_h2c_cmpl_status(descq);
 		if (descq->pend_req_desc) {
 			unlock_descq(descq);
-			qdma4_descq_proc_sgt_request(descq);
-			return;
+			return (int)qdma4_descq_proc_sgt_request(descq);
 		}
 		unlock_descq(descq);
 	}
+
+	return rv;
 }
 
 ssize_t qdma4_descq_proc_sgt_request(struct qdma_descq *descq)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.h
@@ -49,7 +49,7 @@ struct q_state_name {
 
 extern struct q_state_name q_state_list[];
 
-#define QDMA_FLQ_SIZE 80
+#define QDMA_FLQ_SIZE 124
 
 /**
  * @struct - qdma_descq
@@ -315,9 +315,9 @@ int qdma_descq_context_cleanup(struct qdma_descq *descq);
  * @param[in]	budget:		number of descriptors to process
  * @param[in]	c2h_upd_cmpl:	C2H only: if update completion needed
  *
- * @return	none
+ * @return	0 - sucess, < 0 for failure
  *****************************************************************************/
-void qdma4_descq_service_cmpl_update(struct qdma_descq *descq, int budget,
+int qdma4_descq_service_cmpl_update(struct qdma_descq *descq, int budget,
 			bool c2h_upd_cmpl);
 
 /*****************************************************************************/
@@ -483,6 +483,16 @@ void sgl_unmap(struct pci_dev *pdev, struct qdma_sw_sg *sg, unsigned int sgcnt,
  *****************************************************************************/
 void qdma4_descq_flq_free_resource(struct qdma_descq *descq);
 
+/*****************************************************************************/
+/**
+ * descq_flq_free_page_resource() - handler to free the pages for the request
+ *
+ * @param[in]  descq:		pointer to qdma_descq
+ *
+ * @return	none
+ *****************************************************************************/
+void descq_flq_free_page_resource(struct qdma_descq *descq);
+
 int rcv_udd_only(struct qdma_descq *descq, struct qdma_ul_cmpt_info *cmpl);
 int parse_cmpl_entry(struct qdma_descq *descq, struct qdma_ul_cmpt_info *cmpl);
 void cmpt_next(struct qdma_descq *descq);
@@ -529,5 +539,16 @@ void cmpt_next(struct qdma_descq *descq);
 #endif
 
 u64 rdtsc_gettime(void);
+static inline unsigned int get_next_powof2(unsigned int value)
+{
+	unsigned int num_bits, mask, f_value;
+
+	num_bits = fls(value) - 1;
+	mask = (1 << num_bits) - 1;
+	f_value = ((value + mask) >> num_bits) << num_bits;
+
+	return f_value;
+}
+
 
 #endif /* ifndef __QDMA_DESCQ_H__ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_intr.c
@@ -157,6 +157,7 @@ static void data_intr_aggregate(struct xlnx_dma_dev *xdev, int vidx, int irq,
 	uint8_t color = 0;
 	uint8_t intr_type = 0;
 	uint32_t qid = 0;
+	uint32_t num_entries_processed = 0;
 
 	if (!coal_entry) {
 		pr_err("Failed to locate the coalescing entry for vector = %d\n",
@@ -190,8 +191,6 @@ static void data_intr_aggregate(struct xlnx_dma_dev *xdev, int vidx, int irq,
 		return;
 	}
 
-
-
 	do {
 		if (xdev->version_info.ip_type == QDMA_VERSAL_HARD_IP) {
 			color = ring_entry->ring_cpm.coal_color;
@@ -217,6 +216,10 @@ static void data_intr_aggregate(struct xlnx_dma_dev *xdev, int vidx, int irq,
 			return;
 		}
 
+		pr_debug("IRQ[%d]: IVE[%d], Qid = %d, e_color = %d, "
+			 "c_color = %d, intr_type = %d\n",
+			irq, vidx, qid, coal_entry->color, color, intr_type);
+
 		if (descq->conf.ping_pong_en &&
 			descq->conf.q_type == Q_C2H && descq->conf.st)
 			descq->ping_pong_rx_time = timestamp;
@@ -241,8 +244,12 @@ static void data_intr_aggregate(struct xlnx_dma_dev *xdev, int vidx, int irq,
 		} else
 			counter++;
 
+		num_entries_processed++;
 		ring_entry = (coal_entry->intr_ring_base + counter);
 	} while (1);
+
+	if (num_entries_processed == 0)
+		pr_warn("No entries processed\n");
 
 	if (descq)
 		queue_intr_cidx_update(descq->xdev,
@@ -927,7 +934,7 @@ void qdma4_intr_work(struct work_struct *work)
  * @dev_hndl: hndl retured from qdma_device_open()
  * @qhndl: hndl retured from qdma_queue_add()
  */
-void qdma4_queue_service(unsigned long dev_hndl, unsigned long id, int budget,
+int qdma4_queue_service(unsigned long dev_hndl, unsigned long id, int budget,
 			bool c2h_upd_cmpl)
 {
 	struct xlnx_dma_dev *xdev = (struct xlnx_dma_dev *)dev_hndl;
@@ -936,17 +943,19 @@ void qdma4_queue_service(unsigned long dev_hndl, unsigned long id, int budget,
 	/** make sure that the dev_hndl passed is Valid */
 	if (!xdev) {
 		pr_err("dev_hndl is NULL");
-		return;
+		return -EINVAL;
 	}
 
 	if (qdma4_xdev_check_hndl(__func__, xdev->conf.pdev, dev_hndl) < 0) {
 		pr_err("Invalid dev_hndl passed");
-		return;
+		return -EINVAL;
 	}
 
 	descq = qdma4_device_get_descq_by_id(xdev, id, NULL, 0, 0);
 	if (descq)
-		qdma4_descq_service_cmpl_update(descq, budget, c2h_upd_cmpl);
+		return qdma4_descq_service_cmpl_update(descq, budget,
+							c2h_upd_cmpl);
+	return -EINVAL;
 }
 
 static u8 get_intr_vec_index(struct xlnx_dma_dev *xdev, u8 intr_type)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_soft_access.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_soft_access.c
@@ -1,29 +1,5 @@
 /*
  * Copyright(c) 2019-2020 Xilinx, Inc. All rights reserved.
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
  */
 
 #include "qdma_access_common.h"
@@ -3917,15 +3893,15 @@ int qdma_get_device_attributes(void *dev_hndl,
  *
  * Return: string - success and NULL on failure
  *****************************************************************************/
-const char *qdma_hw_get_error_name(enum qdma_error_idx err_idx)
+const char *qdma_hw_get_error_name(uint32_t err_idx)
 {
 	if (err_idx >= QDMA_ERRS_ALL) {
 		qdma_log_error("%s: err_idx=%d is invalid, returning NULL\n",
-					   __func__, err_idx);
+				__func__, (enum qdma_error_idx)err_idx);
 		return NULL;
 	}
 
-	return qdma_err_info[err_idx].err_name;
+	return qdma_err_info[(enum qdma_error_idx)err_idx].err_name;
 }
 
 /*****************************************************************************/

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_soft_access.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_soft_access.h
@@ -1,29 +1,5 @@
 /*
  * Copyright(c) 2019-2020 Xilinx, Inc. All rights reserved.
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
- *
- * This source code is free software; you can redistribute it and/or modify it
- * under the terms and conditions of the GNU General Public License,
- * version 2, as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * The full GNU General Public License is included in this distribution in
- * the file called "COPYING".
  */
 
 #ifndef QDMA_ACCESS_H_
@@ -130,9 +106,9 @@ int qdma_soft_read_dump_queue_context(void *dev_hndl,
 
 int qdma_hw_error_process(void *dev_hndl);
 
-const char *qdma_hw_get_error_name(enum qdma_error_idx err_idx);
+const char *qdma_hw_get_error_name(uint32_t err_idx);
 
-int qdma_hw_error_enable(void *dev_hndl, enum qdma_error_idx err_idx);
+int qdma_hw_error_enable(void *dev_hndl, uint32_t err_idx);
 
 int qdma_get_device_attributes(void *dev_hndl,
 		struct qdma_dev_attributes *dev_info);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_st_c2h.c
@@ -39,44 +39,168 @@
  * ST C2H descq (i.e., freelist) RX buffers
  */
 
-static inline void flq_unmap_one(struct qdma_sw_sg *sdesc,
-				struct qdma_c2h_desc *desc, struct device *dev,
-				unsigned char pg_order)
+static inline void flq_free_one(struct qdma_sw_sg *sdesc,
+					struct qdma_c2h_desc *desc)
 {
 	if (sdesc->dma_addr) {
 		desc->dst_addr = 0UL;
-		dma_unmap_page(dev, sdesc->dma_addr, PAGE_SIZE << pg_order,
-				DMA_FROM_DEVICE);
 		sdesc->dma_addr = 0UL;
 	}
-}
 
-static inline void flq_free_one(struct qdma_sw_sg *sdesc,
-				struct qdma_c2h_desc *desc, struct device *dev,
-				unsigned char pg_order)
-{
 	if (sdesc && sdesc->pg) {
-		flq_unmap_one(sdesc, desc, dev, pg_order);
-		__free_pages(sdesc->pg, pg_order);
 		sdesc->pg = NULL;
+		sdesc->offset = 0;
 	}
 }
 
-static inline int flq_fill_one(struct qdma_sw_sg *sdesc,
-				struct qdma_c2h_desc *desc, struct device *dev,
-				int node, unsigned int buf_sz,
-				unsigned char pg_order, gfp_t gfp)
+static inline int flq_fill_one(struct qdma_descq *descq,
+				struct qdma_sw_sg *sdesc,
+				struct qdma_c2h_desc *desc)
+{
+	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
+	struct qdma_sw_pg_sg *pg_sdesc;
+	unsigned int pg_idx = 0;
+	unsigned int buf_sz = flq->desc_buf_size;
+
+	if (!flq || flq->num_pages == 0) {
+		pr_err("%s: flq is NULL", __func__);
+		return -EINVAL;
+	}
+
+	pg_idx = (flq->alloc_idx & flq->num_pgs_mask);
+
+	if (pg_idx >= flq->num_pages) {
+		pr_err("%s: pg_idx %d is Invalid",
+				__func__,
+				pg_idx);
+		return -EINVAL;
+	}
+
+	pg_sdesc = flq->pg_sdesc + pg_idx;
+	if (!pg_sdesc || !pg_sdesc->pg_base) {
+		pr_err("%s: pg_sdesc is NULL", __func__);
+		return -EINVAL;
+	}
+
+	if (pg_sdesc->pg_offset + buf_sz > flq->max_pg_offset) {
+		pr_err("%s: memory full, alloc_idx %u, recycle_idx = %u offset = %u, pg_idx = %u",
+				__func__,
+				flq->alloc_idx,
+				flq->recycle_idx,
+				pg_sdesc->pg_offset,
+				pg_idx);
+		return -ENOMEM;
+	}
+
+
+	sdesc->pg = pg_sdesc->pg_base;
+	sdesc->offset = pg_sdesc->pg_offset;
+	sdesc->dma_addr = pg_sdesc->pg_dma_base_addr + pg_sdesc->pg_offset;
+	sdesc->len = descq->conf.c2h_bufsz;
+	desc->dst_addr = sdesc->dma_addr;
+#if KERNEL_VERSION(4, 6, 0) < LINUX_VERSION_CODE
+	page_ref_inc(pg_sdesc->pg_base);
+#else
+	atomic_inc(&(pg_sdesc->pg_base->_count));
+#endif
+	pg_sdesc->pg_offset += buf_sz;
+
+	if ((pg_sdesc->pg_offset + buf_sz) > flq->max_pg_offset)
+		flq->alloc_idx++;
+
+	return 0;
+}
+
+static inline void flq_unmap_page_one(struct qdma_sw_pg_sg *pg_sdesc,
+				struct device *dev,
+				unsigned char pg_order)
+{
+	if (pg_sdesc && pg_sdesc->pg_dma_base_addr) {
+		dma_unmap_page(dev, pg_sdesc->pg_dma_base_addr,
+				PAGE_SIZE << pg_order,
+				DMA_FROM_DEVICE);
+		pg_sdesc->pg_dma_base_addr = 0UL;
+	}
+}
+
+static inline void flq_free_page_one(struct qdma_sw_pg_sg *pg_sdesc,
+				struct device *dev,
+				unsigned char pg_order,
+				unsigned int pg_shift)
+{
+	unsigned int page_count = 0;
+	unsigned int i = 0;
+
+	if (pg_sdesc && pg_sdesc->pg_base) {
+		/* +1 for dma_unmap*/
+		page_count = (pg_sdesc->pg_offset >> pg_shift) + 1;
+
+		flq_unmap_page_one(pg_sdesc, dev, pg_order);
+
+		for (i = 0; i < page_count; i++)
+			put_page(pg_sdesc->pg_base);
+
+		pg_sdesc->pg_base = NULL;
+		pg_sdesc->pg_dma_base_addr = 0UL;
+	}
+}
+
+void descq_flq_free_page_resource(struct qdma_descq *descq)
+{
+	struct xlnx_dma_dev *xdev = descq->xdev;
+	struct device *dev = &xdev->conf.pdev->dev;
+	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
+	struct qdma_sw_pg_sg *pg_sdesc = flq->pg_sdesc;
+	unsigned char pg_order = flq->desc_pg_order;
+	int i;
+
+	for (i = 0; i < flq->num_pages; i++, pg_sdesc++)
+		flq_free_page_one(pg_sdesc, dev,
+				pg_order, flq->desc_pg_shift);
+
+	kfree(flq->pg_sdesc);
+	flq->pg_sdesc = NULL;
+
+	memset(flq, 0, sizeof(struct qdma_flq));
+}
+
+void qdma4_descq_flq_free_resource(struct qdma_descq *descq)
+{
+	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
+	struct qdma_sw_sg *sdesc = flq->sdesc;
+	struct qdma_c2h_desc *desc = flq->desc;
+	int i;
+
+	/* It can never be null beyond this */
+	if (!sdesc)
+		return;
+
+	for (i = 0; i < flq->size; i++, sdesc++, desc++)
+		flq_free_one(sdesc, desc);
+
+	kfree(flq->sdesc);
+	flq->sdesc = NULL;
+	flq->sdesc_info = NULL;
+
+}
+
+
+static inline int flq_fill_page_one(struct qdma_sw_pg_sg *pg_sdesc,
+				struct device *dev,
+				int node, unsigned char pg_order, gfp_t gfp)
 {
 	struct page *pg;
 	dma_addr_t mapping;
 
 	pg = alloc_pages_node(node, __GFP_COMP | gfp, pg_order);
 	if (unlikely(!pg)) {
-		pr_info("failed to allocate the pages, order %d.\n", pg_order);
+		pr_err("%s: failed to allocate the pages, order %d.\n",
+				__func__,
+				pg_order);
 		return -ENOMEM;
 	}
 
-	mapping = dma_map_page(dev, pg, 0, PAGE_SIZE << pg_order,
+	mapping = dma_map_page(dev, pg, 0, (PAGE_SIZE << pg_order),
 				PCI_DMA_FROMDEVICE);
 	if (unlikely(dma_mapping_error(dev, mapping))) {
 		dev_err(dev, "page 0x%p mapping error 0x%llx.\n",
@@ -85,38 +209,10 @@ static inline int flq_fill_one(struct qdma_sw_sg *sdesc,
 		return -EINVAL;
 	}
 
-	sdesc->pg = pg;
-	sdesc->dma_addr = mapping;
-	sdesc->len = buf_sz << pg_order;
-	sdesc->offset = 0;
-
-	desc->dst_addr = sdesc->dma_addr;
+	pg_sdesc->pg_base = pg;
+	pg_sdesc->pg_dma_base_addr = mapping;
+	pg_sdesc->pg_offset = 0;
 	return 0;
-}
-
-void qdma4_descq_flq_free_resource(struct qdma_descq *descq)
-{
-	struct xlnx_dma_dev *xdev = descq->xdev;
-	struct device *dev = &xdev->conf.pdev->dev;
-	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
-
-	struct qdma_sw_sg *sdesc = flq->sdesc;
-	struct qdma_c2h_desc *desc = flq->desc;
-	unsigned char pg_order = flq->pg_order;
-	int i;
-
-	for (i = 0; i < flq->size; i++, sdesc++, desc++) {
-		if (sdesc)
-			flq_free_one(sdesc, desc, dev, pg_order);
-		else
-			break;
-	}
-
-	kfree(flq->sdesc);
-	flq->sdesc = NULL;
-	flq->sdesc_info = NULL;
-
-	memset(flq, 0, sizeof(struct qdma_flq));
 }
 
 int qdma4_descq_flq_alloc_resource(struct qdma_descq *descq)
@@ -125,21 +221,85 @@ int qdma4_descq_flq_alloc_resource(struct qdma_descq *descq)
 	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
 	struct device *dev = &xdev->conf.pdev->dev;
 	int node = dev_to_node(dev);
+	struct qdma_sw_pg_sg *pg_sdesc = NULL;
 	struct qdma_sw_sg *sdesc, *prev = NULL;
 	struct qdma_sdesc_info *sinfo, *sprev = NULL;
 	struct qdma_c2h_desc *desc = flq->desc;
 	int i;
 	int rv = 0;
+	/* find the most significant bit number */
+	unsigned int div_bits = 0;
+
+	div_bits = flq->desc_pg_shift;
+	flq->num_bufs_per_pg =
+			(flq->max_pg_offset >> div_bits);
+
+	if (flq->num_bufs_per_pg == 0) {
+		pr_err("%s: flq->num_bufs_per_pg = %d, flq->desc_pg_order = %d, div_bits = %d",
+				__func__,
+				flq->num_bufs_per_pg,
+				flq->desc_pg_order,
+				div_bits);
+		return -EINVAL;
+	}
+
+	flq->num_pages = (flq->size / flq->num_bufs_per_pg) +
+			((flq->size % flq->num_bufs_per_pg) == 0 ? 0 : 1);
+	flq->num_pages = get_next_powof2(flq->num_pages);
+	/* without this, alloc_idx and recycle_idx
+	 * will toeing each other creating a mess
+	 */
+	if (flq->num_pages < flq->size)
+		flq->num_pages = (flq->num_pages << 1);
+	flq->num_pgs_mask = (flq->num_pages - 1);
+
+	pr_debug("%s: conf_c2h_bufsz = %d, flq_c2h_buf_size = %d, num_bufs_per_pg = %d, num_pages = %d, flq->size = %d",
+			__func__,
+			descq->conf.c2h_bufsz,
+			flq->desc_buf_size,
+			flq->num_bufs_per_pg,
+			flq->num_pages,
+			flq->size);
+
+	pg_sdesc = kzalloc_node(flq->num_pages *
+				(sizeof(struct qdma_sw_pg_sg)),
+				GFP_KERNEL, node);
+
+	if (!pg_sdesc) {
+		pr_err("%s: OOM, sz %d * %ld.\n",
+				__func__,
+				flq->num_pages,
+				(sizeof(struct qdma_sw_pg_sg)));
+		return -ENOMEM;
+	}
+	flq->pg_sdesc = pg_sdesc;
+
+	for (pg_sdesc = flq->pg_sdesc, i = 0;
+			i < flq->num_pages; i++, pg_sdesc++) {
+		rv = flq_fill_page_one(pg_sdesc, dev, node,
+				flq->desc_pg_order, GFP_KERNEL);
+		if (rv < 0) {
+			descq_flq_free_page_resource(descq);
+			return rv;
+		}
+	}
 
 	sdesc = kzalloc_node(flq->size * (sizeof(struct qdma_sw_sg) +
 					  sizeof(struct qdma_sdesc_info)),
 				GFP_KERNEL, node);
 	if (!sdesc) {
-		pr_info("OOM, sz %u.\n", flq->size);
+		pr_err("%s: OOM, sz %d * %ld.\n",
+				__func__,
+				flq->size,
+				((sizeof(struct qdma_sw_sg) +
+				sizeof(struct qdma_sdesc_info))));
+		descq_flq_free_page_resource(descq);
 		return -ENOMEM;
 	}
+
 	flq->sdesc = sdesc;
 	flq->sdesc_info = sinfo = (struct qdma_sdesc_info *)(sdesc + flq->size);
+	flq->alloc_idx = 0;
 
 	/* make the flq to be a linked list ring */
 	for (i = 0; i < flq->size; i++, prev = sdesc, sdesc++,
@@ -149,15 +309,16 @@ int qdma4_descq_flq_alloc_resource(struct qdma_descq *descq)
 		if (sprev)
 			sprev->next = sinfo;
 	}
+
 	/* last entry's next points to the first entry */
 	prev->next = flq->sdesc;
 	sprev->next = flq->sdesc_info;
 
 	for (sdesc = flq->sdesc, i = 0; i < flq->size; i++, sdesc++, desc++) {
-		rv = flq_fill_one(sdesc, desc, dev, node, descq->conf.c2h_bufsz,
-				  flq->pg_order, GFP_KERNEL);
+		rv = flq_fill_one(descq, sdesc, desc);
 		if (rv < 0) {
 			qdma4_descq_flq_free_resource(descq);
+			descq_flq_free_page_resource(descq);
 			return rv;
 		}
 	}
@@ -165,21 +326,97 @@ int qdma4_descq_flq_alloc_resource(struct qdma_descq *descq)
 	return 0;
 }
 
+static inline int flq_refill_pages(struct qdma_descq *descq,
+		int count, bool recycle, gfp_t gfp)
+{
+	struct xlnx_dma_dev *xdev = descq->xdev;
+	struct device *dev = &xdev->conf.pdev->dev;
+	int node = dev_to_node(dev);
+	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
+	unsigned int n_recycle_index = flq->recycle_idx;
+	/* find the most significant bit number */
+	unsigned int div_bits = flq->desc_pg_shift;
+	struct qdma_sw_pg_sg *pg_sdesc = flq->pg_sdesc;
+	unsigned int free_bufs_in_pg;
+	unsigned int i = 0, j = 0;
+	int rv;
 
+	for (i = 0; i < count; ) {
+		pg_sdesc = flq->pg_sdesc +
+			(n_recycle_index & flq->num_pgs_mask);
+
+		if (!pg_sdesc) {
+			pr_err("pg_sdesc is NULL");
+			return -EINVAL;
+		}
+
+		free_bufs_in_pg = (pg_sdesc->pg_offset >> div_bits);
+		free_bufs_in_pg =
+			min_t(unsigned int, free_bufs_in_pg, count - i);
+		for (j = 0; j < free_bufs_in_pg; j++) {
+			pg_sdesc->pg_offset -= flq->desc_buf_size;
+			if (!recycle && !descq->conf.fp_descq_c2h_packet)
+				put_page(pg_sdesc->pg_base);
+		}
+		i += free_bufs_in_pg;
+		BUG_ON(i > count);
+		if (!pg_sdesc->pg_offset)
+			n_recycle_index++;
+	}
+
+	if (recycle)
+		flq->recycle_idx = n_recycle_index;
+	else {
+		while (1) {
+			pg_sdesc = flq->pg_sdesc +
+				(flq->recycle_idx & flq->num_pgs_mask);
+
+			if (!pg_sdesc) {
+				pr_err("pg_sdesc is NULL");
+				return -EINVAL;
+			}
+
+			/** Stop the allocation when the pg_offset of
+			 * the page is not 0 and
+			 *  recycle index is less than the alloc index
+			 */
+			if (pg_sdesc->pg_offset ||
+				flq->recycle_idx == flq->alloc_idx)
+				break;
+
+			flq_unmap_page_one(pg_sdesc, dev, flq->desc_pg_order);
+			put_page(pg_sdesc->pg_base);
+			rv = flq_fill_page_one(pg_sdesc,
+					dev, node, flq->desc_pg_order, gfp);
+			if (rv < 0)
+				break;
+
+			flq->recycle_idx++;
+		}
+	}
+
+	return 0;
+}
 
 static int qdma_flq_refill(struct qdma_descq *descq, int idx, int count,
 			int recycle, gfp_t gfp)
 {
-	struct xlnx_dma_dev *xdev = descq->xdev;
 	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
 	struct qdma_sw_sg *sdesc = flq->sdesc + idx;
 	struct qdma_c2h_desc *desc = flq->desc + idx;
 	struct qdma_sdesc_info *sinfo = flq->sdesc_info + idx;
-	int order = flq->pg_order;
 	int i;
+	int rv;
+
+	if (!recycle) {
+		rv = flq_refill_pages(descq, count, recycle, gfp);
+		if (unlikely(rv < 0)) {
+			pr_err("%s: flq_refill_pages failed rv %d error",
+					descq->conf.name, rv);
+		}
+	}
 
 	for (i = 0; i < count; i++, idx++, sdesc++, desc++, sinfo++) {
-
 		if (idx == flq->size) {
 			idx = 0;
 			sdesc = flq->sdesc;
@@ -188,17 +425,13 @@ static int qdma_flq_refill(struct qdma_descq *descq, int idx, int count,
 		}
 
 		if (recycle) {
-			sdesc->len = (descq->conf.c2h_bufsz << order);
-			sdesc->offset = 0;
+			sdesc->len = descq->conf.c2h_bufsz;
 		} else {
-			struct device *dev = &xdev->conf.pdev->dev;
-			int node = dev_to_node(dev);
-			int rv;
-
-			flq_unmap_one(sdesc, desc, dev, order);
-			rv = flq_fill_one(sdesc, desc, dev, node,
-					  descq->conf.c2h_bufsz, order, gfp);
+			flq_free_one(sdesc, desc);
+			rv = flq_fill_one(descq, sdesc, desc);
 			if (unlikely(rv < 0)) {
+				pr_err("%s: rv %d error",
+						descq->conf.name, rv);
 				if (rv == -ENOMEM)
 					flq->alloc_fail++;
 				else
@@ -210,6 +443,7 @@ static int qdma_flq_refill(struct qdma_descq *descq, int idx, int count,
 		sinfo->fbits = 0;
 		descq->avail++;
 	}
+
 	if (list_empty(&descq->work_list) &&
 			list_empty(&descq->pend_list)) {
 		descq->pend_list_empty = 1;
@@ -270,7 +504,6 @@ int qdma4_descq_st_c2h_read(struct qdma_descq *descq, struct qdma_request *req,
 			if (!req->no_memcpy)
 				memcpy(page_address(tsg->pg) + toff,
 				       faddr, copy);
-
 			if (descq->conf.ping_pong_en &&
 				*pkt_tx_time == descq->ping_pong_tx_time) {
 				u64 latency;
@@ -420,7 +653,6 @@ void qdma4_c2h_req_work(struct work_struct *work)
 	unlock_descq(descq);
 }
 
-
 void cmpt_next(struct qdma_descq *descq)
 {
 	u8 *desc_cmpt_cur = (u8 *)descq->desc_cmpt_cur + descq->cmpt_entry_len;
@@ -467,33 +699,74 @@ int parse_cmpl_entry(struct qdma_descq *descq, struct qdma_ul_cmpt_info *cmpl)
 	return 0;
 }
 
+static int get_fl_nr(unsigned int len,
+		unsigned int c2h_bufsz,
+		unsigned int pg_shift, unsigned int pg_mask,
+		unsigned int *last_len)
+{
+	unsigned int l_len = len;
+	int l_fl_nr = 1;
+
+	if ((len & (len-1)) == 0) {
+		/* pr_info("Len is ^2"); */
+		l_fl_nr = len ? ((len + pg_mask) >> pg_shift) : 1;
+		l_len = (len & pg_mask);
+		if (l_len == 0)
+			l_len = c2h_bufsz;
+	} else {
+		/* pr_info("Len is non ^2"); */
+		if (len) {
+			if (len <= c2h_bufsz)
+				l_fl_nr = 1;
+			else {
+				l_fl_nr = 0;
+				while (l_len >= c2h_bufsz) {
+					l_fl_nr++;
+					l_len -= c2h_bufsz;
+				}
+
+				if (l_len)
+					l_fl_nr++;
+				else
+					l_len = c2h_bufsz;
+			}
+		}
+
+	}
+
+	*last_len = l_len;
+	return l_fl_nr;
+}
+
 static int rcv_pkt(struct qdma_descq *descq, struct qdma_ul_cmpt_info *cmpl,
 			unsigned int len)
 {
 	unsigned int pidx = cmpl->pidx;
 	struct qdma_flq *flq = (struct qdma_flq *)descq->flq;
-	unsigned int pg_shift = flq->pg_shift;
+	unsigned int pg_shift = flq->desc_pg_shift;
 	unsigned int pg_mask = (1 << pg_shift) - 1;
 	unsigned int rngsz = descq->conf.rngsz;
 	/* zero length still uses one descriptor */
-	int fl_nr = len ? ((len + pg_mask) >> pg_shift) : 1;
+	unsigned int l_len = 0;
+	int fl_nr = get_fl_nr(len,
+				descq->conf.c2h_bufsz,
+				pg_shift, pg_mask, &l_len);
 	unsigned int last = ring_idx_incr(cmpl->pidx, fl_nr - 1, rngsz);
 	unsigned int next = ring_idx_incr(last, 1, rngsz);
 	struct qdma_sw_sg *sdesc = flq->sdesc + last;
 	unsigned int cidx_next = ring_idx_incr(descq->cidx_cmpt, 1,
 					descq->conf.rngsz_cmpt);
 
+	if (!len)
+		sdesc->len = 0;
+	else
+		sdesc->len = l_len;
+
 	if (descq->avail < fl_nr)
 		return -EBUSY;
+
 	descq->avail -= fl_nr;
 
-	if (len) {
-		unsigned int last_len = len & pg_mask;
-
-		if (last_len)
-			sdesc->len = last_len;
-	} else
-		sdesc->len = 0;
 
 	if (descq->conf.fp_descq_c2h_packet) {
 		int rv = descq->conf.fp_descq_c2h_packet(descq->q_hndl,
@@ -765,8 +1038,8 @@ int qdma4_descq_process_completion_st_c2h(struct qdma_descq *descq, int budget,
 
 	/* once an error happens, stop processing of the Q */
 	if (descq->err) {
-		pr_info("%s: err.\n", descq->conf.name);
-		return 0;
+		pr_err("%s: err.\n", descq->conf.name);
+		return -EINVAL;
 	}
 
 	dma_rmb();
@@ -785,14 +1058,14 @@ int qdma4_descq_process_completion_st_c2h(struct qdma_descq *descq, int budget,
 				return -EINVAL;
 			}
 		}
-		return 0;
+		return -ENODATA;
 	}
 
 #if 0
 	print_hex_dump(KERN_INFO, "st c2h cmpl status: ", DUMP_PREFIX_OFFSET,
 				16, 1, (void *)cs, sizeof(*cs),
 				false);
-	pr_info("st c2h cmpl status: pidx 0x%x, cidx %x, color %d, int_state 0x%x.\n",
+	pr_info("cmpl status: pidx 0x%x, cidx %x, color %d, int_state 0x%x.\n",
 		cs->pidx, cs->cidx, cs->color_isr_status & 0x1,
 		(cs->color_isr_status >> 1) & 0x3);
 #endif


### PR DESCRIPTION
- Check if ST enabled when setting up error mask
- allow bigger c2h freelist buffer allocation.
- misc. update ported from ip eqdma driver