### PR TITLE
Adding default value of 3 to MINOR if null from command: MINOR=cat /etc/centos-release | awk -F. '{ print $2 }'

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -462,6 +462,9 @@ prep_centos8()
     echo "Enabling PowerTools and AppStream repo for CentOS8 ..."
     #minor version of CentOs
     MINOR=`cat /etc/centos-release | awk -F. '{ print $2 }'`
+    if [ -z "$MINOR" ]; then 
+        MINOR=3
+    fi
     if [ $MINOR -gt "2" ]; then
         yum config-manager --set-enabled powertools
         yum config-manager --set-enabled appstream


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
We are trying to install Centos Stream 8 docker image and while running the xrtdeps.sh script in the container, the MINOR variable value is getting NULL as the /etc/centos-release is CentOS Stream release 8 without a dot.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adding a default value of 3 if the MINOR value from the command gets null.  This is so that following will executed
```
if [ $MINOR -gt "2" ]; then
  yum config-manager --set-enabled powertools
  yum config-manager --set-enabled appstream
```

#### Risks (if any) associated the changes in the commit
None, change only has effect when MINOR is not defined.