### PR TITLE
CR-1086191 Running application with 1 RTL kernel and 1 CL kernel got error

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1168,9 +1168,14 @@ class kernel_impl
       return AP_CTRL_NONE;
 
     auto ctrl = ::get_ip_control(ips[0]);
-    for (size_t idx = 1; idx < ips.size(); ++idx)
-      if (IP_CONTROL((ips[idx]->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT) != ctrl)
+    for (size_t idx = 1; idx < ips.size(); ++idx) {
+      auto ctrlatidx = ::get_ip_control(ips[idx]);
+      if (ctrlatidx == ctrl)
+        continue;
+      if (ctrlatidx != AP_CTRL_CHAIN && ctrlatidx != AP_CTRL_HS)
         throw std::runtime_error("CU control protocol mismatch");
+      ctrl = AP_CTRL_HS; // mix of CHAIN and HS is recorded as AP_CTRL_HS
+    }
 
     return ctrl;
   }


### PR DESCRIPTION
Fallout from #4588.  The control protocol is checked for the purpose
of creating proper argument setters.  However both AP_CTRL_HS and
AP_CTRL_CHAIN use the same register map layout and therefor same
argument setter.  Relax check to allow mix of AP_CTRL_CHAIN and
AP_CTRL_HS.