### PR TITLE
XRT-870 xclIPName2Index should get CU index from driver instead of calculate again

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -258,6 +258,10 @@ struct kds_cu_stat
       throw std::runtime_error(errmsg);
 
     result_type cuStats;
+    // stats e.g.
+    // 0,vadd:vadd_1,0x1400000,0x4,0
+    // 1,vadd:vadd_2,0x1500000,0x4,0
+    // 2,mult:mult_1,0x1800000,0x4,0
     for (auto& line : stats) {
       boost::char_separator<char> sep(",");
       tokenizer tokens(line, sep);
@@ -266,7 +270,7 @@ struct kds_cu_stat
         throw std::runtime_error("CU statistic sysfs node corrupted");
 
       data_type data;
-      const int radix = 16;
+      constexpr int radix = 16;
       tokenizer::iterator tok_it = tokens.begin();
       data.index     = std::stoi(std::string(*tok_it++));
       data.name      = std::string(*tok_it++);
@@ -274,7 +278,7 @@ struct kds_cu_stat
       data.status    = std::stoul(std::string(*tok_it++), nullptr, radix);
       data.usages    = std::stoul(std::string(*tok_it++));
 
-      cuStats.push_back(data);
+      cuStats.push_back(std::move(data));
     }
 
     return cuStats;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include <boost/format.hpp>
+#include <boost/tokenizer.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -232,6 +233,51 @@ struct aie_shim_info : aie_metadata
     boost::property_tree::write_json(oss, pt);
     std::string inifile_text = oss.str();
     return inifile_text;
+  }
+};
+
+struct kds_cu_stat
+{
+  using result_type = query::kds_cu_stat::result_type;
+  using data_type = query::kds_cu_stat::data_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    auto edev = get_edgedev(device);
+
+    using tokenizer = boost::tokenizer< boost::char_separator<char> >;
+    std::vector<std::string> stats;
+    std::string errmsg;
+
+    // The kds_custat_raw is printing in formatted string of each line
+    // Format: "%d,%s:%s,0x%lx,0x%x,%lu"
+    // Using comma as separator.
+    edev->sysfs_get("kds_custat_raw", errmsg, stats);
+    if (!errmsg.empty())
+      throw std::runtime_error(errmsg);
+
+    result_type cuStats;
+    for (auto& line : stats) {
+      boost::char_separator<char> sep(",");
+      tokenizer tokens(line, sep);
+
+      if (std::distance(tokens.begin(), tokens.end()) != 5)
+        throw std::runtime_error("CU statistic sysfs node corrupted");
+
+      data_type data;
+      const int radix = 16;
+      tokenizer::iterator tok_it = tokens.begin();
+      data.index     = std::stoi(std::string(*tok_it++));
+      data.name      = std::string(*tok_it++);
+      data.base_addr = std::stoull(std::string(*tok_it++), nullptr, radix);
+      data.status    = std::stoul(std::string(*tok_it++), nullptr, radix);
+      data.usages    = std::stoul(std::string(*tok_it++));
+
+      cuStats.push_back(data);
+    }
+
+    return cuStats;
   }
 };
 
@@ -507,6 +553,9 @@ initialize_query_table()
   emplace_func0_request<query::pcie_bdf,                bdf>();
   emplace_func0_request<query::board_name,              board_name>();
   emplace_func0_request<query::is_ready,                is_ready>();
+
+  emplace_sysfs_get<query::kds_mode>                    ("kds_mode");
+  emplace_func0_request<query::kds_cu_stat,             kds_cu_stat>();
 }
 
 struct X { X() { initialize_query_table(); } };

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -928,21 +928,9 @@ int
 shim::
 xclIPName2Index(const char *name)
 {
-  std::string errmsg;
-  std::vector<char> buf;
-  uint32_t kds_mode = 0;
-  const uint64_t bad_addr = 0xffffffffffffffff;
-
-  kds_mode = xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice);
   /* In new kds, driver determines CU index */
-  if (kds_mode) {
-    std::vector<xrt_core::query::kds_cu_stat::data_type> custats;
-
-    custats = xrt_core::device_query<xrt_core::query::kds_cu_stat>(mCoreDevice);
-    if (custats.empty())
-      return -ENOENT;
-
-    for (auto& stat : custats) {
+  if (xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice)) {
+    for (auto& stat : xrt_core::device_query<xrt_core::query::kds_cu_stat>(mCoreDevice)) {
       if (stat.name != name)
         continue;
 
@@ -952,6 +940,11 @@ xclIPName2Index(const char *name)
     xclLog(XRT_ERROR, "%s not found", name);
     return -ENOENT;
   }
+
+  /* Old kds is enabled */
+  std::string errmsg;
+  std::vector<char> buf;
+  const uint64_t bad_addr = 0xffffffffffffffff;
 
   mDev->sysfs_get("ip_layout", errmsg, buf);
   if (!errmsg.empty()) {

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -26,6 +26,7 @@
 #include "core/include/xcl_perfmon_parameters.h"
 #include "core/common/bo_cache.h"
 #include "core/common/config_reader.h"
+#include "core/common/query_requests.h"
 #include "core/common/error.h"
 
 #include <cerrno>
@@ -929,7 +930,28 @@ xclIPName2Index(const char *name)
 {
   std::string errmsg;
   std::vector<char> buf;
+  uint32_t kds_mode = 0;
   const uint64_t bad_addr = 0xffffffffffffffff;
+
+  kds_mode = xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice);
+  /* In new kds, driver determines CU index */
+  if (kds_mode) {
+    std::vector<xrt_core::query::kds_cu_stat::data_type> custats;
+
+    custats = xrt_core::device_query<xrt_core::query::kds_cu_stat>(mCoreDevice);
+    if (custats.empty())
+      return -ENOENT;
+
+    for (auto& stat : custats) {
+      if (stat.name != name)
+        continue;
+
+      return stat.index;
+    }
+
+    xclLog(XRT_ERROR, "%s not found", name);
+    return -ENOENT;
+  }
 
   mDev->sysfs_get("ip_layout", errmsg, buf);
   if (!errmsg.empty()) {


### PR DESCRIPTION
Before this change, xclIPName2Index() would calculate CU index.

But in new KDS, driver determines CU index. User space should get index from driver.
This is only for hw and no impact for emulation.