### PR TITLE
xbmgmt2 : Addressed timeout and hang CRs

### DIFF
--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -56,8 +56,6 @@
 #include <iostream>
 #include <thread>
 // ------ S T A T I C   V A R I A B L E S -------------------------------------
-// bandwidth testcase takes up-to a min to run
-static const int max_test_duration = 60;
 
 // ------ F U N C T I O N S ---------------------------------------------------
 #ifdef NO_BOOST_PROCESS
@@ -95,6 +93,9 @@ unsigned int
 XBUtilities::runScript( const std::string & env, 
                         const std::string & script, 
                         const std::vector<std::string> & args,
+                        const std::string & running_description,
+                        const std::string & final_description,
+                        int max_running_duration,
                         std::ostringstream & os_stdout,
                         std::ostringstream & os_stderr,
                         bool /*erasePassFailMessage*/)
@@ -130,7 +131,7 @@ XBUtilities::runScript( const std::string & env,
   // Kick off progress reporter
   bool is_done = false;
   // Fix: create busy bar
-  auto run_test = std::make_shared<XBUtilities::ProgressBar>("Running Test", max_test_duration, XBUtilities::is_escape_codes_disabled(), std::cout); 
+  auto run_test = std::make_shared<XBUtilities::ProgressBar>(running_description, max_running_duration, XBUtilities::is_escape_codes_disabled(), std::cout); 
   std::thread t(testCaseProgressReporter, run_test, std::ref(is_done));
 
   // Close existing stderr and set it to be the write end of the pipe.
@@ -163,7 +164,7 @@ XBUtilities::runScript( const std::string & env,
 
   is_done = true;
   bool exitCode = (os_stdout.str().find("PASS") != std::string::npos) ? true : false;
-  run_test.get()->finish(exitCode, "");
+  run_test.get()->finish(exitCode, final_description);
   // Workaround: Clear the default progress bar output so as to print the Error: before printing [FAILED]
   // Remove this once busybar is implemented
   std::cout << EscapeCodes::cursor().prev_line() << EscapeCodes::cursor().clear_line();
@@ -196,6 +197,9 @@ unsigned int
 XBUtilities::runScript( const std::string & env,
                         const std::string & script, 
                         const std::vector<std::string> & args,
+                        const std::string & running_description,
+                        const std::string & final_description,
+                        int max_running_duration,
                         std::ostringstream & os_stdout,
                         std::ostringstream & os_stderr,
                         bool erasePassFailMessage)
@@ -221,7 +225,7 @@ XBUtilities::runScript( const std::string & env,
   _env.erase("XCL_EMULATION_MODE");
 
   // Please fix: Should be a busy bar and NOT a progress bar
-  ProgressBar run_test("Running Test", max_test_duration, XBUtilities::is_escape_codes_disabled(), std::cout); 
+  ProgressBar run_test(running_description, max_running_duration, XBUtilities::is_escape_codes_disabled(), std::cout); 
 
   // Execute the python script and capture the outputs
   boost::process::ipstream ip_stdout;
@@ -241,7 +245,7 @@ XBUtilities::runScript( const std::string & env,
     if (counter >= run_test.getMaxIterations()) {
         if (erasePassFailMessage && (XBUtilities::is_escape_codes_disabled() == 0)) 
           std::cout << EscapeCodes::cursor().prev_line() << EscapeCodes::cursor().clear_line();
-      throw std::runtime_error("Test timed out");
+      throw std::runtime_error("Time Out");
     }
   }
 
@@ -260,7 +264,7 @@ XBUtilities::runScript( const std::string & env,
 
   // Obtain the exit code from the running process
   int exitCode = runningProcess.exit_code();
-  run_test.finish(exitCode == 0 /*Success or failure*/, "Test duration:");
+  run_test.finish(exitCode == 0 /*Success or failure*/, final_description);
 
   // Erase the "Pass Fail" message
   if (erasePassFailMessage && (XBUtilities::is_escape_codes_disabled() == 0)) 

--- a/src/runtime_src/core/tools/common/Process.h
+++ b/src/runtime_src/core/tools/common/Process.h
@@ -25,6 +25,9 @@ namespace XBUtilities {
                const std::string & env, 
                const std::string & script, 
                const std::vector<std::string> & args,
+               const std::string & running_description,
+               const std::string & final_description,
+               int max_running_duration,
                std::ostringstream & os_stdout,
                std::ostringstream & os_stderr,
                bool erasePassFailMessage);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -92,7 +92,7 @@ update_shell(unsigned int index, const std::string& primary, const std::string& 
   if (flasher.upgradeFirmware("", pri.get(), sec.get()) != 0)
     throw xrt_core::error("Failed to update base");
   
-  std::cout << boost::format("%-8s : %s \n") % "INFO" % "Base is updated successfully.";
+  std::cout << boost::format("%-8s : %s \n") % "INFO" % "Base flash image has been programmed successfully.";
 }
 
 /*
@@ -128,7 +128,7 @@ update_shell(unsigned int index, const std::string& flashType,
   if (flasher.upgradeFirmware(flashType, pri.get(), sec.get()) != 0)
     throw xrt_core::error("Failed to update base");
   
-  std::cout << boost::format("%-8s : %s \n") % "INFO" % "Base is updated successfully.";
+  std::cout << boost::format("%-8s : %s \n") % "INFO" % "Base flash image has been programmed successfully.";
   std::cout << "****************************************************\n";
   std::cout << "Cold reboot machine to load the new image on device.\n";
   std::cout << "****************************************************\n";
@@ -165,7 +165,7 @@ update_SC(unsigned int  index, const std::string& file)
     const std::string scFlashPath = "/opt/xilinx/xrt/bin/unwrapped/_scflash.py";
     std::vector<std::string> args = { "-y", "-d", getBDF(index), "-p", file };
     
-    int exit_code = XBU::runScript("python", scFlashPath, args, os_stdout, os_stderr, false);
+    int exit_code = XBU::runScript("python", scFlashPath, args, "Programming SC ", "SC Programmed", 120, os_stdout, os_stderr, false);
 
     if (exit_code != 0) {
       std::string err_msg = "ERROR: " + os_stdout.str() + "\n" + os_stderr.str() + "\n";
@@ -174,8 +174,8 @@ update_SC(unsigned int  index, const std::string& file)
     return;
   }
 
-  std::unique_ptr<firmwareImage> bmc =
-    std::make_unique<firmwareImage>(file.c_str(), BMC_FIRMWARE);
+  std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file.c_str(), BMC_FIRMWARE);
+
   if (bmc->fail())
     throw xrt_core::error(boost::str(boost::format("Failed to read %s") % file));
 
@@ -346,25 +346,26 @@ updateShellAndSC(unsigned int  boardIdx, DSAInfo& candidate, bool& reboot)
   if (current.bmcVer.empty())
     same_bmc = true;
   else
-    same_bmc = (candidate.bmcVer == current.bmcVer);
+    same_bmc = (candidate.bmcVer == current.bmcVer) && !XBU::getForce();
   
   if (same_dsa && same_bmc) {
     std::cout << "update not needed" << std::endl;
     return 0;
   }
 
+  boost::format programFmt("[%s] : %s...\n");
   if (!same_bmc) {
-    std::cout << "Updating SC firmware on device[" << flasher.sGetDBDF() <<
-      "]" << std::endl;
+    std::cout << programFmt % flasher.sGetDBDF() % "Updating SC firmware flash image";
     try {
       update_SC(boardIdx, candidate.file);
     } catch (const xrt_core::error& e) {
-      std::cout << "NOTE: Skipping SC flash. " << e.what() << std:: endl;
+      std::cout << "NOTE: Skipping SC flash: " << e.what() << std::endl;
     }
+    std::cout << std::endl;
   }
 
   if (!same_dsa) {
-    std::cout << boost::format("[%s] : Updating base\n") % flasher.sGetDBDF();
+    std::cout << programFmt % flasher.sGetDBDF() % "Updating base flash image";
     update_shell(boardIdx, candidate.file, candidate.file);
     reboot = true;
   }
@@ -404,12 +405,22 @@ auto_flash(xrt_core::device_collection& deviceCollection)
     if (vendor == ARISTA_ID)
         same_shell = false;
 
+    if (XBU::getForce()) {
+      same_shell = false;
+      same_sc = false;
+    }
+
     if (!same_shell || !same_sc) {
       if(!dsa.hasFlashImage)
         throw xrt_core::error("Flash image is not available");
       boardsToUpdate.push_back(std::make_pair(device->get_device_id(), dsa));
     }
   }
+
+  // Temporary Symptom Fix
+  // Release all of the devices to allow for the SC flash image to be programmed 
+  // on a u30.
+  deviceCollection.clear();
 
   // Continue to flash whatever we have collected in boardsToUpdate.
   uint16_t success = 0;
@@ -696,6 +707,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     XBUtilities::sudo_or_throw("Root privileges are required to update the devices flash image");
     std::string empty = "";
     if(update.compare("all") == 0)
+      // Note: To get around a bug in the SC flashing code base,
+      //       auto_flash will clear the collection. This code need to be refactored and clean up.
       auto_flash(deviceCollection);
     else {
       if(update.compare("flash") == 0)

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -547,8 +547,6 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
                 if (type != MCS_FIRMWARE_PRIMARY)
                 {
                     this->setstate(failbit);
-                    std::cout << "FLASH dsabin supports only primary bitstream: "
-                        << file << std::endl;
                     return;
                 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -558,8 +558,8 @@ int XQSPIPS_Flasher::xclUpgradeFirmware(std::istream& binStream)
     total_size = static_cast<int>(binStream.tellg());
     binStream.seekg(0, binStream.beg);
 
-    std::cout << "INFO: ***BOOT.BIN has " << total_size << " bytes" << std::endl;
     if (total_size >= GOLDEN_BASE) {
+        std::cout << "INFO: **BOOT.BIN has " << total_size << " bytes" << std::endl;
         std::cout << "[ERROR]: BOOT.BIN can't go beyond 96MB!" << std::endl;
         exit(-EINVAL);
     }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -285,7 +285,8 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     std::vector<std::string> args = { test_dir.parent_path().string(), 
                                       "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
     try {
-      int exit_code = XBU::runScript("sh", xrtTestCasePath, args, os_stdout, os_stderr, true);
+      constexpr static int MAX_TEST_DURATION = 60;
+      int exit_code = XBU::runScript("sh", xrtTestCasePath, args, "Running Test", "Test Duration", MAX_TEST_DURATION, os_stdout, os_stderr, true);
       if (exit_code == EOPNOTSUPP) {
         _ptTest.put("status", "skipped");
       }
@@ -319,10 +320,11 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
                                       "-d", std::to_string(_dev.get()->get_device_id()) };
     int exit_code;    
     try {
+      constexpr static int MAX_TEST_DURATION = 60;
       if (py.find(".exe") != std::string::npos)
-        exit_code = XBU::runScript("", xrtTestCasePath, args, os_stdout, os_stderr, true);
+        exit_code = XBU::runScript("", xrtTestCasePath, args, "Running Test", "Test Duration:", MAX_TEST_DURATION, os_stdout, os_stderr, true);
       else
-        exit_code = XBU::runScript("python", xrtTestCasePath, args, os_stdout, os_stderr, true);
+        exit_code = XBU::runScript("python", xrtTestCasePath, args, "Running Test", "Test Duration:", MAX_TEST_DURATION, os_stdout, os_stderr, true);
 
       if (exit_code == EOPNOTSUPP) {
         _ptTest.put("status", "skipped");


### PR DESCRIPTION
Issues
------

The u30 SC flash programming is done via a python script which in turn calls another helper function. Depending on the load on the file server could cause delays in the overall programming time. In some cases, this programming time exceeds the default 60 second time for all operations. Note: Currently, it takes 59 seconds to program the flash device.

In addition, the python flashing script could hang on some systems do multiple open device handles.

Resolutions
------------

- The code was updated to support different timeouts depending on the operation. For the SC flash, it was increased to 120 seconds
- After the device information has been gathered, all of the device handles are release prior to programming the flash images.

CR(s)
-------

CR-1098821 - [Ubuntu 18.04.4] xbmgmt2 --base --shell xilinx_u30_gen3x4_base_1 --device all shows failure when SC firmware from 6.3.5 to 6.3.7
CR-1098830 - [Ubuntu 18.04.4] xbmgmt2 --base --shell xilinx_u30_gen3x4_base_1 --device all shows failure when SC firmware from 6.3.5 to 6.3.7
(cherry picked from commit f3f7eec9dab1445c28d376024c898e986829bb72)