### PR TITLE
CR-1068838: Updated error message in sw emu

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -788,7 +788,7 @@ namespace xclcpuemhal2 {
     if (result == xclemulation::MemoryManager::mNull) {
       auto ddrSize = mDDRMemoryManager[flags]->size();
       std::string ddrSizeStr = std::to_string(ddrSize);
-      std::string initMsg = "ERROR: [SW-EM 12] OutOfMemoryError : Requested Global memory size exceeds DDR limit " + ddrSizeStr + " Bytes";
+      std::string initMsg = "ERROR: [SW-EM 12] OutOfMemoryError : Requested Global memory size exceeds DDR limit 16 GB.";
       std::cout << initMsg << std::endl;
       return result;
     }


### PR DESCRIPTION
Issue : Sw EMU should throw proper error message when users trying to allocate more than 16gb.

Fix: Implemented proper message saying 16GB is the max limit for sw emu

Test : Ran couple of test cases manually, all are passing.

Impact : Low