### PR TITLE
Cleanup xdp code with a mix of tabs and spaces 

### DIFF
--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022, Xilinx Inc - All rights reserved
+ * Copyright (C) 2020-2022, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/common/api/xrt_profile.cpp
+++ b/src/runtime_src/core/common/api/xrt_profile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020, Xilinx Inc - All rights reserved
+ * Copyright (C) 2022, Xilinx Inc - All rights reserved
  * Xilinx Runtime (XRT) Experimental APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -108,8 +108,8 @@ namespace {
   static void load_user_profiling_plugin()
   {
     static xrt_core::module_loader user_event_loader("xdp_user_plugin",
-						     register_user_functions,
-						     nullptr) ;
+                                                     register_user_functions,
+                                                     nullptr) ;
   }
 
 } // end anonymous
@@ -121,13 +121,11 @@ extern "C"
     try {
       load_user_profiling_plugin() ;
       if (user_range_start_cb != nullptr) 
-	user_range_start_cb(id, label, tooltip) ;
+        user_range_start_cb(id, label, tooltip) ;
     }
     catch(const std::exception& ex)
     {
-      xrt_core::message::send(xrt_core::message::severity_level::error,
-			      "XRT",
-			      ex.what()) ;
+      xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what()) ;
     }
   }
 
@@ -136,13 +134,11 @@ extern "C"
     try {
       load_user_profiling_plugin() ;
       if (user_range_end_cb != nullptr) 
-	user_range_end_cb(id);
+        user_range_end_cb(id);
     }
     catch(const std::exception& ex)
     {
-      xrt_core::message::send(xrt_core::message::severity_level::error,
-			      "XRT",
-			      ex.what()) ;
+      xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what()) ;
     }
   }
 
@@ -151,13 +147,11 @@ extern "C"
     try {
       load_user_profiling_plugin() ;
       if (user_event_cb != nullptr) 
-	user_event_cb(label) ;
+        user_event_cb(label) ;
     }
     catch(const std::exception& ex)
     {
-      xrt_core::message::send(xrt_core::message::severity_level::error,
-			      "XRT",
-			      ex.what()) ;
+      xrt_core::message::send(xrt_core::message::severity_level::error, "XRT", ex.what()) ;
     }
   }
 }

--- a/src/runtime_src/core/include/xclperf.h
+++ b/src/runtime_src/core/include/xclperf.h
@@ -45,157 +45,15 @@
 #define IP_LAYOUT_HOST_NAME "HOST"
 #define IP_LAYOUT_SEP "-"
 
-/************************ APM 0: Monitor MIG Ports ****************************/
-
-#define XPAR_AXI_PERF_MON_0_NUMBER_SLOTS                2
-
-#define XPAR_AXI_PERF_MON_0_SLOT0_NAME                  "OCL Region"
-#define XPAR_AXI_PERF_MON_0_SLOT1_NAME                  "Host"
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT             0
-#define XPAR_AXI_PERF_MON_0_HOST_SLOT                   1
-
+/************************ LEGACY XPAR DEFINES *********************************/
 #define XPAR_AIM0_HOST_SLOT                             0
-#define XPAR_AIM0_FIRST_KERNEL_SLOT                     1
-
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT2            2
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT3            3
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT4            4
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT5            5
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT6            6
-#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT7            7
-
-#define XPAR_AXI_PERF_MON_0_SLOT2_NAME                  "OCL Region Master 2"
-#define XPAR_AXI_PERF_MON_0_SLOT3_NAME                  "OCL Region Master 3"
-#define XPAR_AXI_PERF_MON_0_SLOT4_NAME                  "OCL Region Master 4"
-#define XPAR_AXI_PERF_MON_0_SLOT5_NAME                  "OCL Region Master 5"
-#define XPAR_AXI_PERF_MON_0_SLOT6_NAME                  "OCL Region Master 6"
-#define XPAR_AXI_PERF_MON_0_SLOT7_NAME                  "OCL Region Master 7"
-
-#define XPAR_AXI_PERF_MON_0_SLOT0_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT1_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT2_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT3_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT4_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT5_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT6_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_0_SLOT7_DATA_WIDTH            512
-
-/* Profile */
-#define XPAR_AXI_PERF_MON_0_IS_EVENT_COUNT              1
-#define XPAR_AXI_PERF_MON_0_HAVE_SAMPLED_COUNTERS       1
-#define XPAR_AXI_PERF_MON_0_NUMBER_COUNTERS (XPAR_AXI_PERF_MON_0_NUMBER_SLOTS * XAPM_METRIC_COUNTERS_PER_SLOT)
-
-/* Trace */
-#define XPAR_AXI_PERF_MON_0_IS_EVENT_LOG                1
-#define XPAR_AXI_PERF_MON_0_SHOW_AXI_IDS                1
-#define XPAR_AXI_PERF_MON_0_SHOW_AXI_LEN                1
-// 2 DDR platform
-#define XPAR_AXI_PERF_MON_0_SHOW_AXI_IDS_2DDR           0
-#define XPAR_AXI_PERF_MON_0_SHOW_AXI_LEN_2DDR           1
-
-/* AXI Stream FIFOs */
-#define XPAR_AXI_PERF_MON_0_TRACE_NUMBER_FIFO           3
+#define MAX_TRACE_NUMBER_SAMPLES                        16384
 
 #ifdef XRT_EDGE
 #define XPAR_AXI_PERF_MON_0_TRACE_WORD_WIDTH            32
 #else
 #define XPAR_AXI_PERF_MON_0_TRACE_WORD_WIDTH            64
 #endif
-
-#define XPAR_AXI_PERF_MON_0_TRACE_NUMBER_SAMPLES        8192
-#define MAX_TRACE_NUMBER_SAMPLES                        16384
-
-#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_0              0x010000
-#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_1              0x011000
-#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_2              0x012000
-// CR 877788: the extra 0x80001000 is a bug in Vivado where the AXI4 base address is not set correctly
-// TODO: remove it once that bug is fixed!
-//#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL       (0x2000000000 + 0x80001000)
-#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL       0x2000000000
-// Default for new monitoring
-//#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL2      (0x0400000000 + 0x80001000)
-#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL2      0x0400000000
-
-/********************* APM 1: Monitor PCIe DMA Masters ************************/
-
-#define XPAR_AXI_PERF_MON_1_NUMBER_SLOTS                2
-
-#define XPAR_AXI_PERF_MON_1_SLOT0_NAME                  "DMA AXI4 Master"
-#define XPAR_AXI_PERF_MON_1_SLOT1_NAME                  "DMA AXI4-Lite Master"
-#define XPAR_AXI_PERF_MON_1_SLOT2_NAME                  "Null"
-#define XPAR_AXI_PERF_MON_1_SLOT3_NAME                  "Null"
-#define XPAR_AXI_PERF_MON_1_SLOT4_NAME                  "Null"
-#define XPAR_AXI_PERF_MON_1_SLOT5_NAME                  "Null"
-#define XPAR_AXI_PERF_MON_1_SLOT6_NAME                  "Null"
-#define XPAR_AXI_PERF_MON_1_SLOT7_NAME                  "Null"
-
-#define XPAR_AXI_PERF_MON_1_SLOT0_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT1_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT2_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT3_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT4_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT5_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT6_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_1_SLOT7_DATA_WIDTH            512
-
-/* Profile */
-#define XPAR_AXI_PERF_MON_1_IS_EVENT_COUNT              1
-#define XPAR_AXI_PERF_MON_1_HAVE_SAMPLED_COUNTERS       1
-#define XPAR_AXI_PERF_MON_1_NUMBER_COUNTERS (XPAR_AXI_PERF_MON_1_NUMBER_SLOTS * XAPM_METRIC_COUNTERS_PER_SLOT)
-#define XPAR_AXI_PERF_MON_1_SCALE_FACTOR                1
-
-/* Trace */
-#define XPAR_AXI_PERF_MON_1_IS_EVENT_LOG                0
-#define XPAR_AXI_PERF_MON_1_SHOW_AXI_IDS                0
-#define XPAR_AXI_PERF_MON_1_SHOW_AXI_LEN                0
-
-/* AXI Stream FIFOs */
-#define XPAR_AXI_PERF_MON_1_TRACE_NUMBER_FIFO           0
-#define XPAR_AXI_PERF_MON_1_TRACE_WORD_WIDTH            0
-#define XPAR_AXI_PERF_MON_1_TRACE_NUMBER_SAMPLES        0
-
-/************************ APM 2: Monitor OCL Region ***************************/
-
-#define XPAR_AXI_PERF_MON_2_NUMBER_SLOTS                1
-
-#define XPAR_AXI_PERF_MON_2_SLOT0_NAME                  "Kernel0"
-#define XPAR_AXI_PERF_MON_2_SLOT1_NAME                  "Kernel1"
-#define XPAR_AXI_PERF_MON_2_SLOT2_NAME                  "Kernel2"
-#define XPAR_AXI_PERF_MON_2_SLOT3_NAME                  "Kernel3"
-#define XPAR_AXI_PERF_MON_2_SLOT4_NAME                  "Kernel4"
-#define XPAR_AXI_PERF_MON_2_SLOT5_NAME                  "Kernel5"
-#define XPAR_AXI_PERF_MON_2_SLOT6_NAME                  "Kernel6"
-#define XPAR_AXI_PERF_MON_2_SLOT7_NAME                  "Kernel7"
-
-#define XPAR_AXI_PERF_MON_2_SLOT0_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT1_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT2_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT3_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT4_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT5_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT6_DATA_WIDTH            512
-#define XPAR_AXI_PERF_MON_2_SLOT7_DATA_WIDTH            512
-
-/* Profile */
-#define XPAR_AXI_PERF_MON_2_IS_EVENT_COUNT              0
-#define XPAR_AXI_PERF_MON_2_HAVE_SAMPLED_COUNTERS       0
-#define XPAR_AXI_PERF_MON_2_NUMBER_COUNTERS             0
-#define XPAR_AXI_PERF_MON_2_SCALE_FACTOR                1
-
-/* Trace */
-#define XPAR_AXI_PERF_MON_2_IS_EVENT_LOG                1
-#define XPAR_AXI_PERF_MON_2_SHOW_AXI_IDS                0
-#define XPAR_AXI_PERF_MON_2_SHOW_AXI_LEN                0
-
-/* AXI Stream FIFOs */
-/* NOTE: number of FIFOs is dependent upon the number of compute units being monitored */
-//#define XPAR_AXI_PERF_MON_2_TRACE_NUMBER_FIFO           2
-#define XPAR_AXI_PERF_MON_2_TRACE_WORD_WIDTH            64
-#define XPAR_AXI_PERF_MON_2_TRACE_NUMBER_SAMPLES        8192
-
-#define XPAR_AXI_PERF_MON_2_TRACE_OFFSET_0              0x01000
-#define XPAR_AXI_PERF_MON_2_TRACE_OFFSET_1              0x02000
-#define XPAR_AXI_PERF_MON_2_TRACE_OFFSET_2              0x03000
 
 /************************ APM Profile Counters ********************************/
 

--- a/src/runtime_src/core/include/xclperf.h
+++ b/src/runtime_src/core/include/xclperf.h
@@ -1,7 +1,23 @@
 /**
- * Copyright (C) 2016-2022 Xilinx Inc - All rights reserved
+ * Copyright (C) 2016-2017 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Xilinx SDAccel HAL userspace driver extension APIs
  * Performance Monitoring Exposed Parameters
- * HAL userspace driver extension APIs
+ * Copyright (C) 2015-2016, Xilinx Inc - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -29,15 +45,157 @@
 #define IP_LAYOUT_HOST_NAME "HOST"
 #define IP_LAYOUT_SEP "-"
 
-/************************ LEGACY XPAR DEFINES *********************************/
+/************************ APM 0: Monitor MIG Ports ****************************/
+
+#define XPAR_AXI_PERF_MON_0_NUMBER_SLOTS                2
+
+#define XPAR_AXI_PERF_MON_0_SLOT0_NAME                  "OCL Region"
+#define XPAR_AXI_PERF_MON_0_SLOT1_NAME                  "Host"
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT             0
+#define XPAR_AXI_PERF_MON_0_HOST_SLOT                   1
+
 #define XPAR_AIM0_HOST_SLOT                             0
-#define MAX_TRACE_NUMBER_SAMPLES                        16384
+#define XPAR_AIM0_FIRST_KERNEL_SLOT                     1
+
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT2            2
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT3            3
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT4            4
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT5            5
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT6            6
+#define XPAR_AXI_PERF_MON_0_OCL_REGION_SLOT7            7
+
+#define XPAR_AXI_PERF_MON_0_SLOT2_NAME                  "OCL Region Master 2"
+#define XPAR_AXI_PERF_MON_0_SLOT3_NAME                  "OCL Region Master 3"
+#define XPAR_AXI_PERF_MON_0_SLOT4_NAME                  "OCL Region Master 4"
+#define XPAR_AXI_PERF_MON_0_SLOT5_NAME                  "OCL Region Master 5"
+#define XPAR_AXI_PERF_MON_0_SLOT6_NAME                  "OCL Region Master 6"
+#define XPAR_AXI_PERF_MON_0_SLOT7_NAME                  "OCL Region Master 7"
+
+#define XPAR_AXI_PERF_MON_0_SLOT0_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT1_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT2_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT3_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT4_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT5_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT6_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_0_SLOT7_DATA_WIDTH            512
+
+/* Profile */
+#define XPAR_AXI_PERF_MON_0_IS_EVENT_COUNT              1
+#define XPAR_AXI_PERF_MON_0_HAVE_SAMPLED_COUNTERS       1
+#define XPAR_AXI_PERF_MON_0_NUMBER_COUNTERS (XPAR_AXI_PERF_MON_0_NUMBER_SLOTS * XAPM_METRIC_COUNTERS_PER_SLOT)
+
+/* Trace */
+#define XPAR_AXI_PERF_MON_0_IS_EVENT_LOG                1
+#define XPAR_AXI_PERF_MON_0_SHOW_AXI_IDS                1
+#define XPAR_AXI_PERF_MON_0_SHOW_AXI_LEN                1
+// 2 DDR platform
+#define XPAR_AXI_PERF_MON_0_SHOW_AXI_IDS_2DDR           0
+#define XPAR_AXI_PERF_MON_0_SHOW_AXI_LEN_2DDR           1
+
+/* AXI Stream FIFOs */
+#define XPAR_AXI_PERF_MON_0_TRACE_NUMBER_FIFO           3
 
 #ifdef XRT_EDGE
 #define XPAR_AXI_PERF_MON_0_TRACE_WORD_WIDTH            32
 #else
 #define XPAR_AXI_PERF_MON_0_TRACE_WORD_WIDTH            64
 #endif
+
+#define XPAR_AXI_PERF_MON_0_TRACE_NUMBER_SAMPLES        8192
+#define MAX_TRACE_NUMBER_SAMPLES                        16384
+
+#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_0              0x010000
+#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_1              0x011000
+#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_2              0x012000
+// CR 877788: the extra 0x80001000 is a bug in Vivado where the AXI4 base address is not set correctly
+// TODO: remove it once that bug is fixed!
+//#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL       (0x2000000000 + 0x80001000)
+#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL       0x2000000000
+// Default for new monitoring
+//#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL2      (0x0400000000 + 0x80001000)
+#define XPAR_AXI_PERF_MON_0_TRACE_OFFSET_AXI_FULL2      0x0400000000
+
+/********************* APM 1: Monitor PCIe DMA Masters ************************/
+
+#define XPAR_AXI_PERF_MON_1_NUMBER_SLOTS                2
+
+#define XPAR_AXI_PERF_MON_1_SLOT0_NAME                  "DMA AXI4 Master"
+#define XPAR_AXI_PERF_MON_1_SLOT1_NAME                  "DMA AXI4-Lite Master"
+#define XPAR_AXI_PERF_MON_1_SLOT2_NAME                  "Null"
+#define XPAR_AXI_PERF_MON_1_SLOT3_NAME                  "Null"
+#define XPAR_AXI_PERF_MON_1_SLOT4_NAME                  "Null"
+#define XPAR_AXI_PERF_MON_1_SLOT5_NAME                  "Null"
+#define XPAR_AXI_PERF_MON_1_SLOT6_NAME                  "Null"
+#define XPAR_AXI_PERF_MON_1_SLOT7_NAME                  "Null"
+
+#define XPAR_AXI_PERF_MON_1_SLOT0_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT1_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT2_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT3_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT4_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT5_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT6_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_1_SLOT7_DATA_WIDTH            512
+
+/* Profile */
+#define XPAR_AXI_PERF_MON_1_IS_EVENT_COUNT              1
+#define XPAR_AXI_PERF_MON_1_HAVE_SAMPLED_COUNTERS       1
+#define XPAR_AXI_PERF_MON_1_NUMBER_COUNTERS (XPAR_AXI_PERF_MON_1_NUMBER_SLOTS * XAPM_METRIC_COUNTERS_PER_SLOT)
+#define XPAR_AXI_PERF_MON_1_SCALE_FACTOR                1
+
+/* Trace */
+#define XPAR_AXI_PERF_MON_1_IS_EVENT_LOG                0
+#define XPAR_AXI_PERF_MON_1_SHOW_AXI_IDS                0
+#define XPAR_AXI_PERF_MON_1_SHOW_AXI_LEN                0
+
+/* AXI Stream FIFOs */
+#define XPAR_AXI_PERF_MON_1_TRACE_NUMBER_FIFO           0
+#define XPAR_AXI_PERF_MON_1_TRACE_WORD_WIDTH            0
+#define XPAR_AXI_PERF_MON_1_TRACE_NUMBER_SAMPLES        0
+
+/************************ APM 2: Monitor OCL Region ***************************/
+
+#define XPAR_AXI_PERF_MON_2_NUMBER_SLOTS                1
+
+#define XPAR_AXI_PERF_MON_2_SLOT0_NAME                  "Kernel0"
+#define XPAR_AXI_PERF_MON_2_SLOT1_NAME                  "Kernel1"
+#define XPAR_AXI_PERF_MON_2_SLOT2_NAME                  "Kernel2"
+#define XPAR_AXI_PERF_MON_2_SLOT3_NAME                  "Kernel3"
+#define XPAR_AXI_PERF_MON_2_SLOT4_NAME                  "Kernel4"
+#define XPAR_AXI_PERF_MON_2_SLOT5_NAME                  "Kernel5"
+#define XPAR_AXI_PERF_MON_2_SLOT6_NAME                  "Kernel6"
+#define XPAR_AXI_PERF_MON_2_SLOT7_NAME                  "Kernel7"
+
+#define XPAR_AXI_PERF_MON_2_SLOT0_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT1_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT2_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT3_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT4_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT5_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT6_DATA_WIDTH            512
+#define XPAR_AXI_PERF_MON_2_SLOT7_DATA_WIDTH            512
+
+/* Profile */
+#define XPAR_AXI_PERF_MON_2_IS_EVENT_COUNT              0
+#define XPAR_AXI_PERF_MON_2_HAVE_SAMPLED_COUNTERS       0
+#define XPAR_AXI_PERF_MON_2_NUMBER_COUNTERS             0
+#define XPAR_AXI_PERF_MON_2_SCALE_FACTOR                1
+
+/* Trace */
+#define XPAR_AXI_PERF_MON_2_IS_EVENT_LOG                1
+#define XPAR_AXI_PERF_MON_2_SHOW_AXI_IDS                0
+#define XPAR_AXI_PERF_MON_2_SHOW_AXI_LEN                0
+
+/* AXI Stream FIFOs */
+/* NOTE: number of FIFOs is dependent upon the number of compute units being monitored */
+//#define XPAR_AXI_PERF_MON_2_TRACE_NUMBER_FIFO           2
+#define XPAR_AXI_PERF_MON_2_TRACE_WORD_WIDTH            64
+#define XPAR_AXI_PERF_MON_2_TRACE_NUMBER_SAMPLES        8192
+
+#define XPAR_AXI_PERF_MON_2_TRACE_OFFSET_0              0x01000
+#define XPAR_AXI_PERF_MON_2_TRACE_OFFSET_1              0x02000
+#define XPAR_AXI_PERF_MON_2_TRACE_OFFSET_2              0x03000
 
 /************************ APM Profile Counters ********************************/
 

--- a/src/runtime_src/core/include/xclperf.h
+++ b/src/runtime_src/core/include/xclperf.h
@@ -1,23 +1,7 @@
 /**
- * Copyright (C) 2016-2017 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
-/**
- * Xilinx SDAccel HAL userspace driver extension APIs
+ * Copyright (C) 2016-2022 Xilinx Inc - All rights reserved
  * Performance Monitoring Exposed Parameters
- * Copyright (C) 2015-2016, Xilinx Inc - All rights reserved
+ * HAL userspace driver extension APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/pcie/linux/plugin/xdp/vart_profile.cpp
+++ b/src/runtime_src/core/pcie/linux/plugin/xdp/vart_profile.cpp
@@ -24,8 +24,8 @@ namespace profile {
   void load()
   {
     static xrt_core::module_loader xdp_vart_loader("xdp_vart_plugin",
-						    register_callbacks,
-						    warning_callbacks) ;
+                                                    register_callbacks,
+                                                    warning_callbacks) ;
   }
 
   void register_callbacks(void* /*handle*/)

--- a/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
+++ b/src/runtime_src/xdp/profile/database/dynamic_event_database.cpp
@@ -143,7 +143,7 @@ namespace xdp {
           startEvent = (*iter);
           lst.erase(iter);
           break;
-	}
+        }
       }
     }
     return startEvent ;

--- a/src/runtime_src/xdp/profile/database/events/opencl_host_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/opencl_host_events.cpp
@@ -24,12 +24,12 @@ namespace xdp {
   // Host event definitions
   // **************************
   KernelEnqueue::KernelEnqueue(uint64_t s_id, double ts, 
-			       uint64_t dName, 
-			       uint64_t bName, 
-			       uint64_t kName,
-			       uint64_t wgc,
-			       size_t wgs,
-			       const char* enqueueId) :
+                               uint64_t dName, 
+                               uint64_t bName, 
+                               uint64_t kName,
+                               uint64_t wgc,
+                               size_t wgs,
+                               const char* enqueueId) :
     VTFEvent(s_id, ts, KERNEL_ENQUEUE),
     deviceName(dName), binaryName(bName), kernelName(kName),
     workgroupConfiguration(wgc),
@@ -103,10 +103,10 @@ namespace xdp {
   }
 
   OpenCLBufferTransfer::OpenCLBufferTransfer(uint64_t s_id, double ts,
-					     VTFEventType ty,
-					     uint64_t address,
-					     uint64_t resource,
-					     size_t size)
+                                             VTFEventType ty,
+                                             uint64_t address,
+                                             uint64_t resource,
+                                             size_t size)
     :VTFEvent(s_id, ts, ty), threadId(std::this_thread::get_id()),
      deviceAddress(address), memoryResource(resource),
      bufferSize(size)
@@ -132,9 +132,9 @@ namespace xdp {
 
 
   OpenCLCopyBuffer::OpenCLCopyBuffer(uint64_t s_id, double ts, VTFEventType ty,
-				     uint64_t srcAddress, uint64_t srcResource,
-				     uint64_t dstAddress, uint64_t dstResource,
-				     size_t size)
+                                     uint64_t srcAddress, uint64_t srcResource,
+                                     uint64_t dstAddress, uint64_t dstResource,
+                                     size_t size)
     :VTFEvent(s_id, ts, ty), threadId(std::this_thread::get_id()),
      srcDeviceAddress(srcAddress), srcMemoryResource(srcResource),
      dstDeviceAddress(dstAddress), dstMemoryResource(dstResource),
@@ -153,17 +153,17 @@ namespace xdp {
     {
       fout << "," << 1 ; // Transfer type
       fout << "," << bufferSize 
-	   << "," << srcDeviceAddress
-	   << "," << srcMemoryResource
-	   << "," << dstDeviceAddress
-	   << "," << dstMemoryResource 
-	   << ",0x" << std::hex << threadId << std::dec ;
+           << "," << srcDeviceAddress
+           << "," << srcMemoryResource
+           << "," << dstDeviceAddress
+           << "," << dstMemoryResource 
+           << ",0x" << std::hex << threadId << std::dec ;
     }
     fout << std::endl ;
   }
 
   LOPBufferTransfer::LOPBufferTransfer(uint64_t s_id, double ts, 
-				       VTFEventType ty) :
+                                       VTFEventType ty) :
     VTFEvent(s_id, ts, ty), threadId(std::this_thread::get_id())
   {
     

--- a/src/runtime_src/xdp/profile/database/events/user_events.cpp
+++ b/src/runtime_src/xdp/profile/database/events/user_events.cpp
@@ -41,7 +41,7 @@ namespace xdp {
   }
 
   UserRange::UserRange(uint64_t s_id, double ts, bool s, 
-		       uint64_t l, uint64_t tt) :
+                       uint64_t l, uint64_t tt) :
     VTFEvent(s_id, ts, USER_RANGE), isStart(s), label(l), tooltip(tt)
   {
   }

--- a/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info/device_info.cpp
@@ -298,7 +298,7 @@ namespace xdp {
                                  uint8_t num, uint16_t start, uint16_t end,
                                  uint8_t reset, uint32_t load, double freq,
                                  const std::string& mod,
-				 const std::string& aieName)
+                                 const std::string& aieName)
   {
     XclbinInfo* xclbin = currentXclbin() ;
     if (!xclbin)

--- a/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/aie_trace/aie_trace_offload.cpp
@@ -130,7 +130,7 @@ bool AIETraceOffload::initReadTrace()
       XAie_DmaSetAxi(&(gmioDMAInsts[i].shimDmaInst), 0, traceGMIO->burstLength, 0, 0, 0);
 
       XAie_MemInst memInst;
-	  XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
+      XAie_MemCacheProp prop = XAIE_MEM_CACHEABLE;
       xclBufferExportHandle boExportHandle = xclExportBO(deviceHandle, buffers[i].boHandle);
       if(XRT_NULL_BO_EXPORT == boExportHandle) {
         throw std::runtime_error("Unable to export BO while attaching to AIE Driver");

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -263,7 +263,7 @@ DeviceIntf::~DeviceIntf()
 //    readDebugIPlayout();
 
     if (!mIsDeviceProfiling)
-   	  return 0;
+      return 0;
 
     size_t size = 0;
 
@@ -291,7 +291,7 @@ DeviceIntf::~DeviceIntf()
     }
 
     if (!mIsDeviceProfiling)
-   	  return 0;
+      return 0;
 
     size_t size = 0;
 
@@ -328,7 +328,7 @@ DeviceIntf::~DeviceIntf()
     memset(&counterResults, 0, sizeof(xclCounterResults));
 
     if (!mIsDeviceProfiling)
-   	  return 0;
+      return 0;
 
     size_t size = 0;
 
@@ -431,7 +431,7 @@ DeviceIntf::~DeviceIntf()
     }
 
     if (!mIsDeviceProfiling || !mFifoCtrl)
-   	  return 0;
+      return 0;
 
     return mFifoCtrl->reset();
   }
@@ -443,7 +443,7 @@ DeviceIntf::~DeviceIntf()
     }
 
     if (!mIsDeviceProfiling || !mFifoCtrl)
-   	  return 0;
+      return 0;
 
     return mFifoCtrl->getNumTraceSamples();
   }

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -298,8 +298,8 @@ namespace xdp {
         db->getDynamicInfo().addEvent(strmEvent);
         std::get<0>(matchingStart) = strmEvent->getEventType() ;
         std::get<1>(matchingStart) = strmEvent->getEventId(); 
-	std::get<2>(matchingStart) = hostTimestamp ;
-	std::get<3>(matchingStart) = deviceTimestamp ;
+        std::get<2>(matchingStart) = hostTimestamp ;
+        std::get<3>(matchingStart) = deviceTimestamp ;
         hostTimestamp += halfCycleTimeInMs;
       }
       // add end event
@@ -328,7 +328,7 @@ namespace xdp {
       //  then we must have dropped an end packet.  Add a dummy end packet
       //  here.
       if (db->getDynamicInfo().hasMatchingDeviceEventStart(traceId, ty)){
-	std::tuple<VTFEventType, uint64_t, double, uint64_t> matchingStart =
+        std::tuple<VTFEventType, uint64_t, double, uint64_t> matchingStart =
           db->getDynamicInfo().matchingDeviceEventStart(traceId, ty);
         memEvent =
           new DeviceMemoryAccess(std::get<1>(matchingStart),
@@ -357,10 +357,10 @@ namespace xdp {
         memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, deviceId, slot, cuId);
         memEvent->setDeviceTimestamp(deviceTimestamp);
         db->getDynamicInfo().addEvent(memEvent);
-	std::get<0>(matchingStart) = memEvent->getEventType() ;
-	std::get<1>(matchingStart) = memEvent->getEventId() ;
-	std::get<2>(matchingStart) = hostTimestamp ;
-	std::get<3>(matchingStart) = deviceTimestamp ;
+        std::get<0>(matchingStart) = memEvent->getEventType() ;
+        std::get<1>(matchingStart) = memEvent->getEventId() ;
+        std::get<2>(matchingStart) = hostTimestamp ;
+        std::get<3>(matchingStart) = deviceTimestamp ;
 
         // Also, progress time so the end is after the start
         hostTimestamp += halfCycleTimeInMs;
@@ -381,10 +381,10 @@ namespace xdp {
           memEvent = new DeviceMemoryAccess(0, hostTimestamp, ty, deviceId, slot, cuId);
           memEvent->setDeviceTimestamp(deviceTimestamp);
           db->getDynamicInfo().addEvent(memEvent);
-	  std::get<0>(matchingStart) = memEvent->getEventType() ;
-	  std::get<1>(matchingStart) = memEvent->getEventId() ;
-	  std::get<2>(matchingStart) = hostTimestamp ;
-	  std::get<3>(matchingStart) = deviceTimestamp ;
+          std::get<0>(matchingStart) = memEvent->getEventType() ;
+          std::get<1>(matchingStart) = memEvent->getEventId() ;
+          std::get<2>(matchingStart) = hostTimestamp ;
+          std::get<3>(matchingStart) = deviceTimestamp ;
           // Also, progress time so the end is after the start
           hostTimestamp += halfCycleTimeInMs;
         }

--- a/src/runtime_src/xdp/profile/device/traceS2MM.cpp
+++ b/src/runtime_src/xdp/profile/device/traceS2MM.cpp
@@ -271,7 +271,7 @@ void TraceS2MM::parseTraceBuf(void* buf, uint64_t size, std::vector<xclTraceResu
         }
         else {
           mModulus = mModulus + 1 ;
-	}
+        }
       }
       else {
         xclTraceResults result = {};

--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -146,9 +146,9 @@ namespace xdp {
       {"dma_stalls_mm2s",       {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_ACQUIRE_MEM,
                                  XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_ACQUIRE_MEM}},
       {"write_bandwidths",      {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM,
-	                               XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
-	    {"read_bandwidths",       {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM,
-	                               XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}
+                                 XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
+      {"read_bandwidths",       {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM,
+                                 XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}
     };
     mMemoryEndEvents = {
       {"conflicts",             {XAIE_EVENT_GROUP_MEMORY_CONFLICT_MEM, XAIE_EVENT_GROUP_ERRORS_MEM}},
@@ -158,9 +158,9 @@ namespace xdp {
       {"dma_stalls_mm2s",       {XAIE_EVENT_DMA_MM2S_0_STALLED_LOCK_ACQUIRE_MEM,
                                  XAIE_EVENT_DMA_MM2S_1_STALLED_LOCK_ACQUIRE_MEM}},
       {"write_bandwidths",      {XAIE_EVENT_DMA_S2MM_0_FINISHED_BD_MEM,
-	                               XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
-	    {"read_bandwidths",       {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM,
-	                               XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}
+                                 XAIE_EVENT_DMA_S2MM_1_FINISHED_BD_MEM}},
+      {"read_bandwidths",       {XAIE_EVENT_DMA_MM2S_0_FINISHED_BD_MEM,
+                                 XAIE_EVENT_DMA_MM2S_1_FINISHED_BD_MEM}}
     };
 
     // **** PL/Shim Counters ****
@@ -623,7 +623,7 @@ namespace xdp {
     constexpr int NUM_MODULES = 3;
 
     // Get AIE clock frequency
-	  std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
+    std::shared_ptr<xrt_core::device> device = xrt_core::get_userpf_device(handle);
     auto clockFreqMhz = xrt_core::edge::aie::get_clock_freq_mhz(device.get());
 
     int numCounters[NUM_MODULES] =
@@ -859,7 +859,7 @@ namespace xdp {
           xrt_core::message::send(severity_level::warning, "XRT", msg);
           (db->getStaticInfo()).setIsAIECounterRead(deviceId,true);
           return;
-	}
+        }
         else {
           XAie_DevInst* aieDevInst =
             static_cast<XAie_DevInst*>(db->getStaticInfo().getAieDevInst(fetchAieDevInst, handle));

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -107,7 +107,7 @@ namespace xdp {
     }
     else {
       if (xrt_core::config::get_continuous_trace()) {
-	xrt_core::message::send(xrt_core::message::severity_level::warning,
+        xrt_core::message::send(xrt_core::message::severity_level::warning,
                                 "XRT",
                                 "Continuous offload and dumping of device data is not supported in emulation and has been disabled.");
       }
@@ -275,8 +275,8 @@ namespace xdp {
               std::to_string(requested_offload_rate);
             xrt_core::message::send(xrt_core::message::severity_level::warning,
                                     "XRT", msg);
-	  }
-	}
+          }
+        }
       }
     }
     else {

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.cpp
@@ -165,13 +165,13 @@ namespace xdp {
 
     if (!(db->getStaticInfo()).validXclbin(device->get_xcl_handle())) {
       std::string msg =
-	"Device profiling is only supported on xclbins built using " ;
+        "Device profiling is only supported on xclbins built using " ;
       msg += std::to_string((db->getStaticInfo()).earliestSupportedToolVersion()) ;
       msg += " tools or later.  To enable device profiling please rebuild." ;
 
       xrt_core::message::send(xrt_core::message::severity_level::warning,
-			      "XRT",
-			      msg) ;
+                              "XRT",
+                              msg) ;
       return ;
     }
 

--- a/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin_interface.h
+++ b/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin_interface.h
@@ -28,11 +28,11 @@ void hal_generic_cb(bool isStart, const char* name, unsigned long long int id) ;
 // Specialization start/stop callbacks
 XDP_EXPORT
 void buffer_transfer_cb(bool isWrite, 
-			bool isStart,
-			const char* name,
-			unsigned long long int id,
-			unsigned long long int bufferId,
-			unsigned long long int size) ;
+                        bool isStart,
+                        const char* name,
+                        unsigned long long int id,
+                        unsigned long long int bufferId,
+                        unsigned long long int size) ;
 }
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -99,7 +99,7 @@ namespace xdp {
   }
 
   void HALAPIInterface::createProfileResults(xclDeviceHandle deviceHandle, 
-					     void* ret)
+                                             void* ret)
   {
     ProfileResults** retResults = static_cast<ProfileResults**>(ret);
     
@@ -141,12 +141,12 @@ namespace xdp {
       results->kernelTransferData = (KernelTransferData*)calloc(results->numAIM, sizeof(KernelTransferData));
       
       for(unsigned int i=0; i < results->numAIM ; ++i) {
-	std::string monName = currDevice->getMonitorName(XCL_PERF_MON_MEMORY, i);
-	results->kernelTransferData[i].cuPortName = (char*)malloc(monName.length()+1);
-	strcpy(results->kernelTransferData[i].cuPortName, monName.c_str());
-	
-	// argname
-	// memoryname
+        std::string monName = currDevice->getMonitorName(XCL_PERF_MON_MEMORY, i);
+        results->kernelTransferData[i].cuPortName = (char*)malloc(monName.length()+1);
+        strcpy(results->kernelTransferData[i].cuPortName, monName.c_str());
+
+        // argname
+        // memoryname
       }
     }
     
@@ -154,10 +154,10 @@ namespace xdp {
       results->cuExecData = (CuExecData*)calloc(results->numAM, sizeof(CuExecData));
       
       for(unsigned int i=0; i < results->numAM ; ++i) {
-	std::string monName = currDevice->getMonitorName(XCL_PERF_MON_ACCEL, i);
-	results->cuExecData[i].cuName = (char*)malloc((monName.length()+1)*sizeof(char));
-	strcpy(results->cuExecData[i].cuName, monName.c_str());
-	// kernel name
+        std::string monName = currDevice->getMonitorName(XCL_PERF_MON_ACCEL, i);
+        results->cuExecData[i].cuName = (char*)malloc((monName.length()+1)*sizeof(char));
+        strcpy(results->cuExecData[i].cuName, monName.c_str());
+        // kernel name
       }
     }      
     
@@ -166,19 +166,19 @@ namespace xdp {
       results->streamData = (StreamTransferData*)calloc(results->numASM, sizeof(StreamTransferData));
       
       for(unsigned int i=0; i < results->numASM ; ++i) {
-	std::string monName = currDevice->getMonitorName(XCL_PERF_MON_STR, i);
-	std::size_t sepPos  = monName.find(IP_LAYOUT_SEP);
-	if(sepPos == std::string::npos)
-	  continue;
-	
-	std::string masterPort = monName.substr(0, sepPos);
-	std::string slavePort  = monName.substr(sepPos + 1);
-	
-	results->streamData[i].masterPortName = (char*)malloc((masterPort.length()+1));
-	strcpy(results->streamData[i].masterPortName, masterPort.c_str());
-	
-	results->streamData[i].slavePortName = (char*)malloc((slavePort.length()+1));
-	strcpy(results->streamData[i].slavePortName, slavePort.c_str());
+        std::string monName = currDevice->getMonitorName(XCL_PERF_MON_STR, i);
+        std::size_t sepPos  = monName.find(IP_LAYOUT_SEP);
+        if(sepPos == std::string::npos)
+          continue;
+
+        std::string masterPort = monName.substr(0, sepPos);
+        std::string slavePort  = monName.substr(sepPos + 1);
+
+        results->streamData[i].masterPortName = (char*)malloc((masterPort.length()+1));
+        strcpy(results->streamData[i].masterPortName, masterPort.c_str());
+
+        results->streamData[i].slavePortName = (char*)malloc((slavePort.length()+1));
+        strcpy(results->streamData[i].slavePortName, slavePort.c_str());
       }
     }
   }
@@ -193,25 +193,25 @@ namespace xdp {
       // Check for rollover of byte counters; if detected, add 2^32
       // Otherwise, if first read after program with binary, then capture bytes from previous xclbin
       if (!firstReadAfterProgram) {
-	// Update "RollOverCount"
-	if(counterResult.WriteBytes[i]      < loggedResult.WriteBytes[i])      rollOverCount.WriteBytes[i]++;
-	if(counterResult.ReadBytes[i]       < loggedResult.ReadBytes[i])       rollOverCount.ReadBytes[i]++;
-	if(counterResult.WriteTranx[i]      < loggedResult.WriteTranx[i])      rollOverCount.WriteTranx[i]++;
-	if(counterResult.ReadTranx[i]       < loggedResult.ReadTranx[i])       rollOverCount.ReadTranx[i]++;
-	if(counterResult.WriteLatency[i]    < loggedResult.WriteLatency[i])    rollOverCount.WriteLatency[i]++;
-	if(counterResult.ReadLatency[i]     < loggedResult.ReadLatency[i])     rollOverCount.ReadLatency[i]++;
-	if(counterResult.ReadBusyCycles[i]  < loggedResult.ReadBusyCycles[i])  rollOverCount.ReadBusyCycles[i]++;
-	if(counterResult.WriteBusyCycles[i] < loggedResult.WriteBusyCycles[i]) rollOverCount.WriteBusyCycles[i]++;
+        // Update "RollOverCount"
+        if(counterResult.WriteBytes[i]      < loggedResult.WriteBytes[i])      rollOverCount.WriteBytes[i]++;
+        if(counterResult.ReadBytes[i]       < loggedResult.ReadBytes[i])       rollOverCount.ReadBytes[i]++;
+        if(counterResult.WriteTranx[i]      < loggedResult.WriteTranx[i])      rollOverCount.WriteTranx[i]++;
+        if(counterResult.ReadTranx[i]       < loggedResult.ReadTranx[i])       rollOverCount.ReadTranx[i]++;
+        if(counterResult.WriteLatency[i]    < loggedResult.WriteLatency[i])    rollOverCount.WriteLatency[i]++;
+        if(counterResult.ReadLatency[i]     < loggedResult.ReadLatency[i])     rollOverCount.ReadLatency[i]++;
+        if(counterResult.ReadBusyCycles[i]  < loggedResult.ReadBusyCycles[i])  rollOverCount.ReadBusyCycles[i]++;
+        if(counterResult.WriteBusyCycles[i] < loggedResult.WriteBusyCycles[i]) rollOverCount.WriteBusyCycles[i]++;
       } else {
-	// Update "RollOverCounterResults" with logged data
-	rollOverCounterResult.WriteBytes[i]      += loggedResult.WriteBytes[i];
-	rollOverCounterResult.ReadBytes[i]       += loggedResult.ReadBytes[i];
-	rollOverCounterResult.WriteTranx[i]      += loggedResult.WriteTranx[i];
-	rollOverCounterResult.ReadTranx[i]       += loggedResult.ReadTranx[i];
-	rollOverCounterResult.WriteLatency[i]    += loggedResult.WriteLatency[i];
-	rollOverCounterResult.ReadLatency[i]     += loggedResult.ReadLatency[i];
-	rollOverCounterResult.ReadBusyCycles[i]  += loggedResult.ReadBusyCycles[i];
-	rollOverCounterResult.WriteBusyCycles[i] += loggedResult.WriteBusyCycles[i];
+        // Update "RollOverCounterResults" with logged data
+        rollOverCounterResult.WriteBytes[i]      += loggedResult.WriteBytes[i];
+        rollOverCounterResult.ReadBytes[i]       += loggedResult.ReadBytes[i];
+        rollOverCounterResult.WriteTranx[i]      += loggedResult.WriteTranx[i];
+        rollOverCounterResult.ReadTranx[i]       += loggedResult.ReadTranx[i];
+        rollOverCounterResult.WriteLatency[i]    += loggedResult.WriteLatency[i];
+        rollOverCounterResult.ReadLatency[i]     += loggedResult.ReadLatency[i];
+        rollOverCounterResult.ReadBusyCycles[i]  += loggedResult.ReadBusyCycles[i];
+        rollOverCounterResult.WriteBusyCycles[i] += loggedResult.WriteBusyCycles[i];
       }
     }
   }
@@ -225,19 +225,19 @@ namespace xdp {
     for(unsigned int i = 0; i < numAM ; ++i) {
       // Update "RollOverCount" 
       if (!firstReadAfterProgram) {
-	if(counterResult.CuExecCycles[i]     < loggedResult.CuExecCycles[i])     rollOverCount.CuExecCycles[i]++;
-	if(counterResult.CuBusyCycles[i]     < loggedResult.CuBusyCycles[i])     rollOverCount.CuBusyCycles[i]++;
-	if(counterResult.CuStallExtCycles[i] < loggedResult.CuStallExtCycles[i]) rollOverCount.CuStallExtCycles[i]++;
-	if(counterResult.CuStallIntCycles[i] < loggedResult.CuStallIntCycles[i]) rollOverCount.CuStallIntCycles[i]++;
-	if(counterResult.CuStallStrCycles[i] < loggedResult.CuStallStrCycles[i]) rollOverCount.CuStallStrCycles[i]++;
+        if(counterResult.CuExecCycles[i]     < loggedResult.CuExecCycles[i])     rollOverCount.CuExecCycles[i]++;
+        if(counterResult.CuBusyCycles[i]     < loggedResult.CuBusyCycles[i])     rollOverCount.CuBusyCycles[i]++;
+        if(counterResult.CuStallExtCycles[i] < loggedResult.CuStallExtCycles[i]) rollOverCount.CuStallExtCycles[i]++;
+        if(counterResult.CuStallIntCycles[i] < loggedResult.CuStallIntCycles[i]) rollOverCount.CuStallIntCycles[i]++;
+        if(counterResult.CuStallStrCycles[i] < loggedResult.CuStallStrCycles[i]) rollOverCount.CuStallStrCycles[i]++;
       } else {
-	// Update "RollOverCounterResults" with logged data
-	rollOverCounterResult.CuExecCount[i]      += loggedResult.CuExecCount[i];
-	rollOverCounterResult.CuExecCycles[i]     += loggedResult.CuExecCycles[i];
-	rollOverCounterResult.CuBusyCycles[i]     += loggedResult.CuBusyCycles[i];
-	rollOverCounterResult.CuStallExtCycles[i] += loggedResult.CuStallExtCycles[i];
-	rollOverCounterResult.CuStallIntCycles[i] += loggedResult.CuStallIntCycles[i];
-	rollOverCounterResult.CuStallStrCycles[i] += loggedResult.CuStallStrCycles[i];
+        // Update "RollOverCounterResults" with logged data
+        rollOverCounterResult.CuExecCount[i]      += loggedResult.CuExecCount[i];
+        rollOverCounterResult.CuExecCycles[i]     += loggedResult.CuExecCycles[i];
+        rollOverCounterResult.CuBusyCycles[i]     += loggedResult.CuBusyCycles[i];
+        rollOverCounterResult.CuStallExtCycles[i] += loggedResult.CuStallExtCycles[i];
+        rollOverCounterResult.CuStallIntCycles[i] += loggedResult.CuStallIntCycles[i];
+        rollOverCounterResult.CuStallStrCycles[i] += loggedResult.CuStallStrCycles[i];
       }
       
     }
@@ -258,9 +258,9 @@ namespace xdp {
       
       results->cuExecData[i].cuExecCount = counterResults.CuExecCount[i] + rollOverCounterResult.CuExecCount[i];
       results->cuExecData[i].cuExecCycles = counterResults.CuExecCycles[i] + rollOverCounterResult.CuExecCycles[i]
-	+ (rollOverCount.CuExecCycles[i] * 4294967296UL);
+        + (rollOverCount.CuExecCycles[i] * 4294967296UL);
       results->cuExecData[i].cuBusyCycles = counterResults.CuBusyCycles[i] + rollOverCounterResult.CuBusyCycles[i]
-	+ (rollOverCount.CuBusyCycles[i] * 4294967296UL);
+        + (rollOverCount.CuBusyCycles[i] * 4294967296UL);
       
       results->cuExecData[i].cuMaxExecCycles = counterResults.CuMaxExecCycles[i];
       results->cuExecData[i].cuMinExecCycles = counterResults.CuMinExecCycles[i];
@@ -278,7 +278,7 @@ namespace xdp {
     
     for(unsigned int i = 0; i < results->numAIM ; ++i) {
       if(currDevice->isHostAIM(i)) {
-	continue;
+        continue;
       }
       
       results->kernelTransferData[i].totalReadBytes = counterResults.ReadBytes[i] + (rollOverCount.ReadBytes[i] * 4294967296UL);

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
@@ -27,8 +27,8 @@ namespace xdp {
   static LowOverheadProfilingPlugin lopPluginInstance ;
 
   static void lop_cb_log_function_start(const char* functionName,
-					long long queueAddress,
-					unsigned long long int functionID)
+                                        long long queueAddress,
+                                        unsigned long long int functionID)
   {
     // Since these are OpenCL level events, we must use the OpenCL
     //  level time functions to get the proper value of time zero.
@@ -49,8 +49,8 @@ namespace xdp {
   }
 
   static void lop_cb_log_function_end(const char* functionName,
-				      long long queueAddress,
-				      unsigned long long int functionID)
+                                      long long queueAddress,
+                                      unsigned long long int functionID)
   {
     double timestamp = xrt_xocl::time_ns() ;
     VPDatabase* db = lopPluginInstance.getDatabase() ;
@@ -76,8 +76,8 @@ namespace xdp {
     if (!isStart) start = (db->getDynamicInfo()).matchingStart(lopEventId) ;
 
     VTFEvent* event = new LOPBufferTransfer(start,
-					    timestamp,
-					    LOP_READ_BUFFER) ;
+                                            timestamp,
+                                            LOP_READ_BUFFER) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
     if (isStart)
@@ -94,8 +94,8 @@ namespace xdp {
     if (!isStart) start = (db->getDynamicInfo()).matchingStart(lopEventId) ;
 
     VTFEvent* event = new LOPBufferTransfer(start,
-					    timestamp,
-					    LOP_WRITE_BUFFER) ;
+                                            timestamp,
+                                            LOP_WRITE_BUFFER) ;
     (db->getDynamicInfo()).addEvent(event) ;
     if (isStart)
       (db->getDynamicInfo()).markStart(lopEventId, event->getEventId()) ;
@@ -126,14 +126,14 @@ namespace xdp {
 
 extern "C"
 void lop_function_start(const char* functionName, long long queueAddress,
-			unsigned long long int functionID)
+                        unsigned long long int functionID)
 {
   xdp::lop_cb_log_function_start(functionName, queueAddress, functionID) ;
 }
 
 extern "C"
 void lop_function_end(const char* functionName, long long queueAddress,
-		      unsigned long long int functionID)
+                      unsigned long long int functionID)
 {
   xdp::lop_cb_log_function_end(functionName, queueAddress, functionID) ;
 }

--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
@@ -43,7 +43,7 @@ namespace xdp {
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
       for (auto w : writers) {
-	w->write(false) ;
+        w->write(false) ;
       }
       db->unregisterPlugin(this) ;
     }

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -60,7 +60,7 @@ namespace xdp {
       db->broadcast(VPDatabase::READ_TRACE, nullptr) ;
       for (auto w : writers)
       {
-	w->write(false) ;
+        w->write(false) ;
       }
       db->unregisterPlugin(this) ;
     }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
@@ -29,8 +29,8 @@ namespace xdp {
   static OpenCLTracePlugin openclPluginInstance ;
 
   static void log_function_start(const char* functionName,
-				 uint64_t queueAddress,
-				 uint64_t functionID)
+                                 uint64_t queueAddress,
+                                 uint64_t functionID)
   {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
@@ -39,18 +39,18 @@ namespace xdp {
       (db->getStaticInfo()).addCommandQueueAddress(queueAddress) ;
 
     VTFEvent* event = new OpenCLAPICall(0,
-					timestamp,
-					functionID,
-					(db->getDynamicInfo()).addString(functionName),
-					queueAddress
-					) ;
+                                        timestamp,
+                                        functionID,
+                                        (db->getDynamicInfo()).addString(functionName),
+                                        queueAddress
+                                        ) ;
     (db->getDynamicInfo()).addEvent(event) ;
     (db->getDynamicInfo()).markStart(functionID, event->getEventId()) ;
   }
 
   static void log_function_end(const char* functionName,
-			       uint64_t queueAddress,
-			       uint64_t functionID)
+                               uint64_t queueAddress,
+                               uint64_t functionID)
   {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
@@ -58,10 +58,10 @@ namespace xdp {
     uint64_t start = (db->getDynamicInfo()).matchingStart(functionID) ;
 
     VTFEvent* event = new OpenCLAPICall(start,
-					timestamp,
-					functionID,
-					(db->getDynamicInfo()).addString(functionName),
-					queueAddress) ;
+                                        timestamp,
+                                        functionID,
+                                        (db->getDynamicInfo()).addString(functionName),
+                                        queueAddress) ;
     (db->getDynamicInfo()).addEvent(event) ;
   }
 
@@ -73,11 +73,11 @@ namespace xdp {
   }
 
   static void action_read(uint64_t id,
-			  bool isStart,
-			  uint64_t deviceAddress,
-			  const char* memoryResource,
-			  size_t bufferSize,
-			  bool isP2P)
+                          bool isStart,
+                          uint64_t deviceAddress,
+                          const char* memoryResource,
+                          size_t bufferSize,
+                          bool isP2P)
   {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
@@ -88,11 +88,11 @@ namespace xdp {
 
     VTFEvent* event = 
       new OpenCLBufferTransfer(start,
-			       timestamp,
-			       (isP2P ? READ_BUFFER_P2P : READ_BUFFER),
-			       deviceAddress,
-			       memoryResource ? (db->getDynamicInfo()).addString(memoryResource) : 0,
-			       bufferSize) ;
+                               timestamp,
+                               (isP2P ? READ_BUFFER_P2P : READ_BUFFER),
+                               deviceAddress,
+                               memoryResource ? (db->getDynamicInfo()).addString(memoryResource) : 0,
+                               bufferSize) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
     if (isStart) {
@@ -104,11 +104,11 @@ namespace xdp {
   }
 
   static void action_write(uint64_t id,
-			   bool isStart,
-			   uint64_t deviceAddress,
-			   const char* memoryResource,
-			   size_t bufferSize,
-			   bool isP2P)
+                           bool isStart,
+                           uint64_t deviceAddress,
+                           const char* memoryResource,
+                           size_t bufferSize,
+                           bool isP2P)
   {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
@@ -125,11 +125,11 @@ namespace xdp {
 
     VTFEvent* event = 
       new OpenCLBufferTransfer(start,
-			       timestamp,
-			       (isP2P ? WRITE_BUFFER_P2P : WRITE_BUFFER),
-			       deviceAddress,
-			       memoryResource ? (db->getDynamicInfo()).addString(memoryResource) : 0,
-			       bufferSize) ;
+                               timestamp,
+                               (isP2P ? WRITE_BUFFER_P2P : WRITE_BUFFER),
+                               deviceAddress,
+                               memoryResource ? (db->getDynamicInfo()).addString(memoryResource) : 0,
+                               bufferSize) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
     if (isStart) {
@@ -141,13 +141,13 @@ namespace xdp {
   }
 
   static void action_copy(uint64_t id,
-			  bool isStart,
-			  uint64_t srcDeviceAddress,
-			  const char* srcMemoryResource,
-			  uint64_t dstDeviceAddress,
-			  const char* dstMemoryResource,
-			  size_t bufferSize,
-			  bool isP2P)
+                          bool isStart,
+                          uint64_t srcDeviceAddress,
+                          const char* srcMemoryResource,
+                          uint64_t dstDeviceAddress,
+                          const char* dstMemoryResource,
+                          size_t bufferSize,
+                          bool isP2P)
   {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
@@ -158,13 +158,13 @@ namespace xdp {
 
     VTFEvent* event = 
       new OpenCLCopyBuffer(start,
-			   timestamp,
-			   (isP2P ? COPY_BUFFER_P2P : COPY_BUFFER),
-			   srcDeviceAddress,
-			   srcMemoryResource ? (db->getDynamicInfo()).addString(srcMemoryResource) : 0,
-			   dstDeviceAddress,
-			   dstMemoryResource ? (db->getDynamicInfo()).addString(dstMemoryResource) : 0,
-			   bufferSize) ;
+                           timestamp,
+                           (isP2P ? COPY_BUFFER_P2P : COPY_BUFFER),
+                           srcDeviceAddress,
+                           srcMemoryResource ? (db->getDynamicInfo()).addString(srcMemoryResource) : 0,
+                           dstDeviceAddress,
+                           dstMemoryResource ? (db->getDynamicInfo()).addString(dstMemoryResource) : 0,
+                           bufferSize) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
     if (isStart) {
@@ -176,14 +176,14 @@ namespace xdp {
   }
   
   static void action_ndrange(uint64_t id,
-			     bool isStart,
-			     const char* deviceName,
-			     const char* binaryName,
-			     const char* kernelName,
-			     size_t workgroupConfigurationX,
-			     size_t workgroupConfigurationY,
-			     size_t workgroupConfigurationZ,
-			     size_t workgroupSize)
+                             bool isStart,
+                             const char* deviceName,
+                             const char* binaryName,
+                             const char* kernelName,
+                             size_t workgroupConfigurationX,
+                             size_t workgroupConfigurationY,
+                             size_t workgroupConfigurationZ,
+                             size_t workgroupSize)
   {
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
@@ -201,20 +201,20 @@ namespace xdp {
     if (deviceName != nullptr && binaryName != nullptr && kernelName != nullptr)
     {
       enqueueIdentifier = std::string(deviceName) + ":" +
-	                  std::string(binaryName) + ":" +
-	                  std::string(kernelName) ;
+                          std::string(binaryName) + ":" +
+                          std::string(kernelName) ;
       (db->getStaticInfo()).addEnqueuedKernel(enqueueIdentifier) ;
     }
 
     VTFEvent* event = 
       new KernelEnqueue(start, 
-			timestamp,
-			deviceName ? (db->getDynamicInfo()).addString(deviceName) : 0,
-			binaryName ? (db->getDynamicInfo()).addString(binaryName) : 0,
-			kernelName ? (db->getDynamicInfo()).addString(kernelName) : 0,
-			(db->getDynamicInfo()).addString(workgroupConfiguration.c_str()),
-			workgroupSize,
-			enqueueIdentifier == "" ? nullptr : enqueueIdentifier.c_str()) ;
+                        timestamp,
+                        deviceName ? (db->getDynamicInfo()).addString(deviceName) : 0,
+                        binaryName ? (db->getDynamicInfo()).addString(binaryName) : 0,
+                        kernelName ? (db->getDynamicInfo()).addString(kernelName) : 0,
+                        (db->getDynamicInfo()).addString(workgroupConfiguration.c_str()),
+                        workgroupSize,
+                        enqueueIdentifier == "" ? nullptr : enqueueIdentifier.c_str()) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
 
@@ -230,102 +230,102 @@ namespace xdp {
 
 extern "C"
 void function_start(const char* functionName, 
-		    unsigned long long int queueAddress,
-		    unsigned long long int functionID)
+                    unsigned long long int queueAddress,
+                    unsigned long long int functionID)
 {
   xdp::log_function_start(functionName,
-			  static_cast<uint64_t>(queueAddress),
-			  static_cast<uint64_t>(functionID)) ;
+                          static_cast<uint64_t>(queueAddress),
+                          static_cast<uint64_t>(functionID)) ;
 }
 
 extern "C"
 void function_end(const char* functionName, 
-		  unsigned long long int queueAddress,
-		  unsigned long long int functionID)
+                  unsigned long long int queueAddress,
+                  unsigned long long int functionID)
 {
   xdp::log_function_end(functionName,
-			static_cast<uint64_t>(queueAddress),
-			static_cast<uint64_t>(functionID)) ;
+                        static_cast<uint64_t>(queueAddress),
+                        static_cast<uint64_t>(functionID)) ;
 }
 
 extern "C"
 void add_dependency(unsigned long long int id,
-		    unsigned long long int dependency)
+                    unsigned long long int dependency)
 {
   xdp::add_dependency(static_cast<uint64_t>(id),
-		      static_cast<uint64_t>(dependency)) ;
+                      static_cast<uint64_t>(dependency)) ;
 }
 
 extern "C"
 void action_read(unsigned long long int id,
-		 bool isStart,
-		 unsigned long long int deviceAddress,
-		 const char* memoryResource,
-		 size_t bufferSize,
-		 bool isP2P)
+                 bool isStart,
+                 unsigned long long int deviceAddress,
+                 const char* memoryResource,
+                 size_t bufferSize,
+                 bool isP2P)
 {
   xdp::action_read(static_cast<uint64_t>(id),
-		   isStart,
-		   static_cast<uint64_t>(deviceAddress),
-		   memoryResource,
-		   bufferSize, 
-		   isP2P) ;
+                   isStart,
+                   static_cast<uint64_t>(deviceAddress),
+                   memoryResource,
+                   bufferSize, 
+                   isP2P) ;
 }
 
 extern "C"
 void action_write(unsigned long long int id,
-		  bool isStart,
-		  unsigned long long int deviceAddress,
-		  const char* memoryResource,
-		  size_t bufferSize,
-		  bool isP2P)
+                  bool isStart,
+                  unsigned long long int deviceAddress,
+                  const char* memoryResource,
+                  size_t bufferSize,
+                  bool isP2P)
 {
   xdp::action_write(static_cast<uint64_t>(id),
-		    isStart,
-		    static_cast<uint64_t>(deviceAddress),
-		    memoryResource,
-		    bufferSize, 
-		    isP2P) ;
+                    isStart,
+                    static_cast<uint64_t>(deviceAddress),
+                    memoryResource,
+                    bufferSize, 
+                    isP2P) ;
 }
 
 extern "C"
 void action_copy(unsigned long long int id,
-		 bool isStart,
-		 unsigned long long int srcDeviceAddress,
-		 const char* srcMemoryResource,
-		 unsigned long long int dstDeviceAddress,
-		 const char* dstMemoryResource,
-		 size_t bufferSize,
-		 bool isP2P)
+                 bool isStart,
+                 unsigned long long int srcDeviceAddress,
+                 const char* srcMemoryResource,
+                 unsigned long long int dstDeviceAddress,
+                 const char* dstMemoryResource,
+                 size_t bufferSize,
+                 bool isP2P)
 {
   xdp::action_copy(static_cast<uint64_t>(id),
-		   isStart,
-		   static_cast<uint64_t>(srcDeviceAddress),
-		   srcMemoryResource, 
-		   static_cast<uint64_t>(dstDeviceAddress),
-		   dstMemoryResource,
-		   bufferSize,
-		   isP2P) ;
+                   isStart,
+                   static_cast<uint64_t>(srcDeviceAddress),
+                   srcMemoryResource, 
+                   static_cast<uint64_t>(dstDeviceAddress),
+                   dstMemoryResource,
+                   bufferSize,
+                   isP2P) ;
 }
 
 extern "C"
 void action_ndrange(unsigned long long int id,
-		    bool isStart,
-		    const char* deviceName,
-		    const char* binaryName,
-		    const char* kernelName,
-		    size_t workgroupConfigurationX,
-		    size_t workgroupConfigurationY,
-		    size_t workgroupConfigurationZ,
-		    size_t workgroupSize)
+                    bool isStart,
+                    const char* deviceName,
+                    const char* binaryName,
+                    const char* kernelName,
+                    size_t workgroupConfigurationX,
+                    size_t workgroupConfigurationY,
+                    size_t workgroupConfigurationZ,
+                    size_t workgroupSize)
 {
   xdp::action_ndrange(static_cast<uint64_t>(id),
-		      isStart,
-		      deviceName,
-		      binaryName,
-		      kernelName,
-		      workgroupConfigurationX,
-		      workgroupConfigurationY,
-		      workgroupConfigurationZ,
-		      workgroupSize) ;
+                      isStart,
+                      deviceName,
+                      binaryName,
+                      kernelName,
+                      workgroupConfigurationX,
+                      workgroupConfigurationY,
+                      workgroupConfigurationZ,
+                      workgroupSize) ;
 }

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.h
@@ -23,53 +23,53 @@
 //  linked in.  XRT should call them directly.
 extern "C" 
 void function_start(const char* functionName, 
-		    unsigned long long int queueAddress, 
-		    unsigned long long int functionID);
+                    unsigned long long int queueAddress, 
+                    unsigned long long int functionID);
 
 extern "C"
 void function_end(const char* functionName, 
-		  unsigned long long int queueAddress,
-		  unsigned long long int functionID);
+                  unsigned long long int queueAddress,
+                  unsigned long long int functionID);
 
 extern "C"
 void add_dependency(unsigned long long int id,
-		    unsigned long long int dependency) ;
+                    unsigned long long int dependency) ;
 
 extern "C"
 void action_read(unsigned long long int id,
-		 bool isStart,
-		 unsigned long long int deviceAddress,
-		 const char* memoryResource,
-		 size_t bufferSize,
-		 bool isP2P) ;
+                 bool isStart,
+                 unsigned long long int deviceAddress,
+                 const char* memoryResource,
+                 size_t bufferSize,
+                 bool isP2P) ;
 
 extern "C"
 void action_write(unsigned long long int id,
-		  bool isStart,
-		  unsigned long long int deviceAddress,
-		  const char* memoryResource,
-		  size_t bufferSize,
-		  bool isP2P) ;
+                  bool isStart,
+                  unsigned long long int deviceAddress,
+                  const char* memoryResource,
+                  size_t bufferSize,
+                  bool isP2P) ;
 
 extern "C"
 void action_copy(unsigned long long int id,
-		 bool isStart,
-		 unsigned long long int srcDeviceAddress,
-		 const char* srcMemoryResource,
-		 unsigned long long int dstDeviceAddress,
-		 const char* dstMemoryResource,
-		 size_t bufferSize,
-		 bool isP2P) ;
+                 bool isStart,
+                 unsigned long long int srcDeviceAddress,
+                 const char* srcMemoryResource,
+                 unsigned long long int dstDeviceAddress,
+                 const char* dstMemoryResource,
+                 size_t bufferSize,
+                 bool isP2P) ;
 
 extern "C"
 void action_ndrange(unsigned long long int id,
-		    bool isStart,
-		    const char* deviceName,
-		    const char* binaryName,
-		    const char* kernelName,
-		    size_t workgroupConfigurationX,
-		    size_t workgroupConfigurationY,
-		    size_t workgroupConfiguraionZ,
-		    size_t workgroupSize) ;
+                    bool isStart,
+                    const char* deviceName,
+                    const char* binaryName,
+                    const char* kernelName,
+                    size_t workgroupConfigurationX,
+                    size_t workgroupConfigurationY,
+                    size_t workgroupConfiguraionZ,
+                    size_t workgroupSize) ;
 
 #endif

--- a/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/power/power_plugin.cpp
@@ -78,9 +78,9 @@ namespace xdp {
       std::vector<std::string> paths ;
       for (auto f : powerFiles)
       {
-	char sysfsPath[512] ;
-	xclGetSysfsPath(handle, "xmc", f, sysfsPath, 512) ;
-	paths.push_back(sysfsPath) ;
+        char sysfsPath[512] ;
+        xclGetSysfsPath(handle, "xmc", f, sysfsPath, 512) ;
+        paths.push_back(sysfsPath) ;
       }
       filePaths.push_back(paths) ;
 
@@ -103,7 +103,7 @@ namespace xdp {
                                                   index) ;
       writers.push_back(writer) ;
       (db->getStaticInfo()).addOpenedFile(writer->getcurrentFileName(), 
-					  "XRT_POWER_PROFILE") ;
+                                          "XRT_POWER_PROFILE") ;
 
       // Move on to the next device
       xclClose(handle) ;
@@ -125,7 +125,7 @@ namespace xdp {
     {
       for (auto w : writers)
       {
-	w->write(false) ;
+        w->write(false) ;
       }
 
       db->unregisterPlugin(this) ;
@@ -141,27 +141,27 @@ namespace xdp {
       uint64_t index = 0 ;
       for (auto device : filePaths)
       {
-	std::vector<uint64_t> values ;
-	for (auto file : device)
-	{
-	  std::ifstream fs(file) ;
-	  if (!fs)
-	  {
-	    // When we tried to get the path to this file, we got a bad
-	    //  result (like empty string).  So all devices are aligned and
-	    //  have the same amount of information we'll just record this
-	    //  data element as 0.
-	    values.push_back(0) ;
-	    continue ;
-	  }
-	  std::string data ;
-	  std::getline(fs, data) ;
-	  uint64_t dp = data.empty() ? 0 : std::stoul(data) ;
-	  values.push_back(dp) ;
-	  fs.close() ;
-	}
-	(db->getDynamicInfo()).addPowerSample(index, timestamp, values) ;
-	++index ;	
+        std::vector<uint64_t> values ;
+        for (auto file : device)
+        {
+          std::ifstream fs(file) ;
+          if (!fs)
+          {
+            // When we tried to get the path to this file, we got a bad
+            //  result (like empty string).  So all devices are aligned and
+            //  have the same amount of information we'll just record this
+            //  data element as 0.
+            values.push_back(0) ;
+            continue ;
+          }
+          std::string data ;
+          std::getline(fs, data) ;
+          uint64_t dp = data.empty() ? 0 : std::stoul(data) ;
+          values.push_back(dp) ;
+          fs.close() ;
+        }
+        (db->getDynamicInfo()).addPowerSample(index, timestamp, values) ;
+        ++index ;	
       }
 
       std::this_thread::sleep_for(std::chrono::milliseconds(pollingInterval)) ;

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -27,8 +27,8 @@ namespace xdp {
   static UserEventsPlugin userEventsPluginInstance ;
 
   static void user_event_start_cb(unsigned int functionID,
-				  const char* label,
-				  const char* tooltip) 
+                                  const char* label,
+                                  const char* tooltip)
   {
     uint64_t timestamp = xrt_core::time_ns() ;
     VPDatabase* db = userEventsPluginInstance.getDatabase() ;
@@ -37,10 +37,10 @@ namespace xdp {
     const char* tooltipStr = (tooltip == nullptr) ? "" : tooltip ;
 
     VTFEvent* event = new UserRange(0, 
-				    static_cast<double>(timestamp), 
-				    true, // isStart
-				    (db->getDynamicInfo()).addString(labelStr),
-				    (db->getDynamicInfo()).addString(tooltipStr)) ;
+                                    static_cast<double>(timestamp),
+                                    true, // isStart
+                                    (db->getDynamicInfo()).addString(labelStr),
+                                    (db->getDynamicInfo()).addString(tooltipStr)) ;
     (db->getDynamicInfo()).addEvent(event) ;
     (db->getDynamicInfo()).markStart(functionID, event->getEventId()) ;
 
@@ -59,10 +59,10 @@ namespace xdp {
 
     uint64_t start = (db->getDynamicInfo()).matchingStart(functionID) ;
     VTFEvent* event = new UserRange(start, 
-				    static_cast<double>(timestamp), 
-				    false, // isStart
-				    0,
-				    0) ;
+                                    static_cast<double>(timestamp),
+                                    false, // isStart
+                                    0,
+                                    0) ;
 
     (db->getDynamicInfo()).addEvent(event) ;
 
@@ -92,9 +92,9 @@ namespace xdp {
 } // end namespace xdp
 
 extern "C" 
-void user_event_start_cb(unsigned int functionID, 
-			 const char* label, 
-			 const char* tooltip) 
+void user_event_start_cb(unsigned int functionID,
+                         const char* label,
+                         const char* tooltip)
 {
   xdp::user_event_start_cb(functionID, label, tooltip) ;
 }

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.h
@@ -20,9 +20,9 @@
 // These are the functions that are visible when the plugin is dynamically
 //  linked in.  XRT should call them directly
 extern "C"
-void user_event_start_cb(unsigned int functionID, 
-			 const char* label, 
-			 const char* tooltip) ;
+void user_event_start_cb(unsigned int functionID,
+                         const char* label,
+                         const char* tooltip) ;
 
 extern "C"
 void user_event_end_cb(unsigned int functionID) ;

--- a/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_plugin.cpp
@@ -36,7 +36,7 @@ namespace xdp {
       // We were destroyed before the database, so write the writers
       //  and unregister ourselves from the database
       for (auto w : writers) {
-	w->write(false) ;
+        w->write(false) ;
         db->getStaticInfo().addOpenedFile(w->getcurrentFileName(), "VP_TRACE");
       }
       db->unregisterPlugin(this) ;

--- a/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/vp_base/vp_base_plugin.cpp
@@ -55,7 +55,7 @@ namespace xdp {
       (db->getStaticInfo()).setApplicationStartTime(xrt_core::time_ns()) ;
       // If we are the first plugin, check to see if we should add xocl.log
       if (xrt_core::config::get_xocl_debug()) {
-	std::string logFileName =
+        std::string logFileName =
           xrt_core::config::detail::get_string_value("Debug.xocl_log",
                                                      "xocl.log") ;
         db->getStaticInfo().addOpenedFile(logFileName, "XOCL_EVENTS") ;

--- a/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_profile/aie_writer.cpp
@@ -23,7 +23,7 @@
 namespace xdp {
 
   AIEProfilingWriter::AIEProfilingWriter(const char* fileName,
-					     const char* deviceName, uint64_t deviceIndex) :
+                                         const char* deviceName, uint64_t deviceIndex) :
     VPWriter(fileName),
     mDeviceName(deviceName),
     mDeviceIndex(deviceIndex)

--- a/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.cpp
@@ -29,10 +29,10 @@ namespace xdp {
 
 
   HALDeviceTraceWriter::HALDeviceTraceWriter(const char* filename, uint64_t devId, 
-					     const std::string& version,
-					     const std::string& creationTime,
-					     const std::string& xrtV,
-					     const std::string& toolV)
+                                             const std::string& version,
+                                             const std::string& creationTime,
+                                             const std::string& xrtV,
+                                             const std::string& toolV)
       : VPTraceWriter(filename, version, creationTime, 9 /* ns */),
         xrtVersion(xrtV),
         toolVersion(toolV),
@@ -76,8 +76,8 @@ namespace xdp {
       fout << "Group_Start,KDMA" << std::endl ;
       for (unsigned int i = 0 ; i < numKDMA ; ++i)
       {
-	      fout << "Dynamic_Row," << ++rowCount << ",Read, ,KERNEL_READ" << std::endl;
-	      fout << "Dynamic_Row," << ++rowCount << ",Write, ,KERNEL_WRITE" << std::endl;
+              fout << "Dynamic_Row," << ++rowCount << ",Read, ,KERNEL_READ" << std::endl;
+              fout << "Dynamic_Row," << ++rowCount << ",Write, ,KERNEL_WRITE" << std::endl;
       }
       fout << "Group_End,KDMA" << std::endl ;
 #endif

--- a/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_device_trace_writer.h
@@ -50,9 +50,9 @@ namespace xdp {
 
   public:
     HALDeviceTraceWriter(const char* filename, uint64_t deviceId, const std::string& version,
-			 const std::string& creationTime,
-			 const std::string& xrtV,
-			 const std::string& toolV);
+                         const std::string& creationTime,
+                         const std::string& xrtV,
+                         const std::string& toolV);
 
     ~HALDeviceTraceWriter() ;
 

--- a/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.cpp
@@ -19,10 +19,10 @@
 namespace xdp {
 
   HALHostTraceWriter::HALHostTraceWriter(const char* filename, 
-					 const std::string& version,
-					 const std::string& creationTime,
-					 const std::string& xrtV,
-					 const std::string& toolV)
+                                         const std::string& version,
+                                         const std::string& creationTime,
+                                         const std::string& xrtV,
+                                         const std::string& toolV)
     : VPTraceWriter(filename, version, creationTime, 6 /* us */),
       xrtVersion(xrtV),
       toolVersion(toolV)
@@ -78,12 +78,12 @@ namespace xdp {
     fout << "EVENTS" << std::endl ;
     std::vector<VTFEvent*> HALAPIEvents = 
       (db->getDynamicInfo()).filterEvents( [](VTFEvent* e)
-					   {
-					     return e->isHostEvent()  &&
-					            !e->isOpenCLAPI() &&
-					            !e->isLOPHostEvent() ;
-					   }
-					 ) ;
+                                           {
+                                             return e->isHostEvent()  &&
+                                                    !e->isOpenCLAPI() &&
+                                                    !e->isLOPHostEvent() ;
+                                           }
+                                         ) ;
     for (auto e : HALAPIEvents)
     {
       VTFEventType eventType = e->getEventType();

--- a/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/hal/hal_host_trace_writer.h
@@ -47,9 +47,9 @@ namespace xdp {
 
   public:
     HALHostTraceWriter(const char* filename, const std::string& version, 
-		       const std::string& creationTime, 
-		       const std::string& xrtV,
-		       const std::string& toolV);
+                       const std::string& creationTime, 
+                       const std::string& xrtV,
+                       const std::string& toolV);
     ~HALHostTraceWriter() ;
 
     virtual bool write(bool openNewFile) ;

--- a/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/opencl/opencl_trace_writer.cpp
@@ -93,8 +93,8 @@ namespace xdp {
          << ",Write,Write data transfer from host to global memory"
          << std::endl ;
     fout << "Dynamic_Row," << copyBucket
-	 << ",Copy,Copy data transfers from global memory to global memory"
-	 << std::endl ;
+         << ",Copy,Copy data transfers from global memory to global memory"
+         << std::endl ;
     fout << "Group_End,Data Transfer" << std::endl ;
     fout << "Group_Start,Kernel Enqueues" << std::endl ;
     //fout << "Dynamic_Row_Summary," << enqueueSummaryBucket 
@@ -141,16 +141,16 @@ namespace xdp {
         bucket = writeBucket ;
       }
       else if (e->isCopyBuffer()) {
-	bucket = copyBucket ;
+        bucket = copyBucket ;
       }
       else if (e->isKernelEnqueue())
       {
-	// Construct the name
-	KernelEnqueue* ke = dynamic_cast<KernelEnqueue*>(e.get()) ;
-	if (ke != nullptr)
-	  bucket = enqueueBuckets[ke->getIdentifier()] ;
-	else
-	  bucket = generalAPIBucket; // Should never happen
+        // Construct the name
+        KernelEnqueue* ke = dynamic_cast<KernelEnqueue*>(e.get()) ;
+        if (ke != nullptr)
+          bucket = enqueueBuckets[ke->getIdentifier()] ;
+        else
+          bucket = generalAPIBucket; // Should never happen
       }
       e->dump(fout, bucket) ;
     }

--- a/src/runtime_src/xdp/profile/writer/power/power_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/power/power_writer.cpp
@@ -22,8 +22,8 @@
 namespace xdp {
 
   PowerProfilingWriter::PowerProfilingWriter(const char* filename,
-					     const char* d,
-					     uint64_t index) :
+                                             const char* d,
+                                             uint64_t index) :
     VPWriter(filename), deviceName(d), deviceIndex(index)
   {
   }
@@ -37,31 +37,31 @@ namespace xdp {
     // Write header
     fout << "Target device: " << deviceName << std::endl ;
     fout << "timestamp"    << ","
-	 << "12v_aux_curr" << ","
-	 << "12v_aux_vol"  << ","
-	 << "12v_pex_curr" << ","
-	 << "12v_pex_vol"  << ","
-	 << "vccint_curr"  << ","
-	 << "vccint_vol"   << ","
-	 << "3v3_pex_curr" << ","
-	 << "3v3_pex_vol"  << ","
-	 << "cage_temp0"   << ","
-	 << "cage_temp1"   << ","
-	 << "cage_temp2"   << ","
-	 << "cage_temp3"   << ","
-	 << "dimm_temp0"   << ","
-	 << "dimm_temp1"   << ","
-	 << "dimm_temp2"   << ","
-	 << "dimm_temp3"   << ","
-	 << "fan_temp"     << ","
-	 << "fpga_temp"    << ","
-	 << "hbm_temp"     << ","
-	 << "se98_temp0"   << ","
-	 << "se98_temp1"   << ","
-	 << "se98_temp2"   << ","
-	 << "vccint_temp"  << ","
-	 << "fan_rpm"
-	 << std::endl;
+         << "12v_aux_curr" << ","
+         << "12v_aux_vol"  << ","
+         << "12v_pex_curr" << ","
+         << "12v_pex_vol"  << ","
+         << "vccint_curr"  << ","
+         << "vccint_vol"   << ","
+         << "3v3_pex_curr" << ","
+         << "3v3_pex_vol"  << ","
+         << "cage_temp0"   << ","
+         << "cage_temp1"   << ","
+         << "cage_temp2"   << ","
+         << "cage_temp3"   << ","
+         << "dimm_temp0"   << ","
+         << "dimm_temp1"   << ","
+         << "dimm_temp2"   << ","
+         << "dimm_temp3"   << ","
+         << "fan_temp"     << ","
+         << "fpga_temp"    << ","
+         << "hbm_temp"     << ","
+         << "se98_temp0"   << ","
+         << "se98_temp1"   << ","
+         << "se98_temp2"   << ","
+         << "vccint_temp"  << ","
+         << "fan_rpm"
+         << std::endl;
 
     // Write all of the data elements
     std::vector<VPDynamicDatabase::CounterSample> samples = 
@@ -72,7 +72,7 @@ namespace xdp {
       fout << sample.first << "," ; // Timestamp
       for (auto value : sample.second)
       {
-	fout << value << "," ;
+        fout << value << "," ;
       }
       fout << std::endl ;
     }

--- a/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/user/user_events_trace_writer.cpp
@@ -25,9 +25,9 @@ namespace xdp {
 
   UserEventsTraceWriter::UserEventsTraceWriter(const char* filename) :
     VPTraceWriter(filename,
-		  "1.1",
-		  getCurrentDateTime(),
-		  9 /* ns */),
+                  "1.1",
+                  getCurrentDateTime(),
+                  9 /* ns */),
     bucketId(1)
   {
   }
@@ -47,7 +47,7 @@ namespace xdp {
     fout << "STRUCTURE" << std::endl ;
     fout << "Group_Start,User and Internal Events" << std::endl ;
     fout << "Dynamic_Row," << bucketId << ",General,User Events from APIs and Internally Generated Events"
-	 << std::endl ;
+         << std::endl ;
     fout << "Group_End,User and Internal Events" << std::endl ;
   }
 
@@ -62,10 +62,10 @@ namespace xdp {
     fout << "EVENTS" << std::endl ;
     std::vector<VTFEvent*> userEvents = 
       (db->getDynamicInfo()).filterEvents( [](VTFEvent* e)
-					   {
-					     return e->isUserEvent() ;
-					   }
-					 ) ;
+                                           {
+                                             return e->isUserEvent() ;
+                                           }
+                                         ) ;
     for (auto e : userEvents)
     {
       e->dump(fout, bucketId) ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/guidance_rules.cpp
@@ -76,20 +76,20 @@ namespace {
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
           for (auto cu : xclbin->pl.cus) {
-	    std::string cuName = cu.second->getName();
-	    std::vector<std::pair<std::string, xdp::TimeStatistics>> cuCalls =
+            std::string cuName = cu.second->getName();
+            std::vector<std::pair<std::string, xdp::TimeStatistics>> cuCalls =
               db->getStats().getComputeUnitExecutionStats(cuName);
             uint64_t execCount = 0;
             for (auto cuCall : cuCalls) {
               execCount += cuCall.second.numExecutions;
-	    }
+            }
             if (execCount != 0) {
               fout << "CU_CALLS," << device->getUniqueDeviceName() << "|"
                    << cu.second->getName() << ","
                    << execCount << ",\n";
-	    }
-	  }
-	}
+            }
+          }
+        }
       }
     }
   }
@@ -175,13 +175,13 @@ namespace {
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
           for (auto memory : xclbin->pl.memoryInfo) {
-	    std::string memName = memory.second->name ;
+            std::string memName = memory.second->name ;
             if (memName.rfind("bank", 0) == 0)
               memName = "DDR[" + memName.substr(4,4) + "]" ;
 
             fout << "MEMORY_USAGE," << device->getUniqueDeviceName() << "|"
                  << memName << "," << memory.second->used << ",\n" ;
-	  }
+          }
         }
       }
     }
@@ -202,10 +202,10 @@ namespace {
             if (memory.second->name.find("PLRAM") != std::string::npos) {
               hasPLRAM = true ;
               break ;
-	    }
-	  }
+            }
+          }
           if (hasPLRAM) break ;
-	}
+        }
         if (hasPLRAM) break ;
       }
     }
@@ -235,10 +235,10 @@ namespace {
             if (memory.second->name.find("HBM") != std::string::npos) {
               hasHBM = true ;
               break ;
-	    }
-	  }
+            }
+          }
           if (hasHBM) break ;
-	}
+        }
         if (hasHBM) break ;
       }
     }
@@ -264,7 +264,7 @@ namespace {
     else {
       auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
       for (auto device : deviceInfos) {
-	std::string deviceName = device->deviceName ;
+        std::string deviceName = device->deviceName ;
         if (deviceName.find("xilinx_u200_xdma") != std::string::npos ||
             deviceName.find("xilinx_vcu1525_xdma") != std::string::npos) {
           hasKDMA = true ;
@@ -293,7 +293,7 @@ namespace {
     else {
       auto deviceInfos = db->getStaticInfo().getDeviceInfos() ;
       for (auto device : deviceInfos) {
-	std::string deviceName = device->deviceName ;
+        std::string deviceName = device->deviceName ;
         if (deviceName.find("xilinx_u200_xdma")    != std::string::npos ||
             deviceName.find("xilinx_u250_xdma")    != std::string::npos ||
             deviceName.find("samsung")             != std::string::npos ||
@@ -329,24 +329,24 @@ namespace {
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
           for (auto cu : xclbin->pl.cus) {
-	    std::vector<uint32_t>* aimIds = cu.second->getAIMs() ;
-	    std::vector<uint32_t>* asmIds = cu.second->getASMs() ;
+            std::vector<uint32_t>* aimIds = cu.second->getAIMs() ;
+            std::vector<uint32_t>* asmIds = cu.second->getASMs() ;
 
             for (auto aim : (*aimIds)) {
-	      xdp::Monitor* monitor =
+              xdp::Monitor* monitor =
                 db->getStaticInfo().getAIMonitor(device->deviceId, xclbin, aim);
               fout << "PORT_BIT_WIDTH," << cu.second->getName() << "/"
                    << monitor->port << "," << monitor->portWidth << ",\n" ;
             }
 
             for (auto asmId : (*asmIds)) {
-	      xdp::Monitor* monitor =
+              xdp::Monitor* monitor =
                 db->getStaticInfo().getASMonitor(device->deviceId,xclbin,asmId);
               fout << "PORT_BIT_WIDTH," << cu.second->getName() << "/"
                    << monitor->port << "," << monitor->portWidth << ",\n" ;
             }
-	  }
-	}
+          }
+        }
       }
     }
   }
@@ -363,15 +363,15 @@ namespace {
       for (auto device : deviceInfos) {
         for (auto xclbin : device->loadedXclbins) {
           for (auto cu : xclbin->pl.cus) {
-	    std::string kernelName = cu.second->getKernelName() ;
+            std::string kernelName = cu.second->getKernelName() ;
             if (kernelCounts.find(kernelName) == kernelCounts.end()) {
               kernelCounts[kernelName] = 1 ;
-	    }
+            }
             else {
               kernelCounts[kernelName] += 1 ;
-	    }
-	  }
-	}
+            }
+          }
+        }
       }
     }
 
@@ -414,8 +414,8 @@ namespace {
           if (xclbin->pl.usesTs2mm) {
             memType = "TS2MM" ;
             break ;
-	  }
-	}
+          }
+        }
       }
     }
     fout << "TRACE_MEMORY,all," << memType << ",\n" ;
@@ -461,8 +461,8 @@ namespace {
             // To match old flow and tools, print PLRAM_SIZE_BYTES for
             //  first match only.
             break ;
-	  }
-	}
+          }
+        }
         if (done) break ;
       }
       if (done) break ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -332,13 +332,13 @@ namespace xdp {
     fout << "Target platform: " << "Xilinx" << "\n" ;
     fout << "Tool version: " << getToolVersion() << "\n" ;
     fout << "XRT build version: " 
-	 << (xrtInfo.get<std::string>("version", "N/A")) << "\n" ;
+         << (xrtInfo.get<std::string>("version", "N/A")) << "\n" ;
     fout << "Build version branch: " 
-	 << (xrtInfo.get<std::string>("branch", "N/A")) << "\n" ;
+         << (xrtInfo.get<std::string>("branch", "N/A")) << "\n" ;
     fout << "Build version hash: "
-	 << (xrtInfo.get<std::string>("hash", "N/A")) << "\n" ;
+         << (xrtInfo.get<std::string>("hash", "N/A")) << "\n" ;
     fout << "Build version date: "
-	 << (xrtInfo.get<std::string>("date", "N/A")) << "\n" ;
+         << (xrtInfo.get<std::string>("date", "N/A")) << "\n" ;
 
     fout << "Target devices: " ;
     if (getFlowMode() == SW_EMU) {
@@ -348,8 +348,8 @@ namespace xdp {
       std::vector<std::string> deviceNames =
         (db->getStaticInfo()).getDeviceNames() ;
       for (unsigned int i = 0 ; i < deviceNames.size() ; ++i) {
-	if (i != 0) fout << ", " ;
-	fout << deviceNames[i] ;
+        if (i != 0) fout << ", " ;
+        fout << deviceNames[i] ;
       }
       fout << "\n" ;
     }
@@ -372,13 +372,13 @@ namespace xdp {
     // For each function call, across all of the threads, 
     //  consolidate all the information into what we need
     std::map<std::string,
-	     std::tuple<uint64_t,
-			double,
-			double,
-			double> > rows ;
+             std::tuple<uint64_t,
+                        double,
+                        double,
+                        double> > rows ;
 
     std::map<std::pair<std::string, std::thread::id>,
-	     std::vector<std::pair<double, double>>> callCount =
+             std::vector<std::pair<double, double>>> callCount =
       (db->getStats()).getCallCount() ;
     
     for (auto call : callCount) {
@@ -403,34 +403,34 @@ namespace xdp {
       std::vector<std::pair<double, double>> timesOfCalls = call.second ;
 
       if (rows.find(APIName) == rows.end()) {
-	std::tuple<uint64_t, double, double, double> blank = 
-	  std::make_tuple<uint64_t, double, double, double>(0,0,std::numeric_limits<double>::max(),0) ;
+        std::tuple<uint64_t, double, double, double> blank = 
+          std::make_tuple<uint64_t, double, double, double>(0,0,std::numeric_limits<double>::max(),0) ;
 
-	rows[APIName] = blank ;
+        rows[APIName] = blank ;
       }
 
       for (auto executionTime : timesOfCalls) {
-	auto timeTaken = executionTime.second - executionTime.first ;
+        auto timeTaken = executionTime.second - executionTime.first ;
 
-	++(std::get<0>(rows[APIName])) ;
-	std::get<1>(rows[APIName]) += timeTaken ;
-	if (timeTaken < std::get<2>(rows[APIName]))
-	  std::get<2>(rows[APIName]) = timeTaken ;
-	if (timeTaken > std::get<3>(rows[APIName]))
-	  std::get<3>(rows[APIName]) = timeTaken ;
+        ++(std::get<0>(rows[APIName])) ;
+        std::get<1>(rows[APIName]) += timeTaken ;
+        if (timeTaken < std::get<2>(rows[APIName]))
+          std::get<2>(rows[APIName]) = timeTaken ;
+        if (timeTaken > std::get<3>(rows[APIName]))
+          std::get<3>(rows[APIName]) = timeTaken ;
       }
     }
 
     for (auto row : rows) {
       auto averageTime = 
-	(double)(std::get<1>(row.second)) / (double)(std::get<0>(row.second)) ;
+        (double)(std::get<1>(row.second)) / (double)(std::get<0>(row.second)) ;
       if (type != OPENCL) fout << "ENTRY:" ;
       fout << row.first                      << ","     // API Name
-	   << std::get<0>(row.second)        << ","     // Number of calls
-	   << (std::get<1>(row.second)/one_million) << ","     // Total time
-	   << (std::get<2>(row.second)/one_million) << ","     // Minimum time
-	   << (averageTime/one_million)             << ","     // Average time
-	   << (std::get<3>(row.second)/one_million) << ",\n" ; // Maximum time
+           << std::get<0>(row.second)        << ","     // Number of calls
+           << (std::get<1>(row.second)/one_million) << ","     // Total time
+           << (std::get<2>(row.second)/one_million) << ","     // Minimum time
+           << (averageTime/one_million)             << ","     // Average time
+           << (std::get<3>(row.second)/one_million) << ",\n" ; // Maximum time
     }
   }
 
@@ -440,7 +440,7 @@ namespace xdp {
     fout << "OpenCL API Calls\n" ;
     // Columns
     fout << "API Name,Number Of Calls,Total Time (ms),Minimum Time (ms),"
-	 << "Average Time (ms),Maximum Time (ms),\n" ;
+         << "Average Time (ms),Maximum Time (ms),\n" ;
     writeAPICalls(OPENCL) ;
   }
 
@@ -534,15 +534,15 @@ namespace xdp {
 
     // Column headers
     fout << "Kernel,Number Of Enqueues,Total Time (ms),Minimum Time (ms),"
-	 << "Average Time (ms),Maximum Time (ms),\n" ; 
+         << "Average Time (ms),Maximum Time (ms),\n" ; 
 
     for (auto execution : kernelExecutions) {
       fout << execution.first                         << ","
-	   << (execution.second).numExecutions        << ","
-	   << ((execution.second).totalTime / one_million)   << ","
-	   << ((execution.second).minTime / one_million)     << ","
-	   << ((execution.second).averageTime / one_million) << ","
-	   << ((execution.second).maxTime / one_million)     << ",\n" ;
+           << (execution.second).numExecutions        << ","
+           << ((execution.second).totalTime / one_million)   << ","
+           << ((execution.second).minTime / one_million)     << ","
+           << ((execution.second).averageTime / one_million) << ","
+           << ((execution.second).maxTime / one_million)     << ",\n" ;
     }
   }
 
@@ -561,21 +561,21 @@ namespace xdp {
 
     // Columns
     fout << "Kernel Instance Address,Kernel,Context ID,Command Queue ID,"
-	 << "Device,Start Time (ms),Duration (ms),Global Work Size,"
-	 << "Local Work Size,\n" ;
+         << "Device,Start Time (ms),Duration (ms),Global Work Size,"
+         << "Local Work Size,\n" ;
 
     for (std::list<KernelExecutionStats>::iterator iter = (db->getStats()).getTopKernelExecutions().begin() ;
-	 iter != (db->getStats()).getTopKernelExecutions().end() ;
-	 ++iter) {
+         iter != (db->getStats()).getTopKernelExecutions().end() ;
+         ++iter) {
       fout << (*iter).kernelInstanceAddress << ","
-	   << (*iter).kernelName << ","
-	   << (*iter).contextId << ","
-	   << (*iter).commandQueueId << "," 
-	   << (*iter).deviceName << ","
-	   << (double)((*iter).startTime) / one_million << ","
-	   << (double)((*iter).duration) / one_million << ","
-	   << (*iter).globalWorkSize << ","
-	   << (*iter).localWorkSize << ",\n" ;
+           << (*iter).kernelName << ","
+           << (*iter).contextId << ","
+           << (*iter).commandQueueId << "," 
+           << (*iter).deviceName << ","
+           << (double)((*iter).startTime) / one_million << ","
+           << (double)((*iter).duration) / one_million << ","
+           << (*iter).globalWorkSize << ","
+           << (*iter).localWorkSize << ",\n" ;
     }
   }
 
@@ -589,27 +589,27 @@ namespace xdp {
 
     // Columns
     fout << "Buffer Address,Context ID,Command Queue ID,Start Time (ms),"
-	 << "Duration (ms),Buffer Size (KB),Writing Rate(MB/s),\n" ;
+         << "Duration (ms),Buffer Size (KB),Writing Rate(MB/s),\n" ;
 
     for (std::list<BufferTransferStats>::iterator iter = (db->getStats()).getTopHostWrites().begin() ;
-	 iter != (db->getStats()).getTopHostWrites().end() ;
-	 ++iter) {
+         iter != (db->getStats()).getTopHostWrites().end() ;
+         ++iter) {
       double durationMS = (double)((*iter).duration) / one_million ;
       double rate = ((double)((*iter).size) / one_thousand) * durationMS ;
 
       fout << (*iter).address << ","
-	   << (*iter).contextId << ","
-	   << (*iter).commandQueueId << ","
-	   << (double)((*iter).startTime) / one_million << "," ;
+           << (*iter).contextId << ","
+           << (*iter).commandQueueId << ","
+           << (double)((*iter).startTime) / one_million << "," ;
       if (getFlowMode() == HW)
-	fout << durationMS << "," ;
+        fout << durationMS << "," ;
       else
-	fout << "N/A," ;
+        fout << "N/A," ;
       fout << (double)((*iter).size) / one_thousand << "," ;
       if (getFlowMode() == HW)
-	fout << rate << ",\n" ;
+        fout << rate << ",\n" ;
       else
-	fout << "N/A" << ",\n" ;
+        fout << "N/A" << ",\n" ;
     }
   }
 
@@ -623,34 +623,34 @@ namespace xdp {
 
     // Columns
     fout << "Buffer Address,Context ID,Command Queue ID,Start Time (ms),"
-	 << "Duration (ms),Buffer Size (KB),Reading Rate(MB/s),\n" ;
+         << "Duration (ms),Buffer Size (KB),Reading Rate(MB/s),\n" ;
 
     for (std::list<BufferTransferStats>::iterator iter = (db->getStats()).getTopHostReads().begin() ;
-	 iter != (db->getStats()).getTopHostReads().end() ;
-	 ++iter) {
+         iter != (db->getStats()).getTopHostReads().end() ;
+         ++iter) {
       double durationMS = (double)((*iter).duration) / one_million ;
       double rate = ((double)((*iter).size) / one_thousand) * durationMS ;
 
       fout << (*iter).address << "," 
-	   << (*iter).contextId << ","
-	   << (*iter).commandQueueId << ","
-	   << (double)((*iter).startTime) / one_million << "," ;
+           << (*iter).contextId << ","
+           << (*iter).commandQueueId << ","
+           << (double)((*iter).startTime) / one_million << "," ;
       if (getFlowMode() == HW)
-	fout << durationMS << "," ;
+        fout << durationMS << "," ;
       else
-	fout << "N/A," ;
+        fout << "N/A," ;
       fout << (double)((*iter).size) / one_thousand << "," ;
       if (getFlowMode() == HW)
-	fout << rate << ",\n" ;
+        fout << rate << ",\n" ;
       else
-	fout << "N/A" << ",\n" ;
+        fout << "N/A" << ",\n" ;
     }
   }
 
   void SummaryWriter::writeSoftwareEmulationComputeUnitUtilization()
   {
     std::map<std::tuple<std::string, std::string, std::string>,
-	     TimeStatistics> cuStats = 
+             TimeStatistics> cuStats = 
       (db->getStats()).getComputeUnitExecutionStats() ;
 
     if (cuStats.size() == 0)
@@ -661,9 +661,9 @@ namespace xdp {
 
     // Column headers
     fout << "Device,Compute Unit,Kernel,Global Work Size,Local Work Size,"
-	 << "Number Of Calls,Dataflow Execution,Max Overlapping Executions,"
-	 << "Dataflow Acceleration,Total Time (ms),Minimum Time (ms),"
-	 << "Average Time (ms),Maximum Time (ms),Clock Frequency (MHz),\n" ;
+         << "Number Of Calls,Dataflow Execution,Max Overlapping Executions,"
+         << "Dataflow Acceleration,Total Time (ms),Minimum Time (ms),"
+         << "Average Time (ms),Maximum Time (ms),Clock Frequency (MHz),\n" ;
 
     for (auto stat : cuStats) {
       std::string cuName          = (std::get<0>(stat.first)) ;
@@ -681,26 +681,26 @@ namespace xdp {
       std::string kernelName = cuName ;
       auto usPosition = kernelName.find("_") ;
       if (usPosition != std::string::npos) {
-	kernelName = kernelName.substr(0, usPosition - 1) ;
+        kernelName = kernelName.substr(0, usPosition - 1) ;
       }
 
       double speedup = (averageTime*execCount)/totalTime ;
       std::string speedup_string = std::to_string(speedup) + "x" ;
 
       fout << (db->getStaticInfo()).getSoftwareEmulationDeviceName() << ","
-	   << cuName                              << ","
-	   << (cuName.substr(0, cuName.size()-2)) << "," 
-	   << globalWorkGroup                     << "," 
-	   << localWorkGroup                      << ","
-	   << execCount                           << ","
-	   << "No"                                << ","
-	   << 0                                   << "," // TODO?
-	   << speedup_string                      << ","
-	   << (totalTime / one_million)                  << ","
-	   << (minTime / one_million)                    << ","
-	   << (averageTime / one_million)                << ","
-	   << (maxTime / one_million)                    << ","
-	   << 300                                 << ",\n" ;
+           << cuName                              << ","
+           << (cuName.substr(0, cuName.size()-2)) << "," 
+           << globalWorkGroup                     << "," 
+           << localWorkGroup                      << ","
+           << execCount                           << ","
+           << "No"                                << ","
+           << 0                                   << "," // TODO?
+           << speedup_string                      << ","
+           << (totalTime / one_million)                  << ","
+           << (minTime / one_million)                    << ","
+           << (averageTime / one_million)                << ","
+           << (maxTime / one_million)                    << ","
+           << 300                                 << ",\n" ;
     }
   }
 
@@ -720,20 +720,20 @@ namespace xdp {
 
     // Column headers
     fout << "Device"                     << ","
-	 << "Compute Unit"               << ","
-	 << "Kernel"                     << ","
-	 << "Global Work Size"           << ","
-	 << "Local Work Size"            << ","
-	 << "Number Of Calls"            << ","
-	 << "Dataflow Execution"         << ","
-	 << "Max Overlapping Executions" << ","
-	 << "Dataflow Acceleration"      << ","
-	 << "Total Time (ms)"            << ","
-	 << "Minimum Time (ms)"          << ","
-	 << "Average Time (ms)"          << ","
-	 << "Maximum Time (ms)"          << ","
-	 << "Clock Frequency (MHz)"      << "," 
-	 << std::endl ;
+         << "Compute Unit"               << ","
+         << "Kernel"                     << ","
+         << "Global Work Size"           << ","
+         << "Local Work Size"            << ","
+         << "Number Of Calls"            << ","
+         << "Dataflow Execution"         << ","
+         << "Max Overlapping Executions" << ","
+         << "Dataflow Acceleration"      << ","
+         << "Total Time (ms)"            << ","
+         << "Minimum Time (ms)"          << ","
+         << "Average Time (ms)"          << ","
+         << "Maximum Time (ms)"          << ","
+         << "Clock Frequency (MHz)"      << "," 
+         << std::endl ;
 
     // The static portion of this output has to come from the
     //  static database.  The counter portion has to come from the
@@ -748,13 +748,13 @@ namespace xdp {
 
       // For every xclbin that was loaded on this device
       for (auto xclbin : device->loadedXclbins) {
-	xclCounterResults values =
-	  (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
+        xclCounterResults values =
+          (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
 
-	// For every compute unit in the xclbin
-	for (auto cuInfo : xclbin->pl.cus)
-	{
-	  uint64_t amSlotID = (uint64_t)((cuInfo.second)->getAccelMon()) ;
+        // For every compute unit in the xclbin
+        for (auto cuInfo : xclbin->pl.cus)
+        {
+          uint64_t amSlotID = (uint64_t)((cuInfo.second)->getAccelMon()) ;
 
           // Stats don't make sense if runtime or executions = 0
           if ((values.CuBusyCycles[amSlotID] == 0) ||
@@ -762,54 +762,54 @@ namespace xdp {
             continue;
 
           // This info is the same for every execution call
-	  std::string cuName = (cuInfo.second)->getName() ;
-	  std::string kernelName = (cuInfo.second)->getKernelName() ;
-	  std::string cuLocalDimensions = (cuInfo.second)->getDim() ;
-	  std::string dataflowEnabled = 
-	    (cuInfo.second)->getDataflowEnabled() ? "Yes" : "No" ;
-	  
-	  // For each compute unit, we can have executions from the host
-	  //  with different global work sizes.  Determine the number of 
-	  //  execution types here
-	  std::vector<std::pair<std::string, TimeStatistics>> cuCalls = 
-	    (db->getStats()).getComputeUnitExecutionStats(cuName) ;
+          std::string cuName = (cuInfo.second)->getName() ;
+          std::string kernelName = (cuInfo.second)->getKernelName() ;
+          std::string cuLocalDimensions = (cuInfo.second)->getDim() ;
+          std::string dataflowEnabled = 
+            (cuInfo.second)->getDataflowEnabled() ? "Yes" : "No" ;
+          
+          // For each compute unit, we can have executions from the host
+          //  with different global work sizes.  Determine the number of 
+          //  execution types here
+          std::vector<std::pair<std::string, TimeStatistics>> cuCalls = 
+            (db->getStats()).getComputeUnitExecutionStats(cuName) ;
 
-	  for (auto cuCall : cuCalls)
-	  {
-	    std::string globalWorkDimensions = cuCall.first ;
+          for (auto cuCall : cuCalls)
+          {
+            std::string globalWorkDimensions = cuCall.first ;
 
-	    auto kernelClockMHz = xclbin->pl.clockRatePLMHz ;
-	    double deviceCyclesMsec = (double)(kernelClockMHz) * one_thousand ;
+            auto kernelClockMHz = xclbin->pl.clockRatePLMHz ;
+            double deviceCyclesMsec = (double)(kernelClockMHz) * one_thousand ;
 
-	    double cuRunTimeMsec =
-	      (double)(values.CuBusyCycles[amSlotID]) / deviceCyclesMsec ;
-	    double cuRunTimeAvgMsec = (double)(values.CuExecCycles[amSlotID]) / deviceCyclesMsec / (double)(values.CuExecCount[amSlotID]) ;
-	    double cuMaxExecCyclesMsec = (double)(values.CuMaxExecCycles[amSlotID]) / deviceCyclesMsec ;
-	    double cuMinExecCyclesMsec = (double)(values.CuMinExecCycles[amSlotID]) / deviceCyclesMsec ;
+            double cuRunTimeMsec =
+              (double)(values.CuBusyCycles[amSlotID]) / deviceCyclesMsec ;
+            double cuRunTimeAvgMsec = (double)(values.CuExecCycles[amSlotID]) / deviceCyclesMsec / (double)(values.CuExecCount[amSlotID]) ;
+            double cuMaxExecCyclesMsec = (double)(values.CuMaxExecCycles[amSlotID]) / deviceCyclesMsec ;
+            double cuMinExecCyclesMsec = (double)(values.CuMinExecCycles[amSlotID]) / deviceCyclesMsec ;
 
-	    double speedup = (cuRunTimeAvgMsec * (double)(values.CuExecCount[amSlotID])) / cuRunTimeMsec ;
+            double speedup = (cuRunTimeAvgMsec * (double)(values.CuExecCount[amSlotID])) / cuRunTimeMsec ;
 
-	    //double speedup =
-	    // (averageTime*(values.CuExecCount[cuIndex]))/totalTime ;
-	    std::string speedup_string = std::to_string(speedup) + "x" ;
+            //double speedup =
+            // (averageTime*(values.CuExecCount[cuIndex]))/totalTime ;
+            std::string speedup_string = std::to_string(speedup) + "x" ;
 
-	    fout << device->getUniqueDeviceName() << "," 
-		 << cuName << ","
-		 << kernelName << ","
-		 << globalWorkDimensions << ","
-		 << cuLocalDimensions << ","
-		 << values.CuExecCount[amSlotID] << ","
-		 << dataflowEnabled << ","
-		 << values.CuMaxParallelIter[amSlotID] << ","
-		 << speedup_string << ","
-		 << cuRunTimeMsec << "," //<< (totalTime / one_million) << ","
-		 << cuMinExecCyclesMsec << "," //<< (minTime / one_million) << ","
-		 << cuRunTimeAvgMsec << "," //<< (averageTime /one_million) << ","
-		 << cuMaxExecCyclesMsec << "," //<< (maxTime / one_million) << "," 
-		 << (xclbin->pl.clockRatePLMHz) << ","
-		 << std::endl ;
-	  }
-	}
+            fout << device->getUniqueDeviceName() << "," 
+                 << cuName << ","
+                 << kernelName << ","
+                 << globalWorkDimensions << ","
+                 << cuLocalDimensions << ","
+                 << values.CuExecCount[amSlotID] << ","
+                 << dataflowEnabled << ","
+                 << values.CuMaxParallelIter[amSlotID] << ","
+                 << speedup_string << ","
+                 << cuRunTimeMsec << "," //<< (totalTime / one_million) << ","
+                 << cuMinExecCyclesMsec << "," //<< (minTime / one_million) << ","
+                 << cuRunTimeAvgMsec << "," //<< (averageTime /one_million) << ","
+                 << cuMaxExecCyclesMsec << "," //<< (maxTime / one_million) << "," 
+                 << (xclbin->pl.clockRatePLMHz) << ","
+                 << std::endl ;
+          }
+        }
       }
     }
   }
@@ -823,11 +823,11 @@ namespace xdp {
 
     // Column headers
     fout << "Compute Unit"                      << ","
-	 << "Execution Count"                   << ","
-	 << "Running Time (ms)"                 << ","
-	 << "Intra-Kernel Dataflow Stalls (ms)" << ","
-	 << "External Memory Stalls (ms)"       << ","
-	 << "Inter-Kernel Pipe Stalls (ms)"     << "," << std::endl ;
+         << "Execution Count"                   << ","
+         << "Running Time (ms)"                 << ","
+         << "Intra-Kernel Dataflow Stalls (ms)" << ","
+         << "External Memory Stalls (ms)"       << ","
+         << "Inter-Kernel Pipe Stalls (ms)"     << "," << std::endl ;
 
     std::vector<DeviceInfo*> infos = (db->getStaticInfo()).getDeviceInfos() ;
 
@@ -835,20 +835,20 @@ namespace xdp {
     {
       for (auto xclbin : device->loadedXclbins)
       {
-	xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
-	uint64_t j = 0 ;      
-	for (auto cu : (xclbin->pl.cus))
-	{
+        xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+        uint64_t j = 0 ;      
+        for (auto cu : (xclbin->pl.cus))
+        {
           double deviceCyclesMsec = (double)(xclbin->pl.clockRatePLMHz * one_thousand);
 
-	  fout << (cu.second)->getName()     << "," 
-	       << values.CuExecCount[j]      << ","
-	       << (values.CuExecCycles[j] / deviceCyclesMsec)     << ","
-	       << (values.CuStallIntCycles[j] / deviceCyclesMsec) << ","
-	       << (values.CuStallExtCycles[j] / deviceCyclesMsec) << ","
-	       << (values.CuStallStrCycles[j] / deviceCyclesMsec) << std::endl ;
-	  ++j ;
-	}
+          fout << (cu.second)->getName()     << "," 
+               << values.CuExecCount[j]      << ","
+               << (values.CuExecCycles[j] / deviceCyclesMsec)     << ","
+               << (values.CuStallIntCycles[j] / deviceCyclesMsec) << ","
+               << (values.CuStallExtCycles[j] / deviceCyclesMsec) << ","
+               << (values.CuStallStrCycles[j] / deviceCyclesMsec) << std::endl ;
+          ++j ;
+        }
       }
     }
   }
@@ -868,30 +868,30 @@ namespace xdp {
 
     // Column headers
     fout << "Context:Number of Devices"         << ","
-	 << "Transfer Type"                     << ","
-	 << "Number Of Buffer Transfers"        << ","
-	 << "Transfer Rate (MB/s)"              << ","
-	 << "Average Bandwidth Utilization (%)" << ","
-	 << "Average Buffer Size (KB)"          << ","
-	 << "Total Time (ms)"                   << ","
-	 << "Average Time (ms)"                 << "," 
-	 << std::endl ;
+         << "Transfer Type"                     << ","
+         << "Number Of Buffer Transfers"        << ","
+         << "Transfer Rate (MB/s)"              << ","
+         << "Average Bandwidth Utilization (%)" << ","
+         << "Average Buffer Size (KB)"          << ","
+         << "Total Time (ms)"                   << ","
+         << "Average Time (ms)"                 << "," 
+         << std::endl ;
 
     for (auto read : hostReads)
     {
       std::string contextName = "context" + std::to_string(read.first.first) ;
       uint64_t numDevices =
-	(db->getStaticInfo()).getNumDevices(read.first.first) ;
+        (db->getStaticInfo()).getNumDevices(read.first.first) ;
       if (getFlowMode() == HW_EMU)
       {
-	fout << contextName << ":" << numDevices << ","
-	     << "READ" << ","
-	     << (read.second).count << ","
-	     << "N/A" << ","
-	     << "N/A" << ","
-	     << ((double)((read.second).averageSize) / one_thousand) << ","
-	     << "N/A" << ","
-	     << "N/A" << "," << std::endl ;
+        fout << contextName << ":" << numDevices << ","
+             << "READ" << ","
+             << (read.second).count << ","
+             << "N/A" << ","
+             << "N/A" << ","
+             << ((double)((read.second).averageSize) / one_thousand) << ","
+             << "N/A" << ","
+             << "N/A" << "," << std::endl ;
       }
       else
       {
@@ -899,18 +899,18 @@ namespace xdp {
         double totalSizeInMB = (double)((read.second).totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
-	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(read.first.second) ;
-	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        double maxReadBW =
+          (db->getStaticInfo()).getMaxReadBW(read.first.second) ;
+        double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
 
-	fout << contextName << ":" << numDevices << ","
-	     << "READ" << ","
-	     << (read.second).count << ","
-	     << transferRate << ","
-	     << aveBWUtil << ","
-	     << ((double)((read.second).averageSize) / one_thousand) << ","
-	     << ((read.second).totalTime / one_million) << ","
-	     << ((read.second).averageTime / one_million) << "," << std::endl ;
+        fout << contextName << ":" << numDevices << ","
+             << "READ" << ","
+             << (read.second).count << ","
+             << transferRate << ","
+             << aveBWUtil << ","
+             << ((double)((read.second).averageSize) / one_thousand) << ","
+             << ((read.second).totalTime / one_million) << ","
+             << ((read.second).averageTime / one_million) << "," << std::endl ;
       }
     }
 
@@ -918,18 +918,18 @@ namespace xdp {
     {
       std::string contextName = "context" + std::to_string(write.first.first) ;
       uint64_t numDevices =
-	(db->getStaticInfo()).getNumDevices(write.first.first) ;
+        (db->getStaticInfo()).getNumDevices(write.first.first) ;
 
       if (getFlowMode() == HW_EMU)
       {
-	fout << contextName << ":" << numDevices << ","
-	     << "WRITE" << ","
-	     << (write.second).count << ","
-	     << "N/A" << ","
-	     << "N/A" << ","
-	     << ((double)((write.second).averageSize) / one_thousand) << ","
-	     << "N/A" << ","
-	     << "N/A" << "," << std::endl ;
+        fout << contextName << ":" << numDevices << ","
+             << "WRITE" << ","
+             << (write.second).count << ","
+             << "N/A" << ","
+             << "N/A" << ","
+             << ((double)((write.second).averageSize) / one_thousand) << ","
+             << "N/A" << ","
+             << "N/A" << "," << std::endl ;
       }
       else
       {
@@ -937,18 +937,18 @@ namespace xdp {
         double totalSizeInMB = (double)((write.second).totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
-	double maxWriteBW =
-	  (db->getStaticInfo()).getMaxWriteBW(write.first.second);
-	double aveBWUtil = (one_hundred * transferRate) / maxWriteBW ;
+        double maxWriteBW =
+          (db->getStaticInfo()).getMaxWriteBW(write.first.second);
+        double aveBWUtil = (one_hundred * transferRate) / maxWriteBW ;
 
-	fout << contextName << ":" << numDevices << "," 
-	     << "WRITE" << ","
-	     << (write.second).count << ","
-	     << transferRate << ","
-	     << aveBWUtil << ","
-	     << ((double)((write.second).averageSize) / one_thousand) << ","
-	     << ((write.second).totalTime / one_million) << ","
-	     << ((write.second).averageTime / one_million) << "," << std::endl ;
+        fout << contextName << ":" << numDevices << "," 
+             << "WRITE" << ","
+             << (write.second).count << ","
+             << transferRate << ","
+             << aveBWUtil << ","
+             << ((double)((write.second).averageSize) / one_thousand) << ","
+             << ((write.second).totalTime / one_million) << ","
+             << ((write.second).averageTime / one_million) << "," << std::endl ;
       }
     }
   }
@@ -1003,16 +1003,16 @@ namespace xdp {
         auto totalTimeInS  = (double)(stats.totalTime / one_billion);
         auto totalSizeInMB = (double)(stats.totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
-	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(deviceId) ;
-	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        double maxReadBW =
+          (db->getStaticInfo()).getMaxReadBW(deviceId) ;
+        double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
 
-	fout << transferRate << "," ;
-	fout << aveBWUtil << "," ;
-	fout << (stats.maxTime / one_million) << "," ;
-	fout << (stats.minTime / one_million) << "," ;
-	fout << (stats.totalTime / one_million) << "," ;
-	fout << (stats.averageTime / one_million) << "," ;
+        fout << transferRate << "," ;
+        fout << aveBWUtil << "," ;
+        fout << (stats.maxTime / one_million) << "," ;
+        fout << (stats.minTime / one_million) << "," ;
+        fout << (stats.totalTime / one_million) << "," ;
+        fout << (stats.averageTime / one_million) << "," ;
       }
       fout << "\n" ;
     }
@@ -1067,16 +1067,16 @@ namespace xdp {
         auto totalTimeInS  = (double)(stats.totalTime / one_billion);
         auto totalSizeInMB = (double)(stats.totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
-	double maxReadBW =
-	  (db->getStaticInfo()).getMaxReadBW(deviceId) ;
-	double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        double maxReadBW =
+          (db->getStaticInfo()).getMaxReadBW(deviceId) ;
+        double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
 
-	fout << transferRate << "," ;
-	fout << aveBWUtil << "," ;
-	fout << (stats.maxTime / one_million) << "," ;
-	fout << (stats.minTime / one_million) << "," ;
-	fout << (stats.totalTime / one_million) << "," ;
-	fout << (stats.averageTime / one_million) << "," ;
+        fout << transferRate << "," ;
+        fout << aveBWUtil << "," ;
+        fout << (stats.maxTime / one_million) << "," ;
+        fout << (stats.minTime / one_million) << "," ;
+        fout << (stats.totalTime / one_million) << "," ;
+        fout << (stats.averageTime / one_million) << "," ;
       }
       fout << "\n" ;
     }
@@ -1100,9 +1100,9 @@ namespace xdp {
               printTable = true ;
               break ;
             }
-	  }
+          }
           if (printTable) break ;
-	}
+        }
         if (printTable) break ;
       }
       if (printTable) break ;
@@ -1203,8 +1203,8 @@ namespace xdp {
     bool printTable = false ;
     for (auto device : infos) {
       if (device->hasDMAMonitor()) {
-	printTable = true ;
-	break ;
+        printTable = true ;
+        break ;
       }
     }
     if (!printTable) return ;
@@ -1214,14 +1214,14 @@ namespace xdp {
 
     // Columns
     fout << "Device"                   << ","
-	 << "Transfer Type"            << ","
-	 << "Number Of Transfers"      << ","
-	 << "Transfer Rate (MB/s)"     << ","
-	 << "Total Data Transfer (MB)" << ","
-	 << "Total Time (ms)"          << ","
-	 << "Average Size (KB)"        << ","
-	 << "Average Latency (ns)"     << "," 
-	 << std::endl ;
+         << "Transfer Type"            << ","
+         << "Number Of Transfers"      << ","
+         << "Transfer Rate (MB/s)"     << ","
+         << "Total Data Transfer (MB)" << ","
+         << "Total Time (ms)"          << ","
+         << "Average Size (KB)"        << ","
+         << "Average Latency (ns)"     << "," 
+         << std::endl ;
 
 
     for (auto device : infos)
@@ -1232,94 +1232,94 @@ namespace xdp {
       uint64_t AIMIndex = 0 ;
       for (auto monitor : xclbin->pl.aims)
       {
-	if (monitor->name.find("Host to Device") != std::string::npos)
-	{
-	  // This is the monitor we are looking for
-	  xclCounterResults values =
-	    (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+        if (monitor->name.find("Host to Device") != std::string::npos)
+        {
+          // This is the monitor we are looking for
+          xclCounterResults values =
+            (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
 
-	  if (values.WriteTranx[AIMIndex] > 0)
-	  {
-	    uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
-	    double totalWriteTime =
-	      (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	    double writeTransferRate = (totalWriteTime == zero) ? 0 :
-	      (double)(values.WriteBytes[AIMIndex]) / (one_thousand * totalWriteTime);
+          if (values.WriteTranx[AIMIndex] > 0)
+          {
+            uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
+            double totalWriteTime =
+              (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+            double writeTransferRate = (totalWriteTime == zero) ? 0 :
+              (double)(values.WriteBytes[AIMIndex]) / (one_thousand * totalWriteTime);
 
-	    fout << device->getUniqueDeviceName() << ","
-		 << "WRITE" << ","
-		 << values.WriteTranx[AIMIndex] << "," ;
-	    if (getFlowMode() == HW_EMU)
-	    {
-	      fout << "N/A" << "," ;
-	    }
-	    else
-	    {
-	      fout << writeTransferRate << "," ;
-	    }
+            fout << device->getUniqueDeviceName() << ","
+                 << "WRITE" << ","
+                 << values.WriteTranx[AIMIndex] << "," ;
+            if (getFlowMode() == HW_EMU)
+            {
+              fout << "N/A" << "," ;
+            }
+            else
+            {
+              fout << writeTransferRate << "," ;
+            }
 
-	    fout << ((double)(values.WriteBytes[AIMIndex] / one_million)) << "," ;
+            fout << ((double)(values.WriteBytes[AIMIndex] / one_million)) << "," ;
 
-	    if (getFlowMode() == HW_EMU)
-	    {
-	      fout << "N/A" << "," ;
-	    }
-	    else
-	    {
-	      fout << (totalWriteTime / one_million) << "," ;
-	    }
-	    fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / one_thousand << "," ;
-	    if (getFlowMode() == HW_EMU)
-	    {
-	      fout << "N/A" << "," << std::endl ;
-	    }
-	    else
-	    {
-	      fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
-	    }
-	  }
-	  if (values.ReadTranx[AIMIndex] > 0)
-	  {
-	    uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
-	    double totalReadTime =
-	      (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	    double readTransferRate = (totalReadTime == zero) ? 0 :
-	      (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
+            if (getFlowMode() == HW_EMU)
+            {
+              fout << "N/A" << "," ;
+            }
+            else
+            {
+              fout << (totalWriteTime / one_million) << "," ;
+            }
+            fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / one_thousand << "," ;
+            if (getFlowMode() == HW_EMU)
+            {
+              fout << "N/A" << "," << std::endl ;
+            }
+            else
+            {
+              fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
+            }
+          }
+          if (values.ReadTranx[AIMIndex] > 0)
+          {
+            uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+            double totalReadTime =
+              (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+            double readTransferRate = (totalReadTime == zero) ? 0 :
+              (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
 
-	    fout << device->getUniqueDeviceName() << ","
-		 << "READ" << ","
-		 << values.ReadTranx[AIMIndex] << "," ;
-	    if (getFlowMode() == HW_EMU)
-	    {
-	      fout << "N/A" << "," ;
-	    }
-	    else
-	    {
-	      fout << readTransferRate << "," ;
-	    }
+            fout << device->getUniqueDeviceName() << ","
+                 << "READ" << ","
+                 << values.ReadTranx[AIMIndex] << "," ;
+            if (getFlowMode() == HW_EMU)
+            {
+              fout << "N/A" << "," ;
+            }
+            else
+            {
+              fout << readTransferRate << "," ;
+            }
 
-	    fout << ((double)(values.ReadBytes[AIMIndex] / one_million)) << "," ;
+            fout << ((double)(values.ReadBytes[AIMIndex] / one_million)) << "," ;
 
-	    if (getFlowMode() == HW_EMU)
-	    {
-	      fout << "N/A" << "," ;
-	    }
-	    else
-	    {
-	      fout << (totalReadTime / one_million) << "," ;
-	    }
-	    fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / one_thousand << "," ;
-	    if (getFlowMode() == HW_EMU)
-	    {
-	      fout << "N/A" << "," << std::endl ;
-	    }
-	    else
-	    {
-	      fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
-	    }
-	  }
-	}
-	++AIMIndex ;
+            if (getFlowMode() == HW_EMU)
+            {
+              fout << "N/A" << "," ;
+            }
+            else
+            {
+              fout << (totalReadTime / one_million) << "," ;
+            }
+            fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / one_thousand << "," ;
+            if (getFlowMode() == HW_EMU)
+            {
+              fout << "N/A" << "," << std::endl ;
+            }
+            else
+            {
+              fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
+            }
+          }
+        }
+        ++AIMIndex ;
       }
       }
     }
@@ -1333,8 +1333,8 @@ namespace xdp {
     bool printTable = false ;
     for (auto device : infos) {
       if (device->hasDMABypassMonitor()) {
-	printTable = true ;
-	break ;
+        printTable = true ;
+        break ;
       }
     }
     if (!printTable) return ;
@@ -1353,10 +1353,10 @@ namespace xdp {
                 values.ReadTranx[AIMIndex] > 0) {
               printTable = true ;
               break ;
-	    }
-	  }
+            }
+          }
           ++AIMIndex ;
-	}
+        }
         if (printTable) break ;
       }
       if (printTable) break ;
@@ -1368,14 +1368,14 @@ namespace xdp {
 
     // Columns
     fout << "Device"                   << ","
-	 << "Transfer Type"            << ","
-	 << "Number Of Transfers"      << ","
-	 << "Transfer Rate (MB/s)"     << ","
-	 << "Total Data Transfer (MB)" << ","
-	 << "Total Time (ms)"          << ","
-	 << "Average Size (KB)"        << ","
-	 << "Average Latency (ns)"     << "," 
-	 << std::endl ;
+         << "Transfer Type"            << ","
+         << "Number Of Transfers"      << ","
+         << "Transfer Rate (MB/s)"     << ","
+         << "Total Data Transfer (MB)" << ","
+         << "Total Time (ms)"          << ","
+         << "Average Size (KB)"        << ","
+         << "Average Latency (ns)"     << "," 
+         << std::endl ;
 
     for (auto device : infos) {
       for (auto xclbin : device->loadedXclbins) {
@@ -1383,76 +1383,76 @@ namespace xdp {
         for (auto monitor : xclbin->pl.aims) {
           if (monitor->name.find("Peer to Peer") != std::string::npos) {
             // This is the monitor we are looking for
-	    xclCounterResults values =
-	      db->getDynamicInfo().getCounterResults(device->deviceId,
+            xclCounterResults values =
+              db->getDynamicInfo().getCounterResults(device->deviceId,
                                                      xclbin->uuid) ;
             if (values.WriteTranx[AIMIndex] > 0) {
               uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
-	      double totalWriteTime =
-	        (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	      double writeTransferRate = (totalWriteTime == zero) ? 0 :
-	        (double)(values.WriteBytes[AIMIndex]) / (one_thousand * totalWriteTime);
+              double totalWriteTime =
+                (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+              double writeTransferRate = (totalWriteTime == zero) ? 0 :
+                (double)(values.WriteBytes[AIMIndex]) / (one_thousand * totalWriteTime);
 
               fout << device->getUniqueDeviceName() << "," << "WRITE" << ","
                    << values.WriteTranx[AIMIndex] << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," ;
-	      }
-	      else {
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," ;
+              }
+              else {
                 fout << writeTransferRate << "," ;
-	      }
+              }
 
-	      fout << ((double)(values.WriteBytes[AIMIndex] / one_million)) << "," ;
+              fout << ((double)(values.WriteBytes[AIMIndex] / one_million)) << "," ;
 
-	      if (getFlowMode() == HW_EMU) {
-  	        fout << "N/A" << "," ;
-	      }
-	      else {
- 	        fout << (totalWriteTime / one_million) << "," ;
-	      }
-	      fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / one_thousand << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," << std::endl ;
-	      }
-	      else {
-	        fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
-	      }
-	    }
-	    if (values.ReadTranx[AIMIndex] > 0) {
- 	      uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
-	      double totalReadTime =
-	        (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	      double readTransferRate = (totalReadTime == zero) ? 0 :
-	        (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
+              if (getFlowMode() == HW_EMU) {
+                  fout << "N/A" << "," ;
+              }
+              else {
+                 fout << (totalWriteTime / one_million) << "," ;
+              }
+              fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / one_thousand << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," << std::endl ;
+              }
+              else {
+                fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
+              }
+            }
+            if (values.ReadTranx[AIMIndex] > 0) {
+               uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+              double totalReadTime =
+                (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+              double readTransferRate = (totalReadTime == zero) ? 0 :
+                (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
 
-	      fout << device->getUniqueDeviceName() << ","
-	 	   << "READ" << ","
-		   << values.ReadTranx[AIMIndex] << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," ;
-	      }
-	      else {
-	        fout << readTransferRate << "," ;
-	      }
+              fout << device->getUniqueDeviceName() << ","
+                    << "READ" << ","
+                   << values.ReadTranx[AIMIndex] << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," ;
+              }
+              else {
+                fout << readTransferRate << "," ;
+              }
 
-	      fout << ((double)(values.ReadBytes[AIMIndex] / one_million)) << "," ;
+              fout << ((double)(values.ReadBytes[AIMIndex] / one_million)) << "," ;
 
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," ;
-	      }
-	      else {
-	        fout << (totalReadTime / one_million) << "," ;
-	      }
-	      fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / one_thousand << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," << std::endl ;
-	      }
-	      else {
-	        fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
-	      }
-	    }
-	  }
-	  ++AIMIndex ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," ;
+              }
+              else {
+                fout << (totalReadTime / one_million) << "," ;
+              }
+              fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / one_thousand << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," << std::endl ;
+              }
+              else {
+                fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
+              }
+            }
+          }
+          ++AIMIndex ;
         }
       }
     }
@@ -1501,14 +1501,14 @@ namespace xdp {
         for (auto aim : xclbin->pl.aims) {
           auto loc = aim->name.find("memory_subsystem") ;
           if (loc != std::string::npos) {
-	    std::string memoryResource = aim->name.substr(loc + 16) ;
+            std::string memoryResource = aim->name.substr(loc + 16) ;
 
-	    if (values.ReadTranx[AIMIndex] > 0) {
- 	      uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
-	      double totalReadTime =
-	        (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	      double readTransferRate = (totalReadTime == zero) ? 0 :
-	        (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
+            if (values.ReadTranx[AIMIndex] > 0) {
+               uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+              double totalReadTime =
+                (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+              double readTransferRate = (totalReadTime == zero) ? 0 :
+                (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
 
               fout << "ENTRY:" ;
               fout << device->getUniqueDeviceName() << "," ;
@@ -1521,11 +1521,11 @@ namespace xdp {
               fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << ",\n" ;
             }
             if (values.WriteTranx[AIMIndex] > 0) {
- 	      uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
-	      double totalWriteTime =
-	        (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	      double writeTransferRate = (totalWriteTime == zero) ? 0 :
-	        (double)(values.WriteBytes[AIMIndex]) / (one_thousand * totalWriteTime);
+               uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
+              double totalWriteTime =
+                (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+              double writeTransferRate = (totalWriteTime == zero) ? 0 :
+                (double)(values.WriteBytes[AIMIndex]) / (one_thousand * totalWriteTime);
               fout << "ENTRY:" ;
               fout << device->getUniqueDeviceName() << "," ;
               fout << memoryResource << "," ;
@@ -1556,16 +1556,16 @@ namespace xdp {
         for (auto monitor : xclbin->pl.aims) {
           if (monitor->name.find("Memory to Memory") != std::string::npos) {
             xclCounterResults values =
-	      (db->getDynamicInfo()).getCounterResults(device->deviceId,
+              (db->getDynamicInfo()).getCounterResults(device->deviceId,
                                                        xclbin->uuid) ;
             if (values.WriteTranx[AIMIndex] > 0 ||
                 values.ReadTranx[AIMIndex] > 0) {
               printTable = true ;
               break ;
-	    }
-	  }
+            }
+          }
           ++AIMIndex ;
-	}
+        }
         if (printTable) break ;
       }
       if (printTable) break ;
@@ -1578,89 +1578,89 @@ namespace xdp {
 
     // Columns
     fout << "Device"                   << ","
-	 << "Transfer Type"            << ","
-	 << "Number Of Transfers"      << ","
-	 << "Transfer Rate (MB/s)"     << ","
-	 << "Total Data Transfer (MB)" << ","
-	 << "Total Time (ms)"          << ","
-	 << "Average Size (KB)"        << ","
-	 << "Average Latency (ns)"     << ","
-	 << std::endl ;
+         << "Transfer Type"            << ","
+         << "Number Of Transfers"      << ","
+         << "Transfer Rate (MB/s)"     << ","
+         << "Total Data Transfer (MB)" << ","
+         << "Total Time (ms)"          << ","
+         << "Average Size (KB)"        << ","
+         << "Average Latency (ns)"     << ","
+         << std::endl ;
 
     for (auto device : infos) {
       for (auto xclbin : device->loadedXclbins) {
         uint64_t AIMIndex = 0 ;
         for (auto monitor : xclbin->pl.aims) {
-	  if (monitor->name.find("Memory to Memory") != std::string::npos) {
+          if (monitor->name.find("Memory to Memory") != std::string::npos) {
             // This is the monitor we are looking for
-	    xclCounterResults values =
-	      (db->getDynamicInfo()).getCounterResults(device->deviceId,
+            xclCounterResults values =
+              (db->getDynamicInfo()).getCounterResults(device->deviceId,
                                                        xclbin->uuid) ;
             if (values.WriteTranx[AIMIndex] > 0) {
-	      uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
-	      double totalWriteTime =
-	        (double)(totalWriteBusyCycles) / (one_thousand*xclbin->pl.clockRatePLMHz);
+              uint64_t totalWriteBusyCycles = values.WriteBusyCycles[AIMIndex] ;
+              double totalWriteTime =
+                (double)(totalWriteBusyCycles) / (one_thousand*xclbin->pl.clockRatePLMHz);
               double writeTransferRate = (totalWriteTime == zero) ? 0 :
-	        (double)(values.WriteBytes[AIMIndex]) / (one_thousand*totalWriteTime);
+                (double)(values.WriteBytes[AIMIndex]) / (one_thousand*totalWriteTime);
 
               fout << device->getUniqueDeviceName() << "," << "WRITE" << ","
                    << values.WriteTranx[AIMIndex] << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," ;
-              }
-	      else {
-	        fout << writeTransferRate << "," ;
-	      }
-	      fout << ((double)(values.WriteBytes[AIMIndex] / one_million)) << "," ;
               if (getFlowMode() == HW_EMU) {
                 fout << "N/A" << "," ;
               }
-	      else {
-	        fout << (totalWriteTime / one_million) << "," ;
-	      }
-	      fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / one_thousand << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," << std::endl ;
-	      }
-	      else {
-	        fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
-	      }
-	    }
-	    if (values.ReadTranx[AIMIndex] > 0) {
-  	      uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
-	      double totalReadTime =
-	        (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
-	      double readTransferRate = (totalReadTime == zero) ? 0 :
-	        (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
+              else {
+                fout << writeTransferRate << "," ;
+              }
+              fout << ((double)(values.WriteBytes[AIMIndex] / one_million)) << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," ;
+              }
+              else {
+                fout << (totalWriteTime / one_million) << "," ;
+              }
+              fout << ((double)(values.WriteBytes[AIMIndex]) / (double)(values.WriteTranx[AIMIndex])) / one_thousand << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," << std::endl ;
+              }
+              else {
+                fout << ((one_thousand * values.WriteLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.WriteTranx[AIMIndex]) << "," << std::endl ;
+              }
+            }
+            if (values.ReadTranx[AIMIndex] > 0) {
+                uint64_t totalReadBusyCycles = values.ReadBusyCycles[AIMIndex] ;
+              double totalReadTime =
+                (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz);
+              double readTransferRate = (totalReadTime == zero) ? 0 :
+                (double)(values.ReadBytes[AIMIndex]) / (one_thousand * totalReadTime);
 
-	      fout << device->getUniqueDeviceName() << ","
-	  	   << "READ" << ","
-		   << values.ReadTranx[AIMIndex] << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," ;
-	      }
-	      else {
-	        fout << readTransferRate << "," ;
-	      }
+              fout << device->getUniqueDeviceName() << ","
+                     << "READ" << ","
+                   << values.ReadTranx[AIMIndex] << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," ;
+              }
+              else {
+                fout << readTransferRate << "," ;
+              }
 
-	      fout << ((double)(values.ReadBytes[AIMIndex] / one_million)) << "," ;
+              fout << ((double)(values.ReadBytes[AIMIndex] / one_million)) << "," ;
 
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," ;
-	      }
-	      else {
-	        fout << (totalReadTime / one_million) << "," ;
-	      }
-	      fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / one_thousand << "," ;
-	      if (getFlowMode() == HW_EMU) {
-	        fout << "N/A" << "," << std::endl ;
-	      }
-	      else {
-	        fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
-	      }
-	    }
-	  }
-	  ++AIMIndex ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," ;
+              }
+              else {
+                fout << (totalReadTime / one_million) << "," ;
+              }
+              fout << ((double)(values.ReadBytes[AIMIndex]) / (double)(values.ReadTranx[AIMIndex])) / one_thousand << "," ;
+              if (getFlowMode() == HW_EMU) {
+                fout << "N/A" << "," << std::endl ;
+              }
+              else {
+                fout << ((one_thousand * values.ReadLatency[AIMIndex]) / xclbin->pl.clockRatePLMHz) / (values.ReadTranx[AIMIndex]) << "," << std::endl ;
+              }
+            }
+          }
+          ++AIMIndex ;
         }
       }
     }
@@ -1694,111 +1694,111 @@ namespace xdp {
 
     // Column headers
     fout << "Device"                            << ","
-	 << "Compute Unit/Port Name"            << ","
-	 << "Kernel Arguments"                  << ","
-	 << "Memory Resources"                  << ","
-	 << "Transfer Type"                     << ","
-	 << "Number Of Transfers"               << ","
-	 << "Transfer Rate (MB/s)"              << ","
-	 << "Average Bandwidth Utilization (%)" << ","
-	 << "Average Size (KB)"                 << ","
-	 << "Average Latency (ns)"              << "," 
-	 << std::endl ;
+         << "Compute Unit/Port Name"            << ","
+         << "Kernel Arguments"                  << ","
+         << "Memory Resources"                  << ","
+         << "Transfer Type"                     << ","
+         << "Number Of Transfers"               << ","
+         << "Transfer Rate (MB/s)"              << ","
+         << "Average Bandwidth Utilization (%)" << ","
+         << "Average Size (KB)"                 << ","
+         << "Average Latency (ns)"              << "," 
+         << std::endl ;
 
     for (auto device : infos)
     {
       for (auto xclbin : device->loadedXclbins)
       {
-	xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
+        xclCounterResults values = (db->getDynamicInfo()).getCounterResults(device->deviceId, xclbin->uuid) ;
 
-	// Counter results don't use the slotID.  Instead, they are filled
-	//  in the struct in the order in which we found them.
-	uint64_t monitorId = 0 ;
-	for (auto monitor : xclbin->pl.aims) {
-	  if (monitor->cuIndex == -1) {
-	    // This AIM is either a shell or floating 
-	    ++monitorId ;
-	    continue ;
-	  }
+        // Counter results don't use the slotID.  Instead, they are filled
+        //  in the struct in the order in which we found them.
+        uint64_t monitorId = 0 ;
+        for (auto monitor : xclbin->pl.aims) {
+          if (monitor->cuIndex == -1) {
+            // This AIM is either a shell or floating 
+            ++monitorId ;
+            continue ;
+          }
 
-	  auto writeTranx = values.WriteTranx[monitorId] ;
-	  auto readTranx  = values.ReadTranx[monitorId] ;
+          auto writeTranx = values.WriteTranx[monitorId] ;
+          auto readTranx  = values.ReadTranx[monitorId] ;
 
-	  uint64_t totalReadBusyCycles  = values.ReadBusyCycles[monitorId] ;
-	  uint64_t totalWriteBusyCycles = values.WriteBusyCycles[monitorId] ;
+          uint64_t totalReadBusyCycles  = values.ReadBusyCycles[monitorId] ;
+          uint64_t totalWriteBusyCycles = values.WriteBusyCycles[monitorId] ;
 
-	  double totalReadTime = 
-	    (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz) ;
-	  double totalWriteTime =
-	    (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz) ;
+          double totalReadTime = 
+            (double)(totalReadBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz) ;
+          double totalWriteTime =
+            (double)(totalWriteBusyCycles) / (one_thousand * xclbin->pl.clockRatePLMHz) ;
 
-	  // Use the name of the monitor to determine the port and memory
-	  std::string portName   = "" ;
-	  std::string memoryName = "" ;
-	  size_t slashPosition = (monitor->name).find("/") ;
-	  if (slashPosition != std::string::npos) {
-	    auto position = slashPosition + 1 ;
-	    auto length = (monitor->name).size() - position ;
+          // Use the name of the monitor to determine the port and memory
+          std::string portName   = "" ;
+          std::string memoryName = "" ;
+          size_t slashPosition = (monitor->name).find("/") ;
+          if (slashPosition != std::string::npos) {
+            auto position = slashPosition + 1 ;
+            auto length = (monitor->name).size() - position ;
 
-	    // Split the monitor name into port and memory position
-	    std::string lastHalf = (monitor->name).substr(position, length) ;
-	      
-	    size_t dashPosition = lastHalf.find("-") ;
-	    if (dashPosition != std::string::npos) {
-	      auto remainingLength = lastHalf.size() - dashPosition - 1 ;
-	      portName = lastHalf.substr(0, dashPosition) ;
-	      memoryName = lastHalf.substr(dashPosition + 1, remainingLength);
-	    }
-	    else {
-	      portName = lastHalf ;
-	    }
-	  }
-	  if (writeTranx > 0) {
-	    double transferRate = (totalWriteTime == zero) ? 0 :
-	      (double)(values.WriteBytes[monitorId]) / (one_thousand * totalWriteTime);
-	    double aveBW =
-	      (one_hundred * transferRate) / xclbin->pl.maxWriteBW ;
-	    if (aveBW > one_hundred) aveBW = one_hundred ;
-	    auto aveLatency =
+            // Split the monitor name into port and memory position
+            std::string lastHalf = (monitor->name).substr(position, length) ;
+              
+            size_t dashPosition = lastHalf.find("-") ;
+            if (dashPosition != std::string::npos) {
+              auto remainingLength = lastHalf.size() - dashPosition - 1 ;
+              portName = lastHalf.substr(0, dashPosition) ;
+              memoryName = lastHalf.substr(dashPosition + 1, remainingLength);
+            }
+            else {
+              portName = lastHalf ;
+            }
+          }
+          if (writeTranx > 0) {
+            double transferRate = (totalWriteTime == zero) ? 0 :
+              (double)(values.WriteBytes[monitorId]) / (one_thousand * totalWriteTime);
+            double aveBW =
+              (one_hundred * transferRate) / xclbin->pl.maxWriteBW ;
+            if (aveBW > one_hundred) aveBW = one_hundred ;
+            auto aveLatency =
               static_cast<double>(values.WriteLatency[monitorId]) /
               static_cast<double>(writeTranx) ;
 
-	    fout << device->getUniqueDeviceName() << ","
-		 << xclbin->pl.cus[monitor->cuIndex]->getName() << "/"
-		 << portName << ","
-		 << (monitor->args) << ","
-		 << memoryName << ","
-		 << "WRITE" << ","
-		 << writeTranx << ","
-		 << transferRate << ","
-		 << aveBW << ","
-		 << (double)(values.WriteBytes[monitorId] / writeTranx) / one_thousand << ","
-		 << aveLatency << ",\n" ;
-	  }
-	  if (readTranx > 0) {
-	      double transferRate = (totalReadTime == zero) ? 0 :
-		(double)(values.ReadBytes[monitorId]) / (one_thousand * totalReadTime);
-	      double aveBW =
-		(one_hundred * transferRate) / xclbin->pl.maxReadBW ;
-	      if (aveBW > one_hundred) aveBW = one_hundred ;
+            fout << device->getUniqueDeviceName() << ","
+                 << xclbin->pl.cus[monitor->cuIndex]->getName() << "/"
+                 << portName << ","
+                 << (monitor->args) << ","
+                 << memoryName << ","
+                 << "WRITE" << ","
+                 << writeTranx << ","
+                 << transferRate << ","
+                 << aveBW << ","
+                 << (double)(values.WriteBytes[monitorId] / writeTranx) / one_thousand << ","
+                 << aveLatency << ",\n" ;
+          }
+          if (readTranx > 0) {
+              double transferRate = (totalReadTime == zero) ? 0 :
+                (double)(values.ReadBytes[monitorId]) / (one_thousand * totalReadTime);
+              double aveBW =
+                (one_hundred * transferRate) / xclbin->pl.maxReadBW ;
+              if (aveBW > one_hundred) aveBW = one_hundred ;
               auto aveLatency =
                 static_cast<double>(values.ReadLatency[monitorId]) /
                 static_cast<double>(readTranx) ;
 
-	      fout << device->getUniqueDeviceName() << ","
-		   << xclbin->pl.cus[monitor->cuIndex]->getName() << "/"
-		   << portName << ","
-		   << (monitor->args) << ","
-		   << memoryName << ","
-		   << "READ" << ","
-		   << readTranx << ","
-		   << transferRate << ","
-		   << aveBW << ","
-		   << (double)(values.ReadBytes[monitorId] / readTranx) / one_thousand << ","
-		   << aveLatency << ",\n" ;
-	  }
-	  ++monitorId ;
-	}
+              fout << device->getUniqueDeviceName() << ","
+                   << xclbin->pl.cus[monitor->cuIndex]->getName() << "/"
+                   << portName << ","
+                   << (monitor->args) << ","
+                   << memoryName << ","
+                   << "READ" << ","
+                   << readTranx << ","
+                   << transferRate << ","
+                   << aveBW << ","
+                   << (double)(values.ReadBytes[monitorId] / readTranx) / one_thousand << ","
+                   << aveLatency << ",\n" ;
+          }
+          ++monitorId ;
+        }
       }
     }
   }
@@ -1830,15 +1830,15 @@ namespace xdp {
 
     // Columns
     fout << "Device"                     << ","
-	 << "Compute Unit"               << ","
-	 << "Number of Transfers"        << ","
-	 << "Average Bytes per Transfer" << ","
-	 << "Transfer Efficiency (%)"    << ","
-	 << "Total Data Transfer (MB)"   << ","
-	 << "Total Write (MB)"           << ","
-	 << "Total Read (MB)"            << ","
-	 << "Total Transfer Rate (MB/s)" << "," 
-	 << std::endl ;
+         << "Compute Unit"               << ","
+         << "Number of Transfers"        << ","
+         << "Average Bytes per Transfer" << ","
+         << "Transfer Efficiency (%)"    << ","
+         << "Total Data Transfer (MB)"   << ","
+         << "Total Write (MB)"           << ","
+         << "Total Read (MB)"            << ","
+         << "Total Transfer Rate (MB/s)" << "," 
+         << std::endl ;
 
     for (auto device : infos)
     {
@@ -1846,63 +1846,63 @@ namespace xdp {
 
       for (auto xclbin : device->loadedXclbins)
       {
-	xclCounterResults values =
-	  (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
+        xclCounterResults values =
+          (db->getDynamicInfo()).getCounterResults(deviceId, xclbin->uuid) ;
 
-	for (auto cu : xclbin->pl.cus)
-	{
-	  // For each CU, we need to find the monitor that has 
-	  //  the most transactions
-	  std::string computeUnitName = (cu.second)->getName() ;
-	  std::vector<uint32_t>* aimMonitors = (cu.second)->getAIMs() ;
+        for (auto cu : xclbin->pl.cus)
+        {
+          // For each CU, we need to find the monitor that has 
+          //  the most transactions
+          std::string computeUnitName = (cu.second)->getName() ;
+          std::vector<uint32_t>* aimMonitors = (cu.second)->getAIMs() ;
 
-	  // These are the max we have seen so far
-	  uint64_t numTransfers = 0 ;
-	  double aveBytesPerTransfer = 0 ;
-	  double transferEfficiency = 0 ;
-	  uint64_t totalDataTransfer = 0 ;
-	  uint64_t totalWriteBytes = 0 ;
-	  uint64_t totalReadBytes = 0 ;
-	  double totalTransferRate = 0 ;
+          // These are the max we have seen so far
+          uint64_t numTransfers = 0 ;
+          double aveBytesPerTransfer = 0 ;
+          double transferEfficiency = 0 ;
+          uint64_t totalDataTransfer = 0 ;
+          uint64_t totalWriteBytes = 0 ;
+          uint64_t totalReadBytes = 0 ;
+          double totalTransferRate = 0 ;
 
-	  for (auto AIMIndex : (*aimMonitors))
-	  {
-	    auto writeTranx = values.WriteTranx[AIMIndex] ;
-	    auto readTranx = values.ReadTranx[AIMIndex] ;
-	    auto totalTranx = writeTranx + readTranx ;
+          for (auto AIMIndex : (*aimMonitors))
+          {
+            auto writeTranx = values.WriteTranx[AIMIndex] ;
+            auto readTranx = values.ReadTranx[AIMIndex] ;
+            auto totalTranx = writeTranx + readTranx ;
 
-	    if (totalTranx > numTransfers) {
-	      numTransfers = totalTranx ;
-	      totalReadBytes = values.ReadBytes[AIMIndex] ;
-	      totalWriteBytes = values.WriteBytes[AIMIndex] ;
-	      aveBytesPerTransfer =
-		(double)(totalReadBytes + totalWriteBytes)/(double)(numTransfers);
-	      // TODO: Fix bit width calculation here
-	      transferEfficiency = (one_hundred * aveBytesPerTransfer) / 4096 ; 
-	      totalDataTransfer = totalReadBytes + totalWriteBytes ;
-	      auto totalBusyCycles =
-		values.ReadBusyCycles[AIMIndex]+values.WriteBusyCycles[AIMIndex];
-	      double totalTimeMSec = 
-		(double)(totalBusyCycles) /(one_thousand * xclbin->pl.clockRatePLMHz) ;
-	      totalTransferRate =
-		(totalTimeMSec == 0) ? zero :
-		(double)(totalDataTransfer) / (one_thousand * totalTimeMSec) ;
-	    }
-	  }
+            if (totalTranx > numTransfers) {
+              numTransfers = totalTranx ;
+              totalReadBytes = values.ReadBytes[AIMIndex] ;
+              totalWriteBytes = values.WriteBytes[AIMIndex] ;
+              aveBytesPerTransfer =
+                (double)(totalReadBytes + totalWriteBytes)/(double)(numTransfers);
+              // TODO: Fix bit width calculation here
+              transferEfficiency = (one_hundred * aveBytesPerTransfer) / 4096 ; 
+              totalDataTransfer = totalReadBytes + totalWriteBytes ;
+              auto totalBusyCycles =
+                values.ReadBusyCycles[AIMIndex]+values.WriteBusyCycles[AIMIndex];
+              double totalTimeMSec = 
+                (double)(totalBusyCycles) /(one_thousand * xclbin->pl.clockRatePLMHz) ;
+              totalTransferRate =
+                (totalTimeMSec == 0) ? zero :
+                (double)(totalDataTransfer) / (one_thousand * totalTimeMSec) ;
+            }
+          }
 
-	  // Verify that this CU actually had some data transfers registered
-	  if (computeUnitName != "" && numTransfers != 0) {
-	    fout << device->getUniqueDeviceName() << ","
-		 << computeUnitName << ","
-		 << numTransfers << ","
-		 << aveBytesPerTransfer << ","
-		 << transferEfficiency << ","
-		 << (double)(totalDataTransfer) / one_million << ","
-		 << (double)(totalWriteBytes) / one_million << ","
-		 << (double)(totalReadBytes) / one_million << ","
-		 << totalTransferRate << "," << std::endl ;
-	  }
-	}
+          // Verify that this CU actually had some data transfers registered
+          if (computeUnitName != "" && numTransfers != 0) {
+            fout << device->getUniqueDeviceName() << ","
+                 << computeUnitName << ","
+                 << numTransfers << ","
+                 << aveBytesPerTransfer << ","
+                 << transferEfficiency << ","
+                 << (double)(totalDataTransfer) / one_million << ","
+                 << (double)(totalWriteBytes) / one_million << ","
+                 << (double)(totalReadBytes) / one_million << ","
+                 << totalTransferRate << "," << std::endl ;
+          }
+        }
       }
     }
   }
@@ -2003,17 +2003,17 @@ namespace xdp {
 
     for (auto iter : counts) {
       const char* label =
-	(iter.first.first == nullptr) ? " " : iter.first.first;
+        (iter.first.first == nullptr) ? " " : iter.first.first;
       const char* tooltip =
-	(iter.first.second == nullptr) ? " " : iter.first.second ;
+        (iter.first.second == nullptr) ? " " : iter.first.second ;
       fout << label       << ","
-	   << tooltip     << ","
-	   << iter.second << ","
-	   << (double)minDurations[iter.first] / one_million << ","
-	   << (double)maxDurations[iter.first] / one_million << ","
-	   << (double)totalDurations[iter.first] / one_million<< ","
-	   << ((double)totalDurations[iter.first]/(double)(iter.second)) / one_million << ","
-	   << std::endl ;
+           << tooltip     << ","
+           << iter.second << ","
+           << (double)minDurations[iter.first] / one_million << ","
+           << (double)maxDurations[iter.first] / one_million << ","
+           << (double)totalDurations[iter.first] / one_million<< ","
+           << ((double)totalDurations[iter.first]/(double)(iter.second)) / one_million << ","
+           << std::endl ;
     }
   }
 

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_summary_writer.cpp
@@ -49,8 +49,8 @@ namespace xdp {
     {
       // Cannot rename summary file to checkpoint file
       xrt_core::message::send(xrt_core::message::severity_level::warning,
-			      "XRT",
-			      "Cannot create profile summary checkpoint file") ;
+                              "XRT",
+                              "Cannot create profile summary checkpoint file") ;
     }
 
     fout.open(getRawBasename()) ;

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.cpp
@@ -25,9 +25,9 @@ namespace xdp {
   std::atomic<unsigned int> VPTraceWriter::traceIDCtr{0};
 
   VPTraceWriter::VPTraceWriter(const char* filename,
-				 const std::string& v,
-				 const std::string& c,
-				 uint16_t r) :
+                                 const std::string& v,
+                                 const std::string& c,
+                                 uint16_t r) :
     VPWriter(filename),
     version(v), creationTime(c), resolution(r),
     humanReadable(true)

--- a/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
+++ b/src/runtime_src/xdp/profile/writer/vp_base/vp_trace_writer.h
@@ -60,7 +60,7 @@ namespace xdp {
 
   public:
     XDP_EXPORT VPTraceWriter(const char* filename, const std::string& v,
-			     const std::string& c, uint16_t r) ;
+                             const std::string& c, uint16_t r) ;
     XDP_EXPORT ~VPTraceWriter() ;
 
     void setHumanReadable() { humanReadable = true ; } 


### PR DESCRIPTION
Current xdp code mostly uses spaces, but some places have tabs in them making the code harder to read
This also removes unused legacy defines in xclperf.h file


![Capture](https://user-images.githubusercontent.com/2370073/156080998-ecd504f2-9d51-415c-97dc-e0dfe9ec519a.PNG)
.