### PR TITLE
CR-1082277 M2M test fails during xbutil validate (if host_mem has bee…

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1509,6 +1509,11 @@ int xcldev::device::getXclbinuuid(uuid_t &uuid) {
     return 0;
 }
 
+bool xcldev::device::isHostMem(const char *m_tag)
+{
+    return (!strncmp(m_tag, "HOST", 4));
+}
+
 int xcldev::device::kernelVersionTest(void)
 {
     if (getenv_or_null("INTERNAL_BUILD")) {
@@ -2317,6 +2322,9 @@ int xcldev::device::testM2m()
     }
 
     for(int32_t i = 0; i < map->m_count; i++) {
+        if (isHostMem((const char *)map->m_mem_data[i].m_tag))
+            continue;
+
         if(map->m_mem_data[i].m_used &&
             map->m_mem_data[i].m_size * 1024 >= m2mBoSize) {
             /* use u8 m_type field to as bank index */

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1511,7 +1511,9 @@ int xcldev::device::getXclbinuuid(uuid_t &uuid) {
 
 bool xcldev::device::isHostMem(const char *m_tag)
 {
-    return (!strncmp(m_tag, "HOST", 4));
+    std::string str(m_tag);
+
+    return (!str.compare(0, 4, "HOST"));
 }
 
 int xcldev::device::kernelVersionTest(void)

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1727,7 +1727,7 @@ public:
             if(map->m_mem_data[i].m_type == MEM_STREAMING)
                 continue;
 
-            if(!strncmp((const char*)map->m_mem_data[i].m_tag, "HOST", 4))
+            if(isHostMem((const char*)map->m_mem_data[i].m_tag))
                 continue;
 
             if(map->m_mem_data[i].m_used) {
@@ -1950,6 +1950,7 @@ private:
     int runOneTest(std::string testName, std::function<int(void)> testFunc);
 
     int getXclbinuuid(uuid_t &uuid);
+    bool isHostMem(const char *m_tag);
 };
 
 void printHelp(const std::string& exe);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -835,6 +835,10 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
   auto mem_topo = reinterpret_cast<const mem_topology*>(membuf.data());
 
   for (auto& mem : boost::make_iterator_range(mem_topo->m_mem_data, mem_topo->m_mem_data + mem_topo->m_count)) {
+    std::string str((char *)mem.m_tag);
+    if (!str.compare(0, 4, "HOST"))
+        continue;
+
     if(mem.m_used && mem.m_size * 1024 >= bo_size)
       used_banks.push_back(mem);
   }


### PR DESCRIPTION
…n requested)

Per request from the CR, disable m2m test for HOST memory.