### PR TITLE
CR-1052320 ASTeR xbutil2 - installed and running CMC version is not printed out

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -139,11 +139,22 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
     sc.add("expected_version", xrt_core::device_query<xq::expected_sc_version>(device));
     ptree_type cmc;
 
+    /*
+     * The card managment controller (CMC) version number is formatted where the bottom three bytes contain
+     * the Major, Minor, and Version values respectively.
+     * Ex:
+     * CMC version = 010203
+     * This implies
+     * 01 -> Major Number
+     * 02 -> Minor Number
+     * 03 -> Version Number
+     * Output = 1.2.3
+     */
     uint64_t versionValue = std::stoull(xrt_core::device_query<xq::xmc_version>(device), nullptr, 10);
     std::string version = boost::str(boost::format("%u.%u.%u")
-                          % ((versionValue >> (2 * 8)) & 0xFF)
-                          % ((versionValue >> (1 * 8)) & 0xFF)
-                          % ((versionValue >> (0 * 8)) & 0xFF));
+                          % ((versionValue >> (2 * 8)) & 0xFF) // Major
+                          % ((versionValue >> (1 * 8)) & 0xFF) // Minor
+                          % ((versionValue >> (0 * 8)) & 0xFF)); // Version
     cmc.add("version", version);
     cmc.add("serial_number", xrt_core::device_query<xq::xmc_serial_num>(device));
     cmc.add("oem_id", xq::oem_id::parse(xrt_core::device_query<xq::oem_id>(device)));

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -138,13 +138,13 @@ add_controller_info(const xrt_core::device* device, ptree_type& pt)
     sc.add("version", xrt_core::device_query<xq::xmc_sc_version>(device));
     sc.add("expected_version", xrt_core::device_query<xq::expected_sc_version>(device));
     ptree_type cmc;
-    std::stringstream version;
 
-    try {
-       version << "0x" << std::hex << std::stoi(xrt_core::device_query<xq::xmc_version>(device));
-    }
-    catch (...) {}
-    cmc.add("version", version.str());
+    uint64_t versionValue = std::stoull(xrt_core::device_query<xq::xmc_version>(device), nullptr, 10);
+    std::string version = boost::str(boost::format("%u.%u.%u")
+                          % ((versionValue >> (2 * 8)) & 0xFF)
+                          % ((versionValue >> (1 * 8)) & 0xFF)
+                          % ((versionValue >> (0 * 8)) & 0xFF));
+    cmc.add("version", version);
     cmc.add("serial_number", xrt_core::device_query<xq::xmc_serial_num>(device));
     cmc.add("oem_id", xq::oem_id::parse(xrt_core::device_query<xq::oem_id>(device)));
     controller.put_child("satellite_controller", sc);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
There is no XRT commands that print this out, we need an easier way of checking the version.

It would be best to add this to the "xbmgmt flash --scan" print out per card in the same fashion as the SC FW

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The details were printed out in xbutil2 examine, but needed to formatted in a more readable manner

#### How problem was solved, alternative solutions (if any) and why they were rejected
Formatted the displayed card management controller version in the json report to Major.Minor.Version

To do this you need to covert the decimal to hex
201393164 -> C01 040C

Then convert each byte to decimal , the bottom 3 are all that is needed
01 -> 1
04 -> 4
0C -> 12

then put this together to have 1.4.12

#### Risks (if any) associated the changes in the commit
It may be better to change how the CMC version value is stored in the first place. It could be formatted in the desired format similar to the SC version number.

#### What has been tested and how, request additional testing if necessary
Manual testing:
```
dbenusov@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r platform -d 18:00 -f json -o x.json --force

----------------------------------------------
1/1 [0000:18:00.1] : xilinx_u30_gen3x4_base_2
----------------------------------------------
Platform
  XSA Name               : xilinx_u30_gen3x4_base_2
  Platform UUID          : 6E7C97F7-949F-5106-3075-A77784C30A4B
  FPGA Name              :
  JTAG ID Code           : 0x14a5c093
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : not supported

Successfully wrote the json file: x.json
```
x.json:
```
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Mon Dec 20 20:26:01 2021 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:18:00.1",
            "platforms": [
                {
                    "static_region": {
                        "vbnv": "xilinx_u30_gen3x4_base_2",
                        "logic_uuid": "6E7C97F7-949F-5106-3075-A77784C30A4B",
                        "jtag_idcode": "0x14a5c093",
                        "fpga_name": ""
                    },
                    "off_chip_board_info": {
                        "ddr_size_bytes": "0",
                        "ddr_count": "0"
                    },
                    "status": {
                        "mig_calibrated": "true",
                        "p2p_status": "not supported"
                    },
                    "controller": {
                        "satellite_controller": {
                            "version": "6.3.9",
                            "expected_version": "6.3.9"
                        },
                        "card_mgmt_controller": {
                            "version": "1.4.12",
                            "serial_number": "XFL1XGHL3NNO",
                            "oem_id": "Xilinx"
                        }
                    },
                    "macs": ""
                }
            ]
        }
    ]
}
```
