### PR TITLE
CR-1082770 xbutil validate fails dmatest on card[1]

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1215,7 +1215,7 @@ int xcldev::device::runTestCase(const std::string& py,
             return -ENOENT;
         }
 
-        cmd = xrtTestCasePath + " " + xclbinPath;
+        cmd = xrtTestCasePath + " " + xclbinPath + " -d " + std::to_string(m_idx);
     }
     //OLD FLOW:
     else { 


### PR DESCRIPTION
```
# xbutil validate -d 1
INFO: Found 1 cards

INFO: Validating card[1]: xilinx_u30_gen3x4_base_1
INFO: == Starting Kernel version check:
Developer's build. Skipping validation
INFO: == Kernel version check SKIPPED
INFO: == Starting AUX power connector check:
AUX power connector not available. Skipping validation
INFO: == AUX power connector check SKIPPED
INFO: == Starting Power warning check:
INFO: == Power warning check PASSED
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: == Starting DMA test:
Host -> PCIe -> FPGA write bandwidth = 3284.493598 MB/s
Host <- PCIe <- FPGA read bandwidth = 3165.026458 MB/s
INFO: == DMA test PASSED
INFO: == Starting device memory bandwidth test:
.
Maximum throughput: 8822.72MB/s
INFO: == device memory bandwidth test PASSED
INFO: == Starting PCIE peer-to-peer test:
P2P BAR is not enabled. Skipping validation
INFO: == PCIE peer-to-peer test SKIPPED
INFO: == Starting memory-to-memory DMA test:
M2M is not available. Skipping validation
INFO: == memory-to-memory DMA test SKIPPED
INFO: == Starting host memory bandwidth test:
Host_mem is not available. Skipping validation
INFO: == host memory bandwidth test SKIPPED
INFO: Card[1] validated successfully.

INFO: All cards validated successfully.
```
