### PR TITLE
CR-1091955 See "soft lockup " on RH78 management VM

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ospi_versal.c
@@ -234,6 +234,10 @@ static ssize_t xfer_versal_transfer(struct xfer_versal *xv, const char *data,
 		/* Give up CPU to avoid taking too much CPU cycles */
 		schedule();
 
+		/* We don't need to wait for IDLE status for last packet */
+		if (pkt.pkt_flags & XRT_XFR_PKT_FLAGS_LAST)
+			continue;
+
 		/*
 		 * Wait until the data is fetched by device side
 		 * Set timeout to one second. It should be sufficient


### PR DESCRIPTION
When loading XCLBIN, there is a race condition for host xclmgmt driver to wait for IDLE (single packet) and then DONE (whole xclbin blob). In a corner case that IDLE and then DONE are set by device zocl driver before xclmgmt start to wait for IDLE. So host driver will never get IDLE signal.

The fix is, actually, for last packet, host driver does not need to wait for IDLE because no new data need to be transferred. Host can wait for done directly.