### PR TITLE
Vitis-4346 Name argument for xrt calls

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -2054,6 +2054,16 @@ public:
     }
   }
 
+  int
+  get_arg_index(const std::string& argnm) const
+  {
+    for (const auto& arg : kernel->get_args())
+      if (arg.name() == argnm)
+        return arg.index();
+
+    throw xrt_core::error(EINVAL, "No such kernel argument '" + argnm + "'");
+  }
+
   // If this run object's cus were filtered compared to kernel cus
   // then update the command packet encoded cus.
   void
@@ -2834,6 +2844,13 @@ state() const
   });
 }
 
+int
+run::
+get_arg_index(const std::string& argnm) const
+{
+  return handle->get_arg_index(argnm);
+}
+
 void
 run::
 set_arg_at_index(int index, const void* value, size_t bytes)
@@ -2982,6 +2999,13 @@ mailbox::
 get_arg(int index) const
 {
   return handle->get_arg(index);
+}
+
+int
+mailbox::
+get_arg_index(const std::string& argnm) const
+{
+  return handle->get_arg_index(argnm);
 }
 
 void

--- a/src/runtime_src/core/include/experimental/xrt_mailbox.h
+++ b/src/runtime_src/core/include/experimental/xrt_mailbox.h
@@ -176,7 +176,32 @@ public:
     set_arg_at_index(index, &arg, sizeof(arg));
   }
 
+  /**
+   * set_arg - set named argument in the mailbox
+   *
+   * @param argnm
+   *   Name of kernel argument
+   * @param argvalue
+   *   Argument value
+   *
+   * Throws if specified argument name doesn't match kernel
+   * specification. Throws if argument value is incompatible with
+   * specified argument
+   */
+  template <typename ArgType>
+  void
+  set_arg(const std::string& argnm, ArgType&& argvalue)
+  {
+    auto index = get_arg_index(argnm);
+    set_arg(index, std::forward<ArgType>(argvalue));
+  }
+  
+
 private:
+  XCL_DRIVER_DLLESPEC
+  int
+  get_arg_index(const std::string& argnm) const;
+
   XCL_DRIVER_DLLESPEC
   void
   set_arg_at_index(int index, const void* value, size_t bytes);

--- a/src/runtime_src/core/include/xrt/xrt_kernel.h
+++ b/src/runtime_src/core/include/xrt/xrt_kernel.h
@@ -393,6 +393,26 @@ class run
   }
 
   /**
+   * set_arg - set named argument
+   *
+   * @param argnm
+   *   Name of kernel argument
+   * @param argvalue
+   *   Argument value
+   *
+   * Throws if specified argument name doesn't match kernel
+   * specification. Throws if argument value is incompatible with
+   * specified argument
+   */
+  template <typename ArgType>
+  void
+  set_arg(const std::string& argnm, ArgType&& argvalue)
+  {
+    auto index = get_arg_index(argnm);
+    set_arg(index, std::forward<ArgType>(argvalue));
+  }
+
+  /**
    * udpdate_arg() - Asynchronous update of scalar kernel global argument
    *
    * @param index
@@ -498,6 +518,10 @@ public:
 
 private:
   std::shared_ptr<run_impl> handle;
+
+  XCL_DRIVER_DLLESPEC
+  int
+  get_arg_index(const std::string& argnm) const;
 
   XCL_DRIVER_DLLESPEC
   void

--- a/tests/xrt/mailbox/use_mailbox.cpp
+++ b/tests/xrt/mailbox/use_mailbox.cpp
@@ -191,8 +191,8 @@ run(const xrt::device& device, const xrt::uuid& uuid, unsigned int iter)
 
     // prepare for next iteration, update the mailbox with the next
     // value of 'adder'.
-    incr_mbox.set_arg(2, ++adder1); // update the mailbox
-    incr_mbox.set_arg(3, --adder2); // update the mailbox
+    incr_mbox.set_arg("adder1", ++adder1); // update the mailbox
+    incr_mbox.set_arg("adder2", --adder2); // update the mailbox
 
     // write the mailbox content to hw, the write will not be picked
     // up until the next iteration of the pipeline (incr).


### PR DESCRIPTION
#### Problem solved by the commit
Support xrt::run::set_arg for named arguments.
Support xrt :: mailbox::set_arg for named arguments.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add API for setting named argument to specified value.  Implementation
looks up the index of the specified argument and calls set_arg
variants.

#### What has been tested and how, request additional testing if necessary
Update mailbox test to use named argument setting.
