### PR TITLE
xclbinutil: Update SOFT_KERNEL metadata to validate the symbol name string length

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -20,6 +20,7 @@
 namespace XUtil = XclBinUtilities;
 
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 // Disable windows compiler warnings
@@ -227,6 +228,14 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
     softKernelHdr.mpo_symbol_name = sizeof(soft_kernel) + stringBlock.tellp();
     stringBlock << sValue << '\0';
     XUtil::TRACE(XUtil::format("  mpo_symbol_name (0x%lx): '%s'", softKernelHdr.mpo_symbol_name, sValue.c_str()).c_str());
+
+    // DRC Check checking to see if the maximum symbol name length has been violated
+    static const unsigned int MAX_SYMBOL_NAME_LENGTH = 19;
+    if (sValue.length() > MAX_SYMBOL_NAME_LENGTH) {
+      const std::string errMsg = (boost::format("ERROR: The given symbol name '%s' (length %d) exceeds the maximum support length of %d characters.") 
+                                            % sValue % sValue.length() % MAX_SYMBOL_NAME_LENGTH).str();
+      throw std::runtime_error(errMsg);
+    }
   }
 
   // m_num_instances


### PR DESCRIPTION
xclbinutil: Update SOFT_KERNEL metadata to validate the string length of the symbol name (#5037)
The XRT runtime environment can only support a symbol string length of 19 characters.  A DRC check was added to validate this length.

Work Done
---------
+ A DRC check was added to validate the symbol string length.

(cherry picked from commit 5a88b2690d777eebce9136e074a69470da72d91d)