### PR TITLE
PS kernel mem support for XOCL

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -43,7 +43,8 @@ memtype2str(MEM_TYPE mt)
    {MEM_HBM,                  "MEM_HBM"},
    {MEM_BRAM,                 "MEM_BRAM"},
    {MEM_URAM,                 "MEM_URAM"},
-   {MEM_STREAMING_CONNECTION, "MEM_STREAMING_CONNECTION"}
+   {MEM_STREAMING_CONNECTION, "MEM_STREAMING_CONNECTION"},
+   {MEM_PS_KERNEL,            "MEM_PS_KERNEL"}
   };
 
   auto itr = memtype_map.find(mt);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -439,7 +439,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	xocl_xdev_dbg(xdev, "alloc bo from bank%u, flag %x, host bank %d",
 		memidx, xobj->flags, drm_p->cma_bank_idx);
 
-	err = xocl_mm_insert_node_range(drm_p, memidx, xobj->mm_node,
+	err = xocl_mm_insert_node(drm_p, memidx, xobj->mm_node,
 		xobj->base.size);
 	if (err)
 		goto failed;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -443,6 +443,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 		xobj->base.size);
 	if (err)
 		goto failed;
+
 	BO_DEBUG("insert mm_node:%p, start:%llx size: %llx",
 		xobj->mm_node, xobj->mm_node->start,
 		xobj->mm_node->size);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -662,9 +662,13 @@ static int xocl_mm_insert_node_range_all(struct xocl_drm *drm_p, u32 mem_id,
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 7, 0)
 	for (i = 0; i < grp_topology->m_count; i++) {
+		if (IS_HOST_MEM(grp_topology->m_mem_data[i].m_tag) ||
+				XOCL_IS_PS_KERNEL_MEM(grp_topology, i))
+			continue;
+
 		hash_start_addr = grp_topology->m_mem_data[i].m_base_address;
 		hash_for_each_possible(drm_p->mm_range, wrapper, node, hash_start_addr) {
-			if (!wrapper && (wrapper->ddr == drm_p->cma_bank_idx))
+			if (!wrapper)
 				continue;
 
 			start_addr = wrapper->start_addr;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -25,6 +25,7 @@
 typedef void (*xocl_execbuf_callback)(unsigned long data, int error);
 
 #define IS_HOST_MEM(m_tag)	(!strncmp(m_tag, "HOST[0]", 7))
+#define IS_PS_KERNEL_MEM(m_tag)	(!strncmp(m_tag, "MEM_PS_KERNEL", 13))
 #define IS_PLRAM(m_tag)		(!strncmp(m_tag, "PLRAM[", 6))
 
 /**
@@ -110,8 +111,6 @@ void xocl_mm_get_usage_stat(struct xocl_drm *drm_p, u32 ddr,
 void xocl_mm_update_usage_stat(struct xocl_drm *drm_p, u32 ddr,
         u64 size, int count);
 
-int xocl_mm_insert_node_range(struct xocl_drm *drm_p, u32 mem_id,
-                    struct drm_mm_node *node, u64 size);
 int xocl_mm_insert_node(struct xocl_drm *drm_p, u32 ddr,
                 struct drm_mm_node *node, u64 size);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drm.h
@@ -25,7 +25,6 @@
 typedef void (*xocl_execbuf_callback)(unsigned long data, int error);
 
 #define IS_HOST_MEM(m_tag)	(!strncmp(m_tag, "HOST[0]", 7))
-#define IS_PS_KERNEL_MEM(m_tag)	(!strncmp(m_tag, "MEM_PS_KERNEL", 13))
 #define IS_PLRAM(m_tag)		(!strncmp(m_tag, "PLRAM[", 6))
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1548,6 +1548,9 @@ static inline u32 xocl_ddr_count_unified(xdev_handle_t xdev_hdl)
 #define XOCL_IS_STREAM(topo, idx)					\
 	(topo->m_mem_data[idx].m_type == MEM_STREAMING || \
 	 topo->m_mem_data[idx].m_type == MEM_STREAMING_CONNECTION)
+#define XOCL_IS_PS_KERNEL_MEM(topo, idx)					\
+	(topo->m_mem_data[idx].m_type == MEM_PS_KERNEL && \
+	!IS_PS_KERNEL_MEM(topo->m_mem_data[i].m_tag))
 #define XOCL_IS_P2P_MEM(topo, idx)					\
 	((topo->m_mem_data[idx].m_type == MEM_DDR3 ||			\
 	 topo->m_mem_data[idx].m_type == MEM_DDR4 ||			\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -1548,15 +1548,14 @@ static inline u32 xocl_ddr_count_unified(xdev_handle_t xdev_hdl)
 #define XOCL_IS_STREAM(topo, idx)					\
 	(topo->m_mem_data[idx].m_type == MEM_STREAMING || \
 	 topo->m_mem_data[idx].m_type == MEM_STREAMING_CONNECTION)
-#define XOCL_IS_PS_KERNEL_MEM(topo, idx)					\
-	(topo->m_mem_data[idx].m_type == MEM_PS_KERNEL && \
-	!IS_PS_KERNEL_MEM(topo->m_mem_data[i].m_tag))
+#define XOCL_IS_PS_KERNEL_MEM(topo, idx)				\
+	(topo->m_mem_data[idx].m_type == MEM_PS_KERNEL) 
 #define XOCL_IS_P2P_MEM(topo, idx)					\
 	((topo->m_mem_data[idx].m_type == MEM_DDR3 ||			\
 	 topo->m_mem_data[idx].m_type == MEM_DDR4 ||			\
 	 topo->m_mem_data[idx].m_type == MEM_DRAM ||			\
 	 topo->m_mem_data[idx].m_type == MEM_HBM) &&			\
-	!IS_HOST_MEM(topo->m_mem_data[i].m_tag))
+	!IS_HOST_MEM(topo->m_mem_data[idx].m_tag))
 
 struct xocl_mig_label {
 	unsigned char		tag[16];

--- a/src/runtime_src/core/tools/common/ReportMemory.cpp
+++ b/src/runtime_src/core/tools/common/ReportMemory.cpp
@@ -119,7 +119,7 @@ ReportMemory::writeReport( const xrt_core::device* /*_pDevice*/,
     int index = 0;
     _output << std::endl;
     _output << "  Memory Topology" << std::endl;
-    _output << boost::format("    %-17s%-12s%-9s%-10s%-16s\n") % "     Tag" % "Type"
+    _output << boost::format("    %-25s%-17s%-9s%-10s%-16s\n") % "     Tag" % "Type"
         % "Temp(C)" % "Size" % "Base Address";
     try {
       for (auto& v : _pt.get_child("mem_topology.board.memory.memories",empty_ptree)) {
@@ -138,7 +138,7 @@ ReportMemory::writeReport( const xrt_core::device* /*_pDevice*/,
             base_addr = subv.second.get_value<std::string>();
           }
         }
-        _output << boost::format("    [%2d] %-12s%-12s%-9s%-10s%-16s\n") % index
+        _output << boost::format("    [%2d] %-20s%-17s%-9s%-10s%-16s\n") % index
             % tag % type % temp % size % base_addr;
         index++;
       }


### PR DESCRIPTION
Added the build is PS kernel support for XOCL. 
Added memory initialization and alloc BO support. 

Added XRT used space changes to support the same.

XOCL driver is verified on u250 device with created a hand modified xclbin by added MEM_PS_KERNEL in the mem topology.