### PR TITLE
CR-1089519 configure clock freqs for flat shell also (#4770)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -877,8 +877,10 @@ done:
  * Note:
  * 1) Violate this flow will cause random firewall trip.
  * 2) Flat shell: gating logic is not available on these shells.
- *    - So, do not call axigate freeze/free apis for these shells.
- *    - Updating clock freqs without calling axigate apis.
+ *    - So, do not call axigate freeze/free apis for these shells or,
+ *    ignore axigate return value -ENODEV for flat shell
+ *    - Update clock freqs even when axigate returns ENODEV error for flat
+ *    shell.
  */
 static int clock_ocl_freqscaling(struct clock *clock, bool force, int level)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -875,9 +875,13 @@ done:
  *   4) wait for hbm calibration done
  *
  * Note:
- * Violate this flow will cause random firewall trip.
+ * 1) Violate this flow will cause random firewall trip.
+ * 2) Flat shell: gating logic is not available on these shells.
+ *    - So, do not call axigate freeze/free apis for these shells.
+ *    - Updating clock freqs without calling axigate apis.
  */
-static int clock_ocl_freqscaling(struct clock *clock, bool force, int level)
+static int clock_ocl_freqscaling(struct clock *clock, bool force, int level,
+                                 bool freeze)
 {
 	int i, err = 0;
 	u32 curr[CLOCK_MAX_NUM_CLOCKS] = { 0 };
@@ -886,10 +890,12 @@ static int clock_ocl_freqscaling(struct clock *clock, bool force, int level)
 	for (i = 0; i < CLOCK_MAX_NUM_CLOCKS; i++)
 		curr[i] = clock_get_freq_impl(clock, i);
 
-	err = clock_freeze_axi_gate(clock, level);
+	if (freeze)
+		err = clock_freeze_axi_gate(clock, level);
 	if (!err) {
 		err = clock_ocl_freqscaling_impl(clock, force, curr, level);
-		clock_free_axi_gate(clock, level);
+		if (freeze)
+			clock_free_axi_gate(clock, level);
 	}
 
 	CLOCK_INFO(clock, "level: %d return: %d", level, err);
@@ -905,7 +911,7 @@ static int set_freqs(struct clock *clock, unsigned short *freqs, int num_freqs)
 
 	err = clock_update_freqs_request(clock, freqs, num_freqs);
 	if (!err)
-		err = clock_ocl_freqscaling(clock, false, CLOCK_DEV_LEVEL(xdev));
+		err = clock_ocl_freqscaling(clock, false, CLOCK_DEV_LEVEL(xdev), true);
 
 	CLOCK_INFO(clock, "returns %d", err);
 	return err;
@@ -952,14 +958,15 @@ done:
 	return err;
 }
 
-static int clock_freq_rescaling(struct platform_device *pdev, bool force)
+static int clock_freq_rescaling(struct platform_device *pdev, bool force,
+                                bool freeze)
 {
 	struct clock *clock = platform_get_drvdata(pdev);
 	xdev_handle_t xdev = xocl_get_xdev(clock->clock_pdev);
 	int err;
 
 	mutex_lock(&clock->clock_lock);
-	err =  clock_ocl_freqscaling(clock, force, CLOCK_DEV_LEVEL(xdev));
+	err =  clock_ocl_freqscaling(clock, force, CLOCK_DEV_LEVEL(xdev), freeze);
 	mutex_unlock(&clock->clock_lock);
 
 	CLOCK_INFO(clock, "ret: %d.", err);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1213,7 +1213,7 @@ static int icap_download_bitstream(struct icap *icap, const struct axlf *axlf)
 	 * changed.
 	 */
 	if (!err) {
-		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true, true);
+		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true);
 		err = (err == -ENODEV) ? 0 : err;
 	}
 
@@ -2172,7 +2172,7 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 	} else {
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
-		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true, false);
+		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true);
 		if (err)
 			ICAP_ERR(icap, "not able to configure clocks, err: %d", err);
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1213,7 +1213,7 @@ static int icap_download_bitstream(struct icap *icap, const struct axlf *axlf)
 	 * changed.
 	 */
 	if (!err) {
-		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true);
+		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true, true);
 		err = (err == -ENODEV) ? 0 : err;
 	}
 
@@ -2151,9 +2151,9 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 	if (retention) {
 		err = icap_reset_ddr_gate_pin(icap);
 		if (err == -ENODEV)
-			ICAP_INFO(icap, "No ddr gate pin");
+			ICAP_INFO(icap, "No ddr gate pin, err: %d", err);
 		else if (err) {
-			ICAP_ERR(icap, "not able to reset ddr gate pin");
+			ICAP_ERR(icap, "not able to reset ddr gate pin, err: %d", err);
 			goto out;
 		}
 	}
@@ -2172,6 +2172,9 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 	} else {
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
+		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true, false);
+		if (err)
+			ICAP_ERR(icap, "not able to configure clocks, err: %d", err);
 	}
 
 	/* calibrate hbm and ddr should be performed when resources are ready */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1155,7 +1155,7 @@ struct xocl_clock_funcs {
 		unsigned short *freq, int id);
 	int (*get_freq_counter_khz)(struct platform_device *pdev,
 		unsigned int *value, int id);
-	int (*freq_rescaling)(struct platform_device *pdev, bool force, bool freeze);
+	int (*freq_rescaling)(struct platform_device *pdev, bool force);
 	int (*freq_scaling_by_request)(struct platform_device *pdev,
 		unsigned short *freqs, int num_freqs, int verify);
 	int (*freq_scaling_by_topo)(struct platform_device *pdev,
@@ -1189,11 +1189,11 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 	(__idx >= 0 ? (CLOCK_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
 })
 
-#define	xocl_clock_freq_rescaling(xdev, force, freeze)				\
+#define	xocl_clock_freq_rescaling(xdev, force)				\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);					\
 	(CLOCK_CB(xdev, __idx, freq_rescaling) ?				\
-	CLOCK_OPS(xdev, __idx)->freq_rescaling(CLOCK_DEV(xdev, __idx), force, freeze) :	\
+	CLOCK_OPS(xdev, __idx)->freq_rescaling(CLOCK_DEV(xdev, __idx), force) :	\
 	-ENODEV); \
 })
 #define	xocl_clock_get_freq(xdev, region, freqs, num_freqs)		\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1189,7 +1189,7 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 	(__idx >= 0 ? (CLOCK_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
 })
 
-#define	xocl_clock_freq_rescaling(xdev, force)				\
+#define	xocl_clock_freq_rescaling(xdev, force)					\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);					\
 	(CLOCK_CB(xdev, __idx, freq_rescaling) ?				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1155,7 +1155,7 @@ struct xocl_clock_funcs {
 		unsigned short *freq, int id);
 	int (*get_freq_counter_khz)(struct platform_device *pdev,
 		unsigned int *value, int id);
-	int (*freq_rescaling)(struct platform_device *pdev, bool force);
+	int (*freq_rescaling)(struct platform_device *pdev, bool force, bool freeze);
 	int (*freq_scaling_by_request)(struct platform_device *pdev,
 		unsigned short *freqs, int num_freqs, int verify);
 	int (*freq_scaling_by_topo)(struct platform_device *pdev,
@@ -1189,11 +1189,11 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 	(__idx >= 0 ? (CLOCK_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
 })
 
-#define	xocl_clock_freq_rescaling(xdev, force)					\
+#define	xocl_clock_freq_rescaling(xdev, force, freeze)				\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);					\
 	(CLOCK_CB(xdev, __idx, freq_rescaling) ?				\
-	CLOCK_OPS(xdev, __idx)->freq_rescaling(CLOCK_DEV(xdev, __idx), force) :	\
+	CLOCK_OPS(xdev, __idx)->freq_rescaling(CLOCK_DEV(xdev, __idx), force, freeze) :	\
 	-ENODEV); \
 })
 #define	xocl_clock_get_freq(xdev, region, freqs, num_freqs)		\


### PR DESCRIPTION
Gating logic is not available on the u2 flat shells.
So, do not call axigate freeze/free apis for these shells.
Update clock freqs without calling axigate apis.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>