### PR TITLE
CR-1110028 xcopegasus1 (AWS host) firewall output Issue

### DIFF
--- a/src/runtime_src/core/tools/common/ReportFirewall.cpp
+++ b/src/runtime_src/core/tools/common/ReportFirewall.cpp
@@ -35,7 +35,6 @@ ReportFirewall::getPropertyTree20202( const xrt_core::device * _pDevice,
 {
   boost::property_tree::ptree pt;
   try {
-    pt.put("Description","Firewall Information");
     pt.put("firewall_level", xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
     pt.put("firewall_status", boost::format("0x%x") % xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice));
     pt.put("status", xrt_core::utils::parse_firewall_status(static_cast<unsigned int>(xrt_core::device_query<xrt_core::query::firewall_detect_level>(_pDevice))));


### PR DESCRIPTION
CR-1110028 xcopegasus1 (AWS host) firewall output Issue
When firewall IP is not present, print
```
Firewall
    Information Unavailable
```