### PR TITLE
VITIS-750 XRT C++ API for Xclbin meta data extraction

### DIFF
--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -24,26 +24,25 @@
 namespace xrt_core {
 namespace xclbin_int {
 
-/**
- * is_valid_or_error() - Returns the validity of the xrtXclbinHandle handle.
- *
- * @handle:        Xclbin handle
- *
- * Throws if @handle is invalid
- */
+// is_valid_or_error() - Throw if invalid handle
 void
 is_valid_or_error(xrtXclbinHandle handle);
 
-/**
- * get_xclbin_data() - Returns the data of the xrtXclbinHandle handle.
- *
- * @handle:        Xclbin handle
- * Return:         Data of the @handle
- *
- * Throws if @handle is invalid.
- */
-const std::vector<char>&
-get_xclbin_data(xrtXclbinHandle handle);
+// get_axlf() - Retrieve complete axlf from handle
+const axlf*
+get_axlf(xrtXclbinHandle);
+
+// get_xclbin() - Convert handle to object
+xrt::xclbin
+get_xclbin(xrtXclbinHandle);
+
+// get_axlf_section() - Retrieve specified section
+std::pair<const char*, size_t>
+get_axlf_section(const xrt::xclbin& xclbin, axlf_section_kind kind);
+
+// read_xclbin() - Read specified xclbin file 
+std::vector<char>
+read_xclbin(const std::string& fnm);
 
 } //xclbin_int
 }; // xrt_core

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -25,9 +25,14 @@
 #include "core/common/device.h"
 #include "core/common/message.h"
 #include "core/common/query_requests.h"
-#include "core/include/xclbin.h"
 #include "core/common/xclbin_parser.h"
+#include "core/common/xclbin_swemu.h"
+
+#include "core/include/xclbin.h"
+
 #include <fstream>
+#include <set>
+#include <vector>
 
 #ifdef _WIN32
 # include "windows/uuid.h"
@@ -36,126 +41,835 @@
 # include <linux/uuid.h>
 #endif
 
+namespace {
+
+static axlf_section_kind kinds[] = {
+  EMBEDDED_METADATA,
+  AIE_METADATA,
+  IP_LAYOUT,
+  CONNECTIVITY,
+  ASK_GROUP_CONNECTIVITY,
+  ASK_GROUP_TOPOLOGY,
+  MEM_TOPOLOGY,
+  DEBUG_IP_LAYOUT,
+  SYSTEM_METADATA,
+  CLOCK_FREQ_TOPOLOGY,
+  BUILD_METADATA
+};
+
+static bool
+is_sw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
+  return swem;
+}
+
+static std::vector<char>
+read_xclbin(const std::string& fnm)
+{
+  if (fnm.empty())
+    throw std::runtime_error("No xclbin specified");
+
+  // load the file
+  std::ifstream stream(fnm);
+  if (!stream)
+    throw std::runtime_error("Failed to open file '" + fnm + "' for reading");
+
+  stream.seekg(0, stream.end);
+  size_t size = stream.tellg();
+  stream.seekg(0, stream.beg);
+
+  std::vector<char> header(size);
+  stream.read(header.data(), size);
+  return header;
+}
+
+static std::vector<char>
+copy_axlf(const axlf* top)
+{
+  auto size = top->m_header.m_length;
+  std::vector<char> header(size);
+  auto data = reinterpret_cast<const char*>(top);
+  std::copy(data, data + size, header.begin());
+  return header;
+}
+
+}
+
 namespace xrt {
 
-// class xclbin_impl - class for xclbin objects
+// class mem_impl - wrap xclbin mem_data entry
+// Loosely MEM_TOPOLOGY
 //
-// Life time of xclbin are managed through shared pointers.
-// A buffer is freed when last references is released.
+// An xclbin::mem object wraps a mem_data entry from GROUP_TOPOLOGY
+// section in xclbin.  Multiple mem_data entries are referenced from
+// xclbin::arg objects to represent the memory connections associated
+// with a specific ip argument.
+class xclbin::mem_impl
+{
+public: // purposely not a struct to match decl
+  const ::mem_data* m_mem;
+  int32_t m_mem_data_idx;
+
+public:
+  mem_impl(const ::mem_data* mem, int32_t idx)
+    : m_mem(mem), m_mem_data_idx(idx)
+  {}
+};
+
+// class arg_impl - connectivity for an IP argument
+//
+// An xclbin::arg object contains a set of xclbin::mem objects that
+// represent the memory bank or streaming connection of the IP. The
+// object is contructed from the CONNECTIVITY section of the xclbin
+// when the xclbin::ip is constructed.
+//
+// If the argument is associated with a kernel compute unit, then
+// the created object is annotated with kernel argument meta data
+// which is size, offset, type, etc.
+class xclbin::arg_impl
+{
+public: // purposely not a struct to match decl in xrt_xclbin.h
+  std::set<xclbin::mem> m_mems;
+  const xrt_core::xclbin::kernel_argument* m_arginfo = nullptr;
+
+public:
+  arg_impl()
+  {}
+
+  void
+  add_arg(const arg_impl* rhs)
+  {
+    m_mems.insert(rhs->m_mems.begin(), rhs->m_mems.end());
+  }
+
+  void
+  add_mem(const xclbin::mem& mem)
+  {
+    m_mems.insert(mem);
+  }
+
+  void
+  add_arginfo(const xrt_core::xclbin::kernel_argument* arginfo)
+  {
+    m_arginfo = arginfo;
+  }
+};
+
+// class ip_impl - wrap xclbin ip_data entry
+// Loosely IP_LAYOUT
+//  
+// An xclbin::ip wraps an ip_data entry from the xclbin along
+// with connectivity data represeted as xclbin::arg objects.
+class xclbin::ip_impl
+{
+public: // purposely not a struct to match decl in xrt_xclbin.h
+  const ::ip_data* m_ip;            // 
+  int32_t m_ip_layout_idx;          // index in IP_LAYOUT seciton
+  std::vector<xclbin::arg> m_args;  // index by argument index
+
+  void
+  resize_args(size_t size)
+  {
+    if (m_args.size() < size)
+      m_args.resize(size);
+  }
+
+  void
+  add_mem_at_idx(int32_t argidx, const xclbin::mem& mem)
+  {
+    resize_args(argidx + 1);
+    if (!m_args[argidx])
+      m_args[argidx] = xclbin::arg{std::make_shared<arg_impl>()};
+    m_args[argidx].get_handle()->add_mem(mem);
+  }
+
+public:
+  ip_impl(const ::connectivity* conn,
+          const std::vector<xclbin::mem>& mems,
+          const ::ip_data* ip, int32_t ipidx)
+    : m_ip(ip), m_ip_layout_idx(ipidx)
+  {
+    if (!conn)
+      return;
+
+    for (int32_t idx = 0; idx < conn->m_count; ++idx) {
+        auto& cxn = conn->m_connection[idx];
+        if (cxn.m_ip_layout_index != m_ip_layout_idx)
+          continue;
+
+        add_mem_at_idx(cxn.arg_index, mems.at(cxn.mem_data_index));
+    }
+  }
+
+  arg
+  create_arg_if_new(int32_t argidx)
+  {
+    resize_args(argidx + 1);
+    if (!m_args[argidx])
+      m_args[argidx] = xclbin::arg{std::make_shared<arg_impl>()};
+    return m_args[argidx];
+  }
+
+};
+
+// class kernel_impl - wrap xclbin XML kernel entry
+//  
+// The xclbin::kernel groups already constructed xclbin::ip objects
+// and stores xclbin::arg objects represeting each kernel argument. An
+// xclbin::arg object is a collection of memory connections and the
+// xclbin::arg object for a given kernel argument is constructed as
+// the union of the union of all the connections used by the compute
+// units grouped by the kernel.  The xclbin::arg objects are annotated
+// with the kernel argument meta data.
+class xclbin::kernel_impl
+{
+public: // purposely not a struct to match decl in xrt_xclbin.h
+  std::string m_name;
+  std::vector<xclbin::ip> m_cus;
+  std::vector<xclbin::arg> m_args;
+  std::vector<xrt_core::xclbin::kernel_argument> m_arginfo;
+  
+public:
+  kernel_impl(std::string&& nm,
+              std::vector<xclbin::ip>&& cus,
+              std::vector<xrt_core::xclbin::kernel_argument>&& arguments)
+    : m_name(std::move(nm)), m_cus(std::move(cus)), m_arginfo(std::move(arguments))
+  {
+    // For each kernel argument create an xclbin::arg which is the union
+    // of all memory connections used by compute units at this argument
+    for (size_t argidx = 0; argidx < m_arginfo.size(); ++argidx) {
+      const auto& karginfo = m_arginfo[argidx];
+
+      // OpenCL rtinfo argument
+      if (karginfo.index == xrt_core::xclbin::kernel_argument::no_index) 
+        continue;
+
+      // Sanity check
+      if (karginfo.index != argidx)
+        throw std::runtime_error("internal error: argidx mismatch");
+
+      // Create kernel argument for argidx
+      auto kargimpl = std::make_shared<arg_impl>();
+
+      // Populate argument with union of compute units arguments at argidx
+      for (const auto& cu : m_cus) {
+        auto cuimpl = cu.get_handle();
+        // get cu argument at argidx, create if necessary when
+        // argument at index is a scalar not part of connectivity
+        auto cuarg = cuimpl->create_arg_if_new(argidx);  // xclbin::arg
+        auto cuargimpl = cuarg.get_handle();        // arg_impl
+
+        // annotate cuarg with argument info
+        cuargimpl->add_arginfo(&m_arginfo.at(argidx));
+
+        // append cuarg to kernel arg annotate with argument info
+        kargimpl->add_arg(cuargimpl.get());
+        kargimpl->add_arginfo(&m_arginfo.at(argidx));
+      }
+      m_args.emplace_back(std::move(kargimpl));
+    }
+  }
+};
+
+// class xclbin_impl - Base class for xclbin objects
 class xclbin_impl
 {
-protected:
-  std::vector<char> m_axlf;
-  const axlf* m_top;
+  // struct xclbin_info - on demand xclbin meta data access
+  //
+  // Constructed first time data is needed, which in many cases it
+  // never is.  The class keeps xclbin::mem, xclbin::ip, and
+  // xclbin::kernel objects along with references into the xclbin
+  // data itself
+  struct xclbin_info
+  {
+    const xclbin_impl* m_ximpl;
+    std::vector<xclbin::mem> m_mems;
+    std::vector<xclbin::ip> m_ips;
+    std::vector<xclbin::kernel> m_kernels;
+    std::string m_xsa_name;
 
-  void init_axlf_handle()
+    // kernel_cu_to_ip() - convert ::ip_data entry to xclbin::ip object
+    //
+    // Kernels are composed of compute units, which are represented as
+    // xclbin::ip objects.  In the xclbin, kernel compute units are
+    // collected from IP_LAYOUT through name matching.  Since
+    // IP_LAYOUT is processed before xclbin::kernels are created, the
+    // collected ip_data elements for the compute units already exist
+    // in m_ips.
+    //
+    // This function iterates m_ips to look for the xclbin::ip object
+    // corresponding to the ip_data element.  The lookup is O(n) which
+    // makes the overall algorithm for converting kernel CUs O(n^2)
+    // but efficiency doesn't matter here.
+    xclbin::ip
+    kernel_cu_to_ip(const ::ip_data* cu)
+    {
+      for (auto& ip : m_ips)
+        if (ip.get_name() == reinterpret_cast<const char*>(cu->m_name))
+          return ip;
+      throw std::runtime_error("unexpected error, kernel cu doesn't exist");
+    }
+
+    // kernel_cus_to_ips() - convert list of ::ip_data to xclbin::ip objects
+    //
+    // Convert ip_data elements associated with kernel object into
+    // already constructed and cached xclbin::ip objects.  O(n^2) yes,
+    // but not important.
+    std::vector<xclbin::ip>
+    kernel_cus_to_ips(const std::vector<const ::ip_data*>& cus)
+    {
+      std::vector<xclbin::ip> ips;
+      for (auto cu : cus)
+        ips.emplace_back(kernel_cu_to_ip(cu));
+      return ips;
+    }
+
+    // init_mems() - populate m_mems with xrt::mem objects
+    //
+    // Iterate the GROUP_TOPOLOGY section in xclbin and create
+    // xclbin::mem objects for each used mem_data entry.
+    void
+    init_mems()
+    {
+      if (auto mem_topology = m_ximpl->get_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY)) {
+        m_mems.reserve(mem_topology->m_count);
+        for (int32_t idx = 0; idx < mem_topology->m_count; ++idx) {
+          m_mems.emplace_back
+            (std::make_shared<xclbin::mem_impl>(mem_topology->m_mem_data + idx, idx));
+        }
+      }
+    }
+
+    // init_ips() - populate m_ips with xclbin::ip objects
+    //
+    // Iterate the IP_LAYOUT section in the xclbin and create
+    // xclbin::ip objects of each ip_data entry. Note, that xclbin::ip
+    // objects construction also creates xclbin::arg objects based on
+    // CONNECTIVITY information from the xclbin.  
+    //
+    // A pre-condition for this function is that init_mems() must have
+    // been called.
+    void
+    init_ips()
+    {
+      auto ip_layout = m_ximpl->get_section<const ::ip_layout*>(IP_LAYOUT);
+      if (!ip_layout)
+        return;
+      
+      auto conn = m_ximpl->get_section<const ::connectivity*>(ASK_GROUP_CONNECTIVITY);
+
+      m_ips.reserve(ip_layout->m_count);
+      for (int32_t idx = 0; idx < ip_layout->m_count; ++idx)
+        m_ips.emplace_back
+          (std::make_shared<xclbin::ip_impl>
+           (conn, m_mems, ip_layout->m_ip_data + idx, idx));
+    }
+
+    // init_kernels() - populate m_kernels with xclbin::kernel objects
+    //
+    // Iterate the XML meta data section and collect kernel meta data along
+    // with compute units grouped by the kernel.
+    //
+    // Pre-condition for this function is that init_mems() and init_ips()
+    // have been called.
+    void
+    init_kernels()
+    {
+      auto xml = m_ximpl->get_axlf_section(EMBEDDED_METADATA);
+      if (!xml.first)
+        return;
+
+      auto ip_layout = m_ximpl->get_section_or_error<const ::ip_layout*>(IP_LAYOUT);
+
+      for (auto& kernel : xrt_core::xclbin::get_kernels(xml.first, xml.second)) {
+        auto cus = xrt_core::xclbin::get_cus(ip_layout, kernel.name);  // ip_data*
+        auto ips = kernel_cus_to_ips(cus);                             // xrt::xclbin::ip
+        m_kernels.emplace_back
+          (std::make_shared<xclbin::kernel_impl>
+           (std::move(kernel.name), std::move(ips), std::move(kernel.args)));
+      }
+    }
+
+    // xclbin_info() - constructor for xclbin meta data
+    xclbin_info(const xrt::xclbin_impl* impl)
+      : m_ximpl(impl)
+      , m_xsa_name("todo")
+    {
+      init_mems();     // must be first
+      init_ips();      // must be before kernels
+      init_kernels();
+    }
+  };
+  
+  // cache of meta data extracted from xclbin
+  mutable std::unique_ptr<xclbin_info> m_info;
+
+  const xclbin_info*
+  get_xclbin_info() const
+  {
+    if (!m_info)
+      m_info = std::make_unique<xclbin_info>(this);
+    return m_info.get();
+  }
+
+public:
+  virtual
+  ~xclbin_impl() = default;
+
+  virtual
+  std::pair<const char*, size_t>
+  get_axlf_section(axlf_section_kind section) const = 0;
+
+  virtual
+  const std::vector<char>&
+  get_data() const
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  virtual
+  const axlf*
+  get_axlf() const
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  virtual
+  uuid
+  get_uuid() const
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  template <typename SectionType>
+  SectionType
+  get_section(axlf_section_kind kind) const
+  {
+    return reinterpret_cast<SectionType>(get_axlf_section(kind).first);
+  }
+  
+  template <typename SectionType>
+  SectionType
+  get_section_or_error(axlf_section_kind kind) const
+  {
+    auto section = reinterpret_cast<SectionType>(get_axlf_section(kind).first);
+    if (!section)
+      throw std::runtime_error("Request xclbin section " + std::to_string(kind) + " does not exist");
+    return section;
+  }
+
+  std::vector<xclbin::kernel>
+  get_kernels() const
+  {
+    return get_xclbin_info()->m_kernels;
+  }
+
+  xclbin::kernel
+  get_kernel(const std::string& nm) const
+  {
+    for (auto& kernel : get_xclbin_info()->m_kernels)
+      if (kernel.get_name() == nm)
+        return kernel;
+
+    return xclbin::kernel{};
+  }
+
+  std::vector<xclbin::ip>
+  get_ips() const
+  {
+    return get_xclbin_info()->m_ips;
+  }
+
+  xclbin::ip
+  get_ip(const std::string& nm) const
+  {
+    for (auto& ip : get_xclbin_info()->m_ips)
+      if (ip.get_name() == nm)
+        return ip;
+
+    return xclbin::ip{};
+  }
+  
+  std::vector<xclbin::mem>
+  get_mems() const
+  {
+    return get_xclbin_info()->m_mems;
+  }
+
+  std::string
+  get_xsa_name() const
+  {
+    return get_xclbin_info()->m_xsa_name;
+  }
+};
+
+// class xclbin_full - Implementation of full xclbin
+//
+// A full xclbin is constructed from a file on disk or from a complete
+// binary images for file content
+class xclbin_full : public xclbin_impl
+{
+  std::vector<char> m_axlf;  // complete copy of xclbin raw data
+  const axlf* m_top;
+  uuid m_uuid;
+  std::map<axlf_section_kind, std::vector<char>> m_axlf_sections;
+
+  void
+  init_axlf()
   {
     const axlf* tmp = reinterpret_cast<const axlf*>(m_axlf.data());
     if (strncmp(tmp->m_magic, "xclbin2", 7)) // Future: Do not hardcode "xclbin2"
       throw std::runtime_error("Invalid xclbin");
     m_top = tmp;
-  }
 
+    m_uuid = uuid(m_top->m_header.uuid); 
+    
+    const ::ip_layout* ip_layout = nullptr;
+
+    for (auto kind : kinds) {
+      auto hdr = xrt_core::xclbin::get_axlf_section(m_top, kind);
+
+      // software emulation xclbin does not have all sections
+      // create the necessary ones.  important that ip_layout is
+      // before connectivity which needs ip_layout
+      if (!hdr && is_sw_emulation()) {
+        auto data = xrt_core::xclbin::swemu::get_axlf_section(m_top, ip_layout, kind);
+        if (!data.empty()) {
+          auto pos = m_axlf_sections.emplace(kind, std::move(data));
+          if (kind == IP_LAYOUT)
+            ip_layout = reinterpret_cast<const ::ip_layout*>((pos.first)->second.data());
+        }
+      }
+
+      if (!hdr)
+        continue;
+
+      auto section_data = reinterpret_cast<const char*>(m_top) + hdr->m_sectionOffset;
+      std::vector<char> data{section_data, section_data + hdr->m_sectionSize};
+      m_axlf_sections.emplace(kind , std::move(data));
+    }
+  }
+  
 public:
-  xclbin_impl(const std::vector<char>& data)
+  explicit
+  xclbin_full(const std::string& filename)
+    : m_axlf(read_xclbin(filename))
   {
-    m_axlf = data;
-    // Set pointer of type axlf*, and check magic string
-    init_axlf_handle();
+    init_axlf();
   }
 
-  xclbin_impl(const std::string& filename)
+  explicit
+  xclbin_full(std::vector<char> data)
+    : m_axlf(std::move(data))
   {
-    if (filename.empty())
-      throw std::runtime_error("No XCLBIN specified");
-
-    // Load the file into data
-    std::ifstream stream(filename);
-    stream.seekg(0, stream.end);
-    size_t size = stream.tellg();
-    stream.seekg(0, stream.beg);
-    m_axlf.resize(size);
-    stream.read(m_axlf.data(), size);
-
-    // Set pointer of type axlf*, and check magic string
-    init_axlf_handle();
+    init_axlf();
   }
 
-  std::vector<std::string>
-  get_cu_names() const
+  explicit
+  xclbin_full(const axlf* top)
+    : m_axlf(copy_axlf(top))
   {
-    std::vector<std::string> names;
-    for (auto cu : xrt_core::xclbin::get_cus(m_top))
-      names.push_back(xrt_core::xclbin::get_ip_name(m_top, cu));
-
-    return names;
+    init_axlf();
   }
 
-  // TODO - Check that m_header is present in data buffer
-  std::string
-  get_xsa_name() const
-  {
-    auto vbnv = reinterpret_cast<const char*>(m_top->m_header.m_platformVBNV);
-    return {vbnv, strnlen(vbnv, 64)};
-  }
-
-  // TODO - Check that m_header is present in data buffer
+  virtual
   uuid
   get_uuid() const
   {
-    return m_top->m_header.uuid;
+    return m_uuid;
   }
 
-  const std::vector<char>&
-  get_data() const
+  virtual
+  std::pair<const char*, size_t>
+  get_axlf_section(axlf_section_kind kind) const
   {
-    return m_axlf;
+    auto itr = m_axlf_sections.find(kind);
+    return itr != m_axlf_sections.end()
+      ? std::make_pair((*itr).second.data(), (*itr).second.size())
+      : std::make_pair(nullptr, size_t(0));
+  }
+
+  virtual const axlf*
+  get_axlf() const
+  {
+    return m_top;
   }
 };
-
-} //namespace
+  
+} // xrt
 
 ////////////////////////////////////////////////////////////////
 // xrt_xclbin C++ API implementations (xrt_xclbin.h)
 ////////////////////////////////////////////////////////////////
 namespace xrt {
 
+////////////////////////////////////////////////////////////////
+// xrt::xclbin
+////////////////////////////////////////////////////////////////
 xclbin::
 xclbin(const std::string& filename)
-  : handle(std::make_shared<xclbin_impl>(filename))
+  : detail::pimpl<xclbin_impl>(std::make_shared<xclbin_full>(filename))
 {}
 
 xclbin::
 xclbin(const std::vector<char>& data)
-  : handle(std::make_shared<xclbin_impl>(data))
+  : detail::pimpl<xclbin_impl>(std::make_shared<xclbin_full>(data))
 {}
 
-std::vector<std::string>
 xclbin::
-get_cu_names() const
+xclbin(const axlf* top)
+  : detail::pimpl<xclbin_impl>(std::make_shared<xclbin_full>(top))
+{}
+
+std::vector<xclbin::kernel>
+xclbin::
+get_kernels() const
 {
-  return handle->get_cu_names();
+  return handle ? handle->get_kernels() : std::vector<xclbin::kernel>{};
+}
+
+xclbin::kernel
+xclbin::
+get_kernel(const std::string& name) const
+{
+  return handle ? handle->get_kernel(name) : xclbin::kernel{};
+}
+
+std::vector<xclbin::ip>
+xclbin::
+get_ips() const
+{
+  return handle ? handle->get_ips() : std::vector<xclbin::ip>{};
+}
+  
+xclbin::ip
+xclbin::
+get_ip(const std::string& name) const
+{
+  return handle ? handle->get_ip(name) : xclbin::ip{};
 }
 
 std::string
 xclbin::
 get_xsa_name() const
 {
-  return handle->get_xsa_name();
+  return handle ? handle->get_xsa_name() : "";
 }
 
 uuid
 xclbin::
 get_uuid() const
 {
-  return handle->get_uuid();
+  return handle ? handle->get_uuid() : uuid{};
 }
 
-const std::vector<char>&
+const axlf*
 xclbin::
-get_data() const
+get_axlf() const
 {
-  return handle->get_data();
+  return handle ? handle->get_axlf() : nullptr;
+}
+
+////////////////////////////////////////////////////////////////
+// xrt::xclbin::kernel
+////////////////////////////////////////////////////////////////
+std::string
+xclbin::kernel::
+get_name() const
+{
+  return handle ? handle->m_name : "";
+}
+
+std::vector<xclbin::ip>
+xclbin::kernel::
+get_cus() const
+{
+  return handle ? handle->m_cus : std::vector<xclbin::ip>{};
+}
+
+xclbin::ip
+xclbin::kernel::
+get_cu(const std::string& nm) const
+{
+  if (!handle)
+    return {};
+  
+  auto itr = std::find_if(handle->m_cus.begin(), handle->m_cus.end(),
+                          [&nm](const auto& cu) {
+                           return cu.get_name() == nm;
+                         });
+
+  return (itr != handle->m_cus.end())
+    ? (*itr)
+    : xclbin::ip{};
+}
+
+size_t
+xclbin::kernel::
+get_num_args() const
+{
+  return handle ? handle->m_args.size() : 0;
+}
+
+std::vector<xclbin::arg>
+xclbin::kernel::
+get_args() const
+{
+  return handle ? handle->m_args : std::vector<xclbin::arg>{};
+}
+
+xclbin::arg
+xclbin::kernel::
+get_arg(int32_t index) const
+{
+  return handle ? handle->m_args.at(index) : xclbin::arg{};
+}
+////////////////////////////////////////////////////////////////
+// xrt::xclbin::ip
+////////////////////////////////////////////////////////////////
+std::string
+xclbin::ip::
+get_name() const
+{
+  return handle ? reinterpret_cast<const char*>(handle->m_ip->m_name) : "";
+}
+
+size_t
+xclbin::ip::
+get_num_args() const
+{
+  return handle ? handle->m_args.size() : 0;
+}
+
+std::vector<xclbin::arg>
+xclbin::ip::
+get_args() const
+{
+  return handle ? handle->m_args : std::vector<xclbin::arg>{};
+}
+
+xclbin::arg
+xclbin::ip::
+get_arg(int32_t index) const
+{
+  return handle ? handle->m_args.at(index) : xclbin::arg{};
+}
+
+uint64_t
+xclbin::ip::
+get_base_address() const
+{
+  return handle ? handle->m_ip->m_base_address : std::numeric_limits<uint64_t>::max();
+}
+
+////////////////////////////////////////////////////////////////
+// xrt::xclbin::arg
+////////////////////////////////////////////////////////////////
+std::string
+xclbin::arg::
+get_name() const
+{
+  if (!handle || !handle->m_arginfo)
+    return "";
+
+  return handle->m_arginfo->name;
+}
+
+std::vector<xclbin::mem>
+xclbin::arg::
+get_mems() const
+{
+  return handle
+    ? std::vector<xclbin::mem>{handle->m_mems.begin(), handle->m_mems.end()}
+    : std::vector<xclbin::mem>{};
+}
+
+std::string
+xclbin::arg::
+get_port() const
+{
+  return handle && handle->m_arginfo ? handle->m_arginfo->port : 0;
+}
+
+uint64_t
+xclbin::arg::
+get_size() const
+{
+  return handle && handle->m_arginfo ? handle->m_arginfo->size : 0;
+}
+
+uint64_t
+xclbin::arg::
+get_offset() const
+{
+  return handle && handle->m_arginfo ? handle->m_arginfo->offset : std::numeric_limits<uint64_t>::max();
+}
+
+std::string
+xclbin::arg::
+get_host_type() const
+{
+  return handle && handle->m_arginfo ? handle->m_arginfo->hosttype : "<type>";
+}
+////////////////////////////////////////////////////////////////
+// xrt::xclbin::mem
+////////////////////////////////////////////////////////////////
+std::string
+xclbin::mem::
+get_tag() const
+{
+  return handle ? reinterpret_cast<const char*>(handle->m_mem->m_tag) : "";
+}
+
+uint64_t  
+xclbin::mem::
+get_base_address() const
+{
+  if (!handle)
+    return std::numeric_limits<uint64_t>::max();
+
+  auto type = get_type();
+  if (type == memory_type::streaming || type == memory_type::streaming_connection)
+    return std::numeric_limits<uint64_t>::max();
+
+  return handle->m_mem->m_base_address;
+}
+  
+uint64_t  
+xclbin::mem::
+get_size_kb() const
+{
+  if (!handle)
+    return 0;
+
+  auto type = get_type();
+  if (type == memory_type::streaming || type == memory_type::streaming_connection)
+    return 0;
+
+  return handle->m_mem->m_size;
+}
+
+bool  
+xclbin::mem::
+get_used() const
+{
+  return handle ? handle->m_mem->m_used : false;
+}
+
+xclbin::mem::memory_type
+xclbin::mem::
+get_type() const
+{
+  return handle ? static_cast<memory_type>(handle->m_mem->m_type) : static_cast<memory_type>(-1);
+}
+
+int32_t
+xclbin::mem::
+get_index() const
+{
+  return handle ? handle->m_mem_data_idx : std::numeric_limits<int32_t>::max();
 }
 
 } // namespace xrt
@@ -208,10 +922,29 @@ is_valid_or_error(xrtXclbinHandle handle)
     throw xrt_core::error(-EINVAL, "Invalid xclbin handle");
 }
 
-const std::vector<char>&
-get_xclbin_data(xrtXclbinHandle handle)
+const axlf*
+get_axlf(xrtXclbinHandle handle)
 {
-  return get_xclbin(handle)->get_data();
+  auto xclbin = get_xclbin(handle);
+  return xclbin->get_axlf();
+}
+
+xrt::xclbin
+get_xclbin(xrtXclbinHandle handle)
+{
+  return ::get_xclbin(handle);
+}
+
+std::pair<const char*, size_t>
+get_axlf_section(const xrt::xclbin& xclbin, axlf_section_kind kind)
+{
+  return xclbin.get_handle()->get_axlf_section(kind);
+}
+
+std::vector<char>
+read_xclbin(const std::string& fnm)
+{
+  return ::read_xclbin(fnm);
 }
 
 }} // namespace xclbin_int, core_core
@@ -223,7 +956,7 @@ xrtXclbinHandle
 xrtXclbinAllocFilename(const char* filename)
 {
   try {
-    auto xclbin = std::make_shared<xrt::xclbin_impl>(filename);
+    auto xclbin = std::make_shared<xrt::xclbin_full>(filename);
     auto handle = xclbin.get();
     xclbins.emplace(handle, std::move(xclbin));
     return handle;
@@ -244,7 +977,7 @@ xrtXclbinAllocRawData(const char* data, int size)
 {
   try {
     std::vector<char> raw_data(data, data + size);
-    auto xclbin = std::make_shared<xrt::xclbin_impl>(raw_data);
+    auto xclbin = std::make_shared<xrt::xclbin_full>(raw_data);
     auto handle = xclbin.get();
     xclbins.emplace(handle, std::move(xclbin));
     return handle;
@@ -277,41 +1010,6 @@ xrtXclbinFreeHandle(xrtXclbinHandle handle)
   }
 }
 
-#if 0
-// TODO
-// Need a new interface for the C API
-int
-xrtXclbinGetCUNames(xrtXclbinHandle handle, char** names, int* numNames)
-{
-  try {
-    auto xclbin = get_xclbin(handle);
-    const std::vector<std::string> cuNames = xclbin->get_cu_names();
-    // populate numNames if memory is allocated
-    if (numNames)
-      *numNames = cuNames.size();
-    // populate names if memory is allocated
-    if (names) {
-      auto index = 0;
-      for (auto&& name: cuNames) {
-        std::strcpy(names[index++], name.c_str());
-      }
-    }
-    return 0;
-  }
-  catch (const xrt_core::error& ex) {
-    xrt_core::send_exception_message(ex.what());
-    // Set errno globally
-    errno = ex.get();
-    return ex.get();
-  }
-  catch (const std::exception& ex) {
-    send_exception_message(ex.what());
-    // Set errno globally
-    errno = 0;
-    return 0;
-  }
-}
-#endif
 
 int
 xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2019 Xilinx, Inc
+/*
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -97,7 +97,7 @@ struct ishim
   exec_wait(int timeout_ms) const = 0;
 
   virtual void
-  load_xclbin(const struct axlf*) = 0;
+  load_axlf(const axlf*) = 0;
 
   virtual void
   reclock(const uint16_t* target_freq_mhz) = 0;
@@ -338,7 +338,7 @@ struct shim : public DeviceType
   }
 
   virtual void
-  load_xclbin(const struct axlf* buffer)
+  load_axlf(const axlf* buffer)
   {
     if (auto ret = xclLoadXclBin(DeviceType::get_device_handle(), buffer))
       throw error(ret, "failed to load xclbin");

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2019-2020 Xilinx, Inc
+/*
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -618,6 +618,8 @@ get_kernel_arguments(const char* xml_data, size_t xml_size, const std::string& k
       args.emplace_back(kernel_argument{
           xml_arg.second.get<std::string>("<xmlattr>.name")
          ,xml_arg.second.get<std::string>("<xmlattr>.type", "no-type")
+
+            ,xml_arg.second.get<std::string>("<xmlattr>.port", "no-port")
          ,index
          ,convert(xml_arg.second.get<std::string>("<xmlattr>.offset"))
          ,convert(xml_arg.second.get<std::string>("<xmlattr>.size"))
@@ -664,20 +666,24 @@ get_kernel_arguments(const axlf* top, const std::string& kname)
 }
 
 std::vector<kernel_object>
-get_kernels(const axlf* top)
+get_kernels(const char* xml_data, size_t xml_size)
 {
-  auto xml = get_xml_section(top);
   std::vector<kernel_object> kernels;
 
-  auto knames = get_kernel_names(xml.first, xml.second);
-  for (auto& kname : knames) {
-    kernels.emplace_back(kernel_object{
-       kname
-      ,get_kernel_arguments(xml.first, xml.second, kname)
-    });
+  auto knames = get_kernel_names(xml_data, xml_size);
+  for (auto& kname : get_kernel_names(xml_data, xml_size)) {
+    kernels.emplace_back
+      (kernel_object{kname,get_kernel_arguments(xml_data, xml_size, kname)});
   }
 
   return kernels;
+}
+
+std::vector<kernel_object>
+get_kernels(const axlf* top)
+{
+  auto xml = get_xml_section(top);
+  return get_kernels(xml.first, xml.second);
 }
 
 // PDI only XCLBIN has PDI section only;

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,6 +36,7 @@ struct kernel_argument
 
   std::string name;
   std::string hosttype;
+  std::string port;
   size_t index = no_index;
   size_t offset = 0;
   size_t size = 0;
@@ -47,8 +48,8 @@ struct kernel_argument
 
 struct kernel_object
 {
-    std::string name;
-    std::vector<kernel_argument> args;
+  std::string name;
+  std::vector<kernel_argument> args;
 };
 
 /**
@@ -265,6 +266,15 @@ get_kernel_arguments(const char* xml_data, size_t xml_size, const std::string& k
 XRT_CORE_COMMON_EXPORT
 std::vector<kernel_argument>
 get_kernel_arguments(const axlf* top, const std::string& kname);
+
+/**
+ * get_kernels() - Get meta data for all kernels
+ *
+ * Return: List of struct kernel_object
+ */
+XRT_CORE_COMMON_EXPORT
+std::vector<kernel_object>
+get_kernels(const char* xml_data, size_t xml_size);
 
 /**
  * get_kernels() - Get meta data for all kernels

--- a/src/runtime_src/core/common/xclbin_swemu.cpp
+++ b/src/runtime_src/core/common/xclbin_swemu.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -208,5 +208,22 @@ get_axlf_section(const device* device, const axlf* top, axlf_section_kind kind)
   }
 }
 
+std::vector<char>
+get_axlf_section(const axlf* top, const ::ip_layout* ip_layout, axlf_section_kind kind)
+{
+
+  switch (kind) {
+  case MEM_TOPOLOGY:
+  case ASK_GROUP_TOPOLOGY:
+    return get_mem_topology(top);
+  case CONNECTIVITY:
+  case ASK_GROUP_CONNECTIVITY:
+    return get_connectivity(top, ip_layout);
+  case IP_LAYOUT:
+    return get_ip_layout(top);
+  default:
+    return {};
+  }
+}
 
 }}} // swemu, xclbin, xrt_core

--- a/src/runtime_src/core/common/xclbin_swemu.h
+++ b/src/runtime_src/core/common/xclbin_swemu.h
@@ -1,5 +1,5 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
+/*
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -27,5 +27,12 @@ namespace xrt_core { namespace xclbin { namespace swemu {
 // software emulation.
 std::vector<char>
 get_axlf_section(const device* device, const axlf* top, axlf_section_kind kind);
+
+// For xrt_xclbin.cpp
+// ip_layout will be nullptr, until it has been created.  It must be
+// created before this API can be used to create connectivity section.
+// See comments in code that use this API
+std::vector<char>
+get_axlf_section(const axlf* top, const ::ip_layout* ip_layout, axlf_section_kind kind);
 
 }}} // swemu, xclbin, xrt_core

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -16,7 +16,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
 
 install (FILES ${XRT_EXPERIMENTAL_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/experimental COMPONENT ${XRT_DEV_COMPONENT})
 
-message("-- XRT experimental header files")
-foreach (header ${XRT_EXPERIMENTAL_HEADER_SRC})
-  message("-- ${header}")
-endforeach()
+set(XRT_EXPERIMENTAL_DETAIL_HEADER_SRC
+  detail/pimpl.h)
+  
+install (FILES ${XRT_EXPERIMENTAL_DETAIL_HEADER_SRC} DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/experimental/detail COMPONENT ${XRT_DEV_COMPONENT})

--- a/src/runtime_src/core/include/experimental/detail/pimpl.h
+++ b/src/runtime_src/core/include/experimental/detail/pimpl.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _XRT_DETAIL_PIMPL_H_
+#define _XRT_DETAIL_PIMPL_H_
+
+#ifdef __cplusplus
+
+#include <memory>
+
+namespace xrt { namespace detail {
+
+// Utility to replicate pimpl
+template<typename ImplType>
+class pimpl
+{
+public:
+  pimpl() = default;
+
+  virtual
+  ~pimpl() = default;
+
+  explicit
+  pimpl(std::shared_ptr<ImplType> handle)
+    : handle(std::move(handle))
+  {}
+
+  pimpl(const pimpl&) = default;
+
+  pimpl(pimpl&&) = default;
+
+  pimpl&
+  operator=(const pimpl&) = default;
+
+  pimpl&
+  operator=(pimpl&&) = default;
+
+  const std::shared_ptr<ImplType>&
+  get_handle() const
+  {
+    return handle;
+  }
+
+  explicit
+  operator bool() const
+  {
+    return handle != nullptr;
+  }
+
+  bool
+  operator < (const pimpl& rhs) const
+  {
+    return handle < rhs.handle;
+  }
+
+protected:
+  std::shared_ptr<ImplType> handle;
+};
+
+}} // detail, xrt
+
+#endif // __cplusplus
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -124,7 +124,7 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   uuid
-  load_xclbin(const struct axlf* xclbin);
+  load_xclbin(const axlf* xclbin);
 
   /**
    * load_xclbin() - Read and load an xclbin file
@@ -280,7 +280,7 @@ xrtDeviceClose(xrtDeviceHandle dhdl);
  */
 XCL_DRIVER_DLLESPEC
 int
-xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const struct axlf* xclbin);
+xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const axlf* xclbin);
 
 /**
  * xrtDeviceLoadXclbinFile() - Read and load an xclbin file

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -19,10 +19,12 @@
 #define _XRT_XCLBIN_H_
 
 #include "xrt.h"
+#include "xclbin.h"
 #include "experimental/xrt_uuid.h"
+#include "experimental/detail/pimpl.h"
 
 #ifdef __cplusplus
-# include <memory>
+# include <utility>
 # include <vector>
 # include <string>
 #endif
@@ -33,13 +35,437 @@
 typedef void* xrtXclbinHandle;
 
 #ifdef __cplusplus
+
 namespace xrt {
 
+/*!
+ * @class xclbin
+ *
+ * @brief
+ * xrt::xclbin represents an xclbin, provides APIs for inspection it.
+ *
+ * @details
+ * The xclbin object is typically constructed by the user with a file,
+ * or it can be constructed from cached meta data obtained from driver
+ * or elsewhere.
+ * 
+ * If the xclbin object is constructed from a complete xclbin, then it
+ * can be used by xrt::device to program the xclbin onto the device.
+ *
+ * If the xclbin was created from cached meta data, then the xclbin 
+ * can be used for partial introspection primarily.
+ *
+ * First-class objects and class navigation
+ *
+ * All meta data is rooted at xrt::xclbin .  From the xclbin object
+ * xrt::xclbin::kernel or xrt::xclbin::ip objects can be constructed.
+ * 
+ * The xrt:xclbin::kernel is a concept modelled only in the xclbin XML
+ * metadata, it corresponds to a function that can be executed by one
+ * or more compute units modelled by xrt::xclbin::ip objects.  An
+ * xrt::xclbin::ip object corresponds to an entry the xclbin IP_LAYOUT
+ * section, so the xrt::xclbin::kernel object is just a grouping of
+ * one or more of these.
+ *
+ * In many cases the kernel concept is not needed, thus
+ * xrt::xclbin::ip objects corresponding to entries in the xclbin
+ * IP_LAYOUT sections can be accessed directly.
+ *
+ * An xrt::xclbin::arg object corresponds to one or more entries in
+ * the xclbin CONNECTIVITY section decorated with additional meta data
+ * (offset, size, type, etc) from the XML section if available.  An
+ * argument object represents a specific kernel or ip argument, and if
+ * the argument is a global buffer, then it may connect to one or more
+ * memory objects.
+ *
+ * Finally the xrt::xclbin::mem object corresponds to an entry in the
+ * MEM_TOPOLOGY section of the xclbin.
+ */
 class xclbin_impl;
-
-class xclbin
+class xclbin : public detail::pimpl<xclbin_impl>
 {
 public:
+  /*!
+   * @class mem
+   *
+   * @brief
+   * xrt::xclbin::mem represents a physical device memory bank
+   *
+   * @detail
+   * A memory object is constructed from an entry in the MEM_TOPOLOGY
+   * section of an xclbin.
+   */
+  class mem_impl;
+  class mem : public detail::pimpl<mem_impl>
+  {
+  public:
+    /**
+     * @enum memory_type - type of memory 
+     *
+     * @detail
+     * See \ref xclbin.h
+     */
+    enum class memory_type : uint8_t {
+      ddr3                 = MEM_DDR3,
+      ddr4                 = MEM_DDR4,
+      dram                 = MEM_DRAM,
+      streaming            = MEM_STREAMING,
+      preallocated_global  = MEM_PREALLOCATED_GLOB,
+      are                  = MEM_ARE, //Aurora
+      hbm                  = MEM_HBM,
+      bram                 = MEM_BRAM,
+      uram                 = MEM_URAM,
+      streaming_connection = MEM_STREAMING_CONNECTION
+    };
+  
+  public:
+    explicit
+    mem(std::shared_ptr<mem_impl> handle)
+      : detail::pimpl<mem_impl>(std::move(handle))
+    {}
+
+    /**
+     * get_name() - Get tag name
+     *
+     * @return
+     *   Memory tag name
+     */
+    XCL_DRIVER_DLLESPEC
+    std::string
+    get_tag() const;
+
+    /**
+     * get_base_address() - Get the base address of the memory bank
+     *
+     * @return 
+     *  Base address of the memory bank, or -1 for invalid base address
+     */
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_base_address() const;
+
+    /**
+     * get_size() - Get the size of the memory in KB
+     *
+     * @return
+     *  Size of memory in KB, or -1 for invalid size
+     */
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_size_kb() const;
+
+    /**
+     * get_used() - Get used status of the memory
+     *
+     * @return
+     *  True of this memory bank is used by kernels in the xclbin
+     *  or false otherwise.  
+     *
+     * A value of false indicates that no buffer can be allocated
+     * in this memory bank.
+     */
+    XCL_DRIVER_DLLESPEC
+    bool
+    get_used() const;
+
+    /**
+     * get_type() - Get the type of the memory
+     *
+     * @return
+     *  Memory type
+     *
+     */
+    XCL_DRIVER_DLLESPEC
+    memory_type
+    get_type() const;
+
+    /**
+     * get_index() - Get the index of the memory
+     *
+     * @return 
+     *  Index of the memory within the memory topology
+     *
+     * The returned index can be used when allocating buffers using
+     * \ref xrt::bo provided the memory bank is connected / used.
+     */
+    XCL_DRIVER_DLLESPEC
+    int32_t
+    get_index() const;
+  };
+
+  /*!
+   * @class arg
+   *
+   * @brief
+   * class arg - xrt::xclbin::arg represents a compute unit argument
+   *
+   * @detail 
+   * The argument object constructed from the xclbin connectivity
+   * section.  An argument is connected to a memory bank or a memory
+   * group, which dictates where in device memory a global buffer
+   * used with this kernel argument must be allocated.  
+   */
+  class arg_impl;
+  class arg : public detail::pimpl<arg_impl>
+  {
+  public:
+    arg()
+    {}
+
+    explicit
+    arg(std::shared_ptr<arg_impl> handle)
+      : detail::pimpl<arg_impl>(std::move(handle))
+    {}
+
+    /**
+     * get_name() - Get argument name
+     *
+     * @return
+     *  Name of argument.
+     *
+     */
+    XCL_DRIVER_DLLESPEC
+    std::string
+    get_name() const;
+
+    /**
+     * get_mems() - Get list of device memories from xclbin.
+     *
+     * @return
+     *  A list of xrt::xclbin::mem objects to which this argument
+     *  is connected.
+     */
+    XCL_DRIVER_DLLESPEC
+    std::vector<mem>
+    get_mems() const;
+
+    /**
+     * get_port() - Get port name of this argument
+     *
+     * @return
+     *  Port name
+     */
+    XCL_DRIVER_DLLESPEC
+    std::string
+    get_port() const;
+
+    /**
+     * get_size() - Argument size in bytes
+     * 
+     * @return
+     *   Argument size
+     */
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_size() const;
+
+    /**
+     * get_offset() - Argument offset
+     * 
+     * @return
+     *   Argument offset
+     */
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_offset() const;
+
+    /**
+     * get_host_type() - Get the argument host type
+     * 
+     * @return
+     *   Argument host type
+     */
+    XCL_DRIVER_DLLESPEC
+    std::string
+    get_host_type() const;
+  };
+
+  /*!
+   * @class ip 
+   *
+   * @brief 
+   * xrt::xclbin::ip represents a IP in an xclbin.
+   *
+   * @detail
+   * The ip corresponds to an entry in the IP_LAYOUT section of the
+   * xclbin.  
+   */
+  class ip_impl;
+  class ip : public detail::pimpl<ip_impl>
+  {
+  public:
+    ip()
+    {}
+
+    explicit
+    ip(std::shared_ptr<ip_impl> handle)
+      : detail::pimpl<ip_impl>(std::move(handle))
+    {}
+
+    /**
+     * get_name() - Get name of IP
+     *
+     * @return
+     *  IP name.
+     */
+    XCL_DRIVER_DLLESPEC
+    std::string
+    get_name() const;
+
+    /**
+     * get_num_args() - Number of arguments
+     *
+     * @return
+     *  Number of arguments for this IP per CONNECTIVITY section
+     */
+    XCL_DRIVER_DLLESPEC
+    size_t
+    get_num_args() const;
+
+    /**
+     * get_args() - Get list of IP arguments
+     *
+     * @return
+     *  A list sorted of xclbin::arg sorted by argument indices
+     *
+     * An argument may have multiple memory connections
+     */
+    XCL_DRIVER_DLLESPEC
+    std::vector<arg>
+    get_args() const;
+
+    /**
+     * get_arg() - Get argument at index.
+     *
+     * @return
+     *  The argument a specified index
+     *
+     * The argument may have multiple memory connections
+     */
+    XCL_DRIVER_DLLESPEC
+    arg
+    get_arg(int32_t index) const;
+
+    /**
+     * get_base_address() - Get the base address of the cu
+     *
+     * @return
+     *  The base address of the IP
+     */
+    XCL_DRIVER_DLLESPEC
+    uint64_t
+    get_base_address() const;
+  };
+
+  /*!
+   * class kernel
+   *
+   * @brief
+   * xrt::xclbin::kernel represents a kernel in an xclbin.
+   *
+   * @detail
+   * The kernel corresponds to an entry in the XML meta data section
+   * of the xclbin combined with meta data from other xclbin sections.
+   * The kernel object is implicitly constructed from the xclbin
+   * object via APIs.
+   */
+  class kernel_impl;
+  class kernel : public detail::pimpl<kernel_impl>
+  {
+  public:
+    kernel()
+    {}
+
+    explicit
+    kernel(std::shared_ptr<kernel_impl> handle)
+      : detail::pimpl<kernel_impl>(std::move(handle))
+    {}
+
+    /**
+     * get_name() - Get kernel name
+     *
+     * @return
+     *  The name of the kernel
+     */
+    XCL_DRIVER_DLLESPEC
+    std::string
+    get_name() const;
+
+    /**
+     * get_cus() - Get list of cu from kernel.
+     *
+     * @return
+     *  A list of xrt::xclbin::ip objects corresponding the compute units
+     *  for this kernel object.
+     */
+    XCL_DRIVER_DLLESPEC
+    std::vector<ip>
+    get_cus() const;
+
+    /**
+     * get_cu() - Get compute unit by name
+     *
+     * @return
+     *  The xct::xclbin::ip object matching the specified name, or error if 
+     *  not present.
+     */
+    XCL_DRIVER_DLLESPEC
+    ip
+    get_cu(const std::string& name) const;
+
+    /**
+     * get_num_args() - Number of arguments
+     *
+     * @return
+     *  Number of arguments for this kernel.
+     */
+    XCL_DRIVER_DLLESPEC
+    size_t
+    get_num_args() const;
+
+    /**
+     * get_args() - Get list of kernel arguments
+     *
+     * @return
+     *  A list sorted of xclbin::arg sorted by argument indices
+     *
+     * An argument may have multiple memory connections
+     */
+    XCL_DRIVER_DLLESPEC
+    std::vector<arg>
+    get_args() const;
+
+    /**
+     * get_arg() - Get kernel argument at index.
+     *
+     * @return
+     *  The xrt::xclbin::arg object at specified argument index.
+     *
+     * The memory connections of an argument is the union of the
+     * connections for each compute unit for that particular argument.
+     * In other words, for each connection of the argument returned
+     * by ``get_arg()`` there is at least one compute unit that has
+     * that connection.
+     */
+    XCL_DRIVER_DLLESPEC
+    arg
+    get_arg(int32_t index) const;
+  };
+
+public:
+  /**
+   * xclbin() - Construct empty xclbin object
+   */
+  xclbin()
+  {}
+
+  /**
+   * xclbin() - Construct from handle
+   */
+  xclbin(std::shared_ptr<xclbin_impl> handle)
+    : detail::pimpl<xclbin_impl>(handle)
+  {}
+
   /**
    * xclbin() - Constructor from an xclbin filename
    *
@@ -59,45 +485,85 @@ public:
    * @param data
    *  Raw data of xclbin
    *
-   * The raw data of the xclbin can be deleted after calling the constructor.
+   * The raw data of the xclbin can be deleted after calling the
+   * constructor.
    */
   XCL_DRIVER_DLLESPEC
   explicit
   xclbin(const std::vector<char>& data);
 
   /**
-   * xclbin() - Copy ctor
-   */
-  xclbin(const xclbin& rhs) = default;
-
-  /**
-   * xclbin() - Move ctor
-   */
-  xclbin(xclbin&& rhs) = default;
-
-  /**
-   * operator= () - Move assignment
-   */
-  xclbin&
-  operator=(xclbin&& rhs) = default;
-
-  /**
-   * get_cu_names() - Get CU names of xclbin
+   * xclbin() - Constructor from raw data
    *
-   * @return
-   *  A list of CU Names in order of increasing base address.
-   *
-   * An exception is thrown if the data is missing.
+   * @param top
+   *  Raw data of xclbin file as axlf*
    */
   XCL_DRIVER_DLLESPEC
-  std::vector<std::string>
-  get_cu_names() const;
+  explicit
+  xclbin(const axlf* top);
 
   /**
-   * get_xsa_name() - Get Xilinx Support Archive (XSA) Name of xclbin
+   * get_kernels() - Get list of kernels from xclbin.
+   *
+   * @return
+   *  A list of xrt::xclbin::kernel from xclbin.
+   *
+   * Kernels are extracted from embedded XML metadata in the xclbin.
+   * A kernel groups one or more compute units. A kernel has arguments
+   * from which offset, type, etc can be retrived.
+   */
+  XCL_DRIVER_DLLESPEC
+  std::vector<kernel>
+  get_kernels() const;
+
+  /**
+   * get_kernel() - Get a kernel by name from xclbin
+   *
+   * @param name
+   *  Name of kernel to get
+   * @return
+   *  The matching kernel from the xclbin or error
+   *  if no matching kernel is found.
+   *
+   * A matching kernel is extracted from embedded XML metadata in the
+   * xclbin.  A kernel groups one or more compute units. A kernel has
+   * arguments from which offset, type, etc can be retrived.
+   */
+  XCL_DRIVER_DLLESPEC
+  kernel
+  get_kernel(const std::string& name) const;
+
+  /**
+   * get_ips() - Get a list of IPs from the xclbin
+   *
+   * @return
+   *  A list of xrt::xclbin::ip objects from xclbin
+   *
+   * The returned xrt::xclbin::ip objects are extracted from the
+   * IP_LAYOUT section of the xclbin.
+   */
+  XCL_DRIVER_DLLESPEC
+  std::vector<ip>
+  get_ips() const;
+
+  /**
+   * get_ip() - Get a list of IPs from the xclbin
+   *
+   * @return
+   *  A list of xrt::xclbin::ip objects from xclbin
+   *
+   * The returned xrt::xclbin::ip object is extracted from the
+   * IP_LAYOUT section of the xclbin.
+   */
+  XCL_DRIVER_DLLESPEC
+  ip
+  get_ip(const std::string& name) const;
+
+  /**
+   * get_xsa_name() - Get Xilinx Support Archive (XSA) name of xclbin
    *
    * @return 
-   *  Name of XSA
+   *  Name of XSA (vbnv name)
    *
    * An exception is thrown if the data is missing.
    */
@@ -118,21 +584,17 @@ public:
   get_uuid() const;
 
   /**
-   * get_data() - Get the raw data of the xclbin
+   * get_axlf() - Get the axlf data of the xclbin
    *
    * @return 
-   *  The raw data of the xclbin
+   *  The axlf data of the xclbin object
    *
    * An exception is thrown if the data is missing.
    */
   XCL_DRIVER_DLLESPEC
-  const std::vector<char>&
-  get_data() const;
-
-private:
-  std::shared_ptr<xclbin_impl> handle;
+  const axlf*
+  get_axlf() const;
 };
-
 } // namespace xrt
 
 /// @cond
@@ -149,6 +611,16 @@ XCL_DRIVER_DLLESPEC
 xrtXclbinHandle
 xrtXclbinAllocFilename(const char* filename);
 
+
+/**
+ * xrtXclbinAllocAxlf() - Allocate a xclbin using an axlf
+ *
+ * @top_axlf:      an axlf
+ * Return:         xrtXclbinHandle on success or NULL with errno set
+ */
+XCL_DRIVER_DLLESPEC
+xrtXclbinHandle
+xrtXclbinAllocAxlf(const axlf* top_axlf);
 
 /**
  * xrtXclbinAllocRawData() - Allocate a xclbin using raw data
@@ -170,24 +642,6 @@ xrtXclbinAllocRawData(const char* data, int size);
 XCL_DRIVER_DLLESPEC
 int
 xrtXclbinFreeHandle(xrtXclbinHandle xhdl);
-
-#if 0
-/*
- * xrtXclbinGetCUNames() - Get CU names of xclbin
- *
- * @xhdl:        Xclbin handle
- * @names:       Return pointer to a list of CU names.
- *               If the value is nullptr, the content of this value will not be populated.
- *               Otherwise, the the content of this value will be populated.
- * @numNames:    Return pointer to the number of CU names.
- *               If the value is nullptr, the content of this value will not be populated.
- *               Otherwise, the the content of this value will be populated.
- * Return:  0 on success or appropriate error number.
- */
-XCL_DRIVER_DLLESPEC
-int
-xrtXclbinGetCUNames(xrtXclbinHandle xhdl, char** names, int* numNames);
-#endif
 
 /**
  * xrtXclbinGetXSAName() - Get Xilinx Support Archive (XSA) Name of xclbin handle


### PR DESCRIPTION
This pull request is based on work by Bryan Lozano.

Added xrt::xclbin API for accessing xclbin meta data.
Wire xrt::xclbin use into xrt::device loading of xclbin.

Initial implementation supports complete xclbins only. Plan is to
expand implementation to provide services on partial data cached in
driver.