### PR TITLE
Do not overwrite exec buf cu_mask

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -49,6 +49,7 @@ struct in_kernel_cb {
  */
 struct kds_command {
 	struct kds_client	*client;
+	u32			cu_idx;
 	u32			 type;
 	u32			 opcode;
 	struct list_head	 list;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -226,12 +226,7 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 		cu_idx = acquire_cu_idx(&kds->cu_mgmt, xcmd);
 		if (cu_idx < 0)
 			return cu_idx;
-		/* write kds selected cu index in the first cumask
-		 * (first word after header of execbuf)
-		 * TODO: I dislike modify the content of the execbuf
-		 * in this place. Let's refine this later.
-		 */
-		xcmd->execbuf[1] = cu_idx;
+		xcmd->cu_idx = cu_idx;
 	} else {
 		/* Configure command define CU index */
 		ret = kds_cu_config(&kds->cu_mgmt, xcmd);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_30.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_30.c
@@ -648,9 +648,18 @@ static inline int process_ert_rq(struct xocl_ert_30 *ert_30)
 		slot_addr = ecmd->slot_idx * (ert_30->cq_range/ert_30->num_slots);
 
 		ERTUSER_DBG(ert_30, "%s slot_addr %x\n", __func__, slot_addr);
+		if (cmd_opcode(ecmd) == OP_CONFIG) {
+			xocl_memcpy_toio(ert_30->cq_base + slot_addr + 4,
+				  ecmd->xcmd->execbuf+1, epkt->count*sizeof(u32));
+		} else {
+			// write kds selected cu_idx in first cumask (first word after header)
+			iowrite32(ecmd->xcmd->cu_idx, ert_30->cq_base + slot_addr + 4);
 
-		xocl_memcpy_toio(ert_30->cq_base + slot_addr + 4,
-				 ecmd->xcmd->execbuf+1, epkt->count*sizeof(u32));
+			// write remaining packet (past header and cuidx)
+			xocl_memcpy_toio(ert_30->cq_base + slot_addr + 8,
+					 ecmd->xcmd->execbuf+2, (epkt->count-1)*sizeof(u32));
+		}
+
 		iowrite32(epkt->header, ert_30->cq_base + slot_addr);
 
 		if (ert_30->cq_intr) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -582,9 +582,17 @@ static inline int process_ert_rq(struct xocl_ert_user *ert_user)
 		slot_addr = ecmd->slot_idx * (ert_user->cq_range/ert_user->num_slots);
 
 		ERTUSER_DBG(ert_user, "%s slot_addr %x\n", __func__, slot_addr);
+		if (cmd_opcode(ecmd) == OP_CONFIG) {
+			xocl_memcpy_toio(ert_user->cq_base + slot_addr + 4,
+				  ecmd->xcmd->execbuf+1, epkt->count*sizeof(u32));
+		} else {
+			// write kds selected cu_idx in first cumask (first word after header)
+			iowrite32(ecmd->xcmd->cu_idx, ert_user->cq_base + slot_addr + 4);
 
-		xocl_memcpy_toio(ert_user->cq_base + slot_addr + 4,
-				 ecmd->xcmd->execbuf+1, epkt->count*sizeof(u32));
+			// write remaining packet (past header and cuidx)
+			xocl_memcpy_toio(ert_user->cq_base + slot_addr + 8,
+					 ecmd->xcmd->execbuf+2, (epkt->count-1)*sizeof(u32));
+		}
 
 		iowrite32(epkt->header, ert_user->cq_base + slot_addr);
 


### PR DESCRIPTION
We can achieve 200kops with new KDS+ert3.0

./host.exe -k /opt/xilinx/firmware/u50/gen3x16-xdma/base/test/verify.xclbin -d 1
Test running...(pid: 19000, xclbin loaded in 3226.54 ms)
thread 0 running kernel name: hello:{hello_1}

kernel execution throughput:
        process(es): 1
        thread(s) per process: 1
        queue length: 32
        throughput: 206313 ops/s (30000 executions in 145.41 ms)
