### PR TITLE
Miscellaneous fixes on edge with new kds

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -279,6 +279,7 @@ zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf)
 	/* TODO figure out the partition id and uid from xclbin or PDI */
 	req.partition_id = 1;
 	req.uid = 0;
+	req.meta_data = 0;
 
 	if (zdev->aie->aie_dev) {
 		DRM_INFO("Partition %d already requested\n",

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -788,6 +788,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	if (zdev->kernels != NULL) {
 		vfree(zdev->kernels);
 		zdev->kernels = NULL;
+		zdev->ksize = 0;
 	}
 
 	if (axlf_obj->za_ksize > 0) {

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -537,6 +537,7 @@ xclLoadAxlf(const axlf *buffer)
       .za_kernels = NULL,
     };
 
+  std::vector<char> krnl_binary;
   if (!xrt_core::xclbin::is_pdi_only(buffer)) {
     auto kernels = xrt_core::xclbin::get_kernels(buffer);
     /* Calculate size of kernels */
@@ -545,7 +546,7 @@ xclLoadAxlf(const axlf *buffer)
     }
 
     /* Check PCIe's shim.cpp for details of kernels binary */
-    std::vector<char> krnl_binary(axlf_obj.za_ksize);
+    krnl_binary.resize(axlf_obj.za_ksize);
     axlf_obj.za_kernels = krnl_binary.data();
     for (auto& kernel : kernels) {
       auto krnl = reinterpret_cast<kernel_info *>(axlf_obj.za_kernels + off);


### PR DESCRIPTION
Worked with @mamin506 to spot a few issues with new KDS enabled

1. Don't check ip_layout section if there is no one
2. Extend the krnl_binary scope in xclLoadAxlf to make sure it is valid when sending ioctl
3. Update cu info in new kds when we are no longer relying on config command
4. Return successful on all the AIE related context operation to make sure we don't break any existing test cases when enable new kds. The true support will command later
5. Make sure we pass null pointer when register aie partition for now