### PR TITLE
xclbinutil: Added new OVERLAY section

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2015-2021, Xilinx Inc
+ *  Copyright (C) 2015-2022, Xilinx Inc
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -172,6 +172,7 @@ extern "C" {
         ASK_GROUP_CONNECTIVITY = 27,
         SMARTNIC               = 28,
         AIE_RESOURCES          = 29,
+        OVERLAY                = 30,
     };
 
     enum MEM_TYPE {

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -124,6 +124,11 @@ if(NOT WIN32)
     set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel")
     xrt_add_test("ps-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel/PSKernel.py ${TEST_OPTIONS}")
 
+    # -- Binary Images
+    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages")
+    xrt_add_test("binary-images" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages/BinaryImages.py ${TEST_OPTIONS}")
+
+
     endif()
 endif()
 

--- a/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionOverlay.cxx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "SectionOverlay.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+// Static Variables / Classes
+SectionOverlay::_init SectionOverlay::_initializer;
+
+SectionOverlay::SectionOverlay() {
+  // Empty
+}
+
+SectionOverlay::~SectionOverlay() {
+  // Empty
+}
+
+
+

--- a/src/runtime_src/tools/xclbinutil/SectionOverlay.h
+++ b/src/runtime_src/tools/xclbinutil/SectionOverlay.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SectionOverlay_h_
+#define __SectionOverlay_h_
+
+// ----------------------- I N C L U D E S -----------------------------------
+
+// #includes here - please keep these to a bare minimum!
+#include "Section.h"
+#include <boost/functional/factory.hpp>
+
+// ------------ F O R W A R D - D E C L A R A T I O N S ----------------------
+// Forward declarations - use these instead whenever possible...
+
+// --------------- C L A S S :   S e c t i o n P D I -------------------------
+
+class SectionOverlay : public Section {
+ public:
+  SectionOverlay();
+  virtual ~SectionOverlay();
+
+ private:
+  // Static initializer helper class
+  static class _init {
+   public:
+    _init() { registerSectionCtor(OVERLAY, "OVERLAY", "", false, false, boost::factory<SectionOverlay*>()); }
+  } _initializer;
+};
+
+#endif

--- a/src/runtime_src/tools/xclbinutil/unittests/BinaryImages/BinaryImages.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/BinaryImages/BinaryImages.py
@@ -1,0 +1,130 @@
+import subprocess
+import os
+import argparse
+from argparse import RawDescriptionHelpFormatter
+import filecmp
+import json
+
+# Start of our unit test
+# -- main() -------------------------------------------------------------------
+#
+# The entry point to this script.
+#
+# Note: It is called at the end of this script so that the other functions
+#       and classes have been defined and the syntax validated
+def main():
+  # -- Configure the argument parser
+  parser = argparse.ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description='description:\n  Unit test wrapper for the various binary image sections')
+  parser.add_argument('--resource-dir', nargs='?', default=".", help='directory containing data to be used by this unit test')
+  args = parser.parse_args()
+
+  # Validate that the resource directory is valid
+  if not os.path.exists(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' does not exist")
+
+  if not os.path.isdir(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' is not a directory")
+
+  # Prepare for testing
+  xclbinutil = "xclbinutil"
+
+  # Start the tests
+  print ("Starting test")
+
+  # ---------------------------------------------------------------------------
+
+  step = "1) Test Read / Writting of the Binary OVERLAY section"
+
+  inputImage = os.path.join(args.resource_dir, "testimage.txt")
+  outputImage = "testimage_output.txt"
+
+  cmd = [xclbinutil, 
+         "--add-section", "OVERLAY:RAW:" + inputImage, 
+         "--dump-section", "OVERLAY:RAW:" + outputImage, 
+         "--force"]
+  execCmd(step, cmd)
+
+  # Validate that the round trip files are identical
+  binaryFileCompare(inputImage, outputImage)
+  # ---------------------------------------------------------------------------
+
+  # If the code gets this far, all is good.
+  return False
+
+def binaryFileCompare(file1, file2):
+    if not os.path.isfile(file1):
+      raise Exception("Error: The following json file does not exist: '" + file1 +"'")
+
+    if not os.path.isfile(file2):
+      raise Exception("Error: The following json file does not exist: '" + file2 +"'")
+
+    if filecmp.cmp(file1, file2) == False:
+        print ("\nFile1 : "+ file1)
+        print ("\nFile2 : "+ file2)
+
+        raise Exception("Error: The two files are not binary the same")
+
+def jsonFileCompare(file1, file2):
+  if not os.path.isfile(file1):
+    raise Exception("Error: The following json file does not exist: '" + file1 +"'")
+
+  with open(file1) as f:
+    data1 = json.dumps(json.load(f), indent=2)
+
+  if not os.path.isfile(file2):
+    raise Exception("Error: The following json file does not exist: '" + file2 +"'")
+
+  with open(file2) as f:
+    data2 = json.dumps(json.load(f), indent=2)
+
+  if data1 != data2:
+      # Print out the contents of file 1
+      print ("\nFile1 : "+ file1)
+      print ("vvvvv")
+      print (data1)
+      print ("^^^^^")
+
+      # Print out the contents of file 1
+      print ("\nFile2 : "+ file2)
+      print ("vvvvv")
+      print (data2)
+      print ("^^^^^")
+
+      raise Exception("Error: The two files are not the same")
+
+def testDivider():
+  print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+
+
+def execCmd(pretty_name, cmd):
+  testDivider()
+  print(pretty_name)
+  testDivider()
+  cmdLine = ' '.join(cmd)
+  print(cmdLine)
+  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  o, e = proc.communicate()
+  print(o.decode('ascii'))
+  print(e.decode('ascii'))
+  errorCode = proc.returncode
+
+  if errorCode != 0:
+    raise Exception("Operation failed with the return code: " + str(errorCode))
+
+# -- Start executing the script functions
+if __name__ == '__main__':
+  try:
+    if main() == True:
+      print ("\nError(s) occurred.")
+      print("Test Status: FAILED")
+      exit(1)
+  except Exception as error:
+    print(repr(error))
+    print("Test Status: FAILED")
+    exit(1)
+
+
+# If the code get this far then no errors occured
+print("Test Status: PASSED")
+exit(0)
+

--- a/src/runtime_src/tools/xclbinutil/unittests/BinaryImages/testimage.txt
+++ b/src/runtime_src/tools/xclbinutil/unittests/BinaryImages/testimage.txt
@@ -1,0 +1,1 @@
+This is a test image used to represent a binary image.


### PR DESCRIPTION
New Functionality
To better support KRIA (SOM) enablement, the KRIA runtime package for 2022.1 will be be based upon an XRT xclbin container.  That will contain:
1. A full bitstream (used to reprogram the fabric.
2. A device tree overlay to enable the Edge host to communicate with the fabric.
3. Existing runtime xclbin data (e.g., IP_LAYOUT, CONNECTIVITY, EMBEDDED_METADATA, etc)

With the exception of the overlay, there already exists sections and metadata that meet these requirements.   

This pull request adds device tree overlay section support.  This image will be used by the host code and presented to the edge OS to allow its drivers to communicate with the fabric's IPs/kernels.

#### Risks (if any) associated the changes in the commit
Low to none

#### What has been tested and how, request additional testing if necessary
1. Added new unit regression test for this OVERLAY buffer. 
2. Manual testing

#### Documentation impact (if any)
N/A
