### PR TITLE
firewall and plp fix

### DIFF
--- a/src/runtime_src/core/tools/common/ReportFirewall.cpp
+++ b/src/runtime_src/core/tools/common/ReportFirewall.cpp
@@ -17,6 +17,8 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "ReportFirewall.h"
+#include "core/common/query_requests.h"
+#include "core/common/utils.h"
 
 void
 ReportFirewall::getPropertyTreeInternal( const xrt_core::device * _pDevice,
@@ -28,23 +30,33 @@ ReportFirewall::getPropertyTreeInternal( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportFirewall::getPropertyTree20202( const xrt_core::device * /*_pDevice*/,
+ReportFirewall::getPropertyTree20202( const xrt_core::device * _pDevice,
                                        boost::property_tree::ptree &_pt) const
 {
   boost::property_tree::ptree pt;
   pt.put("Description","Firewall Information");
 
+  pt.put("firewall_level", xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
+  pt.put("firewall_status", boost::format("0x%x") % xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
+  pt.put("status", xrt_core::utils::parse_firewall_status(xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice)));
   // There can only be 1 root node
   _pt.add_child("firewall", pt);
 }
 
 
 void 
-ReportFirewall::writeReport(const xrt_core::device * /*_pDevice*/,
+ReportFirewall::writeReport(const xrt_core::device * _pDevice,
                             const std::vector<std::string> & /*_elementsFilter*/,
                             std::iostream & _output) const
 {
-  _output << "ReportFirewall - Hello world\n";
+  boost::property_tree::ptree _pt;
+  boost::property_tree::ptree empty_ptree;
+  getPropertyTreeInternal(_pDevice, _pt);
+
+  _output << "Firewall\n";
+  _output << boost::format("  %s %d: %s %s\n\n") % "Level" % _pt.get<std::string>("firewall.firewall_level") 
+              % _pt.get<std::string>("firewall.firewall_status") % _pt.get<std::string>("firewall.status");
+
 }
 
 

--- a/src/runtime_src/core/tools/common/ReportFirewall.cpp
+++ b/src/runtime_src/core/tools/common/ReportFirewall.cpp
@@ -38,7 +38,7 @@ ReportFirewall::getPropertyTree20202( const xrt_core::device * _pDevice,
 
   pt.put("firewall_level", xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
   pt.put("firewall_status", boost::format("0x%x") % xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
-  pt.put("status", xrt_core::utils::parse_firewall_status(xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice)));
+  pt.put("status", xrt_core::utils::parse_firewall_status(static_cast<unsigned int>(xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice))));
   // There can only be 1 root node
   _pt.add_child("firewall", pt);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -474,8 +474,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' indicates that every found device should be examined.")
     ("partition", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
-                                                                      "  Name (and path) of the partition.\n"
-                                                                      "  Parition's UUID")
+                                                                      "  Name (and path) of the partition.")
     ("update", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images.  Value values:\n"
                                                                          "  ALL   - All images will be updated"
                                                                      /*  "  FLASH - Flash image\n"

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -480,10 +480,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
                                                                          "  ALL   - All images will be updated"
                                                                      /*  "  FLASH - Flash image\n"
                                                                          "  SC    - Satellite controller"*/)
-    ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(), "Specifies an image to use used to update the persistent device(s).  Value values:\n"
-                                                                      "  Name (and path) to the mcs image on disk\n"
-                                                                      "  Name (and path) to the xsabin image on disk\n"
-                                                                      "Note: Multiple images can be specified separated by a space")
     ("force,f", boost::program_options::bool_switch(&force), "Force update the flash image")
     ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image.  Note: This currently only applies to the flash image.")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
@@ -494,6 +490,10 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     ("flash-type", boost::program_options::value<decltype(flashType)>(&flashType), "Overrides the flash mode. Use with caution.  Value values:\n"
                                                                     "  ospi\n"
                                                                     "  ospi_versal")
+    ("image", boost::program_options::value<decltype(image)>(&image)->multitoken(), "Specifies an image to use used to update the persistent device(s).  Value values:\n"
+                                                                    "  Name (and path) to the mcs image on disk\n"
+                                                                    "  Name (and path) to the xsabin image on disk\n"
+                                                                    "Note: Multiple images can be specified separated by a space")
   ;
 
   po::options_description allOptions("All Options");  
@@ -630,27 +630,11 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     if(xrt_core::device_query<xrt_core::query::interface_uuids>(dev).empty())
       throw xrt_core::error("Can not get BLP interface uuid. Please make sure corresponding BLP package is installed.");
 
-    std::vector<DSAInfo> available_partitions;
-    auto installedDSAs = firmwareImage::getIntalledDSAs();
-    for (const auto& dsa : installedDSAs) {
-      if (dsa.uuids.size() != 0) {
-        if (dsa.name.compare(plp) == 0 || dsa.matchIntId(plp))
-          available_partitions.push_back(dsa);
-      }
-    }
+    // Check if file exists
+    if (!boost::filesystem::exists(plp))
+      throw xrt_core::error("File not found. Please specify the correct path");
 
-    if (available_partitions.empty())
-      throw xrt_core::error("No matching partition found");
-
-    if (available_partitions.size() > 1) {
-      std::stringstream errmsg;
-      errmsg << "Multiple partitions found with the same name. Please specify the UUID\n";
-      for (const auto& d : available_partitions)
-        errmsg << boost::format("  - %s [0x%x]\n") % d.name % d.timestamp;
-      throw xrt_core::error(errmsg.str());
-    }
-
-    DSAInfo dsa(available_partitions.front());
+    DSAInfo dsa(plp);
     //TO_DO: add a report for plp before asking permission to proceed. Replace following 2 lines
     std::cout << "Programming PLP on Card [" << flasher.sGetDBDF() << "]..." << std::endl;
     std::cout << "Partition file: " << dsa.file << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -825,11 +825,11 @@ static std::vector<TestCollection> testSuite = {
  * print basic information about a test
  */
 static void
-pretty_print_test_desc(const boost::property_tree::ptree& test, 
+pretty_print_test_desc(const boost::property_tree::ptree& test, int test_idx,
                        size_t testSuiteSize, std::ostream & _ostream)
 {
-  _ostream << boost::format("%d/%d Test #%-10d: %s\n") % test.get<int>("id") % testSuiteSize
-                    % test.get<int>("id") % test.get<std::string>("name");
+  _ostream << boost::format("%d/%d Test #%-10d: %s\n") % test_idx % testSuiteSize
+                    % test_idx % test.get<std::string>("name");
   _ostream << boost::format("    %-16s: %s\n") % "Description" % test.get<std::string>("description");
 }
 
@@ -926,11 +926,12 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
 
   get_platform_info(device, ptDeviceInfo, schemaVersion, _ostream);
 
+  int test_idx = 0;
   for (TestCollection * testPtr : testObjectsToRun) {
     boost::property_tree::ptree ptTest = testPtr->ptTest; // Create a copy of our entry
 
     if(schemaVersion == Report::SchemaVersion::text)
-      pretty_print_test_desc(ptTest, testObjectsToRun.size(), _ostream);
+      pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream);
 
     testPtr->testHandle(device, ptTest);
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );


### PR DESCRIPTION
- Specify the whole path for plp
```
$ sudo xbmgmt --new program -d 0000:65:00.0 --partition=/lib/firmware/xilinx/abad927204cb200a2e88751e9d582807/partition.xsabin
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------
Programming PLP on Card [0000:65:00.0]...
Partition file: /lib/firmware/xilinx/abad927204cb200a2e88751e9d582807/partition.xsabin
Programmed PLP successfully

$ sudo xbmgmt --new program -d 0000:65:00.0 --partition=/lib/firmware/xilinx/abad927204cb200a2e88751e9d582807/partition.xs
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------
XRT build version: 2.8.0
Build hash: a003d156b98a665d2c4aca5687d537ee003faf61
Build date: 2020-09-22 17:15:07
Git branch: firewall
PID: 3983
UID: 0
[Wed Sep 23 01:29:35 2020 GMT]
HOST: xsjsagarwal
EXE: /proj/xsjhdstaff1/sagarw/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbmgmt2
[xbmgmt] ERROR: File not found. Please specify the correct path
```
- XRT-760 xbutil examine report "firewall" is not implemented

```
$ xbutil --new examine -r firewall
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
Firewall
  Level 0: 0x0 (GOOD)
```
- make image option hidden