### PR TITLE
Amend #5933

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -324,8 +324,13 @@ public:
       auto kargimpl = std::make_shared<arg_impl>();
 
       // Populate argument with union of compute units arguments at argidx
-      for (const auto& cu : m_cus) {
+      for (const auto& cu : m_cus) { // xclbin::ip
         auto cuimpl = cu.get_handle();
+
+        // set the address range size, which is a property of the kernel
+        // when it should be a proeprty of the compute unit (ip_layout)
+        cuimpl->set_size(m_properties.address_range);
+        
         // get cu argument at argidx, create if necessary when
         // argument at index is a scalar not part of connectivity
         auto cuarg = cuimpl->create_arg_if_new(argidx);  // xclbin::arg


### PR DESCRIPTION
#### Problem solved by the commit
Set address range on kernel compute unit.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Code reorg in #5933 accidentally removed the address range property of a kernel compute unit.
This will cause failure if using read/write_register, which is where the address range is checked.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Set the address range size when processing kernel compute units.
