### PR TITLE
CR-1082126 DNNDK compilation failure

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt-next.h
+++ b/src/runtime_src/core/include/experimental/xrt-next.h
@@ -18,7 +18,7 @@
 #ifndef _XRT_NEXT_APIS_H_
 #define _XRT_NEXT_APIS_H_
 
-#include "xrt.h"
+#include "../xrt.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Amend #4336.   Don't rely on compiler include search path.

This is bigger issue related to how XRT installs header files.  We
need to change XRT install such that all heades are rooted under an
'xrt/' and such that compiler include search path is up to the
directory containing the xrt sub folder (be that $XILINX_XRT/include
or /usr/include).

This in turn would make it possible to include XRT headers using
such that random xrt headers can conflict with system headers.

All indirect XRT includes would then change to also contain the 'xrt/'
prefix.  This is identical to other 3rd party library includes,
e.g. boost.