### PR TITLE
CID-240500 & CID-240501 Out-of-bounds write

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -242,14 +242,14 @@ struct xgq_sub_queue_entry {
  * All completion queue entries have a same fixed size of 4 words.
  */
 struct xgq_com_queue_entry {
-	struct xgq_cmd_cq_hdr hdr;
 	union {
 		struct {
+			struct xgq_cmd_cq_hdr hdr;
 			uint32_t result;
 			uint32_t resvd;
 			uint32_t rcode;
 		};
-		uint32_t data[3]; // NOLINT
+		uint32_t data[4]; // NOLINT
 	};
 };
 XGQ_STATIC_ASSERT(sizeof(struct xgq_com_queue_entry) == 16, "xgq_com_queue_entry structure no longer is 16 bytes in size");


### PR DESCRIPTION
#### Problem solved by the commit
CID-240500 and CID-240501.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR #5916 introduced the bug. Coverity report discovers it.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Define struct xgq_com_queue_entry in a proper way.

#### Risks (if any) associated the changes in the commit
Low risk.

#### What has been tested and how, request additional testing if necessary
xbutil validate on U50 shell. Need to try this change on versal PCIe platform.
