### PR TITLE
CR-1095014 ASTeR TS9 - u50 nodma - 'xbutil examine' errors with 'No s…

### DIFF
--- a/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
@@ -44,7 +44,11 @@ ReportPcieInfo::getPropertyTree20202( const xrt_core::device * dev,
     ptree.add("sub_vendor", qr::pcie_subsystem_vendor::to_string(xrt_core::device_query<qr::pcie_subsystem_vendor>(dev)));
     ptree.add("link_speed_gbit_sec", xrt_core::device_query<qr::pcie_link_speed_max>(dev));
     ptree.add("express_lane_width_count", xrt_core::device_query<qr::pcie_express_lane_width>(dev));
-    ptree.add("dma_thread_count", xrt_core::device_query<qr::dma_threads_raw>(dev).size());
+
+    //this sysfs node might not be present for nodma, but it is safe to ignore.
+    try {
+      ptree.add("dma_thread_count", xrt_core::device_query<qr::dma_threads_raw>(dev).size());
+    } catch(...) {}
     ptree.add("cpu_affinity", xrt_core::device_query<qr::cpu_affinity>(dev));
     ptree.add("max_shared_host_mem_aperture_bytes", xrt_core::device_query<qr::max_shared_host_mem_aperture_bytes>(dev));
     ptree.add("shared_host_mem_size_bytes", xrt_core::device_query<qr::shared_host_mem>(dev));
@@ -73,8 +77,8 @@ ReportPcieInfo::writeReport( const xrt_core::device * dev,
   output << boost::format("  %-22s : %s\n") % "Sub Device" % pt_pcie.get<std::string>("sub_device");
   output << boost::format("  %-22s : %s\n") % "Sub Vendor" % pt_pcie.get<std::string>("sub_vendor");
   output << boost::format("  %-22s : Gen%sx%s\n") % "PCIe" % pt_pcie.get<std::string>("link_speed_gbit_sec") % pt_pcie.get<std::string>("express_lane_width_count");
-  output << boost::format("  %-22s : %s\n") % "DMA Thread Count" % pt_pcie.get<std::string>("dma_thread_count");
-  output << boost::format("  %-22s : %s\n") % "CPU Affinity" % pt_pcie.get<std::string>("cpu_affinity");
+  output << boost::format("  %-22s : %s\n") % "DMA Thread Count" % pt_pcie.get<std::string>("dma_thread_count", "0");
+  output << boost::format("  %-22s : %s\n") % "CPU Affinity" % pt_pcie.get<std::string>("cpu_affinity", "0");
   output << boost::format("  %-22s : %s Bytes\n") % "Shared Host Memory" % pt_pcie.get<std::string>("host_mem_size_bytes", "0");
   output << boost::format("  %-22s : %s Bytes\n") % "Max Shared Host Memory" % pt_pcie.get<std::string>("max_shared_host_mem_aperture_bytes", "0");
   output << std::endl;


### PR DESCRIPTION
…uch node (dma_thread_count)'