### PR TITLE
CR-1100237: Reducing memory usage when processing large amounts of trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/database.h
+++ b/src/runtime_src/xdp/profile/database/database.h
@@ -40,7 +40,7 @@ namespace xdp {
   {
   public:
     // For messages sent to specific plugins
-    enum MessageType { READ_COUNTERS, READ_TRACE } ;
+    enum MessageType { READ_COUNTERS, READ_TRACE, DUMP_TRACE } ;
 
   private:
     // The information stored in the database will be separated into 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -58,6 +58,8 @@ namespace xdp {
   {
   private:
     VPDatabase* db ;
+    // Number of events to store before flushing to disk
+    const uint64_t DeviceEventThreshold = 10000000 ;
 
   public:
     // Define a public typedef for all plugins that get information

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -42,7 +42,6 @@
 #include "xdp/profile/plugin/vp_base/utility.h"
 
 #include "core/include/xclbin.h"
-#include "core/include/xclperf.h"
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
 

--- a/src/runtime_src/xdp/profile/device/aieTraceS2MM.h
+++ b/src/runtime_src/xdp/profile/device/aieTraceS2MM.h
@@ -64,7 +64,6 @@ public:
      * One word is 64 bit with current implementation
      * IP should support word packing if we want to support 512 bit words
      */
-    virtual void parseTraceBuf(void* /*buf*/, uint64_t /*size*/, xclTraceResultsVector& /*traceVector*/) {}
 };
 
 } //  xdp

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -81,7 +81,7 @@ namespace xdp {
 // Same as defined in vpl tcl
 // NOTE: This converts the property on the FIFO IP in debug_ip_layout
 //       to the corresponding FIFO depth.
-uint32_t GetDeviceTraceBufferSize(uint32_t property)
+uint64_t GetDeviceTraceBufferSize(uint32_t property)
 {
   switch(property) {
     case 0 : return 8192;

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -501,19 +501,12 @@ DeviceIntf::~DeviceIntf()
   }
 
   // Read all values from APM trace AXI stream FIFOs
-  size_t DeviceIntf::readTrace(std::vector<xclTraceResults>& traceVector)
+  size_t DeviceIntf::readTrace(uint32_t*& traceData)
   {
-    if (mVerbose) {
-      std::cout << __func__ << ", " << std::this_thread::get_id()
-                << ", " << &traceVector
-                << ", Reading device trace stream..." << std::endl;
-    }
-
-    if (!mIsDeviceProfiling || !mFifoRead)
-   	  return 0;
+    if (!mIsDeviceProfiling || !mFifoRead) return 0 ;
 
     size_t size = 0;
-    size += mFifoRead->readTrace(traceVector, getTraceCount());
+    size += mFifoRead->readTrace(traceData, getTraceCount());
 
     return size;
   }

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -48,7 +48,7 @@ namespace xdp {
 // Helper methods
 
 XDP_EXPORT
-uint32_t GetDeviceTraceBufferSize(uint32_t property);
+uint64_t GetDeviceTraceBufferSize(uint32_t property);
 
 XDP_EXPORT
 uint64_t GetTS2MMBufSize(bool isAIETrace = false);

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -126,7 +126,7 @@ class DeviceIntf {
     XDP_EXPORT
     size_t stopTrace();
     XDP_EXPORT
-    size_t readTrace(std::vector<xclTraceResults>& traceVector);
+    size_t readTrace(uint32_t*& traceData) ;
 
     /** Trace S2MM Management
      */

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.h
@@ -17,7 +17,6 @@
 #ifndef _XDP_PROFILE_DEVICE_BASE_TRACE_LOGGER_H
 #define _XDP_PROFILE_DEVICE_BASE_TRACE_LOGGER_H
 
-#include "core/include/xclperf.h"
 #include <vector>
 
 #include "xdp/config.h"
@@ -44,6 +43,20 @@ namespace xdp {
     std::vector<uint64_t> aimLastTrans;
     std::vector<uint64_t> asmLastTrans;
 
+    // Parsing functions for getting different parts of a device event packet
+    inline uint64_t getDeviceTimestamp(uint64_t trace)
+      { return (trace & 0x1FFFFFFFFFFF) - firstTimestamp; }
+    inline bool isDeviceEventTypeStart(uint64_t trace)
+      { return ((trace >> 45) & 0xF) ? false : true ;  }
+    inline uint64_t getEventFlags(uint64_t trace)
+      { return ((trace >> 45) & 0xF) | ((trace >> 57) & 0x10) ; }
+    inline uint64_t getTraceId(uint64_t trace)
+      { return ((trace >> 49) & 0xFFF) ; }
+    inline uint64_t getReserved(uint64_t trace)
+      { return ((trace >> 61) & 0x1) ; }
+    inline bool isClockTraining(uint64_t trace)
+      { return (((trace >> 63) & 0x1) == 1) ;}
+
     double clockTrainOffset;
     double traceClockRateMHz;
     double clockTrainSlope;
@@ -53,16 +66,19 @@ namespace xdp {
     void trainDeviceHostTimestamps(uint64_t deviceTimestamp, uint64_t hostTimestamp);
     double convertDeviceToHostTimestamp(uint64_t deviceTimestamp);
 
-    // Functions for adding a specific type of device event
-    void addAMEvent(xclTraceResults& trace, double hostTimestamp);
-    void addAIMEvent(xclTraceResults& trace, double hostTimestamp) ;
+    // Functions for adding device events based on the monitor type
+    void addAMEvent (uint64_t trace, double hostTimestamp) ;
+    void addAIMEvent(uint64_t trace, double hostTimestamp) ;
+    void addASMEvent(uint64_t trace, double hostTimestamp) ;
 
-    void addCUEvent(xclTraceResults& trace, double hostTimestamp,
-                    uint32_t s, uint64_t monTraceID, int32_t cuId);
-    void addStallEvent(xclTraceResults& trace, double hostTimestamp,
-                       uint32_t s, uint64_t monTraceID, int32_t cuId,
+    // Functions for adding specific types of device events from the
+    //  raw device data
+    void addCUEvent(uint64_t trace, double hostTimestamp,
+                    uint32_t slot, uint64_t monTraceId, int32_t cuId) ;
+    void addStallEvent(uint64_t trace, double hostTimestamp,
+                       uint32_t slot, uint64_t monTraceId, int32_t cuId,
                        VTFEventType type, uint64_t mask) ;
-    void addKernelDataTransferEvent(VTFEventType ty, xclTraceResults& trace,
+    void addKernelDataTransferEvent(VTFEventType ty, uint64_t trace,
                                     uint32_t slot, int32_t cuId,
                                     double hostTimestamp) ;
 
@@ -74,19 +90,21 @@ namespace xdp {
     void addApproximateDataTransferEndEvents();
     void addApproximateDataTransferEndEvents(int32_t cuId);
     void addApproximateStreamEndEvents();
-    void addApproximateStallEndEvents(xclTraceResults& trace, double hostTimestamp, uint32_t s, uint64_t monTraceID, int32_t cuId);
+    void addApproximateStallEndEvents(uint64_t trace, double hostTimestamp, uint32_t slot, uint64_t monTraceId, int32_t cuId) ;
 
     void addApproximateDataTransferEvent(VTFEventType type, uint64_t aimTraceID, int32_t amId, int32_t cuId);
     void addApproximateStreamEndEvent(uint64_t asmIndex, uint64_t asmTraceID, VTFEventType streamEventType,
                                       int32_t cuId, int32_t  amId, uint64_t cuLastTimestamp,
                                       uint64_t &asmAppxLastTransTimeStamp, bool &unfinishedASMevents);
 
+    uint64_t firstTimestamp = 0 ;
+
   public:
 
     XDP_EXPORT DeviceTraceLogger(uint64_t devId);
     XDP_EXPORT ~DeviceTraceLogger();
 
-    XDP_EXPORT void processTraceData(std::vector<xclTraceResults>& traceVector);
+    XDP_EXPORT void processTraceData(void* data, uint64_t numBytes) ;
     XDP_EXPORT void endProcessTraceData();
   } ;
 

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -209,8 +209,7 @@ void DeviceTraceOffload::read_trace_fifo(bool)
   if (m_trbuf_full)
     return;
 
-  uint32_t num_packets = 0;
-
+  uint64_t num_packets = 0;
   uint64_t numBytes = 0 ;
 #ifndef _WIN32
   do {

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -136,10 +136,8 @@ void DeviceTraceOffload::process_trace()
     // Processing takes a lot more time compared to everything else
     if (q_read) {
       debug_stream << "Process " << size << " bytes of trace" << std::endl;
-      dev_intf->parseTraceData(buf.get(), size, m_trace_vector);
+      deviceTraceLogger->processTraceData(buf.get(), size) ;
       buf.reset();
-      deviceTraceLogger->processTraceData(m_trace_vector);
-      m_trace_vector.clear();
     }
   } while (!q_empty);
 }
@@ -213,15 +211,18 @@ void DeviceTraceOffload::read_trace_fifo(bool)
 
   uint32_t num_packets = 0;
 
+  uint64_t numBytes = 0 ;
 #ifndef _WIN32
   do {
 #endif
-    m_trace_vector.clear();
-    dev_intf->readTrace(m_trace_vector);
-    deviceTraceLogger->processTraceData(m_trace_vector);
-    num_packets += static_cast<uint32_t>(m_trace_vector.size());
+    uint32_t* buf = nullptr ;
+    numBytes = dev_intf->readTrace(buf) ; // Should allocate buf
+    deviceTraceLogger->processTraceData(buf, numBytes) ;
+    num_packets += numBytes / sizeof(uint64_t) ;
+    if (buf)
+      delete [] buf ;
 #ifndef _WIN32
-  } while (m_trace_vector.size() != 0);
+  } while (numBytes != 0);
 #endif
 
   // Check if fifo is full
@@ -267,7 +268,6 @@ void DeviceTraceOffload::read_trace_end()
 {
   // Trace logger will clear it's state and add approximations 
   // for pending events
-  m_trace_vector.clear();
   deviceTraceLogger->endProcessTraceData();
   if (dev_intf->hasTs2mm()) {
     reset_s2mm();

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -29,7 +29,6 @@
 #include <atomic>
 
 #include "xdp/config.h"
-#include "core/include/xclperf.h"
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/tracedefs.h"
 #include "xdp/profile/device/device_trace_logger.h"
@@ -120,7 +119,6 @@ protected:
     DeviceIntf* dev_intf;
 private:
     DeviceTraceLogger* deviceTraceLogger;
-    std::vector<xclTraceResults> m_trace_vector = {};
     std::function<void(bool)> m_read_trace;
     size_t m_trbuf = 0;
     uint64_t m_trbuf_sz = 0;

--- a/src/runtime_src/xdp/profile/device/profile_ip_access.h
+++ b/src/runtime_src/xdp/profile/device/profile_ip_access.h
@@ -24,7 +24,6 @@
 #include <string>
 #include "xclhal2.h"
 #include "xclbin.h"
-#include "core/include/xclperf.h"
 #include "xdp_base_device.h"
 
 #define PROFILE_IP_SZ 0x1000

--- a/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
+++ b/src/runtime_src/xdp/profile/device/traceFifoFull.cpp
@@ -59,131 +59,33 @@ uint32_t TraceFifoFull::getMaxNumTraceSamples()
     return TRACE_NUMBER_SAMPLES;
 }
 
-uint32_t TraceFifoFull::readTrace(std::vector<xclTraceResults>& traceVector, uint32_t nSamples)
+// This function allocates a buffer and returns the pointer in traceData.
+//  The caller is responsible for reclaiming this memory.
+uint32_t TraceFifoFull::readTrace(uint32_t*& traceData, uint32_t nSamples)
 {
-    if(out_stream)
-      (*out_stream) << " TraceFifoFull::readTrace " << std::endl;
-   
-    if(!nSamples) {
-      return 0;
-    }
+  if (nSamples == 0) {
+    return 0 ;
+  }
 
-    // Limit to max number of samples so we don't overrun trace buffer on host
-    uint32_t maxNumSamples = getMaxNumTraceSamples();
-    uint32_t numSamples    = (nSamples > maxNumSamples) ? maxNumSamples : nSamples;
+  // Limit to max number of samples so we don't overrun trace buffer on host
+  uint32_t maxNumSamples = getMaxNumTraceSamples();
+  uint32_t numSamples = (nSamples > maxNumSamples) ? maxNumSamples : nSamples;
     
-    uint32_t traceBufSz = 0;
-    uint32_t traceSamples = 0; 
+  uint32_t traceBufSz = 0;
+  uint32_t traceSamples = 0;
 
-    /* Get the trace buffer size and actual number of samples for the specific device
-     * On Zynq, we store 2 samples per packet in the FIFO. So, actual number of samples
-     * will be different from the already calculated "numSamples".
-     */
-    getDevice()->getTraceBufferInfo(numSamples, traceSamples /*actual no. of samples for specific device*/, traceBufSz);
+  // Get the trace buffer size and actual number of samples 
+  //  for the specific device.  On Zynq, we store 2 samples per packet
+  //  in the FIFO.  So the actual number of samples will be different
+  //  from the already calculated "numSamples"
 
-    uint32_t *traceBuf = new uint32_t[traceBufSz];
-    uint32_t wordsPerSample = 1;
-    getDevice()->readTraceData(traceBuf, traceBufSz, numSamples/* use numSamples */, getBaseAddress(), wordsPerSample);
+  getDevice()->getTraceBufferInfo(numSamples, traceSamples /*actual no. of samples for specific device*/, traceBufSz);
 
-    processTraceData(traceVector, traceSamples, traceBuf, wordsPerSample); 
+  traceData = new uint32_t[traceBufSz];
+  uint32_t wordsPerSample = 1;
+  getDevice()->readTraceData(traceData, traceBufSz, numSamples/* use numSamples */, getBaseAddress(), wordsPerSample);
 
-    delete [] traceBuf;
-    return 0;
-}
-
-void TraceFifoFull::processTraceData(std::vector<xclTraceResults>& traceVector,uint32_t numSamples, void* data, uint32_t /*wordsPerSample*/)
-{
-    xclTraceResults results = {};
-    int mod = 0;
-    unsigned int clockWordIndex = 7;
-    for (uint32_t i = 0; i < numSamples; i++) {
-
-      // Old method has issues with emulation trace
-      //uint32_t index = wordsPerSample * i;
-      //uint32_t* dataUInt32Ptr = (uint32_t*)data;
-      //uint64_t currentSample = *(dataUInt32Ptr + index) | (uint64_t)*(dataUInt32Ptr + index + 1) << 32;
-      // Works with HW and HW Emu
-
-      uint64_t* dataUInt64Ptr = (uint64_t*)data;
-      uint64_t currentSample = dataUInt64Ptr[i];
-
-      if (!currentSample)
-        continue;
-
-      bool isClockTrain = false;
-      if (mTraceFormat == 1) {
-        isClockTrain = ((currentSample >> 63) & 0x1);
-      } else {
-        isClockTrain = (i <= clockWordIndex && !mclockTrainingdone);
-      }
-
-      // Poor Man's reset
-      if (i == 0 && !mclockTrainingdone)
-        mfirstTimestamp = currentSample & 0x1FFFFFFFFFFF;
-
-      // This section assumes that we write 8 timestamp packets in startTrace
-      if (isClockTrain) {
-        if (mod == 0) {
-          uint64_t currentTimestamp = currentSample & 0x1FFFFFFFFFFF;
-          if (currentTimestamp >= mfirstTimestamp)
-            results.Timestamp = currentTimestamp - mfirstTimestamp;
-          else
-            results.Timestamp = currentTimestamp + (0x1FFFFFFFFFFF - mfirstTimestamp);
-        }
-        uint64_t partial = (((currentSample >> 45) & 0xFFFF) << (16 * mod));
-        results.HostTimestamp = results.HostTimestamp | partial;
-
-        if(out_stream)
-            (*out_stream) << "Updated partial host timestamp : " << std::hex << partial << std::endl;
-
-        if (mod == 3) {
-          if(out_stream) {
-            (*out_stream) << "  Trace sample " << std::dec << i << ": "
-                          << " Timestamp : " << results.Timestamp << "   "
-                          << " Host Timestamp : " << std::hex << results.HostTimestamp << std::endl;
-          }
-          results.isClockTrain = 1 ;
-          traceVector.push_back(results);    // save result
-          memset(&results, 0, sizeof(xclTraceResults));
-        }
-        mod = (mod == 3) ? 0 : mod + 1;
-        continue;
-      }
-
-      // Trace Packet Format
-      results.Timestamp = (currentSample & 0x1FFFFFFFFFFF) - mfirstTimestamp;
-      results.EventType = ((currentSample >> 45) & 0xF) ? XCL_PERF_MON_END_EVENT :
-          XCL_PERF_MON_START_EVENT;
-      results.TraceID = (currentSample >> 49) & 0xFFF;
-      results.Reserved = (currentSample >> 61) & 0x1;
-      results.Overflow = (currentSample >> 62) & 0x1;
-      results.Error = (currentSample >> 63) & 0x1;
-      results.EventID = XCL_PERF_MON_HW_EVENT;
-      results.EventFlags = ((currentSample >> 45) & 0xF) | ((currentSample >> 57) & 0x10) ;
-      results.isClockTrain = 0 ;
-
-      traceVector.push_back(results);   // save result
-
-      if(out_stream) {
-        static uint64_t previousTimestamp = 0;
-        auto packet_dec = std::bitset<64>(currentSample).to_string();
-        (*out_stream) << "  Trace sample " << std::dec << std::setw(5) << i << ": "
-                      <<  packet_dec.substr(0,19) << " : " << packet_dec.substr(19)
-                      << std::endl
-                      << " Timestamp : " << results.Timestamp << "   "
-                      << "Event Type : " << results.EventType << "   "
-                      << "slotID : " << results.TraceID << "   "
-                      << "Start, Stop : " << static_cast<int>(results.Reserved) << "   "
-                      << "Overflow : " << static_cast<int>(results.Overflow) << "   "
-                      << "Error : " << static_cast<int>(results.Error) << "   "
-                      << "EventFlags : " << static_cast<int>(results.EventFlags) << "   "
-                      << "Interval : " << results.Timestamp - previousTimestamp << "   "
-                      << std::endl;
-        previousTimestamp = results.Timestamp;
-      }
-      memset(&results, 0, sizeof(xclTraceResults));
-    }
-    mclockTrainingdone = true;
+  return traceSamples * sizeof(uint64_t) ; // Actual number of bytes used
 }
 
 void TraceFifoFull::showProperties()

--- a/src/runtime_src/xdp/profile/device/traceFifoFull.h
+++ b/src/runtime_src/xdp/profile/device/traceFifoFull.h
@@ -23,7 +23,6 @@
 #include <iostream>
 #include <vector>
 #include "profile_ip_access.h"
-#include "core/include/xclperf.h"
 
 namespace xdp {
 
@@ -64,7 +63,7 @@ public:
 
     uint32_t getNumTraceSamples(/* need type */);
     uint32_t getMaxNumTraceSamples();
-    uint32_t readTrace(std::vector<xclTraceResults>& traceVector, uint32_t nSamples);
+    uint32_t readTrace(uint32_t*& traceData, uint32_t numSamples) ;
 
     size_t reset();
     void setTraceFormat(uint32_t tf) { mTraceFormat = tf; }
@@ -76,8 +75,6 @@ private:
     uint8_t properties;
     uint8_t major_version;
     uint8_t minor_version;
-
-    void processTraceData(std::vector<xclTraceResults>& traceVector, uint32_t numSamples, void* data, uint32_t wordsPerSample);
 
     bool mclockTrainingdone = false;
     uint64_t mfirstTimestamp = 0;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -74,7 +74,7 @@ buffer size and/or reduce trace_buffer_offload_interval."
 #define MIN_TRACE_DUMP_INTERVAL_S 1
 #define TRACE_DUMP_INTERVAL_WARN_MSG "Setting trace file dump interval to minimum supported value of 1 second."
 #define TRACE_DUMP_FILE_COUNT_WARN 10
-#define TRACE_DUMP_FILE_COUNT_WARN_MSG "Contunous Trace might create a large number of trace files. Please use trace_file_dump_interval \
+#define TRACE_DUMP_FILE_COUNT_WARN_MSG "Continuous Trace might create a large number of trace files. Please use trace_file_dump_interval \
 to control how often trace data is written."
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -409,6 +409,10 @@ namespace xdp {
       {
         readTrace() ;
       }
+    case VPDatabase::DUMP_TRACE:
+      {
+	XDPPlugin::forceWrite(true) ;
+      }
     default:
       break ;
     }

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -98,28 +98,6 @@ namespace xdp {
     }
   }
 
-  void HALAPIInterface::startTrace()
-  {
-    for(auto itr : devices) {
-      itr.second->startTrace(0);
-    }
-  }
-
-  void HALAPIInterface::stopTrace()
-  {
-    for(auto itr : devices) {
-      itr.second->stopTrace();
-    }
-  }
-
-  void HALAPIInterface::readTrace()
-  {
-    std::vector<xclTraceResults> traceVector;
-    for(auto itr : devices) {
-      itr.second->readTrace(traceVector);
-    }
-  }
-
   void HALAPIInterface::createProfileResults(xclDeviceHandle deviceHandle, 
 					     void* ret)
   {

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.h
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.h
@@ -69,10 +69,6 @@ namespace xdp {
      void startCounters();
      void stopCounters();
      void readCounters();
-     
-     void startTrace();
-     void stopTrace();
-     void readTrace();
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -149,4 +149,15 @@ namespace xdp {
     }
   }
 
-}
+  void XDPPlugin::forceWrite(bool openNewFiles)
+  {
+    if (is_write_thread_active) {
+      // Continuous offload will write shortly, so don't force the write
+      return ;
+    }
+    for (auto w : writers) {
+      w->write(openNewFiles) ;
+    }
+  }
+
+} // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -68,6 +68,7 @@ namespace xdp {
 
     XDP_EXPORT void startWriteThread(unsigned int interval, std::string type);
     XDP_EXPORT void endWrite(bool openNewFiles);
+    XDP_EXPORT void forceWrite(bool openNewFiles) ;
 
   public:
     XDP_EXPORT XDPPlugin() ;

--- a/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/device_trace/device_trace_writer.cpp
@@ -389,7 +389,10 @@ namespace xdp {
     writeDependencies() ;
     fout << std::endl ;
 
-    if (openNewFile) switchFiles() ;
+    if (openNewFile) {
+      switchFiles() ;
+      db->getStaticInfo().addOpenedFile(getcurrentFileName(), "VP_TRACE") ;
+    }
     return true;
   }
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_writer.cpp
@@ -113,7 +113,9 @@ namespace xdp {
     }
 
     if (fileNum == TRACE_DUMP_FILE_COUNT_WARN && !warnFileNum) {
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TRACE_DUMP_FILE_COUNT_WARN_MSG);
+      if (xrt_core::config::get_continuous_trace()) {
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TRACE_DUMP_FILE_COUNT_WARN_MSG);
+      }
       warnFileNum = true;
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The profiling library took excessive amounts of memory when processing large trace buffers offloaded at the end of application execution.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This pull request now does two things:
1.  Removes the usage of the traceResults structure and combines FIFO offload and TS2MM offload processing into a single code path.
2. Forces dumping to disk when memory used to store device events exceeds a threshold.

#### What has been tested and how, request additional testing if necessary
This change has been tested on the large design that originally exposed the problem as well as a small set of test cases.  Full testing on larger suites will be needed after merging.
