### PR TITLE
CR-1091201: Fixing user event table in OpenCL summary

### DIFF
--- a/src/runtime_src/xdp/profile/database/statistics_database.cpp
+++ b/src/runtime_src/xdp/profile/database/statistics_database.cpp
@@ -167,11 +167,15 @@ namespace xdp {
 
   void VPStatisticsDatabase::addEventCount(const char* label)
   {
-    if (eventCounts.find(label) == eventCounts.end()) {
-      eventCounts[label] = 0 ;
+    std::string converted = "" ;
+    if (label != nullptr) {
+      converted = label ;
+    }
+    if (eventCounts.find(converted) == eventCounts.end()) {
+      eventCounts[converted] = 0 ;
     }
 
-    eventCounts[label] += 1 ;
+    eventCounts[converted] += 1 ;
   }
 
   void VPStatisticsDatabase::addRangeCount(std::pair<const char*, const char*> desc)

--- a/src/runtime_src/xdp/profile/database/statistics_database.h
+++ b/src/runtime_src/xdp/profile/database/statistics_database.h
@@ -185,7 +185,7 @@ namespace xdp {
              std::vector<std::pair<double, double>>> callCount ;
 
     // **** User Level Event Statistics ****
-    std::map<const char*, uint64_t> eventCounts ;
+    std::map<std::string, uint64_t> eventCounts ;
     std::map<std::pair<const char*, const char*>, uint64_t> rangeCounts ;
     std::map<std::pair<const char*, const char*>, uint64_t> minRangeDurations ;
     std::map<std::pair<const char*, const char*>, uint64_t> maxRangeDurations ;
@@ -318,7 +318,7 @@ namespace xdp {
     XDP_EXPORT void addEventCount(const char* label);
     XDP_EXPORT void addRangeCount(std::pair<const char*, const char*> desc);
     XDP_EXPORT void recordRangeDuration(std::pair<const char*, const char*> desc, uint64_t duration) ;
-    inline std::map<const char*, uint64_t>& getEventCounts()
+    inline std::map<std::string, uint64_t>& getEventCounts()
       { return eventCounts; }
     inline std::map<std::pair<const char*, const char*>, uint64_t>&
     getRangeCounts()

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -1516,10 +1516,9 @@ namespace xdp {
 	 << "Count" << ","
 	 << std::endl ;
 
-    std::map<const char*, uint64_t>& counts = (db->getStats()).getEventCounts();
+    std::map<std::string, uint64_t>& counts = (db->getStats()).getEventCounts();
     for (auto iter : counts) {
-      const char* label = (iter.first == nullptr) ? " " : iter.first ;
-      fout << label       << ","
+      fout << iter.first  << ","
 	   << iter.second << ","
 	   << std::endl ;
     }


### PR DESCRIPTION
Changed the statistics database to store user event information based off of strings instead of const character pointers.  This ensures that the XDP side will always have a copy of the string to print out, even if the user originally passed a normal character pointer that was cleaned up before the summary file is generated.