### PR TITLE
Add domain to kernel cu index

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -47,6 +47,7 @@ usage()
     echo "[-noctest]                  Skip unit tests"
     echo "[-with-static-boost <boost> Build binaries using static linking of boost from specified boost install"
     echo "[-clangtidy]                Run clang-tidy as part of build"
+    echo "[-pskernel]                 Enable building of POC ps kernel"
     echo "[-docs]                     Enable documentation generation with sphinx"
     echo "[-j <n>]                    Compile parallel (default: system cores)"
     echo "[-ccache]                   Build using RDI's compile cache"
@@ -156,6 +157,10 @@ while [ $# -gt 0 ]; do
             ;;
         -clangtidy)
             cmake_flags+=" -DXRT_CLANG_TIDY=ON"
+            shift
+            ;;
+        -pskernel)
+            cmake_flags+=" -DXRT_PSKERNEL_BUILD=ON"
             shift
             ;;
         -verbose)

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -19,7 +19,7 @@ INCLUDE_DIRECTORIES(${LIBFFI_INCLUDEDIR})
 
 endif (NOT WIN32)
 
-file(GLOB XRT_CORE_COMMON_LIB_FILES
+file(GLOB XRT_CORE_COMMON_SRC_SHARED
   "config_reader.cpp"
   "debug.cpp"
   "device.cpp"
@@ -39,26 +39,29 @@ file(GLOB XRT_CORE_COMMON_LIB_FILES
   )
 
 if (DEFINED XRT_AIE_BUILD)
-  file(GLOB XRT_CORE_COMMON_AIE_LIB_FILES
-    "api/aie/*.cpp"
-    )
-  list(APPEND XRT_CORE_COMMON_LIB_FILES ${XRT_CORE_COMMON_AIE_LIB_FILES})
+  message("-- enabling api aie build")
+  list(APPEND XRT_CORE_COMMON_SRC_SHARED "api/aie/xrt_graph.cpp")
 endif()
 
+# The static library files may not contain dependencies on dwarf/elf/ffi
+# so can't include ps kernel sources
+set(XRT_CORE_COMMON_SRC_STATIC ${XRT_CORE_COMMON_SRC_SHARED})
+
 if (DEFINED XRT_PSKERNEL_BUILD)
-  list(APPEND XRT_CORE_COMMON_LIB_FILES "pskernel_parse.cpp")
-  list(APPEND XRT_CORE_COMMON_LIB_FILES "api/pskernel/xrt_pskernel.cpp")
+  message("-- enabling api ps build")
+  list(APPEND XRT_CORE_COMMON_SRC_SHARED "pskernel_parse.cpp")
+  list(APPEND XRT_CORE_COMMON_SRC_SHARED "api/pskernel/xrt_pskernel.cpp")
 endif()
 
 # Files to include in object list
-file(GLOB XRT_CORE_COMMON_OBJ_FILES
-  "scheduler.*"
+file(GLOB XRT_CORE_COMMON_SRC_OBJ
+  "scheduler.cpp"
   )
 
 add_compile_options("-DXRT_VERSION_MAJOR=\"${XRT_VERSION_MAJOR}\"")
 
-add_library(xrt_coreutil SHARED ${XRT_CORE_COMMON_LIB_FILES})
-add_library(xrt_coreutil_static STATIC ${XRT_CORE_COMMON_LIB_FILES})
+add_library(xrt_coreutil SHARED ${XRT_CORE_COMMON_SRC_SHARED})
+add_library(xrt_coreutil_static STATIC ${XRT_CORE_COMMON_SRC_STATIC})
 
 set_target_properties(xrt_coreutil PROPERTIES
   VERSION ${XRT_VERSION_STRING}
@@ -83,11 +86,16 @@ target_link_libraries(xrt_coreutil_static
 if (NOT WIN32)
   # Additional link dependencies for xrt_coreutil
   # xrt_uuid.h depends on uuid
-  target_link_libraries(xrt_coreutil PRIVATE pthread dl ${LIBDW_LDFLAGS} ${LIBELF_LDFLAGS} ${LIBFFI_LDFLAGS} PUBLIC uuid)
+  target_link_libraries(xrt_coreutil PRIVATE pthread dl PUBLIC uuid)
 
   # Targets of xrt_coreutil_static must link with these additional
   # system libraries
   target_link_libraries(xrt_coreutil_static INTERFACE uuid dl rt pthread)
+
+  if (DEFINED XRT_PSKERNEL_BUILD)
+    target_link_libraries(xrt_coreutil PRIVATE ${LIBDW_LDFLAGS} ${LIBELF_LDFLAGS} ${LIBFFI_LDFLAGS})
+  endif()
+  
 endif()
 
 install(TARGETS xrt_coreutil
@@ -106,4 +114,4 @@ install(TARGETS xrt_coreutil xrt_coreutil_static
 # files reference xrt_core symbols, hence are excluded from
 # xrt_corecommon shared library and instead linked explicitly into
 # client (core) libraries
-add_library(core_common_objects OBJECT ${XRT_CORE_COMMON_OBJ_FILES})
+add_library(core_common_objects OBJECT ${XRT_CORE_COMMON_SRC_OBJ})

--- a/src/runtime_src/core/common/api/pskernel/xrt_pskernel.cpp
+++ b/src/runtime_src/core/common/api/pskernel/xrt_pskernel.cpp
@@ -65,6 +65,7 @@ namespace {
 
 constexpr size_t max_cus = 128;
 constexpr size_t cus_per_word = 32;
+constexpr uint32_t scu_domain = 0x10000;
 
 XRT_CORE_UNUSED // debug enabled function
 std::string
@@ -439,7 +440,7 @@ public:
   {
     if (access != access_mode::none)
       throw std::runtime_error("Cannot change current access mode");
-    device->open_context(xid.get(), cuidx+max_cus, std::underlying_type<access_mode>::type(am));
+    device->open_context(xid.get(), cuidx | scu_domain, std::underlying_type<access_mode>::type(am));
     access = am;
   }
 
@@ -481,7 +482,7 @@ public:
     if(cuidx==virtual_cu_idx) 
       device->close_context(xid.get(), cuidx);
     else
-      device->close_context(xid.get(), cuidx+max_cus);
+      device->close_context(xid.get(), cuidx | scu_domain);
   }
 
   psip_context(const psip_context&) = delete;
@@ -500,7 +501,7 @@ private:
     , access(am)
   {
     if (access != access_mode::none)
-      device->open_context(xid.get(), cuidx+max_cus, std::underlying_type<access_mode>::type(am));
+      device->open_context(xid.get(), cuidx | scu_domain, std::underlying_type<access_mode>::type(am));
   }
 
   // virtual CU

--- a/src/runtime_src/core/common/cuidx_type.h
+++ b/src/runtime_src/core/common/cuidx_type.h
@@ -1,0 +1,41 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ */
+#ifndef XRT_CORE_CUIDX_TYPE_H
+#define XRT_CORE_CUIDX_TYPE_H
+
+#include <cstdint>
+
+#ifdef _WIN32
+# pragma warning( push )
+# pragma warning( disable : 4201 )
+#endif
+
+namespace xrt_core {
+
+// cuidx_type - encode cuidx and domain
+//
+// @domain_index: index within domain
+// @domain:       domain identifier
+// @index:        combined encoded index
+//
+// The domain_index is used in command cumask in exec_buf
+// The combined index is used in context creation in open_context
+struct cuidx_type {
+  union {
+    std::uint32_t index;
+    struct {
+      std::uint16_t domain_index; // [15-0]
+      std::uint16_t domain;       // [31-16]
+    };
+  };
+};
+
+} // xrt_core
+
+#ifdef _WIN32
+# pragma warning( pop )
+#endif
+
+#endif

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -18,7 +18,7 @@
 #define XRT_CORE_DEVICE_H
 
 #include "config.h"
-
+#include "cuidx_type.h"
 #include "error.h"
 #include "ishim.h"
 #include "query.h"
@@ -297,6 +297,19 @@ public:
   const std::vector<uint64_t>&
   get_cus(const uuid& xclbin_id = uuid()) const;
 
+  // get_cuidx() - Get index of cu identified by name
+  //
+  // @return
+  //  The index of the CU represented as cuidx_type per
+  //  defintion in xrt_core::xclbin
+  //
+  // The index is used when opening a context on this device
+  // and it is used to specify the cumask in commands send
+  // for execution
+  XRT_CORE_COMMON_EXPORT
+  cuidx_type
+  get_cuidx(const std::string& cuname, const uuid& xclbin_id = uuid()) const;
+
   /**
    * get_ert_slots() - Get number of ERT CQ slots
    *
@@ -360,6 +373,7 @@ public:
   id_type m_device_id;
   mutable boost::optional<bool> m_nodma = boost::none;
 
+  std::map<std::string, cuidx_type> m_cu2idx; // cu name mapping to cuidx
   std::vector<uint64_t> m_cus;           // cu base addresses in expeced sort order
   xrt::xclbin m_xclbin;                  // currently loaded xclbin
 };

--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -29,6 +29,12 @@
 
 #define MAX_CUS 128
 
+/* Soft kernel indices are numbered from 0 to some MAX_CUS
+ * but are in a distinct domain which is indiciated by the
+ * first 16 bit of the index used to identify the soft kernel
+ */
+#define SCU_DOMAIN 0x10000
+
 /* The normal CU in ip_layout would assign a interrupt
  * ID in range 0 to 127. Use 128 for m2m cu could ensure
  * m2m CU is at the end of the CU, which is compatible with

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -91,10 +91,14 @@ ssize_t show_kds_scustat_raw(struct kds_sched *kds, char *buf)
 	 * So, this separate kds_scustat_raw is better.
 	 *
 	 * But in the worst case, this is still not good enough.
+	 *
+	 * Soft kernels are namespaced with a domain identifer that
+	 * is or'ed into the scu index.	 For soft kernels the 
+	 * domain is SCU_DOMAIN.
 	 */
 	mutex_lock(&scu_mgmt->lock);
 	for (i = 0; i < scu_mgmt->num_cus; ++i) {
-		sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, i,
+		sz += scnprintf(buf+sz, PAGE_SIZE - sz, cu_fmt, (i | SCU_DOMAIN),
 				scu_mgmt->name[i], scu_mgmt->status[i],
 				cu_stat_read(scu_mgmt,usage[i]));
 	}
@@ -611,12 +615,12 @@ kds_add_scu_context(struct kds_sched *kds, struct kds_client *client,
 	bool shared;
 	int ret = 0;
 
-        if (info->cu_idx < MAX_CUS) {
+	if (info->cu_idx < MAX_CUS) {
 		kds_err(client, "SCU cu_idx %d not valid.  SCU should start from %d", info->cu_idx, MAX_CUS);
 		return -EINVAL;
-        } else {
-                cu_idx = info->cu_idx - MAX_CUS;
-        }
+	} else {
+		cu_idx = info->cu_idx & ~(SCU_DOMAIN);
+	}
 
 	if (cu_idx >= scu_mgmt->num_cus) {
 		kds_err(client, "SCU(%d) not found", cu_idx);
@@ -670,12 +674,12 @@ kds_del_scu_context(struct kds_sched *kds, struct kds_client *client,
 	unsigned long submitted = 0;
 	unsigned long completed = 0;
 
-        if (info->cu_idx < MAX_CUS) {
+	if (info->cu_idx < MAX_CUS) {
 		kds_err(client, "SCU cu_idx %d not valid.  SCU should start from %d", info->cu_idx, MAX_CUS);
 		return -EINVAL;
-        } else {
-                cu_idx = info->cu_idx - MAX_CUS;
-        }
+	} else {
+		cu_idx = info->cu_idx & ~(SCU_DOMAIN);
+	}
 
 	if (cu_idx >= scu_mgmt->num_cus) {
 		kds_err(client, "SCU(%d) not found", cu_idx);

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -13,12 +13,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 #ifndef xclbin_parser_h_
 #define xclbin_parser_h_
 
-#include "core/common/config.h"
-#include "xclbin.h"
+#include "config.h"
+#include "cuidx_type.h"
+#include "core/include/xclbin.h"
+
 #include <array>
 #include <limits>
 #include <map>
@@ -28,9 +29,7 @@
 
 namespace xrt_core { namespace xclbin {
 
-/**
- * struct kernel_argument -
- */
+// struct kernel_argument - kernel argument meta data
 struct kernel_argument
 {
   static constexpr size_t no_index { std::numeric_limits<size_t>::max() };
@@ -51,6 +50,7 @@ struct kernel_argument
   direction dir;
 };
 
+// struct kernel_properties - kernel property metadata
 struct kernel_properties
 {
   enum class kernel_type { none, pl, ps };
@@ -78,14 +78,12 @@ struct kernel_object
   bool sw_reset;
 };
 
-/**
- * struct softkernel_object - wrapper for a soft kernel object
- *
- * @ninst: number of instances
- * @symbol_name: soft kernel symbol name
- * @size: size of soft kernel image
- * @sk_buf: pointer to the soft kernel buffer
- */
+// struct softkernel_object - wrapper for a soft kernel object
+//
+// @ninst: number of instances
+// @symbol_name: soft kernel symbol name
+// @size: size of soft kernel image
+// @sk_buf: pointer to the soft kernel buffer
 struct softkernel_object
 {
   uint32_t ninst;
@@ -149,6 +147,10 @@ get_first_used_mem(const axlf* top);
  */
 int32_t
 address_to_memidx(const mem_topology* mem, uint64_t address);
+
+// get_cu_indices() -
+std::map<std::string, cuidx_type>
+get_cu_indices(const ip_layout* ip_layout);
 
 /**
  * get_max_cu_size() - Compute max register map size of CUs in xclbin


### PR DESCRIPTION
#### Problem solved by the commit
In preparation for xrt::kernel support for pskernel, the compute unit
index has to differentiate between pl and ps kernels.  Rather than
adhoc add 128 (maxcu) to offset the ps kernel index, this PR
introduces the concept of a CU domain.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The CU domain is owned by xocl kernel module.  The domain is different
for a PL kernel CU (cu) and a PS kernel CU (scu), and it is encoded in
the index returned by the driver through sysfs.

In userspace, the encoded index is used when opening a context (shared
or exclusive) on the CU.  The index within a domain (the domain index)
is used in the cumask of the command packet sent to KDS.  The domain
index is obtained by stripping off the domain from the encoded index.

With this change in place, xrt::kernel will be remain more or less
unchanged in the code path that processes and opens compute units
associated with the kernel.

#### Risks (if any) associated the changes in the commit
While transitioning to using encoded cu indices, the core device class
adds a new data member which is a mapping from CU name to encoded
index.  Following PRs will make use of this mapping when constructing
xrt::kernel objects and opening contexts, but in this PR the mapping
is unused.