### PR TITLE
unnecessary sleep in ps_wait() in some cases

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -41,6 +41,7 @@ zocl-y := \
 	zocl_sysfs.o \
 	zocl_ioctl.o \
 	zocl_ert.o \
+	zocl_watchdog.o \
 	zocl_drv.o \
 	zocl_bo.o \
 	zocl_dma.o \

--- a/src/runtime_src/core/edge/drm/zocl/include/sched_exec.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/sched_exec.h
@@ -164,6 +164,16 @@ struct sched_exec_core {
 
 	/* Context switch */
 	atomic_t		  exec_status;
+
+	/*
+	 * Watchdog thread monitoring the state of skd/cmc/cq/sched.
+	 * This is only working in ert mode. And in this mode, kds mode
+	 * is not working, which means there is no handling thread per cu.
+	 * In the future if per thread cu is enabled, since those threads
+	 * are created after xclbin is loaded, we may need a list to
+	 * maitain all of the thread to be monitored.
+	 */
+	struct task_struct      *watchdog_thread;
 };
 
 /**

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -30,6 +30,7 @@
 #include "zocl_bo.h"
 #include "zocl_dma.h"
 #include "zocl_ospi_versal.h"
+#include "zocl_watchdog.h"
 #include "xrt_cu.h"
 
 #if defined(CONFIG_ARM64)
@@ -254,8 +255,6 @@ extern struct platform_driver cu_driver;
 struct zocl_cu_ops {
 	int (*submit)(struct platform_device *pdev, struct kds_command *xcmd);
 };
-
-int zocl_watchdog_thread(void *data);
 
 static inline int
 zocl_cu_submit_xcmd(struct drm_zocl_dev *zdev, int i, struct kds_command *xcmd)

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -255,6 +255,8 @@ struct zocl_cu_ops {
 	int (*submit)(struct platform_device *pdev, struct kds_command *xcmd);
 };
 
+int zocl_watchdog_thread(void *data);
+
 static inline int
 zocl_cu_submit_xcmd(struct drm_zocl_dev *zdev, int i, struct kds_command *xcmd)
 {

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -148,16 +148,7 @@ struct drm_zocl_dev {
 	char			*kernels;
 	struct zocl_error	zdev_error;
 	struct zocl_aie		*aie;
-
-	/*
-	 * Watchdog thread monitoring the state of skd/cmc/cq/sched.
-	 * This is only working in ert mode. And in this mode, kds mode
-	 * is not working, which means there is no handling thread per cu.
-	 * In the future if per thread cu is enabled, since those threads
-	 * are created after xclbin is loaded, we may need a list to
-	 * maitain all of the thread to be monitored.
-	 */
-	struct task_struct      *watchdog_thread;
+	struct zocl_watchdog_dev *watchdog;
 };
 
 int zocl_kds_update(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -148,6 +148,16 @@ struct drm_zocl_dev {
 	char			*kernels;
 	struct zocl_error	zdev_error;
 	struct zocl_aie		*aie;
+
+	/*
+	 * Watchdog thread monitoring the state of skd/cmc/cq/sched.
+	 * This is only working in ert mode. And in this mode, kds mode
+	 * is not working, which means there is no handling thread per cu.
+	 * In the future if per thread cu is enabled, since those threads
+	 * are created after xclbin is loaded, we may need a list to
+	 * maitain all of the thread to be monitored.
+	 */
+	struct task_struct      *watchdog_thread;
 };
 
 int zocl_kds_update(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_watchdog.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_watchdog.h
@@ -47,7 +47,7 @@
  * cq thread
  * sched thread
  *
- * So far when zocl is runnign in ert mode, we don't support kds. If in future
+ * So far when zocl is running in ert mode, we don't support kds. If in future
  * we do support kds, which means, we may not need sched thread and create
  * per cu thread, and since the per cu thread is created when the xclbin is
  * created, the watchdog thread may not know those thread before hand.

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_watchdog.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_watchdog.h
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#ifndef _ZOCL_WATCHDOG_H_
+#define _ZOCL_WATCHDOG_H_
+
+#include <linux/of.h>
+#include <linux/io.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/interrupt.h>
+#include <linux/of_platform.h>
+#include <linux/platform_device.h>
+
+/* watchdog subdev driver name */
+#define ZOCL_WATCHDOG_NAME "zocl_watchdog"
+
+/*
+ * will the cmc process name change?
+ * or
+ * do we even need to monitor cmc?
+ */
+#define CMC "xilinx-cmc"
+
+/* check every 3s */
+#define ZOCL_WATCHDOG_FREQ (3000)
+
+/*
+ * register at ps_reset_controller offset 0xc, upper 16 bits
+ * are being used for the watchdog purpose
+ * 
+ * Among the 16 bits, the upper 8 bits are used as counter and the lower
+ * 8 bits are used to show the state of individual part.
+ *
+ * The counter will be increased by 1 every check and gone back to 1 once
+ * overflow. This happens only when each piece we are monitoring is healthy.
+ * a 0 in counter means nothing is being monitored, say during ps reboot
+ *
+ * The pieces we are monitoring so far include,
+ * skd,
+ * cmc,
+ * cq thread
+ * sched thread
+ *
+ * So far when zocl is runnign in ert mode, we don't support kds. If in future
+ * we do support kds, which means, we may not need sched thread and create
+ * per cu thread, and since the per cu thread is created when the xclbin is
+ * created, the watchdog thread may not know those thread before hand.
+ * In that case, we may need to introduce a list linking all threads being
+ * monitored -- the link itself can be dynamically changed.
+ */
+#define WATCHDOG_OFFSET		0xc
+#define COUNTER_MASK		0xff000000
+#define RESET_MASK		0xffff
+#define SKD_BIT_SHIFT		16
+#define CMC_BIT_SHIFT		17
+#define CQ_THD_BIT_SHIFT	18
+#define SCHED_THD_BIT_SHIFT	19
+#define COUNTER_BITS_SHIFT	24
+
+extern struct platform_driver zocl_watchdog_driver;
+struct zocl_watchdog_dev;
+
+struct watchdog_cfg {
+	bool skd_run;
+	bool cmc_run;
+	bool cq_thread_run;
+	bool sched_thread_run;
+};
+
+struct zocl_watchdog_ops {
+	void (*init)(struct zocl_watchdog_dev *watchdog);
+	void (*fini)(struct zocl_watchdog_dev *watchdog);
+	void (*config)(struct zocl_watchdog_dev *watchdog,
+		       struct watchdog_cfg cfg);
+};
+
+struct zocl_watchdog_dev {
+	struct platform_device       *pdev;
+	void __iomem                 *base;
+	const struct zocl_watchdog_ops    *ops;
+};
+#endif

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -17,10 +17,13 @@
 #include <linux/kthread.h>
 #include <linux/delay.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
+#include <linux/sched/task.h>
 #include "ert.h"
 #include "sched_exec.h"
 #include "zocl_sk.h"
 #include "zocl_xclbin.h"
+#include "zocl_watchdog.h"
 #include "xclbin.h"
 
 //#define SCHED_VERBOSE
@@ -51,13 +54,14 @@
 #endif
 
 static int cq_check(void *data);
+static int watchdog_thread(void *data);
 static irqreturn_t sched_cq_isr(int irq, void *arg);
 
 /* Scheduler call schedule() every MAX_SCHED_LOOP loop*/
 #define MAX_SCHED_LOOP 8
 static int    sched_loop_cnt;
 
-struct scheduler g_sched0;
+static struct scheduler g_sched0;
 static struct sched_ops penguin_ops;
 static struct sched_ops ps_ert_ops;
 
@@ -3259,7 +3263,6 @@ cq_check(void *data)
 		}
 		schedule();
 	}
-	DRM_INFO("cq_thread exits!!\n");
 	SCHED_DEBUG("<- %s", __func__);
 	return 0;
 }
@@ -3287,6 +3290,68 @@ static irqreturn_t sched_cq_isr(int irq, void *arg)
 
 	SCHED_DEBUG("<- %s", __func__);
 	return IRQ_HANDLED;
+}
+
+static int watchdog_thread(void *data)
+{
+	struct drm_zocl_dev *zdev = data;
+	struct zocl_watchdog_dev *watchdog = zdev->watchdog;
+
+	if (!watchdog)
+		goto exit;
+
+	watchdog->ops->init(watchdog);
+	while (!kthread_should_stop()) {
+		struct watchdog_cfg cfg = {
+			.skd_run = false,
+			.cmc_run = false,
+			.cq_thread_run = false,
+			.sched_thread_run = false,
+		} ;
+		struct task_struct *tsk;
+
+		rcu_read_lock();
+		for_each_process(tsk) {
+			if (!strcmp(tsk->comm, "skd")) {
+				/*DRM_INFO("skd(pid: %d) is running\n",
+					task_pid_nr(tsk));*/
+				cfg.skd_run = true;
+			}
+			if (!strncmp(tsk->comm, CMC, strlen(CMC))) {
+				/*DRM_INFO("cmc(pid: %d) is running\n",
+					task_pid_nr(tsk));*/
+				cfg.cmc_run = true;
+			}
+		}
+		rcu_read_unlock();
+
+		/*
+		 * Notes:
+		 * 1. We don't expect the sched thread and cq thread exit, so
+		 *    we don't need a lock when checking the thread state.
+		 * 2. Other than TASK_DEAD, what else state should be monitor?
+		 */
+		if (zdev->exec && zdev->exec->cq_thread &&
+			zdev->exec->cq_thread->state != TASK_DEAD)
+			cfg.cq_thread_run = true;
+		/* DRM_WARN("ert kthread state: %lx\n",
+			zdev->exec->cq_thread->state);*/
+
+		if (g_sched0.sched_thread &&
+			g_sched0.sched_thread->state != TASK_DEAD)
+			cfg.sched_thread_run = true;
+		/*DRM_WARN("sched kthread state: %lx\n",
+			g_sched0.sched_thread->state);*/
+
+		watchdog->ops->config(watchdog, cfg);
+		msleep(ZOCL_WATCHDOG_FREQ);
+		schedule();
+	}
+	watchdog->ops->fini(watchdog);
+exit:
+	zdev->exec->watchdog_thread = NULL;
+	return 0;
+
 }
 
 static inline void init_exec(struct sched_exec_core *exec_core)
@@ -3366,6 +3431,8 @@ sched_init_exec(struct drm_device *drm)
 
 		init_waitqueue_head(&exec_core->cq_wait_queue);
 		exec_core->cq_thread = kthread_run(cq_check, zdev, name);
+		exec_core->watchdog_thread = kthread_run(watchdog_thread, zdev,
+			"zocl_watchdog");
 	}
 
 	SCHED_DEBUG("<- %s\n", __func__);
@@ -3414,6 +3481,9 @@ int sched_fini_exec(struct drm_device *drm)
 	SCHED_DEBUG("-> %s\n", __func__);
 
 	fini_configure(drm);
+
+	if (zdev->exec->watchdog_thread)
+		kthread_stop(zdev->exec->watchdog_thread);
 
 	if (zdev->exec->cq_thread)
 		kthread_stop(zdev->exec->cq_thread);

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -57,7 +57,7 @@ static irqreturn_t sched_cq_isr(int irq, void *arg);
 #define MAX_SCHED_LOOP 8
 static int    sched_loop_cnt;
 
-static struct scheduler g_sched0;
+struct scheduler g_sched0;
 static struct sched_ops penguin_ops;
 static struct sched_ops ps_ert_ops;
 
@@ -3259,6 +3259,7 @@ cq_check(void *data)
 		}
 		schedule();
 	}
+	DRM_INFO("cq_thread exits!!\n");
 	SCHED_DEBUG("<- %s", __func__);
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -869,6 +869,18 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		zdev->ert = (struct zocl_ert_dev *)platform_get_drvdata(subdev);
 	}
 
+	subdev = zocl_find_pdev("reset_ps");
+	if (subdev) {
+		DRM_INFO("reset_ps found: 0x%llx\n", (uint64_t)(uintptr_t)subdev);
+		res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+		if (!res) {
+			DRM_ERROR("The base address of reset_ps is not found or 0\n");
+			return -EINVAL;
+		}
+
+		zdev->watchdog = platform_get_drvdata(subdev);
+	}
+
 	/* For Non PR platform, there is not need to have FPGA manager
 	 * For PR platform, the FPGA manager is required. No good way to
 	 * determin if it is a PR platform at probe.
@@ -965,9 +977,6 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 			goto err_sched;
 	}
 
-	if (zdev->ert)
-		zdev->watchdog_thread = kthread_run(zocl_watchdog_thread, zdev,
-			"zocl_watchdog");
 	return 0;
 
 /* error out in exact reverse order of init */
@@ -1004,11 +1013,6 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 	if (zdev->fpga_mgr)
 		fpga_mgr_put(zdev->fpga_mgr);
 
-	if (zdev->ert) {
-		if (zdev->watchdog_thread)
-			kthread_stop(zdev->watchdog_thread);
-	}
-
 	if (kds_mode == 0)
 		sched_fini_exec(drm);
 
@@ -1044,6 +1048,7 @@ static struct platform_driver zocl_drm_private_driver = {
 
 static struct platform_driver *const drivers[] = {
 	&zocl_ert_driver,
+	&zocl_watchdog_driver,
 	&zocl_ospi_versal_driver,
 	&cu_driver,
 };

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -965,6 +965,9 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 			goto err_sched;
 	}
 
+	if (zdev->ert)
+		zdev->watchdog_thread = kthread_run(zocl_watchdog_thread, zdev,
+			"zocl_watchdog");
 	return 0;
 
 /* error out in exact reverse order of init */
@@ -1000,6 +1003,11 @@ static int zocl_drm_platform_remove(struct platform_device *pdev)
 
 	if (zdev->fpga_mgr)
 		fpga_mgr_put(zdev->fpga_mgr);
+
+	if (zdev->ert) {
+		if (zdev->watchdog_thread)
+			kthread_stop(zdev->watchdog_thread);
+	}
 
 	if (kds_mode == 0)
 		sched_fini_exec(drm);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_watchdog.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_watchdog.c
@@ -53,7 +53,7 @@ static void watchdog_config(struct zocl_watchdog_dev *watchdog,
 	if (!counter)
 		counter++;
 
-	//only update counter when everything is running
+	/* only update counter when everything is running */
 	if (cfg.skd_run && cfg.cmc_run && cfg.cq_thread_run &&
 		cfg.sched_thread_run) {
 		if (counter == (COUNTER_MASK >> COUNTER_BITS_SHIFT))

--- a/src/runtime_src/core/edge/drm/zocl/zocl_watchdog.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_watchdog.c
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+#include <linux/delay.h>
+#include <linux/list.h>
+#include <linux/kthread.h>
+#include <linux/sched/signal.h>
+#include <linux/sched/task.h>
+#include <linux/sched.h>
+#include "zocl_drv.h"
+#include "sched_exec.h"
+
+extern struct scheduler g_sched0;
+
+/* will the cmc process name change? */
+#define CMC "xilinx-cmc"
+
+/* check every 3s */
+#define ZOCL_WATCHDOG_FREQ (3000)
+
+#define PS_RESET_CONTROLLER_ADDR 0x80110000
+
+/*
+ * register at ps_reset_controller offset 0xc, upper 16 bits
+ * are being used for the watchdog purpose
+ * 
+ * Among the 16 bits, the upper 8 bits are used as counter and the lower
+ * 8 bits are used to show the state of individual part.
+ *
+ * The counter will be increased by 1 every check and gone back to 1 once
+ * overflow. This happens only when each piece we are monitoring is healthy.
+ * a 0 in counter means nothing is being monitored, say during ps reboot
+ *
+ * The pieces we are monitoring so far include,
+ * skd,
+ * cmc,
+ * cq thread
+ * sched thread
+ *
+ * So far when zocl is runnign in ert mode, we don't support kds. If in future
+ * we do support kds, which means, we may not need sched thread and create
+ * per cu thread, and since the per cu thread is created when the xclbin is
+ * created, the watchdog thread may not know those thread before hand.
+ * In that case, we may need to introduce a list linking all threads being
+ * monitored -- the link itself can be dynamically changed.
+ */
+#define WATCHDOG_OFFSET		0xc
+#define COUNTER_MASK		0xff000000
+#define RESET_MASK		0xffff
+#define SKD_BIT_SHIFT		16
+#define CMC_BIT_SHIFT		17
+#define CQ_THD_BIT_SHIFT	18
+#define SCHED_THD_BIT_SHIFT	19
+#define COUNTER_BITS_SHIFT	24
+
+int zocl_watchdog_thread(void *data)
+{
+	struct drm_zocl_dev *zdev = (struct drm_zocl_dev *)data;
+	void __iomem		*vaddr = NULL;
+	u32 val;
+	vaddr = ioremap(PS_RESET_CONTROLLER_ADDR, _4KB);
+	if (IS_ERR_OR_NULL(vaddr)) {
+		DRM_ERROR("ioremap ps reset controller address failed");
+		return -EFAULT;
+	}
+	while (!kthread_should_stop()) {
+		bool skd_run = false;
+		bool cmc_run = false;
+		bool cq_thread_run = false;
+		bool sched_thread_run = false;
+		struct task_struct *tsk;
+		u8 counter;
+		val = ioread32(vaddr + WATCHDOG_OFFSET);
+		counter = (val & COUNTER_MASK) >> COUNTER_BITS_SHIFT;
+
+		/* counter 0 has special meaning. So if just started, set counter as 1 */
+		if (!counter)
+			counter++;
+
+		rcu_read_lock();
+		for_each_process(tsk) {
+			if (!strcmp(tsk->comm, "skd")) {
+				/*DRM_INFO("skd(pid: %d) is running\n",
+					task_pid_nr(tsk));*/
+				skd_run = true;
+			}
+			if (!strncmp(tsk->comm, CMC, strlen(CMC))) {
+				/*DRM_INFO("cmc(pid: %d) is running\n",
+					task_pid_nr(tsk));*/
+				cmc_run = true;
+			}
+		}
+		rcu_read_unlock();
+
+		/*
+		 * Notes:
+		 * 1. We don't expect the sched thread and cq thread exit, so
+		 *    we don't need a lock when checking the thread state.
+		 * 2. Other than TASK_DEAD, what else state should be monitor?
+		 */
+		if (zdev->exec && zdev->exec->cq_thread &&
+			zdev->exec->cq_thread->state != TASK_DEAD)
+			cq_thread_run = true;
+		/* DRM_WARN("ert kthread state: %lx\n",
+			zdev->exec->cq_thread->state);*/
+
+		if (g_sched0.sched_thread &&
+			g_sched0.sched_thread->state != TASK_DEAD)
+			sched_thread_run = true;
+		/*DRM_WARN("sched kthread state: %lx\n",
+			g_sched0.sched_thread->state);*/
+
+		//only update counter when everything is running
+		if (skd_run && cmc_run && cq_thread_run && sched_thread_run) {
+			if (counter == (COUNTER_MASK >> COUNTER_BITS_SHIFT))
+				counter = 1;
+			else
+				counter++;
+		}
+		val = (counter << COUNTER_BITS_SHIFT) +
+		       (val & RESET_MASK) +
+		       (skd_run ? 1 << SKD_BIT_SHIFT : 0) +
+		       (cmc_run ? 1 << CMC_BIT_SHIFT : 0) +
+		       (cq_thread_run ? 1 << CQ_THD_BIT_SHIFT : 0) +
+		       (sched_thread_run ? 1 << SCHED_THD_BIT_SHIFT : 0);
+		iowrite32(val, vaddr + WATCHDOG_OFFSET);
+
+		msleep(ZOCL_WATCHDOG_FREQ);
+		schedule();
+	}
+	val = ioread32(vaddr + WATCHDOG_OFFSET);
+	val &= RESET_MASK;
+	iowrite32(val, vaddr + WATCHDOG_OFFSET);
+	iounmap(vaddr);
+	return 0;
+}
+

--- a/src/runtime_src/core/edge/drm/zocl/zocl_watchdog.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_watchdog.c
@@ -5,137 +5,128 @@
  * This file is dual-licensed; you may select either the GNU General Public
  * License version 2 or Apache License, Version 2.0.
  */
-#include <linux/delay.h>
-#include <linux/list.h>
-#include <linux/kthread.h>
-#include <linux/sched/signal.h>
-#include <linux/sched/task.h>
-#include <linux/sched.h>
 #include "zocl_drv.h"
-#include "sched_exec.h"
+#include "zocl_watchdog.h"
 
-extern struct scheduler g_sched0;
-
-/* will the cmc process name change? */
-#define CMC "xilinx-cmc"
-
-/* check every 3s */
-#define ZOCL_WATCHDOG_FREQ (3000)
-
-#define PS_RESET_CONTROLLER_ADDR 0x80110000
+#define watchdog_err(pdev, fmt, args...)  \
+	zocl_err(&pdev->dev, fmt"\n", ##args)
+#define watchdog_info(pdev, fmt, args...)  \
+	zocl_info(&pdev->dev, fmt"\n", ##args)
+#define watchdog_dbg(pdev, fmt, args...)  \
+	zocl_dbg(&pdev->dev, fmt"\n", ##args)
 
 /*
- * register at ps_reset_controller offset 0xc, upper 16 bits
- * are being used for the watchdog purpose
- * 
- * Among the 16 bits, the upper 8 bits are used as counter and the lower
- * 8 bits are used to show the state of individual part.
- *
- * The counter will be increased by 1 every check and gone back to 1 once
- * overflow. This happens only when each piece we are monitoring is healthy.
- * a 0 in counter means nothing is being monitored, say during ps reboot
- *
- * The pieces we are monitoring so far include,
- * skd,
- * cmc,
- * cq thread
- * sched thread
- *
- * So far when zocl is runnign in ert mode, we don't support kds. If in future
- * we do support kds, which means, we may not need sched thread and create
- * per cu thread, and since the per cu thread is created when the xclbin is
- * created, the watchdog thread may not know those thread before hand.
- * In that case, we may need to introduce a list linking all threads being
- * monitored -- the link itself can be dynamically changed.
- */
-#define WATCHDOG_OFFSET		0xc
-#define COUNTER_MASK		0xff000000
-#define RESET_MASK		0xffff
-#define SKD_BIT_SHIFT		16
-#define CMC_BIT_SHIFT		17
-#define CQ_THD_BIT_SHIFT	18
-#define SCHED_THD_BIT_SHIFT	19
-#define COUNTER_BITS_SHIFT	24
-
-int zocl_watchdog_thread(void *data)
+ * do nothing so far
+ */ 
+static void watchdog_init(struct zocl_watchdog_dev *watchdog)
 {
-	struct drm_zocl_dev *zdev = (struct drm_zocl_dev *)data;
-	void __iomem		*vaddr = NULL;
+}
+
+/*
+ * reset counter part to 0.
+ * 0 has special meaning -- nothing is monitored
+ */ 
+static void watchdog_fini(struct zocl_watchdog_dev *watchdog)
+{
 	u32 val;
-	vaddr = ioremap(PS_RESET_CONTROLLER_ADDR, _4KB);
-	if (IS_ERR_OR_NULL(vaddr)) {
-		DRM_ERROR("ioremap ps reset controller address failed");
-		return -EFAULT;
-	}
-	while (!kthread_should_stop()) {
-		bool skd_run = false;
-		bool cmc_run = false;
-		bool cq_thread_run = false;
-		bool sched_thread_run = false;
-		struct task_struct *tsk;
-		u8 counter;
-		val = ioread32(vaddr + WATCHDOG_OFFSET);
-		counter = (val & COUNTER_MASK) >> COUNTER_BITS_SHIFT;
-
-		/* counter 0 has special meaning. So if just started, set counter as 1 */
-		if (!counter)
-			counter++;
-
-		rcu_read_lock();
-		for_each_process(tsk) {
-			if (!strcmp(tsk->comm, "skd")) {
-				/*DRM_INFO("skd(pid: %d) is running\n",
-					task_pid_nr(tsk));*/
-				skd_run = true;
-			}
-			if (!strncmp(tsk->comm, CMC, strlen(CMC))) {
-				/*DRM_INFO("cmc(pid: %d) is running\n",
-					task_pid_nr(tsk));*/
-				cmc_run = true;
-			}
-		}
-		rcu_read_unlock();
-
-		/*
-		 * Notes:
-		 * 1. We don't expect the sched thread and cq thread exit, so
-		 *    we don't need a lock when checking the thread state.
-		 * 2. Other than TASK_DEAD, what else state should be monitor?
-		 */
-		if (zdev->exec && zdev->exec->cq_thread &&
-			zdev->exec->cq_thread->state != TASK_DEAD)
-			cq_thread_run = true;
-		/* DRM_WARN("ert kthread state: %lx\n",
-			zdev->exec->cq_thread->state);*/
-
-		if (g_sched0.sched_thread &&
-			g_sched0.sched_thread->state != TASK_DEAD)
-			sched_thread_run = true;
-		/*DRM_WARN("sched kthread state: %lx\n",
-			g_sched0.sched_thread->state);*/
-
-		//only update counter when everything is running
-		if (skd_run && cmc_run && cq_thread_run && sched_thread_run) {
-			if (counter == (COUNTER_MASK >> COUNTER_BITS_SHIFT))
-				counter = 1;
-			else
-				counter++;
-		}
-		val = (counter << COUNTER_BITS_SHIFT) +
-		       (val & RESET_MASK) +
-		       (skd_run ? 1 << SKD_BIT_SHIFT : 0) +
-		       (cmc_run ? 1 << CMC_BIT_SHIFT : 0) +
-		       (cq_thread_run ? 1 << CQ_THD_BIT_SHIFT : 0) +
-		       (sched_thread_run ? 1 << SCHED_THD_BIT_SHIFT : 0);
-		iowrite32(val, vaddr + WATCHDOG_OFFSET);
-
-		msleep(ZOCL_WATCHDOG_FREQ);
-		schedule();
-	}
-	val = ioread32(vaddr + WATCHDOG_OFFSET);
+	val = ioread32(watchdog->base + WATCHDOG_OFFSET);
 	val &= RESET_MASK;
-	iowrite32(val, vaddr + WATCHDOG_OFFSET);
-	iounmap(vaddr);
+	iowrite32(val, watchdog->base + WATCHDOG_OFFSET);
+}
+
+/*
+ * if everyting is running, increase the counter by 1, set to 1 if overflow 
+ * otherwise, just set the state bit for each individual being monitored
+ */ 
+static void watchdog_config(struct zocl_watchdog_dev *watchdog,
+	struct watchdog_cfg cfg)
+{
+	u32 val;
+	u8 counter;
+	val = ioread32(watchdog->base + WATCHDOG_OFFSET);
+	counter = (val & COUNTER_MASK) >> COUNTER_BITS_SHIFT;
+
+	/*
+	 * counter 0 has special meaning. So if just started,
+	 * set counter as 1
+	 */
+	if (!counter)
+		counter++;
+
+	//only update counter when everything is running
+	if (cfg.skd_run && cfg.cmc_run && cfg.cq_thread_run &&
+		cfg.sched_thread_run) {
+		if (counter == (COUNTER_MASK >> COUNTER_BITS_SHIFT))
+			counter = 1;
+		else
+			counter++;
+	}
+	val = (counter << COUNTER_BITS_SHIFT) +
+	       (val & RESET_MASK) +
+	       (cfg.skd_run ? 1 << SKD_BIT_SHIFT : 0) +
+	       (cfg.cmc_run ? 1 << CMC_BIT_SHIFT : 0) +
+	       (cfg.cq_thread_run ? 1 << CQ_THD_BIT_SHIFT : 0) +
+	       (cfg.sched_thread_run ? 1 << SCHED_THD_BIT_SHIFT : 0);
+	iowrite32(val, watchdog->base + WATCHDOG_OFFSET);
+}
+
+static struct zocl_watchdog_ops watchdog_ops = {
+	.init         = watchdog_init,
+	.fini         = watchdog_fini,
+	.config       = watchdog_config,
+};
+
+static const struct of_device_id zocl_watchdog_of_match[] = {
+	{ .compatible = "xlnx,reset_ps",
+	  .data = &watchdog_ops,
+	},
+	{ /* end of table */ },
+};
+
+MODULE_DEVICE_TABLE(of, zocl_watchdog_of_match);
+
+static int zocl_watchdog_probe(struct platform_device *pdev)
+{
+	struct zocl_watchdog_dev *watchdog;
+	const struct of_device_id *id;
+	struct resource *res;
+	const struct zocl_watchdog_ops *ops;
+	void __iomem *map;
+
+	id = of_match_node(zocl_watchdog_of_match, pdev->dev.of_node);
+	watchdog_info(pdev, "Probing for %s", id->compatible);
+
+	watchdog = devm_kzalloc(&pdev->dev, sizeof(*watchdog), GFP_KERNEL);
+	watchdog->pdev = pdev;
+
+	ops = of_device_get_match_data(&pdev->dev);
+	watchdog->ops = ops;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	map = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(map)) {
+		watchdog_err(pdev, "Failed to map reset controller HW registers:"
+			" %0lx", PTR_ERR(map));
+		return PTR_ERR(map);
+	}
+	watchdog->base = map;
+	watchdog_info(pdev, "IP(reset controller) IO start %lx, end %lx",
+	      (unsigned long)res->start, (unsigned long)res->end);
+
+	platform_set_drvdata(pdev, watchdog);
 	return 0;
 }
 
+static int zocl_watchdog_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+struct platform_driver zocl_watchdog_driver = {
+	.driver = {
+		.name = ZOCL_WATCHDOG_NAME,
+		.of_match_table = zocl_watchdog_of_match,
+	},
+	.probe  = zocl_watchdog_probe,
+	.remove = zocl_watchdog_remove,
+};

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -516,6 +516,8 @@ static int health_check_cb(void *data)
 
 	(void) xocl_clock_status(lro, &latched);
 
+	xocl_ps_check_healthy(lro);
+
 	/*
 	 * UCS doesn't exist on U2, and U2 CMC firmware uses different
 	 * methodology to report clock shutdown status.

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
@@ -59,7 +59,7 @@
  *
  */
 #define RESET_REG_C	0xC
-/* watchdog freq should be same to that defind in zocl_watchdog.c */
+/* watchdog freq should be same to that defined in zocl_watchdog.h */
 #define ZOCL_WATCHDOG_FREQ (3000)
 
 #define ERT_READY_MASK  0x8

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
@@ -166,10 +166,11 @@ static int ps_wait(struct platform_device *pdev)
 		return -ENODEV;
 
 	mutex_lock(&ps->ps_lock);
-	do {
+	reg = READ_REG32(ps, RESET_REG_C);
+	while(retry++ < MAX_WAIT && !(reg & ERT_READY_MASK)) {
 		reg = READ_REG32(ps, RESET_REG_C);
 		msleep(WAIT_INTERVAL);
-	} while(retry++ < MAX_WAIT && !(reg & ERT_READY_MASK));
+	}
 
 	if (retry >= MAX_WAIT) {
 		xocl_err(&pdev->dev, "PS wait time out");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ps.c
@@ -41,11 +41,37 @@
 #define PS_RESET        0xc
 #define POR_RESET       0x3
 
+/*
+ * register at offset 0xc, upper 16 bits are being used for the watchdog
+ * purpose, lower 16 bits are being used to show reset status
+ *
+ * Among the 16 bits for watchdog, the upper 8 bits are used as counter and
+ * the lower 8 bits are used to show the state of individual part.
+ *
+ * The counter will be increased by 1 every check and gone back to 0 once
+ * overflow. This happens only when each piece we are monitoring is healthy.
+ *
+ * The pieces we are monitoring so far include,
+ * skd,
+ * cmc,
+ * cq thread
+ * sched thread
+ *
+ */
 #define RESET_REG_C	0xC
+/* watchdog freq should be same to that defind in zocl_watchdog.c */
+#define ZOCL_WATCHDOG_FREQ (3000)
 
 #define ERT_READY_MASK  0x8
 #define RES_DONE_MASK   0x4
 #define RES_TYPE_MASK   0x3
+#define COUNTER_MASK		0xff000000
+#define RESET_MASK		0xffff
+#define SKD_BIT_SHIFT		16
+#define CMC_BIT_SHIFT		17
+#define CQ_THD_BIT_SHIFT	18
+#define SCHED_THD_BIT_SHIFT	19
+#define COUNTER_BITS_SHIFT	24
 
 #define SK_RESET	0x1
 
@@ -189,8 +215,62 @@ static ssize_t ps_ready_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(ps_ready);
 
+static ssize_t ps_watchdog_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_ps *ps = platform_get_drvdata(to_platform_device(dev));
+	ssize_t count = 0;
+	u32 reg0, reg;
+	bool alive = false;
+
+	mutex_lock(&ps->ps_lock);
+	reg0 = READ_REG32(ps, RESET_REG_C);
+	msleep(ZOCL_WATCHDOG_FREQ);
+	reg = READ_REG32(ps, RESET_REG_C);
+	mutex_unlock(&ps->ps_lock);
+
+	if ((reg & COUNTER_MASK) &&
+		(reg0 & COUNTER_MASK) != (reg & COUNTER_MASK))
+		alive = true;
+	if (alive)
+		count = sprintf(buf, "ps healthy: 1\n");
+	else
+		count = sprintf(buf, "ps healthy: 0\n");
+
+	/*
+	 * counter 0 means the watchdong thread exits. eg. ps reboot,
+	 * zocl unload, etc. In this case, don't show other info
+	 */
+	if (!(reg & COUNTER_MASK))
+		return count;
+
+	if (reg & (1 << SKD_BIT_SHIFT))
+		count += sprintf(buf + count, "skd: running\n");
+	else
+		count += sprintf(buf + count, "skd: not running\n");
+
+	if (reg & (1 << CMC_BIT_SHIFT))
+		count += sprintf(buf + count, "cmc: running\n");
+	else
+		count += sprintf(buf + count, "cmc: not running\n");
+
+	if (reg & (1 << CQ_THD_BIT_SHIFT))
+		count += sprintf(buf + count, "cq thread: running\n");
+	else
+		count += sprintf(buf + count, "cq thread: not running\n");
+
+	if (reg & (1 << SCHED_THD_BIT_SHIFT))
+		count += sprintf(buf + count, "sched thread: running\n");
+	else
+		count += sprintf(buf + count, "sched thread: not running\n");
+
+	return count;
+}
+static DEVICE_ATTR_RO(ps_watchdog);
+
 static struct attribute *ps_attrs[] = {
 	&dev_attr_ps_ready.attr,
+	&dev_attr_ps_watchdog.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -918,6 +918,7 @@ struct xocl_ps_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	void (*reset)(struct platform_device *pdev, int type);
 	int (*wait)(struct platform_device *pdev);
+	void (*check_healthy)(struct platform_device *pdev);
 };
 
 #define	PS_DEV(xdev)		\
@@ -935,6 +936,8 @@ struct xocl_ps_funcs {
 	(PS_CB(xdev, reset) ? PS_OPS(xdev)->reset(PS_DEV(xdev), 3) : NULL)
 #define	xocl_ps_wait(xdev)			\
 	(PS_CB(xdev, reset) ? PS_OPS(xdev)->wait(PS_DEV(xdev)) : -ENODEV)
+#define	xocl_ps_check_healthy(xdev)			\
+	(PS_CB(xdev, check_healthy) ? PS_OPS(xdev)->check_healthy(PS_DEV(xdev)) : true)
 
 
 /* dna callbacks */


### PR DESCRIPTION
tested in these cases the sysfs node in host can see status being reported
1. cq_check thread crash
2. sched thread crash
3. skd killed
4. cmc killed
5. zocl unloaded