### PR TITLE
CR-1115942: Adjusting data transfer table for NoDMA platforms

### DIFF
--- a/src/runtime_src/xdp/profile/database/static_info/device_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2021-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -59,6 +59,7 @@ namespace xdp {
     uint64_t kdmaCount = 0 ;
     bool isEdgeDevice  = false ;
     bool isReady       = false ;
+    bool isNoDMADevice = false ;
 
     // *******************************************************************
     // ****** Information specific to all previously loaded XCLBINs ******
@@ -80,6 +81,7 @@ namespace xdp {
     XDP_EXPORT xrt_core::uuid currentXclbinUUID() ;
     inline std::vector<XclbinInfo*> getLoadedXclbins() { return loadedXclbins ;}
     XDP_EXPORT void cleanCurrentXclbinInfo() ;
+    inline bool isNoDMA() const { return isNoDMADevice ; }
 
     // ****** Functions for information on the currently loaded xclbin *******
     XDP_EXPORT XclbinInfo* currentXclbin() ;

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -1291,7 +1291,10 @@ namespace xdp {
       // This is the first time this device was loaded with an xclbin
       devInfo = new DeviceInfo();
       devInfo->deviceId = deviceId ;
-      if (isEdge()) devInfo->isEdgeDevice = true ;
+      if (isEdge())
+        devInfo->isEdgeDevice = true ;
+      if (device->is_nodma())
+        devInfo->isNoDMADevice = true ;
       deviceInfo[deviceId] = devInfo ;
 
     } else {

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -44,10 +44,6 @@ namespace xdp {
     initializeAPIs() ;
   }
 
-  SummaryWriter::~SummaryWriter()
-  {
-  }
-
   void SummaryWriter::initializeAPIs()
   {
     // For each of the APIs, initialize the sets with the hard coded names
@@ -864,7 +860,7 @@ namespace xdp {
       return ;
 
     // Caption
-    fout << "Data Transfer: Host to Global Memory" << std::endl ;
+    fout << "Data Transfer: Host to Global Memory\n";
 
     // Column headers
     fout << "Context:Number of Devices"         << ","
@@ -874,81 +870,44 @@ namespace xdp {
 	 << "Average Bandwidth Utilization (%)" << ","
 	 << "Average Buffer Size (KB)"          << ","
 	 << "Total Time (ms)"                   << ","
-	 << "Average Time (ms)"                 << "," 
-	 << std::endl ;
+	 << "Average Time (ms)"                 << ",\n";
 
-    for (auto read : hostReads)
-    {
-      std::string contextName = "context" + std::to_string(read.first.first) ;
-      uint64_t numDevices =
-	(db->getStaticInfo()).getNumDevices(read.first.first) ;
-      if (getFlowMode() == HW_EMU)
-      {
-	fout << contextName << ":" << numDevices << ","
-	     << "READ" << ","
-	     << (read.second).count << ","
-	     << "N/A" << ","
-	     << "N/A" << ","
-	     << ((double)((read.second).averageSize) / one_thousand) << ","
-	     << "N/A" << ","
-	     << "N/A" << "," << std::endl ;
-      }
-      else
-      {
-        double totalTimeInS  = (double)((read.second).totalTime / one_billion);
-        double totalSizeInMB = (double)((read.second).totalSize / one_million);
+    std::string types[2] = { "READ", "WRITE" };
+    uint64_t i = 0 ;
+
+    for (auto& map : { hostReads, hostWrites }) {
+      for (auto entry : map) {
+        auto contextID = entry.first.first;
+        auto deviceID = entry.first.second;
+        auto& stats = entry.second;
+
+        std::string contextName = "context" + std::to_string(contextID);
+        uint64_t numDevices = db->getStaticInfo().getNumDevices(contextID);
+        DeviceInfo* device = db->getStaticInfo().getDeviceInfo(deviceID);
+
+        bool printNA =
+          (getFlowMode() == HW_EMU || (device && device->isNoDMA()));
+
+        double totalTimeInS  =
+          static_cast<double>(stats.totalTime / one_billion);
+        double totalSizeInMB =
+          static_cast<double>(stats.totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
-	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(read.first.second) ;
-	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        double maxReadBW = db->getStaticInfo().getMaxReadBW(deviceID);
+        double aveBWUtil = (one_hundred * transferRate) / maxReadBW;
 
-	fout << contextName << ":" << numDevices << ","
-	     << "READ" << ","
-	     << (read.second).count << ","
-	     << transferRate << ","
-	     << aveBWUtil << ","
-	     << ((double)((read.second).averageSize) / one_thousand) << ","
-	     << ((read.second).totalTime / one_million) << ","
-	     << ((read.second).averageTime / one_million) << "," << std::endl ;
-      }
-    }
+        fout << contextName << ":" << numDevices << ",";
+        fout << types[i] << ",";
+        fout << stats.count << ",";
+        printNA ? (fout << "N/A,") : (fout << transferRate << ",");
+        printNA ? (fout << "N/A,") : (fout << aveBWUtil << ",");
+        fout << static_cast<double>(stats.averageSize / one_thousand) << ",";
+        printNA ? (fout << "N/A,") : (fout << stats.totalTime/one_million << ",");
+        printNA ? (fout << "N/A,") : (fout << stats.averageTime / one_million << ",\n");
 
-    for (auto write : hostWrites)
-    {
-      std::string contextName = "context" + std::to_string(write.first.first) ;
-      uint64_t numDevices =
-	(db->getStaticInfo()).getNumDevices(write.first.first) ;
-
-      if (getFlowMode() == HW_EMU)
-      {
-	fout << contextName << ":" << numDevices << ","
-	     << "WRITE" << ","
-	     << (write.second).count << ","
-	     << "N/A" << ","
-	     << "N/A" << ","
-	     << ((double)((write.second).averageSize) / one_thousand) << ","
-	     << "N/A" << ","
-	     << "N/A" << "," << std::endl ;
-      }
-      else
-      {
-        double totalTimeInS  = (double)((write.second).totalTime / one_billion);
-        double totalSizeInMB = (double)((write.second).totalSize / one_million);
-        double transferRate  = totalSizeInMB / totalTimeInS; 
-
-	double maxWriteBW =
-	  (db->getStaticInfo()).getMaxWriteBW(write.first.second);
-	double aveBWUtil = (one_hundred * transferRate) / maxWriteBW ;
-
-	fout << contextName << ":" << numDevices << "," 
-	     << "WRITE" << ","
-	     << (write.second).count << ","
-	     << transferRate << ","
-	     << aveBWUtil << ","
-	     << ((double)((write.second).averageSize) / one_thousand) << ","
-	     << ((write.second).totalTime / one_million) << ","
-	     << ((write.second).averageTime / one_million) << "," << std::endl ;
+        // Move on from READ to WRITE
+        ++i;
       }
     }
   }

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -921,7 +921,7 @@ namespace xdp {
         //
         // In both these cases we print out "N/A"
         printNA ? (fout << "N/A,") : (fout << stats.totalTime/one_million << ",");
-        printNA ? (fout << "N/A,") : (fout << stats.averageTime / one_million << ",\n");
+        printNA ? (fout << "N/A,\n") : (fout << stats.averageTime / one_million << ",\n");
 
         // Move on from READ to WRITE
         ++i;

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -95,7 +95,7 @@ namespace xdp {
   public:
     XDP_EXPORT SummaryWriter(const char* filename) ;
     XDP_EXPORT SummaryWriter(const char* filename, VPDatabase* inst) ;
-    XDP_EXPORT ~SummaryWriter() ;
+    XDP_EXPORT ~SummaryWriter() = default ;
 
     XDP_EXPORT virtual bool write(bool openNewFile) ;
   } ;


### PR DESCRIPTION
#### Problem solved by the commit
The profile summary report generates a table on data transfers from/to the host memory to device memory.  On NoDMA platforms, these transfers are host memory to host memory transfers and do not reflect transfers from/to the device, so the numbers reported were misleading and incorrect.  This pull request replaces those numbers with "N/A" as they are not applicable on NoDMA platforms.
