### PR TITLE
use AIE FAL to report resource utilization

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -348,7 +348,7 @@ get_aie_profile_core_metrics()
 inline std::string
 get_aie_profile_memory_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_profile_memory_metrics", "dma_locks");
+  static std::string value = detail::get_string_value("Debug.aie_profile_memory_metrics", "conflicts");
   return value;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -265,7 +265,8 @@ namespace xdp {
       std::string modType = isCore ? "core" : "memory";
       msg << "Only " << numFreeCtr << " out of " << numTotalEvents
           << " metrics were available for aie "
-          << modType <<  " module profiling due to resource constraints."
+          << modType <<  " module profiling due to resource constraints. "
+          << "AIE profiling uses performance counters which could be taken up by aie trace, ecc etc."
           << std::endl;
 
       msg << "Available metrics : ";

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -266,7 +266,7 @@ namespace xdp {
       msg << "Only " << numFreeCtr << " out of " << numTotalEvents
           << " metrics were available for aie "
           << modType <<  " module profiling due to resource constraints. "
-          << "AIE profiling uses performance counters which could be taken up by aie trace, ecc etc."
+          << "AIE profiling uses performance counters which could be already used by AIE trace, ECC, etc."
           << std::endl;
 
       msg << "Available metrics : ";

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
@@ -27,6 +27,7 @@
 #include "xdp/config.h"
 
 #include "core/common/device.h"
+#include "core/edge/common/aie_parser.h"
 #include "xaiefal/xaiefal.hpp"
 
 extern "C" {
@@ -34,6 +35,8 @@ extern "C" {
 }
 
 namespace xdp {
+
+  using tile_type = xrt_core::edge::aie::tile_type;
 
   class AIEProfilingPlugin : public XDPPlugin
   {
@@ -49,6 +52,13 @@ namespace xdp {
   private:
     void getPollingInterval();
     bool setMetrics(uint64_t deviceId, void* handle);
+
+    // Find minimum number of counters that are available across all tiles
+    uint32_t getNumFreeCtr(xaiefal::XAieDev* aieDevice,
+                            const std::vector<tile_type>& tiles,
+                            bool isCore,
+                            const std::string& metricSet);
+    void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
 
     void pollAIECounters(uint32_t index, void* handle);
     void endPoll();
@@ -66,6 +76,9 @@ namespace xdp {
     std::map<std::string, std::vector<XAie_Events>> mCoreStartEvents;
     std::map<std::string, std::vector<XAie_Events>> mCoreEndEvents;
     std::map<std::string, std::vector<int>> broadcastCoreConfig;
+
+    std::map<std::string, std::vector<std::string>> mCoreEventStrings;
+    std::map<std::string, std::vector<std::string>> mMemoryEventStrings;
 
     std::set<std::string> mMemoryMetricSets;
     std::map<std::string, std::vector<XAie_Events>> mMemoryStartEvents;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.h
@@ -58,7 +58,7 @@ namespace xdp {
                             const std::vector<tile_type>& tiles,
                             bool isCore,
                             const std::string& metricSet);
-    void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
+    void printTileModStats(xaiefal::XAieDev* aieDevice, const tile_type& tile, bool isCore);
 
     void pollAIECounters(uint32_t index, void* handle);
     void endPoll();

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -201,36 +201,67 @@ namespace xdp {
     auto stats = aieDevice->getRscStat(XAIEDEV_DEFAULT_GROUP_AVAIL);
     uint32_t available = 0;
     uint32_t required = 0;
+    std::stringstream msg;
 
     // Core Module perf counters
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
     required = coreCounterStartEvents.size();
-    if (available < required) return false;
+    if (available < required) {
+      msg << "Available core module performance counters : " << available << std::endl
+          << "Required core module performance counters : "  << required << std::endl;
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return false;
+    }
 
     // Core Module trace slots
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
     required = coreCounterStartEvents.size() + coreEventSets[metricSet].size();
-    if (available < required) return false;
+    if (available < required) {
+      msg << "Available core module trace slots : " << available << std::endl
+          << "Required core module trace slots : "  << required << std::endl;
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return false;
+    }
 
     // Core Module broadcasts. 2 events for starting/ending trace
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
     required = memoryEventSets[metricSet].size() + 2;
-    if (available < required) return false;
+    if (available < required) {
+      msg << "Available core module broadcast channels : " << available << std::endl
+          << "Required core module broadcast channels : "  << required << std::endl;
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return false;
+    }
 
    // Memory Module perf counters
     available = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
     required = memoryCounterStartEvents.size();
-    if (available < required) return false;
+    if (available < required) {
+      msg << "Available memory module performance counters : " << available << std::endl
+          << "Required memory module performance counters : "  << required << std::endl;
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return false;
+    }
 
     // Memory Module trace slots
     available = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
     required = memoryCounterStartEvents.size() + memoryEventSets[metricSet].size();
-    if (available < required) return false;
+    if (available < required) {
+      msg << "Available memory module trace slots : " << available << std::endl
+          << "Required memory module trace slots : "  << required << std::endl;
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return false;
+    }
 
     // Memory Module broadcasts. 2 events for starting/ending trace
     available = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
     required = memoryEventSets[metricSet].size() + 2;
-    if (available < required) return false;
+    if (available < required) {
+      msg << "Available memory module broadcast channels : " << available << std::endl
+          << "Required memory module broadcast channels : "  << required << std::endl;
+      xrt_core::message::send(severity_level::info, "XRT", msg.str());
+      return false;
+    }
 
     return true;
   }
@@ -240,6 +271,7 @@ namespace xdp {
     auto col = tile.col;
     auto row = tile.row + 1;
     auto loc = XAie_TileLoc(col, row);
+    std::stringstream msg;
 
     const std::string groups[3] = {
       XAIEDEV_DEFAULT_GROUP_GENERIC,
@@ -247,30 +279,31 @@ namespace xdp {
       XAIEDEV_DEFAULT_GROUP_AVAIL
     };
 
-    std::cout << "Stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
+    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
     for (auto&g : groups) {
       auto stats = aieDevice->getRscStat(g);
       auto pc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
       auto ts = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
       auto bc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
-      std::cout << "Resource Group : " << std::left <<  std::setw(10) << g << " "
-                << "Performance Counters : " << pc << " "
-                << "Trace Slots : " << ts << " "
-                << "Broadcast Channels : " << bc << " "
-                << std::endl;
+      msg << "Resource Group : " << std::left <<  std::setw(10) << g << " "
+          << "Performance Counters : " << pc << " "
+          << "Trace Slots : " << ts << " "
+          << "Broadcast Channels : " << bc << " "
+          << std::endl;
     }
-    std::cout << "Stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
+    msg << "Resource usage stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
     for (auto&g : groups) {
     auto stats = aieDevice->getRscStat(g);
     auto pc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
     auto ts = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
     auto bc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
-    std::cout << "Resource Group : "  << std::left <<  std::setw(10) << g << " "
-              << "Performance Counters : " << pc << " "
-              << "Trace Slots : " << ts << " "
-              << "Broadcast Channels : " << bc << " "
-              << std::endl;
+    msg << "Resource Group : "  << std::left <<  std::setw(10) << g << " "
+        << "Performance Counters : " << pc << " "
+        << "Trace Slots : " << ts << " "
+        << "Broadcast Channels : " << bc << " "
+        << std::endl;
     }
+    xrt_core::message::send(severity_level::info, "XRT", msg.str());
   }
 
   // Configure all resources necessary for trace control and events

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -71,7 +71,6 @@ namespace {
 
 namespace xdp {
   using severity_level = xrt_core::message::severity_level;
-  using tile_type = xrt_core::edge::aie::tile_type;
   using module_type = xrt_core::edge::aie::module_type;
 
   AieTracePlugin::AieTracePlugin()
@@ -197,6 +196,83 @@ namespace xdp {
     return ((tile1.col == tile2.col) && (tile1.row == tile2.row));
   }
 
+  bool AieTracePlugin::tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc, const std::string& metricSet)
+  {
+    auto stats = aieDevice->getRscStat(XAIEDEV_DEFAULT_GROUP_AVAIL);
+    uint32_t available = 0;
+    uint32_t required = 0;
+
+    // Core Module perf counters
+    available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
+    required = coreCounterStartEvents.size();
+    if (available < required) return false;
+
+    // Core Module trace slots
+    available = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+    required = coreCounterStartEvents.size() + coreEventSets[metricSet].size();
+    if (available < required) return false;
+
+    // Core Module broadcasts. 2 events for starting/ending trace
+    available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
+    required = memoryEventSets[metricSet].size() + 2;
+    if (available < required) return false;
+
+   // Memory Module perf counters
+    available = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
+    required = memoryCounterStartEvents.size();
+    if (available < required) return false;
+
+    // Memory Module trace slots
+    available = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+    required = memoryCounterStartEvents.size() + memoryEventSets[metricSet].size();
+    if (available < required) return false;
+
+    // Memory Module broadcasts. 2 events for starting/ending trace
+    available = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
+    required = memoryEventSets[metricSet].size() + 2;
+    if (available < required) return false;
+
+    return true;
+  }
+
+  void AieTracePlugin::printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile)
+  {
+    auto col = tile.col;
+    auto row = tile.row + 1;
+    auto loc = XAie_TileLoc(col, row);
+
+    const std::string groups[3] = {
+      XAIEDEV_DEFAULT_GROUP_GENERIC,
+      XAIEDEV_DEFAULT_GROUP_STATIC,
+      XAIEDEV_DEFAULT_GROUP_AVAIL
+    };
+
+    std::cout << "Stats for Tile : (" << col << "," << row << ") Module : Core" << std::endl;
+    for (auto&g : groups) {
+      auto stats = aieDevice->getRscStat(g);
+      auto pc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
+      auto ts = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+      auto bc = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
+      std::cout << "Resource Group : " << std::left <<  std::setw(10) << g << " "
+                << "Performance Counters : " << pc << " "
+                << "Trace Slots : " << ts << " "
+                << "Broadcast Channels : " << bc << " "
+                << std::endl;
+    }
+    std::cout << "Stats for Tile : (" << col << "," << row << ") Module : Memory" << std::endl;
+    for (auto&g : groups) {
+    auto stats = aieDevice->getRscStat(g);
+    auto pc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
+    auto ts = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
+    auto bc = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
+    std::cout << "Resource Group : "  << std::left <<  std::setw(10) << g << " "
+              << "Performance Counters : " << pc << " "
+              << "Trace Slots : " << ts << " "
+              << "Broadcast Channels : " << bc << " "
+              << std::endl;
+    }
+  }
+
   // Configure all resources necessary for trace control and events
   bool AieTracePlugin::setMetrics(uint64_t deviceId, void* handle)
   {
@@ -309,6 +385,14 @@ namespace xdp {
       std::copy(memoryEventSets[metricSet].begin(), memoryEventSets[metricSet].end(), 
                 back_inserter(memoryCrossEvents));
 
+      // Check Resource Availability
+      // For now only counters are checked
+      if (!tileHasFreeRsc(aieDevice, loc, metricSet)) {
+        xrt_core::message::send(severity_level::warning, "XRT", "Tile doesn't have enough free resources for trace. Aborting trace configuration.");
+        printTileStats(aieDevice, tile);
+        return false;
+      }
+
       //
       // 1. Reserve and start core module counters
       //
@@ -406,6 +490,8 @@ namespace xdp {
         xrt_core::message::send(severity_level::warning, "XRT", msg.str());
 
         releaseCurrentTileCounters(numCoreCounters, numMemoryCounters);
+        // Print resources availability for this tile
+        printTileStats(aieDevice, tile);
         return false;
       }
 
@@ -430,6 +516,8 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
 
           releaseCurrentTileCounters(numCoreCounters, numMemoryCounters);
+          // Print resources availability for this tile
+          printTileStats(aieDevice, tile);
           return false;
         }
 
@@ -489,6 +577,8 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg.str());
 
           releaseCurrentTileCounters(numCoreCounters, numMemoryCounters);
+          // Print resources availability for this tile
+          printTileStats(aieDevice, tile);
           return false;
         }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -207,8 +207,8 @@ namespace xdp {
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_PERFCNT_RSC);
     required = coreCounterStartEvents.size();
     if (available < required) {
-      msg << "Available core module performance counters : " << available << std::endl
-          << "Required core module performance counters : "  << required << std::endl;
+      msg << "Available core module performance counters for aie trace : " << available << std::endl
+          << "Required core module performance counters for aie trace : "  << required << std::endl;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -217,8 +217,8 @@ namespace xdp {
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
     required = coreCounterStartEvents.size() + coreEventSets[metricSet].size();
     if (available < required) {
-      msg << "Available core module trace slots : " << available << std::endl
-          << "Required core module trace slots : "  << required << std::endl;
+      msg << "Available core module trace slots for aie trace : " << available << std::endl
+          << "Required core module trace slots for aie trace : "  << required << std::endl;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -227,8 +227,8 @@ namespace xdp {
     available = stats.getNumRsc(loc, XAIE_CORE_MOD, XAIE_BCAST_CHANNEL_RSC);
     required = memoryEventSets[metricSet].size() + 2;
     if (available < required) {
-      msg << "Available core module broadcast channels : " << available << std::endl
-          << "Required core module broadcast channels : "  << required << std::endl;
+      msg << "Available core module broadcast channels for aie trace : " << available << std::endl
+          << "Required core module broadcast channels for aie trace : "  << required << std::endl;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -237,8 +237,8 @@ namespace xdp {
     available = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_PERFCNT_RSC);
     required = memoryCounterStartEvents.size();
     if (available < required) {
-      msg << "Available memory module performance counters : " << available << std::endl
-          << "Required memory module performance counters : "  << required << std::endl;
+      msg << "Available memory module performance counters for aie trace : " << available << std::endl
+          << "Required memory module performance counters for aie trace : "  << required << std::endl;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -247,8 +247,8 @@ namespace xdp {
     available = stats.getNumRsc(loc, XAIE_MEM_MOD, xaiefal::XAIE_TRACE_EVENTS_RSC);
     required = memoryCounterStartEvents.size() + memoryEventSets[metricSet].size();
     if (available < required) {
-      msg << "Available memory module trace slots : " << available << std::endl
-          << "Required memory module trace slots : "  << required << std::endl;
+      msg << "Available memory module trace slots for aie trace : " << available << std::endl
+          << "Required memory module trace slots for aie trace : "  << required << std::endl;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -257,8 +257,8 @@ namespace xdp {
     available = stats.getNumRsc(loc, XAIE_MEM_MOD, XAIE_BCAST_CHANNEL_RSC);
     required = memoryEventSets[metricSet].size() + 2;
     if (available < required) {
-      msg << "Available memory module broadcast channels : " << available << std::endl
-          << "Required memory module broadcast channels : "  << required << std::endl;
+      msg << "Available memory module broadcast channels for aie trace : " << available << std::endl
+          << "Required memory module broadcast channels for aie trace : "  << required << std::endl;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -208,7 +208,7 @@ namespace xdp {
     required = coreCounterStartEvents.size();
     if (available < required) {
       msg << "Available core module performance counters for aie trace : " << available << std::endl
-          << "Required core module performance counters for aie trace : "  << required << std::endl;
+          << "Required core module performance counters for aie trace : "  << required;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -218,7 +218,7 @@ namespace xdp {
     required = coreCounterStartEvents.size() + coreEventSets[metricSet].size();
     if (available < required) {
       msg << "Available core module trace slots for aie trace : " << available << std::endl
-          << "Required core module trace slots for aie trace : "  << required << std::endl;
+          << "Required core module trace slots for aie trace : "  << required;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -228,7 +228,7 @@ namespace xdp {
     required = memoryEventSets[metricSet].size() + 2;
     if (available < required) {
       msg << "Available core module broadcast channels for aie trace : " << available << std::endl
-          << "Required core module broadcast channels for aie trace : "  << required << std::endl;
+          << "Required core module broadcast channels for aie trace : "  << required;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -238,7 +238,7 @@ namespace xdp {
     required = memoryCounterStartEvents.size();
     if (available < required) {
       msg << "Available memory module performance counters for aie trace : " << available << std::endl
-          << "Required memory module performance counters for aie trace : "  << required << std::endl;
+          << "Required memory module performance counters for aie trace : "  << required;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -248,7 +248,7 @@ namespace xdp {
     required = memoryCounterStartEvents.size() + memoryEventSets[metricSet].size();
     if (available < required) {
       msg << "Available memory module trace slots for aie trace : " << available << std::endl
-          << "Required memory module trace slots for aie trace : "  << required << std::endl;
+          << "Required memory module trace slots for aie trace : "  << required;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -258,7 +258,7 @@ namespace xdp {
     required = memoryEventSets[metricSet].size() + 2;
     if (available < required) {
       msg << "Available memory module broadcast channels for aie trace : " << available << std::endl
-          << "Required memory module broadcast channels for aie trace : "  << required << std::endl;
+          << "Required memory module broadcast channels for aie trace : "  << required;
       xrt_core::message::send(severity_level::info, "XRT", msg.str());
       return false;
     }
@@ -443,9 +443,7 @@ namespace xdp {
         XAie_Events counterEvent;
         perfCounter->getCounterEvent(mod, counterEvent);
         int idx = static_cast<int>(counterEvent) - static_cast<int>(XAIE_EVENT_PERF_CNT_0_CORE);
-        // Following function is broken on FAL so we need to directly call aie driver api
-        // perfCounter->changeThreshold(coreCounterEventValues.at(i));
-        XAie_PerfCounterEventValueSet(aieDevInst, loc, XAIE_CORE_MOD, idx, coreCounterEventValues.at(i));
+        perfCounter->changeThreshold(coreCounterEventValues.at(i));
 
         // Set reset event based on counter number
         perfCounter->changeRstEvent(mod, counterEvent);
@@ -487,9 +485,7 @@ namespace xdp {
         XAie_Events counterEvent;
         perfCounter->getCounterEvent(mod, counterEvent);
         int idx = static_cast<int>(counterEvent) - static_cast<int>(XAIE_EVENT_PERF_CNT_0_MEM);
-        // Following function is broken on FAL so we need to directly call aie driver api
-        // perfCounter->changeThreshold(memoryCounterEventValues.at(i));
-        XAie_PerfCounterEventValueSet(aieDevInst, loc, XAIE_MEM_MOD, idx, memoryCounterEventValues.at(i));
+        perfCounter->changeThreshold(memoryCounterEventValues.at(i));
 
         perfCounter->changeRstEvent(mod, counterEvent);
         memoryEvents.push_back(counterEvent);

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -31,6 +31,8 @@ namespace xdp {
   class AIETraceOffload;
   class AIETraceLogger;
 
+  using tile_type = xrt_core::edge::aie::tile_type;
+
   class AieTracePlugin : public XDPPlugin
   {
     public:
@@ -57,6 +59,10 @@ namespace xdp {
       void releaseCurrentTileCounters(int numCoreCounters, int numMemoryCounters);
       bool setMetrics(uint64_t deviceId, void* handle);
       void setFlushMetrics(uint64_t deviceId, void* handle);
+
+      // Aie resource manager utility functions
+      bool tileHasFreeRsc(xaiefal::XAieDev* aieDevice, XAie_LocType& loc, const std::string& metricSet);
+      void printTileStats(xaiefal::XAieDev* aieDevice, const tile_type& tile);
 
     private:
       // Runtime or compile-time specified trace metrics?


### PR DESCRIPTION
use aie fal to reserve profile counters
use aie fal to check trace resource availability
print utilization
make "conflicts" as default aie profile metric
use aie fal function to set threshold instead of aie driver