### PR TITLE
CR-1119552 M2M test no longer prints out BW measurements

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1295,7 +1295,8 @@ static void
 pretty_print_test_desc(const boost::property_tree::ptree& test, int& test_idx,
                        std::ostream & _ostream, const std::string& bdf)
 {
-  if (test.get<std::string>("status", "").compare(test_token_skipped)) {
+  auto _status = test.get<std::string>("status", "");
+  if (!boost::iequals(_status, test_token_skipped)) {
     std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);
     // Only use the long name option when displaying the test
     _ostream << boost::format("%-26s: %s \n") % test_desc % test.get<std::string>("name", "<unknown>");
@@ -1328,7 +1329,7 @@ pretty_print_test_run(const boost::property_tree::ptree& test,
   // if not supported: verbose
   auto redirect_log = [&](std::string tag, std::string log_str) {
     std::vector<std::string> verbose_tags = {"Xclbin", "Testcase"};
-    if((_status.compare(test_token_skipped)) || (std::find(verbose_tags.begin(), verbose_tags.end(), tag) != verbose_tags.end())) {
+    if(boost::iequals(_status, test_token_skipped) || (std::find(verbose_tags.begin(), verbose_tags.end(), tag) != verbose_tags.end())) {
       if(XBU::getVerbose())
         XBU::message(log_str, false, _ostream);
       else

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1295,6 +1295,7 @@ static void
 pretty_print_test_desc(const boost::property_tree::ptree& test, int& test_idx,
                        std::ostream & _ostream, const std::string& bdf)
 {
+  // If the status is anything other than skipped print the test name
   auto _status = test.get<std::string>("status", "");
   if (!boost::iequals(_status, test_token_skipped)) {
     std::string test_desc = boost::str(boost::format("Test %d [%s]") % ++test_idx % bdf);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1119552
xbutil validation tests such as M2M and other tests were not printing out the desired test information.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fixed the tests xbutil validation tests not printing the correct data. Introduced by #6060 (which is me 👎 ), found by Eamon Connolly through usage of the tests.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Bug was in the comparison conditions in the pretty print functions. Changed .compare to use boost::iequal function so that is it cleaner.

#### What has been tested and how, request additional testing if necessary
Manual testing with a single memory region u250 card. More testing would be great on a multiple memory bank u250 card to verify everything works.
