### PR TITLE
Profiling device trace improvements

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -427,7 +427,7 @@ namespace xdp {
 
     uint64_t transStartTimestamp = 0 ;
     uint64_t transApproxEndTimestamp = 0 ;
-    uint64_t transApproxEndHostTimestamp = 0 ;
+    double transApproxEndHostTimestamp = 0 ;
 
     VTFDeviceEvent* deviceStartEvent=dynamic_cast<VTFDeviceEvent*>(startEvent);
     if (!deviceStartEvent)

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -49,6 +49,122 @@ namespace xdp {
     asmLastTrans.resize((db->getStaticInfo()).getNumASM(deviceId, xclbin)) ;
   }
 
+  void DeviceEventCreatorFromTrace::addCUEvent(xclTraceResults& trace,
+                                               double hostTimestamp,
+                                               uint32_t s,
+                                               uint64_t monTraceID,
+                                               int32_t cuId)
+  {
+    KernelEvent* event = nullptr;
+
+    if (!(trace.EventFlags & XAM_TRACE_CU_MASK)) {
+      // End event
+      VTFEvent* e =
+        db->getDynamicInfo().matchingDeviceEventStart(monTraceID, KERNEL);
+      if(!e) {
+        return ;
+      }
+      if (cuStarts[s].empty()) {
+        return ;
+      }
+
+      cuStarts[s].pop_front();
+      event = new KernelEvent(e->getEventId(), hostTimestamp, KERNEL, deviceId, s, cuId);
+      event->setDeviceTimestamp(trace.Timestamp);
+      db->getDynamicInfo().addEvent(event);
+      (db->getStats()).setLastKernelEndTime(hostTimestamp) ;
+    }
+    else {
+      // start event
+      event = new KernelEvent(0, hostTimestamp, KERNEL, deviceId, s, cuId);
+      event->setDeviceTimestamp(trace.Timestamp);
+      db->getDynamicInfo().addEvent(event);
+      db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
+
+      cuStarts[s].push_back(event);
+      if(1 == cuStarts[s].size()) {
+        traceIDs[s] = 0; // When current CU starts, reset stall status
+      }
+      if (db->getStats().getFirstKernelStartTime() == 0.0)
+        (db->getStats()).setFirstKernelStartTime(hostTimestamp) ;
+      }
+  }
+
+  void DeviceEventCreatorFromTrace::addStallEvent(xclTraceResults& trace,
+                                                  double hostTimestamp,
+                                                  uint32_t s,
+                                                  uint64_t monTraceID,
+                                                  int32_t cuId,
+                                                  VTFEventType type,
+                                                  uint64_t mask)
+  {
+    KernelStall* event = nullptr;
+    if (traceIDs[s] & mask) {
+      // End event
+      VTFEvent* startEvent =
+        db->getDynamicInfo().matchingDeviceEventStart(monTraceID, type) ;
+      event = new KernelStall(startEvent->getEventId(),
+                              hostTimestamp,
+                              type,
+                              deviceId,
+                              s,
+                              cuId) ;
+      event->setDeviceTimestamp(trace.Timestamp);
+      db->getDynamicInfo().addEvent(event);
+    }
+    else {
+      // Start event
+      event = new KernelStall(0, hostTimestamp, type, deviceId, s, cuId);
+      event->setDeviceTimestamp(trace.Timestamp);
+      db->getDynamicInfo().addEvent(event);
+      db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
+    }
+  }
+
+  void DeviceEventCreatorFromTrace::addAMEvent(xclTraceResults& trace,
+                                               double hostTimestamp)
+  {
+    uint32_t s = ((trace.TraceID - MIN_TRACE_ID_AM) / 16);
+    uint64_t monTraceID = s*16 + MIN_TRACE_ID_AM;
+
+    Monitor* mon  = db->getStaticInfo().getAMonitor(deviceId, xclbin, s);
+    if (!mon) {
+      // In hardware emulation, there might be monitors inserted
+      //  that don't show up in the debug ip layout.  These are added
+      //  for their own debugging purposes and we should ignore any
+      //  packets we see from them.
+      return ;
+    }
+
+    int32_t cuId = mon->cuIndex;
+
+    if (trace.TraceID & XAM_TRACE_CU_MASK) {
+      addCUEvent(trace, hostTimestamp, s, monTraceID, cuId);
+    }
+    if (trace.TraceID & XAM_TRACE_STALL_INT_MASK) {
+      addStallEvent(trace, hostTimestamp, s, monTraceID, cuId,
+                    KERNEL_STALL_DATAFLOW, XAM_TRACE_STALL_INT_MASK);
+    }
+    if (trace.TraceID & XAM_TRACE_STALL_STR_MASK) {
+      addStallEvent(trace, hostTimestamp, s, monTraceID, cuId,
+                    KERNEL_STALL_PIPE, XAM_TRACE_STALL_STR_MASK);
+    }
+    if (trace.TraceID & XAM_TRACE_STALL_EXT_MASK) {
+      addStallEvent(trace, hostTimestamp, s, monTraceID, cuId,
+                    KERNEL_STALL_EXT_MEM, XAM_TRACE_STALL_EXT_MASK);
+    }
+
+    traceIDs[s] ^= (trace.TraceID & 0xf);
+    amLastTrans[s] = trace.Timestamp;
+
+    // If a CU just ended completely, we need to tie off any hanging
+    //  reads, writes, and stalls
+    if ((trace.TraceID & XAM_TRACE_CU_MASK) && cuStarts[s].empty()) {
+      addApproximateDataTransferEndEvents(cuId);
+      addApproximateStallEndEvents(trace, hostTimestamp, s, monTraceID, cuId);
+    }
+  }
+
   void DeviceEventCreatorFromTrace::addAIMEvent(xclTraceResults& trace,
                                                 double hostTimestamp)
   {
@@ -162,7 +278,6 @@ namespace xdp {
       }
 
       uint32_t s = 0;
-      uint64_t monTraceID = 0;
       bool AMPacket  = (trace.TraceID >= MIN_TRACE_ID_AM && trace.TraceID <= MAX_TRACE_ID_AM);
       bool AIMPacket = (trace.TraceID >= MIN_TRACE_ID_AIM && trace.TraceID <= MAX_TRACE_ID_AIM);
       bool ASMPacket = (trace.TraceID >= MIN_TRACE_ID_ASM && trace.TraceID < MAX_TRACE_ID_ASM);
@@ -171,109 +286,11 @@ namespace xdp {
       }
       double hostTimestamp = convertDeviceToHostTimestamp(timestamp);
       if (AMPacket) {
-        s = ((trace.TraceID - MIN_TRACE_ID_AM) / 16);
-        monTraceID = s*16 + MIN_TRACE_ID_AM;
-        uint32_t cuEvent       = trace.TraceID & XAM_TRACE_CU_MASK;
-        uint32_t stallIntEvent = trace.TraceID & XAM_TRACE_STALL_INT_MASK;
-        uint32_t stallStrEvent = trace.TraceID & XAM_TRACE_STALL_STR_MASK;
-        uint32_t stallExtEvent = trace.TraceID & XAM_TRACE_STALL_EXT_MASK;
-
-        Monitor* mon  = db->getStaticInfo().getAMonitor(deviceId, xclbin, s);
-        if (!mon) {
-          // In hardware emulation, there might be monitors inserted
-          //  that don't show up in the debug ip layout.  These are added
-          //  for their own debugging purposes and we should ignore any
-          //  packets we see from them.
-          continue ;
-        }
-        int32_t  cuId = mon->cuIndex;
-        
-        if(cuEvent) {
-          KernelEvent* event = nullptr;
-          if (!(trace.EventFlags & XAM_TRACE_CU_MASK)) {
-            // end event
-            VTFEvent* e = db->getDynamicInfo().matchingDeviceEventStart(monTraceID, KERNEL);
-            if(!e) {
-              continue;
-            }
-            if(cuStarts[s].empty()) {
-              continue;
-            }
-            cuStarts[s].pop_front();
-            event = new KernelEvent(e->getEventId(), hostTimestamp, KERNEL, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-            (db->getStats()).setLastKernelEndTime(hostTimestamp) ;
-          } else {
-            // start event
-            event = new KernelEvent(0, hostTimestamp, KERNEL, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-            db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
-            cuStarts[s].push_back(event);
-            if(1 == cuStarts[s].size()) {
-              traceIDs[s] = 0;	// When current CU starts, reset stall status
-            }
-            if (db->getStats().getFirstKernelStartTime() == 0.0)
-              (db->getStats()).setFirstKernelStartTime(hostTimestamp) ;
-          }
-        }
- 
-        if(stallIntEvent) {
-          KernelStall* event = nullptr;
-          if(traceIDs[s] & XAM_TRACE_STALL_INT_MASK) {
-            // end event
-            event = new KernelStall(db->getDynamicInfo().matchingDeviceEventStart(monTraceID, KERNEL_STALL_DATAFLOW)->getEventId(),
-                             hostTimestamp, KERNEL_STALL_DATAFLOW, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-          } else {
-            // start event
-            event = new KernelStall(0, hostTimestamp, KERNEL_STALL_DATAFLOW, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-            db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
-          }
-        } 
-
-        if(stallStrEvent) {
-          KernelStall* event = nullptr;
-          if(traceIDs[s] & XAM_TRACE_STALL_STR_MASK) {
-            // end event
-            event = new KernelStall(db->getDynamicInfo().matchingDeviceEventStart(monTraceID, KERNEL_STALL_PIPE)->getEventId(),
-                             hostTimestamp, KERNEL_STALL_PIPE, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-          } else {
-            // start event
-            event = new KernelStall(0, hostTimestamp, KERNEL_STALL_PIPE, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-            db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
-          }
-        } 
-        if(stallExtEvent) {
-          KernelStall* event = nullptr;
-          if(traceIDs[s] & XAM_TRACE_STALL_EXT_MASK) {
-            // end event
-            event = new KernelStall(db->getDynamicInfo().matchingDeviceEventStart(monTraceID, KERNEL_STALL_EXT_MEM)->getEventId(),
-                             hostTimestamp, KERNEL_STALL_EXT_MEM, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-          } else {
-            // start event
-            event = new KernelStall(0, hostTimestamp, KERNEL_STALL_EXT_MEM, deviceId, s, cuId);
-            event->setDeviceTimestamp(timestamp);
-            db->getDynamicInfo().addEvent(event);
-            db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
-          }
-        }
-        traceIDs[s] ^= (trace.TraceID & 0xf);
-        amLastTrans[s] = timestamp;
-      } // AMPacket
+        addAMEvent(trace, hostTimestamp);
+      }
       else if(AIMPacket) {
         addAIMEvent(trace, hostTimestamp) ;
-      } // AIMPacket
+      }
       else if(ASMPacket) {
         s = trace.TraceID - MIN_TRACE_ID_ASM;
 
@@ -448,7 +465,7 @@ namespace xdp {
     db->getDynamicInfo().addEvent(endEvent);
   }
 
-  void DeviceEventCreatorFromTrace::addApproximateDataTransferEvents()
+  void DeviceEventCreatorFromTrace::addApproximateDataTransferEndEvents()
   {
     // Go through all of our AIMs.  If any of them have any outstanding
     //  reads or writes, then finish them based on the last CU execution time.
@@ -472,6 +489,32 @@ namespace xdp {
         }
       }
 
+      addApproximateDataTransferEvent(KERNEL_READ, aimTraceID, amId, cuId) ;
+      addApproximateDataTransferEvent(KERNEL_WRITE, aimTraceID, amId, cuId) ;
+    }
+  }
+
+  void DeviceEventCreatorFromTrace::addApproximateDataTransferEndEvents(int32_t cuId)
+  {
+    if (cuId == -1)
+      return ;
+    for (uint64_t aimIndex = 0 ;
+         aimIndex < (db->getStaticInfo()).getNumAIM(deviceId, xclbin) ;
+         ++aimIndex) {
+
+      uint64_t aimTraceID = aimIndex + MIN_TRACE_ID_AIM ;
+      Monitor* mon =
+        db->getStaticInfo().getAIMonitor(deviceId, xclbin, aimIndex);
+      if (!mon)
+        continue;
+
+      if (cuId != mon->cuIndex)
+        continue ;
+      int32_t amId = -1 ;
+      ComputeUnitInstance* cu = db->getStaticInfo().getCU(deviceId, cuId);
+      if (cu) {
+        amId = cu->getAccelMon();
+      }
       addApproximateDataTransferEvent(KERNEL_READ, aimTraceID, amId, cuId) ;
       addApproximateDataTransferEvent(KERNEL_WRITE, aimTraceID, amId, cuId) ;
     }
@@ -518,10 +561,31 @@ namespace xdp {
     }
   }
 
+  void DeviceEventCreatorFromTrace::addApproximateStallEndEvents(xclTraceResults& trace, double hostTimestamp, uint32_t s, uint64_t monTraceID, int32_t cuId)
+  {
+    if (traceIDs[s] == 0)
+      return ;
+    // There are some stall events still outstanding that need to be closed
+    const double halfCycleTimeInMs = (0.5/traceClockRateMHz)/1000.0;
+
+    if (traceIDs[s] & XAM_TRACE_STALL_INT_MASK) {
+      addStallEvent(trace, hostTimestamp-halfCycleTimeInMs, s, monTraceID, cuId,
+                    KERNEL_STALL_DATAFLOW, XAM_TRACE_STALL_INT_MASK);
+    }
+    if (traceIDs[s] & XAM_TRACE_STALL_STR_MASK) {
+      addStallEvent(trace, hostTimestamp-halfCycleTimeInMs, s, monTraceID,
+                    cuId, KERNEL_STALL_PIPE, XAM_TRACE_STALL_STR_MASK);
+    }
+    if (traceIDs[s] & XAM_TRACE_STALL_EXT_MASK) {
+      addStallEvent(trace, hostTimestamp-halfCycleTimeInMs, s, monTraceID, cuId,
+                    KERNEL_STALL_EXT_MEM, XAM_TRACE_STALL_EXT_MASK);
+    }
+  }
+
   void DeviceEventCreatorFromTrace::end()
   {
     addApproximateCUEndEvents();
-    addApproximateDataTransferEvents();
+    addApproximateDataTransferEndEvents();
     addApproximateStreamEndEvents();
   }
 

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
@@ -57,14 +57,25 @@ class DeviceEventCreatorFromTrace
   void trainDeviceHostTimestamps(uint64_t deviceTimestamp, uint64_t hostTimestamp);
   double convertDeviceToHostTimestamp(uint64_t deviceTimestamp);
 
-  // Helper functions
+  // Functions for adding a specific type of device event
+  void addAMEvent(xclTraceResults& trace, double hostTimestamp);
   void addAIMEvent(xclTraceResults& trace, double hostTimestamp) ;
 
-  void addKernelDataTransferEvent(VTFEventType ty, xclTraceResults& trace, uint32_t slot, int32_t cuId, double hostTimestamp) ;
+  void addCUEvent(xclTraceResults& trace, double hostTimestamp,
+                  uint32_t s, uint64_t monTraceID, int32_t cuId);
+  void addStallEvent(xclTraceResults& trace, double hostTimestamp,
+                     uint32_t s, uint64_t monTraceID, int32_t cuId,
+                     VTFEventType type, uint64_t mask) ;
+  void addKernelDataTransferEvent(VTFEventType ty, xclTraceResults& trace,
+                                  uint32_t slot, int32_t cuId,
+                                  double hostTimestamp) ;
 
+  // Functions for handling dropped device packets
   void addApproximateCUEndEvents();
-  void addApproximateDataTransferEvents();
+  void addApproximateDataTransferEndEvents();
+  void addApproximateDataTransferEndEvents(int32_t cuId);
   void addApproximateStreamEndEvents();
+  void addApproximateStallEndEvents(xclTraceResults& trace, double hostTimestamp, uint32_t s, uint64_t monTraceID, int32_t cuId);
 
   void addApproximateDataTransferEvent(VTFEventType type, uint64_t aimTraceID, int32_t amId, int32_t cuId);
   void addApproximateStreamEndEvent(uint64_t asmIndex, uint64_t asmTraceID, VTFEventType streamEventType,


### PR DESCRIPTION
This pull request enhances device trace in the following ways:
- Ties off any outstanding reads, writes, and stall events when a compute unit ends to approximate end times.  This handles the case when device packets are dropped before we can process them in software.
- Fixes an issue where some of these approximated events had the end events before the start event