### PR TITLE
xclbinutil: Various Bug Fixes

### DIFF
--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -68,4 +68,4 @@ endif
 echo "XILINX_XRT      : $XILINX_XRT"
 echo "PATH            : $PATH"
 echo "LD_LIBRARY_PATH : $LD_LIBRARY_PATH"
-echo "PYTHONPATH     : $PYTHONPATH"
+echo "PYTHONPATH      : $PYTHONPATH"

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -37,4 +37,4 @@ export PYTHONPATH=$XILINX_XRT/python:$PYTHONPATH
 echo "XILINX_XRT      : $XILINX_XRT"
 echo "PATH            : $PATH"
 echo "LD_LIBRARY_PATH : $LD_LIBRARY_PATH"
-echo "PYTHONPATH     : $PYTHONPATH"
+echo "PYTHONPATH      : $PYTHONPATH"

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -674,15 +674,17 @@ XclBin::removeSection(const std::string & _sSectionToRemove)
   }
 
   removeSection(pSection);
+  pSection = nullptr;
 
   std::string indexEntry;
   if (!sectionIndexName.empty()) {
     indexEntry = "[" + sectionIndexName + "]";
   }
+
   std::cout << std::endl << XUtil::format("Section '%s%s'(%d) was successfully removed",
-                                          pSection->getSectionKindAsString().c_str(), 
+                                          _sSectionToRemove.c_str(), 
                                           indexEntry.c_str(),
-                                          pSection->getSectionKind()) << std::endl;
+                                          _eKind) << std::endl;
 }
 
 


### PR DESCRIPTION
Work Done
---------
+ Corrected echo alignment of the environment scripts (e.g., setup) for the PYTHONPATH
+ Corrected pointer dereference of a deleted object
+ Updated GROUP section logic to not autogenerate the GROUPs if the are delected in the same session.