### PR TITLE
CR-1100341 Copy Buffer Examples failing - Host application did not complete - pass/end string not found. Exiting as a failure

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -204,6 +204,8 @@ int zocl_copy_bo_async(struct drm_device *dev, struct drm_file *fipl,
 bool zocl_can_dma_performed(struct drm_device *dev, struct drm_file *filp,
 	struct drm_zocl_copy_bo *args, uint64_t *dst_paddr,
 	uint64_t *src_paddr);
+int zocl_dma_channel_instance(zocl_dma_handle_t *dma_handle,
+			      struct drm_zocl_dev *zdev);
 
 void zocl_describe(const struct drm_zocl_bo *obj);
 

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -2612,30 +2612,6 @@ static void zocl_dma_complete(void *arg, int ret)
 }
 
 static int
-zocl_dma_channel_instance(zocl_dma_handle_t *dma_handle,
-	struct drm_zocl_dev *zdev)
-{
-	dma_cap_mask_t dma_mask;
-
-	if (!dma_handle->dma_chan && ZOCL_PLATFORM_ARM64) {
-		/* If zdev_dma_chan is NULL, we haven't initialized it yet. */
-		if (!zdev->zdev_dma_chan) {
-			dma_cap_zero(dma_mask);
-			dma_cap_set(DMA_MEMCPY, dma_mask);
-			zdev->zdev_dma_chan =
-			    dma_request_channel(dma_mask, 0, NULL);
-			if (!zdev->zdev_dma_chan) {
-				DRM_WARN("no DMA Channel available.\n");
-				return -EBUSY;
-			}
-		}
-		dma_handle->dma_chan = zdev->zdev_dma_chan;
-	}
-
-	return dma_handle->dma_chan ? 0 : -EINVAL;
-}
-
-static int
 zocl_copy_bo_submit(struct sched_cmd *cmd)
 {
 	struct ert_start_copybo_cmd *ecmd = cmd->ert_cp;


### PR DESCRIPTION
1. Move zocl_dma_channel_instance() to zocl_bo.c, so that it is accessible for both sched_exec.c and zocl_kds.c.
2. Add copybo command support.

Test with hw_emu test case from CR, the test case can pass now.