### PR TITLE
CR-1120510 : AIE report produces non-UTF-8 characters in error_msg

### DIFF
--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -151,3 +151,8 @@ zynq_device *zynq_device::get_dev()
 zynq_device::zynq_device(const std::string& root) : sysfs_root(root)
 {
 }
+
+zynq_device::~zynq_device()
+{
+	sysfs_root = "";
+}

--- a/src/runtime_src/core/edge/user/zynq_dev.h
+++ b/src/runtime_src/core/edge/user/zynq_dev.h
@@ -55,6 +55,7 @@ private:
         bool write = false, bool binary = false);
 
     std::string sysfs_root;
+    ~zynq_device();
     zynq_device(const std::string& sysfs_base);
     zynq_device(const zynq_device& s) = delete;
     zynq_device& operator=(const zynq_device& s) = delete;


### PR DESCRIPTION
Issue : 
While generating aie_status_edge.json which comes from the XRT device info reports under the hood. The third line of the file contains an error_msg string. However, this string contains characters that are not UTF-8 and therefore, parsing this file throws an exception.

CR:
https://jira.xilinx.com/browse/CR-1120510

Added a destructor as "zynq_device" class and reset the sysfs file name. 
Without that sysfs file is holding some garbage value and the same is reflected on the report. 