### PR TITLE
Backport CR-1088585 xbutil validate with a soft kernel test case / example (u30)

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -281,7 +281,8 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     static const std::map<std::string, std::string> test_map = {
       { "22_verify.py",             "validate.exe"    },
       { "23_bandwidth.py",          "kernel_bw.exe"   },
-      { "host_mem_23_bandwidth.py", "slavebridge.exe" }
+      { "host_mem_23_bandwidth.py", "slavebridge.exe" },
+      { "xcl_vcu_test.exe",         "xcl_vcu_test.exe"}
     };
         
     if (test_map.find(py) == test_map.end()) {
@@ -896,6 +897,15 @@ hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost:
 }
 
 /*
+ * TEST #10
+ */
+void
+vcuKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
+{
+  runTestCase(_dev, "xcl_vcu_test.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
+}
+
+/*
 * helper function to initialize test info
 */
 static boost::property_tree::ptree
@@ -924,7 +934,8 @@ static std::vector<TestCollection> testSuite = {
   { create_init_test("Bandwidth kernel", "Run 'bandwidth kernel' and check the throughput", "bandwidth.xclbin"), bandwidthKernelTest },
   { create_init_test("Peer to peer bar", "Run P2P test", "bandwidth.xclbin"), p2pTest },
   { create_init_test("Memory to memory DMA", "Run M2M test", "bandwidth.xclbin"), m2mTest },
-  { create_init_test("Host memory bandwidth test", "Run 'bandwidth kernel' when slave bridge is enabled", "bandwidth.xclbin"), hostMemBandwidthKernelTest }
+  { create_init_test("Host memory bandwidth test", "Run 'bandwidth kernel' when slave bridge is enabled", "bandwidth.xclbin"), hostMemBandwidthKernelTest },
+  { create_init_test("vcu", "Run decoder test", "verify.xclbin"), vcuKernelTest }
 };
 
 /*


### PR DESCRIPTION
Cherry-pick: https://github.com/Xilinx/XRT/pull/4820
```
# /opt/xilinx/xrt/bin/xbutil -new validate -d 17:00 -r vcu
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
Starting validation for 1 devices

Validate device[0000:17:00.1]
Platform            : xilinx_u30_gen3x4_base_1
SC Version          : 6.3.5
Platform ID         : 0x0

1/1 Test #1 [0000:17:00.1]  : vcu
    Description             : Run decoder test
    Xclbin                  : /opt/xilinx/firmware/u30/gen3x4/base/test/verify.xclbin
    Testcase                : /opt/xilinx/xrt/test/xcl_vcu_test.exe
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
Validation completed

```