### PR TITLE
ERT firmware for U2 gc_base_1

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -2072,14 +2072,8 @@ const char *xocl_fdt_get_ert_fw_ver(xdev_handle_t xdev_hdl, void *blob)
 			break;
 		}
 	}
-	if (fw_ver) {
+	if (fw_ver)
 		xocl_xdev_dbg(xdev_hdl, "Load embedded scheduler firmware %s", fw_ver);
-		/* if firmware_branch_name is "legacy", XRT loads the sched.bin */
-		if (!strcmp(fw_ver, "legacy")) {
-			xocl_xdev_dbg(xdev_hdl, "Firmware branch name is legacy. Loading default sched.bin");
-			return NULL;
-		}
-	}
 
 	return fw_ver;
 }


### PR DESCRIPTION
#### Problem solved by the commit
No ERT firmware loaded on u2-gen3x4-xdma-gc-base_1 platform
#### How problem was solved, alternative solutions (if any) and why they were rejected
Specify the right ERT firmware in devices.h
#### What has been tested and how, request additional testing if necessary
Reload xclmgmt and check the ert firmware is loaded

