### PR TITLE
CR-1110437 - did not rename slavebridge.exe in xbutil validate

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -264,6 +264,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
       { "22_verify.py",             "validate.exe"    },
       { "23_bandwidth.py",          "kernel_bw.exe"   },
       { "versal_23_bandwidth.py",   "kernel_bw.exe"   },
+      { "host_mem_23_bandwidth.py", "slavebridge.exe" },
       { "host_mem_23_bandwidth.py", "hostmemory.exe"  },
       { "xcl_vcu_test.exe",         "xcl_vcu_test.exe"},
       { "xcl_iops_test.exe",        "xcl_iops_test.exe"}

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -264,7 +264,6 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
       { "22_verify.py",             "validate.exe"    },
       { "23_bandwidth.py",          "kernel_bw.exe"   },
       { "versal_23_bandwidth.py",   "kernel_bw.exe"   },
-      { "host_mem_23_bandwidth.py", "slavebridge.exe" },
       { "host_mem_23_bandwidth.py", "hostmemory.exe"  },
       { "xcl_vcu_test.exe",         "xcl_vcu_test.exe"},
       { "xcl_iops_test.exe",        "xcl_iops_test.exe"}

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -264,7 +264,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
       { "22_verify.py",             "validate.exe"    },
       { "23_bandwidth.py",          "kernel_bw.exe"   },
       { "versal_23_bandwidth.py",   "kernel_bw.exe"   },
-      { "host_mem_23_bandwidth.py", "slavebridge.exe" },
+      { "host_mem_23_bandwidth.py", "hostmemory.exe"  },
       { "xcl_vcu_test.exe",         "xcl_vcu_test.exe"},
       { "xcl_iops_test.exe",        "xcl_iops_test.exe"}
     };

--- a/tests/validate/CMakeLists.txt
+++ b/tests/validate/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 add_subdirectory(verify_test)
 add_subdirectory(bandwidth_test)
-add_subdirectory(slavebridge_test)
+add_subdirectory(hostmemory_test)
 
 # Special iops performance test cases
 add_subdirectory(xcl_iops_test)

--- a/tests/validate/hostmemory_test/CMakeLists.txt
+++ b/tests/validate/hostmemory_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 #
-set(TESTNAME "slavebridge.exe")
+set(TESTNAME "hostmemory.exe")
 
 if (WIN32)
   set(OpenCL_INCLUDE_DIR ${OCL_ROOT}/include)

--- a/tests/validate/hostmemory_test/src/host.cpp
+++ b/tests/validate/hostmemory_test/src/host.cpp
@@ -13,59 +13,36 @@
 * License for the specific language governing permissions and limitations
 * under the License.
 */
+#include "cmdlineparser.h"
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <math.h>
 #include <sys/time.h>
 #include <xcl2.hpp>
 
-static void printHelp() {
-    std::cout << "usage: %s <options>\n";
-    std::cout << "  -p <path>\n";
-    std::cout << "  -d <device> \n";
-    std::cout << "  -l <loop_iter_cnt> \n";
-    std::cout << "  -s <supported>\n";
-    std::cout << "  -h <help>\n";
-}
-
 int main(int argc, char** argv) {
-    std::string dev_id = "0";
-    std::string test_path;
-    std::string iter_cnt = "10000";
-    std::string b_file = "/slavebridge.xclbin";
-    bool flag_s = false;
-
-    for (int i = 1; i < argc; i++) {
-        if ((strcmp(argv[i], "-p") == 0) || (strcmp(argv[i], "--path") == 0)) {
-            test_path = argv[i + 1];
-        } else if ((strcmp(argv[i], "-d") == 0) || (strcmp(argv[i], "--device") == 0)) {
-            dev_id = argv[i + 1];
-        } else if ((strcmp(argv[i], "-l") == 0) || (strcmp(argv[i], "--loop_iter_cnt") == 0)) {
-            iter_cnt = argv[i + 1];
-        } else if ((strcmp(argv[i], "-s") == 0) || (strcmp(argv[i], "--supported") == 0)) {
-            flag_s = true;
-        } else if ((strcmp(argv[i], "-h") == 0) || (strcmp(argv[i], "--help") == 0)) {
-            printHelp();
-            return 1;
-        }
-    }
-    if (test_path.empty()) {
-        std::cout << "ERROR : please provide the platform test path to -p option\n";
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " <Platform Test Area Path>"
+                  << "<optional> -d device_id"
+                  << "<optional> -l iter_cnt" << std::endl;
         return EXIT_FAILURE;
     }
-    if (flag_s) {
-        std::string binaryFile = test_path + b_file;
-        std::ifstream infile(binaryFile);
-        if (!infile.good()) {
-            std::cout << "\nNOT SUPPORTED" << std::endl;
-            return EOPNOTSUPP;
-        } else {
-            std::cout << "\nSUPPORTED" << std::endl;
-            return EXIT_SUCCESS;
-        }
-    }
+
+    // Command Line Parser
+    sda::utils::CmdLineParser parser;
+
+    // Switches
+    //**************//"<Full Arg>",  "<Short Arg>", "<Description>", "<Default>"
+    parser.addSwitch("--device", "-d", "device id", "0");
+    parser.addSwitch("--iter_cnt", "-l", "loop iteration count", "10000");
+    parser.parse(argc, argv);
+
+    // Read settings
+    std::string dev_id = parser.value("device");
+    std::string iter_cnt = parser.value("iter_cnt");
 
     int NUM_KERNEL;
+    std::string test_path = argv[1];
     std::string filename = "/platform.json";
     std::string platform_json = test_path + filename;
 
@@ -84,6 +61,7 @@ int main(int argc, char** argv) {
         std::cout << msg;
     }
 
+    std::string b_file = "/hostmemory.xclbin";
     std::string binaryFile = test_path + b_file;
     std::ifstream infile(binaryFile);
     if (!infile.good()) {
@@ -93,7 +71,7 @@ int main(int argc, char** argv) {
 
     cl_int err;
     cl::Context context;
-    std::string krnl_name = "slavebridge";
+    std::string krnl_name = "hostmemory";
     std::vector<cl::Kernel> krnls(NUM_KERNEL);
     cl::CommandQueue q;
 
@@ -124,15 +102,6 @@ int main(int argc, char** argv) {
         device = xcl::find_device_bdf(devices, dev_id);
     }
 
-    auto device_name = device.getInfo<CL_DEVICE_NAME>();
-    if (xcl::is_hw_emulation()) {
-        if (device_name.find("202010") != std::string::npos) {
-            std::cout << "[INFO]: The example is not supported for " << device_name
-                      << " for hw_emu. Please try other flows." << '\n';
-            return EXIT_SUCCESS;
-        }
-    }
-
     // Creating Context and Command Queue for selected Device
     OCL_CHECK(err, context = cl::Context(device, nullptr, nullptr, nullptr, &err));
     OCL_CHECK(err, q = cl::CommandQueue(context, device,
@@ -145,7 +114,7 @@ int main(int argc, char** argv) {
         std::cout << "Device program successful!\n";
         for (int i = 0; i < NUM_KERNEL; i++) {
             std::string cu_id = std::to_string(i + 1);
-            std::string krnl_name_full = krnl_name + ":{" + "slavebridge_" + cu_id + "}";
+            std::string krnl_name_full = krnl_name + ":{" + "hostmemory_" + cu_id + "}";
 
             printf("Creating a kernel [%s] for CU(%d)\n", krnl_name_full.c_str(), i + 1);
 

--- a/tests/validate/hostmemory_test/src/host.cpp
+++ b/tests/validate/hostmemory_test/src/host.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
     std::string iter_cnt = "10000";
-    std::string b_file = "/slavebridge.xclbin";
+    std::string b_file = "/hostmemory.xclbin";
     bool flag_s = false;
 
     for (int i = 1; i < argc; i++) {
@@ -84,7 +84,6 @@ int main(int argc, char** argv) {
         std::cout << msg;
     }
 
-    std::string b_file = "/hostmemory.xclbin";
     std::string binaryFile = test_path + b_file;
     std::ifstream infile(binaryFile);
     if (!infile.good()) {


### PR DESCRIPTION
https://jira.xilinx.com/browse/CR-1110437

**_Issue_**
xbutil validate test `host_mem_23_bandwidth.py` is using the incorrect host executable.  It should be using `hostmemory.exe` instead of `slavebridge.exe`.

**_Resolution_**
The code has been updated to use the `hostmemory.exe` host executable.

**_Side Note_**
Being that the hostmemory.exe already exist there are no impacts with this host code naming change.   There is an issue with the xclbin image name change that is being addressed by Vishnu.