### PR TITLE
Default xrt::ip address range to 64k

### DIFF
--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -189,9 +189,10 @@ class ip_impl
   size_t
   address_range(const xrt::uuid& xid, const std::string& ipname) const
   {
+    constexpr auto default_address_range = 64_kb;
     auto xml_section = device->get_axlf_section(EMBEDDED_METADATA, xid);
     if (!xml_section.first)
-      return 0;
+      return default_address_range;
 
     // Normalize ipname to kernel name
     std::string kname(ipname.substr(0,ipname.find(":"))); 


### PR DESCRIPTION
#### Problem solved by the commit
This PR changes xrt::ip default address range from 0 to 64kb, which is the default value used in xclbin_parser when kernel address is missing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The default value changed in this PR comes into play when the xclbin has no XML metadata.

#### Risks (if any) associated the changes in the commit
None, the otherwise default range of 0, rendered the xrt::ip useless.
