### PR TITLE
CR-1076146 xclOpen returning non-null handle

### DIFF
--- a/src/runtime_src/core/edge/tools/xbutil/base.h
+++ b/src/runtime_src/core/edge/tools/xbutil/base.h
@@ -30,25 +30,13 @@
 
 namespace xcldev {
 
-static std::string driver_version(std::string driver)
-{
-    std::string line("unknown");
-    std::string path("/sys/module/");
-    path += driver;
-    path += "/version";
-    std::ifstream ver(path);
-    if (ver.is_open())
-        getline(ver, line);
-    return line;
-}
-
 void xrtInfo(boost::property_tree::ptree &pt)
 {
     pt.put("build.version",   xrt_build_version);
     pt.put("build.hash",      xrt_build_version_hash);
     pt.put("build.date",      xrt_build_version_date);
     pt.put("build.branch",    xrt_build_version_branch);
-    pt.put("build.zocl",      driver_version("zocl"));
+    pt.put("build.zocl",      XRT_DRIVER_VERSION);
 }
 
 void osInfo(boost::property_tree::ptree &pt)

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1553,6 +1553,11 @@ xclOpen(unsigned deviceIndex, const char *logFileName, xclVerbosityLevel level)
 {
   try {
     //std::cout << "xclOpen called" << std::endl;
+    if (deviceIndex >= xclProbe()) {
+      xrt_core::message::send(xrt_core::message::severity_level::XRT_INFO, "XRT",
+                       std::string("Cannot find index " + std::to_string(deviceIndex) + " \n"));
+      return nullptr;
+    }
     auto handle = new ZYNQ::shim(deviceIndex, logFileName, level);
     if (!ZYNQ::shim::handleCheck(handle)) {
       delete handle;


### PR DESCRIPTION
> xclOpen with no physical device or deviceIndex with val greater than 1 returning non null handle on edge platforms
> Added check in shim.cpp to fix this