### PR TITLE
Clean up XRT AIE/Graph interfaces

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -18,9 +18,10 @@
 
 // This file implements XRT APIs as declared in
 // core/include/experimental/xrt_aie.h -- end user APIs
-// core/include/xrt_graph.h -- shim level APIs
+// core/include/experimental/xrt_graph.h -- end user APIs
+// core/include/xcl_graph.h -- shim level APIs
 #include "core/include/experimental/xrt_aie.h"
-#include "core/include/xrt_graph.h" 
+#include "core/include/xcl_graph.h"
 
 #include "core/include/experimental/xrt_device.h"
 #include "core/common/api/device_int.h"
@@ -204,7 +205,7 @@ send_exception_message(const char* msg)
 }
 
 ////////////////////////////////////////////////////////////////
-// xrt_aie API implementations (xrt_aie.h)
+// xrt_aie API implementations (xrt_aie.h, xrt_graph.h)
 ////////////////////////////////////////////////////////////////
 
 xrtGraphHandle
@@ -245,11 +246,11 @@ xrtGraphReset(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -262,11 +263,11 @@ xrtGraphTimeStamp(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -280,11 +281,11 @@ xrtGraphRun(xrtGraphHandle graph_hdl, int iterations)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -297,11 +298,11 @@ xrtGraphWaitDone(xrtGraphHandle graph_hdl, int timeoutMilliSec)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -315,11 +316,11 @@ xrtGraphWait(xrtGraphHandle graph_hdl, uint64_t cycle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -333,11 +334,11 @@ xrtGraphSuspend(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -351,11 +352,11 @@ xrtGraphResume(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -369,11 +370,11 @@ xrtGraphEnd(xrtGraphHandle graph_hdl, uint64_t cycle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -387,11 +388,11 @@ xrtGraphUpdateRTP(xrtGraphHandle graph_hdl, const char* port, const char* buffer
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -405,12 +406,18 @@ xrtGraphReadRTP(xrtGraphHandle graph_hdl, const char* port, char* buffer, size_t
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
+}
+
+int
+xrtAIESyncBO(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+   return xrtSyncBOAIE(handle, bohdl, gmioName, dir, size, offset);
 }
 
 int
@@ -422,12 +429,18 @@ xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
+}
+
+int
+xrtAIEResetArray(xrtDeviceHandle handle)
+{
+  return xrtResetAIEArray(handle);
 }
 
 int
@@ -439,11 +452,11 @@ xrtResetAIEArray(xrtDeviceHandle handle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -460,7 +473,7 @@ xrtResetAIEArray(xrtDeviceHandle handle)
  * @size:            Size of data to synchronize
  * @offset:          Offset within the BO
  *
- * Return:          0 on success, -1 on error.
+ * Return:          0 on success, or appropriate error number.
  *
  * Synchronize the buffer contents between GMIO and AIE.
  * Note: Upon return, the synchronization is submitted or error out
@@ -474,11 +487,11 @@ xrtSyncBOAIENB(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -488,7 +501,7 @@ xrtSyncBOAIENB(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
  * @handle:          Handle to the device
  * @gmioName:        GMIO port name
  *
- * Return:          0 on success, -1 on error.
+ * Return:          0 on success, or appropriate error number.
  */
 int
 xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
@@ -499,11 +512,11 @@ xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -516,7 +529,8 @@ xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
  * @port2Name:       Profiling port 2 name
  * @value:           The number of bytes to trigger the profiling event
  *
- * Return:         An integer profiling handle on success, -1 on error.
+ * Return:         An integer profiling handle on success,
+ *                 or appropriate error number.
  *
  * This function configures the performance counters in AI Engine by given
  * port names and value. The port names and value will have different
@@ -533,11 +547,11 @@ xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, 
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -548,7 +562,7 @@ xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, 
  * @handle:          Handle to the device
  * @pHandle:         Profiling handle.
  *
- * Return:         The performance counter value, -1 on error.
+ * Return:         The performance counter value, or appropriate error number.
  */
 uint64_t
 xrtAIEReadProfiling(xrtDeviceHandle handle, int pHandle)
@@ -558,11 +572,11 @@ xrtAIEReadProfiling(xrtDeviceHandle handle, int pHandle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -574,7 +588,7 @@ xrtAIEReadProfiling(xrtDeviceHandle handle, int pHandle)
  * @handle:          Handle to the device
  * @pHandle:         Profiling handle.
  *
- * Return:         0 on success, -1 on error.
+ * Return:         0 on success, or appropriate error number.
  */
 int
 xrtAIEStopProfiling(xrtDeviceHandle handle, int pHandle)
@@ -585,10 +599,10 @@ xrtAIEStopProfiling(xrtDeviceHandle handle, int pHandle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -20,7 +20,7 @@
 #include "xrt.h"
 #include "experimental/xrt-next.h"
 #include "experimental/xrt_bo.h"
-#include "xrt_graph.h"
+#include "xcl_graph.h"
 #include "error.h"
 #include <stdexcept>
 

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -21,7 +21,7 @@
 #include "shim.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
-#include "xrt_graph.h"
+#include "xcl_graph.h"
  
 xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbosityLevel level)
 {

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -823,7 +823,7 @@ xclStopProfiling(xclDeviceHandle handle, int phdl)
 
 
 ////////////////////////////////////////////////////////////////
-// Shim level Graph API implementations (xrt_graph.h)
+// Shim level Graph API implementations (xcl_graph.h)
 ////////////////////////////////////////////////////////////////
 xclGraphHandle
 xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph)

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt-next.h
   xrt_aie.h
+  xrt_graph.h
   xrt_bo.h
   xrt_device.h
   xrt_enqueue.h

--- a/src/runtime_src/core/include/experimental/xrt_aie.h
+++ b/src/runtime_src/core/include/experimental/xrt_aie.h
@@ -23,166 +23,10 @@
 #include "experimental/xrt_uuid.h"
 #include "experimental/xrt_bo.h"
 #include "experimental/xrt_device.h"
-
-typedef void *xrtGraphHandle;
-
-/**
- * xrtGraphOpen() - Open a graph and obtain its handle.
- *
- * @handle:       Handle to the device with the graph.
- * @xclbinUUID:   UUID of the xclbin with the specified graph.
- * @graphNmae:    The name of graph to be open.
- * Return:        Handle to representing the graph. NULL for error.
- *
- * An xclbin with the specified graph must have been loaded prior
- * to calling this function.
- */
-xrtGraphHandle
-xrtGraphOpen(xrtDeviceHandle handle, const uuid_t xclbinUUID, const char *graphName);
+#include "experimental/xrt_graph.h"
 
 /**
- * xrtGraphClose() - Close an open graph.
- *
- * @gh:            Handle to graph previously opened with xrtGraphOpen.
- *
- */
-void
-xrtGraphClose(xrtGraphHandle gh);
-
-/**
- * xrtGraphReset() - Reset a graph.
- *
- * @gh:            Handle to graph previously opened with xrtGraphOpen.
- * Return:         0 on success, -1 on error
- *
- * Note: Reset by disable tiles and enable tile reset
- */
-int
-xrtGraphReset(xrtGraphHandle gh);
-
-/**
- * xrtGraphTimeStamp() - Get timestamp of a graph. The unit of timestamp is
- *                       AIE Cycle.
- *
- * @gh:             Handle to graph previously opened with xrtGraphOpen.
- * Return:          Timestamp in AIE cycle.
- */
-uint64_t
-xrtGraphTimeStamp(xrtGraphHandle gh);
-
-/**
- * xrtGraphRun() - Start a graph execution
- *
- * @gh:             Handle to graph previously opened with xrtGraphOpen.
- * @iterations:     The run iteration to update to graph.
- *                  0 for default or previous set iterations
- *                  -1 for run forever
- * Return:          0 on success, -1 on error
- *
- * Note: Run by enable tiles and disable tile reset
- */
-int
-xrtGraphRun(xrtGraphHandle gh, int iterations);
-
-/**
- * xrtGraphWaitDone() - Wait for graph to be done. If the graph is not
- *                      done in a given time, bail out with timeout.
- *
- * @gh:              Handle to graph previously opened with xrtGraphOpen.
- * @timeoutMilliSec: Timeout value to wait for graph done.
- *
- * Return:          0 on success, -ETIME on timeout, -1 on error.
- *
- * Note: Wait for done status of ALL the tiles
- */
-int
-xrtGraphWaitDone(xrtGraphHandle gh, int timeoutMilliSec);
-
-/**
- * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
- *                   then stop the graph. If cycle is 0, busy wait until graph
- *                   is done. If graph already run more than the given
- *                   cycle, stop the graph immediateley.
- *
- * @gh:              Handle to graph previously opened with xrtGraphOpen.
- * @cycle:           AIE cycle should wait since last xrtGraphRun. 0 for
- *                   wait until graph is done.
- *
- * Return:          0 on success, -1 on error.
- *
- * Note: This API with non-zero AIE cycle is for graph that is running
- * forever or graph that has multi-rate core(s).
- */
-int
-xrtGraphWait(xrtGraphHandle gh, uint64_t cycle);
-
-/**
- * xrtGraphSuspend() - Suspend a running graph.
- *
- * @gh:             Handle to graph previously opened with xrtGraphOpen.
- * Return:          0 on success, -1 on error.
- */
-int
-xrtGraphSuspend(xrtGraphHandle gh);
-
-/**
- * xrtGraphResume() - Resume a suspended graph.
- *
- * @gh:             Handle to graph previously opened with xrtGraphOpen.
- * Return:          0 on success, -1 on error.
- */
-int
-xrtGraphResume(xrtGraphHandle gh);
-
-/**
- * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
- *                 then end the graph. If cycle is 0, busy wait until graph
- *                 is done before end the graph. If graph already run more
- *                 than the given cycle, stop the graph immediately and end it.
- *
- * @gh:              Handle to graph previously opened with xrtGraphOpen.
- * @cycle:           AIE cycle should wait since last xrtGraphRun. 0 for
- *                   wait until graph is done.
- *
- * Return:          0 on success, -1 on timeout.
- *
- * Note: This API with non-zero AIE cycle is for graph that is running
- * forever or graph that has multi-rate core(s).
- */
-int
-xrtGraphEnd(xrtGraphHandle gh, uint64_t cycle);
-
-/**
- * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
- *
- * @gh:              Handle to graph previously opened with xrtGraphOpen.
- * @hierPathPort:    hierarchial name of RTP port.
- * @buffer:          pointer to the RTP value.
- * @size:            size in bytes of the RTP value.
- *
- * Return:          0 on success, -1 on error.
- */
-int
-xrtGraphUpdateRTP(xrtGraphHandle gh, const char *hierPathPort, const char *buffer, size_t size);
-
-/**
- * xrtGraphReadRTP() - Read RTP value of port with hierarchical name
- *
- * @gh:              Handle to graph previously opened with xrtGraphOpen.
- * @hierPathPort:    hierarchial name of RTP port.
- * @buffer:          pointer to the buffer that RTP value is copied to.
- * @size:            size in bytes of the RTP value.
- *
- * Return:          0 on success, -1 on error.
- *
- * Note: Caller is reponsible for allocating enough memory for RTP value
- *       being copied to.
- */
-int
-xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_t size);
-
-/**
- * xrtSyncBOAIE() - Transfer data between DDR and Shim DMA channel
+ * xrtAIESyncBO() - Transfer data between DDR and Shim DMA channel
  *
  * @handle:          Handle to the device
  * @bohdl:           BO handle.
@@ -191,21 +35,30 @@ xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_
  * @size:            Size of data to synchronize
  * @offset:          Offset within the BO
  *
- * Return:          0 on success, -1 on error.
+ * Return:          0 on success, or appropriate error number.
  *
  * Synchronize the buffer contents between GMIO and AIE.
  * Note: Upon return, the synchronization is done or error out
  */
 int
-xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xrtAIESyncBO(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 /**
  * xrtResetAIEArray() - Reset the AIE array
  *
  * @handle:         Handle to the device.
  *
- * Return:          0 on success, -1 on error.
+ * Return:          0 on success, or appropriate error number.
  */
 int
+xrtAIEResetArray(xrtDeviceHandle handle);
+
+/* Provide this API for backward compatibility. */
+int
+xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+/* Provide this API for backward compatibility. */
+int
 xrtResetAIEArray(xrtDeviceHandle handle);
+
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_graph.h
+++ b/src/runtime_src/core/include/experimental/xrt_graph.h
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ * Author(s): Larry Liu
+ * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XRT_GRAPH_H_
+#define _XRT_GRAPH_H_
+
+#include "xrt.h"
+#include "experimental/xrt_uuid.h"
+#include "experimental/xrt_bo.h"
+#include "experimental/xrt_device.h"
+
+typedef void *xrtGraphHandle;
+
+/**
+ * xrtGraphOpen() - Open a graph and obtain its handle.
+ *
+ * @handle:       Handle to the device with the graph.
+ * @xclbinUUID:   UUID of the xclbin with the specified graph.
+ * @graphNmae:    The name of graph to be open.
+ * Return:        Handle to representing the graph. NULL for error.
+ *
+ * An xclbin with the specified graph must have been loaded prior
+ * to calling this function.
+ */
+xrtGraphHandle
+xrtGraphOpen(xrtDeviceHandle handle, const xuid_t xclbinUUID, const char *graphName);
+
+/**
+ * xrtGraphClose() - Close an open graph.
+ *
+ * @gh:            Handle to graph previously opened with xrtGraphOpen.
+ *
+ */
+void
+xrtGraphClose(xrtGraphHandle gh);
+
+/**
+ * xrtGraphReset() - Reset a graph.
+ *
+ * @gh:            Handle to graph previously opened with xrtGraphOpen.
+ * Return:         0 on success, or appropriate error number
+ *
+ * Note: Reset by disable tiles and enable tile reset
+ */
+int
+xrtGraphReset(xrtGraphHandle gh);
+
+/**
+ * xrtGraphTimeStamp() - Get timestamp of a graph. The unit of timestamp is
+ *                       AIE Cycle.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          Timestamp in AIE cycle.
+ */
+uint64_t
+xrtGraphTimeStamp(xrtGraphHandle gh);
+
+/**
+ * xrtGraphRun() - Start a graph execution
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * @iterations:     The run iteration to update to graph.
+ *                  0 for default or previous set iterations
+ *                  -1 for run forever
+ * Return:          0 on success, or appropriate error number
+ *
+ * Note: Run by enable tiles and disable tile reset
+ */
+int
+xrtGraphRun(xrtGraphHandle gh, int iterations);
+
+/**
+ * xrtGraphWaitDone() - Wait for graph to be done. If the graph is not
+ *                      done in a given time, bail out with timeout.
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @timeoutMilliSec: Timeout value to wait for graph done.
+ *
+ * Return:          0 on success, -ETIME on timeout,
+ *                  or appropriate error number.
+ *
+ * Note: Wait for done status of ALL the tiles
+ */
+int
+xrtGraphWaitDone(xrtGraphHandle gh, int timeoutMilliSec);
+
+/**
+ * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
+ *                   then stop the graph. If cycle is 0, busy wait until graph
+ *                   is done. If graph already run more than the given
+ *                   cycle, stop the graph immediateley.
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @cycle:           AIE cycle should wait since last xrtGraphRun. 0 for
+ *                   wait until graph is done.
+ *
+ * Return:          0 on success, or appropriate error number.
+ *
+ * Note: This API with non-zero AIE cycle is for graph that is running
+ * forever or graph that has multi-rate core(s).
+ */
+int
+xrtGraphWait(xrtGraphHandle gh, uint64_t cycle);
+
+/**
+ * xrtGraphSuspend() - Suspend a running graph.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          0 on success, or appropriate error number.
+ */
+int
+xrtGraphSuspend(xrtGraphHandle gh);
+
+/**
+ * xrtGraphResume() - Resume a suspended graph.
+ *
+ * @gh:             Handle to graph previously opened with xrtGraphOpen.
+ * Return:          0 on success, or appropriate error number.
+ */
+int
+xrtGraphResume(xrtGraphHandle gh);
+
+/**
+ * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
+ *                 then end the graph. If cycle is 0, busy wait until graph
+ *                 is done before end the graph. If graph already run more
+ *                 than the given cycle, stop the graph immediately and end it.
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @cycle:           AIE cycle should wait since last xrtGraphRun. 0 for
+ *                   wait until graph is done.
+ *
+ * Return:          0 on success, or appropriate error number.
+ *
+ * Note: This API with non-zero AIE cycle is for graph that is running
+ * forever or graph that has multi-rate core(s).
+ */
+int
+xrtGraphEnd(xrtGraphHandle gh, uint64_t cycle);
+
+/**
+ * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @hierPathPort:    hierarchial name of RTP port.
+ * @buffer:          pointer to the RTP value.
+ * @size:            size in bytes of the RTP value.
+ *
+ * Return:          0 on success, -1 on error.
+ */
+int
+xrtGraphUpdateRTP(xrtGraphHandle gh, const char *hierPathPort, const char *buffer, size_t size);
+
+/**
+ * xrtGraphReadRTP() - Read RTP value of port with hierarchical name
+ *
+ * @gh:              Handle to graph previously opened with xrtGraphOpen.
+ * @hierPathPort:    hierarchial name of RTP port.
+ * @buffer:          pointer to the buffer that RTP value is copied to.
+ * @size:            size in bytes of the RTP value.
+ *
+ * Return:          0 on success, -1 on error.
+ *
+ * Note: Caller is reponsible for allocating enough memory for RTP value
+ *       being copied to.
+ */
+int
+xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_t size);
+
+#endif

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -18,8 +18,8 @@
 
 // This file defines shim level XRT Graph APIs.
 
-#ifndef _XRT_COMMON_GRAPH_H_
-#define _XRT_COMMON_GRAPH_H_
+#ifndef _XCL_COMMON_GRAPH_H_
+#define _XCL_COMMON_GRAPH_H_
 
 typedef void * xclGraphHandle;
 


### PR DESCRIPTION
This PR addresses
1) Split xrt_aie.h to xrt_aie.h (AIE Array/Shim_tile level API) and xrt_graph.h (sdf Graph level API)
2) Provide correct API name 
   xrtSyncBOAIE --> xrtAIESyncBO
   xrtResetAIE --> xrtAIEReset
3) Keep xrtSyncBOAIE and xrtResetAIE API for backward compatibility
4) Use xuid_t instead of uuid_t
5) Clean up the document to accurate return value