### PR TITLE
Minor fixes in xbutil/xbmgmt

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -720,8 +720,10 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       consoleStream << dev_desc;
       consoleStream << std::string(dev_desc.length(), '-') << std::endl;
 
+      auto is_ready = xrt_core::device_query<xrt_core::query::is_ready>(device);
+
       for (auto &report : reportsToProcess) {
-        if (report->isDeviceRequired() == false)
+        if (report->isDeviceRequired() == false || !is_ready)
           continue;
 
         boost::property_tree::ptree ptReport;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -145,17 +145,17 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     // Collect the reports to be processed
     XBU::collect_and_validate_reports(fullReportCollection, reportNames, reportsToProcess);
 
-    // Output Format
-    schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
-    if (schemaVersion == Report::SchemaVersion::unknown) 
-      throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
-
     // when json is specified, make sure an accompanying output file is also specified
     if (!sFormat.empty() && sOutput.empty())
       throw xrt_core::error("Please specify an output file to redirect the json to");
 
     if(sFormat.empty())
       sFormat = "json";
+
+    // Output Format
+    schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
+    if (schemaVersion == Report::SchemaVersion::unknown) 
+      throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
 
     // Output file
     if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -230,7 +230,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     }
 
     // enforce 1 device specification if multiple reports are requested
-    if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 && reportNames.front().compare("host") != 0)) {
+    if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)) {
       std::cerr << "\nERROR: Examining multiple devices is not supported. Please specify a single device using --device option\n\n";
       std::cout << "List of available devices:" << std::endl;
       boost::property_tree::ptree available_devices = XBU::get_available_devices(true);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -152,7 +152,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   if (devices.size() != 0 && reportNames.size() == 0) {
     reportNames.push_back("platform");
-    reportNames.push_back("compute-units");
+    reportNames.push_back("dynamic-regions");
   }
 
   // Determine default values

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -904,6 +904,17 @@ bandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::proper
 void
 p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  uint32_t no_dma = 0;
+  try {
+    no_dma = xrt_core::device_query<xrt_core::query::nodma>(_dev);
+  } catch(...) { }
+
+  if(no_dma != 0) {
+    logger(_ptTest, "Details", "Not supported on NoDMA platform");
+    _ptTest.put("status", "skipped");
+    return;
+  }
+
   if(!search_and_program_xclbin(_dev, _ptTest)) {
     return;
   }
@@ -956,6 +967,17 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  uint32_t no_dma = 0;
+  try {
+    no_dma = xrt_core::device_query<xrt_core::query::nodma>(_dev);
+  } catch(...) { }
+
+  if(no_dma != 0) {
+    logger(_ptTest, "Details", "Not supported on NoDMA platform");
+    _ptTest.put("status", "skipped");
+    return;
+  }
+
   if(!search_and_program_xclbin(_dev, _ptTest)) {
     return;
   }
@@ -1016,6 +1038,17 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  uint32_t no_dma = 0;
+  try {
+    no_dma = xrt_core::device_query<xrt_core::query::nodma>(_dev);
+  } catch(...) { }
+
+  if(no_dma != 0) {
+    logger(_ptTest, "Details", "Not supported on NoDMA platform");
+    _ptTest.put("status", "skipped");
+    return;
+  }
+
   uint64_t host_mem_size = 0;
   try {
     host_mem_size = xrt_core::device_query<xrt_core::query::host_mem_size>(_dev);


### PR DESCRIPTION
- CR-1088371 "xbutil --new examine" command hangs when a card is not installed property
- Fix xbutil examine to enforce single device
- DRC check misaligned in xbmgmt examine
- CR-1101231 XRT - xbutil2 examine -d [device bdf] reports 'no report generator found for report compute-units'
- CR-1100874 ASTeR TC19.15 - xbutil2 validate fails when p2p is enabled