### PR TITLE
NSPR-8172 monitor kernel clock shutdown status on U2 card

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -453,7 +453,6 @@ static void check_pcie_link_toggle(struct xclmgmt_dev *lro, int clear)
 	u32 sts;
 	int err;
 
-
 	err = xocl_iores_read32(lro, XOCL_SUBDEV_LEVEL_BLD,
 			IORES_PCIE_MON, 0x8, &sts);
 	if (err)
@@ -465,7 +464,6 @@ static void check_pcie_link_toggle(struct xclmgmt_dev *lro, int clear)
 	}
 
 	if (clear) {
-		
 		xocl_iores_write32(lro,XOCL_SUBDEV_LEVEL_BLD ,
 				IORES_PCIE_MON, 0, 1);
 
@@ -475,9 +473,6 @@ static void check_pcie_link_toggle(struct xclmgmt_dev *lro, int clear)
 		xocl_iores_write32(lro, XOCL_SUBDEV_LEVEL_BLD,
 				IORES_PCIE_MON, 0, 0);
 	}
-
-		
-
 }
 
 
@@ -493,6 +488,10 @@ static int health_check_cb(void *data)
 
 	(void) xocl_clock_status(lro, &latched);
 
+	/*
+	 * UCS doesn't exist on U2, and U2 CMC firmware uses different
+	 * methodology to report clock shutdown status.
+	 */
 	xocl_xmc_clock_status(lro, &latched);
 
 	check_sensor(lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -493,6 +493,8 @@ static int health_check_cb(void *data)
 
 	(void) xocl_clock_status(lro, &latched);
 
+	xocl_xmc_clock_status(lro, &latched);
+
 	check_sensor(lro);
 
 	/* Check PCIe Link Toggle */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -128,6 +128,7 @@
 #define	XMC_CLOCK_SCALING_POWER_THRESHOLD_MASK	0xFF
 #define	XMC_CLOCK_SCALING_CRIT_TEMP_THRESHOLD_REG	0x3C
 #define	XMC_CLOCK_SCALING_CRIT_TEMP_THRESHOLD_REG_MASK	0xFF
+#define	XMC_CLOCK_SCALING_CLOCK_STATUS_REG	0x38
 
 //Sensor IDs
 #define	SENSOR_12V_AUX0		0x03
@@ -431,6 +432,7 @@ static int xmc_access(struct platform_device *pdev, enum xocl_xmc_flags flags);
 static bool scaling_condition_check(struct xocl_xmc *xmc);
 static const struct file_operations xmc_fops;
 static bool is_sc_fixed(struct xocl_xmc *xmc);
+static void clock_status_check(struct platform_device *pdev, bool *latched);
 
 static void set_sensors_data(struct xocl_xmc *xmc, struct xcl_sensor *sensors)
 {
@@ -3411,6 +3413,7 @@ static struct xocl_mb_funcs xmc_ops = {
 	.stop			= stop_xmc,
 	.get_data		= xmc_get_data,
 	.xmc_access             = xmc_access,
+	.clock_status			= clock_status_check,
 };
 
 static void xmc_unload_board_info(struct xocl_xmc *xmc)
@@ -3875,6 +3878,26 @@ static int xmc_access(struct platform_device *pdev, enum xocl_xmc_flags flags)
 	return XOCL_DSA_IS_SMARTN(xdev) ?
 		smartnic_cmc_access(pdev, flags) :
 		raptor_cmc_access(pdev, flags);
+}
+
+static void clock_status_check(struct platform_device *pdev, bool *latched)
+{
+	struct xocl_xmc *xmc = platform_get_drvdata(pdev);
+	u32 cntrl;
+	u32 status = 0;
+
+	if (!xmc->sc_presence) {
+		//check if kernel clocks are stopped
+		status = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_CLOCK_STATUS_REG);
+		if (status & 0x1) {
+			xocl_err(&pdev->dev, "Critical temperature event, "
+					"kernel clocks have been stopped, run "
+					"'xbutil valiate -q' to continue. "
+					"See AR 73398 for more details.");
+			/* explicitly indicate reset should be latched */
+			*latched = true;
+		}
+	}
 }
 
 static void xmc_set_board_info(uint32_t *bdinfo_raw, uint32_t bd_info_sz,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -3887,7 +3887,12 @@ static void clock_status_check(struct platform_device *pdev, bool *latched)
 	u32 status = 0;
 
 	if (!xmc->sc_presence) {
-		//check if kernel clocks are stopped
+		/*
+		 * On U2, when board temp is above the critical threshold value for 0.5 sec
+		 * continuously, CMC firmware turns off the kernel clocks, and sets 0th bit in
+		 * XMC_CLOCK_SCALING_CLOCK_STATUS_REG to 1.
+		 * So, check if kernel clocks have been stopped.
+		 */
 		status = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_CLOCK_STATUS_REG);
 		if (status & 0x1) {
 			xocl_err(&pdev->dev, "Critical temperature event, "

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -793,6 +793,7 @@ struct xocl_mb_funcs {
 		u32 len);
 	int (*get_data)(struct platform_device *pdev, enum xcl_group_kind kind, void *buf);
 	int (*xmc_access)(struct platform_device *pdev, enum xocl_xmc_flags flags);
+	void (*clock_status)(struct platform_device *pdev, bool *latched);
 };
 
 #define	MB_DEV(xdev)		\
@@ -822,6 +823,9 @@ struct xocl_mb_funcs {
 	(MB_CB(xdev, xmc_access) ? MB_OPS(xdev)->xmc_access(MB_DEV(xdev), XOCL_XMC_FREEZE) : -ENODEV)
 #define xocl_xmc_free(xdev) 		\
 	(MB_CB(xdev, xmc_access) ? MB_OPS(xdev)->xmc_access(MB_DEV(xdev), XOCL_XMC_FREE) : -ENODEV)
+
+#define xocl_xmc_clock_status(xdev, latched)		\
+	(MB_CB(xdev, clock_status) ? MB_OPS(xdev)->clock_status(MB_DEV(xdev), latched) : -ENODEV)
 
 /* ERT FW callbacks */
 #define ERT_DEV(xdev)							\


### PR DESCRIPTION
Add support in xrt to monitor the clock shutdown status in U2 card

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>