### PR TITLE
C-API thread safety

### DIFF
--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ */
+
+#include "context_mgr.h"
+#include "core/common/debug.h"
+#include "core/common/device.h"
+
+#include <bitset>
+#include <chrono>
+#include <condition_variable>
+#include <limits>
+#include <map>
+#include <mutex>
+
+using namespace std::chrono_literals;
+
+namespace xrt_core { namespace context_mgr {
+
+constexpr size_t max_cus = 129;  // +1 for virtual CU
+constexpr auto virtual_cu_idx = std::numeric_limits<unsigned int>::max();
+
+class device_context_mgr
+{
+  std::mutex m_mutex;
+  std::condition_variable m_cv;
+  xrt_core::device* m_device;
+  std::bitset<max_cus> m_ctx;
+
+  size_t
+  ctxidx(unsigned int ipidx)
+  {
+    // translate ipidx to idx used in bitset.
+    // virtual cu is last entry in bitset.
+    return ipidx == virtual_cu_idx ? max_cus - 1 : ipidx;
+  }
+  
+public:
+  device_context_mgr(xrt_core::device* device)
+    : m_device(device)
+  {}
+
+  // Open the cu context when it is safe to do so.  Note, that usage
+  // of the context manager does not support multiple threads calling
+  // this open() function on the same ip. The intended use-case
+  // (xrt::kernel) prevents this situation.
+  void
+  open(const xrt::uuid& uuid, unsigned int ipidx, bool shared)
+  {
+    auto idx = ctxidx(ipidx);
+    std::unique_lock<std::mutex> ul(m_mutex);
+    while (m_ctx.test(idx)) {
+      if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
+        throw std::runtime_error("aquiring cu context timed out");
+    }
+    m_device->open_context(uuid.get(), ipidx, shared);
+    m_ctx.set(idx);
+  }
+
+  // Close the cu context and notify threads that might be waiting
+  // to open this cu
+  void
+  close(const xrt::uuid& uuid, unsigned int ipidx)
+  {
+    auto idx = ctxidx(ipidx);
+    std::lock_guard<std::mutex> lk(m_mutex);
+    if (!m_ctx.test(idx))
+      throw std::runtime_error("ctx " + std::to_string(ipidx) + " not open");
+    m_device->close_context(uuid.get(), ipidx);
+    m_ctx.reset(idx);
+    m_cv.notify_all();
+  }
+};
+
+// Get (and create) context manager for device.
+// Cache the created manager so other threads can share.
+static std::shared_ptr<device_context_mgr>
+get_device_context_mgr(xrt_core::device* device, bool create = false)
+{
+  static std::map<const xrt_core::device*, std::weak_ptr<device_context_mgr>> d2cmgr;
+  static std::mutex ctx_mutex;
+  std::lock_guard<std::mutex> lk(ctx_mutex);
+  auto cmgr = d2cmgr[device].lock();
+  if (!cmgr && create)
+    d2cmgr[device] = cmgr = std::shared_ptr<device_context_mgr>(new device_context_mgr(device));
+  return cmgr;
+}
+
+
+////////////////////////////////////////////////////////////////  
+// Exposed API
+////////////////////////////////////////////////////////////////  
+std::shared_ptr<device_context_mgr>
+create(const xrt_core::device* device)
+{
+  // creating a context manager doesn't change device, but aqcuiring a
+  // context is a device operation and cannot use const device
+  return get_device_context_mgr(const_cast<xrt_core::device*>(device), true);
+}
+
+void
+open_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx, bool shared)
+{
+  if (auto ctxmgr = get_device_context_mgr(device)) {
+    ctxmgr->open(uuid, cuidx, shared);
+    return;
+  }
+
+  throw std::runtime_error("No context manager for device");
+}
+
+void
+close_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx)
+{
+  if (auto ctxmgr = get_device_context_mgr(device)) {
+    ctxmgr->close(uuid, cuidx);
+    return;
+  }
+
+  throw std::runtime_error("No context manager for device");
+}
+
+}} // context_mgr, xrt_core

--- a/src/runtime_src/core/common/api/context_mgr.h
+++ b/src/runtime_src/core/common/api/context_mgr.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ */
+
+#include "core/include/xrt/xrt_uuid.h"
+#include <memory>
+
+// This file defines APIs for compute unit (ip) context management
+// It is used by xrt::kernel and xrt::ip implementation.
+
+namespace xrt_core {
+
+class device;
+
+// Context management is somewhat complex in multi-threaded host
+// applications where same device object is shared between threads.
+//
+// A call to xclOpenContext must be protected against a race where
+// one thread is in the process of call xclCloseContext.
+namespace context_mgr {
+
+class device_context_mgr;
+
+// Create a context manager for a specific device The manager is
+// shared and cached so that it is constructed only if necessary.  In
+// other words, multi threads using same device can share the same
+// context manager.
+std::shared_ptr<device_context_mgr>
+create(const xrt_core::device* device);
+
+// Open a device context a specified compute unit (ip)
+//
+// @device: device to open context on
+// @uuid:   xclbin uuid with the CU
+// @cuidx:  index of CU
+// @shared: open in shared (true) or exclusive mode (false)
+//
+// The function blocks until the context can be acquired.  If
+// timeout, then the function throws.
+//
+// Note that the context manager is not intended to support two or
+// more threads opening a context on the same compute unit. This
+// situation must be guarded by the client (xrt::kernel) of the
+// manager.
+//
+// The function is simply a synchronization between two threads
+// simultanous use of open_context and close_context.
+void
+open_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx, bool shared);
+
+// Close a previously opened device context
+//
+// @device: device to close context on
+// @uuid:   xclbin uuid with the CU
+// @cuidx:  index of CU
+//
+// The function throws if no context is open on specified CU.
+void
+close_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx);
+ 
+}} // context_mgr, xrt_core

--- a/src/runtime_src/core/common/api/handle.h
+++ b/src/runtime_src/core/common/api/handle.h
@@ -20,36 +20,129 @@ namespace xrt_core {
 template <typename HandleType, typename ImplType>
 class handle_map
 {
-  std::mutex mutex;
-  std::map<HandleType, ImplType> handles;
+};
+
+template <typename HandleType, typename ImplType>
+class handle_map<HandleType, std::shared_ptr<ImplType>>
+{
+  mutable std::mutex mutex;
+  std::map<HandleType, std::shared_ptr<ImplType>> handles;
+
+  std::shared_ptr<ImplType>
+  get_no_lock(HandleType handle) const
+  {
+    auto itr = handles.find(handle);
+    return (itr == handles.end())
+      ? nullptr
+      : itr->second;
+  }
 
 public:
-  // get() - Get implementation for handle
-  ImplType
-  get_impl(HandleType handle)
+  const std::shared_ptr<ImplType>&
+  get_or_error(HandleType handle) const
   {
     std::lock_guard<std::mutex> lk(mutex);
     auto itr = handles.find(handle);
     if (itr == handles.end())
       throw xrt_core::error(-EINVAL, "No such handle");
-    return itr->second;
+
+    return (*itr).second;
   }
 
-  // add() - Record handle impl pair
+  std::shared_ptr<ImplType>
+  get(HandleType handle) const
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto itr = handles.find(handle);
+    return (itr == handles.end())
+      ? nullptr
+      : (*itr).second;
+  }
+
   void
-  add(HandleType handle, ImplType&& impl)
+  add(HandleType handle, std::shared_ptr<ImplType>&& impl)
   {
     std::lock_guard<std::mutex> lk(mutex);
     handles.emplace(handle, std::move(impl));
   }
 
-  // remove() - Remove handle from map
+  void
+  remove_or_error(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    if (handles.erase(handle) == 0)
+      throw xrt_core::error(-EINVAL, "No such handle");
+  }
+
   void
   remove(HandleType handle)
   {
     std::lock_guard<std::mutex> lk(mutex);
+    handles.erase(handle);
+  }
+
+  size_t
+  count(HandleType handle) const
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    return handles.count(handle);
+  }
+};
+
+template <typename HandleType, typename ImplType>
+class handle_map<HandleType, std::unique_ptr<ImplType>>
+{
+  mutable std::mutex mutex;
+  std::map<HandleType, std::unique_ptr<ImplType>> handles;
+
+public:
+  ImplType*
+  get_or_error(HandleType handle) const
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto itr = handles.find(handle);
+    if (itr == handles.end())
+      throw xrt_core::error(-EINVAL, "No such handle");
+    return (*itr).second.get();
+  }
+
+  ImplType*
+  get(HandleType handle) const
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    auto itr = handles.find(handle);
+    return (itr == handles.end())
+      ? nullptr
+      : (*itr).second.get();
+  }
+
+  void
+  add(HandleType handle, std::unique_ptr<ImplType>&& impl)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    handles.emplace(handle, std::move(impl));
+  }
+
+  void
+  remove_or_error(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
     if (handles.erase(handle) == 0)
-    throw xrt_core::error(-EINVAL, "No such handle");
+      throw xrt_core::error(-EINVAL, "No such handle");
+  }
+
+  void
+  remove(HandleType handle)
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    handles.erase(handle);
+  }
+
+  size_t
+  count(HandleType handle) const
+  {
+    std::lock_guard<std::mutex> lk(mutex);
+    return handles.count(handle);
   }
 };
 

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -25,6 +25,7 @@
 #include "bo.h"
 
 #include "device_int.h"
+#include "handle.h"
 #include "kernel_int.h"
 #include "core/common/device.h"
 #include "core/common/memalign.h"
@@ -685,15 +686,12 @@ namespace {
 // handles are inserted in this map.  When the unmanaged handle is
 // closed, it is removed from this map and underlying buffer is
 // deleted if no other shared ptrs exists for this buffer
-static std::map<xrtBufferHandle, std::shared_ptr<xrt::bo_impl>> bo_cache;
+static xrt_core::handle_map<xrtBufferHandle, std::shared_ptr<xrt::bo_impl>> bo_cache;
 
 static const std::shared_ptr<xrt::bo_impl>&
 get_boh(xrtBufferHandle bhdl)
 {
-  auto itr = bo_cache.find(bhdl);
-  if (itr == bo_cache.end())
-    throw xrt_core::error(-EINVAL, "No such buffer handle");
-  return (*itr).second;
+  return bo_cache.get_or_error(bhdl);
 }
 
 static xclBufferHandle
@@ -720,14 +718,6 @@ alloc_bo(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup g
     }
     throw;
   }
-}
-
-
-static void
-free_bo(xrtBufferHandle bhdl)
-{
-  if (bo_cache.erase(bhdl) == 0)
-    throw std::runtime_error("Unexpected internal error");
 }
 
 // driver allocates host buffer
@@ -1080,8 +1070,9 @@ xrtBOAllocUserPtr(xrtDeviceHandle dhdl, void* userptr, size_t size, xrtBufferFla
     return xdp::native::profiling_wrapper(__func__,
     [dhdl, userptr, size, flags, grp]{
       auto boh = alloc_userptr(get_xcl_device_handle(dhdl), userptr, size, flags, grp);
-      bo_cache[boh.get()] = boh;
-      return boh.get();
+      auto hdl = boh.get();
+      bo_cache.add(hdl, std::move(boh));
+      return hdl;
     });
   }
   catch (const xrt_core::error& ex) {
@@ -1102,8 +1093,9 @@ xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGro
     return xdp::native::profiling_wrapper(__func__,
     [dhdl, size, flags, grp]{
       auto boh = alloc(get_xcl_device_handle(dhdl), size, flags, grp);
-      bo_cache[boh.get()] = boh;
-      return boh.get();
+      auto hdl = boh.get();
+      bo_cache.add(hdl, std::move(boh));
+      return hdl;
     });
   }
   catch (const xrt_core::error& ex) {
@@ -1123,8 +1115,10 @@ xrtBOSubAlloc(xrtBufferHandle phdl, size_t sz, size_t offset)
     return xdp::native::profiling_wrapper(__func__, [phdl, sz, offset]{
       const auto& parent = get_boh(phdl);
       auto boh = alloc_sub(parent, sz, offset);
-      bo_cache[boh.get()] = boh;
-      return boh.get();
+      auto hdl = boh.get();
+      bo_cache.add(hdl, std::move(boh));
+      return hdl;
+
     });
   }
   catch (const xrt_core::error& ex) {
@@ -1143,8 +1137,9 @@ xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl)
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, ehdl]{
       auto boh = alloc_import(get_xcl_device_handle(dhdl), ehdl);
-      bo_cache[boh.get()] = boh;
-      return boh.get();
+      auto hdl = boh.get();
+      bo_cache.add(hdl, std::move(boh));
+      return hdl;
     });
   }
   catch (const xrt_core::error& ex) {
@@ -1181,8 +1176,9 @@ xrtBOAllocFromXcl(xrtDeviceHandle dhdl, xclBufferHandle xhdl)
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, xhdl] {
       auto boh = alloc_xbuf(xrtDeviceToXclDevice(dhdl), xhdl);
-      bo_cache[boh.get()] = boh;
-      return boh.get();
+      auto hdl = boh.get();
+      bo_cache.add(hdl, std::move(boh));
+      return hdl;
     });
   }
   catch (const xrt_core::error& ex) {
@@ -1200,7 +1196,7 @@ xrtBOFree(xrtBufferHandle bhdl)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [bhdl]{
-      free_bo(bhdl);
+      bo_cache.remove_or_error(bhdl);
       return 0;
     });
   }

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -31,8 +31,9 @@
 #include "core/common/info_platform.h"
 #include "core/common/query_requests.h"
 
-#include "xclbin_int.h" // Non public xclbin APIs
+#include "handle.h"
 #include "native_profile.h"
+#include "xclbin_int.h" // Non public xclbin APIs
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -46,28 +47,10 @@
 
 namespace {
 
-// C-API handles that must be explicitly closed. Corresponding managed
-// handles are inserted in this map.  When the unmanaged handle is
-// closed, it is removed from this map and underlying buffer is
-// deleted if no other shared ptrs exists for this buffer
-static std::map<xrtDeviceHandle, std::shared_ptr<xrt_core::device>> device_cache;
-
-static std::shared_ptr<xrt_core::device>
-get_device(xrtDeviceHandle dhdl)
-{
-  auto itr = device_cache.find(dhdl);
-  if (itr == device_cache.end())
-    throw xrt_core::error(-EINVAL, "No such device handle");
-  return (*itr).second;
-}
-
-
-static void
-free_device(xrtDeviceHandle dhdl)
-{
-  if (device_cache.erase(dhdl) == 0)
-    throw xrt_core::error(-EINVAL, "No such device handle");
-}
+// C-API handles that must be explicitly closed but corresponding
+// implementation could be shared.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static xrt_core::handle_map<xrtDeviceHandle, std::shared_ptr<xrt_core::device>> device_cache;
 
 inline void
 send_exception_message(const char* msg)
@@ -149,13 +132,13 @@ namespace xrt_core { namespace device_int {
 std::shared_ptr<xrt_core::device>
 get_core_device(xrtDeviceHandle dhdl)
 {
-  return get_device(dhdl); // handle check
+  return device_cache.get_or_error(dhdl);
 }
 
 xclDeviceHandle
 get_xcl_device_handle(xrtDeviceHandle dhdl)
 {
-  auto device = get_device(dhdl); // handle check
+  auto device = device_cache.get_or_error(dhdl);
   return device->get_device_handle();  // shim handle
 }
 
@@ -360,8 +343,9 @@ xrtDeviceOpen(unsigned int index)
   try {
     return xdp::native::profiling_wrapper(__func__, [index]{
       auto device = xrt_core::get_userpf_device(index);
-      device_cache[device.get()] = device;
-      return device.get();
+      auto handle = device.get();
+      device_cache.add(handle, std::move(device));
+      return handle;
     });
   }
   catch (const xrt_core::error& ex) {
@@ -397,7 +381,7 @@ xrtDeviceClose(xrtDeviceHandle dhdl)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl]{
-      free_device(dhdl);
+      device_cache.remove_or_error(dhdl);
       return 0;
     });
   }
@@ -417,7 +401,7 @@ xrtDeviceLoadXclbin(xrtDeviceHandle dhdl, const axlf* top)
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, top]{
       xrt::xclbin xclbin{top};
-      auto device = get_device(dhdl);
+      auto device = device_cache.get_or_error(dhdl);
       device->load_xclbin(xclbin);
       return 0;
     });
@@ -438,7 +422,7 @@ xrtDeviceLoadXclbinFile(xrtDeviceHandle dhdl, const char* fnm)
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, fnm]{
       xrt::xclbin xclbin{fnm};
-      auto device = get_device(dhdl);
+      auto device = device_cache.get_or_error(dhdl);
       device->load_xclbin(xclbin);
       return 0;
     });
@@ -458,7 +442,7 @@ xrtDeviceLoadXclbinHandle(xrtDeviceHandle dhdl, xrtXclbinHandle xhdl)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, xhdl]{
-      auto device = get_device(dhdl);
+      auto device = device_cache.get_or_error(dhdl);
       device->load_xclbin(xrt_core::xclbin_int::get_xclbin(xhdl));
       return 0;
     });
@@ -478,7 +462,7 @@ xrtDeviceLoadXclbinUUID(xrtDeviceHandle dhdl, const xuid_t uuid)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, uuid]{
-      auto device = get_device(dhdl);
+      auto device = device_cache.get_or_error(dhdl);
       device->load_xclbin(uuid);
       return 0;
     });
@@ -498,7 +482,7 @@ xrtDeviceGetXclbinUUID(xrtDeviceHandle dhdl, xuid_t out)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl, out]{
-      auto device = get_device(dhdl);
+      auto device = device_cache.get_or_error(dhdl);
       auto uuid = device->get_xclbin_uuid();
       uuid_copy(out, uuid.get());
       return 0;
@@ -519,7 +503,7 @@ xrtDeviceToXclDevice(xrtDeviceHandle dhdl)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [dhdl]{
-      auto device = get_device(dhdl);
+      auto device = device_cache.get_or_error(dhdl);
       return device->get_device_handle();
     });
   }
@@ -544,8 +528,10 @@ xrtDeviceOpenFromXcl(xclDeviceHandle dhdl)
       // xrtDeviceClose removes the handle from the cache
       if (device_cache.count(device.get()))
         throw xrt_core::error(EINVAL, "Handle is already in use");
-      device_cache[device.get()] = device;
-      return device.get();
+
+      auto handle = device.get();
+      device_cache.add(handle, std::move(device));
+      return handle;
     });
   }
   catch (const xrt_core::error& ex) {

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1230,14 +1230,14 @@ namespace xrt_core { namespace xclbin_int {
 const axlf*
 get_axlf(xrtXclbinHandle handle)
 {
-  auto xclbin = xclbins.get_impl(handle);
+  auto xclbin = xclbins.get_or_error(handle);
   return xclbin->get_axlf();
 }
 
 xrt::xclbin
 get_xclbin(xrtXclbinHandle handle)
 {
-  return xrt::xclbin(xclbins.get_impl(handle));
+  return xrt::xclbin(xclbins.get_or_error(handle));
 }
 
 std::pair<const char*, size_t>
@@ -1335,7 +1335,7 @@ xrtXclbinFreeHandle(xrtXclbinHandle handle)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [handle]{
-      xclbins.remove(handle);
+      xclbins.remove_or_error(handle);
       return 0;
     });
   }
@@ -1356,7 +1356,7 @@ xrtXclbinGetXSAName(xrtXclbinHandle handle, char* name, int size, int* ret_size)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle, name, size, ret_size]{
-      auto xclbin = xclbins.get_impl(handle);
+      auto xclbin = xclbins.get_or_error(handle);
       const std::string& xsaname = xclbin->get_xsa_name();
       // populate ret_size if memory is allocated
       if (ret_size)
@@ -1382,7 +1382,7 @@ xrtXclbinGetUUID(xrtXclbinHandle handle, xuid_t ret_uuid)
 {
   try {
     return xdp::native::profiling_wrapper(__func__, [handle, ret_uuid]{
-      auto xclbin = xclbins.get_impl(handle);
+      auto xclbin = xclbins.get_or_error(handle);
       auto result = xclbin->get_uuid();
       uuid_copy(ret_uuid, result.get());
       return 0;
@@ -1404,7 +1404,7 @@ xrtXclbinGetNumKernels(xrtXclbinHandle handle)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle]{
-      auto xclbin = xclbins.get_impl(handle);
+      auto xclbin = xclbins.get_or_error(handle);
       return xclbin->get_kernels().size();
     });
   }
@@ -1424,7 +1424,7 @@ xrtXclbinGetNumKernelComputeUnits(xrtXclbinHandle handle)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle]{
-      auto xclbin = xclbins.get_impl(handle);
+      auto xclbin = xclbins.get_or_error(handle);
       auto kernels = xclbin->get_kernels();
       return std::accumulate(kernels.begin(), kernels.end(), 0,
                              [](size_t sum, const auto& k) {
@@ -1448,7 +1448,7 @@ xrtXclbinGetData(xrtXclbinHandle handle, char* data, int size, int* ret_size)
   try {
     return xdp::native::profiling_wrapper(__func__,
     [handle, data, size, ret_size]{
-      auto xclbin = xclbins.get_impl(handle);
+      auto xclbin = xclbins.get_or_error(handle);
       auto& result = xclbin->get_data();
       int result_size = result.size();
       // populate ret_size if memory is allocated

--- a/tests/xrt/100_ert_ncu/xrtx.cpp
+++ b/tests/xrt/100_ert_ncu/xrtx.cpp
@@ -150,8 +150,13 @@ struct job_type
     ++runs;
     if (r == XRT_NULL_HANDLE) {
       running = true;
-      r = xrtKernelRun(k, a, b, ELEMENTS);
+      r = xrtRunOpen(k);
       xrtRunSetCallback(r, ERT_CMD_STATE_COMPLETED, kernel_done, this);
+      xrtRunSetArg(r, 0, a);
+      xrtRunSetArg(r, 1, b);
+      xrtRunSetArg(r, 2, ELEMENTS);
+      xrtRunStart(r);
+      //r = xrtKernelRun(k, a, b, ELEMENTS);
     }
     else if (!stop)
       xrtRunStart(r);


### PR DESCRIPTION
#### Problem solved by the commit
This PR extends #5960 to make all C-APIs thread safe. The earlier PR addressed only xrtXclbin APIs.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
In addition to thread safe handling of XRT handles created by C APIs, this PR also addresses a general thread problem (C and C++) for acquiring compute unit context.  If multiple threads share the same device object and acquire / release context on the same CUs, then careful synchronization of low level xclOpen/CloseContext is required.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The synchronization ensures that when a thread is in the process of releasing a context, another thread wont call xclOpenContextbefore the former has closed its context.

#### Risks (if any) associated the changes in the commit
The synchronized context changes is a risk.

#### What has been tested and how, request additional testing if necessary
Multiple testing has been done with arbitrary number of threads creating xclbin, device, kernel, and bo objects in tight loops.  All threading problems have been present since inception, so we need to add specific stress tests for cover the multi-threaded use case.