### PR TITLE
XRT-813 Use multiple threads to test IOPS

### DIFF
--- a/tests/xrt/perf_IOPS/Makefile
+++ b/tests/xrt/perf_IOPS/Makefile
@@ -12,7 +12,7 @@ CPPFLAGS += -g
 endif
 
 CPPFLAGS += -I${XRT_PATH}/include
-CPPLFLAGS += -L${XRT_PATH}/lib -lxrt_core -lxrt_coreutil -luuid
+CPPLFLAGS += -L${XRT_PATH}/lib -lxrt_core -lxrt_coreutil -luuid -lpthread
 
 .PHONY: all clean
 

--- a/tests/xrt/perf_IOPS/xcl_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xcl_api_iops.cpp
@@ -226,7 +226,7 @@ int testMultiThreads(xclDeviceHandle handle, xuid_t uuid, int bank,
         arg[i].handle = handle;
         arg[i].queueLength = queueLength;
         arg[i].total = total;
-        threads[i] = std::move(std::thread(runTestThread, std::ref(arg[i])));
+        threads[i] = std::thread([&](int i){ runTestThread(arg[i]); }, i);
     }
 
     /* Wait threads to prepare to start */

--- a/tests/xrt/perf_IOPS/xcl_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xcl_api_iops.cpp
@@ -4,19 +4,17 @@
 #include <vector>
 #include <memory>
 #include <chrono>
+#include <thread>
 #include <sys/mman.h>
 #include <getopt.h>
 
+#include "xilutil.hpp"
 #include "xrt.h"
 #include "ert.h"
 #include "xclbin.h"
 
 using ms_t = std::chrono::microseconds;
 using Clock = std::chrono::high_resolution_clock;
-
-bool start = false;
-bool stop = false;
-pthread_barrier_t barrier;
 
 struct task_info {
     unsigned                boh;
@@ -34,9 +32,24 @@ typedef struct task_args {
     Clock::time_point end;
 } arg_t;
 
-void usage()
+bool start = false;
+bool stop = false;
+barrier barrier;
+
+static void usage(char *prog)
 {
-    printf("Usage: test -k <xclbin>\n");
+    std::cout << "Usage: " << prog << " -k <xclbin> -d <dev id> [options]\n"
+              << "options:\n"
+              << "    -t       number of threads\n"
+              << "    -l       length of queue (send how many commands without waiting)\n"
+              << "    -a       total amount of commands per thread\n"
+              << std::endl;
+}
+
+static void usage_and_exit(char *prog)
+{
+    usage(prog);
+    exit(0);
 }
 
 static std::vector<char>
@@ -58,11 +71,11 @@ load_file_to_memory(const std::string& fn)
 }
 
 double runTest(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>>& cmds,
-               unsigned int total, arg_t *arg)
+               unsigned int total, arg_t &arg)
 {
     int i = 0;
     unsigned int issued = 0, completed = 0;
-    arg->start = Clock::now();
+    arg.start = Clock::now();
 
     for (auto& cmd : cmds) {
         if (xclExecBuf(handle, cmd->exec_bo))
@@ -90,8 +103,8 @@ double runTest(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>>& 
             i = 0;
     }
 
-    arg->end = Clock::now();
-    return (std::chrono::duration_cast<ms_t>(arg->end - arg->start)).count();
+    arg.end = Clock::now();
+    return (std::chrono::duration_cast<ms_t>(arg.end - arg.start)).count();
 }
 
 void fillCmdVector(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>> &cmds,
@@ -138,12 +151,11 @@ int testSingleThread(xclDeviceHandle handle, xuid_t uuid, int bank)
 {
     std::vector<std::shared_ptr<task_info>> cmds;
     /* The command would incease */
-    //std::vector<unsigned int> cmds_per_run = { 50000,100000,500000,1000000 };
-    std::vector<unsigned int> cmds_per_run = { 5000000 };
+    std::vector<unsigned int> cmds_per_run = { 50000,100000,500000,1000000 };
     /* There is performance and reach maximum FD limited issue */
     //int expected_cmds = 100000;
     int expected_cmds = 128;
-    arg_t *arg = (arg_t *)malloc(sizeof(arg_t));
+    std::vector<arg_t> arg(1);
 
     if (xclOpenContext(handle, uuid, 0, true))
         throw std::runtime_error("Cound not open context");
@@ -151,7 +163,7 @@ int testSingleThread(xclDeviceHandle handle, xuid_t uuid, int bank)
     /* Create 'expected_cmds' commands if possible */
     fillCmdVector(handle, cmds, bank, expected_cmds);
 
-    arg->thread_id = 0;
+    arg[0].thread_id = 0;
     for (auto& num_cmds : cmds_per_run) {
 #if 0
         double total = 0;
@@ -160,7 +172,7 @@ int testSingleThread(xclDeviceHandle handle, xuid_t uuid, int bank)
         }
         double duration = total / 5;
 #else
-        double duration = runTest(handle, cmds, num_cmds, arg);
+        double duration = runTest(handle, cmds, num_cmds, arg[0]);
 #endif
         std::cout << "Commands: " << std::setw(7) << num_cmds
                   << " iops: " << (num_cmds * 1000.0 * 1000.0 / duration)
@@ -177,79 +189,76 @@ int testSingleThread(xclDeviceHandle handle, xuid_t uuid, int bank)
     return 0;
 }
 
-void *runTestThread(void *data)
+void *runTestThread(arg_t &arg)
 {
-    arg_t *arg = (arg_t *)data;
     std::vector<std::shared_ptr<task_info>> cmds;
     /* The command would incease */
 
-    fillCmdVector(arg->handle, cmds, arg->bank, arg->queueLength);
+    fillCmdVector(arg.handle, cmds, arg.bank, arg.queueLength);
 
-    pthread_barrier_wait(&barrier);
+    barrier.wait();
 
-    //wait start from main thread
+    double duration = runTest(arg.handle, cmds, arg.total, arg);
 
-    double duration = runTest(arg->handle, cmds, arg->total, arg);
-
-    pthread_barrier_wait(&barrier);
+    barrier.wait();
 
     for (auto& cmd : cmds) {
-        xclFreeBO(arg->handle, cmd->boh);
+        xclFreeBO(arg.handle, cmd->boh);
         munmap(cmd->ecmd, 4096);
-        xclFreeBO(arg->handle, cmd->exec_bo);
+        xclFreeBO(arg.handle, cmd->exec_bo);
     }
 }
 
-/* let's start from test two threads */
 int testMultiThreads(xclDeviceHandle handle, xuid_t uuid, int bank,
         int threadNumber, int queueLength, unsigned int total)
 {
-    pthread_t *tids = (pthread_t *)malloc(threadNumber * sizeof(pthread_t));
-    arg_t *arg[threadNumber];
+    std::thread threads[threadNumber];
+    std::vector<arg_t> arg(threadNumber);
 
     if (xclOpenContext(handle, uuid, 0, true))
         throw std::runtime_error("Cound not open context");
 
-    pthread_barrier_init(&barrier, NULL, threadNumber+1);
+    barrier.init(threadNumber + 1);
 
     for (int i = 0; i < threadNumber; i++) {
-        arg[i] = (arg_t *)malloc(sizeof(arg_t));
-        arg[i]->thread_id = i;
-        arg[i]->bank = bank;
-        arg[i]->handle = handle;
-        arg[i]->queueLength = queueLength;
-        arg[i]->total = total;
-        pthread_create(&tids[i], NULL, runTestThread, arg[i]);
+        arg[i].thread_id = i;
+        arg[i].bank = bank;
+        arg[i].handle = handle;
+        arg[i].queueLength = queueLength;
+        arg[i].total = total;
+        threads[i] = std::move(std::thread(runTestThread, std::ref(arg[i])));
     }
 
     /* Wait threads to prepare to start */
-    pthread_barrier_wait(&barrier);
+    barrier.wait();
     auto start = Clock::now();
 
     /* Wait threads done */
-    pthread_barrier_wait(&barrier);
+    barrier.wait();
     auto end = Clock::now();
 
     for (int i = 0; i < threadNumber; i++)
-        pthread_join(tids[i], NULL);
+        threads[i].join();
 
+    xclCloseContext(handle, uuid, 0);
+
+    /* calculate performance */
     int overallCommands = 0;
     double duration;
     for (int i = 0; i < threadNumber; i++) {
-        duration = (std::chrono::duration_cast<ms_t>(arg[i]->end - arg[i]->start)).count();
-        std::cout << "Thread " << arg[i]->thread_id
+        duration = (std::chrono::duration_cast<ms_t>(arg[i].end - arg[i].start)).count();
+        std::cout << "Thread " << arg[i].thread_id
                   << " Commands: " << std::setw(7) << total
                   << std::setprecision(0) << std::fixed
                   << " iops: " << (total * 1000000.0 / duration)
                   << std::endl;
         overallCommands += total;
     }
+
     duration = (std::chrono::duration_cast<ms_t>(end - start)).count();
     std::cout << "Overall Commands: " << std::setw(7) << overallCommands
               << " iops: " << (overallCommands * 1000000.0 / duration)
               << std::endl;
-
-    xclCloseContext(handle, uuid, 0);
     return 0;
 }
 
@@ -283,7 +292,7 @@ int _main(int argc, char* argv[])
                 total = std::stoi(optarg);
                 break;
             case 'h':
-                usage();
+                usage_and_exit(argv[0]);
         }
     }
 

--- a/tests/xrt/perf_IOPS/xcl_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xcl_api_iops.cpp
@@ -32,8 +32,7 @@ typedef struct task_args {
     Clock::time_point end;
 } arg_t;
 
-bool start = false;
-bool stop = false;
+bool verbose = false;
 barrier barrier;
 
 static void usage(char *prog)
@@ -215,7 +214,7 @@ int testSingleThread(int dev_id, std::string &xclbin_fn)
     return 0;
 }
 
-void *runTestThread(arg_t &arg)
+void runTestThread(arg_t &arg)
 {
     xclDeviceHandle handle;
     xuid_t uuid;
@@ -293,17 +292,20 @@ int testMultiThreads(int dev_id, std::string &xclbin_fn, int threadNumber, int q
     int overallCommands = 0;
     double duration;
     for (int i = 0; i < threadNumber; i++) {
-        duration = (std::chrono::duration_cast<ms_t>(arg[i].end - arg[i].start)).count();
-        std::cout << "Thread " << arg[i].thread_id
-                  << " Commands: " << std::setw(7) << total
-                  << std::setprecision(0) << std::fixed
-                  << " iops: " << (total * 1000000.0 / duration)
-                  << std::endl;
+        if (verbose) {
+            duration = (std::chrono::duration_cast<ms_t>(arg[i].end - arg[i].start)).count();
+            std::cout << "Thread " << arg[i].thread_id
+                << " Commands: " << std::setw(7) << total
+                << std::setprecision(0) << std::fixed
+                << " iops: " << (total * 1000000.0 / duration)
+                << std::endl;
+        }
         overallCommands += total;
     }
 
     duration = (std::chrono::duration_cast<ms_t>(end - start)).count();
     std::cout << "Overall Commands: " << std::setw(7) << overallCommands
+              << std::setprecision(0) << std::fixed
               << " iops: " << (overallCommands * 1000000.0 / duration)
               << std::endl;
     return 0;
@@ -318,7 +320,7 @@ int _main(int argc, char* argv[])
     int threadNumber = 2;
     char c;
 
-    while ((c = getopt(argc, argv, "k:d:l:t:a:h")) != -1) {
+    while ((c = getopt(argc, argv, "k:d:l:t:a:vh")) != -1) {
         switch (c) {
             case 'k':
                 xclbin_fn = optarg; 
@@ -334,6 +336,9 @@ int _main(int argc, char* argv[])
                 break;
             case 'a':
                 total = std::stoi(optarg);
+                break;
+            case 'v':
+                verbose = true;
                 break;
             case 'h':
                 usage_and_exit(argv[0]);

--- a/tests/xrt/perf_IOPS/xilutil.hpp
+++ b/tests/xrt/perf_IOPS/xilutil.hpp
@@ -1,0 +1,59 @@
+/* Xilinx XRT test case utility header file */
+
+#ifndef XIL_UTIL_HPP
+#define XIL_UTIL_HPP
+
+#include <mutex>
+#include <condition_variable>
+
+/* std::barrier can be used since c++20
+ * Thanks boost library. Modified a little bit with pure c++11 code
+ */
+class barrier
+{
+    static inline unsigned int check_counter(unsigned int count) {
+        if (count == 0)
+            throw std::runtime_error("barrier count cannot be zero");
+        return count;
+    }
+
+    public:
+    barrier()
+        : m_generation(0)
+    {}
+
+    barrier(int count)
+        : m_count(check_counter(count))
+          , m_generation(0)
+          , m_count_reset_val(count)
+    {}
+
+    void init(int count) {
+        m_count = check_counter(count);
+        m_count_reset_val = m_count;
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lk(m_mutex);
+        int gen = m_generation;
+
+        if (--m_count == 0) {
+            m_generation++;
+            m_count = m_count_reset_val;
+            m_cv.notify_all();
+            return;
+        }
+
+        while (gen == m_generation)
+            m_cv.wait(lk);
+    }
+
+    private:
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    unsigned int m_count;
+    unsigned int m_generation;
+    unsigned int m_count_reset_val;
+};
+
+#endif

--- a/tests/xrt/perf_IOPS/xrt_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xrt_api_iops.cpp
@@ -130,7 +130,7 @@ int testMultiThreads(xrt::device& device, xrt::uuid& uuid,
       arg[i].thread_id = i;
       arg[i].queueLength = queueLength;
       arg[i].total = total;
-      threads[i] = std::move(std::thread(runTestThread, std::ref(device), std::ref(hello), std::ref(arg[i])));
+      threads[i] = std::thread([&](int i){ runTestThread(device, hello, arg[i]); }, i);
     }
 
     /* Wait threads to prepare to start */


### PR DESCRIPTION
Compile:
make xcl_api_iops

Usage:
./xcl_api_iops -d -k /opt/xilinx/.../test/verify.xclbin -t 3 -l 64 -a 1000000

Use 3 submitted threads could get best overall performance. 

xrt_api_iops test is updated as well.