### PR TITLE
CR-1091338: Kernel reads/writes with no end event in trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -134,6 +134,20 @@ namespace xdp {
     return startEvent;
   }
 
+  bool VPDynamicDatabase::hasMatchingDeviceEventStart(uint64_t traceID,
+                                                      VTFEventType type)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+    if (deviceEventStartMap.find(traceID) == deviceEventStartMap.end())
+      return false ;
+    auto& lst = deviceEventStartMap[traceID] ;
+    for (auto e: lst) {
+      if (e->getEventType() == type)
+        return true ;
+    }
+    return false ;
+  }
+
   void VPDynamicDatabase::markStart(uint64_t functionID, uint64_t eventID)
   {
     std::lock_guard<std::mutex> lock(hostLock) ;

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -166,6 +166,7 @@ namespace xdp {
     // For Device Events, find matching start for end event
     XDP_EXPORT void markDeviceEventStart(uint64_t slotID, VTFEvent* event);
     XDP_EXPORT VTFEvent* matchingDeviceEventStart(uint64_t slotID, VTFEventType type);
+    XDP_EXPORT bool hasMatchingDeviceEventStart(uint64_t traceID, VTFEventType type);
 
     // A lookup into the string table
     XDP_EXPORT uint64_t addString(const std::string& value) ;

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -79,6 +79,20 @@ namespace xdp {
     double halfCycleTimeInMs = (0.5/traceClockRateMHz)/1000.0;
 
     if (trace.EventType == XCL_PERF_MON_START_EVENT) {
+      // If we see two starts in a row of the same type on the same slot,
+      //  then we must have dropped an end packet.  Add a dummy end packet
+      //  here.
+      if (db->getDynamicInfo().hasMatchingDeviceEventStart(trace.TraceID, ty)){
+        VTFEvent* matchingStart =
+          db->getDynamicInfo().matchingDeviceEventStart(trace.TraceID, ty);
+        memEvent =
+          new DeviceMemoryAccess(matchingStart->getEventId(),
+                                 hostTimestamp - halfCycleTimeInMs,
+                                 ty, deviceId, slot, cuId);
+        memEvent->setDeviceTimestamp(trace.Timestamp);
+        db->getDynamicInfo().addEvent(memEvent);
+      }
+
       memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, deviceId, slot, cuId) ;
       memEvent->setDeviceTimestamp(trace.Timestamp) ;
       db->getDynamicInfo().addEvent(memEvent) ;
@@ -316,7 +330,7 @@ namespace xdp {
     }
   }
 
-  void DeviceEventCreatorFromTrace::end()
+  void DeviceEventCreatorFromTrace::addApproximateCUEndEvents()
   {
     for(uint32_t amIndex = 0; amIndex < cuStarts.size(); ++amIndex) {
       if(cuStarts[amIndex].empty()) {
@@ -384,7 +398,86 @@ namespace xdp {
       event->setDeviceTimestamp(cuLastTimestamp);
       db->getDynamicInfo().addEvent(event); 
     }
+  }
 
+  void DeviceEventCreatorFromTrace::addApproximateDataTransferEvent(VTFEventType type, uint64_t aimTraceID, int32_t amId, int32_t cuId)
+  {
+    VTFEvent* startEvent =
+      db->getDynamicInfo().matchingDeviceEventStart(aimTraceID, type);
+    if (!startEvent)
+      return ;
+
+    uint64_t transStartTimestamp = 0 ;
+    uint64_t transApproxEndTimestamp = 0 ;
+    uint64_t transApproxEndHostTimestamp = 0 ;
+
+    VTFDeviceEvent* deviceStartEvent=dynamic_cast<VTFDeviceEvent*>(startEvent);
+    if (!deviceStartEvent)
+      return ;
+
+    const double halfCycleTimeInMs = (0.5/traceClockRateMHz)/1000.0;
+
+    transStartTimestamp = deviceStartEvent->getDeviceTimestamp();
+    if (amId == -1) {
+      // This is a floating AIM monitor not attached to any particular CU.
+      transApproxEndTimestamp = transStartTimestamp ;
+      transApproxEndHostTimestamp = convertDeviceToHostTimestamp(transStartTimestamp) + halfCycleTimeInMs ;
+    }
+    else {
+      // Check the last known transaction on the CU to approximate the end
+      uint64_t cuLastTimestamp  = amLastTrans[amId];
+      if (transStartTimestamp < cuLastTimestamp) {
+        transApproxEndTimestamp = cuLastTimestamp ;
+        transApproxEndHostTimestamp = convertDeviceToHostTimestamp(cuLastTimestamp);
+      }
+      else {
+        transApproxEndTimestamp = transStartTimestamp ;
+        transApproxEndHostTimestamp = convertDeviceToHostTimestamp(transStartTimestamp) + halfCycleTimeInMs ;
+      }
+    }
+    // Add approximate end event
+    DeviceMemoryAccess* endEvent =
+      new DeviceMemoryAccess(startEvent->getEventId(),
+                             transApproxEndHostTimestamp,
+                             type,
+                             deviceId,
+                             amId,
+                             cuId);
+    endEvent->setDeviceTimestamp(transApproxEndTimestamp);
+    db->getDynamicInfo().addEvent(endEvent);
+  }
+
+  void DeviceEventCreatorFromTrace::addApproximateDataTransferEvents()
+  {
+    // Go through all of our AIMs.  If any of them have any outstanding
+    //  reads or writes, then finish them based on the last CU execution time.
+    for (uint64_t aimIndex = 0 ;
+         aimIndex < (db->getStaticInfo()).getNumAIM(deviceId, xclbin) ;
+         ++aimIndex) {
+
+      uint64_t aimTraceID = aimIndex + MIN_TRACE_ID_AIM ;
+      Monitor* mon =
+        db->getStaticInfo().getAIMonitor(deviceId, xclbin, aimIndex);
+      if (!mon)
+        continue;
+
+      int32_t cuId = mon->cuIndex ;
+      if (cuId == -1)
+        continue ;
+      int32_t amId = -1 ;
+
+      ComputeUnitInstance* cu = db->getStaticInfo().getCU(deviceId, cuId);
+      if (cu) {
+        amId = cu->getAccelMon();
+      }
+
+      addApproximateDataTransferEvent(KERNEL_READ, aimTraceID, amId, cuId) ;
+      addApproximateDataTransferEvent(KERNEL_WRITE, aimTraceID, amId, cuId) ;
+    }
+  }
+
+  void DeviceEventCreatorFromTrace::addApproximateStreamEndEvents()
+  {
     // Find unfinished ASM events
     bool unfinishedASMevents = false;
     for(uint64_t asmIndex = 0; asmIndex < (db->getStaticInfo()).getNumASM(deviceId, xclbin); ++asmIndex) {
@@ -422,6 +515,13 @@ namespace xdp {
       const char* msg = "Found unfinished events on Stream connections. Adding approximate ends for Stream Activity/Stall/Starve on timeline trace.";
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg) ;
     }
+  }
+
+  void DeviceEventCreatorFromTrace::end()
+  {
+    addApproximateCUEndEvents();
+    addApproximateDataTransferEvents();
+    addApproximateStreamEndEvents();
   }
 
   void DeviceEventCreatorFromTrace::addApproximateStreamEndEvent(uint64_t asmIndex, uint64_t asmTraceID, VTFEventType streamEventType, 

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -91,6 +91,7 @@ namespace xdp {
                                  ty, deviceId, slot, cuId);
         memEvent->setDeviceTimestamp(trace.Timestamp);
         db->getDynamicInfo().addEvent(memEvent);
+        aimLastTrans[slot] = trace.Timestamp;
       }
 
       memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, deviceId, slot, cuId) ;

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -462,13 +462,13 @@ namespace xdp {
         continue;
 
       int32_t cuId = mon->cuIndex ;
-      if (cuId == -1)
-        continue ;
       int32_t amId = -1 ;
 
-      ComputeUnitInstance* cu = db->getStaticInfo().getCU(deviceId, cuId);
-      if (cu) {
-        amId = cu->getAccelMon();
+      if (cuId != -1) {
+        ComputeUnitInstance* cu = db->getStaticInfo().getCU(deviceId, cuId);
+        if (cu) {
+          amId = cu->getAccelMon();
+        }
       }
 
       addApproximateDataTransferEvent(KERNEL_READ, aimTraceID, amId, cuId) ;

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
@@ -62,6 +62,11 @@ class DeviceEventCreatorFromTrace
 
   void addKernelDataTransferEvent(VTFEventType ty, xclTraceResults& trace, uint32_t slot, int32_t cuId, double hostTimestamp) ;
 
+  void addApproximateCUEndEvents();
+  void addApproximateDataTransferEvents();
+  void addApproximateStreamEndEvents();
+
+  void addApproximateDataTransferEvent(VTFEventType type, uint64_t aimTraceID, int32_t amId, int32_t cuId);
   void addApproximateStreamEndEvent(uint64_t asmIndex, uint64_t asmTraceID, VTFEventType streamEventType,
                                     int32_t cuId, int32_t  amId, uint64_t cuLastTimestamp,
                                     uint64_t &asmAppxLastTransTimeStamp, bool &unfinishedASMevents);


### PR DESCRIPTION
This pull request approximates the end of device data transfer events in trace in two ways:
- When two starts of the same type on an AIM are detected with no end event in between, we assume a dropped end packet and approximate the end of the previous transaction at that point
- If there are any reads or writes that do not have end events at the end of execution, we assume a dropped end packet and approximate the end of the transaction at the end of the CU execution
