### PR TITLE
VITIS-2540 Autorestart feature support for SW_EMU

### DIFF
--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -261,7 +261,7 @@ has_reg_read_write()
 #ifdef _WIN32
   return false;
 #else
-  return !is_sw_emulation();
+  return true;
 #endif
 }
 

--- a/src/runtime_src/core/include/xcl_api_macros.h
+++ b/src/runtime_src/core/include/xcl_api_macros.h
@@ -238,6 +238,29 @@ mtx.unlock();
     FREE_BUFFERS(); \
     xclWriteAddrKernelCtrl_RETURN();
 
+//--------------------xclRegWrite--------------------------------
+//Generate call and info message
+#define xclRegWrite_SET_PROTOMESSAGE(func_name,baseaddress,offset,data,pf_id,bar_id) \
+    c_msg.set_baseaddress(baseaddress); \
+    c_msg.set_offset(offset); \
+    c_msg.set_data((char*) data, 4); \
+    c_msg.set_pf_id(pf_id); \
+    c_msg.set_bar_id(bar_id);
+
+
+#define xclRegWrite_SET_PROTO_RESPONSE() \
+
+#define xclRegWrite_RETURN()\
+    //return size;
+
+#define xclRegWrite_RPC_CALL(func_name,baseaddress,offset,data,pf_id,bar_id) \
+    RPC_PROLOGUE(func_name); \
+    xclRegWrite_SET_PROTOMESSAGE(func_name,baseaddress,offset,data,pf_id,bar_id); \
+    SERIALIZE_AND_SEND_MSG(func_name)\
+    xclRegWrite_SET_PROTO_RESPONSE(); \
+    FREE_BUFFERS(); \
+    xclRegWrite_RETURN();
+
 //-----------------------xclReadAddrSpaceDeviceRam----------------------------
 //Generate call and info message
 #define xclReadAddrSpaceDeviceRam_SET_PROTOMESSAGE(func_name,address_space,addr,data,size,pf_id,bar_id) \
@@ -292,6 +315,30 @@ mtx.unlock();
     xclReadAddrKernelCtrl_SET_PROTO_RESPONSE(data,size); \
     FREE_BUFFERS(); \
     xclReadAddrKernelCtrl_RETURN();
+//-----------------------xclRegRead----------------------------
+#define xclRegRead_SET_PROTOMESSAGE(func_name,baseaddress,offset,data,size,pf_id,bar_id) \
+    c_msg.set_baseaddress(baseaddress); \
+    c_msg.set_offset(offset); \
+    c_msg.set_size(size); \
+    c_msg.set_pf_id(pf_id); \
+    c_msg.set_bar_id(bar_id);
+
+#define xclRegRead_SET_PROTO_RESPONSE(datax,size) \
+    if (!r_msg.valid()) \
+      size = -1; \
+    else { \
+      memcpy(datax,r_msg.data().c_str(),size);\
+    }
+
+#define xclRegRead_RETURN()\
+
+#define xclRegRead_RPC_CALL(func_name,baseaddress,offset,data,size,pf_id,bar_id) \
+    RPC_PROLOGUE(func_name); \
+    xclRegRead_SET_PROTOMESSAGE(func_name,baseaddress,offset,data,size,pf_id,bar_id); \
+    SERIALIZE_AND_SEND_MSG(func_name) \
+    xclRegRead_SET_PROTO_RESPONSE(data,size); \
+    FREE_BUFFERS(); \
+    xclRegRead_RETURN();
 
 //-------------------xclClose---------------------------------
 #define xclClose_SET_PROTOMESSAGE(func_name,dev_handle) \

--- a/src/runtime_src/core/include/xcl_macros.h
+++ b/src/runtime_src/core/include/xcl_macros.h
@@ -80,5 +80,7 @@
 #define xclGraphResume_n 49
 
 #define xclCopyBOFromFd_n 50
+#define xclRegWrite_n 51
+#define xclRegRead_n 52
 
 #endif

--- a/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
+++ b/src/runtime_src/core/pcie/emulation/common_em/rpc_messages.proto
@@ -153,6 +153,20 @@ message xclWriteAddrKernelCtrl_response {
      required bool valid = 1;
 }
 //---------------------------------------------
+//xclRegWrite
+message xclRegWrite_call {
+     //required bytes xcl_api = 1;
+     required uint32 baseaddress = 1;
+     required uint32 offset = 2;
+     required bytes data = 3;
+     optional uint32 PF_ID = 4;
+     optional uint32 BAR_ID = 5;
+}
+
+message xclRegWrite_response {
+     required bool valid = 1;
+}
+//---------------------------------------------
 //xclReadAddrSpaceDeviceRam
 message xclReadAddrSpaceDeviceRam_call {
      //required bytes xcl_api = 1;
@@ -178,6 +192,23 @@ message xclReadAddrKernelCtrl_call {
 }
 
 message xclReadAddrKernelCtrl_response {
+     required bool valid = 1;
+     optional bytes data = 2;
+}
+
+//--------------------------------------------
+//xclRegRead
+message xclRegRead_call {
+     //required bytes xcl_api = 1;
+     required uint32 baseaddress = 1;
+     required uint32 offset = 2;
+     required uint32 size = 3;
+     optional bytes data = 4;
+     optional uint32 PF_ID = 5;
+     optional uint32 BAR_ID = 6;
+}
+
+message xclRegRead_response {
      required bool valid = 1;
      optional bytes data = 2;
 }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -608,16 +608,16 @@ int xclCloseContext(xclDeviceHandle handle, const uuid_t xclbinId, unsigned ipIn
 }
 
 // Restricted read/write on IP register space
-int xclRegWrite(xclDeviceHandle, uint32_t, uint32_t, uint32_t)
+int xclRegWrite(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset, uint32_t data)
 {
-  std::cerr << "ERROR: xclRegWrite/xclRegRead calls not supported for sw emulation." << std::endl;
-  return -1;
+  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+  return drv ? drv->xclRegWrite(cu_index, offset, data) : -ENODEV;
 }
 
-int xclRegRead(xclDeviceHandle, uint32_t, uint32_t, uint32_t*)
+int xclRegRead(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset, uint32_t *datap)
 {
-  std::cerr << "ERROR: xclRegWrite/xclRegRead calls not supported for sw emulation." << std::endl;
-  return -1;
+  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+  return drv ? drv->xclRegRead(cu_index, offset, datap) : -ENODEV;
 }
 
 int xclCreateProfileResults(xclDeviceHandle handle, ProfileResults** results)

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -508,14 +508,14 @@ namespace xclcpuemhal2 {
     std::string instance_name = "";
     for (const auto& kernel : m_xclbin.get_kernels()) {
       // get properties of each kernel object
-      auto props = xrt_core::xclbin_int::get_properties(kernel);
+      const auto& props = xrt_core::xclbin_int::get_properties(kernel);
       //get CU's of each kernel object.iterate over CU's to get arguments
-      if (props.address_range != 0 && !props.name.empty()) {
-        for (const auto& cu : kernel.get_cus()) {
-          instance_name = cu.get_name();
-          if (!instance_name.empty())
-            mCURangeMap[instance_name] = props.address_range;
-        }
+      if (props.address_range != 0 && !props.name.empty())
+        continue;       
+      for (const auto& cu : kernel.get_cus()) {
+        instance_name = cu.get_name();
+        if (!instance_name.empty())
+          mCURangeMap[instance_name] = props.address_range;
       }
     }
   }

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -32,6 +32,8 @@
 #include "core/common/message.h"
 #include "core/common/xrt_profiling.h"
 #include "core/common/query_requests.h"
+#include "core/common/api/xclbin_int.h"
+#include "core/include/experimental/xrt_xclbin.h"
 
 #include "swscheduler.h"
 #include <stdarg.h>
@@ -66,6 +68,7 @@ namespace xclcpuemhal2 {
       // Helper functions - added for kernel debug
       int dumpXML(const xclBin* header, std::string& fileLocation) ;
       bool parseIni(unsigned int& debugPort) ;
+      void getCuRangeIdx(const axlf* top);
       static std::map<std::string, std::string> mEnvironmentNameValueMap;
   public:
       // HAL2 RELATED member functions start
@@ -161,6 +164,11 @@ namespace xclcpuemhal2 {
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
       //Get CU index from IP_LAYOUT section for corresponding kernel name
       int xclIPName2Index(const char *name);
+
+      int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
+      int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
+      int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
+      
       bool isImported(unsigned int _bo)
       {
         if (mImportedBOs.find(_bo) != mImportedBOs.end())
@@ -474,7 +482,7 @@ namespace xclcpuemhal2 {
       FeatureRomHeader mFeatureRom;
       boost::property_tree::ptree mPlatformData;
       std::map<key_type, std::string> mQueryTable;
-
+      std::map<std::string, uint64_t> mCURangeMap;
       std::set<unsigned int > mImportedBOs;
       exec_core* mCore;
       SWScheduler* mSWSch;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -68,7 +68,7 @@ namespace xclcpuemhal2 {
       // Helper functions - added for kernel debug
       int dumpXML(const xclBin* header, std::string& fileLocation) ;
       bool parseIni(unsigned int& debugPort) ;
-      void getCuRangeIdx(const axlf* top);
+      void getCuRangeIdx();
       static std::map<std::string, std::string> mEnvironmentNameValueMap;
   public:
       // HAL2 RELATED member functions start
@@ -165,6 +165,9 @@ namespace xclcpuemhal2 {
       //Get CU index from IP_LAYOUT section for corresponding kernel name
       int xclIPName2Index(const char *name);
 
+      bool isValidCu(uint32_t cu_index);
+      uint64_t getCuAddRange(uint32_t cu_index);
+      bool isValidOffset(uint32_t offset, uint64_t cuAddRange);
       int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
@@ -483,6 +486,7 @@ namespace xclcpuemhal2 {
       boost::property_tree::ptree mPlatformData;
       std::map<key_type, std::string> mQueryTable;
       std::map<std::string, uint64_t> mCURangeMap;
+      xrt::xclbin m_xclbin;
       std::set<unsigned int > mImportedBOs;
       exec_core* mCore;
       SWScheduler* mSWSch;


### PR DESCRIPTION
#### Problem solved by the commit
Autorestart feature support for SW_EMU

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Feature request per Vitis-2540

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added new xclRegRead and xclRegwrite calls , corresponding APIs, macros and protobuf 
changes which are useful for device process handshake.  Added a supporting proc to know
the cuIdx during LoadXclbin.

#### Risks (if any) associated the changes in the commit
Low.
The newly introduced changes are only hit for autorestart and mailbox tescases.

#### What has been tested and how, request additional testing if necessary
Canary run and the results are good.