### PR TITLE
CR-1110308 xmc: xbmgmt load-config passes true to xmc driver to enable clock scaling feature (#5830)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2020 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
  *
  * Authors: chienwei@xilinx.com
  *
@@ -2272,7 +2272,7 @@ static ssize_t scaling_enabled_store(struct device *dev,
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
 
-	if (strncmp(buf, "enable", strlen("enable")) == 0)
+	if (strncmp(buf, "true", strlen("true")) == 0)
 		runtime_clk_scale_enable(xmc);
 	else
 		runtime_clk_scale_disable(xmc);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -2139,7 +2139,7 @@ static ssize_t scaling_enabled_store(struct device *dev,
 {
 	struct xocl_xmc *xmc = platform_get_drvdata(to_platform_device(dev));
 
-	if (strncmp(buf, "enable", strlen("enable")) == 0)
+	if (strncmp(buf, "true", strlen("true")) == 0)
 		runtime_clk_scale_enable(xmc);
 	else
 		runtime_clk_scale_disable(xmc);


### PR DESCRIPTION

* CR-1110308 xmc: load-config pass true to enable clock scaling feature

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

* fix review comments

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>