### PR TITLE
Fixed issue for new KDS with 32bit zynq

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -948,10 +948,15 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	zdev->zdev_xclbin->zx_refcnt = 0;
 	zocl_xclbin_set_uuid(zdev, &axlf_head.m_header.uuid);
 
-out0:
 	vfree(aie_res);
 	vfree(axlf);
 	DRM_INFO("%s %pUb ret: %d", __func__, zocl_xclbin_get_uuid(zdev), ret);
+	return ret;
+
+out0:
+	write_unlock(&zdev->attr_rwlock);
+	vfree(aie_res);
+	vfree(axlf);
 	return ret;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -942,7 +942,7 @@ out0:
 	write_unlock(&zdev->attr_rwlock);
 	/* out of the atomic context */ 
 
-	/* Creating kernel thread, hence need to call this outside of the atomic context */
+	/* Invoking kernel thread (kthread), hence need to call this outside of the atomic context */
 	if (!ret && kds_mode == 1) {
 		subdev_destroy_cu(zdev);
 		ret = zocl_create_cu(zdev);
@@ -956,6 +956,7 @@ out0:
 out1:
 	vfree(aie_res);
 	vfree(axlf);
+	DRM_INFO("%s %pUb ret: %d", __func__, zocl_xclbin_get_uuid(zdev), ret);
 	return ret;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -722,6 +722,8 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 		vfree(axlf);
 		return -EFAULT;
 	}
+
+	/* After this lock till unlock is an atomic context */ 
 	write_lock(&zdev->attr_rwlock);
 
 	/*
@@ -924,18 +926,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 		goto out0;
 	}
 
-	write_unlock(&zdev->attr_rwlock);
-
-	if (kds_mode == 1) {
-		subdev_destroy_cu(zdev);
-		ret = zocl_create_cu(zdev);
-		if (ret)
-			goto out0;
-		ret = zocl_kds_update(zdev);
-		if (ret)
-			goto out0;
-	}
-
 	zocl_clear_mem(zdev);
 	zocl_init_mem(zdev, zdev->topology);
 
@@ -948,13 +938,22 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	zdev->zdev_xclbin->zx_refcnt = 0;
 	zocl_xclbin_set_uuid(zdev, &axlf_head.m_header.uuid);
 
-	vfree(aie_res);
-	vfree(axlf);
-	DRM_INFO("%s %pUb ret: %d", __func__, zocl_xclbin_get_uuid(zdev), ret);
-	return ret;
-
 out0:
 	write_unlock(&zdev->attr_rwlock);
+	/* out of the atomic context */ 
+
+	/* Creating kernel thread, hence need to call this outside of the atomic context */
+	if (!ret && kds_mode == 1) {
+		subdev_destroy_cu(zdev);
+		ret = zocl_create_cu(zdev);
+		if (ret)
+			goto out1;
+		ret = zocl_kds_update(zdev);
+		if (ret)
+			goto out1;
+	}
+
+out1:
 	vfree(aie_res);
 	vfree(axlf);
 	return ret;


### PR DESCRIPTION
-- For 32bit Zynq new KDS is crashing.
-- On new kds mode we are creating a kernel thread of xrt_cu_polling_thread inside zocl_create_cu(zdev) function under a write lock write_lock(&zdev->attr_rwlock). Which is causing the issue.
-- Fixed this issue by moving zocl_create_cu(zdev) outside the write lock