### PR TITLE
CR-1087328:fix in swsscheduler for sw emu

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/swscheduler.cxx
@@ -172,7 +172,7 @@ namespace xclcpuemhal2 {
     unsigned int size = regmap_size(xcmd);
     uint32_t *regmap = cmd_regmap(xcmd);
     //unsigned int idx;
-
+    regmap[0] = 0;
     mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcu->base + xcu->addr , (void*)(regmap), size*4);
    /* for (idx = 4; idx < size; ++idx)
     {

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/swscheduler.cxx
@@ -172,7 +172,7 @@ namespace xclcpuemhal2 {
     unsigned int size = regmap_size(xcmd);
     uint32_t *regmap = cmd_regmap(xcmd);
     //unsigned int idx;
-
+    regmap[0] = 0;
     mParent->xclWrite(XCL_ADDR_KERNEL_CTRL, xcu->base + xcu->addr , (void*)(regmap), size*4);
    /* for (idx = 4; idx < size; ++idx)
     {


### PR DESCRIPTION
Issue : AP_CTRL register has stale AP_START bit set, so when swsscheduler writes the register map to the CU, it writes the entire register map including AP_CTRL register in one xclWrite call, this ends up starting the CU before the complete register map is written.
Fix : Madee fix in swsscheduler  to clear regmap[0] prior to writing the register map.
Test: Manually tested some cases, all are passing.
code reviewer : @chvamshi-xilinx 
Impact : low