### PR TITLE
CR-1095772: Fix seg fault on profiling in software emulation when multiple devices are present

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -399,6 +399,7 @@ namespace xdp {
     }
 
     for (auto device: platform->get_device_range()) {
+      if (!device->is_active()) continue ;
       auto mem_tp = device->get_axlf_section<const mem_topology*>(axlf_section_kind::MEM_TOPOLOGY) ;
       if (!mem_tp) continue ;
       std::string devName = device->get_unique_name() ;


### PR DESCRIPTION
In software emulation, we collect some information to fill out our profile summary tables from the xocl structures, including parsing the memory topology axlf section.  When multiple software emulation devices exist, we were previously checking each one, which erroneously caused us to fetch a section on an uninitialized device.

This pull request adds a check to make sure the device is active before fetching the mem topology section to avoid a seg fault.
