### PR TITLE
Fix PS kernel instance name to match up with IP_LAYOUT

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -168,7 +168,8 @@ struct kds_scu_stat
     if (!errmsg.empty())
       throw xrt_core::query::sysfs_error(errmsg);
 
-    result_type cuStats;
+    result_type cu_stats;
+    std::map<std::string, unsigned int> name2idx; // kernel name -> instance index
     for (auto& line : stats) {
       boost::char_separator<char> sep(",");
       tokenizer tokens(line, sep);
@@ -180,16 +181,26 @@ struct kds_scu_stat
       const int radix = 16;
       tokenizer::iterator tok_it = tokens.begin();
       data.index  = std::stoi(std::string(*tok_it++));
-      data.name   = std::string(*tok_it++);
+      data.name   = std::string(*tok_it++);  // kernel name
       data.status = std::stoul(std::string(*tok_it++), nullptr, radix);
       data.usages = std::stoul(std::string(*tok_it++));
-      // TODO: Let's avoid this special handling for PS kernel name
-      data.name = data.name + ":scu_" + std::to_string(data.index & ~(scu_domain));
 
-      cuStats.push_back(data);
+      // TODO: Let's avoid this special handling for PS kernel name
+      // Modify instance name to match up with xclbin convention where
+      // instance names are numbered 0..n as in kernel_name:[0..n] for
+      // kernel_name.  It is important that the instance name matches
+      // up with the expectations of core XRT, which is based off of
+      // the instance names in the IP_LAYOUT.  By using a knm -> idx
+      // map the driver can assign internal indeces in any order it
+      // likes and sysfs node does not have to list all kernel
+      // instances of a kernel before instances of another kernel.
+      auto& kidx = name2idx[data.name];  // integral values are zero-initialized
+      data.name += ":scu_" + std::to_string(kidx++);
+
+      cu_stats.push_back(data);
     }
 
-    return cuStats;
+    return cu_stats;
   }
 };
 


### PR DESCRIPTION
#### Problem solved by the commit
Modify instance name to match up with xclbin convention where
instance names are numbered scu_0..n as in kernel_name:scu_[0..n]
for kernel_name. It is important that the instance name matches up with the
expectations of core XRT, which is based off of the instance names in
the IP_LAYOUT.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The instance names are created in user space XRT from the data
obtained from kernel driver, which doesn't use the IP_LAYOUT section
for PS kernels and in fact is not concerned with instance name beyond
the kernel name itself.

This PR uses a using a knm -> idx map, which allows the driver to
assign internal indeces in any order it likes and sysfs node does not
have to list all kernel instances in order of kernel names.

#### Risks (if any) associated the changes in the commit
There is no real risk with this PR as only new #6010 needs the
instance names matching with IP_LAYOUT, this PR just enables support
for multiple different PS kernels each with any number of instances.

