### PR TITLE
Remove "XRT upload build artifacts" step from minipipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,13 +87,13 @@ jobs:
 
       # XRT build aritfacts step uploads the build/Release folder to github action in zip format
       # This step uses upload-artifacts action which is maintained by github
-    - name: XRT build artifacts
+#    - name: XRT build artifacts
       # if always() keyword is set so that even if previous step fails or workflow is cancelled, this step is set to run always
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Build Artifacts
-        path: build/Release
+#      if: always()
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: Build Artifacts
+#        path: build/Release
 
     # This step installs the XRT rpm/deb packages created in the previous step
     - name: Install XRT


### PR DESCRIPTION
 **Problem solved by the commit**

`XRT build artifacts` step is responsible for uploading the `XRT rpm/deb packages` (generated during building XRT) to github. 
Normally, it takes around 10 min for uploading all the build artifacts to github but it can go on for as long as 20 min based on network connectivity and github actions. 
The `verification` job itself has a timeout of 40 min. Hence, PR run will be timed-out, showing as "run has failed" eventhough it is cancelled in midway by github actions. The commit will resolve this timeout issue.

**Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered**

This issue was discovered through manual observation

**How problem was solved, alternative solutions (if any) and why they were rejected**

Removing the XRT build artifacts step resolves the issue. It further speeds up the minipipeline runs. 
Alternative solution is to increase timeout for verification job. This is rejected because allocating 10-20 min of PR build for uploading `1.2GB` folder to github is not a good choice.

**Risks (if any) associated the changes in the commit**

NA

**What has been tested and how, request additional testing if necessary**

NA

**Documentation impact (if any)**

NA
