### PR TITLE
CR-1103258 XRT workaround for CR-1100270

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -92,6 +92,7 @@ struct kds_cu_mgmt {
 
 /* ERT core */
 struct kds_ert {
+	u32			slot_size;
 	void (* submit)(struct kds_ert *ert, struct kds_command *xcmd);
 	void (* abort)(struct kds_ert *ert, struct kds_client *client, int cu_idx);
 	bool (* abort_done)(struct kds_ert *ert, struct kds_client *client, int cu_idx);

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -696,6 +696,11 @@ uint32_t ert_base_addr = 0;
 #define MAX_CONFIG_PACKET_SIZE 512
 
 /*
+* Maximum size of CQ slot
+*/
+#define MAX_CQ_SLOT_SIZE 4096
+
+/*
  * Helper functions to hide details of ert_start_copybo_cmd
  */
 static inline void

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1546,13 +1546,15 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 
 		krnl_info = xocl_query_kernel(xdev, info.kname);
 		if (!krnl_info) {
-			ICAP_WARN(icap, "%s has no metadata. skip", kname);
-			continue;
+			ICAP_WARN(icap, "%s has no metadata. try use default", kname);
+			/* Workaround for U30, maybe we can remove this in the future */
+			/*continue;*/
 		}
 
 		info.inst_idx = inst++;
 		info.addr = ip->m_base_address;
-		info.size = krnl_info->range;
+		/* Workaround for U30, maybe we can remove this in the future */
+		info.size = (krnl_info) ? krnl_info->range : 0x1000;
 		info.num_res = subdev_info.num_res;
 		info.intr_enable = ip->properties & IP_INT_ENABLE_MASK;
 		info.protocol = (ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -418,6 +418,7 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 				     struct drm_xocl_bo *xobj,
 				     struct ert_packet *ecmd)
 {
+	struct kds_sched *kds = &XDEV(xdev)->kds;
 	struct ert_packet *orig;
 	int pkg_size;
 
@@ -441,6 +442,11 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 
 	if (get_size_with_timestamps_or_zero(ecmd) > xobj->base.size) {
 		userpf_err(xdev, "no space for timestamp in exec buf\n");
+		return false;
+	}
+
+	if (!kds->ert_disable && (kds->ert->slot_size < pkg_size)) {
+		userpf_err(xdev, "payload size bigger than CQ slot size\n");
 		return false;
 	}
 
@@ -946,8 +952,13 @@ static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 	regmap_size = kds_get_max_regmap_size(kds);
 	if (ecmd->slot_size < regmap_size + MAX_HEADER_SIZE)
 		ecmd->slot_size = regmap_size + MAX_HEADER_SIZE;
+
+	if (ecmd->slot_size > MAX_CQ_SLOT_SIZE)
+		ecmd->slot_size = MAX_CQ_SLOT_SIZE;
 	/* cfg->slot_size is for debug purpose */
 	/* ecmd->slot_size	= cfg->slot_size; */
+	/* Record slot size so that KDS could validate command */
+	kds->ert->slot_size = ecmd->slot_size;
 
 	/* Fill CU address */
 	for (i = 0; i < num_cu; i++) {


### PR DESCRIPTION
Backport #5411 and #5412 to workaround xclbin metadata issue on U30.