### PR TITLE
CR-1101751 add scaling temp override support

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -98,6 +98,7 @@ enum class key_type
   xmc_reg_base,
   xmc_scaling_enabled,
   xmc_scaling_override,
+  xmc_scaling_temp_override,
   xmc_scaling_reset,
   xmc_qspi_status,
 
@@ -1000,6 +1001,20 @@ struct xmc_scaling_override: request
   using result_type = std::string;  // get value type
   using value_type = std::string;   // put value type
   static const key_type key = key_type::xmc_scaling_override;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+
+};
+
+struct xmc_scaling_temp_override: request
+{
+  using result_type = std::string;  // get value type
+  using value_type = std::string;   // put value type
+  static const key_type key = key_type::xmc_scaling_temp_override;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -458,6 +458,7 @@ initialize_query_table()
   emplace_sysfs_get<query::xmc_reg_base>                       ("xmc", "reg_base");
   emplace_sysfs_getput<query::xmc_scaling_enabled>             ("xmc", "scaling_enabled");
   emplace_sysfs_getput<query::xmc_scaling_override>            ("xmc", "scaling_threshold_power_override");
+  emplace_sysfs_getput<query::xmc_scaling_temp_override>       ("xmc", "scaling_threshold_temp_override");
   emplace_sysfs_put<query::xmc_scaling_reset>                  ("xmc", "scaling_reset");
   emplace_sysfs_get<query::m2m>                                ("m2m", "");
   emplace_sysfs_get<query::nodma>                              ("", "nodma");

--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.h
@@ -36,6 +36,7 @@ class OO_Config : public OptionOptions {
   std::string m_security;
   std::string m_clk_scale;
   std::string m_power_override;
+  std::string m_temp_override;
   std::string m_cs_reset;
   bool m_show;
   bool m_ddr;


### PR DESCRIPTION
Add scaling temp override feature using config command

$xbmgmt advanced --config --cs_threshold_temp_override <temp_val>--device <bdf>

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>