### PR TITLE
XRT-920 implement RPU to APU XGQ communication - VMR

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -135,7 +135,7 @@ struct xgq_cmd_sensor_payload {
 	uint32_t size;
 	uint32_t offset;
 	uint32_t aid:8;
-	uint32_t pid:8;
+	uint32_t sid:8;
 	uint32_t addr_type:3;
 	uint32_t rsvd1:13;
 	uint32_t pad;
@@ -282,7 +282,8 @@ struct xgq_cmd_cq_vmr_payload {
 	uint16_t has_ext_xsabin:1;
 	uint16_t has_ext_scfw:1;
 	uint16_t has_ext_sysdtb:1;
-	uint16_t resvd1:7;
+	uint16_t apu_is_ready:1;
+	uint16_t resvd1:6;
 	uint16_t multi_boot_offset;
 	uint32_t debug_level:3;
 	uint32_t program_progress:7;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- having driver to load apu image and wait till APU is started. Usually it takes a while (11s roughly) but way better than u30 (60s~). And we also avoid re-downloading APU PDI from vmr side.

- fix some header file naming inconsistent name from XGQ spec.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
- Tested on shell 0216.
- ERT works well as well.

#### Documentation impact (if any)
