### PR TITLE
Vitis-3290 AWS F1 NoDMA Small Shell - XRT Support

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -1626,6 +1626,15 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
+#define	XOCL_DEVINFO_MSIX_XDMA				\
+	{						\
+		XOCL_SUBDEV_MSIX,			\
+		XOCL_MSIX_XDMA,				\
+		NULL,					\
+		0,					\
+		.override_idx = -1,			\
+	}
+
 #define	XOCL_DEVINFO_DMA_MSIX				\
 	{						\
 		.id = XOCL_SUBDEV_DMA,			\
@@ -2010,14 +2019,20 @@ struct xocl_subdev_map {
 			XOCL_DEVINFO_INTC_VERSAL,				\
 		})
 
-#define USER_RES_AWS							\
+#define USER_RES_AWS_XDMA						\
 		((struct xocl_subdev_info []) {				\
 			XOCL_DEVINFO_FEATURE_ROM,			\
 			XOCL_DEVINFO_XDMA,				\
-			XOCL_DEVINFO_SCHEDULER_51,			\
 			XOCL_DEVINFO_MAILBOX_USER_SOFTWARE,		\
 			XOCL_DEVINFO_ICAP_USER,				\
-			XOCL_DEVINFO_INTC,				\
+		})
+
+#define USER_RES_AWS_NODMA						\
+		((struct xocl_subdev_info []) {				\
+			XOCL_DEVINFO_FEATURE_ROM,			\
+			XOCL_DEVINFO_MSIX_XDMA,				\
+			XOCL_DEVINFO_MAILBOX_USER_SOFTWARE,		\
+			XOCL_DEVINFO_ICAP_USER,				\
 		})
 
 #define	USER_RES_DSA52							\
@@ -2087,11 +2102,18 @@ struct xocl_subdev_map {
 		.subdev_num = ARRAY_SIZE(USER_RES_XDMA),		\
 	}
 
-#define XOCL_BOARD_USER_AWS						\
+#define XOCL_BOARD_USER_AWS_XDMA					\
 	(struct xocl_board_private){					\
 		.flags		= 0,					\
-		.subdev_info	= USER_RES_AWS,				\
-		.subdev_num = ARRAY_SIZE(USER_RES_AWS),			\
+		.subdev_info	= USER_RES_AWS_XDMA,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_AWS_XDMA),		\
+	}
+
+#define XOCL_BOARD_USER_AWS_NODMA					\
+	(struct xocl_board_private){					\
+		.flags		= 0,					\
+		.subdev_info	= USER_RES_AWS_NODMA,			\
+		.subdev_num = ARRAY_SIZE(USER_RES_AWS_NODMA),		\
 	}
 
 #define	XOCL_BOARD_USER_DSA52_U2				\
@@ -3627,9 +3649,9 @@ struct xocl_subdev_map {
 	{ XOCL_PCI_DEVID(0x10EE, 0x5075, PCI_ANY_ID, X3522PV_USER_RAPTOR2) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0065, PCI_ANY_ID, USER_XDMA) },	\
 	{ XOCL_PCI_DEVID(0x13FE, 0x0077, PCI_ANY_ID, USER_DSA52) },	\
-	{ XOCL_PCI_DEVID(0x1D0F, 0x1042, PCI_ANY_ID, USER_AWS) },	\
-	{ XOCL_PCI_DEVID(0x1D0F, 0xF000, PCI_ANY_ID, USER_AWS) },	\
-	{ XOCL_PCI_DEVID(0x1D0F, 0xF010, PCI_ANY_ID, USER_AWS) },	\
+	{ XOCL_PCI_DEVID(0x1D0F, 0x1042, PCI_ANY_ID, USER_AWS_XDMA) },	\
+	{ XOCL_PCI_DEVID(0x1D0F, 0xF010, PCI_ANY_ID, USER_AWS_XDMA) },	\
+	{ XOCL_PCI_DEVID(0x1D0F, 0xF011, PCI_ANY_ID, USER_AWS_NODMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x6AA0, 0x4360, USER_QDMA) },		\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5011, PCI_ANY_ID, USER_QDMA) },	\
 	{ XOCL_PCI_DEVID(0x10EE, 0x5015, PCI_ANY_ID, USER_QDMA) },	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -2552,11 +2552,14 @@ static int irq_msix_user_setup(struct xdma_dev *xdev)
 	int i;
 	int j = xdev->h2c_channel_max + xdev->c2h_channel_max;
 	int rv = 0;
-	struct interrupt_regs *reg = (struct interrupt_regs *)
-		(xdev->bar[xdev->config_bar_idx] + XDMA_OFS_INT_CTRL);
 
-	if (xdev->no_dma)
-		j = read_register(&reg->user_msi_vector) & 0xf;
+	/*
+	 * hard-code the number of dma channels to 2 for no dma mode.
+	 * should not rely on the register to get the number of dma channels
+	 *
+	 * if (xdev->no_dma)
+	 *	j = read_register(&reg->user_msi_vector) & 0xf;
+	 */	
 
 	/* vectors set in probe_scan_for_msi() */
 	for (i = 0; i < xdev->user_max; i++, j++) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -714,8 +714,9 @@ static int get_header_from_iomem(struct feature_rom *rom)
 	if (val != MAGIC_NUM) {
 		vendor = XOCL_PL_TO_PCI_DEV(pdev)->vendor;
 		did = XOCL_PL_TO_PCI_DEV(pdev)->device;
-		if (vendor == 0x1d0f && (did == 0x1042 || did == 0xf010)) { // MAGIC, we should define elsewhere
-#define AWS_F1_SHELL_NAME "xilinx_aws-vu9p-f1_shell-dynamic"
+		if (vendor == 0x1d0f && (did == 0x1042 || did == 0xf010 || did == 0xf011)) { // MAGIC, we should define elsewhere
+#define AWS_F1_XDMA_SHELL_NAME "xilinx_aws-vu9p-f1_shell-v04261818_201920_3"
+#define AWS_F1_NODMA_SHELL_NAME "xilinx_aws-vu9p-f1_shell-v09142114_202120_1"
 			xocl_dbg(&pdev->dev,
 				"Found AWS VU9P Device without featureROM");
 			/*
@@ -730,8 +731,12 @@ static int get_header_from_iomem(struct feature_rom *rom)
 			strncpy(rom->header.FPGAPartName, "AWS VU9P", 8);
 			memset(rom->header.VBNVName, 0,
 				sizeof(rom->header.VBNVName));
-			strncpy(rom->header.VBNVName,
-				AWS_F1_SHELL_NAME, strlen(AWS_F1_SHELL_NAME));
+			if (did == 0xf010)
+				strncpy(rom->header.VBNVName,
+					AWS_F1_XDMA_SHELL_NAME, strlen(AWS_F1_XDMA_SHELL_NAME));
+			else if (did == 0xf011)
+				strncpy(rom->header.VBNVName,
+					AWS_F1_NODMA_SHELL_NAME, strlen(AWS_F1_NODMA_SHELL_NAME));
 			rom->header.MajorVersion = 4;
 			rom->header.MinorVersion = 0;
 			rom->header.VivadoBuildID = 0xabcd;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -717,6 +717,7 @@ static int get_header_from_iomem(struct feature_rom *rom)
 		if (vendor == 0x1d0f && (did == 0x1042 || did == 0xf010 || did == 0xf011)) { // MAGIC, we should define elsewhere
 #define AWS_F1_XDMA_SHELL_NAME "xilinx_aws-vu9p-f1_shell-v04261818_201920_3"
 #define AWS_F1_NODMA_SHELL_NAME "xilinx_aws-vu9p-f1_shell-v09142114_202120_1"
+#define AWS_F1_DYNAMIC_SHELL_NAME "xilinx_aws-vu9p-f1_shell-dynamic"
 			xocl_dbg(&pdev->dev,
 				"Found AWS VU9P Device without featureROM");
 			/*
@@ -737,6 +738,9 @@ static int get_header_from_iomem(struct feature_rom *rom)
 			else if (did == 0xf011)
 				strncpy(rom->header.VBNVName,
 					AWS_F1_NODMA_SHELL_NAME, strlen(AWS_F1_NODMA_SHELL_NAME));
+			else
+				strncpy(rom->header.VBNVName,
+					AWS_F1_DYNAMIC_SHELL_NAME, strlen(AWS_F1_DYNAMIC_SHELL_NAME));
 			rom->header.MajorVersion = 4;
 			rom->header.MinorVersion = 0;
 			rom->header.VivadoBuildID = 0xabcd;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -715,6 +715,7 @@ static int get_header_from_iomem(struct feature_rom *rom)
 		vendor = XOCL_PL_TO_PCI_DEV(pdev)->vendor;
 		did = XOCL_PL_TO_PCI_DEV(pdev)->device;
 		if (vendor == 0x1d0f && (did == 0x1042 || did == 0xf010)) { // MAGIC, we should define elsewhere
+#define AWS_F1_SHELL_NAME "xilinx_aws-vu9p-f1_shell-dynamic"
 			xocl_dbg(&pdev->dev,
 				"Found AWS VU9P Device without featureROM");
 			/*
@@ -730,7 +731,7 @@ static int get_header_from_iomem(struct feature_rom *rom)
 			memset(rom->header.VBNVName, 0,
 				sizeof(rom->header.VBNVName));
 			strncpy(rom->header.VBNVName,
-				"xilinx_aws-vu9p-f1_shell-v04261818_201920_2", 43);
+				AWS_F1_SHELL_NAME, strlen(AWS_F1_SHELL_NAME));
 			rom->header.MajorVersion = 4;
 			rom->header.MinorVersion = 0;
 			rom->header.VivadoBuildID = 0xabcd;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2977,7 +2977,6 @@ static int icap_cache_bitstream_axlf_section(struct platform_device *pdev,
 
 	if (kind == MEM_TOPOLOGY || kind == ASK_GROUP_TOPOLOGY) {
 		struct mem_topology *mem_topo = *target;
-		u64 hbase, hsz;
 		int i;
 
 		for (i = 0; i< mem_topo->m_count; ++i) {
@@ -2985,11 +2984,10 @@ static int icap_cache_bitstream_axlf_section(struct platform_device *pdev,
 			    mem_topo->m_mem_data[i].m_used)
 				continue;
 
-			if (!xocl_m2m_host_bank(xdev, &hbase, &hsz)) {
-				mem_topo->m_mem_data[i].m_used = 1;
-				mem_topo->m_mem_data[i].m_base_address = hbase;
-				mem_topo->m_mem_data[i].m_size = (hsz >> 10);
-			}
+			xocl_m2m_host_bank(xdev,
+				&(mem_topo->m_mem_data[i].m_base_address),
+				&(mem_topo->m_mem_data[i].m_size),
+				&(mem_topo->m_mem_data[i].m_used));
 		}
 		/* Xclbin binary has been adjusted as a workaround of Bios Limitation of some machine 
 		 * We won't be able to retain the device memory because of the limitation

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/mailbox.c
@@ -2368,6 +2368,14 @@ int mailbox_request(struct platform_device *pdev, void *req, size_t reqlen,
 		MBX_WARN(mbx, "mailbox is running in test mode");
 		return -EACCES;
 	}
+
+	/*
+	 * aws case, return early before mailbox is opened.
+	 * this makes xocl attach faster
+	 */
+	if (MB_SW_ONLY(mbx) && !mbx->mbx_opened)
+		return -EFAULT;
+
 	return _mailbox_request(pdev, req, reqlen, resp, resplen, cb, cbarg,
 		resp_ttl, tx_ttl);	
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -114,6 +114,7 @@ struct xocl_dev	{
 	u32			flags;
 	struct xocl_cma_bank  *cma_bank;
 	struct xocl_pci_info pci_stat;
+	atomic_t		dev_hotplug_done;
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -505,11 +505,6 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		 */
 		if (xocl_axlf_section_header(xdev, axlf, BITSTREAM)) {
 			xocl_xdev_info(xdev, "check interface uuid");
-			if (!XDEV(xdev)->fdt_blob) {
-				userpf_err(xdev, "did not find platform dtb");
-				err = -EINVAL;
-				goto done;
-			}
 			err = xocl_fdt_check_uuids(xdev,
 				(const void *)XDEV(xdev)->fdt_blob,
 				(const void *)((char*)xdev->ulp_blob));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -726,7 +726,7 @@ static ssize_t nodma_show(struct device *dev,
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 
 	/* A shell without dma subdev and with m2m subdev is nodma shell */
-	return sprintf(buf, "%d\n", (M2M_DEV(xdev)) && xocl_m2m_is_nodma(xdev));
+	return sprintf(buf, "%d\n", (!DMA_DEV(xdev) && M2M_DEV(xdev)));
 }
 static DEVICE_ATTR_RO(nodma);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -475,6 +475,28 @@ static ssize_t shutdown_store(struct device *dev,
 }
 static DEVICE_ATTR(shutdown, 0644, shutdown_show, shutdown_store);
 
+static ssize_t dev_hotplug_done_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_dev *xdev = dev_get_drvdata(dev);
+	
+	return sprintf(buf, "%d\n", atomic_read(&xdev->dev_hotplug_done));
+}
+
+static ssize_t dev_hotplug_done_store(struct device *dev,
+	struct device_attribute *da, const char *buf, size_t count)
+{
+	struct xocl_dev *xdev = dev_get_drvdata(dev);
+	u32 val;
+	
+	if (kstrtou32(buf, 10, &val) == -EINVAL)
+		return -EINVAL;
+	
+	atomic_set(&xdev->dev_hotplug_done, val);
+	return count;
+}
+static DEVICE_ATTR(dev_hotplug_done, 0644, dev_hotplug_done_show, dev_hotplug_done_store);
+
 static ssize_t mig_calibration_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
@@ -766,6 +788,7 @@ static struct attribute *xocl_attrs[] = {
  */
 static struct attribute *xocl_persist_attrs[] = {
 	&dev_attr_shutdown.attr,
+	&dev_attr_dev_hotplug_done.attr,
 	&dev_attr_user_pf.attr,
 	NULL,
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -704,7 +704,7 @@ static ssize_t nodma_show(struct device *dev,
 	struct xocl_dev *xdev = dev_get_drvdata(dev);
 
 	/* A shell without dma subdev and with m2m subdev is nodma shell */
-	return sprintf(buf, "%d\n", (!DMA_DEV(xdev) && M2M_DEV(xdev)));
+	return sprintf(buf, "%d\n", (M2M_DEV(xdev)) && xocl_m2m_is_nodma(xdev));
 }
 static DEVICE_ATTR_RO(nodma);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2247,7 +2247,6 @@ struct xocl_m2m_funcs {
 		uint32_t size);
 	void (*get_host_bank)(struct platform_device *pdev, u64 *addr,
 		u64 *size, u8 *used);
-	bool (*is_nodma)(struct platform_device *pdev);
 };
 #define	M2M_DEV(xdev)	\
 	(SUBDEV(xdev, XOCL_SUBDEV_M2M) ? \
@@ -2262,8 +2261,6 @@ struct xocl_m2m_funcs {
 #define xocl_m2m_host_bank(xdev, addr, size, used)				\
 	(M2M_CB(xdev) ? M2M_OPS(xdev)->get_host_bank(M2M_DEV(xdev),	\
 	addr, size, used) : -ENODEV)
-#define xocl_m2m_is_nodma(xdev)				\
-	(M2M_CB(xdev) ? M2M_OPS(xdev)->is_nodma(M2M_DEV(xdev)) : -ENODEV)
 
 struct xocl_pcie_firewall_funcs {
 	struct xocl_subdev_funcs common_funcs;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2245,8 +2245,9 @@ struct xocl_m2m_funcs {
 	int (*copy_bo)(struct platform_device *pdev, uint64_t src_paddr,
 		uint64_t dst_paddr, uint32_t src_handle, uint32_t dst_handle,
 		uint32_t size);
-	int (*get_host_bank)(struct platform_device *pdev, u64 *addr,
-		u64 *size);
+	void (*get_host_bank)(struct platform_device *pdev, u64 *addr,
+		u64 *size, u8 *used);
+	bool (*is_nodma)(struct platform_device *pdev);
 };
 #define	M2M_DEV(xdev)	\
 	(SUBDEV(xdev, XOCL_SUBDEV_M2M) ? \
@@ -2258,9 +2259,11 @@ struct xocl_m2m_funcs {
 #define	xocl_m2m_copy_bo(xdev, src_paddr, dst_paddr, src_handle, dst_handle, size) \
 	(M2M_CB(xdev) ? M2M_OPS(xdev)->copy_bo(M2M_DEV(xdev), src_paddr, dst_paddr, \
 	src_handle, dst_handle, size) : -ENODEV)
-#define xocl_m2m_host_bank(xdev, addr, size)				\
+#define xocl_m2m_host_bank(xdev, addr, size, used)				\
 	(M2M_CB(xdev) ? M2M_OPS(xdev)->get_host_bank(M2M_DEV(xdev),	\
-	addr, size) : -ENODEV)
+	addr, size, used) : -ENODEV)
+#define xocl_m2m_is_nodma(xdev)				\
+	(M2M_CB(xdev) ? M2M_OPS(xdev)->is_nodma(M2M_DEV(xdev)) : -ENODEV)
 
 struct xocl_pcie_firewall_funcs {
 	struct xocl_subdev_funcs common_funcs;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -839,19 +839,6 @@ static struct xocl_subdev_map subdev_map[] = {
 		.max_level = XOCL_SUBDEV_LEVEL_URP,
 	},
 	{
-		.id = XOCL_SUBDEV_M2M,
-		.dev_name = XOCL_M2M,
-		.res_array = (struct xocl_subdev_res[]) {
-			{.res_name = NODE_KDMA_NODMA_CTRL, .regmap_name = PROP_SHELL_KDMA},
-			{NULL},
-		},
-		.required_ip = 1,
-		.flags = 0,
-		.build_priv_data = NULL,
-		.devinfo_cb = NULL,
-		.max_level = XOCL_SUBDEV_LEVEL_URP,
-	},
-	{
 		.id = XOCL_SUBDEV_PCIE_FIREWALL,
 		.dev_name = XOCL_PCIE_FIREWALL,
 		.res_array = (struct xocl_subdev_res[]) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -839,6 +839,19 @@ static struct xocl_subdev_map subdev_map[] = {
 		.max_level = XOCL_SUBDEV_LEVEL_URP,
 	},
 	{
+		.id = XOCL_SUBDEV_M2M,
+		.dev_name = XOCL_M2M,
+		.res_array = (struct xocl_subdev_res[]) {
+			{.res_name = NODE_KDMA_NODMA_CTRL, .regmap_name = PROP_SHELL_KDMA},
+			{NULL},
+		},
+		.required_ip = 1,
+		.flags = 0,
+		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
+		.max_level = XOCL_SUBDEV_LEVEL_URP,
+	},
+	{
 		.id = XOCL_SUBDEV_PCIE_FIREWALL,
 		.dev_name = XOCL_PCIE_FIREWALL,
 		.res_array = (struct xocl_subdev_res[]) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -71,6 +71,7 @@
 #define NODE_CLK_KERNEL2 "ep_aclk_kernel_01"
 #define NODE_CLK_KERNEL3 "ep_aclk_hbm_00"
 #define NODE_KDMA_CTRL "ep_kdma_ctrl_00"
+#define NODE_KDMA_NODMA_CTRL "ep_kdma_nodma_ctrl_00"
 #define NODE_FPGA_CONFIG "ep_fpga_configuration_00"
 #define NODE_FPGA_CONFIG_01 "ep_fpga_configuration_01"
 #define NODE_ICAP_RESET "ep_icap_reset_00"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -71,7 +71,6 @@
 #define NODE_CLK_KERNEL2 "ep_aclk_kernel_01"
 #define NODE_CLK_KERNEL3 "ep_aclk_hbm_00"
 #define NODE_KDMA_CTRL "ep_kdma_ctrl_00"
-#define NODE_KDMA_NODMA_CTRL "ep_kdma_nodma_ctrl_00"
 #define NODE_FPGA_CONFIG "ep_fpga_configuration_00"
 #define NODE_FPGA_CONFIG_01 "ep_fpga_configuration_01"
 #define NODE_ICAP_RESET "ep_icap_reset_00"

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1469,6 +1469,8 @@ int shim::xclLoadAxlf(const axlf *buffer)
         //if EAGAIN is seen, that means a pcie removal&rescan is ongoing, let's just
         //wait and reload 2nd time -- this time the there will be no device id
         //change, hence no pcie removal&rescan, anymore
+	//we need to close the device otherwise the removal&rescan (unload driver) will hang
+	//we also need to reopen the device once removal&rescan completes
         int dev_hotplug_done = 0;
         std::string err;
         dev_fini();

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1464,25 +1464,25 @@ int shim::xclLoadAxlf(const axlf *buffer)
     axlf_obj.kds_cfg.slot_size = mCoreDevice->get_ert_slots(xml_data, xml_size).second;
 
     int ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_READ_AXLF, &axlf_obj);
-    if(ret && errno == EAGAIN) {
+    if (ret && errno == EAGAIN) {
         //special case for aws
-        //if EGAIN is seen, that means a pcie removal&rescan is ongoing, let's just
+        //if EAGAIN is seen, that means a pcie removal&rescan is ongoing, let's just
         //wait and reload 2nd time -- this time the there will be no device id
         //change, hence no pcie removal&rescan, anymore
-        int dev_offline = -1;
+        int dev_hotplug_done = 0;
         std::string err;
         dev_fini();
         std::this_thread::sleep_for(std::chrono::seconds(5));
-        while (dev_offline) {
+        while (!dev_hotplug_done) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(500));
                 pcidev::get_dev(mBoardNumber)->sysfs_get<int>("",
-                "dev_offline", err, dev_offline, -1);
+                "dev_hotplug_done", err, dev_hotplug_done, 0);
         }
         dev_init();
         ret = mDev->ioctl(mUserHandle, DRM_IOCTL_XOCL_READ_AXLF, &axlf_obj);
     }
     
-    if(ret)
+    if (ret)
         return -errno;
 
     // If it is an XPR DSA, zero out the DDR again as downloading the XCLBIN

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.cpp
@@ -566,7 +566,8 @@ int AwsDev::awsLoadXclBin(const xclBin *buffer)
     if (imageInfoOld.spec.map[FPGA_APP_PF].device_id != imageInfoNew.ids.afi_device_ids.device_id ||
         imageInfoOld.sh_version != imageInfoNew.sh_version) {
         std::cout << "pci removal & rescan..." << std::endl;
-        pcidev::get_dev(index)->sysfs_put("", "dev_hotplug_done", errmsg, 0);
+        std::string err;
+        pcidev::get_dev(index)->sysfs_put("", "dev_hotplug_done", err, 0);
 	    
         if (rescan_thread[mBoardNumber].joinable())
                 rescan_thread[mBoardNumber].join();

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -26,6 +26,7 @@
 #include "core/pcie/driver/linux/include/mailbox_proto.h"
 #include "core/pcie/driver/linux/include/mgmt-ioctl.h"
 #include "core/pcie/linux/scan.h"
+#include "core/pcie/linux/shim.h"
 #include "../mpd_plugin.h"
 #include "../common.h"
 #include "../sw_msg.h"
@@ -126,6 +127,7 @@ private:
 #else
     int sleepUntilLoaded( const std::string &afi, fpga_mgmt_image_info* new_afi );
     char* get_afi_from_axlf(const axlf * buffer);
+    int index;
 #endif
 };
 

--- a/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
+++ b/src/runtime_src/core/pcie/tools/cloud-daemon/aws/aws_dev.h
@@ -98,33 +98,6 @@ public:
 
             std::string sysfs_name = domain_str.str() + ":" + bus_str.str() + ":" + dev_str.str() + "." + func_str;
             index_map[sysfs_name] = i;
-
-            if (spec_array[i].map[FPGA_APP_PF].device_id == AWS_UserPF_DEVICE_ID) {
-                std::cout << "aws: load default afi to " << sysfs_name  << std::endl;
-                std::string agfi = DEFAULT_GLOBAL_AFI;
-                fpga_mgmt_load_local_image( i, const_cast<char*>(agfi.c_str()) );
-                int j, result = 0;
-                for (j = 0; j < 300; j++) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                    fpga_mgmt_image_info info;
-                    std::memset( &info, 0, sizeof(struct fpga_mgmt_image_info));
-                    result = fpga_mgmt_describe_local_image(i, &info, 0);
-                    if (result) {
-                        std::cout << "aws: init: load default afi failed: " << result << std::endl;
-                        break;
-                    }
-                    if( (info.status == FPGA_STATUS_LOADED) && !std::strcmp(info.ids.afi_id, const_cast<char*>(agfi.c_str())) ) {
-                        break;
-                }
-                if (j >= 300) {
-                    std::cout << "aws: init: load default afi timeout" << std::endl;
-                    break;
-                }
-                if (result)
-                    break;
-                fpga_pci_rescan_slot_app_pfs(i);
-                }
-            }
         }
 #endif
         return 0;
@@ -151,7 +124,7 @@ private:
 #ifdef INTERNAL_TESTING_FOR_AWS
     int mMgtHandle;
 #else
-    int sleepUntilLoaded( const std::string &afi );
+    int sleepUntilLoaded( const std::string &afi, fpga_mgmt_image_info* new_afi );
     char* get_afi_from_axlf(const axlf * buffer);
 #endif
 };


### PR DESCRIPTION
@xdavidz please review the changes in icap.c
since m2m is created during xclbin is loaded, the mem topology and group metadata have to be cached after the m2m is created. Please review whether the sequence change will bring any issues.
@houlz0507 
there is change in interface-uuid check since is this case, xclbin has partition metadata, while the shell doesn't. for aws nodma xclbin, there is no interface-uuid in the xclbin partition metadata

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. add xrt support to nodma small shell on aws f1
2. add device id and/or shell change xrt support on aws f1 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
1. xclbin for nodma shell is built with raptor flow which has partition metadata, nodma shell on aws is built by aws, there is no metadata at all. xrt needs to handle this case where the m2m and slave bridge IPs are in xclbin metadata
2. CR-1113151 device id change support in aws f1
It is a known issue that we don't support device id change for xdma shell. we loaded a default agfi to change the device id before we open mailbox. once mailbox is opened, we don't allow device id change then
It is a more desired requirement to support device id change in xrt when we have nodma shell support since nodma shell will have a different device id than xdma shell
#### How problem was solved, alternative solutions (if any) and why they were rejected
1. m2m and slavebridge subdevices metadata are in xclbin, and they will be created during xclbin download
2. on aws f1, device id change needs a pcie removal and rescan during xclbin load, which will unload driver, this will make the xclbin load fail.
the fix is in aws plugin, if removal and rescan is required during xclbin load, it returns a EAGAIN  to xrt shim, and at the same time do the removal&rescan in a separate thread. The shim, when seeing the EAGAIN, doesn't return failure to user, it will reload the xclbin later, in which case, the device id has been changed already.  
with the fix, xrt doesn't depend on a default agfi again.
#### Risks (if any) associated the changes in the commit
xrt will not return EAGAIN for other alveo cards during xclbin load, so the change doesn't have any impact or behavior change to non-aws case
#### What has been tested and how, request additional testing if necessary
xdma and nodma test on aws f1
alveo u50 nodma test
#### Documentation impact (if any)
