### PR TITLE
Fix up query request with dynamic subdev and entry

### DIFF
--- a/src/runtime_src/core/common/query.h
+++ b/src/runtime_src/core/common/query.h
@@ -42,6 +42,13 @@ enum class key_type;
  */
 struct request
 {
+  // Modifier for specific request accessor.   For some
+  // query::request types, the accessor can expand into
+  // multiple different requests at run-time. For example
+  // when accessing sysfs nodes, the actual node can be
+  // parameterized by modifying the hardware subdev or entry.
+  enum class modifier { subdev, entry };
+
   virtual
   ~request()
   {}
@@ -57,6 +64,10 @@ struct request
   virtual boost::any
   get(const device*, const boost::any&, const boost::any&) const
   { throw std::runtime_error("query does not support two arguments"); }
+
+  virtual boost::any
+  get(const device*, modifier, const std::string&) const
+  { throw std::runtime_error("query does not support modifier"); }
 
   virtual void
   put(const device*, const boost::any&) const

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -162,7 +162,7 @@ enum class key_type
   firewall_status,
   firewall_time_sec,
   power_microwatts,
-  host_mem_size, 
+  host_mem_size,
   kds_numcdmas,
 
   mig_cache_update,
@@ -1768,7 +1768,7 @@ struct mig_ecc_enabled : request
   static const key_type key = key_type::mig_ecc_enabled;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct mig_ecc_status : request
@@ -1851,7 +1851,7 @@ struct flash_type : request
 
   virtual boost::any
   get(const device*) const = 0;
-  
+
   static std::string
   to_string(result_type value)
   {

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -587,7 +587,7 @@ struct dma_stream : request
   get(const device*) const = 0;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct mem_topology_raw : request
@@ -1756,7 +1756,7 @@ struct mig_cache_update : request
   static const key_type key = key_type::mig_cache_update;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier m, const std::string&) const = 0;
 
   virtual void
   put(const device*, const boost::any&) const = 0;
@@ -1777,7 +1777,7 @@ struct mig_ecc_status : request
   static const key_type key = key_type::mig_ecc_status;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct mig_ecc_ce_cnt : request
@@ -1786,7 +1786,7 @@ struct mig_ecc_ce_cnt : request
   static const key_type key = key_type::mig_ecc_ce_cnt;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct mig_ecc_ue_cnt : request
@@ -1795,7 +1795,7 @@ struct mig_ecc_ue_cnt : request
   static const key_type key = key_type::mig_ecc_ue_cnt;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct mig_ecc_ce_ffa : request
@@ -1804,7 +1804,7 @@ struct mig_ecc_ce_ffa : request
   static const key_type key = key_type::mig_ecc_ce_ffa;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct mig_ecc_ue_ffa : request
@@ -1813,7 +1813,7 @@ struct mig_ecc_ue_ffa : request
   static const key_type key = key_type::mig_ecc_ue_ffa;
 
   virtual boost::any
-  get(const device*, const boost::any&) const = 0;
+  get(const device*, modifier, const std::string&) const = 0;
 };
 
 struct is_mfg : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -67,22 +67,6 @@ struct sysfs_fcn
     return value;
   }
 
-  static ValueType
-  get(const pdev& dev, const char* subdev, const char* entry, const boost::any& v)
-  {
-    std::string err;
-    ValueType value;
-    std::pair <const char*,const char*> p = boost::any_cast<std::pair <const char*,const char*>>(v);
-    if (!strcmp(p.first,"subdev"))
-      subdev = p.second;
-    else if (!strcmp(p.first,"entry"))
-      entry = p.second;
-    dev->sysfs_get(subdev, entry, err, value, static_cast<ValueType>(-1));
-    if (!err.empty())
-      throw std::runtime_error(err);
-    return value;
-  }
-
   static void
   put(const pdev& dev, const char* subdev, const char* entry, ValueType value)
   {
@@ -103,22 +87,6 @@ struct sysfs_fcn<std::string>
   {
     std::string err;
     ValueType value;
-    dev->sysfs_get(subdev, entry, err, value);
-    if (!err.empty())
-      throw std::runtime_error(err);
-    return value;
-  }
-
-  static ValueType
-  get(const pdev& dev, const char* subdev, const char* entry, const boost::any& v)
-  {
-    std::string err;
-    ValueType value;
-    std::pair <const char*,const char*> p = boost::any_cast<std::pair <const char*,const char*>>(v);
-    if (!strcmp(p.first,"subdev"))
-      subdev = p.second;
-    else if (!strcmp(p.first,"entry"))
-      entry = p.second;
     dev->sysfs_get(subdev, entry, err, value);
     if (!err.empty())
       throw std::runtime_error(err);
@@ -146,22 +114,6 @@ struct sysfs_fcn<std::vector<VectorValueType>>
   {
     std::string err;
     ValueType value;
-    dev->sysfs_get(subdev, entry, err, value);
-    if (!err.empty())
-      throw std::runtime_error(err);
-    return value;
-  }
-
-  static ValueType
-  get(const pdev& dev, const char* subdev, const char* entry, const boost::any& v)
-  {
-    std::string err;
-    ValueType value;
-    std::pair <const char*,const char*> p = boost::any_cast<std::pair <const char*,const char*>>(v);
-    if (!strcmp(p.first,"subdev"))
-      subdev = p.second;
-    else if (!strcmp(p.first,"entry"))
-      entry = p.second;
     dev->sysfs_get(subdev, entry, err, value);
     if (!err.empty())
       throw std::runtime_error(err);
@@ -196,12 +148,13 @@ struct sysfs_get : virtual QueryRequestType
   }
 
   boost::any
-  get(const xrt_core::device* device, const boost::any& v) const
+  get(const xrt_core::device* device, query::request::modifier m, const std::string& v) const
   {
+    auto ms = (m == query::request::modifier::subdev) ? v.c_str() : subdev;
+    auto me = (m == query::request::modifier::entry) ? v.c_str() : entry;
     return sysfs_fcn<typename QueryRequestType::result_type>
-      ::get(get_pcidev(device), subdev, entry, v);
+      ::get(get_pcidev(device), ms, me);
   }
-
 };
 
 template <typename QueryRequestType>
@@ -390,7 +343,7 @@ initialize_query_table()
   emplace_sysfs_get<query::host_mem_size>               ("address_translator", "host_mem_size");
   emplace_sysfs_get<query::kds_numcdmas>                ("mb_scheduler", "kds_numcdmas");
 
-  emplace_sysfs_get<query::mig_ecc_enabled>             ("mig", "ecc_enabled");
+  //emplace_sysfs_get<query::mig_ecc_enabled>             ("mig", "ecc_enabled");
   emplace_sysfs_get<query::mig_ecc_status>              ("mig", "ecc_status");
   emplace_sysfs_get<query::mig_ecc_ce_cnt>              ("mig", "ecc_ce_cnt");
   emplace_sysfs_get<query::mig_ecc_ue_cnt>              ("mig", "ecc_ue_cnt");

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -156,8 +156,7 @@ populate_memtopology(const xrt_core::device * device, const std::string& desc)
       else
         status = "N/A";
       try {
-        boost::any a = std::make_pair("entry", lname.c_str());
-        stream_stat = xrt_core::device_query<qr::dma_stream>(device, a);
+        stream_stat = xrt_core::device_query<qr::dma_stream>(device, qr::request::modifier::entry, lname);
         status = "Active";
         for (unsigned k = 0; k < stream_stat.size(); k++) {
           std::vector<std::string> strs;
@@ -188,21 +187,20 @@ populate_memtopology(const xrt_core::device * device, const std::string& desc)
       uint64_t ecc_st = 0xffffffffffffffff;
       std::string ecc_st_str;
       std::string tag(reinterpret_cast<const char *>(map->m_mem_data[i].m_tag));
-      boost::any val = std::make_pair("subdev", tag.c_str());
       try {
-        ecc_st = xrt_core::device_query<qr::mig_ecc_status>(device, val);
+        ecc_st = xrt_core::device_query<qr::mig_ecc_status>(device, qr::request::modifier::subdev, tag);
       } catch (const std::exception& ex){
         pt.put("error_msg", ex.what());
       }
       if (eccStatus2Str(ecc_st, ecc_st_str) == 0) {
         uint64_t ce_cnt = 0;
-        ce_cnt = xrt_core::device_query<qr::mig_ecc_ce_cnt>(device, val);
+        ce_cnt = xrt_core::device_query<qr::mig_ecc_ce_cnt>(device, qr::request::modifier::subdev, tag);
         uint64_t ue_cnt = 0;
-        ue_cnt = xrt_core::device_query<qr::mig_ecc_ue_cnt>(device, val);
+        ue_cnt = xrt_core::device_query<qr::mig_ecc_ue_cnt>(device, qr::request::modifier::subdev, tag);
         uint64_t ce_ffa = 0;
-        ce_ffa = xrt_core::device_query<qr::mig_ecc_ce_ffa>(device, val);
+        ce_ffa = xrt_core::device_query<qr::mig_ecc_ce_ffa>(device, qr::request::modifier::subdev, tag);
         uint64_t ue_ffa = 0;
-        ue_ffa = xrt_core::device_query<qr::mig_ecc_ue_ffa>(device, val);
+        ue_ffa = xrt_core::device_query<qr::mig_ecc_ue_ffa>(device, qr::request::modifier::subdev, tag);
 
         ptMem.put("extended_info.ecc.status", ecc_st_str);
         ptMem.put("extended_info.ecc.error.correctable.count", ce_cnt);


### PR DESCRIPTION
Tweaks to #3860.  Avoid fixing query argument to std::pair, make the
dynamic nature of subdev and entry explicit through a modifier accessor
function.

Subject to change, but little cleaner and more explicit than before.