### PR TITLE
CR-1120136 Kernel limit error

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -227,8 +227,8 @@ struct xrt_cu_info {
 	bool			 sw_reset;
 	struct xrt_cu_arg	*args;
 	u32			 num_args;
-	char			 iname[32];
-	char			 kname[32];
+	char			 iname[64];
+	char			 kname[64];
 	void			*xgq;
 };
 


### PR DESCRIPTION
#### Problem solved by the commit
Extend kernel and instance name to 64 bytes each in driver.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Customer bug encountered problem supposedly when using clSetKernelArg
in older 2021.1 release.  Debugged the problem on XRT main branch and
saw that core XRT could not find a requested compute unit because the
instance name was greater than 32 bytes.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The instance names are returned via sysfs from driver and shows
truncated names. Expanded the arrays holding kernel and instance name
to 64 bytes each.  Per xclbin a kernel:instance name can be 64 bytes,
but there is no special limit on the kernel and instance name and
either can be 64 bytes minus few special chars.

#### Risks (if any) associated the changes in the commit
Not seeing any risks.

#### What has been tested and how, request additional testing if necessary
Old HW regression tests
