### PR TITLE
Update success message for p2p

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -99,7 +99,8 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
 
   uint64_t size = 0;
   try {
-    size = XBUtilities::string_to_bytes(m_size);
+    if(!m_size.empty())
+      size = XBUtilities::string_to_bytes(m_size);
   } 
   catch(const xrt_core::error&) {
     std::cerr << "Value supplied to --size option is invalid" << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -62,19 +62,6 @@ string2action(std::string str)
     throw xrt_core::generic_error(EINVAL, "Invalid p2p action '" + str + "'");
 }
 
-std::string
-print_success_msg(action_type action)
-{
-  if(action == action_type::enable)
-    return "Please WARM reboot the machine to enable P2P now.";
-  if(action == action_type::disable)
-    return "Please WARM reboot the machine to disable P2P now.";
-  if(action == action_type::validate)
-    return "P2P validated successfully.";
-  
-  throw xrt_core::error(std::errc::operation_canceled);
-}
-
 static auto
 p2p_config(xrt_core::device* device)
 {
@@ -297,7 +284,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
   // Honor help option first
   if (std::find(_options.begin(), _options.end(), "--help") != _options.end()) {
     printHelp();
-    throw xrt_core::error(std::errc::operation_canceled);
+    return;
   }
 
   // Parse sub-command ...
@@ -316,7 +303,7 @@ OO_P2P::execute(const SubCmdOptions& _options) const
 
   if (m_help) {
     printHelp();
-    throw xrt_core::error(std::errc::operation_canceled);
+    return;
   }
 
   // Validate the correct action value is used
@@ -369,6 +356,18 @@ OO_P2P::execute(const SubCmdOptions& _options) const
     std::cerr << "ERROR: " << ex.what() << std::endl;
     throw xrt_core::error(std::errc::operation_canceled); 
   }
-  std::cout << print_success_msg(action) << std::endl;
 
+  // Print success message for the user
+  switch (action) {
+    case action_type::enable:
+      std::cout <<  "Please WARM reboot the machine to enable P2P now.\n";
+      break;
+    
+    case action_type::disable:
+      std::cout << "Please WARM reboot the machine to disable P2P now.\n";
+      break;
+
+    case action_type::validate:
+      std::cout << "P2P validated successfully.\n";
+  }
 }


### PR DESCRIPTION
- Update return codes
- Print success message when p2p is enabled or disabled
```
$ sudo xbutil configure --p2p enable -d 65:00
Please WARM reboot the machine to enable P2P now.
$ sudo xbutil configure --p2p disable -d 65:00
Please WARM reboot the machine to disable P2P now.
```