### PR TITLE
CR-1103996 XRT 2021.1 branch + 2018.3 sell Alveo U250 reports incorrect behaviour with kds_mode=1

### DIFF
--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -1131,6 +1131,7 @@ command_queue_fetch(size_type slot_idx)
     slot_cache[slot_idx] = val;
     addr_type addr = cu_section_addr(slot_addr);
     slot.cu_idx = read_reg(addr);
+    slot.opcode = opcode(val);
     slot.header_value = val;
     slot.regmap_addr = regmap_section_addr(val,slot_addr);
     slot.regmap_size = regmap_size(val);


### PR DESCRIPTION
The same bug as #5262.
The legacy ERT firmware needs this fix as well. 