### PR TITLE
Reporting recently added Native XRT APIs in the profile summary file tables

### DIFF
--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -238,6 +238,27 @@ namespace xdp {
     NativeAPIs.emplace("xrtXclbinGetUUID");
     NativeAPIs.emplace("xrtXclbinGetData");
     NativeAPIs.emplace("xrtXclbinUUID");
+    NativeAPIs.emplace("xrt::psrun::psrun");
+    NativeAPIs.emplace("xrt::psrun::start");
+    NativeAPIs.emplace("xrt::psrun::wait");
+    NativeAPIs.emplace("xrt::psrun::state");
+    NativeAPIs.emplace("xrt::psrun::set_event");
+    NativeAPIs.emplace("xrt::psrun::get_ert_packet");
+    NativeAPIs.emplace("xrt::pskernel::kernel");
+    NativeAPIs.emplace("xrt::pskernel::offset");
+    NativeAPIs.emplace("xrtPSKernelOpen");
+    NativeAPIs.emplace("xrtPSKernelOpenExclusive");
+    NativeAPIs.emplace("xrtPSKernelClose");
+    NativeAPIs.emplace("xrtPSRunOpen");
+    NativeAPIs.emplace("xrtPSKernelArgGroupId");
+    NativeAPIs.emplace("xrtPSKernelArgOffset");
+    NativeAPIs.emplace("xrtPSKernelRun");
+    NativeAPIs.emplace("xrtPSRunClose");
+    NativeAPIs.emplace("xrtPSRunState");
+    NativeAPIs.emplace("xrtPSRunWait");
+    NativeAPIs.emplace("xrtPSRunWaitFor");
+    NativeAPIs.emplace("xrtPSRunSetCalback");
+    NativeAPIs.emplace("xrtPSRunStart");
 
     HALAPIs.emplace("xclLoadXclbin") ;
     HALAPIs.emplace("xclProbe") ;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The profile summary report categorizes different APIs under different tables with a set lookup based their name.  This pull request adds recently added Native XRT APIs that are traced to the appropriate table so they get reported in the summary table correctly.
