### PR TITLE
zcu102 test case fixed for multi slot ZOCL changes

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -450,10 +450,6 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 
 	mem_index = GET_MEM_INDEX(args->flags);
 	mem = zocl_get_mem_by_mem_index(zdev, mem_index);
-	if (!mem) {
-		DRM_ERROR("Invalid memory index");
-		return -EINVAL;
-	}
 
 	/* Always allocate EXECBUF from CMA */
 	if (args->flags & ZOCL_BO_FLAGS_EXECBUF)

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -461,7 +461,7 @@ zocl_create_bo_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		 * PL-DDR; For any other cases (invalid bank index), we
 		 * allocate from CMA by default.
 		 */
-		if (mem->zm_used) {
+		if (mem && mem->zm_used) {
 			if (mem->zm_type == ZOCL_MEM_TYPE_CMA)
 				args->flags |= ZOCL_BO_FLAGS_CMA;
 		} else {

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -349,7 +349,7 @@ update_max_apt_number(struct drm_zocl_dev *zdev)
 	zdev->num_apts = 0;
 	for (apt_idx = 0; apt_idx < MAX_APT_NUM; ++apt_idx) {
 		if (zdev->apertures[apt_idx].addr != 0)
-			zdev->num_apts = apt_idx;
+			zdev->num_apts = apt_idx + 1;
 	}
 }
 


### PR DESCRIPTION
Some of the test cases are failing for zcu102 for multi slot changes on zocl. 
The issue is for aperture and memory index.
Fixed the issue.
