### PR TITLE
CR-1105038: Generate stream tables in profile summary when ASMs are configured without trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
+++ b/src/runtime_src/xdp/profile/database/events/creator/device_event_from_trace.cpp
@@ -46,7 +46,7 @@ namespace xdp {
     amLastTrans.resize(numAM);
 
     aimLastTrans.resize((db->getStaticInfo()).getNumAIM(deviceId, xclbin)) ;
-    asmLastTrans.resize((db->getStaticInfo()).getNumASM(deviceId, xclbin)) ;
+    asmLastTrans.resize((db->getStaticInfo()).getNumASMWithTrace(deviceId, xclbin)) ;
   }
 
   void DeviceEventCreatorFromTrace::addCUEndEvent(double hostTimestamp,
@@ -579,7 +579,7 @@ namespace xdp {
   {
     // Find unfinished ASM events
     bool unfinishedASMevents = false;
-    for(uint64_t asmIndex = 0; asmIndex < (db->getStaticInfo()).getNumASM(deviceId, xclbin); ++asmIndex) {
+    for(uint64_t asmIndex = 0; asmIndex < (db->getStaticInfo()).getNumASMWithTrace(deviceId, xclbin); ++asmIndex) {
       uint64_t asmTraceID = asmIndex + MIN_TRACE_ID_ASM;
       Monitor* mon  = db->getStaticInfo().getASMonitor(deviceId, xclbin, asmIndex);
       if(!mon) {

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -485,173 +485,273 @@ namespace xdp {
     return true;
   }
 
+  void VPStaticDatabase::initializeAM(DeviceInfo* devInfo,
+                                      const std::string& name,
+                                      const struct debug_ip_data* debugIpData)
+  {
+    uint64_t index = static_cast<uint64_t>(debugIpData->m_index_lowbyte) |
+      (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
+    if (index < MIN_TRACE_ID_AM) {
+      std::stringstream msg;
+      msg << "AM with incorrect index: " << index ;
+      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+                              msg.str());
+      index = MIN_TRACE_ID_AM ;
+    }
+    uint64_t slotId = (index - MIN_TRACE_ID_AM) / 16;
+
+    for (auto cu : devInfo->loadedXclbins.back()->cus) {
+      ComputeUnitInstance* cuObj = cu.second ;
+      int32_t cuId = cu.second->getIndex() ;
+
+      if (0 == name.compare(cu.second->getName())) {
+        // Set properties on this specific CU
+        if(debugIpData->m_properties & XAM_STALL_PROPERTY_MASK) {
+          cuObj->setStallEnabled(true);
+        }
+
+        Monitor* mon = new Monitor(debugIpData->m_type, index,
+                                   debugIpData->m_name, cuId, -1 /* memId */,
+                                   slotId) ;
+        // First, add this monitor to the list of all AMs
+        devInfo->loadedXclbins.back()->amList.push_back(mon);
+        // Second, determine if this is a trace-enabled AM or just a counter AM
+        //  and add it to the appropriate container
+        if (debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) {
+          devInfo->loadedXclbins.back()->amMap.emplace(slotId, mon);
+          cuObj->setAccelMon(slotId);
+        }
+        else {
+          devInfo->loadedXclbins.back()->noTraceAMs.push_back(mon);
+        }
+        break ;
+      }
+    }
+  }
+
+  void VPStaticDatabase::initializeAIM(DeviceInfo* devInfo,
+                                       const std::string& name,
+                                       const struct debug_ip_data* debugIpData)
+  {
+    uint64_t index = static_cast<uint64_t>(debugIpData->m_index_lowbyte) |
+      (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
+    if (index < MIN_TRACE_ID_AIM) {
+      std::stringstream msg;
+      msg << "AIM with incorrect index: " << index ;
+      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+                              msg.str());
+      index = MIN_TRACE_ID_AIM ;
+    }
+    uint64_t slotId = (index - MIN_TRACE_ID_AIM) / 2;
+
+    // Parse name to find CU Name and Memory
+    size_t pos = name.find('/');
+    std::string monCuName = name.substr(0, pos);
+
+    std::string memName = "" ;
+    std::string portName = "" ;
+    size_t pos1 = name.find('-');
+    if(pos1 != std::string::npos) {
+      memName = name.substr(pos1+1);
+      portName = name.substr(pos+1, pos1-pos-1);
+    }
+
+    ComputeUnitInstance* cuObj = nullptr ;
+    int32_t cuId = -1 ;
+    int32_t memId = -1;
+
+    for(auto cu : devInfo->loadedXclbins.back()->cus) {
+      if(0 == monCuName.compare(cu.second->getName())) {
+        cuId = cu.second->getIndex();
+        cuObj = cu.second;
+        break;
+      }
+    }
+    for(auto mem : devInfo->loadedXclbins.back()->memoryInfo) {
+      if(0 == memName.compare(mem.second->name)) {
+        memId = mem.second->index;
+        break;
+      }
+    }
+    Monitor* mon = new Monitor(debugIpData->m_type, index,
+                               debugIpData->m_name, cuId, memId, slotId);
+    mon->port = portName;
+
+    // Add the monitor to the list of all AIMs
+    devInfo->loadedXclbins.back()->aimList.push_back(mon) ;
+    bool traceEnabled =
+      (debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) != 0 ;
+
+    // Attach to a CU if appropriate
+    if (cuObj) {
+      cuObj->addAIM(slotId, traceEnabled) ;
+    }
+    else {
+      // If not connected to CU and not a shell monitor, then a floating monitor
+      devInfo->loadedXclbins.back()->hasFloatingAIM = true;
+    }
+
+    // If the AIM is an User Space AIM with trace enabled i.e. either
+    //  connected to a CU or floating but not shell AIM
+    if(traceEnabled) {
+      devInfo->loadedXclbins.back()->aimMap.emplace(slotId, mon);
+    } else {
+      devInfo->loadedXclbins.back()->noTraceAIMs.push_back(mon);
+    }
+  }
+
+  void VPStaticDatabase::initializeASM(DeviceInfo* devInfo,
+                                       const std::string& name,
+                                       const struct debug_ip_data* debugIpData)
+  {
+    uint64_t index = static_cast<uint64_t>(debugIpData->m_index_lowbyte) |
+      (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
+    if (index < MIN_TRACE_ID_ASM) {
+      std::stringstream msg;
+      msg << "ASM with incorrect index: " << index ;
+      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+                              msg.str());
+      index = MIN_TRACE_ID_ASM ;
+    }
+    uint64_t slotId = (index - MIN_TRACE_ID_ASM);
+
+    // associate with the first CU
+    size_t pos = name.find('/');
+    std::string monCuName = name.substr(0, pos);
+
+    std::string portName = "";
+    ComputeUnitInstance* cuObj = nullptr ;
+    int32_t cuId = -1 ;
+
+    for(auto cu : devInfo->loadedXclbins.back()->cus) {
+      if(0 == monCuName.compare(cu.second->getName())) {
+        cuId = cu.second->getIndex();
+        cuObj = cu.second;
+        break;
+      }
+    }
+    if(-1 != cuId) {
+      size_t pos1 = name.find('-');
+      if(std::string::npos != pos1) {
+        portName = name.substr(pos+1, pos1-pos-1);
+      }
+    } else { /* (-1 == cuId) */
+      pos = name.find("-");
+      if(std::string::npos != pos) {
+        pos = name.find_first_not_of(" ", pos+1);
+        monCuName = name.substr(pos);
+        pos = monCuName.find('/');
+
+        size_t pos1 = monCuName.find('-');
+        if(std::string::npos != pos1) {
+          portName = monCuName.substr(pos+1, pos1-pos-1);
+        }
+
+        monCuName = monCuName.substr(0, pos);
+
+        for(auto cu : devInfo->loadedXclbins.back()->cus) {
+          if(0 == monCuName.compare(cu.second->getName())) {
+            cuId = cu.second->getIndex();
+            cuObj = cu.second;
+            break;
+          }
+        }
+      }
+    }
+
+    Monitor* mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name,
+                               cuId, -1 /* memId */, slotId);
+    mon->port = portName;
+    if(debugIpData->m_properties & 0x2) {
+      mon->isRead = true;
+    }
+
+    // Add this monitor to the list of all monitors
+    devInfo->loadedXclbins.back()->asmList.push_back(mon) ;
+    bool traceEnabled =
+      (debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) != 0 ;
+
+    // If the ASM is an User Space ASM i.e. either connected to a CU or floating but not shell ASM
+    if (cuObj) {
+      cuObj->addASM(slotId, traceEnabled) ;
+    }
+    else {
+      // If not connected to CU and not a shell monitor, then a floating monitor
+      devInfo->loadedXclbins.back()->hasFloatingASM = true ;
+    }
+
+    if (traceEnabled) {
+      devInfo->loadedXclbins.back()->asmMap.emplace(slotId, mon) ;
+    }
+    else {
+      devInfo->loadedXclbins.back()->noTraceASMs.push_back(mon);
+    }
+  }
+
+  void VPStaticDatabase::initializeNOC(DeviceInfo* devInfo,
+                                       const struct debug_ip_data* debugIpData)
+  {
+    uint64_t index = static_cast<uint64_t>(debugIpData->m_index_lowbyte) |
+      (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
+    uint8_t readTrafficClass  = debugIpData->m_properties >> 2;
+    uint8_t writeTrafficClass = debugIpData->m_properties & 0x3;
+
+    Monitor* mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name,
+                               readTrafficClass, writeTrafficClass);
+    devInfo->loadedXclbins.back()->nocList.push_back(mon);
+    // nocList in xdp::DeviceIntf is sorted; Is that required here?
+  }
+
+  void VPStaticDatabase::initializeTS2MM(DeviceInfo* devInfo,
+                                         const struct debug_ip_data* debugIpData)
+  {
+    // TS2MM IP for either AIE PLIO or PL trace offload
+    if (debugIpData->m_properties & 0x1)
+      devInfo->loadedXclbins.back()->numTracePLIO++;
+    else
+      devInfo->loadedXclbins.back()->usesTs2mm = true;
+  }
+
   bool VPStaticDatabase::initializeProfileMonitors(DeviceInfo* devInfo, const std::shared_ptr<xrt_core::device>& device)
   {
     // Look into the debug_ip_layout section and load information about Profile Monitors
-    // Get DEBUG_IP_LAYOUT section 
-    const debug_ip_layout* debugIpLayoutSection = device->get_axlf_section<const debug_ip_layout*>(DEBUG_IP_LAYOUT);
+    // Get DEBUG_IP_LAYOUT section
+    const debug_ip_layout* debugIpLayoutSection =
+      device->get_axlf_section<const debug_ip_layout*>(DEBUG_IP_LAYOUT);
     if(debugIpLayoutSection == nullptr) return false;
 
     for(uint16_t i = 0; i < debugIpLayoutSection->m_count; i++) {
-      const struct debug_ip_data* debugIpData = &(debugIpLayoutSection->m_debug_ip_data[i]);
+      const struct debug_ip_data* debugIpData =
+        &(debugIpLayoutSection->m_debug_ip_data[i]);
       uint64_t index = static_cast<uint64_t>(debugIpData->m_index_lowbyte) |
-                       (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
-      Monitor* mon = nullptr;
+        (static_cast<uint64_t>(debugIpData->m_index_highbyte) << 8);
 
       std::string name(debugIpData->m_name);
-      int32_t cuId  = -1;
-      ComputeUnitInstance* cuObj = nullptr;
 
       std::stringstream msg;
-      msg << "Initializing profile monitor " << i << ": name = " << name << ", index = " << index;
-      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg.str());
+      msg << "Initializing profile monitor " << i
+          << ": name = " << name << ", index = " << index;
+      xrt_core::message::send(xrt_core::message::severity_level::info, "XRT",
+                              msg.str());
 
-      // find CU
-      if(debugIpData->m_type == ACCEL_MONITOR) {
-        for(auto cu : devInfo->loadedXclbins.back()->cus) {
-          if(0 == name.compare(cu.second->getName())) {
-            cuObj = cu.second;
-            cuId = cu.second->getIndex();
-            mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name, cuId);
-            if((debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) && (index >= MIN_TRACE_ID_AM)) {
-              uint64_t slotID = (index - MIN_TRACE_ID_AM) / 16;
-              devInfo->loadedXclbins.back()->amMap.emplace(slotID, mon);
-              cuObj->setAccelMon(slotID);
-            } else {
-              devInfo->loadedXclbins.back()->noTraceAMs.push_back(mon);
-            }
-            // Also add it to the list of all AMs
-            devInfo->loadedXclbins.back()->amList.push_back(mon);
-            if(debugIpData->m_properties & XAM_STALL_PROPERTY_MASK) {
-              cuObj->setStallEnabled(true);
-            }
-            break;
-          }
-        }
-      } else if(debugIpData->m_type == AXI_MM_MONITOR) {
-        // parse name to find CU Name and Memory
-        size_t pos = name.find('/');
-        std::string monCuName = name.substr(0, pos);
-
-        std::string memName;
-        std::string portName;
-        size_t pos1 = name.find('-');
-        if(pos1 != std::string::npos) {
-          memName = name.substr(pos1+1);
-          portName = name.substr(pos+1, pos1-pos-1);
-        }
-
-        int32_t memId = -1;
-        for(auto cu : devInfo->loadedXclbins.back()->cus) {
-          if(0 == monCuName.compare(cu.second->getName())) {
-            cuId = cu.second->getIndex();
-            cuObj = cu.second;
-            break;
-          }
-        }
-        for(auto mem : devInfo->loadedXclbins.back()->memoryInfo) {
-          if(0 == memName.compare(mem.second->name)) {
-            memId = mem.second->index;
-            break;
-          }
-        }
-        mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name, cuId, memId);
-        mon->port = portName;
-        // If the AIM is an User Space AIM with trace enabled i.e. either connected to a CU or floating but not shell AIM
-        if((debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) && (index >= MIN_TRACE_ID_AIM)) {
-          uint64_t slotID = (index - MIN_TRACE_ID_AIM) / 2;
-          devInfo->loadedXclbins.back()->aimMap.emplace(slotID, mon);
-          if(cuObj) {
-            cuObj->addAIM(slotID);
-          } else {
-            // If not connected to CU and not a shell monitor, then a floating monitor
-            devInfo->loadedXclbins.back()->hasFloatingAIM = true;
-          }
-        } else {
-          devInfo->loadedXclbins.back()->noTraceAIMs.push_back(mon);
-        }
-        // Also add it to the list of all AIMs
-        devInfo->loadedXclbins.back()->aimList.push_back(mon) ;
-      } else if(debugIpData->m_type == AXI_STREAM_MONITOR) {
-        // associate with the first CU
-        size_t pos = name.find('/');
-        std::string monCuName = name.substr(0, pos);
-
-        std::string portName;
-        
-        for(auto cu : devInfo->loadedXclbins.back()->cus) {
-          if(0 == monCuName.compare(cu.second->getName())) {
-            cuId = cu.second->getIndex();
-            cuObj = cu.second;
-            break;
-          }
-        }
-        if(-1 != cuId) {
-          size_t pos1 = name.find('-');
-          if(std::string::npos != pos1) {
-            portName = name.substr(pos+1, pos1-pos-1);
-          }
-        } else { /* (-1 == cuId) */
-          pos = name.find("-");
-          if(std::string::npos != pos) {
-            pos = name.find_first_not_of(" ", pos+1);
-            monCuName = name.substr(pos);
-            pos = monCuName.find('/');
-
-            size_t pos1 = monCuName.find('-');
-            if(std::string::npos != pos1) {
-              portName = monCuName.substr(pos+1, pos1-pos-1);
-            }
-
-            monCuName = monCuName.substr(0, pos);
-
-            for(auto cu : devInfo->loadedXclbins.back()->cus) {
-              if(0 == monCuName.compare(cu.second->getName())) {
-                cuId = cu.second->getIndex();
-                cuObj = cu.second;
-                break;
-              }
-            }
-          }
-        }
-
-        mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name, cuId);
-        mon->port = portName;
-        if(debugIpData->m_properties & 0x2) {
-          mon->isRead = true;
-        }
-        // If the ASM is an User Space ASM with trace enabled i.e. either connected to a CU or floating but not shell ASM
-        if((debugIpData->m_properties & XMON_TRACE_PROPERTY_MASK) && (index >= MIN_TRACE_ID_ASM)) {
-          uint64_t slotID = (index - MIN_TRACE_ID_ASM);
-          devInfo->loadedXclbins.back()->asmMap.emplace(slotID, mon);
-          if(cuObj) {
-            cuObj->addASM(slotID);
-          } else {
-            // If not connected to CU and not a shell monitor, then a floating monitor
-            devInfo->loadedXclbins.back()->hasFloatingASM = true;
-          }
-        } else {
-          devInfo->loadedXclbins.back()->noTraceASMs.push_back(mon);
-        }
-        // Also add it to the list of all ASM monitors
-        devInfo->loadedXclbins.back()->asmList.push_back(mon) ;
-      } else if(debugIpData->m_type == AXI_NOC) {
-        uint8_t readTrafficClass  = debugIpData->m_properties >> 2;
-        uint8_t writeTrafficClass = debugIpData->m_properties & 0x3;
-
-        mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name,
-                          readTrafficClass, writeTrafficClass);
-        devInfo->loadedXclbins.back()->nocList.push_back(mon);
-        // nocList in xdp::DeviceIntf is sorted; Is that required here?
-      } else if (debugIpData->m_type == TRACE_S2MM) { 
-        // TS2MM IP for either AIE PLIO or PL trace offload
-        if (debugIpData->m_properties & 0x1)
-          devInfo->loadedXclbins.back()->numTracePLIO++;
-        else
-          devInfo->loadedXclbins.back()->usesTs2mm = true;
-      } else {
-        // Do nothing since not recognized
-        // mon = new Monitor(debugIpData->m_type, index, debugIpData->m_name);
+      switch (debugIpData->m_type) {
+      case ACCEL_MONITOR:
+        initializeAM(devInfo, name, debugIpData) ;
+        break ;
+      case AXI_MM_MONITOR:
+        initializeAIM(devInfo, name, debugIpData) ;
+        break ;
+      case AXI_STREAM_MONITOR:
+        initializeASM(devInfo, name, debugIpData) ;
+        break ;
+      case AXI_NOC:
+        initializeNOC(devInfo, debugIpData) ;
+        break ;
+      case TRACE_S2MM:
+        initializeTS2MM(devInfo, debugIpData) ;
+        break ;
+      default:
+        break ;
       }
     }
 

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -48,7 +48,10 @@ namespace xdp {
     uint64_t    portWidth; // For OpenCL monitors associated with a port
     bool        isRead;
 
-    Monitor(uint8_t ty, uint64_t idx, const char* n, int32_t cuId = -1, int32_t memId = -1)
+    // The index in the xclCounterResults to use for counter values
+    uint64_t slotIndex ;
+
+    Monitor(uint8_t ty, uint64_t idx, const char* n, int32_t cuId = -1, int32_t memId = -1, uint64_t slotId = 0)
       : type(ty),
         index(idx),
         cuIndex(cuId),
@@ -57,7 +60,8 @@ namespace xdp {
         args(""),
         port(""),
         portWidth(0),
-        isRead(false)
+        isRead(false),
+        slotIndex(slotId)
     {}
   };
 
@@ -197,8 +201,11 @@ class aie_cfg_tile
 
     // All of the slot IDs inside the counter results structure for any
     //  monitors attached to this CU
-    std::vector<uint32_t> aimIds;
-    std::vector<uint32_t> asmIds;
+    std::vector<uint32_t> aimIds; // All AIMs (counters only and trace enabled)
+    std::vector<uint32_t> asmIds; // All ASMs (counters only and trace enabled)
+
+    std::vector<uint32_t> aimIdsWithTrace ; // Only AIMs with trace
+    std::vector<uint32_t> asmIdsWithTrace ; // Only ASMs with trace
 
     bool stall        = false;
     bool dataflow     = false;
@@ -222,11 +229,16 @@ class aie_cfg_tile
     void    setAccelMon(int32_t id) { amId = id; }
     int32_t getAccelMon() { return amId; }
  
-    void addAIM(uint32_t id) { aimIds.push_back(id); }
-    void addASM(uint32_t id) { asmIds.push_back(id); }
+    void addAIM(uint32_t id, bool trace = false)
+      { aimIds.push_back(id); if (trace) aimIdsWithTrace.push_back(id) ; }
+    void addASM(uint32_t id, bool trace = false)
+      { asmIds.push_back(id); if (trace) asmIdsWithTrace.push_back(id) ; }
 
     inline std::vector<uint32_t>* getAIMs() { return &aimIds; }
     inline std::vector<uint32_t>* getASMs() { return &asmIds; }
+
+    inline std::vector<uint32_t>* getAIMsWithTrace() {return &aimIdsWithTrace;}
+    inline std::vector<uint32_t>* getASMsWithTrace() {return &asmIdsWithTrace;}
 
     void setStallEnabled(bool b) { stall = b; }
     bool stallEnabled() { return stall; }
@@ -415,7 +427,7 @@ class aie_cfg_tile
       return 0 ;
     }
 
-    inline uint64_t getNumASM(XclbinInfo* xclbin) {
+    inline uint64_t getNumASMWithTrace(XclbinInfo* xclbin) {
       for (auto bin : loadedXclbins) {
         if (bin == xclbin) return bin->asmMap.size() ;
       }
@@ -445,7 +457,11 @@ class aie_cfg_tile
 
     inline Monitor* getASMonitor(XclbinInfo* xclbin, uint64_t slotID) {
       for (auto bin : loadedXclbins) {
-        if (bin == xclbin) return bin->asmMap[slotID] ;
+        if (bin == xclbin) {
+          for (auto mon : bin->asmList) {
+            if (mon->slotIndex == slotID) return mon ;
+	  }
+        }
       }
       return nullptr ;
     }
@@ -610,6 +626,16 @@ class aie_cfg_tile
     bool setXclbinName(XclbinInfo*, const std::shared_ptr<xrt_core::device>& device);
     bool initializeComputeUnits(XclbinInfo*, const std::shared_ptr<xrt_core::device>&);
     bool initializeProfileMonitors(DeviceInfo*, const std::shared_ptr<xrt_core::device>&);
+    void initializeAM(DeviceInfo* devInfo, const std::string& name,
+                      const struct debug_ip_data* debugIpData) ;
+    void initializeAIM(DeviceInfo* devInfo, const std::string& name,
+                       const struct debug_ip_data* debugIpData) ;
+    void initializeASM(DeviceInfo* devInfo, const std::string& name,
+                       const struct debug_ip_data* debugIpData) ;
+    void initializeNOC(DeviceInfo* devInfo,
+                       const struct debug_ip_data* debugIpData) ;
+    void initializeTS2MM(DeviceInfo* devInfo,
+                         const struct debug_ip_data* debugIpData) ;
 
   public:
     VPStaticDatabase(VPDatabase* d) ;
@@ -888,11 +914,11 @@ class aie_cfg_tile
      * Note : May not match xdp::DeviceIntf::getNumMonitors(XCL_PERF_MON_STR)
      *        as that includes both user-space and shell ASM
      */
-    inline uint64_t getNumASM(uint64_t deviceId, XclbinInfo* xclbin)
+    inline uint64_t getNumASMWithTrace(uint64_t deviceId, XclbinInfo* xclbin)
     {
       if(deviceInfo.find(deviceId) == deviceInfo.end())
         return 0;
-      return deviceInfo[deviceId]->getNumASM(xclbin);
+      return deviceInfo[deviceId]->getNumASMWithTrace(xclbin);
     }
 
     inline uint64_t getNumNOC(uint64_t deviceId, XclbinInfo* xclbin)

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -146,7 +146,7 @@ namespace xdp {
     // Generate Wave group for Read/Write if data transfer monitoring is enabled
     if (!(cu->dataTransferEnabled())) return ;
 
-    std::vector<uint32_t>* cuAIMs = cu->getAIMs() ;
+    std::vector<uint32_t>* cuAIMs = cu->getAIMsWithTrace() ;
     for (auto cuAIM : *cuAIMs) {
       Monitor* aim = (db->getStaticInfo()).getAIMonitor(deviceId, xclbin, cuAIM) ;
       if (nullptr == aim) continue ;
@@ -173,7 +173,7 @@ namespace xdp {
     // Generate Wave group for stream data transfers if enabled
     if (!(cu->streamEnabled())) return ;
 
-    std::vector<uint32_t>* cuASMs = cu->getASMs() ;
+    std::vector<uint32_t>* cuASMs = cu->getASMsWithTrace() ;
     for (auto cuASM : *cuASMs) {
       Monitor* ASM = (db->getStaticInfo()).getASMonitor(deviceId, xclbin, cuASM) ;
       if (nullptr == ASM) continue ;


### PR DESCRIPTION
This pull request fixes an issue where AIMs and ASMs had their slot IDs only tracked if they were configured with trace, leading to the summary file not finding counter values for ASMs that only had counters in mixed designs.  Profiling now stores the slot IDs of all AIMs and ASMs and separately tracks the slot IDs of AIMs and ASMs that have trace enabled.  This allows the summary generation to print tables correctly and the trace generation is unaffected.

This pull request also does some slight refactoring in the setup of the database information.
