### PR TITLE
Metadata update only to disable 56_xclbin from sprite

### DIFF
--- a/tests/xrt/56_xclbin/testinfo.yml
+++ b/tests/xrt/56_xclbin/testinfo.yml
@@ -1,4 +1,5 @@
 #template_tql < $XTC_TEMPLATES/sdx/sdaccel/swhw/template.tql
+disabled: 1
 description: testinfo generated using import_sdx_test.py script
 level: 6
 owner: haeseung


### PR DESCRIPTION
Metadata update only. No source code change. 
This will disable 56_xclbin from sprite run