### PR TITLE
3rd attemp to fix SC mismatch warning msg

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4172,15 +4172,15 @@ static int xmc_load_board_info(struct xocl_xmc *xmc)
 
 		tmp_str = (char *)xocl_icap_get_data(xdev, EXP_BMC_VER);
 		if (tmp_str) {
+			/*
+			 * Start with sc version being the same as expected
+			 * sc version. This should be good enough for shells
+			 * with no sc at all. Later, sc version can be loaded
+			 * from HW, if there is one available.
+			 */
 			strncpy(xmc->exp_bmc_ver, tmp_str,
 				sizeof(xmc->exp_bmc_ver) - 1);
-		}
-		if (!strcmp(xmc->exp_bmc_ver, NONE_BMC_VERSION)) {
-			/*
-			 * No SC image is needed, set expect to be
-			 * the same as current.
-			 */
-			strncpy(xmc->bmc_ver, xmc->exp_bmc_ver,
+			strncpy(xmc->bmc_ver, tmp_str,
 				sizeof(xmc->bmc_ver) - 1);
 		}
 
@@ -4228,6 +4228,14 @@ static int xmc_load_board_info(struct xocl_xmc *xmc)
 			BDINFO_NAME, xmc->bd_name);
 		xmc_set_board_info(bdinfo_raw, bd_info_sz,
 			BDINFO_BMC_VER, xmc->bmc_ver);
+		if (!strcmp(xmc->exp_bmc_ver, NONE_BMC_VERSION)) {
+			/*
+			 * No SC image is needed, set expect to be
+			 * the same as current.
+			 */
+			xmc_set_board_info(bdinfo_raw, bd_info_sz,
+				BDINFO_BMC_VER, xmc->exp_bmc_ver);
+		}
 		xmc_set_board_info(bdinfo_raw, bd_info_sz,
 			BDINFO_MAX_PWR, (char *)&xmc->max_power);
 		xmc_set_board_info(bdinfo_raw, bd_info_sz,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4173,7 +4173,15 @@ static int xmc_load_board_info(struct xocl_xmc *xmc)
 		tmp_str = (char *)xocl_icap_get_data(xdev, EXP_BMC_VER);
 		if (tmp_str) {
 			strncpy(xmc->exp_bmc_ver, tmp_str,
-				XMC_BDINFO_ENTRY_LEN_MAX - 1);
+				sizeof(xmc->exp_bmc_ver) - 1);
+		}
+		if (!strcmp(xmc->exp_bmc_ver, NONE_BMC_VERSION)) {
+			/*
+			 * No SC image is needed, set expect to be
+			 * the same as current.
+			 */
+			strncpy(xmc->bmc_ver, xmc->exp_bmc_ver,
+				sizeof(xmc->bmc_ver) - 1);
 		}
 
 		if ((!is_xmc_ready(xmc) || !is_sc_ready(xmc, false)))
@@ -4220,14 +4228,6 @@ static int xmc_load_board_info(struct xocl_xmc *xmc)
 			BDINFO_NAME, xmc->bd_name);
 		xmc_set_board_info(bdinfo_raw, bd_info_sz,
 			BDINFO_BMC_VER, xmc->bmc_ver);
-		if (!strcmp(xmc->exp_bmc_ver, NONE_BMC_VERSION)) {
-			/*
-			 * No SC image is needed, set expect to be
-			 * the same as current.
-			 */
-			xmc_set_board_info(bdinfo_raw, bd_info_sz,
-				BDINFO_BMC_VER, xmc->exp_bmc_ver);
-		}
 		xmc_set_board_info(bdinfo_raw, bd_info_sz,
 			BDINFO_MAX_PWR, (char *)&xmc->max_power);
 		xmc_set_board_info(bdinfo_raw, bd_info_sz,


### PR DESCRIPTION
The previous fix does not work on U.2 where there is no SC at all!
I have tested on U.2 and U50. @xuhz , pls help to verify on U25/30.