### PR TITLE
windows: add device request "kds_cu_info" to retrieve compute units data

### DIFF
--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -956,7 +956,7 @@ struct kds_cu_info
   static result_type
   mgmt(const xrt_core::device* device, key_type key)
   {
-    mgmtpf_not_supported_error(key);
+    throw mgmtpf_not_supported_error(key);
   }
 };
 

--- a/src/runtime_src/core/pcie/windows/shim.h
+++ b/src/runtime_src/core/pcie/windows/shim.h
@@ -102,6 +102,9 @@ XRT_CORE_PCIE_WINDOWS_EXPORT
 void
 get_firewall_info(xclDeviceHandle hdl, xcl_firewall* value);
 
+XRT_CORE_PCIE_WINDOWS_EXPORT
+void
+get_kds_custat(xclDeviceHandle hdl, char* buffer, DWORD size, int* size_ret);
 } // userpf
 
 

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -131,6 +131,7 @@ populate_cus(const xrt_core::device *device)
         ptCu.put( "name",			layout->m_ip_data[i].m_name);
         ptCu.put( "base_address",		boost::str(boost::format("0x%x") % base_addr));
         ptCu.put( "usage",			usage);
+        ptCu.put( "type",			enum_to_str(cu_type::PL));
         ptCu.add_child( std::string("status"),	get_cu_status(status));
         pt.push_back(std::make_pair("", ptCu));
       }


### PR DESCRIPTION
Added kds_cu_info device request in windows to get the KDS CU information.
Fixed missing type entry in ReportDynamicRegion code

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>