### PR TITLE
Add changes for parsing pci bar mappings in xsabin(firmware)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1429,6 +1429,8 @@ static void xclmgmt_remove(struct pci_dev *pdev)
 		vfree(lro->userpf_blob);
 	if (lro->core.blp_blob)
 		vfree(lro->core.blp_blob);
+	if (lro->core.bars)
+		kfree(lro->core.bars);
 
 	if (lro->preload_xclbin)
 		vfree(lro->preload_xclbin);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1127,6 +1127,9 @@ void xocl_userpf_remove(struct pci_dev *pdev)
 		vfree(xdev->ulp_blob);
 	mutex_destroy(&xdev->dev_lock);
 
+	if (xdev->core.bars)
+		kfree(xdev->core.bars);
+
 	pci_set_drvdata(pdev, NULL);
 	xocl_drvinst_free(hdl);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -536,6 +536,13 @@ struct xocl_work {
 	int			op;
 };
 
+#define NUM_PCI_BARS 6
+/* structure for holding pci bar mappings of CPM */
+struct pci_bars {
+        u64 base_addr;
+        u64 range;
+};
+
 #define SERIAL_NUM_LEN	32
 struct xocl_dev_core {
 	struct pci_dev		*pdev;
@@ -593,6 +600,11 @@ struct xocl_dev_core {
 	 */
 	int			ksize;
 	char			*kernels;
+
+	/*
+	 * Store information about pci bar mappings of CPM.
+	 */
+	struct pci_bars         *bars;
 	/*
 	 * u30 reset relies on working SC and SN info. SN is read and saved in
 	 * parent device so that even if for some reason the xmc is offline

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1504,7 +1504,7 @@ static int xocl_fdt_get_pci_addr(xdev_handle_t xdev_hdl)
                 if (!pfn) {
                         xocl_xdev_err(xdev_hdl, "failed to get physical_function of pci node");
                         ret = -EINVAL;
-			goto done;
+                        goto done;
                 }
                 if (be32_to_cpu(*pfn) != pf)
                         continue;
@@ -1513,13 +1513,13 @@ static int xocl_fdt_get_pci_addr(xdev_handle_t xdev_hdl)
                 if (!bar) {
                         xocl_xdev_err(xdev_hdl, "failed to get bar idx");
                         ret = -EINVAL;
-			goto done;
+                        goto done;
                 }
                 io_off = fdt_getprop(core->fdt_blob, offset, PROP_IO_OFFSET, NULL);
                 if (!io_off) {
                         xocl_xdev_err(xdev_hdl, "failed to get offset, range of pci node");
                         ret = -EINVAL;
-			goto done;
+                        goto done;
                 }
                 bar_idx = be32_to_cpu(*bar);
                 core->bars[bar_idx].base_addr = be64_to_cpu(io_off[0]);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -910,7 +910,7 @@ static bool get_userpf_info(void *fdt, int node, u32 pf)
 	offset = fdt_parent_offset(fdt, node);
 	val = fdt_get_name(fdt, offset, NULL);
 
-	if (!val || (strncmp(val, NODE_ENDPOINTS, strlen(NODE_PROPERTIES))
+	if (!val || (strncmp(val, NODE_ENDPOINTS, strlen(NODE_ENDPOINTS))
 			&& strncmp(val, NODE_BARS, strlen(NODE_BARS))))
 		return true;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -109,6 +109,8 @@
 #define NODE_RESERVED_PSMEM "ep_reserved_ps_mem"
 #define NODE_PS_RESET_CTRL "ep_reset_ps_00"
 #define NODE_ICAP_CONTROLLER "ep_iprog_ctrl_00"
+#define NODE_PCIE "pcie"
+#define NODE_BARS "bars"
 
 #define PROP_BARM_CTRL "axi_bram_ctrl"
 #define PROP_HWICAP "axi_hwicap"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -418,7 +418,7 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 	int retval = 0, i, bar_idx;
 	struct resource *res = NULL;
 	resource_size_t iostart;
-	u64 bar_start;
+	u64 bar_start, bar_end;
 
 	if (subdev->info.override_name)
 		snprintf(devname, sizeof(devname) - 1, "%s",
@@ -470,10 +470,13 @@ static int __xocl_subdev_construct(xdev_handle_t xdev_hdl,
 			 */
 			if(core->bars) {
 				bar_start = core->bars[bar_idx].base_addr;
-				if ((bar_start >> 32) == (res[i].start >> 32))
-					res[i].start ^= bar_start;
-				if ((bar_start >> 32) == (res[i].end >> 32))
-					res[i].end ^= bar_start;
+				bar_end = core->bars[bar_idx].base_addr +
+						core->bars[bar_idx].range - 1;
+				if((bar_start <= res[i].start) &&
+						(res[i].end <= bar_end)) {
+					res[i].start -= bar_start;
+					res[i].end -= bar_start;
+				}
 			}
 			iostart = pci_resource_start(core->pdev, bar_idx);
 			res[i].start += iostart;


### PR DESCRIPTION
> Added changes for parsing pci bar mappings using fdt parser
> Subdev resources with 64 bit offset is converted to 32 bit based on parsed bar mappings as pci expects offset from bar not complete address
> Experiments done on vck190_pcie flat shell by running pl vadd test case and things are working as expected