### PR TITLE
CR-1054524 XRT - Remove the five second delay workaround for CMC/SC b…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -87,6 +87,7 @@
 #define	XMC_HOST_MSG_OFFSET_REG		0x300
 #define	XMC_HOST_MSG_ERROR_REG		0x304
 #define	XMC_HOST_MSG_HEADER_REG		0x308
+#define	XMC_STATUS2_REG			0x30C
 #define	XMC_VCC1V2_I_REG                0x314
 #define	XMC_V12_IN_I_REG                0x320
 #define	XMC_V12_IN_AUX0_I_REG           0x32C
@@ -144,11 +145,17 @@
 
 #define	VALID_ID			0x74736574
 #define	XMC_CORE_SUPPORT_NOTUPGRADABLE	0x0c010004
+#define	XMC_CORE_SUPPORT_SENSOR_READY	0x0c010002
 #define	GPIO_RESET			0x0
 #define	GPIO_ENABLED			0x1
+#define	SENSOR_DATA_READY_MASK 		0x1
 
 #define	SELF_JUMP(ins)			(((ins) & 0xfc00ffff) == 0xb8000000)
 #define	XMC_PRIVILEGED(xmc)		((xmc)->base_addrs[0] != NULL)
+
+#define	VALID_MAGIC(val) 		(val == VALID_ID)
+#define	VALID_CMC_VERSION(val) 		((val & 0xff000000) == 0x0c000000)
+#define	VALID_CORE_VERSION(val) 	((val & 0xff000000) == 0x0c000000)
 
 #define	XMC_DEFAULT_EXPIRE_SECS	1
 
@@ -3202,10 +3209,101 @@ static void xmc_enable_mailbox(struct xocl_xmc *xmc)
 	xocl_info(&xmc->pdev->dev, "XMC mailbox offset: 0x%x", val);
 }
 
+static inline int wait_reg_value(struct xocl_xmc *xmc, void __iomem *base, u32 mask)
+{
+	u32 val = XOCL_READ_REG32(base);
+	int i;
+
+	for (i = 0; !(val & mask) && i < MAX_XMC_RETRY; i++) {
+		msleep(RETRY_INTERVAL);
+		val = XOCL_READ_REG32(base);
+	}
+
+	return (val & mask) ? 0 : -ETIMEDOUT;
+}
+
+/*
+ * Wait for XMC to start
+ * Note that ERT will start long before XMC so we don't check anything
+ */
+static int xmc_sense_ready(struct xocl_xmc *xmc)
+{
+	u32 xmc_core_version = 0;
+	int ret = 0;
+
+	/*
+	 * If dev tree has CMC_MUTEX register defined, we rely on the
+	 * regmap_ready bit to check whether cmc is ready, otherwise,
+	 * we still use the legacy 'init done' bit in REGMAP
+	 */
+	if (xmc->base_addrs[IO_MUTEX]) {
+		ret = wait_reg_value(xmc,
+		    xmc->base_addrs[IO_MUTEX] + XOCL_RES_OFFSET_CHANNEL2,
+		    REGMAP_READY_MASK);
+
+		if (ret) {
+			xocl_err(&xmc->pdev->dev, "REGMAP not ready.");
+			goto errout;
+		}
+		xocl_info(&xmc->pdev->dev, "REGMAP ready.");
+
+		/*
+		 * How to define a cmc_core_version:
+		 *   XMC_MAGIC_REG is magjc number 0x74736574
+		 *   XMC_VERSION_REG start from 0x0c000000
+		 *   XMC_CORE_VERSION_REG starr from 0x0c000000
+		 */
+		if (VALID_MAGIC(READ_REG32(xmc, XMC_MAGIC_REG)) &&
+		    VALID_CMC_VERSION(READ_REG32(xmc, XMC_VERSION_REG)) &&
+		    VALID_CORE_VERSION(READ_REG32(xmc, XMC_CORE_VERSION_REG))) {
+			xmc_core_version = READ_REG32(xmc, XMC_CORE_VERSION_REG);
+		}
+		xocl_info(&xmc->pdev->dev, "Core Version 0x%x", xmc_core_version);
+
+		/* early version do not support quick check, fallback to wait */
+		if (xmc_core_version >= XMC_CORE_SUPPORT_SENSOR_READY) {
+			ret = wait_reg_value(xmc,
+			   xmc->base_addrs[IO_REG] + XMC_STATUS2_REG,
+			   SENSOR_DATA_READY_MASK);
+			if (ret) {
+				/* Legacy CMC, rollback to waiting 5 seconds */
+				ret = 0;
+				xocl_warn(&xmc->pdev->dev, "Sensor Data not ready.");
+			} else {
+				xocl_info(&xmc->pdev->dev, "Sensor Data ready.");
+				/* skip waiting 5 more seconds */
+				goto done;
+			}
+		}
+	} else {
+		ret = wait_reg_value(xmc,
+		   xmc->base_addrs[IO_REG] + XMC_STATUS_REG,
+		   STATUS_MASK_INIT_DONE);
+		if (ret) {
+			xocl_err(&xmc->pdev->dev, "XMC did not finish init.");
+			goto errout;
+		}
+		xocl_info(&xmc->pdev->dev, "XMC init done.");
+	}
+
+	/* not support sensor ready, wait 5 more seconds */
+	xocl_info(&xmc->pdev->dev,
+	    "Wait for 5 seconds to stablize SC connection.");
+	ssleep(5);
+done:
+	return ret;
+
+errout:
+	xocl_err(&xmc->pdev->dev, "Error Reg 0x%x", READ_REG32(xmc, XMC_ERROR_REG));
+	xocl_err(&xmc->pdev->dev, "Status Reg 0x%x", READ_REG32(xmc, XMC_STATUS_REG));
+
+	return ret;
+}
+
 static int load_xmc(struct xocl_xmc *xmc)
 {
 	int retry = 0;
-	u32 reg_val = 0, reg_map_ready;
+	u32 reg_val = 0;
 	int ret = 0;
 	void *xdev_hdl;
 
@@ -3281,60 +3379,11 @@ static int load_xmc(struct xocl_xmc *xmc)
 		goto out;
 	}
 
-	/* Wait for XMC to start
-	 * Note that ERT will start long before XMC so we don't check anything
-	 *
-	 * If dev tree has CMC_MUTEX register defined, we rely on the
-	 * regmap_ready bit to check whether cmc is ready, otherwise,
-	 * we still use the legacy 'init done' bit in REGMAP
-	 */
-	if (xmc->base_addrs[IO_MUTEX]) {
-		reg_map_ready = XOCL_READ_REG32(xmc->base_addrs[IO_MUTEX] +
-				XOCL_RES_OFFSET_CHANNEL2);
-		retry = 0;
-		while (retry++ < MAX_XMC_RETRY &&
-			!(reg_map_ready & REGMAP_READY_MASK)) {
-			msleep(RETRY_INTERVAL);
-			reg_map_ready = XOCL_READ_REG32(
-				xmc->base_addrs[IO_MUTEX] +
-				XOCL_RES_OFFSET_CHANNEL2);
-                }
-		if (reg_map_ready & REGMAP_READY_MASK) {
-			xocl_info(&xmc->pdev->dev, "REGMAP ready");
-		} else {
-			xocl_err(&xmc->pdev->dev, "REGMAP not ready : %d", ret);
-			ret = -ETIMEDOUT;
-			xmc->state = XMC_STATE_ERROR;
-			goto out;
-		}
-	} else {
-		reg_val = READ_REG32(xmc, XMC_STATUS_REG);
-		if (!(reg_val & STATUS_MASK_INIT_DONE)) {
-			xocl_info(&xmc->pdev->dev, "Waiting for XMC to finish init...");
-			retry = 0;
-			while (retry++ < MAX_XMC_RETRY &&
-				!(READ_REG32(xmc, XMC_STATUS_REG) &
-				STATUS_MASK_INIT_DONE))
-				msleep(RETRY_INTERVAL);
-			if (retry >= MAX_XMC_RETRY) {
-				xocl_err(&xmc->pdev->dev,
-					"XMC did not finish init sequence!");
-				xocl_err(&xmc->pdev->dev,
-					"Error Reg 0x%x",
-					READ_REG32(xmc, XMC_ERROR_REG));
-				xocl_err(&xmc->pdev->dev,
-					"Status Reg 0x%x",
-					READ_REG32(xmc, XMC_STATUS_REG));
-				ret = -ETIMEDOUT;
-				xmc->state = XMC_STATE_ERROR;
-				goto out;
-			}
-		}
+	ret = xmc_sense_ready(xmc);
+	if (ret) {
+		xmc->state = XMC_STATE_ERROR;
+		goto out;
 	}
-
-	xocl_info(&xmc->pdev->dev,
-		"Wait for 5 seconds to stable the connection with SC");
-	ssleep(5);
 done:
 	if (READ_GPIO(xmc, 0) == GPIO_ENABLED)
 		xmc->state = XMC_STATE_ENABLED;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xmc.cpp
@@ -19,12 +19,30 @@
 #include <vector>
 #include <thread>
 #include <iomanip>
+#include <sstream>
 
 #include "xmc.h"
 #include "flasher.h"
 #include "core/common/utils.h"
 
 #define BMC_JUMP_ADDR   0x201  /* Hard-coded for now */
+
+static std::map<int, std::string> scStatusMap = {
+        {0, "NOT READY"},
+        {1, "READY"},
+        {2, "BSL_UNSYNCED"},
+        {3, "BSL_SYNCED"},
+        {4, "BSL_SYNCED_SC_NOT_UPGRADABLE"},
+        {5, "READY_SC_NOT_UPGRADABLE"},
+ 
+};
+
+static std::map<int, std::string> cmcStatusMap = {
+        {0, "NOT READY"},
+        {1, "READY"},
+        {2, "STOPPED"},
+        {4, "PAUSED"},
+};
 
 XMC_Flasher::XMC_Flasher(std::shared_ptr<pcidev::pci_device> dev)
 {
@@ -524,6 +542,19 @@ int XMC_Flasher::writeReg(unsigned RegOffset, unsigned value) {
     return 0;
 }
 
+static std::string getStatus(int status, std::map<int, std::string> &map)
+{
+    auto entry = map.find(status);
+    std::ostringstream os;
+
+    os << std::hex << status;
+
+    if (entry != map.end())
+	    os << "(" << entry->second << ")";
+
+    return os.str();
+}
+
 bool XMC_Flasher::isXMCReady()
 {
     bool xmcReady;
@@ -539,10 +570,11 @@ bool XMC_Flasher::isXMCReady()
     if (!xmcReady) {
         auto format = xrt_core::utils::ios_restore(std::cout);
         if (!mDev->get_sysfs_path("xmc", "").empty()) {
-            std::cout << "ERROR: XMC is not ready: 0x" << std::hex
-                << XMC_MODE() << std::endl;
+            std::cout << "ERROR: XMC is not ready: 0x" <<
+                getStatus(XMC_MODE(), cmcStatusMap) << std::endl;
         }
     }
+
     return xmcReady;
 }
 
@@ -553,8 +585,8 @@ bool XMC_Flasher::isBMCReady()
 
     if (!bmcReady) {
       auto format = xrt_core::utils::ios_restore(std::cout);
-        std::cout << "ERROR: SC is not ready: 0x" << std::hex
-                << BMC_MODE() << std::endl;
+        std::cout << "ERROR: SC is not ready: 0x" <<
+            getStatus(BMC_MODE(), scStatusMap) << std::endl;
     }
 
     return bmcReady;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -35,6 +35,22 @@
 namespace XBU = XBUtilities;
 #include "boost/format.hpp"
 
+static std::map<int, std::string> scStatusMap = {
+        {0, "NOT READY"},
+        {1, "READY"},
+        {2, "BSL_UNSYNCED"},
+        {3, "BSL_SYNCED"},
+        {4, "BSL_SYNCED_SC_NOT_UPGRADABLE"},
+        {5, "READY_SC_NOT_UPGRADABLE"},
+ 
+};
+
+static std::map<int, std::string> cmcStatusMap = {
+        {0, "NOT READY"},
+        {1, "READY"},
+        {2, "STOPPED"},
+        {4, "PAUSED"},
+};
 
 //#define XMC_DEBUG
 #define BMC_JUMP_ADDR   0x201  /* Hard-coded for now */
@@ -491,15 +507,29 @@ int XMC_Flasher::writeReg(unsigned int RegOffset, unsigned int value) {
     return 0;
 }
 
+static std::string getStatus(int status, std::map<int, std::string> &map)
+{
+    auto entry = map.find(status);
+    std::ostringstream os;
+
+    os << std::hex << status;
+
+    if (entry != map.end())
+	    os << "(" << entry->second << ")";
+
+    return os.str();
+}
+
 bool XMC_Flasher::isXMCReady()
 {
     bool xmcReady = (XMC_MODE() == XMC_READY);
 
     if (!xmcReady) {
         auto format = xrt_core::utils::ios_restore(std::cout);
-        std::cout << "ERROR: XMC is not ready: 0x" << std::hex
-                  << XMC_MODE() << std::endl;
+        std::cout << "ERROR: XMC is not ready: 0x" <<
+            getStatus(XMC_MODE(), cmcStatusMap) << std::endl;
     }
+
     return xmcReady;
 }
 
@@ -509,9 +539,10 @@ bool XMC_Flasher::isBMCReady()
 
     if (!bmcReady) {
         auto format = xrt_core::utils::ios_restore(std::cout);
-        std::cout << "ERROR: SC is not ready: 0x" << std::hex
-                  << BMC_MODE() << std::endl;
+        std::cout << "ERROR: SC is not ready: 0x" <<
+            getStatus(BMC_MODE(), scStatusMap) << std::endl;
     }
+
     return bmcReady;
 }
 


### PR DESCRIPTION
…ringup

Based on Alan Paul, this is the new procedure to flash the SC.
Sudo code:
```
If (core_version < 0xC010002)
Wait 5 seconds (No.1)
else {
if (status2 == 0)
    wait 5 seconds (No.2)
else if (status2 == 1)
    no wait (No.3)
}
```

Let's wait all auto and manual testing done. 