### PR TITLE
Move XGQ ring buffer base address

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -414,7 +414,7 @@ namespace xclhwemhal2 {
         m_scheduler = new hwemu::xocl_scheduler(this);
     } else if (xclemulation::config::getInstance()->isXgqMode()) {
         m_xgq = new hwemu::xocl_xgq(this);
-        if (m_xgq) {
+        if (m_xgq && pdi && pdiSize > 0) {
             returnValue = m_xgq->load_xclbin(pdi, pdiSize);
         }
     } else {

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/xgq_hwemu.h
@@ -55,11 +55,11 @@ namespace xclhwemhal2 {
   class HwEmShim;
 }
 
-#define XRT_QUEUE1_SUB_BASE    0x0
-#define XRT_QUEUE1_COM_BASE    (XRT_QUEUE1_SUB_BASE + XRT_SUB_Q1_SLOT_SIZE * XRT_QUEUE1_SLOT_NUM)
+constexpr uint64_t XRT_QUEUE1_SUB_BASE = 0x7B000; // hard code for now 512K - 20K
+constexpr uint64_t XRT_QUEUE1_COM_BASE = (XRT_QUEUE1_SUB_BASE + XRT_SUB_Q1_SLOT_SIZE * XRT_QUEUE1_SLOT_NUM);
 
-#define XRT_XGQ_SUB_BASE       0x1040000
-#define XRT_XGQ_COM_BASE       0x1030000
+constexpr uint64_t XRT_XGQ_SUB_BASE = 0x1040000;
+constexpr uint64_t XRT_XGQ_COM_BASE = 0x1030000;
 
 namespace hwemu {
 


### PR DESCRIPTION
1. do not load PDI if there is no one
2. move XGQ ring buffer at high address
3. fix clang-tidy issue