### PR TITLE
Vitis-2001 Support for User-IP through new XRT C++ Class/APIs

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -1,0 +1,324 @@
+/*
+ * Copyright (C) 2021, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This file implements XRT IP APIs as declared in
+// core/include/experimental/xrt_ip.h
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_ip.h
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "core/include/experimental/xrt_ip.h"
+
+#include "core/common/device.h"
+#include "core/common/config_reader.h"
+#include "core/common/debug.h"
+#include "core/common/error.h"
+#include "core/common/xclbin_parser.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <atomic>
+#include <memory>
+#include <string>
+
+#ifdef _WIN32
+# pragma warning( disable : 4244 4996)
+#endif
+
+namespace {
+
+constexpr size_t operator"" _kb(unsigned long long v)  { return 1024u * v; }
+
+inline bool
+is_sw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
+  return swem;
+}
+
+inline bool
+has_reg_read_write()
+{
+#ifdef _WIN32
+  return false;
+#else
+  return !is_sw_emulation();
+#endif
+}
+
+} // namespace
+
+namespace xrt {
+
+class ip::interrupt_impl
+{
+  std::shared_ptr<xrt_core::device> device; // shared ownership
+  xclInterruptNotifyHandle handle;
+  unsigned int irqidx;
+
+public:
+  interrupt_impl(std::shared_ptr<xrt_core::device> dev, unsigned int ipidx)
+    : device(std::move(dev)), irqidx(ipidx)
+  {
+    handle = device->open_ip_interrupt_notify(irqidx);
+    enable();
+  }
+
+  ~interrupt_impl()
+  {
+    try {
+      device->close_ip_interrupt_notify(handle);
+    }
+    catch (...) {
+    }
+  }
+
+  void
+  enable()
+  {
+    device->enable_ip_interrupt(handle);
+  }
+
+  void
+  disable()
+  {
+    device->disable_ip_interrupt(handle);
+  }
+
+  void
+  wait()
+  {
+    // Waits for interrupt, upon return interrupt is disabled.
+    device->wait_ip_interrupt(handle);
+    enable(); // re-enable interrupts
+  }
+};
+
+// struct ip_impl - The internals of an xrt::ip
+class ip_impl
+{
+  // struct ip_context - Simple management IP context
+  //
+  // Constructing an ip object opens a exclusive context on specifed
+  // IP.  Upon deletion of the xrt::ip object implementation, the
+  // context is closed.
+  struct ip_context
+  {
+    std::shared_ptr<xrt_core::device> device;
+    xrt::uuid xclbin_uuid;         //
+    unsigned int idx;      // index of ip per driver
+    const ip_data* ip;
+    uint64_t address;      // base address of ip
+    uint64_t size;         // address range of ip
+
+    ip_context(std::shared_ptr<xrt_core::device> dev, const xrt::uuid& xid, const std::string& nm)
+      : device(std::move(dev)), xclbin_uuid(xid)
+    {
+      auto ip_section = device->get_axlf_section(IP_LAYOUT, xclbin_uuid);
+      if (!ip_section.first)
+        throw std::runtime_error("No ip layout available to construct ip, make sure xclbin is loaded");
+      auto ip_layout = reinterpret_cast<const ::ip_layout*>(ip_section.first);
+
+      auto ips = xrt_core::xclbin::get_cus(ip_layout, nm);
+      if (ips.empty())
+        throw xrt_core::error(EINVAL, "No IP matching '" + nm + "'");
+      if (ips.size() > 1)
+        throw xrt_core::error(EINVAL, "More than one P matching '" + nm + "'");
+
+      ip = ips.front();
+
+      auto all_cus = xrt_core::xclbin::get_cus(ip_layout);  // sort order
+      auto itr = std::find(all_cus.begin(), all_cus.end(), ip->m_base_address);
+      if (itr == all_cus.end())
+        throw xrt_core::internal_error("unexpected error");
+
+      idx = std::distance(all_cus.begin(), itr);
+
+      device->open_context(xclbin_uuid.get(), idx, xrt_core::config::get_rw_shared());
+    }
+
+    ~ip_context()
+    {
+      device->close_context(xclbin_uuid.get(), idx);
+    }
+
+    unsigned int
+    get_idx() const
+    {
+      return idx;
+    }
+
+    uint64_t
+    get_address() const
+    {
+      return ip->m_base_address;
+    }
+
+    uint64_t
+    get_size() const
+    {
+      return 64_kb;  // TODO compute
+    }
+  };
+
+  unsigned int
+  get_cuidx_or_error(size_t offset) const
+  {
+    if ((offset + sizeof(uint32_t)) > ipctx.get_size())
+        throw std::out_of_range("Cannot read or write outside kernel register space");
+
+    return ipctx.get_idx();
+  }
+
+  static uint32_t
+  create_uid()
+  {
+    static std::atomic<uint32_t> count {0};
+    return count++;
+  }
+
+private:
+  std::shared_ptr<xrt_core::device> device;      // shared ownership
+  std::weak_ptr<ip::interrupt_impl> interrupt;   // interrupt if active
+  ip_context ipctx;
+  uint32_t uid;                                  // internal unique id for debug
+
+public:
+  // ip_impl - constructor
+  //
+  // @dev:     device associated with this kernel object
+  // @xid:     uuid of xclbin to mine for kernel meta data
+  // @nm:      name identifying an ip in IP_LAYOUT of xclbin
+  ip_impl(std::shared_ptr<xrt_core::device> dev, const xrt::uuid& xid, const std::string& nm)
+    : device(std::move(dev))                                   // share ownership
+    , ipctx(device, xid, nm)
+    , uid(create_uid())
+  {
+    XRT_DEBUGF("ip_impl::ip_impl(%d)\n" , uid);
+  }
+
+  ~ip_impl()
+  {
+    XRT_DEBUGF("ip_impl::~ip_impl(%d)\n" , uid);
+  }
+
+  uint32_t
+  read_register(uint32_t offset) const
+  {
+    auto idx = get_cuidx_or_error(offset);
+    uint32_t value = 0;
+    if (has_reg_read_write())
+      device->reg_read(idx, offset, &value);
+    else
+      device->xread(ipctx.get_address() + offset, &value, 4);
+    return value;
+  }
+
+  void
+  write_register(uint32_t offset, uint32_t data)
+  {
+    auto idx = get_cuidx_or_error(offset);
+    if (has_reg_read_write())
+      device->reg_write(idx, offset, data);
+    else
+      device->xwrite(ipctx.get_address() + offset, &data, 4);
+  }
+
+  std::shared_ptr<ip::interrupt_impl>
+  get_interrupt()
+  {
+    auto intr = interrupt.lock();
+    if (!intr)
+      interrupt = intr = std::shared_ptr<ip::interrupt_impl>(new ip::interrupt_impl(device, ipctx.get_idx()));
+
+    return intr;
+  }
+
+};
+
+} // namespace xrt
+
+////////////////////////////////////////////////////////////////
+// XRT implmentation access to internal IP APIs
+////////////////////////////////////////////////////////////////
+namespace xrt_core { namespace ip_int {
+
+}} // ip_int, xrt_core
+
+
+////////////////////////////////////////////////////////////////
+// xrt_kernel C++ API implmentations (xrt_kernel.h)
+////////////////////////////////////////////////////////////////
+namespace xrt {
+
+ip::
+ip(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name)
+  : detail::pimpl<ip_impl>(std::make_shared<ip_impl>(device.get_handle(), xclbin_id, name))
+{}
+
+void
+ip::
+write_register(uint32_t offset, uint32_t data)
+{
+  handle->write_register(offset, data);
+}
+
+uint32_t
+ip::
+read_register(uint32_t offset) const
+{
+  return handle->read_register(offset);
+}
+
+xrt::ip::interrupt
+ip::
+create_interrupt_notify()
+{
+  return xrt::ip::interrupt{handle->get_interrupt()};
+}
+
+////////////////////////////////////////////////////////////////
+// xrt::ip::interrupt
+////////////////////////////////////////////////////////////////
+void
+ip::interrupt::
+enable()
+{
+  if (handle)
+    handle->enable();
+}
+
+void
+ip::interrupt::
+disable()
+{
+  if (handle)
+    handle->disable();
+}
+
+void
+ip::interrupt::
+wait()
+{
+  if (handle)
+    handle->wait();
+}
+
+} // namespace xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_kernel API implmentations (xrt_kernel.h)
+////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/error.h
+++ b/src/runtime_src/core/common/error.h
@@ -35,9 +35,18 @@ public:
     : std::system_error(std::abs(ec), cat, what)
   {}
   
+  system_error(std::errc ec, const std::error_category& cat, const std::string& what = "")
+    : std::system_error(static_cast<int>(ec), cat, what)
+  {}
+
   explicit
   system_error(int ec, const std::string& what = "")
     : system_error(ec, std::system_category(), what)
+  {}
+
+  explicit
+  system_error(std::errc ec, const std::string& what = "")
+    : system_error(static_cast<int>(ec), std::system_category(), what)
   {}
 
   // Retrive underlying code for return plain error code
@@ -72,6 +81,11 @@ public:
   generic_error(int ec, const std::string& what = "")
     : system_error(std::abs(ec), std::generic_category(), what)
   {}
+
+  explicit
+  generic_error(std::errc ec, const std::string& what = "")
+    : system_error(ec, std::generic_category(), what)
+  {}
 };
 
 // User space error with POSIX error code
@@ -82,6 +96,11 @@ public:
   explicit
   error(int ec, const std::string& what = "")
     : generic_error(std::abs(ec), what)
+  {}
+
+  explicit
+    error(std::errc ec, const std::string& what = "")
+    : generic_error(ec, what)
   {}
 
   explicit

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -112,9 +112,35 @@ struct ishim
 
   virtual void
   p2p_disable(bool force) = 0;
-  
+
   virtual
   void update_scheduler_status() = 0;
+
+  ////////////////////////////////////////////////////////////////
+  // Interfaces for custom IP interrupt handling
+  // Implemented explicitly by concrete shim device class
+  // 2021.1: Only supported for edge shim
+  ////////////////////////////////////////////////////////////////
+  virtual xclInterruptNotifyHandle
+  open_ip_interrupt_notify(unsigned int)
+  { throw xrt_core::error(std::errc::not_supported,"open_ip_interrupt_notify()"); }
+
+  virtual void
+  close_ip_interrupt_notify(xclInterruptNotifyHandle)
+  { throw xrt_core::error(std::errc::not_supported,"close_ip_interrupt_notify()"); }
+
+  virtual void
+  enable_ip_interrupt(xclInterruptNotifyHandle)
+  { throw xrt_core::error(std::errc::not_supported,"enable_ip_interrupt()"); }
+
+  virtual void
+  disable_ip_interrupt(xclInterruptNotifyHandle)
+  { throw xrt_core::error(std::errc::not_supported,"disable_ip_interrupt()"); }
+
+  virtual void
+  wait_ip_interrupt(xclInterruptNotifyHandle)
+  { throw xrt_core::error(std::errc::not_supported,"wait_ip_interrupt()"); }
+  ////////////////////////////////////////////////////////////////
 
 #ifdef XRT_ENABLE_AIE
   virtual xclGraphHandle

--- a/src/runtime_src/core/edge/common/device_edge.h
+++ b/src/runtime_src/core/edge/common/device_edge.h
@@ -17,7 +17,7 @@
 #ifndef DEVICE_EDGE_H
 #define DEVICE_EDGE_H
 
-#include "common/device.h"
+#include "core/common/device.h"
 
 namespace xrt_core {
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -16,16 +16,18 @@
 
 
 #include "device_linux.h"
-#include "core/common/query_requests.h"
-
 #include "xrt.h"
 #include "zynq_dev.h"
 #include "aie_sys_parser.h"
 
-#include <string>
-#include <memory>
-#include <iostream>
+#include "core/common/query_requests.h"
+
 #include <map>
+#include <memory>
+#include <string>
+
+#include <unistd.h>
+
 #include <boost/format.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -572,6 +574,37 @@ reset(query::reset_type key) const
   default:
     throw error(-ENODEV, "invalid argument");
   }
+}
+
+
+////////////////////////////////////////////////////////////////
+// Custom IP interrupt handling
+////////////////////////////////////////////////////////////////
+void
+device_linux::
+enable_ip_interrupt(xclInterruptNotifyHandle handle)
+{
+  int enable = 1;
+  if (::write(handle, &enable, sizeof(enable)) == -1)
+    throw error(errno, "enable_ip_interrupt failed POSIX write");
+}
+
+void
+device_linux::
+disable_ip_interrupt(xclInterruptNotifyHandle handle)
+{
+  int disable = 1;
+  if (::write(handle, &disable, sizeof(disable)) == -1)
+    throw error(errno, "disable_ip_interrupt failed POSIX write");
+}
+
+void
+device_linux::
+wait_ip_interrupt(xclInterruptNotifyHandle handle)
+{
+  int pending = 0;
+  if (::read(handle, &pending, sizeof(pending)) == -1)
+    throw error(errno, "wait_ip_interrupt failed POSIX read");
 }
 
 } // xrt_core

--- a/src/runtime_src/core/edge/user/device_linux.h
+++ b/src/runtime_src/core/edge/user/device_linux.h
@@ -17,6 +17,7 @@
 #ifndef EDGE_DEVICE_LINUX_H
 #define EDGE_DEVICE_LINUX_H
 
+#include "xrt.h"
 #include "core/common/ishim.h"
 #include "core/edge/common/device_edge.h"
 
@@ -35,6 +36,32 @@ public:
   virtual void read(uint64_t addr, void* buf, uint64_t len) const;
   virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
   virtual void reset(const query::reset_type) const;
+
+  ////////////////////////////////////////////////////////////////
+  // Custom ip interrupt handling
+  // Redefined from xrt_core::ishim
+  ////////////////////////////////////////////////////////////////
+  virtual xclInterruptNotifyHandle
+  open_ip_interrupt_notify(unsigned int ip_index)
+  {
+    return xclOpenIPInterruptNotify(get_device_handle(), ip_index, 0);
+  }
+  
+  virtual void
+  close_ip_interrupt_notify(xclInterruptNotifyHandle handle)
+  {
+    xclCloseIPInterruptNotify(get_device_handle(), handle);
+  }
+
+  virtual void
+  enable_ip_interrupt(xclInterruptNotifyHandle);
+
+  virtual void
+  disable_ip_interrupt(xclInterruptNotifyHandle);
+
+  virtual void
+  wait_ip_interrupt(xclInterruptNotifyHandle);
+  ////////////////////////////////////////////////////////////////
 
 private:
   // Private look up function for concrete query::request

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -7,6 +7,7 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_enqueue.h
   xrt_error.h
   xrt_ini.h
+  xrt_ip.h
   xrt_kernel.h
   xrt_profile.h
   xrt_uuid.h

--- a/src/runtime_src/core/include/experimental/xrt-next.h
+++ b/src/runtime_src/core/include/experimental/xrt-next.h
@@ -20,6 +20,20 @@
 
 #include "../xrt.h"
 
+/*
+ * typedef xclInterruptNotifyHandle
+ *
+ * Implementation specific type representing an interrupt notify handle
+ * that is used by xclOpen/CloseIPInterruptNotify()
+ */  
+#ifdef _WIN32
+typedef void* xclInterruptNotifyHandle;
+# define XCL_NULL_INTC_HANDLE INVALID_HANDLE_VALUE
+#else
+typedef int xclInterruptNotifyHandle;
+# define XCL_NULL_INTC_HANDLE -1
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -252,19 +266,26 @@ xclIPName2Index(xclDeviceHandle handle, const char *ipName);
  * @handle:     Device handle
  * @ipIndex:    IP index
  * @flags:      flags for the fd
- * Return:      fd or appropriate error number
+ * Return:      Interrupt notify handle
  *
- * Caller should own an exclusive context on the IP obtained via xclOpenContext()
- * Support for non managed IP. This is the proper way to support custom IPs which doesn't compliant with supported control protocol.
- * This API would open a file descriptor used for CU interrupt notification. The usage is similar to open a UIO device.
- * Caller could use standard read/poll/select system call to wait for IP interrupts.
- * Once this API was called, xclExecBuf() could not be used to schedule this specific IP.
- * The expectation is the caller performing any necessary actions to make it work.
+ * Caller should own an exclusive context on the IP obtained via
+ * xclOpenContext()
  *
- * Note: the IP irq would be disable after this is called. Caller could manually enable the interrupt by write().
+ * Support for non managed IP. This is the proper way to support
+ * custom IPs which doesn't compliant with supported control protocol.
+ *
+ * This API would open a handle used for CU interrupt
+ * notification. The usage is similar to open a UIO device.  Caller
+ * could use standard read/poll/select system call to wait for IP
+ * interrupts.  Once this API was called, xclExecBuf() could not be
+ * used to schedule this specific IP.  The expectation is the caller
+ * performing any necessary actions to make it work.
+ *
+ * Note: the IP irq would be disable after this is called. Caller
+ * could manually enable the interrupt by write().
  */
 XCL_DRIVER_DLLESPEC
-int
+xclInterruptNotifyHandle
 xclOpenIPInterruptNotify(xclDeviceHandle handle, uint32_t ipIndex, unsigned int flags);
 
 /**

--- a/src/runtime_src/core/include/experimental/xrt_ip.h
+++ b/src/runtime_src/core/include/experimental/xrt_ip.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2021, Xilinx Inc - All rights reserved
+ * Xilinx Runtime (XRT) Experimental APIs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef _XRT_IP_H_
+#define _XRT_IP_H_
+
+#include "xrt.h"
+#include "xrt/xrt_uuid.h"
+#include "xrt/xrt_device.h"
+#include "xrt/detail/pimpl.h"
+
+#ifdef __cplusplus
+# include <cstdint>
+# include <string>
+#endif
+
+#ifdef __cplusplus
+
+namespace xrt {
+
+class ip_impl;
+class ip : public detail::pimpl<ip_impl>
+{
+public:
+  /**
+   * class interrupt - IP interrupt object
+   *
+   * This class represents an IP interrupt event.  The interrupt
+   * object is contructed via `xrt::ip::create_interrupt_notify()`.
+   * The object can be used to enable and disable IP interrupts
+   * and can be used to wait for an interrupt to occur.
+   *
+   * Upon construction IP interrupt is automatically enabled.
+   */
+  class interrupt_impl;
+  class interrupt : public detail::pimpl<interrupt_impl>
+  {
+  public:
+    explicit
+    interrupt(std::shared_ptr<interrupt_impl> handle)
+      : detail::pimpl<interrupt_impl>(std::move(handle))
+    {}
+
+    /**
+     * enable() - Enable interrupt
+     */
+    XCL_DRIVER_DLLESPEC
+    void
+    enable();
+ 
+    /**
+     * disable() - Disable interrupt
+     */
+    XCL_DRIVER_DLLESPEC
+    void
+    disable();
+ 
+    /**
+     * wait() - Wait for interrupt
+     *
+     * Wait for interrupt from IP. Upon return, interrupt is 
+     * re-enabled.
+     */
+    XCL_DRIVER_DLLESPEC
+    void
+    wait();
+  };
+ 
+public:
+  /**
+   * ip() - Construct empty ip object
+   */
+  ip()
+  {}
+
+  /**
+   * ip() - Constructor from a device and xclbin
+   *
+   * @param device
+   *  Device programmed with the IP
+   * @param xclbin_id
+   *  UUID of the xclbin with the IP
+   * @param name
+   *  Name of IP to construct
+   *
+   * The IP is opened with exclusive access meaning that no other xrt::ip
+   * objects can use the same IP, nor will other process be able to use the
+   * IP while one process has been granted access.
+   *
+   * Constructor throws on error.
+   */
+  XCL_DRIVER_DLLESPEC
+  ip(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name);
+ 
+  /**
+   * write_register() - Write to the address range of an ip
+   *
+   * @param offset
+   *  Offset in register space to write to
+   * @param data    
+   *  Data to write
+   *
+   * Throws std::out_or_range if offset is outside the
+   * ip address space
+   */
+  XCL_DRIVER_DLLESPEC
+  void
+  write_register(uint32_t offset, uint32_t data);
+ 
+  /**
+   * read_register() - Read data from ip address range
+   *
+   * @param offset 
+   *  Offset in register space to read from
+   * @return
+   *  Value read from offset
+   *
+   * Throws std::out_or_range if offset is outside the
+   * ip address space
+   */
+  XCL_DRIVER_DLLESPEC
+  uint32_t
+  read_register(uint32_t offset) const;
+ 
+  /**
+   * create_interrupt_notify() - Create xrt::ip::interrupt object
+   *
+   * @return
+   *  xrt::ip::event object can be used to control IP interrupt.
+   *
+   * This function creates an xrt::ip::interrupt object that can be
+   * used to control and wait for IP interrupt.   On successful
+   * return the IP has interrupt enabled.
+   *
+   * Throws if the custom IP doesn't support interrupts.
+   */
+  XCL_DRIVER_DLLESPEC
+  interrupt
+  create_interrupt_notify();  
+};
+
+} // xrt
+#endif
+
+#endif
+

--- a/tests/xrt/100_ert_ncu/CMakeLists.txt
+++ b/tests/xrt/100_ert_ncu/CMakeLists.txt
@@ -12,6 +12,9 @@ target_link_libraries(xrtxx PRIVATE ${xrt_coreutil_LIBRARY})
 add_executable(xrtxx-mt xrtxx-mt.cpp)
 target_link_libraries(xrtxx-mt PRIVATE ${xrt_coreutil_LIBRARY})
 
+add_executable(xrtxx-ip xrtxx-ip.cpp)
+target_link_libraries(xrtxx-ip PRIVATE ${xrt_coreutil_LIBRARY})
+
 add_executable(ocl ocl.cpp)
 target_link_libraries(ocl PRIVATE ${xrt_xilinxopencl_LIBRARY})
 if (WIN32)
@@ -35,10 +38,11 @@ if (NOT WIN32)
   target_link_libraries(xrtx PRIVATE ${uuid_LIBRARY} pthread)
   target_link_libraries(xrtxx PRIVATE ${uuid_LIBRARY} pthread)
   target_link_libraries(xrtxx-mt PRIVATE ${uuid_LIBRARY} pthread)
+  target_link_libraries(xrtxx-ip PRIVATE ${uuid_LIBRARY} pthread)
   target_link_libraries(ocl PRIVATE pthread)
 endif(NOT WIN32)
 
-install(TARGETS xrt xrtx xrtxx xrtxx-mt ocl
+install(TARGETS xrt xrtx xrtxx xrtxx-mt xrtxx-ip ocl
   RUNTIME DESTINATION ${INSTALL_DIR}/${TESTNAME})
 
 add_custom_command(

--- a/tests/xrt/100_ert_ncu/xrtxx-ip.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-ip.cpp
@@ -1,0 +1,307 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+////////////////////////////////////////////////////////////////
+// This test uses xrt::ip for manual control of kernel compute
+// units.  It does set up the CUs for execution first via regular
+// xrt::kernel APIs, just to ensure valid register map before using
+// manual xrt::ip control.
+//
+// Number of jobs created is number of cus specified.  Each job
+// executes in its own thread.
+////////////////////////////////////////////////////////////////
+
+#include "xrt.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_kernel.h"
+#include "xrt/xrt_device.h"
+#include "experimental/xrt_ip.h"
+#include "xclbin.h"
+
+#include <fstream>
+#include <list>
+#include <thread>
+#include <atomic>
+#include <iostream>
+#include <vector>
+#include <cstdlib>
+
+#ifdef _WIN32
+# pragma warning ( disable : 4267 )
+#endif
+
+constexpr uint32_t AP_START    = 0x1;
+constexpr uint32_t AP_DONE     = 0x2;
+constexpr uint32_t AP_IDLE     = 0x4;
+
+const size_t ELEMENTS = 16;
+const size_t ARRAY_SIZE = 8;
+const size_t MAXCUS = 8;
+
+static size_t compute_units = MAXCUS;
+static bool use_interrupt = false;
+
+static void usage()
+{
+  std::cout << "usage: %s [options] \n\n";
+  std::cout << "  -k <bitstream>\n";
+  std::cout << "  -d <bdf | device_index>\n";
+  std::cout << "";
+  std::cout << "  [--cus <number>]: number of cus to use (default: 8) (max: 8)\n";
+  std::cout << "  [--seconds <number>]: number of seconds to run\n";
+  std::cout << "  [--intr]: use IP interrupt notification\n";
+  std::cout << "";
+  std::cout << "* Program schedules a job per CU specified. Each jobs is repeated\n";
+  std::cout << "* unless specified seconds have elapsed\n";
+  std::cout << "* Summary prints \"jsz sec jobs\" for use with awk, where jobs is total number \n";
+  std::cout << "* of jobs executed in the specified run time\n";
+}
+
+static std::string
+get_cu_name(size_t idx)
+{
+  std::string nm("addone:{");
+  nm.append("addone_").append(std::to_string(idx+1)).append("}");
+  return nm;
+}
+
+// Flag to stop job rescheduling.  Is set to true after
+// specified number of seconds.
+static std::atomic<bool> stop{true};
+
+// Data for a single job
+struct job_type
+{
+  size_t id = 0;
+  size_t runs = 0;
+  size_t reads = 0;
+  bool running = false;
+
+  // Custom IP controlled by this job
+  xrt::ip ip;
+
+  // Kernel arguments and run handle are managed by this job
+  xrt::bo a;
+  void* am               = nullptr;
+  xrt::bo b;
+  void* bm               = nullptr;
+
+  job_type(const xrt::device& device, const xrt::uuid& xid, const std::string& cu)
+  {
+    static size_t count=0;
+    id = count++;
+
+    { 
+      // Create kernel to run it once for preceeding of register map
+      // Scoped to ensure automatic object are destructed before xrt::ip is created
+      xrt::kernel kernel{device, xid, cu};
+
+      auto grpid0 = kernel.group_id(0);
+      auto grpid1 = kernel.group_id(1);
+
+      const size_t data_size = ELEMENTS * ARRAY_SIZE;
+      a = xrt::bo(device, data_size*sizeof(unsigned long), grpid0);
+      am = a.map();
+      auto adata = reinterpret_cast<unsigned long*>(am);
+      for (unsigned int i=0;i<data_size;++i)
+        adata[i] = i;
+
+      b = xrt::bo(device, data_size*sizeof(unsigned long), grpid1);
+      bm = b.map();
+      auto bdata = reinterpret_cast<unsigned long*>(bm);
+      for (unsigned int j=0;j<data_size;++j)
+        bdata[j] = id;
+
+      // Run the kernel once
+      auto run = kernel(a, b, ELEMENTS);
+      run.wait();
+    }
+
+    // Create the custom IP
+    ip = xrt::ip{device, xid, cu};
+  }
+
+  job_type(job_type&& rhs)
+    : id(rhs.id)
+    , runs(rhs.runs)
+    , reads(rhs.reads)
+    , running(rhs.running)
+    , ip(std::move(rhs.ip))
+    , a(std::move(rhs.a))
+    , am(rhs.am)
+    , b(std::move(rhs.b))
+    , bm(rhs.bm)
+  {
+    am=bm=nullptr;
+  }
+
+  ~job_type()
+  {
+    std::cout << "wait: " << reads << "\n";
+  }
+
+  void
+  run_poll()
+  {
+    while (1) {
+      ip.write_register(0, AP_START);
+      ++runs;
+
+      uint32_t val = 0;
+      do {
+        val = ip.read_register(0);
+        ++reads;
+      }
+      while (!(val & (AP_IDLE | AP_DONE)));
+
+      if (stop)
+        break;
+    }
+  }
+
+  void
+  run_intr()
+  {
+    auto interrupt = ip.create_interrupt_notify();
+
+    while (1) {
+      interrupt.enable();
+      ip.write_register(0, AP_START);
+      ++runs;
+
+      interrupt.wait();
+
+      if (stop)
+        break;
+    }
+  }
+    
+
+  void
+  run()
+  {
+    if (use_interrupt)
+      run_intr();
+    else
+      run_poll();
+  }
+};
+
+static size_t
+run_async(const xrt::device& device, const xrt::uuid& xid, const std::string& ipnm)
+{
+  job_type job {device, xid, ipnm};
+  job.run();
+  return job.runs;
+}
+
+static int
+run(const xrt::device& device, const xrt::uuid& xid, size_t cus, size_t seconds)
+{
+  std::vector<std::future<size_t>> jobs;
+  jobs.reserve(cus);
+
+  stop = (seconds == 0) ? true : false;
+
+  for (int i=0; i<cus; ++i)
+    jobs.emplace_back(std::async(std::launch::async, run_async, device, xid, get_cu_name(i)));
+
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
+  stop=true;
+
+  size_t total = 0;
+  for (auto& job : jobs) {
+    auto val = job.get();
+    total += val;
+    std::cout << "job count: " << val << "\n";
+  }
+
+  std::cout << "xrtxx-ip: ";
+  std::cout << "jobsize cus seconds total = "
+            << compute_units << " "
+            << compute_units << " "
+            << seconds << " "
+            << total << "\n";
+
+  return 0;
+}
+
+int run(int argc, char** argv)
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+
+  std::string xclbin_fnm;
+  std::string device_id = "0";
+  size_t secs = 0;
+  size_t jobs = 1;
+  size_t cus  = 1;
+
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return 1;
+    }
+
+    if (arg == "--intr") {
+      use_interrupt = true;
+      continue;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "-d")
+      device_id = arg;
+    else if (cur == "-k")
+      xclbin_fnm = arg;
+    else if (cur == "--seconds")
+      secs = std::stoi(arg);
+    else if (cur == "--cus")
+      cus = std::stoi(arg);
+    else
+      throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
+  }
+
+  compute_units = cus = std::min(cus, compute_units);
+
+  xrt::xclbin xclbin{xclbin_fnm};
+  xrt::device device{device_id};
+  auto uuid = device.load_xclbin(xclbin);
+
+  run(device, uuid, cus, secs);
+
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    run(argc,argv);
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}


### PR DESCRIPTION
Add xrt::ip as an experimental API.  Construct IP objects by
specifying name of IP and support read/write_register along with
control of IP interrupts.

Add tests/xrt/100_ert_ncu/xrtxx-ip.cpp for showcasing the API.