### PR TITLE
Ensure KDMA copy uses consolidated execwait

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -277,6 +277,9 @@ public:
     if (!dst_hbuf)
       throw xrt_core::system_error(EINVAL, "No host side buffer in destination buffer");
 
+    // sync to src to ensure data integrity, logically const
+    const_cast<bo_impl*>(src)->sync(XCL_BO_SYNC_BO_FROM_DEVICE, sz, src_offset);
+
     // copy host side buffer
     std::memcpy(dst_hbuf + dst_offset, src_hbuf + src_offset, sz);
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2111,6 +2111,9 @@ copy_bo_with_kdma(const std::shared_ptr<xrt_core::device>& core_device,
                   xclBufferHandle src_bo, size_t src_offset)
 {
 #ifndef _WIN32
+  if (is_sw_emulation())
+    throw std::runtime_error("KDMA not support in software emulation");
+
   // Construct a kernel command to copy bo.  Kernel commands
   // must be shared ptrs
   auto dev = get_device(core_device);
@@ -2167,7 +2170,7 @@ get_control_protocol(const xrt::run& run)
   return run.get_handle()->get_kernel()->get_ip_control_protocol();
 }
 
-  std::vector<const xclbin::kernel_argument*>
+std::vector<const xclbin::kernel_argument*>
 get_args(const xrt::kernel& kernel)
 {
   const auto& args = kernel.get_handle()->get_args();

--- a/src/runtime_src/xocl/api/enqueue.cpp
+++ b/src/runtime_src/xocl/api/enqueue.cpp
@@ -137,29 +137,14 @@ copy_buffer(xocl::event* event,xocl::device* device
             ,cl_mem src_buffer,cl_mem dst_buffer,size_t src_offset,size_t dst_offset,size_t size)
 {
   try {
-    auto cmd = std::make_shared<enqueue_command>(device,event,ERT_START_CU);
-    device->copy_buffer(xocl::xocl(src_buffer),xocl::xocl(dst_buffer),src_offset,dst_offset,size,cmd);
-  }
-  catch (const std::exception& ex) {
-    handle_device_exception(event,ex);
-  }
-}
-
-static void
-copy_p2p_buffer(xocl::event* event,xocl::device* device
-            ,cl_mem src_buffer,cl_mem dst_buffer,size_t src_offset,size_t dst_offset,size_t size)
-{
-  try {
     event->set_status(CL_RUNNING);
-    device->copy_p2p_buffer(xocl::xocl(src_buffer),xocl::xocl(dst_buffer),src_offset,dst_offset,size);
+    device->copy_buffer(xocl::xocl(src_buffer),xocl::xocl(dst_buffer),src_offset,dst_offset,size);
     event->set_status(CL_COMPLETE);
   }
   catch (const std::exception& ex) {
     handle_device_exception(event,ex);
   }
 }
-
-
 
 static void
 map_buffer(xocl::event* event,xocl::device* device
@@ -321,19 +306,6 @@ action_copy_buffer(cl_mem src_buffer,cl_mem dst_buffer,size_t src_offset,size_t 
     copy_buffer(ev,device,src_buffer,dst_buffer,src_offset,dst_offset,size);
   };
 }
-
-xocl::event::action_enqueue_type
-action_copy_p2p_buffer(cl_mem src_buffer,cl_mem dst_buffer,size_t src_offset,size_t dst_offset,size_t size)
-{
-  throw_if_error();
-  return [=](xocl::event* ev) {
-    auto command_queue = ev->get_command_queue();
-    auto device = command_queue->get_device();
-    auto xdevice = device->get_xdevice();
-    xdevice->schedule(copy_p2p_buffer,async_type::misc,ev,device,src_buffer,dst_buffer, src_offset, dst_offset, size);
-  };
-}
-
 
 xocl::event::action_enqueue_type
 action_ndrange_migrate(cl_event event,cl_kernel kernel)

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -393,15 +393,9 @@ public:
    *  The offset in buffer read from
    * @param size
    *  Number of bytes to copy
-   * @param cmd
-   *  Copy command buffer to be scheduled for execution
    */
   void
-  copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t dst_offset, size_t size, const cmd_type& cmd);
-
-  void
-  copy_p2p_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t dst_offset, size_t size);
-
+  copy_buffer(memory* src_buffer, memory* dst_buffer, size_t src_offset, size_t dst_offset, size_t size);
 
   /**
    * Fill size bytes of buffer at offset with specified pattern


### PR DESCRIPTION
Copying in OCL through KDMA should make sure execbuf and execwait use
the xrt::kernel implementation of execwait.  Without this change
execwait could end up being called on two separate threads from same
device and one thread might be missing CU completions.