### PR TITLE
xclbinutil: Added index values to DTB partition bar entries.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionPartitionMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2020 Xilinx, Inc
+ * Copyright (C) 2018 - 2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -166,40 +166,6 @@ SchemaTransformUniversal_firmware( const boost::property_tree::ptree& _ptOrigina
 }
 
 /**
- * Helper method to transform a generic node
- * 
- * @param _ptOriginal The original firmware property tree
- * @param _ptTransformed The transform firmware property tree
- */
-void 
-SchemaTransformUniversal_pcie( const boost::property_tree::ptree& _ptOriginal,
-                               boost::property_tree::ptree & _ptTransformed)
-{
-  boost::property_tree::ptree ptEmpty;
-
-  // --- Bars ---
-  boost::property_tree::ptree ptBarOriginal;
-  ptBarOriginal = _ptOriginal.get_child("bars", ptEmpty);
-
-  if (ptBarOriginal.empty()) 
-    throw std::runtime_error("Error: pcie.bars[] list not found.");
-
-  boost::property_tree::ptree ptBarArray;
-  for (auto barEntryOrig : ptBarOriginal) {
-    boost::property_tree::ptree ptBarEntry;
-
-    SchemaTransform_nameValue("bar", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
-    SchemaTransform_nameValue("physical_function", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
-    SchemaTransform_nameValue("base_address", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
-    SchemaTransform_nameValue("range", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
-
-    ptBarArray.push_back(std::make_pair("", ptBarEntry));
-  }
-
-  _ptTransformed.add_child("bars", ptBarArray);
-}
-
-/**
  * Transform the schema version
  *
  * @param _ptOriginal The original version property tree
@@ -241,6 +207,42 @@ SchemaTransformUniversal_schema_version( const boost::property_tree::ptree& _ptO
 }
 
 // -- Transform to DTC schema functions ---------------------------------------
+
+/**
+ * Helper method to transform a generic node
+ * 
+ * @param _ptOriginal The original firmware property tree
+ * @param _ptTransformed The transform firmware property tree
+ */
+void 
+SchemaTransformToDTC_pcie( const boost::property_tree::ptree& _ptOriginal,
+                           boost::property_tree::ptree & _ptTransformed)
+{
+  boost::property_tree::ptree ptEmpty;
+
+  // --- Bars ---
+  boost::property_tree::ptree ptBarOriginal;
+  ptBarOriginal = _ptOriginal.get_child("bars", ptEmpty);
+
+  if (ptBarOriginal.empty()) 
+    throw std::runtime_error("Error: pcie.bars[] list not found.");
+
+  unsigned int count = 0;
+  boost::property_tree::ptree ptBarArray;
+  for (auto barEntryOrig : ptBarOriginal) {
+    boost::property_tree::ptree ptBarEntry;
+
+    SchemaTransform_nameValue("bar", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("physical_function", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("base_address", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("range", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+
+    ptBarArray.add_child(std::to_string(count++), ptBarEntry);
+  }
+
+  _ptTransformed.add_child("bars", ptBarArray);
+}
+
 void 
 SchemaTransformToDTC_interrupt_endpoint( const std::string _sEndPointName,
                                          const boost::property_tree::ptree& _ptOriginal,
@@ -477,7 +479,7 @@ SchemaTransformToDTC_root( const boost::property_tree::ptree & _ptOriginal,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "pcie", false /*required*/, 
-                           SchemaTransformUniversal_pcie,
+                           SchemaTransformToDTC_pcie,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "addressable_endpoints", false /*required*/, 
@@ -491,6 +493,41 @@ SchemaTransformToDTC_root( const boost::property_tree::ptree & _ptOriginal,
 
 
 // -- Transform to partition metadata schema functions -----------------------
+
+/**
+ * Helper method to transform a generic node
+ * 
+ * @param _ptOriginal The original firmware property tree
+ * @param _ptTransformed The transform firmware property tree
+ */
+void 
+SchemaTransformToPM_pcie( const boost::property_tree::ptree& _ptOriginal,
+                          boost::property_tree::ptree & _ptTransformed)
+{
+  boost::property_tree::ptree ptEmpty;
+
+  // --- Bars ---
+  boost::property_tree::ptree ptBarOriginal;
+  ptBarOriginal = _ptOriginal.get_child("bars", ptEmpty);
+
+  if (ptBarOriginal.empty()) 
+    throw std::runtime_error("Error: pcie.bars[] list not found.");
+
+  boost::property_tree::ptree ptBarArray;
+  for (auto barEntryOrig : ptBarOriginal) {
+    boost::property_tree::ptree ptBarEntry;
+
+    SchemaTransform_nameValue("bar", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("physical_function", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("base_address", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+    SchemaTransform_nameValue("range", "", true  /*required*/, barEntryOrig.second, ptBarEntry);
+
+    ptBarArray.push_back(std::make_pair("", ptBarEntry));
+  }
+
+  _ptTransformed.add_child("bars", ptBarArray);
+}
+
 
 void 
 SchemaTransformToPM_interrupt_endpoint( const boost::property_tree::ptree& _ptOriginal,
@@ -703,7 +740,7 @@ SchemaTransformToPM_root( const boost::property_tree::ptree & _ptOriginal,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "pcie", false /*required*/, 
-                           SchemaTransformUniversal_pcie,
+                           SchemaTransformToPM_pcie,
                            _ptOriginal, _ptTransformed);
 
   SchemaTransform_subNode( "addressable_endpoints", false /*required*/, 


### PR DESCRIPTION
The PARTITION_METADATA JSON pci bars entry is now converted from an JSON array:
```

        "pcie": {
            "bars": [
                {
                    "bar": "0x0",
                    "physical_function": "0x0",
                    "base_address": "0x0000020100000000",
                    "range": "0x0000000002000000"
                },
                {
                    "bar": "0x2",
                    "physical_function": "0x0",
                    "base_address": "0x0000020200000000",
                    "range": "0x0000000002000000"
                },
                {
                    "bar": "0x4",
                    "physical_function": "0x0",
                    "base_address": "0x0000020200000000",
                    "range": "0x0000000002000000"
                }
            ]
        },
```

To an DTB index set (internal representation):

```
        pcie {

                bars {

                        0 {
                                bar = <0x0>;
                                physical_function = <0x0>;
                                base_address = <0x201 0x0>;
                                range = <0x0 0x2000000>;
                        };

                        1 {
                                bar = <0x2>;
                                physical_function = <0x0>;
                                base_address = <0x202 0x0>;
                                range = <0x0 0x2000000>;
                        };

                        2 {
                                bar = <0x4>;
                                physical_function = <0x0>;
                                base_address = <0x202 0x0>;
                                range = <0x0 0x2000000>;
                        };
                };
        };
```
Note
When being written from "RAW" to "JSON", the index values are removed and is represented as an JSON array.