### PR TITLE
CR-1096028: fix arguments count value for kernels with no arguments for AP_CTRL_HS/CHAIN

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1169,6 +1169,7 @@ class kernel_impl
   {
     if (protocol == FAST_ADAPTER)
       amend_fa_args();
+    // For AP_CTRL_HS/CHAIN, first 4 are control register
     if (protocol == AP_CTRL_HS || protocol == AP_CTRL_CHAIN)
       regmap_size = std::max(regmap_size, 4LU);
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1169,6 +1169,8 @@ class kernel_impl
   {
     if (protocol == FAST_ADAPTER)
       amend_fa_args();
+    if (protocol == AP_CTRL_HS || protocol == AP_CTRL_CHAIN)
+      regmap_size = std::max(regmap_size, 4LU);
   }
 
   unsigned int

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1170,8 +1170,9 @@ class kernel_impl
     if (protocol == FAST_ADAPTER)
       amend_fa_args();
     // For AP_CTRL_HS/CHAIN, first 4 are control register
+    size_t regmap_size_default = 4;
     if (protocol == AP_CTRL_HS || protocol == AP_CTRL_CHAIN)
-      regmap_size = std::max(regmap_size, 4LU);
+      regmap_size = std::max(regmap_size, regmap_size_default);
   }
 
   unsigned int


### PR DESCRIPTION
* fix arguments count value for kernels with no arguments for AP_CTRL_HS/CHAIN
* AP_CTRL_HS/CHAIN PL kernel have first 4 control registers so if kernel has no arguments or all streaming arguments it will "start_krnl_ecmd2xcmd" will produce wrong "isize" value and lead to crash.  
  