### PR TITLE
Fixed vcu_test case and updated decoder id based on new chnages

### DIFF
--- a/tests/validate/xcl_vcu_test/src/host.cpp
+++ b/tests/validate/xcl_vcu_test/src/host.cpp
@@ -20,7 +20,7 @@
 #include "plugin_common.h"
 #include "input_out_frame_dump.h"
 
-#define VCU_SK_DECODER_ID 1
+#define VCU_SK_DECODER_ID 0
 #define VCU_SK_ENCODER_ID 32
 
 int main(int argc, char** argv) {

--- a/tests/validate/xcl_vcu_test/src/plugin_dec.cpp
+++ b/tests/validate/xcl_vcu_test/src/plugin_dec.cpp
@@ -581,7 +581,7 @@ gstivas_xvcudec_stop (XrtIvas_XVCUDec *dec)
 {
   int bret = TRUE;
 
-  if (dec->priv->init_done) {
+  if (dec->priv->init_done == TRUE) {
     bret = xvcudec_send_flush (dec);
     if (bret != TRUE)
       return bret;


### PR DESCRIPTION
**CR Id :**
CR-1100111  : 4K HEVC decode fails after u30validateall script

The Issue : 
 ffmpeg test is failing after we ran xcl_vcu_test

The Solution:
1. The decoder id got updated, hence vcu_test also need to updated.
2. deinit never called in the current vcu_test because of invalid if condition, So updated the condition check.
