### PR TITLE
CR-1117926 'bo(xrt::device&, size_t&, int)' is ambiguous

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -185,8 +185,8 @@ public:
     size = prop.size;
   }
 
-  bo_impl(xclDeviceHandle dhdl, pid_t pid, xclBufferExportHandle ehdl)
-    : device(xrt_core::get_userpf_device(dhdl)), handle(device->import_bo(pid, ehdl)), free_bo(true)
+  bo_impl(xclDeviceHandle dhdl, pid_type pid, xclBufferExportHandle ehdl)
+    : device(xrt_core::get_userpf_device(dhdl)), handle(device->import_bo(pid.pid, ehdl)), free_bo(true)
   {
     xclBOProperties prop{};
     device->get_bo_properties(handle, &prop);
@@ -504,7 +504,7 @@ public:
   //
   // This consrructor works on linux only and require pidfd support in
   // linux kernel.
-  buffer_import(xclDeviceHandle dhdl, pid_t pid, xclBufferExportHandle ehdl)
+  buffer_import(xclDeviceHandle dhdl, pid_type pid, xclBufferExportHandle ehdl)
     : bo_impl(dhdl, pid, ehdl)
   {
     try {
@@ -859,7 +859,7 @@ alloc_import(xclDeviceHandle dhdl, xclBufferExportHandle ehdl)
 }
 
 static std::shared_ptr<xrt::bo_impl>
-alloc_import_from_pid(xclDeviceHandle dhdl, pid_t pid, xclBufferExportHandle ehdl)
+alloc_import_from_pid(xclDeviceHandle dhdl, xrt::pid_type pid, xclBufferExportHandle ehdl)
 {
   return std::make_shared<xrt::buffer_import>(dhdl, pid, ehdl);
 }
@@ -990,7 +990,7 @@ bo(xclDeviceHandle dhdl, xclBufferExportHandle ehdl)
 {}
 
 bo::
-bo(xclDeviceHandle dhdl, pid_t pid, xclBufferExportHandle ehdl)
+bo(xclDeviceHandle dhdl, pid_type pid, xclBufferExportHandle ehdl)
   : handle(xdp::native::profiling_wrapper("xrt::bo::bo",
             alloc_import_from_pid, dhdl, pid , ehdl))
 {}

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -52,12 +52,19 @@ typedef uint32_t xrtMemoryGroup;
  * Use when constructing xrt::bo from xclBufferHandle
  */
 struct xcl_buffer_handle { xclBufferHandle bhdl; };
-  
+
 #ifdef __cplusplus
 
 namespace xrt {
 
 using memory_group = xrtMemoryGroup;
+
+/**
+ * Typed pid_t used to prevent ambiguity when contructing
+ * bo with a process id.  
+ * Use xrt::bo bo{..., pid_type{pid}, ...};
+ */  
+struct pid_type { pid_t pid; };
 
 class bo_impl;
 class bo
@@ -91,7 +98,7 @@ public:
     p2p         = XRT_BO_FLAGS_P2P,
     svm         = XRT_BO_FLAGS_SVM,
   };
-  
+
   /**
    * bo() - Constructor for empty bo
    */
@@ -217,7 +224,7 @@ public:
    * mode PTRACE_MODE_ATTACH_REALCREDS check (see ptrace(2)).
    */
   XCL_DRIVER_DLLESPEC
-  bo(xclDeviceHandle dhdl, pid_t pid, xclBufferExportHandle ehdl);
+  bo(xclDeviceHandle dhdl, pid_type pid, xclBufferExportHandle ehdl);
 
   /**
    * bo() - Constructor for sub-buffer

--- a/tests/xrt/import_bo/import.cpp
+++ b/tests/xrt/import_bo/import.cpp
@@ -66,7 +66,7 @@ child(const std::string& device_id, pid_t pid)
   std::cout << "child fd: " << fd << '\n';
   
   xrt::device device{device_id};
-  xrt::bo bo{device, pid, fd};
+  xrt::bo bo{device, xrt::pid_type{pid}, fd};
 
   try {
     auto bo_data = bo.map<char*>();


### PR DESCRIPTION
#### Problem solved by the commit
Fix regression from #6062 with xrt::bo constructor ambiguity.
This PR works around misuse of primitive types in class constructor.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug is during host code compilation only.
Discovered during sprite testing.  A mystery how #6062 slipped through pipeline 
where host code exposing the ambiguity is supposedly compiled.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Provide type to represent the ambiguous argument primitive type

#### Risks (if any) associated the changes in the commit
Code is a new feature, which is currently unused.  Provided the ambiguity which slipped through #6062 has been fixed, there are not other risks.
