### PR TITLE
XRT-861 Check CU‘s metadata and safely ignore unrecognizable CU

### DIFF
--- a/src/CMake/dkms-edge.cmake
+++ b/src/CMake/dkms-edge.cmake
@@ -85,6 +85,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV
   common/drv/kds_core.c
   common/drv/xrt_cu.c
   common/drv/cu_hls.c
+  common/drv/cu_null.c
   common/drv/cu_plram.c
   common/drv/xrt_xclbin.c
   common/drv/Makefile

--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -265,6 +265,7 @@ SET (XRT_DKMS_COMMON_XRT_DRV
   common/drv/kds_core.c
   common/drv/xrt_cu.c
   common/drv/cu_hls.c
+  common/drv/cu_null.c
   common/drv/fast_adapter.c
   common/drv/cu_plram.c
   common/drv/xrt_xclbin.c

--- a/src/runtime_src/core/common/drv/cu_null.c
+++ b/src/runtime_src/core/common/drv/cu_null.c
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Xilinx HLS CU
+ *
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: min.ma@xilinx.com
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#include "xrt_cu.h"
+
+/* This is NULL CU model that handles unexpected CU protocol or unknown CUs.
+ * So that other CUs would still work.
+ *
+ * Note: Any commands submit to this CU would return immediately.
+ */
+
+static int cu_null_alloc_credit(void *core)
+{
+	return 1;
+}
+
+static void cu_null_free_credit(void *core, u32 count)
+{
+}
+
+static int cu_null_peek_credit(void *core)
+{
+	return 1;
+}
+
+static void cu_null_configure(void *core, u32 *data, size_t sz, int type)
+{
+}
+
+static void cu_null_start(void *core)
+{
+}
+
+static void cu_null_check(void *core, struct xcu_status *status)
+{
+	status->num_done = 1;
+	status->num_ready = 1;
+	status->new_status = CU_AP_IDLE;
+}
+
+static void cu_null_enable_intr(void *core, u32 intr_type)
+{
+}
+
+static void cu_null_disable_intr(void *core, u32 intr_type)
+{
+}
+
+static u32 cu_null_clear_intr(void *core)
+{
+	return 0;
+}
+
+static struct xcu_funcs xrt_cu_null_funcs = {
+	.alloc_credit	= cu_null_alloc_credit,
+	.free_credit	= cu_null_free_credit,
+	.peek_credit	= cu_null_peek_credit,
+	.configure	= cu_null_configure,
+	.start		= cu_null_start,
+	.check		= cu_null_check,
+	.enable_intr	= cu_null_enable_intr,
+	.disable_intr	= cu_null_disable_intr,
+	.clear_intr	= cu_null_clear_intr,
+};
+
+int xrt_cu_null_init(struct xrt_cu *xcu)
+{
+	xcu_info(xcu, "CU(%d) is null, command will directly complete",
+		 xcu->info.cu_idx);
+
+	xcu->status = CU_AP_IDLE;
+	xcu->core = NULL;
+	xcu->funcs = &xrt_cu_null_funcs;
+
+	xcu->busy_threshold = -1;
+	xcu->interval_min = 2;
+	xcu->interval_max = 5;
+
+	return xrt_cu_init(xcu);
+}
+
+void xrt_cu_null_fini(struct xrt_cu *xcu)
+{
+	xrt_cu_fini(xcu);
+}
+

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -54,6 +54,7 @@
 #define CU_INTR_READY 0x2
 
 enum xcu_model {
+	XCU_NULL,
 	XCU_HLS,
 	XCU_ACC,
 	XCU_PLRAM,
@@ -375,6 +376,9 @@ ssize_t show_cu_stat(struct xrt_cu *xcu, char *buf);
 ssize_t show_cu_info(struct xrt_cu *xcu, char *buf);
 
 /* CU Implementations */
+int xrt_cu_null_init(struct xrt_cu *xcu);
+void xrt_cu_null_fini(struct xrt_cu *xcu);
+
 #define to_cu_hls(core) ((struct xrt_cu_hls *)(core))
 struct xrt_cu_hls {
 	void __iomem		*vaddr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1521,12 +1521,21 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 	for (i = 0; i < ip_layout->m_count; ++i) {
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_CU;
 		struct ip_data *ip = &ip_layout->m_ip_data[i];
+		u32 range;
 
 		if (ip->m_type != IP_KERNEL)
 			continue;
 
 		if (ip->m_base_address == 0xFFFFFFFF)
 			continue;
+
+		range = subdev_info.res[0].end - subdev_info.res[0].start;
+		/* If CU's address is not aligned, remove CU's resource */
+		if ((ip->m_base_address & range) != 0) {
+			subdev_info.num_res = 0;
+			subdev_info.res[0].start = 0;
+			subdev_info.res[0].end = 0;
+		}
 
 		memset(&info, 0, sizeof(info));
 		/* NOTE: Only support 64 instences in subdev framework */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -42,6 +42,7 @@ endif
 
 drv_common-y   := $(common_dir)/kds_core.o \
 		  $(common_dir)/xrt_cu.o \
+		  $(common_dir)/cu_null.o \
 		  $(common_dir)/cu_hls.o \
 		  $(common_dir)/fast_adapter.o \
 		  $(common_dir)/cu_plram.o \


### PR DESCRIPTION
This change is U30 specific. It would allow incorrect CU address in xclbin and safely handle it.
This change would not break existed cases.