### PR TITLE
Fix parsing of 'size' argument passed to xbutil host_mem

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -768,8 +768,8 @@ XBUtilities::string_to_bytes(std::string str)
     throw xrt_core::error(std::errc::invalid_argument);
 
   std::string units = "B";
-  if(std::isalpha(str.at(str.length()))) {
-    units = str.at(str.length());
+  if(std::isalpha(str.back())) {
+    units = str.back();
     str.pop_back();
   }
 


### PR DESCRIPTION
Resolve the following error:

```
xsj-xw9400:/<6>XRT/build/Release>xbutil configure --host-mem -d 0000:02:00.1 -s 256M ENABLE
XRT build version: 2.12.0
Build hash: f9aa7460a39f904b3f688b330e6bb1cd839f3870
Build date: 2021-08-20 21:36:15
Git branch: master
PID: 267073
UID: 6354
[Sat Aug 21 05:01:19 2021 GMT]
HOST: xsj-xw9400
EXE: /opt/xilinx/xrt/bin/unwrapped/xbutil2
[xbutil] ERROR: basic_string::at: __n (which is 4) >= this->size() (which is 4)
```