### PR TITLE
CR-1106861 : xbutil/xbmgmt: Forego device specification for single device systems

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -161,10 +161,10 @@ void  main_(int argc, char** argv,
     // If there are multiple devices, then no default device can be found.
     if (available_devices.size() > 1) {
       std::cerr << "\nERROR: Multiple devices found. Please specify a single device using the --device option\n\n";
-      std::cout << "List of available devices:" << std::endl;
+      std::cerr << "List of available devices:" << std::endl;
       for (auto &kd : available_devices) {
-        boost::property_tree::ptree& _dev = kd.second;
-        std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
+        boost::property_tree::ptree& dev = kd.second;
+        std::cerr << boost::format("  [%s] : %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv");
       }
 
       std::cout << std::endl;

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -323,7 +323,7 @@ boost::property_tree::ptree
 XBUtilities::get_available_devices(bool inUserDomain)
 {
   xrt_core::device_collection deviceCollection;
-  collect_devices(std::set<std::string> {"all"}, inUserDomain, deviceCollection);
+  collect_devices(std::set<std::string> {"_all_"}, inUserDomain, deviceCollection);
   boost::property_tree::ptree pt;
   for (const auto & device : deviceCollection) {
     boost::property_tree::ptree pt_dev;
@@ -487,7 +487,7 @@ XBUtilities::collect_devices( const std::set<std::string> &_deviceBDFs,
     return;
 
   // -- Collect all of devices if the "all" option is used...anywhere in the collection
-  if (_deviceBDFs.find("all") != _deviceBDFs.end()) {
+  if (_deviceBDFs.find("_all_") != _deviceBDFs.end()) {
     xrt_core::device::id_type total = 0;
     try {
       // If there are no devices in the server a runtime exception is thrown in  mgmt.cpp probe()


### PR DESCRIPTION
At the top program option parser, the optional options --device & -d were added with default and implicit values.  If the user specifies this the 'device' option with no value and there is only 1 device installed, it will be selected and passed to the sub-command.

Work Done
---------
+ Added optional --device & -d option with both default (e.g. "") and implicit (e.g., "default") values to the top-level program option tree.
+ Updated XBMain::_main() to automatically select a device if the is only one device and the users specifies the device option.
+ Added DRC check for systems with no and multiple devices installed.
+ Cleaned up the SubCmdProgram::execute() method.