### PR TITLE
Fix boost/any.hpp transitive dep

### DIFF
--- a/src/CMake/config/xrt.fp.in
+++ b/src/CMake/config/xrt.fp.in
@@ -45,3 +45,8 @@ set(@PROJECT_NAME@_SWEMU_LIBRARIES @PROJECT_NAME@::xrt_swemu)
 set(@PROJECT_NAME@_HWEMU_LIBRARIES @PROJECT_NAME@::xrt_hwemu)
 
 set(@PROJECT_NAME@_FOUND True)
+
+message(STATUS "Found @PROJECT_NAME@: ${@PROJECT_NAME@_CMAKE_DIR} (found version \"${@PROJECT_NAME@_VERSION}\")")
+
+# XRT is requiring Boost in its interface
+find_package(Boost REQUIRED)

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -72,7 +72,9 @@ set_target_properties(xrt_coreutil PROPERTIES
 target_link_libraries(xrt_coreutil
   PRIVATE
   ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_SYSTEM_LIBRARY})
+  ${Boost_SYSTEM_LIBRARY}
+  INTERFACE
+  Boost::boost)
 
 # Targets linking with xrt_coreutil_static must also link with boost
 # libraries used by coreutil.  These type of link dependencies are
@@ -82,7 +84,8 @@ target_link_libraries(xrt_coreutil
 target_link_libraries(xrt_coreutil_static
   INTERFACE
   boost_filesystem
-  boost_system)
+  boost_system
+  Boost::boost)
 
 if (NOT WIN32)
   # Additional link dependencies for xrt_coreutil

--- a/src/runtime_src/core/pcie/linux/CMakeLists.txt
+++ b/src/runtime_src/core/pcie/linux/CMakeLists.txt
@@ -55,6 +55,8 @@ target_link_libraries(xrt_core
   rt
   dl
   uuid
+  INTERFACE
+  Boost::boost
   )
 
 # Targets linking with xrt_core_static must also link with additional
@@ -71,6 +73,7 @@ target_link_libraries(xrt_core_static
   dl
   rt
   pthread
+  Boost::boost
   )
 
 install(TARGETS xrt_core


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
XRT Native APIs are using boost/any.hpp in their public interface. Yet, the CMake infrastructure does not inform consumers that they must use the boost include directory in the project include path.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
