### PR TITLE
CR-1102097 - Fix segmentation fault in aie_only _xclbin load

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -59,6 +59,9 @@ is_sw_emulation()
 static std::vector<size_t>
 compute_memidx_encoding(const ::mem_topology* mem_topology)
 {
+  if ( mem_topology == nullptr )
+    return {};
+
   // The resulting encoding midx -> eidx
   std::vector<size_t> enc(mem_topology->m_count, std::numeric_limits<size_t>::max());
 


### PR DESCRIPTION
> Added check to return empty vector when mem_topology section is not there, this happens with aie_only_xclbin