### PR TITLE
Add xrt_coreutil to xrt.pc

### DIFF
--- a/src/CMake/config/xrt.pc.in
+++ b/src/CMake/config/xrt.pc.in
@@ -9,5 +9,5 @@ includedir=${prefix}/include
 Name: XRT
 Description: Xilinx RunTime
 Version: @XRT_VERSION_STRING@
-Libs: -L${libdir} -lxrt_core
+Libs: -L${libdir} -lxrt_core -lxrt_coreutil
 Cflags: -I${includedir}


### PR DESCRIPTION
Per CR-1103578 -lxrt_coreutil is is missing from xrt.pc.in.  Linking with -lxrt_coreutil is needed to get a the fix in that CR.  When using pkgconfig, xrt.pc must contain the link library.