### PR TITLE
CR-1091928 ASTeR TC7.01 - xbutil2 validate fails at xcl_IOPs test

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -367,7 +367,8 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
   if (py.compare("xcl_iops_test.exe") == 0) {
     auto st = os_stdout.str().find("IOPS:");
     if (st != std::string::npos) {
-      logger(_ptTest, "Details", os_stdout.str().substr(st));
+      size_t end = os_stdout.str().find("\n", st);
+      logger(_ptTest, "Details", os_stdout.str().substr(st, end - st));
     }
   }
 }

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -329,6 +329,7 @@ int main(int argc, char *argv[])
 {
     try {
         _main(argc, argv);
+        std::cout << "TEST PASSED" << std::endl;
         return EXIT_SUCCESS;
     }
     catch (const std::exception& ex) {

--- a/tests/validate/xrt_iops_test/src/xrt_api_iops.cpp
+++ b/tests/validate/xrt_iops_test/src/xrt_api_iops.cpp
@@ -199,6 +199,7 @@ int main(int argc, char *argv[])
 {
   try {
     _main(argc, argv);
+    std::cout << "TEST PASSED" << std::endl;
     return EXIT_SUCCESS;
   }
   catch (const std::exception& ex) {


### PR DESCRIPTION
xbutil2 would try to find "PASS" in the output. Only if it exists, the test case passed.