### PR TITLE
Update static boost build for later versions of boost

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -82,6 +82,18 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
   find_package(Boost
     HINTS $ENV{XRT_BOOST_INSTALL}
     REQUIRED COMPONENTS system filesystem program_options)
+
+  # A bug in FindBoost maybe?  Doesn't set Boost_LIBRARY_DIRS when
+  # Boost install has only static libraries. For static tool linking
+  # this variable is needed in order for linker to locate the static
+  # libraries.  Another bug in FindBoost fails to find static
+  # libraries when shared ones are present too.
+  if (Boost_FOUND AND "${Boost_LIBRARY_DIRS}" STREQUAL "")
+    set (Boost_LIBRARY_DIRS $ENV{XRT_BOOST_INSTALL}/lib)
+  endif()
+
+  # Some later versions of boost spews warnings form property_tree
+  add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 else()
   find_package(Boost 
     REQUIRED COMPONENTS system filesystem program_options)

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -42,7 +42,14 @@
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
 #ifndef NO_BOOST_PROCESS
-#include <boost/process.hpp>
+# ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunused-result"
+# endif
+# include <boost/process.hpp>
+# ifdef __GNUC__
+#  pragma GCC diagnostic pop
+# endif
 #endif
 
 // System - Include Files

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 # Static build is a Linux / Ubuntu option only
 if (XRT_STATIC_BUILD)
   add_executable(${XBMGMT2_NAME}_static ${XBMGMT_V2_SRCS})
-  target_link_options(${XBMGMT2_NAME}_static PRIVATE "-static")
+  target_link_options(${XBMGMT2_NAME}_static PRIVATE "-static" "-L${Boost_LIBRARY_DIRS}")
   target_compile_definitions(${XBMGMT2_NAME}_static PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
   # Bypass FindBoost versions and just link explicitly with boost libraries
   # The -static link option will pick the static libraries. 

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 if (XRT_STATIC_BUILD)
   add_executable(${XBUTIL2_NAME}_static ${XBUTIL_V2_SRCS})
   target_compile_definitions(${XBUTIL2_NAME}_static PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
-  target_link_options(${XBUTIL2_NAME}_static PRIVATE "-static")
+  target_link_options(${XBUTIL2_NAME}_static PRIVATE "-static" "-L${Boost_LIBRARY_DIRS}")
   # Bypass FindBoost versions and just link explicitly with boost libraries
   # The -static link option will pick the static libraries.
   target_link_libraries(${XBUTIL2_NAME}_static

--- a/tests/validate/verify_test/CMakeLists.txt
+++ b/tests/validate/verify_test/CMakeLists.txt
@@ -45,7 +45,11 @@ if (XRT_STATIC_BUILD)
     ../common/includes/cmdparser/cmdlineparser.cpp
     ../common/includes/logger/logger.cpp src/host.cpp
     )
-  target_link_options(${TESTNAME_STATIC} PRIVATE "-static")
+  # Specify path directory with boost static libraries. The boost link dir
+  # should be same as the one used to build XRT. In most case this is the
+  # default /usr/lib, but if XRT was built with -with-static-boost, then
+  # the libraries cannot be located without specified the link path.
+  target_link_options(${TESTNAME_STATIC} PRIVATE "-static" "-L${Boost_LIBRARY_DIRS}")
   target_link_libraries(${TESTNAME_STATIC}
     PRIVATE
     # force linking of whole archive to enable static globals


### PR DESCRIPTION
```
% src/runtime_src/tools/scripts/boost.sh -prefix <dir>/boost-1.75.0 boost-1.75.0
% build/build.sh -with-static-boost <dir>/boost-1.75.0/xrt ...
```

Above ensures that XRT shared libraries are linked with static
boost libraries and all boost symbols are resolved.

This PR fixes a few build errors when using latest version of boost.
It also adds support for static linking of boost on aarch64 (arm64).
Finally, the PR ensures that local version of boost can be used when
static tool build of XRT is enabled.