### PR TITLE
Added support for No-dma platforms in emulation

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -303,7 +303,7 @@ get_polling_throttle()
 inline std::string
 get_hal_logging()
 {
-  static std::string value = detail::get_string_value("Runtime.hal_log","null");
+  static std::string value = detail::get_string_value("Runtime.hal_log","");
   return value;
 }
 

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -166,6 +166,10 @@ namespace xclcpuemhal2 {
       }
       struct exec_core* getExecCore() { return mCore; }
       SWScheduler* getScheduler() { return mSWSch; }
+
+      // New API's for m2m and no-dma
+      bool isM2MEnabled();
+      bool isNoDMAEnabled();
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;
       std::mutex mMemManagerMutex;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2453,21 +2453,41 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     PRINTENDFUNC;
     return -1;
   }
-  if(dBO->fd < 0)
-  {
-    std::cout<<"bo is not exported for copying"<<std::endl;
-    return -1;
+
+  // source buffer is host_only and destination buffer is device_only
+  if (xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_p2p(sBO) && xclemulation::xocl_bo_dev_only(dBO)) {
+    unsigned char* host_only_buffer = (unsigned char*)(sBO->buf) + src_offset;
+    if (xclCopyBufferHost2Device(dBO->base, (void*)host_only_buffer, size, dst_offset, dBO->topology) != size) {
+      return -1;
+    }
   }
 
-  int ack = false;
-  auto fItr = mFdToFileNameMap.find(dBO->fd);
-  if(fItr != mFdToFileNameMap.end())
-  {
-    const std::string& sFileName = std::get<0>((*fItr).second);
-    xclCopyBO_RPC_CALL(xclCopyBO,sBO->base,sFileName,size,src_offset,dst_offset);
+  // source buffer is device_only and destination buffer is host_only
+  if (xclemulation::xocl_bo_host_only(dBO) && !xclemulation::xocl_bo_p2p(dBO) && xclemulation::xocl_bo_dev_only(sBO)) {
+    unsigned char* host_only_buffer = (unsigned char*)(dBO->buf) + dst_offset;
+    if (xclCopyBufferDevice2Host((void*)host_only_buffer, sBO->base, size, src_offset, sBO->topology) != size) {
+      return -1;
+    }
   }
-  if(!ack)
-    return -1;
+
+  // source buffer is device_only and destination buffer is p2p_buffer
+  if (xclemulation::xocl_bo_p2p(dBO) && xclemulation::xocl_bo_dev_only(sBO)) {
+    if (dBO->fd < 0)
+    {
+      std::cout << "bo is not exported for copying" << std::endl;
+      return -1;
+    }
+    int ack = false;
+    auto fItr = mFdToFileNameMap.find(dBO->fd);
+    if (fItr != mFdToFileNameMap.end())
+    {
+      const std::string& sFileName = std::get<0>((*fItr).second);
+      xclCopyBO_RPC_CALL(xclCopyBO, sBO->base, sFileName, size, src_offset, dst_offset);
+    }
+    if (!ack)
+      return -1;    
+  }
+
   PRINTENDFUNC;
   return 0;
 }


### PR DESCRIPTION
Added support for No-DMA platforms in sw and hw emulation.
1. Added copy bo support from host_only to read_only buffers and vice-versa in xclCopyBo()
2. Added device_query nodes for m2m and nodma in both sw and hw emulation.