### PR TITLE
Vitis-4095 Add system level APIs

### DIFF
--- a/src/runtime_src/core/common/api/xrt_message.cpp
+++ b/src/runtime_src/core/common/api/xrt_message.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2021 Xilinx, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// This file implements XRT error APIs as declared in
+// core/include/experimental/xrt_message.h
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_ini.h
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "core/include/experimental/xrt_message.h"
+
+#include "core/common/config_reader.h"
+#include "core/common/message.h"
+
+namespace xrt { namespace message {
+
+namespace detail {
+  
+bool
+enabled(level lvl)
+{
+  return xrt_core::config::get_verbosity() >= static_cast<int>(lvl);
+}
+
+} // detail
+
+void
+log(level lvl, const std::string& tag, const std::string& msg)
+{
+  xrt_core::message::send(lvl, tag, msg);
+}
+
+}} // namespace ini,xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_message C API implmentations (xrt_message.h)
+////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/api/xrt_system.cpp
+++ b/src/runtime_src/core/common/api/xrt_system.cpp
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 Xilinx, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+// This file implements XRT error APIs as declared in
+// core/include/experimental/xrt_system.h
+#define XCL_DRIVER_DLL_EXPORT  // exporting xrt_ini.h
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
+#include "core/include/experimental/xrt_system.h"
+
+#include "core/common/system.h"
+
+namespace xrt { namespace system {
+
+unsigned int
+enumerate_devices()
+{
+  return static_cast<unsigned int>(xrt_core::get_total_devices(true/*is_user*/).second);
+}
+
+}} // namespace ini,xrt
+
+////////////////////////////////////////////////////////////////
+// xrt_message C API implmentations (xrt_message.h)
+////////////////////////////////////////////////////////////////

--- a/src/runtime_src/core/common/message.h
+++ b/src/runtime_src/core/common/message.h
@@ -19,25 +19,14 @@
 #include "core/common/config.h"
 #include "core/common/config_reader.h"
 #include "core/include/xrt.h"
+#include "core/include/experimental/xrt_message.h"
 #include <string>
 #include <cstdio>
 #include <vector>
 
 namespace xrt_core { namespace message {
 
-//modeled based on syslog severity.
-enum class severity_level : unsigned short
-{
-  emergency = xrtLogMsgLevel::XRT_EMERGENCY,
-  alert     = xrtLogMsgLevel::XRT_ALERT,
-  critical  = xrtLogMsgLevel::XRT_CRITICAL,
-  error     = xrtLogMsgLevel::XRT_ERROR,
-  warning   = xrtLogMsgLevel::XRT_WARNING,
-  notice    = xrtLogMsgLevel::XRT_NOTICE,
-  info      = xrtLogMsgLevel::XRT_INFO,
-  debug     = xrtLogMsgLevel::XRT_DEBUG
-};
-
+using severity_level = xrt::message::level;
 
 XRT_CORE_COMMON_EXPORT
 void

--- a/src/runtime_src/core/include/experimental/CMakeLists.txt
+++ b/src/runtime_src/core/include/experimental/CMakeLists.txt
@@ -12,9 +12,11 @@ set(XRT_EXPERIMENTAL_HEADER_SRC
   xrt_ini.h
   xrt_ip.h
   xrt_kernel.h
-  xrt_pskernel.h
   xrt_mailbox.h
+  xrt_message.h
   xrt_profile.h
+  xrt_pskernel.h
+  xrt_system.h
   xrt_uuid.h
   xrt_xclbin.h
   xclbin_util.h

--- a/src/runtime_src/core/include/experimental/xrt_message.h
+++ b/src/runtime_src/core/include/experimental/xrt_message.h
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef xrt_message_h_
+#define xrt_message_h_
+
+#include "xrt.h"
+
+#ifdef __cplusplus
+# include <string>
+# include <boost/format.hpp>
+#endif
+
+#ifdef __cplusplus
+
+/*!
+ * @namespace xrt::message
+ *
+ * APIs for XRT messaging.
+ *
+ * XRT internally uses a message system that supports dispatching of
+ * messages to null, console, file, or syslog under different verbosity
+ * levels.  The sink and verbosity level is controlled statically
+ * through ``xrt.ini`` or at run-time using ``xrt::ini``.
+ *
+ * The APIs in this file allow host application to use the same
+ * message dispatch mechanism as XRT is configured to use.
+ */
+namespace xrt { namespace message {
+
+/**
+ * @enum level - verbosity level for messages
+ *
+ * @var emergency
+ * @var alert
+ * @var critical
+ * @var error
+ * @var warning
+ * @var notice
+ * @var info
+ * @var debug
+ */
+enum class level : unsigned short
+{
+  emergency = xrtLogMsgLevel::XRT_EMERGENCY,
+  alert     = xrtLogMsgLevel::XRT_ALERT,
+  critical  = xrtLogMsgLevel::XRT_CRITICAL,
+  error     = xrtLogMsgLevel::XRT_ERROR,
+  warning   = xrtLogMsgLevel::XRT_WARNING,
+  notice    = xrtLogMsgLevel::XRT_NOTICE,
+  info      = xrtLogMsgLevel::XRT_INFO,
+  debug     = xrtLogMsgLevel::XRT_DEBUG
+};
+
+namespace detail {
+
+template <typename ArgType>
+void
+format(boost::format& fmt, ArgType&& arg)
+{
+  return (fmt % std::forward<ArgType>(arg));
+}
+
+template <typename ArgType, typename ...Args>
+void
+format(boost::format& fmt, ArgType&& arg, Args&&... args)
+{
+  fmt % std::forward<ArgType>(arg);
+  return format(fmt, std::forward<Args>(args)...);
+}
+
+// enabled() - check if specified level is enabled
+XCL_DRIVER_DLLESPEC
+bool
+enabled(level lvl);
+  
+} // detail
+
+/**
+ * log() - Dispatch composed log message
+ *
+ * @param lvl
+ *   Severity level, the message is ignored if configured level
+ *   is less than specified level.
+ * @param tag
+ *   The message tag to use.  
+ *  @param msg
+ *   A formatted composed message
+ */
+XCL_DRIVER_DLLESPEC
+void
+log(level lvl, const std::string& tag, const std::string& msg);
+
+/**
+ * log() - Compose and dispatch log message
+ *
+ * @param lvl
+ *   Severity level, the message is ignored if configured level
+ *   is less than specified level.
+ * @param tag
+ *   The message tag to use.  
+ * @param format
+ *   A format string similar to printf or boost::format
+ *  @param args
+ *   Message arguments for the placeholders used in the format string
+ *
+ * This log function uses boost::format to compose the message from 
+ * specified format string and arguments. 
+ */
+template <typename ...Args>
+void
+log(level lvl, const std::string& tag, const char* format, Args&&... args)
+{
+  if (!detail::enabled(lvl))
+    return;
+
+  auto fmt = boost::format(format);
+  detail::format(fmt, std::forward<Args>(args)...);
+  log(lvl, tag, fmt.str());
+}
+
+}}
+
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/core/include/experimental/xrt_system.h
+++ b/src/runtime_src/core/include/experimental/xrt_system.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef xrt_system_h_
+#define xrt_system_h_
+
+#include "xrt.h"
+
+#ifdef __cplusplus
+
+/*!
+ * @namespace xrt::system
+ *
+ * APIs for system level queries and control.
+ */
+namespace xrt { namespace system {
+
+/**
+ * enumerate_devices() - Enumerate devices found in the system
+ *
+ * @return
+     Number of devices in the system recognized by XRT
+ */
+XCL_DRIVER_DLLESPEC
+unsigned int    
+enumerate_devices();
+
+}}
+
+#endif // __cplusplus
+
+#endif

--- a/src/runtime_src/xrt/util/message.h
+++ b/src/runtime_src/xrt/util/message.h
@@ -14,8 +14,8 @@
  * under the License.
  */
 
-#ifndef xrt_message_h_
-#define xrt_message_h_
+#ifndef xrtx_message_h_
+#define xrtx_message_h_
 
 #include "core/common/message.h"
 #include <string>
@@ -27,7 +27,7 @@ using namespace xrt_core::message;
 inline void
 send(severity_level l, const char* msg)
 {
-  send(l,"XRT",msg);
+  xrt_core::message::send(l,"XRT",msg);
 };
 
 inline void


### PR DESCRIPTION
#### Problem solved by the commit
Expose logging and device enumeration APIs through official APIs.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Introduce namespace xrt::message with logging and dispatching APIs.
Introduce namespace xrt::system for system / host level APIs.  In this pull request enumerate_devices is added.

#### Risks (if any) associated the changes in the commit
Low risks as APIs are not used. The PR has some changes to include guard naming and how internal xrt_core message functions are used.

#### What has been tested and how, request additional testing if necessary
Internal testing of the exposed APis.

#### Documentation impact (if any)
Inline code documentation is sufficient for this these simply APIs.
