### PR TITLE
CR-1110239:  Added A DRC that AP_CTRL_NONE shouldnt have interrupts enabled

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1198,7 +1198,6 @@ int kds_cfg_update(struct kds_sched *kds)
 				continue;
 
 			xcu = cu_mgmt->xcus[i];
-
 			ret = xrt_cu_cfg_update(xcu, kds->cu_intr);
 			if (!ret)
 				cu_mgmt->cu_intr[i] = kds->cu_intr;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1198,11 +1198,6 @@ int kds_cfg_update(struct kds_sched *kds)
 				continue;
 
 			xcu = cu_mgmt->xcus[i];
-			/* Do not start polling/interrupt thread
-			 * for ap_ctrl_none kernels
-			 */
-			if (xrt_cu_get_protocol(xcu) == CTRL_NONE)
-				continue;
 
 			ret = xrt_cu_cfg_update(xcu, kds->cu_intr);
 			if (!ret)

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1198,6 +1198,12 @@ int kds_cfg_update(struct kds_sched *kds)
 				continue;
 
 			xcu = cu_mgmt->xcus[i];
+			/* Do not start polling/interrupt thread
+			 * for ap_ctrl_none kernels
+			 */
+			if (xrt_cu_get_protocol(xcu) == CTRL_NONE)
+				continue;
+
 			ret = xrt_cu_cfg_update(xcu, kds->cu_intr);
 			if (!ret)
 				cu_mgmt->cu_intr[i] = kds->cu_intr;

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -696,6 +696,11 @@ int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr)
 	if (!xcu->info.intr_enable)
 		return -ENOSYS;
 
+	if (xrt_cu_get_protocol(xcu) == CTRL_NONE) {
+		xcu_err(xcu, "Interrupt shouldnt be enabled for ap_ctrl_none cu\n");
+		return -ENOSYS;
+	}
+
 	if (intr)
 		cu_thread = xrt_cu_intr_thread;
 	else

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -697,7 +697,7 @@ int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr)
 		return -ENOSYS;
 
 	if (xrt_cu_get_protocol(xcu) == CTRL_NONE) {
-		xcu_err(xcu, "Interrupt shouldnt be enabled for ap_ctrl_none cu\n");
+		xcu_err(xcu, "Interrupt enabled value should be false for ap_ctrl_none cu\n");
 		return -ENOSYS;
 	}
 


### PR DESCRIPTION
This change fixes the segmentation fault causing for AP_CNTRL_NONE kernels.
We shouldn't create threads for ap_ctrl_none. We are not calling xrt_cu_init also for the ap_ctrl_none kernels.
Need to check how this test is passing in DC cases.