### PR TITLE
Leverage xrt::xclbin abstraction in OpenCL

### DIFF
--- a/src/runtime_src/core/common/api/xclbin_int.h
+++ b/src/runtime_src/core/common/api/xclbin_int.h
@@ -41,6 +41,7 @@ std::vector<char>
 read_xclbin(const std::string& fnm);
 
 // get_properties() - Get kernel properties
+XRT_CORE_COMMON_EXPORT
 const xrt_core::xclbin::kernel_properties&
 get_properties(const xrt::xclbin::kernel& kernel);
 

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -19,7 +19,9 @@
 
 #include "core/common/config.h"
 #include "xclbin.h"
+#include <array>
 #include <limits>
+#include <map>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -39,6 +41,7 @@ struct kernel_argument
   std::string name;
   std::string hosttype;
   std::string port;
+  size_t port_width = 0;
   size_t index = no_index;
   size_t offset = 0;
   size_t size = 0;
@@ -59,6 +62,12 @@ struct kernel_properties
   mailbox_type mailbox = mailbox_type::none;
   size_t address_range = 0;
   bool sw_reset = false;
+
+  // opencl specifics
+  size_t workgroupsize = 0;
+  std::array<size_t, 3> compileworkgroupsize {0};
+  std::array<size_t, 3> maxworkgroupsize {0};
+  std::map<uint32_t, std::string> stringtable;
 };
 
 struct kernel_object

--- a/src/runtime_src/xocl/api/plugin/xdp/profile_trace.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/profile_trace.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -25,6 +25,7 @@
 #include "core/common/dlfcn.h"
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
+#include "core/common/api/xclbin_int.h"
 
 #include "xocl/core/command_queue.h"
 #include "xocl/core/program.h"
@@ -583,11 +584,11 @@ namespace xocl {
       auto xcontext = xevent->get_execution_context() ;
       auto workGroupSize = xkernel->get_wg_size() ;
       auto device = xevent->get_command_queue()->get_device() ;
-      auto xclbin = xkernel->get_program()->get_xclbin(device) ;
+      auto xclbin = device->get_xrt_xclbin();
       
       std::string deviceName = device->get_name() ;
       std::string kernelName = xkernel->get_name() ;
-      std::string binaryName = xclbin.project_name() ;
+      std::string binaryName = xrt_core::xclbin_int::get_project_name(xclbin);
 
       size_t localWorkDim[3] = {0, 0, 0} ;
       range_copy(xkernel->get_compile_wg_size_range(), localWorkDim) ;

--- a/src/runtime_src/xocl/core/compute_unit.cpp
+++ b/src/runtime_src/xocl/core/compute_unit.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,13 +30,11 @@
 namespace xocl {
 
 compute_unit::
-compute_unit(const xclbin::symbol* s,
-             xrt::xclbin::kernel xkernel,
+compute_unit(xrt::xclbin::kernel xkernel,
              xrt::xclbin::ip xcu,
              size_t idx,
              const device* d)
-  : m_symbol(s)
-  , m_xkernel(std::move(xkernel))
+  : m_xkernel(std::move(xkernel))
   , m_xcu(std::move(xcu))
   , m_device(d)
   , m_address(m_xcu.get_base_address())
@@ -119,8 +117,7 @@ get_memidx_union() const
 
 std::unique_ptr<compute_unit>
 compute_unit::
-create(const xclbin::symbol* symbol,
-       const xrt::xclbin::kernel& xkernel,
+create(const xrt::xclbin::kernel& xkernel,
        const xrt::xclbin::ip& xcu,
        const device* device,
        const std::vector<uint64_t>& cu2addr)
@@ -137,6 +134,6 @@ create(const xclbin::symbol* symbol,
 
   // Unfortunately make_unique can't access private ctor
   // return std::make_unique<compute_unit>(symbol,inst.name,inst.base,idx,device);
-  return std::unique_ptr<compute_unit>(new compute_unit(symbol, xkernel, xcu, idx, device));
+  return std::unique_ptr<compute_unit>(new compute_unit(xkernel, xcu, idx, device));
 }
 } // xocl

--- a/src/runtime_src/xocl/core/device.h
+++ b/src/runtime_src/xocl/core/device.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -481,10 +481,22 @@ public:
   /**
    * @return
    *  Current loaded xclbin
+   *
+   * Deprecated, to be removed when core xrt is used
    */
   XRT_XOCL_EXPORT
   xclbin
   get_xclbin() const;
+
+  /**
+   * @return 
+   *   Current loaded xrt::xclbin
+   */
+  const xrt::xclbin&
+  get_xrt_xclbin() const
+  {
+    return m_xclbin;
+  }
 
   /**
    * @return

--- a/src/runtime_src/xocl/core/kernel.cpp
+++ b/src/runtime_src/xocl/core/kernel.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -21,6 +21,7 @@
 #include "compute_unit.h"
 
 #include "core/common/api/kernel_int.h"
+#include "core/common/api/xclbin_int.h"
 #include "core/common/xclbin_parser.h"
 
 #include <sstream>
@@ -147,8 +148,11 @@ set(const void* cvalue, size_t sz)
 }
 
 kernel::
-kernel(program* prog, const std::string& name, const xclbin::symbol& symbol)
-  : m_program(prog), m_name(kernel_utils::normalize_kernel_name(name)), m_symbol(symbol)
+kernel(program* prog, const std::string& name, xrt::xclbin::kernel xk)
+  : m_program(prog)
+  , m_name(kernel_utils::normalize_kernel_name(name))
+  , m_xkernel(std::move(xk))
+  , m_properties(xrt_core::xclbin_int::get_properties(m_xkernel))
 {
   static unsigned int uid_count = 0;
   m_uid = uid_count++;

--- a/src/runtime_src/xocl/core/kernel.h
+++ b/src/runtime_src/xocl/core/kernel.h
@@ -161,8 +161,7 @@ public:
   // only program constructs kernels, but private doesn't work as long
   // std::make_unique is used
   friend class program; // only program constructs kernels
-  kernel(program* prog, const std::string& name,const xclbin::symbol&);
-  kernel(program* prog, const std::string& name);
+  kernel(program* prog, const std::string& name, xrt::xclbin::kernel xk);
 
 public:
   virtual ~kernel();
@@ -175,10 +174,10 @@ public:
   }
 
   // Get unique id for the kernel symbol associated with this object
-  unsigned int
+  const void*
   get_symbol_uid() const
   {
-    return m_symbol.uid;
+    return m_xkernel.get_handle().get();
   }
 
   // Get the program used to construct this kernel object
@@ -200,36 +199,36 @@ public:
     return m_name;
   }
 
-  const std::string&
+  std::string
   get_attributes() const
   {
-    return m_symbol.attributes;
+    return "";
   }
 
   size_t
   get_wg_size() const
   {
-    return m_symbol.workgroupsize;
+    return m_properties.workgroupsize;
   }
 
   // Get compile work group size per xclbin
   range<const size_t*>
   get_compile_wg_size_range() const
   {
-    return range<const size_t*>(m_symbol.compileworkgroupsize,m_symbol.compileworkgroupsize+3);
+    return range<const size_t*>(m_properties.compileworkgroupsize.data(),m_properties.compileworkgroupsize.data()+3);
   }
 
   //  Get max work group size per xclbin
   range<const size_t*>
   get_max_wg_size_range() const
   {
-    return range<const size_t*>(m_symbol.maxworkgroupsize,m_symbol.maxworkgroupsize+3);
+    return range<const size_t*>(m_properties.maxworkgroupsize.data(),m_properties.maxworkgroupsize.data()+3);
   }
 
-  auto
-  get_stringtable() const -> decltype(xclbin::symbol::stringtable)
+  decltype(xrt_core::xclbin::kernel_properties::stringtable)
+  get_stringtable() const
   {
-    return m_symbol.stringtable;
+    return m_properties.stringtable;
   }
 
   bool
@@ -376,7 +375,10 @@ private:
   unsigned int m_uid = 0;
   ptr<program> m_program;     // retain reference
   std::string m_name;
-  const xclbin::symbol& m_symbol;
+
+  // xclbin meta
+  xrt::xclbin::kernel m_xkernel;
+  const xrt_core::xclbin::kernel_properties& m_properties;
 
   xargument_vector_type m_indexed_xargs;
   xargument_vector_type m_rtinfo_xargs;

--- a/src/runtime_src/xocl/core/program.cpp
+++ b/src/runtime_src/xocl/core/program.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -195,15 +195,24 @@ create_kernel(const std::string& kernel_name)
 {
   auto deleter = [](kernel* k) { k->release(); };
 
-  // Look up kernel symbol from arbitrary (first) xclbin
+  // Look up kernel symbol from first matching xclbin
   if (m_binaries.empty())
     throw xocl::error(CL_INVALID_PROGRAM_EXECUTABLE,"No binary for program");
 
-  auto symbol_name = kernel_utils::normalize_kernel_name(kernel_name);
-  auto metadata = get_xclbin(nullptr);
-  auto& symbol = metadata.lookup_kernel(symbol_name);
-  auto k = std::make_unique<kernel>(this,kernel_name,symbol);
-  return std::unique_ptr<kernel,decltype(deleter)>(k.release(),deleter);
+  // Find first matching kernel in any device program
+  auto normalized_kernel_name = kernel_utils::normalize_kernel_name(kernel_name);
+  for (const auto& device : m_devices) {
+    const auto& xclbin = device->get_xrt_xclbin();
+    auto xk = xclbin.get_kernel(normalized_kernel_name);
+    if (!xk)
+      continue;
+
+    auto k = std::make_unique<kernel>(this, kernel_name, xk);
+    return std::unique_ptr<kernel,decltype(deleter)>(k.release(), deleter);
+  }
+
+  throw xocl::error(CL_INVALID_PROGRAM_EXECUTABLE,"Kernel not found");
+
 }
 
 program::creation_type

--- a/src/runtime_src/xocl/xclbin/xclbin.h
+++ b/src/runtime_src/xocl/xclbin/xclbin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
+ * Copyright (C) 2016-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -49,46 +49,6 @@ public:
 
   using target_type = xrt::xclbin::target_type;
 
-  // A symbol captures all data required to construct an xocl::kernel
-  // object.  It is associated with all kernel objects in the xclbin.
-  // The symbol is returned up stream via xclbin::lookup_kernel(name).
-  struct symbol
-  {
-    // Wrap data associated with a kernel argument
-    struct arg {
-      enum class argtype { indexed, printf, rtinfo };
-      std::string name;
-      size_t address_qualifier;
-      std::string id;
-      std::string port;
-      size_t port_width;
-      size_t size;
-      size_t offset;
-      size_t hostoffset;
-      size_t hostsize;
-      std::string type;
-      argtype atype;        // optimization to avoid repeated string cmp
-      symbol* host;
-    };
-
-    // Wrap data associated with kernel instances
-    struct instance {
-      std::string name;   // inst name
-      size_t base;        // base addr
-    };
-
-    std::map<uint32_t,std::string> stringtable;
-
-    std::string name;                // name of kernel
-    unsigned int uid;                // unique id for this symbol, some symbols have same name??
-    std::string attributes;          // attributes as per .cl file
-    size_t workgroupsize = 0;
-    size_t compileworkgroupsize[3] = {0};   //
-    size_t maxworkgroupsize[3] = {0};// xilinx extension
-    std::vector<arg> arguments;      // the args of this kernel
-    std::vector<instance> instances; // the kernel instances
-  };
-
 public:
   xclbin();
 
@@ -107,19 +67,6 @@ public:
   {
     return m_impl != nullptr;
   }
-
-  /**
-   * Get uuid of xclbin
-   */
-  xrt_core::uuid
-  uuid() const;
-
-  /**
-   * Access the project name per xml meta data
-   */
-  XRT_XOCL_EXPORT
-  std::string
-  project_name() const;
 
   /**
    * What target is this xclbin compiled for
@@ -141,24 +88,6 @@ public:
    */
   std::vector<std::string>
   kernel_names() const;
-
-  /**
-   * Get list of kernel symbols in this xclbin
-   */
-  std::vector<const symbol*>
-  kernel_symbols() const;
-
-  /**
-   * Get kernel with specified name.
-   *
-   * The lifetime of the returned object is tied to the lifetime
-   * of this xclbin object, which is tied to the lifetime of the
-   * xocl::program that constructs this object.
-   *
-   * This function is analogous to dlsym.
-   */
-  const symbol&
-  lookup_kernel(const std::string& name) const;
 
   /**
    * Get memory connection indeces for CU argument at specified index


### PR DESCRIPTION
This PR continues #5969, with elimination of the majority of OpenCL
xclbin metadata layer.  In particular all old symbol references now
are entirely based on xrt::xclbin.

Risks are same as for #5969.  Local testing on cached OpenCL HW tests
has been done, but does not cover all cases.
