### PR TITLE
xbutil validate should catch the reason of invalide userHandle

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1639,7 +1639,8 @@ shim *shim::handleCheck(void *handle)
     if (!handle) {
         return 0;
     }
-    if (!((shim *) handle)->isGood()) {
+    if (!((shim *) handle)->isGood() ||
+      ((shim *) handle)->mUserHandle == -1) {
         return 0;
     }
     return (shim *) handle;
@@ -2286,13 +2287,19 @@ xclOpen(unsigned int deviceIndex, const char*, xclVerbosityLevel)
   try {
     if(pcidev::get_dev_total() <= deviceIndex) {
       xrt_core::message::send(xrt_core::message::severity_level::XRT_INFO, "XRT",
-                       std::string("Cannot find index " + std::to_string(deviceIndex) + " \n"));
+        std::string("Cannot find index " + std::to_string(deviceIndex) + " \n"));
       return nullptr;
     }
 
   OPEN_CB;
 
     xocl::shim *handle = new xocl::shim(deviceIndex);
+
+    if (handle->handleCheck(handle) == 0) {
+      xrt_core::send_exception_message(strerror(errno) +
+        std::string(" Device index ") + std::to_string(deviceIndex));
+      return nullptr;
+    }
 
     return static_cast<xclDeviceHandle>(handle);
   }


### PR DESCRIPTION
With the fix:
```
xsjyliu50:~ $ ls -al /dev/dri/renderD1*                                 
crw-rw-rw-+ 1 root render 226, 128 Oct 30 15:44 /dev/dri/renderD128     
crw-rw-rw-+ 1 root render 226, 129 Oct 30 15:44 /dev/dri/renderD129     
crw-rw----+ 1 root render 226, 130 Oct 30 15:46 /dev/dri/renderD130     
crw-rw-rw-+ 1 root render 226, 131 Oct 30 15:44 /dev/dri/renderD131     
xsjyliu50:~ $ /proj/xsjhdstaff2/davidzha/XRT_xocl/build/Debug/runtime_src/core/pcie/tools/xbutil/xbutil validate -d 1 -q
INFO: Found 1 cards                                                                                                     
XRT build version: 2.8.0                                                                                                
Build hash: 8009caadf89c027cb619145bbd61e8284f1b03ee                                                                    
Build date: 2020-10-30 20:26:27                                                                                         
Git branch: xbutil                                                                                                      
PID: 24269                                                                                                              
UID: 2326                                                                                                               
[Sat Oct 31 03:36:50 2020 GMT]                                                                                          
HOST: xsjyliu50                                                                                                         
EXE: /proj/xsjhdstaff2/davidzha/XRT_xocl/build/Debug/runtime_src/core/pcie/tools/xbutil/xbutil                          
[XRT] WARNING: XRT                                                                                                      
[XRT] ERROR: Permission denied Device index 1                                                                           
ERROR: Failed to open device[1]                                                                                         
ERROR: Can't open card[1]                                                                                               

ERROR: Some cards failed to validate.
```

without the fix
````
xsjyliu50:~ $ xbutil validate -d 1 -q
INFO: Found 1 cards                  
XRT build version: 2.8.0             
Build hash: c257427b022f81a57ae07170d00a68c06499d83d
Build date: 2020-10-30 15:37:31                     
Git branch: udev                                    
PID: 24299                                          
UID: 2326                                           
[Sat Oct 31 03:37:05 2020 GMT]                      
HOST: xsjyliu50                                     
EXE: /opt/xilinx/xrt/bin/unwrapped/xbutil           
[XRT] WARNING: XRT                                  

INFO: Validating card[1]: xilinx_u50_gen3x16_xdma_base_4
INFO: == Starting Kernel version check:                 
Developer's build. Skipping validation                  
INFO: == Kernel version check SKIPPED                   
INFO: == Starting AUX power connector check:            
AUX power connector not available. Skipping validation  
INFO: == AUX power connector check SKIPPED              
INFO: == Starting Power warning check:                  
INFO: == Power warning check PASSED                     
INFO: == Starting PCIE link check:                      
INFO: == PCIE link check PASSED                         
INFO: == Starting SC firmware version check:            
INFO: == SC firmware version check PASSED               
INFO: == Starting verify kernel test:                   
ERROR: Failed to download xclbin: verify.xclbin         
ERROR: == verify kernel test FAILED                     
INFO: Card[1] failed to validate.                       

ERROR: Some cards failed to validate.
```