### PR TITLE
CR-1112832: Adding opencl_trace value to the reported parameters listed in the summary file

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -27,6 +27,8 @@ namespace xdp {
                  "Profiling (deprecated)");
     addParameter("opencl_summary", xrt_core::config::get_opencl_summary(),
                  "Generation of OpenCL summary report");
+    addParameter("opencl_trace", xrt_core::config::get_opencl_trace(),
+                 "Generation of trace of OpenCL APIs and memory transfers");
     addParameter("opencl_device_counter",
                  xrt_core::config::get_opencl_device_counter(),
                  "Hardware counters added to OpenCL summary file");


### PR DESCRIPTION
#### Problem solved by the commit
The profiling summary file lists the set values of the xrt.ini file options (which are then displayed in Vitis Analyzer), but was missing the value set for opencl_trace.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This adds the value of opencl_trace to our output files so the user can see how it was set in the run.
