### PR TITLE
CR-1117245 P2P write from NoDMA to XDMA cause server to crash instead…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -279,6 +279,11 @@ int xocl_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 	if (page_offset > num_pages)
 		return VM_FAULT_SIGBUS;
 
+	/*
+	 * It looks vm_insert_mixed() is the newer interface to handle different
+	 * types of page. We may consider to only use this interface when the old
+	 * kernel support is dropped.
+	 */
 	if (xocl_bo_p2p(xobj) || xocl_bo_import(xobj)) {
 #ifdef RHEL_RELEASE_VERSION
 		pfn_t pfn;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -279,7 +279,7 @@ int xocl_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 	if (page_offset > num_pages)
 		return VM_FAULT_SIGBUS;
 
-	if (xocl_bo_p2p(xobj)) {
+	if (xocl_bo_p2p(xobj) || xocl_bo_import(xobj)) {
 #ifdef RHEL_RELEASE_VERSION
 		pfn_t pfn;
 		pfn = phys_to_pfn_t(page_to_phys(xobj->pages[page_offset]), PFN_MAP|PFN_DEV);


### PR DESCRIPTION
… of reporting error

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
vm page fault panic
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
the imported BO is P2P, thus it should use the same way with P2P BO for insert_page.
#### How problem was solved, alternative solutions (if any) and why they were rejected
check imported BO in vm page fault
#### Risks (if any) associated the changes in the commit
low
#### What has been tested and how, request additional testing if necessary
verified with environment mentioned in the CR
#### Documentation impact (if any)
