### PR TITLE
fixing xbmgmt examine issue. Need to use "_all_" with latest tools to get all devices

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -131,7 +131,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   // Determine default values
   if (devices.size() == 0)
-    devices.push_back("all");
+    devices.push_back("_all_");
 
   if (reportNames.size() == 0)
     reportNames.push_back("host");


### PR DESCRIPTION
fixing xbmgmt examine issue. We need to use "_all_" with latest tools to get all devices