### PR TITLE
CR-1090469 ASTeR TC 21.03 - Improve error message for p2p

### DIFF
--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -431,15 +431,30 @@ struct shim : public DeviceType
   void
   p2p_enable(bool force) override
   {
-    if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), true, force))
-      throw system_error(ret, "failed to enable p2p");
+    auto ret = xclP2pEnable(DeviceType::get_device_handle(), true, force);
+    switch (ret) {
+      case -EINVAL:
+      case -ENODEV:
+        throw system_error(ret, "failed to enable p2p");
+        break;
+      default:
+        break;
+    }
   }
+      
 
   void
   p2p_disable(bool force) override
   {
-    if (auto ret = xclP2pEnable(DeviceType::get_device_handle(), false, force))
-      throw system_error(ret, "failed to disable p2p");
+    auto ret = xclP2pEnable(DeviceType::get_device_handle(), false, force);
+    switch (ret) {
+      case -EINVAL:
+      case -ENODEV:
+        throw system_error(ret, "failed to disable p2p");
+        break;
+      default:
+        break;
+    }
   }
 
   void

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1147,7 +1147,8 @@ int shim::p2pEnable(bool enable, bool force)
         mDev->sysfs_put("p2p", "p2p_enable", err, "0");
     }
     if (!err.empty()) {
-        throw std::runtime_error("P2P is not supported");
+        std::cerr << "ERROR: Config P2P failed : P2P is not supported" << std::endl;
+        throw xrt_core::error(std::errc::operation_canceled);
     }
 
     if (force) {
@@ -2664,6 +2665,9 @@ int xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
   try {
     xocl::shim *drv = xocl::shim::handleCheck(handle);
     return drv ? drv->p2pEnable(enable, force) : -ENODEV;
+  }
+  catch(const xrt_core::error&) {
+    throw xrt_core::error(std::errc::operation_canceled);
   }
   catch (const std::exception& ex) {
     xrt_core::send_exception_message(ex.what());

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1134,22 +1134,19 @@ int shim::p2pEnable(bool enable, bool force)
         return -EINVAL;
 
     ret = check_p2p_config(mDev, err);
-    if (ret == P2P_CONFIG_ENABLED && enable) {
+    if (ret == P2P_CONFIG_ENABLED && enable)
         throw std::runtime_error("P2P is already enabled");
-    } else if (ret == P2P_CONFIG_DISABLED && !enable) {
+    else if (ret == P2P_CONFIG_DISABLED && !enable)
         throw std::runtime_error("P2P is already disabled");
-    }
 
     /* write 0 to config for default bar size */
-    if (enable) {
+    if (enable)
         mDev->sysfs_put("p2p", "p2p_enable", err, "1");
-    } else {
+    else
         mDev->sysfs_put("p2p", "p2p_enable", err, "0");
-    }
-    if (!err.empty()) {
-        std::cerr << "ERROR: Config P2P failed : P2P is not supported" << std::endl;
-        throw xrt_core::error(std::errc::operation_canceled);
-    }
+
+    if (!err.empty())
+        throw xrt_core::error(std::errc::operation_canceled, "Config P2P failed : P2P is not supported");
 
     if (force) {
         dev_fini();
@@ -1168,13 +1165,12 @@ int shim::p2pEnable(bool enable, bool force)
     }
 
     ret = check_p2p_config(mDev, err);
-    if (!err.empty()) {
+    if (!err.empty())
         throw std::runtime_error(err);
-    } else if (ret == P2P_CONFIG_DISABLED && enable) {
+    else if (ret == P2P_CONFIG_DISABLED && enable)
         throw std::runtime_error("Can not enable P2P");
-    } else if (ret == P2P_CONFIG_ENABLED && !enable) {
+    else if (ret == P2P_CONFIG_ENABLED && !enable)
         throw std::runtime_error("Can not disable P2P");
-    }
 
     return 0;
 }
@@ -2662,17 +2658,8 @@ int xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 
 int xclP2pEnable(xclDeviceHandle handle, bool enable, bool force)
 {
-  try {
     xocl::shim *drv = xocl::shim::handleCheck(handle);
     return drv ? drv->p2pEnable(enable, force) : -ENODEV;
-  }
-  catch(const xrt_core::error&) {
-    throw xrt_core::error(std::errc::operation_canceled);
-  }
-  catch (const std::exception& ex) {
-    xrt_core::send_exception_message(ex.what());
-    return -ENODEV;
-  }
 }
 
 int xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t total_size)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1090469
When sudo xbutil configure --p2p enable -d <BDF> is ran on an unsupported platform, the error messaging is unclear.  This is also problematic for automated testing parsers the expected string can move around.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Change exception handling for p2p errors to shorten the output message. This was modeled after the XBUtilities::sudo_or_throw function which only prints out an error message and the operation cancelled message.

#### Risks (if any) associated the changes in the commit
It may be more prudent to set the catch for the xrt_core::error to something more specific, something we did not intend to get caught may end up in there. Comment below with suggestions! Perhaps using a more specific type of error?

#### What has been tested and how, request additional testing if necessary
Manually tested on U30 (No P2P) and U280 (P2P present)

U30 Testing:
```
root@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT# xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-96-generic
  Version              : #109-Ubuntu SMP Wed Jan 12 16:49:16 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15671 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Super Server

XRT
  Version              : 2.13.0
  Branch               : CR-1090469
  Hash                 : 9309f5e1ca602dfdc79be5f17d5afb4cb25e5d31
  Hash Date            : 2022-02-15 14:01:47
  XOCL                 : 2.13.0, a1dfb3b2a3efe42fb0c59fdb9afe692403787561
  XCLMGMT              : 2.13.0, a1dfb3b2a3efe42fb0c59fdb9afe692403787561

Devices present
  [0000:b3:00.1] : xilinx_u200_gen3x16_xdma_base_1 user(inst=130)
  [0000:18:00.1] : xilinx_u30_gen3x4_base_2 user(inst=129)
  [0000:17:00.1] : xilinx_u30_gen3x4_base_2 user(inst=128)

root@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT# xbutil configure --p2p enable -d 17:00
ERROR: Config P2P failed : P2P is not supported: Operation canceled
root@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT# echo $?
1
root@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT# xbutil configure --p2p disable -d 17:00
ERROR: Config P2P failed : P2P is not supported: Operation canceled
root@xsjsagarw50:/proj/xsjhdstaff6/dbenusov/XRT# echo $?
1
```

U280 Testing
```
root@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT# xbutil examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-97-generic
  Version              : #110-Ubuntu SMP Thu Jan 13 18:22:13 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1090469
  Hash                 : 9309f5e1ca602dfdc79be5f17d5afb4cb25e5d31
  Hash Date            : 2022-02-15 14:01:47
  XOCL                 : 2.13.376, 9309f5e1ca602dfdc79be5f17d5afb4cb25e5d31
  XCLMGMT              : 2.13.376, 9309f5e1ca602dfdc79be5f17d5afb4cb25e5d31

Devices present
  [0000:65:00.1] : xilinx_u280_xdma_201920_3 user(inst=130)
  [0000:17:00.1] : xilinx_u250_gen3x16_base_3 user(inst=128)

root@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT# xbutil configure --p2p enable -d 65:00
Please WARM reboot the machine to enable P2P now.
root@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT# xbutil configure --p2p disable -d 65:00
Please WARM reboot the machine to disable P2P now.
```