### PR TITLE
zocl driver version

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -37,8 +37,8 @@
 
 #define ZOCL_DRIVER_NAME        "zocl"
 #define ZOCL_DRIVER_DESC        "Zynq BO manager"
-#define ZOCL_DRIVER_DATE        "20180313"
-#define ZOCL_DRIVER_MAJOR       2018
+#define ZOCL_DRIVER_DATE        "20201101"
+#define ZOCL_DRIVER_MAJOR       2020
 #define ZOCL_DRIVER_MINOR       2
 #define ZOCL_DRIVER_PATCHLEVEL  1
 


### PR DESCRIPTION
zocl version update for 2020
This version is used by lspci, etc