### PR TITLE
CR-1092167: Adding emulation files in the run summary only when they exist

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -580,6 +580,13 @@ get_launch_waveform()
 }
 
 inline std::string
+get_debug_mode()
+{
+  static std::string value = detail::get_string_value("Emulation.debug_mode", "off");
+  return value ;
+}
+
+inline std::string
 get_kernel_channel_info()
 {
   static std::string value = detail::get_string_value("Runtime.kernel_channels","");

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -22,8 +22,6 @@
 #include "xdp/profile/plugin/opencl/counters/opencl_counters_plugin.h"
 #include "xdp/profile/writer/opencl/opencl_summary_writer.h"
 
-#include "core/common/config_reader.h"
-
 #ifdef _WIN32
 /* Disable warning for use of std::getenv */
 #pragma warning (disable : 4996)
@@ -61,14 +59,10 @@ namespace xdp {
 
   void OpenCLCountersProfilingPlugin::emulationSetup()
   {
-    XDPPlugin::emulationSetup() 
-;
-
-    std::string debug_mode = xrt_core::config::get_debug_mode() ;
-    bool copy_happens = (debug_mode == "gui" || debug_mode == "batch") ;
+    XDPPlugin::emulationSetup() ;
 
     char* internalsSummary = getenv("VITIS_KERNEL_PROFILE_FILENAME") ;
-    if (internalsSummary != nullptr && copy_happens) {
+    if (internalsSummary != nullptr && emulationFilesCopied()) {
       (db->getStaticInfo()).addOpenedFile(internalsSummary, "KERNEL_PROFILE");
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -22,6 +22,8 @@
 #include "xdp/profile/plugin/opencl/counters/opencl_counters_plugin.h"
 #include "xdp/profile/writer/opencl/opencl_summary_writer.h"
 
+#include "core/common/config_reader.h"
+
 #ifdef _WIN32
 /* Disable warning for use of std::getenv */
 #pragma warning (disable : 4996)
@@ -61,8 +63,12 @@ namespace xdp {
   {
     XDPPlugin::emulationSetup() 
 ;
+
+    std::string debug_mode = xrt_core::config::get_debug_mode() ;
+    bool copy_happens = (debug_mode == "gui" || debug_mode == "batch") ;
+
     char* internalsSummary = getenv("VITIS_KERNEL_PROFILE_FILENAME") ;
-    if (internalsSummary != nullptr) {
+    if (internalsSummary != nullptr && copy_happens) {
       (db->getStaticInfo()).addOpenedFile(internalsSummary, "KERNEL_PROFILE");
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -63,11 +63,8 @@ namespace xdp {
   {
     XDPPlugin::emulationSetup() ;
 
-    std::string debug_mode = xrt_core::config::get_debug_mode() ;
-    bool copy_happens = (debug_mode == "gui" || debug_mode == "batch") ;
-
     char* internalsTrace = getenv("VITIS_KERNEL_TRACE_FILENAME") ;
-    if (internalsTrace != nullptr && copy_happens) {
+    if (internalsTrace != nullptr && emulationFilesCopied()) {
       (db->getStaticInfo()).addOpenedFile(internalsTrace, "KERNEL_TRACE") ;
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -63,8 +63,11 @@ namespace xdp {
   {
     XDPPlugin::emulationSetup() ;
 
+    std::string debug_mode = xrt_core::config::get_debug_mode() ;
+    bool copy_happens = (debug_mode == "gui" || debug_mode == "batch") ;
+
     char* internalsTrace = getenv("VITIS_KERNEL_TRACE_FILENAME") ;
-    if (internalsTrace != nullptr) {
+    if (internalsTrace != nullptr && copy_happens) {
       (db->getStaticInfo()).addOpenedFile(internalsTrace, "KERNEL_TRACE") ;
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -23,6 +23,7 @@
 #include "xdp/profile/database/database.h"
 
 #include "core/common/time.h"
+#include "core/common/config_reader.h"
 
 #ifdef _WIN32
 #pragma warning(disable : 4996)
@@ -52,9 +53,12 @@ namespace xdp {
     if (waveformSetup) return ;
     waveformSetup = true ;
 
+    std::string debug_mode = xrt_core::config::get_debug_mode() ;
+    bool copy_happens = (debug_mode == "gui" || debug_mode == "batch") ;
+
     // For hardware emulation flows, check to see if there is a wdb and wcfg
     char* wdbFile = getenv("VITIS_WAVEFORM_WDB_FILENAME") ;
-    if (wdbFile != nullptr) {
+    if (wdbFile != nullptr && copy_happens) {
       (db->getStaticInfo()).addOpenedFile(wdbFile, "WAVEFORM_DATABASE") ;
 
       // Also the wcfg

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -53,12 +53,9 @@ namespace xdp {
     if (waveformSetup) return ;
     waveformSetup = true ;
 
-    std::string debug_mode = xrt_core::config::get_debug_mode() ;
-    bool copy_happens = (debug_mode == "gui" || debug_mode == "batch") ;
-
     // For hardware emulation flows, check to see if there is a wdb and wcfg
     char* wdbFile = getenv("VITIS_WAVEFORM_WDB_FILENAME") ;
-    if (wdbFile != nullptr && copy_happens) {
+    if (wdbFile != nullptr && emulationFilesCopied()) {
       (db->getStaticInfo()).addOpenedFile(wdbFile, "WAVEFORM_DATABASE") ;
 
       // Also the wcfg
@@ -67,6 +64,16 @@ namespace xdp {
       configName += ".wcfg" ;
       (db->getStaticInfo()).addOpenedFile(configName, "WAVEFORM_CONFIGURATION");
     }
+  }
+
+  bool XDPPlugin::emulationFilesCopied()
+  {
+    // In hardware emulation, the WDB, WCFG, and kernel internal files
+    // are only copied if debug_mode is gui or batch.
+    static bool copyHappened =
+      (xrt_core::config::get_debug_mode() == "gui" ||
+       xrt_core::config::get_debug_mode() == "batch");
+    return copyHappened ;
   }
 
   void XDPPlugin::writeAll(bool openNewFiles)

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -62,6 +62,7 @@ namespace xdp {
     // If there is something that is common amongst all plugins when
     //  dealing with emulation flows.
     XDP_EXPORT virtual void emulationSetup() ;
+    XDP_EXPORT bool emulationFilesCopied() ;
 
     XDP_EXPORT void startWriteThread(unsigned int interval, std::string type);
     XDP_EXPORT void endWrite(bool openNewFiles);

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -174,7 +174,7 @@ namespace xdp {
     {
       std::stringstream setting ;
       setting << "XRT_INI_SETTING,debug_mode,"
-	      << xrt_core::config::get_launch_waveform() ;
+	      << xrt_core::config::get_debug_mode() ;
       iniSettings.push_back(setting.str()) ;
     }
     {


### PR DESCRIPTION
With this change, XDP now checks the Emulation.debug_mode setting in the ini file.  If the setting is either batch or gui, then the WDB, WCFG, and kernel internal files will be copied to the local directory and only then should be added to the run summary.

Note that the environment variables are still necessary as they have the names of the files, but they are not sufficient as the environment variables are set even in cases where the files are not copied.

Also note, XDP is going off of the debug_mode flag as the launch_waveform flag has been deprecated.  Any tests or applications that set launch_waveform will not see the emulation files in the run summary.