### PR TITLE
CR-1110454 ASTeR TC19.15 - validate can intermittently crash (BUG: unable to handle kernel paging request / command_queue_poll+0x15e/0x250 [xocl])

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -752,8 +752,10 @@ int kds_submit_cmd_and_wait(struct kds_sched *kds, struct kds_command *xcmd)
 		return ret;
 
 	ret = wait_for_completion_timeout(&kds->comp, msecs_to_jiffies(3000));
-	if (!ret)
+	if (!ret) {
 		kds->ert->abort_sync(kds->ert, client, NO_INDEX);
+		wait_for_completion(&kds->comp);
+	}
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1058,14 +1058,13 @@ static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 	if (ret)
 		goto out;
 
-	if (ecmd->state > ERT_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Cfg command state %d", ecmd->state);
+	if (ecmd->state != ERT_CMD_STATE_COMPLETED) {
+		userpf_err(xdev, "Cfg command state %d. ERT will be disabled",
+			   ecmd->state);
 		ret = 0;
 		kds->ert_disable = true;
 		goto out;
 	}
-
-	WARN_ON(ecmd->state != ERT_CMD_STATE_COMPLETED);
 
 	/* If xrt.ini is not disabled, let it determines ERT enable/disable */
 	if (!kds->ini_disable)


### PR DESCRIPTION
Somehow, the configure command some time needs more than 3 seconds to complete. But we should consume "kds->comp" after abort, otherwise the next time wait_for_completion_timeout() will return immediately.