### PR TITLE
Added an ini option to force download xclbin in both Edge & DC

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -708,7 +708,7 @@ get_flag_kds_sw_emu()
 // This flag is added to support force xclbin download eventhough same xclbin is already programmed.
 // This is required for aie reset/reinit in next run. Aie is not clean after first
 // run. We need to work with aie team to figureout a solution to reset/reinit AIE in second run.
-// This flag is used only in edge flow
+// This flag is enabled in both edge/dc flows
 inline bool
 get_force_program_xclbin()
 {

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -705,6 +705,17 @@ get_flag_kds_sw_emu()
   return value;
 }
 
+// This flag is added for force xclbin download eventhough it is already loaded.
+// This is required for resetting aie in next run. Aie is not clean after first
+// run. Will remove once we have some other solution to reset/reinit AIE
+// This flag is used only in edge flow
+inline bool
+get_force_program_xclbin()
+{
+  static bool value = detail::get_bool_value("Runtime.force_program_xclbin", false);
+  return value;
+}
+
 inline bool
 get_is_enable_prep_target()
 {

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -708,7 +708,7 @@ get_flag_kds_sw_emu()
 // This flag is added to support force xclbin download eventhough same xclbin is already programmed.
 // This is required for aie reset/reinit in next run. Aie is not clean after first
 // run. We need to work with aie team to figureout a solution to reset/reinit AIE in second run.
-// This flag is enabled in both edge/dc flows
+// This flow is enabled in both edge/dc
 inline bool
 get_force_program_xclbin()
 {

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -705,9 +705,9 @@ get_flag_kds_sw_emu()
   return value;
 }
 
-// This flag is added for force xclbin download eventhough it is already loaded.
-// This is required for resetting aie in next run. Aie is not clean after first
-// run. Will remove once we have some other solution to reset/reinit AIE
+// This flag is added to support force xclbin download eventhough same xclbin is already programmed.
+// This is required for aie reset/reinit in next run. Aie is not clean after first
+// run. We need to work with aie team to figureout a solution to reset/reinit AIE in second run.
 // This flag is used only in edge flow
 inline bool
 get_force_program_xclbin()

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -752,12 +752,10 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Check unique ID */
 	if (zocl_xclbin_same_uuid(zdev, &axlf_head.m_header.uuid)) {
-		if ( !(axlf_obj->za_flags & DRM_ZOCL_FORCE_PROGRAM) )
-		{
+		if (!(axlf_obj->za_flags & DRM_ZOCL_FORCE_PROGRAM)) {
 			if (is_aie_only(axlf)) {
 				write_unlock(&zdev->attr_rwlock);
-				ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin,
-				client);
+				ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin,client);
 				write_lock(&zdev->attr_rwlock);
 				if (ret)
 					DRM_WARN("read xclbin: fail to load AIE");
@@ -769,9 +767,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 				DRM_INFO("%s The XCLBIN already loaded", __func__);
 			}
 			goto out0;
-		}
-		else
-		{
+		} else {
 			// We come here if user sets force_xclbin_program
 			// option "true" in xrt.ini under [Runtime] section
 			DRM_WARN("%s The XCLBIN already loaded. Force xclbin download", __func__);
@@ -838,7 +834,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			goto out0;
 		}
 
-		if ( !(axlf_obj->za_flags & DRM_ZOCL_PLATFORM_PR) ) {
+		if (!(axlf_obj->za_flags & DRM_ZOCL_PLATFORM_PR)) {
 			DRM_INFO("disable partial bitstream download, "
 			    "axlf flags is %d", axlf_obj->za_flags);
 		} else {
@@ -873,7 +869,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			goto out0;
 
 		zocl_cache_xclbin(zdev, axlf, xclbin);
-	} else if ( (axlf_obj->za_flags & DRM_ZOCL_PLATFORM_FLAT) &&
+	} else if ((axlf_obj->za_flags & DRM_ZOCL_PLATFORM_FLAT) &&
 		   axlf_head.m_header.m_mode == XCLBIN_FLAT &&
 		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
 		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU_PR) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -755,7 +755,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 		if (!(axlf_obj->za_flags & DRM_ZOCL_FORCE_PROGRAM)) {
 			if (is_aie_only(axlf)) {
 				write_unlock(&zdev->attr_rwlock);
-				ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin,client);
+				ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin, client);
 				write_lock(&zdev->attr_rwlock);
 				if (ret)
 					DRM_WARN("read xclbin: fail to load AIE");

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -752,21 +752,30 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Check unique ID */
 	if (zocl_xclbin_same_uuid(zdev, &axlf_head.m_header.uuid)) {
-		if (is_aie_only(axlf)) {
-			write_unlock(&zdev->attr_rwlock);
-			ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin,
-			    client);
-			write_lock(&zdev->attr_rwlock);
-			if (ret)
-				DRM_WARN("read xclbin: fail to load AIE");
-			else {
-				zocl_create_aie(zdev, axlf, aie_res);
-				zocl_cache_xclbin(zdev, axlf, xclbin);
+		if ( !(axlf_obj->za_flags & DRM_ZOCL_FORCE_PROGRAM) )
+		{
+			if (is_aie_only(axlf)) {
+				write_unlock(&zdev->attr_rwlock);
+				ret = zocl_load_aie_only_pdi(zdev, axlf, xclbin,
+				client);
+				write_lock(&zdev->attr_rwlock);
+				if (ret)
+					DRM_WARN("read xclbin: fail to load AIE");
+				else {
+					zocl_create_aie(zdev, axlf, aie_res);
+					zocl_cache_xclbin(zdev, axlf, xclbin);
+				}
+			} else {
+				DRM_INFO("%s The XCLBIN already loaded", __func__);
 			}
-		} else {
-			DRM_INFO("%s The XCLBIN already loaded", __func__);
+			goto out0;
 		}
-		goto out0;
+		else
+		{
+			// We come here if user sets force_xclbin_program
+			// option "true" in xrt.ini under [Runtime] section
+			DRM_WARN("%s The XCLBIN already loaded. Force xclbin download", __func__);
+		}
 	}
 
 	if (kds_mode == 0) {
@@ -829,7 +838,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			goto out0;
 		}
 
-		if (axlf_obj->za_flags != DRM_ZOCL_PLATFORM_PR) {
+		if ( !(axlf_obj->za_flags & DRM_ZOCL_PLATFORM_PR) ) {
 			DRM_INFO("disable partial bitstream download, "
 			    "axlf flags is %d", axlf_obj->za_flags);
 		} else {
@@ -864,7 +873,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			goto out0;
 
 		zocl_cache_xclbin(zdev, axlf, xclbin);
-	} else if (axlf_obj->za_flags == DRM_ZOCL_PLATFORM_FLAT &&
+	} else if ( (axlf_obj->za_flags & DRM_ZOCL_PLATFORM_FLAT) &&
 		   axlf_head.m_header.m_mode == XCLBIN_FLAT &&
 		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU &&
 		   axlf_head.m_header.m_mode != XCLBIN_HW_EMU_PR) {

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -356,6 +356,7 @@ enum drm_zocl_axlf_flags {
 	DRM_ZOCL_PLATFORM_BASE		= 0,
 	DRM_ZOCL_PLATFORM_PR		= (1 << 0),
 	DRM_ZOCL_PLATFORM_FLAT		= (1 << 1),
+	DRM_ZOCL_FORCE_PROGRAM		= (1 << 2)
 };
 
 /**

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -513,6 +513,7 @@ xclLoadAxlf(const axlf *buffer)
   auto is_flat_platform = (buffer->m_header.m_mode == XCLBIN_FLAT ) ? true : false;
   auto is_pr_enabled = xrt_core::config::get_enable_pr(); //default value is true
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
+  auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
 
   if (is_pr_platform && is_pr_enabled)
     flags = DRM_ZOCL_PLATFORM_PR;
@@ -525,6 +526,11 @@ xclLoadAxlf(const axlf *buffer)
    */
   else if (is_flat_platform && is_flat_enabled)
     flags = DRM_ZOCL_PLATFORM_FLAT;
+
+  if(force_program)
+  {
+    flags = flags | DRM_ZOCL_FORCE_PROGRAM;
+  }
 #endif
 
     drm_zocl_axlf axlf_obj = {

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -527,8 +527,7 @@ xclLoadAxlf(const axlf *buffer)
   else if (is_flat_platform && is_flat_enabled)
     flags = DRM_ZOCL_PLATFORM_FLAT;
 
-  if(force_program)
-  {
+  if (force_program) {
     flags = flags | DRM_ZOCL_FORCE_PROGRAM;
   }
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -438,11 +438,11 @@ enum drm_xocl_axlf_flags {
  * @flags:	flags passed while programming xclbin
  */
 struct drm_xocl_axlf {
-	struct axlf 		*xclbin;
+	struct axlf		*xclbin;
 	int			 ksize;
 	char			*kernels;
 	struct drm_xocl_kds	 kds_cfg;
-	uint32_t          	 flags;
+	uint32_t		 flags;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -418,6 +418,14 @@ struct drm_xocl_kds {
 	uint32_t unused:25;
 };
 
+/*
+ * enum drm_xocl_axlf_flags - used for axlf programming
+ */
+enum drm_xocl_axlf_flags {
+	XOCL_AXLF_BASE		        = 0,
+	XOCL_AXLF_FORCE_PROGRAM		= (1 << 0)
+};
+
 /**
  * struct drm_xocl_axlf - load xclbin (AXLF) device image
  * used with DRM_IOCTL_XOCL_READ_AXLF ioctl
@@ -426,12 +434,15 @@ struct drm_xocl_kds {
  * @xclbin:	Pointer to user's xclbin structure in memory
  * @ksize:	size of kernels in bytes
  * @kernels:	pointer of argument array
+ * @kds_cfg:	kds configuration
+ * @flags:	flags passed while programming xclbin
  */
 struct drm_xocl_axlf {
-	struct axlf		*xclbin;
-	int			 ksize;
-	char			*kernels;
-	struct drm_xocl_kds	 kds_cfg;
+	struct axlf		        *xclbin;
+	int			              ksize;
+	char			            *kernels;
+	struct drm_xocl_kds	  kds_cfg;
+	uint32_t              flags;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -439,10 +439,10 @@ enum drm_xocl_axlf_flags {
  */
 struct drm_xocl_axlf {
 	struct axlf 		*xclbin;
-	int			ksize;
+	int			 ksize;
 	char			*kernels;
-	struct drm_xocl_kds	kds_cfg;
-	uint32_t          	flags;
+	struct drm_xocl_kds	 kds_cfg;
+	uint32_t          	 flags;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_ioctl.h
@@ -438,11 +438,11 @@ enum drm_xocl_axlf_flags {
  * @flags:	flags passed while programming xclbin
  */
 struct drm_xocl_axlf {
-	struct axlf		        *xclbin;
-	int			              ksize;
-	char			            *kernels;
-	struct drm_xocl_kds	  kds_cfg;
-	uint32_t              flags;
+	struct axlf 		*xclbin;
+	int			ksize;
+	char			*kernels;
+	struct drm_xocl_kds	kds_cfg;
+	uint32_t          	flags;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -406,8 +406,16 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		}
 	}
 
-	if (xclbin_downloaded(xdev, &bin_obj.m_header.uuid))
-		goto done;
+	//
+	if (xclbin_downloaded(xdev, &bin_obj.m_header.uuid)) {
+		if ((axlf_ptr->flags & XOCL_AXLF_FORCE_PROGRAM)) {
+			// We come here if user sets force_xclbin_program
+			// option "true" in xrt.ini under [Runtime] section
+			DRM_WARN("%s Force xclbin download", __func__);
+		} else {
+			goto done;
+		}
+	}
 
 	/*
 	 * Support for multiple processes

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1355,7 +1355,13 @@ int shim::xclLoadAxlf(const axlf *buffer)
 {
     xrt_logmsg(XRT_INFO, "%s, buffer: %s", __func__, buffer);
     drm_xocl_axlf axlf_obj = {const_cast<axlf *>(buffer), 0};
+    unsigned int flags = XOCL_AXLF_BASE;
     int off = 0;
+
+    auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
+    if(force_program) {
+        axlf_obj.flags = flags | XOCL_AXLF_FORCE_PROGRAM;
+    }
 
     auto kernels = xrt_core::xclbin::get_kernels(buffer);
     /* Calculate size of kernels */


### PR DESCRIPTION
This change is to support programming xclbin forcefully in second run thru an ini option eventhough it is already programmed. 

This is required in AIE cases as first run leaves AIE in some intermediate state. We need to force download xclbin to reset/reinit the AIE again.

Default value of this option is "false".