### PR TITLE
CR-1088171 do not show warning about non-supported kernel version

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -91,36 +91,6 @@ static int str2index(const char *arg, unsigned& index)
     return 0;
 }
 
-static bool
-check_os_release(const std::vector<std::string> kernel_versions, std::ostream &ostr)
-{
-    const std::string release = sensor_tree::get<std::string>("system.release");
-    for (const auto& ver : kernel_versions) {
-        if (release.find(ver) != std::string::npos)
-            return true;
-    }
-    ostr << "WARNING: Kernel version " << release << " is not officially supported. "
-        << kernel_versions.back() << " is the latest supported version" << std::endl;
-    return false;
-}
-
-static bool
-is_supported_kernel_version(std::ostream &ostr)
-{
-    std::vector<std::string> ubuntu_kernel_versions =
-        { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0", "5.4.0" };
-    std::vector<std::string> centos_rh_kernel_versions =
-        { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1160.11.1", "3.10.0-1062", "3.10.0-1127", "4.9.184", "4.9.184-35", "4.18.0-147", "4.18.0-193", "4.18.0-240" };
-    const std::string os = sensor_tree::get<std::string>("system.linux", "N/A");
-
-    if(os.find("Ubuntu") != std::string::npos)
-        return check_os_release(ubuntu_kernel_versions, ostr);
-    else if(os.find("Red Hat") != std::string::npos || os.find("CentOS") != std::string::npos)
-        return check_os_release(centos_rh_kernel_versions, ostr);
-
-    return true;
-}
-
 static void print_pci_info(std::ostream &ostr)
 {
     ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
@@ -141,8 +111,6 @@ static void print_pci_info(std::ostream &ostr)
     if (pcidev::get_dev_total() != pcidev::get_dev_ready()) {
         ostr << "WARNING: card(s) marked by '*' are not ready." << std::endl;
     }
-
-    is_supported_kernel_version(ostr);
 }
 
 static int xrt_xbutil_version_cmp()
@@ -1526,18 +1494,6 @@ int xcldev::device::getXclbinuuid(uuid_t &uuid) {
     return 0;
 }
 
-int xcldev::device::kernelVersionTest(void)
-{
-    if (getenv_or_null("INTERNAL_BUILD")) {
-        std::cout << "Developer's build. Skipping validation" << std::endl;
-        return -EOPNOTSUPP;
-    }
-    if (!is_supported_kernel_version(std::cout)) {
-        return  1;
-    }
-    return 0;
-}
-
 /*
  * validate
  */
@@ -1546,12 +1502,6 @@ int xcldev::device::validate(bool quick, bool hidden)
     bool withWarning = false;
     int retVal = 0;
     auto dev = pcidev::get_dev(m_idx);
-
-    retVal = runOneTest("Kernel version check",
-            std::bind(&xcldev::device::kernelVersionTest, this));
-    withWarning = withWarning || (retVal == 1);
-    if (retVal < 0)
-        return retVal;
 
     retVal = runOneTest("AUX power connector check",
             std::bind(&xcldev::device::auxConnectionTest, this));

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -301,24 +301,6 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
 }
 
 /*
- * helper function for kernelVersionTest
- */
-static void
-checkOSRelease(const std::vector<std::string> kernel_versions, const std::string& release,
-                boost::property_tree::ptree& _ptTest)
-{
-  for (const auto& ver : kernel_versions) {
-    if (release.find(ver) != std::string::npos) {
-      _ptTest.put("status", "passed");
-      return;
-    }
-  }
-  _ptTest.put("status", "passed");
-  logger(_ptTest, "Warning", boost::str(boost::format("Kernel version %s is not officially supported. %s is the latest supported version")
-                            % release % kernel_versions.back()));
-}
-
-/*
  * helper function for M2M and P2P test
  */
 static void
@@ -583,32 +565,6 @@ search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::p
  * TEST #1
  */
 void
-kernelVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
-{
-  //please append the new supported versions
-  const std::vector<std::string> ubuntu_kernel_versions = { "4.4.0", "4.13.0", "4.15.0", "4.18.0", "5.0.0", "5.3.0" };
-  const std::vector<std::string> centos_rh_kernel_versions = { "3.10.0-693", "3.10.0-862", "3.10.0-957", "3.10.0-1160.11.1", "3.10.0-1062", "3.10.0-1127", "4.9.184", "4.9.184-35", "4.18.0-147", "4.18.0-193" };
-
-  boost::property_tree::ptree _pt_host;
-  std::make_shared<ReportHost>()->getPropertyTreeInternal(_dev.get(), _pt_host);
-  const std::string os = _pt_host.get<std::string>("host.os.distribution");
-  const std::string release = _pt_host.get<std::string>("host.os.release");
-
-  if(os.find("Ubuntu") != std::string::npos) {
-    checkOSRelease(ubuntu_kernel_versions, release, _ptTest);
-  }
-  else if(os.find("Red Hat") != std::string::npos || os.find("CentOS") != std::string::npos) {
-    checkOSRelease(centos_rh_kernel_versions, release, _ptTest);
-  }
-  else {
-    _ptTest.put("status", "failed");
-  }
-}
-
-/*
- * TEST #2
- */
-void
 auxConnectionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
   const std::vector<std::string> auxPwrRequiredDevice = { "VCU1525", "U200", "U250", "U280" };
@@ -640,7 +596,7 @@ auxConnectionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property
 }
 
 /*
- * TEST #3
+ * TEST #2
  */
 void
 pcieLinkTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -658,7 +614,7 @@ pcieLinkTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree
 }
 
 /*
- * TEST #4
+ * TEST #3
  */
 void
 scVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -678,7 +634,7 @@ scVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tre
 }
 
 /*
- * TEST #5
+ * TEST #4
  */
 void
 verifyKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -687,7 +643,7 @@ verifyKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_
 }
 
 /*
- * TEST #6
+ * TEST #5
  */
 void
 dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -737,7 +693,7 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 }
 
 /*
- * TEST #7
+ * TEST #6
  */
 void
 bandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -755,7 +711,7 @@ bandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::proper
 }
 
 /*
- * TEST #8
+ * TEST #7
  */
 void
 p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -807,7 +763,7 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 }
 
 /*
- * TEST #9
+ * TEST #8
  */
 void
 m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -859,7 +815,7 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 }
 
 /*
- * TEST #10
+ * TEST #9
  */
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
@@ -902,7 +858,6 @@ struct TestCollection {
 * create test suite
 */
 static std::vector<TestCollection> testSuite = {
-  { create_init_test("Kernel version", "Check if kernel version is supported by XRT", ""), kernelVersionTest },
   { create_init_test("Aux connection", "Check if auxiliary power is connected", ""), auxConnectionTest },
   { create_init_test("PCIE link", "Check if PCIE link is active", ""), pcieLinkTest },
   { create_init_test("SC version", "Check if SC firmware is up-to-date", ""), scVersionTest },
@@ -1097,7 +1052,7 @@ getTestNameDescriptions(bool addAdditionOptions)
   // 'verbose' option
   if (addAdditionOptions) {
     reportDescriptionCollection.emplace_back("all", "All known validate tests will be executed (default)");
-    reportDescriptionCollection.emplace_back("quick", "Only the first 5 tests will be executed");
+    reportDescriptionCollection.emplace_back("quick", "Only the first 4 tests will be executed");
   }
 
   // report names and discription
@@ -1240,8 +1195,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 
     if (testsToRun[0] == "quick") {
       testObjectsToRun.push_back(&testSuite[index]);
-      // Only the first 5 should be processed
-      if (index == 4)
+      // Only the first 3 should be processed
+      if (index == 3)
         break;
     }
 


### PR DESCRIPTION
- **Removed kernel version test**: Kernel version test used to be the first test, but it is not run anymore
- **Fixed in xbutil and xbutil2**

**Sample outputs:**
```
$ xbutil --new validate -r quick
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
Starting validation for 1 devices

Validate device[0000:b3:00.1]
Platform            : xilinx_u200_xdma_201830_3
SC Version          : 4.3.9
Platform ID         : 0x5ee83d83

1/4 Test #1 [0000:b3:00.1]  : Aux connection
    Description             : Check if auxiliary power is connected
    Warning                 : Aux power is not connected
    Warning                 : Device is not stable for heavy acceleration tasks
    Test Status             : [PASSED WITH WARNINGS]
-------------------------------------------------------------------------------
2/4 Test #2 [0000:b3:00.1]  : PCIE link
    Description             : Check if PCIE link is active
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
3/4 Test #3 [0000:b3:00.1]  : SC version
    Description             : Check if SC firmware is up-to-date
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
4/4 Test #4 [0000:b3:00.1]  : Verify kernel
    Description             : Run 'Hello World' kernel test
    Xclbin                  : /opt/xilinx/dsa/xilinx_u200_xdma_201830_3/test/verify.xclbin
    Testcase                : /opt/xilinx/xrt/test/22_verify.py
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
Validation completed, but with warnings


$ xbutil validate -q
INFO: Found 1 cards

INFO: Validating card[0]: xilinx_u200_xdma_201830_3
INFO: == Starting AUX power connector check:
AUX POWER NOT CONNECTED, ATTENTION
Board not stable for heavy acceleration tasks.
WARN: == AUX power connector check PASSED with warning
INFO: == Starting Power warning check:
INFO: == Power warning check PASSED
INFO: == Starting PCIE link check:
INFO: == PCIE link check PASSED
INFO: == Starting SC firmware version check:
INFO: == SC firmware version check PASSED
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: Card[0] validated with warnings.

INFO: All cards validated successfully but with warnings.
```

