### PR TITLE
CR-1091373 xbmgmt program succeeded update SC but it report No cards were flashed

### DIFF
--- a/src/runtime_src/tools/scripts/_scflash.py
+++ b/src/runtime_src/tools/scripts/_scflash.py
@@ -118,6 +118,7 @@ def run_xbmgmt(cmdline):
         print(out.decode("utf-8"))
     if err:
         print(err.decode("utf-8"))
+    return p.returncode
 
 #do pcie node remove and rescan
 def run_pcie(cmdline):
@@ -206,9 +207,13 @@ def main():
             run_pcie("echo 2 > " + os.path.join(rootDir, buddy_user, "shutdown"))
         #2
         print("sc flash...")
-        run_xbmgmt([xbmgmt, "flash", "--sc_firmware", "--path", args.path, "--card", mgmt, "--no_cardlevel"])
+        retcode = run_xbmgmt([xbmgmt, "flash", "--sc_firmware", "--path", args.path, "--card", mgmt, "--no_cardlevel"])
+        return retcode
     except Exception as e:
         print(e)
 
 if __name__ == "__main__":
-    main()
+    if main() == 0:
+        print("SC flash PASSED")
+        exit(0)
+    exit(1)


### PR DESCRIPTION
Fixed return codes and std::cout so that "Process.h" can determine if the sc flash passed or failed. This will prevent us from spitting out false SC flash failed messages.

_Note: Our "Process" and "ProgressBar" are not very flexible and are designed to run xbutil validate test cases. We need to make them more generic. That will require a lot of work, testing and is high risk. This PR is a low-risk change for u30 which enhances user experience immensely_ 

Output:
```
----------------------------------------------------
Device : [0000:17:00.0]

Current Configuration
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3
  Platform ID          : 0xbdb6119bac58c962


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/bdb6119bac58c96210629de857a4ce00
  Size                 : 63,400,627 bytes
  Timestamp            : Thu Mar  4 12:07:59 2021

  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform ID          : 0xbdb6119bac58c962
----------------------------------------------------
Actions to perform:
  [0000:17:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: y

Updating SC firmware on card[0000:17:00.0]
[0000:17:00.0] : Updating shell
FLASH dsabin supports only primary bitstream: /lib/firmware/xilinx/bdb6119bac58c96210629de857a4ce00/partition.xsabin
INFO: ***BOOT.BIN has 62973016 bytes
[PASSED] : Flash erased < 1m 45s >
[PASSED] : Flash programmed < 1m 11s >
[PASSED] : Flash verified < 26s >
INFO     : Shell is updated successfully.
----------------------------------------------------
Report
  [0000:17:00.0] : Successfully flashed

1 Card(s) flashed successfully.
****************************************************
Cold reboot machine to load the new image on card(s).
****************************************************
```
