### PR TITLE
CR-1091052 xbutil validate crashes on u50 NoDMA

### DIFF
--- a/src/runtime_src/xrt/device/hal2.cpp
+++ b/src/runtime_src/xrt/device/hal2.cpp
@@ -310,6 +310,8 @@ alloc(size_t sz, Domain domain, uint64_t memory_index, void* userptr)
     flags = xrt::bo::flags::device_only;
   else if (domain == Domain::XRT_HOST_ONLY_MEM)
     flags = xrt::bo::flags::host_only;
+  else if (domain == Domain::XRT_DEVICE_RAM && is_nodma())
+    flags = xrt::bo::flags::normal;
 
   auto bo = userptr
     ? xrt::bo{m_handle, userptr, sz, flags, static_cast<xrt::memory_group>(memory_index)}


### PR DESCRIPTION
OpenCL validate.exe does not support NoDMA due to regression per
changes Jan 4 that switched OpenCL to use native APIs.

OpenCL buffers are created with cacheable flag, which does not handle
nodma.  This PR removes the cacheable flag before contructing nodma
buffer.