### PR TITLE
vcu test to use transcode.xclbin

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1102,7 +1102,7 @@ static std::vector<TestCollection> testSuite = {
   { create_init_test("Memory to memory DMA", "Run M2M test", "bandwidth.xclbin"), m2mTest },
   { create_init_test("Host memory bandwidth test", "Run 'bandwidth kernel' when slave bridge is enabled", "bandwidth.xclbin"), hostMemBandwidthKernelTest },
   { create_init_test("bist", "Run BIST test", "verify.xclbin", true), bistTest },
-  { create_init_test("vcu", "Run decoder test", "verify.xclbin"), vcuKernelTest }
+  { create_init_test("vcu", "Run decoder test", "transcode.xclbin"), vcuKernelTest }
 };
 
 /*

--- a/tests/validate/xcl_vcu_test/src/host.cpp
+++ b/tests/validate/xcl_vcu_test/src/host.cpp
@@ -45,14 +45,8 @@ int main(int argc, char** argv) {
   std::string binaryFile = test_path + b_file;
   std::ifstream infile(binaryFile);
   if (!infile.good()) {
-    /* fall back mode to check whether verify.xclbin present or not */
-    b_file = "/verify.xclbin";
-    binaryFile = test_path + b_file;
-    std::ifstream infile(binaryFile);
-    if (!infile.good()) {
-      std::cout << "NOT SUPPORTED" << std::endl;
-      return EOPNOTSUPP;
-    }
+    std::cout << "NOT SUPPORTED" << std::endl;
+    return EOPNOTSUPP;
   }
 
   auto devices = xcl::get_xil_devices();


### PR DESCRIPTION
With the new validate package, we have an xclbin for each test, i.e., 

verify.xclbin -> Verify Kernel
bandwidth.xclbin -> Bandwidth kernel
transcode.xclbin -> vcu

This makes host.cpp verify.xclbin fallback option redundant 