### PR TITLE
CR-110683 - Need improvement of error message for old xbutil command

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -20,6 +20,20 @@ fi
 DEFAULT=xbmgmt2
 XRT_PROG=""
 
+
+# -- Legacy commands
+declare -A LEGACY_COMMANDS=( \
+        ["help"]="XBMGMT" \
+        ["version"]="XBMGMT" \
+        ["scan"]="XBMGMT" \
+        ["flash"]="XBMGMT" \
+        ["clock"]="XBMGMT" \
+        ["partition"]="XBMGMT" \
+        ["config"]="XBMGMT" \
+        ["nifd"]="XBMGMT" \
+        ["hotplug"]="XBMGMT" \
+    )
+
 # Examine the options and look for -new/--new
 XRTWARP_PROG_ARGS_size=0
 XRTWRAP_PROG_ARGS=()
@@ -72,6 +86,31 @@ if [[ ${XRT_PROG} == "xbmgmt" ]] && [[ -t 1 ]]; then
     Please update your scripts and tools to use the next generation
     sub-commands and options."
     echo "---------------------------------------------------------------------"
+fi
+
+# Determine if the user has specified a legacy command
+LEGACY_PROG=${LEGACY_COMMANDS[${XRTWRAP_PROG_ARGS[0]}]}
+
+# Additional friendly messessages
+if [[ ${XRT_PROG} == "xbmgmt2" ]] && [[ ${LEGACY_PROG} = "XBMGMT" ]]; then
+    echo "---------------------------------------------------------------------"
+    echo "Error: Legacy command used with new tools.
+
+    It has been detected that a depricated legacy command is being used
+    without the --legacy option.  This will ultimately result in
+    a 'Unknown command' error.
+
+    Further information regarding the legacy deprecated sub-commands
+    and options along with their mappings to the next generation
+    sub-commands and options can be found on the Xilinx Runtime (XRT)
+    documentation page:
+    
+    https://xilinx.github.io/XRT/master/html/xbtools_map.html
+
+    Please update your scripts and tools to use the next generation
+    sub-commands and options."
+    echo "---------------------------------------------------------------------"
+    echo
 fi
 
 # -- Find and call the loader

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -96,7 +96,7 @@ if [[ ${XRT_PROG} == "xbmgmt2" ]] && [[ ${LEGACY_PROG} = "XBMGMT" ]]; then
     echo "---------------------------------------------------------------------"
     echo "Error: Legacy command used with new tools.
 
-    It has been detected that a depricated legacy command is being used
+    It has been detected that a deprecated legacy command is being used
     without the --legacy option.  This will ultimately result in
     a 'Unknown command' error.
 

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt
@@ -81,7 +81,7 @@ if [[ ${XRT_PROG} == "xbmgmt" ]] && [[ -t 1 ]]; then
     sub-commands and options can be found on the Xilinx Runtime (XRT)
     documentation page:
     
-    https://xilinx.github.io/XRT/master/html/xbtools_map.html
+    https://xilinx.github.io/XRT/master/html/ 
 
     Please update your scripts and tools to use the next generation
     sub-commands and options."
@@ -93,22 +93,20 @@ LEGACY_PROG=${LEGACY_COMMANDS[${XRTWRAP_PROG_ARGS[0]}]}
 
 # Additional friendly messessages
 if [[ ${XRT_PROG} == "xbmgmt2" ]] && [[ ${LEGACY_PROG} = "XBMGMT" ]]; then
-    echo "---------------------------------------------------------------------"
+   echo "---------------------------------------------------------------------"
     echo "Error: Legacy command used with new tools.
-
-    It has been detected that a deprecated legacy command is being used
-    without the --legacy option.  This will ultimately result in
-    a 'Unknown command' error.
-
-    Further information regarding the legacy deprecated sub-commands
-    and options along with their mappings to the next generation
-    sub-commands and options can be found on the Xilinx Runtime (XRT)
-    documentation page:
+         
+       You are using a deprecated legacy command. This will ultimately 
+       result in an 'Unknown command' error.
     
-    https://xilinx.github.io/XRT/master/html/xbtools_map.html
-
-    Please update your scripts and tools to use the next generation
-    sub-commands and options."
+       It is recommended that you update your scripts and tools to use
+       the next generation sub-commands and options. These are 
+       documented on the Xilinx Runtime (XRT) documentation page:
+ 
+       https://xilinx.github.io/XRT/master/html/ 
+ 
+       If you must use a legacy command, you will have to use the 
+       --legacy option on the command line."
     echo "---------------------------------------------------------------------"
     echo
 fi

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -20,6 +20,30 @@ fi
 DEFAULT=xbutil2
 XRT_PROG=""
 
+# -- Legacy commands
+declare -A LEGACY_COMMANDS=( \
+        ["help"]="XBUTIL" \
+        ["version"]="XBUTIL" \
+        ["clock"]="XBUTIL" \
+        ["boot"]="XBUTIL" \
+        ["query"]="XBUTIL" \
+        ["dump"]="XBUTIL" \
+        ["run"]="XBUTIL" \
+        ["fan"]="XBUTIL" \
+        ["dmatest"]="XBUTIL" \
+        ["list"]="XBUTIL" \
+        ["scan"]="XBUTIL" \
+        ["mem"]="XBUTIL" \
+        ["dd"]="XBUTIL" \
+        ["status"]="XBUTIL" \
+        ["m2mtest"]="XBUTIL" \
+        ["flash"]="XBUTIL" \
+        ["top"]="XBUTIL" \
+        ["p2p"]="XBUTIL" \
+        ["host_mem"]="XBUTIL" \
+        ["scheduler"]="XBUTIL" \
+    )
+
 # -- Examine the options
 XRTWARP_PROG_ARGS_size=0
 XRTWRAP_PROG_ARGS=()
@@ -72,6 +96,31 @@ if [[ ${XRT_PROG} == "xbutil" ]] && [[ -t 1 ]]; then
     Please update your scripts and tools to use the next generation
     sub-commands and options."
     echo "---------------------------------------------------------------------"
+fi
+
+# Determine if the user has specified a legacy command
+LEGACY_PROG=${LEGACY_COMMANDS[${XRTWRAP_PROG_ARGS[0]}]}
+
+# Additional friendly messessages
+if [[ ${XRT_PROG} == "xbutil2" ]] && [[ ${LEGACY_PROG} = "XBUTIL" ]]; then
+    echo "---------------------------------------------------------------------"
+    echo "Error: Legacy command used with new tools.
+
+    It has been detected that a depricated legacy command is being used
+    without the --legacy option.  This will ultimately result in
+    a 'Unknown command' error.
+
+    Further information regarding the legacy deprecated sub-commands
+    and options along with their mappings to the next generation
+    sub-commands and options can be found on the Xilinx Runtime (XRT)
+    documentation page:
+    
+    https://xilinx.github.io/XRT/master/html/xbtools_map.html
+
+    Please update your scripts and tools to use the next generation
+    sub-commands and options."
+    echo "---------------------------------------------------------------------"
+    echo
 fi
 
 # -- Find loader directory

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -106,7 +106,7 @@ if [[ ${XRT_PROG} == "xbutil2" ]] && [[ ${LEGACY_PROG} = "XBUTIL" ]]; then
     echo "---------------------------------------------------------------------"
     echo "Error: Legacy command used with new tools.
 
-    It has been detected that a depricated legacy command is being used
+    It has been detected that a deprecated legacy command is being used
     without the --legacy option.  This will ultimately result in
     a 'Unknown command' error.
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil
+++ b/src/runtime_src/core/tools/xbutil2/xbutil
@@ -91,7 +91,7 @@ if [[ ${XRT_PROG} == "xbutil" ]] && [[ -t 1 ]]; then
     sub-commands and options can be found on the Xilinx Runtime (XRT)
     documentation page:
     
-    https://xilinx.github.io/XRT/master/html/xbtools_map.html
+    https://xilinx.github.io/XRT/master/html/ 
 
     Please update your scripts and tools to use the next generation
     sub-commands and options."
@@ -105,20 +105,18 @@ LEGACY_PROG=${LEGACY_COMMANDS[${XRTWRAP_PROG_ARGS[0]}]}
 if [[ ${XRT_PROG} == "xbutil2" ]] && [[ ${LEGACY_PROG} = "XBUTIL" ]]; then
     echo "---------------------------------------------------------------------"
     echo "Error: Legacy command used with new tools.
-
-    It has been detected that a deprecated legacy command is being used
-    without the --legacy option.  This will ultimately result in
-    a 'Unknown command' error.
-
-    Further information regarding the legacy deprecated sub-commands
-    and options along with their mappings to the next generation
-    sub-commands and options can be found on the Xilinx Runtime (XRT)
-    documentation page:
+         
+       You are using a deprecated legacy command. This will ultimately 
+       result in an 'Unknown command' error.
     
-    https://xilinx.github.io/XRT/master/html/xbtools_map.html
-
-    Please update your scripts and tools to use the next generation
-    sub-commands and options."
+       It is recommended that you update your scripts and tools to use
+       the next generation sub-commands and options. These are 
+       documented on the Xilinx Runtime (XRT) documentation page:
+ 
+       https://xilinx.github.io/XRT/master/html/ 
+ 
+       If you must use a legacy command, you will have to use the 
+       --legacy option on the command line."
     echo "---------------------------------------------------------------------"
     echo
 fi


### PR DESCRIPTION
The xbutil and xbmgmt wrapper has been updated to detect legacy commands being use with the newer tools.  When detected, the following message will be produced prior to executing xbutil or xbmgmt:

```
---------------------------------------------------------------------
$ xbmgmt help
---------------------------------------------------------------------
Error: Legacy command used with new tools.

    It has been detected that a deprecated legacy command is being used
    without the --legacy option.  This will ultimately result in
    a 'Unknown command' error.

    Further information regarding the legacy deprecated sub-commands
    and options along with their mappings to the next generation
    sub-commands and options can be found on the Xilinx Runtime (XRT)
    documentation page:
    
    https://xilinx.github.io/XRT/master/html/xbtools_map.html

    Please update your scripts and tools to use the next generation
    sub-commands and options.
---------------------------------------------------------------------

ERROR: Unknown command: 'help'

DESCRIPTION: The Xilinx (R) Board Management (xbmgmt) is a standalone command line utility that is
             included with the Xilinx Run Time (XRT) installation package.                                                                 

USAGE: xbmgmt [--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:                                                                                                                        
  dump       - Dump out the contents of the specified option
  examine    - Returns detail information for the specified device.                                                                        
  program    - Update image(s) for a given device                                                                                          
  reset      - Resets the given device                                                                                                     

PRELIMINARY COMMANDS:                                                                                                                      
  advanced   - Low level command operations

OPTIONS:                                                                                                                                   
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers                                                                           
  --verbose          - Turn on verbosity                                                                                                   
  --batch            - Enable batch mode (disables escape characters)                                                                      
  --force            - When possible, force an operation                                                                                   
stephenr@xcostephenr41:/proj/xcohdstaff/stephenr/github/XRT/WIP2/build/Debug/opt/xilinx/xrt$ xbmgmt flash
---------------------------------------------------------------------
Error: Legacy command used with new tools.

    It has been detected that a depricated legacy command is being used
    without the --legacy option.  This will ultimately result in
    a 'Unknown command' error.

    Further information regarding the legacy deprecated sub-commands
    and options along with their mappings to the next generation
    sub-commands and options can be found on the Xilinx Runtime (XRT)
    documentation page:
    
    https://xilinx.github.io/XRT/master/html/xbtools_map.html

    Please update your scripts and tools to use the next generation
    sub-commands and options.
---------------------------------------------------------------------

ERROR: Unknown command: 'flash'

DESCRIPTION: The Xilinx (R) Board Management (xbmgmt) is a standalone command line utility that is
             included with the Xilinx Run Time (XRT) installation package.

USAGE: xbmgmt [--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  dump       - Dump out the contents of the specified option
  examine    - Returns detail information for the specified device.
  program    - Update image(s) for a given device
  reset      - Resets the given device

PRELIMINARY COMMANDS:
  advanced   - Low level command operations

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```




Cherry Picked: da6bb1019466caf8aa3061f717f071c2c59a9a0c