### PR TITLE
CR-1072226 :  xbtest precanned tests fails to run due to invalid DUMP format

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -522,7 +522,7 @@ public:
  
         const mem_topology *map = (mem_topology *)buf.data();
         const uint32_t *temp = (uint32_t *)temp_buf.data();
-	    const int temp_size = (uint32_t)temp_buf.size()/sizeof(uint32_t);
+        const int temp_size = (uint32_t)temp_buf.size()/sizeof(uint32_t);
 
         if(buf.empty() || mm_buf.empty())
             return;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -520,10 +520,9 @@ public:
         dev->sysfs_get("", "memstat_raw", errmsg, mm_buf);
         dev->sysfs_get("xmc", "temp_by_mem_topology", errmsg, temp_buf);
  
-	std::cout << "Total number id temp : " << temp_buf.size() << std::endl;
         const mem_topology *map = (mem_topology *)buf.data();
         const uint32_t *temp = (uint32_t *)temp_buf.data();
-	const int temp_size = (uint32_t)temp_buf.size()/sizeof(uint32_t);
+	    const int temp_size = (uint32_t)temp_buf.size()/sizeof(uint32_t);
 
         if(buf.empty() || mm_buf.empty())
             return;


### PR DESCRIPTION
Removed unwanted log message which is causing xbtest regression test failed. 