### PR TITLE
CR-1095828 xbutil validate hangs when ert_polling mode enabled on U50	

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -637,13 +637,6 @@ ert_cfg_host(struct xocl_ert_user *ert_user, struct ert_user_command *ecmd)
 		ert_user->num_slots = 32;
 	}
 
-	ert_user->polling_mode = cfg->polling;
-
-	if (ert_user->polling_mode)
-		ert_intc_enable(ert_user, false);
-	else
-		ert_intc_enable(ert_user, true);
-
 	ERTUSER_INFO(ert_user, "scheduler config ert completed, polling_mode(%d), slots(%d)\n"
 		 , ert_user->polling_mode
 		 , ert_user->num_slots);
@@ -1111,6 +1104,13 @@ static int ert_cfg_cmd(struct xocl_ert_user *ert_user, struct ert_user_command *
 	cfg->dmsg = ert_user->ert_dmsg;
 	cfg->echo = ert_user->echo;
 	cfg->intr = ert_user->intr;
+
+	ert_user->polling_mode = cfg->polling;
+
+	if (ert_user->polling_mode)
+		ert_intc_enable(ert_user, false);
+	else
+		ert_intc_enable(ert_user, true);
 
 	// The KDS side of of the scheduler is now configured.  If ERT is
 	// enabled, then the configure command will be started asynchronously


### PR DESCRIPTION
Before this change, if ert_polling = true, ert_user sub-dev set polling_mode flag after configure command is completed.
In this case, when configure command was submitted to ERT firmware, the ert_user is in interrupt mode, but ERT firmware is in polling mode. This is the reason application hang.

After this change, ert_user set polling_mode flag before send configure command.