### PR TITLE
CR-1088273 incorrect value of MBG temp in xbutil query for u50c/u50

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -726,7 +726,7 @@ public:
             ss_base_addr << "0x" << std::hex << map->m_mem_data[i].m_base_address;
 
             ptMem.put( "type",      str );
-            ptMem.put( "temp",      (i >= temp_size) ? XCL_NO_SENSOR_DEV : temp[i]);
+            ptMem.put( "temp",      (i >= temp_size) ? XCL_INVALID_SENSOR_VAL : temp[i]);
             ptMem.put( "tag",       map->m_mem_data[i].m_tag );
             ptMem.put( "enabled",   map->m_mem_data[i].m_used ? true : false );
             ptMem.put( "base_addr", ss_base_addr.str());


### PR DESCRIPTION
```
root@xsjyliu50:~# grep MBG query.0
[37] MBG[0,1,2,3,4,5     MEM_HBM     N/A      0x0             2 GB    0 Byte      0       
[38] MBG[8,9,10,11,1     MEM_DRAM    N/A      0x80000000      2 GB    0 Byte      0       
[39] MBG[16,17,18,19     MEM_DRAM    N/A      0x100000000     2 GB    0 Byte      0       
[40] MBG[24,25,26,27     MEM_DRAM    N/A      0x180000000     2 GB    0 Byte      0       
root@xsjyliu50:~# grep MBG dump.0 -B1
                    "temp": "0",
                    "tag": "MBG[0,1,2,3,4,5",
--
                    "temp": "0",
                    "tag": "MBG[8,9,10,11,1",
--
                    "temp": "0",
                    "tag": "MBG[16,17,18,19",
--
                    "temp": "0",
                    "tag": "MBG[24,25,26,27",

```