### PR TITLE
xbutil2: fix ps kernel name n instance number

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -78,6 +78,7 @@ enum class key_type
   kds_mode,
   kds_cu_stat,
   kds_scu_stat,
+  ps_kernel,
   xclbin_full,
 
   xmc_version,
@@ -695,6 +696,15 @@ struct kds_cu_stat : request
   using result_type = std::vector<struct data>;
   using data_type = struct data;
   static const key_type key = key_type::kds_cu_stat;
+
+  virtual boost::any
+  get(const device*) const = 0;
+};
+
+struct ps_kernel : request
+{
+  using result_type = std::vector<char>;
+  static const key_type key = key_type::ps_kernel;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -558,6 +558,7 @@ initialize_query_table()
   emplace_sysfs_get<query::kds_mode>                         ("", "kds_mode");
   emplace_func0_request<query::kds_cu_stat,                  kds_cu_stat>();
   emplace_func0_request<query::kds_scu_stat,                 kds_scu_stat>();
+  emplace_sysfs_get<query::ps_kernel>                        ("icap", "ps_kernel");
 
   emplace_func0_request<query::pcie_bdf,                     bdf>();
   emplace_func0_request<query::kds_cu_info,                  kds_cu_info>();

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -135,8 +135,6 @@ populate_cus(const xrt_core::device *device)
 int 
 getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
 {
-  std::string errmsg;
-
   std::vector<char> buf = xrt_core::device_query<xrt_core::query::ps_kernel>(device);
   const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
   if(map->pkn_count < 0)

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -21,7 +21,6 @@
 #include "core/common/query_requests.h"
 #include "core/common/device.h"
 #include "core/common/utils.h"
-#include "core/pcie/linux/scan.h"
 #include "ps_kernel.h"
 
 namespace qr = xrt_core::query;
@@ -137,16 +136,8 @@ int
 getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
 {
     std::string errmsg;
-    std::vector<char> buf;
 
-    pcidev::get_dev(device->get_device_id())->sysfs_get("icap", "ps_kernel", errmsg, buf);
-    if (!errmsg.empty()) {
-        std::cout << errmsg << std::endl;
-        return -EINVAL;
-    }
-    if (buf.empty())
-        return 0;
-
+    std::vector<char> buf = xrt_core::device_query<xrt_core::query::ps_kernel>(device);
     const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
     if(map->pkn_count < 0)
         return -EINVAL;

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -21,6 +21,8 @@
 #include "core/common/query_requests.h"
 #include "core/common/device.h"
 #include "core/common/utils.h"
+#include "core/pcie/linux/scan.h"
+#include "ps_kernel.h"
 
 namespace qr = xrt_core::query;
 
@@ -131,6 +133,30 @@ populate_cus(const xrt_core::device *device)
   return pt;
 }
 
+int 
+getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
+{
+    std::string errmsg;
+    std::vector<char> buf;
+
+    pcidev::get_dev(device->get_device_id())->sysfs_get("icap", "ps_kernel", errmsg, buf);
+    if (!errmsg.empty()) {
+        std::cout << errmsg << std::endl;
+        return -EINVAL;
+    }
+    if (buf.empty())
+        return 0;
+
+    const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
+    if(map->pkn_count < 0)
+        return -EINVAL;
+
+    for (unsigned int i = 0; i < map->pkn_count; i++)
+        psKernels.emplace_back(map->pkn_data[i]);
+
+    return 0;
+}
+
 boost::property_tree::ptree
 populate_cus_new(const xrt_core::device *device)
 {
@@ -160,15 +186,24 @@ populate_cus_new(const xrt_core::device *device)
     pt.push_back(std::make_pair("", ptCu));
   }
 
+  std::vector<ps_kernel_data> psKernels;
+  if (getPSKernels(psKernels, device) < 0) {
+      std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
+      return pt;
+  }
+
+  uint32_t psk_inst = 0;
+  uint32_t num_scu = 0;
   boost::property_tree::ptree pscu_list;
   for (auto& stat : scu_stats) {
     boost::property_tree::ptree ptCu;
-    std::string scu_name = stat.name;
-    auto found = scu_name.rfind("scu");
-    if (found > 0) {
-        std::string scu_i = scu_name.substr(found + 3);
-        scu_name = scu_name.substr(0, found - 1);
-        scu_name.append(scu_i);
+    std::string scu_name = "Illegal";
+    if (psk_inst >= psKernels.size()) {
+      scu_name = stat.name; //This means something is wrong
+    } else {
+      scu_name = psKernels.at(psk_inst).pkd_sym_name;
+      scu_name.append("_");
+      scu_name.append(std::to_string(num_scu));
     }
     ptCu.put( "name",           scu_name);
     ptCu.put( "base_address",   "0x0");
@@ -176,6 +211,15 @@ populate_cus_new(const xrt_core::device *device)
     ptCu.put( "type", enum_to_str(cu_type::PS));
     ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
     pt.push_back(std::make_pair("", ptCu));
+
+    if (psk_inst >= psKernels.size()) {
+      continue;
+    }
+    num_scu++;
+    if (num_scu == psKernels.at(psk_inst).pkd_num_instances) {
+        num_scu = 0;
+        psk_inst++;
+    }
   }
 
   return pt;

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -135,17 +135,17 @@ populate_cus(const xrt_core::device *device)
 int 
 getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
 {
-    std::string errmsg;
+  std::string errmsg;
 
-    std::vector<char> buf = xrt_core::device_query<xrt_core::query::ps_kernel>(device);
-    const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
-    if(map->pkn_count < 0)
-        return -EINVAL;
+  std::vector<char> buf = xrt_core::device_query<xrt_core::query::ps_kernel>(device);
+  const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
+  if(map->pkn_count < 0)
+    return -EINVAL;
 
-    for (unsigned int i = 0; i < map->pkn_count; i++)
-        psKernels.emplace_back(map->pkn_data[i]);
+  for (unsigned int i = 0; i < map->pkn_count; i++)
+    psKernels.emplace_back(map->pkn_data[i]);
 
-    return 0;
+  return 0;
 }
 
 boost::property_tree::ptree
@@ -179,8 +179,8 @@ populate_cus_new(const xrt_core::device *device)
 
   std::vector<ps_kernel_data> psKernels;
   if (getPSKernels(psKernels, device) < 0) {
-      std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
-      return pt;
+    std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
+    return pt;
   }
 
   uint32_t psk_inst = 0;
@@ -190,11 +190,14 @@ populate_cus_new(const xrt_core::device *device)
     boost::property_tree::ptree ptCu;
     std::string scu_name = "Illegal";
     if (psk_inst >= psKernels.size()) {
-      scu_name = stat.name; //This means something is wrong
+      scu_name = stat.name; 
+      //This means something is wrong
+      //scu_name e.g. kernel_vcu_encoder:scu_34
     } else {
       scu_name = psKernels.at(psk_inst).pkd_sym_name;
       scu_name.append("_");
       scu_name.append(std::to_string(num_scu));
+      //scu_name e.g. kernel_vcu_encoder_2
     }
     ptCu.put( "name",           scu_name);
     ptCu.put( "base_address",   "0x0");
@@ -208,8 +211,9 @@ populate_cus_new(const xrt_core::device *device)
     }
     num_scu++;
     if (num_scu == psKernels.at(psk_inst).pkd_num_instances) {
-        num_scu = 0;
-        psk_inst++;
+      //Handled all instances of a PS Kernel, so next is a new PS Kernel
+      num_scu = 0;
+      psk_inst++;
     }
   }
 


### PR DESCRIPTION
After changes:
...
30      kernel_vcu_decoder_30         0x0             0       (IDLE)
31      kernel_vcu_decoder_31         0x0             0       (IDLE)
32      kernel_vcu_encoder_0          0x0             0       (IDLE)
33      kernel_vcu_encoder_1          0x0             0       (IDLE)

Earlier to changes:
...
30      kernel_vcu_decoder_30     0x0             0       (IDLE)
31      kernel_vcu_decoder_31     0x0             0       (IDLE)
32      kernel_vcu_encoder_32     0x0             0       (IDLE)
33      kernel_vcu_encoder_33     0x0             0       (IDLE)
....