### PR TITLE
CR-1104982: Missing kernel arguments in OpenCL profiling summary tables

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -62,11 +62,20 @@ namespace {
     }
 
     // If we find the old "bank" format, just return it as is since our
-    //  monitor name will also have "bank" in it.
-    //if (memoryName.find("bank") != std::string::npos)
-    //  memoryName = "DDR";
+    //  monitor name could also have "bank" in it.  We'll check
+    //  if converting the name to DDR works separately.
 
     return memoryName.substr(0, memoryName.find_last_of("[")) ;
+  }
+
+  static std::string convertBankToDDR(const std::string& name)
+  {
+    auto loc = name.find("bank") ;
+    if (loc == std::string::npos) return name ;
+    std::string ddr = "DDR[" ;
+    ddr += name.substr(loc + 4) ;
+    ddr += "]" ;
+    return ddr ;
   }
 
   static std::string
@@ -373,7 +382,9 @@ namespace xdp {
 
           // Is this particular argument heading to the right memory?
           std::string memoryName = getMemoryNameFromID(matchingCU, arg.id) ;
-          if ((monitor->name).find(memoryName) == std::string::npos)
+          std::string convertedName = convertBankToDDR(memoryName) ;
+          if (monitor->name.find(memoryName) == std::string::npos &&
+              monitor->name.find(convertedName) == std::string::npos )
             continue ;
 
           if (arguments != "") arguments += "|" ;
@@ -406,8 +417,11 @@ namespace xdp {
 
           // Is this particular argument heading to the right memory?
           std::string memoryName = getMemoryNameFromID(matchingCU, arg.id) ;
-          if ((monitor->name).find(memoryName) == std::string::npos)
+          std::string convertedName = convertBankToDDR(memoryName) ;
+          if (monitor->name.find(memoryName) == std::string::npos &&
+              monitor->name.find(convertedName) == std::string::npos) {
             continue ;
+          }
 
           if (arguments != "") arguments += "|" ;
           arguments += arg.name ;


### PR DESCRIPTION
When using OpenCL level information to see the memory name, the function memidxtobanktag will return names like 'bank1' on some platforms.  For these names, when comparing them with the names of the profiling monitors we need to check if both 'bank' or 'DDR' is present in the monitor name as both are valid at insertion time.