### PR TITLE
Add query request exception hierarchy for more granularity

### DIFF
--- a/src/runtime_src/core/common/error.h
+++ b/src/runtime_src/core/common/error.h
@@ -99,7 +99,7 @@ public:
   {}
 
   explicit
-    error(std::errc ec, const std::string& what = "")
+  error(std::errc ec, const std::string& what = "")
     : generic_error(ec, what)
   {}
 

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -243,7 +243,6 @@ enum class key_type
 // because ultimately the base query exception is-a std::exception
 class exception : public std::runtime_error
 {
-  const std::string msg;
 public:
   explicit
   exception(const std::string& err)

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -229,17 +229,43 @@ enum class key_type
   noop
 };
 
-class no_such_key : public std::exception
+// Base class for query request exceptions.
+//
+// Provides granularity for calling code to catch errors specific to
+// query request which are often acceptable errors because some
+// devices may not support all types of query requests.
+//  
+// Other non query exceptions signal a different kind of error which
+// should maybe not be caught.
+//
+// The addition of the query request exception hierarchy does not
+// break existing code that catches std::exception (or all errors)
+// because ultimately the base query exception is-a std::exception
+class exception : public std::runtime_error
+{
+  const std::string msg;
+public:
+  explicit
+  exception(const std::string& err)
+    : std::runtime_error(err)
+  {}
+};
+
+class no_such_key : public exception
 {
   key_type m_key;
-  std::string msg;
 
   using qtype = std::underlying_type<query::key_type>::type;
 public:
   explicit
   no_such_key(key_type k)
-    : m_key(k)
-    , msg(boost::str(boost::format("No such query request (%d)") % static_cast<qtype>(k)))
+    : exception(boost::str(boost::format("No such query request (%d)") % static_cast<qtype>(k)))
+    , m_key(k)
+  {}
+
+  no_such_key(key_type k, const std::string& msg)
+    : exception(msg)
+    , m_key(k)
   {}
 
   key_type
@@ -247,14 +273,25 @@ public:
   {
     return m_key;
   }
-
-  const char*
-  what() const noexcept
-  {
-    return msg.c_str();
-  }
 };
 
+class sysfs_error : public exception
+{
+public:
+  explicit
+  sysfs_error(const std::string& msg)
+    : exception(msg)
+  {}
+};
+
+class not_supported : public exception
+{
+public:
+  explicit
+  not_supported(const std::string& msg)
+    : exception(msg)
+  {}
+};
 
 struct pcie_vendor : request
 {

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -150,23 +150,25 @@ struct dev_info
   }
 };
 
-struct aie_metadata {
-  /* Function to read aie_metadata sysfs, and parse max rows and max columns from it. */
+struct aie_metadata
+{
+  // Function to read aie_metadata sysfs, and parse max rows and max
+  // columns from it.
   static void
   read_aie_metadata(const xrt_core::device* device, uint32_t &row, uint32_t &col)
   {
     std::string err;
     std::string value;
-    const static std::string AIE_TAG = "aie_metadata";
-    const uint32_t major = 1;
-    const uint32_t minor = 0;
-    const uint32_t patch = 0;
+    static std::string AIE_TAG = "aie_metadata";
+    constexpr uint32_t major = 1;
+    constexpr uint32_t minor = 0;
+    constexpr uint32_t patch = 0;
     
     auto dev = get_edgedev(device);
 
     dev->sysfs_get(AIE_TAG, err, value);
     if (!err.empty())
-      throw xrt_core::error(-EINVAL, err);
+      throw xrt_core::query::sysfs_error(err);
 
     std::stringstream ss(value);
     boost::property_tree::ptree pt; 
@@ -255,7 +257,7 @@ struct kds_cu_stat
     // Using comma as separator.
     edev->sysfs_get("kds_custat_raw", errmsg, stats);
     if (!errmsg.empty())
-      throw std::runtime_error(errmsg);
+      throw xrt_core::query::sysfs_error(errmsg);
 
     result_type cuStats;
     // stats e.g.
@@ -267,7 +269,7 @@ struct kds_cu_stat
       tokenizer tokens(line, sep);
 
       if (std::distance(tokens.begin(), tokens.end()) != 5)
-        throw std::runtime_error("CU statistic sysfs node corrupted");
+        throw xrt_core::query::sysfs_error("CU statistic sysfs node corrupted");
 
       data_type data;
       constexpr int radix = 16;
@@ -298,7 +300,7 @@ struct kds_cu_info
     std::string errmsg;
     edev->sysfs_get("kds_custat", errmsg, stats);
     if (!errmsg.empty())
-      throw std::runtime_error(errmsg);
+      throw xrt_core::query::sysfs_error(errmsg);
 
     result_type cuStats;
     for (auto& line : stats) {
@@ -341,8 +343,10 @@ struct aie_reg_read
   // Reading the aie_metadata sysfs.
   dev->sysfs_get(AIE_TAG, err, value);
   if (!err.empty())
-    throw xrt_core::error(-EINVAL, err + ", The loading xclbin acceleration image doesn't use the Artificial "
-                                  + "Intelligent Engines (AIE). No action will be performed.");
+    throw xrt_core::query::sysfs_error
+      (err + ", The loading xclbin acceleration image doesn't use the Artificial "
+       + "Intelligent Engines (AIE). No action will be performed.");
+
   std::stringstream ss(value);
   boost::property_tree::ptree pt;
   boost::property_tree::read_json(ss, pt);
@@ -427,7 +431,8 @@ struct sysfs_fcn
     ValueType value;
     dev->sysfs_get(entry, err, value, static_cast<ValueType>(-1));
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
+
     return value;
   }
 };
@@ -442,7 +447,8 @@ struct sysfs_fcn<std::string>
     std::string value;
     dev->sysfs_get(entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
+
     return value;
   }
 };
@@ -460,7 +466,8 @@ struct sysfs_fcn<std::vector<VectorValueType>>
     ValueType value;
     dev->sysfs_get(entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
+
     return value;
   }
 };

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -73,7 +73,7 @@ struct kds_cu_stat
     // Using comma as separator.
     pdev->sysfs_get("", "kds_custat_raw", errmsg, stats);
     if (!errmsg.empty())
-      throw std::runtime_error(errmsg);
+      throw xrt_core::query::sysfs_error(errmsg);
 
     result_type cuStats;
     for (auto& line : stats) {
@@ -81,7 +81,7 @@ struct kds_cu_stat
       tokenizer tokens(line, sep);
 
       if (std::distance(tokens.begin(), tokens.end()) != 5)
-        throw std::runtime_error("CU statistic sysfs node corrupted");
+        throw xrt_core::query::sysfs_error("CU statistic sysfs node corrupted");
 
       data_type data;
       const int radix = 16;
@@ -118,7 +118,7 @@ struct kds_scu_stat
     // Using comma as separator.
     pdev->sysfs_get("", "kds_scustat_raw", errmsg, stats);
     if (!errmsg.empty())
-      throw std::runtime_error(errmsg);
+      throw xrt_core::query::sysfs_error(errmsg);
 
     result_type cuStats;
     for (auto& line : stats) {
@@ -126,7 +126,7 @@ struct kds_scu_stat
       tokenizer tokens(line, sep);
 
       if (std::distance(tokens.begin(), tokens.end()) != 4)
-        throw std::runtime_error("PS kernel statistic sysfs node corrupted");
+        throw xrt_core::query::sysfs_error("PS kernel statistic sysfs node corrupted");
 
       data_type data;
       const int radix = 16;
@@ -158,7 +158,7 @@ struct kds_cu_info
     std::string errmsg;
     pdev->sysfs_get("mb_scheduler", "kds_custat", errmsg, stats);
     if (!errmsg.empty())
-      throw std::runtime_error(errmsg);
+      throw xrt_core::query::sysfs_error(errmsg);
 
     result_type cuStats;
     for (auto& line : stats) {
@@ -194,7 +194,7 @@ struct qspi_status
     std::string status_str, errmsg;
     pdev->sysfs_get("xmc", "xmc_qspi_status", errmsg, status_str);
     if (!errmsg.empty())
-      throw std::runtime_error(errmsg);
+      throw xrt_core::query::sysfs_error(errmsg);
 
     std::string primary, recovery;
     for (auto status_byte : status_str) {
@@ -242,7 +242,8 @@ struct sysfs_fcn
     ValueType value;
     dev->sysfs_get(subdev, entry, err, value, static_cast<ValueType>(-1));
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
+
     return value;
   }
 
@@ -252,7 +253,7 @@ struct sysfs_fcn
     std::string err;
     dev->sysfs_put(subdev, entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
   }
 };
 
@@ -268,7 +269,8 @@ struct sysfs_fcn<std::string>
     ValueType value;
     dev->sysfs_get(subdev, entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
+
     return value;
   }
 
@@ -278,7 +280,7 @@ struct sysfs_fcn<std::string>
     std::string err;
     dev->sysfs_put(subdev, entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
   }
 };
 
@@ -295,7 +297,8 @@ struct sysfs_fcn<std::vector<VectorValueType>>
     ValueType value;
     dev->sysfs_get(subdev, entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
+
     return value;
   }
 
@@ -305,7 +308,7 @@ struct sysfs_fcn<std::vector<VectorValueType>>
     std::string err;
     dev->sysfs_put(subdev, entry, err, value);
     if (!err.empty())
-      throw std::runtime_error(err);
+      throw xrt_core::query::sysfs_error(err);
   }
 };
 

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -57,7 +57,7 @@ userpf_not_supported_error(key_type key)
 void
 unexpected_query_request_key(key_type key)
 {
-  throw xrt_core::no_such_key
+  throw xrt_core::query::no_such_key
     (key, "unexpected query request ( " + std::to_string(static_cast<qtype>(key)) + ")");
 }
 
@@ -514,7 +514,7 @@ struct bdf
     else if (auto uhdl = dev->get_user_handle())
       userpf::get_bdf_info(uhdl, reinterpret_cast<uint16_t*>(bdf));
     else
-      throw std::internal_error("bdf::init_bdf - No device handle");
+      throw xrt_core::internal_error("bdf::init_bdf - No device handle");
   }
 
   static result_type
@@ -887,7 +887,7 @@ struct data_retention
 {
   using result_type = uint32_t;
   using value_type = uint32_t;
-  
+
   static result_type
   user_get(const xrt_core::device* device)
   {
@@ -919,7 +919,7 @@ struct data_retention
   user_put(const xrt_core::device* device, value_type)
   {
     // data retention can't be set on user side, hence doesn't have driver support
-    throw xrt_core::query_not_supported("device data retention query is not implemented on user windows");
+    throw xrt_core::query::not_supported("device data retention query is not implemented on user windows");
   }
 
   static void
@@ -990,7 +990,7 @@ struct function0_getput : QueryRequestType
     || std::is_same<Getter::result_type, boost::any>::value, "get type mismatch");
   static_assert(std::is_same<Getter::value_type, QueryRequestType::result_type>::value
     || std::is_same<Getter::value_type, boost::any>::value, "value type mismatch");
-  
+
   boost::any
   get(const xrt_core::device* device) const
   {
@@ -1009,7 +1009,7 @@ struct function0_getput : QueryRequestType
       Getter::mgmt_put(device, val);
     else if (device->get_user_handle())
       Getter::user_put(device, val);
-    else 
+    else
       throw xrt_core::internal_error("No device handle");
   }
 };

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -39,6 +39,28 @@ namespace query = xrt_core::query;
 using key_type = xrt_core::query::key_type;
 using qtype = std::underlying_type<query::key_type>::type;
 
+void
+mgmtpf_not_supported_error(key_type key)
+{
+  throw xrt_core::query::no_such_key
+    (key, "query request (" + std::to_string(static_cast<qtype>(key)) + ") not supported for mgmtpf on windows");
+}
+
+void
+userpf_not_supported_error(key_type key)
+{
+  throw xrt_core::query::no_such_key
+    (key, "query request (" + std::to_string(static_cast<qtype>(key)) + ") not supported for userpf on windows");
+}
+
+
+void
+unexpected_query_request_key(key_type key)
+{
+  throw xrt_core::no_such_key
+    (key, "unexpected query request ( " + std::to_string(static_cast<qtype>(key)) + ")");
+}
+
 struct flash
 {
   using result_type = std::string;
@@ -108,8 +130,7 @@ struct firewall
     case key_type::firewall_time_sec:
       return query::firewall_time_sec::result_type(info.err_detected_time);
     default:
-      throw std::runtime_error("device_windows::firewall_info() unexpected qr "
-                               + std::to_string(static_cast<qtype>(key)));
+      unexpected_query_request_key(key);
     }
     // No query for max_level, curr_status and curr_level
   }
@@ -121,11 +142,9 @@ struct firewall
   }
 
   static result_type
-  mgmt(const xrt_core::device* device, key_type key)
+  mgmt(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("query request ("
-                             + std::to_string(static_cast<qtype>(key))
-                             + ") not supported for mgmtpf on windows");
+    mgmtpf_not_supported_error(key);
   }
 };
 
@@ -169,8 +188,7 @@ struct mig
     case key_type::mig_ecc_ue_ffa:
       return query::mig_ecc_ue_ffa::result_type(info.ecc_ue_ffa);
     default:
-      throw std::runtime_error("device_windows::mig_ecc_info() unexpected qr "
-                               + std::to_string(static_cast<qtype>(key)));
+      unexpected_query_request_key(key);
     }
     // No query for mem_type and mem_idx
   }
@@ -182,11 +200,9 @@ struct mig
   }
 
   static result_type
-  mgmt(const xrt_core::device* device, key_type key, query::request::modifier, const std::string&)
+  mgmt(const xrt_core::device*, key_type key, query::request::modifier, const std::string&)
   {
-    throw std::runtime_error("query request ("
-                             + std::to_string(static_cast<qtype>(key))
-                             + ") not supported for mgmtpf on windows");
+    mgmtpf_not_supported_error(key);
   }
 };
 
@@ -227,8 +243,7 @@ struct board
     case key_type::fan_fan_presence:
       return query::fan_fan_presence::result_type(info.fan_presence == 0 ? "P" : "A");
     default:
-      throw std::runtime_error("device_windows::board_info() unexpected qr "
-                               + static_cast<qtype>(key));
+      unexpected_query_request_key(key);
     }
     // No query for mac_addr0, mac_addr1, mac_addr2, mac_addr3, revision, bd_name and config_mode
   }
@@ -240,11 +255,9 @@ struct board
   }
 
   static result_type
-  mgmt(const xrt_core::device* device, key_type key)
+  mgmt(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("query request ("
-                             + std::to_string(static_cast<qtype>(key))
-                             + ") not supported for mgmtpf on windows");
+    mgmtpf_not_supported_error(key);
   }
 };
 
@@ -366,9 +379,7 @@ struct sensor
     case key_type::power_warning:
       return query::power_warning::result_type(info.power_warn);
     default:
-      throw std::runtime_error("device_windows::icap() unexpected qr("
-                               + std::to_string(static_cast<qtype>(key))
-                               + ") for userpf");
+      unexpected_query_request_key(key);
     }
   }
 
@@ -379,11 +390,9 @@ struct sensor
   }
 
   static result_type
-  mgmt(const xrt_core::device* device, key_type key)
+  mgmt(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("query request ("
-                             + std::to_string(static_cast<qtype>(key))
-                             + ") not supported for mgmtpf on windows");
+    mgmtpf_not_supported_error(key);
   }
 };
 
@@ -431,9 +440,7 @@ struct icap
       return query::xclbin_uuid::result_type(uuid_str);
     }
     default:
-      throw std::runtime_error("device_windows::icap() unexpected qr("
-                               + std::to_string(static_cast<qtype>(key))
-                               + ") for userpf");
+      unexpected_query_request_key(key);
     }
     // No query for freq_cntr_0, freq_cntr_1, freq_cntr_2, freq_cntr_3 and uuid
   }
@@ -445,11 +452,9 @@ struct icap
   }
 
   static result_type
-  mgmt(const xrt_core::device* device, key_type key)
+  mgmt(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("query request ("
-                             + std::to_string(static_cast<qtype>(key))
-                             + ") not supported for mgmtpf on windows");
+    mgmtpf_not_supported_error(key);
   }
 };
 
@@ -462,7 +467,7 @@ struct xclbin
   {
     auto uhdl = dev->get_user_handle();
     if (!uhdl)
-      throw std::runtime_error("xclbin query request, missing user device handle");
+      throw xrt_core::internal_error("xclbin query request, missing user device handle");
 
     if (key == key_type::mem_topology_raw) {
       size_t size_ret = 0;
@@ -480,13 +485,13 @@ struct xclbin
       return data;
     }
 
-    throw std::runtime_error("unexpected error");
+    unexpected_query_request_key(key);
   }
 
   static result_type
-  mgmt(const xrt_core::device* dev, key_type key)
+  mgmt(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("mgmt xclbin raw data queries are not implemented on windows");
+    mgmtpf_not_supported_error(key);
   }
 };
 
@@ -509,7 +514,7 @@ struct bdf
     else if (auto uhdl = dev->get_user_handle())
       userpf::get_bdf_info(uhdl, reinterpret_cast<uint16_t*>(bdf));
     else
-      throw std::runtime_error("No device handle");
+      throw std::internal_error("bdf::init_bdf - No device handle");
   }
 
   static result_type
@@ -581,7 +586,7 @@ struct info
     case key_type::pcie_express_lane_width:
       return static_cast<query::pcie_express_lane_width::result_type>(info.MaximumLinkWidth);
     default:
-      throw std::runtime_error("device_windows::info_user() unexpected qr");
+      unexpected_query_request_key(key);
     }
   }
 
@@ -615,7 +620,7 @@ struct info
     case key_type::pcie_subsystem_id:
       return static_cast<query::pcie_subsystem_id::result_type>(info.pcie_info.subsystem_device);
     default:
-      throw std::runtime_error("device_windows::info_mgmt() unexpected qr");
+      unexpected_query_request_key(key);
     }
   }
 };
@@ -625,9 +630,9 @@ struct xmc
   using result_type = boost::any;
 
   static result_type
-  user(const xrt_core::device* device, key_type key)
+  user(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("xmc register base is not implemented on user windows");
+    userpf_not_supported_error(key);
   }
 
   static result_type
@@ -658,7 +663,7 @@ struct xmc
     case key_type::xmc_qspi_status:
       return std::pair<std::string, std::string>("N/A", "N/A");
     default:
-      throw std::runtime_error("device_windows::info_mgmt() unexpected qr");
+      unexpected_query_request_key(key);
     }
   }
 };
@@ -668,9 +673,9 @@ struct devinfo
   using result_type = boost::any;
 
   static result_type
-  user(const xrt_core::device* device, key_type key)
+  user(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("device info data queries are not implemented on user windows");
+    userpf_not_supported_error(key);
   }
 
   static result_type
@@ -696,20 +701,20 @@ struct devinfo
     case key_type::board_name:
       return static_cast<query::board_name::result_type>(info.ShellName);
     case key_type::is_mfg:
-      {
-        auto shell = static_cast<query::board_name::result_type>(info.ShellName);
-        boost::to_upper(shell);
-        return (shell.find("GOLDEN") != std::string::npos) ? true : false;
-      }
+    {
+      auto shell = static_cast<query::board_name::result_type>(info.ShellName);
+      boost::to_upper(shell);
+      return (shell.find("GOLDEN") != std::string::npos) ? true : false;
+    }
     case key_type::xmc_sc_presence:
-      {
-        //xmc is not present in golden image
-        //inverse logic of is_mfg
-        auto shell = static_cast<query::board_name::result_type>(info.ShellName);
-        boost::to_upper(shell);
-        //sample strings: xilinx_u250_GOLDEN, xilinx_u250_gen3x16_base, xilinx_u250_xdma_201830_3
-        return (shell.find("GOLDEN") != std::string::npos) ? false : true;
-      }
+    {
+      //xmc is not present in golden image
+      //inverse logic of is_mfg
+      auto shell = static_cast<query::board_name::result_type>(info.ShellName);
+      boost::to_upper(shell);
+      //sample strings: xilinx_u250_GOLDEN, xilinx_u250_gen3x16_base, xilinx_u250_xdma_201830_3
+      return (shell.find("GOLDEN") != std::string::npos) ? false : true;
+    }
     case key_type::mac_addr_first:
       return std::string(info.MacAddrFirst);
     case key_type::mac_contiguous_num:
@@ -717,7 +722,7 @@ struct devinfo
     case key_type::mac_addr_list:
       return std::vector<std::string>{ std::string(info.MacAddr0), std::string(info.MacAddr1), std::string(info.MacAddr2), std::string(info.MacAddr3) };
     default:
-      throw std::runtime_error("device_windows::info_mgmt() unexpected qr");
+      unexpected_query_request_key(key);
     }
   }
 };
@@ -743,9 +748,9 @@ struct uuid
   using result_type = boost::any;
 
   static result_type
-  user(const xrt_core::device* device, key_type key)
+  user(const xrt_core::device*, key_type key)
   {
-    throw std::runtime_error("device info data queries are not implemented on user windows");
+    userpf_not_supported_error(key);
   }
 
   static result_type
@@ -773,7 +778,7 @@ struct uuid
     case key_type::logic_uuids:
       return std::vector<std::string>{ std::string(info.blp_logic_uuid), std::string(info.plp_logic_uuid) };
     default:
-      throw std::runtime_error("device_windows::info_mgmt() unexpected qr");
+      unexpected_query_request_key(key);
     }
   }
 };
@@ -823,7 +828,7 @@ struct rom
     else if (auto uhdl = dev->get_user_handle())
       userpf::get_rom_info(uhdl, &hdr);
     else
-      throw std::runtime_error("No device handle");
+      throw xrt_core::internal_error("No device handle");
     return hdr;
   }
 
@@ -853,9 +858,7 @@ struct rom
     }
 
     if (device->get_user_handle())
-      throw std::runtime_error("device_windows::rom() unexpected qr("
-                               + std::to_string(static_cast<qtype>(key))
-                               + ") for userpf");
+      unexpected_query_request_key(key);
 
     switch (key) {
     case key_type::rom_uuid:
@@ -863,9 +866,7 @@ struct rom
     case key_type::rom_time_since_epoch:
       return static_cast<query::rom_time_since_epoch::result_type>(hdr.TimeSinceEpoch);
     default:
-      throw std::runtime_error("device_windows::rom() unexpected qr "
-                               + std::to_string(static_cast<qtype>(key))
-                               + ") for mgmgpf");
+      unexpected_query_request_key(key);
     }
   }
 
@@ -918,10 +919,11 @@ struct data_retention
   user_put(const xrt_core::device* device, value_type)
   {
     // data retention can't be set on user side, hence doesn't have driver support
-    throw std::runtime_error("device data retention query is not implemented on user windows");
+    throw xrt_core::query_not_supported("device data retention query is not implemented on user windows");
   }
+
   static void
-    mgmt_put(const xrt_core::device* device, value_type val)
+  mgmt_put(const xrt_core::device* device, value_type val)
   {
     static std::mutex mutex;
     std::lock_guard<std::mutex> lk(mutex);
@@ -932,53 +934,53 @@ struct data_retention
 
 struct mailbox
 {
-    using result_type = boost::any;
+  using result_type = boost::any;
 
-    static xcl_mailbox
-        init_mailbox_info(const xrt_core::device* dev)
+  static xcl_mailbox
+  init_mailbox_info(const xrt_core::device* dev)
+  {
+    xcl_mailbox info = { 0 };
+    userpf::get_mailbox_info(dev->get_user_handle(), &info);
+    return info;
+  }
+
+  static result_type
+  get_info(const xrt_core::device* device, key_type key)
+  {
+    static std::map<const xrt_core::device*, xcl_mailbox> info_map;
+    static std::mutex mutex;
+    std::lock_guard<std::mutex> lk(mutex);
+
+    auto it = info_map.find(device);
+    if (it == info_map.end())
+      it = info_map.emplace(device, init_mailbox_info(device)).first;
+
+    const xcl_mailbox& info = (*it).second;
+    switch (key) {
+    case key_type::mailbox_metrics:
     {
-        xcl_mailbox info = { 0 };
-        userpf::get_mailbox_info(dev->get_user_handle(), &info);
-        return info;
+      std::vector<std::string> vec;
+      vec.push_back(boost::str(boost::format("raw bytes received: %d\n") % info.mbx_recv_raw_bytes));
+      for (int i = 0; i < MAILBOX_REQ_MAX; i++)
+        vec.push_back(boost::str(boost::format("req[%d] received: %d\n") % i % info.mbx_recv_req[i]));
+      return vec;
     }
-
-    static result_type
-        get_info(const xrt_core::device* device, key_type key)
-    {
-        static std::map<const xrt_core::device*, xcl_mailbox> info_map;
-        static std::mutex mutex;
-        std::lock_guard<std::mutex> lk(mutex);
-
-        auto it = info_map.find(device);
-        if (it == info_map.end())
-            it = info_map.emplace(device, init_mailbox_info(device)).first;
-
-        const xcl_mailbox& info = (*it).second;
-        switch (key) {
-        case key_type::mailbox_metrics:
-            {
-              std::vector<std::string> vec;
-              vec.push_back(boost::str(boost::format("raw bytes received: %d\n") % info.mbx_recv_raw_bytes));
-              for (int i = 0; i < MAILBOX_REQ_MAX; i++)
-                  vec.push_back(boost::str(boost::format("req[%d] received: %d\n") % i % info.mbx_recv_req[i]));
-              return vec;
-            }
-        default:
-            throw std::runtime_error("device_windows::mailbox() unexpected qr " + std::to_string(static_cast<qtype>(key)) + ") for userpf");
-        }
+    default:
+      unexpected_query_request_key(key);
     }
+  }
 
-    static result_type
-        user(const xrt_core::device* device, key_type key)
-    {
-        return get_info(device, key);
-    }
+  static result_type
+  user(const xrt_core::device* device, key_type key)
+  {
+    return get_info(device, key);
+  }
 
-    static result_type
-        mgmt(const xrt_core::device* device, key_type key)
-    {
-        return get_info(device, key);
-    }
+  static result_type
+  mgmt(const xrt_core::device* device, key_type key)
+  {
+    return get_info(device, key);
+  }
 }; //end of struct mailbox
 
 template <typename QueryRequestType, typename Getter>
@@ -996,7 +998,7 @@ struct function0_getput : QueryRequestType
       return Getter::mgmt_get(device);
     if (device->get_user_handle())
       return Getter::user_get(device);
-    throw std::runtime_error("No device handle");
+    throw xrt_core::internal_error("No device handle");
   }
 
   void
@@ -1008,7 +1010,7 @@ struct function0_getput : QueryRequestType
     else if (device->get_user_handle())
       Getter::user_put(device, val);
     else 
-      throw std::runtime_error("No device handle");
+      throw xrt_core::internal_error("No device handle");
   }
 };
 
@@ -1027,7 +1029,7 @@ struct function0_getter : QueryRequestType
     else if (auto uhdl = device->get_user_handle())
       return Getter::user(device,k);
     else
-      throw std::runtime_error("No device handle");
+      throw xrt_core::internal_error("No device handle");
   }
 };
 
@@ -1046,7 +1048,7 @@ struct function1_getter : QueryRequestType
     else if (auto uhdl = device->get_user_handle())
       return Getter::user(device,k,any);
     else
-      throw std::runtime_error("No device handle");
+      throw xrt_core::internal_error("No device handle");
   }
 };
 
@@ -1065,7 +1067,7 @@ struct function2_getter : QueryRequestType
     else if (auto uhdl = device->get_user_handle())
       return Getter::user(device,k,m,v);
     else
-      throw std::runtime_error("No device handle");
+      throw xrt_core::internal_error("No device handle");
   }
 };
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -679,11 +679,11 @@ XBUtilities::check_p2p_config(const xrt_core::device* _dev, std::string &msg)
   try {
     config = xrt_core::device_query<xrt_core::query::p2p_config>(_dev);
   }
-  catch (const std::runtime_error&) {
-    msg = "P2P config failed. P2P is not available";
+  catch (const xrt_core::query::no_such_key&) {
     return static_cast<int>(p2p_config::not_supported);
   }
-  catch (const xrt_core::query::no_such_key&) {
+  catch (const std::runtime_error&) {
+    msg = "P2P config failed. P2P is not available";
     return static_cast<int>(p2p_config::not_supported);
   }
 


### PR DESCRIPTION
Provides granularity for calling code to catch errors specific to
query request which are often acceptable errors because some
devices or OSes may not support all types of query requests.

Other non query exceptions signal a different kind of error which
should maybe not be caught.

The addition of the query request exception hierarchy does not
break existing code that catches std::exception (or all errors)
because ultimately the base query exception is-a std::exception