### PR TITLE
Initial implementation of generic profiling summary to replace the OpenCL specific summary

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.cpp
+++ b/src/runtime_src/xdp/profile/database/database.cpp
@@ -20,15 +20,19 @@
 
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/plugin/vp_base/vp_base_plugin.h"
+#include "xdp/profile/writer/vp_base/summary_writer.h"
+#include "core/common/config_reader.h"
 
 namespace xdp {
 
   bool VPDatabase::live ;
 
   VPDatabase::VPDatabase() :
-    stats(this), staticdb(this), dyndb(this), numDevices(0)
+    stats(this), staticdb(this), dyndb(this), pluginInfo(0), numDevices(0)
   {
     VPDatabase::live = true ;
+
+    summary = new SummaryWriter("summary.csv", this) ;
   }
 
   // The database and all the plugins are singletons and can be
@@ -42,6 +46,14 @@ namespace xdp {
     for (auto p : plugins)
     {
       p->writeAll(false) ;
+    }
+
+    // After all the plugins have written their data, we can dump the
+    //  generic summary
+    if (summary != nullptr) {
+      staticdb.addOpenedFile("summary.csv", "PROFILE_SUMMARY") ;
+      summary->write(false) ;
+      delete summary ;
     }
 
     plugins.clear();

--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -57,6 +57,13 @@ namespace xdp {
     //  destroyed at the end of execution.
     std::list<XDPPlugin*> plugins ;
 
+    // The database itself keeps track of the generic summary
+    VPWriter* summary ;
+
+    // Additionally, for summary generation, the database must expose
+    //  what plugins were loaded and what information is available
+    uint64_t pluginInfo ;
+
     // A map of Device SysFs Path to Device Id
     std::map<std::string, uint64_t> devices;
     uint64_t numDevices;
@@ -79,6 +86,8 @@ namespace xdp {
     // Functions that plugins call on startup and destruction
     inline void registerPlugin(XDPPlugin* p)   { plugins.push_back(p) ; }
     inline void unregisterPlugin(XDPPlugin* p) { plugins.remove(p) ; }
+    inline void registerInfo(uint64_t info)    { pluginInfo |= info ; }
+    inline bool infoAvailable(uint64_t info)   { return (pluginInfo&info)!=0; }
 
     XDP_EXPORT uint64_t addDevice(const std::string&);
     XDP_EXPORT uint64_t getDeviceId(const std::string&);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -16,6 +16,7 @@
 
 #define XDP_SOURCE
 
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/aie_profile/aie_plugin.h"
 #include "xdp/profile/writer/aie_profile/aie_writer.h"
 
@@ -40,6 +41,7 @@ namespace xdp {
       : XDPPlugin()
   {
     db->registerPlugin(this);
+    db->registerInfo(info::aie_profile);
     getPollingInterval();
 
     //

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -16,6 +16,7 @@
 
 #define XDP_SOURCE
 
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/aie_trace/aie_trace_plugin.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
 #include "xdp/profile/writer/aie_trace/aie_trace_config_writer.h"
@@ -49,6 +50,7 @@ namespace xdp {
                 : XDPPlugin()
   {
     db->registerPlugin(this);
+    db->registerInfo(info::aie_trace);
 
     // Pre-defined metric sets
     metricSets = {"functions", "functions_partial_stalls", "functions_all_stalls", "all"};

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -23,6 +23,7 @@
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/plugin/device_offload/device_offload_plugin.h"
 #include "xdp/profile/plugin/vp_base/utility.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/writer/device_trace/device_trace_writer.h"
 #include "xdp/profile/database/events/creator/device_event_trace_logger.h"
 
@@ -89,6 +90,7 @@ namespace xdp {
     if (!active) return ; 
 
     db->registerPlugin(this) ;
+    db->registerInfo(info::device_offload);
 
     // Get the profiling continuous offload options from xrt.ini
     //  Device offload continuous offload and dumping is only supported

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -23,6 +23,7 @@
 #include "xdp/profile/writer/hal/hal_summary_writer.h"
 
 #include "xdp/profile/plugin/vp_base/utility.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/device/tracedefs.h"
 
 #include "xdp/profile/database/database.h"
@@ -37,6 +38,7 @@ namespace xdp {
   HALPlugin::HALPlugin() : XDPPlugin()
   {
     db->registerPlugin(this) ;
+    db->registerInfo(info::hal) ;
 
     std::string version = "1.1" ;
 

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -14,6 +14,7 @@
  * under the License.
  */
 
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "xdp/profile/plugin/lop/lop_plugin.h"
 #include "xdp/profile/writer/lop/low_overhead_trace_writer.h"
 #include "core/common/config_reader.h"
@@ -128,6 +129,7 @@ namespace xdp {
   LowOverheadProfilingPlugin::LowOverheadProfilingPlugin() : XDPPlugin()
   {
     db->registerPlugin(this) ;
+    db->registerInfo(info::lop);
     writers.push_back(new LowOverheadTraceWriter("lop_trace.csv")) ;
 
     emulationSetup() ;

--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
@@ -18,12 +18,14 @@
 
 #include "xdp/profile/plugin/native/native_plugin.h"
 #include "xdp/profile/writer/native/native_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 namespace xdp {
 
   NativeProfilingPlugin::NativeProfilingPlugin() : XDPPlugin()
   {
     db->registerPlugin(this) ;
+    db->registerInfo(info::native) ;
     writers.push_back(new NativeTraceWriter("native_trace.csv")) ;
 
     (db->getStaticInfo()).addOpenedFile("native_trace.csv", "VP_TRACE") ;

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -18,6 +18,7 @@
 
 #include "xdp/profile/plugin/noc/noc_plugin.h"
 #include "xdp/profile/writer/noc/noc_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 #include "core/common/system.h"
 #include "core/common/time.h"
@@ -32,7 +33,7 @@ namespace xdp {
       : XDPPlugin(), mKeepPolling(true)
   {
     db->registerPlugin(this);
-   
+    db->registerInfo(info::noc);
     // Just like HAL and power profiling, go through devices 
     //  that exist and open a file for each
     uint64_t index = 0;

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -16,11 +16,14 @@
 
 #define XDP_SOURCE
 
+#include "core/common/config_reader.h"
+
 #include "xocl/core/platform.h"
 #include "xocl/core/device.h"
 
 #include "xdp/profile/plugin/opencl/counters/opencl_counters_plugin.h"
 #include "xdp/profile/writer/opencl/opencl_summary_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 #ifdef _WIN32
 /* Disable warning for use of std::getenv */
@@ -33,8 +36,10 @@ namespace xdp {
   {
     db->registerPlugin(this) ;
 
-    writers.push_back(new OpenCLSummaryWriter("opencl_summary.csv")) ;
-    (db->getStaticInfo()).addOpenedFile("opencl_summary.csv", "PROFILE_SUMMARY") ;
+    // Summary file now handled by generic summary writer in database
+    //writers.push_back(new OpenCLSummaryWriter("opencl_summary.csv")) ;
+    //(db->getStaticInfo()).addOpenedFile("opencl_summary.csv", "PROFILE_SUMMARY") ;
+    db->registerInfo(info::opencl_counters) ;
 
     // If the OpenCL device offload plugin isn't already loaded, this
     //  call will load the HAL device offload plugin and it will take

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -16,6 +16,7 @@
 
 #include "xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h"
 #include "xdp/profile/writer/opencl/opencl_trace_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "core/common/config_reader.h"
 
 #ifdef _WIN32
@@ -29,6 +30,7 @@ namespace xdp {
     XDPPlugin()
   {
     db->registerPlugin(this) ;
+    db->registerInfo(info::opencl_trace) ;
 
     // Add a single writer for the OpenCL host trace
     writers.push_back(new OpenCLTraceWriter("opencl_trace.csv")) ;

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -18,6 +18,7 @@
 
 #include "xdp/profile/plugin/power/power_plugin.h"
 #include "xdp/profile/writer/power/power_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 #include "core/common/system.h"
 #include "core/common/time.h"
 #include "core/common/config_reader.h"
@@ -57,6 +58,7 @@ namespace xdp {
     XDPPlugin(), keepPolling(true), pollingInterval(20)
   {
     db->registerPlugin(this) ;
+    db->registerInfo(info::power) ;
 
     pollingInterval = xrt_core::config::get_power_profile_interval_ms() ;
    

--- a/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
@@ -16,12 +16,14 @@
 
 #include "xdp/profile/plugin/user/user_plugin.h"
 #include "xdp/profile/writer/user/user_events_trace_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 namespace xdp {
 
   UserEventsPlugin::UserEventsPlugin() : XDPPlugin()
   {
     db->registerPlugin(this) ;
+    db->registerInfo(info::user) ;
 
     writers.push_back(new UserEventsTraceWriter("user_events.csv")) ;
     (db->getStaticInfo()).addOpenedFile("user_events.csv", "VP_TRACE") ;

--- a/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vart/vart_plugin.cpp
@@ -18,6 +18,7 @@
 
 #include <cstring>
 #include "xdp/profile/plugin/vart/vart_plugin.h"
+#include "xdp/profile/plugin/vp_base/info.h"
 
 #define MAX_PATH_SZ 512
 
@@ -26,6 +27,7 @@ namespace xdp {
   VARTPlugin::VARTPlugin() : XDPPlugin()
   {
     db->registerPlugin(this);
+    db->registerInfo(info::vart);
 
     //std::string version = "1.0" ;
     //std::string creationTime = xdp::getCurrentDateTime();

--- a/src/runtime_src/xdp/profile/plugin/vp_base/info.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/info.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef INFO_DOT_H
+#define INFO_DOT_H
+
+#include <cstdint>
+
+namespace xdp {
+namespace info {
+
+  const uint64_t aie_profile     = 0x0001 ;
+  const uint64_t aie_trace       = 0x0002 ;
+  const uint64_t device_offload  = 0x0004 ;
+  const uint64_t hal             = 0x0008 ;
+  const uint64_t lop             = 0x0010 ;
+  const uint64_t native          = 0x0020 ;
+  const uint64_t noc             = 0x0040 ;
+  const uint64_t opencl_counters = 0x0080 ;
+  const uint64_t opencl_trace    = 0x0100 ;
+  const uint64_t power           = 0x0200 ;
+  const uint64_t system_compiler = 0x0400 ;
+  const uint64_t user            = 0x0800 ;
+  const uint64_t vart            = 0x1000 ;
+
+} // end namespace info
+} // end namespace xdp ;
+
+#endif

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -1,0 +1,660 @@
+/**
+ * Copyright (C) 2016-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_SOURCE
+
+#include <memory>
+#include <map>
+
+#include "xdp/profile/writer/vp_base/guidance_rules.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
+#include "xdp/profile/plugin/vp_base/info.h"
+
+#include "core/include/xclbin.h"
+#include "core/common/time.h"
+
+// An anonymous namespace for all of the different guidance rules
+namespace {
+
+  static void deviceExecTime(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::string deviceName =
+        db->getStaticInfo().getSoftwareEmulationDeviceName();
+      uint64_t execTime = db->getStats().getDeviceActiveTime(deviceName);
+
+      fout << "DEVICE_EXEC_TIME," << deviceName << ","
+           << (double)execTime / 1e06 << ",\n" ;
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos();
+
+      for (auto device : deviceInfos) {
+        std::string deviceName = device->getUniqueDeviceName();
+        uint64_t execTime = db->getStats().getDeviceActiveTime(deviceName);
+
+        fout << "DEVICE_EXEC_TIME," << deviceName << ","
+             << (double)execTime / 1e06 << ",\n" ;
+      }
+    }
+  }
+
+  static void cuCalls(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::map<std::tuple<std::string, std::string, std::string>,
+               xdp::TimeStatistics> cuStats =
+        db->getStats().getComputeUnitExecutionStats();
+
+      for (auto iter : cuStats) {
+        fout << "CU_CALLS,"
+             << db->getStaticInfo().getSoftwareEmulationDeviceName()
+             << "|" << std::get<0>(iter.first) << ","
+             << iter.second.numExecutions << ",\n" ;
+      }
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos();
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          for (auto cu : xclbin->cus) {
+	    std::string cuName = cu.second->getName();
+	    std::vector<std::pair<std::string, xdp::TimeStatistics>> cuCalls =
+              db->getStats().getComputeUnitExecutionStats(cuName);
+            uint64_t execCount = 0;
+            for (auto cuCall : cuCalls) {
+              execCount += cuCall.second.numExecutions;
+	    }
+            if (execCount != 0) {
+              fout << "CU_CALLS," << device->getUniqueDeviceName() << "|"
+                   << cu.second->getName() << ","
+                   << execCount << ",\n";
+	    }
+	  }
+	}
+      }
+    }
+  }
+
+  static void numMonitors(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    struct MonInfo {
+      std::string type ;
+      uint64_t numTraceEnabled ;
+      uint64_t numTotal ;
+
+      MonInfo(const std::string& s, uint64_t trace, uint64_t total) :
+        type(s), numTraceEnabled(trace), numTotal(total)
+      {}
+      ~MonInfo() {}
+    } ;
+
+    std::map<uint8_t, std::unique_ptr<MonInfo>> monitors ;
+
+    monitors[ACCEL_MONITOR]      =
+      std::make_unique<MonInfo>("XCL_PERF_MON_ACCEL", 0, 0);
+    monitors[AXI_MM_MONITOR]     =
+      std::make_unique<MonInfo>("XCL_PERF_MON_MEMORY", 0, 0);
+    monitors[AXI_STREAM_MONITOR] =
+      std::make_unique<MonInfo>("XCL_PERF_MON_STR", 0, 0);
+
+    auto deviceInfos = db->getStaticInfo().getDeviceInfos();
+    for (auto device : deviceInfos) {
+      for (auto xclbin : device->loadedXclbins) {
+        monitors[ACCEL_MONITOR]->numTotal += xclbin->amList.size();
+        monitors[ACCEL_MONITOR]->numTraceEnabled += xclbin->amMap.size();
+
+        monitors[AXI_MM_MONITOR]->numTotal += xclbin->aimList.size();
+        monitors[AXI_MM_MONITOR]->numTraceEnabled += xclbin->aimMap.size();
+
+        monitors[AXI_STREAM_MONITOR]->numTotal += xclbin->asmList.size();
+        monitors[AXI_STREAM_MONITOR]->numTraceEnabled += xclbin->asmMap.size();
+      }
+      for (auto& mon : monitors) {
+        fout << "NUM_MONITORS,"
+             << device->getUniqueDeviceName() << "|"
+             << mon.second->type << "|"
+             << mon.second->numTraceEnabled << ","
+             << mon.second->numTotal << ",\n" ;
+
+        // Reset the numbers
+        mon.second->numTotal = 0 ;
+        mon.second->numTraceEnabled = 0 ;
+      }
+    }
+  }
+
+  static void migrateMem(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    uint64_t numCalls = db->getStats().getNumMigrateMemCalls();
+
+    fout << "MIGRATE_MEM,host," << numCalls << ",\n" ;
+  }
+
+  static void memoryUsage(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::map<std::string, bool> memUsage =
+        db->getStaticInfo().getSoftwareEmulationMemUsage();
+      for (auto iter : memUsage) {
+        fout << "MEMORY_USAGE," << iter.first << "," << iter.second << ",\n";
+      }
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          for (auto memory : xclbin->memoryInfo) {
+	    std::string memName = memory.second->name ;
+            if (memName.rfind("bank", 0) == 0)
+              memName = "DDR[" + memName.substr(4,4) + "]" ;
+
+            fout << "MEMORY_USAGE," << device->getUniqueDeviceName() << "|"
+                 << memName << "," << memory.second->used << ",\n" ;
+	  }
+        }
+      }
+    }
+  }
+
+  static void PLRAMDevice(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    bool hasPLRAM = false ;
+
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      hasPLRAM = true ;
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos();
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          for (auto memory : xclbin->memoryInfo) {
+            if (memory.second->name.find("PLRAM") != std::string::npos) {
+              hasPLRAM = true ;
+              break ;
+	    }
+	  }
+          if (hasPLRAM) break ;
+	}
+        if (hasPLRAM) break ;
+      }
+    }
+
+    fout << "PLRAM_DEVICE,all," << hasPLRAM << ",\n" ;
+  }
+
+  static void HBMDevice(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    bool hasHBM = false ;
+
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      // In software emulation we have to search the name for known
+      //  platforms that have HBM
+      std::string deviceName =
+        db->getStaticInfo().getSoftwareEmulationDeviceName() ;
+      if (deviceName.find("u280") != std::string::npos ||
+          deviceName.find("u50")  != std::string::npos) {
+        hasHBM = true ;
+      }
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          for (auto memory : xclbin->memoryInfo) {
+            if (memory.second->name.find("HBM") != std::string::npos) {
+              hasHBM = true ;
+              break ;
+	    }
+	  }
+          if (hasHBM) break ;
+	}
+        if (hasHBM) break ;
+      }
+    }
+
+    fout << "HBM_DEVICE,all," << hasHBM << ",\n" ;
+  }
+
+  static void KDMADevice(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    bool hasKDMA = false ;
+
+    // There currently isn't any meta-data that can tell us if the
+    //  device has a KDMA, so we are relying on known platforms.
+
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::string deviceName =
+        db->getStaticInfo().getSoftwareEmulationDeviceName() ;
+      if (deviceName.find("xilinx_u200_xdma") != std::string::npos ||
+          deviceName.find("xilinx_vcu1525_xdma") != std::string::npos) {
+        hasKDMA = true ;
+      }
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+      for (auto device : deviceInfos) {
+	std::string deviceName = device->deviceName ;
+        if (deviceName.find("xilinx_u200_xdma") != std::string::npos ||
+            deviceName.find("xilinx_vcu1525_xdma") != std::string::npos) {
+          hasKDMA = true ;
+          break ;
+        }
+      }
+    }
+
+    fout << "KDMA_DEVICE,all," << hasKDMA << ",\n" ;
+  }
+
+  static void P2PDevice(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    bool hasP2P = false ;
+
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::string deviceName =
+        db->getStaticInfo().getSoftwareEmulationDeviceName() ;
+      if (deviceName.find("xilinx_u200_xdma")    != std::string::npos ||
+          deviceName.find("xilinx_u250_xdma")    != std::string::npos ||
+          deviceName.find("samsung")             != std::string::npos ||
+          deviceName.find("xilinx_vcu1525_xdma") != std::string::npos) {
+        hasP2P = true ;
+      }
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+      for (auto device : deviceInfos) {
+	std::string deviceName = device->deviceName ;
+        if (deviceName.find("xilinx_u200_xdma")    != std::string::npos ||
+            deviceName.find("xilinx_u250_xdma")    != std::string::npos ||
+            deviceName.find("samsung")             != std::string::npos ||
+            deviceName.find("xilinx_vcu1525_xdma") != std::string::npos) {
+          hasP2P = true ;
+          break ;
+        }
+      }
+    }
+
+    fout << "P2P_DEVICE,all," << hasP2P << ",\n" ;
+  }
+
+  static void P2PHostTransfers(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    uint64_t hostP2PTransfers = db->getStats().getNumHostP2PTransfers() ;
+    fout << "P2P_HOST_TRANSFERS,host," << hostP2PTransfers << ",\n" ;
+  }
+
+  static void portBitWidth(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::vector<std::string> portBitWidths =
+        db->getStaticInfo().getSoftwareEmulationPortBitWidths() ;
+      for (auto width : portBitWidths) {
+        fout << "PORT_BIT_WIDTH," << width << ",\n" ;
+      }
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          for (auto cu : xclbin->cus) {
+	    std::vector<uint32_t>* aimIds = cu.second->getAIMs() ;
+	    std::vector<uint32_t>* asmIds = cu.second->getASMs() ;
+
+            for (auto aim : (*aimIds)) {
+	      xdp::Monitor* monitor =
+                db->getStaticInfo().getAIMonitor(device->deviceId, xclbin, aim);
+              fout << "PORT_BIT_WIDTH," << cu.second->getName() << "/"
+                   << monitor->port << "," << monitor->portWidth << ",\n" ;
+            }
+
+            for (auto asmId : (*asmIds)) {
+	      xdp::Monitor* monitor =
+                db->getStaticInfo().getASMonitor(device->deviceId,xclbin,asmId);
+              fout << "PORT_BIT_WIDTH," << cu.second->getName() << "/"
+                   << monitor->port << "," << monitor->portWidth << ",\n" ;
+            }
+	  }
+	}
+      }
+    }
+  }
+
+  void kernelCount(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    std::map<std::string, uint64_t> kernelCounts ;
+
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      kernelCounts = db->getStaticInfo().getSoftwareEmulationCUCounts() ;
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          for (auto cu : xclbin->cus) {
+	    std::string kernelName = cu.second->getKernelName() ;
+            if (kernelCounts.find(kernelName) == kernelCounts.end()) {
+              kernelCounts[kernelName] = 1 ;
+	    }
+            else {
+              kernelCounts[kernelName] += 1 ;
+	    }
+	  }
+	}
+      }
+    }
+
+    for (auto kernel : kernelCounts) {
+      fout << "KERNEL_COUNT," << kernel.first << "," << kernel.second << ",\n" ;
+    }
+  }
+
+  static void objectsReleased(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    uint64_t numReleased = db->getStats().getNumOpenCLObjectsReleased();
+
+    fout << "OBJECTS_RELEASED,all," << numReleased << ",\n" ;
+  }
+
+  static void CUContextEn(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    bool isContextEnabled = db->getStats().getContextEnabled() ;
+
+    fout << "CU_CONTEXT_EN,all," << (uint64_t)(isContextEnabled) << ",\n" ;
+  }
+
+  static void traceMemory(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    std::string memType = "FIFO" ;
+
+    if (xdp::getFlowMode() == xdp::SW_EMU ||
+        xdp::getFlowMode() == xdp::HW_EMU) {
+      memType = "NA" ;
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+
+      for (auto device : deviceInfos) {
+        for (auto xclbin : device->loadedXclbins) {
+          if (xclbin->usesTs2mm) {
+            memType = "TS2MM" ;
+            break ;
+	  }
+	}
+      }
+    }
+    fout << "TRACE_MEMORY,all," << memType << ",\n" ;
+  }
+
+  static void maxParallelKernelEnqueues(xdp::VPDatabase* db,
+                                        std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    auto maxExecs = db->getStats().getAllMaxExecutions();
+
+    for (auto mExec : maxExecs) {
+      fout << "MAX_PARALLEL_KERNEL_ENQUEUES," << mExec.first << ","
+           << mExec.second << ",\n" ;
+    }
+  }
+
+  static void commandQueueOOO(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    auto commandQueueInfo = db->getStats().getCommandQueuesAreOOO() ;
+
+    for (auto cq : commandQueueInfo) {
+      fout << "COMMAND_QUEUE_OOO," << cq.first << "," << cq.second << ",\n" ;
+    }
+  }
+
+  static void PLRAMSizeBytes(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+    bool done = false ;
+
+    for (auto device : deviceInfos) {
+      for (auto xclbin : device->loadedXclbins) {
+        for (auto memory : xclbin->memoryInfo) {
+          if (memory.second->name.find("PLRAM") != std::string::npos) {
+            fout << "PLRAM_SIZE_BYTES,"
+                 << device->getUniqueDeviceName()
+                 << "," << memory.second->size*1024 << ",\n" ;
+            done = true ;
+            // To match old flow and tools, print PLRAM_SIZE_BYTES for
+            //  first match only.
+            break ;
+	  }
+	}
+        if (done) break ;
+      }
+      if (done) break ;
+    }
+  }
+
+  static void kernelBufferInfo(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    // This reports the memory bank, argument, alignment, and size
+    //  of each buffer.
+
+    for (auto& iter : db->getStats().getBufferInfo()) {
+      for (auto& info : iter.second) {
+        fout << "KERNEL_BUFFER_INFO," << info << ",\n" ;
+      }
+    }
+  }
+
+  static void traceBufferFull(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+    for (auto device : deviceInfos) {
+      bool full = db->getDynamicInfo().isTraceBufferFull(device->deviceId);
+      fout << "TRACE_BUFFER_FULL,"
+           << device->getUniqueDeviceName() << ","
+           << (full ? "true" : "false")
+           << "\n" ; // Should there be a comma at the end?
+    }
+  }
+
+  static void memoryTypeBitWidth(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (xdp::getFlowMode() == xdp::SW_EMU) {
+      std::string deviceName =
+        db->getStaticInfo().getSoftwareEmulationDeviceName() ;
+      fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+           << "|HBM," << 256 << ",\n" ;
+      fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+           << "|DDR," << 512 << ",\n" ;
+      fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+           << "|PLRAM," << 512 << ",\n" ;
+    }
+    else {
+      auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+
+      for (auto device : deviceInfos) {
+        std::string deviceName = device->getUniqueDeviceName() ;
+
+        if (device->isEdgeDevice) {
+          fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+               << "|DDR," << 64 << ",\n" ;
+        }
+        else {
+          fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+               << "|HBM," << 256 << ",\n" ;
+          fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+               << "|DDR," << 512 << ",\n" ;
+          fout << "MEMORY_TYPE_BIT_WIDTH," << deviceName
+               << "|PLRAM," << 512 << ",\n" ;
+        }
+      }
+    }
+  }
+
+  static void bufferRdActiveTimeMs(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    fout << "BUFFER_RD_ACTIVE_TIME_MS,all,"
+         << (double)(db->getStats().getTotalHostReadTime()) / 1e06
+         << ",\n" ;
+  }
+
+  static void bufferWrActiveTimeMs(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    fout << "BUFFER_WR_ACTIVE_TIME_MS,all,"
+         << (double)(db->getStats().getTotalHostWriteTime()) / 1e06
+         << ",\n" ;
+  }
+
+  static void bufferTxActiveTimeMs(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    fout << "BUFFER_TX_ACTIVE_TIME_MS,all,"
+         << (double)(db->getStats().getTotalBufferTxTime()) / 1e06
+         << ",\n" ;
+  }
+
+  static void applicationRunTimeMs(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    uint64_t startTime = db->getStaticInfo().getApplicationStartTime() ;
+    uint64_t endTime = xrt_core::time_ns() ; 
+
+    fout << "APPLICATON_RUN_TIME_MS,all," 
+         << (double)(endTime - startTime) / 1e06
+         << ",\n" ;
+  }
+
+  static void totalKernelRunTimeMs(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::opencl_trace)) return ;
+
+    double firstKernelStartTime = db->getStats().getFirstKernelStartTime() ;
+    double lastKernelEndTime = db->getStats().getLastKernelEndTime() ;
+
+    fout << "TOTAL_KERNEL_RUN_TIME_MS,all,"
+         << lastKernelEndTime - firstKernelStartTime << ",\n" ;
+  }
+
+  static void aieCounterResources(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::aie_profile)) return ;
+
+    auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+    for (auto device : deviceInfos) {
+      auto& counters =
+        db->getStaticInfo().getAIECounterResources(device->deviceId) ;
+      for (auto const& counter : counters) {
+        fout << "AIE_COUNTER_RESOURCES," << counter.first << ","
+             << counter.second << ",\n" ;
+      }
+    }
+  }
+
+  static void aieTraceEvents(xdp::VPDatabase* db, std::ofstream& fout)
+  {
+    if (!db->infoAvailable(xdp::info::aie_trace)) return ;
+
+    auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
+    for (auto device : deviceInfos) {
+      auto& coreEvents =
+        db->getStaticInfo().getAIECoreEventResources(device->deviceId) ;
+      for (auto const& coreEvent : coreEvents) {
+        fout << "AIE_CORE_EVENT_RESOURCES," << coreEvent.first << ","
+             << coreEvent.second << ",\n" ;
+      }
+      auto& memoryEvents =
+        db->getStaticInfo().getAIEMemoryEventResources(device->deviceId) ;
+      for (auto const& memoryEvent : memoryEvents) {
+        fout << "AIE_MEMORY_EVENT_RESOURCES," << memoryEvent.first << ","
+             << memoryEvent.second << ",\n" ;
+      }
+    }
+  }
+
+} // end anonymous namespace
+
+namespace xdp {
+
+  GuidanceRules::GuidanceRules() : iniParameters()
+  {
+    // Add the rules that apply to all executions
+    rules.push_back(deviceExecTime) ;
+    rules.push_back(cuCalls);
+    rules.push_back(numMonitors);
+    rules.push_back(memoryUsage);
+    rules.push_back(PLRAMDevice);
+    rules.push_back(HBMDevice) ;
+    rules.push_back(KDMADevice) ;
+    rules.push_back(P2PDevice) ;
+    rules.push_back(portBitWidth) ;
+    rules.push_back(kernelCount) ;
+    rules.push_back(traceMemory) ;
+    rules.push_back(PLRAMSizeBytes) ;
+    rules.push_back(traceBufferFull) ;
+    rules.push_back(memoryTypeBitWidth) ;
+    rules.push_back(applicationRunTimeMs) ;
+
+    // Add the OpenCL specific rules if OpenCL information is available
+    rules.push_back(migrateMem) ;
+    rules.push_back(P2PHostTransfers) ;
+    rules.push_back(objectsReleased) ;
+    rules.push_back(CUContextEn) ;
+    rules.push_back(maxParallelKernelEnqueues);
+    rules.push_back(commandQueueOOO) ;
+    rules.push_back(kernelBufferInfo) ;
+    rules.push_back(bufferRdActiveTimeMs) ;
+    rules.push_back(bufferWrActiveTimeMs) ;
+    rules.push_back(bufferTxActiveTimeMs) ;
+    rules.push_back(totalKernelRunTimeMs) ;
+
+    // Add the AIE information if available
+    rules.push_back(aieCounterResources) ;
+    rules.push_back(aieTraceEvents) ;
+  }
+
+  GuidanceRules::~GuidanceRules()
+  {
+  }
+
+  void GuidanceRules::write(VPDatabase* db, std::ofstream& fout)
+  {
+    // Dump the header
+    fout << "Guidance Parameters\n" ;
+    fout << "Parameter,Element,Value,\n" ;
+
+    for (auto& rule : rules) {
+      rule(db, fout) ;
+    }
+
+    iniParameters.write(fout) ;
+  }
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -569,10 +569,16 @@ namespace {
 
     auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
     for (auto device : deviceInfos) {
-      auto& counters =
-        db->getStaticInfo().getAIECounterResources(device->deviceId) ;
-      for (auto const& counter : counters) {
-        fout << "AIE_COUNTER_RESOURCES," << counter.first << ","
+      auto& coreCounters =
+        db->getStaticInfo().getAIECoreCounterResources(device->deviceId) ;
+      for (auto const& counter : coreCounters) {
+        fout << "AIE_CORE_COUNTER_RESOURCES," << counter.first << ","
+             << counter.second << ",\n" ;
+      }
+      auto& memoryCounters =
+        db->getStaticInfo().getAIEMemoryCounterResources(device->deviceId) ;
+      for (auto const& counter : memoryCounters) {
+        fout << "AIE_MEMORY_COUNTER_RESOURCES," << counter.first << ","
              << counter.second << ",\n" ;
       }
     }

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,25 +14,31 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#ifndef GUIDANCE_RULES_DOT_H
+#define GUIDANCE_RULES_DOT_H
 
-#include "xdp/profile/plugin/system_compiler/system_compiler_plugin.h"
-#include "xdp/profile/plugin/vp_base/info.h"
+#include <vector>
+#include <functional>
+#include <fstream>
+
+#include "xdp/profile/database/database.h"
+#include "xdp/profile/writer/vp_base/ini_parameters.h"
 
 namespace xdp {
 
-  SystemCompilerPlugin::SystemCompilerPlugin() : XDPPlugin()
+  class GuidanceRules
   {
-    db->registerPlugin(this);
-    db->registerInfo(info::system_compiler);
+  private:
+    std::vector<std::function<void (VPDatabase*, std::ofstream&)>> rules ;
 
-    db->getStaticInfo().addOpenedFile("profile_summary.csv", "PROFILE_SUMMARY");
-    db->getStaticInfo().addOpenedFile("sc_trace.csv", "VP_TRACE");
-  }
+    IniParameters iniParameters ;
+  public:
+    GuidanceRules() ;
+    ~GuidanceRules() ;
 
-  SystemCompilerPlugin::~SystemCompilerPlugin()
-  {
-  }
-
+    void write(VPDatabase* db, std::ofstream& fout) ;
+  } ;
 
 } // end namespace xdp
+
+#endif

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2016-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_SOURCE
+
+#include "xdp/profile/writer/vp_base/ini_parameters.h"
+#include "core/common/config_reader.h"
+
+namespace xdp {
+
+  IniParameters::IniParameters()
+  {
+    addParameter("profile", xrt_core::config::get_profile());
+    addParameter("opencl_summary", xrt_core::config::get_opencl_summary());
+    addParameter("opencl_device_counter",
+                 xrt_core::config::get_opencl_device_counter());
+    addParameter("timeline_trace", xrt_core::config::get_timeline_trace());
+    addParameter("xrt_trace", xrt_core::config::get_xrt_trace());
+    addParameter("xrt_profile", xrt_core::config::get_xrt_profile());
+    addParameter("data_transfer_trace",
+                 xrt_core::config::get_data_transfer_trace());
+    addParameter("power_profile", xrt_core::config::get_power_profile());
+    addParameter("power_profile_interval_ms",
+                 xrt_core::config::get_power_profile_interval_ms());
+    addParameter("stall_trace", xrt_core::config::get_stall_trace());
+    addParameter("trace_buffer_size",
+                 xrt_core::config::get_trace_buffer_size());
+    addParameter("verbosity", xrt_core::config::get_verbosity());
+    addParameter("continuous_trace", xrt_core::config::get_continuous_trace());
+    addParameter("continuous_trace_interval_ms",
+                 xrt_core::config::get_continuous_trace_interval_ms());
+    addParameter("trace_buffer_offload_interval_ms",
+                 xrt_core::config::get_trace_buffer_offload_interval_ms());
+    addParameter("lop_trace", xrt_core::config::get_lop_trace());
+    addParameter("debug_mode", xrt_core::config::get_launch_waveform());
+    addParameter("aie_trace", xrt_core::config::get_aie_trace());
+    addParameter("aie_trace_buffer_size",
+                 xrt_core::config::get_aie_trace_buffer_size());
+    addParameter("aie_trace_metrics",
+                 xrt_core::config::get_aie_trace_metrics());
+    addParameter("aie_profile", xrt_core::config::get_aie_profile());
+    addParameter("aie_profile_interval_us",
+                 xrt_core::config::get_aie_profile_interval_us());
+    addParameter("aie_profile_core_metrics",
+                 xrt_core::config::get_aie_profile_core_metrics());
+    addParameter("aie_profile_memory_metrics",
+                 xrt_core::config::get_aie_profile_memory_metrics());
+    addParameter("vitis_ai_profile", xrt_core::config::get_vitis_ai_profile());
+  }
+
+  IniParameters::~IniParameters()
+  {
+  }
+
+  void IniParameters::write(std::ofstream& fout)
+  {
+    for (auto& setting : settings) {
+      fout << setting << "\n" ;
+    }
+  }
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,25 +14,35 @@
  * under the License.
  */
 
-#define XDP_SOURCE
+#ifndef INI_PARAMETERS_DOT_H
+#define INI_PARAMETERS_DOT_H
 
-#include "xdp/profile/plugin/system_compiler/system_compiler_plugin.h"
-#include "xdp/profile/plugin/vp_base/info.h"
+#include <vector>
+#include <string>
+#include <sstream>
+#include <fstream>
 
 namespace xdp {
 
-  SystemCompilerPlugin::SystemCompilerPlugin() : XDPPlugin()
+  class IniParameters
   {
-    db->registerPlugin(this);
-    db->registerInfo(info::system_compiler);
+  private:
+    std::vector<std::string> settings ;
+  public:
+    IniParameters() ;
+    ~IniParameters() ;
 
-    db->getStaticInfo().addOpenedFile("profile_summary.csv", "PROFILE_SUMMARY");
-    db->getStaticInfo().addOpenedFile("sc_trace.csv", "VP_TRACE");
-  }
+    template <typename Arg>
+    void addParameter(const char* name, Arg&& arg)
+    {
+      std::stringstream setting ;
+      setting << "XRT_INI_SETTING," << name << "," << arg << "," ;
+      settings.push_back(setting.str()) ;
+    }
 
-  SystemCompilerPlugin::~SystemCompilerPlugin()
-  {
-  }
-
+    void write(std::ofstream& fout);
+  } ;
 
 } // end namespace xdp
+
+#endif

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1,0 +1,1676 @@
+/**
+ * Copyright (C) 2016-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#define XDP_SOURCE
+
+#include "xdp/profile/writer/vp_base/summary_writer.h"
+#include "xdp/profile/plugin/vp_base/info.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
+
+#include "core/common/config_reader.h"
+
+namespace xdp {
+
+  SummaryWriter::SummaryWriter(const char* filename) 
+    : VPSummaryWriter(filename), guidance()
+  {
+    initializeAPIs() ;
+  }
+
+  SummaryWriter::SummaryWriter(const char* filename, VPDatabase* inst) :
+    VPSummaryWriter(filename, inst), guidance()
+  {
+    initializeAPIs() ;
+  }
+
+  SummaryWriter::~SummaryWriter()
+  {
+  }
+
+  void SummaryWriter::initializeAPIs()
+  {
+    // For each of the APIs, initialize the sets with the hard coded names
+    OpenCLAPIs.emplace("clBuildProgram") ;
+    OpenCLAPIs.emplace("clCompileProgram") ;
+    OpenCLAPIs.emplace("clCreateBuffer") ;
+    OpenCLAPIs.emplace("clCreateCommandQueue") ;
+    OpenCLAPIs.emplace("clCreateContext") ;
+    OpenCLAPIs.emplace("clCreateContextFromType") ;
+    OpenCLAPIs.emplace("clCreateImage2D") ;
+    OpenCLAPIs.emplace("clCreateImage3D") ;
+    OpenCLAPIs.emplace("clCreateImage") ;
+    OpenCLAPIs.emplace("clCreateKernel") ;
+    OpenCLAPIs.emplace("clCreateKernelsInProgram") ;
+    OpenCLAPIs.emplace("clCreatePipe") ;
+    OpenCLAPIs.emplace("clCreateProgramWithBinary") ;
+    OpenCLAPIs.emplace("clCreateProgramWithBuiltInKernels") ;
+    OpenCLAPIs.emplace("clCreateProgramWithSource") ;
+    OpenCLAPIs.emplace("clCreateSampler") ;
+    OpenCLAPIs.emplace("clCreateSubBuffer") ;
+    OpenCLAPIs.emplace("clCreateSubDevices") ;
+    OpenCLAPIs.emplace("clCreateUserEvent") ;
+    OpenCLAPIs.emplace("clEnqueueBarrier") ;
+    OpenCLAPIs.emplace("clEnqueueBarrierWithWaitList") ;
+    OpenCLAPIs.emplace("clEnqueueCopyBuffer") ;
+    OpenCLAPIs.emplace("clEnqueueCopyBufferRect") ;
+    OpenCLAPIs.emplace("clEnqueueCopyBufferToImage") ;
+    OpenCLAPIs.emplace("clEnqueueCopyImage") ;
+    OpenCLAPIs.emplace("clEnqueueCopyImageToBuffer") ;
+    OpenCLAPIs.emplace("clEnqueueFillBuffer") ;
+    OpenCLAPIs.emplace("clEnqueueFillImage") ;
+    OpenCLAPIs.emplace("clEnqueueMapBuffer") ;
+    OpenCLAPIs.emplace("clEnqueueMapImage") ;
+    OpenCLAPIs.emplace("clEnqueueMarker") ;
+    OpenCLAPIs.emplace("clEnqueueMarkerWithWaitList") ;
+    OpenCLAPIs.emplace("clEnqueueMigrateMemObjects") ;
+    OpenCLAPIs.emplace("clEnqueueNativeKernel") ;
+    OpenCLAPIs.emplace("clEnqueueNDRangeKernel") ;
+    OpenCLAPIs.emplace("clEnqueueReadBuffer") ;
+    OpenCLAPIs.emplace("clEnqueueReadBufferRect") ;
+    OpenCLAPIs.emplace("clEnqueueReadImage") ;
+    OpenCLAPIs.emplace("clEnqueueSVMMap") ;
+    OpenCLAPIs.emplace("clEnqueueSVMUnmap") ;
+    OpenCLAPIs.emplace("clEnqueueTask") ;
+    OpenCLAPIs.emplace("clEnqueueUnmapMemObject") ;
+    OpenCLAPIs.emplace("clEnqueueWaitForEvents") ;
+    OpenCLAPIs.emplace("clEnqueueWriteBuffer") ;
+    OpenCLAPIs.emplace("clEnqueueWriteBufferRect") ;
+    OpenCLAPIs.emplace("clEnqueueWriteImage") ;
+    OpenCLAPIs.emplace("clFinish") ;
+    OpenCLAPIs.emplace("clFlush") ;
+    OpenCLAPIs.emplace("clGetCommandQueueInfo") ;
+    OpenCLAPIs.emplace("clGetContextInfo") ;
+    OpenCLAPIs.emplace("clGetDeviceIDs") ;
+    OpenCLAPIs.emplace("clGetDeviceInfo") ;
+    OpenCLAPIs.emplace("clGetEventInfo") ;
+    OpenCLAPIs.emplace("clGetEventProfilingInfo") ;
+    OpenCLAPIs.emplace("clGetExtensionFunctionAddress") ;
+    OpenCLAPIs.emplace("clGetExtensionFunctionAddressForPlatform") ;
+    OpenCLAPIs.emplace("clGetImageInfo") ;
+    OpenCLAPIs.emplace("clGetKernelArgInfo") ;
+    OpenCLAPIs.emplace("clGetKernelInfo") ;
+    OpenCLAPIs.emplace("clGetKernelWorkGroupInfo") ;
+    OpenCLAPIs.emplace("clGetMemObjectInfo") ;
+    OpenCLAPIs.emplace("clGetPipeInfo") ;
+    OpenCLAPIs.emplace("clGetPlatformIDs") ;
+    OpenCLAPIs.emplace("clGetPlatformInfo") ;
+    OpenCLAPIs.emplace("clGetSamplerInfo") ;
+    OpenCLAPIs.emplace("clGetSupportedImageFormats") ;
+    OpenCLAPIs.emplace("clLinkProgram") ;
+    OpenCLAPIs.emplace("clReleaseCommandQueue") ;
+    OpenCLAPIs.emplace("clReleaseContext") ;
+    OpenCLAPIs.emplace("clReleaseDevice") ;
+    OpenCLAPIs.emplace("clReleaseEvent") ;
+    OpenCLAPIs.emplace("clReleaseKernel") ;
+    OpenCLAPIs.emplace("clReleaseMemObject") ;
+    OpenCLAPIs.emplace("clReleaseProgram") ;
+    OpenCLAPIs.emplace("clReleaseSampler") ;
+    OpenCLAPIs.emplace("clRetainContext") ;
+    OpenCLAPIs.emplace("clRetainDevice") ;
+    OpenCLAPIs.emplace("clRetainEvent") ;
+    OpenCLAPIs.emplace("clRetainKernel") ;
+    OpenCLAPIs.emplace("clRetainMemObject") ;
+    OpenCLAPIs.emplace("clRetainProgram") ;
+    OpenCLAPIs.emplace("clRetainSampler") ;
+    OpenCLAPIs.emplace("clSetCommandQueueProperty") ;
+    OpenCLAPIs.emplace("clSetEventCallback") ;
+    OpenCLAPIs.emplace("clSetKernelArg") ;
+    OpenCLAPIs.emplace("clSetKernelArgSMPointer") ;
+    OpenCLAPIs.emplace("clSetMemObjectDestructorCallback") ;
+    OpenCLAPIs.emplace("clSetPrintfCallback") ;
+    OpenCLAPIs.emplace("clSetUserEventStatus") ;
+    OpenCLAPIs.emplace("clSVMAlloc") ;
+    OpenCLAPIs.emplace("clSVMFree") ;
+    OpenCLAPIs.emplace("clUnloadCompiler") ;
+    OpenCLAPIs.emplace("clUnloadPlatformCompiler") ;
+    OpenCLAPIs.emplace("clWaitForEvents") ;
+    OpenCLAPIs.emplace("clCreateStream") ;
+    OpenCLAPIs.emplace("clCreateStreamBuffer") ;
+    OpenCLAPIs.emplace("clPollStream") ;
+    OpenCLAPIs.emplace("clPollStreams") ;
+    OpenCLAPIs.emplace("clReadStream") ;
+    OpenCLAPIs.emplace("clReleaseStream") ;
+    OpenCLAPIs.emplace("clReleaseStreamBuffer") ;
+    OpenCLAPIs.emplace("clSetStreamOpt") ;
+    OpenCLAPIs.emplace("clWriteStream") ;
+    OpenCLAPIs.emplace("xclGetComputeUnitInfo") ;
+
+    NativeAPIs.emplace("xrt::bo::bo");
+    NativeAPIs.emplace("xrt::bo::size");
+    NativeAPIs.emplace("xrt::bo::address");
+    NativeAPIs.emplace("xrt::bo::export_buffer");
+    NativeAPIs.emplace("xrt::bo::sync");
+    NativeAPIs.emplace("xrt::bo::map");
+    NativeAPIs.emplace("xrt::bo::write");
+    NativeAPIs.emplace("xrt::bo::read");
+    NativeAPIs.emplace("xrt::bo::copy");
+    NativeAPIs.emplace("xrtBOAllocUserPtr");
+    NativeAPIs.emplace("xrtBOAlloc");
+    NativeAPIs.emplace("xrtBOSubAlloc");
+    NativeAPIs.emplace("xrtBOImport");
+    NativeAPIs.emplace("xrtBOExport");
+    NativeAPIs.emplace("xrtBOFree");
+    NativeAPIs.emplace("xrtBOSize");
+    NativeAPIs.emplace("xrtBOSync");
+    NativeAPIs.emplace("xrtBOMap");
+    NativeAPIs.emplace("xrtBOWrite");
+    NativeAPIs.emplace("xrtBORead");
+    NativeAPIs.emplace("xrtBOCopy");
+    NativeAPIs.emplace("xrtBOAddress");
+    NativeAPIs.emplace("xrt::device::device");
+    NativeAPIs.emplace("xrt::device::load_xclbin");
+    NativeAPIs.emplace("xrt::device::get_xclbin_uuid");
+    NativeAPIs.emplace("xrt::device::reset");
+    NativeAPIs.emplace("xrt::device::get_xclbin_section");
+    NativeAPIs.emplace("xrtDeviceOpen");
+    NativeAPIs.emplace("xrtDeviceOpenByBDF");
+    NativeAPIs.emplace("xrtDeviceClose");
+    NativeAPIs.emplace("xrtDeviceLoadXclbin");
+    NativeAPIs.emplace("xrtDeviceLoadXclbinFile");
+    NativeAPIs.emplace("xrtDeviceLoadXclbinHandle");
+    NativeAPIs.emplace("xrtDeviceLoadXclbinUUID");
+    NativeAPIs.emplace("xrtDeviceGetXclbinUUID");
+    NativeAPIs.emplace("xrtDeviceToXclDevice");
+    NativeAPIs.emplace("xrtDeviceOpenFromXcl");
+    NativeAPIs.emplace("xrt::error::error");
+    NativeAPIs.emplace("xrt::error::get_timestamp");
+    NativeAPIs.emplace("xrt::error::get_error_code");
+    NativeAPIs.emplace("xrt::error::to_string");
+    NativeAPIs.emplace("xrtErrorGetLast");
+    NativeAPIs.emplace("xrtErrorGetString");
+    NativeAPIs.emplace("xrt::run::run");
+    NativeAPIs.emplace("xrt::run::start");
+    NativeAPIs.emplace("xrt::run::wait");
+    NativeAPIs.emplace("xrt::run::state");
+    NativeAPIs.emplace("xrt::run::set_event");
+    NativeAPIs.emplace("xrt::run::get_ert_packet");
+    NativeAPIs.emplace("xrt::kernel::kernel");
+    NativeAPIs.emplace("xrt::kernel::read_register");
+    NativeAPIs.emplace("xrt::kernel::write_register");
+    NativeAPIs.emplace("xrt::kernel::group_id");
+    NativeAPIs.emplace("xrt::kernel::offset");
+    NativeAPIs.emplace("xrtPLKernelOpen");
+    NativeAPIs.emplace("xrtPLKernelOpenExclusive");
+    NativeAPIs.emplace("xrtKernelClose");
+    NativeAPIs.emplace("xrtRunOpen");
+    NativeAPIs.emplace("xrtKernelArgGroupId");
+    NativeAPIs.emplace("xrtKernelArgOffset");
+    NativeAPIs.emplace("xrtKernelReadRegister");
+    NativeAPIs.emplace("xrtKernelWriteRegister");
+    NativeAPIs.emplace("xrtKernelRun");
+    NativeAPIs.emplace("xrtRunClose");
+    NativeAPIs.emplace("xrtRunState");
+    NativeAPIs.emplace("xrtRunWait");
+    NativeAPIs.emplace("xrtRunWaitFor");
+    NativeAPIs.emplace("xrtRunSetCallback");
+    NativeAPIs.emplace("xrtRunStart");
+    NativeAPIs.emplace("xrtRunUpdateArg");
+    NativeAPIs.emplace("xrtRunUpdateArgV");
+    NativeAPIs.emplace("xrtRunSetArg");
+    NativeAPIs.emplace("xrtRunSetArgV");
+    NativeAPIs.emplace("xrtRunGetArgV");
+    NativeAPIs.emplace("xrtRunGetArgVPP");
+    NativeAPIs.emplace("xrtXclbinAllocFilename");
+    NativeAPIs.emplace("xrtXclbinAllocRawData");
+    NativeAPIs.emplace("xrtXclbinFreeHandle");
+    NativeAPIs.emplace("xrtXclbinGetXSAName");
+    NativeAPIs.emplace("xrtXclbinGetUUID");
+    NativeAPIs.emplace("xrtXclbinGetData");
+    NativeAPIs.emplace("xrtXclbinUUID");
+
+    HALAPIs.emplace("xclLoadXclbin") ;
+    HALAPIs.emplace("xclProbe") ;
+    HALAPIs.emplace("xclOpen") ;
+    HALAPIs.emplace("xclClose") ;
+    HALAPIs.emplace("xclWrite") ;
+    HALAPIs.emplace("xclRead") ;
+    HALAPIs.emplace("xclAllocBO") ;
+    HALAPIs.emplace("xclAllocUserPtrBO") ;
+    HALAPIs.emplace("xclFreeBO") ;
+    HALAPIs.emplace("xclWriteBO") ;
+    HALAPIs.emplace("xclReadBO") ;
+    HALAPIs.emplace("xclMapBO") ;
+    HALAPIs.emplace("xclSyncBO") ;
+    HALAPIs.emplace("xclCopyBO") ;
+    HALAPIs.emplace("xclLockDevice") ;
+    HALAPIs.emplace("xclUnlockDevice") ;
+    HALAPIs.emplace("xclUnmgdPwrite") ;
+    HALAPIs.emplace("xclUnmgdPread") ;
+    HALAPIs.emplace("xclOpenContext") ;
+    HALAPIs.emplace("xclExecBuf") ;
+    HALAPIs.emplace("xclExecWait") ;
+    HALAPIs.emplace("xclCloseContext") ;
+    HALAPIs.emplace("xclGetBOProperties") ;
+  }
+
+  void SummaryWriter::writeHeader()
+  {
+    std::string currentTime = "0000-00-00 0000" ;
+
+    auto time = 
+      std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) ;
+    struct tm* p_tstruct = std::localtime(&time) ;
+    if (p_tstruct) {
+      char buf[80] = {0} ;
+      strftime(buf, sizeof(buf), "%Y-%m-%d %X", p_tstruct) ;
+      currentTime = std::string(buf) ;
+    }
+
+    std::string msecSinceEpoch = "" ;
+    auto timeSinceEpoch = (std::chrono::system_clock::now()).time_since_epoch();
+    auto value =
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeSinceEpoch) ;
+    msecSinceEpoch = std::to_string(value.count()) ;
+
+    std::string execName = "" ;
+#if defined(__linux__) && defined (__x86_64__)
+    const int maxLength = 1024 ;
+    char buf[maxLength] ;
+    ssize_t len ;
+    if ((len=readlink("/proc/self/exe", buf, maxLength-1)) != -1) {
+      buf[len] = '\0' ;
+      execName = buf ;
+    }
+
+    auto slashLocation = execName.find_last_of("/") ;
+    if (slashLocation != std::string::npos) {
+      execName = execName.substr(slashLocation + 1) ;
+    }
+#endif
+
+    boost::property_tree::ptree xrtInfo ;
+    xrt_core::get_xrt_build_info(xrtInfo) ;
+
+    fout << "Profile Summary\n" ;
+    fout << "Generated on: " << currentTime << "\n" ;
+    fout << "Msec since Epoch: " << msecSinceEpoch << "\n" ;
+    fout << "Profiled application: " << execName << "\n" ;
+    fout << "Target platform: " << "Xilinx" << "\n" ;
+    fout << "Tool version: " << getToolVersion() << "\n" ;
+    fout << "XRT build version: " 
+	 << (xrtInfo.get<std::string>("version", "N/A")) << "\n" ;
+    fout << "Build version branch: " 
+	 << (xrtInfo.get<std::string>("branch", "N/A")) << "\n" ;
+    fout << "Build version hash: "
+	 << (xrtInfo.get<std::string>("hash", "N/A")) << "\n" ;
+    fout << "Build version date: "
+	 << (xrtInfo.get<std::string>("date", "N/A")) << "\n" ;
+
+    fout << "Target devices: " ;
+    if (getFlowMode() == SW_EMU) {
+      fout << (db->getStaticInfo()).getSoftwareEmulationDeviceName() << "\n" ;
+    }
+    else {
+      std::vector<std::string> deviceNames =
+        (db->getStaticInfo()).getDeviceNames() ;
+      for (unsigned int i = 0 ; i < deviceNames.size() ; ++i) {
+	if (i != 0) fout << ", " ;
+	fout << deviceNames[i] ;
+      }
+      fout << "\n" ;
+    }
+
+    fout << "Flow mode: " ;
+    switch(getFlowMode())
+    {
+    case SW_EMU:  fout << "Software Emulation" ; break ;
+    case HW_EMU:  fout << "Hardware Emulation" ; break ;
+    case HW:      fout << "System Run" ;         break ;
+    case UNKNOWN: fout << "Unknown" ;            break ;
+    default:      fout << "Unknown" ;            break ;
+    }
+    fout << "\n" ;
+  }
+
+  void
+  SummaryWriter::writeAPICalls(APIType type)
+  {
+    // Columns
+    fout << "API Name,Number Of Calls,Total Time (ms),Minimum Time (ms),"
+	 << "Average Time (ms),Maximum Time (ms),\n" ;
+ 
+    // For each function call, across all of the threads, 
+    //  consolidate all the information into what we need
+    std::map<std::string,
+	     std::tuple<uint64_t,
+			double,
+			double,
+			double> > rows ;
+
+    std::map<std::pair<std::string, std::thread::id>,
+	     std::vector<std::pair<double, double>>> callCount =
+      (db->getStats()).getCallCount() ;
+    
+    for (auto call : callCount) {
+      auto callAndThread = call.first ;
+      auto APIName = callAndThread.first ;
+
+      switch (type) {
+      case OPENCL:
+        if (OpenCLAPIs.find(APIName) == OpenCLAPIs.end()) continue ;
+        break ;
+      case NATIVE:
+        if (NativeAPIs.find(APIName) == NativeAPIs.end()) continue ;
+        break ;
+      case HAL:
+        if (HALAPIs.find(APIName) == HALAPIs.end()) continue ;
+        break ;
+      case ALL: // Intentionally fall through
+      default:
+        break ;
+      }
+
+      std::vector<std::pair<double, double>> timesOfCalls = call.second ;
+
+      if (rows.find(APIName) == rows.end()) {
+	std::tuple<uint64_t, double, double, double> blank = 
+	  std::make_tuple<uint64_t, double, double, double>(0,0,std::numeric_limits<double>::max(),0) ;
+
+	rows[APIName] = blank ;
+      }
+
+      for (auto executionTime : timesOfCalls) {
+	auto timeTaken = executionTime.second - executionTime.first ;
+
+	++(std::get<0>(rows[APIName])) ;
+	std::get<1>(rows[APIName]) += timeTaken ;
+	if (timeTaken < std::get<2>(rows[APIName]))
+	  std::get<2>(rows[APIName]) = timeTaken ;
+	if (timeTaken > std::get<3>(rows[APIName]))
+	  std::get<3>(rows[APIName]) = timeTaken ;
+      }
+    }
+
+    for (auto row : rows) {
+      auto averageTime = 
+	(double)(std::get<1>(row.second)) / (double)(std::get<0>(row.second)) ;
+      fout << row.first                      << ","     // API Name
+	   << std::get<0>(row.second)        << ","     // Number of calls
+	   << (std::get<1>(row.second)/1e06) << ","     // Total time
+	   << (std::get<2>(row.second)/1e06) << ","     // Minimum time
+	   << (averageTime/1e06)             << ","     // Average time
+	   << (std::get<3>(row.second)/1e06) << ",\n" ; // Maximum time
+    }
+  }
+
+  void SummaryWriter::writeOpenCLAPICalls()
+  {
+    // Caption
+    fout << "OpenCL API Calls\n" ;
+    writeAPICalls(OPENCL) ;
+  }
+
+  void SummaryWriter::writeNativeAPICalls()
+  {
+    fout << "Native API Calls\n" ;
+    writeAPICalls(NATIVE) ;
+  }
+
+  void SummaryWriter::writeHALAPICalls()
+  {
+    fout << "HAL API Calls\n" ;
+    writeAPICalls(HAL) ;
+  }
+
+  void SummaryWriter::writeHALTransfers()
+  {
+    fout << "HAL data transfers\n" ;
+    fout << "Device ID,"
+         << "Number of Unmanaged Read transactions,"
+         << "Unmanaged Read bytes transferred,"
+         << "Number of Unmanaged Write transactions,"
+         << "Unmanaged Write bytes transferred,"
+         << "Number of xclRead transactions,"
+         << "xclRead bytes transferred,"
+         << "Number of xclWrite transactions,"
+         << "xclWrite bytes transferred,"
+         << "Number of readBuffer transactions,"
+         << "readBuffer bytes transferred,"
+         << "Number of writeBuffer transactions,"
+         << "writeBuffer bytes transferred,\n" ;
+
+    auto memStats = db->getStats().getMemoryStats() ;
+    for (auto iter : memStats) {
+      fout << iter.first                               << ","
+           << iter.second.channels[0].transactionCount << ","
+           << iter.second.channels[0].totalByteCount   << ","
+           << iter.second.channels[1].transactionCount << ","
+           << iter.second.channels[1].totalByteCount   << ","
+           << iter.second.channels[2].transactionCount << ","
+           << iter.second.channels[2].totalByteCount   << ","
+           << iter.second.channels[3].transactionCount << ","
+           << iter.second.channels[3].totalByteCount   << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeKernelExecutionSummary()
+  {
+    // Caption
+    fout << "Kernel Execution" ;
+    if (getFlowMode() == HW_EMU) {
+      fout << " (includes estimated device time)" ;
+    }
+    fout << "\n" ;
+
+    // Column headers
+    fout << "Kernel,Number Of Enqueues,Total Time (ms),Minimum Time (ms),"
+	 << "Average Time (ms),Maximum Time (ms),\n" ; 
+
+    // We can get kernel executions from purely host information
+    std::map<std::string, TimeStatistics> kernelExecutions = 
+      (db->getStats()).getKernelExecutionStats() ;
+
+    for (auto execution : kernelExecutions) {
+      fout << execution.first                         << ","
+	   << (execution.second).numExecutions        << ","
+	   << ((execution.second).totalTime / 1e06)   << ","
+	   << ((execution.second).minTime / 1e06)     << ","
+	   << ((execution.second).averageTime / 1e06) << ","
+	   << ((execution.second).maxTime / 1e06)     << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeTopKernelExecution()
+  {
+    // Caption
+    fout << "Top Kernel Execution\n";
+
+    // Columns
+    fout << "Kernel Instance Address,Kernel,Context ID,Command Queue ID,"
+	 << "Device,Start Time (ms),Duration (ms),Global Work Size,"
+	 << "Local Work Size,\n" ;
+
+    for (std::list<KernelExecutionStats>::iterator iter = (db->getStats()).getTopKernelExecutions().begin() ;
+	 iter != (db->getStats()).getTopKernelExecutions().end() ;
+	 ++iter) {
+      fout << (*iter).kernelInstanceAddress << ","
+	   << (*iter).kernelName << ","
+	   << (*iter).contextId << ","
+	   << (*iter).commandQueueId << "," 
+	   << (*iter).deviceName << ","
+	   << (double)((*iter).startTime) / 1.0e6 << ","
+	   << (double)((*iter).duration) / 1.0e6 << ","
+	   << (*iter).globalWorkSize << ","
+	   << (*iter).localWorkSize << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeTopMemoryWrites()
+  {
+    // Caption
+    fout << "Top Memory Writes: Host to Global Memory\n" ;
+
+    // Columns
+    fout << "Buffer Address,Context ID,Command Queue ID,Start Time (ms),"
+	 << "Duration (ms),Buffer Size (KB),Writing Rate(MB/s),\n" ;
+
+    for (std::list<BufferTransferStats>::iterator iter = (db->getStats()).getTopHostWrites().begin() ;
+	 iter != (db->getStats()).getTopHostWrites().end() ;
+	 ++iter) {
+      double durationMS = (double)((*iter).duration) / 1.0e6 ;
+      double rate = ((double)((*iter).size) / 1000.0) * durationMS ;
+
+      fout << (*iter).address << ","
+	   << (*iter).contextId << ","
+	   << (*iter).commandQueueId << ","
+	   << (double)((*iter).startTime) / 1.0e6 << "," ;
+      if (getFlowMode() == HW)
+	fout << durationMS << "," ;
+      else
+	fout << "N/A," ;
+      fout << (double)((*iter).size) / 1000.0 << "," ;
+      if (getFlowMode() == HW)
+	fout << rate << ",\n" ;
+      else
+	fout << "N/A" << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeTopMemoryReads()
+  {
+    // Caption
+    fout << "Top Memory Reads: Host to Global Memory\n" ;
+
+    // Columns
+    fout << "Buffer Address,Context ID,Command Queue ID,Start Time (ms),"
+	 << "Duration (ms),Buffer Size (KB),Reading Rate(MB/s),\n" ;
+
+    for (std::list<BufferTransferStats>::iterator iter = (db->getStats()).getTopHostReads().begin() ;
+	 iter != (db->getStats()).getTopHostReads().end() ;
+	 ++iter) {
+      double durationMS = (double)((*iter).duration) / 1.0e6 ;
+      double rate = ((double)((*iter).size) / 1000.0) * durationMS ;
+
+      fout << (*iter).address << "," 
+	   << (*iter).contextId << ","
+	   << (*iter).commandQueueId << ","
+	   << (double)((*iter).startTime) / 1.0e6 << "," ;
+      if (getFlowMode() == HW)
+	fout << durationMS << "," ;
+      else
+	fout << "N/A," ;
+      fout << (double)((*iter).size) / 1000.0 << "," ;
+      if (getFlowMode() == HW)
+	fout << rate << ",\n" ;
+      else
+	fout << "N/A" << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeSoftwareEmulationComputeUnitUtilization()
+  {
+    // Caption
+    fout << "Compute Unit Utilization\n" ;
+
+    // Column headers
+    fout << "Device,Compute Unit,Kernel,Global Work Size,Local Work Size,"
+	 << "Number Of Calls,Dataflow Execution,Max Overlapping Executions,"
+	 << "Dataflow Acceleration,Total Time (ms),Minimum Time (ms),"
+	 << "Average Time (ms),Maximum Time (ms),Clock Frequency (MHz),\n" ;
+
+    std::map<std::tuple<std::string, std::string, std::string>,
+	     TimeStatistics> cuStats = 
+      (db->getStats()).getComputeUnitExecutionStats() ;
+
+    for (auto stat : cuStats) {
+      std::string cuName          = (std::get<0>(stat.first)) ;
+      std::string localWorkGroup  = (std::get<1>(stat.first)) ;
+      std::string globalWorkGroup = (std::get<2>(stat.first)) ;
+
+      double averageTime = (stat.second).averageTime ;
+      double totalTime   = static_cast<double>((stat.second).totalTime) ;
+      double minTime     = static_cast<double>((stat.second).minTime) ;
+      double maxTime     = static_cast<double>((stat.second).maxTime) ;
+      uint64_t execCount = (stat.second).numExecutions ;
+
+      // Temporarily, just strip away the _# of the compute unit to get
+      //  the kernel name
+      std::string kernelName = cuName ;
+      auto usPosition = kernelName.find("_") ;
+      if (usPosition != std::string::npos) {
+	kernelName = kernelName.substr(0, usPosition - 1) ;
+      }
+
+      double speedup = (averageTime*execCount)/totalTime ;
+      std::string speedup_string = std::to_string(speedup) + "x" ;
+
+      fout << (db->getStaticInfo()).getSoftwareEmulationDeviceName() << ","
+	   << cuName                              << ","
+	   << (cuName.substr(0, cuName.size()-2)) << "," 
+	   << globalWorkGroup                     << "," 
+	   << localWorkGroup                      << ","
+	   << execCount                           << ","
+	   << "No"                                << ","
+	   << 0                                   << "," // TODO?
+	   << speedup_string                      << ","
+	   << (totalTime / 1e06)                  << ","
+	   << (minTime / 1e06)                    << ","
+	   << (averageTime / 1e06)                << ","
+	   << (maxTime / 1e06)                    << ","
+	   << 300                                 << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeComputeUnitUtilization()
+  {
+    // Caption
+    fout << "Compute Unit Utilization" ;
+    if (getFlowMode() == HW_EMU)
+    {
+      fout << " (includes estimated device times)" ;
+    }
+    fout << std::endl ;
+
+    // Column headers
+    fout << "Device"                     << ","
+	 << "Compute Unit"               << ","
+	 << "Kernel"                     << ","
+	 << "Global Work Size"           << ","
+	 << "Local Work Size"            << ","
+	 << "Number Of Calls"            << ","
+	 << "Dataflow Execution"         << ","
+	 << "Max Overlapping Executions" << ","
+	 << "Dataflow Acceleration"      << ","
+	 << "Total Time (ms)"            << ","
+	 << "Minimum Time (ms)"          << ","
+	 << "Average Time (ms)"          << ","
+	 << "Maximum Time (ms)"          << ","
+	 << "Clock Frequency (MHz)"      << "," 
+	 << std::endl ;
+
+    // The static portion of this output has to come from the
+    //  static database.  The counter portion has to come from the
+    //  dynamic database.  Right now, the compute units are not
+    //  aligned between the two.  We have to make sure this information
+    //  is accessible.
+    
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    // For every device that is connected...
+    for (auto device : infos)
+    {
+      uint64_t deviceId = device->deviceId ;
+
+      // For every xclbin that was loaded on this device
+      for (auto xclbin : device->loadedXclbins) {
+	xclCounterResults values =
+	  (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
+
+	// For every compute unit in the xclbin
+	for (auto cuInfo : xclbin->cus)
+	{
+	  uint64_t amSlotID = (uint64_t)((cuInfo.second)->getAccelMon()) ;
+
+          // Stats don't make sense if runtime or executions = 0
+          if ((values.CuBusyCycles[amSlotID] == 0) ||
+              (values.CuExecCount[amSlotID] == 0))
+            continue;
+
+          // This info is the same for every execution call
+	  std::string cuName = (cuInfo.second)->getName() ;
+	  std::string kernelName = (cuInfo.second)->getKernelName() ;
+	  std::string cuLocalDimensions = (cuInfo.second)->getDim() ;
+	  std::string dataflowEnabled = 
+	    (cuInfo.second)->dataflowEnabled() ? "Yes" : "No" ;
+	  
+	  // For each compute unit, we can have executions from the host
+	  //  with different global work sizes.  Determine the number of 
+	  //  execution types here
+	  std::vector<std::pair<std::string, TimeStatistics>> cuCalls = 
+	    (db->getStats()).getComputeUnitExecutionStats(cuName) ;
+
+	  for (auto cuCall : cuCalls)
+	  {
+	    std::string globalWorkDimensions = cuCall.first ;
+
+	    auto kernelClockMHz = xclbin->clockRateMHz ;
+	    double deviceCyclesMsec = (double)(kernelClockMHz) * 1000.0 ;
+
+	    double cuRunTimeMsec =
+	      (double)(values.CuBusyCycles[amSlotID]) / deviceCyclesMsec ;
+	    double cuRunTimeAvgMsec = (double)(values.CuExecCycles[amSlotID]) / deviceCyclesMsec / (double)(values.CuExecCount[amSlotID]) ;
+	    double cuMaxExecCyclesMsec = (double)(values.CuMaxExecCycles[amSlotID]) / deviceCyclesMsec ;
+	    double cuMinExecCyclesMsec = (double)(values.CuMinExecCycles[amSlotID]) / deviceCyclesMsec ;
+
+	    double speedup = (cuRunTimeAvgMsec * (double)(values.CuExecCount[amSlotID])) / cuRunTimeMsec ;
+
+	    //double speedup =
+	    // (averageTime*(values.CuExecCount[cuIndex]))/totalTime ;
+	    std::string speedup_string = std::to_string(speedup) + "x" ;
+
+	    fout << device->getUniqueDeviceName() << "," 
+		 << cuName << ","
+		 << kernelName << ","
+		 << globalWorkDimensions << ","
+		 << cuLocalDimensions << ","
+		 << values.CuExecCount[amSlotID] << ","
+		 << dataflowEnabled << ","
+		 << values.CuMaxParallelIter[amSlotID] << ","
+		 << speedup_string << ","
+		 << cuRunTimeMsec << "," //<< (totalTime / 1e06) << ","
+		 << cuMinExecCyclesMsec << "," //<< (minTime / 1e06) << ","
+		 << cuRunTimeAvgMsec << "," //<< (averageTime /1e06) << ","
+		 << cuMaxExecCyclesMsec << "," //<< (maxTime / 1e06) << "," 
+		 << (xclbin->clockRateMHz) << ","
+		 << std::endl ;
+	  }
+	}
+      }
+    }
+  }
+
+  void SummaryWriter::writeComputeUnitStallInformation()
+  {
+    if (!(db->getStaticInfo().hasStallInfo())) return ;
+
+    // Caption
+    fout << "Compute Units: Stall Information" << std::endl ;
+
+    // Column headers
+    fout << "Compute Unit"                      << ","
+	 << "Execution Count"                   << ","
+	 << "Running Time (ms)"                 << ","
+	 << "Intra-Kernel Dataflow Stalls (ms)" << ","
+	 << "External Memory Stalls (ms)"       << ","
+	 << "Inter-Kernel Pipe Stalls (ms)"     << "," << std::endl ;
+
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    for (auto device : infos)
+    {
+      for (auto xclbin : device->loadedXclbins)
+      {
+	xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+	uint64_t j = 0 ;      
+	for (auto cu : (xclbin->cus))
+	{
+          double deviceCyclesMsec = (double)(xclbin->clockRateMHz * 1000.0);
+
+	  fout << (cu.second)->getName()     << "," 
+	       << values.CuExecCount[j]      << ","
+	       << (values.CuExecCycles[j] / deviceCyclesMsec)     << ","
+	       << (values.CuStallIntCycles[j] / deviceCyclesMsec) << ","
+	       << (values.CuStallExtCycles[j] / deviceCyclesMsec) << ","
+	       << (values.CuStallStrCycles[j] / deviceCyclesMsec) << std::endl ;
+	  ++j ;
+	}
+      }
+    }
+  }
+
+  void SummaryWriter::writeDataTransferHostToGlobalMemory()
+  {
+    // Caption
+    fout << "Data Transfer: Host to Global Memory" << std::endl ;
+
+    // Column headers
+    fout << "Context:Number of Devices"         << ","
+	 << "Transfer Type"                     << ","
+	 << "Number Of Buffer Transfers"        << ","
+	 << "Transfer Rate (MB/s)"              << ","
+	 << "Average Bandwidth Utilization (%)" << ","
+	 << "Average Buffer Size (KB)"          << ","
+	 << "Total Time (ms)"                   << ","
+	 << "Average Time (ms)"                 << "," 
+	 << std::endl ;
+
+    std::map<std::pair<uint64_t, uint64_t>, BufferStatistics> hostReads =
+      (db->getStats()).getHostReads() ;
+    std::map<std::pair<uint64_t, uint64_t>, BufferStatistics> hostWrites =
+      (db->getStats()).getHostWrites() ;
+
+    for (auto read : hostReads)
+    {
+      std::string contextName = "context" + std::to_string(read.first.first) ;
+      uint64_t numDevices =
+	(db->getStaticInfo()).getNumDevices(read.first.first) ;
+      if (getFlowMode() == HW_EMU)
+      {
+	fout << contextName << ":" << numDevices << ","
+	     << "READ" << ","
+	     << (read.second).count << ","
+	     << "N/A" << ","
+	     << "N/A" << ","
+	     << ((double)((read.second).averageSize) / 1000.0) << ","
+	     << "N/A" << ","
+	     << "N/A" << "," << std::endl ;
+      }
+      else
+      {
+        double totalTimeInS  = (double)((read.second).totalTime / 1e09);
+        double totalSizeInMB = (double)((read.second).totalSize / 1e06);
+        double transferRate  = totalSizeInMB / totalTimeInS; 
+
+	double maxReadBW =
+	  (db->getStaticInfo()).getMaxReadBW(read.first.second) ;
+	double aveBWUtil = (100.0 * transferRate) / maxReadBW ;
+
+	fout << contextName << ":" << numDevices << ","
+	     << "READ" << ","
+	     << (read.second).count << ","
+	     << transferRate << ","
+	     << aveBWUtil << ","
+	     << ((double)((read.second).averageSize) / 1000.0) << ","
+	     << ((read.second).totalTime / 1e06) << ","
+	     << ((read.second).averageTime / 1e06) << "," << std::endl ;
+      }
+    }
+
+    for (auto write : hostWrites)
+    {
+      std::string contextName = "context" + std::to_string(write.first.first) ;
+      uint64_t numDevices =
+	(db->getStaticInfo()).getNumDevices(write.first.first) ;
+
+      if (getFlowMode() == HW_EMU)
+      {
+	fout << contextName << ":" << numDevices << ","
+	     << "WRITE" << ","
+	     << (write.second).count << ","
+	     << "N/A" << ","
+	     << "N/A" << ","
+	     << ((double)((write.second).averageSize) / 1000.0) << ","
+	     << "N/A" << ","
+	     << "N/A" << "," << std::endl ;
+      }
+      else
+      {
+        double totalTimeInS  = (double)((write.second).totalTime / 1e09);
+        double totalSizeInMB = (double)((write.second).totalSize / 1e06);
+        double transferRate  = totalSizeInMB / totalTimeInS; 
+
+	double maxWriteBW =
+	  (db->getStaticInfo()).getMaxWriteBW(write.first.second);
+	double aveBWUtil = (100.0 * transferRate) / maxWriteBW ;
+
+	fout << contextName << ":" << numDevices << "," 
+	     << "WRITE" << ","
+	     << (write.second).count << ","
+	     << transferRate << ","
+	     << aveBWUtil << ","
+	     << ((double)((write.second).averageSize) / 1000.0) << ","
+	     << ((write.second).totalTime / 1e06) << ","
+	     << ((write.second).averageTime / 1e06) << "," << std::endl ;
+      }
+    }
+  }
+
+  void SummaryWriter::writeStreamDataTransfers()
+  {
+    std::vector<DeviceInfo*> infos = db->getStaticInfo().getDeviceInfos() ;
+    
+    bool printTable = false ;
+    for (auto device : infos) {
+      for (auto xclbin : device->loadedXclbins) {
+        xclCounterResults values =
+          db->getDynamicInfo().getCounterResults(device->deviceId,
+                                                 xclbin->uuid) ;
+        for (auto cu : xclbin->cus) {
+          std::vector<uint32_t>* asmMonitors = (cu.second)->getASMs() ;
+          
+          for (auto asmMonitorId : (*asmMonitors)) {
+            if (values.StrNumTranx[asmMonitorId] != 0) {
+              printTable = true ;
+              break ;
+            }
+	  }
+          if (printTable) break ;
+	}
+        if (printTable) break ;
+      }
+      if (printTable) break ;
+    }
+    if (!printTable) return ;
+
+    // Caption
+    fout << "Data Transfer: Streams" << std::endl ;
+    
+    // Column headers
+    fout << "Device"                  << ","
+         << "Master Port"             << ","
+         << "Master Kernel Arguments" << ","
+         << "Slave Port"              << ","
+         << "Slave Kernel Arguments"  << ","
+         << "Number Of Transfers"     << ","
+         << "Transfer Rate (MB/s)"    << ","
+         << "Average Size (KB)"       << ","
+         << "Link Utilization (%)"    << ","
+         << "Link Starve (%)"         << ","
+         << "Link Stall (%)"          << "," 
+         << std::endl ;
+    
+    //std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+    
+    for (auto device : infos) 
+    {
+      for (auto xclbin : device->loadedXclbins)
+      {
+        xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+        for (auto cu : xclbin->cus)
+        {
+          std::vector<uint32_t>* asmMonitors = (cu.second)->getASMs() ;
+          
+          for (auto asmMonitorId : (*asmMonitors))
+          {
+            Monitor* monitor = (db->getStaticInfo()).getASMonitor(device->deviceId, xclbin, asmMonitorId) ;
+            
+            uint64_t numTranx = values.StrNumTranx[asmMonitorId] ;
+            uint64_t busyCycles = values.StrBusyCycles[asmMonitorId];
+            if(0 == numTranx) {
+              continue;
+            }
+ 
+            std::string masterPort = "" ;
+            std::string slavePort = "" ;
+            std::string masterArgs = "" ;
+            std::string slaveArgs = "" ;
+            
+            size_t dashPosition = (monitor->name).find("-") ;
+            if (dashPosition != std::string::npos)
+            {
+              std::string firstHalf = (monitor->name).substr(0, dashPosition);
+              std::string secondHalf = (monitor->name).substr(dashPosition + 1,
+                  (monitor->name).size()-dashPosition-1) ;
+              size_t slashPosition = firstHalf.find("/") ;
+              masterPort = firstHalf;
+              masterArgs = firstHalf.substr(slashPosition + 1, firstHalf.size()-slashPosition-1) ;
+              
+              slashPosition = secondHalf.find("/") ;
+              slavePort = secondHalf;
+              slaveArgs = secondHalf.substr(slashPosition + 1, secondHalf.size()-slashPosition-1) ;
+            }
+            
+            double transferTime = busyCycles / xclbin->clockRateMHz ;
+            double transferRate = (transferTime == 0.0) ? 0 : values.StrDataBytes[asmMonitorId] / transferTime ;
+            
+            double linkStarve = (0 == busyCycles) ? 0 : 
+                (double)(values.StrStarveCycles[asmMonitorId]) / (double)(busyCycles) * 100.0 ;
+            double linkStall = (0 == busyCycles) ? 0 : 
+                (double)(values.StrStallCycles[asmMonitorId]) / (double)(busyCycles) * 100.0 ;
+            double linkUtil = 100.0 - linkStarve - linkStall ;
+            double avgSizeInKB = ((values.StrDataBytes[asmMonitorId] / numTranx)) / 1000.0;
+            
+            fout << device->getUniqueDeviceName() << ","
+                 << masterPort << ","
+                 << masterArgs << ","
+                 << slavePort << ","
+                 << slaveArgs << ","
+                 << numTranx << ","
+                 << transferRate << ","
+                 << avgSizeInKB << ","
+                 << linkUtil << "," 
+                 << linkStarve << ","
+                 << linkStall << ","
+                 << std::endl ;
+          }
+        }
+      }
+    }
+  }
+
+  void SummaryWriter::writeDataTransferDMA()
+  {
+    // Only output this table and header if some device has 
+    //  DMA monitors in the shell
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    if (infos.size() == 0) return ;
+    bool printTable = false ;
+    for (auto device : infos) {
+      if (device->hasDMAMonitor()) {
+	printTable = true ;
+	break ;
+      }
+    }
+    if (!printTable) return ;
+
+    // Caption
+    fout << "Data Transfer: DMA" << std::endl ;
+
+    // Columns
+    fout << "Device"                   << ","
+	 << "Transfer Type"            << ","
+	 << "Number Of Transfers"      << ","
+	 << "Transfer Rate (MB/s)"     << ","
+	 << "Total Data Transfer (MB)" << ","
+	 << "Total Time (ms)"          << ","
+	 << "Average Size (KB)"        << ","
+	 << "Average Latency (ns)"     << "," 
+	 << std::endl ;
+
+
+    for (auto device : infos)
+    {
+      for (auto xclbin : device->loadedXclbins)
+      {
+      
+      uint64_t AIMIndex = 0 ;
+      for (auto monitor : device->currentXclbin()->aimList)
+      {
+	if (monitor->name.find("Host to Device") != std::string::npos)
+	{
+	  // This is the monitor we are looking for
+	  xclCounterResults values =
+	    (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+
+	  if (values.WriteTranx[AIMIndex] > 0)
+	  {
+	    uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
+	    double totalWriteTime =
+	      (double)(totalWriteBusyCycles) / (1000.0 * xclbin->clockRateMHz);
+	    double writeTransferRate = (totalWriteTime == 0.0) ? 0 :
+	      (double)(values.WriteBytes[AIMIndex]) / (1000.0 * totalWriteTime);
+
+	    fout << device->getUniqueDeviceName() << ","
+		 << "WRITE" << ","
+		 << values.WriteTranx[AIMIndex] << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << writeTransferRate << "," ;
+	    }
+
+	    fout << ((double)(values.WriteBytes[AIMIndex] / 1.0e6)) << "," ;
+
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << (totalWriteTime / 1e06) << "," ;
+	    }
+	    fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / 1000.0 << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," << std::endl ;
+	    }
+	    else
+	    {
+	      fout << ((1000.0 * values.WriteLatency[AIMIndex]) / xclbin->clockRateMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
+	    }
+	  }
+	  if (values.ReadTranx[AIMIndex] > 0)
+	  {
+	    uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+	    double totalReadTime =
+	      (double)(totalReadBusyCycles) / (1000.0 * xclbin->clockRateMHz);
+	    double readTransferRate = (totalReadTime == 0.0) ? 0 :
+	      (double)(values.ReadBytes[AIMIndex]) / (1000.0 * totalReadTime);
+
+	    fout << device->getUniqueDeviceName() << ","
+		 << "READ" << ","
+		 << values.ReadTranx[AIMIndex] << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << readTransferRate << "," ;
+	    }
+
+	    fout << ((double)(values.ReadBytes[AIMIndex] / 1.0e6)) << "," ;
+
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << (totalReadTime / 1e06) << "," ;
+	    }
+	    fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / 1000.0 << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," << std::endl ;
+	    }
+	    else
+	    {
+	      fout << ((1000.0 * values.ReadLatency[AIMIndex]) / xclbin->clockRateMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
+	    }
+	  }
+	}
+	++AIMIndex ;
+      }
+      }
+    }
+  }
+
+  void SummaryWriter::writeDataTransferDMABypass()
+  {
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    if (infos.size() == 0) return ;
+    bool printTable = false ;
+    for (auto device : infos) {
+      if (device->hasDMABypassMonitor()) {
+	printTable = true ;
+	break ;
+      }
+    }
+    if (!printTable) return ;
+
+    printTable = false ;
+    for (auto device : infos) {
+      for (auto xclbin : device->loadedXclbins) {
+        uint64_t AIMIndex = 0 ;
+        for (auto monitor : device->currentXclbin()->aimList) {
+          if (monitor->name.find("Peer to Peer") != std::string::npos) {
+            // This is the monitor we're looking for
+            xclCounterResults values =
+              db->getDynamicInfo().getCounterResults(device->deviceId,
+                                                     xclbin->uuid) ;
+            if (values.WriteTranx[AIMIndex] > 0 ||
+                values.ReadTranx[AIMIndex] > 0) {
+              printTable = true ;
+              break ;
+	    }
+	  }
+          ++AIMIndex ;
+	}
+        if (printTable) break ;
+      }
+      if (printTable) break ;
+    }
+    if (!printTable) return ;
+
+    // Caption
+    fout << "Data Transfer: DMA Bypass" << std::endl ;
+
+    // Columns
+    fout << "Device"                   << ","
+	 << "Transfer Type"            << ","
+	 << "Number Of Transfers"      << ","
+	 << "Transfer Rate (MB/s)"     << ","
+	 << "Total Data Transfer (MB)" << ","
+	 << "Total Time (ms)"          << ","
+	 << "Average Size (KB)"        << ","
+	 << "Average Latency (ns)"     << "," 
+	 << std::endl ;
+
+    for (auto device : infos) {
+      for (auto xclbin : device->loadedXclbins) {
+        uint64_t AIMIndex = 0 ;
+        for (auto monitor : device->currentXclbin()->aimList) {
+          if (monitor->name.find("Peer to Peer") != std::string::npos) {
+            // This is the monitor we are looking for
+	    xclCounterResults values =
+	      db->getDynamicInfo().getCounterResults(device->deviceId,
+                                                     xclbin->uuid) ;
+            if (values.WriteTranx[AIMIndex] > 0) {
+              uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
+	      double totalWriteTime =
+	        (double)(totalWriteBusyCycles) / (1000.0 * xclbin->clockRateMHz);
+	      double writeTransferRate = (totalWriteTime == 0.0) ? 0 :
+	        (double)(values.WriteBytes[AIMIndex]) / (1000.0 * totalWriteTime);
+
+              fout << device->getUniqueDeviceName() << "," << "WRITE" << ","
+                   << values.WriteTranx[AIMIndex] << "," ;
+	      if (getFlowMode() == HW_EMU) {
+	        fout << "N/A" << "," ;
+	      }
+	      else {
+                fout << writeTransferRate << "," ;
+	      }
+
+	      fout << ((double)(values.WriteBytes[AIMIndex] / 1.0e6)) << "," ;
+
+	      if (getFlowMode() == HW_EMU) {
+  	        fout << "N/A" << "," ;
+	      }
+	      else {
+ 	        fout << (totalWriteTime / 1e06) << "," ;
+	      }
+	      fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / 1000.0 << "," ;
+	      if (getFlowMode() == HW_EMU) {
+	        fout << "N/A" << "," << std::endl ;
+	      }
+	      else {
+	        fout << ((1000.0 * values.WriteLatency[AIMIndex]) / xclbin->clockRateMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
+	      }
+	    }
+	    if (values.ReadTranx[AIMIndex] > 0) {
+ 	      uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+	      double totalReadTime =
+	        (double)(totalReadBusyCycles) / (1000.0 * xclbin->clockRateMHz);
+	      double readTransferRate = (totalReadTime == 0.0) ? 0 :
+	        (double)(values.ReadBytes[AIMIndex]) / (1000.0 * totalReadTime);
+
+	      fout << device->getUniqueDeviceName() << ","
+	 	   << "READ" << ","
+		   << values.ReadTranx[AIMIndex] << "," ;
+	      if (getFlowMode() == HW_EMU) {
+	        fout << "N/A" << "," ;
+	      }
+	      else {
+	        fout << readTransferRate << "," ;
+	      }
+
+	      fout << ((double)(values.ReadBytes[AIMIndex] / 1.0e6)) << "," ;
+
+	      if (getFlowMode() == HW_EMU) {
+	        fout << "N/A" << "," ;
+	      }
+	      else {
+	        fout << (totalReadTime / 1e06) << "," ;
+	      }
+	      fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / 1000.0 << "," ;
+	      if (getFlowMode() == HW_EMU) {
+	        fout << "N/A" << "," << std::endl ;
+	      }
+	      else {
+	        fout << ((1000.0 * values.ReadLatency[AIMIndex]) / xclbin->clockRateMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
+	      }
+	    }
+	  }
+	  ++AIMIndex ;
+        }
+      }
+    }
+  }
+
+  void SummaryWriter::writeDataTransferGlobalMemoryToGlobalMemory()
+  {
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    if (infos.size() == 0) return ;
+    bool printTable = false ;
+    for (auto device : infos) {
+      if (device->hasKDMAMonitor()) {
+	printTable = true ;
+	break ;
+      }
+    }
+    if (!printTable) return ;
+
+    // Caption
+    fout << "Data Transfer: Global Memory to Global Memory" << std::endl ;
+
+    // Columns
+    fout << "Device"                   << ","
+	 << "Transfer Type"            << ","
+	 << "Number Of Transfers"      << ","
+	 << "Transfer Rate (MB/s)"     << ","
+	 << "Total Data Transfer (MB)" << ","
+	 << "Total Time (ms)"          << ","
+	 << "Average Size (KB)"        << ","
+	 << "Average Latency (ns)"     << ","
+	 << std::endl ;
+
+    for (auto device : infos)
+    {
+      for (auto xclbin : device->loadedXclbins)
+	{
+      uint64_t AIMIndex = 0 ;
+      for (auto monitor : device->currentXclbin()->aimList)
+      {
+	if (monitor->name.find("Memory to Memory") != std::string::npos)
+	{
+	  // This is the monitor we are looking for
+	  xclCounterResults values =
+	    (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+
+	  if (values.WriteTranx[AIMIndex] > 0)
+	  {
+	    uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
+	    double totalWriteTime =
+	      (double)(totalWriteBusyCycles) / (1000.0 * xclbin->clockRateMHz);
+	    double writeTransferRate = (totalWriteTime == 0.0) ? 0 :
+	      (double)(values.WriteBytes[AIMIndex]) / (1000.0 * totalWriteTime);
+
+	    fout << device->getUniqueDeviceName() << ","
+		 << "WRITE" << ","
+		 << values.WriteTranx[AIMIndex] << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << writeTransferRate << "," ;
+	    }
+
+	    fout << ((double)(values.WriteBytes[AIMIndex] / 1.0e6)) << "," ;
+
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << (totalWriteTime / 1e06) << "," ;
+	    }
+	    fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / 1000.0 << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," << std::endl ;
+	    }
+	    else
+	    {
+	      fout << ((1000.0 * values.WriteLatency[AIMIndex]) / xclbin->clockRateMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
+	    }
+	  }
+	  if (values.ReadTranx[AIMIndex] > 0)
+	  {
+	    uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+	    double totalReadTime =
+	      (double)(totalReadBusyCycles) / (1000.0 * xclbin->clockRateMHz);
+	    double readTransferRate = (totalReadTime == 0.0) ? 0 :
+	      (double)(values.ReadBytes[AIMIndex]) / (1000.0 * totalReadTime);
+
+	    fout << device->getUniqueDeviceName() << ","
+		 << "READ" << ","
+		 << values.ReadTranx[AIMIndex] << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << readTransferRate << "," ;
+	    }
+
+	    fout << ((double)(values.ReadBytes[AIMIndex] / 1.0e6)) << "," ;
+
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," ;
+	    }
+	    else
+	    {
+	      fout << (totalReadTime / 1e06) << "," ;
+	    }
+	    fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / 1000.0 << "," ;
+	    if (getFlowMode() == HW_EMU)
+	    {
+	      fout << "N/A" << "," << std::endl ;
+	    }
+	    else
+	    {
+	      fout << ((1000.0 * values.ReadLatency[AIMIndex]) / xclbin->clockRateMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
+	    }
+	  }
+	}
+	++AIMIndex ;
+      }
+	}
+    }
+  }
+
+  void SummaryWriter::writeDataTransferKernelsToGlobalMemory()
+  {
+    // Caption
+    fout << "Data Transfer: Kernels to Global Memory\n" ;
+
+    // Column headers
+    fout << "Device"                            << ","
+	 << "Compute Unit/Port Name"            << ","
+	 << "Kernel Arguments"                  << ","
+	 << "Memory Resources"                  << ","
+	 << "Transfer Type"                     << ","
+	 << "Number Of Transfers"               << ","
+	 << "Transfer Rate (MB/s)"              << ","
+	 << "Average Bandwidth Utilization (%)" << ","
+	 << "Average Size (KB)"                 << ","
+	 << "Average Latency (ns)"              << "," 
+	 << std::endl ;
+
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    for (auto device : infos)
+    {
+      for (auto xclbin : device->loadedXclbins)
+      {
+	xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+
+	// Counter results don't use the slotID.  Instead, they are filled
+	//  in the struct in the order in which we found them.
+	uint64_t monitorId = 0 ;
+	for (auto monitor : xclbin->aimList) {
+	  if (monitor->cuIndex == -1) {
+	    // This AIM is either a shell or floating 
+	    ++monitorId ;
+	    continue ;
+	  }
+
+	  auto writeTranx = values.WriteTranx[monitorId] ;
+	  auto readTranx  = values.ReadTranx[monitorId] ;
+
+	  uint64_t totalReadBusyCycles  = values.ReadBusyCycles[monitorId] ;
+	  uint64_t totalWriteBusyCycles = values.WriteBusyCycles[monitorId] ;
+
+	  double totalReadTime = 
+	    (double)(totalReadBusyCycles) / (1000.0 * xclbin->clockRateMHz) ;
+	  double totalWriteTime =
+	    (double)(totalWriteBusyCycles) / (1000.0 * xclbin->clockRateMHz) ;
+
+	  // Use the name of the monitor to determine the port and memory
+	  std::string portName   = "" ;
+	  std::string memoryName = "" ;
+	  size_t slashPosition = (monitor->name).find("/") ;
+	  if (slashPosition != std::string::npos) {
+	    auto position = slashPosition + 1 ;
+	    auto length = (monitor->name).size() - position ;
+
+	    // Split the monitor name into port and memory position
+	    std::string lastHalf = (monitor->name).substr(position, length) ;
+	      
+	    size_t dashPosition = lastHalf.find("-") ;
+	    if (dashPosition != std::string::npos) {
+	      auto remainingLength = lastHalf.size() - dashPosition - 1 ;
+	      portName = lastHalf.substr(0, dashPosition) ;
+	      memoryName = lastHalf.substr(dashPosition + 1, remainingLength);
+	    }
+	    else {
+	      portName = lastHalf ;
+	    }
+	  }
+	  if (writeTranx > 0) {
+	    double transferRate = (totalWriteTime == 0.0) ? 0 :
+	      (double)(values.WriteBytes[monitorId]) / (1000.0 * totalWriteTime);
+	    double aveBW =
+	      (100.0 * transferRate) / xclbin->maxWriteBW ;
+	    if (aveBW > 100.0) aveBW = 100.0 ;
+
+	    fout << device->getUniqueDeviceName() << ","
+		 << xclbin->cus[monitor->cuIndex]->getName() << "/"
+		 << portName << ","
+		 << (monitor->args) << ","
+		 << memoryName << ","
+		 << "WRITE" << ","
+		 << writeTranx << ","
+		 << transferRate << ","
+		 << aveBW << ","
+		 << (double)(values.WriteBytes[monitorId] / writeTranx) / 1000.0 << ","
+		 << (values.WriteLatency[monitorId] / writeTranx) << "," 
+		 << std::endl ;
+	  }
+	  if (readTranx > 0) {
+	      double transferRate = (totalReadTime == 0.0) ? 0 :
+		(double)(values.ReadBytes[monitorId]) / (1000.0 * totalReadTime);
+	      double aveBW =
+		(100.0 * transferRate) / xclbin->maxReadBW ;
+	      if (aveBW > 100.0) aveBW = 100.0 ;
+
+	      fout << device->getUniqueDeviceName() << ","
+		   << xclbin->cus[monitor->cuIndex]->getName() << "/"
+		   << portName << ","
+		   << (monitor->args) << ","
+		   << memoryName << ","
+		   << "READ" << ","
+		   << readTranx << ","
+		   << transferRate << ","
+		   << aveBW << ","
+		   << (double)(values.ReadBytes[monitorId] / readTranx) / 1000.0 << ","
+		   << (values.ReadLatency[monitorId] / readTranx) << "," 
+		   << std::endl ;
+	  }
+	  ++monitorId ;
+	}
+      }
+    }
+  }
+
+  void SummaryWriter::writeTopDataTransferKernelAndGlobal()
+  {
+    // Caption
+    fout << "Top Data Transfer: Kernels to Global Memory" << std::endl ;
+
+    // Columns
+    fout << "Device"                     << ","
+	 << "Compute Unit"               << ","
+	 << "Number of Transfers"        << ","
+	 << "Average Bytes per Transfer" << ","
+	 << "Transfer Efficiency (%)"    << ","
+	 << "Total Data Transfer (MB)"   << ","
+	 << "Total Write (MB)"           << ","
+	 << "Total Read (MB)"            << ","
+	 << "Total Transfer Rate (MB/s)" << "," 
+	 << std::endl ;
+
+    std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
+
+    for (auto device : infos)
+    {
+      uint64_t deviceId = device->deviceId ;
+
+      for (auto xclbin : device->loadedXclbins)
+      {
+	xclCounterResults values =
+	  (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
+
+	for (auto cu : xclbin->cus)
+	{
+	  // For each CU, we need to find the monitor that has 
+	  //  the most transactions
+	  std::string computeUnitName = (cu.second)->getName() ;
+	  std::vector<uint32_t>* aimMonitors = (cu.second)->getAIMs() ;
+
+	  // These are the max we have seen so far
+	  uint64_t numTransfers = 0 ;
+	  double aveBytesPerTransfer = 0 ;
+	  double transferEfficiency = 0 ;
+	  uint64_t totalDataTransfer = 0 ;
+	  uint64_t totalWriteBytes = 0 ;
+	  uint64_t totalReadBytes = 0 ;
+	  double totalTransferRate = 0 ;
+
+	  for (auto AIMIndex : (*aimMonitors))
+	  {
+	    auto writeTranx = values.WriteTranx[AIMIndex] ;
+	    auto readTranx = values.ReadTranx[AIMIndex] ;
+	    auto totalTranx = writeTranx + readTranx ;
+
+	    if (totalTranx > numTransfers) {
+	      numTransfers = totalTranx ;
+	      totalReadBytes = values.ReadBytes[AIMIndex] ;
+	      totalWriteBytes = values.WriteBytes[AIMIndex] ;
+	      aveBytesPerTransfer =
+		(double)(totalReadBytes + totalWriteBytes)/(double)(numTransfers);
+	      // TODO: Fix bit width calculation here
+	      transferEfficiency = (100.0 * aveBytesPerTransfer) / 4096 ; 
+	      totalDataTransfer = totalReadBytes + totalWriteBytes ;
+	      auto totalBusyCycles =
+		values.ReadBusyCycles[AIMIndex]+values.WriteBusyCycles[AIMIndex];
+	      double totalTimeMSec = 
+		(double)(totalBusyCycles) /(1000.0 * xclbin->clockRateMHz) ;
+	      totalTransferRate =
+		(totalTimeMSec == 0) ? 0.0 :
+		(double)(totalDataTransfer) / (1000.0 * totalTimeMSec) ;
+	    }
+	  }
+
+	  // Verify that this CU actually had some data transfers registered
+	  if (computeUnitName != "" && numTransfers != 0) {
+	    fout << device->getUniqueDeviceName() << ","
+		 << computeUnitName << ","
+		 << numTransfers << ","
+		 << aveBytesPerTransfer << ","
+		 << transferEfficiency << ","
+		 << (double)(totalDataTransfer) / 1.0e6 << ","
+		 << (double)(totalWriteBytes) / 1.0e6 << ","
+		 << (double)(totalReadBytes) / 1.0e6 << ","
+		 << totalTransferRate << "," << std::endl ;
+	  }
+	}
+      }
+    }
+  }
+
+  void SummaryWriter::writeUserLevelEvents()
+  {
+    if (!db->getStats().eventInformationPresent()) return ;
+
+    fout << "User Level Events\n" ;
+    fout << "Label,Count,\n" ;
+
+    std::map<std::string, uint64_t>& counts = db->getStats().getEventCounts() ;
+    for (auto iter : counts) {
+      fout << iter.first << "," << iter.second << ",\n" ;
+    }
+  }
+
+  void SummaryWriter::writeUserLevelRanges()
+  {
+    if (!db->getStats().rangeInformationPresent()) return ;
+
+    fout << "User Level Ranges\n" ;
+    fout << "Label,Tooltip,Count,Min Duration (ms),Max Duration (ms),"
+         << "Total Time Duration (ms),Average Duration (ms),\n" ;
+
+    std::map<std::pair<const char*, const char*>, uint64_t>& counts =
+      (db->getStats()).getRangeCounts() ;
+    std::map<std::pair<const char*, const char*>, uint64_t>& minDurations =
+      (db->getStats()).getMinRangeDurations() ;
+    std::map<std::pair<const char*, const char*>, uint64_t>& maxDurations =
+      (db->getStats()).getMaxRangeDurations() ;
+    std::map<std::pair<const char*, const char*>, uint64_t>& totalDurations =
+      (db->getStats()).getTotalRangeDurations() ;
+
+    for (auto iter : counts) {
+      const char* label =
+	(iter.first.first == nullptr) ? " " : iter.first.first;
+      const char* tooltip =
+	(iter.first.second == nullptr) ? " " : iter.first.second ;
+      fout << label       << ","
+	   << tooltip     << ","
+	   << iter.second << ","
+	   << (double)minDurations[iter.first] / 1e06 << ","
+	   << (double)maxDurations[iter.first] / 1e06 << ","
+	   << (double)totalDurations[iter.first] / 1e06<< ","
+	   << ((double)totalDurations[iter.first]/(double)(iter.second)) / 1e06 << ","
+	   << std::endl ;
+    }
+  }
+
+  bool SummaryWriter::write(bool openNewFile)
+  {
+    // Every summary has to have a header
+    writeHeader() ;                                      fout << "\n" ;
+
+    if (db->infoAvailable(info::opencl_counters)) {
+      writeOpenCLAPICalls() ;                            fout << "\n" ;
+      writeKernelExecutionSummary() ;                    fout << "\n" ;
+      writeTopKernelExecution() ;                        fout << "\n" ;
+      writeTopMemoryWrites() ;                           fout << "\n" ;
+      writeTopMemoryReads() ;                            fout << "\n" ;
+      if (getFlowMode() == SW_EMU) {
+        writeSoftwareEmulationComputeUnitUtilization() ; fout << "\n" ;
+      }
+      // OpenCL specific device tables
+      if (db->infoAvailable(info::device_offload)) {
+        writeComputeUnitUtilization() ;                  fout << "\n" ;
+        writeDataTransferHostToGlobalMemory() ;          fout << "\n" ;
+      }
+    }
+
+    // Generic device tables
+    if (db->infoAvailable(info::device_offload)) {
+      writeDataTransferDMA() ;                           fout << "\n" ;
+      writeDataTransferDMABypass() ;                     fout << "\n" ;
+      writeStreamDataTransfers() ;                       fout << "\n" ;
+      writeDataTransferKernelsToGlobalMemory() ;         fout << "\n" ;
+      writeTopDataTransferKernelAndGlobal() ;            fout << "\n" ;
+      writeDataTransferGlobalMemoryToGlobalMemory() ;    fout << "\n" ;
+      writeComputeUnitStallInformation() ;               fout << "\n" ;
+    }
+
+    if (db->infoAvailable(info::user)) {
+      writeUserLevelEvents() ;                           fout << "\n" ;
+      writeUserLevelRanges() ;                           fout << "\n" ;
+    }
+
+    if (db->infoAvailable(info::native)) {
+      writeNativeAPICalls() ;                            fout << "\n" ;
+    }
+
+    if (db->infoAvailable(info::hal)) {
+      writeHALAPICalls() ;                               fout << "\n" ;
+      //writeHALTransfers() ;                              fout << "\n" ;
+    }
+
+    // Generate all the applicable guidance rules
+    guidance.write(db, fout) ;
+
+    fout.flush() ;
+    return true ;
+  }
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -22,6 +22,11 @@
 
 #include "core/common/config_reader.h"
 
+#ifdef _WIN32
+/* Disable warning for use of localtime */
+#pragma warning(disable : 4996)
+#endif
+
 namespace xdp {
 
   SummaryWriter::SummaryWriter(const char* filename) 
@@ -1620,7 +1625,7 @@ namespace xdp {
     }
   }
 
-  bool SummaryWriter::write(bool openNewFile)
+  bool SummaryWriter::write(bool /*openNewFile*/)
   {
     // Every summary has to have a header
     writeHeader() ;                                      fout << "\n" ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2016-2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef SUMMARY_WRITER_DOT_H
+#define SUMMARY_WRITER_DOT_H
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <fstream>
+#include <functional>
+#include <set>
+
+#include "xdp/config.h"
+#include "xdp/profile/writer/vp_base/vp_summary_writer.h"
+#include "xdp/profile/writer/vp_base/guidance_rules.h"
+
+namespace xdp {
+
+  class SummaryWriter : public VPSummaryWriter
+  {
+  private:
+    SummaryWriter() = delete ;
+    GuidanceRules guidance ;
+
+    std::set<std::string> OpenCLAPIs ;
+    std::set<std::string> NativeAPIs ;
+    std::set<std::string> HALAPIs ;
+
+    void initializeAPIs() ;
+
+    void writeHeader() ;
+
+    // OpenCL host tables
+    void writeOpenCLAPICalls() ;
+    void writeKernelExecutionSummary() ;
+    void writeTopKernelExecution() ;
+    void writeTopMemoryWrites() ;
+    void writeTopMemoryReads() ;
+
+    // Generic host tables
+    enum APIType { OPENCL, NATIVE, HAL, ALL } ;
+    void writeAPICalls(APIType type) ;
+
+    // OpenCL specific device tables
+    void writeSoftwareEmulationComputeUnitUtilization() ;
+    void writeComputeUnitUtilization() ;
+    void writeComputeUnitStallInformation() ;
+    void writeDataTransferHostToGlobalMemory() ;
+
+    // Generic device tables
+    void writeDataTransferDMA() ;
+    void writeDataTransferDMABypass() ;
+    void writeStreamDataTransfers() ;
+    void writeDataTransferKernelsToGlobalMemory() ;
+    void writeTopDataTransferKernelAndGlobal() ;
+    void writeDataTransferGlobalMemoryToGlobalMemory() ;
+
+    // User event tables
+    void writeUserLevelEvents() ;
+    void writeUserLevelRanges() ;
+
+    // Native XRT tables
+    void writeNativeAPICalls() ;
+
+    // HAL tables
+    void writeHALAPICalls() ;
+    void writeHALTransfers() ;
+
+  public:
+    XDP_EXPORT SummaryWriter(const char* filename) ;
+    XDP_EXPORT SummaryWriter(const char* filename, VPDatabase* inst) ;
+    XDP_EXPORT ~SummaryWriter() ;
+
+    XDP_EXPORT virtual bool write(bool openNewFile) ;
+  } ;
+
+} // end namespace xdp
+
+#endif

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.cpp
@@ -28,6 +28,11 @@ namespace xdp {
   {
   }
 
+  VPSummaryWriter::VPSummaryWriter(const char* filename, VPDatabase* inst) :
+    VPWriter(filename, inst)
+  {
+  }
+
   VPSummaryWriter::~VPSummaryWriter()
   {
   }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.h
@@ -32,6 +32,7 @@ namespace xdp {
     XDP_EXPORT virtual void switchFiles() ;
   public:
     XDP_EXPORT VPSummaryWriter(const char* filename) ;
+    XDP_EXPORT VPSummaryWriter(const char* filename, VPDatabase* inst);
     XDP_EXPORT ~VPSummaryWriter() ;
   } ;
   

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -21,9 +21,14 @@
 
 namespace xdp {
 
-  VPWriter::VPWriter(const char* filename) : 
-    basename(filename), currentFileName(filename), fileNum(1),
-    db(VPDatabase::Instance()), fout(filename)
+  VPWriter::VPWriter(const char* filename) :
+    VPWriter(filename, VPDatabase::Instance())
+  {
+  }
+
+  VPWriter::VPWriter(const char* filename, VPDatabase* inst) :
+    basename(filename), currentFileName(filename), fileNum(1), db(inst),
+    fout(filename)
   {
   }
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -56,6 +56,7 @@ namespace xdp {
     XDP_EXPORT virtual void refreshFile() ;
   public:
     XDP_EXPORT VPWriter(const char* filename) ;
+    XDP_EXPORT VPWriter(const char* filename, VPDatabase* inst) ;
     XDP_EXPORT virtual ~VPWriter() ;
 
     virtual bool isRunSummaryWriter() { return false ; }


### PR DESCRIPTION
This pull request disables the writer for the OpenCL summary and replaces it with a generic summary file produced whenever any profiling plugin is loaded.  Now, every execution that enables any profiling aspect will generate a "summary.csv" file with the applicable information in tables.  Each plugin is now responsible for registering with the database the information that is available for the summary file.

This initial submission also adds two new tables to the profile summary for XRT Native API calls and HAL level calls when information exists.