### PR TITLE
CR-1105737 : Enhanced the xbutil2 for AIE

### DIFF
--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -19,10 +19,10 @@
 #include "ReportAie.h"
 #include "core/common/query_requests.h"
 #include "core/common/device.h"
-#include <boost/optional/optional.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 #define fmtCommon(x) boost::format("    %-22s: " x "\n")
 #define fmt4(x) boost::format("%4s%-22s: " x "\n") % " "
@@ -514,12 +514,18 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
   std::vector<std::string> aieCoreList;
   bool is_less = false;
 
+  // Loop through all the parameters given under _elementsFilter i.e. -e option
   for (auto it = _elementsFilter.begin(); it != _elementsFilter.end(); ++it) {
+    // Only show certain selected cores from aie that are passed under cores
+    // Ex. -r aie -e cores 0,3,5
     if(*it == "cores") {
       auto core_list = std::next(it);
       if (core_list != _elementsFilter.end())
         boost::split(aieCoreList, *core_list, boost::is_any_of(","));
     }
+    // Show less information (core Status, Program Counter, Link Register, Stack
+    // Pointer) for each cores.
+    // Ex. -r aie -e less
     if(*it == "less") {
       is_less = true;
     }
@@ -552,10 +558,10 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
       _output << std::endl;
       count = 0;
       for (auto& tile : graph.get_child("tile")) {
-	int curr_core = count++;
-	if(aieCoreList.size() && (std::find(aieCoreList.begin(), aieCoreList.end(),
+        int curr_core = count++;
+        if(aieCoreList.size() && (std::find(aieCoreList.begin(), aieCoreList.end(),
 		     std::to_string(curr_core)) == aieCoreList.end()))
-	  continue;
+          continue;
 
         _output << boost::format("Core [%2d]\n") % curr_core;
         _output << fmt4("%d") % "Column" % tile.second.get<int>("column");

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -266,12 +266,11 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
 
   _output << "AIE\n";
 
-  if(_elementsFilter.size()) {
-    for(auto& itr : _elementsFilter) {
-      if(itr == "tiles") {
-        auto tile_list = std::next(&itr, 1);
+  for (auto it = _elementsFilter.begin(); it != _elementsFilter.end(); ++it) {
+    if(*it == "tiles") {
+      auto tile_list = std::next(it);
+      if (tile_list != _elementsFilter.end())
         boost::split(aieTileList, *tile_list, boost::is_any_of(","));
-      }
     }
   }
 

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -23,7 +23,6 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/lexical_cast.hpp>
 
 #define fmt4(x) boost::format("%4s%-22s: " x "\n") % " "
 #define fmt8(x) boost::format("%8s%-22s: " x "\n") % " "
@@ -290,7 +289,7 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
     for (auto &tile : ptShimTiles) {
       int curr_tile = count++;
       if(_elementsFilter.size() && (std::find(aieTileList.begin(), aieTileList.end(),
-				boost::lexical_cast<std::string>(curr_tile)) == aieTileList.end()))
+				std::to_string(curr_tile)) == aieTileList.end()))
         continue;
 
       _output << boost::format("Tile[%2d]\n") % curr_tile;

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -31,7 +31,6 @@
 
 
 namespace qr = xrt_core::query;
-std::vector<std::string> aieTileList;
 
 static void
 addnodelist(std::string search_str, std::string node_str,boost::property_tree::ptree& input_pt, boost::property_tree::ptree& output_pt)
@@ -263,6 +262,7 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
                             std::ostream & _output) const
 {
   boost::property_tree::ptree empty_ptree;
+  std::vector<std::string> aieTileList;
 
   _output << "AIE\n";
 
@@ -287,8 +287,8 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
 
     for (auto &tile : ptShimTiles) {
       int curr_tile = count++;
-      if(_elementsFilter.size() && (std::find(aieTileList.begin(), aieTileList.end(),
-				std::to_string(curr_tile)) == aieTileList.end()))
+      if(std::find(aieTileList.begin(), aieTileList.end(),
+				std::to_string(curr_tile)) == aieTileList.end())
         continue;
 
       _output << boost::format("Tile[%2d]\n") % curr_tile;

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -19,10 +19,10 @@
 #include "ReportAieShim.h"
 #include "core/common/query_requests.h"
 #include "core/common/device.h"
-#include <boost/optional/optional.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/property_tree/json_parser.hpp>
 
 #define fmt4(x) boost::format("%4s%-22s: " x "\n") % " "
 #define fmt8(x) boost::format("%8s%-22s: " x "\n") % " "
@@ -266,7 +266,10 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
 
   _output << "AIE\n";
 
+  // Loop through all the parameters given under _elementsFilter i.e. -e option
   for (auto it = _elementsFilter.begin(); it != _elementsFilter.end(); ++it) {
+    // Only show certain selected tiles from aieshim that are passed under tiles
+    // Ex. -r aieshim -e tiles 0,3,5
     if(*it == "tiles") {
       auto tile_list = std::next(it);
       if (tile_list != _elementsFilter.end())

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -82,7 +82,7 @@ target_link_libraries(${XBUTIL2_NAME}
   )
 
 if (NOT WIN32)
-  target_link_libraries(${XBUTIL2_NAME} PRIVATE pthread uuid dl)
+  target_link_libraries(${XBUTIL2_NAME} PRIVATE pthread boost_thread uuid dl)
 endif()
 
 # Install our built executable

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -82,7 +82,7 @@ target_link_libraries(${XBUTIL2_NAME}
   )
 
 if (NOT WIN32)
-  target_link_libraries(${XBUTIL2_NAME} PRIVATE pthread boost_thread uuid dl)
+  target_link_libraries(${XBUTIL2_NAME} PRIVATE pthread uuid dl)
 endif()
 
 # Install our built executable


### PR DESCRIPTION
**CR**
CR-1105737 : Some enhancement request on xbutil2 related to AIE.

**Issue**
Some enhancement request on xbutil2 related to AIE when we talked to internal users:
  - When there're many cores in the design, it's convenient just to report status of specific core and tiles.
     -- Select certain tiles from aieshim that are of intertest
     -- Select certain cores from aie that are of intertest
  - Able to run continuously to detect AIE status (include core status)

**Solution**
Added the above support. 

_$./xbutil2 examine -r aieshim -e tiles 0,1 --device 0000:00:00.0_
![image](https://user-images.githubusercontent.com/54270703/133076795-d9c8babf-6256-4093-beb2-061157537b9b.png)


_$./xbutil2 examine -r aieshim -e coress 1 --device 0000:00:00.0_
![image](https://user-images.githubusercontent.com/54270703/133076872-a5e8b808-9998-485d-a921-321f1d3ab12c.png)

_$./xbutil2 examine -r aie -e less --device 0000:00:00.0_
![image](https://user-images.githubusercontent.com/54270703/133172912-adf44c54-a7d7-41b8-a840-014acbda4f93.png)

The above command will print only status information once. It's user responsibility to run as a watch mode to get continuous status information. 

_$./xbutil2 examine -r aie -e less cores 1 --device 0000:00:00.0_
This to print status information for only core 1 