### PR TITLE
Various Bug Fixes: Added global force option & fixed validate output

### DIFF
--- a/src/runtime_src/core/tools/common/EscapeCodes.h
+++ b/src/runtime_src/core/tools/common/EscapeCodes.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,7 +36,8 @@ namespace EscapeCodes {
     public:
       std::string hide() const { return std::string("\033[?25l"); };
       std::string show() const { return std::string("\033[?25h"); };
-      std::string prev_line() const { return std::string("\033[F"); };
+      std::string up() const { return std::string("\033[1A"); };
+      std::string prev_line() const { return std::string("\r") + up(); };  // Note: "\033[1F" is not ANSI
       std::string clear_line() const { return std::string("\033[2K"); };
   };
   

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -45,6 +45,7 @@ void  main_(int argc, char** argv,
   bool bHelp = false;
   bool bBatchMode = false;
   bool bShowHidden = false;
+  bool bForce = false;
 
   // Build Options
   po::options_description globalOptions("Global Options");
@@ -52,6 +53,7 @@ void  main_(int argc, char** argv,
     ("help",    boost::program_options::bool_switch(&bHelp), "Help to use this application")
     ("verbose", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
     ("batch",   boost::program_options::bool_switch(&bBatchMode), "Enable batch mode (disables escape characters)")
+    ("force",   boost::program_options::bool_switch(&bForce), "When possible, force an operation")
   ;
 
   // Hidden Options
@@ -97,6 +99,7 @@ void  main_(int argc, char** argv,
   XBU::setVerbose( bVerbose );
   XBU::setTrace( bTrace );
   XBU::setShowHidden( bShowHidden );
+  XBU::setForce( bForce );
 
   // Check to see if help was requested and no command was found
   if (vm.count("subCmd") == 0) {

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -86,6 +86,7 @@ static bool m_bVerbose = false;
 static bool m_bTrace = false;
 static bool m_disableEscapeCodes = false;
 static bool m_bShowHidden = false;
+static bool m_bForce = false;
 
 
 // ------ F U N C T I O N S ---------------------------------------------------
@@ -136,6 +137,23 @@ bool
 XBUtilities::getShowHidden()
 {
   return m_bShowHidden;
+}
+
+void
+XBUtilities::setForce(bool _bForce)
+{
+  m_bForce = _bForce;
+
+  if (m_bForce) 
+    trace("Enabling force option");
+  else
+    trace("Disabling force option");
+}
+
+bool 
+XBUtilities::getForce()
+{
+  return m_bForce;
 }
 
 void

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -54,6 +54,9 @@ namespace XBUtilities {
 
   void setShowHidden(bool _bShowHidden);
   bool getShowHidden();
+
+  void setForce(bool _bForce);
+  bool getForce();
 
   void disable_escape_codes( bool _disable );
   bool is_esc_enabled();  

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -546,20 +546,20 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   std::vector<std::string> image;
   bool revertToGolden = false;
   bool help = false;
-  bool force = false;
 
   po::options_description commonOptions("Common Options");  
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' indicates that every found device should be examined.")
     ("shell,s", boost::program_options::value<decltype(plp)>(&plp), "The partition to be loaded.  Valid values:\n"
                                                                       "  Name (and path) of the partition.")
+
+    // TODO: Auto update the 'base' values
     ("base,b", boost::program_options::value<decltype(update)>(&update)->implicit_value("all"), "Update the persistent images."/*  Value values:\n"
                                                                          "  ALL   - All images will be updated"
                                                                          "  FLASH - Flash image\n"
                                                                          "  SC    - Satellite controller"*/)
     ("user,u", boost::program_options::value<decltype(xclbin)>(&xclbin), "The xclbin to be loaded.  Valid values:\n"
                                                                       "  Name (and path) of the xclbin.")
-    ("force,f", boost::program_options::bool_switch(&force), "Force update the flash image")
     ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image. Note: The Satellite Control (MSP432) will not be reverted for a golden image does not exist.")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
@@ -630,24 +630,21 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  if(force) {
-    //force is a sub-option of update
-    if(update.empty())
-      throw xrt_core::error("Usage: xbmgmt program --device='0000:00:00.0' --base --force'");
-  }
-
   // TODO: Added mutually exclusive code for image, update, and revert-to-golden action.
 
   if(!image.empty()) {
     //image is a sub-option of update
     if(update.empty())
       throw xrt_core::error("Usage: xbmgmt program --device='0000:00:00.0' --base --image='/path/to/flash_image' OR shell_name");
+
     //allow only 1 device to be manually flashed at a time
     if(deviceCollection.size() != 1)
       throw xrt_core::error("Please specify a single device to be flashed");
+
     //we support only 2 flash images atm
     if(image.size() > 2)
       throw xrt_core::error("Please specify either 1 or 2 flash images");
+
     //find the absolute path to the specified image
     auto image_paths = find_flash_image_paths(image);
     if(!XBU::can_proceed())
@@ -661,13 +658,16 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     XBU::verbose("Sub command: --base");
     std::string empty = "";
     if(update.compare("all") == 0)
-      auto_flash(deviceCollection, force);
-    else if(update.compare("flash") == 0)
-      throw xrt_core::error("Platform only update is not supported");
-    else if(update.compare("sc") == 0)
-      throw xrt_core::error("SC only update is not supported");
-    else 
+      auto_flash(deviceCollection, XBU::getForce());
+    else {
+      if(update.compare("flash") == 0)
+        throw xrt_core::error("Platform only update is not supported");
+
+      if(update.compare("sc") == 0)
+        throw xrt_core::error("SC only update is not supported");
+       
       throw xrt_core::error("Please specify a valid value");
+    }
     return;
   }
   

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1385,7 +1385,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
 
     // Output file
-    if (!sOutput.empty() && boost::filesystem::exists(sOutput)) 
+    if (!sOutput.empty() && !XBU::getForce() && boost::filesystem::exists(sOutput)) 
         throw xrt_core::error((boost::format("Output file already exists: '%s'") % sOutput).str());
 
     if (testsToRun.empty()) 
@@ -1476,6 +1476,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     fOutput.open(sOutput, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) 
       throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % sOutput).str());
+    std::cout << "Info: The output is being redirected to the file: \'" << sOutput << "\'" << std::endl;
+    std::cout << "Info: Validation started ... " << std::endl;
   }
 
   // Determine where the printed information should be sent.
@@ -1486,6 +1488,12 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   run_tests_on_devices(deviceCollection, schemaVersion, testObjectsToRun, ptDevCollectionTestSuite, oOutput);
 
   // -- Create a summary of the report
-  create_report_summary(ptDevCollectionTestSuite, oOutput);
+  // Note: The report summary is only associated with the human readable format
+  if (schemaVersion == Report::SchemaVersion::text) 
+    create_report_summary(ptDevCollectionTestSuite, oOutput);
+
+  if (!sOutput.empty())
+    std::cout << "Info: Validation completed" << std::endl;
+
 }
 


### PR DESCRIPTION
Work Done
---------
+ Added a global force option
+ Removed "false" exception regarding using the "-f" option (CR 1096041)
+ Added support to overwrite existing files with the --force option (CR 1096038)
+ Added temporary fix for to indicate work is being done when validation is be performed (CR 1096051)
+ Fixed previous line escape sequence issue (CR 1096046)

(cherry picked from commit 965ca291a4517cf0123463a16e2f5164c45e76c7)
(cherry picked from commit 34a9f9851c7a37ec52688585acc6ac7668430105)