### PR TITLE
CR-1111929 P2P required IO space message

### DIFF
--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -108,9 +108,9 @@ add_p2p_config(const xrt_core::device* device, ptree_type& pt)
 {
   try {
     ptree_type pt_p2p;
-    auto config = xrt_core::device_query<xq::p2p_config>(device);
-    auto config_map = xrt_core::query::p2p_config::to_map(config);
-    for(auto& pair : config_map)
+    const auto config = xrt_core::device_query<xq::p2p_config>(device);
+    const auto config_map = xrt_core::query::p2p_config::to_map(config);
+    for(const auto& pair : config_map)
       pt_p2p.add(pair.first, xrt_core::utils::unit_convert(pair.second)); // Turn bytes into GB
     pt.put_child("p2p", pt_p2p);
   }

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -103,33 +103,15 @@ add_mig_info(const xrt_core::device* device, ptree_type& pt)
   }
 }
 
-static std::map<std::string, long long> 
-p2p_convert_config(xrt_core::query::p2p_config::result_type& config)
-{
-  std::map<std::string, long long> map;
-  for (auto& str : config) {
-    // str is in key:value format obtained from p2p_config query
-    auto pos = str.find(":");
-    std::string key = str.substr(0, pos);
-    try {
-      long long value = std::stoll(str.substr(pos + 1));
-      map[key] = value;
-    } catch (const std::exception&) {
-      // Failed to parse a non long long BAR value. Dont parse it into the map and move on!
-    }
-  }
-  return map;
-}
-
 void
 add_p2p_config(const xrt_core::device* device, ptree_type& pt)
 {
   try {
     ptree_type pt_p2p;
     auto config = xrt_core::device_query<xq::p2p_config>(device);
-    auto config_map = p2p_convert_config(config);
+    auto config_map = xrt_core::query::p2p_config::to_map(config);
     for(auto& pair : config_map)
-      pt_p2p.add(pair.first, std::to_string(pair.second/1024/1024/1024)); // Turn bytes into GB
+      pt_p2p.add(pair.first, xrt_core::utils::unit_convert(pair.second)); // Turn bytes into GB
     pt.put_child("p2p", pt_p2p);
   }
   catch (const xq::exception&) {

--- a/src/runtime_src/core/common/info_platform.cpp
+++ b/src/runtime_src/core/common/info_platform.cpp
@@ -124,13 +124,17 @@ p2p_convert_config(xrt_core::query::p2p_config::result_type& config)
 void
 add_p2p_config(const xrt_core::device* device, ptree_type& pt)
 {
-  ptree_type pt_p2p;
-  auto config = xrt_core::device_query<xq::p2p_config>(device);
-  auto config_map = p2p_convert_config(config);
-  for(auto& pair : config_map)
-    pt_p2p.add(pair.first, std::to_string(pair.second/1024/1024/1024)); // Turn bytes into GB
-
-  pt.put_child("p2p", pt_p2p);
+  try {
+    ptree_type pt_p2p;
+    auto config = xrt_core::device_query<xq::p2p_config>(device);
+    auto config_map = p2p_convert_config(config);
+    for(auto& pair : config_map)
+      pt_p2p.add(pair.first, std::to_string(pair.second/1024/1024/1024)); // Turn bytes into GB
+    pt.put_child("p2p", pt_p2p);
+  }
+  catch (const xq::exception&) {
+    // Devices that do not suport p2p will not add anything to the passed in ptree
+  }
 }
 
 void

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -1,6 +1,6 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
  */
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "query_requests.h"

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -5,7 +5,6 @@
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "query_requests.h"
 #include "core/include/xclerr_int.h"
-#include <map>
 #include <string>
 
 #include <boost/algorithm/string.hpp>
@@ -26,6 +25,25 @@ to_string(xrt_core::query::p2p_config::value_type value)
   };
 
   return p2p_config_map[value];
+}
+
+std::map<std::string, int64_t>
+xrt_core::query::p2p_config::
+to_map(const xrt_core::query::p2p_config::result_type& config)
+{
+  std::map<std::string, int64_t> config_map;
+  for (auto& str : config) {
+    // str is in key:value format obtained from p2p_config query
+    auto pos = str.find(":");
+    std::string key = str.substr(0, pos);
+    try {
+      long long value = std::stoll(str.substr(pos + 1));
+      config_map[key] = value;
+    } catch (const std::exception&) {
+      // Failed to parse a non long long BAR value. Dont parse it into the map and move on!
+    }
+  }
+  return config_map;
 }
 
 std::pair<xrt_core::query::p2p_config::value_type, std::string>

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -32,10 +32,12 @@ xrt_core::query::p2p_config::
 to_map(const xrt_core::query::p2p_config::result_type& config)
 {
   std::map<std::string, int64_t> config_map;
-  for (auto& str : config) {
+  for (auto& str_untrimmed : config) {
+    const std::string str = boost::trim_copy(str_untrimmed);
     // str is in key:value format obtained from p2p_config query
     const auto pos = str.find(":");
-    const std::string config_item = str.substr(0, pos);
+    const std::string config_item_untrimmed = str.substr(0, pos);
+    const std::string config_item = boost::trim_copy(config_item_untrimmed);
     try {
       const int64_t value = std::stoll(str.substr(pos + 1));
       config_map[config_item] = value;
@@ -55,11 +57,14 @@ parse(const xrt_core::query::p2p_config::result_type& config)
   // return the config with a message
   if (config_map.find("bar") == config_map.end())
     return {xrt_core::query::p2p_config::value_type::not_supported, "P2P config failed. P2P is not supported. Can't find P2P BAR."};
-  else if (config_map.find("rbar") != config_map.end() && config_map["rbar"] > config_map["bar"])
+
+  if (config_map.find("rbar") != config_map.end() && config_map["rbar"] > config_map["bar"])
     return {xrt_core::query::p2p_config::value_type::reboot, "Warning:Please WARM reboot to enable p2p now."};
-  else if (config_map.find("remap") != config_map.end() && config_map["remap"] > 0 && config_map["remap"] != config_map["bar"])
+
+  if (config_map.find("remap") != config_map.end() && config_map["remap"] > 0 && config_map["remap"] != config_map["bar"])
     return {xrt_core::query::p2p_config::value_type::error, "Error:P2P config failed. P2P remapper is not set correctly"};
-  else if (config_map.find("exp_bar") != config_map.end() && config_map["exp_bar"] == config_map["bar"])
+
+  if (config_map.find("exp_bar") != config_map.end() && config_map["exp_bar"] == config_map["bar"])
     return {xrt_core::query::p2p_config::value_type::enabled, ""};
 
   return {xrt_core::query::p2p_config::value_type::disabled, "P2P bar is not enabled"};

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -34,11 +34,11 @@ to_map(const xrt_core::query::p2p_config::result_type& config)
   std::map<std::string, int64_t> config_map;
   for (auto& str : config) {
     // str is in key:value format obtained from p2p_config query
-    auto pos = str.find(":");
-    std::string key = str.substr(0, pos);
+    const auto pos = str.find(":");
+    const std::string config_item = str.substr(0, pos);
     try {
-      long long value = std::stoll(str.substr(pos + 1));
-      config_map[key] = value;
+      const int64_t value = std::stoll(str.substr(pos + 1));
+      config_map[config_item] = value;
     } catch (const std::exception&) {
       // Failed to parse a non long long BAR value. Dont parse it into the map and move on!
     }

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -56,19 +56,19 @@ std::pair<xrt_core::query::p2p_config::value_type, std::string>
 xrt_core::query::p2p_config::
 parse(const xrt_core::query::p2p_config::result_type& config)
 {
-  auto config_map = xrt_core::query::p2p_config::to_map(config);
+  const auto config_map = xrt_core::query::p2p_config::to_map(config);
 
   // return the config with a message
   if (config_map.find("bar") == config_map.end())
     return {xrt_core::query::p2p_config::value_type::not_supported, "P2P config failed. P2P is not supported. Can't find P2P BAR."};
 
-  if (config_map.find("rbar") != config_map.end() && config_map["rbar"] > config_map["bar"])
+  if (config_map.find("rbar") != config_map.end() && config_map.at("rbar") > config_map.at("bar"))
     return {xrt_core::query::p2p_config::value_type::reboot, "Warning:Please WARM reboot to enable p2p now."};
 
-  if (config_map.find("remap") != config_map.end() && config_map["remap"] > 0 && config_map["remap"] != config_map["bar"])
+  if (config_map.find("remap") != config_map.end() && config_map.at("remap") > 0 && config_map.at("remap") != config_map.at("bar"))
     return {xrt_core::query::p2p_config::value_type::error, "Error:P2P config failed. P2P remapper is not set correctly"};
 
-  if (config_map.find("exp_bar") != config_map.end() && config_map["exp_bar"] == config_map["bar"])
+  if (config_map.find("exp_bar") != config_map.end() && config_map.at("exp_bar") == config_map.at("bar"))
     return {xrt_core::query::p2p_config::value_type::enabled, ""};
 
   return {xrt_core::query::p2p_config::value_type::disabled, "P2P bar is not enabled"};

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <sstream>
 #include <iomanip>
+#include <map>
 #include <stdexcept>
 #include <boost/any.hpp>
 #include <boost/format.hpp>
@@ -1385,6 +1386,10 @@ struct p2p_config : request
   {
     return value;
   }
+
+  XRT_CORE_COMMON_EXPORT
+  static std::map<std::string, int64_t>
+  to_map(const xrt_core::query::p2p_config::result_type& config);
 };
 
 struct temp_card_top_front : request

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -73,7 +73,7 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
 
     const boost::property_tree::ptree& pt_config = pt_platform.get_child("config.p2p");
-    _output << boost::format("  %-23s: %sGB\n") % "P2P Host supported IO memory space required:" % pt_config.get<std::string>("exp_bar");
+    _output << boost::format("  %-23s: %s GB\n") % "P2P Host supported IO memory space required:" % pt_config.get<std::string>("exp_bar");
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if(!clocks.empty()) {

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -75,7 +75,7 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
 
     boost::optional<const boost::property_tree::ptree&> pt_config = pt_platform.get_child_optional("config.p2p");
     if (pt_config)
-      _output << boost::format("  %-23s: %s GB\n") % "P2P IO space required" % (*pt_config).get<std::string>("exp_bar");
+      _output << boost::format("  %-23s: %s\n") % "P2P IO space required" % (*pt_config).get<std::string>("exp_bar"); // Units appended when ptree is created
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if(!clocks.empty()) {

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -72,6 +72,9 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
     _output << boost::format("  %-23s: %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
 
+    const boost::property_tree::ptree& pt_config = pt_platform.get_child("config.p2p");
+    _output << boost::format("  %-23s: %sGB\n") % "P2P Host supported IO memory space required:" % pt_config.get<std::string>("exp_bar");
+
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if(!clocks.empty()) {
       _output << std::endl << "Clocks" << std::endl;

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -23,6 +23,7 @@
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/optional/optional.hpp>
 void
 ReportPlatforms::getPropertyTreeInternal( const xrt_core::device * dev, 
                                               boost::property_tree::ptree &pt) const
@@ -72,8 +73,9 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
     _output << boost::format("  %-23s: %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
 
-    const boost::property_tree::ptree& pt_config = pt_platform.get_child("config.p2p");
-    _output << boost::format("  %-23s: %s GB\n") % "P2P Host supported IO memory space required:" % pt_config.get<std::string>("exp_bar");
+    boost::optional<const boost::property_tree::ptree&> pt_config = pt_platform.get_child_optional("config.p2p");
+    if (pt_config)
+      _output << boost::format("  %-23s: %s GB\n") % "P2P IO space required" % (*pt_config).get<std::string>("exp_bar");
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if(!clocks.empty()) {

--- a/src/runtime_src/core/tools/common/ReportPlatforms.cpp
+++ b/src/runtime_src/core/tools/common/ReportPlatforms.cpp
@@ -23,7 +23,6 @@
 
 // 3rd Party Library - Include Files
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/optional/optional.hpp>
 void
 ReportPlatforms::getPropertyTreeInternal( const xrt_core::device * dev, 
                                               boost::property_tree::ptree &pt) const
@@ -73,9 +72,10 @@ ReportPlatforms::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << boost::format("  %-23s: %s \n") % "Mig Calibrated" % pt_status.get<std::string>("mig_calibrated");
     _output << boost::format("  %-23s: %s \n") % "P2P Status" % pt_status.get<std::string>("p2p_status");
 
-    boost::optional<const boost::property_tree::ptree&> pt_config = pt_platform.get_child_optional("config.p2p");
-    if (pt_config)
-      _output << boost::format("  %-23s: %s\n") % "P2P IO space required" % (*pt_config).get<std::string>("exp_bar"); // Units appended when ptree is created
+    const boost::property_tree::ptree ptEmpty; 
+    const boost::property_tree::ptree& pt_config = pt_platform.get_child("config.p2p", ptEmpty); 
+    if (!pt_config.empty())
+      _output << boost::format("  %-23s: %s\n") % "P2P IO space required" % pt_config.get<std::string>("exp_bar"); // Units appended when ptree is created
 
     const boost::property_tree::ptree& clocks = pt_platform.get_child("clocks", empty_ptree);
     if(!clocks.empty()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1111929
When we enable p2p, often time after warm reboot the machine become unresponsive. I see lot of questions, confusions from the user. Currently we only show p2p is enabled or disabled through xbutil. I propose we will show memory requirement too. This would help the user upfront if his machine/server is capable enough or not. He can then move to another server if required. 

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added checks if a factory image is installed and display the appropriate messaging.

#### Risks (if any) associated the changes in the commit
This does not fix the issue of reboot if the user has not looked at the IO space in the platform report. @AShivangi suggested that a check should be built into the P2P enable command that outputs a warning instead. I think that would be good as a future enhancement.

#### What has been tested and how, request additional testing if necessary
On u280 (p2p supported)
```
Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.1]  :  xilinx_u280_xdma_201920_3  0x5e278820     user(inst=128)

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -d 65:00

-----------------------------------------------
1/1 [0000:65:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Platform
  XSA Name               : xilinx_u280_xdma_201920_3
  Platform UUID          : 0x5e278820
  FPGA Name              : xcu280-fsvh2892-2L-e
  JTAG ID Code           : 0x14b7d093
  DDR Size               : 34359738368 Bytes
  DDR Count              : 2
  Mig Calibrated         : true
  P2P Status             : disabled
  P2P IO space required  : 64 GB

Mac Addresses            : 01:02:03:04:05:06
                         : 01:02:03:04:05:07

Xclbin UUID
  00000000-0000-0000-0000-000000000000

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status
```
On u30 (p2p not supported)
```
Devices present
BDF             :  Shell                            Platform UUID                         Device ID
[0000:b3:00.1]  :  xilinx_u200_gen3x16_xdma_base_1  A2D4F3CF-5B7A-0B7B-70F9-DA589CB5B3CD  user(inst=130)
[0000:18:00.1]  :  xilinx_u30_gen3x4_base_2         6E7C97F7-949F-5106-3075-A77784C30A4B  user(inst=129)
[0000:17:00.1]  :  xilinx_u30_gen3x4_base_2         6E7C97F7-949F-5106-3075-A77784C30A4B  user(inst=128)

dbenusov@xsjsagarw50:~$ xbutil examine -d 18:00

----------------------------------------------
1/1 [0000:18:00.1] : xilinx_u30_gen3x4_base_2
----------------------------------------------
Platform
  XSA Name               : xilinx_u30_gen3x4_base_2
  Platform UUID          : 6E7C97F7-949F-5106-3075-A77784C30A4B
  FPGA Name              :
  JTAG ID Code           : 0x14a5c093
  DDR Size               : 0 Bytes
  DDR Count              : 0
  Mig Calibrated         : true
  P2P Status             : not supported

Xclbin UUID
  00000000-0000-0000-0000-000000000000

Compute Units
  PL Compute Units
    Index   Name                                              Base_Address    Usage   Status

  PS Compute Units
    Index   Name                                              Base_Address    Usage   Status


```