### PR TITLE
CR-1053805 Convert CMC Version No to HEX for XRT output

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -137,7 +137,13 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
     sc.add("version", xrt_core::device_query<xq::xmc_sc_version>(device));
     sc.add("expected_version", xrt_core::device_query<xq::expected_sc_version>(device));
     ptree_type cmc;
-    cmc.add("version", xrt_core::device_query<xq::xmc_version>(device));
+    std::stringstream version;
+    
+    try {
+       version << "0x" << std::hex << std::stoi(xrt_core::device_query<xq::xmc_version>(device));
+    }
+    catch (...) {}
+    cmc.add("version", version.str());
     cmc.add("serial_number", xrt_core::device_query<xq::xmc_serial_num>(device));
     cmc.add("oem_id", xq::oem_id::parse(xrt_core::device_query<xq::oem_id>(device)));
     controller.put_child("satellite_controller", sc);


### PR DESCRIPTION
Here is  the output in hex

  "controller": {
                        "satellite_controller": {
                            "version": "4.6.11",
                            "expected_version": "4.6.11"
                        },
                        "card_mgmt_controller": {
                            "version": "0xc01020f",
                            "serial_number": "21290185T005",
                            "oem_id": "Xilinx"
                        }
                    },
