### PR TITLE
CR-1121688: Regression: XRT error while loading xclbin (argidx mismatch)

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -311,10 +311,6 @@ public:
       if (karginfo.index == xrt_core::xclbin::kernel_argument::no_index)
         continue;
 
-      // Sanity check
-      if (karginfo.index != argidx)
-        throw std::runtime_error("internal error: argidx mismatch");
-
       // Create kernel argument for argidx
       auto kargimpl = std::make_shared<arg_impl>();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
 There is a sanity added in XRT to check whether argument index is same as running index. This doesnt work in all cases.
There is a use case where argument id can be same for multiple entries in xml file
![argindex](https://user-images.githubusercontent.com/40261882/153594609-ed010670-5d61-467c-83e7-92c303acf207.jpg)


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed the Sanity

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Verified the CR

#### Documentation impact (if any)
