### PR TITLE
CR-1072876 ASTeR 22.01 - xbutil validate fails when the slave bridge is enabled

### DIFF
--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -177,7 +177,7 @@ def main(args):
         print("FAILED TEST")
         sys.exit(1)
     finally:
-        xclClose(opt.handle)
+        xrtDeviceClose(opt.handle)
 
 if __name__ == "__main__":
     main(sys.argv)


### PR DESCRIPTION
change xrtClose = > xrtDeviceClose)