### PR TITLE
fix XGQ attached failed error

### DIFF
--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -136,14 +136,16 @@ static inline uint32_t xgq_double_read32(uint64_t io_hdl, uint64_t addr, int is_
 #define XGQ_MAJOR			1
 #define XGQ_MINOR			0
 #define XGQ_MIN_NUM_SLOTS		2
+#define XGQ_VERSION			((XGQ_MAJOR<<16)+XGQ_MINOR)
+#define GET_XGQ_MAJOR(version)		(version>>16)
+#define GET_XGQ_MINOR(version)		(version&0xFFFF)
 
 /*
  * Meta data shared b/w client and server of XGQ
  */
 struct xgq_header {
 	uint32_t xh_magic; /* Always the first member */
-	uint16_t xh_minor;
-	uint16_t xh_major;
+	uint32_t xh_version;
 
 	/* SQ and CQ share the same num of slots. */
 	uint32_t xh_slot_num;
@@ -366,8 +368,7 @@ static inline void xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, ui
 		      n_slots, sizeof(struct xgq_com_queue_entry));
 
 	hdr.xh_magic = 0;
-	hdr.xh_major = XGQ_MAJOR;
-	hdr.xh_minor = XGQ_MINOR;
+	hdr.xh_version = XGQ_VERSION;
 	hdr.xh_slot_num = n_slots;
 	hdr.xh_sq_offset = xgq->xq_sq.xr_slot_addr - ring_addr;
 	hdr.xh_sq_slot_size = slot_size;
@@ -483,7 +484,7 @@ static inline int xgq_attach(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, u
 		return -EAGAIN;
 
 	xgq_copy_from_ring(xgq->xq_io_hdl, &hdr, ring_addr, sizeof(struct xgq_header));
-	if (hdr.xh_major != XGQ_MAJOR)
+	if (GET_XGQ_MAJOR(hdr.xh_version) != XGQ_MAJOR)
 		return -EOPNOTSUPP;
 
 	nslots = hdr.xh_slot_num;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1608,9 +1608,13 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 
 	XDEV(xdev)->kds.xgq_enable = false;
 	ret = xocl_ert_ctrl_connect(xdev);
-	if (ret) {
+	if (ret == -ENODEV) {
 		userpf_info(xdev, "ERT will be disabled, ret %d\n", ret);
 		XDEV(xdev)->kds.ert_disable = true;
+	} else if (ret < 0) {
+		userpf_info(xdev, "ERT connect failed, ret %d\n", ret);
+		ret = -EINVAL;
+		goto out;
 	}
 
 	if (xocl_ert_ctrl_is_version(xdev, 1, 0) > 0)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR is to fix the XGQ attached issue. See #6138 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Recently, we update the Microblaze compiler from 2019.2 to 2021.2 Vitis (#6114 ). But the new XGQ ERT binary doesn't work well. It would not initial the xh_major and xh_minor correctly. We suspect it is related to how 'uint16_t' is handled or optimized by the compiler. But very hard to prove or narrow it down by a small application. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Use 'uint32_t' xh_version instead and add macros to get major/minor version number.
In this change, if XGQ attach error occurs, xclbin download will fail instead of silently switch to KDS mode.

#### Risks (if any) associated the changes in the commit
We still doesn't fully understand why the new compiler generates not working binary.

#### What has been tested and how, request additional testing if necessary
Test on U50 ssv3 and ssv2 shells.

#### Documentation impact (if any)
