### PR TITLE
CR-1114812 and CR-1114810: Profiling flag streamlining

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,16 @@ XRT ChangeLog
 Added
 .....
 
+* Added the xrt.ini flag "device_counter"
+* Added the xrt.ini flag "device_trace"
+
 Removed
 .......
 * Removed deprecated streaming APIs from OpenCL
 * xrt.ini flags "profile," "timeline_trace," and "xrt_profile" no longer load xdp profiling functionality and no longer issue deprecation warning
 * Deprecating the xrt.ini flag "opencl_summary"
 * Deprecating the xrt.ini flag "data_transfer_trace"
+* Deprecating the xrt.ini flag "opencl_device_counter"
 
 2.12.0 (202120.2.12.x)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Removed
 .......
 * Removed deprecated streaming APIs from OpenCL
 * xrt.ini flags "profile," "timeline_trace," and "xrt_profile" no longer load xdp profiling functionality and no longer issue deprecation warning
+* Deprecating the xrt.ini flag "opencl_summary"
 
 2.12.0 (202120.2.12.x)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Removed
 * Removed deprecated streaming APIs from OpenCL
 * xrt.ini flags "profile," "timeline_trace," and "xrt_profile" no longer load xdp profiling functionality and no longer issue deprecation warning
 * Deprecating the xrt.ini flag "opencl_summary"
+* Deprecating the xrt.ini flag "data_transfer_trace"
 
 2.12.0 (202120.2.12.x)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,16 +6,13 @@ XRT ChangeLog
 Added
 .....
 
-* Added the xrt.ini flag "device_counter"
-* Added the xrt.ini flag "device_trace"
+* Added the xrt.ini profiling flags "device_counter" and "device_trace" 
 
 Removed
 .......
 * Removed deprecated streaming APIs from OpenCL
 * xrt.ini flags "profile," "timeline_trace," and "xrt_profile" no longer load xdp profiling functionality and no longer issue deprecation warning
-* Deprecating the xrt.ini flag "opencl_summary"
-* Deprecating the xrt.ini flag "data_transfer_trace"
-* Deprecating the xrt.ini flag "opencl_device_counter"
+* Deprecating the xrt.ini profiling flags "opencl_summary," "data_transfer_trace," and "opencl_device_counter"
 
 2.12.0 (202120.2.12.x)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -306,9 +306,9 @@ get_opencl_device_counter()
 }
 
 inline bool
-get_device_counter()
+get_device_counters()
 {
-  static bool value = detail::get_bool_value("Debug.device_counter", false);
+  static bool value = detail::get_bool_value("Debug.device_counters", false);
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -150,6 +150,16 @@ get_data_transfer_trace()
 }
 
 inline std::string
+get_data_transfer_trace_dep_message()
+{
+  static bool emitted = false ;
+  if (!emitted) {
+    return "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
+  }
+  return "" ;
+}
+
+inline std::string
 get_device_trace()
 {
   static std::string value = detail::get_string_value("Debug.device_trace", "off");

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -295,6 +295,13 @@ get_opencl_device_counter()
 }
 
 inline bool
+get_device_counter()
+{
+  static bool value = detail::get_bool_value("Debug.device_counter", false);
+  return value;
+}
+
+inline bool
 get_aie_trace()
 {
   static bool value = detail::get_bool_value("Debug.aie_trace", false);

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -150,6 +150,13 @@ get_data_transfer_trace()
 }
 
 inline std::string
+get_device_trace()
+{
+  static std::string value = detail::get_string_value("Debug.device_trace", "off");
+  return value;
+}
+
+inline std::string
 get_profiling_directory()
 {
   static std::string value = detail::get_string_value("Debug.profiling_directory", "") ;
@@ -204,8 +211,7 @@ get_noc_profile_interval_ms()
 inline std::string
 get_stall_trace()
 {
-  static std::string data_transfer_enabled = get_data_transfer_trace();
-  static std::string value = ((0 == data_transfer_enabled.compare("off")) ) ? "off" : detail::get_string_value("Debug.stall_trace","off");
+  static std::string value = detail::get_string_value("Debug.stall_trace", "off");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -101,13 +101,6 @@ set(const std::string& key, const std::string& value);
  * file
  */
 inline bool
-get_debug()
-{
-  static bool value  = detail::get_bool_value("Debug.debug",false);
-  return value;
-}
-
-inline bool
 get_app_debug()
 {
   static bool value  = detail::get_bool_value("Debug.app_debug",false);
@@ -220,14 +213,6 @@ inline bool
 get_continuous_trace()
 {
   static bool value = detail::get_bool_value("Debug.continuous_trace",false);
-  return value;
-}
-
-inline unsigned int
-get_continuous_trace_interval_ms()
-{
-  // NOLINTNEXTLINE
-  static unsigned int value = detail::get_uint_value("Debug.continuous_trace_interval_ms",10);
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -222,7 +222,11 @@ get_noc_profile_interval_ms()
 inline std::string
 get_stall_trace()
 {
-  static std::string value = detail::get_string_value("Debug.stall_trace", "off");
+  static bool data_transfer_enabled =
+    (get_data_transfer_trace() != "off") || (get_device_trace() != "off") ;
+  static std::string value =
+    (!data_transfer_enabled) ? "off" :
+    detail::get_string_value("Debug.stall_trace", "off");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -154,6 +154,7 @@ get_data_transfer_trace_dep_message()
 {
   static bool emitted = false ;
   if (!emitted) {
+    emitted = true ;
     return "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
   }
   return "" ;

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -24,6 +24,7 @@
 #include "sc_profile.h"
 
 #include "core/common/config_reader.h"
+#include "core/common/message.h"
 
 namespace xdp {
 namespace hal_hw_plugins {

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -38,7 +38,7 @@ bool load()
 
   if (xrt_core::config::get_data_transfer_trace() != "off" ||
       xrt_core::config::get_device_trace() != "off" ||
-      xrt_core::config::get_device_counter()) {
+      xrt_core::config::get_device_counters()) {
     xdp::hal::device_offload::load() ;
   }
 

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -36,7 +36,8 @@ bool load()
   }
 
   if (xrt_core::config::get_data_transfer_trace() != "off" ||
-      xrt_core::config::get_device_trace() != "off") {
+      xrt_core::config::get_device_trace() != "off" ||
+      xrt_core::config::get_device_counter()) {
     xdp::hal::device_offload::load() ;
   }
 

--- a/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/edge/user/plugin/xdp/plugin_loader.cpp
@@ -35,7 +35,8 @@ bool load()
     xdp::hal::load() ;
   }
 
-  if (xrt_core::config::get_data_transfer_trace() != "off") {
+  if (xrt_core::config::get_data_transfer_trace() != "off" ||
+      xrt_core::config::get_device_trace() != "off") {
     xdp::hal::device_offload::load() ;
   }
 
@@ -64,6 +65,12 @@ bool load()
 
   if (xrt_core::config::get_vitis_ai_profile()) {
     xdp::vart::profile::load() ;
+  }
+
+  if (xrt_core::config::get_data_transfer_trace() != "off") {
+    std::string msg = "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            msg) ;
   }
 
   return true ;

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
@@ -38,7 +38,8 @@ bool load()
   }
 
   if (xrt_core::config::get_data_transfer_trace() != "off" ||
-      xrt_core::config::get_device_trace() != "off") {
+      xrt_core::config::get_device_trace() != "off" ||
+      xrt_core::config::get_device_counter()) {
     xdp::hal::device_offload::load() ;
   }
 

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
@@ -39,7 +39,7 @@ bool load()
 
   if (xrt_core::config::get_data_transfer_trace() != "off" ||
       xrt_core::config::get_device_trace() != "off" ||
-      xrt_core::config::get_device_counter()) {
+      xrt_core::config::get_device_counters()) {
     xdp::hal::device_offload::load() ;
   }
 

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
@@ -25,6 +25,7 @@
 #include "plugin/xdp/sc_profile.h"
 
 #include "core/common/config_reader.h"
+#include "core/common/message.h"
 
 namespace xdp {
 namespace hal_hw_plugins {
@@ -36,7 +37,8 @@ bool load()
     xdp::hal::load() ;
   }
 
-  if (xrt_core::config::get_data_transfer_trace() != "off") {
+  if (xrt_core::config::get_data_transfer_trace() != "off" ||
+      xrt_core::config::get_device_trace() != "off") {
     xdp::hal::device_offload::load() ;
   }
 
@@ -62,6 +64,13 @@ bool load()
 
   if (xrt_core::config::get_vitis_ai_profile()) {
     xdp::vart::profile::load() ;
+  }
+
+  // Deprecation messages
+  if (xrt_core::config::get_data_transfer_trace() != "off") {
+    std::string msg = "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                            msg) ;
   }
 
   return true ;

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/plugin_loader.cpp
@@ -69,9 +69,11 @@ bool load()
 
   // Deprecation messages
   if (xrt_core::config::get_data_transfer_trace() != "off") {
-    std::string msg = "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
-    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-                            msg) ;
+    std::string msg = xrt_core::config::get_data_transfer_trace_dep_message();
+    if (msg != "") {
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                              msg) ;
+    }
   }
 
   return true ;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -53,7 +53,7 @@
 
 #define FIFO_WARN_MSG "Trace FIFO is full because of too many events. Device trace could be incomplete. Suggested fixes:\n\
 1. Use larger FIFO size or DDR/HBM bank as 'trace_memory' in linking options.\n\
-2. Use 'coarse' option for data_transfer_trace and/or turn off stall_trace in runtime settings."
+2. Use 'coarse' option for device_trace and/or turn off stall_trace in runtime settings."
 
 #define CONTINUOUS_OFFLOAD_WARN_MSG_FIFO   "Continuous offload is currently not supported in FIFO trace offload. Disabling this option."
 
@@ -62,7 +62,7 @@
 #define TS2MM_WARN_MSG_BUFSIZE_DEF    "Trace Buffer size could not be parsed. The default size of 1M will be used."
 #define TS2MM_WARN_MSG_ALLOC_FAIL     "Trace Buffer could not be allocated on device. Device trace will be missing."
 #define TS2MM_WARN_MSG_BUF_FULL       "Trace Buffer is full. Device trace could be incomplete. \
-Please increase trace_buffer_size or use 'coarse' option for data_transfer_trace or turn on continuous_trace."
+Please increase trace_buffer_size or use 'coarse' option for device_trace or turn on continuous_trace."
 #define TS2MM_WARN_MSG_CIRC_BUF       "Device trace will be limited to trace buffer size due to insufficient trace offload rate. Please increase trace \
 buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -98,11 +98,8 @@ namespace xdp {
     if (getFlowMode() == HW) {
       continuous_trace = xrt_core::config::get_continuous_trace() ;
 
-    // Use new flag if specified
-      trace_buffer_offload_interval_ms = xrt_core::config::get_continuous_trace_interval_ms() ;
-      auto newInt = xrt_core::config::get_trace_buffer_offload_interval_ms();
-        if (newInt != DEFAULT_TRACE_OFFLOAD_INTERVAL_MS)
-          trace_buffer_offload_interval_ms = newInt;
+      trace_buffer_offload_interval_ms =
+        xrt_core::config::get_trace_buffer_offload_interval_ms();
 
       m_enable_circular_buffer = continuous_trace;
     }

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2021 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -210,7 +210,8 @@ namespace xdp {
 
     // If trace is enabled, set up trace.  Otherwise just keep the offloader
     //  for reading the counters.
-    if (xrt_core::config::get_data_transfer_trace() != "off") {
+    if (xrt_core::config::get_data_transfer_trace() != "off" ||
+        xrt_core::config::get_device_trace() != "off") {
       bool init_successful =
         offloader->read_trace_init(m_enable_circular_buffer) ;
 
@@ -283,6 +284,9 @@ namespace xdp {
     // Collect all the profiling options from xrt.ini
     std::string data_transfer_trace = 
       xrt_core::config::get_data_transfer_trace() ;
+    if (data_transfer_trace == "off") {
+      data_transfer_trace = xrt_core::config::get_device_trace() ;
+    }
     std::string stall_trace = xrt_core::config::get_stall_trace() ;
 
     // Set up the hardware trace option

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -122,6 +122,7 @@ namespace xdp {
       counterOffloadEnabled = true ;
     }
     if (xrt_core::config::get_data_transfer_trace() != "off" ||
+        xrt_core::config::get_device_trace() != "off" ||
         xrt_core::config::get_stall_trace() != "off") {
       counterOffloadEnabled = true ;
       traceOffloadEnabled = true ;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -118,7 +118,8 @@ namespace xdp {
 
     // Based on the xrt.ini flags we will support either offload of
     //  either counters only or counters and trace.
-    if (xrt_core::config::get_opencl_device_counter()) {
+    if (xrt_core::config::get_opencl_device_counter() ||
+        xrt_core::config::get_device_counter()) {
       counterOffloadEnabled = true ;
     }
     if (xrt_core::config::get_data_transfer_trace() != "off" ||

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_offload_plugin.cpp
@@ -119,7 +119,7 @@ namespace xdp {
     // Based on the xrt.ini flags we will support either offload of
     //  either counters only or counters and trace.
     if (xrt_core::config::get_opencl_device_counter() ||
-        xrt_core::config::get_device_counter()) {
+        xrt_core::config::get_device_counters()) {
       counterOffloadEnabled = true ;
     }
     if (xrt_core::config::get_data_transfer_trace() != "off" ||

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -30,8 +30,8 @@ namespace xdp {
     addParameter("opencl_device_counter",
                  xrt_core::config::get_opencl_device_counter(),
                  "Hardware counters added to OpenCL summary file (deprecated)");
-    addParameter("device_counter",
-                 xrt_core::config::get_device_counter(),
+    addParameter("device_counters",
+                 xrt_core::config::get_device_counters(),
                  "Hardware counters added to summary file");
     addParameter("native_xrt_trace", xrt_core::config::get_native_xrt_trace(),
                  "Generation of Native XRT API function trace");

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -51,9 +51,6 @@ namespace xdp {
                  "Verbosity level");
     addParameter("continuous_trace", xrt_core::config::get_continuous_trace(),
                  "Continuous offloading of trace from memory to host");
-    addParameter("continuous_trace_interval_ms",
-                 xrt_core::config::get_continuous_trace_interval_ms(),
-                 "Interval for offloading trace (in ms; deprecated)");
     addParameter("trace_buffer_offload_interval_ms",
                  xrt_core::config::get_trace_buffer_offload_interval_ms(),
                  "Interval for reading of device data to host (in ms)");

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -24,7 +24,7 @@ namespace xdp {
   IniParameters::IniParameters()
   {
     addParameter("opencl_summary", xrt_core::config::get_opencl_summary(),
-                 "Generation of OpenCL summary report");
+                 "Generation of OpenCL summary report (deprecated)");
     addParameter("opencl_trace", xrt_core::config::get_opencl_trace(),
                  "Generation of trace of OpenCL APIs and memory transfers");
     addParameter("opencl_device_counter",

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -29,7 +29,10 @@ namespace xdp {
                  "Generation of trace of OpenCL APIs and memory transfers");
     addParameter("opencl_device_counter",
                  xrt_core::config::get_opencl_device_counter(),
-                 "Hardware counters added to OpenCL summary file");
+                 "Hardware counters added to OpenCL summary file (deprecated)");
+    addParameter("device_counter",
+                 xrt_core::config::get_device_counter(),
+                 "Hardware counters added to summary file");
     addParameter("native_xrt_trace", xrt_core::config::get_native_xrt_trace(),
                  "Generation of Native XRT API function trace");
     addParameter("xrt_trace", xrt_core::config::get_xrt_trace(),

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -36,6 +36,9 @@ namespace xdp {
                  "Generation of hardware SHIM function trace");
     addParameter("data_transfer_trace",
                  xrt_core::config::get_data_transfer_trace(),
+                 "Collection of data from PL monitors and added to summary and trace (deprecated)");
+    addParameter("device_trace",
+                 xrt_core::config::get_device_trace(),
                  "Collection of data from PL monitors and added to summary and trace");
     addParameter("power_profile", xrt_core::config::get_power_profile(),
                  "Polling of power data during execution of application");

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -35,6 +35,7 @@ namespace plugins {
     }
 
     if (xrt_core::config::get_data_transfer_trace() != "off" ||
+        xrt_core::config::get_device_trace() != "off" ||
         xrt_core::config::get_opencl_device_counter()) {
       xdp::device_offload::load() ;
     }
@@ -55,6 +56,12 @@ namespace plugins {
     // Deprecation warnings specific to the .ini flags
     if (xrt_core::config::get_opencl_summary()) {
       std::string msg = "The xrt.ini flag \"opencl_summary\" is deprecated and will be removed in a future release.  A summary file is generated when when any profiling is enabled, so please use the appropriate settings from \"opencl_trace=true\", \"device_counters=true\", and \"device_trace=true.\"" ;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                              msg) ;
+    }
+
+    if (xrt_core::config::get_data_transfer_trace() != "off") {
+      std::string msg = "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
                               msg) ;
     }

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -37,7 +37,7 @@ namespace plugins {
     if (xrt_core::config::get_data_transfer_trace() != "off" ||
         xrt_core::config::get_device_trace() != "off" ||
         xrt_core::config::get_opencl_device_counter() ||
-        xrt_core::config::get_device_counter()) {
+        xrt_core::config::get_device_counters()) {
       xdp::device_offload::load() ;
     }
 

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -56,15 +56,18 @@ namespace plugins {
 
     // Deprecation warnings specific to the .ini flags
     if (xrt_core::config::get_opencl_summary()) {
-      std::string msg = "The xrt.ini flag \"opencl_summary\" is deprecated and will be removed in a future release.  A summary file is generated when when any profiling is enabled, so please use the appropriate settings from \"opencl_trace=true\", \"device_counters=true\", and \"device_trace=true.\"" ;
+      std::string msg = "The xrt.ini flag \"opencl_summary\" is deprecated and will be removed in a future release.  A summary file is generated when when any profiling is enabled, so please use the appropriate settings from \"opencl_trace=true\", \"device_counter=true\", and \"device_trace=true.\"" ;
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
                               msg) ;
     }
 
     if (xrt_core::config::get_data_transfer_trace() != "off") {
-      std::string msg = "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-                              msg) ;
+      std::string msg = xrt_core::config::get_data_transfer_trace_dep_message();
+      if (msg != "") {
+        xrt_core::message::send(xrt_core::message::severity_level::warning,
+                                "XRT",
+                                msg) ;
+      }
     }
 
     if (xrt_core::config::get_opencl_device_counter()) {

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -52,11 +52,6 @@ namespace plugins {
     }
 
     // Deprecation warnings specific to the .ini flags
-    if (xrt_core::config::get_continuous_trace_interval_ms() != 10) {
-      std::string message = "\"continuous_trace_interval_ms\" configuration in xrt.ini will be deprecated in the next release.  Please use \"trace_buffer_offload_interval_ms\" to control trace offload interval." ;
-      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
-                              message) ;
-    }
 
     return true ;
   }

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -44,6 +44,7 @@ namespace plugins {
     }
 
     if (xrt_core::config::get_opencl_trace()) {
+      xocl::profile::load_xdp_opencl_counters() ;
       xdp::opencl_trace::load() ;
     }
 
@@ -52,6 +53,11 @@ namespace plugins {
     }
 
     // Deprecation warnings specific to the .ini flags
+    if (xrt_core::config::get_opencl_summary()) {
+      std::string msg = "The xrt.ini flag \"opencl_summary\" is deprecated and will be removed in a future release.  A summary file is generated when when any profiling is enabled, so please use the appropriate settings from \"opencl_trace=true\", \"device_counters=true\", and \"device_trace=true.\"" ;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                              msg) ;
+    }
 
     return true ;
   }

--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -36,7 +36,8 @@ namespace plugins {
 
     if (xrt_core::config::get_data_transfer_trace() != "off" ||
         xrt_core::config::get_device_trace() != "off" ||
-        xrt_core::config::get_opencl_device_counter()) {
+        xrt_core::config::get_opencl_device_counter() ||
+        xrt_core::config::get_device_counter()) {
       xdp::device_offload::load() ;
     }
 
@@ -62,6 +63,12 @@ namespace plugins {
 
     if (xrt_core::config::get_data_transfer_trace() != "off") {
       std::string msg = "The xrt.ini flag \"data_transfer_trace\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_trace.\"" ;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                              msg) ;
+    }
+
+    if (xrt_core::config::get_opencl_device_counter()) {
+      std::string msg = "The xrt.ini flag \"opencl_device_counter\" is deprecated and will be removed in a future release.  Please use the equivalent flag \"device_counter.\"";
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
                               msg) ;
     }

--- a/src/runtime_src/xocl/api/plugin/xdp/profile_counters.h
+++ b/src/runtime_src/xocl/api/plugin/xdp/profile_counters.h
@@ -30,7 +30,8 @@ namespace xocl {
       inline void
       set_event_action(xocl::event* e, F&& f, Args&&... args)
       {
-	if (xrt_core::config::get_opencl_summary())
+	if (xrt_core::config::get_opencl_summary() ||
+            xrt_core::config::get_opencl_trace())
 	  e->set_profile_counter_action(f(std::forward<Args>(args)...)) ;
       }
      } // end namespace counters

--- a/src/runtime_src/xocl/core/event.h
+++ b/src/runtime_src/xocl/core/event.h
@@ -141,7 +141,8 @@ public:
   void
   set_profile_counter_action(event::action_profile_type&& action)
   {
-    if (xrt_xocl::config::get_opencl_summary())
+    if (xrt_xocl::config::get_opencl_summary() ||
+        xrt_xocl::config::get_opencl_trace())
       m_profile_counter_action = std::move(action) ;
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Deprecating confusing profiling options and replacing them with clearer options more aligned to the new profiling architecture's model.

#### Documentation impact (if any)
Newly deprecated switches now issue warnings when used and the changelog has been updated to reflect the switch changes.