### PR TITLE
 CR-1093195 => zocl lpddr memory enhancement support

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -63,9 +63,9 @@ struct addr_aperture {
 };
 
 enum zocl_mem_type {
-	ZOCL_MEM_TYPE_CMA	= 0,
-	ZOCL_MEM_TYPE_PL_LP_DDR	= 1,
-	ZOCL_MEM_TYPE_STREAMING = 2,
+	ZOCL_MEM_TYPE_CMA		= 0,
+	ZOCL_MEM_TYPE_RANGE_ALLOC	= 1,
+	ZOCL_MEM_TYPE_STREAMING		= 2,
 };
 
 /*
@@ -80,6 +80,7 @@ struct zocl_mem {
 	u64			zm_size;
 	struct drm_zocl_mm_stat zm_stat;
 	struct drm_mm          *zm_mm;    /* DRM MM node for PL-DDR */
+	struct list_head 	zm_mm_list;
 };
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -1044,7 +1044,7 @@ void zocl_init_mem(struct drm_zocl_dev *zdev, struct mem_topology *mtopo)
 			if ((i == j) || !mtopo->m_mem_data[j].m_used)
 				continue;
 
-			if (strstr(mtopo->m_mem_data[i].m_tag, mtopo->m_mem_data[j].m_tag) && 
+			if (strcmp(mtopo->m_mem_data[i].m_tag, mtopo->m_mem_data[j].m_tag) && 
 					list_empty(&zdev->mem[j].zm_mm_list)) {
 				list_add_tail(&zdev->mem[j].zm_mm_list, &memp->zm_mm_list);
 				memp = &zdev->mem[j];

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -192,7 +192,8 @@ zocl_create_range_mem(struct drm_device *dev, size_t size, struct zocl_mem *mem)
 				cma_bo->flags |= ZOCL_BO_FLAGS_CMA;
 				return cma_bo;
 			}
-			DRM_WARN("Memory allocated from CMA region\n");
+			DRM_WARN("Memory allocated from CMA region"
+					" whereas requested for reserved memory region\n");
 		}
 		else {
 			err = drm_mm_insert_node_generic(mem->zm_mm,

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -982,7 +982,7 @@ void zocl_update_mem_stat(struct drm_zocl_dev *zdev, u64 size, int count,
 	write_unlock(&zdev->attr_rwlock);
 }
 
-/* This function retern True if given region are reserved
+/* This function return True if given region is reserved
  * on device tree. Else return False
  */
 static int check_for_reserved_memory(uint64_t start_addr, size_t size)
@@ -998,16 +998,14 @@ static int check_for_reserved_memory(uint64_t start_addr, size_t size)
 
 	/* Traverse through all the child nodes */
 	for (np_it = NULL; (np_it = of_get_next_child(mem_np, np_it)) != NULL;) {
-		if (strcmp(np_it->name, "buffer") == 0) {
-			err = of_address_to_resource(np_it, 0, &res_mem);
-			if (!err) {
-				/* Check the given address and size fall
-				 * in this reserved memory region
-				 */
-				if (start_addr >= res_mem.start &&
-						size <= resource_size(&res_mem))
-					return true;
-			}
+		err = of_address_to_resource(np_it, 0, &res_mem);
+		if (!err) {
+			/* Check the given address and size fall
+			 * in this reserved memory region
+			 */
+			if (start_addr >= res_mem.start &&
+					size <= resource_size(&res_mem))
+				return true;
 		}
 	}
 


### PR DESCRIPTION
CR Number : https://jira.xilinx.com/browse/CR-1093195
The changes are as follows:
Memory Initialization:
1.	Currently CMA memory is initialized based on tag value substr of “DDR” and base address is “0x0”
       a.	We need to find better alternative to initialize CMA memory from zocl 
2.	Created a link list based on similar memory tag.

Memory Allocation:
1.	If memory is not available from one memory region, XRT will try to allocation from other memory region which is having the similar tag. 
2.	NON-CACHEABLE memory can also be allocated from CMA region if tag value is same. 
3.	CACHEABLE memory will be allocating only from the CMA memory region. 

**Clarifications:**
1. If user asks for Cacheable, We are allocating in non-cacheable area if Cacheable memory is not available. (for backward compatibility)

2. If user asks for Non-Cacheable, We are allocating Non-cacheable only, but We are allocating from CMA area which user can use for Cacheable memory. We added a warning/info saying that allocating non-cacheable memory from CMA.
