### PR TITLE
updating BSP names for zynq/zynqmp nodes

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -141,10 +141,10 @@ fi
 source $PETALINUX/settings.sh 
 
 if [[ $AARCH = $aarch64_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zcu106-v2020.2-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/internal/zynqmp/zynqmp-common-v2020.2-final.bsp"
     YOCTO_MACHINE="zynqmp-generic"
 elif [[ $AARCH = $aarch32_dir ]]; then
-    PETA_BSP="$PETALINUX/../../bsp/release/xilinx-zc706-v2020.2-final.bsp"
+    PETA_BSP="$PETALINUX/../../bsp/internal/zynq/zynq-rootfs-common-v2020.2-final.bsp"
     YOCTO_MACHINE="zynq-generic"
 elif [[ $AARCH = $versal_dir ]]; then
     PETA_BSP="$PETALINUX/../../bsp/internal/versal/versal-rootfs-common-v2020.2-final.bsp"


### PR DESCRIPTION
This PR contains a change of BSP names for zynq/zynqmp nodes. Versal is already using updated name