### PR TITLE
- XRT update for XSS

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1481,6 +1481,7 @@ static void xocl_free_sgt_callback(unsigned long cb_hndl, int err)
 	if (cb_func)
 		cb_func((unsigned long)cb_data->orig_data, err);
 
+	kfree(cb_data);
 }
 
 int xocl_sync_bo_callback_ioctl(struct drm_device *dev,
@@ -1606,8 +1607,6 @@ clear:
 	}
 
 out:
-	if (cb_data_alloced)
-		kfree(cb_data);
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -302,7 +302,7 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 
 	if (xcmd->inkern_cb) {
-		int error = (status == ERT_CMD_STATE_COMPLETED)?0:-EFAULT;
+		int error = (status == KDS_COMPLETED)?0:-EFAULT;
 		xcmd->inkern_cb->func((unsigned long)xcmd->inkern_cb->data, error);
 		kfree(xcmd->inkern_cb);
 	} else {


### PR DESCRIPTION
- change in xocl_bo.c file : it is for a XRT crash fix in different block size case.
- change in xocl_kds.c file : It is a typo fix for getting correct error status.