### PR TITLE
Move conditional into one-time executed block

### DIFF
--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2226,11 +2226,11 @@ int shim::xclRegRW(bool rd, uint32_t ipIndex, uint32_t offset, uint32_t *datap)
       cumap.first = static_cast<uint32_t*>(p);
       cumap.second = size;
     }
-  }
 
-  if (cumap.first == nullptr) {
-    xrt_logmsg(XRT_ERROR, "%s: can't map CU: %d", __func__, ipIndex);
-    return -EINVAL;
+    if (cumap.first == nullptr) {
+      xrt_logmsg(XRT_ERROR, "%s: can't map CU: %d", __func__, ipIndex);
+      return -EINVAL;
+    }
   }
 
   if (offset >= cumap.second || (offset & (sizeof(uint32_t) - 1)) != 0) {


### PR DESCRIPTION
#### Problem solved by the commit
Per observation by @herveratigner potentially save few instructions in xclRegRW

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Error conditional resulting from MAP_FAILED should be executed once only.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Move check inside initialization block

