### PR TITLE
fix not able to enable user manage cu interrupt issue

### DIFF
--- a/src/runtime_src/core/common/drv/include/kds_core.h
+++ b/src/runtime_src/core/common/drv/include/kds_core.h
@@ -131,6 +131,10 @@ struct cmdmem_info {
  * @anon_client: driver own kds client used with driver generated command
  * @polling_thread: poll CUs when ERT is disabled
  */
+#define KDS_SYSFS_SETTING_BIT	(1 << 31)
+#define KDS_SET_SYSFS_BIT(val)	(val | KDS_SYSFS_SETTING_BIT)
+#define KDS_SYSFS_SETTING(val)	(val & KDS_SYSFS_SETTING_BIT)
+#define KDS_SETTING(val)	(val & ~KDS_SYSFS_SETTING_BIT)
 struct kds_sched {
 	struct list_head	clients;
 	int			num_client;
@@ -139,15 +143,18 @@ struct kds_sched {
 	struct kds_cu_mgmt	cu_mgmt;
 	struct kds_scu_mgmt	scu_mgmt;
 	struct kds_ert	       *ert;
-	bool			ini_disable;
-	bool			ert_disable;
 	bool			xgq_enable;
 	u32			cu_intr_cap;
-	u32			cu_intr;
 	struct cmdmem_info	cmdmem;
 	struct completion	comp;
 	struct kds_client      *anon_client;
 
+	/* Settings */
+	bool			ini_disable;
+	bool			ert_disable;
+	u32			cu_intr;
+
+	/* KDS polling thread */
 	struct task_struct     *polling_thread;
 	wait_queue_head_t	wait_queue;
 	int			polling_start;

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -139,7 +139,7 @@ ssize_t show_kds_stat(struct kds_sched *kds, char *buf)
 			"CU to host interrupt capability: %d\n",
 			kds->cu_intr_cap);
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "Interrupt mode: %s\n",
-			(kds->cu_intr)? "cu" : "ert");
+			(KDS_SETTING(kds->cu_intr))? "cu" : "ert");
 	sz += scnprintf(buf+sz, PAGE_SIZE - sz, "Number of CUs: %d\n",
 			cu_mgmt->num_cus);
 	for (i = 0; i < MAX_CUS; ++i) {
@@ -1523,12 +1523,12 @@ int kds_cfg_update(struct kds_sched *kds)
 			if (!xcu)
 				continue;
 
-			if (cu_mgmt->cu_intr[i] == kds->cu_intr)
+			if (cu_mgmt->cu_intr[i] == KDS_SETTING(kds->cu_intr))
 				continue;
 
-			ret = xrt_cu_cfg_update(xcu, kds->cu_intr);
+			ret = xrt_cu_cfg_update(xcu, KDS_SETTING(kds->cu_intr));
 			if (!ret)
-				cu_mgmt->cu_intr[i] = kds->cu_intr;
+				cu_mgmt->cu_intr[i] = KDS_SETTING(kds->cu_intr);
 			else if (ret == -ENOSYS) {
 				/* CU doesn't support interrupt */
 				cu_mgmt->cu_intr[i] = 0;
@@ -1538,8 +1538,7 @@ int kds_cfg_update(struct kds_sched *kds)
 	}
 
 run_polling:
-	if (!kds->cu_intr) {
-		BUG_ON(kds->polling_thread);
+	if (!KDS_SETTING(kds->cu_intr) && !kds->polling_thread) {
 		kds->polling_stop = 0;
 		kds->polling_thread = kthread_run(kds_polling_thread, kds, "kds_poll");
 		if (IS_ERR(kds->polling_thread)) {

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -644,7 +644,7 @@ int xrt_cu_cfg_update(struct xrt_cu *xcu, int intr)
 		return -ENOSYS;
 
 	if (xrt_cu_get_protocol(xcu) == CTRL_NONE) {
-		xcu_err(xcu, "Interrupt enabled value should be false for ap_ctrl_none cu\n");
+		xcu_warn(xcu, "Interrupt enabled value should be false for ap_ctrl_none cu\n");
 		return -ENOSYS;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -383,8 +383,6 @@ static void xocl_client_release(struct drm_device *dev, struct drm_file *filp)
 static uint xocl_poll(struct file *filp, poll_table *wait)
 {
 	struct drm_file *priv = filp->private_data;
-	struct drm_device *dev = priv->minor->dev;
-	struct xocl_drm	*drm_p = dev->dev_private;
 
 	BUG_ON(!priv->driver_priv);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -1792,8 +1792,11 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 		goto out;
 	}
 
-	/* By default, use ERT */
-	XDEV(xdev)->kds.cu_intr = 0;
+	if (CFG_GPIO_OPS(xdev))
+		XDEV(xdev)->kds.cu_intr_cap = 1;
+
+	if (!KDS_SYSFS_SETTING(XDEV(xdev)->kds.cu_intr))
+		XDEV(xdev)->kds.cu_intr = 0;
 	ret = kds_cfg_update(&XDEV(xdev)->kds);
 	if (ret)
 		userpf_err(xdev, "KDS configure update failed, ret %d", ret);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Not able to convert to CU interrupt mode.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6077 introduced the bug. This is discovered when we try user manage interrupt application.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is a regression when we support XGQ ERT. Switch CU/ERT interrupt in kds_interrupt sysfs node.

#### Risks (if any) associated the changes in the commit
No.

#### What has been tested and how, request additional testing if necessary
Test with user manage interrupt.

#### Documentation impact (if any)
No.