### PR TITLE
HW_EM_DISABLE_LATENCY set to true by default to improve HBM System C model

### DIFF
--- a/src/runtime_src/core/edge/common_em/config.cxx
+++ b/src/runtime_src/core/edge/common_em/config.cxx
@@ -98,6 +98,7 @@ namespace xclemulation{
 
   void config::populateEnvironmentSetup(std::map<std::string,std::string>& mEnvironmentNameValueMap)
   {
+    setenv("HW_EM_DISABLE_LATENCY", "true", true);
     for (auto i : mEnvironmentNameValueMap)
     {
       std::string name  = i.first;
@@ -176,7 +177,7 @@ namespace xclemulation{
       else if (name == "ENABLE_GMEM_LATENCY" || name == "enable_gmem_latency") {
         //This is then new INI option that sets the ENV HW_EM_DISABLE_LATENCY to appropriate value before 
         //launching simulation
-        bool val = getBoolValue(value, true);
+        bool val = getBoolValue(value, false);
         if (val) {
           setenv("HW_EM_DISABLE_LATENCY", "false", true);
         } else {

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -99,6 +99,7 @@ namespace xclemulation{
 
   void config::populateEnvironmentSetup(std::map<std::string,std::string>& mEnvironmentNameValueMap)
   {
+    setenv("HW_EM_DISABLE_LATENCY", "true", true);
     for (auto i : mEnvironmentNameValueMap)
     {
       std::string name  = i.first;
@@ -177,7 +178,7 @@ namespace xclemulation{
       else if (name == "ENABLE_GMEM_LATENCY" || name == "enable_gmem_latency") {
         //This is then new INI option that sets the ENV HW_EM_DISABLE_LATENCY to appropriate value before 
         //launching simulation
-        bool val = getBoolValue(value, true);
+        bool val = getBoolValue(value, false);
         if (val) {
           setenv("HW_EM_DISABLE_LATENCY", "false", true);
         } else {


### PR DESCRIPTION
The proposed solution is to make the envvar HW_EM_DISABLE_LATENCY set to true by default.  This will disable the latency in the HBM and DDR TLM models by default. 

If need be latency behavior can be enabled by setting the following in xrt.ini  under  [Emulation] banner -
enable_gmem_latency=true

CR:1081268 . Approved by Amit Kasat.
Risk : low
Fix: make the envvar HW_EM_DISABLE_LATENCY set to true by default. Rohit has reviewed the changes.
Tests : Ran canary. Results look good. Rohit manually tested few designs.
Reviewer: Ch Vamshi Krishna
