### PR TITLE
Vitis-3888 Automatic buffer migration using M2M

### DIFF
--- a/src/runtime_src/core/common/api/bo.h
+++ b/src/runtime_src/core/common/api/bo.h
@@ -19,50 +19,33 @@
 #define _XRT_COMMON_BO_H_
 
 // This file defines implementation extensions to the XRT BO APIs.
-#include "core/include/experimental/xrt_bo.h"
+#include "core/include/xrt/xrt_bo.h"
 #include "core/common/config.h"
 #include "core/include/ert.h"
 
 namespace xrt_core { namespace bo {
 
-/**
- * address() - Get physical device address of BO
- *
- * @handle:        Buffer handle
- * Return:         Device address of BO
- */
+// address() - Get physical device address of argument bo
 uint64_t
 address(const xrt::bo& bo);
 uint64_t
 address(xrtBufferHandle handle);
 
-/**
- * group_id() - Get the memory bank index of BO
- *
- * @bo:       Buffer object
- * Return:    Memory bank index where BO is allocated
- */
+// group_id() - Get memory bank index of argument bo
 int32_t
 group_id(const xrt::bo& bo);
 
-/**
- * device_handle() - Get device handle from BO
- *
- * @bo:       Buffer object
- * Return:    Device handle
- */
-//NOTE: will remove this function after migration of xclDeviceHandle to xrt::device in XMA codebase.
+// xcl_device_handle() - Get xcl device handle from BO 
 xclDeviceHandle
 device_handle(const xrt::bo& bo);
 
-/**
- * get_flags() - Get flag from BO
- *
- * @bo:       Buffer object
- * Return:    flag
- */
+// get_flags() - Get the flags used when BO was created
 xrt::bo::flags 
 get_flags(const xrt::bo& bo);
+
+// clone() - Clone src bo into target memory bank
+xrt::bo
+clone(const xrt::bo& src, xrt::memory_group target_grp);
 
 // Fill the ERT copy BO command packet
 XRT_CORE_COMMON_EXPORT

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -506,6 +506,10 @@ public:
   // Throws if argument handle is not from xrtBOAlloc variant
   XCL_DRIVER_DLLESPEC
   bo(xrtBufferHandle);
+
+  bo(std::shared_ptr<bo_impl> impl)
+    : handle(std::move(impl))
+  {}
   /// @endcond
 private:
   std::shared_ptr<bo_impl> handle;

--- a/tests/xrt/m2m_arg/ksrc/krnl_vadd.cpp
+++ b/tests/xrt/m2m_arg/ksrc/krnl_vadd.cpp
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+extern "C" {
+
+void
+krnl_vadd(const int* in1, const int* in2, const int* in3, int* out, int size)
+{
+  for (int i = 0; i < size; i++) {
+    out[i] = in1[i] + in2[i] + in3[i];
+  }
+}
+                  
+}

--- a/tests/xrt/m2m_arg/ksrc/krnl_vadd_factor.cpp
+++ b/tests/xrt/m2m_arg/ksrc/krnl_vadd_factor.cpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+extern "C" {
+
+void
+krnl_vadd_factor(const int *in, int factor, int* out, int size)
+{
+  for (int i = 0; i < size; i++) {
+    out[i] = in[i] + factor;
+  }
+}
+
+}

--- a/tests/xrt/m2m_arg/ksrc/krnl_vmult_factor.cpp
+++ b/tests/xrt/m2m_arg/ksrc/krnl_vmult_factor.cpp
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+extern "C" {
+
+void
+krnl_vmult_factor(const int *in, int factor, int* out, int size)
+{
+  for (int i = 0; i < size; i++) {
+    out[i] = in[i] * factor;
+  }
+}
+
+}

--- a/tests/xrt/m2m_arg/ksrc/vitis_link.cfg
+++ b/tests/xrt/m2m_arg/ksrc/vitis_link.cfg
@@ -1,0 +1,4 @@
+[connectivity]
+sp=krnl_vmult_factor_1.in:DDR[0]
+sp=krnl_vadd_factor_1.in:DDR[1]
+sp=krnl_vadd_1.in1:DDR[2]

--- a/tests/xrt/m2m_arg/main.cpp
+++ b/tests/xrt/m2m_arg/main.cpp
@@ -1,0 +1,230 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/****************************************************************
+This test illustrates m2m copying to local buffer object of
+incompatible kernel arguments.
+
+The test consists of 3 kernels
+
+1) vmult_factor(const int in*, factor, int* out, size): 
+Multiply each element in a vector with a constant factor
+All arguments are allocated in DDR bank0
+
+2) vadd_factor(const int in*, factor, int* out, size):
+Add each element in a vector with a constant factor
+All arguments are allocated in DDR bank1
+
+3) vadd(const int* in1, const int* in2, const int* in3, int* out, size):
+Add 3 input vectors 
+All arguments are allocated in DDR bank2
+
+       _____________
+      |vaddf: bank1 |<----- in   (global memory)
+      | in[] + add  |<----- add  (scalar)
+      |_____________|-----> ovaf (global memory)
+       _____________ 
+      |vmultf: bank0|<----- in   (global memory)
+      | in[] * mult |<----- mult (scalar)
+      |_____________|-----> ovmf (global memory)
+
+      wait();
+       _____________  
+      |vadd: bank2  |<----- in   (global memory)
+      |             |<----- ovaf (global memory)
+      | in1+in2+in3 |<----- ovmf (global memory)
+      |_____________|-----> out  (global memory)
+
+The test allocates one buffer for the vector input 'in' to vaddf,
+vmultf, and vadd.  The buffer object for input is created in bank
+compatibile with the connectivity of 'vadd'.
+
+in, out: bank2
+ovaf: bank1
+ovmf: bank0
+
+Since 'in' is incompatible with vaddf and vmultf two local buffers
+(one for each of these kernels) are created when 'in' is set as 
+argument to these two kernels.
+
+Since 'ovaf' is incompatible with vadd, a local buffer is created 
+for the this input when set on vadd.  Ditto for ovmf.
+
+In all 4 local buffers are created.  If the device supports m2m
+then the local buffers will copy the DDR content of the src buffer.
+****************************************************************/
+
+// % g++ -g -std=c++14 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o m2marg.exe main.cpp -lxrt_coreutil -luuid -pthread
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_kernel.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+# pragma warning( disable : 4996 )
+#endif
+
+static size_t data_size = 4096;
+static size_t data_size_bytes = data_size * sizeof(int);
+
+static void usage()
+{
+  std::cout << "usage: %s [options] \n\n";
+  std::cout << "  -k <bitstream>\n";
+  std::cout << "  -d <bdf | device_index>\n";
+  std::cout << "";
+}
+
+static bool
+is_hw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool hwem = xem ? std::strcmp(xem,"hw_emu")==0 : false;
+  return hwem;
+}
+
+static bool
+is_sw_emulation()
+{
+  static auto xem = std::getenv("XCL_EMULATION_MODE");
+  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
+  return swem;
+}
+
+static void
+adjust_for_emulation()
+{
+  if (!is_hw_emulation() && !is_sw_emulation())
+    return;
+
+  data_size = 128;
+  data_size_bytes = data_size * sizeof(int);
+}
+
+static void
+run(const xrt::device& device, const xrt::uuid& uuid)
+{
+  // vmf(in1, factor, out, data_size)
+  // out[] = in1[] * factor
+  xrt::kernel vmf(device, uuid, "krnl_vmult_factor");
+
+  // vaf(in1, factor, out, data_size)
+  // out[] = in1[] + factor
+  xrt::kernel vaf(device, uuid, "krnl_vadd_factor");
+
+  // vadd(in1, in2, in3, out, data_size)
+  // out[] = in1[] + in2[] + in3[]
+  xrt::kernel vadd(device, uuid, "krnl_vadd");
+
+  // const data input, first input to all 3 kernels, allocated
+  // compatible with vadd kernel
+  xrt::bo in(device, data_size_bytes, vadd.group_id(0));
+  auto in_data = in.map<int*>();
+  std::iota(in_data, in_data + data_size, 0);
+  in.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  // output of vmf, will be used as input to incompatible vadd kernel
+  xrt::bo vmf_out(device, data_size_bytes, vmf.group_id(2));
+  auto vmf_out_data = vmf_out.map<int*>();
+
+  // output of vaf, will be used as input to incompatible vadd kernel
+  xrt::bo vaf_out(device, data_size_bytes, vaf.group_id(2));
+  auto vaf_out_data = vaf_out.map<int*>();
+
+  // output of vadd
+  xrt::bo out(device, data_size_bytes, vadd.group_id(3));
+  auto out_data = out.map<int*>();
+  std::fill(out_data, out_data + data_size, 0);
+  out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  // start vaf and vmf and wait for completion
+  // both these calls will allocated local compatible copies
+  // of the input vector
+  auto run_vmf = vmf(in, 2, vmf_out, data_size);
+  auto run_vaf = vaf(in, 1, vaf_out, data_size);
+  run_vmf.wait();
+  run_vaf.wait();
+
+  // start vadd and wait()
+  // local copies of both vmf_out and vaf_out will be created
+  auto run = vadd(in, vmf_out, vaf_out, out, data_size);
+  run.wait();
+
+  // sync output of vadd to host
+  out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  // compare with expected scalar adder
+  for (size_t i = 0 ; i < data_size; i++) {
+    auto expected = in_data[i] * 2 + in_data[i] + 1 + in_data[i];
+    if (out_data[i] != expected) {
+      std::cout << " expected output[" << i << "] = " << expected
+                << " observed output[" << i << "] = " << out_data[i]
+                << '\n';
+      throw std::runtime_error("result mismatch");
+    }
+  }
+}
+
+static void
+run(int argc, char** argv)
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+
+  std::string xclbin_fnm;
+  std::string device_id = "0";
+
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "-d")
+      device_id = arg;
+    else if (cur == "-k")
+      xclbin_fnm = arg;
+    else
+      throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
+  }
+
+  adjust_for_emulation();
+
+  xrt::xclbin xclbin{xclbin_fnm};
+  xrt::device device{device_id};
+  auto uuid = device.load_xclbin(xclbin);
+
+  run(device, uuid);
+}
+
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    run(argc,argv);
+    std::cout << "TEST PASSED\n";
+    return 0;
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}

--- a/tests/xrt/m2m_arg/xclbin.mk
+++ b/tests/xrt/m2m_arg/xclbin.mk
@@ -1,0 +1,46 @@
+# % source <Vitis>/settings64.sh
+
+# HW:
+# % make -f xclbin.mk XSA=... xclbin
+#
+# HW_EMU
+# % make -f xclbin.mk MODE=hw_emu XSA=... xclbin
+# % make -f xclbin.mk MODE=hw_emu XSA=... emconfig
+VPP := $(XILINX_VITIS)/bin/v++
+EMCONFIGUTIL := $(XILINX_VITIS)/bin/emconfigutil
+MODE := hw
+XSA := $(XPFM_FILE_PATH)
+VPPFLAGS := 
+
+KBLDDIR := $(MODE)/$(basename $(notdir $(XSA)))
+KSRCDIR := ksrc
+KERNEL_SRC := $(wildcard $(KSRCDIR)/*.cpp)
+KERNEL_XO := $(addprefix $(KBLDDIR)/, $(notdir $(addsuffix .xo,$(basename $(KERNEL_SRC)))))
+KERNEL_XCLBIN := $(KBLDDIR)/kernel.$(MODE).xclbin
+EMCONFIG_FILE := emconfig.json
+
+VPPCFLAGS := -s -t $(MODE) --platform $(XSA) --temp_dir $(KBLDDIR)/_x
+VPPLFLAGS := $(VPPCFLAGS) --config $(KSRCDIR)/vitis_link.cfg
+
+%/.vpp :
+	mkdir -p $(dir $@)
+	touch $@
+
+$(KBLDDIR)/krnl_vmult_factor.xo: $(KSRCDIR)/krnl_vmult_factor.cpp | $(KBLDDIR)/.vpp
+	$(VPP) -c -k krnl_vmult_factor $(VPPCFLAGS) -o $@ $<
+
+$(KBLDDIR)/krnl_vadd_factor.xo: $(KSRCDIR)/krnl_vadd_factor.cpp | $(KBLDDIR)/.vpp
+	$(VPP) -c -k krnl_vadd_factor $(VPPCFLAGS) -o $@ $<
+
+$(KBLDDIR)/krnl_vadd.xo: $(KSRCDIR)/krnl_vadd.cpp | $(KBLDDIR)/.vpp
+	$(VPP) -c -k krnl_vadd $(VPPCFLAGS) -o $@ $<
+
+$(KERNEL_XCLBIN) : $(KERNEL_XO)
+	$(VPP) -l $(VPPLFLAGS) -o $@ $^
+
+$(EMCONFIG_FILE):
+	emconfigutil --platform $(XSA) --nd 1
+
+xclbin : $(KERNEL_XCLBIN)
+
+emconfig: $(EMCONFIG_FILE)


### PR DESCRIPTION
#### Problem solved by the commit
Support automatic local buffer creation to allow read access from
buffers allocated in memory bank that is incompatible with kernel
connectivity.

#### How problem was solved, alternative solutions (if any) and why they were rejected
When global buffer is used as argument to kernel, a connectivity check
ensures that the global buffer is compatible with the kernel.  With
this PR an incompatible global buffer is cloned with same properties
as original but allocated in the bank that is compatible with the
kernel.

The local buffer is associated with the original global buffer from a
lifetime point of view, but there is no data integrity management
between the clone and its source, meaning that once cloned any changes
to the source buffer are not reflected in clones if any.

Most practical use of this new cloning feature is when using outputs of
one kernel as input to some other kernel.  The cloning (if necessary)
is expensive as it involves DMA of all source data to the clone.


#### What has been tested and how, request additional testing if necessary
A simple illustrative example exercising the feature has been added to
the XRT native API tests.

#### Documentation impact (if any)
@uday610, not sure how we want to document this feature?
