### PR TITLE
CR-1080843 xbutil validate SEG fault with hal profiling

### DIFF
--- a/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/core/edge/tools/xbutil/CMakeLists.txt
@@ -12,8 +12,8 @@ add_executable(xbutil ${XRT_EDGE_TOOLS_XBUTIL_FILES})
 
 if (DEFINED XRT_AIE_BUILD)
   target_link_libraries(xbutil
-    xrt_core_static
-    xrt_coreutil_static
+    xrt_core
+    xrt_coreutil
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     pthread
@@ -26,8 +26,8 @@ if (DEFINED XRT_AIE_BUILD)
     )
 else()
   target_link_libraries(xbutil
-    xrt_core_static
-    xrt_coreutil_static
+    xrt_core
+    xrt_coreutil
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     pthread

--- a/src/runtime_src/core/pcie/tools/xbutil/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/tools/xbutil/CMakeLists.txt
@@ -13,8 +13,8 @@ set(XBUTIL_SRC ${XBUTIL_FILES})
 add_executable(xbutil ${XBUTIL_SRC})
 
 target_link_libraries(xbutil
-  xrt_core_static
-  xrt_coreutil_static
+  xrt_core
+  xrt_coreutil
   pthread
   rt
   dl

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -74,8 +74,7 @@ else()
   target_link_libraries(
     ${XBUTIL2_NAME}
     xrt_core
-    xrt_core_static
-    xrt_coreutil_static
+    xrt_coreutil
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}


### PR DESCRIPTION
Change xbutil to dynamic link with xrt_core and xrt_coreutil

The static linking caused problems for hal level profiling, which
run-time loads plugin libraries that are dynamically linked with
xrt_core and xrt_coreutil.  Static global data from xrt_core was
duplicated in both xbutil and the plugin library.