### PR TITLE
CR-1107616 xbutil examine --report platform --device not working as expected

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -33,18 +33,22 @@ add_static_region_info(const xrt_core::device* device, ptree_type& pt)
 
   static_region.add("vbnv", xrt_core::device_query<xq::rom_vbnv>(device));
 
+  std::vector<std::string> interface_uuids;
   try {
-    auto interface_uuids = xrt_core::device_query<xq::interface_uuids>(device);
+    interface_uuids = xrt_core::device_query<xq::interface_uuids>(device);
     interface_uuids.erase
       (std::remove_if(interface_uuids.begin(), interface_uuids.end(),
                       [](const std::string& s) {
                         return s.empty();
                       }), interface_uuids.end());
-    if (!interface_uuids.empty())
-      static_region.add("interface_uuid", xq::interface_uuids::to_uuid_upper_string(interface_uuids[0]));
   }
   catch (const xq::exception&) {
   }
+  
+  if (!interface_uuids.empty())
+    static_region.add("interface_uuid", xq::interface_uuids::to_uuid_upper_string(interface_uuids[0]));
+  else 
+    static_region.add("interface_uuid", (boost::format("0x%x") % xrt_core::device_query<xq::rom_time_since_epoch>(device)));
 
   try {
     static_region.add("jtag_idcode", xq::idcode::to_string(xrt_core::device_query<xq::idcode>(device)));


### PR DESCRIPTION
```
$ xbutil examine -r platform -d 65:00

-----------------------------------------------
1/1 [0000:65:00.1] : xilinx_u200_xdma_201830_2 
-----------------------------------------------
Platform                                       
  XSA Name               : xilinx_u200_xdma_201830_2 
  Platform UUID          : 0x5d1211e8                
  FPGA Name              : xcu200-fsgd2104-2-e       
  JTAG ID Code           : 0x14b37093                
  DDR Size               : 68719476736 Bytes         
  DDR Count              : 4                         
  Mig Calibrated         : true                      
  P2P Status             : disabled 
```