### PR TITLE
CR-1052320 XRT - installed and running CMC version is not printed out

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -140,10 +140,12 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
     std::stringstream version;
     
     try {
-       version << "0x" << std::hex << std::stoi(xrt_core::device_query<xq::xmc_version>(device));
+       version << std::hex << std::stoi(xrt_core::device_query<xq::xmc_version>(device));
     }
     catch (...) {}
-    cmc.add("version", version.str());
+
+    std::string version_str = convert_version(version);
+    cmc.add("version", version_str);
     cmc.add("serial_number", xrt_core::device_query<xq::xmc_serial_num>(device));
     cmc.add("oem_id", xq::oem_id::parse(xrt_core::device_query<xq::oem_id>(device)));
     controller.put_child("satellite_controller", sc);

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -26,6 +26,32 @@
 #include <limits>
 #include <boost/algorithm/string.hpp>
 
+std::string convert_version(std::stringstream& version)
+{
+
+  std::string byte ;
+  int VER[10]   = {0};
+  int i =0;
+
+  version.seekg (0, version.end);
+  int len = version.tellg();
+
+  while( i  < 3){
+  len = len -2;
+    if (len < 0){
+      version.seekg(0);
+      version >> std::setw(1) >>byte;
+    }
+    else {
+      version.seekg(len);
+      version >> std::setw(2) >>byte;
+    }
+      VER[i++] = std::stoi(byte,nullptr,16);
+  }
+  auto fmt  = boost::format("%d.%d.%d") % VER[2]  % VER[1] % VER[0];
+  return fmt.str();
+}
+
 namespace {
 
 inline unsigned int
@@ -41,8 +67,6 @@ precision(double value, int p)
   stream << std::fixed << std::setprecision(p) << value;
   return stream.str();
 }
-
-
 
 }
 

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -34,7 +34,10 @@
 #define CU_AP_CONTINUE	(0x1 << 4)
 #define CU_AP_RESET	(0x1 << 5)
 
+std::string convert_version(std::stringstream& version);
+
 namespace xrt_core { namespace utils {
+
 
 /**
  * ios_flags_restore() - scope guard for ios flags


### PR DESCRIPTION
"platforms": [
                {
                    "static_region": {
                        "vbnv": "xilinx_u200_xdma_201830_2",
                        "logic_uuid": "0x5d1211e8",
                        "jtag_idcode": "0x14b37093",
                        "fpga_name": "xcu200-fsgd2104-2-e"
                    },
                    "off_chip_board_info": {
                        "ddr_size_bytes": "68719476736",
                        "ddr_count": "4"
                    },
                    "status": {
                        "mig_calibrated": "true",
                        "p2p_status": "disabled"
                    },
                    "controller": {
                        "satellite_controller": {
                            "version": "4.2.0",
                            "expected_version": "4.2.0"
                        },
                        "card_mgmt_controller": {
                            "version": "30.207.35",
                            "serial_number": "21290491E03K",
                            "oem_id": "N\/A"
                        }
                    },
