### PR TITLE
Fix regression from #5994

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -174,12 +174,14 @@ register_axlf(const axlf* top)
     for (const auto& d : cudata)
       m_cu2idx.emplace(std::move(d.name), cuidx_type{d.index});
 
-    // Soft kernels
-    auto scudata = xrt_core::device_query<xrt_core::query::kds_scu_stat>(this);
-    for (const auto& d : scudata)
-      m_cu2idx.emplace(std::move(d.name), cuidx_type{d.index});
-
-    // Validate softkernel instances against IP_LAYOUT, which 
+    // Soft kernels, not an error if query doesn't exist (edge)
+    try {
+      auto scudata = xrt_core::device_query<xrt_core::query::kds_scu_stat>(this);
+      for (const auto& d : scudata)
+        m_cu2idx.emplace(std::move(d.name), cuidx_type{d.index});
+    }
+    catch (const query::no_such_key&) {
+    }
   }
   catch (const query::no_such_key&) {
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -437,7 +437,7 @@ get_cu_indices(const ip_layout* ip_layout)
   auto cus = get_cus(ip_layout);
 
   // ps kernel cu index start at 0
-  static uint16_t ps_kernel_idx = 0;
+  uint16_t ps_kernel_idx = 0;
 
   std::map<std::string, cuidx_type> cu2idx;
   for (int32_t count=0; count <ip_layout->m_count; ++count) {
@@ -453,7 +453,7 @@ get_cu_indices(const ip_layout* ip_layout)
     else {
       auto itr = std::find(cus.begin(), cus.end(), ip_data.m_base_address);
       if (itr == cus.end())
-        throw std::runtime_error("Internal error: cu not found");
+        continue; // ignore kernels without base address (AP_CTRL_NONE)
 
       cuidx.domain = 0; // magic
       cuidx.domain_index = static_cast<uint16_t>(std::distance(cus.begin(), itr));

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -148,7 +148,12 @@ get_first_used_mem(const axlf* top);
 int32_t
 address_to_memidx(const mem_topology* mem, uint64_t address);
 
-// get_cu_indices() -
+// get_cu_indices() - mapping from cu name to its index type
+//
+// Compute index type for all controllable IPs in IP_LAYOUT Normally
+// indexing is determined by KDS in driver via kds_cu_stat query
+// request, but in emulation mode that query request is not not
+// implemented
 std::map<std::string, cuidx_type>
 get_cu_indices(const ip_layout* ip_layout);
 


### PR DESCRIPTION
#### Problem solved by the commit
Fix CU domain index computation to handle emulation and AP_CTRL_NONE
kernels.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Two bugs addressed in this PR.

(1) When xclbin is loaded, the cu indices are computed. PR #5994
incorrectly assumed that if kds_cu_stat query is supported then
kds_scu_stat is also, but that is not the case since there are no soft
kernels on edge (zocl).

(2) In emulation mode, the kds_cu_stat query request does not exist
and a new function added in #5994 is called to compute the name -> idx
mapping.  This function did not account for AP_CTRL_NONE kernels and
errored out.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problems were fixed by managing the cases described above.  Fixes
are one liners.

#### Risks (if any) associated the changes in the commit
No risks beyond original PR.

#### What has been tested and how, request additional testing if necessary
Normal HW tests which apparently do not include AP_CTRL_NONE kernel
tests.

