### PR TITLE
CR-1110431, CR-1081361 and CR-1101247

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -727,7 +727,7 @@ alloc_nodma(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags, xrtMemoryGroup grp)
   }
   catch (const std::exception& ex) {
     auto fmt = boost::format("Failed to allocate host memory buffer (%s), make sure host bank is enabled "
-                             "(see xbutil host_mem --enable ...)") % ex.what();
+                             "(see xbutil configure --host-mem)") % ex.what();
     send_exception_message(fmt.str());
     throw;
   }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -33,22 +33,22 @@ add_static_region_info(const xrt_core::device* device, ptree_type& pt)
 
   static_region.add("vbnv", xrt_core::device_query<xq::rom_vbnv>(device));
 
-  std::vector<std::string> interface_uuids;
+  std::vector<std::string> logic_uuids;
   try {
-    interface_uuids = xrt_core::device_query<xq::interface_uuids>(device);
-    interface_uuids.erase
-      (std::remove_if(interface_uuids.begin(), interface_uuids.end(),
+    logic_uuids = xrt_core::device_query<xq::logic_uuids>(device);
+    logic_uuids.erase
+      (std::remove_if(logic_uuids.begin(), logic_uuids.end(),
                       [](const std::string& s) {
                         return s.empty();
-                      }), interface_uuids.end());
+                      }), logic_uuids.end());
   }
   catch (const xq::exception&) {
   }
   
-  if (!interface_uuids.empty())
-    static_region.add("interface_uuid", xq::interface_uuids::to_uuid_upper_string(interface_uuids[0]));
+  if (!logic_uuids.empty())
+    static_region.add("logic_uuid", xq::interface_uuids::to_uuid_upper_string(logic_uuids[0]));
   else 
-    static_region.add("interface_uuid", (boost::format("0x%x") % xrt_core::device_query<xq::rom_time_since_epoch>(device)));
+    static_region.add("logic_uuid", (boost::format("0x%x") % xrt_core::device_query<xq::rom_time_since_epoch>(device)));
 
   try {
     static_region.add("jtag_idcode", xq::idcode::to_string(xrt_core::device_query<xq::idcode>(device)));

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -427,7 +427,7 @@ struct shim : public DeviceType
     if(ret == -ENOMEM)
       throw system_error(ret, "Not enough host mem. Please check grub settings.");
     if(ret == -EINVAL)
-      throw system_error(ret, "Invalid host mem size.");
+      throw system_error(ret, "Invalid host mem size. Please specify a memory size between 4M and 1G.");
     if(ret == -ENXIO)
       throw system_error(ret, "Huge page is not supported on this platform");
     if(ret == -ENODEV)

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -60,7 +60,7 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     const boost::property_tree::ptree& pt_platform = kp.second;
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
     _output << boost::format("  %-23s: %s \n") % "XSA Name" % pt_static_region.get<std::string>("vbnv");
-    _output << boost::format("  %-23s: %s \n") % "Platform UUID" % pt_static_region.get<std::string>("interface_uuid");
+    _output << boost::format("  %-23s: %s \n") % "Platform UUID" % pt_static_region.get<std::string>("logic_uuid");
     _output << boost::format("  %-23s: %s \n") % "FPGA Name" % pt_static_region.get<std::string>("fpga_name");
     _output << boost::format("  %-23s: %s \n") % "JTAG ID Code" % pt_static_region.get<std::string>("jtag_idcode");
     

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -103,7 +103,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
       size = XBUtilities::string_to_bytes(m_size);
   } 
   catch(const xrt_core::error&) {
-    std::cerr << "Value supplied to --size option is invalid" << std::endl;
+    std::cerr << "Value supplied to --size option is invalid. Please specify a memory size between 4M and 1G." << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1369,7 +1369,7 @@ get_platform_info(const std::shared_ptr<xrt_core::device>& device,
     const boost::property_tree::ptree& pt_platform = kp.second;
     const boost::property_tree::ptree& pt_static_region = pt_platform.get_child("static_region", empty_ptree);
     ptTree.put("platform", pt_static_region.get<std::string>("vbnv", "N/A"));
-    ptTree.put("platform_id", pt_static_region.get<std::string>("interface_uuid", "N/A"));
+    ptTree.put("platform_id", pt_static_region.get<std::string>("logic_uuid", "N/A"));
     ptTree.put("sc_version", pt_platform.get<std::string>("controller.satellite_controller.version", "N/A"));
 
   }


### PR DESCRIPTION
- CR-1110431 validate error directs user to use a legacy command to fix
- CR-1081361 Please provide a valide range for no dma host mem size
- CR-1101247 xbutil2 validate platform ID is 0x0 for U50 and U250