### PR TITLE
CR-1101325: Improve profiling information on Native XRT profiling

### DIFF
--- a/src/runtime_src/core/common/api/native_profile.cpp
+++ b/src/runtime_src/core/common/api/native_profile.cpp
@@ -38,17 +38,18 @@ std::function<void (const char*, unsigned long long int)> function_start_cb ;
 std::function<void (const char*, unsigned long long int, unsigned long long int)> function_end_cb ;
 
 // Callbacks for individual functions to track start/stop and statistics
-std::function<void (const char*, unsigned long long int)> sync_start_cb ;
+  std::function<void (const char*, unsigned long long int, bool)> sync_start_cb ;
 std::function<void (const char*, unsigned long long int, unsigned long long int, bool, unsigned long long int)> sync_end_cb ;
   
 void register_functions(void* handle)
 {
-  using start_type    = void (*)(const char*, unsigned long long int) ;
-  using end_type      = void (*)(const char*, unsigned long long int,
-                                 unsigned long long int) ;
-  using end_sync_type = void (*)(const char*, unsigned long long int,
-                                 unsigned long long int, bool,
-                                 unsigned long long int) ;
+  using start_type      = void (*)(const char*, unsigned long long int) ;
+  using sync_start_type = void (*)(const char*, unsigned long long int, bool) ;
+  using end_type        = void (*)(const char*, unsigned long long int,
+                                   unsigned long long int) ;
+  using end_sync_type   = void (*)(const char*, unsigned long long int,
+                                   unsigned long long int, bool,
+                                   unsigned long long int) ;
 
   // Generic callbacks
   function_start_cb =
@@ -63,7 +64,7 @@ void register_functions(void* handle)
 
   // Sync callbacks
   sync_start_cb =
-    reinterpret_cast<start_type>(xrt_core::dlsym(handle, "native_sync_start")) ;
+    reinterpret_cast<sync_start_type>(xrt_core::dlsym(handle, "native_sync_start")) ;
   if (xrt_core::dlerror() != nullptr)
     sync_start_cb = nullptr ;
 
@@ -112,7 +113,7 @@ sync_logger(const char* function, bool w, size_t s)
 {
   if (sync_start_cb) {
     m_funcid = xrt_core::utils::issue_id() ;
-    sync_start_cb(m_fullname, m_funcid) ;
+    sync_start_cb(m_fullname, m_funcid, m_is_write) ;
   }
 }
 

--- a/src/runtime_src/xdp/profile/database/events/native_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/native_events.cpp
@@ -36,7 +36,7 @@ namespace xdp {
     fout << "," << functionName << "\n" ;
   }
 
-  void NativeAPICall::dumpSync(std::ofstream& fout, uint32_t bucket)
+  void NativeAPICall::dumpSync(std::ofstream& /*fout*/, uint32_t /*bucket*/)
   {
   }
 

--- a/src/runtime_src/xdp/profile/database/events/native_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/native_events.cpp
@@ -33,7 +33,35 @@ namespace xdp {
   void NativeAPICall::dump(std::ofstream& fout, uint32_t bucket)
   {
     VTFEvent::dump(fout, bucket) ;
-    fout << "," << functionName << std::endl ;
+    fout << "," << functionName << "\n" ;
+  }
+
+  void NativeAPICall::dumpSync(std::ofstream& fout, uint32_t bucket)
+  {
+  }
+
+  NativeSyncRead::NativeSyncRead(uint64_t s_id, double ts, uint64_t name,
+                                 uint64_t r) :
+    NativeAPICall(s_id, ts, name), readStr(r)
+  {
+  }
+
+  void NativeSyncRead::dumpSync(std::ofstream& fout, uint32_t bucket)
+  {
+    VTFEvent::dump(fout, bucket) ;
+    fout << "," << readStr << "\n" ;
+  }
+
+  NativeSyncWrite::NativeSyncWrite(uint64_t s_id, double ts, uint64_t name,
+                                   uint64_t w) :
+    NativeAPICall(s_id, ts, name), writeStr(w)
+  {
+  }
+
+  void NativeSyncWrite::dumpSync(std::ofstream& fout, uint32_t bucket)
+  {
+    VTFEvent::dump(fout, bucket) ;
+    fout << "," << writeStr << "\n" ;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/database/events/native_events.h
+++ b/src/runtime_src/xdp/profile/database/events/native_events.h
@@ -27,9 +27,41 @@ namespace xdp {
     XDP_EXPORT NativeAPICall(uint64_t s_id, double ts, uint64_t name) ;
     XDP_EXPORT ~NativeAPICall() ;
 
-    XDP_EXPORT virtual bool isNativeHostEvent() { return true ; } 
+    XDP_EXPORT virtual bool isNativeHostEvent() { return true ; }
+    XDP_EXPORT virtual bool isWrite() { return false ; }
+    XDP_EXPORT virtual bool isRead()  { return false ; }
 
     XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
+
+    // For printing out the event in a different bucket as a different
+    //  type of event, without having to store additional events in the database
+    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket);
+  } ;
+
+  class NativeSyncRead : public NativeAPICall
+  {
+  private:
+    uint64_t readStr ;
+  public:
+    XDP_EXPORT NativeSyncRead(uint64_t s_id, double ts, uint64_t name,
+                              uint64_t r) ;
+    XDP_EXPORT ~NativeSyncRead() = default ;
+
+    XDP_EXPORT virtual bool isRead() { return true ; }
+    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) ;
+  } ;
+
+  class NativeSyncWrite : public NativeAPICall
+  {
+  private:
+    uint64_t writeStr ;
+  public:
+    XDP_EXPORT NativeSyncWrite(uint64_t s_id, double ts, uint64_t name,
+                               uint64_t w) ;
+    XDP_EXPORT ~NativeSyncWrite() = default ;
+
+    XDP_EXPORT virtual bool isWrite() { return true ; }
+    XDP_EXPORT virtual void dumpSync(std::ofstream& fout, uint32_t bucket) ;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.h
@@ -26,7 +26,7 @@ extern "C"
 void native_function_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp) ;
 
 extern "C"
-void native_sync_start(const char* functionName, unsigned long long int functionID) ;
+void native_sync_start(const char* functionName, unsigned long long int functionID, bool isWrite) ;
 
 extern "C"
 void native_sync_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp, bool isWrite, unsigned long long int size);

--- a/src/runtime_src/xdp/profile/writer/native/native_writer.h
+++ b/src/runtime_src/xdp/profile/writer/native/native_writer.h
@@ -26,6 +26,10 @@ namespace xdp {
   private:
     NativeTraceWriter() = delete ;
 
+    const uint64_t APIBucket = 1 ;
+    const uint64_t readBucket = 2 ;
+    const uint64_t writeBucket = 3 ;
+
   protected:
     virtual void writeHeader() ;
     virtual void writeStructure() ;

--- a/src/runtime_src/xdp/profile/writer/native/native_writer.h
+++ b/src/runtime_src/xdp/profile/writer/native/native_writer.h
@@ -26,9 +26,9 @@ namespace xdp {
   private:
     NativeTraceWriter() = delete ;
 
-    const uint64_t APIBucket = 1 ;
-    const uint64_t readBucket = 2 ;
-    const uint64_t writeBucket = 3 ;
+    const uint32_t APIBucket = 1 ;
+    const uint32_t readBucket = 2 ;
+    const uint32_t writeBucket = 3 ;
 
   protected:
     virtual void writeHeader() ;


### PR DESCRIPTION
This change internally keeps track of xrt::bo::sync calls as either reads or writes and creates a more detailed trace view that explicitly shows when read/write transactions are happening on Native XRT applications.
