### PR TITLE
CR-1121351 ASTeR Basic Sanity json file not created when "r all" option is used

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -210,7 +210,12 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   // Create the report
   std::ostringstream oSchemaOutput;
-  XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
+  bool is_report_output_valid = true;
+  try {
+    XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
+  } catch (const std::exception&) {
+    is_report_output_valid = false;
+  }
 
   // -- Write output file ----------------------------------------------
   if (!sOutput.empty()) {
@@ -223,4 +228,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
     std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
   }
+
+  if (!is_report_output_valid)
+    throw xrt_core::error(std::errc::operation_canceled);
 }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -234,7 +234,12 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
   // Create the report
   std::ostringstream oSchemaOutput;
-  XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
+  bool is_report_output_valid = true;
+  try {
+    XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
+  } catch (const std::exception&) {
+    is_report_output_valid = false;
+  }
 
   // -- Write output file ----------------------------------------------
   if (!sOutput.empty()) {
@@ -249,4 +254,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
 
     std::cout << boost::format("Successfully wrote the %s file: %s") % sFormat % sOutput << std::endl;
   }
+
+  if (!is_report_output_valid)
+    throw xrt_core::error(std::errc::operation_canceled);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1121351
Output file is not generated whenever an xbutil or xbmgmt encounter an error while generating the report.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
A failed test report would not generate an output file when requested. Introduced in https://github.com/Xilinx/XRT/pull/6169

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a throw whenever a report is produced to catch the condition rather than exiting.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manually tested via force pushing
Error in IP config report
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -d 65:00 -f JSON -o /tmp/x.json -r all --force
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-97-generic
  Version              : #110-Ubuntu SMP Thu Jan 13 18:22:13 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1121351
  Hash                 : 6c8d9c966f8c4071cd6488076c316431462c0738
  Hash Date            : 2022-02-07 11:57:19
  XOCL                 : 2.13.363, bad180f7a001d8c4daba3b2cd80f3774c0cf1312
  XCLMGMT              : 2.13.363, bad180f7a001d8c4daba3b2cd80f3774c0cf1312

Devices present
  [0000:65:00.1] : xilinx_u280_xdma_201920_3 user(inst=130)
  [0000:17:00.1] : xilinx_u250_gen3x16_xdma_shell_4_1 user(inst=128)


-----------------------------------------------
1/1 [0000:65:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
AIE
  <AIE information unavailable>


Xclbin UUID
  00000000-0000-0000-0000-000000000000

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status

 INFO: Debug IP Data is not populated.
 INFO: Debug IP Data is not populated.
Debug IP Status
  Number of IPs found :: Debug-ip-status
  ERROR: No such node (total_num_debug_ips)
Pcie Info
  Vendor                 : 0x10ee
  Device                 : 0x500d
  Sub Device             : 0x000e
  Sub Vendor             : 0x10ee
  PCIe                   : Gen3x16
  DMA Thread Count       : 2
  CPU Affinity           : 0-15
  Shared Host Memory     : 0 Byte
  Max Shared Host Memory : 0 Byte
  Enabled Host Memory    : 0

Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : disabled

Mac Addresses            : 01:02:03:04:05:06
                         : 01:02:03:04:05:07

Electrical
  Max Power              : 225 Watts
  Power                  : 335.561652 Watts
  Power Warning          : false

  Power Rails            : Voltage   Current
  12 Volts Auxillary     : 13.710 V, 14.089 A
  12 Volts PCI Express   : 14.182 V, 10.041 A
  3.3 Volts PCI Express  :  3.683 V
  3.3 Volts Auxillary    :  2.670 V
  Internal FPGA Vcc      :  0.851 V,  8.802 A
  DDR Vpp Bottom         :  2.500 V
  DDR Vpp Top            :  2.500 V
  5.5 Volts System       :  6.221 V
  Vcc 1.2 Volts Top      :  1.347 V
  Vcc 1.2 Volts Bottom   :  1.334 V
  1.8 Volts Top          :  1.996 V
  0.9 Volts Vcc          :  1.011 V
  12 Volts SW            : 13.735 V
  Mgt Vtt                :  1.341 V

Mailbox
  Total bytes received   : 889664 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 0
  Firewall trip          : 0
  Download xclbin kaddr  : 0
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 0
  User probe             : 0
  Mgmt state             : 5
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0

Mechanical
  Fans
    FPGA Fan 1
      Critical Trigger Temp : 40 C
      Speed                 : 1283 RPM

Firewall
  Level 0 : 0x0 (GOOD)

Thermals
  PCB Top Front          : 40 C
  PCB Top Rear           : 32 C
  FPGA                   : 46 C
  FPGA HBM               : 41 C

  Primary                : Invalid
  Recovery               : Disabled

CMC
  Status : 0x0 (GOOD)
  Runtime clock scaling feature :
    Supported : false
    Enabled : false
    Critical threshold (clock shutdown) limits:
      Power : 0 W
      Temperature : 0 C
    Throttling threshold limits:
      Power : 0 W
      Temperature : 0 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
Successfully wrote the JSON file: /tmp/x.json
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ touch /tmp/x.json
```
Successful Thermal report
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -d 65:00 -f JSON -o /tmp/x.json -r thermal --force

-----------------------------------------------
1/1 [0000:65:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Thermals
  PCB Top Front          : 39 C
  PCB Top Rear           : 32 C
  FPGA                   : 46 C
  FPGA HBM               : 41 C

Successfully wrote the JSON file: /tmp/x.json
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ cat /tmp/x.json
{
    "schema_version": {
        "schema": "JSON",
        "creation_date": "Mon Feb  7 20:53:30 2022 GMT"
    },
    "devices": [
        {
            "interface_type": "pcie",
            "device_id": "0000:65:00.1",
            "thermals": [
                {
                    "location_id": "pcb_top_front",
                    "description": "PCB Top Front",
                    "temp_C": "39",
                    "is_present": "true"
                },
                {
                    "location_id": "pcb_top_rear",
                    "description": "PCB Top Rear",
                    "temp_C": "32",
                    "is_present": "true"
                },
                {
                    "location_id": "pcb_bottom_front",
                    "description": "PCB Bottom Front",
                    "temp_C": "0",
                    "is_present": "false"
                },
                {
                    "location_id": "cage_temp_0",
                    "description": "Cage0",
                    "temp_C": "0",
                    "is_present": "false"
                },
                {
                    "location_id": "cage_temp_1",
                    "description": "Cage1",
                    "temp_C": "0",
                    "is_present": "false"
                },
                {
                    "location_id": "cage_temp_2",
                    "description": "Cage2",
                    "temp_C": "0",
                    "is_present": "false"
                },
                {
                    "location_id": "cage_temp_3",
                    "description": "Cage3",
                    "temp_C": "0",
                    "is_present": "false"
                },
                {
                    "location_id": "fpga0",
                    "description": "FPGA",
                    "temp_C": "46",
                    "is_present": "true"
                },
                {
                    "location_id": "int_vcc",
                    "description": "Int Vcc",
                    "temp_C": "0",
                    "is_present": "false"
                },
                {
                    "location_id": "fpga_hbm",
                    "description": "FPGA HBM",
                    "temp_C": "41",
                    "is_present": "true"
                }
            ]
        }
    ]
}
```
xbmgmt failure
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ ./xbmgmt2 examine -r all -d 65:00 -o x.json -f JSON --force
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-97-generic
  Version              : #110-Ubuntu SMP Thu Jan 13 18:22:13 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1121351
  Hash                 : 6c8d9c966f8c4071cd6488076c316431462c0738
  Hash Date            : 2022-02-07 11:57:19
  XOCL                 : 2.13.363, bad180f7a001d8c4daba3b2cd80f3774c0cf1312
  XCLMGMT              : 2.13.363, bad180f7a001d8c4daba3b2cd80f3774c0cf1312

Devices present
  [0000:65:00.0] : xilinx_u280_xdma_201920_3 mgmt(inst=25856)
  [0000:17:00.0] : xilinx_u250_gen3x16_xdma_shell_4_1 mgmt(inst=5888)


-----------------------------------------------
1/1 [0000:65:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Platform
  ERROR: Root privileges required
Mechanical
  Fans
    FPGA Fan 1
      Critical Trigger Temp : 40 C
      Speed                 : 1280 RPM

Firewall
  Level 0 : 0x0 (GOOD)

Mailbox
  Total bytes received   : 439168 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 7
  Firewall trip          : 0
  Download xclbin kaddr  : 0
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 3424
  User probe             : 7
  Mgmt state             : 0
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0

CMC
  Status : 0x0 (GOOD)
  Runtime clock scaling feature :
    Supported : false
    Enabled : false
    Critical threshold (clock shutdown) limits:
      Power : 0 W
      Temperature : 0 C
    Throttling threshold limits:
      Power : 0 W
      Temperature : 0 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
Successfully wrote the JSON file: x.json
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ echo $?
1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ touch x.json
```
xbmgmt success
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ ./xbmgmt2 examine -r firewall -d 65:00 -o /tmp/x.json -f JSON --force

-----------------------------------------------
1/1 [0000:65:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Firewall
  Level 0 : 0x0 (GOOD)

Successfully wrote the JSON file: /tmp/x.json
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ echo $?
0
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/runtime_src/core/tools/xbmgmt2$ touch /tmp/x.json
```