### PR TITLE
Vitis-3342 Merge PS kernel execution with xrt::kernel

### DIFF
--- a/src/runtime_src/core/common/api/kernel_int.h
+++ b/src/runtime_src/core/common/api/kernel_int.h
@@ -23,6 +23,7 @@
 
 #include "core/common/config.h"
 #include "core/common/xclbin_parser.h"
+#include "core/include/experimental/xrt_xclbin.h"
 
 #include <bitset>
 #include <cstdint>
@@ -81,7 +82,7 @@ get_num_cus(const xrt::run& run)
 }
 
 XRT_CORE_COMMON_EXPORT
-IP_CONTROL
+xrt::xclbin::ip::control_type
 get_control_protocol(const xrt::run& run);
 
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/xocl/core/execution_context.cpp
+++ b/src/runtime_src/xocl/core/execution_context.cpp
@@ -21,6 +21,7 @@
 
 #include "core/common/xclbin_parser.h"
 #include "core/common/api/kernel_int.h"
+#include "core/include/experimental/xrt_xclbin.h"
 
 #include <iostream>
 #include <fstream>
@@ -370,7 +371,7 @@ execute()
   // In order to keep scheduler busy, we need more than just one
   // workgroup at a time, so here we try to ensure that the scheduled
   // commands at any given time is twice the number of available CUs.
-  auto limit = (m_control == AP_CTRL_CHAIN) ? 20 * m_num_cus : 2 * m_num_cus;
+  auto limit = (m_control == xrt::xclbin::ip::control_type::chain) ? 20 * m_num_cus : 2 * m_num_cus;
   for (size_t i = m_active; !m_done && i < limit; ++i) {
     start();
     XRT_DEBUGF("active=%d\n",m_active);

--- a/src/runtime_src/xocl/core/execution_context.h
+++ b/src/runtime_src/xocl/core/execution_context.h
@@ -22,6 +22,8 @@
 #include "xocl/core/compute_unit.h"
 
 #include "core/include/xclbin.h"
+#include "core/include/experimental/xrt_xclbin.h"
+
 #include <mutex>
 #include <array>
 #include <algorithm>
@@ -85,7 +87,7 @@ private:
   size_t m_num_cus = 0;
 
   // Control protocol
-  IP_CONTROL m_control = IP_CONTROL(0);
+  xrt::xclbin::ip::control_type m_control = xrt::xclbin::ip::control_type::hs;
 
   // The kernel run object to be started and managed by this context
   xrt::run m_run;


### PR DESCRIPTION
#### Problem solved by the commit
Continuation of WIP from #5917, #5927.
Remove last axlf explicit dependency from xrt::kernel, in this case convert IP_CONTROL to abstracted type.

#### What has been tested and how, request additional testing if necessary
The PR has been tested through standard HW regression testing mostly
covering OpenCL use cases, which of course exercises all the native
code that was changed.