### PR TITLE
CR1087058 [XRT] ERROR: No compute units satisfy requested connectivity

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -38,7 +38,7 @@
 #include <set>
 
 #ifdef _WIN32
-# pragma warning( disable : 4244 4100 4996 )
+# pragma warning( disable : 4244 4100 4996 4505 )
 #endif
 
 namespace {

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -43,6 +43,7 @@
 
 namespace {
 
+XRT_CORE_UNUSED
 static bool
 is_noop_emulation()
 {
@@ -51,6 +52,7 @@ is_noop_emulation()
   return noop;
 }
 
+XRT_CORE_UNUSED
 static bool
 is_sw_emulation()
 {
@@ -134,12 +136,11 @@ private:
     addr = prop.paddr;
     grpid = prop.flags & XRT_BO_FLAGS_MEMIDX_MASK;
 
-    if (is_noop_emulation() || is_sw_emulation())
-      return;
-
+#ifdef _WIN32 // All shims minus windows return proper flags
     // Remove when driver returns the flags that were used to ctor the bo
     auto mem_topo = device->get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY);
     grpid = xrt_core::xclbin::address_to_memidx(mem_topo, addr);
+#endif
   }
 
 protected:


### PR DESCRIPTION
Revert to relying on shim level drivers to return the exact BO flags
that were passed to xclAllocBO.  This should be the case now for all
shims.  Edge supports this in #4528.  Pcie in #4522.  Software and
hardware emulation verified manually.

Exception for windows.