### PR TITLE
CR-1080684 U30 security improvements

### DIFF
--- a/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
+++ b/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019, Xilinx Inc - All rights reserved
+ * Copyright (C) 2015-2020, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -27,7 +27,7 @@ extern "C" {
 #define	XRT_MAX_NAME_LENGTH	32
 #define	XRT_MAX_PATH_LENGTH	255
 
-#define	SOFT_KERNEL_FILE_PATH	"/lib/firmware/xilinx/softkernel/"
+#define	SOFT_KERNEL_FILE_PATH	"/home/softkernel/softkernel/"
 #define	SOFT_KERNEL_FILE_NAME	"sk"
 
 #define	SOFT_KERNEL_REG_SIZE	4096

--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2020 Xilinx, Inc
  * Author(s): Min Ma	<min.ma@xilinx.com>
  *          : Larry Liu	<yliu@xilinx.com>
  *
@@ -250,7 +250,7 @@ static int createSoftKernelFile(uint64_t paddr, size_t size, uint32_t cuidx)
     syslog(LOG_ERR, "Cannot initialize XRT.\n");
     return -1;
   }
-    
+
   boHandle = xclGetHostBO(handle, paddr, size);
   buf = xclMapBO(handle, boHandle, false);
   if (!buf) {
@@ -266,7 +266,7 @@ static int createSoftKernelFile(uint64_t paddr, size_t size, uint32_t cuidx)
     if (path[i] == '/') {
       path[i] = '\0';
       if (access(path, F_OK) != 0) {
-        if (mkdir(path, 0644) != 0) {
+        if (mkdir(path, 0744) != 0) {
           syslog(LOG_ERR, "Cannot create soft kernel file.\n");
           return -1;
         }
@@ -341,6 +341,7 @@ void configSoftKernel(xclSKCmd *cmd)
     if (pid == 0) {
       char path[XRT_MAX_PATH_LENGTH];
       char proc_name[PNAME_LEN] = {};
+
       /* Install Signal Handler for the Child Processes/Soft-Kernels */
       struct sigaction act;
       act.sa_handler = sigLog;


### PR DESCRIPTION
This PR is part of softkernel security improvements. It creates softkernel binary file at /home/softkernel/ so that both 'root' user and 'softkernel' user can create softkernel binary files.

Then we can launch skd as user 'softkernel' so that softkernel executable no longer has root privilege. 