### PR TITLE
CR-1078243 xbmgmt config --show reports errors for card in manufactur…

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -179,6 +179,7 @@ enum class key_type
   flash_bar_offset,
   is_mfg,
   mfg_ver,
+  is_recovery,
   is_ready,
   f_flash_type,
   flash_type,
@@ -1886,6 +1887,15 @@ struct mfg_ver : request
 {
   using result_type = uint32_t;
   static const key_type key = key_type::mfg_ver;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct is_recovery : request
+{
+  using result_type = bool;
+  static const key_type key = key_type::is_recovery;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -91,6 +91,15 @@ static ssize_t mfg_ver_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(mfg_ver);
 
+static ssize_t recovery_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
+
+	return sprintf(buf, "%d\n", xocl_subdev_is_vsec_recovery(lro));
+}
+static DEVICE_ATTR_RO(recovery);
+
 static ssize_t mgmt_pf_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
@@ -419,6 +428,7 @@ static struct attribute *mgmt_attrs[] = {
 	&dev_attr_ready.attr,
 	&dev_attr_mfg.attr,
 	&dev_attr_mfg_ver.attr,
+	&dev_attr_recovery.attr,
 	&dev_attr_mgmt_pf.attr,
 	&dev_attr_flash_type.attr,
 	&dev_attr_board_name.attr,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -699,19 +699,6 @@ failed:
 
 }
 
-static bool xocl_subdev_vsec_is_golden(xdev_handle_t xdev_hdl)
-{
-	int bar;
-	u64 offset;
-
-	if (xocl_subdev_vsec(xdev_hdl, XOCL_VSEC_PLATFORM_INFO, &bar, &offset,
-		NULL))
-		return false;
-
-	return xocl_subdev_vsec_read32(xdev_hdl, bar, offset) ==
-		XOCL_VSEC_PLAT_RECOVERY;
-}
-
 int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 {
 	struct xocl_board_private *dev_info = &lro->core.priv;
@@ -722,7 +709,7 @@ int xclmgmt_load_fdt(struct xclmgmt_dev *lro)
 	size_t					fw_size = 0;
 
 
-	if (xocl_subdev_vsec_is_golden(lro)) {
+	if (xocl_subdev_is_vsec_recovery(lro)) {
 		mgmt_info(lro, "Skip load_fdt for vsec Golden image");
 		return 0;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1934,6 +1934,7 @@ int xocl_subdev_vsec(xdev_handle_t xdev, u32 type, int *bar_idx, u64 *offset,
 u32 xocl_subdev_vsec_read32(xdev_handle_t xdev, int bar, u64 offset);
 int xocl_subdev_create_vsec_devs(xdev_handle_t xdev);
 bool xocl_subdev_is_vsec(xdev_handle_t xdev);
+bool xocl_subdev_is_vsec_recovery(xdev_handle_t xdev);
 int xocl_subdev_get_level(struct platform_device *pdev);
 
 void xocl_subdev_register(struct platform_device *pldev, void *ops);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1423,6 +1423,22 @@ bool xocl_subdev_is_vsec(xdev_handle_t xdev)
 	return pci_find_ext_capability(pdev, PCI_EXT_CAP_ID_VNDR) != 0;
 }
 
+bool xocl_subdev_is_vsec_recovery(xdev_handle_t xdev_hdl)
+{
+	int bar;
+	u64 offset;
+
+	if (!xocl_subdev_is_vsec(xdev_hdl))
+		return false;
+
+	if (xocl_subdev_vsec(xdev_hdl, XOCL_VSEC_PLATFORM_INFO, &bar, &offset,
+		NULL))
+		return false;
+
+	return xocl_subdev_vsec_read32(xdev_hdl, bar, offset) ==
+		XOCL_VSEC_PLAT_RECOVERY;
+}
+
 static inline int xocl_subdev_create_vsec_impl(xdev_handle_t xdev,
 	struct xocl_subdev_info *info, u64 offset, int bar)
 {

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -378,6 +378,7 @@ initialize_query_table()
   emplace_sysfs_get<query::flash_bar_offset>            ("flash", "bar_off");
   emplace_sysfs_get<query::is_mfg>                      ("", "mfg");
   emplace_sysfs_get<query::mfg_ver>                     ("", "mfg_ver");
+  emplace_sysfs_get<query::is_recovery>                 ("", "recovery");
   emplace_sysfs_get<query::is_ready>                    ("", "ready");
   emplace_sysfs_get<query::f_flash_type>                ("flash", "flash_type");
   emplace_sysfs_get<query::flash_type>                  ("", "flash_type");

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -1108,7 +1108,7 @@ initialize_query_table()
   emplace_function0_getter<query::flash_bar_offset,          flash_bar_offset>();
   emplace_function0_getter<query::xmc_sc_presence,           xmc_sc_presence>();
   emplace_function0_getput<query::data_retention,            data_retention>();
-  emplace_function0_getput<query::is_recovery,               recovery>();
+  emplace_function0_getter<query::is_recovery,               recovery>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -691,6 +691,22 @@ struct devinfo
   }
 };
 
+struct recovery
+{
+  using result_type = bool;
+  static result_type
+  user(const xrt_core::device* device, key_type key)
+  {
+    return false;
+  }
+
+  static result_type
+  mgmt(const xrt_core::device* device, key_type key)
+  {
+    return false;
+  }
+};
+
 struct uuid
 {
   using result_type = boost::any;
@@ -1092,6 +1108,7 @@ initialize_query_table()
   emplace_function0_getter<query::flash_bar_offset,          flash_bar_offset>();
   emplace_function0_getter<query::xmc_sc_presence,           xmc_sc_presence>();
   emplace_function0_getput<query::data_retention,            data_retention>();
+  emplace_function0_getput<query::is_recovery,               recovery>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -131,8 +131,10 @@ show_device_conf(xrt_core::device* device)
 
   try {
     auto is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
-    if (is_mfg) {
-      throw std::runtime_error("This operation is not supported with golden image");
+    auto is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
+    if (is_mfg || is_recovery) {
+      std::cerr << "This operation is not supported with manufacturing image.\n";
+      return;
     }
   }
   catch (const std::exception& ex) {


### PR DESCRIPTION
…ing state

Recovery img should be handled too. Test results:
```
Card [0000:3b:00.0]
    Card type:          u50
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u50_GOLDEN_9,[SC=INACTIVE]
    Flashable partitions installed in system:
        xilinx_u50_gen3x16_xdma_base_4,[ID=0xab125f1678b6945b],[SC=5.1.4]

Card [0000:5e:00.0]
    Card type:          u55n
    Flash type:         SPI
    Flashable partition running on FPGA:
        xilinx_u55n_recovery,[ID=0x5],[SC=INACTIVE]
    Flashable partitions installed in system:
        xilinx_u55n_gen3x16_xdma_base_2,[ID=0x881fcec1f8fd0720],[SC=7.1.2]

root@xsjyliu50:~# xbmgmt config --show --card 3b:00.0
Daemon:
        host=xsjyliu50
This operation is not supported with manufacturing image
root@xsjyliu50:~# xbmgmt config --show --card 5e:00.0
Daemon:
        host=xsjyliu50
This operation is not supported with manufacturing image

root@xsjyliu50:~# xbmgmt --new advanced --config --showx -d 3b:00.0
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------
0000:3b:00.0
This operation is not supported with manufacturing image.
root@xsjyliu50:~# xbmgmt --new advanced --config --showx -d 5e:00.0
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------
0000:5e:00.0
This operation is not supported with manufacturing image.

```

