### PR TITLE
Windows flash

### DIFF
--- a/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclMgmt_INTF.h
@@ -1,5 +1,5 @@
-/*++
- *  Copyright (C) 2018-2019, Xilinx Inc.  All rights reserved.
+﻿/*
+ *  Copyright (C) 2018-2021, Xilinx Inc.  All rights reserved.
  *
  *  Author(s):
  *  Arpit Patel <arpitp@xilinx.com>
@@ -21,7 +21,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- --*/
+ */
 #pragma once
 #include "xclfeatures.h"
 #include "xclbin.h"
@@ -30,7 +30,7 @@
 //
 // Xilinx driver interface GUID
 //
-DEFINE_GUID (GUID_XILINX_PF_INTERFACE,
+DEFINE_GUID(GUID_XILINX_PF_INTERFACE,
     0xd5bf220b, 0xf9c4, 0x415d, 0xbf, 0xac, 0x8, 0x6e, 0xbd, 0x65, 0x3f, 0x8f);
 
 #define XCLMGMT_REG_NAME               L"Xclmgmt"
@@ -56,6 +56,8 @@ enum XCLMGMT_IOC_TYPES {
     XCLMGMT_IOC_GET_UUID_INFO,
     XCLMGMT_IOC_SET_DATA_RETENTION,
     XCLMGMT_IOC_GET_DATA_RETENTION,
+    XCLMGMT_IOC_PRP_FORCE_ICAP_PROGRAM_AXLF,
+    XCLMGMT_IOC_GET_DEVICE_PCI_INFO,
     XCLMGMT_IOC_MAX
 };
 
@@ -91,8 +93,10 @@ enum XCLMGMT_IOC_TYPES {
 #define XCLMGMT_OID_SET_DATA_RETENTION CTL_CODE(FILE_DEVICE_UNKNOWN, XCLMGMT_IOC_SET_DATA_RETENTION, METHOD_BUFFERED, FILE_ANY_ACCESS)
 /*Get data retention value*/
 #define XCLMGMT_OID_GET_DATA_RETENTION CTL_CODE(FILE_DEVICE_UNKNOWN, XCLMGMT_IOC_GET_DATA_RETENTION, METHOD_BUFFERED, FILE_ANY_ACCESS)
-
-
+/* IOC_PRP_FORCE_ICAP_PROGRAM_AXLF provides  struct xclmgmt_ioc_bitstream_axlf as input, and plp download status as output, force program PRP region */
+#define XCLMGMT_OID_PRP_FORCE_ICAP_PROGRAM_AXLF CTL_CODE(FILE_DEVICE_UNKNOWN, XCLMGMT_IOC_PRP_FORCE_ICAP_PROGRAM_AXLF, METHOD_BUFFERED, FILE_ANY_ACCESS)
+/* IOC_GET_DEVICE_PCI_INFO gets the device-specific info */
+#define XCLMGMT_OID_GET_DEVICE_PCI_INFO     CTL_CODE(FILE_DEVICE_UNKNOWN, XCLMGMT_IOC_GET_DEVICE_PCI_INFO, METHOD_BUFFERED, FILE_ANY_ACCESS)
 //
 // Struct for XCLMGMT_OID_GET_DEVICE_INFO IOCTL
 // MAC address is a 48-bit formatted string - "aa:bb:cc:dd:ee:ff"
@@ -146,8 +150,13 @@ typedef struct sysmon_info {
     UINT32 vcc_bram_max;
 }SYSMON_INFO, *PSYSMON_INFO;
 
-typedef struct xclmgmt_ioc_device_info {
+/* Structure available for golden */
+typedef struct xclmgmt_ioc_device_pci_info {
     PCIE_CONFIG_INFO pcie_info;
+}XCLMGMT_IOC_DEVICE_PCI_INFO, *PXCLMGMT_IOC_DEVICE_PCI_INFO;
+
+/* Structure not available for golden */
+typedef struct xclmgmt_ioc_device_info {
     DRIVER_VERSION   version;
     ULONGLONG        feature_id;
     ULONGLONG        time_stamp;
@@ -159,7 +168,7 @@ typedef struct xclmgmt_ioc_device_info {
     UINT32           ocl_frequency[XCLMGMT_NUM_SUPPORTED_CLOCKS];
     bool             mig_calibration[4];
     USHORT           num_clocks;
-	ULONGLONG        xmc_offset;
+    ULONGLONG        xmc_offset;
     struct FeatureRomHeader rom_hdr;
 }XCLMGMT_IOC_DEVICE_INFO, *PXCLMGMT_IOC_DEVICE_INFO;
 

--- a/src/runtime_src/core/pcie/windows/mgmt.cpp
+++ b/src/runtime_src/core/pcie/windows/mgmt.cpp
@@ -349,6 +349,27 @@ get_data_retention(uint32_t* value)
         throw std::runtime_error("DeviceIoControl XCLMGMT_OID_GET_DATA_RETENTION failed");
 }
 
+void
+get_pcie_info(XCLMGMT_IOC_DEVICE_PCI_INFO* value)
+{
+  DWORD bytes = 0;
+  
+  auto status = DeviceIoControl
+      (m_hdl,
+      XCLMGMT_OID_GET_DEVICE_PCI_INFO,     //ioctl code
+      value,                               //in buffer
+      sizeof(XCLMGMT_IOC_DEVICE_PCI_INFO), //in buffer size
+      value,                               //out buffer
+      sizeof(XCLMGMT_IOC_DEVICE_PCI_INFO), //out buffer size
+      &bytes,                              //size of the data returned 
+      nullptr);                            //ptr to overlapped struct (for async operations)
+
+  if (!status)
+    throw std::runtime_error(boost::str(boost::format("DeviceIoControl XCLMGMT_OID_GET_DEVICE_PCI_INFO failed with status %d") % status));
+  if (bytes != sizeof(XCLMGMT_IOC_DEVICE_PCI_INFO))
+    throw std::runtime_error(boost::str(boost::format("DeviceIoControl XCLMGMT_OID_GET_DEVICE_PCI_INFO failed. Received %d bytes when %d bytes were expected.") % bytes % sizeof(XCLMGMT_IOC_DEVICE_PCI_INFO)));
+}
+
 
 }; // struct mgmt
 
@@ -544,6 +565,15 @@ get_data_retention(xclDeviceHandle hdl, uint32_t* value)
     send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_data_retention()");
   auto mgmt = get_mgmt_object(hdl);
   mgmt->get_data_retention(value);
+}
+
+void
+get_pcie_info(xclDeviceHandle hdl, XCLMGMT_IOC_DEVICE_PCI_INFO* value)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "get_pcie_info()");
+  auto mgmt = get_mgmt_object(hdl);
+  mgmt->get_pcie_info(value);
 }
 
 } // mgmt

--- a/src/runtime_src/core/pcie/windows/mgmt.cpp
+++ b/src/runtime_src/core/pcie/windows/mgmt.cpp
@@ -571,7 +571,7 @@ void
 get_pcie_info(xclDeviceHandle hdl, XCLMGMT_IOC_DEVICE_PCI_INFO* value)
 {
   xrt_core::message::
-    send(xrt_core::message::severity_level::debug, "XRT", "get_pcie_info()");
+    send(xrt_core::message::severity_level::XRT_DEBUG, "XRT", "get_pcie_info()");
   auto mgmt = get_mgmt_object(hdl);
   mgmt->get_pcie_info(value);
 }

--- a/src/runtime_src/core/pcie/windows/mgmt.h
+++ b/src/runtime_src/core/pcie/windows/mgmt.h
@@ -91,6 +91,10 @@ XRT_CORE_PCIE_WINDOWS_EXPORT
 void
 get_data_retention(xclDeviceHandle hdl, uint32_t* value);
 
+XRT_CORE_PCIE_WINDOWS_EXPORT
+void
+get_pcie_info(xclDeviceHandle hdl, XCLMGMT_IOC_DEVICE_PCI_INFO* value);
+
 } // mgmtpf
 
 #endif

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -682,7 +682,19 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
       ptDevice.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
       if (_schemaVersion == Report::SchemaVersion::text) {
-        auto platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
+        bool is_mfg = false;
+        try {
+          is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
+        } catch (...) {}
+        
+        //if factory mode
+        std::string platform = "";
+          if (is_mfg) {
+            platform = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN";
+          }
+          else {
+            platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
+          }
         std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % _devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
         _ostream << std::string(dev_desc.length(), '-') << std::endl;
         _ostream << dev_desc;

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -111,25 +111,20 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
   pt_platform.put("hardware.serial_num", info.mSerialNum);
 
   //Flashable partition running on FPGA
-  // the vectors are being populated by empty strings which need to be removed
-  auto remove_empty_strings = [](std::vector<std::string> uuids) {
-    auto it = uuids.begin();
-    while(it != uuids.end()) {
-      if((*it).empty())
-        uuids.erase(it);
-      else
-        it++;
-    }
-  };
-  
+
   std::vector<std::string> logic_uuids, interface_uuids;
+  // the vectors are being populated by empty strings which need to be removed
   try {
     logic_uuids = xrt_core::device_query<xrt_core::query::logic_uuids>(device);
-    remove_empty_strings(logic_uuids);
+    logic_uuids.erase(
+      std::remove_if(logic_uuids.begin(), logic_uuids.end(),	
+                      [](const std::string& s) { return s.empty(); }), logic_uuids.end());
   } catch (...) {}
   try {
     interface_uuids = xrt_core::device_query<xrt_core::query::interface_uuids>(device);
-    remove_empty_strings(interface_uuids);
+    interface_uuids.erase(
+      std::remove_if(interface_uuids.begin(), interface_uuids.end(),	
+                  [](const std::string& s) { return s.empty(); }), interface_uuids.end());
   } catch (...) {}
   
   

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -111,20 +111,26 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
   pt_platform.put("hardware.serial_num", info.mSerialNum);
 
   //Flashable partition running on FPGA
+  // the vectors are being populated by empty strings which need to be removed
+  auto remove_empty_strings = [](std::vector<std::string> uuids) {
+    auto it = uuids.begin();
+    while(it != uuids.end()) {
+      if((*it).empty())
+        uuids.erase(it);
+      else
+        it++;
+    }
+  };
+  
   std::vector<std::string> logic_uuids, interface_uuids;
-  // the vectors are being populated by empty strings when uuids are not available on windows
-  // this needs to be fixed when the concept of multiple uuids comes into play
-  // Workaround: if the uuid is empty, remove clear the vector
   try {
     logic_uuids = xrt_core::device_query<xrt_core::query::logic_uuids>(device);
-    if (!logic_uuids.empty() && logic_uuids.front().empty())
-      logic_uuids.clear();
-    } catch (...) {}
+    remove_empty_strings(logic_uuids);
+  } catch (...) {}
   try {
     interface_uuids = xrt_core::device_query<xrt_core::query::interface_uuids>(device);
-    if (!interface_uuids.empty() && interface_uuids.front().empty())
-      interface_uuids.clear();
-    } catch (...) {}
+    remove_empty_strings(interface_uuids);
+  } catch (...) {}
   
   
   boost::property_tree::ptree pt_current_shell;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -243,9 +243,10 @@ Flasher::Flasher(unsigned int index) : mFRHeader{}
     //         std::cout << "ERROR: Failed to detect feature ROM." << std::endl;
     //     }
     // }
-    if (is_mfg)
-    {
-       mGoldenVer = xrt_core::device_query<xrt_core::query::mfg_ver>(dev);
+    if (is_mfg) {
+        try {
+            mGoldenVer = xrt_core::device_query<xrt_core::query::mfg_ver>(dev);
+        } catch (...) {}
     }
     //else
     //{

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -314,6 +314,7 @@ XSPI_Flasher::XSPI_Flasher(std::shared_ptr<xrt_core::device> dev)
     mDev = dev;
 
     std::string err;
+    flash_base = 0;
     try {
         flash_base = xrt_core::device_query<xrt_core::query::flash_bar_offset>(mDev.get());
     }


### PR DESCRIPTION
Tested flashing flows:
- 1RP -> golden
- Golden -> 1RP
- 2RP -> 2RP

**NOTE**: This change requires windows driver with git hash [9892023db1ce503427e75647a30f761339c7c2a8](https://github.com/Xilinx/MS_XCLMGMT/commit/9892023db1ce503427e75647a30f761339c7c2a8) or later (Dec 14, 2020)
This version of the windows driver is required since the pcie_info struct has been decoupled from the ioc_device_info struct. Doing so prevents commands run in the golden image from crashing.
_(Cherry-picked from master)_