### PR TITLE
Vitis-1144 Software reset xclbin meta data support

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -630,6 +630,17 @@ get_auto_restart_kernels()
   return value;
 }
 
+// Kernel sw_reset
+// Needed until meta-data support (Vitis-2931)
+// Format is "[/kernel_name/]*"
+// sw_reset_kernels="/kernel1_name/kernel2_name/"
+inline std::string
+get_sw_reset_kernels()
+{
+  static auto value = detail::get_string_value("Runtime.sw_reset_kernels", "");
+  return value;
+}
+
 // WORKAROUND: KDS would only allow xclRegWrite/xclRegRead access
 // exclusively reserved CU.  This switch can loose the limitation. It
 // means xclRegWrite/xclRegRead can access shared CU.

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -54,6 +54,7 @@ struct kernel_properties
   restart_type counted_auto_restart = 0;
   mailbox_type mailbox = mailbox_type::none;
   size_t address_range = 0;
+  bool sw_reset = false;
 };
 
 struct kernel_object
@@ -61,6 +62,7 @@ struct kernel_object
   std::string name;
   std::vector<kernel_argument> args;
   size_t range;
+  bool sw_reset;
 };
 
 /**


### PR DESCRIPTION
Check for sw reset support based on XML meta data.
Support temporary POC via xrt.ini