### PR TITLE
VITIS-717 Move critical management functions to RPU

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -43,6 +43,8 @@
 
 /* This header file defines struct of mgmt command type opcode */
 
+#define CLOCK_MAX_RES           4
+
 enum xgq_cmd_sensor_page_id {
 	XGQ_CMD_SENSOR_PID_ALL		= 0x0,
 	XGQ_CMD_SENSOR_PID_BDINFO	= 0x1,
@@ -50,6 +52,12 @@ enum xgq_cmd_sensor_page_id {
 	XGQ_CMD_SENSOR_PID_VOLTAGE	= 0x3,
 	XGQ_CMD_SENSOR_PID_POWER	= 0x4,
 	XGQ_CMD_SENSOR_PID_QSFP		= 0x5,
+};
+
+enum xgq_cmd_clock_req_type {
+	XGQ_CMD_CLOCK_WIZARD 		= 0x0,
+	XGQ_CMD_CLOCK_COUNTER		= 0x1,
+	XGQ_CMD_CLOCK_SCALE		= 0x2,
 };
 
 struct xgq_cmd_log_payload {
@@ -62,8 +70,11 @@ struct xgq_cmd_log_payload {
 
 struct xgq_cmd_clock_payload {
 	uint32_t ocl_region;
-	uint32_t num_clock;
-	uint8_t  ocl_target_freq[4];
+	uint32_t ocl_req_type:8;
+	uint32_t ocl_req_id:2;
+	uint32_t ocl_req_num:4;
+	uint32_t rsvd1:18;
+	uint32_t ocl_req_freq[CLOCK_MAX_RES];
 };
 
 struct xgq_cmd_data_payload {
@@ -85,4 +96,29 @@ struct xgq_cmd_sq {
 	};
 };
 
+struct xgq_cmd_cq_default_payload {
+	uint32_t result;
+	uint32_t resvd;
+};
+
+struct xgq_cmd_cq_clock_payload {
+	uint32_t ocl_freq;
+	uint32_t resvd;
+};
+
+struct xgq_cmd_cq_sensor_payload {
+	uint32_t result;
+	uint32_t resvd;
+};
+
+struct xgq_cmd_cq {
+	struct xgq_cmd_cq_hdr hdr;
+	union {
+		struct xgq_cmd_cq_default_payload default_payload;
+		struct xgq_cmd_cq_clock_payload clock_payload;
+		struct xgq_cmd_cq_sensor_payload sensor_payload;
+	};
+	uint32_t rcode;
+};
+XGQ_STATIC_ASSERT(sizeof(struct xgq_cmd_cq) == 16, "xgq_cmd_cq has to be 16 bytes in size");
 #endif

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -43,7 +43,8 @@
 
 /* This header file defines struct of mgmt command type opcode */
 
-#define CLOCK_MAX_RES           4
+/* The Clock IP use index 0 for data, 1 for kernel, 2 for sys, 3 for sys1 */ 
+#define XGQ_CLOCK_WIZ_MAX_RES           4
 
 enum xgq_cmd_sensor_page_id {
 	XGQ_CMD_SENSOR_PID_ALL		= 0x0,
@@ -74,7 +75,7 @@ struct xgq_cmd_clock_payload {
 	uint32_t ocl_req_id:2;
 	uint32_t ocl_req_num:4;
 	uint32_t rsvd1:18;
-	uint32_t ocl_req_freq[CLOCK_MAX_RES];
+	uint32_t ocl_req_freq[XGQ_CLOCK_WIZ_MAX_RES];
 };
 
 struct xgq_cmd_data_payload {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -629,9 +629,21 @@ static int xclmgmt_icap_get_data_impl(struct xclmgmt_dev *lro, void *buf)
 static void xclmgmt_clock_get_data_impl(struct xclmgmt_dev *lro, void *buf)
 {
 	struct xcl_pr_region *hwicap = NULL;
+	int ret = 0;
 
 	hwicap = (struct xcl_pr_region *)buf;
-	hwicap->freq_0 = xocl_clock_get_data(lro, CLOCK_FREQ_0);
+	ret = xocl_clock_get_data(lro, CLOCK_FREQ_0);
+	if (ret == -ENODEV) {
+		hwicap->freq_0 = xocl_xgq_clock_get_data(lro, CLOCK_FREQ_0);
+		hwicap->freq_1 = xocl_xgq_clock_get_data(lro, CLOCK_FREQ_1);
+		hwicap->freq_2 = xocl_xgq_clock_get_data(lro, CLOCK_FREQ_2);
+		hwicap->freq_cntr_0 = xocl_xgq_clock_get_data(lro, FREQ_COUNTER_0);
+		hwicap->freq_cntr_1 = xocl_xgq_clock_get_data(lro, FREQ_COUNTER_1);
+		hwicap->freq_cntr_2 = xocl_xgq_clock_get_data(lro, FREQ_COUNTER_2);
+		return;
+	}
+
+	hwicap->freq_0 = ret;
 	hwicap->freq_1 = xocl_clock_get_data(lro, CLOCK_FREQ_1);
 	hwicap->freq_2 = xocl_clock_get_data(lro, CLOCK_FREQ_2);
 	hwicap->freq_cntr_0 = xocl_clock_get_data(lro, FREQ_COUNTER_0);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -677,7 +677,7 @@ static int xgq_freq_scaling(struct platform_device *pdev,
 	int id = 0;
 	int i = 0;
 
-	if (num_freqs <= 0 || num_freqs > CLOCK_MAX_RES) {
+	if (num_freqs <= 0 || num_freqs > XGQ_CLOCK_WIZ_MAX_RES) {
 		XGQ_ERR(xgq, "num_freqs %d is out of range", num_freqs);
 		return -EINVAL;
 	}
@@ -823,7 +823,7 @@ static uint32_t xgq_clock_get_data(struct xocl_xgq *xgq,
 	int id = 0;
 	uint32_t ret = 0;
 
-	if (req_id > CLOCK_MAX_RES) {
+	if (req_id > XGQ_CLOCK_WIZ_MAX_RES) {
 		XGQ_ERR(xgq, "req_id %d is out of range", id);
 		return 0;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2126,6 +2126,8 @@ struct xocl_xgq_funcs {
 	int (*xgq_check_firewall)(struct platform_device *pdev);
 	int (*xgq_freq_scaling)(struct platform_device *pdev,
 		unsigned short *freqs, int num_freqs, int verify);
+	int (*xgq_freq_scaling_by_topo)(struct platform_device *pdev,
+		struct clock_freq_topology *top, int verify);
 	uint64_t (*xgq_get_data)(struct platform_device *pdev,
 		enum data_kind kind);
 };
@@ -2146,6 +2148,9 @@ struct xocl_xgq_funcs {
 #define	xocl_xgq_freq_scaling(xdev, freqs, num_freqs, verify) 	\
 	(XGQ_CB(xdev, xgq_freq_scaling) ?			\
 	XGQ_OPS(xdev)->xgq_freq_scaling(XGQ_DEV(xdev), freqs, num_freqs, verify) : -ENODEV)
+#define	xocl_xgq_freq_scaling_by_topo(xdev, topo, verify) 	\
+	(XGQ_CB(xdev, xgq_freq_scaling_by_topo) ?		\
+	XGQ_OPS(xdev)->xgq_freq_scaling_by_topo(XGQ_DEV(xdev), topo, verify) : -ENODEV)
 #define	xocl_xgq_clock_get_data(xdev, kind) 			\
 	(XGQ_CB(xdev, xgq_get_data) ?				\
 	XGQ_OPS(xdev)->xgq_get_data(XGQ_DEV(xdev), kind) : -ENODEV)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xclbin.c
@@ -140,7 +140,20 @@ static int xgq_xclbin_download(xdev_handle_t xdev, void *args)
 
 static int xgq_xclbin_post_download(xdev_handle_t xdev, void *args)
 {
-	return 0;
+	struct xclbin_arg *arg = (struct xclbin_arg *)args;
+	const struct axlf_section_header *hdr =
+	    xrt_xclbin_get_section_hdr(arg->xclbin, CLOCK_FREQ_TOPOLOGY);
+	struct clock_freq_topology *topo;
+	int ret = 0;
+
+	if (hdr) {
+		/* after download, update clock freq */
+		topo = (struct clock_freq_topology *)
+		    (((char *)(arg->xclbin)) + hdr->m_sectionOffset);
+		ret = xocl_xgq_freq_scaling_by_topo(xdev, topo, 0);
+	}
+
+	return ret;
 }
 
 static struct xocl_xclbin_ops versal_ops = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Added clock support
2. Added new inline return value for both clock and sensor data
3. fix some issues of hot reset, magic number 4 which is sizeof(u32), coverity warnings, etc.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
> This is one of the VMR deliverables: 
> https://confluence.xilinx.com/pages/viewpage.action?pageId=277338276

#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
> Tested with drop1602
> /public/bugcases/CR/1105000-1105999/1105240/XRT_Drop_1602

#### Documentation impact (if any)
> XGQ spec is updated:
> https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261