### PR TITLE
Make setup.sh zsh compatible.

### DIFF
--- a/src/runtime_src/tools/scripts/setup.sh
+++ b/src/runtime_src/tools/scripts/setup.sh
@@ -25,7 +25,7 @@ if [[ $OSDIST == "centos" ]] || [[ $OSDIST == "redhat"* ]]; then
     fi
 fi
 
-XILINX_XRT=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+XILINX_XRT=$(readlink -f $(dirname ${BASH_SOURCE[0]:-${(%):-%x}}))
 
 if [[ $XILINX_XRT != *"/opt/xilinx/xrt" ]]; then
     echo "Invalid location: $XILINX_XRT"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Provides a zsh-compatible alternative to `BASH_SOURCE` when setup.sh is sourced from zsh. There is some discussion of how this works here: https://stackoverflow.com/questions/9901210/bash-source0-equivalent-in-zsh

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Sourcing setup.sh fails noisily under zsh. 

#### What has been tested and how, request additional testing if necessary

This is the change i've been making manually to interact with XRT under zsh.

#### Documentation impact (if any)
