### PR TITLE
Relaxed mem topology check with ep_reserved_ps_mem_00 endpoint in par…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -221,9 +221,10 @@ static bool is_mem_region_valid(struct xocl_drm *drm_p,
 
 		/*
 		 * Memory region in mem_topology needs to match or
-		 * be inside the PS reserved memory region.
+		 * be inside the PS reserved memory region for U30.
+		 * Restriction relaxed for Versal
 		 */
-		if (mem_start >= start && mem_end <= end)
+		if ((mem_start >= start && mem_end <= end) || (XOCL_DSA_IS_VERSAL(xdev)))
 			return true;
 	}
 


### PR DESCRIPTION
…tition metadata for Versal devices.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil validate on Versal VCK5000 Discovery was failing when adding ep_reserved_ps_mem_00 endpoint to partition metadata to support PS kernels.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature on Versal exposed limitation in xocl_drm memory check

#### How problem was solved, alternative solutions (if any) and why they were rejected
If the device is Versal device, do not error out if memory region do not overlap.

#### Risks (if any) associated the changes in the commit
If PL kernel uses memory region that is outside reserved PS mem region, PS kernel will not be able to access those buffers or call those PL kernels.

#### What has been tested and how, request additional testing if necessary
Tested with xbutil validate with VCK5000 Discovery base 1 platform.

#### Documentation impact (if any)
