### PR TITLE
Enabled the XCL GRAPH API definitions in the SW_EMU PCIE driver.

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/CMakeLists.txt
@@ -18,7 +18,6 @@ include_directories(
 file(GLOB EM_SRC_FILES
   "${EM_SRC_DIR}/*.h"
   "${EM_SRC_DIR}/*.cxx"
-  "${COMMON_PCIE_SRC_DIR}/aie_stubs.cpp"
   "${COMMON_PCIE_SRC_DIR}/system_pcie.cpp"
   "${COMMON_PCIE_SRC_DIR}/device_pcie.cpp"
   )

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -2054,6 +2054,27 @@ int CpuemShim::xrtGraphWait(void * gh) {
 }
 
 /**
+* xrtGraphTimedWait() -  Wait a given AIE cycle since the last xrtGraphRun and
+*                   then stop the graph. If cycle is 0, busy wait until graph
+*                   is done. If graph already run more than the given
+*                   cycle, stop the graph immediateley.
+*/
+int CpuemShim::xrtGraphTimedWait(void * gh, uint64_t cycle) {
+  bool ack = false;
+  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
+  if (!ghPtr)
+    return -1;
+  auto graphhandle = ghPtr->getGraphHandle();
+  xclGraphTimedWait_RPC_CALL(xclGraphTimedWait, graphhandle, cycle);
+  if (!ack)
+  {
+    PRINTENDFUNC;
+    return -1;
+  }
+  return 0;
+}
+
+/**
 * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
 *                 then end the graph. If cycle is 0, busy wait until graph
 *                 is done before end the graph. If graph already run more
@@ -2075,6 +2096,56 @@ int CpuemShim::xrtGraphEnd(void * gh) {
     return -1;
   auto graphhandle = ghPtr->getGraphHandle();
   xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
+  if (!ack)
+  {
+    PRINTENDFUNC;
+    return -1;
+  }
+  return 0;
+}
+
+/**
+* xrtGraphTimedEnd() - Wait a given AIE cycle since the last xrtGraphRun and
+*                 then end the graph. If cycle is 0, busy wait until graph
+*                 is done before end the graph. If graph already run more
+*                 than the given cycle, stop the graph immediately and end it.
+*
+* @gh:              Handle to graph previously opened with xrtGraphOpen.
+* @cycle:           AIE cycle should wait since last xrtGraphRun. 0 for
+*                   wait until graph is done.
+*
+* Return:          0 on success, -1 on timeout.
+*
+* Note: This API with non-zero AIE cycle is for graph that is running
+* forever or graph that has multi-rate core(s).
+*/
+int CpuemShim::xrtGraphTimedEnd(void * gh , uint64_t cycle) {
+  bool ack = false;
+  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
+  if (!ghPtr)
+    return -1;
+  auto graphhandle = ghPtr->getGraphHandle();
+  xclGraphTimedEnd_RPC_CALL(xclGraphTimedEnd, graphhandle, cycle);
+  if (!ack)
+  {
+    PRINTENDFUNC;
+    return -1;
+  }
+  return 0;
+}
+
+/**
+* xrtGraphResume() - Resume a suspended graph.
+*
+* Resume graph execution which was paused by suspend() or wait(cycles) APIs
+*/
+int CpuemShim::xrtGraphResume(void * gh) {
+  bool ack = false;
+  auto ghPtr = (xclcpuemhal2::GraphType*)gh;
+  if (!ghPtr)
+    return -1;
+  auto graphhandle = ghPtr->getGraphHandle();
+  xclGraphResume_RPC_CALL(xclGraphResume, graphhandle);
   if (!ack)
   {
     PRINTENDFUNC;
@@ -2125,6 +2196,60 @@ int CpuemShim::xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer
   PRINTENDFUNC
     return 0;
 }
-/******************************* XRT Graph API's End here**************************************************/
+
+/**
+* xrtSyncBOAIENB() - Transfer data between DDR and Shim DMA channel
+*
+* @bo:           BO obj.
+* @gmioName:        GMIO port name
+* @dir:             GM to AIE or AIE to GM
+* @size:            Size of data to synchronize
+* @offset:          Offset within the BO
+*
+* Return:          0 on success, or appropriate error number.
+*
+* Synchronize the buffer contents between GMIO and AIE.
+* Note: Upon return, the synchronization is submitted or error out
+*/
+
+int CpuemShim::xrtSyncBOAIENB(xrt::bo& bo, const char *gmioname, enum xclBOSyncDirection dir, size_t size, size_t offset)
+{
+  bool ack = false;
+  if (!gmioname)
+    return -1;
+
+  if (mLogStream.is_open())
+    mLogStream << __func__ << ", bo.address() " << bo.address() << std::endl; 
+
+  auto boBase = bo.address();
+  xclSyncBOAIENB_RPC_CALL(xclSyncBOAIENB, gmioname, dir, size, offset, boBase);
+  if (!ack) {
+    PRINTENDFUNC;
+    return -1;
+  }
+  return 0;
+}
+
+
+/**
+* xrtGMIOWait() - Wait a shim DMA channel to be idle for a given GMIO port
+*
+* @gmioName:        GMIO port name
+*
+* Return:          0 on success, or appropriate error number.
+*/
+int CpuemShim::xrtGMIOWait(const char *gmioname)
+{
+  bool ack = false;
+  if (!gmioname)
+    return -1;
+  xclGMIOWait_RPC_CALL(xclGMIOWait, gmioname);
+  if (!ack) {
+    PRINTENDFUNC;
+    return -1;
+  }
+  return 0;
+}
+
 /**********************************************HAL2 API's END HERE **********************************************/
 }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -259,6 +259,144 @@ namespace xclcpuemhal2 {
       int
         xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
 
+      /**
+      * xrtSyncBOAIENB() - Transfer data between DDR and Shim DMA channel
+      *
+      * @bo:           BO obj.
+      * @gmioName:        GMIO port name
+      * @dir:             GM to AIE or AIE to GM
+      * @size:            Size of data to synchronize
+      * @offset:          Offset within the BO
+      *
+      * Return:          0 on success, or appropriate error number.
+      *
+      * Synchronize the buffer contents between GMIO and AIE.
+      * Note: Upon return, the synchronization is submitted or error out
+      */
+      int
+        xrtSyncBOAIENB(xrt::bo& bo, const char *gmioname, enum xclBOSyncDirection dir, size_t size, size_t offset);
+
+      /**
+      * xrtGMIOWait() - Wait a shim DMA channel to be idle for a given GMIO port
+      *
+      * @gmioName:        GMIO port name
+      *
+      * Return:          0 on success, or appropriate error number.
+      */
+      int
+        xrtGMIOWait(const char *gmioname);
+
+      /**
+      * xrtGraphResume() - Resume a suspended graph.
+      *
+      * Resume graph execution which was paused by suspend() or wait(cycles) APIs
+      */
+      int
+        xrtGraphResume(void * gh);
+
+      /**
+      * xrtGraphTimedEnd() - Wait a given AIE cycle since the last xrtGraphRun and
+      *                 then end the graph. If cycle is 0, busy wait until graph
+      *                 is done before end the graph. If graph already run more
+      *                 than the given cycle, stop the graph immediately and end it.
+      */
+      int
+        xrtGraphTimedEnd(void * gh, uint64_t cycle);
+
+      /**
+      * xrtGraphTimedWait() -  Wait a given AIE cycle since the last xrtGraphRun and
+      *                   then stop the graph. If cycle is 0, busy wait until graph
+      *                   is done. If graph already run more than the given
+      *                   cycle, stop the graph immediateley.
+      */
+      int
+        xrtGraphTimedWait(void * gh, uint64_t cycle);
+
+      // //******************************* XRT Graph API's **************************************************//
+      // /**
+      // * xrtGraphInit() - Initialize graph 
+      // *
+      // * @gh:             Handle to graph previously opened with xrtGraphOpen.
+      // * Return:          0 on success, -1 on error
+      // *
+      // * Note: Run by enable tiles and disable tile reset
+      // */
+      // int
+      //   xrtGraphInit(void * gh);
+      // 
+      // /**
+      // * xrtGraphRun() - Start a graph execution
+      // *
+      // * @gh:             Handle to graph previously opened with xrtGraphOpen.
+      // * @iterations:     The run iteration to update to graph. 0 for infinite.
+      // * Return:          0 on success, -1 on error
+      // *
+      // * Note: Run by enable tiles and disable tile reset
+      // */
+      // int
+      //   xrtGraphRun(void * gh, uint32_t iterations);
+      // 
+      // /**
+      // * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
+      // *                   then stop the graph. If cycle is 0, busy wait until graph
+      // *                   is done. If graph already run more than the given
+      // *                   cycle, stop the graph immediateley.
+      // *
+      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+      // *
+      // * Return:          0 on success, -1 on error.
+      // *
+      // * Note: This API with non-zero AIE cycle is for graph that is running
+      // * forever or graph that has multi-rate core(s).
+      // */
+      // int
+      //   xrtGraphWait(void * gh);          
+      // 
+      // /**
+      // * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
+      // *                 then end the graph. busy wait until graph
+      // *                 is done before end the graph. If graph already run more
+      // *                 than the given cycle, stop the graph immediately and end it.
+      // *
+      // * @gh:              Handle to graph previously opened with xrtGraphOpen.      
+      // *
+      // * Return:          0 on success, -1 on timeout.
+      // *
+      // * Note: This API with non-zero AIE cycle is for graph that is running
+      // * forever or graph that has multi-rate core(s).
+      // */
+      // int
+      //   xrtGraphEnd(void * gh);
+      // 
+      // /**
+      // * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
+      // *
+      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+      // * @hierPathPort:    hierarchial name of RTP port.
+      // * @buffer:          pointer to the RTP value.
+      // * @size:            size in bytes of the RTP value.
+      // *
+      // * Return:          0 on success, -1 on error.
+      // */
+      // int
+      //   xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size);
+      // 
+      // /**
+      // * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
+      // *
+      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
+      // * @hierPathPort:    hierarchial name of RTP port.
+      // * @buffer:          pointer to the buffer that RTP value is copied to.
+      // * @size:            size in bytes of the RTP value.
+      // *
+      // * Return:          0 on success, -1 on error.
+      // *
+      // * Note: Caller is reponsible for allocating enough memory for RTP value
+      // *       being copied to.
+      // */
+      // int
+      //   xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer, size_t size);
+
     private:
       std::shared_ptr<xrt_core::device> mCoreDevice;
       std::mutex mMemManagerMutex;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Removed the stub calls for sw_emu PCIe driver and added the XCL GRAPH API definitions for sw_emu pcie driver

This is the new enhancement requested as part of the VITIS-3745 Running PS APP as x86
process Enable AIE shim level calls by default on x86 in preparation
for supporting x86 software emulation of graph host code

#### How problem was solved, alternative solutions (if any) and why they were rejected

No risks as the enabled code should not be called at all unless we have additional tests added for PCIe with graph calls

Ran the sw_emu canary and it is clean. And verified few tests where we have the graph calls enabled and ran for the PCIe platform

This is being EA feature, yet not added any tests to sprite.
