### PR TITLE
CR-1122352: Updated aie_trace specific config parameters

### DIFF
--- a/src/runtime_src/core/common/config_reader.h
+++ b/src/runtime_src/core/common/config_reader.h
@@ -248,23 +248,21 @@ get_stall_trace()
 inline bool
 get_continuous_trace()
 {
-  static bool value = detail::get_bool_value("Debug.continuous_trace",false);
+  static bool value = detail::get_bool_value("Debug.continuous_trace", false);
   return value;
 }
 
 inline unsigned int
 get_trace_buffer_offload_interval_ms()
 {
-  // NOLINTNEXTLINE
-  static unsigned int value = detail::get_uint_value("Debug.trace_buffer_offload_interval_ms",10);
+  static unsigned int value = detail::get_uint_value("Debug.trace_buffer_offload_interval_ms", 10);
   return value;
 }
 
 inline unsigned int
 get_trace_file_dump_interval_s()
 {
-  // NOLINTNEXTLINE
-  static unsigned int value = detail::get_uint_value("Debug.trace_file_dump_interval_s",5);
+  static unsigned int value = detail::get_uint_value("Debug.trace_file_dump_interval_s", 5);
   return value;
 }
 
@@ -367,7 +365,7 @@ get_aie_trace_counter_scheme()
 inline std::string
 get_aie_trace_metrics()
 {
-  static std::string value = detail::get_string_value("Debug.aie_trace_metrics", "");
+  static std::string value = detail::get_string_value("Debug.aie_trace_metrics", "functions");
   return value;
 }
 
@@ -382,6 +380,27 @@ inline bool
 get_aie_trace_user_control()
 {
   static bool value = detail::get_bool_value("Debug.aie_trace_user_control", false);
+  return value;
+}
+
+inline bool
+get_periodic_aie_trace_offload()
+{
+  static bool value = detail::get_bool_value("Debug.periodic_aie_trace_offload", true);
+  return value;
+}
+
+inline unsigned int
+get_aie_trace_buffer_offload_interval_ms()
+{
+  static unsigned int value = detail::get_uint_value("Debug.aie_trace_buffer_offload_interval_ms", 10);
+  return value;
+}
+
+inline unsigned int
+get_aie_trace_file_dump_interval_s()
+{
+  static unsigned int value = detail::get_uint_value("Debug.aie_trace_file_dump_interval_s", 5);
   return value;
 }
 

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -73,6 +73,7 @@ buffer size and/or reduce trace_buffer_offload_interval."
 // Trace file Dump Settings and Warnings
 #define MIN_TRACE_DUMP_INTERVAL_S 1
 #define TRACE_DUMP_INTERVAL_WARN_MSG "Setting trace file dump interval to minimum supported value of 1 second."
+#define AIE_TRACE_DUMP_INTERVAL_WARN_MSG "Setting AIE trace file dump interval to minimum supported value of 1 second."
 #define TRACE_DUMP_FILE_COUNT_WARN 10
 #define TRACE_DUMP_FILE_COUNT_WARN_MSG "Continuous Trace might create a large number of trace files. Please use trace_file_dump_interval \
 to control how often trace data is written."

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -89,9 +89,9 @@ namespace xdp {
 
     // Check whether continuous trace is enabled in xrt.ini
     // AIE trace is now supported for HW only
-    continuousTrace = xrt_core::config::get_continuous_trace();
+    continuousTrace = xrt_core::config::get_periodic_aie_trace_offload();
     if (continuousTrace) {
-      offloadIntervalms = xrt_core::config::get_trace_buffer_offload_interval_ms();
+      offloadIntervalms = xrt_core::config::get_aie_trace_buffer_offload_interval_ms();
     }
 
     // Pre-defined metric sets
@@ -161,6 +161,13 @@ namespace xdp {
       memoryCounterStartEvents = {XAIE_EVENT_TRUE_MEM};
       memoryCounterEndEvents   = {XAIE_EVENT_NONE_MEM};
       memoryCounterEventValues = {0x3FF00};
+    }
+
+    //Process the file dump interval
+    aie_trace_file_dump_int_s = xrt_core::config::get_aie_trace_file_dump_interval_s();
+    if (aie_trace_file_dump_int_s < MIN_TRACE_DUMP_INTERVAL_S){
+      aie_trace_file_dump_int_s = MIN_TRACE_DUMP_INTERVAL_S;
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", AIE_TRACE_DUMP_INTERVAL_WARN_MSG);
     }
   }
 
@@ -985,7 +992,7 @@ namespace xdp {
 
     // Continuous Trace Offload is supported only for PLIO flow
     if (continuousTrace && isPLIO) {
-      XDPPlugin::startWriteThread(XDPPlugin::get_trace_file_dump_int_s(), "AIE_EVENT_TRACE");
+      XDPPlugin::startWriteThread(aie_trace_file_dump_int_s, "AIE_EVENT_TRACE");
     }
 
     // First, check against memory bank size

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.h
@@ -82,6 +82,7 @@ namespace xdp {
 
       bool continuousTrace;
       uint64_t offloadIntervalms;
+      unsigned int aie_trace_file_dump_int_s;
 
       // Trace Runtime Status
       AieRC mConfigStatus = XAIE_OK;

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -107,7 +107,7 @@ std::cout << " AIETraceWriter::writeTraceEvents : dataBuffer " << dataBuffer << 
   {
   }
 
-  bool AIETraceWriter::write(bool openNewFile)
+  bool AIETraceWriter::write(bool /*openNewFile*/)
   {
 #if 0
     writeHeader() ;
@@ -124,7 +124,7 @@ std::cout << " AIETraceWriter::writeTraceEvents : dataBuffer " << dataBuffer << 
     fout << std::endl ;
 #endif
 
-    if (openNewFile) switchFiles() ;
+   // if (openNewFile) switchFiles() ;
     return true;
   }
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/ini_parameters.cpp
@@ -63,6 +63,9 @@ namespace xdp {
     addParameter("trace_buffer_offload_interval_ms",
                  xrt_core::config::get_trace_buffer_offload_interval_ms(),
                  "Interval for reading of device data to host (in ms)");
+    addParameter("trace_file_dump_interval_s",
+                 xrt_core::config::get_trace_file_dump_interval_s(),
+                 "Interval for dumping files to host (in s)");              
     addParameter("lop_trace", xrt_core::config::get_lop_trace(),
                  "Generation of lower overhead OpenCL trace. Should not be used with other OpenCL options.");
     addParameter("debug_mode", xrt_core::config::get_launch_waveform(),
@@ -75,6 +78,14 @@ namespace xdp {
     addParameter("aie_trace_metrics",
                  xrt_core::config::get_aie_trace_metrics(),
                  "Configuration level used for AI Engine trace");
+    addParameter("periodic_aie_trace_offload", xrt_core::config::get_periodic_aie_trace_offload(),
+                 "Periodic offloading of aie trace from memory to host");
+    addParameter("aie_trace_buffer_offload_interval_ms",
+                 xrt_core::config::get_aie_trace_buffer_offload_interval_ms(),
+                 "Interval for reading of device aie trace data to host (in ms)");
+    addParameter("aie_trace_file_dump_interval_s",
+                 xrt_core::config::get_aie_trace_file_dump_interval_s(),
+                 "Interval for dumping aie trace files to host (in s)");  
     addParameter("aie_profile", xrt_core::config::get_aie_profile(),
                  "Generation of AI Engine profiling");
     addParameter("aie_profile_interval_us",


### PR DESCRIPTION
Created new options for the periodic aie_trace offload to decouple form the continuous_trace option. Reverted default for aie_trace_metrics to "functions".