### PR TITLE
framework for zocl to query graph info like graph status 

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -187,6 +187,7 @@ enum class key_type
   rp_program_status,
 
   aie_metadata,
+  graph_status,
   noop
 
 };
@@ -607,6 +608,15 @@ struct aie_metadata : request
 {
   using result_type = std::string;
   static const key_type key = key_type::aie_metadata;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct graph_status : request
+{
+  using result_type = std::vector<std::string>;
+  static const key_type key = key_type::graph_status;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
@@ -4,6 +4,7 @@
  *
  * Authors:
  *    Larry Liu <yliu@xilinx.com>
+ *    Himanshu Choudhary <hchoudha@xilinx.com>
  *
  * This file is dual-licensed; you may select either the GNU General Public
  * License version 2 or Apache License, Version 2.0.
@@ -12,6 +13,7 @@
 #ifndef _ZOCL_AIE_H_
 #define _ZOCL_AIE_H_
 
+#include "zynq_ioctl.h"
 
 /* Wait 100 * 1 ms before AIE parition is availabe after reset */
 #define	ZOCL_AIE_RESET_TIMEOUT_INTERVAL	1
@@ -63,5 +65,27 @@ aie_partition_is_available(struct aie_partition_req *req)
 }
 
 #endif
+
+
+struct aie_info {
+	struct list_head	aie_cmd_list;
+	struct list_head	aie_cmd_result_list;
+	struct mutex		aie_lock;
+	wait_queue_head_t	aie_wait_queue;
+	wait_queue_head_t	aie_wait_result_queue;
+};
+
+struct aie_info_packet {
+	enum aie_info_code	opcode;
+	uint32_t		size;
+	char			info[AIE_INFO_SIZE];
+};
+
+struct aie_info_cmd {
+	struct list_head	aiec_list;
+	struct aie_info_packet	*aiec_packet;
+};
+
+int zocl_init_aie(struct drm_device *drm);
 
 #endif /* _ZOCL_AIE_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
@@ -66,13 +66,11 @@ aie_partition_is_available(struct aie_partition_req *req)
 
 #endif
 
-
 struct aie_info {
 	struct list_head	aie_cmd_list;
-	struct list_head	aie_cmd_result_list;
 	struct mutex		aie_lock;
+	struct aie_info_cmd	*cmd_inprogress;
 	wait_queue_head_t	aie_wait_queue;
-	wait_queue_head_t	aie_wait_result_queue;
 };
 
 struct aie_info_packet {
@@ -83,9 +81,10 @@ struct aie_info_packet {
 
 struct aie_info_cmd {
 	struct list_head	aiec_list;
+	struct semaphore	aiec_sem;
 	struct aie_info_packet	*aiec_packet;
 };
 
-int zocl_init_aie(struct drm_device *drm);
+int zocl_init_aie(struct drm_zocl_dev *zdev);
 
 #endif /* _ZOCL_AIE_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
@@ -53,4 +53,8 @@ int zocl_aie_fd_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
 int zocl_aie_reset_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
+int zocl_aie_getcmd_ioctl(struct drm_device *dev, void *data,
+		struct drm_file *filp);
+int zocl_aie_putcmd_ioctl(struct drm_device *dev, void *data,
+		struct drm_file *filp);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -136,6 +136,7 @@ struct drm_zocl_dev {
 	rwlock_t		attr_rwlock;
 
 	struct soft_krnl	*soft_kernel;
+	struct aie_info		*aie_information;
 	struct dma_chan		*zdev_dma_chan;
 	struct mailbox		*zdev_mailbox;
 	const struct zdev_data	*zdev_data_info;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -29,6 +29,7 @@
 #include <linux/spinlock.h>
 #include "zocl_drv.h"
 #include "zocl_sk.h"
+#include "zocl_aie.h"
 #include "zocl_bo.h"
 #include "sched_exec.h"
 #include "zocl_xclbin.h"
@@ -739,6 +740,10 @@ static const struct drm_ioctl_desc zocl_ioctls[] = {
 			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(ZOCL_AIE_RESET, zocl_aie_reset_ioctl,
 			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(ZOCL_AIE_GETCMD, zocl_aie_getcmd_ioctl,
+			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(ZOCL_AIE_PUTCMD, zocl_aie_putcmd_ioctl,
+			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 };
 
 static const struct file_operations zocl_driver_fops = {
@@ -950,6 +955,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 			goto err_sched;
 	}
 
+	zocl_init_aie(drm);
 	return 0;
 
 /* error out in exact reverse order of init */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -955,7 +955,6 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 			goto err_sched;
 	}
 
-	zocl_init_aie(drm);
 	return 0;
 
 /* error out in exact reverse order of init */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -136,8 +136,7 @@ static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 
 static ssize_t graph_status_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
-	struct drm_zocl_dev *zdev;
-	size_t size;
+	struct drm_zocl_dev *zdev = NULL;
 	struct aie_info *aie;
 	struct aie_info_cmd *acmd;
 	struct aie_info_packet *aiec_packet;
@@ -150,6 +149,7 @@ static ssize_t graph_status_show(struct device *dev, struct device_attribute *at
 	if (!aie)
 		return 0;
 
+	/* create request */
 	acmd = kmalloc(sizeof(struct aie_info_cmd), GFP_KERNEL);
 	if (!acmd) {
 		return -ENOMEM;
@@ -160,8 +160,11 @@ static ssize_t graph_status_show(struct device *dev, struct device_attribute *at
 		return -ENOMEM;
 	}
 
+	/* set command */
 	aiec_packet->opcode = GRAPH_STATUS;
 	acmd->aiec_packet = aiec_packet;
+
+	/* init semaphore */
 	sema_init(&acmd->aiec_sem, 0);
 
 	/* caller release the wait aied thread and wait for result */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -11,6 +11,7 @@
  */
 
 #include "zocl_drv.h"
+#include "zocl_aie.h"
 #include "sched_exec.h"
 #include "zocl_xclbin.h"
 #include "xclbin.h"
@@ -133,6 +134,60 @@ static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 	return size;
 }
 
+static ssize_t graph_status_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev;
+	size_t size;
+	struct aie_info *aie;
+	struct aie_info_cmd *acmd;
+	struct aie_info_packet *aiec_packet;
+	ssize_t nread = 0;
+	zdev = dev_get_drvdata(dev);
+	if (!zdev)
+		return 0;
+
+	aie = zdev->aie_information;
+	acmd = kmalloc(sizeof(struct aie_info_cmd), GFP_KERNEL);
+	if (!acmd) {
+		return -ENOMEM;
+	}
+
+	aiec_packet = kmalloc(sizeof(struct aie_info_packet), GFP_KERNEL);
+	if (!aiec_packet) {
+		return -ENOMEM;
+	}
+
+	aiec_packet->opcode = GRAPH_STATUS;
+	acmd->aiec_packet = aiec_packet;
+
+	/* caller release the wait aied thread and wait for result*/
+	mutex_lock(&aie->aie_lock);
+	if (waitqueue_active(&aie->aie_wait_queue)) {
+		list_add_tail(&acmd->aiec_list, &aie->aie_cmd_list);
+		mutex_unlock(&aie->aie_lock);
+		wake_up_interruptible(&aie->aie_wait_queue);
+		if (wait_event_interruptible(aie->aie_wait_result_queue,
+		    !list_empty(&aie->aie_cmd_result_list))) {
+			return -ERESTARTSYS;
+                }
+	} else {
+		mutex_unlock(&aie->aie_lock);
+		return -ERESTARTSYS;
+	}
+	mutex_lock(&aie->aie_lock);
+	
+	acmd = list_first_entry(&aie->aie_cmd_result_list, struct aie_info_cmd,
+	    aiec_list);
+	nread = sprintf(buf, "%s\n", acmd->aiec_packet->info);
+	list_del(&acmd->aiec_list);
+	mutex_unlock(&aie->aie_lock);
+
+        kfree(acmd->aiec_packet);
+        kfree(acmd);
+	return nread;
+}
+static DEVICE_ATTR_RO(graph_status);
+
 static ssize_t read_aie_metadata(struct file *filp, struct kobject *kobj,
 		struct bin_attribute *attr, char *buf, loff_t off, size_t count)
 {
@@ -220,6 +275,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,
 	&dev_attr_errors.attr,
+	&dev_attr_graph_status.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
+++ b/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
@@ -31,6 +31,7 @@ extern "C" {
 #define	SOFT_KERNEL_FILE_NAME	"sk"
 
 #define	SOFT_KERNEL_REG_SIZE	4096
+#define	AIE_INFO_SIZE		4096
 
 struct xclSKCmd {
     uint32_t	opcode;
@@ -39,6 +40,12 @@ struct xclSKCmd {
     uint64_t	xclbin_paddr;
     size_t	xclbin_size;
     char	krnl_name[XRT_MAX_NAME_LENGTH];
+};
+
+struct xclAIECmd {
+    uint32_t	opcode;
+    uint32_t	size;
+    char	info[AIE_INFO_SIZE];
 };
 
 enum xrt_scu_state {
@@ -66,6 +73,24 @@ XCL_DRIVER_DLLESPEC unsigned int xclGetHostBO(xclDeviceHandle handle, uint64_t p
  * Return:         0 on success or appropriate error number
  */
 XCL_DRIVER_DLLESPEC int xclSKGetCmd(xclDeviceHandle handle, xclSKCmd *cmd);
+
+/**
+ * xclAIEGetCmd() - Get a command for AIE
+ *
+ * @handle:        Device handle
+ * @cmd:           Pointer to the command
+ * Return:         0 on success or appropriate error number
+ */
+XCL_DRIVER_DLLESPEC int xclAIEGetCmd(xclDeviceHandle handle, xclAIECmd *cmd);
+
+/**
+ * xclAIEPutCmd() - Put a command for AIE
+ *
+ * @handle:        Device handle
+ * @cmd:           Pointer to the command
+ * Return:         0 on success or appropriate error number
+ */
+XCL_DRIVER_DLLESPEC int xclAIEPutCmd(xclDeviceHandle handle, xclAIECmd *cmd);
 
 /**
  * xclSKCreate() - Create a soft kernel compute unit

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -121,6 +121,10 @@ enum drm_zocl_ops {
 	DRM_ZOCL_AIE_FD,
 	/* Reset AIE Array */
 	DRM_ZOCL_AIE_RESET,
+	/* Get the aie info command */
+	DRM_ZOCL_AIE_GETCMD,
+	/* Put the aie info command */
+	DRM_ZOCL_AIE_PUTCMD,
 	DRM_ZOCL_NUM_IOCTLS
 };
 
@@ -394,6 +398,7 @@ struct drm_zocl_axlf {
 
 #define	ZOCL_MAX_NAME_LENGTH		32
 #define	ZOCL_MAX_PATH_LENGTH		255
+#define AIE_INFO_SIZE			4096
 
 /**
  * struct drm_zocl_sk_getcmd - Get the soft kernel command  (experimental)
@@ -413,6 +418,24 @@ struct drm_zocl_sk_getcmd {
 	size_t		size;
 	uint64_t	paddr;
 	char		name[ZOCL_MAX_NAME_LENGTH];
+};
+
+enum aie_info_code {
+	GRAPH_STATUS = 1,
+};
+
+/**
+ * struct drm_zocl_aie_cmd - Get the aie command
+ * used with DRM_IOCTL_ZOCL_AIE_GETCMD and DRM_IOCTL_ZOCL_AIE_PUTCMD ioctl
+ *
+ * @opcode       : opcode for the Aie Command Packet
+ * @size         : size in bytes of info data
+ * @info         : information to transfer
+ */
+struct drm_zocl_aie_cmd {
+	uint32_t	opcode;
+	uint32_t	size;
+	char		info[AIE_INFO_SIZE];
 };
 
 /**
@@ -500,4 +523,8 @@ struct drm_zocl_error_inject {
                                        DRM_ZOCL_AIE_FD, struct drm_zocl_aie_fd)
 #define DRM_IOCTL_ZOCL_AIE_RESET       DRM_IOWR(DRM_COMMAND_BASE + \
                                        DRM_ZOCL_AIE_RESET, struct drm_zocl_aie_reset)
+#define DRM_IOCTL_ZOCL_AIE_GETCMD      DRM_IOWR(DRM_COMMAND_BASE + \
+                                       DRM_ZOCL_AIE_GETCMD, struct drm_zocl_aie_cmd)
+#define DRM_IOCTL_ZOCL_AIE_PUTCMD      DRM_IOWR(DRM_COMMAND_BASE + \
+                                       DRM_ZOCL_AIE_PUTCMD, struct drm_zocl_aie_cmd)
 #endif

--- a/src/runtime_src/core/edge/user/aie/aied.cpp
+++ b/src/runtime_src/core/edge/user/aie/aied.cpp
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Himanshu Choudhary <hchoudha@xilinx.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sstream>
+#include <iostream>
+
+#include "aied.h"
+#include "core/edge/include/zynq_ioctl.h"
+#include "core/edge/user/shim.h"
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+namespace zynqaie {
+
+Aied::Aied(std::shared_ptr<xrt_core::device> device): mCoreDevice(std::move(device))
+{
+  mPollingThread = std::thread(&Aied::pollAIE, this);
+}
+
+Aied::~Aied()
+{
+
+}
+
+void 
+Aied::pollAIE()
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(mCoreDevice->get_device_handle());
+  xclAIECmd cmd;
+
+  while (1) {
+    /* Calling XRT interface to wait for commands */
+    if (drv->xclAIEGetCmd(&cmd) != 0) {
+      continue;
+    }
+
+    switch (cmd.opcode) {
+    case GRAPH_STATUS: {
+      boost::property_tree::ptree pt;
+      boost::property_tree::ptree pt_status;
+
+      for (auto graph : mGraphs) {
+        pt.put(graph->getname(), graph->getstatus());
+      }
+
+      pt_status.add_child("graphs", pt);
+      std::stringstream ss;
+      boost::property_tree::json_parser::write_json(ss, pt_status);
+      std::string tmp(ss.str());
+      cmd.size = snprintf(cmd.info,(tmp.size() < AIE_INFO_SIZE) ? tmp.size():AIE_INFO_SIZE
+                   , "%s\n", tmp.c_str());
+      break;
+      }
+    default:
+      break;
+    }
+    drv->xclAIEPutCmd(&cmd);
+  }
+}
+
+void
+Aied::registerGraph(graph_type *graph)
+{
+  mGraphs.push_back(graph);
+}
+
+void
+Aied::deregisterGraph(graph_type *graph)
+{
+  mGraphs.erase(std::remove(mGraphs.begin(), mGraphs.end(), graph), mGraphs.end());
+}
+}

--- a/src/runtime_src/core/edge/user/aie/aied.cpp
+++ b/src/runtime_src/core/edge/user/aie/aied.cpp
@@ -15,8 +15,8 @@
  * under the License.
  */
 
-#include <stdio.h>
-#include <errno.h>
+#include <cstdio>
+#include <cerrno>
 #include <unistd.h>
 #include <sstream>
 #include <iostream>
@@ -29,14 +29,9 @@
 
 namespace zynqaie {
 
-Aied::Aied(std::shared_ptr<xrt_core::device> device): mCoreDevice(std::move(device))
+Aied::Aied(xrt_core::device* device): mCoreDevice(device)
 {
   mPollingThread = std::thread(&Aied::pollAIE, this);
-}
-
-Aied::~Aied()
-{
-
 }
 
 void 
@@ -45,6 +40,7 @@ Aied::pollAIE()
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(mCoreDevice->get_device_handle());
   xclAIECmd cmd;
 
+  /* Ever running thread */
   while (1) {
     /* Calling XRT interface to wait for commands */
     if (drv->xclAIEGetCmd(&cmd) != 0) {
@@ -76,13 +72,13 @@ Aied::pollAIE()
 }
 
 void
-Aied::registerGraph(graph_type *graph)
+Aied::registerGraph(const graph_type *graph)
 {
   mGraphs.push_back(graph);
 }
 
 void
-Aied::deregisterGraph(graph_type *graph)
+Aied::deregisterGraph(const graph_type *graph)
 {
   mGraphs.erase(std::remove(mGraphs.begin(), mGraphs.end(), graph), mGraphs.end());
 }

--- a/src/runtime_src/core/edge/user/aie/aied.h
+++ b/src/runtime_src/core/edge/user/aie/aied.h
@@ -34,16 +34,15 @@ namespace zynqaie {
 class Aied
 {
 public:
-  Aied(std::shared_ptr<xrt_core::device> device);
-  ~Aied();
-  void registerGraph(graph_type *graph);
-  void deregisterGraph(graph_type *graph);
+  Aied(xrt_core::device* device);
+  void registerGraph(const graph_type *graph);
+  void deregisterGraph(const graph_type *graph);
 
 private:
   void pollAIE();
   std::thread mPollingThread;
-  std::shared_ptr<xrt_core::device> mCoreDevice;
-  std::vector<graph_type*> mGraphs;
+  xrt_core::device *mCoreDevice;
+  std::vector<const graph_type*> mGraphs;
 };
 } // end namespace
 

--- a/src/runtime_src/core/edge/user/aie/aied.h
+++ b/src/runtime_src/core/edge/user/aie/aied.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Himanshu Choudhary <hchoudha@xilinx.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef AIE_D_H
+#define AIE_D_H
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <thread>
+#include "core/common/device.h"
+#include "core/edge/user/aie/graph.h"
+
+/*
+ * It receives commands from zocl and dispatches back the output.
+ * One typical command is get graph status.
+ */
+namespace zynqaie {
+
+class Aied
+{
+public:
+  Aied(std::shared_ptr<xrt_core::device> device);
+  ~Aied();
+  void registerGraph(graph_type *graph);
+  void deregisterGraph(graph_type *graph);
+
+private:
+  void pollAIE();
+  std::thread mPollingThread;
+  std::shared_ptr<xrt_core::device> mCoreDevice;
+  std::vector<graph_type*> mGraphs;
+};
+} // end namespace
+
+#endif

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -96,14 +96,14 @@ graph_type::
 
 std::string
 graph_type::
-getname()
+getname() const
 {
   return name;
 }
 
 unsigned short
 graph_type::
-getstatus()
+getstatus() const
 {
   return static_cast<unsigned short>(state);
 }

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -80,11 +80,32 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t, const std::strin
 
     state = graph_state::reset;
     startTime = 0;
+#ifndef __AIESIM__
+    drv->getAied()->registerGraph(this);
+#endif
 }
 
 graph_type::
 ~graph_type()
 {
+#ifndef __AIESIM__
+    auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+    drv->getAied()->deregisterGraph(this);
+#endif
+}
+
+std::string
+graph_type::
+getname()
+{
+  return name;
+}
+
+unsigned short
+graph_type::
+getstatus()
+{
+  return static_cast<unsigned short>(state);
 }
 
 void

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -67,10 +67,10 @@ public:
     resume();
 
     std::string
-    getname();
+    getname() const;
 
     unsigned short
-    getstatus();
+    getstatus() const;
 
     void
     end();

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -66,6 +66,12 @@ public:
     void
     resume();
 
+    std::string
+    getname();
+
+    unsigned short
+    getstatus();
+
     void
     end();
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -182,6 +182,7 @@ initialize_query_table()
   emplace_sysfs_get<query::mem_topology_raw>          ("mem_topology");
   emplace_sysfs_get<query::ip_layout_raw>             ("ip_layout");
   emplace_sysfs_get<query::aie_metadata>              ("aie_metadata");
+  emplace_sysfs_get<query::graph_status>              ("graph_status");
   emplace_sysfs_get<query::memstat>                   ("memstat");
   emplace_sysfs_get<query::memstat_raw>               ("memstat_raw");
   emplace_sysfs_get<query::error>                     ("error");

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -724,10 +724,9 @@ int
 shim::
 xclAIEGetCmd(xclAIECmd *cmd)
 {
-  int ret;
   drm_zocl_aie_cmd scmd;
 
-  ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_GETCMD, &scmd);
+  int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_GETCMD, &scmd);
 
   if (!ret) {
     cmd->opcode = scmd.opcode;
@@ -742,15 +741,12 @@ int
 shim::
 xclAIEPutCmd(xclAIECmd *cmd)
 {
-  int ret;
   drm_zocl_aie_cmd scmd;
 
   scmd.opcode = cmd->opcode;
   scmd.size = cmd->size;
   snprintf(scmd.info, cmd->size, "%s",cmd->info);
-  ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_PUTCMD, &scmd);
-
-  return ret;
+  return ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_PUTCMD, &scmd);
 }
 
 int
@@ -1470,7 +1466,7 @@ registerAieArray()
 {
   delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
-  aied = std::make_unique<zynqaie::Aied>(mCoreDevice);
+  aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
 }
 
 bool

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -722,6 +722,39 @@ xclSKGetCmd(xclSKCmd *cmd)
 
 int
 shim::
+xclAIEGetCmd(xclAIECmd *cmd)
+{
+  int ret;
+  drm_zocl_aie_cmd scmd;
+
+  ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_GETCMD, &scmd);
+
+  if (!ret) {
+    cmd->opcode = scmd.opcode;
+    cmd->size = scmd.size;
+    snprintf(cmd->info, scmd.size, "%s", scmd.info);
+  }
+
+  return ret;
+}
+
+int
+shim::
+xclAIEPutCmd(xclAIECmd *cmd)
+{
+  int ret;
+  drm_zocl_aie_cmd scmd;
+
+  scmd.opcode = cmd->opcode;
+  scmd.size = cmd->size;
+  snprintf(scmd.info, cmd->size, "%s",cmd->info);
+  ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_PUTCMD, &scmd);
+
+  return ret;
+}
+
+int
+shim::
 xclSKCreate(unsigned int boHandle, uint32_t cu_idx)
 {
   int ret;
@@ -1424,12 +1457,20 @@ getAieArray()
   return aieArray.get();
 }
 
+zynqaie::Aied*
+shim::
+getAied()
+{
+  return aied.get();
+}
+
 void
 shim::
 registerAieArray()
 {
   delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
+  aied = std::make_unique<zynqaie::Aied>(mCoreDevice);
 }
 
 bool
@@ -1845,6 +1886,24 @@ xclSKGetCmd(xclDeviceHandle handle, xclSKCmd *cmd)
   if (!drv)
     return -EINVAL;
   return drv->xclSKGetCmd(cmd);
+}
+
+int
+xclAIEGetCmd(xclDeviceHandle handle, xclAIECmd *cmd)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  if (!drv)
+    return -EINVAL;
+  return drv->xclAIEGetCmd(cmd);
+}
+
+int
+xclAIEPutCmd(xclDeviceHandle handle, xclAIECmd *cmd)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  if (!drv)
+    return -EINVAL;
+  return drv->xclAIEPutCmd(cmd);
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -37,6 +37,7 @@
 
 #ifdef XRT_ENABLE_AIE
 #include "core/edge/user/aie/aie.h"
+#include "core/edge/user/aie/aied.h"
 #endif
 
 namespace ZYNQ {
@@ -83,6 +84,9 @@ public:
   int xclSKGetCmd(xclSKCmd *cmd);
   int xclSKCreate(unsigned int boHandle, uint32_t cu_idx);
   int xclSKReport(uint32_t cu_idx, xrt_scu_state state);
+
+  int xclAIEGetCmd(xclAIECmd *cmd);
+  int xclAIEPutCmd(xclAIECmd *cmd);
 
   double xclGetDeviceClockFreqMHz();
 
@@ -132,6 +136,7 @@ public:
 
 #ifdef XRT_ENABLE_AIE
   zynqaie::Aie* getAieArray();
+  zynqaie::Aied* getAied();
   int getBOInfo(drm_zocl_info_bo &info);
   void registerAieArray();
   bool isAieRegistered();
@@ -163,6 +168,7 @@ private:
 
 #ifdef XRT_ENABLE_AIE
   std::unique_ptr<zynqaie::Aie> aieArray;
+  std::unique_ptr<zynqaie::Aied> aied;
 #endif
 };
 

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -29,14 +29,29 @@ const uint32_t major = 1;
 const uint32_t minor = 0;
 const uint32_t patch = 0;
 
+inline std::string
+graph_status_to_string(int status) {
+  switch(status)
+  {
+    case 0: return std::string("stop");
+    case 1: return std::string("reset");
+    case 2: return std::string("running");
+    case 3: return std::string("suspend");
+    case 4: return std::string("end");
+    default: return std::string("idle");
+  }
+}
+
 boost::property_tree::ptree
 populate_aie(const xrt_core::device * device, const std::string& desc)
 {
   boost::property_tree::ptree pt;
   std::string aie_data;
+  std::vector<std::string> graph_status;
   pt.put("description", desc);
   boost::property_tree::ptree graph_array;
   boost::property_tree::ptree _pt;
+  boost::property_tree::ptree _gh_status;
 
   try {
     aie_data = xrt_core::device_query<qr::aie_metadata>(device);
@@ -45,6 +60,15 @@ populate_aie(const xrt_core::device * device, const std::string& desc)
   } catch (const std::exception& ex){
     pt.put("error_msg", ex.what());
     return pt;
+  }
+
+  try {
+    graph_status = xrt_core::device_query<qr::graph_status>(device);
+    std::stringstream ss;
+    std::copy(graph_status.begin(), graph_status.end(), std::ostream_iterator<std::string>(ss));
+    boost::property_tree::read_json(ss, _gh_status);
+  } catch (const std::exception& ex){
+    pt.put("error_msg", ex.what());
   }
 
   try {
@@ -138,6 +162,7 @@ populate_aie(const xrt_core::device * device, const std::string& desc)
       boost::property_tree::ptree tile_array;
       igraph.put("id", ograph.get<std::string>("id"));
       igraph.put("name", ograph.get<std::string>("name"));
+      igraph.put("status",graph_status_to_string(_gh_status.get<int>("graphs." + ograph.get<std::string>("name"), -1)));
       auto row_it = gr.second.get_child("core_rows").begin();
       auto memcol_it = gr.second.get_child("iteration_memory_columns").begin();
       auto memrow_it = gr.second.get_child("iteration_memory_rows").begin();
@@ -255,8 +280,9 @@ ReportAie::writeReport(const xrt_core::device * _pDevice,
   try {
     for (auto& gr: _pt.get_child("aie_metadata.graphs")) {
       boost::property_tree::ptree& graph = gr.second;
-      _output << boost::format("  GRAPH[%2d] Name:%2s\n") % graph.get<std::string>("id")
-           % graph.get<std::string>("name");
+      _output << boost::format("  GRAPH[%2d] %-10s: %s\n") % graph.get<std::string>("id")
+           % "Name" % graph.get<std::string>("name");
+      _output << boost::format("            %-10s: %s\n") % "Status" % graph.get<std::string>("status");
       _output << boost::format("    SNo.  %-20s%-30s%-30s\n") % "Core [C:R]"
            % "Iteration_Memory [C:R]" % "Iteration_Memory_Addresses";
       int count = 0;

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -29,16 +29,24 @@ const uint32_t major = 1;
 const uint32_t minor = 0;
 const uint32_t patch = 0;
 
+enum graph_state {   
+  STOP = 0,
+  RESET = 1,
+  RUNNING = 2,
+  SUSPEND = 3,
+  END = 4
+};
+
 inline std::string
 graph_status_to_string(int status) {
   switch(status)
   {
-    case 0: return std::string("stop");
-    case 1: return std::string("reset");
-    case 2: return std::string("running");
-    case 3: return std::string("suspend");
-    case 4: return std::string("end");
-    default: return std::string("idle");
+    case STOP:    return std::string("stop");
+    case RESET:   return std::string("reset");
+    case RUNNING: return std::string("running");
+    case SUSPEND: return std::string("suspend");
+    case END:     return std::string("end");
+    default:      return std::string("idle");
   }
 }
 


### PR DESCRIPTION
- Create thread at xclbin load which waits in zocl to get command from zocl and pass information back to zocl.
- Added 2 ioctl to get command and put result.
- Added read only sysfs node to get graph status.
- Added Graph status info in xbutil2 ReportAie

```
$ xbutil2 examine -r aie | more
Aie
  Aie_Metadata
  GRAPH[ 0] Name      : g
            Status    : running
    SNo.  Core [C:R]          Iteration_Memory [C:R]        Iteration_Memory_Addresses    
    [ 0]   1:0                 1:1                           24708                         
    [ 1]   2:0                 2:1                           24708         

$ xbutil2 examine -r aie -f JSON-2020.2 | more
{
    "schema_version": {
        "schema": "JSON-2020.2",
        "creation_date": "Thu Mar 11 18:20:04 2038 GMT"
    },
    "devices": [
        {
            "aie_metadata": {
                "description": "Aie_Metadata",
                "schema_version": {
                    "major": "1",
                    "minor": "0",
                    "patch": "0"
                },
                "graphs": [
                    {
                        "id": "0",
                        "name": "g",
                        "status": "running",
                        "tile": [
                            {
                                "column": "1",
                                "row": "0",
                                "memory_column": "1",
                                "memory_row": "1",
                                "memory_address": "24708"
                            },
                            {
                                "column": "2",
                                "row": "0",
                                "memory_column": "2",
                                "memory_row": "1",
                                "memory_address": "24708"
                            },
.....
```