### PR TITLE
NSPR-8677 SDx_PCIe_Platforms: New MAC Addressing Reporting Scheme for…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -124,6 +124,8 @@ struct xcl_board_info {
 	uint32_t fan_presence;
 	uint32_t config_mode;
 	char exp_bmc_ver[256];
+	uint32_t mac_contiguous_num;
+	char     mac_addr_first[6];
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1050,6 +1050,8 @@ enum data_kind {
 	XMC_VCCAUX_PMC,
 	XMC_VCCRAM,
 	DATA_RETAIN,
+	MAC_CONT_NUM,
+	MAC_CONT_FIRST,
 };
 
 enum mb_kind {

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -221,14 +221,32 @@ int Flasher::getBoardInfo(BoardInfo& board)
         info[BDINFO_CONFIG_MODE][0] : '\0';
     board.mFanPresence = info.find(BDINFO_FAN_PRESENCE) != info.end() ?
         info[BDINFO_FAN_PRESENCE][0] : '\0';
-    board.mMacAddr0 = charVec2String(info[BDINFO_MAC0]).compare(unassigned_mac) ? 
-        std::move(charVec2String(info[BDINFO_MAC0])) : std::move(std::string("Unassigned"));
-    board.mMacAddr1 = charVec2String(info[BDINFO_MAC1]).compare(unassigned_mac) ? 
-        std::move(charVec2String(info[BDINFO_MAC1])) : std::move(std::string("Unassigned"));
-    board.mMacAddr2 = charVec2String(info[BDINFO_MAC2]).compare(unassigned_mac) ? 
-        std::move(charVec2String(info[BDINFO_MAC2])) : std::move(std::string("Unassigned"));
-    board.mMacAddr3 = charVec2String(info[BDINFO_MAC3]).compare(unassigned_mac) ? 
-        std::move(charVec2String(info[BDINFO_MAC3])) : std::move(std::string("Unassigned"));
+
+    if (info.find(BDINFO_MAC_DYNAMIC) != info.end() &&
+        info[BDINFO_MAC_DYNAMIC].size() == 8) {
+        uint16_t count;
+
+        memcpy(&count, &info[BDINFO_MAC_DYNAMIC][0], sizeof(uint16_t));
+        board.mMacContiguousNum = le16toh(count);
+
+	for (unsigned i = 2; i < 8; i++) {
+	    board.mMacAddrFirst[i-2] = info[BDINFO_MAC_DYNAMIC][i];
+	}
+    } else {
+        board.mMacAddr0 = charVec2String(info[BDINFO_MAC0]).compare(unassigned_mac) ? 
+            std::move(charVec2String(info[BDINFO_MAC0])) :
+	    std::move(std::string("Unassigned"));
+        board.mMacAddr1 = charVec2String(info[BDINFO_MAC1]).compare(unassigned_mac) ? 
+            std::move(charVec2String(info[BDINFO_MAC1])) :
+	    std::move(std::string("Unassigned"));
+        board.mMacAddr2 = charVec2String(info[BDINFO_MAC2]).compare(unassigned_mac) ? 
+            std::move(charVec2String(info[BDINFO_MAC2])) :
+	    std::move(std::string("Unassigned"));
+        board.mMacAddr3 = charVec2String(info[BDINFO_MAC3]).compare(unassigned_mac) ? 
+            std::move(charVec2String(info[BDINFO_MAC3])) :
+	    std::move(std::string("Unassigned"));
+    }
+
     board.mMaxPower = info.find(BDINFO_MAX_PWR) != info.end() ?
         int2PowerString(info[BDINFO_MAX_PWR][0]) : "N/A";
     board.mName = std::move(charVec2String(info[BDINFO_NAME]));

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -230,9 +230,10 @@ int Flasher::getBoardInfo(BoardInfo& board)
         board.mMacContiguousNum = le16toh(count);
 
 	for (unsigned i = 2; i < 8; i++) {
-	    board.mMacAddrFirst[i-2] = info[BDINFO_MAC_DYNAMIC][i];
+            board.mMacAddrFirst[i-2] = info[BDINFO_MAC_DYNAMIC][i];
 	}
     } else {
+        board.mMacContiguousNum = 0;
         board.mMacAddr0 = charVec2String(info[BDINFO_MAC0]).compare(unassigned_mac) ? 
             std::move(charVec2String(info[BDINFO_MAC0])) :
 	    std::move(std::string("Unassigned"));

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
@@ -48,6 +48,8 @@ struct BoardInfo
     std::string mMaxPower;
     unsigned int mConfigMode;
     char mFanPresence;
+    unsigned int mMacContiguousNum;
+    char mMacAddrFirst[6]; //fixed 6 bytes for current mac address version
 };
 
 enum BoardInfoKey
@@ -64,6 +66,8 @@ enum BoardInfoKey
     BDINFO_FAN_PRESENCE,
     BDINFO_CONFIG_MODE
 };
+
+#define BDINFO_MAC_DYNAMIC 0x4B
 
 class Flasher
 {


### PR DESCRIPTION
… greater than 8 Addresses (XRT) - Only for U55N

> Test Results

Test Results;
```
root@xsjyliu50:~# /proj/rdi/staff/davidzha/share/cmcpy1/cmc_board_info.py -c b1
pyxbb: U55N on PCI bus 0000:b1:00.0 found
 SNSR_ID_BOARD_SN:XFL1LWAB5Y1M
 SNSR_ID_TOTAL_POWER_AVAIL:225W
 SNSR_ID_CONFIG_MODE:Master_SPI_x4
 SNSR_ID_FAN_PRESENCE:P
 SNSR_ID_NEW_MAC_SCHEME:Number of MAC addresses 8
 SNSR_ID_NEW_MAC_SCHEME:First MAC addresses 00:0a:35:08:83:01
 SNSR_ID_BOARD_REV:B
 SNSR_ID_SAT_VERSION:7.1.4
 SNSR_ID_BOARD_NAME:ALVEO U55N ES3

root@xsjyliu50:~# ./xbmgmt flash --scan --verbose
Card [0000:b1:00.0]
 Card type: u55n
 Flash type: SPI
 Flashable partition running on FPGA:
 xilinx_u55n_gen3x16_xdma_base_2,[ID=0x881fcec1f8fd0720],[SC=7.1.4]
 Logic UUID:
 881fcec1f8fd0720fb3d345a9430a159
 Flashable partitions installed in system:
 xilinx_u55n_gen3x16_xdma_base_2,[ID=0x881fcec1f8fd0720],[SC=7.1.2]
 Logic UUID:
 881fcec1f8fd0720fb3d345a9430a159
 Card name ALVEO U55N ES3
 Card S/N: XFL1LWAB5Y1M
 Config mode: 7
 Fan presence: P
 Max power level: 225W
 MAC address0: 00:0A:35:08:83:01
 MAC address1: 00:0A:35:08:83:02
 MAC address2: 00:0A:35:08:83:03
 MAC address3: 00:0A:35:08:83:04
 MAC address4: 00:0A:35:08:83:05
 MAC address5: 00:0A:35:08:83:06
 MAC address6: 00:0A:35:08:83:07
 MAC address7: 00:0A:35:08:83:08

root@xsjyliu50:~# ./xbmgmt flash --scan --json
{
 "card0": {
 "shellpackage": "xilinx_u55n_gen3x16_xdma_base_2,[ID=0x881fcec1f8fd0720],[SC=7.1.2]; ",
 "name": "ALVEO U55N ES3",
 "serial": "XFL1LWAB5Y1M",
 "config_mode": "7",
 "fan_presence": "P",
 "max_power": "225W",
 "mac0": "00:0A:35:08:83:01",
 "mac1": "00:0A:35:08:83:02",
 "mac2": "00:0A:35:08:83:03",
 "mac3": "00:0A:35:08:83:04",
 "mac4": "00:0A:35:08:83:05",
 "mac5": "00:0A:35:08:83:06",
 "mac6": "00:0A:35:08:83:07",
 "mac7": "00:0A:35:08:83:08"
 }
}

cat /sys/bus/pci/drivers/xclmgmt/0000\:b1\:00.0/xmc.m.16777217/mac_addr_first
 00:0A:35:08:83:01

cat /sys/bus/pci/drivers/xclmgmt/0000\:b1\:00.0/xmc.m.16777217/mac_contiguous_num
 8

```