### PR TITLE
Add check for NODMA

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -518,9 +518,14 @@ xclGetComputeUnitInfo(cl_kernel             kernel,
  * @type: void*
  * Return: The underlying device handle for use with low
  * level XRT APIs (xrt.h)
+ * 
+ * @CL_DEVICE_NODMA
+ * @type: cl_bool
+ * Return: True if underlying device is NODMA
  */
 #define CL_DEVICE_PCIE_BDF              0x1120  // BUS/DEVICE/FUNCTION
 #define CL_DEVICE_HANDLE                0x1121  // XRT device handle
+#define CL_DEVICE_NODMA                 0x1122  // NODMA device check
 
 // valid target types (CR962714)
 typedef cl_uint cl_program_target_type;

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -39,12 +39,14 @@
 #endif
 
 namespace {
+
 static bool
-is_nodma()
+is_nodma(xclDeviceHandle xhdl)
 {
-  // TODO
-  return false;
+  auto core_device = xrt_core::get_userpf_device(xhdl);
+  return core_device->is_nodma();
 }
+
 }
 
 ////////////////////////////////////////////////////////////////
@@ -514,7 +516,7 @@ alloc(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
   switch (type) {
   case 0:
 #ifndef XRT_EDGE
-    if (is_nodma())
+    if (is_nodma(dhdl))
       return alloc_nodma(dhdl, sz, flags, grp);
     else
       return alloc_hbuf(dhdl, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -46,6 +46,24 @@ device::
   XRT_DEBUGF("xrt_core::device::~device(0x%x) idx(%d)\n", this, m_device_id);
 }
 
+bool
+device::
+is_nodma() const
+{
+  if (m_nodma != boost::none)
+    return *m_nodma;
+
+  try {
+    auto nodma = xrt_core::device_query<xrt_core::query::nodma>(this);
+    m_nodma = xrt_core::query::nodma::to_bool(nodma);
+  }
+  catch (const std::exception&) {
+    m_nodma = false;
+  }
+
+  return *m_nodma;
+}
+
 uuid
 device::
 get_xclbin_uuid() const

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -32,6 +32,7 @@
 #include <map>
 #include <boost/any.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <boost/optional/optional.hpp>
 
 namespace xrt_core {
 
@@ -119,6 +120,17 @@ public:
   {
     return false;
   }
+
+  /**
+   * is_nodma() - Is this device a NODMA device
+   *
+   * Return: true if device is nodma
+   *
+   * This function is added to avoid sysfs access in
+   * critical path.
+   */
+  bool
+  is_nodma() const;
 
  private:
   // Private look up function for concrete query::request
@@ -277,6 +289,7 @@ public:
 
  private:
   id_type m_device_id;
+  mutable boost::optional<bool> m_nodma = boost::none;
 
   // cache xclbin meta data loaded by this process
   uuid m_xclbin_uuid;

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -129,6 +129,7 @@ public:
    * This function is added to avoid sysfs access in
    * critical path.
    */
+  XRT_CORE_COMMON_EXPORT
   bool
   is_nodma() const;
 
@@ -260,7 +261,7 @@ public:
   XRT_CORE_COMMON_EXPORT
   std::pair<size_t, size_t>
   get_ert_slots() const;
-  
+
   // Move all these 'pt' functions out the class interface
   virtual void get_info(boost::property_tree::ptree&) const {}
   /**

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -89,6 +89,7 @@ enum class key_type
 
   m2m,
   error,
+  nodma,
 
   dna_serial_num,
   clock_freqs_mhz,
@@ -780,6 +781,22 @@ struct m2m : request
 {
   using result_type = uint32_t;
   static const key_type key = key_type::m2m;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  static bool
+  to_bool(const result_type& value)
+  {
+    return (value == std::numeric_limits<uint32_t>::max())
+      ? false : value;
+  }
+};
+
+struct nodma : request
+{
+  using result_type = uint32_t;
+  static const key_type key = key_type::nodma;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -322,6 +322,7 @@ initialize_query_table()
   emplace_sysfs_getput<query::xmc_scaling_override>     ("xmc", "scaling_threshold_power_override");
   emplace_sysfs_put<query::xmc_scaling_reset>           ("xmc", "scaling_reset");
   emplace_sysfs_get<query::m2m>                         ("", "m2m");
+  emplace_sysfs_get<query::nodma>                       ("", "nodma");
   emplace_sysfs_get<query::dna_serial_num>              ("dna", "dna");
   emplace_sysfs_getput<query::xmc_scaling_enabled>      ("xmc", "scaling_enabled");
   emplace_sysfs_getput<query::xmc_scaling_override>     ("xmc", "scaling_threshold_power_override");

--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -307,6 +307,9 @@ clGetDeviceInfo(cl_device_id   device,
   case CL_DEVICE_HANDLE:
     buffer.as<void*>() = xdevice->get_handle();
     break;
+  case CL_DEVICE_NODMA:
+    buffer.as<cl_bool>() = xdevice->is_nodma();
+    break;
   default:
     throw error(CL_INVALID_VALUE,"clGetDeviceInfo: invalid param_name");
     break;

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -246,6 +246,17 @@ get_bdf() const
   return xrt_core::query::pcie_bdf::to_string(bdf);
 }
 
+bool
+device::
+is_nodma() const 
+{
+  if (!m_xdevice)
+    throw xocl::error(CL_INVALID_DEVICE, "Can't check for nodma");
+
+  auto core_device = m_xdevice->get_core_device();
+  return core_device->is_nodma();
+}
+
 void*
 device::
 get_handle() const

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -146,6 +146,12 @@ public:
   get_bdf() const;
 
   /**
+   * Check if this device is a NODMA device
+   */
+  bool
+  is_nodma() const;
+
+  /**
    * Get underlying driver device handle
    */
   void*


### PR DESCRIPTION
Cache the check in core device to avoid repeated sysfs access.

Enable nodma check in xrtBOAlloc.

Expose nodma check via clGetDeviceInfo (CL_DEVICE_NODMA) per cl_ext_xilinx.h.