### PR TITLE
Move runtime_clk_scale option in xbmgmt tool to experts only section

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_config.cpp
@@ -28,13 +28,12 @@
 const char *subCmdConfigDesc = "Parse or update daemon/device configuration";
 
 const char *subCmdConfigUsage =
-    "--device [--card bdf] [--runtime_clk_scale enable|disable]\n"
     "--enable_retention [--ddr] [--card bdf]\n"
     "--disable_retention [--ddr] [--card bdf]\n";
 const char *subCmdConfigExpUsage =
     "Experts only:\n"
     "--daemon --host ip-or-hostname-for-peer\n"
-    "--device [--card bdf] [--security level] [--cs_threshold_power_override val] [--cs_threshold_temp_override val] [--cs_reset val]\n"
+    "--device [--card bdf] [--runtime_clk_scale enable|disable] [--security level] [--cs_threshold_power_override val] [--cs_threshold_temp_override val] [--cs_reset val]\n"
     "--show [--daemon | --device [--card bdf]\n";
 
 static struct config {


### PR DESCRIPTION
--runtime_clk_scale option in xbmgmt is used to enable or disable
runtime clock scaling feature.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>