### PR TITLE
CR-1112584: Fixing vck190 DFx issue where multiple xclbins loaded from same App (#5895)

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -560,6 +560,13 @@ get_enable_pr()
 }
 
 inline bool
+get_enable_aied()
+{
+  static bool value = detail::get_bool_value("Runtime.enable_aied",true);
+  return value;
+}
+
+inline bool
 get_multiprocess()
 {
   static bool value = get_kds() && detail::get_bool_value("Runtime.multiprocess",true);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -847,7 +847,15 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 			if (kds_mode == 1 && (zocl_xclbin_get_uuid(zdev) != NULL)) {
 				subdev_destroy_cu(zdev);
 				if (zdev->aie) {
-					zocl_aie_reset(zdev);
+					/*
+					 * Dont reset if aie is already in reset
+					 * state
+					 */
+					if( !zdev->aie->aie_reset) {
+						ret = zocl_aie_reset(zdev);
+						if (ret)
+							goto out0;
+					}
 					zocl_destroy_aie(zdev);
 				}
 			}

--- a/src/runtime_src/core/edge/user/aie/aied.cpp
+++ b/src/runtime_src/core/edge/user/aie/aied.cpp
@@ -24,6 +24,7 @@
 #include "aied.h"
 #include "core/edge/include/zynq_ioctl.h"
 #include "core/edge/user/shim.h"
+#include "core/common/config_reader.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -54,10 +55,13 @@ Aied::pollAIE(void* arg)
 
   signal(SIGUSR1, signalHandler);
 
+  if (!xrt_core::config::get_enable_aied())
+    return NULL;
+
   /* Ever running thread */
   while (1) {
     /* Calling XRT interface to wait for commands */
-    if (drv->xclAIEGetCmd(&cmd) != 0) {
+    if (ai->mGraphs.empty() || drv->xclAIEGetCmd(&cmd) != 0) {
       /* break if destructor called */
       if (ai->done)
         return NULL;


### PR DESCRIPTION
(cherry picked from commit d0daf249f469db01650531cb9c285aea97c4bcab)

Issue:

1. Whenever same application is loading multiple xclbins, We have asked Application to call resetAieArray as XRT cannot reset AIE as it doesn't know whether current xclbin load would be successful or not. When Application is calling Aierest, then xclbin download failing by throwing an error about AIE reset multiple times.
2. AIED is trying to get some commands from zocl to fetch the AIE state which panics the kernel

Fix:

1. ZOCL is checking whether AIE is in reset state or not before calling AIE reset.
2. Added an INI option to completely disable AIED as changes in zocl would be risky at this time.

Verification:

1. Same app multiple xclbin downloads (AIE, PL, AIE+PL)
2. Different app multiple xclbin downloads (AIE, PL, AIE+PL)

Doc Update:

1. No need to document this option is VCK190_DFx is EA in this release

Reviewers: Soren/Saif
Approved by: Sumit