### PR TITLE
CR-1122946 xbmgmt examine -h shows we can use "-d all" but actually it will fail

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -92,7 +92,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   // -- Retrieve and parse the subcommand options -----------------------------
   po::options_description commonOptions("Common Options");  
   commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest.  A value of 'all' (default) indicates that every found device should be examined.")
+    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1122946
`xbmgmt examine --help` prints an `all` options for devices which is not valid

#### How problem was solved, alternative solutions (if any) and why they were rejected
Remove tooltip stating all option for device option from `xbmgmt examine`

#### What has been tested and how, request additional testing if necessary
Manual testing
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine --help

DESCRIPTION: This command will 'examine' the state of the system/device and will generate a report
             of interest in a text or JSON format.

USAGE: xbmgmt examine [-h] [-d arg] [-r arg] [-f arg] [-o arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  -r, --report       - The type of report to be produced. Reports currently available are:
                         all        - All known reports are produced
                         cmc        - CMC status of the device
                         firewall   - Firewall status
                         host       - Host information
                         mailbox    - Mailbox metrics of the device
                         mechanical - Mechanical sensors on and surrounding the device
                         platform   - Platform information
  -f, --format       - Report output format. Valid values are:
                         JSON        - Latest JSON schema
                         JSON-2020.2 - JSON 2020.2 schema
  -o, --output       - Direct the output to the given file
  -h, --help         - Help to use this sub-command

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```

#### Documentation impact (if any)
Documentation is already up to date and has no `-d all` references