### PR TITLE
CR-1073067: Constructing CU index Vs base address map using IP_LAYOUT in hw_emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -273,7 +273,8 @@ using addr_type = uint64_t;
       void parseSimulateLog();
       void setSimPath(std::string simPath) { sim_path = simPath; }
       std::string getSimPath () { return sim_path; }
-      
+      //Construct CU index vs Base address map from IP_LAYOUT section in xclbin.
+      int getCuIdxBaseAddrMap();
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;
       bool simulator_started;


### PR DESCRIPTION
Issue: xclRegRead/Write() using CU index Vs base address map, which is constructed by EMBEDDED_METADATA in xclbin, which is wrong.
Fix: Constructing CU index Vs base address map using IP_LAYOUT in xclbin instead of using EMBEDDED_METADATA.
Test: Ran some test cases manually and also ran canary, results are clean.
Risk: Low.  