### PR TITLE
CR-1114332 PCIe reset does not work on HPE Apollo 6500 server

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -538,6 +538,7 @@ done:
 static void xclmgmt_reset_pci(struct xclmgmt_dev *lro)
 {
 	struct pci_dev *pdev = lro->pci_dev;
+	u16 slot_ctrl_orig = 0, slot_ctrl;
 	struct pci_bus *bus;
 	u8 pci_bctl;
 	u16 pci_cmd, devctl;
@@ -552,6 +553,12 @@ static void xclmgmt_reset_pci(struct xclmgmt_dev *lro)
 	/* Reset secondary bus. */
 	bus = pdev->bus;
 
+	pcie_capability_read_word(bus->self, PCI_EXP_SLTCTL, &slot_ctrl);
+	if (slot_ctrl != (u16) ~0) {
+		slot_ctrl_orig = slot_ctrl;
+		slot_ctrl &= ~(PCI_EXP_SLTCTL_HPIE);
+		pcie_capability_write_word(bus->self, PCI_EXP_SLTCTL, slot_ctrl);
+	}
 	/*
 	 * When flipping the SBR bit, device can fall off the bus. This is usually
 	 * no problem at all so long as drivers are working properly after SBR.
@@ -571,6 +578,9 @@ static void xclmgmt_reset_pci(struct xclmgmt_dev *lro)
 	pci_read_config_byte(bus->self, PCI_BRIDGE_CONTROL, &pci_bctl);
 	pci_bctl |= PCI_BRIDGE_CTL_BUS_RESET;
 	pci_write_config_byte(bus->self, PCI_BRIDGE_CONTROL, pci_bctl);
+
+	if (!slot_ctrl_orig)
+		pcie_capability_write_word(bus->self, PCI_EXP_SLTCTL, slot_ctrl_orig);
 
 	msleep(100);
 	pci_bctl &= ~PCI_BRIDGE_CTL_BUS_RESET;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
pci hot reset does not work on a PCIe hot-plug slot.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
disable the hotplug interrupt before reset and re-enable it after reset
#### Risks (if any) associated the changes in the commit
real hot-plug happens during xbutil hotreset which is manage-able by admin and very unlikely to happen.
#### What has been tested and how, request additional testing if necessary
xbutil reset on u50
#### Documentation impact (if any)
