### PR TITLE
Introduce SchemaVersion enum in get_info() template

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -109,37 +109,37 @@ PYBIND11_MODULE(pyxrt, m) {
                              /* Convert the value to string since we can have only one return type for get_info() */
                              switch (key) {
                              case xrt::info::device::bdf:
-                                 return d.get_info<xrt::info::device::bdf>();
+                                 return d.get_info<xrt::info::device::bdf, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::interface_uuid:
-                                 return d.get_info<xrt::info::device::interface_uuid>().to_string();
+                                 return d.get_info<xrt::info::device::interface_uuid, xrt::info::SchemaVersion::json_latest>().to_string();
                              case xrt::info::device::kdma:
-                                 return std::to_string(d.get_info<xrt::info::device::kdma>());
+                                 return std::to_string(d.get_info<xrt::info::device::kdma, xrt::info::SchemaVersion::json_latest>());
                              case xrt::info::device::max_clock_frequency_mhz:
-                                 return std::to_string(d.get_info<xrt::info::device::max_clock_frequency_mhz>());
+                                 return std::to_string(d.get_info<xrt::info::device::max_clock_frequency_mhz, xrt::info::SchemaVersion::json_latest>());
                              case xrt::info::device::m2m:
-                                 return std::to_string(d.get_info<xrt::info::device::m2m>());
+                                 return std::to_string(d.get_info<xrt::info::device::m2m, xrt::info::SchemaVersion::json_latest>());
                              case xrt::info::device::name:
-                                 return d.get_info<xrt::info::device::name>();
+                                 return d.get_info<xrt::info::device::name, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::nodma:
-                                 return std::to_string(d.get_info<xrt::info::device::nodma>());
+                                 return std::to_string(d.get_info<xrt::info::device::nodma, xrt::info::SchemaVersion::json_latest>());
                              case xrt::info::device::offline:
-                                 return std::to_string(d.get_info<xrt::info::device::offline>());
+                                 return std::to_string(d.get_info<xrt::info::device::offline, xrt::info::SchemaVersion::json_latest>());
                              case xrt::info::device::electrical:
-                                 return d.get_info<xrt::info::device::electrical>();
+                                 return d.get_info<xrt::info::device::electrical, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::thermal:
-                                 return d.get_info<xrt::info::device::thermal>();
+                                 return d.get_info<xrt::info::device::thermal, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::mechanical:
-                                 return d.get_info<xrt::info::device::mechanical>();
+                                 return d.get_info<xrt::info::device::mechanical, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::memory:
-                                 return d.get_info<xrt::info::device::memory>();
+                                 return d.get_info<xrt::info::device::memory, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::platform:
-                                 return d.get_info<xrt::info::device::platform>();
+                                 return d.get_info<xrt::info::device::platform, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::pcie_info:
-                                 return d.get_info<xrt::info::device::pcie_info>();
+                                 return d.get_info<xrt::info::device::pcie_info, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::host:
-                                 return d.get_info<xrt::info::device::host>();
+                                 return d.get_info<xrt::info::device::host, xrt::info::SchemaVersion::json_latest>();
                              case xrt::info::device::dynamic_regions:
-                                 return d.get_info<xrt::info::device::dynamic_regions>();
+                                 return d.get_info<xrt::info::device::dynamic_regions, xrt::info::SchemaVersion::json_latest>();
                              default:
                                  return std::string("NA");
                              }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -252,7 +252,7 @@ get_xclbin_section(axlf_section_kind section, const uuid& uuid) const
 
 boost::any
 device::
-get_info(info::device param) const
+get_info(info::device param, info::SchemaVersion version) const
 {
   switch (param) {
   case info::device::bdf :                    // std::string

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -105,6 +105,28 @@ enum class device : unsigned int {
   dynamic_regions
 };
 
+/*!
+ * @enum SchemaVersion 
+ *
+ * @brief
+ * Json schemaVersion parameters
+ *
+ * @details
+ * Use with `xrt::device::get_info()` to retrieve a perticular version 
+ * of schema of the properties.
+ *
+ * @var json_latest 
+ *  Latest json schema
+ * @var json_20202 
+ *  Json 2020.2 schema
+ */
+enum class SchemaVersion  {
+  unknown,
+  json_latest,
+  json_internal,
+  json_20202,
+};
+
 /// @cond 
 /*
  * Return type for xrt::device::get_info()
@@ -243,19 +265,19 @@ public:
    * get_info() - Retrieve device parameter information
    *
    * This function is templated on the enumeration value as defined in
-   * the enumeration xrt::info::device.
+   * the enumeration xrt::info::device and xrt::info::SchemaVersion.
    *
    * The return type of the parameter is based on the instantiated
    * param_traits for the given param enumeration supplied as template
    * argument, see namespace xrt::info
    */
-  template <info::device param>
+  template <info::device param, info::SchemaVersion version>
   typename info::param_traits<info::device, param>::return_type
   get_info() const
   {
     return boost::any_cast<
       typename info::param_traits<info::device, param>::return_type  
-    >(get_info(param));
+    >(get_info(param, version));
   }
 
   /**
@@ -368,7 +390,7 @@ private:
 
   XCL_DRIVER_DLLESPEC
   boost::any
-  get_info(info::device param) const;
+  get_info(info::device param, info::SchemaVersion version) const;
 
 private:
   std::shared_ptr<xrt_core::device> handle;

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -24,10 +24,10 @@
 
 // Initialize our static mapping.
 const Report::SchemaDescriptionVector Report::m_schemaVersionVector = {
-  { SchemaVersion::unknown,       false, "",              "Unknown entry"},
-  { SchemaVersion::json_20202,    true,  "JSON",          "Latest JSON schema"}, // Note: to be updated to the latest schema version every release
-  { SchemaVersion::json_internal, false, "JSON-internal", "Internal JSON property tree"},
-  { SchemaVersion::json_20202,    true,  "JSON-2020.2",   "JSON 2020.2 schema"}
+  { xrt::info::SchemaVersion::unknown,       false, "",              "Unknown entry"},
+  { xrt::info::SchemaVersion::json_latest,    true,  "JSON",          "Latest JSON schema"},
+  { xrt::info::SchemaVersion::json_internal, false, "JSON-internal", "Internal JSON property tree"},
+  { xrt::info::SchemaVersion::json_20202,    true,  "JSON-2020.2",   "JSON 2020.2 schema"}
 };
 
 
@@ -45,7 +45,7 @@ Report::getSchemaDescription(const std::string & _schemaVersionName)
 }
 
 const Report::SchemaDescription & 
-Report::getSchemaDescription(SchemaVersion _schemaVersion)
+Report::getSchemaDescription(xrt::info::SchemaVersion _schemaVersion)
 {
   // Look for a match
   for (const auto & entry : m_schemaVersionVector) {
@@ -54,7 +54,7 @@ Report::getSchemaDescription(SchemaVersion _schemaVersion)
   }
 
   // Return back the unknown entry
-  return getSchemaDescription(SchemaVersion::unknown);
+  return getSchemaDescription(xrt::info::SchemaVersion::unknown);
 }
 
 
@@ -71,18 +71,22 @@ Report::Report(const std::string & _reportName,
 
 void 
 Report::getFormattedReport( const xrt_core::device *pDevice, 
-                            SchemaVersion schemaVersion,
+                            xrt::info::SchemaVersion schemaVersion,
                             const std::vector<std::string> & elementFilter,
                             std::ostream & consoleStream,
                             boost::property_tree::ptree & pt) const
 {
   try {
     switch (schemaVersion) {
-      case SchemaVersion::json_internal:
+      case xrt::info::SchemaVersion::json_internal:
         getPropertyTreeInternal(pDevice, pt);
         break;
 
-      case SchemaVersion::json_20202:
+      case xrt::info::SchemaVersion::json_20202:
+        getPropertyTree20202(pDevice, pt);
+        break;
+      
+      case xrt::info::SchemaVersion::json_latest: // Note: to be updated to the latest schema version every release
         getPropertyTree20202(pDevice, pt);
         break;
 

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -30,15 +30,10 @@ class Report {
   // 
   // Remember to update the initialization of Report::m_schemaVersionMapping 
   // if new enumeration values are added
-  enum class SchemaVersion  {
-    unknown,
-    json_internal,
-    json_20202,
-  };
  
   // Helper mapping between string and enum
   struct SchemaDescription {
-    SchemaVersion schemaVersion;
+    xrt::info::SchemaVersion schemaVersion;
     bool isVisable;
     std::string optionName;
     std::string shortDescription;
@@ -48,7 +43,7 @@ class Report {
   static const SchemaDescriptionVector m_schemaVersionVector;
 
   static const Report::SchemaDescription & getSchemaDescription(const std::string & _schemaVersionName);
-  static const Report::SchemaDescription & getSchemaDescription(SchemaVersion _schemaVersion);
+  static const Report::SchemaDescription & getSchemaDescription(xrt::info::SchemaVersion _schemaVersion);
   static const SchemaDescriptionVector & getSchemaDescriptionVector() { return m_schemaVersionVector; };
 
   // Supporting APIs
@@ -57,7 +52,7 @@ class Report {
   const std::string & getShortDescription() const { return m_shortDescription; };
   bool isDeviceRequired() const { return m_isDeviceRequired; };
 
-  void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
+  void getFormattedReport(const xrt_core::device *_pDevice, xrt::info::SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 
  // Child methods that need to be implemented
  protected:

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -248,7 +248,7 @@ populate_cus_new(const xrt_core::device *device)
   boost::property_tree::ptree pt_dynamic_regions;
   xrt::device dev(device->get_device_id());
   std::stringstream ss;
-  ss << dev.get_info<xrt::info::device::dynamic_regions>();
+  ss << dev.get_info<xrt::info::device::dynamic_regions, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, pt_dynamic_regions);
   pt_dynamic_regions.add_child("compute_units", pt);
   return pt_dynamic_regions;

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -37,7 +37,7 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
   xrt::device device(_pDevice->get_device_id());
   boost::property_tree::ptree pt_electrical;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::electrical>();
+  ss << device.get_info<xrt::info::device::electrical, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, pt_electrical);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportMechanical.cpp
+++ b/src/runtime_src/core/tools/common/ReportMechanical.cpp
@@ -37,7 +37,7 @@ ReportMechanical::getPropertyTree20202( const xrt_core::device * _pDevice,
   xrt::device device(_pDevice->get_device_id());
   boost::property_tree::ptree pt_mechanical;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::mechanical>();
+  ss << device.get_info<xrt::info::device::mechanical, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, pt_mechanical);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -63,7 +63,7 @@ ReportMemory::getPropertyTree20202( const xrt_core::device * _pDevice,
   xrt::device device(_pDevice->get_device_id());
   boost::property_tree::ptree pt_memory;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::memory>();
+  ss << device.get_info<xrt::info::device::memory, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, pt_memory);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
@@ -38,7 +38,7 @@ ReportPcieInfo::getPropertyTree20202( const xrt_core::device * dev,
   xrt::device device(dev->get_device_id());
   boost::property_tree::ptree pt_pcie_info;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::pcie_info>();
+  ss << device.get_info<xrt::info::device::pcie_info, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, pt_pcie_info);
   
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -39,7 +39,7 @@ ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev,
   xrt::device device(dev->get_device_id());
   boost::property_tree::ptree pt_platform;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::platform>();
+  ss << device.get_info<xrt::info::device::platform, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, pt_platform);
  
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportThermal.cpp
+++ b/src/runtime_src/core/tools/common/ReportThermal.cpp
@@ -37,7 +37,7 @@ ReportThermal::getPropertyTree20202( const xrt_core::device * _pDevice,
 {
   xrt::device device(_pDevice->get_device_id());
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::thermal>();
+  ss << device.get_info<xrt::info::device::thermal, xrt::info::SchemaVersion::json_20202>();
   boost::property_tree::read_json(ss, _pt);
 }
 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -627,7 +627,7 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
 void 
 XBUtilities::produce_reports( xrt_core::device_collection devices, 
                               const ReportCollection & reportsToProcess, 
-                              Report::SchemaVersion schemaVersion, 
+                              xrt::info::SchemaVersion schemaVersion, 
                               std::vector<std::string> & elementFilter,
                               std::ostream & consoleStream,
                               std::ostream & schemaStream)
@@ -638,7 +638,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
     return;
   }
 
-  if (schemaVersion == Report::SchemaVersion::unknown) {
+  if (schemaVersion == xrt::info::SchemaVersion::unknown) {
     consoleStream << "Info: No action taken, 'UNKNOWN' schema value specified.\n";
     return;
   }
@@ -765,7 +765,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
 
   // -- Write the formatted output 
   switch (schemaVersion) {
-    case Report::SchemaVersion::json_20202:
+    case xrt::info::SchemaVersion::json_20202:
       boost::property_tree::json_parser::write_json(schemaStream, ptRoot, true /*Pretty Print*/);
       schemaStream << std::endl;  
       break;

--- a/src/runtime_src/core/tools/common/XBHelpMenus.h
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.h
@@ -86,7 +86,7 @@ namespace XBUtilities {
   void 
      produce_reports( xrt_core::device_collection devices, 
                       const ReportCollection & reportsToProcess, 
-                      Report::SchemaVersion schema, 
+                      xrt::info::SchemaVersion schema, 
                       std::vector<std::string> & elementFilter,
                       std::ostream & consoleStream,
                       std::ostream & schemaStream);

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -139,7 +139,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   // -- Process the options --------------------------------------------
   ReportCollection reportsToProcess;            // Reports of interest
   xrt_core::device_collection deviceCollection;  // The collection of devices to examine
-  Report::SchemaVersion schemaVersion = Report::SchemaVersion::unknown;    // Output schema version
+  xrt::info::SchemaVersion schemaVersion = xrt::info::SchemaVersion::unknown;    // Output schema version
 
   try {
     // Collect the reports to be processed
@@ -154,7 +154,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
     // Output Format
     schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
-    if (schemaVersion == Report::SchemaVersion::unknown) 
+    if (schemaVersion == xrt::info::SchemaVersion::unknown) 
       throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
 
     // Output file

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -172,8 +172,8 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     sFormat = "json";
 
   // DRC: Examine the output format
-  Report::SchemaVersion schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
-  if (schemaVersion == Report::SchemaVersion::unknown) {
+  xrt::info::SchemaVersion schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
+  if (schemaVersion == xrt::info::SchemaVersion::unknown) {
     std::cerr << boost::format("ERROR: Unsupported --format option value '%s'") % sFormat << std::endl
               << boost::format("       Supported values can be found in --format's help section below.") << std::endl;
     printHelp(commonOptions, hiddenOptions);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1344,7 +1344,7 @@ print_status(test_status status, std::ostream & _ostream)
 static void
 get_platform_info(const std::shared_ptr<xrt_core::device>& device,
                   boost::property_tree::ptree& ptTree,
-                  Report::SchemaVersion /*schemaVersion*/,
+                  xrt::info::SchemaVersion /*schemaVersion*/,
                   std::ostream & oStream)
 {
   auto bdf = xrt_core::device_query<xrt_core::query::pcie_bdf>(device);
@@ -1377,7 +1377,7 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
 
 static test_status
 run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
-                       Report::SchemaVersion schemaVersion,
+                       xrt::info::SchemaVersion schemaVersion,
                        std::vector<TestCollection *> testObjectsToRun,
                        boost::property_tree::ptree& ptDevCollectionTestSuite)
 {
@@ -1432,7 +1432,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
 
 static bool
 run_tests_on_devices( xrt_core::device_collection &deviceCollection,
-                      Report::SchemaVersion schemaVersion,
+                      xrt::info::SchemaVersion schemaVersion,
                       std::vector<TestCollection *> testObjectsToRun,
                       std::ostream & output)
 {
@@ -1452,7 +1452,7 @@ run_tests_on_devices( xrt_core::device_collection &deviceCollection,
 
   // -- Write the formatted output
   switch (schemaVersion) {
-    case Report::SchemaVersion::json_20202:
+    case xrt::info::SchemaVersion::json_20202:
       boost::property_tree::json_parser::write_json(output, ptDevCollectionTestSuite, true /*Pretty Print*/);
       output << std::endl;
       break;
@@ -1553,11 +1553,11 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   }
 
   // -- Process the options --------------------------------------------
-  Report::SchemaVersion schemaVersion = Report::SchemaVersion::unknown;    // Output schema version
+  xrt::info::SchemaVersion schemaVersion = xrt::info::SchemaVersion::unknown;    // Output schema version
   try {
     // Output Format
     schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
-    if (schemaVersion == Report::SchemaVersion::unknown)
+    if (schemaVersion == xrt::info::SchemaVersion::unknown)
       throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
 
     // Output file

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -84,31 +84,31 @@ int run(int argc, char** argv)
   if (uuid != xclbin.get_uuid())
     throw std::runtime_error("Unexpected uuid error");
 
-  std::cout << "device name:           " << device.get_info<xrt::info::device::name>() << "\n";
-  std::cout << "device bdf:            " << device.get_info<xrt::info::device::bdf>() << "\n";
-  std::cout << "device kdma:           " << device.get_info<xrt::info::device::kdma>() << "\n";
-  std::cout << "device max freq:       " << device.get_info<xrt::info::device::max_clock_frequency_mhz>() << "\n";
-  std::cout << "device m2m:            " << std::boolalpha << device.get_info<xrt::info::device::m2m>() << std::dec << "\n";
-  std::cout << "device nodma:          " << std::boolalpha << device.get_info<xrt::info::device::nodma>() << std::dec << "\n";
-  std::cout << "device interface uuid: " << device.get_info<xrt::info::device::interface_uuid>().to_string() << "\n";
+  std::cout << "device name:           " << device.get_info<xrt::info::device::name, xrt::info::SchemaVersion::json_latest>() << "\n";
+  std::cout << "device bdf:            " << device.get_info<xrt::info::device::bdf, xrt::info::SchemaVersion::json_latest>() << "\n";
+  std::cout << "device kdma:           " << device.get_info<xrt::info::device::kdma, xrt::info::SchemaVersion::json_latest>() << "\n";
+  std::cout << "device max freq:       " << device.get_info<xrt::info::device::max_clock_frequency_mhz, xrt::info::SchemaVersion::json_latest>() << "\n";
+  std::cout << "device m2m:            " << std::boolalpha << device.get_info<xrt::info::device::m2m, xrt::info::SchemaVersion::json_latest>() << std::dec << "\n";
+  std::cout << "device nodma:          " << std::boolalpha << device.get_info<xrt::info::device::nodma, xrt::info::SchemaVersion::json_latest>() << std::dec << "\n";
+  std::cout << "device interface uuid: " << device.get_info<xrt::info::device::interface_uuid, xrt::info::SchemaVersion::json_latest>().to_string() << "\n";
 
   if (json_queries) {
     std::cout << "device electrical json info ====================================\n";
-    std::cout << device.get_info<xrt::info::device::electrical>();
+    std::cout << device.get_info<xrt::info::device::electrical, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device thermal json info =======================================\n";
-    std::cout << device.get_info<xrt::info::device::thermal>();
+    std::cout << device.get_info<xrt::info::device::thermal, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device mechanical json info ====================================\n";
-    std::cout << device.get_info<xrt::info::device::mechanical>();
+    std::cout << device.get_info<xrt::info::device::mechanical, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device memory json info ========================================\n";
-    std::cout << device.get_info<xrt::info::device::memory>();
+    std::cout << device.get_info<xrt::info::device::memory, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device platform json info ======================================\n";
-    std::cout << device.get_info<xrt::info::device::platform>();
+    std::cout << device.get_info<xrt::info::device::platform, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device pcie json info ==========================================\n";
-    std::cout << device.get_info<xrt::info::device::pcie_info>();
+    std::cout << device.get_info<xrt::info::device::pcie_info, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device dynamic regions json info ===============================\n";
-    std::cout << device.get_info<xrt::info::device::dynamic_regions>();
+    std::cout << device.get_info<xrt::info::device::dynamic_regions, xrt::info::SchemaVersion::json_latest>();
     std::cout << "device host json info ==========================================\n";
-    std::cout << device.get_info<xrt::info::device::host>();
+    std::cout << device.get_info<xrt::info::device::host, xrt::info::SchemaVersion::json_latest>();
   }
 
   return 0;

--- a/tests/xrt/reset/xcl.cpp
+++ b/tests/xrt/reset/xcl.cpp
@@ -54,7 +54,7 @@ SigBusHandler(int sig)
 
   // Create xrt::device from already opened xclDeviceHandle
   xrt::device d(dhdl);
-  if (!d.get_info<xrt::info::device::offline>())
+  if (!d.get_info<xrt::info::device::offline, xrt::info::SchemaVersion::json_latest>())
     throw std::runtime_error("Device is unexpectedly online");
 
   // Close device gracefully before existing on device reset
@@ -75,7 +75,7 @@ SigIntHandler(int sig)
 
   // Create xrt::device from already opened xclDeviceHandle
   xrt::device d(dhdl);
-  if (d.get_info<xrt::info::device::offline>())
+  if (d.get_info<xrt::info::device::offline, xrt::info::SchemaVersion::json_latest>())
     throw std::runtime_error("Device is unexpectedly offline");
 
   // Close device gracefully before existing on ctrl-c

--- a/tests/xrt/reset/xrt.cpp
+++ b/tests/xrt/reset/xrt.cpp
@@ -50,7 +50,7 @@ SigBusHandler(int sig)
   std::lock_guard<std::mutex> lk(mutex);
   std::cout  << "-> sig bus handler\n";
 
-  if (!device.get_info<xrt::info::device::offline>())
+  if (!device.get_info<xrt::info::device::offline, xrt::info::SchemaVersion::json_latest>())
     throw std::runtime_error("Device is unexpectedly online");
 
   // Close device gracefully before existing on device reset
@@ -69,7 +69,7 @@ SigIntHandler(int sig)
   std::lock_guard<std::mutex> lk(mutex);
   std::cout  << "-> sig int handler\n";
 
-  if (device.get_info<xrt::info::device::offline>())
+  if (device.get_info<xrt::info::device::offline, xrt::info::SchemaVersion::json_latest>())
     throw std::runtime_error("Device is unexpectedly offline");
 
   // Nothing to close device will auto close


### PR DESCRIPTION
- Share `SchemaVersion` enum between `xrt_device.h` and `Report.h`
- Updated documentation for github.io
- Fixed test cases