### PR TITLE
CR-1096551: Fixing user range profiling 

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -166,6 +166,23 @@ namespace xdp {
     return 0 ;
   }
 
+  void VPDynamicDatabase::markXRTUIDStart(uint64_t uid, uint64_t eventID)
+  {
+    std::lock_guard<std::mutex> lock(hostLock) ;
+    uidMap[uid] = eventID ;
+  }
+
+  uint64_t VPDynamicDatabase::matchingXRTUIDStart(uint64_t uid)
+  {
+    std::lock_guard<std::mutex> lock(hostLock) ;
+    if (uidMap.find(uid) != uidMap.end()) {
+      uint64_t value = uidMap[uid] ;
+      uidMap.erase(uid) ;
+      return value ;
+    }
+    return 0 ;
+  }
+
   void VPDynamicDatabase::markRange(uint64_t functionID,
                                     std::pair<const char*, const char*> desc,
                                     uint64_t startTimestamp)

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -101,6 +101,9 @@ namespace xdp {
     // For device events
     std::map<uint64_t, std::list<VTFEvent*>> deviceEventStartMap;
 
+    // For callback events that don't have a unique ID
+    std::map<uint64_t, uint64_t> uidMap ;
+
     // Each device will have dynamically updated counter values.
     std::map<std::pair<uint64_t, xrt_core::uuid>, xclCounterResults> deviceCounters ;
 
@@ -167,6 +170,11 @@ namespace xdp {
     XDP_EXPORT void markDeviceEventStart(uint64_t slotID, VTFEvent* event);
     XDP_EXPORT VTFEvent* matchingDeviceEventStart(uint64_t slotID, VTFEventType type);
     XDP_EXPORT bool hasMatchingDeviceEventStart(uint64_t traceID, VTFEventType type);
+
+    // For API events that we cannot guarantee have unique IDs across all
+    //  the plugins, we have a seperate matching of start to end
+    XDP_EXPORT void markXRTUIDStart(uint64_t uid, uint64_t eventID) ;
+    XDP_EXPORT uint64_t matchingXRTUIDStart(uint64_t uid);
 
     // A lookup into the string table
     XDP_EXPORT uint64_t addString(const std::string& value) ;

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
@@ -86,7 +86,7 @@ namespace xdp {
 
     uint64_t start = 0 ;
     
-    if (!isStart) start = (db->getDynamicInfo()).matchingStart(id) ;
+    if (!isStart) start = (db->getDynamicInfo()).matchingXRTUIDStart(id) ;
 
     VTFEvent* event = 
       new OpenCLBufferTransfer(start,
@@ -97,7 +97,9 @@ namespace xdp {
 			       bufferSize) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
-    if (isStart) (db->getDynamicInfo()).markStart(id, event->getEventId()) ;
+    if (isStart) {
+      (db->getDynamicInfo()).markXRTUIDStart(id, event->getEventId()) ;
+    }
     else {
       (db->getDynamicInfo()).addOpenCLMapping(id, event->getEventId(), start);
     }
@@ -125,7 +127,7 @@ namespace xdp {
 
     uint64_t start = 0 ;
     
-    if (!isStart) start = (db->getDynamicInfo()).matchingStart(id) ;
+    if (!isStart) start = (db->getDynamicInfo()).matchingXRTUIDStart(id) ;
 
     // On the OpenCL side, NDRange Migrate might generate buffer transfer
     //  complete events with a buffer size of 0 that don't have corresponding
@@ -142,7 +144,9 @@ namespace xdp {
 			       bufferSize) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
-    if (isStart) (db->getDynamicInfo()).markStart(id, event->getEventId()) ;
+    if (isStart) {
+      (db->getDynamicInfo()).markXRTUIDStart(id, event->getEventId()) ;
+    }
     else {
       (db->getDynamicInfo()).addOpenCLMapping(id, event->getEventId(), start);
     }
@@ -172,7 +176,7 @@ namespace xdp {
 
     uint64_t start = 0 ;
     
-    if (!isStart) start = (db->getDynamicInfo()).matchingStart(id) ;
+    if (!isStart) start = (db->getDynamicInfo()).matchingXRTUIDStart(id) ;
 
     VTFEvent* event = 
       new OpenCLCopyBuffer(start,
@@ -185,7 +189,9 @@ namespace xdp {
 			   bufferSize) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
-    if (isStart) (db->getDynamicInfo()).markStart(id, event->getEventId()) ;
+    if (isStart) {
+      (db->getDynamicInfo()).markXRTUIDStart(id, event->getEventId()) ;
+    }
     else {
       (db->getDynamicInfo()).addOpenCLMapping(id, event->getEventId(), start);
     }
@@ -216,7 +222,7 @@ namespace xdp {
 
     uint64_t start = 0 ;
     
-    if (!isStart) start = (db->getDynamicInfo()).matchingStart(id) ;
+    if (!isStart) start = (db->getDynamicInfo()).matchingXRTUIDStart(id) ;
     std::string workgroupConfiguration = 
       std::to_string(workgroupConfigurationX) + ":" +
       std::to_string(workgroupConfigurationY) + ":" +
@@ -244,7 +250,9 @@ namespace xdp {
 
     (db->getDynamicInfo()).addEvent(event) ;
 
-    if (isStart) (db->getDynamicInfo()).markStart(id, event->getEventId()) ;
+    if (isStart) {
+      (db->getDynamicInfo()).markXRTUIDStart(id, event->getEventId()) ;
+    }
     else {
       (db->getDynamicInfo()).addOpenCLMapping(id, event->getEventId(), start);
     }


### PR DESCRIPTION
The XDP library requires that unique IDs be generated on the XRT side and passed into callbacks so starts and stops can be matched later.  This is done by calling the function xrt_core::utils::issue_id.

In OpenCL, however, there are a few callbacks that rely on the XRT event UID, which may have overlapping values with the values issued by issue_id.  This pull request changes the mechanism on the XDP side of how we match start events and end events for these callbacks that use the XRT event UID.
