### PR TITLE
CR-1045783 xbutil2 bdf host report enhancement

### DIFF
--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -23,7 +23,6 @@
 
 // 3rd Party Library - Include Files
 #include <string>
-#include <map>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
 

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -128,4 +128,12 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   }
 
   _output << device_table << std::endl;
+
+  device_table.removeEntry(0);
+
+  _output << device_table << std::endl;
+
+  device_table.removeHeader("Shell");
+
+  _output << device_table << std::endl;
 }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -128,12 +128,4 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   }
 
   _output << device_table << std::endl;
-
-  device_table.removeEntry(0);
-
-  _output << device_table << std::endl;
-
-  device_table.removeHeader("Shell");
-
-  _output << device_table << std::endl;
 }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -64,10 +64,13 @@ updateDataMapValue(std::map<std::string, size_t>& data_length_map,
                   const boost::property_tree::ptree& dev,
                   const std::string& key)
 {
-  if (data_length_map.find(key) == data_length_map.end())
+  auto itr = data_length_map.find(key);
+  if (itr == data_length_map.end())
     data_length_map[key] = dev.get<std::string>(key).size();
   else
-    data_length_map[key] = std::max(data_length_map[key], dev.get<std::string>(key).size());
+    // Set the value in the map to the maximum among the currently stored string length
+    // and the length of the string referenced by the key
+    (*itr).second = std::max((*itr).second, dev.get<std::string>(key).size());
 }
 
 void

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -143,15 +143,15 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   const std::string instance_header = "Device ID";
   // Verify the headers are not longer than the longest data string
   data_length_map["bdf"] = std::max(data_length_map["bdf"], bdf_header.size());
-  data_length_map["vbnv"] = std::max(data_length_map["vbnv"], vnbv_header.size());
+  data_length_map["vbnv"] = std::max(data_length_map["vbnv"], vbnv_header.size());
   data_length_map["id"] = std::max(data_length_map["id"], id_header.size());
   // Generate the number of blanks required for equal spacing
   std::string bdf_blanks = std::string(data_length_map["bdf"] - bdf_header.size(), ' ');
-  std::string vnbv_blanks = std::string(data_length_map["vbnv"] - vnbv_header.size(), ' ');
+  std::string vbnv_blanks = std::string(data_length_map["vbnv"] - vbnv_header.size(), ' ');
   std::string id_blanks = std::string(data_length_map["id"] - id_header.size(), ' ');
 
   // Output the data headers in a table format
-  _output << boost::format("  %s%s : %s%s %s%s %s\n") % bdf_header % bdf_blanks % vnbv_header % vnbv_blanks % id_header % id_blanks % instance_header;
+  _output << boost::format("  %s%s : %s%s %s%s %s\n") % bdf_header % bdf_blanks % vbnv_header % vbnv_blanks % id_header % id_blanks % instance_header;
 
   // Output each devices data in a table format
   for (auto& kd : available_devices) {
@@ -159,9 +159,9 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
 
     std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
     bdf_blanks = std::string(data_length_map["bdf"] - dev.get<std::string>("bdf").size(), ' ');
-    vnbv_blanks = std::string(data_length_map["vbnv"] - dev.get<std::string>("vbnv").size(), ' ');
+    vbnv_blanks = std::string(data_length_map["vbnv"] - dev.get<std::string>("vbnv").size(), ' ');
     id_blanks = std::string(data_length_map["id"] - dev.get<std::string>("id").size(), ' ');
-    _output << boost::format("  %s%s : %s%s %s%s %s %s\n") % dev.get<std::string>("bdf") % bdf_blanks % dev.get<std::string>("vbnv") % vnbv_blanks % dev.get<std::string>("id") % id_blanks % dev.get<std::string>("instance", "") % note;
+    _output << boost::format("  %s%s : %s%s %s%s %s %s\n") % dev.get<std::string>("bdf") % bdf_blanks % dev.get<std::string>("vbnv") % vbnv_blanks % dev.get<std::string>("id") % id_blanks % dev.get<std::string>("instance", "") % note;
   }
   _output << std::endl;
 }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -137,10 +137,10 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   }
 
   // Allocate the header strings
-  std::string bdf_header = "BDF";
-  std::string vnbv_header = "Shell";
-  std::string id_header = "Interface UUID";
-  std::string instance_header = "Device ID";
+  const std::string bdf_header = "BDF";
+  const std::string vbnv_header = "Shell";
+  const std::string id_header = "Platform UUID";
+  const std::string instance_header = "Device ID";
   // Verify the headers are not longer than the longest data string
   data_length_map["bdf"] = std::max(data_length_map["bdf"], bdf_header.size());
   data_length_map["vbnv"] = std::max(data_length_map["vbnv"], vnbv_header.size());

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -59,7 +59,7 @@ ReportHost::getPropertyTree20202( const xrt_core::device * /*_pDevice*/,
   _pt.add_child("host", pt);
 }
 
-void
+static void
 updateDataMapValue(std::map<std::string, size_t>& data_length_map,
                   const boost::property_tree::ptree& dev,
                   const std::string& key)

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -111,11 +111,11 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
 
   if(available_devices.empty())
     _output << "  0 devices found" << std::endl;
-  
+
   for(auto& kd : available_devices) {
     const boost::property_tree::ptree& dev = kd.second;
     std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
-    _output << boost::format("  [%s] : %s %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % dev.get<std::string>("instance", "") % note;
+    _output << boost::format("  [%s] : [%s] [%s] [%s] %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % dev.get<std::string>("id") % dev.get<std::string>("instance", "") % note;
   }
   _output << std::endl;
 }

--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "Table2D.h"
+
+// 3rd Party Library - Include Files
+#include <algorithm>
+#include <boost/format.hpp>
+
+Table2D::Table2D() : m_entry_count(0)
+{
+}
+
+Table2D::Table2D(const std::vector<HeaderData>& headers_data) : m_entry_count(0)
+{
+    addHeaders(headers_data);
+}
+
+bool
+Table2D::addHeader(const HeaderData& header_data)
+{
+    // Format the header into a table data struct
+    ColumnData column;
+    column.header_data = header_data;
+    column.entry_data = std::vector<std::string>();
+    // The only element in the new column is the header, so it defines the max length
+    column.max_length = header_data.header.size();
+    m_data.push_back(column);
+    return true;
+}
+
+bool
+Table2D::addHeaders(const std::vector<HeaderData>& headers_data)
+{
+    for (auto& header_data : headers_data) {
+        if (!addHeader(header_data))
+            return false;
+    }
+    return true;
+}
+
+bool
+Table2D::addEntry(const std::vector<std::string>& entry_data)
+{
+    // Keep track of each new entry
+    ++m_entry_count;
+
+    if (entry_data.size() < m_data.size())
+        std::cout << "Warning: Given entry data is smaller than table. Later values will be N/A.\n";
+    else if (entry_data.size() > m_data.size())
+        std::cout << "Warning: Given entry data is larger than table. Later values will not be appended.\n";
+
+    // Determine the maximum number of elements to add from the entry
+    const size_t vector_size = std::max(entry_data.size(), m_data.size());
+
+    // Iterate through the entry data and the table adding the table enetry elements in order
+    for (size_t data_index = 0; data_index < vector_size; ++data_index) {
+        auto& table_entry = m_data[data_index];
+        if (data_index < entry_data.size()) {
+            const std::string& entry = entry_data[data_index];
+            table_entry.entry_data.push_back(entry);
+            table_entry.max_length = std::max(table_entry.max_length, entry.size());
+        }
+        else
+            table_entry.entry_data.push_back("N/A");
+    }
+    return true;
+}
+
+bool
+Table2D::addEntries(const std::vector<std::vector<std::string>>& entries_data)
+{
+    for (auto& entry_data : entries_data) {
+        if(!addEntry(entry_data))
+            return false;
+    }
+    return true;
+}
+
+std::ostream& 
+Table2D::print(std::ostream& os)
+{
+    // Stores each row of the table
+    std::vector<std::string> output;
+
+    // Add an empty string for each entry plus a header row
+    for (size_t i = 0; i < m_entry_count + 1; i++) {
+        output.push_back("");
+    }
+
+    // Iterate through the table columns while adding each element to the appropriate row
+    for (auto& table_column : m_data) {
+        size_t left_blanks = 0;
+        size_t right_blanks = 0;
+        
+        // Add header for current entry to the top row
+        std::string& header = table_column.header_data.header;
+        getBlankSizes(table_column, header.size(), left_blanks, right_blanks);
+        output[0].append(boost::str(boost::format("%s%s%s  ") % std::string(left_blanks, ' ') % header % std::string(right_blanks, ' ')));
+
+        // Iterate through each entry in the data column and append the data to the appropriate row
+        std::vector<std::string>& data = table_column.entry_data;
+        for (size_t data_index = 0; data_index < data.size(); ++data_index) {
+            std::string& entry = data[data_index];
+            getBlankSizes(table_column, entry.size(), left_blanks, right_blanks);
+            // Plus one as the 0 element is the header row
+            output[data_index + 1].append(boost::str(boost::format("%s%s%s  ") % std::string(left_blanks, ' ') % entry % std::string(right_blanks, ' ')));
+        }
+    }
+
+    // Add a newline to each output row
+    // Place row into the output stream
+    for (auto& output_line : output) {
+        output_line.append("\n");
+        os << output_line;
+    }
+
+    return os;
+}
+
+void 
+Table2D::getBlankSizes(ColumnData& table_data, size_t string_size, size_t& left_blanks, size_t& right_blanks)
+{
+    const size_t max_string_size = table_data.max_length;
+    const size_t required_buffer = max_string_size - string_size;
+    switch (table_data.header_data.justification) {
+        case Justification::left:
+            left_blanks = required_buffer;
+            right_blanks = 0;
+            break;
+        case Justification::right:
+            left_blanks = 0;
+            right_blanks = required_buffer;
+            break;
+        case Justification::center:
+            left_blanks = (required_buffer)/2;
+            right_blanks = (required_buffer)/2;
+            // If the number of required blanks is an odd number add a space to account for the division loss
+            if (required_buffer % 2 != 0)
+                ++left_blanks;
+            break;
+    }
+}

--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -16,109 +16,140 @@
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // Local - Include Files
 #include "Table2D.h"
+#include "core/common/system.h"
 
 // 3rd Party Library - Include Files
 #include <algorithm>
 #include <boost/format.hpp>
 
+const std::string no_data_string = "N/A";
+
 Table2D::Table2D() : m_entry_count(0)
 {
 }
 
-Table2D::Table2D(const std::vector<HeaderData>& headers_data) : m_entry_count(0)
+Table2D::Table2D(const std::vector<HeaderData>& headers) : m_entry_count(0)
 {
-    addHeaders(headers_data);
+    addHeaders(headers);
 }
 
-bool
-Table2D::addHeader(const HeaderData& header_data)
+void
+Table2D::addHeader(const HeaderData& header)
 {
     // Format the header into a table data struct
     ColumnData column;
-    column.header_data = header_data;
-    column.entry_data = std::vector<std::string>();
-    // The only element in the new column is the header, so it defines the max length
-    column.max_length = header_data.header.size();
-    m_data.push_back(column);
-    return true;
+    column.header = header;
+    // Populate the header with the appropriate amount of N/A
+    column.entry_slices = std::vector<std::string>();
+    for (size_t entry_count = 0; entry_count < m_entry_count; entry_count++)
+        column.entry_slices.push_back(no_data_string);
+    m_table.push_back(column);
 }
 
-bool
-Table2D::addHeaders(const std::vector<HeaderData>& headers_data)
+void
+Table2D::addHeaders(const std::vector<HeaderData>& headers)
 {
-    for (auto& header_data : headers_data) {
-        if (!addHeader(header_data))
-            return false;
-    }
-    return true;
+    for (auto& header : headers)
+        addHeader(header);
 }
 
 bool
-Table2D::addEntry(const std::vector<std::string>& entry_data)
+Table2D::removeHeader(const std::string& header)
+{
+    // Search through each clumn looking for a matching header
+    for (size_t column_index = 0; column_index < m_table.size(); ++column_index) {
+        // If a matching header is found remove the entire column
+        if (m_table[column_index].header.name.compare(header) == 0) {
+            m_table.erase(m_table.begin() + column_index);
+            return true;
+        }
+    }
+    // Return false when no match is found
+    return false;
+}
+
+size_t
+Table2D::addEntry(const std::vector<std::string>& entry)
 {
     // Keep track of each new entry
     ++m_entry_count;
 
-    if (entry_data.size() < m_data.size())
-        std::cout << "Warning: Given entry data is smaller than table. Later values will be N/A.\n";
-    else if (entry_data.size() > m_data.size())
+    if (entry.size() < m_table.size())
+        std::cout << "Warning: Given entry data is smaller than table. Later values will be " << no_data_string << "\n";
+    else if (entry.size() > m_table.size())
         std::cout << "Warning: Given entry data is larger than table. Later values will not be appended.\n";
 
     // Determine the maximum number of elements to add from the entry
-    const size_t vector_size = std::max(entry_data.size(), m_data.size());
+    const size_t vector_size = std::max(entry.size(), m_table.size());
 
-    // Iterate through the entry data and the table adding the table enetry elements in order
-    for (size_t data_index = 0; data_index < vector_size; ++data_index) {
-        auto& table_entry = m_data[data_index];
-        if (data_index < entry_data.size()) {
-            const std::string& entry = entry_data[data_index];
-            table_entry.entry_data.push_back(entry);
-            table_entry.max_length = std::max(table_entry.max_length, entry.size());
+    // Iterate through the entry data and the table adding the table entry elements in order
+    for (size_t i = 0; i < vector_size; ++i) {
+        auto& column = m_table[i];
+        if (i < entry.size()) {
+            column.entry_slices.push_back(entry[i]);
         }
         else
-            table_entry.entry_data.push_back("N/A");
+            column.entry_slices.push_back(no_data_string);
     }
-    return true;
+
+    // Return the actual index of the newly added entry
+    return m_entry_count - 1;
 }
 
-bool
-Table2D::addEntries(const std::vector<std::vector<std::string>>& entries_data)
+std::vector<size_t>
+Table2D::addEntries(const std::vector<std::vector<std::string>>& entries)
 {
-    for (auto& entry_data : entries_data) {
-        if(!addEntry(entry_data))
-            return false;
-    }
-    return true;
+    std::vector<size_t> entries_indicies;
+    for (auto& entry : entries)
+        entries_indicies.push_back(addEntry(entry));
+    return entries_indicies;
 }
 
-std::ostream& 
+void
+Table2D::removeEntry(size_t entry_index)
+{
+    // Verify the index is valid
+    if (entry_index >= m_entry_count)
+        throw xrt_core::error(boost::str(boost::format(
+            "ERROR: Table2D - Given index: %d is larger than data table: %d") % entry_index % m_entry_count));
+    // Remove appropriate row element from each column
+    for (auto& column : m_table)
+        column.entry_slices.erase(column.entry_slices.begin() + entry_index);
+}
+
+std::ostream&
 Table2D::print(std::ostream& os)
 {
     // Stores each row of the table
     std::vector<std::string> output;
 
     // Add an empty string for each entry plus a header row
-    for (size_t i = 0; i < m_entry_count + 1; i++) {
+    for (size_t i = 0; i < m_entry_count + 1; i++)
         output.push_back("");
-    }
 
     // Iterate through the table columns while adding each element to the appropriate row
-    for (auto& table_column : m_data) {
+    for (auto& column : m_table) {
         size_t left_blanks = 0;
         size_t right_blanks = 0;
-        
+
+        auto& header = column.header;
+
+        // Find the largest string in the column and use it for justification
+        size_t max_string_size = header.name.size();
+        for(auto& entry : column.entry_slices)
+            max_string_size = std::max(entry.size(), max_string_size);
+
         // Add header for current entry to the top row
-        std::string& header = table_column.header_data.header;
-        getBlankSizes(table_column, header.size(), left_blanks, right_blanks);
-        output[0].append(boost::str(boost::format("%s%s%s  ") % std::string(left_blanks, ' ') % header % std::string(right_blanks, ' ')));
+        getBlankSizes(max_string_size, header.justification, header.name.size(), left_blanks, right_blanks);
+        output[0].append(boost::str(boost::format("%s%s%s  ") % std::string(left_blanks, ' ') % header.name % std::string(right_blanks, ' ')));
 
         // Iterate through each entry in the data column and append the data to the appropriate row
-        std::vector<std::string>& data = table_column.entry_data;
-        for (size_t data_index = 0; data_index < data.size(); ++data_index) {
-            std::string& entry = data[data_index];
-            getBlankSizes(table_column, entry.size(), left_blanks, right_blanks);
+        auto& entry_slices = column.entry_slices;
+        for (size_t i = 0; i < entry_slices.size(); ++i) {
+            auto& entry = entry_slices[i];
+            getBlankSizes(max_string_size, header.justification, entry.size(), left_blanks, right_blanks);
             // Plus one as the 0 element is the header row
-            output[data_index + 1].append(boost::str(boost::format("%s%s%s  ") % std::string(left_blanks, ' ') % entry % std::string(right_blanks, ' ')));
+            output[i + 1].append(boost::str(boost::format("%s%s%s  ") % std::string(left_blanks, ' ') % entry % std::string(right_blanks, ' ')));
         }
     }
 
@@ -132,12 +163,11 @@ Table2D::print(std::ostream& os)
     return os;
 }
 
-void 
-Table2D::getBlankSizes(ColumnData& table_data, size_t string_size, size_t& left_blanks, size_t& right_blanks)
+void
+Table2D::getBlankSizes(size_t max_string_size, Justification justification, size_t string_size, size_t& left_blanks, size_t& right_blanks)
 {
-    const size_t max_string_size = table_data.max_length;
     const size_t required_buffer = max_string_size - string_size;
-    switch (table_data.header_data.justification) {
+    switch (justification) {
         case Justification::left:
             left_blanks = required_buffer;
             right_blanks = 0;

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -41,7 +41,7 @@ class Table2D {
     /**
      * @brief Add a new header into the table. If entries already exist the column will have empty entries.
      * 
-     * @param header The header to be aded into the table
+     * @param header The header to be added into the table
      */
     void addHeader(const HeaderData& header);
     void addHeaders(const std::vector<HeaderData>& headers);

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -14,8 +14,8 @@
  * under the License.
  */
 
-#ifndef __SubCmd_h_
-#define __SubCmd_h_
+#ifndef __Table2D_h_
+#define __Table2D_h_
 
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // 3rd Party Library - Include Files

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -39,57 +39,29 @@ class Table2D {
         Justification justification;
     } HeaderData;
 
-    Table2D();
     Table2D(const std::vector<HeaderData>& headers);
 
     /**
-     * @brief Add a new header into the table. If entries already exist the column will have empty entries.
-     * 
-     * @param header The header to be added into the table
-     */
-    void addHeader(const HeaderData& header);
-    void addHeaders(const std::vector<HeaderData>& headers);
-
-    /**
-     * @brief Remove the specified header from the table if it exists
-     * 
-     * This will remove the column and all data associated with that column from the table.
-     * 
-     * @param header The ehader name to remove
-     * @return true When the header is found and removed
-     * @return false If the header was not found in the table
-     */
-    bool removeHeader(const std::string& header);
-
-    /**
-     * @brief Add an entry to the table. The entry should contain data for each existing header in the table.
+     * @brief Add an entry to the table. The entry must contain data for each header in the table.
      * 
      * @param entry_data A list of data elements that correspond the headers
-     * @return size_t The index the entry data was placed into. This value will change if entries are removed
      */
-    size_t addEntry(const std::vector<std::string>& entry);
-    std::vector<size_t> addEntries(const std::vector<std::vector<std::string>>& entries);
-
-    /**
-     * @brief Remove an entry from at a specified index
-     * 
-     * @param entry_index The index whose entry should be removed
-     */
-    void removeEntry(size_t entry_index);
+    void addEntry(const std::vector<std::string>& entry);
 
  private:
     typedef struct ColumnData {
         HeaderData header;
-        std::vector<std::string> entry_slices;
+        std::vector<std::string> data;
+        size_t max_element_size;
     } ColumnData;
-
-    size_t m_entry_count;
 
     std::vector<ColumnData> m_table;
 
     std::ostream& print(std::ostream& os);
 
-    void getBlankSizes(size_t max_string_size, Justification justification, size_t string_size, size_t& left_blanks, size_t& right_blanks);
+    void getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks);
+    void addHeader(const HeaderData& header);
+    void appendToOutput(std::string& output, const ColumnData& column, const std::string& data);
 
  public:
     friend std::ostream&

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -13,6 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
+#ifndef __SubCmd_h_
+#define __SubCmd_h_
+
 // ------ I N C L U D E   F I L E S -------------------------------------------
 // 3rd Party Library - Include Files
 #include <vector>
@@ -94,3 +98,5 @@ class Table2D {
         return table.print(os);
     };
 };
+
+#endif

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -31,47 +31,61 @@ class Table2D {
 
     // The header portion of a column
     typedef struct HeaderData {
-        std::string header;
+        std::string name;
         Justification justification;
     } HeaderData;
 
     Table2D();
-    Table2D(const std::vector<HeaderData>& headers_data);
+    Table2D(const std::vector<HeaderData>& headers);
 
     /**
      * @brief Add a new header into the table. If entries already exist the column will have empty entries.
      * 
-     * @param header_data 
-     * @return true 
-     * @return false 
+     * @param header The header to be aded into the table
      */
-    bool addHeader(const HeaderData& header_data);
-    bool addHeaders(const std::vector<HeaderData>& headers_data);
+    void addHeader(const HeaderData& header);
+    void addHeaders(const std::vector<HeaderData>& headers);
+
+    /**
+     * @brief Remove the specified header from the table if it exists
+     * 
+     * This will remove the column and all data associated with that column from the table.
+     * 
+     * @param header The ehader name to remove
+     * @return true When the header is found and removed
+     * @return false If the header was not found in the table
+     */
+    bool removeHeader(const std::string& header);
 
     /**
      * @brief Add an entry to the table. The entry should contain data for each existing header in the table.
      * 
-     * @param entry_data 
-     * @return true 
-     * @return false 
+     * @param entry_data A list of data elements that correspond the headers
+     * @return size_t The index the entry data was placed into. This value will change if entries are removed
      */
-    bool addEntry(const std::vector<std::string>& entry_data);
-    bool addEntries(const std::vector<std::vector<std::string>>& entries_data);
+    size_t addEntry(const std::vector<std::string>& entry);
+    std::vector<size_t> addEntries(const std::vector<std::vector<std::string>>& entries);
+
+    /**
+     * @brief Remove an entry from at a specified index
+     * 
+     * @param entry_index The index whose entry should be removed
+     */
+    void removeEntry(size_t entry_index);
 
  private:
     typedef struct ColumnData {
-        HeaderData header_data;
-        std::vector<std::string> entry_data;
-        size_t max_length;
+        HeaderData header;
+        std::vector<std::string> entry_slices;
     } ColumnData;
 
     size_t m_entry_count;
 
-    std::vector<ColumnData> m_data;
+    std::vector<ColumnData> m_table;
 
     std::ostream& print(std::ostream& os);
 
-    void getBlankSizes(ColumnData& table_data, size_t string_size, size_t& left_blanks, size_t& right_blanks);
+    void getBlankSizes(size_t max_string_size, Justification justification, size_t string_size, size_t& left_blanks, size_t& right_blanks);
 
  public:
     friend std::ostream&

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// 3rd Party Library - Include Files
+#include <vector>
+#include <string>
+#include <iostream>
+#include <utility>
+
+class Table2D {
+ public:
+    // The typesetting options for a column
+    enum Justification {
+        right = 0,
+        center = 1,
+        left = 2
+    };
+
+    // The header portion of a column
+    typedef struct HeaderData {
+        std::string header;
+        Justification justification;
+    } HeaderData;
+
+    Table2D();
+    Table2D(const std::vector<HeaderData>& headers_data);
+
+    /**
+     * @brief Add a new header into the table. If entries already exist the column will have empty entries.
+     * 
+     * @param header_data 
+     * @return true 
+     * @return false 
+     */
+    bool addHeader(const HeaderData& header_data);
+    bool addHeaders(const std::vector<HeaderData>& headers_data);
+
+    /**
+     * @brief Add an entry to the table. The entry should contain data for each existing header in the table.
+     * 
+     * @param entry_data 
+     * @return true 
+     * @return false 
+     */
+    bool addEntry(const std::vector<std::string>& entry_data);
+    bool addEntries(const std::vector<std::vector<std::string>>& entries_data);
+
+ private:
+    typedef struct ColumnData {
+        HeaderData header_data;
+        std::vector<std::string> entry_data;
+        size_t max_length;
+    } ColumnData;
+
+    size_t m_entry_count;
+
+    std::vector<ColumnData> m_data;
+
+    std::ostream& print(std::ostream& os);
+
+    void getBlankSizes(ColumnData& table_data, size_t string_size, size_t& left_blanks, size_t& right_blanks);
+
+ public:
+    friend std::ostream&
+    operator<<(std::ostream& os, Table2D& table)
+    {
+        return table.print(os);
+    };
+};

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -354,7 +354,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
       try { //2RP
         auto logic_uuids = xrt_core::device_query<xrt_core::query::logic_uuids>(device);
         if (!logic_uuids.empty())
-          pt_dev.put("id", boost::str(boost::format("0x%s") % logic_uuids[0]));
+          pt_dev.put("id", xrt_core::query::interface_uuids::to_uuid_upper_string(logic_uuids[0]));
       } catch(...) {
         // The id wasn't added
       }

--- a/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbmgmt2/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB XBMGMT_V2_BASE_FILES
   "../common/ProgressBar.cpp"
   "../common/Process.cpp"
   "../common/Report*.cpp"
+  "../common/Table2D.cpp"
 )
 
 # Collect local directory files

--- a/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbutil2/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB XBUTIL_V2_BASE_FILES
   "../common/Report*.cpp"
   "../common/ProgressBar.cpp"
   "../common/Process.cpp"
+  "../common/Table2D.cpp"
 )
 
 # Collect local directory files


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1045783
Its not clear in the help that this is the case, xbutil list does not educate the user on bdf.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add identifier field to output. Parse the device properties and format the output in a nice looking table.

#### Risks (if any) associated the changes in the commit
There is some code duplication going on in XBUtilies and ReportPlatform::getPropertyTree20202. This could be combined to reduce the amount of code but it is a little involved. Mainly include issues from the DSAInfo class being in xbmgmt2 and XBUtitilies being in common. This could unify what properties are present for each device and it could be useful. Let me know if you would like to see this change.

It would also be prudent to move some of the string based keys used in the get function to a central location. Let me know if that is a reasonable idea.

#### What has been tested and how, request additional testing if necessary
Manual Testing
Single Card (1RP)
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-91-generic
  Version              : #102-Ubuntu SMP Fri Nov 5 16:31:28 UTC 2021
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15700 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1045783
  Hash                 : ac17177529a24454ea1001722b2b2195c18645cd
  Hash Date            : 2022-01-06 14:22:46
  XOCL                 : 2.13.0, 65fd58e857868e041fdf50089c6ec3337afca2a0
  XCLMGMT              : 2.13.0, 65fd58e857868e041fdf50089c6ec3337afca2a0

Devices present
  BDF          : Shell                     Interface UUID Device ID
  0000:02:00.1 : xilinx_u280_xdma_201920_3 0x5e278820     user(inst=128)
```
Multiple Cards (2RP)
```
dbenusov@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-91-generic
  Version              : #102-Ubuntu SMP Fri Nov 5 16:31:28 UTC 2021
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15675 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Super Server

XRT
  Version              : 2.13.0
  Branch               : CR-1045783
  Hash                 : ac17177529a24454ea1001722b2b2195c18645cd
  Hash Date            : 2022-01-06 14:22:46
  XOCL                 : 2.13.0, 004edd7c843421568ef7860ac0c074807d9dc53d
  XCLMGMT              : 2.13.0, 004edd7c843421568ef7860ac0c074807d9dc53d

Devices present
  BDF          : Shell                           Interface UUID                       Device ID
  0000:b3:00.1 : xilinx_u200_gen3x16_xdma_base_1 A2D4F3CF-5B7A-0B7B-70F9-DA589CB5B3CD user(inst=130)
  0000:18:00.1 : xilinx_u30_gen3x4_base_2        6E7C97F7-949F-5106-3075-A77784C30A4B user(inst=129)
  0000:17:00.1 : xilinx_u30_gen3x4_base_2        6E7C97F7-949F-5106-3075-A77784C30A4B user(inst=128)
```