### PR TITLE
CR-1110676: Disable trace when only profiling counters enabled in xrt.ini 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -212,15 +212,20 @@ namespace xdp {
                              trace_buffer_offload_interval_ms, // offload_sleep_ms
                              trace_buffer_size);           // trbuf_size
 
-    bool init_successful = offloader->read_trace_init(m_enable_circular_buffer) ;
+    // If trace is enabled, set up trace.  Otherwise just keep the offloader
+    //  for reading the counters.
+    if (xrt_core::config::get_data_transfer_trace() != "off") {
+      bool init_successful =
+        offloader->read_trace_init(m_enable_circular_buffer) ;
 
-    if (!init_successful) {
-      if (devInterface->hasTs2mm()) {
-        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_ALLOC_FAIL) ;
+      if (!init_successful) {
+        if (devInterface->hasTs2mm()) {
+          xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_ALLOC_FAIL) ;
+        }
+        delete offloader ;
+        delete logger ;
+        return ;
       }
-      delete offloader ;
-      delete logger ;
-      return ;
     }
 
     offloaders[deviceId] = std::make_tuple(offloader, logger, devInterface) ;


### PR DESCRIPTION
The memory monitor table in profile summary exposed a problem where trace was being enabled on designs with TS2MM if only counters were enabled.  This change makes sure that trace is not initialized in cases where the only device information we need from profiling is counter values.
