### PR TITLE
xbutil dump json should dump new mac address as well

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -967,7 +967,7 @@ static void xmc_bdinfo(struct platform_device *pdev, enum data_kind kind,
 		case MAC_CONT_NUM:
 			*buf = xmc->mac_contiguous_num;
 			break;
-		case MAC_CONT_FIRST:
+		case MAC_ADDR_FIRST:
 			memcpy(buf, xmc->mac_addr_first, XMC_BDINFO_MAC_LEN);
 			break;
 		default:
@@ -1020,6 +1020,12 @@ static void xmc_bdinfo(struct platform_device *pdev, enum data_kind kind,
 		case EXP_BMC_VER:
 			memcpy(buf, bdinfo->exp_bmc_ver,
 					XMC_BDINFO_ENTRY_LEN_MAX);
+			break;
+		case MAC_CONT_NUM:
+			*buf = bdinfo->mac_contiguous_num;
+			break;
+		case MAC_ADDR_FIRST:
+			memcpy(buf, bdinfo->mac_addr_first, XMC_BDINFO_MAC_LEN);
 			break;
 		default:
 			break;
@@ -1143,7 +1149,7 @@ static int xmc_get_data(struct platform_device *pdev, enum xcl_group_kind kind,
 		xmc_bdinfo(pdev, CFG_MODE, &bdinfo->config_mode);
 		xmc_bdinfo(pdev, EXP_BMC_VER, (u32 *)bdinfo->exp_bmc_ver);
 		xmc_bdinfo(pdev, MAC_CONT_NUM, &bdinfo->mac_contiguous_num);
-		xmc_bdinfo(pdev, MAC_CONT_FIRST, (u32 *)bdinfo->mac_addr_first);
+		xmc_bdinfo(pdev, MAC_ADDR_FIRST, (u32 *)bdinfo->mac_addr_first);
 		mutex_unlock(&xmc->mbx_lock);
 		break;
 	default:
@@ -4209,6 +4215,8 @@ static int xmc_load_board_info(struct xocl_xmc *xmc)
 		xmc_bdinfo(xmc->pdev, FAN_PRESENCE, &xmc->fan_presence);
 		xmc_bdinfo(xmc->pdev, CFG_MODE, &xmc->config_mode);
 		xmc_bdinfo(xmc->pdev, EXP_BMC_VER, (u32 *)xmc->exp_bmc_ver);
+		xmc_bdinfo(xmc->pdev, MAC_CONT_NUM, &xmc->mac_contiguous_num);
+		xmc_bdinfo(xmc->pdev, MAC_ADDR_FIRST, (u32 *)xmc->mac_addr_first);
 
 		if (bd_info_valid(xmc->serial_num) &&
 			!strcmp(xmc->bmc_ver, xmc->exp_bmc_ver)) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1051,7 +1051,7 @@ enum data_kind {
 	XMC_VCCRAM,
 	DATA_RETAIN,
 	MAC_CONT_NUM,
-	MAC_CONT_FIRST,
+	MAC_ADDR_FIRST,
 };
 
 enum mb_kind {

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -61,6 +61,9 @@ int xclGetDebugProfileDeviceInfo(xclDeviceHandle handle, xclDebugProfileDeviceIn
 #define XCL_INVALID_SENSOR_VAL 0
 
 #define indent(level)   std::string((level) * 4, ' ')
+
+#define HEX_02X std::hex << std::uppercase << std::setw(2) << std::setfill('0')
+
 /*
  * Simple command line tool to query and interact with SDx PCIe devices
  * The tool statically links with xcldma HAL driver inorder to avoid
@@ -742,6 +745,8 @@ public:
         std::vector<std::string> clock_freqs;
         std::vector<std::string> dma_threads;
         std::vector<std::string> mac_addrs;
+        int mac_contiguous_num;
+        std::string mac_addr_first;
         bool mig_calibration;
 
         clock_freqs.resize(3);
@@ -759,6 +764,8 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "mac_addr1",               errmsg, mac_addrs[1] );
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "mac_addr2",               errmsg, mac_addrs[2] );
         pcidev::get_dev(m_idx)->sysfs_get( "xmc", "mac_addr3",               errmsg, mac_addrs[3] );
+        pcidev::get_dev(m_idx)->sysfs_get( "xmc", "mac_contiguous_num",      errmsg, mac_contiguous_num, 0);
+        pcidev::get_dev(m_idx)->sysfs_get( "xmc", "mac_addr_first",          errmsg, mac_addr_first);
         pcidev::get_dev(m_idx)->sysfs_get<int>("rom", "ddr_bank_size",       errmsg, ddr_size,  0 );
         pcidev::get_dev(m_idx)->sysfs_get<int>( "rom", "ddr_bank_count_max", errmsg, ddr_count, 0 );
         pcidev::get_dev(m_idx)->sysfs_get( "icap", "clock_freqs",            errmsg, clock_freqs );
@@ -804,14 +811,29 @@ public:
         sensor_tree::put( "board.info.host_mem_size",   xrt_core::utils::unit_convert(host_mem_size) );
         sensor_tree::put( "board.info.max_host_mem_aperture",   xrt_core::utils::unit_convert(max_host_mem_aperture) );
 
-        for (uint32_t i = 0; i < mac_addrs.size(); ++i) {
-            std::string entry_name = "board.info.mac_addr."+std::to_string(i);
+	if (mac_contiguous_num && !mac_addr_first.empty()) {
+	    std::string mac_prefix = mac_addr_first.substr(0, mac_addr_first.find_last_of(":"));
+	    std::string mac_base = mac_addr_first.substr(mac_addr_first.find_last_of(":") + 1);
+	    std::stringstream ss;
+	    uint32_t mac_base_val = 0;
+	    ss << std::hex << mac_base;
+	    ss >> mac_base_val;
 
-            if (mac_addrs[i].empty())
-                continue;
+	    mac_addrs.resize(mac_contiguous_num);
+	    for (uint32_t i = 0; i < (uint32_t)mac_contiguous_num; i++) {
+	        std::string entry_name = "board.info.mac_addr." + std::to_string(i);
+	        std::ostringstream oss;
+		oss << HEX_02X << mac_base_val + i;
 
-            sensor_tree::put( entry_name,     mac_addrs[i]);
-        }
+		sensor_tree::put(entry_name, mac_prefix + ":" + oss.str());
+	    }
+	} else {
+	    for (uint32_t i = 0; i < mac_addrs.size(); ++i) {
+	        std::string entry_name = "board.info.mac_addr."+std::to_string(i);
+	        if (!mac_addrs[i].empty())
+		    sensor_tree::put(entry_name, mac_addrs[i]);
+	    }
+	}
         //interface uuid
         std::vector<std::string> interface_uuid;
         pcidev::get_dev(m_idx)->sysfs_get( "", "interface_uuids", errmsg, interface_uuid );

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -62,8 +62,6 @@ int xclGetDebugProfileDeviceInfo(xclDeviceHandle handle, xclDebugProfileDeviceIn
 
 #define indent(level)   std::string((level) * 4, ' ')
 
-#define HEX_02X std::hex << std::uppercase << std::setw(2) << std::setfill('0')
-
 /*
  * Simple command line tool to query and interact with SDx PCIe devices
  * The tool statically links with xcldma HAL driver inorder to avoid
@@ -811,29 +809,30 @@ public:
         sensor_tree::put( "board.info.host_mem_size",   xrt_core::utils::unit_convert(host_mem_size) );
         sensor_tree::put( "board.info.max_host_mem_aperture",   xrt_core::utils::unit_convert(max_host_mem_aperture) );
 
-	if (mac_contiguous_num && !mac_addr_first.empty()) {
-	    std::string mac_prefix = mac_addr_first.substr(0, mac_addr_first.find_last_of(":"));
-	    std::string mac_base = mac_addr_first.substr(mac_addr_first.find_last_of(":") + 1);
-	    std::stringstream ss;
-	    uint32_t mac_base_val = 0;
-	    ss << std::hex << mac_base;
-	    ss >> mac_base_val;
+        if (mac_contiguous_num && !mac_addr_first.empty()) {
+            std::string mac_prefix = mac_addr_first.substr(0, mac_addr_first.find_last_of(":"));
+            std::string mac_base = mac_addr_first.substr(mac_addr_first.find_last_of(":") + 1);
+            std::stringstream ss;
+            uint32_t mac_base_val = 0;
+            ss << std::hex << mac_base;
+            ss >> mac_base_val;
 
-	    mac_addrs.resize(mac_contiguous_num);
-	    for (uint32_t i = 0; i < (uint32_t)mac_contiguous_num; i++) {
-	        std::string entry_name = "board.info.mac_addr." + std::to_string(i);
-	        std::ostringstream oss;
-		oss << HEX_02X << mac_base_val + i;
+            mac_addrs.resize(mac_contiguous_num);
+            for (uint32_t i = 0; i < (uint32_t)mac_contiguous_num; i++) {
+                std::string entry_name = "board.info.mac_addr." + std::to_string(i);
+                std::ostringstream oss;
+                oss << boost::format("%02X") % (mac_base_val + i);
 
-		sensor_tree::put(entry_name, mac_prefix + ":" + oss.str());
-	    }
-	} else {
-	    for (uint32_t i = 0; i < mac_addrs.size(); ++i) {
-	        std::string entry_name = "board.info.mac_addr."+std::to_string(i);
-	        if (!mac_addrs[i].empty())
-		    sensor_tree::put(entry_name, mac_addrs[i]);
-	    }
-	}
+                sensor_tree::put(entry_name, mac_prefix + ":" + oss.str());
+            }
+        } else {
+            for (uint32_t i = 0; i < mac_addrs.size(); ++i) {
+                std::string entry_name = "board.info.mac_addr."+std::to_string(i);
+                if (!mac_addrs[i].empty())
+                    sensor_tree::put(entry_name, mac_addrs[i]);
+            }
+        }
+
         //interface uuid
         std::vector<std::string> interface_uuid;
         pcidev::get_dev(m_idx)->sysfs_get( "", "interface_uuids", errmsg, interface_uuid );


### PR DESCRIPTION
Sorry, I found the dump json will include mac addresses as well from user pf. Please take a look.

> Test Result
```
u55n
./xbutil dump -d 0|grep -A10 mac_add
            "mac_addr": {
                "0": "00:0A:35:08:83:01",
                "1": "00:0A:35:08:83:02",
                "2": "00:0A:35:08:83:03",
                "3": "00:0A:35:08:83:04",
                "4": "00:0A:35:08:83:05",
                "5": "00:0A:35:08:83:06",
                "6": "00:0A:35:08:83:07",
                "7": "00:0A:35:08:83:08"
            }
        },

u50 legacy
./xbutil dump -d 2|grep -A5 mac_add
            "mac_addr": {
                "0": "00:0A:35:06:47:7D",
                "1": "00:0A:35:06:47:7E",
                "2": "00:0A:35:06:47:7F",
                "3": "00:0A:35:06:47:80"
            }
```

