### PR TITLE
CR-1117142 Add platform PCIe speed/width to XRT C++ device info API

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -288,8 +288,10 @@ pcie_info(const xrt_core::device * device)
     ptree.add("device", xq::pcie_device::to_string(xrt_core::device_query<xq::pcie_device>(device)));
     ptree.add("sub_device", xq::pcie_subsystem_id::to_string(xrt_core::device_query<xq::pcie_subsystem_id>(device)));
     ptree.add("sub_vendor", xq::pcie_subsystem_vendor::to_string(xrt_core::device_query<xq::pcie_subsystem_vendor>(device)));
-    ptree.add("link_speed_gbit_sec", xrt_core::device_query<xq::pcie_link_speed_max>(device));
+    ptree.add("link_speed_gbit_sec", xrt_core::device_query<xq::pcie_link_speed>(device));
+    ptree.add("expected_link_speed_gbit_sec", xrt_core::device_query<xq::pcie_link_speed_max>(device));
     ptree.add("express_lane_width_count", xrt_core::device_query<xq::pcie_express_lane_width>(device));
+    ptree.add("expected_express_lane_width_count", xrt_core::device_query<xq::pcie_express_lane_width_max>(device));
 
     // dma_thread_count might not be present for nodma, but it is safe to ignore.
     try {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Added _expected_ link speed and lane width

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
```
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Fri Feb  4 20:17:45 2022 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:b3:00.1",
            "pcie_info": {
                "vendor": "0x10ee",
                "device": "0x5001",
                "sub_device": "0x000e",
                "sub_vendor": "0x10ee",
                "link_speed_gbit_sec": "3",
                "expected_link_speed_gbit_sec": "3",
                "express_lane_width_count": "16",
                "expected_express_lane_width_count": "16",
                "dma_thread_count": "2",
                "cpu_affinity": "0-15",
                "max_shared_host_mem_aperture_bytes": "16 GB",
                "shared_host_mem_size_bytes": "128 MB",
                "enabled_host_mem_size_bytes": "128 MB"
            }
        }
    ]
}
```
#### Documentation impact (if any)
None