### PR TITLE
Print host mem error when host only BO allocation fails

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -652,9 +652,20 @@ static xclBufferHandle
 alloc_bo(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
   auto device = xrt_core::get_userpf_device(dhdl);
-  flags = (flags & ~XRT_BO_FLAGS_MEMIDX_MASK) | grp;
-  return device->alloc_bo(sz, flags);
+  auto xflags = (flags & ~XRT_BO_FLAGS_MEMIDX_MASK) | grp;
+  try {
+    return device->alloc_bo(sz, xflags);
+  }
+  catch (const std::exception& ex) {
+    if (flags == XRT_BO_FLAGS_HOST_ONLY) {
+      auto fmt = boost::format("Failed to allocate host memory buffer (%s), make sure host bank is enabled "
+                               "(see xbutil configure --host-mem)") % ex.what();
+      send_exception_message(fmt.str());
+    }
+    throw;
+  }
 }
+
 
 static void
 free_bo(xrtBufferHandle bhdl)
@@ -719,18 +730,10 @@ alloc_nodma(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags, xrtMemoryGroup grp)
     throw xrt_core::error(EINVAL, "Invalid buffer size '" + std::to_string(sz) +
                           "', must be multiple of 64 bytes for NoDMA platforms");
 
-  try {
-    auto hbuf_handle = alloc_bo(dhdl, sz, XCL_BO_FLAGS_HOST_ONLY, grp);
-    auto dbuf_handle = alloc_bo(dhdl, sz, XCL_BO_FLAGS_DEV_ONLY, grp);
-    auto boh = std::make_shared<xrt::buffer_nodma>(dhdl, hbuf_handle, dbuf_handle, sz);
-    return boh;
-  }
-  catch (const std::exception& ex) {
-    auto fmt = boost::format("Failed to allocate host memory buffer (%s), make sure host bank is enabled "
-                             "(see xbutil configure --host-mem)") % ex.what();
-    send_exception_message(fmt.str());
-    throw;
-  }
+  auto hbuf_handle = alloc_bo(dhdl, sz, XCL_BO_FLAGS_HOST_ONLY, grp);
+  auto dbuf_handle = alloc_bo(dhdl, sz, XCL_BO_FLAGS_DEV_ONLY, grp);
+  auto boh = std::make_shared<xrt::buffer_nodma>(dhdl, hbuf_handle, dbuf_handle, sz);
+  return boh;
 }
 
 static std::shared_ptr<xrt::bo_impl>


### PR DESCRIPTION
Show host mem error when ever allocating host only BO fails.
Previously only shown for nodma platforms.