### PR TITLE
Enhance noop emulation to insert completion delay

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -12,10 +12,10 @@ XRTBUILD=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 # and Vivado tools in addition to using XRT.
 
 # Set to location of your preferred SDx install
-vitis=/proj/xbuilds/2019.2_released/installs/lin64/Vitis/2019.2
+vitis=/proj/xbuilds/2020.2_released/installs/lin64/Vitis/2020.2
 
 # Set to location of your preferred Vivado install
-vivado=/proj/xbuilds/2019.2_released/installs/lin64/Vivado/2019.2
+vivado=/proj/xbuilds/2020.2_released/installs/lin64/Vivado/2020.2
 
 ext=.o
 rel="Release"
@@ -34,6 +34,7 @@ usage()
     echo "[-conf]                    Run conformance mode testing"
     echo "[-ini <path>]              Set SDACCEL_INI_PATH"
     echo "[-vitis <path>]            Specify Vitis install (default: $vitis)"
+    echo "[-vivado <path>]           Specify Vivado install (default: $vivado)"
     echo "[-xrt <path>]              Path to XRT install (default: $XRTBUILD/opt/xilinx/xrt)"
     echo "[-ldp <path>]              Prepend path to LD_LIBRARY_PATH"
     echo "[--]                       End option parsing for this script invocation"
@@ -68,6 +69,11 @@ while [ $# -gt 0 ]; do
         -vitis)
             shift
             vitis=$1
+            shift
+            ;;
+        -vivado)
+            shift
+            vivado=$1
             shift
             ;;
         -ini)

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -772,10 +772,10 @@ public:
       complete = m_done = true;
       if (m_event)
         xrt_core::enqueue::done(m_event.get());
-      m_exec_done.notify_all();  // CAN THIS BE MOVED TO END AFTER CALLBACKS?
     }
 
     if (complete) {
+      m_exec_done.notify_all();
       run_callbacks(s);
 
       // Clear the event if any.  This must be last since if used, it

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -476,6 +476,13 @@ get_feature_toggle(const std::string& feature)
   return detail::get_bool_value(feature.c_str(),false);
 }
 
+inline unsigned int
+get_noop_completion_delay_us()
+{
+  static unsigned int delay = detail::get_uint_value("Runtime.noop_completion_delay_us", 0);
+  return delay;
+}
+
 /**
  * Set CMD BO cache size. CUrrently it is only used in xclCopyBO()
  */

--- a/src/runtime_src/core/pcie/noop/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/noop/CMakeLists.txt
@@ -33,6 +33,7 @@ set_target_properties(xrt_noop PROPERTIES VERSION ${XRT_VERSION_STRING}
 target_link_libraries(xrt_noop
   PRIVATE
   xrt_coreutil
+  pthread
   )
 
 install(TARGETS xrt_noop

--- a/tests/xrt/perf_IOPS/Makefile
+++ b/tests/xrt/perf_IOPS/Makefile
@@ -12,7 +12,7 @@ CPPFLAGS += -g
 endif
 
 CPPFLAGS += -I${XRT_PATH}/include
-CPPLFLAGS += -L${XRT_PATH}/lib -lxrt_core -lxrt_coreutil -luuid
+CPPLFLAGS += -L${XRT_PATH}/lib
 
 .PHONY: all clean
 
@@ -22,10 +22,10 @@ all: xrt_api_iops xcl_api_iops
 	g++ -std=c++14 -c ${CPPFLAGS} -o $@ $^
 
 xrt_api_iops: xrt_api_iops.o
-	g++ $^ ${CPPLFLAGS} -o $@
+	g++ $^ ${CPPLFLAGS} -lxrt_coreutil -luuid -o $@
 
 xcl_api_iops: xcl_api_iops.o
-	g++ $^ ${CPPLFLAGS} -o $@
+	g++ $^ ${CPPLFLAGS} -lxrt_coreutil -lxrt_core -luuid -o $@
 
 clean:
 	rm -rf *_iops *.o

--- a/tests/xrt/perf_IOPS/xrt_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xrt_api_iops.cpp
@@ -77,7 +77,6 @@ int _main(int argc, char* argv[])
 
   std::string xclbin_fn = argv[2];
 
-  printf("The system has %d device(s)\n", xclProbe());
   auto device = xrt::device(0);
   auto uuid = device.load_xclbin(xclbin_fn);
 


### PR DESCRIPTION
Minor tweaks based on profiling cost of start() and wait().
Remove xclProbe from xrt iops test case.
Fix xcl iops test case calling unmap.
Ensure both test create same number of commands.