### PR TITLE
CR-1119183: Fixed AIE2GMIO based designs 

### DIFF
--- a/src/runtime_src/core/edge/user/aie/aie.cpp
+++ b/src/runtime_src/core/edge/user/aie/aie.cpp
@@ -246,7 +246,9 @@ clear_bd(BD& bd)
 {
 #ifndef __AIESIM__
   XAie_MemDetach(&bd.memInst);
-  close(bd.buf_fd);
+  /* we shouldnt close the buffer handle here. file handle gets closed in bo
+   * destructor */
+  //close(bd.buf_fd);
 #endif
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIEGMIO tests uses export_bo to get the handle and send those handles to AIE driver. We shouldnt close them until bo is destroyed. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Not closing fd anymore. It gets closed automatically when bo object is destroyed

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified GMIO tests

#### Documentation impact (if any)
