### PR TITLE
support xoclv2 new dev nodes

### DIFF
--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -817,16 +817,16 @@ public:
   std::string get_subdev_path(const std::string& subdev, uint32_t idx)
   {
     std::string path("/dev/xfpga/");
+    path += sysfs_name;
+    path += "/";
     try {
       auto map = find_devfs_map(subdev);
       path += map.subdev_v2;
     } catch (...) {
       path += subdev;
     }
-    path += ".";
-    path += sysfs_name;
     if (idx != (uint32_t)-1)
-      path += "-" + std::to_string(idx);
+      path += "." + std::to_string(idx);
     return path;
   }
   int open(const std::string& subdev, int flag)


### PR DESCRIPTION
To better help w/ docker support, the dev node of xoclv2 devices is changed to /dev/xfpga/<BDF>/subdev[.instance]
e.g.:
maxz@xsjmaxz50:/proj/xsjhdstaff3/maxz/xrt/XRT/build/Release$ find /dev/xfpga
/dev/xfpga
/dev/xfpga/mailbox.u45825.0   <== from existing xocl driver
/dev/xfpga/0000:b3:00.0          <== from xoclv2 (xmgmt), including everything below this dir
/dev/xfpga/0000:b3:00.0/cmc
/dev/xfpga/0000:b3:00.0/mailbox
/dev/xfpga/0000:b3:00.0/flash
/dev/xfpga/0000:b3:00.0/xrt_test.1
/dev/xfpga/0000:b3:00.0/xmgmt
/dev/xfpga/0000:b3:00.0/xrt_test.0
