### PR TITLE
Update tools deprecation message

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -144,9 +144,9 @@ if [[ ${XRT_PROG} == "xbmgmt" ]] && [[ -t 1 ]]; then
     documentation page:
     
     https://xilinx.github.io/XRT/master/html/xbtools_map.html
- 
-    Please do update the scripts and tools to no longer use this
-    deprecated legacy sub-command and/or option."
+
+    Please update your scripts and tools to use the next generation
+    sub-commands and options."
     echo "---------------------------------------------------------------------"
 fi
 

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -134,7 +134,19 @@ fi
 # Friendly message if running in a terminal
 if [[ ${XRT_PROG} == "xbmgmt" ]] && [[ -t 1 ]]; then
     echo "---------------------------------------------------------------------"
-    echo "Legacy xbmgmt is being deprecated, consider moving to next-gen xbmgmt"
+    echo "Deprecation Warning:
+    The given legacy sub-command and/or option has been deprecated
+    to be obsoleted in the next release.
+ 
+    Further information regarding the legacy deprecated sub-commands
+    and options along with their mappings to the next generation
+    sub-commands and options can be found on the Xilinx Runtime (XRT)
+    documentation page:
+    
+    https://xilinx.github.io/XRT/master/html/xbtools_map.html
+ 
+    Please do update the scripts and tools to no longer use this
+    deprecated legacy sub-command and/or option."
     echo "---------------------------------------------------------------------"
 fi
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -216,9 +216,9 @@ if [[ ${XRT_PROG} == "xbutil" ]] && [[ -t 1 ]]; then
     documentation page:
     
     https://xilinx.github.io/XRT/master/html/xbtools_map.html
- 
-    Please do update the scripts and tools to no longer use this
-    deprecated legacy sub-command and/or option."
+
+    Please update your scripts and tools to use the next generation
+    sub-commands and options."
     echo "---------------------------------------------------------------------"
 fi
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -206,7 +206,19 @@ fi
 # Friendly message if running in a terminal
 if [[ ${XRT_PROG} == "xbutil" ]] && [[ -t 1 ]]; then
     echo "---------------------------------------------------------------------"
-    echo "Legacy xbutil is being deprecated, consider moving to next-gen xbutil"
+    echo "Deprecation Warning:
+    The given legacy sub-command and/or option has been deprecated
+    to be obsoleted in the next release.
+ 
+    Further information regarding the legacy deprecated sub-commands
+    and options along with their mappings to the next generation
+    sub-commands and options can be found on the Xilinx Runtime (XRT)
+    documentation page:
+    
+    https://xilinx.github.io/XRT/master/html/xbtools_map.html
+ 
+    Please do update the scripts and tools to no longer use this
+    deprecated legacy sub-command and/or option."
     echo "---------------------------------------------------------------------"
 fi
 


### PR DESCRIPTION
CR-1101920 xrt 2.0 xbutil/xbmgmt deprecation message misleading
```
$ xbutil version
---------------------------------------------------------------------
Deprecation Warning:
    The given legacy sub-command and/or option has been deprecated
    to be obsoleted in the next release.

    Further information regarding the legacy deprecated sub-commands
    and options along with their mappings to the next generation
    sub-commands and options can be found on the Xilinx Runtime (XRT)
    documentation page:

    https://xilinx.github.io/XRT/master/html/xbtools_map.html

    Please update your scripts and tools to use the next generation
    sub-commands and options.
---------------------------------------------------------------------
       XRT Build Version: 2.12.0
    Build Version Branch: dep-msg
      Build Version Hash: 8150d5fd899f19965c6c453d4c6f7c5494d95a6c
 Build Version Hash Date: Wed, 2 Jun 2021 14:15:24 -0700
      Build Version Date: Thu, 03 Jun 2021 12:59:41 -0700
                    XOCL: 2.12.0,595cb14b5270a409343e63eff6fa6d876acf417a
                 XCLMGMT: 2.12.0,595cb14b5270a409343e63eff6fa6d876acf417a

```