### PR TITLE
CR-1101265 xbmgmt dump --force does not overwrite output file

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -178,7 +178,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
     printHelp(commonOptions, hiddenOptions);
     throw xrt_core::error(std::errc::operation_canceled);
   }
-  if (!output.empty() && boost::filesystem::exists(output)) {
+  if (!output.empty() && boost::filesystem::exists(output) && !XBU::getForce()) {
     std::cerr << boost::format("Output file already exists: '%s'") % output << "\n\n";
     throw xrt_core::error(std::errc::operation_canceled);
   }


### PR DESCRIPTION
Debug/opt/xilinx/xrt/bin/xbmgmt dump -c -d 0000:17:00.0 -o foo.ini --force

config has been dumped to foo.ini
