### PR TITLE
CR-1058379 Need ability to compare XRT version at compile-time

### DIFF
--- a/src/CMake/config/version.h.in
+++ b/src/CMake/config/version.h.in
@@ -17,6 +17,9 @@ static const char xrt_modified_files[] = "@XRT_MODIFIED_FILES@";
 
 #define XRT_DRIVER_VERSION "@XRT_VERSION_STRING@,@XRT_HASH@"
 
+#define XRT_VERSION(major, minor) ((major << 16) + (minor))
+#define XRT_VERSION_CODE XRT_VERSION(@XRT_VERSION_MAJOR@, @XRT_VERSION_MINOR@)
+
 # ifdef __cplusplus
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Add XRT_VERSION_CODE and macro XRT_VERSION(major, minor) to version.h.
Allows code to compile-time or run-time compare per CR request.

```
if (XRT_VERSION_CODE > XRT_VERSION(2, 5))
  ...;
else
  ...;
```

```
#if XRT_VERSION_CODE > XRT_VERSION(2, 5)
  ...;
#else
  ...;
#endif
```

Patch version (build number) comparison is not supported.