### PR TITLE
CR-1113250 Process cannot map host buffer of imported userptr BO

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/ert_ctrl.c
@@ -811,7 +811,6 @@ static int ert_ctrl_remove(struct platform_device *pdev)
 
 static int ert_ctrl_probe(struct platform_device *pdev)
 {
-	const char *const devname = dev_name(&pdev->dev);
 	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	bool ert_on = xocl_ert_on(xdev);
 	struct ert_ctrl	*ec = NULL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -736,6 +736,10 @@ int xocl_userptr_bo_ioctl(
 		goto out1;
 	}
 
+	ret = drm_gem_create_mmap_offset(&xobj->base);
+	if (ret < 0)
+		goto out1;
+
 	ret = drm_gem_handle_create(filp, &xobj->base, &args->handle);
 	if (ret)
 		goto out1;
@@ -774,14 +778,9 @@ int xocl_map_bo_ioctl(struct drm_device *dev,
 	}
 
 	BO_ENTER("xobj %p", xobj);
-	if (xocl_bo_userptr(xobj)) {
-		ret = -EPERM;
-		goto out;
-	}
 	/* The mmap offset was set up at BO allocation time. */
 	args->offset = drm_vma_node_offset_addr(&obj->vma_node);
 	xocl_describe(to_xocl_bo(obj));
-out:
 	XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -285,7 +285,7 @@ int xocl_gem_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #else
 		ret = vm_insert_page(vma, vmf_address, xobj->pages[page_offset]);
 #endif
-	} else if (xocl_bo_cma(xobj)) {
+	} else if (xocl_bo_cma(xobj) || xocl_bo_userptr(xobj)) {
 /*  vm_insert_page does not allow driver to insert anonymous pages.
  *  Instead, we call vm_insert_mixed.
  */
@@ -383,11 +383,8 @@ static void xocl_client_release(struct drm_device *dev, struct drm_file *filp)
 static uint xocl_poll(struct file *filp, poll_table *wait)
 {
 	struct drm_file *priv = filp->private_data;
-	struct drm_device *dev = priv->minor->dev;
-	struct xocl_drm	*drm_p = dev->dev_private;
 
 	BUG_ON(!priv->driver_priv);
-
 	DRM_ENTER("");
 	return xocl_poll_client(filp, wait, priv->driver_priv);
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Allow user BO to be mmap()'ed.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
N/A
#### How problem was solved, alternative solutions (if any) and why they were rejected
N/A
#### Risks (if any) associated the changes in the commit
New feature, low risk
#### What has been tested and how, request additional testing if necessary
The original test case does not work even with the fix. The user pointer is obtained through malloc **before** fork(), which will point to a different physical memory when the user buffer is being updated after the fork due to COW. Hence, child process can never see the updated content even successfully imported the BO. A new test case is created to test the fix and is uploaded in the CR.
#### Documentation impact (if any)
No need to advertise that user BO can be mmap()'ed. No use case.