### PR TITLE
CR-1121969 implement force trace flushing in continuous trace

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -710,20 +710,22 @@ namespace xdp {
 
     // Try to find 8 contiguous clock training packets.  Anything before that
     //  is garbage from the previous run
-    
-    bool found = false ;
-    for (uint64_t i = 0 ; i < numPackets - 8 ; ++i) {
-      for (uint64_t j = i ; j < i + 8 ; ++j) {
-        uint64_t packet = (static_cast<uint64_t*>(data))[j] ;
-        if (!isClockTraining(packet)) {
-          break ;
+    // Note: This needs to be done only in beginning chunk of data
+    static bool found = false ;
+    if (!found) {
+      for (uint64_t i = 0 ; i < numPackets - 8 ; ++i) {
+        for (uint64_t j = i ; j < i + 8 ; ++j) {
+          uint64_t packet = (static_cast<uint64_t*>(data))[j] ;
+          if (!isClockTraining(packet)) {
+            break ;
+          }
+          if (j == (i + 7)) {
+            start = i ;
+            found = true ;
+          }
         }
-        if (j == (i + 7)) {
-          start = i ;
-          found = true ;
-        }
+        if (found) break ;
       }
-      if (found) break ;
     }
     
     for (uint64_t i = start ; i < numPackets ; ++i) {

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -141,6 +141,11 @@ void DeviceTraceOffload::process_trace()
       q_read = true;
       q_empty = ts2mm_info.data_queue.empty();
     }
+    if (ts2mm_info.size_queue.size() > TS2MM_QUEUE_SZ_WARN_THRESHOLD) {
+      std::call_once(ts2mm_queue_warning_flag, [](){
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_QUEUE_SZ);
+      });
+    }
     ts2mm_info.process_queue_lock.unlock();
 
     // Processing takes a lot more time compared to everything else

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -202,7 +202,8 @@ private:
     OffloadThreadStatus status = OffloadThreadStatus::IDLE;
     std::thread offload_thread;
     std::thread process_thread;
-    bool continuous = false ;
+    bool continuous = false;
+    std::once_flag ts2mm_queue_warning_flag;
 
     // Clock Training Params
     bool m_force_clk_train = true;

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -51,7 +51,7 @@
 #define TS2MM_MIN_READ_SIZE      0x200
 #define DEFAULT_TRACE_OFFLOAD_INTERVAL_MS 10
 // Throw warning when too much trace in processing pipeline
-// use some arbitrary large number here
+// Use some arbitrary large number here
 #define TS2MM_QUEUE_SZ_WARN_THRESHOLD 5000
 
 #define FIFO_WARN_MSG "Trace FIFO is full because of too many events. Device trace could be incomplete. Suggested fixes:\n\

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -50,6 +50,9 @@
 // Read data only if it's more than 512B unless forced
 #define TS2MM_MIN_READ_SIZE      0x200
 #define DEFAULT_TRACE_OFFLOAD_INTERVAL_MS 10
+// Throw warning when too much trace in processing pipeline.
+// 5000 is arbitrarily chosen
+#define TS2MM_QUEUE_SZ_WARN_THRESHOLD 5000
 
 #define FIFO_WARN_MSG "Trace FIFO is full because of too many events. Device trace could be incomplete. Suggested fixes:\n\
 1. Use larger FIFO size or DDR/HBM bank as 'trace_memory' in linking options.\n\
@@ -67,6 +70,8 @@ Please increase trace_buffer_size or use 'coarse' option for device_trace or tur
 buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."
 #define TS2MM_WARN_MSG_BIG_BUF         "Processing large amount of device trace. It could take a while before application ends."
+#define TS2MM_WARN_MSG_QUEUE_SZ        "Too much trace in processing queue. This could have negative impact on host memory utilization. \
+Please increase trace_buffer_size and/or reduce trace_buffer_offload_interval."
 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
 

--- a/src/runtime_src/xdp/profile/device/tracedefs.h
+++ b/src/runtime_src/xdp/profile/device/tracedefs.h
@@ -50,8 +50,8 @@
 // Read data only if it's more than 512B unless forced
 #define TS2MM_MIN_READ_SIZE      0x200
 #define DEFAULT_TRACE_OFFLOAD_INTERVAL_MS 10
-// Throw warning when too much trace in processing pipeline.
-// 5000 is arbitrarily chosen
+// Throw warning when too much trace in processing pipeline
+// use some arbitrary large number here
 #define TS2MM_QUEUE_SZ_WARN_THRESHOLD 5000
 
 #define FIFO_WARN_MSG "Trace FIFO is full because of too many events. Device trace could be incomplete. Suggested fixes:\n\
@@ -71,7 +71,7 @@ buffer size and/or reduce trace_buffer_offload_interval."
 #define TS2MM_WARN_MSG_CIRC_BUF_OVERWRITE   "Circular buffer overwrite was detected in device trace. Timeline trace could be incomplete."
 #define TS2MM_WARN_MSG_BIG_BUF         "Processing large amount of device trace. It could take a while before application ends."
 #define TS2MM_WARN_MSG_QUEUE_SZ        "Too much trace in processing queue. This could have negative impact on host memory utilization. \
-Please increase trace_buffer_size and/or reduce trace_buffer_offload_interval."
+Please increase trace_buffer_size and trace_buffer_offload_interval together or use 'coarse' option for device_trace."
 
 #define AIE_TS2MM_WARN_MSG_BUF_FULL       "AIE Trace Buffer is full. Device trace could be incomplete."
 

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -992,7 +992,7 @@ namespace xdp {
 
     // Continuous Trace Offload is supported only for PLIO flow
     if (continuousTrace && isPLIO) {
-      XDPPlugin::startWriteThread(aie_trace_file_dump_int_s, "AIE_EVENT_TRACE");
+      XDPPlugin::startWriteThread(aie_trace_file_dump_int_s, "AIE_EVENT_TRACE", false);
     }
 
     // First, check against memory bank size
@@ -1309,7 +1309,7 @@ namespace xdp {
     }
     aieOffloaders.clear();
 
-    XDPPlugin::endWrite(openNewFiles);
+    XDPPlugin::endWrite();
   }
 
 } // namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -1286,7 +1286,7 @@ namespace xdp {
     
   }
 
-  void AieTracePlugin::writeAll(bool openNewFiles)
+  void AieTracePlugin::writeAll(bool /*openNewFiles*/)
   {
     // read the trace data from device and wrie to the output file
     for(auto o : aieOffloaders) {

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -360,7 +360,7 @@ namespace xdp {
     return true;
   }
 
-  void DeviceOffloadPlugin::writeAll(bool openNewFiles)
+  void DeviceOffloadPlugin::writeAll(bool /*openNewFiles*/)
   {
     // This function gets called if the database is destroyed before
     //  the plugin object.  At this time, the information in the database

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -375,7 +375,7 @@ namespace xdp {
     // Also, store away the counter results
     readCounters() ;
 
-    XDPPlugin::endWrite(openNewFiles);
+    XDPPlugin::endWrite();
   }
 
   void DeviceOffloadPlugin::checkTraceBufferFullness(DeviceTraceOffload* offloader, uint64_t deviceId)
@@ -414,7 +414,7 @@ namespace xdp {
       break ;
     case VPDatabase::DUMP_TRACE:
       {
-	XDPPlugin::forceWrite(true) ;
+        XDPPlugin::trySafeWrite("VP_TRACE", true);
       }
       break ;
     default:

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -79,7 +79,7 @@ namespace xdp {
 
       readTrace() ;
       readCounters() ;
-      XDPPlugin::endWrite(false);
+      XDPPlugin::endWrite();
       db->unregisterPlugin(this) ;
     }
 

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -69,7 +69,7 @@ namespace xdp {
     if (VPDatabase::alive()) {
       readTrace() ;
       readCounters() ;
-      XDPPlugin::endWrite(false) ;
+      XDPPlugin::endWrite() ;
       db->unregisterPlugin(this) ;
     }
 

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -158,7 +158,7 @@ namespace xdp {
 
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
-      XDPPlugin::endWrite(false);
+      XDPPlugin::endWrite();
 
       db->unregisterPlugin(this) ;
     }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -52,7 +52,7 @@ namespace xdp {
 
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
-      XDPPlugin::endWrite(false);
+      XDPPlugin::endWrite();
       db->unregisterPlugin(this) ;
     }
   }

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -117,7 +117,10 @@ namespace xdp {
       trySafeWrite(type, openNewFiles);
 
     // Do a final write
-    trySafeWrite(type, false);
+    mtx_writer_list.lock();
+    for (auto w : writers)
+      w->write(false);
+    mtx_writer_list.unlock();
   }
 
   void XDPPlugin::startWriteThread(unsigned int interval, std::string type, bool openNewFiles)

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -132,10 +132,10 @@ namespace xdp {
     if (is_write_thread_active) {
       // Ask writer thread to quit
       {
-        std::lock_guard<std::mutex> l(mtx_writer);
-        stop_writer = true;
+        std::lock_guard<std::mutex> l(mtx_writer_thread);
+        stop_writer_thread = true;
       }
-      cv_writer.notify_one();
+      cv_writer_thread.notify_one();
       write_thread.join();
       is_write_thread_active = false;
     } else {
@@ -143,12 +143,12 @@ namespace xdp {
     }
   }
 
-  void XDPPlugin::trySafeWrite(std::string type, bool openNewFiles)
+  void XDPPlugin::trySafeWrite(const std::string& type, bool openNewFiles)
   {
     if (type.empty() && openNewFiles)
       return;
 
-    // If a writer is already writing then don't do anything
+    // If a writer is already writing, then don't do anything
     if (mtx_writer_list.try_lock()) {
       for (auto w : writers) {
         bool success = w->write(openNewFiles);

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -41,16 +41,16 @@ namespace xdp {
     std::atomic<bool> is_write_thread_active;
     std::thread write_thread;
     // Trace dump thread control
-    bool stop_writer = false;
-    std::mutex mtx_writer;
-    std::condition_variable cv_writer;
+    bool stop_writer_thread = false;
+    std::mutex mtx_writer_thread;
+    std::condition_variable cv_writer_thread;
     // Returns false if stop_trace_dump == true.
     // Stops trace writing thread when host program is ending
     // even if the thread is asleep
     template<class Duration>
     bool writeCondWaitFor(Duration duration) {
-      std::unique_lock<std::mutex> lk(mtx_writer);
-      return !cv_writer.wait_for(lk, duration, [this]() { return stop_writer; });
+      std::unique_lock<std::mutex> lk(mtx_writer_thread);
+      return !cv_writer_thread.wait_for(lk, duration, [this]() { return stop_writer_thread; });
     }
     void writeContinuous(unsigned int interval, std::string type, bool openNewFiles);
     // Mutex to access writer list
@@ -70,7 +70,7 @@ namespace xdp {
 
     XDP_EXPORT void startWriteThread(unsigned int interval, std::string type, bool openNewFiles = true);
     XDP_EXPORT void endWrite();
-    XDP_EXPORT void trySafeWrite(std::string type, bool openNewFiles);
+    XDP_EXPORT void trySafeWrite(const std::string& type, bool openNewFiles);
 
   public:
     XDP_EXPORT XDPPlugin() ;

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.h
@@ -52,7 +52,9 @@ namespace xdp {
       std::unique_lock<std::mutex> lk(mtx_writer);
       return !cv_writer.wait_for(lk, duration, [this]() { return stop_writer; });
     }
-    void writeContinuous(unsigned int interval, std::string type);
+    void writeContinuous(unsigned int interval, std::string type, bool openNewFiles);
+    // Mutex to access writer list
+    std::mutex mtx_writer_list;
 
   protected:
     // A link to the single instance of the database that all plugins
@@ -66,9 +68,9 @@ namespace xdp {
     //  dealing with emulation flows.
     XDP_EXPORT virtual void emulationSetup() ;
 
-    XDP_EXPORT void startWriteThread(unsigned int interval, std::string type);
-    XDP_EXPORT void endWrite(bool openNewFiles);
-    XDP_EXPORT void forceWrite(bool openNewFiles) ;
+    XDP_EXPORT void startWriteThread(unsigned int interval, std::string type, bool openNewFiles = true);
+    XDP_EXPORT void endWrite();
+    XDP_EXPORT void trySafeWrite(std::string type, bool openNewFiles);
 
   public:
     XDP_EXPORT XDPPlugin() ;


### PR DESCRIPTION
1. Implement forced trace flushing in continuous trace
2. Implemented locking mechanism to call trace writers safely
3. Added warning message when trace processing queue becomes too large