### PR TITLE
CR-1079673 XRT build failure with cmake 3.17 and boost 1.65.1

### DIFF
--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -28,15 +28,6 @@ endif()
 
 include (CMake/glibc.cmake)
 
-# Trick to get the Boost Version string and one version greater
-SET(Boost_MINOR_VERSION_ONEGREATER "${Boost_MINOR_VERSION}")
-MATH(EXPR Boost_MINOR_VERSION_ONEGREATER "1 + ${Boost_MINOR_VERSION}")
-SET(Boost_VER_STR "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}")
-SET(Boost_VER_STR_ONEGREATER "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION_ONEGREATER}")
-SET(XRT_BOOST_VER_STR "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-
-message("cpackLin XRT_BOOST_VER_STR=${XRT_BOOST_VER_STR}")
-
 SET(PACKAGE_KIND "TGZ")
 if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
   execute_process(

--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -40,9 +40,8 @@ set(LINUX_KERNEL_VERSION ${CMAKE_SYSTEM_VERSION})
 
 find_package(Boost REQUIRED COMPONENTS system filesystem )
 
-if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
-  add_definitions (-DBOOST_PRE_1_64=1)
-endif()
+# Boost_VERSION_STRING is not working properly, use our own macro
+set(XRT_BOOST_VERSION ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION})
 
 INCLUDE (FindCurses)
 find_package(Curses REQUIRED)

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -71,9 +71,8 @@ else()
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
 
-if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
-  add_definitions (-DBOOST_PRE_1_64=1)
-endif()
+# Boost_VERSION_STRING is not working properly, use our own macro
+set(XRT_BOOST_VERSION ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION})
 
 include_directories(${Boost_INCLUDE_DIRS})
 add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -26,9 +26,8 @@ set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost
   REQUIRED COMPONENTS system filesystem)
 
-if(Boost_VERSION_STRING VERSION_LESS 1.64.0)
-  add_definitions (-DBOOST_PRE_1_64=1)
-endif()
+# Boost_VERSION_STRING is not working properly, use our own macro
+set(XRT_BOOST_VERSION ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION})
 
 include_directories(${Boost_INCLUDE_DIRS})
 add_compile_options("-DBOOST_LOCALE_HIDE_AUTO_PTR")

--- a/src/runtime_src/core/tools/CMakeLists.txt
+++ b/src/runtime_src/core/tools/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (${XRT_BOOST_VERSION} VERSION_LESS 1.64.0)
+  add_compile_options(-DNO_BOOST_PROCESS)
+endif()
+
 add_subdirectory(xbutil2)
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   add_subdirectory(xbmgmt2)

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -41,7 +41,7 @@
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
-#ifndef BOOST_PRE_1_64
+#ifndef NO_BOOST_PROCESS
 #include <boost/process.hpp>
 #endif
 
@@ -53,7 +53,7 @@
 static const int max_test_duration = 60;
 
 // ------ F U N C T I O N S ---------------------------------------------------
-#ifdef BOOST_PRE_1_64
+#ifdef NO_BOOST_PROCESS
 
 /**
  * helper functions for running testcase in linux pipe
@@ -215,9 +215,15 @@ XBUtilities::runPythonScript( const std::string & script,
   // Not really needed, but should be added for completeness 
   runningProcess.wait();
 
+  // boost::process::ipstream::rdbuf() gives conversion error in
+  // 1.65.1 Base class is constructed with underlying buffer so just
+  // use std::istream::rdbuf() instead.
+  std::istream& istr_stdout = ip_stdout;
+  std::istream& istr_stderr = ip_stderr;
+
   // Update the return buffers
-  os_stdout << ip_stdout.rdbuf();
-  os_stderr << ip_stderr.rdbuf();
+  os_stdout << istr_stdout.rdbuf();
+  os_stderr << istr_stderr.rdbuf();
 
   // Obtain the exit code from the running process
   int exitCode = runningProcess.exit_code();


### PR DESCRIPTION
Fix code to work-around boost::process rdbuf() conversion error.
Add proper Boost version check to test if boost::process is available.