### PR TITLE
NSPR-9558 Reconcile MEM TOPOLOGY for U30/VCK5000

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -25,7 +25,7 @@
 typedef void (*xocl_execbuf_callback)(unsigned long data, int error);
 
 #define IS_HOST_MEM(m_tag)	(!strncmp(m_tag, "HOST[0]", 7))
-#define IS_PLRAM(m_tag)		(!strncmp(m_tag, "PLRAM[0]", 8))
+#define IS_PLRAM(m_tag)		(!strncmp(m_tag, "PLRAM[", 6))
 
 /**
  * struct drm_xocl_exec_metadata - Meta data for exec bo

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -25,6 +25,8 @@
 typedef void (*xocl_execbuf_callback)(unsigned long data, int error);
 
 #define IS_HOST_MEM(m_tag)	(!strncmp(m_tag, "HOST[0]", 7))
+#define IS_PLRAM(m_tag)		(!strncmp(m_tag, "PLRAM[0]", 8))
+
 /**
  * struct drm_xocl_exec_metadata - Meta data for exec bo
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -106,6 +106,7 @@
 #define NODE_INTC_CU_02 "ep_intc_cu_02"
 #define NODE_INTC_CU_03 "ep_intc_cu_03"
 #define NODE_HOSTMEM_BANK0 "ep_c2h_data_00"
+#define NODE_RESERVED_PSMEM "ep_reserved_ps_mem"
 #define NODE_PS_RESET_CTRL "ep_reset_ps_00"
 #define NODE_ICAP_CONTROLLER "ep_iprog_ctrl_00"
 


### PR DESCRIPTION
This PR addresses the following potential problem by comparing mem_topology with reserved_ps_mem in xsabin.

Reserving memory at PS Petalinux device tree is to let Petalinux know the memory region is reserved by PS/PL kernel so that OS won't touch it. But this information is not visible by host XRT driver. Host xocl will relies on information in XCLBIN to allocate memory. So if memory region in XCLBIN does not match reserved memory in PS Petalinux, we will have problem

Host will allocate memory that can not be used by PS/PL kernel that causes PS/PL kernel fail/hang (if there is enough hardware protection to prevent PS/PL kernel accessing illegal memory region)
Serious security issue if there is not enough hardware isolation
1) Crash Petalinux
2) Hacking XCBLIN can allow host application to access any portion of device memory