### PR TITLE
CR-1115544 Unable to --force output override for xbutil advanced...

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -97,7 +97,7 @@ OO_MemRead::execute(const SubCmdOptions& _options) const
     device = deviceCollection.front();
 
     //-- Output file
-    if (!m_outputFile.empty() && boost::filesystem::exists(m_outputFile)) 
+    if (!m_outputFile.empty() && boost::filesystem::exists(m_outputFile) && !XBU::getForce())
       throw xrt_core::error((boost::format("Output file already exists: '%s'") % m_outputFile).str());
 
   } catch (const xrt_core::error& e) {


### PR DESCRIPTION
Unable to --force output override for xbutil advanced --read-mem

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Using XRT 2.12.402

Not able to force output override running following:
touch tmp.txt
/opt/xilinx/xrt/bin/xbutil advanced --read-mem -o tmp.txt -d 0000:5e:00.1 --force 0x0 40

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a check for the force flag before outputting a file exists error

#### What has been tested and how, request additional testing if necessary
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov$ XRT/build/Debug/opt/xilinx/xrt/bin/xbutil advanced --read-mem -o tmp.txt -d 0000:02:00.1 --force 0x0 40
INFO: Reading 40 bytes from bank DDR4 address 0x0
INFO: Read size 0x28 B from addr 0x0. Total Read so far 0x28
INFO: Read data saved in file: tmp.txt; Num of bytes: 40 bytes
Memory read succeeded
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov$ XRT/build/Debug/opt/xilinx/xrt/bin/xbutil advanced --read-mem -o tmp.txt -d 0000:02:00.1 0x0 40
ERROR: Output file already exists: 'tmp.txt': Invalid argument

DESCRIPTION: Read from the given memory address

USAGE: xbutil advanced --read-mem [-h] -d arg -o arg address size
  <address>       - Base address to start from
  <size>          - Size (bytes) to read

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -o, --output       - Output file
  -h, --help         - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```