### PR TITLE
CR-1093211: Incorrect trace buffer summary guidance rule in OpenCL summary

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -128,7 +128,7 @@ namespace xdp {
 
   VPStaticDatabase::VPStaticDatabase(VPDatabase* d) :
     db(d), runSummary(nullptr), systemDiagram(""),
-    softwareEmulationDeviceName("")
+    traceBufferSize(""), softwareEmulationDeviceName("")
   {
 #ifdef _WIN32
     pid = _getpid() ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -479,6 +479,7 @@ namespace xdp {
     std::set<uint64_t> commandQueueAddresses ;
     std::set<std::string> enqueuedKernels ; 
     std::map<uint64_t, uint64_t> contextIdToNumDevices ;
+    std::string traceBufferSize ;
 
     // For OpenCL software emulation, we need a tiny bit of device info
     std::string softwareEmulationDeviceName ; 
@@ -520,6 +521,9 @@ namespace xdp {
     inline uint64_t getApplicationStartTime() { return applicationStartTime ; }
     inline void setApplicationStartTime(uint64_t t)
       { applicationStartTime = t ; }
+    inline std::string getTraceBufferSize() { return traceBufferSize ; }
+    inline void setTraceBufferSize(const std::string& size)
+      { traceBufferSize = size ; }
     inline std::vector<std::pair<std::string, std::string>>& getOpenedFiles() 
       { return openedFiles ; }
     inline std::string getSystemDiagram() { return systemDiagram ; }

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -480,6 +480,9 @@ namespace xdp {
     std::set<std::string> enqueuedKernels ; 
     std::map<uint64_t, uint64_t> contextIdToNumDevices ;
     std::string traceBufferSize ;
+    uint64_t traceBufferBytes ;
+    std::string aieTraceBufferSize ;
+    uint64_t aieTraceBufferBytes ;
 
     // For OpenCL software emulation, we need a tiny bit of device info
     std::string softwareEmulationDeviceName ; 
@@ -509,6 +512,8 @@ namespace xdp {
     bool initializeComputeUnits(XclbinInfo*, const std::shared_ptr<xrt_core::device>&);
     bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
 
+    void parseTraceBufferOption(bool isAIETrace, bool throwWarnings);
+
   public:
     VPStaticDatabase(VPDatabase* d) ;
     ~VPStaticDatabase() ;
@@ -521,9 +526,10 @@ namespace xdp {
     inline uint64_t getApplicationStartTime() { return applicationStartTime ; }
     inline void setApplicationStartTime(uint64_t t)
       { applicationStartTime = t ; }
-    inline std::string getTraceBufferSize() { return traceBufferSize ; }
     inline void setTraceBufferSize(const std::string& size)
       { traceBufferSize = size ; }
+    XDP_EXPORT std::string getTraceBufferSize(bool isAIETrace, bool throwWarnings);
+    XDP_EXPORT uint64_t getTraceBufferBytes(bool isAIETrace, bool throwWarnings);
     inline std::vector<std::pair<std::string, std::string>>& getOpenedFiles() 
       { return openedFiles ; }
     inline std::string getSystemDiagram() { return systemDiagram ; }

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -47,7 +47,6 @@
 #include "tracedefs.h"
 #include "core/common/message.h"
 #include "core/common/system.h"
-#include "xdp/profile/database/database.h"
 
 #include <iostream>
 #include <cstdio>
@@ -96,54 +95,6 @@ uint32_t GetDeviceTraceBufferSize(uint32_t property)
     default : break;
   }
   return 8192;
-}
-
-// Get the user-specified trace buffer size by parsing
-// settings from xrt.ini
-uint64_t GetTS2MMBufSize(bool isAIETrace, VPDatabase* db)
-{
-  std::string size_str = isAIETrace ?
-                         xrt_core::config::get_aie_trace_buffer_size() :
-                         xrt_core::config::get_trace_buffer_size();
-  std::smatch pieces_match;
-  
-  if (db && !isAIETrace) db->getStaticInfo().setTraceBufferSize(size_str);
-
-  // Default is 1M
-  uint64_t bytes = TS2MM_DEF_BUF_SIZE;
-  // Regex can parse values like : "1024M" "1G" "8192k"
-  const std::regex size_regex("\\s*([0-9]+)\\s*(K|k|M|m|G|g|)\\s*");
-  if (std::regex_match(size_str, pieces_match, size_regex)) {
-    try {
-      if (pieces_match[2] == "K" || pieces_match[2] == "k") {
-        bytes = std::stoull(pieces_match[1]) * 1024;
-      } else if (pieces_match[2] == "M" || pieces_match[2] == "m") {
-        bytes = std::stoull(pieces_match[1]) * 1024 * 1024;
-      } else if (pieces_match[2] == "G" || pieces_match[2] == "g") {
-        bytes = std::stoull(pieces_match[1]) * 1024 * 1024 * 1024;
-      } else {
-        bytes = std::stoull(pieces_match[1]);
-      }
-    } catch (const std::exception& ) {
-      // User specified number cannot be parsed
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BUFSIZE_DEF);
-      if (db && !isAIETrace) db->getStaticInfo().setTraceBufferSize("1M");
-    }
-  } else {
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BUFSIZE_DEF);
-    if (db && !isAIETrace) db->getStaticInfo().setTraceBufferSize("1M");
-  }
-  if (bytes > TS2MM_MAX_BUF_SIZE) {
-    bytes = TS2MM_MAX_BUF_SIZE;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BUFSIZE_BIG);
-    if (db && !isAIETrace) db->getStaticInfo().setTraceBufferSize("4095M");
-  }
-  if (bytes < TS2MM_MIN_BUF_SIZE) {
-    bytes = TS2MM_MIN_BUF_SIZE;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BUFSIZE_SMALL);
-    if (db && !isAIETrace) db->getStaticInfo().setTraceBufferSize("8K");
-  }
-  return bytes;
 }
 
 // Destructor

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -44,13 +44,16 @@
 
 namespace xdp {
 
+// Forward declarations
+class VPDatabase;
+
 // Helper methods
 
 XDP_EXPORT
 uint32_t GetDeviceTraceBufferSize(uint32_t property);
 
 XDP_EXPORT
-uint64_t GetTS2MMBufSize(bool isAIETrace = false);
+uint64_t GetTS2MMBufSize(bool isAIETrace = false, VPDatabase* db = nullptr);
 
 
 class DeviceIntf {

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -52,10 +52,6 @@ class VPDatabase;
 XDP_EXPORT
 uint32_t GetDeviceTraceBufferSize(uint32_t property);
 
-XDP_EXPORT
-uint64_t GetTS2MMBufSize(bool isAIETrace = false, VPDatabase* db = nullptr);
-
-
 class DeviceIntf {
   public:
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -152,7 +152,7 @@ namespace xdp {
     }
 
     // Create AIE Trace Offloader
-    uint64_t aieTraceBufSz = GetTS2MMBufSize(true /*isAIETrace*/);
+    uint64_t aieTraceBufSz = db->getStaticInfo().getTraceBufferBytes(true, true);
     bool     isPLIO = ((db->getStaticInfo()).getNumTracePLIO(deviceId)) ? true : false;
 
 #if 0

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -177,7 +177,7 @@ namespace xdp {
 
     // If offload via memory is requested, make sure the size requested
     //  fits inside the chosen memory resource.
-    uint64_t trace_buffer_size = GetTS2MMBufSize() ;
+    uint64_t trace_buffer_size = GetTS2MMBufSize(false, db) ;
     if (devInterface->hasTs2mm()) {
       Memory* memory = (db->getStaticInfo()).getMemory(deviceId, devInterface->getTS2MmMemIndex());
       if(nullptr == memory) {

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -177,7 +177,7 @@ namespace xdp {
 
     // If offload via memory is requested, make sure the size requested
     //  fits inside the chosen memory resource.
-    uint64_t trace_buffer_size = GetTS2MMBufSize(false, db) ;
+    uint64_t trace_buffer_size = db->getStaticInfo().getTraceBufferBytes(false, true);
     if (devInterface->hasTs2mm()) {
       Memory* memory = (db->getStaticInfo()).getMemory(deviceId, devInterface->getTS2MmMemIndex());
       if(nullptr == memory) {

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -24,14 +24,12 @@
 #include <tuple>
 #include <limits>
 #include <sstream>
-#include <regex>
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/statistics_database.h"
 #include "xdp/profile/database/static_info_database.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
 #include "xdp/profile/writer/opencl/opencl_summary_writer.h"
-#include "xdp/profile/device/tracedefs.h"
 
 #include "core/common/system.h"
 #include "core/common/time.h"
@@ -41,47 +39,6 @@
 /* Disable warning for use of localtime */
 #pragma warning(disable : 4996)
 #endif
-
-// Anonymous namespace for helper functions
-namespace {
-  // In the case where the user has not done device offload, but still
-  //  has an xrt.ini value set for trace_buffer_size, perform the same
-  //  parsing as in device_intf.cpp 
-  std::string parseTraceBufferSize() {
-
-    std::string size = xrt_core::config::get_trace_buffer_size() ;
-    std::smatch pieces_match ;
-    const std::regex size_regex("\\s*([0-9]+)\\s*(K|k|M|m|G|g|)\\s*");
-
-    uint64_t bytes = TS2MM_DEF_BUF_SIZE;
-    if (std::regex_match(size, pieces_match, size_regex)) {
-      try {
-        if (pieces_match[2] == "K" || pieces_match[2] == "k") {
-          bytes = std::stoull(pieces_match[1]) * 1024;
-        } else if (pieces_match[2] == "M" || pieces_match[2] == "m") {
-          bytes = std::stoull(pieces_match[1]) * 1024 * 1024;
-        } else if (pieces_match[2] == "G" || pieces_match[2] == "g") {
-          bytes = std::stoull(pieces_match[1]) * 1024 * 1024 * 1024;
-        } else {
-          bytes = std::stoull(pieces_match[1]);
-        }
-      } catch (const std::exception& ) {
-        // User specified number cannot be parsed
-        return "1M" ;
-      }
-    }
-    else {
-      return "1M" ;
-    }
-    if (bytes > TS2MM_MAX_BUF_SIZE) {
-      return "4095M" ;
-    }
-    if (bytes < TS2MM_MIN_BUF_SIZE) {
-      return "8K" ;
-    }
-    return size ;
-  }
-}
 
 namespace xdp {
 
@@ -187,12 +144,7 @@ namespace xdp {
     {
       std::stringstream setting ;
       setting << "XRT_INI_SETTING,trace_buffer_size," ;
-      std::string size = db->getStaticInfo().getTraceBufferSize() ;
-      if (size == "") {
-	// We'll have to parse it ourselves and see what the value would 
-        //  have been, but we shouldn't throw any warnings.
-        size = parseTraceBufferSize();
-      }
+      std::string size = db->getStaticInfo().getTraceBufferSize(false, false) ;
       setting << size ;
       iniSettings.push_back(setting.str()) ;
     }
@@ -234,8 +186,9 @@ namespace xdp {
     }
     {
       std::stringstream setting ;
-      setting << "XRT_INI_SETTING,aie_trace_buffer_size,"
-	      << xrt_core::config::get_aie_trace_buffer_size() ;
+      setting << "XRT_INI_SETTING,aie_trace_buffer_size,";
+      std::string size = db->getStaticInfo().getTraceBufferSize(true, false) ;
+      setting << size ;
       iniSettings.push_back(setting.str()) ;
     }
     {


### PR DESCRIPTION
Changing the INI setting guidance rule in the OpenCL summary for trace buffer size.  If the user inputs in incorrect value in the xrt.ini file we should show the value we use instead of the original string.