### PR TITLE
CR-1110133 fixing xbutil examine issue for edge

### DIFF
--- a/src/runtime_src/core/edge/common/device_edge.h
+++ b/src/runtime_src/core/edge/common/device_edge.h
@@ -40,6 +40,16 @@ public:
   xclDeviceHandle
   get_device_handle() const;
 
+  /**
+   * is_userpf_device() - there is no mgmt in edge
+   */
+  bool
+  is_userpf() const
+  {
+    return true;
+  }
+
+
 private:
   xclDeviceHandle m_handle = XRT_NULL_HANDLE;
   bool m_userpf;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1023,7 +1023,7 @@ zocl_xclbin_hold(struct drm_zocl_dev *zdev, const xuid_t *id)
 
 	// check whether uuid is null or not
 	if (uuid_is_null(id)) {
-		DRM_WARN("NULL uuid to hold.");
+		DRM_WARN("NULL uuid to hold\n");
 		return -EINVAL;
 	}
 	BUG_ON(!mutex_is_locked(&zdev->zdev_xclbin_lock));
@@ -1320,6 +1320,7 @@ void
 zocl_xclbin_fini(struct drm_zocl_dev *zdev)
 {
 	if (uuid_is_null(zdev->zdev_xclbin->zx_uuid)) {
+		DRM_WARN("no active uuid\n");
 		return;
 	}
 	vfree(zdev->zdev_xclbin->zx_uuid);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1021,7 +1021,11 @@ zocl_xclbin_hold(struct drm_zocl_dev *zdev, const xuid_t *id)
 {
 	xuid_t *xclbin_id = (xuid_t *)zocl_xclbin_get_uuid(zdev);
 
-	WARN_ON(uuid_is_null(id));
+	// check whether uuid is null or not
+	if (uuid_is_null(id)) {
+		DRM_WARN("NULL uuid to hold.");
+		return -EINVAL;
+	}
 	BUG_ON(!mutex_is_locked(&zdev->zdev_xclbin_lock));
 
 	if (!uuid_equal(id, xclbin_id)) {
@@ -1308,15 +1312,18 @@ zocl_xclbin_init(struct drm_zocl_dev *zdev)
 	}
 
 	zdev->zdev_xclbin->zx_refcnt = 0;
-	zdev->zdev_xclbin->zx_uuid = NULL;
+	zdev->zdev_xclbin->zx_uuid = &uuid_null;
 
 	return 0;
 }
 void
 zocl_xclbin_fini(struct drm_zocl_dev *zdev)
 {
+	if (uuid_is_null(zdev->zdev_xclbin->zx_uuid)) {
+		return;
+	}
 	vfree(zdev->zdev_xclbin->zx_uuid);
-	zdev->zdev_xclbin->zx_uuid = NULL;
+	zdev->zdev_xclbin->zx_uuid = &uuid_null;
 	vfree(zdev->zdev_xclbin);
 	zdev->zdev_xclbin = NULL;
 

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -315,6 +315,28 @@ struct kds_cu_info
   }
 };
 
+struct instance
+{
+  using result_type = query::instance::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    std::string errmsg;
+    auto edev = get_edgedev(device);
+
+    std::string drv_exists;
+    //check whether driver directory exists or not
+    edev->sysfs_get("driver", errmsg, drv_exists);
+    if (!errmsg.empty())
+      throw xrt_core::query::sysfs_error(errmsg);
+
+    //edge always has only one device. Return 0 if driver node is present
+    return 0;
+  }
+};
+
+
 struct aie_reg_read
 {
   using result_type = query::aie_reg_read::result_type;
@@ -328,7 +350,7 @@ struct aie_reg_read
     const auto row = boost::any_cast<query::aie_reg_read::row_type>(r) + 1;
     const auto col = boost::any_cast<query::aie_reg_read::col_type>(c);
     const auto v = boost::any_cast<query::aie_reg_read::reg_type>(reg);
- 
+
 #ifdef XRT_ENABLE_AIE
 #ifndef __AIESIM__
   const static std::string AIE_TAG = "aie_metadata";
@@ -567,6 +589,7 @@ initialize_query_table()
 
   emplace_sysfs_get<query::kds_mode>                    ("kds_mode");
   emplace_func0_request<query::kds_cu_stat,             kds_cu_stat>();
+  emplace_func0_request<query::instance,                instance>();
 }
 
 struct X { X() { initialize_query_table(); } };


### PR DESCRIPTION
xbutil examine is failing to get an instance as corresponding query is not defined in edge driver. Fixed in user space code.
xbutil examine -d 0 is crashing in zocl while holding the xclbin. uuid_equal is failing when we pass null uuid. Fixed zocl.
 