### PR TITLE
CR-1100856 u50 NoDMA PLRAM read using sub-buffers causes panic

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -748,14 +748,15 @@ int xocl_sync_bo_ioctl(struct drm_device *dev,
 
 	xobj = to_xocl_bo(gem_obj);
 	BO_ENTER("xobj %p", xobj);
-	sgt = xobj->sgt;
-	sg = sgt->sgl;
 
 	if (!xocl_bo_sync_able(xobj->flags)) {
 		DRM_ERROR("BO %d doesn't support sync_bo\n", args->handle);
 		ret = -EOPNOTSUPP;
 		goto out;
 	}
+
+	sgt = xobj->sgt;
+	sg = sgt->sgl;
 
 	if (xocl_bo_cma(xobj) || xocl_bo_p2p(xobj)) {
 		if (dir) {


### PR DESCRIPTION
Fix xrt::bo sub buffer sync to handle the case where parent buffer is
a nodma buffer.

General unrelated cleanup, remove dead code.

Prevent kernel panic in case user land calls sync ioctl on nodma buffer.