### PR TITLE
Adding numpy dependency in xrtdeps.sh & installation

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -113,4 +113,7 @@ if [ "$mpd_active" = "active" ]; then
     systemctl start mpd > /dev/null 2>&1
 fi
 
+#install numpy as pyxrt depends on numpy
+pip3 install numpy
+
 exit 0

--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -58,7 +58,7 @@ if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
   endif()
 
   SET(CPACK_DEBIAN_AWS_PACKAGE_DEPENDS "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})")
-  SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-libopencl1 (>= 2.2.0), lsb-release, dkms (>= 2.2.0), udev, python3")
+  SET(CPACK_DEBIAN_XRT_PACKAGE_DEPENDS "ocl-icd-libopencl1 (>= 2.2.0), lsb-release, dkms (>= 2.2.0), udev, python3 , python3-pip")
 
   if (${XRT_DEV_COMPONENT} STREQUAL "xrt")
     # applications link with -luuid
@@ -116,9 +116,9 @@ elseif (${LINUX_FLAVOR} MATCHES "^(RedHat|CentOS|Amazon|Fedora|SUSE)")
   SET(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/local" "/usr/src" "/opt" "/etc/OpenCL" "/etc/OpenCL/vendors" "/usr/lib" "/usr/lib/pkgconfig" "/usr/lib64/pkgconfig" "/lib" "/lib/firmware")
   SET(CPACK_RPM_AWS_PACKAGE_REQUIRES "xrt >= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH}")
   if (${LINUX_FLAVOR} MATCHES "^(SUSE)")
-    SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd-devel >= 2.2, lsb-release, dkms >= 2.2.0, python3 >= 3.6")
+    SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd-devel >= 2.2, lsb-release, dkms >= 2.2.0, python3 >= 3.6 , python3-pip")
   else()
-    SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd >= 2.2, redhat-lsb-core, dkms >= 2.5.0, python3 >= 3.6")
+    SET(CPACK_RPM_XRT_PACKAGE_REQUIRES "ocl-icd >= 2.2, redhat-lsb-core, dkms >= 2.5.0, python3 >= 3.6 , python3-pip")
   endif()
 
   if (${XRT_DEV_COMPONENT} STREQUAL "xrt")

--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -565,6 +565,7 @@ install()
     # Install/upgrade pybind11 for building the XRT python bindings
     # We need 2.6.0 minimum version
     pip3 install -U pybind11
+    pip3 install -U numpy 
 }
 
 update_package_list


### PR DESCRIPTION
This change contains a fix for missing numpy depedency in both xrtdeps.sh and instllation