### PR TITLE
CR-1111644 ASTeR TC 7.01+7.08+19.15 - u55n/x3 - validate can fail with

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -118,6 +118,7 @@ struct xocl_board_private {
 	uint64_t		p2p_bar_sz;
 	const char		*vbnv;
 	const char		*sched_bin;
+	uint32_t		ert_intr_limit;
 };
 
 struct xocl_flash_privdata {
@@ -2813,7 +2814,8 @@ struct xocl_subdev_map {
 		.flags       = XOCL_DSAFLAG_DYNAMIC_IP,                 \
 		.board_name  = "x3522pv",                               \
 		.subdev_info = RES_USER_VSEC,                           \
-		.subdev_num  = ARRAY_SIZE(RES_USER_VSEC)                \
+		.subdev_num  = ARRAY_SIZE(RES_USER_VSEC),                \
+		.ert_intr_limit = 1						\
 	}
 
 #define XOCL_BOARD_X3522PV_MGMT_RAPTOR2                     \
@@ -2869,6 +2871,7 @@ struct xocl_subdev_map {
 		.board_name = "u55n",					\
 		.subdev_info	= RES_USER_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_USER_VSEC),		\
+		.ert_intr_limit = 1					\
 	}
 
 #define	XOCL_BOARD_U55N_MGMT_RAPTOR2					\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1799,6 +1799,7 @@ void xocl_fill_dsa_priv(xdev_handle_t xdev_hdl, struct xocl_board_private *in)
 	core->priv.flash_type = in->flash_type;
 	core->priv.board_name = in->board_name;
 	core->priv.p2p_bar_sz = in->p2p_bar_sz;
+	core->priv.ert_intr_limit = in->ert_intr_limit;
 	if (in->flags & XOCL_DSAFLAG_SET_DSA_VER)
 		core->priv.dsa_ver = in->dsa_ver;
 	if (in->flags & XOCL_DSAFLAG_SET_XPR)


### PR DESCRIPTION
Issue:
ASTeR TC 7.01+7.08+19.15 - u55n/x3 - validate can fail with "ERROR: unable to sync BO: Input/output error" which then causes every attempt after to hang

Issue solved:
XDMA interrupt misses if under pressure, happens on u55n platform

Solution:
Limit the slot number to 32 so only one ert interrupt will be generated