### PR TITLE
Reinitialize trace datamover when circular buffer is used

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -319,8 +319,8 @@ bool DeviceTraceOffload::init_s2mm(bool circ_buf)
   }
 
   // Data Mover will write input stream to this address
-  uint64_t bufAddr = dev_intf->getDeviceAddr(m_trbuf);
-  dev_intf->initTS2MM(m_trbuf_alloc_sz, bufAddr, m_use_circ_buf);
+  m_trbuf_addr = dev_intf->getDeviceAddr(m_trbuf);
+  dev_intf->initTS2MM(m_trbuf_alloc_sz, m_trbuf_addr, m_use_circ_buf);
   return true;
 }
 
@@ -332,7 +332,7 @@ void DeviceTraceOffload::reset_s2mm()
 
   // Need to re-inititlize datamover with circular buffer off for reset to work properly
   if (m_use_circ_buf)
-    dev_intf->initTS2MM(0, 0, 0);
+    dev_intf->initTS2MM(0, m_trbuf_addr, 0);
 
   dev_intf->resetTS2MM();
   dev_intf->freeTraceBuf(m_trbuf);

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -329,6 +329,11 @@ void DeviceTraceOffload::reset_s2mm()
   debug_stream << "DeviceTraceOffload::reset_s2mm" << std::endl;
   if (!m_trbuf)
     return;
+
+  // Need to re-inititlize datamover with circular buffer off for reset to work properly
+  if (m_use_circ_buf)
+    dev_intf->initTS2MM(0, 0, 0);
+
   dev_intf->resetTS2MM();
   dev_intf->freeTraceBuf(m_trbuf);
   m_trbuf = 0;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -140,6 +140,7 @@ private:
 
     bool m_trbuf_full = false;
     bool trbuf_offload_done = false;
+    uint64_t m_trbuf_addr = 0;
 
     // Clock Training Params
     bool m_force_clk_train = true;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -43,20 +43,14 @@
 #define TS2MM_MAX_BUF_SIZE      0xffffefff
 // 1 MB
 #define TS2MM_DEF_BUF_SIZE      0x100000
-//8KB
+// 8KB
 #define TS2MM_MIN_BUF_SIZE      0x2000
-
 // Read data only if it's more than 512B unless forced
 #define TS2MM_MIN_READ_SIZE      0x200
+#define DEFAULT_TRACE_OFFLOAD_INTERVAL_MS 10
 
 #define FIFO_WARN_MSG "Trace FIFO is full because of too many events. Timeline trace could be incomplete. \
 Please use 'coarse' option for data transfer trace or turn off Stall profiling"
-
-#define CONTINUOUS_OFFLOAD_WARN_MSG_STALLS "Enabling stalls with 'continuous_trace' and trace FIFO isn't advisable. Timeline trace could be incorrect. \
-Recommended settings are : 'coarse' option for data transfer trace and no stall profiling"
-
-#define CONTINUOUS_OFFLOAD_WARN_MSG_DEVICE "Continuous offload is currently only supported on one device. Disabling this option."
-#define CONTINUOUS_OFFLOAD_WARN_MSG_FLOW   "Continuous offload is currently only supported on system flow. Disabling this option."
 #define CONTINUOUS_OFFLOAD_WARN_MSG_FIFO   "Continuous offload is currently not supported in FIFO trace offload. Disabling this option."
 
 #define TS2MM_WARN_MSG_BUFSIZE_BIG    "Trace Buffer size is too big. The maximum size of 4095M will be used."
@@ -64,17 +58,14 @@ Recommended settings are : 'coarse' option for data transfer trace and no stall 
 #define TS2MM_WARN_MSG_BUFSIZE_DEF    "Trace Buffer size could not be parsed. The default size of 1M will be used."
 #define TS2MM_WARN_MSG_ALLOC_FAIL     "Trace Buffer could not be allocated on device. Device trace will be missing."
 #define TS2MM_WARN_MSG_BUF_FULL       "Trace Buffer is full. Device trace could be incomplete."
-
-// aie trace
-#define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
-
-#define TS2MM_WARN_MSG_CIRC_BUF       "Unable to use circular buffer for continuous trace offload. Please increase trace \
+#define TS2MM_WARN_MSG_CIRC_BUF       "Device trace will be limited to trace buffer size becasue of less trace offload rate. Please increase trace \
 buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."
 
+#define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
+
+// Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1
 #define TRACE_DUMP_INTERVAL_WARN_MSG "Setting trace file dump interval to minimum supported value of 1 second."
-
-#define DEFAULT_TRACE_OFFLOAD_INTERVAL_MS 10
 
 #endif

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -57,8 +57,9 @@ Please use 'coarse' option for data transfer trace or turn off Stall profiling"
 #define TS2MM_WARN_MSG_BUFSIZE_SMALL  "Trace Buffer size is too small. The minimum size of 8K will be used."
 #define TS2MM_WARN_MSG_BUFSIZE_DEF    "Trace Buffer size could not be parsed. The default size of 1M will be used."
 #define TS2MM_WARN_MSG_ALLOC_FAIL     "Trace Buffer could not be allocated on device. Device trace will be missing."
-#define TS2MM_WARN_MSG_BUF_FULL       "Trace Buffer is full. Device trace could be incomplete."
-#define TS2MM_WARN_MSG_CIRC_BUF       "Device trace will be limited to trace buffer size becasue of less trace offload rate. Please increase trace \
+#define TS2MM_WARN_MSG_BUF_FULL       "Trace Buffer is full. Device trace could be incomplete. \
+Please increase trace_buffer_size or use 'coarse' option for data_transfer_trace or turn on continuous_trace."
+#define TS2MM_WARN_MSG_CIRC_BUF       "Device trace will be limited to trace buffer size due to insufficient trace offload rate. Please increase trace \
 buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."
 


### PR DESCRIPTION
CR-1098948- Datamover reset isn't working properly