### PR TITLE
CR-1101252 Message for invalid xbmgmt examine syntax

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdDump.cpp
@@ -147,11 +147,13 @@ SubCmdDump::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -105,11 +105,13 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -703,12 +703,13 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
 
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdReset.cpp
@@ -128,11 +128,13 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -132,11 +132,13 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdProgram.cpp
@@ -73,11 +73,13 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdReset.cpp
@@ -117,11 +117,13 @@ SubCmdReset::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1596,11 +1596,13 @@ SubCmdValidate::execute(const SubCmdOptions& _options) const
   allOptions.add(commonOptions);
   allOptions.add(hiddenOptions);
 
+  po::positional_options_description positionals;
+
   // Parse sub-command ...
   po::variables_map vm;
 
   try {
-    po::store(po::command_line_parser(_options).options(allOptions).run(), vm);
+    po::store(po::command_line_parser(_options).options(allOptions).positional(positionals).run(), vm);
     po::notify(vm); // Can throw
   } catch (po::error& e) {
     std::cerr << "ERROR: " << e.what() << std::endl << std::endl;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1101252
sudo xbmgmt examine is a valid command
sudo xbmgmt examine 73:00.0 is not

Both commands give the same output instead of an error message for the second command

#### How problem was solved, alternative solutions (if any) and why they were rejected
The problem was solved by adding positional argument detection into the xbutil and xbmgmt commands. Since all of the commands (with the exception of xbutil configure) do not use positional arguments any extra args cause an error message to be displayed.

#### Risks (if any) associated the changes in the commit
The xbmgmt configure command that is currently in review (https://github.com/Xilinx/XRT/pull/6288) will need this fix as well. It would good to merge in master after that PR is finished to bring in the change. In addition, https://github.com/Xilinx/XRT/pull/6298 has a fix for xbutil configure needing positional arguments by outputting an error message if no valid suboption is specified. 

#### What has been tested and how, request additional testing if necessary
Manual Testing:
xbutil examine
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.
....Other options....
```
xbutil program
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil program 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Programs the given acceleration image into the device's shell.

....other options....
```
xbutil reset
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil reset 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Resets the given device.

....other options....
```
xbutil validate
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Validates the given device by executing the platform's validate executable.

....other options....
```
xbmgmt dump
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt dump 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Dump out the contents of the specified option.
....other options....
```
xbmgmt examine
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.
....other options....
```
xbmgmt program
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt program 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Updates the image(s) for a given device.
....other options....
```
xbmgmt reset
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt reset 73:00
ERROR: too many positional options have been specified on the command line


DESCRIPTION: Resets the given device.

....other options....
```
