### PR TITLE
Vitis-3342 Merge PS kernel execution with xrt::kernel

### DIFF
--- a/build/dbg.sh
+++ b/build/dbg.sh
@@ -22,6 +22,7 @@ usage()
     echo "[-help]                    List this help"
     echo "[-j <n>]                   Compile parallel (default: system cores)"
     echo "[-nocmake]                 Skip CMake itself, go straight to make"
+    echo "[-pskernel]                Enable building of POC ps kernel"
     echo "[clean|-clean]             Remove build directories"
     echo "[-noccache]                Disable ccache"
 
@@ -32,6 +33,7 @@ clean=0
 ccache=1
 jcore=$CORE
 nocmake=0
+cmake_flags="-DXOCL_VERBOSE=1 -DXRT_VERBOSE=1 -DCMAKE_BUILD_TYPE=Debug"
 while [ $# -gt 0 ]; do
     case "$1" in
         -help)
@@ -54,6 +56,10 @@ while [ $# -gt 0 ]; do
             nocmake=1
             shift
             ;;
+        -pskernel)
+            cmake_flags+=" -DXRT_PSKERNEL_BUILD=ON"
+            shift
+            ;;
         *)
             echo "unknown option"
             usage
@@ -72,6 +78,7 @@ if [[ $ccache == 1 ]]; then
     if [[ -e /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl ]]; then
         /proj/rdi/env/HEAD/hierdesign/ccache/cleanup.pl 1 30 $RDI_CCACHEROOT
     fi
+    cmake_flags+=" -DRDI_CCACHE=1"
 fi
 
 here=$PWD
@@ -87,7 +94,7 @@ fi
 mkdir -p XDebug
 cd XDebug
 if [ $nocmake == 0 ]; then
-    $CMAKE -DRDI_CCACHE=$ccache -DCMAKE_BUILD_TYPE=Debug -DXOCL_VERBOSE=1 -DXRT_VERBOSE=1 ../../src
+    $CMAKE $cmake_flags ../../src
 fi
 make -j $jcore VERBOSE=1 DESTDIR=$PWD install
 make VERBOSE=1 DESTDIR=$PWD package

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -298,7 +298,7 @@ public: // purposely not a struct to match decl in xrt_xclbin.h
   std::vector<xclbin::ip> m_cus;
   std::vector<xclbin::arg> m_args;
   std::vector<xrt_core::xclbin::kernel_argument> m_arginfo;
-  
+
 public:
   kernel_impl(std::string&& nm,
               xrt_core::xclbin::kernel_properties&& props,

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -38,6 +38,7 @@
 namespace {
 
 namespace pt = boost::property_tree;
+using kernel_type = xrt_core::xclbin::kernel_properties::kernel_type;
 
 // NOLINTNEXTLINE
 constexpr size_t operator"" _kb(unsigned long long v)  { return 1024u * v; }
@@ -46,6 +47,19 @@ static size_t
 convert(const std::string& str)
 {
   return str.empty() ? 0 : std::stoul(str,nullptr,0);
+}
+
+static kernel_type
+to_kernel_type(const std::string& str)
+{
+  if (str == "pl")
+    return kernel_type::pl;
+  else if (str == "ps")
+    return kernel_type::ps;
+  else if (str == "dpu")
+    return kernel_type::dpu;
+
+  return kernel_type::none;
 }
 
 static bool
@@ -866,19 +880,19 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
       continue;
 
     // Determine features
-    auto mailbox = convert_to_mailbox_type(xml_kernel.second.get<std::string>("<xmlattr>.mailbox","none"));
+    auto mailbox = convert_to_mailbox_type(xml_kernel.second.get<std::string>("<xmlattr>.mailbox", "none"));
     if (mailbox == kernel_properties::mailbox_type::none)
       mailbox = get_mailbox_from_ini(kname);
-    auto restart = convert(xml_kernel.second.get<std::string>("<xmlattr>.countedAutoRestart","0"));
+    auto restart = convert(xml_kernel.second.get<std::string>("<xmlattr>.countedAutoRestart", "0"));
     if (restart == 0)
       restart = get_restart_from_ini(kname);
-    auto sw_reset = to_bool(xml_kernel.second.get<std::string>("<xmlattr>.swReset","false"));
+    auto sw_reset = to_bool(xml_kernel.second.get<std::string>("<xmlattr>.swReset", "false"));
     if (!sw_reset)
       sw_reset = get_sw_reset_from_ini(kname);
 
     return kernel_properties
       { kname
-      , kernel_properties::kernel_type::pl
+      , to_kernel_type(xml_kernel.second.get<std::string>("<xmlattr>.type", "pl"))
       , restart
       , mailbox
       , get_address_range(xml_kernel.second)

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -53,7 +53,7 @@ struct kernel_argument
 // struct kernel_properties - kernel property metadata
 struct kernel_properties
 {
-  enum class kernel_type { none, pl, ps };
+  enum class kernel_type { none, pl, ps, dpu };
   enum class mailbox_type { none, in , out, inout };
   using restart_type = size_t;
   std::string name;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -150,6 +150,7 @@ struct kds_scu_stat
 {
   using result_type = query::kds_scu_stat::result_type;
   using data_type = query::kds_scu_stat::data_type;
+  static constexpr uint32_t scu_domain = 0x10000;
 
   static result_type
   get(const xrt_core::device* device, key_type)
@@ -183,7 +184,7 @@ struct kds_scu_stat
       data.status = std::stoul(std::string(*tok_it++), nullptr, radix);
       data.usages = std::stoul(std::string(*tok_it++));
       // TODO: Let's avoid this special handling for PS kernel name
-      data.name = data.name + ":scu_" + std::to_string(data.index);
+      data.name = data.name + ":scu_" + std::to_string(data.index & ~(scu_domain));
 
       cuStats.push_back(data);
     }

--- a/src/runtime_src/xocl/core/compute_unit.cpp
+++ b/src/runtime_src/xocl/core/compute_unit.cpp
@@ -44,7 +44,7 @@ compute_unit(xrt::xclbin::kernel xkernel,
   static unsigned int count = 0;
   m_uid = count++;
 
-  XOCL_DEBUGF("xocl::compute_unit::compute_unit(%d) name(%s) index(%zu) address(0x%x)\n",m_uid,m_name.c_str(),m_index,m_address);
+  XOCL_DEBUGF("xocl::compute_unit::compute_unit(%d) name(%s) index(%zu) address(0x%x)\n",m_uid,m_xcu.get_name().c_str(),m_index,m_address);
 }
 
 compute_unit::


### PR DESCRIPTION
Enable xrt::kernel to support PS kernels.

This PR makes the final touches to enable PS kernel with xrt::kernel.
The changes are mostly around ensuring proper argument setter when
PS kernel type is detected and constructing the proper command opcode.

No significant risks as we have no current code that exercises the PS
kernel support added to xrt::kernel.

Normal HW tests have been run for sanity check.