### PR TITLE
Fix build failure for CentOS 8.* OS versions

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,15 +6,19 @@ OSDIST=`grep '^ID=' /etc/os-release | awk -F= '{print $2}' | tr -d '"'`
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 CORE=`grep -c ^processor /proc/cpuinfo`
 CMAKE=cmake
+CMAKE_MAJOR_VERSION=`cmake --version | head -n 1 | awk '{print $3}' |awk -F. '{print $1}'`
 CPU=`uname -m`
 
-if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then
-    CMAKE=cmake3
-    if [[ ! -x "$(command -v $CMAKE)" ]]; then
-        echo "$CMAKE is not installed, please run xrtdeps.sh"
-        exit 1
+if [[ $CMAKE_MAJOR_VERSION != 3 ]]; then
+    if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "amzn" ]] || [[ $OSDIST == "rhel" ]] || [[ $OSDIST == "fedora" ]]; then
+        CMAKE=cmake3
+        if [[ ! -x "$(command -v $CMAKE)" ]]; then
+            echo "$CMAKE is not installed, please run xrtdeps.sh"
+            exit 1
+        fi
     fi
 fi
+
 
 if [[ $CPU == "aarch64" ]] && [[ $OSDIST == "ubuntu" ]]; then
     # On ARM64 Ubuntu use GCC version 8 if available since default

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -114,14 +114,14 @@ rh_package_list()
 
         RH_LIST+=(systemd-devel)
 
-        if [ $FLAVOR != "centos" ]; then
-            RH_LIST+=(\
-            opencv \
-            )
-        else
-            #fix cmake issue in centos 8.* 
+        if [ $FLAVOR == "centos" ]; then
+            #fix cmake issue in centos 8.*
             RH_LIST+=(\
             libarchive \
+            )
+        else
+            RH_LIST+=(\
+            opencv \
             )
         fi
 

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -447,7 +447,7 @@ prep_centos8()
     echo "Enabling PowerTools and AppStream repo for CentOS8 ..."
     #minor version of CentOs
     MINOR=`cat /etc/centos-release | awk -F. '{ print $2 }'`
-    if [ $MINOR -gt "1" ]; then
+    if [ $MINOR -gt "2" ]; then
         yum config-manager --set-enabled powertools
         yum config-manager --set-enabled appstream
     else

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -84,7 +84,6 @@ rh_package_list()
      ocl-icd \
      ocl-icd-devel \
      opencl-headers \
-     opencv \
      openssl-devel \
      pciutils \
      perl \
@@ -111,10 +110,20 @@ rh_package_list()
         )
     fi
 
-    # Centos8
     if [ $MAJOR == 8 ]; then
 
         RH_LIST+=(systemd-devel)
+
+        if [ $FLAVOR != "centos" ]; then
+            RH_LIST+=(\
+            opencv \
+            )
+        else
+            #fix cmake issue in centos 8.* 
+            RH_LIST+=(\
+            libarchive \
+            )
+        fi
 
         if [ $docker == 0 ]; then
             RH_LIST+=(\
@@ -130,6 +139,7 @@ rh_package_list()
          libudev-devel \
          kernel-devel-$(uname -r) \
          kernel-headers-$(uname -r) \
+         opencv \
          openssl-static \
          protobuf-static \
         )
@@ -415,8 +425,8 @@ prep_rhel8()
     echo "Enabling EPEL repository..."
     rpm -q --quiet epel-release
     if [ $? != 0 ]; then
-    	 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-	 yum check-update
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        yum check-update
     fi
 
     echo "Enabling CodeReady-Builder repository..."
@@ -428,15 +438,23 @@ prep_centos8()
     echo "Enabling EPEL repository..."
     rpm -q --quiet epel-release
     if [ $? != 0 ]; then
-    	 yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-	     yum check-update
+        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        yum check-update
     fi
-    echo "Installing cmake3 from EPEL repository..."
-    yum install -y cmake3
-    echo "Enabling PowerTools repo for CentOS8 ..."
+
     yum install -y dnf-plugins-core
-    yum config-manager --set-enabled PowerTools
-    yum config-manager --set-enabled AppStream
+
+    echo "Enabling PowerTools and AppStream repo for CentOS8 ..."
+    #minor version of CentOs
+    MINOR=`cat /etc/centos-release | awk -F. '{ print $2 }'`
+    if [ $MINOR -gt "1" ]; then
+        yum config-manager --set-enabled powertools
+        yum config-manager --set-enabled appstream
+    else
+        yum config-manager --set-enabled PowerTools
+        yum config-manager --set-enabled AppStream
+    fi
+      
 }
 
 prep_centos()


### PR DESCRIPTION
> cmake3 is no longer available in CentOs 8.* versions
> Latest cmake has a dependency on libarchive package which is added in dependency list
> Repos AppStream and PowerTools name is changed for CentOs versions > 8.1 as appstream and powertools. Added a fix for this change
> Removed opencv package for CentOs 8.* versions as it is not available