### PR TITLE
hwmon_sdm: minor fix for compile time warning

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -91,7 +91,7 @@ static int hwmon_sysfs_create(struct xocl_hwmon_sdm * sdm,
 	int err = 0;
 	iter->dev_attr.attr.name = (char*)devm_kzalloc(&sdm->pdev->dev,
                                 sizeof(char) * strlen(sysfs_name), GFP_KERNEL);
-	strcpy(iter->dev_attr.attr.name, sysfs_name);
+	strcpy((char*)iter->dev_attr.attr.name, sysfs_name);
 	iter->dev_attr.attr.mode = S_IRUGO;
 	iter->dev_attr.show = hwmon_sensor_show;
 	iter->index = repo_id | (field_id << 4) | (buf_index << 8) | (len << 20);


### PR DESCRIPTION
This PR fixes below warning:
>>>
$XRT/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/../subdev/hwmon_sdm.c:94:28: warning: passing argument 1 of 'strcpy' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   94 |  strcpy(iter->dev_attr.attr.name, sysfs_name);
      |         ~~~~~~~~~~~~~~~~~~~^~~~~
./include/linux/string.h:482:37: note: expected 'char *' but argument is of type 'const char *'
  482 | __FORTIFY_INLINE char *strcpy(char *p, const char *q)
>>>

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
