### PR TITLE
CR-1108703 enable XCL_MAILBOX_REQ opcode for u30

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -234,6 +234,7 @@ enum class key_type
 
   config_mailbox_channel_disable,
   config_mailbox_channel_switch,
+  config_xclbin_change,
   cache_xclbin,
 
   clock_timestamp,
@@ -2512,6 +2513,20 @@ struct config_mailbox_channel_switch : request
   using value_type = std::string;   // put value type
 
   static const key_type key = key_type::config_mailbox_channel_switch;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+};
+
+struct config_xclbin_change : request
+{
+  using result_type = std::string;  // get value type
+  using value_type = std::string;   // put value type
+
+  static const key_type key = key_type::config_xclbin_change;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -907,19 +907,11 @@ void xclmgmt_mailbox_srv(void *arg, void *data, size_t len,
 		 * Note:
 		 * 1. it is up to the admin to put authentificated xclbins at
 		 *    predefined location
-		 * 2. the fetched xclbin buf need to be freed here after use
 		 */
 		if (fetch)
-			xclbin = xclmgmt_xclbin_fetch(lro, xclbin);
-
-		if (xclbin) {
+			ret = xclmgmt_xclbin_fetch_and_download(lro, xclbin);
+		else
 			ret = xocl_xclbin_download(lro, xclbin);
-
-			if (fetch)
-				vfree(xclbin);
-		} else {
-			ret = -EINVAL;
-		}
 
 		(void) xocl_peer_response(lro, req->req, msgid, &ret,
 			sizeof(ret));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -200,7 +200,7 @@ int xclmgmt_program_shell(struct xclmgmt_dev *lro);
 void xclmgmt_ocl_reset(struct xclmgmt_dev *lro);
 void xclmgmt_ert_reset(struct xclmgmt_dev *lro);
 void xclmgmt_softkernel_reset(struct xclmgmt_dev *lro);
-struct axlf* xclmgmt_xclbin_fetch(struct xclmgmt_dev *lro, const struct axlf *xclbin);
+int xclmgmt_xclbin_fetch_and_download(struct xclmgmt_dev *lro, const struct axlf *xclbin);
 
 /* bifurcation-reset.c */
 long xclmgmt_hot_reset_bifurcation(struct xclmgmt_dev *lro,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.h
@@ -161,6 +161,9 @@ struct xclmgmt_dev {
 	/* preloaded xclbin */
 	char* preload_xclbin;
 	atomic_t cache_xclbin;
+
+	/* need to change fake xclbin to real xclbin */
+	atomic_t config_xclbin_change;
 };
 
 extern int health_check;
@@ -197,6 +200,7 @@ int xclmgmt_program_shell(struct xclmgmt_dev *lro);
 void xclmgmt_ocl_reset(struct xclmgmt_dev *lro);
 void xclmgmt_ert_reset(struct xclmgmt_dev *lro);
 void xclmgmt_softkernel_reset(struct xclmgmt_dev *lro);
+struct axlf* xclmgmt_xclbin_fetch(struct xclmgmt_dev *lro, const struct axlf *xclbin);
 
 /* bifurcation-reset.c */
 long xclmgmt_hot_reset_bifurcation(struct xclmgmt_dev *lro,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-sysfs.c
@@ -493,6 +493,34 @@ static DEVICE_ATTR(cache_xclbin, 0644,
 	cache_xclbin_show,
 	cache_xclbin_store);
 
+static ssize_t config_xclbin_change_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
+
+	return sprintf(buf, "%d\n", atomic_read(&lro->config_xclbin_change));
+}
+
+static ssize_t config_xclbin_change_store(struct device *dev,
+	struct device_attribute *da, const char *buf, size_t count)
+{
+	struct xclmgmt_dev *lro = dev_get_drvdata(dev);
+	u32 val;
+
+	if (kstrtou32(buf, 10, &val) == -EINVAL)
+		return -EINVAL;
+
+	if (val)
+		atomic_set(&lro->config_xclbin_change, 1);
+	else
+		atomic_set(&lro->config_xclbin_change, 0);
+
+	return count;
+}
+static DEVICE_ATTR(config_xclbin_change, 0644,
+	config_xclbin_change_show,
+	config_xclbin_change_store);
+
 static struct attribute *mgmt_attrs[] = {
 	&dev_attr_instance.attr,
 	&dev_attr_error.attr,
@@ -522,6 +550,7 @@ static struct attribute *mgmt_attrs[] = {
 	&dev_attr_mgmt_reset.attr,
 	&dev_attr_sbr_toggle.attr,
 	&dev_attr_cache_xclbin.attr,
+	&dev_attr_config_xclbin_change.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -855,3 +855,77 @@ void xclmgmt_softkernel_reset(struct xclmgmt_dev *lro)
 {
 	xocl_ps_sk_reset(lro);
 }
+
+static const void* xclmgmt_get_interface_uuid(struct xclmgmt_dev *lro) {
+	int node = -1;
+	const void *uuid;
+
+	if (!lro->core.fdt_blob)
+		return NULL;
+
+	/*
+	 * don't need blp uuid. do we have multiple interface uuid?
+	 */ 
+	node = xocl_fdt_get_next_prop_by_name(lro, lro->core.fdt_blob,
+		-1, PROP_INTERFACE_UUID, &uuid, NULL);
+	if (!uuid || node < 0)
+		return NULL;
+
+	return uuid;
+}
+/*
+ * the xclbins are at
+ * /lib/firmware/xilnx/xclbins/, with format
+ *  uuidA_uuidB.xclbin, where,
+ *  uuidA is the uuid of xclbin (type uuid_t)
+ *  uuidB is the interface uuid of xclbin (type char*)
+ *  both of the uuids are exactly the same to the output of
+ *  xclbinutil --info --input path_to_xclbin |grep -i uuid
+ *  eg
+ *  6250ec80-3f38-4be0-ac90-68bfd3c140a8_937ed70867cf3350bc06304053f4293c.xclbin
+ */
+struct axlf* xclmgmt_xclbin_fetch(struct xclmgmt_dev *lro, const struct axlf *xclbin)
+{
+	const char *interface_uuid;
+	char fw_name[256];
+	const struct firmware *fw;
+	const char* xclbin_location = "xilinx/xclbins";
+	struct axlf* xclbin_ret = NULL;
+	int err;
+
+	interface_uuid = xclmgmt_get_interface_uuid(lro);
+	if (!interface_uuid)
+		goto done;
+	memset(fw_name, 0, sizeof (fw_name));
+
+	snprintf(fw_name, sizeof(fw_name), "%s/"
+		"%02x%02x%02x%02x-"
+		"%02x%02x-"
+		"%02x%02x-"
+		"%02x%02x-"
+		"%02x%02x%02x%02x%02x%02x"
+		"_%s.xclbin",
+		xclbin_location,
+		xclbin->m_header.uuid.b[0], xclbin->m_header.uuid.b[1],
+		xclbin->m_header.uuid.b[2], xclbin->m_header.uuid.b[3],
+		xclbin->m_header.uuid.b[4], xclbin->m_header.uuid.b[5],
+		xclbin->m_header.uuid.b[6], xclbin->m_header.uuid.b[7],
+		xclbin->m_header.uuid.b[8], xclbin->m_header.uuid.b[9],
+		xclbin->m_header.uuid.b[10],xclbin->m_header.uuid.b[11],
+		xclbin->m_header.uuid.b[12],xclbin->m_header.uuid.b[13],
+		xclbin->m_header.uuid.b[14],xclbin->m_header.uuid.b[15],
+	       	interface_uuid);
+
+	mgmt_info(lro, "try loading fw: %s", fw_name);
+	err = request_firmware(&fw, fw_name, &lro->core.pdev->dev);
+	if (err)
+		goto done;
+
+	xclbin_ret = vmalloc(fw->size);
+	if (!xclbin_ret)
+		goto done;
+
+	memcpy(xclbin_ret, fw->data, fw->size);
+done:
+	return xclbin_ret;
+}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -212,13 +212,13 @@ MODULE_PARM_DESC(mailbox_no_intr,
 #define	PACKET_SIZE	16 /* Number of DWORD. */
 
 /*
- * monitor real receive pkt rate for every 8k Bytes.
+ * monitor real receive pkt rate for every 128k Bytes.
  * if the rate is higher than 1MB/s, we think user is trying to
  * transfer xclbin on h/w mailbox, if higher than 1.8MB/s, we think
  * user is doing DOS attack. Neither is allowd. We set a threshold
  * 600000B/s and don't expect any normal msg transfer exceeds it
  */
-#define	RECV_WINDOW_SIZE	0x800 /* Number of DWORD. */
+#define	RECV_WINDOW_SIZE	0x8000 /* Number of DWORD. */
 #define	RECV_RATE_THRESHOLD	600000
 
 #define	FLAG_STI	(1 << 0)
@@ -1156,6 +1156,7 @@ static bool check_recv_pkt_rate(struct mailbox *mbx)
 		mailbox_disable_intr_mode(mbx, false);
 		return false;
 	}
+	MBX_INFO(mbx, "recv pkt rate: %ld B/s", rate);
 
 	return true;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -1425,7 +1425,6 @@ static void xocl_pack_subdev(xdev_handle_t xdev_hdl, struct xocl_subdev *subdev)
 
 	BUG_ON(!subdev || !subdev->res || !subdev->res_name || !subdev->bar_idx);
 
-		xocl_xdev_info(xdev_hdl, "####res num %d", subdev->info.num_res);
 	res = kzalloc(sizeof (struct resource)
 		* subdev->info.num_res, GFP_KERNEL);
 	res_name = kzalloc(XOCL_SUBDEV_RES_NAME_LEN

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -623,6 +623,7 @@ initialize_query_table()
   emplace_sysfs_get<query::ert_data_integrity>               ("ert_user", "data_integrity");
   emplace_sysfs_getput<query::config_mailbox_channel_disable> ("", "config_mailbox_channel_disable");
   emplace_sysfs_getput<query::config_mailbox_channel_switch> ("", "config_mailbox_channel_switch");
+  emplace_sysfs_getput<query::config_xclbin_change>          ("", "config_xclbin_change");
   emplace_sysfs_getput<query::cache_xclbin>                  ("", "cache_xclbin");
 
   emplace_sysfs_get<query::kds_mode>                         ("", "kds_mode");

--- a/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
@@ -146,8 +146,9 @@ OO_LoadConfig::execute(const SubCmdOptions& _options) const
 /*
  * so far, we only support the following configs, eg.
  * [Device]
- * mailbox_channel_disable = 0x120
+ * mailbox_channel_disable = 0x20
  * mailbox_channel_switch = 0
+ * xclbin_change = 1
  * cahce_xclbin = 0
  * we may support in the future, like,
  * [Daemon]
@@ -172,6 +173,10 @@ static void load_config(const std::shared_ptr<xrt_core::device>& _dev, const std
     }
     if (!key.first.compare("mailbox_channel_switch")) {
       xrt_core::device_update<xrt_core::query::config_mailbox_channel_switch>(_dev.get(), key.second.get_value<std::string>());
+      continue;
+    }
+    if (!key.first.compare("xclbin_change")) {
+      xrt_core::device_update<xrt_core::query::config_xclbin_change>(_dev.get(), key.second.get_value<std::string>());
       continue;
     }
     if (!key.first.compare("cache_xclbin")) {

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -77,8 +77,9 @@ is_supported(const std::shared_ptr<xrt_core::device>& dev)
 /*
  * so far, we only support the following configs, eg
  * [Device]
- * mailbox_channel_disable = 0x100
+ * mailbox_channel_disable = 0x20
  * mailbox_channel_switch = 0
+ * xclbin_change = 1
  * cache_xclbin = 0
  */
 static void
@@ -89,6 +90,7 @@ config_dump(const std::shared_ptr<xrt_core::device>& _dev, const std::string out
   boost::property_tree::ptree child;
   child.put("mailbox_channel_disable", xrt_core::device_query<xrt_core::query::config_mailbox_channel_disable>(_dev));
   child.put("mailbox_channel_switch", xrt_core::device_query<xrt_core::query::config_mailbox_channel_switch>(_dev));
+  child.put("xclbin_change", xrt_core::device_query<xrt_core::query::config_xclbin_change>(_dev));
   child.put("cache_xclbin", xrt_core::device_query<xrt_core::query::cache_xclbin>(_dev));
 
   if (is_supported(_dev)) {


### PR DESCRIPTION
1. add one more config item to 'xbmgmt advanced --load-config'. it is used to control whether xclmgmt need to fetch a new xclbin after receiving xclbin load request from xocl
2. add logic to fetch real xclbins before loading to h/w