### PR TITLE
xbutil validate to support flat shell

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1223,6 +1223,13 @@ int xcldev::device::runTestCase(const std::string& py,
         xclbinPath += xclbin;
 
         if (stat(xrtTestCasePath.c_str(), &st) != 0 || stat(xclbinPath.c_str(), &st) != 0) {
+            // flat shell support
+            std::string logic_uuid, errmsg;
+            pcidev::get_dev(m_idx)->sysfs_get( "", "logic_uuids", errmsg, logic_uuid);
+            if (!logic_uuid.empty() && xclbin.compare("verify.xclbin") == 0) {
+                output += "Verify xclbin not available. Skipping validation.";
+                return -EOPNOTSUPP;
+            }
             //if bandwidth xclbin isn't present, skip the test
             if(xclbin.compare("bandwidth.xclbin") == 0) {
                 output += "Bandwidth xclbin not available. Skipping validation.";
@@ -1466,7 +1473,8 @@ int xcldev::device::runOneTest(std::string testName,
 	    std::cout << "INFO: == " << testName << " PASSED" << std::endl;
     } else if (ret == -EOPNOTSUPP) {
 	    std::cout << "INFO: == " << testName << " SKIPPED" << std::endl;
-        ret = 0;
+        if(testName.compare("verify kernel test") != 0)
+            ret = 0;
     } else if (ret == 1) {
 	    std::cout << "WARN: == " << testName << " PASSED with warning"
             << std::endl;
@@ -1554,6 +1562,10 @@ int xcldev::device::validate(bool quick, bool hidden)
     retVal = runOneTest("verify kernel test",
             std::bind(&xcldev::device::verifyKernelTest, this));
     withWarning = withWarning || (retVal == 1);
+    //flat shell support: if the shell doesn't support xclbin download
+    //exit immediately
+    if(retVal == -EOPNOTSUPP)
+        return withWarning ? 1 : 0;
     if (retVal < 0)
         return retVal;
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1223,9 +1223,13 @@ int xcldev::device::runTestCase(const std::string& py,
         xclbinPath += xclbin;
 
         if (stat(xrtTestCasePath.c_str(), &st) != 0 || stat(xclbinPath.c_str(), &st) != 0) {
-            // flat shell support
+            // 0RP (nonDFX) flat shell support.  
+            // Currently, there isn't a clean way to determine if a nonDFX shell's interface is truly flat.  
+            // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
             std::string logic_uuid, errmsg;
             pcidev::get_dev(m_idx)->sysfs_get( "", "logic_uuids", errmsg, logic_uuid);
+            // Only skip the test if it nonDFX platform and the accelerator doesn't exist. 
+            // All other conditions should generate an error.
             if (!logic_uuid.empty() && xclbin.compare("verify.xclbin") == 0) {
                 output += "Verify xclbin not available. Skipping validation.";
                 return -EOPNOTSUPP;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -243,6 +243,15 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     xclbinPath = searchLegacyXclbin(vendor, name, xclbin, _ptTest);
   }
 
+  //flat shell support:
+  //if ssv2 flow and verify kernel is not present, then skip
+  if(!logic_uuid.empty() && !boost::filesystem::exists(xclbinPath)) {
+    //if bandwidth xclbin isn't present, skip the test
+    logger(_ptTest, "Details", "Verify xclbin not available. Skipping validation.");
+    _ptTest.put("status", "skipped");
+    return;
+  }
+
   //check if xclbin is present
   if(xclbinPath.empty()) {
     if(xclbin.compare("bandwidth.xclbin") == 0) {
@@ -940,6 +949,10 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
 
     if(schemaVersion == Report::SchemaVersion::text)
       pretty_print_test_run(ptTest, status, _ostream);
+    
+    //flash shell support: if verify xclbin is not present, exit immediately
+    if(ptTest.get<std::string>("name").compare("Verify kernel") == 0 && ptTest.get<std::string>("status").compare("skipped") == 0)
+      break;
 
     // If a test fails, exit immediately
     if(status == test_status::failed) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -243,8 +243,9 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     xclbinPath = searchLegacyXclbin(vendor, name, xclbin, _ptTest);
   }
 
-  //flat shell support:
-  //if ssv2 flow and verify kernel is not present, then skip
+  // 0RP (nonDFX) flat shell support.  
+  // Currently, there isn't a clean way to determine if a nonDFX shell's interface is truly flat.  
+  // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
   if(!logic_uuid.empty() && !boost::filesystem::exists(xclbinPath)) {
     //if bandwidth xclbin isn't present, skip the test
     logger(_ptTest, "Details", "Verify xclbin not available. Skipping validation.");
@@ -511,6 +512,73 @@ m2mtest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, int b
   return static_cast<double>(total_Mb / timer_duration_sec);
 }
 
+static int 
+program_xclbin(const xclDeviceHandle hdl, const std::string& xclbin, boost::property_tree::ptree& _ptTest)
+{
+  std::ifstream stream(xclbin, std::ios::binary);
+  if (!stream) {
+    logger(_ptTest, "Error", boost::str(boost::format("Could not open %s for reding") % xclbin));
+    return 1;
+  }
+
+  stream.seekg(0,stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0,stream.beg);
+  
+  std::vector<char> raw(size);
+  stream.read(raw.data(),size);
+
+  std::string v(raw.data(),raw.data()+7);
+  if (v != "xclbin2") {
+    logger(_ptTest, "Error", boost::str(boost::format("Bad binary version '%s'") % v));
+    return 1;
+  }
+
+  if (xclLoadXclBin(hdl,reinterpret_cast<const axlf*>(raw.data()))) {
+    logger(_ptTest, "Error", "Could not program device");
+    return 1;
+  }
+  return 0;
+}
+
+static bool
+search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::property_tree::ptree& ptTest)
+{
+  xuid_t uuid;
+  uuid_parse(xrt_core::device_query<xrt_core::query::xclbin_uuid>(dev).c_str(), uuid);
+  std::string xclbin = ptTest.get<std::string>("xclbin", "");
+  
+  //if no xclbin is loaded, locate the default xclbin
+  if (uuid_is_null(uuid) && !xclbin.empty()) {
+    //check if a 2RP platform
+    std::vector<std::string> logic_uuid;
+    try{
+      logic_uuid = xrt_core::device_query<xrt_core::query::logic_uuids>(dev);
+    } catch(...) { }
+
+    std::string xclbinPath;
+    if(!logic_uuid.empty()) {
+      xclbinPath = searchSSV2Xclbin(logic_uuid.front(), xclbin, ptTest);
+    } else {
+      auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(dev);
+      auto name = xrt_core::device_query<xrt_core::query::rom_vbnv>(dev);
+      xclbinPath = searchLegacyXclbin(vendor, name, xclbin, ptTest);
+    }
+
+    if(!boost::filesystem::exists(xclbinPath)) {
+      logger(ptTest, "Details", boost::str(boost::format("%s not available. Skipping validation.") % xclbin));
+      ptTest.put("status", "skipped");
+      return false;
+    }
+
+    if(program_xclbin(dev->get_device_handle(), xclbinPath, ptTest) != 0) {
+      ptTest.put("status", "failed");
+      return false;
+    }
+  }
+  return true;
+}
+
 /*
  * TEST #1
  */
@@ -615,7 +683,7 @@ scVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tre
 void
 verifyKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  runTestCase(_dev, "22_verify.py", "verify.xclbin", _ptTest);
+  runTestCase(_dev, "22_verify.py", _ptTest.get<std::string>("xclbin"), _ptTest);
 }
 
 /*
@@ -624,6 +692,10 @@ verifyKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_
 void
 dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  if(!search_and_program_xclbin(_dev, _ptTest)) {
+    return;
+  }
+
   // get DDR bank count from mem_topology if possible
   auto membuf = xrt_core::device_query<xrt_core::query::mem_topology_raw>(_dev);
   auto mem_topo = reinterpret_cast<const mem_topology*>(membuf.data());
@@ -679,7 +751,7 @@ bandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::proper
     return;
   }
   std::string testcase = (name.find("vck5000") != std::string::npos) ? "versal_23_bandwidth.py" : "23_bandwidth.py";
-  runTestCase(_dev, testcase, std::string("bandwidth.xclbin"), _ptTest);
+  runTestCase(_dev, testcase, _ptTest.get<std::string>("xclbin"), _ptTest);
 }
 
 /*
@@ -688,6 +760,10 @@ bandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::proper
 void
 p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  if(!search_and_program_xclbin(_dev, _ptTest)) {
+    return;
+  }
+
   std::string msg;
   xclbin_lock xclbin_lock(_dev);
   XBU::check_p2p_config(_dev, msg);
@@ -736,6 +812,10 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  if(!search_and_program_xclbin(_dev, _ptTest)) {
+    return;
+  }
+
   xclbin_lock xclbin_lock(_dev);
   uint32_t m2m_enabled = xrt_core::device_query<xrt_core::query::kds_numcdmas>(_dev);
   std::string name = xrt_core::device_query<xrt_core::query::rom_vbnv>(_dev);
@@ -795,17 +875,18 @@ hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost:
       _ptTest.put("status", "skipped");
       return;
   }
-  runTestCase(_dev, "host_mem_23_bandwidth.py", "bandwidth.xclbin", _ptTest);
+  runTestCase(_dev, "host_mem_23_bandwidth.py", _ptTest.get<std::string>("xclbin"), _ptTest);
 }
 
 /*
 * helper function to initialize test info
 */
 static boost::property_tree::ptree
-create_init_test(const std::string& name, const std::string& desc) {
+create_init_test(const std::string& name, const std::string& desc, const std::string& xclbin) {
   boost::property_tree::ptree _ptTest;
   _ptTest.put("name", name);
   _ptTest.put("description", desc);
+  _ptTest.put("xclbin", xclbin);
   return _ptTest;
 }
 
@@ -818,16 +899,16 @@ struct TestCollection {
 * create test suite
 */
 static std::vector<TestCollection> testSuite = {
-  { create_init_test("Kernel version", "Check if kernel version is supported by XRT"), kernelVersionTest },
-  { create_init_test("Aux connection", "Check if auxiliary power is connected"), auxConnectionTest },
-  { create_init_test("PCIE link", "Check if PCIE link is active"), pcieLinkTest },
-  { create_init_test("SC version", "Check if SC firmware is up-to-date"), scVersionTest },
-  { create_init_test("Verify kernel", "Run 'Hello World' kernel test"), verifyKernelTest },
-  { create_init_test("DMA", "Run dma test "), dmaTest },
-  { create_init_test("Bandwidth kernel", "Run 'bandwidth kernel' and check the throughput"), bandwidthKernelTest },
-  { create_init_test("Peer to peer bar", "Run P2P test"), p2pTest },
-  { create_init_test("Memory to memory DMA", "Run M2M test"), m2mTest },
-  { create_init_test("Host memory bandwidth test", "Run 'bandwidth kernel' when slave bridge is enabled"), hostMemBandwidthKernelTest }
+  { create_init_test("Kernel version", "Check if kernel version is supported by XRT", ""), kernelVersionTest },
+  { create_init_test("Aux connection", "Check if auxiliary power is connected", ""), auxConnectionTest },
+  { create_init_test("PCIE link", "Check if PCIE link is active", ""), pcieLinkTest },
+  { create_init_test("SC version", "Check if SC firmware is up-to-date", ""), scVersionTest },
+  { create_init_test("Verify kernel", "Run 'Hello World' kernel test", "verify.xclbin"), verifyKernelTest },
+  { create_init_test("DMA", "Run dma test", "verify.xclbin"), dmaTest },
+  { create_init_test("Bandwidth kernel", "Run 'bandwidth kernel' and check the throughput", "bandwidth.xclbin"), bandwidthKernelTest },
+  { create_init_test("Peer to peer bar", "Run P2P test", "bandwidth.xclbin"), p2pTest },
+  { create_init_test("Memory to memory DMA", "Run M2M test", "bandwidth.xclbin"), m2mTest },
+  { create_init_test("Host memory bandwidth test", "Run 'bandwidth kernel' when slave bridge is enabled", "bandwidth.xclbin"), hostMemBandwidthKernelTest }
 };
 
 /*
@@ -949,10 +1030,6 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
 
     if(schemaVersion == Report::SchemaVersion::text)
       pretty_print_test_run(ptTest, status, _ostream);
-    
-    //flash shell support: if verify xclbin is not present, exit immediately
-    if(ptTest.get<std::string>("name").compare("Verify kernel") == 0 && ptTest.get<std::string>("status").compare("skipped") == 0)
-      break;
 
     // If a test fails, exit immediately
     if(status == test_status::failed) {


### PR DESCRIPTION
Logic: if an xclbin is programmed, use that to run the test. Otherwise, we try to locate the default xclbin which is specified by the test metadata, and program it in order to run the test. If we are not able to find the xclbin, we skip the test. 

Tested scenarios:
- `xbutil --run quick`
- `xbutil --run all`
- `xbtuil --run dma` when no xclbin is loaded
```
Starting validation for 1 devices

Validate device[0000:65:00.1]
Platform            : xilinx_u250_gen3x16_xdma_shell_2_1
SC Version          : 4.5.0
Platform ID         : 0x0

1/1 Test #1 [0000:65:00.1]  : DMA
    Description             : Run dma test
    Details                 : Host -> PCIe -> FPGA write bandwidth = 9300.340135 MB/s
    Details                 : Host <- PCIe <- FPGA read bandwidth = 11445.624899 MB/s
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```

- `xbutil --run dma` when no xclbin is loaded and default xclbin is not found
```
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
Starting validation for 1 devices

Validate device[0000:65:00.1]
Platform            : xilinx_u250_gen3x16_xdma_shell_2_1
SC Version          : 4.5.0
Platform ID         : 0x0

1/1 Test #1 [0000:65:00.1]  : DMA
    Description             : Run dma test
    Details                 : verify.xclbin not available. Skipping validation.
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
```

- `xbutil --run all` when verify xclbin is not found, flat shell scenario
```
Starting validation for 1 devices

Validate device[0000:65:00.1]
Platform            : xilinx_u250_gen3x16_xdma_shell_2_1
SC Version          : 4.5.0
Platform ID         : 0x0

1/10 Test #1 [0000:65:00.1] : Kernel version
    Description             : Check if kernel version is supported by XRT
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
2/10 Test #2 [0000:65:00.1] : Aux connection
    Description             : Check if auxiliary power is connected
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
3/10 Test #3 [0000:65:00.1] : PCIE link
    Description             : Check if PCIE link is active
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
4/10 Test #4 [0000:65:00.1] : SC version
    Description             : Check if SC firmware is up-to-date
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
5/10 Test #5 [0000:65:00.1] : Verify kernel
    Description             : Run 'Hello World' kernel test
    Details                 : Verify xclbin not available. Skipping validation.
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
6/10 Test #6 [0000:65:00.1] : DMA
    Description             : Run dma test
    Details                 : verify.xclbin not available. Skipping validation.
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
7/10 Test #7 [0000:65:00.1] : Bandwidth kernel
    Description             : Run 'bandwidth kernel' and check the throughput
    Details                 : Verify xclbin not available. Skipping validation.
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
8/10 Test #8 [0000:65:00.1] : Peer to peer bar
    Description             : Run P2P test
    Details                 : bandwidth.xclbin not available. Skipping validation.
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
9/10 Test #9 [0000:65:00.1] : Memory to memory DMA
    Description             : Run M2M test
    Details                 : bandwidth.xclbin not available. Skipping validation.
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
10/10 Test #10 [0000:65:00.1]: Host memory bandwidth test
    Description             : Run 'bandwidth kernel' when slave bridge is enabled
    Details                 : Host memory is not enabled
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
```

