### PR TITLE
CR-1076634: Changing the user range interface to take const char*

### DIFF
--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -32,12 +32,11 @@
 
 namespace xrt { namespace profile {
 
-  user_range::user_range(const std::string& label,
-			 const std::string& tooltip) : active(true)
+  user_range::user_range(const char* label, const char* tooltip) : active(true)
   {
     id = static_cast<uint32_t>(xrt_core::utils::issue_id()) ;
 
-    xrtURStart(id, label.c_str(), tooltip.c_str()) ;
+    xrtURStart(id, label, tooltip) ;
   }
 
   user_range::user_range() : id(0), active(false)
@@ -49,14 +48,13 @@ namespace xrt { namespace profile {
     if (active) xrtUREnd(id) ;
   }
 
-  void user_range::start(const std::string& label, 
-			 const std::string& tooltip)
+  void user_range::start(const char* label, const char* tooltip)
   {
     // Handle case where start is called while started
     if (active) xrtUREnd(id) ;
 
     id = static_cast<uint32_t>(xrt_core::utils::issue_id()) ;
-    xrtURStart(id, label.c_str(), tooltip.c_str()) ;
+    xrtURStart(id, label, tooltip) ;
     active = true ;
   }
 

--- a/src/runtime_src/core/include/experimental/xrt_profile.h
+++ b/src/runtime_src/core/include/experimental/xrt_profile.h
@@ -21,7 +21,6 @@
 #include "xrt.h"
 
 #ifdef __cplusplus
-#include <string>
 
 namespace xrt { namespace profile {
 
@@ -51,8 +50,7 @@ namespace xrt { namespace profile {
      * upon construction.
      */
     XCL_DRIVER_DLLESPEC
-    user_range(const std::string& label, 
-		       const std::string& tooltip) ;
+    user_range(const char* label, const char* tooltip) ;
 
     /**
      * user_range() - Copy constructor
@@ -93,7 +91,7 @@ namespace xrt { namespace profile {
      * range and start a new one.
      */
     XCL_DRIVER_DLLESPEC
-    void start(const std::string& label, const std::string& tooltip) ;
+    void start(const char* label, const char* tooltip) ;
 
     /**
      * end() - Mark the end position of a user range

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -33,11 +33,14 @@ namespace xdp {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = userEventsPluginInstance.getDatabase() ;
 
+    const char* labelStr   = (label == nullptr)   ? "" : label ;
+    const char* tooltipStr = (tooltip == nullptr) ? "" : tooltip ;
+
     VTFEvent* event = new UserRange(0, 
 				    timestamp, 
 				    true, // isStart
-				    (db->getDynamicInfo()).addString(label),
-				    (db->getDynamicInfo()).addString(tooltip)) ;
+				    (db->getDynamicInfo()).addString(labelStr),
+				    (db->getDynamicInfo()).addString(tooltipStr)) ;
     (db->getDynamicInfo()).addEvent(event) ;
     (db->getDynamicInfo()).markStart(functionID, event->getEventId()) ;
   }


### PR DESCRIPTION
Since the user range and user marker libraries are called directly from user's host code, the interface should use standard C variable types instead of the C++ std::string to ease linking issues when XRT is built under different development toolsets on CentOS than the user's host code.
