### PR TITLE
CR-1101062 separate option for old KDS

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -436,6 +436,16 @@ get_xma_cpu_mode()
   return value;
 }
 
+/**
+ * Use XMA with old KDS; Default for XMA is to assume KDS2.0
+ */
+inline bool
+get_xma_kds_old()
+{
+  static bool value = detail::get_bool_value("Runtime.xma_kds_old",false);
+  return value;
+}
+
 inline bool
 get_enable_flat()
 {

--- a/src/xma/include/lib/xmaapi.h
+++ b/src/xma/include/lib/xmaapi.h
@@ -42,6 +42,7 @@ typedef struct XmaSingleton
 {
     XmaHwCfg          hwcfg;
     bool              xma_initialized;
+    bool              kds_old;
     uint32_t          cpu_mode;
     std::mutex            m_mutex;
     std::atomic<uint32_t> num_decoders;

--- a/src/xma/include/lib/xmahw_lib.h
+++ b/src/xma/include/lib/xmahw_lib.h
@@ -189,6 +189,7 @@ typedef struct XmaHwSessionPrivate
     std::vector<uint32_t> execbo_to_check;
     bool     using_work_item_done;
     bool     using_cu_cmd_status;
+    std::atomic<bool> cmd_submit_locked;
     std::atomic<bool> execbo_locked;
     std::vector<XmaHwExecBO> kernel_execbos;
     int32_t    num_execbo_allocated;
@@ -212,6 +213,7 @@ typedef struct XmaHwSessionPrivate
     cmd_idle_ticks = 0;
     cmd_busy_ticks_tmp = 0;
     cmd_idle_ticks_tmp = 0;
+    cmd_submit_locked = false;
     execbo_locked = false;
     num_execbo_allocated = -1;
     using_work_item_done = false;

--- a/src/xma/include/lib/xmahw_lib.h
+++ b/src/xma/include/lib/xmahw_lib.h
@@ -189,7 +189,6 @@ typedef struct XmaHwSessionPrivate
     std::vector<uint32_t> execbo_to_check;
     bool     using_work_item_done;
     bool     using_cu_cmd_status;
-    std::atomic<bool> cmd_submit_locked;
     std::atomic<bool> execbo_locked;
     std::vector<XmaHwExecBO> kernel_execbos;
     int32_t    num_execbo_allocated;
@@ -213,7 +212,6 @@ typedef struct XmaHwSessionPrivate
     cmd_idle_ticks = 0;
     cmd_busy_ticks_tmp = 0;
     cmd_idle_ticks_tmp = 0;
-    cmd_submit_locked = false;
     execbo_locked = false;
     num_execbo_allocated = -1;
     using_work_item_done = false;

--- a/src/xma/src/xmaapi/xmaapi.cpp
+++ b/src/xma/src/xmaapi/xmaapi.cpp
@@ -426,6 +426,11 @@ int32_t xma_initialize(XmaXclbinParameter *devXclbins, int32_t num_parms)
             break;
     }
 
+    g_xma_singleton->kds_old = xrt_core::config::get_xma_kds_old();
+    if (g_xma_singleton->kds_old)
+        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA for old KDS.");
+    else
+        xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA for KDS 2.0. Default mode.");
     g_xma_singleton->cpu_mode = xrt_core::config::get_xma_cpu_mode();
     xma_logmsg(XMA_DEBUG_LOG, XMAAPI_MOD, "XMA CPU Mode is: %d", g_xma_singleton->cpu_mode);
 

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -546,7 +546,7 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     //With KDS2.0 ensure no outstanding command
     while (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
         std::unique_lock<std::mutex> lk(priv1->m_mutex);
-        priv1->work_item_done_1plus.wait_for(lk, std::chrono::milliseconds(1));
+        priv1->kernel_done_or_free.wait_for(lk, std::chrono::milliseconds(1));
     }
 
     // Find an available execBO buffer
@@ -788,7 +788,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     //With KDS2.0 ensure no outstanding command
     while (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
         std::unique_lock<std::mutex> lk(priv1->m_mutex);
-        priv1->work_item_done_1plus.wait_for(lk, std::chrono::milliseconds(1));
+        priv1->kernel_done_or_free.wait_for(lk, std::chrono::milliseconds(1));
     }
 
     // Find an available execBO buffer

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -544,6 +544,10 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     bool desired = true;
     int32_t bo_idx = -1;
     //With KDS2.0 ensure no outstanding command
+    while (!priv1->cmd_submit_locked.compare_exchange_weak(expected, desired)) {
+        std::this_thread::yield();
+        expected = false;
+    }
     while (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
         std::unique_lock<std::mutex> lk(priv1->m_mutex);
         priv1->kernel_done_or_free.wait_for(lk, std::chrono::milliseconds(1));
@@ -570,6 +574,7 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
         priv1->execbo_locked = false;
         if (itr > 15) {
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Unable to find free execbo to use\n");
+            priv1->cmd_submit_locked = false;
             if (return_code) *return_code = XMA_ERROR;
             return cmd_obj_error;
         }
@@ -617,14 +622,6 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     // Set count to size in 32-bit words + 4; Three extra_cu_mask are present
     cu_cmd->count = (regmap_size >> 2) + 4;
 
-    //With KDS2.0 ensure no outstanding command
-    if (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
-        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Session id: %d, type: %s. Unexpected error. There is an outstanding cmd.", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str());
-        priv1->execbo_locked = false;
-        if (return_code) *return_code = XMA_ERROR;
-        return cmd_obj_error;
-    }
-
     if (priv1->num_cu_cmds != 0) {
 #ifdef __GNUC__
 # pragma GCC diagnostic push
@@ -639,6 +636,7 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD,
                         "Failed to submit kernel start with xclExecBuf");
             priv1->execbo_locked = false;
+            priv1->cmd_submit_locked = false;
             if (return_code) *return_code = XMA_ERROR;
             return cmd_obj_error;
         }
@@ -649,6 +647,7 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD,
                         "Failed to submit kernel start with xclExecBuf");
             priv1->execbo_locked = false;
+            priv1->cmd_submit_locked = false;
             if (return_code) *return_code = XMA_ERROR;
             return cmd_obj_error;
         }
@@ -697,6 +696,7 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     //xma_logmsg(XMA_DEBUG_LOG, XMAPLUGIN_MOD, "2. Num of cmds in-progress = %lu", priv1->CU_cmds.size());
     //Release execbo lock only after the command is fully populated and inserted in the command list
     priv1->execbo_locked = false;
+    priv1->cmd_submit_locked = false;
     if (return_code) *return_code = XMA_SUCCESS;
     return cmd_obj;
 }
@@ -786,6 +786,10 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     bool desired = true;
     int32_t bo_idx = -1;
     //With KDS2.0 ensure no outstanding command
+    while (!priv1->cmd_submit_locked.compare_exchange_weak(expected, desired)) {
+        std::this_thread::yield();
+        expected = false;
+    }
     while (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
         std::unique_lock<std::mutex> lk(priv1->m_mutex);
         priv1->kernel_done_or_free.wait_for(lk, std::chrono::milliseconds(1));
@@ -812,6 +816,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
         xma_logmsg(XMA_DEBUG_LOG, XMAPLUGIN_MOD, "No available execbo found");
         if (itr > 15) {
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Unable to find free execbo to use\n");
+            priv1->cmd_submit_locked = false;
             if (return_code) *return_code = XMA_ERROR;
             return cmd_obj_error;
         }
@@ -858,14 +863,6 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     // Set count to size in 32-bit words + 4; Three extra_cu_mask are present
     cu_cmd->count = (regmap_size >> 2) + 4;
     
-    //With KDS2.0 ensure no outstanding command
-    if (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
-        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Session id: %d, type: %s. Unexpected error. There is an outstanding cmd.", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str());
-        priv1->execbo_locked = false;
-        if (return_code) *return_code = XMA_ERROR;
-        return cmd_obj_error;
-    }
-
     if (priv1->num_cu_cmds != 0) {
 #ifdef __GNUC__
 # pragma GCC diagnostic push
@@ -880,6 +877,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD,
                         "Failed to submit kernel start with xclExecBuf");
             priv1->execbo_locked = false;
+            priv1->cmd_submit_locked = false;
             if (return_code) *return_code = XMA_ERROR;
             return cmd_obj_error;
         }
@@ -890,6 +888,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
             xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD,
                         "Failed to submit kernel start with xclExecBuf");
             priv1->execbo_locked = false;
+            priv1->cmd_submit_locked = false;
             if (return_code) *return_code = XMA_ERROR;
             return cmd_obj_error;
         }
@@ -935,6 +934,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     //xma_logmsg(XMA_DEBUG_LOG, XMAPLUGIN_MOD, "2. Num of cmds in-progress = %lu", priv1->CU_cmds.size());
     //Release execbo lock only after the command is fully populated and inserted in the command list
     priv1->execbo_locked = false;
+    priv1->cmd_submit_locked = false;
     if (return_code) *return_code = XMA_SUCCESS;
     return cmd_obj;
 }

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -543,6 +543,11 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     bool expected = false;
     bool desired = true;
     int32_t bo_idx = -1;
+    //With KDS2.0 ensure no outstanding command
+    while (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
+        std::unique_lock<std::mutex> lk(priv1->m_mutex);
+        priv1->work_item_done_1plus.wait_for(lk, std::chrono::milliseconds(1));
+    }
 
     // Find an available execBO buffer
     uint32_t itr = 0;
@@ -611,6 +616,14 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
     
     // Set count to size in 32-bit words + 4; Three extra_cu_mask are present
     cu_cmd->count = (regmap_size >> 2) + 4;
+
+    //With KDS2.0 ensure no outstanding command
+    if (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
+        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Session id: %d, type: %s. Unexpected error. There is an outstanding cmd.", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str());
+        priv1->execbo_locked = false;
+        if (return_code) *return_code = XMA_ERROR;
+        return cmd_obj_error;
+    }
 
     if (priv1->num_cu_cmds != 0) {
 #ifdef __GNUC__
@@ -772,6 +785,11 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     bool expected = false;
     bool desired = true;
     int32_t bo_idx = -1;
+    //With KDS2.0 ensure no outstanding command
+    while (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
+        std::unique_lock<std::mutex> lk(priv1->m_mutex);
+        priv1->work_item_done_1plus.wait_for(lk, std::chrono::milliseconds(1));
+    }
 
     // Find an available execBO buffer
     uint32_t itr = 0;
@@ -840,6 +858,14 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
     // Set count to size in 32-bit words + 4; Three extra_cu_mask are present
     cu_cmd->count = (regmap_size >> 2) + 4;
     
+    //With KDS2.0 ensure no outstanding command
+    if (priv1->num_cu_cmds != 0 && !g_xma_singleton->kds_old) {
+        xma_logmsg(XMA_ERROR_LOG, XMAPLUGIN_MOD, "Session id: %d, type: %s. Unexpected error. There is an outstanding cmd.", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str());
+        priv1->execbo_locked = false;
+        if (return_code) *return_code = XMA_ERROR;
+        return cmd_obj_error;
+    }
+
     if (priv1->num_cu_cmds != 0) {
 #ifdef __GNUC__
 # pragma GCC diagnostic push


### PR DESCRIPTION
Use separate option to run with old KDS.
New KDS does not support API xclExecBufWithWaitList
Default is to use new KDS 2.0