### PR TITLE
xgq group alloc for ERT

### DIFF
--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -88,8 +88,6 @@ static inline uint32_t xgq_reg_read32(uint64_t hdl, uint64_t addr)
 #define XGQ_MAJOR			1
 #define XGQ_MINOR			0
 #define XGQ_MIN_NUM_SLOTS		2
-#define XGQ_RING_LEN(nslots, slotsz)	\
-	(sizeof(struct xgq_header) + (nslots) * ((slotsz) + sizeof(struct xrt_com_queue_entry)))
 
 /*
  * Meta data shared b/w client and server of XGQ
@@ -131,7 +129,8 @@ struct xgq_ring {
 #define XGQ_SERVER		(1UL << 0)
 struct xgq {
 	uint64_t xq_flags;
-	uint64_t io_hdl;
+	uint64_t xq_io_hdl;
+	uint64_t xq_header_addr;
 	struct xgq_ring xq_sq ____cacheline_aligned_in_smp;
 	struct xgq_ring xq_cq ____cacheline_aligned_in_smp;
 };
@@ -141,6 +140,11 @@ struct xgq {
 /*
  * XGQ implementation details and helper routines.
  */
+
+static inline size_t xgq_ring_len(size_t nslots, size_t slotsz)
+{
+	return sizeof(struct xgq_header) + nslots * (slotsz + sizeof(struct xrt_com_queue_entry));
+}
 
 static inline void xgq_copy_to_ring(uint64_t io_hdl, void *buf, uint64_t tgt, size_t len)
 {
@@ -214,7 +218,7 @@ static inline int xgq_can_produce(struct xgq *xgq)
 
 	if (!xgq_ring_full(ring))
 		return XGQ_TRUE;
-	xgq_ring_read_consumed(xgq->io_hdl, ring);
+	xgq_ring_read_consumed(xgq->xq_io_hdl, ring);
 	return !xgq_ring_full(ring);
 }
 
@@ -224,8 +228,50 @@ static inline int xgq_can_consume(struct xgq *xgq)
 
 	if (!xgq_ring_empty(ring))
 		return XGQ_TRUE;
-	xgq_ring_read_produced(xgq->io_hdl, ring);
+	xgq_ring_read_produced(xgq->xq_io_hdl, ring);
 	return !xgq_ring_empty(ring);
+}
+
+// Fast forward to where we left, should only be called during attach, ring must be empty now
+static inline int xgq_fast_forward(struct xgq *xgq, struct xgq_ring *ring)
+{
+	xgq_ring_read_produced(xgq->xq_io_hdl, ring);
+	xgq_ring_read_consumed(xgq->xq_io_hdl, ring);
+	if (!xgq_ring_empty(ring))
+		return -EINVAL;
+	return 0;
+}
+
+static inline void xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
+	    size_t n_slots, uint32_t slot_size, uint64_t sq_produced, uint64_t cq_produced)
+{
+	struct xgq_header hdr = {};
+
+	xgq->xq_flags = flags;
+	xgq->xq_io_hdl = io_hdl;
+	xgq->xq_header_addr = ring_addr;
+	xgq_init_ring(&xgq->xq_sq, sq_produced,
+		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),
+		      ring_addr + sizeof(struct xgq_header), n_slots, slot_size);
+	xgq_init_ring(&xgq->xq_cq, cq_produced,
+		      ring_addr + offsetof(struct xgq_header, xh_cq_consumed),
+		      ring_addr + sizeof(struct xgq_header) + n_slots * slot_size,
+		      n_slots, sizeof(struct xrt_com_queue_entry));
+
+	hdr.xh_magic = 0;
+	hdr.xh_major = XGQ_MAJOR;
+	hdr.xh_minor = XGQ_MINOR;
+	hdr.xh_slot_num = n_slots;
+	hdr.xh_sq_offset = xgq->xq_sq.xr_slot_addr - ring_addr;
+	hdr.xh_sq_slot_size = slot_size;
+	hdr.xh_cq_offset = xgq->xq_cq.xr_slot_addr - ring_addr;
+	hdr.xh_sq_consumed = 0;
+	hdr.xh_cq_consumed = 0;
+	xgq_copy_to_ring(xgq->xq_io_hdl, &hdr, ring_addr, sizeof(hdr));
+
+	// Write the magic number to confirm the header is fully initialized
+	hdr.xh_magic = XGQ_ALLOC_MAGIC;
+	xgq_copy_to_ring(xgq->xq_io_hdl, &hdr, ring_addr, sizeof(uint32_t));
 }
 
 
@@ -244,57 +290,63 @@ static inline int xgq_can_consume(struct xgq *xgq)
  * xgq_notify_peer_produced(), which then will publish all entries at once to peer.
  */
 
-static inline int xgq_alloc(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
-	    size_t *ring_len, uint32_t slot_size, uint64_t sq_produced, uint64_t cq_produced)
+static inline int
+xgq_alloc(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr, size_t *ring_len,
+	  uint32_t slot_size, uint64_t sq_produced, uint64_t cq_produced)
 {
+	size_t total_len = 0;
 	size_t rlen = *ring_len;
-	uint32_t numslots = XGQ_MIN_NUM_SLOTS;
-	struct xgq_header hdr = {};
+	uint32_t numslots = 1;
 
 	if (slot_size % sizeof(uint32_t))
 		return -EINVAL;
-	if (XGQ_RING_LEN(numslots, slot_size) > rlen)
-		return -E2BIG;
-	while (XGQ_RING_LEN(numslots << 1, slot_size) <= rlen)
+
+	while (total_len <= rlen) {
 		numslots <<= 1;
+		total_len = xgq_ring_len(numslots, slot_size);
+	}
+	numslots >>= 1;
+	if (numslots < XGQ_MIN_NUM_SLOTS)
+		return -E2BIG;
 
-	xgq->xq_flags = 0;
-	xgq->xq_flags |= flags;
-	xgq->io_hdl = io_hdl;
-	xgq_init_ring(&xgq->xq_sq, sq_produced,
-		      ring_addr + offsetof(struct xgq_header, xh_sq_consumed),
-		      ring_addr + sizeof(struct xgq_header), numslots, slot_size);
-	xgq_init_ring(&xgq->xq_cq, cq_produced,
-		      ring_addr + offsetof(struct xgq_header, xh_cq_consumed),
-		      ring_addr + sizeof(struct xgq_header) + numslots * slot_size,
-		      numslots, sizeof(struct xrt_com_queue_entry));
+	xgq_init(xgq, flags, io_hdl, ring_addr, numslots, slot_size, sq_produced, cq_produced);
 
-	hdr.xh_magic = 0;
-	hdr.xh_major = XGQ_MAJOR;
-	hdr.xh_minor = XGQ_MINOR;
-	hdr.xh_slot_num = numslots;
-	hdr.xh_sq_offset = xgq->xq_sq.xr_slot_addr - ring_addr;
-	hdr.xh_sq_slot_size = slot_size;
-	hdr.xh_cq_offset = xgq->xq_cq.xr_slot_addr - ring_addr;
-	hdr.xh_sq_consumed = 0;
-	hdr.xh_cq_consumed = 0;
-	xgq_copy_to_ring(xgq->io_hdl, &hdr, ring_addr, sizeof(hdr));
-
-	// Write the magic number to confirm the header is fully initialized
-	hdr.xh_magic = XGQ_ALLOC_MAGIC;
-	xgq_copy_to_ring(xgq->io_hdl, &hdr, ring_addr, sizeof(uint32_t));
-
-	*ring_len = XGQ_RING_LEN(numslots, slot_size);
+	*ring_len = xgq_ring_len(numslots, slot_size);
 	return 0;
 }
 
-// Fast forward to where we left, should only be called during attach, ring must be empty now
-static inline int xgq_fast_forward(struct xgq *xgq, struct xgq_ring *ring)
+static inline int
+xgq_group_alloc(struct xgq *a_xgq, size_t n_qs, uint64_t flags, uint64_t io_hdl,
+		uint64_t ring_addr, size_t *ring_len, uint32_t *a_slot_size,
+		uint64_t *a_sq_produced, uint64_t *a_cq_produced)
 {
-	xgq_ring_read_produced(xgq->io_hdl, ring);
-	xgq_ring_read_consumed(xgq->io_hdl, ring);
-	if (!xgq_ring_empty(ring))
-		return -EINVAL;
+	size_t i;
+	size_t total_len = 0;
+	size_t rlen = *ring_len;
+	uint32_t numslots = 1;
+	uint64_t raddr = ring_addr;
+
+	for (i = 0; i < n_qs; i++) {
+		if (a_slot_size[i] % sizeof(uint32_t))
+			return -EINVAL;
+	}
+
+	while (total_len <= rlen) {
+		numslots <<= 1;
+		for (i = 0; i < n_qs; i++)
+			total_len += xgq_ring_len(numslots, a_slot_size[i]);
+	}
+	numslots >>= 1;
+	if (numslots < XGQ_MIN_NUM_SLOTS)
+		return -E2BIG;
+
+	for (i = 0; i < n_qs; i++) {
+		xgq_init(&a_xgq[i], flags, io_hdl, raddr, numslots, a_slot_size[i],
+			a_sq_produced[i], a_cq_produced[i]);
+		raddr += xgq_ring_len(numslots, a_slot_size[i]);
+	}
+
+	*ring_len = raddr - ring_addr;
 	return 0;
 }
 
@@ -305,12 +357,12 @@ static inline int xgq_attach(struct xgq *xgq, uint64_t flags, uint64_t ring_addr
 	uint32_t nslots;
 	int rc;
 
-	xgq_copy_from_ring(xgq->io_hdl, &hdr, ring_addr, sizeof(uint32_t));
+	xgq_copy_from_ring(xgq->xq_io_hdl, &hdr, ring_addr, sizeof(uint32_t));
 	// Magic number must show up to confirm the header is fully initialized
 	if (hdr.xh_magic != XGQ_ALLOC_MAGIC)
 		return -EAGAIN;
 
-	xgq_copy_from_ring(xgq->io_hdl, &hdr, ring_addr, sizeof(struct xgq_header));
+	xgq_copy_from_ring(xgq->xq_io_hdl, &hdr, ring_addr, sizeof(struct xgq_header));
 	if (hdr.xh_major != XGQ_MAJOR)
 		return -EOPNOTSUPP;
 
@@ -367,8 +419,8 @@ static inline int xgq_consume(struct xgq *xgq, uint64_t *slot_addr)
 	 * See comments above XGQ_ENTRY_NEW_FLAG_MASK for details.
 	 */
 	while (!(val & XGQ_ENTRY_NEW_FLAG_MASK))
-		val = xgq_mem_read32(xgq->io_hdl, *slot_addr);
-	xgq_mem_write32(xgq->io_hdl, *slot_addr, val & ~XGQ_ENTRY_NEW_FLAG_MASK);
+		val = xgq_mem_read32(xgq->xq_io_hdl, *slot_addr);
+	xgq_mem_write32(xgq->xq_io_hdl, *slot_addr, val & ~XGQ_ENTRY_NEW_FLAG_MASK);
 #endif
 
 	return 0;
@@ -378,14 +430,14 @@ static inline void xgq_notify_peer_produced(struct xgq *xgq)
 {
 	struct xgq_ring *ring = XGQ_IS_SERVER(xgq) ? &xgq->xq_cq : &xgq->xq_sq;
 
-	xgq_ring_write_produced(xgq->io_hdl, ring);
+	xgq_ring_write_produced(xgq->xq_io_hdl, ring);
 }
 
 static inline void xgq_notify_peer_consumed(struct xgq *xgq)
 {
 	struct xgq_ring *ring = XGQ_IS_SERVER(xgq) ? &xgq->xq_sq : &xgq->xq_cq;
 
-	xgq_ring_write_consumed(xgq->io_hdl, ring);
+	xgq_ring_write_consumed(xgq->xq_io_hdl, ring);
 }
 
 #endif


### PR DESCRIPTION
Add support for group xgq allocation for ERT use case.

Also, remove the check for empty ring during attach, since the peer may start pushing cmds into sq right after xgq alloc is done.