### PR TITLE
Added -full option in build_edge script to run full petalinux build which generates Images aswell

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,1 @@
-PETALINUX="/proj/petalinux/2021.1/petalinux-v2021.1_daily_latest/tool/petalinux-v2021.1-final"
+PETALINUX="/proj/petalinux/2021.2/petalinux-v2021.2_daily_latest/tool/petalinux-v2021.2-final"


### PR DESCRIPTION
Current build_edge.sh only builds XRT RPMs. We have a use case where This script generates a full build so that we can use generated Images/rootfs and other files.
Added -full option in this script to run a full petalinux build
Also, enabled incremental build.