### PR TITLE
CR-1090910 Address Overflow for SCU buffers does not report crash on xbutil query

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -57,6 +57,8 @@
 #define CU_AP_READY	(0x1 << 3)
 #define CU_AP_CONTINUE	(0x1 << 4)
 #define CU_AP_RESET	(0x1 << 5)
+/* Special macro(s) which not defined by HLS CU */
+#define CU_AP_CRASHED	(0xFFFFFFFF)
 
 #define CU_INTR_DONE  0x1
 #define CU_INTR_READY 0x2

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -1072,7 +1072,7 @@ print_and_out:
  * [1  ]      : number of cq slots
  * [1  ]      : number of cus
  * [#numcus]  : cu execution stats (number of executions)
- * [#numcus]  : cu status (1: running, 0: idle)
+ * [#numcus]  : cu status (1: running, 0: idle, -1: crashed)
  * [#slots]   : command queue slot status
  */
 static void


### PR DESCRIPTION
Add crashed statue (used for PS kernel) in new kds.