### PR TITLE
Fixes for CR-1108351, CR-1108354, CR-1108359, and CR-1108361

### DIFF
--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.cpp
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.cpp
@@ -21,9 +21,10 @@
 namespace xdp {
 
   OpenCLAPICall::OpenCLAPICall(uint64_t s_id, double ts, uint64_t /*f_id*/,
-                               uint64_t name, uint64_t q)
+                               uint64_t name, uint64_t q, bool l)
       : APICall(s_id, ts, name, OPENCL_API_CALL),
-        queueAddress(q)
+        queueAddress(q),
+        isLOP(l)
   {
   }
 

--- a/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
+++ b/src/runtime_src/xdp/profile/database/events/opencl_api_calls.h
@@ -27,16 +27,18 @@ namespace xdp {
   {
   private:
     uint64_t queueAddress ;
+    bool isLOP ;
 
     OpenCLAPICall() = delete ;
   public:
-    XDP_EXPORT OpenCLAPICall(uint64_t s_id, double ts, uint64_t f_id, uint64_t name, uint64_t q);
+    XDP_EXPORT OpenCLAPICall(uint64_t s_id, double ts, uint64_t f_id, uint64_t name, uint64_t q, bool l = false);
     XDP_EXPORT ~OpenCLAPICall() ;
 
     inline uint64_t getQueueAddress() { return queueAddress ; } 
 
     virtual bool isOpenCLAPI() { return true ; }
-    virtual bool isOpenCLHostEvent() { return true ; }
+    virtual bool isLOPAPI() { return isLOP ; }
+    virtual bool isOpenCLHostEvent() { return !isLOP ; }
     XDP_EXPORT virtual void dump(std::ofstream& fout, uint32_t bucket) ;
   } ;
 

--- a/src/runtime_src/xdp/profile/database/events/vtf_event.h
+++ b/src/runtime_src/xdp/profile/database/events/vtf_event.h
@@ -103,7 +103,8 @@ namespace xdp {
 
     // Functions that can be used as filters
     virtual bool isUserEvent()       { return false ; }
-    virtual bool isOpenCLAPI()       { return false ; } 
+    virtual bool isOpenCLAPI()       { return false ; }
+    virtual bool isLOPAPI()          { return false ; }
     virtual bool isHALAPI()          { return false ; }
     virtual bool isHostEvent()       { return false ; }
     virtual bool isNativeHostEvent() { return false ; } 

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
@@ -39,11 +39,11 @@ namespace xdp {
       (db->getStaticInfo()).addCommandQueueAddress(queueAddress) ;
 
     VTFEvent* event = new OpenCLAPICall(0,
-					timestamp,
-					functionID,
-					(db->getDynamicInfo()).addString(functionName),
-					queueAddress
-					) ;
+                                        timestamp,
+                                        functionID,
+                                        (db->getDynamicInfo()).addString(functionName),
+                                        queueAddress,
+                                        true); // is Low Overhead
     (db->getDynamicInfo()).addEvent(event) ;
     (db->getDynamicInfo()).markStart(functionID, event->getEventId()) ;
   }
@@ -58,10 +58,11 @@ namespace xdp {
     uint64_t start = (db->getDynamicInfo()).matchingStart(functionID) ;
 
     VTFEvent* event = new OpenCLAPICall(start,
-					timestamp,
-					functionID,
-					(db->getDynamicInfo()).addString(functionName),
-					queueAddress) ;
+                                        timestamp,
+                                        functionID,
+                                        (db->getDynamicInfo()).addString(functionName),
+                                        queueAddress,
+                                        true) ; // is Low Overhead
     (db->getDynamicInfo()).addEvent(event) ;
   }
 

--- a/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
@@ -52,7 +52,7 @@ namespace xdp {
     uint32_t rowCount = 0;
     fout << "STRUCTURE" << std::endl ;
     
-    fout << "Group_Start,Host" << std::endl ;
+    fout << "Group_Start,HAL Host Trace" << std::endl ;
 
     fout << "Group_Start,HAL API Calls" << std::endl ;
     fout << "Dynamic_Row," << ++rowCount << ",General,0x0,API_CALL" << std::endl;
@@ -66,7 +66,7 @@ namespace xdp {
     eventTypeBucketIdMap[WRITE_BUFFER] = rowCount;
     fout << "Group_End,Data Transfer" << std::endl ;
     
-    fout << "Group_End,Host" << std::endl ;
+    fout << "Group_End,HAL Host Trace" << std::endl ;
   }
 
   void HALHostTraceWriter::writeStringTable()

--- a/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
@@ -66,7 +66,7 @@ namespace xdp {
   void LowOverheadTraceWriter::writeHumanReadableStructure()
   {
     fout << "STRUCTURE" << std::endl ;
-    fout << "Group_Start,Host APIs" << std::endl ;
+    fout << "Group_Start,Low Overhead OpenCL Host Trace" << std::endl ;
     fout << "Group_Start,OpenCL API Calls" << std::endl ;
     fout << "Dynamic_Row," << generalAPIBucket
          << ",General,API Events not associated with a Queue" << std::endl ;
@@ -88,7 +88,7 @@ namespace xdp {
     fout << "Group_End,Data Transfer" << std::endl ;
     fout << "Dynamic_Row_Summary," << enqueueBucket 
          << ",Kernel Enqueues,Activity in kernel enqueues" << std::endl ;
-    fout << "Group_End,Host APIs" << std::endl ;
+    fout << "Group_End,Low Overhead OpenCL Host Trace" << std::endl ;
   }
 
   void LowOverheadTraceWriter::writeHumanReadableStringTable()

--- a/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/lop/low_overhead_trace_writer.cpp
@@ -103,7 +103,7 @@ namespace xdp {
     auto APIEvents = 
       (db->getDynamicInfo()).filterEraseHostEvents( [](VTFEvent* e)
                                            {
-                                             return e->isOpenCLAPI() ||
+                                             return e->isLOPAPI() ||
                                                     e->isLOPHostEvent() ;
                                            }
                                          ) ;

--- a/src/runtime_src/xdp/profile/writer/native/native_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/native/native_writer.cpp
@@ -43,15 +43,15 @@ namespace xdp {
   {
     // There is only one bucket where all the APIs will go
     fout << "STRUCTURE" << "\n" ;
-    fout << "Group_Start,Host APIs" << "\n" ;
+    fout << "Group_Start,Native API Host Trace\n" ;
     fout << "Group_Start,Native XRT API Calls" << "\n" ;
     fout << "Dynamic_Row," << APIBucket << ",General,API Events" << "\n" ;
     fout << "Group_End,Native XRT API Calls" << "\n" ;
-    fout << "Group_End,Host APIs" << "\n" ;
     fout << "Group_Start,Host to Device Data Transfers\n" ;
     fout << "Dynamic_Row," << readBucket << ",Reads,Read Transfers\n" ;
     fout << "Dynamic_Row," << writeBucket << ",Writes,Write Transfers\n" ;
     fout << "Group_End,Host to Device Data Transfers\n" ;
+    fout << "Group_End,Native API Host Trace\n" ;
   }
 
   void NativeTraceWriter::writeStringTable()

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -73,7 +73,7 @@ namespace xdp {
   void OpenCLTraceWriter::writeHumanReadableStructure()
   {
     fout << "STRUCTURE" << std::endl ;
-    fout << "Group_Start,Host APIs" << std::endl ;
+    fout << "Group_Start,OpenCL Host Trace" << std::endl ;
     fout << "Group_Start,OpenCL API Calls" << std::endl ;
     fout << "Dynamic_Row," << generalAPIBucket
          << ",General,API Events not associated with a Queue" << std::endl ;
@@ -105,7 +105,7 @@ namespace xdp {
            << ",Kernel Enqueue" << std::endl ;
     }
     fout << "Group_End,Kernel Enqueues" << std::endl ;
-    fout << "Group_End,Host APIs" << std::endl ;
+    fout << "Group_End,OpenCL Host Trace" << std::endl ;
   }
 
   void OpenCLTraceWriter::writeHumanReadableStringTable()


### PR DESCRIPTION
CR-1108351: Renamed the "Host API" section for each of the host side writers to reflect which plugin generated it.  Native API Host Trace, Low Overhead OpenCL Host Trace, HAL Host Trace, and OpenCL Host trace are the new section names so they can be distinguished on the final visualization.

CR-1108354: Adjusted Native API Host Trace so that data transfers appeared at the same level as OpenCL and Low Overhead OpenCL sections.

CR-1108359: Changed the section names of Low Overhead OpenCL and OpenCL trace so they can be distinguished in the final visualization.

CR-1108361: Low Overhead OpenCL and OpenCL profiling plugins were collecting the same types of events, leading to all the OpenCL API calls going in one section when both plugins were loaded.  This pull request adds a boolean to the OpenCL API event type in profiling to distinguish between the two, and the writers now only collect the events for the proper section.