### PR TITLE
Add interface dependencies to static libraries

### DIFF
--- a/src/CMake/config/xrt.fp.in
+++ b/src/CMake/config/xrt.fp.in
@@ -9,6 +9,7 @@
 #   @PROJECT_NAME@_VERSION            - VERSION of this package in x.y.z format
 #   @PROJECT_NAME@_CMAKE_DIR          - Directory where this cmake module was found
 #   @PROJECT_NAME@_INCLUDE_DIRS       - Directory where @PROJECT_NAME@ headers are located.
+#   @PROJECT_NAME@_LINK_DIRS          - Directory where @PROJECT_NAME@ link libraries are located.
 #   @PROJECT_NAME@_CORE_LIBRARIES     - libraries to link against.
 #   @PROJECT_NAME@_COREUTIL_LIBRARIES - libraries to link against.
 #   @PROJECT_NAME@_OPENCL_LIBRARIES   - libraries to link against.
@@ -17,6 +18,7 @@
 @PACKAGE_INIT@
 
 set(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/xrt/include")
+set(@PROJECT_NAME@_LINK_DIRS "${PACKAGE_PREFIX_DIR}/xrt/lib")
 
 set(@PROJECT_NAME@_VERSION @XRT_VERSION_STRING@)
 

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -40,18 +40,34 @@ add_compile_options("-DXRT_VERSION_MAJOR=\"${XRT_VERSION_MAJOR}\"")
 add_library(xrt_coreutil SHARED ${XRT_CORE_COMMON_LIB_FILES})
 add_library(xrt_coreutil_static STATIC ${XRT_CORE_COMMON_LIB_FILES})
 
-set_target_properties(xrt_coreutil PROPERTIES VERSION ${XRT_VERSION_STRING}
+set_target_properties(xrt_coreutil PROPERTIES
+  VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+# Private dependencies for fully resolved dynamic xrt_coreutil
 target_link_libraries(xrt_coreutil
   PRIVATE
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY}
-  )
+  ${Boost_SYSTEM_LIBRARY})
+
+# Targets linking with xrt_coreutil_static must also link with boost
+# libraries used by coreutil.  These type of link dependencies are
+# known as INTERFACE dependencies.  Here the libraries are specified
+# by their system name so that static of target can pick static link
+# libraries of boost
+target_link_libraries(xrt_coreutil_static
+  INTERFACE
+  boost_filesystem
+  boost_system)
 
 if (NOT WIN32)
+  # Additional link dependencies for xrt_coreutil
   # xrt_uuid.h depends on uuid
   target_link_libraries(xrt_coreutil PRIVATE pthread dl PUBLIC uuid)
+
+  # Targets of xrt_coreutil_static must link with these additional
+  # system libraries
+  target_link_libraries(xrt_coreutil_static INTERFACE uuid dl rt pthread)
 endif()
 
 install(TARGETS xrt_coreutil

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -41,6 +41,7 @@ set_target_properties(xrt_core PROPERTIES
   VERSION ${XRT_VERSION_STRING}
   SOVERSION ${XRT_SOVERSION})
 
+# Private dependencies for fully resolved dynamic xrt_core
 target_link_libraries(xrt_core
   PRIVATE
   xrt_coreutil
@@ -50,6 +51,22 @@ target_link_libraries(xrt_core
   rt
   dl
   uuid
+  )
+
+# Targets linking with xrt_core_static must also link with additional
+# libraries to satisfy xrt_core_static dependencies. These type of
+# link dependencies are known as INTERFACE dependencies.  Here the
+# boost libraries are specified by their system name so that static of
+# target can pick static link libraries of boost
+target_link_libraries(xrt_core_static
+  INTERFACE
+  xrt_coreutil_static
+  boost_filesystem
+  boost_system
+  uuid
+  dl
+  rt
+  pthread
   )
 
 install(TARGETS xrt_core

--- a/tests/xrt/22_verify/CMakeLists.txt
+++ b/tests/xrt/22_verify/CMakeLists.txt
@@ -6,22 +6,24 @@ target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 # Experimental demo of static linking.
 # Should be built into to PUBLIC options along with find_package
 if (DEFINED ENV{XRT_STATIC_BUILD})
-add_executable(${TESTNAME}_hw_static main.cpp)
-target_link_options(${TESTNAME}_hw_static PRIVATE "-static")
-target_link_libraries(${TESTNAME}_hw_static
-  PRIVATE
-  -L${XILINX_XRT}/lib
-  xrt_core_static
-  xrt_coreutil_static
-  boost_system
-  boost_filesystem
-  uuid
-  dl
-  -Wl,--whole-archive -lxrt_core_static -lrt -lpthread -Wl,--no-whole-archive
-  xrt_coreutil_static
-  )
-install(TARGETS ${TESTNAME}_hw_static
-  RUNTIME DESTINATION ${INSTALL_DIR}/${TESTNAME})
+  add_executable(${TESTNAME}_hw_static main.cpp)
+  if (NOT WIN32)
+    target_link_options(${TESTNAME}_hw_static PRIVATE "-static" "-L${XRT_LINK_DIRS}")
+    target_link_libraries(${TESTNAME}_hw_static
+      PRIVATE
+      # force linking of whole archive to enable static globals
+      -Wl,--whole-archive -lxrt_core_static -Wl,--no-whole-archive
+      -Wl,--whole-archive -lrt -lpthread -Wl,--no-whole-archive
+      )
+  endif()
+  target_link_libraries(${TESTNAME}_hw_static
+    PRIVATE
+    ${xrt_core_static_LIBRARY}
+    ${xrt_coreutil_static_LIBRARY}
+    )
+
+  install(TARGETS ${TESTNAME}_hw_static
+    RUNTIME DESTINATION ${INSTALL_DIR}/${TESTNAME})
 endif()
 
 if (NOT WIN32)

--- a/tests/xrt/CMakeLists.txt
+++ b/tests/xrt/CMakeLists.txt
@@ -14,6 +14,9 @@ find_package(XRT)
 set(xrt_core_LIBRARY XRT::xrt_core)
 set(xrt_coreutil_LIBRARY XRT::xrt_coreutil)
 set(xrt_xilinxopencl_LIBRARY XRT::xilinxopencl)
+set(xrt_core_static_LIBRARY XRT::xrt_core_static)
+set(xrt_coreutil_static_LIBRARY XRT::xrt_coreutil_static)
+set(xrt_xilinxopencl_static_LIBRARY XRT::xilinxopencl_static)
 
 if (DEFINED ENV{XCL_EMULATION_MODE})
   set(MODE $ENV{XCL_EMULATION_MODE})
@@ -22,8 +25,7 @@ if (DEFINED ENV{XCL_EMULATION_MODE})
   message("=============== XRT_CORE_LIB=${xrt_core_LIBRARY}")
 endif()
 
-# need to export from package
-include_directories(${XILINX_XRT}/include)
+include_directories(${XRT_INCLUDE_DIRS})
 
 if (NOT WIN32)
 find_library(uuid_LIBRARY


### PR DESCRIPTION
Use CMake target_link_libraries INTERFACE for specifying end target
additional link time dependencies when linking with xrt_core_static
and/or xrt_coreutil_static. When CMake find_package(XRT) is used the
interface depdencies are added when link to the libaries found by
find_package.