### PR TITLE
simplified in-kernel command completions

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -39,10 +39,8 @@ struct kds_cmd_ops {
 };
 
 struct in_kernel_cb {
-	struct work_struct work;
 	void (*func)(unsigned long cb_data, int err);
 	void *data;
-	int  cmd_state;
 };
 
 /**


### PR DESCRIPTION
Converting in-kernel completions (called via linux work-queues) to simple function call, so that the in-kernel applications (eg: XSS) be responsible for designing its own completion context (kthread or local workqueue).
