### PR TITLE
clang-tidy support on Ubuntu 20.04

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,5 +1,15 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,bugprone-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,modernize-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-pointer-arithmetic'
+Checks:          >
+clang-diagnostic-*,
+clang-analyzer-*,
+cert-*,bugprone-*,
+clang-analyzer-*,
+concurrency-*,
+cppcoreguidelines-*,
+hicpp-*,
+modernize-*,
+-modernize-use-trailing-return-type,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,287 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,bugprone-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,modernize-*,-modernize-use-trailing-return-type,-cppcoreguidelines-pro-bounds-pointer-arithmetic'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            sonals
+CheckOptions:
+  - key:             bugprone-argument-comment.CommentBoolLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentCharacterLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentFloatLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentIntegerLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentNullPtrs
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentStringLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentUserDefinedLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.IgnoreSingleArgument
+    value:           '0'
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-dynamic-static-initializers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
+    value:           ''
+  - key:             bugprone-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             bugprone-not-null-terminated-result.WantToUseSafeFunctions
+    value:           '1'
+  - key:             bugprone-signed-char-misuse.CharTypdefsToIgnore
+    value:           ''
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             bugprone-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             bugprone-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             bugprone-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit
+    value:           '16'
+  - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+    value:           '1'
+  - key:             bugprone-unused-return-value.CheckedFunctions
+    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty'
+  - key:             cert-dcl16-c.IgnoreMacros
+    value:           '1'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-dcl59-cpp.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             cert-err09-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-err61-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-msc32-c.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             cert-msc51-cpp.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             cert-oop11-cpp.IncludeStyle
+    value:           llvm
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.FinalSpelling
+    value:           final
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
+    value:           override
+  - key:             cppcoreguidelines-macro-usage.AllowedRegexp
+    value:           '^DEBUG_*'
+  - key:             cppcoreguidelines-macro-usage.CheckCapsOnly
+    value:           '0'
+  - key:             cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
+    value:           '1'
+  - key:             cppcoreguidelines-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             cppcoreguidelines-no-malloc.Deallocations
+    value:           '::free'
+  - key:             cppcoreguidelines-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value:           '::free;::realloc;::freopen;::fclose'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
+    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value:           ''
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             hicpp-braces-around-statements.ShortStatementLines
+    value:           '4'
+  - key:             hicpp-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.StatementThreshold
+    value:           '800'
+  - key:             hicpp-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             hicpp-member-init.IgnoreArrays
+    value:           '0'
+  - key:             hicpp-member-init.UseAssignment
+    value:           '0'
+  - key:             hicpp-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             hicpp-multiway-paths-covered.WarnOnMissingElse
+    value:           '0'
+  - key:             hicpp-named-parameter.IgnoreFailedSplit
+    value:           '0'
+  - key:             hicpp-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             hicpp-no-malloc.Deallocations
+    value:           '::free'
+  - key:             hicpp-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
+    value:           '0'
+  - key:             hicpp-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             hicpp-uppercase-literal-suffix.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-uppercase-literal-suffix.NewSuffixes
+    value:           ''
+  - key:             hicpp-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             hicpp-use-auto.RemoveStars
+    value:           '0'
+  - key:             hicpp-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             hicpp-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             hicpp-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             hicpp-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             hicpp-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-use-equals-delete.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-use-noexcept.ReplacementString
+    value:           ''
+  - key:             hicpp-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             hicpp-use-nullptr.NullMacros
+    value:           ''
+  - key:             hicpp-use-override.AllowOverrideAndFinal
+    value:           '0'
+  - key:             hicpp-use-override.FinalSpelling
+    value:           final
+  - key:             hicpp-use-override.IgnoreDestructors
+    value:           '0'
+  - key:             hicpp-use-override.OverrideSpelling
+    value:           override
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           '0'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           '0'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-equals-delete.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-nodiscard.ReplacementString
+    value:           '[[nodiscard]]'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-use-override.AllowOverrideAndFinal
+    value:           '0'
+  - key:             modernize-use-override.FinalSpelling
+    value:           final
+  - key:             modernize-use-override.IgnoreDestructors
+    value:           '0'
+  - key:             modernize-use-override.OverrideSpelling
+    value:           override
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           '0'
+  - key:             modernize-use-using.IgnoreMacros
+    value:           '1'
+...

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,4 +1,9 @@
 ---
+# The following configuration was generated with --dump-config and then manually tweaked to suit XRT coding style.
+# The command line used to generate the global src/.clang-tidy is:
+# clang-tidy "-checks=cert-*,bugprone-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,modernize-*" --dump-config
+# clang-tidy looks for .clang-tidy file walking up the source directory structure to identify which checks to run
+# One can customize checks in specific source directories by placing custom .clang-tidy in those source directories
 Checks:          >
 clang-diagnostic-*,
 clang-analyzer-*,

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -2,7 +2,8 @@
 Checks:          >
 clang-diagnostic-*,
 clang-analyzer-*,
-cert-*,bugprone-*,
+cert-*,
+bugprone-*,
 clang-analyzer-*,
 concurrency-*,
 cppcoreguidelines-*,

--- a/src/CMake/lint.cmake
+++ b/src/CMake/lint.cmake
@@ -1,20 +1,9 @@
-find_program(CLANGTIDY run-clang-tidy)
-
-include(ProcessorCount)
-ProcessorCount(JOBS)
-if (JOBS EQUAL 0)
-   set(JOBS 1)
-endif ()
-
-if (NOT CLANGTIDY)
-  message (WARNING "-- run-clang-tidy not found, static code analysis disabled")
-else ()
-  message ("-- run-clang-tidy found, static code analysis enabled")
-# run-clang-tidy uses CMake generated compile_comands.json with -p switch
-  add_custom_target(
-    clang-tidy
-    COMMAND ${CLANGTIDY}
-    -j ${JOBS}
-    -p ${CMAKE_CURRENT_BINARY_DIR}
-    )
-endif ()
+IF((${CMAKE_VERSION} VERSION_GREATER "3.7.2") AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+  find_program(CLANG_TIDY clang-tidy)
+  if(NOT CLANG_TIDY)
+    message(FATAL_ERROR "clang-tidy not found, static analysis disabled")
+  else()
+    message("-- Enabling clang-tidy")
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=cert-*,bugprone-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,modernize-*")
+  endif()
+endif()

--- a/src/CMake/lint.cmake
+++ b/src/CMake/lint.cmake
@@ -1,9 +1,13 @@
-IF((${CMAKE_VERSION} VERSION_GREATER "3.7.2") AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+
+# Clang Tidy ia integrated into CMake since 3.7.2 and is automatically run if CMAKE_CXX_CLANG_TIDY
+# is set. In future we should refine the checks run using clang-tidy's config files.
+
+IF((${CMAKE_VERSION} VERSION_GREATER "3.7.2") AND (XRT_CLANG_TIDY STREQUAL "ON"))
   find_program(CLANG_TIDY clang-tidy)
   if(NOT CLANG_TIDY)
     message(FATAL_ERROR "clang-tidy not found, static analysis disabled")
   else()
     message("-- Enabling clang-tidy")
-    set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=cert-*,bugprone-*,clang-analyzer-*,concurrency-*,cppcoreguidelines-*,hicpp-*,modernize-*")
+    set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
   endif()
 endif()

--- a/src/CMake/lint.cmake
+++ b/src/CMake/lint.cmake
@@ -1,6 +1,8 @@
 
 # Clang Tidy ia integrated into CMake since 3.7.2 and is automatically run if CMAKE_CXX_CLANG_TIDY
-# is set. In future we should refine the checks run using clang-tidy's config files.
+# is set. We currently rely on a global .clang-tidy placed inside "src" directory that is automatically
+# found by clang-tidy. In future we should refine the checks run for specific directories using
+# custom .clang-tidy config files in those directories.
 
 IF((${CMAKE_VERSION} VERSION_GREATER "3.7.2") AND (XRT_CLANG_TIDY STREQUAL "ON"))
   find_program(CLANG_TIDY clang-tidy)

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -62,11 +62,11 @@ execute_process(COMMAND ${UNAME} -r
 if (DEFINED ENV{XRT_BOOST_INSTALL})
   set(XRT_BOOST_INSTALL $ENV{XRT_BOOST_INSTALL})
   set(Boost_USE_STATIC_LIBS ON)
-  find_package(Boost 
+  find_package(Boost
     HINTS $ENV{XRT_BOOST_INSTALL}
     REQUIRED COMPONENTS system filesystem)
 else()
-  find_package(Boost 
+  find_package(Boost
     REQUIRED COMPONENTS system filesystem)
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
@@ -116,6 +116,9 @@ include (CMake/ccache.cmake)
 message("-- ${CMAKE_SYSTEM_INFO_FILE} (${LINUX_FLAVOR}) (Kernel ${LINUX_KERNEL_VERSION})")
 message("-- Compiler: ${CMAKE_CXX_COMPILER} ${CMAKE_C_COMPILER}")
 
+# --- Lint ---
+include (CMake/lint.cmake)
+
 add_subdirectory(runtime_src)
 
 #XMA settings START
@@ -146,9 +149,6 @@ message("-- XRT version: ${XRT_VERSION_STRING}")
 
 # -- CPack
 include (CMake/cpackLin.cmake)
-
-# --- Lint ---
-include (CMake/lint.cmake)
 
 set (XRT_DKMS_DRIVER_SRC_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core")
 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -477,6 +477,10 @@ install()
         apt install -y "${UB_LIST[@]}"
     fi
 
+    if [ $FLAVOR == "ubuntu" ] && [ $MAJOR == 20 ]; then
+	apt install clang-tidy
+    fi
+
     # Enable EPEL on CentOS/RHEL
     if [ $FLAVOR == "centos" ]; then
         prep_centos


### PR DESCRIPTION
1. Updated xrtdeps.sh to install clang-tidyUpdated xrtdeps.sh to install clang-tidy
2. Update build.sh to take -clangtidy as an argument
3. Update lint.cmake to use CMake build-in support for clang-tidy
4. Added initial .clant-tidy to src directory
5. Run as part of build like this on Ubuntu 20.04: **build.sh -clangtidy**

The report looks like this:

```
/home/sonals/git/XRT/src/runtime_src/core/common/api/sws.cpp:87:18: warning: unused variable 'AP_READY' [clang-diagnostic-unused-const-variable]
const value_type AP_READY    = 0x8;
                 ^
/home/sonals/git/XRT/src/runtime_src/core/common/api/sws.cpp:482:21: warning: private field 'm_xdev' is not used [clang-diagnostic-unused-private-field]
  xrt_core::device* m_xdev = nullptr;
                    ^
/home/sonals/git/XRT/src/runtime_src/core/common/api/sws.cpp:870:24: warning: moving a temporary object prevents copy elision [clang-diagnostic-pessimizing-move]
  s_scheduler_thread = std::move(xrt_core::thread(scheduler_loop));
                       ^
/home/sonals/git/XRT/src/runtime_src/core/common/api/sws.cpp:870:24: note: remove std::move call here
  s_scheduler_thread = std::move(xrt_core::thread(scheduler_loop));
                       ^~~~~~~~~~                                ~
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:126:18: warning: unused variable 'AP_CTRL_HS' [clang-diagnostic-unused-const-variable]
static const u32 AP_CTRL_HS    = 0;
                 ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:127:18: warning: unused variable 'AP_CTRL_CHAIN' [clang-diagnostic-unused-const-variable]
static const u32 AP_CTRL_CHAIN = 1;
                 ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:129:18: warning: unused variable 'AP_CTRL_ME' [clang-diagnostic-unused-const-variable]
static const u32 AP_CTRL_ME    = 3;
                 ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:130:18: warning: unused variable 'ACCEL_ADATER' [clang-diagnostic-unused-const-variable]
static const u32 ACCEL_ADATER  = 4;
                 ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:131:18: warning: unused variable 'FAST_ADATER' [clang-diagnostic-unused-const-variable]
static const u32 FAST_ADATER   = 5;
                 ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:638:47: warning: The result of the left shift is undefined due to shifting by '32', which is greater or equal to the width of type 'int' [clang-analyzer-core.UndefinedBinaryOperatorResult]
  write_reg(STATUS_REGISTER_ADDR[cmd_idx>>5],1<<cmd_idx);
                                              ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1444:5: note: Calling 'cu_interrupt_handler'
    ert_v30::cu_interrupt_handler();
    ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1373:3: note: Assuming 'dmsg' is 0
  DMSGF("interrupt_handler\r\n");
  ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:84:32: note: expanded from macro 'DMSGF'
# define DMSGF(format,...) if (dmsg) xil_printf(format, ##__VA_ARGS__)
                               ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1373:3: note: Taking false branch
  DMSGF("interrupt_handler\r\n");
  ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:84:28: note: expanded from macro 'DMSGF'
# define DMSGF(format,...) if (dmsg) xil_printf(format, ##__VA_ARGS__)
                           ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1376:7: note: Assuming the condition is true
  if (intc_mask & 0x1) { // host interrupt
      ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1376:3: note: Taking true branch
  if (intc_mask & 0x1) { // host interrupt
  ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1377:34: note: Assuming 'w' is < 'num_slot_masks'
    for (size_type w=0,offset=0; w<num_slot_masks; ++w,offset+=32) {
                                 ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1377:5: note: Loop condition is true.  Entering loop body
    for (size_type w=0,offset=0; w<num_slot_masks; ++w,offset+=32) {
    ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1379:7: note: Assuming 'dmsg' is 0
      DMSGF("command queue interrupt from host: 0x%x\r\n",slot_mask);
      ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:84:32: note: expanded from macro 'DMSGF'
# define DMSGF(format,...) if (dmsg) xil_printf(format, ##__VA_ARGS__)
                               ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1379:7: note: Taking false branch
      DMSGF("command queue interrupt from host: 0x%x\r\n",slot_mask);
      ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:84:28: note: expanded from macro 'DMSGF'
# define DMSGF(format,...) if (dmsg) xil_printf(format, ##__VA_ARGS__)
                           ^
/home/sonals/git/XRT/src/runtime_src/ert/scheduler/scheduler_v30.cpp:1381:7: note: Loop condition is false. Execution continues on line 1377
      for (size_type slot_idx=offset; slot_mask; slot_mask >>= 1, ++slot_idx)

...


/home/sonals/git/XRT/src/runtime_src/core/common/message.h:63:44: error: cannot pass object of non-trivial type 'std::__cxx11::basic_string<char>' through variadic function; call will abort at runtime [clang-diagnostic-non-pod-varargs]
    auto sz = snprintf(nullptr, 0, format, args ...);
                                           ^
/home/sonals/git/XRT/src/runtime_src/core/pcie/linux/shim.cpp:95:22: note: in instantiation of function template specialization 'xrt_core::message::send<const char *, std::__cxx11::basic_string<char> >' requested here
  xrt_core::message::send(slvl, "XRT", format, std::forward<Args>(args)...);
                     ^
/home/sonals/git/XRT/src/runtime_src/core/pcie/linux/shim.cpp:1532:9: note: in instantiation of function template specialization '(anonymous namespace)::xrt_logmsg<char const (&)[18], std::__cxx11::basic_string<char> &>' requested here
        xrt_logmsg(XRT_ERROR, "%s: %s", __func__, err);
        ^
/home/sonals/git/XRT/src/runtime_src/core/common/message.h:70:38: error: cannot pass object of non-trivial type 'std::__cxx11::basic_string<char>' through variadic function; call will abort at runtime [clang-diagnostic-non-pod-varargs]
    snprintf(buf.data(), sz, format, args ...);
                                     ^
```