### PR TITLE
Fix zocl fall back to polling mode in case of free running kernels

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1019,6 +1019,9 @@ zocl_xclbin_cus_support_intr(struct drm_zocl_dev *zdev)
 
 	for (i = 0; i < zdev->ip->m_count; ++i) {
 		ip = &zdev->ip->m_ip_data[i];
+		if(xclbin_protocol(ip->properties) & 0x2) {
+			continue;
+		}
 		if (!(ip->properties & 0x1)) {
 			return false;
 		}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1019,7 +1019,7 @@ zocl_xclbin_cus_support_intr(struct drm_zocl_dev *zdev)
 
 	for (i = 0; i < zdev->ip->m_count; ++i) {
 		ip = &zdev->ip->m_ip_data[i];
-		if(xclbin_protocol(ip->properties) & 0x2) {
+		if (xclbin_protocol(ip->properties) == AP_CTRL_NONE) {
 			continue;
 		}
 		if (!(ip->properties & 0x1)) {


### PR DESCRIPTION
> This PR adds a check to skip zocl falling back to polling mode when free running kernel is encountered