### PR TITLE
Throw if OpenCL device cannot be converted to xrt::device

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -291,7 +291,6 @@ class xclbin_impl
     std::vector<xclbin::mem> m_mems;
     std::vector<xclbin::ip> m_ips;
     std::vector<xclbin::kernel> m_kernels;
-    std::string m_xsa_name;
 
     // kernel_cu_to_ip() - convert ::ip_data entry to xclbin::ip object
     //
@@ -398,7 +397,6 @@ class xclbin_impl
     // xclbin_info() - constructor for xclbin meta data
     xclbin_info(const xrt::xclbin_impl* impl)
       : m_ximpl(impl)
-      , m_xsa_name("todo")
     {
       init_mems();     // must be first
       init_ips();      // must be before kernels
@@ -442,6 +440,13 @@ public:
   virtual
   uuid
   get_uuid() const
+  {
+    throw std::runtime_error("not implemented");
+  }
+
+  virtual
+  std::string
+  get_xsa_name() const
   {
     throw std::runtime_error("not implemented");
   }
@@ -499,12 +504,6 @@ public:
   get_mems() const
   {
     return get_xclbin_info()->m_mems;
-  }
-
-  std::string
-  get_xsa_name() const
-  {
-    return get_xclbin_info()->m_xsa_name;
   }
 };
 
@@ -582,6 +581,13 @@ public:
   get_uuid() const
   {
     return m_uuid;
+  }
+
+  virtual
+  std::string
+  get_xsa_name() const
+  {
+    return reinterpret_cast<const char*>(m_top->m_header.m_platformVBNV);
   }
 
   virtual

--- a/src/runtime_src/xocl/api/xlnx/cl2xrt.cpp
+++ b/src/runtime_src/xocl/api/xlnx/cl2xrt.cpp
@@ -28,7 +28,10 @@ namespace xrt { namespace opencl {
 xrt::device
 get_xrt_device(cl_device_id device)
 {
-  return xocl::xocl(device)->get_xrt_device();
+  auto xdevice = xocl::xocl(device)->get_xrt_device();
+  if (!xdevice)
+    throw xrt_core::error(ENODEV, "OpenCL context has not been created, xrt::device does not exist");
+  return xdevice;
 }
 
 xrt::bo

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -95,6 +95,7 @@ run(const std::string& xclbin_fnm)
   auto xclbin = xrt::xclbin(xclbin_fnm);
   auto uuid = xclbin.get_uuid();
   std::cout << xclbin_fnm << "\n";
+  std::cout << "xsa(" << xclbin.get_xsa_name() << ")\n";
   std::cout << "uuid(" << uuid.to_string() << ")\n\n";
 
   for (auto& kernel : xclbin.get_kernels())


### PR DESCRIPTION
A cl_device_id is not associated with a shim level device until a
cl_context is created.  Attempting to convert the cl_device_id to an
xrt::device before creating a cl_context is not possible and now
errors out.

Unrelated change: Add xrt::xclbin::get_xsa_name()