### PR TITLE
XRT-936 add flush_to_legacy flag when there is no FPT or FPT screwed

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -213,7 +213,11 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t boot_on_default:1;
 	uint16_t boot_on_backup:1;
 	uint16_t boot_on_recovery:1;
-	uint16_t resvd1:11;
+	uint16_t has_extfpt:1;
+	uint16_t has_ext_xsabin:1;
+	uint16_t has_ext_scfw:1;
+	uint16_t has_ext_sysdtb:1;
+	uint16_t resvd1:7;
 	uint16_t multi_boot_offset;
 	uint32_t debug_level:3;
 	uint32_t flush_progress:7;

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -126,9 +126,15 @@ struct xgq_cmd_data_payload {
 	uint64_t address;
 	uint32_t size;
 	uint32_t addr_type:4;
-	uint32_t flush_default_only:1;
-	uint32_t rsvd1:27;
+	uint32_t flush_type:4;
+	uint32_t rsvd1:24;
 	uint32_t pad1;
+};
+
+enum xgq_cmd_flush_type {
+	XGQ_CMD_FLUSH_DEFAULT		= 0x0,
+	XGQ_CMD_FLUSH_NO_BACKUP		= 0x1,
+	XGQ_CMD_FLUSH_TO_LEGACY		= 0x2,
 };
 
 /**

--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2021, Xilinx Inc
+ *  Copyright (C) 2021-2022, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -126,6 +126,7 @@ struct xocl_xgq_vmr {
 	bool 			xgq_polling;
 	bool 			xgq_boot_from_backup;
 	bool 			xgq_flush_default_only;
+	bool 			xgq_flush_to_legacy;
 	u32			xgq_intr_base;
 	u32			xgq_intr_num;
 	struct list_head	xgq_submitted_cmds;
@@ -532,6 +533,17 @@ static inline void remove_xgq_cid(struct xocl_xgq_vmr *xgq, int id)
 	mutex_unlock(&xgq->xgq_lock);
 }
 
+static enum xgq_cmd_flush_type inline get_flush_type(struct xocl_xgq_vmr *xgq)
+{
+
+	if (xgq->xgq_flush_to_legacy)
+		return XGQ_CMD_FLUSH_TO_LEGACY;
+	if (xgq->xgq_flush_default_only)
+		return XGQ_CMD_FLUSH_NO_BACKUP;
+
+	return XGQ_CMD_FLUSH_DEFAULT;
+}
+
 /*
  * Utilize shared memory between host and device to transfer data.
  */
@@ -571,7 +583,7 @@ static ssize_t xgq_transfer_data(struct xocl_xgq_vmr *xgq, const void *buf,
 	payload->address = memcpy_to_devices(xgq, buf, len);
 	payload->size = len;
 	payload->addr_type = XGQ_CMD_ADD_TYPE_AP_OFFSET;
-	payload->flush_default_only = xgq->xgq_flush_default_only;
+	payload->flush_type = get_flush_type(xgq);
 
 	/* set up hdr */
 	hdr = &(cmd->xgq_cmd_entry.hdr);
@@ -1236,6 +1248,36 @@ static ssize_t flush_default_only_show(struct device *dev,
 }
 static DEVICE_ATTR(flush_default_only, 0644, flush_default_only_show, flush_default_only_store);
 
+static ssize_t flush_to_legacy_store(struct device *dev,
+	struct device_attribute *attr, const char *buf, size_t count)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	u32 val = 0;
+
+	if (kstrtou32(buf, 10, &val) == -EINVAL)
+		return -EINVAL;
+
+	mutex_lock(&xgq->xgq_lock);
+	xgq->xgq_flush_to_legacy = val ? true : false;
+	mutex_unlock(&xgq->xgq_lock);
+
+	return count;
+}
+
+static ssize_t flush_to_legacy_show(struct device *dev,
+	struct device_attribute *attr, char *buf)
+{
+	struct xocl_xgq_vmr *xgq = platform_get_drvdata(to_platform_device(dev));
+	ssize_t cnt = 0;
+
+	mutex_lock(&xgq->xgq_lock);
+	cnt += sprintf(buf + cnt, "%d\n", xgq->xgq_flush_to_legacy);
+	mutex_unlock(&xgq->xgq_lock);
+
+	return cnt;
+}
+static DEVICE_ATTR(flush_to_legacy, 0644, flush_to_legacy_show, flush_to_legacy_store);
+
 static ssize_t polling_store(struct device *dev,
 	struct device_attribute *attr, const char *buf, size_t count)
 {
@@ -1334,8 +1376,8 @@ static ssize_t vmr_status_show(struct device *dev,
 	cnt += sprintf(buf + cnt, "BOOT_ON_BACKUP:%d\n", vmr_status->boot_on_backup);
 	cnt += sprintf(buf + cnt, "BOOT_ON_RECOVERY:%d\n", vmr_status->boot_on_recovery);
 	cnt += sprintf(buf + cnt, "MULTI_BOOT_OFFSET:0x%x\n", vmr_status->multi_boot_offset);
-	cnt += sprintf(buf + cnt, "DEBUG_LEVEL:0x%x\n", vmr_status->debug_level);
-	cnt += sprintf(buf + cnt, "FLUSH_PROGRESS:0x%x\n", vmr_status->flush_progress);
+	cnt += sprintf(buf + cnt, "DEBUG_LEVEL:%d\n", vmr_status->debug_level);
+	cnt += sprintf(buf + cnt, "FLUSH_PROGRESS:%d\n", vmr_status->flush_progress);
 	mutex_unlock(&xgq->xgq_lock);
 
 	return cnt;
@@ -1346,6 +1388,7 @@ static struct attribute *xgq_attrs[] = {
 	&dev_attr_polling.attr,
 	&dev_attr_boot_from_backup.attr,
 	&dev_attr_flush_default_only.attr,
+	&dev_attr_flush_to_legacy.attr,
 	&dev_attr_vmr_status.attr,
 	&dev_attr_vmr_debug_level.attr,
 	&dev_attr_program_sc.attr,
@@ -1407,6 +1450,7 @@ static int xgq_ospi_open(struct inode *inode, struct file *file)
 		return -ENXIO;
 
 	file->private_data = xgq;
+
 	return 0;
 }
 
@@ -1415,6 +1459,7 @@ static int xgq_ospi_close(struct inode *inode, struct file *file)
 	struct xocl_xgq_vmr *xgq = file->private_data;
 
 	xocl_drvinst_close(xgq);
+
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1416,9 +1416,9 @@ static ssize_t vmr_status_show(struct device *dev,
 	cnt += sprintf(buf + cnt, "BOOT_ON_RECOVERY:%d\n", vmr_status->boot_on_recovery);
 	cnt += sprintf(buf + cnt, "MULTI_BOOT_OFFSET:0x%x\n", vmr_status->multi_boot_offset);
 	cnt += sprintf(buf + cnt, "HAS_EXTFPT:%d\n", vmr_status->has_extfpt);
-	cnt += sprintf(buf + cnt, "HAS_EXT_META_XSABIN:%d\n", vmr_status->has_fpt);
-	cnt += sprintf(buf + cnt, "HAS_EXT_SC_FW:%d\n", vmr_status->has_fpt);
-	cnt += sprintf(buf + cnt, "HAS_EXT_SYSTEM_DTB:%d\n", vmr_status->has_fpt);
+	cnt += sprintf(buf + cnt, "HAS_EXT_META_XSABIN:%d\n", vmr_status->has_ext_xsabin);
+	cnt += sprintf(buf + cnt, "HAS_EXT_SC_FW:%d\n", vmr_status->has_ext_scfw);
+	cnt += sprintf(buf + cnt, "HAS_EXT_SYSTEM_DTB:%d\n", vmr_status->has_ext_sysdtb);
 	cnt += sprintf(buf + cnt, "DEBUG_LEVEL:%d\n", vmr_status->debug_level);
 	cnt += sprintf(buf + cnt, "FLUSH_PROGRESS:%d\n", vmr_status->flush_progress);
 	mutex_unlock(&xgq->xgq_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1494,7 +1494,6 @@ static int xgq_ospi_open(struct inode *inode, struct file *file)
 		return -ENXIO;
 
 	file->private_data = xgq;
-
 	return 0;
 }
 
@@ -1503,7 +1502,6 @@ static int xgq_ospi_close(struct inode *inode, struct file *file)
 	struct xocl_xgq_vmr *xgq = file->private_data;
 
 	xocl_drvinst_close(xgq);
-
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -2,7 +2,7 @@
 /*
  * Xilinx CU driver for memory to memory BO copy
  *
- * Copyright (C) 2021 Xilinx, Inc.
+ * Copyright (C) 2021-2022 Xilinx, Inc.
  *
  * Authors: David Zhang <davidzha@xilinx.com>
  */

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -576,19 +576,13 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
                     return;
                 }
 
-                // Load entire PDI section.
-                std::vector<char> pdibuf(pdiSection->m_sectionSize);
-                in_file.seekg(pdiSection->m_sectionOffset);
-                in_file.read(pdibuf.data(), pdiSection->m_sectionSize);
-                if (!in_file.good())
-                {
-                    this->setstate(failbit);
-                    std::cout << "Can't read PDI section from "<< file << std::endl;
-                    return;
-                }
-                bufsize = pdiSection->m_sectionSize;
+                /*
+                 * By default, we load entire xsabin. 
+		 * For legacy ospiversal type, the Flasher class will trim to PDI.
+		 * For new ospi_xgq type, the Flasher will take entire xsabin.
+                 */
                 mBuf = new char[bufsize];
-                in_file.seekg(pdiSection->m_sectionOffset);
+                in_file.seekg(0);
                 in_file.read(mBuf, bufsize);
             } else {
                 // Obtain MCS section header.
@@ -648,7 +642,7 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
     this->rdbuf()->pubsetbuf(mBuf, bufsize);
 #endif
 #ifdef _WIN32
-	this->str(mBuf);
+    this->str(mBuf);
 #endif
 }
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xgq_vmr.cpp
@@ -28,23 +28,25 @@ XGQ_VMR_Flasher::XGQ_VMR_Flasher(std::shared_ptr<xrt_core::device> dev)
 int XGQ_VMR_Flasher::xclUpgradeFirmware(std::istream& binStream)
 {
   binStream.seekg(0, binStream.end);
-  auto total_size = static_cast<int>(binStream.tellg());
+  ssize_t total_size = static_cast<int>(binStream.tellg());
   binStream.seekg(0, binStream.beg);
 
-  std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
+  std::cout << "INFO: ***xsabin has " << total_size << " bytes" << std::endl;
 
   try {
-    auto fd = m_device->file_open("xgq_vmr", O_RDWR);
     std::vector<char> buffer(total_size);
     binStream.read(buffer.data(), total_size);
     ssize_t ret = total_size;
+
 #ifdef __GNUC__
+    auto fd = m_device->file_open("xgq_vmr", O_RDWR);
     ret = write(fd.get(), buffer.data(), total_size);
 #endif
+    std::cout << "INFO: ***Write " << ret << " bytes" << std::endl;
     return ret == total_size ? 0 : -EIO;
   }
   catch (const std::exception& e) {
-    xrt_core::send_exception_message(e.what(), "XBMGMT");
+    xrt_core::send_exception_message(e.what(), "xgq_vmr operation failed");
     return -EIO;
   }
 }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -44,12 +44,12 @@ int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
     if (!hdr)
         throw std::runtime_error("No PDI section in xclbin");
     ssize_t size = hdr->m_sectionSize;
-    auto data = reinterpret_cast<const char*>(reinterpret_cast<const char*>(top) +
-        hdr->m_sectionOffset);
 
     std::cout << "INFO: ***PDI has " << size << " bytes" << std::endl;
 
 #ifdef __GNUC__
+    auto data = reinterpret_cast<const char*>(reinterpret_cast<const char*>(top) +
+        hdr->m_sectionOffset);
     auto fd = m_device->file_open("xfer_versal", O_RDWR);
     ret = write(fd.get(), data, size);
 #endif

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xospiversal.cpp
@@ -16,6 +16,7 @@
 
 #include <fcntl.h>
 #include "xospiversal.h"
+#include "core/common/xclbin_parser.h"
 
 /**
  * @brief XOSPIVER_Flasher::XOSPIVER_Flasher
@@ -31,20 +32,33 @@ int XOSPIVER_Flasher::xclUpgradeFirmware(std::istream& binStream)
   auto total_size = static_cast<int>(binStream.tellg());
   binStream.seekg(0, binStream.beg);
 
-  std::cout << "INFO: ***PDI has " << total_size << " bytes" << std::endl;
+  std::cout << "INFO: ***xsabin has " << total_size << " bytes" << std::endl;
 
   try {
-    auto fd = m_device->file_open("xfer_versal", O_RDWR);
     std::vector<char> buffer(total_size);
     binStream.read(buffer.data(), total_size);
     ssize_t ret = total_size;
+
+    auto top = reinterpret_cast<const axlf*>(buffer.data());
+    auto hdr = xrt_core::xclbin::get_axlf_section(top, PDI);
+    if (!hdr)
+        throw std::runtime_error("No PDI section in xclbin");
+    ssize_t size = hdr->m_sectionSize;
+    auto data = reinterpret_cast<const char*>(reinterpret_cast<const char*>(top) +
+        hdr->m_sectionOffset);
+
+    std::cout << "INFO: ***PDI has " << size << " bytes" << std::endl;
+
 #ifdef __GNUC__
-    ret = write(fd.get(), buffer.data(), total_size);
+    auto fd = m_device->file_open("xfer_versal", O_RDWR);
+    ret = write(fd.get(), data, size);
 #endif
-    return ret == total_size ? 0 : -EIO;
+    std::cout << "INFO: ***Write " << ret << " bytes" << std::endl;
+
+    return ret == size ? 0 : -EIO;
   }
   catch (const std::exception& e) {
-    xrt_core::send_exception_message(e.what(), "XBMGMT");
+    xrt_core::send_exception_message(e.what(), "xfer_versal operation failed");
     return -EIO;
   }
 }


### PR DESCRIPTION
CR-1119217 VCK5000 - FPT appears to be overwritten when a flashing a different base to memory

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
CR-1119217 VCK5000 - FPT appears to be overwritten when a flashing a different base to memory
XRT-936 add flush_to_legacy flag when there is no FPT or FPT screwed

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This aims to resolve the issue:
https://confluence.xilinx.com/pages/viewpage.action?pageId=441234539
When user screwed the A/B boot, we provide private sysfs interface to allow user flash their shell back to normal without using jtag.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
Updated XGQ document:
https://confluence.xilinx.com/pages/viewpage.action?pageId=302345261#XGQ1.0CommandandQueueSpecification(WIP)-GetLogPage
