### PR TITLE
CR-1120156 OpenCL DMA can cause memory leakage (Out of memory: Kill p…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/lib/libxdma.c
@@ -3351,6 +3351,12 @@ ssize_t xdma_xfer_fastpath(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			       (unsigned long)(&engine->regs->control_w1c) -
 			       (unsigned long)(&engine->regs));
 	}
+	if (!dma_mapped) {
+                pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
+                             engine->dir);
+                sgt->nents = 0;
+        }
+
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
…rocess)

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
memory leak within xdma
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
missed pci_unmap_sg
#### How problem was solved, alternative solutions (if any) and why they were rejected
added pci_unmap_sg
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
dma.cpp attached in the CR
#### Documentation impact (if any)
