### PR TITLE
CR 1111369 - xbutil2 examine command should be ok without "-d" option

### DIFF
--- a/src/runtime_src/core/tools/common/XBMain.cpp
+++ b/src/runtime_src/core/tools/common/XBMain.cpp
@@ -149,6 +149,17 @@ void  main_(int argc, char** argv,
   if (bHelp == true) 
     opts.push_back("--help");
 
+  #ifdef ENABLE_DEFAULT_ONE_DEVICE_OPTION
+  // If the user has NOT specified a device AND the command to be executed
+  // is not the examine command, then automatically add the device.
+  // Note: "examine" produces different reports depending if the user has
+  //       specified the --device option or not.
+  if ( sDevice.empty() &&
+       (subCommand->getName() != "examine")) {
+    sDevice = "default";
+  }
+  #endif
+
 
   // Was default device requested?
   if (boost::iequals(sDevice, "default")) {

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(${XBMGMT2_NAME} ${XBMGMT_V2_SRCS})
 # Determine what functionality should be added
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   target_compile_definitions(${XBMGMT2_NAME} PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
+else()
+  target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
 endif()
 
 # Static build is a Linux / Ubuntu option only

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -48,6 +48,9 @@ add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
 # Determine what functionality should be added
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
+  target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
+else()
+  target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
 endif()
 
 # Static build is a Linux / Ubuntu option only

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -48,7 +48,6 @@ add_executable(${XBUTIL2_NAME} ${XBUTIL_V2_SRCS})
 # Determine what functionality should be added
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_NATIVE_SUBCMDS_AND_REPORTS)
-  target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
 else()
   target_compile_definitions(${XBUTIL2_NAME} PRIVATE ENABLE_DEFAULT_ONE_DEVICE_OPTION)
 endif()


### PR DESCRIPTION
Work Done
----------
+ Creat a new CMake variable to enable / disable implied -d option.
+ For non-native builds, enabled (e.g. defined ENABLE_DEFAULT_ONE_DEVICE_OPTION) the CMake variable
+ Updated XBMain to enable / disable the implied -d option for all commands except for "examine".  Note: The "examine" command produces different reports depending on if the --device option was used.