### PR TITLE
building zocl before xrt sothat RPM names are consistent

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -289,10 +289,10 @@ if [[ $full == 1 ]]; then
   $PETA_BIN/petalinux-build
 else
 #Run just xrt build if -full option is not provided
-  echo "[CMD]: petalinux-build -c xrt"
-  $PETA_BIN/petalinux-build -c xrt
   echo "[CMD]: petalinux-build -c zocl"
   $PETA_BIN/petalinux-build -c zocl
+  echo "[CMD]: petalinux-build -c xrt"
+  $PETA_BIN/petalinux-build -c xrt
 fi
 
 if [ $? != 0 ]; then


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT has dependency on zocl. whenver XRT is being compiled, zocl is also compiled but rpms are not getting released. So, we are building zocl seperately. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Petalinux/Yocto issue

#### How problem was solved, alternative solutions (if any) and why they were rejected
building zocl seperately first

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
all edge cases

#### Documentation impact (if any)
