### PR TITLE
CR-1075936 : Using subset of HBM banks on different ports hangs in hw emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/common_em/memorymanager.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/memorymanager.cxx
@@ -47,6 +47,16 @@ namespace xclemulation {
     if(mChildMemories.size())
     {
 	    size_t remainingSize = size;
+	    // Check whether sufficient memory available before allocation
+	    for (auto it:mChildMemories)
+	    {
+		    size_t sizeToBeAllocated = (it->freeSize() <= remainingSize) ? it->freeSize() : remainingSize;
+		    remainingSize = remainingSize - sizeToBeAllocated;
+	    }
+	    if(remainingSize != 0)
+		    return mNull;
+
+	    remainingSize = size;
 	    for (auto it:mChildMemories)
 	    {
 		    size_t sizeToBeAllocated = (it->freeSize() <= remainingSize) ? it->freeSize() : remainingSize;


### PR DESCRIPTION
-- Added a check for availability of requested memory size before allocation