### PR TITLE
CR-1090123: Fixing mismatch between profiling summary and profiling trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/statistics_database.cpp
+++ b/src/runtime_src/xdp/profile/database/statistics_database.cpp
@@ -337,6 +337,8 @@ namespace xdp {
 					 uint64_t address,
 					 uint64_t commandQueueId)
   {
+    std::lock_guard<std::mutex> lock(readsLock) ;
+
     std::pair<uint64_t, uint64_t> identifier = 
       std::make_pair(contextId, deviceId) ;
     
@@ -367,6 +369,8 @@ namespace xdp {
 					  uint64_t address,
 					  uint64_t commandQueueId)
   {
+    std::lock_guard<std::mutex> lock(writesLock) ;
+
     std::pair<uint64_t, uint64_t> identifier = 
       std::make_pair(contextId, deviceId) ;
     

--- a/src/runtime_src/xdp/profile/database/statistics_database.h
+++ b/src/runtime_src/xdp/profile/database/statistics_database.h
@@ -243,6 +243,8 @@ namespace xdp {
 
     // Since the host code can be multithreaded, we must protect 
     //  the data
+    std::mutex readsLock ;
+    std::mutex writesLock ;
     std::mutex dbLock ;
 
     // Helper functions for OpenCL

--- a/src/runtime_src/xocl/api/plugin/xdp/profile_trace.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/profile_trace.cpp
@@ -639,7 +639,7 @@ namespace xocl {
 
       return [mem0](xocl::event* e, cl_int status, const std::string&)
 	     {
-	       if (xdp::opencl_trace::write_cb) return ;
+	       if (!xdp::opencl_trace::write_cb) return ;
 	       if (status != CL_RUNNING && status != CL_COMPLETE) return ;
 
 		 // Before we cross over to XDP, collect all the 


### PR DESCRIPTION
This pull request:

- Fixes a bug where the OpenCL trace profiling plugin missed capturing writes during NDRange migration
- Adds multithreaded protection to the logging of reads and writes in the statistics database
