### PR TITLE
Disable ABI compile time check when ccache is enabled

### DIFF
--- a/src/CMake/ccache.cmake
+++ b/src/CMake/ccache.cmake
@@ -20,4 +20,8 @@ if (RDI_CCACHE)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${gccarwrap} --with-cache-rw")
   endif ()
 
+  # Disable abi compile time checks which renders ccache close to useless
+  message ("***** CCACHE: DISABLING ABI VERSION CHECK ******")
+  add_compile_options("-DDISABLE_ABI_CHECK")
+
 endif()

--- a/src/runtime_src/core/include/xrt/detail/abi.h
+++ b/src/runtime_src/core/include/xrt/detail/abi.h
@@ -4,7 +4,9 @@
 #ifndef XRT_DETAIL_ABI_H
 #define XRT_DETAIL_ABI_H
 
-#include "version.h"
+#ifndef DISABLE_ABI_CHECK
+# include "version.h"
+#endif
 
 #ifdef __cplusplus
 
@@ -20,9 +22,15 @@ namespace xrt { namespace detail {
 // The struct is used to guarantee schema compability between old
 // version of XRT and new version.
 struct abi {
+#ifndef DISABLE_ABI_CHECK
   const unsigned int major {XRT_MAJOR(XRT_VERSION_CODE)};
   const unsigned int minor {XRT_MINOR(XRT_VERSION_CODE)};
   const unsigned int code  {XRT_VERSION_CODE};
+#else
+  const unsigned int major {0};
+  const unsigned int minor {0};
+  const unsigned int code  {0};
+#endif
 };
 
 }} // detail, xrt


### PR DESCRIPTION
Ever since PR #5816, ccache has been close to useless because
abi.h includes CMake generated version.h which changes from
build to build.

This PR disables inclusion of version.h when ccache is enabled, it
assumes official pipeline master builds are not using ccache.
