### PR TITLE
Fixed the issue when interrupt fails and fallback to polling mode for some of the CUs. 

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -172,7 +172,7 @@ static int cu_probe(struct platform_device *pdev)
 		if (err) {
 			DRM_WARN("Failed to initial CU interrupt. "
 			    "Fall back to polling\n");
-			zcu->base.info->intr_enable = 0;
+			zcu->base.info.intr_enable = 0;
 		}
 	}
 

--- a/src/runtime_src/core/edge/drm/zocl/cu.c
+++ b/src/runtime_src/core/edge/drm/zocl/cu.c
@@ -172,7 +172,7 @@ static int cu_probe(struct platform_device *pdev)
 		if (err) {
 			DRM_WARN("Failed to initial CU interrupt. "
 			    "Fall back to polling\n");
-			info->intr_enable = 0;
+			zcu->base.info->intr_enable = 0;
 		}
 	}
 


### PR DESCRIPTION
This fixed the following CR.
CR-1102913

This is the fix when interrupt fails and fallback to polling mode for some of the CUs. 
Performance is degrading because of that. 
Observed this on interrupt mode, on polling mode there is no issue. 