### PR TITLE
CR-1096474 Remove the GDB debug_mode option as the support is discont…

### DIFF
--- a/src/runtime_src/core/edge/common_em/config.cxx
+++ b/src/runtime_src/core/edge/common_em/config.cxx
@@ -243,10 +243,10 @@ namespace xclemulation{
         {
           setLaunchWaveform(DEBUG_MODE::OFF);
         }
-        else if (boost::iequals(value,"gdb" ))
+        /*else if (boost::iequals(value,"gdb" ))
         {
           setLaunchWaveform(DEBUG_MODE::GDB);
-        }
+        }*/
         else
         {
           setLaunchWaveform(DEBUG_MODE::OFF);
@@ -311,10 +311,10 @@ namespace xclemulation{
       {
         setLaunchWaveform(DEBUG_MODE::OFF);
       }
-      else if (boost::iequals(simulationMode,"gdb" ))
+      /*else if (boost::iequals(simulationMode,"gdb" ))
       {
         setLaunchWaveform(DEBUG_MODE::GDB);
-    }
+      }*/
     }
   }
 

--- a/src/runtime_src/core/edge/common_em/config.h
+++ b/src/runtime_src/core/edge/common_em/config.h
@@ -140,8 +140,7 @@ namespace xclemulation{
   enum DEBUG_MODE {
     OFF,
     BATCH,
-    GUI,
-    GDB
+    GUI
   };
   
   enum ERTMODE {

--- a/src/runtime_src/core/pcie/emulation/common_em/config.cxx
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.cxx
@@ -262,11 +262,11 @@ namespace xclemulation{
         else if (boost::iequals(value,"off" ))
         {
           setLaunchWaveform(DEBUG_MODE::OFF);
-        }
-        else if (boost::iequals(value,"gdb" ))
+        } 
+        /*else if (boost::iequals(value,"gdb")) 
         {
           setLaunchWaveform(DEBUG_MODE::GDB);
-        }
+        }*/
         else
         {
           setLaunchWaveform(DEBUG_MODE::OFF);
@@ -331,10 +331,10 @@ namespace xclemulation{
       {
         setLaunchWaveform(DEBUG_MODE::OFF);
       }
-      else if (boost::iequals(simulationMode,"gdb" ))
+      /*else if (boost::iequals(simulationMode,"gdb" ))
       {
         setLaunchWaveform(DEBUG_MODE::GDB);
-      }
+      }*/
     }
   }
 

--- a/src/runtime_src/core/pcie/emulation/common_em/config.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/config.h
@@ -143,8 +143,7 @@ namespace xclemulation{
   enum DEBUG_MODE {
     OFF,
     BATCH,
-    GUI,
-    GDB
+    GUI
   };
   
   enum ERTMODE {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -846,10 +846,10 @@ namespace xclhwemhal2 {
         setenv("VITIS_LAUNCH_WAVEFORM_BATCH", "1", true);
       }
 
-      if (lWaveform == xclemulation::DEBUG_MODE::GDB) {
+      /*if (lWaveform == xclemulation::DEBUG_MODE::GDB) {
         sim_path = binaryDirectory + "/behav_gdb/" + simulatorType;
         setSimPath(sim_path);
-      }
+      }*/
 
       if (userSpecifiedSimPath.empty() == false)
       {
@@ -861,11 +861,12 @@ namespace xclhwemhal2 {
       {
         if (sim_path.empty())
         {
-          sim_path = binaryDirectory + "/behav_gdb/" + simulatorType;
+          sim_path = binaryDirectory + "/behav_waveform/" + simulatorType;
           setSimPath(sim_path);
         }
 
-        if (boost::filesystem::exists(sim_path) == false)
+        // As GDB feature is unsupported for 2021.1, we removed this cross check. We will re-enable it once we have 2 possibilities
+        /*if (boost::filesystem::exists(sim_path) == false)
         {
           if (lWaveform == xclemulation::DEBUG_MODE::GDB) {
             sim_path = binaryDirectory + "/behav_waveform/" + simulatorType;
@@ -905,7 +906,7 @@ namespace xclhwemhal2 {
 
             logMessage(dMsg, 0);
           }
-        }
+        }*/
       }
 
       if (mLogStream.is_open())


### PR DESCRIPTION
CR-1096474 Remove the GDB debug_mode option as the support is discontinued in Vitis HLS