### PR TITLE
CR-1077533 ASTeR Basic Sanity - U55N xbutil validate hangs

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2676,7 +2676,6 @@ struct xocl_subdev_map {
 		.subdev_info	= RES_MGMT_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
 		.flash_type = FLASH_TYPE_SPI,				\
-		.sched_bin = "xilinx/sched_v20.bin",			\
 		.board_name = "u55n",					\
 		.vbnv = "xilinx_u55n"					\
 	}


### PR DESCRIPTION
Tested on u55n, this changes + metadata fix will work.