### PR TITLE
CR-1113695 Added support for P2P buffer in XclCopyBO

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2815,7 +2815,6 @@ unsigned int HwEmShim::xclImportBO(int boGlobalHandle, unsigned flags)
   auto itr = mFdToFileNameMap.find(boGlobalHandle);
   if(itr != mFdToFileNameMap.end())
   {
-    const std::string& fileName = std::get<0>((*itr).second);
     int size = std::get<1>((*itr).second);
     unsigned boFlags = std::get<3>((*itr).second);
 
@@ -2828,11 +2827,6 @@ unsigned int HwEmShim::xclImportBO(int boGlobalHandle, unsigned flags)
     }
     mImportedBOs.insert(importedBo);
     bo->fd = boGlobalHandle;
-    bool ack;
-    xclImportBO_RPC_CALL(xclImportBO,fileName,bo->base,size);
-    PRINTENDFUNC;
-    if(!ack)
-      return -1;
     return importedBo;
   }
   PRINTENDFUNC;
@@ -2930,17 +2924,43 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
       return -1;
     }
   }
-  else if(dBO->fd >= 0){  //destination p2p buffer
-    int ack = false;
-    auto fItr = mFdToFileNameMap.find(dBO->fd);
-    if (fItr != mFdToFileNameMap.end()) {
-      const std::string& sFileName = std::get<0>((*fItr).second);
-      xclCopyBO_RPC_CALL(xclCopyBO, sBO->base, sFileName, size, src_offset, dst_offset);
+  else if((sBO->fd >=0) && (dBO->fd >= 0)) {  //Both source & destination P2P buffer
+    // CR-1113695 Copy data from source P2P to Dest P2P
+    unsigned char temp_buffer[size];
+    int bytes_read = read(sBO->fd, temp_buffer, size);
+    if (bytes_read) {
+      if (mLogStream.is_open())
+      {
+        mLogStream << __func__ << ", data read successfully from the src fd to local buffer." << std::endl;
+      }
     }
-    if (!ack)
+
+    int bytes_write = write(dBO->fd, temp_buffer, size);
+    if (bytes_write) {
+      if (mLogStream.is_open())
+      {
+        mLogStream << __func__ << ", data written successfully from local buffer to dest fd." << std::endl;
+      }
+    }
+
+  }
+  else if(dBO->fd >= 0){  //destination p2p buffer
+    // CR-1113695 Copy data from temp buffer to exported fd
+    unsigned char temp_buffer[size];
+    if (xclCopyBufferDevice2Host((void*)temp_buffer, sBO->base, size, src_offset, sBO->topology) != size) {
+      std::cerr << "ERROR: copy buffer from device to host failed " << std::endl;
       return -1;
+    }
+    int bytes_write = write(dBO->fd, temp_buffer, size);
+
+    if (bytes_write) {
+      if (mLogStream.is_open())
+      {
+        mLogStream << __func__ << ", data written successfully from local buffer to dest fd." << std::endl;
+      }
+    }
   } 
-  else if (sBO->fd >= 0) {
+  else if (sBO->fd >= 0) {  //source p2p buffer
     // CR-1112934 Copy data from exported fd to temp buffer using read API
     unsigned char temp_buffer[size];
     int bytes_read = read(sBO->fd, temp_buffer, size);


### PR DESCRIPTION
P2P support for Destination P2P and source Non-P2P is enabled in the xclCopyBO

This is a legacy issue which was caught as part of the CR-1113695

There is no workaround for the solution

There is no risk

We have run the Canary suite and also verified various combination testcases of P2P manually

No impact on Documentation
