### PR TITLE
CR-1099159: Fixing VAI issue where EXEC_WRITE shouldnt skip any words for edge

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -111,7 +111,8 @@ void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			  struct kds_command *xcmd);
 void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
-			  struct kds_command *xcmd);
+			  struct kds_command *xcmd,
+			  u32 skip);
 void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			struct kds_command *xcmd);
 int cu_mask_to_cu_idx(struct kds_command *xcmd, uint8_t *cus);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1149,7 +1149,7 @@ void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 }
 
 void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
-			  struct kds_command *xcmd)
+			  struct kds_command *xcmd, u32 skip)
 {
 	xcmd->opcode = OP_START;
 
@@ -1169,8 +1169,8 @@ void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	 * In ert_start_kernel_cmd, the CU register map size is
 	 * (count - (1 + extra_cu_masks)) and skip 6 words for exec_write cmd.
 	 */
-	xcmd->isize = (ecmd->count - xcmd->num_mask - 6) * sizeof(u32);
-	memcpy(xcmd->info, &ecmd->data[6 + ecmd->extra_cu_masks], xcmd->isize);
+	xcmd->isize = (ecmd->count - xcmd->num_mask - skip) * sizeof(u32);
+	memcpy(xcmd->info, &ecmd->data[skip + ecmd->extra_cu_masks], xcmd->isize);
 	xcmd->payload_type = KEY_VAL;
 	ecmd->type = ERT_CU;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -348,7 +348,15 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 	else if (ecmd->opcode == ERT_START_CU)
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 	else if (ecmd->opcode == ERT_EXEC_WRITE)
-		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+	{
+		/* third argument in following function is representing number of
+		 * words to skip when configuring CU. This should be consistent
+		 * for both edge/DC, but due to performance and siome use cases,
+		 * this has veen decided that , DC flows skip 6 words whereas
+		 * edge flows doesnt skip any words.
+		 */
+		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd, 0);
+	}
 	else if (ecmd->opcode == ERT_START_FA)
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 	xcmd->cb.notify_host = notify_execbuf;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -548,7 +548,13 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+		/* third argument in following function is representing number of
+		 * words to skip when writing to CU. This should be consistent
+		 * for both edge/DC, but Due to performance and some use cases
+		 * this is been decided that, DC flows skips first 6 words
+		 * whereas edge flows doesnt skip any words
+		 */
+		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd, 6);
 		break;
 	case ERT_START_FA:
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);


### PR DESCRIPTION
This change contains a fix where VAI is using EXEC_WRITE and XRT is skipping first six bytes from that command packet
We are not skipping any words for edge In old KDS, but in new KDS, we are skipping six words which is causing their tests to fail.

TODO in next release:
We should definitely remove this difference between edge/DC in next release. 
We should also identify from where this 6 words skipping request came from for DC.