### PR TITLE
Fixing regressions caused by xgq ert change

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1553,7 +1553,7 @@ int kds_ip_layout2cu_info(struct ip_layout *ip_layout, struct xrt_cu_info cu_inf
 		 */
 
 		/* Insertion sort */
-		for (j = i; j >= 0; j--) {
+		for (j = num_cus; j >= 0; j--) {
 			struct xrt_cu_info *prev_info;
 
 			if (j == 0) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Cu indexes are not being calculated properly in ZOCL with new XGQ ERT changes (common KDS code)

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/commit/db14fd12e65459a30914bfbba4e8457a12c96ee8

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated code in ZOCL also. Also fixed another issue in insertion sort.

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
All edge pipeline test cases 

#### Documentation impact (if any)
