### PR TITLE
Vitis-3342 Merge PS kernel execution with xrt::kernel

### DIFF
--- a/src/runtime_src/core/common/api/pskernel/xrt_pskernel.cpp
+++ b/src/runtime_src/core/common/api/pskernel/xrt_pskernel.cpp
@@ -22,6 +22,7 @@
 #include "core/include/experimental/xrt_pskernel.h"
 #include "core/common/api/native_profile.h"
 #include "core/common/api/kernel_int.h"
+#include "core/common/api/xclbin_int.h"
 
 #include "core/common/api/command.h"
 #include "core/common/api/exec.h"
@@ -333,7 +334,8 @@ class psip_context
     // @ipidx: index of the ip for which connectivity data is created
     connectivity(const xrt_core::device* device, const xrt::uuid& xclbin_id, int32_t ipidx)
     {
-      const auto& memidx_encoding = device->get_memidx_encoding(xclbin_id);
+      auto xclbin = device->get_xclbin(xclbin_id);
+      const auto& memidx_encoding = xrt_core::xclbin_int::get_membank_encoding(xclbin);
       auto conn = device->get_axlf_section<const ::connectivity*>(ASK_GROUP_CONNECTIVITY, xclbin_id);
       if (!conn)
         return;

--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -63,6 +63,9 @@ get_properties(const xrt::xclbin::kernel& kernel);
 const std::vector<xrt_core::xclbin::kernel_argument>&
 get_arginfo(const xrt::xclbin::kernel& kernel);
 
+const std::vector<size_t>&
+get_membank_encoding(const xrt::xclbin& xclbin);
+
 }} // xclbin_int, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -424,7 +424,7 @@ class ip_context
     // @conn: connectivity section of xclbin
     connectivity(const xrt_core::device* device, const xrt::xclbin& xclbin, const xrt::xclbin::ip& ip)
     {
-      const auto& memidx_encoding = device->get_memidx_encoding(xclbin.get_uuid());
+      const auto& memidx_encoding = xrt_core::xclbin_int::get_membank_encoding(xclbin);
 
       // collect the memory connections for each IP argument
       for (const auto& arg : ip.get_args()) {

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -359,10 +359,11 @@ class xclbin_impl
 {
   // struct xclbin_info - on demand xclbin meta data access
   //
-  // Constructed first time data is needed, which in many cases it
-  // never is.  The class keeps xclbin::mem, xclbin::ip, and
-  // xclbin::kernel objects along with references into the xclbin
-  // data itself
+  // Constructed first time data is needed.  The class keeps
+  // xclbin::mem, xclbin::ip, and xclbin::kernel objects along with
+  // references into the xclbin data itself.
+  //
+  // Also adds some computed data that is used by XRT core implementation.
   struct xclbin_info
   {
     const xclbin_impl* m_ximpl;
@@ -370,60 +371,26 @@ class xclbin_impl
     std::vector<xclbin::ip> m_ips;
     std::vector<xclbin::kernel> m_kernels;
 
-    // kernel_cu_to_ip() - convert ::ip_data entry to xclbin::ip object
-    //
-    // Kernels are composed of compute units, which are represented as
-    // xclbin::ip objects.  In the xclbin, kernel compute units are
-    // collected from IP_LAYOUT through name matching.  Since
-    // IP_LAYOUT is processed before xclbin::kernels are created, the
-    // collected ip_data elements for the compute units already exist
-    // in m_ips.
-    //
-    // This function iterates m_ips to look for the xclbin::ip object
-    // corresponding to the ip_data element.  The lookup is O(n) which
-    // makes the overall algorithm for converting kernel CUs O(n^2)
-    // but efficiency doesn't matter here.
-    //
-    // Awkward handlng of address range, which is a property of the kernel.
-    xclbin::ip
-    kernel_cu_to_ip(const ::ip_data* cu, size_t address_range)
-    {
-      for (auto& ip : m_ips)
-        if (ip.get_name() == reinterpret_cast<const char*>(cu->m_name)) {
-          ip.get_handle()->set_size(address_range); // set kernel address range
-          return ip;
-        }
-      throw std::runtime_error("unexpected error, kernel cu doesn't exist");
-    }
-
-    // kernel_cus_to_ips() - convert list of ::ip_data to xclbin::ip objects
-    //
-    // Convert ip_data elements associated with kernel object into
-    // already constructed and cached xclbin::ip objects.  O(n^2) yes,
-    // but not important.
-    std::vector<xclbin::ip>
-    kernel_cus_to_ips(const std::vector<const ::ip_data*>& cus, size_t address_range)
-    {
-      std::vector<xclbin::ip> ips;
-      for (auto cu : cus)
-        ips.emplace_back(kernel_cu_to_ip(cu, address_range));
-      return ips;
-    }
+    // encoded / compressed memory connection used by
+    // xrt core to manage compute unit connectivity.
+    std::vector<size_t> m_membank_encoding;
 
     // init_mems() - populate m_mems with xrt::mem objects
     //
     // Iterate the GROUP_TOPOLOGY section in xclbin and create
     // xclbin::mem objects for each used mem_data entry.
-    void
-    init_mems()
+    static std::vector<xclbin::mem>
+    init_mems(const xclbin_impl* ximpl)
     {
-      if (auto mem_topology = m_ximpl->get_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY)) {
-        m_mems.reserve(mem_topology->m_count);
+      std::vector<xclbin::mem> mems;
+      if (auto mem_topology = ximpl->get_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY)) {
+        mems.reserve(mem_topology->m_count);
         for (int32_t idx = 0; idx < mem_topology->m_count; ++idx) {
-          m_mems.emplace_back
-            (std::make_shared<xclbin::mem_impl>(mem_topology->m_mem_data + idx, idx));
+          auto mem = mem_topology->m_mem_data + idx;
+          mems.emplace_back(std::make_shared<xclbin::mem_impl>(mem, idx));
         }
       }
+      return mems;
     }
 
     // init_ips() - populate m_ips with xclbin::ip objects
@@ -435,20 +402,23 @@ class xclbin_impl
     //
     // A pre-condition for this function is that init_mems() must have
     // been called.
-    void
-    init_ips()
+    static std::vector<xclbin::ip>
+    init_ips(const xclbin_impl* ximpl, const std::vector<xclbin::mem>& mems)
     {
-      auto ip_layout = m_ximpl->get_section<const ::ip_layout*>(IP_LAYOUT);
+      auto ip_layout = ximpl->get_section<const ::ip_layout*>(IP_LAYOUT);
       if (!ip_layout)
-        return;
+        return {};
       
-      auto conn = m_ximpl->get_section<const ::connectivity*>(ASK_GROUP_CONNECTIVITY);
+      auto conn = ximpl->get_section<const ::connectivity*>(ASK_GROUP_CONNECTIVITY);
 
-      m_ips.reserve(ip_layout->m_count);
+      std::vector<xclbin::ip> ips;
+      ips.reserve(ip_layout->m_count);
       for (int32_t idx = 0; idx < ip_layout->m_count; ++idx)
-        m_ips.emplace_back
+        ips.emplace_back
           (std::make_shared<xclbin::ip_impl>
-           (conn, m_mems, ip_layout->m_ip_data + idx, idx));
+           (conn, mems, ip_layout->m_ip_data + idx, idx));
+
+      return ips;
     }
 
     // init_kernels() - populate m_kernels with xclbin::kernel objects
@@ -458,34 +428,106 @@ class xclbin_impl
     //
     // Pre-condition for this function is that init_mems() and init_ips()
     // have been called.
-    void
-    init_kernels()
+    static std::vector<xclbin::kernel>
+    init_kernels(const xclbin_impl* ximpl, const std::vector<xclbin::ip>& ips)
     {
-      auto xml = m_ximpl->get_axlf_section(EMBEDDED_METADATA);
+      auto xml = ximpl->get_axlf_section(EMBEDDED_METADATA);
       if (!xml.first)
-        return;
+        return {};
 
-      auto ip_layout = m_ximpl->get_section_or_error<const ::ip_layout*>(IP_LAYOUT);
-
+      // get kernel CUs from xclbin meta data
+      std::vector<xclbin::kernel> kernels;
       for (auto& kernel : xrt_core::xclbin::get_kernels(xml.first, xml.second)) {
         auto props = xrt_core::xclbin::get_kernel_properties(xml.first, xml.second, kernel.name);
-        auto cus = xrt_core::xclbin::get_cus(ip_layout, kernel.name);  // ip_data*
-        auto ips = kernel_cus_to_ips(cus, props.address_range);        // xrt::xclbin::ip
-        m_kernels.emplace_back
+        std::vector<xclbin::ip> cus;
+        copy_if_name_match(ips.begin(), ips.end(), std::back_inserter(cus), kernel.name);
+        kernels.emplace_back
           (std::make_shared<xclbin::kernel_impl>
-           (std::move(kernel.name), std::move(props), std::move(ips), std::move(kernel.args)));
+           (std::move(kernel.name), std::move(props), std::move(cus), std::move(kernel.args)));
       }
+
+      return kernels;
+    }
+
+    // init_mem_encoding() - compress memory indices
+    // 
+    // Mapping from memory index to encoded index.  The compressed
+    // indices facilitate small sized std::bitset for representing
+    // kernel argument connectivity.
+    //
+    // The complicated part of this routine is to partition the set of
+    // all memory banks into groups of banks with same base address
+    // and size such that all banks within a group can share the same
+    // encoded index.
+    static std::vector<size_t>
+    init_mem_encoding(std::vector<xclbin::mem> mems) // by-value on purpose
+    {
+      // resulting encoding midx -> eidx, initialize before filtering
+      std::vector<size_t> enc(mems.size(), std::numeric_limits<size_t>::max());
+
+      // collect memory banks of interest (filter streaming entries)
+      mems.erase(std::remove_if(mems.begin(), mems.end(),
+        [](const auto& mem) {
+          if (!mem.get_used())
+            return true; // remove
+          using memory_type = xrt::xclbin::mem::memory_type;
+          auto mt = mem.get_type();
+          return (mt == memory_type::streaming || mt == memory_type::streaming_connection); // remove
+        }), mems.end());
+
+      if (mems.empty())
+        return {};
+
+      // sort collected memory banks on addr decreasing order, the size
+      std::sort(mems.begin(), mems.end(),
+        [](const auto& mb1, const auto& mb2) {
+          // decreasing base address
+          auto a1 = mb1.get_base_address();
+          auto a2 = mb2.get_base_address();
+          if (a1 > a2)
+            return true;
+      
+          // decreasing size
+          auto s1 = mb1.get_size_kb();
+          auto s2 = mb2.get_size_kb();
+          return ((a1 == a2) && (s1 > s2));
+        });
+
+      // process each memory bank and assign encoded index based on
+      // address/size partitioning, such that memory banks with same
+      // base address and same size share same encoded index
+      size_t eidx = 0;  // encoded index
+      auto itr = mems.begin();
+      while (itr != mems.end()) {
+        const auto& mb = *(itr);
+        auto addr = mb.get_base_address();
+        auto size = mb.get_size_kb();
+
+        // first element not part of the sorted (decreasing) range
+        auto upper = std::find_if(itr, mems.end(),
+          [addr, size] (const auto& mb) {
+            return ((mb.get_base_address() != addr) || (mb.get_size_kb() != size));
+          });
+
+        // process the range assigning same encoded index to all banks in group
+        for (; itr != upper; ++itr)
+          enc[(*itr).get_index()] = eidx;
+        
+        ++eidx; // increment for next iteration
+      }
+
+      return enc;
     }
 
     // xclbin_info() - constructor for xclbin meta data
     explicit
     xclbin_info(const xrt::xclbin_impl* impl)
       : m_ximpl(impl)
-    {
-      init_mems();     // must be first
-      init_ips();      // must be before kernels
-      init_kernels();
-    }
+      , m_mems(init_mems(m_ximpl))
+      , m_ips(init_ips(m_ximpl, m_mems))
+      , m_kernels(init_kernels(m_ximpl, m_ips))
+      , m_membank_encoding(init_mem_encoding(m_mems))
+    {}
   };
   
   // cache of meta data extracted from xclbin
@@ -563,7 +605,7 @@ public:
     return section;
   }
 
-  std::vector<xclbin::kernel>
+  const std::vector<xclbin::kernel>&
   get_kernels() const
   {
     return get_xclbin_info()->m_kernels;
@@ -579,7 +621,7 @@ public:
     return xclbin::kernel{};
   }
 
-  std::vector<xclbin::ip>
+  const std::vector<xclbin::ip>&
   get_ips() const
   {
     return get_xclbin_info()->m_ips;
@@ -608,10 +650,16 @@ public:
     return xclbin::ip{};
   }
   
-  std::vector<xclbin::mem>
+  const std::vector<xclbin::mem>&
   get_mems() const
   {
     return get_xclbin_info()->m_mems;
+  }
+
+  const std::vector<size_t>&
+  get_membank_encoding() const
+  {
+    return get_xclbin_info()->m_membank_encoding;
   }
 };
 
@@ -1167,6 +1215,12 @@ const std::vector<xrt_core::xclbin::kernel_argument>&
 get_arginfo(const xrt::xclbin::kernel& kernel)
 {
   return kernel.get_handle()->m_arginfo;
+}
+
+const std::vector<size_t>&
+get_membank_encoding(const xrt::xclbin& xclbin)
+{
+  return xclbin.get_handle()->get_membank_encoding();
 }
 
 }} // namespace xclbin_int, core_core

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -16,104 +16,32 @@
 #define XCL_DRIVER_DLL_EXPORT  // in same dll as exported xrt apis
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "device.h"
-#include "error.h"
-#include "utils.h"
-#include "debug.h"
-#include "query_requests.h"
 #include "config_reader.h"
+#include "debug.h"
+#include "error.h"
+#include "query_requests.h"
+#include "utils.h"
 #include "xclbin_parser.h"
 #include "xclbin_swemu.h"
-#include "core/common/api/xclbin_int.h"
+
+#include "core/include/ert.h"
 #include "core/include/xrt.h"
 #include "core/include/xclbin.h"
-#include "core/include/ert.h"
+#include "core/include/xrt/xrt_uuid.h"
+#include "core/include/experimental/xrt_xclbin.h"
+
+#include "core/common/api/xclbin_int.h"
+
 #include <boost/format.hpp>
-#include <string>
-#include <iostream>
-#include <fstream>
 #include <functional>
+#include <exception>
+#include <string>
+#include <utility>
+#include <vector>
 
 #ifdef _WIN32
 #pragma warning ( disable : 4996 )
 #endif
-
-namespace {
-
-// Encode / compress memory connections, a mapping from mem_topology
-// memory index to encoded index.  The compressed indices facilitate
-// small sized std::bitset for representing kernel argument
-// connectivity.
-//
-// The complicated part of this routine is to partition the set of all
-// memory banks into groups of banks with same base address and size
-// such that all banks within a group can share the same encoded index.
-static std::vector<size_t>
-compute_memidx_encoding(const ::mem_topology* mem_topology)
-{
-  if ( mem_topology == nullptr )
-    return {};
-
-  // The resulting encoding midx -> eidx
-  std::vector<size_t> enc(mem_topology->m_count, std::numeric_limits<size_t>::max());
-
-  struct membank
-  {
-    const mem_data* mdata;
-    int32_t midx;
-    membank(const mem_data* md, int32_t mi) : mdata(md), midx(mi) {}
-  };
-
-  // Collect all memory banks of interest
-  std::vector<membank> membanks;
-  for (int32_t midx = 0; midx < mem_topology->m_count; ++midx) {
-    const auto& mem = mem_topology->m_mem_data[midx];
-
-    if (!mem.m_used)
-      continue;
-    
-    // skip types that are of no interest for global connection
-    if (mem.m_type == MEM_STREAMING || mem.m_type == MEM_STREAMING_CONNECTION)
-      continue;
-
-    membanks.emplace_back(&mem, midx);
-  }
-
-  // Sort collected memory banks on addr decreasing order, the size
-  // use stable sort for predicatability (see #3795)
-  std::stable_sort(membanks.begin(), membanks.end(),
-                   [](const auto& mb1, const auto& mb2) {
-                     return (mb1.mdata->m_base_address > mb2.mdata->m_base_address)
-                       || ((mb1.mdata->m_base_address == mb2.mdata->m_base_address)
-                           && (mb1.mdata->m_size > mb2.mdata->m_size));
-                   });
-
-  // Process each memory bank and assign encoded index based on
-  // address/size partitioning, such that memory banks with same
-  // base address and same size share same encoded index
-  size_t eidx = 0;  // encoded index
-  auto itr = membanks.begin();
-  while (itr != membanks.end()) {
-    const auto& mb = *(itr);
-    auto addr = mb.mdata->m_base_address;
-    auto size = mb.mdata->m_size;
-
-    // first element not part of the sorted (decreasing) range
-    auto upper = std::find_if(itr, membanks.end(),
-                              [addr, size] (const auto& mb) {
-                                return ((mb.mdata->m_base_address != addr) || (mb.mdata->m_size != size));
-                              });
-
-    // process the range assigning same encoded index to all banks in group
-    for (; itr != upper; ++itr)
-      enc[(*itr).midx] = eidx;
-
-    ++eidx; // increment for next iteration
-  }
-
-  return enc;
-}
-
-}
 
 namespace xrt_core {
 
@@ -215,7 +143,7 @@ load_xclbin(const uuid& xclbin_id)
 
 xrt::xclbin
 device::
-get_xclbin(const uuid& xclbin_id)
+get_xclbin(const uuid& xclbin_id) const
 {
   if (xclbin_id && xclbin_id != m_xclbin.get_uuid())
     throw error(EINVAL, "xclbin id mismatch");
@@ -233,10 +161,6 @@ register_axlf(const axlf* top)
 {
   if (!m_xclbin || m_xclbin.get_uuid() != uuid(top->m_header.uuid))
       m_xclbin = xrt::xclbin{top};
-
-  // Compute memidx encoding / compression. The compressed indices facilitate
-  // small sized std::bitset for representing kernel argument connectivity
-  m_memidx_encoding = compute_memidx_encoding(get_axlf_section<const ::mem_topology*>(ASK_GROUP_TOPOLOGY));
 
   // Compute CU sort order, kernel driver zocl and xocl now assign and
   // control the sort order, which is accessible via a query request.
@@ -297,15 +221,6 @@ get_axlf_sections_or_error(axlf_section_kind section, const uuid& xclbin_id) con
   if (!ret.empty())
     return ret;
   throw error(EINVAL, "no such xclbin section");
-}
-
-const std::vector<size_t>&
-device::
-get_memidx_encoding(const uuid& xclbin_id) const
-{
-  if (xclbin_id && xclbin_id != m_xclbin.get_uuid())
-    throw error(EINVAL, "xclbin id mismatch");
-  return m_memidx_encoding;
 }
 
 device::memory_type

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -33,6 +33,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <memory>
 #include <boost/any.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/optional/optional.hpp>
@@ -209,7 +210,7 @@ public:
   // Throws if xclbin uuid does match
   XRT_CORE_COMMON_EXPORT
   xrt::xclbin
-  get_xclbin(const uuid& xclbin_id);
+  get_xclbin(const uuid& xclbin_id) const;
 
   /**
    * register_axlf() - Callback from shim after AXLF succesfully loaded
@@ -288,15 +289,6 @@ public:
   std::vector<std::pair<const char*, size_t>>
   get_axlf_sections_or_error(axlf_section_kind section, const uuid& xclbin_id = uuid()) const;
 
-  /**
-   * get_memidx_encoding() - An encoding compressing mem topology indices
-   *
-   * Returned container is indexed by mem_topology index and maps to
-   * encoded index.
-   */
-  const std::vector<size_t>&
-  get_memidx_encoding(const uuid& xclbin_id = uuid()) const;
-
   memory_type
   get_memory_type(size_t memidx) const;
 
@@ -367,7 +359,6 @@ public:
   id_type m_device_id;
   mutable boost::optional<bool> m_nodma = boost::none;
 
-  std::vector<size_t> m_memidx_encoding; // compressed mem_toplogy indices
   std::vector<uint64_t> m_cus;           // cu base addresses in expeced sort order
   xrt::xclbin m_xclbin;                  // currently loaded xclbin
 };


### PR DESCRIPTION
#### Problem solved by the commit
Consolidate more xclbin metadata access to xrt::xclbin.
This is WIP continuing #5931

#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved some additional parsing to xrt::xclbin from xrt_core::device.   
Improved parsing / building xrt::xclbin abstraction making better use of already abstracted data.

#### Risks (if any) associated the changes in the commit
Somewhat risky as more and more core implementation code now relies on xrt::xclbin.   Parsing is vastly different from old xclbin_parser code and any errors  will result in breakage. 

#### What has been tested and how, request additional testing if necessary
Standard HW OpenCL board tests, but that leaves a big hole for edge, which is left for sprite testing.
