### PR TITLE
CR-1107683: Adding emulation files to the run summary when low overhead profiling trace is enabled

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -134,8 +134,6 @@ namespace xdp {
     VPWriter* writer = new LowOverheadTraceWriter("lop_trace.csv") ;
     writers.push_back(writer) ;
 
-    emulationSetup() ;
-
     (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
 
     // In order to avoid overhead later, preallocate the string table
@@ -156,6 +154,10 @@ namespace xdp {
   {
     if (VPDatabase::alive())
     {
+      // OpenCL could be running hardware emulation or software emulation,
+      //  so be sure to account for any peculiarities here
+      emulationSetup() ;
+
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
       XDPPlugin::endWrite(false);

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -70,8 +70,8 @@ namespace xdp {
 
   void OpenCLCountersProfilingPlugin::emulationSetup()
   {
-    XDPPlugin::emulationSetup() 
-;
+    XDPPlugin::emulationSetup() ;
+
     char* internalsSummary = getenv("VITIS_KERNEL_PROFILE_FILENAME") ;
     if (internalsSummary != nullptr) {
       (db->getStaticInfo()).addOpenedFile(internalsSummary, "KERNEL_PROFILE");


### PR DESCRIPTION
All OpenCL level profiling plugins must call emulationSetup in order to add any files generated by emulation processes (like the simulator) to the run summary file.  This must be done after the hardware emulation shim has set up environment variables pointing at this information.

This pull request moves the call to emulationSetup in the LOP plugin from the constructor to the destructor, where the environment variables will have been set and are accessible.
