### PR TITLE
CR-1108317: Moving profile summary memory data transfer table to a different Vitis Analyzer section

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -549,7 +549,7 @@ namespace {
     uint64_t startTime = db->getStaticInfo().getApplicationStartTime() ;
     uint64_t endTime = xrt_core::time_ns() ; 
 
-    fout << "APPLICATON_RUN_TIME_MS,all," 
+    fout << "APPLICATION_RUN_TIME_MS,all," 
          << (double)(endTime - startTime) / 1e06
          << ",\n" ;
   }

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1449,7 +1449,7 @@ namespace xdp {
     if (!hasMemoryMonitors) return ;
 
     fout << "TITLE:Data Transfer: Memory Resource\n" ;
-    fout << "SECTION:Host Data Transfers,Memory Bank Data Transfer\n" ;
+    fout << "SECTION:Memory Data Transfers,Memory Bank Data Transfer\n" ;
     fout << "COLUMN:<html>Device</html>,string,Name of device\n" ;
     fout << "COLUMN:<html>Memory<br>Resource</html>,string,"
          << "Memory resource on the device\n" ;


### PR DESCRIPTION
Changing the section of the memory transfer table to its own section since it is reporting an aggregate of both host and kernel traffic.