### PR TITLE
ert polling mode cleanup

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_ert.h
+++ b/src/runtime_src/core/common/drv/include/xrt_ert.h
@@ -55,7 +55,7 @@ struct xrt_ert_queue_funcs {
 
 	int (*submit)(struct xrt_ert_command *ecmd, void *queue_handle);
 
-	int  (*queue_config)(uint32_t slot_size, void *ert_handle, void *queue_handle);
+	int  (*queue_config)(uint32_t slot_size, bool polling, void *ert_handle, void *queue_handle);
 
 	uint32_t (*max_slot_num)(void *queue_handle);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
@@ -293,20 +293,15 @@ command_queue_complete(struct xrt_ert_command *ecmd, void *queue_handle)
 	ecmd->cb.complete(ecmd, cmd_queue->ert_handle);
 }
 
-static void
-command_queue_poll(void *queue_handle)
+static inline void
+command_queue_check_csr(struct command_queue *cmd_queue)
 {
-	struct command_queue *cmd_queue = (struct command_queue *)queue_handle;
-	xdev_handle_t xdev = xocl_get_xdev(cmd_queue->pdev);
-	struct xrt_ert_command *ecmd = NULL, *next = NULL;
 	u32 mask = 0;
 	u32 slot_idx = 0, section_idx = 0;
+	struct xrt_ert_command *ecmd = NULL;
+	xdev_handle_t xdev = xocl_get_xdev(cmd_queue->pdev);
 
-	if (!cmd_queue->sq_num)
-		return;
-
-	CMDQUEUE_DBG(cmd_queue, "cmd_queue->sq_num %d\n", cmd_queue->sq_num);
-
+	CMDQUEUE_INFO(cmd_queue, "minm cmd_queue->polling_mode %d\n", cmd_queue->polling_mode);
 	for (section_idx = 0; section_idx < 4; ++section_idx) {
 		mask = xocl_intc_ert_read32(xdev, (section_idx<<2));
 		if (!mask)
@@ -317,17 +312,34 @@ command_queue_poll(void *queue_handle)
 
 			if (!mask)
 				break;
-			if (mask & 0x1) {
-				ecmd = cmd_queue->submit_queue[cmd_idx];
-				if (ecmd) {
-					CMDQUEUE_DBG(cmd_queue, "%s -> ecmd %llx\n", __func__, (u64)ecmd);
-					ecmd->complete_entry.cstate = KDS_COMPLETED;
-					ecmd->cb.notify(cmd_queue->ert_handle);
-				} else
-					CMDQUEUE_DBG(cmd_queue, "ERR: submit queue slot is empty\n");
+			if (mask & 0x1 != 0x1)
+				continue;
+			ecmd = cmd_queue->submit_queue[cmd_idx];
+			if (!ecmd) {
+				CMDQUEUE_DBG(cmd_queue, "ERR: submit queue slot is empty\n");
+				continue;
 			}
+
+			CMDQUEUE_DBG(cmd_queue, "%s -> ecmd %llx\n", __func__, (u64)ecmd);
+			ecmd->complete_entry.cstate = KDS_COMPLETED;
+			ecmd->cb.notify(cmd_queue->ert_handle);
 		}
 	}
+}
+
+static void
+command_queue_poll(void *queue_handle)
+{
+	struct command_queue *cmd_queue = (struct command_queue *)queue_handle;
+	struct xrt_ert_command *ecmd = NULL, *next = NULL;
+
+	if (!cmd_queue->sq_num)
+		return;
+
+	CMDQUEUE_DBG(cmd_queue, "cmd_queue->sq_num %d\n", cmd_queue->sq_num);
+
+	if (cmd_queue->polling_mode)
+		command_queue_check_csr(cmd_queue);
 
 	/* check the completed command in submit queue */
 	list_for_each_entry_safe(ecmd, next, &cmd_queue->sq, list) {
@@ -513,7 +525,7 @@ cmd_queue_isr(int irq, void *arg)
 }
 
 static int
-command_queue_config(uint32_t slot_size, void *ert_handle, void *queue_handle)
+command_queue_config(uint32_t slot_size, bool polling_mode, void *ert_handle, void *queue_handle)
 {
 	struct command_queue *cmd_queue = (struct command_queue *)queue_handle;
 
@@ -539,6 +551,7 @@ command_queue_config(uint32_t slot_size, void *ert_handle, void *queue_handle)
 
 	cmd_queue->num_slots = cmd_queue->cq_range / slot_size;
 	cmd_queue->slot_size = slot_size;
+	cmd_queue->polling_mode = polling_mode;
 
 	cmd_queue_reset(cmd_queue);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -400,14 +400,14 @@ ert_queue_intc_config(struct xocl_ert_user *ert_user, bool enable)
 }
 
 static inline int
-ert_config_queue(struct xocl_ert_user *ert_user, uint32_t slot_size)
+ert_config_queue(struct xocl_ert_user *ert_user, uint32_t slot_size, bool polling)
 {
 	struct ert_queue *queue = ert_user->queue;
 
 	if (!queue)
 		return -ENODEV;
 
-	return queue->func->queue_config(slot_size, ert_user, queue->handle);
+	return queue->func->queue_config(slot_size, polling, ert_user, queue->handle);
 }
 
 static inline uint32_t
@@ -782,7 +782,7 @@ ert_cfg_host(struct xocl_ert_user *ert_user, struct xrt_ert_command *ecmd)
 
 	BUG_ON(cmd_opcode(ecmd) != ERT_CONFIGURE);
 
-	ret = ert_config_queue(ert_user, cfg->slot_size);
+	ret = ert_config_queue(ert_user, cfg->slot_size, cfg->polling);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
Even in ERT interrupt mode, the command queue subdev will read CSR registers to get the completed command. This is redundant. Since when interrupt occurs, intc subdev will read CSR register and let command queue know which slot has interrupted.

I aware of that struct command_queue has defined polling_mode but it is not used. This change will update polling mode flag when configure command queue. Only read CRS register when polling mode is true.

In my test, this change helps to improve performance on u200 201820_2 card, which is using legacy ERT subsystem.
Before:
$/opt/xilinx/xrt/test/xcl_iops_test.exe -k /opt/xilinx/dsa/xilinx_u200_xdma_201830_2/test/verify.xclbin -d 0000:05:00.1
Overall Commands:  100000 **IOPS: 99897 (hello)**
TEST PASSED

After:
$/opt/xilinx/xrt/test/xcl_iops_test.exe -k /opt/xilinx/dsa/xilinx_u200_xdma_201830_2/test/verify.xclbin -d 0000:05:00.1
Overall Commands:  100000 **IOPS: 104482 (hello)**
TEST PASSED

On u50 nodma shell with ERT ssv3. The iops test result has no change.