### PR TITLE
Add xclAddressSpace argument to xread and xwrite methods.

### DIFF
--- a/src/runtime_src/core/common/api/sws.cpp
+++ b/src/runtime_src/core/common/api/sws.cpp
@@ -352,7 +352,7 @@ private:
       XRT_ASSERT(done_cnt <= running_queue.size(),"too many dones");
       // acknowledge done
       value_type cont = AP_CONTINUE;
-      xdev->xwrite(addr,&cont,4);
+      xdev->xwrite(XCL_ADDR_KERNEL_CTRL,addr,&cont,4);
     }
   }
 
@@ -426,13 +426,13 @@ public:
       for (size_type idx = 6; idx < size - 1; idx+=2) {
         addr_type offset = *(regmap + idx);
         value_type value = *(regmap + idx + 1);
-        xdev->xwrite(addr + offset,&value,4);
+        xdev->xwrite(XCL_ADDR_KERNEL_CTRL,addr + offset,&value,4);
       }
     }
     else {
       // write register map consecutively from CU base
       regmap[0] = 0; // clear ctrl register stale data if cmd reuse
-      xdev->xwrite(addr,regmap,size*4);
+      xdev->xwrite(XCL_ADDR_KERNEL_CTRL,addr,regmap,size*4);
     }
 
     // invoke callback for starting cu
@@ -442,9 +442,9 @@ public:
     ctrlreg |= AP_START;
     const_cast<uint32_t*>(regmap)[0] = AP_START;
     if (is_emulation())
-      xdev->xwrite(addr,regmap,size*4);
+      xdev->xwrite(XCL_ADDR_KERNEL_CTRL,addr,regmap,size*4);
     else
-      xdev->xwrite(addr,regmap,4);
+      xdev->xwrite(XCL_ADDR_KERNEL_CTRL,addr,regmap,4);
 
     running_queue.push(xcmd);
     ++run_cnt;

--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -264,7 +264,7 @@ public:
     if (has_reg_read_write())
       device->reg_write(idx, offset, data);
     else
-      device->xwrite(ipctx.get_address() + offset, &data, 4);
+      device->xwrite(XCL_ADDR_KERNEL_CTRL, ipctx.get_address() + offset, &data, 4);
   }
 
   std::shared_ptr<ip::interrupt_impl>

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1525,7 +1525,7 @@ public:
     if (has_reg_read_write())
       device->core_device->reg_write(idx, offset, data);
     else
-      device->core_device->xwrite(ipctxs.back()->get_address() + offset, &data, 4);
+      device->core_device->xwrite(XCL_ADDR_KERNEL_CTRL, ipctxs.back()->get_address() + offset, &data, 4);
   }
 
   // Read 'count' 4 byte registers starting at offset

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -89,7 +89,7 @@ struct ishim
   xread(enum xclAddressSpace addr_space, uint64_t offset, void* buffer, size_t size) const = 0;
 
   virtual void
-  xwrite(uint64_t offset, const void* buffer, size_t size) = 0;
+  xwrite(enum xclAddressSpace addr_space, uint64_t offset, const void* buffer, size_t size) = 0;
 
   virtual void
   unmgd_pread(void* buffer, size_t size, uint64_t offset) = 0;
@@ -354,9 +354,9 @@ struct shim : public DeviceType
   }
 
   virtual void
-  xwrite(uint64_t offset, const void* buffer, size_t size)
+  xwrite(enum xclAddressSpace addr_space, uint64_t offset, const void* buffer, size_t size)
   {
-    if (size != xclWrite(DeviceType::get_device_handle(), XCL_ADDR_KERNEL_CTRL, offset, buffer, size))
+    if (size != xclWrite(DeviceType::get_device_handle(), addr_space, offset, buffer, size))
       throw system_error(-1, "failed to write to address (" + std::to_string(offset) + ")");
   }
 #ifdef __GNUC__


### PR DESCRIPTION
Currently xread/xwrite method calls xclRead/xclWrite for XCL_ADDR_KERNEL_CTRL address space only. 

This new change allows future use of xread/xwrite methods for all address space types like XCL_ADDR_SPACE_DEVICE_PERFMON