### PR TITLE
delete trash code in qspips flasher

### DIFF
--- a/src/runtime_src/core/pcie/tools/xbflash.qspi/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbflash.qspi/xqspips.cpp
@@ -238,17 +238,6 @@ XQSPIPS_Flasher::XQSPIPS_Flasher(pcidev::pci_device *dev)
     }
 
     mBusWidth = 2;
-    if (typeStr.find("x2") != std::string::npos) {
-        int value;
-        // This is a special register in the U30 shell.
-        // Because U30 supports x2 and x4 buswidth. Default: x2.
-        // SC could configure it. U30 firmware would set this register.
-        // TODO: Find a better solution if need.
-        mDev->pcieBarRead(0x11000C, &value, 4);
-        mBusWidth = (value >> 16) & 0x7;
-        if (mBusWidth != 4)
-            mBusWidth = 2;
-    }
 }
 
 /**

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xqspips.cpp
@@ -241,17 +241,6 @@ XQSPIPS_Flasher::XQSPIPS_Flasher(std::shared_ptr<pcidev::pci_device> dev)
     }
 
     mBusWidth = 2;
-    if (typeStr.find("x2") != std::string::npos) {
-        int value;
-        // This is a special register in the U30 shell.
-        // Because U30 supports x2 and x4 buswidth. Default: x2.
-        // SC could configure it. U30 firmware would set this register.
-        // TODO: Find a better solution if need.
-        mDev->pcieBarRead(0x11000C, &value, 4);
-        mBusWidth = (value >> 16) & 0x7;
-        if (mBusWidth != 4)
-            mBusWidth = 2;
-    }
 }
 
 /**

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -262,17 +262,6 @@ XQSPIPS_Flasher::XQSPIPS_Flasher(std::shared_ptr<xrt_core::device> dev)
     }
 
     mBusWidth = 2;
-    if (typeStr.find("x2") != std::string::npos) {
-        int value;
-        // This is a special register in the U30 shell.
-        // Because U30 supports x2 and x4 buswidth. Default: x2.
-        // SC could configure it. U30 firmware would set this register.
-        // TODO: Find a better solution if need.
-        mDev->read(0x11000C, &value, 4);
-        mBusWidth = (value >> 16) & 0x7;
-        if (mBusWidth != 4)
-            mBusWidth = 2;
-    }
 }
 
 /**


### PR DESCRIPTION
that code is (probably) for old u30.
address 0x11000c may be not available or be occupied by other IP. 
reading that address doesn't make sense