### PR TITLE
CR-1091096 xbmgmt2 platform programming command is not working

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -49,9 +49,9 @@ void  main_(int argc, char** argv,
   // Build Options
   po::options_description globalOptions("Global Options");
   globalOptions.add_options()
-    ("help,h",    boost::program_options::bool_switch(&bHelp), "Help to use this application")
-    ("verbose,v", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
-    ("batch,b",   boost::program_options::bool_switch(&bBatchMode), "Enable batch mode (disables escape characters)")
+    ("help",    boost::program_options::bool_switch(&bHelp), "Help to use this application")
+    ("verbose", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
+    ("batch",   boost::program_options::bool_switch(&bBatchMode), "Enable batch mode (disables escape characters)")
   ;
 
   // Hidden Options


### PR DESCRIPTION
Short options removed for global commands for xbutil and xbmgmt:
```
OPTIONS:
  --help             - Help to use this application
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
```
`$ sudo xbmgmt program -b -d all` works now

