### PR TITLE
Fix xclbin uuid output when ip_layout/kds cus data empty

### DIFF
--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -95,17 +95,27 @@ populate_cus(const xrt_core::device *device)
   boost::property_tree::ptree pt;
   std::vector<char> ip_buf;
   std::vector<std::tuple<uint64_t, uint32_t, uint32_t>> cu_stats; // tuple <base_addr, usage, status>
+  boost::property_tree::ptree ptree;
+
+  try {
+    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
+    boost::algorithm::to_upper(uuid);
+    ptree.put("xclbin_uuid", uuid);
+  } catch (...) {  }
 
   try {
     ip_buf = xrt_core::device_query<qr::ip_layout_raw>(device);
     cu_stats = xrt_core::device_query<qr::kds_cu_info>(device);
   } catch (const std::exception& ex){
     pt.put("error_msg", ex.what());
-    return pt;
+    ptree.add_child("compute_units", pt);
+    return ptree;
   }
 
   if(ip_buf.empty() || cu_stats.empty()) {
-    return pt;
+    pt.put("error_msg", "ip_layout/kds_cu data is empty");
+    ptree.add_child("compute_units", pt);
+    return ptree;
   }
 
   const ip_layout *layout = reinterpret_cast<const ip_layout*>(ip_buf.data());
@@ -129,12 +139,6 @@ populate_cus(const xrt_core::device *device)
     }
   }
 
-  boost::property_tree::ptree ptree;
-  try {
-    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
-    boost::algorithm::to_upper(uuid);
-    ptree.put("xclbin_uuid", uuid);
-  } catch (...) {  }
   ptree.add_child("compute_units", pt);
   return ptree;
 }
@@ -164,24 +168,32 @@ boost::property_tree::ptree
 populate_cus_new(const xrt_core::device *device)
 {
   schedulerUpdateStat(const_cast<xrt_core::device *>(device));
-  
+
   boost::property_tree::ptree pt;
   using cu_data_type = qr::kds_cu_stat::data_type;
   using scu_data_type = qr::kds_scu_stat::data_type;
   std::vector<cu_data_type> cu_stats;
   std::vector<scu_data_type> scu_stats;
+  boost::property_tree::ptree ptree;
+  try {
+    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
+    boost::algorithm::to_upper(uuid);
+    ptree.put("xclbin_uuid", uuid);
+  } catch (...) {  }
 
   try {
     cu_stats  = xrt_core::device_query<qr::kds_cu_stat>(device);
     scu_stats = xrt_core::device_query<qr::kds_scu_stat>(device);
-  } 
+  }
   catch (const xrt_core::query::no_such_key&) {
     // Ignoring if not available: Edge Case
   }
   catch (const std::exception& ex) {
     pt.put("error_msg", ex.what());
-    return pt;
+    ptree.add_child("compute_units", pt);
+    return ptree;
   }
+
   for (auto& stat : cu_stats) {
     boost::property_tree::ptree ptCu;
     ptCu.put( "name",           stat.name);
@@ -195,7 +207,7 @@ populate_cus_new(const xrt_core::device *device)
   std::vector<ps_kernel_data> psKernels;
   if (getPSKernels(psKernels, device) < 0) {
     std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
-    return pt;
+    return ptree;
   }
 
   uint32_t psk_inst = 0;
@@ -205,7 +217,7 @@ populate_cus_new(const xrt_core::device *device)
     boost::property_tree::ptree ptCu;
     std::string scu_name = "Illegal";
     if (psk_inst >= psKernels.size()) {
-      scu_name = stat.name; 
+      scu_name = stat.name;
       //This means something is wrong
       //scu_name e.g. kernel_vcu_encoder:scu_34
     } else {
@@ -232,12 +244,6 @@ populate_cus_new(const xrt_core::device *device)
     }
   }
 
-  boost::property_tree::ptree ptree;
-  try {
-    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
-    boost::algorithm::to_upper(uuid);
-    ptree.put("xclbin_uuid", uuid);
-  } catch (...) {  }
   ptree.add_child("compute_units", pt);
   return ptree;
 }


### PR DESCRIPTION
xbutil report is not filling xclbin_uuid node when ip_layout or kds cus data have empty status. So, output "N/A" is seen for
xclbin uuid.
Fix this issue by moving xclbin_uuid node update before compute_units node update.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>