### PR TITLE
Porting recent U30 changes to new KDS

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -22,8 +22,6 @@
 #include "xrt_cu.h"
 #include "kds_stat.h"
 
-#define PRE_ALLOC 0
-
 #define EV_ABORT	0x1
 
 
@@ -62,12 +60,6 @@ struct kds_client {
 	struct list_head	  ev_entry;
 	int			  ev_type;
 
-#if PRE_ALLOC
-	u32			  max_xcmd;
-	u32			  xcmd_idx;
-	void			 *xcmds;
-	void			 *infos;
-#endif
 	/*
 	 * Below are modified when the other thread is completing commands.
 	 * In order to prevent false sharing, they need to be in different

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -20,7 +20,8 @@
 #define KEY_VAL 1
 
 enum kds_opcode {
-	OP_CONFIG = 0,
+	OP_NONE = 0,
+	OP_CONFIG,
 	OP_START,
 	OP_CONFIG_SK, /* TODO: There is a plan to remove softkernel config and unconfig command */
 	OP_START_SK,
@@ -30,8 +31,9 @@ enum kds_opcode {
 };
 
 enum kds_status {
-	KDS_COMPLETED	= 0,
-	KDS_ERROR	= 1,
+	KDS_NEW = 0,
+	KDS_COMPLETED,
+	KDS_ERROR,
 	KDS_ABORT,
 	KDS_TIMEOUT,
 };
@@ -48,10 +50,8 @@ struct in_kernel_cb {
 	void *data;
 };
 
-/* Default cu index of a command.
- * Some command are not CU specific, it would keep to be default index.
- */
-#define DEFAULT_INDEX -1
+/* Default cu index of a command */
+#define NO_INDEX -1
 
 /**
  * struct kds_command: KDS command struct

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -26,6 +26,7 @@ enum kds_opcode {
 	OP_START_SK,
 	OP_CLK_CALIB,
 	OP_VALIDATE,
+	OP_GET_STAT,
 };
 
 enum kds_status {

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -75,7 +75,6 @@ struct kds_cu_mgmt {
 	u32			  cu_intr[MAX_CUS];
 	u32			  cu_refs[MAX_CUS];
 	struct cu_stats __percpu *cu_stats;
-	int			  configured;
 };
 
 #define cu_stat_read(cu_mgmt, field) \
@@ -95,8 +94,6 @@ struct kds_ert {
 	void (* submit)(struct kds_ert *ert, struct kds_command *xcmd);
 	void (* abort)(struct kds_ert *ert, struct kds_client *client, int cu_idx);
 	bool (* abort_done)(struct kds_ert *ert, struct kds_client *client, int cu_idx);
-	struct mutex		  lock;
-	int			  configured;
 };
 
 struct plram_info {
@@ -159,6 +156,8 @@ int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 int kds_del_context(struct kds_sched *kds, struct kds_client *client,
 		    struct kds_ctx_info *info);
 int kds_add_command(struct kds_sched *kds, struct kds_command *xcmd);
+/* Use this function in xclbin download flow for config commands */
+int kds_submit_cmd_and_wait(struct kds_sched *kds, struct kds_command *xcmd);
 
 struct kds_command *kds_alloc_command(struct kds_client *client, u32 size);
 

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -54,6 +54,17 @@ struct kds_ctx_info {
 	u32		  flags;
 };
 
+/* TODO: PS kernel is very different with FPGA kernel.
+ * Let's see if we can unify them later.
+ */
+struct kds_scu_mgmt {
+	struct mutex		  lock;
+	int			  num_cus;
+	u32			  status[MAX_CUS];
+	u32			  usage[MAX_CUS];
+	char			  name[MAX_CUS][32];
+};
+
 /* the MSB of cu_refs is used for exclusive flag */
 #define CU_EXCLU_MASK		0x80000000
 struct kds_cu_mgmt {
@@ -116,6 +127,7 @@ struct kds_sched {
 	struct mutex		lock;
 	bool			bad_state;
 	struct kds_cu_mgmt	cu_mgmt;
+	struct kds_scu_mgmt	scu_mgmt;
 	struct kds_ert	       *ert;
 	bool			ini_disable;
 	bool			ert_disable;
@@ -157,4 +169,5 @@ int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
 		   int kds_mode, u32 clients, int *echo);
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf);
 ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf);
+ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf);
 #endif

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -226,12 +226,10 @@ struct xrt_cu {
 	 * Pending Q is used in thread that is submitting CU cmds.
 	 * Other Qs are used in thread that is completing them.
 	 * In order to prevent false sharing, they need to be in different
-	 * cache lines. Hence we add a "padding" in between (assuming 128-byte
-	 * is big enough for most CPU architectures).
+	 * cache lines.
 	 */
-	u64			  padding[16];
 	/* run queue */
-	struct list_head	  rq;
+	struct list_head	  rq ____cacheline_aligned_in_smp;
 	u32			  num_rq;
 	/* submitted queue */
 	struct list_head	  sq;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -74,6 +74,42 @@ ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf)
 	return sz;
 }
 
+/* Each line is a PS kernel, format:
+ * "idx kernel_name status usage"
+ */
+ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
+{
+	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
+	char *cu_fmt = "%d,%s,0x%x,%u\n";
+	ssize_t sz = 0;
+	int i;
+
+	/* TODO: The number of PS kernel could be 64 or even more.
+	 * Sysfs has PAGE_SIZE limit, which keep bother us in old KDS.
+	 * In 128 PS kernels case, each line is average 32 bytes.
+	 * The kernel name is no more than 19 bytes.
+	 *
+	 * Old KDS shows FPGA Kernel and PS kernel in one file.
+	 * So, this separate kds_scustat_raw is better.
+	 *
+	 * But in the worst case, this is still not good enough.
+	 */
+	mutex_lock(&scu_mgmt->lock);
+	for (i = 0; i < scu_mgmt->num_cus; ++i) {
+		sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, i,
+				scu_mgmt->name[i], scu_mgmt->status[i],
+				scu_mgmt->usage[i]);
+	}
+	mutex_unlock(&scu_mgmt->lock);
+
+	if (sz < PAGE_SIZE - 1)
+		buf[sz++] = 0;
+	else
+		buf[PAGE_SIZE - 1] = 0;
+
+	return sz;
+}
+
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
@@ -157,6 +193,39 @@ kds_cu_config(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 out:
 	mutex_unlock(&cu_mgmt->lock);
 	return ret;
+}
+
+static int
+kds_scu_config(struct kds_scu_mgmt *scu_mgmt, struct kds_command *xcmd)
+{
+	struct ert_configure_sk_cmd *scmd;
+	int i, j;
+
+	scmd = (struct ert_configure_sk_cmd *)xcmd->execbuf;
+	for (i = 0; i < scmd->num_image; i++) {
+		struct config_sk_image *cp = &scmd->image[i];
+
+		for (j = 0; j < cp->num_cus; j++) {
+			int scu_idx = j + cp->start_cuidx;
+
+			/* TODO: Why continue? */
+			if (strlen(scu_mgmt->name[scu_idx]) > 0)
+				continue;
+
+			/*
+			 * TODO: Need consider size limit of the name.
+			 * In case PAGE_SIZE sysfs node cannot show all
+			 * SCUs (more than 64 SCUs or up to 128).
+			 */
+			strncpy(scu_mgmt->name[scu_idx], (char *)cp->sk_name,
+				sizeof(scu_mgmt->name[0]));
+
+			scu_mgmt->num_cus++;
+			scu_mgmt->usage[i] = 0;
+		}
+	}
+
+	return 0;
 }
 
 /**
@@ -256,6 +325,10 @@ kds_submit_cu(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 			xcmd->cb.free(xcmd);
 		}
 		break;
+	case OP_GET_STAT:
+		xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
+		xcmd->cb.free(xcmd);
+		break;
 	default:
 		ret = -EINVAL;
 		kds_err(xcmd->client, "Unknown opcode");
@@ -299,6 +372,11 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 		mutex_unlock(&ert->lock);
 		return 0;
 	case OP_CONFIG_SK:
+		ret = kds_scu_config(&kds->scu_mgmt, xcmd);
+		if (ret)
+			return ret;
+		break;
+	case OP_GET_STAT:
 	case OP_START_SK:
 	case OP_CLK_CALIB:
 	case OP_VALIDATE:
@@ -436,6 +514,7 @@ int kds_init_sched(struct kds_sched *kds)
 	INIT_LIST_HEAD(&kds->clients);
 	mutex_init(&kds->lock);
 	mutex_init(&kds->cu_mgmt.lock);
+	mutex_init(&kds->scu_mgmt.lock);
 	kds->num_client = 0;
 	kds->bad_state = 0;
 	/* At this point, I don't know if ERT subdev exist or not */
@@ -865,9 +944,15 @@ int kds_fini_ert(struct kds_sched *kds)
 
 void kds_reset(struct kds_sched *kds)
 {
+	int idx;
+
 	kds->bad_state = 0;
 	kds->ert_disable = true;
 	kds->ini_disable = false;
+
+	/* TODO: Do we still need this in new KDS? */
+	for (idx = 0; idx < MAX_CUS; ++idx)
+		kds->scu_mgmt.name[idx][0] = 0;
 }
 
 static int kds_fa_assign_plram(struct kds_sched *kds)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -3000,6 +3000,9 @@ static int icap_get_xclbin_metadata(struct platform_device *pdev,
 	case XCLBIN_UUID:
 		*buf = &icap->icap_bitstream_uuid;
 		break;
+	case SOFT_KERNEL:
+		*buf = icap->ps_kernel;
+		break;
 	default:
 		break;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -347,16 +347,12 @@ static int csr_read32(struct platform_device *pdev, u32 off)
 {
 	struct xocl_intc *intc = platform_get_drvdata(pdev);
 
-	WARN_ON(intc->ert[off>>2].enabled_cnt > 0);
-
 	return ioread32(intc->csr_base + off);
 }
 
 static void csr_write32(struct platform_device *pdev, u32 val, u32 off)
 {
 	struct xocl_intc *intc = platform_get_drvdata(pdev);
-
-	WARN_ON(intc->ert[off>>2].enabled_cnt > 0);
 
 	iowrite32(val, intc->csr_base + off);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -14,6 +14,7 @@
  * Cound not avoid coupling xclbin.h
  */
 #include "xclbin.h"
+#include "ps_kernel.h"
 
 #ifdef KDS_VERBOSE
 #define print_ecmd_info(ecmd) \
@@ -388,10 +389,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	struct drm_xocl_bo *xobj;
 	struct ert_packet *ecmd;
 	struct kds_command *xcmd;
-	struct kds_cu_mgmt *cu_mgmt;
-	u32 cdma_addr;
 	int ret = 0;
-	int i;
 
 	if (!client->xclbin_id) {
 		userpf_err(xdev, "The client has no opening context\n");
@@ -429,6 +427,9 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		goto out;
 	}
 	xcmd->cb.free = kds_free_command;
+	xcmd->cb.notify_host = notify_execbuf;
+	xcmd->execbuf = (u32 *)ecmd;
+	xcmd->gem_obj = obj;
 
 	print_ecmd_info(ecmd);
 
@@ -443,31 +444,14 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 
 	switch (ecmd->opcode) {
 	case ERT_CONFIGURE:
-		cfg_ecmd2xcmd(to_cfg_pkg(ecmd), xcmd);
-
-		/* Special handle for m2m cu :( */
-		cu_mgmt = &XDEV(xdev)->kds.cu_mgmt;
-		i = cu_mgmt->num_cus - cu_mgmt->num_cdma;
-		while (i < cu_mgmt->num_cus) {
-			cdma_addr = cu_mgmt->xcus[i]->info.addr;
-			to_cfg_pkg(ecmd)->data[i] = cdma_addr;
-			to_cfg_pkg(ecmd)->count++;
-			to_cfg_pkg(ecmd)->num_cus++;
-			i++;
-		}
-
-		/* Before scheduler config options are removed from xrt.ini */
-		if (XDEV(xdev)->kds.ini_disable)
-			break;
-
-		if (to_cfg_pkg(ecmd)->ert && XDEV(xdev)->kds.ert) {
-			XDEV(xdev)->kds.ert_disable = false;
-			xcmd->type = KDS_ERT;
-		} else {
-			XDEV(xdev)->kds.ert_disable = true;
-			xcmd->type = KDS_CU;
-		}
-		break;
+	case ERT_SK_CONFIG:
+		/* All configure commands are moved to xclbin download flow.
+		 * We can safely ignore user's config command and directly
+		 * return complete.
+		 */
+		xcmd->status = KDS_COMPLETED;
+		xcmd->cb.notify_host(xcmd, xcmd->status);
+		goto out1;
 	case ERT_START_CU:
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
@@ -478,41 +462,33 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		break;
 	case ERT_START_COPYBO:
 		ret = copybo_ecmd2xcmd(xdev, filp, to_copybo_pkg(ecmd), xcmd);
-		if (ret) {
-			xcmd->cb.free(xcmd);
-			return (ret < 0)? ret : 0;
-		}
+		if (ret > 0) {
+			ret = 0;
+			goto out1;
+		} else if (ret < 0)
+			goto out1;
+
 		break;
-	case ERT_SK_CONFIG:
-	case ERT_SK_UNCONFIG:
 	case ERT_SK_START:
 		ret = sk_ecmd2xcmd(xdev, ecmd, xcmd);
-		if (ret) {
-			xcmd->cb.free(xcmd);
-			goto out;
-		}
+		if (ret)
+			goto out1;
 		break;
 	case ERT_CLK_CALIB:
-		xcmd->execbuf = (u32 *)ecmd;
 		xcmd->opcode = OP_CLK_CALIB;
 		break;
 	case ERT_MB_VALIDATE:
-		xcmd->execbuf = (u32 *)ecmd;
 		xcmd->opcode = OP_VALIDATE;
 		break;
 	case ERT_CU_STAT:
-		xcmd->execbuf = (u32 *)ecmd;
 		xcmd->opcode = OP_GET_STAT;
 		xcmd->priv = &XDEV(xdev)->kds;
 		break;
 	default:
 		userpf_err(xdev, "Unsupport command\n");
-		xcmd->cb.free(xcmd);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out1;
 	}
-
-	xcmd->cb.notify_host = notify_execbuf;
-	xcmd->gem_obj = obj;
 
 	if (in_kernel) {
 		struct drm_xocl_execbuf_cb *args_cb =
@@ -522,9 +498,8 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 			xcmd->inkern_cb = kzalloc(sizeof(struct in_kernel_cb),
 								GFP_KERNEL);
 			if (!xcmd->inkern_cb) {
-				xcmd->cb.free(xcmd);
 				ret = -ENOMEM;
-				goto out;
+				goto out1;
 			}
 			xcmd->inkern_cb->func = (void (*)(unsigned long, int))
 						args_cb->cb_func;
@@ -532,10 +507,19 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		}
 	}
 
-	/* Now, we could forget execbuf */
+	/* If add command returns failed, KDS core would take care of
+	 * xcmd and put gem object while notify host.
+	 */
 	ret = kds_add_command(&XDEV(xdev)->kds, xcmd);
 
+	return ret;
+
+out1:
+	xcmd->cb.free(xcmd);
 out:
+	/* Don't forget to put gem object if error happen */
+	if (ret < 0)
+		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 	return ret;
 }
 
@@ -805,25 +789,20 @@ static void xocl_cfg_notify(struct kds_command *xcmd, int status)
 }
 
 /* Construct ERT config command and wait for completion */
-static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
+static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
+			struct ert_packet *pkg, struct drm_xocl_kds *cfg)
 {
-	struct kds_client *client;
-	struct ert_configure_cmd *ecmd;
 	struct kds_command *xcmd;
+	struct ert_configure_cmd *ecmd = to_cfg_pkg(pkg);
 	struct kds_sched *kds = &XDEV(xdev)->kds;
-	pid_t pid = pid_nr(get_pid(task_pid(current)));
-	int num_cu = kds_get_cu_total(&XDEV(xdev)->kds);
+	int num_cu = kds_get_cu_total(kds);
 	u32 base_addr = 0xFFFFFFFF;
 	int ret = 0;
 	int i;
 
-	/* TODO: Use hard code size is not ideal. Let's refine this later */
-	ecmd = vmalloc(0x1000);
-	if (!ecmd)
-		return -ENOMEM;
-
-	client = kds_get_client(kds, pid);
-	BUG_ON(!client);
+	/* Don't send config command if ERT doesn't present */
+	if (!kds->ert)
+		return 0;
 
 	/* Fill header */
 	ecmd->state = ERT_CMD_STATE_NEW;
@@ -833,14 +812,14 @@ static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 
 	ecmd->num_cus	= num_cu;
 	ecmd->cu_shift	= 16;
-	ecmd->slot_size	= cfg.slot_size;
-	ecmd->ert	= cfg.ert;
-	ecmd->polling	= cfg.polling;
-	ecmd->cu_dma	= cfg.cu_dma;
-	ecmd->cu_isr	= cfg.cu_isr;
-	ecmd->cq_int	= cfg.cq_int;
-	ecmd->dataflow	= cfg.dataflow;
-	ecmd->rw_shared	= cfg.rw_shared;
+	ecmd->slot_size	= cfg->slot_size;
+	ecmd->ert	= cfg->ert;
+	ecmd->polling	= cfg->polling;
+	ecmd->cu_dma	= cfg->cu_dma;
+	ecmd->cu_isr	= cfg->cu_isr;
+	ecmd->cq_int	= cfg->cq_int;
+	ecmd->dataflow	= cfg->dataflow;
+	ecmd->rw_shared	= cfg->rw_shared;
 
 	/* Fill CU address */
 	for (i = 0; i < num_cu; i++) {
@@ -873,31 +852,133 @@ static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 	xcmd->cb.notify_host = xocl_cfg_notify;
 	xcmd->priv = kds;
 
-	ret = kds_add_command(kds, xcmd);
+	ret = kds_submit_cmd_and_wait(kds, xcmd);
 	if (ret)
 		goto out;
 
-	ret = wait_for_completion_interruptible(&kds->comp);
-	if (ret == -ERESTARTSYS && !kds->ert_disable) {
-		int bad_state;
-
-		kds->ert->abort(kds->ert, client, -1);
-		do {
-			userpf_info(xdev, "ERT cfg command not finished");
-			msleep(500);
-		} while (ecmd->state < ERT_CMD_STATE_COMPLETED);
-		bad_state = kds->ert->abort_done(kds->ert, client, DEFAULT_INDEX);
-		if (bad_state)
-			kds->bad_state = 1;
-	}
-
-	if (ecmd->state == ERT_CMD_STATE_COMPLETED) {
-		userpf_info(xdev, "Cfg command completed");
-		ret = 0;
-	} else if (ecmd->state > ERT_CMD_STATE_COMPLETED) {
+	if (ecmd->state > ERT_CMD_STATE_COMPLETED) {
 		userpf_err(xdev, "Cfg command state %d", ecmd->state);
 		ret = -EINVAL;
+		goto out;
 	}
+
+	WARN_ON(ecmd->state != ERT_CMD_STATE_COMPLETED);
+
+	/* If xrt.ini is not disabled, let it determines ERT enable/disable */
+	if (!kds->ini_disable)
+		kds->ert_disable = cfg->ert ? false : true;
+
+	userpf_info(xdev, "Cfg command completed");
+
+out:
+	return ret;
+}
+
+/* Construct PS kernel config command and wait for completion */
+static int xocl_scu_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
+			    struct ert_packet *pkg)
+{
+	struct kds_command *xcmd;
+	struct ert_configure_sk_cmd *ecmd = to_cfg_sk_pkg(pkg);
+	struct kds_sched *kds = &XDEV(xdev)->kds;
+	struct ps_kernel_node *ps_kernel = NULL;
+	struct config_sk_image *image;
+	struct ps_kernel_data *scu_data;
+	u32 start_cuidx = 0;
+	u32 img_idx = 0;
+	int ret = 0;
+	int i;
+
+	XOCL_GET_PS_KERNEL(xdev, ps_kernel);
+
+	if (!ps_kernel)
+		goto out;
+
+	/* Clear header */
+	ecmd->header = 0;
+
+	/* Fill PS kernel config command */
+	ecmd->state = ERT_CMD_STATE_NEW;
+	ecmd->opcode = ERT_SK_CONFIG;
+	ecmd->type = ERT_CTRL;
+	ecmd->num_image = ps_kernel->pkn_count;
+	ecmd->count = 1 + ecmd->num_image * sizeof(*image) / 4;
+
+	for (i = 0; i < ecmd->num_image; i++) {
+		image = &ecmd->image[img_idx];
+		scu_data = &ps_kernel->pkn_data[img_idx];
+
+		image->start_cuidx = start_cuidx;
+		image->num_cus = scu_data->pkd_num_instances;
+		image->sk_name[4] = 0;
+		strncpy((char *)image->sk_name, scu_data->pkd_sym_name,
+			PS_KERNEL_NAME_LENGTH);
+
+		start_cuidx += image->num_cus;
+		img_idx++;
+	}
+
+	xcmd = kds_alloc_command(client, ecmd->count * sizeof(u32));
+	if (!xcmd) {
+		userpf_err(xdev, "Failed to alloc xcmd\n");
+		ret = -ENOMEM;
+		goto out;
+	}
+	xcmd->cb.free = kds_free_command;
+
+	print_ecmd_info(ecmd);
+
+	xcmd->type = KDS_ERT;
+	ret = sk_ecmd2xcmd(xdev, (struct ert_packet *)ecmd, xcmd);
+	if (ret) {
+		xcmd->cb.free(xcmd);
+		goto out;
+	}
+
+	xcmd->cb.notify_host = xocl_cfg_notify;
+	xcmd->priv = kds;
+
+	ret = kds_submit_cmd_and_wait(kds, xcmd);
+	if (ret)
+		goto out;
+
+	if (ecmd->state > ERT_CMD_STATE_COMPLETED) {
+		userpf_err(xdev, "PS kernel cfg command state %d", ecmd->state);
+		ret = -EINVAL;
+	} else
+		userpf_info(xdev, "PS kernel cfg command completed");
+
+out:
+	XOCL_PUT_PS_KERNEL(xdev);
+	return ret;
+}
+
+static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
+{
+	struct kds_client *client;
+	struct ert_packet *ecmd;
+	struct kds_sched *kds = &XDEV(xdev)->kds;
+	pid_t pid = pid_nr(get_pid(task_pid(current)));
+	int ret = 0;
+
+	/* TODO: Use hard code size is not ideal. Let's refine this later */
+	ecmd = vmalloc(0x1000);
+	if (!ecmd)
+		return -ENOMEM;
+
+	client = kds_get_client(kds, pid);
+	BUG_ON(!client);
+
+	ret = xocl_cfg_cmd(xdev, client, ecmd, &cfg);
+	if (ret) {
+		userpf_err(xdev, "ERT config command failed");
+		goto out;
+	}
+
+	ret = xocl_scu_cfg_cmd(xdev, client, ecmd);
+	if (ret)
+		userpf_err(xdev, "PS kernel config failed");
+
 out:
 	vfree(ecmd);
 	return ret;
@@ -941,8 +1022,6 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 
 	/* Construct and send configure command */
 	ret = xocl_config_ert(xdev, cfg);
-	if (ret)
-		userpf_info(xdev, "Config command failed, ret %d", ret);
 
 out:
 	return ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -292,10 +292,67 @@ static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,
 	return ret;
 }
 
+/**
+ * New ERT populates:
+ * [1  ]      : header
+ * [1  ]      : custat version
+ * [1  ]      : ert git version
+ * [1  ]      : number of cq slots
+ * [1  ]      : number of cus
+ * [#numcus]  : cu execution stats (number of executions)
+ * [#numcus]  : cu status (1: running, 0: idle)
+ * [#slots]   : command queue slot status
+ *
+ * Old ERT populates
+ * [1  ]      : header
+ * [#numcus]  : cu execution stats (number of executions)
+ */
+static inline void read_ert_stat(struct kds_command *xcmd)
+{
+	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+	struct kds_sched *kds = (struct kds_sched *)xcmd->priv;
+	int num_cu  = kds->cu_mgmt.num_cus;
+	int num_scu = kds->scu_mgmt.num_cus;
+	int off_idx;
+	int i;
+
+	/* New KDS handle FPGA CU statistic on host not ERT */
+	if (ecmd->data[0] != 0x51a10000)
+		return;
+
+	/* Only need PS kernel info, which is after FPGA CUs */
+	mutex_lock(&kds->scu_mgmt.lock);
+	/* Skip header and FPGA CU stats. off_idx points to PS kernel stats */
+	off_idx = 4 + num_cu;
+	for (i = 0; i < num_scu; i++)
+		kds->scu_mgmt.usage[i] = ecmd->data[off_idx + i];
+
+	/* off_idx points to PS kernel status */
+	off_idx += num_scu + num_cu;
+	for (i = 0; i < num_scu; i++) {
+		if (ecmd->data[off_idx + i])
+			kds->scu_mgmt.status[i] = CU_AP_START;
+		else
+			kds->scu_mgmt.status[i] = CU_AP_IDLE;
+	}
+	mutex_unlock(&kds->scu_mgmt.lock);
+}
+
 static void notify_execbuf(struct kds_command *xcmd, int status)
 {
 	struct kds_client *client = xcmd->client;
 	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+
+	if (xcmd->opcode == OP_START_SK) {
+		/* For PS kernel get cmd state and return_code */
+		struct ert_start_kernel_cmd *scmd;
+
+		scmd = (struct ert_start_kernel_cmd *)ecmd;
+		if (scmd->state < ERT_CMD_STATE_COMPLETED)
+			/* It is old shell, return code is missing */
+			scmd->return_code = -ENODATA;
+	} else if (xcmd->opcode == OP_GET_STAT)
+		read_ert_stat(xcmd);
 
 	if (status == KDS_COMPLETED)
 		ecmd->state = ERT_CMD_STATE_COMPLETED;
@@ -442,6 +499,11 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	case ERT_MB_VALIDATE:
 		xcmd->execbuf = (u32 *)ecmd;
 		xcmd->opcode = OP_VALIDATE;
+		break;
+	case ERT_CU_STAT:
+		xcmd->execbuf = (u32 *)ecmd;
+		xcmd->opcode = OP_GET_STAT;
+		xcmd->priv = &XDEV(xdev)->kds;
 		break;
 	default:
 		userpf_err(xdev, "Unsupport command\n");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -242,6 +242,15 @@ kds_custat_raw_show(struct device *dev, struct device_attribute *attr, char *buf
 static DEVICE_ATTR_RO(kds_custat_raw);
 
 static ssize_t
+kds_scustat_raw_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct xocl_dev *xdev = dev_get_drvdata(dev);
+
+	return show_kds_scustat_raw(&XDEV(xdev)->kds, buf);
+}
+static DEVICE_ATTR_RO(kds_scustat_raw);
+
+static ssize_t
 kds_interrupt_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
@@ -659,6 +668,7 @@ static struct attribute *xocl_attrs[] = {
 	&dev_attr_kds_numcdma.attr,
 	&dev_attr_kds_stat.attr,
 	&dev_attr_kds_custat_raw.attr,
+	&dev_attr_kds_scustat_raw.attr,
 	&dev_attr_kds_interrupt.attr,
 	&dev_attr_ert_disable.attr,
 	&dev_attr_dev_offline.attr,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1368,6 +1368,8 @@ enum {
 	(xocl_icap_get_xclbin_metadata(xdev, CONNECTIVITY_AXLF, (void **)&conn))
 #define XOCL_GET_XCLBIN_ID(xdev, xclbin_id)						\
 	(xocl_icap_get_xclbin_metadata(xdev, XCLBIN_UUID, (void **)&xclbin_id))
+#define XOCL_GET_PS_KERNEL(xdev, ps_kernel)						\
+	(xocl_icap_get_xclbin_metadata(xdev, SOFT_KERNEL, (void **)&ps_kernel))
 
 
 #define XOCL_PUT_MEM_TOPOLOGY(xdev)						\
@@ -1379,6 +1381,8 @@ enum {
 #define XOCL_PUT_CONNECTIVITY(xdev)						\
 	xocl_icap_put_xclbin_metadata(xdev)
 #define XOCL_PUT_XCLBIN_ID(xdev)						\
+	xocl_icap_put_xclbin_metadata(xdev)
+#define XOCL_PUT_PS_KERNEL(xdev)						\
 	xocl_icap_put_xclbin_metadata(xdev)
 
 #define XOCL_IS_DDR_USED(topo, ddr) 			\

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -523,9 +523,18 @@ public:
     /* new KDS which supported CU subdevice */
     int parseCUSubdevStat() const
     {
+        if (!std::getenv("XCL_SKIP_CU_READ"))
+          schedulerUpdateStat();
+
         using tokenizer = boost::tokenizer< boost::char_separator<char> >;
         std::vector<std::string> custat;
         std::string errmsg;
+        std::string name(":");
+        uint32_t usage = 0;
+        uint32_t status = 0;
+        int cu_idx = 0;
+        int off_idx = 0;
+        int radix = 16;
 
         // The kds_custat_raw is printing in formatted string of each line
         // Format: "%d,%s:%s,0x%llx,0x%x,%llu"
@@ -533,24 +542,21 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get("", "kds_custat_raw", errmsg, custat);
         for (auto& line : custat) {
             boost::char_separator<char> sep(",");
-            std::string name(":");
             unsigned long long paddr = 0;
-            uint32_t usage = 0;
-            uint32_t status = 0;
-            int cu_idx = 0;
-            int radix = 16;
             tokenizer tokens(line, sep);
 
             // Check if we have 5 tokens: cu_index, name, addr, status, usage
-            if (std::distance(tokens.begin(), tokens.end()) == 5) {
-                tokenizer::iterator tok_it = tokens.begin();
-                cu_idx = std::stoi(std::string(*tok_it++));
-                name = std::string(*tok_it++);
-                paddr = std::stoull(std::string(*tok_it++), nullptr, radix);
-                status = std::stoul(std::string(*tok_it++), nullptr, radix);
-                usage = std::stoul(std::string(*tok_it++));
-            } else
+            if (std::distance(tokens.begin(), tokens.end()) != 5) {
+                std::cout << "WARNING: 'kds_scustat_raw' has no expect tokens, stop parsing.\n";
                 break;
+            }
+
+            tokenizer::iterator tok_it = tokens.begin();
+            cu_idx = std::stoi(std::string(*tok_it++));
+            name = std::string(*tok_it++);
+            paddr = std::stoull(std::string(*tok_it++), nullptr, radix);
+            status = std::stoul(std::string(*tok_it++), nullptr, radix);
+            usage = std::stoul(std::string(*tok_it++));
 
             boost::property_tree::ptree ptCu;
             ptCu.put( "name",         name );
@@ -558,6 +564,40 @@ public:
             ptCu.put( "usage",        usage );
             ptCu.put( "status",       xrt_core::utils::parse_cu_status( status ) );
             sensor_tree::add_child( std::string("board.compute_unit." + std::to_string(cu_idx)), ptCu );
+        }
+
+        // Count PS kernel index in the sensor_tree with offset
+        off_idx = cu_idx;
+
+        // PS kernel info
+        // The kds_scustat_raw is printing in formatted string of each line
+        // Format: "%d,%s,0x%x,%u"
+        // Using comma as separator.
+        pcidev::get_dev(m_idx)->sysfs_get("", "kds_scustat_raw", errmsg, custat);
+        for (auto& line : custat) {
+            boost::char_separator<char> sep(",");
+
+            tokenizer tokens(line, sep);
+            // Check if we have 4 tokens: cu_index, name, status, usage
+            if (std::distance(tokens.begin(), tokens.end()) != 4) {
+                std::cout << "WARNING: 'kds_scustat_raw' has no expect tokens, stop parsing.\n";
+                break;
+            }
+
+            tokenizer::iterator tok_it = tokens.begin();
+            cu_idx = std::stoi(std::string(*tok_it++));
+            name = std::string(*tok_it++);
+            status = std::stoul(std::string(*tok_it++), nullptr, radix);
+            usage = std::stoul(std::string(*tok_it++));
+            // TODO: Let's avoid this special handling for PS kernel name
+            name = name + ":scu_" + std::to_string(cu_idx);
+
+            boost::property_tree::ptree ptCu;
+            ptCu.put( "name",         name );
+            ptCu.put( "base_address", 0 );
+            ptCu.put( "usage",        usage );
+            ptCu.put( "status",       xrt_core::utils::parse_cu_status( status ) );
+            sensor_tree::add_child( std::string("board.compute_unit." + std::to_string(off_idx + cu_idx)), ptCu );
         }
 
         return 0;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -547,7 +547,7 @@ public:
 
             // Check if we have 5 tokens: cu_index, name, addr, status, usage
             if (std::distance(tokens.begin(), tokens.end()) != 5) {
-                std::cout << "WARNING: 'kds_scustat_raw' has no expect tokens, stop parsing.\n";
+                std::cout << "WARNING: 'kds_custat_raw' has no expect tokens, stop parsing.\n";
                 break;
             }
 


### PR DESCRIPTION
Changes:
1. Support xbutil query PS kernel with new KDS
2. Host to PS CQ interrupt (porting #4471 )
3. Support start PS kernel command return code (#4529  & #4540 )
4. Construct and send PS kernel config command to ERT in xclbin download.

@AShivangi  please review xbutil.h changes.
@larry9523 please take a look and provide feedback for all of the changes.
@chienwei-lan please review ert_user.c changes.