### PR TITLE
update validate designs to report mem type in logs

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -349,10 +349,20 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
 
   // Get out max thruput for bandwidth testcase
   if(xclbin.compare("bandwidth.xclbin") == 0) {
+    // old testcases where we have "Maximum throughput:"
     size_t st = os_stdout.str().find("Maximum");
     if (st != std::string::npos) {
       size_t end = os_stdout.str().find("\n", st);
       logger(_ptTest, "Details", os_stdout.str().substr(st, end - st));
+    }
+    else {
+      // new test cases to find "Throughput (Type: {...}) (Bank count: {...}):"
+      auto st = os_stdout.str().find("Throughput", 0);
+      while(st != std::string::npos) {
+        auto end = os_stdout.str().find("\n", st);
+        logger(_ptTest, "Details", os_stdout.str().substr(st, end - st));
+        st = os_stdout.str().find("Throughput" , end);
+      }
     }
   }
 

--- a/tests/validate/bandwidth_test/CMakeLists.txt
+++ b/tests/validate/bandwidth_test/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(WIN32)
 
 include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
 add_executable(${TESTNAME} ../common/includes/xcl2/xcl2.cpp ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/host.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} ) 

--- a/tests/validate/bandwidth_test/src/host.cpp
+++ b/tests/validate/bandwidth_test/src/host.cpp
@@ -54,9 +54,9 @@ int main(int argc, char** argv) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
+    std::string binaryFile = test_path + b_file;
+    std::ifstream infile(binaryFile);
     if (flag_s) {
-        std::string binaryFile = test_path + b_file;
-        std::ifstream infile(binaryFile);
         if (!infile.good()) {
             std::cout << "\nNOT SUPPORTED" << std::endl;
             return EOPNOTSUPP;
@@ -66,29 +66,29 @@ int main(int argc, char** argv) {
         }
     }
 
-    int NUM_KERNEL = 0, NUM_KERNEL_DDR = 0;
+    int num_kernel = 0, num_kernel_ddr = 0;
     bool chk_hbm_mem = false;
     std::string filename = "/platform.json";
     std::string platform_json = test_path + filename;
 
     try {
-        boost::property_tree::ptree loadPtreeRoot;
-        boost::property_tree::read_json(platform_json, loadPtreeRoot);
-        boost::property_tree::ptree temp;
+        boost::property_tree::ptree load_ptree_root;
+        boost::property_tree::read_json(platform_json, load_ptree_root);
 
-        temp = loadPtreeRoot.get_child("total_ddr_banks");
-        NUM_KERNEL = temp.get_value<int>();
-        NUM_KERNEL_DDR = NUM_KERNEL;
-        boost::property_tree::ptree ptMemArray;
-        ptMemArray = loadPtreeRoot.get_child("meminfo");
-        for (auto memEntry : ptMemArray) {
-            boost::property_tree::ptree ptMemEntry = memEntry.second;
-            const std::string& sValue = ptMemEntry.get<std::string>("type");
+        auto temp = load_ptree_root.get_child("total_ddr_banks");
+        num_kernel = temp.get_value<int>();
+        num_kernel_ddr = num_kernel;
+        auto pt_mem_array = load_ptree_root.get_child("meminfo");
+        for (const auto& mem_entry : pt_mem_array) {
+            boost::property_tree::ptree pt_mem_entry = mem_entry.second;
+            auto sValue = pt_mem_entry.get<std::string>("type");
             if (sValue == "HBM") {
                 chk_hbm_mem = true;
             }
         }
-        if (chk_hbm_mem) NUM_KERNEL_DDR = NUM_KERNEL - 1;
+        if (chk_hbm_mem) {
+            num_kernel_ddr = num_kernel - 1;
+        }
     } catch (const std::exception& e) {
         std::string msg("ERROR: Bad JSON format detected while marshaling build metadata (");
         msg += e.what();
@@ -96,8 +96,6 @@ int main(int argc, char** argv) {
         std::cout << msg << std::endl;
     }
 
-    std::string binaryFile = test_path + b_file;
-    std::ifstream infile(binaryFile);
     if (!infile.good()) {
         std::cout << "\nNOT SUPPORTED" << std::endl;
         return EOPNOTSUPP;
@@ -106,7 +104,7 @@ int main(int argc, char** argv) {
     cl_int err;
     cl::Context context;
     std::string krnl_name = "bandwidth";
-    std::vector<cl::Kernel> krnls(NUM_KERNEL);
+    std::vector<cl::Kernel> krnls(num_kernel);
     cl::CommandQueue q;
 
     // OPENCL HOST CODE AREA START
@@ -115,8 +113,8 @@ int main(int argc, char** argv) {
     auto devices = xcl::get_xil_devices();
     // read_binary_file() is a utility API which will load the binaryFile
     // and will return the pointer to file buffer.
-    auto fileBuf = xcl::read_binary_file(binaryFile);
-    cl::Program::Binaries bins{{fileBuf.data(), fileBuf.size()}};
+    auto file_buf = xcl::read_binary_file(binaryFile);
+    cl::Program::Binaries bins{{file_buf.data(), file_buf.size()}};
 
     auto pos = dev_id.find(":");
     cl::Device device;
@@ -146,7 +144,7 @@ int main(int argc, char** argv) {
         std::cout << "Failed to program device with xclbin file!\n";
     } else {
         std::cout << "Device program successful!\n";
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             std::string cu_id = std::to_string(i + 1);
             std::string krnl_name_full = krnl_name + ":{" + "bandwidth_" + cu_id + "}";
 
@@ -161,78 +159,77 @@ int main(int argc, char** argv) {
 
     double max_throughput = 0;
     int reps = stoi(iter_cnt);
-    if (NUM_KERNEL_DDR) {
+    if (num_kernel_ddr) {
         for (uint32_t i = 4 * 1024; i <= 16 * 1024 * 1024; i *= 2) {
-            unsigned int DATA_SIZE = i;
+            unsigned int data_size = i;
 
             if (xcl::is_emulation()) {
                 reps = 2;
-                if (DATA_SIZE > 8 * 1024) break;
+                if (data_size > 8 * 1024) {
+                    break;
+                }
             }
 
-            unsigned int vector_size_bytes = DATA_SIZE;
-            std::vector<unsigned char, aligned_allocator<unsigned char> > input_host(DATA_SIZE);
-            std::vector<unsigned char, aligned_allocator<unsigned char> > output_host[NUM_KERNEL_DDR];
+            unsigned int vector_size_bytes = data_size;
+            std::vector<unsigned char, aligned_allocator<unsigned char> > input_host(data_size);
+            std::vector<unsigned char, aligned_allocator<unsigned char> > output_host[num_kernel_ddr];
 
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
-                output_host[i].resize(DATA_SIZE);
+            for (int i = 0; i < num_kernel_ddr; i++) {
+                output_host[i].resize(data_size);
             }
-            for (uint32_t j = 0; j < DATA_SIZE; j++) {
+            for (uint32_t j = 0; j < data_size; j++) {
                 input_host[j] = j % 256;
             }
 
             // Initializing output vectors to zero
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
                 std::fill(output_host[i].begin(), output_host[i].end(), 0);
             }
 
-            std::vector<cl::Buffer> input_buffer(NUM_KERNEL_DDR);
-            std::vector<cl::Buffer> output_buffer(NUM_KERNEL_DDR);
+            std::vector<cl::Buffer> input_buffer(num_kernel_ddr);
+            std::vector<cl::Buffer> output_buffer(num_kernel_ddr);
 
             // These commands will allocate memory on the FPGA. The cl::Buffer objects
             // can
             // be used to reference the memory locations on the device.
             // Creating Buffers
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
                 OCL_CHECK(err,
                           input_buffer[i] = cl::Buffer(context, CL_MEM_READ_WRITE, vector_size_bytes, nullptr, &err));
                 OCL_CHECK(err,
                           output_buffer[i] = cl::Buffer(context, CL_MEM_READ_WRITE, vector_size_bytes, nullptr, &err));
             }
 
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
                 OCL_CHECK(err, err = krnls[i].setArg(0, input_buffer[i]));
                 OCL_CHECK(err, err = krnls[i].setArg(1, output_buffer[i]));
-                OCL_CHECK(err, err = krnls[i].setArg(2, DATA_SIZE));
+                OCL_CHECK(err, err = krnls[i].setArg(2, data_size));
                 OCL_CHECK(err, err = krnls[i].setArg(3, reps));
             }
 
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
                 OCL_CHECK(err, err = q.enqueueWriteBuffer(input_buffer[i], CL_TRUE, 0, vector_size_bytes,
                                                           input_host.data(), nullptr, nullptr));
                 OCL_CHECK(err, err = q.finish());
             }
 
-            std::chrono::high_resolution_clock::time_point timeStart;
-            std::chrono::high_resolution_clock::time_point timeEnd;
+            auto time_start = std::chrono::high_resolution_clock::now();
 
-            timeStart = std::chrono::high_resolution_clock::now();
-
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
                 OCL_CHECK(err, err = q.enqueueTask(krnls[i]));
             }
             q.finish();
-            timeEnd = std::chrono::high_resolution_clock::now();
+            auto time_end = std::chrono::high_resolution_clock::now();
 
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
                 OCL_CHECK(err, err = q.enqueueReadBuffer(output_buffer[i], CL_TRUE, 0, vector_size_bytes,
                                                          output_host[i].data(), nullptr, nullptr));
                 OCL_CHECK(err, err = q.finish());
             }
 
             // check
-            for (int i = 0; i < NUM_KERNEL_DDR; i++) {
-                for (uint32_t j = 0; j < DATA_SIZE; j++) {
+            for (int i = 0; i < num_kernel_ddr; i++) {
+                for (uint32_t j = 0; j < data_size; j++) {
                     if (output_host[i][j] != input_host[j]) {
                         std::cout << "ERROR : kernel failed to copy entry " << j << " input " << input_host[j]
                                   << " output " << output_host[i][j] << std::endl;
@@ -241,39 +238,35 @@ int main(int argc, char** argv) {
                 }
             }
 
-            double usduration;
-            double dnsduration;
-            double dsduration;
-            double bpersec;
-            double mbpersec;
+            double usduration =
+                (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
 
-            usduration =
-                (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(timeEnd - timeStart).count() / reps);
-
-            dnsduration = (double)usduration;
-            dsduration = dnsduration / ((double)1000000000);
-            bpersec = (DATA_SIZE * NUM_KERNEL_DDR) / dsduration;
-            mbpersec = (2 * bpersec) / ((double)1024 * 1024); // For concurrent Read/Write
+            double dnsduration = (double)usduration;
+            double dsduration = dnsduration / ((double)1000000000);
+            double bpersec = (data_size * num_kernel_ddr) / dsduration;
+            double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // For concurrent Read/Write
 
             if (mbpersec > max_throughput) max_throughput = mbpersec;
         }
 
-        std::cout << "Overall DDRs (total " << NUM_KERNEL_DDR << ") Throughput: " << max_throughput << "MB/s\n";
+        std::cout << "Throughput (Type: DDR) (Bank count: " << num_kernel_ddr << ") : " << max_throughput << "MB/s\n";
     }
     if (chk_hbm_mem) {
         for (uint32_t i = 4 * 1024; i <= 16 * 1024 * 1024; i *= 2) {
-            unsigned int DATA_SIZE = i;
+            unsigned int data_size = i;
 
             if (xcl::is_emulation()) {
                 reps = 2;
-                if (DATA_SIZE > 8 * 1024) break;
+                if (data_size > 8 * 1024) {
+                    break;
+                }
             }
 
-            unsigned int vector_size_bytes = DATA_SIZE;
-            std::vector<unsigned char, aligned_allocator<unsigned char> > input_host(DATA_SIZE);
-            std::vector<unsigned char, aligned_allocator<unsigned char> > output_host(DATA_SIZE);
+            unsigned int vector_size_bytes = data_size;
+            std::vector<unsigned char, aligned_allocator<unsigned char> > input_host(data_size);
+            std::vector<unsigned char, aligned_allocator<unsigned char> > output_host(data_size);
 
-            for (uint32_t j = 0; j < DATA_SIZE; j++) {
+            for (uint32_t j = 0; j < data_size; j++) {
                 input_host[j] = j % 256;
             }
 
@@ -289,30 +282,27 @@ int main(int argc, char** argv) {
             OCL_CHECK(err, input_buffer = cl::Buffer(context, CL_MEM_READ_WRITE, vector_size_bytes, nullptr, &err));
             OCL_CHECK(err, output_buffer = cl::Buffer(context, CL_MEM_READ_WRITE, vector_size_bytes, nullptr, &err));
 
-            OCL_CHECK(err, err = krnls[NUM_KERNEL - 1].setArg(0, input_buffer));
-            OCL_CHECK(err, err = krnls[NUM_KERNEL - 1].setArg(1, output_buffer));
-            OCL_CHECK(err, err = krnls[NUM_KERNEL - 1].setArg(2, DATA_SIZE));
-            OCL_CHECK(err, err = krnls[NUM_KERNEL - 1].setArg(3, reps));
+            OCL_CHECK(err, err = krnls[num_kernel - 1].setArg(0, input_buffer));
+            OCL_CHECK(err, err = krnls[num_kernel - 1].setArg(1, output_buffer));
+            OCL_CHECK(err, err = krnls[num_kernel - 1].setArg(2, data_size));
+            OCL_CHECK(err, err = krnls[num_kernel - 1].setArg(3, reps));
 
             OCL_CHECK(err, err = q.enqueueWriteBuffer(input_buffer, CL_TRUE, 0, vector_size_bytes, input_host.data(),
                                                       nullptr, nullptr));
             OCL_CHECK(err, err = q.finish());
 
-            std::chrono::high_resolution_clock::time_point timeStart;
-            std::chrono::high_resolution_clock::time_point timeEnd;
+            auto time_start = std::chrono::high_resolution_clock::now();
 
-            timeStart = std::chrono::high_resolution_clock::now();
-
-            OCL_CHECK(err, err = q.enqueueTask(krnls[NUM_KERNEL - 1]));
+            OCL_CHECK(err, err = q.enqueueTask(krnls[num_kernel - 1]));
             q.finish();
-            timeEnd = std::chrono::high_resolution_clock::now();
+            auto time_end = std::chrono::high_resolution_clock::now();
 
             OCL_CHECK(err, err = q.enqueueReadBuffer(output_buffer, CL_TRUE, 0, vector_size_bytes, output_host.data(),
                                                      nullptr, nullptr));
             OCL_CHECK(err, err = q.finish());
 
             // check
-            for (uint32_t j = 0; j < DATA_SIZE; j++) {
+            for (uint32_t j = 0; j < data_size; j++) {
                 if (output_host[j] != input_host[j]) {
                     std::cout << "ERROR : kernel failed to copy entry " << j << " input " << input_host[j] << " output "
                               << output_host[j] << std::endl;
@@ -320,24 +310,18 @@ int main(int argc, char** argv) {
                 }
             }
 
-            double usduration;
-            double dnsduration;
-            double dsduration;
-            double bpersec;
-            double mbpersec;
+            double usduration =
+                (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
 
-            usduration =
-                (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(timeEnd - timeStart).count() / reps);
-
-            dnsduration = (double)usduration;
-            dsduration = dnsduration / ((double)1000000000);
-            bpersec = DATA_SIZE / dsduration;
-            mbpersec = (2 * bpersec) / ((double)1024 * 1024); // For concurrent Read/Write
+            double dnsduration = (double)usduration;
+            double dsduration = dnsduration / ((double)1000000000);
+            double bpersec = data_size / dsduration;
+            double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // For concurrent Read/Write
 
             if (mbpersec > max_throughput) max_throughput = mbpersec;
         }
 
-        std::cout << "HBM Single Channel Throughput: " << max_throughput << "MB/s\n";
+        std::cout << "Throughput (Type: HBM) (Bank count: 1) : " << max_throughput << "MB/s\n";
     }
 
     std::cout << "TEST PASSED\n";

--- a/tests/validate/slavebridge_test/CMakeLists.txt
+++ b/tests/validate/slavebridge_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
 #
-set(TESTNAME "slavebridge.exe")
+set(TESTNAME "hostmemory.exe")
 
 if (WIN32)
   set(OpenCL_INCLUDE_DIR ${OCL_ROOT}/include)
@@ -15,7 +15,7 @@ endif(WIN32)
 
 include_directories(../../../src/include/1_2 ../../../src/runtime_src/core/include src/ ../common/includes/xcl2 ../common/includes/cmdparser ../common/includes/logger )
 add_executable(${TESTNAME} ../common/includes/xcl2/xcl2.cpp ../common/includes/cmdparser/cmdlineparser.cpp ../common/includes/logger/logger.cpp src/host.cpp)
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} )

--- a/tests/validate/slavebridge_test/src/host.cpp
+++ b/tests/validate/slavebridge_test/src/host.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     std::string dev_id = "0";
     std::string test_path;
     std::string iter_cnt = "10000";
-    std::string b_file = "/slavebridge.xclbin";
+    std::string b_file = "/hostmemory.xclbin";
     bool flag_s = false;
 
     for (int i = 1; i < argc; i++) {
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
 
     cl_int err;
     cl::Context context;
-    std::string krnl_name = "slavebridge";
+    std::string krnl_name = "hostmemory";
     std::vector<cl::Kernel> krnls(NUM_KERNEL);
     cl::CommandQueue q;
 
@@ -124,15 +124,6 @@ int main(int argc, char** argv) {
         device = xcl::find_device_bdf(devices, dev_id);
     }
 
-    auto device_name = device.getInfo<CL_DEVICE_NAME>();
-    if (xcl::is_hw_emulation()) {
-        if (device_name.find("202010") != std::string::npos) {
-            std::cout << "[INFO]: The example is not supported for " << device_name
-                      << " for hw_emu. Please try other flows." << '\n';
-            return EXIT_SUCCESS;
-        }
-    }
-
     // Creating Context and Command Queue for selected Device
     OCL_CHECK(err, context = cl::Context(device, nullptr, nullptr, nullptr, &err));
     OCL_CHECK(err, q = cl::CommandQueue(context, device,
@@ -145,9 +136,7 @@ int main(int argc, char** argv) {
         std::cout << "Device program successful!\n";
         for (int i = 0; i < NUM_KERNEL; i++) {
             std::string cu_id = std::to_string(i + 1);
-            std::string krnl_name_full = krnl_name + ":{" + "slavebridge_" + cu_id + "}";
-
-            printf("Creating a kernel [%s] for CU(%d)\n", krnl_name_full.c_str(), i + 1);
+            std::string krnl_name_full = krnl_name + ":{" + "hostmemory_" + cu_id + "}";
 
             // Here Kernel object is created by specifying kernel name along with
             // compute unit.
@@ -242,8 +231,8 @@ int main(int argc, char** argv) {
         for (int i = 0; i < NUM_KERNEL; i++) {
             for (uint32_t j = 0; j < DATA_SIZE; j++) {
                 if (map_output_buffer[i][j] != map_input_buffer[i][j]) {
-                    printf("ERROR : kernel failed to copy entry %i input %i output %i\n", j, map_input_buffer[i][j],
-                           map_output_buffer[i][j]);
+                    std::cout << "ERROR : kernel failed to copy entry " << j << " input " << map_input_buffer[i][j]
+                              << " output " << map_output_buffer[i][j] << std::endl;
                     return EXIT_FAILURE;
                 }
             }
@@ -264,7 +253,7 @@ int main(int argc, char** argv) {
 
         if (mbpersec > max_throughput) max_throughput = mbpersec;
     }
-    std::cout << "Maximum throughput: " << max_throughput << "MB/s\n";
+    std::cout << "Throughput: " << max_throughput << "MB/s\n";
 
     std::cout << "TEST PASSED\n";
 

--- a/tests/validate/slavebridge_test/src/host.cpp
+++ b/tests/validate/slavebridge_test/src/host.cpp
@@ -33,6 +33,7 @@ int main(int argc, char** argv) {
     std::string test_path;
     std::string iter_cnt = "10000";
     std::string b_file = "/hostmemory.xclbin";
+    std::string old_b_file = "/slavebridge.xclbin";
     bool flag_s = false;
 
     for (int i = 1; i < argc; i++) {
@@ -53,30 +54,35 @@ int main(int argc, char** argv) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
+    std::string binary_file = test_path + b_file;
+    std::ifstream infile(binary_file);
+    // This is for backward compatibility support when older platforms still having slavebridge.xclbin.
+    std::string old_binary_file = test_path + old_b_file;
+    std::ifstream old_infile(old_binary_file);
     if (flag_s) {
-        std::string binaryFile = test_path + b_file;
-        std::ifstream infile(binaryFile);
         if (!infile.good()) {
-            std::cout << "\nNOT SUPPORTED" << std::endl;
-            return EOPNOTSUPP;
+            if (!old_infile.good()) {
+                std::cout << "\nNOT SUPPORTED" << std::endl;
+                return EOPNOTSUPP;
+            } else {
+                std::cout << "\nSUPPORTED" << std::endl;
+                return EXIT_SUCCESS;
+            }
         } else {
             std::cout << "\nSUPPORTED" << std::endl;
             return EXIT_SUCCESS;
         }
     }
 
-    int NUM_KERNEL;
+    int num_kernel;
     std::string filename = "/platform.json";
     std::string platform_json = test_path + filename;
 
     try {
-        boost::property_tree::ptree loadPtreeRoot;
-        boost::property_tree::read_json(platform_json, loadPtreeRoot);
-        boost::property_tree::ptree temp;
-
-        temp = loadPtreeRoot.get_child("total_host_banks");
-        NUM_KERNEL = temp.get_value<int>();
-
+        boost::property_tree::ptree load_ptree_root;
+        boost::property_tree::read_json(platform_json, load_ptree_root);
+        auto temp = load_ptree_root.get_child("total_host_banks");
+        num_kernel = temp.get_value<int>();
     } catch (const std::exception& e) {
         std::string msg("ERROR: Bad JSON format detected while marshaling build metadata (");
         msg += e.what();
@@ -84,27 +90,37 @@ int main(int argc, char** argv) {
         std::cout << msg;
     }
 
-    std::string binaryFile = test_path + b_file;
-    std::ifstream infile(binaryFile);
     if (!infile.good()) {
-        std::cout << "\nNOT SUPPORTED" << std::endl;
-        return EOPNOTSUPP;
+        if (!old_infile.good()) {
+            std::cout << "\nNOT SUPPORTED" << std::endl;
+            return EOPNOTSUPP;
+        }
     }
 
     cl_int err;
     cl::Context context;
     std::string krnl_name = "hostmemory";
-    std::vector<cl::Kernel> krnls(NUM_KERNEL);
+    if (!infile.good()) {
+        krnl_name = "slavebridge";
+    }
+    std::vector<cl::Kernel> krnls(num_kernel);
     cl::CommandQueue q;
 
     // OPENCL HOST CODE AREA START
     // get_xil_devices() is a utility API which will find the xilinx
     // platforms and will return list of devices connected to Xilinx platform
     auto devices = xcl::get_xil_devices();
-    // read_binary_file() is a utility API which will load the binaryFile
+    // read_binary_file() is a utility API which will load the binary_file
     // and will return the pointer to file buffer.
-    auto fileBuf = xcl::read_binary_file(binaryFile);
-    cl::Program::Binaries bins{{fileBuf.data(), fileBuf.size()}};
+    std::vector<unsigned char> file_buf;
+
+    // Backward compatability support if platform had older xclbin
+    if (infile.good()) {
+        file_buf = xcl::read_binary_file(binary_file);
+    } else {
+        file_buf = xcl::read_binary_file(old_binary_file);
+    }
+    cl::Program::Binaries bins{{file_buf.data(), file_buf.size()}};
 
     auto pos = dev_id.find(":");
     cl::Device device;
@@ -134,9 +150,14 @@ int main(int argc, char** argv) {
         std::cout << "Failed to program device with xclbin file!\n";
     } else {
         std::cout << "Device program successful!\n";
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             std::string cu_id = std::to_string(i + 1);
-            std::string krnl_name_full = krnl_name + ":{" + "hostmemory_" + cu_id + "}";
+            std::string krnl_name_full;
+            if (infile.good()) {
+                krnl_name_full = krnl_name + ":{" + "hostmemory_" + cu_id + "}";
+            } else {
+                krnl_name_full = krnl_name + ":{" + "slavebridge_" + cu_id + "}";
+            }
 
             // Here Kernel object is created by specifying kernel name along with
             // compute unit.
@@ -151,26 +172,28 @@ int main(int argc, char** argv) {
     int reps = stoi(iter_cnt);
 
     for (uint32_t i = 4 * 1024; i <= 16 * 1024 * 1024; i *= 2) {
-        unsigned int DATA_SIZE = i;
+        unsigned int data_size = i;
 
         if (xcl::is_emulation()) {
             reps = 2;
-            if (DATA_SIZE > 8 * 1024) break;
+            if (data_size > 8 * 1024) {
+                break;
+            }
         }
 
-        unsigned int vector_size_bytes = DATA_SIZE;
-        std::vector<unsigned char, aligned_allocator<unsigned char> > input_host(DATA_SIZE);
+        unsigned int vector_size_bytes = data_size;
+        std::vector<unsigned char, aligned_allocator<unsigned char> > input_host(data_size);
 
-        for (uint32_t j = 0; j < DATA_SIZE; j++) {
+        for (uint32_t j = 0; j < data_size; j++) {
             input_host[j] = j % 256;
         }
 
-        std::vector<cl::Buffer> input_buffer(NUM_KERNEL);
-        std::vector<cl::Buffer> output_buffer(NUM_KERNEL);
+        std::vector<cl::Buffer> input_buffer(num_kernel);
+        std::vector<cl::Buffer> output_buffer(num_kernel);
 
-        std::vector<cl_mem_ext_ptr_t> input_buffer_ext(NUM_KERNEL);
-        std::vector<cl_mem_ext_ptr_t> output_buffer_ext(NUM_KERNEL);
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        std::vector<cl_mem_ext_ptr_t> input_buffer_ext(num_kernel);
+        std::vector<cl_mem_ext_ptr_t> output_buffer_ext(num_kernel);
+        for (int i = 0; i < num_kernel; i++) {
             input_buffer_ext[i].flags = XCL_MEM_EXT_HOST_ONLY;
             input_buffer_ext[i].obj = nullptr;
             input_buffer_ext[i].param = 0;
@@ -180,24 +203,24 @@ int main(int argc, char** argv) {
             output_buffer_ext[i].param = 0;
         }
 
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             OCL_CHECK(err, input_buffer[i] = cl::Buffer(context, CL_MEM_READ_WRITE | CL_MEM_EXT_PTR_XILINX,
                                                         vector_size_bytes, &input_buffer_ext[i], &err));
             OCL_CHECK(err, output_buffer[i] = cl::Buffer(context, CL_MEM_READ_WRITE | CL_MEM_EXT_PTR_XILINX,
                                                          vector_size_bytes, &output_buffer_ext[i], &err));
         }
 
-        unsigned char* map_input_buffer[NUM_KERNEL];
-        unsigned char* map_output_buffer[NUM_KERNEL];
+        unsigned char* map_input_buffer[num_kernel];
+        unsigned char* map_output_buffer[num_kernel];
 
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             OCL_CHECK(err, err = krnls[i].setArg(0, input_buffer[i]));
             OCL_CHECK(err, err = krnls[i].setArg(1, output_buffer[i]));
-            OCL_CHECK(err, err = krnls[i].setArg(2, DATA_SIZE));
+            OCL_CHECK(err, err = krnls[i].setArg(2, data_size));
             OCL_CHECK(err, err = krnls[i].setArg(3, reps));
         }
 
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             OCL_CHECK(err,
                       map_input_buffer[i] = (unsigned char*)q.enqueueMapBuffer(
                           (input_buffer[i]), CL_FALSE, CL_MAP_WRITE, 0, vector_size_bytes, nullptr, nullptr, &err));
@@ -205,22 +228,20 @@ int main(int argc, char** argv) {
         }
 
         /* prepare data to be written to the device */
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             for (size_t j = 0; j < vector_size_bytes; j++) {
                 map_input_buffer[i][j] = input_host[j];
             }
         }
-        std::chrono::high_resolution_clock::time_point timeStart;
-        std::chrono::high_resolution_clock::time_point timeEnd;
 
-        timeStart = std::chrono::high_resolution_clock::now();
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        auto time_start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < num_kernel; i++) {
             OCL_CHECK(err, err = q.enqueueTask(krnls[i]));
         }
         q.finish();
-        timeEnd = std::chrono::high_resolution_clock::now();
+        auto time_end = std::chrono::high_resolution_clock::now();
 
-        for (int i = 0; i < NUM_KERNEL; i++) {
+        for (int i = 0; i < num_kernel; i++) {
             OCL_CHECK(err,
                       map_output_buffer[i] = (unsigned char*)q.enqueueMapBuffer(
                           (output_buffer[i]), CL_FALSE, CL_MAP_READ, 0, vector_size_bytes, nullptr, nullptr, &err));
@@ -228,8 +249,8 @@ int main(int argc, char** argv) {
         }
 
         // check
-        for (int i = 0; i < NUM_KERNEL; i++) {
-            for (uint32_t j = 0; j < DATA_SIZE; j++) {
+        for (int i = 0; i < num_kernel; i++) {
+            for (uint32_t j = 0; j < data_size; j++) {
                 if (map_output_buffer[i][j] != map_input_buffer[i][j]) {
                     std::cout << "ERROR : kernel failed to copy entry " << j << " input " << map_input_buffer[i][j]
                               << " output " << map_output_buffer[i][j] << std::endl;
@@ -238,22 +259,16 @@ int main(int argc, char** argv) {
             }
         }
 
-        double usduration;
-        double dnsduration;
-        double dsduration;
-        double bpersec;
-        double mbpersec;
-
-        usduration = (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(timeEnd - timeStart).count() / reps);
-
-        dnsduration = (double)usduration;
-        dsduration = dnsduration / ((double)1000000000);
-        bpersec = (DATA_SIZE * NUM_KERNEL) / dsduration;
-        mbpersec = (2 * bpersec) / ((double)1024 * 1024); // For concurrent Read/Write
+        double usduration =
+            (double)(std::chrono::duration_cast<std::chrono::nanoseconds>(time_end - time_start).count() / reps);
+        double dnsduration = (double)usduration;
+        double dsduration = dnsduration / ((double)1000000000);
+        double bpersec = (data_size * num_kernel) / dsduration;
+        double mbpersec = (2 * bpersec) / ((double)1024 * 1024); // For concurrent Read/Write
 
         if (mbpersec > max_throughput) max_throughput = mbpersec;
     }
-    std::cout << "Throughput: " << max_throughput << "MB/s\n";
+    std::cout << "Throughput (Type: HOST) (Bank count: " << num_kernel << "): " << max_throughput << "MB/s\n";
 
     std::cout << "TEST PASSED\n";
 

--- a/tests/validate/verify_test/CMakeLists.txt
+++ b/tests/validate/verify_test/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(${TESTNAME}
   ../common/includes/logger/logger.cpp src/host.cpp
   )
 
-target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
+target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread ${OpenCL_LIBRARY} )

--- a/tests/validate/verify_test/src/host.cpp
+++ b/tests/validate/verify_test/src/host.cpp
@@ -14,6 +14,7 @@
 * under the License.
 */
 #include "xcl2.hpp"
+#include <boost/filesystem.hpp>
 #include <algorithm>
 #include <vector>
 #define LENGTH 64
@@ -48,9 +49,9 @@ int main(int argc, char** argv) {
         std::cout << "ERROR : please provide the platform test path to -p option\n";
         return EXIT_FAILURE;
     }
+    auto binaryFile = boost::filesystem::path(test_path) / b_file;
+    std::ifstream infile(binaryFile.string());
     if (flag_s) {
-        std::string binaryFile = test_path + b_file;
-        std::ifstream infile(binaryFile);
         if (!infile.good()) {
             std::cout << "\nNOT SUPPORTED" << std::endl;
             return EOPNOTSUPP;
@@ -60,8 +61,6 @@ int main(int argc, char** argv) {
         }
     }
 
-    std::string binaryFile = test_path + b_file;
-    std::ifstream infile(binaryFile);
     if (!infile.good()) {
         std::cout << "\nNOT SUPPORTED" << std::endl;
         return EOPNOTSUPP;
@@ -94,7 +93,7 @@ int main(int argc, char** argv) {
 
     // read_binary_file() is a utility API which will load the binaryFile
     // and will return the pointer to file buffer.
-    auto fileBuf = xcl::read_binary_file(binaryFile);
+    auto fileBuf = xcl::read_binary_file(binaryFile.string());
     cl::Program::Binaries bins{{fileBuf.data(), fileBuf.size()}};
 
     auto pos = dev_id.find(":");


### PR DESCRIPTION
https://jira.xilinx.com/browse/CR-1088690

Validate designs updated to report memory type while reporting throughput.

1. bandwidth_test
**For DDR memory :** 
Throughput (Type: DDR) (Bank count: 4): 52265 MB/s
**For HBM memory :** 
Throughput (Type: HBM) (Bank count: 1): 15328 MB/s
**For DDR and HBM memory :** 
Throughput (Type: DDR) (Bank count: 2): 29265 MB/s
Throughput (Type: HBM) (Bank count: 1): 15328 MB/s 
2. hostmemory_test:
**For HOST memory :** 
Throughput (Type: HOST) (Bank count: 1): 15328 MB/s

@AShivangi Please update the xbutil flow search string to pick the throughput numbers.