### PR TITLE
Fix for argument parsing for soft kernel

### DIFF
--- a/src/runtime_src/core/common/pskernel_parse.cpp
+++ b/src/runtime_src/core/common/pskernel_parse.cpp
@@ -221,7 +221,7 @@ pskernel_parse(char *so_file, size_t size, const char *func_name)
     dwarf_end(dw);
   }
 
-  if (!args.empty())
+  if (args.empty())
     throw std::runtime_error("No PS kernel arguments found!");
  
   return args;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Soft kernel argument passing condition incorrect on the host

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Check for argument empty condition corrected.
Found through internal testing

#### How problem was solved, alternative solutions (if any) and why they were rejected
Corrected the condition check

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on internal soft kernel flow

#### Documentation impact (if any)
None