### PR TITLE
CR-1117704 xbmgmt program -b doesn't work for versal discovery

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -76,6 +76,7 @@ enum xgq_cmd_vmr_control_type {
 	XGQ_CMD_VMR_QUERY	= 0x0,
 	XGQ_CMD_BOOT_DEFAULT	= 0x1,
 	XGQ_CMD_BOOT_BACKUP	= 0x2,
+	XGQ_CMD_PROGRAM_SC	= 0x3,
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -3057,6 +3057,12 @@ struct xocl_subdev_map {
 		},					\
 	})
 
+#define XOCL_PRIV_FLASH_XGQ				\
+	((struct xocl_flash_privdata) {			\
+		0,					\
+		FLASH_TYPE_OSPI_XGQ,			\
+	 })
+
 #define XOCL_DEVINFO_XGQ_VMR_VSEC			\
 	{						\
 		XOCL_SUBDEV_XGQ_VMR,			\
@@ -3065,6 +3071,7 @@ struct xocl_subdev_map {
 		ARRAY_SIZE(XOCL_RES_XGQ_VMR_VSEC),	\
 		.bar_idx = (char []){ 0, 0 },		\
 		.override_idx = -1,			\
+		.priv_data = &XOCL_PRIV_FLASH_XGQ	\
 	}
 
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1289,6 +1289,32 @@ static ssize_t vmr_debug_level_store(struct device *dev,
 }
 static DEVICE_ATTR_WO(vmr_debug_level);
 
+static ssize_t program_sc_store(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	u32 val = 0;
+	int ret = 0;
+
+	if (kstrtou32(buf, 10, &val) == -EINVAL) {
+		return -EINVAL;
+	}
+
+	/* request debug level change */
+	if (val) {
+		ret = vmr_control_op(to_platform_device(dev), XGQ_CMD_PROGRAM_SC);
+		if (ret) {
+			XGQ_ERR(xgq, "failed: %d", ret);
+			return -EINVAL;
+		}
+	}
+
+	XGQ_INFO(xgq, "done");
+
+	return count;
+}
+static DEVICE_ATTR_WO(program_sc);
+
 static ssize_t vmr_status_show(struct device *dev,
 	struct device_attribute *attr, char *buf)
 {
@@ -1322,6 +1348,7 @@ static struct attribute *xgq_attrs[] = {
 	&dev_attr_flush_default_only.attr,
 	&dev_attr_vmr_status.attr,
 	&dev_attr_vmr_debug_level.attr,
+	&dev_attr_program_sc.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1625,6 +1625,7 @@ static inline int xocl_subdev_create_vsec_impl(xdev_handle_t xdev,
 
 int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 {
+	struct xocl_dev_core *core = (struct xocl_dev_core *)xdev;
 	u64 offset;
 	int bar, ret;
 	u32 vtype;
@@ -1709,9 +1710,12 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 		subdev_info.res[1].end = offset_payload + 0x7ffffff;
 		subdev_info.res[1].name = NODE_XGQ_VMR_PAYLOAD_BASE;
 
+		core->priv.flash_type = FLASH_TYPE_OSPI_XGQ;
+
 		xocl_xdev_dbg(xdev,
 		    "VSEC XGQ Start 0x%llx, bar %d. XGQ Payload 0x%llx, bar %d",
 		    offset, bar, offset_payload, bar_payload);
+		xocl_xdev_dbg(xdev, "xdev flash_type %s", core->priv.flash_type);
 
 		ret = xocl_subdev_create(xdev, &subdev_info);
 		if (ret) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
fixed 2 issues:
1) adding program_sc command for program sc on VMR
2) fix flash_type for versal device id hardcoded to ospi_versal, but for XGQ the type is ospi_xgq

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested on TA shell

#### Documentation impact (if any)
