### PR TITLE
report PS kernel in xbutil2

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -75,6 +75,9 @@ enum class key_type
   clock_freq_topology_raw,
   dma_stream,
   kds_cu_info,
+  kds_mode,
+  kds_cu_stat,
+  kds_scu_stat,
 
   xmc_version,
   xmc_board_name,
@@ -655,6 +658,35 @@ struct kds_cu_info : request
   // Returning CUs info as <base_addr, usages, status>
   using result_type = std::vector<std::tuple<uint64_t, uint32_t, uint32_t>>;
   static const key_type key = key_type::kds_cu_info;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct kds_mode : request
+{
+  using result_type = uint32_t;
+  static const key_type key = key_type::kds_mode;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct kds_cu_stat : request
+{
+  // Returning CUs statistic as <index, name, base_addr, status, usages>
+  using result_type = std::vector<std::tuple<uint32_t, std::string, uint64_t, uint32_t, uint64_t>>;
+  static const key_type key = key_type::kds_cu_stat;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct kds_scu_stat : request
+{
+  // Returning PS kernel statistic as <index, name, status, usages>
+  using result_type = std::vector<std::tuple<uint32_t, std::string, uint32_t, uint64_t>>;
+  static const key_type key = key_type::kds_scu_stat;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -674,8 +674,15 @@ struct kds_mode : request
 
 struct kds_cu_stat : request
 {
-  // Returning CUs statistic as <index, name, base_addr, status, usages>
-  using result_type = std::vector<std::tuple<uint32_t, std::string, uint64_t, uint32_t, uint64_t>>;
+  struct data {
+    uint32_t index;
+    std::string name;
+    uint64_t base_addr;
+    uint32_t status;
+    uint64_t usages;
+  };
+  using result_type = std::vector<struct data>;
+  using data_type = struct data;
   static const key_type key = key_type::kds_cu_stat;
 
   virtual boost::any
@@ -684,8 +691,14 @@ struct kds_cu_stat : request
 
 struct kds_scu_stat : request
 {
-  // Returning PS kernel statistic as <index, name, status, usages>
-  using result_type = std::vector<std::tuple<uint32_t, std::string, uint32_t, uint64_t>>;
+  struct data {
+    uint32_t index;
+    std::string name;
+    uint32_t status;
+    uint64_t usages;
+  };
+  using result_type = std::vector<struct data>;
+  using data_type = struct data;
   static const key_type key = key_type::kds_scu_stat;
 
   virtual boost::any

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -99,10 +99,10 @@ boost::property_tree::ptree
 populate_cus_new(const xrt_core::device *device)
 {
   boost::property_tree::ptree pt;
-  // tuple <index, name, base_addr, status, usage>
-  std::vector<std::tuple<uint32_t, std::string, uint64_t, uint32_t, uint64_t>> cu_stats;
-  // tuple <index, name, status, usage>
-  std::vector<std::tuple<uint32_t, std::string, uint32_t, uint64_t>> scu_stats;
+  using cu_data_type = qr::kds_cu_stat::data_type;
+  using scu_data_type = qr::kds_scu_stat::data_type;
+  std::vector<cu_data_type> cu_stats;
+  std::vector<scu_data_type> scu_stats;
 
   try {
     cu_stats  = xrt_core::device_query<qr::kds_cu_stat>(device);
@@ -112,34 +112,21 @@ populate_cus_new(const xrt_core::device *device)
     return pt;
   }
 
-  if (cu_stats.empty()) {
-    return pt;
-  }
-
   for (auto& stat : cu_stats) {
-    std::string name   = std::get<1>(stat);
-    uint64_t base_addr = std::get<2>(stat);
-    uint32_t status    = std::get<3>(stat);
-    uint32_t usage     = std::get<4>(stat);
-
     boost::property_tree::ptree ptCu;
-    ptCu.put( "name",           name);
-    ptCu.put( "base_address",   boost::str(boost::format("0x%x") % base_addr));
-    ptCu.put( "usage",          usage);
-    ptCu.add_child( std::string("status"),	get_cu_status(status));
+    ptCu.put( "name",           stat.name);
+    ptCu.put( "base_address",   boost::str(boost::format("0x%x") % stat.base_addr));
+    ptCu.put( "usage",          stat.usages);
+    ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
     pt.push_back(std::make_pair("", ptCu));
   }
 
   for (auto& stat : scu_stats) {
-    std::string name   = std::get<1>(stat);
-    uint32_t status    = std::get<2>(stat);
-    uint32_t usage     = std::get<3>(stat);
-
     boost::property_tree::ptree ptCu;
-    ptCu.put( "name",           name);
+    ptCu.put( "name",           stat.name);
     ptCu.put( "base_address",   "0x0");
-    ptCu.put( "usage",          usage);
-    ptCu.add_child( std::string("status"),	get_cu_status(status));
+    ptCu.put( "usage",          stat.usages);
+    ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
     pt.push_back(std::make_pair("", ptCu));
   }
 

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -148,10 +148,11 @@ ReportCu::getPropertyTree20202( const xrt_core::device * _pDevice,
 {
   uint32_t kds_mode;
 
-  /* sysfs attribute kds_mode: 1 - new KDS; 0 - old KDS */
+  // sysfs attribute kds_mode: 1 - new KDS; 0 - old KDS
   try {
     kds_mode = xrt_core::device_query<qr::kds_mode>(_pDevice);
-  } catch (const std::exception& ex){
+  } catch (...){
+    // When kds_mode doesn't present, xocl driver supports old KDS
     kds_mode = 0;
   }
 


### PR DESCRIPTION
Work done:
1. Report CU statistic in xbuitl2 when new KDS is enabled.
2. Report PS kernel statistic in xbutil2 when new KDS is enabled.

Sample output:
```
$xbutil examine -d 0000:6d:00.1 -r compute_units
-----------------------------------------------------
 Invoking next generation of the xbutil application 
-----------------------------------------------------
----------------------------------------------
1/1 [0000:6d:00.1] : xilinx_u30_gen3x4_base_1
----------------------------------------------
Compute Units
Index   Name                    Base_Address    Usage   Status  
0       verify:verify_1         0x1400000       0       (IDLE)  
1       kernel2:scu_0           0x0             0       (IDLE)  
2       kernel2:scu_1           0x0             0       (IDLE)  
3       kernel2:scu_2           0x0             0       (IDLE)  
4       kernel2:scu_3           0x0             0       (IDLE) 
```
```
$xbutil examine -d 0000:6d:00.1 -r compute_units -f JSON
-----------------------------------------------------
 Invoking next generation of the xbutil application 
-----------------------------------------------------
{
    "schema_version":
    {
        "schema": "JSON",
        "creation_date": "Mon Mar  1 19:34:15 2021 GMT"
    },
    "devices":
    [
        {
            "interface_type": "pcie",
            "device_id": "0000:6d:00.1",
            "compute_units":
            [
                {
                    "name": "verify:verify_1",
                    "base_address": "0x1400000",
                    "usage": "0",
                    "status":
                    {
                        "bit_mask": "0x4",
                        "bits_set":
                        [
                            "IDLE"
                        ]
                    }
                },
                {
                    "name": "kernel2:scu_0",
                    "base_address": "0x0",
                    "usage": "0",
                    "status":
                    {
                        "bit_mask": "0x4",
                        "bits_set":
                        [
                            "IDLE"
                        ]
                    }
                },
                {
                    "name": "kernel2:scu_1",
                    "base_address": "0x0",
                    "usage": "0",
                    "status":
                    {
                        "bit_mask": "0x4",
                        "bits_set":
                        [
                            "IDLE"
                        ]
                    }
                },
                {
                    "name": "kernel2:scu_2",
                    "base_address": "0x0",
                    "usage": "0",
                    "status":
                    {
                        "bit_mask": "0x4",
                        "bits_set":
                        [
                            "IDLE"
                        ]
                    }
                },
                {
                    "name": "kernel2:scu_3",
                    "base_address": "0x0",
                    "usage": "0",
                    "status":
                    {
                        "bit_mask": "0x4",
                        "bits_set":
                        [
                            "IDLE"
                        ]
                    }
                }
            ]
        }
    ]
}
```
