### PR TITLE
add switch to enable/disable cu to host interrupt

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -119,6 +119,7 @@ struct kds_ert {
  * @cu_mgmt: hardware CUs management data structure
  * @ert: remote scheduler
  * @ert_disable: remote scheduler is disabled or not
+ * @cu_intr_cap: capbility of CU interrupt support
  * @cu_intr: CU or ERT interrupt. 1 for CU, 0 for ERT.
  */
 struct kds_sched {
@@ -129,6 +130,7 @@ struct kds_sched {
 	struct kds_cu_mgmt	cu_mgmt;
 	struct kds_ert	       *ert;
 	bool			ert_disable;
+	u32			cu_intr_cap;
 	u32			cu_intr;
 };
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -2417,7 +2417,9 @@ int xcldev::xclScheduler(int argc, char *argv[])
 {
     bool root = ((getuid() == 0) || (geteuid() == 0));
     static struct option long_opts[] = {
-        {"echo", required_argument, 0, 0},
+        {"echo", required_argument, 0, 'e'},
+        {"kds_schedule", required_argument, 0, 'k'},
+        {"cu_intr", required_argument, 0, xcldev::KDS_CU_INTERRUPT},
         {0, 0, 0, 0}
     };
     const char* short_opts = "d:e:k:";
@@ -2426,6 +2428,7 @@ int xcldev::xclScheduler(int argc, char *argv[])
     unsigned index = 0;
     int kds_echo = -1;
     int ert_disable = -1;
+    int cu_intr = -1;
 
     if (!root) {
         std::cout << "ERROR: root privileges required." << std::endl;
@@ -2450,6 +2453,9 @@ int xcldev::xclScheduler(int argc, char *argv[])
             break;
         case 'k':
             ert_disable = std::atoi(optarg);
+            break;
+        case xcldev::KDS_CU_INTERRUPT:
+            cu_intr = std::atoi(optarg);
             break;
         default:
             /* This is hidden command, silently exit */
@@ -2479,6 +2485,18 @@ int xcldev::xclScheduler(int argc, char *argv[])
         std::string ert_disable;
         pcidev::get_dev(index)->sysfs_get( "", "ert_disable", errmsg, ert_disable);
         std::cout << "Device[" << index << "] ert_disable: " << ert_disable << std::endl;
+    }
+
+    if (cu_intr != -1) {
+        std::string val = (cu_intr == 1)? "cu" : "ert";
+        pcidev::get_dev(index)->sysfs_put( "", "kds_interrupt", errmsg, val);
+        if (!errmsg.empty()) {
+            std::cout << errmsg << std::endl;
+            return -EINVAL;
+        }
+        std::string kds_interrupt;
+        pcidev::get_dev(index)->sysfs_get( "", "kds_interrupt", errmsg, kds_interrupt);
+        std::cout << "Device[" << index << "] interrupt mode: " << kds_interrupt << std::endl;
     }
 
     return 0;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -123,6 +123,9 @@ enum cmacommand {
     CMA_VALIDATE,
     CMA_SIZE,
 };
+enum kdscommand {
+    KDS_CU_INTERRUPT = 0x0,
+};
 
 enum class cu_stat : unsigned short {
   usage = 0,


### PR DESCRIPTION
1. Move sysfs nodes from xocl_kds.c to xocl_sysfs.c
2. Add kds_interrupt sysfs node

By default, the ERT to host interrupt is enabled (backward compatible).
To switch to CU to host interrupt (This only take effect since SSv3)
Recommend method: xbutil scheduler --cu_intr 1 -d <device id>
Use sysfs node: echo "cu” > /sys/bus/pci/devices/<userpf BDF>/kds_interrupt

To switch to ERT to host interrupt
Recommend method: xbutil scheduler --cu_intr 0 -d <device id>
Use sysfs node: echo "ert” > /sys/bus/pci/devices/<userpf BDF>/kds_interrupt