### PR TITLE
CR-1110672: Clarify profiling summary memory resource table entry

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1454,7 +1454,7 @@ namespace xdp {
     fout << "COLUMN:<html>Memory<br>Resource</html>,string,"
          << "Memory resource on the device\n" ;
     fout << "COLUMN:<html>Transfer<br>Type</html>,string,"
-         << "Read or write transfer\n" ;
+         << "Read from this memory resource or write to this memory resource\n";
     fout << "COLUMN:<html>Number<br>of Transfers</html>,int,"
          << "Number of data transfers\n" ;
     fout << "COLUMN:<html>Transfer<br>Rate (MB/s)</html>,float,"


### PR DESCRIPTION
Updating the tooltip on the new Memory Resource table to clarify what directions READ and WRITE is in this context refer to.