### PR TITLE
CR-1087412 xrt API has lower IOPS result vs. xcl API

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -12,10 +12,10 @@ XRTBUILD=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 # and Vivado tools in addition to using XRT.
 
 # Set to location of your preferred SDx install
-vitis=/proj/xbuilds/2019.2_released/installs/lin64/Vitis/2019.2
+vitis=/proj/xbuilds/2020.2_released/installs/lin64/Vitis/2020.2
 
 # Set to location of your preferred Vivado install
-vivado=/proj/xbuilds/2019.2_released/installs/lin64/Vivado/2019.2
+vivado=/proj/xbuilds/2020.2_released/installs/lin64/Vivado/2020.2
 
 ext=.o
 rel="Release"
@@ -34,6 +34,7 @@ usage()
     echo "[-conf]                    Run conformance mode testing"
     echo "[-ini <path>]              Set SDACCEL_INI_PATH"
     echo "[-vitis <path>]            Specify Vitis install (default: $vitis)"
+    echo "[-vivado <path>]           Specify Vivado install (default: $vivado)"
     echo "[-xrt <path>]              Path to XRT install (default: $XRTBUILD/opt/xilinx/xrt)"
     echo "[-ldp <path>]              Prepend path to LD_LIBRARY_PATH"
     echo "[--]                       End option parsing for this script invocation"
@@ -68,6 +69,11 @@ while [ $# -gt 0 ]; do
         -vitis)
             shift
             vitis=$1
+            shift
+            ;;
+        -vivado)
+            shift
+            vivado=$1
             shift
             ;;
         -ini)

--- a/src/runtime_src/core/common/api/exec.cpp
+++ b/src/runtime_src/core/common/api/exec.cpp
@@ -81,16 +81,39 @@ stop()
     sws::stop();
 }
 
-/**
- * Schedule a command for execution on either sws or kds
- */
+
+// Schedule a command for execution on either sws or kds. Use push
+// execution, meaning host will be notified of command completion
 void
-schedule(command* cmd)
+managed_start(command* cmd)
 {
   if (kds_enabled())
-    kds::schedule(cmd);
+    kds::managed_start(cmd);
   else
-    sws::schedule(cmd);
+    sws::managed_start(cmd);
+}
+
+// Schedule a command for execution on either sws or kds. Use poll
+// execution, meaning host must explicitly call unmanaged_wait() to
+// wait for command completion
+void
+unmanaged_start(command* cmd)
+{
+  if (kds_enabled())
+    kds::unmanaged_start(cmd);
+  else
+    sws::unmanaged_start(cmd);
+}
+
+// Wait for a command to complete execution.  This function must be
+// called in poll mode scheduling, and is safe to call in push mode.
+void
+unmanaged_wait(const command* cmd)
+{
+  if (kds_enabled())
+    kds::unmanaged_wait(cmd);
+  else
+    sws::unmanaged_wait(cmd);
 }
 
 void

--- a/src/runtime_src/core/common/api/exec.h
+++ b/src/runtime_src/core/common/api/exec.h
@@ -31,7 +31,16 @@ class command;
 namespace sws {
 
 void
-schedule(command* cmd);
+managed_start(command* cmd);
+
+inline void
+unmanaged_start(command* cmd)
+{
+  managed_start(cmd);
+}
+
+void
+unmanaged_wait(const command* cmd);
 
 void
 start();
@@ -50,7 +59,13 @@ init(xrt_core::device* device);
 namespace kds {
 
 void
-schedule(command* cmd);
+managed_start(command* cmd);
+
+void
+unmanaged_start(command* cmd);
+
+void
+unmanaged_wait(const command* cmd);
 
 void
 start();
@@ -64,11 +79,28 @@ init(xrt_core::device* device);
 } // kds
 
 namespace exec {
-/**
- * Schedule a command for execution on either sws or mbs
- */
+
+// Schedule a command for execution on either sws or kds. Use push
+// execution, meaning host will be notified of command completion This
+// function start / schedules the argument command for execution and
+// manages completion using execution monitor
 void
-schedule(command* cmd);
+managed_start(command* cmd);
+
+// Schedule a command for execution on either sws or kds. Use poll
+// execution, meaning host must explicitly call unmanaged_wait() to
+// wait for command completion.  This function starts / schedules
+// argument command for exectution but doesn't manage completion.  The
+// command must be checked for completion manually.
+void
+unmanaged_start(command* cmd);
+
+// Wait for a command to complete execution.  This function must be
+// called in poll mode (unmanaged) scheduling, and is safe to call in
+// push mode.  The function provides a thread safe interface to
+// exec_waq and by passes execution monitor used in managed execution
+void
+unmanaged_wait(const command* cmd);
 
 void
 start();

--- a/src/runtime_src/core/common/api/kds.cpp
+++ b/src/runtime_src/core/common/api/kds.cpp
@@ -32,20 +32,14 @@
 #include <list>
 #include <map>
 
+////////////////////////////////////////////////////////////////
+// Main command execution interface for scheduling commands for
+// execution and waiting for commands to complete.
+////////////////////////////////////////////////////////////////
 namespace {
 
 using command_queue_type = std::vector<xrt_core::command*>;
-
-////////////////////////////////////////////////////////////////
-// Main command monitor interfacing to embedded MB scheduler
-////////////////////////////////////////////////////////////////
-static std::mutex s_mutex;
-static std::condition_variable s_work;
-static bool s_running = false;
-static bool s_stop = false;
 static std::exception_ptr s_exception;
-static std::map<const xrt_core::device*, command_queue_type> s_device_cmds;
-static std::map<const xrt_core::device*, std::thread> s_device_monitor_threads;
 
 inline ert_cmd_state
 get_command_state(xrt_core::command* cmd)
@@ -60,118 +54,277 @@ completed(xrt_core::command* cmd)
   return (get_command_state(cmd) >= ERT_CMD_STATE_COMPLETED);
 }
 
-static void
-notify_host(xrt_core::command* cmd)
+inline void
+notify_host(xrt_core::command* cmd, ert_cmd_state state)
 {
-  auto state = get_command_state(cmd);
-
   XRT_DEBUGF("xrt_core::kds::command(%d), [running->done]\n", cmd->get_uid());
   auto retain = cmd->shared_from_this();
   cmd->notify(state);
 }
 
-static void
-launch(xrt_core::command* cmd)
+inline void
+notify_host(xrt_core::command* cmd)
 {
-  XRT_DEBUGF("xrt_core::kds::command(%d) [new->submitted->running]\n", cmd->get_uid());
-
-  auto device = cmd->get_device();
-  auto& submitted_cmds = s_device_cmds[device]; // safe since inserted in init
-
-  command_queue_type::const_iterator pos;
-
-  // Store command so completion can be tracked.  Make sure this is
-  // done prior to exec_buf as exec_wait can otherwise be missed.
-  {
-    std::lock_guard<std::mutex> lk(s_mutex);
-    submitted_cmds.push_back(cmd);
-    s_work.notify_all();
-  }
-
-  // Submit the command
-  try {
-    device->exec_buf(cmd->get_exec_bo());
-  }
-  catch (...) {
-    // Remove the pending command
-    std::lock_guard<std::mutex> lk(s_mutex);
-    assert(get_command_state(cmd)==ERT_CMD_STATE_NEW);
-    submitted_cmds.pop_back();
-    throw;
-  }
+  notify_host(cmd, get_command_state(cmd));
 }
 
-static void
-monitor_loop(const xrt_core::device* device)
+  
+// class kds_device - kds book keeping data for command scheduling
+//
+// @device: The core device used for shim level calls
+// @exec_wait_mutex: Synchronize acces to exec_wait
+// @work_mutex: Syncrhonize monitor thread with launched commands
+// @work_cond: Kick off monitor thread when there are new commands
+// @monitor_thread: Thread for asynchronous monitoring of command execution
+// @exec_wait_call_count:  Count of number of calls to exec wait
+// @stop: Stop the monitor thread
+//
+// This class is per xrt_core::device. The class constructor starts a
+// command monitor thread that manages command execution.  It also
+// provides a thread safe interface to shim level exec_wait which can
+// be called explicitly to wait for command completion.
+class kds_device
 {
-  unsigned long loops = 0;           // number of outer loops
-  unsigned long sleeps = 0;          // number of sleeps
+  xrt_core::device* device;
+  std::mutex exec_wait_mutex;
+  std::mutex work_mutex;
+  std::condition_variable work_cond;
+  command_queue_type submitted_cmds;
+  uint64_t exec_wait_call_count = 0;
+  bool stop = false;
 
-  // thread safe access, since guaranteed to be inserted in init
-  auto& submitted_cmds = s_device_cmds[device];
-  std::vector<xrt_core::command*> completed_cmds;
+  // thread can be constructed only after data members are initialized
+  std::thread monitor_thread;  
 
-  while (1) {
-    ++loops;
+  // monitor_loop() - Manage running commands and notify on completion
+  //
+  // The monitor thread services managed command and asynchronously
+  // notifies commands that are found to have completed.
+  //
+  // Commands that are submitted for execution using managed_start()
+  // are monitored for completion by this function.
+  void
+  monitor_loop()
+  {
+    std::vector<xrt_core::command*> busy_cmds;
+    std::vector<xrt_core::command*> running_cmds;
 
-    {
+    while (1) {
+
+      // Larger wait synchronized with launch()
       {
-        std::unique_lock<std::mutex> lk(s_mutex);
-
-        // Larger wait
-        while (!s_stop && submitted_cmds.empty()) {
-          ++sleeps;
-          s_work.wait(lk);
-        }
+        std::unique_lock<std::mutex> lk(work_mutex);
+        while (!stop && running_cmds.empty() && submitted_cmds.empty())
+          work_cond.wait(lk);
       }
 
-      if (s_stop)
+      if (stop)
         return;
 
       // Finer wait
-      while (device->exec_wait(1000)==0) {}
+      exec_wait();
 
+      // Drain submitted commands.  It is important that this comes
+      // after exec_wait and is synchronized with launch() that added
+      // to submitted_cmds.
+      //
+      // Scenario if before exec_wait is that a new command was added
+      // to submitted_cmds and exec_buf immediately after the critical
+      // section above and that the command completion happens in the
+      // exec_wait call. If submitted_cmds was drained, in for example
+      // above critical section, before the call to exec_wait it would
+      // not be in running_cmds and would not be notified of
+      // completion.
+      //
+      // The sequence is very important.  It must be guaranteed that
+      // exec_wait will never return for a command that is not yet
+      // in either running_cmds or submitted_cmds.
       {
-        std::lock_guard<std::mutex> lk(s_mutex);
-        auto size = submitted_cmds.size();
-        for (size_t idx=0; idx<size; ++idx) {
-          auto cmd = submitted_cmds[idx];
-          if (!completed(cmd))
-            continue;
+        std::lock_guard<std::mutex> lk(work_mutex);
+        std::copy(submitted_cmds.begin(), submitted_cmds.end(), std::back_inserter(running_cmds));
+        submitted_cmds.clear();
+      }
+      // At this point running_cmds is guaranteed to contain the
+      // command(s) for which exec_wait returned.
 
-          completed_cmds.push_back(cmd);
-          auto last = submitted_cmds.back();
-          if (last != cmd)
-            submitted_cmds[idx--] = last;
-          submitted_cmds.pop_back();
-          --size;
-        }
+      // Preserve order of processing
+      for (auto cmd : running_cmds) {
+        if (completed(cmd))
+          notify_host(cmd);
+        else
+          busy_cmds.push_back(cmd);
       }
 
-      // Notify host outside lock
-      for (auto cmd : completed_cmds)
-        notify_host(cmd);
-      completed_cmds.clear();
+      running_cmds.swap(busy_cmds);
+      busy_cmds.clear();
+    } // while (1)
+  }
+
+  // Start the monitor thread
+  void
+  monitor()
+  {
+    try {
+      monitor_loop();
+    }
+    catch (const std::exception& ex) {
+      std::string msg = std::string("kds command monitor died unexpectedly: ") + ex.what();
+      xrt_core::send_exception_message(msg.c_str());
+      s_exception = std::current_exception();
+    }
+    catch (...) {
+      xrt_core::send_exception_message("kds command monitor died unexpectedly");
+      s_exception = std::current_exception();
     }
   }
+  
+
+public:
+  // Constructor starts monitor thread
+  kds_device(xrt_core::device* dev)
+      : device(dev), monitor_thread(xrt_core::thread(&kds_device::monitor, this))
+  {}
+
+  // Destructor stops and joins monitor thread
+  ~kds_device()
+  {
+    stop = true;
+    work_cond.notify_one();
+    monitor_thread.join();
+  }
+
+  // Thread safe shim level exec wait call.   This function allows
+  // multiple threads to call exec_wait through same device handle.
+  //
+  // In multi-threaded applications it is possible that a call to shim
+  // level exec_wait by one thread covers completion for other
+  // threads.  Without careful synchronization, a thread that calls
+  // device->exec_wait could end up being stuck either forever or
+  // until some other unrelated command completes.  This function
+  // prevents that scenario from happening.
+  //
+  // Thread local storage keeps a call count that syncs with the
+  // number of times device->exec_wait has been called. If thread
+  // local call count is different from the global count, then this
+  // function resets the thread local call count and return without
+  // calling shim exec_wait.
+  void
+  exec_wait()
+  {
+    static thread_local uint64_t thread_exec_wait_call_count = 0;
+    std::lock_guard<std::mutex> lk(exec_wait_mutex);
+
+    if (thread_exec_wait_call_count != exec_wait_call_count) {
+      // some other thread has called exec_wait and may have
+      // covered this thread's commands, synchronize thread
+      // local call count and return to caller.
+      thread_exec_wait_call_count = exec_wait_call_count;
+      return;
+    }
+
+    while (device->exec_wait(1000)==0) {}
+
+    // synchronize this thread with total call count
+    thread_exec_wait_call_count = ++exec_wait_call_count;
+  }
+
+  // exec_wait() - Wait for specific command completion
+  //
+  // This function is safe to call for managed and unmanaged commands.
+  void
+  exec_wait(const xrt_core::command* cmd)
+  {
+    auto pkt = cmd->get_ert_packet();
+    while (pkt->state < ERT_CMD_STATE_COMPLETED)
+      exec_wait();
+
+    // notify_host is not strictly necessary for unmanaged
+    // command execution but provides a central place to update
+    // and mark commands as done so they can be re-executed.
+    notify_host(const_cast<xrt_core::command*>(cmd), static_cast<ert_cmd_state>(pkt->state));
+  }
+
+  // exec_buf() - Submit a command for execution
+  //
+  // This function is used to schedule unmanaged commands for
+  // execution. The execution monitor is by-passed and will be unaware
+  // of argument command having been scheduled for execution.
+  void
+  exec_buf(xrt_core::command* cmd)
+  {
+    device->exec_buf(cmd->get_exec_bo());
+  }
+
+  // launch() - Submit a command for managed execution
+  //
+  // This function is used to schedule managed commands for
+  // execution. Managed means that the command will be monitored for
+  // completion and notified upon completion.  Notification is through
+  // command callback.
+  void
+  launch(xrt_core::command* cmd)
+  {
+    XRT_DEBUGF("xrt_core::kds::command(%d) [new->submitted->running]\n", cmd->get_uid());
+
+    // Store command so completion can be tracked.  Make sure this is
+    // done prior to exec_buf as exec_wait can otherwise be missed.
+    // See detailed explanation in monitor loop.
+    {
+      std::lock_guard<std::mutex> lk(work_mutex);
+      submitted_cmds.push_back(cmd);
+    }
+
+    // Submit the command
+    try {
+      exec_buf(cmd);
+    }
+    catch (...) {
+      // Remove the pending command
+      std::lock_guard<std::mutex> lk(work_mutex);
+      assert(get_command_state(cmd)==ERT_CMD_STATE_NEW);
+      if (!submitted_cmds.empty())
+        submitted_cmds.pop_back();
+      throw;
+    }
+
+    // This is somewhat expensive, it is better to have this after the
+    // exec_buf call so that actual execution doesn't have to wait.
+    work_cond.notify_one();
+  }
+}; // kds_device
+
+// Statically allocated kds_device object for each core deviced
+static std::map<const xrt_core::device*, std::unique_ptr<kds_device>> kds_devices;
+
+// Get or create kds_device object from core device
+kds_device*
+get_kds_device(xrt_core::device* device)
+{
+  auto itr = kds_devices.find(device);
+  if (itr != kds_devices.end())
+    return (*itr).second.get();
+
+  auto iitr = kds_devices.insert(std::make_pair(device, std::make_unique<kds_device>(device)));
+  return (iitr.first)->second.get();
 }
 
-
-static void
-monitor(const xrt_core::device* device)
+// Get or existing kds_device object from core device.  Throw if
+// kds_device object does not exist (internal error).
+kds_device*
+get_kds_device_or_error(const xrt_core::device* device)
 {
-  try {
-    monitor_loop(device);
-  }
-  catch (const std::exception& ex) {
-    std::string msg = std::string("kds command monitor died unexpectedly: ") + ex.what();
-    xrt_core::send_exception_message(msg.c_str());
-    s_exception = std::current_exception();
-  }
-  catch (...) {
-    xrt_core::send_exception_message("kds command monitor died unexpectedly");
-    s_exception = std::current_exception();
-  }
+  auto itr = kds_devices.find(device);
+  if (itr == kds_devices.end())
+    throw std::runtime_error("internal error: missing kds device");
+  return (*itr).second.get();
+}
+
+// Get kds_device from command object.  Throws if kds_device
+// doesn't exist
+kds_device*
+get_kds_device(const xrt_core::command* cmd)
+{
+  return get_kds_device_or_error(cmd->get_device());
 }
 
 } // namespace
@@ -179,52 +332,57 @@ monitor(const xrt_core::device* device)
 
 namespace xrt_core { namespace kds {
 
+// Wait for command completion for unmanaged command execution
+void
+unmanaged_wait(const xrt_core::command* cmd)
+{
+  auto kdev = get_kds_device(cmd);
+  kdev->exec_wait(cmd);
+}
+
+// Start unmanaged command execution.  The command must be explicitly
+// tested for completion, either by actively polling command state or
+// calling unmanaged wait
+void
+unmanaged_start(xrt_core::command* cmd)
+{
+  auto kdev = get_kds_device(cmd);
+  kdev->exec_buf(cmd);
+}
+
+// Start managed command execution.   The command is monitored
+// for completion and notified when completed.  It is undefined
+// behavior to call unmanaged_wait for a managed command.  While
+// wait will work, the commmand cannot be immediately re-executed
+// until it has completed.
+void
+managed_start(xrt_core::command* cmd)
+{
+  auto kdev = get_kds_device(cmd);
+  kdev->launch(cmd);
+}
+
+// Alias for managed_start
 void
 schedule(xrt_core::command* cmd)
 {
-  return launch(cmd);
+  auto kdev = get_kds_device(cmd);
+  kdev->launch(cmd);
 }
 
 void
 start()
-{
-  if (s_running)
-    throw std::runtime_error("kds command monitor is already started");
-
-  std::lock_guard<std::mutex> lk(s_mutex);
-  s_running = true;
-}
+{}
 
 void
 stop()
-{
-  if (!s_running)
-    return;
+{}
 
-  {
-    std::lock_guard<std::mutex> lk(s_mutex);
-    s_stop = true;
-  }
-
-  s_work.notify_all();
-  for (auto& e : s_device_monitor_threads)
-    e.second.join();
-
-  s_running = false;
-}
-
+// Create and initialize a kds_device object from a core device.
 void
 init(xrt_core::device* device)
 {
-  // create a submitted command queue for this device if necessary,
-  // create a command monitor thread for this device if necessary
-  std::lock_guard<std::mutex> lk(s_mutex);
-  auto itr = s_device_monitor_threads.find(device);
-  if (itr==s_device_monitor_threads.end()) {
-    XRT_DEBUGF("creating monitor thread and queue for device\n");
-    s_device_cmds.emplace(device,command_queue_type());
-    s_device_monitor_threads.emplace(device,xrt_core::thread(::monitor,device));
-  }
+  get_kds_device(device);
 }
 
 }} // kds,xrt_core

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -476,6 +476,13 @@ get_feature_toggle(const std::string& feature)
   return detail::get_bool_value(feature.c_str(),false);
 }
 
+inline unsigned int
+get_noop_completion_delay_us()
+{
+  static unsigned int delay = detail::get_uint_value("Runtime.noop_completion_delay_us", 0);
+  return delay;
+}
+
 /**
  * Set CMD BO cache size. CUrrently it is only used in xclCopyBO()
  */

--- a/src/runtime_src/core/pcie/noop/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/noop/CMakeLists.txt
@@ -33,6 +33,7 @@ set_target_properties(xrt_noop PROPERTIES VERSION ${XRT_VERSION_STRING}
 target_link_libraries(xrt_noop
   PRIVATE
   xrt_coreutil
+  pthread
   )
 
 install(TARGETS xrt_noop

--- a/tests/xrt/100_ert_ncu/CMakeLists.txt
+++ b/tests/xrt/100_ert_ncu/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(xrtx PRIVATE ${xrt_coreutil_LIBRARY})
 add_executable(xrtxx xrtxx.cpp)
 target_link_libraries(xrtxx PRIVATE ${xrt_coreutil_LIBRARY})
 
+add_executable(xrtxx-mt xrtxx-mt.cpp)
+target_link_libraries(xrtxx-mt PRIVATE ${xrt_coreutil_LIBRARY})
+
 add_executable(ocl ocl.cpp)
 target_link_libraries(ocl PRIVATE ${xrt_xilinxopencl_LIBRARY})
 if (WIN32)
@@ -31,10 +34,11 @@ if (NOT WIN32)
   target_link_libraries(xrt PRIVATE ${uuid_LIBRARY} pthread)
   target_link_libraries(xrtx PRIVATE ${uuid_LIBRARY} pthread)
   target_link_libraries(xrtxx PRIVATE ${uuid_LIBRARY} pthread)
+  target_link_libraries(xrtxx-mt PRIVATE ${uuid_LIBRARY} pthread)
   target_link_libraries(ocl PRIVATE pthread)
 endif(NOT WIN32)
 
-install(TARGETS xrt xrtx xrtxx ocl
+install(TARGETS xrt xrtx xrtxx xrtxx-mt ocl
   RUNTIME DESTINATION ${INSTALL_DIR}/${TESTNAME})
 
 add_custom_command(

--- a/tests/xrt/perf_IOPS/Makefile
+++ b/tests/xrt/perf_IOPS/Makefile
@@ -12,7 +12,7 @@ CPPFLAGS += -g
 endif
 
 CPPFLAGS += -I${XRT_PATH}/include
-CPPLFLAGS += -L${XRT_PATH}/lib -lxrt_core -lxrt_coreutil -luuid
+CPPLFLAGS += -L${XRT_PATH}/lib
 
 .PHONY: all clean
 
@@ -22,10 +22,10 @@ all: xrt_api_iops xcl_api_iops
 	g++ -std=c++14 -c ${CPPFLAGS} -o $@ $^
 
 xrt_api_iops: xrt_api_iops.o
-	g++ $^ ${CPPLFLAGS} -o $@
+	g++ $^ ${CPPLFLAGS} -lxrt_coreutil -luuid -o $@
 
 xcl_api_iops: xcl_api_iops.o
-	g++ $^ ${CPPLFLAGS} -o $@
+	g++ $^ ${CPPLFLAGS} -lxrt_coreutil -lxrt_core -luuid -o $@
 
 clean:
 	rm -rf *_iops *.o

--- a/tests/xrt/perf_IOPS/xrt_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xrt_api_iops.cpp
@@ -77,7 +77,6 @@ int _main(int argc, char* argv[])
 
   std::string xclbin_fn = argv[2];
 
-  printf("The system has %d device(s)\n", xclProbe());
   auto device = xrt::device(0);
   auto uuid = device.load_xclbin(xclbin_fn);
 


### PR DESCRIPTION
Revamp how kernel commands are submitted for execution and checked for
completion.

Command completion now supports both poll and push mode with poll
corresponding to calling xrt::run::wait and push correspondng to the
original command monitor thread.

Turns out that push is only required if a command completion callback
is installed, which primarily is true only in enqueued operations such
as in OpenCL.

When no callbacks are installed, commands are submitted for execution
bypassing the execution monitor.  These commands are marked complete
only when they are explicitly queried by calling the command wait
function.  This mode of execution has almost no overhead compared to
the xcl shim APIs. The only overhead is to ensure thread safety such
that multiple threads, indirectly through the APIs, can call exec wait
without the risk of loosing command completions.  This in itself has
been a long outstanding issue with xclExecWait.

This PR is a breaking change.  It is no longer possible to install
command callbacks after a command has been submitted for execution.
An exception is thrown if this is attempted.  The work-around is to
create the xrt::run object, install the callbacks, and then start the
execution.  This ensures that push mode is used when the command is
submitted for execution.

Enhance noop emulation to insert completion delay