### PR TITLE
CR-1082453 multi process test case hanging on zcu104

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -811,6 +811,11 @@ configure(struct sched_cmd *cmd)
 	if (sched_error_on(exec, opcode(cmd) != ERT_CONFIGURE))
 		return 1;
 
+	if (!zdev->ert && exec->configured) {
+		DRM_WARN("Reconfiguration not supported\n");
+		return 1;
+	}
+
 	if (!list_empty(&pending_cmds)) {
 		DRM_ERROR("Pending commands list not empty\n");
 		return 1;


### PR DESCRIPTION
KDS on edge should only be configured once. Otherwise, 
1. different thread will overwrite configuration done by other thread
2. no proper teardown before reconfiguring which leads to memory leak and other unexpected behavior