### PR TITLE
CR-1080628 Set kernel arg with sub buffer fails if xclbin has multiple kernels

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -640,7 +640,8 @@ allocate_buffer_object(memory* mem, memidx_type memidx)
 
   // sub buffer
   if (auto parent = mem->get_sub_buffer_parent()) {
-    auto boh = parent->get_buffer_object(this);
+    // parent buffer should be allocated in bank selected by sub-buffer
+    auto boh = parent->get_buffer_object(this, memidx);
     auto pmemidx = get_boh_memidx(boh);
     if (pmemidx.test(memidx)) {
       auto offset = mem->get_sub_buffer_offset();

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -321,11 +321,20 @@ public:
    *
    * @param device
    *   The device object that creates the buffer object
+   * @param subidx
+   *   The memory bank index required by sub-buffer
    * @return
    *   The buffer object
+   *
+   * The sub-buffer index is used when allocation of this boh is
+   * originating from a sub-buffer allocation.  It means that the
+   * sub-buffer is used as a kernel argument with the 'subidx'
+   * conectitivy.  The parent buffer is the one that is physically
+   * allocated and it must be allocated in the bank indicated by 
+   * the sub buffer.
    */
   virtual buffer_object_handle
-  get_buffer_object(device* device);
+  get_buffer_object(device* device, memidx_type subidx=-1);
 
   /**
    * Get the buffer object on argument device or error out if none
@@ -466,7 +475,7 @@ public:
 
 private:
   memidx_type
-  get_memidx_nolock(const device* d) const;
+  get_memidx_nolock(const device* d, memidx_type subidx=-1) const;
 
   memidx_type
   get_ext_memidx_nolock(const xclbin& xclbin) const;


### PR DESCRIPTION
Using sub-buffers with deferred allocation (until clSetKernelArg) was
broken since inception of sub buffer support in XRT.

When a buffer is allocated via set kernel arg, the CU connectivity is
used to determine where the buffer should be allocated.  If the buffer
is a sub-buffer, it is the parent buffer than must be allocated.  But
since the sub-buffer was used to look up connectivity, only this
buffer has the has the memory bank index.  So this PR contains fixes
that will pass the computed bank index to the parent buffer when it is
allocated.