### PR TITLE
xbutil/xbmgmt: Various bug fixes and EoU enhancments

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -895,7 +895,7 @@ int shim::m2mCopyBO(unsigned int dst_bo_handle,
 	    .src_offset = src_offset,
     };
 
-    return mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_COPY_BO, &m2m);
+    return mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_COPY_BO, &m2m) ? -errno : 0;
 }
 
 /*

--- a/src/runtime_src/core/tools/common/OptionOptions.cpp
+++ b/src/runtime_src/core/tools/common/OptionOptions.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,6 +44,7 @@ OptionOptions::printHelp() const
   XBU::report_subcommand_help( m_executable, 
                                m_command + " --" + m_longName, 
                                m_description, m_extendedHelp, 
-                               m_optionsDescription, m_optionsHidden, m_positionalOptions);
+                               m_optionsDescription, m_optionsHidden, 
+                               m_positionalOptions, m_globalOptions);
 }
 

--- a/src/runtime_src/core/tools/common/OptionOptions.h
+++ b/src/runtime_src/core/tools/common/OptionOptions.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -42,6 +42,8 @@ class OptionOptions {
   const boost::program_options::positional_options_description & 
     getPositionalOptions() const { return m_positionalOptions; } ;
 
+  void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
+
  public:
   virtual ~OptionOptions() {};
 
@@ -67,6 +69,7 @@ class OptionOptions {
   bool m_isHidden;
   std::string m_description;
   std::string m_extendedHelp;
+  boost::program_options::options_description m_globalOptions;
 };
   
 #endif

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -84,7 +84,7 @@ setShellPathEnv(const std::string& var_name, const std::string& trailing_path)
 static void 
 testCaseProgressReporter(std::shared_ptr<XBUtilities::ProgressBar> run_test, bool& is_done)
 {
-  int counter = 0;
+  unsigned int counter = 0;
   while((counter < run_test.get()->getMaxIterations()) && !is_done) {
     run_test.get()->update(counter++);
     std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -96,7 +96,8 @@ XBUtilities::runScript( const std::string & env,
                         const std::string & script, 
                         const std::vector<std::string> & args,
                         std::ostringstream & os_stdout,
-                        std::ostringstream & os_stderr)
+                        std::ostringstream & os_stderr,
+                        bool /*erasePassFailMessage*/)
 {
   // Fix environment variables before running test case
   setenv("XILINX_XRT", "/opt/xilinx/xrt", 0);

--- a/src/runtime_src/core/tools/common/Process.h
+++ b/src/runtime_src/core/tools/common/Process.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,7 +26,8 @@ namespace XBUtilities {
                const std::string & script, 
                const std::vector<std::string> & args,
                std::ostringstream & os_stdout,
-               std::ostringstream & os_stderr);
+               std::ostringstream & os_stderr,
+               bool erasePassFailMessage);
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ProgressBar.cpp
+++ b/src/runtime_src/core/tools/common/ProgressBar.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -55,8 +55,8 @@ static boost::format fmtBatchPF("\n[%s]: %s < %s >\n");
 
 // ------ S T A T I C   F U N C T I O N S -------------------------------------
 
-static std::string
-format_time(std::chrono::duration<double> duration) 
+std::string
+ProgressBar::formatTime(std::chrono::duration<double> duration) 
 {
   auto hours = std::chrono::duration_cast<std::chrono::hours>(duration);
   auto minutes = std::chrono::duration_cast<std::chrono::minutes>(duration);
@@ -88,7 +88,7 @@ ProgressBar::ProgressBar(const std::string &_opNname, unsigned int _maxNumIterat
     , m_lastUpdated(std::chrono::high_resolution_clock::now()) 
 {
   if (!m_isBatch) 
-    m_ostr << fmtUpdate % "" % /*Percent*/ 0 % m_opName % format_time(m_elapsedTime) << std::endl;
+    m_ostr << fmtUpdate % "" % /*Percent*/ 0 % m_opName % formatTime(m_elapsedTime) << std::endl;
   else 
     m_ostr << m_opName << ": ";
 
@@ -114,7 +114,7 @@ ProgressBar::finish(bool _successful, const std::string &_msg)
 
   // -- Batch --
   if (m_isBatch) {
-    m_ostr << fmtBatchPF % (_successful ? "PASSED" : "FAILED") % _msg % format_time(m_elapsedTime);
+    m_ostr << fmtBatchPF % (_successful ? "PASSED" : "FAILED") % _msg % formatTime(m_elapsedTime);
     m_ostr.flush();
     return;
   }
@@ -123,7 +123,7 @@ ProgressBar::finish(bool _successful, const std::string &_msg)
   boost::format &fmt = _successful ? fmtPassed : fmtFailed;
   m_ostr << EscapeCodes::cursor().prev_line()
          << EscapeCodes::cursor().clear_line()
-         << fmt % _msg % format_time(m_elapsedTime)
+         << fmt % _msg % formatTime(m_elapsedTime)
          << std::endl << EscapeCodes::cursor().show();
 
   m_ostr.flush();
@@ -196,7 +196,7 @@ ProgressBar::update(unsigned int _iteration)
 
   // Write the new progress bar
   m_ostr << EscapeCodes::cursor().prev_line()
-         << fmtUpdate % progressBar % runningPercent % m_opName % format_time(m_elapsedTime)
+         << fmtUpdate % progressBar % runningPercent % m_opName % formatTime(m_elapsedTime)
          << std::endl;
 
   m_ostr.flush();

--- a/src/runtime_src/core/tools/common/ProgressBar.h
+++ b/src/runtime_src/core/tools/common/ProgressBar.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -51,6 +51,11 @@ class ProgressBar {
   void
   finish(bool _successful, const std::string &_msg);
 
+  static std::string
+  formatTime(std::chrono::duration<double> duration);
+
+  unsigned int getMaxIterations() {return m_maxNumIterations;}
+  
   ~ProgressBar();
   ProgressBar() = delete;
 

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -25,7 +25,6 @@
 // Initialize our static mapping.
 const Report::SchemaDescriptionVector Report::m_schemaVersionVector = {
   { SchemaVersion::unknown,       false, "",              "Unknown entry"},
-  { SchemaVersion::text,          true,  "text",          "Human readable report (default)"},
   { SchemaVersion::json_20202,    true,  "JSON",          "Latest JSON schema"}, // Note: to be updated to the latest schema version every release
   { SchemaVersion::json_internal, false, "JSON-internal", "Internal JSON property tree"},
   { SchemaVersion::json_20202,    true,  "JSON-2020.2",   "JSON 2020.2 schema"}
@@ -70,41 +69,37 @@ Report::Report(const std::string & _reportName,
 }
 
 
-boost::any 
-Report::getFormattedReport(const xrt_core::device *_pDevice, 
-                           SchemaVersion _schemaVersion,
-                           const std::vector<std::string> & _elementFilter) const
+void 
+Report::getFormattedReport( const xrt_core::device *pDevice, 
+                            SchemaVersion schemaVersion,
+                            const std::vector<std::string> & elementFilter,
+                            std::ostream & consoleStream,
+                            boost::property_tree::ptree & pt) const
 {
-  // Helper variables
-  boost::property_tree::ptree _pt;
-  std::stringstream _ostream;
-  boost::any returnValue;
+  try {
+    switch (schemaVersion) {
+      case SchemaVersion::json_internal:
+        getPropertyTreeInternal(pDevice, pt);
+        break;
 
-  switch (_schemaVersion) {
-    case SchemaVersion::text:  
-      writeReport(_pDevice, _elementFilter, _ostream);
-      returnValue = _ostream.str();
-      return returnValue;
+      case SchemaVersion::json_20202:
+        getPropertyTree20202(pDevice, pt);
+        break;
 
-    case SchemaVersion::json_internal:
-      getPropertyTreeInternal(_pDevice, _pt);
-      returnValue = _pt;
-      return returnValue;
+      default:
+        throw std::runtime_error("ERROR: Unknown schema version.");
+        break;
+    }
 
-    case SchemaVersion::json_20202:
-      getPropertyTree20202(_pDevice, _pt);
-      returnValue = _pt;
-      return returnValue;
+    writeReport(pDevice, pt, elementFilter, consoleStream);
+  } catch (const std::exception& e) {
+    std::string reportName = getReportName();
+    if (!reportName.empty()) {
+      reportName[0] = std::toupper(reportName[0]);
+      std::cerr << reportName << std::endl;
+    }
 
-    case SchemaVersion::unknown:
-      throw std::runtime_error("ERROR: Unknown schema version.");
-
-    // Note: There is no default in this switch statement.  Relying on the
-    //       compiler to produce a warning indicating that all of the enum values
-    //       are present.
+    std::cerr << "  ERROR: " << e.what() << std::endl << std::endl;
+    // Fall through
   }
-
-  // Code will never get here, but the compiler doesn't know that.
-  throw std::runtime_error("Report::getFormattedReport() - Unexpected execution in the code flow.");
 }
-

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -95,7 +95,7 @@ Report::getFormattedReport( const xrt_core::device *pDevice,
   } catch (const std::exception& e) {
     std::string reportName = getReportName();
     if (!reportName.empty()) {
-      reportName[0] = std::toupper(reportName[0]);
+      reportName[0] = static_cast<char>(std::toupper(reportName[0]));
       std::cerr << reportName << std::endl;
     }
 

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -31,7 +31,6 @@ class Report {
   // Remember to update the initialization of Report::m_schemaVersionMapping 
   // if new enumeration values are added
   enum class SchemaVersion  {
-    text,
     unknown,
     json_internal,
     json_20202,
@@ -58,11 +57,11 @@ class Report {
   const std::string & getShortDescription() const { return m_shortDescription; };
   bool isDeviceRequired() const { return m_isDeviceRequired; };
 
-  boost::any getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter) const;
+  void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 
  // Child methods that need to be implemented
  protected:
-  virtual void writeReport(const xrt_core::device *_pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const = 0;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& pt, const std::vector<std::string>& _elementsFilter,std::ostream & _output) const = 0;
   virtual void getPropertyTreeInternal(const xrt_core::device *_pDevice, boost::property_tree::ptree &_pt) const = 0;
   virtual void getPropertyTree20202(const xrt_core::device *_pDevice, boost::property_tree::ptree &_pt) const = 0;
 

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020 Xilinx, Inc
+  Copyright (C) 2020-2021 Xilinx, Inc
  
   Licensed under the Apache License, Version 2.0 (the "License"). You may
   not use this file except in compliance with the License. A copy of the
@@ -542,13 +542,12 @@ ReportAie::getPropertyTree20202(const xrt_core::device * _pDevice,
 }
 
 void 
-ReportAie::writeReport(const xrt_core::device * _pDevice,
-                       const std::vector<std::string> & /*_elementsFilter*/, 
-                       std::iostream & _output) const
+ReportAie::writeReport(const xrt_core::device* _pDevice,
+                       const boost::property_tree::ptree& _pt, 
+                       const std::vector<std::string>& _elementsFilter, 
+                       std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   // validate and print aie metadata by checking schema_version node
   if(!_pt.get_child_optional("aie_metadata.schema_version"))
@@ -559,7 +558,7 @@ ReportAie::writeReport(const xrt_core::device * _pDevice,
 
   try {
     for (auto& gr: _pt.get_child("aie_metadata.graphs")) {
-      boost::property_tree::ptree& graph = gr.second;
+      const boost::property_tree::ptree& graph = gr.second;
       _output << boost::format("  GRAPH[%2d] %-10s: %s\n") % graph.get<std::string>("id")
            % "Name" % graph.get<std::string>("name");
       _output << boost::format("            %-10s: %s\n") % "Status" % graph.get<std::string>("status");
@@ -567,7 +566,7 @@ ReportAie::writeReport(const xrt_core::device * _pDevice,
            % "Iteration_Memory [C:R]" % "Iteration_Memory_Addresses";
       int count = 0;
       for (auto& node : graph.get_child("tile")) {
-        boost::property_tree::ptree& tile = node.second;
+        const boost::property_tree::ptree& tile = node.second;
         _output << boost::format("    [%2d]   %-20s%-30s%-30d\n") % count
             % (tile.get<std::string>("column") + ":" + tile.get<std::string>("row"))
             % (tile.get<std::string>("memory_column") + ":" + tile.get<std::string>("memory_row"))

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -542,9 +542,9 @@ ReportAie::getPropertyTree20202(const xrt_core::device * _pDevice,
 }
 
 void 
-ReportAie::writeReport(const xrt_core::device* _pDevice,
+ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
                        const boost::property_tree::ptree& _pt, 
-                       const std::vector<std::string>& _elementsFilter, 
+                       const std::vector<std::string>& /*_elementsFilter*/, 
                        std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportAie.h
+++ b/src/runtime_src/core/tools/common/ReportAie.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportAie : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -285,20 +285,27 @@ ReportAieShim::getPropertyTree20202(const xrt_core::device * _pDevice,
 }
 
 void 
-ReportAieShim::writeReport(const xrt_core::device * _pDevice,
-                       const std::vector<std::string> & /*_elementsFilter*/, 
-                       std::iostream & _output) const
+ReportAieShim::writeReport( const xrt_core::device* _pDevice,
+                            const boost::property_tree::ptree& _pt, 
+                            const std::vector<std::string>& _elementsFilter,
+                            std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
-  _output << "Aie\n";
-  _output << boost::format("  %-10s\n") % _pt.get<std::string>("aie_shim_status.description");
+  _output << "AIE\n";
 
   try {
     int count = 0;
-    for (auto& tile: _pt.get_child("aie_shim_status.tiles")) {
+    const boost::property_tree::ptree ptShimTiles = _pt.get_child("aie_shim_status.tiles", empty_ptree);
+
+    if (ptShimTiles.empty()) {
+      _output << "  <AIE information unavailable>" << std::endl << std::endl;
+      return;
+    }
+
+    _output << "  Shim Status" << std::endl;
+
+    for (auto &tile : ptShimTiles) {
       _output << boost::format("Tile[%2d]\n") % count++;
       _output << fmt4("%d") % "Column" % tile.second.get<int>("column");
       _output << fmt4("%d") % "Row" % tile.second.get<int>("row");

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -285,9 +285,9 @@ ReportAieShim::getPropertyTree20202(const xrt_core::device * _pDevice,
 }
 
 void 
-ReportAieShim::writeReport( const xrt_core::device* _pDevice,
+ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
                             const boost::property_tree::ptree& _pt, 
-                            const std::vector<std::string>& _elementsFilter,
+                            const std::vector<std::string>& /*_elementsFilter*/,
                             std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportAieShim.h
+++ b/src/runtime_src/core/tools/common/ReportAieShim.h
@@ -28,7 +28,7 @@ class ReportAieShim : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportAsyncError.cpp
+++ b/src/runtime_src/core/tools/common/ReportAsyncError.cpp
@@ -77,9 +77,10 @@ ReportAsyncError::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void
-ReportAsyncError::writeReport( const xrt_core::device* _pDevice,
-                                  const boost::property_tree::ptree& _pt,
-                                  const std::vector<std::string>& _elementsFilter,std::ostream & _output) const
+ReportAsyncError::writeReport( const xrt_core::device* /*_pDevice*/,
+                               const boost::property_tree::ptree& _pt,
+                               const std::vector<std::string>& /*_elementsFilter*/,
+                               std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;
 

--- a/src/runtime_src/core/tools/common/ReportAsyncError.cpp
+++ b/src/runtime_src/core/tools/common/ReportAsyncError.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -77,16 +77,14 @@ ReportAsyncError::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void
-ReportAsyncError::writeReport( const xrt_core::device * _pDevice,
-                                  const std::vector<std::string> & /*_elementsFilter*/,
-                                  std::iostream & _output) const
+ReportAsyncError::writeReport( const xrt_core::device* _pDevice,
+                                  const boost::property_tree::ptree& _pt,
+                                  const std::vector<std::string>& _elementsFilter,std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   //check if a valid report is generated
-  boost::property_tree::ptree& pt_err = _pt.get_child("asynchronous_errors");
+  const boost::property_tree::ptree& pt_err = _pt.get_child("asynchronous_errors");
   if(pt_err.empty())
     return;
 

--- a/src/runtime_src/core/tools/common/ReportAsyncError.h
+++ b/src/runtime_src/core/tools/common/ReportAsyncError.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportAsyncError : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter,std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -251,26 +251,25 @@ ReportCu::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportCu::writeReport( const xrt_core::device * _pDevice,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & _output) const
+ReportCu::writeReport( const xrt_core::device* _pDevice,
+                       const boost::property_tree::ptree& _pt, 
+                       const std::vector<std::string>& _elementsFilter,std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
-  boost::format cuFmt("%-8s%-30s%-16s%-8s%-8s\n");
+  boost::format cuFmt("    %-8s%-30s%-16s%-8s%-8s\n");
 
   //check if a valid CU report is generated
-  boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units");
+  const boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units", empty_ptree);
   if(pt_cu.empty())
     return;
 
-  _output << "PL Compute Units" << std::endl;
+  _output << "Compute Units" << std::endl;
+  _output << "  PL Compute Units" << std::endl;
   _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
   try {
     int index = 0;
     for(auto& kv : pt_cu) {
-      boost::property_tree::ptree& cu = kv.second;
+      const boost::property_tree::ptree& cu = kv.second;
       if(cu.get<std::string>("type").compare("PL") != 0)
         continue;
       std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
@@ -286,12 +285,12 @@ ReportCu::writeReport( const xrt_core::device * _pDevice,
   _output << std::endl;
 
   //PS kernel report
-  _output << "PS Compute Units" << std::endl;
+  _output << "  PS Compute Units" << std::endl;
   _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
   try {
     int index = 0;
     for(auto& kv : pt_cu) {
-      boost::property_tree::ptree& cu = kv.second;
+      const boost::property_tree::ptree& cu = kv.second;
       if(cu.get<std::string>("type").compare("PS") != 0)
         continue;
       std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");

--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -251,9 +251,10 @@ ReportCu::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportCu::writeReport( const xrt_core::device* _pDevice,
+ReportCu::writeReport( const xrt_core::device* /*_pDevice*/,
                        const boost::property_tree::ptree& _pt, 
-                       const std::vector<std::string>& _elementsFilter,std::ostream & _output) const
+                       const std::vector<std::string>& /*_elementsFilter*/,
+                       std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;
   boost::format cuFmt("    %-8s%-30s%-16s%-8s%-8s\n");

--- a/src/runtime_src/core/tools/common/ReportCu.h
+++ b/src/runtime_src/core/tools/common/ReportCu.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportCu : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportDebugIpStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportDebugIpStatus.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -178,9 +178,9 @@ DebugIpStatusCollector::DebugIpStatusCollector(xclDeviceHandle h,
     if (jsonFormat) {
       infoMessage = "Failed to find any Debug IP Layout section in the bitstream loaded on device. Ensure that a valid bitstream with debug IPs (AIM, LAPC) is successfully downloaded." ;
     } else {
-      _output << "INFO: Failed to find any Debug IP Layout section in the bitstream loaded on device. "
-		<< "Ensure that a valid bitstream with debug IPs (AIM, LAPC) is successfully downloaded. \n"
-		<< std::endl;
+      _output << "  INFO: Failed to find any Debug IP Layout section in the bitstream loaded on device. "
+		          << "Ensure that a valid bitstream with debug IPs (AIM, LAPC) is successfully downloaded. \n"
+		          << std::endl;
     }
    return;
   }
@@ -194,7 +194,7 @@ DebugIpStatusCollector::DebugIpStatusCollector(xclDeviceHandle h,
   std::string path(layoutPath.data());
 
   if(path.empty()) {
-    _output << "INFO: Failed to find path to Debug IP Layout. "
+    _output << "  INFO: Failed to find path to Debug IP Layout. "
             << "Ensure that a valid bitstream with debug IPs (AIM, LAPC) is successfully downloaded. \n"
             << std::endl;
     return;
@@ -269,13 +269,13 @@ DebugIpStatusCollector::printOverview(std::ostream& _output)
         // No need to show these Debug IP types
         continue;
       default:
-        _output << "Found invalid IP in debug ip layout with type "
+        _output << "  Found invalid IP in debug ip layout with type "
                 << dbgIpLayout->m_debug_ip_data[i].m_type << std::endl;
         return;
     }
   }
 
-  _output << "Number of IPs found :: " << count << std::endl; // Total count with the IPs actually shown
+  _output << "  Number of IPs found :: " << count << std::endl; // Total count with the IPs actually shown
 
   std::stringstream sstr;
   for(uint32_t i = 0; i < maxDebugIpType; i++) {
@@ -285,7 +285,7 @@ DebugIpStatusCollector::printOverview(std::ostream& _output)
     sstr << debugIpNames[i] << " : " << debugIpNum[i] << std::endl;
   }
 
-  _output << "IPs found [<ipname <(element filter option)>> :<count>)]: " << std::endl << sstr.str() << std::endl;
+  _output << "  IPs found [<ipname <(element filter option)>> :<count>)]: " << std::endl << sstr.str() << std::endl;
 }
 
 void 
@@ -620,12 +620,12 @@ DebugIpStatusCollector::printAIMResults(std::ostream& _output)
   auto col1 = std::max(cuNameMaxStrLen[AXI_MM_MONITOR], strlen("Region or CU")) + 4;
   auto col2 = std::max(portNameMaxStrLen[AXI_MM_MONITOR], strlen("Type or Port"));
 
-  boost::format header("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s %-16s");
+  boost::format header("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s %-16s");
   _output << header % "Region or CU" % "Type or Port" %  "Write kBytes" % "Write Trans." % "Read kBytes" % "Read Tranx."
                     % "Outstanding Cnt" % "Last Wr Addr" % "Last Wr Data" % "Last Rd Addr" % "Last Rd Data"
           << std::endl;
 
-  boost::format valueFormat("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16.3f  %-16llu  %-16.3f  %-16llu  %-16llu  0x%-14x  0x%-14x  0x%-14x 0x%-14x");
+  boost::format valueFormat("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16.3f  %-16llu  %-16.3f  %-16llu  %-16llu  0x%-14x  0x%-14x  0x%-14x 0x%-14x");
   for (size_t i = 0; i< aimResults.NumSlots; ++i) {
     _output << valueFormat
                   % cuNames[AXI_MM_MONITOR][i] % portNames[AXI_MM_MONITOR][i]
@@ -822,11 +822,11 @@ DebugIpStatusCollector::printAMResults(std::ostream& _output)
 
   auto col1 = std::max(cuNameMaxStrLen[ACCEL_MONITOR], strlen("Compute Unit")) + 4;
 
-  boost::format header("%-"+std::to_string(col1)+"s %-8s  %-8s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s");
+  boost::format header("  %-"+std::to_string(col1)+"s %-8s  %-8s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s");
   _output << header % "Compute Unit"  % "Ends" % "Starts" % "Max Parallel Itr" % "Execution" % "Memory Stall" % "Pipe Stall" % "Stream Stall" % "Min Exec" % "Max Exec"
           << std::endl;
 
-  boost::format valueFormat("%-"+std::to_string(col1)+"s %-8llu  %-8llu  %-16llu  0x%-14x  0x%-14x  0x%-14x  0x%-14x  0x%-14x  0x%-14x");
+  boost::format valueFormat("  %-"+std::to_string(col1)+"s %-8llu  %-8llu  %-16llu  0x%-14x  0x%-14x  0x%-14x  0x%-14x  0x%-14x  0x%-14x");
   for (size_t i = 0; i < amResults.NumSlots; ++i) {
     _output << valueFormat
                   % cuNames[ACCEL_MONITOR][i] 
@@ -957,11 +957,11 @@ DebugIpStatusCollector::printASMResults(std::ostream& _output)
   auto col1 = std::max(cuNameMaxStrLen[AXI_STREAM_MONITOR], strlen("Stream Master")) + 4;
   auto col2 = std::max(portNameMaxStrLen[AXI_STREAM_MONITOR], strlen("Stream Slave"));
 
-  boost::format header("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s  %-16s  %-16s");
+  boost::format header("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s  %-16s  %-16s");
   _output << header % "Stream Master" % "Stream Slave" % "Num Trans." % "Data kBytes" % "Busy Cycles" % "Stall Cycles" % "Starve Cycles"
           << std::endl;
 
-  boost::format valueFormat("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16llu  %-16.3f  %-16llu  %-16llu %-16llu");
+  boost::format valueFormat("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16llu  %-16.3f  %-16llu  %-16llu %-16llu");
   for (size_t i = 0; i < asmResults.NumSlots; ++i) {
     _output << valueFormat
                   % cuNames[AXI_STREAM_MONITOR][i] % portNames[AXI_STREAM_MONITOR][i]
@@ -1142,12 +1142,12 @@ DebugIpStatusCollector::printLAPCResults(std::ostream& _output)
     _output << "No AXI violations found \n";
 
   if (violations_found && /*aVerbose &&*/ !invalid_codes) {
-    boost::format header("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s");
+    boost::format header("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s  %-16s");
     _output << header % "CU Name" % "AXI Portname" % "Overall Status" % "Snapshot[0]" % "Snapshot[1]" % "Snapshot[2]" % "Snapshot[3]"
                       % "Cumulative[0]" % "Cumulative[1]" % "Cumulative[2]" % "Cumulative[3]"
             << std::endl;
 
-    boost::format valueFormat("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x");
+    boost::format valueFormat("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x  %-16x");
     for (size_t i = 0; i < lapcResults.NumSlots; ++i) {
       _output << valueFormat
                     % cuNames[LAPC][i] % portNames[LAPC][i]
@@ -1299,12 +1299,12 @@ DebugIpStatusCollector::printSPCResults(std::ostream& _output)
     auto col1 = std::max(cuNameMaxStrLen[AXI_STREAM_PROTOCOL_CHECKER], strlen("CU Name")) + 4;
     auto col2 = std::max(portNameMaxStrLen[AXI_STREAM_PROTOCOL_CHECKER], strlen("AXI Portname"));
 
-    boost::format header("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s");
+    boost::format header("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16s  %-16s  %-16s");
     _output << std::endl
             << header % "CU Name" % "AXI Portname" % "Overall Status" % "Snapshot" % "Current"
             << std::endl;
 
-    boost::format valueFormat("%-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16x  %-16x  %-16x");
+    boost::format valueFormat("  %-"+std::to_string(col1)+"s %-"+std::to_string(col2)+"s  %-16x  %-16x  %-16x");
     for (size_t i = 0; i < spcResults.NumSlots; ++i) {
       _output << valueFormat
                     % cuNames[AXI_STREAM_PROTOCOL_CHECKER][i] % portNames[AXI_STREAM_PROTOCOL_CHECKER][i]
@@ -1612,9 +1612,10 @@ ReportDebugIpStatus::getPropertyTree20202( const xrt_core::device * _pDevice,
 
 
 void 
-ReportDebugIpStatus::writeReport( const xrt_core::device * _pDevice,
-                             const std::vector<std::string> & _elementsFilter, 
-                             std::iostream & _output) const
+ReportDebugIpStatus::writeReport( const xrt_core::device* _pDevice,
+                                  const boost::property_tree::ptree& /*_pt*/, 
+                                  const std::vector<std::string>& _elementsFilter,
+                                  std::ostream & _output) const
 {
   auto handle = _pDevice->get_device_handle();
 

--- a/src/runtime_src/core/tools/common/ReportDebugIpStatus.h
+++ b/src/runtime_src/core/tools/common/ReportDebugIpStatus.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportDebugIpStatus : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -155,9 +155,9 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportElectrical::writeReport( const xrt_core::device* _pDevice,
+ReportElectrical::writeReport( const xrt_core::device* /*_pDevice*/,
                                const boost::property_tree::ptree& _pt, 
-                               const std::vector<std::string>& _elementsFilter,
+                               const std::vector<std::string>& /*_elementsFilter*/,
                                std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -68,7 +68,7 @@ lvl_to_power_watts(uint64_t lvl)
 
 void
 ReportElectrical::getPropertyTreeInternal( const xrt_core::device * _pDevice, 
-                                              boost::property_tree::ptree &_pt) const
+                                           boost::property_tree::ptree &_pt) const
 {
   // Defer to the 20202 format.  If we ever need to update JSON data, 
   // Then update this method to do so.
@@ -77,7 +77,7 @@ ReportElectrical::getPropertyTreeInternal( const xrt_core::device * _pDevice,
 
 void 
 ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice, 
-                                           boost::property_tree::ptree &_pt) const
+                                        boost::property_tree::ptree &_pt) const
 {
   boost::property_tree::ptree pt;
   std::string power_watts;
@@ -155,22 +155,21 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportElectrical::writeReport( const xrt_core::device * _pDevice,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & _output) const
+ReportElectrical::writeReport( const xrt_core::device* _pDevice,
+                               const boost::property_tree::ptree& _pt, 
+                               const std::vector<std::string>& _elementsFilter,
+                               std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   _output << "Electrical\n";
-  boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
-  _output << boost::format("  %-22s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts");
-  _output << boost::format("  %-22s: %s Watts\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts");
-  _output << boost::format("  %-22s: %s\n\n") % "Power Warning" % _pt.get<std::string>("electrical.power_consumption_warning");
-  _output << boost::format("  %-22s: %6s   %6s\n") % "Power Rails" % "Voltage" % "Current";
+  const boost::property_tree::ptree& electricals = _pt.get_child("electrical.power_rails", empty_ptree);
+  _output << boost::format("  %-23s: %s Watts\n") % "Max Power" % _pt.get<std::string>("electrical.power_consumption_max_watts");
+  _output << boost::format("  %-23s: %s Watts\n") % "Power" % _pt.get<std::string>("electrical.power_consumption_watts");
+  _output << boost::format("  %-23s: %s\n\n") % "Power Warning" % _pt.get<std::string>("electrical.power_consumption_warning");
+  _output << boost::format("  %-23s: %6s   %6s\n") % "Power Rails" % "Voltage" % "Current";
   for(auto& kv : electricals) {
-    boost::property_tree::ptree& pt_sensor = kv.second;
+    const boost::property_tree::ptree& pt_sensor = kv.second;
     std::string name = pt_sensor.get<std::string>("description");
     bool volts_is_present = pt_sensor.get<bool>("voltage.is_present");
     std::string volts = pt_sensor.get<std::string>("voltage.volts");
@@ -178,11 +177,11 @@ ReportElectrical::writeReport( const xrt_core::device * _pDevice,
     std::string amps = pt_sensor.get<std::string>("current.amps");
 
     if(volts_is_present && amps_is_present)
-      _output << boost::format("  %-22s: %6s V, %6s A\n") % name % volts % amps;
+      _output << boost::format("  %-23s: %6s V, %6s A\n") % name % volts % amps;
     else if(volts_is_present)
-      _output << boost::format("  %-22s: %6s V\n") % name % volts;
+      _output << boost::format("  %-23s: %6s V\n") % name % volts;
     else if(amps_is_present)
-      _output << boost::format("  %-22s: %16s A\n") % name % amps;
+      _output << boost::format("  %-23s: %16s A\n") % name % amps;
   }
   _output << std::endl;
   

--- a/src/runtime_src/core/tools/common/ReportElectrical.h
+++ b/src/runtime_src/core/tools/common/ReportElectrical.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportElectrical : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportFirewall.cpp
+++ b/src/runtime_src/core/tools/common/ReportFirewall.cpp
@@ -46,9 +46,9 @@ ReportFirewall::getPropertyTree20202( const xrt_core::device * _pDevice,
 
 
 void 
-ReportFirewall::writeReport(const xrt_core::device* _pDevice,
+ReportFirewall::writeReport(const xrt_core::device* /*_pDevice*/,
                             const boost::property_tree::ptree& _pt,
-                            const std::vector<std::string>& _elementsFilter,
+                            const std::vector<std::string>& /*_elementsFilter*/,
                             std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportFirewall.cpp
+++ b/src/runtime_src/core/tools/common/ReportFirewall.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -46,21 +46,22 @@ ReportFirewall::getPropertyTree20202( const xrt_core::device * _pDevice,
 
 
 void 
-ReportFirewall::writeReport(const xrt_core::device * _pDevice,
-                            const std::vector<std::string> & /*_elementsFilter*/,
-                            std::iostream & _output) const
+ReportFirewall::writeReport(const xrt_core::device* _pDevice,
+                            const boost::property_tree::ptree& _pt,
+                            const std::vector<std::string>& _elementsFilter,
+                            std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   _output << "Firewall\n";
   if (_pt.empty()) {
     _output << "  Information unavailable" << std::endl; 
     return;
   }
-  _output << boost::format("  %s %d: %s %s\n\n") % "Level" % _pt.get<std::string>("firewall.firewall_level") 
-              % _pt.get<std::string>("firewall.firewall_status") % _pt.get<std::string>("firewall.status");
+  _output << boost::format("  %s %d: %s %s\n\n") % "Level" 
+              % _pt.get<std::string>("firewall.firewall_level", "--") 
+              % _pt.get<std::string>("firewall.firewall_status", "--") 
+              % _pt.get<std::string>("firewall.status", "--");
 
 }
 

--- a/src/runtime_src/core/tools/common/ReportFirewall.h
+++ b/src/runtime_src/core/tools/common/ReportFirewall.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportFirewall: public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -59,13 +59,12 @@ ReportHost::getPropertyTree20202( const xrt_core::device * /*_pDevice*/,
 
 
 void
-ReportHost::writeReport(const xrt_core::device * _pDevice,
-                        const std::vector<std::string> & /*_elementsFilter*/,
-                        std::iostream & _output) const
+ReportHost::writeReport(const xrt_core::device* _pDevice,
+                        const boost::property_tree::ptree& _pt,
+                        const std::vector<std::string>& _elementsFilter,
+                        std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   _output << "System Configuration\n";
   try {
@@ -76,9 +75,9 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
     _output << boost::format("  %-20s : %s\n") % "CPU Cores" % _pt.get<std::string>("host.os.cores");
     _output << boost::format("  %-20s : %lld MB\n") % "Memory" % (std::strtoll(_pt.get<std::string>("host.os.memory_bytes").c_str(),nullptr,16) / BYTES_TO_MEGABYTES);
     _output << boost::format("  %-20s : %s\n") % "Distribution" % _pt.get<std::string>("host.os.distribution","N/A");
-    boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries", empty_ptree);
+    const boost::property_tree::ptree& available_libraries = _pt.get_child("host.os.libraries", empty_ptree);
     for(auto& kl : available_libraries) {
-      boost::property_tree::ptree& lib = kl.second;
+      const boost::property_tree::ptree& lib = kl.second;
       std::string lib_name = lib.get<std::string>("name", "N/A");
       boost::algorithm::to_upper(lib_name);
       _output << boost::format("  %-20s : %s\n") % lib_name
@@ -91,9 +90,9 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
     _output << boost::format("  %-20s : %s\n") % "Branch" % _pt.get<std::string>("host.xrt.branch", "N/A");
     _output << boost::format("  %-20s : %s\n") % "Hash" % _pt.get<std::string>("host.xrt.hash", "N/A");
     _output << boost::format("  %-20s : %s\n") % "Hash Date" % _pt.get<std::string>("host.xrt.build_date", "N/A");
-    boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers", empty_ptree);
+    const boost::property_tree::ptree& available_drivers = _pt.get_child("host.xrt.drivers", empty_ptree);
     for(auto& drv : available_drivers) {
-      boost::property_tree::ptree& driver = drv.second;
+      const boost::property_tree::ptree& driver = drv.second;
       std::string drv_name = driver.get<std::string>("name", "N/A");
       boost::algorithm::to_upper(drv_name);
       _output << boost::format("  %-20s : %s, %s\n") % drv_name
@@ -107,17 +106,15 @@ ReportHost::writeReport(const xrt_core::device * _pDevice,
   }
 
   _output << "Devices present\n";
-  boost::property_tree::ptree& available_devices = _pt.get_child("host.devices", empty_ptree);
+  const boost::property_tree::ptree& available_devices = _pt.get_child("host.devices", empty_ptree);
 
   if(available_devices.empty())
     _output << "  0 devices found" << std::endl;
   
   for(auto& kd : available_devices) {
-    boost::property_tree::ptree& dev = kd.second;
+    const boost::property_tree::ptree& dev = kd.second;
     std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
     _output << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
   }
   _output << std::endl;
-
-
 }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -59,9 +59,9 @@ ReportHost::getPropertyTree20202( const xrt_core::device * /*_pDevice*/,
 
 
 void
-ReportHost::writeReport(const xrt_core::device* _pDevice,
+ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
                         const boost::property_tree::ptree& _pt,
-                        const std::vector<std::string>& _elementsFilter,
+                        const std::vector<std::string>& /*_elementsFilter*/,
                         std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportHost.h
+++ b/src/runtime_src/core/tools/common/ReportHost.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,7 +30,7 @@ class ReportHost: public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportMailbox.cpp
+++ b/src/runtime_src/core/tools/common/ReportMailbox.cpp
@@ -88,9 +88,9 @@ ReportMailbox::getPropertyTree20202( const xrt_core::device * device,
 
 
 void 
-ReportMailbox::writeReport( const xrt_core::device* _pDevice,
+ReportMailbox::writeReport( const xrt_core::device* /*_pDevice*/,
                             const boost::property_tree::ptree& _pt,
-                            const std::vector<std::string>& _elementsFilter,
+                            const std::vector<std::string>& /*_elementsFilter*/,
                             std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportMailbox.cpp
+++ b/src/runtime_src/core/tools/common/ReportMailbox.cpp
@@ -88,29 +88,27 @@ ReportMailbox::getPropertyTree20202( const xrt_core::device * device,
 
 
 void 
-ReportMailbox::writeReport(const xrt_core::device * device,
-                            const std::vector<std::string> & /*_elementsFilter*/,
-                            std::iostream & output) const
+ReportMailbox::writeReport( const xrt_core::device* _pDevice,
+                            const boost::property_tree::ptree& _pt,
+                            const std::vector<std::string>& _elementsFilter,
+                            std::ostream & _output) const
 {
-  boost::property_tree::ptree pt;
   boost::property_tree::ptree empty_ptree;
-  try {
-    getPropertyTreeInternal(device, pt);
-  } catch (...) {}
 
-  output << "Mailbox\n";
-  if (pt.empty()) {
-    output << "  Information unavailable" << std::endl; 
+  _output << "Mailbox" << std::endl;
+
+  if (_pt.empty()) 
     return;
-  }
-  boost::property_tree::ptree& mailbox = pt.get_child("mailbox.requests", empty_ptree);
-  output << boost::format("  %-22s : %s Bytes\n") % "Total bytes received" % pt.get<std::string>("mailbox.raw_bytes");
-  for(auto& kv : mailbox) {
-    boost::property_tree::ptree& pt_temp = kv.second;
-    output << boost::format("  %-22s : %-2d\n") % pt_temp.get<std::string>("description") % pt_temp.get<int>("msg_count");
-  }
-  output << std::endl;
+  
+  const boost::property_tree::ptree& mailbox = _pt.get_child("mailbox.requests", empty_ptree);
+  _output << boost::format("  %-22s : %s Bytes\n") % "Total bytes received" % _pt.get<std::string>("mailbox.raw_bytes");
 
+  for(auto& kv : mailbox) {
+    const boost::property_tree::ptree& pt_temp = kv.second;
+    _output << boost::format("  %-22s : %-2d\n") % pt_temp.get<std::string>("description") % pt_temp.get<int>("msg_count");
+  }
+
+  _output << std::endl;
 }
 
 

--- a/src/runtime_src/core/tools/common/ReportMailbox.h
+++ b/src/runtime_src/core/tools/common/ReportMailbox.h
@@ -29,7 +29,7 @@ class ReportMailbox : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * device, boost::property_tree::ptree &pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * devicee, boost::property_tree::ptree &pt) const;
-  virtual void writeReport(const xrt_core::device * device, const std::vector<std::string> & elementsFilter, std::iostream & output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter,std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportMechanical.cpp
+++ b/src/runtime_src/core/tools/common/ReportMechanical.cpp
@@ -67,9 +67,9 @@ ReportMechanical::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportMechanical::writeReport( const xrt_core::device* _pDevice,
+ReportMechanical::writeReport( const xrt_core::device* /*_pDevice*/,
                                const boost::property_tree::ptree& _pt, 
-                               const std::vector<std::string>& _elementsFilter,
+                               const std::vector<std::string>& /*_elementsFilter*/,
                                std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportMechanical.cpp
+++ b/src/runtime_src/core/tools/common/ReportMechanical.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -67,19 +67,18 @@ ReportMechanical::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportMechanical::writeReport( const xrt_core::device * _pDevice,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & _output) const
+ReportMechanical::writeReport( const xrt_core::device* _pDevice,
+                               const boost::property_tree::ptree& _pt, 
+                               const std::vector<std::string>& _elementsFilter,
+                               std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   _output << "Mechanical\n";
   _output << "  Fans\n";
-  boost::property_tree::ptree& fans = _pt.get_child("mechanical.fans", empty_ptree);
+  const boost::property_tree::ptree& fans = _pt.get_child("mechanical.fans", empty_ptree);
   for(auto& kv : fans) {
-    boost::property_tree::ptree& pt_fan = kv.second;
+    const boost::property_tree::ptree& pt_fan = kv.second;
     if(!pt_fan.get<bool>("is_present", false)) {
       _output << "    Not present"  << std::endl;
       continue;
@@ -88,6 +87,5 @@ ReportMechanical::writeReport( const xrt_core::device * _pDevice,
     _output << boost::format("      %-22s: %s C\n") % "Critical Trigger Temp" % pt_fan.get<std::string>("critical_trigger_temp_C");
     _output << boost::format("      %-22s: %s RPM\n") % "Speed" % pt_fan.get<std::string>("speed_rpm");
   }
-  _output << std::endl;
-  
+  _output << std::endl; 
 }

--- a/src/runtime_src/core/tools/common/ReportMechanical.h
+++ b/src/runtime_src/core/tools/common/ReportMechanical.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportMechanical : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -275,9 +275,9 @@ ReportMemory::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportMemory::writeReport( const xrt_core::device* _pDevice,
+ReportMemory::writeReport( const xrt_core::device* /*_pDevice*/,
                            const boost::property_tree::ptree& _pt, 
-                           const std::vector<std::string>& _elementsFilter,
+                           const std::vector<std::string>& /*_elementsFilter*/,
                            std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -275,13 +275,12 @@ ReportMemory::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportMemory::writeReport( const xrt_core::device * _pDevice,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & _output) const
+ReportMemory::writeReport( const xrt_core::device* _pDevice,
+                           const boost::property_tree::ptree& _pt, 
+                           const std::vector<std::string>& _elementsFilter,
+                           std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   _output << boost::format("%s\n") % _pt.get<std::string>("mem_topology.description");
 

--- a/src/runtime_src/core/tools/common/ReportMemory.h
+++ b/src/runtime_src/core/tools/common/ReportMemory.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportMemory : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
@@ -55,9 +55,9 @@ ReportPcieInfo::getPropertyTree20202( const xrt_core::device * dev,
 }
 
 void 
-ReportPcieInfo::writeReport( const xrt_core::device* _pDevice,
+ReportPcieInfo::writeReport( const xrt_core::device* /*_pDevice*/,
                              const boost::property_tree::ptree& _pt, 
-                             const std::vector<std::string>& _elementsFilter,
+                             const std::vector<std::string>& /*_elementsFilter*/,
                              std::ostream & _output) const
 {
   _output << "Pcie Info\n";

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
@@ -55,28 +55,26 @@ ReportPcieInfo::getPropertyTree20202( const xrt_core::device * dev,
 }
 
 void 
-ReportPcieInfo::writeReport( const xrt_core::device * dev,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & output) const
+ReportPcieInfo::writeReport( const xrt_core::device* _pDevice,
+                             const boost::property_tree::ptree& _pt, 
+                             const std::vector<std::string>& _elementsFilter,
+                             std::ostream & _output) const
 {
-  boost::property_tree::ptree pt;
-  getPropertyTreeInternal(dev, pt);
-
-  output << "Pcie Info\n";
-  auto& pt_pcie = pt.get_child("pcie_info");
+  _output << "Pcie Info\n";
+  auto& pt_pcie = _pt.get_child("pcie_info");
   if(pt_pcie.empty()) {
-    output << "  Information unavailable" << std::endl; 
+    _output << "  Information unavailable" << std::endl; 
     return;
   }
-  output << boost::format("  %-22s : %s\n") % "Vendor" % pt_pcie.get<std::string>("vendor");
-  output << boost::format("  %-22s : %s\n") % "Device" % pt_pcie.get<std::string>("device");
-  output << boost::format("  %-22s : %s\n") % "Sub Device" % pt_pcie.get<std::string>("sub_device");
-  output << boost::format("  %-22s : %s\n") % "Sub Vendor" % pt_pcie.get<std::string>("sub_vendor");
-  output << boost::format("  %-22s : Gen%sx%s\n") % "PCIe" % pt_pcie.get<std::string>("link_speed_gbit_sec") % pt_pcie.get<std::string>("express_lane_width_count");
-  output << boost::format("  %-22s : %s\n") % "DMA Thread Count" % pt_pcie.get<std::string>("dma_thread_count");
-  output << boost::format("  %-22s : %s\n") % "CPU Affinity" % pt_pcie.get<std::string>("cpu_affinity");
-  output << boost::format("  %-22s : %s Bytes\n") % "Shared Host Memory" % pt_pcie.get<std::string>("host_mem_size_bytes", "0");
-  output << boost::format("  %-22s : %s Bytes\n") % "Max Shared Host Memory" % pt_pcie.get<std::string>("max_shared_host_mem_aperture_bytes", "0");
-  output << std::endl;
+  _output << boost::format("  %-22s : %s\n") % "Vendor" % pt_pcie.get<std::string>("vendor");
+  _output << boost::format("  %-22s : %s\n") % "Device" % pt_pcie.get<std::string>("device");
+  _output << boost::format("  %-22s : %s\n") % "Sub Device" % pt_pcie.get<std::string>("sub_device");
+  _output << boost::format("  %-22s : %s\n") % "Sub Vendor" % pt_pcie.get<std::string>("sub_vendor");
+  _output << boost::format("  %-22s : Gen%sx%s\n") % "PCIe" % pt_pcie.get<std::string>("link_speed_gbit_sec") % pt_pcie.get<std::string>("express_lane_width_count");
+  _output << boost::format("  %-22s : %s\n") % "DMA Thread Count" % pt_pcie.get<std::string>("dma_thread_count");
+  _output << boost::format("  %-22s : %s\n") % "CPU Affinity" % pt_pcie.get<std::string>("cpu_affinity");
+  _output << boost::format("  %-22s : %s Bytes\n") % "Shared Host Memory" % pt_pcie.get<std::string>("host_mem_size_bytes", "0");
+  _output << boost::format("  %-22s : %s Bytes\n") % "Max Shared Host Memory" % pt_pcie.get<std::string>("max_shared_host_mem_aperture_bytes", "0");
+  _output << std::endl;
   
 }

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.h
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.h
@@ -28,7 +28,7 @@ class ReportPcieInfo : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * dev, boost::property_tree::ptree &pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * deve, boost::property_tree::ptree &pt) const;
-  virtual void writeReport(const xrt_core::device * dev, const std::vector<std::string> & _elementsFilter, std::iostream & output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -152,9 +152,9 @@ ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev,
 }
 
 void 
-ReportPlatforms::writeReport( const xrt_core::device* _pDevice,
+ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
                               const boost::property_tree::ptree& _pt, 
-                              const std::vector<std::string>& _elementsFilter,
+                              const std::vector<std::string>& /*_elementsFilter*/,
                               std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -152,48 +152,53 @@ ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev,
 }
 
 void 
-ReportPlatforms::writeReport( const xrt_core::device * dev,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & output) const
+ReportPlatforms::writeReport( const xrt_core::device* _pDevice,
+                              const boost::property_tree::ptree& _pt, 
+                              const std::vector<std::string>& _elementsFilter,
+                              std::ostream & _output) const
 {
-  boost::property_tree::ptree pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(dev, pt);
 
-  output << "Platform\n";
-  boost::property_tree::ptree& platforms = pt.get_child("platforms", empty_ptree);
+  _output << "Platform\n";
+  const boost::property_tree::ptree& platforms = _pt.get_child("platforms", empty_ptree);
   for(auto& kp : platforms) {
-    boost::property_tree::ptree& pt_platform = kp.second;
-    boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region");
-    output << boost::format("  %-20s : %s \n") % "XSA Name" % pt_static_region.get<std::string>("vbnv");
-    output << boost::format("  %-20s : %s \n") % "FPGA Name" % pt_static_region.get<std::string>("fpga_name");
-    output << boost::format("  %-20s : %s \n") % "JTAG ID Code" % pt_static_region.get<std::string>("jtag_idcode");
+    const boost::property_tree::ptree& pt_platform = kp.second;
+    const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
+    _output << boost::format("  %-23s: %s \n") % "XSA Name" % pt_static_region.get<std::string>("vbnv");
+    _output << boost::format("  %-23s: %s \n") % "FPGA Name" % pt_static_region.get<std::string>("fpga_name");
+    _output << boost::format("  %-23s: %s \n") % "JTAG ID Code" % pt_static_region.get<std::string>("jtag_idcode");
     
-    boost::property_tree::ptree& pt_board_info = pt_platform.get_child("off_chip_board_info");
-    output << boost::format("  %-20s : %s Bytes\n") % "DDR Size" % pt_board_info.get<std::string>("ddr_size_bytes");
-    output << boost::format("  %-20s : %s \n") % "DDR Count" % pt_board_info.get<std::string>("ddr_count");
+    const boost::property_tree::ptree& pt_board_info = pt_platform.get_child("off_chip_board_info");
+    _output << boost::format("  %-23s: %s Bytes\n") % "DDR Size" % pt_board_info.get<std::string>("ddr_size_bytes");
+    _output << boost::format("  %-23s: %s \n") % "DDR Count" % pt_board_info.get<std::string>("ddr_count");
     
-    boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
-    output << boost::format("  %-20s : %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
-    output << boost::format("  %-20s : %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
+    const boost::property_tree::ptree& pt_status = pt_platform.get_child("status");
+    _output << boost::format("  %-23s: %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
+    _output << boost::format("  %-23s: %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
 
-    boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
-    if(!clocks.empty())
-      output << "Clocks\n";
-    for(auto& kc : clocks) {
-      boost::property_tree::ptree& pt_clock = kc.second;
-      output << boost::format("  %-20s : %s MHz\n") % pt_clock.get<std::string>("description") % pt_clock.get<std::string>("freq_mhz");
+    const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
+    if(!clocks.empty()) {
+      _output << std::endl << "Clocks" << std::endl;
+      for(auto& kc : clocks) {
+        const boost::property_tree::ptree& pt_clock = kc.second;
+        _output << boost::format("  %-23s: %s MHz\n") % pt_clock.get<std::string>("description") % pt_clock.get<std::string>("freq_mhz");
+      }
     }
 
-    boost::property_tree::ptree& macs = pt_platform.get_child("macs", empty_ptree);
-    if(!macs.empty())
-      output << "Mac Addresses\n";
-    for(auto& km : macs) {
-      boost::property_tree::ptree& pt_mac = km.second;
-      output << boost::format("  %-20s : %s\n") % "" % pt_mac.get<std::string>("address");
+    const boost::property_tree::ptree& macs = pt_platform.get_child("macs", empty_ptree);
+    if(!macs.empty()) {
+      _output << std::endl;
+      unsigned int macCount = 0;
+
+      for(auto& km : macs) {
+        const boost::property_tree::ptree& pt_mac = km.second;
+        if( macCount++ == 0) 
+          _output << boost::format("%-25s: %s\n") % "Mac Addresses" % pt_mac.get<std::string>("address");
+        else
+          _output << boost::format("  %-23s: %s\n") % "" % pt_mac.get<std::string>("address");
+      }
     }
   }
   
-  output << std::endl;
-  
+  _output << std::endl;
 }

--- a/src/runtime_src/core/tools/common/ReportPlatforms.h
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.h
@@ -28,7 +28,7 @@ class ReportPlatforms : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * dev, boost::property_tree::ptree &pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * deve, boost::property_tree::ptree &pt) const;
-  virtual void writeReport(const xrt_core::device * dev, const std::vector<std::string> & _elementsFilter, std::iostream & output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
@@ -44,17 +44,16 @@ ReportQspiStatus::getPropertyTree20202( const xrt_core::device * device,
 }
 
 void 
-ReportQspiStatus::writeReport( const xrt_core::device * device,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & output) const
+ReportQspiStatus::writeReport( const xrt_core::device* _pDevice,
+                               const boost::property_tree::ptree& _pt, 
+                               const std::vector<std::string>& _elementsFilter, 
+                               std::ostream & _output) const
 {
-  boost::property_tree::ptree pt;
-  getPropertyTreeInternal(device, pt);
+  boost::property_tree::ptree ptEmpty;
+  const boost::property_tree::ptree& ptree = _pt.get_child("qspi_wp_status", ptEmpty);
 
-  boost::property_tree::ptree& ptree = pt.get_child("qspi_wp_status");
-
-  output << "QSPI write protection status" << std::endl;
-  output << boost::format("  %-20s : %s\n") % "Primary" % ptree.get<std::string>("primary");
-  output << boost::format("  %-20s : %s\n") % "Recovery" % ptree.get<std::string>("recovery");
-  output << std::endl;
+  _output << "QSPI write protection status" << std::endl;
+  _output << boost::format("  %-23s: %s\n") % "Primary" % ptree.get<std::string>("primary");
+  _output << boost::format("  %-23s: %s\n") % "Recovery" % ptree.get<std::string>("recovery");
+  _output << std::endl;
 }

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
@@ -44,9 +44,9 @@ ReportQspiStatus::getPropertyTree20202( const xrt_core::device * device,
 }
 
 void 
-ReportQspiStatus::writeReport( const xrt_core::device* _pDevice,
+ReportQspiStatus::writeReport( const xrt_core::device* /*_pDevice*/,
                                const boost::property_tree::ptree& _pt, 
-                               const std::vector<std::string>& _elementsFilter, 
+                               const std::vector<std::string>& /*_elementsFilter*/, 
                                std::ostream & _output) const
 {
   boost::property_tree::ptree ptEmpty;

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.h
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.h
@@ -28,7 +28,7 @@ class ReportQspiStatus : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * device, boost::property_tree::ptree &pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * devicee, boost::property_tree::ptree &pt) const;
-  virtual void writeReport(const xrt_core::device * device, const std::vector<std::string> & elementsFilter, std::iostream & output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/ReportThermal.cpp
+++ b/src/runtime_src/core/tools/common/ReportThermal.cpp
@@ -77,9 +77,9 @@ ReportThermal::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportThermal::writeReport( const xrt_core::device* _pDevice,
+ReportThermal::writeReport( const xrt_core::device* /*_pDevice*/,
                             const boost::property_tree::ptree& _pt, 
-                            const std::vector<std::string>& _elementsFilter,
+                            const std::vector<std::string>& /*_elementsFilter*/,
                             std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;

--- a/src/runtime_src/core/tools/common/ReportThermal.cpp
+++ b/src/runtime_src/core/tools/common/ReportThermal.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -77,28 +77,28 @@ ReportThermal::getPropertyTree20202( const xrt_core::device * _pDevice,
 }
 
 void 
-ReportThermal::writeReport( const xrt_core::device * _pDevice,
-                                  const std::vector<std::string> & /*_elementsFilter*/, 
-                                  std::iostream & _output) const
+ReportThermal::writeReport( const xrt_core::device* _pDevice,
+                            const boost::property_tree::ptree& _pt, 
+                            const std::vector<std::string>& _elementsFilter,
+                            std::ostream & _output) const
 {
-  boost::property_tree::ptree _pt;
   boost::property_tree::ptree empty_ptree;
-  getPropertyTreeInternal(_pDevice, _pt);
 
   bool thermals_present = false;
   _output << "Thermals\n";
-  boost::property_tree::ptree& thermals = _pt.get_child("thermals", empty_ptree);
+  const boost::property_tree::ptree& thermals = _pt.get_child("thermals", empty_ptree);
+
   for(auto& kv : thermals) {
-    boost::property_tree::ptree& pt_temp = kv.second;
+    const boost::property_tree::ptree& pt_temp = kv.second;
     if(!pt_temp.get<bool>("is_present", false))
       continue;
+
     thermals_present = true;
-    _output << boost::format("  %-20s : %s C\n") % pt_temp.get<std::string>("description") % pt_temp.get<std::string>("temp_C");
+    _output << boost::format("  %-23s: %s C\n") % pt_temp.get<std::string>("description") % pt_temp.get<std::string>("temp_C");
   }
 
-  if(!thermals_present) {
+  if(!thermals_present) 
     _output << "  No temperature sensors are present" << std::endl;
-  }
+
   _output << std::endl;
-  
 }

--- a/src/runtime_src/core/tools/common/ReportThermal.h
+++ b/src/runtime_src/core/tools/common/ReportThermal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportThermal : public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/SubCmd.cpp
+++ b/src/runtime_src/core/tools/common/SubCmd.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -43,7 +43,7 @@ SubCmd::printHelp( const boost::program_options::options_description & _optionDe
                    const boost::program_options::options_description & _optionHidden) const
 {
   boost::program_options::positional_options_description emptyPOD;
-  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, emptyPOD);
+  XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, emptyPOD, m_globalOptions);
 }
 
 void
@@ -51,7 +51,7 @@ SubCmd::printHelp( const boost::program_options::options_description & _optionDe
                    const boost::program_options::options_description & _optionHidden,
                    const SubOptionOptions & _subOptionOptions) const
 {
- XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions);
+ XBUtilities::report_subcommand_help(m_executableName, m_subCmdName, m_longDescription,  m_exampleSyntax, _optionDescription, _optionHidden, _subOptionOptions, m_globalOptions);
 }
 
 

--- a/src/runtime_src/core/tools/common/SubCmd.h
+++ b/src/runtime_src/core/tools/common/SubCmd.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,6 +44,11 @@ class SubCmd {
    void setExecutableName(const std::string & _name) { m_executableName = _name; };
    const std::string & getExecutableName() const {return m_executableName; };
 
+   void setGlobalOptions(const boost::program_options::options_description &globalOptions) { m_globalOptions.add(globalOptions); };
+
+ protected:
+   const boost::program_options::options_description & getGlobalOptions() const { return m_globalOptions; };
+
  public:
    virtual ~SubCmd() {};
 
@@ -75,6 +80,7 @@ public:
   std::string m_shortDescription;
   std::string m_longDescription;
   std::string m_exampleSyntax;
+  boost::program_options::options_description m_globalOptions;
 
   bool m_isHidden;
   bool m_isDeprecated;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -85,7 +85,7 @@ static const uint8_t FGC_EXTENDED_BODY    = 70;  // 70
 
 
 // ------ S T A T I C   V A R I A B L E S -------------------------------------
-static unsigned int m_maxColumnWidth = 90;
+static unsigned int m_maxColumnWidth = 100;
 static unsigned int m_shortDescriptionColumn = 24;
 
 
@@ -226,22 +226,24 @@ XBUtilities::report_commands_help( const std::string &_executable,
 { 
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
-  const std::string fgc_header     = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER).string();
-  const std::string fgc_headerBody = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
-  const std::string fgc_usageBody  = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
-  const std::string fgc_subCmd     = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_SUBCMD).string();
-  const std::string fgc_subCmdBody = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_SUBCMD_BODY).string();
-  const std::string fgc_reset      = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor::reset();
+  const std::string fgc_header     = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER).string();
+  const std::string fgc_headerBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
+  const std::string fgc_usageBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
+  const std::string fgc_subCmd     = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_SUBCMD).string();
+  const std::string fgc_subCmdBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_SUBCMD_BODY).string();
+  const std::string fgc_reset      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
 
   // Helper variable
-  std::string formattedString;
   static std::string sHidden = "(Hidden)";
 
   // -- Command description
-  XBU::wrap_paragraphs(_description, 13, m_maxColumnWidth, false, formattedString);
-  boost::format fmtHeader(fgc_header + "\nDESCRIPTION: " + fgc_headerBody + "%s\n" + fgc_reset);
-  if ( !formattedString.empty() )
-    std::cout << fmtHeader % formattedString;
+  {
+    static const std::string key = "DESCRIPTION: ";
+    auto formattedString = XBU::wrap_paragraphs(_description, key.size(), m_maxColumnWidth - key.size(), false);
+    boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
+    if ( !formattedString.empty() )
+      std::cout << fmtHeader % formattedString;
+  }
 
   // -- Command usage
   boost::program_options::positional_options_description emptyPOD;
@@ -292,7 +294,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
     std::cout << fmtSubCmdHdr % "AVAILABLE";
     for (auto & subCmdEntry : subCmdsReleased) {
       std::string sPreAppend = subCmdEntry->isHidden() ? sHidden + " " : "";
-      XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false, formattedString);
+      auto formattedString = XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false);
       std::cout << fmtSubCmd % subCmdEntry->getName() % formattedString;
     }
   }
@@ -301,7 +303,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
     std::cout << fmtSubCmdHdr % "PRELIMINARY";
     for (auto & subCmdEntry : subCmdsPreliminary) {
       std::string sPreAppend = subCmdEntry->isHidden() ? sHidden + " " : "";
-      XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false, formattedString);
+      auto formattedString = XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false);
       std::cout << fmtSubCmd % subCmdEntry->getName() % formattedString;
     }
   }
@@ -310,7 +312,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
     std::cout << fmtSubCmdHdr % "DEPRECATED";
     for (auto & subCmdEntry : subCmdsDepricated) {
       std::string sPreAppend = subCmdEntry->isHidden() ? sHidden + " " : "";
-      XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false, formattedString);
+      auto formattedString = XBU::wrap_paragraphs(sPreAppend + subCmdEntry->getShortDescription(), subCmdDescTab, m_maxColumnWidth, false);
       std::cout << fmtSubCmd % subCmdEntry->getName() % formattedString;
     }
   }
@@ -356,10 +358,10 @@ XBUtilities::report_option_help( const std::string & _groupName,
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
-  const std::string fgc_header     = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER).string();
-  const std::string fgc_optionName = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_OPTION).string();
-  const std::string fgc_optionBody = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_OPTION_BODY).string();
-  const std::string fgc_reset      = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor::reset();
+  const std::string fgc_header     = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER).string();
+  const std::string fgc_optionName = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_OPTION).string();
+  const std::string fgc_optionBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_OPTION_BODY).string();
+  const std::string fgc_reset      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
 
   // Determine if there is anything to report
   if (_optionDescription.options().empty())
@@ -383,7 +385,7 @@ XBUtilities::report_option_help( const std::string & _groupName,
 
     std::string optionDisplayFormat = create_option_format_name(option.get(), _bReportParameter);
     unsigned int optionDescTab = 23;
-    XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth, false, formattedString);
+    auto formattedString = XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth - optionDescTab, false);
     std::cout << fmtOption % optionDisplayFormat % formattedString;
   }
 }
@@ -395,26 +397,30 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
                                      const std::string &_extendedHelp,
                                      const boost::program_options::options_description &_optionDescription,
                                      const boost::program_options::options_description &_optionHidden,
-                                     const boost::program_options::positional_options_description & _positionalDescription)
+                                     const boost::program_options::positional_options_description & _positionalDescription,
+                                     const boost::program_options::options_description &_globalOptions)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
-  const std::string fgc_header      = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER).string();
-  const std::string fgc_headerBody  = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
-  const std::string fgc_poption      = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
-  const std::string fgc_poptionBody  = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_POSITIONAL_BODY).string();
-  const std::string fgc_usageBody   = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
-  const std::string fgc_extendedBody = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
-  const std::string fgc_reset       = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor::reset();
+  const std::string fgc_header      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER).string();
+  const std::string fgc_headerBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
+  const std::string fgc_poption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
+  const std::string fgc_poptionBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL_BODY).string();
+  const std::string fgc_usageBody   = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
+  const std::string fgc_extendedBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
+  const std::string fgc_reset       = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
 
   // Helper string
   std::string formattedString;
 
   // -- Command description
-  XBU::wrap_paragraphs(_description, 13, m_maxColumnWidth, false, formattedString);
-  boost::format fmtHeader(fgc_header + "\nDESCRIPTION: " + fgc_headerBody + "%s\n" + fgc_reset);
-  if ( !formattedString.empty() )
-    std::cout << fmtHeader % formattedString;
+  {
+    static const std::string key = "DESCRIPTION: ";
+    auto formattedString = XBU::wrap_paragraphs(_description, key.size(), m_maxColumnWidth - key.size(), false);
+    boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
+    if ( !formattedString.empty() )
+      std::cout << fmtHeader % formattedString;
+  }
 
   // -- Command usage
   std::string usage = XBU::create_usage_string(_optionDescription, _positionalDescription);
@@ -431,7 +437,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
 
     std::string optionDisplayFormat = create_option_format_name(option.get(), false);
     unsigned int optionDescTab = 33;
-    XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth, false, formattedString);
+    auto formattedString = XBU::wrap_paragraphs(option->description(), optionDescTab, m_maxColumnWidth, false);
 
     std::string completeOptionName = option->canonical_display_name(po::command_line_style::allow_dash_for_short);
     std::cout << fmtOOSubPositional % ("<" + option->long_name() + ">") % formattedString;
@@ -441,14 +447,19 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   // -- Options
   report_option_help("OPTIONS", _optionDescription, _positionalDescription, false);
 
+  // -- Global Options
+  report_option_help("GLOBAL OPTIONS", _globalOptions, _positionalDescription, false);
+
   if (XBU::getShowHidden()) 
     report_option_help("OPTIONS (Hidden)", _optionHidden, _positionalDescription, false);
 
   // Extended help
-  boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
-  XBU::wrap_paragraph(_extendedHelp, 2, m_maxColumnWidth, false, formattedString);
-  if (!formattedString.empty()) 
-    std::cout << fmtExtHelp % formattedString;
+  {
+    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
+    auto formattedString = XBU::wrap_paragraphs(_extendedHelp, 2, m_maxColumnWidth, false);
+    if (!formattedString.empty()) 
+      std::cout << fmtExtHelp % formattedString;
+  }
 }
 
 void 
@@ -458,21 +469,22 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
                                      const std::string &_extendedHelp,
                                      const boost::program_options::options_description &_optionDescription,
                                      const boost::program_options::options_description &_optionHidden,
-                                     const SubCmd::SubOptionOptions & _subOptionOptions)
+                                     const SubCmd::SubOptionOptions & _subOptionOptions,
+                                     const boost::program_options::options_description &_globalOptions)
 {
   // Formatting color parameters
   // Color references: https://en.wikipedia.org/wiki/ANSI_escape_code
-  const std::string fgc_header       = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER).string();
-  const std::string fgc_headerBody   = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
-  const std::string fgc_commandBody  = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_SUBCMD).string();
-  const std::string fgc_usageBody    = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
+  const std::string fgc_header       = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER).string();
+  const std::string fgc_headerBody   = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_HEADER_BODY).string();
+  const std::string fgc_commandBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_SUBCMD).string();
+  const std::string fgc_usageBody    = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
 
-  const std::string fgc_ooption      = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_OOPTION).string();
-  const std::string fgc_ooptionBody  = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_OOPTION_BODY).string();
-  const std::string fgc_poption      = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
-  const std::string fgc_poptionBody  = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_POSITIONAL_BODY).string();
-  const std::string fgc_extendedBody = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
-  const std::string fgc_reset        = XBUtilities::is_esc_enabled() ? "" : ec::fgcolor::reset();
+  const std::string fgc_ooption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_OOPTION).string();
+  const std::string fgc_ooptionBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_OOPTION_BODY).string();
+  const std::string fgc_poption      = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL).string();
+  const std::string fgc_poptionBody  = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_POSITIONAL_BODY).string();
+  const std::string fgc_extendedBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
+  const std::string fgc_reset        = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
 
   // Helper string
   std::string formattedString;
@@ -483,10 +495,12 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
     std::cout << fmtCommand % _subCommand;
  
   // -- Command description
-  XBU::wrap_paragraphs(_description, 15, m_maxColumnWidth, false, formattedString);
-  boost::format fmtHeader(fgc_header + "\nDESCRIPTION: " + fgc_headerBody + "%s\n" + fgc_reset);
-  if ( !formattedString.empty() )
-    std::cout << fmtHeader % formattedString;
+  {
+    auto formattedString = XBU::wrap_paragraphs(_description, 15, m_maxColumnWidth, false);
+    boost::format fmtHeader(fgc_header + "\nDESCRIPTION: " + fgc_headerBody + "%s\n" + fgc_reset);
+    if ( !formattedString.empty() )
+      std::cout << fmtHeader % formattedString;
+  }
 
   // -- Usage
   std::string usageSubCmds;
@@ -506,14 +520,19 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   boost::program_options::positional_options_description emptyPOD;
   report_option_help("OPTIONS", _optionDescription, emptyPOD, false);
 
+  // -- Global Options
+  report_option_help("GLOBAL OPTIONS", _globalOptions, emptyPOD, false);
+
   if (XBU::getShowHidden()) 
     report_option_help("OPTIONS (Hidden)", _optionHidden, emptyPOD, false);
 
   // Extended help
-  boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
-  XBU::wrap_paragraph(_extendedHelp, 2, m_maxColumnWidth, false, formattedString);
-  if (!formattedString.empty()) 
-    std::cout << fmtExtHelp % formattedString;
+  {
+    boost::format fmtExtHelp(fgc_extendedBody + "\n  %s\n" +fgc_reset);
+    auto formattedString = XBU::wrap_paragraphs(_extendedHelp, 2, m_maxColumnWidth, false);
+    if (!formattedString.empty()) 
+      std::cout << fmtExtHelp % formattedString;
+  }
 }
 
 std::string 
@@ -540,14 +559,14 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
   }
 
   const unsigned int indention = maxStringLength + 5;  // New line indention after the '-' character (5 extra spaces)
-  boost::format reportFmt(std::string("  %-") + std::to_string(maxStringLength) + "s - %s\n");  
-  boost::format reportFmtQuotes(std::string(" %-") + std::to_string(maxStringLength + 1) + "s - %s\n");  
+  boost::format reportFmt(std::string("  %-") + std::to_string(maxStringLength) + "s - %s");  
+  boost::format reportFmtQuotes(std::string(" %-") + std::to_string(maxStringLength + 1) + "s - %s");  
 
   // Report names and description
   for (const auto & pairs : workingCollection) {
     boost::format &reportFormat = pairs.first[0] == '\'' ? reportFmtQuotes : reportFmt;
-    XBU::wrap_paragraphs(boost::str(reportFormat % pairs.first % pairs.second), indention, maxColumnWidth, false /*indent first line*/, formattedString);
-    supportedValues += formattedString;
+    auto formattedString = XBU::wrap_paragraphs(boost::str(reportFormat % pairs.first % pairs.second), indention, maxColumnWidth, false /*indent first line*/);
+    supportedValues += formattedString + "\n";
   }
 
   return supportedValues;
@@ -616,20 +635,21 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
 
 
 void 
-XBUtilities::produce_reports( xrt_core::device_collection _devices, 
-                              const ReportCollection & _reportsToProcess, 
-                              Report::SchemaVersion _schemaVersion, 
-                              std::vector<std::string> & _elementFilter,
-                              std::ostream &_ostream)
+XBUtilities::produce_reports( xrt_core::device_collection devices, 
+                              const ReportCollection & reportsToProcess, 
+                              Report::SchemaVersion schemaVersion, 
+                              std::vector<std::string> & elementFilter,
+                              std::ostream & consoleStream,
+                              std::ostream & schemaStream)
 {
   // Some simple DRCs
-  if (_reportsToProcess.empty()) {
-    _ostream << "Info: No action taken, no reports given.\n";
+  if (reportsToProcess.empty()) {
+    consoleStream << "Info: No action taken, no reports given.\n";
     return;
   }
 
-  if (_schemaVersion == Report::SchemaVersion::unknown) {
-    _ostream << "Info: No action taken, 'UNKNOWN' schema value specified.\n";
+  if (schemaVersion == Report::SchemaVersion::unknown) {
+    consoleStream << "Info: No action taken, 'UNKNOWN' schema value specified.\n";
     return;
   }
 
@@ -639,7 +659,7 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
   // Add schema version
   {
     boost::property_tree::ptree ptSchemaVersion;
-    ptSchemaVersion.put("schema", Report::getSchemaDescription(_schemaVersion).optionName.c_str());
+    ptSchemaVersion.put("schema", Report::getSchemaDescription(schemaVersion).optionName.c_str());
     ptSchemaVersion.put("creation_date", xrt_core::timestamp());
 
     ptRoot.add_child("schema_version", ptSchemaVersion);
@@ -648,40 +668,32 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
 
   // -- Process the reports that don't require a device
   boost::property_tree::ptree ptSystem;
-  for (const auto & report : _reportsToProcess) {
+  for (const auto & report : reportsToProcess) {
     if (report->isDeviceRequired() == true)
       continue;
 
-    boost::any output = report->getFormattedReport(nullptr, _schemaVersion, _elementFilter);
+    boost::property_tree::ptree ptReport;
+    report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
 
-    // Simple string output
-    if (output.type() == typeid(std::string)) 
-      _ostream << boost::any_cast<std::string>(output);
+    // Only support 1 node on the root
+    if (ptReport.size() > 1)
+      throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schemaVersion).optionName).str());
 
-    if (output.type() == typeid(boost::property_tree::ptree)) {
-      boost::property_tree::ptree ptReport = boost::any_cast< boost::property_tree::ptree>(output);
-
-      // Only support 1 node on the root
-      if (ptReport.size() > 1)
-        throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(_schemaVersion).optionName).str());
-
-      // We have 1 node, copy the child to the root property tree
-      if (ptReport.size() == 1) {
-        for (const auto & ptChild : ptReport) {
-          ptSystem.add_child(ptChild.first, ptChild.second);
-        }
-      }
+    // We have 1 node, copy the child to the root property tree
+    if (ptReport.size() == 1) {
+      for (const auto & ptChild : ptReport) 
+        ptSystem.add_child(ptChild.first, ptChild.second);
     }
   }
   if (!ptSystem.empty()) 
     ptRoot.add_child("system", ptSystem);
 
-  // -- Check if any device sepcific report is requested
-  auto dev_report = [_reportsToProcess]() {
-    for (auto &report : _reportsToProcess) {
+  // -- Check if any device specific report is requested
+  auto dev_report = [reportsToProcess]() {
+    for (auto &report : reportsToProcess) {
       if (report->isDeviceRequired() == true)
         return true;
-      }
+    }
     return false;
   };
 
@@ -689,56 +701,50 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
     // -- Process reports that work on a device
     boost::property_tree::ptree ptDevices;
     int dev_idx = 0;
-    for (const auto & device : _devices) {
+    for (const auto & device : devices) {
       boost::property_tree::ptree ptDevice;
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
       ptDevice.put("interface_type", "pcie");
       ptDevice.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
-      if (_schemaVersion == Report::SchemaVersion::text) {
-        bool is_mfg = false;
-        try {
-          is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
-        } catch (...) {}
-        
-        //if factory mode
-        std::string platform = "<not defined>";
-        try {
-          if (is_mfg) {
-            platform = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN";
-          }
-          else {
-            platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
-          }
-        } catch(...) {
-          // proceed even if the platform name is not available
+
+      bool is_mfg = false;
+      try {
+        is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
+      } catch (...) {}
+      
+      //if factory mode
+      std::string platform = "<not defined>";
+      try {
+        if (is_mfg) {
+          platform = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN";
         }
-        std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % _devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
-        _ostream << std::string(dev_desc.length(), '-') << std::endl;
-        _ostream << dev_desc;
-        _ostream << std::string(dev_desc.length(), '-') << std::endl;
+        else {
+          platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
+        }
+      } catch(...) {
+        // proceed even if the platform name is not available
       }
-      for (auto &report : _reportsToProcess) {
+      std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
+      consoleStream << std::endl;
+      consoleStream << std::string(dev_desc.length(), '-') << std::endl;
+      consoleStream << dev_desc;
+      consoleStream << std::string(dev_desc.length(), '-') << std::endl;
+
+      for (auto &report : reportsToProcess) {
         if (report->isDeviceRequired() == false)
           continue;
 
-        boost::any output = report->getFormattedReport(device.get(), _schemaVersion, _elementFilter);
+        boost::property_tree::ptree ptReport;
+        report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
 
-        // Simple string output
-        if (output.type() == typeid(std::string)) 
-          _ostream << boost::any_cast<std::string>(output);
+        // Only support 1 node on the root
+        if (ptReport.size() > 1)
+          throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(schemaVersion).optionName).str());
 
-        if (output.type() == typeid(boost::property_tree::ptree)) {
-          boost::property_tree::ptree ptReport = boost::any_cast< boost::property_tree::ptree>(output);
-
-          // Only support 1 node on the root
-          if (ptReport.size() > 1)
-            throw xrt_core::error((boost::format("Invalid JSON - The report '%s' has too many root nodes.") % Report::getSchemaDescription(_schemaVersion).optionName).str());
-
-          // We have 1 node, copy the child to the root property tree
-          if (ptReport.size() == 1) {
-            for (const auto & ptChild : ptReport) {
-              ptDevice.add_child(ptChild.first, ptChild.second);
-            }
+        // We have 1 node, copy the child to the root property tree
+        if (ptReport.size() == 1) {
+          for (const auto & ptChild : ptReport) {
+            ptDevice.add_child(ptChild.first, ptChild.second);
           }
         }
       }
@@ -749,14 +755,16 @@ XBUtilities::produce_reports( xrt_core::device_collection _devices,
       ptRoot.add_child("devices", ptDevices);
   }
 
+  // -- Write the formatted output 
+  switch (schemaVersion) {
+    case Report::SchemaVersion::json_20202:
+      boost::property_tree::json_parser::write_json(schemaStream, ptRoot, true /*Pretty Print*/);
+      schemaStream << std::endl;  
+      break;
 
-  // Did we add anything to the property tree.  If so, then write it out.
-  if ((_schemaVersion != Report::SchemaVersion::text) &&
-      (_schemaVersion != Report::SchemaVersion::unknown)) {
-    // Write out JSON format
-    std::ostringstream outputBuffer;
-    boost::property_tree::write_json(outputBuffer, ptRoot, true /*Pretty print*/);
-    _ostream << outputBuffer.str() << std::endl;
+    default:
+      // Do nothing
+      break;
   }
 }
 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -239,7 +239,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
   // -- Command description
   {
     static const std::string key = "DESCRIPTION: ";
-    auto formattedString = XBU::wrap_paragraphs(_description, key.size(), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
+    auto formattedString = XBU::wrap_paragraphs(_description, static_cast<unsigned int>(key.size()), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
     boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
     if ( !formattedString.empty() )
       std::cout << fmtHeader % formattedString;
@@ -410,7 +410,7 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   // -- Command description
   {
     static const std::string key = "DESCRIPTION: ";
-    auto formattedString = XBU::wrap_paragraphs(_description, key.size(), m_maxColumnWidth - key.size(), false);
+    auto formattedString = XBU::wrap_paragraphs(_description, static_cast<unsigned int>(key.size()), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
     boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
     if ( !formattedString.empty() )
       std::cout << fmtHeader % formattedString;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -239,7 +239,7 @@ XBUtilities::report_commands_help( const std::string &_executable,
   // -- Command description
   {
     static const std::string key = "DESCRIPTION: ";
-    auto formattedString = XBU::wrap_paragraphs(_description, key.size(), m_maxColumnWidth - key.size(), false);
+    auto formattedString = XBU::wrap_paragraphs(_description, key.size(), m_maxColumnWidth - static_cast<unsigned int>(key.size()), false);
     boost::format fmtHeader(fgc_header + "\n" + key + fgc_headerBody + "%s\n" + fgc_reset);
     if ( !formattedString.empty() )
       std::cout << fmtHeader % formattedString;
@@ -372,9 +372,6 @@ XBUtilities::report_option_help( const std::string & _groupName,
   if ( !_groupName.empty() )
     std::cout << fmtHeader % _groupName;
 
-  // Helper string
-  std::string formattedString;
-
   // Report the options
   boost::format fmtOption(fgc_optionName + "  %-18s " + fgc_optionBody + "- %s\n" + fgc_reset);
   for (auto & option : _optionDescription.options()) {
@@ -409,9 +406,6 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   const std::string fgc_usageBody   = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_USAGE_BODY).string();
   const std::string fgc_extendedBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
   const std::string fgc_reset       = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
-
-  // Helper string
-  std::string formattedString;
 
   // -- Command description
   {
@@ -486,9 +480,6 @@ XBUtilities::report_subcommand_help( const std::string &_executableName,
   const std::string fgc_extendedBody = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor(FGC_EXTENDED_BODY).string();
   const std::string fgc_reset        = XBUtilities::is_escape_codes_disabled() ? "" : ec::fgcolor::reset();
 
-  // Helper string
-  std::string formattedString;
-
   // -- Command
   boost::format fmtCommand(fgc_header + "\nCOMMAND: " + fgc_commandBody + "%s\n" + fgc_reset);
   if ( !_subCommand.empty() )
@@ -541,7 +532,6 @@ XBUtilities::create_suboption_list_string(const VectorPairStrings &_collection)
   // Working variables
   const unsigned int maxColumnWidth = m_maxColumnWidth - m_shortDescriptionColumn; 
   std::string supportedValues;        // Formatted string of supported values
-  std::string formattedString;        // Helper working string
                                       
   // Make a copy of the data (since it is going to be modified)
   VectorPairStrings workingCollection = _collection;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -44,7 +44,8 @@ namespace XBUtilities {
                             const std::string &_extendedHelp,
                             const boost::program_options::options_description & _optionDescription,
                             const boost::program_options::options_description &_optionHidden,
-                            const boost::program_options::positional_options_description & _positionalDescription );
+                            const boost::program_options::positional_options_description & _positionalDescription,
+                            const boost::program_options::options_description &_globalOptions);
 
   void 
     report_subcommand_help( const std::string &_executableName,
@@ -53,7 +54,8 @@ namespace XBUtilities {
                             const std::string &_extendedHelp,
                             const boost::program_options::options_description &_optionDescription,
                             const boost::program_options::options_description &_optionHidden,
-                            const SubCmd::SubOptionOptions & _subOptionOptions);
+                            const SubCmd::SubOptionOptions & _subOptionOptions,
+                            const boost::program_options::options_description &_globalOptions);
 
   void 
     report_option_help( const std::string & _groupName, 
@@ -82,11 +84,12 @@ namespace XBUtilities {
                                   ReportCollection & reportsToUse);
 
   void 
-     produce_reports( xrt_core::device_collection _devices, 
-                      const ReportCollection & _reportsToProcess, 
-                      Report::SchemaVersion _schema, 
-                      std::vector<std::string> & _elementFilter,
-                      std::ostream &_ostream);
+     produce_reports( xrt_core::device_collection devices, 
+                      const ReportCollection & reportsToProcess, 
+                      Report::SchemaVersion schema, 
+                      std::vector<std::string> & elementFilter,
+                      std::ostream & consoleStream,
+                      std::ostream & schemaStream);
 };
 
 #endif

--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -48,13 +48,18 @@ void  main_(int argc, char** argv,
   bool bForce = false;
 
   // Build Options
-  po::options_description globalOptions("Global Options");
-  globalOptions.add_options()
-    ("help",    boost::program_options::bool_switch(&bHelp), "Help to use this application")
+  po::options_description globalSubCmdOptions("Global Command Options");
+  globalSubCmdOptions.add_options()
     ("verbose", boost::program_options::bool_switch(&bVerbose), "Turn on verbosity")
     ("batch",   boost::program_options::bool_switch(&bBatchMode), "Enable batch mode (disables escape characters)")
     ("force",   boost::program_options::bool_switch(&bForce), "When possible, force an operation")
   ;
+
+  po::options_description globalOptions("Global Options");
+  globalOptions.add_options()
+    ("help",    boost::program_options::bool_switch(&bHelp), "Help to use this application")
+  ;
+  globalOptions.add(globalSubCmdOptions);
 
   // Hidden Options
   po::options_description hiddenOptions("Hidden Options");
@@ -133,10 +138,10 @@ void  main_(int argc, char** argv,
   if (bHelp == true) 
     opts.push_back("--help");
 
+  subCommand->setGlobalOptions(globalSubCmdOptions);
+
   // -- Execute the sub-command
   subCommand->execute(opts);
-
-  return;
 }
 
 

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -60,7 +60,7 @@ namespace XBUtilities {
   bool getForce();
 
   void disable_escape_codes( bool _disable );
-  bool is_esc_enabled();  
+  bool is_escape_codes_disabled();  
 
   void message_(MessageType _eMT, const std::string& _msg, bool _endl = true, std::ostream & _ostream = std::cout);
 
@@ -75,22 +75,17 @@ namespace XBUtilities {
   void trace_print_tree(const std::string & _name, 
                         const boost::property_tree::ptree & _pt);
 
-  bool can_proceed();
+  bool can_proceed(bool force=false);
   void can_proceed_or_throw(const std::string& info, const std::string& error);
 
   void sudo_or_throw(const std::string& msg);
-  // ---------
-  void wrap_paragraph( const std::string & _unformattedString, 
-                       unsigned int _indentWidth, 
-                       unsigned int _columnWidth, 
-                       bool _indentFirstLine,
-                       std::string &_formattedString);
-  void wrap_paragraphs( const std::string & _unformattedString, 
-                        unsigned int _indentWidth, 
-                        unsigned int _columnWidth, 
-                        bool _indentFirstLine,
-                        std::string &_formattedString);
+  void print_exception_and_throw_cancel(const xrt_core::error& e);
+  void print_exception_and_throw_cancel(const std::runtime_error& e);
 
+  std::string wrap_paragraphs( const std::string & unformattedString,
+                               unsigned int indentWidth,
+                               unsigned int columnWidth,
+                               bool indentFirstLine);
   void collect_devices( const std::set<std::string>  &_deviceBDFs,
                         bool _inUserDomain,
                         xrt_core::device_collection &_deviceCollection);

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -205,87 +205,91 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
 static const std::string
 shell_status(bool shell_status, bool sc_status, int num_dsa_shells)
 {
-  if(num_dsa_shells == 0)
+  if (num_dsa_shells == 0)
     return boost::str(boost::format("%-8s : %s\n") % "WARNING" % "No shell is installed on the system.");
-  if(num_dsa_shells > 1)
+
+  if (num_dsa_shells > 1)
     return boost::str(boost::format("%-8s : %s\n") % "WARNING" % "Multiple shells are installed on the system.");
-  if(!shell_status)
+
+  if (!shell_status)
     return boost::str(boost::format("%-8s : %s\n") % "WARNING" % "Device is not up-to-date.");
-  if(!sc_status)
+
+  if (!sc_status)
     return boost::str(boost::format("%-8s : %s\n") % "WARNING" % "SC image on the device is not up-to-date.");
+
   return "";
 }
 
 void 
-ReportPlatform::writeReport( const xrt_core::device * device, 
-                             const std::vector<std::string> & /*_elementsFilter*/, 
-                             std::iostream & output) const
+ReportPlatform::writeReport( const xrt_core::device* _pDevice, 
+                             const boost::property_tree::ptree& _pt, 
+                             const std::vector<std::string>& _elementsFilter,
+                             std::ostream & _output) const
 {
-  boost::property_tree::ptree pt;
-  getPropertyTreeInternal(device, pt);
+  _output << "Flash properties\n";
+  _output << fmtBasic % "Type" % _pt.get<std::string>("platform.flash_type", "N/A");
+  _output << fmtBasic % "Serial Number" % _pt.get<std::string>("platform.hardware.serial_num", "N/A");
+  _output << std::endl;
 
-  output << "Flash properties\n";
-  output << fmtBasic % "Type" % pt.get<std::string>("platform.flash_type", "N/A");
-  output << fmtBasic % "Serial Number" % pt.get<std::string>("platform.hardware.serial_num", "N/A");
-  output << std::endl;
-
-  output << "Flashable partitions running on FPGA\n";
-  output << fmtBasic % "Platform" % pt.get<std::string>("platform.current_shell.vbnv", "N/A");
-  output << fmtBasic % "SC Version" % pt.get<std::string>("platform.current_shell.sc_version", "N/A");
+  _output << "Flashable partitions running on FPGA\n";
+  _output << fmtBasic % "Platform" % _pt.get<std::string>("platform.current_shell.vbnv", "N/A");
+  _output << fmtBasic % "SC Version" % _pt.get<std::string>("platform.current_shell.sc_version", "N/A");
 
   // print platform ID, for 2RP, platform ID = logic UUID 
-  auto logic_uuid = pt.get<std::string>("platform.current_shell.logic-uuid", "");
-  auto interface_uuid = pt.get<std::string>("platform.current_shell.interface-uuid", "");
+  auto logic_uuid = _pt.get<std::string>("platform.current_shell.logic-uuid", "");
+  auto interface_uuid = _pt.get<std::string>("platform.current_shell.interface-uuid", "");
   if (!logic_uuid.empty() && !interface_uuid.empty()) {
-    output << fmtBasic % "Platform UUID" % logic_uuid;
-    output << fmtBasic % "Interface UUID" % interface_uuid;
+    _output << fmtBasic % "Platform UUID" % logic_uuid;
+    _output << fmtBasic % "Interface UUID" % interface_uuid;
   } else {
-    output << fmtBasic % "Platform ID" % pt.get<std::string>("platform.current_shell.id", "N/A");
+    _output << fmtBasic % "Platform ID" % _pt.get<std::string>("platform.current_shell.id", "N/A");
   }
-  output << std::endl;
+  _output << std::endl;
 
   // List PLP running on the system
   boost::property_tree::ptree pt_empty;
-  boost::property_tree::ptree& plps = pt.get_child("platform.current_partitions", pt_empty);
+
+  const boost::property_tree::ptree& plps = _pt.get_child("platform.current_partitions", pt_empty);
   for(auto& kv : plps) {
-    boost::property_tree::ptree& plp = kv.second;
-    output << fmtBasic % "Platform" % plp.get<std::string>("vbnv", "N/A");
-    output << fmtBasic % "Logic UUID" % plp.get<std::string>("logic-uuid", "N/A");
-    output << fmtBasic % "Interface UUID" % plp.get<std::string>("interface-uuid", "N/A");
-    output << std::endl;
+    const boost::property_tree::ptree& plp = kv.second;
+    _output << fmtBasic % "Platform" % plp.get<std::string>("vbnv", "N/A");
+    _output << fmtBasic % "Logic UUID" % plp.get<std::string>("logic-uuid", "N/A");
+    _output << fmtBasic % "Interface UUID" % plp.get<std::string>("interface-uuid", "N/A");
+    _output << std::endl;
   }
 
-  output << "Flashable partitions installed in system\n"; 
-  boost::property_tree::ptree& available_shells = pt.get_child("platform.available_shells");
+  _output << "Flashable partitions installed in system\n"; 
+  const boost::property_tree::ptree& available_shells = _pt.get_child("platform.available_shells");
   
   if(available_shells.empty())
-    output << boost::format("  %-20s\n") % "None" << std::endl;
+    _output << boost::format("  %-20s\n") % "<none found>" << std::endl;
   
   for(auto& kv : available_shells) {
-    boost::property_tree::ptree& available_shell = kv.second;
-    output << fmtBasic % "Platform" % available_shell.get<std::string>("vbnv", "N/A");
-    output << fmtBasic % "SC Version" % available_shell.get<std::string>("sc_version", "N/A");
+    const boost::property_tree::ptree& available_shell = kv.second;
+    _output << fmtBasic % "Platform" % available_shell.get<std::string>("vbnv", "N/A");
+    _output << fmtBasic % "SC Version" % available_shell.get<std::string>("sc_version", "N/A");
     // print platform ID, for 2RP, platform ID = logic UUID 
     auto platform_uuid = available_shell.get<std::string>("logic-uuid", "");
     if (!platform_uuid.empty()) {
-      output << fmtBasic % "Platform UUID" % platform_uuid;
+      _output << fmtBasic % "Platform UUID" % platform_uuid;
     } else {
-      output << fmtBasic % "Platform ID" % available_shell.get<std::string>("id", "N/A");
+      _output << fmtBasic % "Platform ID" % available_shell.get<std::string>("id", "N/A");
     }
-      output << std::endl;
+      _output << std::endl;
   }
 
   //PLPs installed on the system
-  boost::property_tree::ptree& available_plps = pt.get_child("platform.available_partitions", pt_empty);
+  const boost::property_tree::ptree& available_plps = _pt.get_child("platform.available_partitions", pt_empty);
   for(auto& kv : available_plps) {
-    boost::property_tree::ptree& plp = kv.second;
-    output << fmtBasic % "Platform" % plp.get<std::string>("vbnv", "N/A");
-    output << fmtBasic % "Logic UUID" % plp.get<std::string>("logic-uuid", "N/A");
-    output << fmtBasic % "Interface UUID" % plp.get<std::string>("interface-uuid", "N/A");
-    output << std::endl;
+    const boost::property_tree::ptree& plp = kv.second;
+    _output << fmtBasic % "Platform" % plp.get<std::string>("vbnv", "N/A");
+    _output << fmtBasic % "Logic UUID" % plp.get<std::string>("logic-uuid", "N/A");
+    _output << fmtBasic % "Interface UUID" % plp.get<std::string>("interface-uuid", "N/A");
+    _output << std::endl;
   }
 
-  output << "----------------------------------------------------\n"
-         << shell_status(pt.get<bool>("platform.status.shell", false), 
-                         pt.get<bool>("platform.status.sc", false),  static_cast<int>(available_shells.size()));
+  _output << shell_status(_pt.get<bool>("platform.status.shell", false), 
+                          _pt.get<bool>("platform.status.sc", false),  
+                          static_cast<int>(available_shells.size()));
+  _output << std::endl;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -221,9 +221,9 @@ shell_status(bool shell_status, bool sc_status, int num_dsa_shells)
 }
 
 void 
-ReportPlatform::writeReport( const xrt_core::device* _pDevice, 
+ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/, 
                              const boost::property_tree::ptree& _pt, 
-                             const std::vector<std::string>& _elementsFilter,
+                             const std::vector<std::string>& /*_elementsFilter*/,
                              std::ostream & _output) const
 {
   _output << "Flash properties\n";

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.h
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,7 +28,7 @@ class ReportPlatform: public Report {
  public:
   virtual void getPropertyTreeInternal(const xrt_core::device * _pDevice, boost::property_tree::ptree &_pt) const;
   virtual void getPropertyTree20202(const xrt_core::device * _pDevicee, boost::property_tree::ptree &_pt) const;
-  virtual void writeReport(const xrt_core::device * _pDevice, const std::vector<std::string> & _elementsFilter, std::iostream & _output) const;
+  virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& _pt, const std::vector<std::string>& _elementsFilter, std::ostream & _output) const;
 };
 
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -136,5 +136,8 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
     topOptions.push_back("--help");
   }
 
+  optionOption->setGlobalOptions(getGlobalOptions());
+
+  // Execute the option
   optionOption->execute(topOptions);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -226,7 +226,7 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
         retries--;
 
         ret = erase();
-        XBU::ProgressBar sc_flash("Programming SC", static_cast<unsigned int>(mRecordList.size()), XBU::is_esc_enabled(), std::cout);
+        XBU::ProgressBar sc_flash("Programming SC", static_cast<unsigned int>(mRecordList.size()), XBU::is_escape_codes_disabled(), std::cout);
         int counter = 0;
         for (auto i = mRecordList.begin(); ret == 0 && i != mRecordList.end(); ++i) {
             ret = program(tiTxtStream, *i);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -405,7 +405,7 @@ void XQSPIPS_Flasher::program(std::istream& binStream, unsigned base)
 #endif
 
     int beatCount = 0;
-    XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
+    XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(pages), XBU::is_escape_codes_disabled(), std::cout);
     for (unsigned int page = 0; page <= pages; page++) {
         program_flash.update(beatCount++);
 
@@ -439,7 +439,7 @@ int XQSPIPS_Flasher::verify(std::istream& binStream, unsigned base)
     int mismatched = 0;
     bool verified = true;
     int beatCount = 0;
-    XBU::ProgressBar verify_flash("Verifying flash", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
+    XBU::ProgressBar verify_flash("Verifying flash", static_cast<unsigned int>(pages), XBU::is_escape_codes_disabled(), std::cout);
     for (unsigned int page = 0; page <= pages; page++) {
         verify_flash.update(beatCount++);
 
@@ -499,7 +499,7 @@ void XQSPIPS_Flasher::readBack(const std::string& output, unsigned int base)
     const unsigned int pages = total_size / PAGE_SIZE;
 
     int beatCount = 0;
-    XBU::ProgressBar read_flash("Reading flash back", static_cast<unsigned int>(pages), XBU::is_esc_enabled(), std::cout);
+    XBU::ProgressBar read_flash("Reading flash back", static_cast<unsigned int>(pages), XBU::is_escape_codes_disabled(), std::cout);
     for (unsigned int page = 0; page <= pages; page++) {
         read_flash.update(beatCount++);
 
@@ -1114,7 +1114,7 @@ bool XQSPIPS_Flasher::eraseSector(unsigned addr, uint32_t byteCount, uint8_t era
     int beatCount = 0;
     //roundup byteCount to next SECTOR boundary
     byteCount = (byteCount + SECTOR_SIZE - 1) & (~SECTOR_SIZE);
-    XBU::ProgressBar erase_flash("Erasing flash", static_cast<unsigned int>(byteCount / SECTOR_SIZE), XBU::is_esc_enabled(), std::cout);
+    XBU::ProgressBar erase_flash("Erasing flash", static_cast<unsigned int>(byteCount / SECTOR_SIZE), XBU::is_escape_codes_disabled(), std::cout);
     for (Sector = 0; Sector < (byteCount / SECTOR_SIZE); Sector++) {
 
         if(!isFlashReady())

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -1,8 +1,7 @@
 /**
- * Copyright (C) 2016-2018 Xilinx, Inc
- * Author(s) : Sonal Santan
- *           : Hem Neema
- *           : Ryan Radjabi
+ * Copyright (C) 2016-2021
+ * Xilinx, Inc Author(s) : Sonal Santan 
+ *           : Hem Neema : Ryan Radjabi
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1685,7 +1684,7 @@ int XSPI_Flasher::programXSpi(std::istream& mcsStream, uint32_t bitstream_shift_
 
     //Now we can safely erase all subsectors
     int beatCount = 0;
-    XBU::ProgressBar erase_flash("Erasing flash", static_cast<unsigned int>(recordList.size()), XBU::is_esc_enabled(), std::cout);
+    XBU::ProgressBar erase_flash("Erasing flash", static_cast<unsigned int>(recordList.size()), XBU::is_escape_codes_disabled(), std::cout);
     for (ELARecordList::iterator i = recordList.begin(), e = recordList.end(); i != e; ++i) {
         beatCount++;
         // if(beatCount%20==0) {
@@ -1712,7 +1711,7 @@ int XSPI_Flasher::programXSpi(std::istream& mcsStream, uint32_t bitstream_shift_
 
     //Next we program flash. Note that bitstream guard is still active
     beatCount = 0;
-    XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(recordList.size()), XBU::is_esc_enabled(), std::cout);
+    XBU::ProgressBar program_flash("Programming flash", static_cast<unsigned int>(recordList.size()), XBU::is_escape_codes_disabled(), std::cout);
     for (ELARecordList::iterator i = recordList.begin(), e = recordList.end(); i != e; ++i)
     {
         beatCount++;

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt.cpp
@@ -69,8 +69,13 @@ int main( int argc, char** argv )
 
   // -- Ready to execute the code
   try {
-    main_(argc, argv, executable, description, subCommands);
+    main_( argc, argv, executable, description, subCommands);
     return 0;
+  } catch (const xrt_core::error& e) {
+    // Clean exception exit
+    // If the exception is "operation_canceled" then don't print the header debug info
+    if (e.code().value() != static_cast<int>(std::errc::operation_canceled))
+      xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (...) {

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -239,10 +239,12 @@ p2p(xrt_core::device* device, action_type action, bool force)
 {
   if (action == action_type::validate)
     p2ptest::test(device);
+
   if (action == action_type::enable) {
     XBU::sudo_or_throw("Root privileges required to enable p2p");
     device->p2p_enable(force);
   }
+
   if (action == action_type::disable) {
     XBU::sudo_or_throw("Root privileges required to disable p2p");
     device->p2p_disable(force);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -143,5 +143,8 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
     topOptions.push_back("--help");
   }
 
+  optionOption->setGlobalOptions(getGlobalOptions());
+  
+  // Execute the option
   optionOption->execute(topOptions);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -154,7 +154,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   pretty_print_action_list(deviceCollection, type);
 
   // Ask user for permission
-  if(!XBU::can_proceed())
+  if(!XBU::can_proceed(XBU::getForce()))
     return;
 
   //perform reset actions

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -196,8 +196,9 @@ searchLegacyXclbin(const uint16_t vendor, const std::string& dev_name, const std
  * 4. Check results
  */
 void
-runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py, const std::string& xclbin,
-            boost::property_tree::ptree& _ptTest)
+runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& py, 
+             const std::string& xclbin,
+             boost::property_tree::ptree& _ptTest)
 {
   std::string name;
   try {
@@ -247,8 +248,6 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     boost::filesystem::path test_dir(xclbinPath);
     std::string platform_json_path(test_dir.parent_path().string() + platform_metadata);
     return boost::filesystem::exists(platform_json_path) ? true : false;
-    // boost::filesystem::path test_dir(xclbinPath);
-    // return boost::filesystem::exists(test_dir.parent_path().string() + "/platform.json") ? true : false;
   };
 
   std::ostringstream os_stdout;
@@ -285,16 +284,21 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     boost::filesystem::path test_dir(xclbinPath);
     std::vector<std::string> args = { test_dir.parent_path().string(), 
                                       "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
-    int exit_code = XBU::runScript("sh", xrtTestCasePath, args, os_stdout, os_stderr);
-    if (exit_code == EOPNOTSUPP) {
-      _ptTest.put("status", "skipped");
-    }
-    else if (exit_code == EXIT_SUCCESS) {
-      _ptTest.put("status", "passed");
-    }
-    else {
-      logger(_ptTest, "Error", os_stdout.str());
-      logger(_ptTest, "Error", os_stderr.str());
+    try {
+      int exit_code = XBU::runScript("sh", xrtTestCasePath, args, os_stdout, os_stderr, true);
+      if (exit_code == EOPNOTSUPP) {
+        _ptTest.put("status", "skipped");
+      }
+      else if (exit_code == EXIT_SUCCESS) {
+        _ptTest.put("status", "passed");
+      }
+      else {
+        logger(_ptTest, "Error", os_stdout.str());
+        logger(_ptTest, "Error", os_stderr.str());
+        _ptTest.put("status", "failed");
+      }
+    } catch (const std::exception& e) {
+      logger(_ptTest, "Error", e.what());
       _ptTest.put("status", "failed");
     }
   }
@@ -314,21 +318,26 @@ runTestCase(const std::shared_ptr<xrt_core::device>& _dev, const std::string& py
     std::vector<std::string> args = { "-k", xclbinPath, 
                                       "-d", std::to_string(_dev.get()->get_device_id()) };
     int exit_code;    
-    if (py.find(".exe")!=std::string::npos)
-      exit_code = XBU::runScript("", xrtTestCasePath, args, os_stdout, os_stderr);
-    else
-      exit_code = XBU::runScript("python", xrtTestCasePath, args, os_stdout, os_stderr);
+    try {
+      if (py.find(".exe") != std::string::npos)
+        exit_code = XBU::runScript("", xrtTestCasePath, args, os_stdout, os_stderr, true);
+      else
+        exit_code = XBU::runScript("python", xrtTestCasePath, args, os_stdout, os_stderr, true);
 
-    if (exit_code == EOPNOTSUPP) {
-      _ptTest.put("status", "skipped");
-    }
-    else if (exit_code == EXIT_FAILURE) {
-      logger(_ptTest, "Error", os_stdout.str());
-      logger(_ptTest, "Error", os_stderr.str());
+      if (exit_code == EOPNOTSUPP) {
+        _ptTest.put("status", "skipped");
+      }
+      else if (exit_code == EXIT_FAILURE) {
+        logger(_ptTest, "Error", os_stdout.str());
+        logger(_ptTest, "Error", os_stderr.str());
+        _ptTest.put("status", "failed");
+      }
+      else {
+        _ptTest.put("status", "passed");
+      }
+    } catch (const std::exception& e) {
+      logger(_ptTest, "Error", e.what());
       _ptTest.put("status", "failed");
-    }
-    else {
-      _ptTest.put("status", "passed");
     }
   }
 
@@ -443,7 +452,7 @@ p2ptest_bank(xclDeviceHandle handle, boost::property_tree::ptree& _ptTest, std::
   }
 
   int counter = 0;
-  XBU::ProgressBar run_test("Running Test on " + m_tag, 1024, XBU::is_esc_enabled(), std::cout);
+  XBU::ProgressBar run_test("Running Test on " + m_tag, 1024, XBU::is_escape_codes_disabled(), std::cout);
   for(uint64_t c = 0; c < bo_size; c += chunk_size) {
     if(!p2ptest_chunk(handle, boptr + c, addr + c, chunk_size)) {
       _ptTest.put("status", "failed");
@@ -779,7 +788,7 @@ scVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tre
   } catch(...) {}
 
   if (!exp_sc_ver.empty() && sc_ver.compare(exp_sc_ver) != 0) {
-    logger(_ptTest, "Warning", "SC firmware misatch");
+    logger(_ptTest, "Warning", "SC firmware mismatch");
     logger(_ptTest, "Warning", boost::str(boost::format("SC firmware version %s is running on the board, but SC firmware version %s is expected from the installed shell. %s.")
                                           % sc_ver % exp_sc_ver % "Please use xbmgmt examine to check the installed shell"));
   }
@@ -1106,14 +1115,15 @@ pretty_print_test_desc(const boost::property_tree::ptree& test, int& test_idx,
 {
   if(test.get<std::string>("status", "").compare("skipped") != 0) {
     std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);
-    _ostream << boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name");
+    _ostream << boost::format("%-26s: %s \n") % test_desc % test.get<std::string>("name");
+
     if(XBU::getVerbose())
-      XBU::message(boost::str(boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
+      XBU::message(boost::str(boost::format("    %-22s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
   }
   else if(XBU::getVerbose()) {
     std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);
-    XBU::message(boost::str(boost::format("%-28s: %s \n") % test_desc % test.get<std::string>("name")));
-    XBU::message(boost::str(boost::format("    %-24s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
+    XBU::message(boost::str(boost::format("%-26s: %s \n") % test_desc % test.get<std::string>("name")));
+    XBU::message(boost::str(boost::format("    %-22s: %s\n") % "Description" % test.get<std::string>("description")), false, _ostream);
   }
     
 }
@@ -1148,16 +1158,25 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   try {
     for (const auto& dict : test.get_child("log")) {
       for (const auto& kv : dict.second) {
+        std::string formattedString = XBU::wrap_paragraphs(kv.second.get_value<std::string>(), 28 /*Indention*/, 60 /*Max length*/, false /*Indent*/);
+        std::string logType = kv.first;
+
+        if (boost::iequals(logType, "warning")) {
+          warn = true;
+          logType = "Warning(s)";
+        } 
+
+        if (boost::iequals(kv.first, "error")) {
+          error = true;
+          logType = "Error(s)";
+        }
+
         if (kv.first.compare(prev_tag)) {
           prev_tag = kv.first;
-          redirect_log(kv.first, boost::str(boost::format("    %-24s: %s\n") % kv.first % kv.second.get_value<std::string>()));
+          redirect_log(kv.first, boost::str(boost::format("    %-22s: %s\n") % logType % formattedString));
         }
         else
-          redirect_log(kv.first, boost::str(boost::format("    %-24s  %s\n") % "\0" % kv.second.get_value<std::string>()));
-        if (boost::iequals(kv.first, "warning"))
-          warn = true;
-        else if (boost::iequals(kv.first, "error"))
-          error = true;
+          redirect_log(kv.first, boost::str(boost::format("    %-22s  %s\n") % "" % formattedString));
       }
     }
   }
@@ -1172,7 +1191,7 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   }
 
   boost::to_upper(_status);
-  redirect_log("", boost::str(boost::format("    %-24s: [%s]\n") % "Test Status" % _status));
+  redirect_log("", boost::str(boost::format("    %-22s: [%s]\n") % "Test Status" % _status));
   redirect_log("", "-------------------------------------------------------------------------------\n");
 }
 
@@ -1196,29 +1215,28 @@ print_status(test_status status, std::ostream & _ostream)
  */
 
 static void
-get_platform_info(const std::shared_ptr<xrt_core::device>& device, boost::property_tree::ptree& _ptTree, 
-                  Report::SchemaVersion schemaVersion, std::ostream & _ostream)
+get_platform_info(const std::shared_ptr<xrt_core::device>& device, 
+                  boost::property_tree::ptree& ptTree, 
+                  Report::SchemaVersion schemaVersion, std::ostream & oStream)
 {
   auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-  _ptTree.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
-  _ptTree.put("platform", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
-  _ptTree.put("sc_version", xrt_core::device_query<xrt_core::query::xmc_sc_version>(device));
-  _ptTree.put("platform_id", (boost::format("0x%x") % xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
-  if (schemaVersion == Report::SchemaVersion::text) {
-    _ostream << boost::format("Validate device [%s]\n") % _ptTree.get<std::string>("device_id");
-    _ostream << boost::format("%-20s: %s\n") % "Platform" % _ptTree.get<std::string>("platform");
-    _ostream << boost::format("%-20s: %s\n") % "SC Version" % _ptTree.get<std::string>("sc_version");
-    _ostream << boost::format("%-20s: %s\n") % "Platform ID" % _ptTree.get<std::string>("platform_id");
-    _ostream << "-------------------------------------------------------------------------------\n";
-  }
+  ptTree.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
+  ptTree.put("platform", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
+  ptTree.put("sc_version", xrt_core::device_query<xrt_core::query::xmc_sc_version>(device));
+  ptTree.put("platform_id", (boost::format("0x%x") % xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
+
+  // Text output
+  oStream << boost::format("%-26s: [%s]\n") % "Validate Device" % ptTree.get<std::string>("device_id");
+  oStream << boost::format("    %-22s: %s\n") % "Platform" % ptTree.get<std::string>("platform");
+  oStream << boost::format("    %-22s: %s\n") % "SC Version" % ptTree.get<std::string>("sc_version");
+  oStream << boost::format("    %-22s: %s\n") % "Platform ID" % ptTree.get<std::string>("platform_id");
 }
 
-void
-run_test_suite_device(const std::shared_ptr<xrt_core::device>& device, 
-                      Report::SchemaVersion schemaVersion, 
-                      std::vector<TestCollection *> testObjectsToRun,
-                      boost::property_tree::ptree& _ptDevCollectionTestSuite,
-                      std::ostream & _ostream)
+static void
+run_test_suite_device( const std::shared_ptr<xrt_core::device>& device, 
+                       Report::SchemaVersion schemaVersion, 
+                       std::vector<TestCollection *> testObjectsToRun,
+                       boost::property_tree::ptree& ptDevCollectionTestSuite)
 {
   boost::property_tree::ptree ptDeviceTestSuite;
   boost::property_tree::ptree ptDeviceInfo;
@@ -1227,7 +1245,8 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
   if (testObjectsToRun.empty())
     throw std::runtime_error("No test given to validate against.");
 
-  get_platform_info(device, ptDeviceInfo, schemaVersion, _ostream);
+  get_platform_info(device, ptDeviceInfo, schemaVersion, std::cout);
+  std::cout << "-------------------------------------------------------------------------------" << std::endl;
 
   int test_idx = 0;
   for (TestCollection * testPtr : testObjectsToRun) {
@@ -1240,58 +1259,30 @@ run_test_suite_device(const std::shared_ptr<xrt_core::device>& device,
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };
-    if(schemaVersion == Report::SchemaVersion::text) {
-      auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-      if(is_black_box_test())
-        pretty_print_test_desc(ptTest, test_idx, _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
-    }
+
+    auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
+
+    if(is_black_box_test()) 
+      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
 
     testPtr->testHandle(device, ptTest);
     ptDeviceTestSuite.push_back( std::make_pair("", ptTest) );
 
-    if(schemaVersion == Report::SchemaVersion::text) {
-      auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-      if(!is_black_box_test()) 
-        pretty_print_test_desc(ptTest, test_idx, _ostream, xrt_core::query::pcie_bdf::to_string(bdf));
-      pretty_print_test_run(ptTest, status, _ostream);
-    }
-      
+    if(!is_black_box_test()) 
+      pretty_print_test_desc(ptTest, test_idx, std::cout, xrt_core::query::pcie_bdf::to_string(bdf));
 
-    // If a test fails, exit immediately
+    pretty_print_test_run(ptTest, status, std::cout);
+
+    // If a test fails, don't test the remaining ones
     if(status == test_status::failed) {
       break;
     }
   }
 
-  if(schemaVersion == Report::SchemaVersion::text)
-    print_status(status, _ostream);
+  print_status(status, std::cout);
 
   ptDeviceInfo.put_child("tests", ptDeviceTestSuite);
-  _ptDevCollectionTestSuite.push_back( std::make_pair("", ptDeviceInfo) );
-}
-
-static void
-run_tests_on_devices( xrt_core::device_collection &deviceCollection, 
-                      Report::SchemaVersion schemaVersion, 
-                      std::vector<TestCollection *> testObjectsToRun,
-                      boost::property_tree::ptree& ptDevCollectionTestSuite,
-                      std::ostream &_ostream)
-{
-  if (schemaVersion ==  Report::SchemaVersion::text)
-    _ostream << boost::format("Starting validation for %d devices\n\n") % deviceCollection.size();
-
-  boost::property_tree::ptree ptDeviceTested;
-  for(auto const& dev : deviceCollection) {
-    run_test_suite_device(dev, schemaVersion, testObjectsToRun, ptDeviceTested, _ostream);
-  }
-
-  ptDevCollectionTestSuite.put_child("logical_devices", ptDeviceTested);
-
-  if(schemaVersion !=  Report::SchemaVersion::text) {
-    std::stringstream ss;
-    boost::property_tree::json_parser::write_json(ss, ptDevCollectionTestSuite);
-    _ostream << ss.str() << std::endl;
-  }
+  ptDevCollectionTestSuite.push_back( std::make_pair("", ptDeviceInfo) );
 }
 
 static
@@ -1415,6 +1406,7 @@ create_report_summary( const boost::property_tree::ptree& ptDevCollectionTestSui
   }
 
   // -- Report the data collected
+  _ostream << std::endl;
   _ostream << "Validation Summary" << std::endl;
   _ostream << "------------------" << std::endl;
 
@@ -1441,7 +1433,40 @@ create_report_summary( const boost::property_tree::ptree& ptDevCollectionTestSui
   }
 }
 
+static void
+run_tests_on_devices( xrt_core::device_collection &deviceCollection, 
+                      Report::SchemaVersion schemaVersion, 
+                      std::vector<TestCollection *> testObjectsToRun,
+                      std::ostream & output)
+{
+  // -- Root property tree
+  boost::property_tree::ptree ptDevCollectionTestSuite;
 
+  // -- Let the user know that the testing has started
+  std::cout << boost::format("Starting validation for %d devices\n\n") % deviceCollection.size();
+
+  // -- Run the various tests and collect the test data
+  boost::property_tree::ptree ptDeviceTested;
+  for(auto const& dev : deviceCollection) 
+    run_test_suite_device(dev, schemaVersion, testObjectsToRun, ptDeviceTested);
+
+  ptDevCollectionTestSuite.put_child("logical_devices", ptDeviceTested);
+
+  // -- Create summary report
+  // Note: The report summary is only associated with the human readable format
+  create_report_summary(ptDevCollectionTestSuite, std::cout);
+
+  // -- Write the formatted output 
+  switch (schemaVersion) {
+    case Report::SchemaVersion::json_20202:
+      boost::property_tree::json_parser::write_json(output, ptDevCollectionTestSuite, true /*Pretty Print*/);
+      output << std::endl;  
+      break;
+    default:
+      // Do nothing
+      break;
+  }
+}
 
 }
 //end anonymous namespace
@@ -1484,8 +1509,6 @@ void
 SubCmdValidate::execute(const SubCmdOptions& _options) const
 
 {
-  XBU::verbose("SubCommand: validate");
-
   // -- Build up the format options
   const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
@@ -1495,7 +1518,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   // -- Retrieve and parse the subcommand options -----------------------------
   std::vector<std::string> device  = {"all"};
   std::vector<std::string> testsToRun = {"all"};
-  std::string sFormat = "text";
+  std::string sFormat = "JSON";
   std::string sOutput = "";
   bool help = false;
 
@@ -1628,32 +1651,20 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     }
   }
 
-  // -- Prepare the output stream ---------------------------------------------
-  std::ofstream fOutput;
+  // -- Run the tests --------------------------------------------------
+  std::ostringstream oSchemaOutput;
+  run_tests_on_devices(deviceCollection, schemaVersion, testObjectsToRun, oSchemaOutput);
 
-  // Is the output going to a file?  If so prepare to write it to a file
+  // -- Write output file ----------------------------------------------
   if (!sOutput.empty()) {
+    std::ofstream fOutput;
     fOutput.open(sOutput, std::ios::out | std::ios::binary);
     if (!fOutput.is_open()) 
       throw xrt_core::error((boost::format("Unable to open the file '%s' for writing.") % sOutput).str());
-    std::cout << "Info: The output is being redirected to the file: \'" << sOutput << "\'" << std::endl;
-    std::cout << "Info: Validation started ... " << std::endl;
+
+    fOutput << oSchemaOutput.str();
+
+    std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
   }
-
-  // Determine where the printed information should be sent.
-  std::ostream &oOutput = sOutput.empty() ? std::cout : fOutput;
-
-  // -- Run the tests --------------------------------------------------
-  boost::property_tree::ptree ptDevCollectionTestSuite;
-  run_tests_on_devices(deviceCollection, schemaVersion, testObjectsToRun, ptDevCollectionTestSuite, oOutput);
-
-  // -- Create a summary of the report
-  // Note: The report summary is only associated with the human readable format
-  if (schemaVersion == Report::SchemaVersion::text) 
-    create_report_summary(ptDevCollectionTestSuite, oOutput);
-
-  if (!sOutput.empty())
-    std::cout << "Info: Validation completed" << std::endl;
-
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1217,7 +1217,8 @@ print_status(test_status status, std::ostream & _ostream)
 static void
 get_platform_info(const std::shared_ptr<xrt_core::device>& device, 
                   boost::property_tree::ptree& ptTree, 
-                  Report::SchemaVersion schemaVersion, std::ostream & oStream)
+                  Report::SchemaVersion /*schemaVersion*/, 
+                  std::ostream & oStream)
 {
   auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
   ptTree.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));

--- a/src/runtime_src/core/tools/xbutil2/xbutil.cpp
+++ b/src/runtime_src/core/tools/xbutil2/xbutil.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -70,10 +70,16 @@ int main( int argc, char** argv )
   try {
     main_( argc, argv, executable, description, subCommands);
     return 0;
+  } catch (const xrt_core::error& e) {
+    // Clean exception exit
+    // If the exception is "operation_canceled" then don't print the header debug info
+    if (e.code().value() != static_cast<int>(std::errc::operation_canceled))
+      xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (const std::exception &e) {
     xrt_core::send_exception_message(e.what(), executable.c_str());
   } catch (...) {
     xrt_core::send_exception_message("Unknown error", executable.c_str());
   }
+
   return 1;
 }


### PR DESCRIPTION
Work Done
---------
+ Improved the try/catch functionality:
  - Added helper methods to print out a catch message (both runtime_error and system_error)
  - Added support in the entry level portion of the code to not create a debug stack if an std::errc::operation_canceled exception is caught.  Doing so allows for the code to exit the codebase gracefully.
+ Enhanced all command and sub-command help menus to also report the global options.
+ Fixed various spelling errors.
+ Removed format support for human readable 'text' output to files.
+ Enhanced all tools to always produce human readable 'text' output to the console, regardless if the "--output" is used.
+ Cleaned up various error messages
+ Removed dead code
+ Updated copyright notices
+ Renamed XBU::is_esc_enabled() to XBU::is_escape_codes_disabled() for the logic for this function is negative.
+ Replaced the wrap_paragraph() and wrap_paragraphs() function with a brand new wrap_paragraph() function that address bugs related to formating.  In addition, the new function is easier to read.
+ Exposed ProgressBar::formatTime() as a static method.
+ Updated Process to clear the progress bar.
+ Updated Process to throw an exception if the test times out.
+ Updated XBU::can_proceed() with a force option.
+ Command: Validate
  - Cleanup the running output.  The "running" status completion bar is removed after a test completes.
  - Cleaned up formated output to be consistant (e.g., The placement of the colon ':' character)
  - Updated the warning and error printed keys to be Warning(s) and Error(s)
  - Changed the default format type to "json"
  - Refactored how the JSON output file is openned and written to.  Output file write confirmation is echoed to the display.
+ Command: xbutil Examine
  - Changed the default format type to "json"
  - Updated code flow to throw an operation canceled exception for clean exits with an error
  - Updated the DRC checks to validate the format and output file existance cleanly
  - Refactored how the JSON output file is openned and written to.   Output file write confirmation is echoed to the display.
  - Added force support
+ Command: xbmgmt Examine
  - Added force support
  - Refactored how the JSON output file is openned and written to.   Output file write confirmation is echoed to the display.
+ Command: xbutil/xbmgmt Advanced
  - Added support for sub-options to print out the global help data
+ Class XBHelpMenus
  - Added support to report global options
  - Fixed various bugs related to wrapping of paragraphs
  - Updated console output to be write to a console stream instead of directly to std::cout.
  - Updated methods to use a output stream for formatted output.
+ Reports
  - Updated all the human readable reports to be produced from an given property tree, instead of an internally created one.  This tree is obtain and given to the individual reports via the Report class.
  - Cleaned up the formatting of the reports to be more colon ':' column align
  - For writeReport() addressed some missing default values
  - For writeReport() updated const for many of the variables
+ Fixed issue where an exception is thrown when checking the firewall status of a golden card.
+ Addressed various root privileges notificaiton issues.
+ Command reset now reports available devices if one isn't given.

CRs
-----
CR-1096635 - xbutil validate should still report progress to the console with use the --output option
CR-1096027 - verbose does not show in xbutil validate -h
CR-1097111 - /opt/xilinx/xrt/bin/xbutil validate output the json file has non JSON format information
CR-1089728 - Feature request: Force reset device using xbutil
CR-1090669 - xbmgmt2 more information than needed for no sudo