### PR TITLE
CR-1093536 ASTeR basic sanity - running xbutil -new examine crashed t…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2642,7 +2642,11 @@ static int icap_lock_bitstream(struct platform_device *pdev, const xuid_t *id)
 	struct icap *icap = platform_get_drvdata(pdev);
 	int ref = 0, err = 0;
 
-	BUG_ON(uuid_is_null(id));
+	/* ioctl arg might be passed in with NULL uuid */
+	if (uuid_is_null(id)) {
+		ICAP_WARN(icap, "NULL uuid.");
+		return -EINVAL;
+	}
 
 	err = icap_xclbin_rd_lock(icap);
 	if (err) {

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -136,6 +136,8 @@ int
 getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
 {
   std::vector<char> buf = xrt_core::device_query<xrt_core::query::ps_kernel>(device);
+  if (buf.empty())
+    return 0;
   const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
   if(map->pkn_count < 0)
     return -EINVAL;


### PR DESCRIPTION
With new code of kds2.0 and xbutil2, we see this issue:
1) uuid check is removed in kds2.0, icap has to check it.
2) ReportCu removed checking buf.empty() (xbutil.h has this checking) code which can cause segment fault.