### PR TITLE
xball : Fixed issue on how xbmgmt and xbutil are called.

### DIFF
--- a/src/runtime_src/core/tools/common/xball
+++ b/src/runtime_src/core/tools/common/xball
@@ -172,6 +172,7 @@ for device in working_devices:
   print("=====================================================================")
   print("%d / %d [%s] : %s" % (device_count, len(working_devices), device["bdf"], device["vbnv"]))
   cmd = "${XRT_BIN_DIR}/${xrt_app} --device " + device["bdf"] + " $prog_args"
+  cmd = "${XRT_BIN_DIR}/${xrt_app} $prog_args --device " + device["bdf"]
   print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
   print("Command: %s\n" % cmd)
   exit_code = os.system(cmd)

--- a/src/runtime_src/core/tools/common/xball
+++ b/src/runtime_src/core/tools/common/xball
@@ -171,7 +171,6 @@ for device in working_devices:
   print("\n")
   print("=====================================================================")
   print("%d / %d [%s] : %s" % (device_count, len(working_devices), device["bdf"], device["vbnv"]))
-  cmd = "${XRT_BIN_DIR}/${xrt_app} --device " + device["bdf"] + " $prog_args"
   cmd = "${XRT_BIN_DIR}/${xrt_app} $prog_args --device " + device["bdf"]
   print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
   print("Command: %s\n" % cmd)


### PR DESCRIPTION
In 2021.1, there is a bug where xbmgmt and xbutil expect the --device option to be at the end of the command line and not in the front.  This change updates xball to add it to the end of the command line.

CR 1115358 -U30 XRT release : xball doesn't honor xbmgmt / xbutil --device option placement
