### PR TITLE
Added support for cu interrupt in edge case (#5312)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -14,6 +14,7 @@
 
 #include "kds_core.h"
 #include "zocl_error.h"
+#include "zocl_ioctl.h"
 
 #define zocl_err(dev, fmt, args...)     \
 	dev_err(dev, "%s: "fmt, __func__, ##args)
@@ -157,5 +158,5 @@ struct drm_zocl_dev {
 	int			full_overlay_id;
 };
 
-int zocl_kds_update(struct drm_zocl_dev *zdev);
+int zocl_kds_update(struct drm_zocl_dev *zdev, struct drm_zocl_kds *cfg);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -511,7 +511,7 @@ static void zocl_detect_fa_cmdmem(struct drm_zocl_dev *zdev)
 	zdev->kds.cmdmem.size = size;
 }
 
-int zocl_kds_update(struct drm_zocl_dev *zdev)
+int zocl_kds_update(struct drm_zocl_dev *zdev, struct drm_zocl_kds *cfg)
 {
 	struct drm_zocl_bo *bo = NULL;
 	int i;
@@ -527,7 +527,9 @@ int zocl_kds_update(struct drm_zocl_dev *zdev)
 	}
 
 	zocl_detect_fa_cmdmem(zdev);
-	zdev->kds.cu_intr = 0;
+	
+	// Default supporting interrupt mode
+	zdev->kds.cu_intr_cap = 1;	
 
 	for (i = 0; i < zdev->kds.cu_mgmt.num_cus; i++) {
 		struct xrt_cu *xcu;
@@ -542,6 +544,13 @@ int zocl_kds_update(struct drm_zocl_dev *zdev)
 		}
 		update_cu_idx_in_apt(zdev, apt_idx, i);
 	}
+
+	// Check for polling mode and enable CU interrupt if polling_mode is false
+	if (cfg->polling)
+		zdev->kds.cu_intr = 0;
+	else
+		zdev->kds.cu_intr = 1;
+
 
 	return kds_cfg_update(&zdev->kds);
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -980,7 +980,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			write_lock(&zdev->attr_rwlock);
 			goto out0;
 		}
-		ret = zocl_kds_update(zdev);
+		ret = zocl_kds_update(zdev, &axlf_obj->kds_cfg);
 		if (ret) {
 			write_lock(&zdev->attr_rwlock);
 			goto out0;

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -387,6 +387,16 @@ struct kernel_info {
 };
 
 /**
+ * struct drm_zocl_kds - KDS user configuration
+ *
+ * @polling:	poll for command completion
+ */
+struct drm_zocl_kds {
+	uint32_t polling:1;
+	uint32_t unused:31;
+};
+
+/**
  * struct drm_zocl_axlf - Read xclbin (AXLF) device image and map CUs (experimental)
  * used with DRM_IOCTL_ZOCL_READ_AXLF ioctl
  *
@@ -396,10 +406,11 @@ struct kernel_info {
  * @za_kernels:	pointer of argument array
  **/
 struct drm_zocl_axlf {
-	struct axlf 	*za_xclbin_ptr;
-	uint32_t	za_flags;
-	int		za_ksize;
-	char		*za_kernels;
+	struct axlf 		*za_xclbin_ptr;
+	uint32_t		za_flags;
+	int			za_ksize;
+	char			*za_kernels;
+	struct drm_zocl_kds	kds_cfg;
 };
 
 #define	ZOCL_MAX_NAME_LENGTH		32

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -534,6 +534,7 @@ xclLoadAxlf(const axlf *buffer)
       .za_kernels = NULL,
     };
 
+  axlf_obj.kds_cfg.polling = xrt_core::config::get_ert_polling();
   std::vector<char> krnl_binary;
   if (!xrt_core::xclbin::is_pdi_only(buffer)) {
     auto kernels = xrt_core::xclbin::get_kernels(buffer);


### PR DESCRIPTION
### This one is the cherry-pick from master branch for this issue:

Added support for cu interrupt enabling.
This PR has the following changes:

Added cu interrupt support in zocl
Added shim layer support to pass polling flag to userspace to zocl