### PR TITLE
CR-1119552 xbmgmt returns 0 even though one of the functions failed

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2021 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -114,7 +114,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Check to see if help was requested 
@@ -194,18 +194,18 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
         std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
       }
       std::cout << std::endl;
-      return;
+      throw xrt_core::error(std::errc::operation_canceled);
     }
   } catch (const xrt_core::error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
     printHelp(commonOptions, hiddenOptions);
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   catch (const std::runtime_error& e) {
     // Catch only the exceptions that we have generated earlier
     std::cerr << boost::format("ERROR: %s\n") % e.what();
-    return;
+    throw xrt_core::error(std::errc::operation_canceled);
   }
 
   // Create the report


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1117863
Multiple `xbmgmt examine` paths, when given invalid inputs, returned a 0 when a 1 should be returned. The CR originally seemed like only the report generation was affected but that was not the case! There were additional issues with:
1. Invalid device number input
2. Invalid format input
3. A required argument is not given when the input is specified (Ex. -o/--output)
4. Invalid report name input

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
More than just the reports were affected by the original issue as multiple error paths in xbmgmt examine returned rather than throwing exceptions.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Replace returns with throws to issue error codes when unexpected inputs are given.

#### Risks (if any) associated the changes in the commit
If the expected output code from a particular error path is meant to fall through it now errors. Please let me know if any particular input exception should just fall through!

#### What has been tested and how, request additional testing if necessary
Invalid device input
```
root@xsjpranjal01:~# xbmgmt examine -d 12:00
ERROR: Specified device BDF '12:00' not found
 Available devices:
  [0000:65:00.0] : xilinx_u280_xdma_201920_3
  [0000:17:00.0] : xilinx_u250_gen3x16_base_3

root@xsjpranjal01:~# echo $?
1
```

Invalid format input
```
root@xsjpranjal01:~# xbmgmt examine -f asdf -o /tmp/x.json
ERROR: Unknown output format: 'asdf': Invalid argument

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.

USAGE: xbmgmt examine [-h] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of
                       'all' (default) indicates that every found device should be examined.
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all        - All known reports are produced
                         cmc        - CMC status of the device
                         firewall   - Firewall status
                         host       - Host information
                         mailbox    - Mailbox metrics of the device
                         mechanical - Mechanical sensors on and surrounding the device
                         platform   - Platform information
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  -h, --help         - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
root@xsjpranjal01:~# echo $?
1
```

A required argument is not given when the input is specified
```
root@xsjpranjal01:~# xbmgmt examine -f asdf -o
ERROR: the required argument for option '--output' is missing


DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.

USAGE: xbmgmt examine [-h] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of
                       'all' (default) indicates that every found device should be examined.
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all        - All known reports are produced
                         cmc        - CMC status of the device
                         firewall   - Firewall status
                         host       - Host information
                         mailbox    - Mailbox metrics of the device
                         mechanical - Mechanical sensors on and surrounding the device
                         platform   - Platform information
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  -h, --help         - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
root@xsjpranjal01:~# echo $?
1
```

Invalid report name input
```
root@xsjpranjal01:~# xbmgmt examine -r asdf
ERROR: No report generator found for report: 'asdf'
: Invalid argument

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.

USAGE: xbmgmt examine [-h] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of
                       'all' (default) indicates that every found device should be examined.
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all        - All known reports are produced
                         cmc        - CMC status of the device
                         firewall   - Firewall status
                         host       - Host information
                         mailbox    - Mailbox metrics of the device
                         mechanical - Mechanical sensors on and surrounding the device
                         platform   - Platform information
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  -h, --help         - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
root@xsjpranjal01:~# echo $?
1
```