### PR TITLE
CR-1120377 File path could not be auto-completion on bash shell

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
@@ -1,6 +1,6 @@
 # bash completion for xbmgmt                              -*- shell-script -*-
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #
 
 # Generates the command word options dependant on the previous word

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
@@ -105,7 +105,7 @@ _xbmgmt_completion()
 
 COMP_FILE="/usr/share/bash-completion/bash_completion"
 if [ -f "${COMP_FILE}" ]; then
-  source /usr/share/bash-completion/bash_completion
+  bash /usr/share/bash-completion/bash_completion
   complete -F _xbmgmt_completion xbmgmt
   echo Autocomplete enabled for the xbmgmt command
 else

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
@@ -13,44 +13,53 @@
 _command_word_xbmgmt_completion()
 {
   # Get the righthand most word on the command line
-  currentWord=${COMP_WORDS[COMP_CWORD]}
-  # The previous word is used 
-  previousWord=${COMP_WORDS[COMP_CWORD-1]}
+  local cur=${COMP_WORDS[COMP_CWORD]}
+  # The previous word 
+  local prev=${COMP_WORDS[COMP_CWORD-1]}
+
+  # The BDFs (for devices) contain colons which breaks the autocomplete
+  # to get around this a helper function removes colons and helps parse the current and previous
+  # words
+  _get_comp_words_by_ref -n : cur prev
+
   # Each defined case requires an argument so no reply is given
   # All other cases default to using `compgen` output to format COMPREPLY
-  case ${previousWord} in
-    --device)
+  case ${prev} in
+    -d|--device)
+      options=$(xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p')
       ;;
-    -d)
+    -u|--user)
+      _filedir
+      options=""
       ;;
-    --user)
+    -f|--format)
+      options="JSON JSON-2020.2"
       ;;
-    -u)
+    -o|--output)
+      _filedir
+      options=""
       ;;
-    --run)
-      ;;
-    --format)
-      ;;
-    -f)
-      ;;
-    --output)
-      ;;
-    -o)
-      ;;
-    --report)
-      ;;
-    -r)
+    -r|--report)
+      options=$(xbmgmt examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
       ;;
     --shell)
+      _filedir
+      options=""
       ;;
     --image)
+      _filedir
+      options=""
       ;;
     *)
-      # The format of the compgen commands options is seperated from the current word using a --.
-      # The -- character signifies the end of command options. All following arguments are positional.
-      COMPREPLY=($(compgen -W "$1" -- ${currentWord}))
+      # Default to using the passed in options if no particular option is used
+      options=$1
       ;;
   esac
+  # The format of the compgen commands options is seperated from the current word using a --.
+  # The -- character signifies the end of command options. All following arguments are positional.
+  COMPREPLY+=($(compgen -W "$options" -- $cur))
+  # 2nd part of getting aroudn colons in the suggested keywords
+  __ltrim_colon_completions "$cur"
 }
 
 # The main function populating the COMPREPLY
@@ -63,8 +72,7 @@ _xbmgmt_completion()
   case ${COMP_CWORD} in
     # Case for command after xbutil
     1)
-      commandWordOptions="dump examine program reset ${commonSubCommands}"
-      _command_word_xbmgmt_completion "${commandWordOptions}"
+      options="dump examine program reset ${commonSubCommands}"
       ;;
     # Case for options after the above command is entered
     *)
@@ -75,20 +83,16 @@ _xbmgmt_completion()
       # Once a command is identified the options will always be the same
       case ${commandWord} in
         "dump")
-          dumpOptions="--flash -f --config -c --output -o ${commonSubCommands}"
-          _command_word_xbmgmt_completion "${dumpOptions}"
+          options="--flash -f --config -c --output -o ${commonSubCommands}"
           ;;
         "examine")
-          examineOptions="--report -r --format -f --output -o ${commonSubCommands}"
-          _command_word_xbmgmt_completion "${examineOptions}"
+          options="--report -r --format -f --output -o ${commonSubCommands}"
           ;;
         "program")
-          programOptions="--base --image --shell --user -u --revert-to-golden ${commonSubCommands}"
-          _command_word_xbmgmt_completion "${programOptions}"
+          options="--base --image --shell --user -u --revert-to-golden ${commonSubCommands}"
           ;;
         "reset")
-          resetOptions="${commonSubCommands}"
-          _command_word_xbmgmt_completion "${resetOptions}"
+          options="${commonSubCommands}"
           ;;
         # Return an empty reply if an invalid command is entered
         *)
@@ -96,6 +100,7 @@ _xbmgmt_completion()
       esac
       ;;
   esac
+  _command_word_xbmgmt_completion "${options}"
 }
 
 complete -F _xbmgmt_completion xbmgmt

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-bash-completion
@@ -103,7 +103,13 @@ _xbmgmt_completion()
   _command_word_xbmgmt_completion "${options}"
 }
 
-complete -F _xbmgmt_completion xbmgmt
-echo Autocomplete enabled for the xbmgmt command
+COMP_FILE="/usr/share/bash-completion/bash_completion"
+if [ -f "${COMP_FILE}" ]; then
+  source /usr/share/bash-completion/bash_completion
+  complete -F _xbmgmt_completion xbmgmt
+  echo Autocomplete enabled for the xbmgmt command
+else
+  echo ${COMP_FILE} missing! Autocomplete disabled for the xbmgmt command
+fi
 
 # ex: filetype=sh

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-csh-completion
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-csh-completion
@@ -1,19 +1,25 @@
 #!/bin/csh -f
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #
 
 # parse out required variables
 set list = "$COMMAND_LINE"
 # The command word associated with this xbutil invocation
 set commandWord = `echo $list | awk 'BEGIN{FS=" "}{print $2}'`
-# Get the number of arguments. This script turns spaces into commas to count
-# the number of commands. It only really matters for the first couple
-set argsplit=(`echo "$list" | sed -e "s/ /,/g"`)
-set argsplit=(`echo "$argsplit" | sed "s/[a-zA-Z']//g"`)
-set commandCount = (`echo $argsplit | awk '{print length($0)}'`)
+# Get the number of arguments. This script turns spaces into ampersands to count
+# the number of commands. This script is NOT space in path name friendly.
+set argsplit=(`echo "$list" | sed -e "s/ /@/g"`)
+# All non essential characters are removed here (Like hypens) so all definitions below do not have hyphens!
+set argsplit=(`echo "$argsplit" | sed "s/[^a-zA-Z0-9@/']//g"`)
+# Remove all alphanumeric characters and leave only the ampersands for word count
+set argsplit_counter=(`echo "$argsplit" | sed "s/[a-zA-Z0-9/']//g"`)
+# The number of characters left (which is only ampersands) determines the number of words in the argument list.
+# In case it was missed above this is not a space friendly script.
+set commandCount = (`echo $argsplit_counter | awk '{print length($0)}'`)
+set previousWord = `echo $argsplit | awk 'BEGIN{FS="@"}{NF=NF-1;print $NF}'`
 # This is the word on the righthand side
-set currentWord = `echo $list | awk 'BEGIN{FS=" "}{print $NF}'`
+set currentWord = `echo $argsplit | awk 'BEGIN{FS="@"}{print $NF}'`
 
 # The options for the current command line statement
 set programOptions = "--verbose --batch --force --help -h --version"
@@ -45,50 +51,20 @@ else
   endsw
 
   # If the current word requires an argument, clear the option list
-  switch($currentWord)
-    case "--device":
-      set programOptions=""
+  # If an option is "missing" from this list check the wrapper. It is most likely defined there as a 
+  # file search completion
+  switch($previousWord)
+    case "device":
+    case "d":
+      set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'`)
       breaksw
-    case "-d":
-      set programOptions=""
+    case "format":
+    case "f":
+      set programOptions="JSON JSON-2020.2"
       breaksw
-    case "--user":
-      set programOptions=""
-      breaksw
-    case "-u":
-      set programOptions=""
-      breaksw
-    case "--run":
-      set programOptions=""
-      breaksw
-    case "--format":
-      set programOptions=""
-      breaksw
-    case "-f":
-      set programOptions=""
-      breaksw
-    case "--output":
-      set programOptions=""
-      breaksw
-    case "-o":
-      set programOptions=""
-      breaksw
-    case "--report":
-      set programOptions=""
-      breaksw
-    case "--type":
-      set programOptions=""
-      breaksw
-    case "-t":
-      set programOptions=""
-      breaksw
-    # -r shorthand applies to multiple commands under xbutil and requires additional processing
-    # Assuming we want to add something here one day
-    case "-r":
-      set programOptions=""
-      breaksw
-    case "--image":
-      set programOptions=""
+    case "report":
+    case "r":
+      set programOptions=(`xbmgmt examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p'`)
       breaksw
     # do not modify the option list if the argument is not required
     default:

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-csh-completion-wrapper
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-csh-completion-wrapper
@@ -1,6 +1,6 @@
 #!/bin/csh -f
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #
 
 # Enable autocompletion for the xbutil and xbmgmt commands

--- a/src/runtime_src/core/tools/xbmgmt2/xbmgmt-csh-completion-wrapper
+++ b/src/runtime_src/core/tools/xbmgmt2/xbmgmt-csh-completion-wrapper
@@ -5,5 +5,5 @@
 
 # Enable autocompletion for the xbutil and xbmgmt commands
 alias __xbmgmt_completion_csh tcsh $XILINX_XRT/share/completions/xbmgmt-csh-completion
-complete xbmgmt 'p/*/`__xbmgmt_completion_csh`/'
+complete xbmgmt 'n/-u/f/' 'n/--user/f/' 'n/-o/f/' 'n/--output/f/' 'n/--shell/f/' 'n/--image/f/' 'p/*/`__xbmgmt_completion_csh`/'
 echo Autocomplete enabled for the xbmgmt command

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -13,51 +13,54 @@
 _command_word_xbutil_completion()
 {
   # Command word is used to specify further options as the command expands
-  commandWord=${COMP_WORDS[1]}
+  local commandWord=${COMP_WORDS[1]}
   # Get the righthand most word on the command line
-  currentWord=${COMP_WORDS[COMP_CWORD]}
+  local cur=${COMP_WORDS[COMP_CWORD]}
   # The previous word is used 
-  previousWord=${COMP_WORDS[COMP_CWORD-1]}
+  local prev=${COMP_WORDS[COMP_CWORD-1]}
 
-  _get_comp_words_by_ref -n : currentWord previousWord
+  # The BDFs (for devices) contain colons which breaks the autocomplete
+  # to get around this a helper function removes colons and helps parse the current and previous
+  # words
+  _get_comp_words_by_ref -n : cur prev
 
   # Each defined case requires an argument so no reply is given
   # All other cases default to using `compgen` output to format COMPREPLY
-  case ${previousWord} in
+  case ${prev} in
     -d|--device)
       BDFs=$(xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p')
-      COMPREPLY=( $(compgen -W "$BDFs" -- ${currentWord}) )
-      __ltrim_colon_completions "$currentWord"
+      COMPREPLY=( $(compgen -W "$BDFs" -- $cur) )
+      __ltrim_colon_completions "$cur"
       ;;
     -u|--user)
       _filedir
       ;;
     -f|--format)
-      COMPREPLY=( $(compgen -W "JSON JSON-2020.2" -- ${currentWord}) )
+      COMPREPLY=( $(compgen -W "JSON JSON-2020.2" -- $cur) )
       ;;
     -o|--output)
       _filedir
       ;;
     -t|--type)
-      COMPREPLY=( $(compgen -W "hot" -- ${currentWord}) )
+      COMPREPLY=( $(compgen -W "hot" -- $cur) )
       ;;
     # The -r option is used for multiple commands so extra processing is needed in here
     -r|--report|--run)
       case ${commandWord} in
         "validate")
           runs=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
-          COMPREPLY=( $(compgen -W "$runs" -- ${currentWord}) )
+          COMPREPLY=( $(compgen -W "$runs" -- $cur) )
           ;;
         "examine")
           reports=$(xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
-          COMPREPLY=( $(compgen -W "$reports" -- ${currentWord}) )
+          COMPREPLY=( $(compgen -W "$reports" -- $cur) )
           ;;
       esac
       ;;
     *)
       # The format of the compgen commands options is seperated from the current word using a --.
       # The -- character signifies the end of command options. All following arguments are positional.
-      COMPREPLY=($(compgen -W "$1" -- ${currentWord}))
+      COMPREPLY=($(compgen -W "$1" -- $cur))
       ;;
   esac
 }
@@ -106,13 +109,8 @@ _xbutil_completion()
   _command_word_xbutil_completion "${options}"
 }
 
-_xbutil_completion_t()
-{
-  COMPREPLY=($(compgen -W "hello:world testing:test" -- ${currentWord}))
-}
-
 source /usr/share/bash-completion/bash_completion
-complete -F _xbutil_completion_t xbutil
+complete -F _xbutil_completion xbutil
 echo Autocomplete enabled for the xbutil command
 
 # ex: filetype=sh

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -1,6 +1,6 @@
 # bash completion for xbutil                              -*- shell-script -*-
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #
 
 # Generates the command word options dependant on the previous word
@@ -12,11 +12,9 @@
 # 1: The complete list of options for the previous word
 _command_word_xbutil_completion()
 {
-  # Command word is used to specify further options as the command expands
-  local commandWord=${COMP_WORDS[1]}
   # Get the righthand most word on the command line
   local cur=${COMP_WORDS[COMP_CWORD]}
-  # The previous word is used 
+  # The previous word 
   local prev=${COMP_WORDS[COMP_CWORD-1]}
 
   # The BDFs (for devices) contain colons which breaks the autocomplete
@@ -56,6 +54,8 @@ _command_word_xbutil_completion()
       ;;
     # The -r option is used for multiple commands so extra processing is needed in here
     -r|--report|--run)
+      # Command word is used to specify further options as the command expands
+      local commandWord=${COMP_WORDS[1]}
       case ${commandWord} in
         "validate")
           options=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
@@ -66,12 +66,14 @@ _command_word_xbutil_completion()
       esac
       ;;
     *)
-      # The format of the compgen commands options is seperated from the current word using a --.
-      # The -- character signifies the end of command options. All following arguments are positional.
+      # Default to using the passed in options if no particular option is used
       options=$1
       ;;
   esac
+  # The format of the compgen commands options is seperated from the current word using a --.
+  # The -- character signifies the end of command options. All following arguments are positional.
   COMPREPLY+=($(compgen -W "$options" -- $cur))
+  # 2nd part of getting aroudn colons in the suggested keywords
   __ltrim_colon_completions "$cur"
 }
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -122,8 +122,13 @@ _xbutil_completion()
   _command_word_xbutil_completion "${options}"
 }
 
-source /usr/share/bash-completion/bash_completion
-complete -F _xbutil_completion xbutil
-echo Autocomplete enabled for the xbutil command
+COMP_FILE="/usr/share/bash-completion/bash_completion"
+if [ -f "${COMP_FILE}" ]; then
+  source /usr/share/bash-completion/bash_completion
+  complete -F _xbutil_completion xbutil
+  echo Autocomplete enabled for the xbmgmt command
+else
+  echo ${COMP_FILE} missing! Autocomplete disabled for the xbutl command
+fi
 
 # ex: filetype=sh

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -12,6 +12,8 @@
 # 1: The complete list of options for the previous word
 _command_word_xbutil_completion()
 {
+  # Command word is used to specify further options as the command expands
+  commandWord=${COMP_WORDS[1]}
   # Get the righthand most word on the command line
   currentWord=${COMP_WORDS[COMP_CWORD]}
   # The previous word is used 
@@ -19,33 +21,34 @@ _command_word_xbutil_completion()
   # Each defined case requires an argument so no reply is given
   # All other cases default to using `compgen` output to format COMPREPLY
   case ${previousWord} in
-    --device)
+    -d|--device)
+      BDFs=$(xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p')
+      COMPREPLY=( $(compgen -W "$BDFs" -- ${currentWord}) )
       ;;
-    -d)
+    -u|--user)
+      _filedir
       ;;
-    --user)
+    -f|--format)
+      COMPREPLY=( $(compgen -W "JSON JSON-2020.2" -- ${currentWord}) )
       ;;
-    -u)
+    -o|--output)
+      _filedir
       ;;
-    --run)
+    -t|--type)
+      COMPREPLY=( $(compgen -W "hot" -- ${currentWord}) )
       ;;
-    --format)
-      ;;
-    -f)
-      ;;
-    --output)
-      ;;
-    -o)
-      ;;
-    --report)
-      ;;
-    --type)
-      ;;
-    -t)
-      ;;
-    # -r shorthand applies to multiple commands under xbutil and requires additional processing
-    # Assuming we want to add something here one day
-    -r)
+    # The -r option is used for multiple commands so extra processing is needed in here
+    -r|--report|--run)
+      case ${commandWord} in
+        "validate")
+          runs=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
+          COMPREPLY=( $(compgen -W "$runs" -- ${currentWord}) )
+          ;;
+        "examine")
+          reports=$(xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
+          COMPREPLY=( $(compgen -W "$reports" -- ${currentWord}) )
+          ;;
+      esac
       ;;
     *)
       # The format of the compgen commands options is seperated from the current word using a --.
@@ -77,33 +80,30 @@ _xbutil_completion()
       # Once a command is identified the options will always be the same
       case ${commandWord} in
         "program")
-          programOptions="--user -u ${commonSubCommands}"
-          _command_word_xbutil_completion "${programOptions}"
+          options="--user -u ${commonSubCommands}"
           ;;
         "validate")
-          validateOptions="--run -r --format -f --output -o ${commonSubCommands}"
-          _command_word_xbutil_completion "${validateOptions}"
+          options="--run -r --format -f --output -o ${commonSubCommands}"
           ;;
         "examine")
-          examineOptions="--report -r --format -f --output -o ${commonSubCommands}"
-          _command_word_xbutil_completion "${examineOptions}"
+          options="--report -r --format -f --output -o ${commonSubCommands}"
           ;;
         "configure")
-          configureOptions="--host-mem --p2p --size ${commonSubCommands}"
-          _command_word_xbutil_completion "${configureOptions}"
+          options="--host-mem --p2p --size ${commonSubCommands}"
           ;;
         "reset")
-          resetOptions="--type -t ${commonSubCommands}"
-          _command_word_xbutil_completion "${resetOptions}"
+          options="--type -t ${commonSubCommands}"
           ;;
         # Return an empty reply if an invalid command is entered
         *)
           ;;
       esac
+      _command_word_xbutil_completion "${options}"
       ;;
   esac
 }
 
+source /usr/share/bash-completion/bash_completion
 complete -F _xbutil_completion xbutil
 echo Autocomplete enabled for the xbutil command
 

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -128,7 +128,7 @@ if [ -f "${COMP_FILE}" ]; then
   complete -F _xbutil_completion xbutil
   echo Autocomplete enabled for the xbmgmt command
 else
-  echo ${COMP_FILE} missing! Autocomplete disabled for the xbutl command
+  echo ${COMP_FILE} missing! Autocomplete disabled for the xbutil command
 fi
 
 # ex: filetype=sh

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -126,7 +126,7 @@ COMP_FILE="/usr/share/bash-completion/bash_completion"
 if [ -f "${COMP_FILE}" ]; then
   source /usr/share/bash-completion/bash_completion
   complete -F _xbutil_completion xbutil
-  echo Autocomplete enabled for the xbmgmt command
+  echo Autocomplete enabled for the xbutil command
 else
   echo ${COMP_FILE} missing! Autocomplete disabled for the xbutil command
 fi

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -18,12 +18,16 @@ _command_word_xbutil_completion()
   currentWord=${COMP_WORDS[COMP_CWORD]}
   # The previous word is used 
   previousWord=${COMP_WORDS[COMP_CWORD-1]}
+
+  _get_comp_words_by_ref -n : currentWord previousWord
+
   # Each defined case requires an argument so no reply is given
   # All other cases default to using `compgen` output to format COMPREPLY
   case ${previousWord} in
     -d|--device)
       BDFs=$(xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p')
       COMPREPLY=( $(compgen -W "$BDFs" -- ${currentWord}) )
+      __ltrim_colon_completions "$currentWord"
       ;;
     -u|--user)
       _filedir
@@ -102,8 +106,13 @@ _xbutil_completion()
   _command_word_xbutil_completion "${options}"
 }
 
+_xbutil_completion_t()
+{
+  COMPREPLY=($(compgen -W "hello:world testing:test" -- ${currentWord}))
+}
+
 source /usr/share/bash-completion/bash_completion
-complete -F _xbutil_completion xbutil
+complete -F _xbutil_completion_t xbutil
 echo Autocomplete enabled for the xbutil command
 
 # ex: filetype=sh

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -124,7 +124,7 @@ _xbutil_completion()
 
 COMP_FILE="/usr/share/bash-completion/bash_completion"
 if [ -f "${COMP_FILE}" ]; then
-  source /usr/share/bash-completion/bash_completion
+  bash /usr/share/bash-completion/bash_completion
   complete -F _xbutil_completion xbutil
   echo Autocomplete enabled for the xbutil command
 else

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -28,41 +28,51 @@ _command_word_xbutil_completion()
   # All other cases default to using `compgen` output to format COMPREPLY
   case ${prev} in
     -d|--device)
-      BDFs=$(xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p')
-      COMPREPLY=( $(compgen -W "$BDFs" -- $cur) )
-      __ltrim_colon_completions "$cur"
+      options=$(xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p')
       ;;
     -u|--user)
       _filedir
+      options=""
       ;;
     -f|--format)
-      COMPREPLY=( $(compgen -W "JSON JSON-2020.2" -- $cur) )
+      options="JSON JSON-2020.2"
       ;;
     -o|--output)
       _filedir
+      options=""
       ;;
     -t|--type)
-      COMPREPLY=( $(compgen -W "hot" -- $cur) )
+      options="hot"
+      ;;
+    -p|--path)
+      _filedir
+      options=""
+      ;;
+    --p2p)
+      options="ENABLE DISABLE VALIDATE"
+      ;;
+    --host-mem)
+      options="ENABLE DISABLE"
       ;;
     # The -r option is used for multiple commands so extra processing is needed in here
     -r|--report|--run)
       case ${commandWord} in
         "validate")
-          runs=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
-          COMPREPLY=( $(compgen -W "$runs" -- $cur) )
+          options=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
           ;;
         "examine")
-          reports=$(xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
-          COMPREPLY=( $(compgen -W "$reports" -- $cur) )
+          options=$(xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
           ;;
       esac
       ;;
     *)
       # The format of the compgen commands options is seperated from the current word using a --.
       # The -- character signifies the end of command options. All following arguments are positional.
-      COMPREPLY=($(compgen -W "$1" -- $cur))
+      options=$1
       ;;
   esac
+  COMPREPLY+=($(compgen -W "$options" -- $cur))
+  __ltrim_colon_completions "$cur"
 }
 
 # The main function populating the COMPREPLY
@@ -89,7 +99,7 @@ _xbutil_completion()
           options="--user -u ${commonSubCommands}"
           ;;
         "validate")
-          options="--run -r --format -f --output -o ${commonSubCommands}"
+          options="--run -r --format -f --output -o --path -p ${commonSubCommands}"
           ;;
         "examine")
           options="--report -r --format -f --output -o ${commonSubCommands}"
@@ -102,6 +112,7 @@ _xbutil_completion()
           ;;
         # Return an empty reply if an invalid command is entered
         *)
+          options=""
           ;;
       esac
       ;;

--- a/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-bash-completion
@@ -68,8 +68,7 @@ _xbutil_completion()
   case ${COMP_CWORD} in
     # Case for command after xbutil
     1)
-      commandWordOptions="program validate examine configure reset ${commonSubCommands}"
-      _command_word_xbutil_completion "${commandWordOptions}"
+      options="program validate examine configure reset ${commonSubCommands}"
       ;;
     # Case for options after the above command is entered
     *)
@@ -98,9 +97,9 @@ _xbutil_completion()
         *)
           ;;
       esac
-      _command_word_xbutil_completion "${options}"
       ;;
   esac
+  _command_word_xbutil_completion "${options}"
 }
 
 source /usr/share/bash-completion/bash_completion

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
@@ -7,11 +7,15 @@
 set list = "$COMMAND_LINE"
 # The command word associated with this xbutil invocation
 set commandWord = `echo $list | awk 'BEGIN{FS=" "}{print $2}'`
-# Get the number of arguments. This script turns spaces into commas to count
-# the number of commands. It only really matters for the first couple
+# Get the number of arguments. This script turns spaces into ampersands to count
+# the number of commands. This script is NOT space in path name friendly.
 set argsplit=(`echo "$list" | sed -e "s/ /@/g"`)
+# All non essential characters are removed here (Like hypens) so all definitions below do not have hyphens!
 set argsplit=(`echo "$argsplit" | sed "s/[^a-zA-Z0-9@/']//g"`)
+# Remove all alphanumeric characters and leave only the ampersands for word count
 set argsplit_counter=(`echo "$argsplit" | sed "s/[a-zA-Z0-9/']//g"`)
+# The number of characters left (which is only ampersands) determines the number of words in the argument list.
+# In case it was missed above this is not a space friendly script.
 set commandCount = (`echo $argsplit_counter | awk '{print length($0)}'`)
 set previousWord = `echo $argsplit | awk 'BEGIN{FS="@"}{NF=NF-1;print $NF}'`
 # This is the word on the righthand side
@@ -19,11 +23,13 @@ set currentWord = `echo $argsplit | awk 'BEGIN{FS="@"}{print $NF}'`
 
 
 # The options for the current command line statement
-set programOptions = "--verbose --batch --force --help -h --version --device -d"
+set programOptions = "--verbose --batch --force --help -h --version"
 # Handle the default xbutil options first
 if($commandCount == "1") then
     set programOptions="${programOptions} program validate examine configure reset"
 else
+  set commonSubCommands="--device -d ${programOptions}"
+
   # First handle the gathering of all options unique to each command
   switch($commandWord)
     case "program":

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
@@ -10,8 +10,8 @@ set commandWord = `echo $list | awk 'BEGIN{FS=" "}{print $2}'`
 # Get the number of arguments. This script turns spaces into commas to count
 # the number of commands. It only really matters for the first couple
 set argsplit=(`echo "$list" | sed -e "s/ /@/g"`)
-set argsplit=(`echo "$argsplit" | sed "s/[^a-zA-Z@/']//g"`)
-set argsplit_counter=(`echo "$argsplit" | sed "s/[a-zA-Z/']//g"`)
+set argsplit=(`echo "$argsplit" | sed "s/[^a-zA-Z0-9@/']//g"`)
+set argsplit_counter=(`echo "$argsplit" | sed "s/[a-zA-Z0-9/']//g"`)
 set commandCount = (`echo $argsplit_counter | awk '{print length($0)}'`)
 set previousWord = `echo $argsplit | awk 'BEGIN{FS="@"}{NF=NF-1;print $NF}'`
 # This is the word on the righthand side
@@ -19,30 +19,27 @@ set currentWord = `echo $argsplit | awk 'BEGIN{FS="@"}{print $NF}'`
 
 
 # The options for the current command line statement
-set programOptions = ""
+set programOptions = "--verbose --batch --force --help -h --version --device -d"
 # Handle the default xbutil options first
 if($commandCount == "1") then
-    set programOptions="program validate examine configure reset"
-# All other commands enter into this case
+    set programOptions="${programOptions} program validate examine configure reset"
 else
-  set commonSubCommands="--verbose --batch --force --help -h --version --device -d"
-
   # First handle the gathering of all options unique to each command
   switch($commandWord)
     case "program":
-      set programOptions="${commonSubCommands} --user -u"
+      set programOptions="${programOptions} --user -u"
       breaksw
     case "validate":
-      set programOptions="${commonSubCommands} --run -r --format -f --output -o"
+      set programOptions="${programOptions} --run -r --format -f --output -o --path -p"
       breaksw
     case "examine":
-      set programOptions="${commonSubCommands} --report -r --format -f --output -o"
+      set programOptions="${programOptions} --report -r --format -f --output -o"
       breaksw
     case "configure":
-      set programOptions="${commonSubCommands} --host-mem --p2p --size"
+      set programOptions="${programOptions} --host-mem --p2p --size"
       breaksw
     case "reset":
-      set programOptions="${commonSubCommands} --type -t"
+      set programOptions="${programOptions} --type -t"
       breaksw
     # Return an empty reply if an invalid command is entered
     default:
@@ -50,36 +47,36 @@ else
   endsw
 
   # If the current word requires an argument, clear the option list
+  # If an option is "missing" from this list check the wrapper. It is most likely defined there as a 
+  # file search completion
   switch($previousWord)
     case "device":
     case "d":
       set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'`)
       breaksw
-    case "user":
-    case "u":
-      set programOptions=""
-      breaksw
     case "format":
     case "f":
       set programOptions="JSON JSON-2020.2"
-      breaksw
-    case "output":
-    case "o":
-      set programOptions=""
       breaksw
     case "type":
     case "t":
       set programOptions="hot"
       breaksw
+    case "p2p":
+      set programOptions="ENABLE DISABLE VALIDATE"
+      breaksw
+    case "hostmem":
+      set programOptions="ENABLE DISABLE"
+      breaksw
     # -r shorthand applies to multiple commands under xbutil and requires additional processing
     # Assuming we want to add something here one day
     case "report":
     case "run":
-    case "r"
+    case "r":
       if ($commandWord == "validate") then
-        set programOptions=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
+        set programOptions=(`xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p'`)
       else if ($commandWord == "examine") then
-        set programOptions=$(xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
+        set programOptions=(`xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p'`)
       else
         set programOptions=""
       endif

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
@@ -53,7 +53,7 @@ else
   switch($previousWord)
     case "device":
     case "d":
-      set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'` | tr -s '\n' ' ')
+      set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'`)
       breaksw
     case "user":
     case "u":

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
@@ -1,6 +1,6 @@
 #!/bin/csh -f
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #
 
 # parse out required variables
@@ -9,15 +9,17 @@ set list = "$COMMAND_LINE"
 set commandWord = `echo $list | awk 'BEGIN{FS=" "}{print $2}'`
 # Get the number of arguments. This script turns spaces into commas to count
 # the number of commands. It only really matters for the first couple
-set argsplit=(`echo "$list" | sed -e "s/ /,/g"`)
-set argsplit=(`echo "$argsplit" | sed "s/[a-zA-Z']//g"`)
-set commandCount = (`echo $argsplit | awk '{print length($0)}'`)
+set argsplit=(`echo "$list" | sed -e "s/ /@/g"`)
+set argsplit=(`echo "$argsplit" | sed "s/[^a-zA-Z@/']//g"`)
+set argsplit_counter=(`echo "$argsplit" | sed "s/[a-zA-Z/']//g"`)
+set commandCount = (`echo $argsplit_counter | awk '{print length($0)}'`)
+set previousWord = `echo $argsplit | awk 'BEGIN{FS="@"}{NF=NF-1;print $NF}'`
 # This is the word on the righthand side
-set currentWord = `echo $list | awk 'BEGIN{FS=" "}{print $NF}'`
+set currentWord = `echo $argsplit | awk 'BEGIN{FS="@"}{print $NF}'`
+
 
 # The options for the current command line statement
 set programOptions = ""
-
 # Handle the default xbutil options first
 if($commandCount == "1") then
     set programOptions="program validate examine configure reset"
@@ -48,43 +50,38 @@ else
   endsw
 
   # If the current word requires an argument, clear the option list
-  switch($currentWord)
-    case "-d":
+  switch($previousWord)
+    case "device":
+    case "d":
+      set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'`)
+      breaksw
+    case "user":
+    case "u":
+      set dir = `echo $argsplit | awk 'BEGIN{FS="@"}{print $NF}'`
+      if ($dir != "") then
+        if (! -d $dir) then
+          set dir=(`echo "$dir" | grep --perl-regexp '.+[/]|[/].+[/]' --only-matching`)
+        endif
+      endif
+      set programOptions=`ls $dir`
+      breaksw
+    case "format":
+    case "f":
+      set programOptions="JSON JSON-2020.2"
+      breaksw
+    case "output":
+    case "o":
       set programOptions=""
       breaksw
-    case "--user":
-      set programOptions=""
-      breaksw
-    case "-u":
-      set programOptions=""
-      breaksw
-    case "--run":
-      set programOptions=""
-      breaksw
-    case "--format":
-      set programOptions=""
-      breaksw
-    case "-f":
-      set programOptions=""
-      breaksw
-    case "--output":
-      set programOptions=""
-      breaksw
-    case "-o":
-      set programOptions=""
-      breaksw
-    case "--report":
-      set programOptions=""
-      breaksw
-    case "--type":
-      set programOptions=""
-      breaksw
-    case "-t":
+    case "type":
+    case "t":
       set programOptions=""
       breaksw
     # -r shorthand applies to multiple commands under xbutil and requires additional processing
     # Assuming we want to add something here one day
-    case "-r":
+    case "report":
+    case "run":
+    case "r"
       set programOptions=""
       breaksw
     # do not modify the option list if the argument is not required

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
@@ -53,17 +53,11 @@ else
   switch($previousWord)
     case "device":
     case "d":
-      set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'`)
+      set programOptions=(`xbutil examine | sed -n '/Devices present/,/^$/ s/[ \[]*\(0000:[0-9]\+:[0-9]\+.1\)].*/\1/p'` | tr -s '\n' ' ')
       breaksw
     case "user":
     case "u":
-      set dir = `echo $argsplit | awk 'BEGIN{FS="@"}{print $NF}'`
-      if ($dir != "") then
-        if (! -d $dir) then
-          set dir=(`echo "$dir" | grep --perl-regexp '.+[/]|[/].+[/]' --only-matching`)
-        endif
-      endif
-      set programOptions=`ls $dir`
+      set programOptions=""
       breaksw
     case "format":
     case "f":
@@ -75,14 +69,20 @@ else
       breaksw
     case "type":
     case "t":
-      set programOptions=""
+      set programOptions="hot"
       breaksw
     # -r shorthand applies to multiple commands under xbutil and requires additional processing
     # Assuming we want to add something here one day
     case "report":
     case "run":
     case "r"
-      set programOptions=""
+      if ($commandWord == "validate") then
+        set programOptions=$(xbutil validate --help | sed -n '/--run/,/--output/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
+      else if ($commandWord == "examine") then
+        set programOptions=$(xbutil examine --help | sed -n '/--report/,/--format/ s/        [ ]\+\([A-Za-z0-9\-]\+\)[ ]\+- .*/\1/p')
+      else
+        set programOptions=""
+      endif
       breaksw
     # do not modify the option list if the argument is not required
     default:

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion
@@ -49,9 +49,6 @@ else
 
   # If the current word requires an argument, clear the option list
   switch($currentWord)
-    case "--device":
-      set programOptions=""
-      breaksw
     case "-d":
       set programOptions=""
       breaksw

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
@@ -7,5 +7,5 @@
 alias __xbutil_completion_csh tcsh $XILINX_XRT/share/completions/xbutil-csh-completion
 # TCSH is very unfriendly when performing file completions inside the aliased script
 # to get around this we add certain options that default to file/directory searches here
-complete xbutil 'n/-u/f/' 'n/--user/f/' 'n/-o/f/' 'n/--output/f/' 'p/*/`__xbutil_completion_csh`/'
+complete xbutil 'n/-u/f/' 'n/--user/f/' 'n/-o/f/' 'n/--output/f/' 'n/-p/f/' 'n/--path/f/' 'p/*/`__xbutil_completion_csh`/'
 echo Autocomplete enabled for the xbutil command

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
@@ -1,6 +1,6 @@
 #!/bin/csh -f
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #
 
 # Enable autocompletion for the xbutil and xbmgmt commands

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
@@ -5,5 +5,7 @@
 
 # Enable autocompletion for the xbutil and xbmgmt commands
 alias __xbutil_completion_csh tcsh $XILINX_XRT/share/completions/xbutil-csh-completion
-complete xbutil 'n/-u/d/' 'n/--user/d/' 'n/-o/d/' 'n/--output/d/' 'p/*/`__xbutil_completion_csh`/'
+# TCSH is very unfriendly when performing file completions inside the aliased script
+# to get around this we add certain options that default to file/directory searches here
+complete xbutil 'n/-u/f/' 'n/--user/f/' 'n/-o/f/' 'n/--output/f/' 'p/*/`__xbutil_completion_csh`/'
 echo Autocomplete enabled for the xbutil command

--- a/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
+++ b/src/runtime_src/core/tools/xbutil2/xbutil-csh-completion-wrapper
@@ -5,5 +5,5 @@
 
 # Enable autocompletion for the xbutil and xbmgmt commands
 alias __xbutil_completion_csh tcsh $XILINX_XRT/share/completions/xbutil-csh-completion
-complete xbutil 'p/*/`__xbutil_completion_csh`/'
+complete xbutil 'n/-u/d/' 'n/--user/d/' 'n/-o/d/' 'n/--output/d/' 'p/*/`__xbutil_completion_csh`/'
 echo Autocomplete enabled for the xbutil command


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1120377
In the latest XRT, the auto completion script is sourced and it can hint command and command options. But file path cannot be auto filled any more.
For example,
xbutil program -d 17:00.1 -u /opt/xilinx/<tab>
In before, if I type <tab>, it will hint possible files and directories. But now, type <Tab> doesn't hint anything.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The auto completion scripts for both xbmgmt and xbutil did not properly provide options for sub-options which limited the functionality as compared to before. While the higher level hints were available, options hints were not functioning.

#### How problem was solved, alternative solutions (if any) and why they were rejected
The current completion scripts were combined with @mamin506 lower level option completion script to provide full functionality.

#### Risks (if any) associated the changes in the commit
More of a maintenance hassle when editing the tool interface via changing the scripts.

#### What has been tested and how, request additional testing if necessary
xbutil bash testing:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure -
--batch     --device    -h          --host-mem  --size      --version
-d          --force     --help      --p2p       --verbose
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure -
--batch     --device    -h          --host-mem  --size      --version
-d          --force     --help      --p2p       --verbose
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure -d 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure -d 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure -d 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure --host-mem
DISABLE  ENABLE
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure --p2p
DISABLE   ENABLE    VALIDATE
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program -
--batch    -d         --device   --force    -h         --help     -u         --user     --verbose  --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program -
--batch    -d         --device   --force    -h         --help     -u         --user     --verbose  --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program -u
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program --user
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program --user
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program --device 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program --device 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -
--batch    --device   --force    -h         -o         -r         --verbose
-d         -f         --format   --help     --output   --report   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -f JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -f JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine --for
--force   --format
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine --format JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine --format JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine --
--batch    --device   --force    --format   --help     --output   --report   --verbose  --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -
--batch    --device   --force    -h         -o         -r         --verbose
-d         -f         --format   --help     --output   --report   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -o
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine --output
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -
--batch    --device   --force    -h         -o         -r         --verbose
-d         -f         --format   --help     --output   --report   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r
aie              cmc              electrical       host             memory           qspi-status
aieshim          debug-ip-status  error            mailbox          pcie-info        thermal
all              dynamic-regions  firewall         mechanical       platform
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine --report
aie              cmc              electrical       host             memory           qspi-status
aieshim          debug-ip-status  error            mailbox          pcie-info        thermal
all              dynamic-regions  firewall         mechanical       platform
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -
--batch    --device   --force    -h         -o         -r         --verbose
-d         -f         --format   --help     --output   --report   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil reset -
--batch    -d         --device   --force    -h         --help     -t         --type     --verbose  --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -
--batch    --device   --force    -h         -o         -p         -r         --verbose
-d         -f         --format   --help     --output   --path     --run      --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -f JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -p
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -p
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate --path
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -r
all             bist            hostmem-bw      m2m             p2p             quick           vcu
aux-connection  dma             iops            mem-bw          pcie-link       sc-version      verify
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate --run
all             bist            hostmem-bw      m2m             p2p             quick           vcu
aux-connection  dma             iops            mem-bw          pcie-link       sc-version      verify
```
xbutil tcsh testing
```
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil configure
--batch    -d         --device   --force    -h         --help     --host-mem --p2p      --size     --verbose  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil configure -
--batch    -d         --device   --force    -h         --help     --host-mem --p2p      --size     --verbose  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil configure -d
0000:17:00.1 0000:65:00.1
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil configure --device
0000:17:00.1 0000:65:00.1
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil configure --host-mem
DISABLE ENABLE
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil configure --p2p
DISABLE  ENABLE   VALIDATE
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil program
--batch   -d        --device  --force   -h        --help    -u        --user    --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil program -u
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil program -u bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil program --user
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil program --user bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine -f
JSON        JSON-2020.2
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine -f JSON
JSON        JSON-2020.2
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --for
--force  --format
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --format
JSON        JSON-2020.2
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine -o
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine -o bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --output
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --output
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --output
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --output bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --output bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine -r
aie             cmc             electrical      host            memory          qspi-status
aieshim         debug-ip-status error           mailbox         pcie-info       thermal
all             dynamic-regions firewall        mechanical      platform
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil examine --report
aie             cmc             electrical      host            memory          qspi-status
aieshim         debug-ip-status error           mailbox         pcie-info       thermal
all             dynamic-regions firewall        mechanical      platform
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil reset
--batch   -d        --device  --force   -h        --help    -t        --type    --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil reset -t hot
--batch   -d        --device  --force   -h        --help    -t        --type    --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil reset --type hot
--batch   -d        --device  --force   -h        --help    -t        --type    --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate
--batch   --device  --force   -h        -o        -p        -r        --verbose
-d        -f        --format  --help    --output  --path    --run     --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate -p
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate -p bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate --path
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate --path bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate -r
all            bist           hostmem-bw     m2m            p2p            quick          vcu
aux-connection dma            iops           mem-bw         pcie-link      sc-version     verify
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbutil validate --run
all            bist           hostmem-bw     m2m            p2p            quick          vcu
aux-connection dma            iops           mem-bw         pcie-link      sc-version     verify
```
xbmgmt bash testing
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump -d 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump -d 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump --device 0000:
17:00.1  65:00.1
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump --device 0000:65:00.1 -
--batch    --config   --device   --flash    -h         -o         --verbose
-c         -d         -f         --force    --help     --output   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump --device 0000:65:00.1 -
--batch    --config   --device   --flash    -h         -o         --verbose
-c         -d         -f         --force    --help     --output   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump --device 0000:65:00.1 -
--batch    --config   --device   --flash    -h         -o         --verbose
-c         -d         -f         --force    --help     --output   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump -o
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump --output
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -
--batch    --device   --force    -h         -o         -r         --verbose
-d         -f         --format   --help     --output   --report   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -
--batch    --device   --force    -h         -o         -r         --verbose
-d         -f         --format   --help     --output   --report   --version
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -f JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine --for
--force   --format
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine --for
--force   --format
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine --format JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine --format JSON
JSON         JSON-2020.2
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -r
all         cmc         firewall    host        mailbox     mechanical  platform
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine --report
all         cmc         firewall    host        mailbox     mechanical  platform
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program -
--base              --device            --help              --shell             --verbose
--batch             --force             --image             -u                  --version
-d                  -h                  --revert-to-golden  --user
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program --image
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program --shell
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program --shell
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program -u
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program --user
build/            .git/             LICENSE           src/              .vscode/
CHANGELOG.rst     .github/          NOTICE            tests/
CONTRIBUTING.rst  .gitignore        README.rst        .travis.yml
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt reset -
--batch    -d         --device   --force    -h         --help     --verbose  --version
```
xbmgmt tcsh testing
```
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt
--batch   dump      examine   --force   -h        --help    program   reset     --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt
--batch   dump      examine   --force   -h        --help    program   reset     --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -d
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -d -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -d -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -d -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -o
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -o bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -o bin/
mpd*            plp_program.sh* xball*          xbmgmt*         xclbinutil*
msd*            unwrapped/      xbflash.qspi*   xbutil*
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump --device
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump --device -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump --device -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -d
0000:17:00.1 0000:65:00.1
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -d 0000:
0000:17:00.1 0000:65:00.1
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump --device
0000:17:00.1 0000:65:00.1
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump --device 0000:
0000:17:00.1 0000:65:00.1
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -
--batch   --config  --device  --flash   -h        -o        --verbose
-c        -d        -f        --force   --help    --output  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump --output
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt dump -o
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine
--batch   --device  --force   -h        -o        -r        --verbose
-d        -f        --format  --help    --output  --report  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine -
--batch   --device  --force   -h        -o        -r        --verbose
-d        -f        --format  --help    --output  --report  --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine -f
JSON        JSON-2020.2
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine --fo
--force  --format
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine --format
JSON        JSON-2020.2
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine -r
all        cmc        firewall   host       mailbox    mechanical platform
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt examine --report
all        cmc        firewall   host       mailbox    mechanical platform
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program
--base             --device           --help             --shell            --verbose
--batch            --force            --image            -u                 --version
-d                 -h                 --revert-to-golden --user
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program -
--base             --device           --help             --shell            --verbose
--batch            --force            --image            -u                 --version
-d                 -h                 --revert-to-golden --user
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program --image
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program --image
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program --shell
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program --shell
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program -u
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program -u
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program --user
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt program --user
bin/          include/      license/      setup.csh     share/        version.json
etc/          lib/          python/       setup.sh      test/
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt reset
--batch   -d        --device  --force   -h        --help    --verbose --version
xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt% xbmgmt reset -
--batch   -d        --device  --force   -h        --help    --verbose --version
```
#### Documentation impact (if any)
None!