### PR TITLE
CR-1114421 xbutil validate doesn't complete with versal discovery shell

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -906,6 +906,7 @@ verifyKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_
 void
 dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
+  _ptTest.put("status", "skipped");
   if(!search_and_program_xclbin(_dev, _ptTest)) {
     return;
   }
@@ -921,7 +922,6 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
   } catch(...){}
 
   if (dma_thr.size() == 0){
-    _ptTest.put("status", "skipped");
     return ;
   }
 


### PR DESCRIPTION
The status node of the dmatest is not populated which gives a "node not found" error instead of skipping the test. 

Sample output:

```
$ xbutil validate -d 0000:b3:00.1 -r DMA --verbose
Verbose: Enabling Verbosity
Starting validation for 1 devices

Validate Device           : [0000:b3:00.1]
    Platform              : xilinx_vck5000_gen4x8_xdma_base_1
    SC Version            : 
    Platform ID           : DE8394A6-19CC-8A5D-2372-27031164C8C3
-------------------------------------------------------------------------------
size: 128
Test 1 [0000:b3:00.1]     : DMA 

    Description           : Run dma test
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
```