### PR TITLE
CR-1111986 ASTeR TC 22.07 - u55c/n + X3 - validate does not run the host memory test after it has been enabled

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -789,7 +789,7 @@ int xocl_cleanup_mem_nolock(struct xocl_drm *drm_p)
 				continue;
 
 			if (IS_HOST_MEM(topology->m_mem_data[i].m_tag))
-				xocl_addr_translator_disable_remap(drm_p->xdev);
+				xocl_addr_translator_clean(drm_p->xdev);
 
 			xocl_info(drm_p->ddev->dev, "Taking down DDR : %d", i);
 			addr = topology->m_mem_data[i].m_base_address;

--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -163,14 +163,20 @@ XBUtilities::runScript( const std::string & env,
   }
 
   is_done = true;
-  bool exitCode = (os_stdout.str().find("PASS") != std::string::npos) ? true : false;
-  run_test.get()->finish(exitCode, final_description);
+  bool passed = (os_stdout.str().find("PASS") != std::string::npos) ? true : false;
+  bool skipped = (os_stdout.str().find("EOPNOTSUPP") != std::string::npos) ? true : false;
+  run_test.get()->finish(passed, final_description);
   // Workaround: Clear the default progress bar output so as to print the Error: before printing [FAILED]
   // Remove this once busybar is implemented
   std::cout << EscapeCodes::cursor().prev_line() << EscapeCodes::cursor().clear_line();
   t.join();
 
-  return exitCode ? 0 : 1;
+  if (skipped)
+    return EOPNOTSUPP;
+  else if (passed)
+    return 0;
+  else
+    return 1;
 }
 #else
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1136,16 +1136,16 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  uint64_t host_mem_size = 0;
+  uint64_t enabled_host_mem = 0;
   try {
-    host_mem_size = xrt_core::device_query<xrt_core::query::host_mem_size>(_dev);
+    enabled_host_mem = xrt_core::device_query<xrt_core::query::enabled_host_mem>(_dev);
   } catch(...) {
     logger(_ptTest, "Details", "Address translator IP is not available");
     _ptTest.put("status", "skipped");
     return;
   }
 
-  if (!host_mem_size) {
+  if (!enabled_host_mem) {
       logger(_ptTest, "Details", "Host memory is not enabled");
       _ptTest.put("status", "skipped");
       return;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1136,16 +1136,16 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  uint64_t enabled_host_mem = 0;
+  uint64_t shared_host_mem = 0;
   try {
-    enabled_host_mem = xrt_core::device_query<xrt_core::query::enabled_host_mem>(_dev);
+    shared_host_mem = xrt_core::device_query<xrt_core::query::shared_host_mem>(_dev);
   } catch(...) {
     logger(_ptTest, "Details", "Address translator IP is not available");
     _ptTest.put("status", "skipped");
     return;
   }
 
-  if (!enabled_host_mem) {
+  if (!shared_host_mem) {
       logger(_ptTest, "Details", "Host memory is not enabled");
       _ptTest.put("status", "skipped");
       return;

--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -165,6 +165,7 @@ def main(args):
         assert (opt.first_mem >= 0), "Incorrect memory configuration"
 
         if (runKernel(opt) == errno.EOPNOTSUPP):
+            print("EOPNOTSUPP")
             sys.exit(errno.EOPNOTSUPP)
         print("PASSED TEST")
 

--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -21,6 +21,7 @@ import ctypes.util
 import sys
 import time
 import math
+import errno
 
 # Following found in PYTHONPATH setup by XRT
 from xrt_binding import *
@@ -77,7 +78,11 @@ def getInputOutputBuffer(devhdl, krnlhdl, argno, isInput):
     return bo, bobuf
 
 def runKernel(opt):
-    khandle3 = xrtPLKernelOpen(opt.handle, opt.xuuid, "bandwidth3")
+    try:
+        khandle3 = xrtPLKernelOpen(opt.handle, opt.xuuid, "bandwidth3")
+    except Exception as e:
+        return errno.EOPNOTSUPP
+
     kfunc = xrtKernelGetFunc(xrtBufferHandle, xrtBufferHandle, ctypes.c_int, ctypes.c_int)
 
     output_bo3, output_buf3 = getInputOutputBuffer(opt.handle, khandle3, 0, False)
@@ -159,7 +164,8 @@ def main(args):
         initXRT(opt)
         assert (opt.first_mem >= 0), "Incorrect memory configuration"
 
-        runKernel(opt)
+        if (runKernel(opt) == errno.EOPNOTSUPP):
+            sys.exit(errno.EOPNOTSUPP)
         print("PASSED TEST")
 
     except OSError as o:


### PR DESCRIPTION
XRT now looks for the value of reserved host memory to decide either we should run the host memory test or not.

Worth notice that any platform can reserve host memory even without the address translator IP.


If users reserve the host memory with the device w/o address translator IP, host memory test will fail due to unable to allocate buffer over HOST[0]