### PR TITLE
Reverting the DMA BIT MASK settings in edge as it is causing DFx platform to fail

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -863,19 +863,6 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	}
 	mutex_init(&zdev->mm_lock);
 
-#ifdef CONFIG_ARCH_DMA_ADDR_T_64BIT
-	/* Platform did not initialize dma_mask, try to set 64-bit DMA first */
-	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
-	if (ret) {
-		/* If setting 64-bit DMA mask fails, fall back to 32-bit DMA mask */
-		ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
-		if (ret) {
-			DRM_ERROR("DMA configuration failed: 0x%x\n", ret);
-			return ret;
-		}
-	}
-#endif
-
 	subdev = zocl_find_pdev("ert_hw");
 	if (subdev) {
 		DRM_INFO("ert_hw found: 0x%llx\n", (uint64_t)(uintptr_t)subdev);


### PR DESCRIPTION
This change is reverting #5284 as this is causing DFx base tests also to fail. 

@saifuddin-xilinx ,
Please fix with right fix and verify DFx platform also