### PR TITLE
CR-1100200 ASTeR TC 17.06 - vck5000 - xbmgmt2 program --base errors with "Failed to update base: Invalid argument"

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -27,23 +27,24 @@ XOSPIVER_Flasher::XOSPIVER_Flasher(std::shared_ptr<xrt_core::device> dev)
 
 int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
 {
-    binStream.seekg(0, binStream.end);
-    auto total_size = static_cast<int>(binStream.tellg());
-    binStream.seekg(0, binStream.beg);
- 
-    std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
-   
-    try {
-      auto fd = m_device->file_open("xfer_versal", O_RDWR);
-      std::vector<char> buffer(total_size);
-      binStream.read(buffer.data(), total_size);
+  binStream.seekg(0, binStream.end);
+  auto total_size = static_cast<int>(binStream.tellg());
+  binStream.seekg(0, binStream.beg);
+
+  std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
+
+  try {
+    auto fd = m_device->file_open("xfer_versal", O_RDWR);
+    std::vector<char> buffer(total_size);
+    binStream.read(buffer.data(), total_size);
+    ssize_t ret = total_size;
 #ifdef __GNUC__
-      auto ret = write(fd.get(), buffer.data(), total_size);
+    ret = write(fd.get(), buffer.data(), total_size);
 #endif
-      return ret == total_size ? 0 : -EIO;
-    }
-    catch (const std::exception& e) {
-      xrt_core::send_exception_message(e.what(), "XBMGMT");
-      return -EIO;
-    }
+    return ret == total_size ? 0 : -EIO;
+  }
+  catch (const std::exception& e) {
+    xrt_core::send_exception_message(e.what(), "XBMGMT");
+    return -EIO;
+  }
 }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -27,27 +27,23 @@ XOSPIVER_Flasher::XOSPIVER_Flasher(std::shared_ptr<xrt_core::device> dev)
 
 int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
 {
-    int total_size = 0;
-
     binStream.seekg(0, binStream.end);
-    total_size = static_cast<int>(binStream.tellg());
+    auto total_size = static_cast<int>(binStream.tellg());
     binStream.seekg(0, binStream.beg);
-
+ 
     std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
-    
-    xrt_core::scope_value_guard<int, std::function<void()>> fd { 0, nullptr };
+   
     try {
-        fd = m_device->file_open("xfer_versal", O_RDWR); 
-    } catch (const std::exception& e) {
-        xrt_core::send_exception_message(e.what(), "XBMGMT");
-    }
-
-    std::vector<char> buffer(total_size);
-    binStream.read(buffer.data(), total_size);
-	ssize_t ret = total_size;
+      auto fd = m_device->file_open("xfer_versal", O_RDWR);
+      std::vector<char> buffer(total_size);
+      binStream.read(buffer.data(), total_size);
 #ifdef __GNUC__
-	ret = write(fd.get(), buffer.data(), total_size);
+      auto ret = write(fd.get(), buffer.data(), total_size);
 #endif
-
-    return ret == total_size ? 0 : -EIO;
+      return ret == total_size ? 0 : -EIO;
+    }
+    catch (const std::exception& e) {
+      xrt_core::send_exception_message(e.what(), "XBMGMT");
+      return -EIO;
+    }
 }


### PR DESCRIPTION
Sample output:
```
# Debug/opt/xilinx/xrt/bin/xbmgmt program -b -d d9:00 --force 
----------------------------------------------------
Device : [0000:d9:00.0]

Current Configuration
  Platform             : xilinx_vck5000_gen3x16_xdma_base_1
  SC Version           : 4.4.10
  Platform ID          : 0x96e93baba74ed333


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/96e93baba74ed333ee00f559d71933a2
  Size                 : 29,508,709 bytes
  Timestamp            : Sun Sep 26 05:05:33 2021

  Platform             : xilinx_vck5000_gen3x16_xdma_base_1
  SC Version           : 4.4.10
  Platform UUID        : 96E93BAB-A74E-D333-EE00-F559D71933A2
----------------------------------------------------
Actions to perform:
  [0000:d9:00.0] : Program base (FLASH) image
  [0000:d9:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y (Force override)

INFO: Forcing flashing of the Satellite Controller (SC) image (Force flag is set).
[0000:d9:00.0] : Updating Satellite Controller (SC) firmware flash image...
INFO     : found 5 sections
[PASSED] : SC successfully updated < 43s >
INFO     : Loading new firmware on SC
.......

INFO: Forcing flashing of the base (e.g., shell) image (Force flag is set).
[0000:d9:00.0] : Updating base (e.g., shell) flash image...
PDI dsabin supports only primary bitstream: /lib/firmware/xilinx/96e93baba74ed333ee00f559d71933a2/partition.xsabin
INFO: ***PDI has 29099808 bytes
INFO     : Base flash image has been programmed successfully. 
----------------------------------------------------
Report
  [0000:d9:00.0] : Successfully flashed the Satellite Controller (SC) image
  [0000:d9:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```