### PR TITLE
driver: libqdma: fix QDMA_C2H_WRB_COAL_CFG register programming

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libqdma/qdma_regs.c
@@ -571,7 +571,7 @@ int qdma_trq_c2h_config(struct xlnx_dma_dev *xdev)
 					QDMA_C2H_PFCH_CFG_EVT_QCNT_TH_SHIFT);
 	__write_reg(xdev, QDMA_C2H_PFCH_CFG, reg);
 
-	cpml_coal_depth = __read_reg(xdev, QDMA_C2H_CMPT_COAL_BUF_DEPTH);
+	cpml_coal_depth = __read_reg(xdev, QDMA_C2H_CMPT_COAL_BUF_DEPTH) - 2;
 	reg = (cpml_coal_depth << QDMA_C2H_CMPT_COAL_CFG_MAX_BUF_SZ_SHIFT) |
 			(25 << QDMA_C2H_CMPT_COAL_CFG_TICK_VAL_SHIFT) |
 			(5 << QDMA_C2H_CMPT_COAL_CFG_TICK_CNT_SHIFT);


### PR DESCRIPTION
As reported in pg302 (v3.0), max_buf_sz field in register QDMA_C2H_WRB_COAL_CFG (0xB50)
must be programmed as QDMA_C2H_CMPT_COAL_BUF_DEPTH.buffer_depth - 2.