### PR TITLE
Added AIE Fifo info to XRT

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -83,16 +83,22 @@ populate_aie_dma(const boost::property_tree::ptree& pt, boost::property_tree::pt
   // queue_status: mm2s: okay|okay, s2mm: okay|okay
   // current_bd: mm2s: 0|0, s2mm: 0|0
   // fifo_len: 0|0
-  auto fifo_info = pt.get_child("dma.fifo_len", empty_pt).begin();
-  fifo_pt.put("fifo_counter0", fifo_info->second.data());
-  fifo_info++;
-  fifo_pt.put("fifo_counter1", fifo_info->second.data());
-  pt_dma.add_child("dma.fifo_info", fifo_pt);
+  int id = 0;
+  for (const auto& node : pt.get_child("dma.fifo_len", empty_pt)) {
+    std::string counter_id = "Counter";
+    boost::property_tree::ptree fifo_counter;
+    counter_id += std::to_string(id++);
+    fifo_counter.put("counter_id", counter_id);
+    fifo_counter.put("counter_val", node.second.data());
+    fifo_pt.push_back(std::make_pair("", fifo_counter));
+  }
+
+  pt_dma.add_child("dma.fifo.counters", fifo_pt);
 
   auto queue_size = pt.get_child("dma.queue_size.mm2s", empty_pt).begin();
   auto queue_status = pt.get_child("dma.queue_status.mm2s", empty_pt).begin();
   auto current_bd = pt.get_child("dma.current_bd.mm2s", empty_pt).begin();
-  int id = 0;
+  id = 0;
 
   for (const auto& node : pt.get_child("dma.channel_status.mm2s", empty_pt)) {
     boost::property_tree::ptree channel;

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -85,11 +85,11 @@ populate_aie_dma(const boost::property_tree::ptree& pt, boost::property_tree::pt
   // fifo_len: 0|0
   int id = 0;
   for (const auto& node : pt.get_child("dma.fifo_len", empty_pt)) {
-    std::string counter_id = "Counter";
+    std::string index = "Counter";
     boost::property_tree::ptree fifo_counter;
-    counter_id += std::to_string(id++);
-    fifo_counter.put("counter_id", counter_id);
-    fifo_counter.put("counter_val", node.second.data());
+    index += std::to_string(id++);
+    fifo_counter.put("index", index);
+    fifo_counter.put("count", node.second.data());
     fifo_pt.push_back(std::make_pair("", fifo_counter));
   }
 

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -84,11 +84,9 @@ populate_aie_dma(const boost::property_tree::ptree& pt, boost::property_tree::pt
   // current_bd: mm2s: 0|0, s2mm: 0|0
   // fifo_len: 0|0
   auto fifo_info = pt.get_child("dma.fifo_len", empty_pt).begin();
-  boost::property_tree::ptree tmp_ptree;
-  tmp_ptree.put("fifo_counter0", fifo_info->second.data());
+  fifo_pt.put("fifo_counter0", fifo_info->second.data());
   fifo_info++;
-  tmp_ptree.put("fifo_counter1", fifo_info->second.data());
-  fifo_pt.push_back(std::make_pair("", tmp_ptree));
+  fifo_pt.put("fifo_counter1", fifo_info->second.data());
   pt_dma.add_child("dma.fifo_info", fifo_pt);
 
   auto queue_size = pt.get_child("dma.queue_size.mm2s", empty_pt).begin();

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -70,9 +70,19 @@ addnodelist(const std::string& search_str, const std::string& node_str,
 static void
 populate_aie_dma(const boost::property_tree::ptree& pt, boost::property_tree::ptree& pt_dma)
 {
+  boost::property_tree::ptree fifo_len_pt;
   boost::property_tree::ptree mm2s_array;
   boost::property_tree::ptree s2mm_array;
   boost::property_tree::ptree empty_pt;
+
+  /* Extract FIFO SIZE/COUNT information */
+  auto fifo_len = pt.get_child("dma.fifo_len", empty_pt).begin();
+  boost::property_tree::ptree channel;
+  channel.put("fifo_size", fifo_len->second.data());
+  fifo_len++;
+  channel.put("fifo_count", fifo_len->second.data());
+  fifo_len_pt.push_back(std::make_pair("", channel));
+  pt_dma.add_child("dma.fifo_info", fifo_len_pt);
 
   auto queue_size = pt.get_child("dma.queue_size.mm2s", empty_pt).begin();
   auto queue_status = pt.get_child("dma.queue_status.mm2s", empty_pt).begin();

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -75,7 +75,7 @@ populate_aie_dma(const boost::property_tree::ptree& pt, boost::property_tree::pt
   boost::property_tree::ptree s2mm_array;
   boost::property_tree::ptree empty_pt;
 
-  /* Extract FIFO SIZE/COUNT information */
+  // Extract FIFO SIZE/COUNT information
   auto fifo_len = pt.get_child("dma.fifo_len", empty_pt).begin();
   boost::property_tree::ptree channel;
   channel.put("fifo_size", fifo_len->second.data());

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -70,19 +70,26 @@ addnodelist(const std::string& search_str, const std::string& node_str,
 static void
 populate_aie_dma(const boost::property_tree::ptree& pt, boost::property_tree::ptree& pt_dma)
 {
-  boost::property_tree::ptree fifo_len_pt;
+  boost::property_tree::ptree fifo_pt;
   boost::property_tree::ptree mm2s_array;
   boost::property_tree::ptree s2mm_array;
   boost::property_tree::ptree empty_pt;
 
-  // Extract FIFO SIZE/COUNT information
-  auto fifo_len = pt.get_child("dma.fifo_len", empty_pt).begin();
-  boost::property_tree::ptree channel;
-  channel.put("fifo_size", fifo_len->second.data());
-  fifo_len++;
-  channel.put("fifo_count", fifo_len->second.data());
-  fifo_len_pt.push_back(std::make_pair("", channel));
-  pt_dma.add_child("dma.fifo_info", fifo_len_pt);
+  // Extract FIFO COUNT information
+  // Sample sysfs entry for DMA
+  // cat /sys/devices/platform/<aie_path>/aiepart_0_50/47_0/dma
+  // ichannel_status: mm2s: idle|idle, s2mm: idle|idle
+  // queue_size: mm2s: 0|0, s2mm: 0|0
+  // queue_status: mm2s: okay|okay, s2mm: okay|okay
+  // current_bd: mm2s: 0|0, s2mm: 0|0
+  // fifo_len: 0|0
+  auto fifo_info = pt.get_child("dma.fifo_len", empty_pt).begin();
+  boost::property_tree::ptree tmp_ptree;
+  tmp_ptree.put("fifo_counter0", fifo_info->second.data());
+  fifo_info++;
+  tmp_ptree.put("fifo_counter1", fifo_info->second.data());
+  fifo_pt.push_back(std::make_pair("", tmp_ptree));
+  pt_dma.add_child("dma.fifo_info", fifo_pt);
 
   auto queue_size = pt.get_child("dma.queue_size.mm2s", empty_pt).begin();
   auto queue_status = pt.get_child("dma.queue_status.mm2s", empty_pt).begin();

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -133,10 +133,9 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 	if(tile.second.find("dma") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "DMA";
           _output << boost::format("        %s:\n") % "FIFO";
-          for(auto& node : tile.second.get_child("dma.fifo_info")) {
-            _output << fmt16("%s") % "Counter0" % node.second.get<std::string>("fifo_counter0");
-            _output << fmt16("%s") % "Counter1" % node.second.get<std::string>("fifo_counter1");
-	  }
+          auto& fifo_node  = tile.second.get_child("dma.fifo_info");
+          _output << fmt16("%s") % "Counter0" % fifo_node.get<std::string>("fifo_counter0");
+          _output << fmt16("%s") % "Counter1" % fifo_node.get<std::string>("fifo_counter1");
 
           _output << boost::format("        %s:\n") % "MM2S";
 
@@ -161,7 +160,7 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
             _output << fmt16("%s") % "Current BD" % node.second.get<std::string>("current_bd");
             _output << std::endl;
           }
-        } 
+        }
 
         if(tile.second.find("locks") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "Locks";

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -133,10 +133,10 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 	if(tile.second.find("dma") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "DMA";
 
-          _output << boost::format("        %s:\n") % "FIFO";
+          _output << boost::format("%12s:\n") % "FIFO";
           for(auto& node : tile.second.get_child("dma.fifo.counters")) {
-            _output << fmt16("%s") % node.second.get<std::string>("counter_id")
-		    % node.second.get<std::string>("counter_val");
+            _output << fmt16("%s") % node.second.get<std::string>("index")
+		    % node.second.get<std::string>("count");
           }
 
           _output << boost::format("        %s:\n") % "MM2S";

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -134,8 +134,8 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
           _output << boost::format("    %s:\n") % "DMA";
           _output << boost::format("        %s:\n") % "FIFO";
           for(auto& node : tile.second.get_child("dma.fifo_info")) {
-            _output << fmt16("%s") % "Size" % node.second.get<std::string>("fifo_size");
-            _output << fmt16("%s") % "Count" % node.second.get<std::string>("fifo_count");
+            _output << fmt16("%s") % "Counter0" % node.second.get<std::string>("fifo_counter0");
+            _output << fmt16("%s") % "Counter1" % node.second.get<std::string>("fifo_counter1");
 	  }
 
           _output << boost::format("        %s:\n") % "MM2S";

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -133,11 +133,11 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 	if(tile.second.find("dma") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "DMA";
 
-	  _output << boost::format("        %s:\n") % "FIFO";
-
-	  auto& fifo_node  = tile.second.get_child("dma.fifo_info");
-          _output << fmt16("%s") % "Counter0" % fifo_node.get<std::string>("fifo_counter0");
-          _output << fmt16("%s") % "Counter1" % fifo_node.get<std::string>("fifo_counter1");
+          _output << boost::format("        %s:\n") % "FIFO";
+          for(auto& node : tile.second.get_child("dma.fifo.counters")) {
+            _output << fmt16("%s") % node.second.get<std::string>("counter_id")
+		    % node.second.get<std::string>("counter_val");
+          }
 
           _output << boost::format("        %s:\n") % "MM2S";
 

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2020-2021 Xilinx, Inc
+  Copyright (C) 2020-2022 Xilinx, Inc
  
   Licensed under the Apache License, Version 2.0 (the "License"). You may
   not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -132,8 +132,10 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 
 	if(tile.second.find("dma") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "DMA";
-          _output << boost::format("        %s:\n") % "FIFO";
-          auto& fifo_node  = tile.second.get_child("dma.fifo_info");
+
+	  _output << boost::format("        %s:\n") % "FIFO";
+
+	  auto& fifo_node  = tile.second.get_child("dma.fifo_info");
           _output << fmt16("%s") % "Counter0" % fifo_node.get<std::string>("fifo_counter0");
           _output << fmt16("%s") % "Counter1" % fifo_node.get<std::string>("fifo_counter1");
 

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -132,6 +132,12 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 
 	if(tile.second.find("dma") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "DMA";
+          _output << boost::format("        %s:\n") % "FIFO";
+          for(auto& node : tile.second.get_child("dma.fifo_info")) {
+            _output << fmt16("%s") % "Size" % node.second.get<std::string>("fifo_size");
+            _output << fmt16("%s") % "Count" % node.second.get<std::string>("fifo_count");
+	  }
+
           _output << boost::format("        %s:\n") % "MM2S";
 
           _output << boost::format("            %s:\n") % "Channel";

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -99,11 +99,10 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
       _output << fmt4("%d") % "Row" % tile.second.get<int>("row");
       if(tile.second.find("dma") != tile.second.not_found()) {
         _output << boost::format("    %s:\n") % "DMA";
-        _output << boost::format("        %s:\n") % "FIFO";
-        for(auto& node : tile.second.get_child("dma.fifo_info")) {
-          _output << fmt16("%s") % "Size" % node.second.get<std::string>("fifo_size");
-          _output << fmt16("%s") % "Count" % node.second.get<std::string>("fifo_count");
-        }
+	_output << boost::format("        %s:\n") % "FIFO";
+	auto& fifo_node  = tile.second.get_child("dma.fifo_info");
+	_output << fmt16("%s") % "Counter0" % fifo_node.get<std::string>("fifo_counter0");
+	_output << fmt16("%s") % "Counter1" % fifo_node.get<std::string>("fifo_counter1");
 
         _output << boost::format("        %s:\n") % "MM2S";
 

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021 Xilinx, Inc
+  Copyright (C) 2021-2022 Xilinx, Inc
  
   Licensed under the Apache License, Version 2.0 (the "License"). You may
   not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -99,6 +99,12 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
       _output << fmt4("%d") % "Row" % tile.second.get<int>("row");
       if(tile.second.find("dma") != tile.second.not_found()) {
         _output << boost::format("    %s:\n") % "DMA";
+        _output << boost::format("        %s:\n") % "FIFO";
+        for(auto& node : tile.second.get_child("dma.fifo_info")) {
+          _output << fmt16("%s") % "Size" % node.second.get<std::string>("fifo_size");
+          _output << fmt16("%s") % "Count" % node.second.get<std::string>("fifo_count");
+        }
+
         _output << boost::format("        %s:\n") % "MM2S";
 
         _output << boost::format("            %s:\n") % "Channel";

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -100,10 +100,10 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
       if(tile.second.find("dma") != tile.second.not_found()) {
         _output << boost::format("    %s:\n") % "DMA";
 
-	_output << boost::format("        %s:\n") % "FIFO";
+	_output << boost::format("%12s:\n") % "FIFO";
         for(auto& node : tile.second.get_child("dma.fifo.counters")) {
-          _output << fmt16("%s") % node.second.get<std::string>("counter_id")
-                    % node.second.get<std::string>("counter_val");
+          _output << fmt16("%s") % node.second.get<std::string>("index")
+                    % node.second.get<std::string>("count");
         }
 
         _output << boost::format("        %s:\n") % "MM2S";

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -101,10 +101,10 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
         _output << boost::format("    %s:\n") % "DMA";
 
 	_output << boost::format("        %s:\n") % "FIFO";
-
-	auto& fifo_node  = tile.second.get_child("dma.fifo_info");
-	_output << fmt16("%s") % "Counter0" % fifo_node.get<std::string>("fifo_counter0");
-	_output << fmt16("%s") % "Counter1" % fifo_node.get<std::string>("fifo_counter1");
+        for(auto& node : tile.second.get_child("dma.fifo.counters")) {
+          _output << fmt16("%s") % node.second.get<std::string>("counter_id")
+                    % node.second.get<std::string>("counter_val");
+        }
 
         _output << boost::format("        %s:\n") % "MM2S";
 

--- a/src/runtime_src/core/tools/common/ReportAieShim.cpp
+++ b/src/runtime_src/core/tools/common/ReportAieShim.cpp
@@ -99,7 +99,9 @@ ReportAieShim::writeReport( const xrt_core::device* /*_pDevice*/,
       _output << fmt4("%d") % "Row" % tile.second.get<int>("row");
       if(tile.second.find("dma") != tile.second.not_found()) {
         _output << boost::format("    %s:\n") % "DMA";
+
 	_output << boost::format("        %s:\n") % "FIFO";
+
 	auto& fifo_node  = tile.second.get_child("dma.fifo_info");
 	_output << fmt16("%s") % "Counter0" % fifo_node.get<std::string>("fifo_counter0");
 	_output << fmt16("%s") % "Counter1" % fifo_node.get<std::string>("fifo_counter1");


### PR DESCRIPTION
VITIS-4228 : Xbutil enhancements to report new register values reported from Sysfs

As aie driver provides FIFO sysfs entry for FIFO counter0 ad counter1. We have added the support to XRT. 
Also added the same to xbutil output. 

```

 Core [ 1]
       Column                : 25
       Row                   : 4
       Core:
          Status                : enabled, stream_stall_ss0
          Program Counter       : 0x00000300
          Link Register         : 0x000001f0
          Stack Pointer         : 0x0002a080
     DMA:
          FIFO:
                  Counter0                  : 0
                  Counter1                  : 0
          MM2S:


```