### PR TITLE
VITIS 2383: xbutil to show usage stats for all buffer types

### DIFF
--- a/src/runtime_src/core/tools/common/Report.cpp
+++ b/src/runtime_src/core/tools/common/Report.cpp
@@ -57,17 +57,28 @@ Report::getSchemaDescription(SchemaVersion _schemaVersion)
   return getSchemaDescription(SchemaVersion::unknown);
 }
 
-
 Report::Report(const std::string & _reportName,
                const std::string & _shortDescription,
                bool _isDeviceRequired)
   : m_reportName(_reportName)
   , m_shortDescription(_shortDescription)
   , m_isDeviceRequired(_isDeviceRequired)
+  , m_isHidden(false)
 {
   // Empty
 }
 
+Report::Report(const std::string & _reportName,
+               const std::string & _shortDescription,
+               bool _isDeviceRequired,
+               bool _isHidden)
+  : m_reportName(_reportName)
+  , m_shortDescription(_shortDescription)
+  , m_isDeviceRequired(_isDeviceRequired)
+  , m_isHidden(_isHidden)
+{
+  // Empty
+}
 
 void 
 Report::getFormattedReport( const xrt_core::device *pDevice, 

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -56,6 +56,7 @@ class Report {
   const std::string & getReportName() const { return m_reportName; };
   const std::string & getShortDescription() const { return m_shortDescription; };
   bool isDeviceRequired() const { return m_isDeviceRequired; };
+  bool isHidden() const { return m_isHidden; };
 
   void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 
@@ -68,6 +69,7 @@ class Report {
  // Child class Helper methods
  protected:
   Report(const std::string & _reportName, const std::string & _shortDescription, bool _deviceRequired);
+  Report(const std::string & _reportName, const std::string & _shortDescription, bool _deviceRequired, bool _isHidden);
 
  private:
   Report() = delete;
@@ -77,6 +79,8 @@ class Report {
    std::string m_reportName;
    std::string m_shortDescription;
    bool m_isDeviceRequired;
+
+   bool m_isHidden;
 };
 
 

--- a/src/runtime_src/core/tools/common/ReportBOStats.cpp
+++ b/src/runtime_src/core/tools/common/ReportBOStats.cpp
@@ -130,9 +130,9 @@ ReportBOStats::writeReport(const xrt_core::device* /*pDevice*/,
 {
   boost::property_tree::ptree empty_ptree;
 
-  Table2D::HeaderData bo_type = {"Buffer Type", Table2D::Justification::right};
-  Table2D::HeaderData bo_count = {"Buffer Count", Table2D::Justification::center};
-  Table2D::HeaderData mem_used = {"Memory Usage", Table2D::Justification::center};
+  Table2D::HeaderData bo_type = {"Buffer Type", Table2D::Justification::left};
+  Table2D::HeaderData bo_count = {"Buffer Count", Table2D::Justification::right};
+  Table2D::HeaderData mem_used = {"Memory Usage", Table2D::Justification::right};
   std::vector<Table2D::HeaderData> table_headers = {bo_type, bo_count, mem_used};
   Table2D bo_table(table_headers);
 

--- a/src/runtime_src/core/tools/common/ReportBOStats.cpp
+++ b/src/runtime_src/core/tools/common/ReportBOStats.cpp
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+// ------ I N C L U D E   F I L E S -------------------------------------------
+// Local - Include Files
+#include "ReportBOStats.h"
+#include "Table2D.h"
+#include "XBUtilities.h"
+
+// 3rd Party Library - Include Files
+#include <string>
+#include <boost/format.hpp>
+#include <boost/range/as_array.hpp>
+
+namespace xq = xrt_core::query;
+
+void
+ReportBOStats::getPropertyTreeInternal( const xrt_core::device * pDevice,
+                                     boost::property_tree::ptree & pt) const
+{
+  // Defer to the 20202 format.  If we ever need to update JSON data,
+  // Then update this method to do so.
+  getPropertyTree20202(pDevice, pt);
+}
+
+void
+ReportBOStats::getPropertyTree20202( const xrt_core::device * pDevice,
+                                  boost::property_tree::ptree & pt) const
+{
+  boost::property_tree::ptree pt2_list;
+
+  try {
+    auto mem_stat_char = xrt_core::device_query<xrt_core::query::memstat>(pDevice);
+    std::vector<std::string> mem_stat;
+
+    //Convert vector of char from query cmd into vector of strings separated by null char separated by null char
+    boost::split(mem_stat, mem_stat_char, boost::is_any_of("\n"));
+    /* Content of mem_stat now will be as below:
+        [UNUSED] bank0@0x004000000000 (16384MB): 0KB 0BOs
+        [IN-USE] bank1@0x005000000000 (16384MB): 0KB 0BOs
+        [UNUSED] bank2@0x006000000000 (16384MB): 0KB 0BOs
+        [UNUSED] bank3@0x007000000000 (16384MB): 0KB 0BOs
+        [UNUSED] PLRAM[0]@0x003000000000 (0MB): 0KB 0BOs
+        [UNUSED] PLRAM[1]@0x003000400000 (0MB): 0KB 0BOs
+        [UNUSED] PLRAM[2]@0x003000600000 (0MB): 0KB 0BOs
+        [IN-USE] HOST[0]@0x002000000000 (16384MB): 0KB 0BOs
+        [== BO Stats Below ==] NA@0x000000000000 (0MB): 0KB 0BOs
+        [Regular] 0KB 0BOs
+        [UserPointer] 0KB 0BOs
+        [P2P] 0KB 0BOs
+        [DeviceOnly] 0KB 0BOs
+        [Imported] 0KB 0BOs
+        [ExecBuf] 0KB 0BOs
+        [CMA] 0KB 0BOs
+    */
+    bool found = false;
+
+    //Skip DDR usage info by looking for line with string "BO Stats Below"
+    //Following that are BO stats. BO type, size in KB and num of BOs fields separated by blank space
+    for (const auto& line: mem_stat) {
+      if (line.empty())
+        continue;
+
+      //Skip DDR usage stats at begining by looking for beloe string
+      if (!found && line.find("BO Stats Below") != std::string::npos) {
+        found = true;
+	continue;
+      } else if (!found)
+	continue;
+
+      //Capture BOStat fields separated by blank space
+      std::vector<std::string> bo_info;
+      boost::split(bo_info, line, boost::is_any_of("\t "));
+      //Expected fileds are BO type, size in KB and Num of BOs
+      if (bo_info.size() != 3)
+        throw std::runtime_error((boost::format("ERROR: Unexpected format in BO Stats. Line: %s") % line).str());
+
+      boost::property_tree::ptree bo_pt;
+      if (bo_info[0].length() < 5 || bo_info[1].length() < 3 || bo_info[2].length() < 4) {
+        bo_pt.put("bufer_type", "Invalid");
+        bo_pt.put("buffer_count", "n/a");
+        bo_pt.put("memory_used", "n/a");
+        bo_pt.put("memory_used_unit", "n/a");
+        bo_pt.put("memory_used_bytes", "n/a");
+      } else {
+	std::string mem_used(bo_info[1]);
+	mem_used.pop_back();
+	auto mem_used_bytes = XBUtilities::string_to_bytes(mem_used);
+	mem_used.pop_back();
+        bo_pt.put("buffer_type", bo_info[0].substr(1, bo_info[0].length()-2));
+        bo_pt.put("buffer_count", bo_info[2].substr(0, bo_info[2].length()-3));
+        bo_pt.put("memory_used", mem_used);
+        bo_pt.put("memory_used_unit", bo_info[1].substr(bo_info[1].length()-2, 2));
+        bo_pt.put("memory_used_bytes", mem_used_bytes);
+      }
+      pt2_list.push_back(std::make_pair("", bo_pt));
+    }
+  } catch(const xrt_core::error& e) {
+    std::cerr << "ERROR: " << e.what() << std::endl;
+    std::cerr << "ERROR: bo_stats cmd - invalid format" << std::endl;
+    return; //Give error and let script continue
+  } catch (...) {
+    std::cerr << "ERROR: bo_stats cmd - invalid format" << std::endl;
+    return; //Give error and let script continue
+  }
+
+  // There can only be 1 root node
+  pt.add_child("buffer_object_stats", pt2_list);
+}
+
+
+void
+ReportBOStats::writeReport(const xrt_core::device* /*pDevice*/,
+                        const boost::property_tree::ptree& pt,
+                        const std::vector<std::string>& /*elementsFilter*/,
+                        std::ostream & output) const
+{
+  boost::property_tree::ptree empty_ptree;
+
+  Table2D::HeaderData bo_type = {"Buffer Type", Table2D::Justification::right};
+  Table2D::HeaderData bo_count = {"Buffer Count", Table2D::Justification::center};
+  Table2D::HeaderData mem_used = {"Memory Usage", Table2D::Justification::center};
+  std::vector<Table2D::HeaderData> table_headers = {bo_type, bo_count, mem_used};
+  Table2D bo_table(table_headers);
+
+
+  for(auto& kv : pt.get_child("buffer_object_stats", empty_ptree)) {
+    const boost::property_tree::ptree& v = kv.second;
+
+    std::string mem_string = v.get<std::string>("memory_used")
+        + " " + v.get<std::string>("memory_used_unit");
+
+    std::vector<std::string> entry_data = {v.get<std::string>("buffer_type"),
+	v.get<std::string>("buffer_count"),
+	mem_string};
+
+    bo_table.addEntry(entry_data);
+  }
+
+  output << bo_table << std::endl;
+}

--- a/src/runtime_src/core/tools/common/ReportBOStats.cpp
+++ b/src/runtime_src/core/tools/common/ReportBOStats.cpp
@@ -42,79 +42,66 @@ ReportBOStats::getPropertyTree20202( const xrt_core::device * pDevice,
 {
   boost::property_tree::ptree pt2_list;
 
-  try {
-    auto mem_stat_char = xrt_core::device_query<xrt_core::query::memstat>(pDevice);
-    std::vector<std::string> mem_stat;
+  auto mem_stat_char = xrt_core::device_query<xrt_core::query::memstat>(pDevice);
+  std::vector<std::string> mem_stat;
 
-    //Convert vector of char from query cmd into vector of strings separated by null char separated by null char
-    boost::split(mem_stat, mem_stat_char, boost::is_any_of("\n"));
-    /* Content of mem_stat now will be as below:
-        [UNUSED] bank0@0x004000000000 (16384MB): 0KB 0BOs
-        [IN-USE] bank1@0x005000000000 (16384MB): 0KB 0BOs
-        [UNUSED] bank2@0x006000000000 (16384MB): 0KB 0BOs
-        [UNUSED] bank3@0x007000000000 (16384MB): 0KB 0BOs
-        [UNUSED] PLRAM[0]@0x003000000000 (0MB): 0KB 0BOs
-        [UNUSED] PLRAM[1]@0x003000400000 (0MB): 0KB 0BOs
-        [UNUSED] PLRAM[2]@0x003000600000 (0MB): 0KB 0BOs
-        [IN-USE] HOST[0]@0x002000000000 (16384MB): 0KB 0BOs
-        [== BO Stats Below ==] NA@0x000000000000 (0MB): 0KB 0BOs
-        [Regular] 0KB 0BOs
-        [UserPointer] 0KB 0BOs
-        [P2P] 0KB 0BOs
-        [DeviceOnly] 0KB 0BOs
-        [Imported] 0KB 0BOs
-        [ExecBuf] 0KB 0BOs
-        [CMA] 0KB 0BOs
-    */
-    bool found = false;
+  //Convert vector of char from query cmd into vector of strings separated by null char separated by null char
+  boost::split(mem_stat, mem_stat_char, boost::is_any_of("\n"));
+  /* Content of mem_stat now will be as below:
+      [UNUSED] bank0@0x004000000000 (16384MB): 0KB 0BOs
+      [IN-USE] bank1@0x005000000000 (16384MB): 0KB 0BOs
+      [UNUSED] bank2@0x006000000000 (16384MB): 0KB 0BOs
+      [UNUSED] bank3@0x007000000000 (16384MB): 0KB 0BOs
+      [UNUSED] PLRAM[0]@0x003000000000 (0MB): 0KB 0BOs
+      [UNUSED] PLRAM[1]@0x003000400000 (0MB): 0KB 0BOs
+      [UNUSED] PLRAM[2]@0x003000600000 (0MB): 0KB 0BOs
+      [IN-USE] HOST[0]@0x002000000000 (16384MB): 0KB 0BOs
+      [== BO Stats Below ==] NA@0x000000000000 (0MB): 0KB 0BOs
+      [Regular] 0KB 0BOs
+      [UserPointer] 0KB 0BOs
+      [P2P] 0KB 0BOs
+      [DeviceOnly] 0KB 0BOs
+      [Imported] 0KB 0BOs
+      [ExecBuf] 0KB 0BOs
+      [CMA] 0KB 0BOs
+  */
+  bool found = false;
 
-    //Skip DDR usage info by looking for line with string "BO Stats Below"
-    //Following that are BO stats. BO type, size in KB and num of BOs fields separated by blank space
-    for (const auto& line: mem_stat) {
-      if (line.empty())
-        continue;
+  //Skip DDR usage info by looking for line with string "BO Stats Below"
+  //Following that are BO stats. BO type, size in KB and num of BOs fields separated by blank space
+  for (const auto& line: mem_stat) {
+    if (line.empty())
+      continue;
 
-      //Skip DDR usage stats at begining by looking for beloe string
-      if (!found && line.find("BO Stats Below") != std::string::npos) {
+    //Skip DDR usage stats at begining by looking for beloe string
+    if (!found) {
+      if (line.find("BO Stats Below") != std::string::npos)
         found = true;
-	continue;
-      } else if (!found)
-	continue;
-
-      //Capture BOStat fields separated by blank space
-      std::vector<std::string> bo_info;
-      boost::split(bo_info, line, boost::is_any_of("\t "));
-      //Expected fileds are BO type, size in KB and Num of BOs
-      if (bo_info.size() != 3)
-        throw std::runtime_error((boost::format("ERROR: Unexpected format in BO Stats. Line: %s") % line).str());
-
-      boost::property_tree::ptree bo_pt;
-      if (bo_info[0].length() < 5 || bo_info[1].length() < 3 || bo_info[2].length() < 4) {
-        bo_pt.put("bufer_type", "Invalid");
-        bo_pt.put("buffer_count", "n/a");
-        bo_pt.put("memory_used", "n/a");
-        bo_pt.put("memory_used_unit", "n/a");
-        bo_pt.put("memory_used_bytes", "n/a");
-      } else {
-	std::string mem_used(bo_info[1]);
-	mem_used.pop_back();
-	auto mem_used_bytes = XBUtilities::string_to_bytes(mem_used);
-	mem_used.pop_back();
-        bo_pt.put("buffer_type", bo_info[0].substr(1, bo_info[0].length()-2));
-        bo_pt.put("buffer_count", bo_info[2].substr(0, bo_info[2].length()-3));
-        bo_pt.put("memory_used", mem_used);
-        bo_pt.put("memory_used_unit", bo_info[1].substr(bo_info[1].length()-2, 2));
-        bo_pt.put("memory_used_bytes", mem_used_bytes);
-      }
-      pt2_list.push_back(std::make_pair("", bo_pt));
+      continue;
     }
-  } catch(const xrt_core::error& e) {
-    std::cerr << "ERROR: " << e.what() << std::endl;
-    std::cerr << "ERROR: bo_stats cmd - invalid format" << std::endl;
-    return; //Give error and let script continue
-  } catch (...) {
-    std::cerr << "ERROR: bo_stats cmd - invalid format" << std::endl;
-    return; //Give error and let script continue
+
+    //Capture BOStat fields separated by blank space
+    std::vector<std::string> bo_info;
+    boost::split(bo_info, line, boost::is_any_of("\t "));
+    //Expected fileds are BO type, size in KB and Num of BOs
+    if (bo_info.size() != 3)
+      throw std::runtime_error((boost::format("ERROR: Unexpected format in BO Stats. Line: %s") % line).str());
+
+    boost::property_tree::ptree bo_pt;
+    if (bo_info[0].length() < 5 || bo_info[1].length() < 3 || bo_info[2].length() < 4) {
+      bo_pt.put("bufer_type", "Invalid");
+      bo_pt.put("buffer_count", "n/a");
+      bo_pt.put("memory_used_bytes", "n/a");
+    } else {
+      std::string mem_used(bo_info[1]);
+      mem_used.pop_back();
+      auto mem_used_bytes = XBUtilities::string_to_bytes(mem_used);
+      mem_used.pop_back();
+      bo_pt.put("buffer_type", bo_info[0].substr(1, bo_info[0].length()-2));
+      bo_pt.put("buffer_count", bo_info[2].substr(0, bo_info[2].length()-3));
+      bo_pt.put("memory_used_bytes", mem_used_bytes);
+    }
+    pt2_list.push_back(std::make_pair("", bo_pt));
   }
 
   // There can only be 1 root node
@@ -132,7 +119,7 @@ ReportBOStats::writeReport(const xrt_core::device* /*pDevice*/,
 
   Table2D::HeaderData bo_type = {"Buffer Type", Table2D::Justification::left};
   Table2D::HeaderData bo_count = {"Buffer Count", Table2D::Justification::right};
-  Table2D::HeaderData mem_used = {"Memory Usage", Table2D::Justification::right};
+  Table2D::HeaderData mem_used = {"Memory Usage (B)", Table2D::Justification::right};
   std::vector<Table2D::HeaderData> table_headers = {bo_type, bo_count, mem_used};
   Table2D bo_table(table_headers);
 
@@ -140,12 +127,9 @@ ReportBOStats::writeReport(const xrt_core::device* /*pDevice*/,
   for(auto& kv : pt.get_child("buffer_object_stats", empty_ptree)) {
     const boost::property_tree::ptree& v = kv.second;
 
-    std::string mem_string = v.get<std::string>("memory_used")
-        + " " + v.get<std::string>("memory_used_unit");
-
     std::vector<std::string> entry_data = {v.get<std::string>("buffer_type"),
 	v.get<std::string>("buffer_count"),
-	mem_string};
+	v.get<std::string>("memory_used_bytes")};
 
     bo_table.addEntry(entry_data);
   }

--- a/src/runtime_src/core/tools/common/ReportBOStats.h
+++ b/src/runtime_src/core/tools/common/ReportBOStats.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __ReportBOStats_h_
+#define __ReportBOStats_h_
+
+// Please keep eternal include file dependencies to a minimum
+#include "Report.h"
+
+class ReportBOStats: public Report {
+ public:
+  ReportBOStats() : Report("bo-stats", "Usage stats of all BO types", true /*device required*/, true /*isHidden*/) { /*empty*/ };
+
+ // Child methods that need to be implemented
+ public:
+  virtual void getPropertyTreeInternal(const xrt_core::device * pDevice, boost::property_tree::ptree & pt) const;
+  virtual void getPropertyTree20202(const xrt_core::device * pDevice, boost::property_tree::ptree & pt) const;
+  virtual void writeReport(const xrt_core::device* pDevice, const boost::property_tree::ptree& pt, const std::vector<std::string>& elementsFilter, std::ostream & output) const;
+};
+
+#endif
+
+

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -578,8 +578,12 @@ XBUtilities::create_suboption_list_string( const ReportCollection &_reportCollec
   VectorPairStrings reportDescriptionCollection;
 
   // Add the report names and description
-  for (const auto & report : _reportCollection) 
+  for (const auto & report : _reportCollection) {
+    // Skip hidden reports
+    if (!XBU::getShowHidden() && report->isHidden()) 
+      continue;
     reportDescriptionCollection.emplace_back(report->getReportName(), report->getShortDescription());
+  }
 
   // 'verbose' option
   if (_addAllOption) 
@@ -615,7 +619,12 @@ XBUtilities::collect_and_validate_reports( const ReportCollection &allReportsAva
 {
   // If "verbose" used, then use all of the reports
   if (std::find(reportNamesToAdd.begin(), reportNamesToAdd.end(), "all") != reportNamesToAdd.end()) {
-    reportsToUse = allReportsAvailable;
+    for (const auto & report : allReportsAvailable) {
+      // Skip hidden reports
+      if (report->isHidden()) 
+        continue;
+      reportsToUse.emplace_back(report);
+    }
   } else { 
     // Examine each report name for a match 
     for (const auto & reportName : reportNamesToAdd) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -55,28 +55,30 @@ namespace po = boost::program_options;
 #include "tools/common/ReportMailbox.h"
 #include "tools/common/ReportQspiStatus.h"
 #include "tools/common/ReportCmcStatus.h"
+#include "tools/common/ReportBOStats.h"
 
 // Note: Please insert the reports in the order to be displayed (alphabetical)
   static ReportCollection fullReportCollection = {
   // Common reports
     std::make_shared<ReportAie>(),
     std::make_shared<ReportAieShim>(),
-    std::make_shared<ReportMemory>(),
-    std::make_shared<ReportHost>(),
-    std::make_shared<ReportDynamicRegion>(),
-    std::make_shared<ReportDebugIpStatus>(),
     std::make_shared<ReportAsyncError>(),
+    std::make_shared<ReportBOStats>(),
+    std::make_shared<ReportDebugIpStatus>(),
+    std::make_shared<ReportDynamicRegion>(),
+    std::make_shared<ReportHost>(),
+    std::make_shared<ReportMemory>(),
     std::make_shared<ReportPcieInfo>(),
     std::make_shared<ReportPlatforms>(),
   // Native only reports
   #ifdef ENABLE_NATIVE_SUBCMDS_AND_REPORTS
+    std::make_shared<ReportCmcStatus>(),
     std::make_shared<ReportElectrical>(),
+    std::make_shared<ReportFirewall>(),
     std::make_shared<ReportMailbox>(),
     std::make_shared<ReportMechanical>(),
-    std::make_shared<ReportFirewall>(),
-    std::make_shared<ReportThermal>(),
     std::make_shared<ReportQspiStatus>(),
-    std::make_shared<ReportCmcStatus>(),
+    std::make_shared<ReportThermal>(),
   #endif
   };
 


### PR DESCRIPTION
**See json output & txt output info in separate comment below**

Problem solved by the commit
None. Early access feature for xbutil to show usage stats of BOs

Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None

What has been tested and how, request additional testing if necessary
Tested Locally

Documentation impact (if any)
To be done as early access