### PR TITLE
Fix C-API error return code (#5338)

### DIFF
--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -320,10 +320,14 @@ xrtGraphOpen(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, const char* g
     graph_cache[hdl.get()] = hdl;
     return hdl.get();
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 xrtGraphHandle
@@ -334,10 +338,14 @@ xrtGraphOpenExclusive(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, cons
     graph_cache[hdl.get()] = hdl;
     return hdl.get();
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 xrtGraphHandle
@@ -348,10 +356,14 @@ xrtGraphOpenShared(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, const c
     graph_cache[hdl.get()] = hdl;
     return hdl.get();
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 void
@@ -362,6 +374,7 @@ xrtGraphClose(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -378,12 +391,12 @@ xrtGraphReset(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 uint64_t
@@ -395,12 +408,12 @@ xrtGraphTimeStamp(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -413,12 +426,12 @@ xrtGraphRun(xrtGraphHandle graph_hdl, int iterations)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -430,12 +443,12 @@ xrtGraphWaitDone(xrtGraphHandle graph_hdl, int timeoutMilliSec)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -448,12 +461,12 @@ xrtGraphWait(xrtGraphHandle graph_hdl, uint64_t cycle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -466,12 +479,12 @@ xrtGraphSuspend(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -484,12 +497,12 @@ xrtGraphResume(xrtGraphHandle graph_hdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -502,12 +515,12 @@ xrtGraphEnd(xrtGraphHandle graph_hdl, uint64_t cycle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -520,12 +533,12 @@ xrtGraphUpdateRTP(xrtGraphHandle graph_hdl, const char* port, const char* buffer
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -538,12 +551,12 @@ xrtGraphReadRTP(xrtGraphHandle graph_hdl, const char* port, char* buffer, size_t
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 xrtDeviceHandle
@@ -556,6 +569,7 @@ xrtAIEDeviceOpen(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -573,6 +587,7 @@ xrtAIEDeviceOpenExclusive(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -590,6 +605,7 @@ xrtAIEDeviceOpenShared(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -612,12 +628,12 @@ xrtSyncBOAIE(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioName
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -635,12 +651,12 @@ xrtResetAIEArray(xrtDeviceHandle handle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 ////////////////////////////////////////////////////////////////
@@ -670,12 +686,12 @@ xrtSyncBOAIENB(xrtDeviceHandle handle, xrtBufferHandle bohdl, const char *gmioNa
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 /**
@@ -695,12 +711,12 @@ xrtGMIOWait(xrtDeviceHandle handle, const char *gmioName)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 /**
@@ -730,12 +746,12 @@ xrtAIEStartProfiling(xrtDeviceHandle handle, int option, const char *port1Name, 
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 /**
@@ -755,12 +771,12 @@ xrtAIEReadProfiling(xrtDeviceHandle handle, int pHandle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 /**
@@ -782,10 +798,10 @@ xrtAIEStopProfiling(xrtDeviceHandle handle, int pHandle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1013,6 +1013,7 @@ xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -1034,6 +1035,7 @@ xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGro
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -1054,6 +1056,7 @@ xrtBOSubAlloc(xrtBufferHandle phdl, size_t sz, size_t offset)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -1073,6 +1076,7 @@ xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -1090,6 +1094,7 @@ xrtBOExport(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -1108,12 +1113,12 @@ xrtBOFree(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 size_t
@@ -1126,11 +1131,12 @@ xrtBOSize(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
   }
-  return 0;
+  return std::numeric_limits<size_t>::max();
 }
 
 
@@ -1146,12 +1152,12 @@ xrtBOSync(xrtBufferHandle bhdl, xclBOSyncDirection dir, size_t size, size_t offs
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 void*
@@ -1164,6 +1170,7 @@ xrtBOMap(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -1183,12 +1190,12 @@ xrtBOWrite(xrtBufferHandle bhdl, const void* src, size_t size, size_t seek)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -1203,12 +1210,12 @@ xrtBORead(xrtBufferHandle bhdl, void* dst, size_t size, size_t skip)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -1225,12 +1232,12 @@ xrtBOCopy(xrtBufferHandle dhdl, xrtBufferHandle shdl, size_t sz, size_t dst_offs
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 
@@ -1244,10 +1251,10 @@ xrtBOAddress(xrtBufferHandle bhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return std::numeric_limits<uint64_t>::max();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return std::numeric_limits<uint64_t>::max();
   }
+  return std::numeric_limits<uint64_t>::max();
 }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -314,6 +314,7 @@ xrtDeviceOpen(unsigned int index)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -331,6 +332,7 @@ xrtDeviceOpenByBDF(const char* bdf)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -349,12 +351,12 @@ xrtDeviceClose(xrtDeviceHandle dhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -370,12 +372,12 @@ xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const axlf* top)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -391,12 +393,12 @@ xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* fnm)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -411,12 +413,12 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -431,12 +433,12 @@ xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -452,12 +454,12 @@ xrtDeviceGetXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return 1;
   }
+  return -1;
 }
 
 xclDeviceHandle
@@ -471,6 +473,7 @@ xrtDeviceToXclDevice(xrtDeviceHandle dhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -495,6 +498,7 @@ xrtDeviceOpenFromXcl(xclDeviceHandle dhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -311,12 +311,12 @@ xrtErrorGetLast(xrtDeviceHandle dhdl, xrtErrorClass ecl, xrtErrorCode* error, ui
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -342,10 +342,10 @@ xrtErrorGetString(xrtDeviceHandle, xrtErrorCode error, char* out, size_t len, si
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }

--- a/src/runtime_src/core/common/api/xrt_ini.cpp
+++ b/src/runtime_src/core/common/api/xrt_ini.cpp
@@ -46,12 +46,12 @@ xrtIniStringSet(const char* key, const char* value)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -63,10 +63,10 @@ xrtIniUintSet(const char* key, unsigned int value)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2483,10 +2483,14 @@ xrtPLKernelOpen(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char *name
       return api::xrtKernelOpen(dhdl, xclbin_uuid, name, ip_context::access_mode::shared);
     });
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 xrtKernelHandle
@@ -2498,10 +2502,14 @@ xrtPLKernelOpenExclusive(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const c
       return api::xrtKernelOpen(dhdl, xclbin_uuid, name, ip_context::access_mode::exclusive);
     });
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 int
@@ -2515,12 +2523,12 @@ xrtKernelClose(xrtKernelHandle khdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 xrtRunHandle
@@ -2531,10 +2539,14 @@ xrtRunOpen(xrtKernelHandle khdl)
       return api::xrtRunOpen(khdl);
     });
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 int
@@ -2547,12 +2559,12 @@ xrtKernelArgGroupId(xrtKernelHandle khdl, int argno)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 uint32_t
@@ -2565,12 +2577,12 @@ xrtKernelArgOffset(xrtKernelHandle khdl, int argno)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return std::numeric_limits<uint32_t>::max();
   }
+  return std::numeric_limits<uint32_t>::max();
 }
 
 int
@@ -2585,12 +2597,12 @@ xrtKernelReadRegister(xrtKernelHandle khdl, uint32_t offset, uint32_t* datap)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2605,12 +2617,12 @@ xrtKernelWriteRegister(xrtKernelHandle khdl, uint32_t offset, uint32_t data)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 xrtRunHandle
@@ -2631,10 +2643,14 @@ xrtKernelRun(xrtKernelHandle khdl, ...)
     va_end(args);
     return result;
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 int
@@ -2648,12 +2664,12 @@ xrtRunClose(xrtRunHandle rhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 ert_cmd_state
@@ -2663,6 +2679,10 @@ xrtRunState(xrtRunHandle rhdl)
     return xdp::native::profiling_wrapper(__func__, [rhdl]{
       return api::xrtRunState(rhdl);
     });
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
@@ -2678,10 +2698,14 @@ xrtRunWait(xrtRunHandle rhdl)
       return api::xrtRunWait(rhdl, 0);
     });
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return ERT_CMD_STATE_ABORT;
   }
+  return ERT_CMD_STATE_ABORT;
 }
 
 ert_cmd_state
@@ -2692,10 +2716,14 @@ xrtRunWaitFor(xrtRunHandle rhdl, unsigned int timeout_ms)
       return api::xrtRunWait(rhdl, timeout_ms);
     });
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return ERT_CMD_STATE_ABORT;
   }
+  return ERT_CMD_STATE_ABORT;
 }
 
 int
@@ -2712,12 +2740,12 @@ xrtRunSetCallback(xrtRunHandle rhdl, ert_cmd_state state,
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2731,12 +2759,12 @@ xrtRunStart(xrtRunHandle rhdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2757,12 +2785,12 @@ xrtRunUpdateArg(xrtRunHandle rhdl, int index, ...)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2778,12 +2806,12 @@ xrtRunUpdateArgV(xrtRunHandle rhdl, int index, const void* value, size_t bytes)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2804,12 +2832,12 @@ xrtRunSetArg(xrtRunHandle rhdl, int index, ...)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2825,12 +2853,12 @@ xrtRunSetArgV(xrtRunHandle rhdl, int index, const void* value, size_t bytes)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -2846,12 +2874,12 @@ xrtRunGetArgV(xrtRunHandle rhdl, int index, void* value, size_t bytes)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get_code();
   }
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 void

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -678,10 +678,14 @@ xclGraphOpen(xclDeviceHandle handle, const uuid_t xclbin_uuid, const char* graph
   try {
     return api::xclGraphOpen(handle, xclbin_uuid, graph, am);
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return XRT_NULL_HANDLE;
   }
+  return XRT_NULL_HANDLE;
 }
 
 void
@@ -689,6 +693,10 @@ xclGraphClose(xclGraphHandle ghdl)
 {
   try {
     api::xclGraphClose(ghdl);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
@@ -704,12 +712,12 @@ xclGraphReset(xclGraphHandle ghdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 uint64_t
@@ -718,10 +726,14 @@ xclGraphTimeStamp(xclGraphHandle ghdl)
   try {
     return api::xclGraphTimeStamp(ghdl);
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -733,12 +745,12 @@ xclGraphRun(xclGraphHandle ghdl, int iterations)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -750,12 +762,12 @@ xclGraphWaitDone(xclGraphHandle ghdl, int timeout_ms)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -767,12 +779,12 @@ xclGraphWait(xclGraphHandle ghdl, uint64_t cycle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -784,12 +796,12 @@ xclGraphSuspend(xclGraphHandle ghdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -801,12 +813,12 @@ xclGraphResume(xclGraphHandle ghdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -818,12 +830,12 @@ xclGraphEnd(xclGraphHandle ghdl, uint64_t cycle)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -835,12 +847,12 @@ xclGraphUpdateRTP(xclGraphHandle ghdl, const char* port, const char* buffer, siz
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -852,12 +864,12 @@ xclGraphReadRTP(xclGraphHandle ghdl, const char *port, char *buffer, size_t size
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -869,12 +881,12 @@ xclAIEOpenContext(xclDeviceHandle handle, xrt::aie::access_mode am)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -886,12 +898,12 @@ xclSyncBOAIE(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xcl
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -901,10 +913,14 @@ xclResetAIEArray(xclDeviceHandle handle)
     api::xclResetAieArray(handle);
     return 0;
   }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get();
+  }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 ////////////////////////////////////////////////////////////////
@@ -934,12 +950,12 @@ xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum x
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 /**
@@ -959,12 +975,12 @@ xclGMIOWait(xclDeviceHandle handle, const char *gmioName)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return -1;
   }
+  return -1;
 }
 
 int
@@ -983,12 +999,12 @@ xclStartProfiling(xclDeviceHandle handle, int option, const char* port1Name, con
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = 0;
   }
+  return -1;
 }
 
 uint64_t
@@ -1007,12 +1023,12 @@ xclReadProfiling(xclDeviceHandle handle, int phdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = 0;
   }
+  return std::numeric_limits<uint64_t>::max();
 }
 
 int
@@ -1032,10 +1048,10 @@ xclStopProfiling(xclDeviceHandle handle, int phdl)
   }
   catch (const xrt_core::error& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = ex.get();
+    errno = ex.get();
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());
-    return errno = 0;
   }
+  return -1;
 }


### PR DESCRIPTION
The C-API implementation in most cases catches C++ exception, where
payload is POSIX error code

Set thread local errno to positive POSIX error code from exception
https://man7.org/linux/man-pages/man3/errno.3.html
https://en.cppreference.com/w/cpp/error/errc
Return -1 documented error return value to indicate error
(cherry picked from commit 6dc5c5f017b7a82e864901d07e5c61d847be472a)