### PR TITLE
Goto considered harmful

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -483,7 +483,7 @@ static int hwmon_sdm_probe(struct platform_device *pdev)
 	xocl_info(&pdev->dev, "hwmon_sdm driver probe is successful");
 	return 0;
 
-goto failed:
+failed:
 	hwmon_sdm_remove(pdev);
 	return err;
 }


### PR DESCRIPTION
Do not use goto to define labels.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Try to have XRT compiling on my machine.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

I had the bad idea of trying to install the latest XRT

#### How problem was solved, alternative solutions (if any) and why they were rejected

Reading /var/lib/dkms/xrt/2.13.0/build/make.log

#### Risks (if any) associated the changes in the commit

The risk is to have XRT working again and thus needing to answer a lot of questions from customers :-)
 
#### What has been tested and how, request additional testing if necessary

The testing infrastructure is clearly broken.

#### Documentation impact (if any)


All this reminds me https://www.explainxkcd.com/wiki/index.php/292:_goto and made me laugh quite a lot.
I never understood it was bad to the point of this creative XRT sense. ;-)