### PR TITLE
CR-1117863 xbmgmt returns 0 even though one of the function failed

### DIFF
--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2021 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -69,7 +69,7 @@ Report::Report(const std::string & _reportName,
 }
 
 
-void 
+bool 
 Report::getFormattedReport( const xrt_core::device *pDevice, 
                             SchemaVersion schemaVersion,
                             const std::vector<std::string> & elementFilter,
@@ -101,6 +101,7 @@ Report::getFormattedReport( const xrt_core::device *pDevice,
     }
 
     std::cerr << "  ERROR: " << e.what() << std::endl;
-    throw xrt_core::error(std::errc::operation_canceled);
+    return false;
   }
+  return true;
 }

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -76,6 +76,7 @@ Report::getFormattedReport( const xrt_core::device *pDevice,
                             std::ostream & consoleStream,
                             boost::property_tree::ptree & pt) const
 {
+  // If an exception occurs while generating a report throw an error in the catch
   try {
     switch (schemaVersion) {
       case SchemaVersion::json_internal:
@@ -96,8 +97,10 @@ Report::getFormattedReport( const xrt_core::device *pDevice,
     std::string reportName = getReportName();
     if (!reportName.empty()) {
       reportName[0] = static_cast<char>(std::toupper(reportName[0]));
+      std::cerr << reportName << std::endl;
     }
 
-    throw std::runtime_error(boost::str(boost::format("Report: %s - %s\n\n") % reportName % e.what()));
+    std::cerr << "  ERROR: " << e.what() << std::endl;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 }

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -96,10 +96,8 @@ Report::getFormattedReport( const xrt_core::device *pDevice,
     std::string reportName = getReportName();
     if (!reportName.empty()) {
       reportName[0] = static_cast<char>(std::toupper(reportName[0]));
-      std::cerr << reportName << std::endl;
     }
 
-    std::cerr << "  ERROR: " << e.what() << std::endl << std::endl;
-    // Fall through
+    throw std::runtime_error(boost::str(boost::format("Report: %s - %s\n\n") % reportName % e.what()));
   }
 }

--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -69,7 +69,7 @@ Report::Report(const std::string & _reportName,
 }
 
 
-bool 
+void 
 Report::getFormattedReport( const xrt_core::device *pDevice, 
                             SchemaVersion schemaVersion,
                             const std::vector<std::string> & elementFilter,
@@ -101,7 +101,6 @@ Report::getFormattedReport( const xrt_core::device *pDevice,
     }
 
     std::cerr << "  ERROR: " << e.what() << std::endl;
-    return false;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
-  return true;
 }

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2021 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -57,7 +57,7 @@ class Report {
   const std::string & getShortDescription() const { return m_shortDescription; };
   bool isDeviceRequired() const { return m_isDeviceRequired; };
 
-  void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
+  bool getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 
  // Child methods that need to be implemented
  protected:

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -57,7 +57,7 @@ class Report {
   const std::string & getShortDescription() const { return m_shortDescription; };
   bool isDeviceRequired() const { return m_isDeviceRequired; };
 
-  bool getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
+  void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 
  // Child methods that need to be implemented
  protected:

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -664,8 +664,11 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       continue;
 
     boost::property_tree::ptree ptReport;
-    // AND the test status. If any of the reports had an exception the test status must show a failure
-    is_report_output_valid &= report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
+    try {
+      report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
+    } catch (const std::exception& e) {
+      is_report_output_valid = false;
+    }
 
     // Only support 1 node on the root
     if (ptReport.size() > 1)
@@ -745,9 +748,12 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         if((!is_mfg && !is_ready) && !is_recovery)
           continue;
         boost::property_tree::ptree ptReport;
-        // AND the test status with the previous results. If any of the previous reports or the below reports had an exception
-        // the test status must show a failure
-        is_report_output_valid &= report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
+        try {
+          report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
+        } catch (const std::exception& e) {
+          is_report_output_valid = false;
+        }
+        
 
         // Only support 1 node on the root
         if (ptReport.size() > 1)

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2021 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -655,6 +655,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
     ptRoot.add_child("schema_version", ptSchemaVersion);
   }
 
+  bool is_report_output_valid = true;
 
   // -- Process the reports that don't require a device
   boost::property_tree::ptree ptSystem;
@@ -663,7 +664,8 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       continue;
 
     boost::property_tree::ptree ptReport;
-    report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
+    // AND the test status. If any of the reports had an exception the test status must show a failure
+    is_report_output_valid &= report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
 
     // Only support 1 node on the root
     if (ptReport.size() > 1)
@@ -743,7 +745,9 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         if((!is_mfg && !is_ready) && !is_recovery)
           continue;
         boost::property_tree::ptree ptReport;
-        report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
+        // AND the test status with the previous results. If any of the previous reports or the below reports had an exception
+        // the test status must show a failure
+        is_report_output_valid &= report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
 
         // Only support 1 node on the root
         if (ptReport.size() > 1)
@@ -774,5 +778,9 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       // Do nothing
       break;
   }
+
+  // If any the data reports failed to generate with an exception throw an operation cancelled but output everything
+  if(!is_report_output_valid)
+    throw xrt_core::error(std::errc::operation_canceled);
 }
 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -666,7 +666,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
     boost::property_tree::ptree ptReport;
     try {
       report->getFormattedReport(nullptr, schemaVersion, elementFilter, consoleStream, ptReport);
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
       is_report_output_valid = false;
     }
 
@@ -750,7 +750,7 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         boost::property_tree::ptree ptReport;
         try {
           report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
-        } catch (const std::exception& e) {
+        } catch (const std::exception&) {
           is_report_output_valid = false;
         }
         


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1117863
Recently, https://github.com/Xilinx/XRT/pull/6064 cause the failure on the mgmt side.

Because of that issue xbmgmt examine -r all -d <bdf> failed to get the platform information.

However, the xbmgmt examine returns 0 return code instead of 1.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a throw in the report generation should any exceptions occur.

#### What has been tested and how, request additional testing if necessary
Tested by opening two terminals to the same machine, first invoking `xbutil reset -d [BDF]` to reset the device under test on one terminal and immediately invoking `xbmgmt examine -r all -d [BDF]` on the second terminal. The second terminal will show the device is not available and cause the issue found in the original report. Invoking `echo $?` on the second terminal will then printout the result (which is now 1 due to the changes)

First Terminal
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil reset -d 02:00
Performing 'HOT Reset' on
  -[0000:02:00.1]
Are you sure you wish to proceed? [Y/n]: Y
Successfully reset Device[0000:02:00.1]
```

Second Terminal
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ sudo ./xbmgmt2 examine -r all -d 02:00
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-92-generic
  Version              : #103-Ubuntu SMP Fri Nov 26 16:13:00 UTC 2021
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15696 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1117863
  Hash                 : 8ffc42c19a2c45475a250d6699c00a97d9f985bc
  Hash Date            : 2022-01-26 16:51:48
  XOCL                 : 2.13.0, 79d89e5c0c97b582c696453aae9ea7f414bca332
  XCLMGMT              : 2.13.0, 79d89e5c0c97b582c696453aae9ea7f414bca332

Devices present
  [0000:02:00.0] : xilinx_u280_xdma_201920_3 mgmt(inst=512)


-----------------------------------------------
1/1 [0000:02:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : 21760394400G

Device properties
  Type                 : N/A
  Name                 : ALVEO U280 PQ
  Config Mode          : 7
  Max Power            : 225W

Flashable partitions running on FPGA
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820

Flashable partitions installed in system
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820


  Mac Address          : 01:02:03:04:05:06
                       : 01:02:03:04:05:07


XRT build version: 2.13.0
Build hash: 8ffc42c19a2c45475a250d6699c00a97d9f985bc
Build date: 2022-01-26 16:51:48
Git branch: CR-1117863
PID: 1080403
UID: 0
[Thu Jan 27 01:15:56 2022 GMT]
HOST: xsjpranjal01
EXE: /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2/xbmgmt2
[XRT] WARNING: dev_init failed: -6
[XRT] ERROR: No such device or address Device index 0
Mechanical
  ERROR: Could not open device with index '0'
Firewall
  Level 0 : 0x0 (GOOD)

Mailbox
  Total bytes received   : 571776 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 11
  Firewall trip          : 0
  Download xclbin kaddr  : 3
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 4454
  User probe             : 12
  Mgmt state             : 0
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0

CMC
  Status : 0x0 (GOOD)
  Runtime clock scaling feature :
    Supported : false
    Enabled : false
    Critical threshold (clock shutdown) limits:
      Power : 0 W
      Temperature : 0 C
    Throttling threshold limits:
      Power : 0 W
      Temperature : 0 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ echo $?
1
```