### PR TITLE
CR-1099706: Device trace information was offloaded and processed when only device counters was specified

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.h
@@ -46,6 +46,10 @@ namespace xdp {
 
     XDP_EXPORT virtual void readTrace() ;
 
+    // Which capabilities are turned on
+    bool counterOffloadEnabled ;
+    bool traceOffloadEnabled ;
+
   public:
     XDP_EXPORT OpenCLDeviceOffloadPlugin() ;
     XDP_EXPORT ~OpenCLDeviceOffloadPlugin() ;


### PR DESCRIPTION
For OpenCL applications, profiling supports either reading device counters and adding them to the summary file, or reading both trace information and counter information.  If counter only offload was specified, trace was still offloaded and processed even though no trace file was generated.  This caused incorrect warnings to be generated and one table in the summary file to act incorrectly.

This pull request checks for the capabilities at the plugin loading time and only reads trace if trace is enabled via xrt.ini flags.
