### PR TITLE
CR-1086919 Emulation Hang for testcases in Async and Head Tetscases for SW_EMU

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -136,7 +136,10 @@ register_axlf(const axlf* top)
       const auto& mem = mem_topology->m_mem_data[midx];
       if (!mem.m_used)
         continue;
-      if (mem.m_type == MEM_STREAMING || mem.m_type == MEM_STREAMING_CONNECTION)
+      // skip types that are of no interest for global connection
+      // however in software emulation the connectivity seciton
+      // can be incorrect see (CR-1086919) so keep even these.
+      if (!is_sw_emulation() && (mem.m_type == MEM_STREAMING || mem.m_type == MEM_STREAMING_CONNECTION))
         continue;
       enc[midx] = eidx++;
     }


### PR DESCRIPTION
This is a work-around for CR-1086919 that allows XRT to handle bad
connectivity section in xclbin for software emulation.

For the CR, the connectivity section connects all kernel arguments to
a streaming memory type.  Even global arguments are connected to the
stream.  XRT in 2021.1 ignors STREAMING memory types for all global
buffer allocation, it assumes that no global arguments are connected
to these types of memories, but that assumption fails when the
connectivity section is bad as in this CR.

To handle the situation, the work-around keeps the STREAM memory bank
indices and passes the bogus memory bank index into swemu shim, where
the index is used for nothing more than book-keeping.