### PR TITLE
CR-1075962 Use std::chrono instead of xrt::run::wait(unsigned int tim…

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -446,11 +446,11 @@ public:
   }
 
   ert_cmd_state
-  wait(unsigned int timeout_ms) const
+  wait(const std::chrono::milliseconds& timeout_ms) const
   {
     std::unique_lock<std::mutex> lk(m_mutex);
     while (!m_done)
-      m_exec_done.wait_for(lk, timeout_ms * 1ms);
+      m_exec_done.wait_for(lk, timeout_ms);
 
     auto pkt = get_ert_packet();
     return static_cast<ert_cmd_state>(pkt->state);
@@ -1252,9 +1252,9 @@ public:
 
   // wait() - wait for execution to complete
   ert_cmd_state
-  wait(unsigned int timeout_ms) const
+  wait(const std::chrono::milliseconds& timeout_ms) const
   {
-    return timeout_ms ? cmd->wait(timeout_ms) : cmd->wait();
+    return timeout_ms.count() ? cmd->wait(timeout_ms) : cmd->wait();
   }
 
   // state() - get current execution state
@@ -1552,7 +1552,7 @@ ert_cmd_state
 xrtRunWait(xrtRunHandle rhdl, unsigned int timeout_ms)
 {
   auto run = get_run(rhdl);
-  return run->wait(timeout_ms);
+  return run->wait(timeout_ms * 1ms);
 }
 
 void
@@ -1634,7 +1634,7 @@ start()
 
 ert_cmd_state
 run::
-wait(unsigned int timeout_ms) const
+wait(const std::chrono::milliseconds& timeout_ms) const
 {
   return handle->wait(timeout_ms);
 }

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -98,16 +98,17 @@ class run
   /**
    * wait() - Wait for a run to complete execution
    *
-   * @timeout_ms:  Timeout for wait.
-   * Return:       Command state upon return of wait
+   * @timeout:  Timeout for wait (default block till run completes)
+   * Return:    Command state upon return of wait
+   *
+   * The default timeout of 0ms indicates blocking until run completes.
    *
    * The current thread will block until the run completes or timeout
    * expires. Completion does not guarantee success, the run status
    * should be checked by using @state.
    */
-  XCL_DRIVER_DLLESPEC
   ert_cmd_state
-  wait(unsigned int timeout_ms=0) const;
+  wait(const std::chrono::milliseconds& timeout = std::chrono::milliseconds{0}) const;
 
   /**
    * state() - Check the current state of a run object


### PR DESCRIPTION
…eout_ms=0)

Change C++ API to use std::chrono::milliseconds