### PR TITLE
CR-1114887  [XRT] ERROR: No BDF

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -191,7 +191,7 @@ std::string
 device::
 get_bdf() const
 {
-  if (!m_cdevice)
+  if (!m_xdevice)
     throw xocl::error(CL_INVALID_DEVICE, "No BDF");
 
   // logically const


### PR DESCRIPTION
Fix regression due to #5969.
The core device object is only available after the cl_device has been
locked and opened by the driver.
