### PR TITLE
CR-1101816 The transfer of gm2aie/aie2gm will longer when I allocate

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -52,7 +52,10 @@ namespace zynqaie {
 struct BD {
     uint16_t bd_num;
     int      buf_fd;
-#ifndef __AIESIM__
+#ifdef __AIESIM__
+    char     *vaddr;
+    size_t   size;
+#else
     XAie_MemInst memInst;
 #endif
 };

--- a/src/runtime_src/core/edge/user/aie/aie.h
+++ b/src/runtime_src/core/edge/user/aie/aie.h
@@ -51,9 +51,10 @@ namespace zynqaie {
 
 struct BD {
     uint16_t bd_num;
-    char     *vaddr;
-    size_t   size;
     int      buf_fd;
+#ifndef __AIESIM__
+    XAie_MemInst memInst;
+#endif
 };
 
 struct DMAChannel {

--- a/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
+++ b/src/runtime_src/core/edge/user/aie/common_layer/adf_runtime_api.h
@@ -76,7 +76,11 @@ public:
     virtual ~gmio_api() {}
 
     err_code configure();
+#ifndef __AIESIM__
+    err_code enqueueBD(XAie_MemInst *memInst, uint64_t offset, size_t size);
+#else
     err_code enqueueBD(uint64_t address, size_t size);
+#endif
     err_code wait();
 
 private:


### PR DESCRIPTION
extra unused space with GM

XRT GMIO implementation was calling XAie_DmaSetAddrLen to config BD, which requires passing in a virtual address. To obtain a virtual address from a DMA buf, we need call mmap/munmap in the critical path.
AIE driver has a new API XAie_DmaSetAddrOffsetLen where we only need to pass in offset of the DMA buf.

This PR is to make use of the new API to avoid mmap/munmap in the critical path.

@jerryhsu-xilinx please take a look at the code changes, especially the impact to AIE SIM.