### PR TITLE
CR-1103150: Changed the page names as per suggestion from marketing 

### DIFF
--- a/src/runtime_src/doc/toc/xbmgmt.rst
+++ b/src/runtime_src/doc/toc/xbmgmt.rst
@@ -4,8 +4,8 @@
    comment:: SPDX-License-Identifier: Apache-2.0
    comment:: Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 
-xbmgmt
-------
+xbmgmt (Legacy)
+---------------
 
 Xilinx® Board Management (xbmgmt) utility is a standalone command line tool that is included
 with the XRT installation package. The ``xbmgmt`` command supports both Alveo Data Center 

--- a/src/runtime_src/doc/toc/xbmgmt2.rst
+++ b/src/runtime_src/doc/toc/xbmgmt2.rst
@@ -4,8 +4,8 @@
    comment:: SPDX-License-Identifier: Apache-2.0
    comment:: Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 
-xbmgmt (Next Generation)
-========================
+xbmgmt
+======
 
 This document describes the new next-generation ``xbmgmt`` commands. These new commands are default from 21.1 release.   
 

--- a/src/runtime_src/doc/toc/xbtools_map.rst
+++ b/src/runtime_src/doc/toc/xbtools_map.rst
@@ -4,8 +4,8 @@
    comment:: SPDX-License-Identifier: Apache-2.0
    comment:: Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 
-Legacy to new map
-*****************
+Utility Migration Guide 
+***********************
 
 This document maps the legacy ``xbutil``/``xbmgmt`` commands to the new ``xbutil``/``xbmgmt`` commands. It lists out the new ``xbutil``/``xbmgmt`` calls that replace the existing calls. A few points: 
 

--- a/src/runtime_src/doc/toc/xbutil.rst
+++ b/src/runtime_src/doc/toc/xbutil.rst
@@ -4,8 +4,8 @@
    comment:: SPDX-License-Identifier: Apache-2.0
    comment:: Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 
-xbutil
-------
+xbutil (Legacy)
+---------------
 
 The Xilinx® Board Utility (xbutil) is a standalone command line utility that is included with the
 XRT installation package. The ``xbutil`` command supports both Alveo Data Center accelerator cards 

--- a/src/runtime_src/doc/toc/xbutil2.rst
+++ b/src/runtime_src/doc/toc/xbutil2.rst
@@ -5,8 +5,8 @@
    comment:: Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 
 
-xbutil (Next Generation)
-========================
+xbutil
+======
 
 This document describes the new next-generation ``xbutil`` commands. These new commands are default from 21.1 release.   
 


### PR DESCRIPTION
As per suggestion from CR-1103150, page name changes are as below

 Legacy to new map -> Utility Migration Guide

xbuilt                                   -> xbutil (Legacy)

xbmgmt                              -> xbmgmt (Legacy)

xbuilt (Next Generation)      -> xbuilt

xbmgmt (Next Generation) -> xbmgmt

 