### PR TITLE
XRT-848 thread-safe xrt_iops test

### DIFF
--- a/src/CMake/dkms-edge.cmake
+++ b/src/CMake/dkms-edge.cmake
@@ -97,6 +97,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
   common/drv/include/kds_client.h
   common/drv/include/xrt_cu.h
   common/drv/include/xrt_xclbin.h
+  common/drv/include/kds_stat.h
   )
 
 SET (XRT_DKMS_CORE_EDGE_INCLUDES

--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -276,6 +276,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV_INCLUDES
   common/drv/include/kds_client.h
   common/drv/include/xrt_cu.h
   common/drv/include/xrt_xclbin.h
+  common/drv/include/kds_stat.h
   )
 
 SET (XRT_DKMS_ABS_SRCS)

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -22,6 +22,7 @@
 #include "kds_client.h"
 #include "kds_command.h"
 #include "xrt_cu.h"
+#include "kds_stat.h"
 
 #define kds_info(client, fmt, args...)			\
 	dev_info(client->dev, " %llx %s: "fmt, (u64)client->dev, __func__, ##args)
@@ -62,9 +63,21 @@ struct kds_cu_mgmt {
 	int			  num_cdma;
 	u32			  cu_intr[MAX_CUS];
 	u32			  cu_refs[MAX_CUS];
-	u64			  cu_usage[MAX_CUS];
+	struct cu_stats __percpu *cu_stats;
 	int			  configured;
 };
+
+#define cu_stat_read(cu_mgmt, field) \
+	stat_read((cu_mgmt)->cu_stats, field)
+
+#define cu_stat_write(cu_mgmt, field, val) \
+	stat_write((cu_mgmt)->cu_stats, field, val)
+
+#define cu_stat_inc(cu_mgmt, field) \
+	this_stat_inc((cu_mgmt)->cu_stats, field)
+
+#define cu_stat_dec(cu_mgmt, field) \
+	this_stat_dec((cu_mgmt)->cu_stats, field)
 
 /* ERT core */
 struct kds_ert {

--- a/src/runtime_src/core/common/drv/include/kds_stat.h
+++ b/src/runtime_src/core/common/drv/include/kds_stat.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Xilinx Kernel Driver Scheduler
+ *
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: min.ma@xilinx.com
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#ifndef _KDS_STAT_H
+#define _KDS_STAT_H
+
+#include <linux/percpu-defs.h>
+
+#include "xrt_cu.h"
+
+/* This header file defines statistics struct and macros to operates them.
+ * Percpu variable are used for performance concerns.
+ */
+
+struct client_stats {
+	/* Per CU counter that counts when a command is submitted to CU */
+	unsigned long		s_cnt[MAX_CUS];
+	/* Per CU counter that counts when a command is completed or error */
+	unsigned long		c_cnt[MAX_CUS];
+};
+
+struct cu_stats {
+	u64		  usage[MAX_CUS];
+};
+
+/*
+ * Macros to operates on percpu statistics:
+ * this_cpu_* are operations with implied preemption/interrupt protection.
+ */
+#define this_stat_get(statp, field) \
+	this_cpu_read((statp)->field)
+
+#define this_stat_set(statp, field, val) \
+	this_cpu_write((statp)->field, val)
+
+#define this_stat_inc(statp, field) \
+	this_cpu_add((statp)->field, 1)
+
+#define this_stat_dec(statp, field) \
+	this_cpu_add((statp)->field, -1)
+
+#define stat_read(statp, field)					\
+({								\
+	typeof((statp)->field) res = 0;				\
+	unsigned int _cpu;					\
+	for_each_possible_cpu(_cpu)				\
+		res += per_cpu_ptr((statp), _cpu)->field;	\
+	res;							\
+})
+
+#define stat_write(statp, field, val)				\
+({								\
+	unsigned int _cpu;					\
+	for_each_possible_cpu(_cpu)				\
+		per_cpu_ptr((statp), _cpu)->field = val;	\
+})
+
+#endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -191,7 +191,7 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 
 	if (xcmd->cu_idx >= 0)
-		client->c_cnt[xcmd->cu_idx]++;
+		client_stat_inc(client, c_cnt[xcmd->cu_idx]);
 
 	atomic_inc(&client->event);
 	wake_up_interruptible(&client->waitq);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -304,7 +304,7 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 
 	if (xcmd->cu_idx >= 0)
-		client->c_cnt[xcmd->cu_idx]++;
+		client_stat_inc(client, c_cnt[xcmd->cu_idx]);
 
 	if (xcmd->inkern_cb) {
 		int error = (status == ERT_CMD_STATE_COMPLETED)?0:-EFAULT;


### PR DESCRIPTION
The s_cnt had no lock protect. This would be an issue when user application use multiple threads to call xclExecBuf() and share device fd.

But s_cnt is on the critical path, use lock would has negative performance impact. I use percpu variable to fix this issue as Max suggested.

**The IOPS test result** (xsjminm50 + U50 (package 4-3102127)):
$ xbutil scheduler --test xcl_iops --args "-t 1 -l 128 -a 1000000"
Overall Commands: 1000000 IOPS: 1255515

$ xbutil scheduler --test xcl_iops --args "-t 4 -l 128 -a 1000000"
Overall Commands: 4000000 IOPS: 2627524


**Without this change** (Same hardware + XRT 2.10.27)
$ xbutil scheduler --test xcl_iops --args "-t 1 -l 128 -a 1000000"
Overall Commands: 1000000 IOPS: 1212855

$ xbutil scheduler --test xcl_iops --args "-t 4 -l 128 -a 1000000"
Overall Commands: 4000000 IOPS: 2536824
