### PR TITLE
CR-1095761: Fixing missing compute unit utilization information in OpenCL profile summary

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -40,7 +40,7 @@ namespace xdp {
   {
   public:
     // For messages sent to specific plugins
-    enum MessageType { READ_COUNTERS } ;
+    enum MessageType { READ_COUNTERS, READ_TRACE } ;
 
   private:
     // The information stored in the database will be separated into 

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
@@ -70,6 +70,9 @@ class DeviceEventCreatorFromTrace
                                   uint32_t slot, int32_t cuId,
                                   double hostTimestamp) ;
 
+  void addCUEndEvent(double hostTimestamp, uint64_t deviceTimestamp,
+                     uint32_t s, int32_t cuId);
+
   // Functions for handling dropped device packets
   void addApproximateCUEndEvents();
   void addApproximateDataTransferEndEvents();

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -370,6 +370,10 @@ namespace xdp {
         readCounters() ;
       }
       break ;
+    case VPDatabase::READ_TRACE:
+      {
+        readTrace() ;
+      }
     default:
       break ;
     }

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.h
@@ -72,6 +72,7 @@ namespace xdp {
     XDP_EXPORT void startContinuousThreads(uint64_t deviceId) ;
 
     XDP_EXPORT void readCounters() ;
+    XDP_EXPORT virtual void readTrace() = 0 ;
     XDP_EXPORT void printTraceWarns(DeviceTraceOffload* offloader) ;
 
   public:

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.h
@@ -40,6 +40,8 @@ namespace xdp {
     std::vector<void*> deviceHandles ;
     std::map<uint64_t, void*> deviceIdToHandle ;
 
+    XDP_EXPORT virtual void readTrace() ;
+
   public:
     XDP_EXPORT HALDeviceOffloadPlugin() ;
     XDP_EXPORT ~HALDeviceOffloadPlugin() ;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.h
@@ -44,6 +44,8 @@ namespace xdp {
     void updateOpenCLInfo(uint64_t deviceId) ;
     void updateSWEmulationGuidance() ;
 
+    XDP_EXPORT virtual void readTrace() ;
+
   public:
     XDP_EXPORT OpenCLDeviceOffloadPlugin() ;
     XDP_EXPORT ~OpenCLDeviceOffloadPlugin() ;

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -52,8 +52,9 @@ namespace xdp {
       //  so be sure to account for any peculiarities here.
       emulationSetup() ;
 
-      // Before writing, make sure that counters are read.
+      // Before writing, make sure that counters are read and trace is processed
       db->broadcast(VPDatabase::READ_COUNTERS, nullptr) ;
+      db->broadcast(VPDatabase::READ_TRACE, nullptr) ;
       for (auto w : writers)
       {
 	w->write(false) ;

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -554,11 +554,12 @@ namespace xdp {
 	{
 	  uint64_t amSlotID = (uint64_t)((cuInfo.second)->getAccelMon()) ;
 
-    // Stats don't make sense if runtime or executions = 0
-    if ((values.CuBusyCycles[amSlotID] == 0) || (values.CuExecCount[amSlotID] == 0))
-      continue;
+          // Stats don't make sense if runtime or executions = 0
+          if ((values.CuBusyCycles[amSlotID] == 0) ||
+              (values.CuExecCount[amSlotID] == 0))
+            continue;
 
-    // This info is the same for every execution call
+          // This info is the same for every execution call
 	  std::string cuName = (cuInfo.second)->getName() ;
 	  std::string kernelName = (cuInfo.second)->getKernelName() ;
 	  std::string cuLocalDimensions = (cuInfo.second)->getDim() ;


### PR DESCRIPTION
In order to properly print out compute unit utilization, the following two changes needed to be made:

1. Added statistics logging when approximating CU end events.  Previously we added the approximate end events but did not update the statistics so we would not print out information on those compute unit executions.
2. Force the reading and processing of trace to happen before the dumping of the summary file if possible.  Since the different plugins can be destroyed at the end of execution in non-deterministic order, this pull request adds an explicit broadcast call to force the reading of trace if it hadn't already been done at the end of execution 