### PR TITLE
xcl_vcu_test fix : 4K HEVC decode fails after u30validateall script fixes 

### DIFF
--- a/tests/validate/xcl_vcu_test/src/host.cpp
+++ b/tests/validate/xcl_vcu_test/src/host.cpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include "plugin_dec.h"
 
-#define TEST_INSTANCE_ID 1
+#define TEST_INSTANCE_ID 0
 
 int main(int argc, char** argv) {
   if (argc < 2) {

--- a/tests/validate/xcl_vcu_test/src/plugin_dec.cpp
+++ b/tests/validate/xcl_vcu_test/src/plugin_dec.cpp
@@ -615,7 +615,7 @@ gstivas_xvcudec_stop (XrtIvas_XVCUDec *dec)
 {
   int bret = TRUE;
 
-  if (dec->priv->init_done) {
+  if (dec->priv->init_done == TRUE) {
     bret = xvcudec_send_flush (dec);
     if (bret != TRUE)
       return bret;


### PR DESCRIPTION
CR Number CR-1100111 : 

Two fixes are in xcl_vcu_test app of XRT:
1. XRT/tests/validate/xcl_vcu_test/src/plugin_dec.cpp" : Decoder VCU_DEINIT command should be called with prior correct flag assignment/check. The condition check was not correct. Fixed in this PR.
2. XRT/tests/validate/xcl_vcu_tes/src/host.cpp: Host application should set VCU_SK_DECODER_ID to 0 ideally (which is start index)