### PR TITLE
continuous trace enhancements

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -239,6 +239,22 @@ namespace xdp {
     return events;
   }
 
+  bool VPDynamicDatabase::hostEventsExist(std::function<bool(VTFEvent*)> filter)
+  {
+    std::lock_guard<std::mutex> lock(hostEventsLock) ;
+    for (auto it=hostEvents.begin(); it!=hostEvents.end(); it++) {
+      if (filter(it->second))
+        return true;
+    }
+    return false;
+  }
+
+  bool VPDynamicDatabase::deviceEventsExist(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceEventsLock) ;
+    return !(deviceEvents[deviceId].empty());
+  }
+
   std::vector<VTFEvent*> VPDynamicDatabase::getDeviceEvents(uint64_t deviceId)
   {
     std::vector<VTFEvent*> events;

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -176,6 +176,9 @@ namespace xdp {
     XDP_EXPORT std::vector<std::unique_ptr<VTFEvent>> filterEraseHostEvents(std::function<bool(VTFEvent*)> filter);
     XDP_EXPORT std::vector<std::unique_ptr<VTFEvent>> getEraseDeviceEvents(uint64_t deviceId);
 
+    XDP_EXPORT bool deviceEventsExist(uint64_t deviceId);
+    XDP_EXPORT bool hostEventsExist(std::function<bool(VTFEvent*)> filter);
+
     XDP_EXPORT void setCounterResults(uint64_t deviceId,
 				      xrt_core::uuid uuid,
 				      xclCounterResults& values) ;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -108,7 +108,7 @@ namespace xdp {
     uint64_t deviceId = db->addDevice(sysfsPath) ;
 
     // When adding a device, also add a writer to dump the information
-    std::string version = "1.0" ;
+    std::string version = "1.1" ;
     std::string creationTime = xdp::getCurrentDateTime() ;
     std::string xrtVersion   = xdp::getXRTVersion() ;
     std::string toolVersion  = xdp::getToolVersion() ;

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -38,7 +38,7 @@ namespace xdp {
   {
     db->registerPlugin(this) ;
 
-    std::string version = "1.0" ;
+    std::string version = "1.1" ;
 
     std::string creationTime = xdp::getCurrentDateTime() ;
     std::string xrtVersion   = xdp::getXRTVersion() ;

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -144,7 +144,7 @@ namespace xdp {
     auto continuous_trace =
       xrt_core::config::get_continuous_trace() ;
     // TODO: Enable once vp analyze works
-    if (continuous_trace && false) {
+    if (continuous_trace) {
       auto trace_dump_int_s = xrt_core::config::get_trace_dump_interval_s();
       XDPPlugin::startWriteThread(trace_dump_int_s, "VP_TRACE");
     }

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -144,7 +144,7 @@ namespace xdp {
     auto continuous_trace =
       xrt_core::config::get_continuous_trace() ;
     // TODO: Enable once vp analyze works
-    if (continuous_trace) {
+    if (continuous_trace && false) {
       auto trace_dump_int_s = xrt_core::config::get_trace_dump_interval_s();
       XDPPlugin::startWriteThread(trace_dump_int_s, "VP_TRACE");
     }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -38,7 +38,7 @@ namespace xdp {
     continuous_trace =
       xrt_core::config::get_continuous_trace() ;
     // TODO: Enable once vp analyze works
-    if (continuous_trace && false) {
+    if (continuous_trace) {
       trace_dump_int_s = xrt_core::config::get_trace_dump_interval_s();
       XDPPlugin::startWriteThread(trace_dump_int_s, "VP_TRACE");
     }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -38,7 +38,7 @@ namespace xdp {
     continuous_trace =
       xrt_core::config::get_continuous_trace() ;
     // TODO: Enable once vp analyze works
-    if (continuous_trace) {
+    if (continuous_trace && false) {
       trace_dump_int_s = xrt_core::config::get_trace_dump_interval_s();
       XDPPlugin::startWriteThread(trace_dump_int_s, "VP_TRACE");
     }

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -88,8 +88,8 @@ namespace xdp {
     is_write_thread_active = true;
     while (writeCondWaitFor(std::chrono::seconds(interval))) {
       for (auto w : writers) {
-        w->write(true) ;
-        (db->getStaticInfo()).addOpenedFile(w->getcurrentFileName().c_str(), type) ;
+        if (w->write(true))
+          (db->getStaticInfo()).addOpenedFile(w->getcurrentFileName().c_str(), type) ;
       }
     }
 

--- a/src/runtime_src/xdp/profile/writer/aie/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie/aie_writer.cpp
@@ -33,7 +33,7 @@ namespace xdp {
   {    
   }
 
-  void AIEProfilingWriter::write(bool openNewFile)
+  bool AIEProfilingWriter::write(bool openNewFile)
   {
     // Grab AIE clock freq from first counter in metadata
     // NOTE: Assumed the same for all tiles
@@ -64,6 +64,7 @@ namespace xdp {
       }
       fout << std::endl;
     }
+    return true;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/aie/aie_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie/aie_writer.h
@@ -29,7 +29,7 @@ namespace xdp {
                        uint64_t deviceIndex);
     ~AIEProfilingWriter();
 
-    virtual void write(bool openNewFile);
+    virtual bool write(bool openNewFile);
     
   private:
     std::string mDeviceName;

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -102,7 +102,7 @@ std::cout << " AIETraceWriter::writeTraceEvents : dataBuffer " << dataBuffer << 
   {
   }
 
-  void AIETraceWriter::write(bool openNewFile)
+  bool AIETraceWriter::write(bool openNewFile)
   {
 #if 0
     writeHeader() ;
@@ -120,6 +120,7 @@ std::cout << " AIETraceWriter::writeTraceEvents : dataBuffer " << dataBuffer << 
 #endif
 
     if (openNewFile) switchFiles() ;
+    return true;
   }
 
 }

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.h
@@ -54,7 +54,7 @@ namespace xdp {
 		   const std::string& toolV);
     ~AIETraceWriter();
 
-    virtual void write(bool openNewFile);
+    virtual bool write(bool openNewFile);
   };
 
 }

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -346,8 +346,17 @@ namespace xdp {
     // No dependencies in device events
   }
 
+  bool DeviceTraceWriter::traceEventsExist()
+  {
+    return (db->getDynamicInfo()).deviceEventsExist(deviceId);
+  }
+
   bool DeviceTraceWriter::write(bool openNewFile)
   {
+    if (openNewFile && !traceEventsExist()) {
+      return false;
+    }
+
     initialize() ;
 
     writeHeader() ;

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -47,7 +47,7 @@ namespace xdp {
     } else if(xdp::getFlowMode() == xdp::HW_EMU) {
       targetRun = "Hardware Emulation";
     }
-    fout << "TraceID," << deviceId << std::endl
+    fout << "TraceID," << traceID << std::endl
          << "XRT  Version," << xrtVersion  << std::endl
          << "Tool Version," << toolVersion << std::endl
          << "Platform," << (db->getStaticInfo()).getDeviceName(deviceId) << std::endl
@@ -346,7 +346,7 @@ namespace xdp {
     // No dependencies in device events
   }
 
-  void DeviceTraceWriter::write(bool openNewFile)
+  bool DeviceTraceWriter::write(bool openNewFile)
   {
     initialize() ;
 
@@ -362,6 +362,7 @@ namespace xdp {
     fout << std::endl ;
 
     if (openNewFile) switchFiles() ;
+    return true;
   }
 
   void DeviceTraceWriter::initialize()

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.h
@@ -43,6 +43,7 @@ namespace xdp {
     // Helper function for making sure the database has enough information
     //  to print out all of the information it will need.
     void initialize() ;
+    bool traceEventsExist() ;
 
     // Helper functions for individual parts of the STRUCTURE section
     void writeDeviceStructure() ;

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.h
@@ -69,7 +69,7 @@ namespace xdp {
     
     ~DeviceTraceWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
     virtual bool isDevice() { return true ; } 
   } ;
 

--- a/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.cpp
@@ -47,7 +47,8 @@ namespace xdp {
   void HALDeviceTraceWriter::writeHeader()
   {
     VPTraceWriter::writeHeader() ;
-    fout << "XRT  Version," << xrtVersion  << std::endl
+    fout << "TraceID," << traceID << std::endl
+         << "XRT  Version," << xrtVersion  << std::endl
          << "Tool Version," << toolVersion << std::endl
          << "Platform," << (db->getStaticInfo()).getDeviceName(deviceId) << std::endl
          << "Target,System Run" << std::endl;    // hardcoded for now

--- a/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.cpp
@@ -249,7 +249,7 @@ namespace xdp {
     // No dependencies in device events
   }
 
-  void HALDeviceTraceWriter::write(bool openNewFile)
+  bool HALDeviceTraceWriter::write(bool openNewFile)
   {
     writeHeader() ;
     fout << std::endl ;
@@ -263,6 +263,7 @@ namespace xdp {
     fout << std::endl ;
 
     if (openNewFile) switchFiles() ;
+    return true;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.h
@@ -56,7 +56,7 @@ namespace xdp {
 
     ~HALDeviceTraceWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
     virtual bool isDevice() { return true ; } 
     virtual bool isSameDevice(void* /*handle*/) 
     { // return dev->getAbstractDevice()->getRawDevice() == handle ;

--- a/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
@@ -98,7 +98,7 @@ namespace xdp {
     // No dependencies in HAL events
   }
 
-  void HALHostTraceWriter::write(bool openNewFile)
+  bool HALHostTraceWriter::write(bool openNewFile)
   {
     writeHeader() ;
     fout << std::endl ;
@@ -112,6 +112,7 @@ namespace xdp {
     fout << std::endl ;
 
     if (openNewFile) switchFiles() ;
+    return true;
   }
 
 }

--- a/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
@@ -36,7 +36,8 @@ namespace xdp {
   void HALHostTraceWriter::writeHeader()
   {
     VPTraceWriter::writeHeader() ;
-    fout << "XRT  Version," << xrtVersion  << std::endl
+    fout << "TraceID," << traceID << std::endl
+         << "XRT  Version," << xrtVersion  << std::endl
          << "Tool Version," << toolVersion << std::endl;
 
     //fout << "Profiled Application," << xdp::WriterI::getCurrentExecutableName() << std::endl; // check

--- a/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.h
@@ -52,7 +52,7 @@ namespace xdp {
 		       const std::string& toolV);
     ~HALHostTraceWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/writer/hal/hal_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_summary_writer.cpp
@@ -28,7 +28,7 @@ namespace xdp {
   {
   }
 
-  void HALSummaryWriter::write(bool openNewFile)
+  bool HALSummaryWriter::write(bool openNewFile)
   {
     fout << "Call Count" << std::endl ;
     (db->getStats()).dumpCallCount(fout) ;
@@ -37,6 +37,7 @@ namespace xdp {
     (db->getStats()).dumpHALMemory(fout) ;
 
     if (openNewFile) switchFiles() ;
+    return true;
   }
   
 }

--- a/src/runtime_src/xdp/profile/writer/hal/hal_summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_summary_writer.h
@@ -29,7 +29,7 @@ namespace xdp {
     HALSummaryWriter(const char* filename) ;
     ~HALSummaryWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
   } ;
 }
 

--- a/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
@@ -192,8 +192,25 @@ namespace xdp {
     else               writeBinaryDependencies() ;
   }
 
+  bool LowOverheadTraceWriter::traceEventsExist()
+  {
+    return (
+      db->getDynamicInfo().hostEventsExist (
+        [](VTFEvent* e)
+        {
+          return e->isOpenCLAPI() ||
+                 e->isLOPHostEvent() ;
+        }
+      )
+    );
+  }
+
   bool LowOverheadTraceWriter::write(bool openNewFile)
   {
+    if (openNewFile && !traceEventsExist()) {
+      return false;
+    }
+
     // Before writing, set up our information for structures
     setupBuckets() ;
     //setupCommandQueueBuckets() ;

--- a/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
@@ -25,9 +25,9 @@
 namespace xdp {
 
   LowOverheadTraceWriter::LowOverheadTraceWriter(const char* filename) :
-    VPTraceWriter(filename, 
-                   "1.0", 
-                   getCurrentDateTime(), 
+    VPTraceWriter(filename,
+                   "1.1",
+                   getCurrentDateTime(),
                    9 /* ns */),
     generalAPIBucket(-1), readBucket(-1), writeBucket(-1), enqueueBucket(-1)
   {
@@ -59,7 +59,8 @@ namespace xdp {
   void LowOverheadTraceWriter::writeHumanReadableHeader()
   {
     VPTraceWriter::writeHeader() ;
-    fout << "XRT Version," << getToolVersion() << std::endl ;
+    fout << "TraceID," << traceID << std::endl
+         << "XRT Version," << getToolVersion() << std::endl ;
   }
 
   void LowOverheadTraceWriter::writeHumanReadableStructure()
@@ -191,7 +192,7 @@ namespace xdp {
     else               writeBinaryDependencies() ;
   }
 
-  void LowOverheadTraceWriter::write(bool openNewFile)
+  bool LowOverheadTraceWriter::write(bool openNewFile)
   {
     // Before writing, set up our information for structures
     setupBuckets() ;
@@ -209,6 +210,7 @@ namespace xdp {
     if (humanReadable) fout << std::endl ;
 
     if (openNewFile) switchFiles() ;
+    return true;
   }
 
 

--- a/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.h
@@ -62,7 +62,7 @@ namespace xdp {
     LowOverheadTraceWriter(const char* filename) ;
     ~LowOverheadTraceWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.h
@@ -36,6 +36,7 @@ namespace xdp {
     int enqueueBucket ;
 
     void setupBuckets() ;
+    bool traceEventsExist();
 
     void writeHumanReadableHeader() ;
     void writeHumanReadableStructure() ;

--- a/src/runtime_src/xdp/profile/writer/noc/noc_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/noc/noc_writer.cpp
@@ -38,7 +38,7 @@ namespace xdp {
   {    
   }
 
-  void NOCProfilingWriter::write(bool openNewFile)
+  bool NOCProfilingWriter::write(bool openNewFile)
   {
     // Write header #1
     fout << "Target device: " << mDeviceName << std::endl;
@@ -115,6 +115,7 @@ namespace xdp {
       }
       fout << std::endl;
     }
+    return true;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/noc/noc_writer.h
+++ b/src/runtime_src/xdp/profile/writer/noc/noc_writer.h
@@ -30,7 +30,7 @@ namespace xdp {
                        uint64_t deviceIndex);
     ~NOCProfilingWriter();
 
-    virtual void write(bool openNewFile);
+    virtual bool write(bool openNewFile);
     
   private:
     double mSamplePeriod;

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -1580,7 +1580,7 @@ namespace xdp {
     } 
   }
 
-  void OpenCLSummaryWriter::write(bool openNewFile)
+  bool OpenCLSummaryWriter::write(bool openNewFile)
   {
     writeHeader() ;                                 fout << std::endl ;
     writeAPICallSummary() ;                         fout << std::endl ;
@@ -1612,6 +1612,7 @@ namespace xdp {
     {
       switchFiles() ;
     }
+    return true;
   }
 
   void OpenCLSummaryWriter::guidanceDeviceExecTime(OpenCLSummaryWriter* t)

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.h
@@ -91,7 +91,7 @@ namespace xdp {
     XDP_EXPORT OpenCLSummaryWriter(const char* filename) ;
     XDP_EXPORT ~OpenCLSummaryWriter() ;
 
-    XDP_EXPORT virtual void write(bool openNewFile) ;
+    XDP_EXPORT virtual bool write(bool openNewFile) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -269,8 +269,25 @@ namespace xdp {
     else               writeBinaryDependencies() ;
   }
 
+  bool OpenCLTraceWriter::traceEventsExist()
+  {
+    return (
+      db->getDynamicInfo().hostEventsExist (
+        [](VTFEvent* e)
+        {
+          return e->isOpenCLHostEvent();
+        }
+      )
+    );
+  }
+
   bool OpenCLTraceWriter::write(bool openNewFile)
   {
+    if (openNewFile && !traceEventsExist()) {
+      std::cout << "No new opencl trace data.. Skipping new file"<< std::endl;
+      return false;
+    }
+
     // Before writing, set up our information for structures
     setupBuckets() ;
     //setupCommandQueueBuckets() ;

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -284,7 +284,6 @@ namespace xdp {
   bool OpenCLTraceWriter::write(bool openNewFile)
   {
     if (openNewFile && !traceEventsExist()) {
-      std::cout << "No new opencl trace data.. Skipping new file"<< std::endl;
       return false;
     }
 

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -26,9 +26,9 @@
 namespace xdp {
 
   OpenCLTraceWriter::OpenCLTraceWriter(const char* filename) :
-    VPTraceWriter(filename, 
-                   "1.0", 
-                   getCurrentDateTime(), 
+    VPTraceWriter(filename,
+                   "1.1",
+                   getCurrentDateTime(),
                    9 /* ns */),
     generalAPIBucket(-1), readBucket(-1), writeBucket(-1), copyBucket(-1)
   {
@@ -66,7 +66,8 @@ namespace xdp {
   void OpenCLTraceWriter::writeHumanReadableHeader()
   {
     VPTraceWriter::writeHeader() ;
-    fout << "XRT Version," << getToolVersion() << std::endl ;
+    fout << "TraceID," << traceID << std::endl
+         << "XRT Version," << getToolVersion() << std::endl ;
   }
 
   void OpenCLTraceWriter::writeHumanReadableStructure()
@@ -268,7 +269,7 @@ namespace xdp {
     else               writeBinaryDependencies() ;
   }
 
-  void OpenCLTraceWriter::write(bool openNewFile)
+  bool OpenCLTraceWriter::write(bool openNewFile)
   {
     // Before writing, set up our information for structures
     setupBuckets() ;
@@ -286,6 +287,8 @@ namespace xdp {
     if (humanReadable) fout << std::endl ;
 
     if (openNewFile) switchFiles() ;
+
+    return true;
   }
 
 }

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.h
@@ -68,7 +68,7 @@ namespace xdp {
     OpenCLTraceWriter(const char* filename) ;
     ~OpenCLTraceWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.h
@@ -38,6 +38,7 @@ namespace xdp {
     std::map<std::string, int> enqueueBuckets ;
 
     void setupBuckets() ;
+    bool traceEventsExist();
 
     // A helper function to collapse dependency chains when some events
     //  are missing.

--- a/src/runtime_src/xdp/profile/writer/power/power_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/power/power_writer.cpp
@@ -32,7 +32,7 @@ namespace xdp {
   {    
   }
 
-  void PowerProfilingWriter::write(bool openNewFile)
+  bool PowerProfilingWriter::write(bool openNewFile)
   {
     // Write header
     fout << "Target device: " << deviceName << std::endl ;
@@ -76,6 +76,7 @@ namespace xdp {
       }
       fout << std::endl ;
     }
+    return true;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/power/power_writer.h
+++ b/src/runtime_src/xdp/profile/writer/power/power_writer.h
@@ -32,7 +32,7 @@ namespace xdp {
     PowerProfilingWriter(const char* filename, const char* d, uint64_t index) ;
     ~PowerProfilingWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.cpp
@@ -77,7 +77,7 @@ namespace xdp {
     // No dependencies in user events
   }
 
-  void UserEventsTraceWriter::write(bool openNewFile)
+  bool UserEventsTraceWriter::write(bool openNewFile)
   {
     writeHeader() ;
     fout << std::endl ;
@@ -90,6 +90,8 @@ namespace xdp {
     writeDependencies() ;
 
     if (openNewFile) switchFiles() ;
+
+    return true;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.cpp
@@ -25,7 +25,7 @@ namespace xdp {
 
   UserEventsTraceWriter::UserEventsTraceWriter(const char* filename) :
     VPTraceWriter(filename,
-		  "1.0",
+		  "1.1",
 		  getCurrentDateTime(),
 		  9 /* ns */),
     bucketId(1)
@@ -39,6 +39,7 @@ namespace xdp {
   void UserEventsTraceWriter::writeHeader()
   {
     VPTraceWriter::writeHeader() ;
+    fout << "TraceID," << traceID << std::endl;
   }
 
   void UserEventsTraceWriter::writeStructure()

--- a/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.h
@@ -40,7 +40,7 @@ namespace xdp {
     UserEventsTraceWriter(const char* filename) ;
     ~UserEventsTraceWriter() ;
 
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
     
   } ;
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -45,7 +45,7 @@ namespace xdp {
     // Don't actually do anything
   }
 
-  void VPRunSummaryWriter::write(bool /*openNewFile*/)
+  bool VPRunSummaryWriter::write(bool /*openNewFile*/)
   {
     // Ignore openNewFile
     
@@ -53,7 +53,7 @@ namespace xdp {
     //  we dump
     refreshFile() ;
 
-    if (!fout) return ;
+    if (!fout) return false;
 
     // Collect all the files that have been created in this host execution
     //  run and dump their information in the run summary file
@@ -61,7 +61,7 @@ namespace xdp {
       (db->getStaticInfo()).getOpenedFiles() ;
 
     // If there are no files, don't dump anything
-    if (files.empty()) return ; 
+    if (files.empty()) return false; 
 
     boost::property_tree::ptree ptRunSummary ;
     {
@@ -106,6 +106,7 @@ namespace xdp {
     }
 
     boost::property_tree::write_json(fout, ptRunSummary, true) ;
+    return true;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
@@ -37,7 +37,7 @@ namespace xdp {
     ~VPRunSummaryWriter() ;
 
     XDP_EXPORT
-    virtual void write(bool openNewFile) ;
+    virtual bool write(bool openNewFile) ;
 
     virtual bool isRunSummaryWriter() { return true ; }
   } ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
@@ -20,6 +20,12 @@
 #include "xdp/profile/database/database.h"
 #include <iostream>
 
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace xdp {
 
   std::atomic<unsigned int> VPTraceWriter::traceIDCtr{0};
@@ -54,6 +60,17 @@ namespace xdp {
          << "Resolution,ms" << std::endl
          << "Min Resolution," << (resolution == 6 ? "us" : "ns") << std::endl
          << "Trace Version," << version << std::endl; 
+  }
+
+  void VPTraceWriter::setUniqueTraceID()
+  {
+    unsigned int pid;
+    #ifdef _WIN32
+    pid = static_cast<unsigned int>(_getpid()) ;
+    #else
+    pid = static_cast<int>(getpid()) ;
+    #endif
+    traceID = pid + traceIDCtr++;
   }
 
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
@@ -64,12 +64,7 @@ namespace xdp {
 
   void VPTraceWriter::setUniqueTraceID()
   {
-    unsigned int pid;
-    #ifdef _WIN32
-    pid = static_cast<unsigned int>(_getpid()) ;
-    #else
-    pid = static_cast<int>(getpid()) ;
-    #endif
+    unsigned int pid = static_cast<unsigned int>(db->getStaticInfo().getPid());
     traceID = pid + traceIDCtr++;
   }
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
@@ -20,12 +20,6 @@
 #include "xdp/profile/database/database.h"
 #include <iostream>
 
-#ifdef _WIN32
-#include <process.h>
-#else
-#include <unistd.h>
-#endif
-
 namespace xdp {
 
   std::atomic<unsigned int> VPTraceWriter::traceIDCtr{0};

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
@@ -18,8 +18,11 @@
 
 #include "xdp/profile/writer/vp_base/vp_trace_writer.h"
 #include "xdp/profile/database/database.h"
+#include <iostream>
 
 namespace xdp {
+
+  std::atomic<unsigned int> VPTraceWriter::traceIDCtr{0};
 
   VPTraceWriter::VPTraceWriter(const char* filename,
 				 const std::string& v,
@@ -29,6 +32,7 @@ namespace xdp {
     version(v), creationTime(c), resolution(r),
     humanReadable(true)
   {
+    setUniqueTraceID();
   }
 
   VPTraceWriter::~VPTraceWriter()

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
@@ -18,6 +18,8 @@
 #define VP_TRACE_WRITER_DOT_H
 
 #include <string>
+#include <unistd.h>
+#include <atomic>
 
 #include "xdp/profile/writer/vp_base/vp_writer.h"
 #include "xdp/config.h"
@@ -34,6 +36,7 @@ namespace xdp {
     // Also PID, which is stored in the database
     std::string creationTime ;
     uint16_t resolution ;
+    static std::atomic<unsigned int> traceIDCtr;
     
   protected:
     // Each new trace CSV file has the following sections
@@ -45,12 +48,18 @@ namespace xdp {
 
     // Trace formats can either be dumped as a binary or human readable
     bool humanReadable ;
+    unsigned int traceID = 0;
 
     // The different types of VTF file formats supported
     virtual bool isHost()   { return false ; }
     virtual bool isDevice() { return false ; }
     virtual bool isAIE()    { return false ; }
     virtual bool isKernel() { return false ; } 
+
+    // Return a unique ID everytime we're called
+    void setUniqueTraceID() {
+      traceID = static_cast<unsigned int>(getpid()) + traceIDCtr++;
+    }
 
   public:
     XDP_EXPORT VPTraceWriter(const char* filename, const std::string& v,

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
@@ -18,7 +18,6 @@
 #define VP_TRACE_WRITER_DOT_H
 
 #include <string>
-#include <unistd.h>
 #include <atomic>
 
 #include "xdp/profile/writer/vp_base/vp_writer.h"

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
@@ -57,9 +57,7 @@ namespace xdp {
     virtual bool isKernel() { return false ; } 
 
     // Return a unique ID everytime we're called
-    void setUniqueTraceID() {
-      traceID = static_cast<unsigned int>(getpid()) + traceIDCtr++;
-    }
+    XDP_EXPORT void setUniqueTraceID();
 
   public:
     XDP_EXPORT VPTraceWriter(const char* filename, const std::string& v,

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -59,7 +59,8 @@ namespace xdp {
     XDP_EXPORT virtual ~VPWriter() ;
 
     virtual bool isRunSummaryWriter() { return false ; }
-    virtual void write(bool openNewFile = true) = 0 ;
+    // Return false to indicate no data was written
+    virtual bool write(bool openNewFile = true) = 0 ;
     virtual bool isDeviceWriter() { return false ; } 
     virtual DeviceIntf* device() { return nullptr ; } 
     virtual bool isSameDevice(void* /*handle*/) { return false ; }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -19,6 +19,7 @@
 
 #include <fstream>
 #include <string>
+#include <iostream>
 
 #include "xdp/config.h"
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -19,7 +19,6 @@
 
 #include <fstream>
 #include <string>
-#include <iostream>
 
 #include "xdp/config.h"
 

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -78,7 +78,7 @@ namespace xdplop {
     if (xrt_xocl::config::get_opencl_trace() || xrt_xocl::config::get_timeline_trace())
     {
       xrt_xocl::message::send(xrt_xocl::message::severity_level::warning,
-			 "Both low overhead profiling and OpenCL trace are enabled. Disabling LOP trace as it cannot be used together with OpenCL trace\n") ;
+			 "Both low overhead profiling and OpenCL trace are enabled. Disabling LOP trace as it cannot be used together with OpenCL trace.\n") ;
       return false;
     }
     return true;

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -32,7 +32,8 @@ namespace xdplop {
     // Thread safe per C++-11
     static xrt_core::module_loader xdp_lop_loader("xdp_lop_plugin",
 						  register_lop_functions,
-						  lop_warning_function) ;
+						  lop_warning_function,
+              lop_error_function) ;
   }
 
   // All of the function pointers that will be dynamically linked from
@@ -73,15 +74,15 @@ namespace xdplop {
     }
   }
 
-  bool check_lop_trace()
+  int lop_error_function()
   {
     if (xrt_xocl::config::get_opencl_trace() || xrt_xocl::config::get_timeline_trace())
     {
       xrt_xocl::message::send(xrt_xocl::message::severity_level::warning,
 			 "Both low overhead profiling and OpenCL trace are enabled. Disabling LOP trace as it cannot be used together with OpenCL trace.\n") ;
-      return false;
+      return 1;
     }
-    return true;
+    return 0;
   }
 
   LOPFunctionCallLogger::LOPFunctionCallLogger(const char* function) :
@@ -99,7 +100,7 @@ namespace xdplop {
     {
       s_load_lop = true ;
       // In case of a conflict, mark lop plugin as loaded without actually loading the plugin
-      if (xrt_core::config::get_lop_trace() && check_lop_trace()) {
+      if (xrt_core::config::get_lop_trace()) {
         load_xdp_lop() ;
       }
     }

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.cpp
@@ -73,6 +73,17 @@ namespace xdplop {
     }
   }
 
+  bool check_lop_trace()
+  {
+    if (xrt_xocl::config::get_opencl_trace() || xrt_xocl::config::get_timeline_trace())
+    {
+      xrt_xocl::message::send(xrt_xocl::message::severity_level::warning,
+			 "Both low overhead profiling and OpenCL trace are enabled. Disabling LOP trace as it cannot be used together with OpenCL trace\n") ;
+      return false;
+    }
+    return true;
+  }
+
   LOPFunctionCallLogger::LOPFunctionCallLogger(const char* function) :
     LOPFunctionCallLogger(function, 0)
   {    
@@ -87,8 +98,10 @@ namespace xdplop {
     if (!s_load_lop)
     {
       s_load_lop = true ;
-      if (xrt_core::config::get_lop_trace()) 
-	load_xdp_lop() ;
+      // In case of a conflict, mark lop plugin as loaded without actually loading the plugin
+      if (xrt_core::config::get_lop_trace() && check_lop_trace()) {
+        load_xdp_lop() ;
+      }
     }
 
     // Log the stats for this function

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.h
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.h
@@ -45,7 +45,7 @@ namespace xdplop {
   void lop_warning_function() ;
 
   // Check and warn if opencl/timeline trace are enabled
-  bool check_lop_trace();
+  int lop_error_function();
   
   // Every OpenCL API we are interested in will have an instance
   //  of this class constructed at the start

--- a/src/runtime_src/xocl/api/plugin/xdp/lop.h
+++ b/src/runtime_src/xocl/api/plugin/xdp/lop.h
@@ -43,6 +43,9 @@ namespace xdplop {
 
   // A function that outputs any warnings based upon status and configuration
   void lop_warning_function() ;
+
+  // Check and warn if opencl/timeline trace are enabled
+  bool check_lop_trace();
   
   // Every OpenCL API we are interested in will have an instance
   //  of this class constructed at the start


### PR DESCRIPTION
Unique trace ID for each writer
No trace file is created when there's no trace available in ocl, lop, device plugins
Turn off lop trace when opencl trace is enabled