### PR TITLE
CR-1116820 Buffer export handle is not closed

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -29,10 +29,10 @@
 #include <stdexcept>
 
 // Internal shim function forward declarations
-int  xclUpdateSchedulerStat(xclDeviceHandle handle);
-int  xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
-int  xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
-void xclCloseExportHandle(xclBufferExportHandle);
+int xclUpdateSchedulerStat(xclDeviceHandle handle);
+int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
+int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
+int xclCloseExportHandle(xclBufferExportHandle);
 
 namespace xrt_core {
 
@@ -307,7 +307,8 @@ struct shim : public DeviceType
   void
   close_export_handle(xclBufferExportHandle ehdl) override
   {
-    xclCloseExportHandle(ehdl);
+    if (auto err = xclCloseExportHandle(ehdl))
+      throw system_error(err, "failed to close export handle");
   }
 
   void

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -17,19 +17,22 @@
 #ifndef core_common_ishim_h
 #define core_common_ishim_h
 
+#include "error.h"
+#include "xcl_graph.h"
 #include "xrt.h"
+
 #include "experimental/xrt_aie.h"
 #include "experimental/xrt_bo.h"
 #include "experimental/xrt_graph.h"
 #include "experimental/xrt-next.h"
-#include "xcl_graph.h"
-#include "error.h"
+
 #include <stdexcept>
 
 // Internal shim function forward declarations
-int xclUpdateSchedulerStat(xclDeviceHandle handle);
-int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
-int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
+int  xclUpdateSchedulerStat(xclDeviceHandle handle);
+int  xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind);
+int  xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size);
+void xclCloseExportHandle(xclBufferExportHandle);
 
 namespace xrt_core {
 
@@ -63,6 +66,9 @@ struct ishim
 
   virtual xclBufferHandle
   import_bo(xclBufferExportHandle ehdl) = 0;
+
+  virtual void
+  close_export_handle(xclBufferExportHandle) = 0;
 
   // Import an exported BO from another process identified by argument pid.
   // This function is only supported on systems with pidfd kernel support
@@ -230,28 +236,28 @@ struct shim : public DeviceType
     : DeviceType(std::forward<Args>(args)...)
   {}
 
-  virtual void
-  close_device()
+  void
+  close_device() override
   {
     xclClose(DeviceType::get_device_handle());
   }
 
-  virtual void
-  open_context(const xuid_t xclbin_uuid , unsigned int ip_index, bool shared)
+  void
+  open_context(const xuid_t xclbin_uuid , unsigned int ip_index, bool shared) override
   {
     if (auto ret = xclOpenContext(DeviceType::get_device_handle(), xclbin_uuid, ip_index, shared))
       throw system_error(ret, "failed to open ip context");
   }
 
-  virtual void
-  close_context(const xuid_t xclbin_uuid, unsigned int ip_index)
+  void
+  close_context(const xuid_t xclbin_uuid, unsigned int ip_index) override
   {
     if (auto ret = xclCloseContext(DeviceType::get_device_handle(), xclbin_uuid, ip_index))
       throw system_error(ret, "failed to close ip context");
   }
 
-  virtual xclBufferHandle
-  alloc_bo(size_t size, unsigned int flags)
+  xclBufferHandle
+  alloc_bo(size_t size, unsigned int flags) override
   {
     auto bo = xclAllocBO(DeviceType::get_device_handle(), size, 0, flags);
     if (bo == XRT_NULL_BO)
@@ -260,8 +266,8 @@ struct shim : public DeviceType
     return bo;
   }
 
-  virtual xclBufferHandle
-  alloc_bo(void* userptr, size_t size, unsigned int flags)
+  xclBufferHandle
+  alloc_bo(void* userptr, size_t size, unsigned int flags) override
   {
     auto bo = xclAllocUserPtrBO(DeviceType::get_device_handle(), userptr, size, flags);
     if (bo == XRT_NULL_BO)
@@ -270,14 +276,14 @@ struct shim : public DeviceType
     return bo;
   }
 
-  virtual void
-  free_bo(xclBufferHandle bo)
+  void
+  free_bo(xclBufferHandle bo) override
   {
     xclFreeBO(DeviceType::get_device_handle(), bo);
   }
 
-  virtual xclBufferExportHandle
-  export_bo(xclBufferHandle bo) const
+  xclBufferExportHandle
+  export_bo(xclBufferHandle bo) const override
   {
     auto ehdl = xclExportBO(DeviceType::get_device_handle(), bo);
     if (ehdl == XRT_NULL_BO_EXPORT)
@@ -287,8 +293,8 @@ struct shim : public DeviceType
     return ehdl;
   }
 
-  virtual xclBufferHandle
-  import_bo(xclBufferExportHandle ehdl)
+  xclBufferHandle
+  import_bo(xclBufferExportHandle ehdl) override
   {
     auto ihdl = xclImportBO(DeviceType::get_device_handle(), ehdl, 0);
     if (ihdl == XRT_NULL_BO)
@@ -298,51 +304,57 @@ struct shim : public DeviceType
     return ihdl;
   }
 
-  virtual void
-  copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset)
+  void
+  close_export_handle(xclBufferExportHandle ehdl) override
+  {
+    xclCloseExportHandle(ehdl);
+  }
+
+  void
+  copy_bo(xclBufferHandle dst, xclBufferHandle src, size_t size, size_t dst_offset, size_t src_offset) override
   {
     if (auto err = xclCopyBO(DeviceType::get_device_handle(), dst, src, size, dst_offset, src_offset))
       throw system_error(err, "unable to copy BO");
   }
 
-  virtual void
-  sync_bo(xclBufferHandle bo, xclBOSyncDirection dir, size_t size, size_t offset)
+  void
+  sync_bo(xclBufferHandle bo, xclBOSyncDirection dir, size_t size, size_t offset) override
   {
     if (auto err = xclSyncBO(DeviceType::get_device_handle(), bo, dir, size, offset))
       throw system_error(err, "unable to sync BO");
   }
 
-  virtual void*
-  map_bo(xclBufferHandle bo, bool write)
+  void*
+  map_bo(xclBufferHandle bo, bool write) override
   {
     if (auto mapped = xclMapBO(DeviceType::get_device_handle(), bo, write))
       return mapped;
     throw system_error(EINVAL, "could not map BO");
   }
 
-  virtual void
-  unmap_bo(xclBufferHandle bo, void* addr)
+  void
+  unmap_bo(xclBufferHandle bo, void* addr) override
   {
     if (auto ret = xclUnmapBO(DeviceType::get_device_handle(), bo, addr))
       throw system_error(ret, "failed to unmap BO");
   }
 
-  virtual void
-  get_bo_properties(xclBufferHandle bo, struct xclBOProperties *properties) const
+  void
+  get_bo_properties(xclBufferHandle bo, struct xclBOProperties *properties) const override
   {
     if (auto ret = xclGetBOProperties(DeviceType::get_device_handle(), bo, properties))
       throw system_error(ret, "failed to get BO properties");
   }
 
-  virtual void
-  reg_read(uint32_t ipidx, uint32_t offset, uint32_t* data) const
+  void
+  reg_read(uint32_t ipidx, uint32_t offset, uint32_t* data) const override
   {
     if (auto ret = xclRegRead(DeviceType::get_device_handle(), ipidx, offset, data))
       throw system_error(ret, "failed to read ip(" + std::to_string(ipidx) + ")");
   }
 
-  virtual void
-  reg_write(uint32_t ipidx, uint32_t offset, uint32_t data)
+  void
+  reg_write(uint32_t ipidx, uint32_t offset, uint32_t data) override
   {
     if (auto ret = xclRegWrite(DeviceType::get_device_handle(), ipidx, offset, data))
       throw system_error(ret, "failed to write ip(" + std::to_string(ipidx) + ")");
@@ -352,15 +364,15 @@ struct shim : public DeviceType
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-  virtual void
-  xread(enum xclAddressSpace addr_space, uint64_t offset, void* buffer, size_t size) const
+  void
+  xread(enum xclAddressSpace addr_space, uint64_t offset, void* buffer, size_t size) const override
   {
     if (size != xclRead(DeviceType::get_device_handle(), addr_space, offset, buffer, size))
       throw system_error(-1, "failed to read at address (" + std::to_string(offset) + ")");
   }
 
-  virtual void
-  xwrite(enum xclAddressSpace addr_space, uint64_t offset, const void* buffer, size_t size)
+  void
+  xwrite(enum xclAddressSpace addr_space, uint64_t offset, const void* buffer, size_t size) override
   {
     if (size != xclWrite(DeviceType::get_device_handle(), addr_space, offset, buffer, size))
       throw system_error(-1, "failed to write to address (" + std::to_string(offset) + ")");
@@ -369,63 +381,63 @@ struct shim : public DeviceType
 # pragma GCC diagnostic pop
 #endif
 
-  virtual void
-  unmgd_pread(void* buffer, size_t size, uint64_t offset)
+  void
+  unmgd_pread(void* buffer, size_t size, uint64_t offset) override
   {
     if (auto ret = xclUnmgdPread(DeviceType::get_device_handle(), 0, buffer, size, offset))
       throw system_error(static_cast<int>(ret), "failed to read at address (" + std::to_string(offset) + ")");
   }
 
-  virtual void
-  unmgd_pwrite(const void* buffer, size_t size, uint64_t offset)
+  void
+  unmgd_pwrite(const void* buffer, size_t size, uint64_t offset) override
   {
     if (auto ret = xclUnmgdPwrite(DeviceType::get_device_handle(), 0, buffer, size, offset))
       throw system_error(static_cast<int>(ret), "failed to write to address (" + std::to_string(offset) + ")");
   }
 
-  virtual void
-  exec_buf(xclBufferHandle bo)
+  void
+  exec_buf(xclBufferHandle bo) override
   {
     if (auto ret = xclExecBuf(DeviceType::get_device_handle(), bo))
       throw system_error(ret, "failed to launch execution buffer");
   }
 
-  virtual int
-  exec_wait(int timeout_ms) const
+  int
+  exec_wait(int timeout_ms) const override
   {
     return xclExecWait(DeviceType::get_device_handle(), timeout_ms);
   }
 
-  virtual void
-  load_axlf(const axlf* buffer)
+  void
+  load_axlf(const axlf* buffer) override
   {
     if (auto ret = xclLoadXclBin(DeviceType::get_device_handle(), buffer))
       throw system_error(ret, "failed to load xclbin");
   }
 
-  virtual void
-  reclock(const uint16_t* target_freq_mhz)
+  void
+  reclock(const uint16_t* target_freq_mhz) override
   {
     if (auto ret = xclReClock2(DeviceType::get_device_handle(), 0, target_freq_mhz))
       throw system_error(ret, "failed to reclock specified clock");
   }
 
-  virtual void
-  p2p_enable(bool force)
+  void
+  p2p_enable(bool force) override
   {
     if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), true, force))
       throw system_error(ret, "failed to enable p2p");
   }
 
-  virtual void
-  p2p_disable(bool force)
+  void
+  p2p_disable(bool force) override
   {
     if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), false, force))
       throw system_error(ret, "failed to disable p2p");
   }
 
-  virtual void
-  set_cma(bool enable, uint64_t size)
+  void
+  set_cma(bool enable, uint64_t size) override
   {
     auto ret = xclCmaEnable(DeviceType::get_device_handle(), enable, size);
     if(ret == EXIT_SUCCESS)
@@ -444,23 +456,23 @@ struct shim : public DeviceType
       throw system_error(ret);
   }
 
-  virtual void
-  update_scheduler_status()
+  void
+  update_scheduler_status() override
   {
     if (auto ret = xclUpdateSchedulerStat(DeviceType::get_device_handle()))
       throw error(ret, "failed to update scheduler status");
   }
 
-  virtual void
-  user_reset(xclResetKind kind)
+  void
+  user_reset(xclResetKind kind) override
   {
     if (auto ret = xclInternalResetDevice(DeviceType::get_device_handle(), kind))
       throw error(ret, "failed to reset device");
   }
 
 #ifdef XRT_ENABLE_AIE
-  virtual xclGraphHandle
-  open_graph(const xuid_t uuid, const char *gname, xrt::graph::access_mode am)
+  xclGraphHandle
+  open_graph(const xuid_t uuid, const char *gname, xrt::graph::access_mode am) override
   {
     if (auto ghdl = xclGraphOpen(DeviceType::get_device_handle(), uuid, gname, am))
       return ghdl;
@@ -468,136 +480,136 @@ struct shim : public DeviceType
     throw system_error(EINVAL, "failed to open graph");
   }
 
-  virtual void
-  close_graph(xclGraphHandle handle)
+  void
+  close_graph(xclGraphHandle handle) override
   {
     return xclGraphClose(handle);
   }
 
-  virtual void
-  reset_graph(xclGraphHandle handle)
+  void
+  reset_graph(xclGraphHandle handle) override
   {
     if (auto ret = xclGraphReset(handle))
       throw system_error(ret, "fail to reset graph");
   }
 
-  virtual uint64_t
-  get_timestamp(xclGraphHandle handle)
+  uint64_t
+  get_timestamp(xclGraphHandle handle) override
   {
     return xclGraphTimeStamp(handle);
   }
 
-  virtual void
-  run_graph(xclGraphHandle handle, int iterations)
+  void
+  run_graph(xclGraphHandle handle, int iterations) override
   {
     if (auto ret = xclGraphRun(handle, iterations))
       throw system_error(ret, "fail to run graph");
   }
 
-  virtual int
-  wait_graph_done(xclGraphHandle handle, int timeout)
+  int
+  wait_graph_done(xclGraphHandle handle, int timeout) override
   {
     return xclGraphWaitDone(handle, timeout);
   }
 
-  virtual void
-  wait_graph(xclGraphHandle handle, uint64_t cycle)
+  void
+  wait_graph(xclGraphHandle handle, uint64_t cycle) override
   {
     if (auto ret = xclGraphWait(handle, cycle))
       throw system_error(ret, "fail to wait graph");
   }
 
-  virtual void
-  suspend_graph(xclGraphHandle handle)
+  void
+  suspend_graph(xclGraphHandle handle) override
   {
     if (auto ret = xclGraphSuspend(handle))
       throw system_error(ret, "fail to suspend graph");
   }
 
-  virtual void
-  resume_graph(xclGraphHandle handle)
+  void
+  resume_graph(xclGraphHandle handle) override
   {
     if (auto ret = xclGraphResume(handle))
       throw system_error(ret, "fail to resume graph");
   }
 
-  virtual void
-  end_graph(xclGraphHandle handle, uint64_t cycle)
+  void
+  end_graph(xclGraphHandle handle, uint64_t cycle) override
   {
     if (auto ret = xclGraphEnd(handle, cycle))
       throw system_error(ret, "fail to end graph");
   }
 
-  virtual void
-  update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size)
+  void
+  update_graph_rtp(xclGraphHandle handle, const char* port, const char* buffer, size_t size) override
   {
     if (auto ret = xclGraphUpdateRTP(handle, port, buffer, size))
       throw system_error(ret, "fail to update graph rtp");
   }
 
-  virtual void
-  read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size)
+  void
+  read_graph_rtp(xclGraphHandle handle, const char* port, char* buffer, size_t size) override
   {
     if (auto ret = xclGraphReadRTP(handle, port, buffer, size))
       throw system_error(ret, "fail to read graph rtp");
   }
 
-  virtual void
-  open_aie_context(xrt::aie::access_mode am)
+  void
+  open_aie_context(xrt::aie::access_mode am) override
   {
     if (auto ret = xclAIEOpenContext(DeviceType::get_device_handle(), am))
       throw error(ret, "fail to open aie context");
   }
 
-  virtual void
-  sync_aie_bo(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  void
+  sync_aie_bo(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) override
   {
     if (auto ret = xclSyncBOAIE(DeviceType::get_device_handle(), bo, gmioName, dir, size, offset))
       throw system_error(ret, "fail to sync aie bo");
   }
 
-  virtual void
-  reset_aie()
+  void
+  reset_aie() override
   {
     if (auto ret = xclResetAIEArray(DeviceType::get_device_handle()))
       throw system_error(ret, "fail to reset aie");
   }
 
-  virtual void
-  sync_aie_bo_nb(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset)
+  void
+  sync_aie_bo_nb(xrt::bo& bo, const char *gmioName, xclBOSyncDirection dir, size_t size, size_t offset) override
   {
     if (auto ret = xclSyncBOAIENB(DeviceType::get_device_handle(), bo, gmioName, dir, size, offset))
       throw system_error(ret, "fail to sync aie non-blocking bo");
   }
 
-  virtual void
-  wait_gmio(const char *gmioName)
+  void
+  wait_gmio(const char *gmioName) override
   {
     if (auto ret = xclGMIOWait(DeviceType::get_device_handle(), gmioName))
       throw system_error(ret, "fail to wait gmio");
   }
 
-  virtual int
-  start_profiling(int option, const char* port1Name, const char* port2Name, uint32_t value)
+  int
+  start_profiling(int option, const char* port1Name, const char* port2Name, uint32_t value) override
   {
     return xclStartProfiling(DeviceType::get_device_handle(), option, port1Name, port2Name, value);
   }
 
-  virtual uint64_t
-  read_profiling(int phdl)
+  uint64_t
+  read_profiling(int phdl) override
   {
     return xclReadProfiling(DeviceType::get_device_handle(), phdl);
   }
 
-  virtual void
-  stop_profiling(int phdl)
+  void
+  stop_profiling(int phdl) override
   {
     if (auto ret = xclStopProfiling(DeviceType::get_device_handle(), phdl))
       throw system_error(ret, "fail to wait gmio");
   }
 
-  virtual void
-  load_axlf_meta(const axlf* buffer)
+  void
+  load_axlf_meta(const axlf* buffer) override
   {
     if (auto ret = xclLoadXclBinMeta(DeviceType::get_device_handle(), buffer))
       throw system_error(ret, "failed to load xclbin");

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -442,6 +442,12 @@ unsigned int xclImportBO(xclDeviceHandle handle, int boGlobalHandle,unsigned fla
   return drv->xclImportBO(boGlobalHandle,flags);
 }
 
+int xclCloseExportHandle(int ehdl)
+{
+  // Implement per sw_em requirements
+  return 0;
+}
+
 int xclCopyBO(xclDeviceHandle handle, unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)
 {
     xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1763,10 +1763,10 @@ xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
   return drv->xclImportBO(fd, flags);
 }
 
-void
+int
 xclCloseExportHandle(int fd)
 {
-  close(fd);
+  return close(fd) ? -errno : 0;
 }
 
 static int

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  * Author(s): Hem C. Neema
  *          : Min Ma
  * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
@@ -1761,6 +1761,12 @@ xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
   if (!drv)
     return -EINVAL;
   return drv->xclImportBO(fd, flags);
+}
+
+void
+xclCloseExportHandle(int fd)
+{
+  close(fd);
 }
 
 static int

--- a/src/runtime_src/core/include/xrt.h
+++ b/src/runtime_src/core/include/xrt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2015-2022, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -596,7 +596,8 @@ xclCopyBO(xclDeviceHandle handle, xclBufferHandle dstBoHandle,
  *
  * Export a BO for import into another device or Linux subsystem which
  * accepts DMA-BUF fd This operation is backed by Linux DMA-BUF
- * framework
+ * framework.  The file handle must be explicitly closed when no
+ * longer needed.
  */
 XCL_DRIVER_DLLESPEC
 xclBufferExportHandle

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -334,6 +334,13 @@ public:
    * process or another process. For multiprocess transfer, the exported
    * buffer must be transferred through a proper IPC facility to translate
    * the underlying file-descriptor properly into another process. 
+   *
+   * The lifetime of the exported buffer handle is associated with the
+   * exporting buffer (this).  The handle is disposed of when the
+   * exporting buffer is destructed.
+   *
+   * It is undefined behavior to use the export handle after the
+   * exporting buffer object has gone out of scope.
    */
   XCL_DRIVER_DLLESPEC
   xclBufferExportHandle

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -402,9 +402,10 @@ unsigned int xclImportBO(xclDeviceHandle handle, int boGlobalHandle,unsigned fla
   return drv->xclImportBO(boGlobalHandle,flags);
 }
 
-void xclCloseExportHandle(int ehdl)
+int xclCloseExportHandle(int ehdl)
 {
   // Implement per cpu_em requirements
+  return 0;
 }
 
 int xclCopyBO(xclDeviceHandle handle, unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -400,6 +400,11 @@ unsigned int xclImportBO(xclDeviceHandle handle, int boGlobalHandle,unsigned fla
   if (!drv)
     return -1;
   return drv->xclImportBO(boGlobalHandle,flags);
+}
+
+void xclCloseExportHandle(int ehdl)
+{
+  // Implement per cpu_em requirements
 }
 
 int xclCopyBO(xclDeviceHandle handle, unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -38,9 +38,10 @@ unsigned int xclImportBO(xclDeviceHandle handle, int boGlobalHandle, unsigned fl
   return drv->xclImportBO(boGlobalHandle,flags);
 }
 
-void xclCloseExportHandle(int ehdl)
+int xclCloseExportHandle(int ehdl)
 {
   // Implement per hw_em requirements
+  return 0;
 }
 
 int xclCopyBO(xclDeviceHandle handle, unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,6 +36,11 @@ unsigned int xclImportBO(xclDeviceHandle handle, int boGlobalHandle, unsigned fl
   if (!drv)
     return -1;
   return drv->xclImportBO(boGlobalHandle,flags);
+}
+
+void xclCloseExportHandle(int ehdl)
+{
+  // Implement per hw_em requirements
 }
 
 int xclCopyBO(xclDeviceHandle handle, unsigned int dst_boHandle, unsigned int src_boHandle, size_t size, size_t dst_offset, size_t src_offset)

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1,8 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
- * Author(s): Umang Parekh
- *          : Sonal Santan
- *          : Ryan Radjabi
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * XRT PCIe library layered on top of xocl kernel driver
  *
@@ -2698,6 +2695,12 @@ unsigned int xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
         std::cout << __func__ << ", " << std::this_thread::get_id() << ", handle & XOCL Device are bad" << std::endl;
     }
     return drv ? drv->xclImportBO(fd, flags) : -ENODEV;
+}
+
+void
+xclCloseExportHandle(int fd)
+{
+  close(fd);
 }
 
 ssize_t xclUnmgdPwrite(xclDeviceHandle handle, unsigned flags, const void *buf, size_t count, uint64_t offset)

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2697,10 +2697,10 @@ unsigned int xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
     return drv ? drv->xclImportBO(fd, flags) : -ENODEV;
 }
 
-void
+int
 xclCloseExportHandle(int fd)
 {
-  close(fd);
+  return close(fd) ? -errno : 0;
 }
 
 ssize_t xclUnmgdPwrite(xclDeviceHandle handle, unsigned flags, const void *buf, size_t count, uint64_t offset)

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -507,11 +507,12 @@ xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned flags)
   return XRT_NULL_BO_EXPORT;
 }
 
-void
+int
 xclCloseExportHandle(xclBufferExportHandle fd)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::debug, "XRT", "xclCloseExportHandle() NOT IMPLEMENTED");
+  return 0;
 }
 
 int

--- a/src/runtime_src/core/pcie/noop/shim.cpp
+++ b/src/runtime_src/core/pcie/noop/shim.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -505,6 +505,13 @@ xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned flags)
   xrt_core::message::
     send(xrt_core::message::severity_level::debug, "XRT", "xclImportBO() NOT IMPLEMENTED");
   return XRT_NULL_BO_EXPORT;
+}
+
+void
+xclCloseExportHandle(xclBufferExportHandle fd)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclCloseExportHandle() NOT IMPLEMENTED");
 }
 
 int

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1791,11 +1791,12 @@ xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned flags)
   return INVALID_HANDLE_VALUE;
 }
 
-void
+int
 xclCloseExportHandle(xclBufferExportHandle)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::debug, "XRT", "xclCloseExportHandle() NOT IMPLEMENTED");
+  return 0;
 }
 
 int

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  * Copyright (C) 2019 Samsung Semiconductor, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -19,13 +19,16 @@
 #include "shim.h"
 #include "xrt_mem.h"
 #include "xclfeatures.h"
+
 #include "core/common/config_reader.h"
-#include "core/common/xclbin_parser.h"
-#include "core/common/message.h"
-#include "core/common/system.h"
 #include "core/common/device.h"
+#include "core/common/message.h"
 #include "core/common/query_requests.h"
+#include "core/common/system.h"
+#include "core/common/xclbin_parser.h"
+#include "core/common/xrt_profiling.h"
 #include "core/common/AlignedAllocator.h"
+
 #include "core/include/xcl_perfmon_parameters.h"
 
 #include <windows.h>
@@ -34,8 +37,6 @@
 #include <strsafe.h>
 #include <crtdefs.h>
 
-
-// To be simplified
 #include "core/pcie/driver/windows/alveo/include/XoclUser_INTF.h"
 
 #include <cstring>
@@ -1788,6 +1789,13 @@ xclImportBO(xclDeviceHandle handle, xclBufferExportHandle fd, unsigned flags)
   xrt_core::message::
     send(xrt_core::message::severity_level::debug, "XRT", "xclImportBO() NOT IMPLEMENTED");
   return INVALID_HANDLE_VALUE;
+}
+
+void
+xclCloseExportHandle(xclBufferExportHandle)
+{
+  xrt_core::message::
+    send(xrt_core::message::severity_level::debug, "XRT", "xclCloseExportHandle() NOT IMPLEMENTED");
 }
 
 int

--- a/src/runtime_src/core/pcie/windows/alveo/shim.h
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.h
@@ -1,13 +1,12 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
  */
 #ifndef XRT_CORE_PCIE_WINDOWS_ALVEO_SHIM_H
 #define XRT_CORE_PCIE_WINDOWS_ALVEO_SHIM_H
 
 #include "config.h"
 #include "xrt.h"
-#include "core/common/xrt_profiling.h"
 #include "core/pcie/driver/windows/alveo/include/XoclUser_INTF.h"
 
 struct FeatureRomHeader;
@@ -17,43 +16,35 @@ namespace userpf {
 void
 get_rom_info(xclDeviceHandle hdl, FeatureRomHeader* value);
 
-
 void
 get_device_info(xclDeviceHandle hdl, XOCL_DEVICE_INFORMATION* value);
 
-/**
- * get_mem_topology() - Get xclbin mem topology from driver
- *
- * @hdl: device handle
- * @buffer: buffer to hold the mem topology section, ignored if nullptr
- * @size: size of buffer
- * @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
- */
+// get_mem_topology() - Get xclbin mem topology from driver
+//
+// @hdl: device handle
+// @buffer: buffer to hold the mem topology section, ignored if nullptr
+// @size: size of buffer
+// @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
 void
 get_mem_topology(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
 
-/**
- * get_ip_layout() - Get xclbin ip layout  from driver
- *
- * @hdl: device handle
- * @buffer: buffer to hold the iplayout section, ignored if nullptr
- * @size: size of buffer
- * @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
- */
+// get_ip_layout() - Get xclbin ip layout  from driver
+//
+// @hdl: device handle
+// @buffer: buffer to hold the iplayout section, ignored if nullptr
+// @size: size of buffer
+// @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
 void
 get_ip_layout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
 
-/**
- * get_debug_ip_layout() - Get xclbin debug ip layout  from driver
- *
- * @hdl: device handle
- * @buffer: buffer to hold the debug iplayout section, ignored if nullptr
- * @size: size of buffer
- * @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
- */
+// get_debug_ip_layout() - Get xclbin debug ip layout  from driver
+//
+// @hdl: device handle
+// @buffer: buffer to hold the debug iplayout section, ignored if nullptr
+// @size: size of buffer
+// @size_ret: returns actual size in bytes required for buffer, ignored if nullptr
 void
 get_debug_ip_layout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
-
 
 void
 get_bdf_info(xclDeviceHandle hdl, uint16_t bdf[3]);


### PR DESCRIPTION
#### Problem solved by the commit
When exporting a buffer object, the export handle (file descriptor
linux) is not closed automatically so the underlying drm buffer is
not freed even when the exporting buffer object is deleted.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1116820 testing of p2p buffer export and import.    Iterating export/import 
while properly releasing allocated buffer objects causes out-of-memory because 
the underlying export fd are not closed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
In this PR, the export handle is managed by the exporting buffer
object implementation and lifetime is tied to that of the buffer
object.  When the buffer object is destructed, the export handle (if
any) is closed.  The changes in this PR apply to both native XRT APIs
and OpenCL.

#### Risks (if any) associated the changes in the commit
There are two semantic changes in this PR that should be noted:

First, the export handle of a buffer object is now stored with the
exporting buffer object.  If a buffer object is exported multiple
times, the same export handle (fd) is returned.

Second, the export handle lifetime is tied to the exporting buffer
which cannot be closed until after the export handle is no longer
needed.

#### What has been tested and how, request additional testing if necessary
The changes were tested per the associated CR.

#### Documentation impact (if any)
Documentation probably should reflect the lifetime requirement
mentioned above.