### PR TITLE
PS Kernel Bug Fixes - Fixed incorrect offset and id values

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
@@ -390,7 +390,6 @@ get_dw_type(const std::string& typeOffset,
 {
   size_t posOffset = typeOffset.find("<0x") == std::string::npos ? 0 : 3;
   unsigned long offset = readHexString(typeOffset, posOffset);
-  std::cout << boost::format("Offset string: %s', value: 0x%x\n") % typeOffset % offset;
 
   auto it = std::find_if(argTags.begin(), argTags.end(),
                          [&offset](const std::pair<unsigned long, boost::property_tree::ptree>& element) {return element.first == offset;});
@@ -416,7 +415,7 @@ evaluate_DW_TAG_type(const std::string& typeOffset,
   switch (dwTag) {
     case DW_TAG::pointer_type: {
         evaluate_DW_TAG_type(ptTag.get<std::string>("DW_AT_type"), argTags, ptArgument);
-        ptArgument.put("byte-size", ptTag.get<std::string>("DW_AT_byte_size"));
+        ptArgument.put("primitive-byte-size", ptTag.get<std::string>("DW_AT_byte_size"));
         // Add pointer
         std::string argType = ptArgument.get<std::string>("type", "") + "*";
         ptArgument.put<std::string>("type", argType);
@@ -433,7 +432,7 @@ evaluate_DW_TAG_type(const std::string& typeOffset,
 
     case DW_TAG::base_type:
       ptArgument.put("type", ptTag.get<std::string>("DW_AT_name"));
-      ptArgument.put("byte-size", ptTag.get<std::string>("DW_AT_byte_size"));
+      ptArgument.put("primitive-byte-size", ptTag.get<std::string>("DW_AT_byte_size"));
       break;
 
     case DW_TAG::const_type: {

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_expected.xml
@@ -68,13 +68,13 @@
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_64_0_S02_AXI" dstType="kernel" dstInst="vadd_1" dstPort="M_AXI_GMEM"/>
         <kernel name="kernel0" language="c" type="ps">
           <arg name="inA" addressQualifier="1" id="0" size="0x10" offset="0x0" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="inB" addressQualifier="1" id="1" size="0x10" offset="0x8" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="out" addressQualifier="1" id="2" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="input_size" addressQualifier="0" id="3" size="0x4" offset="0x18" hostOffset="0x0" hostSize="0x4" type="const int"/>
-          <arg name="output_size" addressQualifier="0" id="4" size="0x4" offset="0x1c" hostOffset="0x0" hostSize="0x4" type="const int"/>
-          <arg name="increment" addressQualifier="0" id="5" size="0x4" offset="0x20" hostOffset="0x0" hostSize="0x4" type="float"/>
-          <arg name="increment_out" addressQualifier="1" id="6" size="0x10" offset="0x24" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="handles" addressQualifier="1" id="7" size="0x10" offset="0x2c" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
+          <arg name="inB" addressQualifier="1" id="1" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="out" addressQualifier="1" id="2" size="0x10" offset="0x20" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="input_size" addressQualifier="0" id="3" size="0x4" offset="0x30" hostOffset="0x0" hostSize="0x4" type="const int"/>
+          <arg name="output_size" addressQualifier="0" id="4" size="0x4" offset="0x34" hostOffset="0x0" hostSize="0x4" type="const int"/>
+          <arg name="increment" addressQualifier="0" id="5" size="0x4" offset="0x38" hostOffset="0x0" hostSize="0x4" type="float"/>
+          <arg name="increment_out" addressQualifier="1" id="6" size="0x10" offset="0x3c" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="handles" addressQualifier="1" id="" size="0x10" offset="0x4c" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
           <instance name="scu_0"/>
         </kernel>
       </core>

--- a/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/PSKernel/embedded_metadata_psk_expected.xml
@@ -5,13 +5,13 @@
       <core>
         <kernel name="kernel0" language="c" type="ps">
           <arg name="inA" addressQualifier="1" id="0" size="0x10" offset="0x0" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="inB" addressQualifier="1" id="1" size="0x10" offset="0x8" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="out" addressQualifier="1" id="2" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="input_size" addressQualifier="0" id="3" size="0x4" offset="0x18" hostOffset="0x0" hostSize="0x4" type="const int"/>
-          <arg name="output_size" addressQualifier="0" id="4" size="0x4" offset="0x1c" hostOffset="0x0" hostSize="0x4" type="const int"/>
-          <arg name="increment" addressQualifier="0" id="5" size="0x4" offset="0x20" hostOffset="0x0" hostSize="0x4" type="float"/>
-          <arg name="increment_out" addressQualifier="1" id="6" size="0x10" offset="0x24" hostOffset="0x0" hostSize="0x10" type="float*"/>
-          <arg name="handles" addressQualifier="1" id="7" size="0x10" offset="0x2c" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
+          <arg name="inB" addressQualifier="1" id="1" size="0x10" offset="0x10" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="out" addressQualifier="1" id="2" size="0x10" offset="0x20" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="input_size" addressQualifier="0" id="3" size="0x4" offset="0x30" hostOffset="0x0" hostSize="0x4" type="const int"/>
+          <arg name="output_size" addressQualifier="0" id="4" size="0x4" offset="0x34" hostOffset="0x0" hostSize="0x4" type="const int"/>
+          <arg name="increment" addressQualifier="0" id="5" size="0x4" offset="0x38" hostOffset="0x0" hostSize="0x4" type="float"/>
+          <arg name="increment_out" addressQualifier="1" id="6" size="0x10" offset="0x3c" hostOffset="0x0" hostSize="0x10" type="float*"/>
+          <arg name="handles" addressQualifier="1" id="" size="0x10" offset="0x4c" hostOffset="0x0" hostSize="0x10" type="xrtHandles*"/>
           <instance name="scu_0"/>
         </kernel>
       </core>


### PR DESCRIPTION
#### Problem solved by the commit
When inserting PS Kernels into an xclbin container, the EMBEDDED_METADATA attribute values for 'id' and 'offset' were not being set correct. 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue was discovered during development and was the result of reverting the BO byte size to 0x10 bytes.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Code was updated with the correct algorithm.
#### Risks (if any) associated the changes in the commit
None
#### What has been tested and how, request additional testing if necessary
Updated the unit tests to test for correct functionality.
#### Documentation impact (if any)
None.