### PR TITLE
driver: libqdma: fix QDMA_GLBL_ERR_STAT bit masks

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.h
@@ -845,7 +845,7 @@ int qdma_trq_c2h_config(struct xlnx_dma_dev *xdev);
 
 #define QDMA_REG_GLBL_ERR_STAT				0x248
 #define QDMA_REG_GLBL_ERR_MASK				0x24C
-#define QDMA_REG_GLBL_ERR_MASK_VALUE			0xFFFU
+#define QDMA_REG_GLBL_ERR_MASK_VALUE			0x1FFFFU
 #define		QDMA_REG_GLBL_F_ERR_RAM_SBE			0
 #define		QDMA_REG_GLBL_F_ERR_RAM_DBE			1
 #define		QDMA_REG_GLBL_F_ERR_DSC				2
@@ -856,8 +856,8 @@ int qdma_trq_c2h_config(struct xlnx_dma_dev *xdev);
 #define		QDMA_REG_GLBL_F_ERR_C2H_MM_1		7
 #define		QDMA_REG_GLBL_F_ERR_C2H_ST			8
 #define		QDMA_REG_GLBL_F_ERR_IND_CTXT_CMD	9
-#define		QDMA_REG_GLBL_F_ERR_BDG				10
-#define		QDMA_REG_GLBL_F_ERR_H2C_ST			11
+#define		QDMA_REG_GLBL_F_ERR_BDG				15
+#define		QDMA_REG_GLBL_F_ERR_H2C_ST			16
 
 
 /* Global Descriptor Error */


### PR DESCRIPTION
QDMA_GLBL_ERR_STAT register has 17 significant bits. From the QDMA 3.0 documentation (pg302), the bit 16 is err_h2c_st and bit 15 err_bdg.
So fix the bitmask to correctly show those errors and the associated macros.