### PR TITLE
CR-1107824: Align xocl_debug log with profiling data

### DIFF
--- a/src/runtime_src/xocl/core/debug.cpp
+++ b/src/runtime_src/xocl/core/debug.cpp
@@ -40,8 +40,15 @@
 
 namespace {
 
+static unsigned long get_time_zero()
+{
+  // Originally: return xocl::time_ns();
+  return 0 ;
+}
+
 static bool s_debug_on = false;
 static std::string s_debug_log;
+static unsigned long s_zero = get_time_zero();
 
 // Event information
 namespace event {
@@ -67,10 +74,10 @@ struct info
     if (!m_times[CL_RUNNING])
         m_times[CL_RUNNING] = m_times[CL_COMPLETE];
     ostr << id << " " << m_command_type << " "
-         << m_times[CL_QUEUED] << " "
-         << m_times[CL_SUBMITTED] << " "
-         << m_times[CL_RUNNING] << " "
-         << m_times[CL_COMPLETE];
+         << (m_times[CL_QUEUED]-s_zero) << " "
+         << (m_times[CL_SUBMITTED]-s_zero) << " "
+         << (m_times[CL_RUNNING]-s_zero) << " "
+         << (m_times[CL_COMPLETE]-s_zero);
     for (auto d : m_dependencies)
       ostr << " " << d;
     return ostr;
@@ -185,6 +192,8 @@ init()
   s_debug_log = xrt_xocl::config::detail::get_string_value("Debug.xocl_log","xocl.log");
 
   ::event::init();
+
+  s_zero = get_time_zero();
 
   return s_debug_on;
 }

--- a/src/runtime_src/xocl/core/debug.cpp
+++ b/src/runtime_src/xocl/core/debug.cpp
@@ -42,7 +42,6 @@ namespace {
 
 static bool s_debug_on = false;
 static std::string s_debug_log;
-static unsigned long s_zero = xocl::time_ns();
 
 // Event information
 namespace event {
@@ -68,10 +67,10 @@ struct info
     if (!m_times[CL_RUNNING])
         m_times[CL_RUNNING] = m_times[CL_COMPLETE];
     ostr << id << " " << m_command_type << " "
-         << (m_times[CL_QUEUED]-s_zero) << " "
-         << (m_times[CL_SUBMITTED]-s_zero) << " "
-         << (m_times[CL_RUNNING]-s_zero) << " "
-         << (m_times[CL_COMPLETE]-s_zero);
+         << m_times[CL_QUEUED] << " "
+         << m_times[CL_SUBMITTED] << " "
+         << m_times[CL_RUNNING] << " "
+         << m_times[CL_COMPLETE];
     for (auto d : m_dependencies)
       ostr << " " << d;
     return ostr;
@@ -186,9 +185,6 @@ init()
   s_debug_log = xrt_xocl::config::detail::get_string_value("Debug.xocl_log","xocl.log");
 
   ::event::init();
-
-  // reset time zero
-  s_zero = xocl::time_ns();
 
   return s_debug_on;
 }


### PR DESCRIPTION
This pull request changes the internal OpenCL debug file generation (enabled with xocl_debug=true) to use the zero point inside time_ns() instead of its own local zero point.  Removing this local zero time aligns the timestamps in the generated debug file with any timestamps generated by profiling.
