### PR TITLE
CR-1110810: Correct latency type printed in profile summary table

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -1733,6 +1733,9 @@ namespace xdp {
 	    double aveBW =
 	      (one_hundred * transferRate) / xclbin->maxWriteBW ;
 	    if (aveBW > one_hundred) aveBW = one_hundred ;
+	    auto aveLatency =
+              static_cast<double>(values.WriteLatency[monitorId]) /
+              static_cast<double>(writeTranx) ;
 
 	    fout << device->getUniqueDeviceName() << ","
 		 << xclbin->cus[monitor->cuIndex]->getName() << "/"
@@ -1744,8 +1747,7 @@ namespace xdp {
 		 << transferRate << ","
 		 << aveBW << ","
 		 << (double)(values.WriteBytes[monitorId] / writeTranx) / one_thousand << ","
-		 << (values.WriteLatency[monitorId] / writeTranx) << "," 
-		 << std::endl ;
+		 << aveLatency << ",\n" ;
 	  }
 	  if (readTranx > 0) {
 	      double transferRate = (totalReadTime == zero) ? 0 :
@@ -1753,6 +1755,9 @@ namespace xdp {
 	      double aveBW =
 		(one_hundred * transferRate) / xclbin->maxReadBW ;
 	      if (aveBW > one_hundred) aveBW = one_hundred ;
+              auto aveLatency =
+                static_cast<double>(values.ReadLatency[monitorId]) /
+                static_cast<double>(readTranx) ;
 
 	      fout << device->getUniqueDeviceName() << ","
 		   << xclbin->cus[monitor->cuIndex]->getName() << "/"
@@ -1764,8 +1769,7 @@ namespace xdp {
 		   << transferRate << ","
 		   << aveBW << ","
 		   << (double)(values.ReadBytes[monitorId] / readTranx) / one_thousand << ","
-		   << (values.ReadLatency[monitorId] / readTranx) << "," 
-		   << std::endl ;
+		   << aveLatency << ",\n" ;
 	  }
 	  ++monitorId ;
 	}


### PR DESCRIPTION
Change average latency to be printed as a double as expected by downstream tools.