### PR TITLE
Replace boost/detail/endian.hpp with

### DIFF
--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -21,7 +21,7 @@
 #include "compute_unit.h"
 #include "core/common/xclbin_parser.h"
 
-#include <boost/detail/endian.hpp>
+#include <boost/predef/other/endian.h>
 
 #include <sstream>
 #include <iostream>
@@ -130,7 +130,7 @@ void
 kernel::scalar_argument::
 set(size_t size, const void* cvalue)
 {
-  static_assert(BOOST_BYTE_ORDER==1234,"Big endian detected");
+  static_assert(__BYTE_ORDER==1234,"Big endian detected");
 
   if (size != m_sz)
     throw error(CL_INVALID_ARG_SIZE,"Invalid scalar argument size, expected "


### PR DESCRIPTION
 boost/predef/other/endian.h

The use of BOOST_*_ENDIAN and BOOST_BYTE_ORDER is deprecated. Include
<boost/predef/other/endian.h> and use __BYTE_ORDER and1234

Signed-off-by: Sai Hari Chandana Kalluri <chandana.kalluri@xilinx.com>