### PR TITLE
CR-1091075 and CR-1091087

### DIFF
--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -182,12 +182,6 @@ findEnvPath(const std::string & env)
     if (absPath.string().empty()) 
       throw std::runtime_error("Error: Python executable not found in search path.");
   }
-  else {
-    absPath = boost::process::search_path("sh");
-    if (absPath.string().empty()) 
-      throw std::runtime_error("Error: Shell environment not found.");
-  }
-
   return absPath;
 }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -669,7 +669,7 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
     config = xrt_core::device_query<xrt_core::query::p2p_config>(_dev);
   }
   catch (const std::runtime_error&) {
-    msg = "Error:P2P config failed. P2P is not available";
+    msg = "P2P config failed. P2P is not available";
     return static_cast<int>(p2p_config::not_supported);
   }
 
@@ -693,7 +693,7 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
 
   //return the config with a message
   if (bar == -1) {
-    msg = "Error:P2P config failed. P2P is not supported. Can't find P2P BAR.";
+    msg = "P2P config failed. P2P is not supported. Can't find P2P BAR.";
     return static_cast<int>(p2p_config::not_supported);
   }
   else if (rbar != -1 && rbar > bar) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -311,13 +311,13 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     if (exit_code == EOPNOTSUPP) {
       _ptTest.put("status", "skipped");
     }
-    else if (exit_code == EXIT_FAILURE) {
+    else if (exit_code == EXIT_SUCCESS) {
+      _ptTest.put("status", "passed");
+    }
+    else {
       logger(_ptTest, "Error", os_stdout.str());
       logger(_ptTest, "Error", os_stderr.str());
       _ptTest.put("status", "failed");
-    }
-    else {
-      _ptTest.put("status", "passed");
     }
   }
   else {


### PR DESCRIPTION
- **CR-1091075** xbutil validate behavior seems incorrect on xrt 2.10.10
P2P test should be SKIPPED and not show FAILED
```
$ xbutil validate  -r "Peer to peer bar" -d 17:00
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
Starting validation for 1 devices

Validate device[0000:17:00.1]
Platform            : xilinx_u30_gen3x4_base_1
SC Version          : 6.3.5
Platform ID         : 0x0

1/1 Test #1 [0000:17:00.1]  : Peer to peer bar
    Description             : Run P2P test
    Details                 : P2P config failed. P2P is not available
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed

```

- **CR-1091087** xbutil2 validate does not run verify and bandwidth kernels properly
```
$ xbutil validate  -r quick -d 17:00
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
Starting validation for 1 devices

Validate device[0000:17:00.1]
Platform            : xilinx_u30_gen3x4_base_1
SC Version          : 6.3.5
Platform ID         : 0x0

1/4 Test #1 [0000:17:00.1]  : Aux connection
    Description             : Check if auxiliary power is connected
    Details                 : Aux power connector is not available on this board
    Test Status             : [SKIPPED]
-------------------------------------------------------------------------------
2/4 Test #2 [0000:17:00.1]  : PCIE link
    Description             : Check if PCIE link is active
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
3/4 Test #3 [0000:17:00.1]  : SC version
    Description             : Check if SC firmware is up-to-date
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
4/4 Test #4 [0000:17:00.1]  : Verify kernel
    Description             : Run 'Hello World' kernel test
    Xclbin                  : /opt/xilinx/firmware/u30/gen3x4/base/test/verify.xclbin
    Testcase                : /opt/xilinx/xrt/test/validate.exe
    Test Status             : [PASSED]
-------------------------------------------------------------------------------
Validation completed
```