### PR TITLE
Make sure xclProbe() is called when in emulation mode

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
@@ -16,6 +16,7 @@
 
 #include "system_swemu.h"
 #include "device_swemu.h"
+#include "xrt.h"
 
 #include <memory>
 
@@ -41,6 +42,13 @@ struct X
 }
 
 namespace xrt_core { namespace swemu {
+
+system::
+system()
+{
+  // xclProbe must be called to set up data structures
+  xclProbe();
+}
 
 std::pair<device::id_type, device::id_type>
 system::

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.h
@@ -24,6 +24,8 @@ namespace xrt_core { namespace swemu {
 class system : public system_pcie
 {
 public:
+  system();
+  
   std::pair<device::id_type, device::id_type>
   get_total_devices(bool is_user) const;
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
@@ -16,6 +16,7 @@
 
 #include "system_hwemu.h"
 #include "device_hwemu.h"
+#include "xrt.h"
 
 #include <memory>
 
@@ -41,6 +42,13 @@ struct X
 }
 
 namespace xrt_core { namespace hwemu {
+
+system::
+system()
+{
+  // xclProbe must be called to set up data structures
+  xclProbe();
+}
 
 std::pair<device::id_type, device::id_type>
 system::

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.h
@@ -24,6 +24,8 @@ namespace xrt_core { namespace hwemu {
 class system : public system_pcie
 {
 public:
+  system();
+  
   std::pair<device::id_type, device::id_type>
   get_total_devices(bool is_user) const;
 


### PR DESCRIPTION
With new XRT native APIs, xclProbe() is folded into the implementation
and no longer called from host application.  Emulation sets up data
structures as part of xclProbe() so make sure it is called when the
core library is loaded.

See also CR-1076331