### PR TITLE
qdma4: backport commit 3893 & 3965

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/Makefile.in
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/Makefile.in
@@ -12,6 +12,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
+ccflags-y	+= -D_QDMA4_DEBUGFS_
 
 xocl_lib-y	:= ../lib/libxdma.o
 xocl_lib-y	+=  \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/libqdma_export.c
@@ -39,7 +39,7 @@
 #include "qdma_mbox.h"
 #include "qdma_platform.h"
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #include "qdma_debugfs_queue.h"
 
 /** debugfs root */
@@ -482,7 +482,7 @@ int qdma4_device_capabilities_info(unsigned long dev_hndl,
 #ifndef __QDMA_VF__
 /*****************************************************************************/
 /**
- * qdma_config_reg_dump() - display a config registers in a string buffer
+ * qdma4_config_reg_dump() - display a config registers in a string buffer
  *
  * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
  * @param[in]	buflen:		length of the input buffer
@@ -698,7 +698,7 @@ int qdma4_queue_dump(unsigned long dev_hndl, unsigned long id, char *buf,
 
 /*****************************************************************************/
 /**
- * qdma_queue_dump_desc() - display a queue's descriptor ring from index start
+ * qdma4_queue_dump_desc() - display a queue's descriptor ring from index start
  *							~ end in a string buffer
  *
  * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
@@ -859,7 +859,7 @@ int qdma4_queue_remove(unsigned long dev_hndl, unsigned long id, char *buf,
 {
 	struct xlnx_dma_dev *xdev = (struct xlnx_dma_dev *)dev_hndl;
 	struct qdma_descq *descq;
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	struct qdma_descq *pair_descq;
 #endif
 	struct qdma_dev *qdev;
@@ -881,7 +881,7 @@ int qdma4_queue_remove(unsigned long dev_hndl, unsigned long id, char *buf,
 	}
 
 	descq = qdma4_device_get_descq_by_id(xdev, id, buf, buflen, 1);
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	pair_descq = qdma_device_get_pair_descq_by_id(xdev, id, buf, buflen, 1);
 #endif
 
@@ -915,7 +915,7 @@ int qdma4_queue_remove(unsigned long dev_hndl, unsigned long id, char *buf,
 		return -EINVAL;
 	}
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	if (pair_descq)
 		/** if pair_descq is not NULL, it means the queue
 		 * is in ENABLED state
@@ -1249,16 +1249,16 @@ static int is_usable_queue(struct xlnx_dma_dev *xdev, int qidx,
 		if (st && (refmask & Q_PRESENT_C2H_MASK)
 				&& (refmask & c2hq_chkmask)
 					 == Q_PRESENT_C2H_MASK) {
-			pr_err("Q_H2C: MM mode c2h q present.\n");
+			pr_debug("Q_H2C: MM mode c2h q present.\n");
 			goto q_reject; /* MM mode c2h q present*/
 		}
 		if (!st && (refmask & Q_PRESENT_C2H_MASK)
 				&& (refmask & c2hq_chkmask) == c2hq_chkmask) {
-			pr_err("Q_H2C: ST mode c2h q present.\n");
+			pr_debug("Q_H2C: ST mode c2h q present.\n");
 			goto q_reject; /* ST mode c2h q present*/
 		}
 		if (refmask & Q_PRESENT_H2C_MASK) {
-			pr_err("Q_H2C: h2c q already present.\n");
+			pr_debug("Q_H2C: h2c q already present.\n");
 			goto q_reject; /* h2c q already present */
 		}
 	} else {
@@ -1270,16 +1270,16 @@ static int is_usable_queue(struct xlnx_dma_dev *xdev, int qidx,
 		if (st && (refmask & Q_PRESENT_H2C_MASK)
 				&& (refmask & h2cq_chkmask)
 						== Q_PRESENT_H2C_MASK) {
-			pr_err("!Q_H2C: MM mode h2c q present.\n");
+			pr_debug("!Q_H2C: MM mode h2c q present.\n");
 			goto q_reject; /* MM mode h2c q present*/
 		}
 		if (!st && (refmask & Q_PRESENT_H2C_MASK)
 				&& (refmask & h2cq_chkmask) == h2cq_chkmask) {
-			pr_err("!Q_H2C: ST mode h2c q present.\n");
+			pr_debug("!Q_H2C: ST mode h2c q present.\n");
 			goto q_reject; /* ST mode h2c q present*/
 		}
 		if (refmask & Q_PRESENT_C2H_MASK) {
-			pr_err("!Q_H2C: c2h q already present.\n");
+			pr_debug("!Q_H2C: c2h q already present.\n");
 			goto q_reject; /* c2h q already present */
 		}
 	}
@@ -1309,7 +1309,7 @@ int qdma4_queue_add(unsigned long dev_hndl, struct qdma_queue_conf *qconf,
 	unsigned int qcnt;
 	struct qdma_descq *descq;
 	struct qdma_dev *qdev;
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	struct qdma_descq *pairq;
 #endif
 #ifdef __QDMA_VF__
@@ -1606,7 +1606,7 @@ int qdma4_queue_add(unsigned long dev_hndl, struct qdma_queue_conf *qconf,
 	descq->q_hndl = *qhndl;
 
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	if (qconf->q_type != Q_CMPT) {
 		if (qconf->q_type == Q_H2C)
 			pairq = qdev->c2h_descq + qconf->qidx;
@@ -2036,6 +2036,7 @@ int qdma4_intr_ring_dump(unsigned long dev_hndl, unsigned int vector_idx,
 	struct xlnx_dma_dev *xdev = (struct xlnx_dma_dev *)dev_hndl;
 	union qdma_intr_ring *ring_entry;
 	struct intr_coal_conf *coal_entry;
+	struct qdma_intr_cidx_reg_info *intr_cidx_info;
 	char *cur = buf;
 	char * const end = buf + buflen;
 	int counter = 0;
@@ -2095,7 +2096,17 @@ int qdma4_intr_ring_dump(unsigned long dev_hndl, unsigned int vector_idx,
 
 	/** get the intr entry based on vector index */
 	coal_entry = xdev->intr_coal_list + (vector_idx - xdev->dvec_start_idx);
-
+	intr_cidx_info = &coal_entry->intr_cidx_info;
+	cur += snprintf(cur, end - cur,
+			"intr_ring: msix[%d].vector=%d, msix[%d].entry=%d, "
+			"rngsize=%d, cidx = %d\n",
+			vector_idx, xdev->msix[vector_idx].vector, vector_idx,
+			xdev->msix[vector_idx].entry,
+			coal_entry->intr_rng_num_entries,
+			intr_cidx_info->sw_cidx);
+	if (cur >= end)
+		goto handle_truncation;
+	
 	/** make sure that intr ring entry indexes
 	 *  given are with in the range
 	 */
@@ -2696,7 +2707,7 @@ int libqdma4_init(unsigned int num_threads, void *debugfs_root)
 			       num_threads);
 		return ret;
 	}
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 
 	if (debugfs_root) {
 		qdma_debugfs_root = debugfs_root;
@@ -2722,7 +2733,7 @@ int libqdma4_init(unsigned int num_threads, void *debugfs_root)
  *****************************************************************************/
 void libqdma4_exit(void)
 {
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	if (qdma_debufs_cleanup)
 		qdma4_debugfs_exit(qdma_debugfs_root);
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_debugfs_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_debugfs_queue.c
@@ -28,7 +28,7 @@
 #include "qdma_descq.h"
 #include "qdma_regs.h"
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #define DEBUGFS_QUEUE_DESC_SZ	(100)
 #define DEBUGFS_QUEUE_INFO_SZ	(256)
 #define DEBUGFS_QUEUE_CTXT_SZ	(24 * 1024)
@@ -373,7 +373,7 @@ static int create_cmpt_q_dbg_files(struct qdma_descq *descq,
  *****************************************************************************/
 static int q_dbg_file_open(struct inode *inode, struct file *fp)
 {
-	int dev_id = -1;
+	unsigned long dev_id = -1;
 	int qidx = -1;
 	struct dbgfs_q_priv *priv = NULL;
 	int rv = 0;
@@ -415,8 +415,10 @@ static int q_dbg_file_open(struct inode *inode, struct file *fp)
 	}
 
 	/* convert this string as hex integer */
-	rv = kstrtoint((const char *)dev_name, 16, &dev_id);
+	rv = kstrtoul((const char *)dev_name, 16, &dev_id);
 	if (rv < 0) {
+		pr_err("%s, kstrtoint failed for %s, Error:%d\n", __func__,
+			dev_dir->d_iname, rv);
 		rv = -ENODEV;
 		return rv;
 	}
@@ -594,10 +596,10 @@ static int qdbg_desc_read(unsigned long dev_hndl, unsigned long id, char **data,
 		return -ENOMEM;
 
 	if (type != DBGFS_DESC_TYPE_CMPT) {
-		len += qdma_queue_dump_desc(dev_hndl, id,
+		len += qdma4_queue_dump_desc(dev_hndl, id,
 				0, rngsz-1, buf + len, buflen - len);
 	} else {
-		len += qdma_queue_dump_cmpt(dev_hndl, id,
+		len += qdma4_queue_dump_cmpt(dev_hndl, id,
 				0, rngsz-1, buf + len, buflen - len);
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.c
@@ -1406,7 +1406,10 @@ void qdma4_sgt_req_done(struct qdma_descq *descq, struct qdma_sgt_req_cb *cb,
 		}
 		cb->status = error;
 		cb->done = 1;
-		req->fp_done(req, cb->offset, error);
+		if (descq->conf.st && descq->conf.q_type == Q_C2H)
+			req->fp_done(req, req->count - cb->left, error);
+		else
+			req->fp_done(req, cb->offset, error);
 	} else {
 		pr_debug("req 0x%p, cb 0x%p, wake up.\n", req, cb);
 		cb->status = error;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_descq.h
@@ -179,7 +179,7 @@ struct qdma_descq {
 	u64 induce_err;
 	u64 ecc_err;
 #endif
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** debugfs queue index root */
 	struct dentry *dbgfs_qidx_root;
 	/** debugfs queue root */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.c
@@ -431,7 +431,7 @@ struct qdma_descq *qdma4_device_get_descq_by_id(struct xlnx_dma_dev *xdev,
 	return descq;
 }
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 struct qdma_descq *qdma_device_get_pair_descq_by_id(struct xlnx_dma_dev *xdev,
 			unsigned long idx, char *buf, int buflen, int init)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/qdma_device.h
@@ -114,7 +114,7 @@ long qdma4_device_get_id_from_descq(struct xlnx_dma_dev *xdev,
 struct qdma_descq *qdma4_device_get_descq_by_id(struct xlnx_dma_dev *xdev,
 			unsigned long idx, char *buf, int buflen, int init);
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 /*****************************************************************************/
 /**
  * qdma_device_get_pair_descq_by_id() - get the descq using the qid

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.c
@@ -39,7 +39,7 @@
 #include "qdma_intr.h"
 #include "qdma_resource_mgmt.h"
 #include "qdma_access_common.h"
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #include "qdma_debugfs_dev.h"
 #endif
 
@@ -1172,7 +1172,7 @@ int qdma4_device_open(const char *mod_name, struct qdma_dev_conf *conf,
 		dev_name(&pdev->dev), xdev->conf.bdf, pdev, xdev,
 		xdev->dev_cap.mm_channel_max, conf->qsets_max, conf->vf_max);
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** time to clean debugfs */
 	dbgfs_dev_init(xdev);
 #endif
@@ -1234,7 +1234,7 @@ int qdma4_device_close(struct pci_dev *pdev, unsigned long dev_hndl)
 
 	qdma4_device_offline(pdev, dev_hndl, XDEV_FLR_INACTIVE);
 
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** time to clean debugfs */
 	dbgfs_dev_exit(xdev);
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma4/xdev.h
@@ -32,7 +32,7 @@
 #include "libqdma4_export.h"
 #include "qdma_mbox.h"
 #include "qdma_access_errors.h"
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 #include "qdma_debugfs.h"
 
 extern struct dentry *qdma_debugfs_root;
@@ -221,6 +221,15 @@ struct xlnx_dma_dev {
 	char mod_name[QDMA_DEV_NAME_MAXLEN];
 	/**< Board id this device belongs to*/
 	u32 dma_device_index;
+	/**< Keeping track of last updated descq
+	 * Used only in case of auto and intr aggr driver mode
+	 * This is required because HW might prematurely raise interrupt
+	 * without actual new entries in the aggr ring and we need to
+	 * provide some update to the sw_cidx of aggr ring so that
+	 * interrupt gets triggered again
+	 */
+	struct qdma_descq *prev_descq;
+
 	/**< DMA device configuration */
 	struct qdma_dev_conf conf;
 	/**< csr info */
@@ -284,7 +293,7 @@ struct xlnx_dma_dev {
 	u8 err_mon_cancel;
 	/**< error minitor work handler */
 	struct delayed_work err_mon;
-#ifdef DEBUGFS
+#ifdef _QDMA4_DEBUGFS_
 	/** debugfs device root */
 	struct dentry *dbgfs_dev_root;
 	/** debugfs queue root */


### PR DESCRIPTION
#3893

    fix st c2h data_done count
    change some debug messages severity
    make sure # of bytes is returned especially for io_submit()

#3965

    enable libqdma4 debugfs
    add polling of stmc context at ST queue closing to ensure qdma <-> stm reset is done
    temporarily change interrupt to be direct interrupt while debugging interrupt ring problems under load
