### PR TITLE
CR-1086193 [XRT] ERROR: kernel 'mmult' has no compute units to support

### DIFF
--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -29,6 +29,14 @@
 
 namespace {
 
+static bool
+is_sw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
+  return swem;
+}
+
 // Hack to determine if a context is associated with exactly one
 // device.  Additionally, in emulation mode, the device must be
 // active, e.g. loaded through a call to loadBinary.
@@ -249,6 +257,13 @@ get_ext_memidx_nolock(const xclbin& xclbin) const
         m_memidx = -1;
     }
   }
+
+  // In software emulation all connections must default to memory
+  // index 0 to reflect the connectiviy in the internally created
+  // CONNECTIVITY section (core/common/xclbin_swemu.cpp)
+  if (m_memidx > 0 && is_sw_emulation())
+    m_memidx = 0;
+
   return m_memidx;
 }
 

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -22,9 +22,10 @@
 
 
 #include <iostream>
+#include <cstdlib>
 
 #ifdef _WIN32
-#pragma warning ( disable : 4267 4245 )
+#pragma warning ( disable : 4267 4245 4996 )
 #endif
 
 namespace {


### PR DESCRIPTION
Fixed error introduced in #4588 that switched OCL to underlying
xrt::kernel.  IN sw emulation, the connectivity of compute units is
now hardwired to memidx 0, in the internally created CONNECTIVITY
section.

This PR defaults explicity assigned buffers (cl_mem_ext_ptr) to memory
index 0 regardless of what host code specifies.