### PR TITLE
Check kernel configuration and enable FPGA manager accordingly

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -101,6 +101,9 @@ ifeq ($(SYMBOL),1)
 	ccflags-y += -g
 endif
 
+ccflags-$(CONFIG_FPGA) += -DENABLE_FPGA_MGR_SUPPORT
+ccflags-y += $(ccflags-m)
+
 all:
 	echo $(PWD)
 	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/fmgr.c
@@ -21,7 +21,7 @@
  * kernels do not support FPGA Mgr yet.
  */
 #include <linux/version.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0) && !defined(RHEL_RELEASE_VERSION)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0) && defined(ENABLE_FPGA_MGR_SUPPORT)
 #define FPGA_MGR_SUPPORT
 #include <linux/fpga/fpga-mgr.h>
 #endif


### PR DESCRIPTION
This enables building of XRT with GitHub workflow where host is ubuntu but kernel version is 5.4.0-1031-azure not configured with FPGA manager.