### PR TITLE
CR-1111608: Fixing dfx issues on VCK190 DFx platform

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -318,6 +318,9 @@ done:
 void
 zocl_destroy_aie(struct drm_zocl_dev *zdev)
 {
+	if (!zdev->aie_information)
+		return;
+
 	vfree(zdev->aie_information);
 	mutex_lock(&zdev->aie_lock);
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -843,14 +843,12 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			 /*
 			  * cleanup previously loaded xclbin related data
 			  * before loading new bitstream/pdi
-			  * */
+			  */
 			if (kds_mode == 1 && (zocl_xclbin_get_uuid(zdev) != NULL)) {
 				subdev_destroy_cu(zdev);
 				if (zdev->aie) {
 					zocl_aie_reset(zdev);
-					mutex_lock(&zdev->aie_lock);
-					zdev->aie->aie_reset = false;
-					mutex_unlock(&zdev->aie_lock);
+					zocl_destroy_aie(zdev);
 				}
 			}
 			/*

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -840,6 +840,19 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			DRM_INFO("disable partial bitstream download, "
 			    "axlf flags is %d", axlf_obj->za_flags);
 		} else {
+			 /*
+			  * cleanup previously loaded xclbin related data
+			  * before loading new bitstream/pdi
+			  * */
+			if (kds_mode == 1 && (zocl_xclbin_get_uuid(zdev) != NULL)) {
+				subdev_destroy_cu(zdev);
+				if (zdev->aie) {
+					zocl_aie_reset(zdev);
+					mutex_lock(&zdev->aie_lock);
+					zdev->aie->aie_reset = false;
+					mutex_unlock(&zdev->aie_lock);
+				}
+			}
 			/*
 			 * Make sure we load PL bitstream first,
 			 * if there is one, before loading AIE PDI.
@@ -989,7 +1002,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 		 */
 		write_unlock(&zdev->attr_rwlock);
 
-		subdev_destroy_cu(zdev);
 		ret = zocl_create_cu(zdev);
 		if (ret) {
 			write_lock(&zdev->attr_rwlock);

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -93,6 +93,12 @@ graph_type::
 {
 #ifndef __AIESIM__
     auto drv = ZYNQ::shim::handleCheck(device->get_device_handle());
+    if (!drv || !drv->getAied()) {
+	std::stringstream warnMsg;
+	warnMsg << "There is no active device open. Unable to close Graph `" << name << "`";
+	xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", warnMsg.str());
+	return;
+    }
     drv->closeGraphContext(id);
     drv->getAied()->deregisterGraph(this);
 #endif


### PR DESCRIPTION
CR Number
CR-1111608 :On vck190 dfx platform, depending on the AIE xclbin packaging order, using multiple AIE xclbin files causes kernel panic

Issues
- Previously loaded xclbin related stuff is not getting cleaned up when we are downloading new xclbin. 
- We are accessing old IPs after loading new xclbin which is causing a crash
- Graph reset is not being called

Solution
Cleanup previously loaded xclbin stuff.