### PR TITLE
Support FA descriptor for OCL

### DIFF
--- a/src/runtime_src/xocl/core/execution_context.h
+++ b/src/runtime_src/xocl/core/execution_context.h
@@ -127,6 +127,19 @@ private:
   cu_control_type() const;
 
   /**
+   * Fill the Fast Adapter descriptor when 
+   * kernel control type is FAST_ADAPTER
+   */
+  size_t
+  fill_fa_desc(void* data);
+
+  /**
+   * Opcode for command object
+   */
+  ert_cmd_opcode
+  get_opcode() const;
+
+  /**
    * Update workgroup accounting.
    */
   void

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -65,6 +65,7 @@ public:
       size_t offset;
       size_t hostoffset;
       size_t hostsize;
+      size_t fa_desc_offset;// fast adapter desc entry offseet
       std::string type;
       size_t memsize;
       size_t baseaddr;      // progvar base addr
@@ -99,6 +100,11 @@ public:
     std::vector<arg> arguments;      // the args of this kernel
     std::vector<instance> instances; // the kernel instances
     target_type target;              // xclbin target
+    size_t fa_num_inputs = 0;        // Fast adapter number of inputs per meta data
+    size_t fa_num_outputs = 0;       // Fast adapter number of outputs per meta data
+    size_t fa_input_entry_bytes = 0; // Fast adapter input desc bytes
+    size_t fa_output_entry_bytes = 0;// Fast adapter output desc bytes
+    size_t fa_desc_bytes = 0;        // Fast adapter total bytes for descriptor
   };
 
 public:

--- a/src/runtime_src/xrt/scheduler/command.cpp
+++ b/src/runtime_src/xrt/scheduler/command.cpp
@@ -111,7 +111,6 @@ command(xrt::device* device, ert_cmd_opcode opcode)
   auto epacket = get_ert_cmd<ert_packet*>();
   epacket->state = ERT_CMD_STATE_NEW; // new command
   epacket->opcode = opcode & 0x1F; // [4:0]
-  epacket->type = opcode >> 5;     // [9:5]
 
   XRT_DEBUG(std::cout,"xrt::command::command(",m_uid,")\n");
 

--- a/src/runtime_src/xrt/util/regmap.h
+++ b/src/runtime_src/xrt/util/regmap.h
@@ -115,6 +115,12 @@ public:
     return m_size * sizeof(WordType);
   }
 
+  WordType*
+  data()
+  {
+    return m_regmap.data();
+  }
+
   const WordType*
   data() const
   {

--- a/tests/xrt/fa_kernel/CMakeLists.txt
+++ b/tests/xrt/fa_kernel/CMakeLists.txt
@@ -1,11 +1,30 @@
 set(TESTNAME "fa_kernel")
 
-add_executable(${TESTNAME} main.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+add_executable(fa_xrt xrt.cpp)
+target_link_libraries(fa_xrt PRIVATE ${xrt_coreutil_LIBRARY})
+
+add_executable(fa_ocl ocl.cpp)
+target_link_libraries(fa_ocl PRIVATE ${xrt_xilinxopencl_LIBRARY})
+if (WIN32)
+  set(OCL_ROOT c:/Xilinx/XRT/ext)
+  set(OpenCL_INCLUDE_DIR ${OCL_ROOT}/include)
+  find_library(OpenCL_LIBRARY
+    NAMES OpenCL
+    HINTS "${OCL_ROOT}/lib")
+
+  target_include_directories(fa_ocl PUBLIC ${OpenCL_INCLUDE_DIR})
+endif (WIN32)
+target_compile_options(fa_ocl PUBLIC
+  "-DCL_TARGET_OPENCL_VERSION=120"
+  "-DCL_HPP_MINIMUM_OPENCL_VERSION=120"
+  "-DCL_HPP_TARGET_OPENCL_VERSION=120"
+  "-DCL_USE_DEPRECATED_OPENCL_1_2_APIS"
+  )
 
 if (NOT WIN32)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)
+  target_link_libraries(fa_xrt PRIVATE ${uuid_LIBRARY} pthread)
+  target_link_libraries(fa_ocl PRIVATE pthread)
 endif(NOT WIN32)
 
-install(TARGETS ${TESTNAME}
+install(TARGETS fa_xrt fa_ocl
   RUNTIME DESTINATION ${INSTALL_DIR}/${TESTNAME})

--- a/tests/xrt/fa_kernel/ocl.cpp
+++ b/tests/xrt/fa_kernel/ocl.cpp
@@ -1,0 +1,345 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include <CL/cl.h>
+
+#include <algorithm>
+#include <chrono>
+#include <atomic>
+#include <stdexcept>
+#include <string>
+#include <fstream>
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <cstdarg>
+
+static void usage()
+{
+    std::cout << "usage: %s [options] -k <bitstream>\n\n";
+    std::cout << "  -k <bitstream>\n";
+    std::cout << "  -h\n\n";
+    std::cout << "* Bitstream is required\n";
+}
+
+static void
+throw_if_error(cl_int errcode, const char* msg=nullptr)
+{
+  if (!errcode)
+    return;
+  std::string err = "errcode '";
+  err.append(std::to_string(errcode)).append("'");
+  if (msg)
+    err.append(" ").append(msg);
+  throw std::runtime_error(err);
+}
+
+static void
+throw_if_error(cl_int errcode, const std::string& msg)
+{
+  throw_if_error(errcode,msg.c_str());
+}
+
+
+// Flag to stop job rescheduling.  Is set to true after
+// specified number of seconds.
+static bool stop = true;
+
+// Forward declaration of event callback function for event of last
+// copy stage of a job.
+static void
+kernel_done(cl_event event, cl_int status, void* data);
+
+// Data for a single job
+struct job_type
+{
+  static constexpr uint32_t aes_key[16] = {
+    0xeb5aa3b8,
+    0x17750c26,
+    0x9d0db966,
+    0xbcb9e3b6,
+    0x510e08c6,
+    0x83956e46,
+    0x3bd10f72,
+    0x769bf32e,
+    0xfa374467,
+    0x3386553a,
+    0x46f91c6a,
+    0x6b25d1b4,
+    0x6116fa6f,
+    0xd29b1a56,
+    0x9c193635,
+    0x10ed77d4
+  };
+
+  static constexpr uint32_t aes_iv[4] = {
+    0x149f40ae,
+    0x38f1817d,
+    0x32ccb7db,
+    0xa6ef0e05
+  }; 
+
+  static constexpr size_t len = 4096;
+
+  size_t id = 0;
+  size_t runs = 0;
+
+  cl_context context = nullptr;
+  cl_command_queue queue = nullptr;
+  cl_kernel kernel = nullptr;
+
+  cl_mem in;
+  cl_mem out;
+  cl_mem out_status;
+
+  std::atomic<bool> busy{false};
+
+  job_type(cl_context c, cl_command_queue q, cl_kernel k)
+    : context(c), queue(q), kernel(k)
+  {
+    static size_t count=0;
+    id = count++;
+
+    // create buffers
+    cl_int err = CL_SUCCESS;;
+    uint32_t in_data[len/sizeof(uint32_t)];
+    std::iota(std::begin(in_data), std::end(in_data), 0);
+
+    in = clCreateBuffer(context,CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,len,in_data,&err);
+    throw_if_error(err,"failed to allocate 'in' buffer");
+
+    out = clCreateBuffer(context,CL_MEM_WRITE_ONLY,len,nullptr,&err);
+    throw_if_error(err,"failed to allocate 'out' buffer");
+
+    out_status = clCreateBuffer(context,CL_MEM_WRITE_ONLY,len,nullptr,&err);
+    throw_if_error(err,"failed to allocate 'out_status' buffer");
+
+    // set kernel arguments
+    throw_if_error(clSetKernelArg(kernel,0,sizeof(cl_mem),&in), "failed to set kernel arg(0) 'in'");
+    throw_if_error(clSetKernelArg(kernel,1,sizeof(int),&len), "failed to set kernel arg(1) 'len'");
+    throw_if_error(clSetKernelArg(kernel,2,sizeof(cl_mem),&out), "failed to set kernel arg(2) 'out'");
+    throw_if_error(clSetKernelArg(kernel,3,sizeof(int),&len), "failed to set kernel arg(3) 'len'");
+    throw_if_error(clSetKernelArg(kernel,4,sizeof(cl_mem),&out_status), "failed to set kernel arg(4) 'out_status'");
+    throw_if_error(clSetKernelArg(kernel,5,sizeof(aes_key),&aes_key), "failed to set kernel arg(5) 'aes_key'");
+    throw_if_error(clSetKernelArg(kernel,6,sizeof(aes_iv),&aes_iv), "failed to set kernel arg(6) 'aes_iv'");
+
+    // Migrate 'in memory objects to device
+    throw_if_error(clEnqueueMigrateMemObjects(queue,1,&in,0,0,nullptr,nullptr),"failed to migrate");
+    throw_if_error(clFinish(queue),"failed clFinish");
+  }
+
+  job_type(job_type&& rhs)
+    : id(rhs.id), runs(rhs.runs),
+      in(rhs.in), out(rhs.out), out_status(rhs.out_status),
+      context(rhs.context), queue(rhs.queue), kernel(rhs.kernel),
+      busy(false)
+  {}
+
+  ~job_type()
+  {
+    clReleaseMemObject(in);
+    clReleaseMemObject(out);
+    clReleaseMemObject(out_status);
+  }
+
+  void
+  start()
+  {
+    if (busy)
+      throw std::runtime_error("job is already running");
+
+    ++runs;
+    busy = true;
+
+    cl_int err = CL_SUCCESS;
+    cl_event kevent = nullptr;
+
+    static size_t global[3] = {1,0,0};
+    static size_t local[3] = {1,0,0};
+
+    err = clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, global, local, 0, nullptr, &kevent);
+    if (err) throw_if_error(err,"failed to execute job " + std::to_string(id));
+    clSetEventCallback(kevent,CL_COMPLETE,&kernel_done,this);
+  }
+
+  void
+  mark_done()
+  {
+    busy = false;
+  }
+
+  bool
+  is_done() const
+  {
+    return !busy;
+  }
+};
+
+constexpr uint32_t job_type::aes_key[16];
+constexpr uint32_t job_type::aes_iv[4];
+constexpr size_t job_type::len;
+
+static void
+kernel_done(cl_event event, cl_int status, void* data)
+{
+  reinterpret_cast<job_type*>(data)->mark_done();
+  clReleaseEvent(event);
+}
+
+static double
+run(std::vector<job_type>& cmds, size_t total)
+{
+  size_t i = 0;
+  size_t issued = 0, completed = 0;
+  auto start = std::chrono::high_resolution_clock::now();
+
+  for (auto& cmd : cmds) {
+    cmd.start();
+    if (++issued == total)
+      break;
+  }
+
+  while (completed < total) {
+    auto& cmd = cmds[i];
+
+    if (cmd.is_done()) {
+      ++completed;
+      // cmd.verify()
+      if (issued < total) {
+        cmd.start();
+        ++issued;
+      }
+    }
+        
+    if (++i == cmds.size())
+      i = 0;
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  return (std::chrono::duration_cast<std::chrono::microseconds>(end - start)).count();
+  
+}
+
+static int
+run(cl_context context, cl_command_queue queue, cl_kernel kernel)
+{
+  std::vector<size_t> cmds_per_run = { 16, 100, 1000, 10000, 100000, 1000000 };
+  size_t expected_cmds = 10000;
+
+  std::vector<job_type> jobs;
+  jobs.reserve(expected_cmds);
+  for (int i = 0; i < expected_cmds; ++i)
+    jobs.emplace_back(context, queue, kernel);
+
+  for (auto num_cmds : cmds_per_run) {
+    auto duration = run(jobs, num_cmds);
+
+    std::cout << "Commands: " << std::setw(7) << num_cmds
+              << " iops: " << (num_cmds * 1000.0 * 1000.0 / duration)
+              << std::endl;
+  }
+}
+
+static int
+run(const std::string& fnm)
+{
+  // Init OCL
+  cl_int err = CL_SUCCESS;
+  cl_platform_id platform = nullptr;
+  throw_if_error(clGetPlatformIDs(1,&platform,nullptr));
+
+  cl_uint num_devices = 0;
+  throw_if_error(clGetDeviceIDs(platform,CL_DEVICE_TYPE_ACCELERATOR,0,nullptr,&num_devices));
+  throw_if_error(num_devices==0,"no devices");
+  std::vector<cl_device_id> devices(num_devices);
+  throw_if_error(clGetDeviceIDs(platform,CL_DEVICE_TYPE_ACCELERATOR,num_devices,devices.data(),nullptr));
+  cl_device_id device = devices.front();
+
+  cl_context context = clCreateContext(0,1,&device,nullptr,nullptr,&err);
+  throw_if_error(err);
+
+  cl_command_queue queue = clCreateCommandQueue(context,device,CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,&err);
+  throw_if_error(err,"failed to create command queue");
+
+  // Read xclbin and create program
+  std::ifstream stream(fnm);
+  stream.seekg(0,stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
+  std::vector<char> xclbin(size);
+  stream.read(xclbin.data(),size);
+  const unsigned char* data = reinterpret_cast<unsigned char*>(xclbin.data());
+  cl_int status = CL_SUCCESS;
+  auto program = clCreateProgramWithBinary(context,1,&device,&size,&data,&status,&err);
+  throw_if_error(err,"failed to create program");
+  auto kernel = clCreateKernel(program,"fa_aes_xts2_rtl_enc",&err);
+  throw_if_error(err,"failed to allocate kernel object");
+
+  run(context,queue,kernel);
+
+  clReleaseKernel(kernel);
+  clReleaseProgram(program);
+  clReleaseCommandQueue(queue);
+  clReleaseContext(context);
+  clReleaseDevice(device);
+  std::for_each(devices.begin(),devices.end(),[](cl_device_id d){clReleaseDevice(d);});
+  return 0;
+}
+
+int run(int argc, char** argv)
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+
+  std::string xclbin_fnm;
+
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return 1;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "-k")
+      xclbin_fnm = arg;
+    else
+      throw std::runtime_error("Unknown option value " + cur + " " + arg);
+  }
+
+  run(xclbin_fnm);
+
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    run(argc,argv);
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}

--- a/tests/xrt/fa_kernel/xrt.cpp
+++ b/tests/xrt/fa_kernel/xrt.cpp
@@ -30,13 +30,6 @@
 # pragma warning ( disable : 4244 )
 #endif
 
-
-/**
- * Runs an OpenCL kernel which writes known 16 integers into a 64 byte
- * buffer. Does not use OpenCL runtime but directly exercises the HAL
- * driver API.
- */
-
 static void usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
@@ -177,9 +170,7 @@ run(int argc, char** argv)
   }
 
   std::string xclbin_fnm;
-  bool verbose = false;
   unsigned int device_index = 0;
-  bool random = false;
 
   std::vector<std::string> args(argv+1,argv+argc);
   std::string cur;
@@ -187,14 +178,6 @@ run(int argc, char** argv)
     if (arg == "-h") {
       usage();
       return 1;
-    }
-    else if (arg == "-v") {
-      verbose = true;
-      continue;
-    }
-    else if (cur == "-r") {
-      random = true;
-      continue;
     }
 
     if (arg[0] == '-') {


### PR DESCRIPTION
Updated OCL xclbin meta data parser to amend argument meta data with
FA specific data.  This code relies on XML kernel attribute
hwControlProtocol set to "fast_adapter" for FA style kernels.

Execution context take custom code path for Fast Adapter protocol, and
uses computed xclbin meta data to offset and populate the command
payload with the fa_descriptor.

Update low level fa_kernel test to add OCL test case alongside the
existing XRT native test case.  Renamed main.cpp -> xrt.cpp and added
ocl.cpp.  The executables are fa_xrt and fa_ocl when built by CMake.