### PR TITLE
CR-1086632 [regression] vector range error on embedded platforms

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -419,13 +419,6 @@ public:
   {
     return hbuf;
   }
-
-  virtual uint64_t
-  get_group_id() const
-  {
-    return bo_impl::no_group;
-  }
-
 };
 
 // class buffer_dbuf - device only buffer


### PR DESCRIPTION
Make imported BOs return the group_id (memory bank index) per BO
properties returned from driver.

In reality an imported BO should be identical to a host-only-bo, but
in today's XRT xclImportBO allocates a normal BO where the device side
buffer is allocated in first available bank.  This really makes no
sense as the imported BO cannot be used in general as kernel arguments
unless they happen to connect to this default bank.  We really should
treat imported BOs as host-only-bo and error out appropriately when
host code use these as kernel arguments unless kernel truly is
connected to host memory bank.

The CR is for embedded where there is only one bank and as such
imported BOs can be used as regular one and set argument to kernels.