### PR TITLE
CR-1095013 Implement memory read / write functionality

### DIFF
--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -202,15 +202,9 @@ program_plp(const device* dev, const std::vector<char> &buffer)
 }
 
 void
-mem_read(const device* dev, long long addr, long long size, std::string output_file)
+mem_read(const device* dev, long long addr, long long size, const std::string& output_file)
 {
   instance().mem_read(dev, addr, size, output_file);
-}
-
-void
-mem_write(const device* dev, long long addr, long long size, char* buffer)
-{
-  instance().mem_write(dev, addr, size, buffer);
 }
 
 void

--- a/src/runtime_src/core/common/system.cpp
+++ b/src/runtime_src/core/common/system.cpp
@@ -201,4 +201,22 @@ program_plp(const device* dev, const std::vector<char> &buffer)
   instance().program_plp(dev, buffer);
 }
 
+void
+mem_read(const device* dev, long long addr, long long size, std::string output_file)
+{
+  instance().mem_read(dev, addr, size, output_file);
+}
+
+void
+mem_write(const device* dev, long long addr, long long size, char* buffer)
+{
+  instance().mem_write(dev, addr, size, buffer);
+}
+
+void
+mem_write(const device* dev, long long addr, long long size, unsigned int pattern)
+{
+  instance().mem_write(dev, addr, size, pattern);
+}
+
 } // xrt_core

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -128,6 +128,24 @@ public:
   {
     throw std::runtime_error("plp program is not supported");
   }
+
+  virtual void
+  mem_read(const device*, long long, long long, std::string) const
+  {
+    throw std::runtime_error("memory read is not supported");
+  }
+
+  virtual void
+  mem_write(const device*, long long, long long, char*) const
+  {
+    throw std::runtime_error("memory write is not supported");
+  }
+
+  virtual void
+  mem_write(const device*, long long, long long, unsigned int) const
+  {
+    throw std::runtime_error("memory write is not supported");
+  }
 }; // system
 
 /**
@@ -251,6 +269,18 @@ get_monitor_access_type();
 XRT_CORE_COMMON_EXPORT
 void
 program_plp(const device* dev, const std::vector<char> &buffer);
+
+XRT_CORE_COMMON_EXPORT
+void
+mem_read(const device* dev, long long addr, long long size, std::string output_file);
+
+XRT_CORE_COMMON_EXPORT
+void
+mem_write(const device* device, long long addr, long long size, char* buffer);
+
+XRT_CORE_COMMON_EXPORT
+void
+mem_write(const device* device, long long addr, long long size, unsigned int pattern);
 
 } //xrt_core
 

--- a/src/runtime_src/core/common/system.h
+++ b/src/runtime_src/core/common/system.h
@@ -130,15 +130,9 @@ public:
   }
 
   virtual void
-  mem_read(const device*, long long, long long, std::string) const
+  mem_read(const device*, long long, long long, const std::string&) const
   {
     throw std::runtime_error("memory read is not supported");
-  }
-
-  virtual void
-  mem_write(const device*, long long, long long, char*) const
-  {
-    throw std::runtime_error("memory write is not supported");
   }
 
   virtual void
@@ -272,11 +266,7 @@ program_plp(const device* dev, const std::vector<char> &buffer);
 
 XRT_CORE_COMMON_EXPORT
 void
-mem_read(const device* dev, long long addr, long long size, std::string output_file);
-
-XRT_CORE_COMMON_EXPORT
-void
-mem_write(const device* device, long long addr, long long size, char* buffer);
+mem_read(const device* dev, long long addr, long long size, const std::string& output_file);
 
 XRT_CORE_COMMON_EXPORT
 void

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/system_swemu.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/system_swemu.h
@@ -40,6 +40,9 @@ public:
 
   void
   program_plp(const device* dev, const std::vector<char>& buffer) const;
+
+  void
+  mem_read(const device* dev, long long addr, long long size, std::string output_file);
 };
 
 /**

--- a/src/runtime_src/core/edge/user/system_linux.cpp
+++ b/src/runtime_src/core/edge/user/system_linux.cpp
@@ -210,6 +210,13 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
   throw std::runtime_error("plp program is not supported");
 }
 
+void
+system_linux::
+mem_read(const device*, long long, long long, std::string) const
+{
+  throw std::runtime_error("memory read is not supported");
+}
+
 namespace edge_linux {
 
 std::shared_ptr<device>

--- a/src/runtime_src/core/edge/user/system_linux.h
+++ b/src/runtime_src/core/edge/user/system_linux.h
@@ -47,6 +47,9 @@ public:
 
   void
   program_plp(const device* dev, const std::vector<char> &buffer) const;
+
+  void
+  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
 };
 
 namespace edge_linux {

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
@@ -89,9 +89,16 @@ program_plp(const xrt_core::device* dev, const std::vector<char> &buffer) const
 
 void
 system::
-mem_read(const xrt_core::device* dev, long long addr, long long size, std::string output_file) const
+mem_read(const xrt_core::device* dev, long long addr, long long size, const std::string& output_file) const
 {
   throw std::runtime_error("memory read is not supported");
+}
+
+void
+system::
+mem_write(const xrt_core::device* device, long long addr, long long size, unsigned int pattern) const
+{
+  throw std::runtime_error("memory write is not supported");
 }
 
 std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.cxx
@@ -87,6 +87,13 @@ program_plp(const xrt_core::device* dev, const std::vector<char> &buffer) const
   throw std::runtime_error("plp program is not supported");
 }
 
+void
+system::
+mem_read(const xrt_core::device* dev, long long addr, long long size, std::string output_file) const
+{
+  throw std::runtime_error("memory read is not supported");
+}
+
 std::shared_ptr<xrt_core::device>
 get_userpf_device(device::handle_type device_handle, device::id_type id)
 {

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.h
@@ -40,6 +40,9 @@ public:
 
   void
   program_plp(const device* dev, const std::vector<char> &buffer) const;
+
+  void
+  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
 };
 
 /**

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/system_swemu.h
@@ -42,7 +42,10 @@ public:
   program_plp(const device* dev, const std::vector<char> &buffer) const;
 
   void
-  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
+  mem_read(const device* dev, long long addr, long long size, const std::string& output_file) const;
+
+  void
+  mem_write(const device* device, long long addr, long long size, unsigned int pattern) const;
 };
 
 /**

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
@@ -89,9 +89,16 @@ program_plp(const xrt_core::device* dev, const std::vector<char> &buffer) const
 
 void
 system::
-mem_read(const xrt_core::device* dev, long long addr, long long size, std::string output_file) const
+mem_read(const xrt_core::device* dev, long long addr, long long size, const std::string& output_file) const
 {
   throw std::runtime_error("memory read is not supported");
+}
+
+void
+system::
+mem_write(const xrt_core::device* device, long long addr, long long size, unsigned int pattern) const
+{
+  throw std::runtime_error("memory write is not supported");
 }
 
 std::shared_ptr<xrt_core::device>

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.cxx
@@ -87,6 +87,13 @@ program_plp(const xrt_core::device* dev, const std::vector<char> &buffer) const
   throw std::runtime_error("plp program is not supported");
 }
 
+void
+system::
+mem_read(const xrt_core::device* dev, long long addr, long long size, std::string output_file) const
+{
+  throw std::runtime_error("memory read is not supported");
+}
+
 std::shared_ptr<xrt_core::device>
 get_userpf_device(device::handle_type device_handle, device::id_type id)
 {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.h
@@ -40,6 +40,9 @@ public:
 
   void
   program_plp(const device* dev, const std::vector<char> &buffer) const;
+
+  void
+  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
 };
 
 /**

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/system_hwemu.h
@@ -42,7 +42,10 @@ public:
   program_plp(const device* dev, const std::vector<char> &buffer) const;
 
   void
-  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
+  mem_read(const device* dev, long long addr, long long size, const std::string& output_file) const;
+
+  void
+  mem_write(const device* device, long long addr, long long size, unsigned int pattern) const;
 };
 
 /**

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -19,6 +19,7 @@
 #include "core/common/query_requests.h"
 #include "gen/version.h"
 #include "scan.h"
+#include "core/pcie/common/memaccess.h"
 
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/format.hpp>
@@ -252,6 +253,59 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
+}
+
+void
+system_linux::
+mem_read(const device* device, long long addr, long long size, std::string output_file) const
+{
+  auto get_ddr_mem_size = [device]() {
+    auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
+    auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(device);
+
+    return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
+  };
+  auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  auto handle = device->get_device_handle();
+  if(xcldev::memaccess(handle, get_ddr_mem_size(), getpagesize(), bdf_str)
+      .read(output_file, addr, size) < 0)
+    throw xrt_core::error(EINVAL, "Memory read failed");
+}
+
+void
+system_linux::
+mem_write(const device* device, long long addr, long long size, char* buffer) const
+{
+  auto get_ddr_mem_size = [device]() {
+    auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
+    auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(device);
+
+    return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
+  };
+
+  auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  auto handle = device->get_device_handle();
+  if(xcldev::memaccess(handle, get_ddr_mem_size(), getpagesize(), bdf_str)
+      .write(addr, size, buffer) < 0)
+    throw xrt_core::error(EINVAL, "Memory write failed");
+}
+
+void
+system_linux::
+mem_write(const device* device, long long addr, long long size, unsigned int pattern) const
+{
+  auto get_ddr_mem_size = [device]() {
+    auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
+    auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(device);
+
+    return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
+  };
+    
+  auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  auto handle = device->get_device_handle();
+  if(xcldev::memaccess(handle, get_ddr_mem_size(), getpagesize(), bdf_str)
+      .write(addr, size, pattern) < 0)
+    throw xrt_core::error(EINVAL, "Memory write failed");
 }
 
 namespace pcie_linux {

--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -257,12 +257,14 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
 
 void
 system_linux::
-mem_read(const device* device, long long addr, long long size, std::string output_file) const
+mem_read(const device* device, long long addr, long long size, const std::string& output_file) const
 {
   auto get_ddr_mem_size = [device]() {
     auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
     auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(device);
 
+    // convert ddr_size from GB to bytes
+    // return the result in KB
     return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
   };
   auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
@@ -274,33 +276,17 @@ mem_read(const device* device, long long addr, long long size, std::string outpu
 
 void
 system_linux::
-mem_write(const device* device, long long addr, long long size, char* buffer) const
-{
-  auto get_ddr_mem_size = [device]() {
-    auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
-    auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(device);
-
-    return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
-  };
-
-  auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
-  auto handle = device->get_device_handle();
-  if(xcldev::memaccess(handle, get_ddr_mem_size(), getpagesize(), bdf_str)
-      .write(addr, size, buffer) < 0)
-    throw xrt_core::error(EINVAL, "Memory write failed");
-}
-
-void
-system_linux::
 mem_write(const device* device, long long addr, long long size, unsigned int pattern) const
 {
   auto get_ddr_mem_size = [device]() {
     auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(device);
     auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(device);
-
+    
+    // convert ddr_size from GB to bytes
+    // return the result in KB
     return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
   };
-    
+
   auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
   auto handle = device->get_device_handle();
   if(xcldev::memaccess(handle, get_ddr_mem_size(), getpagesize(), bdf_str)

--- a/src/runtime_src/core/pcie/linux/system_linux.h
+++ b/src/runtime_src/core/pcie/linux/system_linux.h
@@ -50,6 +50,15 @@ public:
 
   void
   program_plp(const device* dev, const std::vector<char> &buffer) const;
+  
+  void
+  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
+
+  void
+  mem_write(const device* device, long long addr, long long size, char* buffer) const;
+
+  void
+  mem_write(const device* device, long long addr, long long size, unsigned int pattern) const;
 
   monitor_access_type
   get_monitor_access_type() const

--- a/src/runtime_src/core/pcie/linux/system_linux.h
+++ b/src/runtime_src/core/pcie/linux/system_linux.h
@@ -52,10 +52,7 @@ public:
   program_plp(const device* dev, const std::vector<char> &buffer) const;
   
   void
-  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
-
-  void
-  mem_write(const device* device, long long addr, long long size, char* buffer) const;
+  mem_read(const device* dev, long long addr, long long size, const std::string& output_file) const;
 
   void
   mem_write(const device* device, long long addr, long long size, unsigned int pattern) const;

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -212,4 +212,11 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
   }
 }
 
+void
+system_windows::
+mem_read(const device*, long long, long long, std::string) const
+{
+  throw std::runtime_error("memory read is not supported");
+}
+
 } // xrt_core

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -214,9 +214,16 @@ program_plp(const device* dev, const std::vector<char> &buffer) const
 
 void
 system_windows::
-mem_read(const device*, long long, long long, std::string) const
+mem_read(const device*, long long, long long, const std::string&) const
 {
   throw std::runtime_error("memory read is not supported");
+}
+
+void
+system_windows::
+mem_write(const device* device, long long addr, long long size, unsigned int pattern) const
+{
+  throw std::runtime_error("memory write is not supported");
 }
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/windows/system_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/system_windows.cpp
@@ -221,7 +221,7 @@ mem_read(const device*, long long, long long, const std::string&) const
 
 void
 system_windows::
-mem_write(const device* device, long long addr, long long size, unsigned int pattern) const
+mem_write(const device*, long long, long long, unsigned int) const
 {
   throw std::runtime_error("memory write is not supported");
 }

--- a/src/runtime_src/core/pcie/windows/system_windows.h
+++ b/src/runtime_src/core/pcie/windows/system_windows.h
@@ -49,7 +49,10 @@ public:
   program_plp(const device* dev, const std::vector<char> &buffer) const;
 
   void
-  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
+  mem_read(const device* dev, long long addr, long long size, const std::string& output_file) const;
+
+  void
+  mem_write(const device* device, long long addr, long long size, unsigned int pattern) const;
 };
 
 } // host,xrt_core

--- a/src/runtime_src/core/pcie/windows/system_windows.h
+++ b/src/runtime_src/core/pcie/windows/system_windows.h
@@ -47,6 +47,9 @@ public:
 
   void
   program_plp(const device* dev, const std::vector<char> &buffer) const;
+
+  void
+  mem_read(const device* dev, long long addr, long long size, std::string output_file) const;
 };
 
 } // host,xrt_core

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
@@ -53,7 +53,7 @@ ReportQspiStatus::writeReport( const xrt_core::device * device,
 
   boost::property_tree::ptree& ptree = pt.get_child("qspi_wp_status");
 
-  output << "QSPI write portection status" << std::endl;
+  output << "QSPI write protection status" << std::endl;
   output << boost::format("  %-20s : %s\n") % "Primary" % ptree.get<std::string>("primary");
   output << boost::format("  %-20s : %s\n") % "Recovery" % ptree.get<std::string>("recovery");
   output << std::endl;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -20,7 +20,6 @@
 #include "core/common/error.h"
 #include "core/common/utils.h"
 #include "core/common/message.h"
-#include "core/common/query_requests.h"
 
 #include "common/system.h"
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,6 +20,7 @@
 // Include files
 // Please keep these to the bare minimum
 #include "core/common/device.h"
+#include "core/common/query_requests.h"
 
 #include <string>
 #include <memory>
@@ -136,6 +137,33 @@ namespace XBUtilities {
 
   std::string 
   parse_clock_id(const std::string& id);
+
+ /*
+  * xclbin locking
+  */
+  struct xclbin_lock
+  {
+    xclDeviceHandle m_handle;
+    xuid_t m_uuid;
+
+    xclbin_lock(std::shared_ptr<xrt_core::device> _dev)
+      : m_handle(_dev->get_device_handle())
+    {
+      auto xclbinid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(_dev);
+
+      uuid_parse(xclbinid.c_str(), m_uuid);
+
+      if (uuid_is_null(m_uuid))
+        throw std::runtime_error("'uuid' invalid, please re-program xclbin.");
+
+      if (xclOpenContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max(), true))
+        throw std::runtime_error("'Failed to lock down xclbin");
+    }
+
+    ~xclbin_lock(){
+      xclCloseContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max());
+    }
+  };
 
 };
 

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -114,7 +114,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
     //-- base address
     addr = std::stoll(m_baseAddress, nullptr, 0);
   }
-  catch(const std::invalid_argument) {
+  catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--address'\n") % m_baseAddress;
     return;
   }
@@ -123,7 +123,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
     //-- size
     size = std::stoll(m_sizeBytes, nullptr, 0);
   }
-  catch(const std::invalid_argument) {
+  catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--size'\n") % m_sizeBytes;
     return;
   }

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Licensed under the Apache License, Version
+ * Copyright (C) 2020-2021 Licensed under the Apache License, Version
  * 2.0 (the "License"). You may not use this file except in
  * compliance with the License. A copy of the License is located
  * at
@@ -16,27 +16,69 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "OO_MemRead.h"
+#include "core/common/query_requests.h"
+#include "core/pcie/common/memaccess.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+
+// ----- L O C A L  M E T H O D S -------------------------------------------
+
+size_t get_ddr_mem_size(const xrt_core::device* dev) {
+  auto ddr_size = xrt_core::device_query<xrt_core::query::rom_ddr_bank_size_gb>(dev);
+  auto ddr_bank_count = xrt_core::device_query<xrt_core::query::rom_ddr_bank_count_max>(dev);
+
+  return (ddr_size << 30) * ddr_bank_count / (1024 * 1024);
+}
+
+/*
+ * xclbin locking //todo move to XBU
+ */
+struct xclbin_lock
+{
+  xclDeviceHandle m_handle;
+  xuid_t m_uuid;
+
+  xclbin_lock(std::shared_ptr<xrt_core::device> _dev)
+    : m_handle(_dev->get_device_handle())
+  {
+    auto xclbinid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(_dev);
+
+    uuid_parse(xclbinid.c_str(), m_uuid);
+
+    if (uuid_is_null(m_uuid))
+      throw std::runtime_error("'uuid' invalid, please re-program xclbin.");
+
+    if (xclOpenContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max(), true))
+      throw std::runtime_error("'Failed to lock down xclbin");
+  }
+
+  ~xclbin_lock(){
+    xclCloseContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max());
+  }
+};
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 OO_MemRead::OO_MemRead( const std::string &_longName, bool _isHidden )
     : OptionOptions(_longName, _isHidden, "Read from the given memory address" )
-    , m_device("")
+    , m_device({})
     , m_baseAddress("")
     , m_sizeBytes("")
     , m_outputFile("")
     , m_help(false)
 {
   m_optionsDescription.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
-    ("output,o", boost::program_options::value<decltype(m_outputFile)>(&m_outputFile), "Output file")
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device)->multitoken()->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("output,o", boost::program_options::value<decltype(m_outputFile)>(&m_outputFile)->required(), "Output file")
     ("address", boost::program_options::value<decltype(m_baseAddress)>(&m_baseAddress)->required(), "Base address to start from")
     ("size", boost::program_options::value<decltype(m_sizeBytes)>(&m_sizeBytes)->required(), "Size (bytes) to read")
     ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
@@ -49,8 +91,97 @@ OO_MemRead::OO_MemRead( const std::string &_longName, bool _isHidden )
 }
 
 void
-OO_MemRead::execute(const SubCmdOptions& /*_options*/) const
+OO_MemRead::execute(const SubCmdOptions& _options) const
 {
-  printHelp();
+  XBU::verbose("SubCommand option: read mem");
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  try {
+    po::store(po::command_line_parser(_options).options(m_optionsDescription).positional(m_positionalOptions).run(), vm);
+    po::notify(vm); // Can throw
+  }
+  catch (po::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    printHelp();
+    return;
+  }
+
+  //-- Working variables
+  std::shared_ptr<xrt_core::device> device;
+  long long addr = 0, size = 0;
+
+  try {
+    //-- Device
+    if(m_device.size() > 1)
+      throw xrt_core::error("Multiple devices not supported. Please specify a single device");
+    
+    // Collect the device of interest
+    std::set<std::string> deviceNames;
+    xrt_core::device_collection deviceCollection;
+    for (const auto & deviceName : m_device) 
+      deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
+    
+    XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection); // Can throw
+    // set working variable
+    device = deviceCollection.front();
+
+    //-- Output file
+    if (!m_outputFile.empty() && boost::filesystem::exists(m_outputFile)) 
+      throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_outputFile).str());
+
+  } catch (const xrt_core::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    printHelp();
+    return;
+  }
+  catch (const std::runtime_error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    return;
+  }
+
+  try {
+    //-- base address
+    addr = std::stoll(m_baseAddress, nullptr, 0);
+  }
+  catch(const std::invalid_argument) {
+    std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--address'\n") % m_baseAddress;
+    return;
+  }
+
+  try {
+    //-- size
+    size = std::stoll(m_sizeBytes, nullptr, 0);
+  }
+  catch(const std::invalid_argument) {
+    std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--size'\n") % m_sizeBytes;
+    return;
+  }
+
+  XBU::verbose(boost::str(boost::format("Device: %s") % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device))));
+  XBU::verbose(boost::str(boost::format("Address: %s") % addr));
+  XBU::verbose(boost::str(boost::format("Size: %s") % size));
+  XBU::verbose(boost::str(boost::format("Output file: %s") % m_outputFile));
+
+  //read mem
+  xclbin_lock xclbin_lock(device);
+#ifdef _WIN32
+  std::cout << "mem read is not supported on windows";
+  return;
+#else
+  auto bdf_str = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device));
+  auto handle = device->get_device_handle();
+  if(xcldev::memaccess(handle, get_ddr_mem_size(device.get()), getpagesize(), bdf_str)
+      .read(m_outputFile, addr, size) < 0)
+    std::cout << "Memory read failed\n";
+  else
+    std::cout << "Memory read succeeded\n";
+#endif
 }
 

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,6 +18,7 @@
 #define __OO_MemRead_h_
 
 #include "tools/common/OptionOptions.h"
+#include <vector>
 
 class OO_MemRead : public OptionOptions {
  public:
@@ -27,7 +28,7 @@ class OO_MemRead : public OptionOptions {
   OO_MemRead( const std::string &_longName, bool _isHidden = false );
 
  private:
-   std::string m_device;
+   std::vector<std::string> m_device;
    std::string m_baseAddress;
    std::string m_sizeBytes;
    std::string m_outputFile;

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -122,7 +122,7 @@ XBU::verbose("SubCommand option: read mem");
     //-- size
     size = std::stoll(m_sizeBytes, nullptr, 0);
   }
-  catch(const std::invalid_argument) {
+  catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--size'\n") % m_sizeBytes;
     return;
   }
@@ -132,7 +132,7 @@ XBU::verbose("SubCommand option: read mem");
       //-- fill pattern
       fill_byte = std::stoi(m_fill, nullptr, 0);
     }
-    catch(const std::invalid_argument) {
+    catch(const std::invalid_argument&) {
       std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--fill'. Please specify a value between 0 and 255\n") % m_fill;
       return;
     }

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Licensed under the Apache License, Version
+ * Copyright (C) 2020-2021 Licensed under the Apache License, Version
  * 2.0 (the "License"). You may not use this file except in
  * compliance with the License. A copy of the License is located
  * at
@@ -16,19 +16,26 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "OO_MemWrite.h"
+#include "core/common/query_requests.h"
+#include "core/common/system.h"
 #include "tools/common/XBUtilities.h"
 namespace XBU = XBUtilities;
 
 // 3rd Party Library - Include Files
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
+#include <fstream>
 
 // ----- C L A S S   M E T H O D S -------------------------------------------
 
 OO_MemWrite::OO_MemWrite( const std::string &_longName, bool _isHidden)
     : OptionOptions(_longName, _isHidden, "Write to a given memory address")
-    , m_device("")
+    , m_device({})
     , m_baseAddress("")
     , m_sizeBytes("")
     , m_fill("")
@@ -37,7 +44,7 @@ OO_MemWrite::OO_MemWrite( const std::string &_longName, bool _isHidden)
 
 {
   m_optionsDescription.add_options()
-    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("device,d", boost::program_options::value<decltype(m_device)>(&m_device)->multitoken()->required(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("address", boost::program_options::value<decltype(m_baseAddress)>(&m_baseAddress)->required(), "Base address to start from")
     ("size", boost::program_options::value<decltype(m_sizeBytes)>(&m_sizeBytes)->required(), "Size (bytes) to write")
     ("fill,f", boost::program_options::value<decltype(m_fill)>(&m_fill), "The byte value to fill the memory with")
@@ -52,8 +59,124 @@ OO_MemWrite::OO_MemWrite( const std::string &_longName, bool _isHidden)
 }
 
 void
-OO_MemWrite::execute(const SubCmdOptions& /*_options*/) const
+OO_MemWrite::execute(const SubCmdOptions& _options) const
 {
-  printHelp();
+XBU::verbose("SubCommand option: read mem");
+
+  // Honor help option first
+  if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
+    printHelp();
+    return;
+  }
+
+  // Parse sub-command ...
+  po::variables_map vm;
+  try {
+    po::store(po::command_line_parser(_options).options(m_optionsDescription).positional(m_positionalOptions).run(), vm);
+    po::notify(vm); // Can throw
+  }
+  catch (po::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    printHelp();
+    return;
+  }
+
+  //-- Working variables
+  std::shared_ptr<xrt_core::device> device;
+  std::unique_ptr<char> buffer; //input file contents
+  long long addr = 0, size = 0;
+  unsigned int fill_byte = 'J';
+
+  try {
+    //-- Device
+    if(m_device.size() > 1)
+      throw xrt_core::error("Multiple devices not supported. Please specify a single device");
+    
+    // Collect the device of interest
+    std::set<std::string> deviceNames;
+    xrt_core::device_collection deviceCollection;
+    for (const auto & deviceName : m_device) 
+      deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
+    
+    XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection); // Can throw
+    // set working variable
+    device = deviceCollection.front();
+
+    //-- Input file
+    if (!m_inputFile.empty() && !boost::filesystem::exists(m_inputFile)) 
+      throw xrt_core::error((boost::format("Input file is not valid: '%s'") % m_inputFile).str());
+
+    // open file
+    // std::basic_ifstream<char> file(m_inputFile);
+    // // read data
+    // buffer.insert(buffer.begin(), std::istreambuf_iterator<char>(file)),
+    //                           std::istreambuf_iterator<char>());
+
+    std::ifstream file(m_inputFile);
+    if (file) {
+      file.seekg (0, file.end);
+      int length = file.tellg();
+      file.seekg (0, file.beg);
+      file.read (buffer.get(), length);
+    }
+
+  } catch (const xrt_core::error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    printHelp();
+    return;
+  }
+  catch (const std::runtime_error& e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    return;
+  }
+
+  try {
+    //-- base address
+    addr = std::stoll(m_baseAddress, nullptr, 0);
+  }
+  catch(const std::invalid_argument) {
+    std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--address'\n") % m_baseAddress;
+    return;
+  }
+
+  try {
+    //-- size
+    size = std::stoll(m_sizeBytes, nullptr, 0);
+  }
+  catch(const std::invalid_argument) {
+    std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--size'\n") % m_sizeBytes;
+    return;
+  }
+
+  if(!m_fill.empty()) {
+    try {
+      //-- fill pattern
+      fill_byte = std::stoi(m_fill, nullptr, 0);
+    }
+    catch(const std::invalid_argument) {
+      std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--fill'. Please specify a value between 0 and 255\n") % m_fill;
+      return;
+    }
+  }
+
+  XBU::verbose(boost::str(boost::format("Device: %s") % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device))));
+  XBU::verbose(boost::str(boost::format("Address: %s") % addr));
+  XBU::verbose(boost::str(boost::format("Size: %s") % size));
+  XBU::verbose(boost::str(boost::format("Input file: %s") % m_inputFile));
+  XBU::verbose(boost::str(boost::format("Fill pattern: %s") % m_fill));
+
+  //read mem
+  XBU::xclbin_lock xclbin_lock(device);
+  
+  try {
+    if(buffer.get() == nullptr)
+      xrt_core::mem_write(device.get(), addr, size, fill_byte);
+    else
+      xrt_core::mem_write(device.get(), addr, size, buffer.get());
+  } catch(const xrt_core::error& e) {
+    std::cerr << e.what() << std::endl;
+    return;
+  }
+  std::cout << "Memory write succeeded" << std::endl;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,6 +18,7 @@
 #define __OO_MemWrite_h_
 
 #include "tools/common/OptionOptions.h"
+#include <vector>
 
 class OO_MemWrite : public OptionOptions {
  public:
@@ -27,7 +28,7 @@ class OO_MemWrite : public OptionOptions {
   OO_MemWrite( const std::string &_longName, bool _isHidden = false);
 
  private:
-  std::string m_device;
+  std::vector<std::string> m_device;
   std::string m_baseAddress;
   std::string m_sizeBytes;
   std::string m_fill;

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.h
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.h
@@ -32,7 +32,6 @@ class OO_MemWrite : public OptionOptions {
   std::string m_baseAddress;
   std::string m_sizeBytes;
   std::string m_fill;
-  std::string m_inputFile;
   bool m_help;
 };
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1304,7 +1304,7 @@ getTestNameDescriptions(bool addAdditionOptions)
 
   // 'verbose' option
   if (addAdditionOptions) {
-    reportDescriptionCollection.emplace_back("all", "All known validate tests will be executed (default)");
+    reportDescriptionCollection.emplace_back("all", "All applicable validate tests will be executed (default)");
     reportDescriptionCollection.emplace_back("quick", "Only the first 4 tests will be executed");
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -61,33 +61,6 @@ enum class test_status
 };
 
 /*
- * xclbin locking
- */
-struct xclbin_lock
-{
-  xclDeviceHandle m_handle;
-  xuid_t m_uuid;
-
-  xclbin_lock(std::shared_ptr<xrt_core::device> _dev)
-    : m_handle(_dev->get_device_handle())
-  {
-    auto xclbinid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(_dev);
-
-    uuid_parse(xclbinid.c_str(), m_uuid);
-
-    if (uuid_is_null(m_uuid))
-      throw std::runtime_error("'uuid' invalid, please re-program xclbin.");
-
-    if (xclOpenContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max(), true))
-      throw std::runtime_error("'Failed to lock down xclbin");
-  }
-
-  ~xclbin_lock(){
-    xclCloseContext(m_handle, m_uuid, std::numeric_limits<unsigned int>::max());
-  }
-};
-
-/*
  * mini logger to log errors, warnings and details produced by the test cases
  */
 void logger(boost::property_tree::ptree& _ptTest, const std::string& tag, const std::string& msg)
@@ -900,7 +873,7 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
   }
 
   std::string msg;
-  xclbin_lock xclbin_lock(_dev);
+  XBU::xclbin_lock xclbin_lock(_dev);
   XBU::check_p2p_config(_dev.get(), msg);
 
   if(msg.find("Error") == 0) {
@@ -951,7 +924,7 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
     return;
   }
 
-  xclbin_lock xclbin_lock(_dev);
+  XBU::xclbin_lock xclbin_lock(_dev);
   uint32_t m2m_enabled = xrt_core::device_query<xrt_core::query::kds_numcdmas>(_dev);
   std::string name = xrt_core::device_query<xrt_core::query::rom_vbnv>(_dev);
 
@@ -1042,7 +1015,7 @@ bistTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::pt
     return;
   }
 
-  xclbin_lock xclbin_lock(_dev);
+  XBU::xclbin_lock xclbin_lock(_dev);
 
   if (!clock_calibration(_dev, _dev->get_device_handle(), _ptTest))
      _ptTest.put("status", "failed");


### PR DESCRIPTION
- added read-mem functionality
- moved _xclbin_lock_ to XBUtilities 
- CR-1097100 Typo in "write portection"
- CR-1097099 xbutil validate help is misleading

Sample output:
```
$ xbutil advanced --read-mem 0x800000000 40 -d 17:00 -o x.txt
-----------------------------------------------------
 Invoking next generation of the xbutil application 
-----------------------------------------------------
INFO: Reading from single bank, 40 bytes from DDR/HBM/PLRAM address 0x800000000
INFO: Read size 0x28 B from addr 0x800000000. Total Read so far 0x28
INFO: Read data saved in file: x.txt; Num of bytes: 40 bytes 
Memory read succeeded
```