### PR TITLE
U30 xbutil2 enhancement

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -54,6 +54,9 @@ struct kds_ctx_info {
 	u32		  flags;
 };
 
+/* Soft CUs metrics size to display in sysfs entry */
+#define SCU_STATS_METRIC_SIZE	7
+
 /* TODO: PS kernel is very different with FPGA kernel.
  * Let's see if we can unify them later.
  */

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -58,6 +58,7 @@ struct kds_ctx_info {
  * Let's see if we can unify them later.
  */
 struct scu_usages {
+        u32                       usage;
         u32                       succ_cnt;
         u32                       err_cnt;
         u32                       crsh_cnt;
@@ -74,7 +75,6 @@ struct kds_scu_mgmt {
 	struct mutex		  lock;
 	int			  num_cus;
 	u32			  status[MAX_CUS];
-	u32			  usage[MAX_CUS];
 	char			  name[MAX_CUS][32];
 	struct scu_usages	  usages_stats[MAX_CUS];
 	struct sk_mem_stats	  mem_stats;

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -57,12 +57,27 @@ struct kds_ctx_info {
 /* TODO: PS kernel is very different with FPGA kernel.
  * Let's see if we can unify them later.
  */
+struct scu_usages {
+        u32                       succ_cnt;
+        u32                       err_cnt;
+        u32                       crsh_cnt;
+};
+
+struct sk_mem_stats {
+        u32                       hbo_cnt;
+        u32                       mapbo_cnt;
+        u32                       unmapbo_cnt;
+        u32                       freebo_cnt;
+};
+
 struct kds_scu_mgmt {
 	struct mutex		  lock;
 	int			  num_cus;
 	u32			  status[MAX_CUS];
 	u32			  usage[MAX_CUS];
 	char			  name[MAX_CUS][32];
+	struct scu_usages	  usages_stats[MAX_CUS];
+	struct sk_mem_stats	  mem_stats;
 };
 
 /* the MSB of cu_refs is used for exclusive flag */
@@ -176,4 +191,5 @@ int store_kds_echo(struct kds_sched *kds, const char *buf, size_t count,
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf);
 ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf);
 ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf);
+ssize_t kds_sk_memstat(struct kds_sched *kds, struct sk_mem_stats *stat);
 #endif

--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -54,9 +54,6 @@ struct kds_ctx_info {
 	u32		  flags;
 };
 
-/* Soft CUs metrics size to display in sysfs entry */
-#define SCU_STATS_METRIC_SIZE	7
-
 /* TODO: PS kernel is very different with FPGA kernel.
  * Let's see if we can unify them later.
  */

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -93,7 +93,7 @@ ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
 	for (i = 0; i < scu_mgmt->num_cus; ++i) {
 		sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, i,
 				scu_mgmt->name[i], scu_mgmt->status[i],
-				scu_mgmt->usage[i], 
+				scu_mgmt->usages_stats[i].usage,
 				scu_mgmt->usages_stats[i].succ_cnt,
 				scu_mgmt->usages_stats[i].err_cnt,
 				scu_mgmt->usages_stats[i].crsh_cnt);
@@ -196,7 +196,7 @@ kds_scu_config(struct kds_scu_mgmt *scu_mgmt, struct kds_command *xcmd)
 				sizeof(scu_mgmt->name[0]));
 
 			scu_mgmt->num_cus++;
-			scu_mgmt->usage[i] = 0;
+			scu_mgmt->usages_stats[i].usage = 0;
 		}
 	}
 	mutex_unlock(&scu_mgmt->lock);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -106,7 +106,7 @@ ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
 ssize_t kds_sk_memstat(struct kds_sched *kds, struct sk_mem_stats *stat)
 {
 	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
-	struct sk_mem_stats *mem_stat;
+	struct sk_mem_stats *mem_stat = NULL;
 
 	mutex_lock(&scu_mgmt->lock);
 

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -75,7 +75,7 @@ ssize_t show_kds_custat_raw(struct kds_sched *kds, char *buf)
 ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
 {
 	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
-	char *cu_fmt = "%d,%s,0x%x,%u\n";
+	char *cu_fmt = "%d,%s,0x%x,%u,%u,%u,%u\n";
 	ssize_t sz = 0;
 	int i;
 
@@ -93,11 +93,32 @@ ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
 	for (i = 0; i < scu_mgmt->num_cus; ++i) {
 		sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, i,
 				scu_mgmt->name[i], scu_mgmt->status[i],
-				scu_mgmt->usage[i]);
+				scu_mgmt->usage[i], 
+				scu_mgmt->usages_stats[i].succ_cnt,
+				scu_mgmt->usages_stats[i].err_cnt,
+				scu_mgmt->usages_stats[i].crsh_cnt);
 	}
 	mutex_unlock(&scu_mgmt->lock);
 
 	return sz;
+}
+
+ssize_t kds_sk_memstat(struct kds_sched *kds, struct sk_mem_stats *stat)
+{
+	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
+	struct sk_mem_stats *mem_stat;
+
+	mutex_lock(&scu_mgmt->lock);
+
+	mem_stat = &scu_mgmt->mem_stats;
+	stat->hbo_cnt = mem_stat->hbo_cnt;
+	stat->mapbo_cnt = mem_stat->mapbo_cnt;
+	stat->unmapbo_cnt = mem_stat->unmapbo_cnt;
+	stat->freebo_cnt = mem_stat->freebo_cnt;
+
+	mutex_unlock(&scu_mgmt->lock);
+
+	return 0;
 }
 
 ssize_t show_kds_stat(struct kds_sched *kds, char *buf)

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -757,6 +757,9 @@ struct kds_scu_stat : request
     std::string name;
     uint32_t status;
     uint64_t usages;
+    uint64_t succ_cnt;
+    uint64_t err_cnt;
+    uint64_t crsh_cnt;
   };
   using result_type = std::vector<struct data>;
   using data_type = struct data;

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
@@ -25,6 +25,13 @@
 #define SK_DONE			1
 #define SK_RUNNING		2
 
+enum sk_mem_stats_type {
+	ZOCL_MEM_STAT_TYPE_HBO,
+	ZOCL_MEM_STAT_TYPE_MAPBO,
+	ZOCL_MEM_STAT_TYPE_UNMAPBO,
+	ZOCL_MEM_STAT_TYPE_FREEBO,
+};
+
 struct soft_cu {
 	void			*sc_vregs;
 	struct drm_gem_object	*gem_obj;
@@ -39,6 +46,7 @@ struct soft_cu {
 
 	uint32_t		sc_flags;
 	uint64_t		usage;
+	struct scu_usages 	sc_usages;
 
 	/*
 	 * soft cu pid and parent pid. This can be used to identify if the
@@ -60,6 +68,7 @@ struct soft_krnl {
 	struct mutex		sk_lock;
 	struct soft_cu		*sk_cu[MAX_SOFT_KERNEL];
 
+	struct sk_mem_stats	mem_stats;
 	/*
 	 * sk_ncus is a counter represents how many
 	 * compute units are configured.
@@ -79,5 +88,6 @@ struct soft_krnl_cmd {
 
 int zocl_init_soft_kernel(struct drm_device *drm);
 void zocl_fini_soft_kernel(struct drm_device *drm);
-
+void zocl_update_sk_mem_stat(struct drm_zocl_dev *zdev, int count,
+                unsigned m_stat_type);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
@@ -88,6 +88,6 @@ struct soft_krnl_cmd {
 
 int zocl_init_soft_kernel(struct drm_device *drm);
 void zocl_fini_soft_kernel(struct drm_device *drm);
-void zocl_update_sk_mem_stat(struct drm_zocl_dev *zdev, int count,
+void zocl_sk_mem_stat_incr(struct drm_zocl_dev *zdev,
                 unsigned m_stat_type);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -1072,7 +1072,10 @@ print_and_out:
  * [1  ]      : number of cq slots
  * [1  ]      : number of cus
  * [#numcus]  : cu execution stats (number of executions)
+ * [#numscus] : scu execution stats (number of executions, success, error and crash count)
  * [#numcus]  : cu status (1: running, 0: idle, -1: crashed)
+ * [#numscus] : scu status (1: running, 0: idle, -1: crashed)
+ * [mem stat] : soft kernel memory status
  * [#slots]   : command queue slot status
  */
 static void
@@ -1082,13 +1085,13 @@ cu_stat(struct sched_cmd *cmd)
 	struct zocl_ert_dev *ert = zdev->ert;
 	struct sched_exec_core *exec = zdev->exec;
 	struct soft_krnl *sk = zdev->soft_kernel;
-	struct sk_mem_stats *mem_stat;
-	struct ert_packet *pkg;
-	int slot_idx;
+	struct sk_mem_stats *mem_stat = NULL;
+	struct ert_packet *pkg = NULL;
+	struct pid *p_tmp = NULL;
+	int slot_idx = 0;
 	int pkt_idx = 0;
 	int max_idx = (slot_size(cmd->ddev) >> 2) - 1;
 	int i;
-	struct pid *p_tmp;
 
 	SCHED_DEBUG("-> %s cq_slot_idx %d\n", __func__, cmd->cq_slot_idx);
 	slot_idx = cmd->cq_slot_idx;

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -1082,6 +1082,7 @@ cu_stat(struct sched_cmd *cmd)
 	struct zocl_ert_dev *ert = zdev->ert;
 	struct sched_exec_core *exec = zdev->exec;
 	struct soft_krnl *sk = zdev->soft_kernel;
+	struct sk_mem_stats *mem_stat;
 	struct ert_packet *pkg;
 	int slot_idx;
 	int pkt_idx = 0;
@@ -1094,7 +1095,7 @@ cu_stat(struct sched_cmd *cmd)
 	pkg = cmd->packet;
 
 	/* custat version, update when changing layout of packet */
-	pkg->data[pkt_idx++] = 0x51a10000;
+	pkg->data[pkt_idx++] = ERT_CUSTAT_VERSION_1;
 
 	/* should be git version */
 	pkg->data[pkt_idx++] = ERT_VERSION;
@@ -1112,10 +1113,22 @@ cu_stat(struct sched_cmd *cmd)
 	/* individual SK CU execution stat */
 	mutex_lock(&sk->sk_lock);
 	for (i = 0; i < sk->sk_ncus && pkt_idx < max_idx; ++i) {
-		if (sk->sk_cu[i])
+		struct scu_usages *sc_stat;
+		if (sk->sk_cu[i]) {
+			sc_stat = &sk->sk_cu[i]->sc_usages;
+
 			pkg->data[pkt_idx++] = sk->sk_cu[i]->usage;
-		else //soft kernel cu has crashed
+			pkg->data[pkt_idx++] = sc_stat->succ_cnt;
+			pkg->data[pkt_idx++] = sc_stat->err_cnt;
+			pkg->data[pkt_idx++] = sc_stat->crsh_cnt;
+		}
+		else { //soft kernel cu has crashed
+			// Fill for all the counters for consistency 
 			pkg->data[pkt_idx++] = -1;
+			pkg->data[pkt_idx++] = -1;
+			pkg->data[pkt_idx++] = -1;
+			pkg->data[pkt_idx++] = -1;
+		}
 	}
 	mutex_unlock(&sk->sk_lock);
 
@@ -1147,8 +1160,15 @@ cu_stat(struct sched_cmd *cmd)
 		} else
 			pkg->data[pkt_idx++] = -1;
 	}
-	mutex_unlock(&sk->sk_lock);
 
+	/* Collect other soft-kernel memory stats */
+	mem_stat = &sk->mem_stats;
+	pkg->data[pkt_idx++] = mem_stat->hbo_cnt;
+	pkg->data[pkt_idx++] = mem_stat->mapbo_cnt;
+	pkg->data[pkt_idx++] = mem_stat->unmapbo_cnt;
+	pkg->data[pkt_idx++] = mem_stat->freebo_cnt;
+
+	mutex_unlock(&sk->sk_lock);
 	/* Command slot status
 	 * Hard code QUEUED state. When a NEW command is found,
 	 * ERT/PS will set it to QUEUED. Then no CQ write.

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -19,6 +19,7 @@
 #include <asm/io.h>
 #include "xrt_drv.h"
 #include "zocl_drv.h"
+#include "zocl_sk.h"
 #include "xclbin.h"
 #include "zocl_bo.h"
 
@@ -505,8 +506,10 @@ int zocl_map_bo_ioctl(struct drm_device *dev,
 		struct drm_file *filp)
 {
 	int ret = 0;
+	struct drm_zocl_dev *zdev = dev->dev_private;
 	struct drm_zocl_map_bo *args = data;
 	struct drm_gem_object *gem_obj;
+	struct drm_zocl_bo *bo;
 
 	gem_obj = zocl_gem_object_lookup(dev, filp, args->handle);
 	if (!gem_obj) {
@@ -522,6 +525,11 @@ int zocl_map_bo_ioctl(struct drm_device *dev,
 	/* The mmap offset was set up at BO allocation time. */
 	args->offset = drm_vma_node_offset_addr(&gem_obj->vma_node);
 	zocl_describe(to_zocl_bo(gem_obj));
+
+	/* Update softkernel memory stats */
+	bo = to_zocl_bo(gem_obj);
+	if (bo->flags & ZOCL_BO_FLAGS_HOST_BO)
+        	zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_MAPBO);
 
 out:
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
@@ -887,6 +895,8 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 		return ret;
 	}
 
+	zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_HBO);
+
 	zocl_describe(bo);
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&bo->cma_base.base);
 
@@ -899,6 +909,7 @@ error:
 void zocl_free_host_bo(struct drm_gem_object *gem_obj)
 {
 	struct drm_zocl_bo *zocl_bo = to_zocl_bo(gem_obj);
+	struct drm_zocl_dev *zdev = gem_obj->dev->dev_private;;
 
 	DRM_DEBUG("%s: obj 0x%px", __func__, zocl_bo);
 
@@ -907,6 +918,9 @@ void zocl_free_host_bo(struct drm_gem_object *gem_obj)
 	drm_gem_object_release(gem_obj);
 
 	kfree(&zocl_bo->cma_base);
+			
+	/* Update softkernel memory stats */
+	zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_FREEBO);
 }
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -508,8 +508,8 @@ int zocl_map_bo_ioctl(struct drm_device *dev,
 	int ret = 0;
 	struct drm_zocl_dev *zdev = dev->dev_private;
 	struct drm_zocl_map_bo *args = data;
-	struct drm_gem_object *gem_obj;
-	struct drm_zocl_bo *bo;
+	struct drm_gem_object *gem_obj = NULL;
+	struct drm_zocl_bo *bo = NULL;
 
 	gem_obj = zocl_gem_object_lookup(dev, filp, args->handle);
 	if (!gem_obj) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -529,7 +529,7 @@ int zocl_map_bo_ioctl(struct drm_device *dev,
 	/* Update softkernel memory stats */
 	bo = to_zocl_bo(gem_obj);
 	if (bo->flags & ZOCL_BO_FLAGS_HOST_BO)
-        	zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_MAPBO);
+		zocl_sk_mem_stat_incr(zdev, ZOCL_MEM_STAT_TYPE_MAPBO);
 
 out:
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(gem_obj);
@@ -895,7 +895,7 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 		return ret;
 	}
 
-	zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_HBO);
+	zocl_sk_mem_stat_incr(zdev, ZOCL_MEM_STAT_TYPE_HBO);
 
 	zocl_describe(bo);
 	ZOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(&bo->cma_base.base);
@@ -920,7 +920,7 @@ void zocl_free_host_bo(struct drm_gem_object *gem_obj)
 	kfree(&zocl_bo->cma_base);
 			
 	/* Update softkernel memory stats */
-	zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_FREEBO);
+	zocl_sk_mem_stat_incr(zdev, ZOCL_MEM_STAT_TYPE_FREEBO);
 }
 
 /*

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -713,7 +713,7 @@ void zocl_drm_gem_vm_close(struct vm_area_struct *vma)
 
 	/* Update softkernel memory stats */
 	if (bo->flags & ZOCL_BO_FLAGS_HOST_BO)
-		zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_UNMAPBO);
+		zocl_sk_mem_stat_incr(zdev, ZOCL_MEM_STAT_TYPE_UNMAPBO);
 
 	drm_gem_vm_close(vma);
 }

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -705,10 +705,23 @@ static int zocl_iommu_init(struct drm_zocl_dev *zdev,
 	return 0;
 }
 
+void zocl_drm_gem_vm_close(struct vm_area_struct *vma)
+{
+	struct drm_gem_object *obj = vma->vm_private_data;
+	struct drm_zocl_dev *zdev = obj->dev->dev_private;
+	struct drm_zocl_bo *bo = to_zocl_bo(obj);
+
+	/* Update softkernel memory stats */
+	if (bo->flags & ZOCL_BO_FLAGS_HOST_BO)
+		zocl_update_sk_mem_stat(zdev, 1, ZOCL_MEM_STAT_TYPE_UNMAPBO);
+
+	drm_gem_vm_close(vma);
+}
+
 const struct vm_operations_struct zocl_bo_vm_ops = {
 	.fault = zocl_bo_fault,
 	.open  = drm_gem_vm_open,
-	.close = drm_gem_vm_close,
+	.close = zocl_drm_gem_vm_close,
 };
 
 static const struct drm_ioctl_desc zocl_ioctls[] = {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -140,7 +140,7 @@ zocl_sk_create_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 /*
  * Update the memory stats for softkernel .
  */
-void zocl_update_sk_mem_stat(struct drm_zocl_dev *zdev, int count, 
+void zocl_sk_mem_stat_incr(struct drm_zocl_dev *zdev,
                 unsigned m_stat_type)
 {
 	struct soft_krnl *sk = zdev->soft_kernel;
@@ -149,19 +149,19 @@ void zocl_update_sk_mem_stat(struct drm_zocl_dev *zdev, int count,
 	write_lock(&zdev->attr_rwlock);
 	switch (m_stat_type) {
 		case ZOCL_MEM_STAT_TYPE_HBO:
-			mem_stat->hbo_cnt += count;
+			mem_stat->hbo_cnt++;
 			break;
 
 		case ZOCL_MEM_STAT_TYPE_MAPBO:
-			mem_stat->mapbo_cnt += count;
+			mem_stat->mapbo_cnt++;
 			break;
 
 		case ZOCL_MEM_STAT_TYPE_UNMAPBO:
-			mem_stat->unmapbo_cnt += count;
+			mem_stat->unmapbo_cnt++;
 			break;
 
 		case ZOCL_MEM_STAT_TYPE_FREEBO:
-			mem_stat->freebo_cnt += count;
+			mem_stat->freebo_cnt++;
 			break;
 	}
 	write_unlock(&zdev->attr_rwlock);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -174,9 +174,9 @@ zocl_sk_report_ioctl(struct drm_device *dev, void *data,
 	struct drm_zocl_dev *zdev = dev->dev_private;
 	struct soft_krnl *sk = zdev->soft_kernel;
 	struct drm_zocl_sk_report *args = data;
-	struct soft_cu *scu;
+	struct soft_cu *scu = NULL;
 	uint32_t cu_idx = args->cu_idx;
-	uint32_t *vaddr;
+	uint32_t *vaddr = NULL;
 	struct scu_usages *sc_usage = NULL;
 	enum drm_zocl_scu_state state = args->cu_state;
 	int ret = 0;

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -626,6 +626,12 @@ uint32_t ert_base_addr = 0;
 #endif
 
 /**
+ * This defines ERT packet version which need to sync between Host and ERT
+ */
+#define ERT_CUSTAT_VERSION_0 		  0x51a10000
+#define ERT_CUSTAT_VERSION_1		  0x51a10001
+
+/**
  * Look up table for CUISR for CU addresses
  */
 #define ERT_CUISR_LUT_ADDR                (ERT_CSR_ADDR + 0x400)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mb_scheduler.c
@@ -1586,7 +1586,7 @@ ert_read_custat(struct xocl_ert *xert, struct xocl_cmd *xcmd, unsigned int num_c
 	memset(xert->cq_slot_status, -1, MAX_SLOTS * sizeof(u32));
 
 	// New command style from ERT firmware
-	if (custat_version == 0x51a10000) {
+	if (custat_version == ERT_CUSTAT_VERSION_0) {
 		unsigned int idx = 2; // packet word index past header and version
 		unsigned int max_idx = (xert->slot_size >> 2);
 		u32 git = ioread32(xert->cq_base + slot_addr + (idx++ << 2));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -30,6 +30,8 @@ do {\
 #define print_ecmd_info(ecmd)
 #endif
 
+#define CUSTATS_HEADER_SIZE	4
+
 void xocl_describe(const struct drm_xocl_bo *xobj);
 
 int kds_mode = 1;
@@ -301,7 +303,10 @@ static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,
  * [1  ]      : number of cq slots
  * [1  ]      : number of cus
  * [#numcus]  : cu execution stats (number of executions)
+ * [#numscus] : scu execution stats (number of executions, success, error and crash count)
  * [#numcus]  : cu status (1: running, 0: idle, -1: crashed)
+ * [#numscus] : scu status (1: running, 0: idle, -1: crashed)
+ * [mem stat] : soft kernel memory status
  * [#slots]   : command queue slot status
  *
  * Old ERT populates
@@ -332,7 +337,7 @@ static inline void read_ert_stat(struct kds_command *xcmd)
 	/* Only need PS kernel info, which is after FPGA CUs */
 	mutex_lock(&kds->scu_mgmt.lock);
 	/* Skip header and FPGA CU stats. off_idx points to PS kernel stats */
-	off_idx = 4 + num_cu;
+	off_idx = CUSTATS_HEADER_SIZE + num_cu;
 	for (i = 0; i < num_scu; i++) {
 		kds->scu_mgmt.usages_stats[i].usage = ecmd->data[off_idx++];
 		if (ecmd->data[0] == ERT_CUSTAT_VERSION_1) { // Only for new ERT packet version 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -334,7 +334,7 @@ static inline void read_ert_stat(struct kds_command *xcmd)
 	/* Skip header and FPGA CU stats. off_idx points to PS kernel stats */
 	off_idx = 4 + num_cu;
 	for (i = 0; i < num_scu; i++) {
-		kds->scu_mgmt.usage[i] = ecmd->data[off_idx++];
+		kds->scu_mgmt.usages_stats[i].usage = ecmd->data[off_idx++];
 		if (ecmd->data[0] == ERT_CUSTAT_VERSION_1) { // Only for new ERT packet version 
 			kds->scu_mgmt.usages_stats[i].succ_cnt = ecmd->data[off_idx++];
 			kds->scu_mgmt.usages_stats[i].err_cnt = ecmd->data[off_idx++];

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -325,18 +325,25 @@ static inline void read_ert_stat(struct kds_command *xcmd)
 	 */
 
 	/* New KDS handle FPGA CU statistic on host not ERT */
-	if (ecmd->data[0] != 0x51a10000)
+	if ((ecmd->data[0] != ERT_CUSTAT_VERSION_0) && 
+			(ecmd->data[0] != ERT_CUSTAT_VERSION_1))
 		return;
 
 	/* Only need PS kernel info, which is after FPGA CUs */
 	mutex_lock(&kds->scu_mgmt.lock);
 	/* Skip header and FPGA CU stats. off_idx points to PS kernel stats */
 	off_idx = 4 + num_cu;
-	for (i = 0; i < num_scu; i++)
-		kds->scu_mgmt.usage[i] = ecmd->data[off_idx + i];
+	for (i = 0; i < num_scu; i++) {
+		kds->scu_mgmt.usage[i] = ecmd->data[off_idx++];
+		if (ecmd->data[0] == ERT_CUSTAT_VERSION_1) { // Only for new ERT packet version 
+			kds->scu_mgmt.usages_stats[i].succ_cnt = ecmd->data[off_idx++];
+			kds->scu_mgmt.usages_stats[i].err_cnt = ecmd->data[off_idx++];
+			kds->scu_mgmt.usages_stats[i].crsh_cnt = ecmd->data[off_idx++];
+		}
+	}
 
 	/* off_idx points to PS kernel status */
-	off_idx += num_scu + num_cu;
+	off_idx += num_cu;
 	for (i = 0; i < num_scu; i++) {
 		int status = (int)(ecmd->data[off_idx + i]);
 
@@ -354,6 +361,16 @@ static inline void read_ert_stat(struct kds_command *xcmd)
 			kds->scu_mgmt.status[i] = 0;
 		}
 	}
+
+	/* off_idx points to PS kernel memory stats */
+	if (ecmd->data[0] == ERT_CUSTAT_VERSION_1) { // Only for new ERT packet version 
+		off_idx += num_scu;
+		kds->scu_mgmt.mem_stats.hbo_cnt = ecmd->data[off_idx++];
+		kds->scu_mgmt.mem_stats.mapbo_cnt = ecmd->data[off_idx++];
+		kds->scu_mgmt.mem_stats.unmapbo_cnt = ecmd->data[off_idx++];
+		kds->scu_mgmt.mem_stats.freebo_cnt = ecmd->data[off_idx++];
+	}
+
 	mutex_unlock(&kds->scu_mgmt.lock);
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -172,6 +172,22 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 		size += count;
 	}
 
+	if (raw) {
+		const char *skmem_raw_fmt = "%llu %llu %llu %llu\n";
+		struct sk_mem_stats sk_memstat;
+
+		err = kds_sk_memstat(&XDEV(xdev)->kds, &sk_memstat);
+		if (!err) {
+			count = sprintf(buf, skmem_raw_fmt,
+					sk_memstat.hbo_cnt,
+					sk_memstat.mapbo_cnt,
+					sk_memstat.unmapbo_cnt,
+					sk_memstat.freebo_cnt);
+			buf += count;
+			size += count;
+		}
+	}
+
 done:
 	XOCL_PUT_GROUP_TOPOLOGY(xdev);
 	mutex_unlock(&xdev->dev_lock);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mbscheduler_hwemu.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mbscheduler_hwemu.cxx
@@ -718,7 +718,7 @@ namespace hwemu {
         memset(this->cq_slot_status, -1, MAX_SLOTS * sizeof(uint32_t));
 
         // New command style from ERT firmware
-        if (custat_version == 0x51a10000) {
+        if (custat_version == ERT_CUSTAT_VERSION_0) {
             uint32_t idx = 2; // packet word index past header and version
             uint32_t max_idx = (this->slot_size >> 2);
             uint32_t git = ioread32(this->cq_base + slot_addr + (idx++ << 2));

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -114,7 +114,7 @@ struct kds_scu_stat
     std::string errmsg;
 
     // The kds_scustat_raw is printing in formatted string of each line
-    // Format: "%d,%s:%s,0x%x,%lu"
+    // Format: "%d,%s:%s,0x%x,%lu,%lu,%lu,%lu"
     // Using comma as separator.
     pdev->sysfs_get("", "kds_scustat_raw", errmsg, stats);
     if (!errmsg.empty())
@@ -125,7 +125,7 @@ struct kds_scu_stat
       boost::char_separator<char> sep(",");
       tokenizer tokens(line, sep);
 
-      if (std::distance(tokens.begin(), tokens.end()) != 4)
+      if (std::distance(tokens.begin(), tokens.end()) != 7) 
         throw std::runtime_error("PS kernel statistic sysfs node corrupted");
 
       data_type data;
@@ -135,6 +135,9 @@ struct kds_scu_stat
       data.name   = std::string(*tok_it++);
       data.status = std::stoul(std::string(*tok_it++), nullptr, radix);
       data.usages = std::stoul(std::string(*tok_it++));
+      data.succ_cnt = std::stoul(std::string(*tok_it++));
+      data.err_cnt = std::stoul(std::string(*tok_it++));
+      data.crsh_cnt = std::stoul(std::string(*tok_it++));
       // TODO: Let's avoid this special handling for PS kernel name
       data.name = data.name + ":scu_" + std::to_string(data.index);
 

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -29,6 +29,11 @@
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
 
+/* Soft CUs metrics size to display in sysfs entry */
+#define SCU_STATS_METRIC_SIZE   7
+/* CUs metrics size to display in sysfs entry */
+#define CU_STATS_METRIC_SIZE  	5
+
 namespace {
 
 namespace query = xrt_core::query;
@@ -80,7 +85,7 @@ struct kds_cu_stat
       boost::char_separator<char> sep(",");
       tokenizer tokens(line, sep);
 
-      if (std::distance(tokens.begin(), tokens.end()) != 5)
+      if (std::distance(tokens.begin(), tokens.end()) != CU_STATS_METRIC_SIZE)
         throw std::runtime_error("CU statistic sysfs node corrupted");
 
       data_type data;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -125,7 +125,7 @@ struct kds_scu_stat
       boost::char_separator<char> sep(",");
       tokenizer tokens(line, sep);
 
-      if (std::distance(tokens.begin(), tokens.end()) != 7) 
+      if (std::distance(tokens.begin(), tokens.end()) != SCU_STATS_METRIC_SIZE) 
         throw std::runtime_error("PS kernel statistic sysfs node corrupted");
 
       data_type data;

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -320,27 +320,27 @@ ReportDynamicRegion::writeReport( const xrt_core::device* /*_pDevice*/,
     }
     _output << std::endl;
 
-  //PS kernel report
-  _output << "  PS Compute Units" << std::endl;
-  _output << scuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status" % "Success_Count" % "Error_Count" % "Crash_Count";
-  try {
-    int index = 0;
-    for(auto& kv : pt_cu) {
-      const boost::property_tree::ptree& cu = kv.second;
-      if(cu.get<std::string>("type").compare("PS") != 0)
-        continue;
-      std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
-      uint32_t status_val = std::stoul(cu_status, nullptr, 16);
-      _output << scuFmt % index++ %
+    //PS kernel report
+    _output << "  PS Compute Units" << std::endl;
+    _output << scuFmt % "Index" % "Name" % "Base_Address" % "Usage" % "Status" % "Success_Count" % "Error_Count" % "Crash_Count";
+    try {
+      int index = 0;
+      for(auto& kv : pt_cu) {
+        const boost::property_tree::ptree& cu = kv.second;
+        if(cu.get<std::string>("type").compare("PS") != 0)
+          continue;
+        std::string cu_status = cu.get_child("status").get<std::string>("bit_mask");
+        uint32_t status_val = std::stoul(cu_status, nullptr, 16);
+        _output << scuFmt % index++ %
 	      cu.get<std::string>("name") % cu.get<std::string>("base_address") %
 	      cu.get<std::string>("usage") % xrt_core::utils::parse_cu_status(status_val) %
 	      cu.get<std::string>("succ_return") % cu.get<std::string>("err_return") %
 	      cu.get<std::string>("crsh_return");
+      }
     }
-  }
-  catch( std::exception const& e) {
-    _output << "ERROR: " <<  e.what() << std::endl;
-  }
+    catch( std::exception const& e) {
+      _output << "ERROR: " <<  e.what() << std::endl;
+    }
   }
 
   _output << std::endl;

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -228,11 +228,11 @@ populate_memtopology(const xrt_core::device * device, const std::string& desc)
    
   // Populate softkernel mem stats 
   boost::property_tree::ptree ptSkMem;
-  std::stringstream ss(mm_buf[map->m_count + 1]);
-  if (!ss.str().empty()) {
+  std::stringstream ss_mem(mm_buf[map->m_count + 1]);
+  if (!ss_mem.str().empty()) {
     uint64_t hboCnt, mapboCnt, unmapboCnt, freeboCnt;
   
-    ss >> hboCnt >> mapboCnt >> unmapboCnt >> freeboCnt;
+    ss_mem >> hboCnt >> mapboCnt >> unmapboCnt >> freeboCnt;
     ptSkMem.put("sk_hbo", hboCnt);
     ptSkMem.put("sk_mapbo", mapboCnt);
     ptSkMem.put("sk_unmapbo", unmapboCnt);

--- a/src/runtime_src/ert/scheduler/scheduler.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler.cpp
@@ -913,7 +913,7 @@ cu_stat(size_type slot_idx)
   size_type max_idx = slot_size >> 2; 
 
   // custat version, update when changing layout of packet
-  write_reg(slot.slot_addr + (pkt_idx++ << 2),0x51a10000);
+  write_reg(slot.slot_addr + (pkt_idx++ << 2), ERT_CUSTAT_VERSION_0);
 
   // ert git version
   write_reg(slot.slot_addr + (pkt_idx++ << 2),ERT_VERSION);

--- a/src/runtime_src/ert/scheduler/scheduler_v30.cpp
+++ b/src/runtime_src/ert/scheduler/scheduler_v30.cpp
@@ -961,7 +961,7 @@ cu_stat(size_type slot_idx)
   size_type max_idx = slot_size >> 2; 
 
   // custat version, update when changing layout of packet
-  write_reg(slot.slot_addr + (pkt_idx++ << 2),0x51a10000);
+  write_reg(slot.slot_addr + (pkt_idx++ << 2), ERT_CUSTAT_VERSION_0);
 
   // ert git version
   write_reg(slot.slot_addr + (pkt_idx++ << 2),ERT_VERSION);


### PR DESCRIPTION
CR : https://jira.xilinx.com/browse/CR-1087398

XRT needs to monitor more metrics for the edge stack running on U30 PS. We should at the minimum enhance xbutil query to
report the following:

Xbutil2 Enhancement

1. Memory Report
      Show all buffers information in memory report
               -  xclGetHostBO
               -  xclMapBO
               -  xclUnmapBO
               -  xclFreeBO
               
  ```
Soft Kernel Memory Status
    HostBO Count      MapBO Count     UnmapBO Count   FreeBO Count    
    0                 0               0               0
```     

2. SKD report
       Show all the skd processes running
              - Show how many times a SKD triggered
              - Metrics on how many times SKDs have crashed or have returned nonzero error code
                    - Success Count
                    - Error Count 
                    - Crash Count 
```
 Success_Count   Error_Count     Crash_Count
 608             0               0          
 0               0               0          
 0               0               0          
 0               0               0          
 0               0               0          
 0               0               0          
 0               0               0   
```       

Sample xbutil2 output : 
**xbutil  examine -r memory -d 5f:00.1**
```
Memory Information

  Memory Topology
         Tag         Type        Temp(C)  Size      Base Address    
    [ 0] DDR[0]      MEM_DRAM    N/A      1023 MB   0x800000000     

  Memory Status
         Tag         Type        Size    Mem Usage       BO count
    [ 0] DDR[0]      MEM_DRAM    1 GB    0 Byte          0       

  Soft Kernel Memory Status
    HostBO Count      MapBO Count     UnmapBO Count   FreeBO Count    
    0                 0               0               0              

```
JSON Output for Memory Status
```
"memories": [
    {
        "type": "MEM_DRAM",
        "tag": "DDR[0]",
        "enabled": "true",
        "base_address": "0x800000000",
        "range_bytes": "0x3fffc000",
        "extended_info": {
            "usage": {
                "allocated_bytes": "0",
                "buffer_objects_count": "0"
            }
        }
    }
],
"sk_memories": {
    "sk_hbo": "42",
    "sk_mapbo": "42",
    "sk_unmapbo": "29",
    "sk_freebo": "27"
},
```

**xbutil  examine -r dynamic-regions -d 5f:00.1**
```
Compute Units
  PL Compute Units
    Index   Name                          Base_Address    Usage   Status  
    0       scaler:scaler_1               0x1400000       0       (IDLE)  
    1       lookahead:lookahead_1         0x1440000       0       (IDLE)  
    2       lookahead:lookahead_2         0x1450000       0       (IDLE)  
    3       decoder:decoder_1             0x1451000       0       (IDLE)  
    4       encoder:encoder_1             0x1452000       0       (IDLE)  
    5       VCU:VCU_1                     0x1453000       0       (IDLE)  

  PS Compute Units
    Index   Name                          Base_Address    Usage   Status      Success_Count   Error_Count     Crash_Count     
    0       kernel_vcu_decoder_0          0x0             608     (IDLE)      608             0               0               
    1       kernel_vcu_decoder_1          0x0             0       (IDLE)      0               0               0               
    2       kernel_vcu_decoder_2          0x0             0       (IDLE)      0               0               0               
    3       kernel_vcu_decoder_3          0x0             0       (IDLE)      0               0               0               
    4       kernel_vcu_decoder_4          0x0             0       (IDLE)      0               0               0               
    5       kernel_vcu_decoder_5          0x0             0       (IDLE)      0               0               0               
    6       kernel_vcu_decoder_6          0x0             0       (IDLE)      0               0               0               
    7       kernel_vcu_decoder_7          0x0             0       (IDLE)      0               0               0               
            
```
JSON output for a single PS compute Unit:
```
                        {
                            "name": "kernel_vcu_decoder_1",
                            "base_address": "0x0",
                            "usage": "0",
                            "type": "PS",
                            "succ_return": "0",
                            "err_return": "0",
                            "crsh_return": "0",
                            "status": {
                                "bit_mask": "0x4",
                                "bits_set": [
                                    "IDLE"
                                ]
                            }
                        },

```