### PR TITLE
WIP to remove OCL explicit dependencies on AXLF

### DIFF
--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -20,9 +20,13 @@
 
 // This file defines implementation extensions to the XRT XCLBIN APIs.
 #include "core/include/experimental/xrt_xclbin.h"
+
+#include "core/common/config.h"
 #include "core/common/xclbin_parser.h"
 
-#include <set>
+#include <cstring>
+#include <string>
+#include <vector>
 
 // Provide access to xrt::xclbin data that is not directly exposed
 // to end users via xrt::xclbin.   These functions are used by
@@ -63,8 +67,20 @@ get_properties(const xrt::xclbin::kernel& kernel);
 const std::vector<xrt_core::xclbin::kernel_argument>&
 get_arginfo(const xrt::xclbin::kernel& kernel);
 
+// get_membank_encoding() - Retrive membank encoding
+// The encoding is a mapping from membank index to
+// encoded index and is used to represent connectivity
+// in compressed form.
 const std::vector<size_t>&
 get_membank_encoding(const xrt::xclbin& xclbin);
+
+// get_project_name() - Name of xclbin project
+// Project name is extracted from xml meta data
+// Default project name is empty string if xml
+// is not present.
+XRT_CORE_COMMON_EXPORT
+std::string
+get_project_name(const xrt::xclbin& xclbin);
 
 }} // xclbin_int, xrt_core
 

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -858,4 +858,27 @@ get_vbnv(const axlf* top)
   return {vbnv, strnlen(vbnv, vbnv_length)};
 }
 
+std::string
+get_project_name(const char* xml_data, size_t xml_size)
+{
+  pt::ptree xml_project;
+  std::stringstream xml_stream;
+  xml_stream.write(xml_data,xml_size);
+  pt::read_xml(xml_stream,xml_project);
+
+  return xml_project.get<std::string>("project.<xmlattr>.name","");
+}
+
+std::string
+get_project_name(const axlf* top)
+{
+  try {
+    auto xml = get_xml_section(top);
+    return get_project_name(xml.first, xml.second);
+  }
+  catch (const std::exception&) {
+    return "";
+  }
+}
+
 }} // xclbin, xrt_core

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -340,6 +340,20 @@ XRT_CORE_COMMON_EXPORT
 std::string
 get_vbnv(const axlf* top);
 
+/**
+ * get_project_name() - Get the project name from the XML
+ */
+XRT_CORE_COMMON_EXPORT
+std::string
+get_project_name(const char* xml_data, size_t xml_size);
+
+/**
+ * get_project_name() - Get the project name from the XML
+ */
+XRT_CORE_COMMON_EXPORT
+std::string
+get_project_name(const axlf* top);
+
 }} // xclbin, xrt_core
 
 #endif

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -83,6 +83,15 @@ class xclbin_impl;
 class xclbin : public detail::pimpl<xclbin_impl>
 {
 public:
+  /**
+   * @enum taget_type - type of xclbin
+   *
+   * @details
+   * See `xclbin.h`
+   */
+  enum class target_type { hw, sw_emu, hw_emu };
+
+public:
   /*!
    * @class mem
    *
@@ -657,6 +666,16 @@ public:
   XCL_DRIVER_DLLESPEC
   uuid
   get_uuid() const;
+
+  /**
+   * get_target_type() - Get the type of this xclbin
+   *
+   * @return
+   *  Target type, which can be hw, sw_emu, or hw_emu
+   */
+  XCL_DRIVER_DLLESPEC
+  target_type
+  get_target_type() const;
 
   /// @cond
   /**

--- a/src/runtime_src/xocl/api/clGetProgramBuildInfo.cpp
+++ b/src/runtime_src/xocl/api/clGetProgramBuildInfo.cpp
@@ -69,12 +69,17 @@ clGetProgramBuildInfo(cl_program            program,
     {
       auto type = CL_PROGRAM_TARGET_TYPE_NONE;
       auto target = xocl::xocl(program)->get_target();
-      if (target==xocl::xclbin::target_type::bin)
+      switch (target) {
+      case xrt::xclbin::target_type::hw :
         type = CL_PROGRAM_TARGET_TYPE_HW;
-      else if (target==xocl::xclbin::target_type::csim)
-        type = CL_PROGRAM_TARGET_TYPE_SW_EMU;
-      else if (target==xocl::xclbin::target_type::hwem)
+        break;
+      case xrt::xclbin::target_type::hw_emu :
         type = CL_PROGRAM_TARGET_TYPE_HW_EMU;
+        break;
+      case xrt::xclbin::target_type::sw_emu :
+        type = CL_PROGRAM_TARGET_TYPE_SW_EMU;
+        break;
+      }
       buffer.as<cl_program_target_type>() = type;
     }
     break;

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -99,7 +99,7 @@ get_target() const
 {
   if (auto metadata = get_xclbin(nullptr))
     return metadata.target();
-  return xclbin::target_type::invalid;
+  throw std::runtime_error("No program metadata");
 }
 
 xclbin

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -22,6 +22,8 @@
 #include "core/common/device.h"
 #include "core/common/uuid.h"
 
+#include "core/include/experimental/xrt_xclbin.h"
+
 #include <map>
 #include <string>
 #include <memory>
@@ -45,7 +47,7 @@ public:
   static constexpr memidx_type max_banks = 256;
   using memidx_bitmask_type = std::bitset<max_banks>;
 
-  enum class target_type{ bin,x86,zynqps7,csim,cosim,hwem,invalid};
+  using target_type = xrt::xclbin::target_type;
 
   // A symbol captures all data required to construct an xocl::kernel
   // object.  It is associated with all kernel objects in the xclbin.
@@ -65,7 +67,6 @@ public:
       size_t hostoffset;
       size_t hostsize;
       std::string type;
-      size_t memsize;
       argtype atype;        // optimization to avoid repeated string cmp
       symbol* host;
     };
@@ -81,13 +82,11 @@ public:
     std::string name;                // name of kernel
     unsigned int uid;                // unique id for this symbol, some symbols have same name??
     std::string attributes;          // attributes as per .cl file
-    std::string hash;                // kernel conformance hash
     size_t workgroupsize = 0;
     size_t compileworkgroupsize[3] = {0};   //
     size_t maxworkgroupsize[3] = {0};// xilinx extension
     std::vector<arg> arguments;      // the args of this kernel
     std::vector<instance> instances; // the kernel instances
-    target_type target;              // xclbin target
   };
 
 public:
@@ -160,12 +159,6 @@ public:
    */
   const symbol&
   lookup_kernel(const std::string& name) const;
-
-  /**
-   * Get the mem topology section in xclbin
-   */
-  const mem_topology*
-  get_mem_topology() const;
 
   /**
    * Get memory connection indeces for CU argument at specified index


### PR DESCRIPTION
#### Problem solved by the commit
Move some of old XML xclbin parsing to xrt::xclbin implementation.
This is work-in-progress.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Most axlf parsing is consolidated into xrt::xclbin implementation,
where meta data is read once to build up abstractions used by core
XRT.
#### Risks (if any) associated the changes in the commit
Corner cases not covered by testing are possible
#### What has been tested and how, request additional testing if necessary
Standard OpenCL HW regression tests
