### PR TITLE
CR-1097761: Fixing error condition cases when path to debug_ip_layout is too long

### DIFF
--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -95,6 +95,27 @@ public:
 
   bool valid() const { return m_valid; }
   ReturnValueType get() const { return m_value; }
+};
+
+template <>
+class operations_result<std::string>
+{
+  std::string m_value;
+  bool m_valid;
+
+public:
+  operations_result(std::string&& s)
+    : m_value(std::move(s))
+    , m_valid(true)
+  {}
+
+  operations_result()
+    : m_value("")
+    , m_valid(false)
+  {}
+
+  bool valid() const { return m_valid; }
+  std::string get() const { return m_value; }
 };
 
 template <>

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -546,11 +546,11 @@ public:
   getSysfsPath(const std::string& subdev, const std::string& entry)
   {
     if (!m_ops->mGetSysfsPath)
-      return hal::operations_result<std::string>();
+      return hal::operations_result<std::string>("");
     constexpr size_t max_path = 256;
     char path_buf[max_path];
     if (m_ops->mGetSysfsPath(m_handle, subdev.c_str(), entry.c_str(), path_buf, max_path)) {
-      return hal::operations_result<std::string>();
+      return hal::operations_result<std::string>("");
     }
     path_buf[max_path - 1] = '\0';
     std::string sysfs_path = std::string(path_buf);
@@ -561,11 +561,11 @@ public:
   getSubdevPath(const std::string& subdev, uint32_t idx)
   {
     if (!m_ops->mGetSubdevPath)
-      return hal::operations_result<std::string>();
+      return hal::operations_result<std::string>("");
     constexpr size_t max_path = 256;
     char path_buf[max_path];
     if (m_ops->mGetSubdevPath(m_handle, subdev.c_str(), idx, path_buf, max_path)) {
-      return hal::operations_result<std::string>();
+      return hal::operations_result<std::string>("");
     }
     path_buf[max_path - 1] = '\0';
     std::string path = std::string(path_buf);
@@ -576,12 +576,12 @@ public:
   getDebugIPlayoutPath()
   {
     if(!m_ops->mGetDebugIPlayoutPath)
-      return hal::operations_result<std::string>();
+      return hal::operations_result<std::string>("");
 
-    const size_t maxLen = 512;
+    constexpr size_t maxLen = 512;
     char path[maxLen];
     if(m_ops->mGetDebugIPlayoutPath(m_handle, path, maxLen)) {
-      return hal::operations_result<std::string>();
+      return hal::operations_result<std::string>("");
     }
     path[maxLen - 1] = '\0';
     std::string pathStr(path);


### PR DESCRIPTION
#### Problem solved by the commit
In hardware emulation, it was possible to enable profiling and throw "[XRT] ERROR: basic_string::_S_construct null not valid" if the run directory was located in a directory with length greater than 512 characters.  On Linux, profiling requires the path to the sysfs directory, the path to the device file, and the path to the debug_ip_layout file.

The locations differ based upon if we are running on hardware or hardware emulation, and the respective shims implement the functions that report the path.  Since the functions are in the different shims, the only way to call them is using the dynamically loaded and linked functions, only accessible via a C-interface.  This C-interface requires us to allocate a buffer before calling the function and passing in the buffer and a maximum size.  If the path is larger than the maximum size, then the shim functions return an error condition that we catch.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Since hardware emulation puts the device and debug_ip_layout file in the working directory, and that directory can have a path length greater than our maximum, we create a default hal::operations_result class to return the default.  The code originally had malformed code for strings which resulted in throwing the error when trying to construct a blank string.  The code has been changed to create this object correctly for strings, and an additional specialization of the class for strings has been created to prevent this from happening in the future.

On the profiling side, we catch this type of failure if the path returned is blank and do not initialize profiling in that case.