### PR TITLE
update trace warning messages and do one final trace read for circular buffer

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -465,7 +465,10 @@ namespace xdp {
         continue; // nothing to do? what about unmatched start?
       }
       const char* msg = "Incomplete CU profile trace detected. Timeline trace will have approximate CU End.";
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg) ;
+      if (!warnCUIncomplete) {
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg) ;
+        warnCUIncomplete = true;
+      }
 
       // end event
       double hostTimestamp = convertDeviceToHostTimestamp(cuLastTimestamp);

--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.h
@@ -55,6 +55,8 @@ class DeviceEventCreatorFromTrace
   double traceClockRateMHz;
   double clockTrainSlope;
 
+  bool warnCUIncomplete=false;
+
   void trainDeviceHostTimestamps(uint64_t deviceTimestamp, uint64_t hostTimestamp);
   double convertDeviceToHostTimestamp(uint64_t deviceTimestamp);
 

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -230,7 +230,7 @@ void DeviceTraceOffload::read_trace_s2mm(bool force)
   debug_stream
     << "Elapsed time in microseconds for sync : "
     << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count()
-    << " µs" << std::endl;
+    << " µs" << " nBytes : " << nBytes << std::endl;
 
   if (!host_buf)
     return;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -52,8 +52,10 @@ DeviceTraceOffload::~DeviceTraceOffload()
 
 void DeviceTraceOffload::offload_device_continuous()
 {
-  if (!m_initialized && !read_trace_init(true))
+  if (!m_initialized && !read_trace_init(true)) {
+    offload_finished();
     return;
+  }
 
   while (should_continue()) {
     train_clock();

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -183,6 +183,15 @@ bool DeviceTraceOffload::read_trace_init(bool circ_buf)
 
 void DeviceTraceOffload::read_trace_end()
 {
+  // If we use circular buffer then, final trace read
+  // might stop at trace buffer boundry and to read the entire
+  // trace, we need one last read
+  if (m_use_circ_buf && m_trbuf_sz == m_trbuf_alloc_sz) {
+    debug_stream
+      << "Try to read left over circular buffer data" << std::endl;
+    m_read_trace(true);
+  }
+
   // Trace logger will clear it's state and add approximations 
   // for pending events
   m_trace_vector.clear();
@@ -225,6 +234,12 @@ void DeviceTraceOffload::read_trace_s2mm(bool force)
 
   if (!host_buf)
     return;
+
+  // Print warning if processing large amount of trace
+  if (nBytes > TS2MM_WARN_BIG_BUF_SIZE && !m_trace_warn_big_done) {
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BIG_BUF);
+    m_trace_warn_big_done = true;
+  }
 
   dev_intf->parseTraceData(host_buf, nBytes, m_trace_vector);
   deviceTraceLogger->processTraceData(m_trace_vector);
@@ -279,8 +294,9 @@ bool DeviceTraceOffload::config_s2mm_reader(uint64_t wordCount)
     << "DeviceTraceOffload::config_s2mm_reader "
     << "Reading from 0x"
     << std::hex << m_trbuf_offset << " to 0x" << m_trbuf_sz << std::dec
-    << " Written : " << wordCount * 8
-    << " rollover count : " << m_rollover_count
+    << " Bytes Read : " << bytes_read
+    << " Bytes Written : " << bytes_written
+    << " Rollovers : " << m_rollover_count
     << std::endl;
 
   return true;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -113,12 +113,14 @@ protected:
     DeviceIntf* dev_intf;
 private:
     DeviceTraceLogger* deviceTraceLogger;
-
     std::vector<xclTraceResults> m_trace_vector = {};
     std::function<void(bool)> m_read_trace;
     size_t m_trbuf = 0;
     uint64_t m_trbuf_sz = 0;
     uint64_t m_trbuf_offset = 0;
+    bool m_trbuf_full = false;
+    bool trbuf_offload_done = false;
+    uint64_t m_trbuf_addr = 0;
 
 protected:
     bool m_initialized = false;
@@ -138,14 +140,9 @@ private:
     void offload_device_continuous();
     void offload_finished();
 
-    bool m_trbuf_full = false;
-    bool trbuf_offload_done = false;
-    uint64_t m_trbuf_addr = 0;
-
     // Clock Training Params
     bool m_force_clk_train = true;
     std::chrono::time_point<std::chrono::system_clock> m_prev_clk_train_time;
-
 
     //Circular Buffer Tracking
     bool m_use_circ_buf = false;
@@ -156,6 +153,7 @@ private:
 
     // Used to check read precondition in ts2mm
     uint64_t m_wordcount_old = 0;
+    bool m_trace_warn_big_done = false;
 };
 
 }

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -45,6 +45,8 @@
 #define TS2MM_DEF_BUF_SIZE      0x100000
 // 8KB
 #define TS2MM_MIN_BUF_SIZE      0x2000
+// Throw warning when we process > 50MB trace
+#define TS2MM_WARN_BIG_BUF_SIZE 0x3200000
 // Read data only if it's more than 512B unless forced
 #define TS2MM_MIN_READ_SIZE      0x200
 #define DEFAULT_TRACE_OFFLOAD_INTERVAL_MS 10
@@ -62,11 +64,15 @@ Please increase trace_buffer_size or use 'coarse' option for data_transfer_trace
 #define TS2MM_WARN_MSG_CIRC_BUF       "Device trace will be limited to trace buffer size due to insufficient trace offload rate. Please increase trace \
 buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."
+#define TS2MM_WARN_MSG_BIG_BUF         "Processing large amount of device trace. It could take a while before application ends."
 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
 
 // Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1
 #define TRACE_DUMP_INTERVAL_WARN_MSG "Setting trace file dump interval to minimum supported value of 1 second."
+#define TRACE_DUMP_FILE_COUNT_WARN 10
+#define TRACE_DUMP_FILE_COUNT_WARN_MSG "Contunous Trace might create a large number of trace files. Please use trace_file_dump_interval \
+to control how often trace data is written."
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -338,6 +338,8 @@ namespace xdp {
       if (offloader->continuous_offload())
       {
         offloader->stop_offload() ;
+        // To avoid a race condition, wait until the offloader has stopped
+        while(offloader->get_status() != OffloadThreadStatus::STOPPED) ;
       }
       else
       {

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -143,11 +143,13 @@ namespace xdp {
       auto offloader = std::get<0>(offloaders[deviceId]) ;
       if (offloader->continuous_offload())
       {
-	offloader->stop_offload() ;
+        offloader->stop_offload() ;
+        // To avoid a race condition, wait until the offloader has stopped
+        while(offloader->get_status() != OffloadThreadStatus::STOPPED) ;
       }
       else
       {
-	offloader->read_trace() ;
+        offloader->read_trace() ;
       }
     }
     readCounters() ;
@@ -177,13 +179,13 @@ namespace xdp {
 
     if (!(db->getStaticInfo()).validXclbin(userHandle)) {
       std::string msg =
-	"Device profiling is only supported on xclbins built using " ;
+        "Device profiling is only supported on xclbins built using " ;
       msg += std::to_string((db->getStaticInfo()).earliestSupportedToolVersion()) ;
       msg += " tools or later.  To enable device profiling please rebuild." ;
 
       xrt_core::message::send(xrt_core::message::severity_level::warning,
-			      "XRT",
-			      msg) ;
+                              "XRT",
+                              msg) ;
       return ;
     }
     
@@ -194,7 +196,7 @@ namespace xdp {
       struct xclDeviceInfo2 info ;
       if (xclGetDeviceInfo2(userHandle, &info) == 0)
       {
-	(db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
+        (db->getStaticInfo()).setDeviceName(deviceId, std::string(info.mName));
       }
     }
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -177,6 +177,8 @@ namespace xdp {
       if (offloader->continuous_offload())
       {
         offloader->stop_offload() ;
+        // To avoid a race condition, wait until the offloader has stopped
+        while(offloader->get_status() != OffloadThreadStatus::STOPPED) ;
       }
       else
       {

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -18,6 +18,8 @@
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/writer/vp_base/vp_writer.h"
+#include "xdp/profile/device/tracedefs.h"
+#include "core/common/message.h"
 
 namespace xdp {
 
@@ -33,6 +35,7 @@ namespace xdp {
 
   // After write is called, if we are doing continuous offload
   //  we need to open a new file
+  bool VPWriter::warnFileNum = false;
   void VPWriter::switchFiles()
   {
     fout.close() ;
@@ -40,6 +43,11 @@ namespace xdp {
 
     ++fileNum ;
     currentFileName = std::to_string(fileNum) + std::string("-") + basename ;
+
+    if (fileNum == TRACE_DUMP_FILE_COUNT_WARN && !warnFileNum) {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TRACE_DUMP_FILE_COUNT_WARN_MSG);
+      warnFileNum = true;
+    }
 
     fout.open(currentFileName.c_str()) ;
   }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -41,6 +41,7 @@ namespace xdp {
 
     // The number of files created by this writer (in continuous offload)
     uint32_t fileNum ;
+    static bool warnFileNum;
 
   protected:
     // Connection to the database where all the information is stored


### PR DESCRIPTION
CR-1099502 - Add warning for large number of files
CR-1099485 - Add warning when we process > 50mb of trace
CR-1098345- Do one extra trace read to completely flush trace buffer
Other changes -
Print some warnings only once
Fix race condition when continuous trace is stopped
Fix spaces