### PR TITLE
obsolete xclExecBufWithWaitList()

### DIFF
--- a/src/runtime_src/core/include/deprecated/xrt.h
+++ b/src/runtime_src/core/include/deprecated/xrt.h
@@ -254,6 +254,13 @@ xclPollCompletion(xclDeviceHandle handle, int min_compl, int max_compl,
 
 /* End XRT Stream Queue APIs */
 
+/* Not supported */
+XRT_DEPRECATED
+XCL_DRIVER_DLLESPEC
+int
+xclExecBufWithWaitList(xclDeviceHandle handle, xclBufferHandle cmdBO,
+                       size_t num_bo_in_wait_list, xclBufferHandle *bo_wait_list);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -755,25 +755,6 @@ int
 xclExecBuf(xclDeviceHandle handle, xclBufferHandle cmdBO);
 
 /**
- * xclExecBufWithWaitList() - Submit an execution request to the embedded (or software) scheduler
- *
- * @handle:              Device handle
- * @cmdBO:               BO handle containing command packet
- * @num_bo_in_wait_list: Number of BO handles in wait list
- * @bo_wait_list:        BO handles that must complete execution before cmdBO is started
- * Return:               0 or standard error number
- *
- * Submit an exec buffer for execution. The BO handles in the wait
- * list must complete execution before cmdBO is started.  The BO
- * handles in the wait list must have beeen submitted prior to this
- * call to xclExecBufWithWaitList.
- */
-XCL_DRIVER_DLLESPEC
-int
-xclExecBufWithWaitList(xclDeviceHandle handle, xclBufferHandle cmdBO,
-                       size_t num_bo_in_wait_list, xclBufferHandle *bo_wait_list);
-
-/**
  * xclExecWait() - Wait for one or more execution events on the device
  *
  * @handle:                  Device handle

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1683,6 +1683,14 @@ int shim::xclExecBuf(unsigned int cmdBO, size_t num_bo_in_wait_list, unsigned in
     xrt_logmsg(XRT_INFO, "%s, cmdBO: %d, num_bo_in_wait_list: %d, bo_wait_list: %d",
             __func__, cmdBO, num_bo_in_wait_list, bo_wait_list);
 
+    // New KDS does not support xclExecBufWithWaitList(). Only allow it to go through if
+    // driver is in old KDS mode.
+    static bool newkds = xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice);
+    if (newkds) {
+        xrt_logmsg(XRT_ERROR, "xclExecBufWithWaitList() is no longer supported.");
+        return -ENOTSUP;
+    }
+
     if (num_bo_in_wait_list > MAX_DEPS) {
         xrt_logmsg(XRT_ERROR, "%s, Incorrect argument. Max num of BOs in wait_list: %d",
             __func__, MAX_DEPS);

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -613,8 +613,16 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     cu_cmd->count = (regmap_size >> 2) + 4;
 
     if (priv1->num_cu_cmds != 0) {
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+	/* This is no longer supported by new KDS implementation. */
         if (xclExecBufWithWaitList(priv1->dev_handle, 
                         priv1->kernel_execbos[bo_idx].handle, 1, &priv1->last_execbo_handle) != 0) {
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD,
                         "Failed to submit kernel start with xclExecBuf");
             priv1->execbo_locked = false;
@@ -833,8 +841,16 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     cu_cmd->count = (regmap_size >> 2) + 4;
     
     if (priv1->num_cu_cmds != 0) {
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+	/* This is no longer supported by new KDS implementation. */
         if (xclExecBufWithWaitList(priv1->dev_handle, 
                         priv1->kernel_execbos[bo_idx].handle, 1, &priv1->last_execbo_handle) != 0) {
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD,
                         "Failed to submit kernel start with xclExecBuf");
             priv1->execbo_locked = false;


### PR DESCRIPTION
xclExecBufWithWaitList() is not used and is only supported by old KDS. There is no XRT level API support for this feature as well. Obsoleting it now.