### PR TITLE
CR-1122973 xbutil validate fails on U2, U25, U50LV and U50 on C7.9/RH7.x

### DIFF
--- a/tests/python/23_bandwidth/host_mem_23_bandwidth.py
+++ b/tests/python/23_bandwidth/host_mem_23_bandwidth.py
@@ -165,7 +165,7 @@ def main(args):
         assert (opt.first_mem >= 0), "Incorrect memory configuration"
 
         if (runKernel(opt) == errno.EOPNOTSUPP):
-            print("EOPNOTSUPP")
+            print("NOT SUPPORTED TEST")
             sys.exit(errno.EOPNOTSUPP)
         print("PASSED TEST")
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Host mem python test code shall print "NOT SUPPORTED" when the test is not applicable.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6292
#### How problem was solved, alternative solutions (if any) and why they were rejected
Print correct msg
#### Risks (if any) associated the changes in the commit
Low
#### What has been tested and how, request additional testing if necessary
Tested on the system where the issue can be seen
#### Documentation impact (if any)
N/A