### PR TITLE
Only process CU if configuration completed

### DIFF
--- a/src/runtime_src/ert/scheduler/sched.c
+++ b/src/runtime_src/ert/scheduler/sched.c
@@ -225,6 +225,7 @@ static value_type scratch_mode           = 0;
 
 static value_type flatten_queue          = 0;
 
+static value_type cfg_complete           = 0;
 
 static size_type cmd_queue_slot_size     = 0;
 
@@ -374,6 +375,8 @@ configure_mb(struct sched_cmd *cmd)
   num_cus = XGQ_NUM_CUS(features);
   int ret = 0;
 
+  cfg_complete = 0;
+
   if (num_cus > MAX_XGQ_CU)
     flatten_queue = 0x1;
   else
@@ -420,6 +423,9 @@ configure_mb_end(struct sched_cmd *cmd)
   int ret = setup_cu_queue();
 
   resp_cmd.rcode = ret;
+
+  if (!ret)
+  	cfg_complete = 1;
 
   xgq_ctrl_response(&ctrl_xgq, &resp_cmd, sizeof(struct xgq_com_queue_entry));
 
@@ -745,7 +751,7 @@ _scheduler_loop()
     reg_access_wait();
 #endif
     while(!process_ctrl_command());
-    if (!flatten_queue) {
+    if (cfg_complete) {
       for (slot_idx=0; slot_idx<num_cus; ++slot_idx) {
         while(!xgq_cu_process(&cu_xgqs[slot_idx])) {
           continue;


### PR DESCRIPTION
#### Problem solved by the commit
ERT may touch CU XGQ leftover before configure complete

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6115

#### What has been tested and how, request additional testing if necessary
Test suite passed board.unit, board.dsv_system_qor, board.dsv_rtl,board.dsv_obb

