### PR TITLE
CR-1087409 Provide IOPS test host code for new validate kernels

### DIFF
--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2021, Xilinx Inc
+ *
+ *  This file is dual licensed.  It may be redistributed and/or modified
+ *  under the terms of the Apache 2.0 License OR version 2 of the GNU
+ *  General Public License.
+ *
+ *  Apache License Verbiage
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  GPL license Verbiage:
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License as
+ *  published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.  This program is
+ *  distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ *  License for more details.  You should have received a copy of the
+ *  GNU General Public License along with this program; if not, write
+ *  to the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+ *  Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef _SHIM_INT_H_
+#define _SHIM_INT_H_
+
+
+/* This file defines internal shim APIs, which is not end user visible.
+ * You cannot include this file without include xrt.h.
+ * This header file should not be published to xrt release include/ folder.
+ */
+#ifdef _XCL_XRT_CORE_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * xclOpenByBDF() - Open a device and obtain its handle by PCI BDF
+ *
+ * @bdf:           Deice PCE BDF
+ * @logFileName:   Log file to use for optional logging
+ * @level:         Severity level of messages to log
+ *
+ * Return:         Device handle
+ */
+XCL_DRIVER_DLLESPEC
+xclDeviceHandle
+xclOpenByBDF(const char *bdf, const char *logFileName,
+        enum xclVerbosityLevel level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#else
+#error "Must include xrt.h before include this file"
+#endif
+
+#endif

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1193,12 +1193,7 @@ int xcldev::device::runTestCase(const std::string& py,
         auto device = pcidev::get_dev(m_idx);
         std::string bdf = boost::str(boost::format("%04x:%02x:%02x.%01x") % device->domain % device->bus % device->dev % device->func);
 
-        // Other new flow test cases are using OpenCL APIs, which can find device by BDF.
-        // If XRT and XCL APIs support open device by BDF, we can unify below two cmds.
-        if (py.find("xrt_iops_test") || py.find("xcl_iops_test"))
-            cmd = xrtTestCasePath + " " + xclbinPath + " -d " + std::to_string(m_idx) + " " + args;
-        else
-            cmd = xrtTestCasePath + " " + xclbinPath + " -d " + bdf;
+        cmd = xrtTestCasePath + " " + xclbinPath + " -d " + bdf + " " + args;
 
     }
     else if (py.find(".exe") == std::string::npos) { //OLD FLOW:
@@ -2323,7 +2318,8 @@ xcldev::device::iopsTest()
 {
     std::string output;
 
-    int ret = runTestCase(std::string("xrt_iops_test.exe"), std::string("verify.xclbin"),
+    //TODO: use xrt_iops_test.exe after XRT API supports construct device by BDF
+    int ret = runTestCase(std::string("xcl_iops_test.exe"), std::string("verify.xclbin"),
                 output, std::string(" -t 1 -l 128 -a 500000"));
 
     if (ret != 0) {

--- a/tests/validate/common/includes/cmdparser/cmdlineparser.cpp
+++ b/tests/validate/common/includes/cmdparser/cmdlineparser.cpp
@@ -110,7 +110,7 @@ bool CmdLineParser::addSwitch(const CmdSwitch &s) {
   if (s.istoggle) {
     cmd.default_value = string("false");
     cmd.value = cmd.default_value;
-    cmd.isvalid = true;
+    cmd.isvalid = false;
   } else {
     cmd.value = cmd.default_value;
     cmd.isvalid = false;

--- a/tests/validate/xcl_iops_test/CMakeLists.txt
+++ b/tests/validate/xcl_iops_test/CMakeLists.txt
@@ -8,7 +8,8 @@ if (NOT DEFINED XRT_VALIDATE_DIR)
 endif()
 
 if (NOT WIN32)
-  add_executable(${TESTNAME} src/xcl_api_iops.cpp)
+  include_directories(../common/includes/cmdparser ../common/includes/logger)
+  add_executable(${TESTNAME} ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/xcl_api_iops.cpp)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
   install(TARGETS ${TESTNAME}
     RUNTIME DESTINATION ${XRT_VALIDATE_DIR})

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <thread>
 
+#include "cmdlineparser.h"
+
 #include "xilutil.hpp"
 #include "xrt.h"
 #include "ert.h"
@@ -30,18 +32,25 @@ typedef struct task_args {
     Clock::time_point end;
 } arg_t;
 
+struct krnl_info {
+    std::string     name;
+    bool            new_style;
+};
+
 bool verbose = false;
 barrier barrier;
+struct krnl_info krnl = {"hello", false};
 
 static void usage(char *prog)
 {
-    std::cout << "Usage: " << prog << " -k <xclbin> -d <dev id> [options]\n"
-              << "options:\n"
-              << "    -t       number of threads\n"
-              << "    -l       length of queue (send how many commands without waiting)\n"
-              << "    -a       total amount of commands per thread\n"
-              << "    -v       verbose result\n"
-              << std::endl;
+  std::cout << "Usage: " << prog << " <Platform Test Area Path> [options]\n"
+            << "options:\n"
+            << "    -d       device BDF\n"
+            << "    -t       number of threads\n"
+            << "    -l       length of queue (send how many commands without waiting)\n"
+            << "    -a       total amount of commands per thread\n"
+            << "    -v       verbose result\n"
+            << std::endl;
 }
 
 static std::vector<char>
@@ -102,6 +111,8 @@ double runTest(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>>& 
 void fillCmdVector(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info>> &cmds,
         int bank, int expected_cmds)
 {
+    int rsz;
+
     for (int i = 0; i < expected_cmds; i++) {
         task_info cmd;
         cmd.boh = xclAllocBO(handle, 20, 0, bank);
@@ -131,12 +142,18 @@ void fillCmdVector(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info
             break;
         }
 
-        int rsz = 19;
+        if (krnl.new_style)
+            /* Old style kernel has 1 argument */
+            rsz = 5;
+        else
+            /* Old style kernel has 7 arguments */
+            rsz = 17;
+
         cmd.ecmd->opcode = ERT_START_CU;
         cmd.ecmd->count = rsz;
         cmd.ecmd->cu_mask = 0x1;
-        cmd.ecmd->data[rsz - 3] = boh_addr;
-        cmd.ecmd->data[rsz - 2] = boh_addr >> 32;
+        cmd.ecmd->data[rsz - 1] = boh_addr;
+        cmd.ecmd->data[rsz] = boh_addr >> 32;
 
         cmds.push_back(std::make_shared<task_info>(cmd));
     }
@@ -304,67 +321,67 @@ int testMultiThreads(int dev_id, std::string &xclbin_fn, int threadNumber, int q
     std::cout << "Overall Commands: " << std::setw(7) << overallCommands
               << std::setprecision(0) << std::fixed
               << " IOPS: " << (overallCommands * 1000000.0 / duration)
+              << " (" << krnl.name << ")"
               << std::endl;
     return 0;
 }
 
 int _main(int argc, char* argv[])
 {
-    if (argc < 3) {
+    if (argc < 2) {
         usage(argv[0]);
-        return 1;
+        throw std::runtime_error("Number of argument should not less than 2");
     }
 
-    std::string xclbin_fn;
-    int dev_id = 0;
-    int queueLength = 128;
-    unsigned total = 50000;
-    int threadNumber = 2;
+    // Command Line Parser
+    sda::utils::CmdLineParser parser;
 
-    std::vector<std::string> args(argv + 1, argv + argc);
-    std::string cur;
-    for (auto& arg : args) {
-        if (arg == "-h") {
-            usage(argv[0]);
-            return 1;
-        }
-        else if (arg == "-v") {
-            verbose = true;
-            continue;
-        }
+    // Switches
+    //**************//"<Full Arg>",  "<Short Arg>", "<Description>", "<Default>"
+    parser.addSwitch("--kernel",  "-k", "kernel (imply old style verify.xclbin is used)", "");
+    parser.addSwitch("--device",  "-d", "device id", "0");
+    parser.addSwitch("--threads", "-t", "number of threads", "2");
+    parser.addSwitch("--length",  "-l", "length of queue", "128");
+    parser.addSwitch("--total",   "-a", "total amount of commands per thread", "50000");
+    parser.addSwitch("--verbose", "-v", "verbose output", "", true);
+    parser.parse(argc, argv);
 
-        if (arg[0] == '-') {
-            cur = arg;
-            continue;
-        }
-
-        if (cur == "-k")
-            xclbin_fn = arg;
-        else if (cur == "-d")
-            dev_id = std::stoi(arg);
-        else if (cur == "-t")
-            threadNumber = std::stoi(arg);
-        else if (cur == "-l")
-            queueLength = std::stoi(arg);
-        else if (cur == "-a")
-            total = std::stoi(arg);
-        else
-            throw std::runtime_error("Unknown option value " + cur + " " + arg);
+    /* Could be BDF or device index */
+    std::string device_str = parser.value("device");
+    int threadNumber = parser.value_to_int("threads");
+    int queueLength = parser.value_to_int("length");
+    int total = parser.value_to_int("total");
+    std::string xclbin_fn = parser.value("kernel");
+    if (xclbin_fn.empty()) {
+        std::string test_path = argv[1];
+        xclbin_fn = test_path + "/verify.xclbin";
+        krnl.name = "verify";
+        krnl.new_style = true;
     }
+    verbose = parser.isValid("verbose");
 
     /* Sanity check */
-    if (dev_id < 0)
-        throw std::runtime_error("Negative device ID");
+    std::ifstream infile(xclbin_fn);
+    if (!infile.good())
+        throw std::runtime_error("Wrong xclbin file " + xclbin_fn);
 
     if (queueLength <= 0)
         throw std::runtime_error("Negative/Zero queue length");
 
+    if (total <= 0)
+        throw std::runtime_error("Negative/Zero total command number");
+
     if (threadNumber <= 0)
         throw std::runtime_error("Invalid thread number");
 
-    //printf("The system has %d device(s)\n", xclProbe());
+    int dev_id = 0;
+    if (device_str.find(":") == std::string::npos) {
+        dev_id = std::stoi(device_str);
+        if (dev_id < 0)
+            throw std::runtime_error("Negative device index");
+    } else
+        throw std::runtime_error("Not support BDF");
 
-    //testSingleThread(dev_id, xclbin_fn);
     testMultiThreads(dev_id, xclbin_fn, threadNumber, queueLength, total);
 
     return 0;
@@ -374,7 +391,7 @@ int main(int argc, char *argv[])
 {
     try {
         _main(argc, argv);
-        return 0;
+        return EXIT_SUCCESS;
     }
     catch (const std::exception& ex) {
         std::cout << "TEST FAILED: " << ex.what() << std::endl;
@@ -383,5 +400,5 @@ int main(int argc, char *argv[])
         std::cout << "TEST FAILED" << std::endl;
     }
 
-    return 1;
+    return EXIT_FAILURE;
 };

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -10,6 +10,8 @@
 
 #include "xilutil.hpp"
 #include "xrt.h"
+/* Get internal shim API "xclOpenByBDF" */
+#include "shim_int.h"
 #include "ert.h"
 #include "xclbin.h"
 
@@ -24,9 +26,9 @@ struct task_info {
 
 typedef struct task_args {
     int thread_id;
-    int dev_id;
     int queueLength;
     unsigned int total;
+    std::string dev_str;
     std::string xclbin_fn;
     Clock::time_point start;
     Clock::time_point end;
@@ -160,74 +162,6 @@ void fillCmdVector(xclDeviceHandle handle, std::vector<std::shared_ptr<task_info
     //std::cout << "Allocated commands, expect " << expected_cmds << ", created " << cmds.size() << std::endl;
 }
 
-int testSingleThread(int dev_id, std::string &xclbin_fn)
-{
-    xclDeviceHandle handle;
-    xuid_t uuid;
-    int bank = 0;
-    std::vector<std::shared_ptr<task_info>> cmds;
-    /* The command would incease */
-    std::vector<unsigned int> cmds_per_run = { 50000,100000,500000,1000000 };
-    /* There is performance and reach maximum FD limited issue */
-    //int expected_cmds = 100000;
-    int expected_cmds = 128;
-    std::vector<arg_t> arg(1);
-
-    handle = xclOpen(dev_id, "", XCL_QUIET);
-    if (!handle) {
-        printf("Could not open device\n");
-        return 1;
-    }
-
-    auto xclbin = load_file_to_memory(xclbin_fn);
-    auto top = reinterpret_cast<const axlf*>(xclbin.data());
-    auto topo = xclbin::get_axlf_section(top, MEM_TOPOLOGY);
-    auto topology = reinterpret_cast<mem_topology*>(xclbin.data() + topo->m_sectionOffset);
-    if (xclLoadXclBin(handle, top))
-        throw std::runtime_error("Bitstream download failed");
-
-    uuid_copy(uuid, top->m_header.uuid);
-
-    for (int i = 0; i < topology->m_count; ++i) {
-        if (topology->m_mem_data[i].m_used) {
-            bank = i;
-            break;
-        }
-    }
-
-    if (xclOpenContext(handle, uuid, 0, true))
-        throw std::runtime_error("Cound not open context");
-
-    /* Create 'expected_cmds' commands if possible */
-    fillCmdVector(handle, cmds, bank, expected_cmds);
-
-    arg[0].thread_id = 0;
-    for (auto& num_cmds : cmds_per_run) {
-#if 0
-        double total = 0;
-        for (int i = 0; i < 5; i++) {
-            total += runTest(handle, cmds, num_cmds);
-        }
-        double duration = total / 5;
-#else
-        double duration = runTest(handle, cmds, num_cmds, arg[0]);
-#endif
-        std::cout << "Commands: " << std::setw(7) << num_cmds
-                  << " IOPS: " << (num_cmds * 1000.0 * 1000.0 / duration)
-                  << std::endl;
-    }
-
-    for (auto& cmd : cmds) {
-        xclFreeBO(handle, cmd->boh);
-        xclUnmapBO(handle, cmd->exec_bo, cmd->ecmd);
-        xclFreeBO(handle, cmd->exec_bo);
-    }
-
-    xclCloseContext(handle, uuid, 0);
-    xclClose(handle);
-    return 0;
-}
-
 void runTestThread(arg_t &arg)
 {
     xclDeviceHandle handle;
@@ -235,7 +169,11 @@ void runTestThread(arg_t &arg)
     int bank = 0;
     std::vector<std::shared_ptr<task_info>> cmds;
 
-    handle = xclOpen(arg.dev_id, "", XCL_QUIET);
+    if (arg.dev_str.find(":") == std::string::npos)
+        handle = xclOpen(std::stoi(arg.dev_str), "", XCL_QUIET);
+    else
+        handle = xclOpenByBDF(arg.dev_str.c_str(), "", XCL_QUIET);
+
     if (!handle)
         throw std::runtime_error("Could not open device");
 
@@ -275,7 +213,7 @@ void runTestThread(arg_t &arg)
     xclCloseContext(handle, uuid, 0);
 }
 
-int testMultiThreads(int dev_id, std::string &xclbin_fn, int threadNumber, int queueLength, unsigned int total)
+int testMultiThreads(std::string &dev, std::string &xclbin_fn, int threadNumber, int queueLength, unsigned int total)
 {
     std::thread threads[threadNumber];
     std::vector<arg_t> arg(threadNumber);
@@ -284,7 +222,7 @@ int testMultiThreads(int dev_id, std::string &xclbin_fn, int threadNumber, int q
 
     for (int i = 0; i < threadNumber; i++) {
         arg[i].thread_id = i;
-        arg[i].dev_id = dev_id;
+        arg[i].dev_str = dev;
         arg[i].queueLength = queueLength;
         arg[i].total = total;
         arg[i].xclbin_fn = xclbin_fn;
@@ -374,15 +312,7 @@ int _main(int argc, char* argv[])
     if (threadNumber <= 0)
         throw std::runtime_error("Invalid thread number");
 
-    int dev_id = 0;
-    if (device_str.find(":") == std::string::npos) {
-        dev_id = std::stoi(device_str);
-        if (dev_id < 0)
-            throw std::runtime_error("Negative device index");
-    } else
-        throw std::runtime_error("Not support BDF");
-
-    testMultiThreads(dev_id, xclbin_fn, threadNumber, queueLength, total);
+    testMultiThreads(device_str, xclbin_fn, threadNumber, queueLength, total);
 
     return 0;
 }

--- a/tests/validate/xrt_iops_test/CMakeLists.txt
+++ b/tests/validate/xrt_iops_test/CMakeLists.txt
@@ -8,7 +8,8 @@ if (NOT DEFINED XRT_VALIDATE_DIR)
 endif()
 
 if (NOT WIN32)
-  add_executable(${TESTNAME} src/xrt_api_iops.cpp)
+  include_directories(../common/includes/cmdparser ../common/includes/logger)
+  add_executable(${TESTNAME} ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/xrt_api_iops.cpp)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
   install(TARGETS ${TESTNAME}
     RUNTIME DESTINATION ${XRT_VALIDATE_DIR})


### PR DESCRIPTION
What are added:
1. Support IOPS test case in new 'xbutil validate' flow.
2. Show CU name at the end of IOPS test result
    - Old flow, kernel name 'hello' and has 7 arguments.
    - New flow, kernel name 'verify' and has 1 argument.
3. Add internal API, xclOpenByBDF();

Test result:
U30
```
$xbutil validate -d 0
...
INFO: == Starting verify kernel test:
INFO: == verify kernel test PASSED
INFO: == Starting IOPS test:
Maximum IOPS: 94838 (verify)
INFO: == IOPS test PASSED
...
```
U50
```
...
INFO: == Starting verify kernel test: 
INFO: == verify kernel test PASSED
INFO: == Starting IOPS test: 
Maximum IOPS: 184314 (hello)
INFO: == IOPS test PASSED
...
```

Hi @vishnuchebrolu, I have one change in cmdlineparser.cpp. In before, for a toggle switch, the default value is true. I thought this is a bug. Please confirm. I have a toggle switch '-v' to turn verbose mode on/off.