### PR TITLE
CR-1093815 zc706 Embedded host run failed, RC=139

### DIFF
--- a/src/runtime_src/core/common/api/exec.h
+++ b/src/runtime_src/core/common/api/exec.h
@@ -108,6 +108,7 @@ unmanaged_wait(const command* cmd);
 void
 start();
 
+XRT_CORE_COMMON_EXPORT
 void
 stop();
 

--- a/src/runtime_src/core/common/api/kds.cpp
+++ b/src/runtime_src/core/common/api/kds.cpp
@@ -297,7 +297,7 @@ public:
 static std::map<const xrt_core::device*, std::unique_ptr<kds_device>> kds_devices;
 
 // Get or create kds_device object from core device
-kds_device*
+static kds_device*
 get_kds_device(xrt_core::device* device)
 {
   auto itr = kds_devices.find(device);
@@ -310,7 +310,7 @@ get_kds_device(xrt_core::device* device)
 
 // Get or existing kds_device object from core device.  Throw if
 // kds_device object does not exist (internal error).
-kds_device*
+static kds_device*
 get_kds_device_or_error(const xrt_core::device* device)
 {
   auto itr = kds_devices.find(device);
@@ -321,7 +321,7 @@ get_kds_device_or_error(const xrt_core::device* device)
 
 // Get kds_device from command object.  Throws if kds_device
 // doesn't exist
-kds_device*
+static kds_device*
 get_kds_device(const xrt_core::command* cmd)
 {
   return get_kds_device_or_error(cmd->get_device());
@@ -376,7 +376,10 @@ start()
 
 void
 stop()
-{}
+{
+  kds_devices.clear();
+}
+
 
 // Create and initialize a kds_device object from a core device.
 void

--- a/src/runtime_src/xocl/core/platform.cpp
+++ b/src/runtime_src/xocl/core/platform.cpp
@@ -19,6 +19,7 @@
 #include "debug.h"
 
 #include "xocl/xclbin/xclbin.h"
+#include "core/common/api/exec.h"
 
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
@@ -117,6 +118,10 @@ platform::
 {
   XOCL_DEBUG(std::cout,"xocl::platform::~platform(",m_uid,")\n");
   try {
+    // static global destruction
+    // synchronize with execution monitor thread which
+    // may be in the process of notifying completed events
+    xrt_core::exec::stop();
     g_platform = nullptr;
   }
   catch (const std::exception& ex) {


### PR DESCRIPTION
Fix OCL synchronization error at application exit.  The global
platform destructor must wait for orderly finish of event notification
via command monitor.