### PR TITLE
CR-1073207 HEAD canary failure: Crash: return code -11

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -221,7 +221,7 @@ std::shared_ptr<xrt_core::device>
 device::
 get_core_device() const
 {
-  return xrt_core::get_userpf_device(m_idx);
+  return xrt_core::get_userpf_device(m_handle);
 }
 
 void


### PR DESCRIPTION
Fix access of core device from OCL to access by handle and avoid
xclOpen call.