### PR TITLE
Broadcast enable cores

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -65,6 +65,14 @@ get_driver_config(const pt::ptree& aie_meta)
   return driver_config;
 }
 
+adf::aiecompiler_options
+get_aiecompiler_options(const pt::ptree& aie_meta)
+{
+    adf::aiecompiler_options aiecompiler_options;
+    aiecompiler_options.broadcast_enable_core = aie_meta.get<bool>("aie_metadata.aiecompiler_options.broadcast_enable_core");
+    return aiecompiler_options;
+}
+
 adf::graph_config
 get_graph(const pt::ptree& aie_meta, const std::string& graph_name)
 {

--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -349,6 +349,18 @@ get_driver_config(const xrt_core::device* device)
   return ::get_driver_config(aie_meta);
 }
 
+adf::aiecompiler_options
+get_aiecompiler_options(const xrt_core::device* device)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return adf::aiecompiler_options();
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_aiecompiler_options(aie_meta);
+}
+
 adf::graph_config
 get_graph(const xrt_core::device* device, const std::string& graph_name)
 {

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -38,6 +38,14 @@ adf::driver_config
 get_driver_config(const xrt_core::device* device);
 
 /**
+ * get_aiecompiler_options() - get compiler options from xclbin AIE metadata
+ *
+ * @device: device with loaded meta data
+ */
+adf::aiecompiler_options
+get_aiecompiler_options(const xrt_core::device* device);
+
+/**
  * get_graph() - get tile data from xclbin AIE metadata
  *
  * @device: device with loaded meta data

--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -72,7 +72,9 @@ Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
     if ((rc = XAie_CfgInitialize(&DevInst, &ConfigPtr)) != XAIE_OK)
         throw xrt_core::error(-EINVAL, "Failed to initialize AIE configuration: " + std::to_string(rc));
     devInst = &DevInst;
-    adf::config_manager::initialize(devInst, driver_config.reserved_num_rows, false);
+
+    adf::aiecompiler_options aiecompiler_options = xrt_core::edge::aie::get_aiecompiler_options(device.get());
+    adf::config_manager::initialize(devInst, driver_config.reserved_num_rows, aiecompiler_options.broadcast_enable_core);
 
     /* Initialize PLIO metadata */
     for (auto& plio : xrt_core::edge::aie::get_plios(device.get()))

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_api_config.h
@@ -37,6 +37,11 @@ struct driver_config
     uint8_t aie_tile_num_rows;
 };
 
+struct aiecompiler_options
+{
+    bool broadcast_enable_core;
+};
+
 struct graph_config
 {
     int id;

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -122,9 +122,9 @@ err_code graph_api::run()
 
         // Waiting for 250 cycles to reset the core enable event
         unsigned long long StartTime, CurrentTime = 0;
-        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, coreTiles[0], XAIE_CORE_MOD, (u64*)(&StartTime));
+        driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, (u64*)(&StartTime));
         do {
-            driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, coreTiles[0], XAIE_CORE_MOD, (u64*)(&CurrentTime));
+            driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, (u64*)(&CurrentTime));
         } while ((CurrentTime - StartTime) <= 250);
 
         XAie_StartTransaction(config_manager::s_pDevInst, XAIE_TRANSACTION_ENABLE_AUTO_FLUSH);


### PR DESCRIPTION
This CR is to use broadcast to enable AIE cores to minimize start latency between cores.