### PR TITLE
Leverage xrt::xclbin abstraction in OpenCL implementation

### DIFF
--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -36,7 +36,7 @@ get_axlf_section(const xrt::xclbin& xclbin, axlf_section_kind kind);
 std::vector<std::pair<const char*, size_t>>
 get_axlf_sections(const xrt::xclbin& xclbin, axlf_section_kind kind);
 
-// read_xclbin() - Read specified xclbin file 
+// read_xclbin() - Read specified xclbin file
 std::vector<char>
 read_xclbin(const std::string& fnm);
 
@@ -47,6 +47,7 @@ get_properties(const xrt::xclbin::kernel& kernel);
 // get_arginfo() - Get xclbin kernel argument metadata
 // Sorted by arg index, but appended with rtinfo args (if any)
 // which have no index
+XRT_CORE_COMMON_EXPORT
 const std::vector<xrt_core::xclbin::kernel_argument>&
 get_arginfo(const xrt::xclbin::kernel& kernel);
 

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -293,6 +293,7 @@ public:
   get_memory_type(size_t memidx) const;
 
   // get_cus() - Get list cu base addresses sorted by cu inidex
+  XRT_CORE_COMMON_EXPORT
   const std::vector<uint64_t>&
   get_cus(const uuid& xclbin_id = uuid()) const;
 

--- a/src/runtime_src/xocl/core/compute_unit.cpp
+++ b/src/runtime_src/xocl/core/compute_unit.cpp
@@ -21,6 +21,7 @@
 #include "program.h"
 
 #include "core/common/xclbin_parser.h"
+#include "core/common/api/xclbin_int.h"
 
 #include <algorithm>
 #include <iostream>
@@ -29,9 +30,18 @@
 namespace xocl {
 
 compute_unit::
-compute_unit(const xclbin::symbol* s, const std::string& n, size_t base, size_t idx, const device* d)
-  : m_symbol(s), m_name(n), m_device(d), m_address(base), m_index(idx)
-  , m_control(xrt_core::xclbin::get_cu_control(d->get_axlf_section<const ::ip_layout*>(IP_LAYOUT),base))
+compute_unit(const xclbin::symbol* s,
+             xrt::xclbin::kernel xkernel,
+             xrt::xclbin::ip xcu,
+             size_t idx,
+             const device* d)
+  : m_symbol(s)
+  , m_xkernel(std::move(xkernel))
+  , m_xcu(std::move(xcu))
+  , m_device(d)
+  , m_address(m_xcu.get_base_address())
+  , m_index(idx)
+  , m_control(static_cast<decltype(m_control)>(m_xcu.get_control_type()))
 {
   static unsigned int count = 0;
   m_uid = count++;
@@ -45,21 +55,32 @@ compute_unit::
   XOCL_DEBUG(std::cout,"xocl::compute_unit::~compute_unit(",m_uid,")\n");
 }
 
-xclbin::memidx_bitmask_type
+std::string
 compute_unit::
-get_memidx_nolock(unsigned int argidx) const
+get_name() const
+{
+  std::string name = m_xcu.get_name();
+  auto pos = name.find(":");
+  return (pos != std::string::npos)
+    ? name.substr(pos+1)
+    : name;
+}
+
+  xclbin::memidx_bitmask_type
+compute_unit::
+get_memidx_nolock(size_t argidx) const
 {
   auto itr = m_memidx_mask.find(argidx);
   if (itr == m_memidx_mask.end()) {
     auto xclbin = m_device->get_xclbin();
-    itr = m_memidx_mask.insert(itr,std::make_pair(argidx,xclbin.cu_address_to_memidx(m_address,argidx)));
+    itr = m_memidx_mask.insert(itr,std::make_pair(argidx,xclbin.cu_address_to_memidx(m_address,static_cast<int32_t>(argidx))));
   }
   return (*itr).second;
 }
 
 xclbin::memidx_bitmask_type
 compute_unit::
-get_memidx(unsigned int argidx) const
+get_memidx(size_t argidx) const
 {
   std::lock_guard<std::mutex> lk(m_mutex);
   return get_memidx_nolock(argidx);
@@ -77,13 +98,12 @@ get_memidx_intersect() const
   cached = true;
 
   m_memidx.set(); // all bits true
-  int argidx = 0;
-  for (auto& arg : m_symbol->arguments) {
-    if (arg.atype!=xclbin::symbol::arg::argtype::indexed)
+  for (auto& arg : xrt_core::xclbin_int::get_arginfo(m_xkernel)) {
+    using kernel_argument = xrt_core::xclbin::kernel_argument;
+    if (arg.index == kernel_argument::no_index)
       continue;
-    if (arg.address_qualifier==1 || arg.address_qualifier==2) // global or constant
-      m_memidx &= get_memidx_nolock(argidx);
-    ++argidx;
+    if (arg.type == kernel_argument::argtype::global || arg.type == kernel_argument::argtype::constant)
+      m_memidx &= get_memidx_nolock(arg.index);
   }
 
   return m_memidx;
@@ -99,10 +119,13 @@ get_memidx_union() const
 
 std::unique_ptr<compute_unit>
 compute_unit::
-create(const xclbin::symbol* symbol, const xclbin::symbol::instance& inst,
-       const device* device, const std::vector<uint64_t>& cu2addr)
+create(const xclbin::symbol* symbol,
+       const xrt::xclbin::kernel& xkernel,
+       const xrt::xclbin::ip& xcu,
+       const device* device,
+       const std::vector<uint64_t>& cu2addr)
 {
-  auto itr = std::find(cu2addr.begin(),cu2addr.end(),inst.base);
+  auto itr = std::find(cu2addr.begin(), cu2addr.end(), xcu.get_base_address());
 
   // streaming CUs have bogus inst.base in XML meta data and will not
   // be found in cu2addr.  Here we rely on the sorted cu2addr having
@@ -112,16 +135,8 @@ create(const xclbin::symbol* symbol, const xclbin::symbol::instance& inst,
     ? std::distance(cu2addr.begin(),itr)
     : cu2addr.size()-1;  // unused cus are pushed to end
 
-  // streaming CUs have a bogus / unused base address, the address
-  // doesn't matter we just use max, which corresponds to the sort
-  // order in cu2addr.
-  size_t addr = itr!=cu2addr.end()
-    ? (*itr)
-    : std::numeric_limits<size_t>::max(); // addr doesn't matter
-
   // Unfortunately make_unique can't access private ctor
   // return std::make_unique<compute_unit>(symbol,inst.name,inst.base,idx,device);
-  return std::unique_ptr<compute_unit>(new compute_unit(symbol,inst.name,addr,idx,device));
+  return std::unique_ptr<compute_unit>(new compute_unit(symbol, xkernel, xcu, idx, device));
 }
-
 } // xocl

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -695,11 +695,13 @@ private:
 
   unsigned int m_uid = 0;
   program* m_active = nullptr;   // program loaded on to this device
-  xclbin m_metadata;             // cache xclbin that came from program
+  xrt::xclbin m_xclbin;          // the xclbin loaded on this device
+  xclbin m_metadata;             // cache parsed meta data from xclbin
   unsigned int m_locks = 0;      // number of locks on this device
 
   platform* m_platform = nullptr;
   xrt_xocl::device* m_xdevice = nullptr;
+  xrt_core::device* m_cdevice = nullptr;  // in transition to core xrt
 
   // Set for sub-device only
   ptr<device> m_parent = nullptr;


### PR DESCRIPTION
#### Problem solved by the commit
This is a continuation of #5952.  Minor tweaks to use the xclbin
abstraction in compute unit and device.

#### Risks (if any) associated the changes in the commit
Risks are as for #5952.

#### What has been tested and how, request additional testing if necessary
Testing has excercised OpenCL hw tests and few emulation tests.