### PR TITLE
CR-1109983: Considering default domain as 0000 in xrt c++ apis

### DIFF
--- a/src/runtime_src/core/pcie/linux/system_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/system_linux.cpp
@@ -183,6 +183,12 @@ get_device_id(const std::string& bdf) const
       auto dev_bdf = boost::str(boost::format("%04x:%02x:%02x.%01x") % dev->domain % dev->bus % dev->dev % dev->func);
       if (dev_bdf == bdf)
         return i;
+      //consider default domain as 0000 and try to find a matching device
+      if(dev->domain == 0) {
+        dev_bdf = boost::str(boost::format("%02x:%02x.%01x") % dev->bus % dev->dev % dev->func);
+        if(dev_bdf == bdf)
+          return i;
+      }
   }
 
   throw xrt_core::system_error(EINVAL, "No such device '" + bdf + "'");


### PR DESCRIPTION
This issue fixes the XRT Native APIs regression. User can create xrt_device object with only bus , device and function if domain is 0000.