### PR TITLE
CR-1108242: Add wdb and wcfg to run summary when applicable after hardware emulation run

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
@@ -36,6 +36,10 @@ namespace xdp {
   NativeProfilingPlugin::~NativeProfilingPlugin()
   {
     if (VPDatabase::alive()) {
+      // Applications using the Native API may be running hardware emulation,
+      //  so be sure to account for any emulation specific information
+      emulationSetup() ;
+
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
       for (auto w : writers) {


### PR DESCRIPTION
If Native API profiling is enabled, hardware emulation may be run.  This pull request adds emulation setup to native profiling plugin to add any waveform files to the run summary if they are not already listed.