### PR TITLE
Hot FIX: fix zocl crash when probe on versal device

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -102,12 +102,12 @@ static int zocl_pr_slot_init(struct drm_zocl_dev *zdev,
 	/* TODO : Need to update this function based on the device tree */
 	if (ZOCL_PLATFORM_ARM64) {
 		u64 pr_num;
-		if (of_property_read_u64(pdev->dev.of_node,
-					 "xlnx,pr-num-support", &pr_num))
+		if (!of_property_read_u64(pdev->dev.of_node,
+					  "xlnx,pr-num-support", &pr_num))
 			zdev->num_pr_slot = (int)pr_num;
 	} else {
 		u32 pr_num;
-		if (of_property_read_u32(pdev->dev.of_node,
+		if (!of_property_read_u32(pdev->dev.of_node,
 				 "xlnx,pr-num-support", &pr_num))
 			zdev->num_pr_slot = (int)pr_num;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On versal device, when zocl probe, kernel will crash.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6160 introduce this issue. The of_property_read_u64() returns 0 on success. The bug code use taint pr_num to update num_pr_slot, which is used as the loop boundary. The loop will allocate memory and the system will crash when out of memory.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Correct the condition.

#### Risks (if any) associated the changes in the commit
No seeing any risk.

#### What has been tested and how, request additional testing if necessary
On versal discovery shell.

#### Documentation impact (if any)
No.