### PR TITLE
xclbinutil : Added DRC check to limit softkernel instances to 128.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -230,7 +230,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
     XUtil::TRACE(XUtil::format("  mpo_symbol_name (0x%lx): '%s'", softKernelHdr.mpo_symbol_name, sValue.c_str()).c_str());
 
     // DRC Check checking to see if the maximum symbol name length has been violated
-    static const unsigned int MAX_SYMBOL_NAME_LENGTH = 19;
+    constexpr unsigned int MAX_SYMBOL_NAME_LENGTH = 19;
     if (sValue.length() > MAX_SYMBOL_NAME_LENGTH) {
       const std::string errMsg = (boost::format("ERROR: The given symbol name '%s' (length %d) exceeds the maximum support length of %d characters.") 
                                             % sValue % sValue.length() % MAX_SYMBOL_NAME_LENGTH).str();
@@ -246,7 +246,7 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
     XUtil::TRACE(XUtil::format("  m_num_instances: %d", softKernelHdr.m_num_instances).c_str());
 
     // DRC Check checking the maximum number of instances
-    static const unsigned int MAX_NUM_INSTANCES = 128;
+    constexpr unsigned int MAX_NUM_INSTANCES = 128;
     if (value > MAX_NUM_INSTANCES) {
       const std::string errMsg = (boost::format("ERROR: The number of instances (%d) exceeds the maximum supported value (%d).") 
                                                  % value % MAX_NUM_INSTANCES).str();

--- a/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSoftKernel.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -244,6 +244,14 @@ SectionSoftKernel::copyBufferUpdateMetadata(const char* _pOrigDataSection,
     uint32_t value = ptSK.get<uint32_t>("m_num_instances", defaultValue);
     softKernelHdr.m_num_instances = value;
     XUtil::TRACE(XUtil::format("  m_num_instances: %d", softKernelHdr.m_num_instances).c_str());
+
+    // DRC Check checking the maximum number of instances
+    static const unsigned int MAX_NUM_INSTANCES = 128;
+    if (value > MAX_NUM_INSTANCES) {
+      const std::string errMsg = (boost::format("ERROR: The number of instances (%d) exceeds the maximum supported value (%d).") 
+                                                 % value % MAX_NUM_INSTANCES).str();
+      throw std::runtime_error(errMsg);
+    }
   }
 
   // Last item to be initialized

--- a/src/runtime_src/tools/xclbinutil/unittests/SoftKernel/SectionSoftKernel.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/SoftKernel/SectionSoftKernel.py
@@ -62,6 +62,24 @@ def main():
 
 
   # ---------------------------------------------------------------------------
+  
+  step = "3) Read in a soft kernel and its metadata where the instances are greater then 128"
+  
+  inputJSON = os.path.join(args.resource_dir, "softkernel_129instances.rtd")
+  inputKernel = os.path.join(args.resource_dir, "softkernel.so")
+  softKernelName = "my_kernel"
+  
+  cmd = [xclbinutil, "--add-section", "SOFT_KERNEL[" + softKernelName + "]-OBJ:RAW:" + inputKernel, "--add-section", "SOFT_KERNEL[" + softKernelName + "]-METADATA:JSON:" + inputJSON]
+  
+  try:
+    print("Note: Testing for an excessive instances (expecting an error)")
+    execCmd(step, cmd)
+  except:
+    print("Test passed - Exception raised")
+  else:
+    raise Exception("Error: Large instance count accepted.  DRC check did not trip.")
+
+  # ---------------------------------------------------------------------------
 
   # If the code gets this far, all is good.
   return False

--- a/src/runtime_src/tools/xclbinutil/unittests/SoftKernel/softkernel_129instances.rtd
+++ b/src/runtime_src/tools/xclbinutil/unittests/SoftKernel/softkernel_129instances.rtd
@@ -1,0 +1,9 @@
+{
+  "soft_kernel_metadata": {
+    "mpo_name": "my_kernel",
+    "mpo_version": "0.9.0",
+    "mpo_md5_value": "a794b17fb67e96cad73342598ec9dd45",
+    "mpo_symbol_name" : "nineteen__char_name",
+    "m_num_instances": 129
+  }
+}


### PR DESCRIPTION
Work Done
------------
+ Updated the DRC check to validated that the number of softkernel instances count doesn't exceed 128.
+ Added regression tests to validate DRC check

CRs
----
CR-1090185 - xclbinutil verify ps_kernel symbol name