### PR TITLE
Fix gtest windows build in xrtdeps-win.py

### DIFF
--- a/src/runtime_src/tools/scripts/xrtdeps-win.py
+++ b/src/runtime_src/tools/scripts/xrtdeps-win.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
 # =============================================================================
 # Checks and validates the windows installation environment
@@ -573,7 +573,7 @@ class ICDLibrary:
 
     # -- Create the release library
     if verbose == True:
-      print ("Invoking cmake build the release library...")
+      print ("Invoking cmake to build the release library...")
 
     cmd = "cmake --build . --verbose --config Release"
     print (cmd)
@@ -581,7 +581,7 @@ class ICDLibrary:
 
     # -- Install the library
     if verbose == True:
-      print ("Invoking cmake build to install the library...")
+      print ("Invoking cmake to install the library...")
 
     cmd = "cmake --build . --verbose --config Release --target install"
     print (cmd)
@@ -685,22 +685,6 @@ class GTestLibrary:
       print ("       Google-Test clone directory missing: " + gitDir)
       return True
 
-    # -- Copy the header files
-    srcDir = os.path.join(gitDir, "googletest", "include", "gtest")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "include", "gtest")
-
-    if verbose == True:
-      print ("Creating destination directory: " + dstDir)
-
-    pathlib.Path(dstDir).mkdir(parents=True, exist_ok=True) 
-
-    if verbose == True:
-      print ("Copying header directory.")
-      print ("   Source      : " + srcDir)
-      print ("   Destination : " + dstDir)
-
-    distutils.dir_util.copy_tree(srcDir, dstDir)
-
     # -- Build the library
     buildingDir = pathlib.Path(gitDir, "build")
 
@@ -714,47 +698,25 @@ class GTestLibrary:
     if verbose == True:
       print ("Invoking cmake to create the build scripts...")
 
-    cmd = "cmake -G \"Visual Studio 15 2017 Win64\" .."
+    cmd = "cmake -G \"Visual Studio 15 2017 Win64\" -Dgtest_force_shared_crt=ON -DCMAKE_INSTALL_PREFIX=" + self.install_dir + " .."
     print (cmd)
     os.system(cmd)
 
-	# -- Copying cmake files (GTestConfig, GTestConfigVersion)
-    srcDir = os.path.join(buildingDir, "googletest", "generated")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "lib", "cmake", "gtest")
-    pathlib.Path(dstDir).mkdir(parents=True, exist_ok=True)
-    distutils.dir_util.copy_tree(srcDir, dstDir)
-
     # -- Create the release library
     if verbose == True:
-      print ("Invoking cmake build the release library...")
+      print ("Invoking cmake to build the release library...")
 
     cmd = "cmake --build . --verbose --config Release"
     print (cmd)
     os.system(cmd)
 
-	# -- Create the Debug library
+    # -- Install the library
     if verbose == True:
-      print ("Invoking cmake build the Debug library...")
+      print ("Invoking cmake to install the library...")
 
-    cmd = "cmake --build . --verbose --config Debug"
+    cmd = "cmake --build . --verbose --config Release --target install"
     print (cmd)
     os.system(cmd)
-
-    # -- Copying Release .lib files
-    if verbose == True:
-      print ("Copying Release libraries...")
-
-    srcDir = os.path.join(buildingDir, "lib", "Release")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "lib")
-    distutils.dir_util.copy_tree(srcDir, dstDir)
-
-	# -- Copying Debug .lib files
-    if verbose == True:
-      print ("Copying Debug libraries...")
-
-    srcDir = os.path.join(buildingDir, "lib", "Debug")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "lib")
-    distutils.dir_util.copy_tree(srcDir, dstDir)
 
     return False;
 

--- a/src/runtime_src/tools/scripts/xrtdeps-win19.py
+++ b/src/runtime_src/tools/scripts/xrtdeps-win19.py
@@ -23,7 +23,7 @@
 #             |  +--OpenCL-Headers
 #             |  +--OpenCL-ICD-Loader
 #             +--include
-#             |  +--boost-1_78
+#             |  +--boost-1_75
 #             |  +--CL
 #             +--lib
 # =============================================================================
@@ -573,7 +573,7 @@ class ICDLibrary:
 
     # -- Create the release library
     if verbose == True:
-      print ("Invoking cmake build the release library...")
+      print ("Invoking cmake to build the release library...")
 
     cmd = "cmake --build . --verbose --config Release"
     print (cmd)
@@ -581,7 +581,7 @@ class ICDLibrary:
 
     # -- Install the library
     if verbose == True:
-      print ("Invoking cmake build to install the library...")
+      print ("Invoking cmake to install the library...")
 
     cmd = "cmake --build . --verbose --config Release --target install"
     print (cmd)
@@ -685,22 +685,6 @@ class GTestLibrary:
       print ("       Google-Test clone directory missing: " + gitDir)
       return True
 
-    # -- Copy the header files
-    srcDir = os.path.join(gitDir, "googletest", "include", "gtest")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "include", "gtest")
-
-    if verbose == True:
-      print ("Creating destination directory: " + dstDir)
-
-    pathlib.Path(dstDir).mkdir(parents=True, exist_ok=True) 
-
-    if verbose == True:
-      print ("Copying header directory.")
-      print ("   Source      : " + srcDir)
-      print ("   Destination : " + dstDir)
-
-    distutils.dir_util.copy_tree(srcDir, dstDir)
-
     # -- Build the library
     buildingDir = pathlib.Path(gitDir, "build")
 
@@ -714,47 +698,25 @@ class GTestLibrary:
     if verbose == True:
       print ("Invoking cmake to create the build scripts...")
 
-    cmd = "cmake -G \"Visual Studio 16 2019\" .."
+    cmd = "cmake -G \"Visual Studio 16 2019\" -Dgtest_force_shared_crt=ON -DCMAKE_INSTALL_PREFIX=" + self.install_dir + " .."
     print (cmd)
     os.system(cmd)
 
-	# -- Copying cmake files (GTestConfig, GTestConfigVersion)
-    srcDir = os.path.join(buildingDir, "googletest", "generated")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "lib", "cmake", "gtest")
-    pathlib.Path(dstDir).mkdir(parents=True, exist_ok=True)
-    distutils.dir_util.copy_tree(srcDir, dstDir)
-
     # -- Create the release library
     if verbose == True:
-      print ("Invoking cmake build the release library...")
+      print ("Invoking cmake to build the release library...")
 
     cmd = "cmake --build . --verbose --config Release"
     print (cmd)
     os.system(cmd)
 
-	# -- Create the Debug library
+    # -- Install the library
     if verbose == True:
-      print ("Invoking cmake build the Debug library...")
+      print ("Invoking cmake to install the library...")
 
-    cmd = "cmake --build . --verbose --config Debug"
+    cmd = "cmake --build . --verbose --config Release --target install"
     print (cmd)
     os.system(cmd)
-
-    # -- Copying Release .lib files
-    if verbose == True:
-      print ("Copying Release libraries...")
-
-    srcDir = os.path.join(buildingDir, "lib", "Release")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "lib")
-    distutils.dir_util.copy_tree(srcDir, dstDir)
-
-	# -- Copying Debug .lib files
-    if verbose == True:
-      print ("Copying Debug libraries...")
-
-    srcDir = os.path.join(buildingDir, "lib", "Debug")
-    dstDir = os.path.join(XRT_LIBRARY_INSTALL_DIR, "lib")
-    distutils.dir_util.copy_tree(srcDir, dstDir)
 
     return False;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
GTest was being incorrectly built and installed for Windows.
The existing installation process was manually copying files, which should be handled directly by cmake.
The prior manual copy was omitting files which were critical for actually using the library.. GTestTargets.cmake and related.
Additionally, in all my testing, I've had to add the CMake flag `-Dgtest_force_shared_crt=ON`
Without doing that, there is a nasty linker error.
```
       "C:\Xilinx\BRYAN\new-vai-rt\new-vai-rt\WRelease\ALL_BUILD.vcxproj" (default target) (1) ->
       "C:\Xilinx\BRYAN\new-vai-rt\new-vai-rt\WRelease\tests\run_tests.vcxproj" (default target) (6) ->
       (Link target) ->
         gtest.lib(gtest-all.obj) : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't mat
       ch value '0' in test.cpp.obj [C:\Xilinx\BRYAN\new-vai-rt\new-vai-rt\WRelease\tests\run_tests.vcxproj]
         gtest.lib(gtest-all.obj) : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' does
       n't match value 'MD_DynamicRelease' in test.cpp.obj [C:\Xilinx\BRYAN\new-vai-rt\new-vai-rt\WRelease\tests\run_te
       sts.vcxproj]
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue was discovered when building Vitis-AI and XRT together for Windows.
In this setting, GTest is dynamically linked by Vitis-AI test cases that eventually exercise XRT.

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
