### PR TITLE
Fix aie reset/reload

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -625,11 +625,15 @@ get_kernels(const axlf* top)
   return kernels;
 }
 
+// PDI only XCLBIN has PDI section only;
+// Or has AIE_METADATA and PDI sections only
 bool
 is_pdi_only(const axlf* top)
 {
   auto pdi = axlf_section_type<const char*>::get(top, axlf_section_kind::PDI);
-  return (top->m_header.m_numSections == 1 && pdi != nullptr);
+  auto aie_meta = axlf_section_type<const char*>::get(top, axlf_section_kind::AIE_METADATA);
+
+  return ((top->m_header.m_numSections == 1 && pdi != nullptr) || (top->m_header.m_numSections == 2 && pdi != nullptr && aie_meta != nullptr));
 }
 
 }} // xclbin, xrt_core

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_aie.h
@@ -13,10 +13,23 @@
 #define _ZOCL_AIE_H_
 
 
+/* Wait 100 * 1 ms before AIE parition is availabe after reset */
+#define	ZOCL_AIE_RESET_TIMEOUT_INTERVAL	1
+#define	ZOCL_AIE_RESET_TIMEOUT_NUMBER	100
+
+struct aie_work_data {
+	struct work_struct work;
+	struct drm_zocl_dev *zdev;
+};
+
 struct zocl_aie {
 	struct device	*aie_dev;	/* AI engine partition device */
 	u32		partition_id;	/* Partition ID */
 	u32		uid;		/* Imiage identifier loaded */
+	u32		fd_cnt;		/* # of fd requested */
+	bool		aie_reset;	/* If AIE is reset */
+
+	struct workqueue_struct *wq;	/* AIE work queue */
 };
 
 #ifdef __NONE_PETALINUX__
@@ -42,6 +55,12 @@ aie_partition_get_fd(struct device *aie_dev)
 }
 
 static inline void aie_partition_release(struct device *dev) {}
+
+static inline bool
+aie_partition_is_available(struct aie_partition_req *req)
+{
+	return false;
+}
 
 #endif
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -217,6 +217,7 @@ void zocl_clear_mem(struct drm_zocl_dev *zdev);
 int zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf);
 void zocl_destroy_aie(struct drm_zocl_dev *zdev);
 int zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data);
+int zocl_aie_reset(struct drm_zocl_dev *zdev);
 
 int zocl_inject_error(struct drm_zocl_dev *zdev, void *data,
 		struct drm_file *filp);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ioctl.h
@@ -51,4 +51,6 @@ int zocl_error_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
 int zocl_aie_fd_ioctl(struct drm_device *dev, void *data,
 		struct drm_file *filp);
+int zocl_aie_reset_ioctl(struct drm_device *dev, void *data,
+		struct drm_file *filp);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -737,6 +737,8 @@ static const struct drm_ioctl_desc zocl_ioctls[] = {
 			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 	DRM_IOCTL_DEF_DRV(ZOCL_AIE_FD, zocl_aie_fd_ioctl,
 			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
+	DRM_IOCTL_DEF_DRV(ZOCL_AIE_RESET, zocl_aie_reset_ioctl,
+			DRM_AUTH|DRM_UNLOCKED|DRM_RENDER_ALLOW),
 };
 
 static const struct file_operations zocl_driver_fops = {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -153,3 +153,13 @@ zocl_aie_fd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	ret = zocl_aie_request_part_fd(zdev, args);
 	return ret;
 }
+
+int
+zocl_aie_reset_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
+{
+	struct drm_zocl_dev *zdev = ZOCL_GET_ZDEV(dev);
+	int ret;
+
+	ret = zocl_aie_reset(zdev);
+	return ret;
+}

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -119,6 +119,8 @@ enum drm_zocl_ops {
 	DRM_ZOCL_ERROR_INJECT,
 	/* Request/Release AIE partition */
 	DRM_ZOCL_AIE_FD,
+	/* Reset AIE Array */
+	DRM_ZOCL_AIE_RESET,
 	DRM_ZOCL_NUM_IOCTLS
 };
 
@@ -298,6 +300,10 @@ struct drm_zocl_aie_fd {
 	uint32_t partition_id;
 	uint32_t uid;
 	int fd;
+};
+
+struct drm_zocl_aie_reset {
+	uint32_t partition_id;
 };
 
 /**
@@ -492,4 +498,6 @@ struct drm_zocl_error_inject {
                                        DRM_ZOCL_ERROR_INJECT, struct drm_zocl_error_inject)
 #define DRM_IOCTL_ZOCL_AIE_FD          DRM_IOWR(DRM_COMMAND_BASE + \
                                        DRM_ZOCL_AIE_FD, struct drm_zocl_aie_fd)
+#define DRM_IOCTL_ZOCL_AIE_RESET       DRM_IOWR(DRM_COMMAND_BASE + \
+                                       DRM_ZOCL_AIE_RESET, struct drm_zocl_aie_reset)
 #endif

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -284,4 +284,23 @@ clear_bd(BD& bd)
 #endif
 }
 
+void
+Aie::
+reset(const std::shared_ptr<xrt_core::device>& device)
+{
+#ifndef __AIESIM__
+    int rval = close(fd);
+
+    auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+
+    /* TODO get partition id and uid from XCLBIN or PDI */
+    uint32_t partition_id = 1;
+
+    drm_zocl_aie_reset reset = { partition_id };
+    int ret = drv->resetAIEArray(reset);
+    if (ret)
+        throw xrt_core::error(ret, "Fail to reset AIE Array");
+#endif
+}
+
 }

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -59,7 +59,7 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
     AieRC rc;
     if ((rc = XAie_CfgInitialize(&DevInst, &ConfigPtr)) != XAIE_OK)
         throw xrt_core::error(-EINVAL, "Failed to initialize AIE configuration: " + std::to_string(rc));
-    devInst = DevInst;
+    devInst = &DevInst;
 
     /* Initialize graph GMIO metadata */
     for (auto& gmio : xrt_core::edge::aie::get_gmios(device.get()))
@@ -79,7 +79,7 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
         XAie_LocType shimTile = XAie_TileLoc(gmio.shim_col, 0);
 
         if (!dma->configured) {
-            XAie_DmaDescInit(&devInst, &(dma->desc), shimTile);
+            XAie_DmaDescInit(devInst, &(dma->desc), shimTile);
             dma->configured = true;
         }
 
@@ -87,10 +87,10 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
         /* type 0: GM->AIE; type 1: AIE->GM */
         XAie_DmaDirection dir = gmio.type == 0 ? DMA_MM2S : DMA_S2MM;
         uint8_t pch = CONVERT_LCHANL_TO_PCHANL(chan);
-        XAie_DmaChannelEnable(&devInst, shimTile, pch, dir);
+        XAie_DmaChannelEnable(devInst, shimTile, pch, dir);
         XAie_DmaSetAxi(&(dma->desc), 0, gmio.burst_len, 0, 0, 0);
 
-        XAie_DmaGetMaxQueueSize(&devInst, shimTile, &(dma->maxqSize));
+        XAie_DmaGetMaxQueueSize(devInst, shimTile, &(dma->maxqSize));
         for (int i = 0; i < dma->maxqSize /*XAIEGBL_NOC_DMASTA_STARTQ_MAX */; ++i) {
             /*
              * 16 BDs are allocated to 4 channels.
@@ -110,19 +110,26 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
 Aie::~Aie()
 {
 #ifndef __AIESIM__
-    close(fd);
+  if (devInst)
+    XAie_Finish(devInst);
 #endif
 }
 
 XAie_DevInst* Aie::getDevInst()
 {
-    return &devInst;
+  if (!devInst)
+    throw xrt_core::error(-EINVAL, "AIE is not initialized");
+
+  return devInst;
 }
 
 void
 Aie::
 sync_bo(xrtBufferHandle bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
+  if (!devInst)
+    throw xrt_core::error(-EINVAL, "Can't sync BO: AIE is not initialized");
+
   auto gmio = std::find_if(gmios.begin(), gmios.end(),
             [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
 
@@ -143,6 +150,9 @@ void
 Aie::
 sync_bo_nb(xrtBufferHandle bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
+  if (!devInst)
+    throw xrt_core::error(-EINVAL, "Can't sync BO: AIE is not initialized");
+
   auto gmio = std::find_if(gmios.begin(), gmios.end(),
             [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
 
@@ -156,6 +166,9 @@ void
 Aie::
 wait_gmio(const std::string& gmioName)
 {
+  if (!devInst)
+    throw xrt_core::error(-EINVAL, "Can't wait GMIO: AIE is not initialized");
+
   auto gmio = std::find_if(gmios.begin(), gmios.end(),
             [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
 
@@ -199,7 +212,7 @@ submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum 
   /* Find a free BD. Busy wait until we get one. */
   while (dmap->dma_chan[chan].idle_bds.empty()) {
     uint8_t npend;
-    XAie_DmaGetPendingBdCount(&devInst, shim_tile, pchan, gmdir, &npend);
+    XAie_DmaGetPendingBdCount(devInst, shim_tile, pchan, gmdir, &npend);
 
     int num_comp = dmap->maxqSize - npend;
 
@@ -229,10 +242,10 @@ submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum 
   XAie_DmaEnableBd(&(dmap->desc));
 
   /* Write BD */
-  XAie_DmaWriteBd(&devInst, &(dmap->desc), shim_tile, bd.bd_num);
+  XAie_DmaWriteBd(devInst, &(dmap->desc), shim_tile, bd.bd_num);
 
   /* Enqueue BD */
-  XAie_DmaChannelPushBdToQueue(&devInst, shim_tile, pchan, gmdir, bd.bd_num);
+  XAie_DmaChannelPushBdToQueue(devInst, shim_tile, pchan, gmdir, bd.bd_num);
   dmap->dma_chan[chan].pend_bds.push(bd);
 }
 
@@ -240,7 +253,7 @@ void
 Aie::
 wait_sync_bo(ShimDMA *dmap, uint32_t chan, XAie_LocType& tile, XAie_DmaDirection gmdir, uint32_t timeout)
 {
-  while (XAie_DmaWaitForDone(&devInst, tile, CONVERT_LCHANL_TO_PCHANL(chan), gmdir, timeout) != XAIE_OK);
+  while (XAie_DmaWaitForDone(devInst, tile, CONVERT_LCHANL_TO_PCHANL(chan), gmdir, timeout) != XAIE_OK);
 
   while (!dmap->dma_chan[chan].pend_bds.empty()) {
     BD bd = dmap->dma_chan[chan].pend_bds.front();
@@ -286,10 +299,14 @@ clear_bd(BD& bd)
 
 void
 Aie::
-reset(const std::shared_ptr<xrt_core::device>& device)
+reset(const xrt_core::device* device)
 {
 #ifndef __AIESIM__
-    int rval = close(fd);
+    if (!devInst)
+        throw xrt_core::error(-EINVAL, "Can't Reset AIE: AIE is not initialized");
+
+    XAie_Finish(devInst);
+    devInst = nullptr;
 
     auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
 

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -94,13 +94,13 @@ public:
     wait_gmio(const std::string& gmioName);
 
     void
-    reset(const std::shared_ptr<xrt_core::device>& device);
+    reset(const xrt_core::device* device);
 
 private:
     int numCols;
     int fd;
 
-    XAie_DevInst devInst;         // AIE Device Instance
+    XAie_DevInst* devInst;         // AIE Device Instance
 
     void
     submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size, size_t offset);

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -93,6 +93,9 @@ public:
     void
     wait_gmio(const std::string& gmioName);
 
+    void
+    reset(const std::shared_ptr<xrt_core::device>& device);
+
 private:
     int numCols;
     int fd;

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -752,7 +752,7 @@ xclResetAieArray(xclDeviceHandle handle)
   if (!drv->isAieRegistered())
     throw xrt_core::error(-EINVAL, "No AIE presented");
   auto aieArray = drv->getAieArray();
-  aieArray->reset(device);
+  aieArray->reset(device.get());
 #else
   auto aieArray = getAieArray();
 #endif

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -745,9 +745,17 @@ xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
 void
 xclResetAieArray(xclDeviceHandle handle)
 {
-  /* Do a handle check */
-  xrt_core::get_userpf_device(handle);
+#ifndef __AIESIM__
+  auto device = xrt_core::get_userpf_device(handle);
+  auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
 
+  if (!drv->isAieRegistered())
+    throw xrt_core::error(-EINVAL, "No AIE presented");
+  auto aieArray = drv->getAieArray();
+  aieArray->reset(device);
+#else
+  auto aieArray = getAieArray();
+#endif
 }
 
 } // api

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1427,6 +1427,7 @@ void
 shim::
 registerAieArray()
 {
+  delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
 }
 
@@ -1441,22 +1442,14 @@ int
 shim::
 getPartitionFd(drm_zocl_aie_fd &aiefd)
 {
-  int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_FD, &aiefd);
-  if (ret)
-    return -errno;
-
-  return 0;
+  return ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_FD, &aiefd) ? -errno : 0;
 }
 
 int
 shim::
 resetAIEArray(drm_zocl_aie_reset &reset)
 {
-  int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_RESET, &reset);
-  if (ret)
-    return -errno;
-
-  return 0;
+  return ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_RESET, &reset) ? -errno : 0;
 }
 #endif
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1427,8 +1427,6 @@ void
 shim::
 registerAieArray()
 {
-//not registering AieArray in hw_emu as it is crashing in hw_emu. We can fix the
-//issue once move to AIE-V2 is done
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
 }
 
@@ -1444,6 +1442,17 @@ shim::
 getPartitionFd(drm_zocl_aie_fd &aiefd)
 {
   int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_FD, &aiefd);
+  if (ret)
+    return -errno;
+
+  return 0;
+}
+
+int
+shim::
+resetAIEArray(drm_zocl_aie_reset &reset)
+{
+  int ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_AIE_RESET, &reset);
   if (ret)
     return -errno;
 

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -136,6 +136,7 @@ public:
   void registerAieArray();
   bool isAieRegistered();
   int getPartitionFd(drm_zocl_aie_fd &aiefd);
+  int resetAIEArray(drm_zocl_aie_reset &reset);
 #endif
 
 private:


### PR DESCRIPTION
This PR added the following support
1) xrtResetAIEArray
2) Load AIE only XCLBIN after reset
3) Prevent accessing AIE resources after reset if an AIE only XCLBIN (AIE PDI) is not loaded.