### PR TITLE
trace fixes

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -64,8 +64,7 @@ void DeviceTraceOffload::offload_device_continuous()
   // Do a final forced read
   m_read_trace(true);
   read_trace_end();
-
-  status = OffloadThreadStatus::STOPPED;
+  offload_finished();
 }
 
 void DeviceTraceOffload::train_clock_continuous()
@@ -75,7 +74,7 @@ void DeviceTraceOffload::train_clock_continuous()
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep_interval_ms));
   }
 
-  status = OffloadThreadStatus::STOPPED;
+  offload_finished();
 }
 
 bool DeviceTraceOffload::should_continue()
@@ -103,6 +102,13 @@ void DeviceTraceOffload::stop_offload()
   std::lock_guard<std::mutex> lock(status_lock);
   if (status == OffloadThreadStatus::STOPPED) return ;
   status = OffloadThreadStatus::STOPPING;
+}
+
+void DeviceTraceOffload::offload_finished()
+{
+  std::lock_guard<std::mutex> lock(status_lock);
+  if (status == OffloadThreadStatus::STOPPED) return ;
+  status = OffloadThreadStatus::STOPPED;
 }
 
 void DeviceTraceOffload::train_clock()

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -87,9 +87,6 @@ public:
     void read_trace() {
       m_read_trace(true);
     };
-    bool circular_buffer_overwrite_detected() {
-      return m_circ_buf_overwrite_detected;
-    }
     DeviceTraceLogger* getDeviceTraceLogger() {
       return deviceTraceLogger;
     };
@@ -131,7 +128,7 @@ private:
     void read_trace_fifo(bool force=true);
     void read_trace_s2mm(bool force=true);
     uint64_t read_trace_s2mm_partial();
-    void config_s2mm_reader(uint64_t wordCount);
+    bool config_s2mm_reader(uint64_t wordCount);
     bool init_s2mm(bool circ_buf);
     void reset_s2mm();
     bool should_continue();
@@ -139,6 +136,7 @@ private:
     void offload_device_continuous();
 
     bool m_trbuf_full = false;
+    bool trbuf_offload_done = false;
 
     // Clock Training Params
     bool m_force_clk_train = true;
@@ -151,7 +149,6 @@ private:
     // 100 mb of trace per second
     uint64_t m_circ_buf_min_rate = TS2MM_DEF_BUF_SIZE * 100;
     uint64_t m_circ_buf_cur_rate = 0;
-    bool m_circ_buf_overwrite_detected = false;
 
     // Used to check read precondition in ts2mm
     uint64_t m_wordcount_old = 0;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -61,8 +61,6 @@ public:
     XDP_EXPORT
     void stop_offload();
 
-    inline OffloadThreadStatus get_status() { return status ; }
-
 public:
     XDP_EXPORT
     virtual bool read_trace_init(bool circ_buf = false);
@@ -95,6 +93,10 @@ public:
       min_offload_rate = m_circ_buf_min_rate;
       requested_offload_rate = m_circ_buf_cur_rate;
       return m_use_circ_buf;
+    };
+    inline OffloadThreadStatus get_status() {
+      std::lock_guard<std::mutex> lock(status_lock);
+      return status;
     };
     inline bool continuous_offload() { return continuous ; }
     inline void set_continuous(bool value = true) { continuous = value ; }
@@ -134,6 +136,7 @@ private:
     bool should_continue();
     void train_clock_continuous();
     void offload_device_continuous();
+    void offload_finished();
 
     bool m_trbuf_full = false;
     bool trbuf_offload_done = false;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -69,7 +69,7 @@ Recommended settings are : 'coarse' option for data transfer trace and no stall 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
 
 #define TS2MM_WARN_MSG_CIRC_BUF       "Unable to use circular buffer for continuous trace offload. Please increase trace \
-buffer size and/or reduce continuous trace interval."
+buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."
 
 #define MIN_TRACE_DUMP_INTERVAL_S 1

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -365,17 +365,10 @@ namespace xdp {
       events.mark("Trace FIFO Full");
     }
 
-    if (offloader->has_ts2mm()) {
-      if (offloader->trace_buffer_full()) {
+    if (offloader->has_ts2mm() && offloader->trace_buffer_full()) {
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BUF_FULL);
         xrt::profile::user_event events;
         events.mark("Trace Buffer Full");
-      }
-      if (offloader->circular_buffer_overwrite_detected()) {
-        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE);
-        xrt::profile::user_event events;
-        events.mark("Trace Buffer Overwrite Detected");
-      }
     }
   }
 


### PR DESCRIPTION
1. Print circular buffer warning as soon as we see overrun (CR-1097504)
2. Update overrun warning for new flag (CR-1098578)
3. Use locks to access trace offload status (CR-1098581)