### PR TITLE
 CR-1074448 ASTeR Basic sanity - xbutil dump JSON format broken due to error message printed in output u250 and u50

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -623,7 +623,8 @@ int main(int argc, char *argv[])
         try {
             deviceVec.emplace_back(new xcldev::device(i, nullptr));
         } catch (const std::exception& ex) {
-            std::cout << ex.what() << std::endl;
+            std::cerr << ex.what() << std::endl;
+	    return -ENODEV;
         }
     }
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -278,7 +278,7 @@ public:
         std::string errmsg;
         pcidev::get_dev(m_idx)->sysfs_get("rom", "VBNV", errmsg, m_devicename);
         if(!errmsg.empty())
-            throw std::runtime_error("Failed to determine device name. ");
+            throw std::runtime_error("Failed to determine device name. " + errmsg);
     }
 
     device(device&& rhs) = delete;
@@ -493,7 +493,7 @@ public:
 
         // If unknown status bits, can't support.
         if (status & ~(ce_mask | ue_mask)) {
-            std::cout << "Bad ECC status detected!" << std::endl;
+            std::cerr << "Bad ECC status detected!" << std::endl;
             return -EINVAL;
         }
 


### PR DESCRIPTION
@AShivangi  this is need your attention about xbutil future enhancement. I left comments in CR: http://jira.xilinx.com/browse/CR-1074448

Basically, we might clean up existing xbutil or design a better way to handle some cases where we want to return errors instead of silently print errors into output, or we want to skip reading one sysfs node but continue to read next sysfs node.

Thanks,
David