### PR TITLE
CR-1119057 XRT github documentation has repeated yum install steps for CENTOS 7.x

### DIFF
--- a/src/runtime_src/doc/toc/install.rst
+++ b/src/runtime_src/doc/toc/install.rst
@@ -27,7 +27,6 @@ Steps for RHEL 8.x::
 Steps for CENTOS 7.x::
 
 	yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-	yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 Steps for CENTOS 8.x::
 


### PR DESCRIPTION
#### Problem solved by the commit 
  In xilinx.github.io, XRT Installation, downloading of EPEL step is repeated. In this commit, repeated step is removed
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Repeated line under CentOS 7.x of XRT installation section , `yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm` is removed 
#### Risks (if any) associated the changes in the commit
Low Risk
#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
Repeated step of downloading EPEL package for CentOS 7.x is removed .