### PR TITLE
xbmgmt2 xmc cleanup

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -171,6 +171,7 @@ enum class key_type
   mac_addr_first,
   mac_addr_list,
   oem_id,
+  xmc_board_info,
 
   firewall_detect_level,
   firewall_status,
@@ -1845,6 +1846,15 @@ struct oem_id : request
   using result_type = std::string;
   static const key_type key = key_type::oem_id;
   static const char* name() { return "oem_id"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct xmc_board_info : request
+{
+  using result_type = std::vector<char>;
+  static const key_type key = key_type::xmc_board_info;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -517,6 +517,7 @@ initialize_query_table()
   emplace_sysfs_get<query::mac_contiguous_num>                 ("xmc", "mac_contiguous_num");
   emplace_sysfs_get<query::mac_addr_first>                     ("xmc", "mac_addr_first");
   emplace_sysfs_get<query::oem_id>                             ("xmc", "xmc_oem_id");
+  emplace_sysfs_get<query::xmc_board_info>                     ("xmc", "board_info_raw");
   emplace_func0_request<query::xmc_qspi_status,                qspi_status>();
   emplace_func0_request<query::mac_addr_list,                  mac_addr_list>();
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -159,7 +159,7 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
 
 int Flasher::upgradeBMCFirmware(firmwareImage* bmc)
 {
-    XMC_Flasher flasher(m_device->get_device_id());
+    xrt_tools::XMC_Flasher flasher(m_device->get_device_id());
     const std::string e = flasher.probingErrMsg();
 
     if (!e.empty())
@@ -192,7 +192,7 @@ std::string int2PowerString(unsigned int lvl)
 int Flasher::getBoardInfo(BoardInfo& board)
 {
     std::map<char, std::vector<char>> info;
-    XMC_Flasher flasher(m_device->get_device_id());
+    xrt_tools::XMC_Flasher flasher(m_device->get_device_id());
 
     if (!flasher.probingErrMsg().empty())
     {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -1,11 +1,11 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
  * License is located at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -13,105 +13,267 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-#include <iostream>
-#include <algorithm>
-#include <cstring>
-#include <cassert>
-#include <vector>
-#include <thread>
-#include <iomanip>
-#include <locale>
-
-#include "xmc.h"
-#include "flasher.h"
-#include "core/common/utils.h"
-#include "core/common/system.h"
-#include "core/common/device.h"
-#include "core/common/error.h"
-#include "core/common/query_requests.h"
-#include "core/tools/common/XBUtilities.h"
-#include "core/tools/common/ProgressBar.h"
-namespace XBU = XBUtilities;
-#include "boost/format.hpp"
-
-static std::map<int, std::string> scStatusMap = {
-        {0, "NOT READY"},
-        {1, "READY"},
-        {2, "BSL_UNSYNCED"},
-        {3, "BSL_SYNCED"},
-        {4, "BSL_SYNCED_SC_NOT_UPGRADABLE"},
-        {5, "READY_SC_NOT_UPGRADABLE"},
- 
-};
-
-static std::map<int, std::string> cmcStatusMap = {
-        {0, "NOT READY"},
-        {1, "READY"},
-        {2, "STOPPED"},
-        {4, "PAUSED"},
-};
-
-//#define XMC_DEBUG
-#define BMC_JUMP_ADDR   0x201  /* Hard-coded for now */
-
+// ------ I N C L U D E   F I L E S -------------------------------------------
 #ifdef __GNUC__
-# define XMC_UNUSED __attribute__((unused))
+#define XMC_UNUSED __attribute__((unused))
 #else
-# define XMC_UNUSED
+#define XMC_UNUSED
 #endif
 
 #ifdef _WIN32
-# pragma warning( disable : 4189 4100 4996)
+#pragma warning(disable : 4189 4100 4996)
 #endif
+
+// Local - Include Files
+#include "xmc.h"
+#include "flasher.h"
+#include "core/common/utils.h"
+#include "core/common/device.h"
+#include "core/common/query_requests.h"
+#include "core/tools/common/XBUtilities.h"
+#include "core/tools/common/ProgressBar.h"
+
+// 3rd Party Library - Include Files
+#include "boost/format.hpp"
+
+// System - Include Files
+#include <thread>
+#include <fcntl.h>
+
+// ------ S T A T I C   V A R I A B L E S -------------------------------------
+//#define XMC_DEBUG
+static const int bmc_jump_address = 0x201; /* Hard-coded for now */
+
+// ------ S T A T I C   F U N C T I O N S -------------------------------------
+static std::map<int, std::string> scStatusMap = {
+  {0, "NOT READY"},
+  {1, "READY"},
+  {2, "BSL_UNSYNCED"},
+  {3, "BSL_SYNCED"},
+  {4, "BSL_SYNCED_SC_NOT_UPGRADABLE"},
+  {5, "READY_SC_NOT_UPGRADABLE"},
+};
+
+static std::map<int, std::string> cmcStatusMap = {
+  {0, "NOT READY"},
+  {1, "READY"},
+  {2, "STOPPED"},
+  {4, "PAUSED"},
+};
+
+static std::string getStatus(int status, std::map<int, std::string> &map)
+{
+  auto entry = map.find(status);
+  std::ostringstream os;
+
+  os << std::hex << status;
+
+  if (entry != map.end())
+    os << "(" << entry->second << ")";
+
+  return os.str();
+}
+
+static void tiTxtStreamToBin(std::istream& tiTxtStream,
+    unsigned int& currentAddr, std::vector<unsigned char>& buf)
+{
+  // offset to write to XMC device to set SC jump address.
+  const unsigned int jumpOffset = 0xffffffff;
+  // SC jump address is hard-coded.
+  const unsigned int jumpAddr = 0x201;
+  bool sectionEnd = false;
+
+  buf.clear();
+
+  while (!sectionEnd) {
+    std::string line;
+    std::string sectionEndChar("@qQ"); // any char will mark end of section
+
+    // Check if we're done with current section.
+    char nextChar = static_cast<unsigned char>(tiTxtStream.peek());
+    sectionEnd = (
+        (sectionEndChar.find(nextChar) != std::string::npos && !buf.empty())
+        || (nextChar == EOF));
+    if (sectionEnd)
+        break;
+
+    // Skip empty lines.
+    std::getline(tiTxtStream, line);
+    if (line.size() == 0)
+        continue;
+
+    switch (line[0]) {
+    case '@':
+      // Address line
+      try {
+          currentAddr = std::stoi(line.substr(1), NULL, 16);
+      } catch (...){
+          std::cout << "ERROR: Invalid address " << line.substr(1) << ". No action taken" << std::endl;
+          return;
+      }
+      break;
+    case 'q':
+    case 'Q':
+    {
+      // End of image, return jump section.
+      currentAddr = jumpOffset;
+      auto *tmp = reinterpret_cast<const unsigned char *>(&jumpAddr);
+      for (unsigned int i = 0; i < sizeof(jumpAddr); i++)
+          buf.push_back(tmp[i]);
+      sectionEnd = true;
+      break;
+    }
+    default:
+      // Data line
+      std::stringstream ss(line);
+      std::string token;
+      unsigned char int_token;
+      while (std::getline(ss, token, ' ')) {
+        try {
+          int_token = static_cast<unsigned char>(std::stoi(token, NULL, 16));
+        } catch (...) {
+          std::cout << "ERROR: Invalid address " << token << ". No action taken" << std::endl;
+          return;
+        }
+        buf.push_back(int_token);
+      }
+      break;
+    }
+    }
+}
+
+static int writeImage(std::FILE *xmcDev,
+    unsigned int addr, std::vector<unsigned char>& buf)
+{
+  int ret = 0;
+  size_t len = 0;
+  const size_t max_write = 4050; // Max size per write
+
+  ret = std::fseek(xmcDev, addr, SEEK_SET);
+  if (ret)
+    return ret;
+
+  // Write SC image to xmc and print '.' for each write as progress indicator
+  for (size_t i = 0; ret == 0 && i < buf.size(); i += len) {
+    len = std::min(max_write, buf.size() - i);
+
+    std::cout << "." << std::flush;
+
+    std::size_t s = std::fwrite(buf.data() + i, 1, len, xmcDev);
+    if (s != len)
+      ret = -ferror(xmcDev);
+    if (std::fflush(xmcDev))
+      ret = -ferror(xmcDev);
+  }
+  return ret;
+}
+
+namespace xrt_tools {
+
+// ------ M E M B E R   F U N C T I O N S -------------------------------------
+int XMC_Flasher::xmc_mode()
+{
+  return readReg(static_cast<unsigned int>(xmc_reg_offset::status)) & 0x3;
+}
+
+int XMC_Flasher::bmc_mode()
+{
+  return readReg(static_cast<unsigned int>(xmc_reg_offset::status)) >> 28;
+}
 
 XMC_Flasher::XMC_Flasher(unsigned int device_index)
   : m_device(xrt_core::get_mgmtpf_device(device_index))
 {
-    uint64_t val = 0;
-    mPktBufOffset = 0;
-    mPkt = {};
+  uint64_t val = 0;
+  mPktBufOffset = 0;
+  mPkt = {};
 
-    std::string err;
-    bool is_mfg = false;
-    is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(m_device);
-    if (!is_mfg) {
-        try {
-            val = xrt_core::device_query<xrt_core::query::xmc_status>(m_device);
-        }
-        catch (...) { return; }
-        if (!(val & 1)) {
-            mProbingErrMsg << "Failed to detect XMC, xmc.bin not loaded";
-            return;
-        }
+  /*
+   * If xmc subdev is not online, do not allow xmc flash operations.  In the
+   * future, we will use xmc subdev to do xmc validation and flashing at one
+   * place.
+   *
+   * NOTE: we don't build mProbingErrMsg to differentiate "no xmc subdev" and
+   * "other errors". Caller can treat no error message as just not support.
+   */
+  if (!hasXMC())
+    return;
 
-        try {
-            mRegBase = xrt_core::device_query<xrt_core::query::xmc_reg_base>(m_device);
-        } catch (...) {}
+  bool is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(m_device);
+  if (!is_mfg) {
+    try {
+      val = xrt_core::device_query<xrt_core::query::xmc_status>(m_device);
     }
-    if (mRegBase == 0)
-        mRegBase = XMC_REG_BASE;
-
-    val = readReg(XMC_REG_OFF_MAGIC);
-    if (val != XMC_MAGIC_NUM) {
-      mProbingErrMsg << "Failed to detect XMC, bad magic number: "
-                     << std::hex << val << std::dec;
+    catch (...) {
       return;
     }
-
-    val = readReg(XMC_REG_OFF_VER);
-    if (val < XMC_BASE_VERSION) {
-        mProbingErrMsg << "Found unsupported XMC version: " << val;
-        return;
+    if (!(val & 1)) {
+      mProbingErrMsg << "Failed to detect XMC, xmc.bin not loaded";
+      return;
     }
+  }
 
-    val = readReg(XMC_REG_OFF_FEATURE);
-    if (val & XMC_PKT_SUPPORT_MASK) {
-        mProbingErrMsg << "XMC packet buffer is not supported";
-        return;
+  try {
+    mRegBase = xrt_core::device_query<xrt_core::query::xmc_reg_base>(m_device);
+  }
+  catch (...) { }
+  if (mRegBase == 0)
+    mRegBase = xmc_reg_base;
+
+  try {
+    val = readReg(static_cast<unsigned int>(xmc_reg_offset::magic));
+  } catch (...) {
+    // Xoclv2 driver does not support mmap'ed BAR access from
+    // user space any more. We must use driver to update SC image.
+    xrt_core::scope_value_guard<int, std::function<void()>> fd { 0, nullptr };
+    try {
+      fd = m_device->file_open("xmc", O_RDWR); 
+    } catch (...) { }
+    if (fd.get() >= 0)
+      mXmcDev = fdopen(fd.get(), "r+");
+    if (mXmcDev == nullptr)
+        std::cout << "Failed to open XMC device" << std::endl;
+    return;
+  }
+
+  if (val != xmc_magic_num) {
+    mProbingErrMsg << "Failed to detect XMC, bad magic number: "
+             << std::hex << val << std::dec;
+    return;
+  }
+
+  val = readReg(static_cast<unsigned int>(xmc_reg_offset::version));
+  if (val < xmc_base_version) {
+    mProbingErrMsg << "Found unsupported XMC version: " << val;
+    return;
+  }
+
+  val = readReg(static_cast<unsigned int>(xmc_reg_offset::feature));
+  if (val & static_cast<unsigned int>(xmc_mask::pkt_support)) {
+    mProbingErrMsg << "XMC packet buffer is not supported";
+    return;
+  }
+
+  mPktBufOffset = readReg(static_cast<unsigned int>(xmc_reg_offset::packet_offset));
+
+  mXmcDev = nullptr;
+  xrt_core::scope_value_guard<int, std::function<void()>> fd { 0, nullptr };
+  if (std::getenv("FLASH_VIA_USER") == NULL) {
+    try {
+      fd = m_device->file_open("xmc", O_RDWR); 
+    } catch (...) { }
+    if (fd.get() >= 0)
+      mXmcDev = fdopen(fd.get(), "r+");
+    if (mXmcDev == nullptr) {
+      try {
+        fd = m_device->file_open("xmc.u2", O_RDWR); 
+      } catch (...) { }
+      if (fd.get() >= 0)
+        mXmcDev = fdopen(fd.get(), "r+");
     }
-
-    mPktBufOffset = readReg(XMC_REG_OFF_PKT_OFFSET);
+    if (mXmcDev == nullptr)
+      std::cout << "Failed to open XMC device" << std::endl;
+  }
 }
 
 XMC_Flasher::~XMC_Flasher()
@@ -121,451 +283,525 @@ XMC_Flasher::~XMC_Flasher()
 /*
  * xclUpgradeFirmware
  */
-int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
-    std::string startAddress;
-    ELARecord record;
-    bool endRecordFound = false;
-    bool errorFound = false;
-    int retries = 5;
-    int ret = 0;
+int XMC_Flasher::xclUpgradeFirmware(std::istream &tiTxtStream)
+{
+  if (mXmcDev)
+    return xclUpgradeFirmwareDrv(tiTxtStream);
+  
+  std::string startAddress;
+  ELARecord record;
+  bool endRecordFound = false;
+  bool errorFound = false;
+  int retries = 5;
+  int ret = 0;
 
-    if (!isXMCReady())
-        return -EINVAL;
+  if (!hasSC()) {
+    std::cout << "ERROR: SC is not present on platform" << std::endl;
+    return -EINVAL;
+  }
 
-    while (!tiTxtStream.eof() && !endRecordFound && !errorFound) {
-        std::string line;
-        std::getline(tiTxtStream, line);
-        if (line.size() == 0) {
-            continue;
-        }
+  if (!isXMCReady())
+    return -EINVAL;
 
-        switch (line[0]) {
-        case 'q':
-        case 'Q':
-        {
-            if (startAddress.size()) {
-                // Finish the last record
-                mRecordList.push_back(record);
-                startAddress.clear();
-            }
-            // Create and append the end-of-image record (mDataCount must be 0).
-            record.mStartAddress = BMC_JUMP_ADDR;
-            record.mDataPos = tiTxtStream.tellg();
-            record.mEndAddress = record.mStartAddress;
-            record.mDataCount = 0;
-            mRecordList.push_back(record);
-            endRecordFound = true;
-            break;
-        }
-        case '@':
-        {
-            std::string newAddress = line.substr(1);
-            if (startAddress.size()) {
-                // Finish the last record
-                mRecordList.push_back(record);
-                startAddress.clear();
-            }
-            // Start a new record
-            record.mStartAddress = std::stoi(newAddress, 0 , 16);
-            record.mDataPos = tiTxtStream.tellg();
-            record.mEndAddress = record.mStartAddress;
-            record.mDataCount = 0;
-            startAddress = newAddress;
-            break;
-        }
-        default:
-        {
-            int spaces = 0;
-            int digits = 0;
-            std::locale loc;
-
-            if (startAddress.size() == 0) {
-                    errorFound = true;
-            }
-
-            for (unsigned int i = 0; i < line.size() && !errorFound; i++) {
-                if (line[i] == ' ') {
-                    spaces++;
-                } else if (std::isxdigit(line[i], loc)) {
-                    digits++;
-                } else {
-                    errorFound = true;
-                }
-            }
-
-            // Each line has at most 16-byte of data represented as hex in ASCII
-            if (((digits % 2) != 0) || digits > 16 * 2) {
-                errorFound = true;
-            }
-
-            if (!errorFound) {
-                int bytes = digits / 2;
-
-                record.mDataCount += bytes;
-                record.mEndAddress += bytes;
-                if (bytes < 16) {
-                    // Finish the last record
-                    mRecordList.push_back(record);
-                    startAddress.clear();
-                }
-            }
-        }
-        }
+  while (!tiTxtStream.eof() && !endRecordFound && !errorFound) {
+    std::string line;
+    std::getline(tiTxtStream, line);
+    if (line.size() == 0) {
+      continue;
     }
 
-    tiTxtStream.seekg(0);
-
-    if (errorFound)
-        throw xrt_core::error("Bad firmware file format.");
-
-    // Start of flashing BMC firmware
-    std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "found" % mRecordList.size() % "sections";
-    while(retries != 0) {
-        retries--;
-
-        ret = erase();
-        XBU::ProgressBar sc_flash("Programming SC", static_cast<unsigned int>(mRecordList.size()), XBU::is_esc_enabled(), std::cout);
-        int counter = 0;
-        for (auto i = mRecordList.begin(); ret == 0 && i != mRecordList.end(); ++i) {
-            ret = program(tiTxtStream, *i);
-            sc_flash.update(counter);
-            counter++;
-        }
-
-        if(ret == 0) {
-            sc_flash.finish(true, "SC successfully updated");
-            break;
-        } else {
-            sc_flash.finish(false, "WARN: Failed to flash firmware, retrying...");
-        }
+    switch (line[0]) {
+    case 'q':
+    case 'Q': {
+      if (startAddress.size()) {
+        // Finish the last record
+        mRecordList.push_back(record);
+        startAddress.clear();
+      }
+      // Create and append the end-of-image record (mDataCount must be 0).
+      record.mStartAddress = bmc_jump_address;
+      record.mDataPos = tiTxtStream.tellg();
+      record.mEndAddress = record.mStartAddress;
+      record.mDataCount = 0;
+      mRecordList.push_back(record);
+      endRecordFound = true;
+      break;
     }
-    // End of flashing BMC firmware
-
-    if (ret != 0)
-        return ret;
-
-    // Waiting for BMC to come back online.
-    // It should not take more than 10 sec, but wait for 1 min to be safe.
-    std::cout << boost::format("%-8s : %s\n") % "INFO" % "Loading new firmware on SC";
-    for (int i = 0; i < 60; i++) {
-        if (BMC_MODE() == BMC_STATE_READY)
-            break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        std::cout << "." << std::flush;
+    case '@': {
+      std::string newAddress = line.substr(1);
+      if (startAddress.size())
+      {
+        // Finish the last record
+        mRecordList.push_back(record);
+        startAddress.clear();
+      }
+      // Start a new record
+      record.mStartAddress = std::stoi(newAddress, 0, 16);
+      record.mDataPos = tiTxtStream.tellg();
+      record.mEndAddress = record.mStartAddress;
+      record.mDataCount = 0;
+      startAddress = newAddress;
+      break;
     }
-    std::cout << std::endl;
+    default: {
+      int spaces = 0;
+      int digits = 0;
+      std::locale loc;
 
-    if (!isBMCReady())
-        throw xrt_core::error("Time'd out waiting for SC to come back online");
-    return 0;
+      if (startAddress.size() == 0) {
+        errorFound = true;
+      }
+
+      for (unsigned int i = 0; i < line.size() && !errorFound; i++) {
+        if (line[i] == ' ')
+        {
+          spaces++;
+        }
+        else if (std::isxdigit(line[i], loc))
+        {
+          digits++;
+        }
+        else
+        {
+          errorFound = true;
+        }
+      }
+
+      // Each line has at most 16-byte of data represented as hex in ASCII
+      if (((digits % 2) != 0) || digits > 16 * 2) {
+        errorFound = true;
+      }
+
+      if (!errorFound) {
+        int bytes = digits / 2;
+
+        record.mDataCount += bytes;
+        record.mEndAddress += bytes;
+        if (bytes < 16) {
+          // Finish the last record
+          mRecordList.push_back(record);
+          startAddress.clear();
+        }
+      }
+    }
+    }
+  }
+
+  tiTxtStream.seekg(0);
+
+  if (errorFound)
+    throw xrt_core::error("Bad firmware file format.");
+
+  // Start of flashing BMC firmware
+  std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "found" % mRecordList.size() % "sections";
+  while (retries != 0) {
+    retries--;
+
+    ret = erase();
+    XBUtilities::ProgressBar sc_flash("Programming SC", static_cast<unsigned int>(mRecordList.size()), XBUtilities::is_esc_enabled(), std::cout);
+    int counter = 0;
+    for (auto i = mRecordList.begin(); ret == 0 && i != mRecordList.end(); ++i) {
+      ret = program(tiTxtStream, *i);
+      sc_flash.update(counter);
+      counter++;
+    }
+
+    if (ret == 0) {
+      sc_flash.finish(true, "SC successfully updated");
+      break;
+    }
+    else {
+      sc_flash.finish(false, "WARN: Failed to flash firmware, retrying...");
+    }
+  }
+  // End of flashing BMC firmware
+
+  if (ret != 0)
+    return ret;
+
+  // Waiting for BMC to come back online.
+  // It should not take more than 10 sec, but wait for 1 min to be safe.
+  std::cout << boost::format("%-8s : %s\n") % "INFO" % "Loading new firmware on SC";
+  for (int i = 0; i < 60; i++) {
+    if (bmc_mode() == static_cast<unsigned int>(bmc_state::ready))
+      break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    std::cout << "." << std::flush;
+  }
+  std::cout << std::endl;
+
+  if (!isBMCReady())
+    throw xrt_core::error("Time'd out waiting for SC to come back online");
+  return 0;
 }
 
 int XMC_Flasher::erase()
 {
-    int ret = 0;
+  int ret = 0;
 
-    mPkt = {0};
-    mPkt.hdr.opCode = XPO_MSP432_ERASE_FW;
+  mPkt = {0};
+  mPkt.hdr.opCode = static_cast<unsigned int>(xmc_packet_op::msp432_erase_fw);
 
-    if ((ret = sendPkt(true)) != 0)
-        return ret;
+  if ((ret = sendPkt(true)) != 0)
+    return ret;
 
-    // Flush the last packet sent to XMC
-    return waitTillIdle();
+  // Flush the last packet sent to XMC
+  return waitTillIdle();
 }
 
-int XMC_Flasher::xclGetBoardInfo(std::map<char, std::vector<char>>& info)
+int XMC_Flasher::xclGetBoardInfo(std::map<char, std::vector<char>> &info)
 {
-    int ret = 0;
+  int ret = 0;
 
-    if (!hasSC())
-        return -EOPNOTSUPP;
-
+  if (!hasSC())
+    return -EOPNOTSUPP;
+  std::vector<char> board_info;
+  char *byte;
+  size_t size;
+  
+  try {
+    board_info = xrt_core::device_query<xrt_core::query::xmc_board_info>(m_device);
+  } 
+  catch (...) { }
+  if(board_info.empty()) {
     if (!isXMCReady() || !isBMCReady())
-        return -EINVAL;
-
+      return -EINVAL;
     mPkt = {0};
-    mPkt.hdr.opCode = XPO_BOARD_INFO;
+    mPkt.hdr.opCode = static_cast<unsigned int>(xmc_packet_op::board_info);
 
-    if ((ret = sendPkt(false)) != 0){
-        if(ret == XMC_HOST_MSG_BRD_INFO_MISSING_ERR)
-        {
-            std::cout << "Unable to get card info, need to upgrade firmware"
-                << std::endl;
-        }
-        return ret;
+    if ((ret = sendPkt(false)) != 0) {
+      if (ret == static_cast<unsigned int>(xmc_host_error_msg::brd_info_missing)) {
+        std::cout << "Unable to get card info, need to upgrade firmware"
+            << std::endl;
+      }
+    return ret;
     }
 
     ret = recvPkt();
     if (ret != 0)
-        return ret;
-
-    info.clear();
-    char *byte = reinterpret_cast<char *>(mPkt.data);
-    for(unsigned int i = 0; i < mPkt.hdr.payloadSize;)
-    {
-        char key = byte[i++];
-        uint8_t len = byte[i++];
-        std::vector<char> content(len, 0);
-        for (int n = 0; n < len; n++)
-            content[n] = byte[i++];
-        info[key] = content;
-    }
-
-    return 0;
+      return ret;
+    byte = reinterpret_cast<char *>(mPkt.data);
+    size = mPkt.hdr.payloadSize;
+  }
+  else {
+    byte = reinterpret_cast<char *>(board_info.data());
+    size = board_info.size();
+  }
+  info.clear();
+  for (unsigned int i = 0; i < size;) {
+    char key = byte[i++];
+    uint8_t len = byte[i++];
+    std::vector<char> content(len, 0);
+    for (int n = 0; n < len; n++)
+      content[n] = byte[i++];
+    info[key] = content;
+  }
+  return 0;
 }
 
-int XMC_Flasher::program(std::istream& tiTxtStream, const ELARecord& record) //* prog bar
+int XMC_Flasher::program(std::istream& tiTxtStream, const ELARecord &record)
 {
-    std::string byteStr;
-    int ret = 0;
-    unsigned int ndigit = 0;
-    int pos;
-    char c;
-    uint8_t *data;
-    const int charPerByte = 2;
-    std::locale loc;
+  std::string byteStr;
+  int ret = 0;
+  unsigned int ndigit = 0;
+  int pos;
+  char c;
+  uint8_t *data;
+  const int charPerByte = 2;
+  std::locale loc;
 
-#ifdef  XMC_DEBUG
-    std::cout << std::hex;
-    std::cout << "Address=0x" << record.mStartAddress
+#ifdef XMC_DEBUG
+  std::cout << std::hex;
+  std::cout << "Address=0x" << record.mStartAddress
         << std::dec << ", Length=" << record.mDataCount;
-    std::cout<< std::endl;
+  std::cout << std::endl;
 #endif
-    tiTxtStream.seekg(record.mDataPos, std::ios_base::beg);
+  tiTxtStream.seekg(record.mDataPos, std::ios_base::beg);
 
+  byteStr.clear();
+  mPkt.hdr.opCode =
+    record.mDataCount ? static_cast<unsigned int>(xmc_packet_op::msp432_sec_start) : 
+                        static_cast<unsigned int>(xmc_packet_op::msp432_image_end);
+  mPkt.hdr.reserved = 0;
+
+  const int maxDataSize = sizeof(mPkt.data);
+  data = reinterpret_cast<uint8_t *>(&mPkt.data[0]);
+  // First uint32_t in payload is always the address
+  mPkt.data[0] = record.mStartAddress;
+  mPkt.data[1] = record.mDataCount;
+  pos = sizeof(uint32_t) * 2;
+
+  while (ndigit < record.mDataCount * charPerByte) {
+    if (!tiTxtStream.get(c)) {
+      std::cout << "Cannot read data from firmware file" << std::endl;
+      return -EIO;
+    }
+    if (!std::isxdigit(c, loc))
+      continue;
+    ndigit++;
+
+    byteStr.push_back(c);
+    if (byteStr.size() < charPerByte)
+      continue;
+
+    uint8_t n = static_cast<uint8_t>(std::stoi(byteStr, 0, 16));
     byteStr.clear();
-    mPkt.hdr.opCode =
-        record.mDataCount ? XPO_MSP432_SEC_START : XPO_MSP432_IMAGE_END;
-    mPkt.hdr.reserved = 0;
 
-    const int maxDataSize = sizeof (mPkt.data);
-    data = reinterpret_cast<uint8_t *>(&mPkt.data[0]);
-    // First uint32_t in payload is always the address
-    mPkt.data[0] = record.mStartAddress;
-    mPkt.data[1] = record.mDataCount;
-    pos = sizeof (uint32_t) * 2;
+    data[pos++] = n;
+    if (pos < maxDataSize)
+      continue;
 
-    while (ndigit < record.mDataCount * charPerByte) {
-        if (!tiTxtStream.get(c)) {
-            std::cout << "Cannot read data from firmware file" << std::endl;
-            return -EIO;
-        }
-        if (!std::isxdigit(c, loc))
-            continue;
-        ndigit++;
+    // Send out a fully loaded pkt
+    mPkt.hdr.payloadSize = pos;
+    if ((ret = sendPkt(true)) != 0) //* if prog bar val=true sendPkt false
+      return ret;
+    // Reset opcode and pos for next data pkt
+    mPkt.hdr.opCode = static_cast<unsigned int>(xmc_packet_op::msp432_sec_data);
+    pos = 0;
+  }
 
-        byteStr.push_back(c);
-        if (byteStr.size() < charPerByte)
-            continue;
+  // Send the last partially loaded pkt
+  if (pos) {
+    mPkt.hdr.payloadSize = pos;
+    if ((ret = sendPkt(true)) != 0)
+      return ret;
+  }
 
-        uint8_t n = static_cast<uint8_t>(std::stoi(byteStr, 0 , 16));
-        byteStr.clear();
-
-        data[pos++] = n;
-        if (pos < maxDataSize)
-            continue;
-
-        // Send out a fully loaded pkt
-        mPkt.hdr.payloadSize = pos;
-        if ((ret = sendPkt(true)) != 0) //* if prog bar val=true sendPkt false
-            return ret;
-        // Reset opcode and pos for next data pkt
-        mPkt.hdr.opCode = XPO_MSP432_SEC_DATA;
-        pos = 0;
-    }
-
-    // Send the last partially loaded pkt
-    if (pos) {
-        mPkt.hdr.payloadSize = pos;
-        if ((ret = sendPkt(true)) != 0)
-            return ret;
-    }
-
-    // Flush the last packet sent to XMC
-    return waitTillIdle();
+  // Flush the last packet sent to XMC
+  return waitTillIdle();
 }
 
-void describePkt(struct xmcPkt& pkt, bool send)
+void XMC_Flasher::describePkt(struct xmc_pkt &pkt, bool send)
 {
-    int lenInUint32 = (sizeof (pkt.hdr) + pkt.hdr.payloadSize +
-        sizeof (uint32_t) - 1) / sizeof (uint32_t);
+  int lenInUint32 = (sizeof(pkt.hdr) + pkt.hdr.payloadSize +
+             sizeof(uint32_t) - 1) /
+            sizeof(uint32_t);
 
-    auto format = xrt_core::utils::ios_restore(std::cout);
+  auto format = xrt_core::utils::ios_restore(std::cout);
 
-    if (send)
-        std::cout << "Sending XMC packet: ";
-    else
-        std::cout << "Receiving XMC packet: ";
-    std::cout << std::dec << lenInUint32 << " DWORDs..." << std::endl;
+  if (send)
+    std::cout << "Sending XMC packet: ";
+  else
+    std::cout << "Receiving XMC packet: ";
+  std::cout << std::dec << lenInUint32 << " DWORDs..." << std::endl;
 
-    uint32_t *h = reinterpret_cast<uint32_t *>(&pkt.hdr);
-    std::cout << "opcode=" << static_cast<unsigned>(pkt.hdr.opCode)
-              << " payload_size=" << pkt.hdr.payloadSize
-              << " (0x" << std::hex << std::uppercase << std::setfill('0')
-              << std::setw(8) << *h << std::dec << ")"
-              << std::endl;
+  uint32_t *h = reinterpret_cast<uint32_t *>(&pkt.hdr);
+  std::cout << "opcode=" << static_cast<unsigned>(pkt.hdr.opCode)
+        << " payload_size=" << pkt.hdr.payloadSize
+        << " (0x" << std::hex << std::uppercase << std::setfill('0')
+        << std::setw(8) << *h << std::dec << ")"
+        << std::endl;
 
-#ifdef  XMC_DEBUG_VERBOSE
-    uint8_t *data = reinterpret_cast<uint8_t *>(&pkt.data[0]);
-    std::cout << std::hex;
-    int nbytes = 0;
-    for (unsigned i = 0; i < pkt.hdr.payloadSize; i++) {
-        std::cout << std::uppercase << std::setfill('0') << std::setw(2)
-                  << static_cast<unsigned>(data[i]) << " ";
-        nbytes++;
-        if ((nbytes % 16) == 0)
-            std::cout << std::endl;
-    }
-    std::cout << std::endl;
+#ifdef XMC_DEBUG_VERBOSE
+  uint8_t *data = reinterpret_cast<uint8_t *>(&pkt.data[0]);
+  std::cout << std::hex;
+  int nbytes = 0;
+  for (unsigned i = 0; i < pkt.hdr.payloadSize; i++)
+  {
+    std::cout << std::uppercase << std::setfill('0') << std::setw(2)
+          << static_cast<unsigned>(data[i]) << " ";
+    nbytes++;
+    if ((nbytes % 16) == 0)
+      std::cout << std::endl;
+  }
+  std::cout << std::endl;
 #endif
 }
 
 int XMC_Flasher::recvPkt()
 {
-    uint32_t *pkt = reinterpret_cast<uint32_t *>(&mPkt);
-    *pkt = readReg(mPktBufOffset);
-    unsigned int lenInUint32 =
-        (mPkt.hdr.payloadSize + sizeof (uint32_t) - 1) / sizeof (uint32_t);
+  uint32_t *pkt = reinterpret_cast<uint32_t *>(&mPkt);
+  *pkt = readReg(mPktBufOffset);
+  unsigned int lenInUint32 =
+    (mPkt.hdr.payloadSize + sizeof(uint32_t) - 1) / sizeof(uint32_t);
 
-    if (lenInUint32 <= 0 || lenInUint32 > xmcMaxPayload) {
-        std::cout << "ERROR: Received bad XMC packet" << std::endl;
-        return -EINVAL;
-    }
+  if (lenInUint32 <= 0 || lenInUint32 > xmc_max_payload) {
+    std::cout << "ERROR: Received bad XMC packet" << std::endl;
+    return -EINVAL;
+  }
 
-    for (unsigned int i = 0; i < lenInUint32; i++)
-        mPkt.data[i] = readReg(mPktBufOffset + (i + 1) * sizeof (uint32_t));
+  for (unsigned int i = 0; i < lenInUint32; i++)
+    mPkt.data[i] = readReg(mPktBufOffset + (i + 1) * sizeof(uint32_t));
 
-#ifdef  XMC_DEBUG
-    describePkt(mPkt, false);
+#ifdef XMC_DEBUG
+  describePkt(mPkt, false);
 #endif
-    return waitTillIdle();
+  return waitTillIdle();
 }
 
 int XMC_Flasher::sendPkt(bool print_dot)
 {
-    int lenInUint32 = (sizeof (mPkt.hdr) + mPkt.hdr.payloadSize +
-        sizeof (uint32_t) - 1) / sizeof (uint32_t);
+  int lenInUint32 = (sizeof(mPkt.hdr) + mPkt.hdr.payloadSize +
+             sizeof(uint32_t) - 1) /
+            sizeof(uint32_t);
 
-#ifdef  XMC_DEBUG
-    describePkt(mPkt, true);
+#ifdef XMC_DEBUG
+  describePkt(mPkt, true);
 #else
-    // if (print_dot)
-    //     std::cout << "." << std::flush;
 #endif
 
-    uint32_t *pkt = reinterpret_cast<uint32_t *>(&mPkt);
+  uint32_t *pkt = reinterpret_cast<uint32_t *>(&mPkt);
 
-    for (int i = 0; i < lenInUint32; i++) {
-        writeReg(mPktBufOffset + i * sizeof (uint32_t), pkt[i]);
-    }
+  for (int i = 0; i < lenInUint32; i++) {
+    writeReg(mPktBufOffset + i * sizeof(uint32_t), pkt[i]);
+  }
 
-    // Flip pkt buffer ownership bit
-    writeReg(XMC_REG_OFF_CTL, readReg(XMC_REG_OFF_CTL) | XMC_PKT_OWNER_MASK);
-    return waitTillIdle();
+  // Flip pkt buffer ownership bit
+  writeReg(static_cast<unsigned int>(xmc_reg_offset::control), 
+            readReg(static_cast<unsigned int>(xmc_reg_offset::control)) | 
+            static_cast<unsigned int>(xmc_mask::pkt_owner));
+  return waitTillIdle();
 }
 
 int XMC_Flasher::waitTillIdle()
 {
-    // In total, wait for 500 * 10ms
-    int retry = 500;
-    unsigned int err = 0;
+  // In total, wait for 500 * 10ms
+  int retry = 500;
+  unsigned int err = 0;
 
-#if  XMC_DEBUG
-    std::cout << "INFO: Waiting until idle" << std::endl;
+#if XMC_DEBUG
+  std::cout << "INFO: Waiting until idle" << std::endl;
 #endif
-    while ((retry-- > 0) && (readReg(XMC_REG_OFF_CTL) & XMC_PKT_OWNER_MASK)){
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+  while ((retry-- > 0) && (readReg(static_cast<unsigned int>(xmc_reg_offset::control)) 
+                            & static_cast<unsigned int>(xmc_mask::pkt_owner))) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
 
-    if (retry == 0) {
-        std::cout << "ERROR: Time'd out while waiting for XMC packet to be idle"
-            << std::endl;
-        return -ETIMEDOUT;
-    }
+  if (retry == 0) {
+    std::cout << "ERROR: Time'd out while waiting for XMC packet to be idle"
+          << std::endl;
+    return -ETIMEDOUT;
+  }
 
-    if (readReg(XMC_REG_OFF_ERR) & XMC_PKT_ERR_MASK)
-        err = readReg(XMC_REG_OFF_PKT_STATUS);
+  if (readReg(static_cast<unsigned int>(xmc_reg_offset::error)) & static_cast<unsigned int>(xmc_mask::pkt_error))
+    err = readReg(static_cast<unsigned int>(xmc_reg_offset::packet_status));
 
-    if (err) {
-        std::cout << "ERROR: XMC packet error: " << err << std::endl;
-        writeReg(XMC_REG_OFF_CTL, readReg(XMC_REG_OFF_CTL) | XMC_CTRL_ERR_CLR);
-        return -EINVAL;
-    }
+  if (err) {
+    std::cout << "ERROR: XMC packet error: " << err << std::endl;
+    writeReg(static_cast<unsigned int>(xmc_reg_offset::control), 
+                readReg(static_cast<unsigned int>(xmc_reg_offset::control)) | 
+                static_cast<unsigned int>(xmc_mask::ctrl_error_clear));
+    return -EINVAL;
+  }
 
-    return 0;
+  return 0;
 }
 
-unsigned int XMC_Flasher::readReg(unsigned int RegOffset) {
-    unsigned int value = 0;
-    RegOffset = RegOffset;
-    m_device->read(mRegBase + RegOffset, &value, 4);
-    return value;
-}
-
-int XMC_Flasher::writeReg(unsigned int RegOffset, unsigned int value) {
-    value = value;
-    m_device->write(mRegBase + RegOffset, &value, 4);
-    return 0;
-}
-
-static std::string getStatus(int status, std::map<int, std::string> &map)
+unsigned int XMC_Flasher::readReg(unsigned int RegOffset)
 {
-    auto entry = map.find(status);
-    std::ostringstream os;
+  unsigned int value = 0;
+  RegOffset = RegOffset;
+  m_device->read(mRegBase + RegOffset, &value, 4);
+  return value;
+}
 
-    os << std::hex << status;
-
-    if (entry != map.end())
-	    os << "(" << entry->second << ")";
-
-    return os.str();
+int XMC_Flasher::writeReg(unsigned int RegOffset, unsigned int value)
+{
+  value = value;
+  m_device->write(mRegBase + RegOffset, &value, 4);
+  return 0;
 }
 
 bool XMC_Flasher::isXMCReady()
 {
-    bool xmcReady = (XMC_MODE() == XMC_READY);
+  bool xmcReady;
+  try {
+    xmcReady = (xmc_mode() == static_cast<unsigned int>(xmc_status::ready));
+  }
+  catch(...) {
+    // Xoclv2 driver does not support mmap'ed BAR access from
+    // user space any more.
+    return true;
+  }
 
-    if (!xmcReady) {
-        auto format = xrt_core::utils::ios_restore(std::cout);
-        std::cout << "ERROR: XMC is not ready: 0x" <<
-            getStatus(XMC_MODE(), cmcStatusMap) << std::endl;
-    }
+  if (!xmcReady) { //start here
+    auto format = xrt_core::utils::ios_restore(std::cout);
+    if(hasXMC())
+      std::cout << "ERROR: XMC is not ready: 0x" << getStatus(xmc_mode(), cmcStatusMap) << std::endl;
+  }
 
-    return xmcReady;
+  return xmcReady;
 }
 
 bool XMC_Flasher::isBMCReady()
 {
-    bool bmcReady = (BMC_MODE() == 0x1) || (BMC_MODE() == 0x5);
+  bool bmcReady = (bmc_mode() == static_cast<unsigned int>(bmc_state::ready)) || 
+                    (bmc_mode() == static_cast<unsigned int>(bmc_state::ready_not_upgradable));
 
-    if (!bmcReady) {
-        auto format = xrt_core::utils::ios_restore(std::cout);
-        std::cout << "ERROR: SC is not ready: 0x" <<
-            getStatus(BMC_MODE(), scStatusMap) << std::endl;
-    }
+  if (!bmcReady) {
+    auto format = xrt_core::utils::ios_restore(std::cout);
+    std::cout << "ERROR: SC is not ready: 0x" << getStatus(bmc_mode(), scStatusMap) << std::endl;
+  }
 
-    return bmcReady;
+  return bmcReady;
+}
+
+bool XMC_Flasher::hasXMC()
+{
+  bool xmc_presence = false;
+  try {
+    xrt_core::device_query<xrt_core::query::xmc_sc_version>(m_device);
+    xmc_presence = true;
+  }
+  catch (...) { }
+  return xmc_presence;
 }
 
 bool XMC_Flasher::hasSC()
 {
-    bool sc_presence = false;
-    try {
-        sc_presence = xrt_core::device_query<xrt_core::query::xmc_sc_presence>(m_device);
-    } catch (...) {}
-    return sc_presence;
+  if (!hasXMC())
+    return false;
+  
+  bool sc_presence = false;
+  try {
+    sc_presence = xrt_core::device_query<xrt_core::query::xmc_sc_presence>(m_device);
+  }
+  catch (const std::exception& ex) {
+    std::cerr << "ERROR:" << ex.what() << std::endl;
+   }
+  return sc_presence;
 }
 
 bool XMC_Flasher::fixedSC()
 {
-    bool is_sc_fixed = false;
-    std::string errmsg;
-
-    try {
-        is_sc_fixed = xrt_core::device_query<xrt_core::query::is_sc_fixed>(m_device);
-    } catch (...) {}
-
-    return is_sc_fixed;
+  if (!hasXMC())
+    return false;
+  bool is_sc_fixed = false;
+  try {
+    is_sc_fixed = xrt_core::device_query<xrt_core::query::is_sc_fixed>(m_device);
+  }
+  catch (const std::exception& ex) {
+    std::cerr << "ERROR:" << ex.what() << std::endl;
+   }
+  return is_sc_fixed;
 }
 
+int XMC_Flasher::xclUpgradeFirmwareDrv(std::istream& tiTxtStream)
+{
+  int ret = 0;
+
+  // Parse Ti-TXT data and write each contiguous chunk to XMC.
+  std::vector<unsigned char> buf;
+  unsigned int curAddr = UINT_MAX;
+  while (ret == 0) {
+    tiTxtStreamToBin(tiTxtStream, curAddr, buf);
+    if (buf.empty())
+      break;
+#ifdef  XMC_DEBUG
+    std::cout << "Extracted " << buf.size() << "B firmware image @0x"
+        << std::hex << curAddr << std::dec << std::endl;
+#endif
+    ret = writeImage(mXmcDev, curAddr, buf);
+  }
+  std::cout << std::endl;
+  if (ret) {
+    std::cout << "ERROR: Failed to update SC firmware, err=" << ret
+        << std::endl;
+    std::cout << "ERROR: Please refer to dmesg for more details"
+        << std::endl;
+  }
+
+  return ret;
+}
+
+} //xrt_tools

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.h
@@ -1,11 +1,11 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
  * License is located at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -16,117 +16,150 @@
 #ifndef _XMC_H_
 #define _XMC_H_
 
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "core/common/device.h"
+
+// System - Include Files
 #include <list>
 #include <iostream>
 #include <sstream>
 #include <map>
 #include <vector>
 
-#include "core/common/device.h"
+namespace xrt_tools {
+
+// ------ S T A T I C   C O N S T A N T S   A N D   E N U M S ------------------
 
 // Register offset in mgmt pf BAR 0
-#define XMC_REG_BASE                        0x120000
+static const int xmc_reg_base = 0x120000;
+
+static const int xmc_magic_num = 0x74736574;
+static const int xmc_base_version = 2018201;
 
 // Register offset in register map of XMC
-#define XMC_REG_OFF_MAGIC                   0x0
-#define XMC_REG_OFF_VER                     0x4
-#define XMC_REG_OFF_STATUS                  0x8
-#define XMC_REG_OFF_ERR                     0xc
-#define XMC_REG_OFF_FEATURE                 0x10
-#define XMC_REG_OFF_CTL                     0x18
-#define XMC_REG_OFF_PKT_OFFSET              0x300
-#define XMC_REG_OFF_PKT_STATUS              0x304
-
-#define XMC_MAGIC_NUM                       0x74736574
-#define XMC_BASE_VERSION                    2018201
-
-#define XMC_CTRL_ERR_CLR                    (1 << 1)
-#define XMC_PKT_SUPPORT_MASK                (1 << 3)
-#define XMC_PKT_OWNER_MASK                  (1 << 5)
-#define XMC_PKT_ERR_MASK                    (1 << 26)
-
-#define XMC_HOST_MSG_NO_ERR                 0x00
-#define XMC_HOST_MSG_BAD_OPCODE_ERR         0x01
-#define XMC_HOST_MSG_UNKNOWN_ERR            0x02
-#define XMC_HOST_MSG_MSP432_MODE_ERR        0x03
-#define XMC_HOST_MSG_MSP432_FW_LENGTH_ERR   0x04
-#define XMC_HOST_MSG_BRD_INFO_MISSING_ERR   0x05
-
-#define XMC_MODE()      (readReg(XMC_REG_OFF_STATUS) & 0x3)
-#define BMC_MODE()      (readReg(XMC_REG_OFF_STATUS) >> 28)
-
-enum bmc_state {
-        BMC_STATE_UNKNOWN = 0,
-        BMC_STATE_READY,
-        BMC_STATE_BSL_UNSYNC,
-        BMC_STATE_BSL_SYNC
+enum class xmc_reg_offset
+{
+  magic         = 0x0,
+  version       = 0x4,
+  status        = 0x8,
+  error         = 0xc,
+  feature       = 0x10,
+  control       = 0x18,
+  packet_offset = 0x300,
+  packet_status = 0x304
 };
 
-#define XMC_READY       (0x1 << 0)
-#define XMC_STOPPED     (0x1 << 1)
-#define XMC_PAUSED      (0x1 << 2)
-
-enum xmc_packet_op {
-    XPO_UNKNOWN = 0,
-    XPO_MSP432_SEC_START,
-    XPO_MSP432_SEC_DATA,
-    XPO_MSP432_IMAGE_END,
-    XPO_BOARD_INFO,
-    XPO_MSP432_ERASE_FW
+enum class xmc_mask
+{
+  ctrl_error_clear = 1 << 1,
+  pkt_support      = 1 << 3,
+  pkt_owner        = 1 << 5,
+  pkt_error        = 1 << 26
 };
 
-const size_t xmcPktSize = (1024 / sizeof (uint32_t)) * 4; // In uint32_t
-struct xmcPkt {
-    // Make sure hdr is uint32_t aligned
-    struct xmcPktHdr {
-        unsigned payloadSize : 12;
-        unsigned reserved : 12;
-        unsigned opCode : 8;
-    } hdr;
-    uint32_t data[xmcPktSize - sizeof (hdr) / sizeof (uint32_t)];
+enum class xmc_status
+{
+  ready    = 0x1 << 0,
+  stoppped = 0x1 << 1,
+  paused   = 0x1 << 2
 };
-const size_t xmcMaxPayload =
-    xmcPktSize -sizeof (xmcPkt::xmcPktHdr) / sizeof (uint32_t); // In uint32_t
+
+enum class xmc_host_error_msg 
+{
+  success          = 0x00,
+  bad_opcode       = 0x01,
+  unknown          = 0x02,
+  msp432_mode      = 0x03,
+  msp432_fw_length = 0x04,
+  brd_info_missing = 0x05
+};
+
+enum class bmc_state
+{
+  unknown = 0,
+  ready,
+  bsl_unsync,
+  bsl_sync,
+  bsl_sync_not_upgradable,
+  ready_not_upgradable
+};
+
+enum class xmc_packet_op
+{
+  unknown = 0,
+  msp432_sec_start,
+  msp432_sec_data,
+  msp432_image_end,
+  board_info,
+  msp432_erase_fw
+};
+
+static const size_t xmc_pkt_size = (1024 / sizeof(uint32_t)) * 4;
+struct xmc_pkt
+{
+  // Make sure hdr is uint32_t aligned
+  struct xmc_pkt_header
+  {
+    unsigned payloadSize : 12;
+    unsigned reserved : 12;
+    unsigned opCode : 8;
+  } hdr;
+  uint32_t data[xmc_pkt_size - sizeof(hdr) / sizeof(uint32_t)];
+};
+static const size_t xmc_max_payload = xmc_pkt_size - sizeof(xmc_pkt::xmc_pkt_header) / sizeof(uint32_t);
+
+// ------------- C L A S S :  X M C _ F l a s h e r -----------------
 
 class XMC_Flasher
 {
-    struct ELARecord
-    {
-        unsigned mStartAddress;
-        unsigned mEndAddress;
-        unsigned mDataCount;
-        std::streampos mDataPos;
-        ELARecord() : mStartAddress(0), mEndAddress(0), mDataCount(0), mDataPos(0) {}
-    };
+  struct ELARecord
+  {
+    unsigned mStartAddress;
+    unsigned mEndAddress;
+    unsigned mDataCount;
+    std::streampos mDataPos;
+    ELARecord() : mStartAddress(0), mEndAddress(0), mDataCount(0), mDataPos(0) {}
+  };
 
-    typedef std::list<ELARecord> ELARecordList;
-    ELARecordList mRecordList;
+  using ELARecordList = std::list<ELARecord>;
+  ELARecordList mRecordList;
 
 public:
-    XMC_Flasher(unsigned int device_index);
-    ~XMC_Flasher();
-    int xclUpgradeFirmware(std::istream& tiTxtStream);
-    int xclGetBoardInfo(std::map<char, std::vector<char>>& info);
-    const std::string probingErrMsg() { return mProbingErrMsg.str(); }
-    bool fixedSC();
-
+  XMC_Flasher(unsigned int device_index);
+  ~XMC_Flasher();
+  int xclUpgradeFirmware(std::istream &tiTxtStream);
+  int xclGetBoardInfo(std::map<char, std::vector<char>> &info);
+  const std::string probingErrMsg() { return mProbingErrMsg.str(); }
+  bool hasXMC();
+  bool fixedSC();
 
 private:
-    std::shared_ptr<xrt_core::device> m_device;
-    unsigned mPktBufOffset;
-    uint64_t mRegBase = 0;
-    struct xmcPkt mPkt;
-    std::stringstream mProbingErrMsg;
-    int program(std::istream& tiTxtStream, const ELARecord& record);
-    int erase();
-    int sendPkt(bool print_dot);
-    int recvPkt();
-    int waitTillIdle();
-    unsigned readReg(unsigned RegOffset);
-    int writeReg(unsigned RegOffset, unsigned value);
-    bool isXMCReady();
-    bool isBMCReady();
-    bool hasSC();
+  std::shared_ptr<xrt_core::device> m_device;
+  unsigned mPktBufOffset;
+  uint64_t mRegBase = 0;
+  struct xmc_pkt mPkt;
+  std::stringstream mProbingErrMsg;
+
+  int program(std::istream &tiTxtStream, const ELARecord &record);
+  int erase();
+  int sendPkt(bool print_dot);
+  void describePkt(struct xmc_pkt &pkt, bool send);
+  int recvPkt();
+  int waitTillIdle();
+  unsigned readReg(unsigned RegOffset);
+  int writeReg(unsigned RegOffset, unsigned value);
+  bool isXMCReady();
+  bool isBMCReady();
+  bool hasSC();
+  int xmc_mode();
+  int bmc_mode();
+
+  // Upgrade SC firmware via driver.
+  std::FILE *mXmcDev = nullptr;
+  int xclUpgradeFirmwareDrv(std::istream& tiTxtStream);
 };
+
+} //xrt_tools
 
 #endif


### PR DESCRIPTION
- ported missing functionality from xbmgmt
- encapsulated XMC_Flasher class in xrt_tools namespace
- removed redundant include files
- refactored some code 
- indentation fix
- build on linux/windows