### PR TITLE
CR-1123097 ASTeR basic sanity - vck5000 - VMR version not displayed i…

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -95,7 +95,7 @@ enum xgq_cmd_vmr_control_type {
 enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_AF		= 0x0,
 	XGQ_CMD_LOG_FW		= 0x1,
-	XGQ_CMD_LOG_XCLBIN	= 0x2,
+	XGQ_CMD_LOG_INFO	= 0x2,
 };
 
 /**

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -974,8 +974,6 @@ static int xgq_check_firewall(struct platform_device *pdev)
 		struct xgq_cmd_cq_log_page_payload *log = NULL;
 		u32 log_size = 0;
 
-		mutex_lock(&xgq->xgq_lock);
-
 		log = (struct xgq_cmd_cq_log_page_payload *)&cmd->xgq_cmd_cq_payload;
 		log_size = log->count;
 


### PR DESCRIPTION
…n xbutil/xbmgmt examine

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- This PR will bring VMR verbose version info into host sysfs node as text that user can ready. In the future the xbmgmt/xbutil tools can retrieve those info from it too.
- The solution is to add log_page request and collecting info back via shared memory. Since we have lock protection from the host driver, the shared memory reserved for this log_page won't be released till dumping the info into sysfs's buffer.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
```
cat /sys/bus/pci/devices/0000\:d9\:00.0/xgq_vmr.m.54525952/vmr_verbose_info
XRT only build
vitis version: 2021.2
git hash:7ecedb29f55d1343814a56c0cf4e0db385b6f871
git branch: xgq
build date: Fri, 25 Feb 2022 17:43:55 -0500
apu is ready: 1
A image offset: 0x48000 size: 0x5dd8f0 capacity: 0x5fb8000
K B image offset: 0x6008000 size: 0x5dd780 capacity: 0x5fb8000
SC firmware size: 0x630f0
```
#### Documentation impact (if any)
