### PR TITLE
CR-1120551 Check if Device is NoDMA API is failing for 2022.1

### DIFF
--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -213,7 +213,7 @@ bool
 device::
 is_nodma() const
 {
-  if (!m_cdevice)
+  if (!m_xdevice)
     throw xocl::error(CL_INVALID_DEVICE, "Can't check for nodma");
 
   // logically const


### PR DESCRIPTION
#### Problem solved by the commit
Fix device nodma check in OpenCL

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fix regression due to #5969.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The core device object is only available after the cl_device has been
locked and opened by the driver.

#### Risks (if any) associated the changes in the commit
None, it didn't work before fix.

#### What has been tested and how, request additional testing if necessary
The CR verified to pass.

