### PR TITLE
CR-1086867 Softkernel name is not displayed correctly

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -248,6 +248,7 @@ SET (XRT_DKMS_DRIVER_INCLUDES
   include/profile_ioctl.h
   include/mailbox_proto.h
   include/flash_xrt_data.h
+  include/ps_kernel.h
   )
 
 # includes relative to core

--- a/src/runtime_src/core/common/drv/include/xrt_xclbin.h
+++ b/src/runtime_src/core/common/drv/include/xrt_xclbin.h
@@ -71,7 +71,7 @@ xrt_xclbin_get_section(const struct axlf *xclbin,
 	enum axlf_section_kind kind, void **data, uint64_t *len);
 
 struct axlf_section_header *
-xrt_xclbin_get_section_hdr_next(struct axlf *xclbin,
+xrt_xclbin_get_section_hdr_next(const struct axlf *xclbin,
 	enum axlf_section_kind kind, struct axlf_section_header *cur);
 
 int xrt_xclbin_get_section_num(const struct axlf *xclbin,

--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -243,7 +243,7 @@ xrt_xclbin_section_info(const struct axlf *xclbin, enum axlf_section_kind kind,
 }
 
 struct axlf_section_header *
-xrt_xclbin_get_section_hdr_next(struct axlf *xclbin,
+xrt_xclbin_get_section_hdr_next(const struct axlf *xclbin,
 	enum axlf_section_kind kind, struct axlf_section_header *cur)
 {
 	int i;
@@ -253,7 +253,7 @@ xrt_xclbin_get_section_hdr_next(struct axlf *xclbin,
 	for (i = 0; i < xclbin->m_header.m_numSections; i++) {
 		if (xclbin->m_sections[i].m_sectionKind == kind) {
 			if (match)
-				return &xclbin->m_sections[i];
+				return (struct axlf_section_header *)&xclbin->m_sections[i];
 
 			if (&xclbin->m_sections[i] == cur) {
 				match = true;
@@ -267,7 +267,7 @@ xrt_xclbin_get_section_hdr_next(struct axlf *xclbin,
 	if (found < 0)
 		return NULL;
 
-	return &xclbin->m_sections[found];
+	return (struct axlf_section_header *)&xclbin->m_sections[found];
 }
 
 int xrt_xclbin_get_section_num(const struct axlf *xclbin,

--- a/src/runtime_src/core/pcie/driver/linux/include/ps_kernel.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/ps_kernel.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *		 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _PS_KERNEL_H_
+#define _PS_KERNEL_H_
+
+/*
+ * This header file contains data structure for xrt PS kernel metadata. This
+ * file is included in user space utilities and kernel drivers. The data
+ * structure is used to describe PS kernel which is written by driver
+ * and read by utility.
+ */
+
+#define	PS_KERNEL_NAME_LENGTH	20
+
+struct ps_kernel_data {
+	char		pkd_sym_name[PS_KERNEL_NAME_LENGTH];
+	uint32_t	pkd_num_instances;
+};
+
+struct ps_kernel_node {
+	uint32_t		pkn_count;
+	struct ps_kernel_data	pkn_data[1];
+};
+
+#endif /* _PS_KERNEL_H_ */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4315,15 +4315,13 @@ static int config_scu(struct platform_device *pdev,
 		for (j = cp->start_cuidx; j < cp->start_cuidx + cp->num_cus;
 		    j++) {
 			char scu_name[32];
-			int slen;
 
 			if (strlen(xert->scu_name[j]) > 0)
 				continue;
 			exec->num_sk_cus++;
 
 			/* Add "scu_idx#" suffix to identify PS kernel */
-			slen = strlen((char*)cp->sk_name);
-			strncpy(scu_name, ((char *)cp->sk_name) + slen,
+			strncpy(scu_name, ((char *)cp->sk_name),
 				sizeof(xert->scu_name[0]) - 8);
 			snprintf(xert->scu_name[j], 32, "%s:scu_%d",
 				scu_name, j);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -4321,18 +4321,8 @@ static int config_scu(struct platform_device *pdev,
 				continue;
 			exec->num_sk_cus++;
 
-			/*
-			 * Add "scu_idx#" suffix to identify softkernel
-			 *
-			 * And limit SCU name to the last 11 characters
-			 * to fit kds_custat sysfs node into PAGE_SIZE
-			 * with no more than 64 SCUs.
-			 */
+			/* Add "scu_idx#" suffix to identify PS kernel */
 			slen = strlen((char*)cp->sk_name);
-			if (slen > 11)
-				slen -= 11;
-			else
-				slen = 0;
 			strncpy(scu_name, ((char *)cp->sk_name) + slen,
 				sizeof(xert->scu_name[0]) - 8);
 			snprintf(xert->scu_name[j], 32, "%s:scu_%d",
@@ -4909,16 +4899,16 @@ kds_custat_show(struct device *dev, struct device_attribute *attr, char *buf)
 	}
 
 	if (xert) {
-		/* soft kernel CUs */
+		/* PS kernel CUs */
 		for (;idx < (exec->num_cus + exec->num_sk_cus); ++idx) {
 			cu_status = ert_cu_status(xert, idx);
 			if (!cu_status)
 				cu_status = AP_IDLE;
 			sz_tmp = sz;
-			sz += sprintf(tembuf+sz, "CU[@0x0] : %d status : %d name : %s\n",
+			sz += sprintf(tembuf+sz, "CU[@0x0] : %d status : %d\n",
 				      ert_cu_usage(xert, idx),
-				      cu_status,
-				      xert->scu_name[idx - exec->num_cus]);
+				      cu_status);
+
 			if (sz >= PAGE_SIZE) {
 				sz = sz_tmp;
 				truncated = true;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  * Author: Sonal Santan, Ryan Radjabi
  * Simple command line utility to inetract with SDX PCIe devices
  *
@@ -36,6 +36,7 @@
 #include "core/pcie/common/dmatest.h"
 #include "core/pcie/common/memaccess.h"
 #include "core/pcie/common/dd.h"
+#include "core/pcie/driver/linux/include/ps_kernel.h"
 #include "core/common/utils.h"
 #include "core/common/time.h"
 #include "core/common/sensor.h"
@@ -369,6 +370,30 @@ public:
         return 0;
     }
 
+    int getPSKernels(std::vector<ps_kernel_data> &psKernels) const
+    {
+        std::string errmsg;
+        std::vector<char> buf;
+
+        pcidev::get_dev(m_idx)->sysfs_get("icap", "ps_kernel", errmsg, buf);
+
+        if (!errmsg.empty()) {
+            std::cout << errmsg << std::endl;
+            return -EINVAL;
+        }
+        if (buf.empty())
+            return 0;
+
+        const ps_kernel_node *map = (ps_kernel_node *)buf.data();
+        if(map->pkn_count < 0)
+            return -EINVAL;
+
+        for (unsigned int i = 0; i < map->pkn_count; i++)
+                psKernels.emplace_back(map->pkn_data[i]);
+
+        return 0;
+    }
+
     /* Old kds style */
     uint32_t parseComputeUnitStat(const std::vector<std::string>& custat, uint32_t offset, cu_stat kind) const
     {
@@ -464,17 +489,32 @@ public:
         }
 
         //Soft kernel info below
+        std::vector<ps_kernel_data> psKernels;
+        if (getPSKernels(psKernels) < 0) {
+            std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
+            return 0;
+        }
+
+        int psk_inst = 0;
+        uint32_t num_scu = 0;
         for (unsigned int i = computeUnits.size(); i < parseComputeUnitNum(custat); i++) {
             uint32_t status = parseComputeUnitStat(custat, i, cu_stat::stat);
             uint32_t usage = parseComputeUnitStat(custat, i, cu_stat::usage);
-	    auto name = parseComputeUnitName(custat, i);
+            std::string name = psKernels.at(psk_inst).pkd_sym_name;
+            name += ":scu_" + std::to_string(i - computeUnits.size());
 
-	    boost::property_tree::ptree ptCu;
+            boost::property_tree::ptree ptCu;
             ptCu.put( "name",         name );
             ptCu.put( "base_address", 0 );
             ptCu.put( "usage",        usage );
             ptCu.put( "status",       xrt_core::utils::parse_cu_status( status ) );
             sensor_tree::add_child( std::string("board.compute_unit." + std::to_string(i)), ptCu );
+
+            num_scu++;
+            if (num_scu == psKernels.at(psk_inst).pkd_num_instances) {
+                num_scu = 0;
+                psk_inst++;
+            }
         }
 
         return 0;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -389,7 +389,7 @@ public:
             return -EINVAL;
 
         for (unsigned int i = 0; i < map->pkn_count; i++)
-                psKernels.emplace_back(map->pkn_data[i]);
+            psKernels.emplace_back(map->pkn_data[i]);
 
         return 0;
     }
@@ -428,11 +428,11 @@ public:
        uint32_t cu_count = 0;
 
        if (custat.empty())
-          return 0; 
+          return 0;
 
        //CU or Soft Kernel CU syntax
        //    CU[@0x1400000] : 0 status : 4
-       //    CU[@0x0] : 0 status : 4 name : kernel1
+       //    CU[@0x0] : 0 status : 4
        //
        for (auto& line : custat) {
            cu_count += std::strncmp(line.c_str(), "CU[", 3) ? 0 : 1;
@@ -450,7 +450,7 @@ public:
 
        //CU or Soft Kernel CU syntax
        //    CU[@0x1400000] : 0 status : 4
-       //    CU[@0x0] : 0 status : 4 name : kernel1
+       //    CU[@0x0] : 0 status : 4
        //
        for (auto& line : custat) {
            i += std::strncmp(line.c_str(), "CU[", 3) ? 0 : 1;


### PR DESCRIPTION
Currently, since we are using sysfs-node "kds_custat" to interpret PS kernel name, it is very possible to overflow the plain-text sysfs node which is limited to one PAGE SIZE (4K in this case). If overflowed, either PS kernel symbol name can not be displayed fully and correctly, or some information in that sysfs node is trucated.

The solution is to not rely on kds_custat for SCU name but create a new sysfs node in "icap":"ps_kernel" with bin format. So that we won't have limitation about PS kernel name.

This PR include
1. Extract PS kernel metadata from XCLBIN and cache it into icap softstate
2. Create new sysfs node "ps_kernel"
3. Remove putting PS kernel name into "kds_custat" 
4. Update xbutil tool to use new sysfs node for PS kernel name
5. Minor clean up.  

@AShivangi  Please take a look at the xbuil part. We can discuss how to port this support to xbutil2