### PR TITLE
CR-1077871 Fix xclRead/xclWrite fail with two handles on same device …

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -87,6 +87,8 @@ inline void* wordcopy(void *dst, const void* src, size_t bytes)
 }
 
 namespace ZYNQ {
+//initializing static member
+std::map<uint64_t, uint32_t *> shim::mKernelControl;
 
 shim::
 shim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity)

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -154,7 +154,7 @@ private:
   std::ifstream mVBNV;
   xclVerbosityLevel mVerbosity;
   int mKernelFD;
-  std::map<uint64_t, uint32_t *> mKernelControl;
+  static std::map<uint64_t, uint32_t *> mKernelControl;
   std::unique_ptr<xrt_core::bo_cache> mCmdBOCache;
   zynq_device *mDev = nullptr;
   size_t mKernelClockFreq;


### PR DESCRIPTION
…on edge platforms

> xclRead/xclWrite fails when we use multiple xclOpen calls
> Each xclOpen call creates new shim object, so made mKernelControl object static to be shared among objs.