### PR TITLE
fixed xocl DKMS compilation issues

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -483,7 +483,7 @@ static int hwmon_sdm_probe(struct platform_device *pdev)
 	xocl_info(&pdev->dev, "hwmon_sdm driver probe is successful");
 	return 0;
 
-goto failed:
+failed:
 	hwmon_sdm_remove(pdev);
 	return err;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -569,7 +569,14 @@ void *xocl_drm_init(xdev_handle_t xdev_hdl)
 	}
 	drm_p->xdev = xdev_hdl;
 
+	/*
+	 * The pdev field was removed from drm_device starting from 5.14 and
+	 * should be skipped starting from that version.
+	 * https://github.com/torvalds/linux/commit/b347e04452ff6382ace8fba9c81f5bcb63be17a6
+	 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 14, 0)
 	ddev->pdev = XDEV(xdev_hdl)->pdev;
+#endif
 
 	ret = drm_dev_register(ddev, 0);
 	if (ret) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Linux DKMS driver didn't compile.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
- `goto` in the name of a label
- a field removed in 5.14 was not version-gated

#### How problem was solved, alternative solutions (if any) and why they were rejected
Straightforward fixes.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
DKMS driver is built OK by `sudo dpkg -i xrt_202210.2.13.0_testing-amd64-xrt.deb`

#### Documentation impact (if any)
None.