### PR TITLE
bo stats in sysfs

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -87,6 +87,20 @@ void xocl_describe(const struct drm_xocl_bo *xobj)
 		xobj->sgt ? xobj->sgt->orig_nents : 0, xobj->flags);
 }
 
+void xocl_bo_get_usage_stat(struct xocl_drm *drm_p, u32 bo_idx,
+	struct drm_xocl_mm_stat *pstat)
+{
+	if (!drm_p->bo_usage_stat)
+		return;
+	if (bo_idx < 0)
+		return;
+	if (bo_idx >= XOCL_BO_USAGE_TOTAL)
+		return;
+
+	pstat->memory_usage = drm_p->bo_usage_stat[bo_idx].memory_usage;
+	pstat->bo_count = drm_p->bo_usage_stat[bo_idx].bo_count;
+}
+
 static int xocl_bo_update_usage_stat(struct xocl_drm *drm_p, unsigned bo_flag,
 	u64 size, int count)
 {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.h
@@ -155,6 +155,8 @@ static inline bool xocl_bo_sync_able(unsigned bo_flags)
 		|| (bo_flags & XOCL_CMA_MEM) || (bo_flags & XOCL_P2P_MEM);
 }
 
+void xocl_bo_get_usage_stat(struct xocl_drm *drm_p, u32 bo_idx,
+	struct drm_xocl_mm_stat *pstat);
 int xocl_create_bo_ioctl(struct drm_device *dev, void *data,
 	struct drm_file *filp);
 int xocl_userptr_bo_ioctl(struct drm_device *dev, void *data,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -135,6 +135,8 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 	const char *raw_fmt = "%llu %d %llu\n";
 	struct mem_topology *topo = NULL;
 	struct drm_xocl_mm_stat stat;
+	const char *bo_txt_fmt = "[%s] %lluKB %dBOs\n";
+	const char *bo_types[XOCL_BO_USAGE_TOTAL];
 
 	mutex_lock(&xdev->dev_lock);
 
@@ -168,6 +170,39 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 				topo->m_mem_data[i].m_tag,
 				topo->m_mem_data[i].m_base_address,
 				topo->m_mem_data[i].m_size / 1024,
+				stat.memory_usage / 1024,
+				stat.bo_count);
+		}
+		buf += count;
+		size += count;
+	}
+	/* -- Separator for bo stats -- */
+	if (raw)
+		count = sprintf(buf, raw_fmt, -EINVAL, -EINVAL, -EINVAL);
+	else
+		count = sprintf(buf, txt_fmt,
+			"== BO Stats Below ==",
+			"NA", 0, 0, 0, 0);
+
+	/* -- Append bo stats -- */
+	buf += count;
+	size += count;
+	bo_types[XOCL_BO_USAGE_NORMAL] = "Regular";
+	bo_types[XOCL_BO_USAGE_USERPTR] = "UserPointer";
+	bo_types[XOCL_BO_USAGE_P2P] = "P2P";
+	bo_types[XOCL_BO_USAGE_DEV_ONLY] = "DeviceOnly";
+	bo_types[XOCL_BO_USAGE_IMPORT] = "Imported";
+	bo_types[XOCL_BO_USAGE_EXECBUF] = "ExecBuf";
+	bo_types[XOCL_BO_USAGE_CMA] = "CMA";
+	for (i = 0; i < XOCL_BO_USAGE_TOTAL; i++) {
+		xocl_bo_get_usage_stat(XOCL_DRM(xdev), i, &stat);
+		if (raw) {
+			count = sprintf(buf, raw_fmt,
+				stat.memory_usage,
+				stat.bo_count, 0);
+		} else {
+			count = sprintf(buf, bo_txt_fmt,
+				&bo_types[i],
 				stat.memory_usage / 1024,
 				stat.bo_count);
 		}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_sysfs.c
@@ -202,7 +202,7 @@ static ssize_t xocl_mm_stat(struct xocl_dev *xdev, char *buf, bool raw)
 				stat.bo_count, 0);
 		} else {
 			count = sprintf(buf, bo_txt_fmt,
-				&bo_types[i],
+				bo_types[i],
 				stat.memory_usage / 1024,
 				stat.bo_count);
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Make bo stats available in sysfs node

#### Risks (if any) associated the changes in the commit
xbutil will use this sysfs node to provide info to users

#### Documentation impact (if any)
To be done as part of xbutil guide/document