### PR TITLE
CR-1086077: Fixing exception thrown at end of execution when memory offload used for trace

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -906,6 +906,7 @@ DeviceIntf::~DeviceIntf()
     if (!addr)
       return nullptr;
     mDevice->sync(bufHandle, bytes, offset, xdp::Device::direction::DEVICE2HOST);
+    mDevice->unmap(bufHandle);
     return static_cast<char*>(addr) + offset;
   }
 


### PR DESCRIPTION
Explicitly unmapping the trace buffer after syncing so the XRT side device does not retain the pointer