### PR TITLE
CR-1122354: Added Warning message if generated trace files are empty

### DIFF
--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -38,12 +38,14 @@ namespace xdp {
 
   AIETraceWriter::~AIETraceWriter()
   {
+
+    std::string dId = std::to_string(deviceId);
+    std::string tId = std::to_string(traceStreamId);
+
+    std::string filename = "aie_trace_" + dId + "_" + tId + ".txt";
+
     try {
       // Check if final file output is empty and throw a warning.
-      std::string dId = std::to_string(deviceId);
-      std::string tId = std::to_string(traceStreamId);
-
-      std::string filename = "aie_trace_" + dId + "_" + tId + ".txt";
       std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
 
       // \n is 2 bytes

--- a/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_trace/aie_trace_writer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "xdp/profile/writer/aie_trace/aie_trace_writer.h"
+#include "core/common/message.h"
 
 #include <iostream>
 
@@ -37,6 +38,24 @@ namespace xdp {
 
   AIETraceWriter::~AIETraceWriter()
   {
+    try {
+      // Check if final file output is empty and throw a warning.
+      std::string dId = std::to_string(deviceId);
+      std::string tId = std::to_string(traceStreamId);
+
+      std::string filename = "aie_trace_" + dId + "_" + tId + ".txt";
+      std::ifstream in(filename, std::ifstream::ate | std::ifstream::binary);
+
+      // \n is 2 bytes
+      if (in.tellg() <= 2){
+        std::string msg = "File: " + filename + " (device #" + dId + ", stream #" + tId + ") trace data was not captured.";
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+      }
+
+    } catch (...){
+        std::string msg = "Trace File: " + filename + " not found.";
+        xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+    }
   }
 
   void AIETraceWriter::writeHeader()


### PR DESCRIPTION
Added Warning message if generated latest generated aie trace files are empty. After the trace is written, the file sizes are checked and a warning message is displayed if the trace file is empty.