### PR TITLE
rename conflicting sysfs node "kds_stat"

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -91,7 +91,7 @@ static ssize_t kds_custat_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(kds_custat);
 
-static ssize_t kds_stat_show(struct device *dev,
+static ssize_t kds_stats_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
@@ -130,7 +130,7 @@ static ssize_t kds_stat_show(struct device *dev,
 
 	return sz;
 }
-static DEVICE_ATTR_RO(kds_stat);
+static DEVICE_ATTR_RO(kds_stats);
 
 static ssize_t kds_skstat_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
@@ -359,7 +359,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_xclbinid.attr,
 	&dev_attr_kds_numcus.attr,
 	&dev_attr_kds_custat.attr,
-	&dev_attr_kds_stat.attr,
+	&dev_attr_kds_stats.attr,
 	&dev_attr_kds_skstat.attr,
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,


### PR DESCRIPTION
remove conflict of name (kds_stat) between 
https://github.com/Xilinx/XRT/blob/master/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c#L133 
https://github.com/Xilinx/XRT/blob/master/src/runtime_src/core/edge/drm/zocl/zocl_kds.c#L62
else we get crash on enabling kds_mode=1

```
# insmod /lib/modules/5.4.0-xilinx-v2020.1/extra/zocl.ko  kds_mode=1
[ 2820.236922] [drm] Probing for xlnx,zocl
[ 2820.240937] zocl-drm amba:zyxclmm_drm: IRQ index 32 not found
[ 2820.246801] [drm] FPGA programming device pcap founded.
[ 2820.252019] [drm] PR Isolation addr 0x0
xf86: remove device 0 /sys/devices/platform/amba/amba:zyxclmm_dr[ 2820.252280] [drm] Initialized zocl 2018.2.1 20180313 for amba:zyxclmm_drm on minor 1
m/drm/card1
[ 2820.269469] sysfs: cannot create duplicate filename '/devices/platform/amba/amba:zyxclmm_drm/kds_stat'
[ 2820.279834] CPU: 0 PID: 1315 Comm: insmod Tainted: G           O      5.4.0-xilinx-v2020.1 #1
[ 2820.288347] Hardware name: ZynqMP ZCU102 Rev1.0 (DT)
[ 2820.293294] Call trace:
[ 2820.295731]  dump_backtrace+0x0/0x140
[ 2820.299381]  show_stack+0x14/0x20
```