### PR TITLE
CR-1100269 [AIE ERROR]: Invalid Device Instance - multi proc AIE test…

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -32,10 +32,10 @@
 
 namespace zynqaie {
 
-XAie_InstDeclare(DevInst, &ConfigPtr);   // Declare global device instance
-
 Aie::Aie(const std::shared_ptr<xrt_core::device>& device)
 {
+    DevInst = {0};
+    devInst = nullptr;
     adf::driver_config driver_config = xrt_core::edge::aie::get_driver_config(device.get());
 
     XAie_SetupConfig(ConfigPtr,

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -126,7 +126,15 @@ private:
     int fd;
     xrt::aie::access_mode access_mode = xrt::aie::access_mode::none;
 
-    XAie_DevInst* devInst;         // AIE Device Instance
+    XAie_DevInst* devInst;         // AIE Device Instance pointer
+
+    // XAie_InstDeclare(DevInst, &ConfigPtr) is the interface
+    // to initialize DevInst by the AIE driver. But it does not
+    // work here because we can not make it as a member of Aie
+    // class to maintain its life cylce. So we declair it here.
+    //
+    // Note: need to evolve when XAie_InstDecalare() evolves.
+    XAie_DevInst DevInst;
 
     std::vector<EventRecord> eventRecords;
 


### PR DESCRIPTION
DevInst was a global variable which was created by AIE driver API XAie_InstDeclare(DevInst, &ConfigPtr). But under multi-process, each process should have its own DevInst which has the same life cycle of Aie class. So we can not use XAie_InstDeclare to create DevInst but have to define a member in Aie class.

@larry9523 , FYI, cherry-picked your change to 2021.1 as we need to send final commit id to Petalinux tomorrow.
