### PR TITLE
Provide accessors from OpenCL objects to native XRT objects

### DIFF
--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -57,16 +57,6 @@ if (DEFINED CROSS_COMPILE)
   set(CMAKE_INSTALL_RPATH "${sysroot}/usr/lib:${sysroot}/lib:${sysroot}/usr/lib/aarch64-linux-gnu")
 endif()
 
-# Release OpenCL extension headers
-set(XRT_CL_EXT_SRC
-  include/1_2/CL/cl_ext_xilinx.h
-  include/1_2/CL/cl_ext.h)
-install (FILES ${XRT_CL_EXT_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL)
-message("-- XRT CL extension header files")
-foreach (header ${XRT_CL_EXT_SRC})
-  message("-- ${header}")
-endforeach()
-
 add_compile_options("-DXRT_EDGE")
 
 # Let yocto handle license files in the standard way

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -98,15 +98,6 @@ set (XRT_NAMELINK_SKIP NAMELINK_SKIP)
 #  bin/../lib, lib/xrt/module/../.., bin/unwrapped/../../lib
 SET(CMAKE_INSTALL_RPATH "$ORIGIN/../lib${LIB_SUFFFIX}:$ORIGIN/../..:$ORIGIN/../../lib${LIB_SUFFIX}")
 
-# --- Release: OpenCL extension headers ---
-set(XRT_CL_EXT_SRC
-  include/1_2/CL/cl_ext_xilinx.h
-  include/1_2/CL/cl_ext.h)
-install (FILES ${XRT_CL_EXT_SRC}
-  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
-  COMPONENT ${XRT_DEV_COMPONENT}
-)
-
 # --- Release: eula ---
 file(GLOB XRT_EULA
   "license/*.txt"

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -41,16 +41,6 @@ set (XRT_INSTALL_UNWRAPPED_DIR "${XRT_INSTALL_BIN_DIR}/unwrapped")
 set (XRT_INSTALL_INCLUDE_DIR   "${XRT_INSTALL_DIR}/include")
 set (XRT_INSTALL_LIB_DIR       "${XRT_INSTALL_DIR}/lib")
 
-# --- Release: OpenCL extension headers ---
-set(XRT_CL_EXT_SRC
-  include/1_2/CL/cl_ext_xilinx.h
-  include/1_2/CL/cl_ext.h)
-install (FILES ${XRT_CL_EXT_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL)
-message("-- XRT CL extension header files")
-foreach (header ${XRT_CL_EXT_SRC})
-  message("-- ${header}")
-endforeach()
-
 # --- Release: eula ---
 file(GLOB XRT_EULA
   "license/*.txt"

--- a/src/include/1_2/CL/cl2xrt.hpp
+++ b/src/include/1_2/CL/cl2xrt.hpp
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef XRT_CL2XRT_HPP
+#define XRT_CL2XRT_HPP
+
+#include "experimental/xrt_bo.h"
+#include "experimental/xrt_device.h"
+#include "experimental/xrt_kernel.h"
+
+#include <CL/cl.h>
+
+#if defined(_WIN32)
+# ifdef XOCL_SOURCE
+#  define XOCL_EXPORT __declspec(dllexport)
+# else
+#  define XOCL_EXPORT __declspec(dllimport)
+# endif
+#else
+# define XOCL_EXPORT __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+// C++ extensions that allow host applications to move from OpenCL
+// objects to corresponding XRT native C++ objects
+namespace xrt { namespace opencl {
+
+/**
+ * get_xrt_device() - Retrieve underlying xrt::device object
+ *
+ * @device: OpenCL device ID
+ * Return:  xrt::device object associated with the OpenCL device
+ */
+XOCL_EXPORT
+xrt::device
+get_xrt_device(cl_device_id device);
+
+/**
+ * get_xrt_bo() - Retrieve underlying xrt::bo object
+ *
+ * @device: OpenCL device ID
+ * @mem:    OpenCL memory object to convert to xrt::bo
+ * Return:  xrt::bo object associated with the OpenCL buffer
+ *
+ * OpenCL memory objects are created in a cl_context and are
+ * not uniquely associated with one single device.  It is
+ * possible the cl_mem buffer has not been associated with a 
+ * device and if so, the returned xrt::bo object is empty.
+ */
+XOCL_EXPORT
+xrt::bo
+get_xrt_bo(cl_device_id device, cl_mem mem);
+
+/**
+ * get_xrt_kernel() - Retrieve underlying xrt::kernel object
+ *
+ * @device: OpenCL device ID
+ * @kernel: OpenCL kernel object to convert to xrt::kernel
+ * Return:  xrt::kernel object associated with the OpenCL kernel
+ *
+ * OpenCL kernel objects are created in a cl_context and are not
+ * uniquely associated with a single cl_device.  However, a
+ * xrt::kernel objects is created for each device in the context in
+ * which the cl_kernel objects was created.  This function returns the
+ * xrt::kernel object for specified device and kernel pair.
+ */
+XOCL_EXPORT
+xrt::kernel
+get_xrt_kernel(cl_device_id device, cl_kernel kernel);
+
+/**
+ * get_xrt_run() - Retrieve underlying xrt::run object
+ *
+ * @device: OpenCL device ID
+ * @kernel: OpenCL kernel object to convert to xrt::run
+ * Return:  xrt::run object associated with the OpenCL kernel
+ *
+ * OpenCL kernel object is associated with an xrt::kernel object for
+ * each device in the context in which the cl_kernel was created.
+ * This function returns the xrt::run object corresponding to the
+ * xrt::kernel object that in turn is associated with the cl_device
+ * and cl_kernel pair.
+ *
+ * The returned run object reflects any scalar argument that were set
+ * on the cl_kernel object, but does not reflect the global memory
+ * objects as these are not mapped to a device until the enqueue
+ * operation.
+ *
+ * The returned run object is cloned and detached from the cl_kernel
+ * meaning that any changes to the run object are not reflected
+ * in the cl_kernel object.
+ */
+XOCL_EXPORT
+xrt::run
+get_xrt_run(cl_device_id device, cl_kernel kernel);
+
+}} // opencl, xrt
+
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -12,28 +12,20 @@ include_directories(
 )
 
 file(GLOB XRT_XOCL_API_FILES
-  "${XRT_XOCL_API_DIR}/*.h"
   "${XRT_XOCL_API_DIR}/*.cpp"
-  "${XRT_XOCL_API_DIR}/detail/*.h"
   "${XRT_XOCL_API_DIR}/detail/*.cpp"
   "${XRT_XOCL_API_DIR}/icd/*.cpp"
-  "${XRT_XOCL_API_DIR}/khronos/*.h"
   "${XRT_XOCL_API_DIR}/khronos/*.cpp"
-  "${XRT_XOCL_API_DIR}/xlnx/*.h"
   "${XRT_XOCL_API_DIR}/xlnx/*.cpp"
-  "${XRT_XOCL_API_DIR}/printf/*.h"
   "${XRT_XOCL_API_DIR}/printf/*.cpp"
-  "${XRT_XOCL_API_DIR}/plugin/xdp/*.h"
   "${XRT_XOCL_API_DIR}/plugin/xdp/*.cpp"
   )
 
 file(GLOB XRT_XOCL_CORE_FILES
-  "${XRT_XOCL_CORE_DIR}/*.h"
   "${XRT_XOCL_CORE_DIR}/*.cpp"
   )
 
 file(GLOB XRT_XOCL_XCLBIN_FILES
-  "${XRT_XOCL_XCLBIN_DIR}/*.h"
   "${XRT_XOCL_XCLBIN_DIR}/*.cpp"
   )
 
@@ -110,4 +102,13 @@ install(TARGETS xilinxopencl
   EXPORT xrt-targets-dev
   ARCHIVE DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT}
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR} COMPONENT ${XRT_DEV_COMPONENT} ${XRT_NAMELINK_ONLY}
+)
+
+# Release OpenCL extension headers
+install (FILES
+  ${XRT_SRC_DIR}/include/1_2/CL/cl_ext_xilinx.h
+  ${XRT_SRC_DIR}/include/1_2/CL/cl_ext.h
+  ${XRT_SRC_DIR}/include/1_2/CL/cl2xrt.hpp
+  DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
+  COMPONENT ${XRT_DEV_COMPONENT}
 )

--- a/src/runtime_src/xocl/api/xlnx/cl2xrt.cpp
+++ b/src/runtime_src/xocl/api/xlnx/cl2xrt.cpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#define XOCL_SOURCE  // exported for end application use
+#include "CL/cl2xrt.hpp"
+#include "xocl/core/device.h"
+#include "xocl/core/kernel.h"
+#include "xocl/core/memory.h"
+
+#include "core/include/experimental/xrt_bo.h"
+#include "core/include/experimental/xrt_device.h"
+#include "core/include/experimental/xrt_kernel.h"
+
+namespace xrt { namespace opencl {
+
+xrt::device
+get_xrt_device(cl_device_id device)
+{
+  return xocl::xocl(device)->get_xrt_device();
+}
+
+xrt::bo
+get_xrt_bo(cl_device_id device, cl_mem mem)
+{
+  return xocl::xocl(mem)->get_buffer_object_or_null(xocl::xocl(device));
+}
+
+xrt::kernel
+get_xrt_kernel(cl_device_id device, cl_kernel kernel)
+{
+  return xocl::xocl(kernel)->get_xrt_kernel(xocl::xocl(device));
+}
+
+xrt::run
+get_xrt_run(cl_device_id device, cl_kernel kernel)
+{
+  return xrt_core::kernel_int::clone(xocl::xocl(kernel)->get_xrt_run(xocl::xocl(device)));
+}
+
+}} // opencl, xrt


### PR DESCRIPTION
This allows an OpenCL application to access the underlying native XRT
objects.