### PR TITLE
CR-1066313 Default value of XILINX_XRT=/usr for edge platforms

### DIFF
--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -87,8 +87,13 @@ static bfs::path
 xilinx_xrt()
 {
   bfs::path xrt(value_or_empty(getenv("XILINX_XRT")));
-  if (xrt.empty()) 
+  if (xrt.empty()){
+#if defined (__aarch64__) || defined (__arm__)
+    xrt = bfs::path("/usr");
+#else
     throw std::runtime_error("XILINX_XRT not set");
+#endif
+  }
 
   return xrt;
 }

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -175,11 +175,11 @@ loadDevices()
   // xrt
   bfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
 
-  if (xrt.empty()){
-    #if defined (__aarch64__) || defined (__arm__)
-        xrt /= "/usr";
-    #endif
+#if defined (__aarch64__) || defined (__arm__)
+  if (xrt.empty()) {
+    xrt = bfs::path("/usr");
   }
+#endif
 
   if (!xrt.empty() && !is_emulation()) {
     directoryOrError(xrt);
@@ -233,8 +233,13 @@ load_xdp()
     xdp_once_loader()
     {
       bfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
+
       if (xrt.empty()) {
+#if defined (__aarch64__) || defined (__arm__)
+        xrt = bfs::path("/usr");
+#else
         throw std::runtime_error("Library oclxdp not found! XILINX_XRT not set");
+#endif
       }
       bfs::path xrtlib(xrt / "lib");
       directoryOrError(xrtlib);

--- a/src/runtime_src/xrt/device/hal.cpp
+++ b/src/runtime_src/xrt/device/hal.cpp
@@ -175,6 +175,12 @@ loadDevices()
   // xrt
   bfs::path xrt(emptyOrValue(getenv("XILINX_XRT")));
 
+  if (xrt.empty()){
+    #if defined (__aarch64__) || defined (__arm__)
+        xrt /= "/usr";
+    #endif
+  }
+
   if (!xrt.empty() && !is_emulation()) {
     directoryOrError(xrt);
     auto p = dllpath(xrt,"xrt_core");


### PR DESCRIPTION
> Setting XILINX_XRT=/usr if env variable is not set
> previously runtime error was thrown but changed this behavior on edge platforms to set "/usr" as default value