### PR TITLE
Add a no-op shim layer to ease debugging

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -33,11 +33,12 @@
 #include "core/common/unistd.h"
 #include "core/common/xclbin_parser.h"
 
+#include <cstdlib>
 #include <map>
 #include <set>
 
 #ifdef _WIN32
-# pragma warning( disable : 4244 4100)
+# pragma warning( disable : 4244 4100 4996 )
 #endif
 
 namespace {
@@ -119,7 +120,7 @@ public:
 private:
   void
   get_bo_properties() const
-  { 
+  {
     xclBOProperties prop;
     device->get_bo_properties(handle, &prop);
     addr = prop.paddr;
@@ -127,7 +128,7 @@ private:
 
     if (is_noop_emulation())
       return;
-    
+
     // Remove when driver returns the flags that were used to ctor the bo
     auto mem_topo = device->get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY);
     grpid = xrt_core::xclbin::address_to_memidx(mem_topo, addr);
@@ -293,7 +294,7 @@ public:
   {
     if (addr == no_addr)
       get_bo_properties();
-    
+
     return addr;
   }
 
@@ -415,7 +416,7 @@ public:
   {
     return bo_impl::no_group;
   }
-  
+
 };
 
 // class buffer_dbuf - device only buffer

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1694,7 +1694,7 @@ public:
     auto pkt = cmd->get_ert_packet();
     pkt->state = ERT_CMD_STATE_NEW;
 
-    XRT_DEBUGF("command packet debug (see file (%s))\n", debug_cmd_packet(kernel->get_name(), pkt).c_str());
+    XRT_DEBUG_CALL(debug_cmd_packet(kernel->get_name(), pkt));
 
     cmd->run();
   }

--- a/src/runtime_src/core/common/debug.h
+++ b/src/runtime_src/core/common/debug.h
@@ -58,6 +58,9 @@ void debug(std::ostream& ostr, T&& t, Args&&... args)
   ostr << time_ns() << ": " << t;
   debug_notime(ostr,std::forward<Args>(args)...);
 }
+template <typename ...Args>
+void sink(Args&&... args)
+{}
 
 /**
  * Format debug print to stdout
@@ -87,11 +90,15 @@ xassert(const std::string& file, const std::string& line, const std::string& fun
 # define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__)
 # define XRT_DEBUGF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
 # define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
+# define XRT_DEBUG_CALL(...) xrt_core::call(__VA_ARGS__);
+# define XRT_CALL(...) xrt_core::sink(__VA_ARGS__);
 #else
 # define XRT_DEBUG(...)
 # define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__)
 # define XRT_DEBUGF(...)
 # define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
+# define XRT_DEBUG_CALL(...)
+# define XRT_CALL(...) xrt_core::sink(__VA_ARGS__);
 #endif
 
 #define XRT_ASSERT(expr,msg) ((expr) ? ((void)0) : xrt_core::xassert(__FILE__,std::to_string(__LINE__),__FUNCTION__,#expr))

--- a/src/runtime_src/core/common/module_loader.cpp
+++ b/src/runtime_src/core/common/module_loader.cpp
@@ -60,6 +60,14 @@ is_hw_emulation()
   return hwem;
 }
 
+static bool
+is_noop_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool noop = xem ? (std::strcmp(xem,"noop")==0) : false;
+  return noop;
+}
+
 static std::string
 shim_name()
 {
@@ -79,6 +87,9 @@ shim_name()
       ? "xrt_swemu"
       : sw_em_driver_path;
   }
+
+  if (is_noop_emulation())
+    return "xrt_noop";
 
   throw std::runtime_error("Unexected error creating shim library name");
 }

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -108,7 +108,7 @@ public:
   }
 
   virtual void
-  program_plp(const device* dev, const std::vector<char> &buffer) const
+  program_plp(const device*, const std::vector<char>&) const
   {
     throw std::runtime_error("plp program is not supported");
   }

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -108,7 +108,10 @@ public:
   }
 
   virtual void
-  program_plp(const device* dev, const std::vector<char> &buffer) const = 0;
+  program_plp(const device* dev, const std::vector<char> &buffer) const
+  {
+    throw std::runtime_error("plp program is not supported");
+  }
 }; // system
 
 /**

--- a/src/runtime_src/core/pcie/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/CMakeLists.txt
@@ -10,6 +10,7 @@ if(NOT WIN32)
   if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
     # Emulation flow only works on x86_64
     add_subdirectory(emulation)
+    add_subdirectory(noop)
   endif()
 else()
   add_subdirectory(windows)

--- a/src/runtime_src/core/pcie/noop/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/noop/CMakeLists.txt
@@ -1,0 +1,48 @@
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${Boost_INCLUDE_DIRS}
+  ${CMAKE_BINARY_DIR}
+  )
+
+file(GLOB XRT_PCIE_NOOP_FILES
+  "*.h"
+  "*.cpp"
+  "../common/system_pcie.cpp"
+  "../common/device_pcie.cpp"
+  )
+
+file(GLOB XRT_PCIE_NOOP_SHARED_FILES
+  "shim.cpp"
+  "system_noop.cpp"
+  "../common/system_pcie.cpp"
+  "device_noop.cpp"
+  "../common/device_pcie.cpp"
+  )
+
+set(CMAKE_CXX_FLAGS "-DXCLHAL_MAJOR_VER=2 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-DXCLHAL_MINOR_VER=1 ${CMAKE_CXX_FLAGS}")
+
+add_library(xrt_noop SHARED
+  ${XRT_PCIE_NOOP_SHARED_FILES}
+  $<TARGET_OBJECTS:core_common_objects>
+  )
+
+set_target_properties(xrt_noop PROPERTIES VERSION ${XRT_VERSION_STRING}
+  SOVERSION ${XRT_SOVERSION})
+
+target_link_libraries(xrt_noop
+  PRIVATE
+  xrt_coreutil
+  )
+
+install(TARGETS xrt_noop
+  EXPORT xrt-targets
+  LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} ${XRT_NAMELINK_SKIP}
+  RUNTIME DESTINATION ${XRT_INSTALL_BIN_DIR}
+)
+
+install(TARGETS xrt_noop
+  EXPORT xrt-targets-dev
+  ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
+  LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT} ${XRT_NAMELINK_ONLY}
+)

--- a/src/runtime_src/core/pcie/noop/config.h
+++ b/src/runtime_src/core/pcie/noop/config.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef xrtcore_pcie_noop_config_h_
+#define xrtcore_pcie_noop_config_h_
+
+//------------------Enable dynamic linking on noop-------------------------//
+
+#ifdef _WIN32
+# ifdef XRT_CORE_PCIE_NOOP_SOURCE
+#  define XRT_CORE_PCIE_NOOP_EXPORT __declspec(dllexport)
+# else
+#  define XRT_CORE_PCIE_NOOP_EXPORT __declspec(dllimport)
+# endif
+#endif
+#ifdef __GNUC__
+# ifdef XRT_CORE_PCIE_NOOP_SOURCE
+#  define XRT_CORE_PCIE_NOOP_EXPORT __attribute__ ((visibility("default")))
+# else
+#  define XRT_CORE_PCIE_NOOP_EXPORT
+# endif
+#endif
+
+#ifndef XRT_CORE_PCIE_NOOP_EXPORT
+# define XRT_CORE_PCIE_NOOP_EXPORT
+#endif
+
+#endif

--- a/src/runtime_src/core/pcie/noop/device_noop.cpp
+++ b/src/runtime_src/core/pcie/noop/device_noop.cpp
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#include "device_noop.h"
+#include "shim.h"
+
+#include <string>
+
+namespace {
+
+}
+
+namespace xrt_core { namespace noop {
+
+
+device::
+device(handle_type device_handle, id_type device_id, bool user)
+  : shim<device_pcie>(device_handle, device_id, user)
+{
+}
+
+}} // noop,xrt_core

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2020 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef PCIE_NOOP_DEVICE_LINUX_H
+#define PCIE_NOOP_DEVICE_LINUX_H
+
+#include "core/common/ishim.h"
+#include "core/pcie/common/device_pcie.h"
+
+namespace xrt_core { namespace noop {
+
+// concrete class derives from device_edge, but mixes in
+// shim layer functions for access through base class
+class device : public shim<device_pcie>
+{
+public:
+  device(handle_type device_handle, id_type device_id, bool user);
+
+private:
+  // Private look up function for concrete query::request
+  virtual const query::request&
+  lookup_query(query::key_type query_key) const
+  {
+    throw std::runtime_error("query lookup not implemented");
+  }
+};
+
+}} // noop, xrt_core
+
+#endif

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -1,0 +1,591 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#define XCL_DRIVER_DLL_EXPORT
+#define XRT_CORE_PCIE_NOOP_SOURCE
+#include "shim.h"
+#include "core/include/ert.h"
+#include "core/common/message.h"
+#include "core/common/system.h"
+#include "core/common/device.h"
+
+#include <cstdio>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+namespace { // private implementation details
+
+namespace buffer {
+
+struct bo
+{
+  void* hbuf = nullptr;
+  void* own = nullptr;
+  void* dbuf = reinterpret_cast<void*>(0xdeadbeef);
+  size_t size = 0;
+  unsigned int flags = 0;
+
+  bo(void* uptr, size_t bytes, unsigned int flgs)
+    : hbuf(uptr), size(bytes), flags(flgs)
+  {}
+
+  bo(size_t bytes, unsigned int flgs)
+    : hbuf(malloc(bytes)), own(hbuf), size(bytes), flags(flgs)
+  {
+    std::memset(hbuf, 0, size);
+  }
+
+  ~bo()
+  { if (own) free(own); }
+};
+
+static std::mutex mutex;
+static unsigned int handle = 0;
+static std::map<unsigned int, std::unique_ptr<bo>> h2b;
+
+auto
+find(unsigned int handle)
+{
+  std::lock_guard<std::mutex> lk(mutex);
+  auto itr = h2b.find(handle);
+  if (itr == h2b.end())
+    throw std::runtime_error("no such bo handle: " + std::to_string(handle));
+  return itr;
+}
+
+bo*
+get(unsigned int handle)
+{
+  auto itr = find(handle);
+  return (*itr).second.get();
+}
+
+unsigned int
+alloc(size_t size, unsigned int flags)
+{
+  std::lock_guard<std::mutex> lk(mutex);
+  h2b.insert(std::make_pair(handle, std::make_unique<bo>(size, flags)));
+  return handle++;
+}
+
+unsigned int
+alloc(void* uptr, size_t size, unsigned int flags)
+{
+  std::lock_guard<std::mutex> lk(mutex);
+  h2b.insert(std::make_pair(handle, std::make_unique<bo>(uptr, size, flags)));
+  return handle++;
+}
+
+void*
+map(unsigned int handle)
+{
+  auto bo = get(handle);
+  return bo->hbuf;
+}
+
+void
+free(unsigned int handle)
+{
+  auto itr = find(handle);
+  h2b.erase(itr);
+}
+
+} // bo
+  
+struct shim
+{
+  using buffer_handle_type = xclBufferHandle; // xrt.h
+  unsigned int m_devidx;
+  bool m_locked = false;
+  std::shared_ptr<xrt_core::device> m_core_device;
+
+  // create shim object, open the device, store the device handle
+  shim(unsigned int devidx)
+    : m_devidx(devidx), m_core_device(xrt_core::get_userpf_device(this, m_devidx))
+  {}
+
+  // destruct shim object, close the device
+  ~shim()
+  {}
+
+  buffer_handle_type
+  alloc_bo(size_t size, unsigned int flags)
+  {
+    return buffer::alloc(size, flags);
+  }
+
+  buffer_handle_type
+  alloc_user_ptr_bo(void* userptr, size_t size, unsigned int flags)
+  {
+    return buffer::alloc(userptr, size, flags);
+  }
+
+  void*
+  map_bo(buffer_handle_type handle, bool /*write*/)
+  {
+    return buffer::map(handle);
+  }
+
+  int
+  unmap_bo(buffer_handle_type handle, void* addr)
+  {
+    return 0;
+  }
+
+  void
+  free_bo(buffer_handle_type handle)
+  {
+    buffer::free(handle);
+  }
+
+  int
+  sync_bo(buffer_handle_type, xclBOSyncDirection, size_t, size_t)
+  {
+    return 0;
+  }
+
+  int
+  open_context(const xrt::uuid&, unsigned int, bool)
+  {
+    return 0;
+  }
+
+  int
+  close_context(const xrt::uuid&, unsigned int)
+  {
+    return 0;
+  }
+
+  int
+  exec_buf(buffer_handle_type handle)
+  {
+    auto hbuf = buffer::map(handle);
+    auto cmd = reinterpret_cast<ert_packet*>(hbuf);
+    cmd->state = ERT_CMD_STATE_COMPLETED;
+    return 0;
+  }
+
+  int
+  exec_wait(int msec)
+  {
+    return 1;
+  }
+
+  int
+  get_bo_properties(buffer_handle_type handle, struct xclBOProperties* properties)
+  {
+    auto bo = buffer::get(handle);
+    properties->handle = handle;
+    properties->flags = bo->flags;
+    properties->size = bo->size;
+    properties->paddr = reinterpret_cast<uint64_t>(bo->dbuf);
+
+    return 0;
+  }
+
+  int
+  load_xclbin(const struct axlf*)
+  {
+    return 0;
+  }
+
+  int
+  write(enum xclAddressSpace, uint64_t, const void*, size_t)
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  int
+  read(enum xclAddressSpace, uint64_t, void*, size_t)
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  ssize_t
+  unmgd_pwrite(unsigned int, const void*, size_t, uint64_t)
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  ssize_t
+  unmgd_pread(unsigned int, void*, size_t, uint64_t)
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  int
+  write_bo(xclBufferHandle handle, const void *src, size_t size, size_t seek)
+  {
+    auto bo = buffer::get(handle);
+    auto hbuf = reinterpret_cast<char*>(bo->hbuf) + seek;
+    std::memcpy(hbuf, src, std::min(bo->size - seek, size));
+    return 0;
+  }
+
+  int
+  read_bo(xclBufferHandle handle, void *dst, size_t size, size_t skip)
+  {
+    auto bo = buffer::get(handle);
+    auto hbuf = reinterpret_cast<char*>(bo->hbuf) + skip;
+    std::memcpy(dst, hbuf, std::min(bo->size - skip, size));
+    return 0;
+  }
+
+}; // struct shim
+
+shim*
+get_shim_object(xclDeviceHandle handle)
+{
+  // TODO: Do some sanity check
+  return reinterpret_cast<shim*>(handle);
+}
+
+}
+
+// Basic
+unsigned int
+xclProbe()
+{
+  return 1;
+}
+
+xclDeviceHandle
+xclOpen(unsigned int deviceIndex, const char *logFileName, xclVerbosityLevel level)
+{
+  try {
+    xrt_core::message::
+      send(xrt_core::message::severity_level::debug, "XRT", "xclOpen()");
+    return new shim(deviceIndex);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+  }
+
+  return nullptr;
+}
+
+void
+xclClose(xclDeviceHandle handle)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclClose()");
+  auto shim = get_shim_object(handle);
+  delete shim;
+}
+
+
+// XRT Buffer Management APIs
+xclBufferHandle
+xclAllocBO(xclDeviceHandle handle, size_t size, int unused, unsigned int flags)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclAllocBO()");
+  auto shim = get_shim_object(handle);
+  return shim->alloc_bo(size, flags);
+}
+
+xclBufferHandle
+xclAllocUserPtrBO(xclDeviceHandle handle, void *userptr, size_t size, unsigned int flags)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclAllocUserPtrBO()");
+  auto shim = get_shim_object(handle);
+  return shim->alloc_user_ptr_bo(userptr, size, flags);
+}
+
+void*
+xclMapBO(xclDeviceHandle handle, xclBufferHandle boHandle, bool write)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclMapBO()");
+  auto shim = get_shim_object(handle);
+  return shim->map_bo(boHandle, write);
+}
+
+int
+xclUnmapBO(xclDeviceHandle handle, xclBufferHandle boHandle, void* addr)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclUnmapBO()");
+  auto shim = get_shim_object(handle);
+  return shim->unmap_bo(boHandle, addr);
+}
+
+void
+xclFreeBO(xclDeviceHandle handle, xclBufferHandle boHandle)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclFreeBO()");
+  auto shim = get_shim_object(handle);
+  return shim->free_bo(boHandle);
+}
+
+int
+xclSyncBO(xclDeviceHandle handle, xclBufferHandle boHandle, xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  return 0;
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclSyncBO()");
+  auto shim = get_shim_object(handle);
+  return shim->sync_bo(boHandle, dir, size, offset);
+}
+
+int
+xclCopyBO(xclDeviceHandle handle, xclBufferHandle dstBoHandle,
+          xclBufferHandle srcBoHandle, size_t size, size_t dst_offset,
+          size_t src_offset)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclCopyBO() NOT IMPLEMENTED");
+  return ENOSYS;
+}
+
+int
+xclReClock2(xclDeviceHandle handle, unsigned short region,
+            const uint16_t* targetFreqMHz)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclReClock2() NOT IMPLEMENTED");
+  return ENOSYS;
+}
+
+// Compute Unit Execution Management APIs
+int
+xclOpenContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipIndex, bool shared)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclOpenContext()");
+  auto shim = get_shim_object(handle);
+
+  //Virtual resources are not currently supported by driver
+  return (ipIndex == (unsigned int)-1)
+	  ? 0
+	  : shim->open_context(xclbinId, ipIndex, shared);
+}
+
+int xclCloseContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipIndex)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclCloseContext()");
+  auto shim = get_shim_object(handle);
+
+  //Virtual resources are not currently supported by driver
+  return (ipIndex == (unsigned int) -1)
+	  ? 0
+	  : shim->close_context(xclbinId, ipIndex);
+}
+
+int
+xclExecBuf(xclDeviceHandle handle, xclBufferHandle cmdBO)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclExecBuf()");
+  auto shim = get_shim_object(handle);
+  return shim->exec_buf(cmdBO);
+}
+
+int
+xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclExecWait()");
+  auto shim = get_shim_object(handle);
+  return shim->exec_wait(timeoutMilliSec);
+}
+
+xclBufferExportHandle
+xclExportBO(xclDeviceHandle handle, xclBufferHandle boHandle)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclExportBO() NOT IMPLEMENTED");
+  return XRT_NULL_BO_EXPORT;
+}
+
+xclBufferHandle
+xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned flags)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclImportBO() NOT IMPLEMENTED");
+  return XRT_NULL_BO_EXPORT;
+}
+
+int
+xclGetBOProperties(xclDeviceHandle handle, xclBufferHandle boHandle,
+		   struct xclBOProperties *properties)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclGetBOProperties()");
+  auto shim = get_shim_object(handle);
+  return shim->get_bo_properties(boHandle,properties);
+}
+
+int
+xclLoadXclBin(xclDeviceHandle handle, const struct axlf *buffer)
+{
+  try {
+    xrt_core::message::
+      send(xrt_core::message::severity_level::debug, "XRT", "xclLoadXclbin()");
+    auto shim = get_shim_object(handle);
+    if (auto ret = shim->load_xclbin(buffer))
+      return ret;
+    auto core_device = xrt_core::get_userpf_device(shim);
+    core_device->register_axlf(buffer);
+    return 0;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -EINVAL;
+  }
+}
+
+unsigned int
+xclVersion()
+{
+  return 2;
+}
+
+int
+xclGetDeviceInfo2(xclDeviceHandle handle, struct xclDeviceInfo2 *info)
+{
+  std::memset(info, 0, sizeof(xclDeviceInfo2));
+  info->mMagic = 0;
+  info->mHALMajorVersion = XCLHAL_MAJOR_VER;
+  info->mHALMinorVersion = XCLHAL_MINOR_VER;
+  info->mMinTransferSize = 0;
+  info->mDMAThreads = 2;
+  info->mDataAlignment = 4096; // 4k
+
+  return 0;
+}
+
+int
+xclLockDevice(xclDeviceHandle handle)
+{
+  return 0;
+}
+
+int
+xclUnlockDevice(xclDeviceHandle handle)
+{
+  return 0;
+}
+
+ssize_t
+xclUnmgdPwrite(xclDeviceHandle handle, unsigned int flags, const void *buf, size_t count, uint64_t offset)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclUnmgdPwrite()");
+  auto shim = get_shim_object(handle);
+  return shim->unmgd_pwrite(flags, buf, count, offset) ? 0 : 1;
+}
+
+ssize_t
+xclUnmgdPread(xclDeviceHandle handle, unsigned int flags, void *buf, size_t count, uint64_t offset)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclUnmgdPread()");
+  auto shim = get_shim_object(handle);
+  return shim->unmgd_pread(flags, buf, count, offset) ? 0 : 1;
+}
+
+size_t xclWriteBO(xclDeviceHandle handle, xclBufferHandle boHandle, const void *src, size_t size, size_t seek)
+{
+    xrt_core::message::
+        send(xrt_core::message::severity_level::debug, "XRT", "xclWriteBO()");
+    auto shim = get_shim_object(handle);
+    return shim->write_bo(boHandle, src, size, seek);
+}
+
+size_t xclReadBO(xclDeviceHandle handle, xclBufferHandle boHandle, void *dst, size_t size, size_t skip)
+{
+    xrt_core::message::
+        send(xrt_core::message::severity_level::debug, "XRT", "xclReadBO()");
+    auto shim = get_shim_object(handle);
+    return shim->read_bo(boHandle, dst, size, skip);
+}
+
+void
+xclGetDebugIpLayout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret)
+{
+}
+
+// Deprecated APIs
+size_t
+xclWrite(xclDeviceHandle handle, enum xclAddressSpace space, uint64_t offset, const void *hostbuf, size_t size)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclWrite()");
+  auto shim = get_shim_object(handle);
+  return shim->write(space,offset,hostbuf,size) ? 0 : size;
+}
+
+size_t
+xclRead(xclDeviceHandle handle, enum xclAddressSpace space,
+        uint64_t offset, void *hostbuf, size_t size)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclRead()");
+  auto shim = get_shim_object(handle);
+  return shim->read(space,offset,hostbuf,size) ? 0 : size;
+}
+
+// Restricted read/write on IP register space
+int
+xclRegWrite(xclDeviceHandle handle, uint32_t ipidx, uint32_t offset, uint32_t data)
+{
+  return 1;
+}
+
+int
+xclRegRead(xclDeviceHandle handle, uint32_t ipidx, uint32_t offset, uint32_t* datap)
+{
+  return 1;
+}
+
+int
+xclGetTraceBufferInfo(xclDeviceHandle handle, uint32_t nSamples,
+                      uint32_t& traceSamples, uint32_t& traceBufSz)
+{
+  return 0;
+}
+
+int
+xclReadTraceData(xclDeviceHandle handle, void* traceBuf, uint32_t traceBufSz,
+                 uint32_t numSamples, uint64_t ipBaseAddress,
+                 uint32_t& wordsPerSample)
+{
+  return 0;
+}
+
+int
+xclGetSubdevPath(xclDeviceHandle handle,  const char* subdev,
+                 uint32_t idx, char* path, size_t size)
+{
+  return 0;
+}
+
+int
+xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
+{
+  return 1; // -ENOSYS;
+}

--- a/src/runtime_src/core/pcie/noop/shim.h
+++ b/src/runtime_src/core/pcie/noop/shim.h
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef XRT_CORE_PCIE_NOOP_SHIM_H
+#define XRT_CORE_PCIE_NOOP_SHIM_H
+
+#include "core/pcie/noop/config.h"
+#include "xrt.h"
+
+namespace userpf {
+
+
+} // userpf
+
+
+#endif

--- a/src/runtime_src/core/pcie/noop/system_noop.cpp
+++ b/src/runtime_src/core/pcie/noop/system_noop.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "system_noop.h"
+#include "device_noop.h"
+#include "xrt.h"
+
+#include <memory>
+
+namespace {
+
+// Singleton registers with base class xrt_core::system
+// during static global initialization.  If statically
+// linking with libxrt_core, then explicit initialiation
+// is required
+static xrt_core::noop::system*
+singleton_instance()
+{
+  static xrt_core::noop::system singleton;
+  return &singleton;
+}
+
+// Dynamic linking automatically constructs the singleton
+struct X
+{
+  X() { singleton_instance(); }
+} x;
+
+}
+
+namespace xrt_core { namespace noop {
+
+system::
+system()
+{
+}
+
+std::pair<device::id_type, device::id_type>
+system::
+get_total_devices(bool is_user) const
+{
+  return {0,0};
+}
+
+std::shared_ptr<xrt_core::device>
+system::
+get_userpf_device(device::id_type id) const
+{
+  return xrt_core::get_userpf_device(xclOpen(id, nullptr, XCL_QUIET));
+}
+
+std::shared_ptr<xrt_core::device>
+system::
+get_userpf_device(device::handle_type handle, device::id_type id) const
+{
+  // deliberately not using std::make_shared (used with weak_ptr)
+  return std::shared_ptr<xrt_core::noop::device>(new xrt_core::noop::device(handle, id, true));
+}
+
+std::shared_ptr<xrt_core::device>
+system::
+get_mgmtpf_device(device::id_type id) const
+{
+  // deliberately not using std::make_shared (used with weak_ptr)
+  return std::shared_ptr<xrt_core::noop::device>(new xrt_core::noop::device(nullptr, id, false));
+}
+
+std::shared_ptr<xrt_core::device>
+get_userpf_device(device::handle_type device_handle, device::id_type id)
+{
+  singleton_instance(); // force loading if necessary
+  return xrt_core::get_userpf_device(device_handle, id);
+}
+
+}} // noop, xrt_core

--- a/src/runtime_src/core/pcie/noop/system_noop.h
+++ b/src/runtime_src/core/pcie/noop/system_noop.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef PCIE_SYSTEM_NOOP_LINUX_H
+#define PCIE_SYSTEM_NOOP_LINUX_H
+
+#include "pcie/common/system_pcie.h"
+
+namespace xrt_core { namespace noop {
+
+class system : public system_pcie
+{
+public:
+  system();
+
+  std::pair<device::id_type, device::id_type>
+  get_total_devices(bool is_user) const;
+
+  std::shared_ptr<xrt_core::device>
+  get_userpf_device(device::id_type id) const;
+
+  std::shared_ptr<xrt_core::device>
+  get_userpf_device(device::handle_type device_handle, device::id_type id) const;
+
+  std::shared_ptr<xrt_core::device>
+  get_mgmtpf_device(device::id_type id) const;
+};
+
+/**
+ * get_userpf_device
+ * Force singleton initialization from static linking
+ * with libxrt_core.
+ */
+std::shared_ptr<device>
+get_userpf_device(device::handle_type device_handle, device::id_type id);
+
+}} // noop, xrtcore
+
+#endif

--- a/src/runtime_src/xocl/core/platform.cpp
+++ b/src/runtime_src/xocl/core/platform.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -47,29 +47,6 @@ get_env(const char* env)
   return value_or_empty(std::getenv(env));
 }
 
-static bool
-is_emulation()
-{
-  static bool val = (std::getenv("XCL_EMULATION_MODE") != nullptr);
-  return val;
-}
-
-static bool
-is_sw_emulation()
-{
-  static auto xem = std::getenv("XCL_EMULATION_MODE");
-  static bool swem = xem ? (std::strcmp(xem,"sw_emu")==0) : false;
-  return swem;
-}
-
-static bool
-is_hw_emulation()
-{
-  static auto xem = std::getenv("XCL_EMULATION_MODE");
-  static bool hwem = xem ? (std::strcmp(xem,"hw_emu")==0) : false;
-  return hwem;
-}
-
 } // namespace
 
 namespace xocl {
@@ -77,9 +54,7 @@ namespace xocl {
 class platform::xrt_device_manager
 {
   std::vector<xrt_xocl::device>  m_all; // owner
-  std::vector<xrt_xocl::device*> m_hw;
-  std::vector<xrt_xocl::device*> m_hwem;
-  std::vector<xrt_xocl::device*> m_swem;
+  std::vector<xrt_xocl::device*> m_dev; // handout
 
 public:
   xrt_device_manager()
@@ -87,89 +62,31 @@ public:
   {
     if (m_all.empty())
       throw xocl::error(CL_DEVICE_NOT_FOUND,"No devices found");
-    for (auto& dev : m_all) {
-      std::string driverLibraryName = dev.getDriverLibraryName();
-      if (driverLibraryName.find("sw_em.so") != std::string::npos
-          || driverLibraryName.find("swemu.so") != std::string::npos)
-        m_swem.push_back(&dev);
-      else if (driverLibraryName.find("hwemu.so") != std::string::npos)
-        m_hwem.push_back(&dev);
-      else
-        m_hw.push_back(&dev);
-    }
+    for (auto& dev : m_all)
+      m_dev.push_back(&dev);
 
     // The devices are partitioned into vectors that are popped off
     // the back.  This gives reverse order compared to how hw and
     // hw_em devices were processed in the past.  There is something
     // horribly wrong with these order assumptions.  Anyway, reverse
     // hw and hw_em vectors here.
-    std::reverse(m_hw.begin(),m_hw.end());
-    std::reverse(m_hwem.begin(),m_hwem.end());
-    std::reverse(m_swem.begin(),m_swem.end());
+    std::reverse(m_dev.begin(),m_dev.end());
   }
 
   bool
-  has_hw_devices() const
+  has_devices() const
   {
-    return !m_hw.empty();
-  }
-
-  bool
-  has_swem_devices() const
-  {
-    return !m_swem.empty();
-  }
-
-  bool
-  has_hwem_devices() const
-  {
-    return !m_hwem.empty();
+    return !m_dev.empty();
   }
 
   xrt_xocl::device*
-  get_swem_device()
+  get_device()
   {
     xrt_xocl::device* dev = nullptr;
-    if (has_swem_devices()) {
-      dev = m_swem.back();
-      m_swem.pop_back();
+    if (has_devices()) {
+      dev = m_dev.back();
+      m_dev.pop_back();
     }
-    return dev;
-  }
-
-  xrt_xocl::device*
-  get_hwem_device()
-  {
-    xrt_xocl::device* dev = nullptr;
-    if (has_hwem_devices()) {
-      dev = m_hwem.back();
-      m_hwem.pop_back();
-    }
-    return dev;
-  }
-
-  xrt_xocl::device*
-  get_hw_device()
-  {
-    xrt_xocl::device* dev = nullptr;
-    if (has_hw_devices()) {
-      dev = m_hw.back();
-      m_hw.pop_back();
-    }
-    return dev;
-  }
-
-  xrt_xocl::device*
-  get_hwem_device(const std::string& name)
-  {
-    auto itr = std::find_if(m_hwem.begin(),m_hwem.end(),
-                            [&name](const xrt_xocl::device* dev) {
-                              return dev->getName()==name;
-                            });
-    if (itr==m_hwem.end())
-      return nullptr;
-    xrt_xocl::device* dev = *itr;
-    m_hwem.erase(itr);
     return dev;
   }
 };
@@ -186,28 +103,9 @@ platform()
 
   XOCL_DEBUG(std::cout,"xocl::platform::platform(",m_uid,")\n");
 
-  if (is_sw_emulation()) {
-    while (auto swem_device = m_device_mgr->get_swem_device()) {
-      auto udev = std::make_unique<xocl::device>(this,swem_device);
-      auto dev = udev.release();
-      add_device(dev);
-      dev->release();
-    }
-  }
-      
-  if (is_hw_emulation()) {
-    while (auto hwem_device = m_device_mgr->get_hwem_device()) {
-      auto udev = std::make_unique<xocl::device>(this,hwem_device);
-      auto dev = udev.release();
-      add_device(dev);
-      dev->release();
-    }
-  }
-
-  //User can target either emulation or board. Not both at the same time.
-  if (!is_emulation() && m_device_mgr->has_hw_devices()) {
-    while (xrt_xocl::device* hw_device = m_device_mgr->get_hw_device()) {
-      auto udev = std::make_unique<xocl::device>(this,hw_device);
+  if (m_device_mgr->has_devices()) {
+    while (xrt_xocl::device* device = m_device_mgr->get_device()) {
+      auto udev = std::make_unique<xocl::device>(this, device);
       auto dev = udev.release();
       add_device(dev);
       dev->release();


### PR DESCRIPTION
This pull request builds a shim layer library 'libxrt_noop' which
can be used in emulation mode just like hw_emu and sw_emu by specifying
setting XCL_EMULATION_MODE to 'noop' prior to invoking host application.
The xclbin can be any existing xclbin compiled from hw, hw_emu, or sw_emu.

The current noop shim library is limited in functionality but enough
to debug through simple OpenCL and native API host code with any
platform xclbin.  Of course results will not compare as no kernels are