### PR TITLE
Revert to 2019.2 microblaze tool chain

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -226,7 +226,7 @@ fi
 
 # we pick microblaze toolchain from Vitis install
 if [[ -z ${XILINX_VITIS:+x} ]] || [[ ! -d ${XILINX_VITIS} ]]; then
-    export XILINX_VITIS=/proj/xbuilds/2021.2_released/installs/lin64/Vitis/2021.2
+    export XILINX_VITIS=/proj/xbuilds/2019.2_released/installs/lin64/Vitis/2019.2
     if [[ ! -d ${XILINX_VITIS} ]]; then
         echo "****************************************************************"
         echo "* XILINX_VITIS is undefined or not accessible                  *"


### PR DESCRIPTION
#### Problem solved by the commit
iops performance plunges 30%~50%
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6114
#### How problem was solved, alternative solutions (if any) and why they were rejected
revert back to 2019.2 tool chain
#### What has been tested and how, request additional testing if necessary
xbutil validate --run all

CR:
https://jira.xilinx.com/browse/CR-1119285