### PR TITLE
Bug Fixes: Improved xbutil validate summary report and help

### DIFF
--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -182,7 +182,7 @@ ReportPlatforms::writeReport( const xrt_core::device * dev,
       output << "Clocks\n";
     for(auto& kc : clocks) {
       boost::property_tree::ptree& pt_clock = kc.second;
-      output << boost::format("    %-20s : %s MHz\n") % pt_clock.get<std::string>("description") % pt_clock.get<std::string>("freq_mhz");
+      output << boost::format("  %-20s : %s MHz\n") % pt_clock.get<std::string>("description") % pt_clock.get<std::string>("freq_mhz");
     }
 
     boost::property_tree::ptree& macs = pt_platform.get_child("macs", empty_ptree);
@@ -190,7 +190,7 @@ ReportPlatforms::writeReport( const xrt_core::device * dev,
       output << "Mac Addresses\n";
     for(auto& km : macs) {
       boost::property_tree::ptree& pt_mac = km.second;
-      output << boost::format("    %-20s : %s\n") % "" % pt_mac.get<std::string>("address");
+      output << boost::format("  %-20s : %s\n") % "" % pt_mac.get<std::string>("address");
     }
   }
   

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -536,7 +536,7 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
       pairs.first += "\'";     
     }
 
-    maxStringLength = std::max<unsigned int>(maxStringLength, pairs.first.length());
+    maxStringLength = std::max<unsigned int>(maxStringLength, static_cast<unsigned int>(pairs.first.length()));
   }
 
   const unsigned int indention = maxStringLength + 5;  // New line indention after the '-' character (5 extra spaces)

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -536,7 +536,7 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
       pairs.first += "\'";     
     }
 
-    maxStringLength = std::max(maxStringLength, (unsigned int) pairs.first.length());
+    maxStringLength = std::max<unsigned int>(maxStringLength, pairs.first.length());
   }
 
   const unsigned int indention = maxStringLength + 5;  // New line indention after the '-' character (5 extra spaces)

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -524,17 +524,29 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
   std::string supportedValues;        // Formatted string of supported values
   std::string formattedString;        // Helper working string
                                       
+  // Make a copy of the data (since it is going to be modified)
+  VectorPairStrings workingCollection = _collection;
+
   // Determine the indention width
   unsigned int maxStringLength = 0;
-  for (const auto & pairs : _collection)
+  for (auto & pairs : workingCollection) {
+    // Determine if the keyName needs to have 'quotes', if so add them
+    if (pairs.first.find(' ') != std::string::npos ) {
+      pairs.first.insert(0, 1, '\'');  
+      pairs.first += "\'";     
+    }
+
     maxStringLength = std::max(maxStringLength, (unsigned int) pairs.first.length());
+  }
 
   const unsigned int indention = maxStringLength + 5;  // New line indention after the '-' character (5 extra spaces)
   boost::format reportFmt(std::string("  %-") + std::to_string(maxStringLength) + "s - %s\n");  
+  boost::format reportFmtQuotes(std::string(" %-") + std::to_string(maxStringLength + 1) + "s - %s\n");  
 
-  // report names and discription
-  for (const auto & pairs : _collection) {
-    XBU::wrap_paragraphs(boost::str(reportFmt % pairs.first % pairs.second), indention, maxColumnWidth, false /*indent first line*/, formattedString);
+  // Report names and description
+  for (const auto & pairs : workingCollection) {
+    boost::format &reportFormat = pairs.first[0] == '\'' ? reportFmtQuotes : reportFmt;
+    XBU::wrap_paragraphs(boost::str(reportFormat % pairs.first % pairs.second), indention, maxColumnWidth, false /*indent first line*/, formattedString);
     supportedValues += formattedString;
   }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <map>
 #include <iostream>
+#include <vector>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
@@ -95,6 +96,22 @@ namespace XBUtilities {
   std::string format_base10_shiftdown3(uint64_t value);
   std::string format_base10_shiftdown6(uint64_t value);
   
+  template <typename T>
+  std::vector<T> as_vector( boost::property_tree::ptree const& pt, 
+                            boost::property_tree::ptree::key_type const& key) 
+  {
+    std::vector<T> r;
+
+    boost::property_tree::ptree::const_assoc_iterator it = pt.find(key);
+
+    if( it != pt.not_found()) {
+      for (auto& item : pt.get_child(key)) 
+        r.push_back(item.second);
+    }
+    return r;
+  }
+
+
    /**
    * get_axlf_section() - Get section from the file passed in
    *

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -101,8 +101,8 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
   // Option Variables
-  std::vector<std::string> devices = {"all"};
-  std::vector<std::string> reportNames = {"host"};
+  std::vector<std::string> devices;       // Default values determined later in the flow
+  std::vector<std::string> reportNames;   // Default values determined later in the flow
   std::vector<std::string> elementsFilter;
   std::string sFormat = "text";
   std::string sOutput = "";
@@ -144,6 +144,22 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     printHelp(commonOptions, hiddenOptions);
     return;
   }
+
+  // Determine report level
+  if (devices.size() == 0 && reportNames.size() == 0)
+      reportNames.push_back("host");
+
+  if (devices.size() != 0 && reportNames.size() == 0) {
+    reportNames.push_back("platform");
+    reportNames.push_back("compute-units");
+  }
+
+  // Determine default values
+  if (devices.size() == 0)
+    devices.push_back("all");
+
+  if (reportNames.size() == 0)
+    reportNames.push_back("host");
 
   // -- Process the options --------------------------------------------
   ReportCollection reportsToProcess;            // Reports of interest

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -39,6 +39,7 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <algorithm>
 #include <sstream>
 #include <thread>
 #include <regex>
@@ -1282,7 +1283,7 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
   _ptDevCollectionTestSuite.push_back( std::make_pair("", ptDeviceInfo) );
 }
 
-void
+static void
 run_tests_on_devices( xrt_core::device_collection &deviceCollection, 
                       Report::SchemaVersion schemaVersion, 
                       std::vector<TestCollection *> testObjectsToRun,
@@ -1305,6 +1306,154 @@ run_tests_on_devices( xrt_core::device_collection &deviceCollection,
     _ostream << ss.str() << std::endl;
   }
 }
+
+static
+std::string quote_name(const std::string name)
+{
+  if (name.find(' ') == std::string::npos)
+    return name;
+
+  return std::string("\'") + name + std::string("\'");
+}
+
+static
+void smart_tab_format( const unsigned int max_length,
+                       const std::string & new_entry,
+                       std::vector<std::string> & formatted_lines)
+{
+  // First time through?
+  if (formatted_lines.size() == 0) {
+    formatted_lines.push_back(new_entry);
+    return;
+  }
+
+  // Add a comma
+  unsigned int current_index = formatted_lines.size() - 1;
+  formatted_lines[current_index] += ", ";
+
+  // Determine if we need to add the new_entry to the existing or new line
+  if ((formatted_lines[current_index].length() + new_entry.length()) > max_length)
+    formatted_lines.push_back(new_entry);
+  else
+    formatted_lines[current_index] += new_entry;
+}
+
+static void
+create_report_summary( const boost::property_tree::ptree& ptDevCollectionTestSuite,
+                       std::ostream &_ostream) {
+  // Convert the "logical_devices" array into an vector of child trees
+  std::vector<boost::property_tree::ptree> devices = XBU::as_vector<boost::property_tree::ptree>(ptDevCollectionTestSuite, "logical_devices");
+
+  // Data formats
+  static const unsigned int maxTabLength = 64;
+  static boost::format passFmt(   "  - [%-11s] : %-25s");
+  static boost::format warnFmt(   "  - [%-11s] : %-25s : Test(s): %s");
+  static boost::format failedFmt( "  - [%-11s] : %-25s : First failure: %s");
+  static boost::format skippedFmt("  - [%-11s] : %-25s : Test(s): %s");
+  static boost::format testNextLine("\n%58s%s");
+
+  // Collect the data
+  std::vector<std::string> validatedSuccessfully;
+  std::vector<std::string> validateWithExceptions;
+  std::vector<std::string> validateWithWarnings;
+  std::vector<std::string> validatedWithSkippedTests;
+
+  // Look at each device
+  for (const auto & device : devices) {
+    const std::string & device_id = device.get<std::string>("device_id");
+    const std::string & platform = device.get<std::string>("platform");
+    std::vector<boost::property_tree::ptree> tests = XBU::as_vector<boost::property_tree::ptree>(device, "tests");
+
+    // -- Failed Tests --
+    std::vector<boost::property_tree::ptree> failedTests;
+    std::copy_if(tests.begin(), tests.end(),  std::back_inserter(failedTests), [](boost::property_tree::ptree &pt){return pt.get<std::string>("status") == "failed";});
+
+    for (const auto &test : failedTests) {
+      const std::string test_name = quote_name(test.get<std::string>("name"));
+      validateWithExceptions.push_back(boost::str(failedFmt % device_id % platform % test_name));
+      break;
+    }
+
+    // -- Skipped Tests --
+    std::vector<boost::property_tree::ptree> skippedTests;
+    std::copy_if(tests.begin(), tests.end(),  std::back_inserter(skippedTests), [](boost::property_tree::ptree &pt){return pt.get<std::string>("status") == "skipped";});
+
+    // Now format the skipped the tests
+    std::vector<std::string> tabSkippedTests;
+    for (const auto &test : skippedTests) 
+      smart_tab_format(maxTabLength, quote_name(test.get<std::string>("name")), tabSkippedTests);
+
+    std::string skippedTestStr;
+    for (const auto & entry: tabSkippedTests)
+      if (skippedTestStr.empty())
+        skippedTestStr = boost::str(skippedFmt % device_id % platform % entry);
+      else
+        skippedTestStr += boost::str(testNextLine % "" % entry);
+    
+    if (!skippedTestStr.empty()) 
+      validatedWithSkippedTests.push_back(skippedTestStr);
+    
+    // -- Passed Tests --
+    std::vector<boost::property_tree::ptree> passTests;
+    std::copy_if(tests.begin(), tests.end(),  std::back_inserter(passTests), [](boost::property_tree::ptree &pt){return pt.get<std::string>("status") == "passed";});
+
+    if ((passTests.size() > 0) && 
+        (failedTests.size() == 0)) {            // There must not be any failures
+      validatedSuccessfully.push_back(boost::str(passFmt % device_id % platform));   
+    }
+
+    // -- Warnings --
+    std::vector<std::string> warningTests;
+    for (const auto &test : passTests) {
+      std::vector<boost::property_tree::ptree> entries = XBU::as_vector<boost::property_tree::ptree>(test, "log");
+
+      for (const auto &entry : entries) {
+        if (entry.get<std::string>("Warning","").length() == 0)
+          continue;
+          
+         warningTests.push_back(quote_name(test.get<std::string>("name")));
+         break;
+        }
+      }
+
+      std::string warningTestsStr;
+      for (const auto & entry: warningTests)
+        if (warningTestsStr.empty())
+          warningTestsStr = boost::str(warnFmt % device_id % platform % entry);
+        else
+          warningTestsStr += boost::str(testNextLine % "" % entry);
+    
+      if (!warningTestsStr.empty()) 
+        validateWithWarnings.push_back(warningTestsStr);  
+  }
+
+  // -- Report the data collected
+  _ostream << "Validation Summary" << std::endl;
+  _ostream << "------------------" << std::endl;
+
+  _ostream << boost::format("%-2d device(s) evaluated") % devices.size() << std::endl;
+  _ostream << boost::format("%-2d device(s) validated successfully") % validatedSuccessfully.size() << std::endl;
+  _ostream << boost::format("%-2d device(s) had exceptions during validation") % validateWithExceptions.size() << std::endl;
+
+  _ostream << boost::format("\nValidated successfully [%d device(s)]") % validatedSuccessfully.size() << std::endl;
+  for (const auto &entry : validatedSuccessfully)
+    _ostream << entry << std::endl;
+
+  _ostream << boost::format("\nValidation Exceptions [%d device(s)]") % validateWithExceptions.size() << std::endl;
+  for (const auto &entry : validateWithExceptions)
+    _ostream << entry << std::endl;
+
+  _ostream << boost::format("\nWarnings produced during test [%d device(s)] (Note: The given test successfully validated)") % validateWithWarnings.size() << std::endl;
+  for (const auto &entry : validateWithWarnings)
+    _ostream << entry << std::endl;
+
+  if (XBU::getVerbose()) {
+    _ostream << boost::format("\nUnsupported tests [%d device(s)]") % validatedWithSkippedTests.size() << std::endl;
+    for (const auto &entry : validatedWithSkippedTests)
+      _ostream << entry << std::endl;
+  }
+}
+
 
 
 }
@@ -1492,20 +1641,24 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     }
   }
 
-  boost::property_tree::ptree ptDevCollectionTestSuite;
-  // -- Run the tests --------------------------------------------------
-  if (sOutput.empty()) {
-    run_tests_on_devices(deviceCollection, schemaVersion, testObjectsToRun, ptDevCollectionTestSuite, std::cout);
-  }
-  else {
-    std::ofstream fOutput;
+  // -- Prepare the output stream ---------------------------------------------
+  std::ofstream fOutput;
+
+  // Is the output going to a file?  If so prepare to write it to a file
+  if (!sOutput.empty()) {
     fOutput.open(sOutput, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) 
       throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % sOutput).str());
-
-    run_tests_on_devices(deviceCollection, schemaVersion, testObjectsToRun, ptDevCollectionTestSuite, fOutput);
-
-    fOutput.close();
   }
+
+  // Determine where the printed information should be sent.
+  std::ostream &oOutput = sOutput.empty() ? std::cout : fOutput;
+
+  // -- Run the tests --------------------------------------------------
+  boost::property_tree::ptree ptDevCollectionTestSuite;
+  run_tests_on_devices(deviceCollection, schemaVersion, testObjectsToRun, ptDevCollectionTestSuite, oOutput);
+
+  // -- Create a summary of the report
+  create_report_summary(ptDevCollectionTestSuite, oOutput);
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1328,7 +1328,7 @@ void smart_tab_format( const unsigned int max_length,
   }
 
   // Add a comma
-  unsigned int current_index = formatted_lines.size() - 1;
+  unsigned int current_index = static_cast<unsigned int>(formatted_lines.size()) - 1;
   formatted_lines[current_index] += ", ";
 
   // Determine if we need to add the new_entry to the existing or new line

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1308,7 +1308,7 @@ run_tests_on_devices( xrt_core::device_collection &deviceCollection,
 }
 
 static
-std::string quote_name(const std::string name)
+std::string quote_name(const std::string & name)
 {
   if (name.find(' ') == std::string::npos)
     return name;


### PR DESCRIPTION
Work done
---------
+ EoU : Added summary of validation tests produced across multiple devices (CR-1092567)
+ EoU : Added quotes around report names in help (CR-1096035)
+ EoU:  Update default xbutil examine reports when using and not using the device option (CR-1096013)
            * If the user doesn't specify one, the default host report will be created.  
            * If the user specifies a device, then the platform and compute-units report will be produced.
