### PR TITLE
zocl git hash version

### DIFF
--- a/src/runtime_src/core/edge/drm/Makefile
+++ b/src/runtime_src/core/edge/drm/Makefile
@@ -6,6 +6,12 @@ KBUILD_OPTS := M=$(CURDIR)/$(DRIVER)
 KBUILD_OPTS += ARCH=$(TARGET)
 KBUILD_OPTS += CROSS_COMPILE=$(CROSS_COMPILE)
 
+GIT_HASH := `git -C /proj/rdi-xsj/staff/sarabjee/xrt_git/sarab/XRT/src rev-parse --verify HEAD`
+GIT_HASH_DATE := `git log -1 --pretty=format:%cD`
+GIT_BRANCH := `git rev-parse --abbrev-ref HEAD`
+TMP_MODIFIED_FILES := `git status --porcelain -u no`
+GIT_MODIFIED_FILES := $(subst \\n,\,,$(TMP_MODIFIED_FILES))
+
 all: modules check-env
 
 modules: check-env

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -23,6 +23,7 @@ endif
 endif
 
 ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include -DXRT_HASH=\"$(GIT_HASH)\" -DXRT_HASH_DATE=\"$(GIT_HASH_DATE)\" -DXRT_BRANCH=\"$(GIT_BRANCH)\" -DXRT_MODIFIED_FILES=\"$(GIT_MODIFIED_FILES)\" 
+
 #flags passed from xrt_git.bb file are added below
 ifneq ($(cflags_zocl),)
 	ccflags-y += $(cflags_zocl)

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -22,7 +22,7 @@ endif
 
 endif
 
-ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include
+ccflags-y := -I$(src)/include -I$(src)/../../include -I$(src)/../../../include -I$(src)/../../../common/drv/include -DXRT_HASH=\"$(GIT_HASH)\" -DXRT_HASH_DATE=\"$(GIT_HASH_DATE)\" -DXRT_BRANCH=\"$(GIT_BRANCH)\" -DXRT_MODIFIED_FILES=\"$(GIT_MODIFIED_FILES)\" 
 #flags passed from xrt_git.bb file are added below
 ifneq ($(cflags_zocl),)
 	ccflags-y += $(cflags_zocl)

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -197,6 +197,24 @@ static ssize_t kds_skstat_show(struct device *dev,
 static DEVICE_ATTR_RO(kds_skstat);
 
 
+static ssize_t kds_xrt_version_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	ssize_t sz = 0;
+
+	if (!zdev || !zdev->soft_kernel)
+		return 0;
+
+	sz += sprintf(buf+sz, "XRT GIT BRANCH: %s\n", XRT_BRANCH);
+	sz += sprintf(buf+sz, "XRT GIT HASH: %s\n", XRT_HASH);
+	sz += sprintf(buf+sz, "XRT GIT HASH DATE: %s\n", XRT_HASH_DATE);
+	sz += sprintf(buf+sz, "XRT GIT Modified Files: %s\n", XRT_MODIFIED_FILES);
+
+	return sz;
+}
+static DEVICE_ATTR_RO(kds_xrt_version);
+
 static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
@@ -394,6 +412,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_kds_custat.attr,
 	&dev_attr_kds_stats.attr,
 	&dev_attr_kds_skstat.attr,
+	&dev_attr_kds_xrt_version.attr,
 	&dev_attr_kds_echo.attr,
 	&dev_attr_kds_stat.attr,
 	&dev_attr_memstat.attr,


### PR DESCRIPTION
Added git hash, hash date, branch, etc to zocl driver sysfs
In edge systems it is common to replace zocl.ko directly
Full XRT edge build and boot.bin is not always used
Flash is not update always and instead zocl.ko is directly replaced

So adding version info to zocl sysfs as xbutil version is not sufficient for edge platforms