### PR TITLE
fixing petalinux related builds due to bsp path

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -138,6 +138,7 @@ fi
 if [ -f $SETTINGS_FILE ]; then
     source $SETTINGS_FILE
 fi
+PETALINUX="/proj/petalinux/2020.2/petalinux-v2020.2_1108_1/tool/petalinux-v2020.2-final"
 source $PETALINUX/settings.sh 
 
 if [[ $AARCH = $aarch64_dir ]]; then


### PR DESCRIPTION
* its a temporary fix for pipeline as petalinx linux is in release phase and 1109_1 bsp's are not available