### PR TITLE
xclbinutil - GROUP_TOPOLOGY and GROUP_CONNECTIVITY sections improvements

### DIFF
--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -315,7 +315,7 @@ XclBinUtilities::addKernel(const boost::property_tree::ptree& ptKernel,
 
     // Create the new PS kernel instance and add it to the vector
     boost::property_tree::ptree ptIPEntry;
-    ptIPEntry.put("m_type", "IP_KERNEL");
+    ptIPEntry.put("m_type", "IP_PS_KERNEL");
     ptIPEntry.put("m_base_address", "not_used");
     ptIPEntry.put("m_name", ipLayoutName);
     ipLayout.push_back(ptIPEntry);

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/FixedKernel.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/FixedKernel.py
@@ -63,6 +63,12 @@ def main():
   outputConnectivity = "updated_connectivity.json"
   expectedConnectivity = os.path.join(args.resource_dir, "connectivity_expected.json")
 
+  outputGroupTopology = "updated_group_topology.json"
+  expectedGroupTopology = os.path.join(args.resource_dir, "group_topology_expected.json")
+
+  outputGroupConnectivity = "updated_group_connectivity.json"
+  expectedGroupConnectivity = os.path.join(args.resource_dir, "group_connectivity_expected.json")
+
   outputXCLBIN = "pskernel_output.xclbin"
 
   cmd = [xclbinutil, "--input", workingXCLBIN,
@@ -70,6 +76,8 @@ def main():
                      "--dump-section", "EMBEDDED_METADATA:RAW:" + outputEmbeddedMetadata,
                      "--dump-section", "IP_LAYOUT:JSON:" + outputIpLayout,
                      "--dump-section", "CONNECTIVITY:JSON:" + outputConnectivity,
+                     "--dump-section", "GROUP_TOPOLOGY:JSON:" + outputGroupTopology,
+                     "--dump-section", "GROUP_CONNECTIVITY:JSON:" + outputGroupConnectivity,
                      "--output", outputXCLBIN, 
                      "--force"]
   execCmd(step, cmd)
@@ -78,6 +86,8 @@ def main():
   textFileCompare(outputEmbeddedMetadata, expectedEmbeddedMetadata)
   jsonFileCompare(outputIpLayout, expectedIpLayout)
   jsonFileCompare(outputConnectivity, expectedConnectivity)
+  jsonFileCompare(outputGroupTopology, expectedGroupTopology)
+  jsonFileCompare(outputGroupConnectivity, expectedGroupConnectivity)
   # ---------------------------------------------------------------------------
 
 

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/group_connectivity_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/group_connectivity_expected.json
@@ -1,0 +1,77 @@
+{
+    "group_connectivity": {
+        "m_count": "14",
+        "m_connection": [
+            {
+                "arg_index": "0",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "1",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "2",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "0",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "1",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "2",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "3",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "0",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "1",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "2",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "0",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "1",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "2",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "3",
+                "m_ip_layout_index": "1",
+                "mem_data_index": "0"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/group_topology_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/group_topology_expected.json
@@ -1,0 +1,21 @@
+{
+    "group_topology": {
+        "m_count": "2",
+        "m_mem_data": [
+            {
+                "m_type": "MEM_DRAM",
+                "m_used": "1",
+                "m_sizeKB": "0x10000",
+                "m_tag": "HOST",
+                "m_base_address": "0x4000000"
+            },
+            {
+                "m_type": "MEM_DRAM",
+                "m_used": "0",
+                "m_sizeKB": "0x200",
+                "m_tag": "SRAM",
+                "m_base_address": "0x0"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/ip_layout_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/ip_layout_expected.json
@@ -11,10 +11,8 @@
                 "m_name": "vadd:vadd_1"
             },
             {
-                "m_type": "IP_KERNEL",
-                "m_int_enable": "0",
-                "m_interrupt_id": "0",
-                "m_ip_control": "AP_CTRL_HS",
+                "m_type": "IP_PS_KERNEL",
+                "properties": "0x0",
                 "m_base_address": "not_used",
                 "m_name": "DPU:IPUV1CNN"
             }


### PR DESCRIPTION
After adding a fixed kernel, the GROUP_TOPOLOGY and GROUP_CONNECTIVITY sections were not being automatically generated.  This PR address this issue.

Work Done
---------
+ Updated the code flow to automatically re-create the GROUP_TOPOLOGY and GROUP_CONNECTIVITY sections if fixed kernel is added.
+ Create the hidden helper option '--reset-bank-grouping' that will cause the GROUP_TOPOLOGY and GROUP_CONNECTIVITY sections to be regenerated.
+ Did some code refactoring in the XclBinUtilMain.cxx file
+ Changed the fixed kernel IP_LAYOUT m_type to be IP_PS_KERNEL
+ Updated the unit-tests 