### PR TITLE
CR-1121712: Address seg fault at program teardown in profiling

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -34,8 +34,12 @@
 
 namespace xdp {
 
+  bool HALPlugin::live = false;
+
   HALPlugin::HALPlugin() : XDPPlugin()
   {
+    HALPlugin::live = true;
+
     db->registerPlugin(this) ;
     db->registerInfo(info::hal) ;
 
@@ -69,6 +73,7 @@ namespace xdp {
       db->unregisterPlugin(this) ;
     }
 
+    HALPlugin::live = false;
     // If the database is dead, then we must have already forced a 
     //  write at the database destructor so we can just move on
   }
@@ -76,10 +81,6 @@ namespace xdp {
   void HALPlugin::writeAll(bool openNewFiles)
   {
     for (auto w : writers)
-    {
       w->write(openNewFiles) ;
-    }
   }
 }
-
-

--- a/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/hal/hal_plugin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,7 +24,7 @@ namespace xdp {
   class HALPlugin : public XDPPlugin
   {
   private:
-
+    static bool live;
   public:
     XDP_EXPORT
     HALPlugin() ;
@@ -34,6 +34,8 @@ namespace xdp {
 
     XDP_EXPORT
     virtual void writeAll(bool openNewFiles) ;
+
+    static bool alive() { return HALPlugin::live; }
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal/xdp_hal_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -124,9 +124,9 @@ namespace xdp {
 extern "C"
 void hal_generic_cb(bool isStart, const char* name, unsigned long long int id)
 {
-  if(!xdp::VPDatabase::alive()) {
+  if(!xdp::VPDatabase::alive() || !xdp::HALPlugin::alive())
     return;
-  }
+
   if (isStart)
     xdp::generic_log_function_start(name, static_cast<uint64_t>(id)) ;
   else
@@ -139,9 +139,8 @@ void buffer_transfer_cb(bool isWrite, bool isStart, const char* name,
                         unsigned long long int bufferId,
                         unsigned long long int size)
 {
-  if(!xdp::VPDatabase::alive()) {
+  if(!xdp::VPDatabase::alive() || !xdp::HALPlugin::alive())
     return;
-  }
 
   if (isWrite) {
     if (isStart) {

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,8 +30,11 @@
 
 namespace xdp {
 
+  bool HALAPIInterface::live = false;
+
   HALAPIInterface::HALAPIInterface() 
   {
+    HALAPIInterface::live = true;
   }
 
   HALAPIInterface::~HALAPIInterface()
@@ -42,7 +45,9 @@ namespace xdp {
       delete itr.second;
       itr.second = nullptr;
     }
-    devices.clear();  
+    devices.clear();
+
+    HALAPIInterface::live = false;
   }
 
   void HALAPIInterface::startProfiling(xclDeviceHandle handle)

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.h
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -35,6 +35,8 @@ namespace xdp {
     std::map<std::string, xclCounterResults> mRolloverCounterResultsMap;
     std::map<std::string, xclCounterResults> mRolloverCountsMap;
 
+    static bool live;
+
   private:
     
     void calculateAIMRolloverResult(const std::string& key, 
@@ -69,6 +71,8 @@ namespace xdp {
      void startCounters();
      void stopCounters();
      void readCounters();
+
+     static bool alive() { return HALAPIInterface::live; }
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface_plugin.cpp
@@ -66,6 +66,9 @@ namespace xdp {
 // Interface function visible from main XRT code
 void hal_api_interface_cb_func(HalInterfaceCallbackType cb_type, void* payload)
 {
+  if (!xdp::HALAPIInterface::alive())
+    return;
+
   switch (cb_type)
   {
   case HalInterfaceCallbackType::START_DEVICE_PROFILING:

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_cb.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -30,6 +30,9 @@ namespace xdp {
 					long long queueAddress,
 					unsigned long long int functionID)
   {
+    if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
+      return ;
+
     // Since these are OpenCL level events, we must use the OpenCL
     //  level time functions to get the proper value of time zero.
     double timestamp = xrt_xocl::time_ns() ;
@@ -52,6 +55,9 @@ namespace xdp {
 				      long long queueAddress,
 				      unsigned long long int functionID)
   {
+    if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
+      return ;
+
     double timestamp = xrt_xocl::time_ns() ;
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 
@@ -68,6 +74,9 @@ namespace xdp {
 
   static void lop_read(unsigned int XRTEventId, bool isStart)
   {
+    if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
+      return ;
+
     double timestamp = xrt_xocl::time_ns() ;
     VPDatabase* db = lopPluginInstance.getDatabase() ;
     
@@ -86,6 +95,9 @@ namespace xdp {
 
   static void lop_write(unsigned int XRTEventId, bool isStart)
   {
+    if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
+      return ;
+
     double timestamp = xrt_xocl::time_ns() ;
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 
@@ -103,6 +115,9 @@ namespace xdp {
 
   static void lop_kernel_enqueue(unsigned int XRTEventId, bool isStart)
   {
+    if (!VPDatabase::alive() || !LowOverheadProfilingPlugin::alive())
+      return ;
+
     double timestamp = xrt_xocl::time_ns() ;
     VPDatabase* db = lopPluginInstance.getDatabase() ;
 

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -20,6 +20,8 @@
 #include "core/common/config_reader.h"
 
 namespace xdp {
+
+  bool LowOverheadProfilingPlugin::live = false;
 
   const char* LowOverheadProfilingPlugin::APIs[] =
     {
@@ -128,6 +130,8 @@ namespace xdp {
 
   LowOverheadProfilingPlugin::LowOverheadProfilingPlugin() : XDPPlugin()
   {
+    LowOverheadProfilingPlugin::live = true ;
+
     db->registerPlugin(this) ;
     db->registerInfo(info::lop);
 
@@ -162,6 +166,6 @@ namespace xdp {
 
       db->unregisterPlugin(this) ;
     }
+    LowOverheadProfilingPlugin::live = false ;
   }
-
 }

--- a/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/lop/lop_plugin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,10 +28,14 @@ namespace xdp {
   class LowOverheadProfilingPlugin : public XDPPlugin
   {
   private:
+    static bool live;
+
     static const char* APIs[] ;
   public:
     LowOverheadProfilingPlugin() ;
     ~LowOverheadProfilingPlugin() ;
+
+    static bool alive() { return LowOverheadProfilingPlugin::live; }
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_cb.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -36,6 +36,9 @@ namespace xdp {
 extern "C"
 void native_function_start(const char* functionName, unsigned long long int functionID)
 {
+  if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
+    return;
+
   // Don't include the profiling overhead in the time that we show.
   //  That means there will be "empty gaps" in the timeline trace when
   //  the profiling overhead exists.
@@ -55,6 +58,9 @@ void native_function_start(const char* functionName, unsigned long long int func
 extern "C"
 void native_function_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp)
 {
+  if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
+    return;
+
   xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase() ;
   db->getStats().logFunctionCallEnd(functionName, static_cast<double>(timestamp)) ;
 
@@ -71,6 +77,9 @@ void native_function_end(const char* functionName, unsigned long long int functi
 extern "C"
 void native_sync_start(const char* functionName, unsigned long long int functionID, bool isWrite)
 {
+  if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
+    return;
+
   // Don't include the profiling overhead in the time that we show.
   //  That means there will be "empty gaps" in the timeline trace when
   //  the profiling overhead exists.
@@ -107,6 +116,9 @@ void native_sync_start(const char* functionName, unsigned long long int function
 extern "C"
 void native_sync_end(const char* functionName, unsigned long long int functionID, unsigned long long int timestamp, bool isWrite, unsigned long long int size)
 {
+  if (!xdp::VPDatabase::alive() || !xdp::NativeProfilingPlugin::alive())
+    return;
+
   xdp::VPDatabase* db = xdp::nativePluginInstance.getDatabase() ;
   db->getStats().logFunctionCallEnd(functionName, static_cast<double>(timestamp)) ;
 

--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -22,8 +22,12 @@
 
 namespace xdp {
 
+  bool NativeProfilingPlugin::live = false;
+
   NativeProfilingPlugin::NativeProfilingPlugin() : XDPPlugin()
   {
+    NativeProfilingPlugin::live = true ;
+
     db->registerPlugin(this) ;
     db->registerInfo(info::native) ;
 
@@ -47,6 +51,7 @@ namespace xdp {
       }
       db->unregisterPlugin(this) ;
     }
+    NativeProfilingPlugin::live = false;
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/native/native_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/native/native_plugin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -24,9 +24,12 @@ namespace xdp {
   class NativeProfilingPlugin : public XDPPlugin
   {
   private:
+    static bool live;
   public:
     NativeProfilingPlugin() ;
     ~NativeProfilingPlugin() ;
+
+    static bool alive() { return NativeProfilingPlugin::live; }
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -18,8 +18,8 @@
 
 #include "core/common/config_reader.h"
 
-#include "xocl/core/platform.h"
 #include "xocl/core/device.h"
+#include "xocl/core/platform.h"
 
 #include "xdp/profile/plugin/opencl/counters/opencl_counters_plugin.h"
 #include "xdp/profile/plugin/vp_base/info.h"
@@ -32,8 +32,12 @@
 
 namespace xdp {
 
+  bool OpenCLCountersProfilingPlugin::live = false;
+
   OpenCLCountersProfilingPlugin::OpenCLCountersProfilingPlugin() : XDPPlugin()
   {
+    OpenCLCountersProfilingPlugin::live = true ;
+
     db->registerPlugin(this) ;
     db->registerInfo(info::opencl_counters) ;
 
@@ -64,6 +68,7 @@ namespace xdp {
       }
       db->unregisterPlugin(this) ;
     }
+    OpenCLCountersProfilingPlugin::live = false;
   }
 
   void OpenCLCountersProfilingPlugin::emulationSetup()

--- a/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/opencl/counters/opencl_counters_plugin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -28,12 +28,16 @@ namespace xdp {
   private:
     std::shared_ptr<xocl::platform> platform ;
 
+    static bool live;
+
   protected:
     virtual void emulationSetup() ;
 
   public:
     OpenCLCountersProfilingPlugin() ;
     ~OpenCLCountersProfilingPlugin() ;
+
+    static bool alive() { return OpenCLCountersProfilingPlugin::live; }
 
     // For emulation based flows we need to convert real time into
     //  estimated device time to match what we reported previously

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_cb.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,13 +16,12 @@
 
 #include <iostream>
 
-#include "xdp/profile/plugin/opencl/trace/opencl_trace_cb.h"
-#include "xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h"
-
+#include "core/common/time.h"
 #include "xdp/profile/database/database.h"
 #include "xdp/profile/database/events/opencl_api_calls.h"
 #include "xdp/profile/database/events/opencl_host_events.h"
-#include "core/common/time.h"
+#include "xdp/profile/plugin/opencl/trace/opencl_trace_cb.h"
+#include "xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h"
 
 namespace xdp {
 
@@ -32,6 +31,9 @@ namespace xdp {
 				 uint64_t queueAddress,
 				 uint64_t functionID)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
@@ -52,6 +54,9 @@ namespace xdp {
 			       uint64_t queueAddress,
 			       uint64_t functionID)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
@@ -68,6 +73,9 @@ namespace xdp {
   // The XRT event "id" cannot start until the XRT event "dependency" has ended
   static void add_dependency(uint64_t id, uint64_t dependency)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     VPDatabase* db = openclPluginInstance.getDatabase() ;
     (db->getDynamicInfo()).addDependency(id, dependency) ;
   }
@@ -79,6 +87,9 @@ namespace xdp {
 			  size_t bufferSize,
 			  bool isP2P)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
@@ -110,6 +121,9 @@ namespace xdp {
 			   size_t bufferSize,
 			   bool isP2P)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
@@ -149,6 +163,9 @@ namespace xdp {
 			  size_t bufferSize,
 			  bool isP2P)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 
@@ -185,6 +202,9 @@ namespace xdp {
 			     size_t workgroupConfigurationZ,
 			     size_t workgroupSize)
   {
+    if (!VPDatabase::alive() || !OpenCLTracePlugin::alive())
+      return;
+
     double timestamp = xrt_core::time_ns() ;
     VPDatabase* db = openclPluginInstance.getDatabase() ;
 

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -26,9 +26,13 @@
 
 namespace xdp {
 
+  bool OpenCLTracePlugin::live = false;
+
   OpenCLTracePlugin::OpenCLTracePlugin() :
     XDPPlugin()
   {
+    OpenCLTracePlugin::live = true;
+
     db->registerPlugin(this) ;
     db->registerInfo(info::opencl_trace) ;
 
@@ -55,6 +59,7 @@ namespace xdp {
       XDPPlugin::endWrite();
       db->unregisterPlugin(this) ;
     }
+    OpenCLTracePlugin::live = false;
   }
 
   void OpenCLTracePlugin::emulationSetup()

--- a/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/opencl/trace/opencl_trace_plugin.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -23,6 +23,11 @@ namespace xdp {
 
   class OpenCLTracePlugin : public XDPPlugin
   {
+  private:
+    // There should only ever be one instance of the OpenCLTracePlugin,
+    // and it is destroyed at the end of the program.  To prevent access after
+    // the instance has been destroyed we have this guard.
+    static bool live;
 
   protected:
     virtual void emulationSetup() ;
@@ -30,6 +35,8 @@ namespace xdp {
   public:
     OpenCLTracePlugin() ;
     ~OpenCLTracePlugin() ;
+
+    static bool alive() { return OpenCLTracePlugin::live; }
   } ;
 
 }


### PR DESCRIPTION
#### Problem solved by the commit
The XDP profiling plugins instantiate static objects when the modules are loaded and these static objects are destroyed at the application end.  During application runs, profiling callbacks are hit when the user calls XRT APIs (such as OpenCL APIs or Native XRT APIs) which interact with the XDP static objects.  A test case exposed the problem where users' code additionally had static objects that called XRT APIs in their destructor, which in turn hit the profiling callbacks and caused seg faults if they happened after the profiling objects had been destroyed.  Since the ordering of how static objects is destroyed is different based on the compiler and OS, there can be no implied ordering and all of the static objects' destructors must work regardless of the order in which they are called.

This pull request adds guards to all profiling plugins' callbacks that could be triggered by the user from their own static object destructors, and makes sure that data is only tracked while the objects are alive.
