### PR TITLE
CR-1105541: Change new tables section to match the original OpenCL section in the profiling summary file

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -925,7 +925,7 @@ namespace xdp {
     if (hostReads.size() == 0) return ;
 
     fout << "TITLE:Host Reads from Global Memory\n" ;
-    fout << "SECTION:Host Data Transfer,Host Reads from Global Memory\n" ;
+    fout << "SECTION:Host Data Transfers,Host Reads from Global Memory\n" ;
     fout << "COLUMN:Number of Reads,int,"
          << "Number of host reads (note: may contain OpenCL printf transfers),"
          << "\n" ;
@@ -990,7 +990,7 @@ namespace xdp {
     if (hostWrites.size() == 0) return ;
 
     fout << "TITLE:Host Writes to Global Memory\n" ;
-    fout << "SECTION:Host Data Transfer,Host Writes to Global Memory\n" ;
+    fout << "SECTION:Host Data Transfers,Host Writes to Global Memory\n" ;
     fout << "COLUMN:Number of Writes,int,"
          << "Number of host writes,\n" ;
     fout << "COLUMN:Maximum Buffer Size (KB),float,"
@@ -1754,7 +1754,7 @@ namespace xdp {
       return ;
 
     fout << "TITLE:Top Memory Reads: Host from Global Memory\n" ;
-    fout << "SECTION:Host Data Transfer,Top Memory Reads\n" ;
+    fout << "SECTION:Host Data Transfers,Top Memory Reads\n" ;
     fout << "COLUMN:Start Time (ms),float,Start time of read transfer (in ms),\n" ;
     fout << "COLUMN:Buffer Size (KB),float,Size of read transfer (in KB),\n" ;
     if (getFlowMode() == HW) {
@@ -1782,7 +1782,7 @@ namespace xdp {
       return ;
 
     fout << "TITLE:Top Memory Writes: Host to Global Memory\n" ;
-    fout << "SECTION:Host Data Transfer,Top Memory Writes\n" ;
+    fout << "SECTION:Host Data Transfers,Top Memory Writes\n" ;
     fout << "COLUMN:Start Time (ms),float,Start time of write transfer (in ms),\n" ;
     fout << "COLUMN:Buffer Size (KB),float,Size of write transfer (in KB),\n" ;
     if (getFlowMode() == HW) {


### PR DESCRIPTION
The newly generated tables in the profile summary report have a "SECTION" field that identifies where they should be displayed in Vitis Analyzer.  This pull request changes the SECTION of data transfer tables so they appear in the same section as the previous OpenCL-specific tables.