### PR TITLE
Fix missed std:: for streampos

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbflash.qspi/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbflash.qspi/firmware_image.cpp
@@ -27,7 +27,7 @@ firmwareImage::firmwareImage(const char *file) :
         std::cout << "Can't open " << file << std::endl;
         return;
     }
-    streampos bufsize = in.tellg();
+    auto bufsize = in.tellg();
     in.seekg(0);
 
     // For non-dsabin file, the entire file is the image.

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.cpp
@@ -618,7 +618,7 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
         std::cout << "Can't open " << file << std::endl;
         return;
     }
-    streampos bufsize = in.tellg();
+    auto bufsize = in.tellg();
     in.seekg(0);
 
     std::string fn(file);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -465,7 +465,7 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
         std::cout << "Can't open " << file << std::endl;
         return;
     }
-    streampos bufsize = in_file.tellg();
+    auto bufsize = in_file.tellg();
     in_file.seekg(0);
 
     std::string fn(file);


### PR DESCRIPTION
`streampos` is a member of `std::` and that should be properly specified in order
to comply the standard.