### PR TITLE
CR-1118709 U25 validate is failing with latest XRT

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -378,10 +378,18 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 
 static int ert_ctrl_probe(struct platform_device *pdev)
 {
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
+	bool ert_on = xocl_ert_on(xdev);
 	struct ert_ctrl	*ec = NULL;
 	struct resource *res = NULL;
 	void *hdl = NULL;
 	int err = 0;
+
+	/* If XOCL_DSAFLAG_MB_SCHE_OFF is set, we should not probe */
+	if (!ert_on) {
+		xocl_warn(&pdev->dev, "Disable ERT flag is set");
+		return -ENODEV;
+	}
 
 	ec = xocl_drvinst_alloc(&pdev->dev, sizeof(struct ert_ctrl));
 	if (!ec)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1603,12 +1603,15 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 
 	XDEV(xdev)->kds.xgq_enable = false;
 	ret = xocl_ert_ctrl_connect(xdev);
-	if (ret < 0) {
+	if (ret == -ENODEV) {
+		userpf_info(xdev, "ERT will be disabled, ret %d\n", ret);
+		XDEV(xdev)->kds.ert_disable = true;
+	} else if (ret < 0) {
 		userpf_err(xdev, "failed to connect ERT ctrl, err: %d\n", ret);
 		goto out;
 	}
 
-	if (xocl_ert_ctrl_is_version(xdev, 1, 0))
+	if (xocl_ert_ctrl_is_version(xdev, 1, 0) > 0)
 		ret = xocl_kds_update_xgq(xdev, cfg);
 	else
 		ret = xocl_kds_update_legacy(xdev, cfg);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1118709

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is discovered by regression testing on u25. Introduced by #6077 

#### How problem was solved, alternative solutions (if any) and why they were rejected
On u25, ERT is forced disabled. This doesn't been handling well.
If there is no ert_ctrl subdev, don't break xclbin download flow. Use legacy flow and make sure ert is disabled.

#### Risks (if any) associated the changes in the commit
No.

#### What has been tested and how, request additional testing if necessary
xbutil validate on u25/u50

#### Documentation impact (if any)
no