### PR TITLE
CR-1123564 Handled the condition when we do not have any PL kernels i…

### DIFF
--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -185,8 +185,10 @@ register_axlf(const axlf* top)
   }
   catch (const query::no_such_key&) {
     auto ip_layout = get_axlf_section<const ::ip_layout*>(IP_LAYOUT);
-    m_cus = xclbin::get_cus(ip_layout);
-    m_cu2idx = xclbin::get_cu_indices(ip_layout);
+    if (ip_layout != nullptr) {
+      m_cus = xclbin::get_cus(ip_layout);
+      m_cu2idx = xclbin::get_cu_indices(ip_layout);
+    }
   }
 }
 


### PR DESCRIPTION
Handled the condition when we do not have any PL kernels in the application.

Able to run the sw_emu designs that does have only AIE kernels, no PL kernels.

We started to get the designs which does have only AIE kernels and PS on x86 feature verification found this issue

Having the safe check on ip_layout ptr while accessing the APIs of that object 

Nope

Ran the canary suite and also ran the PS on x86 designs.

#### Documentation impact (if any)
