### PR TITLE
Workaround dead-lock in hardware-emulation shutdown

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -1694,7 +1694,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     }
 
     //bool simDontRun = xclemulation::config::getInstance()->isDontRun();
-    if(!mSimDontRun)
+    /* If XRT_PCIE_HW_EMU_FORCE_SHUTDOWN environment variable
+       is set, skip the dead-locking wait for the simulator ending */
+    if(!mSimDontRun && !std::getenv("XRT_PCIE_HW_EMU_FORCE_SHUTDOWN"))
       while (-1 == waitpid(0, &status, 0));
 
     if(( lWaveform == xclemulation::debug_mode::gui || lWaveform == xclemulation::debug_mode::batch || lWaveform == xclemulation::debug_mode::off)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -28,6 +28,7 @@
 #include <array>
 #include <cctype>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <mutex>
@@ -1522,7 +1523,11 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     if(sock)
     {
       //Currently Versal platforms does not support buffer deallocation
-      if(!mVersalPlatform && sendtoxsim) {
+      if (!mVersalPlatform && sendtoxsim
+          /* If XRT_PCIE_HW_EMU_FORCE_SHUTDOWN environment variable
+             is set, skip the deallocation which seems to deadlock in
+             hw_emu in the communication with the simulation */
+          && !std::getenv("XRT_PCIE_HW_EMU_FORCE_SHUTDOWN")) {
         xclFreeDeviceBuffer_RPC_CALL(xclFreeDeviceBuffer,offset);
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Workaround dead-lock in hardware-emulation shutdown

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Just running some simple SYCL code on xsjsycl41 server.

#### How problem was solved, alternative solutions (if any) and why they were rejected

This is solved by an outrageous hack.

The user needs to define `XRT_PCIE_HW_EMU_FORCE_SHUTDOWN` environment variable before running an XRT program.

#### Risks (if any) associated the changes in the commit

This is probably not to be merged but to be used as a branch by other people hitting this problem while there is a real fix.

#### What has been tested and how, request additional testing if necessary

This works for us™. :-)

#### Documentation impact (if any)