### PR TITLE
CR-1106238: Domain is not mandatory if it is 0000 (#5547)

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -425,7 +425,10 @@ bdf2index(const std::string& bdfstr, bool _inUserDomain)
     dev = static_cast<uint16_t>(std::stoi(std::string(tokens[0]), nullptr, radix));
   }
   bus = static_cast<uint16_t>(std::stoi(std::string(tokens[1]), nullptr, radix));
-  domain = static_cast<uint16_t>(std::stoi(std::string(tokens[2]), nullptr, radix));
+  
+  // domain is not mandatory if it is "0000"
+  if(tokens.size() > 2)
+    domain = static_cast<uint16_t>(std::stoi(std::string(tokens[2]), nullptr, radix));
 
   uint64_t devices = _inUserDomain ? xrt_core::get_total_devices(true).first : xrt_core::get_total_devices(false).first;
   for (uint16_t i = 0; i < devices; i++) {


### PR DESCRIPTION
found a bug while verifying one of the feature. Looks like this bug got recently introduced where xbutil/xbmgmt is always expecting domain value. This is not the case earlier.
Removing that hard check when domain is "0000"