### PR TITLE
C++ API rst documentation

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -41,6 +41,7 @@ usage()
     echo "[-edge]                    Build edge of x64.  Turns off opt and dbg"
     echo "[-nocmake]                 Skip CMake call"
     echo "[-noctest]                 Skip unit tests"
+    echo "[-docs]                    Enable documentation generation with sphinx"
     echo "[-j <n>]                   Compile parallel (default: system cores)"
     echo "[-ccache]                  Build using RDI's compile cache"
     echo "[-toolchain <file>]        Extra toolchain file to configure CMake"
@@ -70,6 +71,7 @@ opt=1
 dbg=1
 edge=0
 nocmake=0
+nobuild=0
 noctest=0
 ertfw=""
 while [ $# -gt 0 ]; do
@@ -130,6 +132,8 @@ while [ $# -gt 0 ]; do
             ;;
 	docs|-docs)
             docs=1
+            dbg=0
+            nobuild=1
             shift
             ;;
         -driver)
@@ -195,8 +199,10 @@ if [[ $dbg == 1 ]]; then
 	echo "$CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src"
 	time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src
   fi
+
   echo "make -j $jcore $verbose DESTDIR=$PWD install"
   time make -j $jcore $verbose DESTDIR=$PWD install
+
   if [[ $noctest == 0 ]]; then
       time ctest --output-on-failure
   fi
@@ -211,16 +217,20 @@ if [[ $opt == 1 ]]; then
 	time $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=$toolchain ../../src
   fi
 
+  if [[ $nobuild == 0 ]]; then
+      echo "make -j $jcore $verbose DESTDIR=$PWD install"
+      time make -j $jcore $verbose DESTDIR=$PWD install
+
+      if [[ $noctest == 0 ]]; then
+          time ctest --output-on-failure
+      fi
+
+      time make package
+  fi
+
   if [[ $docs == 1 ]]; then
-    echo "make xrt_docs"
-    make xrt_docs
-  else
-    echo "make -j $jcore $verbose DESTDIR=$PWD install"
-    time make -j $jcore $verbose DESTDIR=$PWD install
-    if [[ $noctest == 0 ]]; then
-        time ctest --output-on-failure
-    fi
-    time make package
+      echo "make xrt_docs"
+      make xrt_docs
   fi
 
   if [[ $driver == 1 ]]; then

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -240,7 +240,7 @@ xrtXclbinAllocFilename(const char* filename)
 }
 
 xrtXclbinHandle
-xrtXclbinAllocRawData(const char* data, const int size)
+xrtXclbinAllocRawData(const char* data, int size)
 {
   try {
     std::vector<char> raw_data(data, data + size);

--- a/src/runtime_src/core/include/experimental/xrt_bo.h
+++ b/src/runtime_src/core/include/experimental/xrt_bo.h
@@ -66,25 +66,34 @@ public:
   /**
    * bo() - Constructor with user host buffer and flags
    *
-   * @dhdl:     Device handle
-   * @userptr:  Pointer to aligned user memory
-   * @size:     Size of buffer
-   * @flags:    Specify special flags per ``xrt_mem.h``
-   * @grp:      Device memory group to allocate buffer in
+   * @param dhdl
+   *  Device handle
+   * @param userptr
+   *  Pointer to aligned user memory
+   * @param sz
+   *  Size of buffer
+   * @param flags
+   *  Specify special flags per ``xrt_mem.h``
+   * @param grp
+   *  Device memory group to allocate buffer in
    */
   XCL_DRIVER_DLLESPEC
-  bo(xclDeviceHandle dhld, void* userptr, size_t sz, buffer_flags flags, memory_group grp);
+  bo(xclDeviceHandle dhdl, void* userptr, size_t sz, buffer_flags flags, memory_group grp);
 
   /**
    * bo() - Constructor where XRT manages host buffer if any
    *
-   * @dhdl:     Device handle
-   * @size:     Size of buffer
-   * @flags:    Specify special flags per ``xrt_mem.h``
-   * @grp:      Device memory group to allocate buffer in
+   * @param dhdl
+   *  Device handle
+   * @param size
+   *  Size of buffer
+   * @param flags
+   *  Specify special flags per ``xrt_mem.h``
+   * @param grp
+   *  Device memory group to allocate buffer in
    *
    * If the flags require a host buffer, then the host buffer is allocated by
-   * XRT and can be accessed by using @map()
+   * XRT and can be accessed by using map()
    */
   XCL_DRIVER_DLLESPEC
   bo(xclDeviceHandle dhdl, size_t size, buffer_flags flags, memory_group grp);
@@ -92,8 +101,10 @@ public:
   /**
    * bo() - Constructor to import an exported buffer
    *
-   * @dhdl:     Device that imports the exported buffer
-   * @ehdl:     Exported buffer handle, implementation specific type
+   * @param dhdl
+   *  Device that imports the exported buffer
+   * @param ehdl
+   *  Exported buffer handle, implementation specific type
    * 
    * The exported buffer handle is acquired by using the export() method
    * and can be passed to another process.  
@@ -104,9 +115,12 @@ public:
   /**
    * bo() - Constructor for sub-buffer
    *
-   * @parent:   Parent buffer
-   * @size:     Size of sub-buffer
-   * @size:     Offset into parent buffer
+   * @param parent
+   *  Parent buffer
+   * @param size
+   *  Size of sub-buffer
+   * @param offset
+   *  Offset into parent buffer
    */
   XCL_DRIVER_DLLESPEC
   bo(const bo& parent, size_t size, size_t offset);
@@ -114,31 +128,24 @@ public:
   /**
    * bo() - Copy ctor
    */
-  bo(const bo& rhs)
-    : handle(rhs.handle)
-  {}
+  bo(const bo& rhs) = default;
 
   /**
    * bo() - Move ctor
    */
-  bo(bo&& rhs)
-    : handle(std::move(rhs.handle))
-  {}
+  bo(bo&& rhs) = default;
 
   /**
    * operator= () - Move assignment
    */
   bo&
-  operator=(bo&& rhs)
-  {
-    handle = std::move(rhs.handle);
-    return *this;
-  }
+  operator=(bo&& rhs) = default;
 
   /**
    * size() - Get the size of this buffer
    *
-   * Return: size of buffer in bytes
+   * @return 
+   *  Size of buffer in bytes
    */
   XCL_DRIVER_DLLESPEC
   size_t
@@ -147,7 +154,8 @@ public:
   /**
    * address() - Get the device address of this buffer
    *
-   * Return: device address of buffer
+   * @return 
+   *  Device address of buffer
    */
   XCL_DRIVER_DLLESPEC
   uint64_t
@@ -156,7 +164,8 @@ public:
   /**
    * buffer_export() - Export this buffer
    *
-   * Return:  exported buffer handle
+   * @return 
+   *  Exported buffer handle
    *
    * An exported buffer can be imported on another device by this
    * process or another process.
@@ -168,9 +177,12 @@ public:
   /**
    * sync() - Synchronize buffer content with device side 
    *
-   * @dir:     To device or from device
-   * @size:    Size of data to synchronize
-   * @offset:  Offset within the BO
+   * @param dir
+   *  To device or from device
+   * @param size
+   *  Size of data to synchronize
+   * @param offset
+   *  Offset within the BO
    */
   XCL_DRIVER_DLLESPEC
   void
@@ -179,7 +191,8 @@ public:
   /**
    * map() - Map the host side buffer into application
    *
-   * Return: Memory mapped buffer
+   * @return
+   *  Memory mapped buffer
    *
    * Map the contents of the buffer object into host memory
    */
@@ -190,8 +203,10 @@ public:
   /**
    * map() - Map the host side buffer info application
    *
-   * @MapType: Type of mapped data
-   * Return: Memory mapped buffer
+   * @tparam MapType
+   *  Type of mapped data
+   * @return 
+   *  Memory mapped buffer
    */
   template<typename MapType>
   MapType
@@ -203,9 +218,12 @@ public:
   /**
    * write() - Copy-in user data to host backing storage of BO
    *
-   * @src:   Source data pointer
-   * @size:  Size of data to copy
-   * @seek:  Offset within the BO
+   * @param src
+   *  Source data pointer
+   * @param size
+   *  Size of data to copy
+   * @param seek
+   *  Offset within the BO
    *
    * Copy host buffer contents to previously allocated device
    * memory. ``seek`` specifies how many bytes to skip at the beginning
@@ -218,9 +236,12 @@ public:
   /**
    * read() - Copy-out user data from host backing storage of BO
    *
-   * @dst:           Destination data pointer
-   * @size:          Size of data to copy
-   * @skip:          Offset within the BO
+   * @param dst
+   *  Destination data pointer
+   * @param size
+   *  Size of data to copy
+   * @param skip
+   *  Offset within the BO
    *
    * Copy contents of previously allocated device memory to host
    * buffer. ``skip`` specifies how many bytes to skip from the
@@ -234,10 +255,14 @@ public:
   /**
    * copy() - Deep copy BO content from another buffer
    *
-   * @src:          Source BO to copy from
-   * @sz:           Size of data to copy
-   * @src_offset:   Offset into src buffer copy from
-   * @dst_offset:   Offset in this buffer to copy to
+   * @param src
+   *  Source BO to copy from
+   * @param sz
+   *  Size of data to copy
+   * @param src_offset
+   *  Offset into src buffer copy from
+   * @param dst_offset
+   *  Offset into this buffer to copy to
    *
    * A copy size equal to 0 indicates copying complete src bo
    * to this bo.
@@ -247,25 +272,27 @@ public:
   copy(const bo& src, size_t sz=0, size_t src_offset=0, size_t dst_offset=0);
 
 public:
+  /// @cond
   std::shared_ptr<bo_impl>
   get_handle() const
   {
     return handle;
   }
-
+  /// @endcond
 private:
   std::shared_ptr<bo_impl> handle;
 };
 
 } // namespace xrt
 
+/// @cond
 extern "C" {
 #endif
 
 /**
  * xrtBOAllocUserPtr() - Allocate a BO using userptr provided by the user
  *
- * @handle:        Device handle
+ * @dhdl:          Device handle
  * @userptr:       Pointer to 4K aligned user memory
  * @size:          Size of buffer
  * @flags:         Specify type of buffer
@@ -279,7 +306,7 @@ xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
 /**
  * xrtBOAlloc() - Allocate a BO of requested size with appropriate flags
  *
- * @handle:        Device handle
+ * @dhdl:          Device handle
  * @size:          Size of buffer
  * @flags:         Specify type of buffer
  * @grp:           Specify bank information
@@ -305,7 +332,8 @@ xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl);
 /**
  * xrtBOExport() - Export this buffer
  *
- * Return:  exported buffer handle
+ * @bhdl:   Buffer handle
+ * Return:  Exported buffer handle
  *
  * An exported buffer can be imported on another device by this
  * process or another process.
@@ -329,36 +357,37 @@ xrtBOSubAlloc(xrtBufferHandle parent, size_t size, size_t offset);
 /**
  * xrtBOFree() - Free a previously allocated BO
  *
- * @handle:       Buffer handle
+ * @bhdl:         Buffer handle
  * Return:        0 on success, or err code on error
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtBOFree(xrtBufferHandle handle);
+xrtBOFree(xrtBufferHandle bhdl);
 
 /**
  * xrtBOSize() - Get the size of this buffer
  *
- * @handle:       Buffer handle
+ * @bhdl:         Buffer handle
  * Return:        Size of buffer in bytes
  */
 XCL_DRIVER_DLLESPEC
 size_t
-xrtBOSize(xrtBufferHandle handle);
+xrtBOSize(xrtBufferHandle bhdl);
 
 /**
  * xrtBOAddr() - Get the physical address of this buffer
- * @handle:       Buffer handle
+ *
+ * @bhdl:         Buffer handle
  * Return:        Device address of this BO
  */
 XCL_DRIVER_DLLESPEC
 uint64_t
-xrtBOAddress(xrtBufferHandle handle);
+xrtBOAddress(xrtBufferHandle bhdl);
 
 /**
  * xrtBOSync() - Synchronize buffer contents in requested direction
  *
- * @handle:        Bufferhandle
+ * @bhdl:          Bufferhandle
  * @dir:           To device or from device
  * @size:          Size of data to synchronize
  * @offset:        Offset within the BO
@@ -370,12 +399,12 @@ xrtBOAddress(xrtBufferHandle handle);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtBOSync(xrtBufferHandle handle, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xrtBOSync(xrtBufferHandle bhdl, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 /**
  * xrtBOMap() - Memory map BO into user's address space
  *
- * @handle:     Buffer handle
+ * @bhdl:       Buffer handle
  * Return:      Memory mapped buffer, or NULL on error with errno set
  *
  * Map the contents of the buffer object into host memory.  The buffer
@@ -383,12 +412,12 @@ xrtBOSync(xrtBufferHandle handle, enum xclBOSyncDirection dir, size_t size, size
  */
 XCL_DRIVER_DLLESPEC
 void*
-xrtBOMap(xrtBufferHandle handle);
+xrtBOMap(xrtBufferHandle bhdl);
 
 /**
  * xrtBOWrite() - Copy-in user data to host backing storage of BO
  *
- * @handle:        Buffer handle
+ * @bhdl:          Buffer handle
  * @src:           Source data pointer
  * @size:          Size of data to copy
  * @seek:          Offset within the BO
@@ -400,12 +429,12 @@ xrtBOMap(xrtBufferHandle handle);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtBOWrite(xrtBufferHandle handle, const void* src, size_t size, size_t seek);
+xrtBOWrite(xrtBufferHandle bhdl, const void* src, size_t size, size_t seek);
 
 /**
  * xrtBORead() - Copy-out user data from host backing storage of BO
  *
- * @handle:        Buffer handle
+ * @bhdl:          Buffer handle
  * @dst:           Destination data pointer
  * @size:          Size of data to copy
  * @skip:          Offset within the BO
@@ -418,15 +447,16 @@ xrtBOWrite(xrtBufferHandle handle, const void* src, size_t size, size_t seek);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtBORead(xrtBufferHandle handle, void* dst, size_t size, size_t skip);
+xrtBORead(xrtBufferHandle bhdl, void* dst, size_t size, size_t skip);
 
 /**
  * xrtBOCopy() - Deep copy BO content from another buffer
  *
+ * @dst:          Destination BO to copy to
  * @src:          Source BO to copy from
  * @sz:           Size of data to copy
- * @src_offset:   Offset into src buffer copy from
- * @dst_offset:   Offset in this buffer to copy to
+ * @dst_offset:   Offset into destination buffer to copy to
+ * @src_offset:   Offset into src buffer to copy from
  * Return:        0 on success or appropriate error number
  *
  * A copy size equal to 0 indicates copying complete src bo
@@ -436,6 +466,7 @@ XCL_DRIVER_DLLESPEC
 int
 xrtBOCopy(xrtBufferHandle dst, xrtBufferHandle src, size_t sz, size_t dst_offset, size_t src_offset);
 
+/// @endcond  
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -51,12 +51,14 @@ public:
   /**
    * device() - Constructor with user host buffer and flags
    *
-   * @didx:     Device index
+   * @param didx
+   *  Device index
    */
   XCL_DRIVER_DLLESPEC
   explicit
   device(unsigned int didx);
 
+  /// @cond
   /**
    * device() - Constructor from opaque handle
    *
@@ -66,12 +68,15 @@ public:
   device(std::shared_ptr<xrt_core::device> hdl)
     : handle(std::move(hdl))
   {}
+  /// @endcond
 
   /**
    * device() - Create a managed device object from a shim xclDeviceHandle
    *
-   * @dhdl:      Shim xclDeviceHandle
-   * Return:     xrt::device object epresenting the opened device, or exception on error
+   * @param dhdl
+   *  Shim xclDeviceHandle
+   * @return
+   *  xrt::device object epresenting the opened device, or exception on error
    */
   XCL_DRIVER_DLLESPEC
   explicit
@@ -80,35 +85,26 @@ public:
   /**
    * device() - Copy ctor
    */
-  device(const device& rhs)
-    : handle(rhs.handle)
-  {}
+  device(const device& rhs) = default;
 
   /**
    * device() - Move ctor
    */
-  device(device&& rhs)
-    : handle(std::move(rhs.handle))
-  {}
+  device(device&& rhs) = default;
 
   /**
    * operator= () - Move assignment
    */
   device&
-  operator=(device&& rhs)
-  {
-    handle = std::move(rhs.handle);
-    return *this;
-  }
+  operator=(device&& rhs) = default;
 
   /**
    * load_xclbin() - Load an xclbin 
    *
-   * @xclbin:     Pointer to xclbin in memory image
-   * Return:      UUID of argument xclbin
-   *
-   * The xclbin image can safely be deleted after calling
-   * this funciton.
+   * @param xclbin
+   *  Pointer to xclbin in memory image
+   * @return
+   *  UUID of argument xclbin
    */
   XCL_DRIVER_DLLESPEC
   uuid
@@ -117,37 +113,43 @@ public:
   /**
    * load_xclbin() - Read and load an xclbin file
    *
-   * @xclbin_fnm:  Full path to xclbin file
-   * Return:       UUID of argument xclbin
+   * @param xclbin_fnm
+   *  Full path to xclbin file
+   * @return
+   *  UUID of argument xclbin
    *
-   * This function read the file from disk and loads
+   * This function reads the file from disk and loads
    * the xclbin.   Using this function allows one time
    * allocation of data that needs to be kept in memory.
    */
   XCL_DRIVER_DLLESPEC
   uuid
-  load_xclbin(const std::string& xclbin_filename);
+  load_xclbin(const std::string& xclbin_fnm);
 
   /**
    * load_xclbin() - load an xclin from an xclbin object
    *
-   * @xclbin:      xclbin object
-   * Return:       UUID of argument xclbin
+   * @param xclbin
+   *  xrt::xclbin object
+   * @return
+   *  UUID of argument xclbin
    *
-   * This function read the xclbin contents from
-   * the xclbin object.
+   * This function uses the specified xrt::xclbin object created by
+   * caller.  The xrt::xclbin object must contain the complete axlf
+   * structure.
    */
   XCL_DRIVER_DLLESPEC
   uuid
-  load_xclbin(const xclbin& xclbin);
+  load_xclbin(const xrt::xclbin& xclbin);
 
   /**
    * get_xclbin_uuid() - Get UUID of xclbin image loaded on device
    *
-   * Return:       UUID of currently loaded xclbin
+   * @return
+   *  UUID of currently loaded xclbin
    *
    * Note that current UUID can be different from the UUID of 
-   * the xclbin loaded by this process using @load_xclbin()
+   * the xclbin loaded by this process using load_xclbin()
    */
   XCL_DRIVER_DLLESPEC
   uuid
@@ -156,8 +158,12 @@ public:
   /**
    * get_xclbin_section() - Retrieve specified xclbin section
    *
-   * @section: The section to retrieve
-   * @uuid:    Xclbin uuid of the xclbin with the section to retrieve
+   * @param section
+   *  The section to retrieve
+   * @param uuid
+   *  Xclbin uuid of the xclbin with the section to retrieve
+   * @return
+   *  The specified section if available.
    *
    * Get the xclbin section of the xclbin currently loaded on the 
    * device.  The function throws on error
@@ -172,6 +178,7 @@ public:
   }
 
 public:
+  /// @cond
   /**
    * Undocumented temporary interface during porting
    */
@@ -183,6 +190,7 @@ public:
   {
     return handle;
   }
+  /// @endcond
 
 private:
   XCL_DRIVER_DLLESPEC
@@ -195,6 +203,7 @@ private:
 
 } // namespace xrt
 
+/// @cond
 extern "C" {
 #endif
 
@@ -219,7 +228,7 @@ xrtDeviceOpen(unsigned int index);
  */
 XCL_DRIVER_DLLESPEC
 xrtDeviceHandle
-xrtDeviceOpenFromXcl(xclDeviceHandle dhdl);
+xrtDeviceOpenFromXcl(xclDeviceHandle xhdl);
 
 /**
  * xrtDeviceClose() - Close an opened device
@@ -234,7 +243,8 @@ xrtDeviceClose(xrtDeviceHandle dhdl);
 /**
  * xrtDeviceLoadXclbin() - Load an xclbin image
  *
- * @xclbin:     Pointer to xclbin in memory image
+ * @dhdl:       Handle to device previously opened with xrtDeviceOpen
+ * @xclbin:     Pointer to complete axlf in memory image
  * Return:      0 on success, error otherwise
  *
  * The xclbin image can safely be deleted after calling
@@ -247,6 +257,7 @@ xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const struct axlf* xclbin);
 /**
  * xrtDeviceLoadXclbinFile() - Read and load an xclbin file
  *
+ * @dhdl:       Handle to device previously opened with xrtDeviceOpen
  * @xclbin_fnm: Full path to xclbin file
  * Return:      0 on success, error otherwise
  *
@@ -256,16 +267,18 @@ xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const struct axlf* xclbin);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* xclbin_filename);
+xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* xclbin_fnm);
 
 /**
- * xrtDeviceLoadXclbinHandle() - load an xclbin from an xclbin handle
+ * xrtDeviceLoadXclbinHandle() - load an xclbin from an xrt::xclbin handle
  *
- * @xhdl:       xclbin handle
+ * @dhdl:       Handle to device previously opened with xrtDeviceOpen
+ * @xhdl:       xrt::xclbin handle
  * Return:      0 on success, error otherwise
  *
- * This function read the xclbin contents from
- * the xclbin object.
+ * This function uses the specified xrt::xclbin object created by
+ * caller.  The xrt::xclbin object must contain the complete axlf
+ * structure.
  */
 XCL_DRIVER_DLLESPEC
 int
@@ -274,7 +287,7 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl);
 /**
  * xrtDeviceGetXclbinUUID() - Get UUID of xclbin image loaded on device
  *
- * @handle: Device handle
+ * @dhdl:   Handle to device previously opened with xrtDeviceOpen
  * @out:    Return xclbin id in this uuid_t struct
  * Return:  0 on success or appropriate error number
  *
@@ -283,15 +296,16 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl);
  */
 XCL_DRIVER_DLLESPEC
 void
-xrtDeviceGetXclbinUUID(xrtDeviceHandle dhld, xuid_t out);
+xrtDeviceGetXclbinUUID(xrtDeviceHandle dhdl, xuid_t out);
 
-/**
+/*
  * xrtDeviceToXclDevice() - Undocumented access to shim handle
  */
 XCL_DRIVER_DLLESPEC
 xclDeviceHandle
 xrtDeviceToXclDevice(xrtDeviceHandle dhdl);
 
+/// @endcond
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -79,7 +79,7 @@ class run
   /**
    * run() - Construct run object from a kernel object
    *
-   * @krnl: Kernel object representing the kernel to execute
+   * @param krnl: Kernel object representing the kernel to execute
    */
   XCL_DRIVER_DLLESPEC
   explicit
@@ -89,7 +89,7 @@ class run
    * start() - Start execution of a run.
    *
    * This function is asynchronous, run status must be expclicit checked
-   * or @wait() must be used to wait for the run to complete.
+   * or ``wait()`` must be used to wait for the run to complete.
    */
   XCL_DRIVER_DLLESPEC
   void
@@ -98,14 +98,16 @@ class run
   /**
    * wait() - Wait for a run to complete execution
    *
-   * @timeout:  Timeout for wait (default block till run completes)
-   * Return:    Command state upon return of wait
+   * @param timeout  
+   *  Timeout for wait (default block till run completes)
+   * @return 
+   *  Command state upon return of wait
    *
    * The default timeout of 0ms indicates blocking until run completes.
    *
    * The current thread will block until the run completes or timeout
    * expires. Completion does not guarantee success, the run status
-   * should be checked by using @state.
+   * should be checked by using ``state``.
    */
   XCL_DRIVER_DLLESPEC
   ert_cmd_state
@@ -114,14 +116,16 @@ class run
   /**
    * wait() - Wait for specified milliseconds for run to complete
    *
-   * @timeout:  Timeout in milliseconds
-   * Return:    Command state upon return of wait
+   * @param timeout
+   *  Timeout in milliseconds
+   * @return
+   *  Command state upon return of wait
    *
    * The default timeout of 0ms indicates blocking until run completes.
    *
    * The current thread will block until the run completes or timeout
    * expires. Completion does not guarantee success, the run status
-   * should be checked by using @state.
+   * should be checked by using ``state``.
    */
   ert_cmd_state
   wait(unsigned int timeout_ms) const
@@ -132,6 +136,9 @@ class run
   /**
    * state() - Check the current state of a run object
    *
+   * @return 
+   *  Current state of this run object
+   *
    * The state values are defined in ``include/ert.h``
    */
   XCL_DRIVER_DLLESPEC
@@ -141,9 +148,9 @@ class run
   /**
    * add_callback() - Add a callback function for run state
    *
-   * @state:       State to invoke callback on
-   * @callback:    Callback function 
-   * @data:        User data to pass to callback function
+   * @param state       State to invoke callback on
+   * @param callback    Callback function 
+   * @param data        User data to pass to callback function
    *
    * The function is called when the run object changes state to
    * argument state or any error state.  Only
@@ -154,14 +161,15 @@ class run
   XCL_DRIVER_DLLESPEC
   void
   add_callback(ert_cmd_state state,
-               std::function<void(const run&, ert_cmd_state, void*)>,
+               std::function<void(const run&, ert_cmd_state, void*)> callback,
                void* data);
 
 
   /**
    * set_event() - Add event for enqueued operations
    *
-   * @event:      Opaque implementation object
+   * @param event    
+   *   Opaque implementation object
    *
    * This function is used when a run object is enqueued in an event
    * graph.  The event must be notified upon completion of the run.
@@ -173,7 +181,8 @@ class run
   /**
    * operator bool() - Check if run handle is valid
    *
-   * Return: true if run is associated with kernel object, false otherwise
+   * @return 
+   *   True if run is associated with kernel object, false otherwise
    */
   explicit 
   operator bool() const
@@ -184,14 +193,16 @@ class run
   /**
    * set_arg() - Set a specific kernel scalar argument for this run
    *
-   * @index:      Index of kernel argument to update
-   * @arg:        The scalar argument value to set.
+   * @param index
+   *  Index of kernel argument to update
+   * @param arg        
+   *  The scalar argument value to set.
    * 
    * Use this API to explicit set or change a kernel argument prior
    * to starting kernel execution.  After setting arguments, the
-   * kernel can be started using @start() on the run object.
+   * kernel can be started using ``start()`` on the run object.
    *
-   * See also @operator() to set all arguments and start kernel.
+   * See also ``operator()`` to set all arguments and start kernel.
    */
   template <typename ArgType>
   void
@@ -203,14 +214,16 @@ class run
   /**
    * set_arg() - Set a specific kernel global argument for a run
    *
-   * @index:      Index of kernel argument to update
-   * @boh:        The global buffer argument value to set (lvalue).
+   * @param index
+   *  Index of kernel argument to set
+   * @param boh
+   *  The global buffer argument value to set (lvalue).
    * 
    * Use this API to explicit set or change a kernel argument prior
    * to starting kernel execution.  After setting arguments, the
-   * kernel can be started using @start() on the run object.
+   * kernel can be started using ``start()`` on the run object.
    *
-   * See also @operator() to set all arguments and start kernel.
+   * See also ``operator()`` to set all arguments and start kernel.
    */
   void
   set_arg(int index, xrt::bo& boh)
@@ -239,8 +252,10 @@ class run
   /**
    * udpdate_arg() - Asynchronous update of scalar kernel global argument
    *
-   * @index:      Index of kernel argument to update
-   * @arg:        The scalar argument value to set.
+   * @param index
+   *  Index of kernel argument to update
+   * @param arg
+   *  The scalar argument value to set.
    * 
    * Use this API to asynchronously update a specific scalar argument
    * of the kernel associated with the run object.
@@ -257,8 +272,10 @@ class run
   /**
    * update_arg() - Asynchronous update of kernel global argument for a run
    *
-   * @index:      Index of kernel argument to update
-   * @boh:        The global buffer argument value to set.
+   * @param index
+   *  Index of kernel argument to update
+   * @param boh
+   *  The global buffer argument value to set.
    * 
    * Use this API to asynchronously update a specific kernel
    * argument of an existing run.  
@@ -274,7 +291,8 @@ class run
   /**
    * operator() - Set all kernel arguments and start the run
    *
-   * @args: Kernel arguments
+   * @param args
+   *  Kernel arguments
    *
    * Use this API to explicitly set all kernel arguments and 
    * start kernel execution.
@@ -347,18 +365,24 @@ class kernel
   /**
    * cu_access_mode - compute unit access mode
    *
-   * @shared:    CUs can be shared between processes
-   * @exclusive: CUs are owned exclusively by this process
+   * @var shared
+   *  CUs can be shared between processes
+   * @var exclusive
+   *  CUs are owned exclusively by this process
    */
   enum class cu_access_mode : bool { exclusive = false, shared = true };
 
   /**
    * kernel() - Constructor from a device and xclbin
    *
-   * @device: Device on which the kernel should execute
-   * @xclbin_id: UUID of the xclbin with the kernel
-   * @name:  Name of kernel to construct
-   * @mode: Open the kernel instances with specified access (default shared)
+   * @param device
+   *  Device on which the kernel should execute
+   * @param xclbin_id
+   *  UUID of the xclbin with the kernel
+   * @param name
+   *  Name of kernel to construct
+   * @param mode
+   *  Open the kernel instances with specified access (default shared)
    *
    * The kernel name must uniquely identify compatible kernel
    * instances (compute units).  Optionally specify which kernel
@@ -377,7 +401,6 @@ class kernel
   kernel(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name, bool ex)
     : kernel(device, xclbin_id, name, ex ? cu_access_mode::exclusive : cu_access_mode::shared)
   {}
-  /// @endcond
 
   /**
    * Obsoleted construction from xclDeviceHandle
@@ -385,12 +408,15 @@ class kernel
   XCL_DRIVER_DLLESPEC
   kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name,
          cu_access_mode mode = cu_access_mode::shared);
+  /// @endcond
 
   /**
    * operator() - Invoke the kernel function
    *
-   * @args: Kernel arguments
-   * Return: Run object representing this kernel function invocation
+   * @param args
+   *  Kernel arguments
+   * @return 
+   *  Run object representing this kernel function invocation
    */
   template<typename ...Args>
   run
@@ -404,8 +430,10 @@ class kernel
   /**
    * group_id() - Get the memory bank group id of an kernel argument
    *
-   * @argno:  The argument index
-   * Return:  The memory group id to use when allocating buffers (see @xrt::bo)
+   * @param argno
+   *  The argument index
+   * @return
+   *  The memory group id to use when allocating buffers (see xrt::bo)
    *
    * The function throws if the group id is ambigious.
    */
@@ -416,8 +444,10 @@ class kernel
   /**
    * write() - Write to the address range of a kernel
    *
-   * @offset:   Offset in register space to write to
-   * @data:     Data to write
+   * @param offset
+   *  Offset in register space to write to
+   * @param data     
+   *  Data to write
    *
    * Throws std::out_or_range if offset is outside the
    * kernel address space
@@ -432,8 +462,10 @@ class kernel
   /**
    * read() - Read data from kernel address range
    *
-   * @offset:  Offset in register space to read from
-   * Return:   Value read from offset
+   * @param offset  
+   *  Offset in register space to read from
+   * @return 
+   *  Value read from offset
    *
    * Throws std::out_or_range if offset is outside the
    * kernel address space
@@ -446,16 +478,19 @@ class kernel
   read_register(uint32_t offset) const;
 
 public:
+  /// @cond
   std::shared_ptr<kernel_impl>
   get_handle() const
   {
     return handle;
   }
+  /// @endcond
 
 private:
   std::shared_ptr<kernel_impl> handle;
 };
 
+/// @cond
 // Specialization from xrt_enqueue.h for run objects, which
 // are asynchronous waitable objects.
 template <>
@@ -463,9 +498,11 @@ struct callable_traits<run>
 {
   enum { is_async = true };
 };
+/// @endcond
 
 } // namespace xrt
 
+/// @cond
 extern "C" {
 #endif
 
@@ -497,6 +534,11 @@ xrtPLKernelOpen(xrtDeviceHandle deviceHandle, const xuid_t xclbinId, const char 
 
 /**
  * xrtPLKernelOpenExclusive() - Open a PL kernel and obtain its handle.
+ *
+ * @deviceHandle:  Handle to the device with the kernel
+ * @xclbinId:      The uuid of the xclbin with the specified kernel.
+ * @name:          Name of kernel to open.
+ * Return:         Handle representing the opened kernel.
  *
  * Same as @xrtPLKernelOpen(), but opens compute units with exclusive
  * access.  Fails if any compute unit is already opened with either
@@ -537,36 +579,38 @@ xrtKernelArgGroupId(xrtKernelHandle kernelHandle, int argno);
 /**
  * xrtKernelReadRegister() - Read data from kernel address range
  *
- * @offset:  Offset in register space to read from
- * @datap:   Pointer to location where to write data
- * Return:   0 on success, errcode otherwise
+ * @kernelHandle: Handle to kernel previously opened with xrtKernelOpen
+ * @offset:       Offset in register space to read from
+ * @datap:        Pointer to location where to write data
+ * Return:        0 on success, errcode otherwise
  *
  * The kernel must be associated with exactly one kernel instance 
  * (compute unit), which must be opened for exclusive access.
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtKernelReadRegister(xrtKernelHandle, uint32_t offset, uint32_t* datap);
+xrtKernelReadRegister(xrtKernelHandle kernelHandle, uint32_t offset, uint32_t* datap);
 
 /**
  * xrtKernelWriteRegister() - Write to the address range of a kernel
  *
- * @offset:   Offset in register space to write to
- * @data:     Data to write
- * Return:    0 on success, errcode otherwise
+ * @kernelHandle: Handle to kernel previously opened with xrtKernelOpen
+ * @offset:       Offset in register space to write to
+ * @data:         Data to write
+ * Return:        0 on success, errcode otherwise
  *
  * The kernel must be associated with exactly one kernel instance 
  * (compute unit), which must be opened for exclusive access.
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtKernelWriteRegister(xrtKernelHandle, uint32_t offset, uint32_t data);
+xrtKernelWriteRegister(xrtKernelHandle kernelHandle, uint32_t offset, uint32_t data);
 
 /**
  * xrtKernelRun() - Start a kernel execution
  *
  * @kernelHandle: Handle to the kernel to run
- * @args:         Kernel arguments
+ * @...:          Kernel arguments
  * Return:        Run handle which must be closed with xrtRunClose()
  *
  * A run handle is specific to one execution of a kernel.  Once
@@ -595,9 +639,9 @@ xrtRunOpen(xrtKernelHandle kernelHandle);
 /**
  * xrtRunSetArg() - Set a specific kernel argument for this run
  *
- * @runHandle:  Handle to the run object to modify
+ * @rhdl:       Handle to the run object to modify
  * @index:      Index of kernel argument to set
- * @arg:        The argument value to set.
+ * @...:        The argument value to set.
  * Return:      0 on success, -1 on error
  *
  * Use this API to explicitly set specific kernel arguments prior
@@ -606,14 +650,14 @@ xrtRunOpen(xrtKernelHandle kernelHandle);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtRunSetArg(xrtRunHandle runHandle, int index, ...);
+xrtRunSetArg(xrtRunHandle rhdl, int index, ...);
 
 /**
  * xrtRunUpdateArg() - Asynchronous update of kernel argument
  *
- * @runHandle:  Handle to the run object to modify
+ * @rhdl:       Handle to the run object to modify
  * @index:      Index of kernel argument to update
- * @arg:        The argument value to set.
+ * @...:        The argument value to update.
  * Return:      0 on success, -1 on error
  *
  * Use this API to asynchronously update a specific kernel
@@ -628,7 +672,7 @@ xrtRunUpdateArg(xrtRunHandle rhdl, int index, ...);
 /**
  * xrtRunStart() - Start existing run handle
  *
- * @runHandle:  Handle to the run object to start
+ * @rhdl:       Handle to the run object to start
  * Return:      0 on success, -1 on error
  *
  * Use this API when re-using a run handle for more than one execution
@@ -636,26 +680,26 @@ xrtRunUpdateArg(xrtRunHandle rhdl, int index, ...);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtRunStart(xrtRunHandle runHandle);
+xrtRunStart(xrtRunHandle rhdl);
 
 /**
  * xrtRunWait() - Wait for a run to complete
  *
- * @runHandle:  Handle to the run object to start
- * Return:      Run command state for completed run, or
- *              ERT_CMD_STATE_ABORT on error
+ * @rhdl:       Handle to the run object to start
+ * Return:      Run command state for completed run,
+ *              or ERT_CMD_STATE_ABORT on error
  *
  * Blocks current thread until job has completed
  */
 XCL_DRIVER_DLLESPEC
 enum ert_cmd_state
-xrtRunWait(xrtRunHandle runHandle);
+xrtRunWait(xrtRunHandle rhdl);
 
 /**
  * xrtRunWait() - Wait for a run to complete
  *
- * @runHandle:  Handle to the run object to start
- * timeout_ms:  Timeout in millisecond
+ * @rhdl:       Handle to the run object to start
+ * @timeout_ms: Timeout in millisecond
  * Return:      Run command state for completed run, or
  *              current status if timeout.
  *
@@ -663,25 +707,25 @@ xrtRunWait(xrtRunHandle runHandle);
  */
 XCL_DRIVER_DLLESPEC
 enum ert_cmd_state
-xrtRunWaitFor(xrtRunHandle runHandle, unsigned int timeout_ms);
+xrtRunWaitFor(xrtRunHandle rhdl, unsigned int timeout_ms);
 
 /**
  * xrtRunState() - Check the current state of a run
  *
- * @runHandle:  Handle to check
+ * @rhdl:       Handle to check
  * Return:      The underlying command execution state per ert.h
  */
 XCL_DRIVER_DLLESPEC
 enum ert_cmd_state
-xrtRunState(xrtRunHandle runHandle);
+xrtRunState(xrtRunHandle rhdl);
 
 /**
  * xrtRunSetCallback() - Set a callback function
  *
- * @runHandle:   Handle to set callback on
+ * @rhdl:        Handle to set callback on
  * @state:       State to invoke callback on
  * @callback:    Callback function 
- * @userdata:    User data to pass to callback function
+ * @data:        User data to pass to callback function
  *
  * Register a run callback function that is invoked when the
  * run changes underlying execution state to specified state.
@@ -689,19 +733,21 @@ xrtRunState(xrtRunHandle runHandle);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtRunSetCallback(xrtRunHandle runHandle, enum ert_cmd_state state,
-                  void (* pfn_state_notify)(xrtRunHandle, enum ert_cmd_state, void*),
+xrtRunSetCallback(xrtRunHandle rhdl, enum ert_cmd_state state,
+                  void (* callback)(xrtRunHandle, enum ert_cmd_state, void*),
                   void* data);
 
 /**
  * xrtRunClose() - Close a run handle
  *
- * @runHandle:  Handle to close
+ * @rhdl:  Handle to close
  * Return:      0 on success, -1 on error
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtRunClose(xrtRunHandle runHandle);
+xrtRunClose(xrtRunHandle rhdl);
+
+/// @endcond
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -22,11 +22,9 @@
 #include "experimental/xrt_uuid.h"
 
 #ifdef __cplusplus
-
 # include <memory>
 # include <vector>
 # include <string>
-
 #endif
 
 /**
@@ -45,7 +43,8 @@ public:
   /**
    * xclbin() - Constructor from an xclbin filename
    *
-   * @filename:  path to the xclbin file
+   * @param filename
+   *  Path to the xclbin file
    *
    * The xclbin file must be accessible by the application. An
    * exception is thrown file not found
@@ -57,7 +56,8 @@ public:
   /**
    * xclbin() - Constructor from raw data
    *
-   * @data: raw data of xclbin
+   * @param data
+   *  Raw data of xclbin
    *
    * The raw data of the xclbin can be deleted after calling the constructor.
    */
@@ -84,7 +84,8 @@ public:
   /**
    * get_cu_names() - Get CU names of xclbin
    *
-   * Return: A list of CU Names in order of increasing base address.
+   * @return
+   *  A list of CU Names in order of increasing base address.
    *
    * An exception is thrown if the data is missing.
    */
@@ -95,7 +96,8 @@ public:
   /**
    * get_xsa_name() - Get Xilinx Support Archive (XSA) Name of xclbin
    *
-   * Return: Name of XSA
+   * @return 
+   *  Name of XSA
    *
    * An exception is thrown if the data is missing.
    */
@@ -106,7 +108,8 @@ public:
   /**
    * get_uuid() - Get the uuid of the xclbin
    *
-   * Return: UUID of xclbin
+   * @return 
+   *  UUID of xclbin
    *
    * An exception is thrown if the data is missing.
    */
@@ -117,7 +120,8 @@ public:
   /**
    * get_data() - Get the raw data of the xclbin
    *
-   * Return: The raw data of the xclbin
+   * @return 
+   *  The raw data of the xclbin
    *
    * An exception is thrown if the data is missing.
    */
@@ -131,6 +135,7 @@ private:
 
 } // namespace xrt
 
+/// @cond
 extern "C" {
 #endif
 
@@ -154,23 +159,23 @@ xrtXclbinAllocFilename(const char* filename);
  */
 XCL_DRIVER_DLLESPEC
 xrtXclbinHandle
-xrtXclbinAllocRawData(const char* data, const int size);
+xrtXclbinAllocRawData(const char* data, int size);
 
 /**
  * xrtXclbinFreeHandle() - Deallocate the xclbin handle
  *
- * @handle:        xclbin handle
+ * @xhdl:          xclbin handle
  * Return:         0 on success, -1 on error
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinFreeHandle(xrtXclbinHandle handle);
+xrtXclbinFreeHandle(xrtXclbinHandle xhdl);
 
 #if 0
-/**
+/*
  * xrtXclbinGetCUNames() - Get CU names of xclbin
  *
- * @handle:      Xclbin handle
+ * @xhdl:        Xclbin handle
  * @names:       Return pointer to a list of CU names.
  *               If the value is nullptr, the content of this value will not be populated.
  *               Otherwise, the the content of this value will be populated.
@@ -181,13 +186,13 @@ xrtXclbinFreeHandle(xrtXclbinHandle handle);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinGetCUNames(xrtXclbinHandle handle, char** names, int* numNames);
+xrtXclbinGetCUNames(xrtXclbinHandle xhdl, char** names, int* numNames);
 #endif
 
 /**
  * xrtXclbinGetXSAName() - Get Xilinx Support Archive (XSA) Name of xclbin handle
  *
- * @handle:     Xclbin handle
+ * @xhdl:       Xclbin handle
  * @name:       Return name of XSA.
  *              If the value is nullptr, the content of this value will not be populated.
  *              Otherwise, the the content of this value will be populated.
@@ -199,23 +204,23 @@ xrtXclbinGetCUNames(xrtXclbinHandle handle, char** names, int* numNames);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size);
+xrtXclbinGetXSAName(xrtXclbinHandle xhdl, char* name, int size, int* ret_size);
 
 /**
  * xrtXclbinGetUUID() - Get UUID of xclbin handle
  *
- * @handle:   Xclbin handle
+ * @xhdl:     Xclbin handle
  * @ret_uuid: Return xclbin id in this uuid_t struct
  * Return:    0 on success or appropriate error number
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid);
+xrtXclbinGetUUID(xrtXclbinHandle xhdl, xuid_t ret_uuid);
 
 /**
  * xrtXclbinGetData() - Get the raw data of the xclbin handle
  *
- * @handle:     Xclbin handle
+ * @xhdl:       Xclbin handle
  * @data:       Return raw data.
  *              If the value is nullptr, the content of this value will not be populated.
  *              Otherwise, the the content of this value will be populated.
@@ -227,19 +232,20 @@ xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size);
+xrtXclbinGetData(xrtXclbinHandle xhdl, char* data, int size, int* ret_size);
 
-/**
+/*
  * xrtGetXclbinUUID() - Get UUID of xclbin image running on device
  *
- * @handle: Device handle
+ * @dhdl:   Device handle
  * @out:    Return xclbin id in this uuid_t struct
  * Return:  0 on success or appropriate error number
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtXclbinUUID(xclDeviceHandle handle, xuid_t out);
+xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out);
 
+/// @endcond
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/doc/CMakeLists.txt
+++ b/src/runtime_src/doc/CMakeLists.txt
@@ -27,6 +27,35 @@ endif ()
 
 find_program(KERNELDOC_EXECUTABLE ${KERNELDOC} PATHS ${CMAKE_BINARY_DIR})
 find_program(SPHINX_EXECUTABLE sphinx-build)
+find_program(DOXYGEN_EXECUTABLE doxygen)
+
+if (NOT DOXYGEN_EXECUTABLE)
+  message(WARNING "doxygen not found, XRT C++ documentation is disabled")
+  add_custom_target(
+    doxygen
+    )
+else()
+  set(XRT_CPP_APIS
+    ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_device.h
+    ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_bo.h
+    ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_kernel.h
+    ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_xclbin.h
+    )
+  string(REPLACE ";" " " DOXY_INPUT "${XRT_CPP_APIS}")
+  set(DOXYFILE ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+  add_custom_target(
+    doxygen
+    DEPENDS ${XRT_CPP_APIS}
+    COMMAND ${DOXYGEN_EXECUTABLE} -g ${DOXYFILE}
+    COMMAND echo "PROJECT_NAME = XRT" >> ${DOXYFILE}
+    COMMAND echo "GENERATE_XML = YES" >> ${DOXYFILE}
+    COMMAND echo "MACRO_EXPANSION = YES" >> ${DOXYFILE}
+    COMMAND echo "PREDEFINED = __cplusplus XCL_DRIVER_DLLESPEC=" >> ${DOXYFILE}
+    COMMAND echo "EXPAND_AS_DEFINED = XCL_DRIVER_DLLESPEC" >> ${DOXYFILE}
+    COMMAND echo "INPUT = ${DOXY_INPUT}" >> ${DOXYFILE}
+    COMMAND ${DOXYGEN_EXECUTABLE}
+    )
+endif(NOT DOXYGEN_EXECUTABLE)
 
 if (NOT KERNELDOC_EXECUTABLE OR NOT SPHINX_EXECUTABLE)
   MESSAGE (WARNING "kernel-doc or Sphinx not found, XRT documentation build disabled")
@@ -46,6 +75,30 @@ else ()
   add_custom_command(OUTPUT core/zocl_ioctl.rst
     COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_ZOCL_IOCTL_H} > core/zocl_ioctl.rst
     DEPENDS ${XRT_ZOCL_IOCTL_H}
+    VERBATIM
+    )
+
+  add_custom_command(OUTPUT core/xrt_device.rst
+    DEPENDS ${XRT_DEVICE_H}
+    COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_DEVICE_H} > core/xrt_device.rst
+    VERBATIM
+    )
+
+  add_custom_command(OUTPUT core/xrt_bo.rst
+    DEPENDS ${XRT_BO_H}
+    COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_BO_H} > core/xrt_bo.rst
+    VERBATIM
+    )
+
+  add_custom_command(OUTPUT core/xrt_kernel.rst
+    DEPENDS ${XRT_KERNEL_H}
+    COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_KERNEL_H} > core/xrt_kernel.rst
+    VERBATIM
+    )
+
+  add_custom_command(OUTPUT core/xrt_xclbin.rst
+    DEPENDS ${XRT_XCLBIN_H}
+    COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_XCLBIN_H} > core/xrt_xclbin.rst
     VERBATIM
     )
 
@@ -85,9 +138,24 @@ else ()
     VERBATIM
     )
 
+
   add_custom_target(
-    xrt_docs ALL
-    DEPENDS core/mgmt-ioctl.rst core/xocl_ioctl.rst core/zocl_ioctl.rst core/xrt.rst core/ert.rst core/xma.rst core/xmaplugin.rst core/mailbox_proto.rst core/mailbox.rst
+    xrt_docs
+    DEPENDS
+    doxygen
+    core/mgmt-ioctl.rst
+    core/xocl_ioctl.rst
+    core/zocl_ioctl.rst
+    core/xrt_device.rst
+    core/xrt_bo.rst
+    core/xrt_kernel.rst
+    core/xrt_xclbin.rst
+    core/xrt.rst
+    core/ert.rst
+    core/xma.rst
+    core/xmaplugin.rst
+    core/mailbox_proto.rst
+    core/mailbox.rst
     COMMENT "Generating documentation with Sphinx"
     COMMAND ${CMAKE_COMMAND} -E make_directory  html
     COMMAND rm -rf ${DOC_TOC_DIR}/*

--- a/src/runtime_src/doc/toc/conf.py
+++ b/src/runtime_src/doc/toc/conf.py
@@ -31,7 +31,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.graphviz']
+extensions = ['sphinx.ext.graphviz', 'breathe']
 
 graphviz_output_format = 'svg'
 
@@ -51,6 +51,11 @@ master_doc = 'index'
 project = 'XRT'
 copyright = '2017-2020, Xilinx, Inc'
 author = 'Xilinx, Inc'
+
+# Breathe Configuration
+breathe_projects = {
+    "XRT":"../xml",
+}
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/src/runtime_src/doc/toc/xrt.main.rst
+++ b/src/runtime_src/doc/toc/xrt.main.rst
@@ -1,5 +1,35 @@
 .. _xrt.main.rst:
 
+XRT Native Library C++ API
+**************************
+
+.. doxygenclass:: xrt::device
+   :project: XRT
+   :members:
+
+.. doxygenclass:: xrt::bo
+   :project: XRT
+   :members:
+
+.. doxygenclass:: xrt::kernel
+   :project: XRT
+   :members:
+
+.. doxygenclass:: xrt::xclbin
+   :project: XRT
+   :members:
+
+XRT Native Library C API
+************************
+
+.. include:: ../core/xrt_device.rst
+
+.. include:: ../core/xrt_bo.rst
+
+.. include:: ../core/xrt_kernel.rst
+
+.. include:: ../core/xrt_xclbin.rst
+
 XRT Core Library
 ****************
 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -152,6 +152,7 @@ ub_package_list()
      gdb \
      git \
      gnuplot \
+     graphviz \
      libboost-dev \
      libboost-filesystem-dev \
      libboost-program-options-dev \
@@ -189,6 +190,7 @@ ub_package_list()
      python3-pip \
      python3-sphinx \
      python3-sphinx-rtd-theme \
+     python3-breathe \
     )
 
     if [ $docker == 0 ] && [ $sysroot == 0 ]; then


### PR DESCRIPTION
This PR adds support for C++ API documentation.  This is done through
doxygen and a sphinx plugin 'breathe'.  The documetation step in XRT,
runs doxygen on C++ headers to genetated XML data consumed and
formatted by sphinx with the breathe plugin.

This PR also separates documentation generation from building.  By
default the build.sh script no longer generates documentation.  This
is done because the necessary version of sphinx and plugins are not
available on all platforms.  In order to generate documentation, the
build.sh script must be invoked with the '-docs' option, e.g.

% build.sh -docs

Documentation generation will work if and only if sphinx-build and
breathe are installed along with kernel-doc.