### PR TITLE
CR-1091235 p2p on u200 & u280 1RP errors out due to IP segFault

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -470,10 +470,13 @@ public:
   static std::shared_ptr<ip_context>
   open_virtual_cu(xrt_core::device* device, const xrt::uuid& xclbin_id)
   {
-    static std::weak_ptr<ip_context> vctx;
-    auto ipctx = vctx.lock();
+    static std::mutex mutex;
+    static std::map<xrt_core::device*, std::weak_ptr<ip_context>> dev2vip;
+    std::lock_guard<std::mutex> lk(mutex);
+    auto& vip = dev2vip[device];
+    auto ipctx = vip.lock();
     if (!ipctx)
-      vctx = ipctx = std::shared_ptr<ip_context>(new ip_context(device, xclbin_id));
+      vip = ipctx = std::shared_ptr<ip_context>(new ip_context(device, xclbin_id));
     return ipctx;
   }
 


### PR DESCRIPTION
Fix multi-device bug in how virtual CU context is managed.  The
virtual CU has to be opened on all devices used and managed separately.

(cherry picked from commit c4c7a28e32374822966c9dc384ec523127d29f11)