### PR TITLE
CR-1100413: Fixing the get cu index API for kds_mode=0

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -926,20 +926,12 @@ int
 shim::
 xclIPName2Index(const char *name)
 {
-  uint32_t kds_mode;
-  try {
-    kds_mode = xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice);
-  } catch (...){
-    kds_mode = 0;
-  }
-
-  //if kds_mode is enabled, then use kds_cu_stat to get the ip index. Otherwise
-  //use old mechanism to get the cu index
+  //if kds_mode is enabled, use kds_cu_stat to get the ip index. 
+  //if kds_mode is disabled get cu index from get_cus function
 
   // In new kds, driver determines CU index
-  if (kds_mode == 1)
-  {
-    try {
+  try {
+    if (xrt_core::device_query<xrt_core::query::kds_mode>(mCoreDevice)) {
       for (auto& stat : xrt_core::device_query<xrt_core::query::kds_cu_stat>(mCoreDevice))
         if (stat.name == name)
           return stat.index;
@@ -947,9 +939,10 @@ xclIPName2Index(const char *name)
       xclLog(XRT_ERROR, "%s not found", name);
       return -ENOENT;
     }
-    catch (const xrt_core::query::no_such_key&) {
-    }
   }
+  catch (const xrt_core::query::no_such_key&) {
+  }
+
   // Old kds is enabled
   std::string errmsg;
   std::vector<char> buf;


### PR DESCRIPTION
This change contains the fix to get the CU index in old kds mode. Taking decision based on the kds_mode sysfs node.