### PR TITLE
Add xrt profiling support.

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -174,6 +174,27 @@ wait_gmio(xrtDeviceHandle dhdl, const char *gmio_name)
   device->wait_gmio(gmio_name);
 }
 
+static int
+start_profiling(xrtDeviceHandle dhdl, int option, const char *port1_name, const char *port2_name, uint32_t value)
+{
+  auto device = xrt_core::device_int::get_core_device(dhdl);
+  return device->start_profiling(option, port1_name, port2_name, value);
+}
+
+static uint64_t
+read_profiling(xrtDeviceHandle dhdl, int phdl)
+{
+  auto device = xrt_core::device_int::get_core_device(dhdl);
+  return device->read_profiling(phdl);
+}
+
+static void
+stop_profiling(xrtDeviceHandle dhdl, int phdl)
+{
+  auto device = xrt_core::device_int::get_core_device(dhdl);
+  return device->stop_profiling(phdl);
+}
+
 inline void
 send_exception_message(const char* msg)
 {
@@ -474,6 +495,92 @@ xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
 {
   try {
     wait_gmio(handle, gmioName);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+/**
+ * xrtStartProfiling() - Start AIE performance profiling
+ *
+ * @handle:          Handle to the device
+ * @option:          Profiling option.
+ * @port1Name:       Profiling port 1 name
+ * @port2Name:       Profiling port 2 name
+ * @value:           The number of bytes to trigger the profiling event
+ *
+ * Return:         An integer profiling handle on success, -1 on error.
+ *
+ * This function configures the performance counters in AI Engine by given
+ * port names and value. The port names and value will have different
+ * meanings on different options.
+ *
+ * Note: Currently, the only supported io profiling option is
+ *       io_stream_running_event_count (GMIO)
+ */
+int
+xrtStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, const char *port2Name, uint32_t value)
+{
+  try {
+    return start_profiling(handle, option, port1Name, port2Name, value);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+/**
+ * xrtReadProfiling() - Read the current performance counter value
+ *                      associated with the profiling handle.
+ *
+ * @handle:          Handle to the device
+ * @pHandle:         Profiling handle.
+ *
+ * Return:         The performance counter value, -1 on error.
+ */
+uint64_t
+xrtReadProfiling(xrtDeviceHandle handle, int pHandle)
+{
+  try {
+    return read_profiling(handle, pHandle);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return errno = 0;
+  }
+}
+
+/**
+ * xrtStopProfiling() - Stop the current performance profiling
+ *                      associated with the profiling handle and
+ *                      release the corresponding hardware resources.
+ *
+ * @handle:          Handle to the device
+ * @pHandle:         Profiling handle.
+ *
+ * Return:         0 on success, -1 on error.
+ */
+int
+xrtStopProfiling(xrtDeviceHandle handle, int pHandle)
+{
+  try {
+    stop_profiling(handle, pHandle);
     return 0;
   }
   catch (const xrt_core::error& ex) {

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -156,6 +156,15 @@ struct ishim
 
   virtual void
   wait_gmio(const char *gmioName) = 0;
+
+  virtual int
+  start_profiling(int option, const char* port1Name, const char* port2Name, uint32_t value) = 0;
+
+  virtual uint64_t
+  read_profiling(int phdl) = 0;
+
+  virtual void
+  stop_profiling(int phdl) = 0;
 #endif
 };
 
@@ -463,6 +472,26 @@ struct shim : public DeviceType
     if (auto ret = xclGMIOWait(DeviceType::get_device_handle(), gmioName))
       throw error(ret, "fail to wait gmio");
   }
+
+  virtual int
+  start_profiling(int option, const char* port1Name, const char* port2Name, uint32_t value)
+  {
+    return xclStartProfiling(DeviceType::get_device_handle(), option, port1Name, port2Name, value);
+  }
+
+  virtual uint64_t
+  read_profiling(int phdl)
+  {
+    return xclReadProfiling(DeviceType::get_device_handle(), phdl);
+  }
+
+  virtual void
+  stop_profiling(int phdl)
+  {
+    if (auto ret = xclStopProfiling(DeviceType::get_device_handle(), phdl))
+      throw error(ret, "fail to wait gmio");
+  }
+
 #endif
 };
 

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -149,6 +149,7 @@ get_gmio(const pt::ptree& aie_meta)
     gmio.type = type;
     gmio.shim_col = gmio_node.second.get<uint16_t>("shim_column");
     gmio.channel_number = gmio_node.second.get<uint16_t>("channel_number");
+    gmio.stream_id = gmio_node.second.get<uint16_t>("stream_id");
     gmio.burst_len = gmio_node.second.get<uint16_t>("burst_length_in_16byte");
 
     gmios.emplace_back(std::move(gmio));

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -782,3 +782,21 @@ xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
 {
   return 0;
 }
+
+int
+xclStartProfiling(xclDeviceHandle handle, int option, const char* port1Name, const char* port2Nmae, uint32_t value)
+{
+  return 0;
+}
+
+uint64_t
+xclReadProfiling(xclDeviceHandle handle, int phdl)
+{
+  return 0;
+}
+
+int
+xclStopProfiling(xclDeviceHandle handle, int phdl)
+{
+  return 0;
+}

--- a/src/runtime_src/core/edge/user/aie/AIEResources.cpp
+++ b/src/runtime_src/core/edge/user/aie/AIEResources.cpp
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "AIEResources.h"
+#include <iostream>
+
+#include "core/common/error.h"
+#include "core/common/message.h"
+
+namespace zynqaie
+{
+namespace Resources
+{
+    /// performanceCounters, traceEvents, eventBroadcasts are short (int16) arrays where individual element stores the event handle (short, int16) that holds the resources.
+    /// The default element value is -1 (invalid_handle) meaning the resources is available.
+    /// NOTE: to reduce memory footprint for AIEResources, short (int16) data type is used. In adf.h, handle is typedef as int.
+    const short invalid_handle = -1;
+    const short ecc_scrubbing_reserve = -2;
+
+    Module::Module() :
+        traceEvents{ -1, -1, -1, -1, -1, -1, -1, -1 },
+        eventBroadcasts{ -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 },
+        numUsedTraceEvents(0),
+        numUsedBroadcasts(0),
+        traceUnitPacketId(-1)
+    {
+    }
+
+    /// explicit specialization of PerformanceCounter<4>::PerformanceCounter()
+    template<> PerformanceCounter<4>::PerformanceCounter() :
+        performanceCounters { -1, -1, -1, -1 } //4-element performanceCounters
+    {
+    }
+
+    /// explicit specialization of PerformanceCounter<2>::PerformanceCounter()
+    template<> PerformanceCounter<2>::PerformanceCounter() :
+        performanceCounters { -1, -1 } //2-element performanceCounters
+    {
+    }
+
+    CoreAndPLModule::CoreAndPLModule() :
+        streamSwitchEventPorts { -1, -1, -1, -1, -1, -1, -1, -1 },
+        numUsedStreamSwitchEventPorts(0)
+    {
+    }
+
+    CoreModule::CoreModule() :
+        programCounters{ -1, -1, -1, -1 }
+    {
+    }
+
+    template<size_t NUM_PERF_COUNTERS> int PerformanceCounter<NUM_PERF_COUNTERS>::requestPerformanceCounter(short handle)
+    {
+        int index = -1;
+        for (int i=0; i<NUM_PERF_COUNTERS; i++)
+        {
+            if (performanceCounters[i] == invalid_handle)
+            {
+                performanceCounters[i] = handle;
+                index = i;
+                numUsedPerformnceCounters++;
+                break;
+            }
+        }
+        return index;
+    }
+
+    template<size_t NUM_PERF_COUNTERS> bool PerformanceCounter<NUM_PERF_COUNTERS>::requestPerformanceCounter(short handle, size_t index)
+    {
+        bool bResult = false;
+        if (index < NUM_PERF_COUNTERS)
+        {
+            if (performanceCounters[index] == invalid_handle)
+            {
+                performanceCounters[index] = handle;
+                numUsedPerformnceCounters++;
+                bResult = true;
+            }
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the performance counters");
+
+        return bResult;
+    }
+
+    template<size_t NUM_PERF_COUNTERS> void PerformanceCounter<NUM_PERF_COUNTERS>::releasePerformanceCounter(short handle, size_t index)
+    {
+        if (index < NUM_PERF_COUNTERS)
+        {
+            if (performanceCounters[index] == handle)
+            {
+                performanceCounters[index] = invalid_handle;
+                numUsedPerformnceCounters--;
+            }
+            else
+                throw xrt_core::error(-EINVAL, "Failed to release performance counter because the event handle is not the resource owner");
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the performance counters.");
+    }
+
+    template<size_t NUM_PERF_COUNTERS> int PerformanceCounter<NUM_PERF_COUNTERS>::getNumUsedPerformanceCounters()
+    {
+        return numUsedPerformnceCounters;
+    }
+
+    int Module::requestTraceEvent(short handle)
+    {
+        int index = -1;
+        for (int i=0; i<NUM_TRACE_EVENTS && numUsedTraceEvents < NUM_TRACE_EVENTS; i++)
+        {
+            if (traceEvents[i] == invalid_handle)
+            {
+                traceEvents[i] = handle;
+                index = i;
+                numUsedTraceEvents++;
+                break;
+            }
+        }
+        return index;
+    }
+
+    void Module::releaseTraceEvent(short handle, size_t index)
+    {
+        if (index < NUM_TRACE_EVENTS)
+        {
+            if (traceEvents[index] == handle)
+            {
+                traceEvents[index] = invalid_handle;
+                numUsedTraceEvents--;
+            }
+            else
+                throw xrt_core::error(-EINVAL, "Failed to release trace event because the event handle is not the resource owner");
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the trace events");
+    }
+
+    int Module::getNumUsedTraceEvents()
+    {
+        return numUsedTraceEvents;
+    }
+
+    int Module::getNumUsedBroadcasts()
+    {
+        return numUsedBroadcasts;
+    }
+
+    void Module::setTraceUnitPacketId(short id)
+    {
+        traceUnitPacketId = id;
+    }
+
+    short Module::getTraceUnitPacketId()
+    {
+        return traceUnitPacketId;
+    }
+
+    bool Module::isRunning()
+    {
+        return numUsedTraceEvents==0;
+    }
+
+    int Module::requestEventBroadcast(short handle)
+    {
+        int index = -1;
+        for (int i = NUM_EVENT_BROADCASTS -1; i >= 0; i--)
+        {
+            if (eventBroadcasts[i] == invalid_handle)
+            {
+                eventBroadcasts[i] = handle;
+                index = i;
+                numUsedBroadcasts++;
+                break;
+            }
+        }
+        return index;
+    }
+
+    int Module::requestEventBroadcast(short handle, size_t index)
+    {
+        int returnIndex = -1;
+        if (index < NUM_EVENT_BROADCASTS)
+        {
+            if (eventBroadcasts[index] == invalid_handle)
+            {
+                eventBroadcasts[index] = handle;
+                returnIndex = index;
+                numUsedBroadcasts++;
+            }
+            else
+                throw xrt_core::error(-EINVAL, "Failed to grant event broadcast index because the resources is taken");
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the event broadcasts");
+        return returnIndex;
+    }
+
+    void Module::releaseEventBroadcast(short handle, size_t index)
+    {
+        if (index < NUM_EVENT_BROADCASTS)
+        {
+            if (eventBroadcasts[index] == handle)
+            {
+                eventBroadcasts[index] = invalid_handle;
+                numUsedBroadcasts--;
+            }
+            else
+                throw xrt_core::error(-EINVAL, "Failed to release event broadcast because the event handle is not the resource owner");
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the event broadcasts");
+    }
+
+    std::vector<short> Module::availableEventBroadcast() const
+    {
+        return std::vector<short>(eventBroadcasts, eventBroadcasts + NUM_EVENT_BROADCASTS);
+    }
+
+    int CoreAndPLModule::requestStreamEventPort(short handle)
+    {
+        int index = -1;
+        //The first 10? event broadcasts may be reserved for interrupt handler, so grant the resources from the last event broadcast
+        for (int i=0; i<NUM_STREAM_SWITCH_EVENT_PORTS; i++)
+        {
+            if (streamSwitchEventPorts[i] == invalid_handle)
+            {
+                streamSwitchEventPorts[i] = handle;
+                index = i;
+                numUsedStreamSwitchEventPorts++;
+                break;
+            }
+        }
+        return index;
+    }
+
+    void CoreAndPLModule::releaseStreamEventPort(short handle, size_t index)
+    {
+        if (index < NUM_STREAM_SWITCH_EVENT_PORTS)
+        {
+            if (streamSwitchEventPorts[index] == handle) {
+                streamSwitchEventPorts[index] = invalid_handle;
+                numUsedStreamSwitchEventPorts--; }
+            else
+                throw xrt_core::error(-EINVAL, "Failed to release stream switch event port because the event handle is not the resource owner");
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the stream switch event ports");
+    }
+
+    int CoreAndPLModule::getNumUsedStreamEventPorts()
+    {
+        return numUsedStreamSwitchEventPorts;
+    }
+
+
+    int CoreModule::requestProgramCounter(short handle)
+    {
+        int index = -1;
+        for (int i = 0; i<NUM_PROGRAM_COUNTERS; i++)
+        {
+            if (programCounters[i] == invalid_handle)
+            {
+                programCounters[i] = handle;
+                index = i;
+                break;
+            }
+        }
+        return index;
+    }
+
+    std::pair<int, int> CoreModule::requestProgramCountersForRange(short handle)
+    {
+        //For PC range, it needs to be (0,1) or (2,3)
+        if (programCounters[0] == invalid_handle && programCounters[1] == invalid_handle)
+        {
+            programCounters[0] = programCounters[1] = handle;
+            return std::pair<int, int>(0, 1);
+        }
+        else if (programCounters[2] == invalid_handle && programCounters[3] == invalid_handle)
+        {
+            programCounters[2] = programCounters[3] = handle;
+            return std::pair<int, int>(2, 3);
+        }
+        else
+            return std::pair<int, int>(-1, -1);
+    }
+
+    short CoreModule::getTraceUnitPacketType()
+    {
+        return CORE_MODULE_TYPE;
+    }
+
+    void CoreModule::releaseProgramCounter(short handle, size_t index)
+    {
+        if (index < NUM_PROGRAM_COUNTERS)
+        {
+            if (programCounters[index] == handle)
+                programCounters[index] = invalid_handle;
+            else
+                throw xrt_core::error(-EINVAL, "Failed to release program counter because the event handle is not the resource owner");
+        }
+        else
+            throw xrt_core::error(-EINVAL, "Index is outside the range of the program counters");
+    }
+
+    short MemoryModule::getTraceUnitPacketType()
+    {
+        return MEMORY_MODULE_TYPE;
+    }
+
+    short PLModule::getTraceUnitPacketType()
+    {
+        return PL_MODULE_TYPE;
+    }
+
+    //AIE::s_meTiles and AIE::s_shimTiles were static class std::vector member objects, which construction is like global objects.
+    //In C++ the constructor order for global objects across translation units are undefined.
+    //In aie_control.cpp, class initializeAIEControl {...} initAIEControl;
+    //The initAIEControl is a global object, which in turns calls AIE::initialize.
+    //However, it is possible that AIE::s_meTiles and AIE::s_shimTiles are constructed after initAIEControl, in that case, AIE::s_meTiles and AIE::s_shimTiles will be re-constructed back to empty.
+    //See http://jira.xilinx.com/browse/CR-1058390.
+    //The solution in 2020.1 is to make AIE::s_meTiles and AIE::s_shimTiles pointers. g++ compiler should be smart enough to initialize pointers as nulls in ".data" section, so there is no "construction" order against initAIEControl.
+    AIETile* AIE::s_meTiles = nullptr;
+    ShimTile* AIE::s_shimTiles = nullptr;
+    size_t AIE::s_numColumns = 0;
+    size_t AIE::s_numAIERows = 0;
+
+    void AIE::initialize(size_t numColumns, size_t numAIERows)
+    {
+        //FIXME check parameters
+        s_numColumns = numColumns;
+        s_numAIERows = numAIERows;
+        try
+        {
+            s_shimTiles = new ShimTile[numColumns];
+            s_meTiles = new AIETile[numColumns * numAIERows];
+        }
+        catch (std::exception& e)
+        {
+            std::cerr << "EXCEPTION: Resizing trace resource structures : " << e.what() << std::endl;
+        }
+    }
+
+    ShimTile* AIE::getShimTile(size_t column)
+    {
+        if (column < s_numColumns)
+            return &s_shimTiles[column];
+        else
+        {
+            std::cerr<<"ERROR: Column index " << column << " is outside the number of columns " << s_numColumns << " in the AIE array."<<std::endl;
+            return nullptr;
+        }
+    }
+
+    AIETile* AIE::getAIETile(size_t column, size_t row)
+    {
+        if (column < s_numColumns && row < s_numAIERows)
+            return &s_meTiles[column * s_numAIERows + row];
+        else
+        {
+            std::cerr << "ERROR: Column or Row index is outside the AIE array dimensions." << std::endl;
+            return nullptr;
+        }
+    }
+
+    /// Reserve the 0th performance counter for ECC Scrubbing in all core modules
+    /// This is an agreement with SSW AIE Driver team in 2020.2
+    /// Eventually, AIEResources will be replaced with AIE driver's resources manager
+    bool AIE::reservePerformanceCounterEccScrubbing()
+    {
+        bool bResult = true;
+        size_t numAIETiles = s_numColumns * s_numAIERows;
+        for (int i = 0; i < numAIETiles; i++)
+        {
+            int perfCounterIdx = s_meTiles[i].coreModule.requestPerformanceCounter(ecc_scrubbing_reserve);
+            if (perfCounterIdx != 0)
+                bResult = false;
+        }
+        return bResult;
+    }
+
+
+    //explicit template instantiation to force the symbol exists and prevent linker error
+    template class PerformanceCounter<4>;
+    template class PerformanceCounter<2>;
+}
+}

--- a/src/runtime_src/core/edge/user/aie/AIEResources.h
+++ b/src/runtime_src/core/edge/user/aie/AIEResources.h
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <vector>
+
+extern "C"
+{
+#include "xaiengine/xaiegbl.h"
+}
+
+#define NUM_PERF_COUNTERS_PL 2
+#define NUM_PERF_COUNTERS_MEM 2
+#define NUM_PERF_COUNTERS_CORE 4
+#define NUM_TRACE_EVENTS 8
+#define NUM_STREAM_SWITCH_EVENT_PORTS 8
+#define NUM_EVENT_BROADCASTS 16
+#define NUM_PROGRAM_COUNTERS 4
+#define CORE_MODULE_TYPE 0
+#define MEMORY_MODULE_TYPE 1
+#define PL_MODULE_TYPE 2
+
+namespace zynqaie
+{
+    class ObjectImpl;
+
+namespace Resources
+{
+    /// Module is the base class for core, mem, and pl models.
+    class Module
+    {
+    public:
+        int requestTraceEvent(short handle);
+        void releaseTraceEvent(short handle, size_t index);
+        int getNumUsedTraceEvents();
+        int getNumUsedBroadcasts();
+        int requestEventBroadcast(short handle);
+        int requestEventBroadcast(short handle, size_t index);
+        void releaseEventBroadcast(short handle, size_t index);
+        /// Return vector[i] == -1 (invalid_handle) means available, otherwise unavailable
+        std::vector<short> availableEventBroadcast() const;
+
+        void setTraceUnitPacketId(short id);
+        short getTraceUnitPacketId();
+        
+        virtual short getTraceUnitPacketType() {return -1;}
+        
+        bool isRunning();
+
+    protected:
+        Module();
+
+    protected:
+        short traceEvents[NUM_TRACE_EVENTS];
+        /// eventBroadcasts[i] in core and memory module represents resources for Event_Broadcast_i and Event_Broadcast_Block_{South, West, North, East}_i
+        /// eventBroadcasts[i] in pl module represents resources for Event_Broadcast_i_A and Event_Broadcast_{A, B}_Block_{South, West, North, East}_i
+        short eventBroadcasts[NUM_EVENT_BROADCASTS];
+        unsigned short numUsedBroadcasts;
+        unsigned short numUsedTraceEvents;
+        short traceUnitPacketId;
+    };
+    
+    /// NUM_PERF_COUNTERS is a template parameter to specify static size for performanceCounters array.
+    /// CoreModule, MemoryModule, and PLModule are partially (multiple inheritance) derived from explicit template instantiation of PerformanceCounter<NUM_PERF_COUNTERS_CORE>, PerformanceCounter<NUM_PERF_COUNTERS_MEM>, PerformanceCounter<NUM_PERF_COUNTERS_PL>.
+    template<size_t NUM_PERF_COUNTERS> class PerformanceCounter
+    {
+    public:
+        int requestPerformanceCounter(short handle);
+        bool requestPerformanceCounter(short handle, size_t index);	
+        void releasePerformanceCounter(short handle, size_t index);
+        int getNumUsedPerformanceCounters();
+
+    protected:
+        PerformanceCounter();
+
+    protected:
+        short performanceCounters[NUM_PERF_COUNTERS];
+        unsigned short numUsedPerformnceCounters;
+    };
+
+    class CoreAndPLModule : public Module
+    {
+    public:
+        int requestStreamEventPort(short handle);
+        void releaseStreamEventPort(short handle, size_t index);
+        int getNumUsedStreamEventPorts();
+    protected:
+        CoreAndPLModule();
+
+    protected:
+        short streamSwitchEventPorts[NUM_STREAM_SWITCH_EVENT_PORTS];
+	unsigned short numUsedStreamSwitchEventPorts;
+    };
+    
+    class CoreModule : public CoreAndPLModule, public PerformanceCounter<NUM_PERF_COUNTERS_CORE>
+    {
+    public:
+        CoreModule();
+
+        int requestProgramCounter(short handle);
+        std::pair<int, int> requestProgramCountersForRange(short handle);
+        void releaseProgramCounter(short handle, size_t index);
+        short getTraceUnitPacketType() override;
+
+    private:
+        short programCounters[NUM_PROGRAM_COUNTERS];
+    };
+    
+    class MemoryModule : public Module, public PerformanceCounter<NUM_PERF_COUNTERS_MEM>
+    {
+    public:
+        short getTraceUnitPacketType() override;
+    };
+    
+    class PLModule : public CoreAndPLModule, public PerformanceCounter<NUM_PERF_COUNTERS_PL>
+    {
+    public:
+        short getTraceUnitPacketType() override;
+    };
+
+    class ShimTile
+    {
+    public:
+        PLModule plModule;
+    };
+    
+    class AIETile
+    {
+    public:
+        CoreModule coreModule;
+        MemoryModule memoryModule;
+    };
+    
+    class AIE
+    {
+    public:
+        /// @param numAIERows Total number of AIE tile rows, excluding shim
+        static void initialize(size_t numColumns, size_t numAIERows);
+        /// @param row Row 0 means the first AIE array row, does not include shim
+        static AIETile* getAIETile(size_t column, size_t row);
+        static ShimTile* getShimTile(size_t column);
+
+        /// Reserve the 0th performance counter for ECC Scrubbing in all core modules
+        static bool reservePerformanceCounterEccScrubbing();
+        
+    private:
+        static AIETile* s_meTiles;
+        static ShimTile* s_shimTiles;
+        static size_t s_numColumns;
+        static size_t s_numAIERows;
+    };
+    
+    enum module_type
+    {
+        core_module,
+        memory_module,
+        pl_module
+    };
+    
+    enum resource_type
+    {
+        performance_counter,
+        trace_event,
+        stream_switch_event_port,
+        event_broadcast,
+        program_counter,
+        group_event,
+        combo_event
+    };
+    
+    struct AcquiredResource
+    {
+        #ifdef __AIE_DRIVER_V1__
+        XAieGbl_Tile* pTileInst;
+        #else
+        XAie_LocType loc;
+        #endif
+        module_type module;
+        resource_type resource;
+        size_t id;
+    };
+}    
+}

--- a/src/runtime_src/core/edge/user/aie/aie_event.h
+++ b/src/runtime_src/core/edge/user/aie/aie_event.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef xrt_core_edge_user_aie_event_h
+#define xrt_core_edge_user_aie_event_h
+
+#include "AIEResources.h"
+
+XAie_Events XAIETILE_EVENT_SHIM_PORT_RUNNING[] = {
+  XAIE_EVENT_PORT_RUNNING_0_PL,
+  XAIE_EVENT_PORT_RUNNING_1_PL,
+  XAIE_EVENT_PORT_RUNNING_2_PL,
+  XAIE_EVENT_PORT_RUNNING_3_PL,
+  XAIE_EVENT_PORT_RUNNING_4_PL,
+  XAIE_EVENT_PORT_RUNNING_5_PL,
+  XAIE_EVENT_PORT_RUNNING_6_PL,
+  XAIE_EVENT_PORT_RUNNING_7_PL
+};
+
+namespace zynqaie {
+
+static std::map<Resources::module_type, XAie_ModuleType> AIEResourceModuletoXAieModuleTypeMap = {{Resources::pl_module, XAIE_PL_MOD}, {Resources::core_module, XAIE_CORE_MOD}, {Resources::memory_module, XAIE_MEM_MOD}};
+
+}
+#endif

--- a/src/runtime_src/core/include/xrt_graph.h
+++ b/src/runtime_src/core/include/xrt_graph.h
@@ -70,4 +70,13 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
 
 int
 xclGMIOWait(xclDeviceHandle handle, const char *gmioName);
+
+int
+xclStartProfiling(xclDeviceHandle handle, int option, const char* port1Name, const char* port2Nmae, uint32_t value);
+
+uint64_t
+xclReadProfiling(xclDeviceHandle handle, int phdl);
+
+int
+xclStopProfiling(xclDeviceHandle handle, int phdl);
 #endif


### PR DESCRIPTION
This PR 
1) ported aietool profiling implementation to XRT
2) provided XRT profiling API to be used by adf

This is the first attempt to port profiling API to xrt and this PR only implement one io profiling option with GMIO (PLIO and other io profiling option will be followed).