### PR TITLE
Adds missing ret value for out0

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -460,6 +460,7 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 out0:
 	kvfree(pages);
+	return ret;
 out1:
 	zocl_free_userptr_bo(&bo->cma_base.base);
 	DRM_DEBUG("handle creation failed\n");


### PR DESCRIPTION
Signed-off-by: Syed Ahmed <stahmed@seas.upenn.edu>

I got "User buffer is not physical contiguous" when using cl_mem_alloc_host_ptr or cl_mem_use_host_ptr with cl_read_only/cl_write_only. While reading this issue: https://github.com/Xilinx/XRT/pull/2164, I learned that I could handle the warning from the user side? However reading the code, it looks like the set `ret` value is not returned in the `out0` label.