### PR TITLE
Add missing xrt::xclbin::get_mems

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -664,6 +664,13 @@ get_ip(const std::string& name) const
   return handle ? handle->get_ip(name) : xclbin::ip{};
 }
 
+std::vector<xclbin::mem>
+xclbin::
+get_mems() const
+{
+  return handle ? handle->get_mems() : std::vector<xclbin::mem>{};
+}
+
 std::string
 xclbin::
 get_xsa_name() const

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -546,7 +546,7 @@ public:
   get_ips() const;
 
   /**
-   * get_ip() - Get a list of IPs from the xclbin
+   * get_ip() - Get a specific IP from the xclbin
    *
    * @return
    *  A list of xrt::xclbin::ip objects from xclbin.
@@ -557,6 +557,19 @@ public:
   XCL_DRIVER_DLLESPEC
   ip
   get_ip(const std::string& name) const;
+
+  /**
+   * get_mems() - Get list of memory objects
+   *
+   * @return
+   * A list of xrt::xclbin::mem objects from xclbin
+   *
+   * The returned xrt::xclbin::mem objects are extracted from
+   * the xclbin.
+   */
+  XCL_DRIVER_DLLESPEC
+  std::vector<mem>
+  get_mems() const;
 
   /**
    * get_xsa_name() - Get Xilinx Support Archive (XSA) name of xclbin

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -38,6 +38,17 @@ usage()
 }
 
 std::ostream&
+operator << (std::ostream& ostr, const xrt::xclbin::mem& mem)
+{
+  ostr << "mem tag:        " << mem.get_tag() << "\n";
+  ostr << "mem used:       " << (mem.get_used() ? "true" : "false") << "\n";
+  ostr << "mem index:      " << mem.get_index() << "\n";
+  ostr << "mem size (kb):  0x" << std::hex << mem.get_size_kb() << std::dec << "\n";
+  ostr << "mem base addr:  0x" << std::hex << mem.get_base_address() << std::dec << "\n";
+  return ostr;
+}
+
+std::ostream&
 operator << (std::ostream& ostr, const xrt::xclbin::arg& arg)
 {
   ostr << "argument:       " << arg.get_name() << "\n";
@@ -100,6 +111,9 @@ run_cpp(const std::string& xclbin_fnm)
 
   for (auto& kernel : xclbin.get_kernels())
     std::cout << kernel << '\n';
+
+  for (auto& mem : xclbin.get_mems())
+    std::cout << mem << '\n';
 }
 
 void


### PR DESCRIPTION
Return memory objects extracted from mem_toplogy section in xclbin.