### PR TITLE
Promote p2p to a first class command

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -20,7 +20,6 @@
 #include "OO_MemRead.h"
 #include "OO_AieRegRead.h"
 #include "OO_MemWrite.h"
-#include "OO_P2P.h"
 #include "XBReport.h"
 
 #include "common/system.h"
@@ -76,7 +75,6 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
   SubOptionOptions subOptionOptions;
   subOptionOptions.emplace_back(std::make_shared<OO_MemRead>("read-mem"));
   subOptionOptions.emplace_back(std::make_shared<OO_MemWrite>("write-mem"));
-  subOptionOptions.emplace_back(std::make_shared<OO_P2P>("p2p"));
 // Only defined for embedded platform
 #ifndef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
   subOptionOptions.emplace_back(std::make_shared<OO_AieRegRead>("read-aie-reg"));

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -18,6 +18,7 @@
 // Local - Include Files
 #include "SubCmdConfigure.h"
 #include "OO_HostMem.h"
+#include "OO_P2P.h"
 
 #include "common/system.h"
 #include "common/device.h"
@@ -65,6 +66,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
   // -- Define the supporting option options ----
   SubOptionOptions subOptionOptions;
   subOptionOptions.emplace_back(std::make_shared<OO_HostMem>("host-mem"));
+  subOptionOptions.emplace_back(std::make_shared<OO_P2P>("p2p"));
 
   for (auto & subOO : subOptionOptions) {
     if (subOO->isHidden()) 


### PR DESCRIPTION
```
$ xbutil configure -h

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xbutil configure [-h] --[ host-mem | p2p ] [commandArgs]

OPTIONS:
  -h, --help         - Help to use this sub-command
  --host-mem         - Controls host-mem functionality
  --p2p              - Controls P2P functionality

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
