### PR TITLE
Avoid return code

### DIFF
--- a/tests/xrt/02_simple/main.cpp
+++ b/tests/xrt/02_simple/main.cpp
@@ -25,9 +25,10 @@
 #include "xrt/xrt_bo.h"
 
 // This value is shared with worgroup size in kernel.cl
-static const int COUNT = 1024;
+static constexpr int COUNT = 1024;
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -37,7 +38,8 @@ static void usage()
     std::cout << "* Bitstream is required\n";
 }
 
-static int run(const xrt::device& device, const xrt::uuid& uuid, bool verbose)
+static void
+run(const xrt::device& device, const xrt::uuid& uuid, bool verbose)
 {
   const size_t DATA_SIZE = COUNT * sizeof(int);
 
@@ -71,8 +73,6 @@ static int run(const xrt::device& device, const xrt::uuid& uuid, bool verbose)
   // Validate our results
   if (std::memcmp(bo0_map, bufReference, DATA_SIZE))
     throw std::runtime_error("Value read back does not match reference");
-
-  return 0;
 }
 
 int
@@ -121,7 +121,8 @@ run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);

--- a/tests/xrt/03_loopback/main.cpp
+++ b/tests/xrt/03_loopback/main.cpp
@@ -28,14 +28,15 @@
 # pragma warning ( disable : 4996 )
 #endif
 
-static const int DATA_SIZE = 1024;
+static constexpr int DATA_SIZE = 1024;
 
 /**
  * Trivial loopback example which runs OpenCL loopback kernel. Does not use OpenCL
  * runtime but directly exercises the XRT driver API.
  */
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <xclbin>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -46,7 +47,8 @@ static void usage()
     std::cout << "* Bitstream is required\n";
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   if (argc < 3) {
     usage();
@@ -113,7 +115,8 @@ int run(int argc, char** argv)
 }
 
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);

--- a/tests/xrt/04_swizzle/main.cpp
+++ b/tests/xrt/04_swizzle/main.cpp
@@ -24,9 +24,10 @@
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 
-static const int DATA_SIZE = 4096;
+static constexpr int DATA_SIZE = 4096;
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -37,7 +38,8 @@ static void usage()
     std::cout << "* Bitstream is required\n";
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   if (argc < 3) {
     usage();
@@ -129,7 +131,8 @@ int run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);

--- a/tests/xrt/07_sequence/main.cpp
+++ b/tests/xrt/07_sequence/main.cpp
@@ -29,9 +29,10 @@
  * driver API.
  */
 
-static const int DATA_SIZE = 16;
+static constexpr int DATA_SIZE = 16;
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -42,7 +43,7 @@ static void usage()
     std::cout << "* Bitstream is required\n";
 }
 
-const unsigned goldenSequence[16] = {
+static constexpr unsigned goldenSequence[16] = {
     0X586C0C6C,
     'X',
     0X586C0C6C,
@@ -61,7 +62,8 @@ const unsigned goldenSequence[16] = {
     '\0'
 };
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   if (argc < 3) {
     usage();
@@ -120,7 +122,8 @@ int run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);

--- a/tests/xrt/100_ert_ncu/ocl.cpp
+++ b/tests/xrt/100_ert_ncu/ocl.cpp
@@ -28,12 +28,12 @@
 #include <iostream>
 #include <cstdarg>
 
-const size_t ELEMENTS = 16;
-const size_t ARRAY_SIZE = 8;
-const size_t MAXCUS = 8;
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
 
-size_t cus = MAXCUS;
-size_t rsize = std::numeric_limits<size_t>::max();
+static size_t cus = MAXCUS;
+static size_t rsize = std::numeric_limits<size_t>::max();
 
 #define MAYBE_UNUSED __attribute__((unused))
 
@@ -175,7 +175,7 @@ kernel_done(cl_event event, cl_int status, void* data)
   clReleaseEvent(event);
 }
 
-static int
+static void
 run(cl_context context, cl_command_queue queue, cl_kernel kernel, size_t num_jobs, size_t seconds)
 {
   std::vector<job_type> jobs;
@@ -202,11 +202,9 @@ run(cl_context context, cl_command_queue queue, cl_kernel kernel, size_t num_job
             << cus << " "
             << seconds << " "
             << total << "\n";
-
-  return 0;
 }
 
-static int
+static void
 run(const std::string& fnm, size_t jobs, size_t seconds)
 {
   // Init OCL
@@ -250,10 +248,10 @@ run(const std::string& fnm, size_t jobs, size_t seconds)
   clReleaseContext(context);
   clReleaseDevice(device);
   std::for_each(devices.begin(),devices.end(),[](cl_device_id d){clReleaseDevice(d);});
-  return 0;
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   std::vector<std::string> args(argv+1,argv+argc);
 
@@ -297,8 +295,7 @@ int
 main(int argc, char* argv[])
 {
   try {
-    run(argc,argv);
-    return 0;
+    return run(argc,argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << "\n";

--- a/tests/xrt/100_ert_ncu/xrt.cpp
+++ b/tests/xrt/100_ert_ncu/xrt.cpp
@@ -58,13 +58,14 @@ load_xclbin(xclDeviceHandle device, const std::string& fnm)
 
 }
 
-const size_t ELEMENTS = 16;
-const size_t ARRAY_SIZE = 8;
-const size_t MAXCUS = 8;
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
 
-size_t compute_units = MAXCUS;
+static size_t compute_units = MAXCUS;
 
-static void usage()
+static void
+usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
@@ -238,7 +239,7 @@ launcher_thread(xclDeviceHandle d)
 }
 
 
-static int
+static void
 run(xclDeviceHandle d,size_t num_jobs, size_t seconds, int first_used_mem)
 {
   g_jobs.reserve(num_jobs);
@@ -269,11 +270,10 @@ run(xclDeviceHandle d,size_t num_jobs, size_t seconds, int first_used_mem)
             << compute_units << " "
             << seconds << " "
             << total << "\n";
-
-  return 0;
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   std::vector<std::string> args(argv+1,argv+argc);
 
@@ -356,8 +356,7 @@ int
 main(int argc, char* argv[])
 {
   try {
-    run(argc,argv);
-    return 0;
+    return run(argc,argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << "\n";

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -33,13 +33,14 @@
 # pragma warning ( disable : 4267 )
 #endif
 
-const size_t ELEMENTS = 16;
-const size_t ARRAY_SIZE = 8;
-const size_t MAXCUS = 8;
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
 
-size_t compute_units = MAXCUS;
+static size_t compute_units = MAXCUS;
 
-static void usage()
+static void
+usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
@@ -183,7 +184,7 @@ kernel_done(xrtRunHandle rhdl, ert_cmd_state state, void* data)
   reinterpret_cast<job_type*>(data)->done();
 }
 
-static int
+static void
 run(xrtDeviceHandle device, xrtKernelHandle kernel, size_t num_jobs, size_t seconds)
 {
   std::vector<job_type> jobs;
@@ -212,11 +213,10 @@ run(xrtDeviceHandle device, xrtKernelHandle kernel, size_t num_jobs, size_t seco
             << compute_units << " "
             << seconds << " "
             << total << "\n";
-
-  return 0;
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   std::vector<std::string> args(argv+1,argv+argc);
 
@@ -276,8 +276,7 @@ int
 main(int argc, char* argv[])
 {
   try {
-    run(argc,argv);
-    return 0;
+    return run(argc,argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << "\n";

--- a/tests/xrt/100_ert_ncu/xrtxx-ip.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-ip.cpp
@@ -43,18 +43,19 @@
 # pragma warning ( disable : 4267 )
 #endif
 
-constexpr uint32_t AP_START    = 0x1;
-constexpr uint32_t AP_DONE     = 0x2;
-constexpr uint32_t AP_IDLE     = 0x4;
+static constexpr uint32_t AP_START    = 0x1;
+static constexpr uint32_t AP_DONE     = 0x2;
+static constexpr uint32_t AP_IDLE     = 0x4;
 
-const size_t ELEMENTS = 16;
-const size_t ARRAY_SIZE = 8;
-const size_t MAXCUS = 8;
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
 
 static size_t compute_units = MAXCUS;
 static bool use_interrupt = false;
 
-static void usage()
+static void
+usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
@@ -206,7 +207,7 @@ run_async(const xrt::device& device, const xrt::uuid& xid, const std::string& ip
   return job.runs;
 }
 
-static int
+static void
 run(const xrt::device& device, const xrt::uuid& xid, size_t cus, size_t seconds)
 {
   std::vector<std::future<size_t>> jobs;
@@ -233,11 +234,10 @@ run(const xrt::device& device, const xrt::uuid& xid, size_t cus, size_t seconds)
             << compute_units << " "
             << seconds << " "
             << total << "\n";
-
-  return 0;
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   std::vector<std::string> args(argv+1,argv+argc);
 
@@ -291,8 +291,7 @@ int
 main(int argc, char* argv[])
 {
   try {
-    run(argc,argv);
-    return 0;
+    return run(argc,argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << "\n";

--- a/tests/xrt/100_ert_ncu/xrtxx-mt.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-mt.cpp
@@ -39,13 +39,14 @@
 # pragma warning ( disable : 4267 )
 #endif
 
-const size_t ELEMENTS = 16;
-const size_t ARRAY_SIZE = 8;
-const size_t MAXCUS = 8;
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
 
-size_t compute_units = MAXCUS;
+static size_t compute_units = MAXCUS;
 
-static void usage()
+static void
+usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
@@ -156,7 +157,7 @@ run_async(const xrt::device& device, const xrt::kernel& kernel)
   return job.runs;
 }
 
-static int
+static void
 run(const xrt::device& device, const xrt::kernel& kernel, size_t num_jobs, size_t seconds)
 {
   std::vector<std::future<size_t>> jobs;
@@ -183,11 +184,10 @@ run(const xrt::device& device, const xrt::kernel& kernel, size_t num_jobs, size_
             << compute_units << " "
             << seconds << " "
             << total << "\n";
-
-  return 0;
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   std::vector<std::string> args(argv+1,argv+argc);
 
@@ -239,8 +239,7 @@ int
 main(int argc, char* argv[])
 {
   try {
-    run(argc,argv);
-    return 0;
+    return run(argc,argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << "\n";

--- a/tests/xrt/100_ert_ncu/xrtxx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx.cpp
@@ -33,13 +33,14 @@
 # pragma warning ( disable : 4267 )
 #endif
 
-const size_t ELEMENTS = 16;
-const size_t ARRAY_SIZE = 8;
-const size_t MAXCUS = 8;
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
 
-size_t compute_units = MAXCUS;
+static size_t compute_units = MAXCUS;
 
-static void usage()
+static void
+usage()
 {
   std::cout << "usage: %s [options] \n\n";
   std::cout << "  -k <bitstream>\n";
@@ -169,7 +170,7 @@ kernel_done(const void*, ert_cmd_state state, void* data)
   reinterpret_cast<job_type*>(data)->done();
 }
 
-static int
+static void
 run(xrtDeviceHandle device, const xrt::kernel& kernel, size_t num_jobs, size_t seconds)
 {
   std::vector<job_type> jobs;
@@ -198,11 +199,10 @@ run(xrtDeviceHandle device, const xrt::kernel& kernel, size_t num_jobs, size_t s
             << compute_units << " "
             << seconds << " "
             << total << "\n";
-
-  return 0;
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   std::vector<std::string> args(argv+1,argv+argc);
 
@@ -254,8 +254,7 @@ int
 main(int argc, char* argv[])
 {
   try {
-    run(argc,argv);
-    return 0;
+    return run(argc,argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << "\n";

--- a/tests/xrt/102_multiproc_verify/main.cpp
+++ b/tests/xrt/102_multiproc_verify/main.cpp
@@ -85,7 +85,8 @@ stamp(std::ostream& os) {
   return os;
 }
 
-int run_children(int argc, char *argv[], char *envp[], unsigned count)
+static int
+run_children(int argc, char *argv[], char *envp[], unsigned int count)
 {
     const char *path = argv[0];
     char buf[8];
@@ -110,16 +111,17 @@ int run_children(int argc, char *argv[], char *envp[], unsigned count)
  * Runs multiple processes each exercising the same shared hello world kernel in loop
  */
 
-static const unsigned LOOP = 16;
-static const unsigned CHILDREN = 8;
+static constexpr unsigned LOOP = 16;
+static constexpr unsigned CHILDREN = 8;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-int runChildren(int argc, char *argv[], char *envp[], unsigned count);
+int runChildren(int argc, char *argv[], char *envp[], unsigned int count);
 
 static const char gold[] = "Hello World\n";
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -182,7 +184,7 @@ run(const xrt::device& device, const xrt::uuid& uuid, size_t n_runs, bool verbos
 }
 
 
-int
+static int
 run(int argc, char** argv, char *envp[])
 {
   if (argc < 3) {
@@ -249,9 +251,9 @@ main(int argc, char** argv, char *envp[])
   catch (std::exception const& e) {
     std::cout << "Exception: " << e.what() << "\n";
     std::cout << "FAILED TEST\n";
-    return 1;
   }
-
-  std::cout << "PASSED TEST\n";
-  return 0;
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
 }

--- a/tests/xrt/11_fp_mmult256/main.cpp
+++ b/tests/xrt/11_fp_mmult256/main.cpp
@@ -29,8 +29,8 @@
 # pragma warning ( disable : 4244 )
 #endif
 
-static const int size = 256;
-int data_size = size*size;
+static constexpr int size = 256;
+static int data_size = size*size;
 
 /**
  * Runs an OpenCL kernel which writes known 16 integers into a 64 byte
@@ -38,7 +38,8 @@ int data_size = size*size;
  * driver API.
  */
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -s <hal_driver>\n";
@@ -114,7 +115,7 @@ run(xrt::device& device, const xrt::uuid& uuid, bool random, bool verbose)
 }
 
 
-int
+static int
 run(int argc, char** argv)
 {
   if (argc < 3) {
@@ -167,7 +168,8 @@ run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);
@@ -177,9 +179,9 @@ int main(int argc, char** argv)
   catch (std::exception const& e) {
     std::cout << "Exception: " << e.what() << "\n";
     std::cout << "FAILED TEST\n";
-    return 1;
   }
-
-  std::cout << "PASSED TEST\n";
-  return 0;
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
 }

--- a/tests/xrt/13_add_one/main.cpp
+++ b/tests/xrt/13_add_one/main.cpp
@@ -24,13 +24,14 @@
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
 
-#define ARRAY_SIZE 8
+static constexpr int ARRAY_SIZE = 8;
 
 /**
  * Runs an OpenCL addone kernel adding one to every 8 unsigned long
  */
 
-static void usage()
+static void
+usage()
 {
   std::cout << "usage: %s [options] -k <bitstream>\n\n"
             << "\n"
@@ -74,7 +75,8 @@ run(xrt::device& device, const xrt::uuid& uuid, size_t n_elements)
 }
 
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   if (argc < 3) {
     usage();
@@ -124,7 +126,8 @@ int run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);
@@ -134,9 +137,9 @@ int main(int argc, char** argv)
   catch (std::exception const& e) {
     std::cout << "Exception: " << e.what() << "\n";
     std::cout << "FAILED TEST\n";
-    return 1;
   }
-
-  std::cout << "PASSED TEST\n";
-  return 0;
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
 }

--- a/tests/xrt/22_verify/main.cpp
+++ b/tests/xrt/22_verify/main.cpp
@@ -26,16 +26,17 @@
  * Runs an OpenCL kernel which writes "Hello World\n" into the buffer passed
  */
 
-#define ARRAY_SIZE 20
+static constexpr int ARRAY_SIZE = 20;
 ////////////////////////////////////////////////////////////////////////////////
 
-#define LENGTH (20)
+static constexpr int LENGTH = 20;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static const char gold[] = "Hello World\n";
+static constexpr char gold[] = "Hello World\n";
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -74,7 +75,8 @@ run(const xrt::device& device, const xrt::uuid& uuid, bool verbose)
 }
 
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   if (argc < 3) {
     usage();
@@ -130,9 +132,9 @@ int main(int argc, char** argv)
   catch (std::exception const& e) {
     std::cout << "Exception: " << e.what() << "\n";
     std::cout << "FAILED TEST\n";
-    return 1;
   }
-
-  std::cout << "PASSED TEST\n";
-  return 0;
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
 }

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -26,7 +26,7 @@
 #include "xrt/xrt_bo.h"
 
 // This value is shared with worgroup size in kernel.cl
-constexpr auto COUNT = 1024;
+static constexpr auto COUNT = 1024;
 
 static void
 usage()
@@ -127,7 +127,7 @@ run_c(const std::string& xclbin_fnm)
   xrtXclbinFreeHandle(xhdl);
 }
 
-int 
+static int 
 run(int argc, char** argv)
 {
   if (argc < 3) {
@@ -169,7 +169,8 @@ run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     if (!run(argc, argv))

--- a/tests/xrt/fa_kernel/ocl.cpp
+++ b/tests/xrt/fa_kernel/ocl.cpp
@@ -27,7 +27,8 @@
 #include <string>
 #include <vector>
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -331,6 +332,5 @@ main(int argc, char* argv[])
   catch (...) {
     std::cout << "TEST FAILED\n";
   }
-
   return 1;
 }

--- a/tests/xrt/fa_kernel/xrt.cpp
+++ b/tests/xrt/fa_kernel/xrt.cpp
@@ -31,7 +31,8 @@
 # pragma warning ( disable : 4244 )
 #endif
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -139,7 +140,6 @@ run(std::vector<job_type>& cmds, size_t total)
 
   auto end = std::chrono::high_resolution_clock::now();
   return (std::chrono::duration_cast<std::chrono::microseconds>(end - start)).count();
-  
 }
 
 static void
@@ -162,7 +162,7 @@ run(const xrt::device& device, xrt::kernel& aes)
   }
 }
 
-int
+static int
 run(int argc, char** argv)
 {
   if (argc < 3) {
@@ -206,7 +206,8 @@ run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);
@@ -216,9 +217,9 @@ int main(int argc, char** argv)
   catch (std::exception const& e) {
     std::cout << "Exception: " << e.what() << "\n";
     std::cout << "FAILED TEST\n";
-    return 1;
   }
-
-  std::cout << "PASSED TEST\n";
-  return 0;
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
 }

--- a/tests/xrt/fa_kernel/xrt2.cpp
+++ b/tests/xrt/fa_kernel/xrt2.cpp
@@ -31,7 +31,8 @@
 # pragma warning ( disable : 4244 )
 #endif
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -167,7 +168,7 @@ run(const xrt::device& device, xrt::kernel& aes)
   }
 }
 
-int
+static int
 run(int argc, char** argv)
 {
   if (argc < 3) {
@@ -211,7 +212,8 @@ run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);
@@ -223,7 +225,8 @@ int main(int argc, char** argv)
     std::cout << "FAILED TEST\n";
     return 1;
   }
-
-  std::cout << "PASSED TEST\n";
-  return 0;
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
 }

--- a/tests/xrt/perf_IOPS/xrt_api_iops.cpp
+++ b/tests/xrt/perf_IOPS/xrt_api_iops.cpp
@@ -16,12 +16,13 @@
 # pragma warning( disable : 4244 )
 #endif
 
-void usage()
+static void usage()
 {
   std::cout  << "Usage: test -k <xclbin>\n";
 }
 
-double runTest(std::vector<xrt::run>& cmds, unsigned int total)
+static double
+runTest(std::vector<xrt::run>& cmds, unsigned int total)
 {
   int i = 0;
   unsigned int issued = 0, completed = 0;
@@ -50,7 +51,8 @@ double runTest(std::vector<xrt::run>& cmds, unsigned int total)
   return (std::chrono::duration_cast<std::chrono::microseconds>(end - start)).count();
 }
 
-int testSingleThread(const xrt::device& device, const xrt::uuid& uuid)
+static void
+testSingleThread(const xrt::device& device, const xrt::uuid& uuid)
 {
   /* The command would incease */
   std::vector<unsigned int> cmds_per_run = { 10,50,100,200,500,1000,1500,2000,3000,5000,10000,50000,100000,500000,1000000 };
@@ -73,11 +75,10 @@ int testSingleThread(const xrt::device& device, const xrt::uuid& uuid)
               << " iops: " << (num_cmds * 1000.0 * 1000.0 / duration)
               << std::endl;
   }
-
-  return 0;
 }
 
-int _main(int argc, char* argv[])
+static int
+_main(int argc, char* argv[])
 {
   if (argc < 3 || argv[1] != std::string("-k")) {
     usage();
@@ -97,8 +98,7 @@ int _main(int argc, char* argv[])
 int main(int argc, char *argv[])
 {
   try {
-    _main(argc, argv);
-    return 0;
+    return _main(argc, argv);
   }
   catch (const std::exception& ex) {
     std::cout << "TEST FAILED: " << ex.what() << std::endl;

--- a/tests/xrt/query/main.cpp
+++ b/tests/xrt/query/main.cpp
@@ -25,7 +25,8 @@
  * xrt_device.h
  */
 
-static void usage()
+static void
+usage()
 {
     std::cout << "usage: %s [options] -k <bitstream>\n\n";
     std::cout << "  -k <bitstream>\n";
@@ -36,7 +37,8 @@ static void usage()
     std::cout << "* Bitstream is required\n";
 }
 
-int run(int argc, char** argv)
+static int
+run(int argc, char** argv)
 {
   if (argc < 3) {
     usage();
@@ -114,7 +116,8 @@ int run(int argc, char** argv)
   return 0;
 }
 
-int main(int argc, char** argv)
+int
+main(int argc, char** argv)
 {
   try {
     auto ret = run(argc, argv);

--- a/tests/xrt/reset/main.cpp
+++ b/tests/xrt/reset/main.cpp
@@ -48,7 +48,7 @@ install()
   signal(SIGINT, SigIntHandler);
 }
 
-void
+static void
 run(xrt::device& device)
 {
   install();
@@ -57,7 +57,7 @@ run(xrt::device& device)
     cond.wait(lk);
 }
 
-int
+static int
 run(int argc, char* argv[])
 {
   std::string device_index = "0";
@@ -89,7 +89,8 @@ run(int argc, char* argv[])
     cond.wait(lk);
 }
 
-int main(int argc, char* argv[])
+int
+main(int argc, char* argv[])
 {
   try {
     auto ret = run(argc, argv);


### PR DESCRIPTION
Error handling in C++ tests is exceptions.  
Depending on what main returns, first level driver code may need to return a simple 1/0 code.
Fix few const to constexpr.