### PR TITLE
PS Kernels : Removed ID value for xrtHandle* argument entry.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/PSKernel.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/PSKernel.py
@@ -147,11 +147,13 @@ def main():
                      "--output", outputOnlyPSKernelXclbin, 
                      "--force"]
 
+  execCmd(step, cmd)
+
   # Validate the contents of the various sections
-  textFileCompare(outputEmbeddedMetadata, expectedEmbeddedMetadata)
-  jsonFileCompare(outputIpLayout, expectedIpLayout)
-  jsonFileCompare(outputConnectivity, expectedConnectivity)
-  jsonFileCompare(outputMemTopology, expectedMemTopology)
+  textFileCompare(outputPSKEmbeddedMetadata, expectedOnlyPSKEmbeddedMetadata)
+  jsonFileCompare(outputPSKIpLayout, expectedPSKIpLayout)
+  jsonFileCompare(outputPSKConnectivity, expectedPSKConnectivity)
+  jsonFileCompare(outputPSKMemTopology, expectedPSKMemTopology)
 
   execCmd(step, cmd)
 

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
@@ -74,7 +74,7 @@
           <arg name="arg4" addressQualifier="0" id="4" size="0x8" offset="0x38" hostOffset="0x0" hostSize="0x8" type="int"/>
           <arg name="arg5" addressQualifier="0" id="5" size="0x4" offset="0x40" hostOffset="0x0" hostSize="0x4" type="float"/>
           <arg name="arg6" addressQualifier="1" id="6" size="0x10" offset="0x44" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="arg7" addressQualifier="1" id="7" size="0x10" offset="0x54" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
+          <arg name="arg7" addressQualifier="1" id="" size="0x10" offset="0x54" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
           <instance name="scu_0"/>
         </kernel>
       </core>

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
@@ -11,7 +11,7 @@
           <arg name="arg4" addressQualifier="0" id="4" size="0x8" offset="0x38" hostOffset="0x0" hostSize="0x8" type="int"/>
           <arg name="arg5" addressQualifier="0" id="5" size="0x4" offset="0x40" hostOffset="0x0" hostSize="0x4" type="float"/>
           <arg name="arg6" addressQualifier="1" id="6" size="0x10" offset="0x44" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="arg7" addressQualifier="1" id="7" size="0x10" offset="0x54" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
+          <arg name="arg7" addressQualifier="1" id="" size="0x10" offset="0x54" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
           <instance name="scu_0"/>
         </kernel>
       </core>


### PR DESCRIPTION
#### Problem solved by the commit
In the EMBEDDED_METADATA section, the last argument is an xrtHandle pointer.  This argument is supplied by the driver and not the user space.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Integration discovery

#### How problem was solved, alternative solutions (if any) and why they were rejected
In the EMBEDDED_METADATA section, only the PS Kernel arguments will have ID values.  If the argument is driver provide, the ID value will be empty.

#### Risks (if any) associated the changes in the commit
Low to none

#### What has been tested and how, request additional testing if necessary
Manual testing and updated unit tests to validate expected functionality.

#### Documentation impact (if any)
n/a