### PR TITLE
CR-1081828 Changes in xbutil dmatest output

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1746,7 +1746,8 @@ public:
                 if(map->m_mem_data[i].m_size < (blockSize/1024)) {
                     if (verbose)
                         std::cout << "WARNING: unable to perform DMA Test on " << map->m_mem_data[i].m_tag
-                            << ". Cannot allocate " << blockSize << " on " << map->m_mem_data[i].m_size
+                            << ". Cannot allocate " << xrt_core::utils::unit_convert(blockSize)
+                            << " on " << xrt_core::utils::unit_convert(map->m_mem_data[i].m_size * 1024)
                             << " sized bank." << std::endl;
                     result = -EOPNOTSUPP;
                     continue;


### PR DESCRIPTION
xbutil2 doesn't have this option yet

>without the fix
```
xbutil dmatest -d 1 -b 524288
INFO: Found total 4 card(s), 4 are usable
INFO: DMA test on [1]: xilinx_u50_gen3x16_xdma_base_4
Total HBM size: 9472 MB
Buffer Size: 512 MB
Reporting from mem_topology:
WARNING: unable to perform DMA Test on HBM[0]. Cannot allocate 536870912 on 262144 sized bank.
ERROR: xbutil dmatest failed.
```
> with the fix
```
xbutil dmatest -d 1 -b 524288
INFO: Found total 4 card(s), 4 are usable
INFO: DMA test on [1]: xilinx_u50_gen3x16_xdma_base_4
Total HBM size: 9472 MB
Buffer Size: 512 MB
Reporting from mem_topology:
WARNING: unable to perform DMA Test on HBM[0]. Cannot allocate 512 MB on 256 MB sized bank.
ERROR: xbutil dmatest failed.

```
