### PR TITLE
xocl: issue xbutil reset only if device is in ready state (#4725)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -1885,8 +1885,11 @@ int mailbox_request(struct platform_device *pdev, void *req, size_t reqlen,
 	struct mailbox_msg *reqmsg = NULL, *respmsg = NULL;
 	bool sw_ch = req_is_sw(pdev, ((struct xcl_mailbox_req *)req)->req);
 
-	if (req_is_disabled(pdev, ((struct xcl_mailbox_req *)req)->req))
+	if (req_is_disabled(pdev, ((struct xcl_mailbox_req *)req)->req)) {
+		MBX_WARN(mbx, "req %d is received on disabled channel, err: %d",
+				 ((struct xcl_mailbox_req *)req)->req, -EFAULT);
 		return -EFAULT;
+	}
 
 	MBX_INFO(mbx, "sending request: %d via %s",
 		((struct xcl_mailbox_req *)req)->req, (sw_ch ? "SW" : "HW"));

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.cpp
@@ -1766,6 +1766,10 @@ int xcldev::xclReset(int argc, char *argv[])
 
     std::string vbnv, errmsg;
     auto dev = pcidev::get_dev(index);
+    if (!dev->is_ready) {
+        std::cerr << "device [" << index << "] is not ready, reset command exiting" << std::endl;
+        return -EINVAL;
+    }
     dev->sysfs_get( "rom", "VBNV", errmsg, vbnv );
     if (!errmsg.empty()) {
         std::cerr << errmsg << std::endl;


### PR DESCRIPTION
Issue xbutil reset command only when device is in ready state. Also, read return status of xocl peer requests and act accordingly.