### PR TITLE
CR-1101219 Implementation between Edge/DC shouldn't be different for EXEC_WRITE opcode

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_command.h
+++ b/src/runtime_src/core/common/drv/include/kds_command.h
@@ -110,9 +110,8 @@ void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 		   struct kds_command *xcmd);
 void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			  struct kds_command *xcmd);
-void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
-			  struct kds_command *xcmd,
-			  u32 skip);
+void start_krnl_kv_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
+			     struct kds_command *xcmd);
 void start_fa_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 			struct kds_command *xcmd);
 int cu_mask_to_cu_idx(struct kds_command *xcmd, uint8_t *cus);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1276,8 +1276,8 @@ void start_krnl_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	ecmd->type = ERT_CU;
 }
 
-void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
-			  struct kds_command *xcmd, u32 skip)
+void start_krnl_kv_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
+			     struct kds_command *xcmd)
 {
 	xcmd->opcode = OP_START;
 
@@ -1295,10 +1295,10 @@ void exec_write_ecmd2xcmd(struct ert_start_kernel_cmd *ecmd,
 	 *
 	 * Based on ert.h, ecmd->count is the number of words following header.
 	 * In ert_start_kernel_cmd, the CU register map size is
-	 * (count - (1 + extra_cu_masks)) and skip 6 words for exec_write cmd.
+	 * (count - (1 + extra_cu_masks)).
 	 */
-	xcmd->isize = (ecmd->count - xcmd->num_mask - skip) * sizeof(u32);
-	memcpy(xcmd->info, &ecmd->data[skip + ecmd->extra_cu_masks], xcmd->isize);
+	xcmd->isize = (ecmd->count - xcmd->num_mask) * sizeof(u32);
+	memcpy(xcmd->info, &ecmd->data[ecmd->extra_cu_masks], xcmd->isize);
 	xcmd->payload_type = KEY_VAL;
 	ecmd->type = ERT_CU;
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -414,13 +414,15 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		/* third argument in following function is representing number of
-		 * words to skip when configuring CU. This should be consistent
-		 * for both edge/DC, but due to performance and siome use cases,
-		 * this has veen decided that , DC flows skip 6 words whereas
-		 * edge flows doesnt skip any words.
-		 */
-		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd, 0);
+		DRM_WARN("ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
+#if KERNEL_VERSION(5, 4, 0) > LINUX_VERSION_CODE
+		__attribute__ ((fallthrough));
+#else
+		__attribute__ ((__fallthrough__));
+#endif
+		/* pass through */
+	case ERT_START_KEY_VAL:
+		start_krnl_kv_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_START_FA:
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -428,6 +428,7 @@ struct cu_cmd_state_timestamps {
  * @ERT_SK_CONFIG:      configure soft kernel
  * @ERT_SK_START:       start a soft kernel
  * @ERT_SK_UNCONFIG:    unconfigure a soft kernel
+ * @ERT_START_KEY_VAL:  same as ERT_START_CU but with key-value pair flavor
  */
 enum ert_cmd_opcode {
   ERT_START_CU      = 0,
@@ -445,6 +446,7 @@ enum ert_cmd_opcode {
   ERT_START_FA      = 12,
   ERT_CLK_CALIB     = 13,
   ERT_MB_VALIDATE   = 14,
+  ERT_START_KEY_VAL = 15,
 };
 
 /**
@@ -762,10 +764,10 @@ ert_valid_opcode(struct ert_packet *pkt)
     /* 1 cu mask + 4 registers */
     valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 4);
     break;
-  case ERT_EXEC_WRITE:
+  case ERT_START_KEY_VAL:
     skcmd = to_start_krnl_pkg(pkt);
-    /* 1 cu mask + 6 registers */
-    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 6);
+    /* 1 cu mask */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1);
     break;
   case ERT_START_FA:
     skcmd = to_start_krnl_pkg(pkt);

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -769,6 +769,10 @@ ert_valid_opcode(struct ert_packet *pkt)
     /* 1 cu mask */
     valid = (skcmd->count >= skcmd->extra_cu_masks + 1);
     break;
+  case ERT_EXEC_WRITE:
+    skcmd = to_start_krnl_pkg(pkt);
+    /* 1 cu mask + 6 registers */
+    valid = (skcmd->count >= skcmd->extra_cu_masks + 1 + 6);
   case ERT_START_FA:
     skcmd = to_start_krnl_pkg(pkt);
     /* 1 cu mask */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -583,13 +583,11 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		/* third argument in following function is representing number of
-		 * words to skip when writing to CU. This should be consistent
-		 * for both edge/DC, but Due to performance and some use cases
-		 * this is been decided that, DC flows skips first 6 words
-		 * whereas edge flows doesnt skip any words
-		 */
-		exec_write_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd, 6);
+		userpf_err(xdev, "ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
+		ret = -EINVAL;
+		goto out1;
+	case ERT_START_KEY_VAL:
+		start_krnl_kv_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_START_FA:
 		start_fa_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -482,6 +482,21 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 	return true;
 }
 
+/* This function is only used to convert ERT_EXEC_WRITE to
+ * ERT_START_KEY_VAL.
+ * The only difference is that ERT_EXEC_WRITE skip 6 words in the payload.
+ */
+static int convert_exec_write2key_val( struct ert_start_kernel_cmd *ecmd)
+{
+	/* end index of payload = count - (1 + 6) */
+	int end = ecmd->count - 7;
+	int i;
+
+	/* Shift payload 6 words up */
+	for (i = ecmd->extra_cu_masks; i < end; i++)
+		ecmd->data[i] = ecmd->data[i + 6];
+}
+
 static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 			      struct drm_file *filp, bool in_kernel)
 {
@@ -583,9 +598,10 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		userpf_err(xdev, "ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
-		ret = -EINVAL;
-		goto out1;
+		userpf_info(xdev, "ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
+		convert_exec_write2key_val(to_start_krnl_pkg(ecmd));
+		start_krnl_kv_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
+		break;
 	case ERT_START_KEY_VAL:
 		start_krnl_kv_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -649,8 +649,7 @@ inline void
 configure_cu_ooo(addr_type cu_addr, addr_type regmap_addr, size_type regmap_size)
 {
   // write register map addr, value pairs starting 
-  // past reserved 4 ctrl + 2 ctx 
-  for (size_type idx = 6; idx < regmap_size; idx += 2) {
+  for (size_type idx = 0; idx < regmap_size; idx += 2) {
     addr_type offset = read_reg(regmap_addr + (idx << 2));
     value_type value = read_reg(regmap_addr + ((idx + 1) << 2));
     write_reg(cu_addr + offset, value);

--- a/src/runtime_src/ert/scheduler/scheduler_v30.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler_v30.cpp
@@ -685,8 +685,7 @@ inline void
 configure_cu_ooo(addr_type cu_addr, addr_type regmap_addr, size_type regmap_size)
 {
   // write register map addr, value pairs starting 
-  // past reserved 4 ctrl + 2 ctx 
-  for (size_type idx = 6; idx < regmap_size; idx += 2) {
+  for (size_type idx = 0; idx < regmap_size; idx += 2) {
     addr_type offset = read_reg(regmap_addr + (idx << 2));
     value_type value = read_reg(regmap_addr + ((idx + 1) << 2));
     write_reg(cu_addr + offset, value);

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -287,7 +287,7 @@ add(index_type idx, value_type value)
 
 exec_write_command::
 exec_write_command(xrt_device* device)
-  : command(device,ERT_EXEC_WRITE)
+  : command(device,ERT_START_KEY_VAL)
 {
   m_impl->ert_pkt->type = ERT_CU;
   clear();
@@ -327,12 +327,7 @@ clear()
   auto skcmd = m_impl->ert_cu;
   skcmd->cu_mask = 0;
 
-  // clear payload to past reserved fields. Reserved entries are
-  // dictated by mandatory cumask and offset (0x10 and 0x14) of ctx-in
-  // and ctx-out.  Since exec_write is piggybacking on start_kernel,
-  // we have to skip past 4 control registers in register map also.
-  // todo: create separate cmd packet for exec_write
-  m_impl->ert_pkt->count = 1 + 4 + 2; 
+  m_impl->ert_pkt->count = 1; 
 }
 
 }} // exec,xrt


### PR DESCRIPTION
ERT_EXEC_WRITE command required skip the first 6 words in the payload for DC platforms but there is no need to skip any words for EDGE platforms.
This pull request add a new execbuf opcode, which unify this behavior and NO need to skip any words on DC and edge platforms.

After this change, anyone that use ERT_EXEC_WRITE on DC platform would get exec buf error with dmesg said "xocl_command_ioctl: ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL".
On edge platform, user would expect to see a warning with same content.

On DC, this change helps the ERT performance since we decreased the write to the ERT CQ.

Shell: xilinx_u200_gen3x16_xdma_base_1
Before (skip 6 words):
 xcl_iops_test.exe /opt/xilinx/firmware/u200/gen3x16-xdma/base/test/ -d 0000:05:00.1
Overall Commands:  100000 **IOPS: 357096** (verify)
TEST PASSED

After (no skip):
xcl_iops_test.exe /opt/xilinx/firmware/u200/gen3x16-xdma/base/test/ -d 0000:05:00.1
Overall Commands:  100000 **IOPS: 457794** (verify)
TEST PASSED