### PR TITLE
VITIS-2614 Add C++ APIs for AIE multi-process

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -309,8 +309,16 @@ void
 device::
 reset_array()
 {
-  auto handle = get_handle();
-  handle->reset_aie();
+  auto core_device = get_handle();
+  core_device->reset_aie();
+}
+
+void
+device::
+open_context(xrt::aie::device::access_mode am)
+{
+  auto core_device = get_handle();
+  core_device->open_aie_context(am);
 }
 
 }} // namespace aie, xrt

--- a/src/runtime_src/core/include/experimental/xrt_graph.h
+++ b/src/runtime_src/core/include/experimental/xrt_graph.h
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-#ifndef _XRT_GRAPH_H_
-#define _XRT_GRAPH_H_
+#ifndef XRT_GRAPH_H_
+#define XRT_GRAPH_H_
 
 #include <chrono>
 
@@ -35,15 +35,31 @@ namespace xrt {
 /*!
  * @class graph
  *
- * The graph object represents an abstraction exported by aietool matching
- * a specified name.
- * The graph is created by finding matching graph name in the currently
- * loaded xclbin.
+ * The graph object represents an abstraction exported by aietool
+ * matching a specified name.
+ *
+ * The graph is created by finding matching graph name in the
+ * currently loaded xclbin.
  */
 class graph_impl;
 class graph
 {
 public:
+  /**
+   * @enum access_mode - graph access mode
+   *
+   * @var exclusive
+   *   Exclusive access to graph and all graph APIs.  No other process 
+   *   will have access to the graph.
+   * @var primary
+   *   Primary access to graph provides same capabilities as exclusive
+   *   access, but other processes will be allowed shared access as well.
+   * @var shared
+   *   Shared none destructive access to graph, a limited number of APIs
+   *   can be called.
+   *
+   * By default a graph is opened in primary access mode.
+   */
   enum class access_mode : uint8_t { exclusive = 0, primary = 1, shared = 2 };
 
   /**
@@ -55,8 +71,11 @@ public:
    *  UUID of the xclbin with the graph
    * @param name
    *  Name of graph to construct
+   * @param am
+   *  Open the graph with specified access (default primary)
    */
-  graph(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name);
+  graph(const xrt::device& device, const xrt::uuid& xclbin_id, const std::string& name,
+        access_mode am = access_mode::primary);
 
   /**
    * reset() - Reset a graph.

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -18,8 +18,8 @@
 
 // This file defines shim level XRT Graph APIs.
 
-#ifndef _XCL_COMMON_GRAPH_H_
-#define _XCL_COMMON_GRAPH_H_
+#ifndef XCL_COMMON_GRAPH_H_
+#define XCL_COMMON_GRAPH_H_
 
 #include "experimental/xrt_graph.h"
 


### PR DESCRIPTION
Extend xrt_aie.h and xrt_graph.h with C++ access mode support which in
turn facilitates support for multi-process.