### PR TITLE
CR-1078490 Double buffer created in no-dma platform when not using host_only flag

### DIFF
--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -55,9 +55,9 @@ public:
   // device index type
   using id_type = unsigned int;
   using handle_type = xclDeviceHandle;
+  using memory_type = xrt::xclbin::mem::memory_type;
 
 public:
-
   XRT_CORE_COMMON_EXPORT
   device(id_type device_id);
 
@@ -267,6 +267,9 @@ public:
    */
   const std::vector<size_t>&
   get_memidx_encoding(const uuid& xclbin_id = uuid()) const;
+
+  memory_type
+  get_memory_type(size_t memidx) const;
 
   /**
    * get_ert_slots() - Get number of ERT CQ slots

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -114,7 +114,8 @@ public:
       hbm                  = MEM_HBM,
       bram                 = MEM_BRAM,
       uram                 = MEM_URAM,
-      streaming_connection = MEM_STREAMING_CONNECTION
+      streaming_connection = MEM_STREAMING_CONNECTION,
+      host                 = MEM_HOST
     };
   
   public:

--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -184,7 +184,8 @@ extern "C" {
         MEM_HBM,
         MEM_BRAM,
         MEM_URAM,
-        MEM_STREAMING_CONNECTION
+        MEM_STREAMING_CONNECTION,
+        MEM_HOST
     };
 
     enum IP_TYPE {

--- a/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionGroupTopology.cxx
@@ -47,6 +47,8 @@ SectionGroupTopology::getMemTypeStr(enum MEM_TYPE _memType) const {
       return "MEM_ARE";
     case MEM_STREAMING_CONNECTION:
       return "MEM_STREAMING_CONNECTION";
+    case MEM_HOST:
+      return "MEM_HOST";
   }
 
   return XUtil::format("UNKNOWN (%d)", (unsigned int)_memType);
@@ -83,6 +85,9 @@ SectionGroupTopology::getMemType(std::string& _sMemType) const {
 
   if (_sMemType == "MEM_STREAMING_CONNECTION")
     return MEM_STREAMING_CONNECTION;
+
+  if (_sMemType == "MEM_HOST")
+    return MEM_HOST;
 
   std::string errMsg = "ERROR: Unknown memory type: '" + _sMemType + "'";
   throw std::runtime_error(errMsg);

--- a/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
@@ -55,6 +55,8 @@ SectionMemTopology::getMemTypeStr(enum MEM_TYPE _memType) const {
       return "MEM_ARE";
     case MEM_STREAMING_CONNECTION:
       return "MEM_STREAMING_CONNECTION";
+    case MEM_HOST:
+      return "MEM_HOST";
   }
 
   return XUtil::format("UNKNOWN (%d)", (unsigned int)_memType);
@@ -91,6 +93,9 @@ SectionMemTopology::getMemType(std::string& _sMemType) const {
 
   if (_sMemType == "MEM_STREAMING_CONNECTION")
     return MEM_STREAMING_CONNECTION;
+
+  if (_sMemType == "MEM_HOST")
+    return MEM_HOST;
 
   std::string errMsg = "ERROR: Unknown memory type: '" + _sMemType + "'";
   throw std::runtime_error(errMsg);


### PR DESCRIPTION
Adjust buffer flags to infer host_only when buffer is allocated in
host memory bank.  This change impacts NoDMA platforms only, where it
prevents unncessary double BO creation.

This PR reverts support for userptr for NoDMA platforms that was added
in #5187.  Also error out in general when application attempts to
construct host_only BOs with a userptr, which just like NoDMA case
would imply an extra memcpy managed in userspace XRT. XRT should not
hide extra memcpy in general, if host code really wants this, then do
it in the host code itself.

Finally, this PR adds MEM_HOST to the MEM_TYPE enumeration in
xclbin.h.  While the xclbin itself does not use this enumerator, it is
now used internally in XRT implementation when returning the memory
type of a bank based on the mem_data::m_tag comparison. Once supported
fully by upstream tools and platforms, XRT can avoid the string
comparison and rely on the enumerator value in mem_data::m_type.