### PR TITLE
CentOS8 cmake3 no longer exists

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,15 +6,19 @@ OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
+CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{print $1}'`
 CPU=`uname -m`
 
-if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then
-    CMAKE=cmake3
-    if [[ ! -x "$(command -v $CMAKE)" ]]; then
-        echo "$CMAKE is not installed, please run xrtdeps.sh"
-        exit 1
+if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
+    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then
+        CMAKE=cmake3
+        if [[ ! -x "$(command -v $CMAKE)" ]]; then
+            echo "$CMAKE is not installed, please run xrtdeps.sh"
+            exit 1
+        fi
     fi
 fi
+
 
 if [[ $CPU == "aarch64" ]] && [[ $OSDIST == "ubuntu" ]]; then
     # On ARM64 Ubuntu use GCC version 8 if available since default

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -84,7 +84,6 @@ rh_package_list()
      ocl-icd \
      ocl-icd-devel \
      opencl-headers \
-     opencv \
      openssl-devel \
      pciutils \
      perl \
@@ -431,8 +430,6 @@ prep_centos8()
     	 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 	     yum check-update
     fi
-    echo "Installing cmake3 from EPEL repository..."
-    yum install -y cmake3
     echo "Enabling PowerTools repo for CentOS8 ..."
     yum install -y dnf-plugins-core
     yum config-manager --set-enabled PowerTools


### PR DESCRIPTION
Starting with latest CentOS8 updates the default 'cmake' is 3.18.2 and
cmake3 as a link to cmake no longer exists.

This PR changes changes build.sh to check major version of CMake
before complaining that cmake3 is not installed.

xrtdeps.sh is changed for CentOS8 to no longer attempt yum install of
cmake3.  Also removed package dependency on opencv which no longer
exists.