### PR TITLE
CR-1065439: Removing kernel execution tables on edge hardware emulation

### DIFF
--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -433,6 +433,11 @@ namespace xdp {
 
   void OpenCLSummaryWriter::writeKernelExecutionSummary()
   {
+    // On Edge hardware emulation, the numbers in the kernel execution summary
+    //  don't align with the other numbers we display, so don't print this
+    //  table.
+    if (getFlowMode() == HW_EMU && isEdge()) return ;
+
     // Caption
     fout << "Kernel Execution" ;
     if (getFlowMode() == HW_EMU)
@@ -1460,6 +1465,11 @@ namespace xdp {
 
   void OpenCLSummaryWriter::writeTopKernelExecution()
   {
+    // On Edge hardware emulation, the numbers for the top kernel executions
+    //  don't align with the other numbers we display, so don't print this
+    //  table.
+    if (getFlowMode() == HW_EMU && isEdge()) return ;
+
     // Caption
     fout << "Top Kernel Execution" << std::endl ;
 


### PR DESCRIPTION
On hardware emulation on edge platforms, the calculation of the values in the kernel execution table (and top kernel execution) are inconsistent with other values we present due to the nature of the simulation launch and QEMU execution model.

This pull request disables the printing of these tables on Edge hardware emulation so no incorrect or inconsistent information is displayed on the summary file.
