### PR TITLE
XRT-815 DMA test hangs VM when only single vcpu assigned to it

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -3025,7 +3025,7 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 	engine->channel = channel;
 
 	/* set cpu for engine */
-	engine->cpu_idx = channel;
+	engine->cpu_idx = channel % num_online_cpus();
 
 	/* engine interrupt request bit */
 	engine->irq_bitmask = (1 << XDMA_ENG_IRQ_NUM) - 1;


### PR DESCRIPTION
Limit the cpus used for scheduling irq processing to maximum available on the system.