### PR TITLE
fix pipeline crash issue

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -218,7 +218,7 @@ static int ert_ctrl_xgq_init(struct ert_ctrl *ec)
 	ret = xgq_attach(&ec->ec_ctrl_xgq, 0, 0, (u64)ec->ec_cq_base+4, 0, 0);
 	if (ret) {
 		EC_ERR(ec, "Ctrl XGQ attach failed, ret %d", ret);
-		return -ENODEV;
+		return ret;
 	}
 
 	ec->ec_ert.submit = ert_ctrl_submit;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The pipeline crash issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not sure which PR introduced the bug. But this is because host KDS doesn't handle XGQ attach failure well.
The XGQ attach failure in the dmesg log,
[  539.446727] xocl 0000:c1:00.1: ert_ctrl.u.56623104 ffff90bbc7fae410 ert_ctrl_xgq_init: Ctrl XGQ attach failed, ret -95
[  539.446757] xocl 0000:c1:00.1: ert_ctrl.u.56623104 ffff90bbc7fae410 ert_ctrl_connect: connect error -95
@chienwei-lan Could you take a look at the attach issue?
It looks like that the ctrl XGQ major number is wrong.

XGQ header in words: 
offset     |       value
0x00      |      0x00010000  
0x04      |      0x5847513f
0x08      |      **0x00000000**
0x0C      |      0x00000002

The shell is xilinx_u50_gen3x4_xdma_base_2, which is a ssv2 shell.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Even ert_ctrl_connect returns failure, KDS should still setup CU subdev and completely disable ERT.

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test xbutil validate on pipeline server xcosdae304. The issue is fixed.

#### Documentation impact (if any)
