### PR TITLE
VITIS-717 switch to bidirection xgq and enable vsec

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3098,8 +3098,8 @@ struct xocl_subdev_map {
 #define XOCL_RES_MAILBOX_VSEC				\
 	((struct resource []) {				\
 		{					\
-			.start	= 0x0,		\
-			.end	= 0x2F,		\
+			.start	= 0x0,			\
+			.end	= 0x2F,			\
 			.flags  = IORESOURCE_MEM,	\
 		},					\
 	})
@@ -3113,6 +3113,33 @@ struct xocl_subdev_map {
 		.bar_idx = (char []){ 0 },		\
 		.override_idx = -1,			\
 	}
+
+#define XOCL_RES_XGQ_VSEC				\
+	((struct resource []) {				\
+		{					\
+			.start	= 0x0,			\
+			.end	= 0x0,			\
+	 		.name   = NODE_XGQ_SQ_BASE,	\
+			.flags  = IORESOURCE_MEM,	\
+		},					\
+		{					\
+			.start	= 0x0,			\
+			.end	= 0x0,			\
+	 		.name   = NODE_XGQ_RING_BASE,	\
+			.flags  = IORESOURCE_MEM,	\
+		},					\
+	})
+
+#define XOCL_DEVINFO_XGQ_VSEC				\
+	{						\
+		XOCL_SUBDEV_XGQ,			\
+		XOCL_XGQ,				\
+		XOCL_RES_XGQ_VSEC,			\
+		ARRAY_SIZE(XOCL_RES_XGQ_VSEC),		\
+		.bar_idx = (char []){ 0, 0 },		\
+		.override_idx = -1,			\
+	}
+
 
 #define XOCL_RES_FLASH_BLP				\
 	((struct resource []) {				\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -57,12 +57,12 @@
  *	 synchronized operation, client always wait till server respond.
  */
 
-#define XGQ_SQ_TAIL_POINTER	0x0
-#define XGQ_SQ_INTR_REG		0x4
-#define XGQ_SQ_INTR_CTRL	0xC
-#define XGQ_CQ_TAIL_POINTER	0x100
-#define XGQ_CQ_INTR_REG		0x104
-#define XGQ_CQ_INTR_CTRL	0x10C
+#define XGQ_SQ_TAIL_POINTER     0x0
+#define XGQ_SQ_INTR_REG         0x4
+#define XGQ_SQ_INTR_CTRL        0xC
+#define XGQ_CQ_TAIL_POINTER     0x100
+#define XGQ_CQ_INTR_REG         0x104
+#define XGQ_CQ_INTR_CTRL        0x10C
 
 #define	XGQ_ERR(xgq, fmt, arg...)	\
 	xocl_err(&(xgq)->xgq_pdev->dev, fmt "\n", ##arg)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -57,6 +57,13 @@
  *	 synchronized operation, client always wait till server respond.
  */
 
+#define XGQ_SQ_TAIL_POINTER	0x0
+#define XGQ_SQ_INTR_REG		0x4
+#define XGQ_SQ_INTR_CTRL	0xC
+#define XGQ_CQ_TAIL_POINTER	0x100
+#define XGQ_CQ_INTR_REG		0x104
+#define XGQ_CQ_INTR_CTRL	0x10C
+
 #define	XGQ_ERR(xgq, fmt, arg...)	\
 	xocl_err(&(xgq)->xgq_pdev->dev, fmt "\n", ##arg)
 #define	XGQ_WARN(xgq, fmt, arg...)	\
@@ -1162,8 +1169,6 @@ static int xgq_remove(struct platform_device *pdev)
 		iounmap(xgq->xgq_ring_base);
 	if (xgq->xgq_sq_base)
 		iounmap(xgq->xgq_sq_base);
-	if (xgq->xgq_cq_base)
-		iounmap(xgq->xgq_cq_base);
 
 	sysfs_remove_group(&pdev->dev.kobj, &xgq_attr_group);
 	mutex_destroy(&xgq->xgq_lock);
@@ -1212,21 +1217,20 @@ static int xgq_probe(struct platform_device *pdev)
 			xgq->xgq_sq_base = ioremap_nocache(res->start,
 				res->end - res->start + 1);
 		}
-		if (!strncmp(res->name, NODE_XGQ_CQ_BASE, strlen(NODE_XGQ_CQ_BASE))) {
-			xgq->xgq_cq_base = ioremap_nocache(res->start,
-				res->end - res->start + 1);
-		}
 		if (!strncmp(res->name, NODE_XGQ_RING_BASE, strlen(NODE_XGQ_RING_BASE))) {
 			xgq->xgq_ring_base = ioremap_nocache(res->start,
 				res->end - res->start + 1);
 		}
 	}
 
-	if (!xgq->xgq_sq_base || !xgq->xgq_cq_base || !xgq->xgq_ring_base) {
+	if (!xgq->xgq_sq_base || !xgq->xgq_ring_base) {
 		ret = -EIO;
 		XGQ_ERR(xgq, "platform get resource failed");
 		goto attach_failed;
 	}
+
+	xgq->xgq_sq_base = xgq->xgq_sq_base + XGQ_SQ_TAIL_POINTER;
+	xgq->xgq_cq_base = xgq->xgq_sq_base + XGQ_CQ_TAIL_POINTER;
 
 	/* check device is ready */
 	if (xgq_device_is_ready(xgq)) {
@@ -1235,9 +1239,6 @@ static int xgq_probe(struct platform_device *pdev)
 		goto attach_failed;
 	}
 
-	/* server to reset SQ tail pointer status */
-	//iowrite32(0x0, xgq->xgq_sq_base);
-	
 	flags &= ~XGQ_SERVER;
 	ret = xgq_attach(&xgq->xgq_queue, flags, (u64)xgq->xgq_ring_base,
 		(u64)xgq->xgq_sq_base, (u64)xgq->xgq_cq_base);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -337,12 +337,13 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_FLASH_CONTROLER   0x51
 #define XOCL_VSEC_PLATFORM_INFO     0x52
 #define XOCL_VSEC_MAILBOX           0x53
+#define XOCL_VSEC_XGQ          	    0x54
+#define XOCL_VSEC_XGQ_PAYLOAD       0x55
 
 #define XOCL_VSEC_FLASH_TYPE_SPI_IP		0x0
 #define XOCL_VSEC_FLASH_TYPE_SPI_REG		0x1
 #define XOCL_VSEC_FLASH_TYPE_QSPI		0x2
 #define XOCL_VSEC_FLASH_TYPE_XFER_VERSAL	0x3
-#define XOCL_VSEC_FLASH_TYPE_XGQ		0x4
 
 #define XOCL_VSEC_PLAT_RECOVERY     0x0
 #define XOCL_VSEC_PLAT_1RP          0x1

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -337,7 +337,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_FLASH_CONTROLER   0x51
 #define XOCL_VSEC_PLATFORM_INFO     0x52
 #define XOCL_VSEC_MAILBOX           0x53
-#define XOCL_VSEC_XGQ          	    0x54
+#define XOCL_VSEC_XGQ               0x54
 #define XOCL_VSEC_XGQ_PAYLOAD       0x55
 
 #define XOCL_VSEC_FLASH_TYPE_SPI_IP		0x0

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -733,21 +733,6 @@ static struct xocl_subdev_map subdev_map[] = {
 		.max_level = XOCL_SUBDEV_LEVEL_PRP,
 	},
 	{
-		.id = XOCL_SUBDEV_XGQ,
-		.dev_name = XOCL_XGQ,
-		.res_array = (struct xocl_subdev_res[]) {
-			{.res_name = NODE_XGQ_SQ_BASE},
-			{.res_name = NODE_XGQ_CQ_BASE},
-			{.res_name = NODE_XGQ_RING_BASE},
-			{NULL},
-		},
-		.required_ip = 1,
-		.flags = 0,
-		.build_priv_data = NULL,
-		.devinfo_cb = NULL,
-		.max_level = XOCL_SUBDEV_LEVEL_PRP,
-	},
-	{
 		.id = XOCL_SUBDEV_XFER_VERSAL,
 		.dev_name = XOCL_XFER_VERSAL,
 		.res_array = (struct xocl_subdev_res[]) {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -112,7 +112,6 @@
 #define NODE_PCIE "pcie"
 #define NODE_BARS "bars"
 #define NODE_XGQ_SQ_BASE "ep_xgq_mgmt_to_rpu_sq_pi_00"
-#define NODE_XGQ_CQ_BASE "ep_xgq_mgmt_to_rpu_cq_ci_00"
 #define NODE_XGQ_RING_BASE "ep_xgq_payload_mgmt_00"
 
 #define PROP_BARM_CTRL "axi_bram_ctrl"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1455,6 +1455,8 @@ xocl_subdev_vsec_read32(xdev_handle_t xdev, int bar, u64 offset)
  * |rsvd                        |
  * +----+-----------------------|
  *  ... next entry ...
+ *
+ * TODO: refactor this code to use struct bit field and memcpy_fromio
  */
 int
 xocl_subdev_vsec(xdev_handle_t xdev, u32 type,
@@ -1674,30 +1676,53 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			if (ret)
 				return ret;
 			break;
-		case XOCL_VSEC_FLASH_TYPE_XGQ:
-			/*TODO: VSEC definition is TBD, we now get res from metadata */
-			xocl_xdev_dbg(xdev,
-			    "VSEC XGQ FLASH RES Start 0x%llx, bar %d",
-			    offset, bar);
-
-			/* set devinfo to xfer versal */
-			subdev_info.id = XOCL_SUBDEV_XGQ;
-			subdev_info.name = XOCL_XGQ;
-			subdev_info.res[0].name = XOCL_XGQ;
-			memcpy(((struct xocl_flash_privdata *)
-			    (subdev_info.priv_data))->flash_type,
-			    FLASH_TYPE_OSPI_XGQ, strlen(FLASH_TYPE_OSPI_XGQ));
-
-			ret = xocl_subdev_create_vsec_impl(xdev, &subdev_info,
-				offset, bar);
-
-			if (ret)
-				return ret;
-			break;
 		default:
 			xocl_xdev_err(xdev, "Unsupport flash type 0x%x", vtype);
 			break;
 		}
+	}
+
+	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_XGQ, &bar, &offset, NULL);
+	if (!ret) {
+		int bar_payload = 0; 
+		u64 offset_payload = 0;
+		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XGQ_VSEC;
+
+		ret = xocl_subdev_vsec(xdev, XOCL_VSEC_XGQ_PAYLOAD,
+			&bar_payload, &offset_payload, NULL);
+		if (ret) {
+			xocl_xdev_err(xdev, "Found XGQ, but missed XGQ_PAYLOAD");
+			goto done;
+		}
+
+		subdev_info.bar_idx[0] = bar;
+		subdev_info.bar_idx[1] = bar_payload;
+
+		/*
+		 * TODO: update the payload actual size from device later.
+		 * all end_points from VSEC should just have 0x1000(4k) size.
+		 * For now, just hardcode the size which will be reported by
+		 * the device.
+		 */
+		subdev_info.res[0].start = offset;
+		subdev_info.res[0].end = offset + 0xfff;
+		subdev_info.res[0].name = NODE_XGQ_SQ_BASE;
+
+		subdev_info.res[1].start = offset_payload;
+		subdev_info.res[1].end = offset_payload + 0x7ffffff;
+		subdev_info.res[1].name = NODE_XGQ_RING_BASE;
+
+		xocl_xdev_dbg(xdev,
+		    "VSEC XGQ Start 0x%llx, bar %d. XGQ Payload 0x%llx, bar %d",
+		    offset, bar, offset_payload, bar_payload);
+
+		ret = xocl_subdev_create(xdev, &subdev_info);
+		if (ret) {
+			xocl_xdev_err(xdev, "Create XGQ subdev failed. %d", ret);
+			goto done;
+		}
+
+		xocl_xdev_dbg(xdev, "VSEC XGQ created.");
 	}
 
 	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_MAILBOX, &bar, &offset, NULL);
@@ -1714,6 +1739,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 			return ret;
 	}
 
+done:
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
switch to single xgq endpoint
enable VSEC of XGQ

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested with Drop18

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=277338276