### PR TITLE
CR-1119829: Fixing issue where power profiling file names were misformed

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -93,7 +93,7 @@ namespace xdp {
         deviceNumbering[deviceName] = 0 ;
       }
       deviceName += "-" ;
-      deviceName += deviceNumbering[deviceName] ;
+      deviceName += std::to_string(deviceNumbering[deviceName]) ;
       deviceNumbering[deviceName]++ ;
 
       std::string outputFile = "power_profile_" + deviceName + ".csv" ; 


### PR DESCRIPTION
#### Problem solved by the commit
When power profiling was turned on, the files created had malformed names on CentOS machines.  The intended behavior was for the file name to be in the format of power_profile_<shell>-<unique device id>.csv but instead they were appearing without the <unique device id>.csv portion.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The bug was in how the file name was constructed, and the fix was to force the uint64_t for the unique device id to be translated to a string before being used to construct the file name.
