### PR TITLE
CR-1109047 - Vitis-SmartNIC v++ package flow incorrectly stored CBOR in "characters" (expect in raw binary) for EBPF and UUID

### DIFF
--- a/src/runtime_src/tools/xclbinutil/CBOR.cxx
+++ b/src/runtime_src/tools/xclbinutil/CBOR.cxx
@@ -127,6 +127,7 @@ XclBinUtilities::encode_byte_string(const std::string& byte_string)
 {
   std::string encodeBuf = encode_major_type(MajorTypes::byte_string, byte_string.length());
   encodeBuf += byte_string;
+  XUtil::TRACE(std::string("CBOR: [Encode] Byte String"));
 
   return encodeBuf;
 }

--- a/src/runtime_src/tools/xclbinutil/RapidJsonUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/RapidJsonUtilities.cxx
@@ -123,7 +123,7 @@ void recursive_transformation(const std::string& scope,
 
       if (attribute.IsObject()) {
         for (auto itr2 = attribute.MemberBegin(); itr2 != attribute.MemberEnd(); ++itr2) {
-          recursive_transformation(scope + "[]" + itr2->name.GetString(), itr2, keyTypeCollection);
+          recursive_transformation(scope + "[]::" + itr2->name.GetString(), itr2, keyTypeCollection);
         }
       }
     }
@@ -442,7 +442,7 @@ void recursive_collect_array( const std::string& scope,
       return;
 
     for (auto itr = propertiesItr->value.MemberBegin(); itr != propertiesItr->value.MemberEnd(); ++itr) 
-      recursive_collect_properties(scope + "[]" + itr->name.GetString(), itr, keyTypeCollection);
+      recursive_collect_properties(scope + "[]::" + itr->name.GetString(), itr, keyTypeCollection);
 
     return; 
   }

--- a/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSmartNic.cxx
@@ -190,11 +190,11 @@ readAndTransposeByteFiles_recursive(const std::string& scope,
       for (auto itr2 = attribute.MemberBegin(); itr2 != attribute.MemberEnd(); ++itr2) {
 
         // Look "forward" to see if this dictionary contains the node of interest
-        std::string currentScope = scope + "[]" + itr2->name.GetString();
+        std::string currentScope = scope + "[]::" + itr2->name.GetString();
         if (get_expected_type(currentScope, keyTypeCollection) == XUtil::DType::byte_file) 
           renameCollection.push_back(std::string(itr2->name.GetString()));
 
-        readAndTransposeByteFiles_recursive(scope + "[]" + itr2->name.GetString(), itr2, keyTypeCollection, allocator, relativeFromDir);
+        readAndTransposeByteFiles_recursive(scope + "[]::" + itr2->name.GetString(), itr2, keyTypeCollection, allocator, relativeFromDir);
       }
 
       // Now that we are out of that "nasty" Iterator loop, rename the updated keys.


### PR DESCRIPTION
xclbinutil SmartNic bugfix: Bad JSON to CBOR transformation

**_Issue_**
JSON Binary Strings were not being detected when transforming from JSON to CBOR.

This issue was the result of a hierachy scoping tree not be being correctly formed when doing this transformation.

**_Work Done_**
+ The hierarchy transformation scoping hierarchies were updated to be consistant amongst each other.
+ Added new TRACE entry at the CBOR string binary entry function