### PR TITLE
CR-1110386 port u2 flash changes from old xbmgmt tool

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -736,7 +736,7 @@ struct xclbin_full : request
   get(const device*) const = 0;
 };
 
-struct ic_enable: request
+struct ic_enable : request
 {
   using result_type = uint32_t;
   using value_type = uint32_t;
@@ -749,7 +749,7 @@ struct ic_enable: request
   put(const device*, const boost::any&) const = 0;
 };
 
-struct ic_load_flash_address: request
+struct ic_load_flash_address : request
 {
   using result_type = uint32_t;
   using value_type = uint32_t;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -85,6 +85,9 @@ enum class key_type
   ps_kernel,
   xocl_errors,
   xclbin_full,
+  ic_enable,
+  ic_load_flash_address,
+
 
   xmc_version,
   xmc_board_name,
@@ -731,6 +734,32 @@ struct xclbin_full : request
 
   virtual boost::any
   get(const device*) const = 0;
+};
+
+struct ic_enable: request
+{
+  using result_type = uint32_t;
+  using value_type = uint32_t;
+  static const key_type key = key_type::ic_enable;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+};
+
+struct ic_load_flash_address: request
+{
+  using result_type = uint32_t;
+  using value_type = uint32_t;
+  static const key_type key = key_type::ic_load_flash_address;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
 };
 
 struct aie_metadata : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -478,6 +478,8 @@ initialize_query_table()
   emplace_sysfs_get<query::rom_uuid>                           ("rom", "uuid");
   emplace_sysfs_get<query::rom_time_since_epoch>               ("rom", "timestamp");
   emplace_sysfs_get<query::xclbin_uuid>                        ("", "xclbinuuid");
+  emplace_sysfs_getput<query::ic_enable>                       ("icap_controller", "enable");
+  emplace_sysfs_getput<query::ic_load_flash_address>           ("icap_controller", "load_flash_addr");
   emplace_sysfs_get<query::memstat>                            ("", "memstat");
   emplace_sysfs_get<query::memstat_raw>                        ("", "memstat_raw");
   emplace_sysfs_get<query::mem_topology_raw>                   ("icap", "mem_topology");

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -884,62 +884,21 @@ struct recovery
   }
 };
 
-struct ic_enable
+struct icap_controller
 {
-  using result_type = uint32_t;
-  using value_type = uint32_t;
-  user_get(const xrt_core::device* device, key_type key)
+  using result_type = boost::any;
+
+  static result_type
+  user(const xrt_core::device*, key_type key)
   {
-    return 0;
+    throw userpf_not_supported_error(key);
   }
 
   static result_type
-  mgmt_get(const xrt_core::device* device, key_type key)
+  mgmt(const xrt_core::device*, key_type key)
   {
-    return 0;
+    throw mgmtpf_not_supported_error(key);
   }
-
-  static void
-  user_put(const xrt_core::device* device, value_type)
-  {
-    // we can throw an exception
-  }
-
-  static void
-  mgmt_put(const xrt_core::device* device, value_type val)
-  {
-    // we can throw an exception
-  }
-
-};
-
-struct ic_load_flash_address
-{
-  using result_type = uint32_t;
-  using value_type = uint32_t;
-  user_get(const xrt_core::device* device, key_type key)
-  {
-    return 0;
-  }
-
-  static result_type
-  mgmt_get(const xrt_core::device* device, key_type key)
-  {
-    return 0;
-  }
-
-  static void
-  user_put(const xrt_core::device* device, value_type)
-  {
-    // we can throw an exception
-  }
-
-  static void
-  mgmt_put(const xrt_core::device* device, value_type val)
-  {
-    // we can throw an exception
-  }
-
 };
 
 struct uuid
@@ -1497,8 +1456,8 @@ initialize_query_table()
   emplace_function0_getter<query::memstat_raw,               memstat_raw>();
   emplace_function0_getter<query::memstat,                   memstat>();
   emplace_function0_getter<query::group_topology,            group_topology>();
-  emplace_function0_getter<query::ic_enable                  ic_enable>();
-  emplace_function0_getter<query::ic_load_flash_address      ic_load_flash_address>();
+  emplace_function0_getter<query::ic_enable,                 icap_controller>();
+  emplace_function0_getter<query::ic_load_flash_address,     icap_controller>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -884,23 +884,6 @@ struct recovery
   }
 };
 
-struct icap_controller
-{
-  using result_type = boost::any;
-
-  static result_type
-  user(const xrt_core::device*, key_type key)
-  {
-    throw userpf_not_supported_error(key);
-  }
-
-  static result_type
-  mgmt(const xrt_core::device*, key_type key)
-  {
-    throw mgmtpf_not_supported_error(key);
-  }
-};
-
 struct uuid
 {
   using result_type = boost::any;
@@ -1456,8 +1439,6 @@ initialize_query_table()
   emplace_function0_getter<query::memstat_raw,               memstat_raw>();
   emplace_function0_getter<query::memstat,                   memstat>();
   emplace_function0_getter<query::group_topology,            group_topology>();
-  emplace_function0_getter<query::ic_enable,                 icap_controller>();
-  emplace_function0_getter<query::ic_load_flash_address,     icap_controller>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/pcie/windows/device_windows.cpp
+++ b/src/runtime_src/core/pcie/windows/device_windows.cpp
@@ -884,6 +884,64 @@ struct recovery
   }
 };
 
+struct ic_enable
+{
+  using result_type = uint32_t;
+  using value_type = uint32_t;
+  user_get(const xrt_core::device* device, key_type key)
+  {
+    return 0;
+  }
+
+  static result_type
+  mgmt_get(const xrt_core::device* device, key_type key)
+  {
+    return 0;
+  }
+
+  static void
+  user_put(const xrt_core::device* device, value_type)
+  {
+    // we can throw an exception
+  }
+
+  static void
+  mgmt_put(const xrt_core::device* device, value_type val)
+  {
+    // we can throw an exception
+  }
+
+};
+
+struct ic_load_flash_address
+{
+  using result_type = uint32_t;
+  using value_type = uint32_t;
+  user_get(const xrt_core::device* device, key_type key)
+  {
+    return 0;
+  }
+
+  static result_type
+  mgmt_get(const xrt_core::device* device, key_type key)
+  {
+    return 0;
+  }
+
+  static void
+  user_put(const xrt_core::device* device, value_type)
+  {
+    // we can throw an exception
+  }
+
+  static void
+  mgmt_put(const xrt_core::device* device, value_type val)
+  {
+    // we can throw an exception
+  }
+
+};
+
 struct uuid
 {
   using result_type = boost::any;
@@ -1439,6 +1497,8 @@ initialize_query_table()
   emplace_function0_getter<query::memstat_raw,               memstat_raw>();
   emplace_function0_getter<query::memstat,                   memstat>();
   emplace_function0_getter<query::group_topology,            group_topology>();
+  emplace_function0_getter<query::ic_enable                  ic_enable>();
+  emplace_function0_getter<query::ic_load_flash_address      ic_load_flash_address>();
 }
 
 struct X { X() { initialize_query_table(); }};

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
  *
  * This is a wrapper class that does the prep work required to program a flash
  * device. Flasher will create a specific flash object determined by the program
@@ -116,7 +116,14 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         {
             retVal = xspi.xclUpgradeFirmware2(*primary, *secondary);
         }
-        break;
+
+        // program icap controller for webstar flow. Required only for U.2
+        try {
+            uint32_t enable = 1;
+            xrt_core::device_update<xrt_core::query::ic_enable>(m_device.get(), enable);
+        } catch (...) {}
+
+	break;
     }
     case BPI:
     {

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -121,6 +121,7 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
         try {
             uint32_t enable = 1;
             xrt_core::device_update<xrt_core::query::ic_enable>(m_device.get(), enable);
+            std::cout << "Successfully enabled icap controller ip for wbstar flow" << std::endl;
         } catch (...) {}
 
 	break;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.cpp
@@ -2173,6 +2173,7 @@ static int programXSpiDrv(xrt_core::device *dev, std::FILE *mFlashDev, std::istr
     // provide flash controller information to icap controller for webstar flow. Required only for U.2
     try {
         xrt_core::device_update<xrt_core::query::ic_load_flash_address>(dev, startAddr);
+        std::cout << "Successfully programmed flash address into icap controller ip" << std::endl;
     } catch (...) {}
 
     return 0;


### PR DESCRIPTION
In wbstart flow on u2, xbmgmt flasher driver uses icap controller IP to start (enable) the icap programming and to load the flash offset address from where the next bit file should programmed on FPGA.

Ported from original PR https://github.com/Xilinx/XRT/pull/3761 

Signed-off-by: Ch Vamshi Krishna <chvamshi@xilinx.com>
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>