### PR TITLE
Fix building with local static Boost build

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -66,16 +66,14 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
     HINTS $ENV{XRT_BOOST_INSTALL}
     REQUIRED COMPONENTS system filesystem)
 else()
-  # On older systems libboost_system.a is not compiled with -fPIC which leads to
-  # link errors when XRT shared objects try to link with it.
-  # Static linking with Boost is enabled on Ubuntu 18.04 but not 20.04
-#  if ((${LINUX_FLAVOR} STREQUAL Ubuntu) AND (${LINUX_VERSION} STREQUAL 18.04))
-#    set(Boost_USE_STATIC_LIBS  ON)
-#  endif()
   find_package(Boost 
     REQUIRED COMPONENTS system filesystem)
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
+
+if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
+  add_definitions (-DBOOST_PRE_1_64=1)
+endif()
 
 include_directories(${Boost_INCLUDE_DIRS})
 add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -25,6 +25,10 @@ INCLUDE (FindGTest)
 include_directories(${Boost_INCLUDE_DIRS})
 add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")
 
+if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
+  add_definitions (-DBOOST_PRE_1_64=1)
+endif()
+
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR "xrt")
 set (XRT_INSTALL_BIN_DIR       "${XRT_INSTALL_DIR}/bin")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,11 +12,6 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../tests/validate
   )
 
-find_package(Boost EXACT REQUIRED)
-if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
-  add_definitions (-DBOOST_PRE_1_64=1)
-endif()
-
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
Linking was broken after #3863.  Make sure first find_package of Boost
locates and configures based on XRT_BOOST_INSTALL if this variable is
set.