### PR TITLE
CR-1118948 xrtSyncBOAIE failed to close export handle

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -214,8 +214,15 @@ public:
   virtual
   ~bo_impl()
   {
-    if (export_handle != null_export)
-      device->close_export_handle(export_handle);
+    try {
+      if (export_handle != null_export)
+        device->close_export_handle(export_handle);
+    }
+    catch (const std::exception&) {
+      // close of the handle (file descriptor) failed,
+      // maybe it was already closed.  Simply ignore.
+    }
+
     if (free_bo)
       device->free_bo(handle);
   }

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1766,8 +1766,7 @@ xclImportBO(xclDeviceHandle handle, int fd, unsigned flags)
 int
 xclCloseExportHandle(int fd)
 {
-  //return close(fd) ? -errno : 0;
-  return 0;
+  return close(fd) ? -errno : 0;
 }
 
 static int
@@ -2394,7 +2393,7 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
   return 1; // -ENOSYS;
 }
 
-int 
+int
 xclResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
   return -ENOSYS;


### PR DESCRIPTION
#### Problem solved by the commit
Add try/catch around close of BO export handle to protect
against code having manually closed the handle already.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Changes made in #6106 to tie the lifetime of an export handle to the
exporting BO breaks AIE sync because the export handle is closed
explicitly.

#### How problem was solved, alternative solutions (if any) and why they were rejected
We could have removed the explicit close from the code, but it's
preferable to be resilient against application or implementation code
explicitly closing the export handle, and a simple try/catch was
chosen.

#### Risks (if any) associated the changes in the commit
There should be no risks related to this change.
