### PR TITLE
CR-1109197 XRT C++ API - Node name is empty for xrt::info::device::platform

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -226,6 +226,7 @@ void
 add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
 {
   ptree_type pt_platform;
+  ptree_type pt_platforms;
 
   add_static_region_info(device, pt_platform);
   add_board_info(device, pt_platform);
@@ -234,7 +235,8 @@ add_platform_info(const xrt_core::device* device, ptree_type& pt_platform_array)
   add_clock_info(device, pt_platform);
   add_mac_info(device, pt_platform);
 
-  pt_platform_array.push_back(std::make_pair("", pt_platform));
+  pt_platforms.push_back(std::make_pair("", pt_platform));
+  pt_platform_array.add_child("platforms", pt_platforms);
 }
 
 } //unnamed namespace

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -43,7 +43,7 @@ ReportPlatforms::getPropertyTree20202( const xrt_core::device * dev,
   boost::property_tree::read_json(ss, pt_platform);
  
   // There can only be 1 root node
-  pt.add_child("platforms", pt_platform);
+  pt = pt_platform;
 }
 
 void 


### PR DESCRIPTION
The PR which addressed this CR was reverted: https://github.com/Xilinx/XRT/pull/5721. Redoing these changes