### PR TITLE
CR-1088371 "xbutil --new examine" command hangs when a card is not in…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/dna.c
@@ -101,7 +101,7 @@ static void xlnx_dna_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, &dna_status, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, &dna_status, &resp_len, NULL, NULL, 0, 0, false);
 	set_xlnx_dna_data(xlnx_dna, &dna_status);
 
 	vfree(mb_req);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -204,7 +204,7 @@ static void fw_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, &fw_status, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, &fw_status, &resp_len, NULL, NULL, 0, 0, false);
 	set_fw_data(fw, &fw_status);
 
 	vfree(mb_req);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -342,7 +342,7 @@ static void icap_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, &xcl_hwicap, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, &xcl_hwicap, &resp_len, NULL, NULL, 0, 0, false);
 
 	icap_set_data(icap, &xcl_hwicap);
 
@@ -1879,7 +1879,7 @@ static int __icap_peer_xclbin_download(struct icap *icap, struct axlf *xclbin)
 	timeout = max((size_t)timeout, 50UL);
 
 	(void) xocl_peer_request(xdev, mb_req, data_len,
-		&msgerr, &resplen, NULL, NULL, timeout, 0);
+		&msgerr, &resplen, NULL, NULL, timeout, 0, false);
 
 	vfree(mb_req);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -1924,6 +1924,9 @@ int mailbox_request(struct platform_device *pdev, void *req, size_t reqlen,
 		return -EFAULT;
 	}
 
+	/*
+	 * Force sending request to peer or wait till drivers are fully probed.
+	 */
 	if (!force) {
 		uint64_t ch_state = 0;
 		(void) mailbox_get(pdev, CHAN_STATE, &ch_state);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -506,7 +506,7 @@ static void p2p_read_addr_mgmtpf(struct p2p *p2p)
 		mb_p2p->p2p_bar_len, mb_p2p->p2p_bar_addr);
 
 	ret = xocl_peer_request(xdev, mb_req, reqlen, &ret,
-		&resplen, NULL, NULL, 0, 0);
+		&resplen, NULL, NULL, 0, 0, false);
 	vfree(mb_req);
 	if (ret) {
 		p2p_err(p2p, "dropped request (%d), failed with err: %d",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -567,7 +567,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0, 0, false);
 	set_sensors_data(xmc, xcl_sensor);
 
 done:
@@ -1006,7 +1006,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	ret = xocl_peer_request(xdev,
-		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0, 0, false);
 done:
 	if (ret) {
 		/* if we failed to get board info from peer, free it and 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -504,7 +504,7 @@ static void xmc_read_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	(void) xocl_peer_request(xdev,
-		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, xcl_sensor, &resp_len, NULL, NULL, 0, 0, false);
 	set_sensors_data(xmc, xcl_sensor);
 
 done:
@@ -913,7 +913,7 @@ static void read_bdinfo_from_peer(struct platform_device *pdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	ret = xocl_peer_request(xdev,
-		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, xmc->bdinfo_raw, &resp_len, NULL, NULL, 0, 0, false);
 done:
 	if (ret) {
 		/* if we failed to get board info from peer, free it and 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -138,7 +138,7 @@ static void xocl_mig_cache_read_from_peer(struct xocl_dev *xdev)
 	memcpy(mb_req->data, &subdev_peer, data_len);
 
 	ret = xocl_peer_request(xdev,
-		mb_req, reqlen, mig_ecc, &resp_len, NULL, NULL, 0, 0);
+		mb_req, reqlen, mig_ecc, &resp_len, NULL, NULL, 0, 0, false);
 
 	if (!ret)
 		set_mig_cache_data(xdev, mig_ecc);
@@ -314,7 +314,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 
 	userpf_info(xdev, "request mgmtpf to program prp");
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
-		&ret, &resplen, NULL, NULL, 0, 0);
+		&ret, &resplen, NULL, NULL, 0, 0, false);
 	if (mbret)
 		ret = mbret;
 	if (ret) {
@@ -390,7 +390,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 			return 0;
 
 		mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
-			&ret, &resplen, NULL, NULL, 0, 6);
+			&ret, &resplen, NULL, NULL, 0, 6, true);
 		/*
 		 * Check the return values mbret & ret (mpd (peer) side response) and confirm
 		 * reset request success.
@@ -413,7 +413,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 	}
 
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
-		&ret, &resplen, NULL, NULL, 0, 0);
+		&ret, &resplen, NULL, NULL, 0, 0, false);
 
 	xocl_reset_notify(xdev->core.pdev, true);
 
@@ -610,7 +610,7 @@ static void xocl_mb_connect(struct xocl_dev *xdev)
 	mb_conn->version = XCL_MB_PROTOCOL_VER;
 
 	ret = xocl_peer_request(xdev, mb_req, reqlen, resp, &resplen,
-		NULL, NULL, 0, 0);
+		NULL, NULL, 0, 0, true);
 	(void) xocl_mailbox_set(xdev, CHAN_STATE, resp->conn_flags);
 	(void) xocl_mailbox_set(xdev, CHAN_SWITCH, resp->chan_switch);
 	(void) xocl_mailbox_set(xdev, CHAN_DISABLE, resp->chan_disable);
@@ -669,7 +669,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 
 	if (err == 0) {
 		err = xocl_peer_request(xdev, req, reqlen,
-			&msg, &resplen, NULL, NULL, 0, 0);
+			&msg, &resplen, NULL, NULL, 0, 0, false);
 		if (err == 0)
 			err = msg;
 	}
@@ -858,7 +858,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 		subdev_peer.offset = offset;
 		ret = xocl_peer_request(xdev, mb_req, reqlen,
-			resp, &resp_len, NULL, NULL, 0, 0);
+			resp, &resp_len, NULL, NULL, 0, 0, true);
 		if (ret)
 			goto failed;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1163,9 +1163,9 @@ typedef	void (*mailbox_msg_cb_t)(void *arg, void *data, size_t len,
 	u64 msgid, int err, bool sw_ch);
 struct xocl_mailbox_funcs {
 	struct xocl_subdev_funcs common_funcs;
-	int (*request)(struct platform_device *pdev, void *req,
-		size_t reqlen, void *resp, size_t *resplen,
-		mailbox_msg_cb_t cb, void *cbarg, u32 rx_timeout, u32 tx_timeout);
+	int (*request)(struct platform_device *pdev, void *req, size_t reqlen,
+		void *resp, size_t *resplen, mailbox_msg_cb_t cb, void *cbarg,
+		u32 rx_timeout, u32 tx_timeout, bool force);
 	int (*post_notify)(struct platform_device *pdev, void *req, size_t len);
 	int (*post_response)(struct platform_device *pdev,
 		enum xcl_mailbox_request req, u64 reqid, void *resp, size_t len);
@@ -1179,9 +1179,9 @@ struct xocl_mailbox_funcs {
 	((struct xocl_mailbox_funcs *)SUBDEV(xdev, XOCL_SUBDEV_MAILBOX).ops)
 #define MAILBOX_READY(xdev, cb)	\
 	(MAILBOX_DEV(xdev) && MAILBOX_OPS(xdev) && MAILBOX_OPS(xdev)->cb)
-#define	xocl_peer_request(xdev, req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout)	\
+#define	xocl_peer_request(xdev, req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout, force)	\
 	(MAILBOX_READY(xdev, request) ? MAILBOX_OPS(xdev)->request(MAILBOX_DEV(xdev), \
-	req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout) : -ENODEV)
+	req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout, force) : -ENODEV)
 #define	xocl_peer_response(xdev, req, reqid, buf, len)			\
 	(MAILBOX_READY(xdev, post_response) ? MAILBOX_OPS(xdev)->post_response(	\
 	MAILBOX_DEV(xdev), req, reqid, buf, len) : -ENODEV)


### PR DESCRIPTION
I would not call this is a good fix. The root cause is:
1) xbutil2 doesn't use xbutil1's pci rescan to get device number; but directly use the bdf number;
2) when xbutil2 init the shim which will open the device, for some reason, several sysfs nodes can get request and those data will be requested from user driver xocl to mgmt driver xclmgmt. However, the driver is not ready yet due to hardware is not positioned correctly, so mailbox doesn't respond.  While there are lots of requests from xmc.c and icap.c, so the timeout feels longer (not seconds, but minutes).
3) This fix is to demonstrate what I found so far. We might think a better way to fix the issue. 

I recommend:
1) avoiding request peer when driver is not fully loaded, but it seems a wider issue;
2) using xbutil1's original way to avoid open an unhealthy device;
3) additionally, check sysfs node "ready" before doing anything on driver node; 
  
test results:
```
root@xsjyliu50:~# xbutil query -d 1
INFO: Found total 2 card(s), 1 are usable
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
System Configuration                                                            
OS name:        Linux                                                           
Release:        5.4.0-72-generic                                                
Version:        #80-Ubuntu SMP Mon Apr 12 17:35:00 UTC 2021                     
Machine:        x86_64                                                          
Model:          PowerEdge T640
CPU cores:      12
Memory:         63536 MB
Glibc:          2.31
Distribution:   Ubuntu 20.04.1 LTS
Now:            Thu May  6 12:16:39 2021 GMT
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
XRT Information
Version:        2.11.552
Git Hash:       0e0724defb9ab5480717fc597019b472ef9b9ba5
Git Branch:     master
Build Date:     2021-05-02 12:10:05
XOCL:           2.11.552,0e0724defb9ab5480717fc597019b472ef9b9ba5
XCLMGMT:        2.11.552,0e0724defb9ab5480717fc597019b472ef9b9ba5
ERROR: Card index 1 is out of range
root@xsjyliu50:~# xbutil examine
-----------------------------------------------------
 Invoking next generation of the xbutil application
-----------------------------------------------------
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-72-generic
  Version              : #80-Ubuntu SMP Mon Apr 12 17:35:00 UTC 2021
  Machine              : x86_64
  CPU Cores            : 12
  Memory               : 63536 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : PowerEdge T640

XRT
  Version              : 2.11.552
  Branch               : master
  Hash                 : 0e0724defb9ab5480717fc597019b472ef9b9ba5
  Hash Date            : 2021-05-02 12:10:05
  XOCL                 : 2.11.552, 0e0724defb9ab5480717fc597019b472ef9b9ba5
  XCLMGMT              : 2.11.552, 0e0724defb9ab5480717fc597019b472ef9b9ba5

Devices present
  [0000:d9:00.1] : xilinx_u50_gen3x16_nodma_base_1
  [0000:b1:00.1] :  NOTE: Device not ready for use

```