### PR TITLE
Add missing import ctypes.util

### DIFF
--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -17,6 +17,7 @@
  under the License.
 """
 
+import ctypes.util
 import sys
 import time
 import math

--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -17,6 +17,7 @@
  under the License.
 """
 
+import ctypes.util
 import numpy as np
 import sys
 import time

--- a/tests/python/23_bandwidth/versal_23_bandwidth.py
+++ b/tests/python/23_bandwidth/versal_23_bandwidth.py
@@ -17,6 +17,7 @@
  under the License.
 """
 
+import ctypes.util
 import numpy as np
 import sys
 import time


### PR DESCRIPTION
This fixes this issue::

  sudo /opt/xilinx/xrt/bin/xbutil validate

  INFO: Found 1 cards

  INFO: Validating card[0]: xilinx_u200_xdma_201830_2
  INFO: == Starting Kernel version check:
  INFO: == Kernel version check PASSED
  INFO: == Starting AUX power connector check:
  INFO: == AUX power connector check PASSED
  INFO: == Starting PCIE link check:
  INFO: == PCIE link check PASSED
  INFO: == Starting SC firmware version check:
  INFO: == SC firmware version check PASSED
  INFO: == Starting verify kernel test:
  INFO: == verify kernel test PASSED
  INFO: == Starting DMA test:
  Host -> PCIe -> FPGA write bandwidth = 9117.600575 MB/s
  Host <- PCIe <- FPGA read bandwidth = 11773.464290 MB/s
  INFO: == DMA test PASSED
  INFO: == Starting device memory bandwidth test:
  Traceback (most recent call last):
    File "/opt/xilinx/xrt/test/23_bandwidth.py", line 37, in <module>
      libc_name = ctypes.util.find_library("c")
  AttributeError: module 'ctypes' has no attribute 'util'

  ERROR: == device memory bandwidth test FAILED
  INFO: Card[0] failed to validate.

  ERROR: Some cards failed to validate.

I am wondering how it was able to work before...