### PR TITLE
high cpu usage while mailbox is idle

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -248,8 +248,8 @@ MODULE_PARM_DESC(mailbox_no_intr,
 #define	MSG_TX_PER_MB_TTL	1UL	/* in seconds */
 #define	MSG_MAX_TTL		0xFFFFFFFF /* used to disable timer */
 #define	TEST_MSG_LEN		128
-#define	JIFFIES_TO_MS(jiffies) 	(jiffies * 1000 / HZ)
-#define	MAILBOX_TIMER_MS 	JIFFIES_TO_MS(MAILBOX_TIMER)
+#define	JIFFIES_TO_US(jiffies) 	(jiffies * 1000000 / HZ)
+#define	MAILBOX_TIMER_US 	JIFFIES_TO_US(MAILBOX_TIMER)
 
 #define	INVALID_MSG_ID		((u64)-1)
 
@@ -873,7 +873,7 @@ static void chan_worker(struct work_struct *work)
 			 */
 			usleep_range(1000, 2000);
 		} else if (mailbox_no_intr) {
-			usleep_range(MAILBOX_TIMER_MS, MAILBOX_TIMER_MS * 2);
+			usleep_range(MAILBOX_TIMER_US, MAILBOX_TIMER_US * 2);
 		} else {
 			/*
 			 * Wait for next poll triggered by intr or timer, which should

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ulite.c
@@ -612,7 +612,7 @@ int __init xocl_init_ulite(void)
 	return ret;
 }
 
-void __exit xocl_fini_ulite(void)
+void xocl_fini_ulite(void)
 {
 	platform_driver_unregister(&ulite_platform_driver);
 	uart_unregister_driver(&xcl_ulite_driver);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -4150,7 +4150,7 @@ static int xmc_access(struct platform_device *pdev, enum xocl_xmc_flags flags)
 static void clock_status_check(struct platform_device *pdev, bool *latched)
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(pdev);
-	u32 status = 0;
+	u32 status = 0, val, temp, pwr, temp_t;
 
 	if (!xmc->sc_presence) {
 		/*
@@ -4162,12 +4162,12 @@ static void clock_status_check(struct platform_device *pdev, bool *latched)
 		status = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_CLOCK_STATUS_REG);
 
 		if (status & XMC_CLOCK_SCALING_CLOCK_STATUS_CLKS_LOW) {
-			u32 val = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_TEMP_REG);
-			u32 temp = val & XMC_CLOCK_SCALING_TEMP_TARGET_MASK;
+			val = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_TEMP_REG);
+			temp = val & XMC_CLOCK_SCALING_TEMP_TARGET_MASK;
 			val = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_POWER_REG);
-			u32 pwr = val & XMC_CLOCK_SCALING_POWER_TARGET_MASK;
+			pwr = val & XMC_CLOCK_SCALING_POWER_TARGET_MASK;
 			val = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_THRESHOLD_REG);
-			u32 temp_t = val & XMC_CLOCK_SCALING_TEMP_THRESHOLD_MASK;
+			temp_t = val & XMC_CLOCK_SCALING_TEMP_THRESHOLD_MASK;
 			val = (val >> XMC_CLOCK_SCALING_POWER_THRESHOLD_POS) &
 				XMC_CLOCK_SCALING_POWER_THRESHOLD_MASK;
 			xocl_warn(&pdev->dev, "Kernel clocks are running at lowest possible frequency"


### PR DESCRIPTION
mailbox polling thread is polling way too frequently due to that we passed in ms instead of us to the usleep_range(). this will result in high cpu usage (~3%) even when mailbox is idle. After the fix, it drops to almost 0.
this PR also fixes a couple of driver compilation warning.