### PR TITLE
xbutil2/xbmgmt2 post bash cleanup

### DIFF
--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -25,7 +25,7 @@
 // Initialize our static mapping.
 const Report::SchemaDescriptionVector Report::m_schemaVersionVector = {
   { SchemaVersion::unknown,       false, "",              "Unknown entry"},
-  { SchemaVersion::text,          true,  "text (default)","Human readable report"},
+  { SchemaVersion::text,          true,  "text",          "Human readable report (default)"},
   { SchemaVersion::json_internal, false, "JSON-internal", "Internal JSON property tree"},
   { SchemaVersion::json_20202,    true,  "JSON-2020.2",   "JSON 2020.2 schema"}
 };

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -25,7 +25,7 @@
 // Initialize our static mapping.
 const Report::SchemaDescriptionVector Report::m_schemaVersionVector = {
   { SchemaVersion::unknown,       false, "",              "Unknown entry"},
-  { SchemaVersion::text,          true,  "text",          "Human readable report"},
+  { SchemaVersion::text,          true,  "text (default)","Human readable report"},
   { SchemaVersion::json_internal, false, "JSON-internal", "Internal JSON property tree"},
   { SchemaVersion::json_20202,    true,  "JSON-2020.2",   "JSON 2020.2 schema"}
 };

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -100,6 +100,7 @@ void  main_(int argc, char** argv,
 
   // Check to see if help was requested and no command was found
   if (vm.count("subCmd") == 0) {
+    std::cerr << "ERROR: " << "Please specify a valid command" << std::endl << std::endl;
     XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, _subCmds);
     return;
   }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -385,28 +385,6 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
   }
 }
 
-xrt_core::device_collection
-XBUtilities::
-collect_devices(const std::vector<std::string>& _devices, bool _inUserDomain)
-{
-  std::set<std::string> device_set(_devices.begin(), _devices.end());
-  xrt_core::device_collection core_devices;
-  collect_devices(device_set, _inUserDomain, core_devices);
-  return core_devices;
-}
-
-xrt_core::device_collection
-XBUtilities::
-collect_devices( const std::string& _devices, // comma separated no space
-                 bool _inUserDomain )
-{
-  std::set<std::string> device_set;
-  boost::split(device_set, _devices, boost::is_any_of(","));
-  xrt_core::device_collection core_devices;
-  collect_devices(device_set, _inUserDomain, core_devices);
-  return core_devices;
-}
-
 bool
 XBUtilities::can_proceed()
 {

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -88,12 +88,6 @@ namespace XBUtilities {
                         bool _inUserDomain,
                         xrt_core::device_collection &_deviceCollection);
 
-  xrt_core::device_collection
-  collect_devices(const std::vector<std::string>& _devices, bool _inUserDomain);
-              
-  xrt_core::device_collection
-  collect_devices(const std::string& _devices, bool _inUserDomain);
-
   boost::property_tree::ptree
   get_available_devices(bool inUserDomain);
   std::string format_base10_shiftdown3(uint64_t value);

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -229,7 +229,7 @@ memory_retention(xrt_core::device* device, mem_type, bool enable)
 
 OO_Config::OO_Config( const std::string &_longName, bool _isHidden)
     : OptionOptions(_longName, _isHidden, "Utility to modify the memory configuration(s)")
-    , m_device({})
+    , m_devices({})
     , m_help(false)
     , m_daemon(false)
     , m_host("")
@@ -244,7 +244,7 @@ OO_Config::OO_Config( const std::string &_longName, bool _isHidden)
 
 {
   m_optionsDescription.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("device,d", boost::program_options::value<decltype(m_devices)>(&m_devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("retention", boost::program_options::value<decltype(m_retention)>(&m_retention),"Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]")
     ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
@@ -307,7 +307,7 @@ OO_Config::execute(const SubCmdOptions& _options) const
     }
   }
 
-  if (m_device.empty() && !m_daemon)  {
+  if (m_devices.empty() && !m_daemon)  {
     std::cerr << "ERROR: If the daemon is to be used (e.g., set to true) then a device must also be declared." << std::endl;
     printHelp();
     return;
@@ -316,7 +316,7 @@ OO_Config::execute(const SubCmdOptions& _options) const
   // -- process option: device -----------------------------------------------
   std::set<std::string> deviceNames;
   xrt_core::device_collection deviceCollection;
-  for (const auto & deviceName : m_device) 
+  for (const auto & deviceName : m_devices) 
     deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
   
   XBU::collect_devices(deviceNames, false /*inUserDomain*/, deviceCollection);
@@ -346,7 +346,7 @@ OO_Config::execute(const SubCmdOptions& _options) const
   }
 
   //-- process option: device -----------------------------------------------
-  if (!m_device.empty()) {
+  if (!m_devices.empty()) {
     XBU::verbose("Sub command: --device");
     //update security
     if (!m_security.empty())

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
@@ -29,7 +29,7 @@ class OO_Config : public OptionOptions {
   OO_Config(const std::string &_longName, bool _isHidden = false);
 
  private:
-  std::vector<std::string> m_device;
+  std::vector<std::string> m_devices;
   bool m_help;
   bool m_daemon;
   std::string m_host;

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -255,12 +255,12 @@ p2p(xrt_core::device* device, action_type action, bool force)
 
 OO_P2P::OO_P2P( const std::string &_longName, bool _isHidden )
     : OptionOptions(_longName, _isHidden, "Controls P2P functionality")
-    , m_device("")
+    , m_device({})
     , m_action("")
     , m_help(false)
 {
   m_optionsDescription.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("action", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: ENABLE, DISABLE, or VALIDATE")
     ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
@@ -305,7 +305,13 @@ OO_P2P::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  //
-  for (auto& device : XBU::collect_devices(m_device, true))
+  // Collect all of the devices of interest
+  std::set<std::string> deviceNames;
+  xrt_core::device_collection deviceCollection;
+  for (const auto & deviceName : m_device) 
+    deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
+  
+  XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection);
+  for (auto& device : deviceCollection)
     p2p(device.get(), string2action(m_action), false);
 }

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -255,12 +255,12 @@ p2p(xrt_core::device* device, action_type action, bool force)
 
 OO_P2P::OO_P2P( const std::string &_longName, bool _isHidden )
     : OptionOptions(_longName, _isHidden, "Controls P2P functionality")
-    , m_device({})
+    , m_devices({})
     , m_action("")
     , m_help(false)
 {
   m_optionsDescription.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("device,d", boost::program_options::value<decltype(m_devices)>(&m_devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("action", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: ENABLE, DISABLE, or VALIDATE")
     ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
@@ -300,7 +300,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
   }
 
   // Exit if neither action or device specified
-  if(m_help || (m_action.empty() || m_device.empty())) {
+  if(m_help || (m_action.empty() || m_devices.empty())) {
     printHelp();
     return;
   }
@@ -308,7 +308,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
   // Collect all of the devices of interest
   std::set<std::string> deviceNames;
   xrt_core::device_collection deviceCollection;
-  for (const auto & deviceName : m_device) 
+  for (const auto & deviceName : m_devices) 
     deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
   
   XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection);

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.h
@@ -27,7 +27,7 @@ class OO_P2P : public OptionOptions {
   OO_P2P( const std::string &_longName, bool _isHidden = false);
 
  private:
-  std::vector<std::string> m_device;
+  std::vector<std::string> m_devices;
   std::string m_action;
   bool m_help;
 };

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.h
@@ -27,7 +27,7 @@ class OO_P2P : public OptionOptions {
   OO_P2P( const std::string &_longName, bool _isHidden = false);
 
  private:
-  std::string m_device;
+  std::vector<std::string> m_device;
   std::string m_action;
   bool m_help;
 };

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -826,11 +826,11 @@ static std::vector<TestCollection> testSuite = {
  */
 static void
 pretty_print_test_desc(const boost::property_tree::ptree& test, int test_idx,
-                       size_t testSuiteSize, std::ostream & _ostream)
+                       size_t testSuiteSize, std::ostream & _ostream, const std::string& bdf)
 {
-  _ostream << boost::format("%d/%d Test #%-10d: %s\n") % test_idx % testSuiteSize
-                    % test_idx % test.get<std::string>("name");
-  _ostream << boost::format("    %-16s: %s\n") % "Description" % test.get<std::string>("description");
+  _ostream << boost::format("%d/%d Test #%d [%s]: %s \n") % test_idx % testSuiteSize
+                    % test_idx % bdf % test.get<std::string>("name");
+  _ostream << boost::format("    %-22s: %s\n") % "Description" % test.get<std::string>("description");
 }
 
 /*
@@ -848,7 +848,7 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   try {
     for (const auto& dict : test.get_child("log")) {
       for (const auto& kv : dict.second) {
-        _ostream<< boost::format("    %-16s: %s\n") % kv.first % kv.second.get_value<std::string>();
+        _ostream<< boost::format("    %-22s: %s\n") % kv.first % kv.second.get_value<std::string>();
         if (boost::iequals(kv.first, "warning"))
           warn = true;
         else if (boost::iequals(kv.first, "error"))
@@ -930,8 +930,10 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
   for (TestCollection * testPtr : testObjectsToRun) {
     boost::property_tree::ptree ptTest = testPtr->ptTest; // Create a copy of our entry
 
-    if(schemaVersion == Report::SchemaVersion::text)
-      pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream);
+    if(schemaVersion == Report::SchemaVersion::text) {
+      auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
+      pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
+    }
 
     testPtr->testHandle(device, ptTest);
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );


### PR DESCRIPTION
### Issues addressed
----
- **XRT-699 fix "device" inconsistency**: we had 3 functions to parse device list passed in by the user. To maintain consistency, I removed two of them
- **XRT-766 Add default "keyword" option to the "help" text** 
Sample output:
```
...
  -f, --format       - Report output format. Valid values are:
                         text        - Human readable report (default)
                         JSON-2020.2 - JSON 2020.2 schema
...
```
- **XRT-774 support blp programming with shell name** - Tested
- **XRT-775 xbmgmt --status doesn't show helpful help**
```
Sample output:
$ xbutil --new --examine
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
ERROR: Please specify a valid command


DESCRIPTION: The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that is
...
```
- **CR-1077412 xbutil2 validate - show card ID in test**
