### PR TITLE
Add feature toggle for vitis715 to disable temporary code

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -59,6 +59,7 @@ static axlf_section_kind kinds[] = {
   BUILD_METADATA
 };
 
+XRT_CORE_UNUSED
 static bool
 is_sw_emulation()
 {
@@ -528,7 +529,7 @@ class xclbin_full : public xclbin_impl
 
     m_uuid = uuid(m_top->m_header.uuid); 
     
-    const ::ip_layout* ip_layout = nullptr;
+    XRT_CORE_UNUSED const ::ip_layout* ip_layout = nullptr;
 
     for (auto kind : kinds) {
       auto hdr = xrt_core::xclbin::get_axlf_section(m_top, kind);
@@ -536,7 +537,7 @@ class xclbin_full : public xclbin_impl
       // software emulation xclbin does not have all sections
       // create the necessary ones.  important that ip_layout is
       // before connectivity which needs ip_layout
-      if (!hdr && is_sw_emulation()) {
+      if (!hdr && is_sw_emulation() && !xrt_core::config::get_feature_toggle("Runtime.vitis715")) {
         auto data = xrt_core::xclbin::swemu::get_axlf_section(m_top, ip_layout, kind);
         if (!data.empty()) {
           auto pos = m_axlf_sections.emplace(kind, std::move(data));


### PR DESCRIPTION
Vitis-715 is supposed render code added in #4588 obsolete
To disable the obsolete code, use

Runtime.vitis715=true

in either xrt.ini or from command line via env var.