### PR TITLE
Issue #6027 Update Vitis default paths in scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -225,8 +225,14 @@ if [[ ! -z ${XRT_BOOST_INSTALL:+x} ]]; then
 fi
 
 # we pick microblaze toolchain from Vitis install
-if [[ -z ${XILINX_VITIS:+x} ]]; then
-    export XILINX_VITIS=/proj/xbuilds/2019.2_released/installs/lin64/Vitis/2019.2
+if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
+    export XILINX_VITIS=/proj/xbuilds/2021.2_released/installs/lin64/Vitis/2021.2
+    if [[ ! -d ${XILINX_VITIS} ]]; then
+        echo "****************************************************************"
+        echo "* XILINX_VITIS is undefined or not accessible                  *"
+        echo "* MicroBlaze firmware will not be built                        *"
+        echo "****************************************************************"
+    fi
 fi
 
 if [[ $dbg == 1 ]]; then

--- a/build/run.sh
+++ b/build/run.sh
@@ -7,15 +7,17 @@
 #  % run.sh -dbg emacs
 XRTBUILD=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
-# Set to location of your preferred Vitis install
-vitis=/proj/xbuilds/2021.1_released/installs/lin64/Vitis/2021.1
+# Preserve XILINX_VITIS or set to default location
+vitis=${XILINX_VITIS:=/proj/xbuilds/2021.2_released/installs/lin64/Vitis/2021.2}
+
+# Preserve XILINX_XRT if set
+xrt=${XILINX_XRT}
 
 ext=.o
 rel="Release"
 cmd=""
 em=""
 conf=""
-xrt=""
 
 usage()
 {
@@ -86,18 +88,13 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "X$ini" != "X" ] ; then
- echo "SDACCEL_INI_PATH=$ini"
- export SDACCEL_INI_PATH=$ini
+ echo "XRT_INI_PATH=$ini"
+ export XRT_INI_PATH=$ini
 fi
 
 if [ "X$em" != "X" ] ; then
  echo "XCL_EMULATION_MODE=$em"
  export XCL_EMULATION_MODE=$em
-fi
-
-if [ "X$conf" != "X" ] ; then
- echo "XCL_CONFORMANCE=1"
- export XCL_CONFORMANCE=1
 fi
 
 if [ "X$xrt" == "X" ] ; then
@@ -121,10 +118,10 @@ if [ "X$ldp" != "X" ] ; then
  export LD_LIBRARY_PATH=$ldp:${LD_LIBRARY_PATH}
 fi
 
-echo "XILINX_XRT=$XILINX_XRT"
-echo "XILINX_VITIS=$XILINX_VITIS"
-echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
-echo "OCL_ICD_VENDORS=$OCL_ICD_VENDORS"
-echo "PATH=$PATH"
+echo "XILINX_XRT      = $XILINX_XRT"
+echo "XILINX_VITIS    = $XILINX_VITIS"
+echo "LD_LIBRARY_PATH = $LD_LIBRARY_PATH"
+echo "OCL_ICD_VENDORS = $OCL_ICD_VENDORS"
+echo "PATH            = $PATH"
 
 $cmd


### PR DESCRIPTION
#### Problem solved by the commit
Update default VITIS paths in build scripts

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Issues #6027 raises concerns about magically defaulting Vitis paths in build.sh.


#### How problem was solved, alternative solutions (if any) and why they were rejected
Defaulting the paths will not change, but they are updated to more recent versions and warning is issued if path cannot be found. Removing the paths and relying on internal users managing the setting of XILINX_VITIS is not feasible.  The scripts are primarily for convenience of internal users.

#### Risks (if any) associated the changes in the commit
Risk is minimal resulting from path update in build.sh and preservation of XILINX_XRT in run.sh.

This PR closes #6027.
