### PR TITLE
CR-1121536 ASTeR TC 17.06 - vck5000 - crash occurs when flashing is i…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1480,8 +1480,6 @@ static int xgq_collect_sensors(struct platform_device *pdev, int sid,
 
 	ret = cmd->xgq_cmd_rcode;
 
-	printk("DZ__ %d\n", (int)(0xffff));
-
 	if (ret) {
 		XGQ_ERR(xgq, "ret %d", cmd->xgq_cmd_rcode);
 	} else {


### PR DESCRIPTION
…nterrupted with SIGINT/SIGKILL

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is to avoid panic when submitted command gets killed, it's cmd pointer stays in the linkedlist and itself gets freed earlier.
So, each time we remove their cmd pointer from the list before free the cmd.

I think the xgq.c can be optimized with better code structure with better xgq_cmd alloc/free api. @xuhz 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested with multiple times ctrl+c, no panics anymore.

#### Documentation impact (if any)
