### PR TITLE
Added XGQ hw emu load xclbin support

### DIFF
--- a/src/runtime_src/core/include/xgq.h
+++ b/src/runtime_src/core/include/xgq.h
@@ -63,6 +63,16 @@ enum xrt_cmd_opcode {
 	XRT_CMD_OP_EXIT_ERT		= 0x201,
 };
 
+enum xrt_cmd_addr_type {
+	XRT_CMD_ADD_TYPE_DEVICE		= 0x0,
+	XRT_CMD_ADD_TYPE_SLAVEBRIDGE	= 0x1,
+};
+
+enum xrt_cmd_state {
+	XRT_CMD_STATE_COMPLETED		= 0x0,
+	XRT_CMD_STATE_ERROR		= 0x1,
+};
+
 /**
  * struct xrt_sub_queue_entry: XGQ submission queue entry format
  *
@@ -124,7 +134,35 @@ struct xrt_com_queue_entry {
 };
 
 #define XGQ_SUB_HEADER_SIZE	(sizeof(struct xrt_sub_queue_entry) - 4)
-#define	XRT_COM_Q1_SLOT_SIZE	(sizeof(struct xrt_com_queue_entry))
+#define XRT_COM_Q1_SLOT_SIZE	(sizeof(struct xrt_com_queue_entry))
+
+/**
+ * struct xrt_cmd_load_xclbin: load XCLBIN command
+ *
+ * @address:	XCLBIN address
+ * @size:	XCLBIN size in Byte
+ * @addr_type:	Address tyep
+ *
+ * This command is used to load XCLBIN to device through XGQ.
+ * This is an indirect command that XCLBIN blob's address is
+ * embedded.
+ */
+struct xrt_cmd_load_xclbin {
+	union {
+		struct {
+			uint32_t opcode:16; /* [15-0]   */
+			uint32_t count:15;  /* [30-16] */
+			uint32_t state:1;   /* [31] */
+			uint16_t cid;
+			uint16_t rsvd;
+		};
+		uint32_t header[2];
+	};
+	uint64_t address;
+	uint32_t size;
+	uint32_t addr_type:4;
+	uint32_t rsvd1:28;
+};
 
 struct xrt_cmd_configure {
 	union {

--- a/src/runtime_src/core/include/xgq.h
+++ b/src/runtime_src/core/include/xgq.h
@@ -44,12 +44,12 @@
 # include <stdint.h>
 #endif
 
-#define XRT_SUB_Q1_SLOT_SIZE	512
-#define XRT_QUEUE1_SLOT_NUM	4
-#define XRT_QUEUE1_SLOT_MASK	(XRT_QUEUE1_SLOT_NUM - 1)
+#define XRT_SUB_Q1_SLOT_SIZE	512	// NOLINT
+#define XRT_QUEUE1_SLOT_NUM	4	// NOLINT
+#define XRT_QUEUE1_SLOT_MASK	(XRT_QUEUE1_SLOT_NUM - 1)	// NOLINT
 
-#define XRT_Q1_SUB_SIZE		(XRT_SUB_Q1_SLOT_SIZE * XRT_QUEUE1_SLOT_NUM)
-#define XRT_Q1_COM_SIZE		(XRT_COM_Q1_SLOT_SIZE * XRT_QUEUE1_SLOT_NUM)
+#define XRT_Q1_SUB_SIZE		(XRT_SUB_Q1_SLOT_SIZE * XRT_QUEUE1_SLOT_NUM) // NOLINT
+#define XRT_Q1_COM_SIZE		(XRT_COM_Q1_SLOT_SIZE * XRT_QUEUE1_SLOT_NUM) // NOLINT
 
 enum xrt_cmd_opcode {
 	XRT_CMD_OP_LOAD_XCLBIN		= 0x0,
@@ -95,9 +95,9 @@ struct xrt_sub_queue_entry {
 			uint16_t cid;
 			uint16_t rsvd;
 		};
-		uint32_t header[2];
+		uint32_t header[2]; // NONLINT
 	};
-	uint32_t data[1];
+	uint32_t data[1]; // NOLINT
 };
 
 /**
@@ -129,12 +129,12 @@ struct xrt_com_queue_entry {
 			uint16_t cid;
 			uint16_t cstate;
 		};
-		uint32_t data[4];
+		uint32_t data[4]; // NOLINT
 	};
 };
 
-#define XGQ_SUB_HEADER_SIZE	(sizeof(struct xrt_sub_queue_entry) - 4)
-#define XRT_COM_Q1_SLOT_SIZE	(sizeof(struct xrt_com_queue_entry))
+#define XGQ_SUB_HEADER_SIZE	(sizeof(struct xrt_sub_queue_entry) - 4) // NOLINT
+#define XRT_COM_Q1_SLOT_SIZE	(sizeof(struct xrt_com_queue_entry)) // NOLINT
 
 /**
  * struct xrt_cmd_load_xclbin: load XCLBIN command
@@ -156,7 +156,7 @@ struct xrt_cmd_load_xclbin {
 			uint16_t cid;
 			uint16_t rsvd;
 		};
-		uint32_t header[2];
+		uint32_t header[2]; // NOLINT
 	};
 	uint64_t address;
 	uint32_t size;
@@ -173,9 +173,9 @@ struct xrt_cmd_configure {
 			uint16_t cid;
 			uint16_t rsvd;
 		};
-		uint32_t header[2];
+		uint32_t header[2]; // NOLINT
 	};
-	uint32_t data[1];
+	uint32_t data[1]; // NOLINT
 };
 
 /**
@@ -196,10 +196,10 @@ struct xrt_cmd_start_cuidx {
 			uint16_t cid;
 			uint16_t rsvd;
 		};
-		uint32_t header[2];
+		uint32_t header[2]; // NOLINT
 	};
 	uint32_t cu_idx;	/* cu index to start */
-	uint32_t data[1];
+	uint32_t data[1]; // NOLINT
 };
 
 struct xrt_cmd_exit_ert {
@@ -211,7 +211,7 @@ struct xrt_cmd_exit_ert {
 			uint16_t cid;
 			uint16_t rsvd;
 		};
-		uint32_t header[2];
+		uint32_t header[2]; // NOLINT
 	};
 };
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -414,6 +414,9 @@ namespace xclhwemhal2 {
         m_scheduler = new hwemu::xocl_scheduler(this);
     } else if (xclemulation::config::getInstance()->isXgqMode()) {
         m_xgq = new hwemu::xocl_xgq(this);
+        if (m_xgq) {
+            returnValue = m_xgq->load_xclbin(pdi, pdiSize);
+        }
     } else {
         mCore = new exec_core;
         mMBSch = new MBScheduler(this);
@@ -2218,6 +2221,11 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       }
     }
     return 0;
+  }
+
+  std::shared_ptr<xrt_core::device> HwEmShim::getMCoreDevice()
+  {
+    return mCoreDevice;
   }
 
   bool HwEmShim::isLegacyErt()

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -232,6 +232,7 @@ using addr_type = uint64_t;
       unsigned int getDsaVersion();
       bool isCdmaEnabled();
       uint64_t getCdmaBaseAddress(unsigned int index);
+      std::shared_ptr<xrt_core::device> getMCoreDevice();
 
       bool isXPR()           { return bXPR; }
       void setXPR(bool _xpr) { bXPR = _xpr; }

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.cxx
@@ -260,7 +260,7 @@ namespace hwemu {
       case ERT_CONFIGURE:
         {
           sq_buf.resize((payload_size() + XGQ_SUB_HEADER_SIZE) / sizeof(uint32_t));
-          xrt_cmd_configure *cmdp = reinterpret_cast<xrt_cmd_configure *>(sq_buf.data());
+          auto *cmdp = reinterpret_cast<xrt_cmd_configure *>(sq_buf.data());
 
           cmdp->opcode = XRT_CMD_OP_CONFIGURE;
           cmdp->state = 1;
@@ -273,7 +273,7 @@ namespace hwemu {
       case ERT_START_CU:
         {
           sq_buf.resize((payload_size() + XGQ_SUB_HEADER_SIZE) / sizeof(uint32_t));
-          xrt_cmd_start_cuidx *cmdp = reinterpret_cast<xrt_cmd_start_cuidx *>(sq_buf.data());
+          auto *cmdp = reinterpret_cast<xrt_cmd_start_cuidx *>(sq_buf.data());
 
           cmdp->opcode = XRT_CMD_OP_START_PL_CUIDX;
           cmdp->state = 1;
@@ -288,7 +288,7 @@ namespace hwemu {
       case ERT_EXIT:
         {
           sq_buf.resize((payload_size() + XGQ_SUB_HEADER_SIZE) / sizeof(uint32_t));
-          xrt_cmd_exit_ert *cmdp = reinterpret_cast<xrt_cmd_exit_ert*>(sq_buf.data());
+          auto *cmdp = reinterpret_cast<xrt_cmd_exit_ert*>(sq_buf.data());
 
           cmdp->opcode = XRT_CMD_OP_EXIT_ERT;
           cmdp->state = 1;
@@ -309,10 +309,10 @@ namespace hwemu {
   {
     auto data = xbo.map();
     memcpy(data, buf, size);
-    uint32_t paddr = static_cast<uint32_t>(xbo.address());
+    auto paddr = static_cast<uint32_t>(xbo.address());
 
     sq_buf.resize(sizeof(xrt_cmd_load_xclbin));
-    xrt_cmd_load_xclbin *cmdp = reinterpret_cast<xrt_cmd_load_xclbin *>(sq_buf.data());
+    auto *cmdp = reinterpret_cast<xrt_cmd_load_xclbin *>(sq_buf.data());
 
     cmdp->opcode = XRT_CMD_OP_LOAD_XCLBIN;
     cmdp->state = 1;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.h
@@ -149,13 +149,21 @@ namespace hwemu {
 
       uint32_t    opcode();
       void        set_state(enum ert_cmd_state state);
-      int         convert_bo(xclemulation::drm_xocl_bo *bo);
       uint32_t    payload_size();
+      bool        is_ertpkt();
+
+      int         convert_bo(xclemulation::drm_xocl_bo *bo);
+      int         load_xclbin(xrt::bo& xbo, char *buf, size_t size);
+
       uint32_t    xcmd_size();
 
       uint16_t              cmdid;
       std::vector<uint32_t> sq_buf;
       struct ert_packet     *ert_pkt;
+      int                   rval;
+
+      std::mutex              cmd_mutex;
+      std::condition_variable cmd_cv;
 
       //! Static member varibale
       //  to get the unique ID for each command
@@ -175,6 +183,7 @@ namespace hwemu {
       ~xocl_xgq();
 
       int    add_exec_buffer(xclemulation::drm_xocl_bo *buf);
+      int    load_xclbin(char *buf, size_t size);
 
       // TODO support multiple queues
       xgq_queue queue;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.h
@@ -46,6 +46,7 @@
 #include <thread>
 #include <vector>
 
+#include "core/include/xrt/xrt_bo.h"
 #include "em_defines.h"
 #include "ert.h"
 #include "xgq.h"


### PR DESCRIPTION
Enable XGQ to load XCLBIN to device. Today, we just load the PDI section.

A couple of minor fix
1) add comment about tail pointer definition
2) add a member function for HwEmShim to get mCoreDevice (this is for using xrt::device to create xrt::bo object)
3) add a few logs

Note, error handling will be added in a future PR. Currently we only return COMPLETED or ERROR