### PR TITLE
Range check xrt::kernel::group_id argument

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -415,7 +415,7 @@ class ip_context
     int32_t
     get_arg_memidx(size_t argidx) const
     {
-      return default_connection[argidx];
+      return default_connection.at(argidx);
     }
 
     // Validate that specified memory index is a valid connection for


### PR DESCRIPTION
Fail with out_of_range when out-of-range.