### PR TITLE
xbmgmt programming related fixes

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -676,7 +676,7 @@ xclmgmt_load_xclbin(const char* buffer) const {
     xrt_core::send_exception_message(e.what(), "Failed to open device");
   }
 
-  if(ret == -errno) {
+  if(ret != 0) {
     throw error(ret, "Failed to download xclbin");
   }
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -663,8 +663,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
       std::cout << "List of available devices:" << std::endl;
       boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
       for(auto& kd : available_devices) {
-        boost::property_tree::ptree& dev = kd.second;
-        std::cout << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
+        boost::property_tree::ptree& _dev = kd.second;
+        std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
       }
       std::cout << std::endl;
       throw xrt_core::error(std::errc::operation_canceled);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -667,7 +667,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
         std::cout << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
       }
       std::cout << std::endl;
-        return;
+      throw xrt_core::error(std::errc::operation_canceled);
       }
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -655,6 +655,22 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     return;
   }
 
+  // We support programming all devices only for a u30 homogeneous setup
+  // --device all is deprecated 
+  for (const auto& dev : deviceCollection) {
+    if(deviceCollection.size() != 1 && xrt_core::device_query<xrt_core::query::board_name>(dev).compare("u30") != 0) {
+      std::cerr << "\nERROR: Multiple device programming is not supported. Please specify a single device using --device option\n\n";
+      std::cout << "List of available devices:" << std::endl;
+      boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
+      for(auto& kd : available_devices) {
+        boost::property_tree::ptree& dev = kd.second;
+        std::cout << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
+      }
+      std::cout << std::endl;
+        return;
+      }
+  }
+
   // TODO: Added mutually exclusive code for image, update, and revert-to-golden action.
 
   if(!image.empty()) {
@@ -771,6 +787,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   // -- process "user" option ---------------------------------------
   if(!xclbin.empty()) {
     XBU::verbose(boost::str(boost::format("  xclbin: %s") % xclbin));
+    XBU::sudo_or_throw("Root privileges are required to download xclbin");
     //only 1 device and name
     if(deviceCollection.size() > 1)
       throw xrt_core::error("Please specify a single device");

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -405,17 +405,14 @@ bool DSAInfo::matchIntId(std::string &id) const
 
 bool DSAInfo::matchId(const DSAInfo& dsa) const
 {
-    if (uuids.size() != dsa.uuids.size())
-        return false;
-    else if (uuids.size() == 0)
-    {
-        if (timestamp == dsa.timestamp)
-            return true;
-    }
-    else if (uuids[0].compare(dsa.uuids[0]) == 0)
-    {
+    if (uuids.size() == 0 && dsa.uuids.size() == 0 &&
+        timestamp == dsa.timestamp)
         return true;
-    }
+
+    //logid_uuid should always be the 1st.
+    if (uuids.size() > 0 && dsa.uuids.size() > 0 &&
+        uuids[0].compare(dsa.uuids[0]) == 0)
+        return true;
     return false;
 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -405,12 +405,12 @@ bool DSAInfo::matchIntId(std::string &id) const
 
 bool DSAInfo::matchId(const DSAInfo& dsa) const
 {
-    if (uuids.size() == 0 && dsa.uuids.size() == 0 &&
+    if (uuids.empty() && dsa.uuids.empty() &&
         timestamp == dsa.timestamp)
         return true;
 
     //logid_uuid should always be the 1st.
-    if (uuids.size() > 0 && dsa.uuids.size() > 0 &&
+    if (!uuids.empty() && !dsa.uuids.empty() &&
         uuids[0].compare(dsa.uuids[0]) == 0)
         return true;
     return false;


### PR DESCRIPTION
- Don't allow flashing all devices unless it is a homogenous u30 setup
- https://jira.xilinx.com/browse/CR-1097319

Sample output:
```
CASE 1: downloading mismatiching xclbin
$ sudo xbmgmt program --user /opt/xilinx/firmware/u30/gen3x4/base/test/verify.xclbin  -d 65:00
Downloading xclbin on device [0000:65:00.0]...
ERROR: Failed to download xclbin: Operation not permitted

CASE 2: successful download
$ sudo xbmgmt program --user /opt/xilinx/firmware/u30/gen3x4/base/test/verify.xclbin  -d 17:00
Downloading xclbin on device [0000:17:00.0]...
INFO: Successfully downloaded xclbin

CASE 3: missing sudo
$ xbmgmt program --user /opt/xilinx/firmware/u30/gen3x4/base/test/verify.xclbin  -d 17:00
ERROR: Root privileges are required to download xclbin
```
- https://jira.xilinx.com/browse/CR-1097087

Only update SC and not base as base is already upto date.
Sample output:
```
$ sudo xbmgmt program -b -d 18:00
----------------------------------------------------                                                           
Device : [0000:18:00.0]                                                                                        

Current Configuration
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.6                   
  Platform ID          : 0x26291aa7c111172e      


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/26291aa7c111172ecc8675d18da15593
  Size                 : 64,097,920 bytes
  Timestamp            : Thu May  6 15:27:44 2021

  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform UUID        : 26291AA7-C111-172E-CC86-75D18DA15593
----------------------------------------------------
Actions to perform:
  [0000:18:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]:

Updating SC firmware on device[0000:18:00.0]
----------------------------------------------------
Report
  [0000:18:00.0] : Successfully flashed

1 device(s) flashed successfully.
$ sudo xbmgmt examine -d 18:00

----------------------------------------------
1/1 [0000:18:00.0] : xilinx_u30_gen3x4_base_1
----------------------------------------------
Flash properties
  Type                 : qspi_ps_x2_single
  Serial Number        : XFL1XGHL3NNO

Flashable partitions running on FPGA
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform UUID        : 26291AA7-C111-172E-CC86-75D18DA15593
  Interface UUID       : 937ED708-67CF-3350-BC06-304053F4293C

Flashable partitions installed in system
  Platform             : xilinx_u30_gen3x4_base_1
  SC Version           : 6.3.5
  Platform UUID        : 26291AA7-C111-172E-CC86-75D18DA15593

```