### PR TITLE
hwmon_sdm: remove unnecessary check in hwmon_sdm device callbacks

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2185,7 +2185,7 @@ struct xocl_sdm_funcs {
 	(SUBDEV(xdev, XOCL_SUBDEV_HWMON_SDM) ? 			\
 	(struct xocl_sdm_funcs *)SUBDEV(xdev, XOCL_SUBDEV_HWMON_SDM)->ops : NULL)
 #define	SDM_CB(xdev, cb)					\
-	(XGQ_DEV(xdev) && SDM_DEV(xdev) && SDM_OPS(xdev) && SDM_OPS(xdev)->cb)
+	(SDM_DEV(xdev) && SDM_OPS(xdev) && SDM_OPS(xdev)->cb)
 #define	xocl_hwmon_sdm_get_sensors_list(xdev, create_sysfs)		\
 	(SDM_CB(xdev, hwmon_sdm_get_sensors_list) ?			\
 	SDM_OPS(xdev)->hwmon_sdm_get_sensors_list(SDM_DEV(xdev), create_sysfs) : -ENODEV)


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Seeing below errors on versal platform:
[  +0.000250] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 process_request: received request from peer: 16, passed on
[  +0.000011] xclmgmt 0000:d8:00.0: xclmgmt_read_subdev_req: req kind 7
[  +0.261946] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 mailbox_post_response: posting response for: 16 via HW
[  +0.010148] xocl 0000:d8:00.1:  ffff8c082f5ff098 xocl_hwmon_sdm_init_sysfs: hwmon_sdm sysfs creation failed for xcl_sdr 0x7, err: -19
[  +0.000023] xocl 0000:d8:00.1: mailbox.u.9437184 ffff8c0c203bb410 _mailbox_request: sending request: 16 via HW
[  +0.000279] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 process_request: received request from peer: 16, passed on
[  +0.000007] xclmgmt 0000:d8:00.0: xclmgmt_read_subdev_req: req kind 8
[  +0.488620] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 mailbox_post_response: posting response for: 16 via HW
[  +0.010220] xocl 0000:d8:00.1:  ffff8c082f5ff098 xocl_hwmon_sdm_init_sysfs: hwmon_sdm sysfs creation failed for xcl_sdr 0x8, err: -19
[  +0.000013] xocl 0000:d8:00.1: mailbox.u.9437184 ffff8c0c203bb410 _mailbox_request: sending request: 16 via HW
[  +0.000312] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 process_request: received request from peer: 16, passed on
[  +0.000008] xclmgmt 0000:d8:00.0: xclmgmt_read_subdev_req: req kind 10
[  +0.489731] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 mailbox_post_response: posting response for: 16 via HW
[  +0.010131] xocl 0000:d8:00.1:  ffff8c082f5ff098 xocl_hwmon_sdm_init_sysfs: hwmon_sdm sysfs creation failed for xcl_sdr 0xa, err: -19
[  +0.000014] xocl 0000:d8:00.1: mailbox.u.9437184 ffff8c0c203bb410 _mailbox_request: sending request: 16 via HW
[  +0.000267] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 process_request: received request from peer: 16, passed on
[  +0.000008] xclmgmt 0000:d8:00.0: xclmgmt_read_subdev_req: req kind 11
[  +0.489622] xclmgmt 0000:d8:00.0: mailbox.m.9437184 ffff8c0c20c4a410 mailbox_post_response: posting response for: 16 via HW
[  +0.010125] xocl 0000:d8:00.1:  ffff8c082f5ff098 xocl_hwmon_sdm_init_sysfs: hwmon_sdm sysfs creation failed for xcl_sdr 0xb, err: -19

#### How problem was solved, alternative solutions (if any) and why they were rejected
remove unnecessary fix in hwmon_sdm device callbacks
#### Risks (if any) associated the changes in the commit
sensor sysfs nodes are not created due to this unnecessary check
#### What has been tested and how, request additional testing if necessary
Read sensors through hwmon sysfs nodes on versal device
