### PR TITLE
XRT-813 Use multiple threads to test IOPS

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1165,7 +1165,7 @@ int searchXsaAndDsa(int index, std::string xsaPath, std::string
 }
 
 int xcldev::device::runTestCase(const std::string& py,
-    const std::string& xclbin, std::string& output)
+    const std::string& xclbin, std::string& output, const std::string &args = std::string())
 {
     struct stat st;
 
@@ -1208,6 +1208,9 @@ int xcldev::device::runTestCase(const std::string& py,
             { "host_mem_23_bandwidth.py", "slavebridge.exe" }
         };
         
+        if (test_map.find(py) == test_map.end())
+            return -EOPNOTSUPP;
+
         xrtTestCasePath += test_map.find(py)->second;
         // in case the user is trying to run a new platform with an XRT which doesn't support the new platform pkg
         if (!boost::filesystem::exists(xrtTestCasePath)) {
@@ -1217,7 +1220,9 @@ int xcldev::device::runTestCase(const std::string& py,
 
         cmd = xrtTestCasePath + " " + xclbinPath + " -d " + std::to_string(m_idx);
 
-    } else { //OLD FLOW:
+    } else if (py.find(".exe") == std::string::npos) { //OLD FLOW:
+        // Use suffix ".exe" to identify special test case is not ideal. Let's do it for now.
+        // We could refine this once need.
         xrtTestCasePath += py;    
         xclbinPath += xclbin;
 
@@ -1256,6 +1261,11 @@ int xcldev::device::runTestCase(const std::string& py,
         }
 
         cmd = "/usr/bin/python3 " + xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx);
+    } else {
+        xrtTestCasePath += py;
+        xclbinPath += xclbin;
+
+        cmd = xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx) + args;
     }
     return runShellCmd(cmd, output);
 }
@@ -1578,13 +1588,11 @@ int xcldev::device::validate(bool quick, bool hidden)
         return withWarning ? 1 : 0;
 
     // Perform IOPS test
-    if(hidden) {
-        retVal = runOneTest("IOPS test",
+    retVal = runOneTest("IOPS test",
             std::bind(&xcldev::device::iopsTest, this));
-        withWarning = withWarning || (retVal == 1);
-        if (retVal < 0)
-            return retVal;
-    }
+    withWarning = withWarning || (retVal == 1);
+    if (retVal < 0)
+        return retVal;
 
     // Perform DMA test
     retVal = runOneTest("DMA test",
@@ -2346,182 +2354,37 @@ int xcldev::device::testM2m()
 /*
  * iops test
  */
-struct exec_struct {
-    unsigned out_bo_handle;
-    char* output_bo_ptr;
-    unsigned int out_size;
-    unsigned exec_bo_handle;
-    ert_start_kernel_cmd* exec_bo_ptr;
-    unsigned int exec_size;
-};
-
-static int
-get_first_used_mem(unsigned int idx)
-{
-    std::string errmsg;
-    std::vector<char> buf;
-    auto dev = pcidev::get_dev(idx);
-    int first_used_mem = -1;
-
-    if (dev == nullptr)
-        return -EINVAL;
-
-    dev->sysfs_get("icap", "mem_topology", errmsg, buf);
-
-    const mem_topology *map = (mem_topology *)buf.data();
-    if (buf.empty() || map->m_count == 0) {
-        std::cout << "WARNING: 'mem_topology' invalid, "
-            << "unable to perform IOPS Test. Has the bitstream been loaded? "
-            << "See 'xbutil program'." << std::endl;
-        return -EINVAL;
-    }
-    for (int i = 0; i < map->m_count; i++) {
-        if (map->m_mem_data[i].m_used) {
-            first_used_mem = i;
-            break;
-        }
-    }
-    return first_used_mem;
-}
-
-static void
-iops_free_unmap_bo(xclDeviceHandle handle, unsigned boh,
-    void * boptr, size_t boSize)
-{
-    if(boptr != nullptr)
-        munmap(boptr, boSize);
-    if(boh != NULLBO)
-        xclFreeBO(handle, boh);
-}
-
-static void
-iops_alloc_init_bo(xclDeviceHandle handle, int bank, exec_struct* info)
-{
-    info->out_size = 20;
-    info->exec_size = 4096;
-    info->out_bo_handle = xclAllocBO(handle, info->out_size, 0, bank);
-    if (info->out_bo_handle == NULLBO)
-        throw std::runtime_error("Cannot obtain BO handle");
-
-    info->output_bo_ptr = reinterpret_cast<char *>(xclMapBO(handle, info->out_bo_handle, true));
-    if (info->output_bo_ptr == nullptr) {
-        iops_free_unmap_bo(handle, info->out_bo_handle, info->output_bo_ptr, info->out_size);
-        throw std::runtime_error("Cannot obtain output BO");
-    }
-
-    memset(info->output_bo_ptr, 'o', info->out_size);
-    if(xclSyncBO(handle, info->out_bo_handle, XCL_BO_SYNC_BO_TO_DEVICE, info->out_size, 0)) {
-        iops_free_unmap_bo(handle, info->out_bo_handle, info->output_bo_ptr, info->out_size);
-        throw std::runtime_error("Cannot sync output BO to device");
-    }
-
-    xclBOProperties prop;
-    if(xclGetBOProperties(handle, info->out_bo_handle, &prop)) {
-        iops_free_unmap_bo(handle, info->exec_bo_handle, info->exec_bo_ptr, info->exec_size);
-        throw std::runtime_error("Cannot obtain BO dev address");
-    }
-    uint64_t boh_address = prop.paddr;
-
-    info->exec_bo_handle = xclAllocBO(handle, info->exec_size, 0, XCL_BO_FLAGS_EXECBUF);
-    info->exec_bo_ptr = reinterpret_cast<ert_start_kernel_cmd *>(xclMapBO(handle, info->exec_bo_handle, true));
-    if (info->exec_bo_ptr == nullptr) {
-        iops_free_unmap_bo(handle, info->exec_bo_handle, info->exec_bo_ptr, info->exec_size);
-        throw std::runtime_error("Cannot obtain exec buf BO");
-    }
-    std::memset(info->exec_bo_ptr, 0, info->exec_size);
-
-    //construct the exec buffer cmd to start the kernel.
-    int rsz = 19; // regmap array size
-    info->exec_bo_ptr->state = 0;
-    info->exec_bo_ptr->opcode = ERT_START_CU;
-    info->exec_bo_ptr->count = rsz;
-    info->exec_bo_ptr->cu_mask = (0x1 << 0);
-    info->exec_bo_ptr->data[rsz - 3] = boh_address;
-    info->exec_bo_ptr->data[rsz - 2] = (boh_address >> 32);
-}
-
-static void
-execute_cmds(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& cmds,
-    double& duration)
-{
-    auto start = std::chrono::high_resolution_clock::now();
-    for (auto& c : cmds) {
-        if(xclExecBuf(handle, c->exec_bo_handle))
-            throw std::runtime_error("Unable to issue exec buf");
-    }
-    for (auto& c : cmds) {
-        // c->wait();
-        while (c->exec_bo_ptr->state < ERT_CMD_STATE_COMPLETED) {
-            while (xclExecWait(handle, -1) == 0);
-        }
-        if(c->exec_bo_ptr->state != ERT_CMD_STATE_COMPLETED)
-            throw std::runtime_error("CU execution failed");
-    }
-    auto end = std::chrono::high_resolution_clock::now();
-    duration = (std::chrono::duration_cast<std::chrono::microseconds>
-    (end - start)).count();
-}
-
-static void
-run_iops_test(xclDeviceHandle handle, std::vector<std::shared_ptr<exec_struct>>& cmds,
-    std::vector<double>& iops_list, int first_used_mem, unsigned int cmd_per_batch)
-{
-    double duration = 0;
-    double total = 0;
-    for (unsigned int i = 0; i < cmd_per_batch; i++) {
-        exec_struct info = {0};
-        iops_alloc_init_bo(handle, first_used_mem, &info);
-        auto p = std::make_shared<exec_struct>(info);
-        cmds.push_back(p);
-    }
-
-    // Execute the cmds 5 times and get average duration
-    for (int i = 0; i < 5; i++) {
-        execute_cmds(handle, cmds, duration);
-        total += duration;
-    }
-    duration = total / 5.0;
-
-    //verify
-    for(auto& c : cmds) {
-        if(xclSyncBO(handle, c->out_bo_handle, XCL_BO_SYNC_BO_FROM_DEVICE, c->out_size, 0))
-            throw std::runtime_error("Cannot sync output BO from device");
-        if (strncmp(c->output_bo_ptr, "Hello World", 11))
-            throw std::runtime_error("Bad output result after CU execution");
-    }
-    iops_list.push_back(cmds.size() * 1000 * 1000 / duration);
-    std::cout << "Commands: " << cmds.size() << " iops: " << (cmds.size() * 1000 * 1000 / duration) << std::endl;
-}
-
 int
 xcldev::device::iopsTest()
 {
+    std::string output;
 
-    xclbin_lock xclbin_lock(m_handle, m_idx);
-    int first_used_mem = get_first_used_mem(m_idx);
+    int ret = runTestCase(std::string("xrt_iops_test.exe"), std::string("verify.xclbin"),
+                output, std::string(" -t 1 -l 128 -a 500000"));
 
-    if(first_used_mem == -1)
-        return -EINVAL;
-
-    std::vector<std::shared_ptr<exec_struct>> cmds;
-    std::vector<unsigned int> cmd_per_batch = { 10,40,50,900,1000,2000,3000,4000,5000,10000 }; //b
-    std::vector<double> iops_list;
-
-    if(xclOpenContext(m_handle, xclbin_lock.m_uuid, 0, true))
-            throw std::runtime_error("Cannot create context");
-
-    //run different combinations
-    for(const auto& b : cmd_per_batch) {
-        run_iops_test(m_handle, cmds, iops_list, first_used_mem, b);
+    if (ret != 0) {
+        std::cout << output << std::endl;
+        return ret;
     }
 
-    // release all BOs
-    for(auto& c : cmds) {
-        iops_free_unmap_bo(m_handle, c->out_bo_handle, c->output_bo_ptr, c->out_size);
-        iops_free_unmap_bo(m_handle, c->exec_bo_handle, c->exec_bo_ptr, c->exec_size);
+    if (output.find("Overall Commands") == std::string::npos) {
+        std::cout << output << std::endl;
+        ret = -EINVAL;
     }
+    std::cout << output << std::endl;
+    return 0;
+}
 
-    xclCloseContext(m_handle, xclbin_lock.m_uuid, 0);
+int
+xcldev::device::iopsTestWithArgs(const std::string& name, const std::string& args)
+{
+    std::string output;
+
+    int ret = runTestCase(name, std::string("verify.xclbin"), output, args);
+    if (ret != 0)
+        return ret;
+
+    std::cout << output << std::endl;
     return 0;
 }
 
@@ -2531,6 +2394,8 @@ int xcldev::xclScheduler(int argc, char *argv[])
         {"echo", required_argument, 0, 'e'},
         {"kds_schedule", required_argument, 0, 'k'},
         {"cu_intr", required_argument, 0, xcldev::KDS_CU_INTERRUPT},
+        {"test", required_argument, 0, xcldev::KDS_TEST},
+        {"args", required_argument, 0, xcldev::KDS_ARGS},
         {0, 0, 0, 0}
     };
     const char* short_opts = "d:e:k:";
@@ -2540,6 +2405,8 @@ int xcldev::xclScheduler(int argc, char *argv[])
     int kds_echo = -1;
     int ert_disable = -1;
     int cu_intr = -1;
+    std::string test;
+    std::string args;
 
     int ret = isSudo();
     if (ret)
@@ -2566,6 +2433,12 @@ int xcldev::xclScheduler(int argc, char *argv[])
             break;
         case xcldev::KDS_CU_INTERRUPT:
             cu_intr = std::atoi(optarg);
+            break;
+        case xcldev::KDS_TEST:
+            test = optarg;
+            break;
+        case xcldev::KDS_ARGS:
+            args = optarg;
             break;
         default:
             /* This is hidden command, silently exit */
@@ -2607,6 +2480,33 @@ int xcldev::xclScheduler(int argc, char *argv[])
         std::string kds_interrupt;
         pcidev::get_dev(index)->sysfs_get( "", "kds_interrupt", errmsg, kds_interrupt);
         std::cout << "Device[" << index << "] interrupt mode: " << kds_interrupt << std::endl;
+    }
+
+    std::unique_ptr<device> dev = xclGetDevice(index);
+    if (!dev) {
+        std::cout << "ERROR: Can't open card[" << index << "]" << std::endl;
+        return -ENOENT;
+    }
+
+    if (!test.empty()) {
+        int ret = 0;
+        if (test.compare("xcl_iops") == 0) {
+            test = "xcl_iops_test.exe";
+        } else if (test.compare("xrt_iops") == 0) {
+            test = "xcl_iops_test.exe";
+        } else {
+            std::cout << "ERROR:Unknown test" << std::endl;
+            return -EINVAL;
+        }
+
+        args = " " + args;
+        ret = dev->iopsTestWithArgs(test, args);
+        if (ret == -EOPNOTSUPP)
+            std::cout << "Test not support" << std::endl;
+        else if (ret < 0)
+            std::cout << "Test failed" << std::endl;
+        else
+            std::cout << "Test completed" << std::endl;
     }
 
     return 0;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1165,7 +1165,7 @@ int searchXsaAndDsa(int index, std::string xsaPath, std::string
 }
 
 int xcldev::device::runTestCase(const std::string& py,
-    const std::string& xclbin, std::string& output, const std::string &args = std::string())
+    const std::string& xclbin, std::string& output, const std::string &args = "")
 {
     struct stat st;
 
@@ -1220,7 +1220,8 @@ int xcldev::device::runTestCase(const std::string& py,
 
         cmd = xrtTestCasePath + " " + xclbinPath + " -d " + std::to_string(m_idx);
 
-    } else if (py.find(".exe") == std::string::npos) { //OLD FLOW:
+    }
+    else if (py.find(".exe") == std::string::npos) { //OLD FLOW:
         // Use suffix ".exe" to identify special test case is not ideal. Let's do it for now.
         // We could refine this once need.
         xrtTestCasePath += py;    
@@ -1261,7 +1262,8 @@ int xcldev::device::runTestCase(const std::string& py,
         }
 
         cmd = "/usr/bin/python3 " + xrtTestCasePath + " -k " + xclbinPath + " -d " + std::to_string(m_idx);
-    } else {
+    }
+    else {
         xrtTestCasePath += py;
         xclbinPath += xclbin;
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -128,6 +128,8 @@ enum cmacommand {
 };
 enum kdscommand {
     KDS_CU_INTERRUPT = 0x0,
+    KDS_TEST,
+    KDS_ARGS,
 };
 
 enum class cu_stat : unsigned short {
@@ -1955,12 +1957,13 @@ public:
     int testP2p(void);
     int testM2m(void);
     int iopsTest(void);
+    int iopsTestWithArgs(const std::string& name, const std::string& args);
 
 private:
     // Run a test case as <exe> <xclbin> [-d index] on this device and collect
     // all output from the run into "output"
     // Note: exe should assume index to be 0 without -d
-    int runTestCase(const std::string& exe, const std::string& xclbin, std::string& output);
+    int runTestCase(const std::string& exe, const std::string& xclbin, std::string& output, const std::string &args);
 
     int scVersionTest(void);
     int pcieLinkTest(void);

--- a/tests/validate/CMakeLists.txt
+++ b/tests/validate/CMakeLists.txt
@@ -17,3 +17,7 @@ endif()
 add_subdirectory(verify_test)
 add_subdirectory(bandwidth_test)
 add_subdirectory(slavebridge_test)
+
+# Special iops performance test cases
+add_subdirectory(xcl_iops_test)
+add_subdirectory(xrt_iops_test)

--- a/tests/validate/xcl_iops_test/CMakeLists.txt
+++ b/tests/validate/xcl_iops_test/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(TESTNAME "xcl_iops_test.exe")
+
+set(xrt_core_LIBRARY xrt_core)
+set(xrt_coreutil_LIBRARY xrt_coreutil)
+
+include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
+add_executable(${TESTNAME} src/xcl_api_iops.cpp)
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+
+if (NOT WIN32)
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+endif(NOT WIN32)
+
+if (NOT DEFINED XRT_VALIDATE_DIR)
+    set(XRT_VALIDATE_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
+endif()
+
+install(TARGETS ${TESTNAME}
+    RUNTIME DESTINATION ${XRT_VALIDATE_DIR})

--- a/tests/validate/xcl_iops_test/CMakeLists.txt
+++ b/tests/validate/xcl_iops_test/CMakeLists.txt
@@ -3,17 +3,14 @@ set(TESTNAME "xcl_iops_test.exe")
 set(xrt_core_LIBRARY xrt_core)
 set(xrt_coreutil_LIBRARY xrt_coreutil)
 
-include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
-add_executable(${TESTNAME} src/xcl_api_iops.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
-
-if (NOT WIN32)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
-endif(NOT WIN32)
-
 if (NOT DEFINED XRT_VALIDATE_DIR)
-    set(XRT_VALIDATE_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
+  set(XRT_VALIDATE_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
 endif()
 
-install(TARGETS ${TESTNAME}
+if (NOT WIN32)
+  add_executable(${TESTNAME} src/xcl_api_iops.cpp)
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+  install(TARGETS ${TESTNAME}
     RUNTIME DESTINATION ${XRT_VALIDATE_DIR})
+endif(NOT WIN32)
+

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -1,0 +1,380 @@
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <vector>
+#include <memory>
+#include <chrono>
+#include <thread>
+#include <sys/mman.h>
+#include <getopt.h>
+
+#include "xilutil.hpp"
+#include "xrt.h"
+#include "ert.h"
+#include "xclbin.h"
+
+using ms_t = std::chrono::microseconds;
+using Clock = std::chrono::high_resolution_clock;
+
+struct task_info {
+    unsigned                boh;
+    unsigned                exec_bo;
+    ert_start_kernel_cmd   *ecmd;
+};
+
+typedef struct task_args {
+    int thread_id;
+    int dev_id;
+    int queueLength;
+    unsigned int total;
+    std::string xclbin_fn;
+    Clock::time_point start;
+    Clock::time_point end;
+} arg_t;
+
+bool verbose = false;
+barrier barrier;
+
+static void usage(char *prog)
+{
+    std::cout << "Usage: " << prog << " <xclbin> -d <dev id> [options]\n"
+              << "options:\n"
+              << "    -t       number of threads\n"
+              << "    -l       length of queue (send how many commands without waiting)\n"
+              << "    -a       total amount of commands per thread\n"
+              << std::endl;
+}
+
+static void usage_and_exit(char *prog)
+{
+    usage(prog);
+    exit(0);
+}
+
+static std::vector<char>
+load_file_to_memory(const std::string& fn)
+{
+    if (fn.empty())
+        throw std::runtime_error("No xclbin specified");
+
+    // load bit stream
+    std::ifstream stream(fn);
+    stream.seekg(0,stream.end);
+    size_t size = stream.tellg();
+    stream.seekg(0,stream.beg);
+
+    std::vector<char> bin(size);
+    stream.read(bin.data(), size);
+
+    return bin;
+}
+
+double runTest(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>>& cmds,
+               unsigned int total, arg_t &arg)
+{
+    int i = 0;
+    unsigned int issued = 0, completed = 0;
+    arg.start = Clock::now();
+
+    for (auto& cmd : cmds) {
+        if (xclExecBuf(handle, cmd->exec_bo))
+            throw std::runtime_error("Unable to issue exec buf");
+        if (++issued == total)
+            break;
+    }
+
+    while (completed < total) {
+        /* assume commands to the same CU finished in order */
+        while (cmds[i]->ecmd->state < ERT_CMD_STATE_COMPLETED) {
+            while (xclExecWait(handle, -1) == 0);
+        }
+        if (cmds[i]->ecmd->state != ERT_CMD_STATE_COMPLETED)
+            throw std::runtime_error("CU execution failed");
+
+        completed++;
+        if (issued < total) {
+            if (xclExecBuf(handle, cmds[i]->exec_bo))
+                throw std::runtime_error("Unable to issue exec buf");
+            issued++;
+        }
+
+        if (++i == cmds.size())
+            i = 0;
+    }
+
+    arg.end = Clock::now();
+    return (std::chrono::duration_cast<ms_t>(arg.end - arg.start)).count();
+}
+
+void fillCmdVector(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>> &cmds,
+        int bank, int expected_cmds)
+{
+    for (int i = 0; i < expected_cmds; i++) {
+        task_info cmd;
+        cmd.boh = xclAllocBO(handle, 20, 0, bank);
+        if (cmd.boh == NULLBO) {
+            std::cout << "Could not allocate more output buffers" << std::endl;
+            break;
+        }
+        xclBOProperties prop;
+        xclGetBOProperties(handle, cmd.boh, &prop);
+        uint64_t boh_addr = prop.paddr;
+
+        cmd.exec_bo = xclAllocBO(handle, 4096, 0, XCL_BO_FLAGS_EXECBUF);
+        if (cmd.exec_bo == NULLBO) {
+            std::cout << "Could not allocate more exec buf" << std::endl;
+            xclFreeBO(handle, cmd.boh);
+            break;
+        }
+        cmd.ecmd = reinterpret_cast<ert_start_kernel_cmd *>(xclMapBO(handle, cmd.exec_bo, true));
+        if (cmd.ecmd == MAP_FAILED) {
+            std::cout << "Could not map more exec buf" << std::endl;
+            xclFreeBO(handle, cmd.boh);
+            xclFreeBO(handle, cmd.exec_bo);
+            break;
+        }
+
+        int rsz = 19;
+        cmd.ecmd->opcode = ERT_START_CU;
+        cmd.ecmd->count = rsz;
+        cmd.ecmd->cu_mask = 0x1;
+        cmd.ecmd->data[rsz - 3] = boh_addr;
+        cmd.ecmd->data[rsz - 2] = boh_addr >> 32;
+
+        cmds.push_back(std::make_shared<task_info>(cmd));
+    }
+    //std::cout << "Allocated commands, expect " << expected_cmds << ", created " << cmds.size() << std::endl;
+}
+
+int testSingleThread(int dev_id, std::string &xclbin_fn)
+{
+    xclDeviceHandle handle;
+    xuid_t uuid;
+    int bank = 0;
+    std::vector<std::shared_ptr<task_info>> cmds;
+    /* The command would incease */
+    std::vector<unsigned int> cmds_per_run = { 50000,100000,500000,1000000 };
+    /* There is performance and reach maximum FD limited issue */
+    //int expected_cmds = 100000;
+    int expected_cmds = 128;
+    std::vector<arg_t> arg(1);
+
+    handle = xclOpen(dev_id, "", XCL_QUIET);
+    if (!handle) {
+        printf("Could not open device\n");
+        return 1;
+    }
+
+    auto xclbin = load_file_to_memory(xclbin_fn);
+    auto top = reinterpret_cast<const axlf*>(xclbin.data());
+    auto topo = xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+    auto topology = reinterpret_cast<mem_topology*>(xclbin.data() + topo->m_sectionOffset);
+    if (xclLoadXclBin(handle, top))
+        throw std::runtime_error("Bitstream download failed");
+
+    uuid_copy(uuid, top->m_header.uuid);
+
+    for (int i = 0; i < topology->m_count; ++i) {
+        if (topology->m_mem_data[i].m_used) {
+            bank = i;
+            break;
+        }
+    }
+
+    if (xclOpenContext(handle, uuid, 0, true))
+        throw std::runtime_error("Cound not open context");
+
+    /* Create 'expected_cmds' commands if possible */
+    fillCmdVector(handle, cmds, bank, expected_cmds);
+
+    arg[0].thread_id = 0;
+    for (auto& num_cmds : cmds_per_run) {
+#if 0
+        double total = 0;
+        for (int i = 0; i < 5; i++) {
+            total += runTest(handle, cmds, num_cmds);
+        }
+        double duration = total / 5;
+#else
+        double duration = runTest(handle, cmds, num_cmds, arg[0]);
+#endif
+        std::cout << "Commands: " << std::setw(7) << num_cmds
+                  << " iops: " << (num_cmds * 1000.0 * 1000.0 / duration)
+                  << std::endl;
+    }
+
+    for (auto& cmd : cmds) {
+        xclFreeBO(handle, cmd->boh);
+        munmap(cmd->ecmd, 4096);
+        xclFreeBO(handle, cmd->exec_bo);
+    }
+
+    xclCloseContext(handle, uuid, 0);
+    xclClose(handle);
+    return 0;
+}
+
+void runTestThread(arg_t &arg)
+{
+    xclDeviceHandle handle;
+    xuid_t uuid;
+    int bank = 0;
+    std::vector<std::shared_ptr<task_info>> cmds;
+
+    handle = xclOpen(arg.dev_id, "", XCL_QUIET);
+    if (!handle)
+        throw std::runtime_error("Could not open device");
+
+    auto xclbin = load_file_to_memory(arg.xclbin_fn);
+    auto top = reinterpret_cast<const axlf*>(xclbin.data());
+    auto topo = xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+    auto topology = reinterpret_cast<mem_topology*>(xclbin.data() + topo->m_sectionOffset);
+    if (xclLoadXclBin(handle, top))
+        throw std::runtime_error("Bitstream download failed");
+
+    uuid_copy(uuid, top->m_header.uuid);
+
+    for (int i = 0; i < topology->m_count; ++i) {
+        if (topology->m_mem_data[i].m_used) {
+            bank = i;
+            break;
+        }
+    }
+
+    if (xclOpenContext(handle, uuid, 0, true))
+        throw std::runtime_error("Cound not open context");
+
+    fillCmdVector(handle, cmds, bank, arg.queueLength);
+
+    barrier.wait();
+
+    double duration = runTest(handle, cmds, arg.total, arg);
+
+    barrier.wait();
+
+    for (auto& cmd : cmds) {
+        xclFreeBO(handle, cmd->boh);
+        munmap(cmd->ecmd, 4096);
+        xclFreeBO(handle, cmd->exec_bo);
+    }
+
+    xclCloseContext(handle, uuid, 0);
+}
+
+int testMultiThreads(int dev_id, std::string &xclbin_fn, int threadNumber, int queueLength, unsigned int total)
+{
+    std::thread threads[threadNumber];
+    std::vector<arg_t> arg(threadNumber);
+
+    barrier.init(threadNumber + 1);
+
+    for (int i = 0; i < threadNumber; i++) {
+        arg[i].thread_id = i;
+        arg[i].dev_id = dev_id;
+        arg[i].queueLength = queueLength;
+        arg[i].total = total;
+        arg[i].xclbin_fn = xclbin_fn;
+        threads[i] = std::thread([&](int i){ runTestThread(arg[i]); }, i);
+    }
+
+    /* Wait threads to prepare to start */
+    barrier.wait();
+    auto start = Clock::now();
+
+    /* Wait threads done */
+    barrier.wait();
+    auto end = Clock::now();
+
+    for (int i = 0; i < threadNumber; i++)
+        threads[i].join();
+
+    /* calculate performance */
+    int overallCommands = 0;
+    double duration;
+    for (int i = 0; i < threadNumber; i++) {
+        if (verbose) {
+            duration = (std::chrono::duration_cast<ms_t>(arg[i].end - arg[i].start)).count();
+            std::cout << "Thread " << arg[i].thread_id
+                << " Commands: " << std::setw(7) << total
+                << std::setprecision(0) << std::fixed
+                << " iops: " << (total * 1000000.0 / duration)
+                << std::endl;
+        }
+        overallCommands += total;
+    }
+
+    duration = (std::chrono::duration_cast<ms_t>(end - start)).count();
+    std::cout << "Overall Commands: " << std::setw(7) << overallCommands
+              << std::setprecision(0) << std::fixed
+              << " iops: " << (overallCommands * 1000000.0 / duration)
+              << std::endl;
+    return 0;
+}
+
+int _main(int argc, char* argv[])
+{
+    std::string xclbin_fn;
+    int dev_id = 0;
+    int queueLength = 128;
+    unsigned total = 50000;
+    int threadNumber = 2;
+    char c;
+
+    while ((c = getopt(argc, argv, "k:d:l:t:a:vh")) != -1) {
+        switch (c) {
+            case 'k':
+                xclbin_fn = optarg; 
+                break;
+            case 'd':
+                dev_id = std::stoi(optarg);
+                break;
+            case 't':
+                threadNumber = std::stoi(optarg);
+                break;
+            case 'l':
+                queueLength = std::stoi(optarg);
+                break;
+            case 'a':
+                total = std::stoi(optarg);
+                break;
+            case 'v':
+                verbose = true;
+                break;
+            case 'h':
+                usage_and_exit(argv[0]);
+        }
+    }
+
+    /* Sanity check */
+    if (dev_id < 0)
+        throw std::runtime_error("Negative device ID");
+
+    if (queueLength <= 0)
+        throw std::runtime_error("Negative/Zero queue length");
+
+    if (threadNumber <= 0)
+        throw std::runtime_error("Invalid thread number");
+
+    //printf("The system has %d device(s)\n", xclProbe());
+
+    //testSingleThread(dev_id, xclbin_fn);
+    testMultiThreads(dev_id, xclbin_fn, threadNumber, queueLength, total);
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    try {
+        _main(argc, argv);
+        return 0;
+    }
+    catch (const std::exception& ex) {
+        std::cout << "TEST FAILED: " << ex.what() << std::endl;
+    }
+    catch (...) {
+        std::cout << "TEST FAILED" << std::endl;
+    }
+
+    return 1;
+};

--- a/tests/validate/xcl_iops_test/src/xilutil.hpp
+++ b/tests/validate/xcl_iops_test/src/xilutil.hpp
@@ -1,0 +1,59 @@
+/* Xilinx XRT test case utility header file */
+
+#ifndef XIL_UTIL_HPP
+#define XIL_UTIL_HPP
+
+#include <mutex>
+#include <condition_variable>
+
+/* std::barrier can be used since c++20
+ * Thanks boost library. Modified a little bit with pure c++11 code
+ */
+class barrier
+{
+    static inline unsigned int check_counter(unsigned int count) {
+        if (count == 0)
+            throw std::runtime_error("barrier count cannot be zero");
+        return count;
+    }
+
+    public:
+    barrier()
+        : m_generation(0)
+    {}
+
+    barrier(int count)
+        : m_count(check_counter(count))
+          , m_generation(0)
+          , m_count_reset_val(count)
+    {}
+
+    void init(int count) {
+        m_count = check_counter(count);
+        m_count_reset_val = m_count;
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lk(m_mutex);
+        int gen = m_generation;
+
+        if (--m_count == 0) {
+            m_generation++;
+            m_count = m_count_reset_val;
+            m_cv.notify_all();
+            return;
+        }
+
+        while (gen == m_generation)
+            m_cv.wait(lk);
+    }
+
+    private:
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    unsigned int m_count;
+    unsigned int m_generation;
+    unsigned int m_count_reset_val;
+};
+
+#endif

--- a/tests/validate/xrt_iops_test/CMakeLists.txt
+++ b/tests/validate/xrt_iops_test/CMakeLists.txt
@@ -3,17 +3,14 @@ set(TESTNAME "xrt_iops_test.exe")
 set(xrt_core_LIBRARY xrt_core)
 set(xrt_coreutil_LIBRARY xrt_coreutil)
 
-include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
-add_executable(${TESTNAME} src/xrt_api_iops.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
-
-if (NOT WIN32)
-  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
-endif(NOT WIN32)
-
 if (NOT DEFINED XRT_VALIDATE_DIR)
     set(XRT_VALIDATE_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
 endif()
 
-install(TARGETS ${TESTNAME}
+if (NOT WIN32)
+  add_executable(${TESTNAME} src/xrt_api_iops.cpp)
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+  install(TARGETS ${TESTNAME}
     RUNTIME DESTINATION ${XRT_VALIDATE_DIR})
+endif(NOT WIN32)
+

--- a/tests/validate/xrt_iops_test/CMakeLists.txt
+++ b/tests/validate/xrt_iops_test/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(TESTNAME "xrt_iops_test.exe")
+
+set(xrt_core_LIBRARY xrt_core)
+set(xrt_coreutil_LIBRARY xrt_coreutil)
+
+include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
+add_executable(${TESTNAME} src/xrt_api_iops.cpp)
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+
+if (NOT WIN32)
+  target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+endif(NOT WIN32)
+
+if (NOT DEFINED XRT_VALIDATE_DIR)
+    set(XRT_VALIDATE_DIR "${CMAKE_CURRENT_BINARY_DIR}/")
+endif()
+
+install(TARGETS ${TESTNAME}
+    RUNTIME DESTINATION ${XRT_VALIDATE_DIR})

--- a/tests/validate/xrt_iops_test/src/xilutil.hpp
+++ b/tests/validate/xrt_iops_test/src/xilutil.hpp
@@ -1,0 +1,59 @@
+/* Xilinx XRT test case utility header file */
+
+#ifndef XIL_UTIL_HPP
+#define XIL_UTIL_HPP
+
+#include <mutex>
+#include <condition_variable>
+
+/* std::barrier can be used since c++20
+ * Thanks boost library. Modified a little bit with pure c++11 code
+ */
+class barrier
+{
+    static inline unsigned int check_counter(unsigned int count) {
+        if (count == 0)
+            throw std::runtime_error("barrier count cannot be zero");
+        return count;
+    }
+
+    public:
+    barrier()
+        : m_generation(0)
+    {}
+
+    barrier(int count)
+        : m_count(check_counter(count))
+          , m_generation(0)
+          , m_count_reset_val(count)
+    {}
+
+    void init(int count) {
+        m_count = check_counter(count);
+        m_count_reset_val = m_count;
+    }
+
+    void wait() {
+        std::unique_lock<std::mutex> lk(m_mutex);
+        int gen = m_generation;
+
+        if (--m_count == 0) {
+            m_generation++;
+            m_count = m_count_reset_val;
+            m_cv.notify_all();
+            return;
+        }
+
+        while (gen == m_generation)
+            m_cv.wait(lk);
+    }
+
+    private:
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    unsigned int m_count;
+    unsigned int m_generation;
+    unsigned int m_count_reset_val;
+};
+
+#endif

--- a/tests/validate/xrt_iops_test/src/xrt_api_iops.cpp
+++ b/tests/validate/xrt_iops_test/src/xrt_api_iops.cpp
@@ -1,0 +1,240 @@
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <chrono>
+#include <thread>
+#include <getopt.h>
+
+#include "xilutil.hpp"
+#include "experimental/xrt_device.h"
+#include "experimental/xrt_bo.h"
+#include "experimental/xrt_kernel.h"
+
+using ms_t = std::chrono::microseconds;
+using Clock = std::chrono::high_resolution_clock;
+
+typedef struct task_args {
+  int thread_id;
+  int queueLength;
+  unsigned int total;
+  Clock::time_point start;
+  Clock::time_point end;
+} arg_t;
+
+bool verbose = false;
+barrier barrier;
+
+static void usage(char *prog)
+{
+  std::cout << "Usage: " << prog << " -k <xclbin> -d <dev id> [options]\n"
+    << "options:\n"
+    << "    -t       number of threads\n"
+    << "    -l       length of queue (send how many commands without waiting)\n"
+    << "    -a       total amount of commands per thread\n"
+    << std::endl;
+}
+
+static void usage_and_exit(char *prog)
+{
+  usage(prog);
+  exit(0);
+}
+
+double runTest(std::vector<xrt::run>& cmds, unsigned int total, arg_t &arg)
+{
+  int i = 0;
+  unsigned int issued = 0, completed = 0;
+  arg.start = Clock::now();
+
+  for (auto& cmd : cmds) {
+    cmd.start();
+    if (++issued == total)
+      break;
+  }
+
+  while (completed < total) {
+    cmds[i].wait();
+
+    completed++;
+    if (issued < total) {
+      cmds[i].start();
+      issued++;
+    }
+
+    if (++i == cmds.size())
+      i = 0;
+  }
+
+  arg.end = Clock::now();
+  return (std::chrono::duration_cast<ms_t>(arg.end - arg.start)).count();
+}
+
+int testSingleThread(int dev_id, std::string &xclbin_fn)
+{
+  /* The command would incease */
+  std::vector<unsigned int> cmds_per_run = { 50000,100000,500000,1000000 };
+  int expected_cmds = 128;
+  std::vector<arg_t> arg(1);
+
+  auto device = xrt::device(dev_id);
+  auto uuid = device.load_xclbin(xclbin_fn);
+
+  auto hello = xrt::kernel(device, uuid.get(), "hello");
+
+  arg[0].thread_id = 0;
+  /* Create 'expected_cmds' commands if possible */
+  std::vector<xrt::run> cmds;
+  for (int i = 0; i < expected_cmds; i++) {
+    auto run = xrt::run(hello);
+    run.set_arg(0, xrt::bo(device, 20, hello.group_id(0)));
+    cmds.push_back(std::move(run));
+  }
+  std::cout << "Allocated commands, expect " << expected_cmds << ", created " << cmds.size() << std::endl;
+
+  for (auto num_cmds : cmds_per_run) {
+    double duration = runTest(cmds, num_cmds, arg[0]);
+    std::cout << "Commands: " << std::setw(7) << num_cmds
+      << " iops: " << (num_cmds * 1000.0 * 1000.0 / duration)
+      << std::endl;
+  }
+
+  return 0;
+}
+
+void runTestThread(xrt::device &device, xrt::kernel &hello, arg_t &arg)
+{
+  std::vector<xrt::run> cmds;
+
+  for (int i = 0; i < arg.queueLength; i++) {
+    auto run = xrt::run(hello);
+    run.set_arg(0, xrt::bo(device, 20, hello.group_id(0)));
+    cmds.push_back(std::move(run));
+  }
+  barrier.wait();
+
+  double duration = runTest(cmds, arg.total, arg);
+
+  barrier.wait();
+}
+
+int testMultiThreads(int dev_id, std::string &xclbin_fn, int threadNumber, int queueLength, unsigned int total)
+{
+  std::thread threads[threadNumber];
+  std::vector<arg_t> arg(threadNumber);
+
+  auto device = xrt::device(dev_id);
+  auto uuid = device.load_xclbin(xclbin_fn);
+  auto hello = xrt::kernel(device, uuid.get(), "hello");
+
+  barrier.init(threadNumber + 1);
+
+  for (int i = 0; i < threadNumber; i++) {
+    arg[i].thread_id = i;
+    arg[i].queueLength = queueLength;
+    arg[i].total = total;
+    threads[i] = std::thread([&](int i){ runTestThread(device, hello, arg[i]); }, i);
+  }
+
+  /* Wait threads to prepare to start */
+  barrier.wait();
+  auto start = Clock::now();
+
+  /* Wait threads done */
+  barrier.wait();
+  auto end = Clock::now();
+
+  for (int i = 0; i < threadNumber; i++)
+    threads[i].join();
+
+  /* calculate performance */
+  int overallCommands = 0;
+  double duration;
+  for (int i = 0; i < threadNumber; i++) {
+    if (verbose) {
+      duration = (std::chrono::duration_cast<ms_t>(arg[i].end - arg[i].start)).count();
+      std::cout << "Thread " << arg[i].thread_id
+                << " Commands: " << std::setw(7) << total
+                << std::setprecision(0) << std::fixed
+                << " iops: " << (total * 1000000.0 / duration)
+                << std::endl;
+    }
+    overallCommands += total;
+  }
+
+  duration = (std::chrono::duration_cast<ms_t>(end - start)).count();
+  std::cout << "Overall Commands: " << std::setw(7) << overallCommands
+            << std::setprecision(0) << std::fixed
+            << " iops: " << (overallCommands * 1000000.0 / duration)
+            << std::endl;
+  return 0;
+}
+
+int _main(int argc, char* argv[])
+{
+  std::string xclbin_fn;
+  int dev_id = 0;
+  int queueLength = 128;
+  unsigned total = 50000;
+  int threadNumber = 2;
+  char c;
+
+  while ((c = getopt(argc, argv, "k:d:l:t:a:h")) != -1) {
+    switch (c) {
+      case 'k':
+        xclbin_fn = optarg; 
+        break;
+      case 'd':
+        dev_id = std::stoi(optarg);
+        break;
+      case 't':
+        threadNumber = std::stoi(optarg);
+        break;
+      case 'l':
+        queueLength = std::stoi(optarg);
+        break;
+      case 'a':
+        total = std::stoi(optarg);
+        break;
+      case 'v':
+        verbose = true;
+        break;
+      case 'h':
+        usage_and_exit(argv[0]);
+    }
+  }
+
+  /* Sanity check */
+  if (dev_id < 0)
+    throw std::runtime_error("Negative device ID");
+
+  if (queueLength <= 0)
+    throw std::runtime_error("Negative/Zero queue length");
+
+  if (threadNumber <= 0)
+    throw std::runtime_error("Invalid thread number");
+
+  //printf("The system has %d device(s)\n", xclProbe());
+  auto device = xrt::device(dev_id);
+  auto uuid = device.load_xclbin(xclbin_fn);
+
+  //testSingleThread(dev_id, xclbin_fn);
+  testMultiThreads(dev_id, xclbin_fn, threadNumber, queueLength, total);
+
+  return 0;
+}
+
+int main(int argc, char *argv[])
+{
+  try {
+    _main(argc, argv);
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << std::endl;
+  }
+  catch (...) {
+    std::cout << "TEST FAILED" << std::endl;
+  }
+
+  return 1;
+};


### PR DESCRIPTION
add iops test cases in xbutil tool

1. "xbutil validate" would run XRT API iops test case with 1 thread, 128 queue length and totally 500000 commands.
2. "xbutil scheduler" can select iops test type and customize arguments.
Example 1,
xbutil scheduler -d 0 --test <xcl_iops | xrt_iops> --args "-t 3 -l 128 -a 1000000"
where value of --args would pass to the test case executable.
    -t is the number of threads
    -l is the length of queue
    -a is the amount of commands

Example 2 (test echo mode),
xbutil scheduler -d 0 -e 1 --test <xcl_iops | xcl_iops> --args "-t 3 -l 128 -a 1000000"
