### PR TITLE
CR-1091338: Fixing device side events that had multiple end events match a single start event

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -83,7 +83,6 @@ namespace xdp {
         memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, deviceId, slot, cuId);
         memEvent->setDeviceTimestamp(trace.Timestamp);
         db->getDynamicInfo().addEvent(memEvent);
-        db->getDynamicInfo().markDeviceEventStart(trace.TraceID, memEvent);
         matchingStart = memEvent;
 
         // Also, progress time so the end is after the start
@@ -105,7 +104,6 @@ namespace xdp {
           memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, deviceId, slot, cuId);
           memEvent->setDeviceTimestamp(trace.Timestamp);
           db->getDynamicInfo().addEvent(memEvent);
-          db->getDynamicInfo().markDeviceEventStart(trace.TraceID, memEvent);
           matchingStart = memEvent;
           // Also, progress time so the end is after the start
           hostTimestamp += halfCycleTimeInMs;


### PR DESCRIPTION
When handling pulses on the device side (events that have a start and stop event on the same cycle), we are creating dummy start events to match with the end events.  We were erroneously marking these dummy events as start events to be matched later on by adding them to the database.  This pull request removes the marking of those dummy events in the database.
