### PR TITLE
CR-1114287 XRT ERROR: No such xclbin handle: Invalid argument (#5960)

### DIFF
--- a/src/runtime_src/core/common/api/handle.h
+++ b/src/runtime_src/core/common/api/handle.h
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ */
+
+#include "core/common/error.h"
+
+#include <map>
+#include <mutex>
+
+namespace xrt_core {
+
+// Custom mutex protected handle map for managing C-API handles that
+// must be explicitly opened and closed.  For some of the C-APIs,
+// the implmentation is a managed shared object so when the handle
+// is removed from the map, then underlying implementation might
+// still be in use if it was shared.  The sharing of implmentation
+// requires that the handles are stored as opposed to be raw opaque
+// pointers that are reinterpreted.
+template <typename HandleType, typename ImplType>
+class handle_map
+{
+  std::mutex mutex;
+  std::map<HandleType, ImplType> handles;
+
+public:
+  // get() - Get implementation for handle
+  ImplType
+  get_impl(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto itr = handles.find(handle);
+    if (itr == handles.end())
+      throw xrt_core::error(-EINVAL, "No such handle");
+    return itr->second;
+  }
+
+  // add() - Record handle impl pair
+  void
+  add(HandleType handle, ImplType&& impl)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    handles.emplace(handle, std::move(impl));
+  }
+
+  // remove() - Remove handle from map
+  void
+  remove(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    if (handles.erase(handle) == 0)
+    throw xrt_core::error(-EINVAL, "No such handle");
+  }
+};
+
+} // xrt_core

--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -1,20 +1,7 @@
 /*
- * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
  */
-
 #ifndef _XRT_COMMON_XCLBIN_INT_H_
 #define _XRT_COMMON_XCLBIN_INT_H_
 
@@ -23,10 +10,6 @@
 
 namespace xrt_core {
 namespace xclbin_int {
-
-// is_valid_or_error() - Throw if invalid handle
-void
-is_valid_or_error(xrtXclbinHandle handle);
 
 // get_axlf() - Retrieve complete axlf from handle
 const axlf*

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -30,6 +30,7 @@
 
 #include "core/include/xclbin.h"
 
+#include "handle.h"
 #include "native_profile.h"
 
 #include <array>
@@ -889,28 +890,10 @@ get_index() const
 
 namespace {
 
-// C-API handles that must be explicitly freed. Corresponding managed
-// handles are inserted in this map.  When the unmanaged handle is
-// freed, it is removed from this map and underlying object is
-// deleted if no other shared ptrs exists for this xclbin object
+// C-API handles that must be explicitly closed but corresponding
+// implementation could be shared.
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static std::map<xrtXclbinHandle, std::shared_ptr<xrt::xclbin_impl>> xclbins;
-
-static std::shared_ptr<xrt::xclbin_impl>
-get_xclbin(xrtXclbinHandle handle)
-{
-  auto itr = xclbins.find(handle);
-  if (itr == xclbins.end())
-    throw xrt_core::error(-EINVAL, "No such xclbin handle");
-  return itr->second;
-}
-
-static void
-free_xclbin(xrtXclbinHandle handle)
-{
-  if (xclbins.erase(handle) == 0)
-    throw xrt_core::error(-EINVAL, "No such xclbin handle");
-}
+static xrt_core::handle_map<xrtXclbinHandle, std::shared_ptr<xrt::xclbin_impl>> xclbins;
 
 inline void
 send_exception_message(const char* msg)
@@ -929,24 +912,17 @@ send_exception_message(const char* msg)
 ////////////////////////////////////////////////////////////////
 namespace xrt_core { namespace xclbin_int {
 
-void
-is_valid_or_error(xrtXclbinHandle handle)
-{
-  if ((xclbins.find(handle) == xclbins.end()))
-    throw xrt_core::error(-EINVAL, "Invalid xclbin handle");
-}
-
 const axlf*
 get_axlf(xrtXclbinHandle handle)
 {
-  auto xclbin = get_xclbin(handle);
+  auto xclbin = xclbins.get_impl(handle);
   return xclbin->get_axlf();
 }
 
 xrt::xclbin
 get_xclbin(xrtXclbinHandle handle)
 {
-  return xrt::xclbin(::get_xclbin(handle));
+  return xrt::xclbin(xclbins.get_impl(handle));
 }
 
 std::pair<const char*, size_t>
@@ -973,7 +949,7 @@ xrtXclbinAllocFilename(const char* filename)
     return xdp::native::profiling_wrapper(__func__, [filename]{
       auto xclbin = std::make_shared<xrt::xclbin_full>(filename);
       auto handle = xclbin.get();
-      xclbins.emplace(handle, std::move(xclbin));
+      xclbins.add(handle, std::move(xclbin));
       return handle;
     });
   }
@@ -995,7 +971,7 @@ xrtXclbinAllocRawData(const char* data, int size)
       std::vector<char> raw_data(data, data + size);
       auto xclbin = std::make_shared<xrt::xclbin_full>(raw_data);
       auto handle = xclbin.get();
-      xclbins.emplace(handle, std::move(xclbin));
+      xclbins.add(handle, std::move(xclbin));
       return handle;
     });
   }
@@ -1014,7 +990,7 @@ xrtXclbinFreeHandle(xrtXclbinHandle handle)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [handle]{
-      free_xclbin(handle);
+      xclbins.remove(handle);
       return 0;
     });
   }
@@ -1035,7 +1011,7 @@ xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle, name, size, ret_size]{
-      auto xclbin = get_xclbin(handle);
+      auto xclbin = xclbins.get_impl(handle);
       const std::string& xsaname = xclbin->get_xsa_name();
       // populate ret_size if memory is allocated
       if (ret_size)
@@ -1061,7 +1037,7 @@ xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [handle, ret_uuid]{
-      auto xclbin = get_xclbin(handle);
+      auto xclbin = xclbins.get_impl(handle);
       auto result = xclbin->get_uuid();
       uuid_copy(ret_uuid, result.get());
       return 0;
@@ -1083,7 +1059,7 @@ xrtXclbinGetNumKernels(xrtXclbinHandle handle)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle]{
-      auto xclbin = get_xclbin(handle);
+      auto xclbin = xclbins.get_impl(handle);
       return xclbin->get_kernels().size();
     });
   }
@@ -1103,7 +1079,7 @@ xrtXclbinGetNumKernelComputeUnits(xrtXclbinHandle handle)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle]{
-      auto xclbin = get_xclbin(handle);
+      auto xclbin = xclbins.get_impl(handle);
       auto kernels = xclbin->get_kernels();
       return std::accumulate(kernels.begin(), kernels.end(), 0,
                              [](size_t sum, const auto& k) {
@@ -1127,7 +1103,7 @@ xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle, data, size, ret_size]{
-      auto xclbin = get_xclbin(handle);
+      auto xclbin = xclbins.get_impl(handle);
       auto& result = xclbin->get_data();
       int result_size = result.size();
       // populate ret_size if memory is allocated


### PR DESCRIPTION
Handles created by C-APIs are mapped to a managed shared
implementation object that is reference counted.  When handle is
closed, the implementation can still be alive.

This PR solves a race condition when inserting and accessing the map.

A handle map was created to ensure exclusive access.

The bug has been present since inception, e.g., the C-APIs are not
exception safe without using a mutex protected handle map.

(cherry picked from commit 48fa22f86b702dcbc49b63d7cc219507d0d24191)