### PR TITLE
amendment fix for CR-1108702

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2592,10 +2592,13 @@ static int icap_download_bitstream_axlf(struct platform_device *pdev,
 	header = xrt_xclbin_get_section_hdr(xclbin, PARTITION_METADATA);
 	/*
 	 * don't check uuid if the xclbin is a lite one
-	 * the lite xclbin will have neither BITSTREAM nor SOFT_KERNEL 
+	 * the lite xclbin will not have BITSTREAM
+	 * we need the SOFT_KERNEL section since the OBJ and METADATA are
+	 * coupled together.
+	 * The OBJ (soft kernel) is not needed, we can use xclbinutil to
+	 * add a temp small OBJ to reduce the lite xclbin size
 	 */
-	if (header && (xrt_xclbin_get_section_hdr(xclbin, BITSTREAM) ||
-		xrt_xclbin_get_section_hdr(xclbin, SOFT_KERNEL))) {
+	if (header && xrt_xclbin_get_section_hdr(xclbin, BITSTREAM)) {
 		ICAP_INFO(icap, "check interface uuid");
 		if (!XDEV(xdev)->fdt_blob) {
 			ICAP_ERR(icap, "did not find platform dtb");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -499,10 +499,9 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 
 		/*
 		 * don't check uuid if the xclbin is a lite one
-		 * the lite xclbin will have neither BITSTREAM nor SOFT_KERNEL 
+		 * the lite xclbin will not have BITSTREAM 
 		 */
-		if (xocl_axlf_section_header(xdev, axlf, BITSTREAM) ||
-			xocl_axlf_section_header(xdev, axlf, SOFT_KERNEL)) {
+		if (xocl_axlf_section_header(xdev, axlf, BITSTREAM)) {
 			xocl_xdev_info(xdev, "check interface uuid");
 			if (!XDEV(xdev)->fdt_blob) {
 				userpf_err(xdev, "did not find platform dtb");


### PR DESCRIPTION
lite xclbin has to have the SOFT_KERNEL section since the METADATA and OBJ are coupled together. we don't need OBJ but do need METADATA