### PR TITLE
CR-1093252: Fixing trace where there were multiple end events for the same stream starve transaction

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -333,7 +333,6 @@ namespace xdp {
             strmEvent = new DeviceStreamAccess(0, hostTimestamp, streamEventType, deviceId, s, cuId);
             strmEvent->setDeviceTimestamp(timestamp); 
             db->getDynamicInfo().addEvent(strmEvent);
-            db->getDynamicInfo().markDeviceEventStart(trace.TraceID, strmEvent);
             matchingStart = strmEvent;
             hostTimestamp += halfCycleTimeInMs;
           }


### PR DESCRIPTION
This pull request removes the marking and storing of the dummy events we insert when we encounter an end event before a start event.  This led to instances where we would at the end create multiple end events for the same start event.
