### PR TITLE
CR-1106228: removed AR number and xbutil command from the driver messages

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/clock_wiz.c
@@ -1100,9 +1100,7 @@ static int clock_wiz_status_check(struct platform_device *pdev, bool *latched)
 		ucs_status_ch1 = (struct ucs_control_status_ch1 *)&status;
 		if (ucs_status_ch1->shutdown_clocks_latched) {
 			CLOCK_W_ERR(clock_w, "Critical temperature or power event, "
-			    "kernel clocks have been stopped, run "
-			    "'xbutil validate -q' to continue. "
-			    "See AR 73398 for more details.");
+			    "kernel clocks have been stopped.");
 			/* explicitly indicate reset should be latched */
 			*latched = true;
 		} else if (ucs_status_ch1->clock_throttling_average > CLK_MAX_VALUE) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -4394,9 +4394,7 @@ static void clock_status_check(struct platform_device *pdev, bool *latched)
 		status = READ_RUNTIME_CS(xmc, XMC_CLOCK_SCALING_CLOCK_STATUS_REG);
 		if (status & 0x1) {
 			xocl_err(&pdev->dev, "Critical temperature event, "
-					"kernel clocks have been stopped, run "
-					"'xbutil validate -q' to continue. "
-					"See AR 73398 for more details.");
+					"kernel clocks have been stopped.");
 			/* explicitly indicate reset should be latched */
 			*latched = true;
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -4179,9 +4179,7 @@ static void clock_status_check(struct platform_device *pdev, bool *latched)
 
 		if (status & XMC_CLOCK_SCALING_CLOCK_STATUS_SHUTDOWN) {
 			xocl_err(&pdev->dev, "Critical temperature event, "
-					"kernel clocks have been stopped, run "
-					"'xbutil validate -q' to continue. "
-					"See AR 73398 for more details.");
+					"kernel clocks have been stopped.");
 			/* explicitly indicate reset should be latched */
 			*latched = true;
 		}


### PR DESCRIPTION
As decided in PRT removing AR number and xbutil commands from dmesg. CR https://jira.xilinx.com/browse/CR-1106228