### PR TITLE
CR-1101247 xbutil2 validate platform ID is 0x0 for U50 and U250

### DIFF
--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -700,7 +700,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       bool is_mfg = false;
       try {
         is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
-      } catch (...) {}
+      } catch (const xrt_core::query::exception&) {}
 
       //if factory mode
       std::string platform = "<not defined>";
@@ -711,7 +711,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         else {
           platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
         }
-      } catch(...) {
+      } catch(const xrt_core::query::exception&) {
         // proceed even if the platform name is not available
       }
       std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
@@ -721,7 +721,11 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       consoleStream << std::string(dev_desc.length(), '-') << std::endl;
 
       auto is_ready = xrt_core::device_query<xrt_core::query::is_ready>(device);
-      auto is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
+      bool is_recovery = false;
+      try {
+        is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
+      }
+      catch(const xrt_core::query::exception&) { }
 
       for (auto &report : reportsToProcess) {
         if (report->isDeviceRequired() == false)

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -700,10 +700,13 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       bool is_mfg = false;
       try {
         is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(device);
-      } catch (const xrt_core::query::exception&) {}
+      } 
+      catch (const xrt_core::query::exception&) {
+        is_mfg = false;
+      }
 
       //if factory mode
-      std::string platform = "<not defined>";
+      std::string platform;
       try {
         if (is_mfg) {
           platform = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN";
@@ -711,8 +714,10 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         else {
           platform = xrt_core::device_query<xrt_core::query::rom_vbnv>(device);
         }
-      } catch(const xrt_core::query::exception&) {
+      } 
+      catch(const xrt_core::query::exception&) {
         // proceed even if the platform name is not available
+        platform = "<not defined>";
       }
       std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
       consoleStream << std::endl;
@@ -725,7 +730,9 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       try {
         is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
       }
-      catch(const xrt_core::query::exception&) { }
+      catch(const xrt_core::query::exception&) { 
+        is_recovery = false;
+      }
 
       for (auto &report : reportsToProcess) {
         if (report->isDeviceRequired() == false)

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1351,17 +1351,20 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
   ptTree.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
 
   boost::property_tree::ptree platform_report;
-  boost::property_tree::ptree empty_ptree;
+  const boost::property_tree::ptree empty_ptree;
   auto report = std::make_shared<ReportPlatforms>();
   report->getPropertyTreeInternal(device.get(), platform_report);
   
   const boost::property_tree::ptree& platforms = platform_report.get_child("platforms", empty_ptree);
+  if(platforms.size() > 1)
+    throw xrt_core::error(std::errc::operation_canceled);
+
   for(auto& kp : platforms) {
     const boost::property_tree::ptree& pt_platform = kp.second;
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
-    ptTree.put("platform", pt_static_region.get<std::string>("vbnv"));
-    ptTree.put("platform_id", pt_static_region.get<std::string>("interface_uuid"));
-    ptTree.put("sc_version", pt_platform.get<std::string>("controller.satellite_controller.version"));
+    ptTree.put("platform", pt_static_region.get<std::string>("vbnv", "N/A"));
+    ptTree.put("platform_id", pt_static_region.get<std::string>("interface_uuid", "N/A"));
+    ptTree.put("sc_version", pt_platform.get<std::string>("controller.satellite_controller.version", "N/A"));
 
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -18,7 +18,7 @@
 // Local - Include Files
 #include "SubCmdValidate.h"
 #include "tools/common/Report.h"
-#include "tools/common/ReportHost.h"
+#include "tools/common/ReportPlatforms.h"
 #include "tools/common/XBUtilities.h"
 #include "tools/common/XBHelpMenus.h"
 #include "core/common/utils.h"
@@ -1349,9 +1349,21 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
 {
   auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
   ptTree.put("device_id", xrt_core::query::pcie_bdf::to_string(bdf));
-  ptTree.put("platform", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
-  ptTree.put("sc_version", xrt_core::device_query<xrt_core::query::xmc_sc_version>(device));
-  ptTree.put("platform_id", (boost::format("0x%x") % xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
+
+  boost::property_tree::ptree platform_report;
+  boost::property_tree::ptree empty_ptree;
+  auto report = std::make_shared<ReportPlatforms>();
+  report->getPropertyTreeInternal(device.get(), platform_report);
+  
+  const boost::property_tree::ptree& platforms = platform_report.get_child("platforms", empty_ptree);
+  for(auto& kp : platforms) {
+    const boost::property_tree::ptree& pt_platform = kp.second;
+    const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
+    ptTree.put("platform", pt_static_region.get<std::string>("vbnv"));
+    ptTree.put("platform_id", pt_static_region.get<std::string>("interface_uuid"));
+    ptTree.put("sc_version", pt_platform.get<std::string>("controller.satellite_controller.version"));
+
+  }
 
   // Text output
   oStream << boost::format("%-26s: [%s]\n") % "Validate Device" % ptTree.get<std::string>("device_id");
@@ -1415,154 +1427,6 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
   return status;
 }
 
-static
-std::string quote_name(const std::string & name)
-{
-  if (name.find(' ') == std::string::npos)
-    return name;
-
-  return std::string("\'") + name + std::string("\'");
-}
-
-static
-void smart_tab_format( const unsigned int max_length,
-                       const std::string & new_entry,
-                       std::vector<std::string> & formatted_lines)
-{
-  // First time through?
-  if (formatted_lines.size() == 0) {
-    formatted_lines.push_back(new_entry);
-    return;
-  }
-
-  // Add a comma
-  unsigned int current_index = static_cast<unsigned int>(formatted_lines.size()) - 1;
-  formatted_lines[current_index] += ", ";
-
-  // Determine if we need to add the new_entry to the existing or new line
-  if ((formatted_lines[current_index].length() + new_entry.length()) > max_length)
-    formatted_lines.push_back(new_entry);
-  else
-    formatted_lines[current_index] += new_entry;
-}
-
-static void
-create_report_summary( const boost::property_tree::ptree& ptDevCollectionTestSuite,
-                       std::ostream &_ostream) {
-  // Convert the "logical_devices" array into an vector of child trees
-  std::vector<boost::property_tree::ptree> devices = XBU::as_vector<boost::property_tree::ptree>(ptDevCollectionTestSuite, "logical_devices");
-
-  // Data formats
-  static const unsigned int maxTabLength = 64;
-  static boost::format passFmt(   "  - [%-11s] : %-25s");
-  static boost::format warnFmt(   "  - [%-11s] : %-25s : Test(s): %s");
-  static boost::format failedFmt( "  - [%-11s] : %-25s : First failure: %s");
-  static boost::format skippedFmt("  - [%-11s] : %-25s : Test(s): %s");
-  static boost::format testNextLine("\n%58s%s");
-
-  // Collect the data
-  std::vector<std::string> validatedSuccessfully;
-  std::vector<std::string> validateWithExceptions;
-  std::vector<std::string> validateWithWarnings;
-  std::vector<std::string> validatedWithSkippedTests;
-
-  // Look at each device
-  for (const auto & device : devices) {
-    const std::string & device_id = device.get<std::string>("device_id");
-    const std::string & platform = device.get<std::string>("platform");
-    std::vector<boost::property_tree::ptree> tests = XBU::as_vector<boost::property_tree::ptree>(device, "tests");
-
-    // -- Failed Tests --
-    std::vector<boost::property_tree::ptree> failedTests;
-    std::copy_if(tests.begin(), tests.end(),  std::back_inserter(failedTests), [](boost::property_tree::ptree &pt){return pt.get<std::string>("status") == "failed";});
-
-    for (const auto &test : failedTests) {
-      const std::string test_name = quote_name(test.get<std::string>("name"));
-      validateWithExceptions.push_back(boost::str(failedFmt % device_id % platform % test_name));
-      break;
-    }
-
-    // -- Skipped Tests --
-    std::vector<boost::property_tree::ptree> skippedTests;
-    std::copy_if(tests.begin(), tests.end(),  std::back_inserter(skippedTests), [](boost::property_tree::ptree &pt){return pt.get<std::string>("status") == "skipped";});
-
-    // Now format the skipped the tests
-    std::vector<std::string> tabSkippedTests;
-    for (const auto &test : skippedTests)
-      smart_tab_format(maxTabLength, quote_name(test.get<std::string>("name")), tabSkippedTests);
-
-    std::string skippedTestStr;
-    for (const auto & entry: tabSkippedTests)
-      if (skippedTestStr.empty())
-        skippedTestStr = boost::str(skippedFmt % device_id % platform % entry);
-      else
-        skippedTestStr += boost::str(testNextLine % "" % entry);
-
-    if (!skippedTestStr.empty())
-      validatedWithSkippedTests.push_back(skippedTestStr);
-
-    // -- Passed Tests --
-    std::vector<boost::property_tree::ptree> passTests;
-    std::copy_if(tests.begin(), tests.end(),  std::back_inserter(passTests), [](boost::property_tree::ptree &pt){return pt.get<std::string>("status") == "passed";});
-
-    if ((passTests.size() > 0) &&
-        (failedTests.size() == 0)) {            // There must not be any failures
-      validatedSuccessfully.push_back(boost::str(passFmt % device_id % platform));
-    }
-
-    // -- Warnings --
-    std::vector<std::string> warningTests;
-    for (const auto &test : passTests) {
-      std::vector<boost::property_tree::ptree> entries = XBU::as_vector<boost::property_tree::ptree>(test, "log");
-
-      for (const auto &entry : entries) {
-        if (entry.get<std::string>("Warning","").length() == 0)
-          continue;
-
-         warningTests.push_back(quote_name(test.get<std::string>("name")));
-         break;
-        }
-      }
-
-      std::string warningTestsStr;
-      for (const auto & entry: warningTests)
-        if (warningTestsStr.empty())
-          warningTestsStr = boost::str(warnFmt % device_id % platform % entry);
-        else
-          warningTestsStr += boost::str(testNextLine % "" % entry);
-
-      if (!warningTestsStr.empty())
-        validateWithWarnings.push_back(warningTestsStr);
-  }
-
-  // -- Report the data collected
-  _ostream << std::endl;
-  _ostream << "Validation Summary" << std::endl;
-  _ostream << "------------------" << std::endl;
-
-  _ostream << boost::format("%-2d device evaluated") % devices.size() << std::endl;
-  _ostream << boost::format("%-2d device validated successfully") % validatedSuccessfully.size() << std::endl;
-  _ostream << boost::format("%-2d device had exceptions during validation") % validateWithExceptions.size() << std::endl;
-
-  _ostream << boost::format("\nValidated successfully [%d device]") % validatedSuccessfully.size() << std::endl;
-  for (const auto &entry : validatedSuccessfully)
-    _ostream << entry << std::endl;
-
-  _ostream << boost::format("\nValidation Exceptions [%d device]") % validateWithExceptions.size() << std::endl;
-  for (const auto &entry : validateWithExceptions)
-    _ostream << entry << std::endl;
-
-  _ostream << boost::format("\nWarnings produced during test [%d device] (Note: The given test successfully validated)") % validateWithWarnings.size() << std::endl;
-  for (const auto &entry : validateWithWarnings)
-    _ostream << entry << std::endl;
-
-  if (XBU::getVerbose()) {
-    _ostream << boost::format("\nUnsupported tests [%d device]") % validatedWithSkippedTests.size() << std::endl;
-    for (const auto &entry : validatedWithSkippedTests)
-      _ostream << entry << std::endl;
-  }
-}
-
 static bool
 run_tests_on_devices( xrt_core::device_collection &deviceCollection,
                       Report::SchemaVersion schemaVersion,
@@ -1582,10 +1446,6 @@ run_tests_on_devices( xrt_core::device_collection &deviceCollection,
     has_failures |= (run_test_suite_device(dev, schemaVersion, testObjectsToRun, ptDeviceTested) == test_status::failed);
 
   ptDevCollectionTestSuite.put_child("logical_devices", ptDeviceTested);
-
-  // -- Create summary report
-  // Note: The report summary is only associated with the human readable format
-  create_report_summary(ptDevCollectionTestSuite, std::cout);
 
   // -- Write the formatted output
   switch (schemaVersion) {


### PR DESCRIPTION
Work Done:
- Use ReportPlatform to get basic information about the device
- Since we only operate on a single device, remove the validation summary
- Small fix related to: https://github.com/Xilinx/XRT/pull/5646

Sample output:

```
$ xbutil validate -d 65:00 -r quick
Starting validation for 1 devices

Validate Device           : [0000:65:00.1]
    Platform              : xilinx_u200_xdma_201830_2
    SC Version            : 4.2.0
    Platform ID           : 0x5d1211e8
....


$ xbutil validate -d 17:00 -r quick                                         
Starting validation for 1 devices                                                                                                

Validate Device           : [0000:17:00.1]
    Platform              : xilinx_u30_gen3x4_base_1
    SC Version            : 6.3.6                   
    Platform ID           : 937ED708-67CF-3350-BC06-304053F4293C
....
```

