### PR TITLE
CR-1100435: Changing when the user events trace file is added to the run summary

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
@@ -27,7 +27,6 @@ namespace xdp {
 
     VPWriter* writer = new UserEventsTraceWriter("user_events.csv") ;
     writers.push_back(writer) ;
-    (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
   }
 
   UserEventsPlugin::~UserEventsPlugin()
@@ -36,11 +35,19 @@ namespace xdp {
     {
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
-      for (auto w : writers)
-      {
+      for (auto w : writers) {
 	w->write(false) ;
+        db->getStaticInfo().addOpenedFile(w->getcurrentFileName(), "VP_TRACE");
       }
       db->unregisterPlugin(this) ;
+    }
+  }
+
+  void UserEventsPlugin::writeAll(bool openNewFiles)
+  {
+    XDPPlugin::writeAll(openNewFiles) ;
+    for (auto w : writers) {
+      db->getStaticInfo().addOpenedFile(w->getcurrentFileName(), "VP_TRACE") ;
     }
   }
 

--- a/src/runtime_src/xdp/profile/plugin/user/user_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/user/user_plugin.h
@@ -29,6 +29,9 @@ namespace xdp {
   public:
     UserEventsPlugin() ;
     ~UserEventsPlugin() ;
+
+    // Called when the database is destroyed before the plugin
+    virtual void writeAll(bool openNewFiles = true) ;
   } ;
 } // end namespace xdp
 


### PR DESCRIPTION
Previously, the user events trace file was listed in the run summary before the file was written, leading to problems in live trace mode in Vitis Analyzer when empty or partial files were attempted to be written.  This pull request changes the addition of the user event file to the run summary to after it is completely written.