### PR TITLE
mpd: restart mpd services when device's serial number not found during mpd init

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -89,8 +89,7 @@ int init(mpd_plugin_callbacks *cbs)
             (total != fpga_serial_number.size()) ||
             (std::find(fpga_serial_number.begin(), fpga_serial_number.end(), "")
              != fpga_serial_number.end())) {
-            syslog(LOG_INFO, "azure: exiting due to one or more devices serial
-                              number not found\n");
+            syslog(LOG_INFO, "azure: exiting due to one or more devices serial number not found\n");
             return 1;
         }
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.cpp
@@ -73,7 +73,7 @@ int init(mpd_plugin_callbacks *cbs)
         syslog(LOG_INFO, "azure: no device found");
         return ret;
     }
-    if (cbs) 
+    if (cbs)
     {
         // init curl
         int curlInit = curl_global_init(CURL_GLOBAL_ALL);
@@ -83,7 +83,17 @@ int init(mpd_plugin_callbacks *cbs)
         if (!private_ip.empty())
             restip_endpoint = private_ip;
         syslog(LOG_INFO, "azure restserver ip: %s\n", restip_endpoint.c_str());
+
         fpga_serial_number = AzureDev::get_serial_number();
+        if ((fpga_serial_number.empty()) ||
+            (total != fpga_serial_number.size()) ||
+            (std::find(fpga_serial_number.begin(), fpga_serial_number.end(), "")
+             != fpga_serial_number.end())) {
+            syslog(LOG_INFO, "azure: exiting due to one or more devices serial
+                              number not found\n");
+            return 1;
+        }
+
         // hook functions
         cbs->mpc_cookie = NULL;
         cbs->get_remote_msd_fd = get_remote_msd_fd;

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -279,6 +279,7 @@ void Mpd::start()
         int ret = (*plugin_init)(&plugin_cbs);
         if (ret != 0)
             syslog(LOG_ERR, "mpd plugin_init failed: %d, restart the mpd service", ret);
+            throw std::runtime_error("can't start due to plugin_init failed");
     }
 }
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -278,7 +278,7 @@ void Mpd::start()
         }
         int ret = (*plugin_init)(&plugin_cbs);
         if (ret != 0)
-            syslog(LOG_ERR, "mpd plugin_init failed: %d", ret);
+            syslog(LOG_ERR, "mpd plugin_init failed: %d, restart the mpd service", ret);
     }
 }
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -279,6 +279,7 @@ void Mpd::start()
         int ret = (*plugin_init)(&plugin_cbs);
         if (ret != 0) {
             syslog(LOG_ERR, "mpd plugin_init failed: %d, restart the mpd service", ret);
+            stop();
             throw std::runtime_error("can't start due to plugin_init failed");
         }
     }

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -280,7 +280,7 @@ void Mpd::start()
         if (ret != 0) {
             syslog(LOG_ERR, "mpd plugin_init failed: %d, restart the mpd service", ret);
             throw std::runtime_error("can't start due to plugin_init failed");
-		}
+        }
     }
 }
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/mpd.cpp
@@ -277,9 +277,10 @@ void Mpd::start()
             return;
         }
         int ret = (*plugin_init)(&plugin_cbs);
-        if (ret != 0)
+        if (ret != 0) {
             syslog(LOG_ERR, "mpd plugin_init failed: %d, restart the mpd service", ret);
             throw std::runtime_error("can't start due to plugin_init failed");
+		}
     }
 }
 


### PR DESCRIPTION
MPD shall be restarted when it unable to read serial number of one or more
fpga devices during it's init.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>