### PR TITLE
versal flashing bugs

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -506,8 +506,8 @@ auto_flash(std::shared_ptr<xrt_core::device> & workingDevice, const std::string&
     }
     image_path = available_shells.front().second.get<std::string>("file");
   }
-  else if(boost::filesystem::exists(boost::filesystem::path(image))) {
-    update_shell(workingDevice->get_device_id(), image, std::string(""));
+  else if (boost::filesystem::exists(image)) {
+    update_shell(workingDevice->get_device_id(), image, {});
     std::cout <<boost::format("  [%s] : Successfully flashed the base (e.g., shell) image\n") % getBDF(workingDevice->get_device_id());
     std::cout << "****************************************************\n";
     std::cout << "Cold reboot machine to load the new image on device.\n";

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -476,7 +476,7 @@ update_shell(unsigned int boardIdx, DSAInfo& candidate)
  * Refactor code to support only 1 device. 
  */
 static void 
-auto_flash(std::shared_ptr<xrt_core::device> & workingDevice, const std::string& image = "") 
+auto_flash(std::shared_ptr<xrt_core::device> & workingDevice, const std::string& flashType = "", const std::string& image = "") 
 {
   // Get platform information
   boost::property_tree::ptree pt;
@@ -507,11 +507,11 @@ auto_flash(std::shared_ptr<xrt_core::device> & workingDevice, const std::string&
     image_path = available_shells.front().second.get<std::string>("file");
   }
   else if (boost::filesystem::exists(image)) {
-    update_shell(workingDevice->get_device_id(), image, {});
+    if (!flashType.empty()) 
+      update_shell(workingDevice->get_device_id(), flashType, image, {});
+    else
+      update_shell(workingDevice->get_device_id(), image, {});
     std::cout <<boost::format("  [%s] : Successfully flashed the base (e.g., shell) image\n") % getBDF(workingDevice->get_device_id());
-    std::cout << "****************************************************\n";
-    std::cout << "Cold reboot machine to load the new image on device.\n";
-    std::cout << "****************************************************\n";
     return;
   }
   else {
@@ -853,7 +853,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
     // We support up to 2 flash images 
     if (image.size() == 1)
-      auto_flash(workingDevice, image.front());
+      auto_flash(workingDevice, flashType, image.front());
     
     if (image.size() == 2) {
       std::cout << "CAUTION! Force flashing the platform on the device without any checks." <<

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -397,7 +397,7 @@ update_sc(unsigned int boardIdx, DSAInfo& candidate)
 
   // -- Some DRCs (Design Rule Checks) --
   // Is the SC present
-  if (current.bmc_ver().empty()) {
+  if (current.bmc_ver().empty() || candidate.bmc_ver().empty()) {
      std::cout << "INFO: Satellite controller is not present.\n";
      return false;
   }
@@ -505,6 +505,14 @@ auto_flash(std::shared_ptr<xrt_core::device> & workingDevice, const std::string&
       throw xrt_core::error(std::errc::operation_canceled);
     }
     image_path = available_shells.front().second.get<std::string>("file");
+  }
+  else if(boost::filesystem::exists(boost::filesystem::path(image))) {
+    update_shell(workingDevice->get_device_id(), image, std::string(""));
+    std::cout <<boost::format("  [%s] : Successfully flashed the base (e.g., shell) image\n") % getBDF(workingDevice->get_device_id());
+    std::cout << "****************************************************\n";
+    std::cout << "Cold reboot machine to load the new image on device.\n";
+    std::cout << "****************************************************\n";
+    return;
   }
   else {
     //iterate over installed shells


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
- CR-1114400- Invalid argument: xbmgm2 program --base --image
- CR-1114411- versal discover shell doesn't have SC pkg, xbmgmt2 program failed

Issues fixed:
- The user can now flash a non xsabin bitstream, i.e., a pdi or mcs
- If SC image is not present in the shell package, ignore updating the SC

No risks are associated with this PR

Sample outputs:
```
# xbmgmt program -b --image ../../rpu.pdi -d 02:00.0 --flash-type ospi_versal
INFO: ***PDI has 5387792 bytes
INFO     : Base flash image has been programmed successfully. 
  [0000:02:00.0] : Successfully flashed the base (e.g., shell) image
****************************************************
Cold reboot machine to load the new image on device.
****************************************************

# Debug/opt/xilinx/xrt/bin/xbmgmt program -b --image xilinx_vck5000_gen4x8_xdma_base_1 -d 02:00 --force
----------------------------------------------------
Device : [0000:02:00.0]

Current Configuration
  Platform             : xilinx_vck5000_gen4x8_xdma_base_1
  SC Version           : INACTIVE
  Platform ID          : 0x84d86c8f631694c3


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/84d86c8f631694c309ae5c29d5c35143
  Size                 : 5,179,943 bytes
  Timestamp            : Tue Nov  9 12:44:02 2021

  Platform             : xilinx_vck5000_gen4x8_xdma_base_1
  SC Version           : 
  Platform UUID        : 84D86C8F-6316-94C3-09AE-5C29D5C35143
----------------------------------------------------
Actions to perform:
  [0000:02:00.0] : Program base (FLASH) image
  [0000:02:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y (Force override)

INFO: Satellite controller is not present.
INFO: Forcing flashing of the base (e.g., shell) image (Force flag is set).
[0000:02:00.0] : Updating base (e.g., shell) flash image...
PDI dsabin supports only primary bitstream: /lib/firmware/xilinx/84d86c8f631694c309ae5c29d5c35143/partition.xsabin
INFO: ***PDI has 5171376 bytes
INFO     : Base flash image has been programmed successfully. 
----------------------------------------------------
Report
  [0000:02:00.0] : Satellite Controller (SC) is either up-to-date, fixed, or not installed. No actions taken.
  [0000:02:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
```
