### PR TITLE
CR-1083102 Require error message for no DMA p2p on u50

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -122,8 +122,8 @@ static int copybo_ecmd2xcmd(struct xocl_dev *xdev, struct drm_file *filp,
 
 	if (ret_src != ret_dst) {
 		/* One of them is not local BO, perform P2P copy */
-		xocl_copy_import_bo(filp->minor->dev, filp, ecmd);
-		return 1;
+		int err = xocl_copy_import_bo(filp->minor->dev, filp, ecmd);
+		return err < 0 ? err : 1;
 	}
 
 	/* Both BOs are local, copy via cdma CU */


### PR DESCRIPTION
Fix driver to propagate copy error to user land.