### PR TITLE
error message clear when buffer is not resident yet migrating from device to host

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -137,7 +137,7 @@ buffer_resident_or_error(const xocl::memory* buffer, const xocl::device* device)
     throw std::runtime_error("buffer ("
                              + std::to_string(buffer->get_uid())
                              + ") is not resident in device ("
-                             + std::to_string(device->get_uid()) + ")");
+                             + std::to_string(device->get_uid()) + ") so migration from device to host fails");
 }
 
 // Copy hbuf to ubuf if necessary


### PR DESCRIPTION
This CR https://jira.xilinx.com/browse/CR-1067158
This came from customer when they could not understand the error message. 
The error comes only when buffer is not resident but still we are trying to migrate from device->host
Making the error message clear. 