### PR TITLE
CR-1091257 ERROR: Import fd for device only BO on the same device fails

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -414,8 +414,15 @@ class buffer_import : public bo_impl
 
 public:
   buffer_import(xclDeviceHandle dhdl, xclBufferExportHandle ehdl)
-    : bo_impl(dhdl, ehdl), hbuf(device->map_bo(handle, true))
-  {}
+    : bo_impl(dhdl, ehdl)
+  {
+    try {
+      hbuf = device->map_bo(handle, true);
+    }
+    catch (const std::exception&) {
+      hbuf = nullptr;
+    }
+  }
 
   ~buffer_import()
   {
@@ -435,6 +442,8 @@ public:
   virtual void*
   get_hbuf() const
   {
+    if (!hbuf)
+      throw xrt_core::system_error(std::errc::bad_address, "No host memory for imported buffer");
     return hbuf;
   }
 };


### PR DESCRIPTION
A device only BO is exported and imported on same device (same device
really doesn't matter) but import fails because XRT tried to map the
non existent host side buffer.  Fix import to avoid mapping of host
buffer when one doesn't exist.