### PR TITLE
User managed interrupt: add check on number of interrupt

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1012,9 +1012,12 @@ void
 device_linux::
 wait_ip_interrupt(xclInterruptNotifyHandle handle)
 {
-  int pending = 0;
+  int num_interrupts = 0;
   if (::read(handle, &pending, sizeof(pending)) == -1)
     throw error(errno, "wait_ip_interrupt failed POSIX read");
+
+  if (num_interrupts > 1)
+    xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", "More than one interrupt was received");
 }
 
 xclBufferHandle

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1013,7 +1013,7 @@ device_linux::
 wait_ip_interrupt(xclInterruptNotifyHandle handle)
 {
   int num_interrupts = 0;
-  if (::read(handle, &pending, sizeof(pending)) == -1)
+  if (::read(handle, &num_interrupts, sizeof(num_interrupts)) == -1)
     throw error(errno, "wait_ip_interrupt failed POSIX read");
 
   if (num_interrupts > 1)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
None. Warning added for number of interrupts. Usual behavior expects only one interrupt

#### How problem was solved, alternative solutions (if any) and why they were rejected
New check added

#### Documentation impact (if any)
None