### PR TITLE
base structure for xocl last errors

### DIFF
--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -67,6 +67,7 @@ SET (XRT_DKMS_DRIVER_SRCS
   xocl/userpf/xocl_ioctl.c
   xocl/userpf/xocl_sysfs.c
   xocl/userpf/xocl_drv.c
+  xocl/userpf/xocl_errors.c
   xocl/userpf/xocl_kds.c
   xocl/userpf/xocl.dracut.conf
   xocl/userpf/99-xocl.rules
@@ -259,6 +260,8 @@ SET (XRT_DKMS_CORE_INCLUDES
   include/xclfeatures.h
   include/xclbin.h
   include/xclerr.h
+  include/xclerr_int.h
+  include/xrt_error_code.h
   include/xrt_mem.h
   )
 

--- a/src/runtime_src/core/include/xclerr_int.h
+++ b/src/runtime_src/core/include/xclerr_int.h
@@ -59,7 +59,7 @@ typedef struct xclErrorLast {
 	xrtErrorCode	err_code;	/* 64 bits; XRT error code */
 	xrtErrorTime	ts;		/* 64 bits; timestamp */
 	unsigned        pid;            /* 32 bits; pid associated with error, if available */
-};
+} xclErrorLast;
 
 typedef struct xcl_errors {
 	int		num_err;	/* number of errors recorded */

--- a/src/runtime_src/core/include/xclerr_int.h
+++ b/src/runtime_src/core/include/xclerr_int.h
@@ -55,7 +55,7 @@
  * A xrtErrorModule may produce multiple classes of errors
  * xrtErrorCode (64 bits) = ErrorNum + Driver + Severity + Module + Class
  */
-struct xclErrorLast {
+typedef struct xclErrorLast {
 	xrtErrorCode	err_code;	/* 64 bits; XRT error code */
 	xrtErrorTime	ts;		/* 64 bits; timestamp */
 	unsigned        pid;            /* 32 bits; pid associated with error, if available */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -405,9 +405,11 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 	if (!FW_PRIVILEGED(fw))
 		return 0;
 
-	/* TODO for error last functionality 
-	struct xocl_dev_core *core = xocl_get_xdev(pdev);
-	xocl_insert_error_record(core, err_last); to add error record  */
+	/* 
+         * TODO for error last functionality 
+	 * struct xocl_dev_core *core = xocl_get_xdev(pdev);
+	 * xocl_insert_error_record(core, err_last); to add error record  
+         */
 
 	for (i = 0; i < fw->max_level; i++) {
 		val = IS_FIRED(fw, i);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -405,6 +405,10 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 	if (!FW_PRIVILEGED(fw))
 		return 0;
 
+	/* TODO for error last functionality 
+	struct xocl_dev_core *core = xocl_get_xdev(pdev);
+	xocl_insert_error_record(core, err_last); to add error record  */
+
 	for (i = 0; i < fw->max_level; i++) {
 		val = IS_FIRED(fw, i);
 		if (val) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -406,10 +406,10 @@ static u32 check_firewall(struct platform_device *pdev, int *level)
 		return 0;
 
 	/* 
-         * TODO for error last functionality 
+	 * TODO for error last functionality 
 	 * struct xocl_dev_core *core = xocl_get_xdev(pdev);
 	 * xocl_insert_error_record(core, err_last); to add error record  
-         */
+	 */
 
 	for (i = 0; i < fw->max_level; i++) {
 		val = IS_FIRED(fw, i);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/Makefile
@@ -92,6 +92,7 @@ xocl-y := \
 	$(xocl_lib-y)	\
 	$(drv_common-y) \
 	xocl_drv.o	\
+	xocl_errors.o	\
 	xocl_bo.o	\
 	xocl_drm.o	\
 	xocl_ioctl.o	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1587,6 +1587,11 @@ int xocl_userpf_probe(struct pci_dev *pdev,
 	atomic_set(&xdev->outstanding_execs, 0);
 	INIT_LIST_HEAD(&xdev->ctx_list);
 
+	/* TODO
+	 * initialize xocl_errors
+	 * xocl_init_errors(&xdev->core);
+	 */
+
 
 	ret = xocl_subdev_init(xdev, pdev, &userpf_pci_ops);
 	if (ret) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: sarabjee@xilinx.com
  *
@@ -46,7 +46,10 @@ xocl_insert_error_record(struct xocl_dev_core *core, struct xclErrorLast *err_la
 int
 xocl_init_errors(struct xocl_dev_core *core)
 {
-	//TODO
+	/*TODO
+	 * mutex_init(core->errors_lock);
+	 */
+	core->errors = NULL;
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: sarabjee@xilinx.com
  *
@@ -18,24 +18,24 @@
 #include "xocl_drv.h"
 
 static void
-xocl_clear_all_error_record(struct xocl_dev *xdev)
+xocl_clear_all_error_record(struct xocl_dev_core *core)
 {
-	struct xcl_errors *err = xdev->core.errors;
+	struct xcl_errors *err = core->errors;
 	if (!err)
 		return;
 
-	mutex_lock(&xdev->core.errors_lock);
+	mutex_lock(&core->errors_lock);
 
 	memset(err->errors, 0, sizeof(err->errors));
 	err->num_err = 0;
 
-	mutex_unlock(&xdev->core.errors_lock);
+	mutex_unlock(&core->errors_lock);
 }
 
 int
-xocl_insert_error_record(struct xocl_dev *xdev, struct xclErrorLast *err_last)
+xocl_insert_error_record(struct xocl_dev_core *core, struct xclErrorLast *err_last)
 {
-	struct xcl_errors *err = xdev->core.errors;
+	struct xcl_errors *err = core->errors;
 	if (!err)
 		return -ENOENT;
 	//TODO
@@ -44,7 +44,7 @@ xocl_insert_error_record(struct xocl_dev *xdev, struct xclErrorLast *err_last)
 }
 
 int
-xocl_init_errors(struct xocl_dev *xdev)
+xocl_init_errors(struct xocl_dev_core *core)
 {
 	//TODO
 
@@ -52,9 +52,9 @@ xocl_init_errors(struct xocl_dev *xdev)
 }
 
 void
-xocl_fini_errors(struct xocl_dev *xdev)
+xocl_fini_errors(struct xocl_dev_core *core)
 {
-	struct xcl_errors *err = xdev->core.errors;
+	struct xcl_errors *err = core->errors;
 	if (!err)
 		return;
 	//TODO

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
@@ -1,0 +1,63 @@
+/*
+ * A GEM style device manager for PCIe based OpenCL accelerators.
+ *
+ * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ *
+ * Authors: sarabjee@xilinx.com
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include <linux/mutex.h>
+
+#include "xocl_drv.h"
+
+static void
+xocl_clear_all_error_record(struct xocl_dev *xdev)
+{
+	struct xocl_error *err = xdev->xocl_errors;
+	if (!err)
+		return;
+
+	mutex_lock(&xdev->errors_lock);
+
+	memset(err->errors, 0, sizeof(err->errors);
+	err->num_err = 0;
+
+	mutex_unlock(&xdev->errors_lock);
+}
+
+int
+xocl_insert_error_record(struct xocl_dev *xdev, xrtErrorLast *err_last)
+{
+	struct xocl_error *err = xdev->xocl_errors;
+	if (!err)
+		return -ENOENT;
+	//TODO
+
+	return 0;
+}
+
+int
+xocl_init_errors(struct xocl_dev *xdev)
+{
+	//TODO
+
+	return 0;
+}
+
+void
+xocl_fini_errors(struct xocl_dev *xdev)
+{
+	struct xocl_error *err = xdev->xocl_errors;
+	if (!err)
+		return -EINVAL;
+	//TODO
+}
+

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_errors.c
@@ -14,29 +14,28 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-#include <linux/mutex.h>
-
+#include "common.h"
 #include "xocl_drv.h"
 
 static void
 xocl_clear_all_error_record(struct xocl_dev *xdev)
 {
-	struct xocl_error *err = xdev->xocl_errors;
+	struct xcl_errors *err = xdev->core.errors;
 	if (!err)
 		return;
 
-	mutex_lock(&xdev->errors_lock);
+	mutex_lock(&xdev->core.errors_lock);
 
-	memset(err->errors, 0, sizeof(err->errors);
+	memset(err->errors, 0, sizeof(err->errors));
 	err->num_err = 0;
 
-	mutex_unlock(&xdev->errors_lock);
+	mutex_unlock(&xdev->core.errors_lock);
 }
 
 int
-xocl_insert_error_record(struct xocl_dev *xdev, xrtErrorLast *err_last)
+xocl_insert_error_record(struct xocl_dev *xdev, struct xclErrorLast *err_last)
 {
-	struct xocl_error *err = xdev->xocl_errors;
+	struct xcl_errors *err = xdev->core.errors;
 	if (!err)
 		return -ENOENT;
 	//TODO
@@ -55,9 +54,9 @@ xocl_init_errors(struct xocl_dev *xdev)
 void
 xocl_fini_errors(struct xocl_dev *xdev)
 {
-	struct xocl_error *err = xdev->xocl_errors;
+	struct xcl_errors *err = xdev->core.errors;
 	if (!err)
-		return -EINVAL;
+		return;
 	//TODO
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -72,6 +72,20 @@ static ssize_t board_name_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(board_name);
 
+/* last/latest xocl errrors */
+static ssize_t xocl_errors_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_dev *xdev = dev_get_drvdata(dev);
+	struct xcl_errors *err = xdev->core.errors;
+	if (!err)
+		return -ENOENT;
+	//TODO
+
+	return 0;
+}
+static DEVICE_ATTR_RO(xocl_errors);
+
 /* -live client contexts-- */
 static ssize_t kdsstat_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
@@ -657,6 +671,7 @@ static struct attribute *xocl_attrs[] = {
 	&dev_attr_xclbinuuid.attr,
 	&dev_attr_userbar.attr,
 	&dev_attr_board_name.attr,
+	&dev_attr_xocl_errors.attr,
 	&dev_attr_kdsstat.attr,
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -61,6 +61,7 @@
 #include "lib/libfdt/libfdt.h"
 #include <linux/firmware.h>
 #include "kds_core.h"
+#include "xclerr_int.h"
 #if defined(RHEL_RELEASE_CODE)
 #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 3)
 #include <linux/sched/signal.h>
@@ -523,6 +524,9 @@ struct xocl_dev_core {
 	struct workqueue_struct	*wq;
 	struct xocl_work	works[XOCL_WORK_NUM];
 	struct mutex		wq_lock;
+
+	struct xcl_errors	*errors;
+	struct mutex		errors_lock;
 
 	struct kds_sched	kds;
 


### PR DESCRIPTION
base structure for xocl last errors
This will be used in xocl sub devices to add their last errors
Last error info will go into sysfs from where xbutil will utilize it