### PR TITLE
Shutdown mgmt pf before updating SC (#5910)

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -31,6 +31,10 @@ namespace XBU = XBUtilities;
 #include "core/common/message.h"
 #include "core/common/utils.h"
 #include "flash/flasher.h"
+// Remove linux specific code
+#ifdef __GNUC__
+#include "core/pcie/linux/scan.cpp"
+#endif
 
 // 3rd Party Library - Include Files
 #include <boost/format.hpp>
@@ -169,6 +173,18 @@ update_SC(unsigned int  index, const std::string& file)
     throw xrt_core::error(boost::str(boost::format("%d is an invalid index") % index));
 
   auto dev = xrt_core::get_mgmtpf_device(index);
+  
+  //if factory image, update SC
+  auto is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(dev);
+  if(is_mfg) {
+    std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file.c_str(), BMC_FIRMWARE);
+    if (bmc->fail())
+      throw xrt_core::error(boost::str(boost::format("Failed to read %s") % file));
+
+    if (flasher.upgradeBMCFirmware(bmc.get()) != 0)
+      throw xrt_core::error("Failed to update SC flash image");
+    return;
+  }
 
   // If SC is fixed, stop flashing immediately
   if (is_SC_fixed(index)) 
@@ -191,6 +207,16 @@ update_SC(unsigned int  index, const std::string& file)
     return;
   }
 
+// To be replaced with a cleaner fix
+// Mgmt pf needs to shutdown so that the board doesn't brick
+// Hack: added linux specific code to shutdown mgmt pf
+#ifdef __GNUC__
+  auto mgmt_dev = pcidev::get_dev(index, false);
+  auto peer_dev = mgmt_dev->lookup_peer_dev();
+  if (pcidev::shutdown(mgmt_dev))
+    throw xrt_core::error("Only proceed with SC update if all user applications for the target card(s) are stopped.");
+#endif
+
   std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file.c_str(), BMC_FIRMWARE);
 
   if (bmc->fail())
@@ -198,6 +224,28 @@ update_SC(unsigned int  index, const std::string& file)
 
   if (flasher.upgradeBMCFirmware(bmc.get()) != 0)
     throw xrt_core::error("Failed to update SC flash image");
+
+// To be replaced with a cleaner fix
+// Hack: added linux specific code to bring back mgmt pf
+#ifdef __GNUC__
+  std::string errmsg;
+  peer_dev->sysfs_put("", "shutdown", errmsg, "0\n");
+  if (!errmsg.empty())
+    throw xrt_core::error("Userpf is not online. Please warm reboot.");
+  
+  const static int dev_timeout = 60;
+  int wait = 0;
+  do {
+    auto hdl = peer_dev->open("", O_RDWR);
+    if (hdl != -1) {
+      peer_dev->close(hdl);
+      break;
+    }
+    sleep(1);
+  } while (++wait < dev_timeout);
+  if (wait == dev_timeout)
+    throw xrt_core::error("User function is not back online. Please warm reboot.");
+#endif 
 }
 
 /* 


### PR DESCRIPTION
_**Issue:**_ 
CR-1112544 ASTeR 17.01 - u55c/n - flashing can fail from the factory SC FW to the latest (7.1.14) if an xclbin is loaded

**_Issue solved:_**
New xbmgmt doesn't issue a hot reset which can brick the board in some scenarios. Eg: when 2 boards are flashed simultaneously 

**_Temporary solution:_**
Added linux specific code to reset mgmt pf. A full-blown OS-agnostic solution would require more time and architectural changes which we can't afford given we are nearing the release. (We have a CR tracking the bigger effort)

**_Tests:_**
1. Check dmesg for reset
```
...
[  +0.279017] xocl 0000:b3:00.1:  ffff96eb6b5700b0 xocl_hot_reset: resetting device...
...
[  +0.000012] xclmgmt 0000:b3:00.0: xclmgmt_reset_pci: Reset PCI
...
```
2. Remove userpf and make sure that sc flash gives an error
```
...
----------------------------------------------------
Report

Device flashing encountered errors:
ERROR: Only proceed with SC update if all user applications for the target card(s) are stopped.: Invalid argument
```


* shutdown mgmt pf before updating SC
* hot reset before updating SC

(cherry picked from commit 21f7ee18d10f5f6b1319383d6643d645d7d654b2)