### PR TITLE
CR-1054279 Enhanced suppression of XRT messages

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ini.cpp
+++ b/src/runtime_src/core/common/api/xrt_ini.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This file implements XRT error APIs as declared in
+// core/include/experimental/xrt_ini.h
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_ini.h
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "core/include/experimental/xrt_ini.h"
+
+#include "core/common/config_reader.h"
+#include "core/common/error.h"
+
+namespace xrt { namespace ini {
+
+void
+set(const std::string& key, const std::string& value)
+{
+  xrt_core::config::detail::set(key, value);
+}
+
+}} // namespace ini,xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_ini C API implmentations (xrt_ini.h)
+////////////////////////////////////////////////////////////////
+int
+xrtIniStringSet(const char* key, const char* value)
+{
+  try {
+    xrt::ini::set(key, value);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = 1;
+  }
+  return errno;
+}
+
+int
+xrtIniUintSet(const char* key, unsigned int value)
+{
+  try {
+    xrt::ini::set(key, std::to_string(value));
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = 1;
+  }
+  return errno;
+}

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -86,6 +86,10 @@ XRT_CORE_COMMON_EXPORT
 std::ostream&
 debug(std::ostream&, const std::string& ini="");
 
+// Internal method for xrt_ini.cpp implementation
+void
+set(const std::string& key, const std::string& value);
+
 }
 
 /**
@@ -276,14 +280,16 @@ get_api_checks()
 inline std::string
 get_logging()
 {
-  static std::string value = detail::get_string_value("Runtime.runtime_log","console");
+  // Allow this configure value to change on the fly
+  std::string value = detail::get_string_value("Runtime.runtime_log","console");
   return value;
 }
 
 inline unsigned int
 get_verbosity()
 {
-  static unsigned int value = detail::get_uint_value("Runtime.verbosity",4);
+  // Allow this configure value to change on the fly
+  unsigned int value = detail::get_uint_value("Runtime.verbosity",4);
   return value;
 }
 

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -5,6 +5,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_device.h
   xrt_enqueue.h
   xrt_error.h
+  xrt_ini.h
   xrt_kernel.h
   xrt_profile.h
   xrt_uuid.h

--- a/src/runtime_src/core/include/experimental/xrt_ini.h
+++ b/src/runtime_src/core/include/experimental/xrt_ini.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XRT_INI_H_
+#define _XRT_INI_H_
+
+#include "xrt.h"
+
+#ifdef __cplusplus
+# include <string>
+#endif
+
+#ifdef __cplusplus
+
+/*!
+ * @namespace xrt::ini
+ *
+ * APIs for XRT configuration control.
+ *
+ * XRT can be configured through a json xrt.ini file co-located with
+ * the host executable.  If present, XRT uses configuration options 
+ * from the ini file when a given option is first accessed. Without an
+ * ini file, the configuration options take on default values.
+ *
+ * The APIs in this file allow host application to specify
+ * configuration options for XRT programatically.  It is only possible
+ * for the host application to change configuration options before a
+ * given option is used by XRT the very first time.
+ */
+namespace xrt { namespace ini {
+
+/*!
+ * set() - Change xrt.ini string value for specified key
+ *
+ * @param key
+ *  Key to change value for
+ * @param value
+ *  New value for key
+ *
+ * Throws if key value cannot be changed.
+ */
+XCL_DRIVER_DLLESPEC
+void
+set(const std::string& key, const std::string& value);
+
+/*!
+ * set() - Change xrt.ini string value for specified key
+ *
+ * @param key
+ *  Key to change value for
+ * @param value
+ *  New value for key
+ *
+ * Throws if key value cannot be changed.
+ */
+void
+set(const std::string& key, unsigned int value)
+{
+  set(key, std::to_string(value));
+}
+
+
+}} // ini, xrt
+
+/// @cond
+extern "C" {
+#endif
+
+/**
+ * xrtIniSet() - Change xrt.ini string value for specified key
+ * 
+ * @key:    Key to change value for
+ * @value:  New value for key
+ * Return:  0 on success, error if key value cannot be changed
+ */
+XCL_DRIVER_DLLESPEC
+int
+xrtIniStringSet(const char* key, const char* value);
+
+/**
+ * xrtIniUintSet() - Change xrt.ini unsigned int value for specified key
+ * 
+ * @key:    Key to change value for
+ * @value:  New value for key
+ * Return:  0 on success, error if key value cannot be changed
+ */
+XCL_DRIVER_DLLESPEC
+int
+xrtIniUintSet(const char* key, unsigned int value);
+
+/// @endcond  
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_kernel.h
+++ b/src/runtime_src/core/include/experimental/xrt_kernel.h
@@ -56,7 +56,7 @@ namespace xrt {
 class kernel;
 class event_impl;
 
-/**
+/*!
  * @class run 
  *
  * @brief 
@@ -120,7 +120,7 @@ class run
   /**
    * wait() - Wait for specified milliseconds for run to complete
    *
-   * @param timeout
+   * @param timeout_ms
    *  Timeout in milliseconds
    * @return
    *  Command state upon return of wait
@@ -353,7 +353,7 @@ private:
 };
  
 
-/**
+/*!
  * @class kernel
  *
  * A kernel object represents a set of instances matching a specified name.

--- a/src/runtime_src/doc/CMakeLists.txt
+++ b/src/runtime_src/doc/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB XRT_DEVICE_H     ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_
 file(GLOB XRT_BO_H         ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_bo.h)
 file(GLOB XRT_KERNEL_H     ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_kernel.h)
 file(GLOB XRT_XCLBIN_H     ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_xclbin.h)
+file(GLOB XRT_INI_H        ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_ini.h)
 file(GLOB XRT_XRT_H        ${XRT_RUNTIME_SRC_DIR}/core/include/xrt.h)
 file(GLOB XRT_ERT_H        ${XRT_RUNTIME_SRC_DIR}/core/include/ert.h)
 file(GLOB XRT_XMA_H        ${XRT_RUNTIME_SRC_DIR}/../xma/include/xma.h)
@@ -44,6 +45,7 @@ else()
     ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_bo.h
     ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_kernel.h
     ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_xclbin.h
+    ${XRT_RUNTIME_SRC_DIR}/core/include/experimental/xrt_ini.h
     )
   string(REPLACE ";" " " DOXY_INPUT "${XRT_CPP_APIS}")
   set(DOXYFILE ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
@@ -107,6 +109,12 @@ else ()
     VERBATIM
     )
 
+  add_custom_command(OUTPUT core/xrt_ini.rst
+    DEPENDS ${XRT_INI_H}
+    COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_INI_H} > core/xrt_ini.rst
+    VERBATIM
+    )
+
   add_custom_command(OUTPUT core/xrt.rst
     COMMAND ${KERNELDOC_EXECUTABLE} -rst ${XRT_XRT_H} > core/xrt.rst
     DEPENDS ${XRT_XRT_H}
@@ -155,6 +163,7 @@ else ()
     core/xrt_bo.rst
     core/xrt_kernel.rst
     core/xrt_xclbin.rst
+    core/xrt_ini.rst
     core/xrt.rst
     core/ert.rst
     core/xma.rst

--- a/src/runtime_src/doc/toc/xrt_native.main.rst
+++ b/src/runtime_src/doc/toc/xrt_native.main.rst
@@ -3,6 +3,13 @@
 XRT Native Library C++ API
 **************************
 
+Configuration APIs
+~~~~~~~~~~~~~~~~~~
+.. doxygennamespace:: xrt::ini
+   :project: XRT
+   :members:
+
+
 Device and XCLBIN APIs
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -34,6 +41,11 @@ Kernel APIs
 
 XRT Native Library C API
 ************************
+
+Configuration APIs
+~~~~~~~~~~~~~~~~~~
+
+.. include:: ../core/xrt_ini.rst
 
 Device and XCLBIN APIs
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Added APIs for XRT configuration control.

XRT can be configured through a json xrt.ini file co-located with
the host executable.  If present, XRT uses configuration options
from the ini file when a given option is first accessed. Without an
ini file, the configuration options take on default values.

The APIs in newly added xrt_ini.h file allow host application to specify
configuration options for XRT programmatically.  It is only possible
for the host application to change configuration option values before a
given option is used by XRT the very first time.