### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -294,9 +294,13 @@ void xclClose(xclDeviceHandle handle)
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
   if (!drv)
     return ;
-  drv->xclClose();
-  if (xclhwemhal2::HwEmShim::handleCheck(handle) && xclhwemhal2::devices.size() == 0) {
-    delete ((xclhwemhal2::HwEmShim *)handle);
+  try {
+    drv->xclClose();
+    if (xclhwemhal2::HwEmShim::handleCheck(handle) && xclhwemhal2::devices.size() == 0)
+      delete ((xclhwemhal2::HwEmShim *)handle);
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
   }
 }
 

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1619,11 +1619,10 @@ public:
         int length = stream.tellg();
         stream.seekg(0, stream.beg);
 
-        char *buffer = new char[length];
-        stream.read(buffer, length);
-        const xclBin *header = (const xclBin *)buffer;
+        std::vector<char> buffer(length);
+        stream.read(buffer.data(), length);
+        auto header = reinterpret_cast<const xclBin *>(buffer.data());
         int result = xclLoadXclBin(m_handle, header);
-        delete [] buffer;
 
         return result;
     }


### PR DESCRIPTION
Half-hearted fix to hw emulation shim.  All the xclAPI function should
try/catch if any called function can throw.