### PR TITLE
CR-1100472 Design hangs on u280 machine

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1516,6 +1516,7 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 	char kname[64];
 	char *kname_p;
 	int err = 0, i;
+	int inst = 0;
 
 	/* Let CU controller know the dynamic resources */
 	for (i = 0; i < ip_layout->m_count; ++i) {
@@ -1549,7 +1550,7 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 			continue;
 		}
 
-		info.inst_idx = i;
+		info.inst_idx = inst++;
 		info.addr = ip->m_base_address;
 		info.size = krnl_info->range;
 		info.num_res = subdev_info.num_res;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -88,6 +88,11 @@ failed:
 	return ret;
 }
 
+static bool is_valid_override_idx(int override_idx)
+{
+	return (override_idx >= 0) && (override_idx < XOCL_SUBDEV_MAX_INST);
+}
+
 static struct xocl_subdev *xocl_subdev_info2dev(xdev_handle_t xdev_hdl,
 		struct xocl_subdev_info *sdev_info)
 {
@@ -97,7 +102,9 @@ static struct xocl_subdev *xocl_subdev_info2dev(xdev_handle_t xdev_hdl,
 	int i;
 
 	if (sdev_info->override_idx != -1)
-		return &core->subdevs[devid][sdev_info->override_idx];
+		return is_valid_override_idx(sdev_info->override_idx) ?
+			&core->subdevs[devid][sdev_info->override_idx] :
+			NULL;
 	else if (!sdev_info->multi_inst)
 		return &core->subdevs[devid][0];
 


### PR DESCRIPTION
In icap_create_subdev_cu(), i is the index of ip_layout entries. But not all of the ip_layout entries are CUs (e.g. IP_MEM_****, IP_KERNEL with AP_CTRL_NONE and no address), so, use i as instance index is a mistake.

Add a simple check function when override_idx is set.