### PR TITLE
removing petalinux hardcoded path

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -138,7 +138,6 @@ fi
 if [ -f $SETTINGS_FILE ]; then
     source $SETTINGS_FILE
 fi
-PETALINUX="/proj/petalinux/2020.2/petalinux-v2020.2_1108_1/tool/petalinux-v2020.2-final"
 source $PETALINUX/settings.sh 
 
 if [[ $AARCH = $aarch64_dir ]]; then


### PR DESCRIPTION
Removing the Petalinux hardcoded path from build_edge.sh