### PR TITLE
CR-1119487 xclLoadXclBin hang on runs on board with Ubuntu 20 OS

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1486,7 +1486,7 @@ xocl_kds_xgq_cfg_cu(struct xocl_dev *xdev, struct xrt_cu_info *cu_info, int num_
 				max_off_idx = j;
 			}
 		}
-		cfg_cu->payload_size = max_off + cu_info[i].args[max_off_idx].size;
+		cfg_cu->payload_size = max_off + (cu_info[i].num_args ? (cu_info[i].args[max_off_idx].size) : 0);
 		scnprintf(cfg_cu->name, sizeof(cfg_cu->name), "%s:%s",
 			  cu_info[i].kname, cu_info[i].iname);
 


### PR DESCRIPTION
#### Problem solved by the commit
CR-1119487
#### How problem was solved, alternative solutions (if any) and why they were rejected
Check CU argument size

#### What has been tested and how, request additional testing if necessary
Tested with CR-1119487 failing case
#### Documentation impact (if any)
