### PR TITLE
Addressing XDP Coverity issues 212793 and 211146

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -30,7 +30,8 @@
 
 namespace xdp {
 
-  DeviceOffloadPlugin::DeviceOffloadPlugin() : XDPPlugin()
+  DeviceOffloadPlugin::DeviceOffloadPlugin() :
+    XDPPlugin(), continuous_trace(false), continuous_trace_interval_ms(10)
   {
     active = db->claimDeviceOffloadOwnership() ;
     if (!active) return ; 

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -79,7 +79,7 @@ namespace xdp {
 
   void NOCProfilingPlugin::pollNOCCounters()
   {
-    uint32_t pollnum = 0;
+    uint64_t pollnum = 0;
 
     while (mKeepPolling) {
       // Get timestamp in milliseconds


### PR DESCRIPTION
Fixes issue with uninitialized variable in device offload plugin base class and fixes issue with possible loss of data when storing result of uint32_t multiplication into a uint64_t.