### PR TITLE
XRT-932/930 enhance logging and forward to uart

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_common.h
+++ b/src/runtime_src/core/include/xgq_cmd_common.h
@@ -89,7 +89,7 @@ enum xgq_cmd_opcode {
 	XGQ_CMD_OP_CLOCK		= 0xb,
 	XGQ_CMD_OP_SENSOR		= 0xc,
 	XGQ_CMD_OP_LOAD_APUBIN		= 0xd,
-	XGQ_CMD_OP_MULTIPLE_BOOT	= 0xe,
+	XGQ_CMD_OP_VMR_CONTROL		= 0xe,
 
 	/* User command type */
 	XGQ_CMD_OP_START_CUIDX	        = 0x100,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2928,7 +2928,8 @@ struct xocl_subdev_map {
 			XOCL_DSAFLAG_VERSAL,				\
 		.subdev_info = RES_USER_VERSAL_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
-		.board_name = "vck5000"					\
+		.board_name = "vck5000",				\
+		.vbnv       = "xilinx_vck5000"				\
 	}
 #define	XOCL_BOARD_VERSAL_MGMT_RAPTOR2					\
 	(struct xocl_board_private){					\
@@ -2938,7 +2939,8 @@ struct xocl_subdev_map {
 		.subdev_info = RES_MGMT_VSEC,				\
 		.subdev_num = ARRAY_SIZE(RES_MGMT_VSEC),		\
 		.flash_type = FLASH_TYPE_OSPI_VERSAL,			\
-		.board_name = "vck5000"					\
+		.board_name = "vck5000",				\
+		.vbnv       = "xilinx_vck5000"				\
 	}
 
 /*********************************VCK190 MGMTPF START*******************/

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3050,7 +3050,7 @@ struct xocl_subdev_map {
 		{					\
 			.start	= 0x0,			\
 			.end	= 0x0,			\
-	 		.name   = NODE_XGQ_PAYLOAD_BASE,\
+	 		.name   = NODE_XGQ_VMR_PAYLOAD_BASE,\
 			.flags  = IORESOURCE_MEM,	\
 		},					\
 	})

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -276,7 +276,7 @@ enum {
 #define	XOCL_ACCEL_DEADLOCK_DETECTOR	"accel_deadlock"
 #define	XOCL_CFG_GPIO		"ert_cfg_gpio"
 #define	XOCL_COMMAND_QUEUE	"command_queue"
-#define	XOCL_XGQ		"xgq"
+#define	XOCL_XGQ_VMR		"xgq_vmr"
 #define	XOCL_HWMON_SDM		"hwmon_sdm"
 #define XOCL_ERT_CTRL           "ert_ctrl"
 
@@ -335,7 +335,7 @@ enum subdev_id {
 	XOCL_SUBDEV_ACCEL_DEADLOCK_DETECTOR,
 	XOCL_SUBDEV_CFG_GPIO,
 	XOCL_SUBDEV_COMMAND_QUEUE,
-	XOCL_SUBDEV_XGQ,
+	XOCL_SUBDEV_XGQ_VMR,
 	XOCL_SUBDEV_HWMON_SDM,
 	XOCL_SUBDEV_ERT_CTRL,
 	XOCL_SUBDEV_NUM
@@ -3039,7 +3039,7 @@ struct xocl_subdev_map {
 		.override_idx = -1,			\
 	}
 
-#define XOCL_RES_XGQ_VSEC				\
+#define XOCL_RES_XGQ_VMR_VSEC				\
 	((struct resource []) {				\
 		{					\
 			.start	= 0x0,			\
@@ -3050,17 +3050,17 @@ struct xocl_subdev_map {
 		{					\
 			.start	= 0x0,			\
 			.end	= 0x0,			\
-	 		.name   = NODE_XGQ_RING_BASE,	\
+	 		.name   = NODE_XGQ_PAYLOAD_BASE,\
 			.flags  = IORESOURCE_MEM,	\
 		},					\
 	})
 
-#define XOCL_DEVINFO_XGQ_VSEC				\
+#define XOCL_DEVINFO_XGQ_VMR_VSEC			\
 	{						\
-		XOCL_SUBDEV_XGQ,			\
-		XOCL_XGQ,				\
-		XOCL_RES_XGQ_VSEC,			\
-		ARRAY_SIZE(XOCL_RES_XGQ_VSEC),		\
+		XOCL_SUBDEV_XGQ_VMR,			\
+		XOCL_XGQ_VMR,				\
+		XOCL_RES_XGQ_VMR_VSEC,			\
+		ARRAY_SIZE(XOCL_RES_XGQ_VMR_VSEC),	\
 		.bar_idx = (char []){ 0, 0 },		\
 		.override_idx = -1,			\
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -324,7 +324,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	 */
 	if (!XOCL_DSA_PCI_RESET_OFF(lro)) {
 		xocl_subdev_destroy_by_level(lro, XOCL_SUBDEV_LEVEL_URP);
-		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_XGQ);
+		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_XGQ_VMR);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_UARTLITE);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_FLASH);
 		(void) xocl_subdev_offline_by_id(lro, XOCL_SUBDEV_ICAP);
@@ -350,7 +350,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_ICAP);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_FLASH);
 		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_UARTLITE);
-		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_XGQ);
+		(void) xocl_subdev_online_by_id(lro, XOCL_SUBDEV_XGQ_VMR);
 	} else {
 		mgmt_warn(lro, "PCI Hot reset is not supported on this board.");
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -296,7 +296,7 @@ static bool xgq_submitted_cmds_empty(struct xocl_xgq_vmr *xgq)
 
 static void xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq)
 {
-	struct vmr_log log;
+	struct vmr_log log = { 0 };
 
 	xocl_memcpy_fromio(&xgq->xgq_vmr_shared_mem, xgq->xgq_payload_base,
 		sizeof(xgq->xgq_vmr_shared_mem));

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -80,7 +80,7 @@
 #define XOCL_XGQ_DATA_OFFSET (XOCL_XGQ_RING_LEN + XOCL_XGQ_RESERVE_LEN)
 #define XOCL_XGQ_DEV_STAT_OFFSET (XOCL_XGQ_RING_LEN)
 
-static DEFINE_IDR(xocl_xgq_cid_idr);
+static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
 
 /* cmd timeout in seconds */
 #define XOCL_XGQ_FLASH_TIME	msecs_to_jiffies(600 * 1000) 
@@ -88,40 +88,41 @@ static DEFINE_IDR(xocl_xgq_cid_idr);
 #define XOCL_XGQ_CONFIG_TIME	msecs_to_jiffies(30 * 1000) 
 #define XOCL_XGQ_MSLEEP_1S	(1000)      //1 s
 
-typedef void (*xocl_xgq_complete_cb)(void *arg, struct xgq_com_queue_entry *ccmd);
+typedef void (*xocl_vmr_complete_cb)(void *arg, struct xgq_com_queue_entry *ccmd);
 
-struct xocl_xgq_cmd {
+struct xocl_xgq_vmr;
+
+struct xocl_xgq_vmr_cmd {
 	struct xgq_cmd_sq	xgq_cmd_entry;
 	struct list_head	xgq_cmd_list;
 	struct completion	xgq_cmd_complete;
-	xocl_xgq_complete_cb    xgq_cmd_cb;
+	xocl_vmr_complete_cb    xgq_cmd_cb;
 	void			*xgq_cmd_arg;
 	struct timer_list	xgq_cmd_timer;
-	struct xocl_xgq		*xgq;
+	struct xocl_xgq_vmr	*xgq_vmr;
 	u64			xgq_cmd_timeout_jiffies; /* timout till */
 	uint32_t		xgq_cmd_rcode;
 	/* xgq complete command can return in-line data via payload */
-	struct xgq_cmd_cq_vmr_payload	xgq_cmd_cq_payload;
+	struct xgq_cmd_cq_default_payload	xgq_cmd_cq_payload;
 };
-
-struct xocl_xgq;
 
 struct xgq_worker {
 	struct task_struct	*complete_thread;
 	bool			error;
 	bool			stop;
-	struct xocl_xgq		*xgq;
+	struct xocl_xgq_vmr	*xgq_vmr;
 };
 
-struct xocl_xgq {
+struct xocl_xgq_vmr {
 	struct platform_device 	*xgq_pdev;
 	struct xgq	 	xgq_queue;
 	u64			xgq_io_hdl;
-	void __iomem		*xgq_ring_base;
-	u32			xgq_slot_size;
+	void __iomem		*xgq_payload_base;
 	void __iomem		*xgq_sq_base;
+	void __iomem		*xgq_ring_base;
 	void __iomem		*xgq_cq_base;
 	struct mutex 		xgq_lock;
+	struct vmr_shared_mem	xgq_vmr_shared_mem;
 	bool 			xgq_polling;
 	bool 			xgq_boot_from_backup;
 	bool 			xgq_flush_default_only;
@@ -134,21 +135,21 @@ struct xocl_xgq {
 	bool			xgq_halted;
 	int 			xgq_cmd_id;
 	struct semaphore 	xgq_data_sema;
-	/* preserve fpt info for sysfs to display */
-	struct xgq_cmd_cq_multiboot_payload xgq_mb_payload;
+	struct xgq_cmd_cq_default_payload xgq_cq_payload;
+	int 			xgq_vmr_debug_level;
 };
 
 /*
  * when detect cmd is completed, find xgq_cmd from submitted_cmds list
  * and find cmd by cid; perform callback and remove from submitted_cmds.
  */
-static void cmd_complete(struct xocl_xgq *xgq, struct xgq_com_queue_entry *ccmd)
+static void cmd_complete(struct xocl_xgq_vmr *xgq, struct xgq_com_queue_entry *ccmd)
 {
-	struct xocl_xgq_cmd *xgq_cmd = NULL;
+	struct xocl_xgq_vmr_cmd *xgq_cmd = NULL;
 	struct list_head *pos = NULL, *next = NULL;
 
 	list_for_each_safe(pos, next, &xgq->xgq_submitted_cmds) {
-		xgq_cmd = list_entry(pos, struct xocl_xgq_cmd, xgq_cmd_list);
+		xgq_cmd = list_entry(pos, struct xocl_xgq_vmr_cmd, xgq_cmd_list);
 
 		if (xgq_cmd->xgq_cmd_entry.hdr.cid == ccmd->hdr.cid) {
 
@@ -187,7 +188,7 @@ void read_completion(struct xgq_com_queue_entry *ccmd, u64 addr)
 static int complete_worker(void *data)
 {
 	struct xgq_worker *xw = (struct xgq_worker *)data;
-	struct xocl_xgq *xgq = xw->xgq;
+	struct xocl_xgq_vmr *xgq = xw->xgq_vmr;
 
 	while (!xw->stop) {
 		
@@ -229,15 +230,15 @@ static int complete_worker(void *data)
 	return xw->error ? 1 : 0;
 }
 
-static bool xgq_submitted_cmd_check(struct xocl_xgq *xgq)
+static bool xgq_submitted_cmd_check(struct xocl_xgq_vmr *xgq)
 {
-	struct xocl_xgq_cmd *xgq_cmd = NULL;
+	struct xocl_xgq_vmr_cmd *xgq_cmd = NULL;
 	struct list_head *pos = NULL, *next = NULL;
 	bool found_timeout = false;
 
 	mutex_lock(&xgq->xgq_lock);
 	list_for_each_safe(pos, next, &xgq->xgq_submitted_cmds) {
-		xgq_cmd = list_entry(pos, struct xocl_xgq_cmd, xgq_cmd_list);
+		xgq_cmd = list_entry(pos, struct xocl_xgq_vmr_cmd, xgq_cmd_list);
 
 		/* Finding timed out cmds */
 		if (xgq_cmd->xgq_cmd_timeout_jiffies < jiffies) {
@@ -253,14 +254,14 @@ static bool xgq_submitted_cmd_check(struct xocl_xgq *xgq)
 	return found_timeout;
 }
 
-static void xgq_submitted_cmds_drain(struct xocl_xgq *xgq)
+static void xgq_submitted_cmds_drain(struct xocl_xgq_vmr *xgq)
 {
-	struct xocl_xgq_cmd *xgq_cmd = NULL;
+	struct xocl_xgq_vmr_cmd *xgq_cmd = NULL;
 	struct list_head *pos = NULL, *next = NULL;
 
 	mutex_lock(&xgq->xgq_lock);
 	list_for_each_safe(pos, next, &xgq->xgq_submitted_cmds) {
-		xgq_cmd = list_entry(pos, struct xocl_xgq_cmd, xgq_cmd_list);
+		xgq_cmd = list_entry(pos, struct xocl_xgq_vmr_cmd, xgq_cmd_list);
 
 		/* Finding timed out cmds */
 		if (xgq_cmd->xgq_cmd_timeout_jiffies < jiffies) {
@@ -281,7 +282,7 @@ static void xgq_submitted_cmds_drain(struct xocl_xgq *xgq)
  * after disable interrupts and mark device in bad state, a hot_reset
  * is needed to recover the device back to normal.
  */
-static bool xgq_submitted_cmds_empty(struct xocl_xgq *xgq)
+static bool xgq_submitted_cmds_empty(struct xocl_xgq_vmr *xgq)
 {
 	mutex_lock(&xgq->xgq_lock);
 	if (list_empty(&xgq->xgq_submitted_cmds)) {
@@ -293,6 +294,31 @@ static bool xgq_submitted_cmds_empty(struct xocl_xgq *xgq)
 	return false;
 }
 
+static void xgq_vmr_log_dump(struct xocl_xgq_vmr *xgq)
+{
+	struct vmr_log log;
+
+	memcpy_fromio(&xgq->xgq_vmr_shared_mem, xgq->xgq_payload_base,
+		sizeof(xgq->xgq_vmr_shared_mem));
+
+	if (xgq->xgq_vmr_shared_mem.vmr_magic_no == VMR_MAGIC_NO) {
+		u32 idx, log_idx = xgq->xgq_vmr_shared_mem.log_msg_index;
+
+		XGQ_DBG(xgq, "=== start dumping vmr log ===");
+		for (idx = 0; idx < VMR_LOG_MAX_RECS; idx++) {
+			memcpy_fromio(&log.log_buf, xgq->xgq_payload_base +
+				xgq->xgq_vmr_shared_mem.log_msg_buf_off +
+				sizeof(log) * log_idx,
+				sizeof(log));
+			log_idx = (log_idx + 1) % VMR_LOG_MAX_RECS;
+			XGQ_DBG(xgq, "%s", log.log_buf); 
+		}
+		XGQ_DBG(xgq, "=== end dumping vmr log ===");
+	} else {
+		XGQ_WARN(xgq, "vmr payload partition table is not available");
+	}
+}
+
 /*
  * stop service will be called from driver remove or found timeout cmd from health_worker
  * 3 steps to stop the service:
@@ -302,13 +328,15 @@ static bool xgq_submitted_cmds_empty(struct xocl_xgq *xgq)
  *
  * then, we can safely remove all resources.
  */
-static void xgq_stop_services(struct xocl_xgq *xgq)
+static void xgq_stop_services(struct xocl_xgq_vmr *xgq)
 {
 	/* stop receiving incoming commands */
 	mutex_lock(&xgq->xgq_lock);
 	xgq->xgq_halted = true;
 	mutex_unlock(&xgq->xgq_lock);
 
+	/* dump device log immediately */
+	xgq_vmr_log_dump(xgq);
 #if 0	
 	/*TODO: disable interrupts */
 	if (!xgq->xgq_polling)
@@ -338,7 +366,7 @@ static void xgq_stop_services(struct xocl_xgq *xgq)
 static int health_worker(void *data)
 {
 	struct xgq_worker *xw = (struct xgq_worker *)data;
-	struct xocl_xgq *xgq = xw->xgq;
+	struct xocl_xgq_vmr *xgq = xw->xgq_vmr;
 
 	while (!xw->stop) {
 		msleep(XOCL_XGQ_MSLEEP_1S * 10);
@@ -394,7 +422,7 @@ static int fini_worker(struct xgq_worker *xw)
 /* TODO: enabe interrupt */
 static irqreturn_t xgq_irq_handler(int irq, void *arg)
 {
-	struct xocl_xgq *xgq = (struct xocl_xgq *)arg;
+	struct xocl_xgq_vmr *xgq = (struct xocl_xgq_vmr *)arg;
 
 	if (xgq && !xgq->xgq_polling) {
 		/* clear intr for enabling next intr */
@@ -412,7 +440,7 @@ static irqreturn_t xgq_irq_handler(int irq, void *arg)
 /*
  * submit new cmd into XGQ SQ(submition queue)
  */
-static int submit_cmd(struct xocl_xgq *xgq, struct xocl_xgq_cmd *cmd)
+static int submit_cmd(struct xocl_xgq_vmr *xgq, struct xocl_xgq_vmr_cmd *cmd)
 {
 	u64 slot_addr = 0;
 	int rval = 0;
@@ -445,66 +473,66 @@ done:
 
 static void xgq_complete_cb(void *arg, struct xgq_com_queue_entry *ccmd)
 {
-	struct xocl_xgq_cmd *xgq_cmd = (struct xocl_xgq_cmd *)arg;
+	struct xocl_xgq_vmr_cmd *xgq_cmd = (struct xocl_xgq_vmr_cmd *)arg;
 	struct xgq_cmd_cq *cmd_cq = (struct xgq_cmd_cq *)ccmd;
 
 	xgq_cmd->xgq_cmd_rcode = ccmd->rcode;
 	/* preserve payload prior to free xgq_cmd_cq */
-	memcpy(&xgq_cmd->xgq_cmd_cq_payload, &cmd_cq->default_payload,
-		sizeof(cmd_cq->default_payload));
+	memcpy(&xgq_cmd->xgq_cmd_cq_payload, &cmd_cq->cq_default_payload,
+		sizeof(cmd_cq->cq_default_payload));
 
 	complete(&xgq_cmd->xgq_cmd_complete);
 }
 
 /*
- * Write buffer into shared memory and 
- * return translate host based address to device based address.
- * The 0 ~ XOCL_XGQ_RING_LEN is reserved for ring buffer.
- * The XOCL_XGQ_DATA_OFFSET ~ end is for transferring shared data.
+ * Write buffer into shared memory and return start offset.
  */
-static u64 memcpy_to_devices(struct xocl_xgq *xgq, const void *xclbin_data,
+static u64 memcpy_to_devices(struct xocl_xgq_vmr *xgq, const void *xclbin_data,
 	size_t xclbin_len)
 {
-	void __iomem *dst = xgq->xgq_ring_base + XOCL_XGQ_DATA_OFFSET;
+	u32 offset = xgq->xgq_vmr_shared_mem.vmr_data_start;
+	void __iomem *dst = xgq->xgq_payload_base + offset;
 
 	memcpy_toio(dst, xclbin_data, xclbin_len);
 
 	/* This is the offset that device start reading data */
-	return XOCL_XGQ_DATA_OFFSET;
+	return offset;
 }
 
-static void memcpy_from_devices(struct xocl_xgq *xgq, void *dst,
+static void memcpy_from_devices(struct xocl_xgq_vmr *xgq, void *dst,
 	size_t count)
 {
-	void __iomem *src = xgq->xgq_ring_base + XOCL_XGQ_DATA_OFFSET;
+	u32 offset = xgq->xgq_vmr_shared_mem.vmr_data_start;
+	void __iomem *src = xgq->xgq_payload_base + offset;
+
 	memcpy_fromio(dst, src, count);
 }
 
-static inline int get_xgq_cid(struct xocl_xgq *xgq)
+static inline int get_xgq_cid(struct xocl_xgq_vmr *xgq)
 {
 	int id = 0;
 
 	mutex_lock(&xgq->xgq_lock);
-	id = idr_alloc_cyclic(&xocl_xgq_cid_idr, xgq, 0, 0, GFP_KERNEL);
+	id = idr_alloc_cyclic(&xocl_xgq_vmr_cid_idr, xgq, 0, 0, GFP_KERNEL);
 	mutex_unlock(&xgq->xgq_lock);
 
 	return id;
 }
 
-static inline void remove_xgq_cid(struct xocl_xgq *xgq, int id)
+static inline void remove_xgq_cid(struct xocl_xgq_vmr *xgq, int id)
 {
 	mutex_lock(&xgq->xgq_lock);
-	idr_remove(&xocl_xgq_cid_idr, id);
+	idr_remove(&xocl_xgq_vmr_cid_idr, id);
 	mutex_unlock(&xgq->xgq_lock);
 }
 
 /*
  * Utilize shared memory between host and device to transfer data.
  */
-static ssize_t xgq_transfer_data(struct xocl_xgq *xgq, const void *buf,
+static ssize_t xgq_transfer_data(struct xocl_xgq_vmr *xgq, const void *buf,
 	u64 len, enum xgq_cmd_opcode opcode, u32 timer)
 {
-	struct xocl_xgq_cmd *cmd = NULL;
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_data_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	ssize_t ret = 0;
@@ -527,7 +555,7 @@ static ssize_t xgq_transfer_data(struct xocl_xgq *xgq, const void *buf,
 	memset(cmd, 0, sizeof(*cmd));
 	cmd->xgq_cmd_cb = xgq_complete_cb;
 	cmd->xgq_cmd_arg = cmd;
-	cmd->xgq = xgq;
+	cmd->xgq_vmr = xgq;
 
 	/* set up payload */
 	payload = (opcode == XGQ_CMD_OP_LOAD_XCLBIN) ?
@@ -585,7 +613,7 @@ done:
 static int xgq_load_xclbin(struct platform_device *pdev,
 	const void *u_xclbin)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct axlf *xclbin = (struct axlf *)u_xclbin;
 	u64 xclbin_len = xclbin->m_header.m_length;
 	int ret = 0;
@@ -605,8 +633,8 @@ static int xgq_load_xclbin(struct platform_device *pdev,
 
 static int xgq_check_firewall(struct platform_device *pdev)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
-	struct xocl_xgq_cmd *cmd = NULL;
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_log_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
@@ -625,7 +653,7 @@ static int xgq_check_firewall(struct platform_device *pdev)
 	memset(cmd, 0, sizeof(*cmd));
 	cmd->xgq_cmd_cb = xgq_complete_cb;
 	cmd->xgq_cmd_arg = cmd;
-	cmd->xgq = xgq;
+	cmd->xgq_vmr = xgq;
 
 	payload = &(cmd->xgq_cmd_entry.log_payload);
 	/*TODO: payload is to be filed for retriving log back */
@@ -671,8 +699,8 @@ done:
 static int xgq_freq_scaling(struct platform_device *pdev,
 	unsigned short *freqs, int num_freqs, int verify)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
-	struct xocl_xgq_cmd *cmd = NULL;
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_clock_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
@@ -693,7 +721,7 @@ static int xgq_freq_scaling(struct platform_device *pdev,
 	memset(cmd, 0, sizeof(*cmd));
 	cmd->xgq_cmd_cb = xgq_complete_cb;
 	cmd->xgq_cmd_arg = cmd;
-	cmd->xgq = xgq;
+	cmd->xgq_vmr = xgq;
 
 	payload = &(cmd->xgq_cmd_entry.clock_payload);
 	payload->ocl_region = 0;
@@ -745,7 +773,7 @@ done:
 static int xgq_freq_scaling_by_topo(struct platform_device *pdev,
 	struct clock_freq_topology *topo, int verify)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	struct clock_freq *freq = NULL;
 	int data_clk_count = 0;
 	int kernel_clk_count = 0;
@@ -816,10 +844,10 @@ static int xgq_freq_scaling_by_topo(struct platform_device *pdev,
 		verify);
 }
 
-static uint32_t xgq_clock_get_data(struct xocl_xgq *xgq,
+static uint32_t xgq_clock_get_data(struct xocl_xgq_vmr *xgq,
 	enum xgq_cmd_clock_req_type req_type, int req_id)
 {
-	struct xocl_xgq_cmd *cmd = NULL;
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_clock_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int id = 0;
@@ -839,7 +867,7 @@ static uint32_t xgq_clock_get_data(struct xocl_xgq *xgq,
 	memset(cmd, 0, sizeof(*cmd));
 	cmd->xgq_cmd_cb = xgq_complete_cb;
 	cmd->xgq_cmd_arg = cmd;
-	cmd->xgq = xgq;
+	cmd->xgq_vmr = xgq;
 
 	payload = &(cmd->xgq_cmd_entry.clock_payload);
 	payload->ocl_region = 0;
@@ -895,7 +923,7 @@ done:
 static uint64_t xgq_get_data(struct platform_device *pdev,
 	enum data_kind kind)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	uint64_t target = 0;
 
 	switch (kind) {
@@ -927,7 +955,7 @@ static uint64_t xgq_get_data(struct platform_device *pdev,
 static int xgq_download_apu_bin(struct platform_device *pdev, char *buf,
 	size_t len)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 	int ret = 0;
 
 
@@ -964,20 +992,20 @@ static int xgq_download_apu_firmware(struct platform_device *pdev)
 	return ret;
 }
 
-static void vmr_collect_boot_query(struct xocl_xgq *xgq, struct xocl_xgq_cmd *cmd)
+static void vmr_status_copy(struct xocl_xgq_vmr *xgq, struct xocl_xgq_vmr_cmd *cmd)
 {
-	struct xgq_cmd_cq_multiboot_payload *payload =
-		(struct xgq_cmd_cq_multiboot_payload *)&cmd->xgq_cmd_cq_payload;
+	struct xgq_cmd_cq_default_payload *payload =
+		(struct xgq_cmd_cq_default_payload *)&cmd->xgq_cmd_cq_payload;
 
-	memcpy(&xgq->xgq_mb_payload, payload, sizeof(*payload));
+	memcpy(&xgq->xgq_cq_payload, payload, sizeof(*payload));
 }
 
-static int vmr_multiboot_op(struct platform_device *pdev,
-	enum xgq_cmd_multiboot_req_type req_type)
+static int vmr_control_op(struct platform_device *pdev,
+	enum xgq_cmd_vmr_control_type req_type)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
-	struct xocl_xgq_cmd *cmd = NULL;
-	struct xgq_cmd_multiboot_payload *payload = NULL;
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
+	struct xgq_cmd_vmr_control_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
 	int id = 0;
@@ -991,13 +1019,14 @@ static int vmr_multiboot_op(struct platform_device *pdev,
 	memset(cmd, 0, sizeof(*cmd));
 	cmd->xgq_cmd_cb = xgq_complete_cb;
 	cmd->xgq_cmd_arg = cmd;
-	cmd->xgq = xgq;
+	cmd->xgq_vmr = xgq;
 
-	payload = &(cmd->xgq_cmd_entry.multiboot_payload);
+	payload = &(cmd->xgq_cmd_entry.vmr_control_payload);
 	payload->req_type = req_type;
+	payload->debug_level = xgq->xgq_vmr_debug_level;
 
 	hdr = &(cmd->xgq_cmd_entry.hdr);
-	hdr->opcode = XGQ_CMD_OP_MULTIPLE_BOOT;
+	hdr->opcode = XGQ_CMD_OP_VMR_CONTROL;
 	hdr->state = XGQ_SQ_CMD_NEW;
 	hdr->count = sizeof(*payload);
 	id = get_xgq_cid(xgq);
@@ -1027,8 +1056,8 @@ static int vmr_multiboot_op(struct platform_device *pdev,
 	if (ret) {
 		XGQ_ERR(xgq, "Multiboot or reset might not work. ret %d",
 			cmd->xgq_cmd_rcode);
-	} else if (req_type == XGQ_CMD_BOOT_QUERY) {
-		vmr_collect_boot_query(xgq, cmd);
+	} else if (req_type == XGQ_CMD_VMR_QUERY) {
+		vmr_status_copy(xgq, cmd);
 	}
 
 done:
@@ -1040,47 +1069,39 @@ done:
 	return ret;
 }
 
-static int vmr_fpt_query(struct platform_device *pdev)
+static int vmr_status_query(struct platform_device *pdev)
 {
-	return vmr_multiboot_op(pdev, XGQ_CMD_BOOT_QUERY);
+	return vmr_control_op(pdev, XGQ_CMD_VMR_QUERY);
 }
 
 static int vmr_enable_multiboot(struct platform_device *pdev)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
 
-	return vmr_multiboot_op(pdev,
+	return vmr_control_op(pdev,
 		xgq->xgq_boot_from_backup ?  XGQ_CMD_BOOT_BACKUP : XGQ_CMD_BOOT_DEFAULT);
 }
 
-static struct xocl_xgq_cmd* prepare_xgq_cmd(struct xocl_xgq *xgq)
-{
-	struct xocl_xgq_cmd *cmd = NULL;
-
-	cmd = kzalloc(sizeof(*cmd), GFP_KERNEL);
-	if (!cmd) {
-		XGQ_ERR(xgq, "kmalloc failed, retry");
-		return NULL;
-	}
-
-	cmd->xgq_cmd_cb = xgq_complete_cb;
-	cmd->xgq_cmd_arg = cmd;
-	cmd->xgq = xgq;
-
-	return cmd;
-}
-
 static int xgq_collect_sensors(struct platform_device *pdev, int pid,
-							   char *data_buf, uint32_t len)
+	char *data_buf, uint32_t len)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(pdev);
-	struct xocl_xgq_cmd *cmd = prepare_xgq_cmd(xgq);
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(pdev);
+	struct xocl_xgq_vmr_cmd *cmd = NULL;
 	struct xgq_cmd_log_payload *payload = NULL;
 	struct xgq_cmd_sq_hdr *hdr = NULL;
 	int ret = 0;
 	int id = 0;
 
-	/* reset to all 0 first */
+	cmd = kzalloc(sizeof(*cmd), GFP_KERNEL);
+	if (!cmd) {
+		XGQ_ERR(xgq, "kmalloc failed, retry");
+		return -ENOMEM;
+	}
+
+	cmd->xgq_cmd_cb = xgq_complete_cb;
+	cmd->xgq_cmd_arg = cmd;
+	cmd->xgq_vmr = xgq;
+
 	payload = &(cmd->xgq_cmd_entry.sensor_payload);
 	/* set address offset, so that device will write data start from this offset */
 	payload->address = memcpy_to_devices(xgq, data_buf, len);
@@ -1145,7 +1166,7 @@ static int xgq_collect_temp_sensors(struct platform_device *pdev, char *buf, uin
 static ssize_t boot_from_backup_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	u32 val = 0;
 
 	if (kstrtou32(buf, 10, &val) == -EINVAL)
@@ -1161,7 +1182,7 @@ static ssize_t boot_from_backup_store(struct device *dev,
 static ssize_t boot_from_backup_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	ssize_t cnt = 0;
 
 	mutex_lock(&xgq->xgq_lock);
@@ -1175,7 +1196,7 @@ static DEVICE_ATTR(boot_from_backup, 0644, boot_from_backup_show, boot_from_back
 static ssize_t flush_default_only_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	u32 val = 0;
 
 	if (kstrtou32(buf, 10, &val) == -EINVAL)
@@ -1191,7 +1212,7 @@ static ssize_t flush_default_only_store(struct device *dev,
 static ssize_t flush_default_only_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	ssize_t cnt = 0;
 
 	mutex_lock(&xgq->xgq_lock);
@@ -1205,7 +1226,7 @@ static DEVICE_ATTR(flush_default_only, 0644, flush_default_only_show, flush_defa
 static ssize_t polling_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	u32 val = 0;
 
 	if (kstrtou32(buf, 10, &val) == -EINVAL)
@@ -1221,7 +1242,7 @@ static ssize_t polling_store(struct device *dev,
 static ssize_t polling_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
 	ssize_t cnt = 0;
 
 	mutex_lock(&xgq->xgq_lock);
@@ -1232,39 +1253,62 @@ static ssize_t polling_show(struct device *dev,
 }
 static DEVICE_ATTR(polling, 0644, polling_show, polling_store);
 
-static ssize_t boot_status_show(struct device *dev,
+static ssize_t vmr_debug_level_store(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	u32 val = 0;
+
+	if (kstrtou32(buf, 10, &val) == -EINVAL || val > 3) {
+		XGQ_ERR(xgq, "level should be 0 - 3");
+		return -EINVAL;
+	}
+
+	mutex_lock(&xgq->xgq_lock);
+	xgq->xgq_vmr_debug_level = val;
+	mutex_unlock(&xgq->xgq_lock);
+
+	/* request debug level change */
+	if (vmr_status_query(xgq->xgq_pdev))
+		return -EINVAL;
+
+	return count;
+}
+static DEVICE_ATTR_WO(vmr_debug_level);
+
+static ssize_t vmr_status_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
-	struct xocl_xgq *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	struct xgq_cmd_cq_vmr_payload *vmr_status =
+		(struct xgq_cmd_cq_vmr_payload *)&xgq->xgq_cq_payload;
 	ssize_t cnt = 0;
 
 	/* update boot status */
-	vmr_fpt_query(xgq->xgq_pdev);
+	if (vmr_status_query(xgq->xgq_pdev))
+		return -EINVAL;
 
 	mutex_lock(&xgq->xgq_lock);
-	cnt += sprintf(buf + cnt, "HAS_FPT:%d\n",
-		xgq->xgq_mb_payload.has_fpt);
-	cnt += sprintf(buf + cnt, "HAS_FPT_RECOVERY:%d\n",
-		xgq->xgq_mb_payload.has_fpt_recovery);
-	cnt += sprintf(buf + cnt, "BOOT_ON_DEFAULT:%d\n",
-		xgq->xgq_mb_payload.boot_on_default);
-	cnt += sprintf(buf + cnt, "BOOT_ON_BACKUP:%d\n",
-		xgq->xgq_mb_payload.boot_on_backup);
-	cnt += sprintf(buf + cnt, "BOOT_ON_RECOVERY:%d\n",
-		xgq->xgq_mb_payload.boot_on_recovery);
-	cnt += sprintf(buf + cnt, "MULTI_BOOT_OFFSET:0x%x\n",
-		xgq->xgq_mb_payload.multi_boot_offset);
+	cnt += sprintf(buf + cnt, "HAS_FPT:%d\n", vmr_status->has_fpt);
+	cnt += sprintf(buf + cnt, "HAS_FPT_RECOVERY:%d\n", vmr_status->has_fpt_recovery);
+	cnt += sprintf(buf + cnt, "BOOT_ON_DEFAULT:%d\n", vmr_status->boot_on_default);
+	cnt += sprintf(buf + cnt, "BOOT_ON_BACKUP:%d\n", vmr_status->boot_on_backup);
+	cnt += sprintf(buf + cnt, "BOOT_ON_RECOVERY:%d\n", vmr_status->boot_on_recovery);
+	cnt += sprintf(buf + cnt, "MULTI_BOOT_OFFSET:0x%x\n", vmr_status->multi_boot_offset);
+	cnt += sprintf(buf + cnt, "DEBUG_LEVEL:0x%x\n", vmr_status->debug_level);
+	cnt += sprintf(buf + cnt, "FLUSH_PROGRESS:0x%x\n", vmr_status->flush_progress);
 	mutex_unlock(&xgq->xgq_lock);
 
 	return cnt;
 }
-static DEVICE_ATTR_RO(boot_status);
+static DEVICE_ATTR_RO(vmr_status);
 
 static struct attribute *xgq_attrs[] = {
 	&dev_attr_polling.attr,
 	&dev_attr_boot_from_backup.attr,
 	&dev_attr_flush_default_only.attr,
-	&dev_attr_boot_status.attr,
+	&dev_attr_vmr_status.attr,
+	&dev_attr_vmr_debug_level.attr,
 	NULL,
 };
 
@@ -1275,7 +1319,7 @@ static struct attribute_group xgq_attr_group = {
 static ssize_t xgq_ospi_write(struct file *filp, const char __user *udata,
 	size_t data_len, loff_t *off)
 {
-	struct xocl_xgq *xgq = filp->private_data;
+	struct xocl_xgq_vmr *xgq = filp->private_data;
 	ssize_t ret;
 	char *kdata = NULL;
 
@@ -1316,7 +1360,7 @@ done:
 
 static int xgq_ospi_open(struct inode *inode, struct file *file)
 {
-	struct xocl_xgq *xgq = NULL;
+	struct xocl_xgq_vmr *xgq = NULL;
 
 	xgq = xocl_drvinst_open(inode->i_cdev);
 	if (!xgq)
@@ -1328,15 +1372,15 @@ static int xgq_ospi_open(struct inode *inode, struct file *file)
 
 static int xgq_ospi_close(struct inode *inode, struct file *file)
 {
-	struct xocl_xgq *xgq = file->private_data;
+	struct xocl_xgq_vmr *xgq = file->private_data;
 
 	xocl_drvinst_close(xgq);
 	return 0;
 }
 
-static int xgq_remove(struct platform_device *pdev)
+static int xgq_vmr_remove(struct platform_device *pdev)
 {
-	struct xocl_xgq	*xgq;
+	struct xocl_xgq_vmr	*xgq;
 	void *hdl;
 
 	xgq = platform_get_drvdata(pdev);
@@ -1350,8 +1394,8 @@ static int xgq_remove(struct platform_device *pdev)
 	fini_worker(&xgq->xgq_complete_worker);
 	fini_worker(&xgq->xgq_health_worker);
 
-	if (xgq->xgq_ring_base)
-		iounmap(xgq->xgq_ring_base);
+	if (xgq->xgq_payload_base)
+		iounmap(xgq->xgq_payload_base);
 	if (xgq->xgq_sq_base)
 		iounmap(xgq->xgq_sq_base);
 
@@ -1367,25 +1411,31 @@ static int xgq_remove(struct platform_device *pdev)
 }
 
 /* Wait for xgq service is fully ready after a reset. */
-static inline bool xgq_device_is_ready(struct xocl_xgq *xgq)
+static inline bool xgq_device_is_ready(struct xocl_xgq_vmr *xgq)
 {
 	u32 rval = 0;
 	int i = 0, retry = 50;
 
 	for (i = 0; i < retry; i++) {
 		msleep(100);
-		rval = ioread32(xgq->xgq_ring_base + XOCL_XGQ_DEV_STAT_OFFSET);
-		if (rval)
-			return true;
+
+		memcpy_fromio(&xgq->xgq_vmr_shared_mem, xgq->xgq_payload_base,
+			sizeof(xgq->xgq_vmr_shared_mem));
+		if (xgq->xgq_vmr_shared_mem.vmr_magic_no == VMR_MAGIC_NO) {
+			rval = ioread32(xgq->xgq_payload_base +
+				xgq->xgq_vmr_shared_mem.vmr_status_off);
+			if (rval)
+				return true;
+		}
 	}
 	
 	return false;
 }
 
-static int xgq_probe(struct platform_device *pdev)
+static int xgq_vmr_probe(struct platform_device *pdev)
 {
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
-	struct xocl_xgq *xgq = NULL;
+	struct xocl_xgq_vmr *xgq = NULL;
 	struct resource *res = NULL;
 	struct xocl_subdev_info subdev_info = XOCL_DEVINFO_HWMON_SDM;
 	u64 flags = 0;
@@ -1409,13 +1459,14 @@ static int xgq_probe(struct platform_device *pdev)
 			xgq->xgq_sq_base = ioremap_nocache(res->start,
 				res->end - res->start + 1);
 		}
-		if (!strncmp(res->name, NODE_XGQ_RING_BASE, strlen(NODE_XGQ_RING_BASE))) {
-			xgq->xgq_ring_base = ioremap_nocache(res->start,
+		if (!strncmp(res->name, NODE_XGQ_PAYLOAD_BASE,
+			strlen(NODE_XGQ_PAYLOAD_BASE))) {
+			xgq->xgq_payload_base = ioremap_nocache(res->start,
 				res->end - res->start + 1);
 		}
 	}
 
-	if (!xgq->xgq_sq_base || !xgq->xgq_ring_base) {
+	if (!xgq->xgq_sq_base || !xgq->xgq_payload_base) {
 		ret = -EIO;
 		XGQ_ERR(xgq, "platform get resource failed");
 		goto attach_failed;
@@ -1431,6 +1482,7 @@ static int xgq_probe(struct platform_device *pdev)
 		goto attach_failed;
 	}
 
+	xgq->xgq_ring_base = xgq->xgq_payload_base + xgq->xgq_vmr_shared_mem.ring_buffer_off;
 	ret = xgq_attach(&xgq->xgq_queue, flags, 0, (u64)xgq->xgq_ring_base,
 		(u64)xgq->xgq_sq_base, (u64)xgq->xgq_cq_base);
 	if (ret != 0) {
@@ -1465,8 +1517,8 @@ static int xgq_probe(struct platform_device *pdev)
 
 	INIT_LIST_HEAD(&xgq->xgq_submitted_cmds);
 
-	xgq->xgq_complete_worker.xgq = xgq;
-	xgq->xgq_health_worker.xgq = xgq;
+	xgq->xgq_complete_worker.xgq_vmr = xgq;
+	xgq->xgq_health_worker.xgq_vmr = xgq;
 	init_complete_worker(&xgq->xgq_complete_worker);
 	init_health_worker(&xgq->xgq_health_worker);
 #if 0
@@ -1494,7 +1546,7 @@ static int xgq_probe(struct platform_device *pdev)
 	if (ret) {
 		XGQ_ERR(xgq, "create xgq attrs failed: %d", ret);
 		/* Gracefully remove xgq resources */
-		(void) xgq_remove(pdev);
+		(void) xgq_vmr_remove(pdev);
 		return ret;
 	}
 
@@ -1516,7 +1568,7 @@ attach_failed:
 	return ret;
 }
 
-static struct xocl_xgq_funcs xgq_ops = {
+static struct xocl_xgq_vmr_funcs xgq_vmr_ops = {
 	.xgq_load_xclbin = xgq_load_xclbin,
 	.xgq_check_firewall = xgq_check_firewall,
 	.xgq_freq_scaling = xgq_freq_scaling,
@@ -1528,45 +1580,45 @@ static struct xocl_xgq_funcs xgq_ops = {
 	.xgq_collect_temp_sensors = xgq_collect_temp_sensors,
 };
 
-static const struct file_operations xgq_fops = {
+static const struct file_operations xgq_vmr_fops = {
 	.owner = THIS_MODULE,
 	.open = xgq_ospi_open,
 	.release = xgq_ospi_close,
 	.write = xgq_ospi_write,
 };
 
-struct xocl_drv_private xgq_priv = {
-	.ops = &xgq_ops,
-	.fops = &xgq_fops,
+struct xocl_drv_private xgq_vmr_priv = {
+	.ops = &xgq_vmr_ops,
+	.fops = &xgq_vmr_fops,
 	.dev = -1,
 };
 
-struct platform_device_id xgq_id_table[] = {
-	{ XOCL_DEVNAME(XOCL_XGQ), (kernel_ulong_t)&xgq_priv },
+struct platform_device_id xgq_vmr_id_table[] = {
+	{ XOCL_DEVNAME(XOCL_XGQ_VMR), (kernel_ulong_t)&xgq_vmr_priv },
 	{ },
 };
 
-static struct platform_driver	xgq_driver = {
-	.probe		= xgq_probe,
-	.remove		= xgq_remove,
+static struct platform_driver	xgq_vmr_driver = {
+	.probe		= xgq_vmr_probe,
+	.remove		= xgq_vmr_remove,
 	.driver		= {
-		.name = XOCL_DEVNAME(XOCL_XGQ),
+		.name = XOCL_DEVNAME(XOCL_XGQ_VMR),
 	},
-	.id_table = xgq_id_table,
+	.id_table = xgq_vmr_id_table,
 };
 
 int __init xocl_init_xgq(void)
 {
 	int err = 0;
 
-	err = alloc_chrdev_region(&xgq_priv.dev, 0, XOCL_MAX_DEVICES,
+	err = alloc_chrdev_region(&xgq_vmr_priv.dev, 0, XOCL_MAX_DEVICES,
 	    XGQ_DEV_NAME);
 	if (err < 0)
 		return err;
 
-	err = platform_driver_register(&xgq_driver);
+	err = platform_driver_register(&xgq_vmr_driver);
 	if (err) {
-		unregister_chrdev_region(xgq_priv.dev, XOCL_MAX_DEVICES);
+		unregister_chrdev_region(xgq_vmr_priv.dev, XOCL_MAX_DEVICES);
 		return err;
 	}
 
@@ -1575,6 +1627,6 @@ int __init xocl_init_xgq(void)
 
 void xocl_fini_xgq(void)
 {
-	unregister_chrdev_region(xgq_priv.dev, XOCL_MAX_DEVICES);
-	platform_driver_unregister(&xgq_driver);
+	unregister_chrdev_region(xgq_vmr_priv.dev, XOCL_MAX_DEVICES);
+	platform_driver_unregister(&xgq_vmr_driver);
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1605,6 +1605,8 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 	ret = xocl_ert_ctrl_connect(xdev);
 	if (ret < 0) {
 		userpf_err(xdev, "failed to connect ERT ctrl, err: %d\n", ret);
+		/*BYpass*/
+		ret = 0;
 		goto out;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1605,8 +1605,6 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 	ret = xocl_ert_ctrl_connect(xdev);
 	if (ret < 0) {
 		userpf_err(xdev, "failed to connect ERT ctrl, err: %d\n", ret);
-		/*BYpass*/
-		ret = 0;
 		goto out;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -344,7 +344,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define XOCL_VSEC_PLATFORM_INFO     0x52
 #define XOCL_VSEC_MAILBOX           0x53
 #define XOCL_VSEC_XGQ               0x54
-#define XOCL_VSEC_XGQ_PAYLOAD       0x55
+#define XOCL_VSEC_XGQ_VMR_PAYLOAD   0x55
 
 #define XOCL_VSEC_FLASH_TYPE_SPI_IP		0x0
 #define XOCL_VSEC_FLASH_TYPE_SPI_REG		0x1

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2111,7 +2111,7 @@ struct xocl_pmc_funcs {
 #define	xocl_pmc_enable_reset(xdev) \
 	(PMC_CB(xdev) ? PMC_OPS(xdev)->enable_reset(PMC_DEV(xdev)) : -ENODEV)
 
-struct xocl_xgq_funcs {
+struct xocl_xgq_vmr_funcs {
 	struct xocl_subdev_funcs common_funcs;
 	int (*xgq_load_xclbin)(struct platform_device *pdev,
 		const void __user *arg);
@@ -2128,11 +2128,11 @@ struct xocl_xgq_funcs {
 	int (*xgq_collect_temp_sensors)(struct platform_device *pdev, char *buf, uint32_t len);
 };
 #define	XGQ_DEV(xdev)						\
-	(SUBDEV(xdev, XOCL_SUBDEV_XGQ) ? 			\
-	SUBDEV(xdev, XOCL_SUBDEV_XGQ)->pldev : NULL)
+	(SUBDEV(xdev, XOCL_SUBDEV_XGQ_VMR) ? 			\
+	SUBDEV(xdev, XOCL_SUBDEV_XGQ_VMR)->pldev : NULL)
 #define	XGQ_OPS(xdev)						\
-	(SUBDEV(xdev, XOCL_SUBDEV_XGQ) ? 			\
-	(struct xocl_xgq_funcs *)SUBDEV(xdev, XOCL_SUBDEV_XGQ)->ops : NULL)
+	(SUBDEV(xdev, XOCL_SUBDEV_XGQ_VMR) ? 			\
+	(struct xocl_xgq_vmr_funcs *)SUBDEV(xdev, XOCL_SUBDEV_XGQ_VMR)->ops : NULL)
 #define	XGQ_CB(xdev, cb)					\
 	(XGQ_DEV(xdev) && XGQ_OPS(xdev) && XGQ_OPS(xdev)->cb)
 #define	xocl_xgq_download_axlf(xdev, xclbin)			\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -113,7 +113,7 @@
 #define NODE_PCIE "pcie"
 #define NODE_BARS "bars"
 #define NODE_XGQ_SQ_BASE "ep_xgq_mgmt_to_rpu_sq_pi_00"
-#define NODE_XGQ_PAYLOAD_BASE "ep_xgq_payload_mgmt_00"
+#define NODE_XGQ_VMR_PAYLOAD_BASE "ep_xgq_payload_mgmt_00"
 
 #define PROP_BARM_CTRL "axi_bram_ctrl"
 #define PROP_HWICAP "axi_hwicap"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -113,7 +113,7 @@
 #define NODE_PCIE "pcie"
 #define NODE_BARS "bars"
 #define NODE_XGQ_SQ_BASE "ep_xgq_mgmt_to_rpu_sq_pi_00"
-#define NODE_XGQ_RING_BASE "ep_xgq_payload_mgmt_00"
+#define NODE_XGQ_PAYLOAD_BASE "ep_xgq_payload_mgmt_00"
 
 #define PROP_BARM_CTRL "axi_bram_ctrl"
 #define PROP_HWICAP "axi_hwicap"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1685,10 +1685,10 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 		u64 offset_payload = 0;
 		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XGQ_VMR_VSEC;
 
-		ret = xocl_subdev_vsec(xdev, XOCL_VSEC_XGQ_PAYLOAD,
+		ret = xocl_subdev_vsec(xdev, XOCL_VSEC_XGQ_VMR_PAYLOAD,
 			&bar_payload, &offset_payload, NULL);
 		if (ret) {
-			xocl_xdev_err(xdev, "Found XGQ, but missed XGQ_PAYLOAD");
+			xocl_xdev_err(xdev, "Found XGQ, but missed XGQ_VMR_PAYLOAD");
 			goto done;
 		}
 
@@ -1707,7 +1707,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 
 		subdev_info.res[1].start = offset_payload;
 		subdev_info.res[1].end = offset_payload + 0x7ffffff;
-		subdev_info.res[1].name = NODE_XGQ_PAYLOAD_BASE;
+		subdev_info.res[1].name = NODE_XGQ_VMR_PAYLOAD_BASE;
 
 		xocl_xdev_dbg(xdev,
 		    "VSEC XGQ Start 0x%llx, bar %d. XGQ Payload 0x%llx, bar %d",

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1683,7 +1683,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 	if (!ret) {
 		int bar_payload = 0; 
 		u64 offset_payload = 0;
-		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XGQ_VSEC;
+		struct xocl_subdev_info subdev_info = XOCL_DEVINFO_XGQ_VMR_VSEC;
 
 		ret = xocl_subdev_vsec(xdev, XOCL_VSEC_XGQ_PAYLOAD,
 			&bar_payload, &offset_payload, NULL);
@@ -1707,7 +1707,7 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 
 		subdev_info.res[1].start = offset_payload;
 		subdev_info.res[1].end = offset_payload + 0x7ffffff;
-		subdev_info.res[1].name = NODE_XGQ_RING_BASE;
+		subdev_info.res[1].name = NODE_XGQ_PAYLOAD_BASE;
 
 		xocl_xdev_dbg(xdev,
 		    "VSEC XGQ Start 0x%llx, bar %d. XGQ Payload 0x%llx, bar %d",
@@ -1715,11 +1715,11 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 
 		ret = xocl_subdev_create(xdev, &subdev_info);
 		if (ret) {
-			xocl_xdev_err(xdev, "Create XGQ subdev failed. %d", ret);
+			xocl_xdev_err(xdev, "Create VMR subdev failed. %d", ret);
 			goto done;
 		}
 
-		xocl_xdev_dbg(xdev, "VSEC XGQ created.");
+		xocl_xdev_dbg(xdev, "VSEC VMR created.");
 	}
 
 	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_MAILBOX, &bar, &offset, NULL);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -192,7 +192,7 @@ int Flasher::upgradeFirmware(const std::string& flasherType,
     }
     case OSPI_XGQ:
     {
-        XGQ_Flasher xgq_flasher(m_device);
+        XGQ_VMR_Flasher xgq_flasher(m_device);
         if (primary == nullptr)
             std::cout << "ERROR: OSPI XGQ mode does not support reverting to MFG." << std::endl;
         else if(secondary != nullptr)

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
@@ -23,7 +23,7 @@
 
 #include "xspi.h"
 #include "xospiversal.h"
-#include "xgq.h"
+#include "xgq_vmr.h"
 #include "xqspips.h"
 #include "xmc.h"
 #include "firmware_image.h"

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,17 +15,17 @@
  */
 
 #include <fcntl.h>
-#include "xgq.h"
+#include "xgq_vmr.h"
 
 /**
- * @brief XGQ_Flasher::XGQ_Flasher
+ * @brief XGQ_VMR_Flasher::XGQ_VMR_Flasher
  */
-XGQ_Flasher::XGQ_Flasher(std::shared_ptr<xrt_core::device> dev)
+XGQ_VMR_Flasher::XGQ_VMR_Flasher(std::shared_ptr<xrt_core::device> dev)
     : m_device(std::move(dev))
 {
 }
 
-int XGQ_Flasher::xclUpgradeFirmware(std::istream& binStream)
+int XGQ_VMR_Flasher::xclUpgradeFirmware(std::istream& binStream)
 {
   binStream.seekg(0, binStream.end);
   auto total_size = static_cast<int>(binStream.tellg());
@@ -34,7 +34,7 @@ int XGQ_Flasher::xclUpgradeFirmware(std::istream& binStream)
   std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
 
   try {
-    auto fd = m_device->file_open("xgq", O_RDWR);
+    auto fd = m_device->file_open("xgq_vmr", O_RDWR);
     std::vector<char> buffer(total_size);
     binStream.read(buffer.data(), total_size);
     ssize_t ret = total_size;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,18 +14,18 @@
  * under the License.
  */
 
-#ifndef _XGQ_FLASHER_H_
-#define _XGQ_FLASHER_H_
+#ifndef _XGQ_VMR_FLASHER_H_
+#define _XGQ_VMR_FLASHER_H_
 
 #include <iostream>
 #include "core/common/system.h"
 #include "core/common/device.h"
 
-class XGQ_Flasher
+class XGQ_VMR_Flasher
 {
 public:
     /* Constructor of ospi_xgq flash */
-    XGQ_Flasher(std::shared_ptr<xrt_core::device> dev);
+    XGQ_VMR_Flasher(std::shared_ptr<xrt_core::device> dev);
     /* API of flashing binStream via ospi_xgq driver */
     int xclUpgradeFirmware(std::istream& binStream);
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1) Enabling RPU logging mechanism
2) Enabling UART lite for RPU
3) Reporting RPU status
4) Renaming xgq_xocl in xgq driver

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduce new op code (vmr control) to retrieve vmr status.
RPU log will be redirected to UART lite and shared memory.
When system has timeout, logs cached in shared memory will be dumped to host side debug fs "/sys/kernel/debug/xclmgmt/trace"
User can change RPU log level by "echo 0-2" into sysfs.
Change xgq_xocl to another name that is not being conflicted with shared xgq common code that is introduced by @mamin506  

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-Overview