### PR TITLE
CR-1081983: Enables LOP trace and other profiling plugins to work without AIE

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -218,6 +218,12 @@ namespace xdp {
     uint32_t numTracePLIO = 0;
 
     ~DeviceInfo();
+    void addTraceGMIO(uint32_t i, uint16_t col, uint16_t num, uint16_t stream,
+		      uint16_t len) ;
+    void addAIECounter(uint32_t i, uint16_t col, uint16_t r, uint8_t num,
+		       uint8_t start, uint8_t end, uint8_t reset,
+		       double freq, const std::string& mod,
+		       const std::string& aieName) ;
   };
 
   class VPStaticDatabase
@@ -261,7 +267,6 @@ namespace xdp {
     bool setXclbinName(DeviceInfo*, const std::shared_ptr<xrt_core::device>& device);
     bool initializeComputeUnits(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
     bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
-    bool initializeAIECounters(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -460,6 +465,26 @@ namespace xdp {
       if(deviceInfo.find(deviceId) == deviceInfo.end())
         return nullptr;
       return deviceInfo[deviceId]->gmioList[idx];
+    }
+
+    inline void addTraceGMIO(uint64_t deviceId, uint32_t i, uint16_t col,
+			     uint16_t num, uint16_t stream, uint16_t len)
+    {
+      if (deviceInfo.find(deviceId) == deviceInfo.end())
+	return ;
+      deviceInfo[deviceId]->addTraceGMIO(i, col, num, stream, len);
+    }
+
+    inline void addAIECounter(uint64_t deviceId, uint32_t i, uint16_t col,
+			      uint16_t r, uint8_t num, uint8_t start,
+			      uint8_t end, uint8_t reset, double freq,
+			      const std::string& mod,
+			      const std::string& aieName)
+    {
+      if (deviceInfo.find(deviceId) == deviceInfo.end())
+	return ;
+      deviceInfo[deviceId]->addAIECounter(i, col, r, num, start, end, reset,
+					  freq, mod, aieName) ;
     }
 
     // Includes User Space AIM only, but no shell AIM

--- a/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie/aie_plugin.cpp
@@ -28,6 +28,10 @@
 #include "core/edge/common/aie_parser.h"
 #include "xdp/profile/database/database.h"
 
+#ifdef XRT_ENABLE_AIE
+#include "core/edge/common/aie_parser.h"
+#endif
+
 extern "C" {
 #include <xaiengine.h>
 }
@@ -126,6 +130,31 @@ namespace xdp {
           (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
         }
       }
+#ifdef XRT_ENABLE_AIE
+      {
+	// Update the AIE specific portion of the device
+	std::shared_ptr<xrt_core::device> device =
+	  xrt_core::get_userpf_device(handle) ;
+	auto counters = xrt_core::edge::aie::get_profile_counters(device.get());
+	if (xrt_core::config::get_aie_profile() && counters.empty()) {
+	  std::string msg("AIE Profile Counters are not found in AIE metadata of the given design. So, AIE Profile information will not be available.");
+	  xrt_core::message::send(xrt_core::message::severity_level::XRT_WARNING, "XRT", msg) ;			  
+	}
+	for (auto& counter : counters) {
+	  (db->getStaticInfo()).addAIECounter(deviceId,
+					      counter.id,
+					      counter.column,
+					      counter.row,
+					      counter.counterNumber,
+					      counter.startEvent,
+					      counter.endEvent,
+					      counter.resetEvent,
+					      counter.clockFreqMhz,
+					      counter.module,
+					      counter.name) ;
+	}
+      }
+#endif
     }
 
     // Open the writer for this device

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -103,9 +103,10 @@ namespace xdp {
 	// Update the AIE specific portion of the device
 	std::shared_ptr<xrt_core::device> device =
 	  xrt_core::get_userpf_device(handle) ;
-	if (device == nullptr) return ;
-	for (auto& gmio : xrt_core::edge::aie::get_trace_gmios(device.get())) {
-	  (db->getStaticInfo()).addTraceGMIO(deviceId, gmio.id, gmio.shim_col, gmio.channel_number, gmio.stream_id, gmio.burst_len) ;
+	if (device != nullptr) {
+	  for (auto& gmio : xrt_core::edge::aie::get_trace_gmios(device.get())) {
+	    (db->getStaticInfo()).addTraceGMIO(deviceId, gmio.id, gmio.shim_col, gmio.channel_number, gmio.stream_id, gmio.burst_len) ;
+	  }
 	}
       }
 #endif

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -30,6 +30,10 @@
 #include "core/common/message.h"
 #include <iostream>
 
+#ifdef XRT_ENABLE_AIE
+#include "core/edge/common/aie_parser.h"
+#endif
+
 namespace xdp {
 
   AieTracePlugin::AieTracePlugin()
@@ -94,6 +98,17 @@ namespace xdp {
           (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
         }
       }
+#ifdef XRT_ENABLE_AIE
+      {
+	// Update the AIE specific portion of the device
+	std::shared_ptr<xrt_core::device> device =
+	  xrt_core::get_userpf_device(handle) ;
+	if (device == nullptr) return ;
+	for (auto& gmio : xrt_core::edge::aie::get_trace_gmios(device.get())) {
+	  (db->getStaticInfo()).addTraceGMIO(deviceId, gmio.id, gmio.shim_col, gmio.channel_number, gmio.stream_id, gmio.burst_len) ;
+	}
+      }
+#endif
     }
 
     uint64_t numAIETraceOutput = (db->getStaticInfo()).getNumAIETraceStream(deviceId);


### PR DESCRIPTION
This pull request breaks the inherent dependency on Edge between the xdp_core library and the xrt_core library that existed when building for AIE offload.  It put the AIE specific portions into the plugins and makes xdp_core only dependent on xrt_coreutil again.