### PR TITLE
XRT-787 SC flash support on u30

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -318,6 +318,7 @@ struct xmc_pkt_hdr {
 	u32 op		: 8;
 };
 
+#define XMC_MBX_DEF_OFFSET 0x1000
 /* We have a 4k buffer for xmc mailbox */
 #define	XMC_PKT_MAX_SZ	1024 /* In u32 */
 #define	XMC_PKT_MAX_PAYLOAD_SZ	\
@@ -3201,7 +3202,7 @@ static void xmc_enable_mailbox(struct xocl_xmc *xmc)
 
 	xmc->mbx_enabled = true;
 	safe_read32(xmc, XMC_HOST_MSG_OFFSET_REG, &val);
-	xmc->mbx_offset = val;
+	xmc->mbx_offset = val ? val : XMC_MBX_DEF_OFFSET;
 	xocl_info(&xmc->pdev->dev, "XMC mailbox offset: 0x%x", val);
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -318,7 +318,6 @@ struct xmc_pkt_hdr {
 	u32 op		: 8;
 };
 
-#define XMC_MBX_DEF_OFFSET 0x1000
 /* We have a 4k buffer for xmc mailbox */
 #define	XMC_PKT_MAX_SZ	1024 /* In u32 */
 #define	XMC_PKT_MAX_PAYLOAD_SZ	\
@@ -3202,8 +3201,8 @@ static void xmc_enable_mailbox(struct xocl_xmc *xmc)
 
 	xmc->mbx_enabled = true;
 	safe_read32(xmc, XMC_HOST_MSG_OFFSET_REG, &val);
-	xmc->mbx_offset = val ? val : XMC_MBX_DEF_OFFSET;
-	xocl_info(&xmc->pdev->dev, "XMC mailbox offset: 0x%x", val);
+	xmc->mbx_offset = val;
+	xocl_info(&xmc->pdev->dev, "XMC mailbox offset read during probe: 0x%x", val);
 }
 
 static inline int wait_reg_value(struct xocl_xmc *xmc, void __iomem *base, u32 mask)
@@ -3977,7 +3976,7 @@ static int xmc_send_pkt(struct xocl_xmc *xmc)
 	u32 len = XMC_PKT_SZ(&xmc->mbx_pkt.hdr);
 	int ret = 0;
 	u32 i;
-	u32 val;
+	u32 val = 0;
 
 	if (!xmc->mbx_enabled) {
 		xocl_err(&xmc->pdev->dev, "CMC mailbox is not supported");
@@ -3985,6 +3984,21 @@ static int xmc_send_pkt(struct xocl_xmc *xmc)
 	}
 
 	BUG_ON(!mutex_is_locked(&xmc->mbx_lock));
+	/*
+	 * On card with ps, eg, u30, when xmc subdevice is probed on host,
+	 * the cmc running on ps may be not ready yet. so the saved mbx offset
+	 * might be 0. The register should be ready when we are here.
+	 * we need check and update the mbx offset.
+	 */
+	safe_read32(xmc, XMC_HOST_MSG_OFFSET_REG, &val);
+	if (!val) {
+		xocl_err(&xmc->pdev->dev, "CMC mailbox is not ready");
+		return -EIO;
+	}
+	if (val != xmc->mbx_offset) {
+		xocl_info(&xmc->pdev->dev, "CMC mailbox offset updated: 0x%x", val);
+		xmc->mbx_offset = val;
+	}
 #ifdef	MBX_PKT_DEBUG
 	xocl_info(&xmc->pdev->dev, "Sending XMC packet: %d DWORDS...", len);
 	xocl_info(&xmc->pdev->dev, "opcode=%d payload_sz=0x%x (0x%x)",

--- a/src/runtime_src/tools/scripts/CMakeLists.txt
+++ b/src/runtime_src/tools/scripts/CMakeLists.txt
@@ -12,6 +12,7 @@ set (XRT_SCRIPTS
   plp_program.sh)
 
 set(XBRESET
+  _scflash.py
   _xbreset.py)
 else()
 

--- a/src/runtime_src/tools/scripts/_scflash.py
+++ b/src/runtime_src/tools/scripts/_scflash.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+ Copyright (C) 2020 Xilinx, Inc
+ Author(s): Brian Xu (brianx@xlinx.com)
+
+ Licensed under the Apache License, Version 2.0 (the "License"). You may
+ not use this file except in compliance with the License. A copy of the
+ License is located at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
+"""
+
+import sys
+import argparse
+import textwrap
+import os
+import re
+import subprocess
+import time
+
+#In this 'lspci -t' snippet
+#-+-[0000:16]-+-00.0-[17]--+-00.0
+# |           |            \-00.1
+# |           +-01.0-[18]--+-00.0
+# |           |            \-00.1
+#
+#FPGA 17:00.[01] parent is 16.00.0, which has primary bus number 16, and secondary bus number 17
+#FPGA 18:00.[01] parent is 16.01.0, which has primary bus number 16, and secondary bus number 18
+#FPGAs whose parents have identical pcie primary bus number are on same card
+
+#FPGA node and its parent primary bus number mapping
+#eg "0000:17:00.0" "16"
+#   "0000:18:00.0" "16"
+node_bus_mapping = {}
+#FPGA node and its parent node DBDF mapping
+#eg "0000:17:00.0" "0000:16:00.0"
+#   "0000:18:00.0" "0000:16:01.0"
+node_parent_mapping = {}
+#primary bus of pcie bridge and FPGA node mapping
+#eg "16" ["0000:17.00.0", "0000:18:00.0"]
+bus_children = {}
+
+#path of the ps_ready sysfs node of the FPGA
+ps_ready = {}
+
+#path of the sc_is_fixed sysfs node of the FPGA
+sc_is_fixed = {}
+
+rootDir = "/sys/bus/pci/devices/"
+xbmgmt = "/opt/xilinx/xrt/bin/unwrapped/xbmgmt"
+
+#get all above "node vs bus" mappings of xilinx FPGAs
+def get_node_bus_mapping():
+    subdir = os.listdir(rootDir)
+    for subdirName in subdir:
+        if re.search("^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-3]{2}.0$", subdirName) == None:
+            continue
+        with open(os.path.join(rootDir, subdirName, "vendor")) as f : vendor = f.read()
+        if vendor.strip() != "0x10ee":
+            continue
+        files = os.listdir(os.path.join(rootDir, subdirName))
+        for fname in files:
+            if re.search("^processor_system.+$", fname) != None:
+                ps_ready[subdirName] = os.path.join(rootDir, subdirName, fname, "ps_ready")
+            if re.search("^xmc.+$", fname) != None:
+                sc_is_fixed[subdirName] = os.path.join(rootDir, subdirName, fname, "sc_is_fixed")
+        #print("%s: %s " % (subdirName, ps_ready[subdirName]))
+        files = os.listdir(os.path.join(rootDir, subdirName, "dparent"))
+        for fname in files:
+            if re.search("^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-3]{2}.[0-7]:pcie.+$", fname) != None:
+                bus = fname.split(":")[1]
+                node_bus_mapping[subdirName] = bus
+                node_parent_mapping[subdirName] = fname[:fname.rfind(":")]
+                if bus not in bus_children:
+                    bus_children[bus] = []
+                bus_children[bus].append(subdirName);
+
+#call 'xbmgmt' to do the real flash
+def run_xbmgmt(cmdline):
+    print(cmdline)
+    p = subprocess.Popen(cmdline, stdout=subprocess.PIPE)
+    out, err = p.communicate(timeout=120)
+    if out:
+        print(out.decode("utf-8"))
+    if err:
+        print(err.decode("utf-8"))
+
+#call 'xbmgmt reset'
+def run_reset(cmdline):
+    print(cmdline)
+    p1 = subprocess.Popen(["echo", "y"], stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(cmdline, stdout=subprocess.PIPE, stdin=p1.stdout)
+    p1.stdout.close()
+    p2.communicate(timeout=90)[0]
+
+#do pcie node remove and rescan
+def run_pcie(cmdline):
+    #print(cmdline)
+    subprocess.call(cmdline, shell=True)
+
+#wait ps on FPGA back online
+def wait_ps_online(mgmt):
+    while True:
+        with open(ps_ready[mgmt]) as f : ready = f.read()
+        if ready.strip() == '0':
+            time.sleep(3)
+            continue
+        print("%s ps ready" % mgmt)
+        break
+
+#wait FPGA back online
+def wait_xocl_online(user):
+    while True:
+        with open(os.path.join(rootDir, user, "dev_offline")) as f : ready = f.read()
+        if ready.strip() == '1':
+            time.sleep(1)
+            continue
+        print("%s host online" % user)
+        break
+
+
+def main():
+    desc = textwrap.dedent('''\
+        This cmdline tool is mainly used to flash sc on U30.
+        U30 card has 2 FPGAs in one card. Each FPGA has one cmc running
+        on the petalinux but there is only one sc. Only one of the cmc
+        can be used to flash the sc. Please run 'xbmgmt flash --scan' to
+        find the one *without* "Fixed"
+        If there is only one FPGA node in the card, the cmd will fall back
+        to 'xbmgmt flash --sc_firmware' expert cmd
+
+        Root privilege is required to run this cmd
+        
+        Example:
+            scflash -d 0000:17:00.0 -p path_to_sc_firmware
+    ''')
+    if (os.geteuid() != 0):
+        print("ERROR: root privilege is required.")
+        sys.exit(1)
+
+    parser=argparse.ArgumentParser(description=desc,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-d","--dbdf", required=True,
+        help="DBDF of a FPGA node, with format xxxx:xx:xx.x")
+    parser.add_argument("-p","--path", required=True,
+        help="path to the sc firmware file")
+    parser.add_argument("-y","--yes", help="automatic yes to prompts",
+        action="store_true")
+    args = parser.parse_args()
+
+    get_node_bus_mapping()
+    mgmt = args.dbdf[:len(args.dbdf)-1] + "0"
+    user = args.dbdf[:len(args.dbdf)-1] + "1"
+
+    try:
+        if mgmt not in node_bus_mapping:
+            print("ERROR: Is %s a FPGA node?" % user)
+            sys.exit(1)
+
+        #print(node_parent_mapping)
+        nodes_in_cards = bus_children[node_bus_mapping[mgmt]]
+        #print(nodes_in_cards)
+        print("This will reflash sc on the card")
+        print("All existing processes will be killed.")
+        while not args.yes:
+            line = input("Are you sure you wish to proceed? [y/n]:")
+            if line == "n":
+                sys.exit(1)
+            if line == "y":
+                break
+        #steps to flash sc
+        #1. kill processes running on the other FPGA
+        #2. call 'xbmgmt flash' on the specified FPGA
+        #3. call 'xbmgmt reset --ert' on the 'fixed sc' FPGA to reboot cmc
+        #4. wait for FPGAs back online
+        #Note: since this python is called by xbmgmt, so we can't do a card reset
+        #      here, otherwise, card reset will remove the xclmgmt which is still
+        #      being used by the calling xbmgmt.
+        for node in nodes_in_cards:
+            user = node[:len(node)-1] + "1"
+            print("shutdown: %s" % user)
+            run_pcie("echo 2 > " + os.path.join(rootDir, user, "shutdown"))
+        print("sc flash...")
+        run_xbmgmt([xbmgmt, "flash", "--sc_firmware", "--path", args.path, "--card", mgmt, "--no_cardlevel"])
+        time.sleep(1)
+        print("ERT reset...")
+        for node in nodes_in_cards:
+            with open(sc_is_fixed[node]) as f : fixed_sc = f.read()
+            if fixed_sc.strip() != "1":
+                continue
+            run_reset([xbmgmt, "reset", "--ert", "--card", node])
+        time.sleep(1)
+        print("wait FPGAs back on line")
+        for node in nodes_in_cards:
+            user = node[:len(node)-1] + "1"
+            wait_ps_online(node)
+            wait_xocl_online(user)
+    except Exception as e:
+        print(e)
+
+if __name__ == "__main__":
+    main()

--- a/src/runtime_src/tools/scripts/_scflash.py
+++ b/src/runtime_src/tools/scripts/_scflash.py
@@ -178,6 +178,7 @@ def main():
         #1. kill processes running on the other FPGA
         #2. call 'xbmgmt flash' on the specified FPGA
         #3. call 'xbmgmt reset --ert' on the 'fixed sc' FPGA to reboot cmc
+        #   this step 3 is a workaround to https://jira.xilinx.com/browse/CR-1076187
         #4. wait for FPGAs back online
         #Note: since this python is called by xbmgmt, so we can't do a card reset
         #      here, otherwise, card reset will remove the xclmgmt which is still


### PR DESCRIPTION
1. xbmgmt2 is not supported at this time. will file a CR tracking it
2. sc flash for u30 will not do a hot(card) reset. It is doing a ps only reset on the FPGA with fixed sc so far. This is just to workaround https://jira.xilinx.com/browse/CR-1076187
this makes the sc flash takes longer. Once that CR is fixed by cmc, we can remove the ert reset to save time
3. xmc driver set mailbox offset during probe(). For some reason even Alan doesn't know, sometimes, at that time the register doesn't return the value(it returns 0). So we set a default value once in that case. When I use xrt userlevel xmc, since the register is read when the xbmgmt is running, the register never returns 0