### PR TITLE
Construct xrt::device from string / bdf

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -99,6 +99,11 @@ device(unsigned int index)
 {}
 
 device::
+device(const std::string& bdf)
+  : device(xrt_core::get_device_id(bdf))
+{}
+
+device::
 device(xclDeviceHandle dhdl)
   : handle(xrt_core::get_userpf_device(dhdl))
 {}
@@ -178,6 +183,23 @@ xrtDeviceOpen(unsigned int index)
     auto device = xrt_core::get_userpf_device(index);
     device_cache[device.get()] = device;
     return device.get();
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    errno = 0;
+  }
+  return nullptr;
+}
+
+xrtDeviceHandle
+xrtDeviceOpenByBDF(const char* bdf)
+{
+  try {
+    return xrtDeviceOpen(xrt_core::get_device_id(bdf));
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -13,8 +13,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-#define XRT_CORE_COMMON_SOURCE
+#define XCL_DRIVER_DLL_EXPORT  // in same dll as exported xrt apis
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "device.h"
 #include "error.h"
 #include "utils.h"

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -57,6 +57,19 @@ system()
   singleton = this;
 }
 
+// get_device_id() -  Default conversion of device string
+// Redefined in systems that support BDF.
+device::id_type
+system::
+get_device_id(const std::string& str) const
+{
+  size_t pos = 0;
+  auto id = std::stoul(str, &pos);
+  if (pos != str.length())
+    throw xrt_core::system_error(EINVAL, "Invalid device string '" + str + "'");
+  return static_cast<device::id_type>(id);
+}
+
 static void
 load_shim()
 {
@@ -168,6 +181,12 @@ std::pair<uint64_t, uint64_t>
 get_total_devices(bool is_user)
 {
   return instance().get_total_devices(is_user);
+}
+
+device::id_type
+get_device_id(const std::string& str)
+{
+  return instance().get_device_id(str);
 }
 
 system::monitor_access_type

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -52,6 +52,21 @@ public:
   get_devices(boost::property_tree::ptree&) const {}
 
   /**
+   * get_device_id() - Convert string to device index
+   *
+   * Default implementation converts argument string to device index.
+   *
+   * Implement in specialized classes for conversion of special
+   * device string formats, e.g. BDF.
+   *
+   * The native APIs have a xrt::device constructor that takes 
+   * a string.  The implementation of that constructor relies
+   * on this function converting the string to a device index.
+   */
+  virtual device::id_type
+  get_device_id(const std::string& str) const;
+
+  /**
    */
   virtual std::pair<device::id_type, device::id_type>
   get_total_devices(bool is_user = true) const = 0;
@@ -146,6 +161,21 @@ get_devices(boost::property_tree::ptree& pt);
 XRT_CORE_COMMON_EXPORT
 std::pair<uint64_t, uint64_t>
 get_total_devices(bool is_user);
+
+/**
+ * get_device_id() - Convert str to device index
+ *
+ * This function supports string formatted as BDF for systems where
+ * BDF is used.  By default the function converts the argument string
+ * to a number.
+ * 
+ * The native APIs have a xrt::device constructor that takes a string
+ * argument.  The implementation of that constructor relies on this
+ * function converting a bdf to a device index.
+ */
+XRT_CORE_COMMON_EXPORT
+device::id_type
+get_device_id(const std::string& str);
 
 /**
  * get_userpf_device() - Open and create device specified by index

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -59,10 +59,11 @@ public:
    * Implement in specialized classes for conversion of special
    * device string formats, e.g. BDF.
    *
-   * The native APIs have a xrt::device constructor that takes 
+   * The native APIs have a xrt::device constructor that takes
    * a string.  The implementation of that constructor relies
    * on this function converting the string to a device index.
    */
+  XRT_CORE_COMMON_EXPORT
   virtual device::id_type
   get_device_id(const std::string& str) const;
 
@@ -168,7 +169,7 @@ get_total_devices(bool is_user);
  * This function supports string formatted as BDF for systems where
  * BDF is used.  By default the function converts the argument string
  * to a number.
- * 
+ *
  * The native APIs have a xrt::device constructor that takes a string
  * argument.  The implementation of that constructor relies on this
  * function converting a bdf to a device index.

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -49,18 +49,37 @@ public:
   {}
 
   /**
-   * device() - Constructor with user host buffer and flags
+   * device() - Constructor from device index
    *
    * @param didx
    *  Device index
+   *
+   * Throws if no device is found matching the specified index.
    */
   XCL_DRIVER_DLLESPEC
   explicit
   device(unsigned int didx);
 
+  /**
+   * device() - Constructor from string
+   *
+   * @param str
+   *  String identifying the device to open.  
+   *
+   * If the string is in BDF format it matched against devices
+   * installed on the system.  Otherwise the string is assumed
+   * to be a device index.
+   * 
+   * Throws if string format is invalid or no matching device is
+   * found.
+   */
+  XCL_DRIVER_DLLESPEC
+  explicit
+  device(const std::string& bdf);
+
   /// @cond
   /**
-   * device() - Constructor with user host buffer and flags
+   * device() - Constructor from device index
    *
    * @param didx
    *  Device index
@@ -244,6 +263,16 @@ extern "C" {
 XCL_DRIVER_DLLESPEC
 xrtDeviceHandle
 xrtDeviceOpen(unsigned int index);
+
+/**
+ * xrtDeviceOpenByBDF() - Open a device and obtain its handle
+ *
+ * @bdf:           PCIe BDF identifying the device to open
+ * Return:         Handle representing the opened device, or nullptr on error
+ */
+XCL_DRIVER_DLLESPEC
+xrtDeviceHandle
+xrtDeviceOpenByBDF(const char* bdf);
 
 /**
  * xrtDeviceOpenFromXcl() - Open a device from a shim xclDeviceHandle

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -53,15 +53,12 @@ extern "C" {
  * xclOpenByBDF() - Open a device and obtain its handle by PCI BDF
  *
  * @bdf:           Deice PCE BDF
- * @logFileName:   Log file to use for optional logging
- * @level:         Severity level of messages to log
  *
  * Return:         Device handle
  */
 XCL_DRIVER_DLLESPEC
 xclDeviceHandle
-xclOpenByBDF(const char *bdf, const char *logFileName,
-        enum xclVerbosityLevel level);
+xclOpenByBDF(const char *bdf);
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/core/pcie/linux/system_linux.h
+++ b/src/runtime_src/core/pcie/linux/system_linux.h
@@ -30,6 +30,9 @@ public:
   void
   get_os_info(boost::property_tree::ptree &pt);
 
+  device::id_type
+  get_device_id(const std::string& str) const;
+
   std::pair<device::id_type, device::id_type>
   get_total_devices(bool is_user) const;
 
@@ -64,6 +67,14 @@ namespace pcie_linux {
  */
 std::shared_ptr<device>
 get_userpf_device(device::handle_type device_handle, device::id_type id);
+
+/**
+ * get_device_id_from_bdf() - 
+ * Force singleton initialization from static linking
+ * with libxrt_core.
+ */
+device::id_type
+get_device_id_from_bdf(const std::string& bdf);
 
 } // pcie_linux
 

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -213,7 +213,7 @@ is_aligned_ptr(const void* ptr) const
 
 std::string
 device::
-get_bdf() const 
+get_bdf() const
 {
   if (!m_xdevice)
     throw xocl::error(CL_INVALID_DEVICE, "No BDF");
@@ -227,7 +227,7 @@ get_bdf() const
     auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(core_device);
     return xrt_core::query::pcie_bdf::to_string(bdf);
   }
-  catch (const xrt_core::error& ex) {
+  catch (const xrt_core::error&) {
   }
 
   // Provides valid functionality for devices that are
@@ -237,7 +237,7 @@ get_bdf() const
 
 bool
 device::
-is_nodma() const 
+is_nodma() const
 {
   if (!m_xdevice)
     throw xocl::error(CL_INVALID_DEVICE, "Can't check for nodma");
@@ -493,7 +493,7 @@ lock()
   // Open the underlying device if not sub device
   if (!m_parent.get())
     m_xdevice->open();
-  
+
   // All good, return increment lock count
   return ++m_locks;
 }
@@ -818,7 +818,7 @@ copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t ds
     // enable when m2m is the norm
     // cmd_copy_message(src_buffer, dst_buffer);
   }
-  
+
   // Check if any of the buffers are imported
   bool imported = is_imported(src_buffer) || is_imported(dst_buffer);
 

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -222,8 +222,17 @@ get_bdf() const
   auto lk = const_cast<device*>(this)->lock_guard();
 
   auto core_device = m_xdevice->get_core_device();
-  auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(core_device);
-  return xrt_core::query::pcie_bdf::to_string(bdf);
+
+  try {
+    auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(core_device);
+    return xrt_core::query::pcie_bdf::to_string(bdf);
+  }
+  catch (const xrt_core::error& ex) {
+  }
+
+  // Provides valid functionality for devices that are
+  // not identified by bdf
+  return std::to_string(core_device->get_device_id());
 }
 
 bool

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -172,7 +172,7 @@ void runTestThread(arg_t &arg)
     if (arg.dev_str.find(":") == std::string::npos)
         handle = xclOpen(std::stoi(arg.dev_str), "", XCL_QUIET);
     else
-        handle = xclOpenByBDF(arg.dev_str.c_str(), "", XCL_QUIET);
+        handle = xclOpenByBDF(arg.dev_str.c_str());
 
     if (!handle)
         throw std::runtime_error("Could not open device");

--- a/tests/validate/xrt_iops_test/src/xrt_api_iops.cpp
+++ b/tests/validate/xrt_iops_test/src/xrt_api_iops.cpp
@@ -32,7 +32,7 @@ bool verbose = false;
 barrier barrier;
 struct krnl_info krnl = {"hello", false};
 
-static void usage(char *prog)
+static void usage(const char *prog)
 {
   std::cout << "Usage: " << prog << " <Platform Test Area Path> [options]\n"
     << "options:\n"
@@ -73,7 +73,7 @@ double runTest(std::vector<xrt::run>& cmds, unsigned int total, arg_t &arg)
   return (std::chrono::duration_cast<ms_t>(arg.end - arg.start)).count();
 }
 
-void runTestThread(xrt::device &device, xrt::kernel &hello, arg_t &arg)
+void runTestThread(const xrt::device& device, const xrt::kernel& hello, arg_t& arg)
 {
   std::vector<xrt::run> cmds;
 
@@ -89,17 +89,12 @@ void runTestThread(xrt::device &device, xrt::kernel &hello, arg_t &arg)
   barrier.wait();
 }
 
-int testMultiThreads(std::string &dev, std::string &xclbin_fn, int threadNumber, int queueLength, unsigned int total)
+int testMultiThreads(const std::string& dev, const std::string& xclbin_fn, int threadNumber, int queueLength, unsigned int total)
 {
   std::thread threads[threadNumber];
   std::vector<arg_t> arg(threadNumber);
-  xrt::device device;
 
-  if (dev.find(":") == std::string::npos) {
-    device = xrt::device(std::stoi(dev));
-  } else
-    throw std::runtime_error("Not support BDF");
-
+  xrt::device device(dev);
   auto uuid = device.load_xclbin(xclbin_fn);
   auto hello = xrt::kernel(device, uuid.get(), krnl.name);
 

--- a/tests/xrt/00_hello/main.cpp
+++ b/tests/xrt/00_hello/main.cpp
@@ -34,7 +34,7 @@ static void usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
-    std::cout << "  -d <device_index>\n";
+    std::cout << "  -d <bdf | device_index>\n";
     std::cout << "  -c <name of compute unit in xclbin>\n";
     std::cout << "  -v\n";
     std::cout << "  -h\n\n";
@@ -116,7 +116,7 @@ int run(int argc, char** argv)
   std::string xclbin_fnm;
   std::string cu_name = "dummy";
   bool verbose = false;
-  unsigned int device_index = 0;
+  std::string device_index = "0";
 
   std::vector<std::string> args(argv+1,argv+argc);
   std::string cur;
@@ -138,7 +138,7 @@ int run(int argc, char** argv)
     if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "-d")
-      device_index = std::stoi(arg);
+      device_index = arg;
     else if (cur == "-c")
       cu_name = arg;
     else

--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -31,7 +31,7 @@ static void usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
-    std::cout << "  [-d <index>]       (default: 0)\n";
+    std::cout << "  [-d <bdf | index>]  (default: 0)\n";
     std::cout << "  [-v]\n";
     std::cout << "  [-h]\n\n";
     std::cout << "* Bitstream is required\n";
@@ -85,7 +85,7 @@ run(int argc, char** argv)
 
   std::string xclbin_fnm;
   bool verbose = false;
-  unsigned int device_index = 0;
+  std::string device_index = "0";
 
   std::vector<std::string> args(argv+1,argv+argc);
   std::string cur;
@@ -107,7 +107,7 @@ run(int argc, char** argv)
     if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "-d")
-      device_index = std::stoi(arg);
+      device_index = arg;
     else
       throw std::runtime_error("Unknown option value " + cur + " " + arg);
   }

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -39,7 +39,7 @@ static void usage()
 {
     std::cout << "usage: %s [options] -k <xclbin>\n\n";
     std::cout << "  -k <bitstream>\n";
-    std::cout << "  -d <device_index>\n";
+    std::cout << "  -d <bdf | index> (default: 0)\n";
     std::cout << "  -v\n";
     std::cout << "  -h\n\n";
     std::cout << "";
@@ -55,7 +55,7 @@ int run(int argc, char** argv)
 
   std::string xclbin_fnm;
   bool verbose = false;
-  unsigned int device_index = 0;
+  std::string device_index = "0";
 
   std::vector<std::string> args(argv+1,argv+argc);
   std::string cur;
@@ -77,7 +77,7 @@ int run(int argc, char** argv)
     if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "-d")
-      device_index = std::stoi(arg);
+      device_index = arg;
     else
       throw std::runtime_error("Unknown option value " + cur + " " + arg);
   }

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -30,7 +30,7 @@ static void usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
-    std::cout << "  -d <device_index>\n";
+    std::cout << "  -d <bdf | index> (default: 0)\n";
     std::cout << "  -v\n";
     std::cout << "  -h\n\n";
     std::cout << "";
@@ -46,7 +46,7 @@ int run(int argc, char** argv)
 
   std::string xclbin_fnm;
   bool verbose = false;
-  unsigned int device_index = 0;
+  std::string device_index = "0";
 
   std::vector<std::string> args(argv+1,argv+argc);
   std::string cur;
@@ -68,7 +68,7 @@ int run(int argc, char** argv)
     if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "-d")
-      device_index = std::stoi(arg);
+      device_index = arg;
     else
       throw std::runtime_error("Unknown option value " + cur + " " + arg);
   }

--- a/tests/xrt/100_ert_ncu/xrtxx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx.cpp
@@ -43,7 +43,7 @@ static void usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
-  std::cout << "  -d <device_index>\n";
+  std::cout << "  -d <bdf | device_index>\n";
   std::cout << "";
   std::cout << "  [--jobs <number>]: number of concurrently scheduled jobs\n";
   std::cout << "  [--cus <number>]: number of cus to use (default: 8) (max: 8)\n";
@@ -207,7 +207,7 @@ int run(int argc, char** argv)
   std::vector<std::string> args(argv+1,argv+argc);
 
   std::string xclbin_fnm;
-  unsigned int device_index = 0;
+  std::string device_id = "0";
   size_t secs = 0;
   size_t jobs = 1;
   size_t cus  = 1;
@@ -225,7 +225,7 @@ int run(int argc, char** argv)
     }
 
     if (cur == "-d")
-      device_index = std::stoi(arg);
+      device_id = arg;
     else if (cur == "-k")
       xclbin_fnm = arg;
     else if (cur == "--jobs")
@@ -238,7 +238,7 @@ int run(int argc, char** argv)
       throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
   }
 
-  auto device = xrt::device(device_index);
+  auto device = xrt::device(device_id);
   auto uuid = device.load_xclbin(xclbin_fnm);
 
   compute_units = cus = std::min(cus, compute_units);


### PR DESCRIPTION
String can be BDF or just a board number.  Some tweaks to consolidate
and share conversion of BDF string to board number.