### PR TITLE
XRT-828 Fast adapter to host interrupt

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -141,12 +141,37 @@ cu_hls_ctrl_hs_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status)
 static inline void
 cu_hls_ctrl_chain_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status)
 {
-	u32 ctrl_reg;
+	u32 ctrl_reg = 0;
 	u32 done_reg = 0;
 	u32 ready_reg = 0;
 	u32 used_credit;
+	unsigned long flags;
 
 	used_credit = cu_hls->max_credits - cu_hls->credits;
+
+	/* HLS ap_ctrl_chain reqiured software to set ap_continue before
+	 * clear interrupt. Otherwise, the clear would failed.
+	 * So, we have to make ap_continue and clear interrupt as atomic.
+	 */
+	if (cu_hls->intr_en) {
+		spin_lock_irqsave(&cu_hls->cu_lock, flags);
+		status->num_done  = cu_hls->done;
+		status->num_ready = cu_hls->ready;
+		cu_hls->done = 0;
+		cu_hls->ready = 0;
+		spin_unlock_irqrestore(&cu_hls->cu_lock, flags);
+
+		if (status->num_done) {
+			ctrl_reg |= CU_AP_DONE;
+			cu_hls->run_cnts--;
+		}
+
+		if (used_credit && !status->num_ready)
+			ctrl_reg |= CU_AP_START;
+
+		status->new_status = ctrl_reg;
+		return;
+	}
 
 	/* Access CU when there are unsed credits or running commands
 	 * This has a huge impact on performance.
@@ -154,7 +179,7 @@ cu_hls_ctrl_chain_check(struct xrt_cu_hls *cu_hls, struct xcu_status *status)
 	if (!used_credit && !cu_hls->run_cnts)
 		return;
 
-	ctrl_reg  = cu_read32(cu_hls, CTRL);
+	ctrl_reg = cu_read32(cu_hls, CTRL);
 
 	/* if there is submitted tasks, then check if ap_start bit is clear
 	 * See comments in cu_hls_start().
@@ -195,6 +220,9 @@ static void cu_hls_enable_intr(void *core, u32 intr_type)
 {
 	struct xrt_cu_hls *cu_hls = core;
 
+	if (cu_hls->ctrl_chain)
+		cu_hls->intr_en = true;
+
 	cu_write32(cu_hls, GIE, 0x1);
 	cu_write32(cu_hls, IER, intr_type);
 }
@@ -207,6 +235,9 @@ static void cu_hls_disable_intr(void *core, u32 intr_type)
 	 * same to bit 1 for ap_ready.
 	 */
 	u32 new = orig & (~intr_type);
+
+	if (cu_hls->ctrl_chain)
+		cu_hls->intr_en = false;
 
 	cu_write32(cu_hls, GIE, 0x0);
 	cu_write32(cu_hls, IER, new);
@@ -226,6 +257,7 @@ static u32 cu_hls_clear_intr(void *core)
 	 */
 	if (cu_hls->max_credits == 1) {
 		u32 isr;
+		unsigned long flags;
 
 		/*
 		 * The old HLS adapter.
@@ -241,6 +273,21 @@ static u32 cu_hls_clear_intr(void *core)
 		 * trigger interrupt.
 		 */
 		isr = cu_read32(cu_hls, ISR);
+
+		/* See comment in cu_hls_ctrl_chain_check() */
+		if (cu_hls->ctrl_chain) {
+			spin_lock_irqsave(&cu_hls->cu_lock, flags);
+			if (isr & CU_INTR_READY)
+				cu_hls->ready++;
+
+			if (isr & CU_INTR_DONE) {
+				cu_hls->done++;
+				cu_write32(cu_hls, CTRL, CU_AP_CONTINUE);
+			}
+			spin_unlock_irqrestore(&cu_hls->cu_lock, flags);
+
+		}
+
 		cu_write32(cu_hls, ISR, isr);
 		return isr;
 	}
@@ -296,6 +343,10 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	core->credits = core->max_credits;
 	core->run_cnts = 0;
 	core->ctrl_chain = (xcu->info.protocol == CTRL_CHAIN)? true : false;
+	spin_lock_init(&core->cu_lock);
+	core->intr_en = false;
+	core->done = 0;
+	core->ready = 0;
 
 	xcu->status = cu_read32(core, CTRL);
 	xcu->core = core;

--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -202,7 +202,7 @@ static void cu_hls_enable_intr(void *core, u32 intr_type)
 static void cu_hls_disable_intr(void *core, u32 intr_type)
 {
 	struct xrt_cu_hls *cu_hls = core;
-	u32 orig = cu_read32(cu_hls, ISR);
+	u32 orig = cu_read32(cu_hls, IER);
 	/* if bit 0 of intr_type is set, it means disable ap_done,
 	 * same to bit 1 for ap_ready.
 	 */

--- a/src/runtime_src/core/common/drv/fast_adapter.c
+++ b/src/runtime_src/core/common/drv/fast_adapter.c
@@ -30,6 +30,9 @@
 #define CDAR		0x18
 #define FDR		0x1C
 
+#define ENABLE  1
+#define DISABLE 0
+
 extern int kds_echo;
 
 static inline u32 cu_read32(struct xrt_cu_fa *cu, u32 reg)
@@ -154,17 +157,25 @@ static void cu_fa_check(void *core, struct xcu_status *status)
 
 static void cu_fa_enable_intr(void *core, u32 intr_type)
 {
+	struct xrt_cu_fa *cu_fa = core;
+
+	cu_write32(cu_fa, IER, ENABLE);
 	return;
 }
 
 static void cu_fa_disable_intr(void *core, u32 intr_type)
 {
+	struct xrt_cu_fa *cu_fa = core;
+
+	cu_write32(cu_fa, IER, DISABLE);
 	return;
 }
 
 static u32 cu_fa_clear_intr(void *core)
 {
-	return 0;
+	struct xrt_cu_fa *cu_fa = core;
+
+	return cu_read32(cu_fa, ISR);
 }
 
 static struct xcu_funcs xrt_cu_fa_funcs = {

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -382,7 +382,6 @@ struct xrt_cu_hls {
 	int			 credits;
 	int			 run_cnts;
 	bool			 ctrl_chain;
-	bool			 intr_en;
 	spinlock_t		 cu_lock;
 	u32			 done;
 	u32			 ready;

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -375,12 +375,17 @@ ssize_t show_cu_stat(struct xrt_cu *xcu, char *buf);
 ssize_t show_cu_info(struct xrt_cu *xcu, char *buf);
 
 /* CU Implementations */
+#define to_cu_hls(core) ((struct xrt_cu_hls *)(core))
 struct xrt_cu_hls {
 	void __iomem		*vaddr;
 	int			 max_credits;
 	int			 credits;
 	int			 run_cnts;
 	bool			 ctrl_chain;
+	bool			 intr_en;
+	spinlock_t		 cu_lock;
+	u32			 done;
+	u32			 ready;
 };
 
 int xrt_cu_hls_init(struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -325,7 +325,7 @@ int xrt_cu_intr_thread(void *data)
 		if (process_rq(xcu))
 			continue;
 
-		if (xcu->num_sq) {
+		if (xcu->num_sq || is_zero_credit(xcu)) {
 			if (down_interruptible(&xcu->sem_cu))
 				ret = -ERESTARTSYS;
 			xrt_cu_check(xcu);
@@ -473,7 +473,7 @@ int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr)
 	return err;
 }
 
-/* 
+/*
  * If KDS has to manage PLRAM resources, we should come up with a better design.
  * Ideally, CU subdevice should request for plram resource instead of KDS assign
  * plram resource to CU.

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -328,6 +328,7 @@ int xrt_cu_intr_thread(void *data)
 		if (xcu->num_sq) {
 			if (down_interruptible(&xcu->sem_cu))
 				ret = -ERESTARTSYS;
+			xrt_cu_check(xcu);
 			__process_sq(xcu);
 		}
 
@@ -612,7 +613,7 @@ ssize_t show_cu_stat(struct xrt_cu *xcu, char *buf)
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "Bad state:        %d\n",
 			xcu->bad_state);
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "Current credit:   %d\n",
-			xcu->funcs->peek_credit(xcu->core));
+			xrt_cu_peek_credit(xcu));
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "CU status:        0x%x\n",
 			xcu->status);
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "sleep cnt:        %d\n",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -151,7 +151,6 @@ irqreturn_t cu_isr(int irq, void *arg)
 	struct xocl_cu *xcu = arg;
 
 	xrt_cu_clear_intr(&xcu->base);
-	xrt_cu_check(&xcu->base);
 
 	up(&xcu->base.sem_cu);
 


### PR DESCRIPTION
support fast adapter to host interrupt and some bug fix

On U50 shell + enable CU to host interrupt
Fast adapter nocopy kernel: _“IOPS: 967783"_
Verify kernel:                         _"IOPS: 102492"_ 

On U50 shell + disable CU to host interrupt (polling mode)
Fast adapter nocopy kernel: _"IOPS: 992429"_
verify kernel:                         _"IOPS: 213653"_
