### PR TITLE
xbutil2/xbmgmt2 : Fixed various bash reported issues

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -545,7 +545,7 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
 
 std::string 
 XBUtilities::create_suboption_list_string( const ReportCollection &_reportCollection, 
-                                           bool _addVerboseOption)
+                                           bool _addAllOption)
 {
   VectorPairStrings reportDescriptionCollection;
 
@@ -554,8 +554,8 @@ XBUtilities::create_suboption_list_string( const ReportCollection &_reportCollec
     reportDescriptionCollection.emplace_back(report->getReportName(), report->getShortDescription());
 
   // 'verbose' option
-  if (_addVerboseOption) 
-    reportDescriptionCollection.emplace_back("verbose", "All known reports are produced");
+  if (_addAllOption) 
+    reportDescriptionCollection.emplace_back("all", "All known reports are produced");
 
   // Sort the collection
   sort(reportDescriptionCollection.begin(), reportDescriptionCollection.end(), 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -65,16 +65,13 @@ namespace XBUtilities {
     create_usage_string( const boost::program_options::options_description &_od,
                          const boost::program_options::positional_options_description & _pod );
 
-  std::string 
-    create_suboption_list_string(const ReportCollection &_reportCollection, bool _addAll = false);
-
   using VectorPairStrings = std::vector< std::pair< std::string, std::string > >;
 
   std::string 
     create_suboption_list_string(const VectorPairStrings &_collection);
 
   std::string 
-    create_suboption_list_string(const ReportCollection &_reportCollection, bool _addVerboseOption);
+    create_suboption_list_string(const ReportCollection &_reportCollection, bool _addAllOption);
 
   std::string 
     create_suboption_list_string(const Report::SchemaDescriptionVector &_formatCollection);

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -54,10 +54,8 @@ endif()
 add_executable(${XBMGMT2_NAME} ${XBMGMT_V2_SRCS})
 
 # Determine what functionality should be added
-if(WIN32)
-  target_compile_definitions(${XBMGMT2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
-else()
-  target_compile_definitions(${XBMGMT2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
+if (${XRT_NATIVE_BUILD} STREQUAL "yes")
+  target_compile_definitions(${XBMGMT2_NAME} PUBLIC ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
 endif()
 
 # Add the supporting libraries

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -65,7 +65,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   XBU::verbose("SubCommand: examine");
 
   // -- Build up the report & format options
-  const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'verbose' option*/);
+  const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
   const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
   // Option Variables

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -55,12 +55,9 @@ endif()
 add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
 
 # Determine what functionality should be added
-if(WIN32)
-  target_compile_definitions(${XBUTIL2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
-else()
-  target_compile_definitions(${XBUTIL2_NAME} PUBLIC ENABLE_DEPRECATED_2020_1_SUBCMDS)
+if (${XRT_NATIVE_BUILD} STREQUAL "yes")
+  target_compile_definitions(${XBUTIL2_NAME} PUBLIC ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
 endif()
-
 
 # Add the supporting libraries
 if(WIN32)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -49,19 +49,23 @@ namespace po = boost::program_options;
 #include "tools/common/ReportAsyncError.h"
 // #include "tools/common/ReportPlatform.h"
 
-// Note: Please insert the reports in the order to be displayed (current alphabetical)
-static const ReportCollection fullReportCollection = {
-  std::make_shared<ReportElectrical>(),
-  std::make_shared<ReportMechanical>(),
-  std::make_shared<ReportAie>(),
-  std::make_shared<ReportMemory>(),
-  std::make_shared<ReportFirewall>(),
-  std::make_shared<ReportHost>(),
-  std::make_shared<ReportCu>(),
-  std::make_shared<ReportThermal>(),
-  std::make_shared<ReportDebugIpStatus>(),
-  std::make_shared<ReportAsyncError>()
-};
+// Note: Please insert the reports in the order to be displayed (alphabetical)
+  static ReportCollection fullReportCollection = {
+  // Common reports
+    std::make_shared<ReportAie>(),
+    std::make_shared<ReportMemory>(),
+    std::make_shared<ReportHost>(),
+    std::make_shared<ReportCu>(),
+    std::make_shared<ReportDebugIpStatus>(),
+    std::make_shared<ReportAsyncError>(),
+  // Native only reports
+  #ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
+    std::make_shared<ReportElectrical>(),
+    std::make_shared<ReportMechanical>(),
+    std::make_shared<ReportFirewall>(),
+    std::make_shared<ReportThermal>(),
+  #endif
+  };
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
@@ -84,7 +88,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   XBU::verbose("SubCommand: examine");
 
   // -- Build up the report & format options
-  const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'verbose' option*/);
+  const std::string reportOptionValues = XBU::create_suboption_list_string(fullReportCollection, true /*add 'all' option*/);
   const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
   // Option Variables

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -42,7 +42,11 @@ int main( int argc, char** argv )
     // Syntax: SubCmdClass( IsHidden, IsDepricated, IsPreliminary)
     subCommands.emplace_back(std::make_shared<  SubCmdExamine >(false, false, false));
     subCommands.emplace_back(std::make_shared<  SubCmdProgram >(false, false, false));
+
+#ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
     subCommands.emplace_back(std::make_shared< SubCmdValidate >(false,  false, false));
+#endif
+
     subCommands.emplace_back(std::make_shared< SubCmdAdvanced >(true,  false, true ));
     subCommands.emplace_back(std::make_shared<    SubCmdReset >(true,  false, false));
   }


### PR DESCRIPTION
Work Done
---------
+ Renamed report type "verbose" to "all"
+ Enabled the build flow to "optionally" add "native" reports.  Doing so prevents "native" reports from being options for "non-native" builds.
+ Enabled the build flow to "optionally" add "native" commands.  xbutil validate is now a native command.
+ Removed CMakeLists.txt dead code