### PR TITLE
windows: read correct pcie information field for link width

### DIFF
--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -731,7 +731,7 @@ struct info
     case key_type::pcie_express_lane_width_max:
       return static_cast<query::pcie_express_lane_width_max::result_type>(info.MaximumLinkWidth);
     case key_type::pcie_express_lane_width:
-      return static_cast<query::pcie_express_lane_width::result_type>(info.MaximumLinkWidth);
+      return static_cast<query::pcie_express_lane_width::result_type>(info.LinkWidth);
     default:
       throw unexpected_query_request_key(key);
     }

--- a/src/runtime_src/core/pcie/windows/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/shim.cpp
@@ -1382,16 +1382,16 @@ done:
   get_kds_custat(char* buffer, DWORD output_sz, int* size_ret)
   {
       XOCL_STAT_CLASS_ARGS statargs;
-      statargs.StatClass = XoclStatKdsCU;
+      statargs.StatClass = XoclStatKds;
       DWORD bytes = 0;
-      XOCL_KDS_CU_INFORMATION kds_cu;
+      XOCL_KDS_INFORMATION kds_cu;
 
       if (output_sz == 0) {
           //Retrieve CU count in this ioctl request
           auto status = DeviceIoControl(m_dev,
               IOCTL_XOCL_STAT,
               &statargs, sizeof(XOCL_STAT_CLASS_ARGS),
-              &kds_cu, sizeof(XOCL_KDS_CU_INFORMATION),
+              &kds_cu, sizeof(XOCL_KDS_INFORMATION),
               &bytes,
               nullptr);
 
@@ -1402,6 +1402,7 @@ done:
       }
 
       auto kds_cu2 = reinterpret_cast<XOCL_KDS_CU_INFORMATION*>(buffer);
+      statargs.StatClass = XoclStatKdsCU;
 	  auto status = DeviceIoControl(m_dev,
           IOCTL_XOCL_STAT,
           &statargs, sizeof(XOCL_STAT_CLASS_ARGS),


### PR DESCRIPTION
Small fix in reading xocl kds information.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>