### PR TITLE
CR-1077413 and CR-1077405

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -76,7 +76,9 @@ XMC_Flasher::XMC_Flasher(unsigned int device_index)
     bool is_mfg = false;
     is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(m_device);
     if (!is_mfg) {
-      val = xrt_core::device_query<xrt_core::query::xmc_status>(m_device);
+      try {
+        val = xrt_core::device_query<xrt_core::query::xmc_status>(m_device);
+    } catch (...) { return; }
       if (!(val & 1)) {
         mProbingErrMsg << "Failed to detect XMC, xmc.bin not loaded";
         goto nosup;


### PR DESCRIPTION
If the SC is inactive, don't throw an error. 
Sample output:
```
2/2 [0000:af:00.0] : xilinx_u50lv_recovery
-------------------------------------------
Device : [0000:af:00.0]

Flash properties
  Type                 : spi
  Serial Number        :

Flashable partitions running on FPGA
  Platform             : xilinx_u50lv_recovery
  SC Version           :
  Platform ID          : 0x0

Flashable partitions installed in system
  None
```
