### PR TITLE
wait "enough" time for sw reset; check every 1 ms

### DIFF
--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -60,13 +60,17 @@ move_to_queue(struct kds_command *xcmd, struct list_head *dst_q, u32 *dst_len)
 static inline bool
 sw_reset_cu(struct xrt_cu *xcu)
 {
+	int time = 10 * 1000 * 1000;
 	xrt_cu_reset(xcu);
 
-	/* wait 100 ~ 150 micro seconds. Let's see if we need to
-	 * adjust this.
-	 */
-	usleep_range(100, 150);
-	if (!xrt_cu_reset_done(xcu)) {
+	do {
+		usleep_range(1000, 1500);
+		time -= 1000;
+		if (xrt_cu_reset_done(xcu))
+			break;
+	} while (time < 0);
+
+	if (time < 0) {
 		xcu_info(xcu, "CU(%d) Reset timeout", xcu->info.cu_idx);
 		return false;
 	}


### PR DESCRIPTION
In test case https://github.com/Xilinx/XRT/tree/master/tests/xrt/abort, we found out that CU reset time could be more than 10ms.

In this place, check if CU is reset in about 10 seconds, which we assume is enough.
Reported this long reset time issue to HLS, they might take more investigation.

This is not critical path when CU is running well. So, wait a long time here is okay.