### PR TITLE
CR-1106526: Stop printing guidance rule if information doesn't exist

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -31,6 +31,8 @@ namespace {
 
   static void deviceExecTime(xdp::VPDatabase* db, std::ofstream& fout)
   {
+    if (!db->infoAvailable(xdp::info::opencl_counters)) return ;
+
     if (xdp::getFlowMode() == xdp::SW_EMU) {
       std::string deviceName =
         db->getStaticInfo().getSoftwareEmulationDeviceName();


### PR DESCRIPTION
The guidance rule "device execution time" depends on callbacks from the OpenCL level.  For applications that only have Native API interfaces, this information is missing but the guidance rule is still generated with 0 for the time.  This pull request prevents the guidance rule from being generated unless the OpenCL level information is available.