### PR TITLE
Bug fixes of zocl driver.

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_xclbin.c
+++ b/src/runtime_src/core/common/drv/xrt_xclbin.c
@@ -190,6 +190,8 @@ xrt_xclbin_kind_to_string(enum axlf_section_kind kind)
 	case AIE_METADATA: 		return "AIE_METADATA";
 	case ASK_GROUP_TOPOLOGY: 	return "ASK_GROUP_TOPOLOGY";
 	case ASK_GROUP_CONNECTIVITY: 	return "ASK_GROUP_CONNECTIVITY";
+	case SMARTNIC:			return "SMARTNIC";
+	case AIE_RESOURCES:		return "AIE_RESOURCES";
 	default: 			return "UNKNOWN";
 	}
 }


### PR DESCRIPTION
CR-1077058 get section AIE_METADATA err: -22 on VMK180 design
CR-1091511 BUG: scheduling while atomic" and filed to load the xclbin with XRT at linux environment.

1. Get rid of the a call generator message ("err: -22"). The new message schema matches what we display on DC platform
2. Release spin lock before calling into FPGA manager.