### PR TITLE
create CU subdev for ap_ctrl_none cu

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -344,7 +344,6 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	core->done = 0;
 	core->ready = 0;
 
-	xcu->status = cu_read32(core, CTRL);
 	xcu->core = core;
 	xcu->funcs = &xrt_cu_hls_funcs;
 
@@ -352,6 +351,14 @@ int xrt_cu_hls_init(struct xrt_cu *xcu)
 	xcu->interval_min = 2;
 	xcu->interval_max = 5;
 
+	/* No control and interrupt registers in ap_ctrl_none protocol.
+	 * In this case, return here for creating CU sub-dev. No need to setup
+	 * CU thread and queues.
+	 */
+	if (xcu->info.protocol == CTRL_NONE)
+		return  0;
+
+	xcu->status = cu_read32(core, CTRL);
 	err = xrt_cu_init(xcu);
 	if (err)
 		return err;

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -377,6 +377,7 @@ bool xrt_cu_abort_done(struct xrt_cu *xcu, struct kds_client *client);
 int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr);
 int xrt_fa_cfg_update(struct xrt_cu *xcu, u64 bar, u64 dev, void __iomem *vaddr, u32 num_slots);
 int xrt_is_fa(struct xrt_cu *xcu, u32 *size);
+int xrt_cu_get_protocol(struct xrt_cu *xcu);
 
 int  xrt_cu_init(struct xrt_cu *xcu);
 void xrt_cu_fini(struct xrt_cu *xcu);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -237,6 +237,11 @@ acquire_cu_idx(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 	}
 
 out:
+	if (xrt_cu_get_protocol(cu_mgmt->xcus[index]) == CTRL_NONE) {
+		kds_err(client, "Cannot submit command to ap_ctrl_none CU");
+		return -EINVAL;
+	}
+
 	cu_stat_inc(cu_mgmt, usage[index]);
 	client_stat_inc(client, s_cnt[index]);
 	xcmd->cu_idx = index;

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -573,6 +573,11 @@ int xrt_fa_cfg_update(struct xrt_cu *xcu, u64 bar, u64 dev, void __iomem *vaddr,
 	return 0;
 }
 
+int xrt_cu_get_protocol(struct xrt_cu *xcu)
+{
+	return xcu->info.protocol;
+}
+
 int xrt_cu_init(struct xrt_cu *xcu)
 {
 	int err = 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -383,6 +383,7 @@ zocl_create_cu(struct drm_zocl_dev *zdev)
 		switch (info.protocol) {
 		case CTRL_HS:
 		case CTRL_CHAIN:
+		case CTRL_NONE:
 			info.model = XCU_HLS;
 			break;
 		case CTRL_FA:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -252,12 +252,14 @@ static int cu_probe(struct platform_device *pdev)
 	switch (info->protocol) {
 	case CTRL_HS:
 	case CTRL_CHAIN:
+	case CTRL_NONE:
 		xcu->base.info.model = XCU_HLS;
 		break;
 	case CTRL_FA:
 		xcu->base.info.model = XCU_FA;
 		break;
 	default:
+		XCU_ERR(xcu, "Unknown protocol");
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
1. Create CU sub-device for ap_ctrl_none cu. This would allow user to use xclRegRead/xclRegWrite to access CU
2. Submit command to ap_ctrl_none CU through KDS is an invalid use case. xclExecBuf would return error.