### PR TITLE
CR-1122900 hwmon_sdm: fix sensor index alignment & enable voltage sensor requests

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -1073,6 +1073,7 @@ int xocl_hwmon_sdm_init(struct xocl_dev *xdev)
 	(void) xocl_hwmon_sdm_init_sysfs(xdev, XCL_SDR_TEMP);
 	(void) xocl_hwmon_sdm_init_sysfs(xdev, XCL_SDR_CURRENT);
 	(void) xocl_hwmon_sdm_init_sysfs(xdev, XCL_SDR_POWER);
+	(void) xocl_hwmon_sdm_init_sysfs(xdev, XCL_SDR_VOLTAGE);
 
 	return ret;
 }


### PR DESCRIPTION
Fix sensor index alignment issue
Enable voltage sensor sdr request.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
