### PR TITLE
CR-1112071 ASTeR TC7.08 - u55n/x3 - clock shutdown during xbtest causes "list_del corruption" server crash (#5852)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -142,6 +142,7 @@ struct xocl_ert_user {
 
 static void ert_submit_exit_cmd(struct xocl_ert_user *ert_user);
 static inline void ert_user_cmd_submit(struct xocl_ert_user *ert_user, struct xrt_ert_command *ecmd);
+static void free_ert_user_event(struct ert_user_event *event);
 
 static ssize_t clock_timestamp_show(struct device *dev,
 			   struct device_attribute *attr, char *buf)
@@ -1246,6 +1247,7 @@ static void xocl_ert_user_remove_event(struct xocl_ert_user *ert_user, struct er
 			continue;
 
 		list_del(&curr->ev_entry);
+		free_ert_user_event(curr);
 		break;
 	}
 
@@ -1389,6 +1391,7 @@ static bool xocl_ert_user_abort_done(struct kds_ert *ert, struct kds_client *cli
 			continue;
 
 		list_del(&curr->ev_entry);
+		free_ert_user_event(curr);
 		break;
 	}
 
@@ -1438,8 +1441,6 @@ add_event:
 	mutex_unlock(&ert_user->ev_lock);
 
 	wait_for_completion(&event->cmp);
-
-	free_ert_user_event(event);
 
 	return  ert_user->bad_state;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/firewall.c
@@ -656,7 +656,7 @@ static int firewall_remove(struct platform_device *pdev)
 	return 0;
 }
 
-static void get_fw_ep_name(char *res_name, char *result)
+static void get_fw_ep_name(const char *res_name, char *result)
 {
 	if (!strncmp(res_name, NODE_AF_CTRL_MGMT, strlen(NODE_AF_CTRL_MGMT)))
 		strcpy(result, "CTRL_MGMT");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -693,7 +693,7 @@ static ssize_t host_mem_size_show(struct device *dev,
 	if (xdev->cma_bank)
 		val = xdev->cma_bank->entry_sz * xdev->cma_bank->entry_num;
 
-	return sprintf(buf, "%d\n", val);
+	return sprintf(buf, "%lld\n", val);
 }
 static DEVICE_ATTR_RO(host_mem_size);
 


### PR DESCRIPTION
(cherry picked from commit 48626ff6d7c7d9e704955455a83b283e25c2ac64)