### PR TITLE
For u30 card this validation required

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4083,7 +4083,7 @@ static int xmc_send_pkt(struct xocl_xmc *xmc)
 	 * we need check and update the mbx offset.
 	 */
 	safe_read32(xmc, XMC_HOST_MSG_OFFSET_REG, &val);
-	if (!val) {
+	if (!val || val == 0xdeadfa11) {
 		xocl_err(&xmc->pdev->dev, "CMC mailbox is not ready");
 		return -EIO;
 	}


### PR DESCRIPTION
For U30 device while reading 0xdeadfa11 as  0xdeadfa11, which is a invalid value. 
But validation is done only for value "0".
Added 0xdeadfa11 also as a check. 
