### PR TITLE
CR#1087576: xbutil to show soft kernel instance number

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1555,6 +1555,8 @@ public:
                 if (found != std::string::npos) {
                   auto scu_i = std::stoi(cu_n.substr(found + 4));
                   cu_n = cu_n.substr(0, found - 1);
+                  cu_n.append("_"); //Append instance number to name
+                  cu_n.append(std::to_string(scu_i));
                   ostr << "SCU[" << std::right << std::setw(2) << std::dec << scu_i << "]: ";
                 } else
                   ostr << "CU: ";


### PR DESCRIPTION
xbutil to show soft kernel instance number
Eg:
Compute Unit Status                      Addr              Status        Usage
CU[  0]: myCopy:myCopy_cu0               @0x1400000         (IDLE)        N/A
SCU[ 0]: copy_buf_0                      @N/A               (IDLE)        1
SCU[ 1]: copy_buf_1                      @N/A               (IDLE)        1
SCU[ 2]: copy_buf_2                      @N/A               (IDLE)        1
SCU[ 3]: copy_buf_3                      @N/A               (IDLE)        1
...