### PR TITLE
Ignore unused xclOpen arguments (edge)

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -100,16 +100,12 @@ namespace ZYNQ {
 std::map<uint64_t, uint32_t *> shim::mKernelControl;
 
 shim::
-shim(unsigned index, const char *logfileName, xclVerbosityLevel verbosity)
+shim(unsigned index)
   : mCoreDevice(xrt_core::edge_linux::get_userpf_device(this, index))
   , mBoardNumber(index)
-  , mVerbosity(verbosity)
   , mKernelClockFreq(100)
   , mCuMaps(128, nullptr)
 {
-  if (logfileName != nullptr)
-    xclLog(XRT_WARNING, "%s: logfileName is no longer supported", __func__);
-
   xclLog(XRT_INFO, "%s", __func__);
 
   mKernelFD = open("/dev/dri/renderD128", O_RDWR);
@@ -1619,7 +1615,7 @@ xclProbe()
 #endif
 
 xclDeviceHandle
-xclOpen(unsigned deviceIndex, const char *logFileName, xclVerbosityLevel level)
+xclOpen(unsigned deviceIndex, const char*, xclVerbosityLevel)
 {
   try {
     //std::cout << "xclOpen called" << std::endl;
@@ -1633,7 +1629,7 @@ xclOpen(unsigned deviceIndex, const char *logFileName, xclVerbosityLevel level)
     OPEN_CB;
 #endif
 
-    auto handle = new ZYNQ::shim(deviceIndex, logFileName, level);
+    auto handle = new ZYNQ::shim(deviceIndex);
     if (!ZYNQ::shim::handleCheck(handle)) {
       delete handle;
       handle = XRT_NULL_HANDLE;

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -47,8 +47,7 @@ class shim {
   static const int BUFFER_ALIGNMENT = 0x80; // TODO: UKP
 public:
   ~shim();
-  shim(unsigned index, const char *logfileName,
-           xclVerbosityLevel verbosity);
+  shim(unsigned index);
 
   int mapKernelControl(const std::vector<std::pair<uint64_t, size_t>>& offsets);
   void *getVirtAddressOfApture(xclAddressSpace space, const uint64_t phy_addr, uint64_t& offset);
@@ -155,7 +154,6 @@ private:
   const int mBoardNumber = -1;
   std::ofstream mLogStream;
   std::ifstream mVBNV;
-  xclVerbosityLevel mVerbosity;
   int mKernelFD;
   static std::map<uint64_t, uint32_t *> mKernelControl;
   std::unique_ptr<xrt_core::bo_cache> mCmdBOCache;

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -277,15 +277,14 @@ xclProbe();
  * xclOpen() - Open a device and obtain its handle.
  *
  * @deviceIndex:   Slot number of device 0 for first device, 1 for the second device...
- * @logFileName:   Log file to use for optional logging
- * @level:         Severity level of messages to log
+ * @logFileName:   Unused, logging is controlled via xrt.ini
+ * @level:         Unused, verbosity is controlled via xrt.ini
  *
  * Return:         Device handle
  */
 XCL_DRIVER_DLLESPEC
 xclDeviceHandle
-xclOpen(unsigned int deviceIndex, const char *logFileName,
-        enum xclVerbosityLevel level);
+xclOpen(unsigned int deviceIndex, const char* unused1, enum xclVerbosityLevel unused2);
 
 /**
  * xclClose() - Close an opened device


### PR DESCRIPTION
Make edge shim behave as pcie shim and eliminate warning about unused
log file, which has been deprecated for years.  Silently ignore log
file and verbosity parameters passed to xclOpen.

Update comments in xrt.h to note that logfile and verbosity args are
unused.