### PR TITLE
base_2 xdma shell with new endpoints addresses changes

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1737,8 +1737,8 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
-#define	ERT_CSR_ADDR_VERSAL		0x6040000
-#define	ERT_CQ_BASE_ADDR_VERSAL		0x4000000
+#define	ERT_CSR_ADDR_VERSAL		0x2040000
+#define	ERT_CQ_BASE_ADDR_VERSAL		0x6000000
 
 #define XOCL_RES_INTC_VERSAL				\
 	((struct resource []) {				\


### PR DESCRIPTION
Colin fixed the base_2 shell issue with new endpoint address. So far we only have these 2 hard-coded, waiting for new scheduler ready to make it data-driven.

Please hold off merge until we get agreement from platform, we better to have new device id.

As Larry mentioned, we will have to let all developer know that they will need to upgrade their XRT and shell.