### PR TITLE
CR1101364: Fix issue in profile summary where arguments sometimes were not printed in some tables

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -61,9 +61,10 @@ namespace {
       memoryName = "DDR" ;
     }
 
-    // Catch old bank format and report as DDR
-    if (memoryName.find("bank") != std::string::npos)
-      memoryName = "DDR";
+    // If we find the old "bank" format, just return it as is since our
+    //  monitor name will also have "bank" in it.
+    //if (memoryName.find("bank") != std::string::npos)
+    //  memoryName = "DDR";
 
     return memoryName.substr(0, memoryName.find_last_of("[")) ;
   }


### PR DESCRIPTION
When looking up the name of a memory resource, we previously changed memory resources named "bank0" to "DDR."  This is no longer necessary and causes issues on some platforms, so this pull request undoes this conversion.