### PR TITLE
CR-1111450 “xclExecBuf” cannot be executed correctly in 2021.2 XRT

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -414,7 +414,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		start_krnl_ecmd2xcmd(to_start_krnl_pkg(ecmd), xcmd);
 		break;
 	case ERT_EXEC_WRITE:
-		DRM_WARN("ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
+		DRM_WARN_ONCE("ERT_EXEC_WRITE is obsoleted, use ERT_START_KEY_VAL\n");
 #if KERNEL_VERSION(5, 4, 0) > LINUX_VERSION_CODE
 		__attribute__ ((fallthrough));
 #else

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -47,6 +47,15 @@
 	xocl_info(&XDEV(d)->pdev->dev, ##args)
 #define userpf_dbg(d, args...)                     \
 	xocl_dbg(&XDEV(d)->pdev->dev, ##args)
+#define userpf_info_once(d, args...)               \
+({                                                 \
+	 static bool __info_once __read_mostly;    \
+						   \
+	 if (!__info_once) {                       \
+		 __info_once = true;               \
+		 userpf_info(d, ##args);           \
+	 }                                         \
+ })
 
 #define xocl_get_root_dev(dev, root)		\
 	for (root = dev; root->bus && root->bus->self; root = root->bus->self)


### PR DESCRIPTION
(cherry picked from commit d25ba77)