### PR TITLE
Add missing re-throw of exception after handling

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -114,6 +114,7 @@ load_xclbin(const xrt::xclbin& xclbin)
   }
   catch (const std::exception&) {
     m_xclbin = {};
+    throw;
   }
 }
 


### PR DESCRIPTION
Deal with xclbin load failure, but propagate exception to caller