### PR TITLE
Revert regression in #4974

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -132,8 +132,15 @@ load_xclbin(const uuid& xclbin_id)
     throw error(ENODEV, "no cached xclbin data");
 
   const axlf* top = reinterpret_cast<axlf *>(xclbin_full.data());
-  load_axlf_meta(m_xclbin.get_axlf());
-  m_xclbin = xrt::xclbin{top};
+  try {
+    // set before register_axlf is called via load_axlf_meta
+    m_xclbin = xrt::xclbin{top};  
+    load_axlf_meta(m_xclbin.get_axlf());
+  }
+  catch (const std::exception&) {
+    m_xclbin = {};
+    throw;
+  }
 #else
   throw error(ENOTSUP, "load xclbin by uuid is not supported");
 #endif


### PR DESCRIPTION
Loading an xclbin from a uuid was incorrectly modified in #4974.  This
PR restores original behavior.