### PR TITLE
AIEV2 driver support

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -232,7 +232,7 @@ if [[ $opt == 1 ]]; then
 	# I know this is dirty as it messes up the source directory with build artifacts but this is the
 	# quickest way to enable native zocl build in Travis CI environment for aarch64
 	ZOCL_SRC=`readlink -f ../../src/runtime_src/core/edge/drm/zocl`
-	make -C $ZOCL_SRC
+	make -C $ZOCL_SRC EXTRA_CFLAGS=-D__NONE_PETALINUX__
     fi
   fi
   cd $BUILDDIR

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -47,7 +47,8 @@ zocl-y := \
 	zocl_kds.o \
 	cu.o \
 	zocl_generic_cu.o \
-	zocl_error.o
+	zocl_error.o \
+	zocl_aie.o
 
 obj-m	+= zocl.o
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
@@ -19,5 +19,30 @@ struct zocl_aie {
 	u32		uid;		/* Imiage identifier loaded */
 };
 
+#ifdef __NONE_PETALINUX__
+
+struct aie_partition_req {
+	__u32 partition_id;
+	__u32 uid;
+	__u64 meta_data;
+	__u32 flag;
+};
+
+static inline struct device *
+aie_partition_request(struct aie_partition_req *req)
+{
+	return NULL;
+}
+
+static inline int
+aie_partition_get_fd(struct device *aie_dev)
+{
+	return -EINVAL;
+
+}
+
+static inline void aie_partition_release(struct device *dev) {}
+
+#endif
 
 #endif /* _ZOCL_AIE_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu <yliu@xilinx.com>
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#ifndef _ZOCL_AIE_H_
+#define _ZOCL_AIE_H_
+
+
+struct zocl_aie {
+	struct device	*aie_dev;	/* AI engine partition device */
+	u32		partition_id;	/* Partition ID */
+	u32		uid;		/* Imiage identifier loaded */
+};
+
+
+#endif /* _ZOCL_AIE_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -214,6 +214,9 @@ void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size,
 		int count, uint32_t bank);
 void zocl_init_mem(struct drm_zocl_dev *zdev, struct mem_topology *mtopo);
 void zocl_clear_mem(struct drm_zocl_dev *zdev);
+int zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf);
+void zocl_destroy_aie(struct drm_zocl_dev *zdev);
+int zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data);
 
 int zocl_inject_error(struct drm_zocl_dev *zdev, void *data,
 		struct drm_file *filp);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
@@ -49,4 +49,6 @@ int zocl_ctx_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
 int zocl_error_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
+int zocl_aie_fd_ioctl(struct drm_device *dev, void *data,
+		struct drm_file *filp);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -110,6 +110,7 @@ struct drm_zocl_dev {
 	unsigned int		 num_mem;
 	struct zocl_mem		*mem;
 	struct mutex		 mm_lock;
+	struct mutex		 aie_lock;
 
 	struct list_head	 ctx_list;
 
@@ -145,6 +146,7 @@ struct drm_zocl_dev {
 	int			 ksize;
 	char			*kernels;
 	struct zocl_error	zdev_error;
+	struct zocl_aie		*aie;
 };
 
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -17,7 +17,9 @@
 #include "xrt_xclbin.h"
 #include "xclbin.h"
 
+#ifndef __NONE_PETALINUX__
 #include <linux/xlnx-ai-engine.h>
+#endif
 
 int
 zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data)

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * A GEM style (optionally CMA backed) device manager for ZynQ based
+ * OpenCL accelerators.
+ *
+ * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors:
+ *    Larry Liu <yliu@xilinc.com>
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#include "zocl_drv.h"
+#include "zocl_aie.h"
+#include "xrt_xclbin.h"
+#include "xclbin.h"
+
+#include <linux/xlnx-ai-engine.h>
+
+int
+zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data)
+{
+	struct drm_zocl_aie_fd *args = data;
+	int fd;
+	int rval = 0;
+
+	mutex_lock(&zdev->aie_lock);
+
+	if (!zdev->aie) {
+		DRM_ERROR("AIE image is not loaded.\n");
+		rval = -ENODEV;
+		goto done;
+	}
+
+	if (!zdev->aie->aie_dev) {
+		DRM_ERROR("No available AIE partition.\n");
+		rval = -ENODEV;
+		goto done;
+	}
+
+	if (zdev->aie->partition_id != args->partition_id) {
+		DRM_ERROR("AIE partition %d does not exist.\n",
+		    args->partition_id);
+		rval = -ENODEV;
+		goto done;
+	}
+
+	fd = aie_partition_get_fd(zdev->aie->aie_dev);
+	if (fd < 0) {
+		DRM_ERROR("Get AIE partition %d fd: %d\n",
+		    args->partition_id, fd);
+		rval = fd;
+		goto done;
+	}
+
+	args->fd = fd;
+
+done:
+	mutex_unlock(&zdev->aie_lock);
+
+	return rval;
+}
+
+int
+zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf)
+{
+	uint64_t offset;
+	uint64_t size;
+	struct aie_partition_req req;
+	int rval;
+
+	rval = xrt_xclbin_section_info(axlf, AIE_METADATA, &offset, &size);
+	if (rval)
+		return rval;
+
+	mutex_lock(&zdev->aie_lock);
+
+	if (zdev->aie) {
+		DRM_ERROR("AIE already created.\n");
+		rval = -EAGAIN;
+		goto fail_aie;
+	}
+
+	zdev->aie = vzalloc(sizeof (struct zocl_aie));
+
+	/* TODO figure out the partition id and uid from xclbin or PDI */
+	req.partition_id = 1;
+	req.uid = 0;
+	zdev->aie->aie_dev = aie_partition_request(&req);
+
+	if (IS_ERR(zdev->aie->aie_dev)) {
+		rval = PTR_ERR(zdev->aie->aie_dev);
+		DRM_ERROR("Request AIE partition %d, %d\n",
+		    req.partition_id, rval);
+		goto fail_part;
+	}
+
+	zdev->aie->partition_id = req.partition_id;
+	zdev->aie->uid = req.uid;
+	mutex_unlock(&zdev->aie_lock);
+
+	return 0;
+
+fail_part:
+	vfree(zdev->aie);
+	zdev->aie = NULL;
+
+fail_aie:
+	mutex_unlock(&zdev->aie_lock);
+
+	return rval;
+}
+
+void
+zocl_destroy_aie(struct drm_zocl_dev *zdev)
+{
+	mutex_lock(&zdev->aie_lock);
+
+	if (!zdev->aie) {
+		mutex_unlock(&zdev->aie_lock);
+		return;
+	}
+
+	if (zdev->aie->aie_dev)
+		aie_partition_release(zdev->aie->aie_dev);
+
+	vfree(zdev->aie);
+	zdev->aie = NULL;
+	mutex_unlock(&zdev->aie_lock);
+}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -3,7 +3,7 @@
  * A GEM style (optionally CMA backed) device manager for ZynQ based
  * OpenCL accelerators.
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Larry Liu <yliu@xilinc.com>

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -140,6 +140,16 @@ zocl_error_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		return -EACCES;
 
 	ret = zocl_inject_error(zdev, data, filp);
+	return ret;
+}
 
+int
+zocl_aie_fd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+{
+	struct drm_zocl_aie *args = data;
+	struct drm_zocl_dev *zdev = ZOCL_GET_ZDEV(dev);
+	int ret = 0;
+
+	ret = zocl_aie_request_part_fd(zdev, args);
 	return ret;
 }

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -117,6 +117,8 @@ enum drm_zocl_ops {
 	DRM_ZOCL_CTX,
 	/* Error injection */
 	DRM_ZOCL_ERROR_INJECT,
+	/* Request/Release AIE partition */
+	DRM_ZOCL_AIE_FD,
 	DRM_ZOCL_NUM_IOCTLS
 };
 
@@ -290,6 +292,12 @@ struct drm_zocl_ctx {
 	// unused, in future it would return context id
 	uint32_t handle;
 	enum drm_zocl_ctx_code op;
+};
+
+struct drm_zocl_aie_fd {
+	uint32_t partition_id;
+	uint32_t uid;
+	int fd;
 };
 
 /**
@@ -482,4 +490,6 @@ struct drm_zocl_error_inject {
                                        DRM_ZOCL_CTX, struct drm_zocl_ctx)
 #define DRM_IOCTL_ZOCL_ERROR_INJECT    DRM_IOWR(DRM_COMMAND_BASE + \
                                        DRM_ZOCL_ERROR_INJECT, struct drm_zocl_error_inject)
+#define DRM_IOCTL_ZOCL_AIE_FD          DRM_IOWR(DRM_COMMAND_BASE + \
+                                       DRM_ZOCL_AIE_FD, struct drm_zocl_aie_fd)
 #endif

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -92,8 +92,8 @@ graph_type::
 reset()
 {
     for (auto& tile : tiles) {
-      auto pos = aieArray->getTilePos(tile.col, tile.row);
-      XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+      XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+      XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::reset;
@@ -105,9 +105,13 @@ get_timestamp()
 {
     /* TODO just use the first tile to get the timestamp? */
     auto& tile = tiles.at(0);
-    auto pos = aieArray->getTilePos(tile.col, tile.row);
+    XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
 
-    uint64_t timeStamp = XAieTile_CoreReadTimer(&(aieArray->tileArray.at(pos)));
+    uint64_t timeStamp;
+    AieRC rc = XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &timeStamp);
+    if (rc != XAIE_OK)
+        throw xrt_core::error(-EINVAL, "Fail to read timestamp for Graph '" + name);
+
     return timeStamp;
 }
 
@@ -121,13 +125,13 @@ run()
     /* Record a snapshot of graph start time */
     if (!tiles.empty()) {
         auto& tile = tiles.at(0);
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        startTime = XAieTile_CoreReadTimer(&(aieArray->tileArray.at(pos)));
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &startTime);
     }
 
     for (auto& tile : tiles) {
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_ENABLE, XAIE_DISABLE);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_CoreEnable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::running;
@@ -141,20 +145,20 @@ run(int iterations)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is already running or has ended");
 
     for (auto& tile : tiles) {
-        auto pos = aieArray->getTilePos(tile.itr_mem_col, tile.itr_mem_row);
-        XAieTile_DmWriteWord(&(aieArray->tileArray.at(pos)), tile.itr_mem_addr, iterations);
+        XAie_LocType memTile = XAie_TileLoc(tile.itr_mem_col, tile.itr_mem_row);
+        XAie_DataMemWrWord(aieArray->getDevInst(), memTile, tile.itr_mem_addr, iterations);
     }
 
     /* Record a snapshot of graph start time */
     if (!tiles.empty()) {
         auto& tile = tiles.at(0);
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        startTime = XAieTile_CoreReadTimer(&(aieArray->tileArray.at(pos)));
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &startTime);
     }
 
     for (auto& tile : tiles) {
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_ENABLE, XAIE_DISABLE);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_CoreEnable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::running;
@@ -183,8 +187,9 @@ wait_done(int timeout_ms)
                 done = 1;
                 continue;
             }
-            auto pos = aieArray->getTilePos(tile.col, tile.row);
-            done = XAieTile_CoreReadStatusDone(&(aieArray->tileArray.at(pos)));
+
+            XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+            XAie_CoreReadDoneBit(aieArray->getDevInst(), coreTile, &done);
             if (!done)
                 break;
         }
@@ -192,10 +197,11 @@ wait_done(int timeout_ms)
         if (done) {
             state = graph_state::stop;
             for (auto& tile : tiles) {
-                auto pos = aieArray->getTilePos(tile.col, tile.row);
                 if (tile.is_trigger)
                     continue;
-                XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+
+                XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+                XAie_CoreDisable(aieArray->getDevInst(), coreTile);
             }
             return;
         }
@@ -219,13 +225,13 @@ wait()
         if (tile.is_trigger)
             continue;
 
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
         while (1) {
-            if (XAieTile_CoreWaitStatus(&(aieArray->tileArray.at(pos)), 0, XAIETILE_CORE_STATUS_DONE) == XAIETILE_CORE_STATUS_DONE)
+            if (XAie_CoreWaitForDone(aieArray->getDevInst(), coreTile, 0) == XAIE_OK)
                 break;
         }
 
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::stop;
@@ -241,16 +247,20 @@ wait(uint64_t cycle)
     // Adjust the cycle-timeout value
     if (!tiles.empty()) {
         auto& tile = tiles.at(0);
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        uint64_t elapsed_time = XAieTile_CoreReadTimer(&(aieArray->tileArray.at(pos))) - startTime;
+
+        uint64_t elapsed_time;
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &elapsed_time);
+        elapsed_time -= startTime;
+
         if (cycle > elapsed_time)
-            XAieTile_CoreWaitCycles(&(aieArray->tileArray.at(pos)), (cycle - elapsed_time));
+            XAie_WaitCycles(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, (cycle - elapsed_time));
     }
 
     for (auto& tile : tiles)
     {
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::suspend;
@@ -264,8 +274,8 @@ suspend()
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running, cannot suspend");
 
     for (auto& tile : tiles) {
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::suspend;
@@ -280,19 +290,21 @@ resume()
 
     if (!tiles.empty()) {
         auto& tile = tiles.at(0);
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
-        startTime = XAieTile_CoreReadTimer(&(aieArray->tileArray.at(pos)));
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &startTime);
     }
 
     for (auto& tile : tiles) {
-        auto pos = aieArray->getTilePos(tile.col, tile.row);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
 
         /*
          * We only resume the core that is not in done status.
          * XAIE_ENABLE will clear Core_Done status bit.
          */
-        if (!XAieTile_CoreReadStatusDone(&(aieArray->tileArray.at(pos))))
-            XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_ENABLE, XAIE_DISABLE);
+        uint8_t done;
+        XAie_CoreReadDoneBit(aieArray->getDevInst(), coreTile, &done);
+        if (!done)
+            XAie_CoreEnable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::running;
@@ -314,18 +326,18 @@ end()
             continue;
 
         /* Set sync buf to trigger the end procedure */
-        auto pos = aieArray->getTilePos(tile.itr_mem_col, tile.itr_mem_row);
-        XAieTile_DmWriteWord(&(aieArray->tileArray.at(pos)), tile.itr_mem_addr - 4, (u32)1);
+        XAie_LocType memTile = XAie_TileLoc(tile.itr_mem_col, tile.itr_mem_row);
+        XAie_DataMemWrWord(aieArray->getDevInst(), memTile, tile.itr_mem_addr - 4, (u32)1);
 
-        pos = aieArray->getTilePos(tile.col, tile.row);
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_ENABLE, XAIE_DISABLE);
+        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+        XAie_CoreEnable(aieArray->getDevInst(), coreTile);
 
         while (1) {
-            if (XAieTile_CoreWaitStatus(&(aieArray->tileArray.at(pos)), 0, XAIETILE_CORE_STATUS_DONE) == XAIETILE_CORE_STATUS_DONE)
+            if (XAie_CoreWaitForDone(aieArray->getDevInst(), coreTile, 0) == XAIE_OK)
                 break;
         }
 
-        XAieTile_CoreControl(&(aieArray->tileArray.at(pos)), XAIE_DISABLE, XAIE_DISABLE);
+        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
     state = graph_state::end;
@@ -343,10 +355,9 @@ end(uint64_t cycle)
         wait(cycle);
 
     for (auto& tile : tiles) {
-        auto pos = aieArray->getTilePos(tile.itr_mem_col, tile.itr_mem_row);
-
         /* Set sync buf to trigger the end procedure */
-        XAieTile_DmWriteWord(&(aieArray->tileArray.at(pos)), tile.itr_mem_addr - 4, (u32)1);
+        XAie_LocType memTile = XAie_TileLoc(tile.itr_mem_col, tile.itr_mem_row);
+        XAie_DataMemWrWord(aieArray->getDevInst(), memTile, tile.itr_mem_addr - 4, (u32)1);
     }
 
     state = graph_state::end;
@@ -382,44 +393,45 @@ update_rtp(const std::string& port, const char* buffer, size_t size)
             throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': updating connected sync RTP '" + port + "' is not supported");
     }
 
-    auto selector_pos = aieArray->getTilePos(rtp->selector_col, rtp->selector_row);
-    auto selector_tile = &(aieArray->tileArray.at(selector_pos));
-
     /* Don't acquire selector lock for async RTP while graph is not running */
     bool need_lock = rtp->require_lock && (
         rtp->is_async && state == graph_state::running ||
         !rtp->is_async
 	);
 
+    XAie_LocType selector_tile = XAie_TileLoc(rtp->selector_col, rtp->selector_row);
+    XAie_Lock selector_lock = XAie_LockInit(rtp->selector_lock_id, (rtp->is_async ? 0xFF : ACQ_WRITE));
+
     if (need_lock) {
-        uint8_t rc = XAieTile_LockAcquire(selector_tile, rtp->selector_lock_id, (rtp->is_async ? 0xFF : ACQ_WRITE), LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't update graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
     }
 
-    uint32_t selector = XAieTile_DmReadWord(selector_tile, rtp->selector_addr);
+    uint32_t selector;
+    XAie_DataMemRdWord(aieArray->getDevInst(), selector_tile, rtp->selector_addr, &selector);
 
     selector = 1 - selector;
 
-    int update_pos;
+    XAie_LocType update_tile;
     uint16_t lock_id;
     uint64_t start_addr;
     if (selector == 1) {
         /* update pong buffer */
-        update_pos = aieArray->getTilePos(rtp->pong_col, rtp->pong_row);
+        update_tile = XAie_TileLoc(rtp->pong_col, rtp->pong_row);
         lock_id = rtp->pong_lock_id;
         start_addr = rtp->pong_addr;
     } else {
         /* update ping buffer */
-        update_pos = aieArray->getTilePos(rtp->ping_col, rtp->ping_row);
+        update_tile = XAie_TileLoc(rtp->ping_col, rtp->ping_row);
         lock_id = rtp->ping_lock_id;
         start_addr = rtp->ping_addr;
     }
 
-    XAieGbl_Tile *update_tile = &(aieArray->tileArray.at(update_pos));
+    XAie_Lock update_lock = XAie_LockInit(lock_id, (rtp->is_async ? 0xFF : ACQ_WRITE));
     if (need_lock) {
-        uint8_t rc = XAieTile_LockAcquire(update_tile, lock_id, (rtp->is_async ? 0XFF : ACQ_WRITE), LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't update graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
     }
 
@@ -428,26 +440,28 @@ update_rtp(const std::string& port, const char* buffer, size_t size)
     int i;
 
     for (i = 0; i < iterations; ++i) {
-        XAieTile_DmWriteWord(update_tile, start_addr, ((const uint32_t *)buffer)[i]);
+        XAie_DataMemWrWord(aieArray->getDevInst(), update_tile, start_addr, ((const uint32_t *)buffer)[i]);
         start_addr += 4;
     }
     if (remain) {
         uint32_t rdata = 0;
         memcpy(&rdata, &((const uint32_t *)buffer)[i], remain);
-        XAieTile_DmWriteWord(update_tile, start_addr, rdata);
+        XAie_DataMemWrWord(aieArray->getDevInst(), update_tile, start_addr, rdata);
     }
 
     /* update selector */
-    XAieTile_DmWriteWord(selector_tile, rtp->selector_addr, selector);
+    XAie_DataMemWrWord(aieArray->getDevInst(), selector_tile, rtp->selector_addr, selector);
 
     if (rtp->require_lock) {
         /* release lock, need to release lock even graph is not running */
-        uint8_t rc = XAieTile_LockRelease(selector_tile, rtp->selector_lock_id, REL_READ, LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        selector_lock = XAie_LockInit(rtp->selector_lock_id, REL_READ);
+        uint8_t rc = XAie_LockRelease(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't update graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
 
-        rc = XAieTile_LockRelease(update_tile, lock_id, REL_READ, LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        update_lock = XAie_LockInit(lock_id, REL_READ);
+        rc = XAie_LockRelease(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't update graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
     }
 }
@@ -472,47 +486,49 @@ read_rtp(const std::string& port, char* buffer, size_t size)
     if (rtp->is_connected)
       throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': reading connected RTP port '" + port + "' is not supported");
 
-    auto selector_pos = aieArray->getTilePos(rtp->selector_col, rtp->selector_row);
-    auto selector_tile = &(aieArray->tileArray.at(selector_pos));
-
     /* Don't acquire selector lock for async RTP while graph is not running */
     bool need_lock = rtp->require_lock && (
         rtp->is_async && state == graph_state::running ||
         !rtp->is_async
         );
 
+    XAie_LocType selector_tile = XAie_TileLoc(rtp->selector_col, rtp->selector_row);
+    XAie_Lock selector_lock = XAie_LockInit(rtp->selector_lock_id, ACQ_READ);
+
     if (need_lock) {
-        uint8_t rc = XAieTile_LockAcquire(selector_tile, rtp->selector_lock_id, ACQ_READ, LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't read graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
     }
 
-    uint32_t selector = XAieTile_DmReadWord(selector_tile, rtp->selector_addr);
+    uint32_t selector;
+    XAie_DataMemRdWord(aieArray->getDevInst(), selector_tile, rtp->selector_addr, &selector);
 
-    int update_pos;
+    XAie_LocType update_tile;
     uint16_t lock_id;
     uint64_t start_addr;
     if (selector == 1) {
         /* update pong buffer */
-        update_pos = aieArray->getTilePos(rtp->pong_col, rtp->pong_row);
+        update_tile = XAie_TileLoc(rtp->pong_col, rtp->pong_row);
         lock_id = rtp->pong_lock_id;
         start_addr = rtp->pong_addr;
     } else {
         /* update ping buffer */
-        update_pos = aieArray->getTilePos(rtp->ping_col, rtp->ping_row);
+        update_tile = XAie_TileLoc(rtp->ping_col, rtp->ping_row);
         lock_id = rtp->ping_lock_id;
         start_addr = rtp->ping_addr;
     }
 
-    XAieGbl_Tile *update_tile = &(aieArray->tileArray.at(update_pos));
+    XAie_Lock update_lock = XAie_LockInit(lock_id, ACQ_READ);
     if (need_lock) {
-        uint8_t rc = XAieTile_LockAcquire(update_tile, lock_id, ACQ_READ, LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't read graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
 
 	/* sync RTP release lock for write, async RTP relase lock for read */
-        rc = XAieTile_LockRelease(selector_tile, rtp->selector_lock_id, (rtp->is_async ? REL_READ : REL_WRITE), LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        selector_lock = XAie_LockInit(rtp->selector_lock_id, (rtp->is_async ? REL_READ : REL_WRITE));
+        rc = XAie_LockRelease(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't read graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
     }
 
@@ -521,29 +537,22 @@ read_rtp(const std::string& port, char* buffer, size_t size)
     int i;
 
     for (i = 0; i < iterations; ++i) {
-        ((uint32_t *)buffer)[i] = XAieTile_DmReadWord(update_tile, start_addr);
+        XAie_DataMemRdWord(aieArray->getDevInst(), update_tile, start_addr, (u32*)&(((u32*)buffer)[i]));
         start_addr += 4;
     }
     if (remain) {
-        uint32_t rdata = XAieTile_DmReadWord(update_tile, start_addr);
+        uint32_t rdata;
+        XAie_DataMemRdWord(aieArray->getDevInst(), update_tile, start_addr, ((u32*)&rdata));
         memcpy(&((uint32_t *)buffer)[i], &rdata, remain);
     }
 
     if (need_lock) {
         /* release lock */
-        uint8_t rc = XAieTile_LockRelease(update_tile, lock_id, (rtp->is_async ? REL_READ : REL_WRITE), LOCK_TIMEOUT);
-        if (rc != XAIETILE_LOCK_ACQ_SUCCESS)
+        update_lock = XAie_LockInit(lock_id, (rtp->is_async ? REL_READ : REL_WRITE));
+        AieRC rc = XAie_LockRelease(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
+        if (rc != XAIE_OK)
             throw xrt_core::error(-EIO, "Can't read graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
     }
-}
-
-void
-graph_type::
-event_cb(struct XAieGbl *aie_inst, XAie_LocType Loc, u8 module, u8 event, void *arg)
-{
-#ifndef __AIESIM__
-    xrt_core::message::send(xrt_core::message::severity_level::XRT_NOTICE, "XRT", "AIE EVENT: module %d, event %d",  module, event);
-#endif
 }
 
 } // zynqaie
@@ -686,13 +695,12 @@ xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
   auto aieArray = getAieArray();
 #endif
 
-  auto paddr = xrtBOAddress(bohdl);
   auto bosize = xrtBOSize(bohdl);
 
   if (offset + size > bosize)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
 
-  aieArray->sync_bo(paddr + offset, gmioName, dir, size);
+  aieArray->sync_bo(bohdl, gmioName, dir, size, offset);
 }
 
 void
@@ -709,13 +717,12 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
   auto aieArray = getAieArray();
 #endif
 
-  auto paddr = xrtBOAddress(bohdl);
   auto bosize = xrtBOSize(bohdl);
 
   if (offset + size > bosize)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
 
-  aieArray->sync_bo_nb(paddr + offset, gmioName, dir, size);
+  aieArray->sync_bo_nb(bohdl, gmioName, dir, size, offset);
 }
 
 void
@@ -741,8 +748,6 @@ xclResetAieArray(xclDeviceHandle handle)
   /* Do a handle check */
   xrt_core::get_userpf_device(handle);
 
-  XAieLib_NpiAieArrayReset(XAIE_RESETENABLE);
-  XAieLib_NpiAieArrayReset(XAIE_RESETDISABLE);
 }
 
 } // api

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -501,23 +501,24 @@ xclLoadAxlf(const axlf *buffer)
   if (is_pr_platform && is_pr_enabled)
     flags = DRM_ZOCL_PLATFORM_PR;
 
-  drm_zocl_axlf axlf_obj = {
-    .za_xclbin_ptr = const_cast<axlf *>(buffer),
-    .za_flags = flags,
-    .za_ksize = 0,
-    .za_kernels = NULL,
-  };
+    drm_zocl_axlf axlf_obj = {
+      .za_xclbin_ptr = const_cast<axlf *>(buffer),
+      .za_flags = flags,
+      .za_ksize = 0,
+      .za_kernels = NULL,
+    };
 
-  auto kernels = xrt_core::xclbin::get_kernels(buffer);
-  /* Calculate size of kernels */
-  for (auto& kernel : kernels) {
+  if (!xrt_core::xclbin::is_pdi_only(buffer)) {
+    auto kernels = xrt_core::xclbin::get_kernels(buffer);
+    /* Calculate size of kernels */
+    for (auto& kernel : kernels) {
       axlf_obj.za_ksize += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
-  }
+    }
 
-  /* Check PCIe's shim.cpp for details of kernels binary */
-  std::vector<char> krnl_binary(axlf_obj.za_ksize);
-  axlf_obj.za_kernels = krnl_binary.data();
-  for (auto& kernel : kernels) {
+    /* Check PCIe's shim.cpp for details of kernels binary */
+    std::vector<char> krnl_binary(axlf_obj.za_ksize);
+    axlf_obj.za_kernels = krnl_binary.data();
+    for (auto& kernel : kernels) {
       auto krnl = reinterpret_cast<kernel_info *>(axlf_obj.za_kernels + off);
       if (kernel.name.size() > sizeof(krnl->name))
           return -EINVAL;
@@ -527,20 +528,21 @@ xclLoadAxlf(const axlf *buffer)
 
       int ai = 0;
       for (auto& arg : kernel.args) {
-          if (arg.name.size() > sizeof(krnl->args[ai].name))
-              return -EINVAL;
-          std::strncpy(krnl->args[ai].name, arg.name.c_str(), sizeof(krnl->args[ai].name)-1);
-          krnl->args[ai].name[sizeof(krnl->args[ai].name)-1] = '\0';
-          krnl->args[ai].offset = arg.offset;
-          krnl->args[ai].size   = arg.size;
-          // XCLBIN doesn't define argument direction yet and it only support
-          // input arguments.
-          // Driver use 1 for input argument and 2 for output.
-          // Let's refine this line later.
-          krnl->args[ai].dir    = 1;
-          ai++;
+        if (arg.name.size() > sizeof(krnl->args[ai].name))
+          return -EINVAL;
+        std::strncpy(krnl->args[ai].name, arg.name.c_str(), sizeof(krnl->args[ai].name)-1);
+        krnl->args[ai].name[sizeof(krnl->args[ai].name)-1] = '\0';
+        krnl->args[ai].offset = arg.offset;
+        krnl->args[ai].size   = arg.size;
+        // XCLBIN doesn't define argument direction yet and it only support
+        // input arguments.
+        // Driver use 1 for input argument and 2 for output.
+        // Let's refine this line later.
+        krnl->args[ai].dir    = 1;
+        ai++;
       }
       off += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
+    }
   }
 
   ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_READ_AXLF, &axlf_obj);
@@ -1431,6 +1433,17 @@ shim::
 isAieRegistered()
 {
   return (aieArray != nullptr);
+}
+
+int
+shim::
+getPartitionFd(drm_zocl_aie_fd &aiefd)
+{
+  int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_FD, &aiefd);
+  if (ret)
+    return -errno;
+
+  return 0;
 }
 #endif
 

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -135,6 +135,7 @@ public:
   int getBOInfo(drm_zocl_info_bo &info);
   void registerAieArray();
   bool isAieRegistered();
+  int getPartitionFd(drm_zocl_aie_fd &aiefd);
 #endif
 
 private:

--- a/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
@@ -115,14 +115,10 @@ namespace xdp {
           values.push_back(aie->endEvent);
           values.push_back(aie->resetEvent);
 
-          // TODO Comment out for now. Will need to move to use V2 API.
-          // auto pos = aieArray->getTilePos(aie->column, aie->row);
-          // auto tileInst = aieArray->tileArray.at(pos);
-      
           // Read counter value from device
-          // TODO: Below uses v1 of the AIE driver; eventually switch to v2
-          // auto counterValue = XAieTileCore_PerfCounterGet(&tileInst, aie->counterNumber);
-	  u32 counterValue = 0;
+          XAie_LocType tileLocation = XAie_TileLoc(aie->column, aie->row);
+          uint32_t counterValue;
+          XAie_PerfCounterGet(aieArray->getDevInst(), tileLocation, XAIE_CORE_MOD, aie->counterNumber, &counterValue);
           values.push_back(counterValue);
 
           // Get timestamp in milliseconds

--- a/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
@@ -115,13 +115,14 @@ namespace xdp {
           values.push_back(aie->endEvent);
           values.push_back(aie->resetEvent);
 
-          // Get tile instance from AIE array
-          auto pos = aieArray->getTilePos(aie->column, aie->row);
-          auto tileInst = aieArray->tileArray.at(pos);
+          // TODO Comment out for now. Will need to move to use V2 API.
+          // auto pos = aieArray->getTilePos(aie->column, aie->row);
+          // auto tileInst = aieArray->tileArray.at(pos);
       
           // Read counter value from device
           // TODO: Below uses v1 of the AIE driver; eventually switch to v2
-          auto counterValue = XAieTileCore_PerfCounterGet(&tileInst, aie->counterNumber);
+          // auto counterValue = XAieTileCore_PerfCounterGet(&tileInst, aie->counterNumber);
+	  u32 counterValue = 0;
           values.push_back(counterValue);
 
           // Get timestamp in milliseconds


### PR DESCRIPTION
This PR is to switch XRT Graph API to use AIE V2 driver. Major changes include
1) When loading xclbin, zocl will request an AIE partition dev
2) Provide an IOCTL to require AIE partition fd. 
    Any user process who wants to initialize AIE instance and call AIE driver user space API need to talk to zocl driver to require an fd
3) In libxrt_core, xrt will call AIE V2 driver API instead of calling AIE V1 API.

@pgschuey I temporarily comment out a few code in aie_plugin.cpp to get compiling through. Please make changes accordingly to use v2 API.
@mamin506 Please review. Especially the aie_pdi_only part. Hopefully, I won't break anything.
@stsoe Please review the code. This PR can not be merged for now. But once petalinux yocto ai-engien-driver recipe is moved to point to aiev2 repository, this PR needs to be merged ASAP to keep petalinux going. The pipeline will be failing until petalinux move to aiev2 recipe
@chvamshi-xilinx Once it merged, please help to submit the commit id to petalinux yocto xrt recipe ASAP.

Work to be done
xrtResetAIEArray will not work after moving to V2. This is will be my next PR
If do a rmmod zocl and insmod zocl, talking to AIE tile will cause SError. This will be my next PR.