### PR TITLE
generate apu package as part of the build_edge script

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -350,6 +350,13 @@ echo dnf --disablerepo=\"*\" reinstall -y *.rpm | sed -e "s/\<$xrt_dbg\>//g" | s
 cp $ORIGINAL_DIR/$PETALINUX_NAME/rpm.txt $ORIGINAL_DIR/$PETALINUX_NAME/rpms/.
 cp $ORIGINAL_DIR/$PETALINUX_NAME/install_xrt.sh $ORIGINAL_DIR/$PETALINUX_NAME/rpms/.
 cp $ORIGINAL_DIR/$PETALINUX_NAME/reinstall_xrt.sh $ORIGINAL_DIR/$PETALINUX_NAME/rpms/.
+
+if [[ $full == 1 ]]; then
+  mkdir -p $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages
+  export PATH=$PETALINUX/../../tool/petalinux-v$PETALINUX_VER-final/components/yocto/buildtools/sysroots/x86_64-petalinux-linux/usr/bin:$PATH
+  $XRT_REPO_DIR/src/runtime_src/tools/scripts/pkgapu.sh -output $ORIGINAL_DIR/$PETALINUX_NAME/apu_packages -images $ORIGINAL_DIR/$PETALINUX_NAME/images/linux/
+fi
+
 cd $ORIGINAL_DIR
 
 eval "$SAVED_OPTIONS"; # Restore shell options


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- Generating apu package requires two steps today
     - run build_edge.sh -aarch versal -full
     - pkg_apu.sh script with images generated from build_edge.sh
     
-    Generating apu package also as part of the build_edge.sh itself sothat users dont need to run two steps

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Ease of Use. We are giving this script to devops to generate the apu package

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
built apu package using build_edge.sh -aarch versal -full

#### Documentation impact (if any)
No