### PR TITLE
rst files reorganized

### DIFF
--- a/src/runtime_src/doc/toc/index.rst
+++ b/src/runtime_src/doc/toc/index.rst
@@ -49,8 +49,7 @@ FPGA. The key user APIs are defined in ``xrt.h`` header file.
 
    opencl_extension.rst
    xrt_native_apis.rst
-   xrt.main.rst
-   ert.main.rst
+   xrt_native.main.rst
    xma.main.rst
 
 
@@ -60,6 +59,8 @@ FPGA. The key user APIs are defined in ``xrt.h`` header file.
 
    sysfs.rst
    formats.rst
+   xrt.main.rst
+   ert.main.rst
    mgmt-ioctl.main.rst
    xocl_ioctl.main.rst
    zocl_ioctl.main.rst

--- a/src/runtime_src/doc/toc/xrt.main.rst
+++ b/src/runtime_src/doc/toc/xrt.main.rst
@@ -1,35 +1,5 @@
 .. _xrt.main.rst:
 
-XRT Native Library C++ API
-**************************
-
-.. doxygenclass:: xrt::device
-   :project: XRT
-   :members:
-
-.. doxygenclass:: xrt::bo
-   :project: XRT
-   :members:
-
-.. doxygenclass:: xrt::kernel
-   :project: XRT
-   :members:
-
-.. doxygenclass:: xrt::xclbin
-   :project: XRT
-   :members:
-
-XRT Native Library C API
-************************
-
-.. include:: ../core/xrt_device.rst
-
-.. include:: ../core/xrt_bo.rst
-
-.. include:: ../core/xrt_kernel.rst
-
-.. include:: ../core/xrt_xclbin.rst
-
 XRT Core Library
 ****************
 

--- a/src/runtime_src/doc/toc/xrt_native.main.rst
+++ b/src/runtime_src/doc/toc/xrt_native.main.rst
@@ -1,0 +1,51 @@
+.. _xrt_native.main.rst:
+
+XRT Native Library C++ API
+**************************
+
+Device and XCLBIN APIs
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. doxygenclass:: xrt::device
+   :project: XRT
+   :members:
+
+.. doxygenclass:: xrt::xclbin
+   :project: XRT
+   :members:
+
+Buffer APIs
+~~~~~~~~~~~
+
+.. doxygenclass:: xrt::bo
+   :project: XRT
+   :members:
+
+Kernel APIs
+~~~~~~~~~~~
+
+.. doxygenclass:: xrt::kernel
+   :project: XRT
+   :members:
+
+
+XRT Native Library C API
+************************
+
+Device and XCLBIN APIs
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../core/xrt_device.rst
+
+.. include:: ../core/xrt_xclbin.rst
+
+Buffer APIs
+~~~~~~~~~~~
+
+.. include:: ../core/xrt_bo.rst
+
+Kernel APIs
+~~~~~~~~~~~
+.. include:: ../core/xrt_kernel.rst
+
+


### PR DESCRIPTION
1. Core API library now separated from the XRT native library and moved to Developer's section
2. ERT API library also moved to the Developer's section
3. Native API library remains in the User API Library section and added subsections for different kind of APIs (Kernel, Buffers etc)