### PR TITLE
CR-1121553 - Config option changes and features for AIE trace

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -400,9 +400,9 @@ get_aie_profile_memory_metrics()
 }
 
 inline std::string
-get_aie_profile_shim_metrics()
+get_aie_profile_interface_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_profile_shim_metrics", "");
+  static std::string value = detail::get_string_value("Debug.aie_profile_interface_metrics", "");
   return value;
 }
 

--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -367,14 +367,14 @@ get_aie_trace_counter_scheme()
 inline std::string
 get_aie_trace_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_trace_metrics", "functions");
+  static std::string value = detail::get_string_value("Debug.aie_trace_metrics", "");
   return value;
 }
 
 inline std::string
-get_aie_trace_start_delay()
+get_aie_trace_start_time()
 {
-  static std::string value = detail::get_string_value("Debug.aie_trace_start_delay", "0");
+  static std::string value = detail::get_string_value("Debug.aie_trace_start_time", "0");
   return value;
 }
 
@@ -388,21 +388,21 @@ get_aie_trace_user_control()
 inline std::string
 get_aie_profile_core_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_profile_core_metrics", "heat_map");
+  static std::string value = detail::get_string_value("Debug.aie_profile_core_metrics", "");
   return value;
 }
 
 inline std::string
 get_aie_profile_memory_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_profile_memory_metrics", "conflicts");
+  static std::string value = detail::get_string_value("Debug.aie_profile_memory_metrics", "");
   return value;
 }
 
 inline std::string
 get_aie_profile_shim_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_profile_shim_metrics", "bandwidths");
+  static std::string value = detail::get_string_value("Debug.aie_profile_shim_metrics", "");
   return value;
 }
 

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -854,9 +854,12 @@ namespace xdp {
 
         if (counters.empty()) {
           std::string msg = "AIE Profile Counters were not found for this design. "
-                            "Please specify aie_profile_core_metrics and/or aie_profile_memory_metrics in your xrt.ini.";
+                            "Please specify aie_profile_core_metrics, aie_profile_memory_metrics, "
+                            "and/or aie_profile_shim_metrics in your xrt.ini.";
           xrt_core::message::send(severity_level::warning, "XRT", msg);
-        }
+    //      (db->getStaticInfo()).setIsAIECounterRead(deviceId,true);
+    //      return;
+	}
         else {
           XAie_DevInst* aieDevInst =
             static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle));
@@ -880,8 +883,14 @@ namespace xdp {
     xclGetDeviceInfo2(handle, &info);
     std::string deviceName = std::string(info.mName);
     // Create and register writer and file
-    std::string outputFile = "aie_profile_" + deviceName + "_" + mCoreMetricSet
-        + "_" + mMemoryMetricSet + "_" + mShimMetricSet + ".csv";
+    std::string core_str = (mCoreMetricSet.empty()) ? "" : "_" + mCoreMetricSet;
+    std::string mem_str  = (mMemoryMetricSet.empty()) ? "" : "_" + mMemoryMetricSet;
+    std::string shim_str = (mShimMetricSet.empty()) ? "" : "_" + mShimMetricSet;    
+
+    std::string test_msg = "CORE: ," + mCoreMetricSet + "," + mMemoryMetricSet + "," + mShimMetricSet + ",";
+    xrt_core::message::send(severity_level::warning, "XRT", test_msg);
+
+    std::string outputFile = "aie_profile_" + deviceName + core_str + mem_str + shim_str + ".csv";
 
     VPWriter* writer = new AIEProfilingWriter(outputFile.c_str(),
                                               deviceName.c_str(), mIndex);

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -634,7 +634,7 @@ namespace xdp {
     std::string metricSettings[NUM_MODULES] = 
         {xrt_core::config::get_aie_profile_core_metrics(),
          xrt_core::config::get_aie_profile_memory_metrics(),
-         xrt_core::config::get_aie_profile_shim_metrics()};
+         xrt_core::config::get_aie_profile_interface_metrics()};
 
     // Configure core, memory, and shim counters
     for (int module=0; module < NUM_MODULES; ++module) {
@@ -855,7 +855,7 @@ namespace xdp {
         if (counters.empty()) {
           std::string msg = "AIE Profile Counters were not found for this design. "
                             "Please specify aie_profile_core_metrics, aie_profile_memory_metrics, "
-                            "and/or aie_profile_shim_metrics in your xrt.ini.";
+                            "and/or aie_profile_interface_metrics in your xrt.ini.";
           xrt_core::message::send(severity_level::warning, "XRT", msg);
     //      (db->getStaticInfo()).setIsAIECounterRead(deviceId,true);
     //      return;

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -857,8 +857,8 @@ namespace xdp {
                             "Please specify aie_profile_core_metrics, aie_profile_memory_metrics, "
                             "and/or aie_profile_interface_metrics in your xrt.ini.";
           xrt_core::message::send(severity_level::warning, "XRT", msg);
-    //      (db->getStaticInfo()).setIsAIECounterRead(deviceId,true);
-    //      return;
+          (db->getStaticInfo()).setIsAIECounterRead(deviceId,true);
+          return;
 	}
         else {
           XAie_DevInst* aieDevInst =

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -887,9 +887,6 @@ namespace xdp {
     std::string mem_str  = (mMemoryMetricSet.empty()) ? "" : "_" + mMemoryMetricSet;
     std::string shim_str = (mShimMetricSet.empty()) ? "" : "_" + mShimMetricSet;    
 
-    std::string test_msg = "CORE: ," + mCoreMetricSet + "," + mMemoryMetricSet + "," + mShimMetricSet + ",";
-    xrt_core::message::send(severity_level::warning, "XRT", test_msg);
-
     std::string outputFile = "aie_profile_" + deviceName + core_str + mem_str + shim_str + ".csv";
 
     VPWriter* writer = new AIEProfilingWriter(outputFile.c_str(),

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -418,23 +418,27 @@ namespace xdp {
     // Default is 0 cycles
     uint64_t cycles = 0;
     // Regex can parse values like : "1s" "1ms" "1ns"
-    const std::regex size_regex("\\s*([0-9]+)\\s*(s|ms|us|ns|)\\s*");
+    const std::regex size_regex("\\s*(\\d+\\.?\\d*)\\s*(s|ms|us|ns|)\\s*");
     if (std::regex_match(size_str, pieces_match, size_regex)) {
       try {
         if (pieces_match[2] == "s") {
-          cycles = std::stoull(pieces_match[1]) * cycles_per_sec;
+          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec);
         } else if (pieces_match[2] == "ms") {
-          cycles = (std::stoull(pieces_match[1]) * cycles_per_sec) /  1e3;
+          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e3);
         } else if (pieces_match[2] == "us") {
-          cycles = (std::stoull(pieces_match[1]) * cycles_per_sec) /  1e6;
+          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e6);
         } else if (pieces_match[2] == "ns") {
-          cycles = (std::stoull(pieces_match[1]) * cycles_per_sec) /  1e9;
+          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]) * cycles_per_sec /  1e9);
         } else {
-          cycles = std::stoull(pieces_match[1]);
+          cycles = static_cast<uint64_t>(std::stof(pieces_match[1]));
         }
+        
+        std::string msg("Parsed aie_trace_start_time: " + std::to_string(cycles) + " cycles.");
+        xrt_core::message::send(xrt_core::message::severity_level::info, "XRT", msg);
+
       } catch (const std::exception& ) {
         // User specified number cannot be parsed
-        std::string msg("Unable to parse aie_trace_delay. Setting delay to 0.");
+        std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
       }
     }

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -409,7 +409,7 @@ namespace xdp {
     std::smatch pieces_match;
     uint64_t cycles_per_sec = static_cast<uint64_t>(freqMhz * 1e6);
     const uint64_t max_cycles = 0xffffffff;
-    std::string size_str = xrt_core::config::get_aie_trace_start_delay();
+    std::string size_str = xrt_core::config::get_aie_trace_start_time();
 
     // Catch cases like "1Ms" "1NS"
     std::transform(size_str.begin(), size_str.end(), size_str.begin(),

--- a/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/utility.cpp
@@ -48,7 +48,7 @@ namespace xdp {
 
   const char* getToolVersion()
   {
-    return "2021.1" ;
+    return "2022.1" ;
   }
 
   std::string getXRTVersion()


### PR DESCRIPTION
Renamed "start_delay" to "start_time", and "aie_profile_shim_metrics" to "aie_profile_interface_metrics". Removed function defaults for metrics in the config. Now skips aieprofile writing if no metrics are set.

Updated aie_trace delay regex to handle decimal values of time/clock_cycle, which get automatically converted to the closest possible integer clock cycle. 

Updated utility.cpp tool version string to current version.


