### PR TITLE
CR-1080882 M2M fail : usability improvement

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/m2m.c
@@ -75,9 +75,9 @@ static int copy_bo(struct platform_device *pdev, uint64_t src_paddr,
 	    (src_paddr % KDMA_BLOCK_SIZE) ||
 	    (size % KDMA_BLOCK_SIZE)) {
 		M2M_ERR(m2m, "cannot use KDMA. dst: %s, src: %s, size: %s",
-		    (dst_paddr % KDMA_BLOCK_SIZE) ? "not aligned" : "aligned",
-		    (src_paddr % KDMA_BLOCK_SIZE) ? "not aligned" : "aligned",
-		    (size % KDMA_BLOCK_SIZE) ? "not aligned" : "aligned");
+		    (dst_paddr % KDMA_BLOCK_SIZE) ? "not 64-bit aligned" : "aligned",
+		    (src_paddr % KDMA_BLOCK_SIZE) ? "not 64-bit aligned" : "aligned",
+		    (size % KDMA_BLOCK_SIZE) ? "not 64-bit aligned" : "aligned");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
For request 1, so far XRT driver will through out an error code like -22 (EINVAL) to caller. For more error code:
https://www-numi.fnal.gov/offline_software/srt_public_context/WebDocs/Errors/unix_system_errors.html
User land code can use code like: strerror(errno) to try to get human readable reason.

However, XRT doesn't have a way to through out customized root cause from kernel back to userland yet.

For request 2, XRT will enhance the dmesg.