### PR TITLE
Add method to extract fpga device name from xrt::xclbin

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -211,13 +211,13 @@ public:
 
 // class ip_impl - wrap xclbin ip_data entry
 // Loosely IP_LAYOUT
-//  
+//
 // An xclbin::ip wraps an ip_data entry from the xclbin along
 // with connectivity data represeted as xclbin::arg objects.
 class xclbin::ip_impl
 {
 public: // purposely not a struct to match decl in xrt_xclbin.h
-  const ::ip_data* m_ip;            // 
+  const ::ip_data* m_ip;            //
   int32_t m_ip_layout_idx;          // index in IP_LAYOUT seciton
   size_t m_size = 0;                // address range of this ip (a kernel property)
   std::vector<xclbin::arg> m_args;  // index by argument index
@@ -282,7 +282,7 @@ public:
 };
 
 // class kernel_impl - wrap xclbin XML kernel entry
-//  
+//
 // The xclbin::kernel groups already constructed xclbin::ip objects
 // and stores xclbin::arg objects represeting each kernel argument. An
 // xclbin::arg object is a collection of memory connections and the
@@ -315,7 +315,7 @@ public:
       const auto& karginfo = m_arginfo[argidx];
 
       // OpenCL rtinfo argument
-      if (karginfo.index == xrt_core::xclbin::kernel_argument::no_index) 
+      if (karginfo.index == xrt_core::xclbin::kernel_argument::no_index)
         continue;
 
       // Sanity check
@@ -332,7 +332,7 @@ public:
         // set the address range size, which is a property of the kernel
         // when it should be a proeprty of the compute unit (ip_layout)
         cuimpl->set_size(m_properties.address_range);
-        
+
         // get cu argument at argidx, create if necessary when
         // argument at index is a scalar not part of connectivity
         auto cuarg = cuimpl->create_arg_if_new(argidx);  // xclbin::arg
@@ -375,6 +375,7 @@ class xclbin_impl
   {
     const xclbin_impl* m_ximpl;
     std::string m_project_name;           // <project name="foo">
+    std::string m_fpga_device_name;       // <device fpgaDevice="foo">
     std::vector<xclbin::mem> m_mems;
     std::vector<xclbin::ip> m_ips;
     std::vector<xclbin::kernel> m_kernels;
@@ -406,7 +407,7 @@ class xclbin_impl
     // Iterate the IP_LAYOUT section in the xclbin and create
     // xclbin::ip objects of each ip_data entry. Note, that xclbin::ip
     // objects construction also creates xclbin::arg objects based on
-    // CONNECTIVITY information from the xclbin.  
+    // CONNECTIVITY information from the xclbin.
     //
     // A pre-condition for this function is that init_mems() must have
     // been called.
@@ -416,7 +417,7 @@ class xclbin_impl
       auto ip_layout = ximpl->get_section<const ::ip_layout*>(IP_LAYOUT);
       if (!ip_layout)
         return {};
-      
+
       auto conn = ximpl->get_section<const ::connectivity*>(ASK_GROUP_CONNECTIVITY);
 
       std::vector<xclbin::ip> ips;
@@ -466,8 +467,17 @@ class xclbin_impl
         : "";
     }
 
+    static std::string
+    init_fpga_device_name(const xclbin_impl* ximpl)
+    {
+      auto xml = ximpl->get_axlf_section(EMBEDDED_METADATA);
+      return xml.first
+        ? xrt_core::xclbin::get_fpga_device_name(xml.first, xml.second)
+        : "";
+    }
+
     // init_mem_encoding() - compress memory indices
-    // 
+    //
     // Mapping from memory index to encoded index.  The compressed
     // indices facilitate small sized std::bitset for representing
     // kernel argument connectivity.
@@ -503,7 +513,7 @@ class xclbin_impl
           auto a2 = mb2.get_base_address();
           if (a1 > a2)
             return true;
-      
+
           // decreasing size
           auto s1 = mb1.get_size_kb();
           auto s2 = mb2.get_size_kb();
@@ -529,7 +539,7 @@ class xclbin_impl
         // process the range assigning same encoded index to all banks in group
         for (; itr != upper; ++itr)
           enc[(*itr).get_index()] = eidx;
-        
+
         ++eidx; // increment for next iteration
       }
 
@@ -541,13 +551,14 @@ class xclbin_impl
     xclbin_info(const xrt::xclbin_impl* impl)
       : m_ximpl(impl)
       , m_project_name(init_project_name(m_ximpl))
+      , m_fpga_device_name(init_fpga_device_name(m_ximpl))
       , m_mems(init_mems(m_ximpl))
       , m_ips(init_ips(m_ximpl, m_mems))
       , m_kernels(init_kernels(m_ximpl, m_ips))
       , m_membank_encoding(init_mem_encoding(m_mems))
     {}
   };
-  
+
   // cache of meta data extracted from xclbin
   mutable std::unique_ptr<xclbin_info> m_info;
 
@@ -621,7 +632,7 @@ public:
   {
     return reinterpret_cast<SectionType>(get_axlf_section(kind).first);
   }
-  
+
   template <typename SectionType>
   SectionType
   get_section_or_error(axlf_section_kind kind) const
@@ -676,7 +687,7 @@ public:
 
     return xclbin::ip{};
   }
-  
+
   const std::vector<xclbin::mem>&
   get_mems() const
   {
@@ -694,6 +705,13 @@ public:
   {
     return get_xclbin_info()->m_project_name;
   }
+
+  const std::string&
+  get_fpga_device_name() const
+  {
+    return get_xclbin_info()->m_fpga_device_name;
+  }
+
 };
 
 // class xclbin_full - Implementation of full xclbin
@@ -734,8 +752,8 @@ class xclbin_full : public xclbin_impl
       throw std::runtime_error("Invalid xclbin");
     m_top = tmp;
 
-    m_uuid = uuid(m_top->m_header.uuid); 
-    
+    m_uuid = uuid(m_top->m_header.uuid);
+
     const ::ip_layout* ip_layout = nullptr;
     for (auto kind : kinds) {
       auto hdr = xrt_core::xclbin::get_axlf_section(m_top, kind);
@@ -768,7 +786,7 @@ class xclbin_full : public xclbin_impl
   {
     init_axlf();
   }
-  
+
 public:
   explicit
   xclbin_full(const std::string& filename)
@@ -857,7 +875,7 @@ public:
     return m_top;
   }
 };
-  
+
 } // xrt
 
 ////////////////////////////////////////////////////////////////
@@ -903,7 +921,7 @@ get_ips() const
 {
   return handle ? handle->get_ips() : std::vector<xclbin::ip>{};
 }
-  
+
 xclbin::ip
 xclbin::
 get_ip(const std::string& name) const
@@ -924,6 +942,14 @@ get_xsa_name() const
 {
   return handle ? handle->get_xsa_name() : "";
 }
+
+std::string
+xclbin::
+get_fpga_device_name() const
+{
+  return handle ? handle->get_fpga_device_name() : "";
+}
+
 
 uuid
 xclbin::
@@ -1001,7 +1027,7 @@ get_cu(const std::string& nm) const
 {
   if (!handle)
     return {};
-  
+
   auto itr = std::find_if(handle->m_cus.begin(), handle->m_cus.end(),
                           [&nm](const auto& cu) {
                            return cu.get_name() == nm;
@@ -1152,7 +1178,7 @@ get_tag() const
   return handle ? reinterpret_cast<const char*>(handle->m_mem->m_tag) : "";
 }
 
-uint64_t  
+uint64_t
 xclbin::mem::
 get_base_address() const
 {
@@ -1165,8 +1191,8 @@ get_base_address() const
 
   return handle->m_mem->m_base_address;
 }
-  
-uint64_t  
+
+uint64_t
 xclbin::mem::
 get_size_kb() const
 {
@@ -1180,7 +1206,7 @@ get_size_kb() const
   return handle->m_mem->m_size;
 }
 
-bool  
+bool
 xclbin::mem::
 get_used() const
 {
@@ -1220,7 +1246,7 @@ send_exception_message(const char* msg)
 
 ////////////////////////////////////////////////////////////////
 // xrt_xclbin implementation of extension APIs not exposed to end-user
-// 
+//
 // Utility function for device class to verify that the C xclbin
 // handle is valid Needed when the C API for device tries to load an
 // xclbin using C pointer to xclbin
@@ -1495,4 +1521,3 @@ xrtXclbinUUID(xclDeviceHandle dhdl, xuid_t out)
   }
   return -1;
 }
-

--- a/src/runtime_src/core/common/xclbin_parser.cpp
+++ b/src/runtime_src/core/common/xclbin_parser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -304,10 +304,10 @@ get_portname_width_map(const pt::ptree& xml_kernel)
 
     pwmap.emplace(nm, convert(dw));
   }
-  
+
   return pwmap;
 }
-  
+
 } // namespace
 
 namespace xrt_core { namespace xclbin {
@@ -354,7 +354,7 @@ address_to_memidx(const mem_topology* mem_topology, uint64_t address)
 {
   if (is_sw_emulation())
     return 0;  // default bank in software emulation
-  
+
   // Reserve look for preferred group id
   for (int idx = mem_topology->m_count-1; idx >= 0; --idx) {
     auto& mem = mem_topology->m_mem_data[idx];
@@ -897,7 +897,7 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
       , mailbox
       , get_address_range(xml_kernel.second)
       , sw_reset
-          
+
       , convert(xml_kernel.second.get<std::string>("<xmlattr>.workGroupSize", "0"))
       , get_xyz(xml_kernel.second, "compileWorkGroupSize")
       , get_xyz(xml_kernel.second, "maxWorkGroupSize")
@@ -907,7 +907,7 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
 
   return kernel_properties{};
 }
-    
+
 kernel_properties
 get_kernel_properties(const axlf* top, const std::string& kname)
 {
@@ -1004,6 +1004,17 @@ get_project_name(const axlf* top)
   catch (const std::exception&) {
     return "";
   }
+}
+
+std::string
+get_fpga_device_name(const char* xml_data, size_t xml_size)
+{
+  pt::ptree xml_project;
+  std::stringstream xml_stream;
+  xml_stream.write(xml_data,xml_size);
+  pt::read_xml(xml_stream,xml_project);
+
+  return xml_project.get<std::string>("project.platform.device.<xmlattr>.fpgaDevice","");
 }
 
 }} // xclbin, xrt_core

--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -102,7 +102,7 @@ struct softkernel_object
  *
  * This function treats group sections conditionally based on
  * xrt.ini settings
- */ 
+ */
 XRT_CORE_COMMON_EXPORT
 const axlf_section_header*
 get_axlf_section(const axlf* top, axlf_section_kind kind);
@@ -309,7 +309,7 @@ get_kernel_arguments(const axlf* top, const std::string& kname);
  * @kname : Name of kernel
  * Return: Properties for kernel extracted from XML meta data
  */
-XRT_CORE_COMMON_EXPORT 
+XRT_CORE_COMMON_EXPORT
 kernel_properties
 get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& kname);
 
@@ -320,7 +320,7 @@ get_kernel_properties(const char* xml_data, size_t xml_size, const std::string& 
  * @kname : Name of kernel
  * Return: Properties for kernel extracted from XML meta data
  */
-XRT_CORE_COMMON_EXPORT 
+XRT_CORE_COMMON_EXPORT
 kernel_properties
 get_kernel_properties(const axlf* top, const std::string& kname);
 
@@ -369,6 +369,12 @@ get_project_name(const char* xml_data, size_t xml_size);
 XRT_CORE_COMMON_EXPORT
 std::string
 get_project_name(const axlf* top);
+
+/**
+ * get_project_name() - Get the project name from the XML
+ */
+std::string
+get_fpga_device_name(const char* xml_data, size_t xml_size);
 
 }} // xclbin, xrt_core
 

--- a/src/runtime_src/core/include/experimental/xrt_xclbin.h
+++ b/src/runtime_src/core/include/experimental/xrt_xclbin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -314,7 +314,7 @@ public:
   {
   public:
     /**
-     * @enum control_type - 
+     * @enum control_type -
      *
      * @details
      * See `xclbin.h`
@@ -399,7 +399,7 @@ public:
      * @return
      *  The size of this IP
      *
-     * The address range is a property of the kernel and 
+     * The address range is a property of the kernel and
      * as such only valid for for kernel compute units.
      *
      * For IPs that are not associated with a kernel, the
@@ -654,6 +654,16 @@ public:
   XCL_DRIVER_DLLESPEC
   std::string
   get_xsa_name() const;
+
+  /**
+   * get_fpga_device_name() - Get FPGA device name
+   *
+   * @return
+   *  Name of fpga device per XML metadata.
+   */
+  XCL_DRIVER_DLLESPEC
+  std::string
+  get_fpga_device_name() const;
 
   /**
    * get_uuid() - Get the uuid of the xclbin

--- a/tests/xrt/56_xclbin/main.cpp
+++ b/tests/xrt/56_xclbin/main.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,6 +24,9 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 #include "xrt/xrt_bo.h"
+
+// % g++ -g -std=c++14 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o xclbin.exe main.cpp -lxrt_coreutil -luuid -pthread
+
 
 // This value is shared with worgroup size in kernel.cl
 static constexpr auto COUNT = 1024;
@@ -107,7 +110,8 @@ run_cpp(const std::string& xclbin_fnm)
   auto uuid = xclbin.get_uuid();
   std::cout << xclbin_fnm << "\n";
   std::cout << "xsa(" << xclbin.get_xsa_name() << ")\n";
-  std::cout << "uuid(" << uuid.to_string() << ")\n\n";
+  std::cout << "uuid(" << uuid.to_string() << ")\n";
+  std::cout << "fpga(" << xclbin.get_fpga_device_name() << ")\n\n";
 
   for (auto& kernel : xclbin.get_kernels())
     std::cout << kernel << '\n';
@@ -127,7 +131,7 @@ run_c(const std::string& xclbin_fnm)
   xrtXclbinFreeHandle(xhdl);
 }
 
-static int 
+static int
 run(int argc, char** argv)
 {
   if (argc < 3) {
@@ -187,6 +191,6 @@ main(int argc, char** argv)
   }
   catch (...) {
     std::cout << "TEST FAILED for unknown reason\n";
-    return EXIT_FAILURE; 
+    return EXIT_FAILURE;
   }
 }


### PR DESCRIPTION
#### Problem solved by the commit
Per request from emulation team and PR #6112 add method
to extract fpga device name from xclbin metadata.

#### How problem was solved, alternative solutions (if any) and why they were rejected
xrt::xclbin is consolidating xclbin metadata access for
XRT implementation code and end users.

#### What has been tested and how, request additional testing if necessary
Updated low level xrt/56_xclbin/main.cpp to exercise the API.

#### Risks (if any) associated the changes in the commit
No risks.