### PR TITLE
Backport driver fix - Fix driver compilation for 5.11 kernel (#5867)

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -178,8 +178,15 @@ int xocl_sync_bo_callback_ioctl(struct drm_device *dev, void *data,
 struct sg_table *xocl_gem_prime_get_sg_table(struct drm_gem_object *obj);
 struct drm_gem_object *xocl_gem_prime_import_sg_table(struct drm_device *dev,
 	struct dma_buf_attachment *attach, struct sg_table *sgt);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 void *xocl_gem_prime_vmap(struct drm_gem_object *obj);
 void xocl_gem_prime_vunmap(struct drm_gem_object *obj, void *vaddr);
+#else
+int xocl_gem_prime_vmap(struct drm_gem_object *obj, struct dma_buf_map *map);
+void xocl_gem_prime_vunmap(struct drm_gem_object *obj, struct dma_buf_map *map);
+#endif
+
 int xocl_gem_prime_mmap(struct drm_gem_object *obj, struct vm_area_struct *vma);
 int xocl_copy_import_bo(struct drm_device *dev, struct drm_file *filp,
 	struct ert_start_copybo_cmd *cmd);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -508,27 +508,32 @@ static struct drm_driver mm_drm_driver = {
 	.postclose			= xocl_client_release,
 	.open				= xocl_client_open,
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
-	.gem_free_object_unlocked       = xocl_free_object,
-#else
-	.gem_free_object		= xocl_free_object,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
+		.gem_free_object_unlocked       = xocl_free_object,
+	#else
+		.gem_free_object		= xocl_free_object,
+	#endif
 #endif
-	.gem_vm_ops			= &xocl_vm_ops,
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+        .gem_vm_ops                     = &xocl_vm_ops,
+        .gem_prime_get_sg_table         = xocl_gem_prime_get_sg_table,
+        .gem_prime_vmap                 = xocl_gem_prime_vmap,
+        .gem_prime_vunmap               = xocl_gem_prime_vunmap,
+        .gem_prime_export               = drm_gem_prime_export,
+#endif
 
 	.ioctls				= xocl_ioctls,
 	.num_ioctls			= (ARRAY_SIZE(xocl_ioctls)-NUM_KERNEL_IOCTLS),
 	.fops				= &xocl_driver_fops,
 
-	.gem_prime_get_sg_table		= xocl_gem_prime_get_sg_table,
 	.gem_prime_import_sg_table	= xocl_gem_prime_import_sg_table,
-	.gem_prime_vmap			= xocl_gem_prime_vmap,
-	.gem_prime_vunmap		= xocl_gem_prime_vunmap,
 	.gem_prime_mmap			= xocl_gem_prime_mmap,
 
 	.prime_handle_to_fd		= drm_gem_prime_handle_to_fd,
 	.prime_fd_to_handle		= drm_gem_prime_fd_to_handle,
 	.gem_prime_import		= drm_gem_prime_import,
-	.gem_prime_export		= drm_gem_prime_export,
 #if ((LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)) && (LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)))
 	.set_busid			= drm_pci_set_busid,
 #endif
@@ -536,6 +541,17 @@ static struct drm_driver mm_drm_driver = {
 	.desc				= XOCL_DRIVER_DESC,
 	.date				= driver_date,
 };
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+const struct drm_gem_object_funcs xocl_gem_object_funcs = {
+        .free = xocl_free_object,
+        .vm_ops = &xocl_vm_ops,
+        .get_sg_table = xocl_gem_prime_get_sg_table,
+        .vmap = xocl_gem_prime_vmap,
+        .vunmap = xocl_gem_prime_vunmap,
+        .export = drm_gem_prime_export,
+};
+#endif
 
 void *xocl_drm_init(xdev_handle_t xdev_hdl)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -148,4 +148,8 @@ int xocl_init_unmgd(struct drm_xocl_unmgd *unmgd, uint64_t data_ptr,
 		        uint64_t size, u32 write);
 void xocl_finish_unmgd(struct drm_xocl_unmgd *unmgd);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+extern const struct drm_gem_object_funcs xocl_gem_object_funcs;
+#endif
+
 #endif


### PR DESCRIPTION
* Fix driver compilation for 5.11 kernel

> Backport changes from master (966b459c2273cf23a7e5c8f1d9f5e07bc0db52cb)
> Made changes to fix compilation issues of driver with 5.11 kernel version.
> In 5.11 kernel drm_driver structure is changed, added changes in drm framework accordingly.
> Features missing : p2p support changes are missing.
