### PR TITLE
Enabling kds_mode=1, by default on embedded of stress testing

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -25,7 +25,7 @@ do {\
 	}\
 } while(0)
 
-int kds_mode = 0;
+int kds_mode = 1;
 module_param(kds_mode, int, (S_IRUGO|S_IWUSR));
 MODULE_PARM_DESC(kds_mode,
 		 "enable new KDS (0 = disable (default), 1 = enable)");


### PR DESCRIPTION
* enabling common kds on embedded
* this is enabled to do stress testing on sprite