### PR TITLE
Enable user managed interrupts for pcie platforms as well

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -999,4 +999,48 @@ xclmgmt_load_xclbin(const char* buffer) const {
   }
 }
 
+////////////////////////////////////////////////////////////////
+// User Managed IP Interrupt Handling
+////////////////////////////////////////////////////////////////
+xclInterruptNotifyHandle
+device_linux::
+open_ip_interrupt_notify(unsigned int ip_index)
+{
+  return xclOpenIPInterruptNotify(get_device_handle(), ip_index, 0);
+}
+  
+void
+device_linux::
+close_ip_interrupt_notify(xclInterruptNotifyHandle handle)
+{
+  xclCloseIPInterruptNotify(get_device_handle(), handle);
+}
+
+void
+device_linux::
+enable_ip_interrupt(xclInterruptNotifyHandle handle)
+{
+  int enable = 1;
+  if (::write(handle, &enable, sizeof(enable)) == -1)
+    throw error(errno, "enable_ip_interrupt failed POSIX write");
+}
+
+void
+device_linux::
+disable_ip_interrupt(xclInterruptNotifyHandle handle)
+{
+  int disable = 0;
+  if (::write(handle, &disable, sizeof(disable)) == -1)
+    throw error(errno, "disable_ip_interrupt failed POSIX write");
+}
+
+void
+device_linux::
+wait_ip_interrupt(xclInterruptNotifyHandle handle)
+{
+  int pending = 0;
+  if (::read(handle, &pending, sizeof(pending)) == -1)
+    throw error(errno, "wait_ip_interrupt failed POSIX read");
+}
+
 } // xrt_core

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -39,6 +39,25 @@ public:
   virtual void reset(query::reset_type&) const;
   virtual void xclmgmt_load_xclbin(const char* buffer) const;
 
+  ////////////////////////////////////////////////////////////////
+  // Custom ip interrupt handling
+  // Redefined from xrt_core::ishim
+  ////////////////////////////////////////////////////////////////
+  virtual xclInterruptNotifyHandle
+  open_ip_interrupt_notify(unsigned int ip_index);
+  
+  virtual void
+  close_ip_interrupt_notify(xclInterruptNotifyHandle handle);
+
+  virtual void
+  enable_ip_interrupt(xclInterruptNotifyHandle);
+
+  virtual void
+  disable_ip_interrupt(xclInterruptNotifyHandle);
+
+  virtual void
+  wait_ip_interrupt(xclInterruptNotifyHandle);
+
 private:
   // Private look up function for concrete query::request
   virtual const query::request&


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enable support of "user managed interrupts" for PCIE platforms as well

#### What has been tested and how, request additional testing if necessary
Tested on local machine

#### Documentation impact (if any)
None