### PR TITLE
CR-1078052 xbutil validate on one card (u250) is adding excessive del…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1157,6 +1157,13 @@ static int xmc_get_data(struct platform_device *pdev, enum xcl_group_kind kind,
 		xmc_bdinfo(pdev, EXP_BMC_VER, (u32 *)bdinfo->exp_bmc_ver);
 		xmc_bdinfo(pdev, MAC_CONT_NUM, &bdinfo->mac_contiguous_num);
 		xmc_bdinfo(pdev, MAC_ADDR_FIRST, (u32 *)bdinfo->mac_addr_first);
+
+	 	if (strcmp(bdinfo->bmc_ver, bdinfo->exp_bmc_ver)) {
+			xocl_warn(&xmc->pdev->dev, "installed XSABIN has SC version: "
+			    "(%s) mismatch with loaded SC version: (%s).",
+			    bdinfo->exp_bmc_ver, bdinfo->bmc_ver);
+		}
+
 		mutex_unlock(&xmc->mbx_lock);
 		break;
 	default:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -487,7 +487,6 @@ static ssize_t ready_show(struct device *dev,
 {
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 	uint64_t ch_state = 0, ret = 0, daemon_state = 0;
-	struct xcl_board_info *board_info = NULL;
 
 	xocl_mailbox_get(xdev, CHAN_STATE, &ch_state);
 
@@ -503,30 +502,6 @@ static ssize_t ready_show(struct device *dev,
 		ret = ((ch_state & XCL_MB_PEER_READY) && daemon_state)
 			? 1 : 0;
 	}
-
-	/* for now skip checking SC compatibility for 1RP flow */
-	if (!ret || !xocl_rom_get_uuid(xdev))
-		goto bail;
-
-	board_info = vzalloc(sizeof(*board_info));
-	if (!board_info)
-		goto bail;
-	xocl_xmc_get_data(xdev, XCL_BDINFO, board_info);
-	/*
-	 * Lift the restriction of mis-matching SC version for
-	 * experienced user to manually update SC firmware than
-	 * installed xsabin may contain.
-	 */
-	if (strcmp(board_info->bmc_ver, board_info->exp_bmc_ver)) {
-		xocl_warn(dev, "installed XSABIN has SC version: "
-		    "(%s) mismatch with loaded SC version: (%s).",
-		    board_info->exp_bmc_ver, board_info->bmc_ver);
-	}
-	ret = 1;
-
-bail:
-	if (board_info)
-		vfree(board_info);
 
 	return sprintf(buf, "0x%llx\n", ret);
 }


### PR DESCRIPTION
…ay to xbutil operations on another card (u50)

This fix one issue that reading ready sysfs could be slow due to bdinfo request on the card.
This fix cannot fix the issue of opening the device, sometimes opening is also slow.

Eventually, we should ask them to use "xbutil top" instead of "dump".