### PR TITLE
Enabled the usage of AIE XGRAPH Calls even for PCIe targets. (#5964)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,15 @@ if (${XRT_NATIVE_BUILD} STREQUAL "no")
   set (CMAKE_INSTALL_PREFIX "/usr")
 endif()
 
+# Enable AIE even on x86.  This is POC, once
+# complete we will remove the need for these
+# macros and defines.
+if (${XRT_NATIVE_BUILD} STREQUAL "yes")
+  set(XRT_AIE_BUILD "yes")
+  set(XRT_ENABLE_AIE "yes")
+  add_definitions (-DXRT_ENABLE_AIE -DXRT_AIE_BUILD)
+endif()
+
 # Default component name for any install() command without the COMPONENT argument
 # The default component is the xrt run-time component, if XRT_DEV_COMPONENT is
 # set to something different then a development component will be created with

--- a/src/runtime_src/core/common/api/aie/xrt_graph.cpp
+++ b/src/runtime_src/core/common/api/aie/xrt_graph.cpp
@@ -26,9 +26,13 @@
 
 #include "core/include/experimental/xrt_device.h"
 #include "core/common/api/device_int.h"
-#include "core/common/system.h"
 #include "core/common/device.h"
+#include "core/common/error.h"
 #include "core/common/message.h"
+#include "core/common/system.h"
+
+#include <limits>
+#include <memory>
 
 namespace xrt {
 
@@ -125,7 +129,7 @@ namespace {
 static std::map<xrtGraphHandle, std::shared_ptr<xrt::graph_impl>> graph_cache;
 
 static std::shared_ptr<xrt::graph_impl>
-open_graph(xrtDeviceHandle dhdl, const uuid_t xclbin_uuid, const char* graph_name, xrt::graph::access_mode am)
+open_graph(xrtDeviceHandle dhdl, const xuid_t xclbin_uuid, const char* graph_name, xrt::graph::access_mode am)
 {
   auto core_device = xrt_core::device_int::get_core_device(dhdl);
   auto handle = core_device->open_graph(xclbin_uuid, graph_name, am);
@@ -314,7 +318,7 @@ read_port(const std::string& port_name, void* value, size_t bytes)
 ////////////////////////////////////////////////////////////////
 
 xrtGraphHandle
-xrtGraphOpen(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, const char* graph_name)
+xrtGraphOpen(xrtDeviceHandle dev_handle, const xuid_t xclbin_uuid, const char* graph_name)
 {
   try {
     auto hdl = open_graph(dev_handle, xclbin_uuid, graph_name, xrt::graph::access_mode::primary);
@@ -332,7 +336,7 @@ xrtGraphOpen(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, const char* g
 }
 
 xrtGraphHandle
-xrtGraphOpenExclusive(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, const char* graph_name)
+xrtGraphOpenExclusive(xrtDeviceHandle dev_handle, const xuid_t xclbin_uuid, const char* graph_name)
 {
   try {
     auto hdl = open_graph(dev_handle, xclbin_uuid, graph_name, xrt::graph::access_mode::exclusive);
@@ -350,7 +354,7 @@ xrtGraphOpenExclusive(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, cons
 }
 
 xrtGraphHandle
-xrtGraphOpenShared(xrtDeviceHandle dev_handle, const uuid_t xclbin_uuid, const char* graph_name)
+xrtGraphOpenShared(xrtDeviceHandle dev_handle, const xuid_t xclbin_uuid, const char* graph_name)
 {
   try {
     auto hdl = open_graph(dev_handle, xclbin_uuid, graph_name, xrt::graph::access_mode::shared);
@@ -414,7 +418,7 @@ xrtGraphTimeStamp(xrtGraphHandle graph_hdl)
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
   }
-  return -1;
+  return std::numeric_limits<uint64_t>::max();
 }
 
 int
@@ -777,7 +781,7 @@ xrtAIEReadProfiling(xrtDeviceHandle handle, int pHandle)
   catch (const std::exception& ex) {
     send_exception_message(ex.what());
   }
-  return -1;
+  return std::numeric_limits<uint64_t>::max();
 }
 
 /**

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -1053,8 +1053,7 @@ void
 bo::
 sync(const std::string& port, xclBOSyncDirection dir, size_t sz, size_t offset)
 {
-  const auto& handle = get_handle();
-  handle->sync(*this, port, dir, sz, offset);
+  get_handle()->sync(*this, port, dir, sz, offset);
 }
 
 }} // namespace aie, xrt

--- a/src/runtime_src/core/include/xcl_graph.h
+++ b/src/runtime_src/core/include/xcl_graph.h
@@ -21,7 +21,8 @@
 #ifndef XCL_COMMON_GRAPH_H_
 #define XCL_COMMON_GRAPH_H_
 
-#include "experimental/xrt_graph.h"
+#include "xrt/xrt_aie.h"
+#include "xrt/xrt_graph.h"
 
 typedef void * xclGraphHandle;
 

--- a/src/runtime_src/core/pcie/common/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/common/CMakeLists.txt
@@ -28,5 +28,7 @@ get_filename_component(full_path_system_pcie_cpp ${CMAKE_CURRENT_SOURCE_DIR}/sys
 list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_system_pcie_cpp}")
 get_filename_component(full_path_system_pcie_h ${CMAKE_CURRENT_SOURCE_DIR}/system_pcie.h ABSOLUTE)
 list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_system_pcie_h}")
+get_filename_component(full_path_aie_stubs_cpp ${CMAKE_CURRENT_SOURCE_DIR}/aie_stubs.cpp ABSOLUTE)
+list(REMOVE_ITEM XRT_CORE_PCIE_COMMON_FILES "${full_path_aie_stubs_cpp}")
 
 add_library(core_pciecommon_objects OBJECT ${XRT_CORE_PCIE_COMMON_FILES})

--- a/src/runtime_src/core/pcie/common/aie_stubs.cpp
+++ b/src/runtime_src/core/pcie/common/aie_stubs.cpp
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+ */
+#include "core/include/xcl_graph.h"
+#include "core/include/xrt/xrt_aie.h"
+#include "core/include/xrt/xrt_graph.h"
+#include "core/common/error.h"
+
+// This file implements stubs for shim level AIE graph functions.  The
+// file is used to expand the shim layer to include all graph level
+// functions.  It is compiled into each shim core library that does
+// not itself define these functions.
+void*
+xclGraphOpen(xclDeviceHandle, const xuid_t, const char*, xrt::graph::access_mode)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+void
+xclGraphClose(xclGraphHandle)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphReset(xclGraphHandle)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+uint64_t
+xclGraphTimeStamp(xclGraphHandle)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphRun(xclGraphHandle, int)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphWaitDone(xclGraphHandle, int)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphWait(xclGraphHandle, uint64_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphSuspend(xclGraphHandle)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphResume(xclGraphHandle)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphEnd(xclGraphHandle, uint64_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphUpdateRTP(xclGraphHandle, const char*, const char*, size_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGraphReadRTP(xclGraphHandle, const char*, char*, size_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclAIEOpenContext(xclDeviceHandle, xrt::aie::access_mode)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclSyncBOAIE(xclDeviceHandle, xrt::bo&, const char*, enum xclBOSyncDirection, size_t, size_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclResetAIEArray(xclDeviceHandle)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclSyncBOAIENB(xclDeviceHandle, xrt::bo&, const char*, enum xclBOSyncDirection, size_t, size_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclGMIOWait(xclDeviceHandle, const char*)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclStartProfiling(xclDeviceHandle, int, const char*, const char*, uint32_t)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+uint64_t
+xclReadProfiling(xclDeviceHandle, int)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclStopProfiling(xclDeviceHandle, int)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}
+
+int
+xclLoadXclBinMeta(xclDeviceHandle, const xclBin*)
+{
+  throw xrt_core::error(std::errc::not_supported, __func__);
+}

--- a/src/runtime_src/core/pcie/emulation/cpu_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
 file(GLOB EM_SRC_FILES
   "${EM_SRC_DIR}/*.h"
   "${EM_SRC_DIR}/*.cxx"
+  "${COMMON_PCIE_SRC_DIR}/aie_stubs.cpp"
   "${COMMON_PCIE_SRC_DIR}/system_pcie.cpp"
   "${COMMON_PCIE_SRC_DIR}/device_pcie.cpp"
   )

--- a/src/runtime_src/core/pcie/emulation/hw_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/hw_em/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
 file(GLOB EM_SRC_FILES
   "${EM_SRC_DIR}/*.h"
   "${EM_SRC_DIR}/*.cxx"
+  "${COMMON_PCIE_SRC_DIR}/aie_stubs.cpp"
   "${COMMON_PCIE_SRC_DIR}/system_pcie.cpp"
   "${COMMON_PCIE_SRC_DIR}/device_pcie.cpp"
   )

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB XRT_PCIE_LINUX_PLUGIN_XDP_FILES
 file(GLOB XRT_PCIE_LINUX_FILES
   "*.h"
   "*.cpp"
+  "../common/aie_stubs.cpp"
   "../common/system_pcie.cpp"
   "../common/device_pcie.cpp"
   )

--- a/src/runtime_src/core/pcie/noop/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/noop/CMakeLists.txt
@@ -17,6 +17,7 @@ file(GLOB XRT_PCIE_NOOP_FILES
 file(GLOB XRT_PCIE_NOOP_SHARED_FILES
   "shim.cpp"
   "system_noop.cpp"
+  "../common/aie_stubs.cpp"
   "../common/system_pcie.cpp"
   "device_noop.cpp"
   "../common/device_pcie.cpp"

--- a/src/runtime_src/core/pcie/windows/alveo/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/windows/alveo/CMakeLists.txt
@@ -8,14 +8,15 @@ include_directories(
   )
 
 file(GLOB XRT_PCIE_WINDOWS_FILES
-  "*.h"
   "*.cpp"
+  "../../common/aie_stubs.cpp"
   "../../common/system_pcie.cpp"
   "../../common/device_pcie.cpp"
   )
 
 file(GLOB XRT_PCIE_WINDOWS_STATIC_FILES
-  "device_windows.*"
+  "device_windows.cpp"
+  "../../common/aie_stubs.cpp"
   "../../common/system_pcie.cpp"
   "../../common/device_pcie.cpp"
   )
@@ -24,9 +25,10 @@ file(GLOB XRT_PCIE_WINDOWS_SHARED_FILES
   "shim.cpp"
   "mgmt.cpp"
   "perf.cpp"
-  "system_windows.cpp"
-  "../../common/system_pcie.cpp"
   "device_windows.cpp"
+  "system_windows.cpp"
+  "../../common/aie_stubs.cpp"
+  "../../common/system_pcie.cpp"
   "../../common/device_pcie.cpp"
   )
 

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -362,8 +362,11 @@ set_target_properties(xdp_appdebug_plugin PROPERTIES VERSION ${XRT_VERSION_STRIN
 set_target_properties(xdp_power_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 set_target_properties(xdp_system_compiler_plugin PROPERTIES VERSION ${XRT_VERSION_STRING} SOVERSION ${XRT_SOVERSION})
 
-# AI Engine plugins are Edge only
-if (DEFINED XRT_AIE_BUILD)
+# AI Engine plugins are Edge only.
+# With x86 sw_emu support of AIE, XRT_AIE_BUILD is defined even on x86
+# so the condition is strengthen to include native build not defined,
+# which is same condition that compiles edge.
+if (DEFINED XRT_AIE_BUILD AND NOT DEFINED XRT_NATIVE_BUILD)
   # AIE Profile plugin
   add_library(xdp_aie_profile_plugin MODULE ${XRT_XDP_PROFILE_AIE_PLUGIN_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_core)


### PR DESCRIPTION
Enable the usage of AIE XGRAPH Calls even for PCIe targets.

New enhancement done as part of the VITIS-3745 Running PS APP as x86
process Enable AIE shim level calls by default on x86 in preparation
for supporting x86 software emulation of graph host code.

Add stub AIE xcl stub implementation that is compiled into all shim
core libraries.  In this pull request the stubs will throw a runtime
exception. A subsequent pull request will implement the stubs for x86
software emulation.

No risks as the enabled code should not be called at all.

New framework enabled, did not add any tests.

Cherry picked from commit 48928c8 with modifications.

Co-authored-by: Aleti Venkata Prasad <venkatp@xilinx.com>
