### PR TITLE
CR-1081043 : hbm grouping reporting is not showing terminus of hbm range

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -772,10 +772,11 @@ createMemoryBankGroupEntries( std::vector<WorkingConnection> & workingConnection
 
       // Add a tag value to indicate that this entry was the result of grouping memories
       std::string newTag = "MBG[";
-      for (unsigned int memIndex = startIndex; memIndex <= endIndex; ++memIndex) {
-        newTag += std::to_string(workingConnections[memIndex].memIndex);
-        newTag += (memIndex != endIndex) ? "," : "]";
-      }
+      newTag += std::to_string(workingConnections[startIndex].memIndex);
+      if (startIndex != endIndex)
+        newTag += ":" + std::to_string(workingConnections[endIndex].memIndex);
+
+      newTag += "]";
 
       // Record the new tag, honoring the size limitation
       ptGroupMemory.put("m_tag", newTag.substr(0, sizeof(mem_data::m_tag) - 1).c_str());

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -783,21 +783,21 @@ createMemoryBankGroupEntries( std::vector<WorkingConnection> & workingConnection
       // Contigious tag specified as start:end and non-contigious are seperated by ','
       // Ex. MBG[0,2,3,4,6,8,9] becomes MBG[0,2:4,6,8:9]
       std::string newTag = "MBG[";
-      for (unsigned int index = 0; index < memIndexVector.size();)
+      for (unsigned int idx = 0; idx < memIndexVector.size();)
       {
-        auto s_index = index;
-        while ((memIndexVector[index] + 1) == memIndexVector[index + 1])
-          index++;
+        auto s_index = idx;
+        while ((memIndexVector[idx] + 1) == memIndexVector[idx + 1])
+          idx++;
 
         newTag += std::to_string(memIndexVector[s_index]);
-        if (s_index != index) {
+        if (s_index != idx) {
           newTag += ":";
-          newTag += std::to_string(memIndexVector[index]);
+          newTag += std::to_string(memIndexVector[idx]);
         }
         
         // If terminal then add ']' otherwise add ','  
-        newTag += (index != memIndexVector.size() - 1) ? "," : "]";
-        index++;
+        newTag += (idx != memIndexVector.size() - 1) ? "," : "]";
+        idx++;
       }
 
       // Record the new tag, honoring the size limitation

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -795,7 +795,7 @@ createMemoryBankGroupEntries( std::vector<WorkingConnection> & workingConnection
           newTag += std::to_string(memIndexVector[index]);
         }
         
-	// If terminal then add ']' otherwise add ','  
+        // If terminal then add ']' otherwise add ','  
         newTag += (index != memIndexVector.size() - 1) ? "," : "]";
         index++;
       }


### PR DESCRIPTION
Modified group format for HBM, so that it will fit in 16bit buffer
-- Old Format was MBG[0,1,2,3]
-- New format is MBG[0:3]
Also for non-contagious banks i.e. MBG[4,2,3,0,6,8,9] becomes MBG[0,2:4,6,8:9] or MBG MBG[0:0,2:4,6:6,8:9]