### PR TITLE
Fix kernel BUG when unload zocl

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -280,8 +280,6 @@ void subdev_destroy_cu(struct drm_zocl_dev *zdev)
 {
 	int i;
 
-	BUG_ON(zocl_xclbin_refcount(zdev));
-
 	for (i = 0; i < MAX_CU_NUM; ++i) {
 		if (!zdev->cu_pldev[i])
 			continue;


### PR DESCRIPTION
zocl_xclbin_refcount check requires to hold xclbin lock. It is not a right place to this check during load/unload zocl module.