### PR TITLE
Update shim.cpp copyright

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -839,7 +839,7 @@ xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared)
     .uuid_size = sizeof (uuid_t) * sizeof (char),
     .cu_index = ipIndex,
     .flags = flags,
-    .handle = 0,
+    .handle = 0, 
     .op = ZOCL_CTX_OP_ALLOC_CTX,
   };
 

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  * Author(s): Umang Parekh
  *          : Sonal Santan
  *          : Ryan Radjabi

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -2,7 +2,7 @@
 #define _XOCL_GEM_SHIM_H_
 
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  * Author(s): Umang Parekh
  *          : Sonal Santan
  *          : Ryan Radjabi


### PR DESCRIPTION
This is a pure test of pipeline during weekend when pipeline is idle.

Because PR https://github.com/Xilinx/XRT/pull/4865 is failing by the following error, where the code is not touched at all by the changes, this PR is to test if the same error can be caught by pipe line too.

10:46:20 /opt/xrt/src/runtime_src/core/edge/user/shim.cpp: In member function 'int ZYNQ::shim::xclOpenContext(const unsigned char*, unsigned int, bool)':
10:46:20 /opt/xrt/src/runtime_src/core/edge/user/shim.cpp:844:3: sorry, unimplemented: non-trivial designated initializers not supported
10:46:20    };
10:46:20    ^
