### PR TITLE
PS Kernel - Bug fix: Embedded Metadate kernel type not being set to "ps"

### DIFF
--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -119,7 +119,7 @@ void buildXMLKernelEntry(const boost::property_tree::ptree& ptKernel,
   boost::property_tree::ptree ptKernelAttributes;
   ptKernelAttributes.put("name", kernelName);
   ptKernelAttributes.put("language", "c");
-  ptKernelAttributes.put("type", "dpu");
+  ptKernelAttributes.put("type", isFixedPS ? "dpu" : "ps");
   ptKernelXML.add_child("<xmlattr>", ptKernelAttributes);
 
   // -- Build kernel arguments

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
@@ -66,7 +66,7 @@
         </kernel>
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_32_0_M13_AXI" dstType="kernel" dstInst="vadd_1" dstPort="S_AXI_CONTROL"/>
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_64_0_S02_AXI" dstType="kernel" dstInst="vadd_1" dstPort="M_AXI_GMEM"/>
-        <kernel name="kernel0" language="c" type="dpu">
+        <kernel name="kernel0" language="c" type="ps">
           <arg name="arg0" addressQualifier="1" id="0" size="0x10" offset="0x0" hostOffset="0x0" hostSize="0x10" type="float*"/>
           <arg name="arg1" addressQualifier="1" id="1" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
           <arg name="arg2" addressQualifier="1" id="2" size="0x10" offset="0x20" hostOffset="0x0" hostSize="0x10" type="float*"/>

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
@@ -3,7 +3,7 @@
   <platform>
     <device>
       <core>
-        <kernel name="kernel0" language="c" type="dpu">
+        <kernel name="kernel0" language="c" type="ps">
           <arg name="arg0" addressQualifier="1" id="0" size="0x10" offset="0x0" hostOffset="0x0" hostSize="0x10" type="float*"/>
           <arg name="arg1" addressQualifier="1" id="1" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
           <arg name="arg2" addressQualifier="1" id="2" size="0x10" offset="0x20" hostOffset="0x0" hostSize="0x10" type="float*"/>


### PR DESCRIPTION
#### Problem solved by the commit
When added a PS Kernel to an xclbin image, its kernel type was incorrectly being set.  This fix addresses this issue by setting it to "ps".

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug has already been in the code since PS kernel support was added.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Simple code change to set the kernel type to "ps".

#### Risks (if any) associated the changes in the commit
Low to none

#### What has been tested and how, request additional testing if necessary
Manual testing and updated the regression unit tests.

#### Documentation impact (if any)
n/a