### PR TITLE
CR-1115691 xbutil reset command does not support -h

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_Config.cpp
@@ -268,7 +268,7 @@ OO_Config::OO_Config( const std::string &_longName, bool _isHidden)
     ("device,d", boost::program_options::value<decltype(m_devices)>(&m_devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("retention", boost::program_options::value<decltype(m_retention)>(&m_retention),"Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]")
     ("ddr", boost::program_options::bool_switch(&m_ddr), "Enable DDR memory for retention")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_optionsHidden.add_options()

--- a/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/OO_LoadConfig.cpp
@@ -49,7 +49,7 @@ OO_LoadConfig::OO_LoadConfig( const std::string &_longName, bool _isHidden)
   m_optionsDescription.add_options()
     ("device,d", boost::program_options::value<decltype(m_devices)>(&m_devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("input", boost::program_options::value<decltype(m_path)>(&m_path),"INI file with the memory configuration")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_positionalOptions.

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdAdvanced.cpp
@@ -64,7 +64,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   po::options_description commonOptions("Common Options"); 
   commonOptions.add_options()
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -138,7 +138,7 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
     ("config,c", boost::program_options::bool_switch(&config), "Dumps the output of system configuration, requires a .ini output file by -o option")
     ("flash,f", boost::program_options::bool_switch(&flash), "Dumps the output of programmed system image, requires a .bin output file by -o option")
     ("output,o", boost::program_options::value<decltype(output)>(&output), "Direct the output to the given file")
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -96,7 +96,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
-    ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");  

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -687,7 +687,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
                                                                     "  Name (and path) to the mcs image on disk\n"
                                                                     "  Name (and path) to the xsabin image on disk")
     ("revert-to-golden", boost::program_options::bool_switch(&revertToGolden), "Resets the FPGA PROM back to the factory image. Note: The Satellite Controller will not be reverted for a golden image does not exist.")
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");  

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -113,7 +113,7 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   po::options_description commonOptions("Common Options");
   commonOptions.add_options()
     ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.")
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");

--- a/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_AieRegRead.cpp
@@ -387,7 +387,7 @@ OO_AieRegRead::OO_AieRegRead( const std::string &_longName, bool _isHidden )
     ("row", po::value<decltype(m_row)>(&m_row)->required(), "Row of core tile")
     ("col", po::value<decltype(m_col)>(&m_col)->required(), "Column of core tile")
     ("reg", po::value<decltype(m_reg)>(&m_reg)->required(), "Register name to read from core tile")
-    ("help,h", po::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", po::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_positionalOptions.

--- a/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_HostMem.cpp
@@ -47,7 +47,7 @@ OO_HostMem::OO_HostMem( const std::string &_longName, bool _isHidden )
     ("device,d", boost::program_options::value<decltype(m_devices)>(&m_devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("action", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: ENABLE or DISABLE")
     ("size,s", boost::program_options::value<decltype(m_size)>(&m_size), "Size of host memory (bytes) to be enabled (e.g. 256M, 1G)")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_positionalOptions.

--- a/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemRead.cpp
@@ -45,7 +45,7 @@ OO_MemRead::OO_MemRead( const std::string &_longName, bool _isHidden )
     ("output,o", boost::program_options::value<decltype(m_outputFile)>(&m_outputFile)->required(), "Output file")
     ("address", boost::program_options::value<decltype(m_baseAddress)>(&m_baseAddress)->required(), "Base address to start from")
     ("size", boost::program_options::value<decltype(m_sizeBytes)>(&m_sizeBytes)->required(), "Size (bytes) to read")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_positionalOptions.

--- a/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_MemWrite.cpp
@@ -47,7 +47,7 @@ OO_MemWrite::OO_MemWrite( const std::string &_longName, bool _isHidden)
     ("address", boost::program_options::value<decltype(m_baseAddress)>(&m_baseAddress)->required(), "Base address to start from")
     ("size", boost::program_options::value<decltype(m_sizeBytes)>(&m_sizeBytes)->required(), "Size (bytes) to write")
     ("fill,f", boost::program_options::value<decltype(m_fill)>(&m_fill), "The byte value to fill the memory with")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_positionalOptions.

--- a/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
+++ b/src/runtime_src/core/tools/xbutil2/OO_P2P.cpp
@@ -264,7 +264,7 @@ OO_P2P::OO_P2P( const std::string &_longName, bool _isHidden )
   m_optionsDescription.add_options()
     ("device,d", boost::program_options::value<decltype(m_devices)>(&m_devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("action", boost::program_options::value<decltype(m_action)>(&m_action)->required(), "Action to perform: ENABLE, DISABLE, or VALIDATE")
-    ("help,h", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&m_help), "Help to use this sub-command")
   ;
 
   m_positionalOptions.

--- a/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdAdvanced.cpp
@@ -66,7 +66,7 @@ SubCmdAdvanced::execute(const SubCmdOptions& _options) const
 
   po::options_description commonOptions("Common Options"); 
   commonOptions.add_options()
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options"); 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdConfigure.cpp
@@ -58,7 +58,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
   po::options_description commonOptions("Common Options"); 
   commonOptions.add_options()
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options"); 
@@ -119,6 +119,7 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
   // No suboption print help
   if (!optionOption) {
+    std::cerr << "ERROR: Suboption missing" << std::endl;
     printHelp(commonOptions, hiddenOptions, subOptionOptions);
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -120,7 +120,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
-    ("help,h", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&bHelp), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1587,7 +1587,7 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
     ("run,r", boost::program_options::value<decltype(testsToRun)>(&testsToRun)->multitoken(), (std::string("Run a subset of the test suite.  Valid options are:\n") + formatRunValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
     ("path,p", boost::program_options::value<decltype(xclbin_location)>(&xclbin_location), "Path to the directory containing validate xclbins")
-    ("help,h", boost::program_options::bool_switch(&help), "Help to use this sub-command")
+    ("help", boost::program_options::bool_switch(&help), "Help to use this sub-command")
   ;
 
   po::options_description hiddenOptions("Hidden Options");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1115691
There was inconsistent handling of the "-h" option among the xrt tools. `xbutil reset` would display an "unrecognized option" message, `xbutil configure` would not issue an error message, and xbmgmt commands would not issue an error message.

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Add a separate error message into `xbutil configure` to display an error message expressing a missing sub-option command.
2. Remove the "-h" option from xbmgmt commands
#### Risks (if any) associated the changes in the commit
Users who relied on "-h" options will still have the printout but a new error message to contend with. Hopefully any tests use --help instead of -h. The xbmgmt and xbutil commands by themselves do not issue a warning due to how their arguments are processed.

#### What has been tested and how, request additional testing if necessary
Manual testing of commands
xbutil
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil -h

DESCRIPTION: The Xilinx (R) Board Utility (xbutil) is a standalone command line utility that is
             included with the Xilinx Run Time (XRT) installation package. It includes multiple
             commands to validate and identify the installed card(s) along with additional card
             details including DDR, PCIe (R), shell name (DSA), and system information.

             This information can be used for both card administration and application debugging.

USAGE: xbutil [--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  configure  - Device and host configuration
  examine    - Status of the system and device
  program    - Download the acceleration program to a given device
  reset      - Resets the given device
  validate   - Validates the basic shell acceleration functionality

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil configure
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure -h
ERROR: No valid suboptions found

COMMAND: configure

DESCRIPTION: Device and host configuration.

USAGE: xbutil configure [-h] --[ host-mem | p2p ] [commandArgs]

OPTIONS:
  --help             - Help to use this sub-command
  --host-mem         - Controls host-mem functionality
  --p2p              - Controls P2P functionality

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil configure --host-mem
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure --host-mem -h
ERROR: unrecognised option '-h'


DESCRIPTION: Controls host-mem functionality

USAGE: xbutil configure --host-mem [--help] [-d arg] [-s arg] action
  <action>        - Action to perform: ENABLE or DISABLE

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -s, --size         - Size of host memory (bytes) to be enabled (e.g. 256M, 1G)
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil configure --p2p
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil configure --p2p -h
ERROR: unrecognised option '-h'


DESCRIPTION: Controls P2P functionality

USAGE: xbutil configure --p2p [--help] [-d arg] action
  <action>        - Action to perform: ENABLE, DISABLE, or VALIDATE

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil examine
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -h
ERROR: unrecognised option '-h'


DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.

USAGE: xbutil examine [--help] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  -r, --report       - The type of report to be produced. Reports currently available are:
                         aie             - AIE metadata in xclbin
..... All the other reports......
                         thermal         - Thermal sensors present on the device
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil program
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program -h
ERROR: unrecognised option '-h'


DESCRIPTION: Programs the given acceleration image into the device's shell.

USAGE: xbutil program [--help] [-d arg] [-u arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  -u, --user         - The name (and path) of the xclbin to be loaded
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil reset
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil reset -h
ERROR: unrecognised option '-h'


DESCRIPTION: Resets the given device.

USAGE: xbutil reset [--help] [-d arg] [-t arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  -t, --type         - The type of reset to perform. Types resets available:
                         user         - Hot reset (default)
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbutil validate
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -h
ERROR: unrecognised option '-h'


DESCRIPTION: Validates the given device by executing the platform's validate executable.

USAGE: xbutil validate [--help] [-d arg] [-f arg] [-r arg] [-o arg] [-p arg]

OPTIONS:
  -d, --device       - The device of interest. This is specified as follows:
                         <BDF> - Bus:Device.Function (e.g., 0000:d8:00.0)
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -r, --run          - Run a subset of the test suite.  Valid options are:
                         all            - All applicable validate tests will be executed (default)
..... All the other tests.....
                         vcu            - Run decoder test
  -o, --output       - Direct the output to the given file
  -p, --path         - Path to the directory containing validate xclbins
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbmgmt
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt -h

DESCRIPTION: The Xilinx (R) Board Management (xbmgmt) is a standalone command line utility that is
             included with the Xilinx Run Time (XRT) installation package.

USAGE: xbmgmt [--help] [--version] [--verbose] [--batch] [--force] [command [commandArgs]]

AVAILABLE COMMANDS:
  dump       - Dump out the contents of the specified option
  examine    - Returns detail information for the specified device.
  program    - Update image(s) for a given device
  reset      - Resets the given device

PRELIMINARY COMMANDS:
  advanced   - Low level command operations

OPTIONS:
  --help             - Help to use this application
  --version          - Report the version of XRT and its drivers
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbmgmt dump
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump -h
ERROR: unrecognised option '-h'


DESCRIPTION: Dump out the contents of the specified option.

USAGE: xbmgmt dump [-cf] [--help] [-d arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  -c, --config       - Dumps the output of system configuration, requires a .ini output file by -o
                       option
  -f, --flash        - Dumps the output of programmed system image, requires a .bin output file by
                       -o option
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbmgmt examine
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -h
ERROR: unrecognised option '-h'


DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.

USAGE: xbmgmt examine [--help] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of
                       'all' (default) indicates that every found device should be examined.
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all        - All known reports are produced
.....All the other reports.....
                         platform   - Platform information
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbmgmt program
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program -h
ERROR: unrecognised option '-h'


DESCRIPTION: Updates the image(s) for a given device.

USAGE: xbmgmt program [--revert-to-golden] [--help] [-d arg] [-s arg] [-b arg] [-u arg] [image arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  -s, --shell        - The partition to be loaded.  Valid values:
                         Name (and path) of the partition.
  -b, --base         - Update the persistent images and/or the Satellite controller (SC) firmware
                       image.  Value values:
                         ALL   - All images will be updated
                         SHELL - Platform image
                         SC    - Satellite controller
  -u, --user         - The xclbin to be loaded.  Valid values:
                         Name (and path) of the xclbin.
  --image            - Specifies an image to use used to update the persistent device.  Value
                       values:
                         Name (and path) to the mcs image on disk
                         Name (and path) to the xsabin image on disk
  --revert-to-golden - Resets the FPGA PROM back to the factory image. Note: The Satellite
                       Controller will not be reverted for a golden image does not exist.
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
xbmgmt reset
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt reset -h
ERROR: unrecognised option '-h'


DESCRIPTION: Resets the given device.

USAGE: xbmgmt reset [--help] [-d arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.
  --help             - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
None. The documentation states that only "--help" will work