### PR TITLE
Support multiple run object completion

### DIFF
--- a/src/runtime_src/core/common/api/command.h
+++ b/src/runtime_src/core/common/api/command.h
@@ -1,19 +1,5 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
 #ifndef xrt_core_command_h_
 #define xrt_core_command_h_
 
@@ -75,7 +61,7 @@ public:
    * notify() - notify of state change
    */
   virtual void
-  notify(ert_cmd_state) = 0;
+  notify(ert_cmd_state) const = 0;
 
 private:
   unsigned long m_uid;

--- a/src/runtime_src/core/common/api/device_int.h
+++ b/src/runtime_src/core/common/api/device_int.h
@@ -1,25 +1,12 @@
-/*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
 #ifndef _XRT_COMMON_DEVICE_INT_H_
 #define _XRT_COMMON_DEVICE_INT_H_
 
 // This file defines implementation extensions to the XRT Device APIs.
-#include "core/include/experimental/xrt_device.h"
+#include "core/include/xrt/xrt_device.h"
+#include <chrono>
+#include <condition_variable>
 
 namespace xrt_core { namespace device_int {
 
@@ -27,9 +14,15 @@ namespace xrt_core { namespace device_int {
 std::shared_ptr<xrt_core::device>
 get_core_device(xrtDeviceHandle dhdl);
 
-// Get underlying shim device handle 
+// Get underlying shim device handle
 xclDeviceHandle
 get_xcl_device_handle(xrtDeviceHandle dhdl);
+
+// Call exec_wait() safely from multiple threads.  This function
+// returns when exec_wait encounters any command completion or
+// otherwise times out.
+std::cv_status
+exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms);
 
 }} // device_int, xrt_core
 

--- a/src/runtime_src/core/common/api/exec.cpp
+++ b/src/runtime_src/core/common/api/exec.cpp
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2016-2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 
 #include "exec.h"
@@ -115,7 +102,7 @@ unmanaged_wait(const command* cmd)
   else
     sws::unmanaged_wait(cmd);
 }
-    
+
 // Wait for a command to complete execution with timeout.
 std::cv_status
 unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms)
@@ -124,6 +111,15 @@ unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms)
     return kds::unmanaged_wait(cmd, timeout_ms);
   else
     return sws::unmanaged_wait(cmd, timeout_ms);
+}
+
+std::cv_status
+exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms)
+{
+  if (kds_enabled())
+    return kds::exec_wait(device, timeout_ms);
+  else
+    return sws::exec_wait(device, timeout_ms);
 }
 
 void

--- a/src/runtime_src/core/common/api/exec.h
+++ b/src/runtime_src/core/common/api/exec.h
@@ -1,19 +1,5 @@
-/**
- * Copyright (C) 2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #ifndef xrt_core_exec_h_
 #define xrt_core_exec_h_
 
@@ -51,6 +37,9 @@ unmanaged_wait(const command* cmd, const std::chrono::milliseconds&)
   return std::cv_status::no_timeout;
 }
 
+std::cv_status
+exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms);
+
 void
 start();
 
@@ -78,6 +67,9 @@ unmanaged_wait(const command* cmd);
 
 std::cv_status
 unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms);
+
+std::cv_status
+exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms);
 
 void
 start();
@@ -124,6 +116,12 @@ unmanaged_wait(const command* cmd);
 XRT_CORE_COMMON_EXPORT
 std::cv_status
 unmanaged_wait(const command* cmd, const std::chrono::milliseconds& timeout_ms);
+
+// Wait for one call to exec_wait to return either from
+// some command completing or from a timeout.
+XRT_CORE_COMMON_EXPORT
+std::cv_status
+exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms);
 
 void
 start();

--- a/src/runtime_src/core/common/api/kds.cpp
+++ b/src/runtime_src/core/common/api/kds.cpp
@@ -1,36 +1,23 @@
-/**
- * Copyright (C) 2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 
 #include "exec.h"
 #include "ert.h"
 #include "command.h"
+#include "core/common/debug.h"
 #include "core/common/device.h"
 #include "core/common/thread.h"
-#include "core/common/debug.h"
 
-#include <memory>
+#include <algorithm>
 #include <cstring>
 #include <cerrno>
-#include <algorithm>
-#include <thread>
-#include <mutex>
 #include <condition_variable>
 #include <list>
 #include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
 
 ////////////////////////////////////////////////////////////////
 // Main command execution interface for scheduling commands for
@@ -369,6 +356,13 @@ unmanaged_wait(const xrt_core::command* cmd, const std::chrono::milliseconds& ti
 {
   auto kdev = get_kds_device(cmd);
   return kdev->exec_wait(cmd, timeout_ms.count());
+}
+
+std::cv_status
+exec_wait(const xrt_core::device* device, const std::chrono::milliseconds& timeout_ms)
+{
+  auto kdev = get_kds_device_or_error(device);
+  return kdev->exec_wait(timeout_ms.count());
 }
 
 // Start unmanaged command execution.  The command must be explicitly

--- a/src/runtime_src/core/common/api/sws.cpp
+++ b/src/runtime_src/core/common/api/sws.cpp
@@ -1,44 +1,30 @@
-/**
- * Copyright (C) 2016-2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
 
-/**
- * XRT software scheduler in user space.
- *
- * This is a software model of the kds scheduler.  Primarily
- * for debug and bring up.
- */
+// XRT software scheduler in user space.
+//
+// This is a software model of the kds scheduler.  Primarily
+// for debug and bring up.
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 
 #include "exec.h"
 #include "command.h"
 #include "ert.h"
 #include "xclbin.h"
-#include "core/common/device.h"
+
 #include "core/common/debug.h"
+#include "core/common/device.h"
 #include "core/common/task.h"
 #include "core/common/thread.h"
 #include "core/common/xclbin_parser.h"
-#include <limits>
 #include <bitset>
-#include <vector>
+#include <condition_variable>
+#include <cstring>
+#include <limits>
 #include <list>
 #include <map>
 #include <mutex>
-#include <condition_variable>
-#include <cstring>
+#include <vector>
 
 #ifdef _WIN32
 # pragma warning( disable : 4996 4458 4267 4244 )
@@ -861,6 +847,12 @@ unmanaged_wait(const xrt_core::command* cmd)
     s_cmd_complete_cond.wait(lk);
 }
 
+std::cv_status
+exec_wait(const xrt_core::device*, const std::chrono::milliseconds&)
+{
+  throw std::runtime_error("sws::exec_wait not implemented");
+}
+
 void
 start()
 {
@@ -906,7 +898,7 @@ init(xrt_core::device* xdev)
 
   // Slots are computed by device, its a function of device properties
   auto slots = xdev->get_ert_slots(xml_data, xml_size).first;
-  
+
   // create execution core for this device
   cu_trace_enabled = xrt_core::config::get_opencl_summary();
 

--- a/src/runtime_src/core/common/api/xrt_device.cpp
+++ b/src/runtime_src/core/common/api/xrt_device.cpp
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
- * Xilinx Runtime (XRT) Experimental APIs
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
 
 // This file implements XRT xclbin APIs as declared in
 // core/include/experimental/xrt_device.h
@@ -23,24 +9,26 @@
 #include "core/include/xrt/xrt_device.h"
 #include "core/include/xrt/xrt_aie.h"
 
-#include "core/common/system.h"
 #include "core/common/device.h"
-#include "core/common/message.h"
-#include "core/common/sensor.h"
 #include "core/common/info_aie.h"
 #include "core/common/info_memory.h"
 #include "core/common/info_platform.h"
+#include "core/common/message.h"
 #include "core/common/query_requests.h"
+#include "core/common/sensor.h"
+#include "core/common/system.h"
 
+#include "device_int.h"
+#include "exec.h"
 #include "handle.h"
 #include "native_profile.h"
-#include "xclbin_int.h" // Non public xclbin APIs
+#include "xclbin_int.h"
 
 #include <boost/property_tree/json_parser.hpp>
 
+#include <fstream>
 #include <map>
 #include <vector>
-#include <fstream>
 
 #ifdef _WIN32
 # pragma warning( disable : 4244 )
@@ -215,8 +203,13 @@ get_xcl_device_handle(xrtDeviceHandle dhdl)
   return device->get_device_handle();  // shim handle
 }
 
-}} // device_int, xrt_core
+std::cv_status
+exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms)
+{
+  return xrt_core::exec::exec_wait(device.get_handle().get(), timeout_ms);
+}
 
+}} // device_int, xrt_core
 
 namespace xrt {
 

--- a/src/runtime_src/xrt/xrt++/xrtexec.cpp
+++ b/src/runtime_src/xrt/xrt++/xrtexec.cpp
@@ -1,18 +1,5 @@
-/**
- * Copyright (C) 2019-2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #include "xrtexec.hpp"
 #include "xrt/device/device.h"
 #include "core/common/bo_cache.h"
@@ -39,7 +26,7 @@ static void
 add_cu(ert_start_kernel_cmd* skcmd, index_type cuidx)
 {
   auto maskidx = mask_idx(cuidx);
-  if (maskidx > 3) 
+  if (maskidx > 3)
     throw std::runtime_error("Bad CU idx : " + std::to_string(cuidx));
 
   // Shift payload down if necessary to make room for extra cu mask(s).
@@ -98,7 +85,7 @@ create_exec_buf(xrt_xocl::device* device)
     device->add_close_callback(std::bind(at_close, device));
     s_ebocache.emplace(device, std::make_unique<xrt_core::bo_cache>(device->get_xcl_handle(), 128));
   }
-  
+
   return s_ebocache[device]->alloc<ert_packet>();
 }
 
@@ -107,7 +94,7 @@ release_exec_buf(const xrt_xocl::device* device, execbuf_type& ebo)
 {
   s_ebocache[device]->release(ebo);
 }
-  
+
 struct command::impl : xrt_core::command
 {
   impl(xrt_xocl::device* device, ert_cmd_opcode opcode)
@@ -201,15 +188,15 @@ struct command::impl : xrt_core::command
   }
 
   virtual void
-  notify(ert_cmd_state s)
+  notify(ert_cmd_state s) const
   {
-    if (s< ERT_CMD_STATE_COMPLETED)
+    if (s < ERT_CMD_STATE_COMPLETED)
       return;
 
     std::lock_guard<std::mutex> lk(m_mutex);
     m_done = true;
   }
-  
+
 };
 
 command::
@@ -306,7 +293,7 @@ add_ctx(uint32_t ctx)
 {
   if (ctx >= 32)
     throw std::runtime_error("write_exec supports at most 32 contexts numbered 0 through 31");
-  
+
   auto skcmd = m_impl->ert_cu;
   skcmd->data[0x10 >> 2] = ctx;
 }
@@ -327,7 +314,7 @@ clear()
   auto skcmd = m_impl->ert_cu;
   skcmd->cu_mask = 0;
 
-  m_impl->ert_pkt->count = 1; 
+  m_impl->ert_pkt->count = 1;
 }
 
 }} // exec,xrt

--- a/tests/xrt/100_ert_ncu/xrtxx-um.cpp
+++ b/tests/xrt/100_ert_ncu/xrtxx-um.cpp
@@ -1,0 +1,304 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2020-2021 Xilinx, Inc. All rights reserved.
+ */
+
+// This test uses unmanaged execution of kernel, where each run object
+// is reused after it completes.  The test is internal and uses a non
+// exported private function to safely call execwait.
+//
+// The test illustrates how the host code can continuosly start any
+// number of runs, wait on execwait, and then iterate the run obects
+// one by one to check for runs that have completed.  The objective is
+// for the iteration to not have to call execwait again, basically
+// reusing any run objects that have completed by the time it is being
+// checked.
+//
+// The internal exec_wait call will be made public at a later time.
+//
+// % g++ -g -std=c++17 -I${XILINX_XRT}/include -L${XILINX_XRT}/lib -o xrtxx-um.exe xrtxx-um.cpp -lxrt_coreutil -pthread -luuid
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <chrono>
+#include <tuple>
+
+#include "ert.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_kernel.h"
+
+// decl internal non public function
+namespace xrt_core { namespace device_int {
+std::cv_status
+exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms);
+}}
+
+#ifdef _WIN32
+# pragma warning ( disable : 4267 )
+#endif
+
+using namespace std::chrono_literals;
+
+static constexpr size_t ELEMENTS = 16;
+static constexpr size_t ARRAY_SIZE = 8;
+static constexpr size_t MAXCUS = 8;
+
+static size_t compute_units = MAXCUS;
+
+static void
+usage()
+{
+  std::cout << "usage: %s [options] \n\n";
+  std::cout << "  -k <bitstream>\n";
+  std::cout << "  -d <bdf | device_index>\n";
+  std::cout << "";
+  std::cout << "  [--jobs <number>]: number of concurrently scheduled jobs\n";
+  std::cout << "  [--cus <number>]: number of cus to use (default: 8) (max: 8)\n";
+  std::cout << "  [--seconds <number>]: number of seconds to run\n";
+  std::cout << "";
+  std::cout << "* Program schedules specified number of jobs as commands to scheduler.\n";
+  std::cout << "* Scheduler starts commands based on CU availability and state.\n";
+  std::cout << "* Summary prints \"jsz sec jobs\" for use with awk, where jobs is total number \n";
+  std::cout << "* of jobs executed in the specified run time\n";
+}
+
+static std::string
+get_kernel_name(size_t cus)
+{
+  std::string k("addone:{");
+  for (int i=1; i<cus; ++i)
+    k.append("addone_").append(std::to_string(i)).append(",");
+  k.append("addone_").append(std::to_string(cus)).append("}");
+  return k;
+}
+
+// Flag to stop job rescheduling.  Is set to true after
+// specified number of seconds.
+static std::atomic<bool> stop{true};
+
+// Data for a single job
+struct job_type
+{
+  size_t id = 0;
+  size_t runs = 0;
+
+  // Device and kernel are not managed by this job
+  xrt::kernel k;
+
+  // Kernel arguments and run handle are managed by this job
+  xrt::bo a;
+  void* am               = nullptr;
+  xrt::bo b;
+  void* bm               = nullptr;
+  xrt::run r;
+
+  job_type(const xrt::device& device, const xrt::kernel& kernel)
+    : k(kernel)
+  {
+    static size_t count=0;
+    id = count++;
+
+    auto grpid0 = kernel.group_id(0);
+    auto grpid1 = kernel.group_id(1);
+
+    const size_t data_size = ELEMENTS * ARRAY_SIZE;
+    a = xrt::bo(device, data_size*sizeof(unsigned long), grpid0);
+    am = a.map();
+    auto adata = reinterpret_cast<unsigned long*>(am);
+    for (unsigned int i=0;i<data_size;++i)
+      adata[i] = i;
+
+    b = xrt::bo(device, data_size*sizeof(unsigned long), grpid1);
+    bm = b.map();
+    auto bdata = reinterpret_cast<unsigned long*>(bm);
+     for (unsigned int j=0;j<data_size;++j)
+       bdata[j] = id;
+  }
+
+  job_type(job_type&& rhs)
+    : id(rhs.id)
+    , runs(rhs.runs)
+    , k(std::move(rhs.k))
+    , a(std::move(rhs.a))
+    , am(rhs.am)
+    , b(std::move(rhs.b))
+    , bm(rhs.bm)
+    , r(std::move(rhs.r))
+  {
+    am=bm=nullptr;
+  }
+
+  void
+  run()
+  {
+    ++runs;
+    if (!r) {
+      r = xrt::run(k);
+      r(a, b, ELEMENTS);
+    }
+    else if (!stop)
+      r.start();
+  }
+
+  ert_cmd_state
+  wait()
+  {
+    return r.wait();
+  }
+
+  bool
+  is_done() const
+  {
+    auto state = r.state();
+    return (state >= ERT_CMD_STATE_COMPLETED);
+  }
+};
+
+
+
+static std::tuple<size_t, size_t, size_t, size_t>
+run_async(const xrt::device& device, std::vector<job_type>& jobs)
+{
+  size_t completed = 0;
+  size_t loops = 0;
+  size_t skipped = 0;
+  size_t timeout = 0;
+
+  // repeat
+  while (!stop) {
+
+    if (xrt_core::device_int::exec_wait(device, 1ms) == std::cv_status::timeout)
+      ++timeout;
+
+    ++loops;
+
+    for (auto& j : jobs) {
+
+      if (!j.is_done()) {
+        ++skipped;
+        continue;
+      }
+
+      ++completed;
+      j.run();
+    }
+  }
+
+  // drain
+  for (auto& j : jobs) {
+    j.wait();
+    ++completed;
+  }
+
+  return std::make_tuple(completed, loops, skipped, timeout);
+}
+
+static void
+run(const xrt::device& device, const xrt::kernel& kernel, size_t num_jobs, size_t seconds)
+{
+  std::vector<job_type> jobs;
+  jobs.reserve(num_jobs);
+  for (int i=0; i<num_jobs; ++i)
+    jobs.emplace_back(device, kernel);
+
+  stop = (seconds == 0) ? true : false;
+
+  // start all jobs
+  for (auto& j : jobs)
+    j.run();
+
+  // babysit runs in single thread
+  auto value = std::async(std::launch::async, run_async, device, std::ref(jobs));
+
+  std::this_thread::sleep_for(std::chrono::seconds(seconds));
+  stop=true;
+
+  auto cw = value.get();
+  std::cout << "total completed = " << std::get<0>(cw) << "\n";
+  std::cout << "total loops = " << std::get<1>(cw)<< "\n";
+  std::cout << "total skipped = " << std::get<2>(cw)<< "\n";
+  std::cout << "total timeout = " << std::get<3>(cw)<< "\n";
+
+  size_t total = 0;
+  for (auto& job : jobs) {
+    auto val = job.runs;
+    total += val;
+    std::cout << "job count: " << val << "\n";
+  }
+
+  std::cout << "xrtxx-um: ";
+  std::cout << "jobsize cus seconds total = "
+            << num_jobs << " "
+            << compute_units << " "
+            << seconds << " "
+            << total << "\n";
+
+}
+
+
+static int
+run(int argc, char** argv)
+{
+  std::vector<std::string> args(argv+1,argv+argc);
+
+  std::string xclbin_fnm;
+  std::string device_id = "0";
+  size_t secs = 0;
+  size_t jobs = 1;
+  size_t cus  = 1;
+
+  std::string cur;
+  for (auto& arg : args) {
+    if (arg == "-h") {
+      usage();
+      return 1;
+    }
+
+    if (arg[0] == '-') {
+      cur = arg;
+      continue;
+    }
+
+    if (cur == "-d")
+      device_id = arg;
+    else if (cur == "-k")
+      xclbin_fnm = arg;
+    else if (cur == "--jobs")
+      jobs = std::stoi(arg);
+    else if (cur == "--seconds")
+      secs = std::stoi(arg);
+    else if (cur == "--cus")
+      cus = std::stoi(arg);
+    else
+      throw std::runtime_error("bad argument '" + cur + " " + arg + "'");
+  }
+
+  auto device = xrt::device(device_id);
+  auto uuid = device.load_xclbin(xclbin_fnm);
+
+  compute_units = cus = std::min(cus, compute_units);
+  std::string kname = get_kernel_name(cus);
+  auto kernel = xrt::kernel(device, uuid.get(), kname);
+
+  run(device,kernel,jobs,secs);
+
+  return 0;
+}
+
+int
+main(int argc, char* argv[])
+{
+  try {
+    return run(argc,argv);
+  }
+  catch (const std::exception& ex) {
+    std::cout << "TEST FAILED: " << ex.what() << "\n";
+  }
+  catch (...) {
+    std::cout << "TEST FAILED\n";
+  }
+
+  return 1;
+}


### PR DESCRIPTION
#### Problem solved by the commit
XMA multi-thread access to execwait using shared device handle.
XMA checking multiple run objects for completion after one execwait call.


This PR adds an internal APIs to safefly call exec_wait from any host
thread using same device object.

The PR also improves xrt::run::status() to guarantee that the internal
state of the run object reflects possible command completion, thus
allow the run object to be reused for subsequent execution of the
kernel.





#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
