### PR TITLE
CR-1102624 Invalid mac addresses reported

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -191,16 +191,14 @@ add_mac_info(const xrt_core::device* device, ptree_type& pt)
     auto mac_addr_first = xrt_core::device_query<xq::mac_addr_first>(device);
 
     // new flow
-    if (mac_contiguous_num && !mac_addr_first.empty()) {
-      std::string mac_prefix = mac_addr_first.substr(0, mac_addr_first.find_last_of(":"));
-      std::string mac_base = mac_addr_first.substr(mac_addr_first.find_last_of(":") + 1);
-      constexpr int base = 16;
-      auto mac_base_val = std::stoul(mac_base, nullptr, base);
+    if (mac_contiguous_num!=0 && !mac_addr_first.empty()) {
+      // Convert the mac address into a number
+      uint64_t mac_addr_first_value = xrt_core::utils::mac_addr_to_value(mac_addr_first);
 
       for (decltype(mac_contiguous_num) i = 0; i < mac_contiguous_num; ++i) {
         ptree_type addr;
-        auto basex = boost::format("%02X") % (mac_base_val + i);
-        addr.add("address", mac_prefix + ":" + basex.str());
+        // Add desired increment to the mac address value and convert back into a mac address
+        addr.add("address", xrt_core::utils::value_to_mac_addr(mac_addr_first_value + i));
         pt_mac.push_back(std::make_pair("", addr));
       }
     }

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -264,7 +264,7 @@ uint64_t
 mac_addr_to_value(std::string mac_addr)
 {
   boost::erase_all(mac_addr, ":");
-  return std::stoul(mac_addr, nullptr, 16);
+  return std::stoull(mac_addr, nullptr, 16);
 }
 
 std::string

--- a/src/runtime_src/core/common/utils.cpp
+++ b/src/runtime_src/core/common/utils.cpp
@@ -260,46 +260,44 @@ parse_clock_id(const std::string& id)
   return clock_str != clock_map.end() ? clock_str->second : "N/A";
 }
 
-XRT_CORE_COMMON_EXPORT
 uint64_t
-mac_addr_to_value(const std::string& mac_addr){
-  std::string mac_addr_editable = mac_addr; // Make a copy to edit
-  boost::erase_all(mac_addr_editable, ":");
+mac_addr_to_value(std::string mac_addr)
+{
+  boost::erase_all(mac_addr, ":");
   // Convert the reduced string into a value using the hex formatter
-  std::istringstream converter(mac_addr_editable);
+  std::istringstream converter(mac_addr);
   uint64_t mac_addr_value = 0;
   converter >> std::hex >> mac_addr_value;
   return mac_addr_value;
 }
 
-XRT_CORE_COMMON_EXPORT
 std::string
-value_to_mac_addr(const uint64_t mac_addr_value){
+value_to_mac_addr(const uint64_t mac_addr_value)
+{
     // Convert the given value back into a string using a hex format
-    std::stringstream stream;
-    stream << std::hex << mac_addr_value;
-    std::string result( stream.str() );
+    std::stringstream converter;
+    converter << std::hex << mac_addr_value;
+    std::string result( converter.str() );
 
     // prepend zeros if needed
-    if(result.size() < 12)
+    if (result.size() < 12)
       result.insert(0, 12-result.size(), '0');
     // If the string is longer than 12 characters only accept the last 12
     else
-      result = result.substr(result.size()-12,12);
+      result = result.substr(result.size()-12, 12);
 
     // Go through the converted string to add : characters and capitalize all characters
-    std::stringstream newStream;
+    std::stringstream mac_addr_stream;
     const uint32_t MAC_ADDR_SIZE = 6;
-    const char* resultBytes = result.c_str();
-    for(uint32_t i = 0; i < MAC_ADDR_SIZE; ++i)
-    {
+    const char* result_bytes = result.c_str();
+    for (uint32_t i = 0; i < MAC_ADDR_SIZE; ++i){
         // Process the result string bytes in groups of 2. Similar to how MAC addresses hex values are grouped.
-        newStream << (char)toupper(resultBytes[i*2]) << (char)toupper(resultBytes[i*2+1]);
-        // Add the : at the end of each group except the last one!
-        if(i < MAC_ADDR_SIZE - 1)
-          newStream << ":";
+        mac_addr_stream << (char)toupper(result_bytes[i*2]) << (char)toupper(result_bytes[i*2+1]);
+        // Add the : character at the end of each group except the last one!
+        if (i < MAC_ADDR_SIZE - 1)
+          mac_addr_stream << ":";
     }
-    return newStream.str();
+    return mac_addr_stream.str();
 }
 
 }} // utils, xrt_core

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -109,6 +109,14 @@ XRT_CORE_COMMON_EXPORT
 std::string
 parse_cmc_status(unsigned int val);
 
+XRT_CORE_COMMON_EXPORT
+uint64_t
+mac_addr_to_value(const std::string& mac_addr);
+
+XRT_CORE_COMMON_EXPORT
+std::string
+value_to_mac_addr(const uint64_t mac_addr_value);
+
 }} // utils, xrt_core
 
 #endif

--- a/src/runtime_src/core/common/utils.h
+++ b/src/runtime_src/core/common/utils.h
@@ -111,7 +111,7 @@ parse_cmc_status(unsigned int val);
 
 XRT_CORE_COMMON_EXPORT
 uint64_t
-mac_addr_to_value(const std::string& mac_addr);
+mac_addr_to_value(std::string mac_addr);
 
 XRT_CORE_COMMON_EXPORT
 std::string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[https://jira.xilinx.com/browse/CR-1102624](url)
xbutil dump is reporting back invalid mac addresses on the x3522pv device. The reported mac addresses are used by xbtest v5 for gt testing.
```
"mac_addr":  {                
   "0": "00:0A:35:0C:2E:FE",
   "1": "00:0A:35:0C:2E:FF",
   "2": "00:0A:35:0C:2E:100",
   "3": "00:0A:35:0C:2E:101",
   "4": "00:0A:35:0C:2E:102",
   "5": "00:0A:35:0C:2E:103",
   "6": "00:0A:35:0C:2E:104",
   "7": "00:0A:35:0C:2E:105", 
   "8": "00:0A:35:0C:2E:106",
   "9": "00:0A:35:0C:2E:107",
   "10": "00:0A:35:0C:2E:108",
   "11": "00:0A:35:0C:2E:109", 
   "12": "00:0A:35:0C:2E:10A",  
   "13": "00:0A:35:0C:2E:10B",
   "14": "00:0A:35:0C:2E:10C",   
   "15": "00:0A:35:0C:2E:10D"            
} 
```
Index entries 2-15 are invalid values.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Mac address generation only took into account the last two digits of the address when computing contiguous assignments.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Change mac address generation to go into a number for contiguous assignment then into string based mac address for display.

#### What has been tested and how, request additional testing if necessary
The first two tests were completed by hard coding the mac address. The final test used the mac address of the environment's native card to examine how the software will normally behave.
Test 1 - Using mac address given in CR (00:0A:35:0C:2E:FE)
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r platform -d 02:00
-----------------------------------------------
1/1 [0000:02:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : disabled

Clocks
  Data                   : 250 MHz
  Kernel                 : 500 MHz
  N/A                    : 450 MHz

Mac Addresses            : 00:0A:35:0C:2E:FE
                         : 00:0A:35:0C:2E:FF
                         : 00:0A:35:0C:2F:00
                         : 00:0A:35:0C:2F:01
                         : 00:0A:35:0C:2F:02
                         : 00:0A:35:0C:2F:03
                         : 00:0A:35:0C:2F:04
                         : 00:0A:35:0C:2F:05
                         : 00:0A:35:0C:2F:06
                         : 00:0A:35:0C:2F:07
                         : 00:0A:35:0C:2F:08
                         : 00:0A:35:0C:2F:09
                         : 00:0A:35:0C:2F:0A
                         : 00:0A:35:0C:2F:0B
                         : 00:0A:35:0C:2F:0C
                         : 00:0A:35:0C:2F:0D
```
Test 2 - Using mac address to test beyond first grouping (FF:FF:FF:FE:FF:FE)
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r platform -d 02:00

-----------------------------------------------
1/1 [0000:02:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : disabled

Clocks
  Data                   : 250 MHz
  Kernel                 : 500 MHz
  N/A                    : 450 MHz

Mac Addresses            : FF:FF:FF:FE:FF:FE
                         : FF:FF:FF:FE:FF:FF
                         : FF:FF:FF:FF:00:00
                         : FF:FF:FF:FF:00:01
                         : FF:FF:FF:FF:00:02
                         : FF:FF:FF:FF:00:03
                         : FF:FF:FF:FF:00:04
                         : FF:FF:FF:FF:00:05
                         : FF:FF:FF:FF:00:06
                         : FF:FF:FF:FF:00:07
                         : FF:FF:FF:FF:00:08
                         : FF:FF:FF:FF:00:09
                         : FF:FF:FF:FF:00:0A
                         : FF:FF:FF:FF:00:0B
                         : FF:FF:FF:FF:00:0C
                         : FF:FF:FF:FF:00:0D
```
Test 3 - Using non edited mac address from card (From device 02:00)
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r platform -d 02:00

-----------------------------------------------
1/1 [0000:02:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : disabled

Clocks
  Data                   : 250 MHz
  Kernel                 : 500 MHz
  N/A                    : 450 MHz

Mac Addresses            : 01:02:03:04:05:06
                         : 01:02:03:04:05:07
```