### PR TITLE
CR-1103258 XRT workaround for CR-1100270

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1546,13 +1546,15 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 
 		krnl_info = xocl_query_kernel(xdev, info.kname);
 		if (!krnl_info) {
-			ICAP_WARN(icap, "%s has no metadata. skip", kname);
-			continue;
+			ICAP_WARN(icap, "%s has no metadata. try use default", kname);
+			/* Workaround for U30, maybe we can remove this in the future */
+			/*continue;*/
 		}
 
 		info.inst_idx = inst++;
 		info.addr = ip->m_base_address;
-		info.size = krnl_info->range;
+		/* Workaround for U30, maybe we can remove this in the future */
+		info.size = (krnl_info) ? krnl_info->range : 0x1000;
 		info.num_res = subdev_info.num_res;
 		info.intr_enable = ip->properties & IP_INT_ENABLE_MASK;
 		info.protocol = (ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT;


### PR DESCRIPTION
For U30, the xclbin is constructed in a special way. Some CU metadata is missing. This change is to make this kind of xclbin can go through the flow. The missing metadata would be hardcode for U30.

We will file another CR to back this change out.