### PR TITLE
CR-1090725: Initial implementation of system compiler plugin

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -136,6 +136,13 @@ get_profile()
 }
 
 inline bool
+get_sc_profile()
+{
+  static bool value = detail::get_bool_value("Debug.sc_profile", false);
+  return value ;
+}
+
+inline bool
 get_container()
 {
   static bool value = detail::get_bool_value("Debug.container",false);

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -21,6 +21,7 @@
 #include "noc_profile.h"
 #include "aie_trace.h"
 #include "vart_profile.h"
+#include "sc_profile.h"
 
 #include "core/common/config_reader.h"
 
@@ -52,6 +53,10 @@ bool load()
     xdp::power::profile::load() ;
   }
 #endif 
+
+  if (xrt_core::config::get_sc_profile()) {
+    xdp::sc::profile::load();
+  }
 
   if (xrt_core::config::get_aie_trace()) {
     xdp::aie::trace::load() ;

--- a/src/runtime_src/core/edge/user/plugin/xdp/sc_profile.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/sc_profile.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sc_profile.h"
+#include "core/common/module_loader.h"
+
+namespace xdp {
+namespace sc {
+namespace profile {
+
+  void load()
+  {
+    static xrt_core::module_loader xdp_sc_loader("xdp_system_compiler_plugin",
+                                                 register_callbacks,
+                                                 warning_callbacks) ;
+  }
+
+  void register_callbacks(void* /* handle*/)
+  {
+    // No callbacks in System Compiler plugin
+  }
+
+  void warning_callbacks()
+  {
+    // No warnings in System Compiler plugin
+  }
+
+} // end namespace profile
+} // end namespace sc
+} // end namespace xdp

--- a/src/runtime_src/core/edge/user/plugin/xdp/sc_profile.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/sc_profile.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SC_PROFILE_DOT_H
+#define SC_PROFILE_DOT_H
+
+namespace xdp {
+namespace sc {
+namespace profile {
+
+  void load();
+  void register_callbacks(void* handle);
+  void warning_callbacks();
+
+} // end namespace profile
+} // end namespace sc
+} // end namespace xdp
+
+#endif

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
@@ -22,6 +22,7 @@
 #include "plugin/xdp/power_profile.h"
 #include "plugin/xdp/aie_trace.h"
 #include "plugin/xdp/vart_profile.h"
+#include "plugin/xdp/sc_profile.h"
 
 #include "core/common/config_reader.h"
 
@@ -53,6 +54,10 @@ bool load()
 
   if (xrt_core::config::get_aie_trace()) {
     xdp::aie::trace::load() ;
+  }
+
+  if (xrt_core::config::get_sc_profile()) {
+    xdp::sc::profile::load() ;
   }
 
   if (xrt_core::config::get_vitis_ai_profile()) {

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/sc_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/sc_profile.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sc_profile.h"
+#include "core/common/module_loader.h"
+
+namespace xdp {
+namespace sc {
+namespace profile {
+
+  void load()
+  {
+    static xrt_core::module_loader xdp_sc_loader("xdp_system_compiler_plugin",
+                                                 register_callbacks,
+                                                 warning_callbacks) ;
+  }
+
+  void register_callbacks(void* /* handle*/)
+  {
+    // No callbacks in System Compiler plugin
+  }
+
+  void warning_callbacks()
+  {
+    // No warnings in System Compiler plugin
+  }
+
+} // end namespace profile
+} // end namespace sc
+} // end namespace xdp

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/sc_profile.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/sc_profile.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SC_PROFILE_DOT_H
+#define SC_PROFILE_DOT_H
+
+namespace xdp {
+namespace sc {
+namespace profile {
+
+  void load();
+  void register_callbacks(void* handle);
+  void warning_callbacks();
+
+} // end namespace profile
+} // end namespace sc
+} // end namespace xdp
+
+#endif

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -60,6 +60,7 @@ set(XRT_XDP_AIE_TRACE_PLUGIN_DIR         "${CMAKE_CURRENT_SOURCE_DIR}/profile/pl
 set(XRT_XDP_AIE_TRACE_WRITER_DIR         "${CMAKE_CURRENT_SOURCE_DIR}/profile/writer/aie_trace")
 set(XRT_XDP_POWER_PROFILE_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/power")
 set(XRT_XDP_POWER_PROFILE_WRITER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/writer/power")
+set(XRT_XDP_SYSTEM_COMPILER_PLUGIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/system_compiler")
 
 # Files for the new xdp core
 set(XRT_XDP_PROFILE_BASE_PLUGIN_DIR    "${CMAKE_CURRENT_SOURCE_DIR}/profile/plugin/vp_base")
@@ -235,6 +236,11 @@ file(GLOB XRT_XDP_POWER_PROFILE_PLUGIN_FILES
   "${XRT_XDP_POWER_PROFILE_WRITER_DIR}/*.cpp"
   )
 
+file(GLOB XRT_XDP_SYSTEM_COMPILER_PLUGIN_FILES
+  "${XRT_XDP_SYSTEM_COMPILER_PLUGIN_DIR}/*.h"
+  "${XRT_XDP_SYSTEM_COMPILER_PLUGIN_DIR}/*.cpp"
+  )
+
 file(GLOB XRT_XDP_AIE_TRACE_PLUGIN_FILES
   "${XRT_XDP_PROFILE_DEVICE_AIE_TRACE_DIR}/*.h"
   "${XRT_XDP_PROFILE_DEVICE_AIE_TRACE_DIR}/*.cpp"
@@ -334,18 +340,21 @@ if (NOT WIN32)
 add_library(xdp_debug_plugin MODULE ${XRT_XDP_DEBUG_FILES})
 add_library(xdp_appdebug_plugin MODULE ${XRT_XDP_APPDEBUG_FILES})
 add_library(xdp_power_plugin MODULE ${XRT_XDP_POWER_PROFILE_PLUGIN_FILES})
+add_library(xdp_system_compiler_plugin MODULE ${XRT_XDP_SYSTEM_COMPILER_PLUGIN_FILES})
 add_library(xdp_noc_plugin MODULE ${XRT_XDP_PROFILE_NOC_PLUGIN_FILES})
 add_library(xdp_vart_plugin MODULE ${XRT_XDP_PROFILE_VART_PLUGIN_FILES})
 
 add_dependencies(xdp_debug_plugin xrt_coreutil xilinxopencl)
 add_dependencies(xdp_appdebug_plugin xrt_coreutil xilinxopencl)
 add_dependencies(xdp_power_plugin xdp_core xrt_core)
+add_dependencies(xdp_system_compiler_plugin xdp_core)
 add_dependencies(xdp_noc_plugin xdp_core xrt_core)
 add_dependencies(xdp_vart_plugin xdp_core xrt_core)
 
 target_link_libraries(xdp_debug_plugin PRIVATE xrt_coreutil xilinxopencl)
 target_link_libraries(xdp_appdebug_plugin PRIVATE xrt_coreutil xilinxopencl)
 target_link_libraries(xdp_power_plugin PRIVATE xdp_core xrt_core)
+target_link_libraries(xdp_system_compiler_plugin xdp_core)
 target_link_libraries(xdp_noc_plugin PRIVATE xdp_core xrt_core)
 target_link_libraries(xdp_vart_plugin PRIVATE xdp_core xrt_core)
 
@@ -354,6 +363,7 @@ set_target_properties(xdp_vart_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} S
 set_target_properties(xdp_debug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 set_target_properties(xdp_appdebug_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 set_target_properties(xdp_power_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
+set_target_properties(xdp_system_compiler_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
 # AI Engine plugin is Edge only
 if (DEFINED XRT_AIE_BUILD)
@@ -388,6 +398,7 @@ install (TARGETS xdp_aie_trace_plugin
 install (TARGETS xdp_debug_plugin
                  xdp_appdebug_plugin
                  xdp_power_plugin
+                 xdp_system_compiler_plugin
                  xdp_noc_plugin
                  xdp_vart_plugin
   LIBRARY DESTINATION ${XRT_INSTALL_LIB_DIR}/xrt/module

--- a/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_cb.cpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "xdp/profile/plugin/system_compiler/system_compiler_plugin.h"
+
+namespace xdp {
+
+  // The System Compiler plugin currently doesn't have any callbacks.
+  //  Instead, it only has a single static instance of the plugin object.
+
+  static SystemCompilerPlugin systemCompilerPluginInstance ;
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_plugin.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_SOURCE
+
+#include "xdp/profile/plugin/system_compiler/system_compiler_plugin.h"
+
+namespace xdp {
+
+  SystemCompilerPlugin::SystemCompilerPlugin() : XDPPlugin()
+  {
+    db->registerPlugin(this);
+
+    db->getStaticInfo().addOpenedFile("profile_summary.csv", "PROFILE_SUMMARY");
+    db->getStaticInfo().addOpenedFile("sc_trace.csv", "VP_TRACE");
+  }
+
+  SystemCompilerPlugin::~SystemCompilerPlugin()
+  {
+  }
+
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/system_compiler/system_compiler_plugin.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SYSTEM_COMPILER_PLUGIN_DOT_H
+#define SYSTEM_COMPILER_PLUGIN_DOT_H
+
+#include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+
+namespace xdp {
+
+  class SystemCompilerPlugin : public XDPPlugin
+  {
+  public:
+    SystemCompilerPlugin() ;
+    ~SystemCompilerPlugin() ;
+  } ;
+
+} // end namespace xdp
+
+#endif


### PR DESCRIPTION
Adds a switch to the ini file to enable the loading of the system compiler application plugin.  All the plugin does is currently add application-generated files to run summary.