### PR TITLE
CR-1085434 soft kernel info in xbutil query missing / incorrect

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -1120,8 +1120,10 @@ cu_stat(struct sched_cmd *cmd)
 	/* indevidual SK CU status */
 	for (i = 0; i < sk->sk_ncus && pkt_idx < max_idx; ++i) {
 		if (sk->sk_cu[i])
-			pkg->data[pkt_idx++] = (exec->scu_status[cu_mask_idx(i)] &
-				(1 << (i % sizeof(exec->scu_status[0])))) ? 1 : 0;
+			pkg->data[pkt_idx++] =
+			    (exec->scu_status[cu_mask_idx(i)] &
+			    (1 << (i % (sizeof(exec->scu_status[0]) * 8)))) ?
+			    1 : 0;
 		else
 			pkg->data[pkt_idx++] = -1; //soft cu has crashed
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4294,11 +4294,15 @@ static int config_scu(struct platform_device *pdev,
 	for (i = scmd->start_cuidx; i < scmd->start_cuidx + scmd->num_cus;
 	    i++) {
 		if (scmd->opcode == ERT_SK_CONFIG) {
+			char scu_name[32];
 			if (strlen(xert->scu_name[i]) > 0)
 				continue;
 			exec->num_sk_cus++;
-			strncpy(xert->scu_name[i], (char *)scmd->sk_name,
-				sizeof(xert->scu_name[0]) - 1);
+			/* Add "scu_idx#" suffix to identify softkernel */
+			strncpy(scu_name, (char *)scmd->sk_name,
+				sizeof(xert->scu_name[0]) - 8);
+			snprintf(xert->scu_name[i], 32, "%s:scu_%d",
+				scu_name, i);
 		} else {
 			if (strlen(xert->scu_name[i]) == 0)
 				continue;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1543,10 +1543,16 @@ public:
               }
               int cu_i = xclIPName2Index(m_handle, cu_n.c_str());
               if (cu_i < 0) {
-                ostr << "CU: ";
-              } else {
-                ostr << "CU[" << std::right << std::setw(2) << cu_i << "]: ";
-              }
+                std::size_t found = cu_n.rfind("scu");
+                if (found != std::string::npos) {
+                  auto scu_i = std::stoi(cu_n.substr(found + 4));
+                  cu_n = cu_n.substr(0, found - 1);
+                  ostr << "SCU[" << std::right << std::setw(2) << std::dec << scu_i << "]: ";
+                } else
+                  ostr << "CU: ";
+              } else
+                ostr << "CU[" << std::right << std::setw(3) << cu_i << "]: ";
+
               ostr << std::left << std::setw(32) << cu_n
                    << "@" << std::setw(18) << std::hex << cu_ba
                    << cu_s << std::endl;


### PR DESCRIPTION
After this fix the reported CU/SCU status will look like
Compute Unit Status
CU[  0]: scaler:scaler_1                 @0x1400000         (IDLE)
CU[  1]: scaler:scaler_2                 @0x1420000         (IDLE)
SCU[ 0]: kernel1                           @N/A                    (START)
SCU[ 1]: kernel1                           @N/A                    (IDLE)
SCU[ 2]: kernel1                           @N/A                    (IDLE)
SCU[ 3]: kernel1                           @N/A                    (IDLE)
SCU[ 4]: kernel1                           @N/A                    (IDLE)
SCU[ 5]: kernel1                           @N/A                    (IDLE)
SCU[ 6]: kernel1                           @N/A                    (IDLE)
SCU[ 7]: kernel1                           @N/A                    (IDLE)
SCU[ 8]: kernel1                           @N/A                    (IDLE)
SCU[ 9]: kernel1                           @N/A                    (IDLE)
SCU[10]: kernel1                          @N/A                    (IDLE)