### PR TITLE
Drop ERT_CMD_STATE_MAX as it is not useful

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -59,8 +59,7 @@ PYBIND11_MODULE(pyxrt, m) {
         .value("ERT_CMD_STATE_TIMEOUT", ert_cmd_state::ERT_CMD_STATE_TIMEOUT)
         .value("ERT_CMD_STATE_NORESPONSE", ert_cmd_state::ERT_CMD_STATE_NORESPONSE)
         .value("ERT_CMD_STATE_SKERROR", ert_cmd_state::ERT_CMD_STATE_SKERROR)
-        .value("ERT_CMD_STATE_SKCRASHED", ert_cmd_state::ERT_CMD_STATE_SKCRASHED)
-        .value("ERT_CMD_STATE_MAX", ert_cmd_state::ERT_CMD_STATE_MAX);
+        .value("ERT_CMD_STATE_SKCRASHED", ert_cmd_state::ERT_CMD_STATE_SKCRASHED);
 
     py::enum_<xrt::info::device>(m, "xrt_info_device", "Device feature and sensor information")
         .value("bdf", xrt::info::device::bdf)

--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -22,7 +22,7 @@ from utils_binding import *
 
 current_micro_time = lambda: int(round(time.time() * 1000000))
 
-DATASIZE = 1024*1024*16    #16 MB
+DATASIZE = int(1024*1024*16)    #16 MB
 
 def getThreshold(devhdl):
     threshold = 40000
@@ -93,7 +93,7 @@ def runKernel(opt):
             end = current_micro_time()
 
             usduration = end - start
-            limit = beats * (TYPESIZE / 8)
+            limit = beats * int(TYPESIZE / 8)
             output_bo1.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, limit, 0)
             output_bo2.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, limit, 0)
 
@@ -111,7 +111,7 @@ def runKernel(opt):
 
         dnsduration.append(usduration)
         dsduration.append(dnsduration[test]/1000000.0)
-        dbytes.append(reps*beats*(TYPESIZE / 8))
+        dbytes.append(reps*beats*int(TYPESIZE / 8))
         dmbytes.append(dbytes[test]/(1024 * 1024))
         bpersec.append(2.0*dbytes[test]/dsduration[test])
         mbpersec.append(2.0*bpersec[test]/(1024 * 1024))


### PR DESCRIPTION
Force int for integer division in 23_bandwidth.py