### PR TITLE
CR-1090645 Be able to reinstate revert to golden to work only when it…

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_flash.cpp
@@ -395,21 +395,6 @@ static int resetShell(unsigned index, bool force)
     if(!flasher.isValid())
         return -EINVAL;
 
-    // Hack: u30 doesn't support factory reset yet
-    // To be removed after in
-    auto mgmt_dev = pcidev::get_dev(index, false);
-    std::string errmsg, vbnv;
-    mgmt_dev->sysfs_get( "rom", "VBNV", errmsg, vbnv );
-    if (!errmsg.empty()) {
-        std::cerr << errmsg << std::endl;
-        return -EINVAL;
-    }
-    
-    if (vbnv.find("_u30_") != std::string::npos) {
-        std::cout << "Factory reset is not currently supported on U30.\n" << std::endl;
-        return -ECANCELED;
-    }
-
     std::cout << "CAUTION: Resetting Card [" << flasher.sGetDBDF() <<
         "] back to factory mode." << std::endl;
     if(!force && !canProceed())

--- a/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/firmware_image.h
@@ -31,6 +31,7 @@
 // directory where all MCS files are saved
 #define FIRMWARE_DIRS       {"/lib/firmware/xilinx/", "/lib/firmware/arista/"}
 #define FORMATTED_FW_DIR    "/opt/xilinx/firmware"
+#define QSPI_GOLDEN_IMAGE   "BOOT_golden.BIN"	
 #define DSA_FILE_SUFFIX     "mcs"
 #define DSABIN_FILE_SUFFIX  "dsabin"
 #define XSABIN_FILE_SUFFIX  "xsabin"

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.cpp
@@ -19,6 +19,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+#include <boost/algorithm/string.hpp>
+#include "boost/filesystem.hpp"
 #include "flasher.h"
 #include "core/pcie/linux/scan.h"
 #include "core/pcie/driver/linux/include/mgmt-reg.h"
@@ -128,7 +130,14 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         XQSPIPS_Flasher xqspi_ps(mDev);
         if (primary == nullptr)
         {
-            retVal = xqspi_ps.revertToMFG();
+            std::string golden_file = getQspiGolden();
+            if (golden_file.empty()) {
+                std::cout << "ERROR: Doesn't find golden in base pkg" << std::endl;
+                return -ECANCELED;
+            }
+            std::shared_ptr<firmwareImage> golden_image;
+            golden_image = std::make_shared<firmwareImage>(golden_file.c_str(), MCS_FIRMWARE_PRIMARY);
+            retVal = xqspi_ps.revertToMFG(*golden_image);
         }
         else
         {
@@ -424,6 +433,48 @@ DSAInfo Flasher::getOnBoardDSA()
         bmc = DSAInfo::UNKNOWN; // BMC not ready, set it to an invalid version string
 
     return DSAInfo(vbnv, ts, uuid, bmc);
+}
+
+/*
+ * For card with qspi flash like u30, u25, the golden image is supposed to
+ * be flashed at offset 96MB when the card is shipped. however, for some
+ * historical reason, the golden on some board is flashed at offset 0. As
+ * a result, the default revert_to_golden, which erases 0-96MB will brick the
+ * board. To avoid that, before revert_to_golden, flasher will check whether
+ * there is golden at 96MB. To do that, the base pkg will also install the
+ * golden file at, eg 
+ * /opt/xilinx/firmware/u30/gen3x4/base/data/BOOT_golden.BIN
+ * then flasher will compare the contents on flash at 96MB with the file to
+ * see whether the golden is there.
+ * Note: xrt doesn't support flash golden. and once the card is shipped with
+ * golden, we assume all versions of shell pkg have same golden -- new pkg
+ * just installs the golden at same location
+ * If the golden file is not found on disk, or the golden image is not found 
+ * at 96MB, we don't do revert_to_golden.
+ */
+std::string Flasher::getQspiGolden()
+{
+    std::string err;
+    std::string board_name;
+    mDev->sysfs_get("", "board_name", err, board_name);
+    if (!err.empty()) 
+        return "";
+    
+    if (board_name.empty())
+        return "";
+
+    std::string start = FORMATTED_FW_DIR;
+    start += "/";
+    start += board_name;
+    boost::filesystem::recursive_directory_iterator dir(start), end;
+    while (dir != end) {
+        std::string fn = dir->path().filename().string();
+        if (!fn.compare(QSPI_GOLDEN_IMAGE)) {
+            return dir->path().string();
+        }
+        dir++;
+    }
+    return "";
 }
 
 std::string Flasher::sGetDBDF()

--- a/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/flasher.h
@@ -77,6 +77,7 @@ public:
     int upgradeBMCFirmware(firmwareImage* bmc);
     bool isValid(void) { return mDev != nullptr; }
 
+    std::string getQspiGolden();
     std::string sGetDBDF();
     std::string sGetFlashType() { return std::string( getFlasherTypeText( getFlashType() ) ); }
     DSAInfo getOnBoardDSA();

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.h
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.h
@@ -43,7 +43,9 @@ class XQSPIPS_Flasher
 public:
     XQSPIPS_Flasher(std::shared_ptr<pcidev::pci_device> dev);
     ~XQSPIPS_Flasher();
-    int revertToMFG();
+    void program(std::istream& binStream, unsigned base = 0);
+    int verify(std::istream& binStream, unsigned base = 0, bool quiet = false);
+    int revertToMFG(std::istream& binStream);
     int xclUpgradeFirmware(std::istream& binStream);
 
 private:

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.h
@@ -31,6 +31,8 @@
 
 // directory where all MCS files are saved
 #define FIRMWARE_DIRS       {"/lib/firmware/xilinx", "/lib/firmware/arista", "C:\\Xilinx"}
+#define FORMATTED_FW_DIR    "/opt/xilinx/firmware"
+#define QSPI_GOLDEN_IMAGE   "BOOT_golden.BIN"	
 #define DSA_FILE_SUFFIX     "mcs"
 #define DSABIN_FILE_SUFFIX  "dsabin"
 #define XSABIN_FILE_SUFFIX  "xsabin"

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -28,6 +28,8 @@
 #include <cstring>
 #include <cstdarg>
 #include "boost/format.hpp"
+#include <boost/algorithm/string.hpp>
+#include "boost/filesystem.hpp"
 
 
 #define INVALID_ID      0xffff
@@ -124,7 +126,14 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         XQSPIPS_Flasher xqspi_ps(m_device);
         if (primary == nullptr)
         {
-            retVal = xqspi_ps.revertToMFG();
+            std::string golden_file = getQspiGolden();
+            if (golden_file.empty()) {
+                std::cout << "ERROR: Doesn't find golden in base pkg" << std::endl;
+                return -ECANCELED;
+            }
+            std::shared_ptr<firmwareImage> golden_image;
+            golden_image = std::make_shared<firmwareImage>(golden_file.c_str(), MCS_FIRMWARE_PRIMARY);
+            retVal = xqspi_ps.revertToMFG(*golden_image);
         }
         else
         {
@@ -379,6 +388,43 @@ DSAInfo Flasher::getOnBoardDSA()
         bmc = "UNKNOWN"; // BMC not ready, set it to an invalid version string
 
     return DSAInfo(vbnv, ts, uuid, bmc);
+}
+
+/*
+ * For card with qspi flash like u30, u25, the golden image is supposed to
+ * be flashed at offset 96MB when the card is shipped. however, for some
+ * historical reason, the golden on some board is flashed at offset 0. As
+ * a result, the default revert_to_golden, which erases 0-96MB will brick the
+ * board. To avoid that, before revert_to_golden, flasher will check whether
+ * there is golden at 96MB. To do that, the base pkg will also install the
+ * golden file at, eg 
+ * /opt/xilinx/firmware/u30/gen3x4/base/data/BOOT_golden.BIN
+ * then flasher will compare the contents on flash at 96MB with the file to
+ * see whether the golden is there.
+ * Note: xrt doesn't support flash golden. and once the card is shipped with
+ * golden, we assume all versions of shell pkg have same golden -- new pkg
+ * just installs the golden at same location
+ * If the golden file is not found on disk, or the golden image is not found 
+ * at 96MB, we don't do revert_to_golden.
+ */
+std::string Flasher::getQspiGolden()
+{
+    std::string board_name = xrt_core::device_query<xrt_core::query::board_name>(m_device);
+    if (board_name.empty())
+        return "";
+
+    std::string start = FORMATTED_FW_DIR;
+    start += "/";
+    start += board_name;
+    boost::filesystem::recursive_directory_iterator dir(start), end;
+    while (dir != end) {
+        std::string fn = dir->path().filename().string();
+        if (!fn.compare(QSPI_GOLDEN_IMAGE)) {
+            return dir->path().string();
+        }
+        dir++;
+    }
+    return "";
 }
 
 std::string Flasher::sGetDBDF()

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -128,7 +128,7 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         {
             std::string golden_file = getQspiGolden();
             if (golden_file.empty()) {
-                std::cout << "ERROR: Doesn't find golden in base pkg" << std::endl;
+                std::cout << "ERROR: Golden image not found in base package. Can't revert to golden" << std::endl;
                 return -ECANCELED;
             }
             std::shared_ptr<firmwareImage> golden_image;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
@@ -71,6 +71,7 @@ public:
     int upgradeBMCFirmware(firmwareImage* bmc);
     bool isValid(void) { return m_device != nullptr; }
 
+    std::string getQspiGolden();
     std::string sGetDBDF();
     std::string sGetFlashType() { return std::string( getFlasherTypeText( getFlashType() ) ); }
     DSAInfo getOnBoardDSA();

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -452,7 +452,7 @@ int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
     bool verified = true;
 
     binStream.seekg(0, binStream.end);
-    total_size = binStream.tellg();
+    total_size = static_cast<int>(binStream.tellg());
     binStream.seekg(0, binStream.beg);
 
 #if SAVE_FILE

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -530,7 +530,7 @@ int XQSPIPS_Flasher::revertToMFG(std::istream& binStream)
     enterOrExitFourBytesMode(ENTER_4B);
 
     if (verify(binStream, GOLDEN_BASE)) {
-	    std::cout << "[ERROR]: Doesn't find valid golden on flash !!" << std::endl;
+	    std::cout << "[ERROR]: Doesn't find valid golden on flash. Can't revert to golden" << std::endl;
 	    return -ECANCELED;
     }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -382,7 +382,131 @@ bool XQSPIPS_Flasher::waitTxEmpty()
     return false;
 }
 
-int XQSPIPS_Flasher::revertToMFG(void)
+void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
+{
+    int total_size = 0;
+    int remain = 0;
+    int pages = 0;
+    unsigned addr = 0;
+    unsigned size = 0;
+    int beatCount = 0;
+
+    binStream.seekg(0, binStream.end);
+    total_size = static_cast<int>(binStream.tellg());
+    binStream.seekg(0, binStream.beg);
+
+    pages = total_size / PAGE_SIZE;
+    remain = total_size % PAGE_SIZE;
+
+#if defined(_DEBUG)
+    std::cout << "Verify earse flash" << std::endl;
+    int mismatched = 0;
+    for (int page = 0; page <= pages; page++) {
+        addr = page * PAGE_SIZE;
+        if (page != pages)
+            size = PAGE_SIZE;
+        else
+            size = remain;
+
+        readFlash(base + addr, size);
+        for (unsigned i = 0; i < size; i++) {
+            if (0xFF != mReadBuffer[i]) {
+                mismatched = 1;
+            }
+        }
+
+        if (mismatched) {
+            std::cout << "Erase failed at page " << page << std::endl;
+            mismatched = 0;
+        }
+
+    }
+#endif
+
+    beatCount = 0;
+    XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
+    for (int page = 0; page <= pages; page++) {
+        program_flash.update(beatCount++);
+
+        addr = page * PAGE_SIZE;
+        if (page != pages)
+            size = PAGE_SIZE;
+        else
+            size = remain;
+
+        binStream.read((char *)mWriteBuffer, size);
+        writeFlash(base + addr, size);
+    }
+    program_flash.finish(true, "Flash programmed");
+}
+
+int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
+{
+    int total_size = 0;
+    int remain = 0;
+    int pages = 0;
+    unsigned addr = 0;
+    unsigned size = 0;
+    int beatCount = 0;
+    int mismatched = 0;
+    bool verified = true;
+
+    binStream.seekg(0, binStream.end);
+    total_size = binStream.tellg();
+    binStream.seekg(0, binStream.beg);
+
+#if SAVE_FILE
+    std::ofstream of_flash;
+    of_flash.open("/tmp/BOOT.BIN", std::ofstream::out);
+    if (!of_flash.is_open()) {
+        std::cout << "Could not open /tmp/BOOT.BIN" << std::endl;
+        return false;
+    }
+#endif
+
+    remain = total_size % PAGE_SIZE;
+    pages = total_size / PAGE_SIZE;
+
+    beatCount = 0;
+    XBU::ProgressBar verify_flash("Verifying flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
+    for (int page = 0; page <= pages; page++) {
+        verify_flash.update(beatCount++);
+
+        addr = page * PAGE_SIZE;
+        if (page != pages)
+            size = PAGE_SIZE;
+        else
+            size = remain;
+
+        binStream.read((char *)mWriteBuffer, size);
+
+        readFlash(base + addr, size);
+
+        mismatched = 0;
+        for (unsigned i = 0; i < size; i++) {
+#if SAVE_FILE
+            of_flash << mReadBuffer[i];
+#endif
+            if (mWriteBuffer[i] != mReadBuffer[i]) {
+                mismatched = 1;
+                break;
+            }
+        }
+        if (mismatched) {
+            verified = false;
+            break;
+        }
+    }
+    verify_flash.finish(verified, "Flash verified");
+
+#if SAVE_FILE
+    of_flash.close();
+#endif
+
+    return mismatched;
+}
+
+int XQSPIPS_Flasher::revertToMFG(std::istream& binStream)
 {
     initQSpiPS();
 
@@ -405,6 +529,11 @@ int XQSPIPS_Flasher::revertToMFG(void)
     /* Use 4 bytes address mode */
     enterOrExitFourBytesMode(ENTER_4B);
 
+    if (verify(binStream, GOLDEN_BASE)) {
+	    std::cout << "[ERROR]: Doesn't find valid golden on flash !!" << std::endl;
+	    return -ECANCELED;
+    }
+
     // Sectoer size is defined by SECTOR_SIZE
     eraseSector(0, GOLDEN_BASE);
     
@@ -414,12 +543,6 @@ int XQSPIPS_Flasher::revertToMFG(void)
 int XQSPIPS_Flasher::xclUpgradeFirmware(std::istream& binStream)
 {
     int total_size = 0;
-    int remain = 0;
-    int pages = 0;
-    unsigned addr = 0;
-    unsigned size = 0;
-    int beatCount = 0;
-    int mismatched = 0;
 
     binStream.seekg(0, binStream.end);
     total_size = static_cast<int>(binStream.tellg());
@@ -461,98 +584,8 @@ int XQSPIPS_Flasher::xclUpgradeFirmware(std::istream& binStream)
     eraseSector(0, GOLDEN_BASE);
     //eraseBulk();
 
-    pages = total_size / PAGE_SIZE;
-    remain = total_size % PAGE_SIZE;
-
-#if defined(_DEBUG)
-    std::cout << "Verify earse flash" << std::endl;
-    for (int page = 0; page <= pages; page++) {
-        addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
-
-        readFlash(addr, size);
-        for (unsigned i = 0; i < size; i++) {
-            if (0xFF != mReadBuffer[i]) {
-                mismatched = 1;
-            }
-        }
-
-        if (mismatched) {
-            std::cout << "Erase failed at page " << page << std::endl;
-            mismatched = 0;
-        }
-
-    }
-#endif
-
-    beatCount = 0;
-    XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
-    for (int page = 0; page <= pages; page++) {
-        program_flash.update(beatCount++);
-        // if (beatCount % 4000 == 0) {
-        //     std::cout << "." << std::flush;
-        // }
-
-        addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
-
-        binStream.read((char *)mWriteBuffer, size);
-        writeFlash(addr, size);
-    }
-    program_flash.finish(true, "Flash programmed");
-
-    /* Verify (just for debug) */
-    binStream.seekg(0, binStream.beg);
-
-#if SAVE_FILE
-    std::ofstream of_flash;
-    of_flash.open("/tmp/BOOT.BIN", std::ofstream::out);
-    if (!of_flash.is_open()) {
-        std::cout << "Could not open /tmp/BOOT.BIN" << std::endl;
-        return false;
-    }
-#endif
-
-    remain = total_size % PAGE_SIZE;
-    pages = total_size / PAGE_SIZE;
-
-    beatCount = 0;
-    XBU::ProgressBar verify_flash("Verifying flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
-    for (int page = 0; page <= pages; page++) {
-        verify_flash.update(beatCount++);
-
-        addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
-
-        binStream.read((char *)mWriteBuffer, size);
-
-        readFlash(addr, size);
-
-        mismatched = 0;
-        for (unsigned i = 0; i < size; i++) {
-#if SAVE_FILE
-            of_flash << mReadBuffer[i];
-#endif
-            if (mWriteBuffer[i] != mReadBuffer[i])
-                mismatched = 1;
-        }
-        if (mismatched)
-            verify_flash.finish(false, boost::str(boost::format("Mismatch found at %d page\n") % page));
-    }
-    verify_flash.finish(true, "Flash verified");
-
-#if SAVE_FILE
-    of_flash.close();
-#endif
+    program(binStream);
+    verify(binStream);
 
     enterOrExitFourBytesMode(EXIT_4B);
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
@@ -42,7 +42,9 @@ class XQSPIPS_Flasher
 public:
     XQSPIPS_Flasher(std::shared_ptr<xrt_core::device> dev);
     ~XQSPIPS_Flasher();
-    int revertToMFG();
+    void program(std::istream& binStream, unsigned base = 0);
+    int verify(std::istream& binStream, unsigned base = 0);
+    int revertToMFG(std::istream& binStream);
     int xclUpgradeFirmware(std::istream& binStream);
 
 private:


### PR DESCRIPTION
…'s the correct card
xbmgmt2 test example,

case 1: there is no golden file in base pkg,
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# /tmp/xbmgmt2 program --revert-to-golden -d 17:00.0
INFO     : Resetting card [ 0000:17:00.0 ] back to factory mode. 
Are you sure you wish to proceed? [Y/n]: y
ERROR: Doesn't find golden in base pkg

case2: the golden in base pkg is not the same to the one on flash
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# /tmp/xbmgmt2 program --revert-to-golden -d 17:00.0
INFO     : Resetting card [ 0000:17:00.0 ] back to factory mode. 
Are you sure you wish to proceed? [Y/n]: y
[FAILED] : Flash verified < 0s >
[ERROR]: Doesn't find valid golden on flash !!

case3: normal case flash one device
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# /tmp/xbmgmt2 program --revert-to-golden -d 17:00.0
INFO     : Resetting card [ 0000:17:00.0 ] back to factory mode. 
Are you sure you wish to proceed? [Y/n]: y
[PASSED] : Flash verified < 5s >
[PASSED] : Flash erased < 1m 49s >
INFO     : Shell on [ 0000:17:00.0 ] is reset successfully.
****************************************************
Cold reboot machine to load the new image on card(s).
****************************************************

case4: normal case flash all devices
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# /tmp/xbmgmt2 program --revert-to-golden -d all
INFO     : Resetting card [ 0000:66:00.0 ] back to factory mode. 
INFO     : Resetting card [ 0000:18:00.0 ] back to factory mode. 
INFO     : Resetting card [ 0000:17:00.0 ] back to factory mode. 
Are you sure you wish to proceed? [Y/n]: n
Action canceled.
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# echo 1 >/sys/bus/pci/devices/0000\:66\:00.1/remove
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# echo 1 >/sys/bus/pci/devices/0000\:66\:00.0/remove
root@xsjbrd100bx:/opt/xilinx/firmware/u30/gen3x4/base/data# /tmp/xbmgmt2 program --revert-to-golden -d all
INFO     : Resetting card [ 0000:18:00.0 ] back to factory mode. 
INFO     : Resetting card [ 0000:17:00.0 ] back to factory mode. 
Are you sure you wish to proceed? [Y/n]: y
[PASSED] : Flash verified < 5s >
[PASSED] : Flash erased < 1m 47s >
INFO     : Shell on [ 0000:18:00.0 ] is reset successfully.
[PASSED] : Flash verified < 5s >
[PASSED] : Flash erased < 7s >
INFO     : Shell on [ 0000:17:00.0 ] is reset successfully.
****************************************************
Cold reboot machine to load the new image on card(s).
****************************************************

