### PR TITLE
CR-1094616 Disabled the m2m driver logic for timebeing as it is funct…

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2759,8 +2759,10 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
     PRINTENDFUNC;
     return -1;
   }
-
-  if ( deviceQuery(key_type::m2m) && getM2MAddress() != 0 ) {
+   
+  // Disabling the m2m for timebeing as it is not working as expected. So still data is getting transferred thru DMA.
+  // Will enable this logic unless we have a clarity from the m2m hw_emu kernel. Please do not remove this code 
+  /*if ( deviceQuery(key_type::m2m) && getM2MAddress() != 0 ) {
 
     char hostBuf[M2M_KERNEL_ARGS_SIZE];
     std::memset(hostBuf, 0, M2M_KERNEL_ARGS_SIZE);
@@ -2793,7 +2795,7 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
 
     PRINTENDFUNC;
     return 0;
-  }
+  }*/
 
   // source buffer is host_only and destination buffer is device_only
   if (xclemulation::xocl_bo_host_only(sBO) && !xclemulation::xocl_bo_p2p(sBO) && xclemulation::xocl_bo_dev_only(dBO)) {


### PR DESCRIPTION
CR-1094616 Disabled the m2m driver logic for timebeing as it is functioning as expected with the latest nodma platforms. we will re-enable them shorly