### PR TITLE
Fix "ert(1)" when APU is not installed for Versal platform

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -52,6 +52,8 @@
 #define XGQ_SQ_REG		0x0
 #define XGQ_CQ_REG		0x100
 
+#define SHELL_NOT_SUPP_LEGACY(ec) (ec->ec_xgq_ips != NULL)
+
 static uint16_t	g_ctrl_xgq_cid;
 struct xocl_drv_private ert_ctrl_xgq_drv_priv;
 
@@ -616,6 +618,10 @@ static int ert_ctrl_connect(struct platform_device *pdev)
 		err = ert_ctrl_xgq_init(ec);
 		break;
 	default:
+		if (SHELL_NOT_SUPP_LEGACY(ec)) {
+			err = -ENODEV;
+			break;
+		}
 		EC_INFO(ec, "Connect Legacy ERT firmware");
 		err = ert_ctrl_legacy_init(ec);
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When APU is not installed, dmesg still shows "ert(1)".

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is discovered by board farm test

#### How problem was solved, alternative solutions (if any) and why they were rejected
The issue is when APU doesn't present, ERT ctrl subdev will try to setup the flow for legacy ERT.
But legacy ERT user subdev will print 'ert(1)' before it sent config command to ERT firmware. So, we will see this issue.

My fix is to not try setup the flow for legacy ERT on a XGQ based firmware.

After this change, if APU is not loaded, then user will see "ERT will be disabled" warning in dmesg. 
E.g.
[180236.476263] xocl 0000:b3:00.1:  ffff888859e6e0b0 xocl_kds_register_cus: ERT will be disabled, ret -19

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Vck5000, xbutil validate

#### Documentation impact (if any)
No