### PR TITLE
Changed default catch for is_sc_fixed() to false

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -152,8 +152,8 @@ is_SC_fixed(unsigned int index)
   }
   catch (...) {
     //TODO Catching all the exceptions for now. We may need to catch specific exceptions
-    //Work-around. Assume that sc is fixed if above query failed
-    return true;
+    //Work-around. Assume that sc is not fixed if above query throws an exception
+    return false;
   }
 }
 


### PR DESCRIPTION
After a second set of reviews, it was determined that the try/catch routine in is_SC_fixed() should return a false value.

For further information regarding why this was changed, please review the comments in pull request:
https://github.com/Xilinx/XRT/pull/5671
