### PR TITLE
CR-1083145 XRT API to report interface UUID for 2RP shell

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -242,10 +242,15 @@ device::
 get_info(info::device param) const
 {
   switch (param) {
-  case info::device::name :                   // std::string
-    return query::raw<info::device::name, xrt_core::query::rom_vbnv>(handle.get());
   case info::device::bdf :                    // std::string
     return query::to_string<info::device::bdf, xrt_core::query::pcie_bdf>(handle.get());
+  case info::device::interface_uuid :         // std::string
+    return query::to_value<info::device::interface_uuid, xrt_core::query::interface_uuids>
+      (handle.get(), [](const auto& iids) {
+        if (iids.size() != 1)
+          throw xrt_core::error("Unexpected interface uuid from device");
+        return xrt_core::query::interface_uuids::to_uuid(iids[0]);
+      });
   case info::device::kdma :                   // uint32_t
     return query::raw<info::device::kdma, xrt_core::query::kds_numcdmas>(handle.get());
   case info::device::max_clock_frequency_mhz: // unsigned long
@@ -263,6 +268,8 @@ get_info(info::device param) const
     catch (const std::exception&) {
       return false;
     }
+  case info::device::name :                   // std::string
+    return query::raw<info::device::name, xrt_core::query::rom_vbnv>(handle.get());
   case info::device::nodma :                  // bool
     return query::to_value<info::device::nodma, xrt_core::query::nodma>
       (handle.get(), [](const auto& val) { return bool(val); });

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -18,6 +18,8 @@
 #define xrt_core_common_query_requests_h
 
 #include "query.h"
+#include "error.h"
+#include "uuid.h"
 #include <string>
 #include <vector>
 #include <sstream>
@@ -551,6 +553,22 @@ struct interface_uuids : request
   to_string(const std::string& value)
   {
     return value;
+  }
+
+  // Convert string value to proper uuid string if necessary
+  // and return xrt::uuid
+  static uuid
+  to_uuid(const std::string& value)
+  {
+    std::string str = value;
+    if (str.length() < 24)  // for '-' insertion
+      throw xrt_core::system_error(EINVAL, "invalid uuid: " + value);
+    for (auto idx : {8, 13, 18, 23})
+      if (str[idx] != '-')
+        str.insert(idx,1,'-');
+    if (str.length() != 36) // final uuid length must be 36 chars
+      throw xrt_core::system_error(EINVAL, "invalid uuid: " + value);
+    return uuid(str);
   }
 };
 

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -52,22 +52,24 @@ namespace info {
  * with param traits.
  */
 enum class device : unsigned int {
-  name,
   bdf,
+  interface_uuid,
   kdma,
   max_clock_frequency_mhz,
   m2m,
+  name,
   nodma,
 };
 
 /**
  * Return type for xrt::device::get_info()
  */
-XRT_INFO_PARAM_TRAITS(device::name, std::string);
 XRT_INFO_PARAM_TRAITS(device::bdf, std::string);
+XRT_INFO_PARAM_TRAITS(device::interface_uuid, xrt::uuid);
 XRT_INFO_PARAM_TRAITS(device::kdma, std::uint32_t);
 XRT_INFO_PARAM_TRAITS(device::max_clock_frequency_mhz, unsigned long);
 XRT_INFO_PARAM_TRAITS(device::m2m, bool);
+XRT_INFO_PARAM_TRAITS(device::name, std::string);
 XRT_INFO_PARAM_TRAITS(device::nodma, bool);
 
 } // info

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -76,12 +76,13 @@ int run(int argc, char** argv)
   if (uuid != xclbin.get_uuid())
     throw std::runtime_error("Unexpected uuid error");
 
-  std::cout << "device name:     " << device.get_info<xrt::info::device::name>() << "\n";
-  std::cout << "device bdf:      " << device.get_info<xrt::info::device::bdf>() << "\n";
-  std::cout << "device kdma:     " << device.get_info<xrt::info::device::kdma>() << "\n";
-  std::cout << "device max freq: " << device.get_info<xrt::info::device::max_clock_frequency_mhz>() << "\n";
-  std::cout << "device m2m:      " << std::boolalpha << device.get_info<xrt::info::device::m2m>() << std::dec << "\n";
-  std::cout << "device nodma:    " << std::boolalpha << device.get_info<xrt::info::device::nodma>() << std::dec << "\n";
+  std::cout << "device name:           " << device.get_info<xrt::info::device::name>() << "\n";
+  std::cout << "device bdf:            " << device.get_info<xrt::info::device::bdf>() << "\n";
+  std::cout << "device kdma:           " << device.get_info<xrt::info::device::kdma>() << "\n";
+  std::cout << "device max freq:       " << device.get_info<xrt::info::device::max_clock_frequency_mhz>() << "\n";
+  std::cout << "device m2m:            " << std::boolalpha << device.get_info<xrt::info::device::m2m>() << std::dec << "\n";
+  std::cout << "device nodma:          " << std::boolalpha << device.get_info<xrt::info::device::nodma>() << std::dec << "\n";
+  std::cout << "device interface uuid: " << device.get_info<xrt::info::device::interface_uuid>().to_string() << "\n";
 
   return 0;
 }


### PR DESCRIPTION
xrt::device param to retrieve interface uuid from device

```
xrt::device device = ...;
auto uuid = device.get_info<xrt::info::device::interface_uuid>();
std::cout << "interface uuid: " << uuid.to_string() << "\n";
```

See also `XRT/tests/xrt/query/main.cpp`