### PR TITLE
fix xocl build on 5.9.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
     env:
       - CONFIGURATION=linux/ppc64le
 
-  - os: linux
-    arch: arm64
-    dist: bionic
-    env:
-      - CONFIGURATION=linux/arm64
+#  - os: linux
+#    arch: arm64
+#    dist: bionic
+#    env:
+#      - CONFIGURATION=linux/arm64
 
   - os: linux
     arch: amd64

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -98,10 +98,14 @@
 	#define XOCL_USEC tv_usec
 #endif
 
-/* drm_gem_object_put_unlocked and drm_gem_object_get were introduced with Linux
- * 4.12 and backported to Red Hat 7.5.
+/*
+ * drm_gem_object_put_unlocked and drm_gem_object_get were introduced with Linux
+ * 4.12 and backported to Red Hat 7.5. drm_gem_object_put_unlocked is gone since 5.9.
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put
+	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 	#define XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED drm_gem_object_put_unlocked
 	#define XOCL_DRM_GEM_OBJECT_GET drm_gem_object_get
 #elif defined(RHEL_RELEASE_CODE)


### PR DESCRIPTION
This is a regression introduced by https://github.com/Xilinx/XRT/pull/4794.
Also disable ARM build on Travis CI since it does not work any more.