### PR TITLE
CR-1081174 increase tx timeout to 6 sec for hot reset mailbox command

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -101,7 +101,7 @@ static void xlnx_dna_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, &dna_status, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, &dna_status, &resp_len, NULL, NULL, 0, 0);
 	set_xlnx_dna_data(xlnx_dna, &dna_status);
 
 	vfree(mb_req);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -204,7 +204,7 @@ static void fw_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, &fw_status, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, &fw_status, &resp_len, NULL, NULL, 0, 0);
 	set_fw_data(fw, &fw_status);
 
 	vfree(mb_req);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -340,7 +340,7 @@ static void icap_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, &xcl_hwicap, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, &xcl_hwicap, &resp_len, NULL, NULL, 0, 0);
 
 	icap_set_data(icap, &xcl_hwicap);
 
@@ -1865,7 +1865,7 @@ static int __icap_peer_xclbin_download(struct icap *icap, struct axlf *xclbin)
 	timeout = max((size_t)timeout, 50UL);
 
 	(void) xocl_peer_request(xdev, mb_req, data_len,
-		&msgerr, &resplen, NULL, NULL, timeout);
+		&msgerr, &resplen, NULL, NULL, timeout, 0);
 
 	vfree(mb_req);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -474,7 +474,7 @@ static void p2p_read_addr_mgmtpf(struct p2p *p2p)
 		mb_p2p->p2p_bar_len, mb_p2p->p2p_bar_addr); 
 
 	ret = xocl_peer_request(xdev, mb_req, reqlen, &ret,
-		&resplen, NULL, NULL, 0);
+		&resplen, NULL, NULL, 0, 0);
 	vfree(mb_req);
 	if (ret) {
 		p2p_err(p2p, "dropped request (%d), failed with err: %d",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -507,7 +507,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0, 0);
 	set_sensors_data(xmc, xcl_sensor);
 
 done:
@@ -916,7 +916,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	ret = xocl_peer_request(xdev,
-		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0, 0);
 done:
 	if (ret) {
 		/* if we failed to get board info from peer, free it and 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -504,7 +504,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0, 0);
 	set_sensors_data(xmc, xcl_sensor);
 
 done:
@@ -913,7 +913,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	ret = xocl_peer_request(xdev,
-		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0, 0);
 done:
 	if (ret) {
 		/* if we failed to get board info from peer, free it and 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -137,7 +137,7 @@ static void xocl_mig_cache_read_from_peer(struct xocl_dev *xdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	ret = xocl_peer_request(xdev,
-		mb_req, reqlen, mig_ecc, &resp_len, NULL, NULL, 0);
+		mb_req, reqlen, mig_ecc, &resp_len, NULL, NULL, 0, 0);
 
 	if (!ret)
 		set_mig_cache_data(xdev, mig_ecc);
@@ -313,7 +313,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 
 	userpf_info(xdev, "request mgmtpf to program prp");
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
-		&ret, &resplen, NULL, NULL, 0);
+		&ret, &resplen, NULL, NULL, 0, 0);
 	if (mbret)
 		ret = mbret;
 	if (ret) {
@@ -362,14 +362,14 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		xocl_reset_notify(xdev->core.pdev, true);
 
 		xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
-			&ret, &resplen, NULL, NULL, 0);
+			&ret, &resplen, NULL, NULL, 0, 6);
 		/* userpf will back online till receiving mgmtpf notification */
 
 		return 0;
 	}
 
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
-		&ret, &resplen, NULL, NULL, 0);
+		&ret, &resplen, NULL, NULL, 0, 0);
 
 	xocl_reset_notify(xdev->core.pdev, true);
 
@@ -506,7 +506,7 @@ static void xocl_mb_connect(struct xocl_dev *xdev)
 	mb_conn->version = XCL_MB_PROTOCOL_VER;
 
 	ret = xocl_peer_request(xdev, mb_req, reqlen, resp, &resplen,
-		NULL, NULL, 0);
+		NULL, NULL, 0, 0);
 	(void) xocl_mailbox_set(xdev, CHAN_STATE, resp->conn_flags);
 	(void) xocl_mailbox_set(xdev, CHAN_SWITCH, resp->chan_switch);
 	(void) xocl_mailbox_set(xdev, COMM_ID, (u64)(uintptr_t)resp->comm_id);
@@ -561,7 +561,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 
 	if (err == 0) {
 		err = xocl_peer_request(xdev, req, reqlen,
-			&msg, &resplen, NULL, NULL, 0);
+			&msg, &resplen, NULL, NULL, 0, 0);
 		if (err == 0)
 			err = msg;
 	}
@@ -748,7 +748,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 		subdev_peer.offset = offset;
 		ret = xocl_peer_request(xdev, mb_req, reqlen,
-			resp, &resp_len, NULL, NULL, 0);
+			resp, &resp_len, NULL, NULL, 0, 0);
 		if (ret)
 			goto failed;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1076,7 +1076,7 @@ struct xocl_mailbox_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	int (*request)(struct platform_device *pdev, void *req,
 		size_t reqlen, void *resp, size_t *resplen,
-		mailbox_msg_cb_t cb, void *cbarg, u32 timeout);
+		mailbox_msg_cb_t cb, void *cbarg, u32 rx_timeout, u32 tx_timeout);
 	int (*post_notify)(struct platform_device *pdev, void *req, size_t len);
 	int (*post_response)(struct platform_device *pdev,
 		enum xcl_mailbox_request req, u64 reqid, void *resp, size_t len);
@@ -1090,9 +1090,9 @@ struct xocl_mailbox_funcs {
 	((struct xocl_mailbox_funcs *)SUBDEV(xdev, XOCL_SUBDEV_MAILBOX).ops)
 #define MAILBOX_READY(xdev, cb)	\
 	(MAILBOX_DEV(xdev) && MAILBOX_OPS(xdev) && MAILBOX_OPS(xdev)->cb)
-#define	xocl_peer_request(xdev, req, reqlen, resp, resplen, cb, cbarg, timeout)	\
+#define	xocl_peer_request(xdev, req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout)	\
 	(MAILBOX_READY(xdev, request) ? MAILBOX_OPS(xdev)->request(MAILBOX_DEV(xdev), \
-	req, reqlen, resp, resplen, cb, cbarg, timeout) : -ENODEV)
+	req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout) : -ENODEV)
 #define	xocl_peer_response(xdev, req, reqid, buf, len)			\
 	(MAILBOX_READY(xdev, post_response) ? MAILBOX_OPS(xdev)->post_response(	\
 	MAILBOX_DEV(xdev), req, reqid, buf, len) : -ENODEV)


### PR DESCRIPTION
Increased transfer timmeout value to 6 sec for Hot Reset request message in mailbox driver.
It is observed this request is getting timed out in winodws host <-> linux vm case.
There are couple of reasons like wireserver in windows & udev events received by mpd,
causing this timeout issue.
Right before the reset mailbox msg is sent, xocl driver does an offline/online of the mailbox subdev.
This triggers async udev event in mpd. Then when the reset mailbox msg is sent by xocl driver,
the online event may not have been handled yet (the destroyed thread has not been recreated yet),
so nobody will handle the msg – that causes the tx timeout.

Signed-off-by: Brian Xu brianx@xilinx.com
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>