### PR TITLE
CR-1091638 KDS no longer supports ERT_EXEC_WRITE

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -83,8 +83,21 @@ static void cu_hls_configure(void *core, u32 *data, size_t sz, int type)
 		return;
 
 	num_reg = sz / sizeof(u32);
-	for (i = 0; i < num_reg; ++i)
-		cu_write32(cu_hls, ARGS + i * 4, data[i]);
+	switch (type) {
+	case REGMAP:
+		/* Write register map, starting at base_addr + 0x10 (byte) */
+		for (i = 0; i < num_reg; ++i)
+			cu_write32(cu_hls, ARGS + i * 4, data[i]);
+		break;
+	case KEY_VAL:
+		/* Use {offset, value} pairs to configure CU
+		 * data[i]: register offset
+		 * data[i + 1]: value
+		 */
+		for (i = 0; i < num_reg; i += 2)
+			cu_write32(cu_hls, data[i], data[i + 1]);
+		break;
+	}
 }
 
 static void cu_hls_start(void *core)

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -95,6 +95,8 @@ void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 		   struct kds_command *xcmd);
 void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			  struct kds_command *xcmd);
+void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
+			  struct kds_command *xcmd);
 void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			struct kds_command *xcmd);
 int cu_mask_to_cu_idx(struct kds_command *xcmd, uint8_t *cus);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1117,6 +1117,30 @@ void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	 */
 	xcmd->isize = (ecmd->count - xcmd->num_mask - 4) * sizeof(u32);
 	memcpy(xcmd->info, &ecmd->data[4 + ecmd->extra_cu_masks], xcmd->isize);
+	xcmd->payload_type = REGMAP;
+	ecmd->type = ERT_CU;
+}
+
+void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
+			  struct kds_command *xcmd)
+{
+	xcmd->opcode = OP_START;
+
+	xcmd->execbuf = (u32 *)ecmd;
+
+	xcmd->cu_mask[0] = ecmd->cu_mask;
+	memcpy(&xcmd->cu_mask[1], ecmd->data, ecmd->extra_cu_masks);
+	xcmd->num_mask = 1 + ecmd->extra_cu_masks;
+
+	/* Copy resigter map into info and isize is the size of info in bytes.
+	 *
+	 * Based on ert.h, ecmd->count is the number of words following header.
+	 * In ert_start_kernel_cmd, the CU register map size is
+	 * (count - (1 + extra_cu_masks)) and skip 6 words for exec_write cmd.
+	 */
+	xcmd->isize = (ecmd->count - xcmd->num_mask - 6) * sizeof(u32);
+	memcpy(xcmd->info, &ecmd->data[6 + ecmd->extra_cu_masks], xcmd->isize);
+	xcmd->payload_type = KEY_VAL;
 	ecmd->type = ERT_CU;
 }
 

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -210,7 +210,7 @@ static inline int process_rq(struct xrt_cu *xcu)
 		return 0;
 
 	/* if successfully get credit, you must start cu */
-	xrt_cu_config(xcu, (u32 *)xcmd->info, xcmd->isize, 0);
+	xrt_cu_config(xcu, (u32 *)xcmd->info, xcmd->isize, xcmd->payload_type);
 	xrt_cu_start(xcu);
 
 	dst_q = &xcu->sq;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -334,6 +334,8 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		cfg_ecmd2xcmd(to_cfg_pkg(ecmd), xcmd);
 	else if (ecmd->opcode == ERT_START_CU)
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+	else if (ecmd->opcode == ERT_EXEC_WRITE)
+		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 	else if (ecmd->opcode == ERT_START_FA)
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 	xcmd->cb.notify_host = notify_execbuf;

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -738,10 +738,14 @@ ert_valid_opcode(struct ert_packet *pkt)
 
   switch (pkt->opcode) {
   case ERT_START_CU:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 cu mask + 4 registers */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 4);
+    break;
   case ERT_EXEC_WRITE:
     skcmd = to_start_krnl_pkg(pkt);
-    /* 1 cu mask + 4 control registers */
-    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 4);
+    /* 1 cu mask + 6 registers */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 6);
     break;
   case ERT_START_FA:
     skcmd = to_start_krnl_pkg(pkt);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -529,6 +529,9 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	case ERT_START_CU:
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
+	case ERT_EXEC_WRITE:
+		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+		break;
 	case ERT_START_FA:
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		/* ERT doesn't support Fast adapter command */


### PR DESCRIPTION
New KDS should support what old kds supported.
This change is to add exec_write command in new kds.