### PR TITLE
CR-1087453 xbutil query won't update pcie info

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-bifurcation-reset.c
@@ -204,6 +204,7 @@ static long xclmgmt_hot_reset_post(struct xclmgmt_dev *lro, bool force)
 	xocl_thread_start(lro);
 
 	xocl_clear_pci_errors(lro);
+	store_pcie_link_info(lro);
 
 	if (lro->preload_xclbin)
 		xocl_xclbin_download(lro, lro->preload_xclbin);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -176,6 +176,7 @@ void get_pcie_link_info(struct xclmgmt_dev *lro,
 	unsigned short *width, unsigned short *speed, bool is_cap);
 
 void xclmgmt_connect_notify(struct xclmgmt_dev *lro, bool online);
+void store_pcie_link_info(struct xclmgmt_dev *lro);
 
 /* utils.c */
 int pci_fundamental_reset(struct xclmgmt_dev *lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -369,6 +369,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	xocl_thread_start(lro);
 
 	xocl_clear_pci_errors(lro);
+	store_pcie_link_info(lro);
 	if (xrt_reset_syncup)
 		xocl_set_master_on(lro);
 	else if (!force)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -772,6 +772,8 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 	bool offline = false;
 	int ret = 0;
 
+	store_pcie_link_info(xdev);
+
 	ret = xocl_drvinst_get_offline(xdev->core.drm, &offline);
 	if (ret == -ENODEV || offline) {
 		userpf_info(xdev, "online current devices");


### PR DESCRIPTION
in some cases, the pcie width info will change after a reset
those sysfs node info should be updated after reset