### PR TITLE
Silence boost-1.74 warnings

### DIFF
--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -95,13 +95,14 @@ if (DEFINED ENV{XRT_BOOST_INSTALL})
     set (Boost_LIBRARY_DIRS $ENV{XRT_BOOST_INSTALL}/lib)
   endif()
 
-  # Some later versions of boost spews warnings form property_tree
-  add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 else()
   find_package(Boost
     REQUIRED COMPONENTS system filesystem program_options)
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
+
+# Some later versions of boost spew warnings form property_tree
+add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 
 # Boost_VERSION_STRING is not working properly, use our own macro
 set(XRT_BOOST_VERSION ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION})

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -101,7 +101,7 @@ else()
 endif()
 set(Boost_USE_MULTITHREADED ON)             # Multi-threaded libraries
 
-# Some later versions of boost spew warnings form property_tree
+# Some later versions of boost spew warnings from property_tree
 add_compile_options("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
 
 # Boost_VERSION_STRING is not working properly, use our own macro


### PR DESCRIPTION
Some later versions of boost spew warnings from property_tree.  Adding
global define to disable the warnings while awaiting fix in
later version of Boost.
