### PR TITLE
CR-1092577

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1545,13 +1545,15 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 
 		krnl_info = xocl_query_kernel(xdev, info.kname);
 		if (!krnl_info) {
-			ICAP_WARN(icap, "%s has no metadata. Skip", kname);
-			continue;
+			ICAP_WARN(icap, "%s has no metadata.", kname);
 		}
 
 		info.inst_idx = i;
 		info.addr = ip->m_base_address;
-		info.size = krnl_info->range;
+		/* For some special purpose CU, there is no xml krnl info.
+		 * Use hard coding range 64KB for those CUs.
+		 */
+		info.size = (krnl_info) ? krnl_info->range : 0x10000;
 		info.num_res = subdev_info.num_res;
 		info.intr_enable = ip->properties & IP_INT_ENABLE_MASK;
 		info.protocol = (ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -532,6 +532,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	if (XDEV(xdev)->kernels != NULL) {
 		vfree(XDEV(xdev)->kernels);
 		XDEV(xdev)->kernels = NULL;
+		XDEV(xdev)->ksize = 0;
 	}
 
 	/* There is a corner case.


### PR DESCRIPTION
1. System compiler test case has no CU metadata in kernel.xml. So, xdev->kernels is NULL.
2. Should set xdev->ksize to 0 when set xdev->kernels to zero.