### PR TITLE
CR-1118968 Disable PDI reload on warm reboot

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1382,7 +1382,7 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	(void) xocl_subdev_create_by_level(lro, XOCL_SUBDEV_LEVEL_BLD);
 	(void) xocl_subdev_create_vsec_devs(lro);
 
-	(void) xocl_reinit_vmr(lro);
+	(void) xocl_download_apu_firmware(lro);
 
 	/*
 	 * For u30 whose reset relies on SC, and the cmc is running on ps, we

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -298,14 +298,10 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		lro->instance, ep_name,
 		PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
 
-	/*
-	 * reset multi-boot config for next boot.
-	 * This is needed to make sure next boot will be based on pre-loaded
-	 *    boot configuration.
-	 */
-	err = xocl_vmr_enable_multiboot(lro);
-	if (err && err != -ENODEV) {
-		mgmt_info(lro, "reset multi-boot config failed. err: %ld", err);
+	err = xocl_enable_vmr_boot(lro);
+	if (err) {
+		mgmt_err(lro, "enable reset failed");
+		err = -ENODEV;
 		goto failed;
 	}
 
@@ -389,7 +385,7 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	else if (!force)
 		xclmgmt_connect_notify(lro, true);
 
-	(void) xocl_reinit_vmr(lro);
+	(void) xocl_reload_vmr(lro);
 
 	return 0;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -828,6 +828,9 @@ static int xgq_log_page_fw(struct platform_device *pdev,
 			XGQ_ERR(xgq, "need to alloc %d for device data", 
 				fw_result->count);
 			ret = -ENOSPC;
+		} else if (fw_result->count == 0) {
+			XGQ_ERR(xgq, "fw size cannot be zero");
+			ret = -EINVAL;
 		} else {
 			*fw_size = fw_result->count;
 			*fw = vmalloc(*fw_size);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2359,7 +2359,8 @@ int xocl_xrt_version_check(xdev_handle_t xdev_hdl,
 int xocl_alloc_dev_minor(xdev_handle_t xdev_hdl);
 void xocl_free_dev_minor(xdev_handle_t xdev_hdl);
 
-void xocl_reinit_vmr(xdev_handle_t xdev_hdl);
+int xocl_enable_vmr_boot(xdev_handle_t xdev_hdl);
+void xocl_reload_vmr(xdev_handle_t xdev_hdl);
 
 struct resource *xocl_get_iores_byname(struct platform_device *pdev,
 				       char *name);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1920,14 +1920,14 @@ int xocl_enable_vmr_boot(xdev_handle_t xdev)
 	 */
 	err = xocl_vmr_enable_multiboot(xdev);
 	if (err && err != -ENODEV) {
-		xocl_xdev_warn(xdev, "config vmr multi-boot failed. err: %d. continue to reset.", err);
+		xocl_xdev_info(xdev, "config vmr multi-boot failed. err: %d. continue to reset.", err);
 	} 
 
 	/*
 	 * set reset signal 
 	 */
 	err = xocl_pmc_enable_reset(xdev);
-	if (err && err != ENODEV) {
+	if (err && err != -ENODEV) {
 		xocl_xdev_err(xdev, "config pmc reset register failed. err: %d", err);
 		return err;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix the warm reboot hung issue by only setting pmc registers during hot reset.
For the case where system is already hung, we continue to set the registers on the host, then issue a second bus reset. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1118968 Disable PDI reload on warm reboot

#### How problem was solved, alternative solutions (if any) and why they were rejected
There are multiple cases:
1) warm reboot, since we don't see the pmc register, no issue.
2) hot reset, we config vmr then set pmc register, no issue.
3) vmr hung, we config vmr and will fail(xgq service stopped), continue to set pmc register, no issue.
4) switch to B boot, we config vmr, then set pmc regiseter, as long as vmr is working, no issue.
   if vmr is not working, this is the same case as No.3. After system is back from 3, we repeat this step.

#### Risks (if any) associated the changes in the commit
should re-test hot reset 1000+ times and see how reliable of this new solution.

#### What has been tested and how, request additional testing if necessary
tested with latest shell

#### Documentation impact (if any)
