### PR TITLE
CR-1093277, CR-1094277 and xbmgmt report issues (cp to u30)

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -100,7 +100,6 @@ void  main_(int argc, char** argv,
 
   // Check to see if help was requested and no command was found
   if (vm.count("subCmd") == 0) {
-    std::cerr << "ERROR: " << "Please specify a valid command" << std::endl << std::endl;
     XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, _subCmds);
     return;
   }
@@ -108,11 +107,6 @@ void  main_(int argc, char** argv,
   // -- Now see if there is a command to work with
   // Get the command of choice
   std::string sCommand = vm["subCmd"].as<std::string>();
-
-  if (sCommand == "help") {
-    XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, _subCmds);
-    return;
-  }
 
   // Search for the subcommand (case sensitive)
   std::shared_ptr<SubCmd> subCommand;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -103,6 +103,12 @@ XBUtilities::setVerbose(bool _bVerbose)
     verbose("Enabling Verbosity");
 }
 
+bool 
+XBUtilities::getVerbose()
+{
+  return m_bVerbose;
+}
+
 void
 XBUtilities::setTrace(bool _bTrace)
 {
@@ -145,7 +151,7 @@ XBUtilities::is_esc_enabled() {
 
 
 void
-XBUtilities::message_(MessageType _eMT, const std::string& _msg, bool _endl)
+XBUtilities::message_(MessageType _eMT, const std::string& _msg, bool _endl, std::ostream & _ostream)
 {
   static std::map<MessageType, std::string> msgPrefix = {
     { MT_MESSAGE, "" },
@@ -173,17 +179,17 @@ XBUtilities::message_(MessageType _eMT, const std::string& _msg, bool _endl)
       return;
   }
 
-  std::cout << msgPrefix[_eMT] << _msg;
+  _ostream << msgPrefix[_eMT] << _msg;
 
   if (_endl == true) {
-    std::cout << std::endl;
+    _ostream << std::endl;
   }
 }
 
 void
-XBUtilities::message(const std::string& _msg, bool _endl)
+XBUtilities::message(const std::string& _msg, bool _endl, std::ostream & _ostream)
 {
-  message_(MT_MESSAGE, _msg, _endl);
+  message_(MT_MESSAGE, _msg, _endl, _ostream);
 }
 
 void

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <iostream>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
@@ -47,6 +48,7 @@ namespace XBUtilities {
    *                  false - disable verbosity (default)
    */
   void setVerbose(bool _bVerbose);
+  bool getVerbose();
   void setTrace(bool _bVerbose);
 
   void setShowHidden(bool _bShowHidden);
@@ -55,9 +57,9 @@ namespace XBUtilities {
   void disable_escape_codes( bool _disable );
   bool is_esc_enabled();  
 
-  void message_(MessageType _eMT, const std::string& _msg, bool _endl = true);
+  void message_(MessageType _eMT, const std::string& _msg, bool _endl = true, std::ostream & _ostream = std::cout);
 
-  void message(const std::string& _msg, bool _endl = true); 
+  void message(const std::string& _msg, bool _endl = true, std::ostream & _ostream = std::cout); 
   void info(const std::string& _msg, bool _endl = true);
   void warning(const std::string& _msg, bool _endl = true);
   void error(const std::string& _msg, bool _endl = true);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -352,11 +352,7 @@ updateShellAndSC(unsigned int  boardIdx, DSAInfo& candidate, bool& reboot)
 
   if (!same_dsa) {
     std::cout << boost::format("[%s] : Updating base\n") % flasher.sGetDBDF();
-    try {
-      update_shell(boardIdx, candidate.file, candidate.file);
-    } catch (const xrt_core::error& e) {
-      std::cout << "NOTE: " << e.what() << std:: endl;
-    }
+    update_shell(boardIdx, candidate.file, candidate.file);
     reboot = true;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -115,15 +115,17 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("type,r", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
-                                                                        "  hot          - Hot reset (default)\n"
-                                                                        "  kernel       - Kernel communication links\n" 
-                                                                        "  ert          - Reset management processor\n"
-                                                                        "  ecc          - Reset ecc memory\n"
-                                                                        "  soft-kernel  - Reset soft kernel")
+                                                                        "  hot          - Hot reset (default)\n")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");
+  hiddenOptions.add_options()
+    ("type,r", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
+                                                                        "  kernel       - Kernel communication links\n" 
+                                                                        "  ert          - Reset management processor\n"
+                                                                        "  ecc          - Reset ecc memory\n"
+                                                                        "  soft-kernel  - Reset soft kernel");
 
   po::options_description allOptions("All Options");
   allOptions.add(commonOptions);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -128,7 +128,7 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         {
             std::string golden_file = getQspiGolden();
             if (golden_file.empty()) {
-                std::cout << "ERROR: Golden image not found in base package. Can't revert to golden" << std::endl;
+                std::cout << "ERROR: Can’t find the golden image in the installed base pkg. Please install the correct base pkg" << std::endl;
                 return -ECANCELED;
             }
             std::shared_ptr<firmwareImage> golden_image;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -551,7 +551,7 @@ int XQSPIPS_Flasher::revertToMFG(std::istream& binStream)
     enterOrExitFourBytesMode(ENTER_4B);
 
     if (verify(binStream, GOLDEN_BASE)) {
-	    std::cout << "[ERROR]: Doesn't find valid golden on flash. Can't revert to golden" << std::endl;
+	    std::cout << "[ERROR]: Factory reset not supported. No Golden image found on flash." << std::endl;
 	    return -ECANCELED;
     }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -945,9 +945,18 @@ static void
 pretty_print_test_desc(const boost::property_tree::ptree& test, int test_idx,
                        size_t testSuiteSize, std::ostream & _ostream, const std::string& bdf)
 {
-  std::string test_desc = boost::str(boost::format("%d/%d Test #%d [%s]") % test_idx % testSuiteSize % test_idx % bdf);
-  _ostream << boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name");
-  _ostream << boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description");
+  if(test.get<std::string>("status", "").compare("skipped") != 0) {
+    std::string test_desc = boost::str(boost::format("Test %d/%d [%s]") % test_idx % testSuiteSize % bdf);
+    _ostream << boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name");
+    if(XBU::getVerbose())
+      XBU::message(boost::str(boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
+  }
+  else if(XBU::getVerbose()) {
+    std::string test_desc = boost::str(boost::format("Test %d/%d [%s]") % test_idx % testSuiteSize % bdf);
+    XBU::message(boost::str(boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name")));
+    XBU::message(boost::str(boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
+  }
+    
 }
 
 /*
@@ -958,14 +967,34 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
                       test_status& status, std::ostream & _ostream)
 {
   std::string _status = test.get<std::string>("status");
-  auto color = EscapeCodes::FGC_PASS;
+  std::string prev_tag = "";
   bool warn = false;
   bool error = false;
+
+  // if supported and details/error/warning: ostr
+  // if supported and xclbin/testcase: verbose
+  // if not supported: verbose
+  auto redirect_log = [&](std::string tag, std::string log_str) {
+    std::vector<std::string> verbose_tags = {"Xclbin", "Testcase"};
+    if(boost::iequals(_status, "skipped") || std::find(verbose_tags.begin(), verbose_tags.end(), tag) != verbose_tags.end()) {
+      if(XBU::getVerbose())
+        XBU::message(log_str, false, _ostream);
+      else
+        return;
+    }
+    else
+      _ostream << log_str;
+  };
 
   try {
     for (const auto& dict : test.get_child("log")) {
       for (const auto& kv : dict.second) {
-        _ostream<< boost::format("    %-24s: %s\n") % kv.first % kv.second.get_value<std::string>();
+        if (kv.first.compare(prev_tag)) {
+          prev_tag = kv.first;
+          redirect_log(kv.first, boost::str(boost::format("    %-24s: %s\n") % kv.first % kv.second.get_value<std::string>()));
+        }
+        else
+          redirect_log(kv.first, boost::str(boost::format("    %-24s  %s\n") % "\0" % kv.second.get_value<std::string>()));
         if (boost::iequals(kv.first, "warning"))
           warn = true;
         else if (boost::iequals(kv.first, "error"))
@@ -976,19 +1005,16 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   catch(...) {}
 
   if(error) {
-    color = EscapeCodes::FGC_FAIL;
     status = test_status::failed;
   }
   else if(warn) {
     _status.append(" with warnings");
-    color = EscapeCodes::FGC_WARN;
     status = test_status::warning;
   }
 
   boost::to_upper(_status);
-  _ostream << boost::format("    %-24s:") % "Test Status" << EscapeCodes::fgcolor(color).string() << boost::format(" [%s]\n") % _status
-            << EscapeCodes::fgcolor::reset();
-  _ostream << "-------------------------------------------------------------------------------" << std::endl;
+  redirect_log("", boost::str(boost::format("    %-24s: [%s]\n") % "Test Status" % _status));
+  redirect_log("", "-------------------------------------------------------------------------------\n");
 }
 
 /*
@@ -1023,7 +1049,8 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device, boost::proper
     _ostream << boost::format("Validate device[%s]\n") % _ptTree.get<std::string>("device_id");
     _ostream << boost::format("%-20s: %s\n") % "Platform" % _ptTree.get<std::string>("platform");
     _ostream << boost::format("%-20s: %s\n") % "SC Version" % _ptTree.get<std::string>("sc_version");
-    _ostream << boost::format("%-20s: %s\n\n") % "Platform ID" % _ptTree.get<std::string>("platform_id");
+    _ostream << boost::format("%-20s: %s\n") % "Platform ID" % _ptTree.get<std::string>("platform_id");
+    _ostream << "-------------------------------------------------------------------------------\n";
   }
 }
 
@@ -1047,16 +1074,29 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
   for (TestCollection * testPtr : testObjectsToRun) {
     boost::property_tree::ptree ptTest = testPtr->ptTest; // Create a copy of our entry
 
+    // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
+    // we need to print the test description before running the test
+    auto is_black_box_test = [ptTest]() {
+      std::vector<std::string> black_box_tests = {"Verify kernel", "Bandwidth kernel", "iops", "vcu"};
+      auto test = ptTest.get<std::string>("name");
+      return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
+    };
     if(schemaVersion == Report::SchemaVersion::text) {
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-      pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
+      if(is_black_box_test())
+        pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
     }
 
     testPtr->testHandle(device, ptTest);
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );
 
-    if(schemaVersion == Report::SchemaVersion::text)
+    if(schemaVersion == Report::SchemaVersion::text) {
+      auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
+      if(!is_black_box_test()) 
+        pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
       pretty_print_test_run(ptTest, status, _ostream);
+    }
+      
 
     // If a test fails, exit immediately
     if(status == test_status::failed) {


### PR DESCRIPTION
(https://github.com/Xilinx/XRT/pull/5087)
- CR-1093277 add xbutil validate --verbose option to hide skipped test
- CR-1094277 xbmgmt --help issues an error

(https://github.com/Xilinx/XRT/pull/5088) Issue: xbmgmt reports success even if the device fails to update
Fix: Remove the extra try-catch. The caller of this function already has a try/catch which handles device fails cleanly

Improve factory-reset error message handling