### PR TITLE
allow enable ert only when ert subdev exist

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -929,7 +929,13 @@ void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
 	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
 
-	/* Skip first 4 control registers */
+	/* Copy resigter map into info and isize is the size of info in bytes.
+	 *
+	 * Based on ert.h, ecmd->count is the number of words following header.
+	 * In ert_start_kernel_cmd, the CU register map size is
+	 * (count - (1 + extra_cu_masks)) and I would like to Skip
+	 * first 4 control registers
+	 */
 	xcmd->isize = (ecmd->count - xcmd->num_mask - 4) * sizeof(u32);
 	memcpy(xcmd->info, &ecmd->data[4 + ecmd->extra_cu_masks], xcmd->isize);
 }
@@ -945,6 +951,11 @@ void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
 	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
 
+	/* Copy descriptor into info and isize is the size of info in bytes.
+	 *
+	 * Based on ert.h, ecmd->count is the number of words following header.
+	 * The descriptor size is (count - (1 + extra_cu_masks)).
+	 */
 	xcmd->isize = (ecmd->count - xcmd->num_mask) * sizeof(u32);
 	memcpy(xcmd->info, &ecmd->data[ecmd->extra_cu_masks], xcmd->isize);
 }

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -387,7 +387,7 @@ int kds_init_sched(struct kds_sched *kds)
 	mutex_init(&kds->cu_mgmt.lock);
 	kds->num_client = 0;
 	kds->bad_state = 0;
-	kds->ert_disable = 0;
+	kds->ert_disable = 1;
 
 	return 0;
 }
@@ -736,13 +736,13 @@ int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu)
 int kds_init_ert(struct kds_sched *kds, struct kds_ert *ert)
 {
 	kds->ert = ert;
-	/* Do anything necessary */
+	/* By default enable ERT if it exist */
+	kds->ert_disable = 0;
 	return 0;
 }
 
 int kds_fini_ert(struct kds_sched *kds)
 {
-	/* TODO: implement this */
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1937,6 +1937,7 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_XMC_USER_U2,			\
 			XOCL_DEVINFO_AF_USER,				\
 			XOCL_DEVINFO_INTC,				\
+			XOCL_DEVINFO_ERT_USER,				\
 		})
 
 #define USER_RES_SMARTN							\
@@ -2104,6 +2105,7 @@ struct xocl_subdev_map {
 		.subdev_info	= MGMT_RES_U2,				\
 		.subdev_num = ARRAY_SIZE(MGMT_RES_U2),			\
 		.flash_type = FLASH_TYPE_SPI,				\
+		.sched_bin = "xilinx/sched.bin",			\
 	}
 
 #define	XOCL_BOARD_MGMT_VERSAL						\
@@ -2582,7 +2584,6 @@ struct xocl_subdev_map {
 		.subdev_info	= RES_MGMT_U2_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_MGMT_U2_VSEC),		\
 		.flash_type = FLASH_TYPE_SPI,				\
-		.sched_bin = "xilinx/sched.bin",			\
 	}
 
 #define XOCL_BOARD_U2_USER_RAPTOR2					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -357,7 +357,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		}
 
 		/* Before scheduler config options are removed from xrt.ini */
-		if (to_cfg_pkg(ecmd)->ert)
+		if (to_cfg_pkg(ecmd)->ert && XDEV(xdev)->kds.ert)
 			XDEV(xdev)->kds.ert_disable = 0;
 		else
 			XDEV(xdev)->kds.ert_disable = 1;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -338,9 +338,15 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	print_ecmd_info(ecmd);
 #endif
 
-	/* TODO: one ecmd to one xcmd now. Maybe we will need
-	 * one ecmd to multiple xcmds
+	/* xcmd->type is the only thing determine who to handle this command.
+	 * If ERT is supported, use ERT as default handler.
+	 * It could be override later if some command needs specific handler.
 	 */
+	if (XDEV(xdev)->kds.ert_disable)
+		xcmd->type = KDS_CU;
+	else
+		xcmd->type = KDS_ERT;
+
 	switch (ecmd->opcode) {
 	case ERT_CONFIGURE:
 		cfg_ecmd2xcmd(to_cfg_pkg(ecmd), xcmd);
@@ -357,16 +363,21 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		}
 
 		/* Before scheduler config options are removed from xrt.ini */
-		if (to_cfg_pkg(ecmd)->ert && XDEV(xdev)->kds.ert)
+		if (to_cfg_pkg(ecmd)->ert && XDEV(xdev)->kds.ert) {
 			XDEV(xdev)->kds.ert_disable = 0;
-		else
+			xcmd->type = KDS_ERT;
+		} else {
 			XDEV(xdev)->kds.ert_disable = 1;
+			xcmd->type = KDS_CU;
+		}
 		break;
 	case ERT_START_CU:
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_START_FA:
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+		/* ERT doesn't support Fast adapter command */
+		xcmd->type = KDS_CU;
 		break;
 	case ERT_START_COPYBO:
 		ret = copybo_ecmd2xcmd(xdev, filp, to_copybo_pkg(ecmd), xcmd);
@@ -380,11 +391,6 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		xcmd->cb.free(xcmd);
 		return -EINVAL;
 	}
-
-	if (XDEV(xdev)->kds.ert_disable)
-		xcmd->type = KDS_CU;
-	else
-		xcmd->type = KDS_ERT;
 
 	xcmd->cb.notify_host = notify_execbuf;
 	xcmd->gem_obj = obj;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -345,6 +345,10 @@ ert_disable_store(struct device *dev, struct device_attribute *da,
 		return -EINVAL;
 	}
 
+	/* If ERT subdev doesn't present, cound not enable ERT */
+	if (!XDEV(xdev)->kds.ert)
+		disable = 1;
+
 	XDEV(xdev)->kds.ert_disable = disable;
 	mutex_unlock(&XDEV(xdev)->kds.lock);
 


### PR DESCRIPTION
Since ERT is by default enable in xrt.ini and U.2 shell doesn't support ERT, it would cause kernel panic without this fix. 