### PR TITLE
Fix CR-1114444 - Failed to create CU when loading xclbin

### DIFF
--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -378,11 +378,13 @@ struct argument_info {
  * struct kernel_info - Kernel information
  *
  * @name:	kernel name
+ * @range:	kernel range
  * @anums:	number of argument
  * @args:	argument array
  */
 struct kernel_info {
 	char                     name[64];
+	uint32_t		 range;
 	int		         anums;
 	struct argument_info	 args[];
 };

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -557,6 +557,7 @@ xclLoadAxlf(const axlf *buffer)
           return -EINVAL;
       std::strncpy(krnl->name, kernel.name.c_str(), sizeof(krnl->name)-1);
       krnl->name[sizeof(krnl->name)-1] = '\0';
+      krnl->range = kernel.range;
       krnl->anums = kernel.args.size();
 
       int ai = 0;


### PR DESCRIPTION
> when parsing xclbin on edge platforms kernel range is not recorded and we are hardcoding range as 0x10000 in zocl driver
> Made changes to read kernel range while reading xclbin and removed hardcoding in zocl
