### PR TITLE
cherry-pick #5981 - Remove fpga-mgr dependency for xclmgmt loading

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -103,7 +103,10 @@ ifeq ($(SYMBOL),1)
 	ccflags-y += -g
 endif
 
-ccflags-$(CONFIG_FPGA) += -DENABLE_FPGA_MGR_SUPPORT
+# We can only rely on CONFIG_FPGA to check whether system has fpga-mgr module support or not.
+# But it is not true in some Kernels where this config is enabled but fpga-mgr module is not available
+# which is causing xclmgmt driver loading to fail. So commenting this as fpga-mgr is not used anywhere.
+# ccflags-$(CONFIG_FPGA) += -DENABLE_FPGA_MGR_SUPPORT
 ccflags-y += $(ccflags-m)
 
 all:


### PR DESCRIPTION
> We currently rely on CONFIG_FPGA configuration to check whether fpga-mgr module support is present or not
> But in some Kernel even though this config is enabled fpga-mgr module is not available which is causing xclmgmt driver loading to fail.
> Commented out adding fpga-mgr dependency for xclmgmt as it is not used anywhere at present.
> This fix resolves CR-1115038.