### PR TITLE
CR-1090772 xbutil dump should not show information for soft kernel in compute_unit

### DIFF
--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -121,7 +121,7 @@ populate_cus_new(const xrt_core::device *device)
     ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
     cu_list.push_back(std::make_pair("", ptCu));
   }
-  pt.add_child("compute_units", cu_list);
+  pt.add_child("pl_compute_units", cu_list);
 
   boost::property_tree::ptree pscu_list;
   for (auto& stat : scu_stats) {
@@ -178,11 +178,11 @@ ReportCu::writeReport( const xrt_core::device * _pDevice,
   boost::format cuFmt("%-8s%-30s%-16s%-8s%-8s\n");
 
   //check if a valid CU report is generated
-  boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units.compute_units");
+  boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units.pl_compute_units");
   if(pt_cu.empty())
     return;
 
-  _output << "Compute Units" << std::endl;
+  _output << "PL Compute Units" << std::endl;
   _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
   try {
     int index = 0;

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -112,23 +112,27 @@ populate_cus_new(const xrt_core::device *device)
     return pt;
   }
 
+  boost::property_tree::ptree cu_list;
   for (auto& stat : cu_stats) {
     boost::property_tree::ptree ptCu;
     ptCu.put( "name",           stat.name);
     ptCu.put( "base_address",   boost::str(boost::format("0x%x") % stat.base_addr));
     ptCu.put( "usage",          stat.usages);
     ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
-    pt.push_back(std::make_pair("", ptCu));
+    cu_list.push_back(std::make_pair("", ptCu));
   }
+  pt.add_child("compute_units", cu_list);
 
+  boost::property_tree::ptree pscu_list;
   for (auto& stat : scu_stats) {
     boost::property_tree::ptree ptCu;
     ptCu.put( "name",           stat.name);
     ptCu.put( "base_address",   "0x0");
     ptCu.put( "usage",          stat.usages);
     ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
-    pt.push_back(std::make_pair("", ptCu));
+    pscu_list.push_back(std::make_pair("", ptCu));
   }
+  pt.add_child("ps_compute_units", pscu_list);
 
   return pt;
 }
@@ -171,18 +175,41 @@ ReportCu::writeReport( const xrt_core::device * _pDevice,
   boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
   getPropertyTreeInternal(_pDevice, _pt);
+  boost::format cuFmt("%-8s%-30s%-16s%-8s%-8s\n");
 
-  //check if a valid report is generated
-  boost::property_tree::ptree& v = _pt.get_child("compute_units");
-  if(v.empty())
+  //check if a valid CU report is generated
+  boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units.compute_units");
+  if(pt_cu.empty())
     return;
 
   _output << "Compute Units" << std::endl;
-  boost::format cuFmt("%-8s%-24s%-16s%-8s%-8s\n");
   _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
   try {
     int index = 0;
-    for(auto& kv : v) {
+    for(auto& kv : pt_cu) {
+      boost::property_tree::ptree& cu = kv.second;
+      std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
+      uint32_t status_val = std::stoul(cu_status, nullptr, 16);
+      _output << cuFmt % index++ %
+	      cu.get<std::string>("name") % cu.get<std::string>("base_address") %
+	      cu.get<std::string>("usage") % xrt_core::utils::parse_cu_status(status_val);
+    }
+  }
+  catch( std::exception const& e) {
+    _output << "ERROR: " <<  e.what() << std::endl;
+  }
+  _output << std::endl;
+
+  //check if a valid PS kernel report is generated
+  boost::property_tree::ptree& pt_pscu = _pt.get_child("compute_units.ps_compute_units");
+  if(pt_pscu.empty())
+    return;
+
+  _output << "PS Compute Units" << std::endl;
+  _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
+  try {
+    int index = 0;
+    for(auto& kv : pt_pscu) {
       boost::property_tree::ptree& cu = kv.second;
       std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
       uint32_t status_val = std::stoul(cu_status, nullptr, 16);

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -135,7 +135,7 @@ populate_cus_new(const xrt_core::device *device)
     ptCu.put( "name",           stat.name);
     ptCu.put( "base_address",   boost::str(boost::format("0x%x") % stat.base_addr));
     ptCu.put( "usage",          stat.usages);
-    ptCu.put( "compute_unit_type", enum_to_str(cu_type::PL));
+    ptCu.put( "type", enum_to_str(cu_type::PL));
     ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
     pt.push_back(std::make_pair("", ptCu));
   }
@@ -146,7 +146,7 @@ populate_cus_new(const xrt_core::device *device)
     ptCu.put( "name",           stat.name);
     ptCu.put( "base_address",   "0x0");
     ptCu.put( "usage",          stat.usages);
-    ptCu.put( "compute_unit_type", enum_to_str(cu_type::PS));
+    ptCu.put( "type", enum_to_str(cu_type::PS));
     ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
     pt.push_back(std::make_pair("", ptCu));
   }
@@ -205,7 +205,7 @@ ReportCu::writeReport( const xrt_core::device * _pDevice,
     int index = 0;
     for(auto& kv : pt_cu) {
       boost::property_tree::ptree& cu = kv.second;
-      if(cu.get<std::string>("compute_unit_type").compare("PL") != 0)
+      if(cu.get<std::string>("type").compare("PL") != 0)
         continue;
       std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
       uint32_t status_val = std::stoul(cu_status, nullptr, 16);
@@ -226,7 +226,7 @@ ReportCu::writeReport( const xrt_core::device * _pDevice,
     int index = 0;
     for(auto& kv : pt_cu) {
       boost::property_tree::ptree& cu = kv.second;
-      if(cu.get<std::string>("compute_unit_type").compare("PS") != 0)
+      if(cu.get<std::string>("type").compare("PS") != 0)
         continue;
       std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
       uint32_t status_val = std::stoul(cu_status, nullptr, 16);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1255,7 +1255,7 @@ run_tests_on_devices( xrt_core::device_collection &deviceCollection,
 
 SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreliminary)
     : SubCmd("validate",
-             "Validates the basic shell accelleration functionality")
+             "Validates the basic shell acceleration functionality")
 {
   const std::string longDescription = "Validates the given card by executing the platform's validate executable.";
   setLongDescription(longDescription);


### PR DESCRIPTION
**Work Done:** separated out "ps_compute_units" from "compute_units"

**Terminologies:**
- _Compute units_: All CUs
- _PL compute units_: Programmable Logic CUs
- _PS compute units_: Processing System CUs

**Commands affected:**
- xbutil dump
- xbutil top
- xbutil2 examine -r compute_units (-f json)

**Sample outputs for the above-mentioned commands:**
```
$ xbutil dump -d 1
...
"compute_unit": {
            "0": {
                "name": "decoder:decoder_1",
                "base_address": "25161984",
                "usage": "0",
                "status": "(--)"
            },
            "1": {
                "name": "verify:verify_1",
                "base_address": "20971520",
                "usage": "0",
                "status": "(IDLE)"
            }
        },
        "ps_compute_unit": {
            "0": {
                "name": "kernel_vcu_decoder:scu_0",
                "base_address": "0",
                "usage": "0",
                "status": "(IDLE)"
            },
...

$xbutil top -d 1
...
###############################################################################

Compute Unit Usage:
CU[@0x17ff100] : 0
CU[@0x1400000] : 0
SCU[@N/A] : 0
SCU[@N/A] : 0
SCU[@N/A] : 0
SCU[@N/A] : 0
SCU[@N/A] : 0
...

$ xbutil -new examine -d 17:00 -r compute-units
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
----------------------------------------------
1/1 [0000:17:00.1] : xilinx_u30_gen3x4_base_1
----------------------------------------------
PL Compute Units
Index   Name                          Base_Address    Usage   Status
0       decoder:decoder_1             0x17ff100       0       (--)
1       verify:verify_1               0x1400000       0       (IDLE)

PS Compute Units
Index   Name                          Base_Address    Usage   Status
0       kernel_vcu_decoder:scu_0      0x0             0       (IDLE)
1       kernel_vcu_decoder:scu_1      0x0             0       (IDLE)
2       kernel_vcu_decoder:scu_2      0x0             0       (IDLE)
3       kernel_vcu_decoder:scu_3      0x0             0       (IDLE)
4       kernel_vcu_decoder:scu_4      0x0             0       (IDLE)


$ xbutil -new examine -d 17:00 -r compute-units -f json
...
"compute_units": [
                {
                    "name": "decoder:decoder_1",
                    "base_address": "0x17ff100",
                    "usage": "0",
                    "type": "PL",
                    "status": {
                        "bit_mask": "0x0"
                    }
                },
                {
                    "name": "verify:verify_1",
                    "base_address": "0x1400000",
                    "usage": "0",
                    "type": "PL",
                    "status": {
                        "bit_mask": "0x4",
                        "bits_set": [
                            "IDLE"
                        ]
                    }
                },
                {
                    "name": "kernel_vcu_decoder:scu_0",
                    "base_address": "0x0",
                    "usage": "0",
                    "type": "PS",
                    "status": {
                        "bit_mask": "0x4",
                        "bits_set": [
                            "IDLE"
                        ]
                    }
                },

```

