### PR TITLE
CR-1080384 parse clock freq counters from xclbin and update clock driver

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: David Zhang <davidzha@xilinx.com>
  *
@@ -958,6 +958,23 @@ done:
 	return err;
 }
 
+static void clock_freq_reconfig_counters(struct platform_device *pdev,
+                                         struct clock_counter_info *clk_counter)
+{
+	struct clock *clock = platform_get_drvdata(pdev);
+
+	mutex_lock(&clock->clock_lock);
+	if (clk_counter[CCT_K1].start)
+		clock->clock_freq_counters[CCT_K1] =
+			ioremap_nocache(clk_counter[CCT_K1].start,
+						clk_counter[CCT_K1].size);
+	if (clk_counter[CCT_K2].start)
+		clock->clock_freq_counters[CCT_K2] =
+			ioremap_nocache(clk_counter[CCT_K2].start,
+						clk_counter[CCT_K2].size);
+	mutex_unlock(&clock->clock_lock);
+}
+
 static int clock_freq_rescaling(struct platform_device *pdev, bool force)
 {
 	struct clock *clock = platform_get_drvdata(pdev);
@@ -1366,6 +1383,7 @@ static struct xocl_clock_funcs clock_ops = {
 	.freq_scaling_by_topo = clock_freq_scaling_by_topo,
 	.clock_status = clock_status_check,
 	.get_data = clock_get_data,
+	.reconfig_counters = clock_freq_reconfig_counters,
 };
 
 static int clock_remove(struct platform_device *pdev)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2211,14 +2211,11 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 		const struct axlf_section_header *header = NULL;
 		header = xrt_xclbin_get_section_hdr(xclbin, PARTITION_METADATA);
 		if (header) {
-			struct clock_counter_info *clk_counter;
-			clk_counter = (struct clock_counter_info *) vzalloc(CCT_NUM *
-											sizeof(struct clock_counter_info));
+			struct clock_counter_info clk_counter[CCT_NUM];
 			bool present = xocl_fdt_get_freq_cnt_eps(xdev,
 					(char *)xclbin + header->m_sectionOffset, clk_counter);
 			if (present)
 				xocl_clock_reconfig_counters(xdev, clk_counter);
-			vfree(clk_counter);
 		}
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2143,6 +2143,7 @@ static int icap_probe_urpdev_by_id(struct platform_device *pdev,
 
 static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool sref)
 {
+	xdev_handle_t xdev = xocl_get_xdev(icap->icap_pdev);
 	int err = 0;
 	bool retention = ((icap->data_retention & 0x1) == 0x1) && sref;
 
@@ -2180,7 +2181,7 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 	} else {
 		uuid_copy(&icap->icap_bitstream_uuid, &xclbin->m_header.uuid);
 		ICAP_INFO(icap, "xclbin is generated for flat shell, dont need to program the bitstream ");
-		err = xocl_clock_freq_rescaling(xocl_get_xdev(icap->icap_pdev), true);
+		err = xocl_clock_freq_rescaling(xdev, true);
 		if (err)
 			ICAP_ERR(icap, "not able to configure clocks, err: %d", err);
 	}
@@ -2202,6 +2203,23 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 		err = icap_refresh_clock_freq(icap, xclbin);
 		if (err)
 			ICAP_ERR(icap, "not able to refresh clock freq");
+	} else if (err == -EEXIST) {
+		/* Try locating the ep_freq_cnt_aclk_kernel_* endpoints in xclbin
+		 * On u2 raptor2 shells (1RP or 2RP or 0RP), these endpoints are
+		 * available in ULP (i.e. in xclbin) but not in BLP+PLP
+		 */
+		const struct axlf_section_header *header = NULL;
+		header = xrt_xclbin_get_section_hdr(xclbin, PARTITION_METADATA);
+		if (header) {
+			struct clock_counter_info *clk_counter;
+			clk_counter = (struct clock_counter_info *) vzalloc(CCT_NUM *
+											sizeof(struct clock_counter_info));
+			bool present = xocl_fdt_get_freq_cnt_eps(xdev,
+					(char *)xclbin + header->m_sectionOffset, clk_counter);
+			if (present)
+				xocl_clock_reconfig_counters(xdev, clk_counter);
+			vfree(clk_counter);
+		}
 	}
 
 	icap_calib(icap, retention);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2211,7 +2211,7 @@ static int __icap_xclbin_download(struct icap *icap, struct axlf *xclbin, bool s
 		const struct axlf_section_header *header = NULL;
 		header = xrt_xclbin_get_section_hdr(xclbin, PARTITION_METADATA);
 		if (header) {
-			struct clock_counter_info clk_counter[CCT_NUM];
+			struct clock_counter_info clk_counter[CCT_NUM] = { {0} };
 			bool present = xocl_fdt_get_freq_cnt_eps(xdev,
 					(char *)xclbin + header->m_sectionOffset, clk_counter);
 			if (present)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: Lizhi.Hou@Xilinx.com
  *          Jan Stephan <j.stephan@hzdr.de>
@@ -1157,6 +1157,18 @@ struct xocl_mailbox_funcs {
 	(MAILBOX_READY(xdev, get) ? MAILBOX_OPS(xdev)->get(MAILBOX_DEV(xdev), \
 	kind, data) : -ENODEV)
 
+enum CLOCK_COUNTER_TYPE {
+        CCT_K1 = 0,
+        CCT_K2 = 1,
+        CCT_NUM = 2,
+};
+
+struct clock_counter_info {
+        size_t start;
+        size_t end;
+        size_t size;
+};
+
 struct xocl_clock_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	int (*get_freq)(struct platform_device *pdev, unsigned int region,
@@ -1171,6 +1183,7 @@ struct xocl_clock_funcs {
 	int (*freq_scaling_by_topo)(struct platform_device *pdev,
 		struct clock_freq_topology *topo, int verify);
 	int (*clock_status)(struct platform_device *pdev, bool *latched);
+	void (*reconfig_counters)(struct platform_device *pdev, struct clock_counter_info *clk_counter);
 	uint64_t (*get_data)(struct platform_device *pdev, enum data_kind kind);
 };
 #define CLOCK_DEV_INFO(xdev, idx)					\
@@ -1199,6 +1212,13 @@ static inline int xocl_clock_ops_level(xdev_handle_t xdev)
 	(__idx >= 0 ? (CLOCK_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
 })
 
+#define	xocl_clock_reconfig_counters(xdev, clk_counter)			\
+({ \
+	int __idx = xocl_clock_ops_level(xdev);					\
+	(CLOCK_CB(xdev, __idx, reconfig_counters) ?				\
+	CLOCK_OPS(xdev, __idx)->reconfig_counters(CLOCK_DEV(xdev, __idx),	\
+	clk_counter) : -ENODEV); \
+})
 #define	xocl_clock_freq_rescaling(xdev, force)					\
 ({ \
 	int __idx = xocl_clock_ops_level(xdev);					\
@@ -2128,6 +2148,7 @@ const void *xocl_fdt_getprop(xdev_handle_t xdev_hdl, void *blob, int off,
 			     char *name, int *lenp);
 int xocl_fdt_unblock_ip(xdev_handle_t xdev_hdl, void *blob);
 const char *xocl_fdt_get_ert_fw_ver(xdev_handle_t xdev_hdl, void *blob);
+bool xocl_fdt_get_freq_cnt_eps(xdev_handle_t xdev_hdl, void *blob, struct clock_counter_info *clk_counter);
 
 /* init functions */
 int __init xocl_init_userpf(void);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1885,3 +1885,61 @@ const char *xocl_fdt_get_ert_fw_ver(xdev_handle_t xdev_hdl, void *blob)
 
 	return fw_ver;
 }
+
+bool xocl_fdt_get_freq_cnt_eps(xdev_handle_t xdev_hdl, void *blob,
+                               struct clock_counter_info *clk_counter)
+{
+	int offset = 0;
+	const char *ipname = NULL;
+	const u64 *prop;
+	const u32 *bar_idx;
+	int bar;
+	bool found_k1 = false, found_k2 = false;
+
+	if (!blob)
+		return NULL;
+
+	bar_idx = fdt_getprop(blob, offset, PROP_BAR_IDX, NULL);
+	bar = bar_idx ? ntohl(*bar_idx) : 0;
+
+	for (offset = fdt_next_node(blob, -1, NULL);
+		offset >= 0;
+		offset = fdt_next_node(blob, offset, NULL)) {
+		ipname = fdt_get_name(blob, offset, NULL);
+		if (ipname && strncmp(ipname, NODE_CLKFREQ_K1,
+		    strlen(NODE_CLKFREQ_K1)) == 0) {
+			prop = fdt_getprop(blob, offset, PROP_IO_OFFSET, NULL);
+			if (!prop)
+				continue;
+
+			clk_counter[CCT_K1].start = be64_to_cpu(prop[0]) +
+				pci_resource_start(XDEV(xdev_hdl)->pdev, bar);
+			clk_counter[CCT_K1].end = clk_counter[CCT_K1].start +
+				be64_to_cpu(prop[1]) - 1;
+			clk_counter[CCT_K1].size = clk_counter[CCT_K1].end -
+				clk_counter[CCT_K1].start + 1;
+			found_k1 = true;
+		}
+		if (ipname && strncmp(ipname, NODE_CLKFREQ_K2,
+		    strlen(NODE_CLKFREQ_K2)) == 0) {
+			prop = fdt_getprop(blob, offset, PROP_IO_OFFSET, NULL);
+			if (!prop)
+				continue;
+
+			clk_counter[CCT_K2].start = be64_to_cpu(prop[0]) +
+				pci_resource_start(XDEV(xdev_hdl)->pdev, bar);
+			clk_counter[CCT_K2].end = clk_counter[CCT_K2].start +
+				be64_to_cpu(prop[1]) - 1;
+			clk_counter[CCT_K2].size = clk_counter[CCT_K2].end -
+				clk_counter[CCT_K2].start + 1;
+			found_k2 = true;
+		}
+	}
+
+	if (!(found_k1 || found_k2)) {
+		xocl_xdev_err(xdev_hdl, "clock counter end points(ep_freq_cnt_aclk_kernel_*) not found in xclbin");
+		return false;
+	}
+
+	return true;
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1897,7 +1897,7 @@ bool xocl_fdt_get_freq_cnt_eps(xdev_handle_t xdev_hdl, void *blob,
 	bool found_k1 = false, found_k2 = false;
 
 	if (!blob)
-		return NULL;
+		return false;
 
 	bar_idx = fdt_getprop(blob, offset, PROP_BAR_IDX, NULL);
 	bar = bar_idx ? ntohl(*bar_idx) : 0;


### PR DESCRIPTION
U.2 platform architecture is different than other Alveo cards.
 -Clocks and Clock-Freq-Scalers are in ULP in Alveo cards
 -Clocks are in BLP+PLP and Clock-Freq-Scaler in ULP in U.2 card.

So, parse the clock freq counters(scalers) from xclbin during download,
and update the clock driver

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>