### PR TITLE
cr-1100855

### DIFF
--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_profiling_api.cpp
@@ -479,8 +479,6 @@ err_code profiling::stop(std::vector<std::shared_ptr<xaiefal::XAieRsc>>& acquire
         }
         else if (auto pBroadcastRsc = dynamic_cast<xaiefal::XAieBroadcast*>(acquiredResource.get()))
         {
-            //FIXME xaiefal::XAieBroadcast::getChannel is in the latest petalinux but not yet in internal_platform
-            /*
             std::vector<XAie_LocType> tileLocs;
             XAie_ModuleType startModule, endModule;
             u8 broadcastId = (u8)pBroadcastRsc->getBc();
@@ -522,7 +520,6 @@ err_code profiling::stop(std::vector<std::shared_ptr<xaiefal::XAieRsc>>& acquire
                 //east shim tile switch A
                 driverStatus |= XAie_EventBroadcastUnblockDir(config_manager::s_pDevInst, eastTileLoc, XAIE_PL_MOD, XAIE_EVENT_SWITCH_A, (u8)broadcastId, XAIE_EVENT_BROADCAST_EAST | XAIE_EVENT_BROADCAST_NORTH | XAIE_EVENT_BROADCAST_SOUTH); // unblock east, north & south
             }
-            */
         }
 
         if (!fal_util::release(acquiredResource))

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.cpp
@@ -112,6 +112,8 @@ err_code graph_api::run()
         XAie_StartTransaction(config_manager::s_pDevInst, XAIE_TRANSACTION_ENABLE_AUTO_FLUSH);
         for (int i = 0; i < numCores; i++)
         {
+            // Clear disable event occurred bit of Enable_Event
+            XAie_ClearCoreDisableEventOccurred(config_manager::s_pDevInst, coreTiles[i]);
             //Set Enable_Event to XAIE_EVENT_BROADCAST_7_CORE. The resources have been acquired by aiecompiler.
             XAie_CoreConfigureEnableEvent(config_manager::s_pDevInst, coreTiles[i], XAIE_EVENT_BROADCAST_7_CORE);
         }
@@ -125,7 +127,7 @@ err_code graph_api::run()
         driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, (u64*)(&StartTime));
         do {
             driverStatus |= XAie_ReadTimer(config_manager::s_pDevInst, XAie_TileLoc(0, 0), XAIE_PL_MOD, (u64*)(&CurrentTime));
-        } while ((CurrentTime - StartTime) <= 250);
+        } while ((CurrentTime - StartTime) <= 150);
 
         XAie_StartTransaction(config_manager::s_pDevInst, XAIE_TRANSACTION_ENABLE_AUTO_FLUSH);
         for (int i = 0; i < numCores; i++)


### PR DESCRIPTION
Fix CR-1100855 to clear disable event bit before broadcast enable core.
Uncomment code as xaiefal::XAieBroadcast::getChannel should be available in internal_platform