### PR TITLE
CR-1086015 [XRT] ERROR: userptr is not aligned - SW emu,HW emu

### DIFF
--- a/src/runtime_src/core/common/api/bo.h
+++ b/src/runtime_src/core/common/api/bo.h
@@ -56,6 +56,14 @@ XRT_CORE_COMMON_EXPORT
 bool
 is_imported(const xrt::bo& bo);
 
+XRT_CORE_COMMON_EXPORT
+bool
+is_aligned_ptr(const void* ptr);
+
+XRT_CORE_COMMON_EXPORT
+size_t
+alignment();
+
 }} // namespace bo, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -76,7 +76,7 @@ get_alignment()
 }
 
 inline  bool
-is_aligned_ptr(void* p)
+is_aligned_ptr(const void* p)
 {
   return p && (reinterpret_cast<uintptr_t>(p) % get_alignment())==0;
 }
@@ -703,6 +703,18 @@ is_imported(const xrt::bo& bo)
 {
   const auto& boh = bo.get_handle();
   return boh->is_imported();
+}
+
+bool
+is_aligned_ptr(const void* ptr)
+{
+  return ::is_aligned_ptr(ptr);
+}
+
+size_t
+alignment()
+{
+  return ::get_alignment();
 }
 
 }} // namespace bo, xrt_core

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -25,6 +25,7 @@
 #include "xrt/scheduler/scheduler.h"
 #include "xrt/util/config_reader.h"
 
+#include "core/common/api/bo.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
 #include "core/common/query_requests.h"
@@ -195,6 +196,20 @@ init_scheduler(xocl::device* device)
 }
 
 namespace xocl {
+
+size_t
+device::
+get_alignment() const
+{
+  return xrt_core::bo::alignment();
+}
+
+bool
+device::
+is_aligned_ptr(const void* ptr) const
+{
+  return xrt_core::bo::is_aligned_ptr(ptr);
+}
 
 std::string
 device::

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -204,10 +204,7 @@ public:
    * @return Minimum buffer alignment in bytes
    */
   size_t
-  get_alignment() const
-  {
-    return m_xdevice ? m_xdevice->getAlignment() : xrt_core::getpagesize();
-  }
+  get_alignment() const;
 
   /**
    * Check if memory is aligned per device requirement.
@@ -218,10 +215,7 @@ public:
    *   true if ptr is aligned, false otherwise
    */
   bool
-  is_aligned_ptr(void* p) const
-  {
-    return p && (reinterpret_cast<uintptr_t>(p) % get_alignment())==0;
-  }
+  is_aligned_ptr(const void* p) const;
 
   /**
    * Import a buffer object from exporting device to this device

--- a/src/runtime_src/xocl/core/memory.cpp
+++ b/src/runtime_src/xocl/core/memory.cpp
@@ -22,12 +22,21 @@
 
 
 #include <iostream>
+#include <cstdlib>
 
 #ifdef _WIN32
-#pragma warning ( disable : 4267 4245 )
+#pragma warning ( disable : 4267 4245 4996 )
 #endif
 
 namespace {
+
+static bool
+is_sw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
+  return swem;
+}
 
 // Hack to determine if a context is associated with exactly one
 // device.  Additionally, in emulation mode, the device must be
@@ -249,6 +258,13 @@ get_ext_memidx_nolock(const xclbin& xclbin) const
         m_memidx = -1;
     }
   }
+
+  // In software emulation all connections must default to memory
+  // index 0 to reflect the connectiviy in the internally created
+  // CONNECTIVITY section (core/common/xclbin_swemu.cpp)
+  if (m_memidx > 0 && is_sw_emulation())
+    m_memidx = 0;
+
   return m_memidx;
 }
 

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -25,6 +25,7 @@
 
 #include "core/common/memalign.h"
 #include "core/common/unistd.h"
+#include "core/common/api/bo.h"
 #include "core/include/experimental/xrt_bo.h"
 
 #include <map>
@@ -510,7 +511,7 @@ public:
     : memory(ctx,flags) ,m_size(sz), m_host_ptr(host_ptr)
   {
     // device is unknown so alignment requirement has to be hardwired
-    const size_t alignment = xrt_core::getpagesize();
+    const size_t alignment = xrt_core::bo::alignment();
 
     if (flags & (CL_MEM_COPY_HOST_PTR | CL_MEM_ALLOC_HOST_PTR))
       // allocate sufficiently aligned memory and reassign m_host_ptr


### PR DESCRIPTION
Obey alignment requirements per xrt::bo

Old code allowed 128 byte aligned host ptrs to be used, but should
have been pagesized aligned