### PR TITLE
azure: parse xclbin and check if it is valid to sent to mgmt

### DIFF
--- a/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/azure/azure.h
@@ -134,6 +134,7 @@ private:
     void get_fpga_serialNo(std::string &fpgaSerialNo);
     void msleep(long msecs);
     int goingTimeout();
+    bool xclbin_section_hdr_present(const struct axlf *xclbin, enum axlf_section_kind kind);
 };
 
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -156,7 +156,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
       auto hdl = dev->get_device_handle();
       auto bdf = xrt_core::query::pcie_bdf::to_string(xrt_core::device_query<xrt_core::query::pcie_bdf>(dev));
       if (auto err = xclLoadXclBin(hdl,reinterpret_cast<const axlf*>(raw.data())))
-        throw xrt_core::error(err, "Could not program device" + bdf);
+        throw xrt_core::error(err, "Could not program device " + bdf);
 
       std::cout << "INFO: xbutil program succeeded on " << bdf << std::endl;
     }


### PR DESCRIPTION
Parse xclbin in the azure mpd plugin before sending it to mgmt and check if it is valid
xclbin to send.
If the xclbin has BITSTREAM section then it is either DCP xclbin or bit.xclbin (full bitstream), both
these xclbins are not valid to program.

So, adding a check in azure mpd plugin to verify the same.

https://dev.azure.com/AzureXilinx/XRT%20Collaboration/_workitems/edit/84/

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>