### PR TITLE
CR-1081475: Issues with device trace on NoDMA platform

### DIFF
--- a/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aim.cpp
+++ b/src/runtime_src/xdp/profile/device/ioctl_monitors/ioctl_aim.cpp
@@ -101,10 +101,7 @@ size_t IOCtlAIM::readCounter(xclCounterResults& counterResults, uint32_t s)
   if(out_stream)
     (*out_stream) << " IOCtlAIM::readCounter " << std::endl;
 
-  uint32_t sampleInterval = 0;
-  if (s==0 && getDevice()) {
-    counterResults.SampleIntervalUsec = static_cast<float>(sampleInterval / (getDevice()->getDeviceClock()));
-  }
+  counterResults.SampleIntervalUsec = 0 ;
 
   struct aim_counters counter = { 0 };
   ioctl(driver_FD, AIM_IOC_READCNT, &counter);

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -105,15 +105,18 @@ namespace xdp {
     for (auto o : offloaders) {
       auto offloader = std::get<0>(o.second) ;
 
-      if(offloader->continuous_offload()) {
-        offloader->stop_offload();
-        // To avoid a race condition, wait until the thread is stopped
-        while (offloader->get_status() != OffloadThreadStatus::STOPPED) ;
-      } else {
-        offloader->read_trace();
-        offloader->read_trace_end();
+      try {
+        if(offloader->continuous_offload()) {
+          offloader->stop_offload();
+          // To avoid a race condition, wait until the thread is stopped
+          while (offloader->get_status() != OffloadThreadStatus::STOPPED) ;
+        } else {
+          offloader->read_trace();
+          offloader->read_trace_end();
+        }
+        checkTraceBufferFullness(offloader, o.first);
+      } catch (std::exception& /*e*/) {
       }
-      checkTraceBufferFullness(offloader, o.first);
     }
   }
 
@@ -140,16 +143,17 @@ namespace xdp {
 
     if (offloaders.find(deviceId) != offloaders.end())
     {
-      auto offloader = std::get<0>(offloaders[deviceId]) ;
-      if (offloader->continuous_offload())
-      {
-        offloader->stop_offload() ;
-        // To avoid a race condition, wait until the offloader has stopped
-        while(offloader->get_status() != OffloadThreadStatus::STOPPED) ;
-      }
-      else
-      {
-        offloader->read_trace() ;
+      try {
+        auto offloader = std::get<0>(offloaders[deviceId]) ;
+        if (offloader->continuous_offload()) {
+          offloader->stop_offload() ;
+          // To avoid a race condition, wait until the offloader has stopped
+          while(offloader->get_status() != OffloadThreadStatus::STOPPED) ;
+        }
+        else {
+          offloader->read_trace() ;
+        }
+      } catch (std::exception& /*e*/) {
       }
     }
     readCounters() ;


### PR DESCRIPTION
Reading trace from the device may throw an exception in rare cases.  This pull request catches those exceptions and continues on to reading counters and other devices in those rare cases.  Additionally, this pull request removes useless code that could cause seg faults in rare instances when the xrt_xocl::device has been destroyed or invalidated before counter offload happens at the end of execution.
