### PR TITLE
CR-1113975 ERROR: No compute units satisfy requested connectivity

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -41,6 +41,7 @@
 #include <regex>
 #include <set>
 #include <vector>
+#include <mutex>
 
 #ifdef _WIN32
 # include "windows/uuid.h"
@@ -541,6 +542,8 @@ class xclbin_impl
   const xclbin_info*
   get_xclbin_info() const
   {
+    static std::mutex m;
+    std::lock_guard<std::mutex> lk(m);
     if (!m_info)
       m_info = std::make_unique<xclbin_info>(this);
     return m_info.get();


### PR DESCRIPTION
#### Problem solved by the commit
Fix race condition when extracting xclbin meta data, this is a
regression introduced in #5933.  Multi-threaded host code triggers
race in on-demand meta data extraction.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was introduced in #5933 that moved xclbin parsing to xrt::xclbin. 
The bug was discovered by Sprite testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add mutex to guard critical section.

#### What has been tested and how, request additional testing if necessary
OpenCL hw tests (none of which are multi-threaded apparently)
