### PR TITLE
Add check when filling zocl driver version info

### DIFF
--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -70,10 +70,12 @@ driver_version(const std::string& driver)
   std::string hash("unknown");
   //dkms flow is not available for zocl
   //so version.h file is not available at zocl build time
+#if defined(XRT_DRIVER_VERSION)
   std::string zocl_driver_ver = XRT_DRIVER_VERSION;
   std::stringstream ss(zocl_driver_ver);
   getline(ss, ver, ',');
   getline(ss, hash, ',');
+#endif
 
   _pt.put("name", driver);
   _pt.put("version", ver);


### PR DESCRIPTION
> Added check when filling zocl version info
> Report 'unknown' when XRT_DRIVER_VERSION is not available