### PR TITLE
CR-1122745 unsupported hostmem-bw item should be marked as skipped

### DIFF
--- a/src/runtime_src/core/tools/common/Process.cpp
+++ b/src/runtime_src/core/tools/common/Process.cpp
@@ -164,7 +164,7 @@ XBUtilities::runScript( const std::string & env,
 
   is_done = true;
   bool passed = (os_stdout.str().find("PASS") != std::string::npos) ? true : false;
-  bool skipped = (os_stdout.str().find("EOPNOTSUPP") != std::string::npos) ? true : false;
+  bool skipped = (os_stdout.str().find("NOT SUPPORTED") != std::string::npos) ? true : false;
   run_test.get()->finish(passed, final_description);
   // Workaround: Clear the default progress bar output so as to print the Error: before printing [FAILED]
   // Remove this once busybar is implemented


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On CentOS, when a standalone validate test case does not apply for a platform, we failed to skip, but actually failed the xbutil validate. This is because we did not grep the correct output message from the test case's host code.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
Grep the correct string.
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on the machine where the issue can be seen.
#### Documentation impact (if any)
N/A