### PR TITLE
m2m

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -228,6 +228,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/subdev/pmc.c
   xocl/subdev/intc.c
   xocl/subdev/icap_cntrl.c
+  xocl/subdev/m2m.c
   xocl/subdev/version_ctrl.c
   xocl/subdev/msix_xdma.c
   xocl/subdev/ert_user.c

--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -122,6 +122,79 @@ out:
 	status->num_ready = ready_reg;
 }
 
+static void cu_hls_enable_intr(void *core, u32 intr_type)
+{
+	struct xrt_cu_hls *cu_hls = core;
+	u32 *base_addr = cu_hls->vaddr;
+	u32 intr_mask = intr_type & CU_INTR_DONE;
+
+	/* 0x04 and 0x08 -- Interrupt Enable Registers */
+	iowrite32(0x1, base_addr + 1);
+	/*
+	 * bit 0 is ap_done, bit 1 is ap_ready
+	 * only enable ap_done before dataflow support, interrupts are handled
+	 * in sched_exec_isr, please see dataflow comments for more information.
+	 */
+	iowrite32(intr_mask, base_addr + 2);
+}
+
+static void cu_hls_disable_intr(void *core, u32 intr_type)
+{
+	struct xrt_cu_hls *cu_hls = core;
+
+	u32 intr_mask = intr_type & ioread32(cu_hls->vaddr + 0x8);
+
+	/* 0x04 and 0x08 -- Interrupt Enable Registers */
+	iowrite32(0x0, cu_hls->vaddr + 0x4);
+	/* bit 0 is ap_done, bit 1 is ap_ready, disable both of interrupts */
+	iowrite32(intr_mask, cu_hls->vaddr + 0x8);
+}
+
+static u32 cu_hls_clear_intr(void *core)
+{
+	struct xrt_cu_hls *cu_hls = core;
+
+	/* Clear all interrupts of the CU
+	 *
+	 * HLS style kernel has Interrupt Status Register at offset 0x0C
+	 * It has two interrupt bits, bit[0] is ap_done, bit[1] is ap_ready.
+	 *
+	 * The ap_done interrupt means this CU is complete.
+	 * The ap_ready interrupt means all inputs have been read.
+	 */
+	if (cu_hls->max_credits == 1) {
+		u32 isr;
+
+		/*
+		 * The old HLS adapter.
+		 *
+		 * The Interrupt Status Register is Toggle On Write
+		 * RegData = RegData ^ WriteData
+		 *
+		 * So, the reliable way to clear this register is read
+		 * then write the same value back.
+		 *
+		 * Do not write 1 to this register.  If, somehow, the
+		 * status register is 0, write 1 to this register will
+		 * trigger interrupt.
+		 */
+		isr = ioread32(cu_hls->vaddr + 0xc);
+		iowrite32(isr, cu_hls->vaddr + 0xc);
+		return isr;
+	}
+
+	/*
+	 * The new HLS adapter with queue.
+	 *
+	 * The Interrupt Status Register is Clear on Read.
+	 *
+	 * For debug purpose, This register is toggle on write.
+	 * Write 1 to this register will trigger interrupt.
+	 */
+	return ioread32(cu_hls->vaddr + 0xc);
+}
+
+
 static struct xcu_funcs xrt_cu_hls_funcs = {
 	.alloc_credit	= cu_hls_alloc_credit,
 	.free_credit	= cu_hls_free_credit,
@@ -129,6 +202,9 @@ static struct xcu_funcs xrt_cu_hls_funcs = {
 	.configure	= cu_hls_configure,
 	.start		= cu_hls_start,
 	.check		= cu_hls_check,
+	.enable_intr	= cu_hls_enable_intr,
+	.disable_intr	= cu_hls_disable_intr,
+	.clear_intr	= cu_hls_clear_intr,
 };
 
 int xrt_cu_hls_init(struct xrt_cu *xcu)
@@ -145,6 +221,7 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	}
 
 	/* map CU register */
+	/* TODO: add comment why uses res[0] */
 	res = xcu->res[0];
 	size = res->end - res->start + 1;
 	core->vaddr = ioremap_nocache(res->start, size);

--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -125,17 +125,16 @@ out:
 static void cu_hls_enable_intr(void *core, u32 intr_type)
 {
 	struct xrt_cu_hls *cu_hls = core;
-	u32 *base_addr = cu_hls->vaddr;
 	u32 intr_mask = intr_type & CU_INTR_DONE;
 
 	/* 0x04 and 0x08 -- Interrupt Enable Registers */
-	iowrite32(0x1, base_addr + 1);
+	iowrite32(0x1, cu_hls->vaddr + 0x4);
 	/*
 	 * bit 0 is ap_done, bit 1 is ap_ready
 	 * only enable ap_done before dataflow support, interrupts are handled
 	 * in sched_exec_isr, please see dataflow comments for more information.
 	 */
-	iowrite32(intr_mask, base_addr + 2);
+	iowrite32(intr_mask, cu_hls->vaddr + 0x8);
 }
 
 static void cu_hls_disable_intr(void *core, u32 intr_type)

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -40,6 +40,10 @@
 #define CU_AP_CONTINUE	(0x1 << 4)
 #define CU_AP_RESET	(0x1 << 5)
 
+#define CU_INTR_DONE  0x1
+#define CU_INTR_READY 0x2
+
+
 /* PLRAM CU macros */
 
 enum xcu_model {
@@ -220,9 +224,23 @@ struct xrt_cu {
 
 void xrt_cu_reset(struct xrt_cu *xcu);
 int  xrt_cu_reset_done(struct xrt_cu *xcu);
-void xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type);
-void xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type);
-u32  xrt_cu_clear_intr(struct xrt_cu *xcu);
+
+static void inline xrt_cu_enable_intr(struct xrt_cu *xcu, u32 intr_type)
+{
+	if (xcu->funcs)
+		xcu->funcs->enable_intr(xcu->core, intr_type);
+}
+
+static void inline xrt_cu_disable_intr(struct xrt_cu *xcu, u32 intr_type)
+{
+	if (xcu->funcs)
+		xcu->funcs->disable_intr(xcu->core, intr_type);
+}
+
+static u32 inline xrt_cu_clear_intr(struct xrt_cu *xcu)
+{
+	return xcu->funcs ? xcu->funcs->clear_intr(xcu->core) : 0;
+}
 
 static inline void xrt_cu_config(struct xrt_cu *xcu, u32 *data, size_t sz, int type)
 {

--- a/src/runtime_src/core/pcie/driver/linux/include/mgmt-ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mgmt-ioctl.h
@@ -175,5 +175,4 @@ struct xclmgmt_ioc_freqscaling {
 #define XCLMGMT_IOCFREQSCALE		_IOW(XCLMGMT_IOC_MAGIC, XCLMGMT_IOC_FREQ_SCALE, struct xclmgmt_ioc_freqscaling)
 #define XCLMGMT_IOCREBOOT		_IO(XCLMGMT_IOC_MAGIC, XCLMGMT_IOC_REBOOT)
 #define XCLMGMT_IOCERRINFO		_IOR(XCLMGMT_IOC_MAGIC, XCLMGMT_IOC_ERR_INFO, struct xclErrorStatus)
-
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -157,6 +157,8 @@ enum drm_xocl_ops {
 	DRM_XOCL_ALLOC_CMA,
 	/* Free allocated CMA chunk through userpf*/
 	DRM_XOCL_FREE_CMA,
+	/* Memory to Memory BO copy */
+	DRM_XOCL_COPY_BO,
 	DRM_XOCL_NUM_IOCTLS
 };
 
@@ -261,6 +263,24 @@ struct drm_xocl_info_bo {
 	uint32_t flags;
 	uint64_t size;
 	uint64_t paddr;
+};
+
+/**
+ * struct drm_xocl_copy_bo - device memory to memory copy bo
+ * used with DRM_IOCTL_XOCL_COPY_BO IOCTL
+ *
+ * @dst_handle:	dst bo handle
+ * @src_handle:	src bo handle
+ * @size:       bo size in bytes
+ * @dst_offset: dst offset
+ * @src_offset: src offset
+ */
+struct drm_xocl_copy_bo {
+	uint32_t dst_handle;
+	uint32_t src_handle;
+	uint64_t size;
+	uint64_t dst_offset;
+	uint64_t src_offset;
 };
 
 /**
@@ -474,6 +494,7 @@ struct drm_xocl_alloc_cma_info {
 	uint64_t	entry_num;
 	uint64_t	*user_addr;
 };
+
 /*
  * Core ioctls numbers
  */
@@ -502,4 +523,5 @@ struct drm_xocl_alloc_cma_info {
 #define	DRM_IOCTL_XOCL_RECLOCK		XOCL_IOC_ARG(RECLOCK, reclock_info)
 #define	DRM_IOCTL_XOCL_ALLOC_CMA	XOCL_IOC_ARG(ALLOC_CMA, alloc_cma_info)
 #define	DRM_IOCTL_XOCL_FREE_CMA		XOCL_IOC(FREE_CMA)
+#define	DRM_IOCTL_XOCL_COPY_BO		XOCL_IOC_ARG(COPY_BO, copy_bo)
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -251,6 +251,7 @@ enum {
 #define	XOCL_MSIX_XDMA		"msix_xdma"
 #define	XOCL_ERT_USER		"ert_user"
 #define	XOCL_ERT_30		"ert_30"
+#define	XOCL_M2M		"m2m"
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
@@ -260,6 +261,7 @@ enum subdev_id {
 	XOCL_SUBDEV_AXIGATE,
 	XOCL_SUBDEV_MSIX,
 	XOCL_SUBDEV_DMA,
+	XOCL_SUBDEV_M2M,
 	XOCL_SUBDEV_IORES,
 	XOCL_SUBDEV_FLASH,
 	XOCL_SUBDEV_P2P,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4239,7 +4239,10 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 		return 0;
 
 	/* If SSV3 M2M subdev is enabled, execbuf API should not be called for copybo */
-	BUG_ON(M2M_CB(xdev));
+	if (M2M_CB(xdev)) {
+		userpf_err(xdev,"This is SSV3 with m2m enabled, cannot use execbuf.");
+		return -EINVAL;
+	}
 
 	sz = ert_copybo_size(scmd);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4238,6 +4238,9 @@ static int convert_execbuf(struct xocl_dev *xdev, struct drm_file *filp,
 	if (scmd->opcode != ERT_START_COPYBO)
 		return 0;
 
+	/* If SSV3 M2M subdev is enabled, execbuf API should not be called for copybo */
+	BUG_ON(M2M_CB(xdev));
+
 	sz = ert_copybo_size(scmd);
 
 	src_off = ert_copybo_src_offset(scmd);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -82,6 +82,7 @@ xocl-y := \
 	../subdev/cu.o \
 	../subdev/p2p.o \
 	../subdev/intc.o \
+	../subdev/m2m.o \
 	../subdev/version_ctrl.o \
 	../subdev/msix_xdma.o \
 	../subdev/ert_user.o \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -161,6 +161,8 @@ int xocl_pread_unmgd_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_usage_stat_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
+int xocl_copy_bo_ioctl(struct drm_device *dev, void *data,
+	struct drm_file *filp);
 
 struct sg_table *xocl_gem_prime_get_sg_table(struct drm_gem_object *obj);
 struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -360,6 +360,8 @@ static const struct drm_ioctl_desc xocl_ioctls[] = {
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_EXECBUF, xocl_execbuf_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(XOCL_COPY_BO, xocl_copy_bo_ioctl,
+			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_HOT_RESET, xocl_hot_reset_ioctl,
 			  DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(XOCL_RECLOCK, xocl_reclock_ioctl,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1559,6 +1559,7 @@ static int (*xocl_drv_reg_funcs[])(void) __initdata = {
 	xocl_init_msix_xdma,
 	xocl_init_ert_user,
 	xocl_init_ert_30,
+	xocl_init_m2m,
 };
 
 static void (*xocl_drv_unreg_funcs[])(void) = {
@@ -1596,6 +1597,7 @@ static void (*xocl_drv_unreg_funcs[])(void) = {
 	xocl_fini_msix_xdma,
 	xocl_fini_ert_user,
 	xocl_fini_ert_30,
+	xocl_fini_m2m,
 };
 
 static int __init xocl_init(void)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1754,6 +1754,19 @@ struct xocl_p2p_funcs {
 #define XOCL_P2P_CHUNK_SHIFT		28
 #define XOCL_P2P_CHUNK_SIZE		(1UL << XOCL_P2P_CHUNK_SHIFT)
 
+struct xocl_m2m_funcs {
+	struct xocl_subdev_funcs common_funcs;
+	int (*copy_bo)(struct platform_device *pdev, uint64_t src_paddr,
+		uint64_t dst_paddr, uint32_t src_handle, uint32_t dst_handle,
+		uint32_t size);
+};
+#define	M2M_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_M2M).pldev
+#define	M2M_OPS(xdev)	\
+	((struct xocl_m2m_funcs *)SUBDEV(xdev, XOCL_SUBDEV_M2M).ops)
+#define	M2M_CB(xdev)	(M2M_DEV(xdev) && M2M_OPS(xdev))
+#define	xocl_m2m_copy_bo(xdev, src_paddr, dst_paddr, src_handle, dst_handle, size) \
+	(M2M_CB(xdev) ? M2M_OPS(xdev)->copy_bo(M2M_DEV(xdev), src_paddr, dst_paddr, \
+	src_handle, dst_handle, size) : -ENODEV)
 
 /* subdev functions */
 int xocl_subdev_init(xdev_handle_t xdev_hdl, struct pci_dev *pdev,
@@ -2052,6 +2065,9 @@ void xocl_fini_intc(void);
 
 int __init xocl_init_icap_controller(void);
 void xocl_fini_icap_controller(void);
+
+int __init xocl_init_m2m(void);
+void xocl_fini_m2m(void);
 
 int __init xocl_init_version_control(void);
 void xocl_fini_version_control(void);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -675,6 +675,18 @@ static struct xocl_subdev_map subdev_map[] = {
 		.build_priv_data = NULL,
 		.devinfo_cb = NULL,
 	},
+	{
+		.id = XOCL_SUBDEV_M2M,
+		.dev_name = XOCL_M2M,
+		.res_array = (struct xocl_subdev_res[]) {
+			{.res_name = NODE_KDMA_CTRL, .regmap_name = PROP_SHELL_KDMA},
+			{NULL},
+		},
+		.required_ip = 1,
+		.flags = 0,
+		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
+	},
 };
 
 /*

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -100,6 +100,7 @@
 
 #define PROP_HWICAP "axi_hwicap"
 #define PROP_PDI_CONFIG "pdi_config_mem"
+#define PROP_SHELL_KDMA "shell_utils_kdma"
 
 #define RESNAME_GATEPLP		NODE_GATE_PLP
 #define RESNAME_PCIEMON		NODE_PCIE_MON

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -223,6 +223,12 @@ private:
     // QDMA AIO
     aio_context_t mAioContext;
     bool mAioEnabled;
+
+    /* CopyBO helpers */
+    int execbufCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                  size_t dst_offset, size_t src_offset);
+    int m2mCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, size_t size,
+                  size_t dst_offset, size_t src_offset);
 }; /* shim */
 
 } /* xocl */

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -2069,8 +2069,9 @@ static int m2m_alloc_init_bo(xclDeviceHandle handle, unsigned &boh,
         return -EINVAL;
     }
     memset(boptr, pattern, boSize);
-    if(xclSyncBO(handle, boh, XCL_BO_SYNC_BO_TO_DEVICE, boSize, 0)) {
-        std::cout << "ERROR: Unable to sync BO" << std::endl;
+    int err = xclSyncBO(handle, boh, XCL_BO_SYNC_BO_TO_DEVICE, boSize, 0);
+    if (err) {
+        std::cout << "ERROR: Unable to sync BO, err: " << err << std::endl;
         m2m_free_unmap_bo(handle, boh, boptr, boSize);
         return -EINVAL;
     }


### PR DESCRIPTION
this is the first version of data-driver m2m in polling mode. Still working on intr and better code structure. Please feel free to add any comments.

```
root@xsjyliu50:~# xbutil m2mtest
INFO: Found total 1 card(s), 1 are usable
HBM[0] -> HBM[1] M2M bandwidth: 9898.69 MB/s
HBM[0] -> HBM[2] M2M bandwidth: 9905.97 MB/s
HBM[0] -> HBM[3] M2M bandwidth: 9906.74 MB/s

```

> Changed ioctl name to copy_bo as a generic interface;
check in execbuf when SSV3 m2m subdev is on, bug_on the error case;
tested p2p case and wait for Soren's code, this should not block this PR to be merged.
enhanced xrt_cu API, enabled enable_intr, disable_intr and clear_intr for hls CU.