### PR TITLE
Add asynchronous error injection on edge

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -46,7 +46,8 @@ zocl-y := \
 	zocl_sk.o \
 	zocl_kds.o \
 	cu.o \
-	zocl_generic_cu.o
+	zocl_generic_cu.o \
+	zocl_error.o
 
 obj-m	+= zocl.o
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -215,6 +215,11 @@ void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size,
 void zocl_init_mem(struct drm_zocl_dev *zdev, struct mem_topology *mtopo);
 void zocl_clear_mem(struct drm_zocl_dev *zdev);
 
+int zocl_inject_error(struct drm_zocl_dev *zdev, void *data,
+		struct drm_file *filp);
+int zocl_init_error(struct drm_zocl_dev *zdev);
+void zocl_fini_error(struct drm_zocl_dev *zdev);
+
 /* zocl_kds.c */
 int zocl_init_sched(struct drm_zocl_dev *zdev);
 void zocl_fini_sched(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_error.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_error.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ based
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu    <yliu@xilinx.com>
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#ifndef _ZOCL_ERROR_H
+#define _ZOCL_ERROR_H
+
+#include "xrt_error_code.h"
+
+#define	ZOCL_DEFAULT_ERROR_CAPACITY	8
+
+struct zocl_err_record {
+	xrtErrorCode	zer_err_code;	/* XRT error code */
+	u64		zer_ts;		/* timestamp */
+};
+
+struct zocl_error {
+	int		ze_num;		/* number of errors recorded */
+	int		ze_cap;		/* capacity of current error array */
+	struct zocl_err_record *ze_err;	/* error array pointer */
+};
+
+#endif /* _ZOCL_ERROR_H */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
@@ -47,5 +47,6 @@ int zocl_info_cu_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
 int zocl_ctx_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
-
+int zocl_error_ioctl(struct drm_device *dev, void *data,
+		struct drm_file *filp);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -13,6 +13,7 @@
 #define _ZOCL_UTIL_H_
 
 #include "kds_core.h"
+#include "zocl_error.h"
 
 #define zocl_err(dev, fmt, args...)     \
 	dev_err(dev, "%s: "fmt, __func__, ##args)
@@ -143,6 +144,7 @@ struct drm_zocl_dev {
 	struct generic_cu	*generic_cu;
 	int			 ksize;
 	char			*kernels;
+	struct zocl_error	zdev_error;
 };
 
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_error.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_error.c
@@ -23,7 +23,7 @@ zocl_insert_error_record(struct drm_zocl_dev *zdev,
 {
 	struct zocl_error *zer = &zdev->zdev_error;
 	u64 timestamp = ktime_to_ns(ktime_get());
-	xrtErrorCode err_code = XRT_BUILD_ERROR_CODE(
+	xrtErrorCode err_code = XRT_ERROR_CODE_BUILD(
 	    args->err_num,
 	    args->err_driver,
 	    args->err_severity,

--- a/src/runtime_src/core/edge/drm/zocl/zocl_error.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_error.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ based
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu <yliu@xilinx.com>
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#include <linux/mutex.h>
+
+#include "zocl_error.h"
+#include "zocl_drv.h"
+
+static int
+zocl_insert_error_record(struct drm_zocl_dev *zdev,
+		struct drm_zocl_error_inject *args)
+{
+	struct zocl_error *zer = &zdev->zdev_error;
+	u64 timestamp = ktime_to_ns(ktime_get());
+	xrtErrorCode err_code = XRT_BUILD_ERROR_CODE(
+	    args->err_num,
+	    args->err_driver,
+	    args->err_severity,
+	    args->err_module,
+	    args->err_class
+	    );
+
+	write_lock(&zdev->attr_rwlock);
+
+	/*
+	 * TODO Dynamically increase the error cache or limit the
+	 * number of error records for each class
+	 */
+	if (zer->ze_num == zer->ze_cap) {
+		DRM_INFO("Error cache is full. "
+		    "No more asynchronous error will be recorded.\n");
+		write_unlock(&zdev->attr_rwlock);
+		return -ENOSPC;
+	}
+
+	zer->ze_err[zer->ze_num].zer_err_code = err_code;
+	zer->ze_err[zer->ze_num].zer_ts = timestamp;
+	zer->ze_num++;
+
+	write_unlock(&zdev->attr_rwlock);
+
+	return 0;
+}
+
+static void
+zocl_clear_all_error_record(struct drm_zocl_dev *zdev)
+{
+	struct zocl_error *zer = &zdev->zdev_error;
+
+	write_lock(&zdev->attr_rwlock);
+
+	memset(zer->ze_err, 0, sizeof(struct zocl_err_record) * zer->ze_num);
+	zer->ze_num = 0;
+
+	write_unlock(&zdev->attr_rwlock);
+}
+
+int
+zocl_inject_error(struct drm_zocl_dev *zdev, void *data,
+		struct drm_file *filp)
+{
+	struct drm_zocl_error_inject *args = data;
+	int ret = 0;
+
+	switch (args->err_ops) {
+	case ZOCL_ERROR_OP_INJECT:
+		ret = zocl_insert_error_record(zdev, args);
+		break;
+
+	case ZOCL_ERROR_OP_CLEAR_ALL:
+		zocl_clear_all_error_record(zdev);
+		break;
+
+	default:
+		DRM_ERROR("Unknow error ioctl operation code: %d\n",
+		    args->err_ops);
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
+int
+zocl_init_error(struct drm_zocl_dev *zdev)
+{
+	struct zocl_error *zer = &zdev->zdev_error;
+
+	zer->ze_num = 0;
+	zer->ze_cap = ZOCL_DEFAULT_ERROR_CAPACITY;
+
+	zer->ze_err = vzalloc(zer->ze_cap * sizeof(struct zocl_err_record));
+	if (!zer->ze_err) {
+		zer->ze_cap = 0;
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+void
+zocl_fini_error(struct drm_zocl_dev *zdev)
+{
+	struct zocl_error *zer = &zdev->zdev_error;
+
+	vfree(zer->ze_err);
+	zer->ze_err = NULL;
+}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -16,6 +16,7 @@
 #include "sched_exec.h"
 #include "zocl_xclbin.h"
 #include "zocl_generic_cu.h"
+#include "zocl_error.h"
 
 extern int kds_mode;
 
@@ -125,6 +126,20 @@ zocl_execbuf_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		ret = zocl_command_ioctl(zdev, data, filp);
 	else
 		ret = zocl_execbuf_exec(dev, data, filp);
+
+	return ret;
+}
+
+int
+zocl_error_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+{
+	struct drm_zocl_dev *zdev = dev->dev_private;
+	int ret;
+
+	if (!capable(CAP_SYS_ADMIN))
+		return -EACCES;
+
+	ret = zocl_inject_error(zdev, data, filp);
 
 	return ret;
 }

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -115,6 +115,8 @@ enum drm_zocl_ops {
 	DRM_ZOCL_INFO_CU,
 	/* Open/Close context */
 	DRM_ZOCL_CTX,
+	/* Error injection */
+	DRM_ZOCL_ERROR_INJECT,
 	DRM_ZOCL_NUM_IOCTLS
 };
 
@@ -430,6 +432,20 @@ struct drm_zocl_sk_report {
 	enum drm_zocl_scu_state	cu_state;
 };
 
+enum drm_zocl_err_ops {
+	ZOCL_ERROR_OP_INJECT = 0,
+	ZOCL_ERROR_OP_CLEAR_ALL
+};
+
+struct drm_zocl_error_inject {
+	enum drm_zocl_err_ops	err_ops;
+	uint16_t		err_num;
+	uint16_t		err_driver;
+	uint16_t		err_severity;
+	uint16_t		err_module;
+	uint16_t		err_class;
+};
+
 #define DRM_IOCTL_ZOCL_CREATE_BO       DRM_IOWR(DRM_COMMAND_BASE + \
                                        DRM_ZOCL_CREATE_BO,     \
                                        struct drm_zocl_create_bo)
@@ -464,4 +480,6 @@ struct drm_zocl_sk_report {
                                        DRM_ZOCL_INFO_CU, struct drm_zocl_info_cu)
 #define DRM_IOCTL_ZOCL_CTX             DRM_IOWR(DRM_COMMAND_BASE + \
                                        DRM_ZOCL_CTX, struct drm_zocl_ctx)
+#define DRM_IOCTL_ZOCL_ERROR_INJECT    DRM_IOWR(DRM_COMMAND_BASE + \
+                                       DRM_ZOCL_ERROR_INJECT, struct drm_zocl_error_inject)
 #endif

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1388,6 +1388,28 @@ xclGetDeviceClockFreqMHz()
   return (double)clockFreq;
 }
 
+int
+shim::
+xclErrorInject(uint16_t num, uint16_t driver, uint16_t  severity, uint16_t module, uint16_t eclass)
+{
+  int ret;
+  drm_zocl_error_inject ecmd = {ZOCL_ERROR_OP_INJECT, num, driver, severity, module, eclass};
+
+  ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_ERROR_INJECT, &ecmd);
+  return ret;
+}
+
+int
+shim::
+xclErrorClear()
+{
+  int ret;
+  drm_zocl_error_inject ecmd = {ZOCL_ERROR_OP_CLEAR_ALL};
+
+  ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_ERROR_INJECT, &ecmd);
+  return ret;
+}
+
 #ifdef XRT_ENABLE_AIE
 zynqaie::Aie *
 shim::
@@ -2119,4 +2141,24 @@ int
 xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
 {
   return 1; // -ENOSYS;
+}
+
+int
+xclErrorInject(xclDeviceHandle handle, uint16_t num, uint16_t driver, uint16_t severity, uint16_t module, uint16_t eclass)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  if (!drv)
+    return -EINVAL;
+
+  return drv->xclErrorInject(num, driver, severity, module, eclass);
+}
+
+int
+xclErrorClear(xclDeviceHandle handle)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  if (!drv)
+    return -EINVAL;
+
+  return drv->xclErrorClear();
 }

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -127,6 +127,9 @@ public:
   int cmpMonVersions(unsigned int major1, unsigned int minor1,
 		     unsigned int major2, unsigned int minor2);
 
+  int xclErrorInject(uint16_t num, uint16_t driver, uint16_t  severity, uint16_t module, uint16_t eclass);
+  int xclErrorClear();
+
 #ifdef XRT_ENABLE_AIE
   zynqaie::Aie *getAieArray();
   void setAieArray(zynqaie::Aie *aie);

--- a/src/runtime_src/core/include/experimental/xrt-next.h
+++ b/src/runtime_src/core/include/experimental/xrt-next.h
@@ -276,6 +276,35 @@ XCL_DRIVER_DLLESPEC int xclOpenIPInterruptNotify(xclDeviceHandle handle, uint32_
  */
 XCL_DRIVER_DLLESPEC int xclCloseIPInterruptNotify(xclDeviceHandle handle, int fd);
 
+/**
+ * xclErrorInject() - Inject an asynchronous error record into driver
+ *
+ * @handle:     Device handle
+ * @num:        error number
+ * @driver:     driver to inject
+ * @severity:   error severity
+ * @module:     module to inject
+ * @eclass:     error class
+ * Return:      0 or appropriate error number
+ *
+ * Note: this API needs root privilege
+ */
+XCL_DRIVER_DLLESPEC
+int
+xclErrorInject(xclDeviceHandle handle, uint16_t num, uint16_t driver, uint16_t severity, uint16_t module, uint16_t eclass);
+
+/**
+ * xclErrorClear() - Clear all asynchronous error records in driver
+ *
+ * @handle:     Device handle
+ * Return:      0 or appropriate error number
+ *
+ * Note: this API needs root privilege
+ */
+XCL_DRIVER_DLLESPEC
+int
+xclErrorClear(xclDeviceHandle handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/core/include/experimental/xrt-next.h
+++ b/src/runtime_src/core/include/experimental/xrt-next.h
@@ -277,23 +277,6 @@ XCL_DRIVER_DLLESPEC int xclOpenIPInterruptNotify(xclDeviceHandle handle, uint32_
 XCL_DRIVER_DLLESPEC int xclCloseIPInterruptNotify(xclDeviceHandle handle, int fd);
 
 /**
- * xclErrorInject() - Inject an asynchronous error record into driver
- *
- * @handle:     Device handle
- * @num:        error number
- * @driver:     driver to inject
- * @severity:   error severity
- * @module:     module to inject
- * @eclass:     error class
- * Return:      0 or appropriate error number
- *
- * Note: this API needs root privilege
- */
-XCL_DRIVER_DLLESPEC
-int
-xclErrorInject(xclDeviceHandle handle, uint16_t num, uint16_t driver, uint16_t severity, uint16_t module, uint16_t eclass);
-
-/**
  * xclErrorClear() - Clear all asynchronous error records in driver
  *
  * @handle:     Device handle

--- a/src/runtime_src/core/include/xrt_error_code.h
+++ b/src/runtime_src/core/include/xrt_error_code.h
@@ -53,7 +53,7 @@
  * implementation where it is translated into an actual error / info /
  * warning that is propagated to the end user.
  *
- * 63 - 48  47 - 40   39 - 32   31 - 24   16 - 23    15 - 0
+ * 63 - 48  47 - 40   39 - 32   31 - 24   23 - 16    15 - 0
  * --------------------------------------------------------
  * |    |    |    |    |    |    |    |    |    |    |----| xrtErrorNum
  * |    |    |    |    |    |    |    |    |----|---------- xrtErrorDriver
@@ -64,7 +64,25 @@
  *
  */
 typedef uint64_t xrtErrorCode;
- 
+
+#define XRT_ERROR_NUM_MASK		0xFFFFUL
+#define XRT_ERROR_NUM_SHIFT		0
+#define XRT_ERROR_DRIVER_MASK		0xFUL
+#define XRT_ERROR_DRIVER_SHIFT		16
+#define XRT_ERROR_SEVERITY_MASK		0xFUL
+#define XRT_ERROR_SEVERITY_SHIFT	24
+#define XRT_ERROR_MODULE_MASK		0xFUL
+#define XRT_ERROR_MODULE_SHIFT		32
+#define XRT_ERROR_CLASS_MASK		0xFUL
+#define XRT_ERROR_CLASS_SHIFT		40
+
+#define	XRT_BUILD_ERROR_CODE(num, driver, severity, module, eclass) \
+	((((num) & XRT_ERROR_NUM_MASK) << XRT_ERROR_NUM_SHIFT) | \
+	(((driver) & XRT_ERROR_DRIVER_MASK) << XRT_ERROR_DRIVER_SHIFT) | \
+	(((severity) & XRT_ERROR_SEVERITY_MASK) << XRT_ERROR_SEVERITY_SHIFT) | \
+	(((module) & XRT_ERROR_MODULE_MASK) << XRT_ERROR_MODULE_SHIFT) | \
+	(((eclass) & XRT_ERROR_CLASS_MASK) << XRT_ERROR_CLASS_SHIFT))
+
 /**
  * xrt_error_num - XRT specific error numbers
  */
@@ -75,23 +93,14 @@ enum xrtErrorNum {
   XRT_ERROR_NUM_DM_ECC,
   XRT_ERROR_DMA_S2MM_0
 };
- 
-enum xrtErorClass {
-  XRT_ERROR_CLASS_FIRST_ENTRY = 0,
-  XRT_ERROR_CLASS_SYSTEM = XRT_ERROR_CLASS_FIRST_ENTRY,
-  XRT_ERROR_CLASS_AIE,
-  XRT_ERROR_CLASS_HARDWARE,
-  XRT_ERROR_CLASS_LAST_ENTRY,
+
+enum xrtErrorDriver {
+  XRT_ERROR_DRIVER_XOCL,
+  XRT_ERROR_DRIVER_XCLMGMT,
+  XRT_ERROR_DRIVER_ZOCL,
+  XRT_ERROR_DRIVER_AIE
 };
- 
-enum xrtErrorModule {
-  XRT_ERROR_MODULE_FIREWALL = 0,
-  XRT_ERROR_MODULE_CMC,
-  XRT_ERROR_MODULE_AIE_CORE,
-  XRT_ERROR_MODULE_AIE_MEMORY,
-  XRT_ERROR_MODULE_AIE_SHIM
-};
- 
+
 enum xrtErrorSeverity {
   XRT_ERROR_SEVERITY_EMERGENCY = 0,
   XRT_ERROR_SEVERITY_ALERT,
@@ -102,12 +111,21 @@ enum xrtErrorSeverity {
   XRT_ERROR_SEVERITY_INFO,
   XRT_ERROR_SEVERITY_DEBUG
 };
- 
-enum xrtErrorDriver {
-  XRT_ERROR_DRIVER_XOCL,
-  XRT_ERROR_DRIVER_XCLMGMT,
-  XRT_ERROR_DRIVER_ZOCL,
-  XRT_ERROR_DRIVER_AIE
+
+enum xrtErrorModule {
+  XRT_ERROR_MODULE_FIREWALL = 0,
+  XRT_ERROR_MODULE_CMC,
+  XRT_ERROR_MODULE_AIE_CORE,
+  XRT_ERROR_MODULE_AIE_MEMORY,
+  XRT_ERROR_MODULE_AIE_SHIM
+};
+
+enum xrtErorClass {
+  XRT_ERROR_CLASS_FIRST_ENTRY = 0,
+  XRT_ERROR_CLASS_SYSTEM = XRT_ERROR_CLASS_FIRST_ENTRY,
+  XRT_ERROR_CLASS_AIE,
+  XRT_ERROR_CLASS_HARDWARE,
+  XRT_ERROR_CLASS_LAST_ENTRY,
 };
 
 #endif

--- a/src/runtime_src/core/include/xrt_error_code.h
+++ b/src/runtime_src/core/include/xrt_error_code.h
@@ -76,7 +76,7 @@ typedef uint64_t xrtErrorCode;
 #define XRT_ERROR_CLASS_MASK		0xFUL
 #define XRT_ERROR_CLASS_SHIFT		40
 
-#define	XRT_BUILD_ERROR_CODE(num, driver, severity, module, eclass) \
+#define	XRT_ERROR_CODE_BUILD(num, driver, severity, module, eclass) \
 	((((num) & XRT_ERROR_NUM_MASK) << XRT_ERROR_NUM_SHIFT) | \
 	(((driver) & XRT_ERROR_DRIVER_MASK) << XRT_ERROR_DRIVER_SHIFT) | \
 	(((severity) & XRT_ERROR_SEVERITY_MASK) << XRT_ERROR_SEVERITY_SHIFT) | \
@@ -120,7 +120,7 @@ enum xrtErrorModule {
   XRT_ERROR_MODULE_AIE_SHIM
 };
 
-enum xrtErorClass {
+enum xrtErrorClass {
   XRT_ERROR_CLASS_FIRST_ENTRY = 0,
   XRT_ERROR_CLASS_SYSTEM = XRT_ERROR_CLASS_FIRST_ENTRY,
   XRT_ERROR_CLASS_AIE,


### PR DESCRIPTION
Add a capability to inject an asynchronous error and remove all asynchronous errors in zocl driver
1. Add an ioctl to inject/remove error
2. Add an xcl level API to inject/remove error