### PR TITLE
Amend #4233 and #3939

### DIFF
--- a/src/runtime_src/core/common/time.cpp
+++ b/src/runtime_src/core/common/time.cpp
@@ -19,6 +19,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <ctime>
 
 #ifdef _WIN32
 # pragma warning ( disable : 4996 )

--- a/src/runtime_src/core/common/time.h
+++ b/src/runtime_src/core/common/time.h
@@ -19,7 +19,6 @@
 
 #include "core/common/config.h"
 #include <string>
-#include <ctime>
 
 namespace xrt_core {
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -49,7 +49,7 @@ struct bdf
   static result_type
   get(const xrt_core::device* device, key_type)
   {
-    return {0,0,0};
+    return std::make_tuple(0,0,0);
   }
 
 };


### PR DESCRIPTION
#4233: Revert change that move <ctime> from compilation unit to header

#3939: Fix edge compilation on x64