### PR TITLE
NSPR-8630 enable xrt support for U.2 raptor2.0 shell

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3370,11 +3370,11 @@ struct xocl_subdev_map {
 		.priv_data = &XOCL_BOARD_U25_USER_RAPTOR2,              \
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x6987, PCI_ANY_ID,					\
-		.vbnv = "xilinx_u2_xdma_2020_1",			\
+		.vbnv = "xilinx_u2",					\
 		.priv_data = &XOCL_BOARD_U2_MGMT_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x6988, PCI_ANY_ID,					\
-		.vbnv = "xilinx_u2_xdma_2020_1",			\
+		.vbnv = "xilinx_u2",					\
 		.priv_data = &XOCL_BOARD_U2_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -331,7 +331,6 @@ struct xocl_subdev_map {
 			}				\
 		})
 
-
 #define	XOCL_DEVINFO_FEATURE_ROM			\
 	{						\
 		XOCL_SUBDEV_FEATURE_ROM,		\
@@ -2568,6 +2567,29 @@ struct xocl_subdev_map {
 		XOCL_DEVINFO_XMC_USER,					\
 	 })
 
+#define RES_MGMT_U2_VSEC						\
+	((struct xocl_subdev_info []) {					\
+		XOCL_DEVINFO_FEATURE_ROM_MGMT_DYN,			\
+		XOCL_DEVINFO_FMGR,					\
+	 })
+
+#define XOCL_BOARD_U2_MGMT_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,		\
+		.subdev_info	= RES_MGMT_U2_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_MGMT_U2_VSEC),		\
+		.flash_type = FLASH_TYPE_SPI,				\
+		.sched_bin = "xilinx/sched.bin",			\
+	}
+
+#define XOCL_BOARD_U2_USER_RAPTOR2					\
+	(struct xocl_board_private){					\
+		.flags		= XOCL_DSAFLAG_DYNAMIC_IP,		\
+		.subdev_info	= RES_USER_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
+		.flash_type = FLASH_TYPE_SPI,				\
+	}
+
 #define XOCL_BOARD_U25_USER_RAPTOR2                                     \
 	(struct xocl_board_private){                                    \
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |                      \
@@ -3346,6 +3368,14 @@ struct xocl_subdev_map {
 	{ 0x10EE, 0x5051, PCI_ANY_ID,                                   \
 		.vbnv = "xilinx_u25",					\
 		.priv_data = &XOCL_BOARD_U25_USER_RAPTOR2,              \
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x6987, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u2_xdma_2020_1",			\
+		.priv_data = &XOCL_BOARD_U2_MGMT_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x6988, PCI_ANY_ID,					\
+		.vbnv = "xilinx_u2_xdma_2020_1",			\
+		.priv_data = &XOCL_BOARD_U2_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 }
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -280,6 +280,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_PLAT_1RP          0x1
 #define XOCL_VSEC_PLAT_2RP          0x2
 
+#define XOCL_VSEC_ALF_VSEC_ID       0x20
 
 #define XOCL_MAXNAMELEN	64
 
@@ -287,6 +288,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_XLAT_GPA_LOWER_REG_ADDR       0x18C
 #define XOCL_VSEC_XLAT_GPA_BASE_UPPER_REG_ADDR  0x190
 #define XOCL_VSEC_XLAT_GPA_LIMIT_UPPER_REG_ADDR 0x194
+#define XOCL_VSEC_XLAT_VSEC_ID                  0x40
 
 struct xocl_vsec_header {
 	u32		format;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2018-2020 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *
@@ -1306,7 +1306,7 @@ xocl_subdev_vsec_read32(xdev_handle_t xdev, int bar, u64 offset)
  * |------+-------+-------+-----|
  * |rsvd                        |
  * +----+-----------------------|
- *  ... next entry ...          
+ *  ... next entry ...
  */
 int
 xocl_subdev_vsec(xdev_handle_t xdev, u32 type,
@@ -1321,11 +1321,40 @@ xocl_subdev_vsec(xdev_handle_t xdev, u32 type,
 	u64 vsec_off;
 	bool found = false;
 	struct xocl_vsec_header *p_hdr;
+	uint16_t vsec_id = 0;
+	int offset_vsec = 0, nxt_offset = 0, ret = 0;
 
-	/* check vendor specific section */
-	cap = pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VNDR);
+	/*
+	 * 1. To detect the ALF VSEC capability:
+	 *	XRT should look for VSEC Capability with vsec_id = 0x0020.
+	 * 2. Similarly, for Address Translation/Pass through VSEC capability:
+	 *	XRT should look for VSEC Capability with vsec_id = 0x0040
+	 * 3. Check vendor specific section for vsec_id 0x20
+	 */
+	do {
+		nxt_offset = pci_find_next_ext_capability(pdev,
+						offset_vsec, PCI_EXT_CAP_ID_VNDR);
+		if (nxt_offset == 0)
+			break;
+
+		ret = pci_read_config_word(pdev, (nxt_offset + 4), &vsec_id);
+		if (ret != 0) {
+			xocl_err(&core->pdev->dev, "pci read failed for offset: 0x%x, err: %d",
+					 (nxt_offset + 4), ret);
+			offset = 0;
+			nxt_offset = 0;
+			break;
+		}
+
+		if (vsec_id == 0x20)
+			break;
+
+		offset_vsec = nxt_offset;
+	} while (nxt_offset != 0);
+
+	cap = nxt_offset;
 	if (!cap) {
-		xocl_info(&core->pdev->dev, "No Vendor Specific Capability.");
+		xocl_info(&core->pdev->dev, "No Vendor Specific Capability found.");
 		return -EINVAL;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1337,16 +1337,17 @@ xocl_subdev_vsec(xdev_handle_t xdev, u32 type,
 		if (nxt_offset == 0)
 			break;
 
-		ret = pci_read_config_word(pdev, (nxt_offset + 4), &vsec_id);
+		ret = pci_read_config_word(pdev, (nxt_offset + PCI_VNDR_HEADER),
+								   &vsec_id);
 		if (ret != 0) {
 			xocl_err(&core->pdev->dev, "pci read failed for offset: 0x%x, err: %d",
-					 (nxt_offset + 4), ret);
+					 (nxt_offset + PCI_VNDR_HEADER), ret);
 			offset = 0;
 			nxt_offset = 0;
 			break;
 		}
 
-		if (vsec_id == 0x20)
+		if (vsec_id == XOCL_VSEC_ALF_VSEC_ID)
 			break;
 
 		offset_vsec = nxt_offset;


### PR DESCRIPTION
Enabled XRT support for U.2 raptor shell.
XRT applications are tested with ert disabled as u2 shell
doesn't have ert support enabled at present.

Below tests are passed:
xbutil list
Hello world kernel test
Bandwidth kernel test

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>