### PR TITLE
Cherry pick check to ignore DSA check on XMA Legacy from 2019.2 branch (#2466)

### DIFF
--- a/src/xma/xma_legacy/src/xmaapi/xmacfg.c
+++ b/src/xma/xma_legacy/src/xmaapi/xmacfg.c
@@ -81,7 +81,7 @@ static XmaSystemCfgSM systemcfg_sm[] = {
 { "SystemCfg",     &check_systemcfg,   true },
 { "logfile",       &set_logfile,       false },
 { "loglevel",      &set_loglevel,      false },
-{ "dsa",           &set_dsa,           true },
+{ "dsa",           &set_dsa,           false },
 { "pluginpath",    &set_pluginpath,    true },
 { "xclbinpath",    &set_xclbinpath,    true },
 { "ImageCfg",      &check_imagecfg,    true },

--- a/src/xma/xma_legacy/src/xmaapi/xmahw_hal.cpp
+++ b/src/xma/xma_legacy/src/xmaapi/xmahw_hal.cpp
@@ -173,17 +173,6 @@ bool hal_is_compatible(XmaHwCfg *hwcfg, XmaSystemCfg *systemcfg)
         return false;
     }
 
-    /* For each of the requested devices, check that the DSA name matches */
-    for (i = 0; i < num_devices_requested; i++)
-    {
-        if (strcmp(systemcfg->dsa, hwcfg->devices[i].dsa) != 0)
-        {
-            xma_logmsg(XMA_ERROR_LOG, XMAAPI_MOD, "DSA mismatch: requested %s found %s\n",
-                       systemcfg->dsa, hwcfg->devices[i].dsa);
-            return false;
-        }
-    }
-
     return true;
 }
 


### PR DESCRIPTION
This was merged into XRT/2019.2 but not into XRT/master. See commit 5843d44 for the original change.
However, with U30 Raptor bring up, this change helps quickly verify U30 use-cases on XMA legacy.

Requesting to be merged into XRT/master as xma_legacy is not yet End-of-Life.

* Remove DSA check and make DSA in config optional

* Remove #ifdef of DSA compatibility check