### PR TITLE
Hardcoding Petalinux build path to 0131 build

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,1 @@
-PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_daily_latest/tool/petalinux-v2022.1-final"
+PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_01312336/tool/petalinux-v2022.1-final"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- Hardcoding the Petalinux build path to 0131 build path. 
- Don't want to use petalinux_daily_latest to build the APU package as it can break anytime.
- Manual update of this file is required in some interval (mostly bi-weekly) 
- Filed https://jira.xilinx.com/browse/SH-1806 to retain this TA

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
This ensures that there is no petalinux update without our knowledge.

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Built APU Package and verified with this build.

#### Documentation impact (if any)
No