### PR TITLE
Add xrt::bo constructor from xclBufferHandle

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -184,6 +184,14 @@ public:
     size = prop.size;
   }
 
+  bo_impl(xclDeviceHandle dhdl, xcl_buffer_handle xhdl)
+    : device(xrt_core::get_userpf_device(dhdl)), handle(xhdl.bhdl), free_bo(false)
+  {
+    xclBOProperties prop{};
+    device->get_bo_properties(handle, &prop);
+    size = prop.size;
+  }
+
   bo_impl(const bo_impl* parent, size_t sz)
     : device(parent->device), handle(parent->handle), size(sz), free_bo(false)
   {}
@@ -432,6 +440,8 @@ public:
 
   ~buffer_kbuf() override
   {
+    // Imported BO can fail in xclUnmapBO if the exported BO has
+    // already been unmapped or vice versa.
     try {
       device->unmap_bo(handle, hbuf);
     }
@@ -473,6 +483,8 @@ public:
 
   ~buffer_import() override
   {
+    // Imported BO can fail in xclUnmapBO if the exported BO has
+    // already been unmapped or vice versa.
     try {
       device->unmap_bo(handle, hbuf);
     }
@@ -620,6 +632,50 @@ public:
   }
 };
 
+// class buffer_xbuf - Wrapper for extern managed xclBufferHandle
+//
+// This class is added to support xrt::bo object for host
+// managed xclBufferHandles.  This allows the xclBufferHandle
+// to be used as argument for kernel execution.  All other
+// operations must be managed explicity by host via xcl APIs.
+class buffer_xbuf : public bo_impl
+{
+public:
+  buffer_xbuf(xclDeviceHandle dhdl, xclBufferHandle bhdl)
+    : bo_impl(dhdl, xcl_buffer_handle{bhdl})
+  {}
+
+  void*
+  get_hbuf() const override
+  {
+    throw xrt_core::error(std::errc::not_supported, "no host buffer access for xcl managed BOs");
+  }
+
+  void
+  copy(const bo_impl*, size_t, size_t, size_t) override
+  {
+    throw xrt_core::error(std::errc::not_supported, "no copy of xcl managed BOs");
+  }
+
+  void
+  sync(xclBOSyncDirection, size_t, size_t) override
+  {
+    throw xrt_core::error(std::errc::not_supported, "no sync of xcl managed BOs");
+  }
+
+  bool
+  is_sub() const override
+  {
+    throw xrt_core::error(std::errc::not_supported, "no sub buffer property for xcl managed BOs");
+  }
+
+  bool
+  is_imported() const override
+  {
+    throw xrt_core::error(std::errc::not_supported, "no import property for xcl managed BOs");
+  }
+};
+
 } // namespace xrt
 
 // Implementation details
@@ -762,6 +818,12 @@ alloc(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 }
 
 static std::shared_ptr<xrt::bo_impl>
+alloc_xbuf(xclDeviceHandle dhdl, xclBufferHandle xhdl)
+{
+  return std::make_shared<xrt::buffer_xbuf>(dhdl, xhdl);
+}
+
+static std::shared_ptr<xrt::bo_impl>
 alloc_userptr(xclDeviceHandle dhdl, void* userptr, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 {
   return alloc_ubuf(dhdl, userptr, sz, flags, grp);
@@ -778,6 +840,7 @@ alloc_sub(const std::shared_ptr<xrt::bo_impl>& parent, size_t size, size_t offse
 {
   return std::make_shared<xrt::buffer_sub>(parent, size, offset);
 }
+
 
 static xclDeviceHandle
 get_xcl_device_handle(xrtDeviceHandle dhdl)
@@ -901,6 +964,11 @@ bo::
 bo(const bo& parent, size_t size, size_t offset)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
 	   alloc_sub, parent.handle, size, offset))
+{}
+
+bo::
+bo(xclDeviceHandle dhdl, xcl_buffer_handle xhdl)
+  : handle(alloc_xbuf(dhdl, xhdl.bhdl))
 {}
 
 bo::
@@ -1105,6 +1173,26 @@ xrtBOExport(xrtBufferHandle bhdl)
     send_exception_message(ex.what());
   }
   return XRT_NULL_BO_EXPORT;
+}
+
+xrtBufferHandle
+xrtBOAllocFromXcl(xrtDeviceHandle dhdl, xclBufferHandle xhdl)
+{
+  try {
+    return xdp::native::profiling_wrapper(__func__, [dhdl, xhdl] {
+      auto boh = alloc_xbuf(xrtDeviceToXclDevice(dhdl), xhdl);
+      bo_cache[boh.get()] = boh;
+      return boh.get();
+    });
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    errno = ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    send_exception_message(ex.what());
+  }
+  return nullptr;
 }
 
 int

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -46,6 +46,12 @@ typedef uint64_t xrtBufferFlags;
  * typedef xrtMemoryGroup - Memory bank group for buffer
  */
 typedef uint32_t xrtMemoryGroup;
+
+/**
+ * Typed xclBufferHandle used to prevent ambiguity
+ * Use when constructing xrt::bo from xclBufferHandle
+ */
+struct xcl_buffer_handle { xclBufferHandle bhdl; };
   
 #ifdef __cplusplus
 
@@ -203,6 +209,31 @@ public:
    */
   XCL_DRIVER_DLLESPEC
   bo(const bo& parent, size_t size, size_t offset);
+
+  /// @cond
+  /**
+   * bo() - Constructor from xclBufferHandle
+   *
+   * @param dhdl
+   *  Device on which the buffer handle was created
+   * @param xhdl
+   *  Typified shim buffer handle created with xclAllocBO variants
+   *
+   * This function allows construction of xrt::bo object from an
+   * xclBufferHandle supposedly allocated using deprecated xcl APIs.
+   * The buffer handle is allocated with xclAllocBO and must be
+   * freed with xclFreeBO. 
+   *
+   * Note that argument xclBufferHandle must be wrapped as
+   * an xcl_buffer_handle in order to disambiguate the untyped
+   * xclBufferHandle.
+   *
+   * Mixing xcl style APIs and xrt APIs is discouraged and
+   * as such this documentation is not included in doxygen.
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(xclDeviceHandle dhdl, xcl_buffer_handle xhdl);
+  /// @endcond
 
   /**
    * bo() - Copy ctor
@@ -519,6 +550,31 @@ xrtBOExport(xrtBufferHandle bhdl);
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
 xrtBOSubAlloc(xrtBufferHandle parent, size_t size, size_t offset);
+
+/* 
+ * xrtBOAllocFromXcl() - Undocumented allocation from an xclBufferHandle
+ *
+ * @dhdl:  XRT device handle on which the buffer is residing.
+ * @xhdl:  The xcl buffer handle to convert to an xrtBufferHandle
+ * Return: xrtBufferHandle which must be freed using `xrtBOFree`
+ *
+ * Note that argument xclBufferHandle must be wrapped as
+ * an xcl_buffer_handle in order to disambiguate the untyped
+ * xclBufferHandle.
+ *
+ * Please note that the device is an xrtDeviceHandle.  It is the
+ * responsibility of the user to convert an xclDeviceHandle to 
+ * an xrtDeviceHandle before calling this API.
+ *
+ * The xrtBufferHandle returned by this API
+ *
+ * The argument xcl buffer handle must be explicitly freed using
+ * xclFreeBO, in other words xclAllocBO requires xclFreeBO and
+ * xrtBOAlloc requires xrtBOFree.
+ */
+XCL_DRIVER_DLLESPEC
+xrtBufferHandle
+xrtBOAllocFromXcl(xrtDeviceHandle dhdl, xclBufferHandle xhdl);
 
 /**
  * xrtBOFree() - Free a previously allocated BO

--- a/tests/xrt/22_verify/CMakeLists.txt
+++ b/tests/xrt/22_verify/CMakeLists.txt
@@ -6,6 +6,9 @@ set(TESTNAME "22_verify")
 add_executable(${TESTNAME} main.cpp)
 target_link_libraries(${TESTNAME} PRIVATE ${xrt_coreutil_LIBRARY})
 
+add_executable(${TESTNAME}_xcl xcl.cpp)
+target_link_libraries(${TESTNAME}_xcl PRIVATE ${xrt_coreutil_LIBRARY} ${xrt_core_LIBRARY})
+
 # Experimental demo of static linking.
 # Should be built into to PUBLIC options along with find_package
 if (DEFINED ENV{XRT_STATIC_BUILD})
@@ -31,7 +34,8 @@ endif()
 
 if (NOT WIN32)
   target_link_libraries(${TESTNAME} PRIVATE ${uuid_LIBRARY} pthread)
+  target_link_libraries(${TESTNAME}_xcl PRIVATE ${uuid_LIBRARY} pthread)
 endif(NOT WIN32)
 
-install(TARGETS ${TESTNAME}
+install(TARGETS ${TESTNAME} ${TESTNAME}_xcl
   RUNTIME DESTINATION ${INSTALL_DIR}/${TESTNAME})

--- a/tests/xrt/22_verify/xcl.cpp
+++ b/tests/xrt/22_verify/xcl.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/****************************************************************
+Simple verify test bridging from xclBufferHandles to xrt::bo for 
+use with xrt::kernel arguments.
+
+It is strongly discouraged to use xcl APIs, please write the 
+application using XRT native APIs only (see main.cpp).
+
+There are two test drivers in this file, one that use XRT C APIs (not
+recommended) and one that use XRT C++ APIs.  
+
+The sample host code shows how to convert a raw xclBufferHandle
+to an xrt::bo object which is then used as a kernel argument.
+
+% g++ -g -std=c++14 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o xcl.exe xcl.cpp -lxrt_coreutil -lxrt_core -luuid -pthread
+% xcl.exe -k verify.xclbin [--api <c | cpp>]  (default is cpp)
+****************************************************************/
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "xrt.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+#include "xrt/xrt_bo.h"
+
+static constexpr int ARRAY_SIZE = 20;
+static constexpr int LENGTH = 20;
+static constexpr char gold[] = "Hello World\n";
+
+static void
+usage()
+{
+    std::cout << "usage: %s [options] -k <bitstream>\n\n"
+              << "  -k <bitstream>\n"
+              << "  -d <index>\n"
+              << "  -h\n\n"
+              << "  [--api <c | cpp>]  Specify API style (default: cpp)\n"
+              << "* Bitstream is required\n";
+}
+
+static void
+run_c(xclDeviceHandle dhdl, const xrt::uuid& uuid)
+{
+  auto device = xrtDeviceOpenFromXcl(dhdl);
+  auto hello  = xrtPLKernelOpen(device, uuid.get(), "hello:{hello_1}");
+  auto bank = xrtKernelArgGroupId(hello, 0);
+  
+  // Allocate buffer object via xcl
+  auto xclbo = xclAllocBO(dhdl, 1024, 0, XRT_BO_FLAGS_NONE | bank);
+  auto xclbo_data = reinterpret_cast<char*>(xclMapBO(dhdl, xclbo, true));
+  std::memset(xclbo_data, 0, 1024);
+  xclSyncBO(dhdl, xclbo, XCL_BO_SYNC_BO_TO_DEVICE, 1024, 0);
+
+  // Bridge to xrt::bo so that xrt::kernel can be used
+  // In order to disambiguate the untyped xclBufferHandle,
+  // it must be wrapped in typed xcl_buffer_handle.
+  auto xrtbo = xrtBOAllocFromXcl(device, xclbo);
+
+  // Start kernel run
+  auto run = xrtKernelRun(hello, xrtbo);
+  std::cout << "Kernel start command issued" << std::endl;
+  std::cout << "Now wait until the kernel finish" << std::endl;
+
+  // Wait for kernel to complete
+  xrtRunWait(run);
+
+  // None of the xrt objects are needed any more
+  xrtRunClose(run);
+  xrtBOFree(xrtbo);
+  xrtKernelClose(hello);
+  xrtDeviceClose(device);
+
+  // Get the output from the xcl buffer
+  std::cout << "Get the output data from the device" << std::endl;
+  xclSyncBO(dhdl, xclbo, XCL_BO_SYNC_BO_FROM_DEVICE, 1024, 0);
+
+  // Map BO
+  std::cout << "RESULT: " << std::endl;
+  for (unsigned i = 0; i < 20; ++i)
+    std::cout << xclbo_data[i];
+  std::cout << std::endl;
+  if (!std::equal(std::begin(gold), std::end(gold), xclbo_data))
+    throw std::runtime_error("Incorrect value obtained");
+
+  // Finally free the xclBuffer
+  xclFreeBO(dhdl, xclbo);
+}
+
+static void
+run_cpp(xclDeviceHandle dhdl, const xrt::uuid& uuid)
+{
+  auto device = xrt::device{dhdl};
+  auto hello = xrt::kernel(device, uuid.get(), "hello:{hello_1}");
+  auto bank = hello.group_id(0);
+  
+  // Allocate buffer object via xcl
+  auto xclbo = xclAllocBO(dhdl, 1024, 0, XRT_BO_FLAGS_NONE | bank);
+  auto xclbo_data = reinterpret_cast<char*>(xclMapBO(dhdl, xclbo, true));
+  std::memset(xclbo_data, 0, 1024);
+  xclSyncBO(dhdl, xclbo, XCL_BO_SYNC_BO_TO_DEVICE, 1024, 0);
+
+  // Bridge to xrt::bo so that xrt::kernel can be used
+  // In order to disambiguate the untyped xclBufferHandle,
+  // it must be wrapped in typed xcl_buffer_handle.
+  auto bo = xrt::bo(device, xcl_buffer_handle{xclbo});
+
+  auto run = hello(bo);
+  std::cout << "Kernel start command issued" << std::endl;
+  std::cout << "Now wait until the kernel finish" << std::endl;
+
+  run.wait();
+
+  // Get the output
+  std::cout << "Get the output data from the device" << std::endl;
+  xclSyncBO(dhdl, xclbo, XCL_BO_SYNC_BO_FROM_DEVICE, 1024, 0);
+
+  // Map BO
+  std::cout << "RESULT: " << std::endl;
+  for (unsigned i = 0; i < 20; ++i)
+    std::cout << xclbo_data[i];
+  std::cout << std::endl;
+  if (!std::equal(std::begin(gold), std::end(gold), xclbo_data))
+    throw std::runtime_error("Incorrect value obtained");
+
+  // Free the BO
+  xclFreeBO(dhdl, xclbo);
+}
+
+
+static int
+run(int argc, char** argv)
+{
+  if (argc < 3) {
+    usage();
+    return 1;
+  }
+
+  std::string xclbin_fnm;
+  unsigned int device_index = 0;
+  bool cpp = true;
+
+  std::vector<std::string> args(argv+1,argv+argc);
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return 1;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "-k")
+      xclbin_fnm = arg;
+    else if (cur == "-d")
+      device_index = std::stoi(arg);
+    else if (cur == "--api" && arg == "c")
+      cpp = false;
+    else
+      throw std::runtime_error("Unknown option value " + cur + " " + arg);
+  }
+
+  if (xclbin_fnm.empty())
+    throw std::runtime_error("FAILED_TEST\nNo xclbin specified");
+
+  auto device = xrt::device(device_index);
+  auto uuid = device.load_xclbin(xclbin_fnm);
+
+  if (cpp)
+    run_cpp(device, uuid);
+  else 
+    run_c(device, uuid);
+
+  return 0;
+}
+
+int main(int argc, char** argv)
+{
+  try {
+    auto ret = run(argc, argv);
+    std::cout << "PASSED TEST\n";
+    return ret;
+  }
+  catch (std::exception const& e) {
+    std::cout << "Exception: " << e.what() << "\n";
+    std::cout << "FAILED TEST\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+  return 1;
+}


### PR DESCRIPTION
Allow applications to bridge into XRT APIs from old XCL APIs.

Specifically requested to support an IVAS framework where buffers are
allocated using old style APIs but kernel APIs are used for execution.

By allowing construction of xrt::bo from xclBufferHandle, the xrt::bo
can be used as an xrt::kernel argument.

The C++ and C API addition have been tested with XRT/tests/xrt/22_verify/xcl.cpp.