### PR TITLE
 zocl dma enable 64 bit addressing

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -870,7 +870,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 		/* If setting 64-bit DMA mask fails, fall back to 32-bit DMA mask */
 		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
 		if (ret) {
-			DRM_ERROR(&pdev->dev,"DMA configuration failed: 0x%x\n", ret);
+			DRM_ERROR("DMA configuration failed: 0x%x\n", ret);
 			return ret;
 		}
 	}

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -867,11 +867,11 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	/* Platform did not initialize dma_mask, try to set 64-bit DMA first */
 	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
 	if (ret) {
-		/* If seting 64-bit DMA mask fails, fall back to 32-bit DMA mask */
+		/* If setting 64-bit DMA mask fails, fall back to 32-bit DMA mask */
 		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
 		if (ret) {
-			dev_err(&pdev->dev,"DMA configuration failed: 0x%x\n", ret);
-			return -EINVAL;
+			DRM_ERROR(&pdev->dev,"DMA configuration failed: 0x%x\n", ret);
+			return ret;
 		}
 	}
 #endif


### PR DESCRIPTION
CR: 
CR-1098008 : Upstream zocl driver patch to enable 64 bit addressing

This PR has the following changes:
1. Enable 64 bit addressing on zocl dma
2. Changes are under the Macro