### PR TITLE
CR-1097233: Fixing seg fault in continuous trace offload

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -57,12 +57,13 @@ namespace xdp {
     // In addition to creating the event, we must log statistics
 
     // Execution time = (end time) - (start time)
-    auto startTimeEvent = cuStarts[s].front();
-    auto startTime = convertDeviceToHostTimestamp(startTimeEvent->getDeviceTimestamp());
+    std::pair<uint64_t, uint64_t> startEventInfo = cuStarts[s].front();
+    auto startEventID = startEventInfo.first ;
+    auto startTime = convertDeviceToHostTimestamp(startEventInfo.second);
     auto executionTime = hostTimestamp - startTime;
 
     cuStarts[s].pop_front();
-    auto event = new KernelEvent(startTimeEvent->getEventId(),
+    auto event = new KernelEvent(startEventID,
                                  hostTimestamp, KERNEL, deviceId, s, cuId);
     event->setDeviceTimestamp(deviceTimestamp);
     db->getDynamicInfo().addEvent(event);
@@ -107,7 +108,7 @@ namespace xdp {
       db->getDynamicInfo().addEvent(event);
       db->getDynamicInfo().markDeviceEventStart(monTraceID, event);
 
-      cuStarts[s].push_back(event);
+      cuStarts[s].push_back(std::make_pair(event->getEventId(), trace.Timestamp));
       if(1 == cuStarts[s].size()) {
         traceIDs[s] = 0; // When current CU starts, reset stall status
       }

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
@@ -33,7 +33,8 @@ class DeviceEventCreatorFromTrace
   VPDatabase* db = nullptr;
 
   std::vector<uint64_t>  traceIDs;
-  std::vector<std::list<VTFDeviceEvent*>> cuStarts;
+  // Keep track of the event ID and device timestamp of CU starts
+  std::vector<std::list<std::pair<uint64_t, uint64_t>>> cuStarts;
 
   // Last Transactions
   std::vector<uint64_t> amLastTrans;


### PR DESCRIPTION
When translating PL hardware device events into host-aligned events, we were keeping track of the CU start events so we could use them in approximating end events if any hardware packets were dropped.  In continuous offload, however, the underlying event was dumped to disk and cleaned from memory, leaving a stray pointer to a deleted object.

This pull request changes the values we store in the device event creator to the event ID and device timestamp instead of the event object that wasn't owned by this class.