### PR TITLE
Various u30 related CR fixes

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -690,12 +690,16 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
         
         //if factory mode
         std::string platform = "";
+        try {
           if (is_mfg) {
             platform = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN";
           }
           else {
             platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
           }
+        } catch(...) {
+          // proceed even if the platform name is not available
+        }
         std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % _devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
         _ostream << std::string(dev_desc.length(), '-') << std::endl;
         _ostream << dev_desc;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -689,7 +689,7 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
         } catch (...) {}
         
         //if factory mode
-        std::string platform = "";
+        std::string platform = "<not defined>";
         try {
           if (is_mfg) {
             platform = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN";

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -135,11 +135,15 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
     std::string vbnv = "xilinx_" + board_name + "_GOLDEN";
     pt_current_shell.put("vbnv", vbnv);
   } else if(!logic_uuids.empty() && !interface_uuids.empty()) { // 2RP
-      DSAInfo part("", NULL_TIMESTAMP, logic_uuids[0], ""); 
+    try {
+      DSAInfo part("", NULL_TIMESTAMP, logic_uuids[0], "");
       pt_current_shell.put("vbnv", part.name);
       pt_current_shell.put("logic-uuid", XBU::string_to_UUID(logic_uuids[0]));
       pt_current_shell.put("interface-uuid", XBU::string_to_UUID(interface_uuids[0]));
       pt_current_shell.put("id", (boost::format("0x%x") % part.timestamp));
+    } catch (...) {
+      //safe to ignore exceptions. We print out whatever information that is available to us
+    }
 
       boost::property_tree::ptree pt_plps;
       for(unsigned int i = 1; i < logic_uuids.size(); i++) {
@@ -174,6 +178,8 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
     pt_available_shell.put("vbnv", installedDSA.name);
     pt_available_shell.put("sc_version", installedDSA.bmcVer);
     pt_available_shell.put("id", (boost::format("0x%x") % installedDSA.timestamp));
+    //the first UUID in the list is logic-uuid
+    pt_available_shell.put("logic-uuid", XBU::string_to_UUID(installedDSA.uuids[0]));
     pt_available_shell.put("file", installedDSA.file);
 
     boost::property_tree::ptree pt_status;
@@ -231,7 +237,7 @@ ReportPlatform::writeReport( const xrt_core::device * device,
   auto logic_uuid = pt.get<std::string>("platform.current_shell.logic-uuid", "");
   auto interface_uuid = pt.get<std::string>("platform.current_shell.interface-uuid", "");
   if (!logic_uuid.empty() && !interface_uuid.empty()) {
-    output << fmtBasic % "Platform ID" % logic_uuid;
+    output << fmtBasic % "Platform UUID" % logic_uuid;
     output << fmtBasic % "Interface UUID" % interface_uuid;
   } else {
     output << fmtBasic % "Platform ID" % pt.get<std::string>("platform.current_shell.id", "N/A");
@@ -259,8 +265,14 @@ ReportPlatform::writeReport( const xrt_core::device * device,
     boost::property_tree::ptree& available_shell = kv.second;
     output << fmtBasic % "Platform" % available_shell.get<std::string>("vbnv", "N/A");
     output << fmtBasic % "SC Version" % available_shell.get<std::string>("sc_version", "N/A");
-    output << fmtBasic % "Platform ID" % available_shell.get<std::string>("id", "N/A");
-    output << std::endl;
+    // print platform ID, for 2RP, platform ID = logic UUID 
+    auto logic_uuid = available_shell.get<std::string>("logic-uuid", "");
+    if (!logic_uuid.empty()) {
+      output << fmtBasic % "Platform UUID" % logic_uuid;
+    } else {
+      output << fmtBasic % "Platform ID" % available_shell.get<std::string>("id", "N/A");
+    }
+      output << std::endl;
   }
 
   //PLPs installed on the system

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -266,9 +266,9 @@ ReportPlatform::writeReport( const xrt_core::device * device,
     output << fmtBasic % "Platform" % available_shell.get<std::string>("vbnv", "N/A");
     output << fmtBasic % "SC Version" % available_shell.get<std::string>("sc_version", "N/A");
     // print platform ID, for 2RP, platform ID = logic UUID 
-    auto logic_uuid = available_shell.get<std::string>("logic-uuid", "");
-    if (!logic_uuid.empty()) {
-      output << fmtBasic % "Platform UUID" % logic_uuid;
+    auto platform_uuid = available_shell.get<std::string>("logic-uuid", "");
+    if (!platform_uuid.empty()) {
+      output << fmtBasic % "Platform UUID" % platform_uuid;
     } else {
       output << fmtBasic % "Platform ID" % available_shell.get<std::string>("id", "N/A");
     }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -388,7 +388,8 @@ auto_flash(xrt_core::device_collection& deviceCollection, bool force)
   // Collect all indexes of boards need updating
   std::vector<std::pair<unsigned int , DSAInfo>> boardsToUpdate;
   for (const auto & device : deviceCollection) {
-    auto available_shells = _pt.get_child(std::to_string(device->get_device_id()) + ".platform.available_shells");
+    static boost::property_tree::ptree ptEmpty;
+    auto available_shells = _pt.get_child(std::to_string(device->get_device_id()) + ".platform.available_shells", ptEmpty);
     // Check if any base packages are available
     if(available_shells.empty())
       return;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -253,9 +253,12 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice)
   std::cout << std::endl;
   std::cout << "\nIncoming Configuration\n";
   const boost::property_tree::ptree& available_shells = _ptDevice.get_child("platform.available_shells");
+  // if no shells are installed, do not proceed
+  if(available_shells.empty())
+    throw xrt_core::error("No matching base partitions are installed on the system");
   // if multiple shells are installed, do not proceed
   if( available_shells.size() > 1)
-      throw xrt_core::error("Auto update is not possible when multiple shells are installed on the system. Please use --image option to specify the path of a particular flash image.");
+    throw xrt_core::error("Auto update is not possible when multiple shells are installed on the system. Please use --image option to specify the path of a particular flash image.");
 
   const boost::property_tree::ptree& available_shell = available_shells.front().second;
   std::pair <std::string, std::string> s = deployment_path_and_filename(available_shell.get<std::string>("file"));
@@ -266,7 +269,12 @@ pretty_print_platform_info(const boost::property_tree::ptree& _ptDevice)
 
   std::cout << boost::format("  %-20s : %s\n") % "Platform" % available_shell.get<std::string>("vbnv", "N/A");
   std::cout << boost::format("  %-20s : %s\n") % "SC Version" % available_shell.get<std::string>("sc_version", "N/A");
-  std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % available_shell.get<std::string>("id", "N/A");
+  auto logic_uuid = available_shell.get<std::string>("logic-uuid", "");
+  if (!logic_uuid.empty()) {
+    std::cout << boost::format("  %-20s : %s\n") % "Platform UUID" % logic_uuid;
+  } else {
+    std::cout << boost::format("  %-20s : %s\n") % "Platform ID" % available_shell.get<std::string>("id", "N/A");
+  }
 }
 
 static void
@@ -280,7 +288,12 @@ report_status(xrt_core::device_collection& deviceCollection, boost::property_tre
     auto _rep = std::make_unique<ReportPlatform>();
     _rep->getPropertyTreeInternal(device.get(), _ptDevice);
     _pt.push_back(std::make_pair(std::to_string(device->get_device_id()), _ptDevice));
-    pretty_print_platform_info(_ptDevice);
+    try {
+      pretty_print_platform_info(_ptDevice);
+    } catch (xrt_core::error& e) {
+      std::cerr << "  " << e.what() << std::endl;
+      return;
+    }
     std::cout << "----------------------------------------------------\n";
   }
 
@@ -375,7 +388,12 @@ auto_flash(xrt_core::device_collection& deviceCollection, bool force)
   // Collect all indexes of boards need updating
   std::vector<std::pair<unsigned int , DSAInfo>> boardsToUpdate;
   for (const auto & device : deviceCollection) {
-    DSAInfo dsa(_pt.get_child(std::to_string(device->get_device_id()) + ".platform.available_shells").front().second.get<std::string>("file"));
+    auto available_shells = _pt.get_child(std::to_string(device->get_device_id()) + ".platform.available_shells");
+    // Check if any base packages are available
+    if(available_shells.empty())
+      return;
+    
+    DSAInfo dsa(available_shells.front().second.get<std::string>("file"));
     //if the shell is not up-to-date and dsa has a flash image, queue the board for update
     bool same_shell = _pt.get<bool>(std::to_string(device->get_device_id()) + ".platform.status.shell");
     bool same_sc = _pt.get<bool>(std::to_string(device->get_device_id()) + ".platform.status.sc");
@@ -458,7 +476,13 @@ program_plp(const xrt_core::device* dev, const std::string& partition)
   std::vector<char> buffer(total_size);
   stream.read(buffer.data(), total_size);
 
-  xrt_core::program_plp(dev, buffer);
+  try {
+    xrt_core::program_plp(dev, buffer);
+  } 
+  catch(xrt_core::error& e) {
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return;
+  }
   std::cout << "Programmed shell successfully" << std::endl;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1113,17 +1113,17 @@ static std::vector<TestCollection> testSuite = {
  * print basic information about a test
  */
 static void
-pretty_print_test_desc(const boost::property_tree::ptree& test, int test_idx,
-                       size_t testSuiteSize, std::ostream & _ostream, const std::string& bdf)
+pretty_print_test_desc(const boost::property_tree::ptree& test, int& test_idx,
+                       std::ostream & _ostream, const std::string& bdf)
 {
   if(test.get<std::string>("status", "").compare("skipped") != 0) {
-    std::string test_desc = boost::str(boost::format("Test %d/%d [%s]") % test_idx % testSuiteSize % bdf);
+    std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);
     _ostream << boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name");
     if(XBU::getVerbose())
       XBU::message(boost::str(boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
   }
   else if(XBU::getVerbose()) {
-    std::string test_desc = boost::str(boost::format("Test %d/%d [%s]") % test_idx % testSuiteSize % bdf);
+    std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);
     XBU::message(boost::str(boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name")));
     XBU::message(boost::str(boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
   }
@@ -1217,7 +1217,7 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device, boost::proper
   _ptTree.put("sc_version", xrt_core::device_query<xrt_core::query::xmc_sc_version>(device));
   _ptTree.put("platform_id", (boost::format("0x%x") % xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
   if (schemaVersion == Report::SchemaVersion::text) {
-    _ostream << boost::format("Validate device[%s]\n") % _ptTree.get<std::string>("device_id");
+    _ostream << boost::format("Validate device [%s]\n") % _ptTree.get<std::string>("device_id");
     _ostream << boost::format("%-20s: %s\n") % "Platform" % _ptTree.get<std::string>("platform");
     _ostream << boost::format("%-20s: %s\n") % "SC Version" % _ptTree.get<std::string>("sc_version");
     _ostream << boost::format("%-20s: %s\n") % "Platform ID" % _ptTree.get<std::string>("platform_id");
@@ -1255,7 +1255,7 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
     if(schemaVersion == Report::SchemaVersion::text) {
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
       if(is_black_box_test())
-        pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
+        pretty_print_test_desc(ptTest, test_idx, _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
     }
 
     testPtr->testHandle(device, ptTest);
@@ -1264,7 +1264,7 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
     if(schemaVersion == Report::SchemaVersion::text) {
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
       if(!is_black_box_test()) 
-        pretty_print_test_desc(ptTest, ++test_idx, testObjectsToRun.size(), _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
+        pretty_print_test_desc(ptTest, test_idx, _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
       pretty_print_test_run(ptTest, status, _ostream);
     }
       
@@ -1435,7 +1435,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
 
       // Did we have a hit?  If not then let the user know of a typo
       if (nameFound == false) {
-        throw xrt_core::error((boost::format("Invalided test name: '%s'") % userTestName).str());
+        throw xrt_core::error((boost::format("Invalid test name: '%s'") % userTestName).str());
       }
     }
 


### PR DESCRIPTION
- CR-1096199 Crash programming the U30 from Beta -> GA_internal_bash
- CR-1096037 replace "invalided" with "invalid"
- CR-1096026 Add a space before [ in Validate device[0000:04:00.1]
- CR-1096025 Tracking CR: Don't advertise missing tests in the default validate
- CR-1096008 xbutil examine does not show state of card without deployment platform
- CR-1095169 Please enumerate the platform_id UUID in xbmgmt examine
