### PR TITLE
Support U30/XMA/FFMPEG application

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -111,6 +111,8 @@ struct kds_cu_mgmt {
 /* ERT core */
 struct kds_ert {
 	void (* submit)(struct kds_ert *ert, struct kds_command *xcmd);
+	struct mutex		  lock;
+	int			  configured;
 };
 
 struct plram_info {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -750,7 +750,7 @@ struct xocl_subdev_map {
 	((struct resource []) {				\
 		{					\
 			.start	= 0x0,			\
-			.end	= 0x0FFFF,		\
+			.end	= 0x00FFF,		\
 			.flags	= IORESOURCE_MEM,	\
 		}					\
 	})

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -616,16 +616,16 @@ static inline int process_ert_rq(struct xocl_ert_user *ert_user)
 		if (kds_echo) {
 			ecmd->completed = true;
 		} else {
-			if (cmd_opcode(ecmd) == OP_CONFIG) {
-				xocl_memcpy_toio(ert_user->cq_base + slot_addr + 4,
-					  ecmd->xcmd->execbuf+1, epkt->count*sizeof(u32));
-			} else {
+			if (cmd_opcode(ecmd) == OP_START) {
 				// write kds selected cu_idx in first cumask (first word after header)
 				iowrite32(ecmd->xcmd->cu_idx, ert_user->cq_base + slot_addr + 4);
 
 				// write remaining packet (past header and cuidx)
 				xocl_memcpy_toio(ert_user->cq_base + slot_addr + 8,
 						 ecmd->xcmd->execbuf+2, (epkt->count-1)*sizeof(u32));
+			} else {
+				xocl_memcpy_toio(ert_user->cq_base + slot_addr + 4,
+					  ecmd->xcmd->execbuf+1, epkt->count*sizeof(u32));
 			}
 
 			iowrite32(epkt->header, ert_user->cq_base + slot_addr);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -156,10 +156,13 @@ sk_ecmd2xcmd(struct xocl_dev *xdev, struct ert_packet *ecmd,
 		return -EINVAL;
 	}
 
-	if (ecmd->opcode == ERT_SK_START)
+	if (ecmd->opcode == ERT_SK_START) {
 		xcmd->opcode = OP_START_SK;
-	else
+		ecmd->type = ERT_SCU;
+	} else {
 		xcmd->opcode = OP_CONFIG_SK;
+		ecmd->type = ERT_CTRL;
+	}
 
 	xcmd->execbuf = (u32 *)ecmd;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_ctx.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_ctx.c
@@ -21,7 +21,7 @@
  * helper functions to protect driver private data
  */
 DEFINE_MUTEX(xocl_drvinst_lock);
-struct xocl_drvinst *xocl_drvinst_array[XOCL_MAX_DEVICES * 10];
+struct xocl_drvinst *xocl_drvinst_array[XOCL_MAX_DEVICES * 64];
 
 void *xocl_drvinst_alloc(struct device *dev, u32 size)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2037,7 +2037,7 @@ static inline int xocl_kds_fini_ert(xdev_handle_t xdev)
 
 /* context helpers */
 extern struct mutex xocl_drvinst_mutex;
-extern struct xocl_drvinst *xocl_drvinst_array[XOCL_MAX_DEVICES * 10];
+extern struct xocl_drvinst *xocl_drvinst_array[XOCL_MAX_DEVICES * 64];
 
 void *xocl_drvinst_alloc(struct device *dev, u32 size);
 void xocl_drvinst_release(void *data, void **hdl);


### PR DESCRIPTION
1. Only allow 1 configure command to ERT per xclbin.
2. Update ert package type since zocl needs this information to do special handle for soft kernel command.
3. After discussed with Lizhi, don't use xocl_drvinst_alloc() for cu sub-device and enlarge xocl_drvinst_array[].