### PR TITLE
don't create CU subdev if metadata is missing

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1545,15 +1545,13 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 
 		krnl_info = xocl_query_kernel(xdev, info.kname);
 		if (!krnl_info) {
-			ICAP_WARN(icap, "%s has no metadata.", kname);
+			ICAP_WARN(icap, "%s has no metadata. skip", kname);
+			continue;
 		}
 
 		info.inst_idx = i;
 		info.addr = ip->m_base_address;
-		/* For some special purpose CU, there is no xml krnl info.
-		 * Use hard coding range 64KB for those CUs.
-		 */
-		info.size = (krnl_info) ? krnl_info->range : 0x10000;
+		info.size = krnl_info->range;
 		info.num_res = subdev_info.num_res;
 		info.intr_enable = ip->properties & IP_INT_ENABLE_MASK;
 		info.protocol = (ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT;


### PR DESCRIPTION
Revert workaround in #4977. Should not create CU subdevice if metadata is missing.