### PR TITLE
disable ert via xbutil through old kds

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1934,7 +1934,7 @@ exec_cfg_cmd(struct exec_core *exec, struct xocl_cmd *xcmd)
 	unsigned int major = exec->ert_cfg_priv.major;
 	struct ert_configure_cmd *cfg = xcmd->ert_cfg;
 	bool ert = (XOCL_DSA_IS_VERSAL(xdev) || XOCL_DSA_IS_MPSOC(xdev)) ? 1 :
-	    (xocl_mb_sched_on(xdev) && exec->cq_base && exec->csr_base);
+	    (!XDEV(xdev)->kds.ert_disable && xocl_mb_sched_on(xdev) && exec->cq_base && exec->csr_base);
 	bool ert_full = (ert && cfg->ert && !cfg->dataflow);
 	bool ert_poll = (ert && cfg->ert && cfg->dataflow);
 	unsigned int ert_num_slots = 0;


### PR DESCRIPTION
xbutil scheduler -k 1 -d \<board\> disables ert.
xbutil scheduler -k 0 -d \<board\> enables ert.

Make sure to run xbutil reset after the change to make sure the new setting takes effect.