### PR TITLE
try enable new KDS as default

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -32,10 +32,10 @@ do {\
 
 void xocl_describe(const struct drm_xocl_bo *xobj);
 
-int kds_mode = 0;
+int kds_mode = 1;
 module_param(kds_mode, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_mode,
-		 "enable new KDS (0 = disable (default), 1 = enable)");
+		 "enable new KDS (0 = disable, 1 = enable (default))");
 
 /* kds_echo also impact mb_scheduler.c, keep this as global.
  * Let's move it to struct kds_sched in the future.


### PR DESCRIPTION
This PR would enable new KDS as default scheduler.

NOTE: The failure test in regression would expect going higher.
I will keep my eyes on regression test result and fix issues with following PRs.