### PR TITLE
CR-1119410 P2P fail since XRT 2.13.308

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -157,6 +157,7 @@ static int kds_polling_thread(void *data)
 	int loop_cnt = 0;
 	int cu_idx;
 
+	printk("kds polling thread is running\n");
 	while (!kds->polling_stop) {
 		busy_cnt = 0;
 		for (cu_idx = 0; cu_idx < num_cus; cu_idx++) {
@@ -182,6 +183,7 @@ static int kds_polling_thread(void *data)
 
 		wait_event_interruptible(kds->wait_queue, kds_wake_up_poll(kds));
 	}
+	printk("kds polling thread is stopped\n");
 
 	return 0;
 }

--- a/src/runtime_src/core/pcie/driver/linux/include/xocl_xgq.h
+++ b/src/runtime_src/core/pcie/driver/linux/include/xocl_xgq.h
@@ -20,9 +20,12 @@
 struct xocl_xgq_info {
 	int			 xi_id;
 	u64			 xi_addr;
+	void __iomem		*xi_sq_prod;
 	void __iomem		*xi_sq_prod_int;
+	void __iomem		*xi_cq_prod;
 };
 
+ssize_t xocl_xgq_dump_info(void *xgq_handle, char *buf, int count);
 int xocl_xgq_set_command(void *xgq_handle, int id, u32 *cmd, size_t sz);
 void xocl_xgq_notify(void *xgq_handle);
 int xocl_xgq_get_response(void *xgq_handle, int id);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -279,6 +279,7 @@ enum {
 #define	XOCL_XGQ_VMR		"xgq_vmr"
 #define	XOCL_HWMON_SDM		"hwmon_sdm"
 #define XOCL_ERT_CTRL           "ert_ctrl"
+#define XOCL_ERT_CTRL_VERSAL    "ert_ctrl.versal"
 
 #define XOCL_DEVNAME(str)	str SUBDEV_SUFFIX
 
@@ -2916,6 +2917,7 @@ struct xocl_subdev_map {
 #define	XOCL_BOARD_VERSAL_USER_RAPTOR2					\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
+			XOCL_DSAFLAG_MB_SCHE_OFF |			\
 			XOCL_DSAFLAG_VERSAL,				\
 		.subdev_info = RES_USER_VERSAL_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
@@ -2924,6 +2926,7 @@ struct xocl_subdev_map {
 #define	XOCL_BOARD_VERSAL_USER_RAPTOR2_ES3				\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
+			XOCL_DSAFLAG_MB_SCHE_OFF |			\
 			XOCL_DSAFLAG_VERSAL_ES3 |			\
 			XOCL_DSAFLAG_VERSAL,				\
 		.subdev_info = RES_USER_VERSAL_VSEC,			\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -19,6 +19,7 @@
 #include "xgq_cmd_ert.h"
 #include "../xgq_xocl_plat.h"
 #include "xocl_xgq.h"
+#include "xrt_drv.h"
 
 #define	EC_ERR(ec, fmt, arg...)	\
 	xocl_err(&(ec)->ec_pdev->dev, fmt "\n", ##arg)
@@ -47,7 +48,20 @@
 
 #define CTRL_XGQ_SLOT_SIZE          512	
 
+/* XGQ IP offsets */
+#define XGQ_SQ_REG		0x0
+#define XGQ_CQ_REG		0x100
+
 static uint16_t	g_ctrl_xgq_cid;
+struct xocl_drv_private ert_ctrl_xgq_drv_priv;
+
+struct ert_ctrl_xgq_cu {
+	int			 ecxc_id;
+	resource_size_t		 ecxc_xgq_reg;
+	resource_size_t		 ecxc_xgq_range;
+
+	void __iomem		*ecxc_xgq_base;
+};
 
 struct ert_ctrl {
 	struct kds_ert		 ec_ert;
@@ -60,10 +74,11 @@ struct ert_ctrl {
 	struct xgq		 ec_ctrl_xgq;
 	struct mutex		 ec_xgq_lock;
 
+	struct ert_ctrl_xgq_cu	*ec_xgq_ips;
+	size_t			 ec_num_xgq_ips;
 	/* ERT XGQ instances for CU */
 	void			**ec_exgq;
 	uint32_t		 ec_exgq_capacity;
-
 
 	uint64_t		timestamp;
 	uint32_t		cq_read_single;
@@ -193,6 +208,24 @@ data_integrity_show(struct device *dev, struct device_attribute *attr, char *buf
 };
 static DEVICE_ATTR_RO(data_integrity);
 
+static ssize_t
+xgq_info_show(struct device *dev, struct device_attribute *attr, char *buf)
+{
+	struct ert_ctrl *ec = dev_get_drvdata(dev);
+	ssize_t sz = 0;
+	int i;
+
+	for (i = 0; i < ec->ec_exgq_capacity; i++) {
+		if (ec->ec_exgq[i] == NULL)
+			continue;
+
+		sz += xocl_xgq_dump_info(ec->ec_exgq[i], buf+sz, PAGE_SIZE - sz);
+	}
+
+	return sz;
+};
+static DEVICE_ATTR_RO(xgq_info);
+
 static struct attribute *ert_ctrl_attrs[] = {
 	&dev_attr_status.attr,
 	&dev_attr_mb_sleep.attr,
@@ -202,11 +235,57 @@ static struct attribute *ert_ctrl_attrs[] = {
 	&dev_attr_cu_read_cnt.attr,
 	&dev_attr_cu_write_cnt.attr,
 	&dev_attr_data_integrity.attr,
+	&dev_attr_xgq_info.attr,
+	NULL,
+};
+
+static ssize_t
+cq_bin_show(struct file *filp, struct kobject *kobj,
+	    struct bin_attribute *attr, char *buf,
+	    loff_t offset, size_t count)
+{
+	struct ert_ctrl *ec;
+	struct device *dev = container_of(kobj, struct device, kobj);
+	ssize_t nread = 0;
+	size_t size = 0;
+
+	ec = (struct ert_ctrl *)dev_get_drvdata(dev);
+	if (!ec || !ec->ec_cq_base)
+		return nread;
+
+	size = ec->ec_cq_range;
+	if (offset >= size)
+		goto done;
+
+	if (offset + count < size)
+		nread = count;
+	else
+		nread = size - offset;
+
+	xocl_memcpy_fromio(buf, ec->ec_cq_base + offset, nread);
+
+done:
+	return nread;
+}
+
+static struct bin_attribute cq_attr = {
+	.attr = {
+		.name ="cq_bin",
+		.mode = 0444
+	},
+	.read = cq_bin_show,
+	.write = NULL,
+	.size = 0
+};
+
+static struct bin_attribute *ert_ctrl_bin_attrs[] = {
+	&cq_attr,
 	NULL,
 };
 
 static const struct attribute_group ert_ctrl_attrgroup = {
 	.attrs = ert_ctrl_attrs,
+	.bin_attrs = ert_ctrl_bin_attrs,
 };
 
 static inline uint32_t ert_ctrl_read32(void __iomem *addr)
@@ -589,15 +668,28 @@ static void *ert_ctrl_setup_xgq(struct platform_device *pdev, int id, u64 offset
 			return ERR_PTR(ret);
 	}
 
+	/* If this XGQ is already setup, skip */
 	if (ec->ec_exgq[id])
 		goto done;
 
-	/* TODO: Need setup XGQ IP or setup in memory XGQ */
-
-	/* Setup in memory XGQ */
-	xx_info.xi_id = id;
-	xx_info.xi_addr = (u64)ec->ec_cq_base + offset;
-	xx_info.xi_sq_prod_int = xocl_intc_get_csr_base(xdev) + CQ_STATUS_ADDR;
+	if (ec->ec_xgq_ips) {
+		/* XGQ IP presented */
+		xx_info.xi_id = id;
+		xx_info.xi_addr = (u64)ec->ec_cq_base + offset;
+		/* No need to write to a specific register to trigger interrupt.
+		 * Write to SQ produce register will trigger interrupt.
+		 */
+		xx_info.xi_sq_prod_int = NULL;
+		xx_info.xi_sq_prod = ec->ec_xgq_ips[id].ecxc_xgq_base + XGQ_SQ_REG;
+		xx_info.xi_cq_prod = ec->ec_xgq_ips[id].ecxc_xgq_base + XGQ_CQ_REG;
+	} else {
+		/* Setup in memory XGQ */
+		xx_info.xi_id = id;
+		xx_info.xi_addr = (u64)ec->ec_cq_base + offset;
+		xx_info.xi_sq_prod_int = xocl_intc_get_csr_base(xdev) + CQ_STATUS_ADDR;
+		xx_info.xi_sq_prod = NULL;
+		xx_info.xi_cq_prod = NULL;
+	}
 	ec->ec_exgq[id] = xocl_xgq_init(&xx_info);
 	if (IS_ERR(ec->ec_exgq[id])) {
 		void *err_ret = ec->ec_exgq[id];
@@ -609,6 +701,90 @@ static void *ert_ctrl_setup_xgq(struct platform_device *pdev, int id, u64 offset
 
 done:
 	return ec->ec_exgq[id];
+}
+
+static int ert_ctrl_xgq_ip_init(struct platform_device *pdev)
+{
+	struct ert_ctrl	*ec = platform_get_drvdata(pdev);
+	struct resource *res = NULL;
+	int i = 0;
+
+	EC_DBG(ec, "XGQ IPs and Ring buffer model");
+	res = xocl_get_iores_byname(pdev, RESNAME_XGQ_USER_RING);
+	if (!res) {
+		EC_ERR(ec, "failed to get %s", RESNAME_XGQ_USER_RING);
+		return -EINVAL;
+	}
+	EC_INFO(ec, "Ring buffer %pR", res);
+
+	ec->ec_cq_range = res->end - res->start + 1;
+	ec->ec_cq_base = devm_ioremap_wc(&pdev->dev, res->start, ec->ec_cq_range);
+	if (!ec->ec_cq_base) {
+		EC_ERR(ec, "failed to map %s", RESNAME_XGQ_USER_RING);
+		return -ENOMEM;
+	}
+
+	/* Handle all of the XGQ IPs */
+	ec->ec_num_xgq_ips = xocl_count_iores_byname(pdev, RESNAME_XGQ_USER_SQ);
+	ec->ec_xgq_ips = devm_kzalloc(&pdev->dev, sizeof(struct ert_ctrl_xgq_cu) * ec->ec_num_xgq_ips, GFP_KERNEL);
+	if (!ec->ec_xgq_ips) {
+		EC_ERR(ec, "failed to allocate ec_xgq_ips");
+		return -ENOMEM;
+	}
+
+	for (i = 0; i < ec->ec_num_xgq_ips; i++) {
+		struct ert_ctrl_xgq_cu *xgq_ip;
+
+		xgq_ip = &ec->ec_xgq_ips[i];
+		res = xocl_get_iores_with_idx_byname(pdev, RESNAME_XGQ_USER_SQ, i);
+		if (!res) {
+			EC_ERR(ec, "failed to get %s", RESNAME_XGQ_USER_SQ);
+			return -EINVAL;
+		}
+		EC_INFO(ec, "XGQ IP %pR", res);
+
+		xgq_ip->ecxc_xgq_reg = res->start;
+		xgq_ip->ecxc_xgq_range = res->end - res->start + 1;
+		xgq_ip->ecxc_xgq_base = devm_ioremap(&pdev->dev, res->start, xgq_ip->ecxc_xgq_range);
+		if (!xgq_ip->ecxc_xgq_base)
+			return -ENOMEM;
+
+		/* TODO: remove this hack once XGQ IP has reset register */
+		iowrite32(0x1, xgq_ip->ecxc_xgq_base + 0xC);
+		iowrite32(0x0, xgq_ip->ecxc_xgq_base);
+	}
+
+	/* TODO: Should sort XGQ IP by address to make sure the indexing the
+	 * same as device side
+	 */
+
+	return 0;
+}
+
+static int ert_ctrl_cq_init(struct platform_device *pdev)
+{
+	struct ert_ctrl	*ec = platform_get_drvdata(pdev);
+	struct resource *res = NULL;
+
+	EC_DBG(ec, "CSR registers and Command Queue model");
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (!res) {
+		EC_ERR(ec, "failed to get memory resource");
+		return -EINVAL;
+	}
+	EC_INFO(ec, "CQ %pR", res);
+
+	ec->ec_cq_range = res->end - res->start + 1;
+	ec->ec_cq_base = devm_ioremap_wc(&pdev->dev, res->start, ec->ec_cq_range);
+	if (!ec->ec_cq_base) {
+		EC_ERR(ec, "failed to map CQ");
+		return -ENOMEM;
+	}
+
+	ec->ec_xgq_ips = NULL;
+	ec->ec_num_xgq_ips = 0;
+
+	return 0;
 }
 
 static int ert_ctrl_remove(struct platform_device *pdev)
@@ -625,9 +801,6 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 	if (ec->ec_connected)
 		ert_ctrl_disconnect(pdev);
 
-	if (ec->ec_cq_base)
-		iounmap(ec->ec_cq_base);
-
 	if (ec->ec_exgq)
 		kfree(ec->ec_exgq);
 
@@ -640,10 +813,10 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 
 static int ert_ctrl_probe(struct platform_device *pdev)
 {
+	const char *const devname = dev_name(&pdev->dev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	bool ert_on = xocl_ert_on(xdev);
 	struct ert_ctrl	*ec = NULL;
-	struct resource *res = NULL;
 	void *hdl = NULL;
 	int err = 0;
 
@@ -660,28 +833,19 @@ static int ert_ctrl_probe(struct platform_device *pdev)
 	ec->ec_pdev = pdev;
 	platform_set_drvdata(pdev, ec);
 
-	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
-	if (!res) {
-		EC_ERR(ec, "failed to get memory resource\n");
-		err = -EINVAL;
-		goto cq_init_failed;
-	}
-	EC_INFO(ec, "CQ %pR", res);
-
-	ec->ec_cq_range = res->end - res->start + 1;
-	ec->ec_cq_base = ioremap_wc(res->start, ec->ec_cq_range);
-	if (!ec->ec_cq_base) {
-		EC_ERR(ec, "failed to map CQ\n");
-		err = -ENOMEM;
-		goto cq_init_failed;
-	}
+	if (XOCL_GET_DRV_PRI(pdev) == &ert_ctrl_xgq_drv_priv)
+		err = ert_ctrl_xgq_ip_init(pdev);
+	else
+		err = ert_ctrl_cq_init(pdev);
+	if (err)
+		goto init_failed;
 
 	if (sysfs_create_group(&pdev->dev.kobj, &ert_ctrl_attrgroup))
 		EC_ERR(ec, "Not able to create sysfs group");
 
 	return 0;
 
-cq_init_failed:
+init_failed:
 	xocl_drvinst_release(ec, &hdl);
 	platform_set_drvdata(pdev, NULL);
 	xocl_drvinst_free(hdl);
@@ -695,12 +859,6 @@ static struct xocl_ert_ctrl_funcs ert_ctrl_ops = {
 	.is_version	= ert_ctrl_is_version,
 	.get_base	= ert_ctrl_get_base,
 	.setup_xgq	= ert_ctrl_setup_xgq,
-	/*
-	.attach_xgq	= ert_ctrl_attach_xgq,
-	.detach_xgq	= ert_ctrl_detach_xgq,
-	.produce_xgq	= ert_ctrl_produce_xgq,
-	.consume_xgq	= ert_ctrl_consume_xgq,
-	*/
 };
 
 struct xocl_drv_private ert_ctrl_drv_priv = {
@@ -710,8 +868,16 @@ struct xocl_drv_private ert_ctrl_drv_priv = {
 	.cdev_name	= NULL,
 };
 
+struct xocl_drv_private ert_ctrl_xgq_drv_priv = {
+	.ops		= &ert_ctrl_ops,
+	.fops		= NULL,
+	.dev		= -1,
+	.cdev_name	= NULL,
+};
+
 struct platform_device_id ert_ctrl_id_table[] = {
 	{ XOCL_DEVNAME(XOCL_ERT_CTRL), (kernel_ulong_t)&ert_ctrl_drv_priv },
+	{ XOCL_DEVNAME(XOCL_ERT_CTRL_VERSAL), (kernel_ulong_t)&ert_ctrl_xgq_drv_priv },
 	{},
 };
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1435,6 +1435,9 @@ xocl_kds_xgq_cfg_start(struct xocl_dev *xdev, struct drm_xocl_kds cfg, int num_c
 			   resp.hdr.cstate, resp.rcode);
 		return -EINVAL;
 	}
+
+	userpf_info(xdev, "Config start completed, num_cus(%d)\n",
+		    cfg_start->num_cus);
 	return 0;
 }
 
@@ -1476,6 +1479,7 @@ xocl_kds_xgq_cfg_end(struct xocl_dev *xdev)
 			   resp.hdr.cstate, resp.rcode);
 		return -EINVAL;
 	}
+	userpf_info(xdev, "Config end completed\n");
 	return 0;
 }
 
@@ -1551,6 +1555,7 @@ xocl_kds_xgq_cfg_cu(struct xocl_dev *xdev, struct xrt_cu_info *cu_info, int num_
 			ret = -EINVAL;
 			break;
 		}
+		userpf_info(xdev, "Config CU(%d) completed\n", cfg_cu->cu_idx);
 	}
 
 	return ret;
@@ -1596,6 +1601,10 @@ static int xocl_kds_xgq_query_cu(struct xocl_dev *xdev, u32 cu_idx,
 		return -EINVAL;
 	}
 
+	userpf_info(xdev, "Query CU(%d) completed\n", query_cu->cu_idx);
+	userpf_info(xdev, "xgq_id %d\n", resp->xgq_id);
+	userpf_info(xdev, "size %d\n", resp->size);
+	userpf_info(xdev, "offset 0x%x\n", resp->offset);
 	return 0;
 }
 
@@ -1651,15 +1660,17 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 	}
 	xocl_kds_create_cus(xdev, cu_info, num_cus);
 
-	XDEV(xdev)->kds.xgq_enable = true;
-	kfree(cu_info);
-	return 0;
+	XDEV(xdev)->kds.xgq_enable = (cfg.ert)? true : false;
+	goto out;
 
 create_regular_cu:
 	/* Regular CU directly talks to CU, without XGQ */
 	xocl_kds_create_cus(xdev, cu_info, num_cus);
 	XDEV(xdev)->kds.xgq_enable = false;
 
+out:
+	userpf_info(xdev, "scheduler config ert(%d)\n",
+		    XDEV(xdev)->kds.xgq_enable);
 	kfree(cu_info);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1025,7 +1025,7 @@ struct xocl_ps_funcs {
 	(PS_CB(xdev, check_healthy) ? PS_OPS(xdev)->check_healthy(PS_DEV(xdev)) : true)
 
 #define xocl_ps_sched_on(xdev)	\
-	(!xocl_mb_sched_on(xdev) && (XOCL_DSA_IS_VERSAL(xdev) || XOCL_DSA_IS_MPSOC(xdev)))
+	(!XOCL_DSA_MB_SCHE_OFF(xdev) && (XOCL_DSA_IS_VERSAL(xdev) || XOCL_DSA_IS_MPSOC(xdev)))
 
 /* dna callbacks */
 struct xocl_dna_funcs {
@@ -2362,6 +2362,9 @@ void xocl_free_dev_minor(xdev_handle_t xdev_hdl);
 int xocl_enable_vmr_boot(xdev_handle_t xdev_hdl);
 void xocl_reload_vmr(xdev_handle_t xdev_hdl);
 
+int xocl_count_iores_byname(struct platform_device *pdev, char *name);
+struct resource *xocl_get_iores_with_idx_byname(struct platform_device *pdev,
+				       char *name, int idx);
 struct resource *xocl_get_iores_byname(struct platform_device *pdev,
 				       char *name);
 int xocl_get_irq_byname(struct platform_device *pdev, char *name);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -440,11 +440,6 @@ static struct xocl_subdev_map subdev_map[] = {
 		.res_array = (struct xocl_subdev_res[]) {
 			{.res_name = NODE_ERT_CQ_USER, .regmap_name = PROP_ERT_CQ},
 			{.res_name = NODE_ERT_CQ_USER, .regmap_name = PROP_ERT_LEGACY},
-			{.res_name = NODE_XGQ_USR_SQ_00_BASE},
-			{.res_name = NODE_XGQ_USR_SQ_01_BASE},
-			{.res_name = NODE_XGQ_USR_SQ_02_BASE},
-			{.res_name = NODE_XGQ_USR_SQ_03_BASE},
-			{.res_name = NODE_XGQ_USR_RING_BASE},
 			{NULL},
 		},
 		.required_ip = 1,
@@ -452,7 +447,25 @@ static struct xocl_subdev_map subdev_map[] = {
 		.build_priv_data = ert_build_priv,
 		.devinfo_cb = NULL,
 		.max_level = XOCL_SUBDEV_LEVEL_PRP,
- 	},
+	},
+	{
+		/* Platform has XGQ IP, in this case, there is no CQ. */
+		.id = XOCL_SUBDEV_ERT_CTRL,
+		.dev_name = XOCL_ERT_CTRL_VERSAL,
+		.res_array = (struct xocl_subdev_res[]) {
+			{.res_name = NODE_XGQ_USR_RING_BASE},
+			{.res_name = NODE_XGQ_USR_SQ_00_BASE},
+			{.res_name = NODE_XGQ_USR_SQ_01_BASE},
+			{.res_name = NODE_XGQ_USR_SQ_02_BASE},
+			{.res_name = NODE_XGQ_USR_SQ_03_BASE},
+			{NULL},
+		},
+		.required_ip = 1,
+		.flags = XOCL_SUBDEV_MAP_USERPF_ONLY,
+		.build_priv_data = NULL,
+		.devinfo_cb = NULL,
+		.max_level = XOCL_SUBDEV_LEVEL_PRP,
+	},
 	{
 		.id = XOCL_SUBDEV_XVC_PUB,
 		.dev_name = XOCL_XVC_PUB,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.h
@@ -160,6 +160,8 @@
 #define RESNAME_INTC_CU_02	NODE_INTC_CU_02
 #define RESNAME_INTC_CU_03	NODE_INTC_CU_03
 #define RESNAME_ERT_CQ_USER    NODE_ERT_CQ_USER
+#define RESNAME_XGQ_USER_SQ	"ep_xgq_user_to_apu_sq_pi"
+#define RESNAME_XGQ_USER_RING	"ep_xgq_payload_user"
 
 #define ERT_SCHED_INTR_ALIAS_00	"interrupt_cu_bank_00"
 #define ERT_SCHED_INTR_ALIAS_01	"interrupt_cu_bank_01"

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xgq.c
@@ -39,6 +39,17 @@ struct xocl_xgq {
 	void __iomem		*xx_sq_prod_int;
 };
 
+ssize_t xocl_xgq_dump_info(void *xgq_handle, char *buf, int count)
+{
+	struct xocl_xgq *xgq = (struct xocl_xgq *)xgq_handle;
+	char *fmt = "id %d, addr 0x%llx\n";
+	ssize_t sz = 0;
+
+	sz = scnprintf(buf, count, fmt, xgq->xx_id, xgq->xx_addr);
+
+	return sz;
+}
+
 static inline void
 xocl_xgq_write_queue(u32 __iomem *dst, u32 *src, int words)
 {
@@ -157,10 +168,30 @@ void *xocl_xgq_init(struct xocl_xgq_info *info)
 	xgq->xx_sq_prod_int = info->xi_sq_prod_int;
 
 	spin_lock_init(&xgq->xx_lock);
-	ret = xgq_attach(&xgq->xx_xgq, 0, 0, (u64)xgq->xx_addr, 0, 0);
+	ret = xgq_attach(&xgq->xx_xgq, 0, 0, (u64)xgq->xx_addr,
+			 (u64)(uintptr_t)info->xi_sq_prod,
+			 (u64)(uintptr_t)info->xi_cq_prod);
 	if (ret)
 		return (ERR_PTR(-ENODEV));
 
+#if 0
+	printk("sq prod 0x%llx\n", (u64)(uintptr_t)info->xi_sq_prod);
+	printk("cq prod 0x%llx\n", (u64)(uintptr_t)info->xi_cq_prod);
+	printk("\n");
+	printk("xq_sq slot_num %d\n",      xgq->xx_xgq.xq_sq.xr_slot_num);
+	printk("xq_sq slot_sz  %d\n",      xgq->xx_xgq.xq_sq.xr_slot_sz);
+	printk("xq_sq produced %d\n",      xgq->xx_xgq.xq_sq.xr_produced);
+	printk("xq_sq consumed %d\n",      xgq->xx_xgq.xq_sq.xr_consumed);
+	printk("xq_sq produced 0x%llx\n",  xgq->xx_xgq.xq_sq.xr_produced_addr);
+	printk("xq_sq consumed 0x%llx\n",  xgq->xx_xgq.xq_sq.xr_consumed_addr);
+	printk("\n");
+	printk("xq_cq slot_num %d\n",      xgq->xx_xgq.xq_cq.xr_slot_num);
+	printk("xq_cq slot_sz  %d\n",      xgq->xx_xgq.xq_cq.xr_slot_sz);
+	printk("xq_cq produced %d\n",      xgq->xx_xgq.xq_cq.xr_produced);
+	printk("xq_cq consumed %d\n",      xgq->xx_xgq.xq_cq.xr_consumed);
+	printk("xq_cq produced 0x%llx\n",  xgq->xx_xgq.xq_cq.xr_produced_addr);
+	printk("xq_cq consumed 0x%llx\n",  xgq->xx_xgq.xq_cq.xr_consumed_addr);
+#endif
 	return xgq;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Fix CR-1119410
2. Add XGQ Versal support. But it doesn't work yet, XGQ IP fix and zocl update are needed. It will be separate PR.
3. Due to the limitation of 2), disabled XGQ ERT on Versal ES3.
4. Add CQ/Ring binary sysfs node in ctrl_ert for debug purpose

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6115 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Add COPYBO command support

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Test with u50 base 5 shell and Versal shell for run "xbutil validate".

#### Documentation impact (if any)
