### PR TITLE
CR-1112584 : Fix issue while single process tries to use multiple xclbin files

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -846,10 +846,14 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			  */
 			if (kds_mode == 1 && (zocl_xclbin_get_uuid(zdev) != NULL)) {
 				subdev_destroy_cu(zdev);
-				if (zdev->aie) {
-					zocl_aie_reset(zdev);
-					zocl_destroy_aie(zdev);
+				if (zdev->aie && !zdev->aie->aie_reset) {
+					ret = zocl_aie_reset(zdev);
+					if (ret) {
+						DRM_ERROR("AIE Reset Failed");
+						goto out0;
+					}
 				}
+				zocl_destroy_aie(zdev);
 			}
 			/*
 			 * Make sure we load PL bitstream first,

--- a/src/runtime_src/core/edge/user/aie/aied.cpp
+++ b/src/runtime_src/core/edge/user/aie/aied.cpp
@@ -95,6 +95,12 @@ Aied::registerGraph(const graph_type *graph)
   mGraphs.push_back(graph);
 }
 
+bool
+Aied::isregisterGraph()
+{
+  return mGraphs.empty();
+}
+
 void
 Aied::deregisterGraph(const graph_type *graph)
 {

--- a/src/runtime_src/core/edge/user/aie/aied.h
+++ b/src/runtime_src/core/edge/user/aie/aied.h
@@ -39,6 +39,7 @@ public:
   ~Aied();
   void registerGraph(const graph_type *graph);
   void deregisterGraph(const graph_type *graph);
+  bool isregisterGraph();
 
 private:
   bool done;

--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -101,6 +101,7 @@ graph_type::
     }
     drv->closeGraphContext(id);
     drv->getAied()->deregisterGraph(this);
+    drv->deregisterAieArray();
 #endif
 }
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1463,9 +1463,16 @@ void
 shim::
 registerAieArray()
 {
-  delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
   aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
+}
+
+void
+shim::
+deregisterAieArray()
+{
+  delete aieArray.release();
+  delete aied.release();
 }
 
 bool

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1463,6 +1463,7 @@ void
 shim::
 registerAieArray()
 {
+  delete aieArray.release();
   aieArray = std::make_unique<zynqaie::Aie>(mCoreDevice);
   aied = std::make_unique<zynqaie::Aied>(mCoreDevice.get());
 }
@@ -1471,8 +1472,11 @@ void
 shim::
 deregisterAieArray()
 {
-  delete aieArray.release();
-  delete aied.release();
+  if (isAieRegistered())
+    delete aieArray.release();
+
+  if (aied->isregisterGraph())
+    delete aied.release();
 }
 
 bool

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -139,6 +139,7 @@ public:
   zynqaie::Aied* getAied();
   int getBOInfo(drm_zocl_info_bo &info);
   void registerAieArray();
+  void deregisterAieArray();
   bool isAieRegistered();
   int getPartitionFd(drm_zocl_aie_fd &aiefd);
   int resetAIEArray(drm_zocl_aie_reset &reset);


### PR DESCRIPTION
**Issue :** 
CR-1112584 : on vck190 dfx platform, kernel panic happens at the second AIE xclbin download when a single process tries to use multiple xclbin files
[https://jira.xilinx.com/browse/CR-1112584](url)

**Root Cause :** 
While loading the second xclbin, we are not resetting the AIE and AIE Daemon.
Without reset the AIE if we run another test it will not work. Hence either user application has to initiate a AIE Reset or XRT has to do that.

**Solution :** 
1. User application has to call deviceHandle.reset_array(); after a test to use same device for the xecond xclbin
2. XRT has to stop aie daemon before load second xclbin. 
3. XRT has to reset AIE device if user didn't do that. 

**Test :** 
With the above changes the tests mentioned in the CR are working fine; 
