### PR TITLE
Fast adapter descriptor memory maximum size 128KB

### DIFF
--- a/src/runtime_src/core/common/drv/fast_adapter.c
+++ b/src/runtime_src/core/common/drv/fast_adapter.c
@@ -79,12 +79,12 @@ static int cu_fa_peek_credit(void *core)
 static void cu_fa_configure(void *core, u32 *data, size_t sz, int type)
 {
 	struct xrt_cu_fa *cu_fa = core;
-	u32 *slot = cu_fa->plram + cu_fa->head_slot;
+	u32 *slot = cu_fa->cmdmem + cu_fa->head_slot;
 
-	/* avoid plram is not update properly */
-	WARN_ON(!cu_fa->plram);
+	/* in case cmdmem is not update properly */
+	WARN_ON(!cu_fa->cmdmem);
 
-	if (kds_echo || !cu_fa->plram)
+	if (kds_echo || !cu_fa->cmdmem)
 		return;
 
 	/* move commands to device quickly is the key of performance */
@@ -103,7 +103,7 @@ static void cu_fa_start(void *core)
 
 	cu_fa->run_cnts++;
 
-	if (kds_echo || !cu_fa->plram)
+	if (kds_echo || !cu_fa->cmdmem)
 		return;
 
 	/* The MSW of descriptor is fixed */
@@ -127,7 +127,7 @@ static void cu_fa_check(void *core, struct xcu_status *status)
 	u32 task_count;
 	u32 done = 0;
 
-	if (kds_echo || !cu_fa->plram) {
+	if (kds_echo || !cu_fa->cmdmem) {
 		cu_fa->run_cnts--;
 		status->num_done = 1;
 		status->num_ready = 1;
@@ -234,7 +234,7 @@ int xrt_cu_fa_init(struct xrt_cu *xcu)
 	 * Maybe in the future, we could initial all of the CU resource at this
 	 * place. Now, this is just to note that below variables will initial
 	 * when xclbin download finished and kds get update.
-	 *   core->plram
+	 *   core->cmdmem
 	 *   core->paddr
 	 *   core->head_slot
 	 *   core->num_slots

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -99,7 +99,7 @@ struct kds_ert {
 
 /* Fast adapter memory info */
 #define FA_MEM_MAX_SIZE 128 * 1024
-struct plram_info {
+struct cmdmem_info {
 	/* This is use for free bo, do not use it in shared code */
 	void		       *bo;
 	u64			bar_paddr;
@@ -133,7 +133,7 @@ struct kds_sched {
 	bool			ert_disable;
 	u32			cu_intr_cap;
 	u32			cu_intr;
-	struct plram_info	plram;
+	struct cmdmem_info	cmdmem;
 	struct completion	comp;
 };
 

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -97,6 +97,8 @@ struct kds_ert {
 	bool (* abort_done)(struct kds_ert *ert, struct kds_client *client, int cu_idx);
 };
 
+/* Fast adapter memory info */
+#define FA_MEM_MAX_SIZE 128 * 1024
 struct plram_info {
 	/* This is use for free bo, do not use it in shared code */
 	void		       *bo;

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -418,7 +418,7 @@ typedef struct {
 #define to_cu_fa(core) ((struct xrt_cu_fa *)(core))
 struct xrt_cu_fa {
 	void __iomem		*vaddr;
-	void __iomem		*plram;
+	void __iomem		*cmdmem;
 	u64			 paddr;
 	u32			 slot_sz;
 	u32			 num_slots;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -905,7 +905,7 @@ void kds_reset(struct kds_sched *kds)
 	kds->ini_disable = false;
 }
 
-static int kds_fa_assign_plram(struct kds_sched *kds)
+static int kds_fa_assign_cmdmem(struct kds_sched *kds)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
 	u32 total_sz = 0;
@@ -928,14 +928,14 @@ static int kds_fa_assign_plram(struct kds_sched *kds)
 
 	total_sz = round_up_to_next_power2(total_sz);
 
-	if (kds->plram.size < total_sz)
+	if (kds->cmdmem.size < total_sz)
 		return -EINVAL;
 
-	num_slots = kds->plram.size / total_sz;
+	num_slots = kds->cmdmem.size / total_sz;
 
-	bar_addr = kds->plram.bar_paddr;
-	dev_addr = kds->plram.dev_paddr;
-	vaddr = kds->plram.vaddr;
+	bar_addr = kds->cmdmem.bar_paddr;
+	dev_addr = kds->cmdmem.dev_paddr;
+	vaddr = kds->cmdmem.vaddr;
 	for (i = 0; i < cu_mgmt->num_cus; i++) {
 		if (!xrt_is_fa(cu_mgmt->xcus[i], &size))
 			continue;
@@ -962,8 +962,8 @@ int kds_cfg_update(struct kds_sched *kds)
 	kds->scu_mgmt.num_cus = 0;
 
 	/* Update PLRAM CU */
-	if (kds->plram.dev_paddr) {
-		ret = kds_fa_assign_plram(kds);
+	if (kds->cmdmem.dev_paddr) {
+		ret = kds_fa_assign_cmdmem(kds);
 		if (ret)
 			return -EINVAL;
 		/* ERT doesn't understand Fast adapter

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -510,8 +510,8 @@ int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr)
 
 /*
  * If KDS has to manage PLRAM resources, we should come up with a better design.
- * Ideally, CU subdevice should request for plram resource instead of KDS assign
- * plram resource to CU.
+ * Ideally, CU subdevice should request for cmdmem resource instead of KDS assign
+ * cmdmem resource to CU.
  * Or, another solution is to let KDS create CU subdevice indtead of
  * icap/zocl_xclbin.
  */
@@ -553,7 +553,7 @@ int xrt_fa_cfg_update(struct xrt_cu *xcu, u64 bar, u64 dev, void __iomem *vaddr,
 	u32 slot_size;
 
 	if (bar == 0) {
-		cu_fa->plram = NULL;
+		cu_fa->cmdmem = NULL;
 		cu_fa->paddr = 0;
 		cu_fa->slot_sz = 0;
 		cu_fa->num_slots = 0;
@@ -562,7 +562,7 @@ int xrt_fa_cfg_update(struct xrt_cu *xcu, u64 bar, u64 dev, void __iomem *vaddr,
 
 	slot_size = cu_fa_get_desc_size(xcu);
 
-	cu_fa->plram = vaddr;
+	cu_fa->cmdmem = vaddr;
 	cu_fa->paddr = dev;
 	cu_fa->slot_sz = slot_size;
 	cu_fa->num_slots = num_slots;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -428,15 +428,15 @@ void zocl_fini_sched(struct drm_zocl_dev *zdev)
 {
 	struct drm_zocl_bo *bo = NULL;
 
-	bo = zdev->kds.plram.bo;
+	bo = zdev->kds.cmdmem.bo;
 	if (bo)
 		zocl_drm_free_bo(bo);
-	zdev->kds.plram.bo = NULL;
+	zdev->kds.cmdmem.bo = NULL;
 
 	kds_fini_sched(&zdev->kds);
 }
 
-static void zocl_detect_fa_plram(struct drm_zocl_dev *zdev)
+static void zocl_detect_fa_cmdmem(struct drm_zocl_dev *zdev)
 {
 	struct ip_layout    *ip_layout = NULL;
 	struct drm_zocl_bo *bo = NULL;
@@ -483,11 +483,11 @@ static void zocl_detect_fa_plram(struct drm_zocl_dev *zdev)
 	base_addr = (uint64_t)bo->cma_base.paddr;	
 	vaddr = bo->cma_base.vaddr;	
 
-	zdev->kds.plram.bo = bo;
-	zdev->kds.plram.bar_paddr = bar_paddr;
-	zdev->kds.plram.dev_paddr = base_addr;
-	zdev->kds.plram.vaddr = vaddr;
-	zdev->kds.plram.size = size;
+	zdev->kds.cmdmem.bo = bo;
+	zdev->kds.cmdmem.bar_paddr = bar_paddr;
+	zdev->kds.cmdmem.dev_paddr = base_addr;
+	zdev->kds.cmdmem.vaddr = vaddr;
+	zdev->kds.cmdmem.size = size;
 }
 
 int zocl_kds_update(struct drm_zocl_dev *zdev)
@@ -495,17 +495,17 @@ int zocl_kds_update(struct drm_zocl_dev *zdev)
 	struct drm_zocl_bo *bo = NULL;
 	int i;
 
-	if (zdev->kds.plram.bo) {
-		bo = zdev->kds.plram.bo;
+	if (zdev->kds.cmdmem.bo) {
+		bo = zdev->kds.cmdmem.bo;
 		zocl_drm_free_bo(bo);
-		zdev->kds.plram.bo = NULL;
-		zdev->kds.plram.bar_paddr = 0;
-		zdev->kds.plram.dev_paddr = 0;
-		zdev->kds.plram.vaddr = 0;
-		zdev->kds.plram.size = 0;
+		zdev->kds.cmdmem.bo = NULL;
+		zdev->kds.cmdmem.bar_paddr = 0;
+		zdev->kds.cmdmem.dev_paddr = 0;
+		zdev->kds.cmdmem.vaddr = 0;
+		zdev->kds.cmdmem.size = 0;
 	}
 
-	zocl_detect_fa_plram(zdev);
+	zocl_detect_fa_cmdmem(zdev);
 	zdev->kds.cu_intr = 0;
 
 	for (i = 0; i < zdev->kds.cu_mgmt.num_cus; i++) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -819,6 +819,12 @@ static int xocl_detect_fa_plram(struct xocl_dev *xdev)
 
 	base_addr = mem_topo->m_mem_data[mem_idx].m_base_address;
 	size = mem_topo->m_mem_data[mem_idx].m_size * 1024;
+	/* Fast adapter could connect to any memory (DDR, PLRAM, HBM etc.).
+	 * A portion of memory would be reserved for descriptors.
+	 * Reserve entire memory if its size is smaller than FA_MEM_MAX_SIZE
+	 */
+	if (size > FA_MEM_MAX_SIZE)
+		size = FA_MEM_MAX_SIZE;
 	ret = xocl_p2p_get_bar_paddr(xdev, base_addr, size, &bar_paddr);
 	if (ret) {
 		userpf_err(xdev, "Cannot get p2p BAR address");
@@ -843,6 +849,9 @@ static int xocl_detect_fa_plram(struct xocl_dev *xdev)
 		ret = -ENOMEM;
 		goto done;
 	}
+
+	userpf_info(xdev, "fast adapter memory on bank(%d), size 0x%llx",
+		   mem_idx, size);
 
 	XDEV(xdev)->kds.plram.bo = bo;
 	XDEV(xdev)->kds.plram.bar_paddr = bar_paddr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -10,7 +10,7 @@
 #include <linux/workqueue.h>
 #include "common.h"
 #include "kds_core.h"
-/* Need detect fast adapter and find out plram
+/* Need detect fast adapter and find out cmdmem
  * Cound not avoid coupling xclbin.h
  */
 #include "xclbin.h"
@@ -46,15 +46,15 @@ static void xocl_kds_fa_clear(struct xocl_dev *xdev)
 {
 	struct drm_xocl_bo *bo = NULL;
 
-	if (XDEV(xdev)->kds.plram.bo) {
-		bo = XDEV(xdev)->kds.plram.bo;
-		iounmap(XDEV(xdev)->kds.plram.vaddr);
+	if (XDEV(xdev)->kds.cmdmem.bo) {
+		bo = XDEV(xdev)->kds.cmdmem.bo;
+		iounmap(XDEV(xdev)->kds.cmdmem.vaddr);
 		xocl_drm_free_bo(&bo->base);
-		XDEV(xdev)->kds.plram.bo = NULL;
-		XDEV(xdev)->kds.plram.bar_paddr = 0;
-		XDEV(xdev)->kds.plram.dev_paddr = 0;
-		XDEV(xdev)->kds.plram.vaddr = 0;
-		XDEV(xdev)->kds.plram.size = 0;
+		XDEV(xdev)->kds.cmdmem.bo = NULL;
+		XDEV(xdev)->kds.cmdmem.bar_paddr = 0;
+		XDEV(xdev)->kds.cmdmem.dev_paddr = 0;
+		XDEV(xdev)->kds.cmdmem.vaddr = 0;
+		XDEV(xdev)->kds.cmdmem.size = 0;
 	}
 }
 
@@ -697,9 +697,9 @@ void xocl_fini_sched(struct xocl_dev *xdev)
 {
 	struct drm_xocl_bo *bo = NULL;
 
-	bo = XDEV(xdev)->kds.plram.bo;
+	bo = XDEV(xdev)->kds.cmdmem.bo;
 	if (bo) {
-		iounmap(XDEV(xdev)->kds.plram.vaddr);
+		iounmap(XDEV(xdev)->kds.cmdmem.vaddr);
 		xocl_drm_free_bo(&bo->base);
 	}
 
@@ -758,7 +758,7 @@ static int xocl_kds_get_mem_idx(struct xocl_dev *xdev, int ip_index)
 	XOCL_GET_CONNECTIVITY(xdev, conn);
 
 	if (conn) {
-		/* The "last" argument of fast adapter would connect to plram */
+		/* The "last" argument of fast adapter would connect to cmdmem */
 		for (i = 0; i < conn->m_count; ++i) {
 			struct connection *connect = &conn->m_connection[i];
 			if (connect->m_ip_layout_index != ip_index)
@@ -776,7 +776,7 @@ static int xocl_kds_get_mem_idx(struct xocl_dev *xdev, int ip_index)
 	return mem_data_idx;
 }
 
-static int xocl_detect_fa_plram(struct xocl_dev *xdev)
+static int xocl_detect_fa_cmdmem(struct xocl_dev *xdev)
 {
 	struct ip_layout    *ip_layout = NULL;
 	struct mem_topology *mem_topo = NULL;
@@ -789,7 +789,7 @@ static int xocl_detect_fa_plram(struct xocl_dev *xdev)
 	ulong bar_paddr = 0;
 	int ret = 0;
 
-	/* Detect Fast adapter and descriptor plram
+	/* Detect Fast adapter and descriptor cmdmem
 	 * Assume only one PLRAM would be used for descriptor
 	 */
 	XOCL_GET_IP_LAYOUT(xdev, ip_layout);
@@ -809,7 +809,7 @@ static int xocl_detect_fa_plram(struct xocl_dev *xdev)
 		if (prot != FAST_ADAPTER)
 			continue;
 
-		/* TODO: consider if we could support multiple plram */
+		/* TODO: consider if we could support multiple cmdmem */
 		mem_idx = xocl_kds_get_mem_idx(xdev, i);
 		break;
 	}
@@ -853,11 +853,11 @@ static int xocl_detect_fa_plram(struct xocl_dev *xdev)
 	userpf_info(xdev, "fast adapter memory on bank(%d), size 0x%llx",
 		   mem_idx, size);
 
-	XDEV(xdev)->kds.plram.bo = bo;
-	XDEV(xdev)->kds.plram.bar_paddr = bar_paddr;
-	XDEV(xdev)->kds.plram.dev_paddr = base_addr;
-	XDEV(xdev)->kds.plram.vaddr = vaddr;
-	XDEV(xdev)->kds.plram.size = size;
+	XDEV(xdev)->kds.cmdmem.bo = bo;
+	XDEV(xdev)->kds.cmdmem.bar_paddr = bar_paddr;
+	XDEV(xdev)->kds.cmdmem.dev_paddr = base_addr;
+	XDEV(xdev)->kds.cmdmem.vaddr = vaddr;
+	XDEV(xdev)->kds.cmdmem.size = size;
 
 done:
 	XOCL_PUT_MEM_TOPOLOGY(xdev);
@@ -1104,9 +1104,9 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 
 	xocl_kds_fa_clear(xdev);
 
-	ret = xocl_detect_fa_plram(xdev);
+	ret = xocl_detect_fa_cmdmem(xdev);
 	if (ret) {
-		userpf_info(xdev, "Detect FA plram failed, ret %d", ret);
+		userpf_info(xdev, "Detect FA cmdmem failed, ret %d", ret);
 		goto out;
 	}
 


### PR DESCRIPTION
1. By default allocate 128K FA kernel command memory, if connected bank size smaller than 128K, allocate bank size.
2. replace plram with cmdmem to avoid confusing. Since the fast adapter memory type does not has to be plram.