### PR TITLE
Cleanup how XRT links with Boost libraries

### DIFF
--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -21,9 +21,10 @@ endif(GIT_FOUND)
 #set(Boost_DEBUG 1)
 
 INCLUDE (FindBoost)
-find_package(Boost 
-  REQUIRED COMPONENTS system filesystem)
 set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost
+  REQUIRED COMPONENTS system filesystem)
 
 if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
   add_definitions (-DBOOST_PRE_1_64=1)
@@ -67,4 +68,3 @@ include (CMake/version.cmake)
 
 message ("------------ xrt install dir: ${XRT_INSTALL_DIR}")
 add_subdirectory(runtime_src)
-

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -21,13 +21,18 @@ endif(GIT_FOUND)
 #set(Boost_DEBUG 1)
 
 INCLUDE (FindBoost)
-INCLUDE (FindGTest)
-include_directories(${Boost_INCLUDE_DIRS})
-add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")
+find_package(Boost 
+  REQUIRED COMPONENTS system filesystem)
+set(Boost_USE_MULTITHREADED ON)
 
 if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
   add_definitions (-DBOOST_PRE_1_64=1)
 endif()
+
+include_directories(${Boost_INCLUDE_DIRS})
+add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")
+
+INCLUDE (FindGTest)
 
 # --- XRT Variables ---
 set (XRT_INSTALL_DIR "xrt")

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -4,11 +4,6 @@ include_directories(
 
 if (NOT WIN32)
 include_directories(${DRM_INCLUDE_DIRS})
-else()
-set(Boost_USE_STATIC_LIBS     ON)
-set(Boost_USE_MULTITHREADED   ON)
-find_package(Boost REQUIRED COMPONENTS system filesystem )
-include_directories(${Boost_INCLUDE_DIRS})
 endif (NOT WIN32)
 
 file(GLOB XRT_CORE_COMMON_LIB_FILES

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -1,10 +1,5 @@
 # -----------------------------------------------------------------------------
-
-set(Boost_USE_STATIC_LIBS ON)               # Only find static libraries
-set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
-
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
-include_directories(${Boost_INCLUDE_DIRS})
 
 # -----------------------------------------------------------------------------
 
@@ -77,8 +72,7 @@ else()
   target_link_libraries(
     ${XBMGMT2_NAME}
     xrt_core
-    xrt_core_static
-    xrt_coreutil_static
+    xrt_coreutil
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -1,10 +1,5 @@
 # -----------------------------------------------------------------------------
-
-set(Boost_USE_STATIC_LIBS ON)               # Only find static libraries
-set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
-
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
-include_directories(${Boost_INCLUDE_DIRS})
 
 # -----------------------------------------------------------------------------
 

--- a/src/runtime_src/tools/scripts/boost.sh
+++ b/src/runtime_src/tools/scripts/boost.sh
@@ -14,6 +14,7 @@ usage()
     echo "[-install <path>]          Path to install directory (default: $PWD/boost/xrt)"
     echo "[-srcdir <path>]           Directory for boost sources (default: $PWD/boost/build)"
     echo "[-noclone]                 Don't clone fresh, use exist 'srcdir'"
+    echo "[-nobuild]                 Don't build boost, just exit with message"
     echo ""
     echo "Clone, build, and install boost"
     echo "% boost.sh -prefix $HOME/tmp/boost"
@@ -93,6 +94,7 @@ fi
 if [[ $nobuild == 0 ]] ; then
     echo "Building Boost from '$srcdir' and installing in '$install'"
 fi
+
 read -p "Ok to continue (Y/n): " answer
 answer=${answer:-Y}
 echo $answer

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -1,15 +1,7 @@
 # -----------------------------------------------------------------------------
 # Required libraries
 
-#TODO: Remove the window dependency on these settings.  
-if(WIN32)
-  set(Boost_USE_STATIC_LIBS ON)      # Only find static libraries
-  set(Boost_USE_MULTITHREADED ON)    # Multi-threaded libraries
-  set(Boost_USE_STATIC_RUNTIME ON)   # This is how the boost libraries were build
-endif()
-
 find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
-include_directories(${Boost_INCLUDE_DIRS})
 
 # Signing xclbin images are currently only support on Linux
 if(NOT WIN32)

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 
 # Signing xclbin images are currently only support on Linux
 if(NOT WIN32)
-  find_package(OpenSSL REQUIRED)      
+  find_package(OpenSSL REQUIRED)
 endif()
 
 # -----------------------------------------------------------------------------
@@ -20,7 +20,7 @@ set(XCLBINUTIL_NAME "xclbinutil")
 set(XRT_LOADER_SCRIPTS ${XCLBINUTIL_NAME})
 
 if(WIN32)
-  # Add the command shell wrapper in addition to the bash shell wrapper. 
+  # Add the command shell wrapper in addition to the bash shell wrapper.
   # Note: The bash shell wrapper is smart and will call this wrapper
   list(APPEND XRT_LOADER_SCRIPTS ${XCLBINUTIL_NAME}.bat)
 endif()
@@ -31,7 +31,7 @@ file(GLOB XCLBINUTIL_FILES
   "FormattedOutput.cxx"
   "ParameterSectionData.cxx"
   "Section.cxx"     # Note: Due to linking dependency issue, this entry needs to be before the other sections
-  "Section*.cxx"  
+  "Section*.cxx"
   "XclBinClass.cxx"
   "XclBinSignature.cxx"
   "XclBinUtilities.cxx"
@@ -45,16 +45,6 @@ file(GLOB XCLBINUTIL_MAIN_FILE
 set(XCLBINUTIL_SRCS ${XCLBINUTIL_MAIN_FILE} ${XCLBINUTIL_FILES_SRCS})
 
 add_executable(${XCLBINUTIL_NAME} ${XCLBINUTIL_SRCS})
-
-if(WIN32)
-  # Use the static version of the run-time library
-  # Note: Needed to link with boost
-  if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    target_compile_options(${XCLBINUTIL_NAME} PRIVATE /MTd)
-  else()
-    target_compile_options(${XCLBINUTIL_NAME} PRIVATE /MT)
-  endif()
-endif()
 
 # Signing xclbin images currently is not support on windows
 if(NOT WIN32)
@@ -92,23 +82,15 @@ if (GTEST_FOUND)
   set(XCLBINTEST_SRCS ${XCLBINTEST_FILES} ${XCLBINUTIL_FILES_SRCS})
   add_executable(${UNIT_TEST_NAME} ${XCLBINTEST_SRCS})
 
-  if(WIN32) 
+  if(WIN32)
     target_link_libraries(${UNIT_TEST_NAME} PRIVATE Boost::filesystem Boost::program_options Boost::system )
     target_link_libraries(${UNIT_TEST_NAME} PRIVATE ${GTEST_BOTH_LIBRARIES})
-
-    # Use the static version of the run-time library 
-    # Note: Needed to link with boost
-    if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-      target_compile_options(${UNIT_TEST_NAME} PRIVATE /MTd)
-    else()
-      target_compile_options(${UNIT_TEST_NAME} PRIVATE /MT)
-    endif()
   else()
     target_link_libraries(xclbintest ${Boost_LIBRARIES} ${GTEST_BOTH_LIBRARIES} pthread crypto)
   endif()
 
   message(STATUS "Configuring CMake to run unit test after building")
-  add_test(NAME ${UNIT_TEST_NAME} 
+  add_test(NAME ${UNIT_TEST_NAME}
            COMMAND ${UNIT_TEST_NAME}
            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
@@ -118,14 +100,14 @@ if (GTEST_FOUND)
     add_custom_command(
          TARGET ${UNIT_TEST_NAME}
          COMMENT "Run xclbinutil unit-tests"
-         POST_BUILD 
+         POST_BUILD
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
          COMMAND ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE} -R ${UNIT_TEST_NAME} --output-on-failures
       )
   endif()
 
   # Execute unit tests after the xclbintest is created.
-  # Note: This command works GREAT if the tests pass.  If they fail xclbintest is deleted, 
+  # Note: This command works GREAT if the tests pass.  If they fail xclbintest is deleted,
   #       hence this code is commented out.
   #  add_custom_command(
   #     TARGET ${UNIT_TEST_XCLBINUTIL}

--- a/src/runtime_src/xrt/CMakeLists.txt
+++ b/src/runtime_src/xrt/CMakeLists.txt
@@ -6,12 +6,7 @@ include_directories(
 
 if (NOT WIN32)
   include_directories(${DRM_INCLUDE_DIRS})
-else()
-set(Boost_USE_STATIC_LIBS     ON)
-set(Boost_USE_MULTITHREADED   ON)
-find_package(Boost REQUIRED COMPONENTS system filesystem )
-include_directories(${Boost_INCLUDE_DIRS})
-endif (NOT WIN32)
+endif()
 
 set(XRT_XRT_DEVICE_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/device")
 set(XRT_XRT_SCHED_DIR   "${CMAKE_CURRENT_SOURCE_DIR}/scheduler")


### PR DESCRIPTION
On Linux, the default is dynamic linking with Boost in all make-files.  Static linking with Boost is supported only via runtime_src/tools/scripts/boost.sh, which downloads a release of boost, builds static boost libraries with proper options, and lists how to use these static libraries when building XRT.

On Windows, XRT only supports static linking with Boost through libraries built and installed using xrtdeps-win.py.

This PR replaces #4430 