### PR TITLE
support start cu command timestamp in new kds

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -30,12 +30,23 @@ enum kds_opcode {
 	OP_GET_STAT,
 };
 
+/* KDS_NEW:		Command is validated
+ * KDS_QUEUED:		Command is sent to pending queue
+ * KDS_RUNNING:		Command is sent to hardware (CU/ERT)
+ * KDS_COMPLETED:	Command is completed
+ * KDS_ERROR:		Command is error out
+ * KDS_ABORT:		Command is abort
+ * KDS_TIMEOUT:		Command is timeout
+ */
 enum kds_status {
 	KDS_NEW = 0,
+	KDS_QUEUED,
+	KDS_RUNNING,
 	KDS_COMPLETED,
 	KDS_ERROR,
 	KDS_ABORT,
 	KDS_TIMEOUT,
+	KDS_STAT_MAX,
 };
 
 struct kds_command;
@@ -78,6 +89,8 @@ struct kds_command {
 	void			*priv;
 
 	unsigned int		 tick;
+	u32			 timestamp_enabled;
+	u64			 timestamp[KDS_STAT_MAX];
 
 	struct kds_cmd_ops	 cb;
 	/* execbuf is used to update the header
@@ -89,6 +102,8 @@ struct kds_command {
 	/* to notify inkernel exec completion */
 	struct in_kernel_cb	*inkern_cb;
 };
+
+void set_xcmd_timestamp(struct kds_command *xcmd, enum kds_status s);
 
 /* execbuf command related funtions */
 void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -76,6 +76,7 @@ static inline void process_cq(struct xrt_cu *xcu)
 	 */
 	while (xcu->num_cq) {
 		xcmd = list_first_entry(&xcu->cq, struct kds_command, list);
+		set_xcmd_timestamp(xcmd, xcmd->status);
 		xcmd->cb.notify_host(xcmd, xcmd->status);
 		list_del(&xcmd->list);
 		xcmd->cb.free(xcmd);
@@ -212,6 +213,7 @@ static inline int process_rq(struct xrt_cu *xcu)
 	/* if successfully get credit, you must start cu */
 	xrt_cu_config(xcu, (u32 *)xcmd->info, xcmd->isize, xcmd->payload_type);
 	xrt_cu_start(xcu);
+	set_xcmd_timestamp(xcmd, KDS_RUNNING);
 
 	dst_q = &xcu->sq;
 	dst_len = &xcu->num_sq;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -268,6 +268,19 @@ static void notify_execbuf(struct kds_command *xcmd, int status)
 	else if (status == KDS_ABORT)
 		ecmd->state = ERT_CMD_STATE_ABORT;
 
+	if (xcmd->timestamp_enabled) {
+		/* Only start kernel command supports timestamps */
+		struct ert_start_kernel_cmd *scmd;
+		struct cu_cmd_state_timestamps *ts;
+
+		scmd = (struct ert_start_kernel_cmd *)ecmd;
+		ts = ert_start_kernel_timestamps(scmd);
+		ts->skc_timestamps[ERT_CMD_STATE_NEW] = xcmd->timestamp[KDS_NEW];
+		ts->skc_timestamps[ERT_CMD_STATE_QUEUED] = xcmd->timestamp[KDS_QUEUED];
+		ts->skc_timestamps[ERT_CMD_STATE_RUNNING] = xcmd->timestamp[KDS_RUNNING];
+		ts->skc_timestamps[ecmd->state] = xcmd->timestamp[status];
+	}
+
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(xcmd->gem_obj);
 
 	if (xcmd->cu_idx >= 0)

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -815,6 +815,28 @@ ert_start_kernel_timestamps(struct ert_start_kernel_cmd *pkt)
   return (struct cu_cmd_state_timestamps *)
     ((char *)pkt + P2ROUNDUP(offset, sizeof(uint64_t)));
 }
+
+/* Return 0 if this pkt doesn't support timestamp or disabled */
+static inline int
+get_size_with_timestamps_or_zero(struct ert_packet *pkt)
+{
+  struct ert_start_kernel_cmd *skcmd;
+  int size = 0;
+
+  switch (pkt->opcode) {
+  case ERT_START_CU:
+  case ERT_EXEC_WRITE:
+  case ERT_START_FA:
+  case ERT_SK_START:
+    skcmd = to_start_krnl_pkg(pkt);
+    if (skcmd->stat_enabled) {
+      size = (char *)ert_start_kernel_timestamps(skcmd) - (char *)pkt;
+      size += sizeof(struct cu_cmd_state_timestamps);
+    }
+  }
+
+  return size;
+}
 #endif
 
 #ifdef _WIN32

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -715,6 +715,7 @@ static inline void process_ert_cq(struct xocl_ert_user *ert_user)
 		xcmd = ecmd->xcmd;
 		ert_post_process(ert_user, ecmd);
 		ert_release_slot(ert_user, ecmd);
+		set_xcmd_timestamp(xcmd, ecmd->status);
 		xcmd->cb.notify_host(xcmd, ecmd->status);
 		xcmd->cb.free(xcmd);
 		ert_user_free_cmd(ecmd);
@@ -1231,6 +1232,7 @@ static inline int process_ert_rq(struct xocl_ert_user *ert_user, struct ert_user
 
 			iowrite32(epkt->header, ert_user->cq_base + slot_addr);
 		}
+		set_xcmd_timestamp(xcmd, KDS_RUNNING);
 
 		/*
 		 * Always try to trigger interrupt to embedded scheduler.


### PR DESCRIPTION
If record timestamp flag is set, 4 timestamps would be record:
1. New - when user's command is copied and validated
2. Queue - when command is submitted to the pending queue of CU/ert_user sub-device
3. Running - when command is submitted to hardware (CU or ERT CQ)
4. Completed - when command is finished (the statue could be completed/timeout/abort ...)

When notify host, if user's command enabled timestamp, fill above timestamps to user's command.

Test on PCIe/edge, if timestamp is disabled, no performance degrade.