### PR TITLE
Fixes failing tests in sycl

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2210,7 +2210,7 @@ static bool check_bo_user_flags(HwEmShim* dev, unsigned flags)
 	if(ddr_count == 0)
 		return false;
 
-	if (flags == 0xffffffff)
+	if (flags == XOCL_MEM_BANK_MSK)
 		return true;
 
   ddr = xclemulation::xocl_bo_ddr_idx(flags,false);

--- a/src/runtime_src/xocl/api/clEnqueueCopyBufferRect.cpp
+++ b/src/runtime_src/xocl/api/clEnqueueCopyBufferRect.cpp
@@ -248,8 +248,8 @@ clEnqueueCopyBufferRect(cl_command_queue     command_queue ,
   {
     auto device = xocl(command_queue)->get_device();
     auto xdevice = device->get_xrt_device();
-    auto src_boh = xocl(src_buffer)->get_buffer_object_or_error(device);
-    auto dst_boh = xocl(dst_buffer)->get_buffer_object_or_error(device);
+    auto src_boh = xocl(src_buffer)->get_buffer_object(device);
+    auto dst_boh = xocl(dst_buffer)->get_buffer_object(device);
     void* host_ptr_src = xdevice->map(src_boh);
     void* host_ptr_dst = xdevice->map(dst_boh);
 


### PR DESCRIPTION
buffers provided to clEnqueueCopyBufferRect may not yet be associated with a device.

the default flag isn't 0xffffffff but XOCL_MEM_BANK_MSK which is 0xffffff.