### PR TITLE
Add support for Arista LB2 QDMA shell

### DIFF
--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -58,6 +58,7 @@ namespace xcldev {
         std::vector<buffer_and_deleter> mBOList;
         xclDeviceHandle mHandle;
         size_t mSize;
+        size_t mTotalSize;
         unsigned mFlags;
         char mPattern;
 
@@ -112,12 +113,17 @@ namespace xcldev {
         }
 
     public:
-        DMARunner(xclDeviceHandle handle , size_t size, unsigned flags=0) : mHandle(handle), mSize(size),
-                                                                            mFlags(flags), mPattern('x') {
-            long long count = 0x100000000/size;
+        DMARunner(xclDeviceHandle handle, size_t size, unsigned flags = 0, size_t totalSize = 0) :
+                mHandle(handle),
+                mSize(size),
+                mTotalSize(totalSize ? totalSize : 0x100000000),
+                mFlags(flags),
+                mPattern('x') {
+            long long count = mTotalSize / mSize;
 
             if (count == 0)
-                throw xrt_core::error(-EINVAL, "DMA buffer size cannot be larger than 0x100000000.");
+                throw xrt_core::error(-EINVAL,
+                    boost::str(boost::format("DMA buffer size cannot be larger than %#x.") % mTotalSize));
 
             if (count > 0x40000)
                 count = 0x40000;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3161,6 +3161,77 @@ struct xocl_subdev_map {
 		.flash_type = FLASH_TYPE_QSPIPS_X4_SINGLE,		\
 	}
 
+#define XOCL_PRIV_XMC_ARISTA_LB2_QDMA \
+    ((struct xocl_xmc_privdata) {     \
+        .flags = XOCL_XMC_NOSC,       \
+    })
+
+#define XOCL_DEVINFO_XMC_ARISTA_LB2_QDMA              \
+    {                                                 \
+        XOCL_SUBDEV_MB,                               \
+        XOCL_XMC,                                     \
+        XOCL_RES_XMC,                                 \
+        ARRAY_SIZE(XOCL_RES_XMC),                     \
+        .override_idx = -1,                           \
+        .priv_data = &XOCL_PRIV_XMC_ARISTA_LB2_QDMA,  \
+        .data_len = sizeof(struct xocl_xmc_privdata), \
+    }
+
+#define XOCL_DEVINFO_XMC_USER_ARISTA_LB2_QDMA         \
+    {                                                 \
+        XOCL_SUBDEV_MB,                               \
+        XOCL_XMC,                                     \
+        NULL,                                         \
+        0,                                            \
+        .override_idx = -1,                           \
+        .priv_data = &XOCL_PRIV_XMC_ARISTA_LB2_QDMA,  \
+        .data_len = sizeof(struct xocl_xmc_privdata), \
+    }
+
+#define MGMT_RES_ARISTA_LB2_QDMA          \
+    ((struct xocl_subdev_info[]) {        \
+        XOCL_DEVINFO_FEATURE_ROM,         \
+        XOCL_DEVINFO_PRP_IORES_MGMT,      \
+        XOCL_DEVINFO_AXIGATE_ULP,         \
+        XOCL_DEVINFO_CLOCK_LEGACY,        \
+        XOCL_DEVINFO_AF_DSA52,            \
+        XOCL_DEVINFO_XMC_ARISTA_LB2_QDMA, \
+        XOCL_DEVINFO_XVC_PRI,             \
+        XOCL_DEVINFO_NIFD_PRI,            \
+        XOCL_DEVINFO_MAILBOX_MGMT_QDMA,   \
+        XOCL_DEVINFO_ICAP_MGMT,           \
+        XOCL_DEVINFO_FMGR,                \
+        XOCL_DEVINFO_FLASH,               \
+    })
+
+#define USER_RES_ARISTA_LB2_QDMA               \
+    ((struct xocl_subdev_info[]) {             \
+        XOCL_DEVINFO_FEATURE_ROM,              \
+        XOCL_DEVINFO_QDMA,                     \
+        XOCL_DEVINFO_SCHEDULER_QDMA,           \
+        XOCL_DEVINFO_XVC_PUB,                  \
+        XOCL_DEVINFO_MAILBOX_USER_QDMA,        \
+        XOCL_DEVINFO_ICAP_USER,                \
+        XOCL_DEVINFO_XMC_USER_ARISTA_LB2_QDMA, \
+        XOCL_DEVINFO_AF_USER,                  \
+        XOCL_DEVINFO_INTC_QDMA,                \
+    })
+
+#define XOCL_BOARD_MGMT_ARISTA_LB2_QDMA                     \
+    (struct xocl_board_private) {                           \
+        .flags = XOCL_DSAFLAG_FIXED_INTR,                   \
+        .subdev_info = MGMT_RES_ARISTA_LB2_QDMA,            \
+        .subdev_num = ARRAY_SIZE(MGMT_RES_ARISTA_LB2_QDMA), \
+        .flash_type = FLASH_TYPE_SPI,                       \
+    }
+
+#define XOCL_BOARD_USER_ARISTA_LB2_QDMA                     \
+    (struct xocl_board_private) {                           \
+        .flags = 0,                                         \
+        .subdev_info = USER_RES_ARISTA_LB2_QDMA,            \
+        .subdev_num = ARRAY_SIZE(USER_RES_ARISTA_LB2_QDMA), \
+    }
+
 #define	XOCL_MGMT_PCI_IDS						\
 	{ XOCL_PCI_DEVID(0x10EE, 0x4A47, PCI_ANY_ID, MGMT_DEFAULT) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x4A87, PCI_ANY_ID, MGMT_DEFAULT) },	\
@@ -3222,7 +3293,8 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0xD03C, PCI_ANY_ID, XBB_MFG_U30) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0xD04C, PCI_ANY_ID, XBB_MFG_U25) }, \
 	{ XOCL_PCI_DEVID(0x10EE, 0xEB10, PCI_ANY_ID, XBB_MFG("twitch")) }, \
-	{ XOCL_PCI_DEVID(0x13FE, 0x806C, PCI_ANY_ID, XBB_MFG("advantech")) }
+	{ XOCL_PCI_DEVID(0x13FE, 0x806C, PCI_ANY_ID, XBB_MFG("advantech")) }, \
+	{ XOCL_PCI_DEVID(0x3475, 0x5010, PCI_ANY_ID, MGMT_ARISTA_LB2_QDMA) }
 
 #define	XOCL_USER_XDMA_PCI_IDS						\
 	{ XOCL_PCI_DEVID(0x10EE, 0x4A48, PCI_ANY_ID, USER_XDMA) },	\
@@ -3276,7 +3348,8 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5031, PCI_ANY_ID, USER_SMARTN) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5029, PCI_ANY_ID, USER_XDMA_VERSAL) },\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5045, PCI_ANY_ID, USER_XDMA_VERSAL) },\
-	{ XOCL_PCI_DEVID(0x10EE, 0x5049, PCI_ANY_ID, VERSAL_USER_RAPTOR2) }
+	{ XOCL_PCI_DEVID(0x10EE, 0x5049, PCI_ANY_ID, VERSAL_USER_RAPTOR2) }, \
+	{ XOCL_PCI_DEVID(0x3475, 0x5011, PCI_ANY_ID, USER_ARISTA_LB2_QDMA) }
 
 #define XOCL_DSA_VBNV_MAP						\
 	{ 0x10EE, 0x5001, PCI_ANY_ID,					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -378,6 +378,19 @@ static bool is_valid_firmware(struct platform_device *pdev,
 	return true;
 }
 
+static int get_vendor_firmware_dir(u16 vendor, char *buf, size_t len) {
+	int ret = 0;
+	switch (vendor) {
+		case XOCL_ARISTA_VEN:
+			ret = strscpy(buf, "arista", len);
+			break;
+		default:
+			ret = strscpy(buf, "xilinx", len);
+			break;
+	}
+	return ret;
+}
+
 static int load_firmware_from_flash(struct platform_device *pdev,
 	char **fw_buf, size_t *fw_len)
 {
@@ -463,6 +476,7 @@ static int load_firmware_from_disk(struct platform_device *pdev, char **fw_buf,
 	int err = 0;
 	char fw_name[256];
 	const struct firmware *fw;
+	char vendor_fw_dir[16];
 
 	if (funcid != 0) {
 		pcidev_user = pci_get_slot(pcidev->bus,
@@ -475,22 +489,27 @@ static int load_firmware_from_disk(struct platform_device *pdev, char **fw_buf,
 			deviceid = le16_to_cpu(pcidev_user->device);
 	}
 
+	err = get_vendor_firmware_dir(vendor, vendor_fw_dir, sizeof(vendor_fw_dir));
+    // Failure returns -E2BIG
+	if (err < 0)
+		return err;
+
 	/* For 2RP, only uuid is provided */
 	if (is_multi_rp(rom)) {
 		snprintf(fw_name, sizeof(fw_name),
-			"xilinx/%s/partition.%s", rom->uuid, suffix);
+			"%s/%s/partition.%s", vendor_fw_dir, rom->uuid, suffix);
 	} else {
 		snprintf(fw_name, sizeof(fw_name),
-			"xilinx/%04x-%04x-%04x-%016llx.%s",
-			vendor, deviceid, subdevice, timestamp, suffix);
+			"%s/%04x-%04x-%04x-%016llx.%s",
+			vendor_fw_dir, vendor, deviceid, subdevice, timestamp, suffix);
 	}
 
 	xocl_info(&pdev->dev, "try loading fw: %s", fw_name);
 	err = request_firmware(&fw, fw_name, &pcidev->dev);
 	if (err && !is_multi_rp(rom)) {
 		snprintf(fw_name, sizeof(fw_name),
-			"xilinx/%04x-%04x-%04x-%016llx.%s",
-			vendor, (deviceid + 1), subdevice, timestamp, suffix);
+			"%s/%04x-%04x-%04x-%016llx.%s",
+			vendor_fw_dir, vendor, (deviceid + 1), subdevice, timestamp, suffix);
 		xocl_info(&pdev->dev, "try loading fw: %s", fw_name);
 		err = request_firmware(&fw, fw_name, &pcidev->dev);
 	}
@@ -506,7 +525,7 @@ static int load_firmware_from_disk(struct platform_device *pdev, char **fw_buf,
 	}
 
 	release_firmware(fw);
-	return 0;
+	return err;
 }
 
 static int load_firmware(struct platform_device *pdev, char **fw, size_t *len)
@@ -559,7 +578,7 @@ static int get_header_from_peer(struct feature_rom *rom)
 	struct resource res;
 	xdev_handle_t xdev = xocl_get_xdev(rom->pdev);
 	int ret;
-	
+
 	header = XOCL_GET_SUBDEV_PRIV(&rom->pdev->dev);
 	if (!header)
 		return -ENODEV;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -257,7 +257,9 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 
 #define XOCL_ARE_HOP 0x400000000ull
 
-#define	XOCL_XILINX_VEN		0x10EE
+#define XOCL_XILINX_VEN 0x10EE
+#define XOCL_ARISTA_VEN 0x3475
+
 #define	XOCL_CHARDEV_REG_COUNT	16
 
 #define INVALID_SUBDEVICE ~0U

--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -37,11 +37,6 @@
 #include "scan.h"
 #include "core/common/utils.h"
 
-// Supported vendors
-#define XILINX_ID       0x10ee
-#define ADVANTECH_ID    0x13fe
-#define AWS_ID          0x1d0f
-
 #define RENDER_NM       "renderD"
 #define DEV_TIMEOUT	90 // seconds
 
@@ -110,7 +105,7 @@ get_devfs_path(bool is_mgmt, uint32_t instance)
 
 static bool
 is_admin()
-{     
+{
   return (getuid() == 0) || (geteuid() == 0);
 }
 
@@ -449,7 +444,7 @@ sysfs_put(const std::string& subdev, const std::string& entry,
 {
   sysfs::put(sysfs_name, subdev, entry, err, buf);
 }
-  
+
 std::string
 pci_device::
 get_sysfs_path(const std::string& subdev, const std::string& entry)
@@ -519,7 +514,10 @@ pci_device(const std::string& sysfs)
     std::cout << err << std::endl;
     return;
   }
-  if((vendor != XILINX_ID) && (vendor != ADVANTECH_ID) && (vendor != AWS_ID))
+  if ((vendor != XILINX_ID)
+      && (vendor != ADVANTECH_ID)
+      && (vendor != AWS_ID)
+      && (vendor != ARISTA_ID))
     return;
 
   // Determine if the device is mgmt or user pf.
@@ -710,7 +708,7 @@ get_partinfo(std::vector<std::string>& info, void *blob)
     s = p_strings + be32toh(GET_CELL(p));
     if (version < 16 && sz >= 8)
       p = PALIGN(p, 8);
-    
+
     if (strcmp(s, "__INFO")) {
       p = PALIGN(p + sz, 4);
       continue;
@@ -803,7 +801,7 @@ private:
 
     user_list.clear();
     mgmt_list.clear();
-  
+
     if(!bfs::exists(sysfs::root)) {
       std::cout << "File does not exist : " << sysfs::root << std::endl;
       return;
@@ -1055,10 +1053,10 @@ shutdown(std::shared_ptr<pci_device> mgmt_dev, bool remove_user, bool remove_mgm
     int curr_act_dev;
     bfs::ifstream file(parent_path);
     file >> curr_act_dev;
-      
+
     if (curr_act_dev + rem_dev_cnt == active_dev_num)
       return 0;
-     
+
     sleep(1);
   }
 

--- a/src/runtime_src/core/pcie/linux/scan.h
+++ b/src/runtime_src/core/pcie/linux/scan.h
@@ -27,6 +27,12 @@
 #include <fcntl.h>
 #include <mutex>
 
+// Supported vendors
+#define XILINX_ID    0x10ee
+#define ADVANTECH_ID 0x13fe
+#define AWS_ID       0x1d0f
+#define ARISTA_ID    0x3475
+
 #define INVALID_ID      0xffff
 #define MFG_REV_OFFSET  0x131008 // For obtaining Golden image version number
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -42,14 +42,13 @@
 #endif
 
 #define DEFAULT_GLOBAL_AFI "agfi-069ddd533a748059b" // 1.4 shell
-#define XILINX_ID 0x1d0f
 #define AWS_UserPF_DEVICE_ID 0x1042     //userPF device on AWS F1 & Pegasus
 #define AWS_MgmtPF_DEVICE_ID 0x1040     //mgmtPF device on Pegasus (mgmtPF not visible on AWS)
 #define AWS_UserPF_DEVICE_ID_SDx 0xf010 //userPF device on AWS F1 after downloading xclbin into FPGA (SHELL 1.4)
 
 /*
  * This class is used to handle ioctl access to mgmt PF of AWS specific FPGA.
- * 
+ *
  * Since AWS has its own FPGA mgmt hardware/driver, any mgmt HW access request from xocl driver
  * will be forwarded by sw mailbox and be intercepted and interpreted by this mpd plugin. And
  * with the plugin, those special requests will be translated to API calls into the libmgmt.so

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -230,7 +230,7 @@ static int updateShell(unsigned index, std::string flashType,
         if (sec->fail())
             sec = nullptr;
     }
- 
+
     return flasher.upgradeFirmware(flashType, pri.get(), sec.get(),
         stripped.get());
 }
@@ -291,6 +291,9 @@ static int updateShellAndSC(unsigned boardIdx, DSAInfo& candidate, bool& reboot)
     bool same_bmc = false;
     DSAInfo current = flasher.getOnBoardDSA();
     isSameShellOrSC(candidate, current, &same_dsa, &same_bmc);
+
+    // Always update Arista devices.
+    same_dsa = same_dsa && (candidate.vendor_id != ARISTA_ID);
 
     if (same_dsa && same_bmc)
         std::cout << "update not needed" << std::endl;
@@ -375,7 +378,10 @@ static DSAInfo selectShell(unsigned idx, std::string& dsa, std::string& id, bool
     bool same_bmc = false;
     DSAInfo currentDSA = flasher.getOnBoardDSA();
     isSameShellOrSC(candidate, currentDSA, &same_dsa, &same_bmc);
- 
+
+    // Always update Arista devices.
+    same_dsa = same_dsa && (candidate.vendor_id != ARISTA_ID);
+
     if (same_dsa && same_bmc) {
         std::cout << "\t Status: shell is up-to-date" << std::endl;
         return DSAInfo("");
@@ -481,9 +487,9 @@ static int autoFlash(unsigned index, std::string& shell,
     }
 
     if (success != 0) {
-        std::cout << success << " Card(s) flashed successfully." << std::endl; 
+        std::cout << success << " Card(s) flashed successfully." << std::endl;
     } else {
-        std::cout << "No cards were flashed." << std::endl; 
+        std::cout << "No cards were flashed." << std::endl;
     }
 
     if (needreboot) {
@@ -740,9 +746,9 @@ static int shell(int argc, char *argv[])
         std::cout << "--card switch is not provided." << std::endl;
         return -EINVAL;
     }
-    
+
     const char* secondary = secondary_file.empty() ? nullptr : secondary_file.c_str() ;
-    
+
     int ret = updateShell(index, type, primary_file.c_str(), secondary);
     if (ret)
         return ret;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -252,7 +252,7 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id
             [](const char &a){ return a == ':' || a == '.'; }, '_');
         getVendorBoardFromDSAName(name, vendor, board);
         parseDSAFilename(filename, vendor_id, device_id, subsystem_id, timestamp);
-        
+
         // Assume there is only 1 interface UUID is provided for BLP,
         // Show it as ID for flashing
         const axlf_section_header* dtbSection = xclbin::get_axlf_section(ap, PARTITION_METADATA);
@@ -374,32 +374,34 @@ std::vector<DSAInfo>& firmwareImage::getIntalledDSAs()
     if (!installedDSA.empty())
         return installedDSA;
 
+    std::vector<std::string> fw_dirs = FIRMWARE_DIRS;
     struct dirent *entry;
     DIR *dp;
     std::string nm;
 
     // Obtain installed DSA info.
-    dp = opendir(FIRMWARE_DIR);
-    if (dp)
-    {
-        while ((entry = readdir(dp)))
+    for (std::string d : fw_dirs) {
+        dp = opendir(d.c_str());
+        if (dp)
         {
-            std::string d(FIRMWARE_DIR);
-            std::string e(entry->d_name);
+            while ((entry = readdir(dp)))
+            {
+                std::string e(entry->d_name);
 
-            /*
-             * First look for from .xsabin, if failed,
-             * look for .dsabin file.
-             * legacy .mcs file is not supported.
-             */
-            if ((e.find(XSABIN_FILE_SUFFIX) == std::string::npos) &&
-                (e.find(DSABIN_FILE_SUFFIX) == std::string::npos))
-                continue;
+                /*
+                * First look for from .xsabin, if failed,
+                * look for .dsabin file.
+                * legacy .mcs file is not supported.
+                */
+                if ((e.find(XSABIN_FILE_SUFFIX) == std::string::npos) &&
+                    (e.find(DSABIN_FILE_SUFFIX) == std::string::npos))
+                    continue;
 
-            DSAInfo dsa(d + e);
-            installedDSA.push_back(dsa);
+                DSAInfo dsa(d + e);
+                installedDSA.push_back(dsa);
+            }
+            closedir(dp);
         }
-        closedir(dp);
     }
 
     dp = opendir(FORMATTED_FW_DIR);
@@ -469,7 +471,7 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
 
 /**
  * Helper method to find a set of bytes in a given buffer.
- * 
+ *
  * @param pBuffer The buffer to be examined.
  * @param _bufferSize
  *                The size of the buffer.
@@ -477,12 +479,12 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
  *                The string to search for.
  * @param _foundOffset
  *                The offset where the string was found.
- * 
+ *
  * @return true  - The string was found;
  *         false - the string was not found
  */
 static bool findBytesInBuffer(const char * pBuffer, uint64_t _bufferSize,
-                  const std::string& _searchString, 
+                  const std::string& _searchString,
                   unsigned int& _foundOffset) {
 
   // Initialize return values
@@ -516,11 +518,11 @@ static void remove_xsabin_mirror(void * pXsaBinBuffer)
   uint64_t bufferSize = axlf_header->m_header.m_length;
 
   unsigned int startOffset;
-  if (findBytesInBuffer((const char *) pXsaBinBuffer, bufferSize, MIRROR_DATA_START, startOffset) == false) 
+  if (findBytesInBuffer((const char *) pXsaBinBuffer, bufferSize, MIRROR_DATA_START, startOffset) == false)
     return;   // No MIRROR DATA
 
   unsigned int endOffset;
-  if (findBytesInBuffer((const char *) pXsaBinBuffer, bufferSize, MIRROR_DATA_END, endOffset) == false) 
+  if (findBytesInBuffer((const char *) pXsaBinBuffer, bufferSize, MIRROR_DATA_END, endOffset) == false)
     return;   // Badly formed mirror data (we have a start, but no end)
   endOffset += MIRROR_DATA_END.length();
 
@@ -533,7 +535,7 @@ static void remove_xsabin_mirror(void * pXsaBinBuffer)
 
   // Compress the image
   uint64_t bytesToCopy = bufferSize - endOffset;
-  if (bytesToCopy != 0) 
+  if (bytesToCopy != 0)
     std::memcpy((unsigned char *) pXsaBinBuffer + startOffset, (unsigned char *) pXsaBinBuffer + endOffset, bytesToCopy);
 
   // Update length of the buffer
@@ -548,7 +550,7 @@ static void remove_xsabin_section(void * pXsaBinBuffer, enum axlf_section_kind s
 
   axlf *axlf_header = (struct axlf *) pXsaBinBuffer;
 
-  // This loop does need to re-evaluate the m_numSections for it will be 
+  // This loop does need to re-evaluate the m_numSections for it will be
   // reduced as sections are removed.  In addition, we need to start again from
   // the start for there could be multiple sections of the same type that
   // need to be removed.
@@ -738,7 +740,7 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
                 mBuf = new char[bufsize];
                 in.seekg(flashSection->m_sectionOffset + flashMeta.m_image_offset);
                 in.read(mBuf, bufsize);
-            } 
+            }
             else if (pdiSection) {
                 if (type != MCS_FIRMWARE_PRIMARY)
                 {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -29,7 +29,7 @@
 #include <vector>
 
 // directory where all MCS files are saved
-#define FIRMWARE_DIR        "/lib/firmware/xilinx/"
+#define FIRMWARE_DIRS       {"/lib/firmware/xilinx/", "/lib/firmware/arista/"}
 #define FORMATTED_FW_DIR    "/opt/xilinx/firmware"
 #define DSA_FILE_SUFFIX     "mcs"
 #define DSABIN_FILE_SUFFIX  "dsabin"

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -266,7 +266,10 @@ int XMC_Flasher::xclGetBoardInfo(std::map<char, std::vector<char>>& info)
 {
     int ret = 0;
 
-    if (!hasSC() || !isXMCReady() || !isBMCReady())
+    if (!hasSC())
+        return -EOPNOTSUPP;
+
+    if (!isXMCReady() || !isBMCReady())
         return -EINVAL;
 
     mPkt = {0};

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.cpp
@@ -305,7 +305,7 @@ XSPI_Flasher::XSPI_Flasher(std::shared_ptr<pcidev::pci_device> dev)
 static bool isDualQSPI(pcidev::pci_device *dev) {
     std::string err;
     uint16_t deviceID;
-    dev->sysfs_get<uint16_t>("", "device", err, deviceID, 0xffff); 
+    dev->sysfs_get<uint16_t>("", "device", err, deviceID, 0xffff);
 
     if (!err.empty()) {
         std::cout << "Exiting now, as could not find device ID" << std::endl;
@@ -528,8 +528,8 @@ int XSPI_Flasher::xclUpgradeFirmware1(std::istream& mcsStream1,
 
     if (mFlashDev)
         return upgradeFirmware1Drv(mcsStream1, stripped);
-    
-    //Parse MCS file for first flash device 
+
+    //Parse MCS file for first flash device
     status = parseMCS(mcsStream1);
     if(status)
         return status;
@@ -588,7 +588,7 @@ int XSPI_Flasher::xclUpgradeFirmware2(std::istream& mcsStream1,
     if (mFlashDev)
         return upgradeFirmware2Drv(mcsStream1, mcsStream2, stripped);
 
-    //Parse MCS file for first flash device 
+    //Parse MCS file for first flash device
     status = parseMCS(mcsStream1);
     if(status)
         return status;
@@ -617,7 +617,7 @@ int XSPI_Flasher::xclUpgradeFirmware2(std::istream& mcsStream1,
     if(status)
         return status;
 
-    //Parse MCS file for second flash device 
+    //Parse MCS file for second flash device
     status = parseMCS(mcsStream2);
     if(status)
         return status;
@@ -877,6 +877,36 @@ bool XSPI_Flasher::bulkErase()
         return false;
 
     return waitTxEmpty();
+}
+
+// Erases the entire flash
+bool XSPI_Flasher::fullErase() {
+    uint32_t numFlash = isDualQSPI(mDev.get()) ? 2 : 1;
+
+    for (uint32_t i = 0; i < numFlash; ++i) {
+        if (!prepareXSpi(i))
+            return false;
+
+        // Go through and erase every sector. Alternatively use bulk or die
+        // erase depending on whether the device is monolithic or stacked.
+        uint32_t beatCount = 0;
+        std::cout << "Erasing flash " << i << std::endl;
+        for (uint32_t i = 0; i < MAX_NUM_SECTORS << 24; i += 1 << 15) {
+            // Beat every 4MB
+            if (++beatCount % (1 << 7) == 0) {
+                std::cout << "." << std::flush;
+            }
+
+            if (!sectorErase(i, COMMAND_32KB_SUBSECTOR_ERASE)) {
+                std::cout << "\nERROR: Failed to erase subsector!" << std::endl;
+                return false;
+            }
+        }
+
+        std::cout << std::endl;
+    }
+
+    return true;
 }
 
 //Bitstream guard protects from partially programmed bitstreams
@@ -1932,9 +1962,27 @@ static int bitstreamGuardAddress(pcidev::pci_device *dev, uint32_t& addr)
 
 int XSPI_Flasher::revertToMFG(void)
 {
+    int ret;
+    std::string errmsg;
+    uint16_t vendor;
+
+    // Vendor-dependent behaviour
+    mDev->sysfs_get<uint16_t>("", "vendor", errmsg, vendor, -1);
+    if (!errmsg.empty()) {
+        std::cout << errmsg << std::endl;
+        return -EINVAL;
+    }
+
+    switch (vendor) {
+        case ARISTA_ID:
+            return fullErase() ? 0 : -EINVAL;
+        default:
+            break;
+    }
+
     uint32_t bitstream_start_loc;
 
-    int ret = bitstreamGuardAddress(mDev.get(), bitstream_start_loc);
+    ret = bitstreamGuardAddress(mDev.get(), bitstream_start_loc);
     if (ret)
         return ret;
 

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xspi.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xspi.h
@@ -65,6 +65,7 @@ private:
     bool writeBitstreamGuard(unsigned Addr);
     bool clearBitstreamGuard(unsigned Addr);
     bool bulkErase();
+    bool fullErase();
     bool writeEnable();
     bool getFlashId();
     bool finalTransfer(uint8_t *sendBufPtr, uint8_t *recvBufPtr, int byteCount);

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -99,7 +99,7 @@ check_os_release(const std::vector<std::string> kernel_versions, std::ostream &o
         if (release.find(ver) != std::string::npos)
             return true;
     }
-    ostr << "WARNING: Kernel verison " << release << " is not officially supported. " 
+    ostr << "WARNING: Kernel verison " << release << " is not officially supported. "
         << kernel_versions.back() << " is the latest supported version" << std::endl;
     return false;
 }
@@ -117,7 +117,7 @@ is_supported_kernel_version(std::ostream &ostr)
         return check_os_release(ubuntu_kernel_versions, ostr);
     else if(os.find("Red Hat") != std::string::npos || os.find("CentOS") != std::string::npos)
         return check_os_release(centos_rh_kernel_versions, ostr);
-    
+
     return true;
 }
 
@@ -963,8 +963,21 @@ int xcldev::xclTop(int argc, char *argv[])
 }
 
 const std::string dsaPath("/opt/xilinx/dsa/");
-const std::string xsaPath("/opt/xilinx/xsa/");
 const std::string xrtPath("/opt/xilinx/xrt/");
+
+inline std::string getXsaPath(const uint16_t &vendor)
+{
+    std::string vendorName;
+    switch (vendor) {
+        case ARISTA_ID:
+            vendorName = "arista";
+            break;
+        default:
+            vendorName = "xilinx";
+            break;
+    }
+    return vendor ? "/opt/" + vendorName + "/xsa/" : std::string();
+}
 
 void testCaseProgressReporter(bool *quit)
 {    int i = 0;
@@ -1159,8 +1172,15 @@ int xcldev::device::runTestCase(const std::string& py,
         return -EINVAL;
     }
 
+    uint16_t vendor;
+    pcidev::get_dev(m_idx)->sysfs_get<uint16_t>("", "vendor", errmsg, vendor, -1);
+    if (!errmsg.empty()) {
+        std::cout << errmsg << std::endl;
+        return -EINVAL;
+    }
+
     std::string devInfoPath = name + "/test/";
-    std::string xsaXclbinPath = xsaPath + devInfoPath;
+    std::string xsaXclbinPath = getXsaPath(vendor) + devInfoPath;
     std::string dsaXclbinPath = dsaPath + devInfoPath;
     std::string xrtTestCasePath = xrtPath + "test/" + py;
 
@@ -1224,7 +1244,7 @@ int xcldev::device::bandwidthKernelTest(void)
 
     std::string testcase = (vbnv.find("vck5000") != std::string::npos)
         ? "versal_23_bandwidth.py" : "23_bandwidth.py";
-    
+
     int ret = runTestCase(testcase, std::string("bandwidth.xclbin"), output);
 
     if (ret != 0) {
@@ -1258,11 +1278,11 @@ int xcldev::device::hostMemBandwidthKernelTest(void)
 
     if (!host_mem_size) {
         std::cout << "Host_mem is not available. Skipping validation" << std::endl;
-        return -EOPNOTSUPP;        
+        return -EOPNOTSUPP;
     }
 
     std::string testcase = "host_mem_23_bandwidth.py";
-    
+
     int ret = runTestCase(testcase, std::string("bandwidth.xclbin"), output);
 
     if (ret != 0) {
@@ -1307,7 +1327,7 @@ int xcldev::device::scVersionTest(void)
         if (sc_ver.empty())
             std::cout << "Can't determine SC firmware running on board.";
         else if (sc_ver.compare(exp_sc_ver) != 0)
-            std::cout << "SC firmware running on board: " << sc_ver; 
+            std::cout << "SC firmware running on board: " << sc_ver;
         std::cout << ". Expected SC firmware from installed Shell: " << exp_sc_ver << std::endl;
 
         std::cout << "Please use \"xbmgmt flash --scan\" to check installed Shell." << std::endl;
@@ -1424,7 +1444,7 @@ int xcldev::device::getXclbinuuid(uuid_t &uuid) {
     return 0;
 }
 
-int xcldev::device::kernelVersionTest(void) 
+int xcldev::device::kernelVersionTest(void)
 {
     if (getenv_or_null("INTERNAL_BUILD")) {
         std::cout << "Developer's build. Skipping validation" << std::endl;
@@ -1628,7 +1648,7 @@ int xcldev::device::reset(xclResetKind kind)
 #ifdef __GNUC__
 # pragma GCC diagnostic pop
 #endif
-    
+
 }
 
 bool canProceed()
@@ -2029,7 +2049,7 @@ int xcldev::xclCma(int argc, char *argv[])
             << std::endl;
     } else if (ret == -ENODEV) {
         std::cout << "ERROR: Does not support HOST MEM feature"
-            << std::endl; 
+            << std::endl;
     } else if (ret == -EBUSY) {
         std::cout << "ERROR: HOST MEM already enabled or in-use"
             << std::endl;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -308,7 +308,7 @@ public:
         uuid_t uuid;
         int ret, data_retention = 0;
         std::string errmsg;
-        
+
         pcidev::get_dev(m_idx)->sysfs_get("icap", "data_retention", errmsg, data_retention, 0);
         if (!errmsg.empty()) {
             std::cout << errmsg << std::endl;
@@ -519,7 +519,7 @@ public:
         dev->sysfs_get("icap", "group_topology", errmsg, buf);
         dev->sysfs_get("", "memstat_raw", errmsg, mm_buf);
         dev->sysfs_get("xmc", "temp_by_mem_topology", errmsg, temp_buf);
- 
+
         const mem_topology *map = (mem_topology *)buf.data();
         const uint32_t *temp = (uint32_t *)temp_buf.data();
         const int temp_size = (uint32_t)temp_buf.size()/sizeof(uint32_t);
@@ -767,9 +767,9 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get( "icap", "idcode",                 errmsg, idcode );
         pcidev::get_dev(m_idx)->sysfs_get( "dna", "dna",                     errmsg, dna );
         pcidev::get_dev(m_idx)->sysfs_get("", "local_cpulist",               errmsg, cpu_affinity);
-        pcidev::get_dev(m_idx)->sysfs_get<uint64_t>("address_translator", "host_mem_size",  
+        pcidev::get_dev(m_idx)->sysfs_get<uint64_t>("address_translator", "host_mem_size",
                                                                              errmsg, host_mem_size, 0);
-        pcidev::get_dev(m_idx)->sysfs_get<uint64_t>("icap", "max_host_mem_aperture",  
+        pcidev::get_dev(m_idx)->sysfs_get<uint64_t>("icap", "max_host_mem_aperture",
                                                                              errmsg, max_host_mem_aperture, 0);
 
         p2p_enabled = pcidev::check_p2p_config(pcidev::get_dev(m_idx), errmsg);
@@ -1558,6 +1558,22 @@ public:
         if (verbose)
             std::cout << "Reporting from mem_topology:" << std::endl;
 
+        uint16_t vendor;
+        dev->sysfs_get<uint16_t>("", "vendor", errmsg, vendor, -1);
+        if (!errmsg.empty()) {
+            std::cout << errmsg << std::endl;
+            return -EINVAL;
+        }
+
+        size_t totalSize = 0;
+        switch (vendor) {
+            case ARISTA_ID:
+                totalSize = 0x20000000;
+                break;
+            default:
+                break;
+        }
+
         for(int32_t i = 0; i < map->m_count; i++) {
             if(map->m_mem_data[i].m_type == MEM_STREAMING)
                 continue;
@@ -1581,7 +1597,7 @@ public:
                         return result;
                 }
                 try {
-                    DMARunner runner( m_handle, blockSize, i);
+                    DMARunner runner(m_handle, blockSize, i, totalSize);
                     result = runner.run();
                 } catch (const xrt_core::error &ex) {
                     std::cout << "ERROR: " << ex.what() << std::endl;


### PR DESCRIPTION
- Add Arista PCIe IDs
- Support for vendor-dependent firmware paths
- Reduce dmatest memory usage for Arista devices when running `xbutil validate`
- Different flash management in `xbmgmt` for Arista devices