### PR TITLE
CR-1119827: Fixing HW Emulation device trace offload

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -189,7 +189,10 @@ private:
     DeviceTraceLogger* deviceTraceLogger;
     std::function<void(bool)> m_read_trace;
 
-    bool fifo_full;
+    // When using a FIFO for offload, if the FIFO fills up, we cannot
+    //  read from it again (circular buffer in FIFO is not supported).
+    //  The fifo_full flag will keep track if we have seen the FIFO full.
+    bool fifo_full = false;
 
     uint64_t sleep_interval_ms;
     Ts2mmInfo ts2mm_info;


### PR DESCRIPTION
#### Problem solved by the commit
Hardware emulation runs were not offloading PL trace events, and empty device trace files were being generated.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The issue was tracked down to an uninitialized variable, which was keeping track of if we'd seen a full FIFO.  We can read from a FIFO multiple times, but if we ever see a full FIFO we prevent ourselves from reading again. Since hardware emulation uses an emulated FIFO, we would sometimes see no events being offloaded at all since the uninitialized variable would have a random value and block the first read.  This pull request initialized the guard variable to false and fixes the issue.
