### PR TITLE
CRs and qspi report for U30

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -89,6 +89,7 @@ enum class key_type
   xmc_scaling_enabled,
   xmc_scaling_override,
   xmc_scaling_reset,
+  xmc_qspi_status,
 
   m2m,
   error,
@@ -843,6 +844,16 @@ struct xmc_scaling_reset : request
 
   virtual void
   put(const device*, const boost::any&) const = 0;
+};
+
+struct xmc_qspi_status : request
+{
+  // Returning qspi write protection status as <primary qspi, recovery qspi>
+  using result_type = std::pair<std::string, std::string>;
+  static const key_type key = key_type::xmc_qspi_status;
+
+  virtual boost::any
+  get(const device*) const = 0;
 };
 
 struct m2m : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -81,6 +81,44 @@ struct kds_cu_info
   }
 };
 
+/**
+ * qspi write protection status
+ * byte 0:
+ *   0: status not available, 1: status available
+ * byte 1 primary qspi(if status available):
+ *   1: write protect enable, 2: write protect disable
+ * byte 2 recovery qspi(if status available):
+ *   1: write protect enable, 2: write protect disable
+ */
+struct qspi_status
+{
+  using result_type = query::xmc_qspi_status::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    auto pdev = get_pcidev(device);
+  
+    std::string status_str, errmsg;
+    pdev->sysfs_get("xmc", "xmc_qspi_status", errmsg, status_str);
+    if (!errmsg.empty())
+      throw std::runtime_error(errmsg);
+
+    std::string primary, recovery;
+    for (auto x : status_str) {
+      int status_byte = x - '0';
+      if(status_byte == 0)
+        return std::pair<std::string, std::string>("N/A", "N/A");
+
+      if(primary.empty())
+        primary = status_byte == 1 ? "Enabled": status_byte == 2 ? "Disabled" : "Invalid";
+      else
+        recovery = status_byte == 1 ? "Enabled": status_byte == 2 ? "Disabled" : "Invalid";
+    }
+    return std::pair<std::string, std::string>(primary, recovery);
+  }
+};
+
 struct mac_addr_list
 {
   using result_type = query::mac_addr_list::result_type;
@@ -388,6 +426,7 @@ initialize_query_table()
   emplace_sysfs_get<query::mac_contiguous_num>                 ("xmc", "mac_contiguous_num");
   emplace_sysfs_get<query::mac_addr_first>                     ("xmc", "mac_addr_first");
   emplace_sysfs_get<query::oem_id>                             ("xmc", "xmc_oem_id");
+  emplace_func0_request<query::xmc_qspi_status,                qspi_status>();
   emplace_func0_request<query::mac_addr_list,                  mac_addr_list>();
 
   emplace_sysfs_get<query::firewall_detect_level>             ("firewall", "detected_level");

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -84,11 +84,11 @@ struct kds_cu_info
 /**
  * qspi write protection status
  * byte 0:
- *   0: status not available, 1: status available
+ *   '0': status not available, '1': status available
  * byte 1 primary qspi(if status available):
- *   1: write protect enable, 2: write protect disable
+ *   '1': write protect enable, '2': write protect disable
  * byte 2 recovery qspi(if status available):
- *   1: write protect enable, 2: write protect disable
+ *   '1': write protect enable, '2': write protect disable
  */
 struct qspi_status
 {
@@ -105,15 +105,14 @@ struct qspi_status
       throw std::runtime_error(errmsg);
 
     std::string primary, recovery;
-    for (auto x : status_str) {
-      int status_byte = x - '0';
-      if(status_byte == 0)
+    for (auto status_byte : status_str) {
+      if(status_byte == '0')
         return std::pair<std::string, std::string>("N/A", "N/A");
 
       if(primary.empty())
-        primary = status_byte == 1 ? "Enabled": status_byte == 2 ? "Disabled" : "Invalid";
+        primary = status_byte == '1' ? "Enabled": status_byte == '2' ? "Disabled" : "Invalid";
       else
-        recovery = status_byte == 1 ? "Enabled": status_byte == 2 ? "Disabled" : "Invalid";
+        recovery = status_byte == '1' ? "Enabled": status_byte == '2' ? "Disabled" : "Invalid";
     }
     return std::pair<std::string, std::string>(primary, recovery);
   }

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -174,9 +174,10 @@ findEnvPath(const std::string & env)
   boost::filesystem::path absPath;
   if(env.compare("python") == 0) {
     // Find the python executable
-    absPath = boost::process::search_path("py");  
+    absPath = boost::process::search_path("py");
+    // Find python3 path on linux
     if (absPath.string().empty()) 
-      absPath = boost::process::search_path("python");   
+      absPath = boost::process::search_path("python3");   
 
     if (absPath.string().empty()) 
       throw std::runtime_error("Error: Python executable not found in search path.");

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -114,6 +114,8 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
   sensor_array.push_back(std::make_pair("", 
     populate_sensor<qr::v1v2_vcc_bottom_millivolts, qr::noop>(_pDevice, "vcc_1v2_btm", "Vcc 1.2 Volts Bottom")));
   sensor_array.push_back(std::make_pair("", 
+    populate_sensor<qr::v1v8_millivolts, qr::noop>(_pDevice, "1v8_top", "1.8 Volts Top")));
+  sensor_array.push_back(std::make_pair("", 
     populate_sensor<qr::v0v9_vcc_millivolts, qr::noop>(_pDevice, "0v9_vcc", "0.9 Volts Vcc")));
   sensor_array.push_back(std::make_pair("", 
     populate_sensor<qr::v12v_sw_millivolts, qr::noop>(_pDevice, "12v_sw", "12 Volts SW")));

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "ReportQspiStatus.h"
+#include "core/common/query_requests.h"
+
+namespace qr = xrt_core::query;
+
+void
+ReportQspiStatus::getPropertyTreeInternal(const xrt_core::device * device, 
+                                              boost::property_tree::ptree &pt) const
+{
+  // Defer to the 20202 format.  If we ever need to update JSON data, 
+  // Then update this method to do so.
+  getPropertyTree20202(device, pt);
+}
+
+void 
+ReportQspiStatus::getPropertyTree20202( const xrt_core::device * device, 
+                                           boost::property_tree::ptree &pt) const
+{
+  auto qspi_stat = xrt_core::device_query<qr::xmc_qspi_status>(device);
+  boost::property_tree::ptree ptree;
+  ptree.put("primary", std::get<0>(qspi_stat));
+  ptree.put("recovery", std::get<1>(qspi_stat));
+  
+  // There can only be 1 root node
+  pt.add_child("qspi_wp_status", ptree);
+}
+
+void 
+ReportQspiStatus::writeReport( const xrt_core::device * device,
+                                  const std::vector<std::string> & /*_elementsFilter*/, 
+                                  std::iostream & output) const
+{
+  boost::property_tree::ptree pt;
+  getPropertyTreeInternal(device, pt);
+
+  boost::property_tree::ptree& ptree = pt.get_child("qspi_wp_status");
+
+  output << "QSPI write portection status" << std::endl;
+  output << boost::format("  %-20s : %s\n") % "Primary" % ptree.get<std::string>("primary");
+  output << boost::format("  %-20s : %s\n") % "Recovery" % ptree.get<std::string>("recovery");
+  output << std::endl;
+}

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.h
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,21 +14,21 @@
  * under the License.
  */
 
-#ifndef __ReportCu_h_
-#define __ReportCu_h_
+#ifndef __ReportQspiStatus_h_
+#define __ReportQspiStatus_h_
 
 // Please keep external include file dependencies to a minimum
 #include "Report.h"
 
-class ReportCu : public Report {
+class ReportQspiStatus : public Report {
  public:
-  ReportCu() : Report("compute-units", "Information of the compute units", true /*deviceRequired*/) { /*empty*/ };
+  ReportQspiStatus() : Report("qspi-status", "QSPI write protection status", true /*deviceRequired*/) { /*empty*/ };
 
  // Child methods that need to be implemented
  public:
-  virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
-  virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void getPropertyTreeInternal(const xrt_core::device * device, boost::property_tree::ptree &pt) const;
+  virtual void getPropertyTree20202(const xrt_core::device * devicee, boost::property_tree::ptree &pt) const;
+  virtual void writeReport(const xrt_core::device * device, const std::vector<std::string> & elementsFilter, std::iostream & output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -142,37 +142,33 @@ show_device_conf(xrt_core::device* device)
   }
 
   try {
-    std::cout << "\tSecurity level: ";
     auto sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
-    std::cout << sec_level << "\n";
+    std::cout << boost::format("  %-33s: %s\n") % "Security level" % sec_level;
   }
   catch (const std::exception& ex) {
     std::cout << ex.what() << "\n";
   }
 
   try {
-    std::cout << "\tRuntime clock scaling enabled status: ";
     auto scaling_enabled = xrt_core::device_query<xrt_core::query::xmc_scaling_enabled>(device);
-    std::cout << scaling_enabled << "\n";
+    std::cout << boost::format("  %-33s: %s\n") % "Runtime clock scaling enabled" % scaling_enabled;
   }
   catch (const std::exception& ex) {
-    std::cout << ex.what() << "\n";
+    //safe to ignore. These sysfs nodes are not present for u30
   }
 
   try {
-    std::cout << "\tScaling threshold power override: ";
     auto scaling_override = xrt_core::device_query<xrt_core::query::xmc_scaling_override>(device);
-    std::cout << scaling_override << "\n";
+    std::cout << boost::format("  %-33s: %s\n") % "Scaling threshold power override" % scaling_override;
   }
   catch (const std::exception& ex) {
-    std::cout << ex.what() << "\n";
+    //safe to ignore. These sysfs nodes are not present for u30
   }
 
   try {
-    std::cout << "\tData retention: ";
     auto value = xrt_core::device_query<xrt_core::query::data_retention>(device);
     auto data_retention = xrt_core::query::data_retention::to_bool(value);
-    std::cout << (data_retention ? "enabled" : "disabled") << "\n";
+    std::cout << boost::format("  %-33s: %s\n") % "Data retention" % (data_retention ? "enabled" : "disabled");
   }
   catch (const std::exception& ex) {
     std::cout << ex.what() << "\n";

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -153,7 +153,7 @@ show_device_conf(xrt_core::device* device)
     auto scaling_enabled = xrt_core::device_query<xrt_core::query::xmc_scaling_enabled>(device);
     std::cout << boost::format("  %-33s: %s\n") % "Runtime clock scaling enabled" % scaling_enabled;
   }
-  catch (const std::exception& ex) {
+  catch (...) {
     //safe to ignore. These sysfs nodes are not present for u30
   }
 
@@ -161,7 +161,7 @@ show_device_conf(xrt_core::device* device)
     auto scaling_override = xrt_core::device_query<xrt_core::query::xmc_scaling_override>(device);
     std::cout << boost::format("  %-33s: %s\n") % "Scaling threshold power override" % scaling_override;
   }
-  catch (const std::exception& ex) {
+  catch (...) {
     //safe to ignore. These sysfs nodes are not present for u30
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -50,6 +50,7 @@ namespace po = boost::program_options;
 #include "tools/common/ReportPlatforms.h"
 #include "tools/common/ReportPcieInfo.h"
 #include "tools/common/ReportMailbox.h"
+#include "tools/common/ReportQspiStatus.h"
 
 // Note: Please insert the reports in the order to be displayed (alphabetical)
   static ReportCollection fullReportCollection = {
@@ -69,6 +70,7 @@ namespace po = boost::program_options;
     std::make_shared<ReportMechanical>(),
     std::make_shared<ReportFirewall>(),
     std::make_shared<ReportThermal>(),
+    std::make_shared<ReportQspiStatus>(),
   #endif
   };
 


### PR DESCRIPTION
### Work Done:
- **CR-1088239** ASTeR tc_09_01_to_09_35_low_power_query_sensor - xbutil2: sensors not reported
- **CR-1089315** ASTeR TS21 - U30 - 'xbmgmt --new advanced --config --showx' does not show status correctly
- Boost process to use python3 instead of python (which could be pointing to puthon2)
- QSPI write protection status report in xbutil2