### PR TITLE
CR-1107957: Print profiling summary table for data transfers to memory resources

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -593,6 +593,10 @@ namespace xdp {
     size_t pos = name.find('/');
     std::string monCuName = name.substr(0, pos);
 
+    if (monCuName == "memory_subsystem") {
+      devInfo->loadedXclbins.back()->hasMemoryAIM = true ;
+    }
+
     std::string memName = "" ;
     std::string portName = "" ;
     size_t pos1 = name.find('-');


### PR DESCRIPTION
This pull request reintroduces code to set when xclbins have memory monitors in the XDP data structures that was erroneously removed when developing the feature and merging with the master branch.

