### PR TITLE
Removed XRT driver warning message for xbutil about kernel version. Verified 4.9.184-35 on RHEL 7.8

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -109,7 +109,7 @@ is_supported_kernel_version(std::ostream &ostr)
     std::vector<std::string> ubuntu_kernel_versions =
         { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0", "5.4.0" };
     std::vector<std::string> centos_rh_kernel_versions =
-        { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.18.0-147", "4.18.0-193", "4.18.0-240" };
+        { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.9.184-35", "4.18.0-147", "4.18.0-193", "4.18.0-240" };
     const std::string os = sensor_tree::get<std::string>("system.linux", "N/A");
 
     if(os.find("Ubuntu") != std::string::npos)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -587,7 +587,7 @@ kernelVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property
 {
   //please append the new supported versions
   const std::vector<std::string> ubuntu_kernel_versions = { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0" };
-  const std::vector<std::string> centos_rh_kernel_versions = { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.18.0-147", "4.18.0-193" };
+  const std::vector<std::string> centos_rh_kernel_versions = { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1062", "3.10.0-1127", "4.9.184-35", "4.18.0-147", "4.18.0-193" };
 
   boost::property_tree::ptree _pt_host;
   std::make_shared<ReportHost>()->getPropertyTreeInternal(_dev.get(), _pt_host);


### PR DESCRIPTION
For U30 device we need to support 4.9.184-35 kernel fir RHEL 7.8.
Currently, xbutil validate showing a warning message for XRT driver version mismatch.
Added 4.8.184-35 kernel as a supported kernel version. 
Now the warning is removed. 