### PR TITLE
CR-1093062 Typo in dmesg command instructions

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock.c
@@ -1177,7 +1177,7 @@ static int clock_status_check(struct platform_device *pdev, bool *latched)
 		if (ucs_status_ch1->shutdown_clocks_latched) {
 			CLOCK_ERR(clock, "Critical temperature or power event, "
 			    "kernel clocks have been stopped, run "
-			    "'xbutil valiate -q' to continue. "
+			    "'xbutil validate -q' to continue. "
 			    "See AR 73398 for more details.");
 			/* explicitly indicate reset should be latched */
 			*latched = true;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4495,7 +4495,7 @@ static void clock_status_check(struct platform_device *pdev, bool *latched)
 		if (status & 0x1) {
 			xocl_err(&pdev->dev, "Critical temperature event, "
 					"kernel clocks have been stopped, run "
-					"'xbutil valiate -q' to continue. "
+					"'xbutil validate -q' to continue. "
 					"See AR 73398 for more details.");
 			/* explicitly indicate reset should be latched */
 			*latched = true;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -4151,7 +4151,7 @@ static void clock_status_check(struct platform_device *pdev, bool *latched)
 		if (status & 0x1) {
 			xocl_err(&pdev->dev, "Critical temperature event, "
 					"kernel clocks have been stopped, run "
-					"'xbutil valiate -q' to continue. "
+					"'xbutil validate -q' to continue. "
 					"See AR 73398 for more details.");
 			/* explicitly indicate reset should be latched */
 			*latched = true;


### PR DESCRIPTION
This  is a typo fix. It has been fixed in 3 files.