### PR TITLE
CR:1093523: Changing the name of the generated run summary file

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -844,7 +844,7 @@ namespace xdp {
 
     if (runSummary == nullptr)
     {
-      runSummary = new VPRunSummaryWriter("xclbin.run_summary", db) ;
+      runSummary = new VPRunSummaryWriter("xrt.run_summary", db) ;
     }
     runSummary->write(false) ;
   }


### PR DESCRIPTION
The run summary file generated by profiling should be more reflective of what was the source that generated it.  Hence this change, from xclbin.run_summary to xrt.run_summary.  Run summary files generated by other sources will now be easier to distinguish.