### PR TITLE
CR-1110886: Adding native_xrt_trace to list of ini parameters reported in profile summary

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -32,12 +32,12 @@ namespace xdp {
                  "Hardware counters added to OpenCL summary file");
     addParameter("timeline_trace", xrt_core::config::get_timeline_trace(),
                  "Timeline trace (deprecated)");
+    addParameter("native_xrt_trace", xrt_core::config::get_native_xrt_trace(),
+                 "Generation of Native XRT API function trace");
     addParameter("xrt_trace", xrt_core::config::get_xrt_trace(),
                  "Generation of hardware SHIM function trace");
     addParameter("xrt_profile", xrt_core::config::get_xrt_profile(),
                  "Equivalent to xrt_trace (deprecated)");
-    addParameter("native_xrt_trace", xrt_core::config::get_native_xrt_trace(),
-                 "Generation of Native XRT API function trace");
     addParameter("data_transfer_trace",
                  xrt_core::config::get_data_transfer_trace(),
                  "Collection of data from PL monitors and added to summary and trace");

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -36,6 +36,8 @@ namespace xdp {
                  "Generation of hardware SHIM function trace");
     addParameter("xrt_profile", xrt_core::config::get_xrt_profile(),
                  "Equivalent to xrt_trace (deprecated)");
+    addParameter("native_xrt_trace", xrt_core::config::get_native_xrt_trace(),
+                 "Generation of Native XRT API function trace");
     addParameter("data_transfer_trace",
                  xrt_core::config::get_data_transfer_trace(),
                  "Collection of data from PL monitors and added to summary and trace");


### PR DESCRIPTION
Adding the value of "native_xrt_trace" specified in the ini file to the guidance section of the generated profile summary.csv file so it shows up in Vitis Analyzer under the "Settings" tab.