### PR TITLE
CR-1097291 [Regression] ERROR: failed to launch execution buffer

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -146,7 +146,7 @@ class ip_impl
 
       ip = ips.front();
 
-      auto all_cus = xrt_core::xclbin::get_cus(ip_layout);  // sort order
+      auto all_cus = device->get_cus(xclbin_uuid);  // sort order
       auto itr = std::find(all_cus.begin(), all_cus.end(), ip->m_base_address);
       if (itr == all_cus.end())
         throw xrt_core::internal_error("unexpected error");

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -303,7 +303,7 @@ struct device_type
   device_type(device_type&&) = delete;
   device_type& operator=(device_type&) = delete;
   device_type& operator=(device_type&&) = delete;
-  
+
   template <typename CommandType>
   xrt_core::bo_cache::cmd_bo<CommandType>
   create_exec_buf()
@@ -650,7 +650,7 @@ public:
     for (size_t cu_idx = 0; cu_idx < max_cus; ++cu_idx) {
       if (!cumask.test(cu_idx))
         continue;
-      auto mask_idx = cu_idx / cus_per_word;              
+      auto mask_idx = cu_idx / cus_per_word;
       auto idx_in_mask = cu_idx - mask_idx * cus_per_word;
       ecmd->data[mask_idx] |= (1 << idx_in_mask);
     }
@@ -1330,7 +1330,7 @@ public:
     if (kernel_cus.empty())
       throw std::runtime_error("No compute units matching '" + nm + "'");
 
-    auto all_cus = xrt_core::xclbin::get_cus(ip_layout);  // sort order
+    auto all_cus = device->core_device->get_cus(xclbin_id);  // sort order
     for (const ip_data* cu : kernel_cus) {
       if (::get_ip_control(cu) == AP_CTRL_NONE)
         continue;

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -271,6 +271,10 @@ public:
   memory_type
   get_memory_type(size_t memidx) const;
 
+  // get_cus() - Get list cu base addresses sorted by cu inidex
+  const std::vector<uint64_t>
+  get_cus(const uuid& xclbin_id) const;
+
   /**
    * get_ert_slots() - Get number of ERT CQ slots
    *
@@ -298,7 +302,7 @@ public:
   virtual void write(uint64_t, const void*, uint64_t) const {}
 
   virtual void reset(query::reset_type&) const {}
- 
+
   /**
    * xclmgmt_load_xclbin() - loads the xclbin through the mgmt pf
    */
@@ -335,6 +339,7 @@ public:
   mutable boost::optional<bool> m_nodma = boost::none;
 
   std::vector<size_t> m_memidx_encoding; // compressed mem_toplogy indices
+  std::vector<uint64_t> m_cus;           // cu base addresses in expeced sort order
   xrt::xclbin m_xclbin;                  // currently loaded xclbin
 };
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -926,20 +926,19 @@ int
 shim::
 xclIPName2Index(const char *name)
 {
-  /* In new kds, driver determines CU index */
-  if (xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice)) {
-    for (auto& stat : xrt_core::device_query<xrt_core::query::kds_cu_stat>(mCoreDevice)) {
-      if (stat.name != name)
-        continue;
-
-      return stat.index;
-    }
+  // In new kds, driver determines CU index
+  try {
+    for (auto& stat : xrt_core::device_query<xrt_core::query::kds_cu_stat>(mCoreDevice))
+      if (stat.name == name)
+        return stat.index;
 
     xclLog(XRT_ERROR, "%s not found", name);
     return -ENOENT;
   }
+  catch (const xrt_core::query::no_such_key&) {
+  }
 
-  /* Old kds is enabled */
+  // Old kds is enabled
   std::string errmsg;
   std::vector<char> buf;
   const uint64_t bad_addr = 0xffffffffffffffff;
@@ -2373,8 +2372,18 @@ xclRegRead(xclDeviceHandle handle, uint32_t ipIndex, uint32_t offset,
 int
 xclIPName2Index(xclDeviceHandle handle, const char *name)
 {
-  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
-  return (drv) ? drv->xclIPName2Index(name) : -ENODEV;
+  try {
+    ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+    return (drv) ? drv->xclIPName2Index(name) : -ENODEV;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -ENOENT;
+  }
 }
 
 int

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -18,6 +18,7 @@
 #define PCIE_NOOP_DEVICE_LINUX_H
 
 #include "core/common/ishim.h"
+#include "core/common/query_requests.h"
 #include "core/pcie/common/device_pcie.h"
 
 namespace xrt_core { namespace noop {
@@ -34,7 +35,7 @@ private:
   virtual const query::request&
   lookup_query(query::key_type query_key) const
   {
-    throw std::runtime_error("query lookup not implemented");
+    throw query::no_such_key(query_key);
   }
 };
 


### PR DESCRIPTION
Record CU indices when loading the xclbin. Use the CU indices from
driver if available, otherwise use xrt_core::xclbin::get_cus(ip_layout).