### PR TITLE
Open binary files as binary

### DIFF
--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -77,7 +77,7 @@ read_xclbin(const std::string& fnm)
     throw std::runtime_error("No xclbin specified");
 
   // load the file
-  std::ifstream stream(fnm);
+  std::ifstream stream(fnm, std::ios::binary);
   if (!stream)
     throw std::runtime_error("Failed to open file '" + fnm + "' for reading");
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -606,7 +606,7 @@ XBUtilities::print_exception_and_throw_cancel(const std::runtime_error& e)
 std::vector<char>
 XBUtilities::get_axlf_section(const std::string& filename, axlf_section_kind kind)
 {
-  std::ifstream in(filename);
+  std::ifstream in(filename, std::ios::binary);
   if (!in.is_open())
     throw std::runtime_error(boost::str(boost::format("Can't open %s") % filename));
 


### PR DESCRIPTION
#### Problem solved by the commit
The xclbin axlf format is binary, opening the xclbin file should
use std::ios::binary.  In particular windows chokes on the binary
format and modifies read data.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered on native windows when reading xclbin via xrt::xclbin.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Open the file in binary mode.

