### PR TITLE
Should call put_unlocked if not using struct_mutex

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -507,7 +507,7 @@ static struct drm_driver mm_drm_driver = {
 	.postclose			= xocl_client_release,
 	.open				= xocl_client_open,
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
 	.gem_free_object_unlocked       = xocl_free_object,
 #else
 	.gem_free_object		= xocl_free_object,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -101,10 +101,7 @@
 /* drm_gem_object_put_unlocked and drm_gem_object_get were introduced with Linux
  * 4.12 and backported to Red Hat 7.5.
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
-	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put
-	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
 	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
 #elif defined(RHEL_RELEASE_CODE)


### PR DESCRIPTION
Since drm_gem_object_put check the struct_mutex is locked or not, and we are not locking struct_mutex in xocl. 

` 

   	 drm_gem_object_put(struct drm_gem_object *obj) 
  	 { 
	    if (obj) { 
		  WARN_ON(!mutex_is_locked(&obj->dev->struct_mutex));
		  kref_put(&obj->refcount, drm_gem_object_free);
	   } 
   	 }

`
Therefore, we will see the dmesg flood with the warning

**WARNING: CPU: 4 PID: 120132 at drivers/gpu/drm/drm_gem.c:1034 drm_gem_object_put+0x4c/0x60 [drm]**


If we are not using struct_mutex directly in xocl, we should always call drm_gem_object_put_unlocked



