### PR TITLE
Added support for HBM backward compatibility of existing application

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -869,6 +869,14 @@ XclBinUtilities::createMemoryBankGrouping(XclBin & xclbin)
       // Transform and group the memories
       transformMemoryBankGroupingCollections(connectivity, groupTopology, groupConnectivity);
 
+      // Perform some DRC checks on the memory grouping and connectivity produced before marging to group connectivity
+      validateMemoryBankGroupEntries((unsigned int) memTopology.size(), groupTopology, groupConnectivity);
+
+      // Merge connectivity information into the group connectivity
+      for (auto & connection : connectivity) {
+	      groupConnectivity.push_back(connection);
+      }
+
       // Re-create the property tree, create and re-populate the Group Connectivity section, and add it.
       {
         boost::property_tree::ptree ptConnection;
@@ -908,9 +916,6 @@ XclBinUtilities::createMemoryBankGrouping(XclBin & xclbin)
     pGroupTopologySection->readJSONSectionImage(ptTop);
     xclbin.addSection(pGroupTopologySection);
   }
-
-  // Perform some DRC checks on the memory grouping and connectivity produced
-  validateMemoryBankGroupEntries((unsigned int) memTopology.size(), groupTopology, groupConnectivity);
 }
 
 

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -729,9 +729,9 @@ get_cu_memidx() const
       for (auto& cu : get_cu_range())
         mask &= cu->get_memidx_intersect();
 
-	  // Select first common Group index if present prior to bank index.
-	  // Traverse from the higher order of the mask as groups comes in higher order
-      for (size_t idx=mask.size() - 1; idx >= 0; --idx) {
+      // Select first common Group index if present prior to bank index.
+      // Traverse from the higher order of the mask as groups comes in higher order
+      for (int idx=mask.size() - 1; idx >= 0; --idx) {
         if (mask.test(idx)) {
           m_cu_memidx = idx;
           break;

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -729,8 +729,9 @@ get_cu_memidx() const
       for (auto& cu : get_cu_range())
         mask &= cu->get_memidx_intersect();
 
-      // select first common memory bank index if any
-      for (size_t idx=0; idx<mask.size(); ++idx) {
+	  // Select first common Group index if present prior to bank index.
+	  // Traverse from the higher order of the mask as groups comes in higher order
+      for (size_t idx=mask.size() - 1; idx >= 0; --idx) {
         if (mask.test(idx)) {
           m_cu_memidx = idx;
           break;


### PR DESCRIPTION
- This supports the backward compatibility of the existing applications.
- Application code with EXT pointer will still work with this change. 
- It is advisable not to use EXT pointer in the application. 