### PR TITLE
CR-1081755 XRT to internally handle NoDMA buffer that is not 64 byte multiple

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -895,7 +895,7 @@ int shim::m2mCopyBO(unsigned int dst_bo_handle,
 	    .src_offset = src_offset,
     };
 
-    return mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_COPY_BO, &m2m);
+    return mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_COPY_BO, &m2m) ? -errno : 0;
 }
 
 /*


### PR DESCRIPTION
Cannot support or work-arounds hardware limitation.

This PR throws error when buffer size is not a multiple of 64 bytes.

It also adds NoDMA support with userptr and issues warning about
encurring extra copying.