### PR TITLE
Fix for CR-1114398: XRT github documentation is still referencing xbm…

### DIFF
--- a/src/runtime_src/doc/toc/platforms_partitions.rst
+++ b/src/runtime_src/doc/toc/platforms_partitions.rst
@@ -62,7 +62,7 @@ Shell
 
     Alveo shell partitions and loading for 2RP platform
 
-In two stage platforms, Shell partition contains additional shell components such as PCIe DMA engine, AXI Firewalls, Address Re-mapper, ERT, etc. Shell partition is explicitly loaded by system administrator using ``xbmgmt partition`` command. After Shell partition is loaded, xclmgmt driver posts ``XCL_MAILBOX_REQ_MGMT_STATE`` message to the xocl driver via mailbox to indicate shell has changed. xocl driver then requests for metadata via ``XCL_MAILBOX_REQ_PEER_DATA`` opcode. xclmgmt managemet driver responds by sending relevant information about shell components such as XDMA that should be managed by xocl driver. A system administrator can pre-load a Shell based on the workload the system is being provised for. A new Shell xsabin load clobbers previous Shell and User images.
+In two stage platforms, Shell partition contains additional shell components such as PCIe DMA engine, AXI Firewalls, Address Re-mapper, ERT, etc. Shell partition is explicitly loaded by system administrator using ``xbmgmt program --shell <shell-file w/ path>`` command. After Shell partition is loaded, xclmgmt driver posts ``XCL_MAILBOX_REQ_MGMT_STATE`` message to the xocl driver via mailbox to indicate shell has changed. xocl driver then requests for metadata via ``XCL_MAILBOX_REQ_PEER_DATA`` opcode. xclmgmt managemet driver responds by sending relevant information about shell components such as XDMA that should be managed by xocl driver. A system administrator can pre-load a Shell based on the workload the system is being provised for. A new Shell xsabin load clobbers previous Shell and User images.
 
 User
 ====


### PR DESCRIPTION

#### Problem solved by the commit
CR-1114398 : Doc issue


#### How problem was solved, alternative solutions (if any) and why they were rejected

New command `xbmgmt program --shell ` is documented instead of old `xbmgmt partition`