### PR TITLE
Fix intermittent crash in kernel_command

### DIFF
--- a/src/runtime_src/core/common/debug.h
+++ b/src/runtime_src/core/common/debug.h
@@ -90,7 +90,7 @@ xassert(const std::string& file, const std::string& line, const std::string& fun
 # define XRT_PRINT(...) xrt_core::debug(__VA_ARGS__)
 # define XRT_DEBUGF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
 # define XRT_PRINTF(format,...) xrt_core::debugf(format, ##__VA_ARGS__)
-# define XRT_DEBUG_CALL(...) xrt_core::call(__VA_ARGS__);
+# define XRT_DEBUG_CALL(...) xrt_core::sink(__VA_ARGS__);
 # define XRT_CALL(...) xrt_core::sink(__VA_ARGS__);
 #else
 # define XRT_DEBUG(...)


### PR DESCRIPTION
QuasiRandomSequence_amd_hw_xilinx_u200_xdma_201830_1 crash because
kernel_command dtor made use of already deleted bo cache. Fix is to
retain ownership of internal device object.

Also fix debug compile.