### PR TITLE
CR-1074939 DMESG reports MIG calibration took 0s but the time delta for the step is longer than this

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -663,7 +663,7 @@ static int calibrate_mig(struct icap *icap)
 		return -ETIMEDOUT;
 	}
 
-	ICAP_INFO(icap, "took %ds", i/2);
+	ICAP_DBG(icap, "took %ds", i/2);
 	return 0;
 }
 


### PR DESCRIPTION
We should just not print out the calibration time at all.