### PR TITLE
NSPR-9557 Eliminate COFIG_SOFTKERNEL ert

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_xclbin.h
+++ b/src/runtime_src/core/common/drv/include/xrt_xclbin.h
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver XCLBIN parser
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: David Zhang <davidzha@xilinx.com>
  *
@@ -70,4 +70,11 @@ int
 xrt_xclbin_get_section(const struct axlf *xclbin,
 	enum axlf_section_kind kind, void **data, uint64_t *len);
 
-#endif
+struct axlf_section_header *
+xrt_xclbin_get_section_hdr_next(struct axlf *xclbin,
+	enum axlf_section_kind kind, struct axlf_section_header *cur);
+
+int xrt_xclbin_get_section_num(const struct axlf *xclbin,
+	enum axlf_section_kind kind);
+
+#endif /* _XRT_XCLBIN_H */

--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver XCLBIN parser
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: David Zhang <davidzha@xilinx.com>
  *
@@ -240,6 +240,47 @@ xrt_xclbin_section_info(const struct axlf *xclbin, enum axlf_section_kind kind,
 	*size = memHeader->m_sectionSize;
 
 	return 0;
+}
+
+struct axlf_section_header *
+xrt_xclbin_get_section_hdr_next(struct axlf *xclbin,
+	enum axlf_section_kind kind, struct axlf_section_header *cur)
+{
+	int i;
+	int found = -1;
+	bool match = false;
+
+	for (i = 0; i < xclbin->m_header.m_numSections; i++) {
+		if (xclbin->m_sections[i].m_sectionKind == kind) {
+			if (match)
+				return &xclbin->m_sections[i];
+
+			if (&xclbin->m_sections[i] == cur) {
+				match = true;
+				found = -1;
+				continue;
+			} else
+				found = (found < 0 ? i : found);
+		}
+	}
+
+	if (found < 0)
+		return NULL;
+
+	return &xclbin->m_sections[found];
+}
+
+int xrt_xclbin_get_section_num(const struct axlf *xclbin,
+	enum axlf_section_kind kind)
+{
+	int i, cnt = 0;
+
+	for (i = 0; i < xclbin->m_header.m_numSections; i++) {
+		if (xclbin->m_sections[i].m_sectionKind == kind)
+			cnt++;
+	}
+
+	return cnt;
 }
 
 /* caller should free the allocated memory for **data */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ospi_versal.c
@@ -3,7 +3,7 @@
  * A GEM style (optionally CMA backed) device manager for ZynQ based
  * OpenCL accelerators.
  *
- * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Larry Liu <yliu@xilinx.com>
@@ -425,6 +425,8 @@ static int zocl_ov_thread(void *data)
 
 static const struct of_device_id zocl_ospi_versal_of_match[] = {
 	{ .compatible = "xlnx,ospi_versal",
+	},
+	{ .compatible = "xlnx,mpsoc_ocm",
 	},
 	{ /* end of table */ },
 };

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -177,6 +177,7 @@ zocl_load_pskernel(struct drm_zocl_dev *zdev, struct axlf *axlf)
 			ret = PTR_ERR(sip->si_bo);
 			DRM_ERROR("%s Failed to allocate BO: %d\n",
 			    __func__, ret);
+			mutex_unlock(&sk->sk_lock);
 			return ret;
 		}
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -2,7 +2,7 @@
 /*
  * MPSoC based OpenCL accelerators Compute Units.
  *
- * Copyright (C) 2019-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    David Zhang <davidzha@xilinx.com>
@@ -15,6 +15,7 @@
 #include "sched_exec.h"
 #include "zocl_xclbin.h"
 #include "zocl_aie.h"
+#include "zocl_sk.h"
 #include "xrt_xclbin.h"
 #include "xclbin.h"
 
@@ -127,6 +128,72 @@ zocl_load_bitstream(struct drm_zocl_dev *zdev, char *buffer, int length)
 		/* 0 is for full bitstream */
 		return zocl_fpga_mgr_load(zdev, buffer, length, 0);
 	}
+}
+
+static int
+zocl_load_pskernel(struct drm_zocl_dev *zdev, struct axlf *axlf)
+{
+	struct axlf_section_header *header = NULL;
+	char *xclbin = (char *)axlf;
+	struct soft_krnl *sk = zdev->soft_kernel;
+	int count, sec_idx = 0, scu_idx = 0;
+	int i, ret;
+
+	if (!sk) {
+		DRM_ERROR("%s Failed: no softkernel support\n", __func__);
+		return -ENODEV;
+	}
+
+	mutex_lock(&sk->sk_lock);
+	for (i = 0; i < sk->sk_nimg; i++)
+		ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&sk->sk_img[i].si_bo->gem_base);
+	kfree(sk->sk_img);
+	sk->sk_nimg = 0;
+	sk->sk_img = NULL;
+	mutex_unlock(&sk->sk_lock);
+
+	count = xrt_xclbin_get_section_num(axlf, SOFT_KERNEL);
+	if (count == 0)
+		return 0;
+
+	mutex_lock(&sk->sk_lock);
+
+	sk->sk_nimg = count;
+	sk->sk_img = kzalloc(sizeof(struct scu_image) * count, GFP_KERNEL);
+
+	header = xrt_xclbin_get_section_hdr_next(axlf, SOFT_KERNEL, header);
+	while (header) {
+		struct soft_kernel *sp =
+		    (struct soft_kernel *)&xclbin[header->m_sectionOffset];
+		char *begin = (char *)sp;
+		struct scu_image *sip = &sk->sk_img[sec_idx++];
+
+		sip->si_start = scu_idx;
+		sip->si_end = scu_idx + sp->m_num_instances - 1;
+
+		sip->si_bo = zocl_drm_create_bo(zdev->ddev, sp->m_image_size,
+		    ZOCL_BO_FLAGS_CMA);
+		if (IS_ERR(sip->si_bo)) {
+			ret = PTR_ERR(sip->si_bo);
+			DRM_ERROR("%s Failed to allocate BO: %d\n",
+			    __func__, ret);
+			return ret;
+		}
+
+		sip->si_bo->flags = ZOCL_BO_FLAGS_CMA;
+		sip->si_bohdl = -1;
+		memcpy(sip->si_bo->cma_base.vaddr, begin + sp->m_image_offset,
+		    sp->m_image_size);
+
+		scu_idx += sp->m_num_instances;
+
+		header = xrt_xclbin_get_section_hdr_next(axlf, SOFT_KERNEL,
+		    header);
+	}
+
+	mutex_unlock(&sk->sk_lock);
+
+	return 0;
 }
 
 static int
@@ -368,6 +435,7 @@ zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data)
 	size_t num_of_sections;
 	uint64_t size = 0;
 	int ret = 0;
+	int count;
 
 	if (memcmp(axlf_head->m_magic, "xclbin2", 8)) {
 		DRM_INFO("Invalid xclbin magic string");
@@ -398,12 +466,25 @@ zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data)
 
 	size = zocl_offsetof_sect(BITSTREAM_PARTIAL_PDI, &section_buffer,
 	    axlf, xclbin);
-	if (size > 0)
+	if (size > 0) {
 		ret = zocl_load_partial(zdev, section_buffer, size);
+		if (ret)
+			goto out;
+	}
 
 	size = zocl_offsetof_sect(PDI, &section_buffer, axlf, xclbin);
-	if (size > 0)
+	if (size > 0) {
 		ret = zocl_load_partial(zdev, section_buffer, size);
+		if (ret)
+			goto out;
+	}
+
+	count = xrt_xclbin_get_section_num(axlf, SOFT_KERNEL);
+	if (count > 0) {
+		ret = zocl_load_pskernel(zdev, axlf);
+		if (ret)
+			goto out;
+	}
 
 	/* preserve uuid, avoid double download */
 	zocl_xclbin_set_uuid(zdev, &axlf_head->m_header.uuid);
@@ -606,11 +687,11 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj)
 		ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin);
 		if (ret)
 			goto out0;
-	} else if (axlf_obj->za_flags == DRM_ZOCL_PLATFORM_FLAT && 
-		   axlf_head.m_header.m_mode == XCLBIN_FLAT && 
+	} else if (axlf_obj->za_flags == DRM_ZOCL_PLATFORM_FLAT &&
+		   axlf_head.m_header.m_mode == XCLBIN_FLAT &&
 		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
 		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU_PR) {
-		/* 
+		/*
 		 * Load full bitstream, enabled in xrt runtime config
 		 * and xclbin has full bitstream and its not hw emulation
 		 */

--- a/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
+++ b/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2015-2021, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -37,9 +37,8 @@ struct xclSKCmd {
     uint32_t	opcode;
     uint32_t	start_cuidx;
     uint32_t	cu_nums;
-    uint64_t	xclbin_paddr;
-    size_t	xclbin_size;
     char	krnl_name[XRT_MAX_NAME_LENGTH];
+    int		bohdl;
 };
 
 struct xclAIECmd {

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -2,7 +2,7 @@
 /*
  * A GEM style CMA backed memory manager for ZynQ based OpenCL accelerators.
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *    Sonal Santan <sonal.santan@xilinx.com>
@@ -389,9 +389,9 @@ struct kernel_info {
  **/
 struct drm_zocl_axlf {
 	struct axlf 	*za_xclbin_ptr;
-	uint32_t         za_flags;
-	int	             za_ksize;
-	char			*za_kernels;
+	uint32_t	za_flags;
+	int		za_ksize;
+	char		*za_kernels;
 };
 
 #define	ZOCL_MAX_NAME_LENGTH		32
@@ -408,14 +408,14 @@ struct drm_zocl_axlf {
  * @size         : size in bytes of soft kernel image
  * @paddr        : soft kernel image's physical address (little endian)
  * @name         : symbol name of soft kernel
+ * @bohdl        : BO to hold soft kernel image
  */
 struct drm_zocl_sk_getcmd {
 	uint32_t	opcode;
 	uint32_t	start_cuidx;
 	uint32_t	cu_nums;
-	size_t		size;
-	uint64_t	paddr;
 	char		name[ZOCL_MAX_NAME_LENGTH];
+	uint32_t	bohdl;
 };
 
 enum aie_info_code {

--- a/src/runtime_src/core/edge/skd/main.cpp
+++ b/src/runtime_src/core/edge/skd/main.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  * Author(s): Min Ma	<min.ma@xilinx.com>
  *          : Larry Liu	<yliu@xilinx.com>
  *
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
 
     switch (cmd.opcode) {
     case ERT_SK_CONFIG:
-      configSoftKernel(&cmd);
+      configSoftKernel(handle, &cmd);
       break;
     default:
       syslog(LOG_WARNING, "Unknow management command, ignore it");
@@ -90,6 +90,7 @@ int main(int argc, char *argv[])
     }
   }
 
+  xclClose(handle);
   syslog(LOG_INFO, "Daemon stop\n");
   closelog();
 

--- a/src/runtime_src/core/edge/skd/sk_daemon.h
+++ b/src/runtime_src/core/edge/skd/sk_daemon.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  * Author(s): Min Ma	<min.ma@xilinx.com>
  *          : Larry Liu	<yliu@xilinx.com>
  *
@@ -31,6 +31,6 @@
 #include "xclhal2_mpsoc.h"
 
 xclDeviceHandle initXRTHandle(unsigned deviceIndex);
-void configSoftKernel(xclSKCmd *cmd);
+void configSoftKernel(xclDeviceHandle handle, xclSKCmd *cmd);
 
 #endif

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  * Author(s): Hem C. Neema
  *          : Min Ma
  * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
@@ -743,7 +743,6 @@ xclGetWriteMaxBandwidthMBps()
   return 9600.0;
 }
 
-
 int
 shim::
 xclSKGetCmd(xclSKCmd *cmd)
@@ -752,13 +751,11 @@ xclSKGetCmd(xclSKCmd *cmd)
   drm_zocl_sk_getcmd scmd;
 
   ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_SK_GETCMD, &scmd);
-
   if (!ret) {
     cmd->opcode = scmd.opcode;
     cmd->start_cuidx = scmd.start_cuidx;
     cmd->cu_nums = scmd.cu_nums;
-    cmd->xclbin_paddr = scmd.paddr;
-    cmd->xclbin_size = scmd.size;
+    cmd->bohdl = scmd.bohdl;
     snprintf(cmd->krnl_name, ZOCL_MAX_NAME_LENGTH, "%s", scmd.name);
   }
 

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019-2020, Xilinx Inc
+ *  Copyright (C) 2019-2021, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -126,9 +126,9 @@ struct ert_start_kernel_cmd {
   /* payload */
   union {
     uint32_t cu_mask;          /* mandatory cu mask */
-    int32_t return_code;      /* return code from soft kernel*/
+    int32_t return_code;       /* return code from soft kernel*/
   };
-  uint32_t data[1];          /* count-1 number of words */
+  uint32_t data[1];            /* count-1 number of words */
 };
 
 /**
@@ -264,21 +264,31 @@ struct ert_configure_cmd {
   uint32_t data[1];
 };
 
+/*
+ * Note: We need to put maximum 128 soft kernel image
+ *       in one config command (1024 DWs including header).
+ *       So each one needs to be smaller than 8 DWs.
+ *
+ * @start_cuidx:     start index of compute units of each image
+ * @num_cus:         number of compute units of each image
+ * @sk_name:         symbol name of soft kernel of each image
+ */
+struct config_sk_image {
+  uint32_t start_cuidx;
+  uint32_t num_cus;
+  uint32_t sk_name[5];
+};
+
 /**
  * struct ert_configure_sk_cmd: ERT configure soft kernel command format
  *
  * @state:           [3-0] current state of a command
- * @count:           [22-12] number of words in payload (13 DWords)
+ * @count:           [22-12] number of words in payload
  * @opcode:          [27-23] 1, opcode for configure
  * @type:            [31-27] 0, type of configure
  *
- * @start_cuidx:     start index of compute units
- * @sk_type:         type of soft kernel.
- * @num_cus:         number of compute units in program
- * @sk_size:         size in bytes of soft kernel image
- * @sk_name:         symbol name of soft kernel
- * @sk_addr:         soft kernel image's physical address (little endian)
- */
+ * @num_image:       number of images
+*/
 struct ert_configure_sk_cmd {
   union {
     struct {
@@ -292,12 +302,8 @@ struct ert_configure_sk_cmd {
   };
 
   /* payload */
-  uint32_t start_cuidx:16;
-  uint32_t sk_type:16;
-  uint32_t num_cus;
-  uint32_t sk_size;		/* soft kernel size */
-  uint32_t sk_name[8];		/* soft kernel name */
-  uint64_t sk_addr;
+  uint32_t num_image;
+  struct config_sk_image image[1];
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors:
  *
@@ -72,6 +72,7 @@
 #define NODE_CLK_KERNEL3 "ep_aclk_hbm_00"
 #define NODE_KDMA_CTRL "ep_kdma_ctrl_00"
 #define NODE_FPGA_CONFIG "ep_fpga_configuration_00"
+#define NODE_FPGA_CONFIG_01 "ep_fpga_configuration_01"
 #define NODE_ICAP_RESET "ep_icap_reset_00"
 #define NODE_ERT_SCHED "ep_ert_sched_00"
 #define NODE_XDMA "ep_xdma_00"


### PR DESCRIPTION
This PR addresses the following issue on U30
1) Remove the attached PS (soft) kernel binary in ert CONFIG_SOFTKERNEL command 
2) One XCLBIN will only send one CONFIG_SOFTKERNEL command to PS and it will contain all SCU's metadata.
3) PS kernel binaries will be transferred to PS side via mgmt PF during load xclbin and will be activated when receiving CONFIG_SOFTKERNEL command
4) When PS kernel crashes due to bad PS kernel binary or bad host code, the host ert command will not hang but returns error
5) The race condition to write to ERT command queue between host mb_scheduler and ert scheduler is removed

This is an incompatible changes which requires host and device (U30 shell) update together. 
1) If new host XRT is talking to old shell, the load xclbin function will fail with following message
    "download_axlf: Platform does not support load xclbin"
    "icap_peer_xclbin_download: peer xclbin download err: -524"
    "ffff8800b7d43098 xocl_read_axlf_helper: Failed to download xclbin, err: -524"

2) If old host XRT is talking to new shell (you are not likely getting into this because once update shell, you are supposed to update host package), the PS (soft) kernel will not work properly because the PS kernel binary (inside CONFIG_SOFTKERNEL command) will not be accepted.

3) There will be a noticeable delay when load_xclbin because PS kernel binaries are now transferred to PS through a secure channel at mgmt side other than DMA at user PF. But for same xclbin uuid, this transfer is only required once. 

Reviewers, you are welcome to review the whole code changes. Particularly, please take a close look at the following portion for each reviewer
@xuhz mb_scheduler changes and any impact to the U30 reset
@houlz0507 fdt related changes
@xdavidz fdt changes, xrt_xclbin.[ch], zocl_xclbin[ch], impact to vck5000
@mamin506 zocl, sk daemon changes, impact to new kds