### PR TITLE
Bug fix: xclbinutil cannot add a PS kernel when RTD sections are empty

### DIFF
--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -194,10 +194,6 @@ XclBinUtilities::addKernel(const boost::property_tree::ptree& ptKernel,
                            bool isFixedPS,
                            boost::property_tree::ptree& ptEmbeddedData)
 {
-  // -- Validate destination
-  if (ptEmbeddedData.empty())
-    throw std::runtime_error("Embedded Metadata section is empty");
-
   boost::property_tree::ptree ptEmpty;
 
   XUtil::TRACE_PrintTree("Embedded Data XML", ptEmbeddedData);
@@ -337,13 +333,13 @@ XclBinUtilities::addKernel(const boost::property_tree::ptree& ptKernel,
     throw std::runtime_error("Missing kernel name");
 
   // Transform the sections into something more manageable
-  boost::property_tree::ptree& ptIPLayout = ptIPLayoutRoot.get_child("ip_layout");
+  const boost::property_tree::ptree& ptIPLayout = ptIPLayoutRoot.get_child("ip_layout", ptEmpty);
   auto ipLayout = XUtil::as_vector<boost::property_tree::ptree>(ptIPLayout, "m_ip_data");
 
-  const boost::property_tree::ptree& ptMemTopology = ptMemTopologyRoot.get_child("mem_topology");
+  const boost::property_tree::ptree& ptMemTopology = ptMemTopologyRoot.get_child("mem_topology", ptEmpty);
   auto memTopology = XUtil::as_vector<boost::property_tree::ptree>(ptMemTopology, "m_mem_data");
 
-  boost::property_tree::ptree& ptConnectivity = ptConnectivityRoot.get_child("connectivity");
+  const boost::property_tree::ptree& ptConnectivity = ptConnectivityRoot.get_child("connectivity", ptEmpty);
   auto connectivity = XUtil::as_vector<boost::property_tree::ptree>(ptConnectivity, "m_connection");
 
   // -- Create the kernel instances

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/PSKernel.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/PSKernel.py
@@ -122,6 +122,40 @@ def main():
 
   jsonFileCompare(expectedKernelJSON, outputKernelJSON)
 
+  # ---------------------------------------------------------------------------
+  step = "3) Validate adding just a soft kernel"
+
+  outputOnlyPSKernelXclbin = "only_pskernel.xclbin"
+  outputPSKEmbeddedMetadata = "embedded_metadata_psk.xml"
+  expectedOnlyPSKEmbeddedMetadata = os.path.join(args.resource_dir, "embedded_metadata_psk_expected.xml")
+
+  outputPSKIpLayout = "ip_layout_psk.json"
+  expectedPSKIpLayout = os.path.join(args.resource_dir, "ip_layout_psk_expected.json")
+
+  outputPSKConnectivity = "connectivity_psk.json"
+  expectedPSKConnectivity = os.path.join(args.resource_dir, "connectivity_psk_expected.json")
+
+  outputPSKMemTopology = "mem_topology_psk.json"
+  expectedPSKMemTopology = os.path.join(args.resource_dir, "mem_topology_psk_expected.json")
+
+
+  cmd = [xclbinutil, "--add-pskernel", psKernelSharedLibrary,
+                     "--dump-section", "EMBEDDED_METADATA:RAW:" + outputPSKEmbeddedMetadata,
+                     "--dump-section", "IP_LAYOUT:JSON:" + outputPSKIpLayout,
+                     "--dump-section", "CONNECTIVITY:JSON:" + outputPSKConnectivity,
+                     "--dump-section", "MEM_TOPOLOGY:JSON:" + outputPSKMemTopology,
+                     "--output", outputOnlyPSKernelXclbin, 
+                     "--force"]
+
+  # Validate the contents of the various sections
+  textFileCompare(outputEmbeddedMetadata, expectedEmbeddedMetadata)
+  jsonFileCompare(outputIpLayout, expectedIpLayout)
+  jsonFileCompare(outputConnectivity, expectedConnectivity)
+  jsonFileCompare(outputMemTopology, expectedMemTopology)
+
+  execCmd(step, cmd)
+
+  # ---------------------------------------------------------------------------
 
   # If the code gets this far, all is good.
   return False

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/connectivity_psk_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/connectivity_psk_expected.json
@@ -1,0 +1,32 @@
+{
+    "connectivity": {
+        "m_count": "5",
+        "m_connection": [
+            {
+                "arg_index": "0",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "1",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "2",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "6",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            },
+            {
+                "arg_index": "7",
+                "m_ip_layout_index": "0",
+                "mem_data_index": "0"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+  <platform>
+    <device>
+      <core>
+        <kernel name="kernel0" language="c" type="dpu">
+          <arg name="arg0" addressQualifier="1" id="0" size="0x10" offset="0x0" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="arg1" addressQualifier="1" id="1" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="arg2" addressQualifier="1" id="2" size="0x10" offset="0x20" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="arg3" addressQualifier="0" id="3" size="0x8" offset="0x30" hostOffset="0x0" hostSize="0x8" type="int"/>
+          <arg name="arg4" addressQualifier="0" id="4" size="0x8" offset="0x38" hostOffset="0x0" hostSize="0x8" type="int"/>
+          <arg name="arg5" addressQualifier="0" id="5" size="0x4" offset="0x40" hostOffset="0x0" hostSize="0x4" type="float"/>
+          <arg name="arg6" addressQualifier="1" id="6" size="0x10" offset="0x44" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="arg7" addressQualifier="1" id="7" size="0x10" offset="0x54" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
+          <instance name="scu_0"/>
+        </kernel>
+      </core>
+    </device>
+  </platform>
+</project>

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/ip_layout_psk_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/ip_layout_psk_expected.json
@@ -1,0 +1,13 @@
+{
+    "ip_layout": {
+        "m_count": "1",
+        "m_ip_data": [
+            {
+                "m_type": "IP_PS_KERNEL",
+                "properties": "0x0",
+                "m_base_address": "not_used",
+                "m_name": "kernel0:scu_0"
+            }
+        ]
+    }
+}

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/mem_topology_psk_expected.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/mem_topology_psk_expected.json
@@ -1,0 +1,14 @@
+{
+    "mem_topology": {
+        "m_count": "1",
+        "m_mem_data": [
+            {
+                "m_type": "MEM_PS_KERNEL",
+                "m_used": "1",
+                "m_sizeKB": "0x0",
+                "m_tag": "MEM_PS_KERNEL",
+                "m_base_address": "0x0"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Problem solved by the commit
xclbinutil would error out when attempting to add a PS Kernel to an xclbin container if any of the RTD (Runtime Data) sections (e.g., MEM_TOPOLOGY, IP_LAYOUT, CONNECTIVITY, and EMBEDDED_METADATA) were empty.  This error (an exception) was produced when the boost method get_child() could not find the property tree entry.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This code was present since this feature was added a few months ago.

#### How problem was solved, alternative solutions (if any) and why they were rejected
A default empty property tree is used with the get_child() method.  If the node is not present, this tree will be returned.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manual tested and unit-tests added.

#### Documentation impact (if any)
None