### PR TITLE
CR-1120081:: Printing XTLM Message from simulate.log to the console

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -204,17 +204,13 @@ namespace xclhwemhal2 {
     return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
   }
 
-  void HwEmShim::parseHLSPrintf(const std::string& simPath)
+  void HwEmShim::parseString(const std::string& simPath , const std::string& searchString)
   {
     std::ifstream ifs(simPath + "/simulate.log");
-    std::string word = "HLS_PRINT";
-    std::string line;
-    while( getline(ifs, line ))
-    {
-      size_t pos = line.find(word);
-      if ( pos != std::string::npos) {
-        logMessage(line, 0);
-      }
+    std::string lineHandle;
+    while(getline(ifs, lineHandle)) {
+      if(lineHandle.find(searchString, 0) != std::string::npos)
+        logMessage(lineHandle, 0);
     }
   }
 
@@ -222,7 +218,7 @@ namespace xclhwemhal2 {
   {
     std::string simPath = getSimPath();
     std::string content = loadFileContentsToString(simPath + "/simulate.log");
-    parseHLSPrintf(simPath);
+    parseString(simPath,"HLS_PRINT");
     if (content.find("// ERROR!!! DEADLOCK DETECTED ") != std::string::npos) {
       size_t first = content.find("// ERROR!!! DEADLOCK DETECTED");
       size_t last = content.find("detected!", first);
@@ -230,6 +226,10 @@ namespace xclhwemhal2 {
       std::string deadlockMsg = content.substr(first , last + 9 - first);
       logMessage(deadlockMsg, 0);
     }
+
+    //CR-1120081 Changes Start
+    parseString(simPath,"SIM-IPC's external process can be connected to instance");
+    //CR-1120081 Changes End
   }
 
   static void sigHandler(int sn, siginfo_t *si, void *sc)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -279,7 +279,8 @@ using addr_type = uint64_t;
       void createPreSimScript(const std::string& wcfgFilePath, std::string& preSimScriptPath);
       std::string loadFileContentsToString(const std::string& path);
       void constructQueryTable();
-      void parseHLSPrintf(const std::string& simPath);	  
+      //CR-1120081
+      void parseString(const std::string& simPath , const std::string& searchString);
       void parseSimulateLog();
       void setSimPath(std::string simPath) { sim_path = simPath; }
       std::string getSimPath () { return sim_path; }


### PR DESCRIPTION

#### Problem solved by the commit
 Printing XTLM Message from simulate.log to the console

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1120081

#### How problem was solved, alternative solutions (if any) and why they were rejected
Parsing simulate.log generated by xsim

#### Risks (if any) associated the changes in the commit
Low Risk

#### What has been tested and how, request additional testing if necessary
1. Canary is neat
2. Verified with "rx_passthrough_vitis" example 
https://gitenterprise.xilinx.com/vitis-emu/X3_EMU_NTG/tree/main/examples/rx_passthrough_vitis

#### Documentation impact (if any)
NA
