### PR TITLE
fix versal ps kernel host mem mapping issue

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -326,5 +326,6 @@ extern u32 zocl_cu_get_status(struct platform_device *pdev);
 extern u32 zocl_scu_get_status(struct platform_device *pdev);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
 extern const struct drm_gem_object_funcs zocl_gem_object_funcs;
+extern const struct drm_gem_object_funcs zocl_cma_default_funcs;
 #endif
 #endif

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -963,8 +963,7 @@ zocl_cma_create(struct drm_device *dev, size_t size)
 	cma_obj = container_of(gem_obj, struct drm_gem_cma_object, base);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
-	if (!gem_obj->funcs)
-		gem_obj->funcs = &zocl_cma_default_funcs;
+	gem_obj->funcs = &zocl_cma_default_funcs;
 #endif
 
 	ret = drm_gem_object_init(dev, gem_obj, size);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_bo.c
@@ -962,6 +962,11 @@ zocl_cma_create(struct drm_device *dev, size_t size)
 	}
 	cma_obj = container_of(gem_obj, struct drm_gem_cma_object, base);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	if (!gem_obj->funcs)
+		gem_obj->funcs = &zocl_cma_default_funcs;
+#endif
+
 	ret = drm_gem_object_init(dev, gem_obj, size);
 	if (ret) {
 		DRM_ERROR("cma_create: gem_obj_init failed\n");

--- a/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_drv.c
@@ -987,6 +987,12 @@ const struct drm_gem_object_funcs zocl_gem_object_funcs = {
 	.vmap = drm_gem_cma_vmap,
 	.export = drm_gem_prime_export,
 };
+
+const struct drm_gem_object_funcs zocl_cma_default_funcs = {
+	.free = zocl_free_bo,
+	.get_sg_table = drm_gem_cma_get_sg_table,
+	.vm_ops = &zocl_bo_vm_ops,
+};
 #endif
 static const struct zdev_data zdev_data_mpsoc = {
 	.fpga_driver_name = "pcap",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VCK5000 is running Linux 5.15. PS kernel cannot create host bo. The reason is Linux DRM API changed.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is found on 5.15 Linux.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Adapter to new Linux DRM API.

#### Risks (if any) associated the changes in the commit
No.

#### What has been tested and how, request additional testing if necessary
VCK5000 PS kernel

#### Documentation impact (if any)
No