### PR TITLE
Fix CU indexing in HW emulation

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -146,7 +146,7 @@ class ip_impl
 
       ip = ips.front();
 
-      auto all_cus = device->get_cus(xclbin_uuid);  // sort order
+      const auto& all_cus = device->get_cus(xclbin_uuid);  // sort order
       auto itr = std::find(all_cus.begin(), all_cus.end(), ip->m_base_address);
       if (itr == all_cus.end())
         throw xrt_core::internal_error("unexpected error");

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1353,7 +1353,7 @@ public:
     if (kernel_cus.empty())
       throw std::runtime_error("No compute units matching '" + nm + "'");
 
-    auto all_cus = device->core_device->get_cus(xclbin_id);  // sort order
+    const auto& all_cus = device->core_device->get_cus(xclbin_id);  // sort order
     for (const ip_data* cu : kernel_cus) {
       if (::get_ip_control(cu) == AP_CTRL_NONE)
         continue;

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -291,7 +291,7 @@ get_memory_type(size_t memidx) const
     : mtype;
 }
 
-const std::vector<uint64_t>
+const std::vector<uint64_t>&
 device::
 get_cus(const uuid& xclbin_id) const
 {

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -273,7 +273,7 @@ public:
 
   // get_cus() - Get list cu base addresses sorted by cu inidex
   const std::vector<uint64_t>
-  get_cus(const uuid& xclbin_id) const;
+  get_cus(const uuid& xclbin_id = uuid()) const;
 
   /**
    * get_ert_slots() - Get number of ERT CQ slots

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -272,7 +272,7 @@ public:
   get_memory_type(size_t memidx) const;
 
   // get_cus() - Get list cu base addresses sorted by cu inidex
-  const std::vector<uint64_t>
+  const std::vector<uint64_t>&
   get_cus(const uuid& xclbin_id = uuid()) const;
 
   /**

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,17 +17,18 @@
 #include "shim.h"
 #include "system_hwemu.h"
 #include "xclbin.h"
-#include <cctype>
-#include <string.h>
-#include <boost/property_tree/xml_parser.hpp>
-#include <errno.h>
-#include <unistd.h>
-#include <boost/lexical_cast.hpp>
 #include "core/common/xclbin_parser.h"
 #include "core/common/AlignedAllocator.h"
 #include "xcl_perfmon_parameters.h"
+#include <boost/property_tree/xml_parser.hpp>
+#include <unistd.h>
+#include <array>
+#include <cctype>
+#include <cerrno>
+#include <cstring>
 #include <mutex>
 #include <set>
+#include <vector>
 
 #define SEND_RESP2QDMA() \
     { \
@@ -186,7 +187,7 @@ namespace xclhwemhal2 {
       handle->saveWaveDataBase();
 
       if (xclemulation::config::getInstance()->isKeepRunDirEnabled() == false) {
-        systemUtil::makeSystemCall(handle->deviceDirectory, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(handle->deviceDirectory, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
       }
     }
 
@@ -448,8 +449,6 @@ namespace xclhwemhal2 {
     boost::format fmt = boost::format("%1%/tempFile_%2%.zip") % deviceDirectory.c_str() % std::to_string(binaryCounter);
     std::string zip_fileName = fmt.str();
 
-    //systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::PERMISSIONS, "777", boost::lexical_cast<std::string>(__LINE__));
-
     if (mMemModel)
     {
       delete mMemModel;
@@ -465,8 +464,8 @@ namespace xclhwemhal2 {
     ss << deviceDirectory << "/binary_" << binaryCounter;
     std::string binaryDirectory = ss.str();
 
-    systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::CREATE, "", boost::lexical_cast<std::string>(__LINE__));
-    systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777", boost::lexical_cast<std::string>(__LINE__));
+    systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::CREATE, "", std::to_string(__LINE__));
+    systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777", std::to_string(__LINE__));
 
     mRunDeviceBinDir = binaryDirectory;
 
@@ -744,12 +743,12 @@ namespace xclhwemhal2 {
         if (mLogStream.is_open())
           mLogStream << __func__ << " UNZIP of sim bin started" << std::endl;
 
-        systemUtil::makeSystemCall(zip_fileName, systemUtil::systemOperation::UNZIP, binaryDirectory, boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(zip_fileName, systemUtil::systemOperation::UNZIP, binaryDirectory, std::to_string(__LINE__));
 
         if (mLogStream.is_open())
           mLogStream << __func__ << " UNZIP of sim bin complete" << std::endl;
 
-        systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777", boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777", std::to_string(__LINE__));
 
         if (mLogStream.is_open())
           mLogStream << __func__ << " Permissions operation is complete" << std::endl;
@@ -842,7 +841,7 @@ namespace xclhwemhal2 {
       {
         sim_path = userSpecifiedSimPath;
         setSimPath(sim_path);
-        systemUtil::makeSystemCall(sim_path, systemUtil::systemOperation::PERMISSIONS, "777", boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(sim_path, systemUtil::systemOperation::PERMISSIONS, "777", std::to_string(__LINE__));
       }
       else
       {
@@ -1131,8 +1130,8 @@ namespace xclhwemhal2 {
       os.close();
 
       std::string emuDataFilePath(emuDataFileName.get());
-      systemUtil::makeSystemCall(emuDataFilePath, systemUtil::systemOperation::UNZIP, simPath, boost::lexical_cast<std::string>(__LINE__));
-      systemUtil::makeSystemCall(mRunDeviceBinDir, systemUtil::systemOperation::PERMISSIONS, "777", boost::lexical_cast<std::string>(__LINE__));
+      systemUtil::makeSystemCall(emuDataFilePath, systemUtil::systemOperation::UNZIP, simPath, std::to_string(__LINE__));
+      systemUtil::makeSystemCall(mRunDeviceBinDir, systemUtil::systemOperation::PERMISSIONS, "777", std::to_string(__LINE__));
     }
   }
 
@@ -1644,28 +1643,28 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
           }
           std::string wdbFileName = binaryDirectory + "/" + fileName + "."+extension;
           std::string destPath = "'" + std::string(path) + "/" + fileName +"." + extension + "'";
-          systemUtil::makeSystemCall(wdbFileName, systemUtil::systemOperation::COPY,destPath, boost::lexical_cast<std::string>(__LINE__));
+          systemUtil::makeSystemCall(wdbFileName, systemUtil::systemOperation::COPY,destPath, std::to_string(__LINE__));
 
           // Copy waveform config
           std::string wcfgFilePath= binaryDirectory + "/" + bdName + "_behav.wcfg";
           std::string destPath2 = "'" + std::string(path) + "/" + fileName + ".wcfg'";
-          systemUtil::makeSystemCall(wcfgFilePath, systemUtil::systemOperation::COPY, destPath2, boost::lexical_cast<std::string>(__LINE__));
+          systemUtil::makeSystemCall(wcfgFilePath, systemUtil::systemOperation::COPY, destPath2, std::to_string(__LINE__));
 
           // Append to detailed kernel trace data mining results file
           std::string logFilePath= binaryDirectory + "/profile_kernels.csv";
           std::string destPath3 = "'" + std::string(path) + "/profile_kernels.csv'";
-          systemUtil::makeSystemCall(logFilePath, systemUtil::systemOperation::APPEND, destPath3, boost::lexical_cast<std::string>(__LINE__));
+          systemUtil::makeSystemCall(logFilePath, systemUtil::systemOperation::APPEND, destPath3, std::to_string(__LINE__));
           xclemulation::copyLogsFromOneFileToAnother(logFilePath, mDebugLogStream);
 
           // Append to detailed kernel trace "timeline" file
           std::string traceFilePath = binaryDirectory + "/timeline_kernels.csv";
           std::string destPath4 = "'" + std::string(path) + "/timeline_kernels.csv'";
-          systemUtil::makeSystemCall(traceFilePath, systemUtil::systemOperation::APPEND, destPath4, boost::lexical_cast<std::string>(__LINE__));
+          systemUtil::makeSystemCall(traceFilePath, systemUtil::systemOperation::APPEND, destPath4, std::to_string(__LINE__));
 
           // Copy proto inst file
           std::string protoFilePath= binaryDirectory + "/" + bdName + "_behav.protoinst";
           std::string destPath6 = "'" + std::string(path) + "/" + fileName + ".protoinst'";
-          systemUtil::makeSystemCall(protoFilePath, systemUtil::systemOperation::COPY, destPath6, boost::lexical_cast<std::string>(__LINE__));
+          systemUtil::makeSystemCall(protoFilePath, systemUtil::systemOperation::COPY, destPath6, std::to_string(__LINE__));
 
 
           if (mLogStream.is_open())
@@ -1675,13 +1674,13 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
         // Copy Simulation Log file
         std::string simulationLogFilePath= binaryDirectory + "/" + "simulate.log";
         std::string destPath5 = "'" + std::string(path) + "/" + fileName + "_simulate.log'";
-        systemUtil::makeSystemCall(simulationLogFilePath, systemUtil::systemOperation::COPY, destPath5, boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(simulationLogFilePath, systemUtil::systemOperation::COPY, destPath5, std::to_string(__LINE__));
 
 
         // Copy xsc_report Log file
         std::string xscReportLogFilePath= binaryDirectory + "/" + "xsc_report.log";
         std::string destPath8 = "'" + std::string(path) + "/" + fileName + "_xsc_report.log'";
-        systemUtil::makeSystemCall(xscReportLogFilePath, systemUtil::systemOperation::COPY, destPath8, boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(xscReportLogFilePath, systemUtil::systemOperation::COPY, destPath8, std::to_string(__LINE__));
 
       }
       i++;
@@ -1719,7 +1718,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     if (!sock)
     {
       if (xclemulation::config::getInstance()->isKeepRunDirEnabled() == false) {
-        systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
       }
 
       if(mMBSch && mCore)
@@ -1771,7 +1770,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 
     saveWaveDataBase();
     if( xclemulation::config::getInstance()->isKeepRunDirEnabled() == false)
-      systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+      systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
     google::protobuf::ShutdownProtobufLibrary();
     PRINTENDFUNC;
     if (mLogStream.is_open()) {
@@ -1878,7 +1877,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
 #endif
       closemMessengerThread();
       //clean up directories which are created inside the driver
-      systemUtil::makeSystemCall(socketName, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+      systemUtil::makeSystemCall(socketName, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
     }
 
     if(saveWdb)
@@ -2104,8 +2103,8 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     deviceName = "device"+std::to_string(deviceIndex);
     deviceDirectory = xclemulation::getRunDirectory() +"/" + std::to_string(getpid())+"/hw_em/"+deviceName;
 
-    systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::CREATE, "", boost::lexical_cast<std::string>(__LINE__));
-    systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::PERMISSIONS, "777", boost::lexical_cast<std::string>(__LINE__));
+    systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::CREATE, "", std::to_string(__LINE__));
+    systemUtil::makeSystemCall(deviceDirectory, systemUtil::systemOperation::PERMISSIONS, "777", std::to_string(__LINE__));
 
     mPlatformData = platformData;
     constructQueryTable();
@@ -2133,9 +2132,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       if(pPath)
       {
         std::string sdxProfileKernelFile = std::string(path) + "/profile_kernels.csv";
-        systemUtil::makeSystemCall(sdxProfileKernelFile, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(sdxProfileKernelFile, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
         std::string sdxTraceKernelFile = std::string(path) + "/timeline_kernels.csv";
-        systemUtil::makeSystemCall(sdxTraceKernelFile, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+        systemUtil::makeSystemCall(sdxTraceKernelFile, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
       }
     }
     bUnified = _unified;
@@ -2277,7 +2276,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
   {
     if (xclemulation::config::getInstance()->getIsPlatformEnabled()) {
       if (mPlatformData.get_optional<std::string>("plp.numCdma").is_initialized()) {
-        int numCdma = boost::lexical_cast<int>(mPlatformData.get<std::string>("plp.numCdma"));
+        int numCdma = std::stoi(mPlatformData.get<std::string>("plp.numCdma"));
         return (numCdma > 0 ? true : false);
       }
     }
@@ -2508,9 +2507,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     if(pPath)
     {
       std::string sdxProfileKernelFile = std::string(path) + "/profile_kernels.csv";
-      systemUtil::makeSystemCall(sdxProfileKernelFile, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+      systemUtil::makeSystemCall(sdxProfileKernelFile, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
       std::string sdxTraceKernelFile = std::string(path) + "/timeline_kernels.csv";
-      systemUtil::makeSystemCall(sdxTraceKernelFile, systemUtil::systemOperation::REMOVE, "", boost::lexical_cast<std::string>(__LINE__));
+      systemUtil::makeSystemCall(sdxTraceKernelFile, systemUtil::systemOperation::REMOVE, "", std::to_string(__LINE__));
     }
 
     std::string logFilePath = xrt_core::config::get_hal_logging();
@@ -3639,47 +3638,20 @@ int HwEmShim::xclLogMsg(xrtLogMsgLevel level, const char* tag, const char* forma
     return 0;
 }
 
-  void HwEmShim::closemMessengerThread() {
-	  if(mMessengerThreadStarted) {
-		  mMessengerThread.join();
-		  mMessengerThreadStarted = false;
-	  }
-      if(mHostMemAccessThreadStarted) {
-	      mHostMemAccessThreadStarted = false;
-          if(mHostMemAccessThread.joinable()){
-              mHostMemAccessThread.join();
-          }
-      }
+void HwEmShim::closemMessengerThread()
+{
+  if (mMessengerThreadStarted) {
+    mMessengerThread.join();
+    mMessengerThreadStarted = false;
   }
 
-//Construct CU index vs Base address map from IP_LAYOUT section in xclbin.
- int HwEmShim::getCuIdxBaseAddrMap()
- {
-   std::string errmsg;
-   if (!mCoreDevice){
-     errmsg = "ERROR: [HW-EMU] getCuIdxBaseAddrMap - core device not found";
-     std::cerr << errmsg << std::endl;
-     return -EINVAL;
-   }
-   auto buffer = mCoreDevice->get_axlf_section(IP_LAYOUT);
-   if (!buffer.first){
-     errmsg = "ERROR: [HW-EMU] getCuIdxBaseAddrMap - can't load ip_layout section";
-     std::cerr << errmsg << std::endl;
-     return -EINVAL;
-   }
-   auto map = reinterpret_cast<const ::ip_layout*>(buffer.first);
-   if (map->m_count < 0) {
-     errmsg = "ERROR: [HW-EMU] getCuIdxBaseAddrMap - invalid ip_layout section content";
-     std::cerr << errmsg << std::endl;
-     return -EINVAL;
-   }
-   mCuIndxVsBaseAddrMap.clear();
-   //Fill map with CU Index and Base address of the kernel in IP_LAYOUT section in XCLBIN
-   for (int i = 0; i < map->m_count; i++) {
-     mCuIndxVsBaseAddrMap[i] = map->m_ip_data[i].m_base_address;
-   }
-   return 0;
- }
+  if (mHostMemAccessThreadStarted) {
+    mHostMemAccessThreadStarted = false;
+    if (mHostMemAccessThread.joinable()) {
+      mHostMemAccessThread.join();
+    }
+  }
+}
 
 //CU register space for xclRegRead/Write()
 int HwEmShim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap)
@@ -3687,42 +3659,41 @@ int HwEmShim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *da
   if (mLogStream.is_open()) {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << (*datap) << std::endl;
   }
-  //get cu idx vs base addr map from IP_LAYOUT section in xclbin.
-  getCuIdxBaseAddrMap();
-  std::string strCuidx = boost::lexical_cast<std::string>(cu_index);
-  if (cu_index >= mCuIndxVsBaseAddrMap.size()) {
-    std::string strMsg = "ERROR: [HW-EMU 20] xclRegRW - invalid CU index: " + strCuidx;
+
+  // get sorted cu addresses to match up with cu_index
+  auto cuidx2addr = mCoreDevice->get_cus();
+  if (cu_index >= cuidx2addr.size()) {
+    std::string strMsg = "ERROR: [HW-EMU 20] xclRegRW - invalid CU index: " + std::to_string(cu_index);
     logMessage(strMsg);
     return -EINVAL;
   }
   if (offset >= mCuMapSize || (offset & (sizeof(uint32_t) - 1)) != 0) {
-    std::string strOffset = boost::lexical_cast<std::string>(offset);
-    std::string strMsg = "ERROR: [HW-EMU 21] xclRegRW - invalid CU offset: " + strOffset;
+    std::string strMsg = "ERROR: [HW-EMU 21] xclRegRW - invalid CU offset: " + std::to_string(offset);
     logMessage(strMsg);
     return -EINVAL;
   }
-  char *buff = new char[REG_BUFF_SIZE];
-  std::memset(buff, 0, sizeof(char)*REG_BUFF_SIZE);
 
-  uint64_t baseAddr = mCuIndxVsBaseAddrMap[cu_index] + offset;
-    if (rd) {
-      if (xclRead(XCL_ADDR_KERNEL_CTRL, baseAddr, buff, REG_BUFF_SIZE) != REG_BUFF_SIZE) {
-        std::string strMsg = "ERROR: [HW-EMU 22] xclRegRW - xclRead failed for CU: " + strCuidx;
-        logMessage(strMsg);
-        return -EINVAL;
-      }
-      uint32_t * tmp_buff = (uint32_t *) buff;
-      *datap = tmp_buff[0];
+  std::array<char, REG_BUFF_SIZE> buff;
+
+  uint64_t baseAddr = cuidx2addr[cu_index] + offset;
+  if (rd) {
+    if (xclRead(XCL_ADDR_KERNEL_CTRL, baseAddr, buff.data(), REG_BUFF_SIZE) != REG_BUFF_SIZE) {
+      std::string strMsg = "ERROR: [HW-EMU 22] xclRegRW - xclRead failed for CU: " + std::to_string(cu_index);
+      logMessage(strMsg);
+      return -EINVAL;
     }
-    else {
-      uint32_t * tmp_buff = (uint32_t *)buff;
-      tmp_buff[0] = *datap;
-      if (xclWrite(XCL_ADDR_KERNEL_CTRL, baseAddr, tmp_buff, REG_BUFF_SIZE) != REG_BUFF_SIZE) {
-        std::string strMsg = "ERROR: [HW-EMU 23] xclRegRW - xclWrite failed for CU: " + strCuidx;
-        logMessage(strMsg);
-        return -EINVAL;
-      }
+    auto tmp_buff = reinterpret_cast<uint32_t*>(buff.data());
+    *datap = tmp_buff[0];
+  }
+  else {
+    uint32_t * tmp_buff = reinterpret_cast<uint32_t*>(buff.data());
+    tmp_buff[0] = *datap;
+    if (xclWrite(XCL_ADDR_KERNEL_CTRL, baseAddr, tmp_buff, REG_BUFF_SIZE) != REG_BUFF_SIZE) {
+      std::string strMsg = "ERROR: [HW-EMU 23] xclRegRW - xclWrite failed for CU: " + std::to_string(cu_index);
+      logMessage(strMsg);
+      return -EINVAL;
     }
+  }
   return 0;
 }
 

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -3661,7 +3661,7 @@ int HwEmShim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *da
   }
 
   // get sorted cu addresses to match up with cu_index
-  auto cuidx2addr = mCoreDevice->get_cus();
+  const auto& cuidx2addr = mCoreDevice->get_cus();
   if (cu_index >= cuidx2addr.size()) {
     std::string strMsg = "ERROR: [HW-EMU 20] xclRegRW - invalid CU index: " + std::to_string(cu_index);
     logMessage(strMsg);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -280,8 +280,6 @@ using addr_type = uint64_t;
       void parseSimulateLog();
       void setSimPath(std::string simPath) { sim_path = simPath; }
       std::string getSimPath () { return sim_path; }
-      //Construct CU index vs Base address map from IP_LAYOUT section in xclbin.
-      int getCuIdxBaseAddrMap();
       bool isHostOnlyBuffer(const struct xclemulation::drm_xocl_bo *bo) {
     	  if(xclemulation::config::getInstance()->isDisabledHostBUffer()) {
     		  return false;
@@ -389,8 +387,6 @@ using addr_type = uint64_t;
       bool mHostMemAccessThreadStarted;
       void closemMessengerThread();
       bool mIsTraceHubAvailable;
-      //CU register space for xclRegRead/Write()
-      std::map<uint32_t, uint64_t> mCuIndxVsBaseAddrMap;
       uint32_t mCuIndx;
       const size_t mCuMapSize = 64 * 1024;
       std::string simulatorType;


### PR DESCRIPTION
Make sure HW emulation is using the same indexing order as user space
XRT.  Without this fix, the index order used by xclRegRW was using
IP_LAYOUT order as opposed to interrupt index ordering used by rest of
XRT.

Fix is to use already computed compute unit indeces from core device.

Eliminate the use of legacy boost::lexical_cast.

See also #4342