### PR TITLE
CR-1098839: Fixing profiling regression on non-AIE Versal designs

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -147,13 +147,13 @@ namespace xdp {
       delete runSummary ;
     }
 
-    for (auto iter : deviceInfo) {
-      delete iter.second ;
-    }
-
     // AIE specific functions
     if (aieDevice != nullptr && deallocateAieDevice != nullptr)
       deallocateAieDevice(aieDevice) ;
+
+    for (auto iter : deviceInfo) {
+      delete iter.second ;
+    }
   }
 
   bool VPStaticDatabase::validXclbin(void* devHandle)

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -128,7 +128,8 @@ namespace xdp {
 
   VPStaticDatabase::VPStaticDatabase(VPDatabase* d) :
     db(d), runSummary(nullptr), systemDiagram(""),
-    softwareEmulationDeviceName("")
+    softwareEmulationDeviceName(""), aieDevInst(nullptr),
+    aieDevice(nullptr), deallocateAieDevice(nullptr)
   {
 #ifdef _WIN32
     pid = _getpid() ;
@@ -136,11 +137,6 @@ namespace xdp {
     pid = static_cast<int>(getpid()) ;
 #endif
     applicationStartTime = 0 ;
-
-#ifdef XRT_ENABLE_AIE
-    aieDevInst = nullptr;
-    aieDevice = nullptr;
-#endif
   }
 
   VPStaticDatabase::~VPStaticDatabase()

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -30,11 +30,6 @@
 #include "core/common/system.h"
 #include "core/common/device.h"
 
-#ifdef XRT_ENABLE_AIE
-#include "xaiefal/xaiefal.hpp"
-#include "core/edge/user/shim.h"
-#endif
-
 namespace xdp {
 
   // Forward declarations
@@ -598,12 +593,12 @@ class aie_cfg_tile
 
     // Static info can be accessed via any host thread
     std::mutex dbLock ;
+    std::mutex aieLock ;
 
     // AIE device (Supported devices only)
-#ifdef XRT_ENABLE_AIE
-    XAie_DevInst *aieDevInst;
-    std::shared_ptr<xaiefal::XAieDev> aieDevice;
-#endif
+    void* aieDevInst = nullptr ; // XAie_DevInst
+    void* aieDevice = nullptr ; // xaiefal::XAieDev
+    std::function<void (void*)> deallocateAieDevice = nullptr ;
 
     bool resetDeviceInfo(uint64_t deviceId, const std::shared_ptr<xrt_core::device>& device);
 
@@ -1137,10 +1132,11 @@ class aie_cfg_tile
       return deviceInfo[deviceId]->gmioList.size();
     }
 
-#ifdef XRT_ENABLE_AIE
-    XDP_EXPORT XAie_DevInst * getAieDevInst(void* devHandle) ;
-    XDP_EXPORT std::shared_ptr<xaiefal::XAieDev> getAieDevice(void* devHandle) ;
-#endif
+    XDP_EXPORT void* getAieDevInst(std::function<void* (void*)> fetch,
+                                   void* devHandle) ;
+    XDP_EXPORT void* getAieDevice(std::function<void* (void*)> allocate,
+                                  std::function<void (void*)> deallocate,
+                                  void* devHandle) ;
 
     // Reseting device information whenever a new xclbin is added
     XDP_EXPORT void updateDevice(uint64_t deviceId, void* devHandle) ;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -50,7 +50,7 @@ namespace {
   {
     XAie_DevInst* aieDevInst =
       static_cast<XAie_DevInst*>(fetchAieDevInst(devHandle)) ;
-    if (aieDevInst != nullptr)
+    if (!aieDevInst)
       return nullptr ;
     return new xaiefal::XAieDev(aieDevInst, false) ;
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -34,6 +34,36 @@
 #define NUM_MEMORY_COUNTERS 2
 #define BASE_MEMORY_COUNTER 128
 
+namespace {
+  static void* fetchAieDevInst(void* devHandle)
+  {
+    auto drv = ZYNQ::shim::handleCheck(devHandle);
+    if (!drv)
+      return nullptr ;
+    auto aieArray = drv->getAieArray() ;
+    if (!aieArray)
+      return nullptr ;
+    return aieArray->getDevInst() ;
+  }
+
+  static void* allocateAieDevice(void* devHandle)
+  {
+    XAie_DevInst* aieDevInst =
+      static_cast<XAie_DevInst*>(fetchAieDevInst(devHandle)) ;
+    if (aieDevInst != nullptr)
+      return nullptr ;
+    return new xaiefal::XAieDev(aieDevInst, false) ;
+  }
+
+  static void* deallocateAieDevice(void* aieDevice)
+  {
+    xaiefal::XAieDev* object = static_cast<xaiefal::XAieDev*>(aieDevice) ;
+    if (object != nullptr)
+      delete object ;
+  }
+
+} // end anonymous namespace
+
 namespace xdp {
 
   AIEProfilingPlugin::AIEProfilingPlugin() 
@@ -103,8 +133,10 @@ namespace xdp {
 
   bool AIEProfilingPlugin::setMetrics(uint64_t deviceId, void* handle)
   {
-    auto aieDevInst = (db->getStaticInfo()).getAieDevInst(handle);
-    auto aieDevice  = (db->getStaticInfo()).getAieDevice(handle);
+    XAie_DevInst* aieDevInst =
+      static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
+    xaiefal::XAieDev* aieDevice =
+      static_cast<xaiefal::XAieDev*>(db->getStaticInfo().getAieDevice(allocateAieDevice, deallocateAieDevice, handle)) ;
     if (!aieDevInst || !aieDevice) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", 
           "Unable to get AIE device. There will be no AIE profiling.");
@@ -313,7 +345,8 @@ namespace xdp {
       // Wait until xclbin has been loaded and device has been updated in database
       if (!(db->getStaticInfo().isDeviceReady(index)))
         continue;
-      auto aieDevInst = (db->getStaticInfo()).getAieDevInst(handle);
+      XAie_DevInst* aieDevInst =
+        static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle)) ;
       if (!aieDevInst)
         continue;
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -55,7 +55,7 @@ namespace {
     return new xaiefal::XAieDev(aieDevInst, false) ;
   }
 
-  static void* deallocateAieDevice(void* aieDevice)
+  static void deallocateAieDevice(void* aieDevice)
   {
     xaiefal::XAieDev* object = static_cast<xaiefal::XAieDev*>(aieDevice) ;
     if (object != nullptr)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -59,7 +59,7 @@ namespace {
     return new xaiefal::XAieDev(aieDevInst, false) ;
   }
 
-  static void* deallocateAieDevice(void* aieDevice)
+  static void deallocateAieDevice(void* aieDevice)
   {
     xaiefal::XAieDev* object = static_cast<xaiefal::XAieDev*>(aieDevice) ;
     if (object != nullptr)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -54,7 +54,7 @@ namespace {
   {
     XAie_DevInst* aieDevInst =
       static_cast<XAie_DevInst*>(fetchAieDevInst(devHandle)) ;
-    if (aieDevInst != nullptr)
+    if (!aieDevInst)
       return nullptr ;
     return new xaiefal::XAieDev(aieDevInst, false) ;
   }


### PR DESCRIPTION
A recent checkin added information specific to AIE designs into the profiling code in the xdp_core library.  On applications where the AIE library is not loaded, this caused the programs to fail when loading xdp_core due to unresolved references.

This pull request moves the AIE specific implementation out of xdp_core and into the aie plugins, while still storing the information in the xdp_core database.  In order to accomplish this, the database now needs additional function pointers to know how to allocate and deallocate the specific pointers as they are stored as void*.
