### PR TITLE
xclbinutil: Fixed encoding bug where a 32-bit and 64-bit byte storage count was incorrect.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/CBOR.cxx
+++ b/src/runtime_src/tools/xclbinutil/CBOR.cxx
@@ -55,7 +55,7 @@ std::string
 XclBinUtilities::encode_major_type(const MajorTypes majorType,
                                    const uint64_t count) 
 {
-  XUtil::TRACE((boost::format("CBOR: [Encode] %s(%d), Count: %d") % enum_to_string(majorType) % static_cast<uint8_t>(majorType) % count).str());
+  XUtil::TRACE((boost::format("CBOR: [Encode] %s(%d), Count: %d") % enum_to_string(majorType) % static_cast<unsigned int>(majorType) % count).str());
 
   // This method doesn't support Primitive types
   if (majorType == MajorTypes::primitives)
@@ -73,25 +73,25 @@ XclBinUtilities::encode_major_type(const MajorTypes majorType,
   if (count <= MAX_TINY_SIZE) {                              // -- Encode Tiny (bits 5 - 1)
     byte_array[0] |= static_cast<uint8_t>(count & 0x1F);
   } else {                                                  // -- Byte encoding
-    uint8_t num_bytes = 8;        // Assume 64 bits
+    uint8_t num_bytes = 3;         // Assume 64 bits
 
     if (count <= 0xffffffff)       // Less than 32 bits
-      num_bytes = 4;
-
-    if (count <= 0xffff)           // Less than 16 bits
       num_bytes = 2;
 
-    if (count <= 0xff)             // Less than 8 bits
+    if (count <= 0xffff)           // Less than 16 bits
       num_bytes = 1;
+
+    if (count <= 0xff)             // Less than 8 bits
+      num_bytes = 0;
 
     // Encode extended payload flags (bits 5 & 4)
     byte_array[0] |= 0x18;
 
     // Encode extended payload size
-    byte_array[0] |= (num_bytes - 1);
+    byte_array[0] |= num_bytes;
 
     // Encode the count size (big endian)
-    for (uint8_t shiftCount = num_bytes; shiftCount != 0; shiftCount--)
+    for (uint8_t shiftCount = 1 << num_bytes; shiftCount != 0; shiftCount--)
       byte_array.push_back(static_cast<uint8_t>((count >> ((shiftCount - 1) * 8)) & 0xff));
   }
 

--- a/src/runtime_src/tools/xclbinutil/unittests/SmartNic/smartnic_all_syntax.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/SmartNic/smartnic_all_syntax.json
@@ -69,7 +69,7 @@
                 ],
                 "address_mapping": {
                     "offset": "1024",
-                    "aperture_size_bytes": "1024"
+                    "aperture_size_bytes": "8388608"
                 },
                 "setup": {
                     "ebpf": "0BDFF1DE05A94A6FB5739B8E6CB034A1B9AFE8A4F05147B3AC9F763A60A500C7"


### PR DESCRIPTION
Work Done
------------
+ Fix original bug
+ Validated fix against external CBOR tools
+ Updated unit tests to validate correctness
+ Fix TRACE reporting issue