### PR TITLE
Base headers for support of kernels with multiple interrupts

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -33,6 +33,9 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <thread>
+#include <condition_variable>
+#include <mutex>
 
 #ifdef _WIN32
 # pragma warning( disable : 4244 4996)
@@ -110,6 +113,12 @@ public:
     // Waits for interrupt, upon return interrupt is disabled.
     device->wait_ip_interrupt(handle);
     enable(); // re-enable interrupts
+  }
+
+  void
+  wait(const std::chrono::milliseconds& timeout_ms) const
+  {
+    throw std::runtime_error("Not supported. Use wait()");
   }
 };
 
@@ -221,6 +230,13 @@ private:
   ip_context ipctx;
   uint32_t uid;                                  // internal unique id for debug
 
+  //callback thread: To run callback functions on receiving an async interrupt
+  //Upto 16 interrupts/callbacks; async interrupts (eg for always running kernels)
+  std::thread cb_thread;
+  mutable std::mutex m_mutex;
+  mutable std::condition_variable m_int_cb;
+  //std::unique_ptr<callback_list> m_callbacks;
+
 public:
   // ip_impl - constructor
   //
@@ -323,6 +339,15 @@ ip::
 create_interrupt_notify()
 {
   return xrt::ip::interrupt{handle->get_interrupt()};
+}
+
+void
+ip::
+add_callback(unsigned int interrupt_bit,
+             std::function<void(const void*, unsigned int, void*)> callback,
+             void* data)
+{
+  throw std::runtime_error("Not supported.");
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/include/experimental/xrt_ip.h
+++ b/src/runtime_src/core/include/experimental/xrt_ip.h
@@ -25,6 +25,8 @@
 #ifdef __cplusplus
 # include <cstdint>
 # include <string>
+# include <chrono>
+# include <functional>
 #endif
 
 #ifdef __cplusplus
@@ -108,6 +110,18 @@ public:
     XCL_DRIVER_DLLESPEC
     void
     wait();
+
+    /**
+     * wait() - Wait for interrupt
+     *
+     * Wait for interrupt from IP. On interrupt,
+     * interrupt is re-enabled and returns.
+     * On timeout, exception is thrown
+     */
+    XCL_DRIVER_DLLESPEC
+    void
+    wait(const std::chrono::milliseconds& timeout = std::chrono::milliseconds{0}) const;
+
   };
  
 public:
@@ -181,6 +195,31 @@ public:
   XCL_DRIVER_DLLESPEC
   interrupt
   create_interrupt_notify();  
+
+  /**
+   * add_callback() - Add a callback function for an interrupt bit
+   *
+   * @param interrupt_bit   Interrupt bit to invoke callback on
+   * @param callback        Callback function
+   * @param data            User data to pass to callback function
+   *
+   * The function is called when interrupt is raised for the chosen interrupt bit
+   * Upto 16 interrupt bits are supported.
+   *
+   * The function object's first parameter is a unique 'key'
+   * for this xrt::ip object implmentation on which the callback
+   * was added. This 'key' can be used to identify an actual ip
+   * object that refers to the implementaion that is maybe shared
+   * by multiple xrt::ip objects.
+   *
+   * Only one callback per interrupt bit is supported
+   */
+  XCL_DRIVER_DLLESPEC
+  void
+  add_callback(unsigned int interrupt_bit,
+    std::function<void(const void*, unsigned int, void*)> callback,
+    void* data);
+
 };
 
 } // xrt


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
New feature support for multiple interrupts requires callbacks to be supported in
user managed kernels. Adding header changes for callback functions.

#### How problem was solved, alternative solutions (if any) and why they were rejected
xrt::ip to use a thread (cb_thread) to run callback functions.
User space can manage these callbacks for "user managed kernels".
One callback per interrupt bit to be supported

#### Risks (if any) associated the changes in the commit
Following PRs will add more header changes and more functionality for the feature
