### PR TITLE
update validate designs to provide --supported feature

### DIFF
--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -41,14 +41,12 @@ int main(int argc, char** argv) {
     std::string iter_cnt = "10000";
     std::string b_file = "/bandwidth.xclbin";
     bool flag_s = false;
-    bool flag_p = false;
     // Commandline
-    int c;
+    int c = 0;
     while ((c = getopt_long(argc, argv, "p:d:l:s", long_options, &option_index)) != -1) {
         switch (c) {
             case 'p':
                 test_path = optarg;
-                flag_p = true;
                 break;
             case 'd':
                 dev_id = optarg;
@@ -64,7 +62,7 @@ int main(int argc, char** argv) {
                 return 1;
         }
     }
-    if (!flag_p) {
+    if (test_path.empty()) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }

--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -17,51 +17,39 @@
 #include <boost/property_tree/ptree.hpp>
 #include <math.h>
 #include <sys/time.h>
-#include <getopt.h>
 #include <xcl2.hpp>
-
-const static struct option long_options[] = {{"path", required_argument, 0, 'p'},
-                                             {"device", required_argument, 0, 'd'},
-                                             {"iter_cnt", required_argument, 0, 'l'},
-                                             {"supported", no_argument, 0, 's'},
-                                             {0, 0, 0, 0}};
 
 static void printHelp() {
     std::cout << "usage: %s <options>\n";
-    std::cout << "  -p <platform_test_area_path>\n";
+    std::cout << "  -p <path>\n";
     std::cout << "  -d <device> \n";
     std::cout << "  -l <loop_iter_cnt> \n";
-    std::cout << "  -s <check_supported>\n";
+    std::cout << "  -s <supported>\n";
+    std::cout << "  -h <help>\n";
 }
 
 int main(int argc, char** argv) {
-    int option_index = 0;
     std::string dev_id = "0";
     std::string test_path;
     std::string iter_cnt = "10000";
     std::string b_file = "/bandwidth.xclbin";
     bool flag_s = false;
-    // Commandline
-    int c = 0;
-    while ((c = getopt_long(argc, argv, "p:d:l:s", long_options, &option_index)) != -1) {
-        switch (c) {
-            case 'p':
-                test_path = optarg;
-                break;
-            case 'd':
-                dev_id = optarg;
-                break;
-            case 's':
-                flag_s = true;
-                break;
-            case 'l':
-                iter_cnt = atoi(optarg);
-                break;
-            default:
-                printHelp();
-                return 1;
+
+    for (int i = 1; i < argc; i++) {
+        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
+            test_path = argv[i + 1];
+        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
+            dev_id = argv[i + 1];
+        } else if ((strcmp(argv[i], "-l") == 0) || (strcmp(argv[i], "--loop_iter_cnt") == 0)) {
+            iter_cnt = atoi(argv[i + 1]);
+        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
+            flag_s = true;
+        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
+            printHelp();
+            return 1;
         }
     }
+
     if (test_path.empty()) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;

--- a/tests/validate/slavebridge_test/src/host.cpp
+++ b/tests/validate/slavebridge_test/src/host.cpp
@@ -41,14 +41,12 @@ int main(int argc, char** argv) {
     std::string iter_cnt = "10000";
     std::string b_file = "/slavebridge.xclbin";
     bool flag_s = false;
-    bool flag_p = false;
     // Commandline
-    int c;
+    int c = 0;
     while ((c = getopt_long(argc, argv, "p:d:l:s", long_options, &option_index)) != -1) {
         switch (c) {
             case 'p':
                 test_path = optarg;
-                flag_p = true;
                 break;
             case 'd':
                 dev_id = optarg;
@@ -64,7 +62,7 @@ int main(int argc, char** argv) {
                 return 1;
         }
     }
-    if (!flag_p) {
+    if (test_path.empty()) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }

--- a/tests/validate/slavebridge_test/src/host.cpp
+++ b/tests/validate/slavebridge_test/src/host.cpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) 2020 Xilinx, Inc
+* Copyright (C) 2019-2021 Xilinx, Inc
 *
 * Licensed under the Apache License, Version 2.0 (the "License"). You may
 * not use this file except in compliance with the License. A copy of the
@@ -13,36 +13,74 @@
 * License for the specific language governing permissions and limitations
 * under the License.
 */
-#include "cmdlineparser.h"
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <math.h>
 #include <sys/time.h>
+#include <getopt.h>
 #include <xcl2.hpp>
 
+const static struct option long_options[] = {{"path", required_argument, 0, 'p'},
+                                             {"device", required_argument, 0, 'd'},
+                                             {"iter_cnt", required_argument, 0, 'l'},
+                                             {"supported", no_argument, 0, 's'},
+                                             {0, 0, 0, 0}};
+
+static void printHelp() {
+    std::cout << "usage: %s <options>\n";
+    std::cout << "  -p <platform_test_area_path>\n";
+    std::cout << "  -d <device> \n";
+    std::cout << "  -l <loop_iter_cnt> \n";
+    std::cout << "  -s <check_supported>\n";
+}
+
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cout << "Usage: " << argv[0] << " <Platform Test Area Path>"
-                  << "<optional> -d device_id"
-                  << "<optional> -l iter_cnt" << std::endl;
+    int option_index = 0;
+    std::string dev_id = "0";
+    std::string test_path;
+    std::string iter_cnt = "10000";
+    std::string b_file = "/slavebridge.xclbin";
+    bool flag_s = false;
+    bool flag_p = false;
+    // Commandline
+    int c;
+    while ((c = getopt_long(argc, argv, "p:d:l:s", long_options, &option_index)) != -1) {
+        switch (c) {
+            case 'p':
+                test_path = optarg;
+                flag_p = true;
+                break;
+            case 'd':
+                dev_id = optarg;
+                break;
+            case 's':
+                flag_s = true;
+                break;
+            case 'l':
+                iter_cnt = atoi(optarg);
+                break;
+            default:
+                printHelp();
+                return 1;
+        }
+    }
+    if (!flag_p) {
+        std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
-
-    // Command Line Parser
-    sda::utils::CmdLineParser parser;
-
-    // Switches
-    //**************//"<Full Arg>",  "<Short Arg>", "<Description>", "<Default>"
-    parser.addSwitch("--device", "-d", "device id", "0");
-    parser.addSwitch("--iter_cnt", "-l", "loop iteration count", "10000");
-    parser.parse(argc, argv);
-
-    // Read settings
-    std::string dev_id = parser.value("device");
-    std::string iter_cnt = parser.value("iter_cnt");
+    if (flag_s) {
+        std::string binaryFile = test_path + b_file;
+        std::ifstream infile(binaryFile);
+        if (!infile.good()) {
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+            return EOPNOTSUPP;
+        } else {
+            std::cout << "\nSUPPORTED" << std::endl;
+            return EXIT_SUCCESS;
+        }
+    }
 
     int NUM_KERNEL;
-    std::string test_path = argv[1];
     std::string filename = "/platform.json";
     std::string platform_json = test_path + filename;
 
@@ -61,7 +99,6 @@ int main(int argc, char** argv) {
         std::cout << msg;
     }
 
-    std::string b_file = "/slavebridge.xclbin";
     std::string binaryFile = test_path + b_file;
     std::ifstream infile(binaryFile);
     if (!infile.good()) {
@@ -100,6 +137,15 @@ int main(int argc, char** argv) {
             return EXIT_FAILURE;
         }
         device = xcl::find_device_bdf(devices, dev_id);
+    }
+
+    auto device_name = device.getInfo<CL_DEVICE_NAME>();
+    if (xcl::is_hw_emulation()) {
+        if (device_name.find("202010") != std::string::npos) {
+            std::cout << "[INFO]: The example is not supported for " << device_name
+                      << " for hw_emu. Please try other flows." << '\n';
+            return EXIT_SUCCESS;
+        }
     }
 
     // Creating Context and Command Queue for selected Device
@@ -224,8 +270,7 @@ int main(int argc, char** argv) {
         double bpersec;
         double mbpersec;
 
-        usduration =
-            (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(timeEnd - timeStart).count() / reps);
+        usduration = (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(timeEnd - timeStart).count() / reps);
 
         dnsduration = (double)usduration;
         dsduration = dnsduration / ((double)1000000000);
@@ -240,4 +285,3 @@ int main(int argc, char** argv) {
 
     return EXIT_SUCCESS;
 }
-

--- a/tests/validate/slavebridge_test/src/host.cpp
+++ b/tests/validate/slavebridge_test/src/host.cpp
@@ -17,49 +17,36 @@
 #include <boost/property_tree/ptree.hpp>
 #include <math.h>
 #include <sys/time.h>
-#include <getopt.h>
 #include <xcl2.hpp>
-
-const static struct option long_options[] = {{"path", required_argument, 0, 'p'},
-                                             {"device", required_argument, 0, 'd'},
-                                             {"iter_cnt", required_argument, 0, 'l'},
-                                             {"supported", no_argument, 0, 's'},
-                                             {0, 0, 0, 0}};
 
 static void printHelp() {
     std::cout << "usage: %s <options>\n";
-    std::cout << "  -p <platform_test_area_path>\n";
+    std::cout << "  -p <path>\n";
     std::cout << "  -d <device> \n";
     std::cout << "  -l <loop_iter_cnt> \n";
-    std::cout << "  -s <check_supported>\n";
+    std::cout << "  -s <supported>\n";
+    std::cout << "  -h <help>\n";
 }
 
 int main(int argc, char** argv) {
-    int option_index = 0;
     std::string dev_id = "0";
     std::string test_path;
     std::string iter_cnt = "10000";
     std::string b_file = "/slavebridge.xclbin";
     bool flag_s = false;
-    // Commandline
-    int c = 0;
-    while ((c = getopt_long(argc, argv, "p:d:l:s", long_options, &option_index)) != -1) {
-        switch (c) {
-            case 'p':
-                test_path = optarg;
-                break;
-            case 'd':
-                dev_id = optarg;
-                break;
-            case 's':
-                flag_s = true;
-                break;
-            case 'l':
-                iter_cnt = atoi(optarg);
-                break;
-            default:
-                printHelp();
-                return 1;
+
+    for (int i = 1; i < argc; i++) {
+        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
+            test_path = argv[i + 1];
+        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
+            dev_id = argv[i + 1];
+        } else if ((strcmp(argv[i], "-l") == 0) || (strcmp(argv[i], "--loop_iter_cnt") == 0)) {
+            iter_cnt = atoi(argv[i + 1]);
+        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
+            flag_s = true;
+        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
+            printHelp();
+            return 1;
         }
     }
     if (test_path.empty()) {

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -16,45 +16,34 @@
 #include "xcl2.hpp"
 #include <algorithm>
 #include <vector>
-#include <getopt.h>
 #define LENGTH 64
-
-const static struct option long_options[] = {{"path", required_argument, 0, 'p'},
-                                             {"device", required_argument, 0, 'd'},
-                                             {"supported", no_argument, 0, 's'},
-                                             {0, 0, 0, 0}};
 
 static void printHelp() {
     std::cout << "usage: %s <options>\n";
-    std::cout << "  -p <platform_test_area_path>\n";
+    std::cout << "  -p <path>\n";
     std::cout << "  -d <device> \n";
-    std::cout << "  -s <check_supported>\n";
+    std::cout << "  -s <supported>\n";
+    std::cout << "  -h <help>\n";
 }
 
 int main(int argc, char** argv) {
-    int option_index = 0;
     std::string dev_id = "0";
     std::string test_path;
     std::string b_file = "/verify.xclbin";
     bool flag_s = false;
-    // Commandline
-    int c = 0;
-    while ((c = getopt_long(argc, argv, "p:d:s", long_options, &option_index)) != -1) {
-        switch (c) {
-            case 'p':
-                test_path = optarg;
-                break;
-            case 'd':
-                dev_id = optarg;
-                break;
-            case 's':
-                flag_s = true;
-                break;
-            default:
-                printHelp();
-                return 1;
+    for (int i = 1; i < argc; i++) {
+        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
+            test_path = argv[i + 1];
+        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
+            dev_id = argv[i + 1];
+        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
+            flag_s = true;
+        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
+            printHelp();
+            return 1;
         }
     }
+
     if (test_path.empty()) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -37,14 +37,12 @@ int main(int argc, char** argv) {
     std::string test_path;
     std::string b_file = "/verify.xclbin";
     bool flag_s = false;
-    bool flag_p = false;
     // Commandline
-    int c;
+    int c = 0;
     while ((c = getopt_long(argc, argv, "p:d:s", long_options, &option_index)) != -1) {
         switch (c) {
             case 'p':
                 test_path = optarg;
-                flag_p = true;
                 break;
             case 'd':
                 dev_id = optarg;
@@ -57,7 +55,7 @@ int main(int argc, char** argv) {
                 return 1;
         }
     }
-    if (!flag_p) {
+    if (test_path.empty()) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) 2020-2021 Xilinx, Inc
+* Copyright (C) 2019-2021 Xilinx, Inc
 *
 * Licensed under the Apache License, Version 2.0 (the "License"). You may
 * not use this file except in compliance with the License. A copy of the
@@ -13,35 +13,66 @@
 * License for the specific language governing permissions and limitations
 * under the License.
 */
-#include "cmdlineparser.h"
 #include "xcl2.hpp"
 #include <algorithm>
 #include <vector>
+#include <getopt.h>
 #define LENGTH 64
 
+const static struct option long_options[] = {{"path", required_argument, 0, 'p'},
+                                             {"device", required_argument, 0, 'd'},
+                                             {"supported", no_argument, 0, 's'},
+                                             {0, 0, 0, 0}};
+
+static void printHelp() {
+    std::cout << "usage: %s <options>\n";
+    std::cout << "  -p <platform_test_area_path>\n";
+    std::cout << "  -d <device> \n";
+    std::cout << "  -s <check_supported>\n";
+}
+
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        std::cout << "Usage: " << argv[0] << " <Platform Test Area Path>"
-                  << "<optional> -d device_id" << std::endl;
+    int option_index = 0;
+    std::string dev_id = "0";
+    std::string test_path;
+    std::string b_file = "/verify.xclbin";
+    bool flag_s = false;
+    bool flag_p = false;
+    // Commandline
+    int c;
+    while ((c = getopt_long(argc, argv, "p:d:s", long_options, &option_index)) != -1) {
+        switch (c) {
+            case 'p':
+                test_path = optarg;
+                flag_p = true;
+                break;
+            case 'd':
+                dev_id = optarg;
+                break;
+            case 's':
+                flag_s = true;
+                break;
+            default:
+                printHelp();
+                return 1;
+        }
+    }
+    if (!flag_p) {
+        std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
+    if (flag_s) {
+        std::string binaryFile = test_path + b_file;
+        std::ifstream infile(binaryFile);
+        if (!infile.good()) {
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+            return EOPNOTSUPP;
+        } else {
+            std::cout << "\nSUPPORTED" << std::endl;
+            return EXIT_SUCCESS;
+        }
+    }
 
-    // Command Line Parser
-    sda::utils::CmdLineParser parser;
-
-    // Switches
-    //**************//"<Full Arg>",  "<Short Arg>", "<Description>", "<Default>"
-    parser.addSwitch("--device", "-d", "device id", "0");
-    parser.addSwitch("--kernel", "-k", "kernel name", "verify");
-    parser.parse(argc, argv);
-
-    // Read settings
-    std::string dev_id = parser.value("device");
-    std::string krnl_name = parser.value("kernel");
-
-    std::string test_path = argv[1];
-
-    std::string b_file = "/verify.xclbin";
     std::string binaryFile = test_path + b_file;
     std::ifstream infile(binaryFile);
     if (!infile.good()) {
@@ -106,7 +137,7 @@ int main(int argc, char** argv) {
         std::cout << "Failed to program device with xclbin file!\n";
     } else {
         std::cout << "Device program successful!\n";
-        OCL_CHECK(err, krnl_verify = cl::Kernel(program, krnl_name.c_str(), &err));
+        OCL_CHECK(err, krnl_verify = cl::Kernel(program, "verify", &err));
     }
 
     OCL_CHECK(err, cl::Buffer d_buf(context, CL_MEM_WRITE_ONLY, sizeof(char) * LENGTH, nullptr, &err));


### PR DESCRIPTION
We have made changes in existing commandline flow. As now host is expecting path should be coming with -p otherwise design will fail.

1.	Change in the commandline flow : 
a.	Older flow:
Verify test : ./validate.exe <path to platform test folder>
b.	New flow :
Verify test : ./validate.exe -p <path to platform test folder>   
2.	New –supported feature usage
a.	Verify test : ./validate.exe -s -p <path to platform test folder>
