### PR TITLE
VITIS-2372 : header update for bo type usage stats

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -44,6 +44,20 @@
 #define XOCL_BO_EXECBUF		(XOCL_HOST_MEM | XOCL_DRV_ALLOC | XOCL_DRM_SHMEM)
 #define XOCL_BO_CMA		(XOCL_HOST_MEM | XOCL_CMA_MEM)
 
+/*
+ * BO Usage stats stored in an array in drm_device.
+ * BO types are tracked: P2P, EXECBUF, etc
+ * BO usage stats to be shown in sysfs & with xbutil
+*/
+#define XOCL_BO_USAGE_TOTAL	7
+#define XOCL_BO_USAGE_NORMAL	0 //Array indexes
+#define XOCL_BO_USAGE_USERPTR	1
+#define XOCL_BO_USAGE_P2P	2
+#define XOCL_BO_USAGE_DEV_ONLY	3
+#define XOCL_BO_USAGE_IMPORT	4
+#define XOCL_BO_USAGE_EXECBUF	5
+#define XOCL_BO_USAGE_CMA	6
+
 #define XOCL_BO_DDR0 (1 << 0)
 #define XOCL_BO_DDR1 (1 << 1)
 #define XOCL_BO_DDR2 (1 << 2)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -885,6 +885,10 @@ int xocl_cleanup_mem(struct xocl_drm *drm_p)
 	int ret;
 	mutex_lock(&drm_p->mm_lock);
 	ret = xocl_cleanup_mem_nolock(drm_p);
+	if (drm_p->bo_usage_stat) {
+		vfree(drm_p->bo_usage_stat);
+		drm_p->bo_usage_stat = NULL;
+	}
 	mutex_unlock(&drm_p->mm_lock);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -786,6 +786,10 @@ int xocl_cleanup_mem_nolock(struct xocl_drm *drm_p)
 
 	BUG_ON(!mutex_is_locked(&drm_p->mm_lock));
 
+	if (drm_p->bo_usage_stat) {
+		vfree(drm_p->bo_usage_stat);
+		drm_p->bo_usage_stat = NULL;
+	}
 	err = xocl_check_topology(drm_p);
 	if (err)
 		return err;
@@ -885,10 +889,6 @@ int xocl_cleanup_mem(struct xocl_drm *drm_p)
 	int ret;
 	mutex_lock(&drm_p->mm_lock);
 	ret = xocl_cleanup_mem_nolock(drm_p);
-	if (drm_p->bo_usage_stat) {
-		vfree(drm_p->bo_usage_stat);
-		drm_p->bo_usage_stat = NULL;
-	}
 	mutex_unlock(&drm_p->mm_lock);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -965,6 +965,13 @@ int xocl_init_mem(struct xocl_drm *drm_p)
 		goto done;
 	}
 
+	drm_p->bo_usage_stat = vzalloc(XOCL_BO_USAGE_TOTAL * sizeof(struct drm_xocl_mm_stat));
+	if (!drm_p->bo_usage_stat) {
+		err = -ENOMEM;
+		XOCL_PUT_GROUP_TOPOLOGY(drm_p->xdev);
+		goto done;
+	}
+
 	drm_p->cma_bank_idx = -1;
 	for (i = 0; i < group_topo->m_count; i++) {
 		mem_data = &group_topo->m_mem_data[i];

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -64,6 +64,8 @@ struct xocl_drm {
 	struct drm_mm           *mm;
 	struct mutex            mm_lock;
 	struct drm_xocl_mm_stat **mm_usage_stat;
+	/* Array of bo usage stats */
+	struct drm_xocl_mm_stat *bo_usage_stat;
 
 	int			cma_bank_idx;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
For rugged XRT, header change to store bo usage based on type of bo.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Array of bo stats to be tracked in driver. Stats will be available in sysfs and with xbutil

#### Risks (if any) associated the changes in the commit
Following PRs will make use of this array to update usage info

#### Documentation impact (if any)
Will be documented ad part of xbutil usage info on completion