### PR TITLE
Remove fpga-mgr dependency for inserting xclmgmt.ko

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -21,7 +21,7 @@
  * kernels do not support FPGA Mgr yet.
  */
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0) && !defined(RHEL_RELEASE_VERSION)
 #define FPGA_MGR_SUPPORT
 #include <linux/fpga/fpga-mgr.h>
 #endif


### PR DESCRIPTION
> xclmgmt.ko inserting depends on symbols exported by fpga-mgr.c file
> CentOs and RHEL does not support this by default, so removing dependency in them
> With RHEL_RELEASE_VERSION macro disabled fpga_mgr_support for both RHEL and CentOs. So this feature is only supported on Ubuntu with kernel version > 4.15