### PR TITLE
CR-1081102 update AWS platform shell with latest shell

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -710,7 +710,7 @@ static int get_header_from_iomem(struct feature_rom *rom)
 			memset(rom->header.VBNVName, 0,
 				sizeof(rom->header.VBNVName));
 			strncpy(rom->header.VBNVName,
-				"xilinx_aws-vu9p-f1_shell-v04261818_201920_2", 35);
+				"xilinx_aws-vu9p-f1_shell-v04261818_201920_2", 43);
 			rom->header.MajorVersion = 4;
 			rom->header.MinorVersion = 0;
 			rom->header.VivadoBuildID = 0xabcd;


### PR DESCRIPTION
Updated string length to 43 to match length of string being returned