### PR TITLE
Hide doxygen for xrt::xclbin axlf specific APIs

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -597,6 +597,7 @@ public:
   uuid
   get_uuid() const;
 
+  /// @cond
   /**
    * get_axlf() - Get the axlf data of the xclbin
    *
@@ -630,6 +631,7 @@ public:
   {
     return reinterpret_cast<SectionType>(get_axlf_section(section).first);
   }
+  /// @endcond
 
 private:
   XCL_DRIVER_DLLESPEC


### PR DESCRIPTION
We are not documenting xclbin binary structure, so we should also
not document how users can access the axlf and specific sections.
The APIs are there for use if you know what you are doing.