### PR TITLE
Dynamically load XRT core library from coreutil

### DIFF
--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -39,6 +39,8 @@ file(GLOB XRT_CORE_COMMON_OBJ_FILES
   "scheduler.*"
   )
 
+add_compile_options("-DXRT_VERSION_MAJOR=\"${XRT_VERSION_MAJOR}\"")
+
 add_library(xrt_coreutil SHARED ${XRT_CORE_COMMON_LIB_FILES})
 add_library(xrt_coreutil_static STATIC ${XRT_CORE_COMMON_LIB_FILES})
 

--- a/src/runtime_src/core/common/module_loader.h
+++ b/src/runtime_src/core/common/module_loader.h
@@ -27,48 +27,58 @@
 
 namespace xrt_core {
 
-  /*
-   * class: module_loader
-   * 
-   * This class is responsible for loading a plugin module from the
-   * appropriate directory under the XILINX_XRT installation.  The loading
-   * happens at object construction time, so the XRT side implementation should
-   * contain a function that instantiates a single static instance of this 
-   * class to handle the loading of a module once in a thread safe manner.
+/**
+ * This class is responsible for loading a plugin module from the
+ * appropriate directory under the XILINX_XRT installation.  The
+ * loading happens at object construction time, so the XRT side
+ * implementation should contain a function that instantiates a single
+ * static instance of this class to handle the loading of a module
+ * once in a thread safe manner.
+ */
+class module_loader
+{
+public:
+  /**
+   * module_loader() - Open a plugin module at runtime
+   *
+   * @plugin_name : The name of the plugin (without prefix or extension)
+   * @registration_function : A function responsible for connecting
+   *   plugin functionality with XRT callback functions via dlsym
+   * @warning_function : A function that will issue warnings specific to
+   *   the plugin after the plugin has been loaded
+   * @error_function : A function that will check preconditions before loading
+   *   the plugin and halt the loading if an error condition is detected
+   *
+   * A module is used only for runtime loading using dlopen.
    *
    */
+  XRT_CORE_COMMON_EXPORT
+  module_loader(const std::string& plugin_name,
+                std::function<void (void*)> registration_function,
+                std::function<void ()> warning_function,
+                std::function<int ()> error_function = nullptr);
+};
 
-  class module_loader
-  {
-  public:
+/**
+ * Load XRT core library at runtime
+ */
+class shim_loader
+{
+public:
+  /**
+   * shim_loader() - Load a versioned core XRT library
+   *
+   * The shim library is the XRT core library.  The actual library
+   * loaded at runtime depends on XCL_EMULATION_MODE set or not.
+   *
+   * The shim library is also a link library and as such located 
+   * in the $XILINX_XRT/lib folder.  This function loads the 
+   * versioned core XRT library.
+   */
+  XRT_CORE_COMMON_EXPORT
+  shim_loader();
+};
 
-    /*
-     * module_loader constructor
-     *
-     * pluginName : The name of the plugin (without prefix or extension)
-     *
-     * registrationFunction : A function responsible for connecting
-     *                        plugin functionality with XRT callback functions
-     *                        via dlsym
-     *
-     * warningFunction : A function that will issue warnings specific to
-     *                   the plugin after the plugin has been loaded
-     *
-     * errorFunction : A function that will check preconditions before loading
-     *                 the plugin and halt the loading if an error condition
-     *                 is detected
-     */
-
-    XRT_CORE_COMMON_EXPORT
-    module_loader(const char* pluginName, 
-		  std::function<void (void*)> registrationFunction,
-		  std::function<void ()> warningFunction,
-		  std::function<int ()> errorFunction = nullptr) ;
-
-    XRT_CORE_COMMON_EXPORT
-      ~module_loader() ;
-  } ;
-  
 } // end namespace xrt_core
 
 #endif

--- a/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
@@ -17,6 +17,7 @@ if (DEFINED XRT_AIE_BUILD)
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     pthread
+    dl
     rt
     uuid
     ${CURSES_LIBRARIES}
@@ -30,6 +31,7 @@ else()
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     pthread
+    dl
     rt
     uuid
     ${CURSES_LIBRARIES}

--- a/tests/xrt/00_hello/CMakeLists.txt
+++ b/tests/xrt/00_hello/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "00_hello")
 
 add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/00_hello/main.cpp
+++ b/tests/xrt/00_hello/main.cpp
@@ -116,9 +116,6 @@ int run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
   auto kernel = xrt::kernel(device, uuid, cu_name);

--- a/tests/xrt/02_simple/CMakeLists.txt
+++ b/tests/xrt/02_simple/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "02_simple")
 
 add_executable(02_simple main.cpp)
-target_link_libraries(02_simple PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(02_simple PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(02_simple PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -115,9 +115,6 @@ run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
   run(device, uuid, verbose);

--- a/tests/xrt/03_loopback/CMakeLists.txt
+++ b/tests/xrt/03_loopback/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "03_loopback")
 
 add_executable(03_loopback main.cpp)
-target_link_libraries(03_loopback PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(03_loopback PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(03_loopback PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -85,9 +85,6 @@ int run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/04_swizzle/CMakeLists.txt
+++ b/tests/xrt/04_swizzle/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "04_swizzle")
 
 add_executable(04_swizzle main.cpp)
-target_link_libraries(04_swizzle PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(04_swizzle PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(04_swizzle PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -76,9 +76,6 @@ int run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/07_sequence/CMakeLists.txt
+++ b/tests/xrt/07_sequence/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "07_sequence")
 
 add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/07_sequence/main.cpp
+++ b/tests/xrt/07_sequence/main.cpp
@@ -100,9 +100,6 @@ int run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/100_ert_ncu/CMakeLists.txt
+++ b/tests/xrt/100_ert_ncu/CMakeLists.txt
@@ -4,10 +4,10 @@ add_executable(xrt xrt.cpp)
 target_link_libraries(xrt PRIVATE ${xrt_core_LIBRARY})
 
 add_executable(xrtx xrtx.cpp)
-target_link_libraries(xrtx PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+target_link_libraries(xrtx PRIVATE ${xrt_coreutil_LIBRARY})
 
 add_executable(xrtxx xrtxx.cpp)
-target_link_libraries(xrtxx PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+target_link_libraries(xrtxx PRIVATE ${xrt_coreutil_LIBRARY})
 
 add_executable(ocl ocl.cpp)
 target_link_libraries(ocl PRIVATE ${xrt_xilinxopencl_LIBRARY})

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -274,10 +274,6 @@ int run(int argc, char** argv)
       throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
   }
 
-  auto probe = xclProbe();
-  if (probe < device_index)
-    throw std::runtime_error("Bad device index '" + std::to_string(device_index) + "'");
-
   auto device = xrtDeviceOpen(device_index);
 
   auto header = load_xclbin(device, xclbin_fnm);

--- a/tests/xrt/100_ert_ncu/xrtxx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx.cpp
@@ -237,10 +237,6 @@ int run(int argc, char** argv)
       throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
   }
 
-  auto probe = xclProbe();
-  if (probe < device_index)
-    throw std::runtime_error("Bad device index '" + std::to_string(device_index) + "'");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/102_multiproc_verify/CMakeLists.txt
+++ b/tests/xrt/102_multiproc_verify/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "102_multiproc_verify")
 
 add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/102_multiproc_verify/main.cpp
+++ b/tests/xrt/102_multiproc_verify/main.cpp
@@ -226,9 +226,6 @@ run(int argc, char** argv, char *envp[])
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/11_fp_mmult256/CMakeLists.txt
+++ b/tests/xrt/11_fp_mmult256/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "11_fp_mmult256")
 
 add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/11_fp_mmult256/main.cpp
+++ b/tests/xrt/11_fp_mmult256/main.cpp
@@ -159,9 +159,6 @@ run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/13_add_one/CMakeLists.txt
+++ b/tests/xrt/13_add_one/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "13_addone")
 
 add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/13_add_one/main.cpp
+++ b/tests/xrt/13_add_one/main.cpp
@@ -116,9 +116,6 @@ int run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/22_verify/CMakeLists.txt
+++ b/tests/xrt/22_verify/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "22_verify")
 
 add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/22_verify/main.cpp
+++ b/tests/xrt/22_verify/main.cpp
@@ -113,9 +113,6 @@ int run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
   auto device = xrt::device(device_index);
   auto uuid = device.load_xclbin(xclbin_fnm);
 

--- a/tests/xrt/56_xclbin/CMakeLists.txt
+++ b/tests/xrt/56_xclbin/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TESTNAME "56_xclbin")
 
 add_executable(56_xclbin main.cpp)
-target_link_libraries(56_xclbin PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(56_xclbin PRIVATE ${xrt_coreutil_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(56_xclbin PRIVATE ${uuid_LIBRARY} pthread)

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -111,10 +111,6 @@ run(int argc, char** argv)
   if (xclbin_fnm.empty())
     throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
 
-  if (device_index >= xclProbe())
-    throw std::runtime_error("Cannot find device index (" + std::to_string(device_index) + ") specified");
-
-
   auto xclbin = xrt::xclbin(xclbin_fnm); // C++ API, construct xclbin object from filename
 
   std::vector<std::string> cu_names = xclbin.get_cu_names();


### PR DESCRIPTION
No longer require host applicaiton to link with xrt_core.  Instead
load proper core library at run-time.  Application can continue to
link with core library if necessary for some reason.

Remove explicit linking with xrt_core library from XRT native tests.