### PR TITLE
xbutil2/xbmgmt2: Bash feedback changes

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -529,7 +529,7 @@ extern "C" {
         auto begin = current_section + 1;        // Point to the next section
         if (begin == end) { return nullptr; }
 
-        auto itr = std::find_if(begin, end, [kind](const axlf_section_header &sec) {return sec.m_sectionKind == (const uint32_t)kind;});
+        auto itr = std::find_if(begin, end, [kind](const axlf_section_header &sec) {return sec.m_sectionKind == static_cast<uint32_t>(kind);});
         return (itr!=end) ? &(*itr) : nullptr;
       }
     }

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB XBMGMT_V2_BASE_FILES
 file(GLOB XBMGMT_V2_SUBCMD_FILES
   "SubCmdProgram.cpp"
   "SubCmdReset.cpp"
-  "SubCmdStatus.cpp"
+  "SubCmdExamine.cpp"
   "SubCmdAdvanced.cpp"
   "OO_Clock.cpp"
   "OO_Config.cpp"

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -16,7 +16,7 @@
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
-#include "SubCmdStatus.h"
+#include "SubCmdExamine.h"
 #include "core/common/error.h"
 
 // Utilities
@@ -46,8 +46,8 @@ static const ReportCollection fullReportCollection = {
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
-SubCmdStatus::SubCmdStatus(bool _isHidden, bool _isDepricated, bool _isPreliminary)
-    : SubCmd("status", 
+SubCmdExamine::SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary)
+    : SubCmd("examine", 
              "Returns detail information for the specified device.")
 {
   const std::string longDescription = "This command will 'examine' the state of the system/device and will"
@@ -60,9 +60,9 @@ SubCmdStatus::SubCmdStatus(bool _isHidden, bool _isDepricated, bool _isPrelimina
 }
 
 void
-SubCmdStatus::execute(const SubCmdOptions& _options) const
+SubCmdExamine::execute(const SubCmdOptions& _options) const
 {
-  XBU::verbose("SubCommand: status");
+  XBU::verbose("SubCommand: examine");
 
   // -- Build up the report & format options
   const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'verbose' option*/);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.h
@@ -14,17 +14,17 @@
  * under the License.
  */
 
-#ifndef __SubCmdStatus_h_
-#define __SubCmdStatus_h_
+#ifndef __SubCmdExamine_h_
+#define __SubCmdExamine_h_
 
 #include "tools/common/SubCmd.h"
 
-class SubCmdStatus : public SubCmd {
+class SubCmdExamine : public SubCmd {
  public:
   virtual void execute(const SubCmdOptions &_options) const;
 
  public:
-  SubCmdStatus(bool _isHidden, bool _isDepricated, bool _isPreliminary);
+  SubCmdExamine(bool _isHidden, bool _isDepricated, bool _isPreliminary);
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -17,7 +17,7 @@
 // Sub Commands
 #include "SubCmdProgram.h"
 #include "SubCmdReset.h"
-#include "SubCmdStatus.h"
+#include "SubCmdExamine.h"
 #include "SubCmdAdvanced.h"
 
 // Supporting tools
@@ -52,7 +52,7 @@ int main( int argc, char** argv )
     subCommands.emplace_back(std::make_shared<   SubCmdProgram  >(false, false, false));
     subCommands.emplace_back(std::make_shared<     SubCmdReset  >(false, false, false));
     subCommands.emplace_back(std::make_shared<  SubCmdAdvanced  >(false, false,  true));
-    subCommands.emplace_back(std::make_shared<    SubCmdStatus  >(false, false, false));
+    subCommands.emplace_back(std::make_shared<   SubCmdExamine  >(false, false, false));
   }
 
   const std::string executable = "xbmgmt";

--- a/src/runtime_src/tools/scripts/setup.csh
+++ b/src/runtime_src/tools/scripts/setup.csh
@@ -65,10 +65,11 @@ else
     setenv PYTHONPATH $XILINX_XRT/python:$PYTHONPATH
 endif
 
-setenv XRT_TOOLS_NEXTGEN false
+# To use the newest version of the XRT tools, either uncomment or set 
+# the following environment variable in your profile:
+#   setenv XRT_TOOLS_NEXTGEN true
 
 echo "XILINX_XRT        : $XILINX_XRT"
 echo "PATH              : $PATH"
 echo "LD_LIBRARY_PATH   : $LD_LIBRARY_PATH"
 echo "PYTHONPATH        : $PYTHONPATH"
-echo "XRT_TOOLS_NEXTGEN : $XRT_TOOLS_NEXTGEN"

--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -29,14 +29,16 @@ if [[ $XILINX_XRT != *"/opt/xilinx/xrt" ]]; then
     return 1
 fi
 
+# To use the newest version of the XRT tools, either uncomment or set 
+# the following environment variable in your profile:
+#   export XRT_TOOLS_NEXTGEN=true
+
 export XILINX_XRT
 export LD_LIBRARY_PATH=$XILINX_XRT/lib:$LD_LIBRARY_PATH
 export PATH=$XILINX_XRT/bin:$PATH
 export PYTHONPATH=$XILINX_XRT/python:$PYTHONPATH
-export XRT_TOOLS_NEXTGEN=false
 
 echo "XILINX_XRT        : $XILINX_XRT"
 echo "PATH              : $PATH"
 echo "LD_LIBRARY_PATH   : $LD_LIBRARY_PATH"
 echo "PYTHONPATH        : $PYTHONPATH"
-echo "XRT_TOOLS_NEXTGEN : $XRT_TOOLS_NEXTGEN"


### PR DESCRIPTION
Work Done
------------
1. Removed setting the environment variable XRT_TOOLS_NEXTGEN from the setup scripts.
2. Rename xbmgmt command "status" to "examine"
3. Replaced a "C-Style" cast with a static_cast<> in the get_axlf_section() method.  For some compilers the "C-Style" cast was creating a compiler error.