### PR TITLE
Fixed the  issue for AIE seg fault

### DIFF
--- a/src/runtime_src/core/edge/user/aie/graph.cpp
+++ b/src/runtime_src/core/edge/user/aie/graph.cpp
@@ -414,8 +414,10 @@ xclGraphOpen(xclDeviceHandle dhdl, const uuid_t xclbin_uuid, const char* name, x
 void
 xclGraphClose(xclGraphHandle ghdl)
 {
-  auto graph = get_graph(ghdl);
-  graphs.erase(graph.get());
+  if (!graphs.empty()) {
+    auto graph = get_graph(ghdl);
+    graphs.erase(graph.get());
+  }
 }
 
 void


### PR DESCRIPTION
Canon facing AIE application issue as follows:
Segfault occurs when program finishes | Program runs and behaves as expected but segfaults on exit.

The issue is the order of the destructor. Right now we need to go through full AIE to fic this issue. But this is a workaround to avoid segmentation fault issues. 




