### PR TITLE
signal handler before child

### DIFF
--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -338,9 +338,8 @@ void configSoftKernel(xclSKCmd *cmd)
      * kernel image.
      */
     pid = fork();
-    if (pid > 0) {
+    if (pid > 0)
       signal(SIGCHLD,SIG_IGN);
-    }
 
     if (pid == 0) {
       char path[XRT_MAX_PATH_LENGTH];

--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -338,6 +338,10 @@ void configSoftKernel(xclSKCmd *cmd)
      * kernel image.
      */
     pid = fork();
+    if (pid > 0) {
+      signal(SIGCHLD,SIG_IGN);
+    }
+
     if (pid == 0) {
       char path[XRT_MAX_PATH_LENGTH];
       char proc_name[PNAME_LEN] = {};
@@ -375,9 +379,6 @@ void configSoftKernel(xclSKCmd *cmd)
       syslog(LOG_INFO, "Kernel %s was terminated\n", cmd->krnl_name);
       exit(EXIT_SUCCESS);
     }
-
-    if (pid > 0)
-      signal(SIGCHLD,SIG_IGN);
 
     if (pid < 0)
       syslog(LOG_ERR, "Unable to create soft kernel process( %d)\n", i);


### PR DESCRIPTION
zombie process seen on PS after soft kernel errors
signal handler is needed before creation of soft kernel child process