### PR TITLE
CR-1091252: Fixing the argument list in profile summary and trace

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -36,6 +36,11 @@ namespace xdp {
     writers.push_back(new OpenCLSummaryWriter("opencl_summary.csv")) ;
     (db->getStaticInfo()).addOpenedFile("opencl_summary.csv", "PROFILE_SUMMARY") ;
 
+    // If the OpenCL device offload plugin isn't already loaded, this
+    //  call will load the HAL device offload plugin and it will take
+    //  control of the offload.  Since there is OpenCL information we want
+    //  we should make sure the counters plugin is loaded after the
+    //  OpenCL device offload plugin when applicable.
     platform = xocl::get_shared_platform() ;
   }
 

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -34,6 +34,11 @@ namespace plugins {
       xocl::appdebug::load_xdp_app_debug() ;
     }
 
+    if (xrt_core::config::get_data_transfer_trace() != "off" ||
+        xrt_core::config::get_opencl_device_counter()) {
+      xdp::device_offload::load() ;
+    }
+
     if (xrt_core::config::get_profile() ||
         xrt_core::config::get_opencl_summary()) {
       xocl::profile::load_xdp_opencl_counters() ;
@@ -46,11 +51,6 @@ namespace plugins {
 
     if (xrt_core::config::get_lop_trace()) {
       xdp::lop::load() ;
-    }
-
-    if (xrt_core::config::get_data_transfer_trace() != "off" ||
-        xrt_core::config::get_opencl_device_counter()) {
-      xdp::device_offload::load() ;
     }
 
     // Deprecation warnings specific to the .ini flags


### PR DESCRIPTION
Adjusted the order of loading the OpenCL level profiling plugins in order to break a dependency that was causing the HAL level device offload plugin to be loaded instead of the OpenCL level device offload plugin.
