### PR TITLE
CR-1081167 Golden Image does not load on about 50% of VCK5000 boards

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3458,11 +3458,11 @@ struct xocl_subdev_map {
 		.priv_data = &XOCL_BOARD_U50_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5044, PCI_ANY_ID,					\
-		.vbnv = "xilinx_vck5000",				\
+		.vbnv = "xilinx_vck5000-es1",				\
 		.priv_data = &XOCL_BOARD_VERSAL_MGMT_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5045, PCI_ANY_ID,					\
-		.vbnv = "xilinx_vck5000",				\
+		.vbnv = "xilinx_vck5000-es1",				\
 		.priv_data = &XOCL_BOARD_VERSAL_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5050, PCI_ANY_ID,                                   \

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -985,7 +985,6 @@ static int identify_bar_by_dts(struct xocl_dev *xdev)
 	struct pci_dev *pdev = xdev->core.pdev;
 	int ret;
 	int bar_id;
-	int i;
 	resource_size_t bar_len;
 
 	BUG_ON(!XOCL_DEV_HAS_DEVICE_TREE(xdev));


### PR DESCRIPTION
before
```
[root@localhost test]# /opt/xilinx/xrt/bin/xbmgmt flash --scan
Card [0000:08:00.0]
    Card type:          vck5000
    Flash type:         OSPI_VERSAL
    Flashable partition running on FPGA:
       xilinx_vck5000,[ID=0x26a01b29a3e07f7a],[SC=INACTIVE]
    Flashable partitions installed in system:   (None)
```

after
```
Card [0000:d9:00.0]
Card type: vck5000-es1
Flash type: OSPI_VERSAL
Flashable partition running on FPGA:
xilinx_vck5000-es1,[ID=0x26a01b29a3e07f7a],[SC=INACTIVE]
Flashable partitions installed in system:
xilinx_vck5000-es1_gen3x16_base_2,[ID=0x938fc99d867776fb],[SC=4.4.6]

```