### PR TITLE
Convert XRT Native C-API to be xrtDeviceHandle aware

### DIFF
--- a/src/python/xrt_binding.py
+++ b/src/python/xrt_binding.py
@@ -28,6 +28,7 @@ libcore = ctypes.CDLL(os.environ['XILINX_XRT'] + "/lib/libxrt_core.so", mode=cty
 libcoreutil = ctypes.CDLL(os.environ['XILINX_XRT'] + "/lib/libxrt_coreutil.so", mode=ctypes.RTLD_GLOBAL)
 
 xclDeviceHandle = ctypes.c_void_p
+xrtDeviceHandle = ctypes.c_void_p
 xrtKernelHandle = ctypes.c_void_p
 xrtRunHandle = ctypes.c_void_p
 xrtKernelRunHandle = ctypes.c_void_p
@@ -942,6 +943,38 @@ def xclDebugReadIPStatus(handle, type, debugResults):
     libcore.xclDebugReadIPStatus.argtypes = [xclDeviceHandle, ctypes.c_int, ctypes.c_void_p]
     return libcore.xclDebugReadIPStatus(handle, type, debugResults)
 
+def xrtDeviceOpen(deviceIndex):
+    """
+    xrtDeviceOpen(): Open a device and obtain its xrt device handle
+
+    :param deviceIndex: (unsigned int) Slot number of device 0 for first device, 1 for the second device...
+    """
+    libcoreutil.xrtDeviceOpen.restype = ctypes.POINTER(xrtDeviceHandle)
+    libcoreutil.xrtDeviceOpen.argTypes = [ctypes.c_uint]
+    return _valueOrError(libcoreutil.xrtDeviceOpen(deviceIndex))
+
+def xrtDeviceClose(handle):
+    """
+    xrtDeviceClose(): Close an device handle opened with xrtDeviceOpen()
+
+    :param handle: XRT device handle
+    :return: 0 on success or appropriate error number
+    """
+    libcoreutil.xrtDeviceClose.restype = ctypes.c_int
+    libcoreutil.xrtDeviceClose.argTypes = [xrtDeviceHandle]
+    return _valueOrError(libcoreutil.xrtDeviceClose(handle))
+
+def xrtDeviceToXclDevice(handle):
+    """
+    Convert xrt device handle to xcl device handle for shim level APIs
+
+    :param handle: XRT device handle
+    :return: XCL device handle
+    """
+    libcoreutil.xrtDeviceToXclDevice.restype = ctypes.POINTER(xclDeviceHandle)
+    libcoreutil.xrtDeviceToXclDevice.argtypes = [xrtDeviceHandle]
+    return _valueOrError(libcoreutil.xrtDeviceToXclDevice(handle))
+    
 def xrtPLKernelOpen(handle, xclbinId, name):
     """
     Open a PL kernel and obtain its handle

--- a/src/runtime_src/core/common/api/device_int.h
+++ b/src/runtime_src/core/common/api/device_int.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XRT_COMMON_DEVICE_INT_H_
+#define _XRT_COMMON_DEVICE_INT_H_
+
+// This file defines implementation extensions to the XRT Device APIs.
+#include "core/include/experimental/xrt_device.h"
+
+namespace xrt_core { namespace device_int {
+
+// Retrieve xrt_core::device from xrtDeviceHandle
+std::shared_ptr<xrt_core::device>
+get_core_device(xrtDeviceHandle dhdl);
+
+// Get underlying shim device handle 
+xclDeviceHandle
+get_xcl_device_handle(xrtDeviceHandle dhdl);
+
+}} // device_int, xrt_core
+
+#endif

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -22,6 +22,7 @@
 #include "core/include/experimental/xrt_bo.h"
 
 #include "bo.h"
+#include "device_int.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
 #include "core/common/memalign.h"
@@ -483,6 +484,12 @@ sub_buffer(const std::shared_ptr<xrt::bo_impl>& parent, size_t size, size_t offs
   return std::make_shared<xrt::buffer_sub>(parent, size, offset);
 }
 
+static xclDeviceHandle
+get_xcl_device_handle(xrtDeviceHandle dhdl)
+{
+  return xrt_core::device_int::get_xcl_device_handle(dhdl);
+}
+
 } // namespace
 
 ////////////////////////////////////////////////////////////////
@@ -580,10 +587,10 @@ read(void* dst, size_t size, size_t skip)
 // xrt_bo API implmentations (xrt_bo.h)
 ////////////////////////////////////////////////////////////////
 xrtBufferHandle
-xrtBOAllocUserPtr(xclDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp)
+xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
   try {
-    auto boh = alloc(dhdl, userptr, size, flags, grp);
+    auto boh = alloc(get_xcl_device_handle(dhdl), userptr, size, flags, grp);
     bo_cache[boh.get()] = boh;
     return boh.get();
   }
@@ -599,10 +606,10 @@ xrtBOAllocUserPtr(xclDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
 }
 
 xrtBufferHandle
-xrtBOAlloc(xclDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp)
+xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
   try {
-    auto boh = alloc(dhdl, size, flags, grp);
+    auto boh = alloc(get_xcl_device_handle(dhdl), size, flags, grp);
     bo_cache[boh.get()] = boh;
     return boh.get();
   }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -85,6 +85,24 @@ send_exception_message(const char* msg)
 
 } // unnamed namespace
 
+namespace xrt_core { namespace device_int {
+
+std::shared_ptr<xrt_core::device>
+get_core_device(xrtDeviceHandle dhdl)
+{
+  return get_device(dhdl); // handle check
+}
+
+xclDeviceHandle
+get_xcl_device_handle(xrtDeviceHandle dhdl)
+{
+  auto device = get_device(dhdl); // handle check
+  return device->get_device_handle();  // shim handle
+}
+
+}} // device_int, xrt_core
+
+
 namespace xrt {
 
 ////////////////////////////////////////////////////////////////
@@ -254,5 +272,23 @@ xrtDeviceGetXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
     send_exception_message(ex.what());
     errno = 0;
   }
-
 }
+
+xclDeviceHandle
+xrtDeviceToXclDevice(xrtDeviceHandle dhdl)
+{
+  try {
+    auto device = get_device(dhdl);
+    return device->get_device_handle();
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    errno = 0;
+  }
+  return nullptr;
+}
+

--- a/src/runtime_src/core/include/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/experimental/xrt_aie.h
@@ -36,7 +36,7 @@ typedef void *xrtGraphHandle;
  * to calling this function.
  */
 xrtGraphHandle
-xrtGraphOpen(xclDeviceHandle handle, const uuid_t xclbinUUID, const char *graphName);
+xrtGraphOpen(xrtDeviceHandle handle, const uuid_t xclbinUUID, const char *graphName);
 
 /**
  * xrtGraphClose() - Close an open graph.
@@ -195,7 +195,7 @@ xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_
  * Note: Upon return, the synchronization is done or error out
  */
 int
-xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 /**
  * xrtResetAIEArray() - Reset the AIE array
@@ -204,7 +204,6 @@ xrtSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
  *
  * Return:          0 on success, -1 on error.
  */
-
 int
-xrtResetAIEArray(xclDeviceHandle handle);
+xrtResetAIEArray(xrtDeviceHandle handle);
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_bo.h
+++ b/src/runtime_src/core/include/experimental/xrt_bo.h
@@ -26,10 +26,8 @@
 
 /**
  * typedef xrtDeviceHandle - opaque device handle
- *
- * Typedef alias from xrt.h
  */
-typedef xclDeviceHandle xrtDeviceHandle;
+typedef void* xrtDeviceHandle;
 
 /**
  * typedef xrtBufferHandle - opaque buffer handle
@@ -249,7 +247,7 @@ extern "C" {
  */
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
-xrtBOAllocUserPtr(xclDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp);
+xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp);
 
 /**
  * xrtBOAlloc() - Allocate a BO of requested size with appropriate flags
@@ -262,7 +260,7 @@ xrtBOAllocUserPtr(xclDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
  */
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
-xrtBOAlloc(xclDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp);
+xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp);
 
 /**
  * xrtBOImport() - Allocate a BO imported from another device
@@ -275,7 +273,7 @@ xrtBOAlloc(xclDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGro
  */  
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
-xrtBOImport(xclDeviceHandle dhdl, xclBufferExportHandle ehdl);
+xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl);
 
 /**
  * xrtBOExport() - Export this buffer
@@ -344,8 +342,8 @@ xrtBOSync(xrtBufferHandle handle, enum xclBOSyncDirection dir, size_t size, size
  * @handle:     Buffer handle
  * Return:      Memory mapped buffer, or NULL on error with errno set
  *
- * Map the contents of the buffer object into host memory
- * To unmap the buffer call xclUnmapBO().
+ * Map the contents of the buffer object into host memory.  The buffer
+ * object is unmapped when freed.
  */
 XCL_DRIVER_DLLESPEC
 void*

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -158,6 +158,12 @@ public:
   XCL_DRIVER_DLLESPEC
   operator xclDeviceHandle () const;
 
+  std::shared_ptr<xrt_core::device>
+  get_handle() const
+  {
+    return handle;
+  }
+
 private:
   XCL_DRIVER_DLLESPEC
   std::pair<const char*, size_t>
@@ -245,6 +251,13 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl);
 XCL_DRIVER_DLLESPEC
 void
 xrtDeviceGetXclbinUUID(xrtDeviceHandle dhld, xuid_t out);
+
+/**
+ * xrtDeviceToXclDevice() - Undocumented access to shim handle
+ */
+XCL_DRIVER_DLLESPEC
+xclDeviceHandle
+xrtDeviceToXclDevice(xrtDeviceHandle dhdl);
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -22,6 +22,7 @@
 #include "ert.h"
 #include "experimental/xrt_uuid.h"
 #include "experimental/xrt_bo.h"
+#include "experimental/xrt_device.h"
 
 #ifdef __cplusplus
 # include "experimental/xrt_enqueue.h"
@@ -302,7 +303,7 @@ public:
   /**
    * kernel() - Constructor from a device and xclbin
    *
-   * @dhdl:  Device handle on which the kernel should execute
+   * @device: Device on which the kernel should execute
    * @xclbin_id: UUID of the xclbin with the kernel
    * @name:  Name of kernel to construct
    * @exclusive: Open the kernel instances with exclusive access (default shared)
@@ -315,6 +316,12 @@ public:
    * other kernels and other process will have shared access to same
    * compute units.  If exclusive access is needed then set @exclusive
    * argument to true.
+   */
+  XCL_DRIVER_DLLESPEC
+  kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, bool exclusive=false);
+
+  /**
+   * Obsoleted construction from xclDeviceHandle
    */
   XCL_DRIVER_DLLESPEC
   kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name, bool exclusive=false);
@@ -426,7 +433,7 @@ extern "C" {
  */
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
-xrtPLKernelOpen(xclDeviceHandle deviceHandle, const xuid_t xclbinId, const char *name);
+xrtPLKernelOpen(xrtDeviceHandle deviceHandle, const xuid_t xclbinId, const char *name);
 
 /**
  * xrtPLKernelOpenExclusive() - Open a PL kernel and obtain its handle.
@@ -437,7 +444,7 @@ xrtPLKernelOpen(xclDeviceHandle deviceHandle, const xuid_t xclbinId, const char 
  */
 XCL_DRIVER_DLLESPEC
 xrtKernelHandle
-xrtPLKernelOpenExclusive(xclDeviceHandle deviceHandle, const xuid_t xclbinId, const char *name);
+xrtPLKernelOpenExclusive(xrtDeviceHandle deviceHandle, const xuid_t xclbinId, const char *name);
 
 /**
  * xrtKernelClose() - Close an opened kernel

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -210,7 +210,7 @@ xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinGetUUID(xclDeviceHandle handle, xuid_t ret_uuid);
+xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid);
 
 /**
  * xrtXclbinGetData() - Get the raw data of the xclbin handle
@@ -239,6 +239,7 @@ xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size);
 XCL_DRIVER_DLLESPEC
 int
 xrtXclbinUUID(xclDeviceHandle handle, xuid_t out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -36,16 +36,16 @@ def runKernel(opt):
     name = list(filter(lambda val: rule.match, opt.kernels))[0]
     khandle = xrtPLKernelOpen(opt.handle, opt.xuuid, name)
 
-    boHandle1 = xclAllocBO(opt.handle, opt.DATA_SIZE, 0, opt.first_mem)
-    bo1 = xclMapBO(opt.handle, boHandle1, True)
+    boHandle1 = xclAllocBO(opt.xcl_handle, opt.DATA_SIZE, 0, opt.first_mem)
+    bo1 = xclMapBO(opt.xcl_handle, boHandle1, True)
     ctypes.memset(bo1, 0, opt.DATA_SIZE)
 
-    boHandle2 = xclAllocBO(opt.handle, opt.DATA_SIZE, 0, opt.first_mem)
-    bo2 = xclMapBO(opt.handle, boHandle2, True)
+    boHandle2 = xclAllocBO(opt.xcl_handle, opt.DATA_SIZE, 0, opt.first_mem)
+    bo2 = xclMapBO(opt.xcl_handle, boHandle2, True)
     ctypes.memset(bo2, 0, opt.DATA_SIZE)
 
-    xclSyncBO(opt.handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, opt.DATA_SIZE, 0)
-    xclSyncBO(opt.handle, boHandle2, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, opt.DATA_SIZE, 0)
+    xclSyncBO(opt.xcl_handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, opt.DATA_SIZE, 0)
+    xclSyncBO(opt.xcl_handle, boHandle2, xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, opt.DATA_SIZE, 0)
 
     print("Original string = [%s]" % bo1[:64].decode("utf-8"))
     print("Original string = [%s]" % bo2[:64].decode("utf-8"))
@@ -60,8 +60,8 @@ def runKernel(opt):
     xrtRunWait(rhandle2)
 
     print("Get the output data produced by the 2 kernel runs from the device")
-    xclSyncBO(opt.handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, opt.DATA_SIZE, 0)
-    xclSyncBO(opt.handle, boHandle2, xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, opt.DATA_SIZE, 0)
+    xclSyncBO(opt.xcl_handle, boHandle1, xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, opt.DATA_SIZE, 0)
+    xclSyncBO(opt.xcl_handle, boHandle2, xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, opt.DATA_SIZE, 0)
     result1 = bo1[:len("Hello World")]
     result2 = bo2[:len("Hello World")]
     print("Result string = [%s]" % result1.decode("utf-8"))
@@ -72,10 +72,10 @@ def runKernel(opt):
     xrtRunClose(rhandle2)
     xrtRunClose(rhandle1)
     xrtKernelClose(khandle)
-    xclUnmapBO(opt.handle, boHandle2, bo2)
-    xclFreeBO(opt.handle, boHandle2)
-    xclUnmapBO(opt.handle, boHandle1, bo1)
-    xclFreeBO(opt.handle, boHandle1)
+    xclUnmapBO(opt.xcl_handle, boHandle2, bo2)
+    xclFreeBO(opt.xcl_handle, boHandle2)
+    xclUnmapBO(opt.xcl_handle, boHandle1, bo1)
+    xclFreeBO(opt.xcl_handle, boHandle1)
 
 def main(args):
     opt = Options()
@@ -101,7 +101,7 @@ def main(args):
         print("FAILED TEST")
         sys.exit(1)
     finally:
-        xclClose(opt.handle)
+        xrtDeviceClose(opt.handle)
 
 if __name__ == "__main__":
     os.environ["Runtime.xrt_bo"] = "false"

--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -85,7 +85,7 @@ def runKernel(opt):
     input_bo2, input_buf2 = getInputOutputBuffer(opt.handle, khandle2, 1, True)
 
     typesize = 512
-    threshold = getThreshold(opt.handle)
+    threshold = getThreshold(opt.xcl_handle)
     globalbuffersizeinbeats = globalbuffersize/(typesize>>3)
     tests= int(math.log(globalbuffersizeinbeats, 2.0))+1
     beats = 16
@@ -185,7 +185,7 @@ def main(args):
         print("FAILED TEST")
         sys.exit(1)
     finally:
-        xclClose(opt.handle)
+        xrtDeviceClose(opt.handle)
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/tests/python/utils_binding.py
+++ b/tests/python/utils_binding.py
@@ -37,6 +37,7 @@ class Options(object):
         self.cu_index = 0
         self.verbose = False
         self.handle = None
+        self.xcl_handle = None
         self.first_mem = -1
         self.cu_base_addr = -1
         self.xuuid = uuid.uuid4()
@@ -93,9 +94,10 @@ def initXRT(opt):
     if opt.index >= xclProbe():
         raise RuntimeError("Incorrect device index")
 
-    opt.handle = xclOpen(opt.index, None, xclVerbosityLevel.XCL_INFO)
+    opt.handle = xrtDeviceOpen(opt.index)
+    opt.xcl_handle = xrtDeviceToXclDevice(opt.handle)
 
-    xclGetDeviceInfo2(opt.handle, ctypes.byref(deviceInfo))
+    xclGetDeviceInfo2(opt.xcl_handle, ctypes.byref(deviceInfo))
 
     if sys.version_info[0] == 3:
         print("Shell = %s" % deviceInfo.mName)
@@ -125,7 +127,7 @@ def initXRT(opt):
         if xbinary.m_magic.decode("utf-8") != "xclbin2":
             raise RuntimeError("Invalid Bitsream")
 
-        xclLoadXclBin(opt.handle, blob)
+        xclLoadXclBin(opt.xcl_handle, blob)
         print("Finished downloading bitstream %s" % opt.bitstreamFile)
 
         myuuid = memoryview(xbinary.m_header.u2.uuid)[:]


### PR DESCRIPTION
This is a breaking change.

All XRT Native C-APIs are moved from shim level device handle to
native API device handle.  End user host C code must use
xrtDeviceHandle obtained by calling xrtDeviceOpen.  Host code can no
longer use xclOpen/xclClose with the native APis such as kernel and
bo.