### PR TITLE
CR-1120952: Fixing Crash where all banks are either unused or streaming

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -496,7 +496,7 @@ class xclbin_impl
         }), mems.end());
 
       if (mems.empty())
-        return {};
+        return enc;
 
       // sort collected memory banks on addr decreasing order, the size
       std::sort(mems.begin(), mems.end(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- Whenever all the banks are either unused or streaming, XRT user space is crashing with vector::_M_range_check error. 
- memory bank encoding size should be always equal to number of memories in xclbin.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Creating a vector of number of banks size

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified CR and couple of other cases

#### Documentation impact (if any)
No