### PR TITLE
CR-1084972: Adding the absolute path of the run summary file to the run summary file itself

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -88,7 +88,6 @@ namespace xdp {
       auto value = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp) ;
       uint64_t timeMsec = value.count() ;
 
-
       std::string pathToFile = "" ;
 #ifdef _WIN32
       char buffer[MAX_PATH] ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_run_summary.cpp
@@ -23,6 +23,12 @@
 
 #define XDP_SOURCE
 
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "xdp/profile/writer/vp_base/vp_run_summary.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/static_info_database.h"
@@ -71,7 +77,7 @@ namespace xdp {
     {
       boost::property_tree::ptree ptSchema ;
       ptSchema.put("major", "1") ;
-      ptSchema.put("minor", "1") ;
+      ptSchema.put("minor", "2") ;
       ptSchema.put("patch", "0") ; 
       ptRunSummary.add_child("schema_version", ptSchema) ;
     }
@@ -82,7 +88,25 @@ namespace xdp {
       auto value = std::chrono::duration_cast<std::chrono::milliseconds>(timestamp) ;
       uint64_t timeMsec = value.count() ;
 
+
+      std::string pathToFile = "" ;
+#ifdef _WIN32
+      char buffer[MAX_PATH] ;
+      char* result = _getcwd(buffer, sizeof(buffer)) ;
+#else
+      char buffer[PATH_MAX] ;
+      char* result = getcwd(buffer, sizeof(buffer)) ;
+#endif
+      if (result != nullptr) {
+        pathToFile = buffer ;
+        pathToFile += separator ; // From base class
+        pathToFile += getcurrentFileName() ;
+      }
+
       boost::property_tree::ptree ptGeneration ;
+      if (pathToFile != "") {
+        ptGeneration.put("this_file", pathToFile) ;
+      }
       ptGeneration.put("source", "vp") ;
       ptGeneration.put("PID", std::to_string(pid)) ;
       ptGeneration.put("timestamp", std::to_string(timeMsec)) ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.h
@@ -41,8 +41,9 @@ namespace xdp {
 
     // The directory where all the files will be dumped
     std::string directory ;
+  protected:
     char separator ;
-
+  private:
     // The number of files created by this writer (in continuous offload)
     uint32_t fileNum ;
     static bool warnFileNum;


### PR DESCRIPTION
To support packaging and moving projects based on the run summary, this pull request adds a field to the generated run summary file that lists the absolute path to the file itself.  This also upgrades the minor version of the run summary that we generate.