### PR TITLE
qdma4: enable libqdma4 debugfs, misc. stmc fix

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/Makefile.in
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/Makefile.in
@@ -12,6 +12,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
+ccflags-y	+= -D_QDMA4_DEBUGFS_
 
 xocl_lib-y	:= ../lib/libxdma.o
 xocl_lib-y	+=  \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_debugfs_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_debugfs_queue.c
@@ -28,7 +28,7 @@
 #include "qdma_descq.h"
 #include "qdma_regs.h"
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #define DEBUGFS_QUEUE_DESC_SZ	(100)
 #define DEBUGFS_QUEUE_INFO_SZ	(256)
 #define DEBUGFS_QUEUE_CTXT_SZ	(24 * 1024)
@@ -373,7 +373,7 @@ static int create_cmpt_q_dbg_files(struct qdma_descq *descq,
  *****************************************************************************/
 static int q_dbg_file_open(struct inode *inode, struct file *fp)
 {
-	int dev_id = -1;
+	unsigned long dev_id = -1;
 	int qidx = -1;
 	struct dbgfs_q_priv *priv = NULL;
 	int rv = 0;
@@ -415,8 +415,10 @@ static int q_dbg_file_open(struct inode *inode, struct file *fp)
 	}
 
 	/* convert this string as hex integer */
-	rv = kstrtoint((const char *)dev_name, 16, &dev_id);
+	rv = kstrtoul((const char *)dev_name, 16, &dev_id);
 	if (rv < 0) {
+		pr_err("%s, kstrtoint failed for %s, Error:%d\n", __func__,
+			dev_dir->d_iname, rv);
 		rv = -ENODEV;
 		return rv;
 	}
@@ -594,10 +596,10 @@ static int qdbg_desc_read(unsigned long dev_hndl, unsigned long id, char **data,
 		return -ENOMEM;
 
 	if (type != DBGFS_DESC_TYPE_CMPT) {
-		len += qdma_queue_dump_desc(dev_hndl, id,
+		len += qdma4_queue_dump_desc(dev_hndl, id,
 				0, rngsz-1, buf + len, buflen - len);
 	} else {
-		len += qdma_queue_dump_cmpt(dev_hndl, id,
+		len += qdma4_queue_dump_cmpt(dev_hndl, id,
 				0, rngsz-1, buf + len, buflen - len);
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.h
@@ -179,7 +179,7 @@ struct qdma_descq {
 	u64 induce_err;
 	u64 ecc_err;
 #endif
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** debugfs queue index root */
 	struct dentry *dbgfs_qidx_root;
 	/** debugfs queue root */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.c
@@ -431,7 +431,7 @@ struct qdma_descq *qdma4_device_get_descq_by_id(struct xlnx_dma_dev *xdev,
 	return descq;
 }
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 struct qdma_descq *qdma_device_get_pair_descq_by_id(struct xlnx_dma_dev *xdev,
 			unsigned long idx, char *buf, int buflen, int init)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.h
@@ -114,7 +114,7 @@ long qdma4_device_get_id_from_descq(struct xlnx_dma_dev *xdev,
 struct qdma_descq *qdma4_device_get_descq_by_id(struct xlnx_dma_dev *xdev,
 			unsigned long idx, char *buf, int buflen, int init);
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 /*****************************************************************************/
 /**
  * qdma_device_get_pair_descq_by_id() - get the descq using the qid

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
@@ -39,7 +39,7 @@
 #include "qdma_intr.h"
 #include "qdma_resource_mgmt.h"
 #include "qdma_access_common.h"
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #include "qdma_debugfs_dev.h"
 #endif
 
@@ -1172,7 +1172,7 @@ int qdma4_device_open(const char *mod_name, struct qdma_dev_conf *conf,
 		dev_name(&pdev->dev), xdev->conf.bdf, pdev, xdev,
 		xdev->dev_cap.mm_channel_max, conf->qsets_max, conf->vf_max);
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** time to clean debugfs */
 	dbgfs_dev_init(xdev);
 #endif
@@ -1234,7 +1234,7 @@ int qdma4_device_close(struct pci_dev *pdev, unsigned long dev_hndl)
 
 	qdma4_device_offline(pdev, dev_hndl, XDEV_FLR_INACTIVE);
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** time to clean debugfs */
 	dbgfs_dev_exit(xdev);
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.h
@@ -32,7 +32,7 @@
 #include "libqdma4_export.h"
 #include "qdma_mbox.h"
 #include "qdma_access_errors.h"
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #include "qdma_debugfs.h"
 
 extern struct dentry *qdma_debugfs_root;
@@ -221,6 +221,15 @@ struct xlnx_dma_dev {
 	char mod_name[QDMA_DEV_NAME_MAXLEN];
 	/**< Board id this device belongs to*/
 	u32 dma_device_index;
+	/**< Keeping track of last updated descq
+	 * Used only in case of auto and intr aggr driver mode
+	 * This is required because HW might prematurely raise interrupt
+	 * without actual new entries in the aggr ring and we need to
+	 * provide some update to the sw_cidx of aggr ring so that
+	 * interrupt gets triggered again
+	 */
+	struct qdma_descq *prev_descq;
+
 	/**< DMA device configuration */
 	struct qdma_dev_conf conf;
 	/**< csr info */
@@ -284,7 +293,7 @@ struct xlnx_dma_dev {
 	u8 err_mon_cancel;
 	/**< error minitor work handler */
 	struct delayed_work err_mon;
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** debugfs device root */
 	struct dentry *dbgfs_dev_root;
 	/** debugfs queue root */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/qdma4.c
@@ -62,10 +62,9 @@ unsigned int qdma4_max_channel = 16;
 module_param(qdma4_max_channel, uint, 0644);
 MODULE_PARM_DESC(qdma4_max_channel, "Set number of channels for qdma, default is 16");
 
-static unsigned int qdma4_poll_mode;
-module_param(qdma4_poll_mode, uint, 0644);
-MODULE_PARM_DESC(poll_mode, "Set 1 for hw polling, default is 0 (interrupts)");
-
+static unsigned int qdma4_interrupt_mode = DIRECT_INTR_MODE;
+module_param(qdma4_interrupt_mode, uint, 0644);
+MODULE_PARM_DESC(interrupt_mode, "0:auto, 1:poll, 2:direct, 3:intr_ring, default is 2");
 
 struct dentry *qdma4_debugfs_root;
 
@@ -1926,11 +1925,10 @@ static int qdma4_probe(struct platform_device *pdev)
 	conf->bar_num_user = -1;
 	conf->bar_num_bypass = -1;
 	conf->no_mailbox = 1;
-	//conf->qdma_drv_mode = POLL_MODE;
 	conf->data_msix_qvec_max = 1;
 	conf->user_msix_qvec_max = 8;
 	conf->msix_qvec_max = 16;
-	conf->qdma_drv_mode = qdma4_poll_mode ? POLL_MODE : AUTO_MODE;
+	conf->qdma_drv_mode = qdma4_interrupt_mode;
 
 	conf->fp_user_isr_handler = qdma_isr;
 	conf->uld = (unsigned long)qdma;


### PR DESCRIPTION
- enable libqdma4 debugfs
- add polling of stmc context at ST queue closing to ensure qdma <-> stm reset is done
- temporarily change interrupt to be direct interrupt while debugging interrupt ring problems under load