### PR TITLE
CR-1121892 Crash when testing latest XRT on VCK190

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -25,6 +25,11 @@
 #define MAX_CU_NUM     128
 /* Apertures contains both ip and debug ip information */
 #define MAX_APT_NUM		2*MAX_CU_NUM
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+#define EMPTY_APT_VALUE		0xFFFFffffFFFFffff
+#else
+#define EMPTY_APT_VALUE		0xFFFFffff
+#endif
 #define CU_SIZE        _64KB
 #define PR_ISO_SIZE    _4KB
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -25,10 +25,7 @@
 #define MAX_CU_NUM     128
 /* Apertures contains both ip and debug ip information */
 #define MAX_APT_NUM		2*MAX_CU_NUM
-#ifdef CONFIG_PHYS_ADDR_T_64BIT
-#define EMPTY_APT_VALUE		0xFFFFffffFFFFffff
-#else
-#define EMPTY_APT_VALUE		0xFFFFffff
+#define EMPTY_APT_VALUE		(phys_addr_t) -1;
 #endif
 #define CU_SIZE        _64KB
 #define PR_ISO_SIZE    _4KB

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -25,7 +25,7 @@
 #define MAX_CU_NUM     128
 /* Apertures contains both ip and debug ip information */
 #define MAX_APT_NUM		2*MAX_CU_NUM
-#define EMPTY_APT_VALUE		(phys_addr_t) -1;
+#define EMPTY_APT_VALUE		((phys_addr_t) -1)
 #define CU_SIZE        _64KB
 #define PR_ISO_SIZE    _4KB
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -26,7 +26,6 @@
 /* Apertures contains both ip and debug ip information */
 #define MAX_APT_NUM		2*MAX_CU_NUM
 #define EMPTY_APT_VALUE		(phys_addr_t) -1;
-#endif
 #define CU_SIZE        _64KB
 #define PR_ISO_SIZE    _4KB
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -200,13 +200,26 @@ static void zocl_pr_slot_fini(struct drm_zocl_dev *zdev)
  */
 static int zocl_aperture_init(struct drm_zocl_dev *zdev)
 {
+	struct addr_aperture *apts = NULL;
+	int i;
+
 	zdev->apertures = kcalloc(MAX_APT_NUM, sizeof(struct addr_aperture),
 				 GFP_KERNEL);
 	if (!zdev->apertures) {
 		DRM_ERROR("Out of memory for Aperture\n");
 		return -ENOMEM;
 	}
+	
+	apts = zdev->apertures;
 
+	/* Consider this magic number as uninitialized aperture identity */
+	for (i = 0; i < MAX_APT_NUM; ++i) {
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+		apts[i].addr = 0xFFFFffffFFFFffff;
+#else
+		apts[i].addr = 0xFFFFffff;
+#endif	
+	}
 	zdev->num_apts = 0;
 
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -201,7 +201,7 @@ static void zocl_pr_slot_fini(struct drm_zocl_dev *zdev)
 static int zocl_aperture_init(struct drm_zocl_dev *zdev)
 {
 	struct addr_aperture *apts = NULL;
-	int i;
+	int i = 0;
 
 	zdev->apertures = kcalloc(MAX_APT_NUM, sizeof(struct addr_aperture),
 				 GFP_KERNEL);
@@ -209,17 +209,12 @@ static int zocl_aperture_init(struct drm_zocl_dev *zdev)
 		DRM_ERROR("Out of memory for Aperture\n");
 		return -ENOMEM;
 	}
-	
-	apts = zdev->apertures;
 
+	apts = zdev->apertures;
 	/* Consider this magic number as uninitialized aperture identity */
-	for (i = 0; i < MAX_APT_NUM; ++i) {
-#ifdef CONFIG_PHYS_ADDR_T_64BIT
-		apts[i].addr = 0xFFFFffffFFFFffff;
-#else
-		apts[i].addr = 0xFFFFffff;
-#endif	
-	}
+	for (i = 0; i < MAX_APT_NUM; ++i)
+		apts[i].addr = EMPTY_APT_VALUE;
+
 	zdev->num_apts = 0;
 
 	return 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -327,7 +327,11 @@ get_next_free_apt_index(struct drm_zocl_dev *zdev)
 	int apt_idx = 0;
 
 	for (apt_idx = 0; apt_idx < MAX_APT_NUM; ++apt_idx) {
-		if (zdev->apertures[apt_idx].addr == 0)
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+		if (zdev->apertures[apt_idx].addr == 0xFFFFffffFFFFffff)
+#else
+		if (zdev->apertures[apt_idx].addr == 0xFFFFffff)
+#endif
 			return apt_idx;
 	}
 
@@ -371,7 +375,11 @@ zocl_clean_aperture(struct drm_zocl_dev *zdev, u32 slot_idx)
 		apt = &zdev->apertures[apt_idx];
 		if (apt->slot_idx == slot_idx) {
 			/* Reset this aperture index */
-			apt->addr = 0;
+#ifdef CONFIG_PHYS_ADDR_T_64BIT
+			apt->addr = 0xFFFFffffFFFFffff;
+#else
+			apt->addr = 0xFFFFffff;
+#endif
 			apt->size = 0;
 			apt->prop = 0;
 			apt->cu_idx = -1;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -327,11 +327,7 @@ get_next_free_apt_index(struct drm_zocl_dev *zdev)
 	int apt_idx = 0;
 
 	for (apt_idx = 0; apt_idx < MAX_APT_NUM; ++apt_idx) {
-#ifdef CONFIG_PHYS_ADDR_T_64BIT
-		if (zdev->apertures[apt_idx].addr == 0xFFFFffffFFFFffff)
-#else
-		if (zdev->apertures[apt_idx].addr == 0xFFFFffff)
-#endif
+		if (zdev->apertures[apt_idx].addr == EMPTY_APT_VALUE)
 			return apt_idx;
 	}
 
@@ -375,11 +371,7 @@ zocl_clean_aperture(struct drm_zocl_dev *zdev, u32 slot_idx)
 		apt = &zdev->apertures[apt_idx];
 		if (apt->slot_idx == slot_idx) {
 			/* Reset this aperture index */
-#ifdef CONFIG_PHYS_ADDR_T_64BIT
-			apt->addr = 0xFFFFffffFFFFffff;
-#else
-			apt->addr = 0xFFFFffff;
-#endif
+			apt->addr = EMPTY_APT_VALUE;
 			apt->size = 0;
 			apt->prop = 0;
 			apt->cu_idx = -1;


### PR DESCRIPTION
kernel_4mem_access AIE_EVENT_TRACE 16_plio test  is failing for multi slot changes.
for aperture issue. 

Existing code we consider address "0" as a initialize address and considered that that's not a valid address for a CU.
But in this test case CU address is "0".
Fixed the issue. Used a magic numbe r0xFFFFffffFFFFffff for invalid address. 