### PR TITLE
CR-1089476 RTL kernel with k2k streaming hung right after loading xclbin on board for 3 platforms

### DIFF
--- a/src/runtime_src/ert/scheduler/scheduler_v30.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler_v30.cpp
@@ -638,7 +638,10 @@ configure_cu(addr_type cu_addr, addr_type regmap_addr, size_type regmap_size)
   uint32_t *addr_ptr = (uint32_t *)(uintptr_t)cu_addr;
   uint32_t *regmap_ptr = (uint32_t *)(uintptr_t)regmap_addr;
 
-  memcpy(addr_ptr+4, regmap_ptr+4, (regmap_size-4)<<2);
+  //memcpy(addr_ptr+4, regmap_ptr+4, (regmap_size-4)<<2);
+  for (int i = 4; i < regmap_size; i++)
+    *(addr_ptr + i) = *(regmap_ptr + i);
+
 #endif
   // start kernel at base + 0x0
   write_reg(cu_addr, 0x1);


### PR DESCRIPTION
Not sure why memcpy() sometime would not be able to copy all of the bytes to CU. All of the input argument is as expected.

Need more efforts to investigate why memcpy() is not working properly.

For now, I have to use for loop to copy data to CU.