### PR TITLE
CR-1100587: Align device profiling events on Edge 

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -269,18 +269,18 @@ namespace xdp {
           continue ;
 
         try {
-	  std::string port = clock.second.get<std::string>("<xmlattr>.port") ;
+          std::string port = clock.second.get<std::string>("<xmlattr>.port") ;
           if (port != "DATA_CLK")
             continue ;
-	  std::string freq = clock.second.get<std::string>("<xmlattr>.frequency") ;
-	  std::string freqNumeral = freq.substr(0, freq.find('M')) ;
+          std::string freq = clock.second.get<std::string>("<xmlattr>.frequency") ;
+          std::string freqNumeral = freq.substr(0, freq.find('M')) ;
           double frequency = defaultClockSpeed ;
-	  std::stringstream convert ;
+          std::stringstream convert ;
           convert << freqNumeral ;
           convert >> frequency ;
           return frequency ;
         }
-        catch (std::exception& e) {
+        catch (std::exception& /*e*/) {
           continue ;
         }
       }

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -228,6 +228,68 @@ namespace xdp {
     return false ;
   }
 
+  double VPStaticDatabase::findClockRate(std::shared_ptr<xrt_core::device> device)
+  {
+    double defaultClockSpeed = 300.0 ;
+
+    // First, check the clock frequency topology
+    const clock_freq_topology* clockSection =
+      device->get_axlf_section<const clock_freq_topology*>(CLOCK_FREQ_TOPOLOGY);
+
+    if(clockSection) {
+      for(int32_t i = 0; i < clockSection->m_count; i++) {
+        const struct clock_freq* clk = &(clockSection->m_clock_freq[i]);
+        if(clk->m_type != CT_DATA) {
+          continue;
+        }
+        return clk->m_freq_Mhz ;
+      }
+    }
+
+    if (isEdge()) {
+      // On Edge, we can try to get the "DATA_CLK" from the embedded metadata
+      std::pair<const char*, size_t> metadataSection =
+        device->get_axlf_section(EMBEDDED_METADATA) ;
+      const char* rawXml = metadataSection.first ;
+      size_t xmlSize = metadataSection.second ;
+      if (rawXml == nullptr || xmlSize == 0)
+        return defaultClockSpeed ;
+
+      // Convert the raw character stream into a boost::property_tree
+      std::string xmlFile ;
+      xmlFile.assign(rawXml, xmlSize) ;
+      std::stringstream xmlStream ;
+      xmlStream << xmlFile ;
+      boost::property_tree::ptree xmlProject ;
+      boost::property_tree::read_xml(xmlStream, xmlProject) ;
+
+      // Dig in and find all of the kernel clocks
+      for (auto& clock : xmlProject.get_child("project.platform.device.core.kernelClocks")) {
+        if (clock.first != "clock")
+          continue ;
+
+        try {
+	  std::string port = clock.second.get<std::string>("<xmlattr>.port") ;
+          if (port != "DATA_CLK")
+            continue ;
+	  std::string freq = clock.second.get<std::string>("<xmlattr>.frequency") ;
+	  std::string freqNumeral = freq.substr(0, freq.find('M')) ;
+          double frequency = defaultClockSpeed ;
+	  std::stringstream convert ;
+          convert << freqNumeral ;
+          convert >> frequency ;
+          return frequency ;
+        }
+        catch (std::exception& e) {
+          continue ;
+        }
+      }
+    }
+
+    // We didn't find it in any section, so just assume 300 MHz for now
+    return defaultClockSpeed ;
+  }
+
   // This function is called whenever a device is loaded with an 
   //  xclbin.  It has to clear out any previous device information and
   //  reload our information.
@@ -267,20 +329,9 @@ namespace xdp {
     
     XclbinInfo* currentXclbin = new XclbinInfo() ;
     currentXclbin->uuid = device->get_xclbin_uuid() ;
+    currentXclbin->clockRateMHz = findClockRate(device) ;
 
-    const clock_freq_topology* clockSection = device->get_axlf_section<const clock_freq_topology*>(CLOCK_FREQ_TOPOLOGY);
 
-    if(clockSection) {
-      for(int32_t i = 0; i < clockSection->m_count; i++) {
-        const struct clock_freq* clk = &(clockSection->m_clock_freq[i]);
-        if(clk->m_type != CT_DATA) {
-          continue;
-        }
-        currentXclbin->clockRateMHz = clk->m_freq_Mhz ;
-      }
-    } else {
-      currentXclbin->clockRateMHz = 300;
-    }
     /* Configure AMs if context monitoring is supported
      * else disable alll AMs on this device
      */

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -636,6 +636,7 @@ class aie_cfg_tile
                        const struct debug_ip_data* debugIpData) ;
     void initializeTS2MM(DeviceInfo* devInfo,
                          const struct debug_ip_data* debugIpData) ;
+    double findClockRate(std::shared_ptr<xrt_core::device> device) ;
 
   public:
     VPStaticDatabase(VPDatabase* d) ;


### PR DESCRIPTION
For xclbins that do not have a clock_freq_topology section, we were assuming a device frequency of 300 MHz.  On Edge devices, this was not always accurate leading to a misalignment between host profiling events and device profiling events.

This pull request adds an additional check on the embedded_metadata section and uses it to find device clock speed.
