### PR TITLE
Xbutil2 edge fix for compute-unit and platform 

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -682,6 +682,9 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
     msg = "P2P config failed. P2P is not available";
     return static_cast<int>(p2p_config::not_supported);
   }
+  catch (const xrt_core::query::no_such_key&) {
+    return static_cast<int>(p2p_config::not_supported);
+  }
 
   int64_t bar = -1;
   int64_t rbar = -1;


### PR DESCRIPTION
This PR will fil following CRs:
CR-1094073
CR-1094072

Issues : 
Because of platform and compute-unit changes in xbutil2, it is failing on edge platform. 

Fixes :
Some of the sysfs nodes are not present on edge platform. We may need to placed them under the try block and handle/ignore for edge case. 

New Logs :
 ./xbutil2 examine -r platform
           -------------------------------------------------
          1/1 [0000:00:00.0] : xilinx_vck190_base_202110_1
          -------------------------------------------------
          Platform
            XSA Name               : xilinx_vck190_base_202110_1 
            FPGA Name              : N/A 
            JTAG ID Code           : N/A 
            DDR Size               : 4294967296 Bytes
            DDR Count              : 1 
            Mig Calibrated         : N/A 
            P2P Status             : not supported 

./xbutil2 examine -r compute-units
            -------------------------------------------------
            1/1 [0000:00:00.0] : xilinx_vck190_base_202110_1
            -------------------------------------------------
            Compute Units
              PL Compute Units
                Index   Name                          Base_Address    Usage   Status  
                0       vadd:vadd_1                   0xa4050000      1       (START) 
            
              PS Compute Units
                Index   Name                          Base_Address    Usage   Status  



