### PR TITLE
Issue 5546

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -121,6 +121,7 @@ struct cmdmem_info {
  * @ert_disable: remote scheduler is disabled or not
  * @cu_intr_cap: capbility of CU interrupt support
  * @cu_intr: CU or ERT interrupt. 1 for CU, 0 for ERT.
+ * @anon_client: driver own kds client used with driver generated command
  */
 struct kds_sched {
 	struct list_head	clients;
@@ -136,6 +137,7 @@ struct kds_sched {
 	u32			cu_intr;
 	struct cmdmem_info	cmdmem;
 	struct completion	comp;
+	struct kds_client      *anon_client;
 };
 
 int kds_init_sched(struct kds_sched *kds);
@@ -149,7 +151,6 @@ int kds_cfg_update(struct kds_sched *kds);
 int is_bad_state(struct kds_sched *kds);
 u32 kds_live_clients(struct kds_sched *kds, pid_t **plist);
 u32 kds_live_clients_nolock(struct kds_sched *kds, pid_t **plist);
-struct kds_client *kds_get_client(struct kds_sched *kds, pid_t pid);
 int kds_add_cu(struct kds_sched *kds, struct xrt_cu *xcu);
 int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu);
 int kds_get_cu_total(struct kds_sched *kds);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1238,25 +1238,6 @@ out:
 	return count;
 }
 
-struct kds_client *kds_get_client(struct kds_sched *kds, pid_t pid)
-{
-	struct kds_client *client = NULL;
-	struct kds_client *curr;
-
-	mutex_lock(&kds->lock);
-	if (list_empty(&kds->clients))
-		goto done;
-
-	list_for_each_entry(curr, &kds->clients, link) {
-		if (pid_nr(curr->pid) == pid)
-			client = curr;
-	}
-
-done:
-	mutex_unlock(&kds->lock);
-	return client;
-}
-
 /* User space execbuf command related functions below */
 void cfg_ecmd2xcmd(struct ert_configure_cmd *ecmd,
 		   struct kds_command *xcmd)


### PR DESCRIPTION
The std:thread is implemented by clone() syscall on Linux. The created thread would have a different PID number. When driver construct ERT configure command during xclbin download, it is not able to find the kds client with same PID. This is why it failed.
In this change, KDS scheduler would keep a anonymous client for all driver construct commands.

Fix #5546 