### PR TITLE
CR-1120196 , CR-1118376, CR-1079476

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -2,7 +2,7 @@
 /*
  * Xilinx Kernel Driver Scheduler
  *
- * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
  *
  * Authors: min.ma@xilinx.com
  *

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -548,6 +548,20 @@ static void ert_ctrl_legacy_fini(struct ert_ctrl *ec)
 	return;
 }
 
+static void ert_ctrl_unset_xgq(struct platform_device *pdev)
+{
+	struct ert_ctrl *ec = platform_get_drvdata(pdev);
+	int i = 0;
+
+	for (i = 0; i < ec->ec_exgq_capacity; i++) {
+		if (ec->ec_exgq[i] == NULL)
+			continue;
+
+		xocl_xgq_fini(ec->ec_exgq[i]);
+		ec->ec_exgq[i] = NULL;
+	}
+}
+
 static int ert_ctrl_xgq_init(struct ert_ctrl *ec)
 {
 	xdev_handle_t xdev = xocl_get_xdev(ec->ec_pdev);
@@ -811,7 +825,6 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 
 static int ert_ctrl_probe(struct platform_device *pdev)
 {
-	const char *const devname = dev_name(&pdev->dev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	bool ert_on = xocl_ert_on(xdev);
 	struct ert_ctrl	*ec = NULL;
@@ -862,6 +875,7 @@ static struct xocl_ert_ctrl_funcs ert_ctrl_ops = {
 	.is_version	= ert_ctrl_is_version,
 	.get_base	= ert_ctrl_get_base,
 	.setup_xgq	= ert_ctrl_setup_xgq,
+	.unset_xgq	= ert_ctrl_unset_xgq,
 };
 
 struct xocl_drv_private ert_ctrl_drv_priv = {

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -593,7 +593,7 @@ static int ert_ctrl_connect(struct platform_device *pdev)
 	int err = 0;
 
 	if (ec->ec_connected)
-		return -EBUSY;
+		return 0;
 
 	ec->ec_version = ert_ctrl_read32(ec->ec_cq_base + ERT_CTRL_VER_OFFSET);
 	switch (ec->ec_version) {
@@ -837,6 +837,11 @@ static int ert_ctrl_probe(struct platform_device *pdev)
 		err = ert_ctrl_cq_init(pdev);
 	if (err)
 		goto init_failed;
+
+	/* At this point, we are not able to attach control XGQ, since we don't
+	 * know if XGQ ERT is ready or not. We cannot wait for it.
+	 * The attach control XGQ can happen later by calling ert_ctrl_connect.
+	 */
 
 	if (sysfs_create_group(&pdev->dev.kobj, &ert_ctrl_attrgroup))
 		EC_ERR(ec, "Not able to create sysfs group");

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2333,8 +2333,8 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 	int err = 0;
 	int count = 0;
 
-	/* TODO: Pass slot handle to KDS to let it destroy CUs. */
-	xocl_kds_unregister_cus(xdev, 0);
+	/* TODO: Use slot handle to unregister CUs. CU subdev will be destroyed */
+	xocl_unregister_cus(xdev, 0);
 
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
@@ -2358,8 +2358,9 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 	if (count > 0)
 		icap_create_subdev_scu(pdev);
 
-	/* Create cu/scu subdev via KDS */
-	xocl_kds_register_cus(xdev, 0, uuid, icap->ip_layout, icap->ps_kernel);
+	/* Create cu/scu subdev by slot */
+	xocl_register_cus(xdev, 0, &xclbin->m_header.uuid,
+			  icap->ip_layout, icap->ps_kernel);
 
 	icap_create_subdev_debugip(pdev);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -2333,6 +2333,9 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 	int err = 0;
 	int count = 0;
 
+	/* TODO: Pass slot handle to KDS to let it destroy CUs. */
+	xocl_kds_unregister_cus(xdev, 0);
+
 	xocl_subdev_destroy_by_level(xdev, XOCL_SUBDEV_LEVEL_URP);
 
 	err = __icap_peer_xclbin_download(icap, xclbin, force_download);
@@ -2354,6 +2357,9 @@ static int __icap_download_bitstream_user(struct platform_device *pdev,
 	count = xrt_xclbin_get_section_num(xclbin, SOFT_KERNEL);
 	if (count > 0)
 		icap_create_subdev_scu(pdev);
+
+	/* Create cu/scu subdev via KDS */
+	xocl_kds_register_cus(xdev, 0, uuid, icap->ip_layout, icap->ps_kernel);
 
 	icap_create_subdev_debugip(pdev);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -231,5 +231,9 @@ u32 xocl_kds_live_clients(struct xocl_dev *xdev, pid_t **plist);
 int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds kds_cfg);
 void xocl_kds_cus_enable(struct xocl_dev *xdev);
 void xocl_kds_cus_disable(struct xocl_dev *xdev);
+int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hd, xuid_t *uuid,
+			  struct ip_layout *ip_layout,
+			  struct ps_kernel_node *ps_kernel);
+void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hd);
 
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -161,6 +161,22 @@ void xocl_update_mig_cache(struct xocl_dev *xdev)
 	mutex_unlock(&xdev->dev_lock);
 }
 
+int xocl_register_cus(xdev_handle_t xdev_hdl, int slot_hdl, xuid_t *uuid,
+		      struct ip_layout *ip_layout,
+		      struct ps_kernel_node *ps_kernel)
+{
+	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
+
+	return xocl_kds_register_cus(xdev, slot_hdl, uuid, ip_layout, ps_kernel);
+}
+
+void xocl_unregister_cus(xdev_handle_t xdev_hdl, int slot_hdl)
+{
+	struct xocl_dev *xdev = container_of(XDEV(xdev_hdl), struct xocl_dev, core);
+
+	return xocl_kds_unregister_cus(xdev, slot_hdl);
+}
+
 static int userpf_intr_config(xdev_handle_t xdev_hdl, u32 intr, bool en)
 {
 	int ret;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -519,7 +519,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		XDEV(xdev)->kernels = kernels;
 	}
 
-	xocl_ert_ctrl_disconnect(xdev);
+	memcpy(&XDEV(xdev)->kds_cfg, &axlf_ptr->kds_cfg, sizeof(axlf_ptr->kds_cfg));
 
 	err = xocl_icap_download_axlf(xdev, axlf, force_download);
 	/*

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1700,6 +1700,15 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 
 	num_cus = xocl_kds_fill_cu_info(xdev, slot_hdl, ip_layout, cu_info, MAX_CUS);
 
+	 /* The XGQ ERT doesn't support more than 64 CUs. Let this hardcoding.
+	  * We will re-looking at this once at supporting multiple xclbins.
+	  */
+	if (num_cus > 64) {
+		userpf_err(xdev, "More than 64 CUs found\n");
+		ret = -EINVAL;
+		goto out;
+	}
+
 	/* Don't send config command if ERT doesn't present */
 	if (!XDEV(xdev)->kds.ert)
 		goto create_regular_cu;
@@ -1717,7 +1726,8 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 	userpf_info(xdev, "Got ERT XGQ command version %d.%d\n", major, minor);
 	if (major != 1 && minor != 0) {
 		userpf_err(xdev, "Only support ERT XGQ command 1.0\n");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto out;
 	}
 
 	ret = xocl_kds_xgq_cfg_start(xdev, cfg, num_cus);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -917,7 +917,6 @@ int xocl_kds_reset(struct xocl_dev *xdev, const xuid_t *xclbin_id)
 {
 	xocl_kds_fa_clear(xdev);
 
-	kds_reset(&XDEV(xdev)->kds);
 	return 0;
 }
 
@@ -1851,5 +1850,7 @@ void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 		XDEV(xdev)->kds.ert_disable = true;
 	}
 
+	xocl_ert_ctrl_unset_xgq(xdev);
+	kds_reset(&XDEV(xdev)->kds);
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1725,6 +1725,19 @@ out:
 	return ret;
 }
 
+int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hd, xuid_t *uuid,
+			  struct struct ip_layout *ip_layout,
+			  struct struct ps_kernel_node *ps_kernel)
+{
+	userpf_err(xdev, "minm ----\n");
+	return 0;
+}
+
+void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hd)
+{
+	userpf_err(xdev, "minm ----\n");
+}
+
 /* The xocl_kds_update function should be called after xclbin is
  * downloaded. Do not use this function in other place.
  */

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1976,6 +1976,7 @@ struct xocl_ert_ctrl_funcs {
 	       int (* is_version)(struct platform_device *pdev, u32 major, u32 minor);
 	       u64 (* get_base)(struct platform_device *pdev);
 	       void *(* setup_xgq)(struct platform_device *pdev, int id, u64 offset);
+	       void (* unset_xgq)(struct platform_device *pdev);
 	};
 
 #define ERT_CTRL_DEV(xdev)     \
@@ -2005,6 +2006,9 @@ struct xocl_ert_ctrl_funcs {
 #define xocl_ert_ctrl_setup_xgq(xdev, id, offset) \
 	(ERT_CTRL_CB(xdev, setup_xgq) ? \
 	 ERT_CTRL_OPS(xdev)->setup_xgq(ERT_CTRL_DEV(xdev), id, offset) : NULL)
+#define xocl_ert_ctrl_unset_xgq(xdev) \
+	(ERT_CTRL_CB(xdev, unset_xgq) ? \
+	 ERT_CTRL_OPS(xdev)->unset_xgq(ERT_CTRL_DEV(xdev)) : NULL)
 
 /* helper functions */
 xdev_handle_t xocl_get_xdev(struct platform_device *pdev);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -62,6 +62,7 @@
 #include <linux/firmware.h>
 #include "kds_core.h"
 #include "xclerr_int.h"
+#include "ps_kernel.h"
 #if defined(RHEL_RELEASE_CODE)
 #if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 3)
 #include <linux/sched/signal.h>
@@ -611,6 +612,7 @@ struct xocl_dev_core {
 	 */
 	int			ksize;
 	char			*kernels;
+	struct drm_xocl_kds	kds_cfg;
 
 	/*
 	 * Store information about pci bar mappings of CPM.
@@ -2432,6 +2434,24 @@ static inline int xocl_kds_fini_ert(xdev_handle_t xdev)
 {
 	return kds_fini_ert(&XDEV(xdev)->kds);
 }
+
+#if PF == MGMTPF
+static inline int xocl_register_cus(xdev_handle_t xdev, int slot_hdl, xuid_t *uuid,
+		      struct ip_layout *ip_layout,
+		      struct ps_kernel_node *ps_kernel)
+{
+	return 0;
+}
+static inline void xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl)
+{
+	return;
+}
+#else
+int xocl_register_cus(xdev_handle_t xdev, int slot_hdl, xuid_t *uuid,
+		      struct ip_layout *ip_layout,
+		      struct ps_kernel_node *ps_kernel);
+void xocl_unregister_cus(xdev_handle_t xdev, int slot_hdl);
+#endif
 
 /* context helpers */
 extern struct mutex xocl_drvinst_mutex;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. Add identify XGQ command to detect ERT version and fix CR-1079476
2. Fix CR-1120196, stress test hang issue
3. Add 64 CU limite on ERT

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Fix stress test hang issue. It was introduced by enabling XGQ.

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. During xclbin download, host will send XGQ identify command, print the <major.minor> version on dmesg and check the supported version.
2. Fix stress test hang issue. Stop KDS thread in unregister CU function call, which is called by ICAP and just before program the device.

#### Risks (if any) associated the changes in the commit
No obviously risks

#### What has been tested and how, request additional testing if necessary
xbutil validate on U50

#### Documentation impact (if any)
No
