### PR TITLE
CR-1116717 ASTER TC 18.01 - xbutil dmatest: "ERROR: DMA failed: No such file or directory" when running test for 256MB

### DIFF
--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -85,8 +85,8 @@ namespace xcldev {
                 return future0.get();
             }
 
-            auto len = ((e - b) < count) ? 1 : (e - b)/count;
-            const auto ajust_e = b + len * count;
+            unsigned len = ((e - b) < count) ? 1 : (e - b)/count;
+            const auto ajust_e = b + len * std::min(count, len);
             std::vector<std::future<int>> threads;
             while (b < ajust_e) {
                 threads.push_back(std::async(std::launch::async, &DMARunner::runSyncWorker, this, b, b + len, dir));

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -77,7 +77,7 @@ namespace xcldev {
             return result;
         }
 
-        int runSync(xclBOSyncDirection dir, unsigned count) const {
+        int runSync(xclBOSyncDirection dir, unsigned int count) const {
             auto b = mBOList.begin();
             const auto e = mBOList.end();
             if (count == 1) {
@@ -85,7 +85,7 @@ namespace xcldev {
                 return future0.get();
             }
 
-            auto len = ((e - b) < count) ? 1 : (e - b)/count;
+            unsigned int len = ((e - b) < count) ? 1 : (e - b)/count;
             const auto ajust_e = b + len * std::min<unsigned int>(count, len);
             std::vector<std::future<int>> threads;
             while (b < ajust_e) {

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -85,8 +85,8 @@ namespace xcldev {
                 return future0.get();
             }
 
-            unsigned len = ((e - b) < count) ? 1 : (e - b)/count;
-            const auto ajust_e = b + len * std::min(count, len);
+            auto len = ((e - b) < count) ? 1 : (e - b)/count;
+            const auto ajust_e = b + len * std::min(count, (unsigned)len);
             std::vector<std::future<int>> threads;
             while (b < ajust_e) {
                 threads.push_back(std::async(std::launch::async, &DMARunner::runSyncWorker, this, b, b + len, dir));

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -85,7 +85,7 @@ namespace xcldev {
                 return future0.get();
             }
 
-            unsigned int len = ((e - b) < count) ? 1 : (e - b)/count;
+            unsigned int len = (((unsigned int)(e - b)) < count) ? 1 : ((unsigned int)(e - b))/count;
             const auto ajust_e = b + len * std::min<unsigned int>(count, len);
             std::vector<std::future<int>> threads;
             while (b < ajust_e) {

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -86,7 +86,7 @@ namespace xcldev {
             }
 
             auto len = ((e - b) < count) ? 1 : (e - b)/count;
-            const auto ajust_e = b + len * std::min(count, (unsigned)len);
+            const auto ajust_e = b + len * std::min<unsigned int>(count, len);
             std::vector<std::future<int>> threads;
             while (b < ajust_e) {
                 threads.push_back(std::async(std::launch::async, &DMARunner::runSyncWorker, this, b, b + len, dir));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The issue is calling xclSyncBo with non-exist BO handle. In this case, we have only one BO and two DMA threads, adjust_e will be b+2 which is not true and the number should be b+1 since we only have one BO, choose the smaller number between BO list size and DMA threads

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#4971

