### PR TITLE
xbutil scan always return 0 even device is not ready

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -120,12 +120,12 @@ is_supported_kernel_version(std::ostream &ostr)
     return true;
 }
 
-static void print_pci_info(std::ostream &ostr)
+static bool print_pci_info(std::ostream &ostr)
 {
     ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
     if (pcidev::get_dev_total() == 0) {
         ostr << "No card found!" << std::endl;
-        return;
+        return true;
     }
 
     for (unsigned j = 0; j < pcidev::get_dev_total(); j++) {
@@ -139,9 +139,10 @@ static void print_pci_info(std::ostream &ostr)
 
     if (pcidev::get_dev_total() != pcidev::get_dev_ready()) {
         ostr << "WARNING: card(s) marked by '*' are not ready." << std::endl;
+        return false;
     }
 
-    is_supported_kernel_version(ostr);
+    return is_supported_kernel_version(ostr);
 }
 
 static int xrt_xbutil_version_cmp()
@@ -614,8 +615,7 @@ int main(int argc, char *argv[])
     }
 
     if (cmd == xcldev::SCAN || cmd == xcldev::LIST) {
-        print_pci_info(std::cout);
-        return 0;
+        return print_pci_info(std::cout) ? 0 : -ENOENT;
     }
 
     for (unsigned i = 0; i < count; i++) {


### PR DESCRIPTION
When I am testing the xbutil scan for multiple devices on one system, the xbutil scan always return 0 even one of the device is not ready. Compare the code just around this code, we return -ENOENT for not ready device. Not sure if this is acceptable or by design, but certainly it will help my script. 

examples:

```
INFO: Found total 1 card(s), 0 are usable                                                                      
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                               
System Configuration                                                                                           
OS name:        Linux                                                                                          
Release:        5.4.0-53-generic                                                                               
Version:        #59-Ubuntu SMP Wed Oct 21 09:38:44 UTC 2020                                                    
Machine:        x86_64                                                                                         
Model:          PowerEdge T640                                                                                 
CPU cores:      12                                                                                             
Memory:         63367 MB                                                                                       
Glibc:          2.31                                                                                           
Distribution:   Ubuntu 20.04.1 LTS                                                                             
Now:            Wed Nov 11 20:55:13 2020 GMT                                                                   
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                               
XRT Information                                                                                                
Version:        2.8.721                                                                                        
Git Hash:       c9744bbeed4ef319332805b7b61c81042c18ded7                                                       
Git Branch:     2020.2                                                                                         
Build Date:     2020-11-09 14:05:37                                                                            
XOCL:           unknown                                                                                        
XCLMGMT:        2.8.721,c9744bbeed4ef319332805b7b61c81042c18ded7                                               
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                               
*[0] 0000:3b:00.1  user(inst=128)                                                                              
WARNING: card(s) marked by '*' are not ready.                                                                  
INFO: Found total 1 card(s), 0 are usable    
```

```                                                                  
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                               
System Configuration                                                                                           
OS name:        Linux                                                                                          
Release:        5.4.0-53-generic                                                                               
Version:        #59-Ubuntu SMP Wed Oct 21 09:38:44 UTC 2020                                                    
Machine:        x86_64                                                                                         
Model:          PowerEdge T640                                                                                 
CPU cores:      12                                                                                             
Memory:         63367 MB
Glibc:          2.31
Distribution:   Ubuntu 20.04.1 LTS
Now:            Wed Nov 11 20:55:13 2020 GMT
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
XRT Information
Version:        2.8.721
Git Hash:       c9744bbeed4ef319332805b7b61c81042c18ded7
Git Branch:     2020.2
Build Date:     2020-11-09 14:05:37
XOCL:           unknown
XCLMGMT:        2.8.721,c9744bbeed4ef319332805b7b61c81042c18ded7
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
*[0] 0000:3b:00.1  user(inst=128)
WARNING: card(s) marked by '*' are not ready.
ERROR: Card[1] not found
ERROR: Card index 1 is out of range
INFO: Found total 1 card(s), 0 are usable

```