### PR TITLE
Enabling Versal APU XGQ

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -157,7 +157,6 @@ static int kds_polling_thread(void *data)
 	int loop_cnt = 0;
 	int cu_idx;
 
-	printk("kds polling thread is running\n");
 	while (!kds->polling_stop) {
 		busy_cnt = 0;
 		for (cu_idx = 0; cu_idx < num_cus; cu_idx++) {
@@ -183,7 +182,6 @@ static int kds_polling_thread(void *data)
 
 		wait_event_interruptible(kds->wait_queue, kds_wake_up_poll(kds));
 	}
-	printk("kds polling thread is stopped\n");
 
 	return 0;
 }

--- a/src/runtime_src/core/edge/drm/zocl/Makefile
+++ b/src/runtime_src/core/edge/drm/zocl/Makefile
@@ -58,6 +58,7 @@ zocl-y := \
 	zocl_aie.o \
 	zocl_ctrl_ert.o \
 	zocl_xgq.o \
+	zocl_lib.o \
 	zocl_cu_xgq.o \
 	zocl_rpu_channel.o \
 	zocl_csr_intc.o \

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_cu_xgq.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_cu_xgq.h
@@ -19,10 +19,8 @@
 /*
  * Resources for one cu xgq device.
  */
-/* Producer pointer reg. Use in-mem version, if not provided. */
-#define	ZCX_RES_SQ_PROD		"ZOCL_CU_XGQ_SQ_PRODUDER"
-/* Consumer pointer reg. Use in-mem version, if not provided. */
-#define	ZCX_RES_CQ_PROD		"ZOCL_CU_XGQ_CQ_PRODUDER"
+/* XGQ IP reg. Use in-mem version, if not provided. */
+#define	ZCX_RES_XGQ_IP		"ZOCL_CU_XGQ_IP"
 /* Reg to trigger interrupt to peer. Use prod/con pointer regs, if not provided. */
 #define	ZCX_RES_CQ_PROD_INT	"ZOCL_CU_XGQ_CQ_PRODUCER_INT"
 /* Shared ring buffer. */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
@@ -14,6 +14,8 @@
 
 #include <linux/platform_device.h>
 #include <linux/interrupt.h>
+#include <linux/slab.h>
+#include <linux/io.h>
 #include "zocl_lib.h"
 
 #define ERT_CSR_INTC_DEV_NAME		"ZOCL_CSR_INTC"

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_ert_intc.h
@@ -12,11 +12,11 @@
 #ifndef _ZOCL_ERT_INTC_H_
 #define _ZOCL_ERT_INTC_H_
 
+#include <linux/platform_device.h>
 #include <linux/interrupt.h>
+#include "zocl_lib.h"
 
-#define ERT_CQ_INTC_DEV_NAME		"ZOCL_CQ_INTC"
-/* TODO: support CU intc when hardware supports ERT ssv3 */
-#define ERT_CU_INTC_DEV_NAME		"ZOCL_CU_INTC"
+#define ERT_CSR_INTC_DEV_NAME		"ZOCL_CSR_INTC"
 #define ERT_XGQ_INTC_DEV_NAME		"ZOCL_XGQ_INTC"
 
 /*
@@ -42,7 +42,7 @@ struct zocl_ert_intc_handler {
 struct zocl_ert_intc_drv_data {
 	void (*add)(struct platform_device *pdev, u32 id, irq_handler_t handler, void *arg);
 	void (*remove)(struct platform_device *pdev, u32 id);
-	void (*config)(struct platform_device *pdev, u32 id);
+	void (*config)(struct platform_device *pdev, u32 id, bool enabled);
 };
 
 #define	ERT_INTC_DRVDATA(pdev)	\
@@ -60,7 +60,38 @@ zocl_ert_intc_remove(struct platform_device *pdev, u32 id)
 	ERT_INTC_DRVDATA(pdev)->remove(pdev, id);
 }
 
-/* TODO: */
-//extern void zocl_ert_intc_config(struct platform_device *pdev, u32 id, bool enabled);
+static inline void zocl_ert_intc_config(struct platform_device *pdev, u32 id, bool enabled)
+{
+	ERT_INTC_DRVDATA(pdev)->config(pdev, id, enabled);
+}
+
+static inline int zocl_ert_create_intc(struct device *dev, u32 *irqs, size_t num_irqs,
+				       u64 status_reg, const char *dev_name,
+				       struct platform_device **pdevp)
+{
+	/* Total num of res is irqs + status reg. */
+	struct resource *res = kzalloc(sizeof(*res) * (num_irqs + 1), GFP_KERNEL);
+	int ret = 0;
+	size_t i = 0;
+
+	if (!res)
+		return -ENOMEM;
+
+	/* Fill in IRQ and status reg resources. */
+	for (i = 0; i < num_irqs; i++)
+		fill_irq_res(&res[i], irqs[i], ZEI_RES_IRQ);
+	fill_iomem_res(&res[i++], status_reg, sizeof(struct zocl_ert_intc_status_reg),
+		       ZEI_RES_STATUS);
+
+	ret = zlib_create_subdev(dev, dev_name, res, i, NULL, 0, pdevp);
+	kfree(res);
+
+	return ret;
+}
+
+static inline void zocl_ert_destroy_intc(struct platform_device *pdev)
+{
+	zlib_destroy_subdev(pdev);
+}
 
 #endif /* _ZOCL_ERT_INTC_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_lib.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_lib.h
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
+ *
+ * Author(s):
+ *        Max Zhen <maxz@xilinx.com>
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#ifndef _ZOCL_LIB_H_
+#define _ZOCL_LIB_H_
+
+#include <linux/platform_device.h>
+
+#define zocl_err(dev, fmt, args...)	dev_err(dev, "%s: "fmt, __func__, ##args)
+#define zocl_info(dev, fmt, args...)	dev_info(dev, "%s: "fmt, __func__, ##args)
+#define zocl_dbg(dev, fmt, args...)	dev_dbg(dev, "%s: "fmt, __func__, ##args)
+
+void __iomem *zlib_map_res(struct device *dev, struct resource *res, u64 *startp, size_t *szp);
+void __iomem *zlib_map_res_by_id(struct platform_device *pdev, int id, u64 *startp, size_t *szp);
+void __iomem *zlib_map_res_by_name(struct platform_device *pdev,
+				   const char *name, u64 *startp, size_t *szp);
+int zlib_create_subdev(struct device *dev, const char *devname, struct resource *res, size_t nres,
+		       void *info, size_t info_size, struct platform_device **pdevp);
+void zlib_destroy_subdev(struct platform_device *pdev);
+
+static inline void fill_irq_res(struct resource *res, u32 irq, char *name)
+{
+	res->start = irq;
+	res->end = irq;
+	res->flags = IORESOURCE_IRQ;
+	res->name = name;
+}
+
+static inline void fill_iomem_res(struct resource *res, resource_size_t start,
+				  resource_size_t size, char *name)
+{
+	res->start = start;
+	res->end = start + size - 1;
+	res->flags = IORESOURCE_MEM;
+	res->name = name;
+}
+
+static inline void fill_reg_res(struct resource *res, resource_size_t start, char *name)
+{
+	fill_iomem_res(res, start, sizeof(u32), name);
+}
+
+#endif /* _ZOCL_LIB_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_lib.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_lib.h
@@ -22,6 +22,8 @@ void __iomem *zlib_map_res(struct device *dev, struct resource *res, u64 *startp
 void __iomem *zlib_map_res_by_id(struct platform_device *pdev, int id, u64 *startp, size_t *szp);
 void __iomem *zlib_map_res_by_name(struct platform_device *pdev,
 				   const char *name, u64 *startp, size_t *szp);
+void __iomem *zlib_map_phandle_res_by_name(struct platform_device *pdev,
+					   const char *name, u64 *startp, size_t *szp);
 int zlib_create_subdev(struct device *dev, const char *devname, struct resource *res, size_t nres,
 		       void *info, size_t info_size, struct platform_device **pdevp);
 void zlib_destroy_subdev(struct platform_device *pdev);

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -12,16 +12,10 @@
 #ifndef _ZOCL_UTIL_H_
 #define _ZOCL_UTIL_H_
 
+#include "zocl_lib.h"
 #include "kds_core.h"
 #include "zocl_error.h"
 #include "zynq_ioctl.h"
-
-#define zocl_err(dev, fmt, args...)     \
-	dev_err(dev, "%s: "fmt, __func__, ##args)
-#define zocl_info(dev, fmt, args...)    \
-	dev_info(dev, "%s: "fmt, __func__, ##args)
-#define zocl_dbg(dev, fmt, args...)     \
-	dev_dbg(dev, "%s: "fmt, __func__, ##args)
 
 #define _4KB	0x1000
 #define _8KB	0x2000

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xgq.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xgq.h
@@ -28,8 +28,7 @@ struct zocl_xgq_init_args {
 	void __iomem		*zxia_ring;
 	size_t			zxia_ring_size;
 	size_t			zxia_ring_slot_size;
-	void __iomem		*zxia_sq_prod;
-	void __iomem		*zxia_cq_prod;
+	void __iomem		*zxia_xgq_ip;
 	void __iomem		*zxia_cq_prod_int;
 	zxgq_cmd_handler	zxia_cmd_handler;
 	bool			zxia_simple_cmd_hdr;

--- a/src/runtime_src/core/edge/drm/zocl/sched_exec.c
+++ b/src/runtime_src/core/edge/drm/zocl/sched_exec.c
@@ -3136,9 +3136,12 @@ get_packet_size(struct ert_packet *packet)
 	case ERT_EXIT:
 	case ERT_ABORT:
 		SCHED_DEBUG("abort or stop cmd");
+		payload = 0;
+		break;
 
 	default:
 		payload = 0;
+		break;
 	}
 
 	SCHED_DEBUG("<- %s", __func__);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_csr_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_csr_intc.c
@@ -109,7 +109,7 @@ static int zintc_probe(struct platform_device *pdev)
 		zintc_err(zintc, "failed to find IRQ"); 
 		return -EINVAL;
 	}
-	/* We expect only one irq. */
+	/* TODO: We expect only one irq for now, needs to support 4. */
 	zintc->zei_irq = res->start;
 	zintc_info(zintc, "managing IRQ: %d", zintc->zei_irq); 
 
@@ -194,8 +194,7 @@ static struct zocl_ert_intc_drv_data zocl_csr_intc_drvdata = {
 };
 
 static const struct platform_device_id zocl_csr_intc_id_match[] = {
-	{ ERT_CQ_INTC_DEV_NAME, (kernel_ulong_t)&zocl_csr_intc_drvdata },
-	{ ERT_CU_INTC_DEV_NAME, (kernel_ulong_t)&zocl_csr_intc_drvdata },
+	{ ERT_CSR_INTC_DEV_NAME, (kernel_ulong_t)&zocl_csr_intc_drvdata },
 	{ /* end of table */ },
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_csr_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_csr_intc.c
@@ -11,14 +11,16 @@
 
 #include <linux/mod_devicetable.h>
 #include <linux/platform_device.h>
-#include "zocl_util.h"
+#include "zocl_lib.h"
 #include "zocl_ert_intc.h"
 
+#define WORD_BITS			32
 /* ERT INTC driver name. */
 #define ZINTC_NAME			"zocl_csr_intc"
-/* The CSR IP provided 128 bit status. We only support the first 32 bit here since, in practice,
- * it's unlikely to create a design with more than 32 units. */
-#define ZINTC_MAX_VECTORS		32
+/* The CSR IP provided 128 bit status. */
+#define ZINTC_MAX_VECTORS		128
+/* Every 32 status bits requires one irq */
+#define ZINTC_MAX_IRQS			(ZINTC_MAX_VECTORS / WORD_BITS)
 
 #define ZINTC2PDEV(zintc)		((zintc)->zei_pdev)
 #define ZINTC2DEV(zintc)		(&ZINTC2PDEV(zintc)->dev)
@@ -28,7 +30,8 @@
 
 struct zocl_csr_intc {
 	struct platform_device		*zei_pdev;
-	u32				zei_irq;
+	int				zei_num_irqs;
+	u32				zei_irqs[ZINTC_MAX_IRQS];
 	struct zocl_ert_intc_status_reg	*zei_status;
 
 	spinlock_t			zei_lock;
@@ -45,42 +48,25 @@ static inline u32 reg_read(void __iomem *addr)
 	return ioread32(addr);
 }
 
-static void __iomem *zintc_map_res(struct zocl_csr_intc *zintc, const char *name, size_t *szp)
-{
-	struct resource *res;
-	void __iomem *map;
-
-	res = platform_get_resource_byname(ZINTC2PDEV(zintc), IORESOURCE_MEM, name);
-	if (!res) {
-		zintc_err(zintc, "res not found: %s", name);
-		return NULL;
-	}
-	zintc_info(zintc, "%s range: %pR", name, res);
-
-	map = devm_ioremap_resource(ZINTC2DEV(zintc), res);
-	if (IS_ERR(map)) {
-		zintc_err(zintc, "Failed to map res: %s: %ld", name, PTR_ERR(map));
-		return NULL;
-	}
-
-	if (szp)
-		*szp = res->end - res->start + 1;
-	return map;
-}
-
 static irqreturn_t zintc_isr(int irq, void *arg)
 {
 	unsigned long irqflags;
 	const u32 lastbit = 0x1;
-	int i;
+	int word_idx, i;
 	u32 intr;
 	struct zocl_csr_intc *zintc = (struct zocl_csr_intc *)arg;
 	struct zocl_ert_intc_handler *h;
 
 	spin_lock_irqsave(&zintc->zei_lock, irqflags);
-	/* Only fetch first 32 status bits. */
-	intr = reg_read(&zintc->zei_status->zeisr_status[0]);
-	for (i = 0; i < ZINTC_MAX_VECTORS && intr; i++, intr >>= 1) {
+	/* Find out status word based on irq. */
+	for (word_idx = 0; word_idx < zintc->zei_num_irqs; word_idx++) {
+		if (zintc->zei_irqs[word_idx] == irq)
+			break;
+	}
+	BUG_ON(word_idx >= zintc->zei_num_irqs);
+
+	intr = reg_read(&zintc->zei_status->zeisr_status[i]);
+	for (i = word_idx * WORD_BITS; i < (word_idx + 1) * WORD_BITS && intr; i++, intr >>= 1) {
 		if ((intr & lastbit) == 0) 
 			continue;
 		h = &zintc->zei_handler[i];
@@ -97,23 +83,23 @@ static int zintc_probe(struct platform_device *pdev)
 {
 	int ret;
 	int i;
-	struct resource *res;
-	struct zocl_csr_intc *zintc = devm_kzalloc(&pdev->dev, sizeof(*zintc), GFP_KERNEL);
+	struct zocl_csr_intc *zintc = NULL;
+	int num_irqs = platform_irq_count(pdev);
 
+	if (num_irqs <= 0 || num_irqs > ZINTC_MAX_IRQS) {
+		zocl_err(&pdev->dev, "invalid num of IRQ: %d\n", num_irqs); 
+		return -EINVAL;
+	}
+
+	zintc = devm_kzalloc(&pdev->dev, sizeof(*zintc), GFP_KERNEL);
 	if (!zintc)
 		return -ENOMEM;
 	zintc->zei_pdev = pdev;
+	zintc->zei_num_irqs = num_irqs;
+	spin_lock_init(&zintc->zei_lock);
+	platform_set_drvdata(pdev, zintc);
 
-	res = platform_get_resource_byname(ZINTC2PDEV(zintc), IORESOURCE_IRQ, ZEI_RES_IRQ);
-	if (!res) {
-		zintc_err(zintc, "failed to find IRQ"); 
-		return -EINVAL;
-	}
-	/* TODO: We expect only one irq for now, needs to support 4. */
-	zintc->zei_irq = res->start;
-	zintc_info(zintc, "managing IRQ: %d", zintc->zei_irq); 
-
-	zintc->zei_status = zintc_map_res(zintc, ZEI_RES_STATUS, NULL);
+	zintc->zei_status = zlib_map_res_by_name(pdev, ZEI_RES_STATUS, NULL, NULL);
 	if (!zintc->zei_status) {
 		zintc_err(zintc, "failed to find INTC Status registers"); 
 		return -EINVAL;
@@ -121,22 +107,27 @@ static int zintc_probe(struct platform_device *pdev)
 	/* Disable interrupt till we are ready to handle it. */
 	reg_write(&zintc->zei_status->zeisr_enable, 0);
 
-	spin_lock_init(&zintc->zei_lock);
-	platform_set_drvdata(pdev, zintc);
+	for (i = 0; i < num_irqs; i++) {
+		struct resource *res = platform_get_resource(pdev, IORESOURCE_IRQ, i);
+		u32 irq = res->start;
+
+		zintc->zei_irqs[i] = irq;
+		ret = devm_request_irq(&pdev->dev, irq, zintc_isr, 0, ZINTC_NAME, zintc);
+		if (ret)
+			zintc_err(zintc, "failed to add isr for IRQ: %d: %d", irq, ret); 
+		else
+			zintc_info(zintc, "managing IRQ %d", irq); 
+	}
 
 	for (i = 0; i < ZINTC_MAX_VECTORS; i++) {
 		struct zocl_ert_intc_handler *h = &zintc->zei_handler[i];
 
 		h->zeih_pdev = pdev;
-		h->zeih_irq = zintc->zei_irq;
+		h->zeih_irq = zintc->zei_irqs[i / WORD_BITS];
 	}
 
 	/* Ready to turn on interrupts! */
-	ret = devm_request_irq(ZINTC2DEV(zintc), zintc->zei_irq, zintc_isr, 0, ZINTC_NAME, zintc);
-	if (ret)
-		zintc_err(zintc, "failed to add isr for IRQ: %d: %d", zintc->zei_irq, ret); 
-	else
-		reg_write(&zintc->zei_status->zeisr_enable, 1);
+	reg_write(&zintc->zei_status->zeisr_enable, 1);
 	return 0;
 }
 
@@ -163,6 +154,9 @@ static void zocl_csr_intc_add(struct platform_device *pdev, u32 id, irq_handler_
 	spin_lock_irqsave(&zintc->zei_lock, irqflags);
 
 	h = &zintc->zei_handler[id];
+	if (h->zeih_irq == 0)
+		zintc_err(zintc, "vector %d has no matching irq", id);
+
 	BUG_ON(h->zeih_cb);
 	h->zeih_cb = cb;
 	h->zeih_arg = arg;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_ctrl_ert.c
@@ -420,8 +420,8 @@ static int zert_versal_init(struct zocl_ctrl_ert *zert)
 	u32 *irqs = NULL;
 
 	/* Obtain shared ring buffer. */
-	zert->zce_cq = zlib_map_res_by_name(ZERT2PDEV(zert), cq_res_name, &zert->zce_cq_start,
-					    &zert->zce_cq_size);
+	zert->zce_cq = zlib_map_phandle_res_by_name(ZERT2PDEV(zert), cq_res_name,
+						    &zert->zce_cq_start, &zert->zce_cq_size);
 	if (!zert->zce_cq) {
 		zert_err(zert, "failed to find ERT command queue");
 		return -EINVAL;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
@@ -138,8 +138,7 @@ struct zocl_cu_xgq {
 	u32			zxc_irq;
 	void __iomem		*zxc_ring;
 	size_t			zxc_ring_size;
-	void __iomem		*zxc_sq_prod;
-	void __iomem		*zxc_cq_prod;
+	void __iomem		*zxc_xgq_ip;
 	void __iomem		*zxc_cq_prod_int;
 #ifdef ZCU_XGQ_DEBUG
 	struct log_ring		zxc_log;
@@ -292,8 +291,7 @@ static void zcu_xgq_init_xgq(struct zocl_cu_xgq *zcu_xgq)
 	arg.zxia_intc_pdev = zcu_xgq->zxc_pdata->zcxi_intc_pdev;
 	if (ZCU_XGQ_MAX_SLOT_SIZE < arg.zxia_ring_slot_size)
 		arg.zxia_ring_slot_size = ZCU_XGQ_MAX_SLOT_SIZE;
-	arg.zxia_sq_prod = zcu_xgq->zxc_sq_prod;
-	arg.zxia_cq_prod = zcu_xgq->zxc_cq_prod;
+	arg.zxia_xgq_ip = zcu_xgq->zxc_xgq_ip;
 	arg.zxia_cq_prod_int = zcu_xgq->zxc_cq_prod_int;
 	arg.zxia_cmd_handler = zcu_xgq->zxc_pdata->zcxi_echo_mode ? NULL : zcu_xgq_cmd_handler;
 	arg.zxia_simple_cmd_hdr = ZCU_XGQ_FAST_PATH(zcu_xgq);
@@ -340,8 +338,7 @@ static int zcu_xgq_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	zcu_xgq->zxc_sq_prod = zcu_xgq_map_res(zcu_xgq, ZCX_RES_SQ_PROD, NULL);
-	zcu_xgq->zxc_cq_prod = zcu_xgq_map_res(zcu_xgq, ZCX_RES_CQ_PROD, NULL);
+	zcu_xgq->zxc_xgq_ip = zcu_xgq_map_res(zcu_xgq, ZCX_RES_XGQ_IP, NULL);
 	zcu_xgq->zxc_cq_prod_int = zcu_xgq_map_res(zcu_xgq, ZCX_RES_CQ_PROD_INT, NULL);
 
 	zcu_xgq->zxc_zdev = zocl_get_zdev();

--- a/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_cu_xgq.c
@@ -12,7 +12,7 @@
 #include <linux/mod_devicetable.h>
 #include <linux/platform_device.h>
 #include <linux/mutex.h>
-#include "zocl_util.h"
+#include "zocl_lib.h"
 #include "zocl_drv.h"
 #include "zocl_xgq.h"
 #include "zocl_cu_xgq.h"
@@ -27,9 +27,6 @@
 
 #define ZCU_XGQ_MAX_SLOT_SIZE	1024
 #define ZCU_XGQ_FAST_PATH(zcu_xgq)		((zcu_xgq)->zxc_num_cu == 1)
-//#define ZCU_XGQ_FAST_PATH(zcu_xgq)		(false)
-
-//#define ZCU_XGQ_DEBUG
 
 static void zcu_xgq_cmd_handler(struct platform_device *pdev, struct xgq_cmd_sq_hdr *cmd);
 
@@ -256,29 +253,6 @@ static inline u32 reg_read(void __iomem *addr)
 	return ioread32(addr);
 }
 
-static void __iomem *zcu_xgq_map_res(struct zocl_cu_xgq *zcu_xgq, const char *name, size_t *szp)
-{
-	struct resource *res;
-	void __iomem *map;
-
-	res = platform_get_resource_byname(ZCU_XGQ2PDEV(zcu_xgq), IORESOURCE_MEM, name);
-	if (!res) {
-		zcu_xgq_err(zcu_xgq, "res not found: %s", name);
-		return NULL;
-	}
-	zcu_xgq_info(zcu_xgq, "%s range: %pR", name, res);
-
-	map = devm_ioremap(ZCU_XGQ2DEV(zcu_xgq), res->start, res->end - res->start + 1);
-	if (IS_ERR(map)) {
-		zcu_xgq_err(zcu_xgq, "Failed to map res: %s: %ld", name, PTR_ERR(map));
-		return NULL;
-	}
-
-	if (szp)
-		*szp = res->end - res->start + 1;
-	return map;
-}
-
 static void zcu_xgq_init_xgq(struct zocl_cu_xgq *zcu_xgq)
 {
 	struct zocl_xgq_init_args arg = {};
@@ -330,7 +304,7 @@ static int zcu_xgq_probe(struct platform_device *pdev)
 	zcu_xgq->zxc_pdata = dev_get_platdata(ZCU_XGQ2DEV(zcu_xgq));
 	BUG_ON(zcu_xgq->zxc_pdata == NULL);
 
-	zcu_xgq->zxc_ring = zcu_xgq_map_res(zcu_xgq, ZCX_RES_RING, &zcu_xgq->zxc_ring_size);
+	zcu_xgq->zxc_ring = zlib_map_res_by_name(pdev, ZCX_RES_RING, NULL, &zcu_xgq->zxc_ring_size);
 	if (!zcu_xgq->zxc_ring)
 		return -EINVAL;
 
@@ -338,8 +312,8 @@ static int zcu_xgq_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	zcu_xgq->zxc_xgq_ip = zcu_xgq_map_res(zcu_xgq, ZCX_RES_XGQ_IP, NULL);
-	zcu_xgq->zxc_cq_prod_int = zcu_xgq_map_res(zcu_xgq, ZCX_RES_CQ_PROD_INT, NULL);
+	zcu_xgq->zxc_xgq_ip = zlib_map_res_by_name(pdev, ZCX_RES_XGQ_IP, NULL, NULL);
+	zcu_xgq->zxc_cq_prod_int = zlib_map_res_by_name(pdev, ZCX_RES_CQ_PROD_INT, NULL, NULL);
 
 	zcu_xgq->zxc_zdev = zocl_get_zdev();
 	mutex_init(&zcu_xgq->zxc_lock);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_lib.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_lib.c
@@ -44,9 +44,23 @@ void __iomem *zlib_map_res_by_id(struct platform_device *pdev, int id, u64 *star
 	return zlib_map_res(dev, res, startp, szp);
 }
 
-
 void __iomem *zlib_map_res_by_name(struct platform_device *pdev,
 				   const char *name, u64 *startp, size_t *szp)
+{
+	struct device *dev = &pdev->dev;
+	struct resource *res = platform_get_resource_byname(pdev, IORESOURCE_MEM, name);
+
+	if (!res) {
+		zocl_err(dev, "failed to find resource (%s)", name);
+		return NULL;
+	}
+	zocl_info(dev, "Found resource (%s): %pR", name, res);
+
+	return zlib_map_res(dev, res, startp, szp);
+}
+
+void __iomem *zlib_map_phandle_res_by_name(struct platform_device *pdev,
+					   const char *name, u64 *startp, size_t *szp)
 {
 	int ret = -EINVAL;
 	struct resource res = {};

--- a/src/runtime_src/core/edge/drm/zocl/zocl_lib.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_lib.c
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: GPL-2.0 OR Apache-2.0 */
+/*
+ * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ *
+ * Author(s):
+ *        Max Zhen <maxz@xilinx.com>
+ *
+ * This file is dual-licensed; you may select either the GNU General Public
+ * License version 2 or Apache License, Version 2.0.
+ */
+
+#include <linux/platform_device.h>
+#include <linux/of_address.h>
+#include <linux/io.h>
+#include "zocl_lib.h"
+
+void __iomem *zlib_map_res(struct device *dev, struct resource *res, u64 *startp, size_t *szp)
+{
+	void __iomem *map = devm_ioremap(dev, res->start, res->end - res->start + 1);
+
+	if (IS_ERR(map)) {
+		zocl_err(dev, "Failed to map resource: %ld", PTR_ERR(map));
+		return NULL;
+	}
+
+	if (startp)
+		*startp = res->start;
+	if (szp)
+		*szp = res->end - res->start + 1;
+	return map;
+}
+
+void __iomem *zlib_map_res_by_id(struct platform_device *pdev, int id, u64 *startp, size_t *szp)
+{
+	struct device *dev = &pdev->dev;
+	struct resource *res = platform_get_resource(pdev, IORESOURCE_MEM, id);
+
+	if (!res) {
+		zocl_err(dev, "failed to find resource ID (%d)", id);
+		return NULL;
+	}
+	zocl_info(dev, "Found resource (%d): %pR", id, res);
+
+	return zlib_map_res(dev, res, startp, szp);
+}
+
+
+void __iomem *zlib_map_res_by_name(struct platform_device *pdev,
+				   const char *name, u64 *startp, size_t *szp)
+{
+	int ret = -EINVAL;
+	struct resource res = {};
+	struct device_node *np = NULL;
+	struct device *dev = &pdev->dev;
+
+	np = of_parse_phandle(dev->of_node, name, 0);
+	if (np)
+		ret = of_address_to_resource(np, 0, &res);
+	if (ret) {
+		zocl_err(dev, "failed to find resource (%s): %d", name, ret);
+		return NULL;
+	}
+	zocl_info(dev, "Found resource (%s): %pR", name, &res);
+
+	return zlib_map_res(dev, &res, startp, szp);
+}
+
+int zlib_create_subdev(struct device *dev, const char *devname, struct resource *res, size_t nres,
+		       void *info, size_t info_size, struct platform_device **pdevp)
+{
+	struct platform_device *pldev;
+	int ret;
+
+	pldev = platform_device_alloc(devname, PLATFORM_DEVID_AUTO);
+	if (!pldev) {
+		zocl_err(dev, "Failed to alloc %s device", devname);
+		return -ENOMEM;
+	}
+
+	ret = platform_device_add_resources(pldev, res, nres);
+	if (ret) {
+		zocl_err(dev, "Failed to add resource for %s device", devname);
+		goto err;
+	}
+
+	if (info) {
+		ret = platform_device_add_data(pldev, info, info_size);
+		if (ret) {
+			zocl_err(dev, "Failed to add data for %s device", devname);
+			goto err;
+		}
+	}
+
+	pldev->dev.parent = dev;
+
+	ret = platform_device_add(pldev);
+	if (ret) {
+		zocl_err(dev, "Failed to create %s device", devname);
+		goto err;
+	}
+
+	ret = device_attach(&pldev->dev);
+	if (ret != 1) {
+		ret = -EINVAL;
+		zocl_err(dev, "Failed to attach driver to %s device", devname);
+		goto err1;
+	}
+
+	*pdevp = pldev;
+
+	return 0;
+
+err1:
+	platform_device_del(pldev);
+err:
+	platform_device_put(pldev);
+	return ret;
+}
+
+void zlib_destroy_subdev(struct platform_device *pdev)
+{
+	if (!pdev)
+		return;
+
+	platform_device_del(pdev);
+	platform_device_put(pdev);
+}
+

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -186,8 +186,8 @@ static int zrpu_channel_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, chan);
 
 	/* Discover and init shared ring buffer. */
-	chan->mem_base = zlib_map_res_by_name(ZCHAN2PDEV(chan), mem_res_name,
-					      &chan->mem_start, &chan->mem_size);
+	chan->mem_base = zlib_map_phandle_res_by_name(ZCHAN2PDEV(chan), mem_res_name,
+						      &chan->mem_start, &chan->mem_size);
 	if (!chan->mem_base) {
 		zchan_err(chan, "failed to find channel buffer");
 		return -EINVAL;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -240,11 +240,9 @@ static int zrpu_channel_probe(struct platform_device *pdev)
 	xgq_arg.zxia_ring = chan->mem_base + ZRPU_CHANNEL_XGQ_BUFFER;
 	xgq_arg.zxia_ring_size = ZRPU_CHANNEL_XGQ_BUFFER_SIZE;
 	xgq_arg.zxia_ring_slot_size = ZRPU_CHANNEL_XGQ_SLOT_SIZE;
-#if 0	/* TODO: Wait for XGQ IP fix on the shell */
 	xgq_arg.zxia_irq = irq;
 	xgq_arg.zxia_intc_pdev = chan->intc_pdev;
 	xgq_arg.zxia_xgq_ip = chan->xgq_base;
-#endif
 	xgq_arg.zxia_cmd_handler = zchan_cmd_handler;
 	chan->xgq_hdl = zxgq_init(&xgq_arg);
 	if (!chan->xgq_hdl) {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_rpu_channel.c
@@ -12,11 +12,14 @@
 #include <linux/mod_devicetable.h>
 #include <linux/platform_device.h>
 #include <linux/of_address.h>
+#include <linux/of_irq.h>
 #include "zocl_drv.h"
+#include "zocl_ert_intc.h"
+#include "zocl_xgq.h"
 
 #define ZRPU_CHANNEL_NAME "zocl_rpu_channel"
 
-#define ZCHAN2PDEV(chan)		((chan)->zrc_pdev)
+#define ZCHAN2PDEV(chan)		((chan)->pdev)
 #define ZCHAN2DEV(chan)			(&ZCHAN2PDEV(chan)->dev)
 #define zchan_err(chan, fmt, args...)	zocl_err(ZCHAN2DEV(chan), fmt"\n", ##args)
 #define zchan_info(chan, fmt, args...)	zocl_info(ZCHAN2DEV(chan), fmt"\n", ##args)
@@ -26,12 +29,17 @@
 #define ZRPU_CHANNEL_READY		0
 #define ZRPU_CHANNEL_XGQ_OFF		4
 
-/* hardcode XGQ buffer from offset 4K */
+/* hardcode XGQ buffer from offset 4K, size is 4K, too */
 #define ZRPU_CHANNEL_XGQ_BUFFER		4096
+#define ZRPU_CHANNEL_XGQ_BUFFER_SIZE	4096
+#define ZRPU_CHANNEL_XGQ_SLOT_SIZE	1024
 
 struct zocl_rpu_channel {
-	struct platform_device *zrc_pdev;
+	struct platform_device *pdev;
+	struct platform_device *intc_pdev;
 	void __iomem *mem_base;
+	void __iomem *xgq_base;
+	void *xgq_hdl;
 	u64 mem_start;
 	size_t mem_size;
 };
@@ -44,42 +52,6 @@ static inline void reg_write(void __iomem *base, u64 off, u32 val)
 static inline u32 reg_read(void __iomem *base, u64 off)
 {
 	return ioread32(base + off);
-}
-
-static void __iomem *zchan_map_res(struct zocl_rpu_channel *chan,
-				   struct resource *res, u64 *startp, size_t *szp)
-{
-	void __iomem *map = devm_ioremap(ZCHAN2DEV(chan), res->start, res->end - res->start + 1);
-
-	if (IS_ERR(map)) {
-		zchan_err(chan, "Failed to map channel resource: %ld", PTR_ERR(map));
-		return NULL;
-	}
-
-	if (startp)
-		*startp = res->start;
-	if (szp)
-		*szp = res->end - res->start + 1;
-	return map;
-}
-
-static void __iomem *zchan_map_res_by_name(struct zocl_rpu_channel *chan, const char *name,
-					  u64 *startp, size_t *szp)
-{
-	int ret = -EINVAL;
-	struct resource res = {};
-	struct device_node *np = NULL;
-
-	np = of_parse_phandle(ZCHAN2PDEV(chan)->dev.of_node, name, 0);
-	if (np)
-		ret = of_address_to_resource(np, 0, &res);
-	if (ret) {
-		zchan_err(chan, "failed to find channel resource (%s): %d", name, ret);
-		return NULL;
-	}
-	zchan_info(chan, "Found channel resource (%s): %pR", name, &res);
-
-	return zchan_map_res(chan, &res, startp, szp);
 }
 
 static ssize_t ready_store(struct device *dev, struct device_attribute *da,
@@ -113,39 +85,190 @@ static const struct of_device_id zocl_rpu_channel_of_match[] = {
 	{ /* end of table */ },
 };
 
+#define ZCHAN_CMD_HANDLER_VER_MAJOR	1
+#define ZCHAN_CMD_HANDLER_VER_MINOR	0
+
+typedef void (*cmd_handler)(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
+			    struct xgq_com_queue_entry *resp);
+
+static void init_resp(struct xgq_com_queue_entry *resp, u16 cid, u32 rcode)
+{
+	memset(resp, 0, sizeof(*resp));
+	resp->hdr.cid = cid;
+	resp->hdr.cstate = XGQ_CMD_STATE_COMPLETED;
+	resp->rcode = rcode;
+}
+
+static void zchan_cmd_identify(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
+			       struct xgq_com_queue_entry *resp)
+{
+	struct xgq_cmd_resp_identify *r = (struct xgq_cmd_resp_identify *)resp;
+
+	init_resp(resp, cmd->cid, 0);
+
+	r->major = ZCHAN_CMD_HANDLER_VER_MAJOR;
+	r->minor = ZCHAN_CMD_HANDLER_VER_MINOR;
+}
+
+static void zchan_cmd_default_handler(struct zocl_rpu_channel *chan, struct xgq_cmd_sq_hdr *cmd,
+				      struct xgq_com_queue_entry *resp)
+{
+	zchan_err(chan, "Unknown cmd: %d", cmd->opcode);
+	init_resp(resp, cmd->cid, -ENOTTY);
+}
+
+struct zchan_ops {
+	u32 op;
+	char *name;
+	cmd_handler handler;
+} zchan_op_table[] = {
+	{ XGQ_CMD_OP_IDENTIFY, "XGQ_CMD_OP_IDENTIFY", zchan_cmd_identify }
+};
+
+static inline const struct zchan_ops *opcode2op(u32 op)
+{
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(zchan_op_table); i++) {
+		if (zchan_op_table[i].op == op)
+			return &zchan_op_table[i];
+	}
+	return NULL;
+}
+
+static inline const char *opcode2name(u32 opcode)
+{
+	const struct zchan_ops *op = opcode2op(opcode);
+
+	return op ? op->name : "UNKNOWN_CMD";
+}
+
+static inline cmd_handler opcode2handler(u32 opcode)
+{
+	const struct zchan_ops *op = opcode2op(opcode);
+
+	return op ? op->handler : NULL;
+}
+
+/* All channel command is run-to-complete, no async process is supported. */
+static void zchan_cmd_handler(struct platform_device *pdev, struct xgq_cmd_sq_hdr *cmd)
+{
+	struct zocl_rpu_channel *chan = platform_get_drvdata(pdev);
+	u32 op = cmd->opcode;
+	cmd_handler func = opcode2handler(op);
+	struct xgq_com_queue_entry r = {};
+
+	zchan_info(chan, "%s received", opcode2name(op));
+	if (func)
+		func(chan, cmd, &r);
+	else
+		zchan_cmd_default_handler(chan, cmd, &r);
+	zxgq_send_response(chan->xgq_hdl, &r);
+	kfree(cmd);
+}
+
 static int zrpu_channel_probe(struct platform_device *pdev)
 {
+	const char *mem_res_name = "xlnx,xgq_buffer";
+	const char *xgq_res_name = "xlnx,xgq_device";
+	struct device_node *np = NULL;
+	struct resource res = {};
 	struct zocl_rpu_channel *chan;
+	struct zocl_xgq_init_args xgq_arg = {};
 	int ret;
+	u32 irq;
 
 	chan = devm_kzalloc(&pdev->dev, sizeof(*chan), GFP_KERNEL);
 	if (!chan)
 		return -ENOMEM;
 
-	chan->zrc_pdev = pdev;
+	chan->pdev = pdev;
 	platform_set_drvdata(pdev, chan);
 
-	chan->mem_base = zchan_map_res_by_name(chan, "xlnx,xgq_buffer",
-					       &chan->mem_start, &chan->mem_size);
+	/* Discover and init shared ring buffer. */
+	chan->mem_base = zlib_map_res_by_name(ZCHAN2PDEV(chan), mem_res_name,
+					      &chan->mem_start, &chan->mem_size);
 	if (!chan->mem_base) {
 		zchan_err(chan, "failed to find channel buffer");
 		return -EINVAL;
 	}
 	reg_write(chan->mem_base, ZRPU_CHANNEL_XGQ_OFF, ZRPU_CHANNEL_XGQ_BUFFER);
 
-	ret = sysfs_create_group(&pdev->dev.kobj, &zrpu_channel_attrgroup);
+	/* Discover and init XGQ. */
+	ret = of_count_phandle_with_args(ZCHAN2DEV(chan)->of_node, xgq_res_name, NULL);
+	if (ret <= 0) {
+		zchan_err(chan, "failed to find RPU channel XGQ");
+		return -EINVAL;
+	}
+	if (ret != 1) {
+		zchan_info(chan, "found > 1 XGQs, only use the first one");
+	}
+	np = of_parse_phandle(ZCHAN2DEV(chan)->of_node, xgq_res_name, 0);
+	if (!np) {
+		zchan_err(chan, "failed to find node for XGQ");
+		return -EINVAL;
+	}
+	ret = of_address_to_resource(np, 0, &res);
+	if (ret) {
+		zchan_err(chan, "failed to find res for XGQ: %d", ret);
+		return -EINVAL;
+	}
+	irq = of_irq_get(np, 0);
+	zchan_info(chan, "Found XGQ @ %pR on irq %d", &res, irq);
+	chan->xgq_base = zlib_map_res(ZCHAN2DEV(chan), &res, NULL, NULL);
+	if (!chan->xgq_base) {
+		zchan_err(chan, "failed to map XGQ IP");
+		return -EINVAL;
+	}
+
+	ret = sysfs_create_group(&ZCHAN2DEV(chan)->kobj, &zrpu_channel_attrgroup);
 	if (ret) {
 		zchan_err(chan, "failed to create sysfs: %d", ret);
 		return ret;
 	}
 
+	/* Bringup INTC sub-dev to handle interrupts for this XGQ. */
+	ret = zocl_ert_create_intc(ZCHAN2DEV(chan), &irq, 1, 0,
+				   ERT_XGQ_INTC_DEV_NAME, &chan->intc_pdev);
+	if (ret) {
+		zchan_err(chan, "Failed to create xgq intc device: %d", ret);
+		goto err_intc;
+	}
+
+	/* Bringup the XGQ. */
+	xgq_arg.zxia_pdev = ZCHAN2PDEV(chan);
+	xgq_arg.zxia_ring = chan->mem_base + ZRPU_CHANNEL_XGQ_BUFFER;
+	xgq_arg.zxia_ring_size = ZRPU_CHANNEL_XGQ_BUFFER_SIZE;
+	xgq_arg.zxia_ring_slot_size = ZRPU_CHANNEL_XGQ_SLOT_SIZE;
+#if 0	/* TODO: Wait for XGQ IP fix on the shell */
+	xgq_arg.zxia_irq = irq;
+	xgq_arg.zxia_intc_pdev = chan->intc_pdev;
+	xgq_arg.zxia_xgq_ip = chan->xgq_base;
+#endif
+	xgq_arg.zxia_cmd_handler = zchan_cmd_handler;
+	chan->xgq_hdl = zxgq_init(&xgq_arg);
+	if (!chan->xgq_hdl) {
+		zchan_err(chan, "failed to initialize XGQ");
+		goto err_xgq;
+	}
+
 	return 0;
+
+err_intc:
+	sysfs_remove_group(&pdev->dev.kobj, &zrpu_channel_attrgroup);
+err_xgq:
+	zocl_ert_destroy_intc(chan->intc_pdev);
+	return -EINVAL;
 };
 
 static int zrpu_channel_remove(struct platform_device *pdev)
 {
-	sysfs_remove_group(&pdev->dev.kobj, &zrpu_channel_attrgroup);
+	struct zocl_rpu_channel *chan = platform_get_drvdata(pdev);
 
+	if (chan->xgq_hdl)
+		zxgq_fini(chan->xgq_hdl);
+	zocl_ert_destroy_intc(chan->intc_pdev);
+	sysfs_remove_group(&pdev->dev.kobj, &zrpu_channel_attrgroup);
 	return 0;
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq_intc.c
@@ -11,7 +11,7 @@
 
 #include <linux/mod_devicetable.h>
 #include <linux/platform_device.h>
-#include "zocl_util.h"
+#include "zocl_lib.h"
 #include "zocl_ert_intc.h"
 
 /* ERT INTC driver name. */
@@ -28,7 +28,7 @@ struct zocl_xgq_intc {
 
 	spinlock_t			zei_lock;
 
-	size_t				zei_num_irqs;
+	int				zei_num_irqs;
 	/* variable length based on num of irqs, always the last member */
 	struct zocl_ert_intc_handler	zei_handler[0];
 };

--- a/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/devices.h
@@ -2917,7 +2917,6 @@ struct xocl_subdev_map {
 #define	XOCL_BOARD_VERSAL_USER_RAPTOR2					\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
-			XOCL_DSAFLAG_MB_SCHE_OFF |			\
 			XOCL_DSAFLAG_VERSAL,				\
 		.subdev_info = RES_USER_VERSAL_VSEC,			\
 		.subdev_num = ARRAY_SIZE(RES_USER_VERSAL_VSEC),		\
@@ -2926,7 +2925,6 @@ struct xocl_subdev_map {
 #define	XOCL_BOARD_VERSAL_USER_RAPTOR2_ES3				\
 	(struct xocl_board_private){					\
 		.flags = XOCL_DSAFLAG_DYNAMIC_IP |			\
-			XOCL_DSAFLAG_MB_SCHE_OFF |			\
 			XOCL_DSAFLAG_VERSAL_ES3 |			\
 			XOCL_DSAFLAG_VERSAL,				\
 		.subdev_info = RES_USER_VERSAL_VSEC,			\


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. This is a follow-up PR (for https://github.com/Xilinx/XRT/pull/6194) to enable APU XGQ on Versal. Note that the latest Versal shell on TA is required to be able to run this code.
2. This PR also include some code refactoring to move some common file into zocl_lib.c for multiple platform device drivers.
3. This PR also enabled XGQ between APU and RPU (not tested so far).
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
N/A
#### What has been tested and how, request additional testing if necessary
Run xbutil validate on latest Versal shell on TA
#### Documentation impact (if any)
N/A