### PR TITLE
Some bug fix for new KDS + ERT 2.0

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -206,36 +206,32 @@ out:
 	return index;
 }
 
-static void
+static int
 kds_cu_dispatch(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 {
 	int cu_idx;
 
 	cu_idx = acquire_cu_idx(cu_mgmt, xcmd);
-	if (cu_idx < 0) {
-		xcmd->cb.notify_host(xcmd, KDS_ERROR);
-		xcmd->cb.free(xcmd);
-		return;
-	}
+	if (cu_idx < 0)
+		return cu_idx;
 
 	xrt_cu_submit(cu_mgmt->xcus[cu_idx], xcmd);
+	return 0;
 }
 
 static int
 kds_submit_cu(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 {
 	int ret = 0;
-	u32 status = KDS_COMPLETED;
 
 	if (xcmd->opcode != OP_CONFIG)
-		kds_cu_dispatch(cu_mgmt, xcmd);
+		ret = kds_cu_dispatch(cu_mgmt, xcmd);
 	else {
 		ret = kds_cu_config(cu_mgmt, xcmd);
-		if (ret)
-			status = KDS_ERROR;
-
-		xcmd->cb.notify_host(xcmd, status);
-		xcmd->cb.free(xcmd);
+		if (ret == 0) {
+			xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
+			xcmd->cb.free(xcmd);
+		}
 	}
 
 	return ret;
@@ -254,7 +250,7 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 		/* KDS should select a CU and set it in cu_mask */
 		cu_idx = acquire_cu_idx(&kds->cu_mgmt, xcmd);
 		if (cu_idx < 0)
-			goto err;
+			return cu_idx;
 		/* write kds selected cu index in the first cumask
 		 * (first word after header of execbuf)
 		 * TODO: I dislike modify the content of the execbuf
@@ -265,16 +261,11 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 		/* Configure command define CU index */
 		ret = kds_cu_config(&kds->cu_mgmt, xcmd);
 		if (ret)
-			goto err;
+			return ret;
 	}
 
 	ert->submit(ert, xcmd);
 	return 0;
-
-err:
-	xcmd->cb.notify_host(xcmd, KDS_ERROR);
-	xcmd->cb.free(xcmd);
-	return ret;
 }
 
 static int
@@ -458,10 +449,8 @@ int kds_add_command(struct kds_sched *kds, struct kds_command *xcmd)
 	struct kds_client *client = xcmd->client;
 	int err = 0;
 
-	if (!xcmd->cb.notify_host || !xcmd->cb.free) {
-		kds_dbg(client, "Command callback empty");
-		return -EINVAL;
-	}
+	BUG_ON(!xcmd->cb.notify_host);
+	BUG_ON(!xcmd->cb.free);
 
 	/* TODO: Check if command is blocked */
 
@@ -475,11 +464,13 @@ int kds_add_command(struct kds_sched *kds, struct kds_command *xcmd)
 		break;
 	default:
 		kds_err(client, "Unknown type");
-		xcmd->cb.notify_host(xcmd, KDS_ERROR);
-		xcmd->cb.free(xcmd);
 		err = -EINVAL;
 	}
 
+	if (err) {
+		xcmd->cb.notify_host(xcmd, KDS_ERROR);
+		xcmd->cb.free(xcmd);
+	}
 	return err;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -282,8 +282,6 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 
 	/* Now, we could forget execbuf */
 	ret = kds_add_command(&zdev->kds, xcmd);
-	if (ret)
-		kds_free_command(xcmd);
 
 out:
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -317,8 +317,6 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 
 	/* Now, we could forget execbuf */
 	ret = kds_add_command(&XDEV(xdev)->kds, xcmd);
-	if (ret)
-		kds_free_command(xcmd);
 
 out:
 	return ret;


### PR DESCRIPTION
1. Fix double free xcmd issue when kds_add_command() is called.
2. ert_user sub-dev would use register offset instead of physical address to access interrupt status registers.
3. Do not enable MSI-x interrupt by default. Otherwise, if ert_polling mode is enabled, the interrupt handler and csr_read32() both would access interrupt status register.

This is test on SSv2 shell. ERT polling and interrupt mode work well. 