### PR TITLE
User managed interrupt: decrement on each poll

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -725,10 +725,15 @@ static __poll_t kds_ucu_poll(struct file *filp, poll_table *wait)
 	__poll_t ret = 0;
 #endif
 	struct xrt_cu *xcu = filp->private_data;
+	s32 events = 0;
+
+	events = atomic_dec_if_positive(&xcu->ucu_event);
+	if (events >= 0)
+		ret = POLLIN;
 
 	poll_wait(filp, &xcu->ucu_waitq, wait);
-
-	if (atomic_read(&xcu->ucu_event) > 0)
+	events = atomic_dec_if_positive(&xcu->ucu_event);
+	if (events >= 0)
 		ret = POLLIN;
 
 	return ret;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On poll num of events was not decremented and thus event check was incorrect

#### How problem was solved, alternative solutions (if any) and why they were rejected
ucu_event is decremented on each poll execution and thus will always have correct value on each poll call

#### What has been tested and how, request additional testing if necessary
Tested locally
