### PR TITLE
Vitis-3342 Merge PS kernel execution with xrt::kernel

### DIFF
--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -20,9 +20,14 @@
 
 // This file defines implementation extensions to the XRT XCLBIN APIs.
 #include "core/include/experimental/xrt_xclbin.h"
+#include "core/common/xclbin_parser.h"
 
-namespace xrt_core {
-namespace xclbin_int {
+#include <set>
+
+// Provide access to xrt::xclbin data that is not directly exposed
+// to end users via xrt::xclbin.   These functions are used by
+// XRT core implementation.
+namespace xrt_core { namespace xclbin_int {
 
 // is_valid_or_error() - Throw if invalid handle
 void
@@ -48,7 +53,27 @@ get_axlf_sections(const xrt::xclbin& xclbin, axlf_section_kind kind);
 std::vector<char>
 read_xclbin(const std::string& fnm);
 
-} //xclbin_int
-}; // xrt_core
+// get_properties() - Get kernel properties
+const xrt_core::xclbin::kernel_properties&
+get_properties(const xrt::xclbin::kernel& kernel);
+
+// get_arginfo() - Get xclbin kernel argument metadata
+// Sorted by arg index, but appended with rtinfo args (if any)
+// which have no index
+const std::vector<xrt_core::xclbin::kernel_argument>&
+get_arginfo(const xrt::xclbin::kernel& kernel);
+
+// get_ip_idx() - Get the ip_layout index of a ip in the xclbin
+// This is used to cross-correlated to connectivity information
+// To be rooted out after refactoring completes
+unsigned int
+get_ip_idx(const xrt::xclbin::ip& ip);
+
+// get_ip_data() - Get the ip_data element of an ip in the xclbin
+// To be rooted out after refactoring completes
+const ip_data*
+get_ip_data(const xrt::xclbin::ip& ip);
+
+}} // xclbin_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -21,8 +21,10 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "core/include/experimental/xrt_kernel.h"
 #include "core/include/experimental/xrt_mailbox.h"
+#include "core/include/experimental/xrt_xclbin.h"
 #include "native_profile.h"
 #include "kernel_int.h"
+#include "xclbin_int.h"
 
 #include "command.h"
 #include "exec.h"
@@ -1048,8 +1050,12 @@ private:
     }
   };
 
+  // Kernel argument meta data is copied from xrt::xclbin
+  // but should consider using it directly from xrt::xclbin
+  // as its lifetime exceed that of xrt::kernel (ensured by
+  // shared xrt::xclbin ownership in kernel object).
   using xarg = xrt_core::xclbin::kernel_argument;
-  xarg arg;         // argument meta data from xclbin
+  xarg arg; // argument meta data from xclbin
 
   std::unique_ptr<iarg> content;
 
@@ -1065,8 +1071,8 @@ public:
   {}
 
   explicit
-  argument(xarg&& karg)
-    : arg(std::move(karg))
+  argument(const xarg& karg)
+    : arg(karg)
   {
     // Determine type
     switch (arg.type) {
@@ -1202,13 +1208,15 @@ class kernel_impl
   using property_type = xrt_core::xclbin::kernel_properties;
   using mailbox_type = property_type::mailbox_type;
 
-  std::shared_ptr<device_type> device; // shared ownership
   std::string name;                    // kernel name
+  std::shared_ptr<device_type> device; // shared ownership
+  xrt::xclbin xclbin;                  // xclbin with this kernel
+  xrt::xclbin::kernel xkernel;         // kernel xclbin metadata
   std::vector<argument> args;          // kernel args sorted by argument index
   std::vector<ipctx> ipctxs;           // CU context locks
+  const property_type& properties;     // Kernel properties from XML meta
   ipctx vctx;                          // virtual CU context
   std::bitset<max_cus> cumask;         // cumask for command execution
-  property_type properties;            // Kernel properties from XML meta
   size_t regmap_size = 0;              // CU register map size
   size_t fa_num_inputs = 0;            // Fast adapter number of inputs per meta data
   size_t fa_num_outputs = 0;           // Fast adapter number of outputs per meta data
@@ -1296,22 +1304,22 @@ class kernel_impl
   }
 
   IP_CONTROL
-  get_ip_control(const std::vector<const ip_data*>& ips)
+  get_ip_control(const std::vector<xrt::xclbin::ip>& ips)
   {
     if (ips.empty())
       return AP_CTRL_NONE;
 
-    auto ctrl = ::get_ip_control(ips[0]);
+    auto ctrl = ips[0].get_control_type();
     for (size_t idx = 1; idx < ips.size(); ++idx) {
-      auto ctrlatidx = ::get_ip_control(ips[idx]);
+      auto ctrlatidx = ips[idx].get_control_type();
       if (ctrlatidx == ctrl)
         continue;
-      if (ctrlatidx != AP_CTRL_CHAIN && ctrlatidx != AP_CTRL_HS)
+      if (ctrlatidx != xrt::xclbin::ip::control_type::chain && ctrlatidx != xrt::xclbin::ip::control_type::hs)
         throw std::runtime_error("CU control protocol mismatch");
-      ctrl = AP_CTRL_HS; // mix of CHAIN and HS is recorded as AP_CTRL_HS
+      ctrl = xrt::xclbin::ip::control_type::hs; // mix of CHAIN and HS is recorded as AP_CTRL_HS
     }
 
-    return ctrl;
+    return static_cast<IP_CONTROL>(ctrl);
   }
 
   void
@@ -1342,6 +1350,15 @@ class kernel_impl
     return count++;
   }
 
+  static xrt::xclbin::kernel
+  get_kernel_or_error(const xrt::xclbin& xclbin, const std::string& nm)
+  {
+    if (auto krnl = xclbin.get_kernel(nm))
+      return krnl;
+
+    throw xrt_core::error("No such kernel '" + nm + "'");
+  }
+
 public:
   // kernel_type - constructor
   //
@@ -1350,26 +1367,15 @@ public:
   // @nm:      name identifying kernel and/or kernel and instances
   // @am:      access mode for underlying compute units
   kernel_impl(std::shared_ptr<device_type> dev, const xrt::uuid& xclbin_id, const std::string& nm, ip_context::access_mode am)
-    : device(std::move(dev))                                   // share ownership
-    , name(nm.substr(0,nm.find(":")))                          // filter instance names
+    : name(nm.substr(0,nm.find(":")))                          // filter instance names
+    , device(std::move(dev))                                   // share ownership
+    , xclbin(device->core_device->get_xclbin(xclbin_id))       // xclbin with kernel
+    , xkernel(get_kernel_or_error(xclbin, name))               // kernel meta data managed by xclbin
+    , properties(xrt_core::xclbin_int::get_properties(xkernel))// cache kernel properties
     , vctx(ip_context::open_virtual_cu(device->core_device.get(), xclbin_id))
     , uid(create_uid())
   {
     XRT_DEBUGF("kernel_impl::kernel_impl(%d)\n" , uid);
-
-    // ip_layout section for collecting CUs
-    auto ip_section = device->core_device->get_axlf_section(IP_LAYOUT, xclbin_id);
-    if (!ip_section.first)
-      throw std::runtime_error("No ip layout available to construct kernel, make sure xclbin is loaded");
-    auto ip_layout = reinterpret_cast<const ::ip_layout*>(ip_section.first);
-
-    // xml section for kernel arguments
-    auto xml_section = device->core_device->get_axlf_section(EMBEDDED_METADATA, xclbin_id);
-    if (!xml_section.first)
-      throw std::runtime_error("No xml metadata available to construct kernel, make sure xclbin is loaded");
-
-    // initialize kernel properties from xml meta data
-    properties = xrt_core::xclbin::get_kernel_properties(xml_section.first, xml_section.second, name);
 
     // mailbox kernels opens CU in exclusive mode for direct read/write access
     if (properties.mailbox != mailbox_type::none || properties.counted_auto_restart > 0) {
@@ -1378,32 +1384,34 @@ public:
     }
 
     // Compare the matching CUs against the CU sort order to create cumask
-    auto kernel_cus = xrt_core::xclbin::get_cus(ip_layout, nm);
+    const auto& kernel_cus = xkernel.get_cus(nm);  // xrt::xclbin::ip objects for matching kernel CUs
     if (kernel_cus.empty())
       throw std::runtime_error("No compute units matching '" + nm + "'");
 
-    const auto& all_cus = device->core_device->get_cus(xclbin_id);  // sort order
-    for (const ip_data* cu : kernel_cus) {
-      if (::get_ip_control(cu) == AP_CTRL_NONE)
+    const auto& all_cus = device->core_device->get_cus(xclbin_id); // sort order
+    for (const auto& cu : kernel_cus) {
+      if (cu.get_control_type() == xrt::xclbin::ip::control_type::none)
         throw xrt_core::error(ENOTSUP, "AP_CTRL_NONE is only supported by XRT native API xrt::ip");
-      auto itr = std::find(all_cus.begin(), all_cus.end(), cu->m_base_address);
+
+      auto itr = std::find(all_cus.begin(), all_cus.end(), cu.get_base_address());
       if (itr == all_cus.end())
         throw std::runtime_error("unexpected error");
-      auto cuidx = std::distance(all_cus.begin(), itr);         // sort order index
-      auto ipidx = std::distance(ip_layout->m_ip_data, cu); // ip_layout index
-      ipctxs.emplace_back(ip_context::open(device->get_core_device(), xclbin_id, properties.address_range, cu, ipidx, cuidx, am));
+      auto cuidx = std::distance(all_cus.begin(), itr);     // sort order index
+      auto ipidx = xrt_core::xclbin_int::get_ip_idx(cu);    // ip_layout index
+      auto ipdata = xrt_core::xclbin_int::get_ip_data(cu);  // ::ip_data* 
+      ipctxs.emplace_back(ip_context::open(device->get_core_device(), xclbin_id, properties.address_range, ipdata, ipidx, cuidx, am));
       cumask.set(cuidx);
       num_cumasks = std::max<size_t>(num_cumasks, (cuidx / cus_per_word) + 1);
     }
-
+    
     // set kernel protocol
     protocol = get_ip_control(kernel_cus);
 
-    // get kernel arguments from xml parser
+    // get kernel arguments from xclbin kernel meta data
     // compute regmap size, convert to typed argument
-    for (auto& arg : xrt_core::xclbin::get_kernel_arguments(xml_section.first, xml_section.second, name)) {
+    for (auto& arg : xrt_core::xclbin_int::get_arginfo(xkernel)) {
       regmap_size = std::max(regmap_size, (arg.offset + arg.size) / sizeof(uint32_t));
-      args.emplace_back(std::move(arg));
+      args.emplace_back(arg);
     }
 
     // amend args with computed data based on kernel protocol

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -213,6 +213,16 @@ load_xclbin(const uuid& xclbin_id)
 #endif
 }
 
+xrt::xclbin
+device::
+get_xclbin(const uuid& xclbin_id)
+{
+  if (xclbin_id && xclbin_id != m_xclbin.get_uuid())
+    throw error(EINVAL, "xclbin id mismatch");
+
+  return m_xclbin;
+}
+
 // This function is called after an axlf has been succesfully loaded
 // by the shim layer API xclLoadXclBin().  Since xclLoadXclBin() can
 // be called explicitly by end-user code, the callback is necessary in

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -204,6 +204,13 @@ public:
   void
   load_xclbin(const uuid& xclbin_id);
 
+
+  // Get the currently loaded xclbin
+  // Throws if xclbin uuid does match
+  XRT_CORE_COMMON_EXPORT
+  xrt::xclbin
+  get_xclbin(const uuid& xclbin_id);
+
   /**
    * register_axlf() - Callback from shim after AXLF succesfully loaded
    *

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -777,7 +777,7 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
     if (!sw_reset)
       sw_reset = get_sw_reset_from_ini(kname);
 
-    return kernel_properties{kname, restart, mailbox, address_range, sw_reset};
+    return kernel_properties{kname, kernel_properties::kernel_type::pl, restart, mailbox, address_range, sw_reset};
   }
 
   return kernel_properties{};

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -50,9 +50,11 @@ struct kernel_argument
 
 struct kernel_properties
 {
+  enum class kernel_type { none, pl, ps };
   enum class mailbox_type { none, in , out, inout };
   using restart_type = size_t;
   std::string name;
+  kernel_type type = kernel_type::none;
   restart_type counted_auto_restart = 0;
   mailbox_type mailbox = mailbox_type::none;
   size_t address_range = 0;

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -294,6 +294,15 @@ public:
   class ip : public detail::pimpl<ip_impl>
   {
   public:
+    /**
+     * @enum control_type - 
+     *
+     * @details
+     * See `xclbin.h`
+     */
+    enum class control_type : uint8_t { hs = 0, chain = 1, none = 2, fa = 5 };
+
+  public:
     ip() = default;
 
     explicit
@@ -310,6 +319,16 @@ public:
     XCL_DRIVER_DLLESPEC
     std::string
     get_name() const;
+
+    /**
+     * get_control_type() - Get the IP control protocol
+     *
+     * @return
+     *  Control type
+     */
+    XCL_DRIVER_DLLESPEC
+    control_type
+    get_control_type() const;
 
     /**
      * get_num_args() - Number of arguments
@@ -399,6 +418,22 @@ public:
     XCL_DRIVER_DLLESPEC
     std::vector<ip>
     get_cus() const;
+
+    /**
+     * get_cus() - Get list of compute units that matches name
+     *
+     * @param name
+     *  Name to match against, prefixed with kernel name
+     * @return
+     *  A list of xrt::xclbin::ip objects that are compute units
+     *  of this kernel object and matches the specified name.
+     *
+     * The kernel name can optionally specify which kernel instance(s) to
+     * match "kernel:{cu1,cu2,...} syntax.
+     */
+    XCL_DRIVER_DLLESPEC
+    std::vector<ip>
+    get_cus(const std::string& kname) const;
 
     /**
      * get_cu() - Get compute unit by name


### PR DESCRIPTION
This is WIP to abstract xrt::kernel dependencies on xclbin
metadata. Dependencies on axlf are moved to xrt::xclbin where
implementation can differentiate / extract data from whatever format
makes up the xclbin.

In this PR a few explicit axlf dependencies within xrt::kernel
implementation were eliminated.

This a medium risk change. Iteration of certain axlf meta data
elements are now iteration of xrt::xclbin abstractions. Prior to this
PR, the abstractions were never use by XRT core implementation, they
were used only by host applications that made use of xrt::xclbin for
introspection.  As such there could be corner cases where parsing per
xrt::xclbin expections could fail.

The PR has been tested through standard HW regression testing mostly
covering OpenCL use cases, which of course exercises all the native
code that was changed.

No documentation impact, as there are no visible end-user changes.