### PR TITLE
CR-1082221 add icap controller endpoint support for Raptor2 0RP shell

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -66,6 +66,11 @@ enum {
 	XOCL_XMC_CLK_SCALING	= (1 << 2),
 };
 
+/* icap controller flags */
+enum {
+	XOCL_IC_FLAT_SHELL	= (1 << 0),
+};
+
 #define	FLASH_TYPE_SPI	"spi"
 #define	FLASH_TYPE_QSPIPS	"qspi_ps"
 #define	FLASH_TYPE_QSPIPS_X2_SINGLE	"qspi_ps_x2_single"
@@ -132,6 +137,10 @@ struct xocl_sysmon_privdata {
 };
 
 struct xocl_xmc_privdata {
+	uint16_t		flags;
+};
+
+struct xocl_icap_cntrl_privdata {
 	uint16_t		flags;
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -273,7 +273,7 @@ static void *icap_cntrl_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t 
 			xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_ULP, NODE_ENDPOINTS);
 
 		node1 = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_PLP);
-		if (node < 0)
+		if (node1 < 0)
 			xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_PLP, NODE_ENDPOINTS);
 
 		if ((node < 0) && (node1 < 0))

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -246,6 +246,38 @@ static void *p2p_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	return p2p_priv;
 }
 
+static void *icap_cntrl_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
+{
+	struct xocl_dev_core *core = XDEV(xdev_hdl);
+	void *blob;
+	struct xocl_icap_cntrl_privdata *priv;
+	int node;
+
+	blob = core->fdt_blob;
+	if (!blob)
+		return NULL;
+
+	priv = vzalloc(sizeof(*priv));
+	if (!priv)
+		return NULL;
+
+	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_ICAP_CONTROLLER);
+	if (node < 0) {
+		xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_ICAP_CONTROLLER, NODE_ENDPOINTS);
+		return NULL;
+	}
+
+	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_ULP);
+	if (node < 0) {
+		xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_ULP, NODE_ENDPOINTS);
+		priv->flags |= XOCL_IC_FLAT_SHELL;
+	}
+
+	*len = sizeof(*priv);
+
+	return priv;
+}
+
 static void devinfo_cb_setlevel(void *dev_hdl, void *subdevs, int num)
 {
 	struct xocl_subdev *subdev = subdevs;
@@ -785,6 +817,19 @@ static struct xocl_subdev_map subdev_map[] = {
 		.required_ip = 1,
 		.flags = 0,
 		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
+		.max_level = XOCL_SUBDEV_LEVEL_PRP,
+	},
+	{
+		.id = XOCL_SUBDEV_ICAP_CNTRL,
+		.dev_name = XOCL_ICAP_CNTRL,
+		.res_array = (struct xocl_subdev_res[]) {
+			{.res_name = NODE_ICAP_CONTROLLER},
+			{NULL},
+		},
+		.required_ip = 1,
+		.flags = 0,
+		.build_priv_data = icap_cntrl_build_priv,
 		.devinfo_cb = NULL,
 		.max_level = XOCL_SUBDEV_LEVEL_PRP,
 	},

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -251,7 +251,7 @@ static void *icap_cntrl_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t 
 	struct xocl_dev_core *core = XDEV(xdev_hdl);
 	void *blob;
 	struct xocl_icap_cntrl_privdata *priv;
-	int node;
+	int node, node1;
 
 	blob = core->fdt_blob;
 	if (!blob)
@@ -267,12 +267,18 @@ static void *icap_cntrl_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t 
 		return NULL;
 	}
 
-	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_ULP);
-	if (node < 0) {
-		xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_ULP, NODE_ENDPOINTS);
-		priv->flags |= XOCL_IC_FLAT_SHELL;
-	}
+	{
+		node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_ULP);
+		if (node < 0)
+			xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_ULP, NODE_ENDPOINTS);
 
+		node1 = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_PLP);
+		if (node < 0)
+			xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_PLP, NODE_ENDPOINTS);
+
+		if ((node < 0) && (node1 < 0))
+			priv->flags |= XOCL_IC_FLAT_SHELL;
+	}
 	*len = sizeof(*priv);
 
 	return priv;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -106,6 +106,7 @@
 #define NODE_INTC_CU_03 "ep_intc_cu_03"
 #define NODE_HOSTMEM_BANK0 "ep_c2h_data_00"
 #define NODE_PS_RESET_CTRL "ep_reset_ps_00"
+#define NODE_ICAP_CONTROLLER "ep_iprog_ctrl_00"
 
 #define PROP_HWICAP "axi_hwicap"
 #define PROP_PDI_CONFIG "pdi_config_mem"


### PR DESCRIPTION
-XRT will confirm if the shell is flat shell when the platform doesn't have isolate_ulp endpoint defined in the partition metadata.
-Add icap controller programming endpoint support for raptor2 0RP flow

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>