### PR TITLE
CR-1108493 : Fix for multiple zocl load/unload

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -1032,11 +1032,14 @@ static bool check_for_reserved_memory(uint64_t start_addr, size_t size)
 			 * in this reserved memory region
 			 */
 			if (start_addr >= res_mem.start &&
-					size <= resource_size(&res_mem))
+					size <= resource_size(&res_mem)) {
+				of_node_put(mem_np);
 				return true;
+			}
 		}
 	}
 
+	of_node_put(mem_np);
 	return false;
 }
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -1020,7 +1020,7 @@ static bool check_for_reserved_memory(uint64_t start_addr, size_t size)
 	struct resource res_mem;
 	int err;
 
-	mem_np = of_find_node_by_name(of_root, "reserved-memory");
+	mem_np = of_find_node_by_name(NULL, "reserved-memory");
 	if(!mem_np)
 		return false;
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -898,7 +898,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 	 * For PR platform, the FPGA manager is required. No good way to
 	 * determin if it is a PR platform at probe.
 	 */
-	fnode = of_find_node_by_name(of_root,
+	fnode = of_find_node_by_name(NULL,
 	    zdev->zdev_data_info->fpga_driver_name);
 	if (fnode) {
 		zdev->fpga_mgr = of_fpga_mgr_get(fnode);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -906,6 +906,7 @@ static int zocl_drm_platform_probe(struct platform_device *pdev)
 			zdev->fpga_mgr = NULL;
 		DRM_INFO("FPGA programming device %s founded.\n",
 		    zdev->zdev_data_info->fpga_driver_name);
+		of_node_put(fnode);
 	}
 
 	if (ZOCL_PLATFORM_ARM64) {


### PR DESCRIPTION
CR-1108493 : dfx-manager fails to load overlay after ~32 iterations . Linux OS hangs

**Issue:**
Unloading and loading zocl driver repeatedly over 45 times causes the Linux operating system to hang . 

**Root Cause:**
To get the pcap driver we are searching from device tree using "of_find_node_by_name" Kernel function. 
The params we are passing as "of_root" which is causing the issue. As per petaLinux kernel none of the module/driver used this param. Instead used NULL as a param to traverse all the node in the device tree. 

**Solution:**
Update the param to "NULL" in of_find_node_by_name function resolved the issue.  

**Test:**
```
for i in {1..100} 
do
  echo "Welcome $i times";
  rmmod zocl;
  insmod zocl.ko; 
done
```

Tested this solution on following boards:
zcu102
zcu102_dfx
vck190
