### PR TITLE
fix issue 4525

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -60,7 +60,7 @@ MODULE_PARM_DESC(desc_blen_max,
  * maintains a list of the xdma devices
  */
 static LIST_HEAD(xdev_list);
-static DEFINE_MUTEX(xdev_mutex);
+static DEFINE_SPINLOCK(xdev_lock);
 
 static LIST_HEAD(xdev_rcu_list);
 static DEFINE_SPINLOCK(xdev_rcu_lock);
@@ -83,7 +83,9 @@ static inline unsigned int incr_ptr_idx(unsigned int cur, unsigned int incr,
 
 static inline void xdev_list_add(struct xdma_dev *xdev)
 {
-	mutex_lock(&xdev_mutex);
+	unsigned long flags;
+
+	spin_lock_irqsave(&xdev_lock, flags);
 	if (list_empty(&xdev_list))
 		xdev->idx = 0;
 	else {
@@ -93,7 +95,7 @@ static inline void xdev_list_add(struct xdma_dev *xdev)
 		xdev->idx = last->idx + 1;
 	}
 	list_add_tail(&xdev->list_head, &xdev_list);
-	mutex_unlock(&xdev_mutex);
+	spin_unlock_irqrestore(&xdev_lock, flags);
 
 	dbg_init("dev %s, xdev 0x%p, xdma idx %d.\n",
 		dev_name(&xdev->pdev->dev), xdev, xdev->idx);
@@ -107,9 +109,11 @@ static inline void xdev_list_add(struct xdma_dev *xdev)
 
 static inline void xdev_list_remove(struct xdma_dev *xdev)
 {
-	mutex_lock(&xdev_mutex);
+	unsigned long flags;
+
+	spin_lock_irqsave(&xdev_lock, flags);
 	list_del(&xdev->list_head);
-	mutex_unlock(&xdev_mutex);
+	spin_unlock_irqrestore(&xdev_lock, flags);
 
 	spin_lock(&xdev_rcu_lock);
 	list_del_rcu(&xdev->rcu_node);
@@ -120,15 +124,16 @@ static inline void xdev_list_remove(struct xdma_dev *xdev)
 static struct xdma_dev *xdev_find_by_pdev(struct pci_dev *pdev)
 {
         struct xdma_dev *xdev, *tmp;
+	unsigned long flags;
 
-        mutex_lock(&xdev_mutex);
+	spin_lock_irqsave(&xdev_lock, flags);
         list_for_each_entry_safe(xdev, tmp, &xdev_list, list_head) {
                 if (xdev->pdev == pdev) {
-                        mutex_unlock(&xdev_mutex);
+			spin_unlock_irqrestore(&xdev_lock, flags);
                         return xdev;
                 }
         }
-        mutex_unlock(&xdev_mutex);
+	spin_unlock_irqrestore(&xdev_lock, flags);
         return NULL;
 }
 


### PR DESCRIPTION
Use spin lock instead of mutex, since xdev_find_by_pdev() could be called in an interrupt service routine.
#4525 