### PR TITLE
Use new protobuf API instead of deprecated one

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -175,9 +175,17 @@ namespace xclcpuemhal2 {
     mCore = nullptr;
     mSWSch = nullptr;
 
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    ci_buf = malloc(ci_msg.ByteSize());
+#else
     ci_buf = malloc(ci_msg.ByteSizeLong());
+#endif
     ri_msg.set_size(0);
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    ri_buf = malloc(ri_msg.ByteSize());
+#else
     ri_buf = malloc(ri_msg.ByteSizeLong());
+#endif
     buf = nullptr;
     buf_size = 0;
 

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -175,9 +175,9 @@ namespace xclcpuemhal2 {
     mCore = nullptr;
     mSWSch = nullptr;
 
-    ci_buf = malloc(ci_msg.ByteSize());
+    ci_buf = malloc(ci_msg.ByteSizeLong());
     ri_msg.set_size(0);
-    ri_buf = malloc(ri_msg.ByteSize());
+    ri_buf = malloc(ri_msg.ByteSizeLong());
     buf = nullptr;
     buf_size = 0;
 

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -32,22 +32,22 @@ mtx.unlock();
     AQUIRE_MUTEX()
 
 #define SERIALIZE_AND_SEND_MSG(func_name)\
-     unsigned c_len = c_msg.ByteSize(); \
+     unsigned c_len = c_msg.ByteSizeLong(); \
     buf_size = alloc_void(c_len); \
     bool rv = c_msg.SerializeToArray(buf,c_len); \
     if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
     \
     ci_msg.set_size(c_len); \
     ci_msg.set_xcl_api(func_name##_n); \
-    unsigned ci_len = ci_msg.ByteSize(); \
+    unsigned ci_len = ci_msg.ByteSizeLong(); \
     rv = ci_msg.SerializeToArray(ci_buf,ci_len); \
     if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
     \
     _s_inst->sk_write(ci_buf,ci_len); \
     _s_inst->sk_write(buf,c_len); \
     \
-    _s_inst->sk_read(ri_buf,ri_msg.ByteSize()); \
-    rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSize()); \
+    _s_inst->sk_read(ri_buf,ri_msg.ByteSizeLong()); \
+    rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSizeLong()); \
     assert(true == rv);\
     buf_size = alloc_void(ri_msg.size()); \
     _s_inst->sk_read(buf,ri_msg.size()); \

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -32,14 +32,14 @@ mtx.unlock();
     AQUIRE_MUTEX()
 
 #define SERIALIZE_AND_SEND_MSG(func_name)\
-     unsigned c_len = c_msg.ByteSizeLong(); \
+    auto c_len = c_msg.ByteSizeLong(); \
     buf_size = alloc_void(c_len); \
     bool rv = c_msg.SerializeToArray(buf,c_len); \
     if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
     \
     ci_msg.set_size(c_len); \
     ci_msg.set_xcl_api(func_name##_n); \
-    unsigned ci_len = ci_msg.ByteSizeLong(); \
+    auto ci_len = ci_msg.ByteSizeLong(); \
     rv = ci_msg.SerializeToArray(ci_buf,ci_len); \
     if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
     \

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -31,28 +31,55 @@ mtx.unlock();
     func_name##_response r_msg; \
     AQUIRE_MUTEX()
 
-#define SERIALIZE_AND_SEND_MSG(func_name)\
-    auto c_len = c_msg.ByteSizeLong(); \
-    buf_size = alloc_void(c_len); \
-    bool rv = c_msg.SerializeToArray(buf,c_len); \
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+// Use the deprecated 32 bit version of the size
+#define SERIALIZE_AND_SEND_MSG(func_name)                               \
+    auto c_len = c_msg.ByteSize();                                      \
+    buf_size = alloc_void(c_len);                                       \
+    bool rv = c_msg.SerializeToArray(buf,c_len);                        \
     if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
-    \
-    ci_msg.set_size(c_len); \
-    ci_msg.set_xcl_api(func_name##_n); \
-    auto ci_len = ci_msg.ByteSizeLong(); \
-    rv = ci_msg.SerializeToArray(ci_buf,ci_len); \
+                                                                        \
+    ci_msg.set_size(c_len);                                             \
+    ci_msg.set_xcl_api(func_name##_n);                                  \
+    auto ci_len = ci_msg.ByteSize();                                    \
+    rv = ci_msg.SerializeToArray(ci_buf,ci_len);                        \
     if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
-    \
-    _s_inst->sk_write(ci_buf,ci_len); \
-    _s_inst->sk_write(buf,c_len); \
-    \
-    _s_inst->sk_read(ri_buf,ri_msg.ByteSizeLong()); \
-    rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSizeLong()); \
-    assert(true == rv);\
-    buf_size = alloc_void(ri_msg.size()); \
-    _s_inst->sk_read(buf,ri_msg.size()); \
-    rv = r_msg.ParseFromArray(buf,ri_msg.size()); \
-    assert(true == rv);\
+                                                                        \
+    _s_inst->sk_write(ci_buf,ci_len);                                   \
+    _s_inst->sk_write(buf,c_len);                                       \
+                                                                        \
+    _s_inst->sk_read(ri_buf,ri_msg.ByteSize());                         \
+    rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSize());               \
+    assert(true == rv);                                                 \
+    buf_size = alloc_void(ri_msg.size());                               \
+    _s_inst->sk_read(buf,ri_msg.size());                                \
+    rv = r_msg.ParseFromArray(buf,ri_msg.size());                       \
+    assert(true == rv);
+#else
+// More recent protoc handles 64 bit size objects and the 32 bit version is deprecated
+#define SERIALIZE_AND_SEND_MSG(func_name)                               \
+    auto c_len = c_msg.ByteSizeLong();                                  \
+    buf_size = alloc_void(c_len);                                       \
+    bool rv = c_msg.SerializeToArray(buf,c_len);                        \
+    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
+                                                                        \
+    ci_msg.set_size(c_len);                                             \
+    ci_msg.set_xcl_api(func_name##_n);                                  \
+    auto ci_len = ci_msg.ByteSizeLong();                                \
+    rv = ci_msg.SerializeToArray(ci_buf,ci_len);                        \
+    if(rv == false){std::cerr<<"FATAL ERROR:protobuf SerializeToArray failed"<<std::endl;exit(1);} \
+                                                                        \
+    _s_inst->sk_write(ci_buf,ci_len);                                   \
+    _s_inst->sk_write(buf,c_len);                                       \
+                                                                        \
+    _s_inst->sk_read(ri_buf,ri_msg.ByteSizeLong());                     \
+    rv = ri_msg.ParseFromArray(ri_buf,ri_msg.ByteSizeLong());           \
+    assert(true == rv);                                                 \
+    buf_size = alloc_void(ri_msg.size());                               \
+    _s_inst->sk_read(buf,ri_msg.size());                                \
+    rv = r_msg.ParseFromArray(buf,ri_msg.size());                       \
+    assert(true == rv);
+#endif
 
 //RELEASE BUFFER MEMORIES
 #define FREE_BUFFERS() \

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -59,10 +59,10 @@ namespace xclcpuemhal2 {
     ci_msg.set_xcl_api(0);
     mCore = nullptr;
     mSWSch = nullptr;
-  
-    ci_buf = malloc(ci_msg.ByteSize());
+
+    ci_buf = malloc(ci_msg.ByteSizeLong());
     ri_msg.set_size(0);
-    ri_buf = malloc(ri_msg.ByteSize());
+    ri_buf = malloc(ri_msg.ByteSizeLong());
     buf = nullptr;
     buf_size = 0;
 

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -60,9 +60,17 @@ namespace xclcpuemhal2 {
     mCore = nullptr;
     mSWSch = nullptr;
 
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    ci_buf = malloc(ci_msg.ByteSize());
+#else
     ci_buf = malloc(ci_msg.ByteSizeLong());
+#endif
     ri_msg.set_size(0);
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    ri_buf = malloc(ri_msg.ByteSize());
+#else
     ri_buf = malloc(ri_msg.ByteSizeLong());
+#endif
     buf = nullptr;
     buf_size = 0;
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2053,9 +2053,17 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 
     ci_msg.set_size(0);
     ci_msg.set_xcl_api(0);
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    ci_buf = malloc(ci_msg.ByteSize());
+#else
     ci_buf = malloc(ci_msg.ByteSizeLong());
+#endif
     ri_msg.set_size(0);
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    ri_buf = malloc(ri_msg.ByteSize());
+#else
     ri_buf = malloc(ri_msg.ByteSizeLong());
+#endif
 
     buf = nullptr;
     buf_size = 0;
@@ -3807,8 +3815,13 @@ Q2H_helper :: Q2H_helper(xclhwemhal2::HwEmShim* _inst) {
     header->set_xcl_api(0);
     response_header->set_size(0);
     response_header->set_xcl_api(0);
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+    i_len           = header->ByteSize();
+    ri_len          = response_header->ByteSize();
+#else
     i_len           = header->ByteSizeLong();
     ri_len          = response_header->ByteSizeLong();
+#endif
 }
 Q2H_helper::~Q2H_helper() {
     delete Q2h_sock;
@@ -3846,7 +3859,11 @@ int Q2H_helper::poolingon_Qdma() {
         bool resp = inst->device2xrt_rd_trans_cb((unsigned long int)payload.addr(),(void* const)data.get(),(unsigned long int)payload.size());
         response_payload.set_valid(resp);
         response_payload.set_data((void*)data.get(),payload.size());
-        int r_len = response_payload.ByteSizeLong();
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+        auto r_len = response_payload.ByteSize();
+#else
+        auto r_len = response_payload.ByteSizeLong();
+#endif
         SEND_RESP2QDMA()
     }
     if (header->xcl_api() == xclQdma2HostWriteMem_n) {
@@ -3855,7 +3872,11 @@ int Q2H_helper::poolingon_Qdma() {
     	payload.ParseFromArray((void*)raw_payload.get(), r);
         bool resp = inst->device2xrt_wr_trans_cb((unsigned long int)payload.addr(),(void const*)payload.data().c_str(),(unsigned long int)payload.size());
         response_payload.set_valid(resp);
-        int r_len = response_payload.ByteSizeLong();
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+        auto r_len = response_payload.ByteSize();
+#else
+        auto r_len = response_payload.ByteSizeLong();
+#endif
         SEND_RESP2QDMA()
     }
     if (header->xcl_api() == xclQdma2HostInterrupt_n) {
@@ -3865,7 +3886,11 @@ int Q2H_helper::poolingon_Qdma() {
         uint32_t interrupt_line = payload.interrupt_line();
         bool resp = inst->device2xrt_irq_trans_cb(interrupt_line,4);
         response_payload.set_valid(resp);
-        int r_len = response_payload.ByteSizeLong();
+#if GOOGLE_PROTOBUF_VERSION < 3006001
+        auto r_len = response_payload.ByteSize();
+#else
+        auto r_len = response_payload.ByteSizeLong();
+#endif
         SEND_RESP2QDMA()
     }
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2053,9 +2053,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 
     ci_msg.set_size(0);
     ci_msg.set_xcl_api(0);
-    ci_buf = malloc(ci_msg.ByteSize());
+    ci_buf = malloc(ci_msg.ByteSizeLong());
     ri_msg.set_size(0);
-    ri_buf = malloc(ri_msg.ByteSize());
+    ri_buf = malloc(ri_msg.ByteSizeLong());
 
     buf = nullptr;
     buf_size = 0;
@@ -3807,8 +3807,8 @@ Q2H_helper :: Q2H_helper(xclhwemhal2::HwEmShim* _inst) {
     header->set_xcl_api(0);
     response_header->set_size(0);
     response_header->set_xcl_api(0);
-    i_len           = header->ByteSize();
-    ri_len          = response_header->ByteSize();
+    i_len           = header->ByteSizeLong();
+    ri_len          = response_header->ByteSizeLong();
 }
 Q2H_helper::~Q2H_helper() {
     delete Q2h_sock;
@@ -3846,7 +3846,7 @@ int Q2H_helper::poolingon_Qdma() {
         bool resp = inst->device2xrt_rd_trans_cb((unsigned long int)payload.addr(),(void* const)data.get(),(unsigned long int)payload.size());
         response_payload.set_valid(resp);
         response_payload.set_data((void*)data.get(),payload.size());
-        int r_len = response_payload.ByteSize();
+        int r_len = response_payload.ByteSizeLong();
         SEND_RESP2QDMA()
     }
     if (header->xcl_api() == xclQdma2HostWriteMem_n) {
@@ -3855,7 +3855,7 @@ int Q2H_helper::poolingon_Qdma() {
     	payload.ParseFromArray((void*)raw_payload.get(), r);
         bool resp = inst->device2xrt_wr_trans_cb((unsigned long int)payload.addr(),(void const*)payload.data().c_str(),(unsigned long int)payload.size());
         response_payload.set_valid(resp);
-        int r_len = response_payload.ByteSize();
+        int r_len = response_payload.ByteSizeLong();
         SEND_RESP2QDMA()
     }
     if (header->xcl_api() == xclQdma2HostInterrupt_n) {
@@ -3865,7 +3865,7 @@ int Q2H_helper::poolingon_Qdma() {
         uint32_t interrupt_line = payload.interrupt_line();
         bool resp = inst->device2xrt_irq_trans_cb(interrupt_line,4);
         response_payload.set_valid(resp);
-        int r_len = response_payload.ByteSize();
+        int r_len = response_payload.ByteSizeLong();
         SEND_RESP2QDMA()
     }
 


### PR DESCRIPTION
This fixes compilation failures like
```
  error: ‘int google::protobuf::MessageLite::ByteSize() const’ is deprecated: Please use ByteSizeLong() instead [-Werror=deprecated-declarations]
```
This should fix https://github.com/Xilinx/XRT/issues/4131