### PR TITLE
using vck5000 as VBNV name of versal ES3 board

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3681,11 +3681,11 @@ struct xocl_subdev_map {
 		.priv_data = &XOCL_BOARD_VERSAL_USER_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5048, PCI_ANY_ID,					\
-		.vbnv = "xilinx_vck5000-es3",				\
+		.vbnv = "xilinx_vck5000",				\
 		.priv_data = &XOCL_BOARD_VERSAL_MGMT_RAPTOR2,		\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x5049, PCI_ANY_ID,					\
-		.vbnv = "xilinx_vck5000-es3",				\
+		.vbnv = "xilinx_vck5000",				\
 		.priv_data = &XOCL_BOARD_VERSAL_USER_RAPTOR2_ES3,	\
 		.type = XOCL_DSAMAP_RAPTOR2 },				\
 	{ 0x10EE, 0x6098, PCI_ANY_ID,					\


### PR DESCRIPTION
As we discussed in the meeting with Gary, we switch the VBNV name back to vck5000.