### PR TITLE
CR-1108292: Resolve references in profiling trace files to missing strings in the mapping section

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -349,6 +349,7 @@ namespace xdp {
 
   void VPDynamicDatabase::dumpStringTable(std::ofstream& fout)
   {
+    std::lock_guard<std::mutex> lock(stringLock) ;
     // Windows compilation fails unless c_str() is used
     for (auto s : stringTable)
     {

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -216,8 +216,8 @@ namespace xdp {
 
   uint64_t VPDynamicDatabase::addString(const std::string& value)
   {
-    if (stringTable.find(value) == stringTable.end())
-    {
+    std::lock_guard<std::mutex> lock(stringLock) ;
+    if (stringTable.find(value) == stringTable.end()) {
       stringTable[value] = stringId++ ;
     }
     return stringTable[value] ;

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -144,8 +144,7 @@ namespace xdp {
     // Trace parser states and other metadata data structures
     std::mutex deviceLock ;
     std::mutex hostLock ;
-
-    //std::map<uint64_t, uint64_t> traceIDMap;
+    std::mutex stringLock ;
 
     void addHostEvent(VTFEvent* event) ;
     void addDeviceEvent(uint64_t deviceId, VTFEvent* event) ;


### PR DESCRIPTION
Occasionally, events will be generated in trace files that refer to strings that do not exist in the string mapping section of the file. 
 This was due to multithreaded access and addition to the database.  This pull request adds multithreaded protection for the string table in the dynamic database.