### PR TITLE
Add CL_DEVICE_KDMA_COUNT param for clGetDeviceInfo

### DIFF
--- a/src/include/1_2/CL/cl_ext_xilinx.h
+++ b/src/include/1_2/CL/cl_ext_xilinx.h
@@ -517,10 +517,15 @@ xclGetComputeUnitInfo(cl_kernel             kernel,
  * @CL_DEVICE_NODMA
  * @type: cl_bool
  * Return: True if underlying device is NODMA
+ *
+ * @CL_DEVICE_KDMA_COUNT
+ * @type: cl_uint
+ * Return: Number of kernel DMA blocks supported by device
  */
 #define CL_DEVICE_PCIE_BDF              0x1120  // BUS/DEVICE/FUNCTION
 #define CL_DEVICE_HANDLE                0x1121  // XRT device handle
 #define CL_DEVICE_NODMA                 0x1122  // NODMA device check
+#define CL_DEVICE_KDMA_COUNT            0x1123  // KDMA blocks
 
 // valid target types (CR962714)
 typedef cl_uint cl_program_target_type;

--- a/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetDeviceInfo.cpp
@@ -309,6 +309,9 @@ clGetDeviceInfo(cl_device_id   device,
   case CL_DEVICE_NODMA:
     buffer.as<cl_bool>() = xdevice->is_nodma();
     break;
+  case CL_DEVICE_KDMA_COUNT:
+    buffer.as<cl_uint>() = static_cast<cl_uint>(xdevice->get_num_cdmas());
+    break;
   default:
     throw error(CL_INVALID_VALUE,"clGetDeviceInfo: invalid param_name");
     break;


### PR DESCRIPTION
Returns number of kernel DMA blocks supported by device.

```
 % cat cl_ext_xilinx.h
...
/**
 * clGetDeviceInfo()
 * ...
 * @CL_DEVICE_KDMA_COUNT
 * @type: cl_uint
 * Return: Number of kernel DMA blocks supported by device
 *...
```