### PR TITLE
Add CU info to dynamic-regions c++ API

### DIFF
--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -182,7 +182,7 @@ get_info(const xrt_core::device* device, xrt::info::device param, const xrt::det
   case xrt::info::device::pcie_info : // std::string
     return json_str(xrt_core::platform::pcie_info(device), abi);
   case xrt::info::device::dynamic_regions : // std::string
-    return json_str(xrt_core::memory::xclbin_info(device), abi);
+    return json_str(xrt_core::memory::dynamic_regions(device), abi);
   case xrt::info::device::aie : // std::string
     return json_str(xrt_core::aie::aie_core(device), abi);
   case xrt::info::device::aie_shim : // std::string

--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -17,6 +17,8 @@
 #include "info_memory.h"
 #include "query_requests.h"
 #include "xclbin.h"
+#include "ps_kernel.h"
+#include "utils.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -408,6 +410,188 @@ xclbin_info(const xrt_core::device * device)
     pt.put("error_msg", ex.what());
   }
 
+  return pt;
+}
+
+enum class cu_type {
+  PL,
+  PS
+};
+
+static std::string 
+enum_to_str(cu_type type) {
+  switch(type) {
+    case cu_type::PL:
+      return "PL";
+    case cu_type::PS:
+      return "PS";
+    default:
+      break;
+  }
+  return "UNKNOWN";
+}
+
+boost::property_tree::ptree
+get_cu_status(uint32_t cu_status)
+{
+  boost::property_tree::ptree pt;
+  std::vector<std::string> bit_set;
+  if (cu_status & 0x1)
+    bit_set.push_back("START");
+  if (cu_status & 0x2)
+    bit_set.push_back("DONE");
+  if (cu_status & 0x4)
+    bit_set.push_back("IDLE");
+  if (cu_status & 0x8)
+    bit_set.push_back("READY");
+  if (cu_status & 0x10)
+    bit_set.push_back("RESTART");
+
+  pt.put("bit_mask",	boost::str(boost::format("0x%x") % cu_status));
+  boost::property_tree::ptree ptSt_arr;
+  for(auto& str : bit_set)
+    ptSt_arr.push_back(std::make_pair("", boost::property_tree::ptree(str)));
+
+  if (!ptSt_arr.empty())
+    pt.add_child( std::string("bits_set"), ptSt_arr);
+
+  return pt;
+}
+
+static void
+schedulerUpdateStat(xrt_core::device *device)
+{
+  try {
+    // lock xclbin
+    std::string xclbin_uuid = xrt_core::device_query<xq::xclbin_uuid>(device);
+    // dont open a context if xclbin_uuid is empty
+    if(xclbin_uuid.empty())
+	    return;
+    auto uuid = xrt::uuid(xclbin_uuid);
+    device->open_context(uuid.get(), std::numeric_limits<unsigned int>::max(), true);
+    auto at_exit = [] (auto device, auto uuid) { device->close_context(uuid.get(), std::numeric_limits<unsigned int>::max()); };
+    xrt_core::scope_guard<std::function<void()>> g(std::bind(at_exit, device, uuid));
+
+    device->update_scheduler_status();
+  }
+  catch (const std::exception&) {
+    // xclbin_lock failed, safe to ignore
+  }
+}
+
+int 
+getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
+{
+  try {
+    std::vector<char> buf = xrt_core::device_query<xq::ps_kernel>(device);
+    if (buf.empty())
+      return 0;
+    const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
+    if(map->pkn_count < 0)
+      return -EINVAL;
+
+    for (unsigned int i = 0; i < map->pkn_count; i++)
+      psKernels.emplace_back(map->pkn_data[i]);
+  }
+  catch (const xq::no_such_key&) {
+    // Ignoring if not available: Edge Case
+  }
+
+  return 0;
+}
+
+boost::property_tree::ptree
+populate_cus(const xrt_core::device *device)
+{
+  schedulerUpdateStat(const_cast<xrt_core::device *>(device));
+
+  boost::property_tree::ptree pt;
+  using cu_data_type = xq::kds_cu_info::data_type;
+  using scu_data_type = xq::kds_scu_info::data_type;
+  std::vector<cu_data_type> cu_stats;
+  std::vector<scu_data_type> scu_stats;
+  boost::property_tree::ptree ptree;
+  try {
+    std::string uuid = xrt::uuid(xrt_core::device_query<xq::xclbin_uuid>(device)).to_string();
+    boost::algorithm::to_upper(uuid);
+    ptree.put("xclbin_uuid", uuid);
+  } catch (xq::exception&) {  }
+
+  try {
+    cu_stats  = xrt_core::device_query<xq::kds_cu_info>(device);
+    scu_stats = xrt_core::device_query<xq::kds_scu_info>(device);
+  }
+  catch (const xq::no_such_key&) {
+    // Ignoring if not available: Edge Case
+  }
+  catch (const std::exception& ex) {
+    ptree.put("error_msg", ex.what());
+    return ptree;
+  }
+
+  for (auto& stat : cu_stats) {
+    boost::property_tree::ptree ptCu;
+    ptCu.put( "name",           stat.name);
+    ptCu.put( "base_address",   boost::str(boost::format("0x%x") % stat.base_addr));
+    ptCu.put( "usage",          stat.usages);
+    ptCu.put( "type", enum_to_str(cu_type::PL));
+    ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
+    pt.push_back(std::make_pair("", ptCu));
+  }
+
+  std::vector<ps_kernel_data> psKernels;
+  if (getPSKernels(psKernels, device) < 0) {
+    std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
+    return ptree;
+  }
+
+  uint32_t psk_inst = 0;
+  uint32_t num_scu = 0;
+  boost::property_tree::ptree pscu_list;
+  for (auto& stat : scu_stats) {
+    boost::property_tree::ptree ptCu;
+    std::string scu_name = "Illegal";
+    if (psk_inst >= psKernels.size()) {
+      scu_name = stat.name;
+      //This means something is wrong
+      //scu_name e.g. kernel_vcu_encoder:scu_34
+    } else {
+      scu_name = psKernels.at(psk_inst).pkd_sym_name;
+      scu_name.append("_");
+      scu_name.append(std::to_string(num_scu));
+      //scu_name e.g. kernel_vcu_encoder_2
+    }
+    ptCu.put( "name",           scu_name);
+    ptCu.put( "base_address",   "0x0");
+    ptCu.put( "usage",          stat.usages);
+    ptCu.put( "type", enum_to_str(cu_type::PS));
+    ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
+    pt.push_back(std::make_pair("", ptCu));
+
+    if (psk_inst >= psKernels.size()) {
+      continue;
+    }
+    num_scu++;
+    if (num_scu == psKernels.at(psk_inst).pkd_num_instances) {
+      //Handled all instances of a PS Kernel, so next is a new PS Kernel
+      num_scu = 0;
+      psk_inst++;
+    }
+  }
+
+  boost::property_tree::ptree pt_dynamic_regions;
+  pt_dynamic_regions = xclbin_info(device);
+  pt_dynamic_regions.add_child("compute_units", pt);
+  return pt_dynamic_regions;
+}
+
+boost::property_tree::ptree
+dynamic_regions(const xrt_core::device * device)
+{
+  ptree_type pt;
+  boost::property_tree::ptree pt_dynamic_region;
+  pt_dynamic_region.push_back(std::make_pair("", populate_cus(device)));
+  pt.add_child("dynamic_regions", pt_dynamic_region);
   return pt;
 }
 

--- a/src/runtime_src/core/common/info_memory.h
+++ b/src/runtime_src/core/common/info_memory.h
@@ -28,7 +28,7 @@ boost::property_tree::ptree
 memory_topology(const xrt_core::device * device);
 
 boost::property_tree::ptree
-xclbin_info(const xrt_core::device * device);
+dynamic_regions(const xrt_core::device * device);
 
 }} // memory, xrt
 

--- a/src/runtime_src/core/common/info_memory.h
+++ b/src/runtime_src/core/common/info_memory.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -21,188 +21,11 @@
 #include "core/common/query_requests.h"
 #include "core/common/device.h"
 #include "core/common/utils.h"
-#include "ps_kernel.h"
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
 
 namespace qr = xrt_core::query;
-
-enum class cu_type {
-  PL,
-  PS
-};
-
-static std::string 
-enum_to_str(cu_type type) {
-  switch(type) {
-    case cu_type::PL:
-      return "PL";
-    case cu_type::PS:
-      return "PS";
-    default:
-      break;
-  }
-  return "UNLNOWN";
-}
-
-boost::property_tree::ptree
-get_cu_status(uint32_t cu_status)
-{
-  boost::property_tree::ptree pt;
-  std::vector<std::string> bit_set;
-
-  if (cu_status & 0x1)
-    bit_set.push_back("START");
-  if (cu_status & 0x2)
-    bit_set.push_back("DONE");
-  if (cu_status & 0x4)
-    bit_set.push_back("IDLE");
-  if (cu_status & 0x8)
-    bit_set.push_back("READY");
-  if (cu_status & 0x10)
-    bit_set.push_back("RESTART");
-
-  pt.put("bit_mask",	boost::str(boost::format("0x%x") % cu_status));
-  boost::property_tree::ptree ptSt_arr;
-  for(auto& str : bit_set)
-    ptSt_arr.push_back(std::make_pair("", boost::property_tree::ptree(str)));
-
-  if (!ptSt_arr.empty())
-    pt.add_child( std::string("bits_set"), ptSt_arr);
-
-  return pt;
-}
-
-static void
-schedulerUpdateStat(xrt_core::device *device)
-{
-  try {
-    // lock xclbin
-    std::string xclbin_uuid = xrt_core::device_query<xrt_core::query::xclbin_uuid>(device);
-    // dont open a context if xclbin_uuid is empty
-    if(xclbin_uuid.empty())
-	    return;
-    auto uuid = xrt::uuid(xclbin_uuid);
-    device->open_context(uuid.get(), std::numeric_limits<unsigned int>::max(), true);
-    auto at_exit = [] (auto device, auto uuid) { device->close_context(uuid.get(), std::numeric_limits<unsigned int>::max()); };
-    xrt_core::scope_guard<std::function<void()>> g(std::bind(at_exit, device, uuid));
-
-    device->update_scheduler_status();
-  }
-  catch (const std::exception&) {
-    // xclbin_lock failed, safe to ignore
-  }
-}
-
-int 
-getPSKernels(std::vector<ps_kernel_data> &psKernels, const xrt_core::device *device)
-{
-  try {
-    std::vector<char> buf = xrt_core::device_query<xrt_core::query::ps_kernel>(device);
-    if (buf.empty())
-      return 0;
-    const ps_kernel_node *map = reinterpret_cast<ps_kernel_node *>(buf.data());
-    if(map->pkn_count < 0)
-      return -EINVAL;
-
-    for (unsigned int i = 0; i < map->pkn_count; i++)
-      psKernels.emplace_back(map->pkn_data[i]);
-  }
-  catch (const xrt_core::query::no_such_key&) {
-    // Ignoring if not available: Edge Case
-  }
-
-  return 0;
-}
-
-boost::property_tree::ptree
-populate_cus(const xrt_core::device *device)
-{
-  schedulerUpdateStat(const_cast<xrt_core::device *>(device));
-
-  boost::property_tree::ptree pt;
-  using cu_data_type = qr::kds_cu_info::data_type;
-  using scu_data_type = qr::kds_scu_info::data_type;
-  std::vector<cu_data_type> cu_stats;
-  std::vector<scu_data_type> scu_stats;
-  boost::property_tree::ptree ptree;
-  try {
-    std::string uuid = xrt::uuid(xrt_core::device_query<xrt_core::query::xclbin_uuid>(device)).to_string();
-    boost::algorithm::to_upper(uuid);
-    ptree.put("xclbin_uuid", uuid);
-  } catch (...) {  }
-
-  try {
-    cu_stats  = xrt_core::device_query<qr::kds_cu_info>(device);
-    scu_stats = xrt_core::device_query<qr::kds_scu_info>(device);
-  }
-  catch (const xrt_core::query::no_such_key&) {
-    // Ignoring if not available: Edge Case
-  }
-  catch (const std::exception& ex) {
-    ptree.put("error_msg", ex.what());
-    return ptree;
-  }
-
-  for (auto& stat : cu_stats) {
-    boost::property_tree::ptree ptCu;
-    ptCu.put( "name",           stat.name);
-    ptCu.put( "base_address",   boost::str(boost::format("0x%x") % stat.base_addr));
-    ptCu.put( "usage",          stat.usages);
-    ptCu.put( "type", enum_to_str(cu_type::PL));
-    ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
-    pt.push_back(std::make_pair("", ptCu));
-  }
-
-  std::vector<ps_kernel_data> psKernels;
-  if (getPSKernels(psKernels, device) < 0) {
-    std::cout << "WARNING: 'ps_kernel' invalid. Has the PS kernel been loaded? See 'xbutil program'.\n";
-    return ptree;
-  }
-
-  uint32_t psk_inst = 0;
-  uint32_t num_scu = 0;
-  boost::property_tree::ptree pscu_list;
-  for (auto& stat : scu_stats) {
-    boost::property_tree::ptree ptCu;
-    std::string scu_name = "Illegal";
-    if (psk_inst >= psKernels.size()) {
-      scu_name = stat.name;
-      //This means something is wrong
-      //scu_name e.g. kernel_vcu_encoder:scu_34
-    } else {
-      scu_name = psKernels.at(psk_inst).pkd_sym_name;
-      scu_name.append("_");
-      scu_name.append(std::to_string(num_scu));
-      //scu_name e.g. kernel_vcu_encoder_2
-    }
-    ptCu.put( "name",           scu_name);
-    ptCu.put( "base_address",   "0x0");
-    ptCu.put( "usage",          stat.usages);
-    ptCu.put( "type", enum_to_str(cu_type::PS));
-    ptCu.add_child( std::string("status"),	get_cu_status(stat.status));
-    pt.push_back(std::make_pair("", ptCu));
-
-    if (psk_inst >= psKernels.size()) {
-      continue;
-    }
-    num_scu++;
-    if (num_scu == psKernels.at(psk_inst).pkd_num_instances) {
-      //Handled all instances of a PS Kernel, so next is a new PS Kernel
-      num_scu = 0;
-      psk_inst++;
-    }
-  }
-
-  boost::property_tree::ptree pt_dynamic_regions;
-  xrt::device dev(device->get_device_id());
-  std::stringstream ss;
-  ss << dev.get_info<xrt::info::device::dynamic_regions>();
-  boost::property_tree::read_json(ss, pt_dynamic_regions);
-  pt_dynamic_regions.add_child("compute_units", pt);
-  return pt_dynamic_regions;
-}
 
 void
 ReportDynamicRegion::getPropertyTreeInternal(const xrt_core::device * _pDevice, 
@@ -217,10 +40,10 @@ void
 ReportDynamicRegion::getPropertyTree20202( const xrt_core::device * _pDevice, 
                                            boost::property_tree::ptree &_pt) const
 {
-  boost::property_tree::ptree pt_dynamic_region;
-  pt_dynamic_region.push_back(std::make_pair("", populate_cus(_pDevice)));
-  
-  _pt.add_child("dynamic_regions", pt_dynamic_region);
+  xrt::device device(_pDevice->get_device_id());
+  std::stringstream ss;
+  ss << device.get_info<xrt::info::device::dynamic_regions>();
+  boost::property_tree::read_json(ss, _pt);
 }
 
 void 

--- a/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
+++ b/src/runtime_src/core/tools/common/ReportDynamicRegion.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
C++ dynamics regions API only provided the xclbin info and not the rest of the CU related info. It was all being collected and parsed in ReportDynamicsRegion.cpp file

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This was discovered while working on xbtop which uses info::dynamic_regions API to get CU info

#### How problem was solved, alternative solutions (if any) and why they were rejected
Move code to the right location in info_memory.cpp

#### What has been tested and how, request additional testing if necessary
`xbutil exaine -d <bdf> --report dynamic-regions`

