### PR TITLE
Move config command to xclbin download context

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -75,7 +75,6 @@ struct kds_client {
 	 */
 	wait_queue_head_t	  waitq ____cacheline_aligned_in_smp;
 	atomic_t		  event;
-	struct completion	  comp;
 };
 
 /* Macros to operates client statistics */

--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -75,6 +75,7 @@ struct kds_client {
 	 */
 	wait_queue_head_t	  waitq ____cacheline_aligned_in_smp;
 	atomic_t		  event;
+	struct completion	  comp;
 };
 
 /* Macros to operates client statistics */

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -46,6 +46,11 @@ struct in_kernel_cb {
 	void *data;
 };
 
+/* Default cu index of a command.
+ * Some command are not CU specific, it would keep to be default index.
+ */
+#define DEFAULT_INDEX -1
+
 /**
  * struct kds_command: KDS command struct
  * @client: the client that the command belongs to
@@ -68,6 +73,7 @@ struct kds_command {
 	u32			 num_mask;
 	u32			 payload_type;
 	u64			 start;
+	void			*priv;
 
 	unsigned int		 tick;
 

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -122,6 +122,7 @@ struct kds_sched {
 	u32			cu_intr_cap;
 	u32			cu_intr;
 	struct plram_info	plram;
+	struct completion	comp;
 };
 
 int kds_init_sched(struct kds_sched *kds);

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -135,8 +135,12 @@ int kds_cfg_update(struct kds_sched *kds);
 int is_bad_state(struct kds_sched *kds);
 u32 kds_live_clients(struct kds_sched *kds, pid_t **plist);
 u32 kds_live_clients_nolock(struct kds_sched *kds, pid_t **plist);
+struct kds_client *kds_get_client(struct kds_sched *kds, pid_t pid);
 int kds_add_cu(struct kds_sched *kds, struct xrt_cu *xcu);
 int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu);
+int kds_get_cu_total(struct kds_sched *kds);
+u32 kds_get_cu_addr(struct kds_sched *kds, int idx);
+u32 kds_get_cu_proto(struct kds_sched *kds, int idx);
 int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 		    struct kds_ctx_info *info);
 int kds_del_context(struct kds_sched *kds, struct kds_client *client,

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -440,6 +440,7 @@ int kds_init_sched(struct kds_sched *kds)
 	/* At this point, I don't know if ERT subdev exist or not */
 	kds->ert_disable = true;
 	kds->ini_disable = false;
+	init_completion(&kds->comp);
 
 	return 0;
 }
@@ -473,7 +474,7 @@ struct kds_command *kds_alloc_command(struct kds_client *client, u32 size)
 
 	xcmd->client = client;
 	xcmd->type = 0;
-	xcmd->cu_idx = -1;
+	xcmd->cu_idx = DEFAULT_INDEX;
 
 #if PRE_ALLOC
 	xcmd->info = client->infos + sizeof(u32) * 128;
@@ -542,7 +543,6 @@ int kds_init_client(struct kds_sched *kds, struct kds_client *client)
 	client->pid = get_pid(task_pid(current));
 	mutex_init(&client->lock);
 
-	init_completion(&client->comp);
 	init_waitqueue_head(&client->waitq);
 	atomic_set(&client->event, 0);
 
@@ -795,6 +795,7 @@ int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu)
 	return -ENODEV;
 }
 
+/* Do not use this function when xclbin can be changed */
 int kds_get_cu_total(struct kds_sched *kds)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
@@ -802,6 +803,7 @@ int kds_get_cu_total(struct kds_sched *kds)
 	return cu_mgmt->num_cus;
 }
 
+/* Do not use this function when xclbin can be changed */
 u32 kds_get_cu_addr(struct kds_sched *kds, int idx)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
@@ -809,6 +811,7 @@ u32 kds_get_cu_addr(struct kds_sched *kds, int idx)
 	return cu_mgmt->xcus[idx]->info.addr;
 }
 
+/* Do not use this function when xclbin can be changed */
 u32 kds_get_cu_proto(struct kds_sched *kds, int idx)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;

--- a/src/runtime_src/core/common/scheduler.cpp
+++ b/src/runtime_src/core/common/scheduler.cpp
@@ -104,6 +104,10 @@ namespace xrt_core { namespace scheduler {
 int
 init(xclDeviceHandle handle, const axlf* top)
 {
+  /* TODO: At the end of the day, ERT configure would move to driver
+   * and become a step of xclbin download.
+   * Please do not add more configure options in this place.
+   */
   auto execbo = create_exec_bo(handle,0x1000);
   auto ecmd = reinterpret_cast<ert_configure_cmd*>(execbo->data);
   ecmd->state = ERT_CMD_STATE_NEW;

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -389,6 +389,30 @@ struct drm_xocl_kinfo_bo {
 };
 
 /**
+ * struct drm_xocl_kds - KDS user configuration
+ *
+ * @slot_size:	CQ slot size
+ * @ert:	enable embedded HW scheduler
+ * @polling:	poll for command completion
+ * @cu_dma:	enable CUDMA custom module for HW scheduler
+ * @cu_isr:	enable CUISR custom module for HW scheduler
+ * @cq_int:	enable interrupt from host to HW scheduler
+ * @dataflow:	enable dataflow mode
+ * @rw_shared:	allow xclRegWrite/xclRegRead access shared CU
+ */
+struct drm_xocl_kds {
+	uint32_t slot_size;
+	uint32_t ert:1;
+	uint32_t polling:1;
+	uint32_t cu_dma:1;
+	uint32_t cu_isr:1;
+	uint32_t cq_int:1;
+	uint32_t dataflow:1;
+	uint32_t rw_shared:1;
+	uint32_t unused:25;
+};
+
+/**
  * struct drm_xocl_axlf - load xclbin (AXLF) device image
  * used with DRM_IOCTL_XOCL_READ_AXLF ioctl
  * NOTE: This ioctl will be removed in next release
@@ -401,6 +425,7 @@ struct drm_xocl_axlf {
 	struct axlf		*xclbin;
 	int			 ksize;
 	char			*kernels;
+	struct drm_xocl_kds	 kds_cfg;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -845,10 +845,8 @@ static inline int process_ert_rq(struct xocl_ert_user *ert_user)
 				++ert_user->num_cq;
 				continue;
 			}
-		} else if (cmd_opcode(ecmd) == OP_START) {
-			if (ert_user->ctrl_busy || !ert_user->config)
-				return 0;
-		}
+		} else if (cmd_opcode(ecmd) == OP_START)
+			BUG_ON(ert_user->ctrl_busy || !ert_user->config);
 
 		if (ert_acquire_slot(ert_user, ecmd) == no_index) {
 			ERTUSER_DBG(ert_user, "%s not slot available\n", __func__);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -218,6 +218,6 @@ int xocl_kds_reconfig(struct xocl_dev *xdev);
 int xocl_cu_map_addr(struct xocl_dev *xdev, u32 cu_idx,
 		     void *drm_filp, u32 *addrp);
 u32 xocl_kds_live_clients(struct xocl_dev *xdev, pid_t **plist);
-int xocl_kds_update(struct xocl_dev *xdev);
+int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds kds_cfg);
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -588,7 +588,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 
 	/* The finial step is to update KDS configuration */
 	if (!err && kds_mode)
-		err = xocl_kds_update(xdev);
+		err = xocl_kds_update(xdev, axlf_ptr->kds_cfg);
 
 done:
 	if (size < 0)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -15,14 +15,19 @@
  */
 #include "xclbin.h"
 
+#ifdef KDS_VERBOSE
 #define print_ecmd_info(ecmd) \
 do {\
 	int i;\
-	printk("%s: ecmd header 0x%x\n", __func__, ecmd->header);\
-	for (i = 0; i < ecmd->count; i++) {\
-		printk("%s: ecmd data[%d] 0x%x\n", __func__, i, ecmd->data[i]);\
+	struct ert_packet *packet = (struct ert_packet *)ecmd;\
+	printk("%s: ecmd header 0x%x\n", __func__, packet->header);\
+	for (i = 0; i < packet->count; i++) {\
+		printk("%s: ecmd data[%d] 0x%x\n", __func__, i, packet->data[i]);\
 	}\
 } while(0)
+#else
+#define print_ecmd_info(ecmd)
+#endif
 
 void xocl_describe(const struct drm_xocl_bo *xobj);
 
@@ -368,9 +373,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	}
 	xcmd->cb.free = kds_free_command;
 
-#if 0
 	print_ecmd_info(ecmd);
-#endif
 
 	/* xcmd->type is the only thing determine who to handle this command.
 	 * If ERT is supported, use ERT as default handler.
@@ -718,7 +721,124 @@ done:
 	return ret;
 }
 
-int xocl_kds_update(struct xocl_dev *xdev)
+static void xocl_cfg_notify(struct kds_command *xcmd, int status)
+{
+	struct kds_client *client = xcmd->client;
+	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+
+	if (status == KDS_COMPLETED)
+		ecmd->state = ERT_CMD_STATE_COMPLETED;
+	else if (status == KDS_ERROR)
+		ecmd->state = ERT_CMD_STATE_ERROR;
+	else if (status == KDS_TIMEOUT)
+		ecmd->state = ERT_CMD_STATE_TIMEOUT;
+	else if (status == KDS_ABORT)
+		ecmd->state = ERT_CMD_STATE_ABORT;
+
+	complete(&client->comp);
+}
+
+/* Construct ERT config command and wait for completion */
+static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
+{
+	struct kds_client *client;
+	struct ert_configure_cmd *ecmd;
+	struct kds_command *xcmd;
+	struct kds_sched *kds = &XDEV(xdev)->kds;
+	pid_t pid = pid_nr(get_pid(task_pid(current)));
+	int num_cu = kds_get_cu_total(&XDEV(xdev)->kds);
+	u32 base_addr = 0xFFFFFFFF;
+	int ret = 0;
+	int i;
+
+	ecmd = vmalloc(0x1000);
+	if (!ecmd)
+		return -ENOMEM;
+
+	client = kds_get_client(kds, pid);
+	BUG_ON(!client);
+
+	/* Fill header */
+	ecmd->state = ERT_CMD_STATE_NEW;
+	ecmd->opcode = ERT_CONFIGURE;
+	ecmd->type = ERT_CTRL;
+	ecmd->count = 5 + num_cu;
+
+	ecmd->num_cus	= num_cu;
+	ecmd->cu_shift	= 16;
+	ecmd->slot_size	= cfg.slot_size;
+	ecmd->ert	= cfg.ert;
+	ecmd->polling	= cfg.polling;
+	ecmd->cu_dma	= cfg.cu_dma;
+	ecmd->cu_isr	= cfg.cu_isr;
+	ecmd->cq_int	= cfg.cq_int;
+	ecmd->dataflow	= cfg.dataflow;
+	ecmd->rw_shared	= cfg.rw_shared;
+
+	/* Fill CU address */
+	for (i = 0; i < num_cu; i++) {
+		u32 cu_addr;
+		u32 proto;
+
+		cu_addr = kds_get_cu_addr(kds, i);
+		if (base_addr > cu_addr)
+			base_addr = cu_addr;
+
+		/* encode handshaking control in lower unused address bits [2-0] */
+		proto = kds_get_cu_proto(kds, i);
+		cu_addr |= proto;
+		ecmd->data[i] = cu_addr;
+	}
+	ecmd->cu_base_addr = base_addr;
+
+	xcmd = kds_alloc_command(client, ecmd->count * sizeof(u32));
+	if (!xcmd) {
+		userpf_err(xdev, "Failed to alloc xcmd\n");
+		ret = -ENOMEM;
+		goto out;
+	}
+	xcmd->cb.free = kds_free_command;
+
+	print_ecmd_info(ecmd);
+
+	xcmd->type = KDS_ERT;
+	cfg_ecmd2xcmd(ecmd, xcmd);
+	xcmd->cb.notify_host = xocl_cfg_notify;
+
+	ret = kds_add_command(kds, xcmd);
+	if (ret)
+		goto out;
+
+	ret = wait_for_completion_interruptible(&client->comp);
+	if (ret == -ERESTARTSYS && !kds->ert_disable) {
+		int bad_state;
+
+		kds->ert->abort(kds->ert, client, -1);
+		do {
+			userpf_info(xdev, "ERT cfg command not finished");
+			msleep(500);
+		} while (ecmd->state < ERT_CMD_STATE_COMPLETED);
+		bad_state = kds->ert->abort_done(kds->ert, client, -1);
+		if (bad_state)
+			kds->bad_state = 1;
+	}
+
+	if (ecmd->state == ERT_CMD_STATE_COMPLETED) {
+		userpf_info(xdev, "Cfg command completed");
+		ret = 0;
+	} else if (ecmd->state > ERT_CMD_STATE_COMPLETED) {
+		userpf_err(xdev, "Cfg command state %d", ecmd->state);
+		ret = -EINVAL;
+	}
+out:
+	vfree(ecmd);
+	return ret;
+}
+
+/* The xocl_kds_update function sould be called after xclbin is
+ * downloaded. Do not use this function in other place.
+ */
+int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 {
 	int ret = 0;
 
@@ -738,10 +858,24 @@ int xocl_kds_update(struct xocl_dev *xdev)
 	xocl_kds_fa_clear(xdev);
 
 	ret = xocl_detect_fa_plram(xdev);
-	if (ret)
-		return ret;
+	if (ret) {
+		userpf_info(xdev, "Detect FA plram failed, ret %d", ret);
+		goto out;
+	}
 
 	/* By default, use ERT */
 	XDEV(xdev)->kds.cu_intr = 0;
-	return kds_cfg_update(&XDEV(xdev)->kds);
+	ret = kds_cfg_update(&XDEV(xdev)->kds);
+	if (ret) {
+		userpf_info(xdev, "KDS configure update failed, ret %d", ret);
+		goto out;
+	}
+
+	/* Construct and send configure command */
+	ret = xocl_config_ert(xdev, cfg);
+	if (ret)
+		userpf_info(xdev, "Config command failed, ret %d", ret);
+
+out:
+	return ret;
 }

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1421,6 +1421,28 @@ int shim::xclLoadAxlf(const axlf *buffer)
         off += sizeof(kernel_info) + sizeof(argument_info) * kernel.args.size();
     }
 
+    /* To make download xclbin and configure KDS/ERT as an atomic operation. */
+    axlf_obj.kds_cfg.ert = xrt_core::config::get_ert();
+    axlf_obj.kds_cfg.polling = xrt_core::config::get_ert_polling();
+    axlf_obj.kds_cfg.cu_dma = xrt_core::config::get_ert_cudma();
+    axlf_obj.kds_cfg.cu_isr = xrt_core::config::get_ert_cuisr() && xrt_core::xclbin::get_cuisr(buffer);
+    axlf_obj.kds_cfg.cq_int = xrt_core::config::get_ert_cqint();
+    axlf_obj.kds_cfg.dataflow = xrt_core::config::get_feature_toggle("Runtime.dataflow") || xrt_core::xclbin::get_dataflow(buffer);
+    axlf_obj.kds_cfg.rw_shared = xrt_core::config::get_rw_shared();
+
+    /* TODO: In scheduler.cpp init() function, it use get_ert_slots(void) to get slot size.
+     * But we cannot do this here, since the xclbin is not registered.
+     * Currently, emulation flow use get_ert_slots() as well.
+     * We will consider how to better determine slot size in new kds.
+     */
+    //axlf_obj.kds_cfg.slot_size = mCoreDevice->get_ert_slots().second;
+    auto xml_hdr = xrt_core::xclbin::get_axlf_section(buffer, EMBEDDED_METADATA);
+    if (!xml_hdr)
+        throw std::runtime_error("No xml metadata in xclbin");
+    auto xml_size = xml_hdr->m_sectionSize;
+    auto xml_data = reinterpret_cast<const char*>(reinterpret_cast<const char*>(buffer) + xml_hdr->m_sectionOffset);
+    axlf_obj.kds_cfg.slot_size = mCoreDevice->get_ert_slots(xml_data, xml_size).second;
+
     int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_READ_AXLF, &axlf_obj);
     if(ret)
         return -errno;


### PR DESCRIPTION
This change would revert #4726 . In that case, we observed start CU commands go to ERT before configure command completed in multiple process scenario. We should fix this in KDS layer not ERT.

The solution is to let driver construct configure command and make configure ERT as a step of download xclbin.