### PR TITLE
CR-1096826 remap bar doesn't exist in u2 platform

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -1060,7 +1060,10 @@ static int p2p_remap_resource(struct platform_device *pdev, int bar_idx,
 
 	if (!p2p->remapper) {
 		p2p_err(p2p, "remap does not exist");
-		return -EINVAL;
+		/* remap bar doesn't exist on u2 platforms and remap_range set to entire
+		 * p2p bar len in p2p_mem_init(). So, check remap_range val before returning err code.
+		 */
+		return (p2p->remap_range ? 0 : -EINVAL);
 	}
 
 	mutex_lock(&p2p->p2p_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/p2p.c
@@ -1060,10 +1060,9 @@ static int p2p_remap_resource(struct platform_device *pdev, int bar_idx,
 
 	if (!p2p->remapper) {
 		p2p_err(p2p, "remap does not exist");
-		/* remap bar doesn't exist on u2 platforms and remap_range set to entire
-		 * p2p bar len in p2p_mem_init(). So, check remap_range val before returning err code.
+		/* remap bar doesn't exist on u2 platforms, return -ENODEV error
 		 */
-		return (p2p->remap_range ? 0 : -EINVAL);
+		return -ENODEV;
 	}
 
 	mutex_lock(&p2p->p2p_lock);


### PR DESCRIPTION
Since remap bar doesn't exist in u2 platform, do not return any error
code during subdev p2p construct() phase of xbutil reset operation.

With this, validate test is passed after xbutil reset operation as well.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>