### PR TITLE
CR-1123117 xbmgmt examine fails to display devices if one has a golden image

### DIFF
--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -341,13 +341,14 @@ XBUtilities::get_available_devices(bool inUserDomain)
       auto mGoldenVer = xrt_core::device_query<xrt_core::query::mfg_ver>(device);
       std::string vbnv = "xilinx_" + xrt_core::device_query<xrt_core::query::board_name>(device) + "_GOLDEN_"+ std::to_string(mGoldenVer);
       pt_dev.put("vbnv", vbnv);
+      pt_dev.put("id", "n/a");
+      pt_dev.put("instance","n/a");
     }
     else {
       pt_dev.put("vbnv", xrt_core::device_query<xrt_core::query::rom_vbnv>(device));
       try { //1RP
         pt_dev.put("id", xrt_core::query::rom_time_since_epoch::to_string(xrt_core::device_query<xrt_core::query::rom_time_since_epoch>(device)));
-      } catch(...)
-      {
+      } catch(...) {
         // The id wasn't added
       }
 
@@ -369,7 +370,6 @@ XBUtilities::get_available_devices(bool inUserDomain)
        }
 
     }
-
     pt_dev.put("is_ready", xrt_core::device_query<xrt_core::query::is_ready>(device));
     pt.push_back(std::make_pair("", pt_dev));
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1123117
When running `xbmgmt examine` if one of the devices on the machine has a golden image flashed the command will have an internal exception.

```
root@xsjpranjal01:~# xbmgmt examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 TowerXRT
  Version              : 2.13.0
  Branch               : CR-1109025
  Hash                 : d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  Hash Date            : 2022-02-21 14:54:19
  XOCL                 : 2.13.0, b1c1ec4d8a46d272cd95dcdf55255552246ac0f0
  XCLMGMT              : 2.13.0, b1c1ec4d8a46d272cd95dcdf55255552246ac0f0
Devices present
Host
  ERROR: No such node (id)
```

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced by https://github.com/Xilinx/XRT/pull/6219. It was discovered attempting to fix https://jira.xilinx.com/browse/CR-1108420

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added id and instance fields to golden image device ptree. This prevent the crash and displays the correct information

#### What has been tested and how, request additional testing if necessary
Manually tested with u280
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1123117
  Hash                 : d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  Hash Date            : 2022-02-22 12:56:29
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                       Platform UUID                         Device ID
[0000:17:00.0]  :  xilinx_u250_gen3x16_base_3  48810C9D-1786-0EF5-3E9E-529E8B14CE39  mgmt(inst=5888)
[0000:65:00.0]  :  xilinx_u280_GOLDEN_8        n/a                                   n/a
```
