### PR TITLE
CR-1104794: Stop outputting kernel to global memory tables in profile summary if no monitors exist

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1551,6 +1551,19 @@ namespace xdp {
     std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
     if (infos.size() == 0) return ;
 
+    bool monitorsExist = false ;
+    for (auto device : infos) {
+      for (auto xclbin : device->getLoadedXclbins()) {
+        if (xclbin->aimList.size() > 0 || xclbin->asmList.size() > 0) {
+          monitorsExist = true ;
+          break ;
+        }
+      }
+      if (monitorsExist) break ;
+    }
+
+    if (!monitorsExist) return ;
+
     // Caption
     fout << "Data Transfer: Kernels to Global Memory\n" ;
 
@@ -1665,6 +1678,19 @@ namespace xdp {
   {
     std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
     if (infos.size() == 0) return ;
+
+    bool monitorsExist = false ;
+    for (auto device : infos) {
+      for (auto xclbin : device->getLoadedXclbins()) {
+        if (xclbin->aimList.size() > 0 || xclbin->asmList.size() > 0) {
+          monitorsExist = true ;
+          break ;
+        }
+      }
+      if (monitorsExist) break ;
+    }
+
+    if (!monitorsExist) return ;
 
     // Caption
     fout << "Top Data Transfer: Kernels to Global Memory" << std::endl ;


### PR DESCRIPTION
Previously, we printed out the kernel to global memory tables in the profile summary if device information existed.  This pull request adds an additional prerequisite that we should only print out these tables if monitors that collect data exist on any of these devices, preventing us from dumping empty tables.
