### PR TITLE
CR-1111463: xbutil examine is slow when device is not ready: Merge pull request #5832 from chvamshi-xilinx/xbutil_slow

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -999,6 +999,15 @@ void shim::xclSysfsGetDeviceInfo(xclDeviceInfo2 *info)
     info->mNumClocks = numClocks(info->mName);
 
     mDev->sysfs_get<unsigned short>("mb_scheduler", "kds_numcdmas", errmsg, info->mNumCDMA, static_cast<unsigned short>(-1));
+    
+    mDev->sysfs_get("", "link_width", errmsg, info->mPCIeLinkWidth, static_cast<unsigned short>(-1));
+    mDev->sysfs_get("", "link_speed", errmsg, info->mPCIeLinkSpeed, static_cast<unsigned short>(-1));
+    mDev->sysfs_get("", "link_speed_max", errmsg, info->mPCIeLinkSpeedMax, static_cast<unsigned short>(-1));
+    mDev->sysfs_get("", "link_width_max", errmsg, info->mPCIeLinkWidthMax, static_cast<unsigned short>(-1));
+    
+    //dont try to get any information which needs mailbox communication when device is not ready.
+    if(!mDev->is_mgmt() && !mDev->is_ready)
+        return;
 
     //get sensors
     unsigned int m12VPex, m12VAux, mPexCurr, mAuxCurr, mDimmTemp_0, mDimmTemp_1, mDimmTemp_2,
@@ -1062,10 +1071,6 @@ void shim::xclSysfsGetDeviceInfo(xclDeviceInfo2 *info)
 
     //get sensors end
 
-    mDev->sysfs_get("", "link_width", errmsg, info->mPCIeLinkWidth, static_cast<unsigned short>(-1));
-    mDev->sysfs_get("", "link_speed", errmsg, info->mPCIeLinkSpeed, static_cast<unsigned short>(-1));
-    mDev->sysfs_get("", "link_speed_max", errmsg, info->mPCIeLinkSpeedMax, static_cast<unsigned short>(-1));
-    mDev->sysfs_get("", "link_width_max", errmsg, info->mPCIeLinkWidthMax, static_cast<unsigned short>(-1));
     mDev->sysfs_get("", "mig_calibration", errmsg, info->mMigCalib, false);
     std::vector<uint64_t> freqs;
     mDev->sysfs_get("icap", "clock_freqs", errmsg, freqs);


### PR DESCRIPTION
CR-1111463: xbutil examine is slow when device is not ready
(cherry picked from commit a75bcd2b8e872e9ace794c22d30964bfdb6bb749)

**Root cause:**
Xbutil examine is trying to get the sensor information in xclOpen. We shouldn't try to get any information which requires mailbox communication when device is not ready. Each request takes some time to timeout.

**Fix:**
Don't read sensors information if device is not in ready state

**Reviewers:**
Max/Shivangi/Stephen