### PR TITLE
Fix edge multi-processes regression

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -280,6 +280,8 @@ void subdev_destroy_cu(struct drm_zocl_dev *zdev)
 {
 	int i;
 
+	BUG_ON(zocl_xclbin_refcount(zdev));
+
 	for (i = 0; i < MAX_CU_NUM; ++i) {
 		if (!zdev->cu_pldev[i])
 			continue;


### PR DESCRIPTION
This is a regression that cu sub devices are destroyed/created even we have same xclbin already being loaded. This will lead to bad behavior in multi-processes where when process is actively using the cu sub devices and another process destroy/reset them.

The fix is resume only the behavior that we only destroy/create cu sub devices when we swap xclbin.