### PR TITLE
VITIS-1309 and VITIS-1308 streamline XRT graph API integration

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -68,7 +68,6 @@ get_driver_config(const pt::ptree& aie_meta)
 adf::graph_config
 get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
 {
-    std::cout << "here3" << std::endl;
     adf::graph_config graph_config;
 
   for (auto& graph : aie_meta.get_child("aie_metadata.graphs")) {
@@ -77,7 +76,7 @@ get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
 
     graph_config.id = graph.second.get<int>("id");
     graph_config.name = graph.second.get<std::string>("name");
-    
+
     int count = 0;
     for (auto& node : graph.second.get_child("core_columns")) {
       graph_config.coreColumns.push_back(std::stoul(node.second.data()));
@@ -85,7 +84,7 @@ get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
     }
 
     int num_tiles = count;
-    
+
     count = 0;
     for (auto& node : graph.second.get_child("core_rows"))
     {
@@ -127,7 +126,7 @@ get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
     throw_if_error(count < num_tiles,"multirate_triggers < num_tiles");
 
   }
-  std::cout << "here4" << std::endl;
+
   return graph_config;
 }
 
@@ -153,7 +152,7 @@ get_rtp(const pt::ptree& aie_meta, int graph_id)
   for (auto& rtp_node : aie_meta.get_child("aie_metadata.RTPs")) {
     if (rtp_node.second.get<int>("graph_id") != graph_id)
       continue;
-    
+
     adf::rtp_config rtp;
     rtp.portId = rtp_node.second.get<int>("port_id");
     rtp.aliasId = rtp_node.second.get<int>("alias_id");
@@ -219,7 +218,7 @@ std::unordered_map<std::string, adf::gmio_config>
 get_gmios(const pt::ptree& aie_meta)
 {
   std::unordered_map<std::string, adf::gmio_config> gmios;
-  
+
   for (auto& gmio_node : aie_meta.get_child("aie_metadata.GMIOs")) {
     adf::gmio_config gmio;
 

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -50,25 +50,25 @@ read_aie_metadata(const char* data, size_t size, pt::ptree& aie_project)
 adf::driver_config
 get_driver_config(const pt::ptree& aie_meta)
 {
-    adf::driver_config driver_config;
-    driver_config.hw_gen = aie_meta.get<uint8_t>("aie_metadata.driver_config.hw_gen");
-    driver_config.base_address = aie_meta.get<uint64_t>("aie_metadata.driver_config.base_address");
-    driver_config.column_shift = aie_meta.get<uint8_t>("aie_metadata.driver_config.column_shift");
-    driver_config.row_shift = aie_meta.get<uint8_t>("aie_metadata.driver_config.row_shift");
-    driver_config.num_columns = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_columns");
-    driver_config.num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_rows");
-    driver_config.shim_row = aie_meta.get<uint8_t>("aie_metadata.driver_config.shim_row");
-    driver_config.reserved_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
-    driver_config.reserved_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
-    driver_config.aie_tile_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_row_start");
-    driver_config.aie_tile_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_num_rows");
-    return driver_config;
+  adf::driver_config driver_config;
+  driver_config.hw_gen = aie_meta.get<uint8_t>("aie_metadata.driver_config.hw_gen");
+  driver_config.base_address = aie_meta.get<uint64_t>("aie_metadata.driver_config.base_address");
+  driver_config.column_shift = aie_meta.get<uint8_t>("aie_metadata.driver_config.column_shift");
+  driver_config.row_shift = aie_meta.get<uint8_t>("aie_metadata.driver_config.row_shift");
+  driver_config.num_columns = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_columns");
+  driver_config.num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_rows");
+  driver_config.shim_row = aie_meta.get<uint8_t>("aie_metadata.driver_config.shim_row");
+  driver_config.reserved_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
+  driver_config.reserved_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
+  driver_config.aie_tile_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_row_start");
+  driver_config.aie_tile_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_num_rows");
+  return driver_config;
 }
 
 adf::graph_config
 get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
 {
-    adf::graph_config graph_config;
+  adf::graph_config graph_config;
 
   for (auto& graph : aie_meta.get_child("aie_metadata.graphs")) {
     if (graph.second.get<std::string>("name") != graph_name)
@@ -86,40 +86,35 @@ get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
     int num_tiles = count;
 
     count = 0;
-    for (auto& node : graph.second.get_child("core_rows"))
-    {
+    for (auto& node : graph.second.get_child("core_rows")) {
       graph_config.coreRows.push_back(std::stoul(node.second.data()));
       count++;
     }
     throw_if_error(count < num_tiles,"core_rows < num_tiles");
 
     count = 0;
-    for (auto& node : graph.second.get_child("iteration_memory_columns"))
-    {
+    for (auto& node : graph.second.get_child("iteration_memory_columns")) {
       graph_config.iterMemColumns.push_back(std::stoul(node.second.data()));
       count++;
     }
     throw_if_error(count < num_tiles,"iteration_memory_columns < num_tiles");
 
     count = 0;
-    for (auto& node : graph.second.get_child("iteration_memory_rows"))
-    {
+    for (auto& node : graph.second.get_child("iteration_memory_rows")) {
       graph_config.iterMemRows.push_back(std::stoul(node.second.data()));
       count++;
     }
     throw_if_error(count < num_tiles,"iteration_memory_rows < num_tiles");
 
     count = 0;
-    for (auto& node : graph.second.get_child("iteration_memory_addresses"))
-    {
+    for (auto& node : graph.second.get_child("iteration_memory_addresses")) {
       graph_config.iterMemAddrs.push_back(std::stoul(node.second.data()));
       count++;
     }
     throw_if_error(count < num_tiles,"iteration_memory_addresses < num_tiles");
 
     count = 0;
-    for (auto& node : graph.second.get_child("multirate_triggers"))
-    {
+    for (auto& node : graph.second.get_child("multirate_triggers")) {
       graph_config.triggered.push_back(node.second.data() == "true");
       count++;
     }

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -28,8 +28,6 @@
 namespace {
 
 namespace pt = boost::property_tree;
-using tile_type = xrt_core::edge::aie::tile_type;
-using rtp_type = xrt_core::edge::aie::rtp_type;
 using gmio_type = xrt_core::edge::aie::gmio_type;
 using plio_type = xrt_core::edge::aie::plio_type;
 using counter_type = xrt_core::edge::aie::counter_type;
@@ -49,51 +47,88 @@ read_aie_metadata(const char* data, size_t size, pt::ptree& aie_project)
   pt::read_json(aie_stream,aie_project);
 }
 
-std::vector<tile_type>
-get_tiles(const pt::ptree& aie_meta, const std::string& graph_name)
+adf::driver_config
+get_driver_config(const pt::ptree& aie_meta)
 {
-  std::vector<tile_type> tiles;
+    adf::driver_config driver_config;
+    driver_config.hw_gen = aie_meta.get<uint8_t>("aie_metadata.driver_config.hw_gen");
+    driver_config.base_address = aie_meta.get<uint64_t>("aie_metadata.driver_config.base_address");
+    driver_config.column_shift = aie_meta.get<uint8_t>("aie_metadata.driver_config.column_shift");
+    driver_config.row_shift = aie_meta.get<uint8_t>("aie_metadata.driver_config.row_shift");
+    driver_config.num_columns = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_columns");
+    driver_config.num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.num_rows");
+    driver_config.shim_row = aie_meta.get<uint8_t>("aie_metadata.driver_config.shim_row");
+    driver_config.reserved_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_row_start");
+    driver_config.reserved_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.reserved_num_rows");
+    driver_config.aie_tile_row_start = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_row_start");
+    driver_config.aie_tile_num_rows = aie_meta.get<uint8_t>("aie_metadata.driver_config.aie_tile_num_rows");
+    return driver_config;
+}
+
+adf::graph_config
+get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
+{
+    std::cout << "here3" << std::endl;
+    adf::graph_config graph_config;
 
   for (auto& graph : aie_meta.get_child("aie_metadata.graphs")) {
     if (graph.second.get<std::string>("name") != graph_name)
       continue;
 
+    graph_config.id = graph.second.get<int>("id");
+    graph_config.name = graph.second.get<std::string>("name");
+    
     int count = 0;
     for (auto& node : graph.second.get_child("core_columns")) {
-      tiles.push_back(tile_type());
-      auto& t = tiles.at(count++);
-      t.col = std::stoul(node.second.data());
+      graph_config.coreColumns.push_back(std::stoul(node.second.data()));
+      count++;
     }
 
     int num_tiles = count;
+    
     count = 0;
     for (auto& node : graph.second.get_child("core_rows"))
-      tiles.at(count++).row = std::stoul(node.second.data());
+    {
+      graph_config.coreRows.push_back(std::stoul(node.second.data()));
+      count++;
+    }
     throw_if_error(count < num_tiles,"core_rows < num_tiles");
 
     count = 0;
     for (auto& node : graph.second.get_child("iteration_memory_columns"))
-      tiles.at(count++).itr_mem_col = std::stoul(node.second.data());
+    {
+      graph_config.iterMemColumns.push_back(std::stoul(node.second.data()));
+      count++;
+    }
     throw_if_error(count < num_tiles,"iteration_memory_columns < num_tiles");
 
     count = 0;
     for (auto& node : graph.second.get_child("iteration_memory_rows"))
-      tiles.at(count++).itr_mem_row = std::stoul(node.second.data());
+    {
+      graph_config.iterMemRows.push_back(std::stoul(node.second.data()));
+      count++;
+    }
     throw_if_error(count < num_tiles,"iteration_memory_rows < num_tiles");
 
     count = 0;
     for (auto& node : graph.second.get_child("iteration_memory_addresses"))
-      tiles.at(count++).itr_mem_addr = std::stoul(node.second.data());
+    {
+      graph_config.iterMemAddrs.push_back(std::stoul(node.second.data()));
+      count++;
+    }
     throw_if_error(count < num_tiles,"iteration_memory_addresses < num_tiles");
 
     count = 0;
     for (auto& node : graph.second.get_child("multirate_triggers"))
-      tiles.at(count++).is_trigger = (node.second.data() == "true");
+    {
+      graph_config.triggered.push_back(node.second.data() == "true");
+      count++;
+    }
     throw_if_error(count < num_tiles,"multirate_triggers < num_tiles");
 
   }
-
-  return tiles;
+  std::cout << "here4" << std::endl;
+  return graph_config;
 }
 
 int
@@ -110,44 +145,51 @@ get_graph_id(const pt::ptree& aie_meta, const std::string& graph_name)
   return -1;
 }
 
-std::vector<rtp_type>
-get_rtp(const pt::ptree& aie_meta)
+std::unordered_map<std::string, adf::rtp_config>
+get_rtp(const pt::ptree& aie_meta, int graph_id)
 {
-  std::vector<rtp_type> rtps;
+  std::unordered_map<std::string, adf::rtp_config> rtps;
 
   for (auto& rtp_node : aie_meta.get_child("aie_metadata.RTPs")) {
-    rtp_type rtp;
+    if (rtp_node.second.get<int>("graph_id") != graph_id)
+      continue;
+    
+    adf::rtp_config rtp;
+    rtp.portId = rtp_node.second.get<int>("port_id");
+    rtp.aliasId = rtp_node.second.get<int>("alias_id");
+    rtp.portName = rtp_node.second.get<std::string>("port_name");
+    rtp.aliasName = rtp_node.second.get<std::string>("alias_name");
+    rtp.graphId = rtp_node.second.get<int>("graph_id");
+    rtp.numBytes = rtp_node.second.get<size_t>("number_of_bytes");
+    rtp.selectorRow = rtp_node.second.get<short>("selector_row");
+    rtp.selectorColumn = rtp_node.second.get<short>("selector_column");
+    rtp.selectorLockId = rtp_node.second.get<unsigned short>("selector_lock_id");
+    rtp.selectorAddr = rtp_node.second.get<size_t>("selector_address");
 
-    rtp.name = rtp_node.second.get<std::string>("port_name");
-    rtp.selector_row = rtp_node.second.get<uint16_t>("selector_row");
-    rtp.selector_col = rtp_node.second.get<uint16_t>("selector_column");
-    rtp.selector_lock_id = rtp_node.second.get<uint16_t>("selector_lock_id");
-    rtp.selector_addr = rtp_node.second.get<uint64_t>("selector_address");
+    rtp.pingRow = rtp_node.second.get<short>("ping_buffer_row");
+    rtp.pingColumn = rtp_node.second.get<short>("ping_buffer_column");
+    rtp.pingLockId = rtp_node.second.get<unsigned short>("ping_buffer_lock_id");
+    rtp.pingAddr = rtp_node.second.get<size_t>("ping_buffer_address");
 
-    rtp.ping_row = rtp_node.second.get<uint16_t>("ping_buffer_row");
-    rtp.ping_col = rtp_node.second.get<uint16_t>("ping_buffer_column");
-    rtp.ping_lock_id = rtp_node.second.get<uint16_t>("ping_buffer_lock_id");
-    rtp.ping_addr = rtp_node.second.get<uint64_t>("ping_buffer_address");
+    rtp.pongRow = rtp_node.second.get<short>("pong_buffer_row");
+    rtp.pongColumn = rtp_node.second.get<short>("pong_buffer_column");
+    rtp.pongLockId = rtp_node.second.get<unsigned short>("pong_buffer_lock_id");
+    rtp.pongAddr = rtp_node.second.get<size_t>("pong_buffer_address");
 
-    rtp.pong_row = rtp_node.second.get<uint16_t>("pong_buffer_row");
-    rtp.pong_col = rtp_node.second.get<uint16_t>("pong_buffer_column");
-    rtp.pong_lock_id = rtp_node.second.get<uint16_t>("pong_buffer_lock_id");
-    rtp.pong_addr = rtp_node.second.get<uint64_t>("pong_buffer_address");
+    rtp.isPL = rtp_node.second.get<bool>("is_PL_RTP");
+    rtp.isInput = rtp_node.second.get<bool>("is_input");
+    rtp.isAsync = rtp_node.second.get<bool>("is_asynchronous");
+    rtp.isConnect = rtp_node.second.get<bool>("is_connected");
+    rtp.hasLock = rtp_node.second.get<bool>("requires_lock");
 
-    rtp.is_plrtp = rtp_node.second.get<bool>("is_PL_RTP");
-    rtp.is_input = rtp_node.second.get<bool>("is_input");
-    rtp.is_async = rtp_node.second.get<bool>("is_asynchronous");
-    rtp.is_connected = rtp_node.second.get<bool>("is_connected");
-    rtp.require_lock = rtp_node.second.get<bool>("requires_lock");
-
-    rtps.emplace_back(std::move(rtp));
+    rtps[rtp.portName] = rtp;
   }
 
   return rtps;
 }
 
 std::vector<gmio_type>
-get_gmio(const pt::ptree& aie_meta)
+get_old_gmio(const pt::ptree& aie_meta)
 {
   std::vector<gmio_type> gmios;
 
@@ -168,6 +210,34 @@ get_gmio(const pt::ptree& aie_meta)
     gmio.burst_len = gmio_node.second.get<uint16_t>("burst_length_in_16byte");
 
     gmios.emplace_back(std::move(gmio));
+  }
+
+  return gmios;
+}
+
+std::unordered_map<std::string, adf::gmio_config>
+get_gmios(const pt::ptree& aie_meta)
+{
+  std::unordered_map<std::string, adf::gmio_config> gmios;
+  
+  for (auto& gmio_node : aie_meta.get_child("aie_metadata.GMIOs")) {
+    adf::gmio_config gmio;
+
+    // Only get AIE GMIO type, 0: GM->AIE; 1: AIE->GM
+    auto type = (adf::gmio_config::gmio_type)gmio_node.second.get<uint16_t>("type");
+    if (type != adf::gmio_config::gm2aie && type != adf::gmio_config::aie2gm)
+      continue;
+
+    gmio.id = gmio_node.second.get<int>("id");
+    gmio.name = gmio_node.second.get<std::string>("name");
+    gmio.logicalName = gmio_node.second.get<std::string>("logical_name");
+    gmio.type = type;
+    gmio.shimColumn = gmio_node.second.get<short>("shim_column");
+    gmio.channelNum = gmio_node.second.get<short>("channel_number");
+    gmio.streamId = gmio_node.second.get<short>("stream_id");
+    gmio.burstLength = gmio_node.second.get<short>("burst_length_in_16byte");
+
+    gmios[gmio.name] = gmio;
   }
 
   return gmios;
@@ -265,16 +335,28 @@ get_trace_gmio(const pt::ptree& aie_meta)
 
 namespace xrt_core { namespace edge { namespace aie {
 
-std::vector<tile_type>
-get_tiles(const xrt_core::device* device, const std::string& graph_name)
+adf::driver_config
+get_driver_config(const xrt_core::device* device)
 {
   auto data = device->get_axlf_section(AIE_METADATA);
   if (!data.first || !data.second)
-    return std::vector<tile_type>();
+    return adf::driver_config();
 
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
-  return ::get_tiles(aie_meta, graph_name);
+  return ::get_driver_config(aie_meta);
+}
+
+adf::graph_config
+get_graph(const xrt_core::device* device, const std::string& graph_name)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return adf::graph_config();
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_graph(aie_meta, graph_name);
 }
 
 int
@@ -289,20 +371,20 @@ get_graph_id(const xrt_core::device* device, const std::string& graph_name)
   return ::get_graph_id(aie_meta, graph_name);
 }
 
-std::vector<rtp_type>
-get_rtp(const xrt_core::device* device)
+std::unordered_map<std::string, adf::rtp_config>
+get_rtp(const xrt_core::device* device, int graph_id)
 {
   auto data = device->get_axlf_section(AIE_METADATA);
   if (!data.first || !data.second)
-    return std::vector<rtp_type>();
+    return std::unordered_map<std::string, adf::rtp_config>();
 
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
-  return ::get_rtp(aie_meta);
+  return ::get_rtp(aie_meta, graph_id);
 }
 
 std::vector<gmio_type>
-get_gmios(const xrt_core::device* device)
+get_old_gmios(const xrt_core::device* device)
 {
   auto data = device->get_axlf_section(AIE_METADATA);
   if (!data.first || !data.second)
@@ -310,7 +392,19 @@ get_gmios(const xrt_core::device* device)
 
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
-  return ::get_gmio(aie_meta);
+  return ::get_old_gmio(aie_meta);
+}
+
+std::unordered_map<std::string, adf::gmio_config>
+get_gmios(const xrt_core::device* device)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return std::unordered_map<std::string, adf::gmio_config>();
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_gmios(aie_meta);
 }
 
 std::vector<plio_type>

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -19,6 +19,8 @@
 
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include "../user/aie/common_layer/adf_api_config.h"
 
 namespace xrt_core {
 
@@ -27,26 +29,22 @@ class device;
 namespace edge { namespace aie {
 
 const int NON_EXIST_ID = -1;
-
-struct tile_type
-{
-  uint16_t row;
-  uint16_t col;
-  uint16_t itr_mem_row;
-  uint16_t itr_mem_col;
-  uint64_t itr_mem_addr;
-
-  bool     is_trigger;
-};
+/**
+ * get_driver_config() - get driver configuration from xclbin AIE metadata
+ *
+ * @device: device with loaded meta data
+ */
+adf::driver_config
+get_driver_config(const xrt_core::device* device);
 
 /**
- * get_tiles() - get tile data from xclbin AIE metadata
+ * get_graph() - get tile data from xclbin AIE metadata
  *
  * @device: device with loaded meta data
  * @graph: name of graph to extract tile data for
  */
-std::vector<tile_type>
-get_tiles(const xrt_core::device* device, const std::string& graph_name);
+adf::graph_config
+get_graph(const xrt_core::device* device, const std::string& graph_name);
 
 /**
  * get_graph_id() - get graph id from xclbin AIE metadata
@@ -58,39 +56,13 @@ get_tiles(const xrt_core::device* device, const std::string& graph_name);
 int
 get_graph_id(const xrt_core::device* device, const std::string& graph_name);
 
-struct rtp_type
-{
-  std::string     name;
-
-  uint16_t        selector_row;
-  uint16_t        selector_col;
-  uint16_t        selector_lock_id;
-  uint64_t        selector_addr;
-
-  uint16_t        ping_row;
-  uint16_t        ping_col;
-  uint16_t        ping_lock_id;
-  uint64_t        ping_addr;
-
-  uint16_t        pong_row;
-  uint16_t        pong_col;
-  uint16_t        pong_lock_id;
-  uint64_t        pong_addr;
-
-  bool            is_plrtp;
-  bool            is_input;
-  bool            is_async;
-  bool            is_connected;
-  bool            require_lock;
-};
-
 /**
  * get_rtp() - get rtp data from xclbin AIE metadata
  *
  * @device: device with loaded meta data
  */
-std::vector<rtp_type>
-get_rtp(const xrt_core::device* device);
+std::unordered_map<std::string, adf::rtp_config>
+get_rtp(const xrt_core::device* device, int graph_id);
 
 struct gmio_type
 {
@@ -104,12 +76,15 @@ struct gmio_type
   uint16_t        burst_len;
 };
 
+std::vector<gmio_type>
+get_old_gmios(const xrt_core::device* device);
+
 /**
  * get_gmios() - get gmio data from xclbin AIE metadata
  *
  * @device: device with loaded meta data
  */
-std::vector<gmio_type>
+std::unordered_map<std::string, adf::gmio_config>
 get_gmios(const xrt_core::device* device);
 
 struct plio_type

--- a/src/runtime_src/core/edge/hw_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/hw_em/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(EM_SRC_DIR  "${CMAKE_CURRENT_SOURCE_DIR}")
 set(COMMON_EM_SRC_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/../user")
 set(AIE_HW_EM_SRC_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/../user/aie")
+set(AIE_HW_EM_CL_SRC_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/../user/aie/common_layer")
 
 include_directories(
   ${EM_SRC_DIR}
@@ -23,6 +24,8 @@ file(GLOB XRT_CORE_EDGE_USER_AIE_HW_EM_FILES
   "${AIE_HW_EM_SRC_DIR}/*.h"
   "${AIE_HW_EM_SRC_DIR}/*.cpp"
   "${AIE_HW_EM_SRC_DIR}/*.c"
+  "${AIE_HW_EM_CL_SRC_DIR}/*.h"
+  "${AIE_HW_EM_CL_SRC_DIR}/*.cpp"
   )
 
 if (DEFINED XRT_AIE_BUILD)

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -10,6 +10,8 @@ if (DEFINED XRT_AIE_BUILD)
     "aie/*.h"
     "aie/*.cpp"
     "aie/*.c"
+    "aie/common_layer/*.h"
+    "aie/common_layer/*.cpp"
   )
 
   set(CMAKE_CXX_FLAGS "-DXAIE_DEBUG ${CMAKE_CXX_FLAGS}")

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -36,11 +36,20 @@ XAie_InstDeclare(DevInst, &ConfigPtr);   // Declare global device instance
 
 Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
 {
-    XAie_SetupConfig(ConfigPtr, HW_GEN, XAIE_BASE_ADDR, XAIE_COL_SHIFT,
-        XAIE_ROW_SHIFT, XAIE_NUM_COLS, XAIE_NUM_ROWS,
-        XAIE_SHIM_ROW, XAIE_RESERVED_TILE_ROW_START,
-        XAIE_RESERVED_TILE_NUM_ROWS, XAIE_AIE_TILE_ROW_START,
-        XAIE_AIE_TILE_NUM_ROWS);
+    adf::driver_config driver_config = xrt_core::edge::aie::get_driver_config(device.get());
+
+    XAie_SetupConfig(ConfigPtr,
+        driver_config.hw_gen,
+        driver_config.base_address,
+        driver_config.column_shift,
+        driver_config.row_shift,
+        driver_config.num_columns,
+        driver_config.num_rows,
+        driver_config.shim_row,
+        driver_config.reserved_row_start,
+        driver_config.reserved_num_rows,
+        driver_config.aie_tile_row_start,
+        driver_config.aie_tile_num_rows);
 
 #ifndef __AIESIM__
     auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
@@ -61,57 +70,25 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
     if ((rc = XAie_CfgInitialize(&DevInst, &ConfigPtr)) != XAIE_OK)
         throw xrt_core::error(-EINVAL, "Failed to initialize AIE configuration: " + std::to_string(rc));
     devInst = &DevInst;
-
+    adf::config_manager::initialize(devInst, driver_config.reserved_num_rows, false); //FIXME handle broadcast enable cores
+    
     /* Initialize PLIO metadata */
     for (auto& plio : xrt_core::edge::aie::get_plios(device.get()))
         plios.emplace_back(std::move(plio));
 
     /* Initialize graph GMIO metadata */
-    for (auto& gmio : xrt_core::edge::aie::get_gmios(device.get()))
-        gmios.emplace_back(std::move(gmio));
-
-    /*
-     * Initialize AIE shim DMA on column base if there is one for
-     * this column.
-     */
-    numCols = XAIE_NUM_COLS;
-    shim_dma.resize(numCols);
-    for (auto& gmio : gmios) {
-        if (gmio.shim_col > numCols)
-            throw xrt_core::error(-EINVAL, "GMIO " + gmio.name + " shim column " + std::to_string(gmio.shim_col) + " does not exist");
-
-        auto dma = &shim_dma.at(gmio.shim_col);
-        XAie_LocType shimTile = XAie_TileLoc(gmio.shim_col, 0);
-
-        if (!dma->configured) {
-            XAie_DmaDescInit(devInst, &(dma->desc), shimTile);
-            dma->configured = true;
-        }
-
-        auto chan = gmio.channel_number;
-        /* type 0: GM->AIE; type 1: AIE->GM */
-        XAie_DmaDirection dir = gmio.type == 0 ? DMA_MM2S : DMA_S2MM;
-        uint8_t pch = CONVERT_LCHANL_TO_PCHANL(chan);
-        XAie_DmaChannelEnable(devInst, shimTile, pch, dir);
-        XAie_DmaSetAxi(&(dma->desc), 0, gmio.burst_len, 0, 0, 0);
-
-        XAie_DmaGetMaxQueueSize(devInst, shimTile, &(dma->maxqSize));
-        for (int i = 0; i < dma->maxqSize; ++i) {
-            /*
-             * 16 BDs are allocated to 4 channels.
-             * Channel0: BD0~BD3
-             * Channel1: BD4~BD7
-             * Channel2: BD8~BD11
-             * Channel3: BD12~BD15
-             */
-            int bd_num = chan * dma->maxqSize + i;
-            BD bd;
-            bd.bd_num = bd_num;
-            dma->dma_chan[chan].idle_bds.push(bd);
-        }
+    gmios = xrt_core::edge::aie::get_old_gmios(device.get());
+    
+    /* Initialize gmio api instances */
+    gmio_configs = xrt_core::edge::aie::get_gmios(device.get());
+    for (auto config_itr = gmio_configs.begin(); config_itr != gmio_configs.end(); config_itr++)
+    {
+        auto p_gmio_api = std::make_shared<adf::gmio_api>(&config_itr->second);
+        p_gmio_api->configure();
+        gmio_apis[config_itr->first] = p_gmio_api;
     }
 
-    Resources::AIE::initialize(XAIE_NUM_COLS, XAIE_NUM_ROWS);
+    Resources::AIE::initialize(driver_config.num_columns, driver_config.aie_tile_num_rows);
 }
 
 Aie::~Aie()
@@ -136,21 +113,17 @@ sync_bo(xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t s
 {
   if (!devInst)
     throw xrt_core::error(-EINVAL, "Can't sync BO: AIE is not initialized");
-
-  auto gmio = std::find_if(gmios.begin(), gmios.end(),
-            [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
-
-  if (gmio == gmios.end())
+  
+  auto gmio_itr = gmio_apis.find(gmioName);
+  if (gmio_itr == gmio_apis.end())
+    throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
+  
+  auto gmio_config_itr = gmio_configs.find(gmioName);
+  if (gmio_config_itr == gmio_configs.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
 
-  submit_sync_bo(bo, gmio, dir, size, offset);
-
-  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
-  auto chan = gmio->channel_number;
-  auto shim_tile = XAie_TileLoc(gmio->shim_col, 0);
-  XAie_DmaDirection gmdir = gmio->type == 0 ? DMA_MM2S : DMA_S2MM;
-
-  wait_sync_bo(dmap, chan, shim_tile, gmdir, 0);
+  submit_sync_bo(bo, gmio_itr->second, gmio_config_itr->second, dir, size, offset);
+  gmio_itr->second->wait();
 }
 
 void
@@ -160,13 +133,15 @@ sync_bo_nb(xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_
   if (!devInst)
     throw xrt_core::error(-EINVAL, "Can't sync BO: AIE is not initialized");
 
-  auto gmio = std::find_if(gmios.begin(), gmios.end(),
-            [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
-
-  if (gmio == gmios.end())
+  auto gmio_itr = gmio_apis.find(gmioName);
+  if (gmio_itr == gmio_apis.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
-
-  submit_sync_bo(bo, gmio, dir, size, offset);
+  
+  auto gmio_config_itr = gmio_configs.find(gmioName);
+  if (gmio_config_itr == gmio_configs.end())
+    throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
+  
+  submit_sync_bo(bo, gmio_itr->second, gmio_config_itr->second, dir, size, offset);
 }
 
 void
@@ -176,31 +151,24 @@ wait_gmio(const std::string& gmioName)
   if (!devInst)
     throw xrt_core::error(-EINVAL, "Can't wait GMIO: AIE is not initialized");
 
-  auto gmio = std::find_if(gmios.begin(), gmios.end(),
-            [gmioName](gmio_type it) { return it.name.compare(gmioName) == 0; });
-
-  if (gmio == gmios.end())
-    throw xrt_core::error(-EINVAL, "Can't wait GMIO: GMIO name not found");
-
-  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
-  auto chan = gmio->channel_number;
-  auto shim_tile = XAie_TileLoc(gmio->shim_col, 0);
-  XAie_DmaDirection gmdir = gmio->type == 0 ? DMA_MM2S : DMA_S2MM;
-
-  wait_sync_bo(dmap, chan, shim_tile, gmdir, 0);
+  auto gmio_itr = gmio_apis.find(gmioName);
+  if (gmio_itr == gmio_apis.end())
+    throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
+    
+  gmio_itr->second->wait();  
 }
 
 void
 Aie::
-submit_sync_bo(xrt::bo& bo, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size, size_t offset)
+submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio_api, adf::gmio_config& gmio_config, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
   switch (dir) {
   case XCL_BO_SYNC_BO_GMIO_TO_AIE:
-    if (gmio->type != 0)
+    if (gmio_config.type != 0)
       throw xrt_core::error(-EINVAL, "Sync BO direction does not match GMIO type");
     break;
   case XCL_BO_SYNC_BO_AIE_TO_GMIO:
-    if (gmio->type != 1)
+    if (gmio_config.type != 1)
       throw xrt_core::error(-EINVAL, "Sync BO direction does not match GMIO type");
     break;
   default:
@@ -209,65 +177,15 @@ submit_sync_bo(xrt::bo& bo, std::vector<gmio_type>::iterator& gmio, enum xclBOSy
 
   if (size & XAIEDMA_SHIM_TXFER_LEN32_MASK != 0)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: size is not 32 bits aligned.");
-
-  ShimDMA *dmap = &shim_dma.at(gmio->shim_col);
-  auto chan = gmio->channel_number;
-  auto shim_tile = XAie_TileLoc(gmio->shim_col, 0);
-  XAie_DmaDirection gmdir = gmio->type == 0 ? DMA_MM2S : DMA_S2MM;
-  uint32_t pchan = CONVERT_LCHANL_TO_PCHANL(chan);
-
-  /* Find a free BD. Busy wait until we get one. */
-  while (dmap->dma_chan[chan].idle_bds.empty()) {
-    uint8_t npend;
-    XAie_DmaGetPendingBdCount(devInst, shim_tile, pchan, gmdir, &npend);
-
-    int num_comp = dmap->maxqSize - npend;
-
-    /* Pending BD is completed by order per Shim DMA spec. */
-    for (int i = 0; i < num_comp; ++i) {
-      BD bd = dmap->dma_chan[chan].pend_bds.front();
-      dmap->dma_chan[chan].pend_bds.pop();
-      dmap->dma_chan[chan].idle_bds.push(bd);
-    }
-  }
-
-  BD_scope bd_scope(dmap->dma_chan[chan].idle_bds.front(), this);
-  auto& bd = bd_scope.get();
-  dmap->dma_chan[chan].idle_bds.pop();
+    
+  BD bd;
   prepare_bd(bd, bo);
-
-#ifndef __AIESIM__
-  XAie_DmaSetAddrLen(&(dmap->desc), (uint64_t)(bd.vaddr + offset), size);
+#ifndef __AIESIM__  
+  gmio_api->enqueueBD((uint64_t)bd.vaddr + offset, size);
 #else
-  XAie_DmaSetAddrLen(&(dmap->desc), (uint64_t)(bo.address() + offset), size);
+  gmio_api->enqueueBD((uint64_t)bo.address() + offset, size);
 #endif
-
-  /* Set BD lock */
-  auto acq_lock = XAie_LockInit(bd.bd_num, XAIE_LOCK_WITH_NO_VALUE);
-  auto rel_lock = XAie_LockInit(bd.bd_num, XAIE_LOCK_WITH_NO_VALUE);
-  XAie_DmaSetLock(&(dmap->desc), acq_lock, rel_lock);
-
-  XAie_DmaEnableBd(&(dmap->desc));
-
-  /* Write BD */
-  XAie_DmaWriteBd(devInst, &(dmap->desc), shim_tile, bd.bd_num);
-
-  /* Enqueue BD */
-  XAie_DmaChannelPushBdToQueue(devInst, shim_tile, pchan, gmdir, bd.bd_num);
-  dmap->dma_chan[chan].pend_bds.push(bd);
-}
-
-void
-Aie::
-wait_sync_bo(ShimDMA *dmap, uint32_t chan, XAie_LocType& tile, XAie_DmaDirection gmdir, uint32_t timeout)
-{
-  while (XAie_DmaWaitForDone(devInst, tile, CONVERT_LCHANL_TO_PCHANL(chan), gmdir, timeout) != XAIE_OK);
-
-  while (!dmap->dma_chan[chan].pend_bds.empty()) {
-    BD bd = dmap->dma_chan[chan].pend_bds.front();
-    dmap->dma_chan[chan].pend_bds.pop();
-    dmap->dma_chan[chan].idle_bds.push(bd);
-  }
+  clear_bd(bd);
 }
 
 void

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  * Author(s): Larry Liu
  * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
  *
@@ -70,15 +70,15 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
     if ((rc = XAie_CfgInitialize(&DevInst, &ConfigPtr)) != XAIE_OK)
         throw xrt_core::error(-EINVAL, "Failed to initialize AIE configuration: " + std::to_string(rc));
     devInst = &DevInst;
-    adf::config_manager::initialize(devInst, driver_config.reserved_num_rows, false); //FIXME handle broadcast enable cores
-    
+    adf::config_manager::initialize(devInst, driver_config.reserved_num_rows, false);
+
     /* Initialize PLIO metadata */
     for (auto& plio : xrt_core::edge::aie::get_plios(device.get()))
         plios.emplace_back(std::move(plio));
 
     /* Initialize graph GMIO metadata */
     gmios = xrt_core::edge::aie::get_old_gmios(device.get());
-    
+
     /* Initialize gmio api instances */
     gmio_configs = xrt_core::edge::aie::get_gmios(device.get());
     for (auto config_itr = gmio_configs.begin(); config_itr != gmio_configs.end(); config_itr++)
@@ -113,11 +113,11 @@ sync_bo(xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t s
 {
   if (!devInst)
     throw xrt_core::error(-EINVAL, "Can't sync BO: AIE is not initialized");
-  
+
   auto gmio_itr = gmio_apis.find(gmioName);
   if (gmio_itr == gmio_apis.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
-  
+
   auto gmio_config_itr = gmio_configs.find(gmioName);
   if (gmio_config_itr == gmio_configs.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
@@ -136,11 +136,11 @@ sync_bo_nb(xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_
   auto gmio_itr = gmio_apis.find(gmioName);
   if (gmio_itr == gmio_apis.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
-  
+
   auto gmio_config_itr = gmio_configs.find(gmioName);
   if (gmio_config_itr == gmio_configs.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
-  
+
   submit_sync_bo(bo, gmio_itr->second, gmio_config_itr->second, dir, size, offset);
 }
 
@@ -154,8 +154,8 @@ wait_gmio(const std::string& gmioName)
   auto gmio_itr = gmio_apis.find(gmioName);
   if (gmio_itr == gmio_apis.end())
     throw xrt_core::error(-EINVAL, "Can't sync BO: GMIO name not found");
-    
-  gmio_itr->second->wait();  
+
+  gmio_itr->second->wait();
 }
 
 void
@@ -177,10 +177,10 @@ submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio_api, adf::gmio_
 
   if (size & XAIEDMA_SHIM_TXFER_LEN32_MASK != 0)
     throw xrt_core::error(-EINVAL, "Sync AIE Bo fails: size is not 32 bits aligned.");
-    
+
   BD bd;
   prepare_bd(bd, bo);
-#ifndef __AIESIM__  
+#ifndef __AIESIM__
   gmio_api->enqueueBD((uint64_t)bd.vaddr + offset, size);
 #else
   gmio_api->enqueueBD((uint64_t)bo.address() + offset, size);

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -28,21 +28,11 @@
 #include "experimental/xrt_bo.h"
 #include "experimental/xrt_aie.h"
 #include "AIEResources.h"
+#include "common_layer/adf_api_config.h"
+#include "common_layer/adf_runtime_api.h"
 extern "C" {
 #include <xaiengine.h>
 }
-
-#define HW_GEN                        XAIE_DEV_GEN_AIE
-#define XAIE_NUM_ROWS                 9
-#define XAIE_NUM_COLS                 50
-#define XAIE_BASE_ADDR                0x20000000000
-#define XAIE_COL_SHIFT                23
-#define XAIE_ROW_SHIFT                18
-#define XAIE_SHIM_ROW                 0
-#define XAIE_RESERVED_TILE_ROW_START  0
-#define XAIE_RESERVED_TILE_NUM_ROWS   0
-#define XAIE_AIE_TILE_ROW_START       1
-#define XAIE_AIE_TILE_NUM_ROWS        8
 
 //#define XAIEGBL_NOC_DMASTA_STARTQ_MAX 4
 #define XAIEDMA_SHIM_MAX_NUM_CHANNELS 4
@@ -94,8 +84,10 @@ public:
     std::vector<ShimDMA> shim_dma;   // shim DMA
 
     /* This is the collections of gmios that are used. */
-    std::vector<gmio_type> gmios;
+    std::unordered_map<std::string, adf::gmio_config> gmio_configs;
+    std::unordered_map<std::string, std::shared_ptr<adf::gmio_api>> gmio_apis;
 
+    std::vector<gmio_type> gmios;
     std::vector<plio_type> plios;
 
     XAie_DevInst *getDevInst();
@@ -134,13 +126,9 @@ private:
     XAie_DevInst* devInst;         // AIE Device Instance
 
     std::vector<EventRecord> eventRecords;
-
-    void
-    submit_sync_bo(xrt::bo& bo, std::vector<gmio_type>::iterator& gmio, enum xclBOSyncDirection dir, size_t size, size_t offset);
-
-    /* Wait for all the BD transfers for a given channel */
-    void
-    wait_sync_bo(ShimDMA *dmap, uint32_t chan, XAie_LocType& tile, XAie_DmaDirection gmdir, uint32_t timeout);
+    
+    void 
+    submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio, adf::gmio_config& gmio_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void
     get_profiling_config(const std::string& port_name, XAie_LocType& out_shim_tile, XAie_StrmPortIntf& out_mode, uint8_t& out_stream_id);
@@ -156,26 +144,6 @@ private:
 
     int
     start_profiling_event_count(const std::string& port_name);
-};
-
-struct BD_scope {
-  BD bd;
-  Aie* aie;
-
-  BD_scope(const BD& bd_in, Aie* host)
-    : bd(bd_in), aie(host)
-  {}
-
-  ~BD_scope()
-  {
-    aie->clear_bd(bd);
-  }
-
-  BD&
-  get()
-  {
-    return bd;
-  }
 };
 
 }

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  * Author(s): Larry Liu
  * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
  *
@@ -126,8 +126,8 @@ private:
     XAie_DevInst* devInst;         // AIE Device Instance
 
     std::vector<EventRecord> eventRecords;
-    
-    void 
+
+    void
     submit_sync_bo(xrt::bo& bo, std::shared_ptr<adf::gmio_api>& gmio, adf::gmio_config& gmio_config, enum xclBOSyncDirection dir, size_t size, size_t offset);
 
     void

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -97,7 +97,7 @@ struct gmio_config
     short channelNum;
     /// Shim stream switch port id (slave: gm-->me, master: me-->gm)
     short streamId;
-    /// For type == gm2aie or type == aie2gm, burstLength is the burst length for the AXI-MM transfer 
+    /// For type == gm2aie or type == aie2gm, burstLength is the burst length for the AXI-MM transfer
     /// (4 or 8 or 16 in C_RTS API). The burst length in bytes is burstLength * 16 bytes (128-bit aligned).
     /// For type == gm2pl or type == pl2gm, burstLength is the burst length in bytes.
     short burstLength;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) 2020 Xilinx, Inc
+* Copyright (C) 2021 Xilinx, Inc
 *
 * Licensed under the Apache License, Version 2.0 (the "License"). You may
 * not use this file except in compliance with the License. A copy of the
@@ -63,7 +63,8 @@ struct rtp_config
     bool isConnect;
     size_t numBytes;
     bool isPL;
-    bool hasLock; //for graph::update to connected async input RTP, if the connection is within a core, there may not be a lock
+    //for graph::update to connected async input RTP, if the connection is within a core, there may not be a lock
+    bool hasLock;
     short selectorColumn;
     short selectorRow;
     size_t selectorAddr;
@@ -96,7 +97,8 @@ struct gmio_config
     short channelNum;
     /// Shim stream switch port id (slave: gm-->me, master: me-->gm)
     short streamId;
-    /// For type == gm2me or type == me2gm, burstLength is the burst length for the AXI-MM transfer (4 or 8 or 16 in C_RTS API). The burst length in bytes is burstLength * 16 bytes (128-bit aligned).
+    /// For type == gm2aie or type == aie2gm, burstLength is the burst length for the AXI-MM transfer 
+    /// (4 or 8 or 16 in C_RTS API). The burst length in bytes is burstLength * 16 bytes (128-bit aligned).
     /// For type == gm2pl or type == pl2gm, burstLength is the burst length in bytes.
     short burstLength;
 };
@@ -112,7 +114,7 @@ struct kernel_config
 
 struct dma_config
 {
-    ///DMA object   
+    ///DMA object
     short column;
     short row;
     std::vector<int> hierarchicalGraphIds;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -1,0 +1,150 @@
+/**
+* Copyright (C) 2020 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace adf
+{
+
+struct driver_config
+{
+    uint8_t hw_gen;
+    uint64_t base_address;
+    uint8_t column_shift;
+    uint8_t row_shift;
+    uint8_t num_columns;
+    uint8_t num_rows;
+    uint8_t shim_row;
+    uint8_t reserved_row_start;
+    uint8_t reserved_num_rows;
+    uint8_t aie_tile_row_start;
+    uint8_t aie_tile_num_rows;
+};
+
+struct graph_config
+{
+    int id;
+    std::string name;
+
+    std::vector<short> coreColumns;
+    std::vector<short> coreRows;
+    /// Core iteration memory address
+    std::vector<short> iterMemColumns;
+    std::vector<short> iterMemRows;
+    std::vector<size_t> iterMemAddrs;
+    std::vector<bool> triggered;
+};
+
+struct rtp_config
+{
+    int portId;
+    int aliasId;
+    std::string portName;
+    std::string aliasName;
+    int graphId;
+    bool isInput;
+    bool isAsync;
+    bool isConnect;
+    size_t numBytes;
+    bool isPL;
+    bool hasLock; //for graph::update to connected async input RTP, if the connection is within a core, there may not be a lock
+    short selectorColumn;
+    short selectorRow;
+    size_t selectorAddr;
+    unsigned short selectorLockId;
+    short pingColumn;
+    short pingRow;
+    size_t pingAddr;
+    unsigned short pingLockId;
+    short pongColumn;
+    short pongRow;
+    size_t pongAddr;
+    unsigned short pongLockId;
+};
+
+struct gmio_config
+{
+    enum gmio_type { gm2aie, aie2gm, gm2pl, pl2gm };
+
+    /// GMIO object id
+    int id;
+    /// GMIO variable name
+    std::string name;
+    /// GMIO loginal name
+    std::string logicalName;
+    /// GMIO type
+    gmio_type type;
+    /// Shim tile column to where the GMIO is mapped
+    short shimColumn;
+    /// Channel number (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1).
+    short channelNum;
+    /// Shim stream switch port id (slave: gm-->me, master: me-->gm)
+    short streamId;
+    /// For type == gm2me or type == me2gm, burstLength is the burst length for the AXI-MM transfer (4 or 8 or 16 in C_RTS API). The burst length in bytes is burstLength * 16 bytes (128-bit aligned).
+    /// For type == gm2pl or type == pl2gm, burstLength is the burst length in bytes.
+    short burstLength;
+};
+
+struct kernel_config
+{
+    ///Kernel object id
+    int id;
+    std::vector<int> hierarchicalGraphIds;
+    short column;
+    short row;
+};
+
+struct dma_config
+{
+    ///DMA object   
+    short column;
+    short row;
+    std::vector<int> hierarchicalGraphIds;
+    std::vector<int> channel;
+};
+
+struct plio_config
+{
+    /// PLIO object id
+    int id;
+    /// PLIO variable name
+    std::string name;
+    /// PLIO loginal name
+    std::string logicalName;
+    /// Shim tile column to where the GMIO is mapped
+    short shimColumn;
+    /// slave or master. 0:slave, 1:master
+    short slaveOrMaster;
+    /// Shim stream switch port id
+    short streamId;
+};
+
+struct trace_unit_config
+{
+    /// tile column
+    short column;
+    /// tile row
+    short row;
+    /// core module 0, memory module 1, shim pl module 2
+    short module;
+    /// packet id
+    short packetId;
+};
+
+}

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_message.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_message.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) 2020 Xilinx, Inc
+* Copyright (C) 2021 Xilinx, Inc
 *
 * Licensed under the Apache License, Version 2.0 (the "License"). You may
 * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_message.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_message.h
@@ -1,0 +1,33 @@
+/**
+* Copyright (C) 2020 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+#pragma once
+
+#include "core/common/error.h"
+
+adf::err_code errorMsg(adf::err_code code, std::string msg)
+{
+    throw xrt_core::error(-((int)code), msg);
+    return code;
+}
+
+void debugMsg(std::string msg)
+{
+}
+
+void infoMsg(std::string msg)
+{
+}

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -1,0 +1,710 @@
+/**
+* Copyright (C) 2020 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+#include "adf_runtime_api.h"
+#include "adf_api_message.h"
+
+#include <algorithm>
+#include <sstream>
+#include <map>
+
+extern "C"
+{
+    #include "xaiengine.h"
+}
+
+namespace adf {
+/********************************* Statics & Constants *********************************/
+
+static constexpr short INVALID_TILE_COORD = 0xFF;
+
+static constexpr int ACQ_WRITE = 0;
+static constexpr int ACQ_READ = 1;
+static constexpr int REL_READ = 1;
+static constexpr int REL_WRITE = 0;
+
+static constexpr int AIE_ML_REL_WRITE = -1;
+static constexpr int AIE_ML_ASYNC_REL = 1;
+static constexpr int AIE_ML_ASYNC_ACQ = -1; //negative lock value -> acquire_greater_equal
+static constexpr int AIE_ML_ASYNC_ACQ_FIRST_TIME = 0;
+
+static constexpr unsigned LOCK_TIMEOUT = 0x7FFFFFFF;
+
+
+/********************************* config_manager *************************************/
+
+XAie_DevInst* config_manager::s_pDevInst = nullptr;
+bool config_manager::s_bInitialized = false;
+size_t config_manager::s_num_reserved_rows = 0;
+bool config_manager::s_broadcast_enable_core = false;
+
+err_code config_manager::initialize(XAie_DevInst* devInst, size_t num_reserved_rows, bool broadcast_enable_core)
+{
+    if(!s_bInitialized)
+    {
+        if(!devInst)
+            return errorMsg(err_code::internal_error, "ERROR: config_manager::initialize: Cannot initialize device instance.");
+        
+        s_pDevInst = devInst;
+        s_num_reserved_rows = num_reserved_rows;
+        s_broadcast_enable_core = broadcast_enable_core;
+
+        /*
+        Resources::AIE::initialize(s_pDevInst->NumCols, s_pDevInst->NumRows - 1);
+        
+        debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "config_manager::initialize: initialized Resources::AIE: " << (int)s_pDevInst->NumCols << " columns, " << (int)(s_pDevInst->NumRows - 1) << " AIE rows").str());
+        
+        if (s_pDevInst->EccStatus == XAIE_ENABLE)
+        {
+            if (Resources::AIE::reservePerformanceCounterEccScrubbing())
+                debugMsg("config_manager::initialize: reserved performance counter in core module for ECC Scrubbing");
+            else
+                return errorMsg(err_code::internal_error, "ERROR: config_manager::initialize: failed to reserve performance counter in core module for ECC Scrubbing");
+        }*/
+        
+        s_bInitialized = true;
+    }
+    return err_code::ok;
+}    
+
+/************************************ graph_api ************************************/
+
+graph_api::graph_api(const graph_config* pConfig) : pGraphConfig(pConfig), isConfigured(false), isRunning(false), startTime(0)
+{}
+
+err_code graph_api::configure()
+{
+    if (!pGraphConfig)
+        return errorMsg(err_code::internal_error, "ERROR: adf::graph_api::configure: Invalid graph configuration.");
+
+    int numCores = pGraphConfig->coreColumns.size();
+    if (pGraphConfig->coreRows.size() != numCores || pGraphConfig->iterMemAddrs.size() != numCores || pGraphConfig->triggered.size() != numCores || pGraphConfig->iterMemColumns.size() != numCores || pGraphConfig->iterMemRows.size() != numCores)
+        return errorMsg(err_code::internal_error, "ERROR: adf::graph_api::configure: inconsistent number of cores.");
+
+    coreTiles.resize(numCores);
+    iterMemTiles.resize(numCores);
+    for (int i = 0; i < numCores; i++)
+    {
+        size_t numReservedRows = config_manager::s_num_reserved_rows;
+        coreTiles[i] = XAie_TileLoc(pGraphConfig->coreColumns[i], pGraphConfig->coreRows[i] + numReservedRows + 1);
+        iterMemTiles[i] = XAie_TileLoc(pGraphConfig->iterMemColumns[i], pGraphConfig->iterMemRows[i] + numReservedRows + 1);
+    }
+
+    isConfigured = true;
+    return err_code::ok;
+}
+
+err_code graph_api::run()
+{
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::run: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+    int numCores = coreTiles.size();
+
+    // Record a snapshot of the graph cores startup/enable time
+    if (numCores)
+        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, coreTiles[0], XAIE_CORE_MOD, (u64*)(&startTime));
+    
+    infoMsg("Enabling core(s) of graph " + pGraphConfig->name);
+    
+    if (config_manager::s_broadcast_enable_core)
+    {
+        for (int i = 0; i < numCores; i++)
+        {
+            //Set Enable_Event bits in http://cervino-doc/r2p16/tile_links/xregdb_me_tile_doc.html#tile_core___Enable_Events to 113
+            //XAie_CoreConfigureEnableEvent(config_managers_pDevInst, coreTiles[i], XAIE_EVENT_BROADCAST_7_CORE);
+            XAie_Write32(config_manager::s_pDevInst, (_XAie_GetTileAddr(config_manager::s_pDevInst, coreTiles[i].Row, coreTiles[i].Col) + 0x00032008), 0x4472);
+        }
+
+        //Trigger event 113 in shim_tile at column 0 by writing to http://cervino-doc/r2p16/tile_links/xregdb_me_pl_tile_doc.html#pl_module___Event_Generate
+        XAie_EventGenerate(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, XAIE_EVENT_BROADCAST_A_6_PL);
+
+        for (int i = 0; i < numCores; i++)
+        {
+            //Set Enable_Event bits in http://cervino-doc/r2p16/tile_links/xregdb_me_tile_doc.html#tile_core___Enable_Events to 0
+            //if (XAie_Read32(config_manager::s_pDevInst, (_XAie_GetTileAddr(config_manager::s_pDevInst, coreTiles[i].Row, coreTiles[i].Col) +  0x00032004) & 0x0001) == 1)
+            //XAie_CoreConfigureEnableEvent(config_manager::s_pDevInst, coreTiles[i], XAIE_EVENT_NONE_CORE);
+            XAie_Write32(config_manager::s_pDevInst, (_XAie_GetTileAddr(config_manager::s_pDevInst, coreTiles[i].Row, coreTiles[i].Col) + 0x00032008), 0x4400);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < numCores; i++)
+            driverStatus |= XAie_CoreEnable(config_manager::s_pDevInst, coreTiles[i]);
+    }
+
+#ifdef ENABLE_LARGE_PROGRAM
+    // BG: Manage Program Memory
+    for (int i = 0; i < coreTiles.size(); i++)
+    {
+        u8 DebugStatusBit = 0;
+        while (AieRC::XAIE_OK != XAie_CoreReadDebugStatusBit(config_manager::s_pDevInst, coreTiles[i], &DebugStatusBit)) {}
+        infoMsg("Debug Status is enabled... Core is halted due to debug event 0");
+        u32 pmAddr = 0;
+        if (AieRC::XAIE_OK == XAie_GetProgMemAddr(config_manager::s_pDevInst, coreTiles[i], &pmAddr))
+            infoMsg(static_cast<std::stringstream &&>(std::stringstream() << "Current PM addr = " << std::hex << pmAddr << std::dec).str());
+        infoMsg("Enable the user event to resume the core");
+        if (AieRC::XAIE_OK != XAie_EventGenerate(config_manager::s_pDevInst, coreTiles[i], XAIE_CORE_MOD, XAIE_EVENT_USER_EVENT_0_CORE))
+            errorMsg(err_code::aie_driver_error, "Enabling user event to resume core failed");
+    }
+#endif
+    
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::run: AIE driver error.");
+    
+    isRunning = true;  // Set graph enable after enabling all cores
+    return err_code::ok;
+}
+
+
+err_code graph_api::run(int iterations)
+{
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::run: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    // Set iterations for the core(s) of graph
+    infoMsg("Set iterations for the core(s) of graph " + pGraphConfig->name);
+
+    int numCores = coreTiles.size();
+    for (int i = 0; i < numCores; i++)
+        driverStatus |= XAie_DataMemWrWord(config_manager::s_pDevInst, iterMemTiles[i], pGraphConfig->iterMemAddrs[i], (u32)iterations);
+    
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::run: AIE driver error.");
+
+    return run();
+}
+
+
+err_code graph_api::wait()
+{
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::wait: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+    
+    infoMsg("Waiting for core(s) of graph " + pGraphConfig->name + " to finish execution ...");
+
+    int numCores = coreTiles.size();
+    for (int i = 0; i < numCores; i++)
+    {
+        if (!pGraphConfig->triggered[i])
+        {
+            while (XAie_CoreWaitForDone(config_manager::s_pDevInst, coreTiles[i], 0) == XAIE_CORE_STATUS_TIMEOUT) {} // Default timeout is 500us. The timeout is counted on AIE clock. So even for a simple test-case this API call returns with error code XAIE_CORE_STATUS_TIMEOUT. 
+
+            driverStatus |= XAie_CoreDisable(config_manager::s_pDevInst, coreTiles[i]);
+        }
+    }
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::wait: AIE driver error.");
+
+    infoMsg("core(s) are done executing");
+    
+    isRunning = false;
+    return err_code::ok;
+}    
+
+
+err_code graph_api::wait(unsigned long long cycleTimeout)
+{
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::wait: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    // XAie_WaitCycles API note says - "CycleCnt has an upper limit of 0xFFFFFFFFFFFF or 300 trillion* cycles to prevent overflow". As per Dishita Vashi - "There is a possibility of unsigned integer 64 bit overflow for variable EndVal i.e. StartVal + CycleCnt. If we limit the CycleCnt value we can avoid that. I have set an upper bound of 0x0xffff-ffff-ffff which is 300 trillion cycles or 3 days at 1GHz which is a very high upper bound for wait cycles." (CR-1066349)
+    if(cycleTimeout > 0xFFFFFFFFFFFF)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::wait: Max cycle timeout value can be 0xFFFFFFFFFFFF.");
+    
+    infoMsg("Waiting for core(s) of graph " + pGraphConfig->name + " to complete " + std::to_string(cycleTimeout) + " cycles ...");
+
+    int numCores = coreTiles.size();
+    if (numCores)
+    {
+        // Adjust the cycle-timeout value
+        unsigned long long elapsedTime;
+        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, coreTiles[0], XAIE_CORE_MOD, (u64*)(&elapsedTime));
+        elapsedTime -= startTime;
+        if (cycleTimeout > elapsedTime)
+            driverStatus |= XAie_WaitCycles(config_manager::s_pDevInst, coreTiles[0], XAIE_CORE_MOD, (cycleTimeout - elapsedTime));
+    }
+
+    infoMsg("core(s) execution timed out");
+    infoMsg("Disabling core(s) of graph " + pGraphConfig->name);
+
+    for (int i = 0; i < numCores; i++)
+        driverStatus |= XAie_CoreDisable (config_manager::s_pDevInst, coreTiles[i]);
+    
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::wait: AIE driver error.");
+    
+    isRunning = false;
+    return err_code::ok;
+}
+
+
+err_code graph_api::resume()
+{
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::resume: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+ 
+    infoMsg("Re-enabling unfinished core(s) of graph " + pGraphConfig->name);
+
+    int numCores = coreTiles.size();
+    if (numCores) // Reset the graph timer
+        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, coreTiles[0], XAIE_CORE_MOD, (u64*)(&startTime));
+
+    for (int i = 0; i < numCores; i++)
+    {
+        bool isDone = false;
+        driverStatus |= XAie_CoreReadDoneBit(config_manager::s_pDevInst, coreTiles[i], (u8*)(&isDone));
+        if (!isDone)
+            driverStatus |= XAie_CoreEnable (config_manager::s_pDevInst, coreTiles[i]); //Core Enable will clear Core_Done status bit
+    }
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::resume: AIE driver error.");
+    
+    return err_code::ok;
+}
+
+
+err_code graph_api::end()
+{
+    // see https://confluence.xilinx.com/pages/viewpageattachments.action?pageId=100660646&sortBy=date&highlight=GraphRunResetProblemSolution.pptx&&preview=/100660646/182332415/GraphRunResetProblemSolution.pptx
+    // this is to:
+    // 1) wait for the done() inside the outer while loop in core main()
+    // 2) set the end signal in sync_buffer[0] (which is 4 byte before iteration address)
+    // 3) enable the core to let it continue to the next PC, which will evaluate "if (sync_buffer[2] > 0) break;" and breaks out of outer while loop
+    // 4) wait for the done() inserted by single core compiler at the end of main() program
+    // 5) disable core after the final done()
+    
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::end: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    bool isRunningBefore = isRunning;
+    err_code ret = wait(); //wait core done. //wait() sets isRunning to false    
+    if (ret != err_code::ok)
+        return ret;
+    
+    int numCores = coreTiles.size();
+    for (int i = 0; i < numCores; i++)
+    {
+        //if the end sequence is done before, do not do it again. this is to allow multiple g.end(), g.end() ...
+        if (isRunningBefore && !pGraphConfig->triggered[i])
+        {
+            driverStatus |= XAie_DataMemWrWord(config_manager::s_pDevInst, iterMemTiles[i], pGraphConfig->iterMemAddrs[i] - 4, (u32)1);
+
+            driverStatus |= XAie_CoreEnable(config_manager::s_pDevInst, coreTiles[i]);
+
+            while (XAie_CoreWaitForDone(config_manager::s_pDevInst, coreTiles[i], 0) == XAIE_CORE_STATUS_TIMEOUT) {} // Default timeout is 500us. The timeout is counted on AIE clock. So even for a simple test-case this API call returns with error code XAIE_CORE_STATUS_TIMEOUT.
+
+            driverStatus |= XAie_CoreDisable(config_manager::s_pDevInst, coreTiles[i]);
+        }
+    }
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::end: AIE driver error.");
+
+    return err_code::ok;
+}
+
+
+err_code graph_api::end(unsigned long long cycleTimeout)
+{
+    if (!isConfigured)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::end: graph is not configured.");
+
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    err_code ret = wait(cycleTimeout);    
+    if (ret != err_code::ok)
+        return ret;
+    
+    int numCores = iterMemTiles.size();
+    for (int i = 0; i < numCores; i++)
+        driverStatus |= XAie_DataMemWrWord(config_manager::s_pDevInst, iterMemTiles[i], pGraphConfig->iterMemAddrs[i] - 4, (u32)1); //set the end signal in sync_buffer[0] (which is 4 byte before iteration address)
+    
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::end: AIE driver error.");
+    
+    return err_code::ok;
+}
+
+err_code checkRTPConfigForUpdate(const rtp_config* pRTPConfig, const graph_config* pGraphConfig, size_t numBytes, bool isRunning)
+{
+    if (!pRTPConfig)
+        return errorMsg(err_code::internal_error, "ERROR: adf::graph::update: invalid RTP configuration.");
+
+    //error checking: does this port belong to the graph
+    if (pRTPConfig->graphId != pGraphConfig->id)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::update: RTP port " + pRTPConfig->portName + " does not belong to graph " + pGraphConfig->name + ".");
+
+    // error checking: direction
+    if (!pRTPConfig->isInput)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::update only supports input RTP port.");
+
+    // error checking: size
+    if (numBytes != pRTPConfig->numBytes)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::update parameter size " + std::to_string(numBytes) + " is inconsistent with RTP port " + pRTPConfig->portName + " size " + std::to_string(pRTPConfig->numBytes) + ".");
+
+    // error checking: connected RTP port
+    if (pRTPConfig->isConnect)
+    {
+        if (pRTPConfig->isPL)
+            return errorMsg(err_code::user_error, "ERROR: adf::graph::update to connected RL input RTP is not supported.");
+        else //AIE RTP
+        {
+            // For connected async input RTP, only allow graph update before graph run
+            if (pRTPConfig->isAsync)
+            {
+                if (isRunning)
+                    return errorMsg(err_code::user_error, "ERROR: adf::graph::update to connected asynchronous input RTP is not allowed during graph run.");
+            }
+            // Does not support connected sync input RTP
+            else
+                return errorMsg(err_code::user_error, "ERROR: adf::graph::update to connected synchronous input RTP is not supported.");
+        }
+    }
+
+    return err_code::ok;
+}
+
+err_code graph_api::update(const rtp_config* pRTPConfig, const void* pValue, size_t numBytes)
+{
+    ///////////////////////////// Error Checking //////////////////////////////
+    
+    err_code ret = checkRTPConfigForUpdate(pRTPConfig, pGraphConfig, numBytes, isRunning);
+    if (ret != err_code::ok)
+        return ret;
+    
+    ///////////////////////////// Configuration //////////////////////////////
+    
+    size_t numReservedRows = config_manager::s_num_reserved_rows;
+    XAie_LocType selectorTile = XAie_TileLoc(pRTPConfig->selectorColumn, pRTPConfig->selectorRow + numReservedRows + 1);
+    XAie_LocType pingTile = XAie_TileLoc(pRTPConfig->pingColumn, pRTPConfig->pingRow + numReservedRows + 1);
+    XAie_LocType pongTile = XAie_TileLoc(pRTPConfig->pongColumn, pRTPConfig->pongRow + numReservedRows + 1);
+
+    // Do NOT lock async RTP when graph is suspended; otherwise, it may deadlock. We don't support synchronous RTP in suspended mode
+    bool bAcquireLock = !(pRTPConfig->isAsync && !isRunning);
+
+    //https://confluence.xilinx.com/display/XSW/2020.2+Cardano+AIE2#id-2020.2CardanoAIE2-RTP_AIE1_AIE2
+    int8_t acquireVal = (pRTPConfig->isAsync ? XAIE_LOCK_WITH_NO_VALUE : ACQ_WRITE); //AIE1
+    int8_t releaseVal = REL_READ; //AIE1
+
+    ///////////////////////////// RTP update operation //////////////////////////////
+
+    infoMsg("Updating RTP value to port " + pRTPConfig->portName);
+
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    // sync ports acquire selector lock for WRITE, async ports acquire selector lock unconditionally
+    if (pRTPConfig->hasLock && bAcquireLock)
+        driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, acquireVal), LOCK_TIMEOUT);
+    
+    // Read the selector value
+    u32 selector;
+    driverStatus |= XAie_DataMemRdWord(config_manager::s_pDevInst, selectorTile, pRTPConfig->selectorAddr, ((u32*)&selector));
+    selector = 1 - selector;
+
+    if (selector == 1) //pong
+    {
+        // sync ports acquire buffer lock for WRITE, async ports acquire buffer lock unconditionally
+        if (pRTPConfig->hasLock && bAcquireLock)
+            driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, pongTile, XAie_LockInit(pRTPConfig->pongLockId, acquireVal), LOCK_TIMEOUT);
+        
+        driverStatus |= XAie_DataMemBlockWrite(config_manager::s_pDevInst, pongTile, pRTPConfig->pongAddr, pValue, numBytes);
+    }
+    else //ping
+    {
+        // sync ports acquire buffer lock for WRITE, async ports acquire buffer lock unconditionally
+        if (pRTPConfig->hasLock && bAcquireLock)
+            driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, pingTile, XAie_LockInit(pRTPConfig->pingLockId, acquireVal), LOCK_TIMEOUT);
+
+        driverStatus |= XAie_DataMemBlockWrite(config_manager::s_pDevInst, pingTile, pRTPConfig->pingAddr, pValue, numBytes);
+    }
+
+    // write the new selector value
+    driverStatus |= XAie_DataMemWrWord(config_manager::s_pDevInst, selectorTile, pRTPConfig->selectorAddr, selector);
+
+    if (pRTPConfig->hasLock)
+    {
+        // release selector and buffer locks for ME
+        // still need to release async RTP selector lock FOR_READ even when the graph is suspended; otherwise, the ME side may deadlock in acquiring selector lock FOR_READ
+        driverStatus |= XAie_LockRelease(config_manager::s_pDevInst, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, releaseVal), LOCK_TIMEOUT);
+
+        // still need to release async RTP buffer lock FOR_READ even when the graph is suspended; otherwise, the AIE side may deadlock in acquiring buffer lock FOR_READ (note that there is one selector lock but two buffer locks)
+        if (selector == 1) //pong
+            driverStatus |= XAie_LockRelease(config_manager::s_pDevInst, pongTile, XAie_LockInit(pRTPConfig->pongLockId, releaseVal), LOCK_TIMEOUT);
+        else //ping
+            driverStatus |= XAie_LockRelease(config_manager::s_pDevInst, pingTile, XAie_LockInit(pRTPConfig->pingLockId, releaseVal), LOCK_TIMEOUT);
+    }
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::update: XAieTile_LockAcquire timeout or AIE driver error.");
+    
+    return err_code::ok;
+}
+
+err_code checkRTPConfigForRead(const rtp_config* pRTPConfig, const graph_config* pGraphConfig, size_t numBytes)
+{
+    if (!pRTPConfig)
+        return errorMsg(err_code::internal_error, "ERROR: adf::graph::read: Invalid RTP configuration.");
+
+    //error checking: does this port belong to the graph
+    if (pRTPConfig->graphId != pGraphConfig->id)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::read: RTP port " + pRTPConfig->portName + " does not belong to graph " + pGraphConfig->name + ".");
+
+    // error checking: direction
+    if (pRTPConfig->isInput)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::read does not support input RTP port.");
+
+    // error checking: size
+    if (numBytes != pRTPConfig->numBytes)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::read parameter size " + std::to_string(numBytes) + " is inconsistent with RTP port " + pRTPConfig->portName + " size " + std::to_string(pRTPConfig->numBytes) + ".");
+
+    // error checking: connected RTP port
+    if (pRTPConfig->isConnect)
+        return errorMsg(err_code::user_error, "ERROR: adf::graph::read from connected RTP port is not supported.");
+
+    return err_code::ok;
+}
+
+err_code graph_api::read(const rtp_config* pRTPConfig, void* pValue, size_t numBytes)
+{
+    ///////////////////////////// Error Checking //////////////////////////////
+
+    err_code ret = checkRTPConfigForRead(pRTPConfig, pGraphConfig, numBytes);
+    if (ret != err_code::ok)
+        return ret;
+    
+    ///////////////////////////// Configuration //////////////////////////////
+    
+    // Do NOT lock async RTP when graph is suspended; otherwise, it may deadlock. We don't support synchronous RTP in suspended mode
+    bool bHasAndAcquireLock = !(pRTPConfig->isAsync && !isRunning) && pRTPConfig->hasLock;
+
+    //https://confluence.xilinx.com/display/XSW/2020.2+Cardano+AIE2#id-2020.2CardanoAIE2-RTP_AIE1_AIE2
+    int8_t acquireVal = ACQ_READ; //AIE1
+    int8_t releaseVal = (pRTPConfig->isAsync ? REL_READ : REL_WRITE); //AIE1
+    
+    size_t numReservedRows = config_manager::s_num_reserved_rows;
+    XAie_LocType selectorTile = XAie_TileLoc(pRTPConfig->selectorColumn, pRTPConfig->selectorRow + numReservedRows + 1);
+    XAie_LocType pingTile = XAie_TileLoc(pRTPConfig->pingColumn, pRTPConfig->pingRow + numReservedRows + 1);
+    XAie_LocType pongTile = XAie_TileLoc(pRTPConfig->pongColumn, pRTPConfig->pongRow + numReservedRows + 1);
+
+    ///////////////////////////// RTP read operation //////////////////////////////
+
+    infoMsg("Reading RTP value from port " + pRTPConfig->portName);
+
+    int driverStatus = AieRC::XAIE_OK; //0
+
+    if (bHasAndAcquireLock)
+    {
+        // synchronous RTP acquires lock for READ, async RTP requiring first-time sync acquires lock for READ 
+        driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, acquireVal), LOCK_TIMEOUT);
+    }
+
+    // Read the selector value
+    u32 selector;
+    driverStatus |= XAie_DataMemRdWord(config_manager::s_pDevInst, selectorTile, pRTPConfig->selectorAddr, ((u32*)&selector));
+
+    if (bHasAndAcquireLock)
+    {
+        // synchronous RTP acquires buffer for READ, async RTP requiring first-time sync acquires lock for READ
+        if (selector == 1) //pong
+            driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, pongTile, XAie_LockInit(pRTPConfig->pongLockId, acquireVal), LOCK_TIMEOUT);
+        else //ping
+            driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, pingTile, XAie_LockInit(pRTPConfig->pingLockId, acquireVal), LOCK_TIMEOUT);
+    }
+
+    //if lock was aquired, release the selector lock
+    if (bHasAndAcquireLock)
+    {
+        // synchronous RTP releases lock for WRITE, async RTP requiring first-time sync release lock for READ
+        driverStatus |= XAie_LockRelease(config_manager::s_pDevInst, selectorTile, XAie_LockInit(pRTPConfig->selectorLockId, releaseVal), LOCK_TIMEOUT);
+    }
+
+    if (selector == 1) //pong
+        driverStatus |= XAie_DataMemBlockRead(config_manager::s_pDevInst, pongTile, pRTPConfig->pongAddr, pValue, numBytes);
+    else //ping
+        driverStatus |= XAie_DataMemBlockRead(config_manager::s_pDevInst, pingTile, pRTPConfig->pingAddr, pValue, numBytes);
+
+    //release buffer lock
+    if (bHasAndAcquireLock)
+    {
+        if (selector == 1) //pong
+            driverStatus |= XAie_LockRelease(config_manager::s_pDevInst, pongTile, XAie_LockInit(pRTPConfig->pongLockId, releaseVal), LOCK_TIMEOUT);
+        else //ping
+            driverStatus |= XAie_LockRelease(config_manager::s_pDevInst, pingTile, XAie_LockInit(pRTPConfig->pingLockId, releaseVal), LOCK_TIMEOUT);
+    }
+
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::graph::read: XAieTile_LockAcquire timeout or AIE driver error.");
+    
+     return err_code::ok;
+}
+
+
+/************************************ gmio_api ************************************/
+
+/// GMIO API helper functions
+static inline u8 convertLogicalToPhysicalDMAChNum(short logicalChNum)
+{
+    return (logicalChNum > 1 ? (logicalChNum - 2) : logicalChNum);
+}
+
+size_t frontAndPop(std::queue<size_t>& bdQueue)
+{
+    size_t bd = bdQueue.front();
+    bdQueue.pop();
+    return bd;
+}
+
+gmio_api::gmio_api(const gmio_config* pConfig) : pGMIOConfig(pConfig), isConfigured(false), dmaStartQMaxSize(4)
+{}
+
+err_code gmio_api::configure()
+{
+    if (!pGMIOConfig)
+        return errorMsg(err_code::internal_error, "ERROR: gmio_api::configure: Invalid GMIO configuration.");
+
+    if (pGMIOConfig->type == gmio_config::gm2aie || pGMIOConfig->type == gmio_config::aie2gm)
+    {
+        int driverStatus = AieRC::XAIE_OK; //0
+        gmioTileLoc = XAie_TileLoc(pGMIOConfig->shimColumn, 0);            
+        driverStatus |= XAie_DmaDescInit(config_manager::s_pDevInst, &shimDmaInst, gmioTileLoc);
+        driverStatus |= XAie_DmaChannelEnable(config_manager::s_pDevInst, gmioTileLoc, convertLogicalToPhysicalDMAChNum(pGMIOConfig->channelNum), (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM)); //enable shim DMA channel, need to start first so the status is correct
+        
+        driverStatus |= XAie_DmaGetMaxQueueSize(config_manager::s_pDevInst, gmioTileLoc, &dmaStartQMaxSize);
+        
+        //decide 4 BD numbers to use for this GMIO based on channel number (0-S2MM0,1-S2MM1,2-MM2S0,3-MM2S1)
+        for (int j = 0; j < dmaStartQMaxSize; j++)
+        {
+            int bdNum = pGMIOConfig->channelNum * dmaStartQMaxSize + j;
+
+            availableBDs.push(bdNum);
+
+            //set AXI burst length, this won't change during runtime
+            driverStatus |= XAie_DmaSetAxi(&shimDmaInst, 0 /*Smid*/, pGMIOConfig->burstLength /*BurstLen*/, 0 /*Qos*/, 0 /*Cache*/, 0 /*Secure*/);
+            debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "GMIO id " << pGMIOConfig->id << " assigned BD num " << bdNum).str());
+        }
+
+        if (driverStatus != AieRC::XAIE_OK)
+            return errorMsg(err_code::aie_driver_error, "ERROR: adf::gmio_api::configure: AIE driver error.");
+    }
+    else
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::gmio_api::configure: GM - PL connection is not supported in GMIO AIE API.");
+    
+    isConfigured = true;
+    return err_code::ok;
+}
+
+
+err_code gmio_api::enqueueBD(uint64_t address, size_t size)
+{
+    if (!isConfigured)
+        return errorMsg(err_code::internal_error, "ERROR: adf::gmio_api::enqueueBD: GMIO is not configured.");
+    
+    debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "gmio_api::enqueueBD: (id " << pGMIOConfig->id << ") available number of BDs " << availableBDs.size()).str());
+    
+    int driverStatus = XAIE_OK; //0
+        
+    //wait for available BD
+    while (availableBDs.empty())
+    {
+        u8 numPendingBDs = 0;
+        driverStatus |= XAie_DmaGetPendingBdCount(config_manager::s_pDevInst, gmioTileLoc, convertLogicalToPhysicalDMAChNum(pGMIOConfig->channelNum), (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), &numPendingBDs);
+        
+        int numBDCompleted = dmaStartQMaxSize - numPendingBDs;
+        
+        //move completed BDs from enqueuedBDs to availableBDs
+        for (int i = 0; i < numBDCompleted; i++)
+        {
+            size_t bdNumber = frontAndPop(enqueuedBDs);           
+            availableBDs.push(bdNumber);
+        }
+    }
+    
+    debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "gmio_api::enqueneBD: (id " << pGMIOConfig->id << ") available number of BDs " << availableBDs.size()).str());
+    
+    //get an available BD
+    size_t bdNumber = frontAndPop(availableBDs);
+
+    //set up BD
+    //FIXME round up transaction_size to 32-bit word (4 byte)
+    //FIXME transaction size < burst length (4,6,8) * burst size (16 bytes)
+    driverStatus |= XAie_DmaSetAddrLen(&shimDmaInst, (u64)address, (u32)size);
+    
+    //set up lock for BD.
+    //According to Zachary Dickman, in ME RTL implementation, if lock is set, shim DMA channel will wait until AXI-MM acknowledgement before moving to the next BD.
+    //If lock is not set, shim DMA channel will move to the next BD as soon as the last AXI-MM transaction goes out.
+    //According to Herve, NoC DDR controller will send back "early acknowledgement" to shim DMA, it means the AXI-MM transaction is enqueued in NoC DDR controller.
+    //To ensure read (PS reads from DDR) after write (ME writes to DDR) or write (PS writes to DDR) after read (ME reads from DDR), as long as PS AXI-MM request enters NoC DDR controller after ME AXI-MM request, the order is guaranteed.
+    //As a result, for PS program, to ensure read after write, lock is set by default.
+    //However, it prevents shim DMA channel to work on the next BD at the earlies possible state, and potentially reduce performance.
+    //For Alpha 6, lock is set to ensure correctness but at the cost of less performance.
+    
+        driverStatus |= XAie_DmaSetLock(&shimDmaInst, XAie_LockInit(bdNumber, XAIE_LOCK_WITH_NO_VALUE), XAie_LockInit(bdNumber, XAIE_LOCK_WITH_NO_VALUE));
+    
+    driverStatus |= XAie_DmaEnableBd(&shimDmaInst);
+    
+    //write BD
+    driverStatus |= XAie_DmaWriteBd(config_manager::s_pDevInst, &shimDmaInst, gmioTileLoc, bdNumber);
+    
+    //enqueue BD
+    driverStatus |= XAie_DmaChannelPushBdToQueue(config_manager::s_pDevInst, gmioTileLoc, convertLogicalToPhysicalDMAChNum(pGMIOConfig->channelNum), (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), bdNumber);
+    enqueuedBDs.push(bdNumber);
+
+    debugMsg(static_cast<std::stringstream &&>(std::stringstream() << "gmio_api::enqueueBD: (id " << pGMIOConfig->id << ") enqueue BD num " << bdNumber << " to shim DMA channel " << pGMIOConfig->channelNum << ", DDR address " << std::hex << address << ", transaction size " << std::dec << size).str());
+    
+    // Update status after using AIE driver
+    if (driverStatus != AieRC::XAIE_OK)
+        return errorMsg(err_code::aie_driver_error, "ERROR: adf::gmio_api::enqueueBD: AIE driver error.");
+    
+    return err_code::ok;
+}
+
+
+err_code gmio_api::wait()
+{
+    if (!isConfigured)
+        return errorMsg(err_code::internal_error, "ERROR: adf::gmio_api::enqueueBD: GMIO is not configured.");
+
+    if (pGMIOConfig->type == gmio_config::gm2pl || pGMIOConfig->type == gmio_config::pl2gm)
+        return errorMsg(err_code::user_error, "ERROR: GMIO::wait can only be used by GMIO objects connecting to AIE, not PL.");
+
+    debugMsg("gmio_api::wait::XAie_DmaWaitForDone ...");
+
+    while (XAie_DmaWaitForDone(config_manager::s_pDevInst, gmioTileLoc, convertLogicalToPhysicalDMAChNum(pGMIOConfig->channelNum), (pGMIOConfig->type == gmio_config::gm2aie ? DMA_MM2S : DMA_S2MM), 0) != XAIE_OK) {}
+
+    while (!enqueuedBDs.empty())
+    {
+        size_t bdNumber = frontAndPop(enqueuedBDs);
+        availableBDs.push(bdNumber);
+    }
+
+    return err_code::ok;
+}
+
+}

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -50,9 +50,9 @@ bool config_manager::s_broadcast_enable_core = false;
 
 err_code config_manager::initialize(XAie_DevInst* devInst, size_t num_reserved_rows, bool broadcast_enable_core)
 {
-    if(!s_bInitialized)
+    if (!s_bInitialized)
     {
-        if(!devInst)
+        if (!devInst)
             return errorMsg(err_code::internal_error, "ERROR: config_manager::initialize: Cannot initialize device instance.");
 
         s_pDevInst = devInst;
@@ -112,7 +112,6 @@ err_code graph_api::run()
         for (int i = 0; i < numCores; i++)
         {
             //Set Enable_Event bits to 113
-            //XAie_CoreConfigureEnableEvent(config_managers_pDevInst, coreTiles[i], XAIE_EVENT_BROADCAST_7_CORE);
             XAie_Write32(config_manager::s_pDevInst, (_XAie_GetTileAddr(config_manager::s_pDevInst, coreTiles[i].Row, coreTiles[i].Col) + 0x00032008), 0x4472);
         }
 
@@ -122,8 +121,6 @@ err_code graph_api::run()
         for (int i = 0; i < numCores; i++)
         {
             //Set Enable_Event bits to 0
-            //if (XAie_Read32(config_manager::s_pDevInst, (_XAie_GetTileAddr(config_manager::s_pDevInst, coreTiles[i].Row, coreTiles[i].Col) +  0x00032004) & 0x0001) == 1)
-            //XAie_CoreConfigureEnableEvent(config_manager::s_pDevInst, coreTiles[i], XAIE_EVENT_NONE_CORE);
             XAie_Write32(config_manager::s_pDevInst, (_XAie_GetTileAddr(config_manager::s_pDevInst, coreTiles[i].Row, coreTiles[i].Col) + 0x00032008), 0x4400);
         }
     }
@@ -198,7 +195,7 @@ err_code graph_api::wait(unsigned long long cycleTimeout)
     int driverStatus = AieRC::XAIE_OK; //0
 
     // CycleCnt has an upper limit of 0xFFFFFFFFFFFF or 300 trillion* cycles to prevent overflow
-    if(cycleTimeout > 0xFFFFFFFFFFFF)
+    if (cycleTimeout > 0xFFFFFFFFFFFF)
         return errorMsg(err_code::user_error, "ERROR: adf::graph::wait: Max cycle timeout value can be 0xFFFFFFFFFFFF.");
 
     infoMsg("Waiting for core(s) of graph " + pGraphConfig->name + " to complete " + std::to_string(cycleTimeout) + " cycles ...");
@@ -393,7 +390,7 @@ err_code graph_api::update(const rtp_config* pRTPConfig, const void* pValue, siz
         if (pRTPConfig->hasLock && bAcquireLock)
             driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, pongTile, XAie_LockInit(pRTPConfig->pongLockId, acquireVal), LOCK_TIMEOUT);
 
-        driverStatus |= XAie_DataMemBlockWrite(config_manager::s_pDevInst, pongTile, pRTPConfig->pongAddr, pValue, numBytes);
+        driverStatus |= XAie_DataMemBlockWrite(config_manager::s_pDevInst, pongTile, pRTPConfig->pongAddr, const_cast<void*>(pValue), numBytes);
     }
     else //ping
     {
@@ -401,7 +398,7 @@ err_code graph_api::update(const rtp_config* pRTPConfig, const void* pValue, siz
         if (pRTPConfig->hasLock && bAcquireLock)
             driverStatus |= XAie_LockAcquire(config_manager::s_pDevInst, pingTile, XAie_LockInit(pRTPConfig->pingLockId, acquireVal), LOCK_TIMEOUT);
 
-        driverStatus |= XAie_DataMemBlockWrite(config_manager::s_pDevInst, pingTile, pRTPConfig->pingAddr, pValue, numBytes);
+        driverStatus |= XAie_DataMemBlockWrite(config_manager::s_pDevInst, pingTile, pRTPConfig->pingAddr, const_cast<void*>(pValue), numBytes);
     }
 
     // write the new selector value

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -1,0 +1,108 @@
+/**
+* Copyright (C) 2020 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+#pragma once
+
+#include "errno.h"
+#include "adf_api_config.h"
+
+#include <string>
+#include <queue>
+
+extern "C"
+{
+    #include "xaiengine/xaiegbl.h"
+}
+
+namespace adf
+{
+
+enum class err_code : int
+{
+    ok = 0,
+    user_error = EINVAL,
+    internal_error = ENOTSUP,
+    aie_driver_error = EIO
+};
+
+class config_manager
+{
+public:
+    static err_code initialize(XAie_DevInst* devInst, size_t num_reserved_rows, bool broadcast_enable_core);
+
+    static XAie_DevInst* s_pDevInst;
+
+    static bool s_bInitialized;
+    static size_t s_num_reserved_rows;
+    static bool s_broadcast_enable_core;
+};
+
+
+class graph_api
+{
+public:
+    graph_api(const graph_config* pConfig);
+    virtual ~graph_api() {}
+
+    err_code configure();
+    err_code run();
+    err_code run(int testIter);
+    err_code wait();
+    err_code wait(unsigned long long cycleTimeout);
+    err_code resume();
+    err_code end();
+    err_code end(unsigned long long cycleTimeout);
+    err_code update(const rtp_config* pRTPConfig, const void* pValue, size_t numBytes);
+    err_code read(const rtp_config* pRTPConfig, void* pValue, size_t numBytes);
+
+private:
+    const graph_config* pGraphConfig;
+    bool isConfigured;
+    bool isRunning;
+    unsigned long long startTime;
+
+    std::vector<XAie_LocType> coreTiles;
+    std::vector<XAie_LocType> iterMemTiles;
+};
+
+class gmio_api
+{
+public:
+    gmio_api(const gmio_config* pConfig);
+    virtual ~gmio_api() {}
+
+    err_code configure();
+    err_code enqueueBD(uint64_t address, size_t size);
+    err_code wait();
+
+private:
+    /// GMIO shim DMA physical configuration compiled by the AIE compiler 
+    const gmio_config* pGMIOConfig;
+
+    /// C_RTS Shim DMA to where this GMIO object is mapped
+    XAie_DmaDesc shimDmaInst;
+    XAie_LocType gmioTileLoc;
+
+    bool isConfigured;
+    uint8_t dmaStartQMaxSize;
+    std::queue<size_t> enqueuedBDs;
+    std::queue<size_t> availableBDs;
+};
+
+err_code checkRTPConfigForUpdate(const rtp_config* pRTPConfig, const graph_config* pGraphConfig, size_t numBytes, bool isRunning = false);
+err_code checkRTPConfigForRead(const rtp_config* pRTPConfig, const graph_config* pGraphConfig, size_t numBytes);
+
+}

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) 2020 Xilinx, Inc
+* Copyright (C) 2021 Xilinx, Inc
 *
 * Licensed under the Apache License, Version 2.0 (the "License"). You may
 * not use this file except in compliance with the License. A copy of the
@@ -89,7 +89,7 @@ public:
     err_code wait();
 
 private:
-    /// GMIO shim DMA physical configuration compiled by the AIE compiler 
+    /// GMIO shim DMA physical configuration compiled by the AIE compiler
     const gmio_config* pGMIOConfig;
 
     /// C_RTS Shim DMA to where this GMIO object is mapped

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -62,6 +62,7 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t uuid, const std::
     aieArray = getAieArray();
 #endif
 
+#ifndef __AIESIM__
     id = xrt_core::edge::aie::get_graph_id(device.get(), name);
     if (id == xrt_core::edge::aie::NON_EXIST_ID)
         throw xrt_core::error(-EINVAL, "Can not get id for Graph '" + name + "'");
@@ -69,31 +70,20 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t uuid, const std::
     int ret = drv->openGraphContext(uuid, id, am);
     if (ret)
         throw xrt_core::error(ret, "Can not open Graph context");
+#endif
     access_mode = am;
 
-    /* Initialize graph tile metadata */
-    for (auto& tile : xrt_core::edge::aie::get_tiles(device.get(), name)) {
-      /*
-       * Since row 0 is shim row, according to Vitis aietools, row data in
-       * xclbin is off-by-one. To talk to AIE driver, we need to add
-       * shim row back.
-       */
-      tile.row += 1;
-      tile.itr_mem_row += 1;
-      tiles.emplace_back(std::move(tile));
-    }
+    /* Initialize graph tile metadata */   
+    graph_config = xrt_core::edge::aie::get_graph(device.get(), name);
+
 
     /* Initialize graph rtp metadata */
-    for (auto &rtp : xrt_core::edge::aie::get_rtp(device.get())) {
-      rtp.selector_row += 1;
-      rtp.ping_row += 1;
-      rtp.pong_row += 1;
-      std::string port_name(rtp.name);
-      rtps.emplace(std::move(port_name), std::move(rtp));
-    }
+    rtps = xrt_core::edge::aie::get_rtp(device.get(), graph_config.id);
+    
+    pAIEConfigAPI = std::make_shared<adf::graph_api>(&graph_config);
+    pAIEConfigAPI->configure();
 
     state = graph_state::reset;
-    startTime = 0;
 #ifndef __AIESIM__
     drv->getAied()->registerGraph(this);
 #endif
@@ -130,8 +120,8 @@ reset()
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not reset graph");
 
-    for (auto& tile : tiles) {
-      XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+    for (int i = 0; i < graph_config.coreColumns.size(); i++) {
+      XAie_LocType coreTile = XAie_TileLoc(graph_config.coreColumns[i], graph_config.coreRows[i] + adf::config_manager::s_num_reserved_rows + 1);
       XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
@@ -143,8 +133,7 @@ graph_type::
 get_timestamp()
 {
     /* TODO just use the first tile to get the timestamp? */
-    auto& tile = tiles.at(0);
-    XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+    XAie_LocType coreTile = XAie_TileLoc(graph_config.coreColumns[0], graph_config.coreRows[0] + adf::config_manager::s_num_reserved_rows + 1);
 
     uint64_t timeStamp;
     AieRC rc = XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &timeStamp);
@@ -160,21 +149,11 @@ run()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not run graph");
-
+    
     if (state != graph_state::stop && state != graph_state::reset)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is already running or has ended");
 
-    /* Record a snapshot of graph start time */
-    if (!tiles.empty()) {
-        auto& tile = tiles.at(0);
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &startTime);
-    }
-
-    for (auto& tile : tiles) {
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_CoreEnable(aieArray->getDevInst(), coreTile);
-    }
+    pAIEConfigAPI->run();
 
     state = graph_state::running;
 }
@@ -185,26 +164,11 @@ run(int iterations)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not run graph");
-
+    
     if (state != graph_state::stop && state != graph_state::reset)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is already running or has ended");
 
-    for (auto& tile : tiles) {
-        XAie_LocType memTile = XAie_TileLoc(tile.itr_mem_col, tile.itr_mem_row);
-        XAie_DataMemWrWord(aieArray->getDevInst(), memTile, tile.itr_mem_addr, iterations);
-    }
-
-    /* Record a snapshot of graph start time */
-    if (!tiles.empty()) {
-        auto& tile = tiles.at(0);
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &startTime);
-    }
-
-    for (auto& tile : tiles) {
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_CoreEnable(aieArray->getDevInst(), coreTile);
-    }
+    pAIEConfigAPI->run(iterations);
 
     state = graph_state::running;
 }
@@ -215,7 +179,7 @@ wait_done(int timeout_ms)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not wait on graph");
-
+    
     if (state == graph_state::stop)
       return;
 
@@ -230,14 +194,14 @@ wait_done(int timeout_ms)
      */
     while (1) {
         uint8_t done;
-        for (auto& tile : tiles) {
+        for (int i = 0; i < graph_config.coreColumns.size(); i++){
             /* Skip multi-rate core */
-            if (tile.is_trigger) {
+            if (graph_config.triggered[i]) {
                 done = 1;
                 continue;
             }
 
-            XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+            XAie_LocType coreTile = XAie_TileLoc(graph_config.coreColumns[i], graph_config.coreRows[i] + adf::config_manager::s_num_reserved_rows + 1);
             XAie_CoreReadDoneBit(aieArray->getDevInst(), coreTile, &done);
             if (!done)
                 break;
@@ -245,11 +209,11 @@ wait_done(int timeout_ms)
 
         if (done) {
             state = graph_state::stop;
-            for (auto& tile : tiles) {
-                if (tile.is_trigger)
+            for (int i = 0; i < graph_config.coreColumns.size(); i++){
+                if (graph_config.triggered[i])
                     continue;
 
-                XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+                XAie_LocType coreTile = XAie_TileLoc(graph_config.coreColumns[i], graph_config.coreRows[i] + adf::config_manager::s_num_reserved_rows + 1);
                 XAie_CoreDisable(aieArray->getDevInst(), coreTile);
             }
             return;
@@ -269,25 +233,14 @@ wait()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not wait on graph");
-
+    
     if (state == graph_state::stop)
         return;
 
     if (state != graph_state::running)
         throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running, cannot wait");
 
-    for (auto& tile : tiles) {
-        if (tile.is_trigger)
-            continue;
-
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        while (1) {
-            if (XAie_CoreWaitForDone(aieArray->getDevInst(), coreTile, 0) == XAIE_OK)
-                break;
-        }
-
-        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
-    }
+    pAIEConfigAPI->wait();
 
     state = graph_state::stop;
 }
@@ -298,31 +251,14 @@ wait(uint64_t cycle)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not wait on graph");
-
+    
     if (state == graph_state::suspend)
         return;
 
     if (state != graph_state::running)
         throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running, cannot wait");
 
-    // Adjust the cycle-timeout value
-    if (!tiles.empty()) {
-        auto& tile = tiles.at(0);
-
-        uint64_t elapsed_time;
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &elapsed_time);
-        elapsed_time -= startTime;
-
-        if (cycle > elapsed_time)
-            XAie_WaitCycles(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, (cycle - elapsed_time));
-    }
-
-    for (auto& tile : tiles)
-    {
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
-    }
+    pAIEConfigAPI->wait(cycle);
 
     state = graph_state::suspend;
 }
@@ -333,12 +269,12 @@ suspend()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not suspend graph");
-
+    
     if (state != graph_state::running)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running, cannot suspend");
 
-    for (auto& tile : tiles) {
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
+    for (int i = 0; i < graph_config.coreColumns.size(); i++) {
+        XAie_LocType coreTile = XAie_TileLoc(graph_config.coreColumns[i], graph_config.coreRows[i] + adf::config_manager::s_num_reserved_rows + 1);
         XAie_CoreDisable(aieArray->getDevInst(), coreTile);
     }
 
@@ -351,28 +287,11 @@ resume()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not resume on graph");
-
+    
     if (state != graph_state::suspend)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not suspended (wait(cycle)), cannot resume");
 
-    if (!tiles.empty()) {
-        auto& tile = tiles.at(0);
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_ReadTimer(aieArray->getDevInst(), coreTile, XAIE_CORE_MOD, &startTime);
-    }
-
-    for (auto& tile : tiles) {
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-
-        /*
-         * We only resume the core that is not in done status.
-         * XAIE_ENABLE will clear Core_Done status bit.
-         */
-        uint8_t done;
-        XAie_CoreReadDoneBit(aieArray->getDevInst(), coreTile, &done);
-        if (!done)
-            XAie_CoreEnable(aieArray->getDevInst(), coreTile);
-    }
+    pAIEConfigAPI->resume();
 
     state = graph_state::running;
 }
@@ -383,32 +302,11 @@ end()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not end graph");
-
+    
     if (state != graph_state::running && state != graph_state::stop)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running or stop, cannot end");
 
-    /* Wait for graph done first. The state will be set to stop */
-    if (state == graph_state::running)
-        wait();
-
-    for (auto& tile : tiles) {
-        if (tile.is_trigger)
-            continue;
-
-        /* Set sync buf to trigger the end procedure */
-        XAie_LocType memTile = XAie_TileLoc(tile.itr_mem_col, tile.itr_mem_row);
-        XAie_DataMemWrWord(aieArray->getDevInst(), memTile, tile.itr_mem_addr - 4, (u32)1);
-
-        XAie_LocType coreTile = XAie_TileLoc(tile.col, tile.row);
-        XAie_CoreEnable(aieArray->getDevInst(), coreTile);
-
-        while (1) {
-            if (XAie_CoreWaitForDone(aieArray->getDevInst(), coreTile, 0) == XAIE_OK)
-                break;
-        }
-
-        XAie_CoreDisable(aieArray->getDevInst(), coreTile);
-    }
+    pAIEConfigAPI->end();
 
     state = graph_state::end;
 }
@@ -419,28 +317,15 @@ end(uint64_t cycle)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not end graph");
-
+    
     if (state != graph_state::running && state != graph_state::suspend)
         throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running or suspended, cannot end(cycle_timeout)");
 
-    /* Wait(cycle) will suspend graph. */
-    if (state == graph_state::running)
-        wait(cycle);
-
-    for (auto& tile : tiles) {
-        /* Set sync buf to trigger the end procedure */
-        XAie_LocType memTile = XAie_TileLoc(tile.itr_mem_col, tile.itr_mem_row);
-        XAie_DataMemWrWord(aieArray->getDevInst(), memTile, tile.itr_mem_addr - 4, (u32)1);
-    }
+    pAIEConfigAPI->end(cycle);
 
     state = graph_state::end;
 }
 
-#define LOCK_TIMEOUT 0x7FFFFFFF
-#define ACQ_WRITE    0
-#define ACQ_READ     1
-#define REL_READ     1
-#define REL_WRITE    0
 
 void
 graph_type::
@@ -450,83 +335,14 @@ update_rtp(const std::string& port, const char* buffer, size_t size)
     if (it == rtps.end())
       throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP port '" + port + "' not found");
     auto& rtp = it->second;
-
-    if (access_mode == xrt::graph::access_mode::shared && !rtp.is_async)
+    
+    if (access_mode == xrt::graph::access_mode::shared && !rtp.isAsync)
         throw xrt_core::error(-EPERM, "Shared context can not update sync RTP");
-
-    if (rtp.is_plrtp)
+    
+    if (rtp.isPL)
       throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP port '" + port + "' is not AIE RTP");
-
-    if (!rtp.is_input)
-      throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP port '" + port + "' is not input");
-
-    /* If RTP port is connected, only support async update */
-    if (rtp.is_connected) {
-        if (rtp.is_async && state == graph_state::running)
-            throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': updating connected async RTP '" + port + "' is not supported while graph is running");
-        if (!rtp.is_async)
-            throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': updating connected sync RTP '" + port + "' is not supported");
-    }
-
-    /* Don't acquire selector lock for async RTP while graph is not running */
-    bool need_lock = rtp.require_lock && (
-        rtp.is_async && state == graph_state::running ||
-        !rtp.is_async
-	);
-
-    XAie_LocType selector_tile = XAie_TileLoc(rtp.selector_col, rtp.selector_row);
-    XAie_Lock selector_lock = XAie_LockInit(rtp.selector_lock_id, (rtp.is_async ? 0xFF : ACQ_WRITE));
-
-    if (need_lock) {
-        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't update graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
-    }
-
-    uint32_t selector;
-    XAie_DataMemBlockRead(aieArray->getDevInst(), selector_tile, rtp.selector_addr, &selector, sizeof(selector));
-
-    selector = 1 - selector;
-
-    XAie_LocType update_tile;
-    uint16_t lock_id;
-    uint64_t start_addr;
-    if (selector == 1) {
-        /* update pong buffer */
-        update_tile = XAie_TileLoc(rtp.pong_col, rtp.pong_row);
-        lock_id = rtp.pong_lock_id;
-        start_addr = rtp.pong_addr;
-    } else {
-        /* update ping buffer */
-        update_tile = XAie_TileLoc(rtp.ping_col, rtp.ping_row);
-        lock_id = rtp.ping_lock_id;
-        start_addr = rtp.ping_addr;
-    }
-
-    XAie_Lock update_lock = XAie_LockInit(lock_id, (rtp.is_async ? 0xFF : ACQ_WRITE));
-    if (need_lock) {
-        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't update graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
-    }
-
-    XAie_DataMemBlockWrite(aieArray->getDevInst(), update_tile, start_addr, const_cast<char *>(buffer), size);
-
-    /* update selector */
-    XAie_DataMemBlockWrite(aieArray->getDevInst(), selector_tile, rtp.selector_addr, &selector, sizeof(selector));
-
-    if (rtp.require_lock) {
-        /* release lock, need to release lock even graph is not running */
-        selector_lock = XAie_LockInit(rtp.selector_lock_id, REL_READ);
-        uint8_t rc = XAie_LockRelease(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't update graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
-
-        update_lock = XAie_LockInit(lock_id, REL_READ);
-        rc = XAie_LockRelease(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't update graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
-    }
+    
+    pAIEConfigAPI->update(&rtp, (const void*)buffer, size);
 }
 
 void
@@ -538,71 +354,10 @@ read_rtp(const std::string& port, char* buffer, size_t size)
       throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': RTP port '" + port + "' not found");
     auto& rtp = it->second;
 
-    if (rtp.is_plrtp)
+    if (rtp.isPL)
       throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': RTP port '" + port + "' is not AIE RTP");
-
-    if (rtp.is_input)
-      throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': RTP port '" + port + "' is input");
-
-    /* If RTP port is connected, only support async update */
-    if (rtp.is_connected)
-      throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': reading connected RTP port '" + port + "' is not supported");
-
-    /* Don't acquire selector lock for async RTP while graph is not running */
-    bool need_lock = rtp.require_lock && (
-        rtp.is_async && state == graph_state::running ||
-        !rtp.is_async
-        );
-
-    XAie_LocType selector_tile = XAie_TileLoc(rtp.selector_col, rtp.selector_row);
-    XAie_Lock selector_lock = XAie_LockInit(rtp.selector_lock_id, ACQ_READ);
-
-    if (need_lock) {
-        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't read graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
-    }
-
-    uint32_t selector;
-    XAie_DataMemBlockRead(aieArray->getDevInst(), selector_tile, rtp.selector_addr, &selector, sizeof(selector));
-
-    XAie_LocType update_tile;
-    uint16_t lock_id;
-    uint64_t start_addr;
-    if (selector == 1) {
-        /* update pong buffer */
-        update_tile = XAie_TileLoc(rtp.pong_col, rtp.pong_row);
-        lock_id = rtp.pong_lock_id;
-        start_addr = rtp.pong_addr;
-    } else {
-        /* update ping buffer */
-        update_tile = XAie_TileLoc(rtp.ping_col, rtp.ping_row);
-        lock_id = rtp.ping_lock_id;
-        start_addr = rtp.ping_addr;
-    }
-
-    XAie_Lock update_lock = XAie_LockInit(lock_id, ACQ_READ);
-    if (need_lock) {
-        AieRC rc = XAie_LockAcquire(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't read graph '" + name + "': acquire lock for RTP '" + port + "' failed or timeout");
-
-	/* sync RTP release lock for write, async RTP relase lock for read */
-        selector_lock = XAie_LockInit(rtp.selector_lock_id, (rtp.is_async ? REL_READ : REL_WRITE));
-        rc = XAie_LockRelease(aieArray->getDevInst(), selector_tile, selector_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't read graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
-    }
-
-    XAie_DataMemBlockRead(aieArray->getDevInst(), update_tile, start_addr, buffer, size);
-
-    if (need_lock) {
-        /* release lock */
-        update_lock = XAie_LockInit(lock_id, (rtp.is_async ? REL_READ : REL_WRITE));
-        AieRC rc = XAie_LockRelease(aieArray->getDevInst(), update_tile, update_lock, LOCK_TIMEOUT);
-        if (rc != XAIE_OK)
-            throw xrt_core::error(-EIO, "Can't read graph '" + name + "': release lock for RTP '" + port + "' failed or timeout");
-    }
+    
+    pAIEConfigAPI->read(&rtp, (void*)buffer, size);
 }
 
 } // zynqaie

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -73,13 +73,13 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t uuid, const std::
 #endif
     access_mode = am;
 
-    /* Initialize graph tile metadata */   
+    /* Initialize graph tile metadata */
     graph_config = xrt_core::edge::aie::get_graph(device.get(), name);
 
 
     /* Initialize graph rtp metadata */
     rtps = xrt_core::edge::aie::get_rtp(device.get(), graph_config.id);
-    
+
     pAIEConfigAPI = std::make_shared<adf::graph_api>(&graph_config);
     pAIEConfigAPI->configure();
 
@@ -149,7 +149,7 @@ run()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not run graph");
-    
+
     if (state != graph_state::stop && state != graph_state::reset)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is already running or has ended");
 
@@ -164,7 +164,7 @@ run(int iterations)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not run graph");
-    
+
     if (state != graph_state::stop && state != graph_state::reset)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is already running or has ended");
 
@@ -179,7 +179,7 @@ wait_done(int timeout_ms)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not wait on graph");
-    
+
     if (state == graph_state::stop)
       return;
 
@@ -233,7 +233,7 @@ wait()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not wait on graph");
-    
+
     if (state == graph_state::stop)
         return;
 
@@ -251,7 +251,7 @@ wait(uint64_t cycle)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not wait on graph");
-    
+
     if (state == graph_state::suspend)
         return;
 
@@ -269,7 +269,7 @@ suspend()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not suspend graph");
-    
+
     if (state != graph_state::running)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running, cannot suspend");
 
@@ -287,7 +287,7 @@ resume()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not resume on graph");
-    
+
     if (state != graph_state::suspend)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not suspended (wait(cycle)), cannot resume");
 
@@ -302,7 +302,7 @@ end()
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not end graph");
-    
+
     if (state != graph_state::running && state != graph_state::stop)
       throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running or stop, cannot end");
 
@@ -317,7 +317,7 @@ end(uint64_t cycle)
 {
     if (access_mode == xrt::graph::access_mode::shared)
         throw xrt_core::error(-EPERM, "Shared context can not end graph");
-    
+
     if (state != graph_state::running && state != graph_state::suspend)
         throw xrt_core::error(-EINVAL, "Graph '" + name + "' is not running or suspended, cannot end(cycle_timeout)");
 
@@ -335,13 +335,13 @@ update_rtp(const std::string& port, const char* buffer, size_t size)
     if (it == rtps.end())
       throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP port '" + port + "' not found");
     auto& rtp = it->second;
-    
+
     if (access_mode == xrt::graph::access_mode::shared && !rtp.isAsync)
         throw xrt_core::error(-EPERM, "Shared context can not update sync RTP");
-    
+
     if (rtp.isPL)
       throw xrt_core::error(-EINVAL, "Can't update graph '" + name + "': RTP port '" + port + "' is not AIE RTP");
-    
+
     pAIEConfigAPI->update(&rtp, (const void*)buffer, size);
 }
 
@@ -356,7 +356,7 @@ read_rtp(const std::string& port, char* buffer, size_t size)
 
     if (rtp.isPL)
       throw xrt_core::error(-EINVAL, "Can't read graph '" + name + "': RTP port '" + port + "' is not AIE RTP");
-    
+
     pAIEConfigAPI->read(&rtp, (void*)buffer, size);
 }
 

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -76,7 +76,6 @@ graph_type(std::shared_ptr<xrt_core::device> dev, const uuid_t uuid, const std::
     /* Initialize graph tile metadata */
     graph_config = xrt_core::edge::aie::get_graph(device.get(), name);
 
-
     /* Initialize graph rtp metadata */
     rtps = xrt_core::edge::aie::get_rtp(device.get(), graph_config.id);
 

--- a/src/runtime_src/core/edge/user/aie/graph.h
+++ b/src/runtime_src/core/edge/user/aie/graph.h
@@ -24,6 +24,8 @@
 #include "core/edge/common/aie_parser.h"
 #include "core/common/device.h"
 #include "experimental/xrt_graph.h"
+#include "common_layer/adf_api_config.h"
+#include "common_layer/adf_runtime_api.h"
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -35,9 +37,6 @@ namespace zynqaie {
 class graph_type
 {
 public:
-    using tile_type = xrt_core::edge::aie::tile_type;
-    using rtp_type = xrt_core::edge::aie::rtp_type;
-
     graph_type(std::shared_ptr<xrt_core::device> device, const uuid_t xclbin_uuid, const std::string& name, xrt::graph::access_mode);
     ~graph_type();
 
@@ -107,7 +106,6 @@ private:
     int id;
     graph_state state;
     std::string name;
-    uint64_t startTime;
     xrt::graph::access_mode access_mode;
 
     /**
@@ -122,10 +120,10 @@ private:
      * A tile is represented by a pair of number <col, row>
      * It represents the tile position in the AIE array.
      */
-    std::vector<tile_type> tiles;
-
+    adf::graph_config graph_config;
+    std::shared_ptr<adf::graph_api> pAIEConfigAPI;
     /* This is the collections of rtps that are used. */
-    std::unordered_map<std::string, rtp_type> rtps;
+    std::unordered_map<std::string, adf::rtp_config> rtps;
 };
 
 }


### PR DESCRIPTION
This pull request is for VITIS-1309 and VITIS-1308. The objective is to refactor graph API code (for graph, gmio, profiling, and event tracing) in cardano side and in XRT side so both tools can share the same code that is used by adf graph API (for linux hw through XRT, for hw_emu through XRT, for aiesim through cardano, and for bare metal through cardano). With this refactoring, any fixes, improvements, and new features from cardano side can be easily made available to XRT. The scope of this work is within the XRT AIE API functions that are used by adf graph API and the metadata parser to share the common metadata structure. There is no change in XRT user API and no change in PL API.

The changes in this pull request cover graph and gmio API. Profiling and event tracing will be handled in the next pull request.

The common code is in core/edge/user/aie/common_layer. The changed files are edge/common/aie_parser.h(.cpp), edge/user/aie/aie.h(.cpp) and edge/user/aie/graph.h(.cpp).

DSV team tested a rpm from this change.

Note:
1. In aie_parser.h, there is a temporary function get_old_gmios that returns the old metadata structure for profiling purpose. This will be cleaned up in the next pull request when we make the common profiling code ready using the new AIE driver resource manager.
2. The temporary AIEResource.h(.cpp) from previous release will be cleaned up in the next pull request because we will use the new AIE driver resource manager.
3. edge/user/aie/common_layer/adf_api_message.h is for XRT to custom error, debug, and info messages. For now, error message connects to xrt_core::error.