### PR TITLE
CR-1077772 ZOCL version number fix

### DIFF
--- a/src/runtime_src/core/edge/tools/xbutil/base.h
+++ b/src/runtime_src/core/edge/tools/xbutil/base.h
@@ -30,25 +30,13 @@
 
 namespace xcldev {
 
-static std::string driver_version(std::string driver)
-{
-    std::string line("unknown");
-    std::string path("/sys/module/");
-    path += driver;
-    path += "/version";
-    std::ifstream ver(path);
-    if (ver.is_open())
-        getline(ver, line);
-    return line;
-}
-
 void xrtInfo(boost::property_tree::ptree &pt)
 {
     pt.put("build.version",   xrt_build_version);
     pt.put("build.hash",      xrt_build_version_hash);
     pt.put("build.date",      xrt_build_version_date);
     pt.put("build.branch",    xrt_build_version_branch);
-    pt.put("build.zocl",      driver_version("zocl"));
+    pt.put("build.zocl",      XRT_DRIVER_VERSION);
 }
 
 void osInfo(boost::property_tree::ptree &pt)


### PR DESCRIPTION
> Driver version of zocl is reporting outdated value, fixed to report latest value similar to pcie platforms
> As zocl doesnot follow dkms flow, version.h file is not available at zocl build time
> Instead of reading zocl sysfs node 'version', reading directly XRT_DRIVER_VERSION macro which is available at userspace build time