### PR TITLE
VITIS-2944 XRT kernel driver memory footprint reduction

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2133,12 +2133,14 @@ static void icap_probe_urpdev_all(struct platform_device *pdev,
 	/* create the rest of subdevs for both mgmt and user pf */
 	icap_probe_urpdev(pdev, xclbin, &num_dev, &subdevs);
 	if (num_dev > 0) {
-		for (i = 0; i < num_dev; i++)
+		for (i = 0; i < num_dev; i++) {
 			(void) xocl_subdev_create(xdev, &subdevs[i].info);
+			xocl_subdev_dyn_free(subdevs + i);
+		}
 	}
 
 	if (subdevs)
-		vfree(subdevs);
+		kfree(subdevs);
 }
 
 /* Create specific subdev */
@@ -2162,8 +2164,10 @@ static int icap_probe_urpdev_by_id(struct platform_device *pdev,
 		}
 	}
 
+	for (i = 0; i < num_dev; i++)
+		xocl_subdev_dyn_free(subdevs + i);
 	if (subdevs)
-		vfree(subdevs);
+		kfree(subdevs);
 
 	return found ? err : -ENODATA;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/intc.c
@@ -337,7 +337,7 @@ static int request_intr(struct platform_device *pdev, int id,
 
 	/* register handler */
 	if (handler) {
-		info = vzalloc(sizeof(struct intr_info));
+		info = kzalloc(sizeof(struct intr_info), GFP_KERNEL);
 		info->handler = handler;
 		info->intr_id = id;
 		info->arg = arg;
@@ -348,7 +348,7 @@ static int request_intr(struct platform_device *pdev, int id,
 
 	/* unregister handler */
 	if (data->info[intr_src]) {
-		vfree(data->info[intr_src]);
+		kfree(data->info[intr_src]);
 		data->info[intr_src] = NULL;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -370,9 +370,9 @@ struct xocl_subdev {
 	struct cdev			*cdev;
 	bool				hold;
 
-	struct resource		res[XOCL_SUBDEV_MAX_RES];
-	char	res_name[XOCL_SUBDEV_MAX_RES][XOCL_SUBDEV_RES_NAME_LEN];
-	char			bar_idx[XOCL_SUBDEV_MAX_RES];
+	struct resource			*res;
+	char				*res_name;
+	char				*bar_idx;
 };
 
 #define XOCL_GET_DRV_PRI(pldev)					\
@@ -411,6 +411,33 @@ static inline void *xocl_subdev_priv_alloc(u32 size)
 		return NULL;
 
 	return priv->data;
+}
+
+static inline int xocl_subdev_dyn_alloc(struct xocl_subdev *subdev, int num)
+{
+	subdev->res = kzalloc(num * sizeof (struct resource), GFP_KERNEL);
+	subdev->res_name = kzalloc(num * XOCL_SUBDEV_RES_NAME_LEN, GFP_KERNEL);
+	subdev->bar_idx = kzalloc(num * sizeof (char), GFP_KERNEL);
+
+	if (!subdev->res || !subdev->res_name || !subdev->bar_idx)
+		return -ENOMEM;
+	return 0;
+}
+
+static inline void xocl_subdev_dyn_free(struct xocl_subdev *subdev)
+{
+	if (subdev->res) {
+		kfree(subdev->res);
+		subdev->res = NULL;
+	}
+	if (subdev->res_name) {
+		kfree(subdev->res_name);
+		subdev->res_name = NULL;
+	}
+	if (subdev->bar_idx) {
+		kfree(subdev->bar_idx);
+		subdev->bar_idx = NULL;
+	}
 }
 
 typedef	void *xdev_handle_t;
@@ -491,7 +518,7 @@ struct xocl_work {
 struct xocl_dev_core {
 	struct pci_dev		*pdev;
 	int			dev_minor;
-	struct xocl_subdev	*subdevs[XOCL_SUBDEV_NUM];
+	struct xocl_subdev	**subdevs[XOCL_SUBDEV_NUM];
 	struct xocl_subdev	*dyn_subdev_store;
 	int			dyn_subdev_num;
 	struct xocl_pci_funcs	*pci_ops;
@@ -608,9 +635,11 @@ struct xocl_rom_funcs {
 };
 
 #define ROM_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_FEATURE_ROM).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_FEATURE_ROM) ? \
+	 SUBDEV(xdev, XOCL_SUBDEV_FEATURE_ROM)->pldev : NULL)
 #define	ROM_OPS(xdev)	\
-	((struct xocl_rom_funcs *)SUBDEV(xdev, XOCL_SUBDEV_FEATURE_ROM).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_FEATURE_ROM) ? \
+	(struct xocl_rom_funcs *)SUBDEV(xdev, XOCL_SUBDEV_FEATURE_ROM)->ops : NULL)
 #define ROM_CB(xdev, cb)	\
 	(ROM_DEV(xdev) && ROM_OPS(xdev) && ROM_OPS(xdev)->cb)
 #define	xocl_is_unified(xdev)		\
@@ -657,9 +686,11 @@ struct xocl_version_ctrl_funcs {
 };
 
 #define VC_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL)->pldev : NULL)
 #define	VC_OPS(xdev)	\
-	((struct xocl_version_ctrl_funcs *)SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL) ? \
+	(struct xocl_version_ctrl_funcs *)SUBDEV(xdev, XOCL_SUBDEV_VERSION_CTRL)->ops : NULL)
 #define VC_CB(xdev, cb)	\
 	(VC_DEV(xdev) && VC_OPS(xdev) && VC_OPS(xdev)->cb)
 #define	xocl_flat_shell_check(xdev)		\
@@ -676,9 +707,11 @@ struct xocl_msix_funcs {
 	int (*user_intr_unreg)(struct platform_device *pdev, u32 intr);
 };
 #define MSIX_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_MSIX).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_MSIX) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_MSIX)->pldev : NULL)
 #define	MSIX_OPS(xdev)	\
-	((struct xocl_msix_funcs *)SUBDEV(xdev, XOCL_SUBDEV_MSIX).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_MSIX) ? \
+	(struct xocl_msix_funcs *)SUBDEV(xdev, XOCL_SUBDEV_MSIX)->ops : NULL)
 #define MSIX_CB(xdev, cb)	\
 	(MSIX_DEV(xdev) && MSIX_OPS(xdev) && MSIX_OPS(xdev)->cb)
 #define xocl_msix_intr_config(xdev, irq, en)			\
@@ -712,9 +745,11 @@ struct xocl_dma_funcs {
 };
 
 #define DMA_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_DMA).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_DMA) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_DMA)->pldev : NULL)
 #define	DMA_OPS(xdev)	\
-	((struct xocl_dma_funcs *)SUBDEV(xdev, XOCL_SUBDEV_DMA).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_DMA) ? \
+	(struct xocl_dma_funcs *)SUBDEV(xdev, XOCL_SUBDEV_DMA)->ops : NULL)
 #define DMA_CB(xdev, cb)	\
 	(DMA_DEV(xdev) && DMA_OPS(xdev) && DMA_OPS(xdev)->cb)
 #define	xocl_migrate_bo(xdev, sgt, to_dev, paddr, chan, len)	\
@@ -761,10 +796,12 @@ struct xocl_mb_scheduler_funcs {
 		void *drm_filp, u32 *addrp);
 };
 #define	MB_SCHEDULER_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_MB_SCHEDULER).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_MB_SCHEDULER) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_MB_SCHEDULER)->pldev : NULL)
 #define	MB_SCHEDULER_OPS(xdev)	\
-	((struct xocl_mb_scheduler_funcs *)SUBDEV(xdev,		\
-		XOCL_SUBDEV_MB_SCHEDULER).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_MB_SCHEDULER) ? \
+	(struct xocl_mb_scheduler_funcs *)SUBDEV(xdev,		\
+		XOCL_SUBDEV_MB_SCHEDULER)->ops : NULL)
 #define SCHE_CB(xdev, cb)	\
 	(MB_SCHEDULER_DEV(xdev) && MB_SCHEDULER_OPS(xdev))
 #define	xocl_exec_create_client(xdev, priv)		\
@@ -821,10 +858,12 @@ struct xocl_sysmon_funcs {
 	int (*get_prop)(struct platform_device *pdev, u32 prop, void *val);
 };
 #define	SYSMON_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_SYSMON).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_SYSMON) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_SYSMON)->pldev : NULL)
 #define	SYSMON_OPS(xdev)	\
-	((struct xocl_sysmon_funcs *)SUBDEV(xdev,	\
-		XOCL_SUBDEV_SYSMON).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_SYSMON) ? \
+	(struct xocl_sysmon_funcs *)SUBDEV(xdev,	\
+		XOCL_SUBDEV_SYSMON)->ops : NULL)
 #define SYSMON_CB(xdev, cb)	\
 	(SYSMON_DEV(xdev) && SYSMON_OPS(xdev) && SYSMON_OPS(xdev)->cb)
 #define	xocl_sysmon_get_prop(xdev, prop, val)		\
@@ -848,10 +887,12 @@ struct xocl_firewall_funcs {
 	void (*get_data)(struct platform_device *pdev, void *buf);
 };
 #define AF_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_AF).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_AF) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_AF)->pldev : NULL)
 #define	AF_OPS(xdev)	\
-	((struct xocl_firewall_funcs *)SUBDEV(xdev,	\
-	XOCL_SUBDEV_AF).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_AF) ? \
+	(struct xocl_firewall_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_AF)->ops : NULL)
 #define AF_CB(xdev, cb)	\
 	(AF_DEV(xdev) && AF_OPS(xdev) && AF_OPS(xdev)->cb)
 #define	xocl_af_get_prop(xdev, prop, val)		\
@@ -888,10 +929,12 @@ struct xocl_mb_funcs {
 };
 
 #define	MB_DEV(xdev)		\
-	SUBDEV(xdev, XOCL_SUBDEV_MB).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_MB) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_MB)->pldev : NULL)
 #define	MB_OPS(xdev)		\
-	((struct xocl_mb_funcs *)SUBDEV(xdev,	\
-	XOCL_SUBDEV_MB).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_MB) ? \
+	(struct xocl_mb_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_MB)->ops : NULL)
 #define MB_CB(xdev, cb)	\
 	(MB_DEV(xdev) && MB_OPS(xdev) && MB_OPS(xdev)->cb)
 #define	xocl_xmc_reset(xdev)			\
@@ -925,10 +968,12 @@ struct xocl_mb_funcs {
 	(MB_CB(xdev, sensor_status) ? MB_OPS(xdev)->sensor_status(MB_DEV(xdev)) : -ENODEV)
 /* ERT FW callbacks */
 #define ERT_DEV(xdev)							\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_MB, XOCL_MB_ERT).pldev
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_MB, XOCL_MB_ERT) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_MB, XOCL_MB_ERT)->pldev : NULL)
 #define ERT_OPS(xdev)							\
-	((struct xocl_mb_funcs *)SUBDEV_MULTI(xdev,			\
-	XOCL_SUBDEV_MB, XOCL_MB_ERT).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_MB, XOCL_MB_ERT) ?		\
+	(struct xocl_mb_funcs *)SUBDEV_MULTI(xdev,			\
+	XOCL_SUBDEV_MB, XOCL_MB_ERT)->ops : NULL)
 #define ERT_CB(xdev, cb)						\
 	(ERT_DEV(xdev) && ERT_OPS(xdev) && ERT_OPS(xdev)->cb)
 #define xocl_ert_reset(xdev)						\
@@ -972,10 +1017,12 @@ struct xocl_ps_funcs {
 };
 
 #define	PS_DEV(xdev)		\
-	SUBDEV(xdev, XOCL_SUBDEV_PS).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_PS) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_PS)->pldev : NULL)
 #define	PS_OPS(xdev)		\
-	((struct xocl_ps_funcs *)SUBDEV(xdev,	\
-	XOCL_SUBDEV_PS).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_PS) ? \
+	(struct xocl_ps_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_PS)->ops : NULL)
 #define PS_CB(xdev, cb)	\
 	(PS_DEV(xdev) && PS_OPS(xdev) && PS_OPS(xdev)->cb)
 #define	xocl_ps_sk_reset(xdev)			\
@@ -1002,10 +1049,12 @@ struct xocl_dna_funcs {
 };
 
 #define	DNA_DEV(xdev)		\
-	SUBDEV(xdev, XOCL_SUBDEV_DNA).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_DNA) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_DNA)->pldev : NULL)
 #define	DNA_OPS(xdev)		\
-	((struct xocl_dna_funcs *)SUBDEV(xdev,	\
-	XOCL_SUBDEV_DNA).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_DNA) ? \
+	(struct xocl_dna_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_DNA)->ops : NULL)
 #define DNA_CB(xdev, cb)	\
 	(DNA_DEV(xdev) && DNA_OPS(xdev) && DNA_OPS(xdev)->cb)
 #define	xocl_dna_status(xdev)			\
@@ -1019,10 +1068,12 @@ struct xocl_dna_funcs {
 
 
 #define	ADDR_TRANSLATOR_DEV(xdev)		\
-	SUBDEV(xdev, XOCL_SUBDEV_ADDR_TRANSLATOR).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_ADDR_TRANSLATOR) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_ADDR_TRANSLATOR)->pldev : NULL)
 #define	ADDR_TRANSLATOR_OPS(xdev)		\
-	((struct xocl_addr_translator_funcs *)SUBDEV(xdev,	\
-	XOCL_SUBDEV_ADDR_TRANSLATOR).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_ADDR_TRANSLATOR) ? \
+	(struct xocl_addr_translator_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_ADDR_TRANSLATOR)->ops : NULL)
 #define ADDR_TRANSLATOR_CB(xdev, cb)	\
 	(ADDR_TRANSLATOR_DEV(xdev) && ADDR_TRANSLATOR_OPS(xdev) && ADDR_TRANSLATOR_OPS(xdev)->cb)
 #define	xocl_addr_translator_get_entries_num(xdev)			\
@@ -1176,9 +1227,12 @@ struct xocl_mailbox_funcs {
 	int (*set)(struct platform_device *pdev, enum mb_kind kind, u64 data);
 	int (*get)(struct platform_device *pdev, enum mb_kind kind, u64 *data);
 };
-#define	MAILBOX_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX).pldev
+#define	MAILBOX_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_MAILBOX) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX)->pldev : NULL)
 #define	MAILBOX_OPS(xdev)	\
-	((struct xocl_mailbox_funcs *)SUBDEV(xdev, XOCL_SUBDEV_MAILBOX).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_MAILBOX) ? \
+	(struct xocl_mailbox_funcs *)SUBDEV(xdev, XOCL_SUBDEV_MAILBOX)->ops : NULL)
 #define MAILBOX_READY(xdev, cb)	\
 	(MAILBOX_DEV(xdev) && MAILBOX_OPS(xdev) && MAILBOX_OPS(xdev)->cb)
 #define	xocl_peer_request(xdev, req, reqlen, resp, resplen, cb, cbarg, rx_timeout, tx_timeout)	\
@@ -1206,12 +1260,15 @@ struct xocl_clock_counter_funcs {
 		u32 *value, int id);
 };
 #define CLOCK_C_DEV_INFO(xdev, idx)					\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx).info
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx) ?		\
+	&(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx)->info) : NULL)
 #define	CLOCK_C_DEV(xdev, idx)						\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx).pldev
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx)->pldev : NULL)
 #define	CLOCK_C_OPS(xdev, idx)						\
-	((struct xocl_clock_counter_funcs *)				\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx) ?		\
+	(struct xocl_clock_counter_funcs *)				\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_COUNTER, idx)->ops : NULL)
 static inline int xocl_clock_c_ops_level(xdev_handle_t xdev)
 {
 	int i;
@@ -1229,7 +1286,8 @@ static inline int xocl_clock_c_ops_level(xdev_handle_t xdev)
 #define CLOCK_C_DEV_LEVEL(xdev) 						\
 ({ \
 	int __idx = xocl_clock_c_ops_level(xdev);				\
-	(__idx >= 0 ? (CLOCK_C_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
+	(__idx >= 0  && CLOCK_C_DEV_INFO(xdev, __idx) ? \
+	 (CLOCK_C_DEV_INFO(xdev, __idx)->level) : -ENODEV); 	\
 })
 #define	xocl_clock_get_freq_counter(xdev, value, id)				\
 ({ \
@@ -1254,11 +1312,14 @@ struct xocl_clock_wiz_funcs {
 	uint64_t (*get_data)(struct platform_device *pdev, enum data_kind kind);
 };
 #define CLOCK_W_DEV_INFO(xdev, idx)					\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx).info
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx) ?		\
+	&(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx)->info) : NULL)
 #define	CLOCK_W_DEV(xdev, idx)						\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx).pldev
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx)->pldev : NULL)
 #define	CLOCK_W_OPS(xdev, idx)						\
-	((struct xocl_clock_wiz_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx) ?		\
+	(struct xocl_clock_wiz_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_CLOCK_WIZ, idx)->ops : NULL)
 static inline int xocl_clock_w_ops_level(xdev_handle_t xdev)
 {
 	int i;
@@ -1277,7 +1338,8 @@ static inline int xocl_clock_w_ops_level(xdev_handle_t xdev)
 #define CLOCK_W_DEV_LEVEL(xdev) 						\
 ({ \
 	int __idx = xocl_clock_w_ops_level(xdev);				\
-	(__idx >= 0 ? (CLOCK_W_DEV_INFO(xdev, __idx).level) : -ENODEV); 	\
+	(__idx >= 0 && CLOCK_W_DEV_INFO(xdev, __idx) ? \
+	 (CLOCK_W_DEV_INFO(xdev, __idx)->level) : -ENODEV); 	\
 })
 
 #define	xocl_clock_freq_rescaling(xdev, force)					\
@@ -1366,9 +1428,12 @@ enum {
 	RP_DOWNLOAD_FORCE,
 	RP_DOWNLOAD_CLEAR,
 };
-#define	ICAP_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_ICAP).pldev
+#define	ICAP_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_ICAP) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_ICAP)->pldev : NULL)
 #define	ICAP_OPS(xdev)							\
-	((struct xocl_icap_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ICAP).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_ICAP) ? \
+	(struct xocl_icap_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ICAP)->ops : NULL)
 #define ICAP_CB(xdev, cb)						\
 	(ICAP_DEV(xdev) && ICAP_OPS(xdev) && ICAP_OPS(xdev)->cb)
 #define	xocl_icap_reset_axi_gate(xdev)					\
@@ -1513,9 +1578,12 @@ struct xocl_mig_funcs {
 	uint32_t (*get_id)(struct platform_device *pdev);
 };
 
-#define	MIG_DEV(xdev, idx)	SUBDEV_MULTI(xdev, XOCL_SUBDEV_MIG, idx).pldev
+#define	MIG_DEV(xdev, idx)	\
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_MIG, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_MIG, idx)->pldev : NULL)
 #define	MIG_OPS(xdev, idx)							\
-	((struct xocl_mig_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_MIG, idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_MIG, idx) ?		\
+	(struct xocl_mig_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_MIG, idx)->ops : NULL)
 #define	MIG_CB(xdev, idx)	\
 	(MIG_DEV(xdev, idx) && MIG_OPS(xdev, idx))
 #define	xocl_mig_get_data(xdev, idx, buf, entry_sz)				\
@@ -1539,9 +1607,12 @@ struct xocl_iores_funcs {
 	uint64_t (*get_offset)(struct platform_device *pdev, u32 id);
 };
 
-#define IORES_DEV(xdev, idx)  SUBDEV_MULTI(xdev, XOCL_SUBDEV_IORES, idx).pldev
+#define IORES_DEV(xdev, idx)  \
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_IORES, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_IORES, idx)->pldev : NULL)
 #define	IORES_OPS(xdev, idx)						\
-	((struct xocl_iores_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_IORES, idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_IORES, idx) ?		\
+	(struct xocl_iores_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_IORES, idx)->ops : NULL)
 #define IORES_CB(xdev, idx, cb)		\
 	(IORES_DEV(xdev, idx) && IORES_OPS(xdev, idx) &&		\
 	IORES_OPS(xdev, idx)->cb)
@@ -1596,10 +1667,12 @@ struct xocl_axigate_funcs {
 };
 
 #define AXIGATE_DEV(xdev, idx)			\
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_AXIGATE, idx).pldev
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_AXIGATE, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_AXIGATE, idx)->pldev : NULL)
 #define AXIGATE_OPS(xdev, idx)			\
-	((struct xocl_axigate_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_AXIGATE, \
-	idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_AXIGATE, idx) ?		\
+	(struct xocl_axigate_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_AXIGATE, \
+	idx)->ops : NULL)
 #define AXIGATE_CB(xdev, idx, cb)		\
 	(AXIGATE_DEV(xdev, idx) && AXIGATE_OPS(xdev, idx) &&		\
 	AXIGATE_OPS(xdev, idx)->cb)
@@ -1630,10 +1703,12 @@ struct xocl_mailbox_versal_funcs {
 	int (*free_intr)(struct platform_device *pdev);
 };
 #define	MAILBOX_VERSAL_DEV(xdev)	\
-	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL).pldev
+	(SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL)->pldev : NULL)
 #define	MAILBOX_VERSAL_OPS(xdev)	\
-	((struct xocl_mailbox_versal_funcs *)SUBDEV(xdev,	\
-	XOCL_SUBDEV_MAILBOX_VERSAL).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_MAILBOX_VERSAL) ? \
+	(struct xocl_mailbox_versal_funcs *)SUBDEV(xdev,	\
+	XOCL_SUBDEV_MAILBOX_VERSAL)->ops : NULL)
 #define MAILBOX_VERSAL_READY(xdev, cb)	\
 	(MAILBOX_VERSAL_DEV(xdev) && MAILBOX_VERSAL_OPS(xdev) &&	\
 	 MAILBOX_VERSAL_OPS(xdev)->cb)
@@ -1664,9 +1739,12 @@ struct xocl_srsr_funcs {
 	uint32_t (*cache_size)(struct platform_device *pdev);
 };
 
-#define	SRSR_DEV(xdev, idx)	SUBDEV_MULTI(xdev, XOCL_SUBDEV_SRSR, idx).pldev
+#define	SRSR_DEV(xdev, idx)	\
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_SRSR, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_SRSR, idx)->pldev : NULL)
 #define	SRSR_OPS(xdev, idx)							\
-	((struct xocl_srsr_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_SRSR, idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_SRSR, idx) ?		\
+	(struct xocl_srsr_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_SRSR, idx)->ops : NULL)
 #define	SRSR_CB(xdev, idx)	\
 	(SRSR_DEV(xdev, idx) && SRSR_OPS(xdev, idx))
 #define	xocl_srsr_reset(xdev, idx)				\
@@ -1699,9 +1777,12 @@ struct calib_storage_funcs {
 	int (*restore)(struct platform_device *pdev);
 };
 
-#define	CALIB_STORAGE_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE).pldev
+#define	CALIB_STORAGE_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE)->pldev : NULL)
 #define	CALIB_STORAGE_OPS(xdev)							\
-	((struct calib_storage_funcs *)SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE) ? \
+	(struct calib_storage_funcs *)SUBDEV(xdev, XOCL_SUBDEV_CALIB_STORAGE)->ops : NULL)
 #define	CALIB_STORAGE_CB(xdev)	\
 	(CALIB_STORAGE_DEV(xdev) && CALIB_STORAGE_OPS(xdev))
 #define	xocl_calib_storage_save(xdev)				\
@@ -1719,9 +1800,11 @@ struct xocl_cu_funcs {
 	int (*submit)(struct platform_device *pdev, struct kds_command *xcmd);
 };
 #define CU_DEV(xdev, idx) \
-	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx).pldev
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx) ?		\
+	SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx)->pldev : NULL)
 #define CU_OPS(xdev, idx) \
-	((struct xocl_cu_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx).ops)
+	(SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx) ?		\
+	(struct xocl_cu_funcs *)SUBDEV_MULTI(xdev, XOCL_SUBDEV_CU, idx)->ops : NULL)
 #define CU_CB(xdev, idx, cb) \
 	(CU_DEV(xdev, idx) && CU_OPS(xdev, idx) && CU_OPS(xdev, idx)->cb)
 
@@ -1741,9 +1824,12 @@ struct xocl_intc_funcs {
 	int (*csr_read32)(struct platform_device *pdev, u32 off);
 	void (*csr_write32)(struct platform_device *pdev, u32 val, u32 off);
 };
-#define	INTC_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_INTC).pldev
+#define	INTC_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_INTC) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_INTC)->pldev : NULL)
 #define INTC_OPS(xdev)  \
-	((struct xocl_intc_funcs *)SUBDEV(xdev, XOCL_SUBDEV_INTC).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_INTC) ? \
+	(struct xocl_intc_funcs *)SUBDEV(xdev, XOCL_SUBDEV_INTC)->ops : NULL)
 #define INTC_CB(xdev, cb) \
 	(INTC_DEV(xdev) && INTC_OPS(xdev) && INTC_OPS(xdev)->cb)
 #define xocl_intc_ert_request(xdev, id, handler, arg) \
@@ -1812,9 +1898,12 @@ struct xocl_ert_user_funcs {
 	int (* enable)(struct platform_device *pdev, bool enable);
 };
 
-#define	ERT_USER_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_ERT_USER).pldev
+#define	ERT_USER_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_ERT_USER) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_ERT_USER)->pldev : NULL)
 #define ERT_USER_OPS(xdev)  \
-	((struct xocl_ert_user_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ERT_USER).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_ERT_USER) ? \
+	(struct xocl_ert_user_funcs *)SUBDEV(xdev, XOCL_SUBDEV_ERT_USER)->ops : NULL)
 #define ERT_USER_CB(xdev, cb)  \
 	(ERT_USER_DEV(xdev) && ERT_USER_OPS(xdev) && ERT_USER_OPS(xdev)->cb)
 
@@ -1900,9 +1989,12 @@ struct xocl_flash_funcs {
 		char *buf, size_t n, loff_t off);
 	int (*get_size)(struct platform_device *pdev, size_t *size);
 };
-#define	FLASH_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_FLASH).pldev
+#define	FLASH_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_FLASH) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_FLASH)->pldev : NULL)
 #define	FLASH_OPS(xdev)				\
-	((struct xocl_flash_funcs *)SUBDEV(xdev, XOCL_SUBDEV_FLASH).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_FLASH) ? \
+	(struct xocl_flash_funcs *)SUBDEV(xdev, XOCL_SUBDEV_FLASH)->ops : NULL)
 #define	FLASH_CB(xdev)	(FLASH_DEV(xdev) && FLASH_OPS(xdev))
 #define	xocl_flash_read(xdev, buf, n, off)	\
 	(FLASH_CB(xdev) ?			\
@@ -1915,9 +2007,12 @@ struct xocl_xfer_versal_funcs {
 	int (*download_axlf)(struct platform_device *pdev,
 		const void __user *arg);
 };
-#define	XFER_VERSAL_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL).pldev
+#define	XFER_VERSAL_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL)->pldev : NULL)
 #define	XFER_VERSAL_OPS(xdev)					\
-	((struct xocl_xfer_versal_funcs *)SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL) ? \
+	(struct xocl_xfer_versal_funcs *)SUBDEV(xdev, XOCL_SUBDEV_XFER_VERSAL)->ops : NULL)
 #define	XFER_VERSAL_CB(xdev)	(XFER_VERSAL_DEV(xdev) && XFER_VERSAL_OPS(xdev))
 #define	xocl_xfer_versal_download_axlf(xdev, xclbin)	\
 	(XFER_VERSAL_CB(xdev) ?					\
@@ -1926,9 +2021,12 @@ struct xocl_xfer_versal_funcs {
 struct xocl_pmc_funcs {
 	int (*enable_reset)(struct platform_device *pdev);
 };
-#define	PMC_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_PMC).pldev
+#define	PMC_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_PMC) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_PMC)->pldev : NULL)
 #define	PMC_OPS(xdev) \
-	((struct xocl_pmc_funcs *)SUBDEV(xdev, XOCL_SUBDEV_PMC).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_PMC) ? \
+	(struct xocl_pmc_funcs *)SUBDEV(xdev, XOCL_SUBDEV_PMC)->ops : NULL)
 #define	PMC_CB(xdev)	(PMC_DEV(xdev) && PMC_OPS(xdev))
 #define	xocl_pmc_enable_reset(xdev) \
 	(PMC_CB(xdev) ? PMC_OPS(xdev)->enable_reset(PMC_DEV(xdev)) : -ENODEV)
@@ -1967,9 +2065,12 @@ struct xocl_p2p_funcs {
 	int (*adjust_mem_topo)(struct platform_device *pdev, void *mem_topo);
 	int (*mem_reclaim)(struct platform_device *pdev);
 };
-#define	P2P_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_P2P).pldev
+#define	P2P_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_P2P) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_P2P)->pldev : NULL)
 #define	P2P_OPS(xdev)				\
-	((struct xocl_p2p_funcs *)SUBDEV(xdev, XOCL_SUBDEV_P2P).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_P2P) ? \
+	(struct xocl_p2p_funcs *)SUBDEV(xdev, XOCL_SUBDEV_P2P)->ops : NULL)
 #define	P2P_CB(xdev)	(P2P_DEV(xdev) && P2P_OPS(xdev))
 #define	xocl_p2p_mem_map(xdev, ba, bs, off, len, bar_off)	\
 	(P2P_CB(xdev) ?			\
@@ -2023,9 +2124,12 @@ struct xocl_m2m_funcs {
 	int (*get_host_bank)(struct platform_device *pdev, u64 *addr,
 		u64 *size);
 };
-#define	M2M_DEV(xdev)	SUBDEV(xdev, XOCL_SUBDEV_M2M).pldev
+#define	M2M_DEV(xdev)	\
+	(SUBDEV(xdev, XOCL_SUBDEV_M2M) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_M2M)->pldev : NULL)
 #define	M2M_OPS(xdev)	\
-	((struct xocl_m2m_funcs *)SUBDEV(xdev, XOCL_SUBDEV_M2M).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_M2M) ? \
+	(struct xocl_m2m_funcs *)SUBDEV(xdev, XOCL_SUBDEV_M2M)->ops : NULL)
 #define	M2M_CB(xdev)	(M2M_DEV(xdev) && M2M_OPS(xdev))
 #define	xocl_m2m_copy_bo(xdev, src_paddr, dst_paddr, src_handle, dst_handle, size) \
 	(M2M_CB(xdev) ? M2M_OPS(xdev)->copy_bo(M2M_DEV(xdev), src_paddr, dst_paddr, \
@@ -2039,9 +2143,12 @@ struct xocl_pcie_firewall_funcs {
 	int (*unblock)(struct platform_device *pdev, int pf, int bar);
 };
 
-#define PCIE_FIREWALL_DEV(xdev) SUBDEV(xdev, XOCL_SUBDEV_PCIE_FIREWALL).pldev
+#define PCIE_FIREWALL_DEV(xdev) \
+	(SUBDEV(xdev, XOCL_SUBDEV_PCIE_FIREWALL) ? \
+	SUBDEV(xdev, XOCL_SUBDEV_PCIE_FIREWALL)->pldev : NULL)
 #define PCIE_FIREWALL_OPS(xdev)					\
-	((struct xocl_pcie_firewall_funcs*)SUBDEV(xdev, XOCL_SUBDEV_PCIE_FIREWALL).ops)
+	(SUBDEV(xdev, XOCL_SUBDEV_PCIE_FIREWALL) ? \
+	(struct xocl_pcie_firewall_funcs*)SUBDEV(xdev, XOCL_SUBDEV_PCIE_FIREWALL)->ops : NULL)
 #define PCIE_FIREWALL_CB(xdev) (PCIE_FIREWALL_DEV(xdev) && PCIE_FIREWALL_OPS(xdev))
 #define xocl_pcie_firewall_unblock(xdev, pf, bar)			\
 	(PCIE_FIREWALL_CB(xdev) ? PCIE_FIREWALL_OPS(xdev)->unblock(PCIE_FIREWALL_DEV(xdev), pf, bar) : -ENODEV)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1082,12 +1082,13 @@ static int xocl_fdt_parse_ip(xdev_handle_t xdev_hdl, char *blob,
 		subdev->res[idx].end = subdev->res[idx].start +
 		       be64_to_cpu(io_off[1]) - 1;
 		subdev->res[idx].flags = IORESOURCE_MEM;
-		snprintf(subdev->res_name[idx],
+		snprintf(subdev->res_name + idx * XOCL_SUBDEV_RES_NAME_LEN,
 			XOCL_SUBDEV_RES_NAME_LEN,
 			"%s %d %d %d %s",
 			ip->name, ip->major, ip->minor,
 			ip->level, ip->regmap_name ? ip->regmap_name : "");
-		subdev->res[idx].name = subdev->res_name[idx];
+		subdev->res[idx].name = subdev->res_name +
+		       	idx * XOCL_SUBDEV_RES_NAME_LEN;
 
 		subdev->bar_idx[idx] = bar_idx ? ntohl(*bar_idx) : 0;
 
@@ -1102,12 +1103,13 @@ static int xocl_fdt_parse_ip(xdev_handle_t xdev_hdl, char *blob,
 		subdev->res[idx].start = ntohl(irq_off[0]);
 		subdev->res[idx].end = ntohl(irq_off[1]);
 		subdev->res[idx].flags = IORESOURCE_IRQ;
-		snprintf(subdev->res_name[idx],
+		snprintf(subdev->res_name + idx * XOCL_SUBDEV_RES_NAME_LEN,
 			XOCL_SUBDEV_RES_NAME_LEN,
 			"%s %d %d %d %s",
 			ip->name, ip->major, ip->minor,
 			ip->level, ip->regmap_name ? ip->regmap_name : "");
-		subdev->res[idx].name = subdev->res_name[idx];
+		subdev->res[idx].name = subdev->res_name +
+		       	idx * XOCL_SUBDEV_RES_NAME_LEN;
 		subdev->info.num_res++;
 		sz -= sizeof(*irq_off) * 2;
 		irq_off += 2;
@@ -1124,12 +1126,13 @@ static int xocl_fdt_parse_ip(xdev_handle_t xdev_hdl, char *blob,
 		ret = xocl_fdt_parse_intr_alias(xdev_hdl, blob, intr_alias,
 			&subdev->res[idx]);
 		if (!ret) {
-			snprintf(subdev->res_name[idx],
+			snprintf(subdev->res_name + idx * XOCL_SUBDEV_RES_NAME_LEN,
 				XOCL_SUBDEV_RES_NAME_LEN,
 				"%s %d %d %d %s",
 				ip->name, ip->major, ip->minor,
 				ip->level, intr_alias);
-			subdev->res[idx].name = subdev->res_name[idx];
+			subdev->res[idx].name = subdev->res_name +
+		       		idx * XOCL_SUBDEV_RES_NAME_LEN;
 			subdev->info.num_res++;
 		}
 	}
@@ -1257,12 +1260,26 @@ static int xocl_fdt_get_devinfo(xdev_handle_t xdev_hdl, char *blob,
 	int num = 0, i = 0, ret;
 
 	if (rtn_subdevs) {
+		struct resource *res_tmp;
+		char *res_name_tmp, *bar_idx_tmp;
+
 		subdev = rtn_subdevs;
+		res_tmp = subdev->res;
+		res_name_tmp = subdev->res_name;
+		bar_idx_tmp = subdev->bar_idx;
 		memset(subdev, 0, sizeof(*subdev));
+		subdev->res = res_tmp;
+		subdev->res_name = res_name_tmp;
+		subdev->bar_idx = bar_idx_tmp;
 	} else {
-		subdev = vzalloc(sizeof(*subdev));
+		subdev = kzalloc(sizeof(*subdev), GFP_KERNEL);
 		if (!subdev)
 			return -ENOMEM;
+		ret = xocl_subdev_dyn_alloc(subdev, XOCL_SUBDEV_MAX_RES);
+		if (ret) {
+			num = ret;
+			goto failed;
+		}
 	}
 
 	for (res = &map_p->res_array[0]; res && res->res_name != NULL;
@@ -1302,14 +1319,17 @@ static int xocl_fdt_get_devinfo(xdev_handle_t xdev_hdl, char *blob,
 	subdev->info.bar_idx = subdev->bar_idx;
 	subdev->info.override_idx = -1;
 	for (i = 0; i < subdev->info.num_res; i++)
-		subdev->info.res[i].name = subdev->res_name[i];
+		subdev->info.res[i].name = subdev->res_name +
+			i * XOCL_SUBDEV_RES_NAME_LEN;
 
 	if (map_p->devinfo_cb)
 		map_p->devinfo_cb(xdev_hdl, rtn_subdevs, 1);
 
 failed:
-	if (!rtn_subdevs)
-		vfree(subdev);
+	if (!rtn_subdevs) {
+		xocl_subdev_dyn_free(subdev);
+		kfree(subdev);
+	}
 	for (i = 0; i < ip_num; i++) {
 		if (ip[i].used || !ip[i].match)
 			continue;
@@ -1384,10 +1404,55 @@ end:
 	return total;
 }
 
+static void xocl_pack_subdev(xdev_handle_t xdev_hdl, struct xocl_subdev *subdev)
+{
+	struct resource *res;
+	char *res_name, *bar_idx;
+	int i;
+
+	BUG_ON(!subdev || !subdev->res || !subdev->res_name || !subdev->bar_idx);
+
+		xocl_xdev_info(xdev_hdl, "####res num %d", subdev->info.num_res);
+	res = kzalloc(sizeof (struct resource)
+		* subdev->info.num_res, GFP_KERNEL);
+	res_name = kzalloc(XOCL_SUBDEV_RES_NAME_LEN
+		* subdev->info.num_res, GFP_KERNEL);
+	bar_idx = kzalloc(sizeof (char)
+		* subdev->info.num_res, GFP_KERNEL);
+		
+	if (!res || !res_name || !bar_idx) {
+		if (res)
+			kfree(res);
+		if (res_name)
+			kfree(res_name);
+		if (bar_idx)
+			kfree(bar_idx);
+		return;
+	}
+
+	memcpy(res, subdev->res, sizeof (struct resource) * subdev->info.num_res);
+	memcpy(res_name, subdev->res_name, XOCL_SUBDEV_RES_NAME_LEN * subdev->info.num_res);
+	memcpy(bar_idx, subdev->bar_idx, sizeof (char) * subdev->info.num_res);
+	for (i = 0; i < subdev->info.num_res; i++)
+		res[i].name = res_name + i * XOCL_SUBDEV_RES_NAME_LEN;
+
+	xocl_subdev_dyn_free(subdev);
+
+	subdev->res = res;
+	subdev->res_name = res_name;
+	subdev->bar_idx = bar_idx;
+
+	subdev->info.res = subdev->res;
+	subdev->info.bar_idx = subdev->bar_idx;
+	for (i = 0; i < subdev->info.num_res; i++)
+		subdev->info.res[i].name = subdev->res_name +
+			i * XOCL_SUBDEV_RES_NAME_LEN;
+}
+
 int xocl_fdt_parse_blob(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 		struct xocl_subdev **subdevs)
 {
-	int		dev_num; 
+	int	i, dev_num, ret; 
 
 	*subdevs = NULL;
 
@@ -1410,13 +1475,33 @@ int xocl_fdt_parse_blob(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 		goto failed;
 	}
 
-	*subdevs = vzalloc(dev_num * sizeof(struct xocl_subdev));
+	*subdevs = kzalloc(dev_num * sizeof(struct xocl_subdev), GFP_KERNEL);
 	if (!*subdevs)
 		return -ENOMEM;
 
+	for (i = 0; i < dev_num; i++) {
+		ret = xocl_subdev_dyn_alloc(*subdevs + i, XOCL_SUBDEV_MAX_RES);
+			
+		if (ret) {
+			dev_num = ret;
+			goto failed;
+		}
+	}
+
 	xocl_fdt_parse_subdevs(xdev_hdl, blob, *subdevs, dev_num);
 
+	for (i = 0; i < dev_num; i++) {
+		xocl_xdev_info(xdev_hdl, "%s: dyn_subdev_num: %d",
+			(*subdevs + i)->info.name, (*subdevs + i)->info.num_res);
+		xocl_pack_subdev(xdev_hdl, *subdevs + i);
+	}
+
+	return dev_num;
+
 failed:
+	for (i = 0; i < dev_num && *subdevs; i++)
+		xocl_subdev_dyn_free(*subdevs + i);
+
 	return dev_num;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -437,7 +437,7 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 	}
 
 	if (subdev->info.num_res > 0) {
-		res = vzalloc(subdev->info.num_res);
+		res = vzalloc(sizeof (*res) * subdev->info.num_res);
 		if (!res) {
 			retval = -ENOMEM;
 			goto error;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -42,17 +42,28 @@ int xocl_subdev_find_vsec_offset(xdev_handle_t xdev);
 void xocl_subdev_fini(xdev_handle_t xdev_hdl)
 {
 	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev_hdl;
-	int i;
+	int i, j;
 
 	for (i = 0; i < XOCL_SUBDEV_NUM; i++) {
 		if (core->subdevs[i]) {
-			vfree(core->subdevs[i]);
+			for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++) {
+				if (core->subdevs[i][j]) {
+					xocl_subdev_dyn_free(core->subdevs[i][j]);
+					kfree(core->subdevs[i][j]);
+					core->subdevs[i][j] = NULL;
+				}
+			}
+			kfree(core->subdevs[i]);
 			core->subdevs[i] = NULL;
 		}
+		
 	}
 
-	if (core->dyn_subdev_store)
-		vfree(core->dyn_subdev_store);
+	if (core->dyn_subdev_store) {
+		for (i = 0; i < core->dyn_subdev_num; i++)
+			xocl_subdev_dyn_free(core->dyn_subdev_store + i);
+		kfree(core->dyn_subdev_store);
+	}
 	mutex_destroy(&core->lock);
 	mutex_destroy(&core->wq_lock);
 }
@@ -61,7 +72,7 @@ int xocl_subdev_init(xdev_handle_t xdev_hdl, struct pci_dev *pdev,
 		struct xocl_pci_funcs *pci_ops)
 {
 	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev_hdl;
-	int i, ret = 0, j;
+	int i, ret = 0;
 
 	mutex_init(&core->lock);
 	core->pci_ops = pci_ops;
@@ -71,18 +82,15 @@ int xocl_subdev_init(xdev_handle_t xdev_hdl, struct pci_dev *pdev,
 	mutex_init(&core->wq_lock);
 
 	for (i = 0; i < XOCL_SUBDEV_NUM; i++) {
-		core->subdevs[i] = vzalloc(sizeof(struct xocl_subdev) *
-				XOCL_SUBDEV_MAX_INST);
+		core->subdevs[i] = kzalloc(sizeof(struct xocl_subdev *) *
+			XOCL_SUBDEV_MAX_INST, GFP_KERNEL);
 		if (!core->subdevs[i]) {
 			ret = -ENOMEM;
 			goto failed;
 		}
-		for (j = 0; j < XOCL_SUBDEV_MAX_INST; ++j)
-			core->subdevs[i][j].info.dev_idx = j;
 	}
 
 	return 0;
-
 failed:
 	xocl_subdev_fini(xdev_hdl);
 	return ret;
@@ -101,17 +109,42 @@ static struct xocl_subdev *xocl_subdev_info2dev(xdev_handle_t xdev_hdl,
 	int devid = sdev_info->id;
 	int i;
 
-	if (sdev_info->override_idx != -1)
-		return is_valid_override_idx(sdev_info->override_idx) ?
-			&core->subdevs[devid][sdev_info->override_idx] :
-			NULL;
-	else if (!sdev_info->multi_inst)
-		return &core->subdevs[devid][0];
+	/**
+	 * To reduce memory footprint, the subdev is allocated when required.
+	 */
+	if (sdev_info->override_idx != -1) {
+		if (!is_valid_override_idx(sdev_info->override_idx))
+			return NULL;
+		subdev = core->subdevs[devid][sdev_info->override_idx];
+		if (!subdev) {
+			subdev = kzalloc(sizeof (struct xocl_subdev), GFP_KERNEL);
+			core->subdevs[devid][sdev_info->override_idx] = subdev;
+		}
+		if (subdev)
+			subdev->info.dev_idx = sdev_info->override_idx;
+		return subdev;
+	} else if (!sdev_info->multi_inst) {
+		subdev = core->subdevs[devid][0];
+		if (!subdev) {
+			subdev = kzalloc(sizeof (struct xocl_subdev), GFP_KERNEL);
+			core->subdevs[devid][0] = subdev;
+		}
+		if (subdev)
+			subdev->info.dev_idx = 0;
+		return subdev;
+	}
 
 	for (i = 0; i < XOCL_SUBDEV_MAX_INST; i++) {
-		subdev = &core->subdevs[devid][i];
-		if (subdev->state == XOCL_SUBDEV_STATE_UNINIT)
-			return subdev;
+		subdev = core->subdevs[devid][i];
+		if (!subdev) {
+			subdev = kzalloc(sizeof (struct xocl_subdev), GFP_KERNEL);
+			core->subdevs[devid][i] = subdev;
+		}
+		if (subdev) {
+			subdev->info.dev_idx = i;
+		        if (subdev->state == XOCL_SUBDEV_STATE_UNINIT)
+				return subdev;
+		}
 	}
 
 	return NULL;
@@ -158,8 +191,9 @@ static struct xocl_subdev *xocl_subdev_lookup(struct platform_device *pldev)
 
 	for (j = 0; j < XOCL_SUBDEV_NUM; j++)
 		for (i = 0; i < XOCL_SUBDEV_MAX_INST; i++)
-			if (core->subdevs[j][i].pldev == pldev)
-				return &core->subdevs[j][i];
+			if (core->subdevs[j][i] &&
+				core->subdevs[j][i]->pldev == pldev)
+				return core->subdevs[j][i];
 
 	return NULL;
 }
@@ -338,7 +372,7 @@ static void __xocl_subdev_destroy(xdev_handle_t xdev_hdl,
 	struct platform_device *pldev;
 	int state;
 
-	if (subdev->state == XOCL_SUBDEV_STATE_UNINIT)
+	if (!subdev || subdev->state == XOCL_SUBDEV_STATE_UNINIT)
 		return;
 
 	pldev = subdev->pldev;
@@ -530,12 +564,24 @@ static int __xocl_subdev_create(xdev_handle_t xdev_hdl,
 			retval = -EINVAL;
 			goto error;
 		}
+		/**
+	 	 * To reduce memory footprint, res, res_name, and bar_idx
+		 * are allocated when required.
+		 */
+		xocl_subdev_dyn_free(subdev);
+		retval = xocl_subdev_dyn_alloc(subdev, sdev_info->num_res);
+
+		if (retval)
+			goto error;
+
 		res = subdev->res;
 		memcpy(res, sdev_info->res, sizeof(*res) * sdev_info->num_res);
 		for (i = 0; i < sdev_info->num_res; i++) {
 			if (sdev_info->res[i].name) {
-				res[i].name = subdev->res_name[i];
-				strncpy(subdev->res_name[i],
+				res[i].name = subdev->res_name + 
+					i * XOCL_SUBDEV_RES_NAME_LEN;
+				strncpy(subdev->res_name +
+					i * XOCL_SUBDEV_RES_NAME_LEN,
 					sdev_info->res[i].name,
 					XOCL_SUBDEV_RES_NAME_LEN - 1);
 			} else
@@ -659,10 +705,11 @@ int xocl_subdev_destroy_by_name(xdev_handle_t xdev_hdl, char *name)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--)
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++)
-			if (!strcmp(core->subdevs[i][j].info.name,
+			if (core->subdevs[i][j] &&
+				!strcmp(core->subdevs[i][j]->info.name,
 				name)) {
 				__xocl_subdev_destroy(xdev_hdl,
-					&core->subdevs[i][j]);
+					core->subdevs[i][j]);
 				xocl_unlock_xdev(xdev_hdl);
 				return 0;
 			}
@@ -903,15 +950,15 @@ void xocl_subdev_destroy_by_id(xdev_handle_t xdev_hdl, uint32_t subdev_id)
 		return;
 	xocl_lock_xdev(xdev_hdl);
 	for (i = 0; i < XOCL_SUBDEV_MAX_INST; i++)
-		__xocl_subdev_destroy(xdev_hdl, &core->subdevs[subdev_id][i]);
+		__xocl_subdev_destroy(xdev_hdl, core->subdevs[subdev_id][i]);
 	xocl_unlock_xdev(xdev_hdl);
 }
 
 #define for_each_subdev(core, subdev)					\
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--)		\
-		for (j = 0, subdev = &core->subdevs[i][j];		\
+		for (j = 0, subdev = core->subdevs[i][j];		\
 		    j < XOCL_SUBDEV_MAX_INST;				\
-		    j++, subdev = &core->subdevs[i][j])
+		    j++, subdev = core->subdevs[i][j])
 
 void xocl_subdev_destroy_all(xdev_handle_t xdev_hdl)
 {
@@ -921,7 +968,7 @@ void xocl_subdev_destroy_all(xdev_handle_t xdev_hdl)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--)
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++)
-			__xocl_subdev_destroy(xdev_hdl, &core->subdevs[i][j]);
+			__xocl_subdev_destroy(xdev_hdl, core->subdevs[i][j]);
 	xocl_unlock_xdev(xdev_hdl);
 }
 
@@ -933,9 +980,10 @@ void xocl_subdev_destroy_by_level(xdev_handle_t xdev_hdl, int level)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--)
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++)
-			if (core->subdevs[i][j].info.level == level)
+			if (core->subdevs[i][j] &&
+				core->subdevs[i][j]->info.level == level)
 				__xocl_subdev_destroy(xdev_hdl,
-					&core->subdevs[i][j]);
+					core->subdevs[i][j]);
 	xocl_unlock_xdev(xdev_hdl);
 }
 
@@ -948,7 +996,7 @@ void xocl_subdev_destroy_by_baridx(xdev_handle_t xdev_hdl, int bar_idx)
 	xocl_lock_xdev(xdev_hdl);
 
 	for_each_subdev(core, subdev) {
-		if (!subdev->info.bar_idx)
+		if (!subdev  || !subdev->info.bar_idx)
 			continue;
 
 		for (k = 0; k < subdev->info.num_res; k++) {
@@ -970,6 +1018,7 @@ static int __xocl_subdev_offline(xdev_handle_t xdev_hdl,
 	struct platform_device *pldev;
 	int ret = 0;
 
+	BUG_ON(!subdev);
 	if (subdev->state < XOCL_SUBDEV_STATE_ACTIVE) {
 		if (subdev->state != XOCL_SUBDEV_STATE_UNINIT) {
 			xocl_xdev_dbg(xdev_hdl, "%s, already offline",
@@ -1024,6 +1073,7 @@ static int __xocl_subdev_online(xdev_handle_t xdev_hdl,
 	struct xocl_subdev_funcs *subdev_funcs;
 	int ret = 0;
 
+	BUG_ON(!subdev);
 	/* UNINIT state means subdev does not exist. exist without error in this case */
 	if (subdev->state == XOCL_SUBDEV_STATE_UNINIT)
 		return 0;
@@ -1107,10 +1157,11 @@ int xocl_subdev_offline_by_id(xdev_handle_t xdev_hdl, uint32_t subdev_id)
 
 	xocl_lock_xdev(xdev_hdl);
 	for (i = 0; i < XOCL_SUBDEV_MAX_INST; i++) {
-		if (!core->subdevs[subdev_id][i].pldev)
+		if (!core->subdevs[subdev_id][i] ||
+			!core->subdevs[subdev_id][i]->pldev)
 			continue;
 		ret = __xocl_subdev_offline(xdev_hdl,
-				&core->subdevs[subdev_id][i]);
+				core->subdevs[subdev_id][i]);
 		if (ret)
 			break;
 	}
@@ -1129,8 +1180,10 @@ int xocl_subdev_online_by_id(xdev_handle_t xdev_hdl, uint32_t subdev_id)
 
 	xocl_lock_xdev(xdev_hdl);
 	for (i = 0; i < XOCL_SUBDEV_MAX_INST; i++) {
+		if (!core->subdevs[subdev_id][i])
+			continue;
 		ret = __xocl_subdev_online(xdev_hdl,
-				&core->subdevs[subdev_id][i]);
+				core->subdevs[subdev_id][i]);
 		if (ret && ret != -EAGAIN)
 			break;
 	}
@@ -1152,7 +1205,7 @@ int xocl_subdev_online_by_id_and_inst(xdev_handle_t xdev_hdl, uint32_t subdev_id
 	xocl_lock_xdev(xdev_hdl);
 
 	ret = __xocl_subdev_online(xdev_hdl,
-			&core->subdevs[subdev_id][inst_id]);
+			core->subdevs[subdev_id][inst_id]);
 
 	xocl_unlock_xdev(xdev_hdl);
 
@@ -1167,9 +1220,10 @@ int xocl_subdev_offline_by_level(xdev_handle_t xdev_hdl, int level)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--)
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++)
-			if (core->subdevs[i][j].info.level == level) {
+			if (core->subdevs[i][j] &&
+				core->subdevs[i][j]->info.level == level) {
 				ret = __xocl_subdev_offline(xdev_hdl,
-					&core->subdevs[i][j]);
+					core->subdevs[i][j]);
 				if (ret)
 					goto failed;
 			}
@@ -1187,9 +1241,10 @@ int xocl_subdev_online_by_level(xdev_handle_t xdev_hdl, int level)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--)
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++)
-			if (core->subdevs[i][j].info.level == level) {
+			if (core->subdevs[i][j] &&
+				core->subdevs[i][j]->info.level == level) {
 				ret = __xocl_subdev_online(xdev_hdl,
-					&core->subdevs[i][j]);
+					core->subdevs[i][j]);
 				if (ret && ret != -EAGAIN)
 					goto failed;
 				else
@@ -1215,8 +1270,10 @@ int xocl_subdev_offline_all(xdev_handle_t xdev_hdl)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = ARRAY_SIZE(core->subdevs) - 1; i >= 0; i--) {
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++) {
+			if (!core->subdevs[i][j])
+				continue;
 			ret = __xocl_subdev_offline(xdev_hdl,
-				&core->subdevs[i][j]);
+				core->subdevs[i][j]);
 			if (ret)
 				goto failed;
 		}
@@ -1235,8 +1292,10 @@ int xocl_subdev_online_all(xdev_handle_t xdev_hdl)
 	xocl_lock_xdev(xdev_hdl);
 	for (i = 0; i < ARRAY_SIZE(core->subdevs); i++) {
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++) {
+			if (!core->subdevs[i][j])
+				continue;
 			ret = __xocl_subdev_online(xdev_hdl,
-				&core->subdevs[i][j]);
+				core->subdevs[i][j]);
 			if (ret && ret != -EAGAIN)
 				goto failed;
 			else
@@ -1260,8 +1319,9 @@ int xocl_subdev_get_level(struct platform_device *pdev)
 
 	for (i = 0; i < ARRAY_SIZE(core->subdevs); i++) {
 		for (j = 0; j < XOCL_SUBDEV_MAX_INST; j++) {
-			if (core->subdevs[i][j].pldev == pdev) {
-				level = core->subdevs[i][j].info.level;
+			if (core->subdevs[i][j] &&
+				core->subdevs[i][j]->pldev == pdev) {
+				level = core->subdevs[i][j]->info.level;
 				goto found;
 			}
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -79,8 +79,10 @@ static int versal_xclbin_post_download(xdev_handle_t xdev, void *args)
 		    xrt_xclbin_get_section_hdr(arg->xclbin, CLOCK_FREQ_TOPOLOGY);
 		struct clock_freq_topology *topo;
 
-		for (i = 0; i < arg->num_dev; i++)
+		for (i = 0; i < arg->num_dev; i++) {
 			(void) xocl_subdev_create(xdev, &(arg->urpdevs[i].info));
+			xocl_subdev_dyn_free(arg->urpdevs + i);
+		}
 		xocl_subdev_create_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
 		if (hdr) {
@@ -90,6 +92,9 @@ static int versal_xclbin_post_download(xdev_handle_t xdev, void *args)
 			ret = xocl_clock_freq_scaling_by_topo(xdev, topo, 0);
 		}
 	}
+
+	if (arg->urpdevs)
+		kfree(arg->urpdevs);
 
 	return ret;
 }


### PR DESCRIPTION
reduce xclmgmt/xocl memory footprint,
1. change static subdev allocation to dynamic allocation
2. avoid vmalloc for small data structures.

test result on a machine with 4 u30 (2 cards) and 1 u25,

before,

xclmgmt: 69288 KB
xocl: 75492 KB

after,

xclmgmt: 5692 KB
xocl: 12176 KB