### PR TITLE
CR-1076201 xrt::kernel::<member_function> to get argument offset

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1002,6 +1002,12 @@ public:
     return args.at(argno).group_id();
   }
 
+  int
+  arg_offset(int argno)
+  {
+    return args.at(argno).offset();
+  }
+
   uint32_t
   read_register(uint32_t offset, bool force=false) const
   {
@@ -1728,6 +1734,13 @@ group_id(int argno) const
   return handle->group_id(argno);
 }
 
+uint32_t
+kernel::
+offset(int argno) const
+{
+  return handle->arg_offset(argno);
+}
+
 } // namespace xrt
 
 ////////////////////////////////////////////////////////////////
@@ -1800,6 +1813,23 @@ xrtKernelArgGroupId(xrtKernelHandle khdl, int argno)
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
     return -1;
+  }
+}
+
+uint32_t
+xrtKernelArgOffset(xrtKernelHandle khdl, int argno)
+{
+  try {
+    auto kernel = get_kernel(khdl);
+    return kernel->arg_offset(argno);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return std::numeric_limits<uint32_t>::max();
   }
 }
 

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -598,8 +598,8 @@ xrtKernelArgGroupId(xrtKernelHandle kernelHandle, int argno);
  * @argno:  Index of kernel argument
  * Return:  The kernel register offset of the argument with specified index
  *
- * Use with ``read_register()`` and ``write_register()`` if manually
- * reading or writing kernel registers for explicit arguments.
+ * Use with ``xrtKernelReadRegister()`` and ``xrtKernelWriteRegister()`` 
+ * if manually reading or writing kernel registers for explicit arguments.
  */
 XCL_DRIVER_DLLESPEC
 uint32_t

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -442,6 +442,21 @@ class kernel
   group_id(int argno) const;
 
   /**
+   * offset() - Get the offset of kernel argument
+   *
+   * @param argno
+   *  The argument index
+   * @return
+   *  The kernel register offset of the argument with specified index
+   *
+   * Use with ``read_register()`` and ``write_register()`` if manually
+   * reading or writing kernel registers for explicit arguments. 
+   */
+  XCL_DRIVER_DLLESPEC
+  uint32_t
+  offset(int argno) const;
+
+  /**
    * write() - Write to the address range of a kernel
    *
    * @param offset
@@ -575,6 +590,20 @@ xrtKernelClose(xrtKernelHandle kernelHandle);
 XCL_DRIVER_DLLESPEC
 int
 xrtKernelArgGroupId(xrtKernelHandle kernelHandle, int argno);
+
+/**
+ * xrtKernelArgOffset() - Get the offset of kernel argument
+ *
+ * @khdl:   Handle to kernel previously opened with xrtKernelOpen
+ * @argno:  Index of kernel argument
+ * Return:  The kernel register offset of the argument with specified index
+ *
+ * Use with ``read_register()`` and ``write_register()`` if manually
+ * reading or writing kernel registers for explicit arguments.
+ */
+XCL_DRIVER_DLLESPEC
+uint32_t
+xrtKernelArgOffset(xrtKernelHandle khdl, int argno);
 
 /**
  * xrtKernelReadRegister() - Read data from kernel address range

--- a/tests/xrt/00_hello/main.cpp
+++ b/tests/xrt/00_hello/main.cpp
@@ -78,11 +78,11 @@ static void
 register_test(const xrt::kernel& kernel, int argno)
 {
   try {
-    (void) argno;
+    auto offset = kernel.offset(argno);
     // Throws unless Runtime.rw_shared=true
     // Note, that xclbin must also be loaded with rw_shared=true
-    auto val = kernel.read_register(0x10); 
-    std::cout << "value at 0x10: " << val << "\n";
+    auto val = kernel.read_register(offset);
+    std::cout << "value at 0x" << std::hex << offset << " = 0x" << val << std::dec << "\n";
   }
   catch (const std::exception& ex) {
     std::cout << "Expected failed kernel register read (" << ex.what() << ")\n";


### PR DESCRIPTION
Added for both C++ and C