### PR TITLE
cherry-pick xbutil reset to u30

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -26,6 +26,7 @@
 
 // Internal shim function forward declarations
 int xclUpdateSchedulerStat(xclDeviceHandle handle);
+int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
 
 namespace xrt_core {
 
@@ -113,6 +114,9 @@ struct ishim
   
   virtual
   void update_scheduler_status() = 0;
+
+  virtual void
+  user_reset(xclResetKind kind) = 0;
 
 #ifdef XRT_ENABLE_AIE
   virtual xclGraphHandle
@@ -376,6 +380,13 @@ struct shim : public DeviceType
   {
     if (auto ret = xclUpdateSchedulerStat(DeviceType::get_device_handle()))
       throw error(ret, "failed to update scheduler status");
+  }
+
+  virtual void
+  user_reset(xclResetKind kind)
+  {
+    if (auto ret = xclInternalResetDevice(DeviceType::get_device_handle(), kind))
+      throw error(ret, "failed to reset device");
   }
 
 #ifdef XRT_ENABLE_AIE

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -169,6 +169,7 @@ enum class key_type
   vcc_aux_pmc_millivolts,
   vcc_ram_millivolts,
   int_vcc_io_millivolts,
+  v0v9_int_vcc_vcu_millivolts,
   mac_contiguous_num,
   mac_addr_first,
   mac_addr_list,
@@ -1814,6 +1815,21 @@ struct int_vcc_io_millivolts : request
 {
   using result_type = uint64_t;
   static const key_type key = key_type::int_vcc_io_millivolts;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  static std::string
+  to_string(result_type value)
+  {
+    return std::to_string(value);
+  }
+};
+
+struct v0v9_int_vcc_vcu_millivolts : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::v0v9_int_vcc_vcu_millivolts;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/common/query_reset.h
+++ b/src/runtime_src/core/common/query_reset.h
@@ -36,7 +36,8 @@ enum class reset_key {
   ert = 3,
   ecc = 4,
   soft_kernel = 5,
-  aie = 6
+  aie = 6,
+  user = 7
 };
 
 class reset_type {

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -600,6 +600,12 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
   return -ENOSYS;
 }
 
+int 
+xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+  return -ENOSYS;
+}
+
 /*
  * API to get number of live processes.
  * Applicable only for System Flow as it supports Multiple processes on same device.

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -2047,7 +2047,7 @@ xclGetDebugProfileDeviceInfo(xclDeviceHandle handle, xclDebugProfileDeviceInfo* 
 }
 
 int
-xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
+_xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
   return 0;
 }
@@ -2319,6 +2319,12 @@ int
 xclUpdateSchedulerStat(xclDeviceHandle handle)
 {
   return 1; // -ENOSYS;
+}
+
+int 
+xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+  return -ENOSYS;
 }
 
 int

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -649,6 +649,12 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
   return -ENOSYS;
 }
 
+int 
+xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+  return -ENOSYS;
+}
+
 int
 xclUpdateSchedulerStat(xclDeviceHandle handle)
 {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -541,6 +541,12 @@ xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
   return -ENOSYS;
 }
 
+int 
+xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+  return -ENOSYS;
+}
+
 int
 xclUpdateSchedulerStat(xclDeviceHandle handle)
 {

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -514,6 +514,7 @@ initialize_query_table()
   emplace_sysfs_get<query::hbm_1v2_millivolts>                 ("xmc", "xmc_hbm_1v2_vol");
   emplace_sysfs_get<query::v2v5_vpp_millivolts>                ("xmc", "xmc_vpp2v5_vol");
   emplace_sysfs_get<query::int_vcc_io_millivolts>              ("xmc", "xmc_vccint_bram_vol");
+  emplace_sysfs_get<query::v0v9_int_vcc_vcu_millivolts>        ("xmc", "xmc_vccint_vcu_0v9");
   emplace_sysfs_get<query::mac_contiguous_num>                 ("xmc", "mac_contiguous_num");
   emplace_sysfs_get<query::mac_addr_first>                     ("xmc", "mac_addr_first");
   emplace_sysfs_get<query::oem_id>                             ("xmc", "xmc_oem_id");

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2512,6 +2512,13 @@ int xclUnlockDevice(xclDeviceHandle handle)
 
 int xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
+    return xclInternalResetDevice(handle, kind);
+}
+
+int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+    // NOTE: until xclResetDevice is made completely internal,
+    // this wrapper is being used to limit the pragma use to this file
     xocl::shim *drv = xocl::shim::handleCheck(handle);
     return drv ? drv->resetDevice(kind) : -ENODEV;
 }

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -594,3 +594,9 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
 {
   return 1; // -ENOSYS;
 }
+
+int 
+xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+  return 1; // -ENOSYS;
+}

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1715,3 +1715,10 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
 {
   return 1; // -ENOSYS;
 }
+
+int 
+xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
+{
+  return 1; // -ENOSYS;
+}
+

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -143,6 +143,8 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
     populate_sensor<qr::vcc_aux_pmc_millivolts, qr::noop>(_pDevice, "vcc_aux_pmc", "Vcc Auxillary Pmc")));
   sensor_array.push_back(std::make_pair("", 
     populate_sensor<qr::vcc_ram_millivolts, qr::noop>(_pDevice, "vcc_ram", "Vcc Ram")));
+  sensor_array.push_back(std::make_pair("", 
+    populate_sensor<qr::v0v9_int_vcc_vcu_millivolts, qr::noop>(_pDevice, "0v9_vccint_vcu", "0.9 Volts Vcc Vcu")));
   
   pt.add_child("power_rails", sensor_array);
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -717,7 +717,8 @@ static const std::map<std::string, xrt_core::query::reset_type> reset_map = {
     { "ert", xrt_core::query::reset_type(xrt_core::query::reset_key::ert, "ERT Reset", "", "mgmt_reset", "", "3") },
     { "ecc", xrt_core::query::reset_type(xrt_core::query::reset_key::ecc, "ECC Reset", "", "ecc_reset", "", "4") },
     { "soft-kernel", xrt_core::query::reset_type(xrt_core::query::reset_key::soft_kernel, "SOFT KERNEL Reset", "", "mgmt_reset", "", "5") },
-    { "aie", xrt_core::query::reset_type(xrt_core::query::reset_key::aie, "AIE Reset", "", "mgmt_reset", "", "6") }
+    { "aie", xrt_core::query::reset_type(xrt_core::query::reset_key::aie, "AIE Reset", "", "mgmt_reset", "", "6") },
+    { "user", xrt_core::query::reset_type(xrt_core::query::reset_key::user, "HOT Reset", "", "", "", "") },
   };
 
 xrt_core::query::reset_type

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -39,27 +39,14 @@ declare -A VALOPT=( \
     )
 
 # Table to resolve reset sub-command based on switch passed to reset
-#declare -A RSTOPT=( \
-#        ["--device"]="XBUTIL2" \
-#        ["--type"]="XBUTIL2" \
-#        ["--help"]="XBUTIL2" \
-#        ["-d"]="DEVICE" \
-#        ["-r"]="XBUTIL2" \
-#        ["-h"]="XBUTIL2" \
-#    )
-
-# Switch to the table above once xbutil reset is implemented by the
-# next generation tool. For now redirect all reset requests to classic
-# tool
-
 declare -A RSTOPT=( \
-        ["--device"]="XBUTIL" \
-        ["--type"]="XBUTIL" \
-        ["--help"]="XBUTIL" \
-        ["-d"]="XBUTIL" \
-        ["-r"]="XBUTIL" \
-        ["-h"]="XBUTIL" \
-    )
+       ["--device"]="XBUTIL2" \
+       ["--type"]="XBUTIL2" \
+       ["--help"]="XBUTIL2" \
+       ["-d"]="DEVICE" \
+       ["-r"]="XBUTIL2" \
+       ["-h"]="XBUTIL2" \
+   )
 
 # Table to resolve program sub-command based on switch passed to program
 declare -A PROGOPT=( \


### PR DESCRIPTION
(https://github.com/Xilinx/XRT/pull/5072)
- CR-1077374 xbutil --new reset errors out
- CR-1090281 xbutil2 - u30 - missing sensor: VCCINT_VCU_0V9
- Addtional notes:
  - Removed AIE reset related code as it is not functional at the moment 
  - Refactored the code to contain pragmas within shim.cpp
```
$ xbutil reset -d 43:00                      
-----------------------------------------------------
 Invoking next generation of the xbutil application  
-----------------------------------------------------
Performing 'HOT Reset' on                            
  -[0000:43:00.1]                                    
Are you sure you wish to proceed? [Y/n]: y           
Card level reset. This will reset all FPGAs on the card.
Successfully reset Device[0000:43:00.1] 
```