### PR TITLE
Bug Fix: xbmgmt examine command didn't check for existance of directory

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -430,7 +430,10 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
     // Obtain installed DSA info.
     std::vector<boost::filesystem::path> fw_dirs(FIRMWARE_DIRS);
     for (auto& root : fw_dirs) {
-        if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root))
+        if (!boost::filesystem::exists(root))
+            continue;
+
+        if (!boost::filesystem::is_directory(root))
             continue;
 
         boost::filesystem::recursive_directory_iterator end_iter;


### PR DESCRIPTION
The search algorithm for platforms examines a collection of root platform directions.  Depending on the compiler, there is a chance where checking of the directory existance is being performed prior to determine if the path was a directory or file.  When this occurs an exception is thrown.

This fix assures that doesn't happen.