### PR TITLE
Update kernel default address range to 64k

### DIFF
--- a/src/runtime_src/core/common/xclbin_parser.h
+++ b/src/runtime_src/core/common/xclbin_parser.h
@@ -60,7 +60,7 @@ struct kernel_properties
   kernel_type type = kernel_type::none;
   restart_type counted_auto_restart = 0;
   mailbox_type mailbox = mailbox_type::none;
-  size_t address_range = 0;
+  size_t address_range = 0x10000;  // NOLINT, default address range
   bool sw_reset = false;
 
   // opencl specifics


### PR DESCRIPTION
#### Problem solved by the commit
Change kernel_properties::address_range to default 64k.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Normally address range is extracted from XML meta data in xclbin and
returned to core XRT in a kernel_property struct.  For some RTL
kernels, the XML section may not be present, but kernel properties are
still created used by xrt::ip to determine the address range.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The address range should be be meta data in xclbin one way or another,
and defaulting to 64k should not be done.  However, we still have to
figure out where address range can be maintained for kernels without
XML metadata.

#### Risks (if any) associated the changes in the commit
Affects only kernels without XML metadata and when used with xrt::ip.  Without this 
change xrt::ip cannot even be used with these kernels. 

