### PR TITLE
CR-1112943: Fixing issue in profiling when both memory AIMs and trace-enabled AIMs are included

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -427,7 +427,7 @@ class aie_cfg_tile
 
     inline uint64_t getNumAIM(XclbinInfo* xclbin) {
       for (auto bin : loadedXclbins) {
-        if (bin == xclbin) return bin->aimMap.size() ;
+        if (bin == xclbin) return bin->aimList.size() ;
       }
       return 0 ;
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
As device trace is processed, we keep track of the last transaction on each AIM we see so we can approximate events that might have been dropped in the hardware.  We allocate vectors to store this last transaction data based on the number of AIMs that exist in the loaded xclbin.  The function that was being called, however, was returning the number of AIMs that had trace enabled, and not the total number of AIMs, so xclbins created with a mix of AIMs configured for trace and only counters would sometimes lead to an out of bounds access to this vector, causing a seg fault in some other part of memory when it was attempted to be reclaimed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This pull request changes the function that returns the number of AIMs in an xclbin to the total number instead of just the number with trace, as expected.