### PR TITLE
CR-1110322: Add tracing of xrt::ip read_register and write_register when native API profiling enabled

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -20,6 +20,7 @@
 #define XCL_DRIVER_DLL_EXPORT  // exporting xrt_ip.h
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_ip.h"
+#include "core/common/api/native_profile.h"
 
 #include "core/common/device.h"
 #include "core/common/config_reader.h"
@@ -303,14 +304,18 @@ void
 ip::
 write_register(uint32_t offset, uint32_t data)
 {
-  handle->write_register(offset, data);
+  xdp::native::profiling_wrapper("xrt::ip::write_register",[this, offset, data]{
+    handle->write_register(offset, data);
+  }) ;
 }
 
 uint32_t
 ip::
 read_register(uint32_t offset) const
 {
-  return handle->read_register(offset);
+  return xdp::native::profiling_wrapper("xrt::ip::read_register", [this, offset] {
+    return handle->read_register(offset);
+  }) ;
 }
 
 xrt::ip::interrupt


### PR DESCRIPTION
Enable the generation of tracing data of xrt::ip::read_register and xrt::ip::write_register when native_xrt_trace=true by adding the profiling_wrapper.