### PR TITLE
Fix compile error in XlcBin::setKeyValue by converting keyvalue to reference

### DIFF
--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1585,7 +1585,7 @@ XclBin::setKeyValue(const std::string& _keyValue)
 
     // Now create a new tree to add back into the section
     boost::property_tree::ptree ptKeyValuesNew;
-    for (const auto keyvalue : keyValues) {
+    for (const auto &keyvalue : keyValues) {
       ptKeyValuesNew.push_back(std::make_pair("", keyvalue));
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The PR fixes compilation with GCC 11.2.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
On Debian testing, compilation with GCC 11.2 fails with
```
/home/vk/src/x/XRT.fail/src/runtime_src/tools/xclbinutil/XclBinClass.cxx: In member function ‘void XclBin::setKeyValue(const string&)’:
/home/vk/src/x/XRT.fail/src/runtime_src/tools/xclbinutil/XclBinClass.cxx:1588:21: error: loop variable ‘keyvalue’ creates a copy from type ‘const boost::property_tree::basic_ptree<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >’ [-Werror=range-loop-construct]
 1588 |     for (const auto keyvalue : keyValues) {
      |                     ^~~~~~~~
/home/vk/src/x/XRT.fail/src/runtime_src/tools/xclbinutil/XclBinClass.cxx:1588:21: note: use reference type to prevent copying
 1588 |     for (const auto keyvalue : keyValues) {
      |                     ^~~~~~~~
      |                     &
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
A reference was added as per the GCC hint.

#### Risks (if any) associated the changes in the commit
Possible incompatibility with earlier versions of GCC.

#### What has been tested and how, request additional testing if necessary
Only GCC 11.2 was tested. The PR should be tested against earlier versions of GCC to confirm it doesn't break those.

#### Documentation impact (if any)
None.