### PR TITLE
xclbinutil: Added clock info support to the --info option

### DIFF
--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -613,9 +613,9 @@ reportClocks( std::ostream & _ostream,
   }
 
   // the following information is from SYSTEM_METADATA section (system diagram json)
-  _ostream << std::endl;
-  _ostream << "System Clocks" << std::endl;
-  _ostream << "------" << std::endl;
+  _ostream << "\n"
+           << "System Clocks\n"
+           << "------\n";
   // system_diagram_metadata
   //   xsa
   //     clocks
@@ -668,14 +668,15 @@ reportClocks( std::ostream & _ostream,
     if (boost::iequals(sType, "RESERVED"))
       continue;
 
-    _ostream << boost::format("   %-15s %s\n") % "Name:" % sName;
-    _ostream << boost::format("   %-15s %s\n") % "Type:" % sType;
-    _ostream << boost::format("   %-15s %s MHz\n") % "Default Freq:" % sSpecFreq;
+    boost::format systemClockFmt("   %-15s %s %s\n");
+    _ostream << systemClockFmt % "Name:" % sName % "";
+    _ostream << systemClockFmt % "Type:" % sType % "";
+    _ostream << systemClockFmt % "Default Freq:" % sSpecFreq % "MHz";
 
-    // display requested and achived frequency only for scalable clocks 
+    // display requested and achieved frequency only for scalable clocks 
     if (boost::iequals(sType, "SCALABLE")) {
-      _ostream << boost::format("   %-15s %s MHz\n") % "Requested Freq:" % sRequestedFreq;
-      _ostream << boost::format("   %-15s %s MHz\n") % "Achieved Freq:" % sAchievedFreq;
+      _ostream << systemClockFmt % "Requested Freq:" % sRequestedFreq % "MHz";
+      _ostream << systemClockFmt % "Achieved Freq:" % sAchievedFreq % "MHz";
     }
 
     if (&ptClock != &clocks.back()) 

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -178,13 +178,13 @@ FormattedOutput::getKernelDDRMemory(const std::string _sKernelInstanceName,
   XUtil::TRACE_PrintTree("Top", ptSections);
 
   boost::property_tree::ptree& ptMemTopology = ptSections.get_child("mem_topology");
-  std::vector<boost::property_tree::ptree> memTopology = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology, "m_mem_data");
+  auto memTopology = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology, "m_mem_data");
 
   boost::property_tree::ptree& ptConnectivity = ptSections.get_child("connectivity");
-  std::vector<boost::property_tree::ptree> connectivity = XUtil::as_vector<boost::property_tree::ptree>(ptConnectivity, "m_connection");
+  auto connectivity = XUtil::as_vector<boost::property_tree::ptree>(ptConnectivity, "m_connection");
 
   boost::property_tree::ptree& ptIPLayout = ptSections.get_child("ip_layout");
-  std::vector<boost::property_tree::ptree> ipLayout = XUtil::as_vector<boost::property_tree::ptree>(ptIPLayout, "m_ip_data");
+  auto ipLayout = XUtil::as_vector<boost::property_tree::ptree>(ptIPLayout, "m_ip_data");
 
   // 3) Establish the connections
   std::set<int> addedIndex;
@@ -291,9 +291,9 @@ reportXclbinInfo( std::ostream & _ostream,
     std::string sKernels;
     if (!_ptMetaData.empty()) {
       boost::property_tree::ptree &ptXclBin = _ptMetaData.get_child("xclbin");
-      std::vector<boost::property_tree::ptree> userRegions = XUtil::as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
+      auto userRegions = XUtil::as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
       for (auto & userRegion : userRegions) {
-        std::vector<boost::property_tree::ptree> kernels = XUtil::as_vector<boost::property_tree::ptree>(userRegion,"kernels");
+        auto kernels = XUtil::as_vector<boost::property_tree::ptree>(userRegion,"kernels");
         for (auto & kernel : kernels) {
            std::string sKernel = kernel.get<std::string>("name", "");
            if (sKernel.empty()) {
@@ -593,7 +593,7 @@ reportClocks( std::ostream & _ostream,
     _ostream << "   No scalable clock data available."  << std::endl;
   }
 
-  std::vector<boost::property_tree::ptree> clockFreqs = XUtil::as_vector<boost::property_tree::ptree>(ptClockFreqTopology,"m_clock_freq");
+  auto clockFreqs = XUtil::as_vector<boost::property_tree::ptree>(ptClockFreqTopology,"m_clock_freq");
   for (unsigned int index = 0; index < clockFreqs.size(); ++index) {
     boost::property_tree::ptree &ptClockFreq = clockFreqs[index];
     std::string sName = ptClockFreq.get<std::string>("m_name");
@@ -650,7 +650,7 @@ reportClocks( std::ostream & _ostream,
     }
   }
 
-  std::vector<boost::property_tree::ptree> clocks = XUtil::as_vector<boost::property_tree::ptree>(ptXsa,"clocks");
+  auto clocks = XUtil::as_vector<boost::property_tree::ptree>(ptXsa,"clocks");
   if (clocks.size() == 0) {
     _ostream << "   No system clock data available."  << std::endl;
     return;
@@ -706,7 +706,7 @@ reportMemoryConfiguration( std::ostream & _ostream,
     return;
   }
 
-  std::vector<boost::property_tree::ptree> memDatas = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology,"m_mem_data");
+  auto memDatas = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology,"m_mem_data");
   for (unsigned int index = 0; index < memDatas.size(); ++index) {
     boost::property_tree::ptree & ptMemData = memDatas[index];
 
@@ -766,9 +766,9 @@ reportKernels( std::ostream & _ostream,
   }
 
   boost::property_tree::ptree &ptXclBin = _ptMetaData.get_child("xclbin");
-  std::vector<boost::property_tree::ptree> userRegions = XUtil::as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
+  auto userRegions = XUtil::as_vector<boost::property_tree::ptree>(ptXclBin,"user_regions");
   for (auto & userRegion : userRegions) {
-    std::vector<boost::property_tree::ptree> kernels = XUtil::as_vector<boost::property_tree::ptree>(userRegion,"kernels");
+    auto kernels = XUtil::as_vector<boost::property_tree::ptree>(userRegion,"kernels");
     if (kernels.size() == 0) 
       _ostream << "Kernel(s): <None Found>" << std::endl;
 
@@ -778,9 +778,9 @@ reportKernels( std::ostream & _ostream,
       std::string sKernel = ptKernel.get<std::string>("name");
       _ostream << XUtil::format("%s %s", "Kernel:", sKernel.c_str()).c_str() << std::endl;
 
-      std::vector<boost::property_tree::ptree> ports = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"ports");
-      std::vector<boost::property_tree::ptree> arguments = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"arguments");
-      std::vector<boost::property_tree::ptree> instances = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"instances");
+      auto ports = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"ports");
+      auto arguments = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"arguments");
+      auto instances = XUtil::as_vector<boost::property_tree::ptree>(ptKernel,"instances");
 
       _ostream << std::endl;
 

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -26,6 +26,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 
 // Generated include files
 #include "version.h"

--- a/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
+++ b/src/runtime_src/tools/xclbinutil/FormattedOutput.cxx
@@ -574,6 +574,8 @@ void
 reportClocks( std::ostream & _ostream,
               const std::vector<Section*> _sections)
 {
+  boost::property_tree::ptree ptEmpty;
+
   _ostream << "Scalable Clocks" << std::endl;
   _ostream << "------" << std::endl;
 
@@ -641,31 +643,31 @@ reportClocks( std::ostream & _ostream,
       boost::property_tree::ptree pt;
       pSection->getPayload(pt);
       if (!pt.empty()) {
-        boost::property_tree::ptree ptSysDiaMet = pt.get_child("system_diagram_metadata");
-        if (!ptSysDiaMet.empty()) {
-          ptXsa = ptSysDiaMet.get_child("xsa");
-        }
+        boost::property_tree::ptree ptSysDiaMet = pt.get_child("system_diagram_metadata", ptEmpty);
+        if (!ptSysDiaMet.empty()) 
+          ptXsa = ptSysDiaMet.get_child("xsa", ptEmpty);
       }
       break;
     }
   }
 
   auto clocks = XUtil::as_vector<boost::property_tree::ptree>(ptXsa,"clocks");
-  if (clocks.size() == 0) {
-    _ostream << "   No system clock data available."  << std::endl;
+  if (clocks.empty()) {
+    _ostream << "   No system clock data available.\n";
     return;
   }
 
   for (const auto & ptClock : clocks) {
-    std::string sName = ptClock.get<std::string>("orig_name");
-    std::string sType = ptClock.get<std::string>("type");
-    std::string sSpecFreq = ptClock.get<std::string>("spec_frequency");
-    std::string sRequestedFreq = ptClock.get<std::string>("requested_frequency");
-    std::string sAchievedFreq = ptClock.get<std::string>("achieved_frequency");
+    std::string sName = ptClock.get<std::string>("orig_name","");
+    std::string sType = ptClock.get<std::string>("type","");
+    std::string sSpecFreq = ptClock.get<std::string>("spec_frequency","");
+    std::string sRequestedFreq = ptClock.get<std::string>("requested_frequency","");
+    std::string sAchievedFreq = ptClock.get<std::string>("achieved_frequency","");
 
     // skip CPU clocks (type = RESERVED)
     if (boost::iequals(sType, "RESERVED"))
       continue;
+
     _ostream << boost::format("   %-15s %s\n") % "Name:" % sName;
     _ostream << boost::format("   %-15s %s\n") % "Type:" % sType;
     _ostream << boost::format("   %-15s %s MHz\n") % "Default Freq:" % sSpecFreq;
@@ -676,9 +678,8 @@ reportClocks( std::ostream & _ostream,
       _ostream << boost::format("   %-15s %s MHz\n") % "Achieved Freq:" % sAchievedFreq;
     }
 
-    if (&ptClock != &clocks.back()) {
+    if (&ptClock != &clocks.back()) 
       _ostream << std::endl;
-    }
   }
 }
 

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
@@ -17,6 +17,7 @@
 #include "SectionSystemMetadata.h"
 
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/format.hpp>
 
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
@@ -51,7 +52,7 @@ SectionSystemMetadata::marshalToJSON(char* _pDataSection,
   try {
     boost::property_tree::read_json(ss, _ptree);
   } catch (const std::exception & e) {
-    const std::string errMsg = boost::str(boost::format("ERROR: Bad JSON format detected while marshaling SYSTEM_METADATA (%s).") % e.what());
+    const std::string errMsg = (boost::format("ERROR: Bad JSON format detected while marshaling SYSTEM_METADATA (%s).") % e.what()).str();
     throw std::runtime_error(errMsg);
   }
 }

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 Xilinx, Inc
+ * Copyright (C) 2018, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,6 +16,8 @@
 
 #include "SectionSystemMetadata.h"
 
+#include <boost/property_tree/json_parser.hpp>
+
 #include "XclBinUtilities.h"
 namespace XUtil = XclBinUtilities;
 
@@ -31,4 +33,34 @@ SectionSystemMetadata::~SectionSystemMetadata() {
 }
 
 
+void
+SectionSystemMetadata::marshalToJSON(char* _pDataSection,
+                                     unsigned int _sectionSize,
+                                     boost::property_tree::ptree& _ptree) const {
+  XUtil::TRACE("");
+  XUtil::TRACE("Extracting: SYSTEM_METADATA");
+  XUtil::TRACE_BUF("SYSTEM_METADATA Section Buffer", reinterpret_cast<const char*>(_pDataSection), _sectionSize);
+
+  // Determine if there is something to do, if not then leave
+  if (_sectionSize == 0)
+    return;
+
+  std::stringstream ss;
+  ss.write(_pDataSection, _sectionSize);
+
+  try {
+    boost::property_tree::read_json(ss, _ptree);
+  } catch (const std::exception & e) {
+    const std::string errMsg = boost::str(boost::format("ERROR: Bad JSON format detected while marshaling SYSTEM_METADATA (%s).") % e.what());
+    throw std::runtime_error(errMsg);
+  }
+}
+
+void
+SectionSystemMetadata::marshalFromJSON(const boost::property_tree::ptree& _ptSection,
+                                         std::ostringstream& _buf) const {
+
+   XUtil::TRACE("SYSTEM_METADATA");
+   boost::property_tree::write_json(_buf, _ptSection, false );
+}
 

--- a/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionSystemMetadata.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018 - 2019 Xilinx, Inc
+ * Copyright (C) 2018 - 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -32,6 +32,10 @@ class SectionSystemMetadata : public Section {
  public:
   SectionSystemMetadata();
   virtual ~SectionSystemMetadata();
+
+ protected:
+  virtual void marshalToJSON(char* _DataSection, unsigned int _sectionSize, boost::property_tree::ptree& _ptree) const;
+  virtual void marshalFromJSON(const boost::property_tree::ptree& _ptSection, std::ostringstream& _buf) const;
 
  private:
   // Purposefully private and undefined ctors...


### PR DESCRIPTION
In the perforce repository, work was done to add static clock information reporting support to the --info option.   This work is being merged into the github repository.

For example:
```
System Clocks
------
   Name:           clk_wiz_0_clk_out1
   Type:           FIXED
   Default Freq:   150 MHz

   Name:           clk_wiz_0_clk_out2
   Type:           FIXED
   Default Freq:   300 MHz

   Name:           clk_wiz_0_clk_out3
   Type:           FIXED
   Default Freq:   75 MHz

   Name:           clk_wiz_0_clk_out4
   Type:           FIXED
   Default Freq:   100 MHz

   Name:           clk_wiz_0_clk_out5
   Type:           FIXED
   Default Freq:   200 MHz

   Name:           clk_wiz_0_clk_out6
   Type:           FIXED
   Default Freq:   400 MHz

   Name:           clk_wiz_0_clk_out7
   Type:           FIXED
   Default Freq:   600 MHz
```

