### PR TITLE
xclbinutil : Fix PSKernel hang issue

### DIFF
--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -579,7 +579,7 @@ XclBinUtilities::validateFunctions(const std::string& kernelLibrary, const boost
   // Validate kernel's last argument
   auto args = XUtil::as_vector<boost::property_tree::ptree>(kernels[0], "args");
   if (args.back().get<std::string>("type") != "xrtHandles*")
-    throw std::runtime_error("Error: Last kernel argument isn't a xrtHandle pointer."
+    throw std::runtime_error("Error: Last kernel argument isn't a xrtHandle pointer.\n"
                              "Shared Library: '" + kernelLibrary + "'\n"
                              "Kernel Function: '" + kernels[0].get<std::string>("signature"));
 }

--- a/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinClass.cxx
@@ -1676,6 +1676,7 @@ parsePSKernelString(const std::string& encodedString,
 //
 // Note: A file name can contain a colen (e.g., C:\test)
 {
+  XUtil::TRACE("Parsing PSKernel command argument: '" + encodedString + "'");
   const std::string delimiters = ":";  
 
   // Working variables
@@ -1719,6 +1720,8 @@ parsePSKernelString(const std::string& encodedString,
 
   // -- [2]: Symbolic name --
   symbol_name = (tokens.size() > 2) ? tokens[2] : "";
+
+  XUtil::TRACE((boost::format("PSKernel command arguments: symbol_name='%s'; num_instances=%d; library='%s'") % symbol_name % num_instances % path_to_library).str());
 }
 
 void getSectionPayload(const XclBin* pXclBin,
@@ -1784,6 +1787,7 @@ updateKernelSections(const std::vector<boost::property_tree::ptree> &kernels,
 void
 XclBin::addPsKernel(const std::string& encodedString)
 {
+  XUtil::TRACE("Adding PSKernel");
   // Get the PS Kernel metadata from the encoded string
   std::string symbolicName;
   std::string kernelLibrary;

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -42,6 +42,7 @@
 #include <boost/process.hpp>
 #include <boost/process/child.hpp>
 #include <boost/process/env.hpp>
+#include <boost/asio/io_service.hpp>
 #endif
 
 

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1042,23 +1042,23 @@ XclBinUtilities::exec(const boost::filesystem::path &cmd,
                       std::ostringstream & os_stdout,
                       std::ostringstream & os_stderr)
 {
-  boost::process::ipstream ip_stdout;
-  boost::process::ipstream ip_stderr;
+  //boost::process::ipstream ip_stdout;
+  //boost::process::ipstream ip_stderr;
+  std::future<std::string> data_stdout;
+  std::future<std::string> data_stderr;
+
+  boost::asio::io_service svc;
   boost::process::child runningProcess( cmd.string(), 
                                         args, 
-                                        boost::process::std_out > ip_stdout,
-                                        boost::process::std_err > ip_stderr,
-                                        boost::this_process::environment());
-  runningProcess.wait();
-  // boost::process::ipstream::rdbuf() gives conversion error in
-  // 1.65.1 Base class is constructed with underlying buffer so just
-  // use std::istream::rdbuf() instead.
-  std::istream& istr_stdout = ip_stdout;
-  std::istream& istr_stderr = ip_stderr;
+                                        boost::process::std_out > data_stdout,
+                                        boost::process::std_err > data_stderr,
+                                        boost::this_process::environment(),
+                                        svc);
+  svc.run();   // Block until the process completes
 
   // Update the return buffers
-  os_stdout << istr_stdout.rdbuf();
-  os_stderr << istr_stderr.rdbuf();
+  os_stdout << data_stdout.get();
+  os_stderr << data_stderr.get();
 
   // Obtain the exit code from the running process
   int exitCode = runningProcess.exit_code();

--- a/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/XclBinUtilities.cxx
@@ -1055,7 +1055,8 @@ XclBinUtilities::exec(const boost::filesystem::path &cmd,
                                         boost::process::std_err > data_stderr,
                                         boost::this_process::environment(),
                                         svc);
-  svc.run();   // Block until the process completes
+  svc.run();   
+  runningProcess.wait();
 
   // Update the return buffers
   os_stdout << data_stdout.get();
@@ -1069,6 +1070,7 @@ XclBinUtilities::exec(const boost::filesystem::path &cmd,
                                                         "     Cmd: %s %s\n"
                                                         "  StdOut: %s\n"
                                                         "  StdErr: %s\n")
+                                          % exitCode 
                                           % cmd.string() % boost::algorithm::join(args, " ")
                                           % os_stdout.str()
                                           % os_stderr.str());


### PR DESCRIPTION
#### Problem solved by the commit
xclbinutil would 'hang" the objdump returned more than 4K of data.

**_Underlying issue_**
If the calling OS process return more data then the buffer associated with std::out has removed for, the calling process would become block, which in turns hangs the application. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue is not a regression.  Instead it was discovered during stress testing.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This issue was addressed by making a boost  asyncronous process call instead of a syncronous process call.

#### Risks (if any) associated the changes in the commit
No risks.  Code is now more stable

#### What has been tested and how, request additional testing if necessary
Manual testing against the AIE profiling PS Kernel.  

#### Documentation impact (if any)
N/A