### PR TITLE
Support timeout when waiting for kernel completion

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -166,6 +166,9 @@ PYBIND11_MODULE(pyxrt, m) {
         .def("set_arg", [](xrt::run& r, int i, int& item){
                             r.set_arg<int&>(i, item);
                         }, "Set a specific kernel scalar argument for this run")
+        .def("wait", ([](xrt::run& r)  {
+                           return r.wait(0);
+                      }), "Wait for the run to complete")
         .def("wait", ([](xrt::run& r, unsigned int timeout_ms)  {
                           return r.wait(timeout_ms);
                       }), "Wait for the specified milliseconds for the run to complete")

--- a/src/runtime_src/core/common/api/exec.cpp
+++ b/src/runtime_src/core/common/api/exec.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -114,6 +114,16 @@ unmanaged_wait(const command* cmd)
     kds::unmanaged_wait(cmd);
   else
     sws::unmanaged_wait(cmd);
+}
+    
+// Wait for a command to complete execution with timeout.
+std::cv_status
+unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms)
+{
+  if (kds_enabled())
+    return kds::unmanaged_wait(cmd, timeout_ms);
+  else
+    return sws::unmanaged_wait(cmd, timeout_ms);
 }
 
 void

--- a/src/runtime_src/core/common/api/exec.h
+++ b/src/runtime_src/core/common/api/exec.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,8 +18,9 @@
 #define xrt_core_exec_h_
 
 #include "core/common/config.h"
-#include <vector>
+#include <condition_variable>
 #include <memory>
+#include <vector>
 
 namespace xrt_core {
 
@@ -42,6 +43,13 @@ unmanaged_start(command* cmd)
 
 void
 unmanaged_wait(const command* cmd);
+
+inline std::cv_status
+unmanaged_wait(const command* cmd, const std::chrono::milliseconds&)
+{
+  unmanaged_wait(cmd);
+  return std::cv_status::no_timeout;
+}
 
 void
 start();
@@ -67,6 +75,9 @@ unmanaged_start(command* cmd);
 
 void
 unmanaged_wait(const command* cmd);
+
+std::cv_status
+unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms);
 
 void
 start();
@@ -100,10 +111,19 @@ unmanaged_start(command* cmd);
 // Wait for a command to complete execution.  This function must be
 // called in poll mode (unmanaged) scheduling, and is safe to call in
 // push mode.  The function provides a thread safe interface to
-// exec_waq and by passes execution monitor used in managed execution
+// exec_wait and by passes execution monitor used in managed execution
 XRT_CORE_COMMON_EXPORT
 void
 unmanaged_wait(const command* cmd);
+
+// Wait for a command to complete execution with a timeout.  This
+// function must be called in poll mode (unmanaged) scheduling, and is
+// safe to call in push mode.  The function provides a thread safe
+// interface to exec_wait and by passes execution monitor used in
+// managed execution
+XRT_CORE_COMMON_EXPORT
+std::cv_status
+unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms);
 
 void
 start();

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -832,10 +832,11 @@ public:
       std::unique_lock<std::mutex> lk(m_mutex);
       while (!m_done)
         if (m_exec_done.wait_for(lk, timeout_ms) == std::cv_status::timeout)
-          break;
+          return ERT_CMD_STATE_TIMEOUT;
     }
     else {
-      xrt_core::exec::unmanaged_wait(this);
+      if (xrt_core::exec::unmanaged_wait(this, timeout_ms) == std::cv_status::timeout)
+        return ERT_CMD_STATE_TIMEOUT;
     }
 
     return get_state();
@@ -2001,7 +2002,7 @@ public:
   }
 
   ert_cmd_state
-  abort()
+  abort() const
   {
     // don't bother if command is done by the time abort is called
     if (cmd->is_done()) {

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -195,13 +195,26 @@ class run
    * @param timeout  
    *  Timeout for wait (default block till run completes)
    * @return 
-   *  Command state upon return of wait
+   *  Command state upon return of wait, or ERT_CMD_STATE_TIMEOUT
+   *  if timeout exceeded.
    *
    * The default timeout of 0ms indicates blocking until run completes.
    *
    * The current thread will block until the run completes or timeout
    * expires. Completion does not guarantee success, the run status
    * should be checked by using ``state``.
+   *
+   * If specified time out is exceeded, the function returns with
+   * ERT_CMD_STATE_TIMEOUT, it is the callers responsibility to abort
+   * the run if it continues to time out.
+   *
+   * The current implementation of this API can mask out the timeout
+   * of this run so that the call either never returns or doesn't
+   * return until the run completes by itself. This can happen if
+   * other runs are continuosly completing within the specified
+   * timeout for this run.  If the device is otherwise idle, or if the
+   * time between run completion exceeds the specified timeout, then
+   * this function will identify the timeout.
    */
   XCL_DRIVER_DLLESPEC
   ert_cmd_state
@@ -213,13 +226,26 @@ class run
    * @param timeout_ms
    *  Timeout in milliseconds
    * @return
-   *  Command state upon return of wait
+   *  Command state upon return of wait, or ERT_CMD_STATE_TIMEOUT
+   *  if timeout exceeded.
    *
    * The default timeout of 0ms indicates blocking until run completes.
    *
    * The current thread will block until the run completes or timeout
    * expires. Completion does not guarantee success, the run status
    * should be checked by using ``state``.
+   *
+   * If specified time out is exceeded, the function returns with
+   * ERT_CMD_STATE_TIMEOUT, it is the callers responsibility to abort
+   * the run if it continues to time out.
+   *
+   * The current implementation of this API can mask out the timeout
+   * of this run so that the call either never returns or doesn't
+   * return until the run completes by itself. This can happen if
+   * other runs are continuosly completing within the specified
+   * timeout for this run.  If the device is otherwise idle, or if the
+   * time between run completion exceeds the specified timeout, then
+   * this function will identify the timeout.
    */
   ert_cmd_state
   wait(unsigned int timeout_ms) const

--- a/tests/python/02_simple/main.py
+++ b/tests/python/02_simple/main.py
@@ -46,7 +46,7 @@ def runKernel(opt):
     print("Start the kernel, simple")
     run = simple(boHandle1, boHandle2, 0x10)
     print("Now wait for the kernel simple to finish")
-    state = run.wait(5)
+    state = run.wait()
 
     print("Get the output data from the device and validate it")
     boHandle1.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, DATA_SIZE, 0)

--- a/tests/python/04_swizzle/main.py
+++ b/tests/python/04_swizzle/main.py
@@ -62,7 +62,7 @@ def runKernel(opt):
         run.set_arg(0, subobj)
         run.start()
         state = run.state()
-        state = run.wait(5)
+        state = run.wait()
 
     obj.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, size, 0)
 

--- a/tests/python/22_verify/22_verify.py
+++ b/tests/python/22_verify/22_verify.py
@@ -54,8 +54,8 @@ def runKernel(opt):
     run2 = hello(boHandle2)
 
     print("Now wait for the kernels to finish using xrtRunWait()")
-    state1 = run1.wait(5)
-    state2 = run2.wait(5)
+    state1 = run1.wait()
+    state2 = run2.wait()
 
     print("Get the output data produced by the 2 kernel runs from the device")
     boHandle1.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, opt.DATA_SIZE, 0)

--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -88,8 +88,8 @@ def runKernel(opt):
             start = current_micro_time()
             rhandle1 = khandle1(output_bo1, input_bo1, beats, reps)
             rhandle2 = khandle2(output_bo2, input_bo2, beats, reps)
-            rhandle1.wait(5)
-            rhandle2.wait(5)
+            rhandle1.wait()
+            rhandle2.wait()
             end = current_micro_time()
 
             usduration = end - start

--- a/tests/xrt/102_multiproc_verify/main.cpp
+++ b/tests/xrt/102_multiproc_verify/main.cpp
@@ -159,7 +159,7 @@ run(const xrt::device& device, const xrt::uuid& uuid, size_t n_runs, bool verbos
   while (count && (time_ns() - start) * 10e-9 < 30) {
     int run_idx = 0;
     for (auto& run : runs) {
-      auto state = run.wait(1000);
+      auto state = run.wait();
       switch (state) {
       case ERT_CMD_STATE_COMPLETED:
       case ERT_CMD_STATE_ERROR:


### PR DESCRIPTION
Implement xrt::run::wait(timeout).  The API was already there but
the implementation didn't timeout as expected.

Now time out is supported with the caveat as noted in documenation
regarding reset of timeout value under special circumstances.

Fix tests that relied on old no-timeout behavior.