### PR TITLE
Return cached xclbin uuid when query fails

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -75,8 +75,9 @@ get_xclbin_uuid() const
   catch (const query::no_such_key&) {
   }
 
-  // Emulation mode likely
-  return uuid();
+  // Emulation mode likely, just return m_xclbin_uuid which reflects
+  // the uuid of the xclbin loaded by this process.
+  return m_xclbin_uuid;
 }
 
 void


### PR DESCRIPTION
If device query for xclbin uuid fails, then return the uuid of the
xclbin loaded by current process.  Emulation mode doesn't respond to
the uuid query request, so this change makes get_xclbin_uuid() behave
corretly in emulation mode which where there any way is just one
process.