### PR TITLE
CR-1090793 System Crash due to regfile overflow

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -84,6 +84,7 @@ struct kds_command {
 	 * of execbuf when notifying host
 	 */
 	u32			*execbuf;
+	u32			*u_execbuf;
 	void			*gem_obj;
 	/* to notify inkernel exec completion */
 	struct in_kernel_cb	*inkern_cb;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -868,8 +868,6 @@ int kds_fini_ert(struct kds_sched *kds)
 
 void kds_reset(struct kds_sched *kds)
 {
-	int idx;
-
 	kds->bad_state = 0;
 	kds->ert_disable = true;
 	kds->ini_disable = false;

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -64,6 +64,10 @@
     ((struct ert_start_copybo_cmd *)(pkg))
 #define to_cfg_sk_pkg(pkg) \
     ((struct ert_configure_sk_cmd *)(pkg))
+#define to_init_krnl_pkg(pkg) \
+    ((struct ert_init_kernel_cmd *)(pkg))
+#define to_validate_pkg(pkg) \
+    ((struct ert_validate_cmd *)(pkg))
 
 /**
  * struct ert_packet: ERT generic packet format
@@ -352,14 +356,16 @@ struct ert_abort_cmd {
   };
 };
 
-
-
+/**
+ * struct ert_validate_cmd: ERT BIST command format.
+ *
+ */
 struct ert_validate_cmd {
   union {
     struct {
       uint32_t state:4;          /* [3-0]   */
-      uint32_t unused:11;        /* [14-4]  */
-      uint32_t idx:8;            /* [22-15] */
+      uint32_t custom:8;         /* [11-4]  */
+      uint32_t count:11;         /* [22-12] */
       uint32_t opcode:5;         /* [27-23] */
       uint32_t type:4;           /* [31-27] */
     };
@@ -717,6 +723,70 @@ static inline uint64_t
 ert_copybo_size(struct ert_start_copybo_cmd *pkt)
 {
   return pkt->size;
+}
+
+static inline bool
+ert_valid_opcode(struct ert_packet *pkt)
+{
+  struct ert_start_kernel_cmd *skcmd;
+  struct ert_init_kernel_cmd *ikcmd;
+  struct ert_start_copybo_cmd *sccmd;
+  struct ert_configure_cmd *ccmd;
+  struct ert_configure_sk_cmd *cscmd;
+  struct ert_validate_cmd *vcmd;
+  bool valid;
+
+  switch (pkt->opcode) {
+  case ERT_START_CU:
+  case ERT_EXEC_WRITE:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 cu mask + 4 control registers */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 4);
+    break;
+  case ERT_START_FA:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 cu mask */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1);
+    break;
+  case ERT_SK_START:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 cu mask + 1 control word */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 1);
+    break;
+  case ERT_CONFIGURE:
+    ccmd = to_cfg_pkg(pkt);
+    /* 5 mandatory fields in struct */
+    valid = (ccmd->count >= 5 + ccmd->num_cus);
+    break;
+  case ERT_START_COPYBO:
+    sccmd = to_copybo_pkg(pkt);
+    valid = (sccmd->count == 16);
+    break;
+  case ERT_INIT_CU:
+    ikcmd = to_init_krnl_pkg(pkt);
+    /* 9 mandatory words in struct + 4 control registers */
+    valid = (ikcmd->count >= ikcmd->extra_cu_masks + 9 + 4);
+    break;
+  case ERT_SK_CONFIG:
+    cscmd = to_cfg_sk_pkg(pkt);
+    valid = (cscmd->count == sizeof(struct config_sk_image) * cscmd->num_image / 4 + 1);
+    break;
+  case ERT_CLK_CALIB:
+  case ERT_MB_VALIDATE:
+    vcmd = to_validate_pkg(pkt);
+    valid = (vcmd->count == 5);
+    break;
+  case ERT_CU_STAT: /* TODO: Rules to validate? */
+  case ERT_EXIT:
+  case ERT_ABORT:
+    valid = true;
+    break;
+  case ERT_SK_UNCONFIG: /* NOTE: obsolete */
+  default:
+    valid = false;
+  }
+
+  return valid;
 }
 
 #ifdef __GNUC__

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -505,7 +505,7 @@ ert_get_return(struct xocl_ert_user *ert_user, struct ert_user_command *ecmd)
 		return;
 
 	slot_addr = ecmd->slot_idx * slot_size;
-	xocl_memcpy_fromio(ecmd->xcmd->execbuf, ert_user->cq_base + slot_addr, size);
+	xocl_memcpy_fromio(ecmd->xcmd->u_execbuf, ert_user->cq_base + slot_addr, size);
 }
 
 static inline bool ert_special_cmd(struct ert_user_command *ecmd)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -466,7 +466,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	}
 
 	/* An exec buf bo is at least 1 PAGE.
-	 * This is enought to carry metadata for any execbuf command struct.
+	 * This is enough to carry metadata for any execbuf command struct.
 	 * It is safe to make the assumption and validate will be simpler.
 	 */
 	if (xobj->base.size < PAGE_SIZE) {
@@ -474,14 +474,14 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		ret = -EINVAL;
 		goto out;
 	}
- 
+
 	ecmd = kzalloc(xobj->base.size, GFP_KERNEL);
 	if (!ecmd) {
 		ret = -ENOMEM;
 		goto out;
 	}
 
-	/* If xobj contain a validate command, ecmd would be a copy */
+	/* If xobj contain a valid command, ecmd would be a copy */
 	if (!copy_and_validate_execbuf(xdev, xobj, ecmd)) {
 		userpf_err(xdev, "Invalid command\n");
 		ret = -EINVAL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -310,7 +310,7 @@ static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,
  */
 static inline void read_ert_stat(struct kds_command *xcmd)
 {
-	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+	struct ert_packet *ecmd = (struct ert_packet *)xcmd->u_execbuf;
 	struct kds_sched *kds = (struct kds_sched *)xcmd->priv;
 	int num_cu  = kds->cu_mgmt.num_cus;
 	int num_scu = kds->scu_mgmt.num_cus;
@@ -360,7 +360,7 @@ static inline void read_ert_stat(struct kds_command *xcmd)
 static void notify_execbuf(struct kds_command *xcmd, int status)
 {
 	struct kds_client *client = xcmd->client;
-	struct ert_packet *ecmd = (struct ert_packet *)xcmd->execbuf;
+	struct ert_packet *ecmd = (struct ert_packet *)xcmd->u_execbuf;
 
 	if (xcmd->opcode == OP_START_SK) {
 		/* For PS kernel get cmd state and return_code */
@@ -386,6 +386,7 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	}
 
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
+	kfree(xcmd->execbuf);
 
 	if (xcmd->cu_idx >= 0)
 		client_stat_inc(client, c_cnt[xcmd->cu_idx]);
@@ -400,28 +401,24 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	}
 }
 
-static bool is_valid_execbuf(struct xocl_dev *xdev, struct drm_xocl_bo *xobj)
+static bool is_valid_execbuf(struct xocl_dev *xdev, struct drm_xocl_bo *xobj,
+			     struct ert_packet *ecmd)
 {
-	struct ert_packet *ecmd;
+	struct ert_packet *orig;
 	int pkg_size;
 	bool op_valid;
 
-	if (!xocl_bo_execbuf(xobj)) {
-		userpf_err(xdev, "Command buffer is not exec buf\n");
-		return false;
-	}
+	orig = (struct ert_packet *)xobj->vmapping;
+	orig->state = ERT_CMD_STATE_NEW;
+	ecmd->header = orig->header;
 
-	if (xobj->base.size < sizeof(struct ert_packet *)) {
-		userpf_err(xdev, "exec buf is too small\n");
-		return false;
-	}
-
-	ecmd = (struct ert_packet *)xobj->vmapping;
 	pkg_size = sizeof(ecmd->header) + ecmd->count * sizeof(u32);
 	if (xobj->base.size < pkg_size) {
 		userpf_err(xdev, "payload size bigger than exec buf\n");
 		return false;
 	}
+
+	memcpy(ecmd->data, orig->data, ecmd->count * sizeof(u32));
 
 	/* opcode specific validation */
 	op_valid = ert_valid_opcode(ecmd);
@@ -461,15 +458,35 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	}
 
 	xobj = to_xocl_bo(obj);
-	if (!is_valid_execbuf(xdev, xobj)) {
+
+	if (!xocl_bo_execbuf(xobj)) {
+		userpf_err(xdev, "Command buffer is not exec buf\n");
+		return false;
+	}
+
+	/* An exec buf bo is at least 1 PAGE.
+	 * This is enought to carry metadata for any execbuf command struct.
+	 * It is safe to make the assumption and validate will be simpler.
+	 */
+	if (xobj->base.size < PAGE_SIZE) {
+		userpf_err(xdev, "exec buf is too small\n");
+		ret = -EINVAL;
+		goto out;
+	}
+ 
+	ecmd = kzalloc(xobj->base.size, GFP_KERNEL);
+	if (!ecmd) {
+		ret = -ENOMEM;
+		goto out;
+	}
+
+	/* If xobj contain a validate command, ecmd would be a copy */
+	if (!is_valid_execbuf(xdev, xobj, ecmd)) {
 		userpf_err(xdev, "Invalid command\n");
 		ret = -EINVAL;
 		goto out;
 	}
 
-	ecmd = (struct ert_packet *)xobj->vmapping;
-
-	ecmd->state = ERT_CMD_STATE_NEW;
 	/* only the user command knows the real size of the payload.
 	 * count is more than enough!
 	 */
@@ -481,7 +498,10 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	}
 	xcmd->cb.free = kds_free_command;
 	xcmd->cb.notify_host = notify_execbuf;
+	/* xcmd->execbuf points to kernel space copy */
 	xcmd->execbuf = (u32 *)ecmd;
+	/* xcmd->u_execbuf points to user's original for write back/notice */
+	xcmd->u_execbuf = xobj->vmapping;
 	xcmd->gem_obj = obj;
 
 	print_ecmd_info(ecmd);
@@ -1015,7 +1035,7 @@ static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 	int ret = 0;
 
 	/* TODO: Use hard code size is not ideal. Let's refine this later */
-	ecmd = vmalloc(0x1000);
+	ecmd = vzalloc(0x1000);
 	if (!ecmd)
 		return -ENOMEM;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -401,8 +401,9 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	}
 }
 
-static bool is_valid_execbuf(struct xocl_dev *xdev, struct drm_xocl_bo *xobj,
-			     struct ert_packet *ecmd)
+static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
+				     struct drm_xocl_bo *xobj,
+				     struct ert_packet *ecmd)
 {
 	struct ert_packet *orig;
 	int pkg_size;
@@ -481,7 +482,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	}
 
 	/* If xobj contain a validate command, ecmd would be a copy */
-	if (!is_valid_execbuf(xdev, xobj, ecmd)) {
+	if (!copy_and_validate_execbuf(xdev, xobj, ecmd)) {
 		userpf_err(xdev, "Invalid command\n");
 		ret = -EINVAL;
 		goto out;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -657,6 +657,7 @@ bist_alloc_execbuf_and_wait(xclDeviceHandle handle, enum ert_cmd_opcode opcode, 
   std::memset(ecmd, 0, bo_size);
   ecmd->opcode = opcode;
   ecmd->type = ERT_CTRL;
+  ecmd->count = 5;
 
   if (xclExecBuf(handle,boh)) {
       logger(_ptTest, "Error", "Couldn't map BO");


### PR DESCRIPTION
1. Copy user execbuf to a kernel space buffer
2. Add validate execbuf function in xocl_kds.c
2. Add opcode validate helper function in ert.h

Hi @stsoe, please help review changes in ert.h