### PR TITLE
Update OpenClTracePlugin name, remove unnecessary member variable 

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -143,10 +143,8 @@ namespace xdp {
     {
       (db->getDynamicInfo()).addString(api) ;
     }
-    auto continuous_trace =
-      xrt_core::config::get_continuous_trace() ;
 
-    if (continuous_trace)
+    if (xrt_core::config::get_continuous_trace())
       XDPPlugin::startWriteThread(XDPPlugin::get_trace_file_dump_int_s(), "VP_TRACE");
   }
 

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
@@ -26,7 +26,7 @@
 
 namespace xdp {
 
-  static OpenCLTraceProfilingPlugin openclPluginInstance ;
+  static OpenCLTracePlugin openclPluginInstance ;
 
   static void log_function_start(const char* functionName,
 				 uint64_t queueAddress,

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -26,7 +26,7 @@
 
 namespace xdp {
 
-  OpenCLTraceProfilingPlugin::OpenCLTraceProfilingPlugin() :
+  OpenCLTracePlugin::OpenCLTracePlugin() :
     XDPPlugin()
   {
     db->registerPlugin(this) ;
@@ -38,14 +38,11 @@ namespace xdp {
     (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), "VP_TRACE") ;
 
     // Continuous writing of opencl trace
-    continuous_trace =
-      xrt_core::config::get_continuous_trace() ;
-
-    if (continuous_trace)
+    if (xrt_core::config::get_continuous_trace()) 
       XDPPlugin::startWriteThread(XDPPlugin::get_trace_file_dump_int_s(), "VP_TRACE");
   }
 
-  OpenCLTraceProfilingPlugin::~OpenCLTraceProfilingPlugin()
+  OpenCLTracePlugin::~OpenCLTracePlugin()
   {
     if (VPDatabase::alive())
     {
@@ -60,7 +57,7 @@ namespace xdp {
     }
   }
 
-  void OpenCLTraceProfilingPlugin::emulationSetup()
+  void OpenCLTracePlugin::emulationSetup()
   {
     XDPPlugin::emulationSetup() ;
 

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h
@@ -21,17 +21,15 @@
 
 namespace xdp {
 
-  class OpenCLTraceProfilingPlugin : public XDPPlugin
+  class OpenCLTracePlugin : public XDPPlugin
   {
-  private:
-    bool continuous_trace ;
 
   protected:
     virtual void emulationSetup() ;
 
   public:
-    OpenCLTraceProfilingPlugin() ;
-    ~OpenCLTraceProfilingPlugin() ;
+    OpenCLTracePlugin() ;
+    ~OpenCLTracePlugin() ;
   } ;
 
 }


### PR DESCRIPTION
Update OpenClTracePlugin name, remove unnecessary member variable and local variable
This is a minor refactoring.