### PR TITLE
CR 1094631 : xbutil2 validate --batch option does not remove all escape characters

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1050,7 +1050,8 @@ p2pTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
   else
     run_test.finish(true, "");
  
-  std::cout << EscapeCodes::cursor().prev_line() << EscapeCodes::cursor().clear_line();
+  if (XBU::is_escape_codes_disabled() == true) 
+    std::cout << EscapeCodes::cursor().prev_line() << EscapeCodes::cursor().clear_line();
 }
 
 /*


### PR DESCRIPTION
Issue: The original issue reported by the CR filer _**only occurs for Ubuntu 16.04**_.  This OS release is obsolete.  That said, upon further code introspection, there was one issue at the end of the P2P validation test that would produce escape codes in the batch mode.  

This PR address this remaining issue.