### PR TITLE
Adjust for missing argument type in xml metadata

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -567,7 +567,7 @@ get_kernel_arguments(const char* xml_data, size_t xml_size, const std::string& k
 
       args.emplace_back(kernel_argument{
           xml_arg.second.get<std::string>("<xmlattr>.name")
-         ,xml_arg.second.get<std::string>("<xmlattr>.type")
+         ,xml_arg.second.get<std::string>("<xmlattr>.type", "no-type")
          ,index
          ,convert(xml_arg.second.get<std::string>("<xmlattr>.offset"))
          ,convert(xml_arg.second.get<std::string>("<xmlattr>.size"))


### PR DESCRIPTION
Test failure exposed after #3873