### PR TITLE
CR-1079617: Add Guidance for AIE counters usage (active vs.. stalls)

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -358,7 +358,8 @@ class aie_cfg_tile
 
     std::vector<AIECounter*>     aieList;
     std::vector<TraceGMIO*>      gmioList;
-    std::map<uint32_t, uint32_t> aieCountersMap;
+    std::map<uint32_t, uint32_t> aieCoreCountersMap;
+    std::map<uint32_t, uint32_t> aieMemoryCountersMap;
     std::map<uint32_t, uint32_t> aieCoreEventsMap;
     std::map<uint32_t, uint32_t> aieMemoryEventsMap;
     std::vector<std::unique_ptr<aie_cfg_tile>> aieCfgList;
@@ -536,8 +537,11 @@ class aie_cfg_tile
            uint8_t start, uint8_t end, uint8_t reset,
            double freq, const std::string& mod,
            const std::string& aieName) ;
-    void addAIECounterResources(uint32_t numCounters, uint32_t numTiles) {
-      aieCountersMap[numCounters] = numTiles;
+    void addAIECounterResources(uint32_t numCounters, uint32_t numTiles, bool isCore) {
+      if (isCore)
+        aieCoreCountersMap[numCounters] = numTiles;
+      else
+        aieMemoryCountersMap[numCounters] = numTiles;
     }
     void addAIECoreEventResources(uint32_t numEvents, uint32_t numTiles) {
       aieCoreEventsMap[numEvents] = numTiles;
@@ -952,9 +956,15 @@ class aie_cfg_tile
     }
 
     inline std::map<uint32_t, uint32_t>&
-    getAIECounterResources(uint64_t deviceId)
+    getAIECoreCounterResources(uint64_t deviceId)
     {
-      return deviceInfo[deviceId]->aieCountersMap;
+      return deviceInfo[deviceId]->aieCoreCountersMap;
+    }
+
+    inline std::map<uint32_t, uint32_t>&
+    getAIEMemoryCounterResources(uint64_t deviceId)
+    {
+      return deviceInfo[deviceId]->aieMemoryCountersMap;
     }
 
     inline std::map<uint32_t, uint32_t>&
@@ -1002,10 +1012,10 @@ class aie_cfg_tile
                 freq, mod, aieName) ;
     }
 
-    inline void addAIECounterResources(uint64_t deviceId, uint32_t numCounters, uint32_t numTiles) {
+    inline void addAIECounterResources(uint64_t deviceId, uint32_t numCounters, uint32_t numTiles, bool isCore) {
       if (deviceInfo.find(deviceId) == deviceInfo.end())
         return ;
-      deviceInfo[deviceId]->addAIECounterResources(numCounters, numTiles) ;
+      deviceInfo[deviceId]->addAIECounterResources(numCounters, numTiles, isCore) ;
     }
     
     inline void addAIECoreEventResources(uint64_t deviceId, uint32_t numEvents, uint32_t numTiles) {

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -306,14 +306,15 @@ namespace xdp {
           }
 
           // Set masks for group events
+          // NOTE: Writing to group error enable register is blocked, so ignoring
           if (startEvents.at(i) == XAIE_EVENT_GROUP_DMA_ACTIVITY_MEM)
             XAie_EventGroupControl(aieDevInst, loc, mod, startEvents.at(i), GROUP_DMA_MASK);
           else if (startEvents.at(i) == XAIE_EVENT_GROUP_LOCK_MEM)
             XAie_EventGroupControl(aieDevInst, loc, mod, startEvents.at(i), GROUP_LOCK_MASK);
           else if (startEvents.at(i) == XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM)
             XAie_EventGroupControl(aieDevInst, loc, mod, startEvents.at(i), GROUP_CONFLICT_MASK);
-          else if (startEvents.at(i) == XAIE_EVENT_GROUP_ERRORS_MEM)
-            XAie_EventGroupControl(aieDevInst, loc, mod, startEvents.at(i), GROUP_ERROR_MASK);
+          //else if (startEvents.at(i) == XAIE_EVENT_GROUP_ERRORS_MEM)
+          //  XAie_EventGroupControl(aieDevInst, loc, mod, startEvents.at(i), GROUP_ERROR_MASK);
 
           // Store counter info in database
           std::string counterName = "AIE Counter " + std::to_string(counterId);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -338,7 +338,7 @@ namespace xdp {
           msg << n << ": " << numTileCounters[n] << " tiles";
           if (n != NUM_COUNTERS) msg << ", ";
 
-          (db->getStaticInfo()).addAIECounterResources(deviceId, n, numTileCounters[n]);
+          (db->getStaticInfo()).addAIECounterResources(deviceId, n, numTileCounters[n], isCore);
         }
         xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg.str());
       }

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_summary_writer.cpp
@@ -2276,10 +2276,19 @@ namespace xdp {
     auto infos = (t->db->getStaticInfo()).getDeviceInfos() ;
     for (auto device : infos)
     {
-      auto& counters = (t->db->getStaticInfo()).getAIECounterResources(device->deviceId) ;
-      for (auto const& counter : counters)
+      auto& coreCounters = (t->db->getStaticInfo()).getAIECoreCounterResources(device->deviceId) ;
+      for (auto const& counter : coreCounters)
       {
-        (t->fout) << "AIE_COUNTER_RESOURCES" << ","
+        (t->fout) << "AIE_CORE_COUNTER_RESOURCES" << ","
+	                << counter.first << ","
+	                << counter.second << ","
+	                << std::endl ;
+      }
+
+      auto& memoryCounters = (t->db->getStaticInfo()).getAIEMemoryCounterResources(device->deviceId) ;
+      for (auto const& counter : memoryCounters)
+      {
+        (t->fout) << "AIE_MEMORY_COUNTER_RESOURCES" << ","
 	                << counter.first << ","
 	                << counter.second << ","
 	                << std::endl ;


### PR DESCRIPTION
* made distinction in reporting of AIE core and memory module counter resources
* turned off write to group error enable register since it's blocked