### PR TITLE
CR-1082655:Added support for device buffer to device buffer copy in xclCopyBO in sw and hw emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1372,7 +1372,7 @@ int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, s
       return -1;
     }
   }
-  else if (dBO->fd > 0) {
+  else if (dBO->fd >= 0) {
     int ack = false;
     auto fItr = mFdToFileNameMap.find(dBO->fd);
     if (fItr != mFdToFileNameMap.end()) {

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1359,21 +1359,32 @@ int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, s
       return -1;
     }
   }
-  else {
-    if (dBO->fd < 0)
-    {
-      std::cout << "bo is not exported for copying" << std::endl;
+  else if (!xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_host_only(dBO) && (dBO->fd < 0) && (sBO->fd < 0)) {
+    unsigned char temp_buffer[size];
+    // copy data from source buffer to temp buffer
+    if (xclCopyBufferDevice2Host((void*)temp_buffer, sBO->base, size, src_offset) != size) {
+      std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
       return -1;
     }
+    // copy data from temp buffer to destination buffer
+    if (xclCopyBufferHost2Device(dBO->base, (void*)temp_buffer, size, dst_offset) != size) {
+      std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;
+      return -1;
+    }
+  }
+  else if (dBO->fd > 0) {
     int ack = false;
     auto fItr = mFdToFileNameMap.find(dBO->fd);
-    if (fItr != mFdToFileNameMap.end())
-    {
+    if (fItr != mFdToFileNameMap.end()) {
       const std::string& sFileName = std::get<0>((*fItr).second);
       xclCopyBO_RPC_CALL(xclCopyBO, sBO->base, sFileName, size, src_offset, dst_offset);
     }
     if (!ack)
       return -1;
+  }
+  else {
+    std::cerr << "ERROR: Copy buffer from source to destination faliled" << std::endl;
+    return -1;
   }
 
   PRINTENDFUNC;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2622,12 +2622,21 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     if (xclCopyBufferDevice2Host((void*)host_only_buffer, sBO->base, size, src_offset, sBO->topology) != size) {
       return -1;
     }
-  }
-  else {
-    if (dBO->fd < 0) {
-      std::cout << "bo is not exported for copying" << std::endl;
+  }// source and destination buffers are device_only
+  else if (!xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_host_only(dBO) && (dBO->fd < 0) && (sBO->fd < 0)) {
+    unsigned char temp_buffer[size];
+    // copy data from source buffer to temp buffer
+    if (xclCopyBufferDevice2Host((void*)temp_buffer, sBO->base, size, src_offset, sBO->topology) != size) {
+      std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
       return -1;
     }
+    // copy data from temp buffer to destination buffer
+    if (xclCopyBufferHost2Device(dBO->base, (void*)temp_buffer, size, dst_offset, dBO->topology) != size) {
+      std::cerr << "ERROR: copy buffer from host to device failed " << std::endl;
+      return -1;
+    }
+  }
+  else if(dBO->fd > 0){  //destination p2p buffer 
     int ack = false;
     auto fItr = mFdToFileNameMap.find(dBO->fd);
     if (fItr != mFdToFileNameMap.end()) {
@@ -2636,6 +2645,10 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     }
     if (!ack)
       return -1;
+  }
+  else{
+     std::cerr << "ERROR: Copy buffer from source to destination faliled" << std::endl;
+     return -1;
   }
 
   PRINTENDFUNC;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2636,7 +2636,7 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
       return -1;
     }
   }
-  else if(dBO->fd > 0){  //destination p2p buffer 
+  else if(dBO->fd >= 0){  //destination p2p buffer 
     int ack = false;
     auto fItr = mFdToFileNameMap.find(dBO->fd);
     if (fItr != mFdToFileNameMap.end()) {


### PR DESCRIPTION
Issue: when XDMA+M2M enabled, xclCopyBO is not supported for copy of one device buffer to another device buffer in sw emu/hw emu
Fix: Added support for copy of device buffer to another device buffer in xclCopyBO for both sw emu and hw emu drivers.
Test: Manually tested some cases which are dependent on xclCopyBO like P2P, NoDMA cases, slave bridge, slave bridge+M2M, XDMA+M2M cases. and also ran canary with the fix
Risk: Low