### PR TITLE
CR#1087576: add soft kernel instance to name in query cmd

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -501,7 +501,6 @@ public:
             uint32_t status = parseComputeUnitStat(custat, i, cu_stat::stat);
             uint32_t usage = parseComputeUnitStat(custat, i, cu_stat::usage);
             std::string name = psKernels.at(psk_inst).pkd_sym_name;
-            //name += ":scu_" + std::to_string(i - computeUnits.size());
             name += ":scu_" + std::to_string(num_scu);
 
             boost::property_tree::ptree ptCu;

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -501,7 +501,8 @@ public:
             uint32_t status = parseComputeUnitStat(custat, i, cu_stat::stat);
             uint32_t usage = parseComputeUnitStat(custat, i, cu_stat::usage);
             std::string name = psKernels.at(psk_inst).pkd_sym_name;
-            name += ":scu_" + std::to_string(i - computeUnits.size());
+            //name += ":scu_" + std::to_string(i - computeUnits.size());
+            name += ":scu_" + std::to_string(num_scu);
 
             boost::property_tree::ptree ptCu;
             ptCu.put( "name",         name );
@@ -1598,6 +1599,7 @@ public:
              << std::setw(14) << "Usage" << std::endl;
 
         try {
+          uint32_t scu_index = 0;
           for (auto& v : sensor_tree::get_child( "board.compute_unit" )) {
             int index = std::stoi(v.first);
             if( index >= 0 ) {
@@ -1621,7 +1623,10 @@ public:
                 if (found != std::string::npos) {
                   auto scu_i = std::stoi(cu_n.substr(found + 4));
                   cu_n = cu_n.substr(0, found - 1);
-                  ostr << "SCU[" << std::right << std::setw(2) << std::dec << scu_i << "]: ";
+                  cu_n.append("_");
+                  cu_n.append(std::to_string(scu_i));
+                  ostr << "SCU[" << std::right << std::setw(2) << std::dec << scu_index << "]: ";
+                  scu_index++;
                 } else
                   ostr << "CU: ";
               } else


### PR DESCRIPTION
add soft kernel instance to name in query cmd
New output:
...
SCU[26]: kernel_vcu_decoder_26           @N/A               (IDLE)        N/A
SCU[27]: kernel_vcu_decoder_27           @N/A               (IDLE)        N/A
SCU[28]: kernel_vcu_decoder_28           @N/A               (IDLE)        N/A
SCU[29]: kernel_vcu_decoder_29           @N/A               (IDLE)        N/A
SCU[30]: kernel_vcu_decoder_30           @N/A               (IDLE)        N/A
SCU[31]: kernel_vcu_decoder_31           @N/A               (IDLE)        N/A
SCU[32]: kernel_vcu_encoder_0            @N/A               (IDLE)        N/A
SCU[33]: kernel_vcu_encoder_1            @N/A               (IDLE)        N/A
SCU[34]: kernel_vcu_encoder_2            @N/A               (IDLE)        N/A
SCU[35]: kernel_vcu_encoder_3            @N/A               (IDLE)        N/A
SCU[36]: kernel_vcu_encoder_4            @N/A               (IDLE)        N/A
...