### PR TITLE
xclbinutil: Added support for a pcie node in the partition_metadata section

### DIFF
--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -107,6 +107,10 @@ if(NOT WIN32)
     set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SoftKernel")
     xrt_add_test("softkernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SoftKernel/SectionSoftKernel.py ${TEST_OPTIONS}")
 
+    # -- Partion Metadata
+    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata")
+    xrt_add_test("partition_metadata" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata/SectionPartitionMetadata.py ${TEST_OPTIONS}")
+
     endif()
 endif()
 

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -39,24 +39,28 @@ SectionPartitionMetadata::_init SectionPartitionMetadata::_initializer;
 
 // Variable name to data size mapping table
 const FDTProperty::PropertyNameFormat SectionPartitionMetadata::m_propertyNameFormat = {
-  { "major", FDTProperty::DF_u32 },
-  { "minor", FDTProperty::DF_u32 },
-  { "logic_uuid", FDTProperty::DF_sz },
-  { "resolves_interface_uuid", FDTProperty::DF_sz },
-  { "interface_uuid", FDTProperty::DF_sz },
-  { "reg", FDTProperty::DF_au64 },
-  { "pcie_physical_function", FDTProperty::DF_u32},
-  { "pcie_bar_mapping", FDTProperty::DF_u32},
+  { "__INFO", FDTProperty::DF_sz },
+  { "alias_name", FDTProperty::DF_sz },
+  { "bar", FDTProperty::DF_u32},
+  { "base_address", FDTProperty::DF_u64 },
   { "compatible", FDTProperty::DF_asz },
-  { "interrupts", FDTProperty::DF_au32 },
-  { "firmware_product_name", FDTProperty::DF_sz },
   { "firmware_branch_name", FDTProperty::DF_sz },
+  { "firmware_product_name", FDTProperty::DF_sz },
   { "firmware_version_major", FDTProperty::DF_u32 },
   { "firmware_version_minor", FDTProperty::DF_u32 },
   { "firmware_version_revision", FDTProperty::DF_u32 },
+  { "interface_uuid", FDTProperty::DF_sz },
   { "interrupt_alias", FDTProperty::DF_asz },
-  { "alias_name", FDTProperty::DF_sz },
-  { "__INFO", FDTProperty::DF_sz }
+  { "interrupts", FDTProperty::DF_au32 },
+  { "logic_uuid", FDTProperty::DF_sz },
+  { "major", FDTProperty::DF_u32 },
+  { "minor", FDTProperty::DF_u32 },
+  { "pcie_bar_mapping", FDTProperty::DF_u32},
+  { "pcie_physical_function", FDTProperty::DF_u32},
+  { "physical_function", FDTProperty::DF_u32},
+  { "range", FDTProperty::DF_u64 },
+  { "reg", FDTProperty::DF_au64 },
+  { "resolves_interface_uuid", FDTProperty::DF_sz },
 };
 
 // -- Helper transformation helper functions ---------------------------------
@@ -145,7 +149,7 @@ SchemaTransform_nameValue( const std::string & _valueName,
 
 
 /**
- * Help method to transform the firmware section
+ * Helper method to transform the firmware section
  * 
  * @param _ptOriginal The original firmware property tree
  * @param _ptTransformed The transform firmware property tree
@@ -159,6 +163,19 @@ SchemaTransformUniversal_firmware( const boost::property_tree::ptree& _ptOrigina
   SchemaTransform_nameValue("firmware_version_major", "", true  /*required*/, _ptOriginal, _ptTransformed);
   SchemaTransform_nameValue("firmware_version_minor", "", false  /*required*/, _ptOriginal, _ptTransformed);
   SchemaTransform_nameValue("firmware_version_revision", "", false  /*required*/, _ptOriginal, _ptTransformed);
+}
+
+/**
+ * Helper method to transform a generic node
+ * 
+ * @param _ptOriginal The original firmware property tree
+ * @param _ptTransformed The transform firmware property tree
+ */
+void 
+SchemaTransformUniversal_generic( const boost::property_tree::ptree& _ptOriginal,
+                                  boost::property_tree::ptree & _ptTransformed)
+{
+  _ptTransformed = _ptOriginal;
 }
 
 /**
@@ -438,6 +455,10 @@ SchemaTransformToDTC_root( const boost::property_tree::ptree & _ptOriginal,
                            SchemaTransformToDTC_interfaces,
                            _ptOriginal, _ptTransformed);
 
+  SchemaTransform_subNode( "pcie", false /*required*/, 
+                           SchemaTransformUniversal_generic,
+                           _ptOriginal, _ptTransformed);
+
   SchemaTransform_subNode( "addressable_endpoints", false /*required*/, 
                            SchemaTransformToDTC_addressable_endpoints,
                            _ptOriginal, _ptTransformed);
@@ -658,6 +679,10 @@ SchemaTransformToPM_root( const boost::property_tree::ptree & _ptOriginal,
 
   SchemaTransform_subNode( "interfaces", true /*required*/, 
                            SchemaTransformToPM_interfaces,
+                           _ptOriginal, _ptTransformed);
+
+  SchemaTransform_subNode( "pcie", false /*required*/, 
+                           SchemaTransformUniversal_generic,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "addressable_endpoints", false /*required*/, 

--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -172,10 +172,31 @@ SchemaTransformUniversal_firmware( const boost::property_tree::ptree& _ptOrigina
  * @param _ptTransformed The transform firmware property tree
  */
 void 
-SchemaTransformUniversal_generic( const boost::property_tree::ptree& _ptOriginal,
-                                  boost::property_tree::ptree & _ptTransformed)
+SchemaTransformUniversal_pcie( const boost::property_tree::ptree& _ptOriginal,
+                               boost::property_tree::ptree & _ptTransformed)
 {
-  _ptTransformed = _ptOriginal;
+  boost::property_tree::ptree ptEmpty;
+
+  // --- Bars ---
+  boost::property_tree::ptree ptBarOriginal;
+  ptBarOriginal = _ptOriginal.get_child("bars", ptEmpty);
+
+  if (ptBarOriginal.empty()) 
+    throw std::runtime_error("Error: pcie.bars[] list not found.");
+
+  boost::property_tree::ptree ptBarArray;
+  for (auto barEntryOrig : ptBarOriginal) {
+    boost::property_tree::ptree ptBarEntry;
+
+    SchemaTransform_nameValue("bar", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("physical_function", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("base_address", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("range", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+
+    ptBarArray.push_back(std::make_pair("", ptBarEntry));
+  }
+
+  _ptTransformed.add_child("bars", ptBarArray);
 }
 
 /**
@@ -456,7 +477,7 @@ SchemaTransformToDTC_root( const boost::property_tree::ptree & _ptOriginal,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "pcie", false /*required*/, 
-                           SchemaTransformUniversal_generic,
+                           SchemaTransformUniversal_pcie,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "addressable_endpoints", false /*required*/, 
@@ -682,7 +703,7 @@ SchemaTransformToPM_root( const boost::property_tree::ptree & _ptOriginal,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "pcie", false /*required*/, 
-                           SchemaTransformUniversal_generic,
+                           SchemaTransformUniversal_pcie,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "addressable_endpoints", false /*required*/, 

--- a/src/runtime_src/tools/xclbinutil/unittests/PartitionMetadata/SectionPartitionMetadata.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/PartitionMetadata/SectionPartitionMetadata.py
@@ -1,0 +1,114 @@
+import subprocess
+import os
+import argparse
+from argparse import RawDescriptionHelpFormatter
+import filecmp
+import json
+
+# Start of our unit test
+# -- main() -------------------------------------------------------------------
+#
+# The entry point to this script.
+#
+# Note: It is called at the end of this script so that the other functions
+#       and classes have been defined and the syntax validated
+def main():
+  # -- Configure the argument parser
+  parser = argparse.ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description='description:\n  Unit test wrapper for the Partion Metadata section')
+  parser.add_argument('--resource-dir', nargs='?', default=".", help='directory containing data to be used by this unit test')
+  args = parser.parse_args()
+
+  # Validate that the resource directory is valid
+  if not os.path.exists(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' does not exist")
+
+  if not os.path.isdir(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' is not a directory")
+
+  # Prepare for testing
+  xclbinutil = "xclbinutil"
+
+  # Start the tests
+  print ("Starting test")
+
+  # ---------------------------------------------------------------------------
+
+  step = "1) Read and write the PARTITION METADATA JSON section"
+
+  inputJSON = os.path.join(args.resource_dir, "partition_metadata_all.rtd")
+  outputJSON = "partition_metadata_all_dump.rtd"
+
+  cmd = [xclbinutil, "--add-section", "PARTITION_METADATA:JSON:" + inputJSON, "--dump-section", "PARTITION_METADATA:JSON:" + outputJSON, "--force"]
+  execCmd(step, cmd)
+
+  jsonFileCompare(inputJSON, outputJSON)
+
+  # ---------------------------------------------------------------------------
+
+  # If the code gets this far, all is good.
+  return False
+
+def jsonFileCompare(file1, file2):
+  if not os.path.isfile(file1):
+    raise Exception("Error: The following json file does not exist: '" + file1 +"'")
+
+  with open(file1) as f:
+    data1 = json.dumps(json.load(f), indent=2)
+
+  if not os.path.isfile(file2):
+    raise Exception("Error: The following json file does not exist: '" + file2 +"'")
+
+  with open(file2) as f:
+    data2 = json.dumps(json.load(f), indent=2)
+
+  if data1 != data2:
+      # Print out the contents of file 1
+      print ("\nFile1 : "+ file1)
+      print ("vvvvv")
+      print (data1)
+      print ("^^^^^")
+
+      # Print out the contents of file 1
+      print ("\nFile2 : "+ file2)
+      print ("vvvvv")
+      print (data2)
+      print ("^^^^^")
+
+      raise Exception("Error: The two files are not the same")
+
+def testDivider():
+  print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+
+
+def execCmd(pretty_name, cmd):
+  testDivider()
+  print(pretty_name)
+  testDivider()
+  cmdLine = ' '.join(cmd)
+  print(cmdLine)
+  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  o, e = proc.communicate()
+  print(o.decode('ascii'))
+  print(e.decode('ascii'))
+  errorCode = proc.returncode
+
+  if errorCode != 0:
+    raise Exception("Operation failed with the return code: " + str(errorCode))
+
+# -- Start executing the script functions
+if __name__ == '__main__':
+  try:
+    if main() == True:
+      print ("\nError(s) occurred.")
+      print("Test Status: FAILED")
+      exit(1)
+  except Exception as error:
+    print(repr(error))
+    print("Test Status: FAILED")
+    exit(1)
+
+
+# If the code get this far then no errors occured
+print("Test Status: PASSED")
+exit(0)
+

--- a/src/runtime_src/tools/xclbinutil/unittests/PartitionMetadata/partition_metadata_all.rtd
+++ b/src/runtime_src/tools/xclbinutil/unittests/PartitionMetadata/partition_metadata_all.rtd
@@ -1,0 +1,195 @@
+{
+    "partition_metadata": {
+        "schema_version": {
+            "major": "0x1",
+            "minor": "0x0"
+        },
+        "logic_uuid": "b772b6bbd3ba046439ece1b7763c69c7",
+        "interfaces": [
+            {
+                "interface_uuid": "d7612a7c701e012c10959c59e9cad082"
+            }
+        ],
+        "pcie": {
+            "bars": [
+                {
+                    "bar": "0x0",
+                    "physical_function": "0x0",
+                    "base_address": "0x0000020100000000",
+                    "range": "0x0000000002000000"
+                },
+                {
+                    "bar": "0x2",
+                    "physical_function": "0x0",
+                    "base_address": "0x0000020200000000",
+                    "range": "0x0000000002000000"
+                },
+                {
+                    "bar": "0x4",
+                    "physical_function": "0x0",
+                    "base_address": "0x0000020200000000",
+                    "range": "0x0000000002000000"
+                }
+            ]
+        },
+        "addressable_endpoints": {
+            "ep_card_flash_program_00": {
+                "offset": "0x0000000001f06000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_quad_spi:1.0",
+                "msix_interrupt_start_index": "0x3",
+                "msix_interrupt_end_index": "0x3"
+            },
+            "ep_cmc_firmware_mem_00": {
+                "offset": "0x0000000001e20000",
+                "range": "0x0000000000020000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_bram_ctrl:1.0",
+                "firmware": {
+                    "firmware_product_name": "cmc",
+                    "firmware_branch_name": "u200-u250",
+                    "firmware_version_major": "0x1"
+                }
+            },
+            "ep_cmc_intc_00": {
+                "offset": "0x0000000001e03000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_intc:1.0",
+                "msix_interrupt_start_index": "0x4",
+                "msix_interrupt_end_index": "0x4"
+            },
+            "ep_cmc_mutex_00": {
+                "offset": "0x0000000001e02000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_gpio:1.0"
+            },
+            "ep_cmc_regmap_00": {
+                "offset": "0x0000000001e08000",
+                "range": "0x0000000000002000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_bram_ctrl:1.0",
+                "firmware": {
+                    "firmware_product_name": "sc-fw",
+                    "firmware_branch_name": "u200-u250",
+                    "firmware_version_major": "0x4"
+                }
+            },
+            "ep_cmc_reset_00": {
+                "offset": "0x0000000001e01000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:aresetn_gpio:1.0"
+            },
+            "ep_debug_bscan_mgmt_00": {
+                "offset": "0x0000000001e90000",
+                "range": "0x0000000000010000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:debug_bridge:1.0"
+            },
+            "ep_firewall_blp_ctrl_mgmt_00": {
+                "offset": "0x0000000001f02000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_firewall:1.0",
+                "msix_interrupt_start_index": "0x1",
+                "msix_interrupt_end_index": "0x1"
+            },
+            "ep_firewall_blp_ctrl_user_00": {
+                "offset": "0x0000000001f03000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_firewall:1.0",
+                "msix_interrupt_start_index": "0x1",
+                "msix_interrupt_end_index": "0x1"
+            },
+            "ep_fpga_configuration_00": {
+                "offset": "0x0000000001e88000",
+                "range": "0x0000000000008000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_hwicap:1.0",
+                "msix_interrupt_start_index": "0x2",
+                "msix_interrupt_end_index": "0x2"
+            },
+            "ep_icap_arb_00": {
+                "offset": "0x0000000001e81000",
+                "range": "0x0000000000010000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:debug_bridge:1.0"
+            },
+            "ep_icap_reset_00": {
+                "offset": "0x0000000001f07000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_gpio:1.0"
+            },
+            "ep_mailbox_mgmt_00": {
+                "offset": "0x0000000001f10000",
+                "range": "0x0000000000010000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:mailbox:1.0",
+                "msix_interrupt_start_index": "0x0",
+                "msix_interrupt_end_index": "0x0"
+            },
+            "ep_mailbox_user_00": {
+                "offset": "0x0000000001f00000",
+                "range": "0x0000000000010000",
+                "pcie_physical_function": "0x1",
+                "register_abstraction_name": "xilinx.com:reg_abs:mailbox:1.0",
+                "msix_interrupt_start_index": "0x8",
+                "msix_interrupt_end_index": "0x8"
+            },
+            "ep_pcie_link_mon_00": {
+                "offset": "0x0000000001f05000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_gpio:1.0"
+            },
+            "ep_pr_isolate_plp_00": {
+                "offset": "0x0000000001f01000",
+                "range": "0x0000000000001000",
+                "pcie_physical_function": "0x0",
+                "register_abstraction_name": "xilinx.com:reg_abs:axi_gpio:1.0"
+            }
+        },
+        "partition_info": {
+            "installation": {
+                "installed_package_dir": "\/opt\/xilinx\/firmware\/u250\/gen3x16\/base",
+                "installed_package_name": "xilinx-u250-gen3x16-base",
+                "installed_package_release": "2947128",
+                "installed_package_version": "2"
+            },
+            "partition_card": "u250",
+            "partition_family": "gen3x16",
+            "partition_features": {
+                "pcie": {
+                    "device_ids": {
+                        "5004": {
+                            "role": "management_pf"
+                        },
+                        "5005": {
+                            "role": "user_pf"
+                        }
+                    },
+                    "extended_capabilities": "enabled",
+                    "max_link_speed": "gen3x16",
+                    "subsystem_id": "000e",
+                    "vendor_id": "10ee"
+                }
+            },
+            "partition_identifiers": {
+                "interface_uuids": {
+                    "d7612a7c701e012c10959c59e9cad082": {
+                        "type": "exposed"
+                    }
+                },
+                "logic_uuid": "b772b6bbd3ba046439ece1b7763c69c7"
+            },
+            "partition_name": "base",
+            "partition_type": "base",
+            "partition_vendor": "xilinx"
+        }
+    }
+}


### PR DESCRIPTION
Work Done
---------
+ Added support the for the pci node in partition_metadata.  
Sample Syntax:
```
  "pcie": {
	"bars": [{
		"bar": "0",
		"physical_function": "0",
		"base_address": "0x0020100000000",
		"range": "0x2000000"
	},
	{
		"bar": "2",
		"physical_function": "0",
		"base_address": "0x0020200000000",
		"range": "0x2000000"
	},
	{
		"bar": "4",
		"physical_function": "0",
		"base_address": "0x0020200000000",
		"range": "0x2000000"
	}
        ]
  }
```
+ Sorted the collection `SectionPartitionMetadata::m_propertyNameFormat`  alphabetically
+ Added unit-tests to test correct operation of marshalling and unmarshalling the JSON to DTB to JSON transformations
