### PR TITLE
Vitis-3928 IPC facility using XRT BO APIs for export/import

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -64,6 +64,12 @@ struct ishim
   virtual xclBufferHandle
   import_bo(xclBufferExportHandle ehdl) = 0;
 
+  // Import an exported BO from another process identified by argument pid.
+  // This function is only supported on systems with pidfd kernel support
+  virtual xclBufferHandle
+  import_bo(pid_t, xclBufferExportHandle)
+  { throw xrt_core::error(std::errc::not_supported,"import_bo(pid, hdl)"); }
+
   virtual void
   copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset) = 0;
 

--- a/src/runtime_src/core/include/windows/types.h
+++ b/src/runtime_src/core/include/windows/types.h
@@ -18,5 +18,6 @@
 #define core_include_windows_types_h_
 
 typedef size_t ssize_t;
+typedef int pid_t;
 
 #endif

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -194,10 +194,30 @@ public:
    * If the exported buffer handle acquired by using the export() method is 
    * from another process, then it must be transferred through proper IPC 
    * mechanism translating the underlying file-descriptor asscociated with 
-   * the buffer 
+   * the buffer, see also constructor taking process id as argument.
    */
   XCL_DRIVER_DLLESPEC
   bo(xclDeviceHandle dhdl, xclBufferExportHandle ehdl);
+
+  /**
+   * bo() - Constructor to import an exported buffer from another process
+   *
+   * @param dhdl
+   *  Device that imports the exported buffer
+   * @param pid
+   *  Process id of exporting process
+   * @param ehdl
+   *  Exported buffer handle, implementation specific type
+   * 
+   * The exported buffer handle is obtained from exporting process by
+   * calling `export()`. This contructor requires that XRT is built on
+   * and running on a system with pidfd support.  Also the importing 
+   * process must have permission to duplicate the exporting process'
+   * file descriptor.  This permission is controlled by ptrace access 
+   * mode PTRACE_MODE_ATTACH_REALCREDS check (see ptrace(2)).
+   */
+  XCL_DRIVER_DLLESPEC
+  bo(xclDeviceHandle dhdl, pid_t pid, xclBufferExportHandle ehdl);
 
   /**
    * bo() - Constructor for sub-buffer

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -33,6 +33,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <sys/syscall.h>
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/filesystem.hpp>
@@ -749,7 +750,7 @@ initialize_query_table()
   emplace_sysfs_get<query::xmc_scaling_support>                ("xmc", "scaling_support");
   emplace_sysfs_getput<query::xmc_scaling_enabled>             ("xmc", "scaling_enabled");
   emplace_sysfs_get<query::xmc_scaling_critical_pow_threshold> ("xmc", "scaling_critical_power_threshold");
-  emplace_sysfs_get<query::xmc_scaling_critical_temp_threshold> ("xmc", "scaling_critical_temp_threshold");
+  emplace_sysfs_get<query::xmc_scaling_critical_temp_threshold>("xmc", "scaling_critical_temp_threshold");
   emplace_sysfs_get<query::xmc_scaling_threshold_power_limit>  ("xmc", "scaling_threshold_power_limit");
   emplace_sysfs_get<query::xmc_scaling_threshold_temp_limit>   ("xmc", "scaling_threshold_temp_limit");
   emplace_sysfs_get<query::xmc_scaling_power_override_enable>  ("xmc", "scaling_threshold_power_override_en");
@@ -826,66 +827,65 @@ initialize_query_table()
   emplace_func0_request<query::xmc_qspi_status,                qspi_status>();
   emplace_func0_request<query::mac_addr_list,                  mac_addr_list>();
 
-  emplace_sysfs_get<query::firewall_detect_level>             ("firewall", "detected_level");
-  emplace_sysfs_get<query::firewall_detect_level_name>        ("firewall", "detected_level_name");
-  emplace_sysfs_get<query::firewall_status>                   ("firewall", "detected_status");
-  emplace_sysfs_get<query::firewall_time_sec>                 ("firewall", "detected_time");
+  emplace_sysfs_get<query::firewall_detect_level>              ("firewall", "detected_level");
+  emplace_sysfs_get<query::firewall_detect_level_name>         ("firewall", "detected_level_name");
+  emplace_sysfs_get<query::firewall_status>                    ("firewall", "detected_status");
+  emplace_sysfs_get<query::firewall_time_sec>                  ("firewall", "detected_time");
 
-  emplace_sysfs_get<query::power_microwatts>                  ("xmc", "xmc_power");
-  emplace_sysfs_get<query::power_warning>                     ("xmc", "xmc_power_warn");
-  emplace_sysfs_get<query::host_mem_size>                     ("address_translator", "host_mem_size");
-  emplace_sysfs_get<query::kds_numcdmas>                      ("mb_scheduler", "kds_numcdmas");
+  emplace_sysfs_get<query::power_microwatts>                   ("xmc", "xmc_power");
+  emplace_sysfs_get<query::power_warning>                      ("xmc", "xmc_power_warn");
+  emplace_sysfs_get<query::host_mem_size>                      ("address_translator", "host_mem_size");
+  emplace_sysfs_get<query::kds_numcdmas>                       ("mb_scheduler", "kds_numcdmas");
 
-  //emplace_sysfs_get<query::mig_ecc_enabled>                ("mig", "ecc_enabled");
-  emplace_sysfs_get<query::mig_ecc_status>                   ("mig", "ecc_status");
-  emplace_sysfs_get<query::mig_ecc_ce_cnt>                   ("mig", "ecc_ce_cnt");
-  emplace_sysfs_get<query::mig_ecc_ue_cnt>                   ("mig", "ecc_ue_cnt");
-  emplace_sysfs_get<query::mig_ecc_ce_ffa>                   ("mig", "ecc_ce_ffa");
-  emplace_sysfs_get<query::mig_ecc_ue_ffa>                   ("mig", "ecc_ue_ffa");
-  emplace_sysfs_get<query::flash_bar_offset>                 ("flash", "bar_off");
-  emplace_sysfs_get<query::is_mfg>                           ("", "mfg");
-  emplace_sysfs_get<query::mfg_ver>                          ("", "mfg_ver");
-  emplace_sysfs_get<query::is_recovery>                      ("", "recovery");
-  emplace_sysfs_get<query::is_ready>                         ("", "ready");
-  emplace_sysfs_get<query::is_offline>                       ("", "dev_offline");
-  emplace_sysfs_get<query::f_flash_type>                     ("flash", "flash_type");
-  emplace_sysfs_get<query::flash_type>                       ("", "flash_type");
-  emplace_sysfs_get<query::board_name>                       ("", "board_name");
-  emplace_sysfs_get<query::logic_uuids>                      ("", "logic_uuids");
-  emplace_sysfs_get<query::interface_uuids>                  ("", "interface_uuids");
-  emplace_sysfs_getput<query::rp_program_status>             ("", "rp_program");
-  emplace_sysfs_get<query::shared_host_mem>                  ("", "host_mem_size");
-  emplace_sysfs_get<query::enabled_host_mem>                  ("address_translator", "host_mem_size");
-  emplace_sysfs_get<query::cpu_affinity>                     ("", "local_cpulist");
-  emplace_sysfs_get<query::mailbox_metrics>                  ("mailbox", "recv_metrics");
-  emplace_sysfs_get<query::clock_timestamp>                  ("ert_user", "clock_timestamp");
-  emplace_sysfs_getput<query::ert_sleep>                     ("ert_user", "mb_sleep");
-  emplace_sysfs_get<query::ert_cq_read>                      ("ert_user", "cq_read_cnt");
-  emplace_sysfs_get<query::ert_cq_write>                     ("ert_user", "cq_write_cnt");
-  emplace_sysfs_get<query::ert_cu_read>                      ("ert_user", "cu_read_cnt");
-  emplace_sysfs_get<query::ert_cu_write>                     ("ert_user", "cu_write_cnt");
-  emplace_sysfs_get<query::ert_data_integrity>               ("ert_user", "data_integrity");
-  emplace_sysfs_getput<query::config_mailbox_channel_disable> ("", "config_mailbox_channel_disable");
-  emplace_sysfs_getput<query::config_mailbox_channel_switch> ("", "config_mailbox_channel_switch");
-  emplace_sysfs_getput<query::config_xclbin_change>          ("", "config_xclbin_change");
-  emplace_sysfs_getput<query::cache_xclbin>                  ("", "cache_xclbin");
+  emplace_sysfs_get<query::mig_ecc_status>                     ("mig", "ecc_status");
+  emplace_sysfs_get<query::mig_ecc_ce_cnt>                     ("mig", "ecc_ce_cnt");
+  emplace_sysfs_get<query::mig_ecc_ue_cnt>                     ("mig", "ecc_ue_cnt");
+  emplace_sysfs_get<query::mig_ecc_ce_ffa>                     ("mig", "ecc_ce_ffa");
+  emplace_sysfs_get<query::mig_ecc_ue_ffa>                     ("mig", "ecc_ue_ffa");
+  emplace_sysfs_get<query::flash_bar_offset>                   ("flash", "bar_off");
+  emplace_sysfs_get<query::is_mfg>                             ("", "mfg");
+  emplace_sysfs_get<query::mfg_ver>                            ("", "mfg_ver");
+  emplace_sysfs_get<query::is_recovery>                        ("", "recovery");
+  emplace_sysfs_get<query::is_ready>                           ("", "ready");
+  emplace_sysfs_get<query::is_offline>                         ("", "dev_offline");
+  emplace_sysfs_get<query::f_flash_type>                       ("flash", "flash_type");
+  emplace_sysfs_get<query::flash_type>                         ("", "flash_type");
+  emplace_sysfs_get<query::board_name>                         ("", "board_name");
+  emplace_sysfs_get<query::logic_uuids>                        ("", "logic_uuids");
+  emplace_sysfs_get<query::interface_uuids>                    ("", "interface_uuids");
+  emplace_sysfs_getput<query::rp_program_status>               ("", "rp_program");
+  emplace_sysfs_get<query::shared_host_mem>                    ("", "host_mem_size");
+  emplace_sysfs_get<query::enabled_host_mem>                   ("address_translator", "host_mem_size");
+  emplace_sysfs_get<query::cpu_affinity>                       ("", "local_cpulist");
+  emplace_sysfs_get<query::mailbox_metrics>                    ("mailbox", "recv_metrics");
+  emplace_sysfs_get<query::clock_timestamp>                    ("ert_user", "clock_timestamp");
+  emplace_sysfs_getput<query::ert_sleep>                       ("ert_user", "mb_sleep");
+  emplace_sysfs_get<query::ert_cq_read>                        ("ert_user", "cq_read_cnt");
+  emplace_sysfs_get<query::ert_cq_write>                       ("ert_user", "cq_write_cnt");
+  emplace_sysfs_get<query::ert_cu_read>                        ("ert_user", "cu_read_cnt");
+  emplace_sysfs_get<query::ert_cu_write>                       ("ert_user", "cu_write_cnt");
+  emplace_sysfs_get<query::ert_data_integrity>                 ("ert_user", "data_integrity");
+  emplace_sysfs_getput<query::config_mailbox_channel_disable>  ("", "config_mailbox_channel_disable");
+  emplace_sysfs_getput<query::config_mailbox_channel_switch>   ("", "config_mailbox_channel_switch");
+  emplace_sysfs_getput<query::config_xclbin_change>            ("", "config_xclbin_change");
+  emplace_sysfs_getput<query::cache_xclbin>                    ("", "cache_xclbin");
 
-  emplace_sysfs_get<query::kds_mode>                         ("", "kds_mode");
-  emplace_func0_request<query::kds_cu_stat,                  kds_cu_stat>();
-  emplace_func0_request<query::kds_scu_stat,                 kds_scu_stat>();
-  emplace_sysfs_get<query::ps_kernel>                        ("icap", "ps_kernel");
-  emplace_sysfs_get<query::xocl_errors>                       ("", "xocl_errors");
+  emplace_sysfs_get<query::kds_mode>                           ("", "kds_mode");
+  emplace_func0_request<query::kds_cu_stat,                    kds_cu_stat>();
+  emplace_func0_request<query::kds_scu_stat,                   kds_scu_stat>();
+  emplace_sysfs_get<query::ps_kernel>                          ("icap", "ps_kernel");
+  emplace_sysfs_get<query::xocl_errors>                        ("", "xocl_errors");
 
-  emplace_func0_request<query::pcie_bdf,                     bdf>();
-  emplace_func0_request<query::kds_cu_info,                  kds_cu_info>();
-  emplace_func0_request<query::instance,                     instance>();
+  emplace_func0_request<query::pcie_bdf,                       bdf>();
+  emplace_func0_request<query::kds_cu_info,                    kds_cu_info>();
+  emplace_func0_request<query::instance,                       instance>();
 
-  emplace_func4_request<query::aim_counter,                  aim_counter>();
-  emplace_func4_request<query::am_counter,                   am_counter>();
-  emplace_func4_request<query::asm_counter,                  asm_counter>();
-  emplace_func4_request<query::lapc_status,                  lapc_status>();
-  emplace_func4_request<query::spc_status,                   spc_status>();
-  emplace_func4_request<query::accel_deadlock_status,        accel_deadlock_status>();
+  emplace_func4_request<query::aim_counter,                    aim_counter>();
+  emplace_func4_request<query::am_counter,                     am_counter>();
+  emplace_func4_request<query::asm_counter,                    asm_counter>();
+  emplace_func4_request<query::lapc_status,                    lapc_status>();
+  emplace_func4_request<query::spc_status,                     spc_status>();
+  emplace_func4_request<query::accel_deadlock_status,          accel_deadlock_status>();
 }
 
 struct X { X() { initialize_query_table(); }};
@@ -1000,8 +1000,11 @@ xclmgmt_load_xclbin(const char* buffer) const {
 }
 
 ////////////////////////////////////////////////////////////////
-// User Managed IP Interrupt Handling
+// Custom ishim implementation
+// Redefined from xrt_core::ishim for functions that are not
+// universally implemented by all shims
 ////////////////////////////////////////////////////////////////
+// User Managed IP Interrupt Handling
 xclInterruptNotifyHandle
 device_linux::
 open_ip_interrupt_notify(unsigned int ip_index)
@@ -1041,6 +1044,34 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle)
   int pending = 0;
   if (::read(handle, &pending, sizeof(pending)) == -1)
     throw error(errno, "wait_ip_interrupt failed POSIX read");
+
+xclBufferHandle
+device_linux::
+import_bo(pid_t pid, xclBufferExportHandle ehdl)
+{
+  if (getpid() == pid)
+    return shim::import_bo(ehdl);
+
+#if defined(SYS_pidfd_open) && defined(SYS_pidfd_getfd)
+  auto pidfd = syscall(SYS_pidfd_open, pid, 0);
+  if (pidfd < 0)
+    throw xrt_core::system_error(errno, "pidfd_open failed");
+
+  auto bofd = syscall(SYS_pidfd_getfd, pidfd, ehdl, 0);
+  if (bofd < 0)
+    throw xrt_core::system_error
+      (errno, "pidfd_getfd failed, check that ptrace access mode "
+       "allows PTRACE_MODE_ATTACH_REALCREDS.  For more details please "
+       "check /etc/sysctl.d/10-ptrace.conf");
+
+  return shim::import_bo(bofd);
+#else
+  throw xrt_core::system_error
+    (std::errc::not_supported,
+     "Importing buffer object from different process requires XRT "
+     " built and installed on a system with 'pidfd' kernel support");
+#endif
+>>>>>>> Vitis-3928 IPC facility using XRT BO APIs for export/import
 }
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1044,6 +1044,7 @@ wait_ip_interrupt(xclInterruptNotifyHandle handle)
   int pending = 0;
   if (::read(handle, &pending, sizeof(pending)) == -1)
     throw error(errno, "wait_ip_interrupt failed POSIX read");
+}
 
 xclBufferHandle
 device_linux::
@@ -1071,7 +1072,6 @@ import_bo(pid_t pid, xclBufferExportHandle ehdl)
      "Importing buffer object from different process requires XRT "
      " built and installed on a system with 'pidfd' kernel support");
 #endif
->>>>>>> Vitis-3928 IPC facility using XRT BO APIs for export/import
 }
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -39,24 +39,30 @@ public:
   virtual void reset(query::reset_type&) const;
   virtual void xclmgmt_load_xclbin(const char* buffer) const;
 
+public:
   ////////////////////////////////////////////////////////////////
-  // Custom ip interrupt handling
-  // Redefined from xrt_core::ishim
+  // Custom ishim implementation
+  // Redefined from xrt_core::ishim for functions that are not
+  // universally implemented by all shims
   ////////////////////////////////////////////////////////////////
-  virtual xclInterruptNotifyHandle
-  open_ip_interrupt_notify(unsigned int ip_index);
+  xclInterruptNotifyHandle
+  open_ip_interrupt_notify(unsigned int ip_index) override;
   
-  virtual void
-  close_ip_interrupt_notify(xclInterruptNotifyHandle handle);
+  void
+  close_ip_interrupt_notify(xclInterruptNotifyHandle handle) override;
 
-  virtual void
-  enable_ip_interrupt(xclInterruptNotifyHandle);
+  void
+  enable_ip_interrupt(xclInterruptNotifyHandle) override;
 
-  virtual void
-  disable_ip_interrupt(xclInterruptNotifyHandle);
+  void
+  disable_ip_interrupt(xclInterruptNotifyHandle) override;
 
-  virtual void
-  wait_ip_interrupt(xclInterruptNotifyHandle);
+  void
+  wait_ip_interrupt(xclInterruptNotifyHandle) override;
+
+  xclBufferHandle
+  import_bo(pid_t pid, xclBufferExportHandle ehdl) override;
+  ////////////////////////////////////////////////////////////////
 
 private:
   // Private look up function for concrete query::request

--- a/tests/xrt/import_bo/import.cpp
+++ b/tests/xrt/import_bo/import.cpp
@@ -1,0 +1,186 @@
+#include <unistd.h>
+#include <cstring>
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+// Test export / import of XRT buffer object between processes.
+//
+// Test requires pidfd Linux kernel support and is supposed only on
+// x86.  The example has been tested on Ubuntu 21.10
+//
+// % uname -r
+// 5.13.0-22-generic
+//
+// Also, note that the importing process must have permission to
+// duplicate the exporting process' file descriptor.  This permission
+// is controlled by ptrace access mode PTRACE_MODE_ATTACH_REALCREDS
+// check (see ptrace(2)).  Alternatively, run the example as root.
+//
+// In the test, the parent process writes "parent" to the BO. The
+// child child process waits for the host buffer to contain the parent
+// string and writes "child" and program terminates after parent sees
+// the child string.
+//
+// The program allocates the buffer in memory bank 0, so make sure a
+// corresponding xclbin is loaded, e.g. bandwidth.xclbin
+//
+// % g++ -g -std=c++14 -I${XILINX_XRT}/include -L${XILINX_XRT}/lib -o import.exe import.cpp -lxrt_coreutil -pthread -luuid
+//
+// # kernel allocates host buffer
+// % import.exe -k verify.xclbin
+//
+// # userspace allocates host buffer (fails in xrt-2.12.x)
+// % import.exe -k verify.xclbin --ubuf
+
+// Golden pattern from kernel
+static constexpr char gold[] = "Hello World\n";
+
+// A pipe to communicate exported bo handle to child
+static int talk[2];
+
+static void
+usage()
+{
+  std::cout << "usage: %s [options] \n\n"
+            << "  -k <bitstream>\n"
+            << "  -d <bdf | device_index>\n"
+            << ""
+            << "  [--ubuf]: BO host backing should be created in user space (default kernel space)\n";
+}
+
+
+static void
+child(const std::string& device_id, pid_t pid)
+{
+  close(talk[1]);
+  int fd = 0;
+  read(talk[0], &fd, sizeof(fd));
+  close(talk[0]);
+
+  std::cout << "child pid: " << pid << '\n';
+  std::cout << "child fd: " << fd << '\n';
+  
+  xrt::device device{device_id};
+  xrt::bo bo{device, pid, fd};
+
+  try {
+    auto bo_data = bo.map<char*>();
+    int count = 5;
+    while (!std::equal(std::begin(gold), std::end(gold), bo_data) && --count)
+      bo.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    std::cout << "child reads: " << bo_data << '\n';
+    if (!count)
+      std::cout << "child times out\n";
+    else
+      bo.write("child");
+    bo.write("child");
+  }
+  catch (const std::exception& ex) {
+    std::cout << "child fails with: " << ex.what() << "\n";
+  }
+}
+
+static void
+parent(const std::string& device_id, const std::string& xclbin_fnm, xrt::bo::flags flags)
+{
+  close(talk[0]);
+  
+  xrt::device device{device_id};
+  auto uuid = device.load_xclbin(xclbin_fnm);
+  xrt::kernel hello(device, uuid, "hello");
+  xrt::bo bo(device, 1024, flags, hello.group_id(0));
+  auto bo_data = bo.map<char*>();
+
+  // clear device data
+  std::fill(bo_data, bo_data + 1024, 0);
+  bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  auto export_handle = bo.export_buffer();
+  write(talk[1], &export_handle, sizeof(export_handle));
+  close(talk[1]);
+
+  // run kernel, child will wait for golden string
+  // the write "child" to buffer
+  auto run = hello(bo);
+  run.wait();
+
+  // wait for child to write to buffer
+  int count = 5;
+  while (strncmp(bo_data, "child", bo.size()) && --count)
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  if (!count)
+    std::cout << "parent times out\n";
+  else
+    std::cout << "parent reads: " << bo_data << '\n';
+}
+
+static int
+run(int argc, char* argv[])
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+  std::string xclbin_fnm;
+  std::string device_id = "0";
+  xrt::bo::flags flags = xrt::bo::flags::cacheable;
+  
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return 1;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+
+      if (cur == "--ubuf")
+        flags = xrt::bo::flags::normal;
+
+      continue;
+    }
+
+    if (cur == "-d")
+      device_id = arg;
+    else if (cur == "-k")
+      xclbin_fnm = arg;
+    else
+      throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
+  }
+
+  pipe(talk);
+  
+  switch (fork()) {
+  case 0:
+    child(device_id, getppid());
+    break;
+  case -1:
+    throw std::runtime_error("error forking process");
+    break;
+  default:
+    parent(device_id, xclbin_fnm, flags);
+    break;
+  }
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    return run(argc, argv);
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << '\n';
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}


### PR DESCRIPTION
#### Problem solved by the commit
This PR adds limited support for contructing an xrt::bo object from a
buffer exported by another process.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Vitis-3928, requested support.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The implementation is supported on x86 Linux only where both the
system used to build XRT and the system running XRT must have pidfd
support. Per documentation Linux > 5.6 should support this but it is
dependent on a system call that is not implemented by libc and as such
sys/syscall.h must have support as well.  Please check pidfd_getfd(2)
for details, and note also the ptrace permission requirement.

The process id and buffer export handle must be known / communicated
to the importing process.

xrt::bo constructor added to take process id along with buffer export
handle. Implementation code for importing the exported buffer is
conditional on pidfd support or errors out otherwise.

#### Risks (if any) associated the changes in the commit
No risks, code is new and currently unused.

#### What has been tested and how, request additional testing if necessary
Sample test case added for illustration.

#### Documentation impact (if any)
@uday610 do we need documentation above and beyond what is documented
in API header file?
