### PR TITLE
CR-1112403: Reenable loading of HAL-level profile plugins

### DIFF
--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.cpp
@@ -79,14 +79,17 @@ std::function<void (bool, bool, const char*, unsigned long long int,
                                                   error_function) ;
   }
 
-static bool hal_plugins_loaded = false ;
-
-  api_call_logger::api_call_logger(const char* function)
-    : m_id(0), m_fullname(function)
+  bool loader::hal_plugins_loaded = false ;
+  loader::loader()
   {
     if (hal_plugins_loaded) return ;
     hal_plugins_loaded = true ;
     xdp::hal_hw_plugins::load() ;
+  }
+
+  api_call_logger::api_call_logger(const char* function)
+    : m_id(0), m_fullname(function)
+  {
   }
 
   generic_api_call_logger::generic_api_call_logger(const char* function)

--- a/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.h
+++ b/src/runtime_src/core/edge/user/plugin/xdp/hal_profile.h
@@ -25,6 +25,15 @@
 namespace xdp {
 namespace hal {
 
+class loader
+{
+ private:
+  static bool hal_plugins_loaded ;
+ public:
+  loader() ;
+  ~loader() = default ;
+} ;
+
 class api_call_logger
 {
  protected:
@@ -55,6 +64,7 @@ auto
 profiling_wrapper(const char* function, Callable&& f, Args&&...args)
 {
 #ifndef __HWEM__
+  loader load_object ;
   if (xrt_core::config::get_xrt_trace()) {
     generic_api_call_logger log_object(function) ;
     return f(std::forward<Args>(args)...) ;
@@ -88,6 +98,7 @@ buffer_transfer_profiling_wrapper(const char* function, size_t size,
                                   bool isWrite, Callable&& f, Args&&...args)
 {
 #ifndef __HWEM__
+  loader load_object ;
   if (xrt_core::config::get_xrt_trace()) {
     buffer_transfer_logger log_object(function, size, isWrite) ;
     return f(std::forward<Args>(args)...) ;

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.cpp
@@ -79,14 +79,17 @@ std::function<void (bool, bool, const char*, unsigned long long int,
                                                   error_function) ;
   }
 
-static bool hal_plugins_loaded = false ;
-
-  api_call_logger::api_call_logger(const char* function)
-    : m_id(0), m_fullname(function)
+  bool loader::hal_plugins_loaded = false ;
+  loader::loader()
   {
     if (hal_plugins_loaded) return ;
     hal_plugins_loaded = true ;
     xdp::hal_hw_plugins::load() ;
+  }
+
+  api_call_logger::api_call_logger(const char* function)
+    : m_id(0), m_fullname(function)
+  {
   }
 
   generic_api_call_logger::generic_api_call_logger(const char* function)

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.h
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/hal_profile.h
@@ -25,6 +25,15 @@
 namespace xdp {
 namespace hal {
 
+class loader
+{
+ private:
+  static bool hal_plugins_loaded ;
+ public:
+  loader() ;
+  ~loader() = default ;
+} ;
+
 class api_call_logger
 {
  protected:
@@ -54,6 +63,7 @@ template <typename Callable, typename ...Args>
 auto
 profiling_wrapper(const char* function, Callable&& f, Args&&...args)
 {
+  loader load_object ;
   if (xrt_core::config::get_xrt_trace()) {
     generic_api_call_logger log_object(function) ;
     return f(std::forward<Args>(args)...) ;
@@ -85,6 +95,7 @@ auto
 buffer_transfer_profiling_wrapper(const char* function, size_t size,
                                   bool isWrite, Callable&& f, Args&&...args)
 {
+  loader load_object ;
   if (xrt_core::config::get_xrt_trace()) {
     buffer_transfer_logger log_object(function, size, isWrite) ;
     return f(std::forward<Args>(args)...) ;


### PR DESCRIPTION
Add hooks in profiling to load all of the HAL level plugins, regardless of the xrt_trace ini setting.  This restores the functionality from before the refactoring.