### PR TITLE
Report sensor data using sensor API

### DIFF
--- a/src/runtime_src/core/tools/common/ReportMechanical.cpp
+++ b/src/runtime_src/core/tools/common/ReportMechanical.cpp
@@ -20,9 +20,6 @@
 
 #include "core/common/sensor.h"
 
-// 3rd Party Library - Include Files
-#include <boost/property_tree/json_parser.hpp>
-
 void
 ReportMechanical::getPropertyTreeInternal( const xrt_core::device * _pDevice,
                                            boost::property_tree::ptree &_pt) const

--- a/src/runtime_src/core/tools/common/ReportMechanical.cpp
+++ b/src/runtime_src/core/tools/common/ReportMechanical.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2021 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,35 +18,31 @@
 // Local - Include Files
 #include "ReportMechanical.h"
 
+#include "core/common/sensor.h"
+
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
 
 void
-ReportMechanical::getPropertyTreeInternal( const xrt_core::device * _pDevice, 
-                                              boost::property_tree::ptree &_pt) const
+ReportMechanical::getPropertyTreeInternal( const xrt_core::device * _pDevice,
+                                           boost::property_tree::ptree &_pt) const
 {
-  // Defer to the 20202 format.  If we ever need to update JSON data, 
+  // Defer to the 20202 format.  If we ever need to update JSON data,
   // Then update this method to do so.
   getPropertyTree20202(_pDevice, _pt);
 }
 
-void 
-ReportMechanical::getPropertyTree20202( const xrt_core::device * _pDevice, 
-                                           boost::property_tree::ptree &_pt) const
+void
+ReportMechanical::getPropertyTree20202( const xrt_core::device * _pDevice,
+                                        boost::property_tree::ptree &_pt) const
 {
-  xrt::device device(_pDevice->get_device_id());
-  boost::property_tree::ptree pt_mechanical;
-  std::stringstream ss;
-  ss << device.get_info<xrt::info::device::mechanical>();
-  boost::property_tree::read_json(ss, pt_mechanical);
-
   // There can only be 1 root node
-  _pt.add_child("mechanical", pt_mechanical);
+  _pt.add_child("mechanical", xrt_core::sensor::read_mechanical(_pDevice));
 }
 
-void 
+void
 ReportMechanical::writeReport( const xrt_core::device* /*_pDevice*/,
-                               const boost::property_tree::ptree& _pt, 
+                               const boost::property_tree::ptree& _pt,
                                const std::vector<std::string>& /*_elementsFilter*/,
                                std::ostream & _output) const
 {
@@ -65,5 +61,5 @@ ReportMechanical::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << boost::format("      %-22s: %s C\n") % "Critical Trigger Temp" % pt_fan.get<std::string>("critical_trigger_temp_C");
     _output << boost::format("      %-22s: %s RPM\n") % "Speed" % pt_fan.get<std::string>("speed_rpm");
   }
-  _output << std::endl; 
+  _output << std::endl;
 }


### PR DESCRIPTION
#### Problem solved by the commit
Fix code to not go via xrt::device::get_info(), which is an end-user API, not a tool API.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Report function is called with a mgmtpf device, which was incorrectly converted to
userpf device because the device id was reopened as an xrt::device object.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Core XRT (implies tools) should use xrt_core::device exclusively.   The core device is opened
explicitly as a mgmtpf device by xbmgmt thus all query calls operate on the mgmtpf device 
expected.   Also, it was wasteful to first convert ptree to string only to read the string back as a ptree, now the code stays with ptree.

#### Risks (if any) associated the changes in the commit
Can't think of any

#### What has been tested and how, request additional testing if necessary
Manual xbmgmt test before and after
