### PR TITLE
CR-1111450 “xclExecBuf” cannot be executed correctly in 2021.2 XRT

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -414,7 +414,6 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		DRM_WARN("ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
 #if KERNEL_VERSION(5, 4, 0) > LINUX_VERSION_CODE
 		__attribute__ ((fallthrough));
 #else

--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -414,6 +414,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
+		DRM_WARN_ONCE("ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
 #if KERNEL_VERSION(5, 4, 0) > LINUX_VERSION_CODE
 		__attribute__ ((fallthrough));
 #else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -47,6 +47,15 @@
 	xocl_info(&XDEV(d)->pdev->dev, ##args)
 #define userpf_dbg(d, args...)                     \
 	xocl_dbg(&XDEV(d)->pdev->dev, ##args)
+#define userpf_info_once(d, args...)               \
+({                                                 \
+	 static bool __info_once __read_mostly;    \
+						   \
+	 if (!__info_once) {                       \
+		 __info_once = true;               \
+		 userpf_info(d, ##args);           \
+	 }                                         \
+ })
 
 #define xocl_get_root_dev(dev, root)		\
 	for (root = dev; root->bus && root->bus->self; root = root->bus->self)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -604,6 +604,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
+		userpf_info_once(xdev, "ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
 		/* PS ERT is not sync with host. Have to skip 6 data */
 		if (!xocl_ps_sched_on(xdev))
 			convert_exec_write2key_val(to_start_krnl_pkg(ecmd));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -604,8 +604,9 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		userpf_info(xdev, "ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
-		convert_exec_write2key_val(to_start_krnl_pkg(ecmd));
+		/* PS ERT is not sync with host. Have to skip 6 data */
+		if (!xocl_ps_sched_on(xdev))
+			convert_exec_write2key_val(to_start_krnl_pkg(ecmd));
 		start_krnl_kv_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_START_KEY_VAL:
@@ -1015,6 +1016,10 @@ static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 	regmap_size = kds_get_max_regmap_size(kds);
 	if (ecmd->slot_size < regmap_size + MAX_HEADER_SIZE)
 		ecmd->slot_size = regmap_size + MAX_HEADER_SIZE;
+
+	/* PS ERT required slot size to be power of 2 */
+	if (xocl_ps_sched_on(xdev))
+		ecmd->slot_size = round_up_to_next_power2(ecmd->slot_size);
 
 	if (ecmd->slot_size > MAX_CQ_SLOT_SIZE)
 		ecmd->slot_size = MAX_CQ_SLOT_SIZE;


### PR DESCRIPTION
1. PS ERT (zocl) is not sync with host code change. We have to skip first 6 data in EXEC_WRITE command
2. PS ERT is required command slot size to be power of 2. This is unexpected in before. Since we update PS ERT is not easy, we will round up the slot size to next power of 2 in KDS.