### PR TITLE
Add AIE PLIO event counter profiling support

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -508,7 +508,7 @@ xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
 }
 
 /**
- * xrtStartProfiling() - Start AIE performance profiling
+ * xrtAIEStartProfiling() - Start AIE performance profiling
  *
  * @handle:          Handle to the device
  * @option:          Profiling option.
@@ -523,10 +523,10 @@ xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
  * meanings on different options.
  *
  * Note: Currently, the only supported io profiling option is
- *       io_stream_running_event_count (GMIO)
+ *       io_stream_running_event_count (GMIO and PLIO)
  */
 int
-xrtStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, const char *port2Name, uint32_t value)
+xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, const char *port2Name, uint32_t value)
 {
   try {
     return start_profiling(handle, option, port1Name, port2Name, value);
@@ -542,8 +542,8 @@ xrtStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, con
 }
 
 /**
- * xrtReadProfiling() - Read the current performance counter value
- *                      associated with the profiling handle.
+ * xrtAIEReadProfiling() - Read the current performance counter value
+ *                         associated with the profiling handle.
  *
  * @handle:          Handle to the device
  * @pHandle:         Profiling handle.
@@ -551,7 +551,7 @@ xrtStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, con
  * Return:         The performance counter value, -1 on error.
  */
 uint64_t
-xrtReadProfiling(xrtDeviceHandle handle, int pHandle)
+xrtAIEReadProfiling(xrtDeviceHandle handle, int pHandle)
 {
   try {
     return read_profiling(handle, pHandle);
@@ -567,9 +567,9 @@ xrtReadProfiling(xrtDeviceHandle handle, int pHandle)
 }
 
 /**
- * xrtStopProfiling() - Stop the current performance profiling
- *                      associated with the profiling handle and
- *                      release the corresponding hardware resources.
+ * xrtAIEStopProfiling() - Stop the current performance profiling
+ *                         associated with the profiling handle and
+ *                         release the corresponding hardware resources.
  *
  * @handle:          Handle to the device
  * @pHandle:         Profiling handle.
@@ -577,7 +577,7 @@ xrtReadProfiling(xrtDeviceHandle handle, int pHandle)
  * Return:         0 on success, -1 on error.
  */
 int
-xrtStopProfiling(xrtDeviceHandle handle, int pHandle)
+xrtAIEStopProfiling(xrtDeviceHandle handle, int pHandle)
 {
   try {
     stop_profiling(handle, pHandle);

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -31,6 +31,7 @@ namespace pt = boost::property_tree;
 using tile_type = xrt_core::edge::aie::tile_type;
 using rtp_type = xrt_core::edge::aie::rtp_type;
 using gmio_type = xrt_core::edge::aie::gmio_type;
+using plio_type = xrt_core::edge::aie::plio_type;
 using counter_type = xrt_core::edge::aie::counter_type;
 
 inline void
@@ -158,6 +159,31 @@ get_gmio(const pt::ptree& aie_meta)
   return gmios;
 }
 
+std::vector<plio_type>
+get_plio(const pt::ptree& aie_meta)
+{
+  std::vector<plio_type> plios;
+
+  auto plio_nodes = aie_meta.get_child_optional("aie_metadata.PLIOs");
+  if (!plio_nodes)
+    return plios;
+
+  for (auto& plio_node : aie_meta.get_child("aie_metadata.PLIOs")) {
+    plio_type plio;
+
+    plio.id = plio_node.second.get<uint32_t>("id");
+    plio.name = plio_node.second.get<std::string>("name");
+    plio.logical_name = plio_node.second.get<std::string>("logical_name");
+    plio.shim_col = plio_node.second.get<uint16_t>("shim_column");
+    plio.stream_id = plio_node.second.get<uint16_t>("stream_id");
+    plio.is_master = plio_node.second.get<bool>("slaveOrMaster");
+
+    plios.emplace_back(std::move(plio));
+  }
+
+  return plios;
+}
+
 std::vector<counter_type>
 get_profile_counter(const pt::ptree& aie_meta)
 {
@@ -249,6 +275,18 @@ get_gmios(const xrt_core::device* device)
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
   return ::get_gmio(aie_meta);
+}
+
+std::vector<plio_type>
+get_plios(const xrt_core::device* device)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return std::vector<plio_type>();
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_plio(aie_meta);
 }
 
 std::vector<counter_type>

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -166,7 +166,7 @@ get_plio(const pt::ptree& aie_meta)
 
   auto plio_nodes = aie_meta.get_child_optional("aie_metadata.PLIOs");
   if (!plio_nodes)
-    return plios;
+    return {};
 
   for (auto& plio_node : aie_meta.get_child("aie_metadata.PLIOs")) {
     plio_type plio;

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -162,11 +162,11 @@ get_gmio(const pt::ptree& aie_meta)
 std::vector<plio_type>
 get_plio(const pt::ptree& aie_meta)
 {
-  std::vector<plio_type> plios;
-
   auto plio_nodes = aie_meta.get_child_optional("aie_metadata.PLIOs");
   if (!plio_nodes)
     return {};
+
+  std::vector<plio_type> plios;
 
   for (auto& plio_node : aie_meta.get_child("aie_metadata.PLIOs")) {
     plio_type plio;

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -100,6 +100,25 @@ struct gmio_type
 std::vector<gmio_type>
 get_gmios(const xrt_core::device* device);
 
+struct plio_type
+{
+  std::string     name;
+  std::string     logical_name;
+
+  uint32_t        id;
+  uint16_t        shim_col;
+  uint16_t        stream_id;
+  bool            is_master;
+};
+
+/**
+ * get_plios() - get plio data from xclbin AIE metadata
+ *
+ * @device: device with loaded meta data
+ */
+std::vector<plio_type>
+get_plios(const xrt_core::device* device);
+
 struct counter_type
 {
   uint32_t        id;

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -62,6 +62,10 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
         throw xrt_core::error(-EINVAL, "Failed to initialize AIE configuration: " + std::to_string(rc));
     devInst = &DevInst;
 
+    /* Initialize PLIO metadata */
+    for (auto& plio : xrt_core::edge::aie::get_plios(device.get()))
+        plios.emplace_back(std::move(plio));
+
     /* Initialize graph GMIO metadata */
     for (auto& gmio : xrt_core::edge::aie::get_gmios(device.get()))
         gmios.emplace_back(std::move(gmio));
@@ -338,32 +342,50 @@ start_profiling(int option, const std::string& port1Name, const std::string& por
   auto gmio = std::find_if(gmios.begin(), gmios.end(),
             [port1Name](gmio_type it) { return it.name.compare(port1Name) == 0; });
 
-  if (gmio == gmios.end())
+  // For PLIO inside graph, there is no name property.
+  // So we need to match logical name too
+  auto plio = std::find_if(plios.begin(), plios.end(),
+            [port1Name](plio_type it) { return it.name.compare(port1Name) == 0; });
+  if (plio == plios.end()) {
+    plio = std::find_if(plios.begin(), plios.end(),
+            [port1Name](plio_type it) { return it.logical_name.compare(port1Name) == 0; });
+  }
+
+  if (gmio == gmios.end() && plio == plios.end())
     throw xrt_core::error(-EINVAL, "Can't start profiling: port name '" + port1Name + "' not found");
 
-  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
-  auto chan = gmio->channel_number;
-  auto shim_tile = XAie_TileLoc(gmio->shim_col, 0);
-  /* type 0: GM->AIE; type 1: AIE->GM */
-  auto mode = gmio->type == 0 ? XAIE_STRMSW_SLAVE : XAIE_STRMSW_MASTER;
+  if (gmio != gmios.end() && plio != plios.end())
+    throw xrt_core::error(-EINVAL, "Can't start profiling: ambiguous port name '" + port1Name + "'");
+
+  XAie_LocType shim_tile;
+  XAie_StrmPortIntf mode;
+  uint8_t stream_id;
+  if (gmio != gmios.end()) {
+    shim_tile = XAie_TileLoc(gmio->shim_col, 0);
+    /* type 0: GM->AIE; type 1: AIE->GM */
+    mode = gmio->type == 1 ? XAIE_STRMSW_MASTER : XAIE_STRMSW_SLAVE;
+    stream_id = gmio->stream_id;
+  } else {
+    shim_tile = XAie_TileLoc(plio->shim_col, 0);
+    mode = plio->is_master ? XAIE_STRMSW_MASTER: XAIE_STRMSW_SLAVE;
+    stream_id = plio->stream_id;
+  }
 
   int handleId = eventRecords.size();
-  int eventPortId = Resources::AIE::getShimTile(gmio->shim_col)->plModule.requestStreamEventPort(handleId);
-  int counterId = Resources::AIE::getShimTile(gmio->shim_col)->plModule.requestPerformanceCounter(handleId);
-
+  int eventPortId = Resources::AIE::getShimTile(shim_tile.Col)->plModule.requestStreamEventPort(handleId);
+  int counterId = Resources::AIE::getShimTile(shim_tile.Col)->plModule.requestPerformanceCounter(handleId);
   if (counterId >= 0 && eventPortId >= 0) {
-    XAie_EventSelectStrmPort(devInst, shim_tile, (uint8_t)eventPortId, mode, SOUTH, (uint8_t)gmio->stream_id);
+    XAie_EventSelectStrmPort(devInst, shim_tile, (uint8_t)eventPortId, mode, SOUTH, stream_id);
     XAie_PerfCounterControlSet(devInst, shim_tile, XAIE_PL_MOD, (uint8_t)counterId, XAIETILE_EVENT_SHIM_PORT_RUNNING[eventPortId],                                     XAIETILE_EVENT_SHIM_PORT_RUNNING[eventPortId]);
-
     eventRecords.push_back({ option,
                 { { shim_tile, Resources::pl_module, Resources::performance_counter, (size_t)counterId },
                 { shim_tile, Resources::pl_module, Resources::stream_switch_event_port, (size_t)eventPortId } } });
     handle = handleId;
   } else {
     if (counterId >= 0)
-      Resources::AIE::getShimTile(gmio->shim_col)->plModule.releasePerformanceCounter(handleId, counterId);
+      Resources::AIE::getShimTile(shim_tile.Col)->plModule.releasePerformanceCounter(handleId, counterId);
     if (eventPortId >= 0)
-      Resources::AIE::getShimTile(gmio->shim_col)->plModule.releaseStreamEventPort(handleId, eventPortId);
+      Resources::AIE::getShimTile(shim_tile.Col)->plModule.releaseStreamEventPort(handleId, eventPortId);
     throw xrt_core::error(-EAGAIN, "Can't start profiling: Failed to request performance counter or stream switch event port resources.");
   }
 

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -329,7 +329,7 @@ reset(const xrt_core::device* device)
 
 int
 Aie::
-start_profiling(int option, const std::string& port1Name, const std::string& port2Name, uint32_t value)
+start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value)
 {
   int handle = -1;
 
@@ -340,22 +340,22 @@ start_profiling(int option, const std::string& port1Name, const std::string& por
     throw xrt_core::error(-EINVAL, "Start profiling fails: unknown profiling option.");
 
   auto gmio = std::find_if(gmios.begin(), gmios.end(),
-            [port1Name](gmio_type it) { return it.name.compare(port1Name) == 0; });
+            [&port1_name](auto& it) { return it.name.compare(port1_name) == 0; });
 
   // For PLIO inside graph, there is no name property.
   // So we need to match logical name too
   auto plio = std::find_if(plios.begin(), plios.end(),
-            [port1Name](plio_type it) { return it.name.compare(port1Name) == 0; });
+            [&port1_name](auto& it) { return it.name.compare(port1_name) == 0; });
   if (plio == plios.end()) {
     plio = std::find_if(plios.begin(), plios.end(),
-            [port1Name](plio_type it) { return it.logical_name.compare(port1Name) == 0; });
+            [&port1_name](auto& it) { return it.logical_name.compare(port1_name) == 0; });
   }
 
   if (gmio == gmios.end() && plio == plios.end())
-    throw xrt_core::error(-EINVAL, "Can't start profiling: port name '" + port1Name + "' not found");
+    throw xrt_core::error(-EINVAL, "Can't start profiling: port name '" + port1_name + "' not found");
 
   if (gmio != gmios.end() && plio != plios.end())
-    throw xrt_core::error(-EINVAL, "Can't start profiling: ambiguous port name '" + port1Name + "'");
+    throw xrt_core::error(-EINVAL, "Can't start profiling: ambiguous port name '" + port1_name + "'");
 
   XAie_LocType shim_tile;
   XAie_StrmPortIntf mode;

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -113,7 +113,7 @@ public:
     reset(const xrt_core::device* device);
 
     int
-    start_profiling(int option, const std::string& port1Name, const std::string& port2Name, uint32_t value);
+    start_profiling(int option, const std::string& port1_name, const std::string& port2_name, uint32_t value);
 
     uint64_t
     read_profiling(int phdl);

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -86,6 +86,7 @@ struct EventRecord {
 class Aie {
 public:
     using gmio_type = xrt_core::edge::aie::gmio_type;
+    using plio_type = xrt_core::edge::aie::plio_type;
 
     ~Aie();
     Aie(const std::shared_ptr<xrt_core::device>& device);
@@ -94,6 +95,8 @@ public:
 
     /* This is the collections of gmios that are used. */
     std::vector<gmio_type> gmios;
+
+    std::vector<plio_type> plios;
 
     XAie_DevInst *getDevInst();
 


### PR DESCRIPTION
This PR added
1. PLIO event profiling (so that we have a full support for event counter performance counter option)
2. Update the interface name
xrtStartProfiling --> xrtAIEStartProfiling
xrtReadProfiling --> xrtAIEReadProfiling
xrtStopProfiling --> xrtAIEStopProfiling