### PR TITLE
CR-1120790 ASTeR TS04 +07 - u50, u250 - xbutil validate fails during verify test while ERT is disabled

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_ert.h
+++ b/src/runtime_src/core/include/xgq_cmd_ert.h
@@ -213,6 +213,7 @@ struct xgq_cmd_config_end {
  * @haddr: higher 32 bits of the CU address
  * @payload_size: CU XGQ slot payload size
  * @name: name of the CU
+ * @uuid: UUID of the XCLBIN of the CU
  *
  * Configure PL/PS CUs.
  */
@@ -230,6 +231,7 @@ struct xgq_cmd_config_cu {
 	uint32_t haddr;
 	uint32_t payload_size;
 	char name[64];
+	char uuid[16];
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/command_queue.c
@@ -669,6 +669,11 @@ static int command_queue_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, cmd_queue);
 
 	priv = XOCL_GET_SUBDEV_PRIV(&pdev->dev);
+	if (!priv) {
+		xocl_err(&pdev->dev, "Cannot get subdev priv");
+		err = -EINVAL;
+		goto done;
+	}
 	cmd_queue->cq_range = priv->cq_range;
 	cmd_queue->cq_base = priv->cq_base;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -498,7 +498,7 @@ static inline int ert_ctrl_alloc_ert_xgq(struct ert_ctrl *ec, int num)
 	if (num <= ec->ec_exgq_capacity)
 		return 0;
 
-	tmp = kzalloc(sizeof(void *) * num, GFP_KERNEL);
+	tmp = kzalloc(sizeof(ec->ec_exgq[0]) * num, GFP_KERNEL);
 	if (!tmp)
 		return -ENOMEM;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -793,10 +793,8 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 	void *hdl = NULL;
 
 	ec = platform_get_drvdata(pdev);
-	if (!ec) {
-		EC_ERR(ec, "ec is null");
+	if (!ec)
 		return -EINVAL;
-	}
 
 	if (ec->ec_connected)
 		ert_ctrl_disconnect(pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -473,7 +473,7 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 	if (kds->xgq_enable)
 		return true;
 
-	if (!kds->ert_disable && (kds->ert->slot_size < pkg_size)) {
+	if ((kds->ert->slot_size > 0) && (kds->ert->slot_size < pkg_size)) {
 		userpf_err(xdev, "payload size bigger than CQ slot size\n");
 		return false;
 	}
@@ -1633,6 +1633,11 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 	/* Don't send config command if ERT doesn't present */
 	if (!XDEV(xdev)->kds.ert)
 		goto create_regular_cu;
+
+	if (!cfg.ert) {
+		XDEV(xdev)->kds.ert_disable = true;
+		goto create_regular_cu;
+	}
 
 	ret = xocl_kds_xgq_cfg_start(xdev, cfg, num_cus);
 	if (ret)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1285,8 +1285,10 @@ xocl_kds_fill_cu_info(struct xocl_dev *xdev, struct xrt_cu_info *cu_info,
 	 * - protocol
 	 */
 	XOCL_GET_IP_LAYOUT(xdev, ip_layout);
+	if (!ip_layout)
+		goto done;
+
 	num_cus = kds_ip_layout2cu_info(ip_layout, cu_info, num_info);
-	XOCL_PUT_MEM_TOPOLOGY(xdev);
 
 	/*
 	 * Get CU metadata from XML,
@@ -1320,6 +1322,8 @@ xocl_kds_fill_cu_info(struct xocl_dev *xdev, struct xrt_cu_info *cu_info,
 		cu_info[i].args = (struct xrt_cu_arg *)krnl_info->args;
 	}
 
+done:
+	XOCL_PUT_IP_LAYOUT(xdev);
 	return num_cus;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_xgq.c
@@ -128,7 +128,7 @@ int xocl_xgq_get_response(void *xgq_handle, int id)
 	if (xgq->xx_num_client == 1)
 		goto unlock_and_out;
 
-	xocl_xgq_read_queue((u32 *)&resp, (u32 __iomem *)addr, sizeof(resp));
+	xocl_xgq_read_queue((u32 *)&resp, (u32 __iomem *)addr, sizeof(resp)/4);
 
 unlock_and_out:
 	xgq_notify_peer_consumed(&xgq->xx_xgq);
@@ -171,8 +171,10 @@ void *xocl_xgq_init(struct xocl_xgq_info *info)
 	ret = xgq_attach(&xgq->xx_xgq, 0, 0, (u64)xgq->xx_addr,
 			 (u64)(uintptr_t)info->xi_sq_prod,
 			 (u64)(uintptr_t)info->xi_cq_prod);
-	if (ret)
+	if (ret) {
+		kfree(xgq);
 		return (ERR_PTR(-ENODEV));
+	}
 
 #if 0
 	printk("sq prod 0x%llx\n", (u64)(uintptr_t)info->xi_sq_prod);

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -280,13 +280,13 @@ int testMultiThreads(std::string &dev, std::string &xclbin_fn, int threadNumber,
     /* calculate performance */
     int overallCommands = 0;
     double duration;
-    std::ios_base::fmtflags f(cout.flags());
+    std::ios_base::fmtflags f(std::cout.flags());
     for (int i = 0; i < threadNumber; i++) {
         /* For some special case, memory bank is too small to allocate buffers.
          * Return not support error code if a thread has 0 command buffer.
          */
         if (arg[i].total == 0) {
-            cout.flags(f); // restore format
+            std::cout.flags(f); // restore format
             return EOPNOTSUPP;
         }
 
@@ -307,7 +307,7 @@ int testMultiThreads(std::string &dev, std::string &xclbin_fn, int threadNumber,
               << " IOPS: " << (overallCommands * 1000000.0 / duration)
               << " (" << krnl.name << ")"
               << std::endl;
-    cout.flags(f); // restore format
+    std::cout.flags(f); // restore format
     return 0;
 }
 

--- a/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
+++ b/tests/validate/xcl_iops_test/src/xcl_api_iops.cpp
@@ -197,6 +197,8 @@ void runTestThread(arg_t &arg)
     auto xclbin = load_file_to_memory(arg.xclbin_fn);
     auto top = reinterpret_cast<const axlf*>(xclbin.data());
     auto topo = xclbin::get_axlf_section(top, MEM_TOPOLOGY);
+    if (!topo)
+        throw std::runtime_error("MEM_TOPOLOGY not found in XCLBIN");
     auto topology = reinterpret_cast<mem_topology*>(xclbin.data() + topo->m_sectionOffset);
     if (xclLoadXclBin(handle, top))
         throw std::runtime_error("Bitstream download failed");
@@ -278,12 +280,15 @@ int testMultiThreads(std::string &dev, std::string &xclbin_fn, int threadNumber,
     /* calculate performance */
     int overallCommands = 0;
     double duration;
+    std::ios_base::fmtflags f(cout.flags());
     for (int i = 0; i < threadNumber; i++) {
         /* For some special case, memory bank is too small to allocate buffers.
          * Return not support error code if a thread has 0 command buffer.
          */
-        if (arg[i].total == 0)
+        if (arg[i].total == 0) {
+            cout.flags(f); // restore format
             return EOPNOTSUPP;
+        }
 
         if (verbose) {
             duration = (std::chrono::duration_cast<ms_t>(arg[i].end - arg[i].start)).count();
@@ -302,6 +307,7 @@ int testMultiThreads(std::string &dev, std::string &xclbin_fn, int threadNumber,
               << " IOPS: " << (overallCommands * 1000000.0 / duration)
               << " (" << krnl.name << ")"
               << std::endl;
+    cout.flags(f); // restore format
     return 0;
 }
 
@@ -361,6 +367,9 @@ int _main(int argc, char* argv[])
 
     if (threadNumber <= 0)
         throw std::runtime_error("Invalid thread number");
+
+    if (threadNumber > 1024)
+        throw std::runtime_error("Invalid thread number. Do not larger than 1024");
 
     if (flag_s) {
         if (!infile.good()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Fix CR-1120790, when ert=false, xclExecbuf failed
2. Add UUID into config CU command
3. Fix some coverity issues

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
1. When ert=false, xclExecbuf go check slot size, which is 0 if XGQ is used. Then it failed.
2. Need UUID in config CU command to let device be able to identify XCLBIN of the CU.

#### How problem was solved, alternative solutions (if any) and why they were rejected
If ert=false, then don't config XGQ ERT and use KDS mode.

#### Risks (if any) associated the changes in the commit
No see any risks.

#### What has been tested and how, request additional testing if necessary
xbutil validate on u50 and versal discovery shell.

#### Documentation impact (if any)
No