### PR TITLE
CR-1090469 and CR-1090166

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -669,7 +669,7 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
     config = xrt_core::device_query<xrt_core::query::p2p_config>(_dev);
   }
   catch (const std::runtime_error&) {
-    msg = "P2P is not available";
+    msg = "Error:P2P config failed. P2P is not available";
     return static_cast<int>(p2p_config::not_supported);
   }
 
@@ -693,7 +693,7 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
 
   //return the config with a message
   if (bar == -1) {
-    msg = "Error:P2P is not supported. Can't find P2P BAR.";
+    msg = "Error:P2P config failed. P2P is not supported. Can't find P2P BAR.";
     return static_cast<int>(p2p_config::not_supported);
   }
   else if (rbar != -1 && rbar > bar) {
@@ -701,7 +701,7 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
     return static_cast<int>(p2p_config::reboot);
   }
   else if (remap > 0 && remap != bar) {
-    msg = "Error:P2P remapper is not set correctly";
+    msg = "Error:P2P config failed. P2P remapper is not set correctly";
     return static_cast<int>(p2p_config::error);
   }
   else if (bar == exp_bar) {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -206,6 +206,8 @@ int Flasher::getBoardInfo(BoardInfo& board)
 
     std::string unassigned_mac = "FF:FF:FF:FF:FF:FF";
     board.mBMCVer = std::move(charVec2String(info[BDINFO_BMC_VER]));
+    if (flasher.fixedSC())
+        board.mBMCVer += "(FIXED)";
     board.mConfigMode = info.find(BDINFO_CONFIG_MODE) != info.end() ?
         info[BDINFO_CONFIG_MODE][0] : '\0';
     board.mFanPresence = info.find(BDINFO_FAN_PRESENCE) != info.end() ?

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -537,7 +537,7 @@ bool XMC_Flasher::isXMCReady()
 
 bool XMC_Flasher::isBMCReady()
 {
-    bool bmcReady = (BMC_MODE() == 0x1);
+    bool bmcReady = (BMC_MODE() == 0x1) || (BMC_MODE() == 0x5);
 
     if (!bmcReady) {
         auto format = xrt_core::utils::ios_restore(std::cout);
@@ -556,3 +556,16 @@ bool XMC_Flasher::hasSC()
     } catch (...) {}
     return sc_presence;
 }
+
+bool XMC_Flasher::fixedSC()
+{
+    bool is_sc_fixed = false;
+    std::string errmsg;
+
+    try {
+        is_sc_fixed = xrt_core::device_query<xrt_core::query::is_sc_fixed>(m_device);
+    } catch (...) {}
+
+    return is_sc_fixed;
+}
+

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.h
@@ -108,6 +108,8 @@ public:
     int xclUpgradeFirmware(std::istream& tiTxtStream);
     int xclGetBoardInfo(std::map<char, std::vector<char>>& info);
     const std::string probingErrMsg() { return mProbingErrMsg.str(); }
+    bool fixedSC();
+
 
 private:
     std::shared_ptr<xrt_core::device> m_device;


### PR DESCRIPTION
- CR-1090469 ASTeR TC 21.03 - u30 - Improve error message when p2p is not supported, but is attempted to be enabled
- CR-1090166 xbmgmt2 not seeing the U30 SC
```
$ xbmgmt -new examine
-----------------------------------------------------
 Invoking next generation of the xbmgmt application
-----------------------------------------------------
-----------------------------------------------
1/16 [0000:6d:00.0] : xilinx_u30_gen3x4_base_1
-----------------------------------------------
Flash properties
  Type                 : qspi_ps_x2_single
  Serial Number        : XFL1BRW4DUYR

Flashable partitions running on FPGA
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform ID          : BDB6119B-AC58-C962-1062-9DE857A4CE00
  Interface UUID       : 265FF36F-14F4-A973-3531-A7BF8EE32083

Flashable partitions installed in system
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform ID          : 0xbdb6119bac58c962

----------------------------------------------------
-----------------------------------------------
2/16 [0000:6c:00.0] : xilinx_u30_gen3x4_base_1
-----------------------------------------------
Flash properties
  Type                 : qspi_ps_x2_single
  Serial Number        : XFL1BRW4DUYR

Flashable partitions running on FPGA
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5(FIXED)
  Platform ID          : BDB6119B-AC58-C962-1062-9DE857A4CE00
  Interface UUID       : 265FF36F-14F4-A973-3531-A7BF8EE32083

Flashable partitions installed in system
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform ID          : 0xbdb6119bac58c962

```