### PR TITLE
Enable Native XRT tracing

### DIFF
--- a/src/runtime_src/core/common/api/native_profile.h
+++ b/src/runtime_src/core/common/api/native_profile.h
@@ -40,20 +40,19 @@ class api_call_logger
 {
  private:
   uint64_t m_funcid ;
-  const char* m_name = nullptr ;
-  const char* m_type = nullptr ;
+  const char* m_fullname = nullptr ;
+
  public:
-  api_call_logger(const char* function, const char* type = nullptr) ;
+  api_call_logger(const char* function) ;
   ~api_call_logger() ;
 } ;
 
 template <typename Callable, typename ...Args>
 auto
-profiling_wrapper(const char* function, const char* type,
-                  Callable&& f, Args&&...args)
+profiling_wrapper(const char* function, Callable&& f, Args&&...args)
 {
   if (xrt_core::config::get_native_xrt_trace()) {
-    api_call_logger log_object(function, type) ;
+    api_call_logger log_object(function) ;
     return f(std::forward<Args>(args)...) ;
   }
   return f(std::forward<Args>(args)...) ;

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -747,31 +747,31 @@ namespace xrt {
 
 bo::
 bo(xclDeviceHandle dhdl, void* userptr, size_t sz, bo::flags flags, memory_group grp)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
            alloc_userptr, dhdl, userptr, sz, static_cast<xrtBufferFlags>(flags), grp))
 {}
 
 bo::
 bo(xclDeviceHandle dhdl, size_t size, bo::flags flags, memory_group grp)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
            alloc, dhdl, size, static_cast<xrtBufferFlags>(flags), grp))
 {}
 
 bo::
 bo(xclDeviceHandle dhdl, xclBufferExportHandle ehdl)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
 	   alloc_import, dhdl, ehdl))
 {}
 
 bo::
 bo(const bo& parent, size_t size, size_t offset)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
 	   sub_buffer, parent.handle, size, offset))
 {}
 
 bo::
 bo(xrtBufferHandle xhdl)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
 	   get_boh, xhdl))
 {}
 
@@ -779,7 +779,7 @@ size_t
 bo::
 size() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::bo", [this]{
+  return xdp::native::profiling_wrapper("xrt::bo::size", [this]{
     return handle->get_size();
   }) ;
 }
@@ -788,7 +788,7 @@ uint64_t
 bo::
 address() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::bo", [this]{
+  return xdp::native::profiling_wrapper("xrt::bo::address", [this]{
     return handle->get_address();
   });
 }
@@ -797,7 +797,7 @@ xclBufferExportHandle
 bo::
 export_buffer()
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::bo", [this]{
+  return xdp::native::profiling_wrapper("xrt::bo::export_buffer", [this]{
     return handle->export_buffer();
   });
 }
@@ -806,7 +806,7 @@ void
 bo::
 sync(xclBOSyncDirection dir, size_t size, size_t offset)
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  return xdp::native::profiling_wrapper("xrt::bo::sync",
     [this, dir, size, offset]{
       handle->sync(dir, size, offset);
     });
@@ -816,7 +816,7 @@ void*
 bo::
 map()
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::bo", [this]{
+  return xdp::native::profiling_wrapper("xrt::bo::map", [this]{
     return handle->get_hbuf();
   });
 }
@@ -825,7 +825,7 @@ void
 bo::
 write(const void* src, size_t size, size_t seek)
 {
-  xdp::native::profiling_wrapper(__func__, "xrt::bo", [this, src, size, seek]{
+  xdp::native::profiling_wrapper("xrt::bo::write", [this, src, size, seek]{
     handle->write(src, size, seek);
   });
 }
@@ -834,7 +834,7 @@ void
 bo::
 read(void* dst, size_t size, size_t skip)
 {
-  xdp::native::profiling_wrapper(__func__, "xrt::bo", [this, dst, size, skip]{
+  xdp::native::profiling_wrapper("xrt::bo::read", [this, dst, size, skip]{
     handle->read(dst, size, skip);
   });
 }
@@ -843,7 +843,7 @@ void
 bo::
 copy(const bo& src, size_t sz, size_t src_offset, size_t dst_offset)
 {
-  xdp::native::profiling_wrapper(__func__, "xrt::bo",
+  xdp::native::profiling_wrapper("xrt::bo::copy",
     [this, &src, sz, src_offset, dst_offset]{
       handle->copy(src.handle.get(), sz, src_offset, dst_offset);
     });
@@ -875,7 +875,7 @@ xrtBufferHandle
 xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [dhdl, userptr, size, flags, grp]{
       auto boh = alloc_userptr(get_xcl_device_handle(dhdl), userptr, size, flags, grp);
       bo_cache[boh.get()] = boh;
@@ -896,7 +896,7 @@ xrtBufferHandle
 xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [dhdl, size, flags, grp]{
       auto boh = alloc(get_xcl_device_handle(dhdl), size, flags, grp);
       bo_cache[boh.get()] = boh;
@@ -916,7 +916,7 @@ xrtBufferHandle
 xrtBOSubAlloc(xrtBufferHandle phdl, size_t sz, size_t offset)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [phdl, sz, offset]{
+    return xdp::native::profiling_wrapper(__func__, [phdl, sz, offset]{
       const auto& parent = get_boh(phdl);
       auto boh = sub_buffer(parent, sz, offset);
       bo_cache[boh.get()] = boh;
@@ -936,7 +936,7 @@ xrtBufferHandle
 xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, ehdl]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, ehdl]{
       auto boh = alloc_import(get_xcl_device_handle(dhdl), ehdl);
       bo_cache[boh.get()] = boh;
       return boh.get();
@@ -955,7 +955,7 @@ xclBufferExportHandle
 xrtBOExport(xrtBufferHandle bhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [bhdl]{
+    return xdp::native::profiling_wrapper(__func__, [bhdl]{
       return get_boh(bhdl)->export_buffer();
     });
   }
@@ -972,7 +972,7 @@ int
 xrtBOFree(xrtBufferHandle bhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [bhdl]{
+    return xdp::native::profiling_wrapper(__func__, [bhdl]{
       free_bo(bhdl);
       return 0;
     });
@@ -991,7 +991,7 @@ size_t
 xrtBOSize(xrtBufferHandle bhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [bhdl]{
+    return xdp::native::profiling_wrapper(__func__, [bhdl]{
       return get_boh(bhdl)->get_size();
     });
   }
@@ -1009,7 +1009,7 @@ int
 xrtBOSync(xrtBufferHandle bhdl, xclBOSyncDirection dir, size_t size, size_t offset)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [bhdl, dir, size, offset]{
       get_boh(bhdl)->sync(dir, size, offset);
       return 0;
@@ -1029,7 +1029,7 @@ void*
 xrtBOMap(xrtBufferHandle bhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [bhdl]{
+    return xdp::native::profiling_wrapper(__func__, [bhdl]{
       return get_boh(bhdl)->get_hbuf();
     });
   }
@@ -1046,7 +1046,7 @@ int
 xrtBOWrite(xrtBufferHandle bhdl, const void* src, size_t size, size_t seek)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [bhdl, src, size, seek]{
       get_boh(bhdl)->write(src, size, seek);
       return 0;
@@ -1066,7 +1066,7 @@ int
 xrtBORead(xrtBufferHandle bhdl, void* dst, size_t size, size_t skip)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [bhdl, dst, size, skip]{
       get_boh(bhdl)->read(dst, size, skip);
       return 0;
@@ -1086,7 +1086,7 @@ int
 xrtBOCopy(xrtBufferHandle dhdl, xrtBufferHandle shdl, size_t sz, size_t dst_offset, size_t src_offset)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [dhdl, shdl, sz, dst_offset, src_offset]{
       const auto& dst = get_boh(dhdl);
       const auto& src = get_boh(shdl);
@@ -1109,7 +1109,7 @@ uint64_t
 xrtBOAddress(xrtBufferHandle bhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [bhdl]{
+    return xdp::native::profiling_wrapper(__func__, [bhdl]{
       return get_boh(bhdl)->get_address();
     });
   }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -155,7 +155,7 @@ namespace xrt {
 
 device::
 device(unsigned int index)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::device",
+  : handle(xdp::native::profiling_wrapper("xrt::device::device",
 	   alloc_device_index, index))
 {}
 
@@ -166,7 +166,7 @@ device(const std::string& bdf)
 
 device::
 device(xclDeviceHandle dhdl)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::device",
+  : handle(xdp::native::profiling_wrapper("xrt::device::device",
 	   alloc_device_handle, dhdl))
 {}
 
@@ -174,7 +174,7 @@ uuid
 device::
 load_xclbin(const struct axlf* top)
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::device", [this, top]{
+  return xdp::native::profiling_wrapper("xrt::device::load_xclbin", [this, top]{
     xrt::xclbin xclbin{top};
     handle->load_xclbin(xclbin);
     return xclbin.get_uuid();
@@ -185,7 +185,7 @@ uuid
 device::
 load_xclbin(const std::string& fnm)
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::device", [this, &fnm]{
+  return xdp::native::profiling_wrapper("xrt::device::load_xclbin", [this, &fnm]{
     xrt::xclbin xclbin{fnm};
     handle->load_xclbin(xclbin);
     return xclbin.get_uuid();
@@ -196,7 +196,7 @@ uuid
 device::
 load_xclbin(const xclbin& xclbin)
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::device",
+  return xdp::native::profiling_wrapper("xrt::device::load_xclbin",
   [this, &xclbin]{
     handle->load_xclbin(xclbin);
     return xclbin.get_uuid();
@@ -207,7 +207,7 @@ uuid
 device::
 get_xclbin_uuid() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::device", [this]{
+  return xdp::native::profiling_wrapper("xrt::device::get_xclbin_uuid", [this]{
     return handle->get_xclbin_uuid();
   });
 }
@@ -222,7 +222,7 @@ void
 device::
 reset()
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::device", [this]{
+  return xdp::native::profiling_wrapper("xrt::device::reset", [this]{
     handle.reset();
   });
 }
@@ -231,7 +231,7 @@ std::pair<const char*, size_t>
 device::
 get_xclbin_section(axlf_section_kind section, const uuid& uuid) const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::device",
+  return xdp::native::profiling_wrapper("xrt::device::get_xclbin_section",
     [this, section, &uuid]{
       return handle->get_axlf_section_or_error(section, uuid);
     });
@@ -297,7 +297,7 @@ xrtDeviceHandle
 xrtDeviceOpen(unsigned int index)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [index]{
+    return xdp::native::profiling_wrapper(__func__, [index]{
       auto device = xrt_core::get_userpf_device(index);
       device_cache[device.get()] = device;
       return device.get();
@@ -316,7 +316,7 @@ xrtDeviceHandle
 xrtDeviceOpenByBDF(const char* bdf)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [bdf]{
+    return xdp::native::profiling_wrapper(__func__, [bdf]{
       return xrtDeviceOpen(xrt_core::get_device_id(bdf));
     });
   }
@@ -333,7 +333,7 @@ int
 xrtDeviceClose(xrtDeviceHandle dhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl]{
       free_device(dhdl);
       return 0;
     });
@@ -352,7 +352,7 @@ int
 xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const axlf* top)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, top]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, top]{
       xrt::xclbin xclbin{top};
       auto device = get_device(dhdl);
       device->load_xclbin(xclbin);
@@ -373,7 +373,7 @@ int
 xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* fnm)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, fnm]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, fnm]{
       xrt::xclbin xclbin{fnm};
       auto device = get_device(dhdl);
       device->load_xclbin(xclbin);
@@ -394,7 +394,7 @@ int
 xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, xhdl]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, xhdl]{
       auto device = get_device(dhdl);
       device->load_xclbin(xrt_core::xclbin_int::get_xclbin(xhdl));
       return 0;
@@ -414,7 +414,7 @@ int
 xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, uuid]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, uuid]{
       auto device = get_device(dhdl);
       device->load_xclbin(uuid);
       return 0;
@@ -434,7 +434,7 @@ int
 xrtDeviceGetXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, out]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, out]{
       auto device = get_device(dhdl);
       auto uuid = device->get_xclbin_uuid();
       uuid_copy(out, uuid.get());
@@ -455,7 +455,7 @@ xclDeviceHandle
 xrtDeviceToXclDevice(xrtDeviceHandle dhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl]{
       auto device = get_device(dhdl);
       return device->get_device_handle();
     });
@@ -473,7 +473,7 @@ xrtDeviceHandle
 xrtDeviceOpenFromXcl(xclDeviceHandle dhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl]{
       auto device = xrt_core::get_userpf_device(dhdl);
 
       // Only one xrt unmanaged device per xclDeviceHandle

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -255,13 +255,13 @@ namespace xrt {
 
 error::
 error(const xrt::device& device, xrtErrorClass ecl)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::error",
+  : handle(xdp::native::profiling_wrapper("xrt::error::error",
            alloc_error_from_device, device.get_handle().get(), ecl))
 {}
 
 error::
 error(xrtErrorCode code, xrtErrorTime timestamp)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::error",
+  : handle(xdp::native::profiling_wrapper("xrt::error::error",
 	   alloc_error_from_code, code, timestamp))
 {}
 
@@ -269,7 +269,7 @@ xrtErrorTime
 error::
 get_timestamp() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::error", [this]{
+  return xdp::native::profiling_wrapper("xrt::error::get_timestamp", [this]{
     return handle->get_timestamp();
   });
 }
@@ -278,7 +278,7 @@ xrtErrorCode
 error::
 get_error_code() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::error", [this]{
+  return xdp::native::profiling_wrapper("xrt::error::get_error_code", [this]{
     return handle->get_error_code();
   });
 }
@@ -287,7 +287,7 @@ std::string
 error::
 to_string() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::error", [this]{
+  return xdp::native::profiling_wrapper("xrt::error::to_string", [this]{
     return handle->to_string();
   });
 }
@@ -301,7 +301,7 @@ int
 xrtErrorGetLast(xrtDeviceHandle dhdl, xrtErrorClass ecl, xrtErrorCode* error, uint64_t* timestamp)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [dhdl, ecl, error, timestamp]{
       auto handle = xrt::error_impl(xrt_core::device_int::get_core_device(dhdl).get(), ecl);
       *error = handle.get_error_code();
@@ -323,7 +323,7 @@ int
 xrtErrorGetString(xrtDeviceHandle, xrtErrorCode error, char* out, size_t len, size_t* out_len)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [error, out, len, out_len]{
       auto str = error_code_to_string(error);
 

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2235,7 +2235,7 @@ namespace xrt {
 
 run::
 run(const kernel& krnl)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::run",
+  : handle(xdp::native::profiling_wrapper("xrt::run::run",
 					alloc_run, krnl.get_handle()))
 {}
 
@@ -2243,7 +2243,7 @@ void
 run::
 start()
 {
-  xdp::native::profiling_wrapper(__func__, "xrt::run", [this]{
+  xdp::native::profiling_wrapper("xrt::run::start", [this]{
     handle->start();
   });
 }
@@ -2252,7 +2252,7 @@ ert_cmd_state
 run::
 wait(const std::chrono::milliseconds& timeout_ms) const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::run",
+  return xdp::native::profiling_wrapper("xrt::run::wait",
     [this, &timeout_ms] {
       return handle->wait(timeout_ms);
     });
@@ -2262,7 +2262,7 @@ ert_cmd_state
 run::
 state() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::run", [this]{
+  return xdp::native::profiling_wrapper("xrt::run::state", [this]{
     return handle->state();
   });
 }
@@ -2319,7 +2319,7 @@ void
 run::
 set_event(const std::shared_ptr<event_impl>& event) const
 {
-  xdp::native::profiling_wrapper(__func__, "xrt::run", [this, &event]{
+  xdp::native::profiling_wrapper("xrt::run::set_event", [this, &event]{
     handle->set_event(event);
   });
 }
@@ -2328,20 +2328,20 @@ ert_packet*
 run::
 get_ert_packet() const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::run", [this]{
+  return xdp::native::profiling_wrapper("xrt::run::get_ert_packet", [this]{
     return handle->get_ert_packet();
   });
 }
 
 kernel::
 kernel(const xrt::device& xdev, const xrt::uuid& xclbin_id, const std::string& name, cu_access_mode mode)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::kernel",
+  : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
 	   alloc_kernel, get_device(xdev), xclbin_id, name, mode))
 {}
 
 kernel::
 kernel(xclDeviceHandle dhdl, const xrt::uuid& xclbin_id, const std::string& name, cu_access_mode mode)
-  : handle(xdp::native::profiling_wrapper(__func__, "xrt::kernel",
+  : handle(xdp::native::profiling_wrapper("xrt::kernel::kernel",
 	   alloc_kernel, get_device(xrt_core::get_userpf_device(dhdl)), xclbin_id, name, mode))
 {}
 
@@ -2349,7 +2349,7 @@ uint32_t
 kernel::
 read_register(uint32_t offset) const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::kernel", [this, offset]{
+  return xdp::native::profiling_wrapper("xrt::kernel::read_register", [this, offset]{
     return handle->read_register(offset);
   });
 }
@@ -2358,7 +2358,7 @@ void
 kernel::
 write_register(uint32_t offset, uint32_t data)
 {
-  xdp::native::profiling_wrapper(__func__, "xrt::kernel", [this, offset, data]{
+  xdp::native::profiling_wrapper("xrt::kernel::write_register", [this, offset, data]{
     handle->write_register(offset, data);
   });
 }
@@ -2368,7 +2368,7 @@ int
 kernel::
 group_id(int argno) const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::kernel", [this, argno]{
+  return xdp::native::profiling_wrapper("xrt::kernel::group_id", [this, argno]{
     return handle->group_id(argno);
   });
 }
@@ -2377,7 +2377,7 @@ uint32_t
 kernel::
 offset(int argno) const
 {
-  return xdp::native::profiling_wrapper(__func__, "xrt::kernel", [this, argno]{
+  return xdp::native::profiling_wrapper("xrt::kernel::offset", [this, argno]{
     return handle->arg_offset(argno);
   });
 }
@@ -2391,7 +2391,7 @@ xrtKernelHandle
 xrtPLKernelOpen(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char *name)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [dhdl, xclbin_uuid, name]{
       return api::xrtKernelOpen(dhdl, xclbin_uuid, name, ip_context::access_mode::shared);
     });
@@ -2406,7 +2406,7 @@ xrtKernelHandle
 xrtPLKernelOpenExclusive(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char *name)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [dhdl, xclbin_uuid, name]{
       return api::xrtKernelOpen(dhdl, xclbin_uuid, name, ip_context::access_mode::exclusive);
     });
@@ -2421,7 +2421,7 @@ int
 xrtKernelClose(xrtKernelHandle khdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [khdl]{
+    return xdp::native::profiling_wrapper(__func__, [khdl]{
       api::xrtKernelClose(khdl);
       return 0;
     });
@@ -2440,7 +2440,7 @@ xrtRunHandle
 xrtRunOpen(xrtKernelHandle khdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [khdl]{
+    return xdp::native::profiling_wrapper(__func__, [khdl]{
       return api::xrtRunOpen(khdl);
     });
   }
@@ -2454,7 +2454,7 @@ int
 xrtKernelArgGroupId(xrtKernelHandle khdl, int argno)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [khdl, argno]{
+    return xdp::native::profiling_wrapper(__func__, [khdl, argno]{
       return get_kernel(khdl)->group_id(argno);
     });
   }
@@ -2472,7 +2472,7 @@ uint32_t
 xrtKernelArgOffset(xrtKernelHandle khdl, int argno)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [khdl, argno]{
+    return xdp::native::profiling_wrapper(__func__, [khdl, argno]{
       return get_kernel(khdl)->arg_offset(argno);
     });
   }
@@ -2490,7 +2490,7 @@ int
 xrtKernelReadRegister(xrtKernelHandle khdl, uint32_t offset, uint32_t* datap)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [khdl, offset, datap]{
       *datap = get_kernel(khdl)->read_register(offset);
       return 0;
@@ -2510,7 +2510,7 @@ int
 xrtKernelWriteRegister(xrtKernelHandle khdl, uint32_t offset, uint32_t data)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [khdl, offset, data]{
       get_kernel(khdl)->write_register(offset, data);
       return 0;
@@ -2533,7 +2533,7 @@ xrtKernelRun(xrtKernelHandle khdl, ...)
     std::va_list args;
     std::va_list* argptr = &args ;
     va_start(args, khdl);
-    auto result = xdp::native::profiling_wrapper(__func__, nullptr,
+    auto result = xdp::native::profiling_wrapper(__func__,
     [khdl, argptr]{
       auto handle = xrtRunOpen(khdl);
       auto run = get_run(handle);
@@ -2554,7 +2554,7 @@ int
 xrtRunClose(xrtRunHandle rhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [rhdl]{
+    return xdp::native::profiling_wrapper(__func__, [rhdl]{
       api::xrtRunClose(rhdl);
       return 0;
     });
@@ -2573,7 +2573,7 @@ ert_cmd_state
 xrtRunState(xrtRunHandle rhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [rhdl]{
+    return xdp::native::profiling_wrapper(__func__, [rhdl]{
       return api::xrtRunState(rhdl);
     });
   }
@@ -2587,7 +2587,7 @@ ert_cmd_state
 xrtRunWait(xrtRunHandle rhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [rhdl]{
+    return xdp::native::profiling_wrapper(__func__, [rhdl]{
       return api::xrtRunWait(rhdl, 0);
     });
   }
@@ -2601,7 +2601,7 @@ ert_cmd_state
 xrtRunWaitFor(xrtRunHandle rhdl, unsigned int timeout_ms)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [rhdl, timeout_ms]{
+    return xdp::native::profiling_wrapper(__func__, [rhdl, timeout_ms]{
       return api::xrtRunWait(rhdl, timeout_ms);
     });
   }
@@ -2617,7 +2617,7 @@ xrtRunSetCallback(xrtRunHandle rhdl, ert_cmd_state state,
                   void* data)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [rhdl, state, pfn_state_notify, data]{
       api::xrtRunSetCallback(rhdl, state, pfn_state_notify, data);
       return 0;
@@ -2637,7 +2637,7 @@ int
 xrtRunStart(xrtRunHandle rhdl)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [rhdl]{
+    return xdp::native::profiling_wrapper(__func__, [rhdl]{
       api::xrtRunStart(rhdl);
       return 0;
     });
@@ -2659,7 +2659,7 @@ xrtRunUpdateArg(xrtRunHandle rhdl, int index, ...)
     std::va_list args;
     std::va_list* argptr = &args;
     va_start(args, index);
-    auto result = xdp::native::profiling_wrapper(__func__, nullptr,
+    auto result = xdp::native::profiling_wrapper(__func__,
     [rhdl, index, argptr]{
       auto upd = get_run_update(rhdl);
       upd->update_arg_at_index(index, argptr);
@@ -2682,7 +2682,7 @@ int
 xrtRunUpdateArgV(xrtRunHandle rhdl, int index, const void* value, size_t bytes)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [rhdl, index, value, bytes]{
       auto upd = get_run_update(rhdl);
       upd->update_arg_at_index(index, value, bytes);
@@ -2706,7 +2706,7 @@ xrtRunSetArg(xrtRunHandle rhdl, int index, ...)
     std::va_list args;
     std::va_list* argptr = &args ;
     va_start(args, index);
-    auto result = xdp::native::profiling_wrapper(__func__, nullptr,
+    auto result = xdp::native::profiling_wrapper(__func__,
     [rhdl, index, argptr]{
       auto run = get_run(rhdl);
       run->set_arg_at_index(index, argptr);
@@ -2729,7 +2729,7 @@ int
 xrtRunSetArgV(xrtRunHandle rhdl, int index, const void* value, size_t bytes)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [rhdl, index, value, bytes]{
       auto run = get_run(rhdl);
       run->set_arg_at_index(index, value, bytes);
@@ -2750,7 +2750,7 @@ int
 xrtRunGetArgV(xrtRunHandle rhdl, int index, void* value, size_t bytes)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [rhdl, index, value, bytes]{
       auto run = get_run(rhdl);
       run->get_arg_at_index(index, static_cast<uint32_t*>(value), bytes);
@@ -2770,7 +2770,7 @@ xrtRunGetArgV(xrtRunHandle rhdl, int index, void* value, size_t bytes)
 void
 xrtRunGetArgVPP(xrt::run run, int index, void* value, size_t bytes)
 {
-  xdp::native::profiling_wrapper(__func__, nullptr, [run, index, value, bytes]{
+  xdp::native::profiling_wrapper(__func__, [run, index, value, bytes]{
     const auto& rimpl = run.get_handle();
     rimpl->get_arg_at_index(index, static_cast<uint32_t*>(value), bytes);
   });

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -958,7 +958,7 @@ xrtXclbinHandle
 xrtXclbinAllocFilename(const char* filename)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [filename]{
+    return xdp::native::profiling_wrapper(__func__, [filename]{
       auto xclbin = std::make_shared<xrt::xclbin_full>(filename);
       auto handle = xclbin.get();
       xclbins.emplace(handle, std::move(xclbin));
@@ -978,7 +978,7 @@ xrtXclbinHandle
 xrtXclbinAllocRawData(const char* data, int size)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [data, size]{
+    return xdp::native::profiling_wrapper(__func__, [data, size]{
       std::vector<char> raw_data(data, data + size);
       auto xclbin = std::make_shared<xrt::xclbin_full>(raw_data);
       auto handle = xclbin.get();
@@ -999,7 +999,7 @@ int
 xrtXclbinFreeHandle(xrtXclbinHandle handle)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [handle]{
+    return xdp::native::profiling_wrapper(__func__, [handle]{
       free_xclbin(handle);
       return 0;
     });
@@ -1019,7 +1019,7 @@ int
 xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [handle, name, size, ret_size]{
       auto xclbin = get_xclbin(handle);
       const std::string& xsaname = xclbin->get_xsa_name();
@@ -1046,7 +1046,7 @@ int
 xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [handle, ret_uuid]{
+    return xdp::native::profiling_wrapper(__func__, [handle, ret_uuid]{
       auto xclbin = get_xclbin(handle);
       auto result = xclbin->get_uuid();
       uuid_copy(ret_uuid, result.get());
@@ -1067,7 +1067,7 @@ int
 xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr,
+    return xdp::native::profiling_wrapper(__func__,
     [handle, data, size, ret_size]{
       auto xclbin = get_xclbin(handle);
       auto& result = xclbin->get_data();
@@ -1100,7 +1100,7 @@ int
 xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out)
 {
   try {
-    return xdp::native::profiling_wrapper(__func__, nullptr, [dhdl, out]{
+    return xdp::native::profiling_wrapper(__func__, [dhdl, out]{
       auto device = xrt_core::get_userpf_device(dhdl);
       auto uuid = device->get_xclbin_uuid();
       uuid_copy(out, uuid.get());

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -258,12 +258,8 @@ get_xrt_trace()
 inline bool
 get_native_xrt_trace()
 {
-  // Temporarily disabling
-  return false;
-  /*
   static bool value = detail::get_bool_value("Debug.native_xrt_trace", false);
   return value;
-  */
 }
 
 inline bool

--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.cpp
@@ -474,11 +474,23 @@ void warning_callbacks()
 {
 }
 
+int error_function()
+{
+  if (xrt_core::config::get_native_xrt_trace()) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning,
+                            "XRT",
+                            "Enabling both Native XRT and HAL level trace is not currently supported.  Only Native XRT tracing will be enabled");
+    return 1;
+  }
+  return 0 ;
+}
+
 void load()
 {
   static xrt_core::module_loader xdp_hal_loader("xdp_hal_plugin",
                                                 register_callbacks,
-                                                warning_callbacks) ;
+                                                warning_callbacks,
+                                                error_function) ;
 }
 
 } // end namespace hal

--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.h
@@ -231,6 +231,8 @@ class CloseContextCallLogger : public CallLogger
 void load();
 void register_callbacks(void* handle) ;
 void warning_callbacks() ;
+int error_function() ;
+
 
 } // end namespace hal
 } // end namespace xdp

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
@@ -1,6 +1,8 @@
 #include "plugin/xdp/plugin_loader.h"
 #include "plugin/xdp/hal_profile.h"
 #include "core/common/module_loader.h"
+#include "core/common/config_reader.h"
+#include "core/common/message.h"
 #include "core/common/utils.h"
 #include "core/common/dlfcn.h"
 
@@ -467,11 +469,23 @@ LoadXclbinCallLogger::~LoadXclbinCallLogger()
   {
   }
 
+  int error_function()
+  {
+    if (xrt_core::config::get_native_xrt_trace()) {
+      xrt_core::message::send(xrt_core::message::severity_level::warning,
+                              "XRT",
+                              "Enabling both Native XRT and HAL level trace is not currently supported.  Only Native XRT tracing will be enabled.");
+      return 1;
+    }
+    return 0;
+  }
+
   void load()
   {
     static xrt_core::module_loader xdp_hal_loader("xdp_hal_plugin",
                                                   register_callbacks,
-                                                  warning_callbacks) ;
+                                                  warning_callbacks,
+                                                  error_function) ;
   }
 
 } // end namespace hal

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.h
@@ -227,6 +227,7 @@ class CloseContextCallLogger : public CallLogger
 void load();
 void register_callbacks(void* handle) ;
 void warning_callbacks() ;
+int error_function() ;
 
 } // end namespace hal
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -92,10 +92,11 @@ namespace xdp {
     XDP_EXPORT virtual ~VTFEvent() ;
 
     // Getters and Setters
-    inline double       getTimestamp()   const { return timestamp ; }
-    inline uint64_t     getEventId()           { return id ; } 
-    inline void         setEventId(uint64_t i) { id = i ; }
-    inline VTFEventType getEventType()         { return type; }
+    inline double       getTimestamp()    const { return timestamp ; }
+    inline void         setTimestamp(double ts) { timestamp = ts ; }
+    inline uint64_t     getEventId()            { return id ; }
+    inline void         setEventId(uint64_t i)  { id = i ; }
+    inline VTFEventType getEventType()          { return type; }
 
     // Functions that can be used as filters
     virtual bool isUserEvent()       { return false ; }

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.h
@@ -23,6 +23,6 @@ extern "C"
 void native_function_start(const char* functionName, unsigned long long int functionID) ;
 
 extern "C"
-void native_function_end(const char* functionName, unsigned long long int functionID) ;
+void native_function_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp) ;
 
 #endif

--- a/src/runtime_src/xdp/profile/writer/native/native_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/native/native_writer.cpp
@@ -57,15 +57,27 @@ namespace xdp {
 
   void NativeTraceWriter::writeTraceEvents()
   {
-    std::vector<std::unique_ptr<VTFEvent>> APIEvents = 
-      (db->getDynamicInfo()).filterEraseHostEvents([](VTFEvent* e)
-                                                   {
-                                                     return e->isNativeHostEvent() ;
-                                                   }
-                                                  ) ;
+    std::vector<VTFEvent*> APIEvents =
+      (db->getDynamicInfo()).filterEraseUnsortedHostEvents(
+        [](VTFEvent* e)
+        {
+          return e->isNativeHostEvent() ;
+        } ) ;
+
+    std::sort(APIEvents.begin(), APIEvents.end(),
+              [](VTFEvent* x, VTFEvent* y)
+                {
+                  if (x->getTimestamp() < y->getTimestamp()) return true;
+                  return false ;
+                }) ;
+
     fout << "EVENTS" << "\n" ;
     for (auto& e : APIEvents) {
       e->dump(fout, 1) ; // 1 is the only bucket
+    }
+
+    for (auto& e : APIEvents) {
+      delete e ;
     }
   }
 


### PR DESCRIPTION
This pull request:

- Enables Native C/C++ API tracing (with the xrt.ini option native_xrt_trace=true)
- Restricts the user from enabling both Native API tracing and HAL level tracing
- Minimizes overhead by removing string manipulation
- Captures the timestamps displayed on the timeline trace as close as possible to the beginning and end of the observed function
- Adds a new set of unsorted events to the XDP database, which are stored in a vector and must be sorted before being dumped to the CSV file.  Currently, only used by the Native XRT events.