### PR TITLE
CR-1045783 xbutil2 bdf host report enhancement

### DIFF
--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -115,7 +115,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   for(auto& kd : available_devices) {
     const boost::property_tree::ptree& dev = kd.second;
     std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-    _output << boost::format("  [%s] : %s %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % dev.get<std::string>("instance", "") % note;
+    _output << boost::format("  [%s] : %s [%s] %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % dev.get<std::string>("id") % dev.get<std::string>("instance", "") % note;
   }
   _output << std::endl;
 }


### PR DESCRIPTION
sadasiva@pranjal-dell:/proj/rdi/staff/sadasiva/XRT/build$ xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 4.15.0-147-generic
  Version              : #151-Ubuntu SMP Fri Jun 18 19:21:19 UTC 2021
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15727 MB
  Distribution         : Ubuntu 18.04.5 LTS
  GLIBC                : 2.27
  Model                : Precision 5820 Tower

XRT
  Version              : 2.12.0
  Branch               : interface
  Hash                 : a2765388a8cd9b3c31ca670a789a7787872ea7a7
  Hash Date            : 2021-09-09 05:28:40
  XOCL                 : 2.12.69, 37f86ed80380ced5c192acd10f7d3a2f6751877f
  XCLMGMT              : 2.12.69, 37f86ed80380ced5c192acd10f7d3a2f6751877f

Devices present
  [0000:17:00.1] : xilinx_u200_gen3x16_xdma_base_1 [15FB8DA1-F552-A9F9-23DE-6DC54AA8968F] user(inst=129) 

sadasiva@pranjal-dell:/proj/rdi/staff/sadasiva/XRT/build$ 
