### PR TITLE
Fix memory bug

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -862,8 +862,6 @@ namespace xclcpuemhal2 {
     src = (unsigned char*)src + seek;
     dest += seek;
 
-    void *handle = this;
-
     unsigned int messageSize = get_messagesize();
     unsigned int c_size = messageSize;
     unsigned int processed_bytes = 0;
@@ -878,7 +876,7 @@ namespace xclcpuemhal2 {
       uint64_t c_dest = dest + processed_bytes;
 #ifndef _WINDOWS
       uint32_t space =0;
-      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,handle,c_dest,c_src,c_size,seek,space);
+      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,this,c_dest,c_src,c_size,seek,space);
 #endif
       processed_bytes += c_size;
     }

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -260,7 +260,7 @@ mtx.unlock();
 
 //-------------------xclClose---------------------------------
 #define xclClose_SET_PROTOMESSAGE(func_name,dev_handle) \
-    c_msg.set_xcldevicehandle((char*)dev_handle);\
+    c_msg.set_xcldevicehandle((void*)dev_handle, sizeof(decltype(*dev_handle)));\
     c_msg.set_closeall(mCloseAll);
 
 #define xclClose_SET_PROTO_RESPONSE() \
@@ -279,7 +279,7 @@ mtx.unlock();
 
 //-----------xclCopyBufferHost2Device-----------------
 #define xclCopyBufferHost2Device_SET_PROTOMESSAGE(func_name,dev_handle,dest,src,size,seek,space) \
-    c_msg.set_xcldevicehandle((char*)dev_handle); \
+    c_msg.set_xcldevicehandle((void*)dev_handle, sizeof(decltype(*dev_handle))); \
     c_msg.set_dest(dest); \
     c_msg.set_src((char*)src,size); \
     c_msg.set_size(size); \
@@ -303,7 +303,7 @@ mtx.unlock();
 
 //-----------xclCopyBufferDevice2Host-----------------
 #define xclCopyBufferDevice2Host_SET_PROTOMESSAGE(func_name,dev_handle,dest,src,size,skip,space) \
-    c_msg.set_xcldevicehandle((char*)dev_handle); \
+    c_msg.set_xcldevicehandle((void*)dev_handle, sizeof(decltype(*dev_handle))); \
     c_msg.set_dest((char*)dest,size); \
     c_msg.set_src(src); \
     c_msg.set_size(size); \

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -875,8 +875,6 @@ namespace xclcpuemhal2 {
     src = (unsigned char*)src + seek;
     dest += seek;
 
-    void *handle = this;
-
     unsigned int messageSize = get_messagesize();
     unsigned int c_size = messageSize;
     unsigned int processed_bytes = 0;
@@ -891,7 +889,7 @@ namespace xclcpuemhal2 {
       uint64_t c_dest = dest + processed_bytes;
 #ifndef _WINDOWS
       uint32_t space =0;
-      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,handle,c_dest,c_src,c_size,seek,space);
+      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,this,c_dest,c_src,c_size,seek,space);
 #endif
       processed_bytes += c_size;
     }
@@ -912,7 +910,6 @@ namespace xclcpuemhal2 {
       launchTempProcess();
     }
     src += skip;
-    void *handle = this;
 
     unsigned int messageSize = get_messagesize();
     unsigned int c_size = messageSize;
@@ -929,7 +926,7 @@ namespace xclcpuemhal2 {
       uint64_t c_src = src + processed_bytes;
 #ifndef _WINDOWS
       uint32_t space =0;
-      xclCopyBufferDevice2Host_RPC_CALL(xclCopyBufferDevice2Host,handle,c_dest,c_src,c_size,skip,space);
+      xclCopyBufferDevice2Host_RPC_CALL(xclCopyBufferDevice2Host,this,c_dest,c_src,c_size,skip,space);
 #endif
 
       processed_bytes += c_size;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1330,7 +1330,6 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     }
     std::string dMsg ="INFO: [HW-EMU 02-0] Copying buffer from host to device started : size = " + std::to_string(size);
     logMessage(dMsg,1);
-    void *handle = this;
 
     uint64_t messageSize = xclemulation::config::getInstance()->getPacketSize();
     uint64_t c_size = messageSize;
@@ -1348,7 +1347,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       // TODO: Windows build support
       // *_RPC_CALL uses unix_socket
       uint32_t space = getAddressSpace(topology);
-      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,handle,c_dest,c_src,c_size,seek,space);
+      xclCopyBufferHost2Device_RPC_CALL(xclCopyBufferHost2Device,this,c_dest,c_src,c_size,seek,space);
 #endif
       processed_bytes += c_size;
     }
@@ -1378,7 +1377,6 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 
     std::string dMsg ="INFO: [HW-EMU 05-0] Copying buffer from device to host started. size := " + std::to_string(size);
     logMessage(dMsg,1);
-    void *handle = this;
 
     uint64_t messageSize = xclemulation::config::getInstance()->getPacketSize();
     uint64_t c_size = messageSize;
@@ -1395,7 +1393,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       uint64_t c_src = src + processed_bytes;
 #ifndef _WINDOWS
       uint32_t space = getAddressSpace(topology);
-      xclCopyBufferDevice2Host_RPC_CALL(xclCopyBufferDevice2Host,handle,c_dest,c_src,c_size,skip,space);
+      xclCopyBufferDevice2Host_RPC_CALL(xclCopyBufferDevice2Host,this,c_dest,c_src,c_size,skip,space);
 #endif
 
       processed_bytes += c_size;


### PR DESCRIPTION
using the set_xcldevicehandle(const char*) the parameter is interpreted as null-terminated character array.
but set_xcldevicehandle is called from xclClose_RPC_CALL where dev_handle is a pointer to an object. it is wrong to interpret object as null-terminated character array, the size computed by strlen will be wrong.
This patch also correct other wrong indirect uses of set_xcldevicehandle(const char*).
