### PR TITLE
In the similar lines of the Versal and ZynqMP, moving the device proc…

### DIFF
--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -155,8 +155,8 @@ namespace xclcpuemhal2 {
       }
     }
     xclBinName = xml_project.get<std::string>("project.<xmlattr>.name", "");
-    //check for Versal,zynqmp Platforms
-    if (fpgaDevice != "" && (fpgaDevice.find("versal:") != std::string::npos || fpgaDevice.find("zynquplus:") != std::string::npos)) {
+    // check for versal,zynqmp and zynq platforms. Enabling to run the device process in x86 instead of QEMU for all the Zynq, ZynqMP and Versal platforms
+    if (fpgaDevice != "" && (fpgaDevice.find("versal:") != std::string::npos || fpgaDevice.find("zynq") != std::string::npos)) {
       deviceProcessInQemu = false;
     }
     return true;


### PR DESCRIPTION
In the similar lines of the Versal and ZynqMP, moving the device process execution to x86 even for zynq7 platforms. Post this submit we have Vitis perforce checkins

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Unified flow for all the edge platforms

Enhancement to improve the kernel execution time

There are no alternate solutions

No risk, this is enhancment request

This is being edge platform, created the RPMs for aarch32 (zynq7 architecture) and test the designs manually

Nope
