### PR TITLE
CR-1110055

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver Scheduler
  *
- * Copyright (C) 2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -912,7 +912,8 @@ int zocl_get_hbo_ioctl(struct drm_device *dev, void *data,
 		return -EINVAL;
 	}
 	if (!(host_mem_start <= args->paddr &&
-	      args->paddr + args->size <= host_mem_end)) {
+	   args->paddr < host_mem_end &&
+	   args->size <= host_mem_end - args->paddr)) {
 		DRM_ERROR("get_hbo: Buffer at out side of reserved memory region\n");
 		return -ENOMEM;
 	}


### PR DESCRIPTION
Improve check for mapping host BO to prevent arg->size overflow. In previous check, paddr + size can overflow and falls into the valid address range.