### PR TITLE
CR 1086988 - AIE Trace data mover IP is not writing raw events data received from AIE to DDR Memory

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -321,7 +321,7 @@ get_aie_trace_flush()
 inline std::string
 get_aie_trace_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_trace_metrics", "functions");
+  static std::string value = detail::get_string_value("Debug.aie_trace_metrics", "");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -314,7 +314,7 @@ get_aie_trace()
 inline bool
 get_aie_trace_flush()
 {
-  static bool value = detail::get_bool_value("Debug.aie_trace_flush", false);
+  static bool value = detail::get_bool_value("Debug.aie_trace_flush", true);
   return value;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -722,7 +722,7 @@ namespace xdp {
     // New start & end events for trace control and counters
     //coreTraceStartEvent = XAIE_EVENT_TIMER_SYNC_CORE;
     coreTraceStartEvent = XAIE_EVENT_TRUE_CORE;
-	  coreTraceEndEvent   = XAIE_EVENT_TIMER_VALUE_REACHED_CORE;
+    coreTraceEndEvent   = XAIE_EVENT_TIMER_VALUE_REACHED_CORE;
 
     // Timer trigger value: 300* 1020*1020 = 312,120,000 = 0x129A92C0
     // NOTES: Each packet has 7 payload words (one word: 32bits)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -720,7 +720,8 @@ namespace xdp {
     }
 
     // New start & end events for trace control and counters
-    coreTraceStartEvent = XAIE_EVENT_TIMER_SYNC_CORE;
+    //coreTraceStartEvent = XAIE_EVENT_TIMER_SYNC_CORE;
+    coreTraceStartEvent = XAIE_EVENT_TRUE_CORE;
 	  coreTraceEndEvent   = XAIE_EVENT_TIMER_VALUE_REACHED_CORE;
 
     // Timer trigger value: 300* 1020*1020 = 312,120,000 = 0x129A92C0
@@ -768,6 +769,7 @@ namespace xdp {
       counter->stop();
       counter->changeStartEvent(XAIE_CORE_MOD, coreTraceStartEvent);
       counter->changeStopEvent(XAIE_CORE_MOD,  coreTraceEndEvent);
+      counter->changeThreshold( coreCounterEventValues.at(i % 2) );
       counter->start();
     }
 
@@ -822,7 +824,7 @@ namespace xdp {
     // dummy packets to ensure all execution trace gets written to DDR.
     if (xrt_core::config::get_aie_trace_flush()) {
       setFlushMetrics(deviceId, handle);
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
+      std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
 
     if(aieOffloaders.find(deviceId) != aieOffloaders.end()) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -167,8 +167,8 @@ namespace xdp {
     // Get AIE tiles and metric set
     std::string metricsStr = xrt_core::config::get_aie_trace_metrics();
     if (metricsStr.empty()) {
-      std::string msg("The setting aie_trace_metrics was not specified in xrt.ini. If metrics were not specified at compile-time, then AIE event trace will not be available.");
-      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
+      std::string msg("The setting aie_trace_metrics was not specified in xrt.ini. AIE event trace will only be available if metrics were specified at compile time.");
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
       return false;
     }
 
@@ -757,7 +757,7 @@ namespace xdp {
         XAie_LocType tileLocation = XAie_TileLoc(col, row + 1);
         XAie_SetTimerTrigEventVal(aieDevInst, tileLocation, XAIE_CORE_MOD,
                                   timerTrigValueLow, timerTrigValueHigh);
-        XAie_ResetTimer(aieDevInst, tileLocation, XAIE_CORE_MOD);
+        //XAie_ResetTimer(aieDevInst, tileLocation, XAIE_CORE_MOD);
       }
 
       // 2. For every counter, change start/stop events
@@ -773,7 +773,7 @@ namespace xdp {
       counter->start();
     }
 
-    // 3. For every tile, restart trace
+    // 3. For every tile, restart trace and reset timer
     prevCol = 0;
     prevRow = 0;
     for (int i=0; i < coreCounters.size(); ++i) {
@@ -786,6 +786,9 @@ namespace xdp {
         auto& core     = aieDevice->tile(col, row + 1).core();
         auto coreTrace = core.traceControl();
         coreTrace->start();
+
+        XAie_LocType tileLocation = XAie_TileLoc(col, row + 1);
+        XAie_ResetTimer(aieDevInst, tileLocation, XAIE_CORE_MOD);
       }
     }
   }

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -34,6 +34,7 @@
 #include "core/common/system.h"
 #include "core/common/time.h"
 #include "core/common/config_reader.h"
+#include "core/common/message.h"
 
 #ifdef _WIN32
 /* Disable warning for use of localtime */
@@ -1626,8 +1627,8 @@ namespace xdp {
     
     // Columns
     fout << "Parameter" << ","
-	 << "Element"   << ","
-	 << "Value"     << "," << std::endl ;
+         << "Element"   << ","
+         << "Value"     << "," << std::endl ;
 
     for (auto rule : guidanceRules)
     {
@@ -1637,6 +1638,8 @@ namespace xdp {
 
   bool OpenCLSummaryWriter::write(bool openNewFile)
   {
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT", 
+                            "OpenCLSummaryWriter: write contents");
     writeHeader() ;                                 fout << std::endl ;
     writeAPICallSummary() ;                         fout << std::endl ;
     writeKernelExecutionSummary() ;                 fout << std::endl ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -28,6 +28,7 @@
 #include "xdp/profile/database/static_info_database.h"
 
 #include "core/common/time.h"
+#include "core/common/message.h"
 
 namespace xdp {
 
@@ -49,6 +50,9 @@ namespace xdp {
   {
     // Ignore openNewFile
     
+    xrt_core::message::send(xrt_core::message::severity_level::debug, "XRT",
+                            "VPRunSummaryWriter: write contents");
+
     // We could be called to write multiple times, so refresh before
     //  we dump
     refreshFile() ;
@@ -75,8 +79,7 @@ namespace xdp {
     {
       auto pid = (db->getStaticInfo()).getPid() ;
       auto timestamp = (std::chrono::system_clock::now()).time_since_epoch() ;
-      auto value =
-	std::chrono::duration_cast<std::chrono::milliseconds>(timestamp) ;
+      auto value = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp) ;
       uint64_t timeMsec = value.count() ;
 
       boost::property_tree::ptree ptGeneration ;


### PR DESCRIPTION
* made adjustments to trace flush and turned it on by default
* added some debug messaging