### PR TITLE
CR-1097328 P2p regression in XRT in 2021.1

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -540,10 +540,15 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	case ERT_START_COPYBO:
 		ret = copybo_ecmd2xcmd(xdev, filp, to_copybo_pkg(ecmd), xcmd);
 		if (ret > 0) {
+			xcmd->status = KDS_COMPLETED;
+			xcmd->cb.notify_host(xcmd, xcmd->status);
 			ret = 0;
 			goto out1;
-		} else if (ret < 0)
+		} else if (ret < 0) {
+			xcmd->status = KDS_ERROR;
+			xcmd->cb.notify_host(xcmd, xcmd->status);
 			goto out1;
+		}
 
 		break;
 	case ERT_SK_START:


### PR DESCRIPTION
The application hang is because new KDS doesn't notify host when perform P2P copy.