### PR TITLE
CR-1081187 Reduce number of decimal places to one for xbutil validate…

### DIFF
--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -166,7 +166,7 @@ namespace xcldev {
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; // s
-            ostr << boost::str(boost::format("Host -> PCIe -> FPGA write bandwidth = %f MB/s\n") % rate);
+            ostr << boost::str(boost::format("Host -> PCIe -> FPGA write bandwidth = %.1f MB/s\n") % rate);
 
             timer.reset();
             result = runSync(XCL_BO_SYNC_BO_FROM_DEVICE, info.mDMAThreads);
@@ -178,7 +178,7 @@ namespace xcldev {
             rate /= 0x100000; // MB
             rate /= timer_stop;
             rate *= 1000000; //
-            ostr << boost::str(boost::format("Host <- PCIe <- FPGA read bandwidth = %f MB/s\n") % rate);
+            ostr << boost::str(boost::format("Host <- PCIe <- FPGA read bandwidth = %.1f MB/s\n") % rate);
 
             // data integrity check: compare with initialized pattern
             return validate();


### PR DESCRIPTION
**### Reduced number of decimal places to one for xbutil validate**

sadasiva@pranjal-dell:/proj/rdi/staff/sadasiva/XRT/build$ xbutil --new validate --verbose -d 0000:17:00.1

```
Test 5 [0000:17:00.1] : DMA
Description : Run dma test
Details : Host -> PCIe -> FPGA write bandwidth = 9523.6 MB/s
Host <- PCIe <- FPGA read bandwidth = 11800.7 MB/s
Test Status : [PASSED]
```

