### PR TITLE
CR-1108702 xocl should skip checking interface uuid for xclbins if th…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2590,7 +2590,12 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 	}
 
 	header = xrt_xclbin_get_section_hdr(xclbin, PARTITION_METADATA);
-	if (header) {
+	/*
+	 * don't check uuid if the xclbin is a lite one
+	 * the lite xclbin will have neither BITSTREAM nor SOFT_KERNEL 
+	 */
+	if (header && (xrt_xclbin_get_section_hdr(xclbin, BITSTREAM) ||
+		xrt_xclbin_get_section_hdr(xclbin, SOFT_KERNEL))) {
 		ICAP_INFO(icap, "check interface uuid");
 		if (!XDEV(xdev)->fdt_blob) {
 			ICAP_ERR(icap, "did not find platform dtb");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -497,19 +497,26 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		}
 		memcpy(xdev->ulp_blob, ulp_blob, fdt_totalsize(ulp_blob));
 
-		xocl_xdev_info(xdev, "check interface uuid");
-		if (!XDEV(xdev)->fdt_blob) {
-			userpf_err(xdev, "did not find platform dtb");
-			err = -EINVAL;
-			goto done;
-		}
-		err = xocl_fdt_check_uuids(xdev,
-			(const void *)XDEV(xdev)->fdt_blob,
-			(const void *)((char*)xdev->ulp_blob));
-		if (err) {
-			userpf_err(xdev, "interface uuids do not match");
-			err = -EINVAL;
-			goto done;
+		/*
+		 * don't check uuid if the xclbin is a lite one
+		 * the lite xclbin will have neither BITSTREAM nor SOFT_KERNEL 
+		 */
+		if (xocl_axlf_section_header(xdev, axlf, BITSTREAM) ||
+			xocl_axlf_section_header(xdev, axlf, SOFT_KERNEL)) {
+			xocl_xdev_info(xdev, "check interface uuid");
+			if (!XDEV(xdev)->fdt_blob) {
+				userpf_err(xdev, "did not find platform dtb");
+				err = -EINVAL;
+				goto done;
+			}
+			err = xocl_fdt_check_uuids(xdev,
+				(const void *)XDEV(xdev)->fdt_blob,
+				(const void *)((char*)xdev->ulp_blob));
+			if (err) {
+				userpf_err(xdev, "interface uuids do not match");
+				err = -EINVAL;
+				goto done;
+			}
 		}
 	}
 


### PR DESCRIPTION
…ey are lite
To solve u30 v1 compatibility issue,  don't check interface uuid if the xclbin is lite (strip bitstream and ps kernel) in xocl
1. there is behavior change to other alveo cards
2. xclmgmt changes will be in later (not backport to u30 branch, see CR-1108703)