### PR TITLE
xbutil2: Adding xclbin uuid to CU report 

### DIFF
--- a/src/runtime_src/core/tools/common/ReportCu.cpp
+++ b/src/runtime_src/core/tools/common/ReportCu.cpp
@@ -129,7 +129,14 @@ populate_cus(const xrt_core::device *device)
     }
   }
 
-  return pt;
+  boost::property_tree::ptree ptree;
+  try {
+    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
+    boost::algorithm::to_upper(uuid);
+    ptree.put("xclbin_uuid", uuid);
+  } catch (...) {  }
+  ptree.add_child("compute_units", pt);
+  return ptree;
 }
 
 int 
@@ -225,7 +232,14 @@ populate_cus_new(const xrt_core::device *device)
     }
   }
 
-  return pt;
+  boost::property_tree::ptree ptree;
+  try {
+    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
+    boost::algorithm::to_upper(uuid);
+    ptree.put("xclbin_uuid", uuid);
+  } catch (...) {  }
+  ptree.add_child("compute_units", pt);
+  return ptree;
 }
 
 void
@@ -267,8 +281,12 @@ ReportCu::writeReport( const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree empty_ptree;
   boost::format cuFmt("    %-8s%-30s%-16s%-8s%-8s\n");
 
+  _output << "Xclbin UUID" << std::endl;
+  _output << "  " + _pt.get_child("compute_units").get<std::string>("xclbin_uuid", "N/A") << std::endl;
+  _output << std::endl;
+
   //check if a valid CU report is generated
-  const boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units", empty_ptree);
+  const boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units").get_child("compute_units", empty_ptree);
   if(pt_cu.empty())
     return;
 

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -17,7 +17,7 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include <boost/algorithm/string.hpp>
-#include "ReportCu.h"
+#include "ReportDynamicRegion.h"
 #include "core/common/query_requests.h"
 #include "core/common/device.h"
 #include "core/common/utils.h"
@@ -243,7 +243,7 @@ populate_cus_new(const xrt_core::device *device)
 }
 
 void
-ReportCu::getPropertyTreeInternal(const xrt_core::device * _pDevice, 
+ReportDynamicRegion::getPropertyTreeInternal(const xrt_core::device * _pDevice, 
                                               boost::property_tree::ptree &_pt) const
 {
   // Defer to the 20202 format.  If we ever need to update JSON data, 
@@ -252,7 +252,7 @@ ReportCu::getPropertyTreeInternal(const xrt_core::device * _pDevice,
 }
 
 void 
-ReportCu::getPropertyTree20202( const xrt_core::device * _pDevice, 
+ReportDynamicRegion::getPropertyTree20202( const xrt_core::device * _pDevice, 
                                            boost::property_tree::ptree &_pt) const
 {
   uint32_t kds_mode;
@@ -264,16 +264,18 @@ ReportCu::getPropertyTree20202( const xrt_core::device * _pDevice,
     // When kds_mode doesn't present, xocl driver supports old KDS
     kds_mode = 0;
   }
-
+  boost::property_tree::ptree pt_dynamic_region;
   // There can only be 1 root node
   if (kds_mode == 0) // Old kds
-      _pt.add_child("compute_units", populate_cus(_pDevice));
+    pt_dynamic_region.push_back(std::make_pair("", populate_cus(_pDevice)));
   else // new kds
-      _pt.add_child("compute_units", populate_cus_new(_pDevice));
+    pt_dynamic_region.push_back(std::make_pair("", populate_cus_new(_pDevice)));
+  
+  _pt.add_child("dynamic_regions", pt_dynamic_region);
 }
 
 void 
-ReportCu::writeReport( const xrt_core::device* /*_pDevice*/,
+ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
                        const boost::property_tree::ptree& _pt, 
                        const std::vector<std::string>& /*_elementsFilter*/,
                        std::ostream & _output) const
@@ -281,54 +283,58 @@ ReportCu::writeReport( const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree empty_ptree;
   boost::format cuFmt("    %-8s%-30s%-16s%-8s%-8s\n");
 
-  _output << "Xclbin UUID" << std::endl;
-  _output << "  " + _pt.get_child("compute_units").get<std::string>("xclbin_uuid", "N/A") << std::endl;
-  _output << std::endl;
-
   //check if a valid CU report is generated
-  const boost::property_tree::ptree& pt_cu = _pt.get_child("compute_units").get_child("compute_units", empty_ptree);
-  if(pt_cu.empty())
+  const boost::property_tree::ptree& pt_dfx = _pt.get_child("dynamic_regions", empty_ptree);
+  if(pt_dfx.empty())
     return;
 
-  _output << "Compute Units" << std::endl;
-  _output << "  PL Compute Units" << std::endl;
-  _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
-  try {
-    int index = 0;
-    for(auto& kv : pt_cu) {
-      const boost::property_tree::ptree& cu = kv.second;
-      if(cu.get<std::string>("type").compare("PL") != 0)
-        continue;
-      std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
-      uint32_t status_val = std::stoul(cu_status, nullptr, 16);
-      _output << cuFmt % index++ %
-	      cu.get<std::string>("name") % cu.get<std::string>("base_address") %
-	      cu.get<std::string>("usage") % xrt_core::utils::parse_cu_status(status_val);
-    }
-  }
-  catch( std::exception const& e) {
-    _output << "ERROR: " <<  e.what() << std::endl;
-  }
-  _output << std::endl;
+  for(auto& k_dfx : pt_dfx) {
+    const boost::property_tree::ptree& dfx = k_dfx.second;
+    _output << "Xclbin UUID" << std::endl;
+    _output << "  " + dfx.get<std::string>("xclbin_uuid", "N/A") << std::endl;
+    _output << std::endl;
 
-  //PS kernel report
-  _output << "  PS Compute Units" << std::endl;
-  _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
-  try {
-    int index = 0;
-    for(auto& kv : pt_cu) {
-      const boost::property_tree::ptree& cu = kv.second;
-      if(cu.get<std::string>("type").compare("PS") != 0)
-        continue;
-      std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
-      uint32_t status_val = std::stoul(cu_status, nullptr, 16);
-      _output << cuFmt % index++ %
-	      cu.get<std::string>("name") % cu.get<std::string>("base_address") %
-	      cu.get<std::string>("usage") % xrt_core::utils::parse_cu_status(status_val);
+    const boost::property_tree::ptree& pt_cu = dfx.get_child("compute_units", empty_ptree);
+    _output << "Compute Units" << std::endl;
+    _output << "  PL Compute Units" << std::endl;
+    _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
+    try {
+      int index = 0;
+      for(auto& kv : pt_cu) {
+        const boost::property_tree::ptree& cu = kv.second;
+        if(cu.get<std::string>("type").compare("PL") != 0)
+          continue;
+        std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
+        uint32_t status_val = std::stoul(cu_status, nullptr, 16);
+        _output << cuFmt % index++ %
+          cu.get<std::string>("name") % cu.get<std::string>("base_address") %
+          cu.get<std::string>("usage") % xrt_core::utils::parse_cu_status(status_val);
+      }
     }
-  }
-  catch( std::exception const& e) {
-    _output << "ERROR: " <<  e.what() << std::endl;
+    catch( std::exception const& e) {
+      _output << "ERROR: " <<  e.what() << std::endl;
+    }
+    _output << std::endl;
+
+    //PS kernel report
+    _output << "  PS Compute Units" << std::endl;
+    _output << cuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status";
+    try {
+      int index = 0;
+      for(auto& kv : pt_cu) {
+        const boost::property_tree::ptree& cu = kv.second;
+        if(cu.get<std::string>("type").compare("PS") != 0)
+          continue;
+        std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
+        uint32_t status_val = std::stoul(cu_status, nullptr, 16);
+        _output << cuFmt % index++ %
+          cu.get<std::string>("name") % cu.get<std::string>("base_address") %
+          cu.get<std::string>("usage") % xrt_core::utils::parse_cu_status(status_val);
+      }
+    }
+    catch( std::exception const& e) {
+      _output << "ERROR: " <<  e.what() << std::endl;
+    }
   }
 
   _output << std::endl;

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.h
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.h
@@ -14,15 +14,15 @@
  * under the License.
  */
 
-#ifndef __ReportCu_h_
-#define __ReportCu_h_
+#ifndef __ReportDynamicRegion_h_
+#define __ReportDynamicRegion_h_
 
 // Please keep external include file dependencies to a minimum
 #include "Report.h"
 
-class ReportCu : public Report {
+class ReportDynamicRegion : public Report {
  public:
-  ReportCu() : Report("compute-units", "Information of the compute units", true /*deviceRequired*/) { /*empty*/ };
+  ReportDynamicRegion() : Report("dynamic-regions", "Information about the xclbin and the compute units", true /*deviceRequired*/) { /*empty*/ };
 
  // Child methods that need to be implemented
  public:

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -694,11 +694,8 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
     for (const auto & device : devices) {
       boost::property_tree::ptree ptDevice;
       auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
-      std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
-      boost::algorithm::to_upper(uuid);
       ptDevice.put("interface_type", "pcie");
       ptDevice.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
-      ptDevice.put("xclbin_uuid", uuid);
 
       bool is_mfg = false;
       try {
@@ -722,10 +719,6 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       consoleStream << std::string(dev_desc.length(), '-') << std::endl;
       consoleStream << dev_desc;
       consoleStream << std::string(dev_desc.length(), '-') << std::endl;
-
-      consoleStream << "Xclbin UUID" << std::endl;
-      consoleStream << "  " + uuid << std::endl;
-      consoleStream << std::endl;
 
       for (auto &report : reportsToProcess) {
         if (report->isDeviceRequired() == false)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -39,7 +39,7 @@ namespace po = boost::program_options;
 // ---- Reports ------
 #include "tools/common/Report.h"
 #include "tools/common/ReportHost.h"
-#include "tools/common/ReportCu.h"
+#include "tools/common/ReportDynamicRegion.h"
 #include "tools/common/ReportFirewall.h"
 #include "tools/common/ReportDebugIpStatus.h"
 #include "tools/common/ReportElectrical.h"
@@ -61,7 +61,7 @@ namespace po = boost::program_options;
     std::make_shared<ReportAieShim>(),
     std::make_shared<ReportMemory>(),
     std::make_shared<ReportHost>(),
-    std::make_shared<ReportCu>(),
+    std::make_shared<ReportDynamicRegion>(),
     std::make_shared<ReportDebugIpStatus>(),
     std::make_shared<ReportAsyncError>(),
     std::make_shared<ReportPcieInfo>(),


### PR DESCRIPTION
- **CR-1100427** ASTeR basic sanity - xbmgmt2 examine - ERROR: Failed to open /sys/bus/pci/devices/0000:d8:00.0//xclbinuuid for reading
- **CR-1083710** display xclbin uuid info in xbutil examine command (re-do)

We have to move xclbin-uuid to compute units because:
1. xclbinuuid is not available for xbmgmt
2. we want to show the uuid only for dynamic-regions report (the earlier change had it displayed for all reports)

Sample outputs:
```
$ xbutil examine -d 17:00  -r compute-units -f json -o o.txt --force
----------------------------------------------
1/1 [0000:17:00.1] : xilinx_u30_gen3x4_base_1 
----------------------------------------------
Xclbin UUID                                   
  6250EC80-3F38-4BE0-AC90-68BFD3C140A8        

Compute Units
  PL Compute Units
    Index   Name                          Base_Address    Usage   Status  
    0       verify:verify_1               0x1400000       1       (IDLE)  

  PS Compute Units
    Index   Name                          Base_Address    Usage   Status  

Successfully wrote the json file: o.txt

$cat o.txt
{                                      
    "schema_version": {                
        "schema": "JSON",              
        "creation_date": "Thu May 20 21:33:04 2021 GMT"
    },                                                 
    "devices": [                                       
        {                                              
            "interface_type": "pcie",                  
            "device_id": "0000:17:00.1",               
            "dynamic_regions": [                       
                {                                      
                    "xclbin_uuid": "6250EC80-3F38-4BE0-AC90-68BFD3C140A8",
                    "compute_units": [                                    
                        {                                                 
                            "name": "verify:verify_1",                    
                            "base_address": "0x1400000",                  
                            "usage": "1",                                 
                            "type": "PL",                                 
                            "status": {                                   
                                "bit_mask": "0x4",                        
                                "bits_set": [                             
                                    "IDLE"                                
                                ]                                         
                            }                                             
                        }                                                 
                    ]                                                     
                }
            ]
        }
    ]
}
```