### PR TITLE
CR-1082322: kernel argument fix in cpp api

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1053,10 +1053,8 @@ public:
     // get kernel arguments from xml parser
     // compute regmap size, convert to typed argument
     for (auto& arg : xrt_core::xclbin::get_kernel_arguments(xml_section.first, xml_section.second, name)) {
-      if (arg.index != xrt_core::xclbin::kernel_argument::no_index) {
-        regmap_size = std::max(regmap_size, (arg.offset + arg.size) / 4);
-        args.emplace_back(device->get_core_device(), std::move(arg), get_arg_grpid(connectivity, arg.index, ip2idx));
-      }
+      regmap_size = std::max(regmap_size, (arg.offset + arg.size) / 4);
+      args.emplace_back(device->get_core_device(), std::move(arg), get_arg_grpid(connectivity, arg.index, ip2idx));
     }
 
     // amend args with computed data based on kernel protocol
@@ -1149,7 +1147,9 @@ public:
   const argument&
   get_arg(size_t argidx) const
   {
-    return args.at(argidx);
+    auto& arg = args.at(argidx);
+    arg.valid_or_error();
+    return arg;
   }
 };
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1053,8 +1053,10 @@ public:
     // get kernel arguments from xml parser
     // compute regmap size, convert to typed argument
     for (auto& arg : xrt_core::xclbin::get_kernel_arguments(xml_section.first, xml_section.second, name)) {
-      regmap_size = std::max(regmap_size, (arg.offset + arg.size) / 4);
-      args.emplace_back(device->get_core_device(), std::move(arg), get_arg_grpid(connectivity, arg.index, ip2idx));
+      if (arg.index != xrt_core::xclbin::kernel_argument::no_index) {
+        regmap_size = std::max(regmap_size, (arg.offset + arg.size) / 4);
+        args.emplace_back(device->get_core_device(), std::move(arg), get_arg_grpid(connectivity, arg.index, ip2idx));
+      }
     }
 
     // amend args with computed data based on kernel protocol


### PR DESCRIPTION
kernel argument check added
This fix addresses below problem.

If extra argument was passed to kernel:
    - No error was given
    - Kernel output was incorrect