### PR TITLE
Fix regex matching of kernel name

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -187,17 +187,21 @@ pybo.def(py::init<xrt::device, size_t, xrt::bo::flags, xrt::memory_group>())
 
 /*
  *
- * xrt::xclbin::ip
+ * xrt::xclbin::ip xrt::xclbin::kernel
  *
  */
 py::class_<xrt::xclbin> pyxclbin(m, "xclbin");
 py::class_<xrt::xclbin::ip> pyxclbinip(pyxclbin, "xclbinip");
 py::bind_vector<std::vector<xrt::xclbin::ip>>(m, "xclbinip_vector");
+py::class_<xrt::xclbin::kernel> pyxclbinkernel(pyxclbin, "xclbinkernel");
+py::bind_vector<std::vector<xrt::xclbin::kernel>>(m, "xclbinkernel_vector");
 
 
 pyxclbinip.def(py::init<>())
     .def("get_name", &xrt::xclbin::ip::get_name);
 
+pyxclbinkernel.def(py::init<>())
+    .def("get_name", &xrt::xclbin::kernel::get_name);
 /*
  *
  * xrt::xclbin::ip
@@ -212,6 +216,7 @@ pyxclbin.def(py::init<>())
                       return new xrt::xclbin(top);
                   }))
     .def("get_ips", &xrt::xclbin::get_ips)
+    .def("get_kernels", &xrt::xclbin::get_kernels)
     .def("get_xsa_name", &xrt::xclbin::get_xsa_name)
     .def("get_uuid", &xrt::xclbin::get_uuid);
 }

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -367,12 +367,12 @@ get_cus(const ip_layout* ip_layout, const std::string& kname)
     std::regex r("^(.*):\\{(.*)\\}$");
     std::smatch m;
     if (!regex_search(str,m,r))
-      return "^(" + str + ")((.*))$";            // "(kernel):((.*))"
+      return "^(" + str + "):((.*))$";            // "(kernel):((.*))"
 
     std::string kernel = m[1];
-    std::string insts = m[2];                  // "cu1,cu2,cu3"
-    std::string regex = "^(" + kernel + "):(";  // "(kernel):("
-    std::vector<std::string> cus;              // split at ','
+    std::string insts = m[2];                     // "cu1,cu2,cu3"
+    std::string regex = "^(" + kernel + "):(";    // "(kernel):("
+    std::vector<std::string> cus;                 // split at ','
     boost::split(cus,insts,boost::is_any_of(","));
 
     // compose final regex

--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -28,11 +28,11 @@ def runKernel(opt):
     xbin = pyxrt.xclbin(opt.bitstreamFile)
     uuid = d.load_xclbin(xbin)
 
-    iplist = xbin.get_ips()
+    kernellist = xbin.get_kernels()
 
     rule = re.compile("hello*")
-    ip = list(filter(lambda val: rule.match(val.get_name()), iplist))[0]
-    hello = pyxrt.kernel(d, uuid, ip.get_name(), pyxrt.kernel.shared)
+    kernel = list(filter(lambda val: rule.match(val.get_name()), kernellist))[0]
+    hello = pyxrt.kernel(d, uuid, kernel.get_name(), pyxrt.kernel.shared)
 
     zeros = bytearray(opt.DATA_SIZE)
     boHandle1 = pyxrt.bo(d, opt.DATA_SIZE, pyxrt.bo.normal, hello.group_id(0))


### PR DESCRIPTION
If clCreateKernel or xrt::kernel objects are contructed with a kernel
name that is a substring of other kernel names, then matching fails
because of missing ":" in dynamically created regex.

Add missing ":" seperator in regex "(kernelname):(.*)".