### PR TITLE
Decouple iops test from BIST

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1211,8 +1211,6 @@ bistTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::pt
   if (!ert_validate(_dev, _dev->get_device_handle(), _ptTest))
     _ptTest.put("status", test_token_failed);
 
-  runTestCase(_dev, "xcl_iops_test.exe", _ptTest.get<std::string>("xclbin"), _ptTest);
-
   _ptTest.put("status", test_token_passed);
 }
 


### PR DESCRIPTION
#### Problem solved by the commit
Decoupling iops test from bist. 

If users like to get the iops number, they should call xbutil validate --run iops explicitly. 