### PR TITLE
xbmgmt2 dump config/flash & load-config support

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -206,6 +206,10 @@ enum class key_type
   graph_status,
   mailbox_metrics,
 
+  config_mailbox_channel_disable,
+  config_mailbox_channel_switch,
+  cache_xclbin,
+
   clock_timestamp,
   ert_sleep,
   ert_cq_write,
@@ -2161,6 +2165,48 @@ struct mailbox_metrics : request
   {
     return value;
   }
+};
+
+struct config_mailbox_channel_disable : request
+{
+  using result_type = std::string;  // get value type
+  using value_type = std::string;   // put value type
+
+  static const key_type key = key_type::config_mailbox_channel_disable;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+};
+
+struct config_mailbox_channel_switch : request
+{
+  using result_type = std::string;  // get value type
+  using value_type = std::string;   // put value type
+
+  static const key_type key = key_type::config_mailbox_channel_switch;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+};
+
+struct cache_xclbin : request
+{
+  using result_type = std::string;  // get value type
+  using value_type = std::string;   // put value type
+
+  static const key_type key = key_type::cache_xclbin;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
 };
 
 struct ert_sleep : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -554,6 +554,9 @@ initialize_query_table()
   emplace_sysfs_get<query::ert_cq_write>                     ("ert_user", "cq_write_cnt");
   emplace_sysfs_get<query::ert_cu_read>                      ("ert_user", "cu_read_cnt");
   emplace_sysfs_get<query::ert_cu_write>                     ("ert_user", "cu_write_cnt");
+  emplace_sysfs_getput<query::config_mailbox_channel_disable> ("", "config_mailbox_channel_disable");
+  emplace_sysfs_getput<query::config_mailbox_channel_switch> ("", "config_mailbox_channel_switch");
+  emplace_sysfs_getput<query::cache_xclbin>                  ("", "cache_xclbin");
 
   emplace_sysfs_get<query::kds_mode>                         ("", "kds_mode");
   emplace_func0_request<query::kds_cu_stat,                  kds_cu_stat>();

--- a/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
@@ -153,12 +153,12 @@ OO_LoadConfig::execute(const SubCmdOptions& _options) const
  */
 static bool load_config(const std::shared_ptr<xrt_core::device>& _dev, const std::string path)
 {
-  boost::property_tree::ptree PtRoot;
-  boost::property_tree::ini_parser::read_ini(path, PtRoot);
+  boost::property_tree::ptree ptRoot;
+  boost::property_tree::ini_parser::read_ini(path, ptRoot);
   static boost::property_tree::ptree emptyTree;
 
   const boost::property_tree::ptree PtDevice =
-    PtRoot.get_child("Device", emptyTree);
+    ptRoot.get_child("Device", emptyTree);
 
   if (PtDevice.empty()) {
     std::cerr << boost::format("ERROR: No [Device] section in the config file\n");
@@ -176,7 +176,7 @@ static bool load_config(const std::shared_ptr<xrt_core::device>& _dev, const std
       xrt_core::device_update<xrt_core::query::cache_xclbin>(
         _dev.get(), key.second.get_value<std::string>());
     else
-      std::cerr << boost::format("WARN: '%s' is not a supported config entry\n") % key.first;   
+      std::cerr << boost::format("WARNING: '%s' is not a supported config entry\n") % key.first;   
   }
 
   return true;

--- a/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.h
@@ -18,6 +18,7 @@
 #define __OOLoadConfig_h_
 
 #include "tools/common/OptionOptions.h"
+#include "core/common/query_requests.h"
 
 #include <vector>
 
@@ -32,6 +33,7 @@ class OO_LoadConfig : public OptionOptions {
   std::vector<std::string> m_devices;
   bool m_help;
   std::string m_path;
+  void loadconfig(const std::shared_ptr<xrt_core::device>& _dev) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.h
@@ -33,7 +33,6 @@ class OO_LoadConfig : public OptionOptions {
   std::vector<std::string> m_devices;
   bool m_help;
   std::string m_path;
-  void loadconfig(const std::shared_ptr<xrt_core::device>& _dev) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -21,8 +21,11 @@
 namespace XBU = XBUtilities;
 
 #include "core/common/query_requests.h"
+#include "flash/flasher.h"
 
 // 3rd Party Library - Include Files
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ini_parser.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 namespace po = boost::program_options;
@@ -34,7 +37,7 @@ namespace po = boost::program_options;
 // ------ L O C A L   F U N C T I O N S ---------------------------------------
 
 static void
-flash_dump(std::ofstream& /*fOutput*/)
+flash_dump(const std::string& output, const std::shared_ptr<xrt_core::device>& _dev)
 {
   XBU::verbose("Option: flash");
   // Sample output:
@@ -42,14 +45,42 @@ flash_dump(std::ofstream& /*fOutput*/)
   //   Flash Size: 0x222 (Mbits)  
   //   <Progress Bar>
 
-  // TO-DO
+  Flasher flasher(_dev->get_device_id());
+  if(!flasher.isValid()) {
+    xrt_core::error(boost::str(boost::format("%d is an invalid index") % _dev->get_device_id()));
+    return;
+  }
+  flasher.readBack(output);
 }
 
+/*
+ * so far, we only support the following configs
+ * [Device]
+ * mailbox_channel_disable = xxx
+ * mailbox_channel_switch = xxx
+ * cahce_xclbin = xxx
+ */
 static void
-config_dump(std::ofstream& /*fOutput*/)
+config_dump(const std::string& output, std::shared_ptr<xrt_core::device>& _dev)
 {
   XBU::verbose("Option: config");
-  //TO-DO
+
+  if(boost::filesystem::extension(output).compare(".ini") != 0) {
+    std::cerr << boost::format("ERROR: output file should be an INI file: '%s'") % output << "\n\n";
+    return;
+  }
+
+  boost::property_tree::ptree m_tree;
+
+  m_tree.put("Device.mailbox_channel_disable",
+    xrt_core::device_query<xrt_core::query::config_mailbox_channel_disable>(_dev));
+  m_tree.put("Device.mailbox_channel_switch",
+    xrt_core::device_query<xrt_core::query::config_mailbox_channel_switch>(_dev));
+  m_tree.put("Device.cache_xclbin",
+    xrt_core::device_query<xrt_core::query::cache_xclbin>(_dev));
+
+  boost::property_tree::ini_parser::write_ini(output, m_tree);
+  std::cout << "config has been dumped to " << output << std::endl;
 }
 
 SubCmdDump::SubCmdDump(bool _isHidden, bool _isDepricated, bool _isPreliminary)
@@ -159,23 +190,15 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
     return;
   }
     
-  std::ofstream fOutput;
-  fOutput.open(output, std::ios::out | std::ios::binary);
-  if (!fOutput.is_open()) {
-    std::cerr << boost::format("ERROR: Unable to open the file '%s' for writing.") % output << "\n\n";
-    return;
-  }
-
   //decide the contents of the dump file
   if(flash)
-    flash_dump(fOutput);
+    flash_dump(output, deviceCollection[0]);
   else if (config)
-    config_dump(fOutput);
+    config_dump(output, deviceCollection[0]);
   else {
     std::cerr << "ERROR: Please specify a valid option to determine the type of dump" << "\n\n";
     printHelp(commonOptions, hiddenOptions);
     return;
   }
 
-  fOutput.close();
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -70,12 +70,9 @@ config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string out
   boost::property_tree::ptree ptRoot;
 
   boost::property_tree::ptree child;
-  child.put("mailbox_channel_disable",
-    xrt_core::device_query<xrt_core::query::config_mailbox_channel_disable>(_dev));
-  child.put("mailbox_channel_switch",
-    xrt_core::device_query<xrt_core::query::config_mailbox_channel_switch>(_dev));
-  child.put("cache_xclbin",
-    xrt_core::device_query<xrt_core::query::cache_xclbin>(_dev));
+  child.put("mailbox_channel_disable", xrt_core::device_query<xrt_core::query::config_mailbox_channel_disable>(_dev));
+  child.put("mailbox_channel_switch", xrt_core::device_query<xrt_core::query::config_mailbox_channel_switch>(_dev));
+  child.put("cache_xclbin", xrt_core::device_query<xrt_core::query::cache_xclbin>(_dev));
   ptRoot.put_child("Device", child);
 
   boost::property_tree::ini_parser::write_ini(output, ptRoot);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -67,7 +67,7 @@ config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string out
     return;
   }
 
-  boost::property_tree::ptree PtRoot;
+  boost::property_tree::ptree ptRoot;
 
   boost::property_tree::ptree child;
   child.put("mailbox_channel_disable",
@@ -76,9 +76,9 @@ config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string out
     xrt_core::device_query<xrt_core::query::config_mailbox_channel_switch>(_dev));
   child.put("cache_xclbin",
     xrt_core::device_query<xrt_core::query::cache_xclbin>(_dev));
-  PtRoot.put_child("Device", child);
+  ptRoot.put_child("Device", child);
 
-  boost::property_tree::ini_parser::write_ini(output, PtRoot);
+  boost::property_tree::ini_parser::write_ini(output, ptRoot);
   std::cout << "config has been dumped to " << output << std::endl;
 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -177,6 +177,27 @@ int Flasher::upgradeBMCFirmware(firmwareImage* bmc)
     return flasher.xclUpgradeFirmware(*bmc);
 }
 
+/*
+ * readback from flash and save in the file specified
+ * only qspi_ps is supported currently
+ */
+void Flasher::readBack(const std::string& output)
+{
+    E_FlasherType type = getFlashType("");
+
+    switch(type)
+    {
+    case QSPIPS:
+    {
+        XQSPIPS_Flasher xqspi_ps(m_device);
+        xqspi_ps.readBack(output);
+        return;
+    }
+    default:
+        std::cout << "ERROR: flash read back is not supported" << std::endl;
+    }
+}
+
 std::string charVec2String(std::vector<char>& v)
 {
     std::stringstream ss;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -193,8 +193,13 @@ void Flasher::readBack(const std::string& output)
         xqspi_ps.readBack(output);
         return;
     }
-    default:
+    case SPI:
+    case OSPIVERSAL:
         std::cout << "ERROR: flash read back is not supported" << std::endl;
+        return;
+    default:
+        std::cout << "ERROR: flash type is not supported" << std::endl;
+        return;
     }
 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
@@ -69,6 +69,7 @@ public:
     Flasher(unsigned int index);
     int upgradeFirmware(const std::string& typeStr, firmwareImage* primary, firmwareImage* secondary);
     int upgradeBMCFirmware(firmwareImage* bmc);
+    void readBack(const std::string& output);
     bool isValid(void) { return m_device != nullptr; }
 
     std::string getQspiGolden();

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -384,29 +384,21 @@ bool XQSPIPS_Flasher::waitTxEmpty()
 
 void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
 {
-    int total_size = 0;
-    int remain = 0;
-    int pages = 0;
-    unsigned addr = 0;
-    unsigned size = 0;
-    int beatCount = 0;
-
     binStream.seekg(0, binStream.end);
-    total_size = static_cast<int>(binStream.tellg());
+    const unsigned int total_size = static_cast<int>(binStream.tellg());
     binStream.seekg(0, binStream.beg);
 
-    pages = total_size / PAGE_SIZE;
-    remain = total_size % PAGE_SIZE;
+    const unsigned int pages = total_size / PAGE_SIZE;
+    const unsigned remain = total_size % PAGE_SIZE;
+    unsigned addr = 0;
+    unsigned size = 0;
 
 #if defined(_DEBUG)
     std::cout << "Verify earse flash" << std::endl;
     int mismatched = 0;
-    for (int page = 0; page <= pages; page++) {
+    for (unsigned int page = 0; page <= pages; page++) {
         addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
+        size = page != pages ? PAGE_SIZE : remain;
 
         readFlash(base + addr, size);
         for (unsigned i = 0; i < size; i++) {
@@ -423,16 +415,13 @@ void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
     }
 #endif
 
-    beatCount = 0;
+    int beatCount = 0;
     XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
-    for (int page = 0; page <= pages; page++) {
+    for (unsigned int page = 0; page <= pages; page++) {
         program_flash.update(beatCount++);
 
         addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
+        size = page != pages ? PAGE_SIZE : remain;
 
         binStream.read((char *)mWriteBuffer, size);
         writeFlash(base + addr, size);
@@ -442,17 +431,8 @@ void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
 
 int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
 {
-    int total_size = 0;
-    int remain = 0;
-    int pages = 0;
-    unsigned addr = 0;
-    unsigned size = 0;
-    int beatCount = 0;
-    int mismatched = 0;
-    bool verified = true;
-
     binStream.seekg(0, binStream.end);
-    total_size = static_cast<int>(binStream.tellg());
+    const unsigned int total_size = static_cast<int>(binStream.tellg());
     binStream.seekg(0, binStream.beg);
 
 #if SAVE_FILE
@@ -464,19 +444,18 @@ int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
     }
 #endif
 
-    remain = total_size % PAGE_SIZE;
-    pages = total_size / PAGE_SIZE;
+    const unsigned int remain = total_size % PAGE_SIZE;
+    const unsigned int pages = total_size / PAGE_SIZE;
 
-    beatCount = 0;
+    int mismatched = 0;
+    bool verified = true;
+    int beatCount = 0;
     XBU::ProgressBar verify_flash("Verifying flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
-    for (int page = 0; page <= pages; page++) {
+    for (unsigned int page = 0; page <= pages; page++) {
         verify_flash.update(beatCount++);
 
-        addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
+        unsigned int addr = page * PAGE_SIZE;
+        unsigned int size = page != pages ? PAGE_SIZE : remain;
 
         binStream.read((char *)mWriteBuffer, size);
 
@@ -506,14 +485,13 @@ int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
     return mismatched;
 }
 
-void XQSPIPS_Flasher::readBack(const std::string& output, unsigned base, unsigned total_size)
+unsigned int XQSPIPS_Flasher::getFlashSize()
 {
-    int remain = 0;
-    int pages = 0;
-    unsigned addr = 0;
-    unsigned size = 0;
-    int beatCount = 0;
+    return 0x8000000; //hard-code as 128MB so far
+}
 
+void XQSPIPS_Flasher::readBack(const std::string& output, unsigned base)
+{
     std::ofstream of_flash;
     of_flash.open(output, std::ofstream::out);
     if (!of_flash.is_open()) {
@@ -521,26 +499,27 @@ void XQSPIPS_Flasher::readBack(const std::string& output, unsigned base, unsigne
         return;
     }
 
+    const unsigned int total_size = getFlashSize();
     std::cout << "Output file: " << output << std::endl;
     std::cout << "Flash size: " << total_size << std::endl;
 
-    remain = total_size % PAGE_SIZE;
-    pages = total_size / PAGE_SIZE;
+    /*
+     * Flash is read/write no larger than PAGE_SIZE
+     */
+    const unsigned int remain = total_size % PAGE_SIZE;
+    const unsigned int pages = total_size / PAGE_SIZE;
 
-    beatCount = 0;
-    XBU::ProgressBar read_flash("reading flash back", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
-    for (int page = 0; page <= pages; page++) {
+    int beatCount = 0;
+    XBU::ProgressBar read_flash("Reading flash back", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
+    for (unsigned int page = 0; page <= pages; page++) {
         read_flash.update(beatCount++);
 
-        addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
+        unsigned int addr = page * PAGE_SIZE;
+        unsigned int size = page != pages ? PAGE_SIZE : remain;
 
         readFlash(base + addr, size);
 
-        for (unsigned i = 0; i < size; i++)
+        for (unsigned int i = 0; i < size; i++)
             of_flash << mReadBuffer[i];
     }
     read_flash.finish(true, "Flash read back");
@@ -584,7 +563,7 @@ int XQSPIPS_Flasher::revertToMFG(std::istream& binStream)
 
 int XQSPIPS_Flasher::xclUpgradeFirmware(std::istream& binStream)
 {
-    int total_size = 0;
+    unsigned int total_size = 0;
 
     binStream.seekg(0, binStream.end);
     total_size = static_cast<int>(binStream.tellg());
@@ -1503,10 +1482,10 @@ int XQSPIPS_Flasher::xclTestXQSpiPS(int)
     unsigned size = 0;
     // Write/Read 16K + 100 bytes
     //int total_size = 16 * 1024 + 100;
-    int total_size = 300;
+    unsigned int total_size = 300;
 
-    int remain = total_size % PAGE_SIZE;
-    int pages = total_size / PAGE_SIZE;
+    unsigned int remain = total_size % PAGE_SIZE;
+    unsigned int pages = total_size / PAGE_SIZE;
 
     std::cout << "Write " << total_size << " bytes" << std::endl;
 
@@ -1514,7 +1493,7 @@ int XQSPIPS_Flasher::xclTestXQSpiPS(int)
     //eraseBulk();
 
     std::cout << ">>>>>> Write " << std::endl;
-    for (int page = 0; page <= pages; page++) {
+    for (unsigned int page = 0; page <= pages; page++) {
         addr = page * PAGE_SIZE;
         if (page != pages)
             size = PAGE_SIZE;
@@ -1532,7 +1511,7 @@ int XQSPIPS_Flasher::xclTestXQSpiPS(int)
     pages = total_size / 256;
 
     std::cout << ">>>>>> Verify data" << std::endl;
-    for (int page = 0; page <= pages; page++) {
+    for (unsigned int page = 0; page <= pages; page++) {
         addr = page * 256;
         if (page != pages)
             size = 256;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -389,9 +389,9 @@ void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
     binStream.seekg(0, binStream.beg);
 
     const unsigned int pages = total_size / PAGE_SIZE;
-    const unsigned remain = total_size % PAGE_SIZE;
-    unsigned addr = 0;
-    unsigned size = 0;
+    const unsigned int remain = total_size % PAGE_SIZE;
+    unsigned int addr = 0;
+    unsigned int size = 0;
 
 #if defined(_DEBUG)
     std::cout << "Verify earse flash" << std::endl;
@@ -401,7 +401,7 @@ void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
         size = page != pages ? PAGE_SIZE : remain;
 
         readFlash(base + addr, size);
-        for (unsigned i = 0; i < size; i++) {
+        for (unsigned int i = 0; i < size; i++) {
             if (0xFF != mReadBuffer[i]) {
                 mismatched = 1;
             }
@@ -462,7 +462,7 @@ int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
         readFlash(base + addr, size);
 
         mismatched = 0;
-        for (unsigned i = 0; i < size; i++) {
+        for (unsigned int i = 0; i < size; i++) {
 #if SAVE_FILE
             of_flash << mReadBuffer[i];
 #endif
@@ -490,7 +490,7 @@ unsigned int XQSPIPS_Flasher::getFlashSize()
     return 0x8000000; //hard-code as 128MB so far
 }
 
-void XQSPIPS_Flasher::readBack(const std::string& output, unsigned base)
+void XQSPIPS_Flasher::readBack(const std::string& output, unsigned int base)
 {
     std::ofstream of_flash;
     of_flash.open(output, std::ofstream::out);
@@ -1478,8 +1478,8 @@ int XQSPIPS_Flasher::xclTestXQSpiPS(int)
     enterOrExitFourBytesMode(ENTER_4B);
 
     std::cout << ">>> Testing simple read and write <<<" << std::endl;
-    unsigned addr = 0;
-    unsigned size = 0;
+    unsigned int addr = 0;
+    unsigned int size = 0;
     // Write/Read 16K + 100 bytes
     //int total_size = 16 * 1024 + 100;
     unsigned int total_size = 300;
@@ -1495,10 +1495,7 @@ int XQSPIPS_Flasher::xclTestXQSpiPS(int)
     std::cout << ">>>>>> Write " << std::endl;
     for (unsigned int page = 0; page <= pages; page++) {
         addr = page * PAGE_SIZE;
-        if (page != pages)
-            size = PAGE_SIZE;
-        else
-            size = remain;
+	size = page != pages ? PAGE_SIZE : remain;
 
         for (unsigned i = 0; i < size; i++) {
             mWriteBuffer[i] = (uint8_t)i;
@@ -1507,16 +1504,10 @@ int XQSPIPS_Flasher::xclTestXQSpiPS(int)
         writeFlash(addr, size);
     }
 
-    remain = total_size % 256;
-    pages = total_size / 256;
-
     std::cout << ">>>>>> Verify data" << std::endl;
     for (unsigned int page = 0; page <= pages; page++) {
-        addr = page * 256;
-        if (page != pages)
-            size = 256;
-        else
-            size = remain;
+        addr = page * PAGE_SIZE;
+	size = page != pages ? PAGE_SIZE : remain;
 
         readFlash(addr, size);
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
@@ -22,8 +22,8 @@
 #include "core/common/system.h"
 #include "core/common/device.h"
 
-const static unsigned int PAGE_SIZE = 256;
-const static unsigned int PAGE_8K   = 8192;
+#define PAGE_SIZE  256
+#define PAGE_8K    8192
 
 class XQSPIPS_Flasher
 {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
@@ -22,9 +22,8 @@
 #include "core/common/system.h"
 #include "core/common/device.h"
 
-const static int PAGE_SIZE = 256;
-const static int PAGE_8K   = 8192;
-const static int FLASH_SIZE = 0x8000000; //128MB
+const static unsigned int PAGE_SIZE = 256;
+const static unsigned int PAGE_8K   = 8192;
 
 class XQSPIPS_Flasher
 {
@@ -43,9 +42,10 @@ class XQSPIPS_Flasher
 public:
     XQSPIPS_Flasher(std::shared_ptr<xrt_core::device> dev);
     ~XQSPIPS_Flasher();
+    unsigned int getFlashSize();
     void program(std::istream& binStream, unsigned base = 0);
     int verify(std::istream& binStream, unsigned base = 0);
-    void readBack(const std::string& output, unsigned base = 0, unsigned total_size = FLASH_SIZE);
+    void readBack(const std::string& output, unsigned base = 0);
     int revertToMFG(std::istream& binStream);
     int xclUpgradeFirmware(std::istream& binStream);
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.h
@@ -24,6 +24,7 @@
 
 const static int PAGE_SIZE = 256;
 const static int PAGE_8K   = 8192;
+const static int FLASH_SIZE = 0x8000000; //128MB
 
 class XQSPIPS_Flasher
 {
@@ -44,6 +45,7 @@ public:
     ~XQSPIPS_Flasher();
     void program(std::istream& binStream, unsigned base = 0);
     int verify(std::istream& binStream, unsigned base = 0);
+    void readBack(const std::string& output, unsigned base = 0, unsigned total_size = FLASH_SIZE);
     int revertToMFG(std::istream& binStream);
     int xclUpgradeFirmware(std::istream& binStream);
 


### PR DESCRIPTION
root@xsjbrd100bx:/tmp# ./xbmgmt2 dump -c -o /tmp/bb.ini -d 17:00.0
config has been dumped to /tmp/bb.ini

root@xsjbrd100bx:/tmp# cat /tmp/bb.ini
[Device]
mailbox_channel_disable=0x120
mailbox_channel_switch=0x0
cache_xclbin=0

root@xsjbrd100bx:/tmp# ./xbmgmt2 advanced --load-config --input /tmp/bb.ini -d 17:00.0
config has been successfully loaded

root@xsjbrd100bx:/tmp# ./xbmgmt2 dump --flash -o /tmp/flashtest -d 17:00.0
Output file already exists: '/tmp/flashtest'

root@xsjbrd100bx:/tmp# rm /tmp/flashtest 
root@xsjbrd100bx:/tmp# ./xbmgmt2 dump --flash -o /tmp/flashtest -d 17:00.0
Output file: /tmp/flashtest
Flash size: 134217728
[PASSED] : Flash read back < 1m 9s >
