### PR TITLE
Update changelog for u30 branch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,24 @@
 XRT ChangeLog
 -------------
 
+2.10.0 (202020.2.10.x)
+~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+.....
+
+Removed
+.......
+
+
+2.9.0 (202020.2.9.x)
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+.....
+* Implementation of OpenCL changed to use native XRT APIs.  This change can trigger detection of errors in OpenCL applications that were not previously reported.  For example, if applicaton code attempts to do read-before-write from device memory, an error is now propagated to application and reported as a sync BO error.
+* Various bugfixes
+
 2.8.0 (202020.2.8.x)
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Reflect 2.9.x (PU1) change related to sync bo error.