### PR TITLE
EoU u30 CRs (#4982)

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -24,6 +24,9 @@
 #include "error.h"
 #include <stdexcept>
 
+// Internal shim function forward declarations
+int xclUpdateSchedulerStat(xclDeviceHandle handle);
+
 namespace xrt_core {
 
 /**
@@ -107,6 +110,9 @@ struct ishim
 
   virtual void
   p2p_disable(bool force) = 0;
+  
+  virtual
+  void update_scheduler_status() = 0;
 
 #ifdef XRT_ENABLE_AIE
   virtual xclGraphHandle
@@ -363,6 +369,13 @@ struct shim : public DeviceType
   {
     if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), false, force))
       throw error(ret, "failed to disable p2p");
+  }
+
+  virtual void
+  update_scheduler_status()
+  {
+    if (auto ret = xclUpdateSchedulerStat(DeviceType::get_device_handle()))
+      throw error(ret, "failed to update scheduler status");
   }
 
 #ifdef XRT_ENABLE_AIE

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -594,6 +594,12 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
   return -ENOSYS;
 }
 
+int
+xclUpdateSchedulerStat(xclDeviceHandle handle)
+{
+  return -ENOSYS;
+}
+
 /*
  * API to get number of live processes.
  * Applicable only for System Flow as it supports Multiple processes on same device.

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -2316,6 +2316,12 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
 }
 
 int
+xclUpdateSchedulerStat(xclDeviceHandle handle)
+{
+  return 1; // -ENOSYS;
+}
+
+int
 xclErrorInject(xclDeviceHandle handle, uint16_t num, uint16_t driver, uint16_t severity, uint16_t module, uint16_t eclass)
 {
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -649,6 +649,12 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
   return -ENOSYS;
 }
 
+int
+xclUpdateSchedulerStat(xclDeviceHandle handle)
+{
+  return -ENOSYS;
+}
+
 //Get CU index from IP_LAYOUT section for corresponding kernel name
 int xclIPName2Index(xclDeviceHandle handle, const char *name)
 {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -541,6 +541,12 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
   return -ENOSYS;
 }
 
+int
+xclUpdateSchedulerStat(xclDeviceHandle handle)
+{
+  return -ENOSYS;
+}
+
 //Get CU index from IP_LAYOUT section for corresponding kernel name
 int xclIPName2Index(xclDeviceHandle handle, const char *name)
 {

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -588,3 +588,9 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
 {
   return 1; // -ENOSYS;
 }
+
+int
+xclUpdateSchedulerStat(xclDeviceHandle handle)
+{
+  return 1; // -ENOSYS;
+}

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1709,3 +1709,9 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
 {
   return 1; // -ENOSYS;
 }
+
+int
+xclUpdateSchedulerStat(xclDeviceHandle handle)
+{
+  return 1; // -ENOSYS;
+}

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -50,7 +50,7 @@ ReportHost::getPropertyTree20202( const xrt_core::device * /*_pDevice*/,
   xrt_core::get_xrt_info(pt_xrt_info);
   pt.add_child("xrt", pt_xrt_info);
 
-  auto dev_pt = XBUtilities::get_available_devices(true);
+  auto dev_pt = XBUtilities::get_available_devices(m_is_user);
   pt.add_child("devices", dev_pt);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportHost.h
+++ b/src/runtime_src/core/tools/common/ReportHost.h
@@ -21,8 +21,10 @@
 #include "Report.h"
 
 class ReportHost: public Report {
+ private:
+  bool m_is_user;
  public:
-  ReportHost() : Report("host", "Host information", false /*device required*/) { /*empty*/ };
+  ReportHost(bool is_user = true) : Report("host", "Host information", false /*device required*/) { /*empty*/ m_is_user = is_user;};
 
  // Child methods that need to be implemented
  public:

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -45,7 +45,7 @@ namespace po = boost::program_options;
 // Note: Please insert the reports in the order to be displayed (current alphabetical)
 static const ReportCollection fullReportCollection = {
   // Common reports
-    std::make_shared<ReportHost>(),
+    std::make_shared<ReportHost>(false),
     std::make_shared<ReportPlatform>(),
   // Native only reports
   #ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -245,7 +245,7 @@ Flasher::Flasher(unsigned int index) : mFRHeader{}
 {
     auto dev = xrt_core::get_mgmtpf_device(index);
     if(dev == nullptr) {
-        std::cout << "ERROR: Invalid card index:" << index << std::endl;
+        std::cout << "ERROR: Invalid device index:" << index << std::endl;
         return;
     }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -290,7 +290,7 @@ int XMC_Flasher::xclGetBoardInfo(std::map<char, std::vector<char>>& info)
     if ((ret = sendPkt(false)) != 0){
         if(ret == XMC_HOST_MSG_BRD_INFO_MISSING_ERR)
         {
-            std::cout << "Unable to get card info, need to upgrade firmware"
+            std::cout << "Unable to get device info, need to upgrade firmware"
                 << std::endl;
         }
         return ret;

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1105,7 +1105,7 @@ SubCmdValidate::SubCmdValidate(bool _isHidden, bool _isDepricated, bool _isPreli
     : SubCmd("validate",
              "Validates the basic shell acceleration functionality")
 {
-  const std::string longDescription = "Validates the given card by executing the platform's validate executable.";
+  const std::string longDescription = "Validates the given device by executing the platform's validate executable.";
   setLongDescription(longDescription);
   setExampleSyntax("");
   setIsHidden(_isHidden);

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 # Include the generated header files (e.g., version.h)
 include_directories(${CMAKE_BINARY_DIR}/gen)
 
-
 # ==-- x c l b i n u t i l --==================================================
 
 set(XCLBINUTIL_NAME "xclbinutil")


### PR DESCRIPTION
CRs addressed:
- CR-1091797 xbutil examine CU status gives a false negative
- CR-1091660 Xbutil examine shows bug that xbutil query does not
- CR-1091505 Modify verbiage to keep cards vs devices straight during programming
- CR-1091489 xbmgmt examine -r host is reporting in user space
- CR-1091093 xbmgmt2 programming command error references an undocumented --update switch
- CR-1091091 Please have programming operations work for all u30 devices

(cherry picked from commit 1b0abaaea0487a53be86dc3feb83df879b297f15)