### PR TITLE
add interrupt register dump to xdma fastpath

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -3341,7 +3341,7 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 		    ((engine->dir == DMA_TO_DEVICE) &&
 		    (val & XDMA_STAT_H2C_ERR_MASK))) {
 			pr_err("engine %s, status error 0x%x.\n", engine->name,
-			        engine->status);
+			        val);
 			engine_status_dump(engine);
 			engine_reg_dump(engine);
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -1080,7 +1080,7 @@ int xocl_copy_import_bo(struct drm_device *dev, struct drm_file *filp,
 	} else {
 		/*
 		 * dst is local
-		 * reading from remote BO, performance degraded"
+		 * reading from remote BO, performance degraded
 		 */
 		local_xobj = dst_xobj;
 		local_offset = ert_copybo_dst_offset(cmd);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When dma timeout (xdma fastpath), dump interrupt registers.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
added interrupt register dump when timeout happens
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
