### PR TITLE
xbutil/xbmgmt: Fixed previous line escape sequence

### DIFF
--- a/src/runtime_src/core/tools/common/EscapeCodes.h
+++ b/src/runtime_src/core/tools/common/EscapeCodes.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,7 +36,8 @@ namespace EscapeCodes {
     public:
       std::string hide() const { return std::string("\033[?25l"); };
       std::string show() const { return std::string("\033[?25h"); };
-      std::string prev_line() const { return std::string("\033[F"); };
+      std::string up() const { return std::string("\033[1A"); };
+      std::string prev_line() const { return std::string("\r") + up(); };  // Note: "\033[1F" is not ANSI
       std::string clear_line() const { return std::string("\033[2K"); };
   };
   


### PR DESCRIPTION
Unfortunately, not all terminals support the previous line escape sequence.  Updated the code base to instead perform the following action: "carriage return" followed by a "cursor up"

This PR fixes:
  CR-1096046 - xbutil2 validate and xbmgmt2 dump to a file print multiple status lines in console
