### PR TITLE
Only register AIE when AIE_METADATA is present

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1669,7 +1669,9 @@ xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
     core_device->register_axlf(buffer);
 
 #ifdef XRT_ENABLE_AIE
-    drv->registerAieArray();
+    auto data = core_device->get_axlf_section(AIE_METADATA);
+    if (data.first && data.second)
+      drv->registerAieArray();
 #endif
 
     /* If PDI is the only section, return here */


### PR DESCRIPTION
Check for AIE metadata before registering AIE array