### PR TITLE
Don't reset ERT and soft kernels if loading same xclbin

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4263,8 +4263,7 @@ static int config_scu(struct platform_device *pdev,
 			exec->num_sk_cus++;
 			strncpy(xert->scu_name[i], (char *)scmd->sk_name,
 				sizeof(xert->scu_name[0]) - 1);
-			if (strlen(xert->scu_name[i]) == 0)
-				strcpy(xert->scu_name[i], " ");
+			strcpy(xert->scu_name[i], " ");
 		} else {
 			if (strlen(xert->scu_name[i]) == 0)
 				continue;

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -28,6 +28,7 @@
 #include "core/common/bo_cache.h"
 #include "core/common/config_reader.h"
 #include "core/common/AlignedAllocator.h"
+#include "core/include/experimental/xclbin_util.h"
 
 #include "plugin/xdp/hal_profile.h"
 #include "plugin/xdp/hal_api_interface.h"
@@ -544,6 +545,13 @@ shim(unsigned index)
   , mCuMaps(128, nullptr)
 {
   init(index);
+}
+
+int shim::get_dev_xclbin_uuid(xuid_t out)
+{
+    auto tmp_uuid = mCoreDevice->get_xclbin_uuid();
+    memcpy(out, &tmp_uuid, sizeof(xuid_t));
+    return 0;
 }
 
 int shim::dev_init()
@@ -2320,6 +2328,20 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
     xdphal::flush_device(handle) ;
     xdpaie::flush_aie_device(handle) ;
 
+    bool same_xclbin = false;
+    xuid_t new_xclbin_uuid;
+    xclbin_uuid((char *)buffer, new_xclbin_uuid);
+    xrt::uuid new_xclbin_uuid_xrt(new_xclbin_uuid);
+
+    xuid_t dev_uuid;
+    drv->get_dev_xclbin_uuid(dev_uuid);
+    if (new_xclbin_uuid_xrt) {
+        //This is not a legacy xclbin without uuid
+        if(xrt::uuid(dev_uuid) == new_xclbin_uuid_xrt) {
+            same_xclbin = true;
+        }
+    }
+
 #ifdef DISABLE_DOWNLOAD_XCLBIN
     int ret = 0;
 #else
@@ -2334,7 +2356,10 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
       xdpaie::update_aie_device(handle);
 
 #ifndef DISABLE_DOWNLOAD_XCLBIN
-      ret = xrt_core::scheduler::init(handle, buffer);
+      if (!same_xclbin) {
+          //Do not reset and re-init ERT & soft kernels if same xclbin
+          ret = xrt_core::scheduler::init(handle, buffer);
+      }
       START_DEVICE_PROFILING_CB(handle);
 #endif
     }

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -59,6 +59,7 @@ public:
     shim(unsigned index);
     void init(unsigned index);
 
+    int get_dev_xclbin_uuid(xuid_t out);
     static int xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* format, va_list args1);
     // Raw unmanaged read/write on the entire PCIE user BAR
     size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);


### PR DESCRIPTION
Don't reset ERT and soft kernels if loading same xclbin