### PR TITLE
Support for continuous offload of AIE Trace

### DIFF
--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -456,7 +456,8 @@ namespace xdp {
         return nullptr;
     }
     AIETraceDataType* traceData = aieTraceDataEntry[strmIndex];
-    aieTraceDataEntry[strmIndex] = nullptr;
+    aieTraceData[deviceId][strmIndex] = new AIETraceDataType; // assign new entry
+//    aieTraceDataEntry[strmIndex] = nullptr;
     return traceData;
   }
 

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -432,35 +432,32 @@ namespace xdp {
   {
     std::lock_guard<std::mutex> lock(aieLock);
 
-    if(aieTraceData.find(deviceId) == aieTraceData.end()) {
+    if (aieTraceData.find(deviceId) == aieTraceData.end()) {
       AIETraceDataVector newDataVector;
       aieTraceData[deviceId] = newDataVector;	// copy
       aieTraceData[deviceId].resize((db->getStaticInfo()).getNumAIETraceStream(deviceId));
     }
-    if(nullptr == aieTraceData[deviceId][strmIndex]) {
+    if (nullptr == aieTraceData[deviceId][strmIndex]) {
       aieTraceData[deviceId][strmIndex] = new AIETraceDataType;
     }
     aieTraceData[deviceId][strmIndex]->buffer.push_back(buffer);
     aieTraceData[deviceId][strmIndex]->bufferSz.push_back(bufferSz);
-#if 0
-    aieTraceData[deviceId][strmIndex] = new AIETraceDataType;
-    aieTraceData[deviceId][strmIndex]->buffer = buffer;
-    aieTraceData[deviceId][strmIndex]->bufferSz = bufferSz;
-#endif
   }
 
   AIETraceDataType* VPDynamicDatabase::getAIETraceData(uint64_t deviceId, uint64_t strmIndex)
   {
     std::lock_guard<std::mutex> lock(aieLock) ;
 
-    if(aieTraceData.find(deviceId) == aieTraceData.end()) {
+    if (aieTraceData.find(deviceId) == aieTraceData.end()) {
         return nullptr;
     }
     auto aieTraceDataEntry = aieTraceData[deviceId];
-    if(aieTraceData[deviceId].size() == 0 || aieTraceDataEntry[strmIndex] == nullptr) {
+    if (0 == aieTraceData[deviceId].size() || nullptr == aieTraceDataEntry[strmIndex]) {
         return nullptr;
     }
-    return aieTraceDataEntry[strmIndex];
+    AIETraceDataType* traceData = aieTraceDataEntry[strmIndex];
+    aieTraceDataEntry[strmIndex] = nullptr;
+    return traceData;
   }
 
   void VPDynamicDatabase::addPowerSample(uint64_t deviceId, double timestamp,

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.h
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.h
@@ -39,17 +39,10 @@ namespace xdp {
   class VPDatabase ;
 
   // AIE Trace data type
-#if 0
-  struct AIETraceDataType {
-    void* buffer;
-    uint64_t bufferSz;
-  };
-#endif
   struct AIETraceDataType {
     std::vector<void*> buffer;
     std::vector<uint64_t> bufferSz;
   };
-//  typedef std::pair<void* /*buffer*/, uint64_t /*bufferSz*/> AIETraceDataType;
   typedef std::vector<AIETraceDataType*> AIETraceDataVector;
 
   // The Dynamic Database will own all VTFEvents and is responsible
@@ -123,6 +116,12 @@ namespace xdp {
     std::map<uint64_t, std::vector<uint64_t>> dependencyMap ;
 
     // For AIE Trace events
+    // Chunks of AIE Trace buffers from each stream mapped to device ID
+    /* aieTraceData : 
+     * Map of deviceId 
+     *     vs. 
+     * Vector of trace data (vectors of buffer chunks and their sizes) from all streams
+     */ 
     std::map<uint64_t, AIETraceDataVector> aieTraceData;
 
     // In order to reduce memory overhead, instead of each event holding

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -294,12 +294,8 @@ void AIETraceOffload::continuousOffload()
     std::this_thread::sleep_for(std::chrono::milliseconds(offloadIntervalms));
   }
 
-  // Do final forced reads
   readTrace();
-
   endReadTrace();
-
-  // Tell external plugin that offload has finished
   offloadFinished();
 }
 

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -53,7 +53,7 @@ AIETraceOffload::AIETraceOffload(void* handle, uint64_t id,
                  isPLIO(isPlio),
                  totalSz(totalSize),
                  numStream(numStrm),
-                 continuousTrace(false),
+                 traceContinuous(false),
                  offloadIntervalms(0),
                  bufferInitialized(false),
                  offloadStatus(AIEOffloadThreadStatus::IDLE)

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -63,7 +63,7 @@ AIETraceOffload::AIETraceOffload(void* handle, uint64_t id,
 
 AIETraceOffload::~AIETraceOffload()
 {
-  stopoffload();
+  stopOffload();
   if (offloadThread.joinable()) {
     offloadThread.join();
   }

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.h
@@ -79,10 +79,11 @@ public:
     inline AIETraceLogger* getAIETraceLogger() { return traceLogger; }
     inline void setContinuousTrace() { traceContinuous = true; }
     inline bool continuousTrace()    { return traceContinuous; }
+    inline void setOffloadIntervalms(uint64_t v) { offloadIntervalms = v; }
 
     inline AIEOffloadThreadStatus getOffloadStatus() {
       std::lock_guard<std::mutex> lock(statusLock);
-      return status;
+      return offloadStatus;
     };
 
     // no circular buffer for now

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1283,9 +1283,7 @@ namespace xdp {
     }
     aieOffloaders.clear();
 
-    for(auto w : writers) {
-      w->write(openNewFiles);
-    }
+    XDPPlugin::endWrite(openNewFiles);
   }
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1061,7 +1061,7 @@ namespace xdp {
     // Continuous Trace Offload is supported only for PLIO flow
     if (continuousTrace && isPLIO) {
       aieTraceOffloader->setContinuousTrace();
-      aieTraceOffloader->setOffloadIntervalms();
+      aieTraceOffloader->setOffloadIntervalms(offloadIntervalms);
       aieTraceOffloader->startOffload();
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -73,6 +73,9 @@ namespace xdp {
       // Runtime or compile-time specified trace metrics?
       bool runtimeMetrics = true;
 
+      bool continuousTrace;
+      uint64_t offloadIntervalms;
+
       // Trace Runtime Status
       AieRC mConfigStatus = XAIE_OK;
 

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -114,8 +114,13 @@ namespace xdp {
     is_write_thread_active = true;
     while (writeCondWaitFor(std::chrono::seconds(interval))) {
       for (auto w : writers) {
-        if (w->write(true))
-          (db->getStaticInfo()).addOpenedFile(w->getcurrentFileName().c_str(), type) ;
+        if (0 != type.compare("AIE_EVENT_TRACE")) {
+          if (w->write(true)) {
+            (db->getStaticInfo()).addOpenedFile(w->getcurrentFileName().c_str(), type) ;
+          }
+        } else {
+          w->write(false);
+        }
       }
     }
 

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -65,7 +65,8 @@ namespace xdp {
       void*    buf = traceData->buffer[j];
       // We write 4 bytes at a time
       // Max chunk size should be multiple of 4
-      // If last chunk is not multiple of 4 then in worst case, 3 bytes of data will not be written
+      // If last chunk is not multiple of 4 then in worst case, 
+      // 3 bytes of data will not be written. But this is not possible, as we always write full packet.
       uint64_t bufferSz = (traceData->bufferSz[j] / 4);
       if(nullptr == buf) {
         fout << std::endl;
@@ -78,6 +79,7 @@ namespace xdp {
       }
     }
     fout << std::endl;
+    delete traceData;
 
 #if 0
     void*    buf = traceData->buffer;


### PR DESCRIPTION
Add support for continuous offload of AIE Trace. This support uses the same xrt.ini configurations as continuous offload of PL trace. However, AIE continuous trace is supported for PLIO flow only and trace data is appended to the trace output files created for each stream. Each stream has a single trace output file and recorded trace packets are continuously appended to them.