### PR TITLE
CR-1085740 and XRT-843

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -79,10 +79,10 @@ enum class key_type
   xmc_version,
   xmc_board_name,
   xmc_serial_num,
-  xmc_max_power,
+  max_power_level,
   xmc_sc_presence,
-  xmc_bmc_version,
-  expected_bmc_version,
+  xmc_sc_version,
+  expected_sc_version,
   xmc_status,
   xmc_reg_base,
   xmc_scaling_enabled,
@@ -98,6 +98,7 @@ enum class key_type
   idcode,
   data_retention,
   sec_level,
+  max_shared_host_mem_aperture_bytes,
 
   status_mig_calibrated,
   p2p_config,
@@ -161,6 +162,11 @@ enum class key_type
   vcc_aux_pmc_millivolts,
   vcc_ram_millivolts,
   int_vcc_io_millivolts,
+  mac_contiguous_num,
+  mac_addr_first,
+  mac_addr_list,
+  oem_id,
+
   firewall_detect_level,
   firewall_status,
   firewall_time_sec,
@@ -187,6 +193,8 @@ enum class key_type
   interface_uuids,
   logic_uuids,
   rp_program_status,
+  cpu_affinity,
+  shared_host_mem,
 
   aie_metadata,
   graph_status,
@@ -282,7 +290,7 @@ struct pcie_subsystem_id : request
   static std::string
   to_string(result_type val)
   {
-    return boost::str(boost::format("0x%x") % val);
+    return boost::str(boost::format("0x%04x") % val);
   }
 };
 
@@ -700,11 +708,11 @@ struct xmc_serial_num : request
   }
 };
 
-struct xmc_max_power : request
+struct max_power_level : request
 {
   using result_type = uint64_t;
-  static const key_type key = key_type::xmc_max_power;
-  static const char* name() { return "max_power"; }
+  static const key_type key = key_type::max_power_level;
+  static const char* name() { return "max_power_level"; }
 
   virtual boost::any
   get(const device*) const = 0;
@@ -732,10 +740,10 @@ struct xmc_sc_presence : request
   }
 };
 
-struct xmc_bmc_version : request
+struct xmc_sc_version : request
 {
   using result_type = std::string;
-  static const key_type key = key_type::xmc_bmc_version;
+  static const key_type key = key_type::xmc_sc_version;
   static const char* name() { return "sc_version"; }
 
   virtual boost::any
@@ -748,10 +756,10 @@ struct xmc_bmc_version : request
   }
 };
 
-struct expected_bmc_version : request
+struct expected_sc_version : request
 {
   using result_type = std::string;
-  static const key_type key = key_type::expected_bmc_version;
+  static const key_type key = key_type::expected_sc_version;
   static const char* name() { return "expected_sc_version"; }
 
   virtual boost::any
@@ -951,6 +959,16 @@ struct sec_level : request
 
   virtual void
   put(const device*, const boost::any&) const = 0;
+};
+
+struct max_shared_host_mem_aperture_bytes : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::max_shared_host_mem_aperture_bytes;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
 };
 
 struct status_mig_calibrated : request
@@ -1712,6 +1730,46 @@ struct int_vcc_io_millivolts : request
   }
 };
 
+struct mac_contiguous_num : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::mac_contiguous_num;
+  static const char* name() { return "mac_contiguous_num"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct mac_addr_first : request
+{
+  using result_type = std::string;
+  static const key_type key = key_type::mac_addr_first;
+  static const char* name() { return "mac_addr_first"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct mac_addr_list : request
+{
+  using result_type = std::vector<std::string>;
+  static const key_type key = key_type::mac_addr_list;
+  static const char* name() { return "mac_addr_list"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct oem_id : request
+{
+  using result_type = std::string;
+  static const key_type key = key_type::oem_id;
+  static const char* name() { return "oem_id"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
 struct firewall_detect_level : request
 {
   using result_type = uint64_t;
@@ -1970,6 +2028,25 @@ struct rp_program_status : request
   {
     return (value != 0) ? false : true;
   }
+};
+
+struct cpu_affinity : request
+{
+  using result_type = std::string;
+  static const key_type key = key_type::cpu_affinity;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct shared_host_mem : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::shared_host_mem;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
 };
 
 struct noop : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -968,7 +968,6 @@ struct max_shared_host_mem_aperture_bytes : request
 
   virtual boost::any
   get(const device*) const = 0;
-
 };
 
 struct status_mig_calibrated : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -79,6 +79,27 @@ struct kds_cu_info
   }
 };
 
+struct mac_addr_list
+{
+  using result_type = query::mac_addr_list::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    std::vector<std::string> list;
+    auto pdev = get_pcidev(device);
+
+    //legacy code exposes only 4 mac addr sysfs nodes (0-3)
+    for (int i=0; i < 4; i++) {
+      std::string addr, errmsg;
+      pdev->sysfs_get("xmc", "mac_addr"+std::to_string(i), errmsg, addr);
+      list.push_back(addr);
+    }
+
+    return list;
+  }
+};
+
 // Specialize for other value types.
 template <typename ValueType>
 struct sysfs_fcn
@@ -259,136 +280,143 @@ emplace_sysfs_getput(const char* subdev, const char* entry)
 static void
 initialize_query_table()
 {
-  emplace_sysfs_get<query::pcie_vendor>                 ("", "vendor");
-  emplace_sysfs_get<query::pcie_device>                 ("", "device");
-  emplace_sysfs_get<query::pcie_subsystem_vendor>       ("", "subsystem_vendor");
-  emplace_sysfs_get<query::pcie_subsystem_id>           ("", "subsystem_device");
-  emplace_sysfs_get<query::pcie_link_speed>             ("", "link_speed");
-  emplace_sysfs_get<query::pcie_link_speed_max>         ("", "link_speed_max");
-  emplace_sysfs_get<query::pcie_express_lane_width>     ("", "link_width");
-  emplace_sysfs_get<query::pcie_express_lane_width_max> ("", "link_width_max");
-  emplace_sysfs_get<query::dma_threads_raw>             ("dma", "channel_stat_raw");
-  emplace_sysfs_get<query::rom_vbnv>                    ("rom", "VBNV");
-  emplace_sysfs_get<query::rom_ddr_bank_size_gb>        ("rom", "ddr_bank_size");
-  emplace_sysfs_get<query::rom_ddr_bank_count_max>      ("rom", "ddr_bank_count_max");
-  emplace_sysfs_get<query::rom_fpga_name>               ("rom", "FPGA");
-  emplace_sysfs_get<query::rom_raw>                     ("rom", "raw");
-  emplace_sysfs_get<query::rom_uuid>                    ("rom", "uuid");
-  emplace_sysfs_get<query::rom_time_since_epoch>        ("rom", "timestamp");
-  emplace_sysfs_get<query::xclbin_uuid>                 ("", "xclbinuuid");
-  emplace_sysfs_get<query::memstat>                     ("", "memstat");
-  emplace_sysfs_get<query::memstat_raw>                 ("", "memstat_raw");
-  emplace_sysfs_get<query::mem_topology_raw>            ("icap", "mem_topology");
-  emplace_sysfs_get<query::dma_stream>                  ("dma", "");
-  emplace_sysfs_get<query::group_topology>              ("icap", "group_topology");
-  emplace_sysfs_get<query::ip_layout_raw>               ("icap", "ip_layout");
-  emplace_sysfs_get<query::clock_freq_topology_raw>     ("icap", "clock_freq_topology");
-  emplace_sysfs_get<query::clock_freqs_mhz>             ("icap", "clock_freqs");
-  emplace_sysfs_get<query::idcode>                      ("icap", "idcode");
-  emplace_sysfs_getput<query::data_retention>           ("icap", "data_retention");
-  emplace_sysfs_getput<query::sec_level>                ("icap", "sec_level");
-  emplace_sysfs_get<query::status_mig_calibrated>       ("", "mig_calibration");
-  emplace_sysfs_getput<query::mig_cache_update>         ("", "mig_cache_update");
-  emplace_sysfs_get<query::temp_by_mem_topology>        ("xmc", "temp_by_mem_topology");
-  emplace_sysfs_get<query::xmc_version>                 ("xmc", "version");
-  emplace_sysfs_get<query::xmc_board_name>              ("xmc", "bd_name");
-  emplace_sysfs_get<query::xmc_serial_num>              ("xmc", "serial_num");
-  emplace_sysfs_get<query::xmc_max_power>               ("xmc", "max_power");
-  emplace_sysfs_get<query::xmc_sc_presence>             ("xmc", "sc_presence");
-  emplace_sysfs_get<query::xmc_bmc_version>             ("xmc", "bmc_ver");
-  emplace_sysfs_get<query::expected_bmc_version>        ("xmc", "exp_bmc_ver");
-  emplace_sysfs_get<query::xmc_status>                  ("xmc", "status");
-  emplace_sysfs_get<query::xmc_reg_base>                ("xmc", "reg_base");
-  emplace_sysfs_getput<query::xmc_scaling_enabled>      ("xmc", "scaling_enabled");
-  emplace_sysfs_getput<query::xmc_scaling_override>     ("xmc", "scaling_threshold_power_override");
-  emplace_sysfs_put<query::xmc_scaling_reset>           ("xmc", "scaling_reset");
-  emplace_sysfs_get<query::m2m>                         ("m2m", "");
-  emplace_sysfs_get<query::nodma>                       ("", "nodma");
-  emplace_sysfs_get<query::dna_serial_num>              ("dna", "dna");
-  emplace_sysfs_get<query::p2p_config>                  ("p2p", "config");
-  emplace_sysfs_get<query::temp_card_top_front>         ("xmc", "xmc_se98_temp0");
-  emplace_sysfs_get<query::temp_card_top_rear>          ("xmc", "xmc_se98_temp1");
-  emplace_sysfs_get<query::temp_card_bottom_front>      ("xmc", "xmc_se98_temp2");
-  emplace_sysfs_get<query::temp_fpga>                   ("xmc", "xmc_fpga_temp");
-  emplace_sysfs_get<query::fan_trigger_critical_temp>   ("xmc", "xmc_fan_temp");
-  emplace_sysfs_get<query::fan_fan_presence>            ("xmc", "fan_presence");
-  emplace_sysfs_get<query::fan_speed_rpm>               ("xmc", "xmc_fan_rpm");
-  emplace_sysfs_get<query::ddr_temp_0>                  ("xmc", "xmc_ddr_temp0");
-  emplace_sysfs_get<query::ddr_temp_1>                  ("xmc", "xmc_ddr_temp1");
-  emplace_sysfs_get<query::ddr_temp_2>                  ("xmc", "xmc_ddr_temp2");
-  emplace_sysfs_get<query::ddr_temp_3>                  ("xmc", "xmc_ddr_temp3");
-  emplace_sysfs_get<query::hbm_temp>                    ("xmc", "xmc_hbm_temp");
-  emplace_sysfs_get<query::cage_temp_0>                 ("xmc", "xmc_cage_temp0");
-  emplace_sysfs_get<query::cage_temp_1>                 ("xmc", "xmc_cage_temp1");
-  emplace_sysfs_get<query::cage_temp_2>                 ("xmc", "xmc_cage_temp2");
-  emplace_sysfs_get<query::cage_temp_3>                 ("xmc", "xmc_cage_temp3");
-  emplace_sysfs_get<query::v12v_pex_millivolts>         ("xmc", "xmc_12v_pex_vol");
-  emplace_sysfs_get<query::v12v_pex_milliamps>          ("xmc", "xmc_12v_pex_curr");
-  emplace_sysfs_get<query::v12v_aux_millivolts>         ("xmc", "xmc_12v_aux_vol");
-  emplace_sysfs_get<query::v12v_aux_milliamps>          ("xmc", "xmc_12v_aux_curr");
-  emplace_sysfs_get<query::v3v3_pex_millivolts>         ("xmc", "xmc_3v3_pex_vol");
-  emplace_sysfs_get<query::v3v3_aux_millivolts>         ("xmc", "xmc_3v3_aux_vol");
-  emplace_sysfs_get<query::v3v3_aux_milliamps>          ("xmc", "xmc_3v3_aux_cur");
-  emplace_sysfs_get<query::ddr_vpp_bottom_millivolts>   ("xmc", "xmc_ddr_vpp_btm");
-  emplace_sysfs_get<query::ddr_vpp_top_millivolts>      ("xmc", "xmc_ddr_vpp_top");
+  emplace_sysfs_get<query::pcie_vendor>                        ("", "vendor");
+  emplace_sysfs_get<query::pcie_device>                        ("", "device");
+  emplace_sysfs_get<query::pcie_subsystem_vendor>              ("", "subsystem_vendor");
+  emplace_sysfs_get<query::pcie_subsystem_id>                  ("", "subsystem_device");
+  emplace_sysfs_get<query::pcie_link_speed>                    ("", "link_speed");
+  emplace_sysfs_get<query::pcie_link_speed_max>                ("", "link_speed_max");
+  emplace_sysfs_get<query::pcie_express_lane_width>            ("", "link_width");
+  emplace_sysfs_get<query::pcie_express_lane_width_max>        ("", "link_width_max");
+  emplace_sysfs_get<query::dma_threads_raw>                    ("dma", "channel_stat_raw");
+  emplace_sysfs_get<query::rom_vbnv>                           ("rom", "VBNV");
+  emplace_sysfs_get<query::rom_ddr_bank_size_gb>               ("rom", "ddr_bank_size");
+  emplace_sysfs_get<query::rom_ddr_bank_count_max>             ("rom", "ddr_bank_count_max");
+  emplace_sysfs_get<query::rom_fpga_name>                      ("rom", "FPGA");
+  emplace_sysfs_get<query::rom_raw>                            ("rom", "raw");
+  emplace_sysfs_get<query::rom_uuid>                           ("rom", "uuid");
+  emplace_sysfs_get<query::rom_time_since_epoch>               ("rom", "timestamp");
+  emplace_sysfs_get<query::xclbin_uuid>                        ("", "xclbinuuid");
+  emplace_sysfs_get<query::memstat>                            ("", "memstat");
+  emplace_sysfs_get<query::memstat_raw>                        ("", "memstat_raw");
+  emplace_sysfs_get<query::mem_topology_raw>                   ("icap", "mem_topology");
+  emplace_sysfs_get<query::dma_stream>                         ("dma", "");
+  emplace_sysfs_get<query::group_topology>                     ("icap", "group_topology");
+  emplace_sysfs_get<query::ip_layout_raw>                      ("icap", "ip_layout");
+  emplace_sysfs_get<query::clock_freq_topology_raw>            ("icap", "clock_freq_topology");
+  emplace_sysfs_get<query::clock_freqs_mhz>                    ("icap", "clock_freqs");
+  emplace_sysfs_get<query::idcode>                             ("icap", "idcode");
+  emplace_sysfs_getput<query::data_retention>                  ("icap", "data_retention");
+  emplace_sysfs_getput<query::sec_level>                       ("icap", "sec_level");
+  emplace_sysfs_get<query::max_shared_host_mem_aperture_bytes> ("icap", "max_host_mem_aperture");
+  emplace_sysfs_get<query::status_mig_calibrated>              ("", "mig_calibration");
+  emplace_sysfs_getput<query::mig_cache_update>                ("", "mig_cache_update");
+  emplace_sysfs_get<query::temp_by_mem_topology>               ("xmc", "temp_by_mem_topology");
+  emplace_sysfs_get<query::xmc_version>                        ("xmc", "version");
+  emplace_sysfs_get<query::xmc_board_name>                     ("xmc", "bd_name");
+  emplace_sysfs_get<query::xmc_serial_num>                     ("xmc", "serial_num");
+  emplace_sysfs_get<query::max_power_level>                    ("xmc", "max_power");
+  emplace_sysfs_get<query::xmc_sc_presence>                    ("xmc", "sc_presence");
+  emplace_sysfs_get<query::xmc_sc_version>                     ("xmc", "bmc_ver");
+  emplace_sysfs_get<query::expected_sc_version>                ("xmc", "exp_bmc_ver");
+  emplace_sysfs_get<query::xmc_status>                         ("xmc", "status");
+  emplace_sysfs_get<query::xmc_reg_base>                       ("xmc", "reg_base");
+  emplace_sysfs_getput<query::xmc_scaling_enabled>             ("xmc", "scaling_enabled");
+  emplace_sysfs_getput<query::xmc_scaling_override>            ("xmc", "scaling_threshold_power_override");
+  emplace_sysfs_put<query::xmc_scaling_reset>                  ("xmc", "scaling_reset");
+  emplace_sysfs_get<query::m2m>                                ("m2m", "");
+  emplace_sysfs_get<query::nodma>                              ("", "nodma");
+  emplace_sysfs_get<query::dna_serial_num>                     ("dna", "dna");
+  emplace_sysfs_get<query::p2p_config>                         ("p2p", "config");
+  emplace_sysfs_get<query::temp_card_top_front>                ("xmc", "xmc_se98_temp0");
+  emplace_sysfs_get<query::temp_card_top_rear>                 ("xmc", "xmc_se98_temp1");
+  emplace_sysfs_get<query::temp_card_bottom_front>             ("xmc", "xmc_se98_temp2");
+  emplace_sysfs_get<query::temp_fpga>                          ("xmc", "xmc_fpga_temp");
+  emplace_sysfs_get<query::fan_trigger_critical_temp>          ("xmc", "xmc_fan_temp");
+  emplace_sysfs_get<query::fan_fan_presence>                   ("xmc", "fan_presence");
+  emplace_sysfs_get<query::fan_speed_rpm>                      ("xmc", "xmc_fan_rpm");
+  emplace_sysfs_get<query::ddr_temp_0>                         ("xmc", "xmc_ddr_temp0");
+  emplace_sysfs_get<query::ddr_temp_1>                         ("xmc", "xmc_ddr_temp1");
+  emplace_sysfs_get<query::ddr_temp_2>                         ("xmc", "xmc_ddr_temp2");
+  emplace_sysfs_get<query::ddr_temp_3>                         ("xmc", "xmc_ddr_temp3");
+  emplace_sysfs_get<query::hbm_temp>                           ("xmc", "xmc_hbm_temp");
+  emplace_sysfs_get<query::cage_temp_0>                        ("xmc", "xmc_cage_temp0");
+  emplace_sysfs_get<query::cage_temp_1>                        ("xmc", "xmc_cage_temp1");
+  emplace_sysfs_get<query::cage_temp_2>                        ("xmc", "xmc_cage_temp2");
+  emplace_sysfs_get<query::cage_temp_3>                        ("xmc", "xmc_cage_temp3");
+  emplace_sysfs_get<query::v12v_pex_millivolts>                ("xmc", "xmc_12v_pex_vol");
+  emplace_sysfs_get<query::v12v_pex_milliamps>                 ("xmc", "xmc_12v_pex_curr");
+  emplace_sysfs_get<query::v12v_aux_millivolts>                ("xmc", "xmc_12v_aux_vol");
+  emplace_sysfs_get<query::v12v_aux_milliamps>                 ("xmc", "xmc_12v_aux_curr");
+  emplace_sysfs_get<query::v3v3_pex_millivolts>                ("xmc", "xmc_3v3_pex_vol");
+  emplace_sysfs_get<query::v3v3_aux_millivolts>                ("xmc", "xmc_3v3_aux_vol");
+  emplace_sysfs_get<query::v3v3_aux_milliamps>                 ("xmc", "xmc_3v3_aux_cur");
+  emplace_sysfs_get<query::ddr_vpp_bottom_millivolts>          ("xmc", "xmc_ddr_vpp_btm");
+  emplace_sysfs_get<query::ddr_vpp_top_millivolts>             ("xmc", "xmc_ddr_vpp_top");
 
-  emplace_sysfs_get<query::v5v5_system_millivolts>      ("xmc", "xmc_sys_5v5");
-  emplace_sysfs_get<query::v1v2_vcc_top_millivolts>     ("xmc", "xmc_1v2_top");
-  emplace_sysfs_get<query::v1v2_vcc_bottom_millivolts>  ("xmc", "xmc_vcc1v2_btm");
-  emplace_sysfs_get<query::v1v8_millivolts>             ("xmc", "xmc_1v8");
-  emplace_sysfs_get<query::v0v85_millivolts>            ("xmc", "xmc_0v85");
-  emplace_sysfs_get<query::v0v9_vcc_millivolts>         ("xmc", "xmc_mgt0v9avcc");
-  emplace_sysfs_get<query::v12v_sw_millivolts>          ("xmc", "xmc_12v_sw");
-  emplace_sysfs_get<query::mgt_vtt_millivolts>          ("xmc", "xmc_mgtavtt");
-  emplace_sysfs_get<query::int_vcc_millivolts>          ("xmc", "xmc_vccint_vol");
-  emplace_sysfs_get<query::int_vcc_milliamps>           ("xmc", "xmc_vccint_curr");
-  emplace_sysfs_get<query::int_vcc_temp>                ("xmc", "xmc_vccint_temp");
+  emplace_sysfs_get<query::v5v5_system_millivolts>             ("xmc", "xmc_sys_5v5");
+  emplace_sysfs_get<query::v1v2_vcc_top_millivolts>            ("xmc", "xmc_1v2_top");
+  emplace_sysfs_get<query::v1v2_vcc_bottom_millivolts>         ("xmc", "xmc_vcc1v2_btm");
+  emplace_sysfs_get<query::v1v8_millivolts>                    ("xmc", "xmc_1v8");
+  emplace_sysfs_get<query::v0v85_millivolts>                   ("xmc", "xmc_0v85");
+  emplace_sysfs_get<query::v0v9_vcc_millivolts>                ("xmc", "xmc_mgt0v9avcc");
+  emplace_sysfs_get<query::v12v_sw_millivolts>                 ("xmc", "xmc_12v_sw");
+  emplace_sysfs_get<query::mgt_vtt_millivolts>                 ("xmc", "xmc_mgtavtt");
+  emplace_sysfs_get<query::int_vcc_millivolts>                 ("xmc", "xmc_vccint_vol");
+  emplace_sysfs_get<query::int_vcc_milliamps>                  ("xmc", "xmc_vccint_curr");
+  emplace_sysfs_get<query::int_vcc_temp>                       ("xmc", "xmc_vccint_temp");
 
-  emplace_sysfs_get<query::v12_aux1_millivolts>         ("xmc", "xmc_12v_aux1");
-  emplace_sysfs_get<query::vcc1v2_i_milliamps>          ("xmc", "xmc_vcc1v2_i");
-  emplace_sysfs_get<query::v12_in_i_milliamps>          ("xmc", "xmc_v12_in_i");
-  emplace_sysfs_get<query::v12_in_aux0_i_milliamps>     ("xmc", "xmc_v12_in_aux0_i");
-  emplace_sysfs_get<query::v12_in_aux1_i_milliamps>     ("xmc", "xmc_v12_in_aux1_i");
-  emplace_sysfs_get<query::vcc_aux_millivolts>          ("xmc", "xmc_vccaux");
-  emplace_sysfs_get<query::vcc_aux_pmc_millivolts>      ("xmc", "xmc_vccaux_pmc");
-  emplace_sysfs_get<query::vcc_ram_millivolts>          ("xmc", "xmc_vccram");
+  emplace_sysfs_get<query::v12_aux1_millivolts>                ("xmc", "xmc_12v_aux1");
+  emplace_sysfs_get<query::vcc1v2_i_milliamps>                 ("xmc", "xmc_vcc1v2_i");
+  emplace_sysfs_get<query::v12_in_i_milliamps>                 ("xmc", "xmc_v12_in_i");
+  emplace_sysfs_get<query::v12_in_aux0_i_milliamps>            ("xmc", "xmc_v12_in_aux0_i");
+  emplace_sysfs_get<query::v12_in_aux1_i_milliamps>            ("xmc", "xmc_v12_in_aux1_i");
+  emplace_sysfs_get<query::vcc_aux_millivolts>                 ("xmc", "xmc_vccaux");
+  emplace_sysfs_get<query::vcc_aux_pmc_millivolts>             ("xmc", "xmc_vccaux_pmc");
+  emplace_sysfs_get<query::vcc_ram_millivolts>                 ("xmc", "xmc_vccram");
 
-  emplace_sysfs_get<query::v3v3_pex_milliamps>          ("xmc", "xmc_3v3_pex_curr");
-  emplace_sysfs_get<query::v3v3_aux_milliamps>          ("xmc", "xmc_3v3_aux_cur");
-  emplace_sysfs_get<query::int_vcc_io_milliamps>        ("xmc", "xmc_0v85_curr");
-  emplace_sysfs_get<query::v3v3_vcc_millivolts>         ("xmc", "xmc_3v3_vcc_vol");
-  emplace_sysfs_get<query::hbm_1v2_millivolts>          ("xmc", "xmc_hbm_1v2_vol");
-  emplace_sysfs_get<query::v2v5_vpp_millivolts>         ("xmc", "xmc_vpp2v5_vol");
-  emplace_sysfs_get<query::int_vcc_io_millivolts>       ("xmc", "xmc_vccint_bram_vol");
+  emplace_sysfs_get<query::v3v3_pex_milliamps>                 ("xmc", "xmc_3v3_pex_curr");
+  emplace_sysfs_get<query::v3v3_aux_milliamps>                 ("xmc", "xmc_3v3_aux_cur");
+  emplace_sysfs_get<query::int_vcc_io_milliamps>               ("xmc", "xmc_0v85_curr");
+  emplace_sysfs_get<query::v3v3_vcc_millivolts>                ("xmc", "xmc_3v3_vcc_vol");
+  emplace_sysfs_get<query::hbm_1v2_millivolts>                 ("xmc", "xmc_hbm_1v2_vol");
+  emplace_sysfs_get<query::v2v5_vpp_millivolts>                ("xmc", "xmc_vpp2v5_vol");
+  emplace_sysfs_get<query::int_vcc_io_millivolts>              ("xmc", "xmc_vccint_bram_vol");
+  emplace_sysfs_get<query::mac_contiguous_num>                 ("xmc", "mac_contiguous_num");
+  emplace_sysfs_get<query::mac_addr_first>                     ("xmc", "mac_addr_first");
+  emplace_sysfs_get<query::oem_id>                             ("xmc", "xmc_oem_id");
+  emplace_func0_request<query::mac_addr_list,                  mac_addr_list>();
 
-  emplace_sysfs_get<query::firewall_detect_level>       ("firewall", "detected_level");
-  emplace_sysfs_get<query::firewall_status>             ("firewall", "detected_status");
-  emplace_sysfs_get<query::firewall_time_sec>           ("firewall", "detected_time");
+  emplace_sysfs_get<query::firewall_detect_level>             ("firewall", "detected_level");
+  emplace_sysfs_get<query::firewall_status>                   ("firewall", "detected_status");
+  emplace_sysfs_get<query::firewall_time_sec>                 ("firewall", "detected_time");
 
-  emplace_sysfs_get<query::power_microwatts>            ("xmc", "xmc_power");
-  emplace_sysfs_get<query::host_mem_size>               ("address_translator", "host_mem_size");
-  emplace_sysfs_get<query::kds_numcdmas>                ("mb_scheduler", "kds_numcdmas");
+  emplace_sysfs_get<query::power_microwatts>                  ("xmc", "xmc_power");
+  emplace_sysfs_get<query::host_mem_size>                     ("address_translator", "host_mem_size");
+  emplace_sysfs_get<query::kds_numcdmas>                      ("mb_scheduler", "kds_numcdmas");
 
-  //emplace_sysfs_get<query::mig_ecc_enabled>             ("mig", "ecc_enabled");
-  emplace_sysfs_get<query::mig_ecc_status>              ("mig", "ecc_status");
-  emplace_sysfs_get<query::mig_ecc_ce_cnt>              ("mig", "ecc_ce_cnt");
-  emplace_sysfs_get<query::mig_ecc_ue_cnt>              ("mig", "ecc_ue_cnt");
-  emplace_sysfs_get<query::mig_ecc_ce_ffa>              ("mig", "ecc_ce_ffa");
-  emplace_sysfs_get<query::mig_ecc_ue_ffa>              ("mig", "ecc_ue_ffa");
-  emplace_sysfs_get<query::flash_bar_offset>            ("flash", "bar_off");
-  emplace_sysfs_get<query::is_mfg>                      ("", "mfg");
-  emplace_sysfs_get<query::mfg_ver>                     ("", "mfg_ver");
-  emplace_sysfs_get<query::is_recovery>                 ("", "recovery");
-  emplace_sysfs_get<query::is_ready>                    ("", "ready");
-  emplace_sysfs_get<query::f_flash_type>                ("flash", "flash_type");
-  emplace_sysfs_get<query::flash_type>                  ("", "flash_type");
-  emplace_sysfs_get<query::board_name>                  ("", "board_name");
-  emplace_sysfs_get<query::logic_uuids>                 ("", "logic_uuids");
-  emplace_sysfs_get<query::interface_uuids>             ("", "interface_uuids");
-  emplace_sysfs_getput<query::rp_program_status>        ("", "rp_program");
+  //emplace_sysfs_get<query::mig_ecc_enabled>                ("mig", "ecc_enabled");
+  emplace_sysfs_get<query::mig_ecc_status>                   ("mig", "ecc_status");
+  emplace_sysfs_get<query::mig_ecc_ce_cnt>                   ("mig", "ecc_ce_cnt");
+  emplace_sysfs_get<query::mig_ecc_ue_cnt>                   ("mig", "ecc_ue_cnt");
+  emplace_sysfs_get<query::mig_ecc_ce_ffa>                   ("mig", "ecc_ce_ffa");
+  emplace_sysfs_get<query::mig_ecc_ue_ffa>                   ("mig", "ecc_ue_ffa");
+  emplace_sysfs_get<query::flash_bar_offset>                 ("flash", "bar_off");
+  emplace_sysfs_get<query::is_mfg>                           ("", "mfg");
+  emplace_sysfs_get<query::mfg_ver>                          ("", "mfg_ver");
+  emplace_sysfs_get<query::is_recovery>                      ("", "recovery");
+  emplace_sysfs_get<query::is_ready>                         ("", "ready");
+  emplace_sysfs_get<query::f_flash_type>                     ("flash", "flash_type");
+  emplace_sysfs_get<query::flash_type>                       ("", "flash_type");
+  emplace_sysfs_get<query::board_name>                       ("", "board_name");
+  emplace_sysfs_get<query::logic_uuids>                      ("", "logic_uuids");
+  emplace_sysfs_get<query::interface_uuids>                  ("", "interface_uuids");
+  emplace_sysfs_getput<query::rp_program_status>             ("", "rp_program");
+  emplace_sysfs_get<query::shared_host_mem>                  ("address_translator", "host_mem_size");
+  emplace_sysfs_get<query::cpu_affinity>                     ("", "local_cpulist");
 
-  emplace_func0_request<query::pcie_bdf,                bdf>();
-  emplace_func0_request<query::kds_cu_info,             kds_cu_info>();
+  emplace_func0_request<query::pcie_bdf,                     bdf>();
+  emplace_func0_request<query::kds_cu_info,                  kds_cu_info>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -32,6 +32,7 @@ namespace {
 namespace query = xrt_core::query;
 using pdev = std::shared_ptr<pcidev::pci_device>;
 using key_type = query::key_type;
+const static int LEGACY_COUNT = 4;
 
 inline pdev
 get_pcidev(const xrt_core::device* device)
@@ -90,7 +91,7 @@ struct mac_addr_list
     auto pdev = get_pcidev(device);
 
     //legacy code exposes only 4 mac addr sysfs nodes (0-3)
-    for (int i=0; i < 4; i++) {
+    for (int i=0; i < LEGACY_COUNT; i++) {
       std::string addr, errmsg;
       pdev->sysfs_get("xmc", "mac_addr"+std::to_string(i), errmsg, addr);
       list.push_back(addr);

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -52,6 +52,20 @@ populate_sensor(const xrt_core::device * device, const std::string loc_id, const
   return pt;
 }
 
+/**
+ * device query returns a level which 
+ * need to be converted to human readable power in watts
+ * 0 -> 75W
+ * 1 -> 150W
+ * 2 -> 225W
+ */
+static std::string
+lvl_to_power_watts(unsigned int lvl)
+{
+  std::vector<std::string> powers{ "75", "150", "225" };
+  return lvl < powers.size() ? powers[lvl] : "0";
+}
+
 void
 ReportElectrical::getPropertyTreeInternal( const xrt_core::device * _pDevice, 
                                               boost::property_tree::ptree &_pt) const
@@ -66,7 +80,15 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
                                            boost::property_tree::ptree &_pt) const
 {
   boost::property_tree::ptree pt;
-  
+  std::string power_watts;
+  try {
+    auto power_level = xrt_core::device_query<qr::max_power_level>(_pDevice);
+    power_watts = lvl_to_power_watts(power_level);
+  }
+  catch (...) {
+    power_watts = "N/A";
+  }
+  pt.put("power_consumption_max_watts", power_watts);
   pt.put("power_consumption_watts", XBUtilities::format_base10_shiftdown6(xrt_core::device_query<qr::power_microwatts>(_pDevice)));
   boost::property_tree::ptree sensor_array;
   sensor_array.push_back(std::make_pair("", 
@@ -138,6 +160,7 @@ ReportElectrical::writeReport( const xrt_core::device * _pDevice,
 
   _output << "Electrical\n";
   boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
+  _output << boost::format("  %-22s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts");
   _output << boost::format("  %-22s: %s Watts\n\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts");
   _output << boost::format("  %-22s: %6s   %6s\n") % "Power Rails" % "Voltage" % "Current";
   for(auto& kv : electricals) {

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -63,7 +63,7 @@ static std::string
 lvl_to_power_watts(unsigned int lvl)
 {
   std::vector<std::string> powers{ "75", "150", "225" };
-  return lvl < powers.size() ? powers[lvl] : "0";
+  return lvl < powers.size() ? powers[lvl] : "N/A";
 }
 
 void

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "ReportPcieInfo.h"
+#include "XBUtilities.h"
+#include "core/common/query_requests.h"
+#include "core/common/device.h"
+namespace qr = xrt_core::query;
+
+
+void
+ReportPcieInfo::getPropertyTreeInternal( const xrt_core::device * dev, 
+                                              boost::property_tree::ptree &pt) const
+{
+  // Defer to the 20202 format.  If we ever need to update JSON data, 
+  // Then update this method to do so.
+  getPropertyTree20202(dev, pt);
+}
+
+void 
+ReportPcieInfo::getPropertyTree20202( const xrt_core::device * dev, 
+                                           boost::property_tree::ptree &pt) const
+{
+  boost::property_tree::ptree ptree;
+  try {
+    ptree.add("vendor", qr::pcie_vendor::to_string(xrt_core::device_query<qr::pcie_vendor>(dev)));
+    ptree.add("device", qr::pcie_device::to_string(xrt_core::device_query<qr::pcie_device>(dev)));
+    ptree.add("sub_device", qr::pcie_subsystem_id::to_string(xrt_core::device_query<qr::pcie_subsystem_id>(dev)));
+    ptree.add("sub_vendor", qr::pcie_subsystem_vendor::to_string(xrt_core::device_query<qr::pcie_subsystem_vendor>(dev)));
+    ptree.add("link_speed_gbit_sec", xrt_core::device_query<qr::pcie_link_speed_max>(dev));
+    ptree.add("express_lane_width_count", xrt_core::device_query<qr::pcie_express_lane_width>(dev));
+    ptree.add("dma_thread_count", xrt_core::device_query<qr::dma_threads_raw>(dev).size());
+    ptree.add("cpu_affinity", xrt_core::device_query<qr::cpu_affinity>(dev));
+    ptree.add("max_shared_host_mem_aperture_bytes", xrt_core::device_query<qr::max_shared_host_mem_aperture_bytes>(dev));
+    ptree.add("shared_host_mem_size_bytes", xrt_core::device_query<qr::shared_host_mem>(dev));
+  } catch(...) {}
+  
+  // There can only be 1 root node
+    pt.add_child("pcie_info", ptree);
+}
+
+void 
+ReportPcieInfo::writeReport( const xrt_core::device * dev,
+                                  const std::vector<std::string> & /*_elementsFilter*/, 
+                                  std::iostream & output) const
+{
+  boost::property_tree::ptree pt;
+  getPropertyTreeInternal(dev, pt);
+
+  output << "Pcie Info\n";
+  auto& pt_pcie = pt.get_child("pcie_info");
+  if(pt_pcie.empty()) {
+    output << "  Information unavailable" << std::endl; 
+    return;
+  }
+  output << boost::format("  %-22s : %s\n") % "Vendor" % pt_pcie.get<std::string>("vendor");
+  output << boost::format("  %-22s : %s\n") % "Device" % pt_pcie.get<std::string>("device");
+  output << boost::format("  %-22s : %s\n") % "Sub Device" % pt_pcie.get<std::string>("sub_device");
+  output << boost::format("  %-22s : %s\n") % "Sub Vendor" % pt_pcie.get<std::string>("sub_vendor");
+  output << boost::format("  %-22s : Gen%sx%s\n") % "PCIe" % pt_pcie.get<std::string>("link_speed_gbit_sec") % pt_pcie.get<std::string>("express_lane_width_count");
+  output << boost::format("  %-22s : %s\n") % "DMA Thread Count" % pt_pcie.get<std::string>("dma_thread_count");
+  output << boost::format("  %-22s : %s\n") % "CPU Affinity" % pt_pcie.get<std::string>("cpu_affinity");
+  output << boost::format("  %-22s : %s Bytes\n") % "Shared Host Memory" % pt_pcie.get<std::string>("host_mem_size_bytes", "0");
+  output << boost::format("  %-22s : %s Bytes\n") % "Max Shared Host Memory" % pt_pcie.get<std::string>("max_shared_host_mem_aperture_bytes", "0");
+  output << std::endl;
+  
+}

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.h
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __ReportPcieInfo_h_
+#define __ReportPcieInfo_h_
+
+// Please keep external include file dependencies to a minimum
+#include "Report.h"
+
+class ReportPcieInfo : public Report {
+ public:
+  ReportPcieInfo() : Report("pcie-info", "Pcie information of the device", true /*deviceRequired*/) { /*empty*/ };
+
+ // Child methods that need to be implemented
+ public:
+  virtual void getPropertyTreeInternal(const xrt_core::device * dev, boost::property_tree::ptree &pt) const;
+  virtual void getPropertyTree20202(const xrt_core::device * deve, boost::property_tree::ptree &pt) const;
+  virtual void writeReport(const xrt_core::device * dev, const std::vector<std::string> & _elementsFilter, std::iostream & output) const;
+};
+
+#endif
+
+

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -28,9 +28,9 @@ namespace qr = xrt_core::query;
 static std::map<int, std::string> p2p_config_map = {
   { 0, "disabled" },
   { 1, "enabled" },
-  { 2, "reboot" },
-  { 3, "not supported" },
-  { 4, "error" },
+  { 2, "error" },
+  { 3, "reboot" },
+  { 4, "not supported" },
 };
 
 /**
@@ -135,7 +135,7 @@ ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev,
     for(int i = 0; i < clock_topology->m_count; i++) {
       boost::property_tree::ptree clock;
       clock.add("id", clock_topology->m_clock_freq[i].m_name);
-      clock.add("desc", XBUtilities::parse_clock_id(clock_topology->m_clock_freq[i].m_name));
+      clock.add("description", XBUtilities::parse_clock_id(clock_topology->m_clock_freq[i].m_name));
       clock.add("freq_mhz", clock_topology->m_clock_freq[i].m_freq_Mhz);
       pt_clocks.push_back(std::make_pair("", clock));
     }
@@ -182,7 +182,7 @@ ReportPlatforms::writeReport( const xrt_core::device * dev,
       output << "Clocks\n";
     for(auto& kc : clocks) {
       boost::property_tree::ptree& pt_clock = kc.second;
-      output << boost::format("    %-20s : %s MHz\n") % pt_clock.get<std::string>("desc") % pt_clock.get<std::string>("freq_mhz");
+      output << boost::format("    %-20s : %s MHz\n") % pt_clock.get<std::string>("description") % pt_clock.get<std::string>("freq_mhz");
     }
 
     boost::property_tree::ptree& macs = pt_platform.get_child("macs", empty_ptree);

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// System - Include Files
+#include <map>
+
+// Local - Include Files
+#include "ReportPlatforms.h"
+#include "XBUtilities.h"
+#include "core/common/query_requests.h"
+#include "core/common/device.h"
+namespace qr = xrt_core::query;
+
+static std::map<int, std::string> p2p_config_map = {
+  { 0, "disabled" },
+  { 1, "enabled" },
+  { 2, "reboot" },
+  { 3, "not supported" },
+  { 4, "error" },
+};
+
+/**
+ * New flow for exposing mac addresses
+ * qr::mac_contiguous_num is the total number of mac addresses
+ * avaliable contiguously starting from qr::mac_addr_first
+ * 
+ * Old flow: Query the four sysfs nodes we have and validate them
+ * before adding them to the property tree
+ */
+static boost::property_tree::ptree
+mac_addresses(const xrt_core::device * dev)
+{
+  boost::property_tree::ptree ptree;
+  auto mac_contiguous_num = xrt_core::device_query<qr::mac_contiguous_num>(dev);
+  auto mac_addr_first = xrt_core::device_query<qr::mac_addr_first>(dev);
+  
+  //new flow
+  if (mac_contiguous_num && !mac_addr_first.empty()) {
+    std::string mac_prefix = mac_addr_first.substr(0, mac_addr_first.find_last_of(":"));
+    std::string mac_base = mac_addr_first.substr(mac_addr_first.find_last_of(":") + 1);
+    std::stringstream ss;
+    uint32_t mac_base_val = 0;
+    ss << std::hex << mac_base;
+    ss >> mac_base_val;
+
+    for (uint32_t i = 0; i < (uint32_t)mac_contiguous_num; i++) {
+      boost::property_tree::ptree addr;
+      auto base = boost::format("%02X") % (mac_base_val + i);
+      addr.add("address", mac_prefix + ":" + base.str());
+      ptree.push_back(std::make_pair("", addr));
+    } 
+  }
+  else { //old flow
+    auto mac_addr = xrt_core::device_query<qr::mac_addr_list>(dev);
+    for (const auto& a : mac_addr) {
+      boost::property_tree::ptree addr;
+      if (a.compare("FF:FF:FF:FF:FF:FF") != 0) {
+        addr.add("address", a);
+        ptree.push_back(std::make_pair("", addr));
+      }
+    }
+   }
+  return ptree;
+
+}
+
+void
+ReportPlatforms::getPropertyTreeInternal( const xrt_core::device * dev, 
+                                              boost::property_tree::ptree &pt) const
+{
+  // Defer to the 20202 format.  If we ever need to update JSON data, 
+  // Then update this method to do so.
+  getPropertyTree20202(dev, pt);
+}
+
+void 
+ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev, 
+                                           boost::property_tree::ptree &pt) const
+{
+  boost::property_tree::ptree ptree;
+  boost::property_tree::ptree pt_platform;
+  
+  boost::property_tree::ptree static_region;
+  static_region.add("vbnv", xrt_core::device_query<qr::rom_vbnv>(dev));
+  static_region.add("jtag_idcode", qr::idcode::to_string(xrt_core::device_query<qr::idcode>(dev)));
+  static_region.add("fpga_name", xrt_core::device_query<qr::rom_fpga_name>(dev));
+  pt_platform.put_child("static_region", static_region);
+
+  boost::property_tree::ptree bd_info;
+  auto ddr_size_bytes = [](uint64_t size_gb, uint64_t count) {
+    auto bytes = size_gb * 1024 * 1024 * 1024;
+    return bytes * count;
+  };
+  bd_info.add("ddr_size_bytes", ddr_size_bytes(xrt_core::device_query<qr::rom_ddr_bank_size_gb>(dev), xrt_core::device_query<qr::rom_ddr_bank_count_max>(dev)));
+  bd_info.add("ddr_count", xrt_core::device_query<qr::rom_ddr_bank_count_max>(dev));
+  pt_platform.put_child("off_chip_board_info", bd_info);
+
+  boost::property_tree::ptree status;
+  status.add("mig_calibrated", xrt_core::device_query<qr::status_mig_calibrated>(dev));
+  std::string msg;
+  auto value = XBUtilities::check_p2p_config(dev, msg);
+  status.add("p2p_status", p2p_config_map[value]);
+  pt_platform.put_child("status", status);
+
+  boost::property_tree::ptree controller;
+  boost::property_tree::ptree sc;
+  boost::property_tree::ptree cmc;
+  sc.add("version", xrt_core::device_query<qr::xmc_sc_version>(dev));
+  sc.add("expected_version", xrt_core::device_query<qr::expected_sc_version>(dev));
+  cmc.add("version", xrt_core::device_query<qr::xmc_version>(dev));
+  cmc.add("serial_number", xrt_core::device_query<qr::xmc_serial_num>(dev));
+  cmc.add("oem_id", XBUtilities::parse_oem_id(xrt_core::device_query<qr::oem_id>(dev)));
+  controller.put_child("satellite_controller", sc);
+  controller.put_child("card_mgmt_controller", cmc);
+  pt_platform.put_child("controller", controller);
+
+  boost::property_tree::ptree pt_clocks;
+  auto raw = xrt_core::device_query<qr::clock_freq_topology_raw>(dev);
+  auto clock_topology = reinterpret_cast<const clock_freq_topology*>(raw.data());
+  for(int i = 0; i < clock_topology->m_count; i++) {
+    boost::property_tree::ptree clock;
+    clock.add("id", clock_topology->m_clock_freq[i].m_name);
+    clock.add("freq_mhz", clock_topology->m_clock_freq[i].m_freq_Mhz);
+    pt_clocks.push_back(std::make_pair("", clock));
+  }
+  pt_platform.put_child("clocks", pt_clocks);
+  
+  auto macs = mac_addresses(dev);
+  if(!macs.empty())
+    pt_platform.put_child("macs", macs);
+  
+  ptree.push_back(std::make_pair("", pt_platform));
+  // There can only be 1 root node
+  pt.add_child("platforms", ptree);
+}
+
+void 
+ReportPlatforms::writeReport( const xrt_core::device * dev,
+                                  const std::vector<std::string> & /*_elementsFilter*/, 
+                                  std::iostream & output) const
+{
+  boost::property_tree::ptree pt;
+  boost::property_tree::ptree empty_ptree;
+  getPropertyTreeInternal(dev, pt);
+
+  output << "Platform\n";
+  boost::property_tree::ptree& platforms = pt.get_child("platforms", empty_ptree);
+  for(auto& kv : platforms) {
+    boost::property_tree::ptree& pt_platform = kv.second;
+    boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region");
+    output << boost::format("  %-20s : %s \n") % "XSA Name" % pt_static_region.get<std::string>("vbnv");
+    output << boost::format("  %-20s : %s \n") % "FPGA Name" % pt_static_region.get<std::string>("fpga_name");
+    output << boost::format("  %-20s : %s \n") % "JTAG ID Code" % pt_static_region.get<std::string>("jtag_idcode");
+    
+    boost::property_tree::ptree& pt_board_info = pt_platform.get_child("off_chip_board_info");
+    output << boost::format("  %-20s : %s Bytes\n") % "DDR Size" % pt_board_info.get<std::string>("ddr_size_bytes");
+    output << boost::format("  %-20s : %s \n") % "DDR Count" % pt_board_info.get<std::string>("ddr_count");
+    
+    boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
+    output << boost::format("  %-20s : %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
+    output << boost::format("  %-20s : %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
+
+    boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
+    for(auto& kv : clocks) {
+      boost::property_tree::ptree& pt_clock = kv.second;
+      output << boost::format("  %-20s : %s MHz\n") % pt_clock.get<std::string>("id") % pt_clock.get<std::string>("freq_mhz");
+    }
+
+    boost::property_tree::ptree& macs = pt_platform.get_child("macs", empty_ptree);
+    for(auto& kv : macs) {
+      boost::property_tree::ptree& pt_mac = kv.second;
+      output << boost::format("  %-20s : %s\n") % "Mac Address" % pt_mac.get<std::string>("address");
+    }
+  }
+  
+  output << std::endl;
+  
+}

--- a/src/runtime_src/core/tools/common/ReportPlatforms.h
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __ReportPlatforms_h_
+#define __ReportPlatforms_h_
+
+// Please keep external include file dependencies to a minimum
+#include "Report.h"
+
+class ReportPlatforms : public Report {
+ public:
+  ReportPlatforms() : Report("platform", "Platforms flashed on the device", true /*deviceRequired*/) { /*empty*/ };
+
+ // Child methods that need to be implemented
+ public:
+  virtual void getPropertyTreeInternal(const xrt_core::device * dev, boost::property_tree::ptree &pt) const;
+  virtual void getPropertyTree20202(const xrt_core::device * deve, boost::property_tree::ptree &pt) const;
+  virtual void writeReport(const xrt_core::device * dev, const std::vector<std::string> & _elementsFilter, std::iostream & output) const;
+};
+
+#endif
+
+

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -680,6 +680,7 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
     for (const auto & device : _devices) {
       boost::property_tree::ptree ptDevice;
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
+      ptDevice.put("interface_type", "pcie");
       ptDevice.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
       if (_schemaVersion == Report::SchemaVersion::text) {
         bool is_mfg = false;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -662,7 +662,7 @@ XBUtilities::get_uuids(const void *dtbuf)
 }
 
 int
-XBUtilities::check_p2p_config(const std::shared_ptr<xrt_core::device>& _dev, std::string &msg)
+XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
 {
   std::vector<std::string> config;
   try {
@@ -770,4 +770,33 @@ XBUtilities::string_to_UUID(std::string str)
   uuid.append(str);
 
   return uuid;
+}
+
+static const std::map<int, std::string> oemid_map = {
+  {0x10da, "Xilinx"},
+  {0x02a2, "Dell"},
+  {0x12a1, "IBM"},
+  {0xb85c, "HP"},
+  {0x2a7c, "Super Micro"},
+  {0x4a66, "Lenovo"},
+  {0xbd80, "Inspur"},
+  {0x12eb, "Amazon"},
+  {0x2b79, "Google"}
+};
+
+std::string 
+XBUtilities::parse_oem_id(std::string oemid)
+{
+  unsigned int oem_id_val = 0;
+  std::stringstream ss;
+
+  try {
+    ss << std::hex << oemid;
+    ss >> oem_id_val;
+  } catch (const std::exception&) {
+    //failed to parse oemid to hex value, ignore erros and print original value
+  }
+
+  auto oemstr = oemid_map.find(oem_id_val);
+  return oemstr != oemid_map.end() ? oemstr->second : "N/A";
 }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -785,7 +785,7 @@ static const std::map<int, std::string> oemid_map = {
 };
 
 std::string 
-XBUtilities::parse_oem_id(std::string oemid)
+XBUtilities::parse_oem_id(const std::string& oemid)
 {
   unsigned int oem_id_val = 0;
   std::stringstream ss;
@@ -800,3 +800,17 @@ XBUtilities::parse_oem_id(std::string oemid)
   auto oemstr = oemid_map.find(oem_id_val);
   return oemstr != oemid_map.end() ? oemstr->second : "N/A";
 }
+
+static const std::map<std::string, std::string> clock_map = {
+  {"DATA_CLK", "Data"},
+  {"KERNEL_CLK", "Kernel"},
+  {"SYSTEM_CLK", "System"},
+};
+
+std::string 
+XBUtilities::parse_clock_id(const std::string& id)
+{
+  auto clock_str = clock_map.find(id);
+  return clock_str != clock_map.end() ? clock_str->second : "N/A";
+}
+

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -130,7 +130,11 @@ namespace XBUtilities {
    * Return: Manufacturer's name
    */
   std::string 
-  parse_oem_id(std::string oemid);
+  parse_oem_id(const std::string& oemid);
+
+  std::string 
+  parse_clock_id(const std::string& id);
+
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -112,7 +112,7 @@ namespace XBUtilities {
    */
   std::vector<std::string> get_uuids(const void *dtbuf);
 
-  int check_p2p_config(const std::shared_ptr<xrt_core::device>& _dev, std::string &err);
+  int check_p2p_config(const xrt_core::device* _dev, std::string &err);
 
   xrt_core::query::reset_type str_to_reset_obj(const std::string& str);
 
@@ -122,6 +122,15 @@ namespace XBUtilities {
    * Returns: 00000000-0000-0000-0000-000000000000 formatted uuid
    */
   std::string string_to_UUID(std::string str);
+
+  /**
+   * OEM ID is a unique number called as the 
+   * Private Enterprise Number (PEN) maintained by IANA
+   * 
+   * Return: Manufacturer's name
+   */
+  std::string 
+  parse_oem_id(std::string oemid);
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -157,7 +157,7 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
 
   std::string sc_ver;
   try {
-    sc_ver = xrt_core::device_query<xrt_core::query::xmc_bmc_version>(device);
+    sc_ver = xrt_core::device_query<xrt_core::query::xmc_sc_version>(device);
   } catch (...) {}
   if(sc_ver.empty())
     sc_ver = info.mBMCVer;

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -83,14 +83,15 @@ get_installed_partitions(std::string interface_uuid)
     // Find the UUID that it exposes for other partitions
     for(unsigned int j = 1; j < installedDSA.uuids.size(); j++){
       //check if the interface UUID is resolution of BLP
-      if(interface_uuid.compare(installedDSA.uuids[j]) == 0)
+      if(interface_uuid.compare(installedDSA.uuids[j]) != 0)
         continue;
       pt_plp.put("interface-uuid", XBU::string_to_UUID(installedDSA.uuids[j]));
     }
     pt_plp.put("file", installedDSA.file);
-    std::cout << std::endl;
 
-    pt_plps.push_back( std::make_pair("", pt_plp) );
+    //if the partition doesn't resolve the passed in BLP, don't add it to the list
+    if(!pt_plp.get<std::string>("interface-uuid", "").empty())
+      pt_plps.push_back( std::make_pair("", pt_plp) );
   }
   return pt_plps;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -639,6 +639,13 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
     std::vector<Flasher> flasher_list;
     for (const auto & dev : deviceCollection) {
+      // Hack: u30 doesn't support factory reset yet
+      if(xrt_core::device_query<xrt_core::query::interface_uuids>(dev).empty()) {
+        std::cout << "****************************************************\n";
+        std::cout << "Factory reset is currently not supported on U30.\n";
+        std::cout << "****************************************************\n\n";
+        return;
+      }
       //collect information of all the cards that will be reset
       Flasher flasher(dev->get_device_id());
       if(!flasher.isValid()) {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -312,7 +312,8 @@ DSAInfo::DSAInfo(const std::string& filename, uint64_t ts, const std::string& id
         }
         // For 2RP platform, only UUIDs are provided
         //timestamp = ap->m_header.m_featureRomTimeStamp;
-        hasFlashImage = (xclbin::get_axlf_section(ap, MCS) != nullptr) || (xclbin::get_axlf_section(ap, PDI) != nullptr);
+        hasFlashImage = (xclbin::get_axlf_section(ap, MCS) != nullptr) || (xclbin::get_axlf_section(ap, PDI) != nullptr) || 
+                            (xclbin::get_axlf_section(ap, ASK_FLASH) != nullptr);
 
         // Find out BMC version
         // Obtain BMC section header.

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -47,7 +47,8 @@ namespace po = boost::program_options;
 #include "tools/common/ReportMemory.h"
 #include "tools/common/ReportThermal.h"
 #include "tools/common/ReportAsyncError.h"
-// #include "tools/common/ReportPlatform.h"
+#include "tools/common/ReportPlatforms.h"
+#include "tools/common/ReportPcieInfo.h"
 
 // Note: Please insert the reports in the order to be displayed (alphabetical)
   static ReportCollection fullReportCollection = {
@@ -58,6 +59,8 @@ namespace po = boost::program_options;
     std::make_shared<ReportCu>(),
     std::make_shared<ReportDebugIpStatus>(),
     std::make_shared<ReportAsyncError>(),
+    std::make_shared<ReportPcieInfo>(),
+    std::make_shared<ReportPlatforms>(),
   // Native only reports
   #ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
     std::make_shared<ReportElectrical>(),

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -614,7 +614,7 @@ auxConnectionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property
   const std::vector<std::string> auxPwrRequiredDevice = { "VCU1525", "U200", "U250", "U280" };
 
   std::string name = xrt_core::device_query<xrt_core::query::xmc_board_name>(_dev);
-  uint64_t max_power = xrt_core::device_query<xrt_core::query::xmc_max_power>(_dev);
+  uint64_t max_power = xrt_core::device_query<xrt_core::query::max_power_level>(_dev);
 
   //check if device has aux power connector
   bool auxDevice = false;
@@ -663,10 +663,10 @@ pcieLinkTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree
 void
 scVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  auto sc_ver = xrt_core::device_query<xrt_core::query::xmc_bmc_version>(_dev);
+  auto sc_ver = xrt_core::device_query<xrt_core::query::xmc_sc_version>(_dev);
   std::string exp_sc_ver = "";
   try{
-    exp_sc_ver = xrt_core::device_query<xrt_core::query::expected_bmc_version>(_dev);
+    exp_sc_ver = xrt_core::device_query<xrt_core::query::expected_sc_version>(_dev);
   } catch(...) {}
 
   if (!exp_sc_ver.empty() && sc_ver.compare(exp_sc_ver) != 0) {
@@ -766,7 +766,7 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 
   std::string msg;
   xclbin_lock xclbin_lock(_dev);
-  XBU::check_p2p_config(_dev, msg);
+  XBU::check_p2p_config(_dev.get(), msg);
 
   if(msg.find("Error") == 0) {
     logger(_ptTest, "Error", msg.substr(msg.find(':')+1));
@@ -993,7 +993,7 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device, boost::proper
   auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
   _ptTree.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
   _ptTree.put("platform", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
-  _ptTree.put("sc_version", xrt_core::device_query<xrt_core::query::xmc_bmc_version>(device));
+  _ptTree.put("sc_version", xrt_core::device_query<xrt_core::query::xmc_sc_version>(device));
   _ptTree.put("platform_id", (boost::format("0x%x") % xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
   if (schemaVersion == Report::SchemaVersion::text) {
     _ostream << boost::format("Validate device[%s]\n") % _ptTree.get<std::string>("device_id");

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -328,6 +328,7 @@ xma_plg_buffer_free(XmaSession s_handle, XmaBufferObj b_obj)
     }
     XmaBufferObjPrivate* b_obj_priv = (XmaBufferObjPrivate*) b_obj.private_do_not_touch;
     //xclDeviceHandle dev_handle = s_handle.hw_session.dev_handle;
+    xclUnmapBO(b_obj_priv->dev_handle, b_obj_priv->boHandle, b_obj.data);
     xclFreeBO(b_obj_priv->dev_handle, b_obj_priv->boHandle);
     b_obj_priv->dummy = nullptr;
     b_obj_priv->size = -1;


### PR DESCRIPTION
### Work done
- Added pcie-info report to xbutil2
- Added platform report to xbutil2
- Block u30 factory-reset in xbmgmt2
- Changed some query names to reflect the new terminologies
- xbmgmt2 examine: printing correct shells and partitions

**CR/XRT tasks:**
- XRT-843 Regression: port all queries to xbutil2 examine
- CR-1085740 U30 cards bricked after running restore to golden

### Sample outputs
**Pcie-info report:**
```
$ xbutil -new examine -r pcie-info
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
-----------------------------------------------
1/1 [0000:b3:00.1] : xilinx_u200_xdma_201830_3
-----------------------------------------------
Pcie Info
  Vendor                 : 0x10ee
  Device                 : 0x5001
  Sub Device             : 0x000e
  Sub Vendor             : 0x10ee
  PCIe                   : Gen3x16
  DMA Thread Count       : 2
  CPU Affinity           : 0-15
  Shared Host Memory     : 0 Bytes
  Max Shared Host Memory : 0 Bytes


$ xbutil -new examine -r pcie-info -f json
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Thu Feb 11 20:48:31 2021 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:b3:00.1",
            "pcie_info": {
                "vendor": "0x10ee",
                "device": "0x5001",
                "sub_device": "0x000e",
                "sub_vendor": "0x10ee",
                "link_speed_gbit_sec": "3",
                "express_lane_width_count": "16",
                "dma_thread_count": "2",
                "cpu_affinity": "0-15",
                "max_shared_host_mem_aperture_bytes": "0"
            }
        }
    ]
}
```

**Platform report:**
```
$ xbutil -new examine -r platform  -f json
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Thu Feb 11 21:26:00 2021 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:b3:00.1",
            "platforms": [
                {
                    "static_region": {
                        "vbnv": "xilinx_u200_xdma_201830_3",
                        "jtag_idcode": "0x14b37093",
                        "fpga_name": "xcu200-fsgd2104-2-e"
                    },
                    "off_chip_board_info": {
                        "ddr_size_bytes": "68719476736",
                        "ddr_count": "4"
                    },
                    "status": {
                        "mig_calibrated": "true",
                        "p2p_status": "disabled"
                    },
                    "controller": {
                        "satellite_controller": {
                            "version": "4.5.0",
                            "expected_version": "4.5.0"
                        },
                        "card_mgmt_controller": {
                            "version": "2019201",
                            "serial_number": "12809621T512",
                            "oem_id": "N\/A"
                        }
                    },
                    "clocks": [
                        {
                            "id": "DATA_CLK",
                            "description": "Data",
                            "freq_mhz": "300"
                        },
                        {
                            "id": "KERNEL_CLK",
                            "description": "Kernel",
                            "freq_mhz": "500"
                        }
                    ]
                }
            ]
        }
    ]
}

$ xbutil -new examine -r platform
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
-----------------------------------------------
1/1 [0000:b3:00.1] : xilinx_u200_xdma_201830_3
-----------------------------------------------
Platform
  XSA Name             : xilinx_u200_xdma_201830_3
  FPGA Name            : xcu200-fsgd2104-2-e
  JTAG ID Code         : 0x14b37093
  DDR Size             : 68719476736 Bytes
  DDR Count            : 4
  Mig Calibrated       : true
  P2P Status           : disabled
Clocks
    Data                 : 300 MHz
    Kernel               : 500 MHz
```