### PR TITLE
VITIS-1114 XRT caching framework

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -415,6 +415,26 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl)
 }
 
 int
+xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid)
+{
+  try {
+    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, uuid]{
+      auto device = get_device(dhdl);
+      device->load_xclbin(uuid);
+      return 0;
+    });
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return (errno = ex.get());
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+    return (errno = 0);
+  }
+}
+
+int
 xrtDeviceGetXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
 {
   try {

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -200,6 +200,10 @@ public:
   void
   load_xclbin(const xrt::xclbin& xclbin);
 
+  XRT_CORE_COMMON_EXPORT
+  void
+  load_xclbin(const uuid& xclbin_id);
+
   /**
    * register_axlf() - Callback from shim after AXLF succesfully loaded
    *

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -170,6 +170,9 @@ struct ishim
 
   virtual void
   stop_profiling(int phdl) = 0;
+
+  virtual void
+  load_axlf_meta(const axlf*) = 0;
 #endif
 };
 
@@ -508,6 +511,12 @@ struct shim : public DeviceType
       throw error(ret, "fail to wait gmio");
   }
 
+  virtual void
+  load_axlf_meta(const axlf* buffer)
+  {
+    if (auto ret = xclLoadXclBinMeta(DeviceType::get_device_handle(), buffer))
+      throw error(ret, "failed to load xclbin");
+  }
 #endif
 };
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -78,6 +78,7 @@ enum class key_type
   kds_mode,
   kds_cu_stat,
   kds_scu_stat,
+  xclbin_full,
 
   xmc_version,
   xmc_board_name,
@@ -622,6 +623,15 @@ struct mem_topology_raw : request
 {
   using result_type = std::vector<char>;
   static const key_type key = key_type::mem_topology_raw;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct xclbin_full : request
+{
+  using result_type = std::vector<char>;
+  static const key_type key = key_type::xclbin_full;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
 /*
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Author(s):
  *        Min Ma <min.ma@xilinx.com>
@@ -119,6 +119,8 @@ struct drm_zocl_dev {
 	struct debug_ip_layout	*debug_ip;
 	struct connectivity	*connectivity;
 	struct addr_aperture	*apertures;
+	struct axlf             *axlf;
+	size_t                   axlf_size;
 	struct aie_metadata	 aie_data;
 	unsigned int		 num_apts;
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -29,7 +29,7 @@ int zocl_unlock_bitstream(struct drm_zocl_dev *zdev, const uuid_t *id);
 
 int zocl_xclbin_refcount(struct drm_zocl_dev *zdev);
 int zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev,
-	struct drm_zocl_axlf *axlf_obj);
+	struct drm_zocl_axlf *axlf_obj, struct sched_client_ctx *client);
 int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data);
 
 bool zocl_xclbin_accel_adapter(int kds_mask);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -77,6 +77,11 @@ void zocl_free_sections(struct drm_zocl_dev *zdev)
 		vfree(zdev->topology);
 		CLEAR(zdev->topology);
 	}
+	if (zdev->axlf) {
+		vfree(zdev->axlf);
+		CLEAR(zdev->axlf);
+		zdev->axlf_size = 0;
+	}
 }
 
 #if KERNEL_VERSION(5, 3, 0) <= LINUX_VERSION_CODE

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ioctl.c
@@ -41,10 +41,11 @@ zocl_read_axlf_ioctl(struct drm_device *ddev, void *data, struct drm_file *filp)
 {
 	struct drm_zocl_axlf *axlf_obj = data;
 	struct drm_zocl_dev *zdev = ZOCL_GET_ZDEV(ddev);
+	struct sched_client_ctx *client = filp->driver_priv;
 	int ret;
 
 	mutex_lock(&zdev->zdev_xclbin_lock);
-	ret = zocl_xclbin_read_axlf(zdev, axlf_obj);
+	ret = zocl_xclbin_read_axlf(zdev, axlf_obj, client);
 	mutex_unlock(&zdev->zdev_xclbin_lock);
 
 	return ret;

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -941,3 +941,10 @@ xclStopProfiling(xclDeviceHandle handle, int phdl)
 {
   return 0;
 }
+
+int
+xclLoadXclBinMeta(xclDeviceHandle handle, const xclBin *buffer)
+{
+  return 0;
+}
+

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -274,6 +274,7 @@ initialize_query_table()
   emplace_sysfs_get<query::memstat>                   ("memstat");
   emplace_sysfs_get<query::memstat_raw>               ("memstat_raw");
   emplace_sysfs_get<query::error>                     ("errors");
+  emplace_sysfs_get<query::xclbin_full>               ("xclbin_full");
   emplace_func0_request<query::pcie_bdf,                bdf>();
   emplace_func0_request<query::board_name,              board_name>();
   emplace_func0_request<query::is_ready,                is_ready>();

--- a/src/runtime_src/core/include/experimental/xrt_device.h
+++ b/src/runtime_src/core/include/experimental/xrt_device.h
@@ -395,6 +395,21 @@ int
 xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl);
 
 /**
+ * xrtDeviceLoadXclbinHandle() - load an xclbin from an xrt::xclbin handle
+ *
+ * @dhdl:       Handle to device previously opened with xrtDeviceOpen
+ * @uuid:       uuid_t struct of xclbin id
+ * Return:      0 on success, error otherwise
+ *
+ * This function reads the xclbin id already loaded in the system and
+ * comapres it with the input uuid. If they match, load the cached
+ * xclbin metadata into caller's process. Otherwise returns error.
+ */
+XCL_DRIVER_DLLESPEC
+int
+xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid);
+
+/**
  * xrtDeviceGetXclbinUUID() - Get UUID of xclbin image loaded on device
  *
  * @dhdl:   Handle to device previously opened with xrtDeviceOpen

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -84,4 +84,8 @@ xclReadProfiling(xclDeviceHandle handle, int phdl);
 
 int
 xclStopProfiling(xclDeviceHandle handle, int phdl);
+
+int
+xclLoadXclBinMeta(xclDeviceHandle handle, const xclBin *buffer);
+
 #endif


### PR DESCRIPTION
This PR added the following feature
1) Added a new xrt level C api to use xclbin loaded onto the system by specify xclbin UUID
    int xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid);
   This API, now, only works on VCK190 platform to support AIE multi-processes; Calling this API on other platform will get error 
    "load xclbin by uuid is not supported"
   It will be extended to support other edge platform and DC in future PRs
2) In zocl driver, we will error out when shared AIE context tries to load AIE only xclbin because shared context does not allow to change the hardware
3) When valid context loads AIE only xclbin, the xclbin blob will be cached into a sysfs node. So that any AIE context can load this cached xclbin by its UUID. (because it does not change hardware)
