### PR TITLE
CR-1107336 workaround code in xdma driver for limiting channel to 2 for ES3 board

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -53,6 +53,7 @@ enum {
 	XOCL_DSAFLAG_VERSAL			= (1 << 11),
 	XOCL_DSAFLAG_MPSOC			= (1 << 12),
 	XOCL_DSAFLAG_CUSTOM_DTB                 = (1 << 13),
+	XOCL_DSAFLAG_VERSAL_ES3			= (1 << 14),
 };
 
 /* sysmon flags */
@@ -2977,7 +2978,15 @@ struct xocl_subdev_map {
 		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
 		.board_name = "vck5000"					\
 	}
-
+#define	XOCL_BOARD_VERSAL_USER_RAPTOR2_ES3				\
+	(struct xocl_board_private){					\
+		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
+			XOCL_DSAFLAG_VERSAL_ES3 |			\
+			XOCL_DSAFLAG_VERSAL,				\
+		.subdev_info = RES_USER_VERSAL_VSEC,			\
+		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
+		.board_name = "vck5000"					\
+	}
 #define	XOCL_BOARD_VERSAL_MGMT_RAPTOR2					\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_VERSAL |				\
@@ -3670,6 +3679,14 @@ struct xocl_subdev_map {
 	{ 0x10EE, 0x5045, PCI_ANY_ID,					\
 		.vbnv = "xilinx_vck5000-es1",				\
 		.priv_data = &XOCL_BOARD_VERSAL_USER_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5048, PCI_ANY_ID,					\
+		.vbnv = "xilinx_vck5000-es3",				\
+		.priv_data = &XOCL_BOARD_VERSAL_MGMT_RAPTOR2,		\
+		.type = XOCL_DSAMAP_RAPTOR2 },				\
+	{ 0x10EE, 0x5049, PCI_ANY_ID,					\
+		.vbnv = "xilinx_vck5000-es3",				\
+		.priv_data = &XOCL_BOARD_VERSAL_USER_RAPTOR2_ES3,	\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x6098, PCI_ANY_ID,					\
                 .vbnv = "xilinx_vck190",				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -481,6 +481,10 @@ static int xdma_probe(struct platform_device *pdev)
 		ret = -EIO;
 		goto failed;
 	}
+	if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
+		xocl_info(&pdev->dev, "VERSAL ES3, set to 2 channels");
+		xdma->channel = 2;
+	}
 
 	xdma->user_msix_table = devm_kzalloc(&pdev->dev,
 			xdma->max_user_intr *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -308,6 +308,9 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_DSA_IS_VERSAL(xdev)                \
 	(XDEV(xdev)->priv.flags & XOCL_DSAFLAG_VERSAL)
 
+#define XOCL_DSA_IS_VERSAL_ES3(xdev)                \
+	(XDEV(xdev)->priv.flags & XOCL_DSAFLAG_VERSAL_ES3)
+
 #define	XOCL_DEV_ID(pdev)			\
 	((pci_domain_nr(pdev->bus) << 16) |	\
 	PCI_DEVID(pdev->bus->number, pdev->devfn))


### PR DESCRIPTION
We have to apply workaround for setting max channel to 2 for ES3 boards only. The other type of boards will not be affected.

I have also filed another CR for removing this code out when we have V65 board.


https://jira.xilinx.com/browse/CR-1107335