### PR TITLE
CR-1121860 U25: xbutil validate hangs

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -489,7 +489,7 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 	if (kds->xgq_enable)
 		return true;
 
-	if ((kds->ert->slot_size > 0) && (kds->ert->slot_size < pkg_size)) {
+	if (kds->ert && (kds->ert->slot_size > 0) && (kds->ert->slot_size < pkg_size)) {
 		userpf_err(xdev, "payload size bigger than CQ slot size\n");
 		return false;
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On u25, xbutil validate crash.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6241 introduce this bug. U25 which manually disabled ERT exposed this issue.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Check if ert existed in the condition.

#### Risks (if any) associated the changes in the commit
no

#### What has been tested and how, request additional testing if necessary
U25 xbutil validate

#### Documentation impact (if any)
no