### PR TITLE
disable interrupt if enable_flat is true

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -355,6 +355,13 @@ get_xma_cpu_mode()
   return value;
 }
 
+inline bool
+get_enable_flat()
+{
+  static unsigned int value = detail::get_bool_value("Runtime.enable_flat",false);
+  return value;
+}
+
 /**
  * Enable / Disable kernel driver scheduling when running in hardware.
  * If disabled, xrt will be scheduling either using the software scheduler
@@ -382,7 +389,12 @@ get_ert()
 inline bool
 get_ert_polling()
 {
-  static bool value = detail::get_bool_value("Runtime.ert_polling",false);
+  /**
+   * enable_flat is flag added for embedded platform where it load bitstream after boot
+   * but this feature does not support interrupt mode as interrupt controller exist in pl and
+   * is configured at boot time. So if enable_flat is true, polling mode should be enabled default.
+   */
+  static bool value = get_enable_flat() || detail::get_bool_value("Runtime.ert_polling",false);
   return value;
 }
 
@@ -438,13 +450,6 @@ inline bool
 get_enable_pr()
 {
   static unsigned int value = detail::get_bool_value("Runtime.enable_pr",true);
-  return value;
-}
-
-inline bool
-get_enable_flat()
-{
-  static unsigned int value = detail::get_bool_value("Runtime.enable_flat",false);
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -358,7 +358,7 @@ get_xma_cpu_mode()
 inline bool
 get_enable_flat()
 {
-  static unsigned int value = detail::get_bool_value("Runtime.enable_flat",false);
+  static bool value = detail::get_bool_value("Runtime.enable_flat",false);
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -390,9 +390,10 @@ inline bool
 get_ert_polling()
 {
   /**
-   * enable_flat is flag added for embedded platform where it load bitstream after boot
-   * but this feature does not support interrupt mode as interrupt controller exist in pl and
-   * is configured at boot time. So if enable_flat is true, polling mode should be enabled default.
+   * enable_flat flag is added for embedded platforms where it load full bitstream after boot.
+   * This feature does not support interrupt mode as interrupt controller exist in pl 
+   * and is configured at boot time. 
+   * So if enable_flat is true, polling mode should be enabled by default.
    */
   static bool value = get_enable_flat() || detail::get_bool_value("Runtime.ert_polling",false);
   return value;


### PR DESCRIPTION
enable_flat flag is added for embedded platforms where it load full bitstream after boot. This feature does not support interrupt mode as interrupt controller exist in pl and is configured at boot time. So if enable_flat is true, polling mode should be enabled by default.