### PR TITLE
CR-1119741: Fix for XRT error due to trying to open device with same device handle

### DIFF
--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -45,8 +45,10 @@ HalDevice::HalDevice(void* halDeviceHandle)
 
 HalDevice::~HalDevice()
 {
-  xrtDeviceClose(mXrtDeviceHandle);
-  mXrtDeviceHandle = nullptr;
+  if (mXrtDeviceHandle) {
+    xrtDeviceClose(mXrtDeviceHandle);
+    mXrtDeviceHandle = nullptr;
+  }
 }
 
 std::string HalDevice::getDebugIPlayoutPath()

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -39,10 +39,15 @@ namespace xdp {
 HalDevice::HalDevice(void* halDeviceHandle)
           : Device(),
             mHalDevice(halDeviceHandle)
-{}
+{
+  mXrtDeviceHandle = xrtDeviceOpenFromXcl(mHalDevice);
+}
 
 HalDevice::~HalDevice()
-{}
+{
+  xrtDeviceClose(mXrtDeviceHandle);
+  mXrtDeviceHandle = nullptr;
+}
 
 std::string HalDevice::getDebugIPlayoutPath()
 {
@@ -125,7 +130,7 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
     return xclBufHandles.size();
   }
 
-  xrtBufferHandle boHandle = xrtBOAlloc(xrtDeviceOpenFromXcl(mHalDevice), size, flags, memoryIndex);
+  xrtBufferHandle boHandle = xrtBOAlloc(mXrtDeviceHandle, size, flags, memoryIndex);
   if(nullptr == boHandle) {
     throw std::bad_alloc();
   }

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -38,6 +38,7 @@ namespace xdp {
 class HalDevice : public xdp::Device
 {
   xclDeviceHandle mHalDevice;
+  xrtDeviceHandle mXrtDeviceHandle;
   std::vector<void*>  mMappedBO;
   std::vector<xrtBufferHandle> xrtBufHandles;
   std::vector<xclBufferHandle> xclBufHandles;


### PR DESCRIPTION
When XDP flow changed to using HALDevice by default, designs with multiple TS2MMs for multiple SLR enabled for device_trace started failing with the following error 
[XRT] ERROR: Handle is already in use: Invalid argument
[XRT] ERROR: No such handle: Invalid argument
[XRT] ERROR: std::bad_alloc
[XRT] ERROR: failed to load xclbin: Invalid argument
This was due to calling xrtDeviceOpenFromXcl multiple times with the same xclDeviceHandle while allocating buffer objects (handles) for each TS2MM.
This is now fixed in current PR.