### PR TITLE
soft kernel return code not available with old zocl

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -2544,6 +2544,7 @@ exec_mark_cmd_complete(struct exec_core *exec, struct xocl_cmd *xcmd)
 			//Possible to upgrade XRT on host without changing zocl on PS
 			if (cmd_state < ERT_CMD_STATE_COMPLETED) {//It is old zocl
 				cmd_state = ERT_CMD_STATE_COMPLETED;
+				pkt->return_code = -ENODATA;//return code is missing
 			} else {//It is new zocl
 				pkt->return_code = tmp_pkt.return_code;
 			}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -2541,11 +2541,12 @@ exec_mark_cmd_complete(struct exec_core *exec, struct xocl_cmd *xcmd)
 			struct ert_start_kernel_cmd tmp_pkt;
 			xocl_memcpy_fromio((void*)&tmp_pkt.header, xert->cq_base + slot_addr, 2 * sizeof(u32));
 			cmd_state = tmp_pkt.state;
-			//Possible to upgrade XRT on host without changing zocl on PS
-			if (cmd_state < ERT_CMD_STATE_COMPLETED) {//It is old zocl
+			/* Possible to upgrade XRT on host without changing zocl on PS */
+			if (cmd_state < ERT_CMD_STATE_COMPLETED) {
+				/* It is old shell */
 				cmd_state = ERT_CMD_STATE_COMPLETED;
-				pkt->return_code = -ENODATA;//return code is missing
-			} else {//It is new zocl
+				pkt->return_code = -ENODATA;/* return code is missing */
+			} else {/* It is new shell like: xilinx-u30-gen3x4-base_1 */
 				pkt->return_code = tmp_pkt.return_code;
 			}
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -2541,7 +2541,12 @@ exec_mark_cmd_complete(struct exec_core *exec, struct xocl_cmd *xcmd)
 			struct ert_start_kernel_cmd tmp_pkt;
 			xocl_memcpy_fromio((void*)&tmp_pkt.header, xert->cq_base + slot_addr, 2 * sizeof(u32));
 			cmd_state = tmp_pkt.state;
-			pkt->return_code = tmp_pkt.return_code;
+			//Possible to upgrade XRT on host without changing zocl on PS
+			if (cmd_state < ERT_CMD_STATE_COMPLETED) {//It is old zocl
+				cmd_state = ERT_CMD_STATE_COMPLETED;
+			} else {//It is new zocl
+				pkt->return_code = tmp_pkt.return_code;
+			}
 		}
 	}
 	exec_mark_cmd_state(exec, xcmd,


### PR DESCRIPTION
If PS has old zocl then ensure cmd completion and don't expect return_code