### PR TITLE
XRT Graph c++ API

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -108,19 +108,7 @@ public:
   }
 
   void
-  update_rtp(const std::string& port, const char* buffer, size_t size)
-  {
-    device->update_graph_rtp(handle, port, buffer, size);
-  }
-
-  void
   read_rtp(const char* port, char* buffer, size_t size)
-  {
-    device->read_graph_rtp(handle, port, buffer, size);
-  }
-
-  void
-  read_rtp(const std::string& port, char* buffer, size_t size)
   {
     device->read_graph_rtp(handle, port, buffer, size);
   }
@@ -316,14 +304,14 @@ void
 graph::
 update_port(const std::string& port_name, const void* value, size_t bytes)
 {
-  handle->update_rtp(port_name, reinterpret_cast<const char*>(value), bytes);
+  handle->update_rtp(port_name.c_str(), reinterpret_cast<const char*>(value), bytes);
 }
 
 void
 graph::
 read_port(const std::string& port_name, void* value, size_t bytes)
 {
-  handle->read_rtp(port_name, reinterpret_cast<char *>(value), bytes);
+  handle->read_rtp(port_name.c_str(), reinterpret_cast<char *>(value), bytes);
 }
 
 } // namespace xrt

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -249,22 +249,26 @@ run(uint32_t iterations)
 
 void
 graph::
-wait(int timeout_ms)
+wait(std::chrono::milliseconds timeout_ms)
 {
-  if (timeout_ms == 0)
+  if (timeout_ms.count() == 0)
     handle->wait(static_cast<uint64_t>(0));
   else
-    handle->wait(timeout_ms);
+    handle->wait(static_cast<int>(timeout_ms.count()));
 }
 
 void
 graph::
-suspend(uint64_t cycles)
+wait(uint64_t cycles)
 {
-  if (cycles == 0)
-    handle->suspend();
-  else
-    wait(cycles);
+  handle->wait(cycles);
+}
+
+void
+graph::
+suspend()
+{
+  handle->suspend();
 }
 
 void

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -20,6 +20,7 @@
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_bo.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_bo.h"
+#include "core/include/experimental/xrt_aie.h"
 #include "bo.h"
 
 #include "device_int.h"
@@ -241,6 +242,12 @@ public:
 
     // sync modified host buffer to device
     sync(XCL_BO_SYNC_BO_TO_DEVICE, sz, dst_offset);
+  }
+
+  void
+  sync(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
+  {
+    device->sync_aie_bo(bo, port.c_str(), dir, sz, offset);
   }
 
   virtual void
@@ -723,6 +730,22 @@ copy(const bo& src, size_t sz, size_t src_offset, size_t dst_offset)
 }
 
 } // xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_aie_bo C++ API implmentations (xrt_aie.h)
+////////////////////////////////////////////////////////////////
+namespace xrt { namespace aie {
+
+void
+bo::
+sync(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
+{
+  auto handle = get_handle();
+
+  handle->sync(*this, port, dir, sz, offset);
+}
+
+}} // namespace aie, xrt
 
 ////////////////////////////////////////////////////////////////
 // xrt_bo API implmentations (xrt_bo.h)

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -244,11 +244,13 @@ public:
     sync(XCL_BO_SYNC_BO_TO_DEVICE, sz, dst_offset);
   }
 
+#ifdef XRT_ENABLE_AIE
   void
   sync(xrt::bo& bo, const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
   {
     device->sync_aie_bo(bo, port.c_str(), dir, sz, offset);
   }
+#endif
 
   virtual void
   sync(xclBOSyncDirection dir, size_t sz, size_t offset)
@@ -731,6 +733,7 @@ copy(const bo& src, size_t sz, size_t src_offset, size_t dst_offset)
 
 } // xrt
 
+#ifdef XRT_ENABLE_AIE
 ////////////////////////////////////////////////////////////////
 // xrt_aie_bo C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
@@ -746,6 +749,7 @@ sync(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
 }
 
 }} // namespace aie, xrt
+#endif
 
 ////////////////////////////////////////////////////////////////
 // xrt_bo API implmentations (xrt_bo.h)

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -17,10 +17,11 @@
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_device.h
-#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_bo.h
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_device.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 
 #include "core/include/experimental/xrt_device.h"
+#include "core/include/experimental/xrt_aie.h"
 
 #include "core/common/system.h"
 #include "core/common/device.h"
@@ -168,6 +169,21 @@ get_xclbin_section(axlf_section_kind section, const uuid& uuid) const
 }
 
 } // xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_aie_device C++ API implmentations (xrt_aie.h)
+////////////////////////////////////////////////////////////////
+namespace xrt { namespace aie {
+
+void
+device::
+reset_array()
+{
+  auto handle = get_handle();
+  handle->reset_aie();
+}
+
+}} // namespace aie, xrt
 
 ////////////////////////////////////////////////////////////////
 // xrt_device API implmentations (xrt_device.h)

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -170,6 +170,7 @@ get_xclbin_section(axlf_section_kind section, const uuid& uuid) const
 
 } // xrt
 
+#ifdef XRT_ENABLE_AIE
 ////////////////////////////////////////////////////////////////
 // xrt_aie_device C++ API implmentations (xrt_aie.h)
 ////////////////////////////////////////////////////////////////
@@ -184,6 +185,7 @@ reset_array()
 }
 
 }} // namespace aie, xrt
+#endif
 
 ////////////////////////////////////////////////////////////////
 // xrt_device API implmentations (xrt_device.h)

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -146,13 +146,13 @@ struct ishim
   read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) = 0;
 
   virtual void
-  sync_aie_bo(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
+  sync_aie_bo(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
 
   virtual void
   reset_aie() = 0;
 
   virtual void
-  sync_aie_bo_nb(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
+  sync_aie_bo_nb(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
 
   virtual void
   wait_gmio(const char *gmioName) = 0;
@@ -450,9 +450,9 @@ struct shim : public DeviceType
   }
 
   virtual void
-  sync_aie_bo(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  sync_aie_bo(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
   {
-    if (auto ret = xclSyncBOAIE(DeviceType::get_device_handle(), bohdl, gmioName, dir, size, offset))
+    if (auto ret = xclSyncBOAIE(DeviceType::get_device_handle(), bo, gmioName, dir, size, offset))
       throw error(ret, "fail to sync aie bo");
   }
 
@@ -464,9 +464,9 @@ struct shim : public DeviceType
   }
 
   virtual void
-  sync_aie_bo_nb(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  sync_aie_bo_nb(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
   {
-    if (auto ret = xclSyncBOAIENB(DeviceType::get_device_handle(), bohdl, gmioName, dir, size, offset))
+    if (auto ret = xclSyncBOAIENB(DeviceType::get_device_handle(), bo, gmioName, dir, size, offset))
       throw error(ret, "fail to sync aie non-blocking bo");
   }
 

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -143,13 +143,7 @@ struct ishim
   update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size) = 0;
 
   virtual void
-  update_graph_rtp(xclGraphHandle handle, const std::string& port, const char* buffer, size_t size) = 0;
-
-  virtual void
   read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) = 0;
-
-  virtual void
-  read_graph_rtp(xclGraphHandle handle, const std::string& port, char* buffer, size_t size) = 0;
 
   virtual void
   sync_aie_bo(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
@@ -449,21 +443,7 @@ struct shim : public DeviceType
   }
 
   virtual void
-  update_graph_rtp(xclGraphHandle handle, const std::string& port, const char* buffer, size_t size)
-  {
-    if (auto ret = xclGraphUpdateRTP(handle, port, buffer, size))
-      throw error(ret, "fail to update graph rtp");
-  }
-
-  virtual void
   read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size)
-  {
-    if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
-      throw error(ret, "fail to read graph rtp");
-  }
-
-  virtual void
-  read_graph_rtp(xclGraphHandle handle, const std::string& port, char* buffer, size_t size)
   {
     if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
       throw error(ret, "fail to read graph rtp");

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -143,7 +143,13 @@ struct ishim
   update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size) = 0;
 
   virtual void
+  update_graph_rtp(xclGraphHandle handle, const std::string& port, const char* buffer, size_t size) = 0;
+
+  virtual void
   read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) = 0;
+
+  virtual void
+  read_graph_rtp(xclGraphHandle handle, const std::string& port, char* buffer, size_t size) = 0;
 
   virtual void
   sync_aie_bo(xrtBufferHandle bohdl, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) = 0;
@@ -443,7 +449,21 @@ struct shim : public DeviceType
   }
 
   virtual void
+  update_graph_rtp(xclGraphHandle handle, const std::string& port, const char* buffer, size_t size)
+  {
+    if (auto ret = xclGraphUpdateRTP(handle, port, buffer, size))
+      throw error(ret, "fail to update graph rtp");
+  }
+
+  virtual void
   read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size)
+  {
+    if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
+      throw error(ret, "fail to read graph rtp");
+  }
+
+  virtual void
+  read_graph_rtp(xclGraphHandle handle, const std::string& port, char* buffer, size_t size)
   {
     if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
       throw error(ret, "fail to read graph rtp");

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -288,6 +288,7 @@ zocl_hls_check(void *core, struct zcu_tasks_info *tasks_info)
 		ctrl_reg = ioread32(cu_core->vaddr);
 		if ((ctrl_reg & CU_AP_DONE) != 0)
 			DRM_ERROR("AP_DONE is not zero: 0x%x", ctrl_reg);
+
 	}
 
 	tasks_info->num_tasks_ready = ready_cnt;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu.c
@@ -288,7 +288,6 @@ zocl_hls_check(void *core, struct zcu_tasks_info *tasks_info)
 		ctrl_reg = ioread32(cu_core->vaddr);
 		if ((ctrl_reg & CU_AP_DONE) != 0)
 			DRM_ERROR("AP_DONE is not zero: 0x%x", ctrl_reg);
-
 	}
 
 	tasks_info->num_tasks_ready = ready_cnt;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -776,7 +776,7 @@ xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size
 }
 
 int
-xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   return 0;
 }
@@ -788,7 +788,7 @@ xclResetAIEArray(xclDeviceHandle handle)
 }
 
 int
-xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   return 0;
 }

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -770,7 +770,19 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 int
+xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size)
+{
+  return 0;
+}
+
+int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size)
+{
+  return 0;
+}
+
+int
+xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char *buffer, size_t size)
 {
   return 0;
 }

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -770,19 +770,7 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 int
-xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size)
-{
-  return 0;
-}
-
-int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size)
-{
-  return 0;
-}
-
-int
-xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char *buffer, size_t size)
 {
   return 0;
 }

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -101,10 +101,10 @@ public:
     XAie_DevInst *getDevInst();
 
     void
-    sync_bo(xrtBufferHandle bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    sync_bo(xrt::bo& bo, const char *dmaID, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
-    sync_bo_nb(xrtBufferHandle bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    sync_bo_nb(xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
     wait_gmio(const std::string& gmioName);
@@ -122,7 +122,7 @@ public:
     stop_profiling(int phdl);
 
     void
-    prepare_bd(BD& bd, xrtBufferHandle& bo);
+    prepare_bd(BD& bd, xrt::bo& bo);
 
     void
     clear_bd(BD& bd);
@@ -136,7 +136,7 @@ private:
     std::vector<EventRecord> eventRecords;
 
     void
-    submit_sync_bo(xrtBufferHandle bo, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size, size_t offset);
+    submit_sync_bo(xrt::bo& bo, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     /* Wait for all the BD transfers for a given channel */
     void
@@ -180,5 +180,4 @@ struct BD_scope {
 
 }
 
-uint64_t xrtBOAddress(xrtBufferHandle bhdl);
 #endif

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -695,7 +695,7 @@ xclGraphReadRTP(xclGraphHandle ghdl, const char* port, char* buffer, size_t size
 }
 
 void
-xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
 #ifndef __AIESIM__
   auto device = xrt_core::get_userpf_device(handle);
@@ -708,16 +708,16 @@ xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
   auto aieArray = getAieArray();
 #endif
 
-  auto bosize = xrtBOSize(bohdl);
+  auto bosize = bo.size();
 
   if (offset + size > bosize)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
 
-  aieArray->sync_bo(bohdl, gmioName, dir, size, offset);
+  aieArray->sync_bo(bo, gmioName, dir, size, offset);
 }
 
 void
-xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
 #ifndef __AIESIM__
   auto device = xrt_core::get_userpf_device(handle);
@@ -730,12 +730,12 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
   auto aieArray = getAieArray();
 #endif
 
-  auto bosize = xrtBOSize(bohdl);
+  auto bosize = bo.size();
 
   if (offset + size > bosize)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: exceed BO boundary.");
 
-  aieArray->sync_bo_nb(bohdl, gmioName, dir, size, offset);
+  aieArray->sync_bo_nb(bo, gmioName, dir, size, offset);
 }
 
 void
@@ -1020,10 +1020,10 @@ xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size
 }
 
 int
-xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
-    api::xclSyncBOAIE(handle, bohdl, gmioName, dir, size, offset);
+    api::xclSyncBOAIE(handle, bo, gmioName, dir, size, offset);
     return 0;
   }
   catch (const xrt_core::error& ex) {
@@ -1068,10 +1068,10 @@ xclResetAIEArray(xclDeviceHandle handle)
  * Note: Upon return, the synchronization is submitted or error out
  */
 int
-xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
+xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
-    api::xclSyncBOAIENB(handle, bohdl, gmioName, dir, size, offset);
+    api::xclSyncBOAIENB(handle, bo, gmioName, dir, size, offset);
     return 0;
   }
   catch (const xrt_core::error& ex) {

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -688,7 +688,21 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 void
+xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size)
+{
+  auto graph = get_graph(ghdl);
+  graph->update_rtp(port, buffer, size);
+}
+
+void
 xclGraphReadRTP(xclGraphHandle ghdl, const char* port, char* buffer, size_t size)
+{
+  auto graph = get_graph(ghdl);
+  graph->read_rtp(port, buffer, size);
+}
+
+void
+xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char* buffer, size_t size)
 {
   auto graph = get_graph(ghdl);
   graph->read_rtp(port, buffer, size);
@@ -1003,7 +1017,41 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 int
+xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size)
+{
+  try {
+    api::xclGraphUpdateRTP(ghdl, port, buffer, size);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -1;
+  }
+}
+
+int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size)
+{
+  try {
+    api::xclGraphReadRTP(ghdl, port, buffer, size);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -1;
+  }
+}
+
+int
+xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char *buffer, size_t size)
 {
   try {
     api::xclGraphReadRTP(ghdl, port, buffer, size);

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -688,21 +688,7 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 void
-xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size)
-{
-  auto graph = get_graph(ghdl);
-  graph->update_rtp(port, buffer, size);
-}
-
-void
 xclGraphReadRTP(xclGraphHandle ghdl, const char* port, char* buffer, size_t size)
-{
-  auto graph = get_graph(ghdl);
-  graph->read_rtp(port, buffer, size);
-}
-
-void
-xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char* buffer, size_t size)
 {
   auto graph = get_graph(ghdl);
   graph->read_rtp(port, buffer, size);
@@ -1017,41 +1003,7 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
 }
 
 int
-xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size)
-{
-  try {
-    api::xclGraphUpdateRTP(ghdl, port, buffer, size);
-    return 0;
-  }
-  catch (const xrt_core::error& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return ex.get();
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return -1;
-  }
-}
-
-int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size)
-{
-  try {
-    api::xclGraphReadRTP(ghdl, port, buffer, size);
-    return 0;
-  }
-  catch (const xrt_core::error& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return ex.get();
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return -1;
-  }
-}
-
-int
-xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char *buffer, size_t size)
 {
   try {
     api::xclGraphReadRTP(ghdl, port, buffer, size);

--- a/src/runtime_src/core/include/experimental/xrt_graph.h
+++ b/src/runtime_src/core/include/experimental/xrt_graph.h
@@ -26,6 +26,205 @@
 
 typedef void *xrtGraphHandle;
 
+#ifdef __cplusplus
+
+namespace xrt {
+
+/*!
+ * @class graph
+ *
+ * The graph object represents an abstraction exported by aietool matching
+ * a specified name.
+ * The graph is created by finding matching graph name in the currently
+ * loaded xclbin.
+ */
+class graph_impl;
+class graph
+{
+public:
+  /**
+   * graph() - Constructor from a device, xclbin and graph name
+   *
+   * @param device
+   *  Device on which the graph should execute
+   * @param xclbin_id
+   *  UUID of the xclbin with the graph
+   * @param name
+   *  Name of graph to construct
+   */
+  graph(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name);
+
+  /**
+   * reset() - Reset a graph.
+   *
+   * Reset graph by disabling tiles and enable tiles reset
+   */
+  void
+  reset() const;
+
+  /**
+   * get_timestamp() - Get timestamp of a graph.
+   *
+   * @return
+   * Timestamp in AIE cycle
+   */
+  uint64_t
+  get_timestamp() const;
+
+  /**
+   * run() - Start graph execution.
+   *
+   * Start the graph execution by default. Run forever; Or run a fixed
+   * number of iterations if specified during compilation time.
+   */
+  void
+  run();
+
+  /**
+   * run() - Start graph execution.
+   *
+   * @param iterations
+   *  Number of iterations the graph should run.
+   */
+  void
+  run(uint32_t iterations);
+
+  /**
+   * wait_done() - Wait for specified milliseconds for graph to complete.
+   *
+   * @param timeout_ms
+   *  Timeout in milliseconds
+   *
+   * Wait for done status for all the tiles in graph.
+   *
+   * The current thread will block until graph run completes or timeout.
+   */
+  void
+  wait_done(int timeout_ms);
+
+  /**
+   * wait() - Wait for graph to complete.
+   *
+   * Busy wait until graph is done.
+   *
+   * The current thread will block until graph run completes.
+   */
+  void
+  wait();
+
+  /**
+   * wait() - Wait for graph to complete for specified AIE cycles.
+   *
+   * @param cycles
+   *  AIE cycles to wait since last run starts.
+   *
+   * Wait a given AIE cycle since the last graph run and then pause the
+   * graph. If graph already runs more than the given cycles, stop the
+   * graph immediately.
+   *
+   * This API with non-zero AIE cycle is for grahp that is running forever
+   * or graph that has multi-rate core(s); zero AIE cycle means busy wait
+   * until graph is done. It has the same effect as wait() API.
+   *
+   * The current thread will block until graph run completes or is paused.
+   */
+  void
+  wait(uint64_t cycles);
+
+  /**
+   * suspend() - Suspend a running graph.
+   *
+   * Suspend graph execution.
+   */
+  void
+  suspend();
+
+  /**
+   * resume() - Resume a suspended graph.
+   *
+   * Resume graph execution which was paused by suspend() or wait(cycles) APIs
+   */
+  void
+  resume();
+
+  /**
+   * end() - Busy wait for graph to complete and terminate the graph.
+   *
+   * When terminating, all active processors exit their main thread and
+   * disable themselves.
+   *
+   * The current thread will block until graph is terminated.
+   */
+  void
+  end();
+
+ /**
+   * end() - Wait for graph to complete for specified AIE cycles and then
+   * terminate the graph.
+   *
+   * @param cycles
+   *  AIE cycles to wait since last run starts.
+   *
+   * Wait a given AIE cycle since the last graph run and then terminate
+   * the graph. If graph already runs more than the given cycles, terminate
+   * the graph immediately.
+   *
+   * This API with non-zero AIE cycle is for graph that is running forever
+   * or graph that has multi-rate core(s); zero AIE cycle means busy wait
+   * until graph is done. It has the same effect as end() API.
+   *
+   * The current thread will block until graph is terminated.
+   */
+  void
+  end(uint64_t cycles);
+
+  /**
+   * update() - Update graph Run Time Parameters.
+   *
+   * @param port_name
+   *  Hierarchical name of RTP port.
+   * @param arg
+   *  The argument to set.
+   */
+  template<typename ArgType>
+  void
+  update(const std::string& port_name, ArgType&& arg)
+  {
+    update_port(port_name, &arg, sizeof(arg));
+  }
+
+  /**
+   * read() - Read graph Run Time Parameters value.
+   *
+   * @param port_name
+   *  Hierarchical name of RTP port.
+   * @param arg
+   *  The RTP value is written to.
+   */
+  template<typename ArgType>
+  void
+  read(const std::string& port_name, ArgType& arg)
+  {
+    read_port(port_name, &arg, sizeof(arg));
+  }
+
+private:
+  std::shared_ptr<graph_impl> handle;
+
+  void
+  update_port(const std::string& port_name, const void* value, size_t bytes);
+
+  void
+  read_port(const std::string& port_name, void* value, size_t bytes);
+};
+
+} // namespace xrt
+
+/// @cond
+extern "C" {
+
+#endif
+
 /**
  * xrtGraphOpen() - Open a graph and obtain its handle.
  *
@@ -181,5 +380,11 @@ xrtGraphUpdateRTP(xrtGraphHandle gh, const char *hierPathPort, const char *buffe
  */
 int
 xrtGraphReadRTP(xrtGraphHandle gh, const char *hierPathPort, char *buffer, size_t size);
+
+/// @endcond
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_graph.h
+++ b/src/runtime_src/core/include/experimental/xrt_graph.h
@@ -74,20 +74,17 @@ public:
   /**
    * run() - Start graph execution.
    *
-   * Start the graph execution by default. Run forever; Or run a fixed
-   * number of iterations if specified during compilation time.
-   */
-  void
-  run();
-
-  /**
-   * run() - Start graph execution.
-   *
    * @param iterations
    *  Number of iterations the graph should run.
+   *
+   * Start the graph execution with given iterations.
+   *
+   * The default iterations of 0 indicates start the graph execution by
+   * default, run forever; or run a fixed number of iterations if specified
+   * during compilation time.
    */
   void
-  run(uint32_t iterations);
+  run(uint32_t iterations = 0);
 
   /**
    * wait_done() - Wait for specified milliseconds for graph to complete.
@@ -95,49 +92,30 @@ public:
    * @param timeout_ms
    *  Timeout in milliseconds
    *
-   * Wait for done status for all the tiles in graph.
+   * Wait for done status for all the tiles in graph. The default timeout
+   * of 0ms indicates blocking until run completes.
    *
    * The current thread will block until graph run completes or timeout.
    */
   void
-  wait_done(int timeout_ms);
+  wait(int timeout_ms = 0);
 
   /**
-   * wait() - Wait for graph to complete.
-   *
-   * Busy wait until graph is done.
-   *
-   * The current thread will block until graph run completes.
-   */
-  void
-  wait();
-
-  /**
-   * wait() - Wait for graph to complete for specified AIE cycles.
-   *
-   * @param cycles
-   *  AIE cycles to wait since last run starts.
+   * suspend() - Wait for graph to complete for specified AIE cycles and
+   *             then suspend the graph.
    *
    * Wait a given AIE cycle since the last graph run and then pause the
    * graph. If graph already runs more than the given cycles, stop the
    * graph immediately.
    *
-   * This API with non-zero AIE cycle is for grahp that is running forever
-   * or graph that has multi-rate core(s); zero AIE cycle means busy wait
-   * until graph is done. It has the same effect as wait() API.
+   * This API is for graph that is running forever or graph that has
+   * multi-rate core(s);
+   * Zero AIE cycle means suspend the graph immediately.
    *
-   * The current thread will block until graph run completes or is paused.
+   * The current thread will block until graph is paused.
    */
   void
-  wait(uint64_t cycles);
-
-  /**
-   * suspend() - Suspend a running graph.
-   *
-   * Suspend graph execution.
-   */
-  void
-  suspend();
+  suspend(uint64_t cycles = 0);
 
   /**
    * resume() - Resume a suspended graph.
@@ -148,17 +126,6 @@ public:
   resume();
 
   /**
-   * end() - Busy wait for graph to complete and terminate the graph.
-   *
-   * When terminating, all active processors exit their main thread and
-   * disable themselves.
-   *
-   * The current thread will block until graph is terminated.
-   */
-  void
-  end();
-
- /**
    * end() - Wait for graph to complete for specified AIE cycles and then
    * terminate the graph.
    *
@@ -171,12 +138,12 @@ public:
    *
    * This API with non-zero AIE cycle is for graph that is running forever
    * or graph that has multi-rate core(s); zero AIE cycle means busy wait
-   * until graph is done. It has the same effect as end() API.
+   * until graph is done.
    *
    * The current thread will block until graph is terminated.
    */
   void
-  end(uint64_t cycles);
+  end(uint64_t cycles = 0);
 
   /**
    * update() - Update graph Run Time Parameters.

--- a/src/runtime_src/core/include/experimental/xrt_graph.h
+++ b/src/runtime_src/core/include/experimental/xrt_graph.h
@@ -19,6 +19,8 @@
 #ifndef _XRT_GRAPH_H_
 #define _XRT_GRAPH_H_
 
+#include <chrono>
+
 #include "xrt.h"
 #include "experimental/xrt_uuid.h"
 #include "experimental/xrt_bo.h"
@@ -87,35 +89,46 @@ public:
   run(uint32_t iterations = 0);
 
   /**
-   * wait_done() - Wait for specified milliseconds for graph to complete.
+   * wait() - Wait for specified milliseconds for graph to complete.
    *
    * @param timeout_ms
    *  Timeout in milliseconds
    *
-   * Wait for done status for all the tiles in graph. The default timeout
-   * of 0ms indicates blocking until run completes.
+   * Wait for done status for all the tiles in graph.
+   * Zero millisecond indicates blocking until run completes.
    *
    * The current thread will block until graph run completes or timeout.
    */
   void
-  wait(int timeout_ms = 0);
+  wait(std::chrono::milliseconds timeout_ms);
 
   /**
-   * suspend() - Wait for graph to complete for specified AIE cycles and
-   *             then suspend the graph.
+   * wait() - Wait for graph to complete for specified AIE cycles and
+   *          then suspend the graph.
+   *
+   * @param cycles
+   *  AIE cycles to wait since last run starts.
    *
    * Wait a given AIE cycle since the last graph run and then pause the
    * graph. If graph already runs more than the given cycles, stop the
    * graph immediately.
    *
-   * This API is for graph that is running forever or graph that has
-   * multi-rate core(s);
-   * Zero AIE cycle means suspend the graph immediately.
+   * This API with non-zero AIE cycles is for graph that is running
+   * forever or graph that has multi-rate core(s);
+   * Zero AIE cycle indicates blocking until run completes.
    *
    * The current thread will block until graph is paused.
    */
   void
-  suspend(uint64_t cycles = 0);
+  wait(uint64_t cycles = 0);
+
+  /**
+   * suspend() - Suspend a running graph.
+   *
+   * Suspend graph execution.
+   */
+  void
+  suspend();
 
   /**
    * resume() - Resume a suspended graph.

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -60,13 +60,13 @@ int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size);
 
 int
-xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 int
 xclResetAIEArray(xclDeviceHandle handle);
 
 int
-xclSyncBOAIENB(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
+xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
 int
 xclGMIOWait(xclDeviceHandle handle, const char *gmioName);

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -57,13 +57,7 @@ int
 xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, size_t size);
 
 int
-xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size);
-
-int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size);
-
-int
-xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char *buffer, size_t size);
 
 int
 xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -57,7 +57,13 @@ int
 xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, size_t size);
 
 int
+xclGraphUpdateRTP(xclGraphHandle ghdl, const std::string& port, const char* buffer, size_t size);
+
+int
 xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size);
+
+int
+xclGraphReadRTP(xclGraphHandle ghdl, const std::string& port, char *buffer, size_t size);
 
 int
 xclSyncBOAIE(xclDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset);


### PR DESCRIPTION
This PR added XRT Graph C++ API. (AIE level will C++ API will be followed). An example usage of Graph C++ API looks like

auto device = xrt::device(0);
auto uuid = device.load_xclbin(xclbin_file);
auto graph = xrt::graph(device, uuid, "mygraph");
graph.reset();
graph.run(3);
graph.update("mygraph.k1.in[2]", inputVector);
graph.wait();
graph.read("mygraph.k2.inout[2]", outputVectorAsync[0]);
graph.update("mygraph.k1.in[2]", inputVector); 
graph.run(3);
graph.end();
