### PR TITLE
fix m2m outputs in xbutil2

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -431,14 +431,14 @@ m2m_alloc_init_bo(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, 
 /* 
  * helper function for M2M test
  */ 
-static int 
+static double 
 m2mtest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, int bank_a, int bank_b, size_t bo_size)
 {
   xclBufferHandle bo_src = NULLBO;
   xclBufferHandle bo_tgt = NULLBO;
   char *bo_src_ptr = nullptr;
   char *bo_tgt_ptr = nullptr;
-  int bandwidth = 0;
+  double bandwidth = 0;
 
   //Allocate and init bo_src
   if(m2m_alloc_init_bo(handle, _ptTest, bo_src, bo_src_ptr, bo_size, bank_a, 'A'))
@@ -453,7 +453,7 @@ m2mtest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, int b
   XBU::Timer timer;
   if (xclCopyBO(handle, bo_tgt, bo_src, bo_size, 0, 0))
     return bandwidth;
-  double timer_stop = timer.stop().count();
+  double timer_duration_sec = timer.stop().count();
 
   if(xclSyncBO(handle, bo_tgt, XCL_BO_SYNC_BO_FROM_DEVICE, bo_size, 0)) {
     free_unmap_bo(handle, bo_src, bo_src_ptr, bo_size);
@@ -476,8 +476,8 @@ m2mtest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, int b
   }
 
   //bandwidth
-  size_t total = bo_size / (1024 * 1024); //convert to MB
-  return static_cast<int>(total / timer_stop);
+  size_t total_Mb = bo_size / (1024 * 1024); //convert to MB
+  return static_cast<double>(total_Mb / timer_duration_sec);
 }
 
 /*

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -476,7 +476,7 @@ m2mtest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, int b
   }
 
   //bandwidth
-  size_t total_Mb = bo_size / (1024 * 1024); //convert to MB
+  double total_Mb = static_cast<double>(bo_size) / static_cast<double>(1024 * 1024); //convert to MB
   return static_cast<double>(total_Mb / timer_duration_sec);
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -476,9 +476,7 @@ m2mtest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, int b
   }
 
   //bandwidth
-  size_t total = bo_size;
-  total *= 1000000; // convert us to s
-  total /= (1024 * 1024); //convert to MB
+  size_t total = bo_size / (1024 * 1024); //convert to MB
   return static_cast<int>(total / timer_stop);
 }
 
@@ -721,12 +719,11 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 
   for(unsigned int i = 0; i < used_banks.size()-1; i++) {
     for(unsigned int j = i+1; j < used_banks.size(); j++) {
-      std::cout << used_banks[i].m_tag << " -> " << used_banks[j].m_tag << " M2M bandwidth: ";
       if(!used_banks[i].m_size || !used_banks[j].m_size)
         continue;
       
       double m2m_bandwidth = m2mtest_bank(_dev->get_device_handle(), _ptTest, i, j, bo_size);
-      logger(_ptTest, "Details", boost::str(boost::format("%s -> %s M2M bandwidth: %f MB/s") % used_banks[i].m_tag 
+      logger(_ptTest, "Details", boost::str(boost::format("%s -> %s M2M bandwidth: %.2f MB/s") % used_banks[i].m_tag
                   %used_banks[j].m_tag % m2m_bandwidth));
       
       if(m2m_bandwidth == 0) //test failed, exit


### PR DESCRIPTION
Output:
```
......
9/10 Test #9         : Memory to memory DMA
    Description     : Run M2M test
    Details         : bank0 -> bank1 M2M bandwidth: 12701.00 MB/s
    Details         : bank0 -> bank2 M2M bandwidth: 12768.00 MB/s
    Details         : bank0 -> bank3 M2M bandwidth: 12711.00 MB/s
    Details         : bank1 -> bank2 M2M bandwidth: 12716.00 MB/s
    Details         : bank1 -> bank3 M2M bandwidth: 12749.00 MB/s
    Details         : bank2 -> bank3 M2M bandwidth: 12725.00 MB/s
    [PASSED]
.....
```