### PR TITLE
CR-1113703 and CR-1113150

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -337,6 +337,7 @@ public:
     , mem_topo(mem_topo_raw.empty() ? nullptr : reinterpret_cast<const mem_topology*>(mem_topo_raw.data()))
     , grp_topo(grp_topo_raw.empty() ? nullptr : reinterpret_cast<const mem_topology*>(grp_topo_raw.data()))
     , mem_stat(xrt_core::device_query<xq::memstat_raw>(device))
+    , mem_temp(0)
   {
     try {
       mem_temp_raw = xrt_core::device_query<xq::temp_by_mem_topology>(dev);

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -169,8 +169,8 @@ add_clock_info(const xrt_core::device* device, ptree_type& pt)
     auto clock_topology = reinterpret_cast<const clock_freq_topology*>(raw.data());
     for(int i = 0; i < clock_topology->m_count; i++) {
       ptree_type pt_clock;
-      pt_clock.add("id", clock_topology->m_clock_freq[i].m_name);
-      pt_clock.add("description", xq::clock_freq_topology_raw::parse(clock_topology->m_clock_freq[i].m_name));
+      pt_clock.add("id", clock_topology->m_clock_freq[i].m_type);
+      pt_clock.add("description", xq::clock_freq_topology_raw::parse(clock_topology->m_clock_freq[i].m_type));
       pt_clock.add("freq_mhz", clock_topology->m_clock_freq[i].m_freq_Mhz);
       pt_clock_array.push_back(std::make_pair("", pt_clock));
     }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -17,6 +17,7 @@
 #include "info_platform.h"
 #include "query_requests.h"
 #include "utils.h"
+#include "xclbin.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -155,6 +156,23 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
   }
 }
 
+static std::string
+enum_to_str(CLOCK_TYPE type)
+{
+  switch(type) {
+    case CT_UNUSED:
+      return "Unused";
+    case CT_DATA:
+      return "Data";
+    case CT_KERNEL:
+      return "Kernel";
+    case CT_SYSTEM:
+      return "System";
+    default:
+      throw xrt_core::internal_error("enum value does not exists");
+    }
+}
+
 void
 add_clock_info(const xrt_core::device* device, ptree_type& pt)
 {
@@ -169,8 +187,8 @@ add_clock_info(const xrt_core::device* device, ptree_type& pt)
     auto clock_topology = reinterpret_cast<const clock_freq_topology*>(raw.data());
     for(int i = 0; i < clock_topology->m_count; i++) {
       ptree_type pt_clock;
-      pt_clock.add("id", clock_topology->m_clock_freq[i].m_type);
-      pt_clock.add("description", xq::clock_freq_topology_raw::parse(clock_topology->m_clock_freq[i].m_type));
+      pt_clock.add("id", clock_topology->m_clock_freq[i].m_name);
+      pt_clock.add("description", enum_to_str(static_cast<CLOCK_TYPE>(clock_topology->m_clock_freq[i].m_type)));
       pt_clock.add("freq_mhz", clock_topology->m_clock_freq[i].m_freq_Mhz);
       pt_clock_array.push_back(std::make_pair("", pt_clock));
     }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -138,7 +138,7 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
     sc.add("expected_version", xrt_core::device_query<xq::expected_sc_version>(device));
     ptree_type cmc;
     std::stringstream version;
-    
+
     try {
        version << "0x" << std::hex << std::stoi(xrt_core::device_query<xq::xmc_version>(device));
     }
@@ -217,7 +217,7 @@ add_mac_info(const xrt_core::device* device, ptree_type& pt)
     pt.put_child("macs", pt_mac);
 
   }
-  catch (const xq::no_such_key&) {
+  catch (const xq::exception&) {
     // Ignoring if not available: Edge Case
   }
 }
@@ -268,7 +268,7 @@ pcie_info(const xrt_core::device * device)
     try {
       ptree.add("dma_thread_count", xrt_core::device_query<xq::dma_threads_raw>(device).size());
     }
-    catch(const xq::no_such_key&) {
+    catch(const xq::exception&) {
     }
 
     ptree.add("cpu_affinity", xrt_core::device_query<xq::cpu_affinity>(device));

--- a/src/runtime_src/core/common/info_platform.h
+++ b/src/runtime_src/core/common/info_platform.h
@@ -19,6 +19,7 @@
 
 // Local - Include Files
 #include "device.h"
+#include "xclbin.h"
 
 namespace xrt_core { namespace platform {
 

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -110,17 +110,11 @@ parse(const xrt_core::query::oem_id::result_type& value)
 
 std::string
 xrt_core::query::clock_freq_topology_raw::
-parse(const std::string& clock)
+parse(uint8_t clock)
 {
-  static const std::map<std::string, std::string> clock_map =
-  {
-   {"DATA_CLK", "Data"},
-   {"KERNEL_CLK", "Kernel"},
-   {"SYSTEM_CLK", "System"},
-  };
-
-  auto clock_str = clock_map.find(clock);
-  return clock_str != clock_map.end() ? clock_str->second : "N/A";
+    // from CLOCK_TYPE enum in xclbin.h
+    std::vector<std::string> clock_names = { "Unused", "Data", "Kernel", "System"};
+    return clock < clock_names.size() ? clock_names[clock] : "N/A";
 }
 
 std::pair<uint64_t, uint64_t>

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -108,15 +108,6 @@ parse(const xrt_core::query::oem_id::result_type& value)
   return "N/A";
 }
 
-std::string
-xrt_core::query::clock_freq_topology_raw::
-parse(uint8_t clock)
-{
-    // from CLOCK_TYPE enum in xclbin.h
-    std::vector<std::string> clock_names = { "Unused", "Data", "Kernel", "System"};
-    return clock < clock_names.size() ? clock_names[clock] : "N/A";
-}
-
 std::pair<uint64_t, uint64_t>
 xrt_core::query::xocl_errors::
 to_value(const std::vector<char>& buf, xrtErrorClass ecl)

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -872,7 +872,7 @@ struct clock_freq_topology_raw : request
   // parse a clock_freq_topo::clock_freq::m_name (null terminated string)
   XRT_CORE_COMMON_EXPORT
   static std::string
-  parse(const std::string& value);
+  parse(uint8_t value);
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -869,11 +869,6 @@ struct clock_freq_topology_raw : request
   using result_type = std::vector<char>;
   static const key_type key = key_type::clock_freq_topology_raw;
 
-  // parse a clock_freq_topo::clock_freq::m_name (null terminated string)
-  XRT_CORE_COMMON_EXPORT
-  static std::string
-  parse(uint8_t value);
-
   virtual boost::any
   get(const device*) const = 0;
 };

--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -194,17 +194,23 @@ read_electrical(const xrt_core::device * device)
     populate_sensor<xq::v0v9_int_vcc_vcu_millivolts, xq::noop>(device, "0v9_vccint_vcu", "0.9 Volts Vcc Vcu")));
   root.add_child("power_rails", sensor_array);
 
+  std::string max_power_watts;
   std::string power_watts;
+  std::string warning;
   try {
     auto power_level = xrt_core::device_query<xq::max_power_level>(device);
-    power_watts = lvl_to_power_watts(power_level);
+    max_power_watts = lvl_to_power_watts(power_level);
+    power_watts = xrt_core::utils::format_base10_shiftdown6(xrt_core::device_query<xq::power_microwatts>(device));
+    warning = xq::power_warning::to_string(xrt_core::device_query<xq::power_warning>(device));
   }
-  catch (...) {
+  catch (const xq::exception&) {
+    max_power_watts = "N/A";
     power_watts = "N/A";
+    warning = "N/A";
   }
-  root.put("power_consumption_max_watts", power_watts);
-  root.put("power_consumption_watts", xrt_core::utils::format_base10_shiftdown6(xrt_core::device_query<xq::power_microwatts>(device)));
-  root.put("power_consumption_warning", xq::power_warning::to_string(xrt_core::device_query<xq::power_warning>(device)));
+  root.put("power_consumption_max_watts", max_power_watts);
+  root.put("power_consumption_watts", power_watts);
+  root.put("power_consumption_warning", warning);
   return root;
 }
 

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -77,7 +77,8 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
       _output << std::endl << "Clocks" << std::endl;
       for(auto& kc : clocks) {
         const boost::property_tree::ptree& pt_clock = kc.second;
-        _output << boost::format("  %-23s: %s MHz\n") % pt_clock.get<std::string>("description") % pt_clock.get<std::string>("freq_mhz");
+        std::string clock_name_type = pt_clock.get<std::string>("id") + " (" + pt_clock.get<std::string>("description") + ")"; 
+        _output << boost::format("  %-23s: %3s MHz\n") % clock_name_type % pt_clock.get<std::string>("freq_mhz");
       }
     }
 

--- a/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportQspiStatus.cpp
@@ -34,10 +34,13 @@ void
 ReportQspiStatus::getPropertyTree20202( const xrt_core::device * device, 
                                            boost::property_tree::ptree &pt) const
 {
-  auto qspi_stat = xrt_core::device_query<qr::xmc_qspi_status>(device);
   boost::property_tree::ptree ptree;
-  ptree.put("primary", std::get<0>(qspi_stat));
-  ptree.put("recovery", std::get<1>(qspi_stat));
+  try {
+    auto qspi_stat = xrt_core::device_query<qr::xmc_qspi_status>(device);
+    ptree.put("primary", std::get<0>(qspi_stat));
+    ptree.put("recovery", std::get<1>(qspi_stat));
+  } 
+  catch (const qr::exception&) {}
   
   // There can only be 1 root node
   pt.add_child("qspi_wp_status", ptree);
@@ -52,8 +55,7 @@ ReportQspiStatus::writeReport( const xrt_core::device* /*_pDevice*/,
   boost::property_tree::ptree ptEmpty;
   const boost::property_tree::ptree& ptree = _pt.get_child("qspi_wp_status", ptEmpty);
 
-  _output << "QSPI write protection status" << std::endl;
-  _output << boost::format("  %-23s: %s\n") % "Primary" % ptree.get<std::string>("primary");
-  _output << boost::format("  %-23s: %s\n") % "Recovery" % ptree.get<std::string>("recovery");
+  _output << boost::format("  %-23s: %s\n") % "Primary" % ptree.get<std::string>("primary", "N/A");
+  _output << boost::format("  %-23s: %s\n") % "Recovery" % ptree.get<std::string>("recovery", "N/A");
   _output << std::endl;
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -837,7 +837,7 @@ auxConnectionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property
   const std::vector<std::string> auxPwrRequiredDevice = { "VCU1525", "U200", "U250", "U280" };
 
   std::string name;
-  uint64_t max_power;
+  uint64_t max_power = 0;
   try {
     name = xrt_core::device_query<xrt_core::query::xmc_board_name>(_dev);
     max_power = xrt_core::device_query<xrt_core::query::max_power_level>(_dev);

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1634,6 +1634,10 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       XBU::verbose("Sub command: --path");
       if (!boost::filesystem::exists(xclbin_location) || !boost::filesystem::is_directory(xclbin_location))
         throw xrt_core::error((boost::format("Invalid directory path : '%s'") % xclbin_location).str());
+      if(xclbin_location.compare(".") == 0 || xclbin_location.compare("./") == 0)
+        xclbin_location = boost::filesystem::current_path().string();
+      if(xclbin_location.back() != '/')
+        xclbin_location.append("/");
     }
 
   } catch (const xrt_core::error& e) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -221,9 +221,14 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
   } catch(...) { }
 
   std::string xclbinPath;
-  if(!logic_uuid.empty()) {
+  auto xclbin_location = _ptTest.get<std::string>("xclbin_directory", "");
+  if(!xclbin_location.empty()) {
+    xclbinPath = xclbin_location + xclbin;
+  }
+  else if(!logic_uuid.empty()) {
     xclbinPath = searchSSV2Xclbin(logic_uuid.front(), xclbin, _ptTest);
-  } else {
+  } 
+  else {
     auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev);
     xclbinPath = searchLegacyXclbin(vendor, name, xclbin, _ptTest);
   }
@@ -688,7 +693,11 @@ search_and_program_xclbin(const std::shared_ptr<xrt_core::device>& dev, boost::p
     } catch(...) { }
 
     std::string xclbinPath;
-    if(!logic_uuid.empty()) {
+    auto xclbin_location = ptTest.get<std::string>("xclbin_directory", "");
+    if(!xclbin_location.empty()) {
+      xclbinPath = xclbin_location + xclbin;
+    }
+    else if(!logic_uuid.empty()) {
       xclbinPath = searchSSV2Xclbin(logic_uuid.front(), xclbin, ptTest);
     } else {
       auto vendor = xrt_core::device_query<xrt_core::query::pcie_vendor>(dev);
@@ -827,9 +836,14 @@ auxConnectionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property
 {
   const std::vector<std::string> auxPwrRequiredDevice = { "VCU1525", "U200", "U250", "U280" };
 
-  std::string name = xrt_core::device_query<xrt_core::query::xmc_board_name>(_dev);
-  uint64_t max_power = xrt_core::device_query<xrt_core::query::max_power_level>(_dev);
-
+  std::string name;
+  uint64_t max_power;
+  try {
+    name = xrt_core::device_query<xrt_core::query::xmc_board_name>(_dev);
+    max_power = xrt_core::device_query<xrt_core::query::max_power_level>(_dev);
+  }
+  catch (const xrt_core::query::exception&) { }
+  
   //check if device has aux power connector
   bool auxDevice = false;
   for (auto bd : auxPwrRequiredDevice) {
@@ -877,11 +891,12 @@ pcieLinkTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree
 void
 scVersionTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  auto sc_ver = xrt_core::device_query<xrt_core::query::xmc_sc_version>(_dev);
+  std::string sc_ver;
   std::string exp_sc_ver = "";
   try{
-    exp_sc_ver = xrt_core::device_query<xrt_core::query::expected_sc_version>(_dev);
-  } catch(...) {}
+      sc_ver = xrt_core::device_query<xrt_core::query::xmc_sc_version>(_dev);
+      exp_sc_ver = xrt_core::device_query<xrt_core::query::expected_sc_version>(_dev);
+  } catch(const xrt_core::query::exception& ) {}
 
   if (!exp_sc_ver.empty() && sc_ver.compare(exp_sc_ver) != 0) {
     logger(_ptTest, "Warning", "SC firmware mismatch");
@@ -1531,6 +1546,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   std::vector<std::string> testsToRun = {"all"};
   std::string sFormat = "JSON";
   std::string sOutput = "";
+  std::string xclbin_location;
   bool help = false;
 
   po::options_description commonOptions("Commmon Options");
@@ -1540,6 +1556,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("run,r", boost::program_options::value<decltype(testsToRun)>(&testsToRun)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
+    ("path,p", boost::program_options::value<decltype(xclbin_location)>(&xclbin_location), "Path to the directory containing validate xclbins")
     ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
@@ -1612,6 +1629,13 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     for (auto &userTestName : testsToRun)
       boost::algorithm::to_lower(userTestName);   // Lower case the string entry
 
+    // check if xclbin folder path is provided
+    if (!xclbin_location.empty()) {
+      XBU::verbose("Sub command: --path");
+      if (!boost::filesystem::exists(xclbin_location) || !boost::filesystem::is_directory(xclbin_location))
+        throw xrt_core::error((boost::format("Invalid directory path : '%s'") % xclbin_location).str());
+    }
+
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -1654,11 +1678,15 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
       if(testSuite[index].ptTest.get<bool>("explicit"))
         continue;
       testObjectsToRun.push_back(&testSuite[index]);
+      if(!xclbin_location.empty())
+        testSuite[index].ptTest.put("xclbin_directory", xclbin_location);
       continue;
     }
 
     if (testsToRun[0] == "quick") {
       testObjectsToRun.push_back(&testSuite[index]);
+      if(!xclbin_location.empty())
+        testSuite[index].ptTest.put("xclbin_directory", xclbin_location);
       // Only the first 3 should be processed
       if (index == 3)
         break;
@@ -1669,6 +1697,8 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     for (const auto & testName : testsToRun) {
       if (testName.compare(testSuiteName) == 0) {
         testObjectsToRun.push_back(&testSuite[index]);
+        if(!xclbin_location.empty())
+          testSuite[index].ptTest.put("xclbin_directory", xclbin_location);
         break;
       }
     }


### PR DESCRIPTION
#### Problem solved by the commit
- CR-1113150 xbutil validate support in aws f1
- CR-1113703 xbutil examine -r platform on aws f1 not working
#### Bug / issue (if any) fixed, and how
2 issues are fixed by this PR:
- AWS f1 doesn't have xmc sub-driver which was causing query_requests to falsely fail in xbutil. _try/catch were added around query_requests which called sysfs nodes within the xmc driver_
- AWS f1 shell doesn't have a defined path to validate package. _A new option "--path" was added to xbutil validate which takes in the path to the test package. This overrides auto validate package search_

_NOTE: the test package content needs to be standard, i.e., it should have platform.json, .exes and corresponding .xclbins_
#### What has been tested and how, request additional testing if necessary
- xbutil examine -r all was tested against xbutil --legacy query output
- xbutil validate -p [path to a new dir]
- xbutil validate -p [invalid path]
