### PR TITLE
CR-1078348 rw_shared support in xrt::kernel opening

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -853,7 +853,7 @@ class kernel_impl
       throw std::runtime_error("Cannot read or write kernel with multiple compute units");
     auto& ipctx = ipctxs.back();
     auto mode = ipctx->get_access_mode();
-    if (!force && mode != ip_context::access_mode::exclusive)
+    if (!force && mode != ip_context::access_mode::exclusive && !xrt_core::config::get_rw_shared())
       throw std::runtime_error("Cannot read or write kernel with shared access");
 
     if ((offset + sizeof(uint32_t)) > ipctx->get_size())

--- a/tests/xrt/00_hello/main.cpp
+++ b/tests/xrt/00_hello/main.cpp
@@ -74,6 +74,21 @@ copy_test(const xrt::device& device, size_t bytes, int32_t grpidx)
     throw std::runtime_error("Value read back from copy bo does not match value written");
 }
 
+static void
+register_test(const xrt::kernel& kernel, int argno)
+{
+  try {
+    (void) argno;
+    // Throws unless Runtime.rw_shared=true
+    // Note, that xclbin must also be loaded with rw_shared=true
+    auto val = kernel.read_register(0x10); 
+    std::cout << "value at 0x10: " << val << "\n";
+  }
+  catch (const std::exception& ex) {
+    std::cout << "Expected failed kernel register read (" << ex.what() << ")\n";
+  }      
+}
+
 int run(int argc, char** argv)
 {
   if (argc < 3) {
@@ -126,6 +141,9 @@ int run(int argc, char** argv)
 
   // Copy through host not 64 byte aligned
   copy_test(device, 40, grpidx);
+
+  // Test of kernel.read_register (expected failure)
+  register_test(kernel, 0);
 
   return 0;
 }


### PR DESCRIPTION
Don't bail on shared CU if Runtime.rw_shared is true.