### PR TITLE
Changes to enable load xclbin with UUID in PS kernel daemon.

### DIFF
--- a/src/runtime_src/core/common/drv/include/xrt_cu.h
+++ b/src/runtime_src/core/common/drv/include/xrt_cu.h
@@ -234,7 +234,7 @@ struct xrt_cu_info {
 	char			 kname[64];
 	void			*xgq;
 	int			 cu_domain;
-	char			 uuid[16];
+	unsigned char		 uuid[16];
 };
 
 struct per_custat {

--- a/src/runtime_src/core/edge/drm/zocl/scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/scu.c
@@ -88,7 +88,7 @@ static const struct attribute_group scu_attrgroup = {
 	.attrs = scu_attrs,
 };
 
-static int configure_soft_kernel(u32 cuidx, char kname[64], char uuid[16])
+static int configure_soft_kernel(u32 cuidx, char kname[64], unsigned char uuid[16])
 {
 	struct drm_zocl_dev *zdev = zocl_get_zdev();
 	struct soft_krnl *sk = zdev->soft_kernel;
@@ -179,18 +179,14 @@ err:
 
 static int scu_remove(struct platform_device *pdev)
 {
-	struct zocl_scu *zcu = NULL;
-	struct drm_zocl_dev *zdev = NULL;
-	struct xrt_cu_info *info = NULL;
+	struct zocl_scu *zcu = platform_get_drvdata(pdev);
+	struct xrt_cu *xcu = &zcu->base;
+	struct xrt_cu_scu *cu_scu = xcu->core;
+	struct drm_zocl_dev *zdev = zocl_get_zdev();
+	struct xrt_cu_info *info = &zcu->base.info;
 
-	zcu = platform_get_drvdata(pdev);
-	if (!zcu)
-		return -EINVAL;
-
-	info = &zcu->base.info;
 	xrt_cu_scu_fini(&zcu->base);
 
-	zdev = zocl_get_zdev();
 	zocl_kds_del_cu(zdev, &zcu->base);
 
 	if (zcu->base.res)

--- a/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
+++ b/src/runtime_src/core/edge/include/xclhal2_mpsoc.h
@@ -39,7 +39,7 @@ struct xclSKCmd {
     char	krnl_name[XRT_MAX_NAME_LENGTH];
     int		bohdl;
     int		meta_bohdl;
-    char	uuid[16];
+    unsigned char uuid[16];
 };
 
 struct xclAIECmd {

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -442,7 +442,7 @@ struct drm_zocl_sk_getcmd {
 	char		name[ZOCL_MAX_NAME_LENGTH];
 	int		bohdl;
 	int		meta_bohdl;
-	char		uuid[16];
+	unsigned char	uuid[16];
 };
 
 enum aie_info_code {

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -31,7 +31,7 @@ namespace xrt {
    * @param soft kernel CU index
    *
    */
-  skd::skd(xclDeviceHandle handle, int sk_meta_bohdl, int sk_bohdl, char *kname, uint32_t cu_index, char *uuid) {
+  skd::skd(xclDeviceHandle handle, int sk_meta_bohdl, int sk_bohdl, char *kname, uint32_t cu_index, unsigned char *uuid) {
     strcpy(sk_name,kname);
     devHdl = handle;
     xrtdHdl = xrtDeviceOpenFromXcl(handle);
@@ -101,6 +101,8 @@ namespace xrt {
       if(ret) {
 	syslog(LOG_ERR, "Cannot load xclbin from UUID!\n");
 	return -1;
+      } else {
+	syslog(LOG_INFO, "Finished loading xlcin from UUID.\n");
       }
       xrtHandle = kernel_init(devHdl,reinterpret_cast<unsigned char*>(xclbin_uuid));
       if(xrtHandle) {
@@ -181,7 +183,7 @@ namespace xrt {
       /* Reg file indicates the kernel should not be running. */
       if (!(args_from_host[0] & 0x1))
 	continue; //AP_START bit is not set; New Cmd is not available
-      
+
       // FFI PS Kernel implementation
       // Map buffers used by kernel
       for(int i=0;i<num_args;i++) {
@@ -193,7 +195,7 @@ namespace xrt {
 	  uint64_t *buf_size_ptr = (uint64_t*)(&args_from_host[(args[i].offset+PS_KERNEL_REG_OFFSET)/4+2]);
 	  uint64_t buf_size = reinterpret_cast<uint64_t>(*buf_size_ptr);
 	  boSize[i] = buf_size;
-	  
+
 	  boHandles[i] = xclGetHostBO(devHdl,buf_addr,buf_size);
 	  bos[i] = xclMapBO(devHdl,boHandles[i],true);
 	  ffi_arg_values[i] = &bos[i];

--- a/src/runtime_src/core/edge/skd/xrt_skd.h
+++ b/src/runtime_src/core/edge/skd/xrt_skd.h
@@ -69,7 +69,7 @@ class skd
    * @param soft kernel CU index
    *
    */
-  skd(xclDeviceHandle handle, int sk_meta_bohdl, int sk_bohdl, char *kname, uint32_t cu_index, char *uuid);
+  skd(xclDeviceHandle handle, int sk_meta_bohdl, int sk_bohdl, char *kname, uint32_t cu_index, unsigned char *uuid);
   ~skd();
   
   XCL_DRIVER_DLLESPEC
@@ -93,7 +93,7 @@ class skd
     pscontext* xrtHandle = NULL;
     int sk_bo;
     int sk_meta_bo;
-    char xclbin_uuid[16];
+    unsigned char xclbin_uuid[16];
     
     void* sk_handle;
     void* kernel;

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -290,7 +290,7 @@ struct config_sk_image {
   uint32_t start_cuidx;
   uint32_t num_cus;
   uint32_t sk_name[5];
-  char     sk_uuid[16];
+  unsigned char     sk_uuid[16];
 };
 
 /**

--- a/src/runtime_src/core/include/xgq_cmd_ert.h
+++ b/src/runtime_src/core/include/xgq_cmd_ert.h
@@ -234,7 +234,7 @@ struct xgq_cmd_config_cu {
 	uint32_t haddr;
 	uint32_t payload_size;
 	char name[64];
-	char uuid[16];
+	unsigned char uuid[16];
 };
 
 /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Allow loading of xclbin with UUID with only metadata support

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
New feature in PS kernel to support PL kernels and AIE kernels.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed passing of UUID from host all the way to PS kernel daemon, and skipped scheduler init and mmap of kernel controls when loading metadata only

#### Risks (if any) associated the changes in the commit
Will need to verify edge use case

#### What has been tested and how, request additional testing if necessary
Tested with PS kernel with init function that creates xrt::kernel from bandwidth PL kernel

#### Documentation impact (if any)
