### PR TITLE
CR-1110133: fixing multiple null checks around uuid usage

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -72,7 +72,7 @@ static ssize_t xclbinid_show(struct device *dev,
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
 	ssize_t size;
 
-	if (!zdev)
+	if (!zdev || !zdev->zdev_xclbin || !zdev->zdev_xclbin->zx_uuid)
 		return 0;
 
 	size = sprintf(buf, "%pUb\n", zdev->zdev_xclbin->zx_uuid);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1025,6 +1025,11 @@ zocl_xclbin_hold(struct drm_zocl_dev *zdev, const xuid_t *id)
 {
 	xuid_t *xclbin_id = (xuid_t *)zocl_xclbin_get_uuid(zdev);
 
+	if (!xclbin_id){
+		DRM_ERROR("No active xclbin. Cannot hold ");
+		return -EINVAL;
+	}
+
 	// check whether uuid is null or not
 	if (uuid_is_null(id)) {
 		DRM_WARN("NULL uuid to hold\n");
@@ -1060,6 +1065,11 @@ static int
 zocl_xclbin_release(struct drm_zocl_dev *zdev, const xuid_t *id)
 {
 	xuid_t *xclbin_uuid = (xuid_t *)zocl_xclbin_get_uuid(zdev);
+
+	if (!xclbin_uuid){
+		DRM_ERROR("No active xclbin. Cannot release");
+		return -EINVAL;
+	}
 
 	BUG_ON(!mutex_is_locked(&zdev->zdev_xclbin_lock));
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1025,7 +1025,7 @@ zocl_xclbin_hold(struct drm_zocl_dev *zdev, const xuid_t *id)
 {
 	xuid_t *xclbin_id = (xuid_t *)zocl_xclbin_get_uuid(zdev);
 
-	if (!xclbin_id){
+	if (!xclbin_id) {
 		DRM_ERROR("No active xclbin. Cannot hold ");
 		return -EINVAL;
 	}
@@ -1066,7 +1066,7 @@ zocl_xclbin_release(struct drm_zocl_dev *zdev, const xuid_t *id)
 {
 	xuid_t *xclbin_uuid = (xuid_t *)zocl_xclbin_get_uuid(zdev);
 
-	if (!xclbin_uuid){
+	if (!xclbin_uuid) {
 		DRM_ERROR("No active xclbin. Cannot release");
 		return -EINVAL;
 	}

--- a/src/runtime_src/core/include/xrt/xrt_uuid.h
+++ b/src/runtime_src/core/include/xrt/xrt_uuid.h
@@ -71,12 +71,17 @@ public:
    * uuid() - Construct uuid from a string representaition
    *
    * @param uuid_str
-   *  A string formatted as a uuid string 
+   *  A string formatted as a uuid string
    *
    * A uuid string is 36 bytes with '-' at 8, 13, 18, and 23
    */
   explicit uuid(const std::string& uuid_str)
   {
+    if(uuid_str.empty())
+    {
+      uuid_clear(m_uuid);
+      return;
+    }
     uuid_parse(uuid_str.c_str(), m_uuid);
   }
 

--- a/src/runtime_src/core/include/xrt/xrt_uuid.h
+++ b/src/runtime_src/core/include/xrt/xrt_uuid.h
@@ -77,8 +77,7 @@ public:
    */
   explicit uuid(const std::string& uuid_str)
   {
-    if(uuid_str.empty())
-    {
+    if (uuid_str.empty()) {
       uuid_clear(m_uuid);
       return;
     }

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -79,11 +79,15 @@ schedulerUpdateStat(xrt_core::device *device)
 {
   try {
     // lock xclbin
-    auto uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device));
+    std::string xclbin_uuid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(device);
+    // dont open a context if xclbin_uuid is empty
+    if(xclbin_uuid.empty())
+	    return;
+    auto uuid = xrt::uuid(xclbin_uuid);
     device->open_context(uuid.get(), std::numeric_limits<unsigned int>::max(), true);
     auto at_exit = [] (auto device, auto uuid) { device->close_context(uuid.get(), std::numeric_limits<unsigned int>::max()); };
     xrt_core::scope_guard<std::function<void()>> g(std::bind(at_exit, device, uuid));
-    
+
     device->update_scheduler_status();
   }
   catch (const std::exception&) {


### PR DESCRIPTION
This change fixes the multiple uuid null checks.
1) xclbin uuid sysfs node comes empty when no xclbin is loaded. We were getting some uninitialized value earlier.
2) lock/unlock bistreams should fail whenever lock device called without loading xclbin
3) uuid constructor with string should initialize uuid with clear state.
4) don't open the context when xclbin is null