### PR TITLE
CR-1103864 Checkout compatible OpenCL libraries using correct tag

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps-win.py
+++ b/src/runtime_src/tools/scripts/xrtdeps-win.py
@@ -308,6 +308,7 @@ class OpenCLHeaders:
     self.install_dir = XRT_LIBRARY_INSTALL_DIR
     self.root_build_dir = XRT_LIBRARY_BUILD_DIR
     self.skipBuildInstall = skip
+    self.tag_version = "v2020.03.13"
     self.headerDir = "CL"
     self.buildDir = "OpenCL-Headers"
 
@@ -399,7 +400,7 @@ class OpenCLHeaders:
       print ("Retrieving git repository...")
 
     gitDir = os.path.join(self.root_build_dir, self.buildDir)
-    cloneCmd = "git clone https://github.com/KhronosGroup/OpenCL-Headers.git " + gitDir
+    cloneCmd = "git clone --branch=" + self.tag_version + " https://github.com/KhronosGroup/OpenCL-Headers.git " + gitDir
     print (cloneCmd)
     os.system(cloneCmd)
 
@@ -445,6 +446,7 @@ class ICDLibrary:
     self.install_dir = XRT_LIBRARY_INSTALL_DIR
     self.root_build_dir = XRT_LIBRARY_BUILD_DIR
     self.skipBuildInstall = skip
+    self.tag_version = "v2020.03.13"
     self.headerDir = "CL"
     self.buildDir = "OpenCL-ICD-Loader"
 
@@ -527,7 +529,7 @@ class ICDLibrary:
       print ("Retrieving git repository...")
 
     gitDir = os.path.join(self.root_build_dir, self.buildDir)
-    cloneCmd = "git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader.git " + gitDir
+    cloneCmd = "git clone --branch=" + self.tag_version + " https://github.com/KhronosGroup/OpenCL-ICD-Loader.git " + gitDir
     print (cloneCmd)
     os.system(cloneCmd)
 

--- a/src/runtime_src/tools/scripts/xrtdeps-win.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps-win.sh
@@ -192,7 +192,7 @@ opencl_install()
 
     # Clone https://github.com/KhronosGroup/OpenCL-Headers.git
     mkdir -p $KHRONOS
-    git clone https://github.com/KhronosGroup/OpenCL-Headers.git $KHRONOS/OpenCL-Headers
+    git clone -b v2020.03.13 https://github.com/KhronosGroup/OpenCL-Headers.git $KHRONOS/OpenCL-Headers
     rsync -avz $KHRONOS/OpenCL-Headers/CL $KHRONOS/include
 }
 
@@ -206,7 +206,7 @@ icd_install()
         return
     fi
 
-    git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader.git $KHRONOS/OpenCL-ICD-Loader
+    git clone -b v2020.03.13 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git $KHRONOS/OpenCL-ICD-Loader
     rsync -avz $KHRONOS/OpenCL-Headers/CL $KHRONOS/OpenCL-ICD-Loader/inc
     local here=$PWD
     cd $KHRONOS/OpenCL-ICD-Loader


### PR DESCRIPTION
Get the compatible version of OpenCL library while setting up Windows build environment for XRT. Current checking out version 2020.3.13 