### PR TITLE
CR-1094835 : Need new xbutil to return non 0 if error happens

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -96,7 +96,7 @@ void  main_(int argc, char** argv,
     // Something bad happen with parsing our options
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     XBU::report_commands_help(_executable, _description, globalOptions, hiddenOptions, _subCmds);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
  
   // -- Enable/Disable helper "global" options
@@ -128,7 +128,7 @@ void  main_(int argc, char** argv,
   if ( !subCommand) {
     std::cerr << "ERROR: " << "Unknown command: '" << sCommand << "'" << std::endl;
     XBU::report_commands_help( _executable, _description, globalOptions, hiddenOptions, _subCmds);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // -- Prepare the data

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -344,13 +344,19 @@ XBUtilities::get_available_devices(bool inUserDomain)
     else {
       pt_dev.put("vbnv", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
       try { //1RP
-      pt_dev.put("id", xrt_core::query::rom_time_since_epoch::to_string(xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
-      } catch(...) {}
+        pt_dev.put("id", xrt_core::query::rom_time_since_epoch::to_string(xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
+      } catch(...) 
+      {
+        // The id wasn't added
+      }
+
       try { //2RP
         auto logic_uuids = xrt_core::device_query<xrt_core::query::logic_uuids>(device);
         if (!logic_uuids.empty())
           pt_dev.put("id", boost::str(boost::format("0x%s") % logic_uuids[0]));
-      } catch(...) {}
+      } catch(...) {
+        // The id wasn't added
+      }
     }
 
     pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device));

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -1,8 +1,8 @@
 /**
- * Copyright (C) 2020 Licensed under the Apache License, Version
- * 2.0 (the "License"). You may not use this file except in
- * compliance with the License. A copy of the License is located
- * at
+ * Copyright (C) 2020-2021 Licensed under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except
+ * in compliance with the License. A copy of the License is
+ * located at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -293,7 +293,7 @@ OO_Config::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check the options
@@ -311,14 +311,14 @@ OO_Config::execute(const SubCmdOptions& _options) const
         (m_retention != "DISABLE")) {
       std::cerr << "ERROR: Invalidate '--retention' option: " << m_retention << std::endl;
       printHelp();
-      return;
+      throw xrt_core::error(std::errc::operation_canceled);
     }
   }
 
   if (m_devices.empty() && !m_daemon)  {
     std::cerr << "ERROR: If the daemon is to be used (e.g., set to true) then a device must also be declared." << std::endl;
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // -- process option: device -----------------------------------------------
@@ -332,7 +332,7 @@ OO_Config::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification

--- a/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
@@ -90,7 +90,7 @@ OO_LoadConfig::execute(const SubCmdOptions& _options) const
   // -- process "device" option -----------------------------------------------
   if(m_devices.empty()) {
     std::cerr << "ERROR: Please specify a single device using --device option" << "\n\n";
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Collect all of the devices of interest
@@ -104,14 +104,14 @@ OO_LoadConfig::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification
   if(deviceCollection.size() != 1) {
     std::cerr << "ERROR: Please specify a single device. Multiple devices are not supported" << "\n\n";
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   std::shared_ptr<xrt_core::device>& workingDevice = deviceCollection[0];
@@ -120,15 +120,17 @@ OO_LoadConfig::execute(const SubCmdOptions& _options) const
   if (m_path.empty()) {
     std::cerr << "ERROR: Please specify an input file" << "\n\n";
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
+
   if (!boost::filesystem::exists(m_path)) {
     std::cerr << boost::format("ERROR: Input file does not exist: '%s'") % m_path << "\n\n";
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
+
   if(boost::filesystem::extension(m_path).compare(".ini") != 0) {
     std::cerr << boost::format("ERROR: Input file should be an INI file: '%s'") % m_path << "\n\n";
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   try {
@@ -137,7 +139,7 @@ OO_LoadConfig::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cout << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -112,7 +112,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
   } catch (const std::exception & e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
     printHelp(commonOptions, hiddenOptions, subOptionOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Find the subOption;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -57,7 +57,7 @@ flash_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string outp
  * [Device]
  * mailbox_channel_disable = 0x100
  * mailbox_channel_switch = 0
- * cahce_xclbin = 0
+ * cache_xclbin = 0
  */
 static void
 config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string output)
@@ -123,7 +123,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check to see if help was requested or no command was found
@@ -143,7 +143,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   if(devices.empty()) {
     std::cerr << "ERROR: Please specify a single device using --device option" << "\n\n";
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Collect all of the devices of interest
@@ -157,14 +157,14 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification
   if(deviceCollection.size() != 1) {
     std::cerr << "ERROR: Please specify a single device. Multiple devices are not supported" << "\n\n";
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   std::shared_ptr<xrt_core::device>& workingDevice = deviceCollection[0];
@@ -176,11 +176,11 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   if (output.empty()) {
     std::cerr << "ERROR: Please specify an output file using --output option" << "\n\n";
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   if (!output.empty() && boost::filesystem::exists(output)) {
     std::cerr << boost::format("Output file already exists: '%s'") % output << "\n\n";
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
     
   //decide the contents of the dump file
@@ -195,5 +195,5 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
 
   std::cerr << "ERROR: Please specify a valid option to determine the type of dump" << "\n\n";
   printHelp(commonOptions, hiddenOptions);
-
+  throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -137,7 +137,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check to see if help was requested or no command was found
@@ -161,7 +161,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification
@@ -183,7 +183,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   // Ask user for permission
   XBUtilities::sudo_or_throw("Root privileges are required to perform management resets");
   if(!XBU::can_proceed(XBU::getForce()))
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
 
   //perform reset actions
   for (const auto & dev : deviceCollection) {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xqspips.cpp
@@ -245,7 +245,7 @@ XQSPIPS_Flasher::XQSPIPS_Flasher(std::shared_ptr<xrt_core::device> dev)
     try{
         flash_base = xrt_core::device_query<xrt_core::query::flash_bar_offset>(mDev.get());
     } catch(...) { }
-	if (flash_base == 0)
+    if (flash_base == 0)
         flash_base = FLASH_BASE;
 
     // maybe initialized QSPI here

--- a/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
@@ -431,7 +431,7 @@ OO_AieRegRead::execute(const SubCmdOptions& _options) const
     std::cerr << "ERROR: " << e.what() << "\n\n";
 
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Exit if neither action or device specified
@@ -450,17 +450,22 @@ OO_AieRegRead::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
+  bool errorOccured = false;
   for (auto& device : deviceCollection) {
     try {
       uint32_t val = xrt_core::device_query<qr::aie_reg_read>(device, m_row, m_col, m_reg);
       std::cout << boost::format("Register %s Value of Row:%d Column:%d is 0x%08x\n") % m_reg.c_str() % m_row %  m_col % val;
     } catch (const std::exception& e){
       std::cerr << boost::format("ERROR: %s\n") % e.what();
+      errorOccured = true;
     }
   }
+
+  if (errorOccured)
+    throw xrt_core::error(std::errc::operation_canceled);
 
 }
 

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -74,7 +74,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
   catch (po::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   //-- Working variables
@@ -103,11 +103,11 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
   } catch (const xrt_core::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   catch (const std::runtime_error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   try {
@@ -116,7 +116,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
   }
   catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--address'\n") % m_baseAddress;
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   try {
@@ -125,7 +125,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
   }
   catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--size'\n") % m_sizeBytes;
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   XBU::verbose(boost::str(boost::format("Device: %s") % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(device))));
@@ -140,7 +140,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
     xrt_core::mem_read(device.get(), addr, size, m_outputFile);
   } catch(const xrt_core::error& e) {
     std::cerr << e.what() << std::endl;
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   std::cout << "Memory read succeeded" << std::endl;
 }

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -76,7 +76,7 @@ XBU::verbose("SubCommand option: read mem");
   catch (po::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   //-- Working variables
@@ -102,11 +102,11 @@ XBU::verbose("SubCommand option: read mem");
   } catch (const xrt_core::error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   catch (const std::runtime_error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   try {
@@ -115,7 +115,7 @@ XBU::verbose("SubCommand option: read mem");
   }
   catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--address'\n") % m_baseAddress;
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   try {
@@ -124,7 +124,7 @@ XBU::verbose("SubCommand option: read mem");
   }
   catch(const std::invalid_argument&) {
     std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--size'\n") % m_sizeBytes;
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   if(!m_fill.empty()) {
@@ -134,7 +134,7 @@ XBU::verbose("SubCommand option: read mem");
     }
     catch(const std::invalid_argument&) {
       std::cerr << boost::format("ERROR: '%s' is an invalid argument for '--fill'. Please specify a value between 0 and 255\n") % m_fill;
-      return;
+      throw xrt_core::error(std::errc::operation_canceled);
     }
   }
 

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -1,8 +1,8 @@
 /**
- * Copyright (C) 2020 Licensed under the Apache License, Version
- * 2.0 (the "License"). You may not use this file except in
- * compliance with the License. A copy of the License is located
- * at
+ * Copyright (C) 2020-2021 Licensed under the Apache License, 
+ * Version 2.0 (the "License"). You may not use this file except 
+ * in compliance with the License. A copy of the License is 
+ * located at 
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -298,18 +298,33 @@ OO_P2P::execute(const SubCmdOptions& _options) const
     std::cerr << "ERROR: " << e.what() << "\n\n";
 
     printHelp();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+  if (m_help) {
+    printHelp();
     return;
   }
 
-  // Exit if neither action or device specified
-  if(m_help || (m_action.empty() || m_devices.empty())) {
-    printHelp();
-    return;
+  // Validate the correct action value is used
+  try {
+     string2action(m_action);
+  } catch (const xrt_core::generic_error e) {
+    std::cerr << boost::format("ERROR: %s\n") % e.what();
+    throw xrt_core::error(std::errc::operation_canceled);
+  }
+
+
+  // Validate the correct action value is used
+  if (m_devices.empty()) {
+    std::cerr << boost::format("ERROR: A device needs to be specified.\n");
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Collect all of the devices of interest
   std::set<std::string> deviceNames;
   xrt_core::device_collection deviceCollection;
+
   for (const auto & deviceName : m_devices) 
     deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
   
@@ -318,7 +333,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -309,7 +309,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
   // Validate the correct action value is used
   try {
      string2action(m_action);
-  } catch (const xrt_core::generic_error e) {
+  } catch (const xrt_core::generic_error &e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -241,7 +241,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
         std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
       }
       std::cout << std::endl;
-      return;
+      throw xrt_core::error(std::errc::operation_canceled);
     }
   } catch (const xrt_core::error& e) {
     XBU::print_exception_and_throw_cancel(e);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -82,7 +82,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check to see if help was requested or no command was found
@@ -105,7 +105,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
       std::cout << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
     }
     std::cout << std::endl;
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Collect all of the devices of interest
@@ -119,7 +119,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification
@@ -139,7 +139,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   if (!xclbin.empty()) {
     std::ifstream stream(xclbin, std::ios::binary);
     if (!stream)
-      throw xrt_core::error(boost::str(boost::format("Could not open %s for reding") % xclbin));
+      throw xrt_core::error(boost::str(boost::format("Could not open %s for reading") % xclbin));
 
     stream.seekg(0,stream.end);
     size_t size = stream.tellg();
@@ -162,6 +162,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
     }
     return;
   }
+
   std::cout << "\nERROR: Missing program operation. No action taken.\n\n";
   printHelp(commonOptions, hiddenOptions);
+  throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -126,7 +126,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check to see if help was requested or no command was found
@@ -147,7 +147,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   } catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification
@@ -168,7 +168,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
 
   // Ask user for permission
   if(!XBU::can_proceed(XBU::getForce()))
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
 
   //perform reset actions
   for (const auto & dev : deviceCollection) {
@@ -184,7 +184,5 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
         % xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
     }
   }
-
-  return;
 }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1674,7 +1674,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check to see if help was requested or no command was found
@@ -1732,7 +1732,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
 
@@ -1746,7 +1746,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     XBU::collect_devices(deviceNames, true /*inUserDomain*/, deviceCollection);
   } catch (const std::runtime_error& e) {
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // enforce 1 device specification


### PR DESCRIPTION
Updated the code base to return non-zero values if an error occurs.   This is accomplished via throwing the exception `std::errc::operation_canceled` when the code needs to exit with an error code.

Work Done
---------
+ Updated various pieces of the code base to throw the throw the `std::errc::operation_canceled` exception
+ Refactored code to be more error friendly