### PR TITLE
XRT-923 enable hot reset for versal discovery

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -89,6 +89,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_CLOCK		= 0xb,
 	XGQ_CMD_OP_SENSOR		= 0xc,
 	XGQ_CMD_OP_LOAD_APUBIN		= 0xd,
+	XGQ_CMD_OP_MULTIPLE_BOOT	= 0xe,
 
 	/* User command type */
 	XGQ_CMD_OP_START_CUIDX	        = 0x100,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1382,8 +1382,7 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	(void) xocl_subdev_create_by_level(lro, XOCL_SUBDEV_LEVEL_BLD);
 	(void) xocl_subdev_create_vsec_devs(lro);
 
-	(void) xocl_pmc_enable_reset(lro);
-	(void) xocl_download_apu_firmware(lro);
+	(void) xocl_reinit_vmr(lro);
 
 	/*
 	 * For u30 whose reset relies on SC, and the cmc is running on ps, we

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -378,6 +378,8 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	else if (!force)
 		xclmgmt_connect_notify(lro, true);
 
+	(void) xocl_reinit_vmr(lro);
+
 done:
 	return err;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -239,8 +239,9 @@ static bool xgq_submitted_cmd_check(struct xocl_xgq *xgq)
 
 		/* Finding timed out cmds */
 		if (xgq_cmd->xgq_cmd_timeout_jiffies < jiffies) {
-			XGQ_ERR(xgq, "cmd id: %d timed out, hot reset is required!",
-				xgq_cmd->xgq_cmd_entry.hdr.cid);
+			XGQ_ERR(xgq, "cmd id: %d op: 0x%x timed out, hot reset is required!",
+				xgq_cmd->xgq_cmd_entry.hdr.cid,
+				xgq_cmd->xgq_cmd_entry.hdr.opcode);
 			found_timeout = true;
 			break;
 		}
@@ -616,6 +617,10 @@ static int xgq_check_firewall(struct platform_device *pdev)
 	int ret = 0;
 	int id = 0;
 
+	/* skip periodic firewall check when xgq service is halted */
+	if (xgq->xgq_halted)
+		return 0;
+
 	cmd = kmalloc(sizeof(*cmd), GFP_KERNEL);	
 	if (!cmd) {
 		XGQ_ERR(xgq, "kmalloc failed, retry");
@@ -964,6 +969,67 @@ static int xgq_download_apu_firmware(struct platform_device *pdev)
 	return ret;
 }
 
+static int vmr_enable_multiboot(struct platform_device *pdev)
+{
+	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_cmd *cmd = NULL;
+	struct xgq_cmd_sq_hdr *hdr = NULL;
+	int ret = 0;
+	int id = 0;
+
+	cmd = kmalloc(sizeof(*cmd), GFP_KERNEL);
+	if (!cmd) {
+		XGQ_ERR(xgq, "kmalloc failed, retry");
+		return -ENOMEM;
+	}
+
+	memset(cmd, 0, sizeof(*cmd));
+	cmd->xgq_cmd_cb = xgq_complete_cb;
+	cmd->xgq_cmd_arg = cmd;
+	cmd->xgq = xgq;
+
+	/* no payload for this cmd */
+	hdr = &(cmd->xgq_cmd_entry.hdr);
+	hdr->opcode = XGQ_CMD_OP_MULTIPLE_BOOT;
+	hdr->state = XGQ_SQ_CMD_NEW;
+	hdr->count = 0;
+	id = get_xgq_cid(xgq);
+	if (id < 0) {
+		XGQ_ERR(xgq, "alloc cid failed: %d", id);
+		goto done;
+	}
+	hdr->cid = id;
+
+	/* init condition veriable */
+	init_completion(&cmd->xgq_cmd_complete);
+
+	/* set timout actual jiffies */
+	cmd->xgq_cmd_timeout_jiffies = jiffies + XOCL_XGQ_CONFIG_TIME;
+
+	ret = submit_cmd(xgq, cmd);
+	if (ret) {
+		XGQ_ERR(xgq, "submit cmd failed, cid %d", id);
+		goto done;
+	}
+
+	/* wait for command completion */
+	wait_for_completion_interruptible(&cmd->xgq_cmd_complete);
+
+	ret = cmd->xgq_cmd_rcode;
+
+	if (ret)
+		XGQ_ERR(xgq, "Multiboot or reset might not work. ret %d",
+			cmd->xgq_cmd_rcode);
+
+done:
+	if (cmd) {
+		remove_xgq_cid(xgq, id);
+		kfree(cmd);
+	}
+
+	return ret;
+}
+
 static int xgq_collect_sensor_data(struct xocl_xgq *xgq)
 {
 	struct xocl_xgq_cmd *cmd = NULL;
@@ -1196,6 +1262,8 @@ static int xgq_remove(struct platform_device *pdev)
 	fini_worker(&xgq->xgq_complete_worker);
 	fini_worker(&xgq->xgq_health_worker);
 
+	kfree(xgq->sensor_data);
+
 	if (xgq->xgq_ring_base)
 		iounmap(xgq->xgq_ring_base);
 	if (xgq->xgq_sq_base)
@@ -1212,13 +1280,20 @@ static int xgq_remove(struct platform_device *pdev)
 	return 0;
 }
 
+/* Wait for xgq service is fully ready after a reset. */
 static inline bool xgq_device_is_ready(struct xocl_xgq *xgq)
 {
 	u32 rval = 0;
+	int i = 0, retry = 50;
 
-	rval = ioread32(xgq->xgq_ring_base + XOCL_XGQ_DEV_STAT_OFFSET);
+	for (i = 0; i < retry; i++) {
+		msleep(100);
+		rval = ioread32(xgq->xgq_ring_base + XOCL_XGQ_DEV_STAT_OFFSET);
+		if (rval)
+			return true;
+	}
 	
-	return rval != 0;
+	return false;
 }
 
 static int xgq_probe(struct platform_device *pdev)
@@ -1227,6 +1302,7 @@ static int xgq_probe(struct platform_device *pdev)
 	struct resource *res = NULL;
 	u64 flags = 0;
 	int ret = 0, i = 0;
+	void *hdl;
 
 	xgq = xocl_drvinst_alloc(&pdev->dev, sizeof (*xgq));
 	if (!xgq)
@@ -1339,10 +1415,15 @@ static int xgq_probe(struct platform_device *pdev)
 	}
 
 	XGQ_INFO(xgq, "Initialized xgq subdev, polling (%d)", xgq->xgq_polling);
+
 	return ret;
 
 attach_failed:
+	kfree(xgq->sensor_data);
 	platform_set_drvdata(pdev, NULL);
+	xocl_drvinst_release(xgq, &hdl);
+	xocl_drvinst_free(hdl);
+
 	return ret;
 }
 
@@ -1353,6 +1434,7 @@ static struct xocl_xgq_funcs xgq_ops = {
 	.xgq_freq_scaling_by_topo = xgq_freq_scaling_by_topo,
 	.xgq_get_data = xgq_get_data,
 	.xgq_download_apu_firmware = xgq_download_apu_firmware,
+	.vmr_enable_multiboot = vmr_enable_multiboot,
 };
 
 static const struct file_operations xgq_fops = {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2132,6 +2132,7 @@ struct xocl_xgq_funcs {
 	uint64_t (*xgq_get_data)(struct platform_device *pdev,
 		enum data_kind kind);
 	int (*xgq_download_apu_firmware)(struct platform_device *pdev);
+	int (*vmr_enable_multiboot)(struct platform_device *pdev);
 };
 #define	XGQ_DEV(xdev)						\
 	(SUBDEV(xdev, XOCL_SUBDEV_XGQ) ? 			\
@@ -2159,6 +2160,9 @@ struct xocl_xgq_funcs {
 #define	xocl_download_apu_firmware(xdev) 			\
 	(XGQ_CB(xdev, xgq_download_apu_firmware) ?		\
 	XGQ_OPS(xdev)->xgq_download_apu_firmware(XGQ_DEV(xdev)) : -ENODEV)
+#define	xocl_vmr_enable_multiboot(xdev) 				\
+	(XGQ_CB(xdev, vmr_enable_multiboot) ?			\
+	XGQ_OPS(xdev)->vmr_enable_multiboot(XGQ_DEV(xdev)) : -ENODEV)
 
 /* subdev mbx messages */
 #define XOCL_MSG_SUBDEV_VER	1
@@ -2335,6 +2339,8 @@ int xocl_xrt_version_check(xdev_handle_t xdev_hdl,
 	struct axlf *bin_obj, bool major_only);
 int xocl_alloc_dev_minor(xdev_handle_t xdev_hdl);
 void xocl_free_dev_minor(xdev_handle_t xdev_hdl);
+
+void xocl_reinit_vmr(xdev_handle_t xdev_hdl);
 
 struct resource *xocl_get_iores_byname(struct platform_device *pdev,
 				       char *name);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1918,6 +1918,25 @@ void xocl_free_dev_minor(xdev_handle_t xdev_hdl)
 	}
 }
 
+/*
+ * This function will reinitialize the versal platform after a cold or warm
+ * reboot. First, we should re-enable the reset registers, either via host or
+ * via vmr firmware. Second, we should try to load apu firmware via vmr.
+ * Note: we ignore errors after all subdev has been probed after extended_probe.
+ *       if any of this procedure fails due to fatal error, a hot reset warning
+ *       will be reported.
+ */
+void xocl_reinit_vmr(xdev_handle_t xdev)
+{
+	int rc = 0;
+
+	rc = xocl_pmc_enable_reset(xdev);
+	if (rc == -ENODEV)
+		xocl_vmr_enable_multiboot(xdev);
+
+	(void) xocl_download_apu_firmware(xdev);
+}
+
 int xocl_ioaddr_to_baroff(xdev_handle_t xdev_hdl, resource_size_t io_addr,
 		int *bar_idx, resource_size_t *bar_off)
 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR is designed to enable hot reset via VMR on R5.
The API is handled by XGQ and also support future multi-boot feature (TO BE IMPLEMENTED).

The design is described in the Documentation below. A simple example would be after each reset (or system boot, warm or cold), XRT driver to set/clear some registers to notify versal system the second bus reset can be performed, and multi-boot flag is also set correctly.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested over whole night by looping "hot reset, wait 30s, xbutil validate".

#### Documentation impact (if any)
https://confluence.xilinx.com/display/XIP/Versal+PCIe-Reset+Sequence
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261