### PR TITLE
Record the size of OCL imported of buffer

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -505,7 +505,9 @@ getBufferFromFd(int fd, size_t& size, unsigned flags)
 {
 #ifndef _WIN32
   auto export_handle = static_cast<xclBufferExportHandle>(fd);
-  return xrt::bo{m_handle, export_handle};
+  xrt::bo bo{m_handle, export_handle};
+  size = bo.size();
+  return bo;
 #else
   throw std::runtime_error("ImportBO function not supported on windows");
 #endif


### PR DESCRIPTION
Test fails P2P when importing 'fd' from peer.  The size of the import
BO was not recorded in the xocl::memory.

This was a regression from #4488