### PR TITLE
Remove invalid try catch

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -352,11 +352,7 @@ updateShellAndSC(unsigned int  boardIdx, DSAInfo& candidate, bool& reboot)
 
   if (!same_dsa) {
     std::cout << boost::format("[%s] : Updating base\n") % flasher.sGetDBDF();
-    try {
-      update_shell(boardIdx, candidate.file, candidate.file);
-    } catch (const xrt_core::error& e) {
-      std::cout << "NOTE: " << e.what() << std:: endl;
-    }
+    update_shell(boardIdx, candidate.file, candidate.file);
     reboot = true;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -128,7 +128,7 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         {
             std::string golden_file = getQspiGolden();
             if (golden_file.empty()) {
-                std::cout << "ERROR: Golden image not found in base package. Can't revert to golden" << std::endl;
+                std::cout << "ERROR: Can’t find the golden image in the installed base pkg. Please install the correct base pkg" << std::endl;
                 return -ECANCELED;
             }
             std::shared_ptr<firmwareImage> golden_image;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -540,7 +540,7 @@ int XQSPIPS_Flasher::revertToMFG(std::istream& binStream)
     enterOrExitFourBytesMode(ENTER_4B);
 
     if (verify(binStream, GOLDEN_BASE)) {
-	    std::cout << "[ERROR]: Doesn't find valid golden on flash. Can't revert to golden" << std::endl;
+	    std::cout << "[ERROR]: Factory reset not supported. No Golden image found on flash." << std::endl;
 	    return -ECANCELED;
     }
 


### PR DESCRIPTION
Issue: xbmgmt reports success even if the device fails to update
Fix: Remove the extra try-catch. The caller of this function already has a try/catch which handles device fails cleanly

Improve factory-reset error message handling