### PR TITLE
Caching xclbin received from VMR in ZOCL

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -36,7 +36,7 @@ int zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev,
 	struct drm_zocl_axlf *axlf_obj, struct sched_client_ctx *client);
 int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data,
 			struct drm_zocl_slot *slot);
-
+int zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data);
 bool zocl_xclbin_accel_adapter(int kds_mask);
 
 #endif /* _ZOCL_XCLBIN_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xgq.c
@@ -311,7 +311,6 @@ void *zxgq_init(struct zocl_xgq_init_args *arg)
 	size_t ringsz = arg->zxia_ring_size;
 	struct zocl_xgq *zxgq = devm_kzalloc(&arg->zxia_pdev->dev, sizeof(*zxgq), GFP_KERNEL);
 	u64 sqprod = 0, cqprod = 0;
-	u32 conf;
 
 	if (!zxgq)
 		return NULL;
@@ -328,13 +327,6 @@ void *zxgq_init(struct zocl_xgq_init_args *arg)
 	} else {
 		sqprod = (u64)(uintptr_t)(arg->zxia_xgq_ip + ZXGQ_IP_SQ_PROD);
 		cqprod = (u64)(uintptr_t)(arg->zxia_xgq_ip + ZXGQ_IP_CQ_PROD);
-		/* note: apply this when XGQ is reserved.
-		cqprod = (u64)(uintptr_t)(arg->zxia_xgq_ip + ZXGQ_IP_SQ_PROD);
-		sqprod = (u64)(uintptr_t)(arg->zxia_xgq_ip + ZXGQ_IP_CQ_PROD);
-		*/
-		/* Reset sq/cq tail pointer. */
-		conf = ioread32(arg->zxia_xgq_ip + ZXGQ_IP_CQ_CONF);
-		iowrite32(conf | ZXGQ_IP_RESET, arg->zxia_xgq_ip + ZXGQ_IP_CQ_CONF);
 	}
 	/* Reset ring buffer. */
 	memset_io(arg->zxia_ring, 0, ringsz);

--- a/src/runtime_src/core/include/xgq_impl.h
+++ b/src/runtime_src/core/include/xgq_impl.h
@@ -329,8 +329,7 @@ static inline int xgq_can_consume(struct xgq *xgq)
 }
 
 /*
- * Fast forward to where we left, should only be called during attach.
- * The ring may not be empty if peer alloc'ed ring, then pushed cmds to it before we attach.
+ * Fast forward to where we left. Used only during xgq_attach().
  */
 static inline void xgq_fast_forward(struct xgq *xgq, struct xgq_ring *ring)
 {
@@ -339,16 +338,19 @@ static inline void xgq_fast_forward(struct xgq *xgq, struct xgq_ring *ring)
 }
 
 /*
- * Check if XGQ tail pointer is reset to 0, which is required during allocation.
+ * Set consumed to be the same as produced to ignore any existing commands. And there should not
+ * be any left over commands anyway. Used only during xgq_alloc().
  */
-static inline int xgq_check_reset(struct xgq *xgq, struct xgq_ring *ring)
+static inline void xgq_soft_reset(struct xgq *xgq, struct xgq_ring *ring)
 {
 	xgq_ring_read_produced(xgq->xq_io_hdl, ring);
-	return ring->xr_produced == 0;
+	ring->xr_consumed = ring->xr_produced;
+	xgq_ring_write_consumed(xgq->xq_io_hdl, ring);
 }
 
-static inline void xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
-	    size_t n_slots, uint32_t slot_size, uint64_t sq_produced, uint64_t cq_produced)
+static inline void
+xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr,
+	 size_t n_slots, uint32_t slot_size, uint64_t sq_produced, uint64_t cq_produced)
 {
 	struct xgq_header hdr = {};
 	uint64_t sqprod, cqprod;
@@ -388,6 +390,9 @@ static inline void xgq_init(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, ui
 	hdr.xh_cq_produced = 0;
 	hdr.xh_flags = xgq->xq_flags;
 	xgq_copy_to_ring(xgq->xq_io_hdl, &hdr, ring_addr, sizeof(hdr));
+
+	xgq_soft_reset(xgq, &xgq->xq_sq);
+	xgq_soft_reset(xgq, &xgq->xq_cq);
 
 	// Write the magic number to confirm the header is fully initialized
 	hdr.xh_magic = XGQ_ALLOC_MAGIC;
@@ -440,11 +445,6 @@ xgq_alloc(struct xgq *xgq, uint64_t flags, uint64_t io_hdl, uint64_t ring_addr, 
 		return -E2BIG;
 
 	xgq_init(xgq, flags, io_hdl, ring_addr, numslots, slot_size, sq_produced, cq_produced);
-
-	/* Ring is not reset, stale commands may exist, can't use this xgq. */
-	if (!xgq_check_reset(xgq, &xgq->xq_sq) || !xgq_check_reset(xgq, &xgq->xq_cq))
-		return -EEXIST;
-
 	*ring_len = xgq_ring_len(numslots, slot_size);
 	return 0;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Cache XCLBIN received from VMR in ZOCL on Versal discovery platform. This is needed for follow-up PS kernel development work done by @jeffli-xilinx  and @rozumx .
2. Allow developers to manually swap out ZOCL on Versal discovery platform without impacting VMR.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
Risk is low since code path is not exercised on non-Versal discovery platform.
#### What has been tested and how, request additional testing if necessary
Tested with 0209 Shell + latest VMR.
#### Documentation impact (if any)
N/A