### PR TITLE
Fix version info for embedded deb package created using sbuild

### DIFF
--- a/build/build_edge_deb.sh
+++ b/build/build_edge_deb.sh
@@ -35,8 +35,8 @@ PROGRAM=`basename $0`
 
 # XRT Version variables
 XRT_MAJOR_VERSION=2
-XRT_MINOR_VERSION=11
-RELEASE_VERSION=202110
+XRT_MINOR_VERSION=13
+RELEASE_VERSION=202210
 
 # Pick XRT_VERSION_PATCH from Env variable
 if [ -z $XRT_VERSION_PATCH ]; then
@@ -83,7 +83,7 @@ XRT_DIR=`readlink -f $THIS_SCRIPT_DIR/../`
 DEBIAN=`readlink -f $THIS_SCRIPT_DIR/debian`
 
 if [ -z $AARCH ]; then
-    error "$AARCH is required option"
+    error "-aarch is required option"
 fi
 
 if [[ $AARCH == "aarch64" ]]; then
@@ -120,15 +120,21 @@ cd $DEBIAN_ARTIFACTS
 rsync -r $XRT_DIR/* $DEBIAN_ARTIFACTS --exclude=build
 
 #creating source code tarball for sbuild
-tar -cvf $THIS_SCRIPT_DIR/$BUILD_FOLDER/xrt_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}.orig.tar .
-xz -z $THIS_SCRIPT_DIR/$BUILD_FOLDER/xrt_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}.orig.tar
+tar -cvf $THIS_SCRIPT_DIR/$BUILD_FOLDER/xrt_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}.orig.tar .
+xz -z $THIS_SCRIPT_DIR/$BUILD_FOLDER/xrt_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}.orig.tar
 cp -rf $DEBIAN $DEBIAN_ARTIFACTS
 
 # changing XRT package version number
 sed -i "1d" $DEBIAN_ARTIFACTS/debian/changelog
-sed -i "1s/^/xrt (${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}-0ubuntu2) experimental;urgency=medium\n/" $DEBIAN_ARTIFACTS/debian/changelog
+sed -i "1s/^/xrt (${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}) experimental;urgency=medium\n/" $DEBIAN_ARTIFACTS/debian/changelog
 
 time sbuild --no-run-lintian -d focal --arch=arm64 -c $SYSROOT -s
+
+cd $THIS_SCRIPT_DIR/$BUILD_FOLDER
+# rename the packages created for consistency
+mv xrt-embedded_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.deb xrt_embedded_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_20.04-arm64.deb
+mv xrt-zocl-dkms_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.deb xrt_zocl_dkms_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_20.04-arm64.deb
+mv xrt-embedded-dbgsym_${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_arm64.ddeb xrt_embedded_dbgsym_${RELEASE_VERSION}.${XRT_MAJOR_VERSION}.${XRT_MINOR_VERSION}.${XRT_VERSION_PATCH}_20.04-arm64.ddeb
 
 eval "$SAVED_OPTIONS"; # Restore shell options
 echo "** COMPLETE [${BASH_SOURCE[0]}] **"


### PR DESCRIPTION
> version of deb embedded package is shown as 202210.2.13.0, fixed it to show proper version 2.13.0
> renamed package names for consistency
> package names that are created are :  **xrt_embedded_202210.2.13.0_20.04-arm64.deb**, **xrt_zocl_dkms_202210.2.13.0_20.04-arm64.deb**, **xrt_embedded_dbgsym_202210.2.13.0_20.04-arm64.ddeb**
> dpkg --info xrt_embedded_202210.2.13.0_20.04-arm64.deb
new Debian package, version 2.0.
 size 2599988 bytes: control archive=3064 bytes.
     571 bytes,    14 lines      control              
    5893 bytes,    86 lines      md5sums              
     362 bytes,     9 lines      shlibs               
      73 bytes,     2 lines      triggers             
 Package: xrt-embedded
 Source: xrt
 **Version: 2.13.0**
 Architecture: arm64
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Installed-Size: 21060
 Depends: libboost-filesystem1.71.0, libboost-program-options1.71.0, libc6 (>= 2.29), libgcc-s1 (>= 3.0), libprotobuf17, libstdc++6 (>= 9), libuuid1 (>= 2.16)
 Section: libdevel
 Priority: optional
 Description: Xilinx Runtime (XRT) - runtime libraries
  The Xilinx Runtime (XRT) provides acceleration across PCIe and MPSoC
  based Xilinx platforms.
  .
  This package contains the XRT libraries, headers, and tools.
