### PR TITLE
Using existing property names for the new schema (bar mappings) in partition metadata for consistency

### DIFF
--- a/src/runtime_src/tools/xclbinutil/unittests/PartitionMetadata/partition_metadata_all.rtd
+++ b/src/runtime_src/tools/xclbinutil/unittests/PartitionMetadata/partition_metadata_all.rtd
@@ -13,21 +13,21 @@
         "pcie": {
             "bars": [
                 {
-                    "bar": "0x0",
-                    "physical_function": "0x0",
-                    "base_address": "0x0000020100000000",
+                    "pcie_base_address_register": "0x0",
+                    "pcie_physical_function": "0x0",
+                    "offset": "0x0000020100000000",
                     "range": "0x0000000002000000"
                 },
                 {
-                    "bar": "0x2",
-                    "physical_function": "0x0",
-                    "base_address": "0x0000020200000000",
+                    "pcie_base_address_register": "0x2",
+                    "pcie_physical_function": "0x0",
+                    "offset": "0x0000020200000000",
                     "range": "0x0000000002000000"
                 },
                 {
-                    "bar": "0x4",
-                    "physical_function": "0x0",
-                    "base_address": "0x0000020200000000",
+                    "pcie_base_address_register": "0x4",
+                    "pcie_physical_function": "0x0",
+                    "offset": "0x0000020200000000",
                     "range": "0x0000000002000000"
                 }
             ]


### PR DESCRIPTION
This fix contain following changes.

We already have pcie_physical_function property which represents pf . Renaming "physical_function" with "pcie_physical_function".
We already have pcie_base_address_register which represents bar index. Renaming "bar" with "pcie_base_address_register"
We have a reg property which represents offset and range. Using same here as well.