### PR TITLE
Revert "Add schema version and fix platform schema"

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -78,9 +78,6 @@ PYBIND11_MODULE(pyxrt, m) {
         .value("pcie_info", xrt::info::device::pcie_info)
         .value("host", xrt::info::device::host)
         .value("dynamic_regions", xrt::info::device::dynamic_regions);
-
-    py::enum_<xrt::info::InfoSchemaVersion>(m, "xrt_info_schema", "Schema version for device information")
-        .value("json_20202", xrt::info::InfoSchemaVersion::json_20202);
 /*
  *
  * XRT:: UUID (needed since UUID classes passed outside of objects)
@@ -108,41 +105,41 @@ PYBIND11_MODULE(pyxrt, m) {
                                 return d.load_xclbin(xclbin);
                             }, "Load the xclbin to the device")
         .def("get_xclbin_uuid", &xrt::device::get_xclbin_uuid, "Return the UUID object representing the xclbin loaded on the device")
-        .def("get_info", [] (xrt::device& d, xrt::info::device key, xrt::info::InfoSchemaVersion version) {
+        .def("get_info", [] (xrt::device& d, xrt::info::device key) {
                              /* Convert the value to string since we can have only one return type for get_info() */
                              switch (key) {
                              case xrt::info::device::bdf:
-                                 return d.get_info<xrt::info::device::bdf>(version);
+                                 return d.get_info<xrt::info::device::bdf>();
                              case xrt::info::device::interface_uuid:
-                                 return d.get_info<xrt::info::device::interface_uuid>(version).to_string();
+                                 return d.get_info<xrt::info::device::interface_uuid>().to_string();
                              case xrt::info::device::kdma:
-                                 return std::to_string(d.get_info<xrt::info::device::kdma>(version));
+                                 return std::to_string(d.get_info<xrt::info::device::kdma>());
                              case xrt::info::device::max_clock_frequency_mhz:
-                                 return std::to_string(d.get_info<xrt::info::device::max_clock_frequency_mhz>(version));
+                                 return std::to_string(d.get_info<xrt::info::device::max_clock_frequency_mhz>());
                              case xrt::info::device::m2m:
-                                 return std::to_string(d.get_info<xrt::info::device::m2m>(version));
+                                 return std::to_string(d.get_info<xrt::info::device::m2m>());
                              case xrt::info::device::name:
-                                 return d.get_info<xrt::info::device::name>(version);
+                                 return d.get_info<xrt::info::device::name>();
                              case xrt::info::device::nodma:
-                                 return std::to_string(d.get_info<xrt::info::device::nodma>(version));
+                                 return std::to_string(d.get_info<xrt::info::device::nodma>());
                              case xrt::info::device::offline:
-                                 return std::to_string(d.get_info<xrt::info::device::offline>(version));
+                                 return std::to_string(d.get_info<xrt::info::device::offline>());
                              case xrt::info::device::electrical:
-                                 return d.get_info<xrt::info::device::electrical>(version);
+                                 return d.get_info<xrt::info::device::electrical>();
                              case xrt::info::device::thermal:
-                                 return d.get_info<xrt::info::device::thermal>(version);
+                                 return d.get_info<xrt::info::device::thermal>();
                              case xrt::info::device::mechanical:
-                                 return d.get_info<xrt::info::device::mechanical>(version);
+                                 return d.get_info<xrt::info::device::mechanical>();
                              case xrt::info::device::memory:
-                                 return d.get_info<xrt::info::device::memory>(version);
+                                 return d.get_info<xrt::info::device::memory>();
                              case xrt::info::device::platform:
-                                 return d.get_info<xrt::info::device::platform>(version);
+                                 return d.get_info<xrt::info::device::platform>();
                              case xrt::info::device::pcie_info:
-                                 return d.get_info<xrt::info::device::pcie_info>(version);
+                                 return d.get_info<xrt::info::device::pcie_info>();
                              case xrt::info::device::host:
-                                 return d.get_info<xrt::info::device::host>(version);
+                                 return d.get_info<xrt::info::device::host>();
                              case xrt::info::device::dynamic_regions:
-                                 return d.get_info<xrt::info::device::dynamic_regions>(version);
+                                 return d.get_info<xrt::info::device::dynamic_regions>();
                              default:
                                  return std::string("NA");
                              }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -250,10 +250,9 @@ get_xclbin_section(axlf_section_kind section, const uuid& uuid) const
     });
 }
 
-//version plumbing will be added when we introduce new versions of json schema
 boost::any
 device::
-get_info(info::device param, info::InfoSchemaVersion /*version*/) const
+get_info(info::device param) const
 {
   switch (param) {
   case info::device::bdf :                    // std::string

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -226,7 +226,6 @@ void
 add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
 {
   ptree_type pt_platform;
-  ptree_type pt_platforms;
 
   add_static_region_info(device, pt_platform);
   add_board_info(device, pt_platform);
@@ -235,8 +234,7 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
   add_clock_info(device, pt_platform);
   add_mac_info(device, pt_platform);
 
-  pt_platforms.push_back(std::make_pair("", pt_platform));
-  pt_platform_array.add_child("platforms", pt_platforms);
+  pt_platform_array.push_back(std::make_pair("", pt_platform));
 }
 
 } //unnamed namespace

--- a/src/runtime_src/core/include/xrt/xrt_device.h
+++ b/src/runtime_src/core/include/xrt/xrt_device.h
@@ -105,23 +105,6 @@ enum class device : unsigned int {
   dynamic_regions
 };
 
-/*!
- * @enum InfoSchemaVersion 
- *
- * @brief
- * Json schemaVersion parameters
- *
- * @details
- * Use with `xrt::device::get_info()` to retrieve a perticular version 
- * of schema of the properties.
- *
- * @var json_20202 
- *  Json 2020.2 schema
- */
-enum class InfoSchemaVersion  {
-  json_20202
-};
-
 /// @cond 
 /*
  * Return type for xrt::device::get_info()
@@ -260,8 +243,7 @@ public:
    * get_info() - Retrieve device parameter information
    *
    * This function is templated on the enumeration value as defined in
-   * the enumeration xrt::info::device and takes in 
-   * xrt::info::InfoSchemaVersion as a parameter.
+   * the enumeration xrt::info::device.
    *
    * The return type of the parameter is based on the instantiated
    * param_traits for the given param enumeration supplied as template
@@ -269,11 +251,11 @@ public:
    */
   template <info::device param>
   typename info::param_traits<info::device, param>::return_type
-  get_info(info::InfoSchemaVersion version) const
+  get_info() const
   {
     return boost::any_cast<
       typename info::param_traits<info::device, param>::return_type  
-    >(get_info(param, version));
+    >(get_info(param));
   }
 
   /**
@@ -386,7 +368,7 @@ private:
 
   XCL_DRIVER_DLLESPEC
   boost::any
-  get_info(info::device param, info::InfoSchemaVersion version) const;
+  get_info(info::device param) const;
 
 private:
   std::shared_ptr<xrt_core::device> handle;

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -252,7 +252,7 @@ populate_cus_new(const xrt_core::device *device)
   boost::property_tree::ptree pt_dynamic_regions;
   xrt::device dev(device->get_device_id());
   std::stringstream ss;
-  ss << dev.get_info<xrt::info::device::dynamic_regions>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << dev.get_info<xrt::info::device::dynamic_regions>();
   boost::property_tree::read_json(ss, pt_dynamic_regions);
   pt_dynamic_regions.add_child("compute_units", pt);
   return pt_dynamic_regions;

--- a/src/runtime_src/core/tools/common/ReportElectrical.cpp
+++ b/src/runtime_src/core/tools/common/ReportElectrical.cpp
@@ -37,7 +37,7 @@ ReportElectrical::getPropertyTree20202( const xrt_core::device * _pDevice,
   xrt::device device(_pDevice->get_device_id());
   boost::property_tree::ptree pt_electrical;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::electrical>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << device.get_info<xrt::info::device::electrical>();
   boost::property_tree::read_json(ss, pt_electrical);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportMechanical.cpp
+++ b/src/runtime_src/core/tools/common/ReportMechanical.cpp
@@ -37,7 +37,7 @@ ReportMechanical::getPropertyTree20202( const xrt_core::device * _pDevice,
   xrt::device device(_pDevice->get_device_id());
   boost::property_tree::ptree pt_mechanical;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::mechanical>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << device.get_info<xrt::info::device::mechanical>();
   boost::property_tree::read_json(ss, pt_mechanical);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -63,7 +63,7 @@ ReportMemory::getPropertyTree20202( const xrt_core::device * _pDevice,
   xrt::device device(_pDevice->get_device_id());
   boost::property_tree::ptree pt_memory;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::memory>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << device.get_info<xrt::info::device::memory>();
   boost::property_tree::read_json(ss, pt_memory);
 
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
+++ b/src/runtime_src/core/tools/common/ReportPcieInfo.cpp
@@ -38,7 +38,7 @@ ReportPcieInfo::getPropertyTree20202( const xrt_core::device * dev,
   xrt::device device(dev->get_device_id());
   boost::property_tree::ptree pt_pcie_info;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::pcie_info>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << device.get_info<xrt::info::device::pcie_info>();
   boost::property_tree::read_json(ss, pt_pcie_info);
   
   // There can only be 1 root node

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -39,11 +39,11 @@ ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev,
   xrt::device device(dev->get_device_id());
   boost::property_tree::ptree pt_platform;
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::platform>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << device.get_info<xrt::info::device::platform>();
   boost::property_tree::read_json(ss, pt_platform);
  
   // There can only be 1 root node
-  pt = pt_platform;
+  pt.add_child("platforms", pt_platform);
 }
 
 void 

--- a/src/runtime_src/core/tools/common/ReportThermal.cpp
+++ b/src/runtime_src/core/tools/common/ReportThermal.cpp
@@ -37,7 +37,7 @@ ReportThermal::getPropertyTree20202( const xrt_core::device * _pDevice,
 {
   xrt::device device(_pDevice->get_device_id());
   std::stringstream ss;
-  ss << device.get_info<xrt::info::device::thermal>(xrt::info::InfoSchemaVersion::json_20202);
+  ss << device.get_info<xrt::info::device::thermal>();
   boost::property_tree::read_json(ss, _pt);
 }
 

--- a/tests/python/23_bandwidth/23_bandwidth.py
+++ b/tests/python/23_bandwidth/23_bandwidth.py
@@ -26,7 +26,7 @@ DATASIZE = int(1024*1024*16)    #16 MB
 
 def getThreshold(devhdl):
     threshold = 40000
-    name = devhdl.get_info(pyxrt.xrt_info_device.name, pyxrt.xrt_info_schema.json_20202)
+    name = devhdl.get_info(pyxrt.xrt_info_device.name);
 
     if "qdma" in name or "qep" in name:
         threshold = 30000
@@ -40,7 +40,7 @@ def getThreshold(devhdl):
 
 def getInputOutputBuffer(devhdl, krnlhdl, argno, isInput):
     bo = pyxrt.bo(devhdl, DATASIZE, pyxrt.bo.normal, krnlhdl.group_id(argno))
-    buf = bo.map()
+    buf = bo.map();
 
     for i in range(DATASIZE):
         buf[i] = i%256 if isInput else 0
@@ -97,11 +97,11 @@ def runKernel(opt):
             output_bo1.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, limit, 0)
             output_bo2.sync(pyxrt.xclBOSyncDirection.XCL_BO_SYNC_BO_FROM_DEVICE, limit, 0)
 
-            failed = (input_buf1[:limit] != output_buf1[:limit])
+            failed = (input_buf1[:limit] != output_buf1[:limit]);
             if (failed):
                 break
 
-            failed = (input_buf2[:limit] != output_buf2[:limit])
+            failed = (input_buf2[:limit] != output_buf2[:limit]);
             if (failed):
                 break
             # print("Reps = %d, Beats = %d, Duration = %lf us" %(reps, beats, usduration)) # for debug

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -84,31 +84,31 @@ int run(int argc, char** argv)
   if (uuid != xclbin.get_uuid())
     throw std::runtime_error("Unexpected uuid error");
 
-  std::cout << "device name:           " << device.get_info<xrt::info::device::name>(xrt::info::InfoSchemaVersion::json_20202) << "\n";
-  std::cout << "device bdf:            " << device.get_info<xrt::info::device::bdf>(xrt::info::InfoSchemaVersion::json_20202) << "\n";
-  std::cout << "device kdma:           " << device.get_info<xrt::info::device::kdma>(xrt::info::InfoSchemaVersion::json_20202) << "\n";
-  std::cout << "device max freq:       " << device.get_info<xrt::info::device::max_clock_frequency_mhz>(xrt::info::InfoSchemaVersion::json_20202) << "\n";
-  std::cout << "device m2m:            " << std::boolalpha << device.get_info<xrt::info::device::m2m>(xrt::info::InfoSchemaVersion::json_20202) << std::dec << "\n";
-  std::cout << "device nodma:          " << std::boolalpha << device.get_info<xrt::info::device::nodma>(xrt::info::InfoSchemaVersion::json_20202) << std::dec << "\n";
-  std::cout << "device interface uuid: " << device.get_info<xrt::info::device::interface_uuid>(xrt::info::InfoSchemaVersion::json_20202).to_string() << "\n";
+  std::cout << "device name:           " << device.get_info<xrt::info::device::name>() << "\n";
+  std::cout << "device bdf:            " << device.get_info<xrt::info::device::bdf>() << "\n";
+  std::cout << "device kdma:           " << device.get_info<xrt::info::device::kdma>() << "\n";
+  std::cout << "device max freq:       " << device.get_info<xrt::info::device::max_clock_frequency_mhz>() << "\n";
+  std::cout << "device m2m:            " << std::boolalpha << device.get_info<xrt::info::device::m2m>() << std::dec << "\n";
+  std::cout << "device nodma:          " << std::boolalpha << device.get_info<xrt::info::device::nodma>() << std::dec << "\n";
+  std::cout << "device interface uuid: " << device.get_info<xrt::info::device::interface_uuid>().to_string() << "\n";
 
   if (json_queries) {
     std::cout << "device electrical json info ====================================\n";
-    std::cout << device.get_info<xrt::info::device::electrical>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::electrical>();
     std::cout << "device thermal json info =======================================\n";
-    std::cout << device.get_info<xrt::info::device::thermal>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::thermal>();
     std::cout << "device mechanical json info ====================================\n";
-    std::cout << device.get_info<xrt::info::device::mechanical>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::mechanical>();
     std::cout << "device memory json info ========================================\n";
-    std::cout << device.get_info<xrt::info::device::memory>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::memory>();
     std::cout << "device platform json info ======================================\n";
-    std::cout << device.get_info<xrt::info::device::platform>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::platform>();
     std::cout << "device pcie json info ==========================================\n";
-    std::cout << device.get_info<xrt::info::device::pcie_info>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::pcie_info>();
     std::cout << "device dynamic regions json info ===============================\n";
-    std::cout << device.get_info<xrt::info::device::dynamic_regions>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::dynamic_regions>();
     std::cout << "device host json info ==========================================\n";
-    std::cout << device.get_info<xrt::info::device::host>(xrt::info::InfoSchemaVersion::json_20202);
+    std::cout << device.get_info<xrt::info::device::host>();
   }
 
   return 0;

--- a/tests/xrt/reset/xcl.cpp
+++ b/tests/xrt/reset/xcl.cpp
@@ -54,7 +54,7 @@ SigBusHandler(int sig)
 
   // Create xrt::device from already opened xclDeviceHandle
   xrt::device d(dhdl);
-  if (!d.get_info<xrt::info::device::offline, xrt::info::InfoSchemaVersion::json_20202>())
+  if (!d.get_info<xrt::info::device::offline>())
     throw std::runtime_error("Device is unexpectedly online");
 
   // Close device gracefully before existing on device reset
@@ -75,7 +75,7 @@ SigIntHandler(int sig)
 
   // Create xrt::device from already opened xclDeviceHandle
   xrt::device d(dhdl);
-  if (d.get_info<xrt::info::device::offline, xrt::info::InfoSchemaVersion::json_20202>())
+  if (d.get_info<xrt::info::device::offline>())
     throw std::runtime_error("Device is unexpectedly offline");
 
   // Close device gracefully before existing on ctrl-c

--- a/tests/xrt/reset/xrt.cpp
+++ b/tests/xrt/reset/xrt.cpp
@@ -50,7 +50,7 @@ SigBusHandler(int sig)
   std::lock_guard<std::mutex> lk(mutex);
   std::cout  << "-> sig bus handler\n";
 
-  if (!device.get_info<xrt::info::device::offline, xrt::info::InfoSchemaVersion::json_20202>())
+  if (!device.get_info<xrt::info::device::offline>())
     throw std::runtime_error("Device is unexpectedly online");
 
   // Close device gracefully before existing on device reset
@@ -69,7 +69,7 @@ SigIntHandler(int sig)
   std::lock_guard<std::mutex> lk(mutex);
   std::cout  << "-> sig int handler\n";
 
-  if (device.get_info<xrt::info::device::offline, xrt::info::InfoSchemaVersion::json_20202>())
+  if (device.get_info<xrt::info::device::offline>())
     throw std::runtime_error("Device is unexpectedly offline");
 
   // Nothing to close device will auto close


### PR DESCRIPTION
Reverts Xilinx/XRT#5721
Breaks ABI and not a friendly change to have to specify schema version, which is not applicable to some keys.