### PR TITLE
CR-1080596 xbutil validate -q hang for xilinx_u50_gen3x4_xdma_2_202010_1 on Ubuntu16.04

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -396,12 +396,12 @@ static int load_firmware_from_flash(struct platform_device *pdev,
 	char **fw_buf, size_t *fw_len)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
-	struct flash_data_header header = { 0 };
+	struct flash_data_header header = { {{0}} };
 	const size_t magiclen = sizeof(header.fdh_id_begin.fdi_magic);
 	size_t flash_size = 0;
 	int ret = 0;
 	char *buf = NULL;
-	struct flash_data_ident id = { 0 };
+	struct flash_data_ident id = { {0} };
 
 	xocl_info(&pdev->dev, "try loading fw from flash");
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -134,7 +134,7 @@ static ssize_t xdma_async_migrate_bo(struct platform_device *pdev,
 	int i = 0;
 	ssize_t ret;
 	unsigned long long pgaddr;
-	struct xdma_io_cb *io_cb;
+	struct xdma_io_cb *io_cb = NULL;
 	struct xdma_async_context *async_ctx;
 
 	xdma = platform_get_drvdata(pdev);
@@ -169,8 +169,6 @@ static ssize_t xdma_async_migrate_bo(struct platform_device *pdev,
 
 		io_cb->io_done = xdma_async_migrate_done;
 		io_cb->private = async_ctx;
-	} else {
-		io_cb = NULL;
 	}
 
 	//pr_info("%s: iocb:%llx ",__func__, (u64)io_cb);
@@ -193,6 +191,7 @@ static ssize_t xdma_async_migrate_bo(struct platform_device *pdev,
 	}
 
 failed:
+	kfree(io_cb);
 	return ret;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -81,9 +81,6 @@ struct xocl_dev	{
 	struct xocl_dev_core	core;
 
 	struct list_head	ctx_list;
-	struct workqueue_struct	*wq;
-	struct xocl_work	works[XOCL_WORK_NUM];
-	struct mutex		wq_lock;
 
 	/*
 	 * Per xdev lock protecting client list and all client contexts in the

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1495,6 +1495,7 @@ int xocl_sync_bo_callback_ioctl(struct drm_device *dev,
 	struct scatterlist *sg;
 	void (*cb_func)(unsigned long cb_hndl, int err) = NULL;
 	void *cb_data = NULL;
+	bool cb_data_alloced = false;
 
 	u32 dir = (args->dir == DRM_XOCL_SYNC_BO_TO_DEVICE) ? 1 : 0;
 	struct drm_gem_object *gem_obj = xocl_gem_object_lookup(dev, filp,
@@ -1564,6 +1565,7 @@ int xocl_sync_bo_callback_ioctl(struct drm_device *dev,
 				ret = -ENOMEM;
 				goto out;
 			}
+			cb_data_alloced = true;
 			cb_func = xocl_free_sgt_callback;
 			((struct free_sgt_cb *)cb_data)->sgt = sgt;
 			((struct free_sgt_cb *)cb_data)->orig_func = (void *)args->cb_func;
@@ -1602,6 +1604,8 @@ clear:
 	}
 
 out:
+	if (cb_data_alloced)
+		kfree(cb_data);
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1491,11 +1491,12 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 	}
 
 	xocl_queue_work(xdev, XOCL_WORK_REFRESH_SUBDEV, 1);
-
+	/* Waiting for all subdev to be initialized before returning. */
+	flush_delayed_work(&xdev->core.works[XOCL_WORK_REFRESH_SUBDEV].work);
 
 	xdev->mig_cache_expire_secs = XDEV_DEFAULT_EXPIRE_SECS;
 
-    /* store link width & speed stats */
+	/* store link width & speed stats */
 	store_pcie_link_info(xdev);
 
 	return 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -271,7 +271,7 @@ static bool xclbin_downloaded(struct xocl_dev *xdev, xuid_t *xclbin_id)
 	bool ret = false;
 	int err = 0;
 	xuid_t *downloaded_xclbin =  NULL;
-	bool changed;
+	bool changed = false;
 
 	xocl_p2p_conf_status(xdev, &changed);
 	if (changed) {


### PR DESCRIPTION
Also fixed a few coverity issues.