### PR TITLE
PS Kernel : Updated DWARF parser to accept anonymous functions

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
@@ -524,8 +524,9 @@ add_DWTAG_subprogram(size_t& index,
 
   const auto& functionName = ptFunction.get<std::string>("name", "");
 
-  if (functionName.empty())
-    throw std::runtime_error("ERROR: Could not find the function name for the sub-program. Index: " + std::to_string(subProgramIndex));
+  if (functionName.empty()) {
+    XUtil::TRACE("Info: Could not find the function name for the sub-program. Index: " + std::to_string(subProgramIndex));
+  }
 
   // See if this function is visible
   if (std::find(exportedFunctions.begin(), exportedFunctions.end(), functionName) == exportedFunctions.end())

--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -252,8 +252,9 @@ XclBinUtilities::addKernel(const boost::property_tree::ptree& ptKernel,
   }
 
   // Add the kernel
-  XUtil::TRACE("Fix kernel '" + kernelName + "' added to EMBEDDED_METADATA");
   ptCore.add_child("kernel", ptKernelXML);
+
+  XUtil::TRACE_PrintTree("EMBEDDED_METADATA XML", ptEmbeddedData);
 }
 
 void addArgsToMemoryConnections(const unsigned int ipLayoutIndexID,
@@ -316,6 +317,11 @@ void transformVectorToPtree(const std::vector<boost::property_tree::ptree>& vect
                             const std::string& arrayName,
                             boost::property_tree::ptree& ptRoot)
 {
+  ptRoot.clear();
+
+  if (vectorOfPtree.empty())
+    return;
+
   boost::property_tree::ptree ptBase;
   ptBase.put("m_count", std::to_string(vectorOfPtree.size()));
 
@@ -326,7 +332,6 @@ void transformVectorToPtree(const std::vector<boost::property_tree::ptree>& vect
 
   ptBase.add_child(arrayName, ptArray);
 
-  ptRoot.clear();
   ptRoot.add_child(sectionName, ptBase);
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
When parsing the DWARF metadata xclbinutil would produce a DRC error stating that the name for a SUB_PROGRAM was not found.   This DRC should not have been done for there does exist "anonymous" no-name inline functions.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue was discovered during exploratory testing. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
The parser was updated to not throw the DRC error.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
Manual testing and system testing.

#### Documentation impact (if any)
N/A