### PR TITLE
Add changes to support 5.15 kernel in edge platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -296,3 +296,7 @@ zocl_cu_submit_xcmd(struct drm_zocl_dev *zdev, int i, struct kds_command *xcmd)
 }
 
 #endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+extern const struct drm_gem_object_funcs zocl_gem_object_funcs;
+#endif

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -3371,6 +3371,15 @@ static int watchdog_thread(void *data)
 		 *    we don't need a lock when checking the thread state.
 		 * 2. Other than TASK_DEAD, what else state should be monitor?
 		 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+		if (zdev->exec && zdev->exec->cq_thread &&
+			zdev->exec->cq_thread->__state != TASK_DEAD)
+			cfg.cq_thread_run = true;
+
+		if (g_sched0.sched_thread &&
+			g_sched0.sched_thread->__state != TASK_DEAD)
+			cfg.sched_thread_run = true;
+#else
 		if (zdev->exec && zdev->exec->cq_thread &&
 			zdev->exec->cq_thread->state != TASK_DEAD)
 			cfg.cq_thread_run = true;
@@ -3378,6 +3387,7 @@ static int watchdog_thread(void *data)
 		if (g_sched0.sched_thread &&
 			g_sched0.sched_thread->state != TASK_DEAD)
 			cfg.sched_thread_run = true;
+#endif
 
 		watchdog->ops->config(watchdog, cfg);
 		msleep_interruptible(ZOCL_WATCHDOG_FREQ);


### PR DESCRIPTION
> Petalinux kernel moved to version 5.15, added changes to fix zocl driver compilation with Linux kernel version - 5.15
> Tested by running hello world example in hw_emu using latest kernel(5.15), compatible rootfs and sysroot
> Backward compatibility is maintained