### PR TITLE
Add drc to skip if xclbin is not found

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -244,10 +244,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
 
   //check if xclbin is present
   if(xclbinPath.empty() || !boost::filesystem::exists(xclbinPath)) {
-    if(xclbin.compare("bandwidth.xclbin") == 0) {
-      //if an xclbin isn't present, skip the test
-      _ptTest.put("status", "skipped");
-    }
+    _ptTest.put("status", "skipped");
     return;
   }
   // log xclbin path for debugging purposes

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -243,7 +243,7 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
   }
 
   //check if xclbin is present
-  if(xclbinPath.empty()) {
+  if(xclbinPath.empty() || !boost::filesystem::exists(xclbinPath)) {
     if(xclbin.compare("bandwidth.xclbin") == 0) {
       //if an xclbin isn't present, skip the test
       _ptTest.put("status", "skipped");


### PR DESCRIPTION
Missed a drc check to make sure that the xclbin path is valid

Sample output:
```
$ ./xbutil2_static validate -d -p test-xclbins/ -r "Bandwidth kernel" --verbose
Verbose: Enabling Verbosity
Verbose: Sub command: --path
Starting validation for 1 devices

Validate Device           : [0000:85:00.0]
    Platform              : xilinx_aws-vu9p-f1_dynamic-shell
    SC Version            : N/A
    Platform ID           : 0xabcd
-------------------------------------------------------------------------------
Test 1 [0000:85:00.0]     : Bandwidth kernel 
    Description           : Run 'bandwidth kernel' and check the throughput
    Test Status           : [SKIPPED]
-------------------------------------------------------------------------------
Validation completed
```