### PR TITLE
Try to free an invalid pointer

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -600,8 +600,11 @@ static void *ert_ctrl_setup_xgq(struct platform_device *pdev, int id, u64 offset
 	xx_info.xi_sq_prod_int = xocl_intc_get_csr_base(xdev) + CQ_STATUS_ADDR;
 	ec->ec_exgq[id] = xocl_xgq_init(&xx_info);
 	if (IS_ERR(ec->ec_exgq[id])) {
+		void *err_ret = ec->ec_exgq[id];
+
+		ec->ec_exgq[id] = NULL;
 		EC_ERR(ec, "Initial xocl XGQ failed");
-		return ec->ec_exgq[id];
+		return err_ret;
 	}
 
 done:


### PR DESCRIPTION
#### Problem solved by the commit
In ert_ctrl_xgq_fini, it will free ec->ec_exgq[i]. 

static void ert_ctrl_xgq_fini(struct ert_ctrl *ec)
{
...
		xocl_xgq_fini(ec->ec_exgq[i]); // it does kfree(ec->ec_exgq[i]);

However, ec->ec_exgq[i] could be an ERR_PTR. Under thecondition, xgq_fini will try to free an invalid pointer

static void *ert_ctrl_setup_xgq(struct platform_device *pdev, int id, u64 offset)
{
...
	ec->ec_exgq[id] = xocl_xgq_init(&xx_info);
	if (IS_ERR(ec->ec_exgq[id])) {

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6077
