### PR TITLE
CR-1104794: Remove blank data transfer tables in the profile summary file

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1649,10 +1649,14 @@ namespace xdp {
     bool monitorsExist = false ;
     for (auto device : infos) {
       for (auto xclbin : device->getLoadedXclbins()) {
-        if (xclbin->aimList.size() > 0 || xclbin->asmList.size() > 0) {
-          monitorsExist = true ;
-          break ;
+        for (auto aim : xclbin->aimList) {
+          if (aim->cuIndex != -1) {
+            monitorsExist = true ;
+            break ;
+          }
+          // else a floating monitor or shell monitor not reported in this table
         }
+        if (monitorsExist) break ;
       }
       if (monitorsExist) break ;
     }
@@ -1777,10 +1781,14 @@ namespace xdp {
     bool monitorsExist = false ;
     for (auto device : infos) {
       for (auto xclbin : device->getLoadedXclbins()) {
-        if (xclbin->aimList.size() > 0 || xclbin->asmList.size() > 0) {
-          monitorsExist = true ;
-          break ;
+        for (auto aim : xclbin->aimList) {
+          if (aim->cuIndex != -1) {
+            monitorsExist = true ;
+            break ;
+          }
+          // else a floating monitor or shell monitor not reported in this table
         }
+        if (monitorsExist) break ;
       }
       if (monitorsExist) break ;
     }


### PR DESCRIPTION
Changing the prerequisite code for printing out data transfer tables to ignore shell and floating monitors.  Previously, designs on shells that had shell monitors were still printing out blank tables (table headers with no entries) for the kernel to global memory data transfer tables.