### PR TITLE
CR-1090281 xbutil2 - u30 - missing sensor: VCCINT_VCU_0V9

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
@@ -189,6 +189,7 @@ struct xcl_sensor {
 	uint32_t vol_vccram;
 	uint32_t power_warn;
 	uint32_t qspi_status;
+	uint32_t vccint_vcu_0v9;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -96,6 +96,7 @@
 #define	XMC_VCCAUX_PMC_REG              0x350
 #define	XMC_VCCRAM_REG                  0x35C
 #define	XMC_POWER_WARN_REG              0x370
+#define	XMC_VCCINT_VCU_0V9_REG          0x380
 #define	XMC_HOST_NEW_FEATURE_REG1	0xB20
 #define	XMC_HOST_NEW_FEATURE_REG1_SC_NO_CS (1 << 30)
 #define	XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT (1 << 29)
@@ -739,6 +740,9 @@ static void xmc_sensor(struct platform_device *pdev, enum data_kind kind,
 		case XMC_QSPI_STATUS:
 			safe_read32(xmc, XMC_QSPI_STATUS_REG, val);
 			break;
+		case XMC_VCCINT_VCU_0V9:
+			READ_SENSOR(xmc, XMC_VCCINT_VCU_0V9_REG, val, val_kind);
+			break;
 		default:
 			break;
 		}
@@ -904,6 +908,9 @@ static void xmc_sensor(struct platform_device *pdev, enum data_kind kind,
 			break;
 		case XMC_QSPI_STATUS:
 			*val = xmc->cache->qspi_status;
+			break;
+		case XMC_VCCINT_VCU_0V9:
+			*(u32 *)val = xmc->cache->vccint_vcu_0v9;
 			break;
 		default:
 			break;
@@ -1175,6 +1182,7 @@ static int xmc_get_data(struct platform_device *pdev, enum xcl_group_kind kind,
 		xmc_sensor(pdev, XMC_VCCRAM, &sensors->vol_vccram, SENSOR_INS);
 		xmc_sensor(pdev, XMC_POWER_WARN, &sensors->power_warn, SENSOR_INS);
 		xmc_sensor(pdev, XMC_QSPI_STATUS, &sensors->qspi_status, SENSOR_INS);
+		xmc_sensor(pdev, XMC_VCCINT_VCU_0V9, &sensors->vccint_vcu_0v9, SENSOR_INS);
 		break;
 	case XCL_BDINFO:
 		mutex_lock(&xmc->mbx_lock);
@@ -1400,6 +1408,7 @@ SENSOR_SYSFS_NODE(xmc_vccaux_pmc, XMC_VCCAUX_PMC);
 SENSOR_SYSFS_NODE(xmc_vccram, XMC_VCCRAM);
 SENSOR_SYSFS_NODE(xmc_power_warn, XMC_POWER_WARN);
 SENSOR_SYSFS_NODE(xmc_qspi_status, XMC_QSPI_STATUS);
+SENSOR_SYSFS_NODE(xmc_vccint_vcu_0v9, XMC_VCCINT_VCU_0V9);
 
 static ssize_t xmc_power_show(struct device *dev,
 	struct device_attribute *da, char *buf)
@@ -1486,6 +1495,7 @@ static DEVICE_ATTR_RO(core_version);
 	&dev_attr_xmc_vccaux_pmc.attr,					\
 	&dev_attr_xmc_vccram.attr,					\
 	&dev_attr_xmc_power_warn.attr,					\
+	&dev_attr_xmc_vccint_vcu_0v9.attr,				\
 	&dev_attr_xmc_qspi_status.attr
 
 /*

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1097,6 +1097,7 @@ enum data_kind {
 	MAC_ADDR_FIRST,
 	XMC_POWER_WARN,
 	XMC_QSPI_STATUS,
+	XMC_VCCINT_VCU_0V9,
 };
 
 enum mb_kind {

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -1129,7 +1129,7 @@ public:
                      m0v85, mgt0v9avcc, m12v_sw, mgtavtt, vccint_vol, vccint_curr, m3v3_pex_curr, m0v85_curr, m3v3_vcc_vol,
                      hbm_1v2_vol, vpp2v5_vol, vccint_bram_vol, m12v_pex_vol, m12v_aux_curr, m12v_pex_curr, m12v_aux_vol,
                      vol_12v_aux1, vol_vcc1v2_i, vol_v12_in_i, vol_v12_in_aux0_i, vol_v12_in_aux1_i, vol_vccaux,
-                     vol_vccaux_pmc, vol_vccram, m3v3_aux_cur, power_warn;
+                     vol_vccaux_pmc, vol_vccram, m3v3_aux_cur, power_warn, vccint_vcu_0v9;
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_12v_pex_vol",    m12v_pex_vol);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_12v_pex_curr",   m12v_pex_curr);
         pcidev::get_dev(m_idx)->sysfs_get_sensor( "xmc", "xmc_12v_aux_vol",    m12v_aux_vol);
@@ -1164,6 +1164,7 @@ public:
         pcidev::get_dev(m_idx)->sysfs_get_sensor("xmc", "xmc_vccaux_pmc",      vol_vccaux_pmc);
         pcidev::get_dev(m_idx)->sysfs_get_sensor("xmc", "xmc_vccram",          vol_vccram);
         pcidev::get_dev(m_idx)->sysfs_get_sensor("xmc", "xmc_power_warn",      power_warn);
+        pcidev::get_dev(m_idx)->sysfs_get_sensor("xmc", "xmc_vccint_vcu_0v9",  vccint_vcu_0v9);
         sensor_tree::put( "board.physical.electrical.12v_pex.voltage",         m12v_pex_vol );
         sensor_tree::put( "board.physical.electrical.12v_pex.current",         m12v_pex_curr );
         sensor_tree::put( "board.physical.electrical.12v_aux.voltage",         m12v_aux_vol );
@@ -1200,6 +1201,7 @@ public:
         sensor_tree::put( "board.physical.electrical.vccaux_pmc.voltage",      vol_vccaux_pmc);
         sensor_tree::put( "board.physical.electrical.vccram.voltage",          vol_vccram);
         sensor_tree::put( "board.physical.electrical.power_warn.current",      power_warn);
+        sensor_tree::put( "board.physical.electrical.vccint_vcu_0v9.current",  vccint_vcu_0v9);
 
         // physical.power
         sensor_tree::put( "board.physical.power", static_cast<unsigned>(sysfs_power()));
@@ -1494,9 +1496,10 @@ public:
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccaux.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccaux_pmc.voltage" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccram.voltage"  ) << std::endl;
-        ostr << std::setw(16) << "3V3 AUX CURR" << std::setw(16) << "POWER WARN" << std::setw(16) << std::endl;
+        ostr << std::setw(16) << "3V3 AUX CURR" << std::setw(16) << "POWER WARN" << std::setw(16) << "VCCINT VCU 0V9" << std::endl;
         ostr << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.3v3_aux.current" )
              << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.power_warn.current" )
+             << std::setw(16) << sensor_tree::get_pretty<unsigned int>( "board.physical.electrical.vccint_vcu_0v9.current" )
              <<  std::endl;
 
         ostr << "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";


### PR DESCRIPTION
Conflicts:
	src/runtime_src/core/pcie/driver/linux/include/mailbox_proto.h
	src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
	src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h

Manually merged.