### PR TITLE
soft kernels: Send xclbin uuid with config n unconfig commands to zocl

### DIFF
--- a/src/runtime_src/core/common/scheduler.cpp
+++ b/src/runtime_src/core/common/scheduler.cpp
@@ -196,6 +196,7 @@ init(xclDeviceHandle handle, const axlf* top)
       sk.symbol_name.copy(reinterpret_cast<char*>(scmd->sk_name), 31);
       scmd->sk_addr = skbo->prop.paddr;
       scmd->sk_size = skbo->prop.size;
+      uuid_copy(scmd->uuid, uuid);
       std::memcpy(skbo->data, sk.sk_buf, sk.size);
       if (xclSyncBO(handle, skbo->bo, XCL_BO_SYNC_BO_TO_DEVICE, sk.size, 0))
 	    throw std::runtime_error("unable to synch BO to device");

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -54,7 +54,12 @@
 #ifdef _WIN32
 # pragma warning( push )
 # pragma warning( disable : 4201 )
+# include "windows/uuid.h"
+#else
+#include "/usr/include/uuid/uuid.h"
+typedef uuid_t xuid_t;
 #endif
+
 
 #define to_cfg_pkg(pkg) \
     ((struct ert_configure_cmd *)(pkg))
@@ -290,6 +295,7 @@ struct ert_configure_sk_cmd {
   uint32_t sk_size;		/* soft kernel size */
   uint32_t sk_name[8];		/* soft kernel name */
   uint64_t sk_addr;
+  xuid_t   uuid;
 };
 
 /**
@@ -318,6 +324,7 @@ struct ert_unconfigure_sk_cmd {
   /* payload */
   uint32_t start_cuidx;
   uint32_t num_cus;
+  xuid_t   uuid;
 };
 
 /**

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -54,10 +54,6 @@
 #ifdef _WIN32
 # pragma warning( push )
 # pragma warning( disable : 4201 )
-# include "windows/uuid.h"
-#else
-#include "/usr/include/uuid/uuid.h"
-typedef uuid_t xuid_t;
 #endif
 
 
@@ -295,7 +291,7 @@ struct ert_configure_sk_cmd {
   uint32_t sk_size;		/* soft kernel size */
   uint32_t sk_name[8];		/* soft kernel name */
   uint64_t sk_addr;
-  xuid_t   uuid;
+  unsigned char   uuid[16];//xuid_t or uuid/uuid.h doesn't compile for zocl
 };
 
 /**
@@ -324,7 +320,7 @@ struct ert_unconfigure_sk_cmd {
   /* payload */
   uint32_t start_cuidx;
   uint32_t num_cus;
-  xuid_t   uuid;
+  unsigned char   uuid[16];
 };
 
 /**


### PR DESCRIPTION
soft kernels: Send xclbin uuid with config n unconfig commands to zocl
This will be used in zocl to check which xlcbin soft kernels are used and to avoid killing of soft kernels in multi-process scenario
Currently zocl has no check for xclbin uuid