### PR TITLE
Added check to GMIO type and shim column

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -138,9 +138,14 @@ get_gmio(const pt::ptree& aie_meta)
   for (auto& gmio_node : aie_meta.get_child("aie_metadata.GMIOs")) {
     gmio_type gmio;
 
+    // Only get AIE GMIO type, 0: GM->AIE; 1: AIE->GM
+    auto type = gmio_node.second.get<uint16_t>("type");
+    if (type != 0 && type != 1)
+      continue;
+
     gmio.id = gmio_node.second.get<uint32_t>("id");
     gmio.name = gmio_node.second.get<std::string>("name");
-    gmio.type = gmio_node.second.get<uint16_t>("type");
+    gmio.type = type;
     gmio.shim_col = gmio_node.second.get<uint16_t>("shim_column");
     gmio.channel_number = gmio_node.second.get<uint16_t>("channel_number");
     gmio.burst_len = gmio_node.second.get<uint16_t>("burst_length_in_16byte");

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -72,6 +72,9 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
      */
     shim_dma.resize(numCols);
     for (auto& gmio : gmios) {
+        if (gmio.shim_col > numCols)
+            throw xrt_core::error(-EINVAL, "GMIO " + gmio.name + " shim column " + std::to_string(gmio.shim_col) + " does not exist");
+
         auto dma = &shim_dma.at(gmio.shim_col);
         auto pos = getTilePos(gmio.shim_col, 0);
         if (!dma->configured) {


### PR DESCRIPTION
PL GMIO type has a -1 shim_column # which causes 
[XRT] ERROR: vector::_M_range_check: __n (which is 65535) >= this->size() (which is 50)

This PR added check to gmio type and shim_column