### PR TITLE
CR-1071356 Integrate verify, bandwidth and slave bridge git examples in xbutil validate

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1197,8 +1197,7 @@ int xcldev::device::runTestCase(const std::string& py,
     // if platform.json exists in the new shell pakcage then use the new testcase
     // else fallback to old python test cases
     
-    // NEW FLOW: runs if platform.json is available and the platform is not versal
-    // Note: we don't have cpp based versal bw testcase
+    // NEW FLOW: runs if platform.json is available
     auto json_exists = [xclbinPath]() { return boost::filesystem::exists(xclbinPath + "platform.json") ? true : false; };
     
     if(json_exists()) {    

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1186,37 +1186,70 @@ int xcldev::device::runTestCase(const std::string& py,
     std::string devInfoPath = name + "/test/";
     std::string xsaXclbinPath = getXsaPath(vendor) + devInfoPath;
     std::string dsaXclbinPath = dsaPath + devInfoPath;
-    std::string xrtTestCasePath = xrtPath + "test/" + py;
+    std::string xrtTestCasePath = xrtPath + "test/";
 
     output.clear();
 
     std::string xclbinPath;
     searchXsaAndDsa(m_idx, xsaXclbinPath, dsaXclbinPath, xclbinPath, output);
-    xclbinPath += xclbin;
-
-    if (stat(xrtTestCasePath.c_str(), &st) != 0 || stat(xclbinPath.c_str(), &st) != 0) {
-        //if bandwidth xclbin isn't present, skip the test
-        if(xclbin.compare("bandwidth.xclbin") == 0) {
-            output += "Bandwidth xclbin not available. Skipping validation.";
-            return -EOPNOTSUPP;
+    std::string cmd;
+    
+    // if platform.json exists in the new shell pakcage then use the new testcase
+    // else fallback to old python test cases
+    
+    // NEW FLOW: runs if platform.json is available and the platform is not versal
+    // Note: we don't have cpp based versal bw testcase
+    auto json_exists = [xclbinPath]() 
+        {
+            return boost::filesystem::exists(xclbinPath + "platform.json") ? true : false;
+        };
+    if(json_exists() && xclbin.compare("versal_23_bandwidth.py") != 0) {
+        
+        //map old testcase names to new testcase names
+        static const std::map<std::string, std::string> test_map = {
+            { "22_verify.py",             "validate.exe"    },
+            { "23_bandwidth.py",          "kernel_bw.exe"   },
+            { "host_mem_23_bandwidth.py", "slavebridge.exe" }
+        };
+        
+        xrtTestCasePath += test_map.find(py)->second;
+        // in case the user is trying to run a new platform with an older XRT
+        if (!boost::filesystem::exists(xrtTestCasePath)) {
+            output += "ERROR: Failed to find " + xrtTestCasePath + ". Please update XRT.";
+            return -ENOENT;
         }
-        output += "ERROR: Failed to find ";
-        output += py;
-        output += " or ";
-        output += xclbin;
-        output += ", Shell package not installed properly.";
-        return -ENOENT;
-    }
 
-    // Program xclbin first.
-    int ret = program(xclbinPath, 0);
-    if (ret != 0) {
-        output += "ERROR: Failed to download xclbin: ";
-        output += xclbin;
-        return -EINVAL;
+        cmd = xrtTestCasePath + " " + xclbinPath;
     }
+    //OLD FLOW:
+    else { 
+        xrtTestCasePath += py;    
+        xclbinPath += xclbin;
 
-    std::string cmd = "/usr/bin/python3 " + xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx);
+        if (stat(xrtTestCasePath.c_str(), &st) != 0 || stat(xclbinPath.c_str(), &st) != 0) {
+            //if bandwidth xclbin isn't present, skip the test
+            if(xclbin.compare("bandwidth.xclbin") == 0) {
+                output += "Bandwidth xclbin not available. Skipping validation.";
+                return -EOPNOTSUPP;
+            }
+            output += "ERROR: Failed to find ";
+            output += py;
+            output += " or ";
+            output += xclbin;
+            output += ", Shell package not installed properly.";
+            return -ENOENT;
+        }
+
+        // Program xclbin first.
+        int ret = program(xclbinPath, 0);
+        if (ret != 0) {
+            output += "ERROR: Failed to download xclbin: ";
+            output += xclbin;
+            return -EINVAL;
+        }
+
+        cmd = "/usr/bin/python3 " + xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx);
+    }
     return runShellCmd(cmd, output);
 }
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1199,12 +1199,9 @@ int xcldev::device::runTestCase(const std::string& py,
     
     // NEW FLOW: runs if platform.json is available and the platform is not versal
     // Note: we don't have cpp based versal bw testcase
-    auto json_exists = [xclbinPath]() 
-        {
-            return boost::filesystem::exists(xclbinPath + "platform.json") ? true : false;
-        };
-    if(json_exists() && xclbin.compare("versal_23_bandwidth.py") != 0) {
-        
+    auto json_exists = [xclbinPath]() { return boost::filesystem::exists(xclbinPath + "platform.json") ? true : false; };
+    
+    if(json_exists()) {    
         //map old testcase names to new testcase names
         static const std::map<std::string, std::string> test_map = {
             { "22_verify.py",             "validate.exe"    },
@@ -1215,7 +1212,7 @@ int xcldev::device::runTestCase(const std::string& py,
         xrtTestCasePath += test_map.find(py)->second;
         // in case the user is trying to run a new platform with an XRT which doesn't support the new platform pkg
         if (!boost::filesystem::exists(xrtTestCasePath)) {
-            output += "ERROR: Failed to find " + xrtTestCasePath + ". Please update XRT.";
+            output += "ERROR: Failed to find " + xrtTestCasePath + ", Shell package not installed properly.";
             return -ENOENT;
         }
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1213,7 +1213,7 @@ int xcldev::device::runTestCase(const std::string& py,
         };
         
         xrtTestCasePath += test_map.find(py)->second;
-        // in case the user is trying to run a new platform with an older XRT
+        // in case the user is trying to run a new platform with an XRT which doesn't support the new platform pkg
         if (!boost::filesystem::exists(xrtTestCasePath)) {
             output += "ERROR: Failed to find " + xrtTestCasePath + ". Please update XRT.";
             return -ENOENT;


### PR DESCRIPTION
- Cases handled:
```
            |     Old XRT       |    New XRT
Old shell   |   Runs python     |  Runs python
New shell   |  Throws an error  |  Runs cpp
```
- Versal will always run py test case since we don't have the cpp equivalent
- Todo: add to xbutil2