### PR TITLE
CR-1119283: Clarifying profiling switch combination usage

### DIFF
--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc and AMD, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -61,6 +61,12 @@ namespace plugins {
       std::string msg = "The xrt.ini flag \"opencl_summary\" is deprecated and will be removed in a future release.  A summary file is generated when when any profiling is enabled, so please use the appropriate settings from \"opencl_trace=true\", \"device_counter=true\", and \"device_trace=true.\"" ;
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
                               msg) ;
+    }
+
+    if (xrt_core::config::get_opencl_summary() && xrt_core::config::get_host_trace()) {
+      std::string msg = "The generic host_trace option may not work as expected due to the inclusion of the deprecated opencl_summary option.  For OpenCL level trace, please specify opencl_trace=true when using opencl_summary=true in the xrt.ini file.";
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT",
+                              msg);
     }
 
     if (xrt_core::config::get_data_transfer_trace() != "off") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The xrt.ini switch "opencl_summary" (which is being deprecated) forces the loading of profiling counter information from the device.  The new xrt.ini switch "host_trace" loads the appropriate trace plugin based on the first level of XRT API that is encountered.  When both are active, for hardware runs the first level of API encountered is the HAL level due to opencl_summary turning on device information, forcing the loading of HAL trace even if the application was written in OpenCL.  In hardware and software emulation, both switches on works as expected.

As opencl_summary is deprecated and host_trace is newly added, this pull request adds a warning for the case when the user specifies both of these options and advises on the alternate flags to get the desired behavior.
