### PR TITLE
CR-1097118 [regression] Exception: Failed to open /sys/class/drm/renderD128/device/kds_mode for reading: No such file or directory

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -42,6 +42,13 @@ kds_echo_store(struct device *dev, struct device_attribute *da,
 static DEVICE_ATTR(kds_echo, 0644, kds_echo_show, kds_echo_store);
 
 static ssize_t
+kds_mode_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", kds_mode);
+}
+static DEVICE_ATTR_RO(kds_mode);
+
+static ssize_t
 kds_stat_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
@@ -414,6 +421,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_kds_skstat.attr,
 	&dev_attr_kds_xrt_version.attr,
 	&dev_attr_kds_echo.attr,
+	&dev_attr_kds_mode.attr,
 	&dev_attr_kds_stat.attr,
 	&dev_attr_memstat.attr,
 	&dev_attr_memstat_raw.attr,


### PR DESCRIPTION
This is the missing change in #5103 . Without this change, you will see no kds_mode sysfs node error on edge device.