### PR TITLE
CR-1073296 Kernel Oops in zocl requires system reboot to recover

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
@@ -21,6 +21,7 @@
 
 struct soft_cu {
 	void			*sc_vregs;
+	struct drm_gem_object	*gem_obj;
 
 	/*
 	 * This semaphore is used for each soft kernel
@@ -53,5 +54,6 @@ struct soft_krnl_cmd {
 };
 
 int zocl_init_soft_kernel(struct drm_device *drm);
+void zocl_fini_soft_kernel(struct drm_device *drm);
 
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -3259,6 +3259,9 @@ int sched_fini_exec(struct drm_device *drm)
 	if (zdev->exec->cq_thread)
 		kthread_stop(zdev->exec->cq_thread);
 
+	if (zdev->ert)
+		zocl_fini_soft_kernel(drm);
+
 	fini_scheduler_thread();
 	zocl_cleanup_cu_timer(zdev);
 	SCHED_DEBUG("<- %s\n", __func__);


### PR DESCRIPTION
While soft kernel process was killed by incident, the exchange buffer was free but zocl driver might still try to access it. This pull request is to fix this issue.
Let zocl driver hold a refcnt of that buffer. Release it until receive "unconfigure" soft kernel command or driver is unloaded. 