### PR TITLE
CR-1075952 Buffer flags in C++ and C

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_bo.h
+++ b/src/runtime_src/core/include/experimental/xrt_bo.h
@@ -19,6 +19,7 @@
 #define _XRT_BO_H_
 
 #include "xrt.h"
+#include "xrt_mem.h"
 
 #ifdef __cplusplus
 # include <memory>
@@ -80,6 +81,26 @@ public:
   XCL_DRIVER_DLLESPEC
   bo(xclDeviceHandle dhdl, void* userptr, size_t sz, buffer_flags flags, memory_group grp);
 
+  
+  /**
+   * bo() - Constructor with user host buffer 
+   *
+   * @param dhdl
+   *  Device handle
+   * @param userptr
+   *  Pointer to aligned user memory
+   * @param sz
+   *  Size of buffer
+   * @param grp
+   *  Device memory group to allocate buffer in
+   *
+   * The buffer type is default buffer object with host buffer and
+   * device buffer, where the host buffer is managed by user.
+   */
+  bo(xclDeviceHandle dhdl, void* userptr, size_t sz, memory_group grp)
+    : bo(dhdl, userptr, sz, XCL_BO_FLAGS_NONE, grp)
+  {}
+
   /**
    * bo() - Constructor where XRT manages host buffer if any
    *
@@ -97,6 +118,23 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   bo(xclDeviceHandle dhdl, size_t size, buffer_flags flags, memory_group grp);
+
+  /**
+   * bo() - Constructor, default flags, where XRT manages host buffer if any
+   *
+   * @param dhdl
+   *  Device handle
+   * @param size
+   *  Size of buffer
+   * @param grp
+   *  Device memory group to allocate buffer in
+   *
+   * The buffer type is default buffer object with host buffer and device buffer.
+   * The host buffer is allocated and managed by XRT.
+   */
+  bo(xclDeviceHandle dhdl, size_t size, memory_group grp)
+    : bo(dhdl, size, XCL_BO_FLAGS_NONE, grp)
+  {}
 
   /**
    * bo() - Constructor to import an exported buffer

--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -42,8 +42,8 @@ static int run(const xrt::device& device, const xrt::uuid& uuid, bool verbose)
   const size_t DATA_SIZE = COUNT * sizeof(int);
 
   auto simple = xrt::kernel(device, uuid.get(), "simple");
-  auto bo0 = xrt::bo(device, DATA_SIZE, XCL_BO_FLAGS_NONE, simple.group_id(0));
-  auto bo1 = xrt::bo(device, DATA_SIZE, XCL_BO_FLAGS_NONE, simple.group_id(1));
+  auto bo0 = xrt::bo(device, DATA_SIZE, simple.group_id(0));
+  auto bo1 = xrt::bo(device, DATA_SIZE, simple.group_id(1));
   auto bo0_map = bo0.map<int*>();
   auto bo1_map = bo1.map<int*>();
   std::fill(bo0_map, bo0_map + COUNT, 0);

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -89,8 +89,8 @@ int run(int argc, char** argv)
   auto uuid = device.load_xclbin(xclbin_fnm);
 
   auto loopback = xrt::kernel(device, uuid.get(), "loopback");
-  auto bo0 = xrt::bo(device, DATA_SIZE, XCL_BO_FLAGS_NONE, loopback.group_id(0));  // handle 1
-  auto bo1 = xrt::bo(device, DATA_SIZE, XCL_BO_FLAGS_NONE, loopback.group_id(1));  // handle 2
+  auto bo0 = xrt::bo(device, DATA_SIZE, loopback.group_id(0));  // handle 1
+  auto bo1 = xrt::bo(device, DATA_SIZE, loopback.group_id(1));  // handle 2
 
   auto bo1_map = bo1.map<char*>();
   std::fill(bo1_map, bo1_map + DATA_SIZE, 0);

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -84,7 +84,7 @@ int run(int argc, char** argv)
   auto swizzle = xrt::kernel(device, uuid.get(), "vectorswizzle");
 
   // Create a parent BO for kernel input data
-  auto bo = xrt::bo(device, DATA_SIZE*sizeof(int), 0, swizzle.group_id(0));
+  auto bo = xrt::bo(device, DATA_SIZE*sizeof(int), swizzle.group_id(0));
   auto bo_mapped = bo.map<int*>();
 
   //Populate the input and reference vectors.

--- a/tests/xrt/07_sequence/main.cpp
+++ b/tests/xrt/07_sequence/main.cpp
@@ -105,7 +105,7 @@ int run(int argc, char** argv)
 
   auto mysequence = xrt::kernel(device, uuid.get(), "mysequence");
 
-  auto bo = xrt::bo(device, DATA_SIZE*sizeof(unsigned int), 0, mysequence.group_id(0));
+  auto bo = xrt::bo(device, DATA_SIZE*sizeof(unsigned int), mysequence.group_id(0));
   auto bo_mapped = bo.map<unsigned int*>();
   memset(bo_mapped, 0, DATA_SIZE*sizeof(unsigned int));
   bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, DATA_SIZE*sizeof(unsigned int), 0);

--- a/tests/xrt/100_ert_ncu/xrtxx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx.cpp
@@ -101,13 +101,13 @@ struct job_type
     auto grpid1 = kernel.group_id(1);
 
     const size_t data_size = ELEMENTS * ARRAY_SIZE;
-    a = xrt::bo(device, data_size*sizeof(unsigned long), 0, grpid0);
+    a = xrt::bo(device, data_size*sizeof(unsigned long), grpid0);
     am = a.map();
     auto adata = reinterpret_cast<unsigned long*>(am);
     for (unsigned int i=0;i<data_size;++i)
       adata[i] = i;
 
-    b = xrt::bo(device, data_size*sizeof(unsigned long), 0, grpid1);
+    b = xrt::bo(device, data_size*sizeof(unsigned long), grpid1);
     bm = b.map();
     auto bdata = reinterpret_cast<unsigned long*>(bm);
      for (unsigned int j=0;j<data_size;++j)

--- a/tests/xrt/102_multiproc_verify/main.cpp
+++ b/tests/xrt/102_multiproc_verify/main.cpp
@@ -140,7 +140,7 @@ run(const xrt::device& device, const xrt::uuid& uuid, size_t n_runs, bool verbos
   std::vector<xrt::run> runs;
 
   for (size_t i=0; i<n_runs; ++i) {
-    auto bo = xrt::bo(device, size, 0, kernel.group_id(0));
+    auto bo = xrt::bo(device, size, kernel.group_id(0));
     auto bo_data = bo.map<char*>();
     std::fill(bo_data, bo_data + size, 0);
     bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, size, 0);

--- a/tests/xrt/11_fp_mmult256/main.cpp
+++ b/tests/xrt/11_fp_mmult256/main.cpp
@@ -55,8 +55,8 @@ run(xrt::device& device, const xrt::uuid& uuid, bool random, bool verbose)
 {
   auto mmult = xrt::kernel(device, uuid.get(), "mmult");
 
-  auto a = xrt::bo(device, 2*data_size*sizeof(float), 0, mmult.group_id(0));
-  auto output = xrt::bo(device, data_size*sizeof(float), 0, mmult.group_id(1));
+  auto a = xrt::bo(device, 2*data_size*sizeof(float), mmult.group_id(0));
+  auto output = xrt::bo(device, data_size*sizeof(float), mmult.group_id(1));
 
   auto a_mapped = a.map<float*>();
 

--- a/tests/xrt/13_add_one/main.cpp
+++ b/tests/xrt/13_add_one/main.cpp
@@ -51,12 +51,12 @@ run(xrt::device& device, const xrt::uuid& uuid, size_t n_elements)
   const size_t size = n_elements * ARRAY_SIZE;
   const size_t bytes = sizeof(data_type) * size;
 
-  auto a = xrt::bo(device, bytes, 0, addone.group_id(0));
+  auto a = xrt::bo(device, bytes, addone.group_id(0));
   auto a_data = a.map<unsigned long*>();
   std::iota(a_data,a_data+size,0);
   a.sync(XCL_BO_SYNC_BO_TO_DEVICE , bytes, 0);
 
-  auto b = xrt::bo(device, bytes, 0, addone.group_id(1));
+  auto b = xrt::bo(device, bytes, addone.group_id(1));
 
   auto run = addone(a, b, n_elements);
   run.wait();

--- a/tests/xrt/22_verify/main.cpp
+++ b/tests/xrt/22_verify/main.cpp
@@ -50,7 +50,7 @@ run(const xrt::device& device, const xrt::uuid& uuid, bool verbose)
 {
   auto hello = xrt::kernel(device, uuid.get(), "hello:hello_1");
 
-  auto bo = xrt::bo(device, 1024, 0, hello.group_id(0));
+  auto bo = xrt::bo(device, 1024, hello.group_id(0));
   auto bo_data = bo.map<char*>();
   std::fill(bo_data, bo_data + 1024, 0);
   bo.sync(XCL_BO_SYNC_BO_TO_DEVICE, 1024,0);

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -43,8 +43,8 @@ static int run(const xrt::device& device, const xrt::uuid& uuid, const std::stri
   const size_t DATA_SIZE = COUNT * sizeof(int);
 
   auto simple = xrt::kernel(device, uuid.get(), cuName);
-  auto bo0 = xrt::bo(device, DATA_SIZE, XCL_BO_FLAGS_NONE, simple.group_id(0));
-  auto bo1 = xrt::bo(device, DATA_SIZE, XCL_BO_FLAGS_NONE, simple.group_id(1));
+  auto bo0 = xrt::bo(device, DATA_SIZE, simple.group_id(0));
+  auto bo1 = xrt::bo(device, DATA_SIZE, simple.group_id(1));
   auto bo0_map = bo0.map<int*>();
   auto bo1_map = bo1.map<int*>();
   std::fill(bo0_map, bo0_map + COUNT, 0);

--- a/tests/xrt/fa_kernel/xrt.cpp
+++ b/tests/xrt/fa_kernel/xrt.cpp
@@ -77,9 +77,9 @@ struct job_type
 
   job_type(const xrt::device& device, const xrt::kernel& aes)
     : run(aes)
-    , in(device, len, 0, aes.group_id(0))
-    , out(device, len, 0, aes.group_id(2))
-    , out_status(device, len, 0, aes.group_id(4))
+    , in(device, len, aes.group_id(0))
+    , out(device, len, aes.group_id(2))
+    , out_status(device, len, aes.group_id(4))
   {
     auto in_data = in.map<uint32_t*>();
     std::iota(in_data, in_data + len/sizeof(uint32_t), 0);

--- a/tests/xrt/perf_IOPS/xrt_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xrt_api_iops.cpp
@@ -53,7 +53,7 @@ int testSingleThread(const xrt::device& device, const xrt::uuid& uuid)
   std::vector<xrt::run> cmds;
   for (int i = 0; i < expected_cmds; i++) {
     auto run = xrt::run(hello);
-    run.set_arg(0, xrt::bo(device, 20, 0, hello.group_id(0)));
+    run.set_arg(0, xrt::bo(device, 20, hello.group_id(0)));
     cmds.push_back(std::move(run));
   }
   std::cout << "Allocated commands, expect " << expected_cmds << ", created " << cmds.size() << std::endl;


### PR DESCRIPTION
Add bo constructor overload for default buffer flags.