### PR TITLE
Amend #4267

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -826,13 +826,15 @@ class kernel_impl
   int32_t
   get_arg_grpid(const connectivity* cons, int32_t argidx, int32_t ipidx)
   {
-    for (int count = (cons ? cons->m_count-1 : -1); count >=0; --count) {
-      auto& con = cons->m_connection[count];
-      if (con.m_ip_layout_index != ipidx)
-        continue;
-      if (con.arg_index != argidx)
-        continue;
-      return con.mem_data_index;
+    if (cons) {
+      for (int count = cons->m_count-1; count >=0; --count) {
+        auto& con = cons->m_connection[count];
+        if (con.m_ip_layout_index != ipidx)
+          continue;
+        if (con.arg_index != argidx)
+          continue;
+        return con.mem_data_index;
+      }
     }
     return std::numeric_limits<int32_t>::max();
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -818,11 +818,15 @@ class kernel_impl
       amend_fa_args();
   }
 
-  // Traverse xclbin connectivity section and find
+  // Traverse xclbin connectivity section and find connectivity
+  // for {argument,ipidx}.  Connectivity is checked from high order
+  // of connectivity entries, since these entries represent groups
+  // formed from low order connectivity if and only if groups are
+  // used
   int32_t
   get_arg_grpid(const connectivity* cons, int32_t argidx, int32_t ipidx)
   {
-    for (int32_t count=0; cons && count <cons->m_count; ++count) {
+    for (int count = (cons ? cons->m_count-1 : -1); count >=0; --count) {
       auto& con = cons->m_connection[count];
       if (con.m_ip_layout_index != ipidx)
         continue;


### PR DESCRIPTION
Native kernel API group index should look for CU connectivity in reverse
order of the connectivity entries.

This ensures that merged group entries will be found by default since
group entries are appended after the original (no merged) CONNECTIVITY
section entries.