### PR TITLE
skd: Install signal Handlers and attempt to capture stacktrace

### DIFF
--- a/src/runtime_src/core/edge/skd/CMakeLists.txt
+++ b/src/runtime_src/core/edge/skd/CMakeLists.txt
@@ -20,4 +20,6 @@ target_link_libraries(skd
   dl
   )
 
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
+
 install (TARGETS skd RUNTIME DESTINATION ${XRT_INSTALL_DIR}/bin)


### PR DESCRIPTION
In this PR, I am attempting to add some signal handling and stacktrace logging.

What we have observed while performing longevity tests or other such U30 tests, we would see hangs/failures. On further inspection, we observed that a few of the encode or decode soft-kernels were unresponsive to the XMA2 (host/x86) plugins.
There was no indication beyond some drm logs indicating that a drm device was closed by zocl.

In order to better understand failures of soft-kernels, here I present signal handlers and some backtrace walking to log a few symbols. In case of synchronous signals (like SIGSEGV, SIGABRT, SIGTERM), the relevant stacktrace gets logged to syslog.

There were a few of ways of doing this 

1. Use boost's stacktrace() functionality, however, with stdout being closed for daemonized processes. The other option was to use this and perform file I/O. Boost overloads the "<<" stream operator. Thus it can be logged to a file via that.

2. Using the backtrace() functionality from glibc, here a malloc is called internally by the backtrace_symbols() routine.

3. Using the backtrace_symbols_fd() from glibc, here an fd (file descriptor) is fed to the call, and I/O is performed to the file.

Options 1 & 3 involve performing file I/O within a signal handler and Option 2 involves performing a malloc within the signal handler. Neither is ideal, however, I am open to addressing a better solution. 

I went ahead with Option#2 since it gave us the simplest way to check for logs. We already log the encoder/decoder soft-kernel status to syslog, thus logging backtraces to syslog just meant we had one log to grok/grep/parse.
 
Signed-off-by: Rohit Athavale <rathaval@xilinx.com>