### PR TITLE
Adding new XGQ cmd opcode to return the version of ERT

### DIFF
--- a/src/runtime_src/ert/scheduler/sched.c
+++ b/src/runtime_src/ert/scheduler/sched.c
@@ -713,7 +713,7 @@ process_ctrl_command()
     ret = identify_xgq(cmd);
     break;
   default:
-    ret = -EINVAL;
+    ret = -ENOTTY;
     break;
   }
 

--- a/src/runtime_src/ert/scheduler/sched.c
+++ b/src/runtime_src/ert/scheduler/sched.c
@@ -647,6 +647,23 @@ exit_mb(struct sched_cmd *cmd)
 #endif
   CTRL_DEBUGF("mb wakeup\r\n");
 }
+
+
+static int32_t
+identify_xgq(struct sched_cmd *cmd)
+{
+  struct xgq_cmd_resp_identify resp_cmd = {0};
+
+  resp_cmd.minor = MINOR;
+  resp_cmd.major = MAJOR;
+
+  resp_cmd.rcode = 0;
+
+  xgq_ctrl_response(&ctrl_xgq, &resp_cmd, sizeof(struct xgq_cmd_resp_identify));
+
+  return 0;
+}
+
 /**
  * Process special command.
  *
@@ -691,6 +708,9 @@ process_ctrl_command()
     break;
   case XGQ_CMD_OP_EXIT:
     exit_mb(cmd);
+    break;
+  case XGQ_CMD_OP_IDENTIFY:
+    ret = identify_xgq(cmd);
     break;
   default:
     ret = -EINVAL;


### PR DESCRIPTION
#### Problem solved by the commit
Adding XGQ_CMD_OP_IDENTIFY command in Microblaze ERT to return the version of ERT

