### PR TITLE
xclbinutil : Enhanced exception handling when reading/merging JSON data.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -452,13 +452,12 @@ Section::readPayload(std::fstream& _istream, enum FormatType _eFormatType)
         // O.K. - Lint checking is done and write it to our buffer
         try {
           readJSONSectionImage(pt);
-        } catch (std::exception &e) {
-          std::cerr << std::endl;
-          std::cerr << "ERROR: An exception was thrown while attempting to add following JSON image to the section: '" << getSectionKindAsString() << "'" << std::endl;
-          std::cerr << "       Exception Message: " << e.what() << std::endl;
+        } catch (const std::exception &e) {
+          std::cerr << "\nERROR: An exception was thrown while attempting to add following JSON image to the section: '" << getSectionKindAsString() << "'\n";
+          std::cerr << "       Exception Message: " << e.what() << "\n";
           std::ostringstream jsonBuf;
           boost::property_tree::write_json(jsonBuf, pt, true);
-          std::cerr << jsonBuf.str() << std::endl;
+          std::cerr << jsonBuf.str() << "\n";
           throw std::runtime_error("Aborting remaining operations");
         }
         break;

--- a/src/runtime_src/tools/xclbinutil/Section.cxx
+++ b/src/runtime_src/tools/xclbinutil/Section.cxx
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <sstream>
 
 
 #include "XclBinUtilities.h"
@@ -449,7 +450,17 @@ Section::readPayload(std::fstream& _istream, enum FormatType _eFormatType)
         boost::property_tree::read_json(ss, pt);
 
         // O.K. - Lint checking is done and write it to our buffer
-        readJSONSectionImage(pt);
+        try {
+          readJSONSectionImage(pt);
+        } catch (std::exception &e) {
+          std::cerr << std::endl;
+          std::cerr << "ERROR: An exception was thrown while attempting to add following JSON image to the section: '" << getSectionKindAsString() << "'" << std::endl;
+          std::cerr << "       Exception Message: " << e.what() << std::endl;
+          std::ostringstream jsonBuf;
+          boost::property_tree::write_json(jsonBuf, pt, true);
+          std::cerr << jsonBuf.str() << std::endl;
+          throw std::runtime_error("Aborting remaining operations");
+        }
         break;
       }
     case FT_HTML:

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -483,7 +483,7 @@ XclBin::findAndReadMirrorData(std::fstream& _istream, boost::property_tree::ptre
 
   try {
     boost::property_tree::read_json(ss, _mirrorData);
-  } catch (boost::property_tree::json_parser_error &e) {
+  } catch (const boost::property_tree::json_parser_error &e) {
     std::string errMsg = XUtil::format("ERROR: Parsing mirror metadata in the xclbin archive on line %d: %s", e.line(), e.message().c_str());
     throw std::runtime_error(errMsg);
   }
@@ -619,7 +619,7 @@ readJSONFile(const std::string & filename, boost::property_tree::ptree &pt)
   // Read in the JSON file
   try {
     boost::property_tree::read_json(fs, pt);
-  } catch (boost::property_tree::json_parser_error &e) {
+  } catch (const boost::property_tree::json_parser_error &e) {
     std::string errMsg = XUtil::format("ERROR: Parsing the file '%s' on line %d: %s", filename.c_str(), e.line(), e.message().c_str());
     throw std::runtime_error(errMsg);
   }
@@ -671,13 +671,12 @@ XclBin::addMergeSection(ParameterSectionData & _PSD)
   // Merge the sections 
   try {
     pSection->appendToSectionMetadata(ptMerge, ptPayload);
-  } catch (std::exception &e) {
-    std::cerr << std::endl;
-    std::cerr << "ERROR: An exception was thrown while attempting to merge the following JSON image to the section: '" << pSection->getSectionKindAsString() << "'" << std::endl;
-    std::cerr << "       Exception Message: " << e.what() << std::endl;
+  } catch (const std::exception &e) {
+    std::cerr << "\nERROR: An exception was thrown while attempting to merge the following JSON image to the section: '" << pSection->getSectionKindAsString() << "'\n";
+    std::cerr << "       Exception Message: " << e.what() << "\n";
     std::ostringstream jsonBuf;
     boost::property_tree::write_json(jsonBuf, ptMerge, true);
-    std::cerr << jsonBuf.str() << std::endl;
+    std::cerr << jsonBuf.str() << "\n";
     throw std::runtime_error("Aborting remaining operations");
   }
 
@@ -1081,7 +1080,7 @@ XclBin::addSections(ParameterSectionData &_PSD)
   boost::property_tree::ptree pt;
   try {
     boost::property_tree::read_json(fs, pt);
-  } catch (boost::property_tree::json_parser_error &e) {
+  } catch (const boost::property_tree::json_parser_error &e) {
     std::string errMsg = XUtil::format("ERROR: Parsing the file '%s' on line %d: %s", sJSONFileName.c_str(), e.line(), e.message().c_str());
     throw std::runtime_error(errMsg);
   }
@@ -1112,7 +1111,17 @@ XclBin::addSections(ParameterSectionData &_PSD)
     }
 
     pSection = Section::createSectionObjectOfKind(eKind);
-    pSection->readJSONSectionImage(pt);
+    try {
+      pSection->readJSONSectionImage(pt);
+    } catch (const std::exception &e) {
+      std::cerr << "\nERROR: An exception was thrown while attempting to add following JSON image to the section: '" << pSection->getSectionKindAsString() << "'\n";
+      std::cerr << "       Exception Message: " << e.what() << "\n";
+      std::ostringstream jsonBuf;
+      boost::property_tree::write_json(jsonBuf, pt, true);
+      std::cerr << jsonBuf.str() << "\n";
+      throw std::runtime_error("Aborting remaining operations");
+    }
+
     if (pSection->getSize() == 0) {
       XUtil::QUIET("");
       XUtil::QUIET(XUtil::format("Section: '%s'(%d) was empty.  No action taken.\nFormat : %s\nFile   : '%s'", 
@@ -1191,13 +1200,12 @@ XclBin::appendSections(ParameterSectionData &_PSD)
 
     try {
       pSection->appendToSectionMetadata(ptSection->second, ptPayload);
-    } catch (std::exception &e) {
-      std::cerr << std::endl;
-      std::cerr << "ERROR: An exception was thrown while attempting to append the following JSON image to the section: '" << pSection->getSectionKindAsString() << "'" << std::endl;
+    } catch (const std::exception &e) {
+      std::cerr << "\nERROR: An exception was thrown while attempting to append the following JSON image to the section: '" << pSection->getSectionKindAsString() << "'\n";
       std::cerr << "       Exception Message: " << e.what() << std::endl;
       std::ostringstream jsonBuf;
       boost::property_tree::write_json(jsonBuf, ptSection->second, true);
-      std::cerr << jsonBuf.str() << std::endl;
+      std::cerr << jsonBuf.str() << "\n";
       throw std::runtime_error("Aborting remaining operations");
     }
 

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -26,6 +26,7 @@
 #include <boost/uuid/uuid_io.hpp>       // for to_string
 #include <boost/filesystem.hpp>
 #include <random>
+#include <sstream>
 
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
@@ -668,7 +669,17 @@ XclBin::addMergeSection(ParameterSectionData & _PSD)
   pSection->getPayload(ptPayload);
 
   // Merge the sections 
-  pSection->appendToSectionMetadata(ptMerge, ptPayload);
+  try {
+    pSection->appendToSectionMetadata(ptMerge, ptPayload);
+  } catch (std::exception &e) {
+    std::cerr << std::endl;
+    std::cerr << "ERROR: An exception was thrown while attempting to merge the following JSON image to the section: '" << pSection->getSectionKindAsString() << "'" << std::endl;
+    std::cerr << "       Exception Message: " << e.what() << std::endl;
+    std::ostringstream jsonBuf;
+    boost::property_tree::write_json(jsonBuf, ptMerge, true);
+    std::cerr << jsonBuf.str() << std::endl;
+    throw std::runtime_error("Aborting remaining operations");
+  }
 
   // Store the resulting merger
   pSection->purgeBuffers();
@@ -1178,7 +1189,17 @@ XclBin::appendSections(ParameterSectionData &_PSD)
     boost::property_tree::ptree ptPayload;
     pSection->getPayload(ptPayload);
 
-    pSection->appendToSectionMetadata(ptSection->second, ptPayload);
+    try {
+      pSection->appendToSectionMetadata(ptSection->second, ptPayload);
+    } catch (std::exception &e) {
+      std::cerr << std::endl;
+      std::cerr << "ERROR: An exception was thrown while attempting to append the following JSON image to the section: '" << pSection->getSectionKindAsString() << "'" << std::endl;
+      std::cerr << "       Exception Message: " << e.what() << std::endl;
+      std::ostringstream jsonBuf;
+      boost::property_tree::write_json(jsonBuf, ptSection->second, true);
+      std::cerr << jsonBuf.str() << std::endl;
+      throw std::runtime_error("Aborting remaining operations");
+    }
 
     pSection->purgeBuffers();
     pSection->readJSONSectionImage(ptPayload);

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2020 Xilinx, Inc
+ * Copyright (C) 2018, 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
Enhance the exception message when a JSON node is not found.  Prior to the change only the message:
`No such node (m_base_address)`
would be produced.  

Now the message is:
```
ERROR: An exception was thrown while attempting to append the following JSON image to the section: 'IP_LAYOUT'
       Exception Message: No such node (m_base_address)
{
    "m_count": "2",
    "m_ip_data": [
        {
            "m_type": "IP_DDR4_CONTROLLER",
            "properties": "0"
        },
        {
            "m_type": "IP_DDR4_CONTROLLER",
            "properties": "1"
        }
    ]
}
```
CRs
----
CR-1064447 - Enhance runlink error reporting