### PR TITLE
CR-1091355 icap mgmt cache uuid too early

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2552,7 +2552,7 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 		goto done;
 	}
 
-    if (!xocl_verify_timestamp(xdev,
+	if (!xocl_verify_timestamp(xdev,
 		xclbin->m_header.m_featureRomTimeStamp)) {
 		ICAP_ERR(icap, "TimeStamp of ROM did not match Xclbin");
 		err = -EOPNOTSUPP;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -195,13 +195,17 @@ int xocl_xclbin_download(xdev_handle_t xdev, const void *xclbin)
 	if (XOCL_DSA_IS_VERSAL(xdev))
 		return xocl_xclbin_download_impl(xdev, xclbin, &versal_ops);
 	else {
-		int rval;
-		/* TODO: return xocl_xclbin_download_impl(xdev, xclbin, &icap_ops); */
+		/*
+		 * TODO:
+		 * return xocl_xclbin_download_impl(xdev, xclbin, &icap_ops);
+		 */
+		int rval = 0;
 		rval = xocl_icap_download_axlf(xdev, xclbin);
-		if (!rval && XOCL_DSA_IS_MPSOC(xdev)) {
-			return xocl_xclbin_download_impl(xdev, xclbin,
-			    &mpsoc_ops);
-		}
+		if (!rval && XOCL_DSA_IS_MPSOC(xdev))
+			rval = xocl_xclbin_download_impl(xdev, xclbin, &mpsoc_ops);
+
+		if (rval)
+			xocl_icap_clean_bitstream(xdev);
 
 		return rval;
 	}


### PR DESCRIPTION
See CR for more info, the case is that even the mpsoc download failed with rval=1, the icap mgmt still cached the uuid.
The next xocl icap download will check via PEER_UUID and pull the cached uuid to userland, then xocl driver will think the xclbin is already downloaded. Thus, we are running on a system without successfully downloaded full xclbin.

