### PR TITLE
Fix of hotplug error with latest script on RHEL 8.x during removal

### DIFF
--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -1151,16 +1151,16 @@ get_uuids(std::shared_ptr<char>& dtbbuf, std::vector<std::string>& uuids)
 
 /*
  * This is for the RHEL 8.x kernel. From the RHEL 8.x kernel removed the runtime_active_kids sysfs
- * node for the Linux power driver. Hence, to get the active kids under a abridge we need this
+ * node for the Linux power driver. Hence, to get the active kids under a bridge we need this
  * alternative solution.
  */
 int
-get_runtime_active_kids(std::string pci_bridge_path)
+get_runtime_active_kids(std::string &pci_bridge_path)
 {
   int curr_act_dev = 0;
   std::vector<bfs::path> vec{bfs::directory_iterator(pci_bridge_path), bfs::directory_iterator()};
 
-  // Under the bridge check how many xilinx devices are present. 
+  // Check number of Xilinx devices under this bridge. 
   for (auto& path : vec) {
     if (bfs::is_directory(path)) {
       path += "/vendor";


### PR DESCRIPTION
**CR Number**
https://jira.xilinx.com/browse/CR-1103663
Managed Hotplug gives error with latest script on RHEL during removal

**Issues** 
The managed hotplug script gives the following error while removing the mgmt pf on RHEL 8.1 on 740xd machine:
xbmgmt hotplug --offline BDF
ERROR: can not read active device number\nRemoving device faied. -2\n

**Root Cause**
Current implementation of xbmgmt tool, it checks the active nodes by reading dparent/power/runtime_active_kids sysfs node.
But on RHEL 8.x that sysfs file is deprecated.

**Solution**
- Added a separate function for RHEL 8.x to handle this situation.  
- The new function check under the bridge how many xilinx devices are present 
- That is considered as active device under that bridge. 
