### PR TITLE
Add support for loading xclbin for vck190_dfx platform

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -149,6 +149,8 @@ struct drm_zocl_dev {
 	struct zocl_error	zdev_error;
 	struct zocl_aie		*aie;
 	struct zocl_watchdog_dev *watchdog;
+	u16			pr_isolation_freeze;
+	u16			pr_isolation_unfreeze;
 };
 
 int zocl_kds_update(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -896,9 +896,16 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	}
 
 	if (ZOCL_PLATFORM_ARM64) {
+		zdev->pr_isolation_freeze = 0x0;
+		zdev->pr_isolation_unfreeze = 0x3;
 		if (of_property_read_u64(pdev->dev.of_node,
 		    "xlnx,pr-isolation-addr", &zdev->pr_isolation_addr))
 			zdev->pr_isolation_addr = 0;
+		if (of_property_read_bool(pdev->dev.of_node,
+		    "xlnx,pr-decoupler")) {
+			zdev->pr_isolation_freeze = 0x1;
+			zdev->pr_isolation_unfreeze = 0x0;
+		}
 	} else {
 		u32 prop_addr = 0;
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -78,10 +78,10 @@ zocl_load_partial(struct drm_zocl_dev *zdev, const char *buffer, int length)
 	}
 
 	/* Freeze PR ISOLATION IP for bitstream download */
-	iowrite32(0x0, map);
+	iowrite32(zdev->pr_isolation_freeze, map);
 	err = zocl_fpga_mgr_load(zdev, buffer, length, FPGA_MGR_PARTIAL_RECONFIG);
 	/* Unfreeze PR ISOLATION IP */
-	iowrite32(0x3, map);
+	iowrite32(zdev->pr_isolation_unfreeze, map);
 
 	iounmap(map);
 	return err;


### PR DESCRIPTION
> vck190_dfx uses pr-decoupler ip, and the ip expects 0x1 for freezing 0x0 for unfreezing dfx region
> made changes to reflect same
> added two new variables in drm_zocl_dev structure for holding values to be written fro freezing and unfreezing dfx region