### PR TITLE
Fixed a issue for backward compatibility  changes

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -730,6 +730,13 @@ get_cu_memidx() const
       for (auto& cu : get_cu_range())
         mask &= cu->get_memidx_intersect();
 
+      // If all bits are set i.e. No Banks are specified. Hence return the
+      // default bank i.e. Bank 0.
+      if (mask.all()) {
+        m_cu_memidx = 0;
+	return m_cu_memidx;
+      }
+
       // Select first common Group index if present prior to bank index.
       // Traverse from the higher order of the mask as groups comes in higher order
       for (int idx=mask.size() - 1; idx >= 0; --idx) {

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -734,7 +734,7 @@ get_cu_memidx() const
       // default bank i.e. Bank 0.
       if (mask.all()) {
         m_cu_memidx = 0;
-	return m_cu_memidx;
+        return m_cu_memidx;
       }
 
       // Select first common Group index if present prior to bank index.

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -730,13 +730,6 @@ get_cu_memidx() const
       for (auto& cu : get_cu_range())
         mask &= cu->get_memidx_intersect();
 
-      // If all bits are set i.e. No Banks are specified. Hence return the
-      // default bank i.e. Bank 0.
-      if (mask.all()) {
-        m_cu_memidx = 0;
-        return m_cu_memidx;
-      }
-
       // Select first common Group index if present prior to bank index.
       // Traverse from the higher order of the mask as groups comes in higher order
       for (int idx=mask.size() - 1; idx >= 0; --idx) {

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -178,7 +178,9 @@ get_buffer_object(device* device, memory::memidx_type subidx)
   // To be deleted when strict bank rules are enforced
   if (boh && m_memidx==-1) {
     auto mset = device->get_boh_memidx(boh);
-    for (size_t idx=0; idx<mset.size(); ++idx) {
+    // As connectivity section contains both group and bank index. Traverse from
+    // the higher order to give priority on group index over bank index
+    for (int idx=mset.size() - 1; idx >= 0; --idx) {
       if (mset.test(idx)) {
         m_memidx=idx;
         break;
@@ -277,7 +279,9 @@ memory::
 update_memidx_nolock(const device* device, const buffer_object_handle& boh)
 {
   auto mset = device->get_boh_memidx(boh);
-  for (size_t idx=0; idx<mset.size(); ++idx) {
+  // As connectivity section contains both group and bank index. Traverse from
+  // the higher order to give priority on group index over bank index
+  for (int idx=mset.size() - 1; idx >= 0; --idx) {
     if (mset.test(idx)) {
       m_memidx=idx;
       break;

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -333,7 +333,9 @@ get_memidx_nolock(const device* dev, memory::memidx_type subidx) const
   if (mset.none())
     throw std::runtime_error("No matching memory index");
 
-  for (size_t idx=0; idx<mset.size(); ++idx) {
+  // As connectivity section contains both group and bank index. Traverse from
+  // the higher order to give priority on group index over bank index
+  for (int idx=mset.size() - 1; idx >= 0; --idx) {
     if (mset.test(idx)) {
       m_memidx = idx;
       break;


### PR DESCRIPTION
-- This is missed for backward compatibility fix
-- As group connectivity section contains both group and bank index, we need to traverse from higher-order to give priority group over bank index
-- We hit this issue CR-1077272 "Multi kernel with port sharing hung in hw_emu"