### PR TITLE
Add xrt::bo APIs for getting memory bank and flags

### DIFF
--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -869,7 +869,7 @@ alloc(xclDeviceHandle dhdl, size_t sz, xrtBufferFlags flags, xrtMemoryGroup grp)
     if (is_nodma(dhdl))
       return alloc_nodma(dhdl, sz, flags, grp);
     else if (is_sw_emulation())
-      // In DC scenario, for sw_emu, use the xclAllocBO and xclMapBO instead of xclAllocUserPtrBO, 
+      // In DC scenario, for sw_emu, use the xclAllocBO and xclMapBO instead of xclAllocUserPtrBO,
       // which helps to remove the extra copy in sw_emu.
       return alloc_kbuf(dhdl, sz, flags, grp);
     else
@@ -1108,6 +1108,25 @@ address() const
 {
   return xdp::native::profiling_wrapper("xrt::bo::address", [this]{
     return handle->get_address();
+  });
+}
+
+
+memory_group
+bo::
+get_memory_group() const
+{
+  return xdp::native::profiling_wrapper("xrt::bo::memory_group", [this]{
+    return handle->get_group_id();
+  });
+}
+
+bo::flags
+bo::
+get_flags() const
+{
+  return xdp::native::profiling_wrapper("xrt::bo::get_flags", [this]{
+    return handle->get_flags();
   });
 }
 

--- a/src/runtime_src/core/include/xrt/xrt_bo.h
+++ b/src/runtime_src/core/include/xrt/xrt_bo.h
@@ -34,7 +34,7 @@ typedef void* xrtDeviceHandle;
  * typedef xrtBufferHandle - opaque buffer handle
  */
 typedef void* xrtBufferHandle;
-  
+
 /**
  * typedef xrtBufferFlags - flags for BO
  *
@@ -61,9 +61,9 @@ using memory_group = xrtMemoryGroup;
 
 /**
  * Typed pid_t used to prevent ambiguity when contructing
- * bo with a process id.  
+ * bo with a process id.
  * Use xrt::bo bo{..., pid_type{pid}, ...};
- */  
+ */
 struct pid_type { pid_t pid; };
 
 class bo_impl;
@@ -86,7 +86,7 @@ public:
    * @var svm
    *  Create a BO for SVM (supported on specific platforms only)
    *
-   * The flags used by xrt::bo are compatible with XCL style 
+   * The flags used by xrt::bo are compatible with XCL style
    * flags as define in ``xrt_mem.h``
    */
   enum class flags : uint32_t
@@ -128,9 +128,9 @@ public:
     : bo(dhdl, userptr, sz, static_cast<bo::flags>(flags), grp)
   {}
   /// @endcond
-  
+
   /**
-   * bo() - Constructor with user host buffer 
+   * bo() - Constructor with user host buffer
    *
    * @param dhdl
    *  Device handle
@@ -197,10 +197,10 @@ public:
    *  Device that imports the exported buffer
    * @param ehdl
    *  Exported buffer handle, implementation specific type
-   * 
-   * If the exported buffer handle acquired by using the export() method is 
-   * from another process, then it must be transferred through proper IPC 
-   * mechanism translating the underlying file-descriptor asscociated with 
+   *
+   * If the exported buffer handle acquired by using the export() method is
+   * from another process, then it must be transferred through proper IPC
+   * mechanism translating the underlying file-descriptor asscociated with
    * the buffer, see also constructor taking process id as argument.
    */
   XCL_DRIVER_DLLESPEC
@@ -215,12 +215,12 @@ public:
    *  Process id of exporting process
    * @param ehdl
    *  Exported buffer handle, implementation specific type
-   * 
+   *
    * The exported buffer handle is obtained from exporting process by
    * calling `export()`. This contructor requires that XRT is built on
-   * and running on a system with pidfd support.  Also the importing 
+   * and running on a system with pidfd support.  Also the importing
    * process must have permission to duplicate the exporting process'
-   * file descriptor.  This permission is controlled by ptrace access 
+   * file descriptor.  This permission is controlled by ptrace access
    * mode PTRACE_MODE_ATTACH_REALCREDS check (see ptrace(2)).
    */
   XCL_DRIVER_DLLESPEC
@@ -251,7 +251,7 @@ public:
    * This function allows construction of xrt::bo object from an
    * xclBufferHandle supposedly allocated using deprecated xcl APIs.
    * The buffer handle is allocated with xclAllocBO and must be
-   * freed with xclFreeBO. 
+   * freed with xclFreeBO.
    *
    * Note that argument xclBufferHandle must be wrapped as
    * an xcl_buffer_handle in order to disambiguate the untyped
@@ -307,7 +307,7 @@ public:
   /**
    * size() - Get the size of this buffer
    *
-   * @return 
+   * @return
    *  Size of buffer in bytes
    */
   XCL_DRIVER_DLLESPEC
@@ -317,7 +317,7 @@ public:
   /**
    * address() - Get the device address of this buffer
    *
-   * @return 
+   * @return
    *  Device address of buffer
    */
   XCL_DRIVER_DLLESPEC
@@ -325,15 +325,35 @@ public:
   address() const;
 
   /**
+   * get_memory_group() - Get the memory group in which this buffer is allocated
+   *
+   * @return
+   *  Memory group index with which the buffer was constructed
+   */
+  XCL_DRIVER_DLLESPEC
+  memory_group
+  get_memory_group() const;
+
+  /**
+   * get_flags() - Get the flags with which this buffer was constructed
+   *
+   * @return
+   *  The xrt::bo::Flgas used when the buffer was contructed
+   */
+  XCL_DRIVER_DLLESPEC
+  flags
+  get_flags() const;
+
+  /**
    * buffer_export() - Export this buffer
    *
-   * @return 
+   * @return
    *  Exported buffer handle
    *
    * An exported buffer can be imported on another device by this
    * process or another process. For multiprocess transfer, the exported
    * buffer must be transferred through a proper IPC facility to translate
-   * the underlying file-descriptor properly into another process. 
+   * the underlying file-descriptor properly into another process.
    *
    * The lifetime of the exported buffer handle is associated with the
    * exporting buffer (this).  The handle is disposed of when the
@@ -347,7 +367,7 @@ public:
   export_buffer();
 
   /**
-   * sync() - Synchronize buffer content with device side 
+   * sync() - Synchronize buffer content with device side
    *
    * @param dir
    *  To device or from device
@@ -363,7 +383,7 @@ public:
   sync(xclBOSyncDirection dir, size_t sz, size_t offset);
 
   /**
-   * sync() - Synchronize buffer content with device side 
+   * sync() - Synchronize buffer content with device side
    *
    * @param dir
    *  To device or from device
@@ -393,7 +413,7 @@ public:
    *
    * @tparam MapType
    *  Type of mapped data
-   * @return 
+   * @return
    *  Memory mapped buffer
    */
   template<typename MapType>
@@ -418,7 +438,7 @@ public:
    * of the BO before copying-in ``size`` bytes to host buffer.
    */
   XCL_DRIVER_DLLESPEC
-  void 
+  void
   write(const void* src, size_t size, size_t seek);
 
   /**
@@ -484,7 +504,7 @@ public:
    * Throws if copy size is 0 or sz + src/dst_offset is out of bounds.
    */
   XCL_DRIVER_DLLESPEC
-  void    
+  void
   copy(const bo& src, size_t sz, size_t src_offset=0, size_t dst_offset=0);
 
   /**
@@ -560,10 +580,10 @@ xrtBOAlloc(xrtDeviceHandle dhdl, size_t size, xrtBufferFlags flags, xrtMemoryGro
  *
  * @dhdl:     Device that imports the exported buffer
  * @ehdl:     Exported buffer handle, implementation specific type
- * 
+ *
  * The exported buffer handle is acquired by using the export() method
- * and can be passed to another process.  
- */  
+ * and can be passed to another process.
+ */
 XCL_DRIVER_DLLESPEC
 xrtBufferHandle
 xrtBOImport(xrtDeviceHandle dhdl, xclBufferExportHandle ehdl);
@@ -585,7 +605,7 @@ xrtBOExport(xrtBufferHandle bhdl);
  * xrtBOSubAlloc() - Allocate a sub buffer from a parent buffer
  *
  * @parent:        Parent buffer handle
- * @size:          Size of sub buffer 
+ * @size:          Size of sub buffer
  * @offset:        Offset into parent buffer
  * Return:         xrtBufferHandle on success or NULL
  */
@@ -593,7 +613,7 @@ XCL_DRIVER_DLLESPEC
 xrtBufferHandle
 xrtBOSubAlloc(xrtBufferHandle parent, size_t size, size_t offset);
 
-/* 
+/*
  * xrtBOAllocFromXcl() - Undocumented allocation from an xclBufferHandle
  *
  * @dhdl:  XRT device handle on which the buffer is residing.
@@ -605,7 +625,7 @@ xrtBOSubAlloc(xrtBufferHandle parent, size_t size, size_t offset);
  * xclBufferHandle.
  *
  * Please note that the device is an xrtDeviceHandle.  It is the
- * responsibility of the user to convert an xclDeviceHandle to 
+ * responsibility of the user to convert an xclDeviceHandle to
  * an xrtDeviceHandle before calling this API.
  *
  * The xrtBufferHandle returned by this API
@@ -729,7 +749,7 @@ XCL_DRIVER_DLLESPEC
 int
 xrtBOCopy(xrtBufferHandle dst, xrtBufferHandle src, size_t sz, size_t dst_offset, size_t src_offset);
 
-/// @endcond  
+/// @endcond
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
#### Problem solved by the commit
Per request provide access to the flags and memory group used when the
buffer object was constructed.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Accessors were already available in implementation, just expose these
in class xrt::bo.
