### PR TITLE
CR-1079709: Add an option to generate all profiling files in a sub direcotory

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -156,6 +156,13 @@ get_data_transfer_trace()
   return value;
 }
 
+inline std::string
+get_profiling_directory()
+{
+  static std::string value = detail::get_string_value("Debug.profiling_directory", "") ;
+  return value ;
+}
+
 inline bool
 get_power_profile()
 {

--- a/src/runtime_src/xdp/profile/database/database.cpp
+++ b/src/runtime_src/xdp/profile/database/database.cpp
@@ -51,7 +51,7 @@ namespace xdp {
     // After all the plugins have written their data, we can dump the
     //  generic summary
     if (summary != nullptr) {
-      staticdb.addOpenedFile("summary.csv", "PROFILE_SUMMARY") ;
+      staticdb.addOpenedFile(summary->getcurrentFileName(), "PROFILE_SUMMARY") ;
       summary->write(false) ;
       delete summary ;
     }

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -699,7 +699,7 @@ namespace xdp {
 
     if (runSummary == nullptr)
     {
-      runSummary = new VPRunSummaryWriter("xclbin.run_summary") ;
+      runSummary = new VPRunSummaryWriter("xclbin.run_summary", db) ;
     }
     runSummary->write(false) ;
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -479,9 +479,11 @@ namespace xdp {
     std::string deviceName = std::string(info.mName);
     // Create and register writer and file
     std::string outputFile = "aie_profile_" + deviceName + ".csv";
-    writers.push_back(new AIEProfilingWriter(outputFile.c_str(),
-        deviceName.c_str(), mIndex));
-    db->getStaticInfo().addOpenedFile(outputFile.c_str(), "AIE_PROFILE");
+
+    VPWriter* writer = new AIEProfilingWriter(outputFile.c_str(),
+                                              deviceName.c_str(), mIndex);
+    writers.push_back(writer);
+    db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "AIE_PROFILE");
 
     // Start the AIE profiling thread
     mThreadCtrlMap[handle] = true;

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -703,21 +703,23 @@ namespace xdp {
     // Create runtime config file
     if (runtimeMetrics) {
       std::string configFile = "aie_event_runtime_config.json";
-      writers.push_back(new AieTraceConfigWriter(configFile.c_str(),
-                                                 deviceId, metricSet));
-      (db->getStaticInfo()).addOpenedFile(configFile, "AIE_EVENT_RUNTIME_CONFIG");
+      VPWriter* writer = new AieTraceConfigWriter(configFile.c_str(),
+                                                  deviceId, metricSet) ;
+      writers.push_back(writer);
+      (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "AIE_EVENT_RUNTIME_CONFIG");
     }
 
     // Create trace output files
     for(uint64_t n = 0; n < numAIETraceOutput; n++) {
       // Consider both Device Id and Stream Id to create the output file name
       std::string fileName = "aie_trace_" + std::to_string(deviceId) + "_" + std::to_string(n) + ".txt";
-      writers.push_back(new AIETraceWriter(fileName.c_str(), deviceId, n,
-                            "" /*version*/,
-                            "" /*creationTime*/,
-                            "" /*xrtVersion*/,
-                            "" /*toolVersion*/));
-      (db->getStaticInfo()).addOpenedFile(fileName, "AIE_EVENT_TRACE");
+      VPWriter* writer = new AIETraceWriter(fileName.c_str(), deviceId, n,
+                                            "" /*version*/,
+                                            "" /*creationTime*/,
+                                            "" /*xrtVersion*/,
+                                            "" /*toolVersion*/);
+      writers.push_back(writer);
+      (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "AIE_EVENT_TRACE");
 
       std::stringstream msg;
       msg << "Creating AIE trace file " << fileName << " for device " << deviceId;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -133,15 +133,15 @@ namespace xdp {
 
     std::string filename = 
       "device_trace_" + std::to_string(deviceId) + ".csv" ;
-      
-    writers.push_back(new DeviceTraceWriter(filename.c_str(),
-                                            deviceId,
-                                            version,
-                                            creationTime,
-                                            xrtVersion,
-                                            toolVersion)) ;
 
-    (db->getStaticInfo()).addOpenedFile(filename.c_str(), "VP_TRACE") ;
+    VPWriter* writer = new DeviceTraceWriter(filename.c_str(),
+                                             deviceId,
+                                             version,
+                                             creationTime,
+                                             xrtVersion,
+                                             toolVersion);
+    writers.push_back(writer) ;
+    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
 
     if (continuous_trace)
       XDPPlugin::startWriteThread(XDPPlugin::get_trace_file_dump_int_s(), "VP_TRACE");

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -47,12 +47,13 @@ namespace xdp {
     std::string toolVersion  = xdp::getToolVersion() ;
 
     // Based upon the configuration, create the appropriate writers
-    writers.push_back(new HALHostTraceWriter("hal_host_trace.csv",
-					     version,
-					     creationTime,
-					     xrtVersion,
-                         toolVersion)) ;
-    (db->getStaticInfo()).addOpenedFile("hal_host_trace.csv", "VP_TRACE");
+    VPWriter* writer = new HALHostTraceWriter("hal_host_trace.csv",
+                                              version,
+                                              creationTime,
+                                              xrtVersion,
+                                              toolVersion) ;
+    writers.push_back(writer) ;
+    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE");
 #ifdef HAL_SUMMARY
     writers.push_back(new HALSummaryWriter("hal_summary.csv"));
 #endif

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -130,11 +130,13 @@ namespace xdp {
   {
     db->registerPlugin(this) ;
     db->registerInfo(info::lop);
-    writers.push_back(new LowOverheadTraceWriter("lop_trace.csv")) ;
+
+    VPWriter* writer = new LowOverheadTraceWriter("lop_trace.csv") ;
+    writers.push_back(writer) ;
 
     emulationSetup() ;
 
-    (db->getStaticInfo()).addOpenedFile("lop_trace.csv", "VP_TRACE") ;
+    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
 
     // In order to avoid overhead later, preallocate the string table
     //  in the dynamic database with all of the strings we will store

--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
@@ -26,9 +26,11 @@ namespace xdp {
   {
     db->registerPlugin(this) ;
     db->registerInfo(info::native) ;
-    writers.push_back(new NativeTraceWriter("native_trace.csv")) ;
 
-    (db->getStaticInfo()).addOpenedFile("native_trace.csv", "VP_TRACE") ;
+    VPWriter* writer = new NativeTraceWriter("native_trace.csv") ;
+    writers.push_back(writer) ;
+
+    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
   }
 
   NativeProfilingPlugin::~NativeProfilingPlugin()

--- a/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/noc/noc_plugin.cpp
@@ -46,9 +46,11 @@ namespace xdp {
       mDevices.push_back(deviceName);
 
       std::string outputFile = "noc_profile_" + deviceName + ".csv"; 
-      writers.push_back(new NOCProfilingWriter(outputFile.c_str(),
-          deviceName.c_str(), index));
-      db->getStaticInfo().addOpenedFile(outputFile.c_str(), "NOC_PROFILE") ;
+      VPWriter* writer = new NOCProfilingWriter(outputFile.c_str(),
+                                                deviceName.c_str(),
+                                                index) ;
+      writers.push_back(writer);
+      db->getStaticInfo().addOpenedFile(writer->getcurrentFileName(), "NOC_PROFILE") ;
 
       // Move on to next device
       xclClose(handle);

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -33,8 +33,9 @@ namespace xdp {
     db->registerInfo(info::opencl_trace) ;
 
     // Add a single writer for the OpenCL host trace
-    writers.push_back(new OpenCLTraceWriter("opencl_trace.csv")) ;
-    (db->getStaticInfo()).addOpenedFile("opencl_trace.csv", "VP_TRACE") ;
+    VPWriter* writer = new OpenCLTraceWriter("opencl_trace.csv") ;
+    writers.push_back(writer) ;
+    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
 
     // Continuous writing of opencl trace
     continuous_trace =

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -84,10 +84,11 @@ namespace xdp {
       std::string deviceName = std::string(info.mName) ;
       std::string outputFile = "power_profile_" + deviceName + ".csv" ; 
 
-      writers.push_back(new PowerProfilingWriter(outputFile.c_str(),
-						 deviceName.c_str(),
-					         index)) ;
-      (db->getStaticInfo()).addOpenedFile(outputFile.c_str(), 
+      VPWriter* writer = new PowerProfilingWriter(outputFile.c_str(),
+                                                  deviceName.c_str(),
+                                                  index) ;
+      writers.push_back(writer) ;
+      (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), 
 					  "XRT_POWER_PROFILE") ;
 
       // Move on to the next device

--- a/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
@@ -25,8 +25,9 @@ namespace xdp {
     db->registerPlugin(this) ;
     db->registerInfo(info::user) ;
 
-    writers.push_back(new UserEventsTraceWriter("user_events.csv")) ;
-    (db->getStaticInfo()).addOpenedFile("user_events.csv", "VP_TRACE") ;
+    VPWriter* writer = new UserEventsTraceWriter("user_events.csv") ;
+    writers.push_back(writer) ;
+    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
   }
 
   UserEventsPlugin::~UserEventsPlugin()

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -32,8 +32,8 @@
 
 namespace xdp {
 
-  VPRunSummaryWriter::VPRunSummaryWriter(const char* filename) :
-    VPWriter(filename)
+  VPRunSummaryWriter::VPRunSummaryWriter(const char* filename, VPDatabase* inst)
+    : VPWriter(filename, inst, false)
   {
   }
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.h
@@ -32,7 +32,7 @@ namespace xdp {
     virtual void switchFiles() ;
   public:
     XDP_EXPORT
-    VPRunSummaryWriter(const char* filename) ;
+    VPRunSummaryWriter(const char* filename, VPDatabase* inst) ;
     XDP_EXPORT
     ~VPRunSummaryWriter() ;
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -20,6 +20,14 @@
 #include "xdp/profile/writer/vp_base/vp_writer.h"
 #include "xdp/profile/device/tracedefs.h"
 #include "core/common/message.h"
+#include "core/common/config_reader.h"
+
+#ifdef _WIN32
+#else
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 namespace xdp {
 
@@ -28,10 +36,61 @@ namespace xdp {
   {
   }
 
-  VPWriter::VPWriter(const char* filename, VPDatabase* inst) :
-    basename(filename), currentFileName(filename), fileNum(1), db(inst),
-    fout(filename)
+  VPWriter::VPWriter(const char* filename, VPDatabase* inst, bool useDir) :
+    basename(filename), currentFileName(filename), directory(""),
+#ifdef _WIN32
+    separator('\\'),
+#else
+    separator('/'),
+#endif
+    fileNum(1), db(inst)
   {
+    std::string directory = xrt_core::config::get_profiling_directory() ;
+
+    if (!useDir || directory == "") {
+      // If no directory was specified, just use the file in
+      //  the working directory
+      fout.open(filename) ;
+      return ;
+    }
+
+    // The directory was specified.  Check if it exists and is writable
+    bool dirExists  = false ;
+    bool writeable  = false ;
+#ifdef _WIN32
+#else
+    struct stat buf ;
+    int result = stat(directory.c_str(), &buf) ;
+    if (!result) {
+      // The file exists.  Is it a directory?
+      dirExists = S_ISDIR(buf.st_mode) ;
+      if (dirExists) {
+        // The directory exists, but can we write to it?
+        writeable = (buf.st_mode & S_IWUSR) != 0 ;
+      }
+      //else {
+        // The file exists, but it is not a directory.  We cannot write to it
+      //}
+    }
+    else {
+      // The file does not exist at all, so try to create it
+      result = mkdir(directory.c_str(), 0777) ;
+      if (!result) {
+        dirExists = true ;
+        writeable = true ;
+      }
+    }
+#endif
+    if (!dirExists || !writeable) {
+      // If we cannot create the directory, or if we cannot write to
+      //  the directory, then just use the filename
+      fout.open(filename) ;
+      return ;
+    }
+
+    // Set the file name to directory + filename
+    currentFileName = directory + separator + basename ;
+    fout.open(currentFileName) ;
   }
 
   VPWriter::~VPWriter()
@@ -48,6 +107,9 @@ namespace xdp {
 
     ++fileNum ;
     currentFileName = std::to_string(fileNum) + std::string("-") + basename ;
+    if (directory != "") {
+      currentFileName = directory + separator + currentFileName ;
+    }
 
     if (fileNum == TRACE_DUMP_FILE_COUNT_WARN && !warnFileNum) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TRACE_DUMP_FILE_COUNT_WARN_MSG);
@@ -65,6 +127,11 @@ namespace xdp {
     fout.clear() ;
 
     fout.open(currentFileName.c_str()) ;
+  }
+
+  std::string VPWriter::getcurrentFileName()
+  {
+    return currentFileName ;
   }
 
 }

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -45,7 +45,7 @@ namespace xdp {
 #endif
     fileNum(1), db(inst)
   {
-    std::string directory = xrt_core::config::get_profiling_directory() ;
+    directory = xrt_core::config::get_profiling_directory() ;
 
     if (!useDir || directory == "") {
       // If no directory was specified, just use the file in

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -59,7 +59,7 @@ namespace xdp {
     bool writeable  = false ;
 #ifdef _WIN32
 #else
-    struct stat buf ;
+    struct stat buf = {0} ;
     int result = stat(directory.c_str(), &buf) ;
     if (!result) {
       // The file exists.  Is it a directory?
@@ -74,7 +74,8 @@ namespace xdp {
     }
     else {
       // The file does not exist at all, so try to create it
-      result = mkdir(directory.c_str(), 0777) ;
+      const mode_t rwx_all = 0777 ;
+      result = mkdir(directory.c_str(), rwx_all) ;
       if (!result) {
         dirExists = true ;
         writeable = true ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -39,6 +39,10 @@ namespace xdp {
     // The current name of the open file
     std::string currentFileName ;
 
+    // The directory where all the files will be dumped
+    std::string directory ;
+    char separator ;
+
     // The number of files created by this writer (in continuous offload)
     uint32_t fileNum ;
     static bool warnFileNum;
@@ -57,8 +61,10 @@ namespace xdp {
     XDP_EXPORT virtual void refreshFile() ;
   public:
     XDP_EXPORT VPWriter(const char* filename) ;
-    XDP_EXPORT VPWriter(const char* filename, VPDatabase* inst) ;
+    XDP_EXPORT VPWriter(const char* filename, VPDatabase* inst, bool useDir = true) ;
     XDP_EXPORT virtual ~VPWriter() ;
+
+    XDP_EXPORT virtual std::string getcurrentFileName() ;
 
     virtual bool isRunSummaryWriter() { return false ; }
     // Return false to indicate no data was written
@@ -66,7 +72,8 @@ namespace xdp {
     virtual bool isDeviceWriter() { return false ; } 
     virtual DeviceIntf* device() { return nullptr ; } 
     virtual bool isSameDevice(void* /*handle*/) { return false ; }
-    virtual std::string getcurrentFileName() { return currentFileName ; }
+
+    virtual std::string getDirectory() { return directory ; }
   } ;
 
 }


### PR DESCRIPTION
This pull request adds the option "profiling_directory" to the xrt.ini file which specifies a directory to dump all of the generated profiling files, including AIE profiling, power profiling, summary file, and trace files.  The run summary will still be generated in the current working directory.  

This initial submission only adds Linux support.  If the directory doesn't exist or the application cannot create the directory, then files will still be dumped in the working directory.