### PR TITLE
Fixed the hotplug issue for Ubuntu OS

### DIFF
--- a/src/runtime_src/core/pcie/linux/scan.cpp
+++ b/src/runtime_src/core/pcie/linux/scan.cpp
@@ -1238,7 +1238,7 @@ shutdown(std::shared_ptr<pci_device> mgmt_dev, bool remove_user, bool remove_mgm
     return 0;
 
   /* Cache the parent sysfs path before remove the PF */
-  std::string parent_path = mgmt_dev->get_sysfs_path("", "dparent/power/runtime_active_kids");
+  std::string parent_path = mgmt_dev->get_sysfs_path("", "dparent");
   /* Get the absolute path from the symbolic link */
   parent_path = (bfs::canonical(parent_path)).c_str();
 
@@ -1277,7 +1277,7 @@ shutdown(std::shared_ptr<pci_device> mgmt_dev, bool remove_user, bool remove_mgm
 
   for (int wait = 0; wait < DEV_TIMEOUT; wait++) {
     int curr_act_dev;
-    std::string active_kids_path = parent_path + "power/runtime_active_kids";
+    std::string active_kids_path = parent_path + "/power/runtime_active_kids";
     if (!bfs::exists(active_kids_path)) {
       // RHEL 8.x specific 
       curr_act_dev = get_runtime_active_kids(parent_path);


### PR DESCRIPTION
CR Number
CR-1110075 : xbmgmt hotplug --offline does not work

Issue
On Ubuntu machine, where "runtime_active_kids" file is present, the hotplug is failing.

Solution
Fixed this issue as required.