### PR TITLE
CR-1074750 Seg fault for info CL_DEVICE_PCIE_BDF

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -241,6 +241,9 @@ get_bdf() const
   if (!m_xdevice)
     throw xocl::error(CL_INVALID_DEVICE, "No BDF");
 
+  // logically const
+  auto lk = const_cast<device*>(this)->lock_guard();
+
   auto core_device = m_xdevice->get_core_device();
   auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(core_device);
   return xrt_core::query::pcie_bdf::to_string(bdf);
@@ -252,6 +255,9 @@ is_nodma() const
 {
   if (!m_xdevice)
     throw xocl::error(CL_INVALID_DEVICE, "Can't check for nodma");
+
+  // logically const
+  auto lk = const_cast<device*>(this)->lock_guard();
 
   auto core_device = m_xdevice->get_core_device();
   return core_device->is_nodma();


### PR DESCRIPTION
Make sure to open the device before checking its BDF.