### PR TITLE
CR-1078044 Fix zocl build fail when using petalinux v2019.2

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -23,6 +23,10 @@ endif
 endif
 
 ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include
+#flags passed from xrt_git.bb file are added below
+ifneq ($(cflags_zocl),)
+	ccflags-y += $(cflags_zocl)
+endif
 
 drv_common-y   := $(common_dir)/kds_core.o \
                   $(common_dir)/cu_hls.o \


### PR DESCRIPTION
> Added changes to zocl makefile to incorporate flags from xrt_git.bb file