### PR TITLE
Add circular buffer in cu subdev for debug purpose

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/cu.c
@@ -30,24 +30,26 @@ struct xocl_cu {
 static ssize_t debug_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-#if 0
 	struct platform_device *pdev = to_platform_device(dev);
 	struct xocl_cu *cu = platform_get_drvdata(pdev);
 	struct xrt_cu *xcu = &cu->base;
-#endif
-	/* Place holder for now. */
-	return 0;
+
+	return sprintf(buf, "%d\n", xcu->debug);
 }
 
 static ssize_t debug_store(struct device *dev,
 	struct device_attribute *da, const char *buf, size_t count)
 {
-#if 0
 	struct platform_device *pdev = to_platform_device(dev);
 	struct xocl_cu *cu = platform_get_drvdata(pdev);
 	struct xrt_cu *xcu = &cu->base;
-#endif
-	/* Place holder for now. */
+	u32 debug;
+
+	if (kstrtou32(buf, 10, &debug) == -EINVAL)
+		return -EINVAL;
+
+	xcu->debug = debug;
+
 	return count;
 }
 
@@ -181,6 +183,22 @@ is_ucu_show(struct device *dev, struct device_attribute *attr, char *buf)
 }
 static DEVICE_ATTR_RO(is_ucu);
 
+static ssize_t
+crc_buf_show(struct file *filp, struct kobject *kobj,
+	     struct bin_attribute *attr, char *buf,
+	     loff_t offset, size_t count)
+{
+	struct device *dev = container_of(kobj, struct device, kobj);
+	struct xocl_cu *cu = (struct xocl_cu *)dev_get_drvdata(dev);
+	struct xrt_cu *xcu;
+
+	if (!cu)
+		return 0;
+
+	xcu = &cu->base;
+	return xrt_cu_circ_consume_all(xcu, buf, count);
+}
+
 static struct attribute *cu_attrs[] = {
 	&dev_attr_debug.attr,
 	&dev_attr_cu_stat.attr,
@@ -195,14 +213,31 @@ static struct attribute *cu_attrs[] = {
 	NULL,
 };
 
+static struct bin_attribute crc_buf_attr = {
+	.attr = {
+		.name = "crc_buf",
+		.mode = 0444
+	},
+	.read = crc_buf_show,
+	.write = NULL,
+	.size = 0,
+};
+
+static struct bin_attribute *cu_bin_attrs[] = {
+	&crc_buf_attr,
+	NULL,
+};
+
 static const struct attribute_group cu_attrgroup = {
 	.attrs = cu_attrs,
+	.bin_attrs = cu_bin_attrs,
 };
 
 irqreturn_t cu_isr(int irq, void *arg)
 {
 	struct xocl_cu *xcu = arg;
 
+	xrt_cu_circ_produce(&xcu->base, CU_LOG_STAGE_ISR, 0);
 	xrt_cu_clear_intr(&xcu->base);
 
 	up(&xcu->base.sem_cu);


### PR DESCRIPTION
1. Add a circular buffer and add a debug flag for CU subdev
2. The circular buffer can be read as binary format through sysfs
3. The debug flag can be set/clear through sysfs

Debug is by default false. In this case, everything is just like before (This has no impact on iops test result).

If debug is set, then the CU thread would put records into circular buffer when command stage change.
A record consist of stage, command unique ID and time stamp.

To enable debug,
$ echo 1 > /sys/bus/pci/devices/0000\:03\:00.1/cu.u.42991616/debug

To read circular buffer,
$ cat /sys/bus/pci/devices/0000\:03\:00.1/cu.u.42991616/crc_buf > /tmp/crc_buf.bin

Create a user space circular buffer analyzer is possible.