### PR TITLE
CR-1093969 support older shell kernels in iops test (#5337)

### DIFF
--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -198,8 +198,13 @@ void runTestThread(arg_t &arg)
     // CU name shoue be "hello:hello_1" or "verify:verify_1"
     std::string cu_name = krnl.name + ":" + krnl.name + "_1";
     krnl.cu_idx = xclIPName2Index(handle, cu_name.c_str());
-    if (krnl.cu_idx < 0)
-        throw std::runtime_error(cu_name + " not found");
+    if (krnl.cu_idx < 0) {
+        // hello:hello_cu0 is U2 shell special
+        cu_name = krnl.name + ":" + krnl.name + "_cu0";
+        krnl.cu_idx = xclIPName2Index(handle, cu_name.c_str());
+        if (krnl.cu_idx < 0)
+            throw std::runtime_error(cu_name + " not found");
+    }
 
     if (xclOpenContext(handle, uuid, krnl.cu_idx, true))
         throw std::runtime_error("Cound not open context");


### PR DESCRIPTION
* CR-1093969 support older shell kernels in iops test

U2 older shell (xilinx_u2_gen3x4_xdma_gc_base_1) has hello kernel's
cu name defined as hello_cu0. So, support this case also in iops test

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* fix review comment

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>