### PR TITLE
Fix for CR 1116896 : If compile trace option is set, run time metric can be empty

### DIFF
--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -366,7 +366,7 @@ set_target_properties(xdp_system_compiler_plugin PROPERTIES VERSION ${XRT_VERSIO
 # With x86 sw_emu support of AIE, XRT_AIE_BUILD is defined even on x86
 # so the condition is strengthen to include native build not defined,
 # which is same condition that compiles edge.
-if (DEFINED XRT_AIE_BUILD AND NOT DEFINED XRT_NATIVE_BUILD)
+if (DEFINED XRT_AIE_BUILD AND ${XRT_NATIVE_BUILD} STREQUAL "no")
   # AIE Profile plugin
   add_library(xdp_aie_profile_plugin MODULE ${XRT_XDP_PROFILE_AIE_PLUGIN_FILES})
   add_dependencies(xdp_aie_profile_plugin xdp_core xrt_core)

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -442,8 +442,11 @@ namespace xdp {
     }
 
     auto metricSet = getMetricSet(handle);
-    if (metricSet.empty())
+    if (metricSet.empty()) {
+      if (!runtimeMetrics)
+        return true;
       return false;
+    }
     auto tiles = getTilesForTracing(handle);
 
     // getTraceStartDelayCycles is 32 bit for now


### PR DESCRIPTION
#### Problem solved by the commit
AIE designs not generating AIE trace output files in XRT flow when compile trace option is set
Also, there was a breakage in generation of shared objects for xdp_aie_trace_plugin and xdp_aie_profile_plugin due to a bad conditional check in xdp/CMakeLists.txt. This PR addresses both the issues and now the plugins are built and AIE trace output files are generated when compile trace option is used.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR 1116896

#### What has been tested and how, request additional testing if necessary
unit tests

#### Documentation impact (if any)
