### PR TITLE
CR-1120170 Fix for seg fault when connectivity section is missing in sw emu xclbin

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -754,21 +754,8 @@ class xclbin_full : public xclbin_impl
 
     m_uuid = uuid(m_top->m_header.uuid);
 
-    const ::ip_layout* ip_layout = nullptr;
     for (auto kind : kinds) {
       auto hdr = xrt_core::xclbin::get_axlf_section(m_top, kind);
-
-      // software emulation xclbin does not have all sections
-      // create the necessary ones.  important that ip_layout is
-      // before connectivity which needs ip_layout
-      if (!hdr && is_sw_emulation() && !xrt_core::config::get_feature_toggle("Runtime.vitis715")) {
-        auto data = xrt_core::xclbin::swemu::get_axlf_section(m_top, ip_layout, kind);
-        if (!data.empty()) {
-          auto pos = m_axlf_sections.emplace(kind, std::move(data));
-          if (kind == IP_LAYOUT)
-            ip_layout = reinterpret_cast<const ::ip_layout*>(pos->second.data());
-        }
-      }
 
       if (!hdr)
         continue;

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -69,13 +69,6 @@ static const std::array<axlf_section_kind, max_sections> kinds = {
 };
 
 XRT_CORE_UNUSED
-static bool
-is_sw_emulation()
-{
-  static auto xem = std::getenv("XCL_EMULATION_MODE");
-  static bool swem = xem ? std::strcmp(xem,"sw_emu")==0 : false;
-  return swem;
-}
 
 static std::vector<char>
 read_xclbin(const std::string& fnm)


### PR DESCRIPTION
#### Problem solved by the commit
Fix for seg fault when connectivity section is missing in sw emu xclbin

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
There are few cases where connectivity section is missing because all kernel args are scalars.  
This lead to a crash because there is no connectivity.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Since 2021.2 we have rtd getting generated for all software emulation xclbins, and we can 
now remove the xclbin_swemu.cpp code path that kicks in when connectivity section is missing.

#### Risks (if any) associated the changes in the commit
Removes sw emulation support for legacy xclbins that do not include runtime data.
Supposedly there should be none of these by now and if there is, the xclbins should be regenerated.

#### What has been tested and how, request additional testing if necessary
Canary run and the results are good.