### PR TITLE
CR-1088262: fix grp index issue for use host mem ptr in edge

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -403,13 +403,16 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	struct drm_zocl_userptr_bo *args = data;
 	struct page **pages;
 	unsigned int sg_count;
+	uint32_t user_flags;
+
+	user_flags = args->flags;
 
 	if (offset_in_page(args->addr)) {
 		DRM_ERROR("User ptr not PAGE aligned\n");
 		return -EINVAL;
 	}
 
-	if (args->flags & ZOCL_BO_FLAGS_EXECBUF) {
+	if (user_flags & ZOCL_BO_FLAGS_EXECBUF) {
 		DRM_ERROR("Exec buf could not be a user buffer\n");
 		return -EINVAL;
 	}
@@ -474,6 +477,7 @@ zocl_userptr_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	bo->flags |= ZOCL_BO_FLAGS_USERPTR;
 
+	bo->user_flags = user_flags;
 	zocl_describe(bo);
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&bo->cma_base.base);
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -292,11 +292,11 @@ unsigned int
 shim::
 xclAllocUserPtrBO(void *userptr, size_t size, unsigned flags)
 {
-  (void)flags;
-  drm_zocl_userptr_bo info = {reinterpret_cast<uint64_t>(userptr), size, 0xffffffff, DRM_ZOCL_BO_FLAGS_USERPTR};
+  flags |= DRM_ZOCL_BO_FLAGS_USERPTR;
+  drm_zocl_userptr_bo info = {reinterpret_cast<uint64_t>(userptr), size, 0xffffffff, flags};
   int result = ioctl(mKernelFD, DRM_IOCTL_ZOCL_USERPTR_BO, &info);
 
-  xclLog(XRT_DEBUG, "XRT", "%s: userptr %p size %ld, flags 0x%x", __func__, userptr, size, DRM_ZOCL_BO_FLAGS_USERPTR);
+  xclLog(XRT_DEBUG, "XRT", "%s: userptr %p size %ld, flags 0x%x", __func__, userptr, size, flags);
   xclLog(XRT_INFO, "XRT", "%s: ioctl return %d, bo handle %d", __func__, result, info.handle);
 
   return info.handle;


### PR DESCRIPTION
* Recent changes in XRT userspace is relying on driver to get group/bank index.
* xocl userspace is getting the group/bank index from the flags which are returned by driver.
* xclAllocBO is storing the bo flags and returning them whenever getBOproperties get called.
* xclAllocUserPtrBo is not handling this in edge driver.
* Fix: made changes in xclAllocUserPtrBo also.