### PR TITLE
CR-1107094: Adding xocl debug log to the run summary if enabled

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -51,8 +51,13 @@ namespace xdp {
 
   XDPPlugin::XDPPlugin() : db(VPDatabase::Instance())
   {
-    if ((db->getStaticInfo()).getApplicationStartTime() == 0)
+    if ((db->getStaticInfo()).getApplicationStartTime() == 0) {
       (db->getStaticInfo()).setApplicationStartTime(xrt_core::time_ns()) ;
+      // If we are the first plugin, check to see if we should add xocl.log
+      if (xrt_core::config::get_xocl_debug()) {
+        db->getStaticInfo().addOpenedFile(xrt_core::config::detail::get_string_value("Debug.xocl_log", "xocl.log"), "XOCL_EVENTS") ;
+      }
+    }
     is_write_thread_active = false;
   }
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -55,7 +55,10 @@ namespace xdp {
       (db->getStaticInfo()).setApplicationStartTime(xrt_core::time_ns()) ;
       // If we are the first plugin, check to see if we should add xocl.log
       if (xrt_core::config::get_xocl_debug()) {
-        db->getStaticInfo().addOpenedFile(xrt_core::config::detail::get_string_value("Debug.xocl_log", "xocl.log"), "XOCL_EVENTS") ;
+	std::string logFileName =
+          xrt_core::config::detail::get_string_value("Debug.xocl_log",
+                                                     "xocl.log") ;
+        db->getStaticInfo().addOpenedFile(logFileName, "XOCL_EVENTS") ;
       }
     }
     is_write_thread_active = false;


### PR DESCRIPTION
On the first XDP plugin creation, check if xocl.log is being generated and add it to the run summary.