### PR TITLE
Use same function to get the CU base address in get_cus and get_cu_indeces functions

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -451,7 +451,7 @@ get_cu_indices(const ip_layout* ip_layout)
       cuidx.domain_index = ps_kernel_idx++;
     }
     else {
-      auto itr = std::find(cus.begin(), cus.end(), ip_data.m_base_address);
+      auto itr = std::find(cus.begin(), cus.end(), get_base_addr(ip_data));
       if (itr == cus.end())
         throw std::runtime_error("Internal error: cu not found");
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Creating Cu indices is throwing an exception for the CUs without Addresses. Fixed the issue. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in PR which is calculating soft kernel indices and domain
#### How problem was solved, alternative solutions (if any) and why they were rejected
Calling the same function to get the base address 
#### Risks (if any) associated the changes in the commit
No
#### What has been tested and how, request additional testing if necessary
Edge/Hw_emu
#### Documentation impact (if any)
No