### PR TITLE
CR-1119807 - Fix writing data to fd from xclExportBO api

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -721,11 +721,7 @@ static struct drm_driver zocl_driver = {
 	.prime_fd_to_handle        = drm_gem_prime_fd_to_handle,
 	.gem_prime_import          = zocl_gem_import,
 	.gem_prime_import_sg_table = drm_gem_cma_prime_import_sg_table,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
 	.gem_prime_mmap            = drm_gem_prime_mmap,
-#else
-	.gem_prime_mmap            = drm_gem_cma_prime_mmap,
-#endif
 	.ioctls                    = zocl_ioctls,
 	.num_ioctls                = ARRAY_SIZE(zocl_ioctls),
 	.fops                      = &zocl_driver_fops,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
> writing to fd using mmap exported from xclExportBO is not working in edge platforms

#### How problem was solved, alternative solutions (if any) and why they were rejected
> callback for gem_prime_mmap is set to drm_gem_prime_mmap which handles both cma and non cma memory

#### Risks (if any) associated the changes in the commit
> none

#### What has been tested and how, request additional testing if necessary
> tested with dpu example and things are working as expected

#### Documentation impact (if any)
