### PR TITLE
xclbinutil Bug Fix: Corrected getDebugIPType to return the correct enumeration value

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -367,7 +367,8 @@ extern "C" {
         TRACE_S2MM,
         AXI_DMA,
         TRACE_S2MM_FULL,
-        AXI_NOC
+        AXI_NOC,
+        ACCEL_DEADLOCK_DETECTOR
     };
 
     struct debug_ip_data {

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -63,6 +63,8 @@ SectionDebugIPLayout::getDebugIPTypeStr(enum DEBUG_IP_TYPE _debugIpType) const {
       return "AXI_DMA";
     case AXI_NOC:
       return "AXI_NOC";
+    case ACCEL_DEADLOCK_DETECTOR:
+      return "ACCEL_DEADLOCK_DETECTOR";
   }
 
   return XUtil::format("UNKNOWN (%d)", static_cast<unsigned int>(_debugIpType));
@@ -107,6 +109,9 @@ SectionDebugIPLayout::getDebugIPType(std::string& _sDebugIPType) const {
     return AXI_STREAM_MONITOR;
 
   if ( _sDebugIPType == "AXI_STREAM_PROTOCOL_CHECKER" ) 
+    return AXI_STREAM_PROTOCOL_CHECKER;
+
+  if ( _sDebugIPType == "ACCEL_DEADLOCK_DETECTOR" ) 
     return AXI_STREAM_PROTOCOL_CHECKER;
 
   if (_sDebugIPType == "UNDEFINED")

--- a/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionDebugIPLayout.cxx
@@ -112,7 +112,7 @@ SectionDebugIPLayout::getDebugIPType(std::string& _sDebugIPType) const {
     return AXI_STREAM_PROTOCOL_CHECKER;
 
   if ( _sDebugIPType == "ACCEL_DEADLOCK_DETECTOR" ) 
-    return AXI_STREAM_PROTOCOL_CHECKER;
+    return ACCEL_DEADLOCK_DETECTOR;
 
   if (_sDebugIPType == "UNDEFINED")
     return UNDEFINED;


### PR DESCRIPTION
The incorrect enumeration value is being returned from getDebugIPType() for ACCEL_DEADLOCK_DETECTOR.

