### PR TITLE
Add IP_PS_KERNEL to xclbin IP_TYPE

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -196,6 +196,7 @@ extern "C" {
         IP_MEM_DDR4,
         IP_MEM_HBM,
         IP_MEM_HBM_ECC,
+        IP_PS_KERNEL,
     };
 
     enum ACTION_MASK {

--- a/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionIPLayout.cxx
@@ -50,6 +50,8 @@ SectionIPLayout::getIPTypeStr(enum IP_TYPE _ipType) const {
       return "IP_MEM_HBM";
     case IP_MEM_HBM_ECC:
       return "IP_MEM_HBM_ECC";
+    case IP_PS_KERNEL:
+      return "IP_PS_KERNEL";
   }
 
   return XUtil::format("UNKNOWN (%d)", (unsigned int)_ipType);
@@ -64,6 +66,7 @@ SectionIPLayout::getIPType(std::string& _sIPType) const {
   if (_sIPType == "IP_MEM_DDR4") return IP_MEM_DDR4;
   if (_sIPType == "IP_MEM_HBM") return IP_MEM_HBM;
   if (_sIPType == "IP_MEM_HBM_ECC") return IP_MEM_HBM_ECC;
+  if (_sIPType == "IP_PS_KERNEL") return IP_PS_KERNEL;
 
   std::string errMsg = "ERROR: Unknown IP type: '" + _sIPType + "'";
   throw std::runtime_error(errMsg);


### PR DESCRIPTION
#### Problem solved by the commit
This is a simple change to add a new enumerator to the IP_TYPE xclbin
enumeration.  This change is required for subsequent PRs that explore
the IP_LAYOUT for PS kernel IPs for use by xrt::kernel.

#### Risks (if any) associated the changes in the commit
Enumerator is currently unused so no apparent risk

