### PR TITLE
CR-1084683 xbutil validate should give more precise message if it fai…

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1216,9 +1216,8 @@ int xcldev::device::runTestCase(const std::string& py,
         }
 
         cmd = xrtTestCasePath + " " + xclbinPath + " -d " + std::to_string(m_idx);
-    }
-    //OLD FLOW:
-    else { 
+
+    } else { //OLD FLOW:
         xrtTestCasePath += py;    
         xclbinPath += xclbin;
 
@@ -1228,10 +1227,11 @@ int xcldev::device::runTestCase(const std::string& py,
             // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
             std::string logic_uuid, errmsg;
             pcidev::get_dev(m_idx)->sysfs_get( "", "logic_uuids", errmsg, logic_uuid);
+
             // Only skip the test if it nonDFX platform and the accelerator doesn't exist. 
             // All other conditions should generate an error.
             if (!logic_uuid.empty() && xclbin.compare("verify.xclbin") == 0) {
-                output += "Verify xclbin not available. Skipping validation.";
+                output += "Verify xclbin not available or shell partition is not programmed. Skipping validation.";
                 return -EOPNOTSUPP;
             }
             //if bandwidth xclbin isn't present, skip the test

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -248,7 +248,7 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
   // At this time, this is determined by whether or not it delivers an accelerator (e.g., verify.xclbin)
   if(!logic_uuid.empty() && !boost::filesystem::exists(xclbinPath)) {
     //if bandwidth xclbin isn't present, skip the test
-    logger(_ptTest, "Details", "Verify xclbin not available. Skipping validation.");
+    logger(_ptTest, "Details", "Verify xclbin not available or shell partition is not programmed. Skipping validation.");
     _ptTest.put("status", "skipped");
     return;
   }


### PR DESCRIPTION
…ls to run the validation procedure
@AShivangi Not sure if we should fix xbutil2, please advise.
@houlz0507 seems partition_type could be base or shell. So just simply enhance the error message. Please let me know your thoughts.

Test results:
[root@xsjhemn41 ~]# /proj/xsjhdstaff2/davidzha/XRT_zocl/build/Debug/runtime_src/core/pcie/tools/xbutil/xbutil validate -q
INFO: Found 1 cards                                                                                                      

INFO: Validating card[0]: xilinx_u200_gen3x16_base_1
INFO: == Starting Kernel version check:             
Developer's build. Skipping validation              
INFO: == Kernel version check SKIPPED
INFO: == Starting AUX power connector check:
INFO: == AUX power connector check PASSED
INFO: == Starting Power warning check:
INFO: == Power warning check PASSED
INFO: == Starting PCIE link check:
LINK ACTIVE, ATTENTION
Ensure Card is plugged in to Gen3x16, instead of Gen1x16
Lower performance may be experienced
WARN: == PCIE link check PASSED with warning
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
**Verify xclbin not available or shell partition is not programmed. Skipping validation.**
INFO: == verify kernel test SKIPPED
INFO: Card[0] validated with warnings.

INFO: All cards validated successfully but with warnings.
[root@xsjhemn41 ~]# xbmgmt partition --program --name xilinx_u200_gen3x16_xdma_shell_1_1
Programming PLP on Card [0000:18:00.0]...
Partition file: /opt/xilinx/firmware/u200/gen3x16/xdma-shell/partition.xsabin
Program successfully
[root@xsjhemn41 ~]# /proj/xsjhdstaff2/davidzha/XRT_zocl/build/Debug/runtime_src/core/pcie/tools/xbutil/xbutil validate -q
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_u200_gen3x16_xdma_shell_1_1
INFO: == Starting Kernel version check:
Developer's build. Skipping validation
INFO: == Kernel version check SKIPPED
INFO: == Starting AUX power connector check:
INFO: == AUX power connector check PASSED
INFO: == Starting Power warning check:
INFO: == Power warning check PASSED
INFO: == Starting PCIE link check:
LINK ACTIVE, ATTENTION
Ensure Card is plugged in to Gen3x16, instead of Gen1x16
Lower performance may be experienced
WARN: == PCIE link check PASSED with warning
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated with warnings.

INFO: All cards validated successfully but with warnings.

