### PR TITLE
CR-1078587 & CR-1079255 Add new check to handle NO SC case on U2

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1053,8 +1053,13 @@ static bool xmc_clk_scale_on(struct platform_device *pdev)
 static bool nosc_xmc(struct platform_device *pdev)
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(pdev);
+	struct xmc_status status;
 
 	if (xmc->priv_data && (xmc->priv_data->flags & XOCL_XMC_NOSC))
+		return true;
+
+	safe_read32(xmc, XMC_STATUS_REG, (u32 *)&status);
+	if (status.sc_mode == XMC_SC_NORMAL_MODE_SC_NOT_UPGRADABLE)
 		return true;
 
 	return false;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -228,7 +228,8 @@ enum sc_mode {
 	XMC_SC_BSL_MODE_UNSYNCED = 2,
 	XMC_SC_BSL_MODE_SYNCED = 3,
 	XMC_SC_BSL_MODE_SYNCED_SC_NOT_UPGRADABLE = 4,
-	XMC_SC_NORMAL_MODE_SC_NOT_UPGRADABLE = 5
+	XMC_SC_NORMAL_MODE_SC_NOT_UPGRADABLE = 5,
+	XMC_SC_NOSC_MODE = 6
 };
 
 #define	READ_REG32(xmc, off)			\
@@ -1066,7 +1067,7 @@ static bool nosc_xmc(struct platform_device *pdev)
 		return true;
 
 	safe_read32(xmc, XMC_STATUS_REG, (u32 *)&status);
-	if (status.sc_mode == XMC_SC_NORMAL_MODE_SC_NOT_UPGRADABLE)
+	if (status.sc_mode == XMC_SC_NOSC_MODE)
 		return true;
 
 	return false;


### PR DESCRIPTION
Satellite controller mode NOSC_MODE used to handle NO SC case on Raptor2 1RP U2 platform.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>