### PR TITLE
CR-1101115: Fixing a som use-case where app wants to control CU (Regression: new KDS issue)

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -118,10 +118,13 @@ static int cu_probe(struct platform_device *pdev)
 		goto err1;
 	}
 
-	args = vmalloc(sizeof(struct xrt_cu_arg) * krnl_info->anums);
-	if (!args) {
-		err = -ENOMEM;
-		goto err1;
+	if(krnl_info->anums)
+	{
+		args = vmalloc(sizeof(struct xrt_cu_arg) * krnl_info->anums);
+		if (!args) {
+			err = -ENOMEM;
+			goto err1;
+		}
 	}
 
 	for (i = 0; i < krnl_info->anums; i++) {


### PR DESCRIPTION
SOM's Kernels have zero arguments but they have AXI-LITE control on kernel. They are using xclRegRead/xclRegWrite to control their kernels. 
Things are working in old KDS, CU subdevice is not getting created in new KDS. Fixed the issue by considering above case aswell.