### PR TITLE
Added AIE/Graph context support with new kds

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_client.h
+++ b/src/runtime_src/core/common/drv/include/kds_client.h
@@ -50,6 +50,11 @@ struct kds_client {
 	void			 *xclbin_id;
 	int			  num_ctx;
 	int			  virt_cu_ref;
+
+	struct list_head          graph_list;
+	spinlock_t                graph_list_lock;
+	u32                       aie_ctx;
+
 	DECLARE_BITMAP(cu_bitmap, MAX_CUS);
 	/* Per client statistics. Use percpu variable for two reasons
 	 * 1. no lock is need while modifying these counters

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -237,6 +237,15 @@ int zocl_aie_alloc_context(struct drm_zocl_dev *zdev, u32 ctx_code,
 		struct sched_client_ctx *client);
 int zocl_aie_free_context(struct drm_zocl_dev *zdev,
 		struct sched_client_ctx *client);
+int zocl_aie_kds_add_graph_context(struct drm_zocl_dev *zdev, u32 gid,
+	        u32 ctx_code, struct kds_client *client);
+int zocl_aie_kds_del_graph_context(struct drm_zocl_dev *zdev, u32 gid,
+	        struct kds_client *client);
+void zocl_aie_kds_del_graph_context_all(struct kds_client *client);
+int zocl_aie_kds_add_context(struct drm_zocl_dev *zdev, u32 ctx_code,
+	struct kds_client *client);
+int zocl_aie_kds_del_context(struct drm_zocl_dev *zdev,
+	struct kds_client *client);
 
 int zocl_inject_error(struct drm_zocl_dev *zdev, void *data,
 		struct drm_file *filp);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -643,6 +643,212 @@ zocl_aie_free_context(struct drm_zocl_dev *zdev,
 }
 
 int
+zocl_aie_kds_add_graph_context(struct drm_zocl_dev *zdev, u32 gid,
+	u32 ctx_code, struct kds_client *client)
+{
+	struct list_head *cptr, *gptr;
+	struct zocl_graph_ctx_node *gnode;
+	struct kds_client *ctx;
+	unsigned long graph_flags;
+	struct kds_sched *kds = &zdev->kds;
+	int ret;
+
+	mutex_lock(&kds->lock);
+
+	list_for_each(cptr, &kds->clients) {
+		ctx = list_entry(cptr, struct kds_client, link);
+
+		spin_lock_irqsave(&ctx->graph_list_lock, graph_flags);
+
+		list_for_each(gptr, &ctx->graph_list) {
+			gnode = list_entry(gptr, struct zocl_graph_ctx_node,
+			    link);
+
+			if (gnode->gid != gid)
+				continue;
+
+			if (ctx == client) {
+				/*
+				 * This graph has been opened by same
+				 * context.
+				 */
+				DRM_ERROR("Graph %d has been opened.\n", gid);
+				ret = -EINVAL;
+				goto out;
+			}
+
+			if (gnode->ctx_code == ZOCL_CTX_EXCLUSIVE ||
+			    ctx_code == ZOCL_CTX_EXCLUSIVE) {
+				/*
+				 * This graph has been opened with
+				 * exclusive context or;
+				 * We request exclusive context but
+				 * this graph has been opened with
+				 * non-exclusive context
+				 */
+				DRM_ERROR("Graph %d only one exclusive context can be opened.\n",
+				    gid);
+				ret = -EBUSY;
+				goto out;
+			}
+
+			if (gnode->ctx_code == ZOCL_CTX_PRIMARY &&
+			    ctx_code != ZOCL_CTX_SHARED) {
+				/*
+				 * This graph has been opened with
+				 * primary context but the request
+				 * is not shared context
+				 */
+				DRM_ERROR("Graph %d has been opened with primary context.\n",
+				    gid);
+				ret = -EBUSY;
+				goto out;
+			}
+		}
+		spin_unlock_irqrestore(&ctx->graph_list_lock, graph_flags);
+	}
+
+	gnode = kzalloc(sizeof(*gnode), GFP_KERNEL);
+	gnode->ctx_code = ctx_code;
+	gnode->gid = gid;
+	list_add_tail(&gnode->link, &client->graph_list);
+
+	mutex_unlock(&kds->lock);
+	return 0;
+
+out:
+	spin_unlock_irqrestore(&ctx->graph_list_lock, graph_flags);
+	mutex_unlock(&kds->lock);
+
+	return ret;
+}
+
+int
+zocl_aie_kds_del_graph_context(struct drm_zocl_dev *zdev, u32 gid,
+	struct kds_client *client)
+{
+	struct list_head *gptr, *next;
+	struct zocl_graph_ctx_node *gnode;
+	unsigned long flags = 0;
+	int ret;
+
+	spin_lock_irqsave(&client->graph_list_lock, flags);
+
+	list_for_each_safe(gptr, next, &client->graph_list) {
+		gnode = list_entry(gptr, struct zocl_graph_ctx_node, link);
+
+		if (gnode->gid == gid) {
+			list_del(gptr);
+			kfree(gnode);
+			ret = 0;
+			goto out;
+		}
+	}
+
+	DRM_ERROR("Fail to close graph context: Graph %d does not exist.\n",
+	    gid);
+	ret = -EINVAL;
+
+out:
+	spin_unlock_irqrestore(&client->graph_list_lock, flags);
+	return ret;
+}
+
+void
+zocl_aie_kds_del_graph_context_all(struct kds_client *client)
+{
+	struct list_head *gptr, *next;
+	struct zocl_graph_ctx_node *gnode;
+	unsigned long flags = 0;
+
+	spin_lock_irqsave(&client->graph_list_lock, flags);
+
+	list_for_each_safe(gptr, next, &client->graph_list) {
+		gnode = list_entry(gptr, struct zocl_graph_ctx_node, link);
+
+		list_del(gptr);
+		kfree(gnode);
+	}
+
+	spin_unlock_irqrestore(&client->graph_list_lock, flags);
+}
+
+int
+zocl_aie_kds_add_context(struct drm_zocl_dev *zdev, u32 ctx_code,
+	struct kds_client *client)
+{
+	struct list_head *cptr;
+	struct kds_client *ctx;
+	struct kds_sched *kds = &zdev->kds;
+	int ret = 0;
+
+	mutex_lock(&kds->lock);
+
+	if (client->aie_ctx != ZOCL_CTX_NOOPS) {
+		DRM_ERROR("Changing AIE context is not supported.\n");
+		ret = -EBUSY;
+		goto out;
+	}
+
+	list_for_each(cptr, &kds->clients) {
+		ctx = list_entry(cptr, struct kds_client, link);
+
+		if (ctx == client || ctx->aie_ctx == ZOCL_CTX_NOOPS)
+			continue;
+
+		if (ctx->aie_ctx == ZOCL_CTX_EXCLUSIVE ||
+		    ctx_code == ZOCL_CTX_EXCLUSIVE) {
+			/*
+			 * This AIE array has been allocated exclusive
+			 * context or;
+			 * We request exclusive context but this AIE array
+			 * has been allocated with non-exclusive context
+			 */
+			DRM_ERROR("Only one exclusive AIE context can be allocated.\n");
+			ret = -EBUSY;
+			goto out;
+		}
+
+		if (ctx->aie_ctx == ZOCL_CTX_PRIMARY &&
+		    ctx_code != ZOCL_CTX_SHARED) {
+			/*
+			 * This AIE array has been allocated primary context
+			 * but the request is not shared context
+			 */
+			DRM_ERROR("Primary AIE context has been allocated.\n");
+			ret = -EBUSY;
+			goto out;
+		}
+	}
+
+	client->aie_ctx = ctx_code;
+
+out:
+	mutex_unlock(&kds->lock);
+	return ret;
+}
+
+int
+zocl_aie_kds_del_context(struct drm_zocl_dev *zdev, struct kds_client *client)
+{
+	struct kds_sched *kds = &zdev->kds;
+
+	mutex_lock(&kds->lock);
+
+	if (client->aie_ctx == ZOCL_CTX_NOOPS) {
+		DRM_ERROR("No AIE context has been allocated.\n");
+		mutex_unlock(&kds->lock);
+		return -EINVAL;
+	}
+
+	client->aie_ctx = ZOCL_CTX_NOOPS;
+
+	mutex_unlock(&kds->lock);
+	return 0;
+
+}
+
+int
 zocl_aie_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 {
 	int ret;


### PR DESCRIPTION
Port the graph/aie context support to new kds.

@mamin506 you may notice there are some dup code with old and new kds. There are couple of reasons that I decide not to share a common code
1) Client structure between old and new kds are different, even we use same name for AIE/Graph context, it is not easy to share then because of the offset inside the structure and the use of lock (mutex vs spinlock)
2) We probably will gradually remove old kds code once new kds getting mature. So there is not much benefit we can get by the big effort to share the code between old and new kds. 