### PR TITLE
Initial add of pybind11 wrappers for the native C++ API

### DIFF
--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -17,11 +17,6 @@ if (DEFINED ENV{XCL_EMULATION_MODE})
   message("=============== XRT_CORE_LIB=${XRT_CORE_LIBRARY}")
 endif()
 
-find_library(xrt_core_LIBRARY
-  NAMES ${XRT_CORE_LIBRARY}
-  HINTS "${XILINX_XRT}/lib")
-message("xrt_core_LIBRARY=${xrt_core_LIBRARY}")
-
 find_library(xrt_coreutil_LIBRARY
   NAMES xrt_coreutil
   HINTS "${XILINX_XRT}/lib")
@@ -41,5 +36,5 @@ endif (NOT WIN32)
 include_directories(${XILINX_XRT}/include)
 
 pybind11_add_module(pyxrt src/pyxrt.cpp)
-target_link_libraries(pyxrt PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(pyxrt PRIVATE ${xrt_coreutil_LIBRARY})
 target_link_libraries(pyxrt PRIVATE ${uuid_LIBRARY} pthread)

--- a/src/python/pybind11/CMakeLists.txt
+++ b/src/python/pybind11/CMakeLists.txt
@@ -1,0 +1,45 @@
+project(pyxrt)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
+
+find_package(pybind11 REQUIRED)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(XILINX_XRT $ENV{XILINX_XRT})
+set(XRT_CORE_LIBRARY xrt_core)
+set(MODE hw)
+
+if (DEFINED ENV{XCL_EMULATION_MODE})
+  set(MODE $ENV{XCL_EMULATION_MODE})
+  string(REPLACE "_" "" XCL_EMU_SUFFIX ${MODE})
+  set(XRT_CORE_LIBRARY xrt_${XCL_EMU_SUFFIX})
+  message("=============== XRT_CORE_LIB=${XRT_CORE_LIBRARY}")
+endif()
+
+find_library(xrt_core_LIBRARY
+  NAMES ${XRT_CORE_LIBRARY}
+  HINTS "${XILINX_XRT}/lib")
+message("xrt_core_LIBRARY=${xrt_core_LIBRARY}")
+
+find_library(xrt_coreutil_LIBRARY
+  NAMES xrt_coreutil
+  HINTS "${XILINX_XRT}/lib")
+message("xrt_coreutil_LIBRARY=${xrt_coreutil_LIBRARY}")
+
+find_library(xrt_xilinxopencl_LIBRARY
+  NAMES xilinxopencl
+  HINTS "${XILINX_XRT}/lib")
+message("xrt_xilinxopencl_LIBRARY=${xrt_xilinxopencl_LIBRARY}")
+
+if (NOT WIN32)
+find_library(uuid_LIBRARY
+  NAMES uuid)
+message("uuid_LIBRARY=${uuid_LIBRARY}")
+endif (NOT WIN32)
+
+include_directories(${XILINX_XRT}/include)
+
+pybind11_add_module(pyxrt src/pyxrt.cpp)
+target_link_libraries(pyxrt PRIVATE ${xrt_core_LIBRARY} ${xrt_coreutil_LIBRARY})
+target_link_libraries(pyxrt PRIVATE ${uuid_LIBRARY} pthread)

--- a/src/python/pybind11/README.md
+++ b/src/python/pybind11/README.md
@@ -22,7 +22,6 @@ https://github.com/Xilinx/XRT/tree/master/tests/xrt/02_simple
 ```python
 import pyxrt
 
-pyxrt.xclProbe()
 d = pyxrt.device(0)
 
 xclbin = './simple.xclbin'

--- a/src/python/pybind11/README.md
+++ b/src/python/pybind11/README.md
@@ -1,0 +1,44 @@
+# Python package for the XRT Native C++ API
+
+This python package can be used for binding the XRT Native C++ API into Python applications.  Installation of this 
+package uses the same build dependencies for XRT and can be installed by running the following steps: 
+
+```bash
+git clone https://github.com/Xilinx/XRT
+cd src/python/pybind11
+pip install .
+```
+
+After installation, the package can be accessed by simply running from Python:
+
+```python
+import pyxrt
+```
+
+The below example was run in a hardware emulation environment using the simple kernel that can be built at:
+https://github.com/Xilinx/XRT/tree/master/tests/xrt/02_simple
+
+
+```python
+import pyxrt
+
+pyxrt.xclProbe()
+d = pyxrt.device(0)
+
+xclbin = './simple.xclbin'
+uuid = d.load_xclbin(xclbin)
+
+simple = pyxrt.kernel(d, uuid.get(), "simple", False)
+
+bo0 = pyxrt.bo(d, 1024, pyxrt.XCL_BO_FLAGS_NONE, simple.group_id(0))
+bo1 = pyxrt.bo(d, 1024, pyxrt.XCL_BO_FLAGS_NONE, simple.group_id(1))
+
+bo0.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, 1024, 0)
+bo1.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE, 1024, 0)
+
+run = simple(*(bo0, bo1, 0x10))
+run.wait()
+
+bo0.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, 1024, 0)
+
+```

--- a/src/python/pybind11/setup.py
+++ b/src/python/pybind11/setup.py
@@ -1,0 +1,63 @@
+"""
+
+ Copyright (C) 2016-2020 Xilinx, Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License"). You may
+ not use this file except in compliance with the License. A copy of the
+ License is located at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+ under the License.
+
+"""
+
+import os
+import sys
+import platform
+import subprocess
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+        cmake_args += ['-DCMAKE_BUILD_TYPE=' + 'Release']
+        
+        build_args = ['--config', 'Release']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
+                                                               self.distribution.get_version())
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+            
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+
+
+setup(
+    name='pyxrt',
+    version='1.0.0',
+    author='Graham Schelle',
+    author_email='graham.schelle@xilinx.com',
+    description="Pybind11 package for Xilinx's XRT",
+    ext_modules=[CMakeExtension('pyxrt')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    zip_safe=False,
+)

--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -15,18 +15,10 @@
  */
 
 
-#include <iostream>
-#include <stdexcept>
-#include <string>
-#include <cstring>
-#include <tuple>
-#include <typeinfo>
-
 // XRT includes
 #include "experimental/xrt_device.h"
 #include "experimental/xrt_kernel.h"
 #include "experimental/xrt_bo.h"
-#include "xrt.h"
 
 // Pybind11 includes
 #include <pybind11/pybind11.h>
@@ -49,14 +41,6 @@ m.attr("XCL_BO_FLAGS_NONE") = py::int_(XCL_BO_FLAGS_NONE);
 py::enum_<xclBOSyncDirection>(m, "xclBOSyncDirection")
     .value("XCL_BO_SYNC_BO_TO_DEVICE", xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE)
     .value("XCL_BO_SYNC_BO_FROM_DEVICE", xclBOSyncDirection::XCL_BO_SYNC_BO_FROM_DEVICE);
-
-
-/*
- *
- * XRT:: Functions
- *
- */
-m.def("xclProbe", &xclProbe); 
 
 
 /*

--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2016-2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <cstring>
+#include <tuple>
+#include <typeinfo>
+
+// XRT includes
+#include "experimental/xrt_device.h"
+#include "experimental/xrt_kernel.h"
+#include "experimental/xrt_bo.h"
+#include "xrt.h"
+
+// Pybind11 includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(pyxrt, m) {
+m.doc() = "Pybind11 module for XRT";
+
+/*
+ *
+ * Constants and Enums
+ *
+ *
+ */
+m.attr("XCL_BO_FLAGS_NONE") = py::int_(XCL_BO_FLAGS_NONE);
+
+py::enum_<xclBOSyncDirection>(m, "xclBOSyncDirection")
+    .value("XCL_BO_SYNC_BO_TO_DEVICE", xclBOSyncDirection::XCL_BO_SYNC_BO_TO_DEVICE)
+    .value("XCL_BO_SYNC_BO_FROM_DEVICE", xclBOSyncDirection::XCL_BO_SYNC_BO_FROM_DEVICE);
+
+
+/*
+ *
+ * XRT:: Functions
+ *
+ */
+m.def("xclProbe", &xclProbe); 
+
+
+/*
+ *
+ * XRT:: UUID (needed since UUID classes passed outside of objects)
+ *
+ */
+py::class_<xrt::uuid>(m, "uuid")
+   .def(py::init<char *>())
+   .def("get",
+      [](xrt::uuid & u){
+        py::array_t<unsigned char> result = py::array_t<unsigned char>(16);
+        py::buffer_info bufinfo = result.request();
+        unsigned char* bufptr = (unsigned char*) bufinfo.ptr;
+        memcpy(bufptr,u.get(),16);
+        return result;
+     }
+    )
+    .def("to_string", &xrt::uuid::to_string)
+    ;
+
+
+/*
+ *
+ * XRT::Device
+ *
+ */
+py::class_<xrt::device>(m, "device")
+    .def(py::init<>())
+    .def(py::init<unsigned int>())
+    .def("load_xclbin",
+       [](xrt::device & d, const std::string& xclbin){
+	     return d.load_xclbin(xclbin);
+       }
+     )
+    .def("get_xclbin_uuid", &xrt::device::get_xclbin_uuid)
+    ;
+
+
+/*
+ *
+ * XRT::Kernel
+ *
+ */
+py::class_<xrt::run>(m, "run")
+   .def(py::init<>())
+   .def(py::init<const xrt::kernel &>()) 
+   .def("start", &xrt::run::start)
+   .def("set_arg", [](xrt::run & r, int i, xrt::bo & item){
+       r.set_arg(i, item);
+     })
+   .def("set_arg", [](xrt::run & r, int i, int & item){
+       r.set_arg<int>(i, item);
+     })  
+   .def("wait", [](xrt::run & r) {
+       r.wait();
+     })
+    .def("state", &xrt::run::state)
+    .def("add_callback", &xrt::run::add_callback)
+    ;
+
+py::class_<xrt::kernel>(m, "kernel")
+    .def(py::init([](xrt::device d, const py::array_t<unsigned char> u, const std::string & n, bool e){
+        return new xrt::kernel(d, (const unsigned char*) u.request().ptr, n, e);
+    }))
+  .def("__call__", [](xrt::kernel & k, py::args args) -> xrt::run {    
+	int i =0;
+	xrt::run r(k);
+	
+	for (auto item : args) {
+	  try 
+	    { r.set_arg(i, item.cast<xrt::bo>()); }
+	  catch (std::exception e) {  }
+	  
+	  try 
+	    { r.set_arg<int>(i, item.cast<int>()); }
+	  catch (std::exception e) {  }
+	  
+	  i++;
+	}
+	
+	r.start();
+	return r;
+    })
+    .def("group_id", &xrt::kernel::group_id)
+    .def("write_register", &xrt::kernel::write_register)
+    .def("read_register", &xrt::kernel::read_register)
+    ;
+
+
+/*
+ *
+ * XRT:: BO
+ *
+ */
+py::class_<xrt::bo>(m, "bo")
+    .def(py::init<xrt::device,size_t,xrt::buffer_flags,xrt::memory_group>())
+    .def("write", ([](xrt::bo &b, py::array_t<int> pyb, size_t seek)  {
+	  py::buffer_info info = pyb.request();
+	  int* pybptr = (int*) info.ptr;
+
+	  b.write(info.ptr, info.itemsize * info.size , 0);
+    }))
+    .def("read", ([](xrt::bo &b, size_t size, size_t skip) {
+	  int nitems = size/sizeof(int);
+	  py::array_t<int> result = py::array_t<int>(nitems);
+	  
+	  py::buffer_info bufinfo = result.request();
+	  int* bufptr = (int*) bufinfo.ptr;
+	  b.read(bufptr, size, skip);
+	  return result;
+     }))
+  .def("sync", ([](xrt::bo &b, xclBOSyncDirection dir, size_t size, size_t offset)  {	
+	b.sync(dir, size, offset);
+      }))
+    ;
+}


### PR DESCRIPTION
Initial add of pybind11 support for the C++ Native API.  This package can be built with
either cmake or pip install - see instructions in the README.  

A subset of the full API is included in the pull-request.  Currently the device, uuid, 
kernel, and bo classes are supported in order to run the simple designs in the test
folders.

Signed-off-by: Graham Schelle <graham.schelle@xilinx.com>