### PR TITLE
Remove --device all from all commands

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -335,6 +335,19 @@ OO_Config::execute(const SubCmdOptions& _options) const
     return;
   }
 
+  // enforce 1 device specification
+  if(deviceCollection.size() > 1) {
+    std::cerr << "\nERROR: Configuring multiple devices is not supported. Please specify a single device using --device option\n\n";
+    std::cout << "List of available devices:" << std::endl;
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
+    for(auto& kd : available_devices) {
+      boost::property_tree::ptree& _dev = kd.second;
+      std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+    }
+    std::cout << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
   //Option:show
   if (m_show) {
     XBU::verbose("Sub command: --show");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -80,8 +80,8 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   const std::string formatOptionValues = XBU::create_suboption_list_string(Report::getSchemaDescriptionVector());
 
   // Option Variables
-  std::vector<std::string> devices = {"all"};
-  std::vector<std::string> reportNames = {"platform"};
+  std::vector<std::string> devices;
+  std::vector<std::string> reportNames;
   std::vector<std::string> elementsFilter;
   std::string sFormat = "json";
   std::string sOutput = "";
@@ -121,6 +121,21 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     return;
   }
 
+  // Determine report level
+  if (devices.size() == 0 && reportNames.size() == 0)
+    reportNames.push_back("host");
+
+  if (devices.size() != 0 && reportNames.size() == 0) {
+    reportNames.push_back("platform");
+  }
+
+  // Determine default values
+  if (devices.size() == 0)
+    devices.push_back("all");
+
+  if (reportNames.size() == 0)
+    reportNames.push_back("host");
+
   // -- Process the options --------------------------------------------
   ReportCollection reportsToProcess;            // Reports of interest
   xrt_core::device_collection deviceCollection;  // The collection of devices to examine
@@ -158,6 +173,19 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
         for (const auto & report : missingReports) 
           std::cout << boost::format("         - %s\n") % report;
       }
+    }
+
+    // enforce 1 device specification if multiple reports are requested
+    if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)) {
+      std::cerr << "\nERROR: Examining multiple devices is not supported. Please specify a single device using --device option\n\n";
+      std::cout << "List of available devices:" << std::endl;
+      boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
+      for(auto& kd : available_devices) {
+        boost::property_tree::ptree& _dev = kd.second;
+        std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+      }
+      std::cout << std::endl;
+      return;
     }
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -112,7 +112,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 
   po::options_description commonOptions("Common Options");
   commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
+    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("type,r", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
                                                                         "  hot          - Hot reset (default)\n")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
@@ -152,10 +152,10 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   XBU::verbose(boost::str(boost::format("  Reset: %s") % resetType));
 
   // -- process "device" option -----------------------------------------------
-  // enforce device specification
-  if(devices.empty()) {
+  // enforce 1 device specification
+  if(devices.empty() || devices.size() > 1) {
     std::cerr << std::endl
-              << "ERROR: Device not specified." << std::endl
+              << "ERROR: Please specify a single device." << std::endl
               << "Specifying a device via '--device' is required to apply a reset." << std::endl << std::endl
               << "The following devices are available to use:" << std::endl;
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -152,22 +152,6 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   XBU::verbose(boost::str(boost::format("  Reset: %s") % resetType));
 
   // -- process "device" option -----------------------------------------------
-  // enforce 1 device specification
-  if(devices.empty() || devices.size() > 1) {
-    std::cerr << std::endl
-              << "ERROR: Please specify a single device." << std::endl
-              << "Specifying a device via '--device' is required to apply a reset." << std::endl << std::endl
-              << "The following devices are available to use:" << std::endl;
-
-    boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
-    for(auto& kd : available_devices) {
-      boost::property_tree::ptree& dev = kd.second;
-      std::cerr << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
-    }
-    std::cerr << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
   // Collect all of the devices of interest
   std::set<std::string> deviceNames;
   xrt_core::device_collection deviceCollection;  // The collection of devices to examine
@@ -180,6 +164,19 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     return;
+  }
+
+  // enforce 1 device specification
+  if(deviceCollection.size() != 1) {
+    std::cerr << "\nERROR: Multiple device reset is not supported. Please specify a single device using --device option\n\n";
+    std::cout << "List of available devices:" << std::endl;
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
+    for(auto& kd : available_devices) {
+      boost::property_tree::ptree& _dev = kd.second;
+      std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+    }
+    std::cout << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   
   xrt_core::query::reset_type type = XBU::str_to_reset_obj(resetType);

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -320,6 +320,20 @@ OO_P2P::execute(const SubCmdOptions& _options) const
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     return;
   }
+
+  // enforce 1 device specification
+  if(deviceCollection.size() > 1) {
+    std::cerr << "\nERROR: Multiple devices are not supported. Please specify a single device using --device option\n\n";
+    std::cout << "List of available devices:" << std::endl;
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(true);
+    for(auto& kd : available_devices) {
+      boost::property_tree::ptree& _dev = kd.second;
+      std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+    }
+    std::cout << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
   for (auto& device : deviceCollection)
     p2p(device.get(), string2action(m_action), false);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -146,7 +146,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   // Determine report level
   if (devices.size() == 0 && reportNames.size() == 0)
-      reportNames.push_back("host");
+    reportNames.push_back("host");
 
   if (devices.size() != 0 && reportNames.size() == 0) {
     reportNames.push_back("platform");
@@ -216,6 +216,19 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
         for (const auto & report : missingReports) 
           std::cout << boost::format("         - %s\n") % report;
       }
+    }
+
+    // enforce 1 device specification if multiple reports are requested
+    if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 && reportNames.front().compare("host") != 0)) {
+      std::cerr << "\nERROR: Examining multiple devices is not supported. Please specify a single device using --device option\n\n";
+      std::cout << "List of available devices:" << std::endl;
+      boost::property_tree::ptree available_devices = XBU::get_available_devices(true);
+      for(auto& kd : available_devices) {
+        boost::property_tree::ptree& _dev = kd.second;
+        std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+      }
+      std::cout << std::endl;
+      return;
     }
   } catch (const xrt_core::error& e) {
     XBU::print_exception_and_throw_cancel(e);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -93,13 +93,13 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 {
   XBU::verbose("SubCommand: reset");
   // -- Retrieve and parse the subcommand options -----------------------------
-  std::vector<std::string> devices = {"all"};
+  std::vector<std::string> devices;
   std::string resetType = "user";
   bool help = false;
 
   po::options_description commonOptions("Common Options");
   commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
+    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
     ("type,r", boost::program_options::value<decltype(resetType)>(&resetType)->notifier(supported), "The type of reset to perform. Types resets available:\n"
                                                                        "  user         - Hot reset (default)\n"
                                                                        /*"  aie          - Reset Aie array\n"*/
@@ -148,6 +148,19 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     return;
+  }
+
+  // enforce 1 device specification
+  if(deviceCollection.empty() || deviceCollection.size() > 1) {
+    std::cerr << "\nERROR: Please specify a single device using --device option\n\n";
+    std::cout << "List of available devices:" << std::endl;
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(true);
+    for(auto& kd : available_devices) {
+      boost::property_tree::ptree& _dev = kd.second;
+      std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+    }
+    std::cout << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   xrt_core::query::reset_type type = XBU::str_to_reset_obj(resetType);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1338,7 +1338,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   const std::string formatRunValues = XBU::create_suboption_list_string(testNameDescription);
 
   // -- Retrieve and parse the subcommand options -----------------------------
-  std::vector<std::string> device  = {"all"};
+  std::vector<std::string> device;
   std::vector<std::string> testsToRun = {"all"};
   std::string sFormat = "JSON";
   std::string sOutput = "";
@@ -1347,8 +1347,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   po::options_description commonOptions("Commmon Options");
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(device)>(&device)->multitoken(), "The device of interest. This is specified as follows:\n"
-                                                                           "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)\n"
-                                                                           "  all   - Examines all known devices (default)")
+                                                                           "  <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)")
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("run,r", boost::program_options::value<decltype(testsToRun)>(&testsToRun)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
@@ -1443,6 +1442,19 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     return;
+  }
+
+  // enforce 1 device specification
+  if(deviceCollection.empty() || deviceCollection.size() > 1) {
+    std::cerr << "\nERROR: Please specify a single device using --device option\n\n";
+    std::cout << "List of available devices:" << std::endl;
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(true);
+    for(auto& kd : available_devices) {
+      boost::property_tree::ptree& _dev = kd.second;
+      std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+    }
+    std::cout << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Collect all of the tests of interests


### PR DESCRIPTION
- Removed support for -d all from all commands which supported multiple devices
- Removed "all" from help menus
- Testing for xbmgmt/xbutil examine:

```
xbmgmt/xbutil examine                        ----> host report
xbmgmt/xbutil examine -r host                ----> host report
xbmgmt/xbutil examine -r host -d 17:00 18:00 ----> host report
xbmgmt/xbutil examine -d 17:00 18:00         ----> ERROR
xbutil examine -d 17:00                      ----> platform and CU report
xbmgmt examine -d 17:00                      ----> platform
```

Sample output:
```
$ xbmgmt examine -d 17:00 18:00

ERROR: Examining multiple devices is not supported. Please specify a single device using --device option

List of available devices:
  [0000:65:00.0] : xilinx_u200_xdma_201830_2
  [0000:18:00.0] : xilinx_u30_gen3x4_base_1
  [0000:17:00.0] : xilinx_u30_gen3x4_base_1
```

- CR-1098821