### PR TITLE
Add xrt.ini option to ignore xclbin group sections

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -277,6 +277,13 @@ get_api_checks()
   return value;
 }
 
+inline bool
+get_use_xclbin_group_sections()
+{
+  static bool value = detail::get_bool_value("Runtime.use_xclbin_group_sections",true);
+  return value;
+}
+
 inline std::string
 get_logging()
 {

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -89,19 +89,11 @@ register_axlf(const axlf* top)
                                ASK_GROUP_CONNECTIVITY, ASK_GROUP_TOPOLOGY, 
                                MEM_TOPOLOGY, DEBUG_IP_LAYOUT, SYSTEM_METADATA, CLOCK_FREQ_TOPOLOGY};
   for (auto kind : kinds) {
-    auto hdr = ::xclbin::get_axlf_section(top, kind);
-    if (!hdr) {
-      /* If group topology or group connectivity doesn't exists then use the
-       * mem topology or connectivity respectively section for the same.
-       */
-      if (kind == ASK_GROUP_TOPOLOGY)
-        hdr = ::xclbin::get_axlf_section(top, MEM_TOPOLOGY);
-      else if (kind == ASK_GROUP_CONNECTIVITY)
-        hdr = ::xclbin::get_axlf_section(top, CONNECTIVITY);
+    auto hdr = xrt_core::xclbin::get_axlf_section(top, kind);
 
-      if (!hdr)
-        continue;
-    }
+    if (!hdr)
+      continue;
+
     auto section_data = reinterpret_cast<const char*>(top) + hdr->m_sectionOffset;
     std::vector<char> data{section_data, section_data + hdr->m_sectionSize};
     m_axlf_sections.emplace(kind , std::move(data));

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -97,7 +97,8 @@ is_legacy_cu_intr(const ip_layout *ips)
   return (cu_cnt == intr_cnt);
 }
 
-bool compare_intr_id(struct ip_data &l, struct ip_data &r)
+bool
+compare_intr_id(struct ip_data &l, struct ip_data &r)
 {
     /* We need to put free running CU at the end */
     if (l.m_base_address == static_cast<size_t>(-1))
@@ -155,6 +156,26 @@ kernel_max_ctx(const ip_data& ip)
 } // namespace
 
 namespace xrt_core { namespace xclbin {
+
+const axlf_section_header*
+get_axlf_section(const axlf* top, axlf_section_kind kind)
+{
+  static bool use_groups = xrt_core::config::get_use_xclbin_group_sections();
+  if (kind == ASK_GROUP_TOPOLOGY && !use_groups)
+    kind = MEM_TOPOLOGY;
+  else if (kind == ASK_GROUP_CONNECTIVITY && !use_groups)
+    kind = CONNECTIVITY;
+
+  if (auto hdr = ::xclbin::get_axlf_section(top, kind))
+    return hdr;
+
+  if (kind == ASK_GROUP_TOPOLOGY)
+    return ::xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+  else if (kind == ASK_GROUP_CONNECTIVITY)
+    return ::xclbin::get_axlf_section(top, CONNECTIVITY);
+
+  return nullptr;
+}
 
 std::string
 memidx_to_name(const mem_topology* mem_topology,  int32_t midx)

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -160,6 +160,8 @@ namespace xrt_core { namespace xclbin {
 const axlf_section_header*
 get_axlf_section(const axlf* top, axlf_section_kind kind)
 {
+  // replace group kinds with none group kinds if grouping
+  // is disabled per xrt.ini
   static bool use_groups = xrt_core::config::get_use_xclbin_group_sections();
   if (kind == ASK_GROUP_TOPOLOGY && !use_groups)
     kind = MEM_TOPOLOGY;
@@ -169,6 +171,9 @@ get_axlf_section(const axlf* top, axlf_section_kind kind)
   if (auto hdr = ::xclbin::get_axlf_section(top, kind))
     return hdr;
 
+  // hdr is nullptr, check if kind is one of the group sections,
+  // which then does not appear in the xclbin and should default to
+  // the none group one.
   if (kind == ASK_GROUP_TOPOLOGY)
     return ::xclbin::get_axlf_section(top, MEM_TOPOLOGY);
   else if (kind == ASK_GROUP_CONNECTIVITY)

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -69,6 +69,19 @@ struct softkernel_object
 };
 
 /**
+ * get_axlf_section_header() - retrieve axlf section header
+ *
+ * @top: axlf to retrieve section from
+ * @kind: section kind to retrieve
+ *
+ * This function treats group sections conditionally based on
+ * xrt.ini settings
+ */ 
+XRT_CORE_COMMON_EXPORT
+const axlf_section_header*
+get_axlf_section(const axlf* top, axlf_section_kind kind);
+
+/**
  * Get specific binary section of the axlf structure
  *
  * auto data = axlf_section_type::get<const ip_layout*>(top,axlf_section_kind::IP_LAYOUT);
@@ -82,7 +95,7 @@ struct axlf_section_type<SectionType*>
   static SectionType*
   get(const axlf* top, axlf_section_kind kind)
   {
-    if (auto header = ::xclbin::get_axlf_section(top, kind)) {
+    if (auto header = get_axlf_section(top, kind)) {
       auto begin = reinterpret_cast<const char*>(top) + header->m_sectionOffset ;
       return reinterpret_cast<SectionType*>(begin);
     }

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -25,18 +25,6 @@
 #include <errno.h>
 #include <unistd.h>
 
-namespace {
-
-static auto
-get_mem_topology(const axlf* top)
-{
-  if (auto sec = xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
-    return sec;
-  return xclbin::get_axlf_section(top, MEM_TOPOLOGY);
-}
-
-}
-
 namespace xclcpuemhal2 {
 
   std::map<unsigned int, CpuemShim*> devices;
@@ -538,7 +526,7 @@ namespace xclcpuemhal2 {
           sharedlib = xclbininmemory + sec->m_sectionOffset;
           sharedliblength = sec->m_sectionSize;
         }
-        if (auto sec = get_mem_topology(top)) {
+        if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY)) {
           memTopologySize = sec->m_sectionSize;
           memTopology = new char[memTopologySize];
           memcpy(memTopology, xclbininmemory + sec->m_sectionOffset, memTopologySize);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -27,17 +27,6 @@
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/lexical_cast.hpp>
 
-namespace {
-
-static auto
-get_mem_topology(const axlf* top)
-{
-  if (auto sec = xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
-    return sec;
-  return xclbin::get_axlf_section(top, MEM_TOPOLOGY);
-}
-
-}
 
 namespace xclcpuemhal2 {
 
@@ -547,7 +536,7 @@ namespace xclcpuemhal2 {
           sharedlib = xclbininmemory + sec->m_sectionOffset;
           sharedliblength = sec->m_sectionSize;
         }
-        if (auto sec = get_mem_topology(top)) {
+        if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY)) {
           memTopologySize = sec->m_sectionSize;
           memTopology = new char[memTopologySize];
           memcpy(memTopology, xclbininmemory + sec->m_sectionOffset, memTopologySize);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -46,14 +46,6 @@ file_exists(const std::string& fnm)
   return stat(fnm.c_str(), &statBuf) == 0;
 }
 
-static auto
-get_mem_topology(const axlf* top)
-{
-  if (auto sec = xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY))
-    return sec;
-  return xclbin::get_axlf_section(top, MEM_TOPOLOGY);
-}
-
 }
 
 namespace xclhwemhal2 {
@@ -302,7 +294,7 @@ namespace xclhwemhal2 {
       debugFile = new char[debugFileSize];
       memcpy(debugFile, bitstreambin + sec->m_sectionOffset, debugFileSize);
     }
-    if (auto sec = get_mem_topology(top)) {
+    if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY)) {
       memTopologySize = sec->m_sectionSize;
       memTopology = new char[memTopologySize];
       memcpy(memTopology, bitstreambin + sec->m_sectionOffset, memTopologySize);

--- a/src/xma/src/xmaapi/xmaxclbin.cpp
+++ b/src/xma/src/xmaapi/xmaxclbin.cpp
@@ -32,24 +32,6 @@ static int get_xclbin_iplayout(const char *buffer, XmaXclbinInfo *xclbin_info);
 static int get_xclbin_mem_topology(const char *buffer, XmaXclbinInfo *xclbin_info);
 static int get_xclbin_connectivity(const char *buffer, XmaXclbinInfo *xclbin_info);
 
-static const axlf_section_header*
-get_mem_topology(const axlf* xclbin)
-{
-  if (auto hdr = xclbin::get_axlf_section(xclbin, ASK_GROUP_TOPOLOGY))
-    return hdr;
-
-  return xclbin::get_axlf_section(xclbin, MEM_TOPOLOGY);
-}
-
-static const axlf_section_header*
-get_connectivity(const axlf* xclbin)
-{
-  if (auto hdr = xclbin::get_axlf_section(xclbin, ASK_GROUP_CONNECTIVITY))
-    return hdr;
-
-  return xclbin::get_axlf_section(xclbin, CONNECTIVITY);
-}
-
 std::vector<char> xma_xclbin_file_open(const std::string& xclbin_name)
 {
     xma_logmsg(XMA_INFO_LOG, XMAAPI_MOD, "Loading %s ", xclbin_name.c_str());
@@ -298,7 +280,7 @@ static int get_xclbin_mem_topology(const char *buffer, XmaXclbinInfo *xclbin_inf
 {
     const axlf *xclbin = reinterpret_cast<const axlf *>(buffer);
 
-    const axlf_section_header *ip_hdr = get_mem_topology(xclbin);
+    const axlf_section_header *ip_hdr = xrt_core::xclbin::get_axlf_section(xclbin, ASK_GROUP_TOPOLOGY);
     if (ip_hdr)
     {
         const char *data = &buffer[ip_hdr->m_sectionOffset];
@@ -339,7 +321,7 @@ static int get_xclbin_connectivity(const char *buffer, XmaXclbinInfo *xclbin_inf
 {
     const axlf *xclbin = reinterpret_cast<const axlf *>(buffer);
 
-    const axlf_section_header *ip_hdr = get_connectivity(xclbin);
+    const axlf_section_header *ip_hdr = xrt_core::xclbin::get_axlf_section(xclbin, ASK_GROUP_CONNECTIVITY);
     if (ip_hdr)
     {
         const char *data = &buffer[ip_hdr->m_sectionOffset];

--- a/src/xma/xma_legacy/src/xmaapi/xmaxclbin.cpp
+++ b/src/xma/xma_legacy/src/xmaapi/xmaxclbin.cpp
@@ -14,11 +14,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#include <stdio.h>
+#include <cstdio>
 #include <fstream>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include <cstring>
+#include <cstdlib>
+#include <cstdint>
+#include "core/common/xclbin_parser.h"
 #include "xclbin.h"
 #include "app/xmaerror.h"
 #include "app/xmalogger.h"
@@ -30,24 +31,6 @@
 static int get_xclbin_iplayout(char *buffer, XmaXclbinInfo *xclbin_info);
 static int get_xclbin_mem_topology(char *buffer, XmaXclbinInfo *xclbin_info);
 static int get_xclbin_connectivity(char *buffer, XmaXclbinInfo *xclbin_info);
-
-static const axlf_section_header*
-get_mem_topology(const axlf* xclbin)
-{
-  if (auto hdr = xclbin::get_axlf_section(xclbin, ASK_GROUP_TOPOLOGY))
-    return hdr;
-
-  return xclbin::get_axlf_section(xclbin, MEM_TOPOLOGY);
-}
-
-static const axlf_section_header*
-get_connectivity(const axlf* xclbin)
-{
-  if (auto hdr = xclbin::get_axlf_section(xclbin, ASK_GROUP_CONNECTIVITY))
-    return hdr;
-
-  return xclbin::get_axlf_section(xclbin, CONNECTIVITY);
-}
 
 char *xma_xclbin_file_open(const char *xclbin_name)
 {
@@ -114,7 +97,7 @@ static int get_xclbin_mem_topology(char *buffer, XmaXclbinInfo *xclbin_info)
     //int rc = XMA_SUCCESS;
     axlf *xclbin = reinterpret_cast<axlf *>(buffer);
 
-    const axlf_section_header *ip_hdr = get_mem_topology(xclbin);
+    const axlf_section_header *ip_hdr = xrt_core::xclbin::get_axlf_section(xclbin, ASK_GROUP_TOPOLOGY);
     if (ip_hdr)
     {
         char *data = &buffer[ip_hdr->m_sectionOffset];
@@ -149,7 +132,7 @@ static int get_xclbin_connectivity(char *buffer, XmaXclbinInfo *xclbin_info)
     //int rc = XMA_SUCCESS;
     axlf *xclbin = reinterpret_cast<axlf *>(buffer);
 
-    const axlf_section_header *ip_hdr = get_connectivity(xclbin);
+    const axlf_section_header *ip_hdr = xrt_core::xclbin::get_axlf_section(xclbin, ASK_GROUP_CONNECTIVITY);
     if (ip_hdr)
     {
         char *data = &buffer[ip_hdr->m_sectionOffset];


### PR DESCRIPTION
Memory topology and CU connectivity by default comes from
ASK_GROUP_TOPOLOGY and ASK_GROUP_CONNECTIVITY sections in the xclbin
if these sections exist.

This PR adds an xrt.ini option, Runtime.use_xclbin_group_sections, which
defaults to true but can be set to false if user space should ignore
the group sections in the xclbin.

When using groups, multiple connections for a CU argument are merged
into a single group when possible, but buffer placement within this
group cannot be controlled.  By disabling groups via xrt.ini, user
space will see the unmerged connections to multiple memory banks and
host code can control allocation of buffers in any of the connected
banks.