### PR TITLE
In non cacheable buffer scenario, ensure to use the mmap mechanism to sha…

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -868,14 +868,12 @@ alloc(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
 #ifndef XRT_EDGE
     if (is_nodma(dhdl)) {
       return alloc_nodma(dhdl, sz, flags, grp);
-    } else {
+    } else if (is_sw_emulation()) {
       // In DC scenario, for sw_emu, use the xclAllocBO and xclMapBO instead of xclAllocUserPtrBO, 
       // which helps to remove the extra copy in sw_emu.
-      if (is_sw_emulation()) {
-        return alloc_kbuf(dhdl, sz, flags, grp);
-      } else {
-        return alloc_hbuf(dhdl, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);
-      }
+      return alloc_kbuf(dhdl, sz, flags, grp);
+    } else {
+      return alloc_hbuf(dhdl, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);
     }
 #endif
   case XCL_BO_FLAGS_CACHEABLE:

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -866,15 +866,14 @@ alloc(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
   switch (type) {
   case 0:
 #ifndef XRT_EDGE
-    if (is_nodma(dhdl)) {
+    if (is_nodma(dhdl))
       return alloc_nodma(dhdl, sz, flags, grp);
-    } else if (is_sw_emulation()) {
+    else if (is_sw_emulation())
       // In DC scenario, for sw_emu, use the xclAllocBO and xclMapBO instead of xclAllocUserPtrBO, 
       // which helps to remove the extra copy in sw_emu.
       return alloc_kbuf(dhdl, sz, flags, grp);
-    } else {
+    else
       return alloc_hbuf(dhdl, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);
-    }
 #endif
   case XCL_BO_FLAGS_CACHEABLE:
   case XCL_BO_FLAGS_SVM:

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -866,10 +866,17 @@ alloc(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
   switch (type) {
   case 0:
 #ifndef XRT_EDGE
-    if (is_nodma(dhdl))
+    if (is_nodma(dhdl)) {
       return alloc_nodma(dhdl, sz, flags, grp);
-    else
-      return alloc_hbuf(dhdl, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);
+    } else {
+      // In DC scenario, for sw_emu, use the xclAllocBO and xclMapBO instead of xclAllocUserPtrBO, 
+      // which helps to remove the extra copy in sw_emu.
+      if (is_sw_emulation()) {
+        return alloc_kbuf(dhdl, sz, flags, grp);
+      } else {
+        return alloc_hbuf(dhdl, xrt_core::aligned_alloc(get_alignment(), sz), sz, flags, grp);
+      }
+    }
 #endif
   case XCL_BO_FLAGS_CACHEABLE:
   case XCL_BO_FLAGS_SVM:

--- a/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
+++ b/src/runtime_src/core/pcie/emulation/common_em/em_defines.h
@@ -167,6 +167,9 @@ namespace xclemulation {
     return xocl_bo_dev_only(bo) || xocl_bo_p2p(bo) ;
   }
 
+  static inline bool is_cacheable(const struct drm_xocl_bo *bo) {
+    return (bo->flags & XCL_BO_FLAGS_CACHEABLE);
+  }  
 }
 
 /**


### PR DESCRIPTION
In non Cacheable buffer scenario, ensure to use the mmap mechanism to share the memory across the process for sw_emu.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is an enhancement request for sw_emu as we are running the AIE designs in x86 mode. For sw_emu specifically we need to call the xrtSyncBO call when the host code written using XRT Native APIs where the buffers are non cacheable by fault. In non cacheable scenario, we do not require to call teh xrtSyncBO for hw/hw_emu targets, this is an extra requirement only for sw_emu, so to address this issue, we are going for mmap mechanism even when the buffer is non cacheable.

There are no alternate solution, 

No Risks

tested the opencl and xrt native apis host designs and ran the canary to ensure all the existing cases are un impacted

Nope. Now it is inline with the hw and hw_emu targets 
