### PR TITLE
xclbinutil : Updated IP_LAYOUT and PARTITION_METADATA section

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2020 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -108,6 +108,15 @@ SectionIPLayout::marshalToJSON(char* _pDataSection,
   XUtil::TRACE("");
   XUtil::TRACE("Extracting: IP_LAYOUT");
   XUtil::TRACE_BUF("Section Buffer", reinterpret_cast<const char*>(_pDataSection), _sectionSize);
+  if (_sectionSize == 0) {
+    XUtil::TRACE("IP_LAYOUT Section is empty.  Adding an empty entry.");
+    boost::property_tree::ptree iplayout;
+    iplayout.put("m_count", "0");
+    boost::property_tree::ptree ipData;
+    iplayout.add_child("m_ip_data",ipData);
+    _ptree.add_child("ip_layout", iplayout);
+    return;
+  }
 
   // Do we have enough room to overlay the header structure
   if (_sectionSize < sizeof(ip_layout)) {

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -551,7 +551,7 @@ SchemaTransformToPM_addressable_endpoint( const std::string _sEndPointName,
     // Determine if an older format was used 
     size_t dashCount = std::count(registerAbstraction.begin(), registerAbstraction.end(), '-');
     if (dashCount == 1) 
-      std::string replaceStr = ":" + compatableVector[1] + ":";
+      replaceStr = ":" + compatableVector[1] + ":";
 
     boost::replace_all(registerAbstraction,searchStr,replaceStr);
     // Example:  xilinx.com:reg_abs:xdma_msix:1.0 xdma_msix

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -16,6 +16,8 @@
 
 #include "SectionPartitionMetadata.h"
 #include "DTC.h"
+#include <algorithm>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include "XclBinUtilities.h"
@@ -310,7 +312,8 @@ SchemaTransformToDTC_addressable_endpoint( const std::string _sEndPointName,
       throw std::runtime_error("Error: 'addressable_endpoints." + _sEndPointName + ".register_abstraction_name' is invalid: '" + sAbstractName + "'");
     }
 
-    std::string sCompLine1 = tokens[0] + "," + tokens[1] + "-" + tokens[3];
+    // Example Format: "xilinx.com,reg_abs-xdma_msix-1.0"
+    std::string sCompLine1 = tokens[0] + "," + tokens[1] + "-" + tokens[2] + "-" + tokens[3];
     boost::property_tree::ptree ptCompLine1;
     ptCompLine1.put("", sCompLine1.c_str());
 
@@ -528,6 +531,8 @@ SchemaTransformToPM_addressable_endpoint( const std::string _sEndPointName,
   SchemaTransform_nameValue("pcie_physical_function", "", false  /*required*/, _ptOriginal, _ptTransformed);
 
   // -- Transform 'compatible' to 'register_abstraction_name'
+  // Example: (new)  xilinx.com,reg_abs-xdma_msix-1.0 xdma_msix
+  //          (old)  xilinx.com,reg_abs-1.0           xdma_msix
   if (_ptOriginal.find("compatible") != _ptOriginal.not_found()) {
     std::vector<std::string> compatableVector = as_vector<std::string>(_ptOriginal, "compatible");
     if (compatableVector.size() != 2) {
@@ -535,12 +540,21 @@ SchemaTransformToPM_addressable_endpoint( const std::string _sEndPointName,
     }
 
     std::string registerAbstraction = compatableVector[0];
-    std::string seachStr = ",";
-    registerAbstraction.replace(registerAbstraction.find(seachStr),seachStr.length(),":");
+    std::string searchStr = ",";
+    registerAbstraction.replace(registerAbstraction.find(searchStr),searchStr.length(),":");
+    // Example: (new)  xilinx.com:reg_abs-xdma_msix-1.0 xdma_msix
+    //          (old)  xilinx.com:reg_abs-1.0           xdma_msix
 
-    seachStr = "-";
-    std::string replaceStr = ":" + compatableVector[1] + ":";
-    registerAbstraction.replace(registerAbstraction.find(seachStr),seachStr.length(),replaceStr);
+    searchStr = "-";
+    std::string replaceStr = ":";                 // Assume new syntax
+
+    // Determine if an older format was used 
+    size_t dashCount = std::count(registerAbstraction.begin(), registerAbstraction.end(), '-');
+    if (dashCount == 1) 
+      std::string replaceStr = ":" + compatableVector[1] + ":";
+
+    boost::replace_all(registerAbstraction,searchStr,replaceStr);
+    // Example:  xilinx.com:reg_abs:xdma_msix:1.0 xdma_msix
 
     _ptTransformed.put("register_abstraction_name", registerAbstraction.c_str());
   }

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1083,8 +1083,8 @@ XclBin::appendSections(ParameterSectionData &_PSD)
     if (pSection == nullptr) {
       Section *pTempSection = Section::createSectionObjectOfKind(eKind);
 
-      // Add DTC exception. Only for 2019.1
-      if (eKind == PARTITION_METADATA) {
+      if ((eKind == PARTITION_METADATA) || 
+          (eKind == IP_LAYOUT)) {
         pSection = Section::createSectionObjectOfKind(eKind);
         addSection(pSection);
       } else {


### PR DESCRIPTION
Work Done
---------
1) Enhanced the append option to allow appending to an empy IP_LAYOUT section.
2) Updated the "compatability" dtb format.  For example:
   The compatable dtb format use to be:
      xilinx.com,reg_abs-1.0
    and now is:
      xilinx.com,reg_abs-xdma_msix-1.0