### PR TITLE
CR-1089519 configure clock freqs for flat shell also

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -875,7 +875,10 @@ done:
  *   4) wait for hbm calibration done
  *
  * Note:
- * Violate this flow will cause random firewall trip.
+ * 1) Violate this flow will cause random firewall trip.
+ * 2) Flat shell: gating logic is not available on these shells.
+ *    - So, do not call axigate freeze/free apis for these shells.
+ *    - Updating clock freqs without calling axigate apis.
  */
 static int clock_ocl_freqscaling(struct clock *clock, bool force, int level,
                                  bool freeze)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -878,7 +878,7 @@ done:
  * Violate this flow will cause random firewall trip.
  */
 static int clock_ocl_freqscaling(struct clock *clock, bool force, int level,
-								 bool freeze)
+                                 bool freeze)
 {
 	int i, err = 0;
 	u32 curr[CLOCK_MAX_NUM_CLOCKS] = { 0 };
@@ -956,7 +956,7 @@ done:
 }
 
 static int clock_freq_rescaling(struct platform_device *pdev, bool force,
-								bool freeze)
+                                bool freeze)
 {
 	struct clock *clock = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1211,8 +1211,7 @@ static int icap_download_bitstream(struct icap *icap, const struct axlf *axlf)
 	 * changed.
 	 */
 	if (!err) {
-		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true,
-										true);
+		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true, true);
 		err = (err == -ENODEV) ? 0 : err;
 	}
 
@@ -2167,8 +2166,7 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 	} else {
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
-		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true,
-										false);
+		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true, false);
 		if (err)
 			ICAP_ERR(icap, "not able to configure clocks, err: %d", err);
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1196,13 +1196,25 @@ static long axlf_set_freqscaling(struct icap *icap)
 	    icap->xclbin_clock_freq_topology, 0);
 }
 
-static int icap_download_bitstream(struct icap *icap, const struct axlf *axlf)
+static int icap_download_bitstream(struct icap *icap, struct axlf *axlf)
 {
 	long err = 0;
 
 	icap_freeze_axi_gate(icap);
+	/* xclbin generated for the flat shell contains MCS files which
+	 * includes the accelerator these MCS files should have been already
+	 * flashed into the device using xbmgmt tool we dont need to reprogram
+	 * the xclbin for the FLAT shells.
+	 * TODO: Currently , There is no way to check whether the programmed
+	 * xclbin matches with this xclbin or not
+	 */
+	if (axlf->m_header.m_mode != XCLBIN_FLAT) {
+		err = icap_download_hw(icap, axlf);
+	} else {
+		uuid_copy(&icap->icap_bitstream_uuid, &axlf->m_header.uuid);
+		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
+	}
 
-	err = icap_download_hw(icap, axlf);
 	/*
 	 * Perform frequency scaling since PR download can silenty overwrite
 	 * MMCM settings in static region changing the clock frequencies
@@ -2152,26 +2164,18 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 		}
 	}
 
-	/* xclbin generated for the flat shell contains MCS files which
-	 * includes the accelerator these MCS files should have been already
-	 * flashed into the device using xbmgmt tool we dont need to reprogram
-	 * the xclbin for the FLAT shells.
-	 * TODO: Currently , There is no way to check whether the programmed
-	 * xclbin matches with this xclbin or not
-	 */
-	if (xclbin->m_header.m_mode != XCLBIN_FLAT) {
-		err = icap_download_bitstream(icap, xclbin);
-		if (err)
-			goto out;
-	} else {
-		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
-		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
+	err = icap_download_bitstream(icap, xclbin);
+	if (err) {
+		ICAP_ERR(icap, "not able to download bitstream, err: %d", err);
+		goto out;
 	}
 
 	/* calibrate hbm and ddr should be performed when resources are ready */
 	err = icap_create_post_download_subdevs(icap->icap_pdev, xclbin);
-	if (err)
+	if (err) {
+		ICAP_ERR(icap, "hbm & ddr calib failed, err: %d", err);
 		goto out;
+	}
 
 	/*
 	 * Perform the following exact sequence to avoid firewall trip.

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1155,7 +1155,7 @@ struct xocl_clock_funcs {
 		unsigned short *freq, int id);
 	int (*get_freq_counter_khz)(struct platform_device *pdev,
 		unsigned int *value, int id);
-	int (*freq_rescaling)(struct platform_device *pdev, bool force);
+	int (*freq_rescaling)(struct platform_device *pdev, bool force, bool freeze);
 	int (*freq_scaling_by_request)(struct platform_device *pdev,
 		unsigned short *freqs, int num_freqs, int verify);
 	int (*freq_scaling_by_topo)(struct platform_device *pdev,
@@ -1189,11 +1189,11 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 	(__idx >= 0 ? (CLOCK_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
 })
 
-#define	xocl_clock_freq_rescaling(xdev, force)					\
+#define	xocl_clock_freq_rescaling(xdev, force, freeze)				\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);					\
 	(CLOCK_CB(xdev, __idx, freq_rescaling) ?				\
-	CLOCK_OPS(xdev, __idx)->freq_rescaling(CLOCK_DEV(xdev, __idx), force) :	\
+	CLOCK_OPS(xdev, __idx)->freq_rescaling(CLOCK_DEV(xdev, __idx), force, freeze) :	\
 	-ENODEV); \
 })
 #define	xocl_clock_get_freq(xdev, region, freqs, num_freqs)		\


### PR DESCRIPTION
Gating logic is not available on the flat shells. So, do not call axigate freeze/free apis for these shells.
Updating clock freqs without calling axigate apis.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>