### PR TITLE
CR-1116528 Enable configs in build_edge.sh to customize linux kernel build for versal

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -70,7 +70,7 @@ install_recipes()
     eval "$SAVED_OPTIONS_LOCAL"
 }
 
-config_project()
+config_versal_project()
 {
     # remove following unused packages from rootfs sothat its size would fit in QSPI
 
@@ -264,8 +264,10 @@ fi
 echo " * Performing PetaLinux Build (from: ${PWD})"
 #Run a full build if -full option is provided
 if [[ $full == 1 ]]; then
-  # configure the project with appropriate options
-  config_project
+  if [[ $AARCH = $versal_dir ]]; then
+    # configure the project with appropriate options
+    config_versal_project
+  fi
 
   echo "[CMD]: petalinux-config -c kernel --silentconfig"
   $PETA_BIN/petalinux-config -c kernel --silentconfig

--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -101,6 +101,10 @@ config_project()
     echo "CONFIG_XILINX_OF_BOARD_DTB_ADDR=0x40000" > project-spec/meta-user/recipes-bsp/u-boot/files/$UBOOT_USER_SCRIPT
     echo "SRC_URI += \"file://${UBOOT_USER_SCRIPT}\"" >> project-spec/meta-user/recipes-bsp/u-boot/u-boot-xlnx_%.bbappend
 
+    # Configure kernel
+    echo "CONFIG_SUSPEND=n" >> project-spec/meta-user/recipes-kernel/linux/linux-xlnx/bsp.cfg
+    echo "CONFIG_PM=n" >> project-spec/meta-user/recipes-kernel/linux/linux-xlnx/bsp.cfg
+    echo "CONFIG_SPI=n" >> project-spec/meta-user/recipes-kernel/linux/linux-xlnx/bsp.cfg
 }
 
 # --- End internal functions

--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,1 @@
-PETALINUX="/proj/petalinux/2021.2/petalinux-v2021.2_daily_latest/tool/petalinux-v2021.2-final"
+PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_daily_latest/tool/petalinux-v2022.1-final"


### PR DESCRIPTION
> added configs in bsp.cfg to disable CONFIG_SUSPEND, CONFIG_PM, CONFIG_SPI
> when these configs are enabled kernel build will pass only with petalinux >= 2022.1 version 
