### PR TITLE
CR-1071604 xbutil dmatest & mem --write failed for xilinx_u250_gen3x16_xdma_shell_2_1

### DIFF
--- a/src/runtime_src/core/pcie/common/memaccess.h
+++ b/src/runtime_src/core/pcie/common/memaccess.h
@@ -147,7 +147,7 @@ namespace xcldev {
         ifs.read( buffer, buf_size ); // TODO: read entry by entry instead of entire mem_topology struct.
         mem_topology *map = (mem_topology *)buffer;
         for( int i = 0; i < map->m_count; i++ ) {
-            if( map->m_mem_data[i].m_used && map->m_mem_data[i].m_type != MEM_STREAMING ) {
+            if( map->m_mem_data[i].m_used && map->m_mem_data[i].m_type != MEM_STREAMING && map->m_mem_data[i].m_size ) {
                 aBanks.emplace_back( map->m_mem_data[i].m_base_address, map->m_mem_data[i].m_size*1024, i );
             }
         }


### PR DESCRIPTION
Ignore memory bank with empty size