### PR TITLE
Polpulating device's PCI slot address into existing field in xclDeviceInfo2

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1001,7 +1001,7 @@ void shim::xclSysfsGetDeviceInfo(xclDeviceInfo2 *info)
     mDev->sysfs_get<unsigned long long>("rom", "timestamp", errmsg, info->mTimeStamp, static_cast<unsigned long long>(-1));
     mDev->sysfs_get<unsigned short>("rom", "ddr_bank_count_max", errmsg, info->mDDRBankCount, static_cast<unsigned short>(-1));
     info->mDDRSize *= info->mDDRBankCount;
-
+    info->mPciSlot = (mDev->domain<<16) + (mDev->bus<<8) + (mDev->dev<<3) + mDev->func;
     info->mNumClocks = numClocks(info->mName);
 
     mDev->sysfs_get<unsigned short>("mb_scheduler", "kds_numcdmas", errmsg, info->mNumCDMA, static_cast<unsigned short>(-1));


### PR DESCRIPTION
The application needs FPGA device's PCI  slot address to be able to find its peer NVME device in case of SmartSSD.  The field already existed in the xclDeviceInfo2, which is returned by xclGetDeviceInfo2, but was not filled previously. Added this change to fill the PCI slot address in the following format: (domain<<16) + (bus<<8) + (dev<<3) + function.