### PR TITLE
Various CR fixes and EoU enhancements for validate

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -137,7 +137,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
     // when json is specified, make sure an accompanying output file is also specified
     if (!vm["format"].defaulted() && sOutput.empty())
-      throw xrt_core::error("ERROR: Please specify an output file to redirect the json to.");
+      throw xrt_core::error("Please specify an output file to redirect the json to");
 
     // Output file
     if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -92,7 +92,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat)->default_value("json"), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
     ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
@@ -136,8 +136,11 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
       throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
 
     // when json is specified, make sure an accompanying output file is also specified
-    if (!vm["format"].defaulted() && sOutput.empty())
+    if (!sFormat.empty() && sOutput.empty())
       throw xrt_core::error("Please specify an output file to redirect the json to");
+
+    if(sFormat.empty())
+      sFormat = "json";
 
     // Output file
     if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -83,7 +83,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   std::vector<std::string> devices = {"all"};
   std::vector<std::string> reportNames = {"platform"};
   std::vector<std::string> elementsFilter;
-  std::string sFormat = "json";
+  std::string sFormat = "";
   std::string sOutput = "";
   bool bHelp = false;
 
@@ -92,7 +92,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat)->default_value("json"), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
     ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
@@ -134,6 +134,10 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
     if (schemaVersion == Report::SchemaVersion::unknown) 
       throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
+
+    // when json is specified, make sure an accompanying output file is also specified
+    if (!vm["format"].defaulted() && sOutput.empty())
+      throw xrt_core::error("ERROR: Please specify an output file to redirect the json to.");
 
     // Output file
     if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -329,6 +329,7 @@ static int
 updateShellAndSC(unsigned int  boardIdx, DSAInfo& candidate, bool& reboot, bool& warm_reboot)
 {
   reboot = false;
+  warm_reboot = false;
 
   Flasher flasher(boardIdx);
 
@@ -436,7 +437,8 @@ auto_flash(xrt_core::device_collection& deviceCollection)
 
     // Perform DSA and BMC updating
     for (auto& p : boardsToUpdate) {
-      bool reboot, warm_reboot;
+      bool reboot = false;
+      bool warm_reboot = false;
       std::cout << std::endl;
       try {
         updateShellAndSC(p.first, p.second, reboot, warm_reboot);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -469,9 +469,9 @@ auto_flash(xrt_core::device_collection& deviceCollection)
     std::cout << "Cold reboot machine to load the new image on device(s).\n";
     std::cout << "****************************************************\n";
   } else if (need_warm_reboot) {
-    std::cout << "****************************************************\n";
-    std::cout << "Warm reboot machine to load the new SC image on device(s).\n";
-    std::cout << "****************************************************\n";
+    std::cout << "******************************************************************\n";
+    std::cout << "Warm reboot is required to recognize new SC image on the device.\n";
+    std::cout << "******************************************************************\\n";
   }
 
   if (success != boardsToUpdate.size()) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -105,7 +105,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   std::vector<std::string> devices;       // Default values determined later in the flow
   std::vector<std::string> reportNames;   // Default values determined later in the flow
   std::vector<std::string> elementsFilter;
-  std::string sFormat = "json";
+  std::string sFormat = "";
   std::string sOutput = "";
   bool bHelp = false;
 
@@ -114,7 +114,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat)->default_value("json"), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
     ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
@@ -169,6 +169,12 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % sFormat << std::endl
               << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
     printHelp(commonOptions, hiddenOptions);
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  // when json is specified, make sure an accompanying output file is also specified
+  if (!vm["format"].defaulted() && sOutput.empty()) {
+    std::cerr << "ERROR: Please specify an output file to redirect the json to." << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -114,7 +114,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
-    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat)->default_value("json"), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
+    ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
     ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
@@ -163,18 +163,21 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     reportNames.push_back("host");
 
   // -- DRC checks --
+  // when json is specified, make sure an accompanying output file is also specified
+  if (!sFormat.empty() && sOutput.empty()) {
+    std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  if(sFormat.empty())
+    sFormat = "json";
+
   // Examine the output format
   Report::SchemaVersion schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
   if (schemaVersion == Report::SchemaVersion::unknown) {
     std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % sFormat << std::endl
               << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-
-  // when json is specified, make sure an accompanying output file is also specified
-  if (!vm["format"].defaulted() && sOutput.empty()) {
-    std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -174,7 +174,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   // when json is specified, make sure an accompanying output file is also specified
   if (!vm["format"].defaulted() && sOutput.empty()) {
-    std::cerr << "ERROR: Please specify an output file to redirect the json to." << std::endl;
+    std::cerr << "ERROR: Please specify an output file to redirect the json to" << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -285,7 +285,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     std::vector<std::string> args = { test_dir.parent_path().string(), 
                                       "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
     try {
-      constexpr static int MAX_TEST_DURATION = 120;
+      constexpr static int MAX_TEST_DURATION = 300; //5 minutes
       int exit_code = XBU::runScript("sh", xrtTestCasePath, args, "Running Test", "Test Duration", MAX_TEST_DURATION, os_stdout, os_stderr, true);
       if (exit_code == EOPNOTSUPP) {
         _ptTest.put("status", "skipped");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -285,7 +285,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     std::vector<std::string> args = { test_dir.parent_path().string(), 
                                       "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
     try {
-      constexpr static int MAX_TEST_DURATION = 60;
+      constexpr static int MAX_TEST_DURATION = 120;
       int exit_code = XBU::runScript("sh", xrtTestCasePath, args, "Running Test", "Test Duration", MAX_TEST_DURATION, os_stdout, os_stderr, true);
       if (exit_code == EOPNOTSUPP) {
         _ptTest.put("status", "skipped");
@@ -842,8 +842,15 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
       break;
   }
 
+  auto is_host_mem = [](std::string tag) {
+    return tag.compare(0,4,"HOST") == 0;
+  };
+
   for (auto& mem : boost::make_iterator_range(mem_topo->m_mem_data, mem_topo->m_mem_data + mem_topo->m_count)) {
     auto midx = std::distance(mem_topo->m_mem_data, &mem);
+    if(is_host_mem(std::string(reinterpret_cast<const char*>(mem.m_tag))))
+      continue;
+
     if (mem.m_type == MEM_STREAMING)
       continue;
 
@@ -1215,12 +1222,12 @@ static void
 print_status(test_status status, std::ostream & _ostream)
 {
   if (status == test_status::failed)
-    _ostream<< "Validation failed";
+    _ostream << "Validation failed";
   else
     _ostream << "Validation completed";
   if (status == test_status::warning)
-    _ostream<< ", but with warnings";
-  _ostream<< std::endl;
+    _ostream << ", but with warnings";
+  _ostream << ". Please run the command '--verbose' option for more details" << std::endl;
 }
 
 /*


### PR DESCRIPTION
- CR-1099874 xbutil2 validate fails on xilinx_u250_gen3x16_xdma_shell_3_1 after the slave bridge is enabled (Fix: host mem check)
- CR-1099470 xbutil valdiate fail after call "xbutil hostmem --enable --size 512M" for xilinx_u200_gen3x16_xdma_1_202110_1 (Dup of above)
- CR-1099860 xbutil2 validate on xilinx_u250_gen3x16_xdma_shell_3_1 shows unclear message about vcu test, which is not supported (Fix: add a message at the end asking the user to run --verbose for more details. A much bigger cleanup will come after 21.1 release)
- CR-1099056 xbutil2 validate bandwidth kernel times out on U50 gen3x16 shells (Fix: increase timeout to 2 minutes)
- CR-1097540 new xrt tool sc flash behavior needs to improve (Workaround: ask the user to do a warm reboot)
- Enforce user to specify output file when "--format" is specified

Sample outputs:
DMA test when host mem is enabled & 'Please run the command '--verbose' option for more details' message
```
% Debug/opt/xilinx/xrt/bin/xbutil validate -d 65:00 -r 'DMA'
Starting validation for 1 devices

Validate Device           : [0000:65:00.1]
    Platform              : xilinx_u250_gen3x16_xdma_shell_3_1
    SC Version            : 
    Platform ID           : 0x0
-------------------------------------------------------------------------------
Test 1 [0000:65:00.1]     : DMA 
    Details               : Host -> PCIe -> FPGA write bandwidth = 9463.452728 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 11775.021201 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Validation completed. Please run the command '--verbose' option for more details
```
Specify output file:
```
$ xbutil examine -d 17:00 -f json
ERROR: Please specify an output file to redirect the json to
```