### PR TITLE
Xclbin sysfs issue for multi slot changes  

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_util.h
@@ -133,10 +133,8 @@ struct drm_zocl_dev {
 	phys_addr_t		 res_start;
 	unsigned int		 cu_num;
 	unsigned int             irq[MAX_CU_NUM];
-	/* Saif TODO : This is for old kds. Not required now */
 	struct sched_exec_core  *exec;
-	/* Saif TODO : Hopefully this is not required */
-	//unsigned int		 num_mem;
+	/* Zocl driver memory list head */
 	struct list_head	 zm_list_head;
 	struct drm_mm           *zm_drm_mm;    /* DRM MM node for PL-DDR */
 	struct mutex		 mm_lock;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -342,7 +342,7 @@ zocl_create_bo(struct drm_device *dev, uint64_t unaligned_size, u32 user_flags)
 		if (mem == NULL)
 			return ERR_PTR(-ENOMEM);
 
-		if (mem->zm_used || mem->zm_type != ZOCL_MEM_TYPE_RANGE_ALLOC)
+		if (!mem->zm_used || mem->zm_type != ZOCL_MEM_TYPE_RANGE_ALLOC)
 			return ERR_PTR(-EINVAL);
 
 		bo = zocl_create_range_mem(dev, size, mem);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -186,7 +186,6 @@ static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 
 	read_lock(&zdev->attr_rwlock);
 
-
         list_for_each_entry(memp, &zdev->zm_list_head, link) {
 		if (memp->zm_type == ZOCL_MEM_TYPE_STREAMING)
 			continue;
@@ -195,7 +194,7 @@ static ssize_t zocl_get_memstat(struct device *dev, char *buf, bool raw)
 		bo_count = memp->zm_stat.bo_count;
 
 		if (raw)
-			count = sprintf(buf, raw_fmt, memory_usage, bo_count,0);
+			count = sprintf(buf, raw_fmt, memory_usage, bo_count, 0);
 		else {
 			count = sprintf(buf, txt_fmt,
 			    memp->zm_used ? "IN-USE" : "UNUSED",

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -307,10 +307,10 @@ struct xclbin_uuid
     if (!errmsg.empty())
       throw xrt_core::query::sysfs_error(errmsg);
 
-    result_type xclbin_data;
     // xclbin_uuid e.g.
-    // 0 <uuid_slot_0>
-    // 1 <uuid_slot_1>
+    // <slot_id> <uuid_slot_0>
+    //	   0	 <uuid_slot_0>
+    //	   1	 <uuid_slot_1>
     for (auto& line : xclbin_info) {
       boost::char_separator<char> sep(" ");
       tokenizer tokens(line, sep);
@@ -321,8 +321,9 @@ struct xclbin_uuid
       tokenizer::iterator tok_it = tokens.begin();
       unsigned int slot_index = std::stoi(std::string(*tok_it++));
       //return the first slot uuid always for backward compatibility
-      return std::string(*tok_it++);
+      return std::string(*tok_it);
     }
+
     return "";
   }
 };


### PR DESCRIPTION
1. There is a issue of xclbin sysfs entry.  We need to support backward comparability after multi slot changes. Added that support.
2. ZOCL memory unused pointer has been used some of the code. Which is a issue for some of the corner cases, 

Fixed above issue. Tested with basic sanity test cases. 
