### PR TITLE
CR-1101897 inst=### information missing from tools 2.0

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -56,6 +56,7 @@ enum class key_type
   pcie_express_lane_width_max,
   pcie_bdf,
 
+  instance,
   edge_vendor,
 
   dma_threads_raw,
@@ -851,6 +852,24 @@ struct xmc_version : request
     return value;
   }
 };
+
+
+struct instance : request
+{
+  using result_type = int64_t;
+  static const key_type key = key_type::instance;
+  static const char* name() { return "instance"; }
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  static std::string 
+  to_string(const result_type& value)
+  {
+    return std::to_string(value);
+  }
+};
+
 
 struct xmc_board_name : request
 {

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -28,6 +28,7 @@
 #include <functional>
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
+#include <boost/filesystem.hpp>
 
 namespace {
 
@@ -35,6 +36,29 @@ namespace query = xrt_core::query;
 using pdev = std::shared_ptr<pcidev::pci_device>;
 using key_type = query::key_type;
 const static int LEGACY_COUNT = 4;
+
+static int
+get_render_value(const std::string dir)
+{
+  static const std::string render_name = "renderD"; 
+  int instance_num = INVALID_ID;
+  std::string sub;
+
+  boost::filesystem::path render_dirs(dir);
+  if (!boost::filesystem::is_directory(render_dirs))
+    return instance_num;
+ 
+  boost::filesystem::recursive_directory_iterator end_iter;
+    for(boost::filesystem::recursive_directory_iterator iter(render_dirs); iter != end_iter; ++iter) {
+      if (iter->path().filename().string().compare(0,render_name.size(),render_name)== 0) {   
+        sub = iter->path().filename().string().substr(render_name.size());
+        instance_num = std::stoi(sub);
+        break;
+      }
+    }
+    return instance_num;
+}
+
 
 inline pdev
 get_pcidev(const xrt_core::device* device)
@@ -98,6 +122,29 @@ struct kds_cu_stat
     return cuStats;
   }
 };
+
+struct instance 
+{
+  using result_type = query::instance::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    static const std::string  dev_root = "/sys/bus/pci/devices/";
+    std::string errmsg;
+    auto pdev = get_pcidev(device);
+
+    auto sysfsname = boost::str( boost::format("%04x:%02x:%02x.%x") % pdev->domain % pdev->bus % pdev->dev %  pdev->func);
+    if(device->is_userpf())
+      pdev->instance = get_render_value(dev_root + sysfsname + "/drm");
+    else
+      pdev->sysfs_get("", "instance", errmsg, pdev->instance,static_cast<uint32_t>(INVALID_ID));
+  
+    return pdev->instance;
+  }
+
+};
+
 
 struct kds_scu_stat
 {
@@ -576,6 +623,7 @@ initialize_query_table()
 
   emplace_func0_request<query::pcie_bdf,                     bdf>();
   emplace_func0_request<query::kds_cu_info,                  kds_cu_info>();
+  emplace_func0_request<query::instance,                     instance>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -26,6 +26,7 @@
 #include <boost/algorithm/string.hpp>
 
 #define BYTES_TO_MEGABYTES 0x100000ll
+namespace xq = xrt_core::query;
 
 void
 ReportHost::getPropertyTreeInternal( const xrt_core::device * _pDevice,
@@ -114,7 +115,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   for(auto& kd : available_devices) {
     const boost::property_tree::ptree& dev = kd.second;
     std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-    _output << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
+    _output << boost::format("  [%s] : %s %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % dev.get<std::string>("instance") % note;
   }
   _output << std::endl;
 }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -79,6 +79,7 @@ static bool m_disableEscapeCodes = false;
 static bool m_bShowHidden = false;
 static bool m_bForce = false;
 
+namespace xq = xrt_core::query;
 
 // ------ F U N C T I O N S ---------------------------------------------------
 void
@@ -357,6 +358,16 @@ XBUtilities::get_available_devices(bool inUserDomain)
       } catch(...) {
         // The id wasn't added
       }
+
+     try {
+       std::string stream;
+       auto  instance = xrt_core::device_query<xrt_core::query::instance>(device);
+       std::string pf = device->is_userpf() ? "user" : "mgmt";
+       pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));
+     } catch(const xrt_core::query::exception&) {
+         // The instance wasn't added 
+       }
+
     }
 
     pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device));


### PR DESCRIPTION
sadasiva@pranjal-dell:/proj/rdi/staff/sadasiva/XRT/build$ xbmgmt examine
System Configuration
  OS Name              : Linux
  Release              : 4.15.0-147-generic
  Version              : #151-Ubuntu SMP Fri Jun 18 19:21:19 UTC 2021
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15727 MB
  Distribution         : Ubuntu 18.04.5 LTS
  GLIBC                : 2.27
  Model                : Precision 5820 Tower

XRT
  Version              : 2.12.0
  Branch               : instance
  Hash                 : eca6120ee4a6aa3c2224bd1b945cd0ddf165a66c
  Hash Date            : 2021-08-25 16:40:55
  XOCL                 : 2.12.69, 37f86ed80380ced5c192acd10f7d3a2f6751877f
  XCLMGMT              : 2.12.69, 37f86ed80380ced5c192acd10f7d3a2f6751877f

Devices present
  [0000:17:00.0] : xilinx_u200_gen3x16_xdma_base_1 mgmt(inst=5888) 



sadasiva@pranjal-dell:/proj/rdi/staff/sadasiva/XRT/build$ xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 4.15.0-147-generic
  Version              : #151-Ubuntu SMP Fri Jun 18 19:21:19 UTC 2021
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15727 MB
  Distribution         : Ubuntu 18.04.5 LTS
  GLIBC                : 2.27
  Model                : Precision 5820 Tower

XRT
  Version              : 2.12.0
  Branch               : instance
  Hash                 : eca6120ee4a6aa3c2224bd1b945cd0ddf165a66c
  Hash Date            : 2021-08-25 16:40:55
  XOCL                 : 2.12.69, 37f86ed80380ced5c192acd10f7d3a2f6751877f
  XCLMGMT              : 2.12.69, 37f86ed80380ced5c192acd10f7d3a2f6751877f

Devices present
  [0000:17:00.1] : xilinx_u200_gen3x16_xdma_base_1 user(inst=129) 
