### PR TITLE
Add XRT Graph API in libxrt_coreutil.

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -27,6 +27,13 @@ file(GLOB XRT_CORE_COMMON_LIB_FILES
   "api/*.cpp"
   )
 
+if (DEFINED XRT_AIE_BUILD)
+  file(GLOB XRT_CORE_COMMON_AIE_LIB_FILES
+    "api/aie/*.cpp"
+    )
+  list(APPEND XRT_CORE_COMMON_LIB_FILES ${XRT_CORE_COMMON_AIE_LIB_FILES})
+endif()
+
 # Files to include in object list
 file(GLOB XRT_CORE_COMMON_OBJ_FILES
   "scheduler.*"

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (C) 2020, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
@@ -21,7 +22,7 @@
 #include "core/include/experimental/xrt_aie.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
-#include "core/common/xrt_graph.h"
+#include "xrt_graph.h"
 #include "core/common/message.h"
 
 namespace xrt {

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -1,0 +1,482 @@
+/*
+ * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This file implements XRT APIs as declared in
+// core/include/experimental/xrt_aie.h
+
+#include "core/include/experimental/xrt_aie.h"
+#include "core/common/system.h"
+#include "core/common/device.h"
+#include "core/common/xrt_graph.h"
+#include "core/common/message.h"
+
+namespace xrt {
+
+class graph_impl {
+private:
+  std::shared_ptr<xrt_core::device> device;
+  xclGraphHandle handle;
+
+public:
+  graph_impl(xclDeviceHandle dhdl, xclGraphHandle ghdl)
+    : device(xrt_core::get_userpf_device(dhdl)), handle(ghdl)
+  {}
+
+  ~graph_impl()
+  {
+    device->close_graph(handle);
+  }
+
+  xclGraphHandle
+  get_handle() const
+  {
+    return handle;
+  }
+
+  void
+  reset()
+  {
+    device->reset_graph(handle);
+  }
+
+  uint64_t
+  get_timestamp()
+  {
+    return (device->get_timestamp(handle));
+  }
+
+  void
+  run(int iterations)
+  {
+    device->run_graph(handle, iterations);
+  }
+
+  int
+  wait(int timeout)
+  {
+    return (device->wait_graph_done(handle, timeout));
+  }
+
+  void
+  wait(uint64_t cycle)
+  {
+    device->wait_graph(handle, cycle);
+  }
+
+  void
+  suspend()
+  {
+    device->suspend_graph(handle);
+  }
+
+  void
+  resume()
+  {
+    device->resume_graph(handle);
+  }
+
+  void
+  end(uint64_t cycle)
+  {
+    device->end_graph(handle, cycle);
+  }
+
+  void
+  update_rtp(const char* port, const char* buffer, size_t size)
+  {
+    device->update_graph_rtp(handle, port, buffer, size);
+  }
+
+  void
+  read_rtp(const char* port, char* buffer, size_t size)
+  {
+    device->read_graph_rtp(handle, port, buffer, size);
+  }
+};
+
+}
+
+namespace {
+
+// C-API Graph handles are inserted to this map.
+// Note: xrtGraphClose must be explicitly called before xclClose.
+static std::map<xrtGraphHandle, std::shared_ptr<xrt::graph_impl>> graph_cache;
+
+static std::shared_ptr<xrt::graph_impl>
+open_graph(xclDeviceHandle dhdl, const uuid_t xclbin_uuid, const char* graph_name)
+{
+  auto device = xrt_core::get_userpf_device(dhdl);
+  auto handle = device->open_graph(xclbin_uuid, graph_name);
+  auto ghdl = std::make_shared<xrt::graph_impl>(dhdl, handle);
+  return ghdl;
+}
+
+static std::shared_ptr<xrt::graph_impl>
+get_graph_hdl(xrtGraphHandle graph_handle)
+{
+  auto itr = graph_cache.find(graph_handle);
+  if (itr == graph_cache.end())
+    throw xrt_core::error(-EINVAL, "No such graph handle");
+  return (*itr).second;
+}
+
+static void
+close_graph(xrtGraphHandle hdl)
+{
+  if (graph_cache.erase(hdl) == 0)
+    throw std::runtime_error("Unexpected internal error");
+}
+
+static void
+sync_aie_bo(xclDeviceHandle dhdl, xrtBufferHandle bohdl, const char *gmio_name, xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  auto device = xrt_core::get_userpf_device(dhdl);
+  device->sync_aie_bo(bohdl, gmio_name, dir, size, offset);
+}
+
+static void
+reset_aie(xclDeviceHandle dhdl)
+{
+  auto device = xrt_core::get_userpf_device(dhdl);
+  device->reset_aie();
+}
+
+static void
+sync_aie_bo_nb(xclDeviceHandle dhdl, xrtBufferHandle bohdl, const char *gmio_name, xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  auto device = xrt_core::get_userpf_device(dhdl);
+  device->sync_aie_bo_nb(bohdl, gmio_name, dir, size, offset);
+}
+
+static void
+wait_gmio(xclDeviceHandle dhdl, const char *gmio_name)
+{
+  auto device = xrt_core::get_userpf_device(dhdl);
+  device->wait_gmio(gmio_name);
+}
+
+inline void
+send_exception_message(const char* msg)
+{
+  xrt_core::message::send(xrt_core::message::severity_level::XRT_ERROR, "XRT", msg);
+}
+
+}
+
+////////////////////////////////////////////////////////////////
+// xrt_aie API implementations (xrt_aie.h)
+////////////////////////////////////////////////////////////////
+
+xrtGraphHandle
+xrtGraphOpen(xclDeviceHandle dev_handle, const uuid_t xclbin_uuid, const char* graph_name)
+{
+  try {
+    auto hdl = open_graph(dev_handle, xclbin_uuid, graph_name);
+    graph_cache[hdl.get()] = hdl;
+    return hdl.get();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return XRT_NULL_HANDLE;
+  }
+}
+
+void
+xrtGraphClose(xrtGraphHandle graph_hdl)
+{
+  try {
+    close_graph(graph_hdl);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+  }
+}
+
+int
+xrtGraphReset(xrtGraphHandle graph_hdl)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->reset();
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+uint64_t
+xrtGraphTimeStamp(xrtGraphHandle graph_hdl)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    return hdl->get_timestamp();
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphRun(xrtGraphHandle graph_hdl, int iterations)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->run(iterations);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphWaitDone(xrtGraphHandle graph_hdl, int timeoutMilliSec)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    return hdl->wait(timeoutMilliSec);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphWait(xrtGraphHandle graph_hdl, uint64_t cycle)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->wait(cycle);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphSuspend(xrtGraphHandle graph_hdl)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->suspend();
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphResuem(xrtGraphHandle graph_hdl)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->resume();
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphEnd(xrtGraphHandle graph_hdl, uint64_t cycle)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->end(cycle);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphUpdateRTP(xrtGraphHandle graph_hdl, const char* port, const char* buffer, size_t size)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->update_rtp(port, buffer, size);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtGraphReadRTP(xrtGraphHandle graph_hdl, const char* port, char* buffer, size_t size)
+{
+  try {
+    auto hdl = get_graph_hdl(graph_hdl);
+    hdl->read_rtp(port, buffer, size);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  try {
+    sync_aie_bo(handle, bohdl, gmioName, dir, size, offset);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+int
+xrtResetAIEArray(xclDeviceHandle handle)
+{
+  try {
+    reset_aie(handle);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+////////////////////////////////////////////////////////////////
+// Exposed for Cardano as extensions to xrt_aie.h
+////////////////////////////////////////////////////////////////
+/**
+ * xrtSyncBOAIENB() - Transfer data between DDR and Shim DMA channel
+ *
+ * @handle:          Handle to the device
+ * @bohdl:           BO handle.
+ * @gmioName:        GMIO port name
+ * @dir:             GM to AIE or AIE to GM
+ * @size:            Size of data to synchronize
+ * @offset:          Offset within the BO
+ *
+ * Return:          0 on success, -1 on error.
+ *
+ * Synchronize the buffer contents between GMIO and AIE.
+ * Note: Upon return, the synchronization is submitted or error out
+ */
+int
+xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  try {
+    sync_aie_bo_nb(handle, bohdl, gmioName, dir, size, offset);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+/**
+ * xrtGMIOWait() - Wait a shim DMA channel to be idle for a given GMIO port
+ *
+ * @handle:          Handle to the device
+ * @gmioName:        GMIO port name
+ *
+ * Return:          0 on success, -1 on error.
+ */
+int
+xrtGMIOWait(xclDeviceHandle handle, const char *gmioName)
+{
+  try {
+    wait_gmio(handle, gmioName);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -20,7 +20,7 @@
 #include "xrt.h"
 #include "experimental/xrt-next.h"
 #include "experimental/xrt_bo.h"
-#include "../common/xrt_graph.h"
+#include "xrt_graph.h"
 #include "error.h"
 #include <stdexcept>
 

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -19,6 +19,8 @@
 
 #include "xrt.h"
 #include "experimental/xrt-next.h"
+#include "experimental/xrt_bo.h"
+#include "../common/xrt_graph.h"
 #include "error.h"
 #include <stdexcept>
 
@@ -90,6 +92,56 @@ struct ishim
 
   virtual void
   load_xclbin(const struct axlf*) = 0;
+
+#ifdef XRT_ENABLE_AIE
+  virtual xclGraphHandle
+  open_graph(const xuid_t, const char*) = 0;
+
+  virtual void
+  close_graph(xclGraphHandle handle) = 0;
+
+  virtual void
+  reset_graph(xclGraphHandle handle) = 0;
+
+  virtual uint64_t
+  get_timestamp(xclGraphHandle handle) = 0;
+
+  virtual void
+  run_graph(xclGraphHandle handle, int iterations) = 0;
+
+  virtual int
+  wait_graph_done(xclGraphHandle handle, int timeout) = 0;
+
+  virtual void
+  wait_graph(xclGraphHandle handle, uint64_t cycle) = 0;
+
+  virtual void
+  suspend_graph(xclGraphHandle handle) = 0;
+
+  virtual void
+  resume_graph(xclGraphHandle handle) = 0;
+
+  virtual void
+  end_graph(xclGraphHandle handle, uint64_t cycle) = 0;
+
+  virtual void
+  update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size) = 0;
+
+  virtual void
+  read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) = 0;
+
+  virtual void
+  sync_aie_bo(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
+
+  virtual void
+  reset_aie() = 0;
+
+  virtual void
+  sync_aie_bo_nb(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
+
+  virtual void
+  wait_gmio(const char *gmioName) = 0;
+#endif
 };
 
 template <typename DeviceType>
@@ -250,6 +302,119 @@ struct shim : public DeviceType
     if (auto ret = xclLoadXclBin(DeviceType::get_device_handle(), buffer))
       throw error(ret, "failed to load xclbin");
   }
+
+#ifdef XRT_ENABLE_AIE
+  virtual xclGraphHandle
+  open_graph(const xuid_t uuid, const char *gname)
+  {
+    if (auto ghdl = xclGraphOpen(DeviceType::get_device_handle(), uuid, gname))
+      return ghdl;
+
+    throw std::runtime_error("failed to open graph");
+  }
+
+  virtual void
+  close_graph(xclGraphHandle handle)
+  {
+    return xclGraphClose(handle);
+  }
+
+  virtual void
+  reset_graph(xclGraphHandle handle)
+  {
+    if (auto ret = xclGraphReset(handle))
+      throw error(ret, "fail to reset graph");
+  }
+
+  virtual uint64_t
+  get_timestamp(xclGraphHandle handle)
+  {
+    return xclGraphTimeStamp(handle);
+  }
+
+  virtual void
+  run_graph(xclGraphHandle handle, int iterations)
+  {
+    if (auto ret = xclGraphRun(handle, iterations))
+      throw error(ret, "fail to run graph");
+  }
+
+  virtual int
+  wait_graph_done(xclGraphHandle handle, int timeout)
+  {
+    return xclGraphWaitDone(handle, timeout);
+  }
+
+  virtual void
+  wait_graph(xclGraphHandle handle, uint64_t cycle)
+  {
+    if (auto ret = xclGraphWait(handle, cycle))
+      throw error(ret, "fail to wait graph");
+  }
+
+  virtual void
+  suspend_graph(xclGraphHandle handle)
+  {
+    if (auto ret = xclGraphSuspend(handle))
+      throw error(ret, "fail to suspend graph");
+  }
+
+  virtual void
+  resume_graph(xclGraphHandle handle)
+  {
+    if (auto ret = xclGraphResume(handle))
+      throw error(ret, "fail to resume graph");
+  }
+
+  virtual void
+  end_graph(xclGraphHandle handle, uint64_t cycle)
+  {
+    if (auto ret = xclGraphEnd(handle, cycle))
+      throw error(ret, "fail to end graph");
+  }
+
+  virtual void
+  update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size)
+  {
+    if (auto ret = xclGraphUpdateRTP(handle, port, buffer, size))
+      throw error(ret, "fail to update graph rtp");
+  }
+
+  virtual void
+  read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size)
+  {
+    if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
+      throw error(ret, "fail to read graph rtp");
+  }
+
+  virtual void
+  sync_aie_bo(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  {
+    if (auto ret = xclSyncBOAIE(DeviceType::get_device_handle(), bohdl, gmioName, dir, size, offset))
+      throw error(ret, "fail to sync aie bo");
+  }
+
+  virtual void
+  reset_aie()
+  {
+    if (auto ret = xclResetAIEArray(DeviceType::get_device_handle()))
+      throw error(ret, "fail to reset aie");
+  }
+
+  virtual void
+  sync_aie_bo_nb(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  {
+    if (auto ret = xclSyncBOAIENB(DeviceType::get_device_handle(), bohdl, gmioName, dir, size, offset))
+      throw error(ret, "fail to sync aie non-blocking bo");
+  }
+
+  virtual void
+  wait_gmio(const char *gmioName)
+  {
+    if (auto ret = xclGMIOWait(DeviceType::get_device_handle(), gmioName))
+      throw error(ret, "fail to wait gmio");
+  }
+#endif
 };
 
 } // xrt_core

--- a/src/runtime_src/core/common/xrt_graph.h
+++ b/src/runtime_src/core/common/xrt_graph.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This file defines shim level XRT Graph APIs.
+
+#ifndef _XRT_COMMON_GRAPH_H_
+#define _XRT_COMMON_GRAPH_H_
+
+typedef void * xclGraphHandle;
+
+xclGraphHandle
+xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbinUUID, const char *graphName);
+
+void
+xclGraphClose(xclGraphHandle gh);
+
+int
+xclGraphReset(xclGraphHandle gh);
+
+uint64_t
+xclGraphTimeStamp(xclGraphHandle gh);
+
+int
+xclGraphRun(xclGraphHandle gh, int iterations);
+
+int
+xclGraphWaitDone(xclGraphHandle gh, int timeoutMilliSec);
+
+int
+xclGraphWait(xclGraphHandle gh, uint64_t cycle);
+
+int
+xclGraphSuspend(xclGraphHandle gh);
+
+int
+xclGraphResume(xclGraphHandle gh);
+
+int
+xclGraphEnd(xclGraphHandle gh, uint64_t cycle);
+
+int
+xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, size_t size);
+
+int
+xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size);
+
+int
+xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+int
+xclResetAIEArray(xclDeviceHandle handle);
+
+int
+xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+int
+xclGMIOWait(xclDeviceHandle handle, const char *gmioName);
+#endif

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,7 +21,7 @@
 #include "shim.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
-#include "core/common/xrt_graph.h"
+#include "xrt_graph.h"
  
 xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbosityLevel level)
 {

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -21,6 +21,7 @@
 #include "shim.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
+#include "core/common/xrt_graph.h"
  
 xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbosityLevel level)
 {
@@ -640,6 +641,103 @@ xclGetDebugIpLayout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size
 
 int xclGetSubdevPath(xclDeviceHandle handle,  const char* subdev,
                         uint32_t idx, char* path, size_t size)
+{
+  return 0;
+}
+
+// Temporary place holder for XRT shim level Graph APIs
+
+void*
+xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph)
+{
+  return nullptr;
+}
+
+void
+xclGraphClose(xclGraphHandle ghl)
+{
+}
+
+int
+xclGraphReset(xclGraphHandle ghl)
+{
+  return 0;
+}
+
+uint64_t
+xclGraphTimeStamp(xclGraphHandle ghl)
+{
+  return 0;
+}
+
+int
+xclGraphRun(xclGraphHandle gh, int iterations)
+{
+  return 0;
+}
+
+int
+xclGraphWaitDone(xclGraphHandle gh, int timeoutMilliSec)
+{
+  return 0;
+}
+
+int
+xclGraphWait(xclGraphHandle gh, uint64_t cycle)
+{
+  return 0;
+}
+
+int
+xclGraphSuspend(xclGraphHandle gh)
+{
+  return 0;
+}
+
+int
+xclGraphResume(xclGraphHandle gh)
+{
+  return 0;
+}
+
+int
+xclGraphEnd(xclGraphHandle gh, uint64_t cycle)
+{
+  return 0;
+}
+
+int
+xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, size_t size)
+{
+  return 0;
+}
+
+int
+xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size)
+{
+  return 0;
+}
+
+int
+xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  return 0;
+}
+
+int
+xclResetAIEArray(xclDeviceHandle handle)
+{
+  return 0;
+}
+
+int
+xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  return 0;
+}
+
+int
+xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
 {
   return 0;
 }

--- a/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
@@ -10,15 +10,30 @@ file(GLOB XRT_EDGE_TOOLS_XBUTIL_FILES
 
 add_executable(xbutil ${XRT_EDGE_TOOLS_XBUTIL_FILES})
 
-target_link_libraries(xbutil
-  xrt_core_static
-  xrt_coreutil_static
-  ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
-  pthread
-  rt
-  uuid
-  ${CURSES_LIBRARIES}
-  )
+if (DEFINED XRT_AIE_BUILD)
+  target_link_libraries(xbutil
+    xrt_core_static
+    xrt_coreutil_static
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    pthread
+    rt
+    uuid
+    ${CURSES_LIBRARIES}
+    metal
+    xaiengine
+    )
+else()
+  target_link_libraries(xbutil
+    xrt_core_static
+    xrt_coreutil_static
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+    pthread
+    rt
+    uuid
+    ${CURSES_LIBRARIES}
+    )
+endif()
 
 install (TARGETS xbutil RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -29,11 +29,20 @@ else()
     )
 endif()
 
-add_library(xrt_core_static STATIC ${XRT_EDGE_USER_FILES}
-  $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_no_dl_load_objects>
-  $<TARGET_OBJECTS:core_edge_common_objects>
-  $<TARGET_OBJECTS:core_common_objects>
-  )
+if (DEFINED XRT_AIE_BUILD)
+  add_library(xrt_core_static STATIC ${XRT_EDGE_USER_FILES}
+    $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_no_dl_load_objects>
+    $<TARGET_OBJECTS:core_edge_common_objects>
+    $<TARGET_OBJECTS:core_common_objects>
+    $<TARGET_OBJECTS:core_edge_user_aie_object>
+    )
+else()
+  add_library(xrt_core_static STATIC ${XRT_EDGE_USER_FILES}
+    $<TARGET_OBJECTS:core_edgeuser_plugin_xdp_no_dl_load_objects>
+    $<TARGET_OBJECTS:core_edge_common_objects>
+    $<TARGET_OBJECTS:core_common_objects>
+    )
+endif()
 
 set_target_properties(xrt_core PROPERTIES VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -21,7 +21,6 @@
 #include "core/edge/user/shim.h"
 #include "core/common/message.h"
 #endif
-//#include "core/include/experimental/xrt_aie.h"
 #include "core/common/error.h"
 
 #include <cstring>

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -21,7 +21,7 @@
 #include "core/edge/user/shim.h"
 #include "core/common/message.h"
 #endif
-#include "core/include/experimental/xrt_aie.h"
+//#include "core/include/experimental/xrt_aie.h"
 #include "core/common/error.h"
 
 #include <cstring>
@@ -564,16 +564,16 @@ namespace {
 using graph_type = zynqaie::graph_type;
 
 // Active graphs per xrtGraphOpen/Close.  This is a mapping from
-// xrtGraphHandle to the corresponding graph object. xrtGraphHandles
+// xclGraphHandle to the corresponding graph object. xclGraphHandles
 // is the address of the graph object.  This is shared ownership, as
 // internals can use the graph object while applicaiton has closed the
 // correspoding handle. The map content is deleted when user closes
 // the handle, but underlying graph object may remain alive per
 // reference count.
-static std::map<xrtGraphHandle, std::shared_ptr<graph_type>> graphs;
+static std::map<xclGraphHandle, std::shared_ptr<graph_type>> graphs;
 
 static std::shared_ptr<graph_type>
-get_graph(xrtGraphHandle ghdl)
+get_graph(xclGraphHandle ghdl)
 {
   auto itr = graphs.find(ghdl);
   if (itr == graphs.end())
@@ -587,8 +587,8 @@ namespace api {
 
 using graph_type = zynqaie::graph_type;
 
-xrtGraphHandle
-xrtGraphOpen(xclDeviceHandle dhdl, const uuid_t xclbin_uuid, const char* name)
+xclGraphHandle
+xclGraphOpen(xclDeviceHandle dhdl, const uuid_t xclbin_uuid, const char* name)
 {
   auto device = xrt_core::get_userpf_device(dhdl);
   auto graph = std::make_shared<graph_type>(device, xclbin_uuid, name);
@@ -598,28 +598,28 @@ xrtGraphOpen(xclDeviceHandle dhdl, const uuid_t xclbin_uuid, const char* name)
 }
 
 void
-xrtGraphClose(xrtGraphHandle ghdl)
+xclGraphClose(xclGraphHandle ghdl)
 {
   auto graph = get_graph(ghdl);
   graphs.erase(graph.get());
 }
 
 void
-xrtGraphReset(xrtGraphHandle ghdl)
+xclGraphReset(xclGraphHandle ghdl)
 {
   auto graph = get_graph(ghdl);
   graph->reset();
 }
 
 uint64_t
-xrtGraphTimeStamp(xrtGraphHandle ghdl)
+xclGraphTimeStamp(xclGraphHandle ghdl)
 {
   auto graph = get_graph(ghdl);
   return graph->get_timestamp();
 }
 
 void
-xrtGraphRun(xrtGraphHandle ghdl, int iterations)
+xclGraphRun(xclGraphHandle ghdl, int iterations)
 {
   auto graph = get_graph(ghdl);
   if (iterations == 0)
@@ -629,14 +629,14 @@ xrtGraphRun(xrtGraphHandle ghdl, int iterations)
 }
 
 void
-xrtGraphWaitDone(xrtGraphHandle ghdl, int timeout_ms)
+xclGraphWaitDone(xclGraphHandle ghdl, int timeout_ms)
 {
   auto graph = get_graph(ghdl);
   graph->wait_done(timeout_ms);
 }
 
 void
-xrtGraphWait(xrtGraphHandle ghdl, uint64_t cycle)
+xclGraphWait(xclGraphHandle ghdl, uint64_t cycle)
 {
   auto graph = get_graph(ghdl);
   if (cycle == 0)
@@ -646,21 +646,21 @@ xrtGraphWait(xrtGraphHandle ghdl, uint64_t cycle)
 }
 
 void
-xrtGraphSuspend(xrtGraphHandle ghdl)
+xclGraphSuspend(xclGraphHandle ghdl)
 {
   auto graph = get_graph(ghdl);
   graph->suspend();
 }
 
 void
-xrtGraphResume(xrtGraphHandle ghdl)
+xclGraphResume(xclGraphHandle ghdl)
 {
   auto graph = get_graph(ghdl);
   graph->resume();
 }
 
 void
-xrtGraphEnd(xrtGraphHandle ghdl, uint64_t cycle)
+xclGraphEnd(xclGraphHandle ghdl, uint64_t cycle)
 {
   auto graph = get_graph(ghdl);
   if (cycle == 0)
@@ -670,21 +670,21 @@ xrtGraphEnd(xrtGraphHandle ghdl, uint64_t cycle)
 }
 
 void
-xrtGraphUpdateRTP(xrtGraphHandle ghdl, const char* port, const char* buffer, size_t size)
+xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, size_t size)
 {
   auto graph = get_graph(ghdl);
   graph->update_rtp(port, buffer, size);
 }
 
 void
-xrtGraphReadRTP(xrtGraphHandle ghdl, const char* port, char* buffer, size_t size)
+xclGraphReadRTP(xclGraphHandle ghdl, const char* port, char* buffer, size_t size)
 {
   auto graph = get_graph(ghdl);
   graph->read_rtp(port, buffer, size);
 }
 
 void
-xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   zynqaie::Aie *aieArray = nullptr;
 
@@ -707,7 +707,7 @@ xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
 }
 
 void
-xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   zynqaie::Aie *aieArray = nullptr;
 
@@ -730,7 +730,7 @@ xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
 }
 
 void
-xrtGMIOWait(xclDeviceHandle handle, const char *gmioName)
+xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
 {
   zynqaie::Aie *aieArray = nullptr;
 
@@ -747,7 +747,7 @@ xrtGMIOWait(xclDeviceHandle handle, const char *gmioName)
 }
 
 void
-xrtResetAieArray(xclDeviceHandle handle)
+xclResetAieArray(xclDeviceHandle handle)
 {
   /* Do a handle check */
   xrt_core::get_userpf_device(handle);
@@ -760,13 +760,13 @@ xrtResetAieArray(xclDeviceHandle handle)
 
 
 ////////////////////////////////////////////////////////////////
-// xrt_aie API implementations (xrt_aie.h)
+// Shim level Graph API implementations (xrt_graph.h)
 ////////////////////////////////////////////////////////////////
-xrtGraphHandle
-xrtGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph)
+xclGraphHandle
+xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph)
 {
   try {
-    return api::xrtGraphOpen(handle, xclbin_uuid, graph);
+    return api::xclGraphOpen(handle, xclbin_uuid, graph);
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
@@ -775,10 +775,10 @@ xrtGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph
 }
 
 void
-xrtGraphClose(xrtGraphHandle ghdl)
+xclGraphClose(xclGraphHandle ghdl)
 {
   try {
-    api::xrtGraphClose(ghdl);
+    api::xclGraphClose(ghdl);
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
@@ -786,10 +786,10 @@ xrtGraphClose(xrtGraphHandle ghdl)
 }
 
 int
-xrtGraphReset(xrtGraphHandle ghdl)
+xclGraphReset(xclGraphHandle ghdl)
 {
   try {
-    api::xrtGraphReset(ghdl);
+    api::xclGraphReset(ghdl);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -803,10 +803,10 @@ xrtGraphReset(xrtGraphHandle ghdl)
 }
 
 uint64_t
-xrtGraphTimeStamp(xrtGraphHandle ghdl)
+xclGraphTimeStamp(xclGraphHandle ghdl)
 {
   try {
-    return api::xrtGraphTimeStamp(ghdl);
+    return api::xclGraphTimeStamp(ghdl);
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
@@ -815,10 +815,10 @@ xrtGraphTimeStamp(xrtGraphHandle ghdl)
 }
 
 int
-xrtGraphRun(xrtGraphHandle ghdl, int iterations)
+xclGraphRun(xclGraphHandle ghdl, int iterations)
 {
   try {
-    api::xrtGraphRun(ghdl, iterations);
+    api::xclGraphRun(ghdl, iterations);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -832,10 +832,10 @@ xrtGraphRun(xrtGraphHandle ghdl, int iterations)
 }
 
 int
-xrtGraphWaitDone(xrtGraphHandle ghdl, int timeout_ms)
+xclGraphWaitDone(xclGraphHandle ghdl, int timeout_ms)
 {
   try {
-    api::xrtGraphWaitDone(ghdl, timeout_ms);
+    api::xclGraphWaitDone(ghdl, timeout_ms);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -849,10 +849,10 @@ xrtGraphWaitDone(xrtGraphHandle ghdl, int timeout_ms)
 }
 
 int
-xrtGraphWait(xrtGraphHandle ghdl, uint64_t cycle)
+xclGraphWait(xclGraphHandle ghdl, uint64_t cycle)
 {
   try {
-    api::xrtGraphWait(ghdl, cycle);
+    api::xclGraphWait(ghdl, cycle);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -866,10 +866,10 @@ xrtGraphWait(xrtGraphHandle ghdl, uint64_t cycle)
 }
 
 int
-xrtGraphSuspend(xrtGraphHandle ghdl)
+xclGraphSuspend(xclGraphHandle ghdl)
 {
   try {
-    api::xrtGraphSuspend(ghdl);
+    api::xclGraphSuspend(ghdl);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -883,10 +883,10 @@ xrtGraphSuspend(xrtGraphHandle ghdl)
 }
 
 int
-xrtGraphResume(xrtGraphHandle ghdl)
+xclGraphResume(xclGraphHandle ghdl)
 {
   try {
-    api::xrtGraphResume(ghdl);
+    api::xclGraphResume(ghdl);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -900,10 +900,10 @@ xrtGraphResume(xrtGraphHandle ghdl)
 }
 
 int
-xrtGraphEnd(xrtGraphHandle ghdl, uint64_t cycle)
+xclGraphEnd(xclGraphHandle ghdl, uint64_t cycle)
 {
   try {
-    api::xrtGraphEnd(ghdl, cycle);
+    api::xclGraphEnd(ghdl, cycle);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -917,10 +917,10 @@ xrtGraphEnd(xrtGraphHandle ghdl, uint64_t cycle)
 }
 
 int
-xrtGraphUpdateRTP(xrtGraphHandle ghdl, const char* port, const char* buffer, size_t size)
+xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, size_t size)
 {
   try {
-    api::xrtGraphUpdateRTP(ghdl, port, buffer, size);
+    api::xclGraphUpdateRTP(ghdl, port, buffer, size);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -934,10 +934,10 @@ xrtGraphUpdateRTP(xrtGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 int
-xrtGraphReadRTP(xrtGraphHandle ghdl, const char *port, char *buffer, size_t size)
+xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size)
 {
   try {
-    api::xrtGraphReadRTP(ghdl, port, buffer, size);
+    api::xclGraphReadRTP(ghdl, port, buffer, size);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -951,10 +951,10 @@ xrtGraphReadRTP(xrtGraphHandle ghdl, const char *port, char *buffer, size_t size
 }
 
 int
-xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
-    api::xrtSyncBOAIE(handle, bohdl, gmioName, dir, size, offset);
+    api::xclSyncBOAIE(handle, bohdl, gmioName, dir, size, offset);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -968,10 +968,10 @@ xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
 }
 
 int
-xrtResetAIEArray(xclDeviceHandle handle)
+xclResetAIEArray(xclDeviceHandle handle)
 {
   try {
-    api::xrtResetAieArray(handle);
+    api::xclResetAieArray(handle);
     return 0;
   }
   catch (const std::exception& ex) {
@@ -999,10 +999,10 @@ xrtResetAIEArray(xclDeviceHandle handle)
  * Note: Upon return, the synchronization is submitted or error out
  */
 int
-xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
-    api::xrtSyncBOAIENB(handle, bohdl, gmioName, dir, size, offset);
+    api::xclSyncBOAIENB(handle, bohdl, gmioName, dir, size, offset);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -1024,10 +1024,10 @@ xrtSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
  * Return:          0 on success, -1 on error.
  */
 int
-xrtGMIOWait(xclDeviceHandle handle, const char *gmioName)
+xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
 {
   try {
-    api::xrtGMIOWait(handle, gmioName);
+    api::xclGMIOWait(handle, gmioName);
     return 0;
   }
   catch (const xrt_core::error& ex) {

--- a/src/runtime_src/core/include/xrt_graph.h
+++ b/src/runtime_src/core/include/xrt_graph.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * Copyright (C) 2020, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
@@ -23,7 +24,7 @@
 typedef void * xclGraphHandle;
 
 xclGraphHandle
-xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbinUUID, const char *graphName);
+xclGraphOpen(xclDeviceHandle handle, const xuid_t xclbinUUID, const char *graphName);
 
 void
 xclGraphClose(xclGraphHandle gh);


### PR DESCRIPTION
This PR is the first phase to move XRT Graph API from libxrt_core to libxrt_coreutil so that all targets (hw, hw_emu, sw_emu) can make use of XRT Graph API by linking to same common library libxrt_coreutil and have their own implementations in separate shim layer libraries.

Next phase, more common code across targets will be moved to libxrt_coreutil. And then, c++ Graph API will be provided.
@stsoe @chvamshi-xilinx please take a close look at the architecture, impact on Windows, and impact on other edge platforms without AIE 