### PR TITLE
xclbinutil: Added new options to add/replace and add/merge sections

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ParameterSectionData.cxx
+++ b/src/runtime_src/tools/xclbinutil/ParameterSectionData.cxx
@@ -144,10 +144,7 @@ ParameterSectionData::transformFormattedString(const std::string _formattedStrin
 
     // Is the section name is valid
     enum axlf_section_kind eKind;
-    if (Section::translateSectionKindStrToKind(m_section, eKind) == false) {
-      std::string errMsg = XUtil::format("Error: Section '%s' isn't a valid section name.", m_section.c_str());
-      throw std::runtime_error(errMsg);
-    }
+    Section::translateSectionKindStrToKind(m_section, eKind);
 
     // Does the section support subsections
     if (!m_subSection.empty() && (Section::supportsSubSections(eKind) == false)) {

--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -37,6 +37,7 @@ std::map<enum axlf_section_kind, std::string> Section::m_mapIdToName;
 std::map<std::string, enum axlf_section_kind> Section::m_mapNameToId;
 std::map<enum axlf_section_kind, Section::Section_factory> Section::m_mapIdToCtor;
 std::map<std::string, enum axlf_section_kind> Section::m_mapJSONNameToKind;
+std::map<enum axlf_section_kind, std::string> Section::m_mapKindToJSONName;
 std::map<enum axlf_section_kind, bool> Section::m_mapIdToSubSectionSupport;
 std::map<enum axlf_section_kind, bool> Section::m_mapIdToSectionIndexSupport;
 
@@ -115,6 +116,9 @@ Section::registerSectionCtor(enum axlf_section_kind _eKind,
 
   
   // At this point we know we are good, lets initialize the arrays
+  // TODO: These mappings are no longer scalable. 
+  //       Please refactor to a cleaner solution at the next earliest possibility.
+  m_mapKindToJSONName[_eKind] = _sHeaderJSONName;
   m_mapIdToName[_eKind] = _sKindStr;
   m_mapNameToId[_sKindStr] = _eKind;
   m_mapIdToCtor[_eKind] = _Section_factory;
@@ -185,6 +189,10 @@ Section::getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eK
   return true;
 }
 
+std::string
+Section::getJSONOfKind(enum axlf_section_kind _eKind) {
+  return m_mapKindToJSONName[_eKind];
+}
 
 Section*
 Section::createSectionObjectOfKind( enum axlf_section_kind _eKind, 

--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -126,14 +126,14 @@ Section::registerSectionCtor(enum axlf_section_kind _eKind,
   m_mapIdToSectionIndexSupport[_eKind] = _bSupportsIndexing;
 }
 
-bool
-Section::translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind)
+void
+Section::translateSectionKindStrToKind(const std::string & sKind, enum axlf_section_kind & eKind)
 {
-  if (m_mapNameToId.find(_sKindStr) == m_mapNameToId.end()) {
-    return false;   
+  if (m_mapNameToId.find(sKind) == m_mapNameToId.end()) {
+    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", sKind.c_str());
+    throw std::runtime_error(errMsg);
   }
-  _eKind = m_mapNameToId[_sKindStr];
-  return true;
+  eKind = m_mapNameToId[sKind];
 }
 
 bool

--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -237,7 +237,7 @@ Section::initXclBinSectionHeader(axlf_section_header& _sectionHeader) {
 }
 
 void
-Section::writeXclBinSectionBuffer(std::fstream& _ostream) const
+Section::writeXclBinSectionBuffer(std::ostream& _ostream) const
 {
   if ((m_pBuffer == nullptr) ||
       (m_bufferSize == 0)) {
@@ -519,7 +519,7 @@ Section::readXclBinBinary(std::fstream& _istream, enum FormatType _eFormatType)
 
 
 void 
-Section::dumpContents(std::fstream& _ostream, enum FormatType _eFormatType) const
+Section::dumpContents(std::ostream& _ostream, enum FormatType _eFormatType) const
 {
   switch (_eFormatType) {
   case FT_RAW:

--- a/src/runtime_src/tools/xclbinutil/Section.h
+++ b/src/runtime_src/tools/xclbinutil/Section.h
@@ -52,7 +52,7 @@ class Section {
  public:
   static void getKinds(std::vector< std::string > & kinds);
   static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind, const std::string _sIndexName = "");
-  static bool translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind);
+  static void translateSectionKindStrToKind(const std::string & sKind, enum axlf_section_kind & eKind);
   static bool getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind);
   static std::string getJSONOfKind(enum axlf_section_kind _eKind);
   static enum FormatType getFormatType(const std::string _sFormatType);

--- a/src/runtime_src/tools/xclbinutil/Section.h
+++ b/src/runtime_src/tools/xclbinutil/Section.h
@@ -82,10 +82,10 @@ class Section {
   bool getSubPayload(std::ostringstream &_buf, const std::string _sSubSection, enum Section::FormatType _eFormatType) const;
   void readSubPayload(std::fstream& _istream, const std::string & _sSubSection, enum Section::FormatType _eFormatType);
   virtual void initXclBinSectionHeader(axlf_section_header& _sectionHeader);
-  virtual void writeXclBinSectionBuffer(std::fstream& _ostream) const;
+  virtual void writeXclBinSectionBuffer(std::ostream& _ostream) const;
   virtual void appendToSectionMetadata(const boost::property_tree::ptree& _ptAppendData, boost::property_tree::ptree& _ptToAppendTo);
 
-  void dumpContents(std::fstream& _ostream, enum FormatType _eFormatType) const;
+  void dumpContents(std::ostream& _ostream, enum FormatType _eFormatType) const;
   void dumpSubSection(std::fstream& _ostream, std::string _sSubSection, enum FormatType _eFormatType) const;
 
   void getPayload(boost::property_tree::ptree& _pt) const;

--- a/src/runtime_src/tools/xclbinutil/Section.h
+++ b/src/runtime_src/tools/xclbinutil/Section.h
@@ -54,6 +54,7 @@ class Section {
   static Section* createSectionObjectOfKind(enum axlf_section_kind _eKind, const std::string _sIndexName = "");
   static bool translateSectionKindStrToKind(const std::string &_sKindStr, enum axlf_section_kind &_eKind);
   static bool getKindOfJSON(const std::string &_sJSONStr, enum axlf_section_kind &_eKind);
+  static std::string getJSONOfKind(enum axlf_section_kind _eKind);
   static enum FormatType getFormatType(const std::string _sFormatType);
   static bool supportsSubSections(enum axlf_section_kind &_eKind);
   static bool supportsSectionIndex(enum axlf_section_kind &_eKind);
@@ -125,6 +126,7 @@ class Section {
   static std::map<std::string, enum axlf_section_kind> m_mapNameToId;
   static std::map<enum axlf_section_kind, Section_factory> m_mapIdToCtor;
   static std::map<std::string, enum axlf_section_kind> m_mapJSONNameToKind;
+  static std::map<enum axlf_section_kind, std::string> m_mapKindToJSONName;
   static std::map<enum axlf_section_kind, bool> m_mapIdToSubSectionSupport;
   static std::map<enum axlf_section_kind, bool> m_mapIdToSectionIndexSupport;
 

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Xilinx, Inc
+ * Copyright (C) 2018-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -591,10 +591,7 @@ void
 XclBin::addReplaceSection(ParameterSectionData &_PSD)
 {
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind); 
 
   // Determine if the section exists, if so remove it
   const Section *pSection = findSection(eKind);
@@ -632,10 +629,7 @@ void
 XclBin::addMergeSection(ParameterSectionData & _PSD)
 {
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
   if (_PSD.getFormatType() != Section::FT_JSON) {
     std::string errMsg = "ERROR: Adding or merging of sections are only supported with the JSON format.";
@@ -752,10 +746,7 @@ XclBin::removeSection(const std::string & _sSectionToRemove)
 
   enum axlf_section_kind _eKind;
   
-  if (Section::translateSectionKindStrToKind(sectionName, _eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", sectionName.c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(sectionName, _eKind);
 
   if ((Section::supportsSectionIndex(_eKind) == true) && 
       (sectionIndexName.empty())) {
@@ -794,10 +785,7 @@ void
 XclBin::replaceSection(ParameterSectionData &_PSD)
 {
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
   Section *pSection = findSection(eKind);
   if (pSection == nullptr) {
@@ -898,10 +886,7 @@ XclBin::addSubSection(ParameterSectionData &_PSD)
 
   // Get the section kind
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name for the command: %s", _PSD.getSectionName().c_str(), _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
   // See if the section support sub-sections
   if (Section::supportsSubSections(eKind) == false) {
@@ -990,10 +975,7 @@ XclBin::addSection(ParameterSectionData &_PSD)
 
   // Get the section kind
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
   // Open the file to be read.
   std::string sSectionFileName = _PSD.getFile();
@@ -1222,10 +1204,7 @@ XclBin::dumpSubSection(ParameterSectionData &_PSD)
 
   // Get the section kind
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name for the command: %s", _PSD.getSectionName().c_str(), _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
   // See if the section support sub-sections
   if (Section::supportsSubSections(eKind) == false) {
@@ -1285,10 +1264,7 @@ XclBin::dumpSection(ParameterSectionData &_PSD)
   }
 
   enum axlf_section_kind eKind;
-  if (Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind) == false) {
-    std::string errMsg = XUtil::format("ERROR: Section '%s' isn't a valid section name.", _PSD.getSectionName().c_str());
-    throw std::runtime_error(errMsg);
-  }
+  Section::translateSectionKindStrToKind(_PSD.getSectionName(), eKind);
 
   const Section *pSection = findSection(eKind);
   if (pSection == nullptr) {

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -48,6 +48,7 @@ class XclBin {
   void removeSection(const std::string & _sSectionToRemove);
   void addSection(ParameterSectionData &_PSD);
   void addReplaceSection(ParameterSectionData &_PSD);
+  void addMergeSection(ParameterSectionData &_PSD);
   void addSections(ParameterSectionData &_PSD);
   void appendSections(ParameterSectionData &_PSD);
   void replaceSection(ParameterSectionData &_PSD);

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Xilinx, Inc
+ * Copyright (C) 2018-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.h
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.h
@@ -47,6 +47,7 @@ class XclBin {
   void writeXclBinBinary(const std::string &_binaryFileName, bool _bSkipUUIDInsertion);
   void removeSection(const std::string & _sSectionToRemove);
   void addSection(ParameterSectionData &_PSD);
+  void addReplaceSection(ParameterSectionData &_PSD);
   void addSections(ParameterSectionData &_PSD);
   void appendSections(ParameterSectionData &_PSD);
   void replaceSection(ParameterSectionData &_PSD);
@@ -72,7 +73,7 @@ class XclBin {
   void findAndReadMirrorData(std::fstream& _istream, boost::property_tree::ptree& _mirrorData) const;
   void readXclBinaryMirrorImage(std::fstream& _istream, const boost::property_tree::ptree& _mirrorData);
 
-  void writeXclBinBinaryMirrorData(std::fstream& _ostream, const boost::property_tree::ptree& _mirroredData) const;
+  void writeXclBinBinaryMirrorData(std::ostream& _ostream, const boost::property_tree::ptree& _mirroredData) const;
 
   void addHeaderMirrorData(boost::property_tree::ptree& _pt_header);
 
@@ -89,8 +90,8 @@ class XclBin {
  private:
   void readXclBinHeader(const boost::property_tree::ptree& _ptHeader, struct axlf& _axlfHeader);
   void readXclBinSection(std::fstream& _istream, const boost::property_tree::ptree& _ptSection);
-  void writeXclBinBinaryHeader(std::fstream& _ostream, boost::property_tree::ptree& _mirroredData);
-  void writeXclBinBinarySections(std::fstream& _ostream, boost::property_tree::ptree& _mirroredData);
+  void writeXclBinBinaryHeader(std::ostream& _ostream, boost::property_tree::ptree& _mirroredData);
+  void writeXclBinBinarySections(std::ostream& _ostream, boost::property_tree::ptree& _mirroredData);
 
 
  protected:

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2020 Xilinx, Inc
+ * Copyright (C) 2018-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -365,6 +365,11 @@ int main_(int argc, const char** argv) {
     }
 
     for (auto section : sectionsToAdd) {
+      ParameterSectionData psd(section);
+      inputFiles.push_back(psd.getFile());
+    }
+
+    for (auto section : sectionsToAddReplace) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
     }

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -354,39 +354,36 @@ int main_(int argc, const char** argv) {
   // Check to see if there any file conflicts
   std::vector< std::string> inputFiles;
   {
-    if (!sInputFile.empty()) {
-       inputFiles.push_back(sInputFile);
-    }
+    if (!sInputFile.empty()) 
+      inputFiles.push_back(sInputFile);
 
-    if (!sCertificate.empty()) {
-       inputFiles.push_back(sCertificate);
-    }
+    if (!sCertificate.empty()) 
+      inputFiles.push_back(sCertificate);
 
-    if (!sPrivateKey.empty()) {
-       inputFiles.push_back(sPrivateKey);
-    }
+    if (!sPrivateKey.empty()) 
+      inputFiles.push_back(sPrivateKey);
 
-    for (auto section : sectionsToAdd) {
+    for (const auto &section : sectionsToAdd) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
     }
 
-    for (auto section : sectionsToAddReplace) {
+    for (const auto &section : sectionsToAddReplace) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
     }
 
-    for (auto section : sectionsToAddMerge) {
+    for (const auto &section : sectionsToAddMerge) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
     }
 
-    for (auto section : sectionsToReplace ) {
+    for (const auto &section : sectionsToReplace ) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
     }
 
-    for (auto section : sectionsToAppend) {
+    for (const auto & section : sectionsToAppend) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
     }

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -159,6 +159,7 @@ int main_(int argc, const char** argv) {
 
   std::vector<std::string> sectionsToReplace;
   std::vector<std::string> sectionsToAdd;
+  std::vector<std::string> sectionsToAddReplace;
   std::vector<std::string> sectionsToRemove;
   std::vector<std::string> sectionsToDump;
   std::vector<std::string> sectionsToAppend;
@@ -187,8 +188,9 @@ int main_(int argc, const char** argv) {
 
       ("migrate-forward", boost::program_options::bool_switch(&bMigrateForward), "Migrate the xclbin archive forward to the new binary format.")
 
-      ("remove-section", boost::program_options::value<std::vector<std::string> >(&sectionsToRemove)->multitoken(), "Section name to remove.")
       ("add-section", boost::program_options::value<std::vector<std::string> >(&sectionsToAdd)->multitoken(), "Section name to add.  Format: <section>:<format>:<file>")
+      ("add-replace-section", boost::program_options::value<std::vector<std::string> >(&sectionsToAddReplace)->multitoken(), "Section name to add or replace.  Format: <section>:<format>:<file>")
+      ("remove-section", boost::program_options::value<std::vector<std::string> >(&sectionsToRemove)->multitoken(), "Section name to remove.")
       ("dump-section", boost::program_options::value<std::vector<std::string> >(&sectionsToDump)->multitoken(), "Section to dump. Format: <section>:<format>:<file>")
       ("replace-section", boost::program_options::value<std::vector<std::string> >(&sectionsToReplace)->multitoken(), "Section to replace. ")
 
@@ -477,6 +479,12 @@ int main_(int argc, const char** argv) {
   // -- Remove Sections --
   for (auto section : sectionsToRemove) 
     xclBin.removeSection(section);
+
+   // -- Add or Replace Sections --
+  for (auto section : sectionsToAddReplace) {
+    ParameterSectionData psd(section);
+    xclBin.addReplaceSection( psd );
+  }
 
   // -- Replace Sections --
   for (auto section : sectionsToReplace) {

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -160,6 +160,7 @@ int main_(int argc, const char** argv) {
   std::vector<std::string> sectionsToReplace;
   std::vector<std::string> sectionsToAdd;
   std::vector<std::string> sectionsToAddReplace;
+  std::vector<std::string> sectionsToAddMerge;
   std::vector<std::string> sectionsToRemove;
   std::vector<std::string> sectionsToDump;
   std::vector<std::string> sectionsToAppend;
@@ -190,6 +191,7 @@ int main_(int argc, const char** argv) {
 
       ("add-section", boost::program_options::value<std::vector<std::string> >(&sectionsToAdd)->multitoken(), "Section name to add.  Format: <section>:<format>:<file>")
       ("add-replace-section", boost::program_options::value<std::vector<std::string> >(&sectionsToAddReplace)->multitoken(), "Section name to add or replace.  Format: <section>:<format>:<file>")
+      ("add-merge-section", boost::program_options::value<std::vector<std::string> >(&sectionsToAddMerge)->multitoken(), "Section name to add or merge.  Format: <section>:<format>:<file>")
       ("remove-section", boost::program_options::value<std::vector<std::string> >(&sectionsToRemove)->multitoken(), "Section name to remove.")
       ("dump-section", boost::program_options::value<std::vector<std::string> >(&sectionsToDump)->multitoken(), "Section to dump. Format: <section>:<format>:<file>")
       ("replace-section", boost::program_options::value<std::vector<std::string> >(&sectionsToReplace)->multitoken(), "Section to replace. ")
@@ -374,6 +376,11 @@ int main_(int argc, const char** argv) {
       inputFiles.push_back(psd.getFile());
     }
 
+    for (auto section : sectionsToAddMerge) {
+      ParameterSectionData psd(section);
+      inputFiles.push_back(psd.getFile());
+    }
+
     for (auto section : sectionsToReplace ) {
       ParameterSectionData psd(section);
       inputFiles.push_back(psd.getFile());
@@ -485,7 +492,7 @@ int main_(int argc, const char** argv) {
   for (auto section : sectionsToRemove) 
     xclBin.removeSection(section);
 
-   // -- Add or Replace Sections --
+  // -- Add or Replace Sections --
   for (auto section : sectionsToAddReplace) {
     ParameterSectionData psd(section);
     xclBin.addReplaceSection( psd );
@@ -506,6 +513,12 @@ int main_(int argc, const char** argv) {
     } else {
       xclBin.addSection(psd);
     }
+  }
+
+  // -- Add or Merge Sections --
+  for (auto section : sectionsToAddMerge) {
+    ParameterSectionData psd(section);
+    xclBin.addMergeSection( psd );
   }
 
   // -- Append to Sections --

--- a/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
@@ -4,6 +4,9 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 // Simple Add Test
 TEST(AddSection, AddClearingBitstream) {
    XclBin xclBin;
@@ -140,15 +143,21 @@ TEST(AddSection, AddMergeIPLayout) {
    pSection->dumpContents(oDumpFile, Section::FT_JSON);
 
    // Validate the JSON images on disk
-   std::ifstream ioutput(outputFile);
    std::stringstream obuffer;
-   obuffer << ioutput.rdbuf();
-   
+   {
+      boost::property_tree::ptree ptOutput;
+      boost::property_tree::read_json(outputFile, ptOutput);
+      boost::property_tree::write_json(obuffer, ptOutput);
+   }
+
    boost::filesystem::path ip_layoutMergeExpect(TestUtilities::getResourceDir());
    ip_layoutMergeExpect /= "ip_layout_merged_expected.json";
-   std::ifstream iexpected(ip_layoutMergeExpect.string());
    std::stringstream ebuffer;
-   ebuffer << iexpected.rdbuf();
+   {
+      boost::property_tree::ptree ptExpected;
+      boost::property_tree::read_json(ip_layoutMergeExpect.string(), ptExpected);
+      boost::property_tree::write_json(ebuffer, ptExpected);
+   }
 
    ASSERT_TRUE(obuffer.str().compare(ebuffer.str()) == 0) 
       << "Unexpected JSON file produced." <<  std::endl 

--- a/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
+++ b/src/runtime_src/tools/xclbinutil/unittests/TestAddSection.cxx
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <boost/filesystem.hpp>
 
+// Simple Add Test
 TEST(AddSection, AddClearingBitstream) {
    XclBin xclBin;
   
@@ -22,7 +23,7 @@ TEST(AddSection, AddClearingBitstream) {
    const Section * pSection = xclBin.findSection(_eKind);
    ASSERT_EQ(pSection, nullptr) << "Section '" << sSection << "' found.";
 
-   // Remove Section
+   // Add Section
    const std::string formattedString = std::string("CLEARING_BITSTREAM:RAW:") + sampleXclbin.string();
    ParameterSectionData psd(formattedString);
    xclBin.addSection(psd);
@@ -30,6 +31,64 @@ TEST(AddSection, AddClearingBitstream) {
    // Check to see if section was removed
    pSection = xclBin.findSection(_eKind);
    ASSERT_NE(pSection, nullptr) << "Section  '" << sSection << "' was not added.";
+}
+
+// Add or replace test
+TEST(AddReplaceSection, AddReplaceClearingBitstream) {
+   XclBin xclBin;
+  
+   // We will be testing using the clearing bitstream section  
+   const std::string sSection = "CLEARING_BITSTREAM";
+   enum axlf_section_kind _eKind;
+   Section::translateSectionKindStrToKind(sSection, _eKind);
+
+   // Load the xclbin image of interest
+   boost::filesystem::path sampleXclbin(TestUtilities::getResourceDir());
+   sampleXclbin /= "sample_1_2018.2.xclbin";
+   xclBin.readXclBinBinary(sampleXclbin.string(), false /* bMigrateForward */);
+
+   // Check that the clearing bitstream" section does not exist
+   const Section * pSection = xclBin.findSection(_eKind);
+   ASSERT_EQ(pSection, nullptr) << "Section '" << sSection << "' found.";
+
+   {
+      // Add dummy unique data to the "clearning bitstream" section
+      boost::filesystem::path uniqueData1(TestUtilities::getResourceDir());
+      uniqueData1 /= "unique_data1.bin";
+
+      const std::string formattedString = sSection + ":RAW:" + uniqueData1.string();
+      ParameterSectionData psd(formattedString);
+      xclBin.addReplaceSection(psd);
+
+      // Check to see if section was added
+      pSection = xclBin.findSection(_eKind);
+      ASSERT_NE(pSection, nullptr) << "Section  '" << sSection << "' was not added.";
+   }
+
+   // Record the contents that was read in
+   std::ostringstream uniqueData1Contents;
+   pSection->dumpContents(uniqueData1Contents, Section::FT_RAW);
+
+   {
+      // Replace the contents of the "clearning bitstream" section
+      boost::filesystem::path uniqueData2(TestUtilities::getResourceDir());
+      uniqueData2 /= "unique_data2.bin";
+
+      const std::string formattedString = sSection + ":RAW:" + uniqueData2.string();
+      ParameterSectionData psd(formattedString);
+      xclBin.addReplaceSection(psd);
+
+      // Check to see if section is still there
+      pSection = xclBin.findSection(_eKind);
+      ASSERT_NE(pSection, nullptr) << "Section  '" << sSection << "' does not exist.";
+   }
+
+   // Record the contents that was read in
+   std::ostringstream uniqueData2Contents;
+   pSection->dumpContents(uniqueData2Contents, Section::FT_RAW);
+
+   // Validate the data is different
+   ASSERT_TRUE(uniqueData1Contents.str().compare(uniqueData2Contents.str())) << "Data contents was not replaced";
 }
 
 

--- a/src/runtime_src/tools/xclbinutil/unittests/test_data/ip_layout_base.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/test_data/ip_layout_base.json
@@ -1,0 +1,16 @@
+{
+    "ip_layout": {
+        "m_count": "1",
+        "m_ip_data": [
+            {
+                "m_type": "IP_KERNEL",
+                "properties": "0x0",
+                "m_int_enable": "1",
+                "m_interrupt_id": "0",
+                "m_ip_control": "AP_CTRL_HS",
+                "m_base_address": "0x1e00000",
+                "m_name": "rtl_krnl_vadd_const:rtl_krnl_vadd_const_1"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/test_data/ip_layout_merge.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/test_data/ip_layout_merge.json
@@ -1,0 +1,16 @@
+{
+    "ip_layout": {
+        "m_count": "1",
+        "m_ip_data": [
+            {
+                "m_type": "IP_KERNEL",
+                "properties": "0x0",
+                "m_int_enable": "1",
+                "m_interrupt_id": "0",
+                "m_ip_control": "AP_CTRL_HS",
+                "m_base_address": "0xFF00000",
+                "m_name": "rtl_krnl_vsub_const:rtl_krnl_vsub_const_1"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/test_data/ip_layout_merged_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/test_data/ip_layout_merged_expected.json
@@ -1,0 +1,23 @@
+{
+    "ip_layout": {
+        "m_count": "2",
+        "m_ip_data": [
+            {
+                "m_type": "IP_KERNEL",
+                "m_int_enable": "1",
+                "m_interrupt_id": "0",
+                "m_ip_control": "AP_CTRL_HS",
+                "m_base_address": "0x1e00000",
+                "m_name": "rtl_krnl_vadd_const:rtl_krnl_vadd_const_1"
+            },
+            {
+                "m_type": "IP_KERNEL",
+                "m_int_enable": "0",
+                "m_interrupt_id": "0",
+                "m_ip_control": "AP_CTRL_HS",
+                "m_base_address": "0xff00000",
+                "m_name": "rtl_krnl_vsub_const:rtl_krnl_vsub_const_1"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/test_data/unique_data1.bin
+++ b/src/runtime_src/tools/xclbinutil/unittests/test_data/unique_data1.bin
@@ -1,0 +1,2 @@
+File: unique_data1.bin
+Data: 491AFB6D32864C5F8A350BB0A1D2C9AF

--- a/src/runtime_src/tools/xclbinutil/unittests/test_data/unique_data2.bin
+++ b/src/runtime_src/tools/xclbinutil/unittests/test_data/unique_data2.bin
@@ -1,0 +1,2 @@
+File: unique_data2.bin
+Unique Data: 7A3EDE980F8742DCBE22A95620D9968D


### PR DESCRIPTION
With the introduction of v++ packaging, the is a need to "add or replace" and "add or merge" a section.   

Unfortunately, the current options only allow a more atomic operation such as adding, removing, replacing, or appending a section.  It doesn't allow for "adding or replacing" or "adding or removing" in the same operation.  To accomplish those operations, requires several calls to xclbinutil to determine the the presents of a section to determine the appropriate options to use. 

This pull request, introduces the following two new options:
- --add-replace-section : If the section is not present it will be added, else the existing section will be replace with the new section.
- --add-merge-section : If the section is not present it will be added. else this new data will be merged with it (if the section supports it)

Work Done
---------
+ Created a new option --add-replace-section
+ Created a new option --add-merge-section
+ Added support to add and/or remove sections
+ Added support to add and/or merge sections
+ Added unit tests to validate correct operations of this new functionality 
+ Refactored some methods to use std::ostream classes instead of std::fstream. Doing so allows for writing to an std::ostreamstream.