### PR TITLE
CR-1089544 p2p_fpga2fpga test is failing in SW emulation in Vitis Canaries

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -254,6 +254,12 @@ public:
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",  fmt.str());
     }
 
+    // special case sw emulation on imported buffers
+    if (is_sw_emulation() && (is_imported() || src->is_imported())) {
+      device->copy_bo(get_xcl_handle(), src->get_xcl_handle(), sz, dst_offset, src_offset);
+      return;
+    }
+      
     // revert to copying through host
     copy_through_host(src, sz, src_offset, dst_offset);
   }

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -154,6 +154,10 @@ get_axlf_section(axlf_section_kind section, const uuid& xclbin_id) const
 {
   if (xclbin_id && xclbin_id != m_xclbin.get_uuid())
     throw std::runtime_error("xclbin id mismatch");
+
+  if (!m_xclbin)
+    return {nullptr, 0};
+
   return xrt_core::xclbin_int::get_axlf_section(m_xclbin, section);
 }
 


### PR DESCRIPTION
Regression from recent changes caused p2p for software emulation to
take host copy path when it should call xclCopyBO.