### PR TITLE
CR-1091258 U200 Crash: return code None

### DIFF
--- a/src/runtime_src/xrt/scheduler/kds.cpp
+++ b/src/runtime_src/xrt/scheduler/kds.cpp
@@ -163,7 +163,7 @@ monitor_loop(const xrt_xocl::device* device)
         return;
 
       // Finer wait
-      while (device->exec_wait(1000)==0) ;
+      // while (submitted_cmds.empty() && device->exec_wait(1000)==0) ;
 
       std::lock_guard<std::mutex> lk(s_mutex);
       auto end = submitted_cmds.end();


### PR DESCRIPTION
Hang in execwait similar to what was fixed in #4878.  On this branch
the fix is less intrusive and just removes the exec_wait call for
scheduled KDMA execbuf.

Eliminating the exec_wait implies busy wait for KDMA completion, which
is not a problem given that the old execution monitor is used only for
KDMA right now.  In 2021.1 the old execution monitor can be completely
eliminated.