### PR TITLE
print vbnv instead of board name

### DIFF
--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -106,7 +106,7 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   for(auto& kd : available_devices) {
     boost::property_tree::ptree& dev = kd.second;
     std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-    _output << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("board") % note;
+    _output << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
   }
   _output << std::endl;
   

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -531,7 +531,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
     for(auto& kd : available_devices) {
       boost::property_tree::ptree& dev = kd.second;
-      std::cout << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("board");
+      std::cout << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
     }
     std::cout << std::endl;
     return;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -517,5 +517,9 @@ bool XMC_Flasher::isBMCReady()
 
 bool XMC_Flasher::hasSC()
 {
-    return xrt_core::device_query<xrt_core::query::xmc_sc_presence>(m_device);
+    bool sc_presence = false;
+    try {
+        sc_presence = xrt_core::device_query<xrt_core::query::xmc_sc_presence>(m_device);
+    } catch(...) { }
+    return sc_presence;
 }


### PR DESCRIPTION
- **CR-1076161 Regression - xbutil2 does not show platform**
- **CR-1076666 xbutil2 reports "no such node" while xbutil1 can work properly**

Sample outputs:
- Tested with 1rp, 2rp and golden
- Fixed outputs in xbmgmt program and examine
```
$ xbmgmt --new program
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------

ERROR: Device not specified.

List of available devices:
  [0000:b3:00.0] : xilinx_u200_xdma_201830_3
  [0000:65:00.0] : xilinx_u250_gen3x16_xdma_shell_2_1


$ xbutil --new examine
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
System Configuration
  OS Name              : Linux
  Release              : 4.4.0-142-generic
  Version              : #168-Ubuntu SMP Wed Jan 16 21:00:45 UTC 2019
  Machine              : x86_64
  Distribution         : Ubuntu 16.04.5 LTS
  GLIBC                : 2.23

XRT
  Version              : 2.8.0
  Branch               : cleanup
  Hash                 : 98be785bf8b6704407e317f4ee70b2d3d352b210
  Hash Date            : 2020-09-21 15:49:03
  XOCL                 : 2.8.0, 64cd06169dd513df9fc5f8764fa1a148bdfc66ea
  XCLMGMT              : 2.8.0, 64cd06169dd513df9fc5f8764fa1a148bdfc66ea

Devices
  [0000:b3:00.1] : xilinx_u200_xdma_201830_3
  [0000:65:00.1] : xilinx_u250_gen3x16_xdma_shell_2_1
```
- With a golden card:
```

$ xbmgmt --new program
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------

ERROR: Device not specified.

List of available devices:
  [0000:65:00.0] : xilinx_u250_gen3x16_base_2
  [0000:b3:00.0] : xilinx_u200_GOLDEN

$ xbutil --new examine
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
System Configuration
  OS Name              : Linux
  Release              : 4.4.0-142-generic
  Version              : #168-Ubuntu SMP Wed Jan 16 21:00:45 UTC 2019
  Machine              : x86_64
  Distribution         : Ubuntu 16.04.5 LTS
  GLIBC                : 2.23

XRT
  Version              : 2.8.0
  Branch               : cleanup
  Hash                 : 98be785bf8b6704407e317f4ee70b2d3d352b210
  Hash Date            : 2020-09-21 16:04:35
  XOCL                 : 2.8.0, 64cd06169dd513df9fc5f8764fa1a148bdfc66ea
  XCLMGMT              : 2.8.0, 64cd06169dd513df9fc5f8764fa1a148bdfc66ea

Devices
  [0000:65:00.1] : xilinx_u250_gen3x16_base_2
```

 - **XRT-730 xbmgmt2 negative testing error regression**
Sample output: 
```
$ xbmgmt --new status -d 0000:b3:00.0
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------
Device : [0000:b3:00.0]

Flash properties
  Type                 : spi
  Serial Number        :

Flashable partitions running on FPGA
  Platform             : xilinx_u200_GOLDEN
  SC Version           :
  Platform ID          : N/A

Flashable partitions installed in system
  Platform             : xilinx_u200_xdma_201830_3
  SC Version           : 4.3.9
  Platform ID          : 0x5ee83d83
```


