### PR TITLE
Vitis-1144 Software resettable kernels

### DIFF
--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -309,17 +309,16 @@ static void cu_hls_reset(void *core)
 	cu_write32(cu_hls, CTRL, CU_AP_SW_RESET);
 }
 
-static int cu_hls_reset_done(void *core)
+static bool cu_hls_reset_done(void *core)
 {
 	struct xrt_cu_hls *cu_hls = core;
 	u32 ctrl_reg;
 
 	ctrl_reg = cu_read32(cu_hls, CTRL);
 	if (ctrl_reg & CU_AP_SW_RESET)
-		return 0;
+		return false;
 
-	/* ap_sw_reset is clear, reset is done */
-	return 1;
+	return true;
 }
 
 static struct xcu_funcs xrt_cu_hls_funcs = {

--- a/src/runtime_src/core/common/drv/cu_hls.c
+++ b/src/runtime_src/core/common/drv/cu_hls.c
@@ -18,6 +18,8 @@
  * Bit 2: ap_idle(Read only).
  * Bit 3: ap_ready(Read only). Self clear after clear ap_start.
  * Bit 4: ap_continue(Read/Set). Self clear.
+ * Bit 5-7: Not support yet
+ * Bit 8: ap_sw_reset. Clear when reset is done.
  */
 #define CTRL		0x0
 /* Global interrupt enable: Set bit 0 to enable. Clear it to disable */
@@ -300,6 +302,26 @@ static u32 cu_hls_clear_intr(void *core)
 	return cu_read32(cu_hls, ISR);
 }
 
+static void cu_hls_reset(void *core)
+{
+	struct xrt_cu_hls *cu_hls = core;
+
+	cu_write32(cu_hls, CTRL, CU_AP_SW_RESET);
+}
+
+static int cu_hls_reset_done(void *core)
+{
+	struct xrt_cu_hls *cu_hls = core;
+	u32 ctrl_reg;
+
+	ctrl_reg = cu_read32(cu_hls, CTRL);
+	if (ctrl_reg & CU_AP_SW_RESET)
+		return 0;
+
+	/* ap_sw_reset is clear, reset is done */
+	return 1;
+}
+
 static struct xcu_funcs xrt_cu_hls_funcs = {
 	.alloc_credit	= cu_hls_alloc_credit,
 	.free_credit	= cu_hls_free_credit,
@@ -310,6 +332,8 @@ static struct xcu_funcs xrt_cu_hls_funcs = {
 	.enable_intr	= cu_hls_enable_intr,
 	.disable_intr	= cu_hls_disable_intr,
 	.clear_intr	= cu_hls_clear_intr,
+	.reset		= cu_hls_reset,
+	.reset_done	= cu_hls_reset_done,
 };
 
 int xrt_cu_hls_init(struct xrt_cu *xcu)

--- a/src/runtime_src/core/common/drv/fast_adapter.c
+++ b/src/runtime_src/core/common/drv/fast_adapter.c
@@ -178,6 +178,17 @@ static u32 cu_fa_clear_intr(void *core)
 	return cu_read32(cu_fa, ISR);
 }
 
+static void cu_fa_reset(void *core)
+{
+	/* Fast adapter doesn't define software reset */
+	return;
+}
+
+static int cu_fa_reset_done(void *core)
+{
+	return 1;
+}
+
 static struct xcu_funcs xrt_cu_fa_funcs = {
 	.alloc_credit	= cu_fa_alloc_credit,
 	.free_credit	= cu_fa_free_credit,
@@ -188,6 +199,8 @@ static struct xcu_funcs xrt_cu_fa_funcs = {
 	.enable_intr	= cu_fa_enable_intr,
 	.disable_intr	= cu_fa_disable_intr,
 	.clear_intr	= cu_fa_clear_intr,
+	.reset		= cu_fa_reset,
+	.reset_done	= cu_fa_reset_done,
 };
 
 int xrt_cu_fa_init(struct xrt_cu *xcu)

--- a/src/runtime_src/core/common/drv/fast_adapter.c
+++ b/src/runtime_src/core/common/drv/fast_adapter.c
@@ -184,9 +184,9 @@ static void cu_fa_reset(void *core)
 	return;
 }
 
-static int cu_fa_reset_done(void *core)
+static bool cu_fa_reset_done(void *core)
 {
-	return 1;
+	return true;
 }
 
 static struct xcu_funcs xrt_cu_fa_funcs = {

--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -23,6 +23,7 @@ enum kds_opcode {
 	OP_NONE = 0,
 	OP_CONFIG,
 	OP_START,
+	OP_ABORT,
 	OP_CONFIG_SK, /* TODO: There is a plan to remove softkernel config and unconfig command */
 	OP_START_SK,
 	OP_CLK_CALIB,
@@ -99,6 +100,7 @@ struct kds_command {
 	u32			*execbuf;
 	u32			*u_execbuf;
 	void			*gem_obj;
+	u32			 exec_bo_handle;
 	/* to notify inkernel exec completion */
 	struct in_kernel_cb	*inkern_cb;
 };
@@ -115,6 +117,8 @@ void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			  u32 skip);
 void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			struct kds_command *xcmd);
+void abort_ecmd2xcmd(struct ert_abort_cmd *ecmd,
+		     struct kds_command *xcmd);
 int cu_mask_to_cu_idx(struct kds_command *xcmd, uint8_t *cus);
 
 #endif

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -150,9 +150,8 @@ struct xcu_funcs {
 	 * @reset_done:
 	 *
 	 * Check if CU is properly reset
-	 * Return 1 if reset done, 0 if not done
 	 */
-	int (*reset_done)(void *core);
+	bool (*reset_done)(void *core);
 
 	/**
 	 * @enable_intr:
@@ -335,7 +334,7 @@ static inline void xrt_cu_reset(struct xrt_cu *xcu)
 	xcu->funcs->reset(xcu->core);
 }
 
-static inline int xrt_cu_reset_done(struct xrt_cu *xcu)
+static inline bool xrt_cu_reset_done(struct xrt_cu *xcu)
 {
 	return xcu->funcs->reset_done(xcu->core);
 }

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -207,6 +207,7 @@ struct xrt_cu_info {
 	u32			 is_m2m;
 	u32			 num_res;
 	bool			 intr_enable;
+	bool			 sw_reset;
 	struct xrt_cu_arg	*args;
 	u32			 num_args;
 	char			 iname[32];

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -276,6 +276,38 @@ kds_cu_dispatch(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 	return 0;
 }
 
+static void
+kds_cu_abort_cmd(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
+{
+	struct kds_sched *kds;
+	int i;
+
+	/* Broadcast abort command to each CU and let CU finds out how to abort
+	 * the target command.
+	 */
+	for (i = 0; i < cu_mgmt->num_cus; i++) {
+		xrt_cu_hpq_submit(cu_mgmt->xcus[i], xcmd);
+
+		if (xcmd->status == KDS_NEW)
+			continue;
+
+		if (xcmd->status == KDS_TIMEOUT) {
+			kds = container_of(cu_mgmt, struct kds_sched, cu_mgmt);
+			kds->bad_state = 1;
+			kds_info(xcmd->client, "CU(%d) hangs, reset device", i);
+		}
+
+		xcmd->cb.notify_host(xcmd, xcmd->status);
+		xcmd->cb.free(xcmd);
+		return;
+	}
+
+	/* Command is not found in any CUs and any queues */
+	xcmd->status = KDS_ERROR;
+	xcmd->cb.notify_host(xcmd, xcmd->status);
+	xcmd->cb.free(xcmd);
+}
+
 static int
 kds_submit_cu(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 {
@@ -290,6 +322,9 @@ kds_submit_cu(struct kds_cu_mgmt *cu_mgmt, struct kds_command *xcmd)
 	case OP_GET_STAT:
 		xcmd->cb.notify_host(xcmd, KDS_COMPLETED);
 		xcmd->cb.free(xcmd);
+		break;
+	case OP_ABORT:
+		kds_cu_abort_cmd(cu_mgmt, xcmd);
 		break;
 	default:
 		ret = -EINVAL;
@@ -1326,6 +1361,14 @@ void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	xcmd->isize = (ecmd->count - xcmd->num_mask) * sizeof(u32);
 	memcpy(xcmd->info, &ecmd->data[ecmd->extra_cu_masks], xcmd->isize);
 	ecmd->type = ERT_CTRL;
+}
+
+void abort_ecmd2xcmd(struct ert_abort_cmd *ecmd, struct kds_command *xcmd)
+{
+	u32 *exec_bo_handle = xcmd->info;
+
+	xcmd->opcode = OP_ABORT;
+	*exec_bo_handle = ecmd->exec_bo_handle;
 }
 
 void set_xcmd_timestamp(struct kds_command *xcmd, enum kds_status s)

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -720,6 +720,8 @@ ssize_t show_cu_info(struct xrt_cu *xcu, char *buf)
 			info->intr_enable);
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "Interrupt ID:  %d\n",
 			info->intr_id);
+	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "SW Resettable: %d\n",
+			info->sw_reset);
 
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "--- Arguments ---\n");
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "Number of arguments: %d\n",

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -71,6 +71,8 @@
     ((struct ert_init_kernel_cmd *)(pkg))
 #define to_validate_pkg(pkg) \
     ((struct ert_validate_cmd *)(pkg))
+#define to_abort_pkg(pkg) \
+    ((struct ert_abort_cmd *)(pkg))
 
 /**
  * struct ert_packet: ERT generic packet format
@@ -344,19 +346,22 @@ struct ert_unconfigure_sk_cmd {
 /**
  * struct ert_abort_cmd: ERT abort command format.
  *
- * @idx: The slot index of command to abort
+ * @exec_bo_handle: The bo handle of execbuf command to abort
  */
 struct ert_abort_cmd {
   union {
     struct {
       uint32_t state:4;          /* [3-0]   */
-      uint32_t unused:11;        /* [14-4]  */
-      uint32_t idx:8;            /* [22-15] */
+      uint32_t custom:8;         /* [11-4]  */
+      uint32_t count:11;         /* [22-12] */
       uint32_t opcode:5;         /* [27-23] */
       uint32_t type:4;           /* [31-27] */
     };
     uint32_t header;
   };
+
+  /* payload */
+  uint32_t exec_bo_handle;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -355,18 +355,22 @@ struct argument_info {
 	uint32_t	dir;
 };
 
+/* Kernel features macro */
+#define KRNL_SW_RESET	(1 << 0)
 /**
  * struct kernel_info - Kernel information
  *
  * @name:	kernel name
  * @range:	kernel register range
  * @anums:	number of argument
+ * @features:	number of argument
  * @args:	argument array
  */
 struct kernel_info {
 	char			 name[64];
 	uint32_t		 range;
 	int			 anums;
+	int			 features;
 	struct argument_info	 args[];
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1555,6 +1555,8 @@ static int icap_create_subdev_cu(struct platform_device *pdev)
 		info.addr = ip->m_base_address;
 		/* Workaround for U30, maybe we can remove this in the future */
 		info.size = (krnl_info) ? krnl_info->range : 0x1000;
+		if (krnl_info->features & KRNL_SW_RESET)
+			info.sw_reset = true;
 		info.num_res = subdev_info.num_res;
 		info.intr_enable = ip->properties & IP_INT_ENABLE_MASK;
 		info.protocol = (ip->properties & IP_CONTROL_MASK) >> IP_CONTROL_SHIFT;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -557,6 +557,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	/* xcmd->u_execbuf points to user's original for write back/notice */
 	xcmd->u_execbuf = xobj->vmapping;
 	xcmd->gem_obj = obj;
+	xcmd->exec_bo_handle = args->exec_bo_handle;
 
 	print_ecmd_info(ecmd);
 
@@ -621,6 +622,9 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	case ERT_CU_STAT:
 		xcmd->opcode = OP_GET_STAT;
 		xcmd->priv = &XDEV(xdev)->kds;
+		break;
+	case ERT_ABORT:
+		abort_ecmd2xcmd(to_abort_pkg(ecmd), xcmd);
 		break;
 	default:
 		userpf_err(xdev, "Unsupport command\n");

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1405,6 +1405,10 @@ int shim::xclLoadAxlf(const axlf *buffer)
         krnl->anums = kernel.args.size();
         krnl->range = kernel.range;
 
+        krnl->features = 0;
+        if (kernel.sw_reset)
+            krnl->features |= KRNL_SW_RESET;
+
         int ai = 0;
         for (auto& arg : kernel.args) {
             if (arg.name.size() > sizeof(krnl->args[ai].name)) {


### PR DESCRIPTION
1. KDS could support abort command from user space. The payload is the bo handle of execbuf command ('target command' in below) to abort
2. Pass down the sw_reset bit to CU subdevice while load xclbin.
3. KDS try submit a abort command to each CU until a CU find target command to abort. If target command is not found by any CU, user would get ERT_CMD_STATE_ERROR from the abort command.
4. If CU foundtarget command, and it isn't submitted to CU hardware, abort it from the internal running queue.
5. If CU found target command, and it is submitted to CU hardware, try reset CU and wait about 100 us then check if CU reset:
     a) If CU reset is done, abort target command and return ERT_CMD_STATE_COMPLETE to user.
     6) If CU reset is not done, abort target command and ask for reset the whole board. User would get ERT_CMD_STATE_TIMEOUT.

Since HLS bug, I have no positive test case, that sw reset works. I mimic different hang situations by modified driver to test different code path. I have done some simple test:  
    
1. One CU xclbin on U50
2. Multiple CUs xclbin on U200

About performance, test with xbutil validate on U50 and U200, the IOPS test case shows similar result w/ and wo/ this change.