### PR TITLE
CR-1067492, Minor bug fix to not to delete the deviceDirectory even d…

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -133,7 +133,10 @@ namespace xclhwemhal2 {
       if(!handle)
         continue;
       handle->saveWaveDataBase();
-      systemUtil::makeSystemCall(handle->deviceDirectory, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+
+      if (xclemulation::config::getInstance()->isKeepRunDirEnabled() == false) {
+        systemUtil::makeSystemCall(handle->deviceDirectory, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+      }
     }
 
   }
@@ -1468,10 +1471,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     // The core device must correspond to open and close, so
     // reset here rather than in destructor
     mCoreDevice.reset();
-
-    if (getenv("ENABLE_HAL_HW_EMU_DEBUG")) {
-      resetProgram(false);
-    }
+    resetProgram(false);
 
     if (!sock) 
     {
@@ -1492,12 +1492,6 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
         mLogStream.close();
       }
       return;
-    }
-
-    if (getenv("ENABLE_HAL_HW_EMU_DEBUG")) {
-    }
-    else {
-      resetProgram(false);
     }
 
     int status = 0;


### PR DESCRIPTION
CR-1067492, Minor bug fix to not to delete the deviceDirectory even during the seg fault when user opted for keep_run_dir INI switch. And corrected the resetProgram call. With this we could see issues regarding the deviceDirectory removal is subsided.