### PR TITLE
CR-1110308 xmc: xbmgmt load-config passes true to xmc driver to enable clock scaling feature

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -2272,8 +2272,7 @@ static ssize_t scaling_enabled_store(struct device *dev,
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
 
-	if ((strncmp(buf, "enable", strlen("enable")) == 0) ||
-	   (strncmp(buf, "true", strlen("true")) == 0))
+	if (strncmp(buf, "true", strlen("true")) == 0)
 		runtime_clk_scale_enable(xmc);
 	else
 		runtime_clk_scale_disable(xmc);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: chienwei@xilinx.com
  *
@@ -2272,7 +2272,8 @@ static ssize_t scaling_enabled_store(struct device *dev,
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
 
-	if (strncmp(buf, "enable", strlen("enable")) == 0)
+	if ((strncmp(buf, "enable", strlen("enable")) == 0) ||
+	   (strncmp(buf, "true", strlen("true")) == 0))
 		runtime_clk_scale_enable(xmc);
 	else
 		runtime_clk_scale_disable(xmc);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -2139,7 +2139,8 @@ static ssize_t scaling_enabled_store(struct device *dev,
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
 
-	if (strncmp(buf, "enable", strlen("enable")) == 0)
+	if ((strncmp(buf, "enable", strlen("enable")) == 0) ||
+	   (strncmp(buf, "true", strlen("true")) == 0))
 		runtime_clk_scale_enable(xmc);
 	else
 		runtime_clk_scale_disable(xmc);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -2139,8 +2139,7 @@ static ssize_t scaling_enabled_store(struct device *dev,
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
 
-	if ((strncmp(buf, "enable", strlen("enable")) == 0) ||
-	   (strncmp(buf, "true", strlen("true")) == 0))
+	if (strncmp(buf, "true", strlen("true")) == 0)
 		runtime_clk_scale_enable(xmc);
 	else
 		runtime_clk_scale_disable(xmc);


### PR DESCRIPTION
Runtime clock scaling feature is one of the device configs and corresponding driver expects enable/disable string to enable/disable this feature through xbmgmt commands. But, new xbmgmt dumps device configs in true/false onto .ini file.
So, just aligning with this new tool, modified xmc driver to accept true/false instead of enable/disable.
xbmgmt legacy commands also works well with true/false.

Legacy (old) commands: to enable/disable Runtime clock scaling feature.
xbmgmt --legacy config --device --card 62:00.0 --runtime_clk_scale true
xbmgmt --legacy config --device --card 62:00.0 --runtime_clk_scale false
xbmgmt --legacy config --device --card 62:00.0 --runtime_clk_scale enable
xbmgmt --legacy config --device --card 62:00.0 --runtime_clk_scale disable

New commands: modify .ini file to enable/disable Runtime clock scaling feature.
scaling_enabled=true
scaling_enabled=false
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>