### PR TITLE
Various CRs for 2021.1

### DIFF
--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -81,7 +81,7 @@ mac_addresses(const xrt_core::device * dev)
     }
     for (const auto& a : mac_addr) {
       boost::property_tree::ptree addr;
-      if (a.empty() || a.compare("FF:FF:FF:FF:FF:FF") != 0) {
+      if (!a.empty() && a.compare("FF:FF:FF:FF:FF:FF") != 0) {
         addr.add("address", a);
         ptree.push_back(std::make_pair("", addr));
       }

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -723,9 +723,11 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       auto is_ready = xrt_core::device_query<xrt_core::query::is_ready>(device);
 
       for (auto &report : reportsToProcess) {
-        if (report->isDeviceRequired() == false || !is_ready)
+        if (report->isDeviceRequired() == false)
           continue;
-
+        //if the device is not in factory mode and is ready to use, continue to create reports
+        if(!is_mfg && !is_ready)
+          continue;
         boost::property_tree::ptree ptReport;
         report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
 

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -88,7 +88,7 @@ mac_addresses(const xrt_core::device * dev)
     catch (...) {  }
     for (const auto& a : mac_addr) {
       boost::property_tree::ptree addr;
-      if (a.empty() || a.compare("FF:FF:FF:FF:FF:FF") != 0) {
+      if (!a.empty() && a.compare("FF:FF:FF:FF:FF:FF") != 0) {
         addr.add("address", a);
         ptree.push_back(std::make_pair("", addr));
       }
@@ -377,6 +377,7 @@ ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/,
     
     for(auto & km : macs) 
       formattedStr += boost::str(fmtBasic % (formattedStr.empty() ? "Mac Address" : "") % km.second.get<std::string>("address", "N/A"));
+    _output << formattedStr << std::endl;
   }
 
   _output << shell_status(_pt.get<bool>("platform.status.shell", false), 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -252,6 +252,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
 
   std::ostringstream os_stdout;
   std::ostringstream os_stderr;
+  constexpr static int MAX_TEST_DURATION = 300; //5 minutes
 
   if(json_exists()) {
     //map old testcase names to new testcase names
@@ -285,7 +286,6 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     std::vector<std::string> args = { test_dir.parent_path().string(), 
                                       "-d", xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(_dev)) };
     try {
-      constexpr static int MAX_TEST_DURATION = 300; //5 minutes
       int exit_code = XBU::runScript("sh", xrtTestCasePath, args, "Running Test", "Test Duration", MAX_TEST_DURATION, os_stdout, os_stderr, true);
       if (exit_code == EOPNOTSUPP) {
         _ptTest.put("status", "skipped");
@@ -320,7 +320,6 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
                                       "-d", std::to_string(_dev.get()->get_device_id()) };
     int exit_code;    
     try {
-      constexpr static int MAX_TEST_DURATION = 60;
       if (py.find(".exe") != std::string::npos)
         exit_code = XBU::runScript("", xrtTestCasePath, args, "Running Test", "Test Duration:", MAX_TEST_DURATION, os_stdout, os_stderr, true);
       else
@@ -995,14 +994,6 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
     return;
   }
 
-  int nodma = xrt_core::device_query<xrt_core::query::nodma>(_dev);
-
-  if (nodma == 1 ) {
-    logger(_ptTest, "Details","M2M Test is not available");
-    _ptTest.put("status", "skipped");
-    return;
-  }
-
   std::vector<mem_data> used_banks;
   const size_t bo_size = 256L * 1024 * 1024;
   auto membuf = xrt_core::device_query<xrt_core::query::mem_topology_raw>(_dev);
@@ -1038,17 +1029,6 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  uint32_t no_dma = 0;
-  try {
-    no_dma = xrt_core::device_query<xrt_core::query::nodma>(_dev);
-  } catch(...) { }
-
-  if(no_dma != 0) {
-    logger(_ptTest, "Details", "Not supported on NoDMA platform");
-    _ptTest.put("status", "skipped");
-    return;
-  }
-
   uint64_t host_mem_size = 0;
   try {
     host_mem_size = xrt_core::device_query<xrt_core::query::host_mem_size>(_dev);


### PR DESCRIPTION
- CR-1092183 ASTeR - TC13 Manu Data : xbmgmt2 examine missing info
- CR-1101832 ASTeR TS 1 - xbmgmt examine format is missing information with a card is in factory state
- CR-1099056  xbutil2 validate bandwidth kernel times out on U50 gen3x16 shells
- CR-1101891 xbutil2 - "Host memory bandwidth test" for u50 nodma validate is not ran (Regression 2.11.610 - 614)