### PR TITLE
Removed mdash

### DIFF
--- a/2018.3/html/index.html
+++ b/2018.3/html/index.html
@@ -8,7 +8,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Xilinx Runtime (XRT) Architecture &mdash; Xilinx Runtime 2018.3 documentation</title>
+  <title>Xilinx Runtime (XRT) Architecture 2018.3 documentation</title>
   
 
   

--- a/2019.1/html/index.html
+++ b/2019.1/html/index.html
@@ -8,7 +8,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Xilinx Runtime (XRT) Architecture &mdash; Xilinx Runtime 2019.1 documentation</title>
+  <title>Xilinx Runtime (XRT) Architecture 2019.1 documentation</title>
   
 
   

--- a/2019.2/html/index.html
+++ b/2019.2/html/index.html
@@ -8,7 +8,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Xilinx® Runtime (XRT) Architecture &mdash; XRT 2019.2 documentation</title>
+  <title>Xilinx® Runtime (XRT) Architecture 2019.2 documentation</title>
   
 
   

--- a/2020.1/html/debug.log
+++ b/2020.1/html/debug.log
@@ -1,0 +1,2 @@
+[1130/104837.761:ERROR:exit_code_watcher_win.cc(87)] Failed to wait for process exit or stop event
+[1130/104837.915:ERROR:registration_protocol_win.cc(131)] TransactNamedPipe: The pipe has been ended. (0x6D)

--- a/2020.1/html/index.html
+++ b/2020.1/html/index.html
@@ -8,7 +8,7 @@
   
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
-  <title>Xilinx® Runtime (XRT) Architecture &mdash; XRT 2020.1 documentation</title>
+  <title>Xilinx® Runtime (XRT) Architecture 2020.1 documentation</title>
   
 
   


### PR DESCRIPTION
The &mdash tag was causing errors for us when linking to the page from our documentation tool. I think it can be safely removed, and I've made edits in the four folders where it was being used. This also simplified the titles of those pages.