### PR TITLE
CR-1110052 1327449 : KDS Driver - Multiple arbitrary memory corruptions due to improper validation of 'cu_idx' parameter

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -163,7 +163,7 @@ int kds_add_context(struct kds_sched *kds, struct kds_client *client,
 		    struct kds_ctx_info *info);
 int kds_del_context(struct kds_sched *kds, struct kds_client *client,
 		    struct kds_ctx_info *info);
-int kds_open_ucu(struct kds_sched *kds, struct kds_client *client, int cu_idx);
+int kds_open_ucu(struct kds_sched *kds, struct kds_client *client, u32 cu_idx);
 int kds_map_cu_addr(struct kds_sched *kds, struct kds_client *client,
 		    int idx, unsigned long size, u32 *addrp);
 int kds_add_command(struct kds_sched *kds, struct kds_command *xcmd);

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -384,7 +384,7 @@ kds_add_cu_context(struct kds_sched *kds, struct kds_client *client,
 		   struct kds_ctx_info *info)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
-	int cu_idx = info->cu_idx;
+	u32 cu_idx = info->cu_idx;
 	u32 prop;
 	bool shared;
 	int ret = 0;
@@ -437,7 +437,7 @@ kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
 		   struct kds_ctx_info *info)
 {
 	struct kds_cu_mgmt *cu_mgmt = &kds->cu_mgmt;
-	int cu_idx = info->cu_idx;
+	u32 cu_idx = info->cu_idx;
 	unsigned long submitted;
 	unsigned long completed;
 	bool bad_state = false;
@@ -602,13 +602,17 @@ static const struct file_operations ucu_fops = {
 	.llseek		= noop_llseek,
 };
 
-int kds_open_ucu(struct kds_sched *kds, struct kds_client *client, int cu_idx)
+int kds_open_ucu(struct kds_sched *kds, struct kds_client *client, u32 cu_idx)
 {
 	int fd;
 	struct kds_cu_mgmt *cu_mgmt;
 	struct xrt_cu *xcu;
 
 	cu_mgmt = &kds->cu_mgmt;
+	if (cu_idx >= cu_mgmt->num_cus) {
+		kds_err(client, "CU(%d) not found", cu_idx);
+		return -EINVAL;
+	}
 
 	if (!test_bit(cu_idx, client->cu_bitmap)) {
 		kds_err(client, "cu(%d) isn't reserved\n", cu_idx);

--- a/src/runtime_src/core/edge/drm/zocl/include/sched_exec.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/sched_exec.h
@@ -299,8 +299,8 @@ void zocl_untrack_ctx(struct drm_device *dev, struct sched_client_ctx *fpriv);
 int zocl_exec_valid_cu(struct sched_exec_core *exec, unsigned int cuid);
 u32 sched_is_busy(struct drm_zocl_dev *zdev);
 u32 sched_live_clients(struct drm_zocl_dev *zdev, pid_t **plist);
-int sched_attach_cu(struct drm_zocl_dev *zdev, int cu_idx);
-int sched_detach_cu(struct drm_zocl_dev *zdev, int cu_idx);
+int sched_attach_cu(struct drm_zocl_dev *zdev, u32 cu_idx);
+int sched_detach_cu(struct drm_zocl_dev *zdev, u32 cu_idx);
 int zocl_execbuf_exec(struct drm_device *dev, void *data,
 		      struct drm_file *filp);
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -3647,7 +3647,7 @@ sched_is_busy(struct drm_zocl_dev *zdev)
 	return (atomic_read(&exec->scheduler->num_pending) + atomic_read(&exec->scheduler->num_running));
 }
 
-int sched_attach_cu(struct drm_zocl_dev *zdev, int cu_idx)
+int sched_attach_cu(struct drm_zocl_dev *zdev, u32 cu_idx)
 {
 	struct sched_exec_core *exec = zdev->exec;
 	int ret;
@@ -3669,7 +3669,7 @@ int sched_attach_cu(struct drm_zocl_dev *zdev, int cu_idx)
 	return ret;
 }
 
-int sched_detach_cu(struct drm_zocl_dev *zdev, int cu_idx)
+int sched_detach_cu(struct drm_zocl_dev *zdev, u32 cu_idx)
 {
 	struct sched_exec_core *exec = zdev->exec;
 	int cu_mask;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -273,7 +273,7 @@ zocl_open_ucu(struct drm_zocl_dev *zdev, struct kds_client *client,
 	      struct drm_zocl_ctx *args)
 {
 	struct kds_sched  *kds;
-	int cu_idx = args->cu_index;
+	u32 cu_idx = args->cu_index;
 
 	kds = &zdev->kds;
 	return kds_open_ucu(kds, client, cu_idx);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -277,17 +277,22 @@ xocl_open_ucu(struct xocl_dev *xdev, struct kds_client *client,
 	      struct drm_xocl_ctx *args)
 {
 	struct kds_sched *kds = &XDEV(xdev)->kds;
-	int cu_idx = args->cu_index;
+	u32 cu_idx = args->cu_index;
+	int ret;
 
 	if (!kds->cu_intr_cap) {
 		userpf_err(xdev, "Shell not support CU to host interrupt");
 		return -EOPNOTSUPP;
 	}
 
+	ret = kds_open_ucu(kds, client, cu_idx);
+	if (ret < 0)
+		return ret;
+
 	userpf_info(xdev, "User manage interrupt found, disable ERT");
 	xocl_ert_user_disable(xdev);
 
-	return kds_open_ucu(kds, client, cu_idx);
+	return 0;
 }
 
 static int xocl_context_ioctl(struct xocl_dev *xdev, void *data,


### PR DESCRIPTION
If user space send a cu index with highest bit as 1, since cu_idx is signal integer, "cu_idx >= cu_mgmt->num_cus" check would not work as expected.