### PR TITLE
XRT-925 bring up A/B boot

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -46,6 +46,9 @@
 /* The Clock IP use index 0 for data, 1 for kernel, 2 for sys, 3 for sys1 */ 
 #define XGQ_CLOCK_WIZ_MAX_RES           4
 
+/**
+ * sensor data request types
+ */
 enum xgq_cmd_sensor_page_id {
 	XGQ_CMD_SENSOR_PID_ALL		= 0x0,
 	XGQ_CMD_SENSOR_PID_BDINFO	= 0x1,
@@ -55,12 +58,34 @@ enum xgq_cmd_sensor_page_id {
 	XGQ_CMD_SENSOR_PID_QSFP		= 0x5,
 };
 
+/**
+ * clock operation request types
+ */
 enum xgq_cmd_clock_req_type {
 	XGQ_CMD_CLOCK_WIZARD 		= 0x0,
 	XGQ_CMD_CLOCK_COUNTER		= 0x1,
 	XGQ_CMD_CLOCK_SCALE		= 0x2,
 };
 
+/**
+ * multi-boot operation request types
+ */
+enum xgq_cmd_multiboot_req_type {
+	XGQ_CMD_BOOT_QUERY	= 0x0,
+	XGQ_CMD_BOOT_DEFAULT	= 0x1,
+	XGQ_CMD_BOOT_BACKUP	= 0x2,
+};
+
+/**
+ * struct xgq_cmd_log_payload: log_page request command
+ *
+ * @address:	pre-allocated log data, device writes log data at this address
+ * @size:	size of pre-allocated log data
+ * @pid:	log_page page id
+ * @addr_type:	pre-allocated address type
+ *
+ * This payload is used for log_page and sensor data report.
+ */
 struct xgq_cmd_log_payload {
 	uint64_t address;
 	uint32_t size;
@@ -69,6 +94,15 @@ struct xgq_cmd_log_payload {
 	uint32_t rsvd1:13;
 };
 
+/**
+ * struct xgq_cmd_clock_payload: clock request command
+ *
+ * @ocl_region:		clock region
+ * @ocl_req_type:	clock request type
+ * @ocl_req_id:		clock resource index 0,1,2,3
+ * @ocl_req_num:	max effective index 1 -> 4
+ * @ocl_req_freq:	request freq number array
+ */
 struct xgq_cmd_clock_payload {
 	uint32_t ocl_region;
 	uint32_t ocl_req_type:8;
@@ -78,6 +112,13 @@ struct xgq_cmd_clock_payload {
 	uint32_t ocl_req_freq[XGQ_CLOCK_WIZ_MAX_RES];
 };
 
+/**
+ * struct xgq_cmd_data_payload: data request payload command
+ *
+ * @address:		data that needs to be transferred
+ * @size:		data size
+ * @addr_type:		address_type
+ */
 struct xgq_cmd_data_payload {
 	uint64_t address;
 	uint32_t size;
@@ -86,38 +127,102 @@ struct xgq_cmd_data_payload {
 	uint32_t pad1;
 };
 
+/**
+ * struct xgq_cmd_multiboot_payload: multiboot request payload
+ *
+ * @req_type:		request type
+ */
+struct xgq_cmd_multiboot_payload {
+	uint32_t req_type:8;
+	uint32_t rsvd:24;
+};
+
+/**
+ * struct xgq_cmd_sq: vmr xgq command
+ *
+ * @hdr:		vmr xgq command header
+ *
+ * @log_payload:	corresponding payload definition in a union
+ * @clock_payload:
+ * @pdi_payload:
+ * @xclbin_payload:
+ * @sensor_payload:
+ */
 struct xgq_cmd_sq {
 	struct xgq_cmd_sq_hdr hdr;
 	union {
-		struct xgq_cmd_log_payload 	log_payload;
-		struct xgq_cmd_clock_payload 	clock_payload;
-		struct xgq_cmd_data_payload 	pdi_payload;
-		struct xgq_cmd_data_payload 	xclbin_payload;
-		struct xgq_cmd_log_payload 	sensor_payload;
+		struct xgq_cmd_log_payload 		log_payload;
+		struct xgq_cmd_clock_payload 		clock_payload;
+		struct xgq_cmd_data_payload 		pdi_payload;
+		struct xgq_cmd_data_payload 		xclbin_payload;
+		struct xgq_cmd_log_payload 		sensor_payload;
+		struct xgq_cmd_multiboot_payload 	multiboot_payload;
 	};
 };
 
-struct xgq_cmd_cq_default_payload {
-	uint32_t result;
-	uint32_t resvd;
+/**
+ * struct xgq_cmd_cq_default_payload: vmr default completion payload
+ *
+ * @result:	result code
+ */
+struct xgq_cmd_cq_vmr_payload {
+	uint32_t resvd0;
+	uint32_t resvd1;
 };
 
+/**
+ * struct xgq_cmd_cq_clock_payload: vmr clock completion payload 
+ *
+ * @ocl_freq: 	result of clock frequency value
+ */
 struct xgq_cmd_cq_clock_payload {
 	uint32_t ocl_freq;
 	uint32_t resvd;
 };
 
+/**
+ * struct xgq_cmd_cq_sensor_payload: vmr sensor completion payload
+ *
+ * @result: 	result code
+ */
 struct xgq_cmd_cq_sensor_payload {
 	uint32_t result;
 	uint32_t resvd;
 };
 
+/**
+ * struct xgq_cmd_cq_fpt_payload: vmr multiboot fpt competion payload
+ *
+ * bitfields for indicting flash partition statistics.
+ */
+struct xgq_cmd_cq_multiboot_payload {
+	uint16_t has_fpt:1;
+	uint16_t has_fpt_recovery:1;
+	uint16_t boot_on_default:1;
+	uint16_t boot_on_backup:1;
+	uint16_t boot_on_recovery:1;
+	uint16_t resvd1:11;
+	uint16_t multi_boot_offset;
+	uint32_t resvd2;
+};
+
+/*
+ * struct xgq_cmd_cq: vmr completion command
+ *
+ * @hdr:		vmr completion command header
+ *
+ * @default_payload: 	payload definitions in a union
+ * @clock_payload:
+ * @sensor_payload:
+ * @multiboot_payload:
+ */
 struct xgq_cmd_cq {
 	struct xgq_cmd_cq_hdr hdr;
 	union {
-		struct xgq_cmd_cq_default_payload default_payload;
-		struct xgq_cmd_cq_clock_payload clock_payload;
-		struct xgq_cmd_cq_sensor_payload sensor_payload;
+		struct xgq_cmd_cq_vmr_payload		default_payload;
+		struct xgq_cmd_cq_clock_payload		clock_payload;
+		struct xgq_cmd_cq_sensor_payload	sensor_payload;
+		struct xgq_cmd_cq_multiboot_payload	multiboot_payload;
 	};
 	uint32_t rcode;
 };

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -123,7 +123,8 @@ struct xgq_cmd_data_payload {
 	uint64_t address;
 	uint32_t size;
 	uint32_t addr_type:4;
-	uint32_t rsvd1:28;
+	uint32_t flush_default_only:1;
+	uint32_t rsvd1:27;
 	uint32_t pad1;
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -298,6 +298,17 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		lro->instance, ep_name,
 		PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
 
+	/*
+	 * reset multi-boot config for next boot.
+	 * This is needed to make sure next boot will be based on pre-loaded
+	 *    boot configuration.
+	 */
+	err = xocl_vmr_enable_multiboot(lro);
+	if (err && err != -ENODEV) {
+		mgmt_info(lro, "reset multi-boot config failed. err: %ld", err);
+		goto done;
+	}
+
 	if (!force && xrt_reset_syncup) {
 		mgmt_info(lro, "wait for master off for all functions");
 		err = xocl_wait_master_off(lro);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -99,9 +99,9 @@ struct xocl_xgq_cmd {
 	struct timer_list	xgq_cmd_timer;
 	struct xocl_xgq		*xgq;
 	u64			xgq_cmd_timeout_jiffies; /* timout till */
-	/*TODO: the xgq cq can have up-to 3 u32 payload, optimze the code later */
 	uint32_t		xgq_cmd_rcode;
-	uint32_t		xgq_cmd_rdata;
+	/* xgq complete command can return in-line data via payload */
+	struct xgq_cmd_cq_vmr_payload	xgq_cmd_cq_payload;
 };
 
 struct xocl_xgq;
@@ -123,6 +123,7 @@ struct xocl_xgq {
 	void __iomem		*xgq_cq_base;
 	struct mutex 		xgq_lock;
 	bool 			xgq_polling;
+	bool 			xgq_boot_from_backup;
 	u32			xgq_intr_base;
 	u32			xgq_intr_num;
 	struct list_head	xgq_submitted_cmds;
@@ -134,6 +135,8 @@ struct xocl_xgq {
 	void			*sensor_data;
 	u32			sensor_data_length;
 	struct semaphore 	xgq_data_sema;
+	/* preserve fpt info for sysfs to display */
+	struct xgq_cmd_cq_multiboot_payload xgq_mb_payload;
 };
 
 /*
@@ -444,20 +447,12 @@ done:
 static void xgq_complete_cb(void *arg, struct xgq_com_queue_entry *ccmd)
 {
 	struct xocl_xgq_cmd *xgq_cmd = (struct xocl_xgq_cmd *)arg;
-
-	/* Note: we only care rcode for now */
-	xgq_cmd->xgq_cmd_rcode = ccmd->rcode;
-
-	complete(&xgq_cmd->xgq_cmd_complete);
-}
-
-static void xgq_complete_clock_cb(void *arg, struct xgq_com_queue_entry *ccmd)
-{
-	struct xocl_xgq_cmd *xgq_cmd = (struct xocl_xgq_cmd *)arg;
 	struct xgq_cmd_cq *cmd_cq = (struct xgq_cmd_cq *)ccmd;
 
 	xgq_cmd->xgq_cmd_rcode = ccmd->rcode;
-	xgq_cmd->xgq_cmd_rdata = cmd_cq->clock_payload.ocl_freq;
+	/* preserve payload prior to free xgq_cmd_cq */
+	memcpy(&xgq_cmd->xgq_cmd_cq_payload, &cmd_cq->default_payload,
+		sizeof(cmd_cq->default_payload));
 
 	complete(&xgq_cmd->xgq_cmd_complete);
 }
@@ -842,7 +837,7 @@ static uint32_t xgq_clock_get_data(struct xocl_xgq *xgq,
 	}
 
 	memset(cmd, 0, sizeof(*cmd));
-	cmd->xgq_cmd_cb = xgq_complete_clock_cb;
+	cmd->xgq_cmd_cb = xgq_complete_cb;
 	cmd->xgq_cmd_arg = cmd;
 	cmd->xgq = xgq;
 
@@ -885,7 +880,7 @@ static uint32_t xgq_clock_get_data(struct xocl_xgq *xgq,
 		ret = 0;
 	} else {
 		/* freq result is in rdata */
-		ret = cmd->xgq_cmd_rdata;
+		ret = ((struct xgq_cmd_cq_clock_payload *)&cmd->xgq_cmd_cq_payload)->ocl_freq;
 	}
 
 done:
@@ -969,10 +964,20 @@ static int xgq_download_apu_firmware(struct platform_device *pdev)
 	return ret;
 }
 
-static int vmr_enable_multiboot(struct platform_device *pdev)
+static void vmr_collect_boot_query(struct xocl_xgq *xgq, struct xocl_xgq_cmd *cmd)
+{
+	struct xgq_cmd_cq_multiboot_payload *payload =
+		(struct xgq_cmd_cq_multiboot_payload *)&cmd->xgq_cmd_cq_payload;
+
+	memcpy(&xgq->xgq_mb_payload, payload, sizeof(*payload));
+}
+
+static int vmr_multiboot_op(struct platform_device *pdev,
+	enum xgq_cmd_multiboot_req_type req_type)
 {
 	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
 	struct xocl_xgq_cmd *cmd = NULL;
+	struct xgq_cmd_multiboot_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
 	int id = 0;
@@ -988,11 +993,13 @@ static int vmr_enable_multiboot(struct platform_device *pdev)
 	cmd->xgq_cmd_arg = cmd;
 	cmd->xgq = xgq;
 
-	/* no payload for this cmd */
+	payload = &(cmd->xgq_cmd_entry.multiboot_payload);
+	payload->req_type = req_type;
+
 	hdr = &(cmd->xgq_cmd_entry.hdr);
 	hdr->opcode = XGQ_CMD_OP_MULTIPLE_BOOT;
 	hdr->state = XGQ_SQ_CMD_NEW;
-	hdr->count = 0;
+	hdr->count = sizeof(*payload);
 	id = get_xgq_cid(xgq);
 	if (id < 0) {
 		XGQ_ERR(xgq, "alloc cid failed: %d", id);
@@ -1017,9 +1024,12 @@ static int vmr_enable_multiboot(struct platform_device *pdev)
 
 	ret = cmd->xgq_cmd_rcode;
 
-	if (ret)
+	if (ret) {
 		XGQ_ERR(xgq, "Multiboot or reset might not work. ret %d",
 			cmd->xgq_cmd_rcode);
+	} else if (req_type == XGQ_CMD_BOOT_QUERY) {
+		vmr_collect_boot_query(xgq, cmd);
+	}
 
 done:
 	if (cmd) {
@@ -1028,6 +1038,19 @@ done:
 	}
 
 	return ret;
+}
+
+static int vmr_fpt_query(struct platform_device *pdev)
+{
+	return vmr_multiboot_op(pdev, XGQ_CMD_BOOT_QUERY);
+}
+
+static int vmr_enable_multiboot(struct platform_device *pdev)
+{
+	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+
+	return vmr_multiboot_op(pdev,
+		xgq->xgq_boot_from_backup ?  XGQ_CMD_BOOT_BACKUP : XGQ_CMD_BOOT_DEFAULT);
 }
 
 static int xgq_collect_sensor_data(struct xocl_xgq *xgq)
@@ -1103,6 +1126,37 @@ done:
 }
 
 /* sysfs */
+static ssize_t boot_from_backup_store(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	u32 val = 0;
+
+	if (kstrtou32(buf, 10, &val) == -EINVAL)
+		return -EINVAL;
+
+	mutex_lock(&xgq->xgq_lock);
+	xgq->xgq_boot_from_backup = val ? true : false;
+	mutex_unlock(&xgq->xgq_lock);
+
+	return count;
+}
+
+static ssize_t boot_from_backup_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	ssize_t cnt = 0;
+
+	mutex_lock(&xgq->xgq_lock);
+	cnt += sprintf(buf + cnt, "%d\n", xgq->xgq_boot_from_backup);
+	mutex_unlock(&xgq->xgq_lock);
+
+	return cnt;
+}
+static DEVICE_ATTR(boot_from_backup, 0644, boot_from_backup_show, boot_from_backup_store);
+
+
 static ssize_t polling_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
@@ -1133,8 +1187,38 @@ static ssize_t polling_show(struct device *dev,
 }
 static DEVICE_ATTR(polling, 0644, polling_show, polling_store);
 
+static ssize_t boot_status_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	ssize_t cnt = 0;
+
+	/* update boot status */
+	vmr_fpt_query(xgq->xgq_pdev);
+
+	mutex_lock(&xgq->xgq_lock);
+	cnt += sprintf(buf + cnt, "HAS_FPT:%d\n",
+		xgq->xgq_mb_payload.has_fpt);
+	cnt += sprintf(buf + cnt, "HAS_FPT_RECOVERY:%d\n",
+		xgq->xgq_mb_payload.has_fpt_recovery);
+	cnt += sprintf(buf + cnt, "BOOT_ON_DEFAULT:%d\n",
+		xgq->xgq_mb_payload.boot_on_default);
+	cnt += sprintf(buf + cnt, "BOOT_ON_BACKUP:%d\n",
+		xgq->xgq_mb_payload.boot_on_backup);
+	cnt += sprintf(buf + cnt, "BOOT_ON_RECOVERY:%d\n",
+		xgq->xgq_mb_payload.boot_on_recovery);
+	cnt += sprintf(buf + cnt, "MULTI_BOOT_OFFSET:0x%x\n",
+		xgq->xgq_mb_payload.multi_boot_offset);
+	mutex_unlock(&xgq->xgq_lock);
+
+	return cnt;
+}
+static DEVICE_ATTR_RO(boot_status);
+
 static struct attribute *xgq_attrs[] = {
 	&dev_attr_polling.attr,
+	&dev_attr_boot_from_backup.attr,
+	&dev_attr_boot_status.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2160,7 +2160,7 @@ struct xocl_xgq_funcs {
 #define	xocl_download_apu_firmware(xdev) 			\
 	(XGQ_CB(xdev, xgq_download_apu_firmware) ?		\
 	XGQ_OPS(xdev)->xgq_download_apu_firmware(XGQ_DEV(xdev)) : -ENODEV)
-#define	xocl_vmr_enable_multiboot(xdev) 				\
+#define	xocl_vmr_enable_multiboot(xdev) 			\
 	(XGQ_CB(xdev, vmr_enable_multiboot) ?			\
 	XGQ_OPS(xdev)->vmr_enable_multiboot(XGQ_DEV(xdev)) : -ENODEV)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
enable A/B boot functionality

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
1) provide sysfs node to enable/disable boot from backup and flush default only
2) provide sysfs node to check boot configuration, A boot, B boot, partition table statistics
3) enhance xbutil reset and driver load procedure to config to A boot or B boot

#### Risks (if any) associated the changes in the commit
N/A

#### What has been tested and how, request additional testing if necessary
Tested on TA shell

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-Overview