### PR TITLE
disable 'xbutil reset' if the reset mailbox opcode is disabled

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -23,6 +23,7 @@
 #endif
 #include "version.h"
 #include "common.h"
+#include "mailbox_proto.h"
 
 extern int kds_mode;
 
@@ -639,6 +640,15 @@ int xocl_hot_reset_ioctl(struct drm_device *dev, void *data,
 {
 	struct xocl_drm *drm_p = dev->dev_private;
 	struct xocl_dev *xdev = drm_p->xdev;
+	uint64_t chan_disable = 0;
+
+	/*
+	 * if the reset mailbox opcode is disabled, we don't allow
+	 * user run 'xbutil reset'
+	 */
+	xocl_mailbox_get(xdev, CHAN_DISABLE, &chan_disable);
+	if (chan_disable & (1 << XCL_MAILBOX_REQ_HOT_RESET))
+		return -EOPNOTSUPP;
 
 	xocl_drvinst_set_offline(xdev->core.drm, true);
 	xocl_queue_work(xdev, XOCL_WORK_RESET, XOCL_RESET_DELAY);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
In some cases, like aws vt1, the reset mailbox opcode is disabled, so that xclmgmt will not do reset.
but at userland of xocl side, something still happens, like, killing apps.
This will cause confusion to the user
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
in vt1 instance, user run 'xbutil reset' in guest vm, the xrm and ffmpeg get killed, but card doesn't get reset
#### How problem was solved, alternative solutions (if any) and why they were rejected
check the mailbox disable config info in 'xbutil reset', and return if the reset opcode is disabled
#### Risks (if any) associated the changes in the commit
very low
#### What has been tested and how, request additional testing if necessary
in above case, 'xbutil reset' return immediately 
#### Documentation impact (if any)
na