### PR TITLE
CID 240262 Logically dead code

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
@@ -312,7 +312,7 @@ command_queue_check_csr(struct command_queue *cmd_queue)
 
 			if (!mask)
 				break;
-			if (mask & 0x1 != 0x1)
+			if (!(mask & 0x1))
 				continue;
 			ecmd = cmd_queue->submit_queue[cmd_idx];
 			if (!ecmd) {


### PR DESCRIPTION
C Operator Precedence issue, the operator != has higher precedence than the operator &, 
then it will be the variable mask does a Bitwise And with 0x0. 

To fix it, add parentheses around mask & 0x1