### PR TITLE
Fix for OpenCL sub-device kernel execution

### DIFF
--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -63,6 +63,13 @@ XRT_CORE_COMMON_EXPORT
 xrt::run
 clone(const xrt::run& run);
 
+// This API is provide to allow implementations such as OpenCL
+// to dictate what kernel CUs to use.  For example sub-device
+// may restrict CUs.
+XRT_CORE_COMMON_EXPORT
+void
+set_cus(xrt::run& run, const std::bitset<128>& mask);
+
 XRT_CORE_COMMON_EXPORT
 const std::bitset<128>&
 get_cumask(const xrt::run& run);


### PR DESCRIPTION
Fix 108_4cu_4ddr_agnostic testcase that uses single shared kernel
object with multiple sub-devices, where each sub-device has
incompatible CU (different connectivity).

The CUs in the shared kernel object are trimmed according to
connectivity of CU used by first device.  When second device is used,
the kernel object has no CUs meeting the expected connectivity.

The test is fixed to create a new kernel object for each execution
(really for each sub-device).  The kernel created for a sub-device is
limitted to the CUs available to the sub-devices, this in turn ensures
equal distribution of kernel workloads between the different CUs on
the different sub-devices.

Risk is minimum, new code was added to filter the CUs when kernels are
constructed.

Testing is done via normal HW OpenCL regression suite.

No user-visible changes.