### PR TITLE
Install devtoolset-9 for CentOS7.x

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps.sh
+++ b/src/runtime_src/tools/scripts/xrtdeps.sh
@@ -144,21 +144,21 @@ rh_package_list()
 
     if [ $docker == 0 ]; then
         if [ $FLAVOR == "centos" ]; then
-        # In CentOs kernel-devel and headers with $(uname -r) version 
-        # are not available always which causes xrtdeps to fail if we 
+        # In CentOs kernel-devel and headers with $(uname -r) version
+        # are not available always which causes xrtdeps to fail if we
         # include these packages with specific version.
             RH_LIST+=(\
               kernel-devel \
               kernel-headers \
             )
-        else 
+        else
             RH_LIST+=(\
               kernel-devel-$(uname -r) \
               kernel-headers-$(uname -r) \
             )
         fi
     fi
- 
+
     #dmidecode is only applicable for x86_64
     if [ $ARCH == "x86_64" ]; then
         RH_LIST+=( dmidecode )
@@ -462,7 +462,7 @@ prep_centos8()
     echo "Enabling PowerTools and AppStream repo for CentOS8 ..."
     #minor version of CentOs
     MINOR=`cat /etc/centos-release | awk -F. '{ print $2 }'`
-    if [ -z "$MINOR" ]; then 
+    if [ -z "$MINOR" ]; then
         MINOR=3
     fi
     if [ $MINOR -gt "2" ]; then
@@ -472,7 +472,7 @@ prep_centos8()
         yum config-manager --set-enabled PowerTools
         yum config-manager --set-enabled AppStream
     fi
-      
+
 }
 
 prep_centos()
@@ -555,10 +555,9 @@ install()
             yum install -y devtoolset-7
 	elif [ $MAJOR -lt "8" ]  && [ $FLAVOR != "amzn" ]; then
             if [ $FLAVOR == "centos" ]; then
-                yum --enablerepo=base install -y devtoolset-9
-            else
-                yum install -y devtoolset-9
+                yum install -y centos-release-scl-rh
             fi
+            yum install -y devtoolset-9
 	fi
     fi
 


### PR DESCRIPTION
#### Problem solved by the commit
Fix xrtdeps.sh to remove error when installing devtoolset-9 on
CentOS7.x 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Some pipeline has cached devtoolset-6  and is enabling this on CentOS7.x builds.
In particular http://xcoengvm229019:8080/job/XBB/job/XRT/job/XRT_PR_Builds/10738/execution/node/145/log/?consoleFull
ends up using devtoolset-6 and choke on some more recent c++17 syntax. 

The CentOS7.x pipeline needs to enable the installed devtoolset before running XRT build.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Install centos-release-scl-rh, then devtoolset-9

#### Risks (if any) associated the changes in the commit
Risk of using newer compiler.

#### What has been tested and how, request additional testing if necessary
Local docker builds were run

#### Documentation impact (if any)
Update instructions maybe for how to build XRT on CentOS7.x
