### PR TITLE
Fix typo and edge build

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -321,7 +321,7 @@ xrtGraphSuspend(xrtGraphHandle graph_hdl)
 }
 
 int
-xrtGraphResuem(xrtGraphHandle graph_hdl)
+xrtGraphResume(xrtGraphHandle graph_hdl)
 {
   try {
     auto hdl = get_graph_hdl(graph_hdl);

--- a/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
@@ -103,12 +103,6 @@ namespace xdp {
           continue;
         auto aieArray = drv->getAieArray();
 
-        // TEMPORARY: Larry is making AIE array available when xclbin gets loaded  
-        if (!aieArray) {
-          aieArray = new zynqaie::Aie(device);
-          drv->setAieArray(aieArray);
-        }
-
         // Iterate over all AIE Counters
         auto numCounters = db->getStaticInfo().getNumAIECounter(index);
         for (uint64_t c=0; c < numCounters; c++) {


### PR DESCRIPTION
1. Fix edge build because we remove setAieArray().
2. Fix a critical typo