### PR TITLE
CR-1093736: Fix seg fault in profiling when continuous offload is enabled

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -24,10 +24,8 @@ namespace xdp {
 DeviceTraceOffload::DeviceTraceOffload(DeviceIntf* dInt,
                                        DeviceTraceLogger* dTraceLogger,
                                        uint64_t sleep_interval_ms,
-                                       uint64_t trbuf_sz,
-                                       bool start_thread)
-                   : continuous(start_thread),
-                     sleep_interval_ms(sleep_interval_ms),
+                                       uint64_t trbuf_sz)
+                   : sleep_interval_ms(sleep_interval_ms),
                      m_trbuf_alloc_sz(trbuf_sz),
                      dev_intf(dInt),
                      deviceTraceLogger(dTraceLogger)
@@ -40,10 +38,6 @@ DeviceTraceOffload::DeviceTraceOffload(DeviceIntf* dInt,
   }
 
   m_prev_clk_train_time = std::chrono::system_clock::now();
-
-  if (start_thread) {
-    start_offload(OffloadThreadType::TRACE);
-  }
 }
 
 DeviceTraceOffload::~DeviceTraceOffload()
@@ -68,6 +62,8 @@ void DeviceTraceOffload::offload_device_continuous()
   // Do a final forced read
   m_read_trace(true);
   read_trace_end();
+
+  status = OffloadThreadStatus::STOPPED;
 }
 
 void DeviceTraceOffload::train_clock_continuous()
@@ -76,6 +72,8 @@ void DeviceTraceOffload::train_clock_continuous()
     train_clock();
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep_interval_ms));
   }
+
+  status = OffloadThreadStatus::STOPPED;
 }
 
 bool DeviceTraceOffload::should_continue()

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -53,14 +53,15 @@ class DeviceTraceOffload {
 public:
     XDP_EXPORT
     DeviceTraceOffload(DeviceIntf* dInt, DeviceTraceLogger* dTraceLogger,
-                       uint64_t offload_sleep_ms, uint64_t trbuf_sz,
-                       bool start_thread = true);
+                       uint64_t offload_sleep_ms, uint64_t trbuf_sz);
     XDP_EXPORT
     virtual ~DeviceTraceOffload();
     XDP_EXPORT
     void start_offload(OffloadThreadType type);
     XDP_EXPORT
     void stop_offload();
+
+    inline OffloadThreadStatus get_status() { return status ; }
 
 public:
     XDP_EXPORT
@@ -96,6 +97,7 @@ public:
       return m_use_circ_buf;
     };
     inline bool continuous_offload() { return continuous ; }
+    inline void set_continuous(bool value = true) { continuous = value ; }
 
 private:
     std::mutex status_lock;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -202,9 +202,8 @@ namespace xdp {
     // We start the thread manually because of race conditions
     DeviceTraceOffload* offloader = 
       new DeviceTraceOffload(devInterface, logger,
-                             continuous_trace_interval_ms, // offload_sleep_ms,
-                             trace_buffer_size,            // trbuf_size,
-                             false);
+                             continuous_trace_interval_ms, // offload_sleep_ms
+                             trace_buffer_size);           // trbuf_size
 
     bool init_successful = offloader->read_trace_init(m_enable_circular_buffer) ;
 
@@ -245,6 +244,7 @@ namespace xdp {
     // We have TS2MM
     if (continuous_trace) {
       offloader->start_offload(OffloadThreadType::TRACE);
+      offloader->set_continuous();
       if (m_enable_circular_buffer) {
         auto tdma = devInterface->getTs2mm() ;
         if (tdma->supportsCircBuf()) {

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -90,6 +90,8 @@ namespace xdp {
 
         if(offloader->continuous_offload()) {
           offloader->stop_offload();
+          // To avoid a race condition, wait until the thread is stopped
+          while (offloader->get_status() != OffloadThreadStatus::STOPPED) ;
         } else {
           offloader->read_trace();
           offloader->read_trace_end();

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -126,6 +126,8 @@ namespace xdp {
           if (offloader->continuous_offload())
           {
             offloader->stop_offload() ;
+            // To avoid a race condition, wait until the offloader has stopped
+            while(offloader->get_status() != OffloadThreadStatus::STOPPED) ;
           }
           else
           {


### PR DESCRIPTION
This pull request fixes a segmentation fault at the end of execution when continuous offload of trace is turned on.

Specifically, this pull request:
- Removes the "start_thread" parameter from the device trace offloader as it is no longer used
- Sets the "continuous" member when continuous offload is enabled so we can correctly check it at the end of execution
- Waits for the offload to complete when flushing a device