### PR TITLE
CR-1108464 - need a way to update xclbin uuid

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1516,6 +1516,14 @@ XclBin::setKeyValue(const std::string & _keyValue)
       return; // Key processed 
     }
 
+    if (sKey == "XclbinUUID") {
+      std::cout << "Warning: Changing this 'XclbinUUID' property to a non-unique value can result in non-determinist negative runtime behavior.\n";
+      sValue.erase(std::remove(sValue.begin(), sValue.end(), '-'), sValue.end()); // Remove the '-'
+      XUtil::hexStringToBinaryBuffer(sValue, (unsigned char*)&m_xclBinHeader.m_header.uuid, sizeof(axlf_header::uuid));
+      return; // Key processed 
+    }
+
+
     std::string errMsg = XUtil::format("ERROR: Unknown key '%s' for key-value pair '%s'.", sKey.c_str(), _keyValue.c_str());
     throw std::runtime_error(errMsg);
   } 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx
@@ -325,6 +325,10 @@ int main_(int argc, const char** argv) {
     }
   }
 
+  // If the user is specifying the xclbin's UUID, honor it
+  if (!XclBin::findKeyAndGetValue("SYS","XclbinUUID", keyValuePairs).empty())
+    bSkipUUIDInsertion = true;
+
   // Signing DRCs
   if (bValidateSignature == true) {
     if (sCertificate.empty()) {


### PR DESCRIPTION
**_Issue_**
There isn't a clean way to specify a given UUID for an xclbin image.  Currently, this value is automatically determined.

**_Resolution_**
xclbinutil has been updated to support a new system property (e.g., XclbinUUID) that will allow the user to specify this value manually.  

**_Example_**
To set the value: `39c4d9f0-8ace-9955-6de9-aa053a64b374`
The following option would be used: `--key-value SYS:XclbinUUID:39c4d9f0-8ace-9955-6de9-aa053a64b374`