### PR TITLE
Update xrt::kernel implementation to use domain/index for compute unit

### DIFF
--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "context_mgr.h"
+#include "core/common/cuidx_type.h"
 #include "core/common/debug.h"
 #include "core/common/device.h"
 
@@ -21,19 +22,37 @@ namespace xrt_core { namespace context_mgr {
 constexpr size_t max_cus = 129;  // +1 for virtual CU
 constexpr auto virtual_cu_idx = std::numeric_limits<unsigned int>::max();
 
+// class device_context_mgr - synchroize open and close context for IPs
+//    
+// If multiple threads share the same device object and acquire /
+// release context on the same CUs, then careful synchronization of
+// low level xclOpen/CloseContext is required.
+//
+// The synchronization ensures that when a thread is in the process of
+// releasing a context, another thread wont call xclOpenContext before
+// the former has closed its context.
 class device_context_mgr
 {
   std::mutex m_mutex;
   std::condition_variable m_cv;
   xrt_core::device* m_device;
-  std::bitset<max_cus> m_ctx;
+
+  using domain_type = cuidx_type::domain_type;
+  std::map<domain_type, std::bitset<max_cus>> m_d2ctx; // domain -> cxt
+
+  std::bitset<max_cus>&
+  get_ctx(cuidx_type ipidx)
+  {
+    return m_d2ctx[ipidx.domain];
+  }
 
   size_t
-  ctxidx(unsigned int ipidx)
+  ctxidx(cuidx_type ipidx)
   {
     // translate ipidx to idx used in bitset.
     // virtual cu is last entry in bitset.
-    return ipidx == virtual_cu_idx ? max_cus - 1 : ipidx;
+    // virtual cu is always in default domain 0.
+    return ipidx.index == virtual_cu_idx ? max_cus - 1 : ipidx.domain_index;
   }
   
 public:
@@ -46,29 +65,31 @@ public:
   // this open() function on the same ip. The intended use-case
   // (xrt::kernel) prevents this situation.
   void
-  open(const xrt::uuid& uuid, unsigned int ipidx, bool shared)
+  open(const xrt::uuid& uuid, cuidx_type ipidx, bool shared)
   {
     auto idx = ctxidx(ipidx);
     std::unique_lock<std::mutex> ul(m_mutex);
-    while (m_ctx.test(idx)) {
+    auto& ctx = get_ctx(ipidx);
+    while (ctx.test(idx)) {
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
     }
-    m_device->open_context(uuid.get(), ipidx, shared);
-    m_ctx.set(idx);
+    m_device->open_context(uuid.get(), ipidx.index, shared);
+    ctx.set(idx);
   }
 
   // Close the cu context and notify threads that might be waiting
   // to open this cu
   void
-  close(const xrt::uuid& uuid, unsigned int ipidx)
+  close(const xrt::uuid& uuid, cuidx_type ipidx)
   {
     auto idx = ctxidx(ipidx);
     std::lock_guard<std::mutex> lk(m_mutex);
-    if (!m_ctx.test(idx))
-      throw std::runtime_error("ctx " + std::to_string(ipidx) + " not open");
-    m_device->close_context(uuid.get(), ipidx);
-    m_ctx.reset(idx);
+    auto& ctx = get_ctx(ipidx);
+    if (!ctx.test(idx))
+      throw std::runtime_error("ctx " + std::to_string(ipidx.index) + " not open");
+    m_device->close_context(uuid.get(), ipidx.index);
+    ctx.reset(idx);
     m_cv.notify_all();
   }
 };
@@ -100,7 +121,7 @@ create(const xrt_core::device* device)
 }
 
 void
-open_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx, bool shared)
+open_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx, bool shared)
 {
   if (auto ctxmgr = get_device_context_mgr(device)) {
     ctxmgr->open(uuid, cuidx, shared);
@@ -111,7 +132,7 @@ open_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx
 }
 
 void
-close_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx)
+close_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx)
 {
   if (auto ctxmgr = get_device_context_mgr(device)) {
     ctxmgr->close(uuid, cuidx);

--- a/src/runtime_src/core/common/api/context_mgr.h
+++ b/src/runtime_src/core/common/api/context_mgr.h
@@ -4,6 +4,7 @@
  */
 
 #include "core/include/xrt/xrt_uuid.h"
+#include "core/common/cuidx_type.h"
 #include <memory>
 
 // This file defines APIs for compute unit (ip) context management
@@ -47,7 +48,7 @@ create(const xrt_core::device* device);
 // The function is simply a synchronization between two threads
 // simultanous use of open_context and close_context.
 void
-open_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx, bool shared);
+open_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx, bool shared);
 
 // Close a previously opened device context
 //
@@ -57,6 +58,6 @@ open_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx
 //
 // The function throws if no context is open on specified CU.
 void
-close_context(xrt_core::device* device, const xrt::uuid& uuid, unsigned int cuidx);
+close_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx);
  
 }} // context_mgr, xrt_core

--- a/src/runtime_src/core/common/cuidx_type.h
+++ b/src/runtime_src/core/common/cuidx_type.h
@@ -30,6 +30,10 @@ struct cuidx_type {
       std::uint16_t domain;       // [31-16]
     };
   };
+
+  // Ensure consistent use of domain and index types
+  using domain_type = uint16_t;
+  using domain_index_type = uint16_t;
 };
 
 } // xrt_core


### PR DESCRIPTION
#### Problem solved by the commit
This PR builds on #5994 to leverage the CU domain.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Context management is per domain, so the grunt of the work in this PR
is adding an extra level of indexing to structures that capture and
manage context opened and closed using xclOpenContext and
xclCloseContext.  The extra level of indexing is basically a mapping
from domain to contexts acquired and released within that domain.

The CU domain index remains consecutive and in the range from 0 to
max_cus (128).  Kernel execution uses the domain index for the
command cumask.

#### Risks (if any) associated the changes in the commit
The risk in this PR is that native xrt::kernel APIs have switched to
use the mapping from CU name to encoded CU index introduced in

#### What has been tested and how, request additional testing if necessary
The standard OpenCL HW tests have been validated against the changes
in this PR.