### PR TITLE
flash type reported by vsec is not fine-grained

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
@@ -232,8 +232,6 @@ XQSPIPS_Flasher::XQSPIPS_Flasher(std::shared_ptr<pcidev::pci_device> dev)
 
     // maybe initialized QSPI here
     if (typeStr.empty())
-        mDev->sysfs_get("flash", "flash_type", err, typeStr);
-    if (typeStr.empty())
         mDev->sysfs_get("", "flash_type", err, typeStr);
 
     // By default, it is 'perallel'


### PR DESCRIPTION
qspi flash type reported by vsec is not fine-grained to tell it is single or not, qspi flasher should rely on the flash type defined in devices.h to get the accurate info