### PR TITLE
skip scheduler init removed

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -29,7 +29,6 @@
 #include "core/common/config_reader.h"
 #include "core/common/query_requests.h"
 #include "core/common/AlignedAllocator.h"
-#include "core/include/experimental/xclbin_util.h"
 
 #include "plugin/xdp/hal_profile.h"
 #include "plugin/xdp/hal_api_interface.h"
@@ -546,13 +545,6 @@ shim(unsigned index)
   , mCuMaps(128, nullptr)
 {
   init(index);
-}
-
-int shim::get_dev_xclbin_uuid(xuid_t out)
-{
-    auto tmp_uuid = mCoreDevice->get_xclbin_uuid();
-    memcpy(out, &tmp_uuid, sizeof(xuid_t));
-    return 0;
 }
 
 int shim::dev_init()

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2345,12 +2345,11 @@ int xclLoadXclBin(xclDeviceHandle handle, const xclBin *buffer)
 
 #ifndef DISABLE_DOWNLOAD_XCLBIN
       //scheduler::init can not be skipped even for same_xclbin
-      //as in multiplt process stress tests it fails as
-      //below init step is without a lock with above driver load xclbin.
-      //New kds fixes this by ensuring that scheduler init is done by driver itself
+      //as in multiple process stress tests it fails as
+      //below init step is without a lock with above driver load xclbin step.
+      //New KDS fixes this by ensuring that scheduler init is done by driver itself
       //along with icap download in single command call and then below init step in user space
       //is ignored
-      //Do not reset and re-init ERT & soft kernels if same xclbin
       ret = xrt_core::scheduler::init(handle, buffer);
       START_DEVICE_PROFILING_CB(handle);
 #endif

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -59,7 +59,6 @@ public:
     shim(unsigned index);
     void init(unsigned index);
 
-    int get_dev_xclbin_uuid(xuid_t out);
     static int xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* format, va_list args1);
     // Raw unmanaged read/write on the entire PCIE user BAR
     size_t xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size);


### PR DESCRIPTION
removed as stress test fail in multiple process case. As no lock into load_xclbin and scheduler::init in user space