### PR TITLE
Prevent dtor from throwing

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -384,7 +384,11 @@ public:
 
   ~buffer_kbuf()
   {
-    device->unmap_bo(handle, hbuf);
+    try {
+      device->unmap_bo(handle, hbuf);
+    }
+    catch (...) {
+    }
   }
 
   virtual void*
@@ -409,7 +413,11 @@ public:
 
   ~buffer_import()
   {
-    device->unmap_bo(handle, hbuf);
+    try {
+      device->unmap_bo(handle, hbuf);
+    }
+    catch (...) {
+    }
   }
 
   virtual bool


### PR DESCRIPTION
Imported BO can fail in xclUnmapBO if the exported BO has already been
unmapped or vice versa.  Prevent the unmap failure from propagating
out of destructor of xrt::bo.