### PR TITLE
xbutil2 reset aie array

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -24,6 +24,7 @@
 #include "scope_guard.h"
 #include "uuid.h"
 #include "core/include/xrt.h"
+#include "query_reset.h"
 
 // Please keep eternal include file dependencies to a minimum
 #include <cstdint>
@@ -264,7 +265,7 @@ public:
    */
   virtual void write(uint64_t, const void*, uint64_t) const {}
 
-  virtual void reset(const char*, const char*, const char*) const {}
+  virtual void reset(query::reset_type) const {}
 
   /**
    * open() - opens a device with an fd which can be used for non pcie read/write

--- a/src/runtime_src/core/common/query_reset.h
+++ b/src/runtime_src/core/common/query_reset.h
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef xrt_core_common_query_reset_h
+#define xrt_core_common_query_reset_h
+
+#include "query.h"
+#include <string>
+#include <vector>
+#include <sstream>
+#include <iomanip>
+#include <stdexcept>
+#include <boost/any.hpp>
+#include <boost/format.hpp>
+
+namespace xrt_core {
+
+namespace query {
+
+enum class reset_key {
+  hot = 1,
+  kernel = 2,
+  ert = 3,
+  ecc = 4,
+  soft_kernel = 5,
+  aie = 6
+};
+
+class reset_type {
+  reset_key mKey; 
+  std::string mName;
+  std::string mSubdev;
+  std::string mEntry;
+  std::string mWarning;
+  std::string mValue;
+
+public:
+  reset_type(reset_key key, std::string name, std::string subdev, std::string entry, std::string warning, std::string value)
+    : mKey(key), mName(name), mSubdev(subdev), mEntry(entry), mWarning(warning), mValue(value)
+  {
+  }
+
+  reset_key get_key() {
+    return mKey;
+  }
+
+  std::string get_name() {
+    return mName;
+  }
+
+  std::string get_subdev() {
+    return mSubdev;
+  }
+
+  std::string get_entry() {
+    return mEntry;
+  }
+
+  void set_subdev(std::string str) {
+    mSubdev = str;
+  }
+
+  void set_entry(std::string str) {
+    mEntry = str;
+  }
+
+  std::string get_warning() {
+    return mWarning;
+  }
+
+  std::string get_value() {
+    return mValue;
+  }
+};
+
+} // query
+
+} // xrt_core
+
+
+#endif

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -49,7 +49,8 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    return std::make_tuple(0,0,0);
+    //return std::make_tuple(0,0,0);
+    return {0,0,0};
   }
 
 };
@@ -62,8 +63,7 @@ struct board_name
   get(const xrt_core::device* device, key_type)
   {
     result_type deviceName("edge");
-    std::ifstream VBNV;
-    VBNV.open("/etc/xocl.txt");
+    std::ifstream VBNV("/etc/xocl.txt");
     if (VBNV.is_open()) {
       VBNV >> deviceName;
     }
@@ -295,16 +295,12 @@ reset(const char* subdev, const char* key, const char* value) const
   switch(val) {
   case 1:
     throw error(-ENODEV, "Hot reset not supported");
-    break;
   case 2:
     throw error(-ENODEV, "OCL dynamic region reset not supported");
-    break;
   case 3:
     throw error(-ENODEV, "ERT reset not supported");
-    break;
   case 4:
     throw error(-ENODEV, "Soft Kernel reset not supported");
-    break;
   case 5:
     if (auto ret = xclResetAIEArray(get_device_handle()))
       throw error(ret, "fail to reset aie array");

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -42,6 +42,47 @@ get_edgedev(const xrt_core::device* device)
   return zynq_device::get_dev();
 }
 
+struct bdf 
+{
+  using result_type = query::pcie_bdf::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    return std::make_tuple(0,0,0);
+  }
+
+};
+
+struct board_name 
+{
+  using result_type = query::board_name::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    result_type deviceName("edge");
+    std::ifstream VBNV;
+    VBNV.open("/etc/xocl.txt");
+    if (VBNV.is_open()) {
+      VBNV >> deviceName;
+    }
+    VBNV.close();
+    return deviceName;
+  }
+};
+
+struct is_ready 
+{
+  using result_type = query::is_ready::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    return true;
+  }
+};
+
 struct devInfo
 {
   static boost::any
@@ -166,6 +207,14 @@ emplace_func0_get()
   query_tbl.emplace(k, std::make_unique<function0_get<QueryRequestType, Getter>>());
 }
 
+template <typename QueryRequestType, typename Getter>
+static void
+emplace_func0_request()
+{
+  auto k = QueryRequestType::key;
+  query_tbl.emplace(k, std::make_unique<function0_get<QueryRequestType, Getter>>());
+}
+
 static void
 initialize_query_table()
 {
@@ -185,6 +234,9 @@ initialize_query_table()
   emplace_sysfs_get<query::memstat>                   ("memstat");
   emplace_sysfs_get<query::memstat_raw>               ("memstat_raw");
   emplace_sysfs_get<query::error>                     ("error");
+  emplace_func0_request<query::pcie_bdf,                bdf>();
+  emplace_func0_request<query::board_name,              board_name>();
+  emplace_func0_request<query::is_ready,                is_ready>();
 }
 
 struct X { X() { initialize_query_table(); } };
@@ -231,6 +283,35 @@ device_linux::
 write(uint64_t offset, const void* buf, uint64_t len) const
 {
   throw error(-ENODEV, "write failed");
+}
+
+
+void 
+device_linux::
+reset(const char* subdev, const char* key, const char* value) const 
+{
+  int val = atoi(value);
+
+  switch(val) {
+  case 1:
+    throw error(-ENODEV, "Hot reset not supported");
+    break;
+  case 2:
+    throw error(-ENODEV, "OCL dynamic region reset not supported");
+    break;
+  case 3:
+    throw error(-ENODEV, "ERT reset not supported");
+    break;
+  case 4:
+    throw error(-ENODEV, "Soft Kernel reset not supported");
+    break;
+  case 5:
+    if (auto ret = xclResetAIEArray(get_device_handle()))
+      throw error(ret, "fail to reset aie array");
+    break;
+  default:
+    throw error(-ENODEV, "invalid argument");
+  }
 }
 
 } // xrt_core

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -49,7 +49,6 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    //return std::make_tuple(0,0,0);
     return {0,0,0};
   }
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -287,22 +287,21 @@ write(uint64_t offset, const void* buf, uint64_t len) const
 
 void 
 device_linux::
-reset(const char* subdev, const char* key, const char* value) const 
+reset(query::reset_type key) const 
 {
-  int val = atoi(value);
-
-  switch(val) {
-  case 1:
+  switch(key.get_key()) {
+  case query::reset_key::hot:
     throw error(-ENODEV, "Hot reset not supported");
-  case 2:
+  case query::reset_key::kernel:
     throw error(-ENODEV, "OCL dynamic region reset not supported");
-  case 3:
+  case query::reset_key::ert:
     throw error(-ENODEV, "ERT reset not supported");
-  case 4:
+  case query::reset_key::ecc:
     throw error(-ENODEV, "Soft Kernel reset not supported");
-  case 5:
-    if (auto ret = xclResetAIEArray(get_device_handle()))
-      throw error(ret, "fail to reset aie array");
+  case query::reset_key::aie:
+    /* Commented till xrt shift to aie v2 driver */
+    //if (auto ret = xclResetAIEArray(get_device_handle()))
+    //  throw error(ret, "fail to reset aie array");
     break;
   default:
     throw error(-ENODEV, "invalid argument");

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -34,7 +34,7 @@ public:
 
   virtual void read(uint64_t addr, void* buf, uint64_t len) const;
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
-  virtual void reset(const char*, const char*, const char*) const;
+  virtual void reset(const query::reset_type) const;
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -34,6 +34,7 @@ public:
 
   virtual void read(uint64_t addr, void* buf, uint64_t len) const;
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
+  virtual void reset(const char*, const char*, const char*) const;
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -427,10 +427,10 @@ write(uint64_t offset, const void* buf, uint64_t len) const
 
 void
 device_linux::
-reset(const char* subdev, const char* key, const char* value) const
+reset(query::reset_type key) const 
 {
   std::string err;
-  pcidev::get_dev(get_device_id(), false)->sysfs_put(subdev, key, err, value);
+  pcidev::get_dev(get_device_id(), false)->sysfs_put(key.get_subdev(), key.get_entry(), err, key.get_value());
   if (!err.empty())
     throw error("reset failed");
 }

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -36,7 +36,7 @@ public:
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
   virtual int  open(const std::string& subdev, int flag) const;
   virtual void close(int dev_handle) const;
-  virtual void reset(const char*, const char*, const char*) const;
+  virtual void reset(const query::reset_type) const;
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -606,7 +606,8 @@ static const std::map<std::string, reset_type> reset_map = {
     { "kernel", reset_type::kernel },
     { "ert", reset_type::ert },
     { "ecc", reset_type::ecc },
-    { "soft_kernel", reset_type::soft_kernel }
+    { "soft_kernel", reset_type::soft_kernel },
+    { "aie", reset_type::aie }
   };
 
 XBUtilities::reset_type

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -601,17 +601,17 @@ XBUtilities::check_p2p_config(const std::shared_ptr<xrt_core::device>& _dev, std
   return static_cast<int>(p2p_config::disabled);
 }
 
-static const std::map<std::string, reset_type> reset_map = {
-    { "hot", reset_type::hot },
-    { "kernel", reset_type::kernel },
-    { "ert", reset_type::ert },
-    { "ecc", reset_type::ecc },
-    { "soft_kernel", reset_type::soft_kernel },
-    { "aie", reset_type::aie }
+static const std::map<std::string, xrt_core::query::reset_type> reset_map = {
+    { "hot", xrt_core::query::reset_type(xrt_core::query::reset_key::hot, "HOT Reset", "", "mgmt_reset", "Please make sure xocl driver is unloaded.", "1") },
+    { "kernel", xrt_core::query::reset_type(xrt_core::query::reset_key::kernel, "KERNEL Reset", "", "mgmt_reset", "Please make sure no application is currently running.", "2") },
+    { "ert", xrt_core::query::reset_type(xrt_core::query::reset_key::ert, "ERT Reset", "", "mgmt_reset", "", "3") },
+    { "ecc", xrt_core::query::reset_type(xrt_core::query::reset_key::ecc, "ECC Reset", "", "ecc_reset", "", "4") },
+    { "soft_kernel", xrt_core::query::reset_type(xrt_core::query::reset_key::soft_kernel, "SOFT KERNEL Reset", "", "mgmt_reset", "", "5") },
+    { "aie", xrt_core::query::reset_type(xrt_core::query::reset_key::aie, "AIE Reset", "", "mgmt_reset", "", "6") }
   };
 
-XBUtilities::reset_type
-XBUtilities::str_to_enum_reset(const std::string& str)
+xrt_core::query::reset_type
+XBUtilities::str_to_reset_obj(const std::string& str)
 {
   auto it = reset_map.find(str);
   if (it != reset_map.end())

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -45,7 +45,8 @@ namespace XBUtilities {
     kernel,
     ert,
     ecc,
-    soft_kernel
+    soft_kernel,
+    aie
   };
 
   /**

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -40,15 +40,6 @@ namespace XBUtilities {
     MT_UNKNOWN, 
   } MessageType;
 
-  enum class reset_type {
-    hot,
-    kernel,
-    ert,
-    ecc,
-    soft_kernel,
-    aie
-  };
-
   /**
    * Enables / Disables verbosity
    * 
@@ -129,7 +120,7 @@ namespace XBUtilities {
 
   int check_p2p_config(const std::shared_ptr<xrt_core::device>& _dev, std::string &err);
 
-  reset_type str_to_enum_reset(const std::string& str);
+  xrt_core::query::reset_type str_to_reset_obj(const std::string& str);
 
   /**
    * string_to_UUID(): convert a string to hyphen formatted UUID

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -30,35 +30,24 @@ namespace po = boost::program_options;
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 static void
-pretty_print_action_list(xrt_core::device_collection& deviceCollection, XBU::reset_type reset)
+pretty_print_action_list(xrt_core::device_collection& deviceCollection, xrt_core::query::reset_type reset)
 {
-  if(reset == XBU::reset_type::hot)
-    std::cout << "Performing 'hot' reset on " << std::endl;
-  else if(reset == XBU::reset_type::aie) 
-    std::cout << "Performing 'aie' reset on " << std::endl;
-  
+  std::cout << "Performing '" << reset.get_name() << "' on " << std::endl;
   for(const auto & device: deviceCollection) {
       std::cout << boost::format("  -[%s]\n") % 
         xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
   }
 
-  if(reset == XBU::reset_type::hot)
-    std::cout << "WARNING: Please make sure xocl driver is unloaded." << std::endl;
-  std::cout << std::endl; 
+  if (!reset.get_warning().empty())
+    std::cout << "WARNING: " << reset.get_warning() << std::endl;
 }
 
 static void
-reset_device(std::shared_ptr<xrt_core::device> dev, XBU::reset_type reset)
+reset_device(std::shared_ptr<xrt_core::device> dev, xrt_core::query::reset_type reset)
 {
-  if(reset == XBU::reset_type::hot) {
-    dev->reset("", "mgmt_reset", "1");
-    std::cout << boost::format("Successfully reset Device[%s]\n") 
-      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
-  } else if(reset == XBU::reset_type::aie) {
-    dev->reset("", "mgmt_reset", "5");
-    std::cout << boost::format("Successfully reset Device[%s]\n") 
-      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
-  }
+  dev->reset(reset);
+  std::cout << boost::format("Successfully reset Device[%s]\n") 
+    % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
 }
 
 SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary)
@@ -71,6 +60,16 @@ SubCmdReset::SubCmdReset(bool _isHidden, bool _isDepricated, bool _isPreliminary
   setIsHidden(_isHidden);
   setIsDeprecated(_isDepricated);
   setIsPreliminary(_isPreliminary);
+}
+
+void
+supported(std::string resetType) {
+  std::vector<std::string> vec { "hot", "aie" };
+  std::vector<std::string>::iterator it;
+  it = std::find (vec.begin(), vec.end(), resetType); 
+  if (it == vec.end()) {
+    throw xrt_core::error(-ENODEV, "reset not supported");
+  }
 }
 
 void
@@ -87,7 +86,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   po::options_description commonOptions("Common Options");
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
-    ("type,r", boost::program_options::value<decltype(resetType)>(&resetType), "The type of reset to perform. Types resets available:\n"
+    ("type,r", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
                                                                        "  hot          - Hot reset (default)\n"
                                                                        "  aie          - Reset Aie array\n"
                                                                        /*"  kernel       - Kernel communication links\n"*/
@@ -132,7 +131,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
     deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
 
   XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection);
-  XBU::reset_type type = XBU::str_to_enum_reset(resetType);
+  xrt_core::query::reset_type type = XBU::str_to_reset_obj(resetType);
   pretty_print_action_list(deviceCollection, type);
 
   // Ask user for permission

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -34,6 +34,8 @@ pretty_print_action_list(xrt_core::device_collection& deviceCollection, XBU::res
 {
   if(reset == XBU::reset_type::hot)
     std::cout << "Performing 'hot' reset on " << std::endl;
+  else if(reset == XBU::reset_type::aie) 
+    std::cout << "Performing 'aie' reset on " << std::endl;
   
   for(const auto & device: deviceCollection) {
       std::cout << boost::format("  -[%s]\n") % 
@@ -50,6 +52,10 @@ reset_device(std::shared_ptr<xrt_core::device> dev, XBU::reset_type reset)
 {
   if(reset == XBU::reset_type::hot) {
     dev->reset("", "mgmt_reset", "1");
+    std::cout << boost::format("Successfully reset Device[%s]\n") 
+      % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
+  } else if(reset == XBU::reset_type::aie) {
+    dev->reset("", "mgmt_reset", "5");
     std::cout << boost::format("Successfully reset Device[%s]\n") 
       % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
   }
@@ -83,6 +89,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("type,r", boost::program_options::value<decltype(resetType)>(&resetType), "The type of reset to perform. Types resets available:\n"
                                                                        "  hot          - Hot reset (default)\n"
+                                                                       "  aie          - Reset Aie array\n"
                                                                        /*"  kernel       - Kernel communication links\n"*/
                                                                        /*"  scheduler    - Scheduler\n"*/
                                                                        /*"  clear-fabric - Clears the accleration fabric with the\n"*/


### PR DESCRIPTION
```
$ xbutil2 reset -h    
                                                                                                                                                                  
DESCRIPTION: Resets the given device.

USAGE: xbutil reset [--help] [-d arg] [-r arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  
                       A value of 'all' (default) indicates that every found device 
                       should be examined.
  -r, --type         - The type of reset to perform. Types resets available:
                         hot          - Hot reset (default)
                         aie          - Reset Aie array

  --help             - Help to use this sub-command


$ xbutil2 reset -r aie
Performing 'aie' reset on 
  -[0000:00:00.0]

Are you sure you wish to proceed? [Y/n]: y
Successfully reset Device[0000:00:00.0]
