### PR TITLE
CR-1077304: Displaying copy buffer events in the OpenCL timeline trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -117,6 +117,8 @@ namespace xdp {
     virtual bool isWriteBuffer() { return type == WRITE_BUFFER || 
 	                                  type == WRITE_BUFFER_P2P ||
 	                                  type == LOP_WRITE_BUFFER ; }
+    virtual bool isCopyBuffer() { return type == COPY_BUFFER ||
+                                         type == COPY_BUFFER_P2P ; }
     virtual bool isKernelEnqueue() { return type == KERNEL_ENQUEUE ||
 	                                    type == LOP_KERNEL_ENQUEUE ; }
 

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -30,7 +30,7 @@ namespace xdp {
                    "1.0", 
                    getCurrentDateTime(), 
                    9 /* ns */),
-    generalAPIBucket(-1), readBucket(-1), writeBucket(-1)
+    generalAPIBucket(-1), readBucket(-1), writeBucket(-1), copyBucket(-1)
   {
   }
 
@@ -51,6 +51,8 @@ namespace xdp {
     readBucket = rowID ;
     ++rowID ;
     writeBucket = rowID ;
+    ++rowID ;
+    copyBucket = rowID ;
     ++rowID ;
     for (auto e : (db->getStaticInfo()).getEnqueuedKernels())
     {
@@ -89,6 +91,9 @@ namespace xdp {
     fout << "Dynamic_Row," << writeBucket
          << ",Write,Write data transfer from host to global memory"
          << std::endl ;
+    fout << "Dynamic_Row," << copyBucket
+	 << ",Copy,Copy data transfers from global memory to global memory"
+	 << std::endl ;
     fout << "Group_End,Data Transfer" << std::endl ;
     fout << "Group_Start,Kernel Enqueues" << std::endl ;
     //fout << "Dynamic_Row_Summary," << enqueueSummaryBucket 
@@ -133,6 +138,9 @@ namespace xdp {
       else if (e->isWriteBuffer())
       {
         bucket = writeBucket ;
+      }
+      else if (e->isCopyBuffer()) {
+	bucket = copyBucket ;
       }
       else if (e->isKernelEnqueue())
       {

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.h
@@ -34,6 +34,7 @@ namespace xdp {
     int generalAPIBucket ;
     int readBucket ;
     int writeBucket ;
+    int copyBucket ;
     std::map<std::string, int> enqueueBuckets ;
 
     void setupBuckets() ;


### PR DESCRIPTION
Reintroducing the "Copy" category in the opencl_trace file for copy buffer events.  This was missing in the refactored code and copy buffer events were being put in the general API bucket.