### PR TITLE
CR-1112292  Not giving clear message when host mem is not a power of 2

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -811,13 +811,6 @@ XBUtilities::string_to_bytes(std::string str)
   return size;
 }
 
-bool 
-XBUtilities::
-isPowerOf2(const uint64_t x)
-{
-  return !(x==0 || (x & (x - 1)));
-}
-
 std::string
 XBUtilities::
 get_xrt_pretty_version()

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -811,6 +811,13 @@ XBUtilities::string_to_bytes(std::string str)
   return size;
 }
 
+bool 
+XBUtilities::
+isPowerOf2(const uint64_t x)
+{
+  return !(x & (x - 1));
+}
+
 std::string
 XBUtilities::
 get_xrt_pretty_version()

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -815,7 +815,7 @@ bool
 XBUtilities::
 isPowerOf2(const uint64_t x)
 {
-  return !(x & (x - 1));
+  return !(x==0 || (x & (x - 1)));
 }
 
 std::string

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -152,8 +152,16 @@ namespace XBUtilities {
   uint64_t 
   string_to_bytes(std::string str);
 
-  bool
-  isPowerOf2(const uint64_t x);
+  inline bool 
+  is_power_of_2(const uint64_t x)
+  {
+    /*
+    * Verify that the given value is greater than zero
+    * and that only one bit is set in the given value
+    * if only one bit is set this implies the given value is a power of 2
+    */
+    return (x != 0) && ((x & (x - 1)) == 0);
+  }
 
  /*
   * xclbin locking

--- a/src/runtime_src/core/tools/common/XBUtilities.h
+++ b/src/runtime_src/core/tools/common/XBUtilities.h
@@ -152,6 +152,9 @@ namespace XBUtilities {
   uint64_t 
   string_to_bytes(std::string str);
 
+  bool
+  isPowerOf2(const uint64_t x);
+
  /*
   * xclbin locking
   */

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -118,7 +118,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
 
     // Exit if ENABLE action is specified and 
     // size is not 0 or size is not a power of 2
-    if(enable && ((0 == size) || !XBUtilities::isPowerOf2(size)))
+    if(enable && ((size == 0) || !XBUtilities::is_power_of_2(size)))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 
     // Collect all of the devices of interest

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -117,8 +117,8 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
     enable =  boost::iequals(m_action, "ENABLE");
 
     // Exit if ENABLE action is specified and 
-    // size is zero or size is not a power of 2
-    if(enable && (size == 0 || !XBUtilities::isPowerOf2(size)))
+    // size is not a power of 2
+    if(enable && !XBUtilities::isPowerOf2(size))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 
     // Collect all of the devices of interest

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -118,7 +118,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
 
     // Exit if ENABLE action is specified but size is not 
     // or is a power of 2
-    if(enable && (size == 0 || (size & (size - 1))))
+    if(enable && (size == 0 || !XBUtilities::isPowerOf2(size)))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 
     // Collect all of the devices of interest

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -116,8 +116,8 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
     }
     enable =  boost::iequals(m_action, "ENABLE");
 
-    // Exit if ENABLE action is specified but size is not 
-    // or is a power of 2
+    // Exit if ENABLE action is specified and 
+    // size is zero or size is not a power of 2
     if(enable && (size == 0 || !XBUtilities::isPowerOf2(size)))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -118,7 +118,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
 
     // Exit if ENABLE action is specified and 
     // size is not a power of 2
-    if(enable && !XBUtilities::isPowerOf2(size))
+    if(enable && ((0 == size) || !XBUtilities::isPowerOf2(size)))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 
     // Collect all of the devices of interest

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -117,7 +117,7 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
     enable =  boost::iequals(m_action, "ENABLE");
 
     // Exit if ENABLE action is specified and 
-    // size is not a power of 2
+    // size is not 0 or size is not a power of 2
     if(enable && ((0 == size) || !XBUtilities::isPowerOf2(size)))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -116,8 +116,9 @@ OO_HostMem::execute(const SubCmdOptions& _options) const
     }
     enable =  boost::iequals(m_action, "ENABLE");
 
-    // Exit if ENABLE action is specified but size is not
-    if(enable && size == 0)
+    // Exit if ENABLE action is specified but size is not 
+    // or is a power of 2
+    if(enable && (size == 0 || (size & (size - 1))))
       throw xrt_core::error(std::errc::invalid_argument, "Please specify a non-zero memory size between 4M and 1G as a power of 2.");
 
     // Collect all of the devices of interest


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Neither the malformed command, nor the unsupported memory size convey the power of 2 restriction

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
```
[dpeascoe@xcowtsalveo1 /scratch]$ sudo xbutil configure --host-mem enable -d 82:00.1 -s 6M
ERROR: Not enough host mem. Please check grub settings.: Cannot allocate memory
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add check to verify input size is a power of two

#### What has been tested and how, request additional testing if necessary
```
root@xsjpranjal01:~# xbutil configure --host-mem enable -d 02:00.1 6M
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Controls host-mem functionality

USAGE: xbutil configure --host-mem [-h] [-d arg] [-s arg] action
  <action>        - Action to perform: ENABLE or DISABLE

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -s, --size         - Size of host memory (bytes) to be enabled (e.g. 256M, 1G)
  -h, --help         - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
root@xsjpranjal01:~# xbutil configure --host-mem enable -d 02:00.1 -s 6M

ERROR: Please specify a non-zero memory size between 4M and 1G as a power of 2.: Invalid argument
```
