### PR TITLE
CR-1081090 Memory leak happens in hardware for AIE GMIO design.

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -258,7 +258,7 @@ submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum 
   /*
    * We are safe to release the exported BO DMA Buf here.
    * 1. The physical address of BO is set to AIE register already;
-   * 2. The reference count of the buffer is hold by BO itself.
+   * 2. The reference count of the buffer is held by BO itself.
    */
   clear_bd(bd);
 }

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -231,7 +231,8 @@ submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum 
     }
   }
 
-  BD bd = dmap->dma_chan[chan].idle_bds.front();
+  BD_scope bd_scope(dmap->dma_chan[chan].idle_bds.front(), this);
+  auto& bd = bd_scope.get();
   dmap->dma_chan[chan].idle_bds.pop();
   prepare_bd(bd, bo);
 
@@ -254,13 +255,6 @@ submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum 
   /* Enqueue BD */
   XAie_DmaChannelPushBdToQueue(devInst, shim_tile, pchan, gmdir, bd.bd_num);
   dmap->dma_chan[chan].pend_bds.push(bd);
-
-  /*
-   * We are safe to release the exported BO DMA Buf here.
-   * 1. The physical address of BO is set to AIE register already;
-   * 2. The reference count of the buffer is held by BO itself.
-   */
-  clear_bd(bd);
 }
 
 void

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -27,8 +27,8 @@
 #include <sys/mman.h>
 #endif
 
-#include <iostream>
 #include <cerrno>
+#include <iostream>
 
 namespace zynqaie {
 

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -19,9 +19,9 @@
 #ifndef xrt_core_edge_user_aie_h
 #define xrt_core_edge_user_aie_h
 
-#include <vector>
-#include <queue>
 #include <memory>
+#include <queue>
+#include <vector>
 
 #include "core/common/device.h"
 #include "core/edge/common/aie_parser.h"
@@ -121,6 +121,12 @@ public:
     void
     stop_profiling(int phdl);
 
+    void
+    prepare_bd(BD& bd, xrtBufferHandle& bo);
+
+    void
+    clear_bd(BD& bd);
+
 private:
     int numCols;
     int fd;
@@ -137,12 +143,6 @@ private:
     wait_sync_bo(ShimDMA *dmap, uint32_t chan, XAie_LocType& tile, XAie_DmaDirection gmdir, uint32_t timeout);
 
     void
-    prepare_bd(BD& bd, xrtBufferHandle& bo);
-
-    void
-    clear_bd(BD& bd);
-
-    void
     get_profiling_config(const std::string& port_name, XAie_LocType& out_shim_tile, XAie_StrmPortIntf& out_mode, uint8_t& out_stream_id);
 
     int
@@ -156,6 +156,26 @@ private:
 
     int
     start_profiling_event_count(const std::string& port_name);
+};
+
+struct BD_scope {
+  BD bd;
+  Aie* aie;
+
+  BD_scope(const BD& bd_in, Aie* host)
+    : bd(bd_in), aie(host)
+  {}
+
+  ~BD_scope()
+  {
+    aie->clear_bd(bd);
+  }
+
+  BD&
+  get()
+  {
+    return bd;
+  }
 };
 
 }


### PR DESCRIPTION
This PR fixed a GMIO memory leak issue.

The reason of the leak is currently, in non block GMIO case, we rely on xrtGMIOWait to be called to detach DMA Buf from aie driver. But xrtGMIOWait may not always be called. So a reference count of the buffer could be hold by aie driver.

The fix is: once we have done the BD setting, we can detach the DMA Buf so that the detachment will be guaranteed to be called.