### PR TITLE
Potential issue of handling soft cu completion

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2,7 +2,7 @@
 /*
  * A GEM style device manager for MPSoC based OpenCL accelerators.
  *
- * Copyright (C) 2017-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2017-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Soren Soe   <soren.soe@xilinx.com>
@@ -2766,9 +2766,10 @@ mark_sk_complete(struct sched_cmd *cmd, int32_t ret)
 		slot_sz = slot_size(zdev->ddev);
 		packet = ert->cq_ioremap + (cmd->cq_slot_idx * slot_sz);
 
-		memcpy_toio(packet, &skc->header, 2 * sizeof(u32));
+		memcpy_toio(packet->data, &skc->return_code, sizeof(u32));
 	}
 }
+
 /**
  * ps_ert_query() - Check command status of argument command
  *


### PR DESCRIPTION
While we are reusing cu_mask field in ert_start_kernel_cmd, we copy both header field and cu_mask (return_code) back to command queue. Since the state field in ert command header is the only flag we check to see if a new command is coming in, this copy will make ert (zocl) thought there is a new command and start to handle it. This could cause serious problem

1) If return_code is zero (cu_mask for the extra command), the extra command may not be executed because we can not find valid CU. But it will sent an extra interrupt to host in the cq slot of previous valid command. This could be a race if host just sent a new command to that slot and will get this false interrupt.
2) If return_code is not zero, the extra command could be falsely executed and may corrupt device memory
3) It will double the command number in ert(zocl).

To fix it, we just need to copy the return_code (cu_mask) but not the header.