### PR TITLE
Notify host if AP_DONE | AP_IDLE

### DIFF
--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -1154,8 +1154,14 @@ scheduler_loop()
         if (!cu_status[cuidx])
           continue; // CU is not used
 
+        /* For dataflow kernel, KDS and ERT will check the CUs from both sides.
+         * It's likely that ERT checks the CUs after the CUs are completed by KDS.
+         * So here ERT should check both AP_DONE and AP_IDLE bits or ERT will keep
+         * polling CU status register and never get AP_DONE. It may cause firewall
+         * tripped if we freeze the axi gate of the dynamic region.
+         */
         auto cuvalue = read_reg(cu_idx_to_addr(cuidx));
-        if (!(cuvalue & AP_DONE))
+        if (!(cuvalue & (AP_DONE|AP_IDLE)))
           continue;
 
         cu_status[cuidx] = !cu_status[cuidx]; // disable polling until host re-enables

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -1159,6 +1159,9 @@ scheduler_loop()
          * So here ERT should check both AP_DONE and AP_IDLE bits or ERT will keep
          * polling CU status register and never get AP_DONE. It may cause firewall
          * tripped if we freeze the axi gate of the dynamic region.
+         *
+         * For some CUs have no cmd to execute but AP_IDLE remain 0x0
+         * We should turn off ert and let KDS be in charge of this alone
          */
         auto cuvalue = read_reg(cu_idx_to_addr(cuidx));
         if (!(cuvalue & (AP_DONE|AP_IDLE)))


### PR DESCRIPTION
If the CU is a dataflow CU, KDS and ERT have weak relationship with each other which means KDS doesn't have to wait ERT's response for action, KDS may issue another CU START command if CU marked as AP_DONE.


https://github.com/Xilinx/XRT/pull/4127