### PR TITLE
CR-1114287 XRT] ERROR: No such xclbin handle: Invalid argument

### DIFF
--- a/src/runtime_src/core/common/api/handle.h
+++ b/src/runtime_src/core/common/api/handle.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ */
+
+#include "core/common/error.h"
+
+#include <map>
+#include <mutex>
+
+namespace xrt_core {
+
+// Custom mutex protected handle map for managing C-API handles that
+// must be explicitly opened and closed.  For some of the C-APIs,
+// the implmentation is a managed shared object so when the handle
+// is removed from the map, then underlying implementation might
+// still be in use if it was shared.  The sharing of implmentation
+// requires that the handles are stored as opposed to be raw opaque
+// pointers that are reinterpreted.
+template <typename HandleType, typename ImplType>
+class handle_map
+{
+  std::mutex mutex;
+  std::map<HandleType, ImplType> handles;
+
+public:
+  // get() - Get implementation for handle
+  ImplType
+  get_impl(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto itr = handles.find(handle);
+    if (itr == handles.end())
+      throw xrt_core::error(-EINVAL, "No such handle");
+    return itr->second;
+  }
+
+  // add() - Record handle impl pair
+  void
+  add(HandleType handle, ImplType&& impl)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    handles.emplace(handle, std::move(impl));
+  }
+
+  // remove() - Remove handle from map
+  void
+  remove(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    if (handles.erase(handle) == 0)
+    throw xrt_core::error(-EINVAL, "No such handle");
+  }
+};
+
+} // xrt_core

--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -1,20 +1,7 @@
 /*
- * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
  */
-
 #ifndef _XRT_COMMON_XCLBIN_INT_H_
 #define _XRT_COMMON_XCLBIN_INT_H_
 
@@ -32,10 +19,6 @@
 // to end users via xrt::xclbin.   These functions are used by
 // XRT core implementation.
 namespace xrt_core { namespace xclbin_int {
-
-// is_valid_or_error() - Throw if invalid handle
-void
-is_valid_or_error(xrtXclbinHandle handle);
 
 // get_axlf() - Retrieve complete axlf from handle
 const axlf*


### PR DESCRIPTION
#### Problem solved by the commit
Handles created by C-APIs are mapped to a managed shared implementation object that is reference counted.  When handle is closed, the implementation can still be alive.

This PR solves a race condition when inserting and accessing the map.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug has been present since inception, e.g., the C-APIs are not exception safe without using a mutex protected handle map.

#### How problem was solved, alternative solutions (if any) and why they were rejected
A handle map was created to ensure exclusive access.  Alternative solution would be to use raw opaque implementation handles that are reinterpreted, but that would not allow sharing of the implementation which is needed certainly for xclbin objects if they are loaded onto a device.

#### Risks (if any) associated the changes in the commit
Changes have no impact on C++ APIs so risk is low.

#### What has been tested and how, request additional testing if necessary
Stress testing of xclbin creation with multiple threads.
