### PR TITLE
Coverity fix: Adding a missing break in switch statement

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -409,10 +409,12 @@ namespace xdp {
       {
         readTrace() ;
       }
+      break ;
     case VPDatabase::DUMP_TRACE:
       {
 	XDPPlugin::forceWrite(true) ;
       }
+      break ;
     default:
       break ;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Coverity detected a switch statement in recently modified code that did not have a break, resulting in fall through behavior that could result in empty device trace files being generated.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The missing break was introduced in pull request 5977 on November 11 and was discovered via Coverity scan.

