### PR TITLE
Internal API for constructing xrt device from xclDeviceHandle

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -35,32 +35,6 @@
 # pragma warning( disable : 4244 )
 #endif
 
-////////////////////////////////////////////////////////////////
-// Exposed for Vitis aietools as extensions to xrt_device.h
-////////////////////////////////////////////////////////////////
-/**
- * xrtDeviceOpenFromXcl() - Open a device from a shim xclDeviceHandle
- *
- * @xhdl:         Shim xclDeviceHandle
- * Return:        Handle representing the opened device, or nullptr on error
- *
- * The returned XRT device handle must be explicitly closed when
- * nolonger needed.
- */
-XCL_DRIVER_DLLESPEC
-xrtDeviceHandle
-xrtDeviceOpenFromXcl(xclDeviceHandle dhdl);
-
-/**
- * xrtDeviceFromXcl() - Create a managed device object from a shim xclDeviceHandle
- *
- * @xhdl:         Shim xclDeviceHandle
- * Return:        xrt::device object epresenting the opened device, or exception on error
- */
-XCL_DRIVER_DLLESPEC
-xrt::device
-xrtDeviceFromXcl(xclDeviceHandle dhdl);
-
 namespace {
 
 // C-API handles that must be explicitly closed. Corresponding managed
@@ -141,6 +115,11 @@ namespace xrt {
 device::
 device(unsigned int index)
   : handle(xrt_core::get_userpf_device(index))
+{}
+
+device::
+device(xclDeviceHandle dhdl)
+  : handle(xrt_core::get_userpf_device(dhdl))
 {}
 
 uuid
@@ -343,10 +322,4 @@ xrtDeviceOpenFromXcl(xclDeviceHandle dhdl)
     errno = 0;
   }
   return nullptr;
-}
-
-xrt::device
-xrtDeviceFromXcl(xclDeviceHandle dhdl)
-{
-  return xrt::device(xrt_core::get_userpf_device(dhdl));
 }

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -43,7 +43,7 @@ class device
 {
 public:
   /**
-   * device() - Constructor for empty bo
+   * device() - Constructor for empty device
    */
   device()
   {}
@@ -56,6 +56,16 @@ public:
   XCL_DRIVER_DLLESPEC
   explicit
   device(unsigned int didx);
+
+  /**
+   * device() - Constructor from opaque handle
+   *
+   * Implementation defined constructor
+   */
+  explicit
+  device(std::shared_ptr<xrt_core::device> hdl)
+    : handle(std::move(hdl))
+  {}
 
   /**
    * device() - Copy ctor

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -68,6 +68,16 @@ public:
   {}
 
   /**
+   * device() - Create a managed device object from a shim xclDeviceHandle
+   *
+   * @dhdl:      Shim xclDeviceHandle
+   * Return:     xrt::device object epresenting the opened device, or exception on error
+   */
+  XCL_DRIVER_DLLESPEC
+  explicit
+  device(xclDeviceHandle dhdl);
+
+  /**
    * device() - Copy ctor
    */
   device(const device& rhs)
@@ -197,6 +207,19 @@ extern "C" {
 XCL_DRIVER_DLLESPEC
 xrtDeviceHandle
 xrtDeviceOpen(unsigned int index);
+
+/**
+ * xrtDeviceOpenFromXcl() - Open a device from a shim xclDeviceHandle
+ *
+ * @xhdl:         Shim xclDeviceHandle
+ * Return:        Handle representing the opened device, or nullptr on error
+ *
+ * The returned XRT device handle must be explicitly closed when
+ * nolonger needed.
+ */
+XCL_DRIVER_DLLESPEC
+xrtDeviceHandle
+xrtDeviceOpenFromXcl(xclDeviceHandle dhdl);
 
 /**
  * xrtDeviceClose() - Close an opened device


### PR DESCRIPTION
Added internal API to allow OpenCL to use native APIs that require xrt::device or
xrtDeviceHandles. The APIs are internal for Vitis use, but will likely
disappear as OCL implementation moves to native XRT APIs.