### PR TITLE
support polling interval and threshold to reduce CPU usage

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -298,6 +298,10 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	xcu->core = core;
 	xcu->funcs = &xrt_cu_hls_funcs;
 
+	xcu->busy_threshold = -1;
+	xcu->interval_min = 2;
+	xcu->interval_max = 5;
+
 	err = xrt_cu_init(xcu);
 	if (err)
 		return err;

--- a/src/runtime_src/core/common/drv/fast_adapter.c
+++ b/src/runtime_src/core/common/drv/fast_adapter.c
@@ -231,7 +231,7 @@ int xrt_cu_fa_init(struct xrt_cu *xcu)
 	/* Not sure what is the best initial value.
 	 * But below parameters are configurable to user. No worry.
 	 */
-	xcu->busy_threshold = 8;
+	xcu->busy_threshold = core->max_credits / 2;
 	xcu->interval_min = 2;
 	xcu->interval_max = 5;
 

--- a/src/runtime_src/core/common/drv/fast_adapter.c
+++ b/src/runtime_src/core/common/drv/fast_adapter.c
@@ -134,6 +134,7 @@ static void cu_fa_check(void *core, struct xcu_status *status)
 	if (!cu_fa->run_cnts)
 		return;
 
+	cu_fa->check_count++;
 	task_count = cu_read32(cu_fa, TCR);
 	/* If taskCount register overflow once, below calculate is still correct.
 	 * Only when the register overflow more than once, this is wrong.
@@ -227,6 +228,12 @@ int xrt_cu_fa_init(struct xrt_cu *xcu)
 
 	xcu->core = core;
 	xcu->funcs = &xrt_cu_fa_funcs;
+	/* Not sure what is the best initial value.
+	 * But below parameters are configurable to user. No worry.
+	 */
+	xcu->busy_threshold = 8;
+	xcu->interval_min = 2;
+	xcu->interval_max = 5;
 
 	err = xrt_cu_init(xcu);
 	if (err)

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -241,6 +241,9 @@ struct xrt_cu {
 	u32			  ready_cnt;
 	u32			  status;
 	u64			  run_timeout;
+	int			  busy_threshold;
+	u32			  interval_min;
+	u32			  interval_max;
 	struct kds_command	 *old_cmd;
 	struct xrt_cu_event	  ev;
 	/**
@@ -325,6 +328,11 @@ static inline int is_zero_credit(struct xrt_cu *xcu)
 	return (xcu->funcs->peek_credit(xcu->core) == 0);
 }
 
+static inline int xrt_cu_peek_credit(struct xrt_cu *xcu)
+{
+	return xcu->funcs->peek_credit(xcu->core);
+}
+
 static inline void xrt_cu_put_credit(struct xrt_cu *xcu, u32 count)
 {
 	xcu->funcs->free_credit(xcu->core, count);
@@ -390,6 +398,7 @@ typedef struct {
 	u32 data[];
 } descriptor_t;
 
+#define to_cu_fa(core) ((struct xrt_cu_fa *)(core))
 struct xrt_cu_fa {
 	void __iomem		*vaddr;
 	void __iomem		*plram;
@@ -402,11 +411,15 @@ struct xrt_cu_fa {
 	int			 max_credits;
 	int			 credits;
 	int			 run_cnts;
+	u64			 check_count;
 };
 
 int xrt_cu_fa_init(struct xrt_cu *xcu);
 void xrt_cu_fa_fini(struct xrt_cu *xcu);
 
+/* PLRAM CU -- deprecated
+ * TODO: Delete this type of CU once fast adapter is full supported
+ */
 struct xrt_cu_plram {
 	void __iomem		*vaddr;
 	void __iomem		*plram;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -69,6 +69,59 @@ cu_info_show(struct device *dev, struct device_attribute *attr, char *buf)
 static DEVICE_ATTR_RO(cu_info);
 
 static ssize_t
+poll_interval_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+
+	return sprintf(buf, "%d\n", cu->base.interval_min);
+}
+
+static ssize_t
+poll_interval_store(struct device *dev, struct device_attribute *attr,
+	    const char *buf, size_t count)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+	u32 interval;
+
+	if (kstrtou32(buf, 10, &interval) == -EINVAL)
+		return -EINVAL;
+
+	cu->base.interval_min = interval;
+	cu->base.interval_max = interval + 3;
+
+	return count;
+}
+static DEVICE_ATTR_RW(poll_interval);
+
+static ssize_t
+busy_threshold_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+
+	return sprintf(buf, "%d\n", cu->base.busy_threshold);
+}
+
+static ssize_t
+busy_threshold_store(struct device *dev, struct device_attribute *attr,
+		     const char *buf, size_t count)
+{
+	struct platform_device *pdev = to_platform_device(dev);
+	struct xocl_cu *cu = platform_get_drvdata(pdev);
+	int threshold;
+
+	if (kstrtos32(buf, 10, &threshold) == -EINVAL)
+		return -EINVAL;
+
+	cu->base.busy_threshold = threshold;
+
+	return count;
+}
+static DEVICE_ATTR_RW(busy_threshold);
+
+static ssize_t
 name_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct platform_device *pdev = to_platform_device(dev);
@@ -83,6 +136,8 @@ static struct attribute *cu_attrs[] = {
 	&dev_attr_debug.attr,
 	&dev_attr_cu_stat.attr,
 	&dev_attr_cu_info.attr,
+	&dev_attr_poll_interval.attr,
+	&dev_attr_busy_threshold.attr,
 	&dev_attr_name.attr,
 	NULL,
 };


### PR DESCRIPTION
Use usleep_range() to delay based on https://github.com/torvalds/linux/blob/a351e9b9fc24e982ec2f0e76379a49826036da12/Documentation/timers/timers-howto.txt 