### PR TITLE
Mb sched off chk

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1303,8 +1303,7 @@ static int ert_user_probe(struct platform_device *pdev)
 	int err = 0;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xocl_ert_sched_privdata *priv = NULL;
-	bool ert = (XOCL_DSA_IS_VERSAL(xdev) || XOCL_DSA_IS_MPSOC(xdev)) ? true :
-	    xocl_mb_sched_on(xdev);
+	bool ert = xocl_mb_sched_on(xdev);
 
 	/* If XOCL_DSAFLAG_MB_SCHE_OFF is set, we should not probe ert */
 	if (!ert)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -1303,6 +1303,12 @@ static int ert_user_probe(struct platform_device *pdev)
 	int err = 0;
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xocl_ert_sched_privdata *priv = NULL;
+	bool ert = (XOCL_DSA_IS_VERSAL(xdev) || XOCL_DSA_IS_MPSOC(xdev)) ? true :
+	    xocl_mb_sched_on(xdev);
+
+	/* If XOCL_DSAFLAG_MB_SCHE_OFF is set, we should not probe ert */
+	if (!ert)
+		return -ENODEV;
 
 	ert_user = xocl_drvinst_alloc(&pdev->dev, sizeof(struct xocl_ert_user));
 	if (!ert_user)


### PR DESCRIPTION
U25 has ert in its shell, however due to bug, we have a flag MB_SCHED_OFF_CHK as workaround.

Once the bit is set, we should not probe ert then it will fall back to KDS mode