### PR TITLE
Improve the error message when memory index is unknown

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -387,7 +387,7 @@ device::
 allocate_buffer_object(memory* mem, memidx_type memidx)
 {
   if (memidx==-1)
-    throw std::runtime_error("Cannot create buffer at unknown memory index");
+    throw std::runtime_error("Cannot allocate buffer at unknown memory index");
 
   if (mem->get_flags() & CL_MEM_REGISTER_MAP)
     throw std::runtime_error("Cannot allocate register map buffer on bank");


### PR DESCRIPTION
## Problem solved by the commit

Got misled by an error `Unexpected error memidx == -1` that was a little confusing to understand, the error message misled me suspecting there maybe some bug inside the XRT code. 

## Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

None

## How problem was solved, alternative solutions (if any) and why they were rejected

The error message is improved so that the user can get some hint that buffer location is not specified and hence throwing error. 

## Risks (if any) associated the changes in the commit

None, just error message change

## What has been tested and how, request additional testing if necessary

Not applicable

## Documentation impact (if any)

Not applicable 