### PR TITLE
Vitis-970 Consistent user facing error handling 

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -556,11 +556,9 @@ xrtAIEDeviceOpen(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -575,11 +573,9 @@ xrtAIEDeviceOpenExclusive(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -594,11 +590,9 @@ xrtAIEDeviceOpenShared(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -884,11 +884,9 @@ xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 
@@ -907,11 +905,9 @@ xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGro
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -929,11 +925,9 @@ xrtBOSubAlloc(xrtBufferHandle phdl, size_t sz, size_t offset)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -950,11 +944,9 @@ xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -969,11 +961,9 @@ xrtBOExport(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return XRT_NULL_BO_EXPORT;
 }
@@ -989,11 +979,11 @@ xrtBOFree(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -1007,11 +997,9 @@ xrtBOSize(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return 0;
 }
@@ -1029,11 +1017,11 @@ xrtBOSync(xrtBufferHandle bhdl, xclBOSyncDirection dir, size_t size, size_t offs
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -1047,11 +1035,9 @@ xrtBOMap(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -1068,11 +1054,11 @@ xrtBOWrite(xrtBufferHandle bhdl, const void* src, size_t size, size_t seek)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -1088,11 +1074,11 @@ xrtBORead(xrtBufferHandle bhdl, void* dst, size_t size, size_t skip)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -1110,11 +1096,11 @@ xrtBOCopy(xrtBufferHandle dhdl, xrtBufferHandle shdl, size_t sz, size_t dst_offs
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return errno = 0;
+    return -1;
   }
 }
 
@@ -1129,10 +1115,10 @@ xrtBOAddress(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return static_cast<uint64_t>(errno = ex.get());
+    return std::numeric_limits<uint64_t>::max();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return static_cast<uint64_t>(errno = 0);
+    return std::numeric_limits<uint64_t>::max();
   }
 }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -305,11 +305,9 @@ xrtDeviceOpen(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -324,11 +322,9 @@ xrtDeviceOpenByBDF(const char* bdf)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -344,11 +340,11 @@ xrtDeviceClose(xrtDeviceHandle dhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return (errno = ex.get());
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return (errno = 0);
+    return -1;
   }
 }
 
@@ -365,11 +361,11 @@ xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const axlf* top)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return (errno = ex.get());
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return (errno = 0);
+    return -1;
   }
 }
 
@@ -386,11 +382,11 @@ xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* fnm)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return (errno = ex.get());
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return (errno = 0);
+    return -1;
   }
 }
 
@@ -406,11 +402,11 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return (errno = ex.get());
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return (errno = 0);
+    return -1;
   }
 }
 
@@ -426,11 +422,11 @@ xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return (errno = ex.get());
+    return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return (errno = 0);
+    return -1;
   }
 }
 
@@ -466,11 +462,9 @@ xrtDeviceToXclDevice(xrtDeviceHandle dhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -485,18 +479,16 @@ xrtDeviceOpenFromXcl(xclDeviceHandle dhdl)
       // Only one xrt unmanaged device per xclDeviceHandle
       // xrtDeviceClose removes the handle from the cache
       if (device_cache.count(device.get()))
-        throw xrt_core::error(-EINVAL, "Handle is already in use");
+        throw xrt_core::error(EINVAL, "Handle is already in use");
       device_cache[device.get()] = device;
       return device.get();
     });
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -311,13 +311,12 @@ xrtErrorGetLast(xrtDeviceHandle dhdl, xrtErrorClass ecl, xrtErrorCode* error, ui
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = 1;
+    return -1;
   }
-  return errno;
 }
 
 int
@@ -343,11 +342,10 @@ xrtErrorGetString(xrtDeviceHandle, xrtErrorCode error, char* out, size_t len, si
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = 1;
+    return -1;
   }
-  return errno;
 }

--- a/src/runtime_src/core/common/api/xrt_ini.cpp
+++ b/src/runtime_src/core/common/api/xrt_ini.cpp
@@ -46,13 +46,12 @@ xrtIniStringSet(const char* key, const char* value)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = 1;
+    return -1;
   }
-  return errno;
 }
 
 int
@@ -64,11 +63,10 @@ xrtIniUintSet(const char* key, unsigned int value)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
+    return ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = 1;
+    return -1;
   }
-  return errno;
 }

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -967,11 +967,9 @@ xrtXclbinAllocFilename(const char* filename)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -990,11 +988,9 @@ xrtXclbinAllocRawData(const char* data, int size)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    errno = ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    errno = 0;
   }
   return nullptr;
 }
@@ -1038,15 +1034,11 @@ xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    // Set errno globally
-    errno = ex.get();
     return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    // Set errno globally
-    errno = 0;
-    return 0;
+    return -1;
   }
 }
 
@@ -1063,15 +1055,11 @@ xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    // Set errno globally
-    errno = ex.get();
     return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    // Set errno globally
-    errno = 0;
-    return 0;
+    return -1;
   }
 }
 
@@ -1097,15 +1085,11 @@ xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    // Set errno globally
-    errno = ex.get();
     return ex.get();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    // Set errno globally
-    errno = 0;
-    return 0;
+    return -1;
   }
 }
 
@@ -1129,7 +1113,7 @@ xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out)
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-   return -1;
+    return -1;
   }
 }
 

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -237,7 +237,7 @@ struct shim : public DeviceType
     if (ehdl == XRT_NULL_BO_EXPORT)
       throw system_error(EINVAL, "Unable to export BO");
     if (ehdl < 0) // system error code
-      throw system_error(ehdl, "Unable to export BO");
+      throw system_error(ENODEV, "Unable to export BO");
     return ehdl;
   }
 
@@ -248,7 +248,7 @@ struct shim : public DeviceType
     if (ihdl == XRT_NULL_BO)
       throw system_error(EINVAL, "unable to import BO");
     if (ihdl < 0) // system error code
-      throw system_error(ihdl, "unable to import BO");
+      throw system_error(ENODEV, "unable to import BO");
     return ihdl;
   }
 

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -194,14 +194,14 @@ struct shim : public DeviceType
   open_context(const xuid_t xclbin_uuid , unsigned int ip_index, bool shared)
   {
     if (auto ret = xclOpenContext(DeviceType::get_device_handle(), xclbin_uuid, ip_index, shared))
-      throw error(ret, "failed to open ip context");
+      throw system_error(ret, "failed to open ip context");
   }
 
   virtual void
   close_context(const xuid_t xclbin_uuid, unsigned int ip_index)
   {
     if (auto ret = xclCloseContext(DeviceType::get_device_handle(), xclbin_uuid, ip_index))
-      throw error(ret, "failed to close ip context");
+      throw system_error(ret, "failed to close ip context");
   }
 
   virtual xclBufferHandle
@@ -235,30 +235,35 @@ struct shim : public DeviceType
   {
     auto ehdl = xclExportBO(DeviceType::get_device_handle(), bo);
     if (ehdl == XRT_NULL_BO_EXPORT)
-      throw std::runtime_error("Unable to export BO");
+      throw system_error(EINVAL, "Unable to export BO");
+    if (ehdl < 0) // system error code
+      throw system_error(ehdl, "Unable to export BO");
     return ehdl;
   }
 
   virtual xclBufferHandle
   import_bo(xclBufferExportHandle ehdl)
   {
-    if (auto bo = xclImportBO(DeviceType::get_device_handle(), ehdl, 0))
-      return bo;
-    throw std::runtime_error("unable to import BO");
+    auto ihdl = xclImportBO(DeviceType::get_device_handle(), ehdl, 0);
+    if (ihdl == XRT_NULL_BO)
+      throw system_error(EINVAL, "unable to import BO");
+    if (ihdl < 0) // system error code
+      throw system_error(ihdl, "unable to import BO");
+    return ihdl;
   }
 
   virtual void
   copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset)
   {
     if (auto err = xclCopyBO(DeviceType::get_device_handle(), dst, src, size, dst_offset, src_offset))
-      throw std::runtime_error("unable to copy BO");
+      throw system_error(err, "unable to copy BO");
   }
 
   virtual void
   sync_bo(xclBufferHandle bo, xclBOSyncDirection dir, size_t size, size_t offset)
   {
     if (auto err = xclSyncBO(DeviceType::get_device_handle(), bo, dir, size, offset))
-      throw std::runtime_error("unable to sync BO");
+      throw system_error(err, "unable to sync BO");
   }
 
   virtual void*
@@ -266,35 +271,35 @@ struct shim : public DeviceType
   {
     if (auto mapped = xclMapBO(DeviceType::get_device_handle(), bo, write))
       return mapped;
-    throw std::runtime_error("could not map BO");
+    throw system_error(EINVAL, "could not map BO");
   }
 
   virtual void
   unmap_bo(xclBufferHandle bo, void* addr)
   {
     if (auto ret = xclUnmapBO(DeviceType::get_device_handle(), bo, addr))
-      throw error(ret, "failed to unmap BO");
+      throw system_error(ret, "failed to unmap BO");
   }
 
   virtual void
   get_bo_properties(xclBufferHandle bo, struct xclBOProperties *properties) const
   {
     if (auto ret = xclGetBOProperties(DeviceType::get_device_handle(), bo, properties))
-      throw error(ret, "failed to get BO properties");
+      throw system_error(ret, "failed to get BO properties");
   }
 
   virtual void
   reg_read(uint32_t ipidx, uint32_t offset, uint32_t* data) const
   {
     if (auto ret = xclRegRead(DeviceType::get_device_handle(), ipidx, offset, data))
-      throw error(ret, "failed to read ip(" + std::to_string(ipidx) + ")");
+      throw system_error(ret, "failed to read ip(" + std::to_string(ipidx) + ")");
   }
 
   virtual void
   reg_write(uint32_t ipidx, uint32_t offset, uint32_t data)
   {
     if (auto ret = xclRegWrite(DeviceType::get_device_handle(), ipidx, offset, data))
-      throw error(ret, "failed to write ip(" + std::to_string(ipidx) + ")");
+      throw system_error(ret, "failed to write ip(" + std::to_string(ipidx) + ")");
   }
 
 #ifdef __GNUC__
@@ -305,14 +310,14 @@ struct shim : public DeviceType
   xread(uint64_t offset, void* buffer, size_t size) const
   {
     if (size != xclRead(DeviceType::get_device_handle(), XCL_ADDR_KERNEL_CTRL, offset, buffer, size))
-      throw error(1, "failed to read at address (" + std::to_string(offset) + ")");
+      throw system_error(-1, "failed to read at address (" + std::to_string(offset) + ")");
   }
 
   virtual void
   xwrite(uint64_t offset, const void* buffer, size_t size)
   {
     if (size != xclWrite(DeviceType::get_device_handle(), XCL_ADDR_KERNEL_CTRL, offset, buffer, size))
-      throw error(1, "failed to write to address (" + std::to_string(offset) + ")");
+      throw system_error(-1, "failed to write to address (" + std::to_string(offset) + ")");
   }
 #ifdef __GNUC__
 # pragma GCC diagnostic pop
@@ -322,21 +327,21 @@ struct shim : public DeviceType
   unmgd_pread(void* buffer, size_t size, uint64_t offset)
   {
     if (auto ret = xclUnmgdPread(DeviceType::get_device_handle(), 0, buffer, size, offset))
-      throw error(static_cast<int>(ret), "failed to read at address (" + std::to_string(offset) + ")");
+      throw system_error(static_cast<int>(ret), "failed to read at address (" + std::to_string(offset) + ")");
   }
 
   virtual void
   unmgd_pwrite(const void* buffer, size_t size, uint64_t offset)
   {
     if (auto ret = xclUnmgdPwrite(DeviceType::get_device_handle(), 0, buffer, size, offset))
-      throw error(static_cast<int>(ret), "failed to write to address (" + std::to_string(offset) + ")");
+      throw system_error(static_cast<int>(ret), "failed to write to address (" + std::to_string(offset) + ")");
   }
 
   virtual void
   exec_buf(xclBufferHandle bo)
   {
     if (auto ret = xclExecBuf(DeviceType::get_device_handle(), bo))
-      throw error(ret, "failed to launch execution buffer");
+      throw system_error(ret, "failed to launch execution buffer");
   }
 
   virtual int
@@ -349,28 +354,28 @@ struct shim : public DeviceType
   load_axlf(const axlf* buffer)
   {
     if (auto ret = xclLoadXclBin(DeviceType::get_device_handle(), buffer))
-      throw error(ret, "failed to load xclbin");
+      throw system_error(ret, "failed to load xclbin");
   }
 
   virtual void
   reclock(const uint16_t* target_freq_mhz)
   {
     if (auto ret = xclReClock2(DeviceType::get_device_handle(), 0, target_freq_mhz))
-      throw error(ret, "failed to reclock specified clock");
+      throw system_error(ret, "failed to reclock specified clock");
   }
 
   virtual void
   p2p_enable(bool force)
   {
     if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), true, force))
-      throw error(ret, "failed to enable p2p");
+      throw system_error(ret, "failed to enable p2p");
   }
 
   virtual void
   p2p_disable(bool force)
   {
     if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), false, force))
-      throw error(ret, "failed to disable p2p");
+      throw system_error(ret, "failed to disable p2p");
   }
 
 #ifdef XRT_ENABLE_AIE
@@ -380,7 +385,7 @@ struct shim : public DeviceType
     if (auto ghdl = xclGraphOpen(DeviceType::get_device_handle(), uuid, gname, am))
       return ghdl;
 
-    throw std::runtime_error("failed to open graph");
+    throw system_error(EINVAL, "failed to open graph");
   }
 
   virtual void
@@ -393,7 +398,7 @@ struct shim : public DeviceType
   reset_graph(xclGraphHandle handle)
   {
     if (auto ret = xclGraphReset(handle))
-      throw error(ret, "fail to reset graph");
+      throw system_error(ret, "fail to reset graph");
   }
 
   virtual uint64_t
@@ -406,7 +411,7 @@ struct shim : public DeviceType
   run_graph(xclGraphHandle handle, int iterations)
   {
     if (auto ret = xclGraphRun(handle, iterations))
-      throw error(ret, "fail to run graph");
+      throw system_error(ret, "fail to run graph");
   }
 
   virtual int
@@ -419,42 +424,42 @@ struct shim : public DeviceType
   wait_graph(xclGraphHandle handle, uint64_t cycle)
   {
     if (auto ret = xclGraphWait(handle, cycle))
-      throw error(ret, "fail to wait graph");
+      throw system_error(ret, "fail to wait graph");
   }
 
   virtual void
   suspend_graph(xclGraphHandle handle)
   {
     if (auto ret = xclGraphSuspend(handle))
-      throw error(ret, "fail to suspend graph");
+      throw system_error(ret, "fail to suspend graph");
   }
 
   virtual void
   resume_graph(xclGraphHandle handle)
   {
     if (auto ret = xclGraphResume(handle))
-      throw error(ret, "fail to resume graph");
+      throw system_error(ret, "fail to resume graph");
   }
 
   virtual void
   end_graph(xclGraphHandle handle, uint64_t cycle)
   {
     if (auto ret = xclGraphEnd(handle, cycle))
-      throw error(ret, "fail to end graph");
+      throw system_error(ret, "fail to end graph");
   }
 
   virtual void
   update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size)
   {
     if (auto ret = xclGraphUpdateRTP(handle, port, buffer, size))
-      throw error(ret, "fail to update graph rtp");
+      throw system_error(ret, "fail to update graph rtp");
   }
 
   virtual void
   read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size)
   {
     if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
-      throw error(ret, "fail to read graph rtp");
+      throw system_error(ret, "fail to read graph rtp");
   }
 
   virtual void
@@ -468,28 +473,28 @@ struct shim : public DeviceType
   sync_aie_bo(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
   {
     if (auto ret = xclSyncBOAIE(DeviceType::get_device_handle(), bo, gmioName, dir, size, offset))
-      throw error(ret, "fail to sync aie bo");
+      throw system_error(ret, "fail to sync aie bo");
   }
 
   virtual void
   reset_aie()
   {
     if (auto ret = xclResetAIEArray(DeviceType::get_device_handle()))
-      throw error(ret, "fail to reset aie");
+      throw system_error(ret, "fail to reset aie");
   }
 
   virtual void
   sync_aie_bo_nb(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
   {
     if (auto ret = xclSyncBOAIENB(DeviceType::get_device_handle(), bo, gmioName, dir, size, offset))
-      throw error(ret, "fail to sync aie non-blocking bo");
+      throw system_error(ret, "fail to sync aie non-blocking bo");
   }
 
   virtual void
   wait_gmio(const char *gmioName)
   {
     if (auto ret = xclGMIOWait(DeviceType::get_device_handle(), gmioName))
-      throw error(ret, "fail to wait gmio");
+      throw system_error(ret, "fail to wait gmio");
   }
 
   virtual int
@@ -508,14 +513,14 @@ struct shim : public DeviceType
   stop_profiling(int phdl)
   {
     if (auto ret = xclStopProfiling(DeviceType::get_device_handle(), phdl))
-      throw error(ret, "fail to wait gmio");
+      throw system_error(ret, "fail to wait gmio");
   }
 
   virtual void
   load_axlf_meta(const axlf* buffer)
   {
     if (auto ret = xclLoadXclBinMeta(DeviceType::get_device_handle(), buffer))
-      throw error(ret, "failed to load xclbin");
+      throw system_error(ret, "failed to load xclbin");
   }
 #endif
 };

--- a/src/runtime_src/core/include/experimental/xrt_bo.h
+++ b/src/runtime_src/core/include/experimental/xrt_bo.h
@@ -463,7 +463,7 @@ extern "C" {
  * @size:          Size of buffer
  * @flags:         Specify type of buffer
  * @grp:           Specify bank information
- * Return:         xrtBufferHandle on success or NULL with errno set
+ * Return:         xrtBufferHandle on success or NULL
  */
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
@@ -476,7 +476,7 @@ xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
  * @size:          Size of buffer
  * @flags:         Specify type of buffer
  * @grp:           Specify bank information
- * Return:         xrtBufferHandle on success or NULL with errno set
+ * Return:         xrtBufferHandle on success or NULL
  */
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
@@ -514,7 +514,7 @@ xrtBOExport(xrtBufferHandle bhdl);
  * @parent:        Parent buffer handle
  * @size:          Size of sub buffer 
  * @offset:        Offset into parent buffer
- * Return:         xrtBufferHandle on success or NULL with errno set
+ * Return:         xrtBufferHandle on success or NULL
  */
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
@@ -544,7 +544,7 @@ xrtBOSize(xrtBufferHandle bhdl);
  * xrtBOAddr() - Get the physical address of this buffer
  *
  * @bhdl:         Buffer handle
- * Return:        Device address of this BO
+ * Return:        Device address of this BO, or LLONG_MAX on error
  */
 XCL_DRIVER_DLLESPEC
 uint64_t
@@ -557,7 +557,7 @@ xrtBOAddress(xrtBufferHandle bhdl);
  * @dir:           To device or from device
  * @size:          Size of data to synchronize
  * @offset:        Offset within the BO
- * Return:         0 on success or standard errno
+ * Return:         0 on success or error
  *
  * Synchronize the buffer contents between host and device. Depending
  * on the memory model this may require DMA to/from device or CPU
@@ -571,7 +571,7 @@ xrtBOSync(xrtBufferHandle bhdl, enum xclBOSyncDirection dir, size_t size, size_t
  * xrtBOMap() - Memory map BO into user's address space
  *
  * @bhdl:       Buffer handle
- * Return:      Memory mapped buffer, or NULL on error with errno set
+ * Return:      Memory mapped buffer, or NULL on error
  *
  * Map the contents of the buffer object into host memory.  The buffer
  * object is unmapped when freed.

--- a/src/runtime_src/core/include/experimental/xrt_error.h
+++ b/src/runtime_src/core/include/experimental/xrt_error.h
@@ -30,7 +30,6 @@ class error_impl;
 class error
 {
 public:
-
   /**
    * error() -  Constructor for last asynchronous error of a class
    *
@@ -46,7 +45,7 @@ public:
    * @ecl:       Error code
    * @timestamp: Time stamp
    *
-   * Allow construction of error from manually retrieved
+   * Allow construction of error object from manually retrieved
    * error code and timestamp
    */
   XCL_DRIVER_DLLESPEC

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -232,7 +232,7 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
     xrt_core::scope_value_guard<int, std::function<void()>> fd = dev->file_open("icap", O_WRONLY);
     auto ret = write(fd.get(), buffer.data(), buffer.size());
     if (static_cast<size_t>(ret) != buffer.size())
-      throw xrt_core::error("Write plp to icap subdev failed");
+      throw xrt_core::error(EINVAL, "Write plp to icap subdev failed");
 
   } catch (const std::exception& e) {
     xrt_core::send_exception_message(e.what(), "XBMGMT");
@@ -248,7 +248,7 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
   while (!is_complete && retry_count++ < program_timeout_sec) {
     is_complete = xrt_core::query::rp_program_status::to_bool(xrt_core::device_query<xrt_core::query::rp_program_status>(dev));
     if (retry_count == program_timeout_sec)
-      throw xrt_core::error("PLP programmming timed out");
+      throw xrt_core::error(ETIMEDOUT, "PLP programmming timed out");
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }


### PR DESCRIPTION
Ensure POSIX error codes trickle up through C-APIs via exceptions.  If
a system error occurs in for example driver, then it translates to a
std::system_error exceptions carrying the POSIX error code.  The
system_error exception must be handle by application if C++, or is
automatically converted back to POSIX error return code if application
calls C-API.