### PR TITLE
Error get last for xocl driver

### DIFF
--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -208,10 +208,10 @@ public:
   {
     //Code for new format; Binary array of error structs in sysfs
     try {
-      std::vector<char> buf = xrt_core::device_query<xrt_core::query::xocl_errors>(device);
+      auto buf = xrt_core::device_query<xrt_core::query::xocl_errors>(device);
       if (buf.empty())
         return;
-      const xcl_errors *errors_buf = reinterpret_cast<xcl_errors *>(buf.data());
+      auto errors_buf = reinterpret_cast<xcl_errors *>(buf.data());
       if (errors_buf->num_err <= 0)
         return;
       if (errors_buf->num_err > XCL_ERROR_CAPACITY)

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -24,6 +24,7 @@
 #include "native_profile.h"
 #include "device_int.h"
 #include "error_int.h"
+#include "core/include/xclerr_int.h"
 #include "core/common/error.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
@@ -205,6 +206,27 @@ class error_impl
 public:
   error_impl(const xrt_core::device* device, xrtErrorClass ecl)
   {
+    //Code for new format; Binary array of error structs in sysfs
+    try {
+      std::vector<char> buf = xrt_core::device_query<xrt_core::query::xocl_errors>(device);
+      if (buf.empty())
+        return;
+      const xcl_errors *errors_buf = reinterpret_cast<xcl_errors *>(buf.data());
+      if (errors_buf->num_err <= 0)
+        return;
+
+      for (int i = 0; i < errors_buf->num_err; i++) {
+        if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
+          continue;
+        m_errcode = XRT_ERROR_NUM(errors_buf->errors[i].err_code);
+        m_timestamp = errors_buf->errors[i].ts;
+      }
+      return;
+    } catch (const xrt_core::query::no_such_key&) {
+      // Ignoring for now. Check below for edge if not available
+      // query table of zocl doesn't have xocl_errors key
+    }
+    //Below code will be removed after zocl changes for new format
     auto errors = xrt_core::device_query<xrt_core::query::error>(device);
     for (auto& line : errors) {
       auto ect = xrt_core::query::error::to_value(line);

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -214,11 +214,13 @@ public:
       const xcl_errors *errors_buf = reinterpret_cast<xcl_errors *>(buf.data());
       if (errors_buf->num_err <= 0)
         return;
+      if (errors_buf->num_err > XCL_ERROR_CAPACITY)
+        return;
 
       for (int i = 0; i < errors_buf->num_err; i++) {
         if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
           continue;
-        m_errcode = XRT_ERROR_NUM(errors_buf->errors[i].err_code);
+        m_errcode = errors_buf->errors[i].err_code;
         m_timestamp = errors_buf->errors[i].ts;
       }
       return;

--- a/src/runtime_src/core/common/api/xrt_error.cpp
+++ b/src/runtime_src/core/common/api/xrt_error.cpp
@@ -211,18 +211,8 @@ public:
       auto buf = xrt_core::device_query<xrt_core::query::xocl_errors>(device);
       if (buf.empty())
         return;
-      auto errors_buf = reinterpret_cast<xcl_errors *>(buf.data());
-      if (errors_buf->num_err <= 0)
-        return;
-      if (errors_buf->num_err > XCL_ERROR_CAPACITY)
-        return;
-
-      for (int i = 0; i < errors_buf->num_err; i++) {
-        if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
-          continue;
-        m_errcode = errors_buf->errors[i].err_code;
-        m_timestamp = errors_buf->errors[i].ts;
-      }
+      auto ect = xrt_core::query::xocl_errors::to_value(buf, ecl);
+      std::tie(m_errcode, m_timestamp) = ect;
       return;
     } catch (const xrt_core::query::no_such_key&) {
       // Ignoring for now. Check below for edge if not available

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -4,6 +4,7 @@
  */
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "query_requests.h"
+#include "core/include/xclerr_int.h"
 #include <map>
 #include <string>
 
@@ -120,6 +121,49 @@ parse(const std::string& clock)
 
   auto clock_str = clock_map.find(clock);
   return clock_str != clock_map.end() ? clock_str->second : "N/A";
+}
+
+std::pair<uint64_t, uint64_t>
+xrt_core::query::xocl_errors::
+to_value(const std::vector<char>& buf, xrtErrorClass ecl)
+{
+  uint64_t errcode = 0;
+  uint64_t ts = 0;
+  if (buf.empty())
+    return {0, 0};
+  auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
+  if (errors_buf->num_err <= 0)
+    return {0, 0};
+  if (errors_buf->num_err > XCL_ERROR_CAPACITY)
+    throw xrt_core::system_error(EINVAL, "Invalid data in sysfs");
+
+  for (int i = errors_buf->num_err; i >= 0; i--) {
+    if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
+      continue;
+    errcode = errors_buf->errors[i].err_code;
+    ts = errors_buf->errors[i].ts;
+    break;
+  }
+  return {errcode, ts};
+}
+
+std::vector<xclErrorLast>
+xrt_core::query::xocl_errors::
+to_errors(const std::vector<char>& buf)
+{
+  if (buf.empty())
+    return {};
+  auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
+  if (errors_buf->num_err <= 0)
+    return {};
+  if (errors_buf->num_err > XCL_ERROR_CAPACITY)
+    throw xrt_core::system_error(EINVAL, "Invalid data in sysfs");
+
+  std::vector<xclErrorLast> errors;
+  for (int i = 0; i < errors_buf->num_err; i++)
+    errors.emplace_back(errors_buf->errors[i]);
+
+  return errors;
 }
   
 }} // query, xrt_core

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -127,24 +127,21 @@ std::pair<uint64_t, uint64_t>
 xrt_core::query::xocl_errors::
 to_value(const std::vector<char>& buf, xrtErrorClass ecl)
 {
-  uint64_t errcode = 0;
-  uint64_t ts = 0;
   if (buf.empty())
     return {0, 0};
+
   auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
   if (errors_buf->num_err <= 0)
     return {0, 0};
+
   if (errors_buf->num_err > XCL_ERROR_CAPACITY)
     throw xrt_core::system_error(EINVAL, "Invalid data in sysfs");
 
-  for (int i = errors_buf->num_err; i >= 0; i--) {
-    if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
-      continue;
-    errcode = errors_buf->errors[i].err_code;
-    ts = errors_buf->errors[i].ts;
-    break;
+  for (int i = errors_buf->num_err-1; i >= 0; i--) {
+    if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) == ecl)
+      return {errors_buf->errors[i].err_code, errors_buf->errors[i].ts};
   }
-  return {errcode, ts};
+  return {0, 0};
 }
 
 std::vector<xclErrorLast>

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -1085,46 +1085,14 @@ struct xocl_errors : request
   get(const device*) const = 0;
 
   // Parse sysfs line and from class get error code and timestamp
+  XRT_CORE_COMMON_EXPORT
   static std::pair<uint64_t, uint64_t>
-  to_value(const std::vector<char>& buf, xrtErrorClass ecl)
-  {
-    uint64_t errcode = 0;
-    uint64_t ts = 0;
-    if (buf.empty())
-      return std::make_pair(errcode, ts);
-    auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
-    if (errors_buf->num_err <= 0)
-      return std::make_pair(errcode, ts);
-    if (errors_buf->num_err > XCL_ERROR_CAPACITY)
-      return std::make_pair(errcode, ts);
-
-    for (int i = 0; i < errors_buf->num_err; i++) {
-      if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
-        continue;
-      errcode = errors_buf->errors[i].err_code;
-      ts = errors_buf->errors[i].ts;
-    }
-    return std::make_pair(errcode, ts);
-  }
+  to_value(const std::vector<char>& buf, xrtErrorClass ecl);
 
   // Parse sysfs raw data and get list of errors
+  XRT_CORE_COMMON_EXPORT
   static std::vector<xclErrorLast>
-  to_errors(const std::vector<char>& buf)
-  {
-    std::vector<xclErrorLast> errors;
-    if (buf.empty())
-      return errors;
-    auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
-    if (errors_buf->num_err <= 0)
-      return errors;
-    if (errors_buf->num_err > XCL_ERROR_CAPACITY)
-      return errors;
-
-    for (int i = 0; i < errors_buf->num_err; i++) {
-      errors.emplace_back(errors_buf->errors[i]);
-    }
-    return errors;
-  }
+  to_errors(const std::vector<char>& buf);
 };
 
 struct dna_serial_num : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -81,6 +81,7 @@ enum class key_type
   kds_cu_stat,
   kds_scu_stat,
   ps_kernel,
+  xocl_errors,
   xclbin_full,
 
   xmc_version,
@@ -1071,6 +1072,16 @@ struct error : request
     auto time = std::stoul(line.substr(pos));
     return std::make_pair(code, time);
   }
+};
+
+// Retrieve asynchronous xocl errors from xocl driver
+struct xocl_errors : request
+{
+  using result_type = std::vector<char>;
+  static const key_type key = key_type::xocl_errors;
+
+  virtual boost::any
+  get(const device*) const = 0;
 };
 
 struct dna_serial_num : request

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -17,6 +17,7 @@
 #ifndef xrt_core_common_query_requests_h
 #define xrt_core_common_query_requests_h
 
+#include "core/include/xclerr_int.h"
 #include "query.h"
 #include "error.h"
 #include "uuid.h"
@@ -1082,6 +1083,48 @@ struct xocl_errors : request
 
   virtual boost::any
   get(const device*) const = 0;
+
+  // Parse sysfs line and from class get error code and timestamp
+  static std::pair<uint64_t, uint64_t>
+  to_value(const std::vector<char>& buf, xrtErrorClass ecl)
+  {
+    uint64_t errcode = 0;
+    uint64_t ts = 0;
+    if (buf.empty())
+      return std::make_pair(errcode, ts);
+    auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
+    if (errors_buf->num_err <= 0)
+      return std::make_pair(errcode, ts);
+    if (errors_buf->num_err > XCL_ERROR_CAPACITY)
+      return std::make_pair(errcode, ts);
+
+    for (int i = 0; i < errors_buf->num_err; i++) {
+      if (XRT_ERROR_CLASS(errors_buf->errors[i].err_code) != ecl)
+        continue;
+      errcode = errors_buf->errors[i].err_code;
+      ts = errors_buf->errors[i].ts;
+    }
+    return std::make_pair(errcode, ts);
+  }
+
+  // Parse sysfs raw data and get list of errors
+  static std::vector<xclErrorLast>
+  to_errors(const std::vector<char>& buf)
+  {
+    std::vector<xclErrorLast> errors;
+    if (buf.empty())
+      return errors;
+    auto errors_buf = reinterpret_cast<const xcl_errors *>(buf.data());
+    if (errors_buf->num_err <= 0)
+      return errors;
+    if (errors_buf->num_err > XCL_ERROR_CAPACITY)
+      return errors;
+
+    for (int i = 0; i < errors_buf->num_err; i++) {
+      errors.emplace_back(errors_buf->errors[i]);
+    }
+    return errors;
+  }
 };
 
 struct dna_serial_num : request

--- a/src/runtime_src/core/include/xclerr_int.h
+++ b/src/runtime_src/core/include/xclerr_int.h
@@ -47,7 +47,7 @@
 
 #include "xrt_error_code.h"
 
-#define	XCL_ERROR_CAPACITY	16
+#define	XCL_ERROR_CAPACITY	32
 
 /**
  * struct xclErrorLast - Container for all last(latest) error records

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -78,18 +78,13 @@ static ssize_t xocl_errors_show(struct device *dev,
 {
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 	struct xcl_errors *err = xdev->core.errors;
-	int size = 0, i = 0;
+	int size = 0;
 	if (!err)
-		return sprintf(buf, "%s\n", "Error: Device errors not found");
+		return sprintf(buf, "%d%d, %s\n", 0, 0, "Error: Device errors not found");
 
-	size += sprintf(buf, "Num of xocl_errors: %d\n", err->num_err);
-	for (i = 0; i < err->num_err; i++) {
-		size += sprintf(buf + size, "Error# %d: PID: %d, Timestamp: %llu, Class: %llu, Module: %llu, Severity: %llu, Code: %llu\n", 
-			i, err->errors[i].pid, err->errors[i].ts, XRT_ERROR_CLASS(err->errors[i].err_code),
-			XRT_ERROR_MODULE(err->errors[i].err_code),
-			XRT_ERROR_SEVERITY(err->errors[i].err_code),
-			XRT_ERROR_NUM(err->errors[i].err_code));
-	}
+	size = sizeof(xcl_errors);
+
+	memcpy(buf, err, size);
 	return size;
 }
 static DEVICE_ATTR_RO(xocl_errors);

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -568,6 +568,7 @@ initialize_query_table()
   emplace_func0_request<query::kds_cu_stat,                  kds_cu_stat>();
   emplace_func0_request<query::kds_scu_stat,                 kds_scu_stat>();
   emplace_sysfs_get<query::ps_kernel>                        ("icap", "ps_kernel");
+  emplace_sysfs_get<query::xocl_errors>                       ("", "xocl_errors");
 
   emplace_func0_request<query::pcie_bdf,                     bdf>();
   emplace_func0_request<query::kds_cu_info,                  kds_cu_info>();


### PR DESCRIPTION
Adding error get last support for xocl driver side.
errors to be captured in sysfs node.
Format of sysfs node to be changed to binary for both xocl & zocl