### PR TITLE
CR-1072452 vck5000 xclbin clock scaling is not working

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -859,8 +859,8 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 
 		ret = xocl_icap_ocl_update_clock_freq_topology(lro, clk);
 		if (ret == -ENODEV)
-		    ret = xocl_clock_update_freq(lro, clk->ocl_target_freq,
-		        ARRAY_SIZE(clk->ocl_target_freq), 1);
+			ret = xocl_clock_freq_scaling_by_request(lro,
+			    clk->ocl_target_freq, ARRAY_SIZE(clk->ocl_target_freq), 1);
 
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,
 			sizeof(ret));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -47,6 +47,11 @@
 /* no float number in kernel, x/33.333 will be converted to x * 1000 / 33333) */
 #define	CLK_ACAP_INPUT_FREQ_X_1000	33333
 
+#define	CLK_TYPE_DATA	0
+#define	CLK_TYPE_KERNEL	1
+#define	CLK_TYPE_SYSTEM	2
+#define	CLK_TYPE_MAX	4
+
 #define	CLOCK_ERR(clock, fmt, arg...)	\
 	xocl_err(&(clock)->clock_pdev->dev, fmt "\n", ##arg)
 #define	CLOCK_WARN(clock, fmt, arg...)	\
@@ -947,7 +952,7 @@ done:
 	return err;
 }
 
-static int clock_freq_scaling(struct platform_device *pdev, bool force)
+static int clock_freq_rescaling(struct platform_device *pdev, bool force)
 {
 	struct clock *clock = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);
@@ -961,7 +966,7 @@ static int clock_freq_scaling(struct platform_device *pdev, bool force)
 	return err;
 }
 
-static int clock_update_freq(struct platform_device *pdev,
+static int clock_freq_scaling_by_request(struct platform_device *pdev,
 	unsigned short *freqs, int num_freqs, int verify)
 {
 	struct clock *clock = platform_get_drvdata(pdev);
@@ -975,6 +980,81 @@ static int clock_update_freq(struct platform_device *pdev,
 
 	CLOCK_INFO(clock, "verify: %d ret: %d.", verify, err);
 	return err;
+}
+
+static int clock_freq_scaling_by_topo(struct platform_device *pdev,
+	struct clock_freq_topology *topo, int verify)
+{
+	struct clock *clock = platform_get_drvdata(pdev);
+	struct clock_freq *freq = NULL;
+	int data_clk_count = 0;
+	int kernel_clk_count = 0;
+	int system_clk_count = 0;
+	int clock_type_count = 0;
+	unsigned short target_freqs[4] = {0};
+	int i = 0;
+
+	if (!topo)
+		return -EINVAL;
+
+	if (topo->m_count > CLK_TYPE_MAX) {
+		CLOCK_ERR(clock, "More than 4 clocks found in clock topology");
+		return -EDOM;
+	}
+
+	/* Error checks - we support 1 data clk (reqd), 1 kernel clock(reqd) and
+	 * at most 2 system clocks (optional/reqd for aws).
+	 * Data clk needs to be the first entry, followed by kernel clock
+	 * and then system clocks
+	 */
+	for (i = 0; i < topo->m_count; i++) {
+		freq = &(topo->m_clock_freq[i]);
+		if (freq->m_type == CT_DATA)
+			data_clk_count++;
+		if (freq->m_type == CT_KERNEL)
+			kernel_clk_count++;
+		if (freq->m_type == CT_SYSTEM)
+			system_clk_count++;
+	}
+	if (data_clk_count != 1) {
+		CLOCK_ERR(clock, "Data clock not found in clock topology");
+		return -EDOM;
+	}
+	if (kernel_clk_count != 1) {
+		CLOCK_ERR(clock, "Kernel clock not found in clock topology");
+		return -EDOM;
+	}
+	if (system_clk_count > 2) {
+		CLOCK_ERR(clock,
+			"More than 2 system clocks found in clock topology");
+		return -EDOM;
+	}
+
+	for (i = 0; i < topo->m_count; i++) {
+		freq = &(topo->m_clock_freq[i]);
+		if (freq->m_type == CT_DATA)
+			target_freqs[CLK_TYPE_DATA] = freq->m_freq_Mhz;
+	}
+
+	for (i = 0; i < topo->m_count; i++) {
+		freq = &(topo->m_clock_freq[i]);
+		if (freq->m_type == CT_KERNEL)
+			target_freqs[CLK_TYPE_KERNEL] = freq->m_freq_Mhz;
+	}
+
+	clock_type_count = CLK_TYPE_SYSTEM;
+	for (i = 0; i < topo->m_count; i++) {
+		freq = &(topo->m_clock_freq[i]);
+		if (freq->m_type == CT_SYSTEM)
+			target_freqs[clock_type_count++] = freq->m_freq_Mhz;
+	}
+
+	CLOCK_INFO(clock, "set %lu freq, data: %d, kernel: %d, sys: %d, sys1: %d",
+	    ARRAY_SIZE(target_freqs), target_freqs[0], target_freqs[1],
+	    target_freqs[2], target_freqs[3]);
+
+	return clock_freq_scaling_by_request(pdev, target_freqs,
+	    ARRAY_SIZE(target_freqs), verify);
 }
 
 static int clock_get_freq_counter_khz(struct platform_device *pdev,
@@ -1272,11 +1352,12 @@ static struct attribute_group clock_attr_group = {
 };
 
 static struct xocl_clock_funcs clock_ops = {
-	.freq_scaling = clock_freq_scaling,
 	.get_freq_counter_khz = clock_get_freq_counter_khz,
 	.get_freq_by_id = clock_get_freq_by_id,
 	.get_freq = clock_get_freq,
-	.update_freq = clock_update_freq,
+	.freq_rescaling = clock_freq_rescaling,
+	.freq_scaling_by_request = clock_freq_scaling_by_request,
+	.freq_scaling_by_topo = clock_freq_scaling_by_topo,
 	.clock_status = clock_status_check,
 	.get_data = clock_get_data,
 };


### PR DESCRIPTION
clock setting should be performed during xclbin download which is missed for versal.
We thought that the xclbin will be run on default freq, but they have lots of different xclbins with different freqs setting, we really should perform the clock setting during xclbin download.

Also refactor code in icap. Even though caching topology benefits other function, but versal download can just use the xclbin topology and do not cache topology on mgmt side. We don't have memory calibration, etc... 