### PR TITLE
Use xrt::bo in xdp::HalDevice

### DIFF
--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -40,20 +40,10 @@ HalDevice::HalDevice(void* halDeviceHandle)
           : Device(),
             mHalDevice(halDeviceHandle)
 {
-//  mXrtDeviceHandle = xrtDeviceOpenFromXcl(mHalDevice);
 }
 
 HalDevice::~HalDevice()
 {
-#if 0
-  if (mXrtDeviceHandle) {
-    xrtDeviceClose(mXrtDeviceHandle);
-    mXrtDeviceHandle = nullptr;
-  }
-  for(auto& e: xrt_bo) {
-    delete e;
-  }
-#endif
 }
 
 std::string HalDevice::getDebugIPlayoutPath()
@@ -137,23 +127,10 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
     return xclBufHandles.size();
   }
 
-//  xrt::bo *bobj = new xrt::bo(mHalDevice, size, flags, memoryIndex);
   auto bobj = xrt::bo(mHalDevice, size, flags, memoryIndex);
   xrt_bo.push_back(bobj);
   mMappedBO.push_back(bobj.map());
   return xrt_bo.size();
-
-#if 0
-  xrtBufferHandle boHandle = xrtBOAlloc(mXrtDeviceHandle, size, flags, memoryIndex);
-  if(nullptr == boHandle) {
-    throw std::bad_alloc();
-  }
-  xrtBufHandles.push_back(boHandle);
-
-  void* ptr = xrtBOMap(boHandle);
-  mMappedBO.push_back(ptr);
-  return xrtBufHandles.size();
-#endif
 }
 
 void HalDevice::free(size_t id)
@@ -165,9 +142,6 @@ void HalDevice::free(size_t id)
     xclFreeBO(mHalDevice, xclBufHandles[boIndex]);
     return;
   }
-
-  // nothing to do
-//  xrtBOFree(xrtBufHandles[boIndex]);
 }
 
 void* HalDevice::map(size_t id)
@@ -194,8 +168,6 @@ void HalDevice::sync(size_t id, size_t size, size_t offset, direction d, bool )
   }
 
   xrt_bo[boIndex].sync(dir, size, offset);
-//  xrt_bo[boIndex]->sync(dir, size, offset);
-//  xrtBOSync(xrtBufHandles[boIndex], dir, size, offset);
 }
 
 uint64_t HalDevice::getDeviceAddr(size_t id)
@@ -209,8 +181,6 @@ uint64_t HalDevice::getDeviceAddr(size_t id)
   }
 
   return xrt_bo[boIndex].address();
-//  return xrt_bo[boIndex]->address();
-//  return xrtBOAddress(xrtBufHandles[boIndex]);
 }
 
 double HalDevice::getMaxBwRead()

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -45,8 +45,10 @@ HalDevice::HalDevice(void* halDeviceHandle)
 
 HalDevice::~HalDevice()
 {
-  xrtDeviceClose(mXrtDeviceHandle);
-  mXrtDeviceHandle = nullptr;
+  if (mXrtDeviceHandle) {
+    xrtDeviceClose(mXrtDeviceHandle);
+    mXrtDeviceHandle = nullptr;
+  }
 }
 
 std::string HalDevice::getDebugIPlayoutPath()

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -39,10 +39,15 @@ namespace xdp {
 HalDevice::HalDevice(void* halDeviceHandle)
           : Device(),
             mHalDevice(halDeviceHandle)
-{}
+{
+  mXrtDeviceHandle = xrtDeviceOpenFromXcl(mHalDevice);
+}
 
 HalDevice::~HalDevice()
-{}
+{
+  xrtDeviceClose(mXrtDeviceHandle);
+  mXrtDeviceHandle = nullptr;
+}
 
 std::string HalDevice::getDebugIPlayoutPath()
 {
@@ -125,7 +130,7 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
     return xclBufHandles.size();
   }
 
-  xrtBufferHandle boHandle = xrtBOAlloc(xrtDeviceOpenFromXcl(mHalDevice), size, flags, memoryIndex);
+  xrtBufferHandle boHandle = xrtBOAlloc(mXrtDeviceHandle, size, flags, memoryIndex);
   if(nullptr == boHandle) {
     throw std::bad_alloc();
   }

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -40,15 +40,20 @@ HalDevice::HalDevice(void* halDeviceHandle)
           : Device(),
             mHalDevice(halDeviceHandle)
 {
-  mXrtDeviceHandle = xrtDeviceOpenFromXcl(mHalDevice);
+//  mXrtDeviceHandle = xrtDeviceOpenFromXcl(mHalDevice);
 }
 
 HalDevice::~HalDevice()
 {
+#if 0
   if (mXrtDeviceHandle) {
     xrtDeviceClose(mXrtDeviceHandle);
     mXrtDeviceHandle = nullptr;
   }
+  for(auto& e: xrt_bo) {
+    delete e;
+  }
+#endif
 }
 
 std::string HalDevice::getDebugIPlayoutPath()
@@ -132,6 +137,13 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
     return xclBufHandles.size();
   }
 
+//  xrt::bo *bobj = new xrt::bo(mHalDevice, size, flags, memoryIndex);
+  auto bobj = xrt::bo(mHalDevice, size, flags, memoryIndex);
+  xrt_bo.push_back(bobj);
+  mMappedBO.push_back(bobj.map());
+  return xrt_bo.size();
+
+#if 0
   xrtBufferHandle boHandle = xrtBOAlloc(mXrtDeviceHandle, size, flags, memoryIndex);
   if(nullptr == boHandle) {
     throw std::bad_alloc();
@@ -141,6 +153,7 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
   void* ptr = xrtBOMap(boHandle);
   mMappedBO.push_back(ptr);
   return xrtBufHandles.size();
+#endif
 }
 
 void HalDevice::free(size_t id)
@@ -153,7 +166,8 @@ void HalDevice::free(size_t id)
     return;
   }
 
-  xrtBOFree(xrtBufHandles[boIndex]);
+  // nothing to do
+//  xrtBOFree(xrtBufHandles[boIndex]);
 }
 
 void* HalDevice::map(size_t id)
@@ -179,7 +193,9 @@ void HalDevice::sync(size_t id, size_t size, size_t offset, direction d, bool )
     return;
   }
 
-  xrtBOSync(xrtBufHandles[boIndex], dir, size, offset);
+  xrt_bo[boIndex].sync(dir, size, offset);
+//  xrt_bo[boIndex]->sync(dir, size, offset);
+//  xrtBOSync(xrtBufHandles[boIndex], dir, size, offset);
 }
 
 uint64_t HalDevice::getDeviceAddr(size_t id)
@@ -192,7 +208,9 @@ uint64_t HalDevice::getDeviceAddr(size_t id)
     return (!xclGetBOProperties(mHalDevice, xclBufHandles[boIndex], &p)) ? p.paddr : ((uint64_t)-1);
   }
 
-  return xrtBOAddress(xrtBufHandles[boIndex]);
+  return xrt_bo[boIndex].address();
+//  return xrt_bo[boIndex]->address();
+//  return xrtBOAddress(xrtBufHandles[boIndex]);
 }
 
 double HalDevice::getMaxBwRead()

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -128,9 +128,9 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
   }
 
   auto bobj = xrt::bo(mHalDevice, size, flags, memoryIndex);
-  xrt_bo.push_back(bobj);
+  xrt_bos.push_back(bobj);
   mMappedBO.push_back(bobj.map());
-  return xrt_bo.size();
+  return xrt_bos.size();
 }
 
 void HalDevice::free(size_t id)
@@ -148,7 +148,8 @@ void* HalDevice::map(size_t id)
 {
   if(!id) return nullptr;
   size_t boIndex = id - 1;
-  return mMappedBO[boIndex];
+  return xrt_bos[boIndex].map();
+//  return mMappedBO[boIndex];
 }
 
 void HalDevice::unmap(size_t)
@@ -167,7 +168,7 @@ void HalDevice::sync(size_t id, size_t size, size_t offset, direction d, bool )
     return;
   }
 
-  xrt_bo[boIndex].sync(dir, size, offset);
+  xrt_bos[boIndex].sync(dir, size, offset);
 }
 
 uint64_t HalDevice::getDeviceAddr(size_t id)
@@ -180,7 +181,7 @@ uint64_t HalDevice::getDeviceAddr(size_t id)
     return (!xclGetBOProperties(mHalDevice, xclBufHandles[boIndex], &p)) ? p.paddr : ((uint64_t)-1);
   }
 
-  return xrt_bo[boIndex].address();
+  return xrt_bos[boIndex].address();
 }
 
 double HalDevice::getMaxBwRead()

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -115,17 +115,13 @@ size_t HalDevice::alloc(size_t size, uint64_t memoryIndex)
   uint64_t flags = memoryIndex;
   flags |= XCL_BO_FLAGS_CACHEABLE;
 
-  auto bobj = xrt::bo(mHalDevice, size, flags, memoryIndex);
-  xrt_bos.push_back(bobj);
-  mMappedBO.push_back(bobj.map());
+  xrt_bos.push_back(xrt::bo(mHalDevice, size, flags, memoryIndex));
   return xrt_bos.size();
 }
 
-void HalDevice::free(size_t id)
+void HalDevice::free(size_t)
 {
-//  if(!id) return;
-//  size_t boIndex = id - 1;
-
+  return;
 }
 
 void* HalDevice::map(size_t id)
@@ -133,7 +129,6 @@ void* HalDevice::map(size_t id)
   if(!id) return nullptr;
   size_t boIndex = id - 1;
   return xrt_bos[boIndex].map();
-//  return mMappedBO[boIndex];
 }
 
 void HalDevice::unmap(size_t)

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -28,9 +28,7 @@ namespace xdp {
 class HalDevice : public xdp::Device
 {
   xclDeviceHandle mHalDevice;
-  std::vector<void*>  mMappedBO;
   std::vector<xrt::bo> xrt_bos;
-  std::vector<xclBufferHandle> xclBufHandles;
 
 public:
   HalDevice(void* halDeviceHandle);

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -38,6 +38,7 @@ namespace xdp {
 class HalDevice : public xdp::Device
 {
   xclDeviceHandle mHalDevice;
+  xrtDeviceHandle mXrtDeviceHandle;
   std::vector<void*>  mMappedBO;
   std::vector<xrtBufferHandle> xrtBufHandles;
   std::vector<xclBufferHandle> xclBufHandles;

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -20,7 +20,6 @@
 
 #include<vector>
 #include "core/include/xrt.h"
-//#include "core/include/experimental/xrt_bo.h"
 #include "core/include/xrt/xrt_bo.h"
 #include "xdp/profile/device/xdp_base_device.h"
 
@@ -29,11 +28,8 @@ namespace xdp {
 class HalDevice : public xdp::Device
 {
   xclDeviceHandle mHalDevice;
-//  xrtDeviceHandle mXrtDeviceHandle;
   std::vector<void*>  mMappedBO;
-//  std::vector<xrtBufferHandle> xrtBufHandles;
-  std::vector<xrt::bo> xrt_bo;
-//  std::vector<xrt::bo*> xrt_bo;
+  std::vector<xrt::bo> xrt_bos;
   std::vector<xclBufferHandle> xclBufHandles;
 
 public:

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,29 +20,21 @@
 
 #include<vector>
 #include "core/include/xrt.h"
-#include "core/include/experimental/xrt_bo.h"
+//#include "core/include/experimental/xrt_bo.h"
+#include "core/include/xrt/xrt_bo.h"
 #include "xdp/profile/device/xdp_base_device.h"
 
 namespace xdp {
 
-#if 0
-  union BufferHandleStoreType {
-    std::vector<xrtBufferHandle> xrtBufHandles;
-    std::vector<xclBufferHandle> xclBufHandles;
-
-    BufferHandleStoreType() {}
-    ~BufferHandleStoreType() {}
-  };
-#endif
-
 class HalDevice : public xdp::Device
 {
   xclDeviceHandle mHalDevice;
-  xrtDeviceHandle mXrtDeviceHandle;
+//  xrtDeviceHandle mXrtDeviceHandle;
   std::vector<void*>  mMappedBO;
-  std::vector<xrtBufferHandle> xrtBufHandles;
+//  std::vector<xrtBufferHandle> xrtBufHandles;
+  std::vector<xrt::bo> xrt_bo;
+//  std::vector<xrt::bo*> xrt_bo;
   std::vector<xclBufferHandle> xclBufHandles;
-//  BufferHandleStoreType mBufHandleStore;
 
 public:
   HalDevice(void* halDeviceHandle);


### PR DESCRIPTION
Improves implementation of xdp::HalDevice by using reference counted xrt::bo s in place of C APIs. Also, xrt::bo s works well in both PCIe and Edge flows. So, use of xcl*BO APIs for Edge has been removed.