### PR TITLE
Add drc to skip if xclbin is not found (#6072)

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -243,11 +243,8 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
   }
 
   //check if xclbin is present
-  if(xclbinPath.empty()) {
-    if(xclbin.compare("bandwidth.xclbin") == 0) {
-      //if an xclbin isn't present, skip the test
-      _ptTest.put("status", "skipped");
-    }
+  if(xclbinPath.empty() || !boost::filesystem::exists(xclbinPath)) {
+    _ptTest.put("status", "skipped");
     return;
   }
   // log xclbin path for debugging purposes


### PR DESCRIPTION
* add drc to skip if xclbin is not found

* remove redundant drc check

(cherry picked from commit c440ece357256b30ec05cfb7ecdbab8de1059953)

