### PR TITLE
CR-1117201 Backport SUSE SLES 15 SP2 fixes

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/Makefile
@@ -104,7 +104,10 @@ ifeq ($(SYMBOL),1)
 	ccflags-y += -g
 endif
 
-ccflags-$(CONFIG_FPGA) += -DENABLE_FPGA_MGR_SUPPORT
+# We can only rely on CONFIG_FPGA to check whether system has fpga-mgr module support or not.
+# But it is not true in some Kernels where this config is enabled but fpga-mgr module is not available
+# which is causing xclmgmt driver loading to fail. So commenting this as fpga-mgr is not used anywhere.
+# ccflags-$(CONFIG_FPGA) += -DENABLE_FPGA_MGR_SUPPORT
 ccflags-y += $(ccflags-m)
 
 all:

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_user.c
@@ -891,11 +891,17 @@ ert_pre_process(struct xocl_ert_user *ert_user, struct xrt_ert_command *ecmd)
 	case ERT_SK_START:
 		BUG_ON(ert_user->ctrl_busy);
 #if KERNEL_VERSION(5, 4, 0) > LINUX_VERSION_CODE
-	#if defined(RHEL_RELEASE_CODE)
+	#if defined(CONFIG_SUSE_KERNEL)
+		#if SLE_VERSION(SUSE_VERSION, SUSE_PATCHLEVEL, SUSE_AUXRELEASE) >= SLE_VERSION(15, 2, 0)
+			__attribute__ ((__fallthrough__));
+		#else
+			__attribute__ ((fallthrough));
+		#endif
+	#elif defined(RHEL_RELEASE_CODE)
 		#if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 4)
 			__attribute__ ((__fallthrough__));
 		#else
-		__attribute__ ((fallthrough));
+			__attribute__ ((fallthrough));
 		#endif
 	#else
 		__attribute__ ((fallthrough));


### PR DESCRIPTION
> Backported changes from master branch to 2021.2
> Fix driver compilation issues on SUSE SLES 15 SP2
> Remove fpga-mgr dependency from xclmgmt driver