### PR TITLE
Switch ReportAsyncError() to xrt::error APIs

### DIFF
--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -257,6 +257,13 @@ get_timestamp() const
   return handle->get_timestamp();
 }
 
+xrtErrorCode
+error::
+get_error_code() const
+{
+  return handle->get_error_code();
+}
+
 std::string
 error::
 to_string() const

--- a/src/runtime_src/core/include/experimental/xrt_error.h
+++ b/src/runtime_src/core/include/experimental/xrt_error.h
@@ -62,6 +62,15 @@ public:
   get_timestamp() const;
 
   /**
+   * get_error_code() - Get the error code for this error
+   *
+   * Return:  Underlying xrt error code
+   */
+  XCL_DRIVER_DLLESPEC
+  xrtErrorCode
+  get_error_code() const;
+
+  /**
    * to_string() - Convert error object into a formatted string
    *
    * Return:  Formatted string for error

--- a/src/runtime_src/core/tools/common/ReportAsyncError.cpp
+++ b/src/runtime_src/core/tools/common/ReportAsyncError.cpp
@@ -32,26 +32,32 @@ populate_async_error(const xrt_core::device * device)
 {
   boost::property_tree::ptree pt;
   boost::property_tree::ptree error_array;
-  auto dhdl = xrtDeviceOpenFromXcl(device->get_device_handle());
-  for (xrtErrorClass ecl = XRT_ERROR_CLASS_FIRST_ENTRY; ecl < XRT_ERROR_CLASS_LAST_ENTRY ; ecl = xrtErrorClass(ecl+1)) {
-    xrtErrorCode errorCode = 0;
-    uint64_t timestamp = 0;
-    int rval = xrtErrorGetLast(dhdl, ecl, &errorCode, &timestamp);
-    if (rval == 0 && errorCode && timestamp) {
-      boost::property_tree::ptree _pt;
-      boost::property_tree::ptree node;
-      xrt_core::error_int::get_error_code_to_json(errorCode, _pt);
-      node.put("time.epoch", timestamp);
-      node.put("time.timestamp", xrt_core::timestamp(timestamp/NanoSecondsPerSecond));
-      node.put("class", _pt.get<std::string>("class.string"));
-      node.put("module", _pt.get<std::string>("module.string"));
-      node.put("severity", _pt.get<std::string>("severity.string"));
-      node.put("driver", _pt.get<std::string>("driver.string"));
-      node.put("error_code.error_id", _pt.get<int>("number.code"));
-      node.put("error_code.error_msg", _pt.get<std::string>("number.string"));
-      error_array.push_back(std::make_pair("", node));
+  xrt::device xdevice(device->get_device_handle());
+  try {
+    for (xrtErrorClass ecl = XRT_ERROR_CLASS_FIRST_ENTRY; ecl < XRT_ERROR_CLASS_LAST_ENTRY ; ecl = xrtErrorClass(ecl+1)) {
+      xrt::error error(xdevice, ecl);
+      auto error_code = error.get_error_code();
+      auto timestamp = error.get_timestamp();
+      if (error_code && timestamp) {
+        boost::property_tree::ptree _pt;
+        boost::property_tree::ptree node;
+        xrt_core::error_int::get_error_code_to_json(error_code, _pt);
+        node.put("time.epoch", timestamp);
+        node.put("time.timestamp", xrt_core::timestamp(timestamp/NanoSecondsPerSecond));
+        node.put("class", _pt.get<std::string>("class.string"));
+        node.put("module", _pt.get<std::string>("module.string"));
+        node.put("severity", _pt.get<std::string>("severity.string"));
+        node.put("driver", _pt.get<std::string>("driver.string"));
+        node.put("error_code.error_id", _pt.get<int>("number.code"));
+        node.put("error_code.error_msg", _pt.get<std::string>("number.string"));
+        error_array.push_back(std::make_pair("", node));
+      }
     }
   }
+  catch (const std::exception&) {
+    // ignore, likely that async error not supported
+  }
+
   pt.add_child("errors", error_array);
 
   return error_array;


### PR DESCRIPTION
The C++ error APIs propagate errors as exceptions, which gives caller
chance to catch and take corrective action.  The C-APIs, by nature of
C, return error codes after printing the exception message.