### PR TITLE
VITIS 1753 Refactor XRT driver logs

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/axigate.c
@@ -85,7 +85,7 @@ static int axigate_freeze(struct platform_device *pdev)
 done:
 	mutex_unlock(&gate->gate_lock);
 
-	xocl_xdev_info(xdev, "freeze gate %s level %d",
+	xocl_info(XDEV2DEV(xdev), "freeze gate %s level %d",
 			gate->ep_name, gate->level);
 	return 0;
 }
@@ -111,7 +111,7 @@ static int axigate_free(struct platform_device *pdev)
 
 done:
 	mutex_unlock(&gate->gate_lock);
-	xocl_xdev_info(xdev, "free gate %s level %d", gate->ep_name,
+	xocl_info(XDEV2DEV(xdev), "free gate %s level %d", gate->ep_name,
 			gate->level);
 	return 0;
 }
@@ -126,7 +126,7 @@ static int axigate_reset(struct platform_device *pdev)
 	reg_wr(gate, 0x1, iag_wr);
 	mutex_unlock(&gate->gate_lock);
 
-	xocl_xdev_info(xdev, "ep_name %s level %d", gate->ep_name, gate->level);
+	xocl_info(XDEV2DEV(xdev), "ep_name %s level %d", gate->ep_name, gate->level);
 	return 0;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/feature_rom.c
@@ -595,7 +595,7 @@ static int get_header_from_peer(struct feature_rom *rom)
 
 	memcpy(&rom->header, header, sizeof(*header));
 
-	xocl_xdev_dbg(xdev, "Searching CDMA in dtb.");
+	xocl_dbg(XDEV2DEV(xdev), "Searching CDMA in dtb.");
 	offset = xocl_fdt_path_offset(xdev, XDEV(xdev)->fdt_blob,
 				      "/" NODE_ENDPOINTS "/" RESNAME_KDMA);
 	if (offset < 0)
@@ -604,7 +604,7 @@ static int get_header_from_peer(struct feature_rom *rom)
 	io_off = xocl_fdt_getprop(xdev, XDEV(xdev)->fdt_blob, offset,
 				  PROP_IO_OFFSET, NULL);
 	if (!io_off) {
-		xocl_xdev_err(xdev, "dtb maybe corrupted\n");
+		xocl_err(XDEV2DEV(xdev), "dtb maybe corrupted\n");
 		return -EINVAL;
 	}
 	res.start = be64_to_cpu(io_off[0]);
@@ -612,7 +612,7 @@ static int get_header_from_peer(struct feature_rom *rom)
 	memset(rom->header.CDMABaseAddress, 0,
 	       sizeof(rom->header.CDMABaseAddress));
 	rom->header.CDMABaseAddress[0] = (uint32_t)res.start;
-	xocl_xdev_dbg(xdev, "CDMA is on, CU offset: 0x%x",
+	xocl_dbg(XDEV2DEV(xdev), "CDMA is on, CU offset: 0x%x",
 		       rom->header.CDMABaseAddress[0]);
 
 	return 0;
@@ -636,7 +636,7 @@ static int init_rom_by_dtb(struct feature_rom *rom)
 	if (XDEV(xdev)->fdt_blob) {
 		vbnv = fdt_getprop(XDEV(xdev)->fdt_blob, 0, "vbnv", NULL);
 		if (vbnv) {
-			xocl_xdev_dbg(xdev, "found vbnv prop, %s", vbnv);
+			xocl_dbg(XDEV2DEV(xdev), "found vbnv prop, %s", vbnv);
 			strncpy(header->VBNVName, vbnv,
 				sizeof(header->VBNVName) - 1);
 			for (i = 0; i < strlen(header->VBNVName); i++)
@@ -646,18 +646,18 @@ static int init_rom_by_dtb(struct feature_rom *rom)
 		}
 	}
 
-	xocl_xdev_dbg(xdev, "Searching ERT and CMC in dtb.");
+	xocl_dbg(XDEV2DEV(xdev), "Searching ERT and CMC in dtb.");
 	ret = xocl_subdev_get_resource(xdev, NODE_CMC_FW_MEM,
 			IORESOURCE_MEM, &res);
 	if (!ret) {
-		xocl_xdev_dbg(xdev, "CMC is on");
+		xocl_dbg(XDEV2DEV(xdev), "CMC is on");
 		header->FeatureBitMap |= BOARD_MGMT_ENBLD;
 	}
 
 	ret = xocl_subdev_get_resource(xdev, NODE_ERT_FW_MEM,
 			IORESOURCE_MEM, &res);
 	if (!ret) {
-		xocl_xdev_dbg(xdev, "ERT is on");
+		xocl_dbg(XDEV2DEV(xdev), "ERT is on");
 		header->FeatureBitMap |= MB_SCHEDULER;
 	}
 
@@ -693,19 +693,19 @@ static int get_header_from_vsec(struct feature_rom *rom)
 		if (XDEV(xdev)->priv.flags & XOCL_DSAFLAG_CUSTOM_DTB) {
 			rom->uuid_len = strlen(rom_uuid);
 			if (rom->uuid_len == 0 || rom->uuid_len > 64) {
-				xocl_xdev_info(xdev, "Invalid ROM UUID");
+				xocl_info(XDEV2DEV(xdev), "Invalid ROM UUID");
 				return -EINVAL;
 			}
 			strcpy(rom->uuid,rom_uuid);
-			xocl_xdev_info(xdev, "rom UUID is: %s",rom->uuid);
+			xocl_info(XDEV2DEV(xdev), "rom UUID is: %s",rom->uuid);
 			return init_rom_by_dtb(rom);
 		}
-		xocl_xdev_info(xdev, "Does not get UUID ROM");
+		xocl_info(XDEV2DEV(xdev), "Does not get UUID ROM");
 		return -ENODEV;
 	}
 
 	offset += pci_resource_start(XDEV(xdev)->pdev, bar);
-	xocl_xdev_dbg(xdev, "Mapping uuid at offset 0x%llx", offset);
+	xocl_dbg(XDEV2DEV(xdev), "Mapping uuid at offset 0x%llx", offset);
 	rom->base = ioremap_nocache(offset, PAGE_SIZE);
 	rom->uuid_len = 32;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/icap.c
@@ -1093,19 +1093,19 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 	mbreq.req = XCL_MAILBOX_REQ_CHG_SHELL;
 	mutex_lock(&icap->icap_lock);
 	if (flag == RP_DOWNLOAD_CLEAR) {
-		xocl_xdev_info(xdev, "Clear firmware bins");
+		xocl_info(XDEV2DEV(xdev), "Clear firmware bins");
 		icap_free_bins(icap);
 		goto end;
 	}
 	if (!icap->rp_bit || !icap->rp_fdt) {
-		xocl_xdev_err(xdev, "Invalid reprogram request %p.%p",
+		xocl_err(XDEV2DEV(xdev), "Invalid reprogram request %p.%p",
 			icap->rp_bit, icap->rp_fdt);
 		ret = -EINVAL;
 		goto failed;
 	}
 
 	if (!XDEV(xdev)->blp_blob) {
-		xocl_xdev_err(xdev, "Empty BLP blob");
+		xocl_err(XDEV2DEV(xdev), "Empty BLP blob");
 		ret = -EINVAL;
 		goto failed;
 	}
@@ -1113,7 +1113,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 	ret = xocl_fdt_check_uuids(xdev, icap->rp_fdt,
 		XDEV(xdev)->blp_blob);
 	if (ret) {
-		xocl_xdev_err(xdev, "Incompatible uuids");
+		xocl_err(XDEV2DEV(xdev), "Incompatible uuids");
 		goto failed;
 	}
 
@@ -1129,13 +1129,13 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 	ret = xocl_fdt_blob_input(xdev, icap->rp_fdt, icap->rp_fdt_len,
 			XOCL_SUBDEV_LEVEL_PRP, icap->rp_vbnv);
 	if (ret) {
-		xocl_xdev_err(xdev, "failed to parse fdt %d", ret);
+		xocl_err(XDEV2DEV(xdev), "failed to parse fdt %d", ret);
 		goto failed;
 	}
 
 	ret = xocl_axigate_freeze(xdev, XOCL_SUBDEV_LEVEL_BLD);
 	if (ret) {
-		xocl_xdev_err(xdev, "freeze blp gate failed %d", ret);
+		xocl_err(XDEV2DEV(xdev), "freeze blp gate failed %d", ret);
 		goto failed;
 	}
 
@@ -1157,7 +1157,7 @@ static int icap_download_rp(struct platform_device *pdev, int level, int flag)
 
 	ret = xocl_axigate_free(xdev, XOCL_SUBDEV_LEVEL_BLD);
 	if (ret) {
-		xocl_xdev_err(xdev, "freeze blp gate failed %d", ret);
+		xocl_err(XDEV2DEV(xdev), "freeze blp gate failed %d", ret);
 		goto failed;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -3728,7 +3728,7 @@ static int raptor_cmc_access(struct platform_device *pdev,
 		 */
 		addr = xocl_iores_get_offset(xdev, IORES_GAPPING);
 		if (addr == (uint64_t)-1) {
-			xocl_xdev_info(xdev, "No %s resource, skip.",
+			xocl_info(XDEV2DEV(xdev), "No %s resource, skip.",
 			    NODE_GAPPING);
 			return 0;
 		}
@@ -3744,17 +3744,17 @@ static int raptor_cmc_access(struct platform_device *pdev,
 		val &= ~0x1FFFFFF;
 		val |= ((addr & 0x01FFFFFF) | XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT);
 		WRITE_REG32(xmc, val, XMC_HOST_NEW_FEATURE_REG1);
-		xocl_xdev_info(xdev, "%s is 0x%llx, set New Feature Table to 0x%x\n",
+		xocl_info(XDEV2DEV(xdev), "%s is 0x%llx, set New Feature Table to 0x%x\n",
 		    NODE_GAPPING, addr, val);
 	} else if (flags == XOCL_XMC_FREEZE) {
 		grant = 0;
 	} else {
-		xocl_xdev_info(xdev, "invalid flags %d", flags);
+		xocl_info(XDEV2DEV(xdev), "invalid flags %d", flags);
 		return -EINVAL;
 	}
 
 	if (!xmc->base_addrs[IO_MUTEX]) {
-		xocl_xdev_info(xdev, "No %s resource, skip.",
+		xocl_info(XDEV2DEV(xdev), "No %s resource, skip.",
 		    NODE_CMC_MUTEX);
 		return 0;
 	}
@@ -3770,14 +3770,14 @@ static int raptor_cmc_access(struct platform_device *pdev,
 	}
 
 	if ((grant & MUTEX_GRANT_MASK) != (ack & MUTEX_ACK_MASK)) {
-		xocl_xdev_err(xdev,
+		xocl_err(XDEV2DEV(xdev),
 		    "Grant falied. The bit 0 in Ack (0x%x) is not the same "
 		    "in grant (0x%x)", ack, grant);
 		err = -EBUSY;
 		goto fail;
 	}
 
-	xocl_xdev_info(xdev, "%s CMC succeeded.",
+	xocl_info(XDEV2DEV(xdev), "%s CMC succeeded.",
 	    flags == XOCL_XMC_FREE ? "Grant" : "Release");
 fail:
 	return err;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc_u2.c
@@ -3551,7 +3551,7 @@ static int raptor_cmc_access(struct platform_device *pdev,
 		 */
 		addr = xocl_iores_get_offset(xdev, IORES_GAPPING);
 		if (addr == (uint64_t)-1) {
-			xocl_xdev_info(xdev, "No %s resource, skip.",
+			xocl_info(XDEV2DEV(xdev), "No %s resource, skip.",
 			    NODE_GAPPING);
 			return 0;
 		}
@@ -3567,17 +3567,17 @@ static int raptor_cmc_access(struct platform_device *pdev,
 		val &= ~0x1FFFFFF;
 		val |= ((addr & 0x01FFFFFF) | XMC_HOST_NEW_FEATURE_REG1_FEATURE_PRESENT);
 		WRITE_REG32(xmc, val, XMC_HOST_NEW_FEATURE_REG1);
-		xocl_xdev_info(xdev, "%s is 0x%llx, set New Feature Table to 0x%x\n",
+		xocl_info(XDEV2DEV(xdev), "%s is 0x%llx, set New Feature Table to 0x%x\n",
 		    NODE_GAPPING, addr, val);
 	} else if (flags == XOCL_XMC_FREEZE) {
 		grant = 0;
 	} else {
-		xocl_xdev_info(xdev, "invalid flags %d", flags);
+		xocl_info(XDEV2DEV(xdev), "invalid flags %d", flags);
 		return -EINVAL;
 	}
 
 	if (!xmc->base_addrs[IO_MUTEX]) {
-		xocl_xdev_info(xdev, "No %s resource, skip.",
+		xocl_info(XDEV2DEV(xdev), "No %s resource, skip.",
 		    NODE_CMC_MUTEX);
 		return 0;
 	}
@@ -3593,14 +3593,14 @@ static int raptor_cmc_access(struct platform_device *pdev,
 	}
 
 	if ((grant & MUTEX_GRANT_MASK) != (ack & MUTEX_ACK_MASK)) {
-		xocl_xdev_err(xdev,
+		xocl_err(XDEV2DEV(xdev),
 		    "Grant falied. The bit 0 in Ack (0x%x) is not the same "
 		    "in grant (0x%x)", ack, grant);
 		err = -EBUSY;
 		goto fail;
 	}
 
-	xocl_xdev_info(xdev, "%s CMC succeeded.",
+	xocl_info(XDEV2DEV(xdev), "%s CMC succeeded.",
 	    flags == XOCL_XMC_FREE ? "Grant" : "Release");
 fail:
 	return err;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/common.h
@@ -41,19 +41,20 @@
 	((XOCL_DRIVER_MAJOR)*1000 + (XOCL_DRIVER_MINOR)*100 +   \
 	XOCL_DRIVER_PATCHLEVEL)
 
-#define userpf_err(d, args...)                     \
-	xocl_err(&XDEV(d)->pdev->dev, ##args)
-#define userpf_info(d, args...)                    \
-	xocl_info(&XDEV(d)->pdev->dev, ##args)
-#define userpf_dbg(d, args...)                     \
-	xocl_dbg(&XDEV(d)->pdev->dev, ##args)
+/*#define userpf_err(d, args...)                     \
+ *	xocl_err(&XDEV(d)->pdev->dev, ##args)
+ *#define userpf_info(d, args...)                    \
+ *	xocl_info(&XDEV(d)->pdev->dev, ##args)
+ *#define userpf_dbg(d, args...)                     \
+ *	xocl_dbg(&XDEV(d)->pdev->dev, ##args)
+ */
 #define userpf_info_once(d, args...)               \
 ({                                                 \
 	 static bool __info_once __read_mostly;    \
 						   \
 	 if (!__info_once) {                       \
 		 __info_once = true;               \
-		 userpf_info(d, ##args);           \
+		 xocl_info(XDEV2DEV(d), ##args);           \
 	 }                                         \
  })
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -286,12 +286,12 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 
 	if (topo) {
 		if (XOCL_IS_STREAM(topo, ddr)) {
-			xocl_err(&XDEV(xdev), "Bank %d is Stream", ddr);
+			xocl_err(XDEV2DEV(xdev), "Bank %d is Stream", ddr);
 			err = -EINVAL;
 			goto done;
 		}
 		if (!XOCL_IS_DDR_USED(topo, ddr)) {
-			xocl_err(&XDEV(xdev),
+			xocl_err(XDEV2DEV(xdev),
 				"Bank %d is marked as unused in axlf", ddr);
 			err = -EINVAL;
 			goto done;
@@ -925,14 +925,14 @@ static int xocl_migrate_unmgd(struct xocl_dev *xdev, uint64_t data_ptr, uint64_t
 
 	ret = xocl_init_unmgd(&unmgd, data_ptr, size, dir);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "init unmgd failed %d", ret);
+		xocl_err(XDEV2DEV(xdev), "init unmgd failed %d", ret);
 		return ret;
 	}
 
 	channel = xocl_acquire_channel(xdev, dir);
 
 	if (channel < 0) {
-		xocl_err(&XDEV(xdev), "acquire channel failed");
+		xocl_err(XDEV2DEV(xdev), "acquire channel failed");
 		ret = -EINVAL;
 		goto clear;
 	}
@@ -1412,7 +1412,7 @@ int xocl_pwrite_unmgd_ioctl(struct drm_device *dev, void *data,
 	int ret = 0;
 
 	if (args->address_space != 0) {
-		xocl_err(&XDEV(xdev), "invalid addr space");
+		xocl_err(XDEV2DEV(xdev), "invalid addr space");
 		return -EFAULT;
 	}
 
@@ -1423,7 +1423,7 @@ int xocl_pwrite_unmgd_ioctl(struct drm_device *dev, void *data,
 	 * it is unclear that what addresses are valid other than
 	 * ddr area. we should revisit this sometime.
 	 * if (!xocl_validate_paddr(xdev, args->paddr, args->size)) {
-	 *	xocl_err(&XDEV(xdev), "invalid paddr: 0x%llx, size:0x%llx",
+	 *	xocl_err(XDEV2DEV(xdev), "invalid paddr: 0x%llx, size:0x%llx",
 	 *		args->paddr, args->size);
 	 *	return -EINVAL;
 	 * }
@@ -1444,7 +1444,7 @@ int xocl_pread_unmgd_ioctl(struct drm_device *dev, void *data,
 	int ret = 0;
 
 	if (args->address_space != 0) {
-		xocl_err(&XDEV(xdev), "invalid addr space");
+		xocl_err(XDEV2DEV(xdev), "invalid addr space");
 		return -EFAULT;
 	}
 
@@ -1455,7 +1455,7 @@ int xocl_pread_unmgd_ioctl(struct drm_device *dev, void *data,
 	 * it is unclear that what addresses are valid other than
 	 * ddr area. we should revisit this sometime.
 	 * if (!xocl_validate_paddr(xdev, args->paddr, args->size)) {
-	 *	xocl_err(&XDEV(xdev), "invalid paddr: 0x%llx, size:0x%llx",
+	 *	xocl_err(XDEV2DEV(xdev), "invalid paddr: 0x%llx, size:0x%llx",
 	 *		args->paddr, args->size);
 	 *	return -EINVAL;
 	 * }
@@ -1501,7 +1501,7 @@ static int get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 
 	obj = xocl_gem_object_lookup(ddev, filp, bo_hdl);
 	if (!obj) {
-		xocl_err(&XDEV(xdev), "Failed to look up GEM BO 0x%x\n", bo_hdl);
+		xocl_err(XDEV2DEV(xdev), "Failed to look up GEM BO 0x%x\n", bo_hdl);
 		return -ENOENT;
 	}
 
@@ -1513,7 +1513,7 @@ static int get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 	}
 
 	if (obj->size <= off || obj->size < off + size) {
-		xocl_err(&XDEV(xdev), "Failed to get paddr for BO 0x%x\n", bo_hdl);
+		xocl_err(XDEV2DEV(xdev), "Failed to get paddr for BO 0x%x\n", bo_hdl);
 		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 		return -EINVAL;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_bo.c
@@ -286,12 +286,12 @@ static inline int check_bo_user_reqs(const struct drm_device *dev,
 
 	if (topo) {
 		if (XOCL_IS_STREAM(topo, ddr)) {
-			userpf_err(xdev, "Bank %d is Stream", ddr);
+			xocl_err(&XDEV(xdev), "Bank %d is Stream", ddr);
 			err = -EINVAL;
 			goto done;
 		}
 		if (!XOCL_IS_DDR_USED(topo, ddr)) {
-			userpf_err(xdev,
+			xocl_err(&XDEV(xdev),
 				"Bank %d is marked as unused in axlf", ddr);
 			err = -EINVAL;
 			goto done;
@@ -401,7 +401,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 		if (xobj->flags &
 		    (XOCL_USER_MEM | XOCL_DRM_IMPORT | XOCL_P2P_MEM)) {
 			err = -EINVAL;
-			xocl_xdev_err(xdev, "invalid HOST BO req. flag %x",
+			xocl_err(XDEV2DEV(xdev), "invalid HOST BO req. flag %x",
 				xobj->flags);
 			goto failed;
 		}
@@ -436,7 +436,7 @@ static struct drm_xocl_bo *xocl_create_bo(struct drm_device *dev,
 	}
 
 	/* Attempt to allocate buffer on the requested DDR */
-	xocl_xdev_dbg(xdev, "alloc bo from bank%u, flag %x, host bank %d",
+	xocl_dbg(XDEV2DEV(xdev), "alloc bo from bank%u, flag %x, host bank %d",
 		memidx, xobj->flags, drm_p->cma_bank_idx);
 
 	err = xocl_mm_insert_node(drm_p, memidx, xobj->mm_node,
@@ -569,7 +569,7 @@ __xocl_create_bo_ioctl(struct drm_device *dev,
 				xobj->base.size,
 				&bar_off);
 			if (ret) {
-				xocl_xdev_err(xdev, "map P2P failed,ret = %d",
+				xocl_err(XDEV2DEV(xdev), "map P2P failed,ret = %d",
 						ret);
 			} else
 				xobj->p2p_bar_offset = bar_off;
@@ -925,14 +925,14 @@ static int xocl_migrate_unmgd(struct xocl_dev *xdev, uint64_t data_ptr, uint64_t
 
 	ret = xocl_init_unmgd(&unmgd, data_ptr, size, dir);
 	if (ret) {
-		userpf_err(xdev, "init unmgd failed %d", ret);
+		xocl_err(&XDEV(xdev), "init unmgd failed %d", ret);
 		return ret;
 	}
 
 	channel = xocl_acquire_channel(xdev, dir);
 
 	if (channel < 0) {
-		userpf_err(xdev, "acquire channel failed");
+		xocl_err(&XDEV(xdev), "acquire channel failed");
 		ret = -EINVAL;
 		goto clear;
 	}
@@ -1412,7 +1412,7 @@ int xocl_pwrite_unmgd_ioctl(struct drm_device *dev, void *data,
 	int ret = 0;
 
 	if (args->address_space != 0) {
-		userpf_err(xdev, "invalid addr space");
+		xocl_err(&XDEV(xdev), "invalid addr space");
 		return -EFAULT;
 	}
 
@@ -1423,7 +1423,7 @@ int xocl_pwrite_unmgd_ioctl(struct drm_device *dev, void *data,
 	 * it is unclear that what addresses are valid other than
 	 * ddr area. we should revisit this sometime.
 	 * if (!xocl_validate_paddr(xdev, args->paddr, args->size)) {
-	 *	userpf_err(xdev, "invalid paddr: 0x%llx, size:0x%llx",
+	 *	xocl_err(&XDEV(xdev), "invalid paddr: 0x%llx, size:0x%llx",
 	 *		args->paddr, args->size);
 	 *	return -EINVAL;
 	 * }
@@ -1444,7 +1444,7 @@ int xocl_pread_unmgd_ioctl(struct drm_device *dev, void *data,
 	int ret = 0;
 
 	if (args->address_space != 0) {
-		userpf_err(xdev, "invalid addr space");
+		xocl_err(&XDEV(xdev), "invalid addr space");
 		return -EFAULT;
 	}
 
@@ -1455,7 +1455,7 @@ int xocl_pread_unmgd_ioctl(struct drm_device *dev, void *data,
 	 * it is unclear that what addresses are valid other than
 	 * ddr area. we should revisit this sometime.
 	 * if (!xocl_validate_paddr(xdev, args->paddr, args->size)) {
-	 *	userpf_err(xdev, "invalid paddr: 0x%llx, size:0x%llx",
+	 *	xocl_err(&XDEV(xdev), "invalid paddr: 0x%llx, size:0x%llx",
 	 *		args->paddr, args->size);
 	 *	return -EINVAL;
 	 * }
@@ -1501,7 +1501,7 @@ static int get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 
 	obj = xocl_gem_object_lookup(ddev, filp, bo_hdl);
 	if (!obj) {
-		userpf_err(xdev, "Failed to look up GEM BO 0x%x\n", bo_hdl);
+		xocl_err(&XDEV(xdev), "Failed to look up GEM BO 0x%x\n", bo_hdl);
 		return -ENOENT;
 	}
 
@@ -1513,7 +1513,7 @@ static int get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 	}
 
 	if (obj->size <= off || obj->size < off + size) {
-		userpf_err(xdev, "Failed to get paddr for BO 0x%x\n", bo_hdl);
+		xocl_err(&XDEV(xdev), "Failed to get paddr for BO 0x%x\n", bo_hdl);
 		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 		return -EINVAL;
 	}

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -118,7 +118,7 @@ static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
 	xdev_handle_t xdev = drm_p->xdev;
 
 	if (vma->vm_pgoff > MAX_CUS) {
-		userpf_err(xdev, "invalid native mmap offset: 0x%lx",
+		xocl_err(&XDEV(xdev), "invalid native mmap offset: 0x%lx",
 			vma->vm_pgoff);
 		return -EINVAL;
 	}
@@ -128,7 +128,7 @@ static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
 
 	if (vma->vm_pgoff == 0) {
 		if (vsize > XDEV(xdev)->bar_size) {
-			userpf_err(xdev,
+			xocl_err(&XDEV(xdev),
 				"bad size (0x%lx) for native BAR mmap", vsize);
 			return -EINVAL;
 		}
@@ -151,11 +151,11 @@ static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
 				 res_start >> PAGE_SHIFT,
 				 vsize, vma->vm_page_prot);
 	if (ret != 0) {
-		userpf_err(xdev, "io_remap_pfn_range failed: %d", ret);
+		xocl_err(&XDEV(xdev), "io_remap_pfn_range failed: %d", ret);
 		return ret;
 	}
 
-	userpf_info(xdev, "successful native mmap @0x%lx with size 0x%lx",
+	xocl_info(&XDEV(xdev), "successful native mmap @0x%lx with size 0x%lx",
 		vma->vm_pgoff >> PAGE_SHIFT, vsize);
 	return ret;
 }
@@ -554,14 +554,14 @@ void *xocl_drm_init(xdev_handle_t xdev_hdl)
 
 	ddev = drm_dev_alloc(&mm_drm_driver, &XDEV(xdev_hdl)->pdev->dev);
 	if (!ddev) {
-		xocl_xdev_err(xdev_hdl, "alloc drm dev failed");
+		xocl_err(XDEV2DEV(xdev_hdl), "alloc drm dev failed");
 		ret = -ENOMEM;
 		goto failed;
 	}
 
 	drm_p = xocl_drvinst_alloc(&XDEV(xdev_hdl)->pdev->dev, sizeof(*drm_p));
 	if (!drm_p) {
-		xocl_xdev_err(xdev_hdl, "alloc drm inst failed");
+		xocl_err(XDEV2DEV(xdev_hdl), "alloc drm inst failed");
 		ret = -ENOMEM;
 		goto failed;
 	}
@@ -578,7 +578,7 @@ void *xocl_drm_init(xdev_handle_t xdev_hdl)
 
 	ret = drm_dev_register(ddev, 0);
 	if (ret) {
-		xocl_xdev_err(xdev_hdl, "register drm dev failed 0x%x", ret);
+		xocl_err(XDEV2DEV(xdev_hdl), "register drm dev failed 0x%x", ret);
 		goto failed;
 	}
 	drm_registered = true;
@@ -588,7 +588,7 @@ void *xocl_drm_init(xdev_handle_t xdev_hdl)
 #if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 4, 0)
 	ret = drm_dev_set_unique(ddev, dev_name(ddev->dev));
 	if (ret) {
-		xocl_xdev_err(xdev_hdl, "set unique name failed 0x%x", ret);
+		xocl_err(XDEV2DEV(xdev_hdl), "set unique name failed 0x%x", ret);
 		goto failed;
 	}
 #endif

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drm.c
@@ -118,7 +118,7 @@ static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
 	xdev_handle_t xdev = drm_p->xdev;
 
 	if (vma->vm_pgoff > MAX_CUS) {
-		xocl_err(&XDEV(xdev), "invalid native mmap offset: 0x%lx",
+		xocl_err(XDEV2DEV(xdev), "invalid native mmap offset: 0x%lx",
 			vma->vm_pgoff);
 		return -EINVAL;
 	}
@@ -128,7 +128,7 @@ static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
 
 	if (vma->vm_pgoff == 0) {
 		if (vsize > XDEV(xdev)->bar_size) {
-			xocl_err(&XDEV(xdev),
+			xocl_err(XDEV2DEV(xdev),
 				"bad size (0x%lx) for native BAR mmap", vsize);
 			return -EINVAL;
 		}
@@ -151,11 +151,11 @@ static int xocl_native_mmap(struct file *filp, struct vm_area_struct *vma)
 				 res_start >> PAGE_SHIFT,
 				 vsize, vma->vm_page_prot);
 	if (ret != 0) {
-		xocl_err(&XDEV(xdev), "io_remap_pfn_range failed: %d", ret);
+		xocl_err(XDEV2DEV(xdev), "io_remap_pfn_range failed: %d", ret);
 		return ret;
 	}
 
-	xocl_info(&XDEV(xdev), "successful native mmap @0x%lx with size 0x%lx",
+	xocl_info(XDEV2DEV(xdev), "successful native mmap @0x%lx with size 0x%lx",
 		vma->vm_pgoff >> PAGE_SHIFT, vsize);
 	return ret;
 }

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -281,14 +281,14 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 	if (!force && !list_is_singular(&xdev->ctx_list)) {
 		/* We should have one context for ourselves. */
 		BUG_ON(list_empty(&xdev->ctx_list));
-		xocl_err(&XDEV(xdev), "device is in use, can't program");
+		xocl_err(XDEV2DEV(xdev), "device is in use, can't program");
 		ret = -EBUSY;
 	}
 	mutex_unlock(&xdev->dev_lock);
 	if (ret < 0)
 		return ret;
 
-	xocl_info(&XDEV(xdev), "program shell...");
+	xocl_info(XDEV2DEV(xdev), "program shell...");
 
 	xocl_drvinst_set_offline(xdev->core.drm, true);
 
@@ -305,7 +305,7 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 
 	ret = xocl_subdev_offline_all(xdev);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "failed to offline subdevs %d", ret);
+		xocl_err(XDEV2DEV(xdev), "failed to offline subdevs %d", ret);
 		goto failed;
 	}
 
@@ -314,20 +314,20 @@ int xocl_program_shell(struct xocl_dev *xdev, bool force)
 
 	ret = xocl_subdev_online_by_id(xdev, XOCL_SUBDEV_MAILBOX);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "online mailbox failed %d", ret);
+		xocl_err(XDEV2DEV(xdev), "online mailbox failed %d", ret);
 		goto failed;
 	}
 	ret = xocl_peer_listen(xdev, xocl_mailbox_srv, (void *)xdev);
 	if (ret)
 		goto failed;
 
-	xocl_info(&XDEV(xdev), "request mgmtpf to program prp");
+	xocl_info(XDEV2DEV(xdev), "request mgmtpf to program prp");
 	mbret = xocl_peer_request(xdev, &mbreq, sizeof(struct xcl_mailbox_req),
 		&ret, &resplen, NULL, NULL, 0, 0);
 	if (mbret)
 		ret = mbret;
 	if (ret) {
-		xocl_info(&XDEV(xdev), "request program prp failed %d, mret %d",
+		xocl_info(XDEV2DEV(xdev), "request program prp failed %d, mret %d",
 				ret, mbret);
 		goto failed;
 	}
@@ -374,14 +374,14 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 	if (!(flag & XOCL_RESET_FORCE) && !list_is_singular(&xdev->ctx_list)) {
 		/* We should have one context for ourselves. */
 		BUG_ON(list_empty(&xdev->ctx_list));
-		xocl_err(&XDEV(xdev), "device is in use, can't reset");
+		xocl_err(XDEV2DEV(xdev), "device is in use, can't reset");
 		ret = -EBUSY;
 	}
 	mutex_unlock(&xdev->dev_lock);
 	if (ret < 0)
 		return ret;
 
-	xocl_info(&XDEV(xdev), "resetting device...");
+	xocl_info(XDEV2DEV(xdev), "resetting device...");
 
 	if (flag & XOCL_RESET_FORCE)
 		xocl_drvinst_kill_proc(xdev->core.drm);
@@ -412,7 +412,7 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 		 *  successfully.
 		 */
 		if (mbret || (ret && ret != -ESHUTDOWN)) {
-			xocl_err(&XDEV(xdev), "reset request failed, mbret: %d, peer resp: %d",
+			xocl_err(XDEV2DEV(xdev), "reset request failed, mbret: %d, peer resp: %d",
 					   mbret, ret);
 			xocl_reset_notify(xdev->core.pdev, false);
 			xocl_drvinst_set_offline(xdev->core.drm, false);
@@ -439,16 +439,16 @@ int xocl_hot_reset(struct xocl_dev *xdev, u32 flag)
 	if (!mbret && ret == -ESHUTDOWN)
 		flag |= XOCL_RESET_SHUTDOWN;
 	if (mbret) {
-		xocl_err(&XDEV(xdev), "Requested peer failed %d", mbret);
+		xocl_err(XDEV2DEV(xdev), "Requested peer failed %d", mbret);
 		ret = mbret;
 		goto failed_notify;
 	}
 	if (ret) {
-		xocl_err(&XDEV(xdev), "Hotreset peer response %d", ret);
+		xocl_err(XDEV2DEV(xdev), "Hotreset peer response %d", ret);
 		goto failed_notify;
 	}
 
-	xocl_info(&XDEV(xdev), "Set master off then wait it on");
+	xocl_info(XDEV2DEV(xdev), "Set master off then wait it on");
 	pci_read_config_word(pdev, PCI_COMMAND, &pci_cmd);
 	pci_cmd &= ~PCI_COMMAND_MASTER;
 	pci_write_config_word(pdev, PCI_COMMAND, pci_cmd);
@@ -631,7 +631,7 @@ static void xocl_mb_connect(struct xocl_dev *xdev)
 	 */
 	xocl_xmc_get_serial_num(xdev);
 
-	xocl_info(&XDEV(xdev), "ch_state 0x%llx, ret %d\n", resp->conn_flags, ret);
+	xocl_info(XDEV2DEV(xdev), "ch_state 0x%llx, ret %d\n", resp->conn_flags, ret);
 
 done:
 	kfree(kaddr);
@@ -670,7 +670,7 @@ int xocl_reclock(struct xocl_dev *xdev, void *data)
 	memcpy(req->data, data, data_len);
 
 	if (get_live_clients(xdev, NULL)) {
-		xocl_err(&XDEV(xdev), "device is in use, can't reset");
+		xocl_err(XDEV2DEV(xdev), "device is in use, can't reset");
 		err = -EBUSY;
 	}
 
@@ -706,11 +706,11 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 	if (err != 0)
 		return;
 
-	xocl_info(&XDEV(xdev), "received request (%d) from peer\n", req->req);
+	xocl_info(XDEV2DEV(xdev), "received request (%d) from peer\n", req->req);
 
 	switch (req->req) {
 	case XCL_MAILBOX_REQ_FIREWALL:
-		xocl_info(&XDEV(xdev),
+		xocl_info(XDEV2DEV(xdev),
 			"Card is in a BAD state, please issue xbutil reset");
 		err_last.pid = 0;
 		err_last.ts = 0; //TODO timestamp
@@ -726,15 +726,15 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 		st = (struct xcl_mailbox_peer_state *)req->data;
 		if (st->state_flags & XCL_MB_STATE_ONLINE) {
 			/* Mgmt is online, try to probe peer */
-			xocl_info(&XDEV(xdev), "mgmt driver online\n");
+			xocl_info(XDEV2DEV(xdev), "mgmt driver online\n");
 			xocl_queue_work(xdev, XOCL_WORK_REFRESH_SUBDEV, 1);
 
 		} else if (st->state_flags & XCL_MB_STATE_OFFLINE) {
 			/* Mgmt is offline, mark peer as not ready */
-			xocl_info(&XDEV(xdev), "mgmt driver offline\n");
+			xocl_info(XDEV2DEV(xdev), "mgmt driver offline\n");
 			(void) xocl_mailbox_set(xdev, CHAN_STATE, 0);
 		} else {
-			xocl_err(&XDEV(xdev), "unknown peer state flag (0x%llx)\n",
+			xocl_err(XDEV2DEV(xdev), "unknown peer state flag (0x%llx)\n",
 				st->state_flags);
 		}
 		break;
@@ -743,7 +743,7 @@ static void xocl_mailbox_srv(void *arg, void *data, size_t len,
 				XOCL_PROGRAM_SHELL_DELAY);
 		break;
 	default:
-		xocl_err(&XDEV(xdev), "dropped bad request (%d)\n", req->req);
+		xocl_err(XDEV2DEV(xdev), "dropped bad request (%d)\n", req->req);
 		break;
 	}
 }
@@ -757,7 +757,7 @@ void store_pcie_link_info(struct xocl_dev *xdev)
 	result = pcie_capability_read_word(xdev->core.pdev, pos, &stat);
 	if (result) {
 		xdev->pci_stat.link_width_max = xdev->pci_stat.link_speed_max = 0;
-		xocl_err(&XDEV(xdev), "Read pcie capability failed for offset: 0x%x", pos);
+		xocl_err(XDEV2DEV(xdev), "Read pcie capability failed for offset: 0x%x", pos);
 	} else {
 		xdev->pci_stat.link_width_max = (stat & PCI_EXP_LNKSTA_NLW) >>
 			PCI_EXP_LNKSTA_NLW_SHIFT;
@@ -769,7 +769,7 @@ void store_pcie_link_info(struct xocl_dev *xdev)
 	result = pcie_capability_read_word(xdev->core.pdev, pos, &stat);
 	if (result) {
 		xdev->pci_stat.link_width = xdev->pci_stat.link_speed = 0;
-		xocl_err(&XDEV(xdev), "Read pcie capability failed for offset: 0x%x", pos);
+		xocl_err(XDEV2DEV(xdev), "Read pcie capability failed for offset: 0x%x", pos);
 	} else {
 		xdev->pci_stat.link_width = (stat & PCI_EXP_LNKSTA_NLW) >>
 			PCI_EXP_LNKSTA_NLW_SHIFT;
@@ -802,7 +802,7 @@ uint64_t xocl_get_data(struct xocl_dev *xdev, enum data_kind kind)
 		ret = xocl_icap_get_data(xdev, MIG_CALIB);
 		break;
 	default:
-		xocl_err(&XDEV(xdev), "dropped bad request (%d)\n", kind);
+		xocl_err(XDEV2DEV(xdev), "dropped bad request (%d)\n", kind);
 		break;
 	}
 
@@ -828,12 +828,12 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 	ret = xocl_drvinst_get_offline(xdev->core.drm, &offline);
 	if (ret == -ENODEV || offline) {
-		xocl_info(&XDEV(xdev), "online current devices");
+		xocl_info(XDEV2DEV(xdev), "online current devices");
 	        xocl_reset_notify(xdev->core.pdev, false);
 		xocl_drvinst_set_offline(xdev->core.drm, false);
 	}
 
-	xocl_info(&XDEV(xdev), "get fdt from peer");
+	xocl_info(XDEV2DEV(xdev), "get fdt from peer");
 	mb_req = vzalloc(reqlen);
 	if (!mb_req) {
 		ret = -ENOMEM;
@@ -899,7 +899,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 	if (resp->rtncode != XOCL_MSG_SUBDEV_RTN_COMPLETE &&
 		resp->rtncode != XOCL_MSG_SUBDEV_RTN_UNCHANGED) {
-		xocl_err(&XDEV(xdev), "Unexpected return code %d", resp->rtncode);
+		xocl_err(XDEV2DEV(xdev), "Unexpected return code %d", resp->rtncode);
 		ret = -EINVAL;
 		goto failed;
 	}
@@ -914,7 +914,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 	if (blob) {
 		ret = xocl_fdt_blob_input(xdev, blob, blob_len, -1, NULL);
 		if (ret) {
-			xocl_err(&XDEV(xdev), "parse blob failed %d", ret);
+			xocl_err(XDEV2DEV(xdev), "parse blob failed %d", ret);
 			goto failed;
 		}
 		blob = NULL;
@@ -932,25 +932,25 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 	ret = identify_bar(xdev);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "failed to identify bar");
+		xocl_err(XDEV2DEV(xdev), "failed to identify bar");
 		goto failed;
 	}
 
 	ret = xocl_subdev_create_all(xdev);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "create subdev failed %d", ret);
+		xocl_err(XDEV2DEV(xdev), "create subdev failed %d", ret);
 		goto failed;
 	}
 
 	ret = xocl_p2p_init(xdev);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "failed to init p2p memory");
+		xocl_err(XDEV2DEV(xdev), "failed to init p2p memory");
 		goto failed;
 	}
 
 	ret = xocl_hwmon_sdm_init(xdev);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "failed to init hwmon_sdm driver, err: %d", ret);
+		xocl_err(XDEV2DEV(xdev), "failed to init hwmon_sdm driver, err: %d", ret);
 		ret = 0;
 	}
 
@@ -958,14 +958,14 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 
 	ret = xocl_init_sysfs(xdev);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "Unable to create sysfs %d", ret);
+		xocl_err(XDEV2DEV(xdev), "Unable to create sysfs %d", ret);
 		goto failed;
 	}
 
 	if (!xdev->core.drm) {
 		xdev->core.drm = xocl_drm_init(xdev);
 		if (!xdev->core.drm) {
-			xocl_err(&XDEV(xdev), "Unable to init drm");
+			xocl_err(XDEV2DEV(xdev), "Unable to init drm");
 			goto failed;
 		}
 	}
@@ -1039,7 +1039,7 @@ static int xocl_hwmon_sdm_init_sysfs(struct xocl_dev *xdev, enum xcl_group_kind 
 
 	ret = xocl_peer_request(xdev, mb_req, reqlen, in_buf, &resp_len, NULL, NULL, 0, 0);
 	if (ret) {
-		xocl_err(&XDEV(xdev), "sdr peer request failed, err: %d", ret);
+		xocl_err(XDEV2DEV(xdev), "sdr peer request failed, err: %d", ret);
 		goto done;
 	}
 
@@ -1049,9 +1049,9 @@ static int xocl_hwmon_sdm_init_sysfs(struct xocl_dev *xdev, enum xcl_group_kind 
 
 	ret = xocl_hwmon_sdm_create_sensors_sysfs(xdev, in_buf, resp_len, kind);
 	if (ret)
-		xocl_err(&XDEV(xdev), "hwmon_sdm sysfs creation failed for xcl_sdr 0x%x, err: %d", kind, ret);
+		xocl_err(XDEV2DEV(xdev), "hwmon_sdm sysfs creation failed for xcl_sdr 0x%x, err: %d", kind, ret);
 	else
-		xocl_dbg(&XDEV(xdev), "successfully created hwmon_sdm sensor sysfs node for xcl_sdr 0x%x", kind);
+		xocl_dbg(XDEV2DEV(xdev), "successfully created hwmon_sdm sensor sysfs node for xcl_sdr 0x%x", kind);
 
 done:
 	vfree(in_buf);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_ioctl.c
@@ -37,7 +37,7 @@ int xocl_info_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	struct pci_dev *pdev = xdev->core.pdev;
 	u32 major, minor, patch;
 
-	xocl_info(&XDEV(xdev), "INFO IOCTL");
+	xocl_info(XDEV2DEV(xdev), "INFO IOCTL");
 
 	sscanf(XRT_DRIVER_VERSION, "%d.%d.%d", &major, &minor, &patch);
 
@@ -253,7 +253,7 @@ static bool xclbin_downloaded(struct xocl_dev *xdev, xuid_t *xclbin_id)
 
 	xocl_p2p_conf_status(xdev, &changed);
 	if (changed) {
-		xocl_info(&XDEV(xdev), "p2p configure changed\n");
+		xocl_info(XDEV2DEV(xdev), "p2p configure changed\n");
 		return false;
 	}
 
@@ -263,7 +263,7 @@ static bool xclbin_downloaded(struct xocl_dev *xdev, xuid_t *xclbin_id)
 
 	if (downloaded_xclbin && uuid_equal(downloaded_xclbin, xclbin_id)) {
 		ret = true;
-		xocl_info(&XDEV(xdev), "xclbin is already downloaded\n");
+		xocl_info(XDEV2DEV(xdev), "xclbin is already downloaded\n");
 	}
 	XOCL_PUT_XCLBIN_ID(xdev);
 
@@ -319,10 +319,10 @@ static int xocl_preserve_mem(struct xocl_drm *drm_p, struct mem_topology *new_to
 	if (xocl_icap_get_data(xdev, DATA_RETAIN) && (topology != NULL) && drm_p->mm) {
 		if ((size == sizeof_sect(topology, m_mem_data)) &&
 		    !xocl_preserve_memcmp(new_topology, topology, size)) {
-			xocl_info(&XDEV(xdev), "preserving mem_topology.");
+			xocl_info(XDEV2DEV(xdev), "preserving mem_topology.");
 			ret = 1;
 		} else {
-			xocl_info(&XDEV(xdev), "not preserving mem_topology.");
+			xocl_info(XDEV2DEV(xdev), "not preserving mem_topology.");
 		}
 	}
 	XOCL_PUT_MEM_TOPOLOGY(xdev);
@@ -335,7 +335,7 @@ static bool xocl_xclbin_in_use(struct xocl_dev *xdev)
 	BUG_ON(!xdev);
 
 	if (live_clients(xdev, NULL) || atomic_read(&xdev->outstanding_execs)) {
-		xocl_err(&XDEV(xdev), " Current xclbin is in-use, can't change\n");
+		xocl_err(XDEV2DEV(xdev), " Current xclbin is in-use, can't change\n");
 		return true;
 	}
 	return false;
@@ -358,18 +358,18 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	bool force_download = false;
 
 	if (!xocl_is_unified(xdev)) {
-		xocl_err(&XDEV(xdev), "XOCL: not unified Shell\n");
+		xocl_err(XDEV2DEV(xdev), "XOCL: not unified Shell\n");
 		return -EINVAL;
 	}
 
 	if (copy_from_user(&bin_obj, axlf_ptr->xclbin, sizeof(struct axlf)))
 		return -EFAULT;
 	if (memcmp(bin_obj.m_magic, ICAP_XCLBIN_V2, sizeof(ICAP_XCLBIN_V2))) {
-		xocl_err(&XDEV(xdev), "invalid xclbin magic string\n");
+		xocl_err(XDEV2DEV(xdev), "invalid xclbin magic string\n");
 		return -EINVAL;
 	}
 	if (uuid_is_null(&bin_obj.m_header.uuid)) {
-		xocl_err(&XDEV(xdev), "invalid xclbin uuid\n");
+		xocl_err(XDEV2DEV(xdev), "invalid xclbin uuid\n");
 		return -EINVAL;
 	}
 
@@ -404,14 +404,14 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 
 	/* Really need to download, sanity check xclbin, first. */
 	if (xocl_xrt_version_check(xdev, &bin_obj, true)) {
-		xocl_err(&XDEV(xdev), "Xclbin isn't supported by current XRT\n");
+		xocl_err(XDEV2DEV(xdev), "Xclbin isn't supported by current XRT\n");
 		err = -EINVAL;
 		goto done;
 	}
 
 	if (!xocl_verify_timestamp(xdev,
 		bin_obj.m_header.m_featureRomTimeStamp)) {
-		xocl_err(&XDEV(xdev), "TimeStamp of ROM did not match Xclbin\n");
+		xocl_err(XDEV2DEV(xdev), "TimeStamp of ROM did not match Xclbin\n");
 		err = -EOPNOTSUPP;
 		goto done;
 	}
@@ -419,7 +419,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	/* Copy bitstream from user space and proceed. */
 	axlf = vmalloc(bin_obj.m_header.m_length);
 	if (!axlf) {
-		xocl_err(&XDEV(xdev), "Unable to alloc mem for xclbin, size=%llu\n",
+		xocl_err(XDEV2DEV(xdev), "Unable to alloc mem for xclbin, size=%llu\n",
 			bin_obj.m_header.m_length);
 		err = -ENOMEM;
 		goto done;
@@ -435,7 +435,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 		ulp_blob = (char*)axlf + dtbHeader->m_sectionOffset;
 		if (fdt_check_header(ulp_blob) || fdt_totalsize(ulp_blob) >
 				dtbHeader->m_sectionSize) {
-			xocl_err(&XDEV(xdev), "Invalid PARTITION_METADATA");
+			xocl_err(XDEV2DEV(xdev), "Invalid PARTITION_METADATA");
 			err = -EINVAL;
 			goto done;
 		}
@@ -460,7 +460,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 				(const void *)XDEV(xdev)->fdt_blob,
 				(const void *)((char*)xdev->ulp_blob));
 			if (err) {
-				xocl_err(&XDEV(xdev), "interface uuids do not match");
+				xocl_err(XDEV2DEV(xdev), "interface uuids do not match");
 				err = -EINVAL;
 				goto done;
 			}
@@ -505,7 +505,7 @@ xocl_read_axlf_helper(struct xocl_drm *drm_p, struct drm_xocl_axlf *axlf_ptr)
 	if (axlf_ptr->ksize) {
 		kernels = vmalloc(axlf_ptr->ksize);
 		if (!kernels) {
-			xocl_err(&XDEV(xdev), "Unable to alloc mem for kernels, size=%u\n",
+			xocl_err(XDEV2DEV(xdev), "Unable to alloc mem for kernels, size=%u\n",
 				   axlf_ptr->ksize);
 			err = -ENOMEM;
 			goto done;
@@ -551,10 +551,10 @@ done:
 	if (size < 0)
 		err = size;
 	if (err) {
-		xocl_err(&XDEV(xdev), "Failed to download xclbin, err: %ld\n", err);
+		xocl_err(XDEV2DEV(xdev), "Failed to download xclbin, err: %ld\n", err);
 	}
 	else
-		xocl_info(&XDEV(xdev), "Loaded xclbin %pUb", &bin_obj.m_header.uuid);
+		xocl_info(XDEV2DEV(xdev), "Loaded xclbin %pUb", &bin_obj.m_header.uuid);
 
 	vfree(axlf);
 	return err;
@@ -608,7 +608,7 @@ int xocl_reclock_ioctl(struct drm_device *dev, void *data,
 	err = xocl_reclock(xdev, data);
 	xocl_drvinst_set_offline(xdev->core.drm, false);
 
-	xocl_info(&XDEV(xdev), "%s err: %d\n", __func__, err);
+	xocl_info(XDEV2DEV(xdev), "%s err: %d\n", __func__, err);
 	return err;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -62,7 +62,7 @@ get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 
 	obj = xocl_gem_object_lookup(ddev, filp, bo_hdl);
 	if (!obj) {
-		userpf_err(xdev, "Failed to look up GEM BO 0x%x\n", bo_hdl);
+		xocl_err(&XDEV(xdev), "Failed to look up GEM BO 0x%x\n", bo_hdl);
 		return -ENOENT;
 	}
 
@@ -74,7 +74,7 @@ get_bo_paddr(struct xocl_dev *xdev, struct drm_file *filp,
 	}
 
 	if (obj->size <= off || obj->size < off + size) {
-		userpf_err(xdev, "Failed to get paddr for BO 0x%x\n", bo_hdl);
+		xocl_err(&XDEV(xdev), "Failed to get paddr for BO 0x%x\n", bo_hdl);
 		XOCL_DRM_GEM_OBJECT_PUT_UNLOCKED(obj);
 		return -EINVAL;
 	}
@@ -124,11 +124,11 @@ static int copybo_ecmd2xcmd(struct xocl_dev *xdev, struct drm_file *filp,
 	if (cu_mgmt->num_cdma == 0)
 		return -EINVAL;
 
-	userpf_info(xdev,"checking alignment requirments for KDMA sz(%lu)",sz);
+	xocl_info(&XDEV(xdev),"checking alignment requirments for KDMA sz(%lu)",sz);
 	if ((dst_addr + dst_off) % KDMA_BLOCK_SIZE ||
 	    (src_addr + src_off) % KDMA_BLOCK_SIZE ||
 	    sz % KDMA_BLOCK_SIZE) {
-		userpf_err(xdev,"improper alignment, cannot use KDMA");
+		xocl_err(&XDEV(xdev),"improper alignment, cannot use KDMA");
 		return -EINVAL;
 	}
 
@@ -152,7 +152,7 @@ sk_ecmd2xcmd(struct xocl_dev *xdev, struct ert_packet *ecmd,
 	     struct kds_command *xcmd)
 {
 	if (XDEV(xdev)->kds.ert_disable) {
-		userpf_err(xdev, "Soft kernels cannot be used if ERT is off");
+		xocl_err(&XDEV(xdev), "Soft kernels cannot be used if ERT is off");
 		return -EINVAL;
 	}
 
@@ -247,14 +247,14 @@ static int xocl_del_context(struct xocl_dev *xdev, struct kds_client *client,
 	/* xclCloseContext() would send xclbin_id and cu_idx.
 	 * Be more cautious while delete. Do sanity check */
 	if (!uuid) {
-		userpf_err(xdev, "No context was opened");
+		xocl_err(&XDEV(xdev), "No context was opened");
 		ret = -EINVAL;
 		goto out;
 	}
 
 	/* If xclbin id looks good, unlock bitstream should not fail. */
 	if (!uuid_equal(uuid, &args->xclbin_id)) {
-		userpf_err(xdev, "Try to delete CTX on wrong xclbin");
+		xocl_err(&XDEV(xdev), "Try to delete CTX on wrong xclbin");
 		ret = -EBUSY;
 		goto out;
 	}
@@ -290,7 +290,7 @@ xocl_open_ucu(struct xocl_dev *xdev, struct kds_client *client,
 	int ret;
 
 	if (!kds->cu_intr_cap) {
-		userpf_err(xdev, "Shell not support CU to host interrupt");
+		xocl_err(&XDEV(xdev), "Shell not support CU to host interrupt");
 		return -EOPNOTSUPP;
 	}
 
@@ -298,7 +298,7 @@ xocl_open_ucu(struct xocl_dev *xdev, struct kds_client *client,
 	if (ret < 0)
 		return ret;
 
-	userpf_info(xdev, "User manage interrupt found, disable ERT");
+	xocl_info(&XDEV(xdev), "User manage interrupt found, disable ERT");
 	xocl_ert_user_disable(xdev);
 
 	return ret;
@@ -513,7 +513,7 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 
 	pkg_size = sizeof(ecmd->header) + ecmd->count * sizeof(u32);
 	if (xobj->base.size < pkg_size) {
-		userpf_err(xdev, "payload size bigger than exec buf\n");
+		xocl_err(&XDEV(xdev), "payload size bigger than exec buf\n");
 		err_last.pid = pid_nr(task_tgid(current));
 		err_last.ts = 0; //TODO timestamp
 		err_last.err_code = XRT_ERROR_NUM_KDS_EXEC;
@@ -525,12 +525,12 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 
 	/* opcode specific validation */
 	if (!ert_valid_opcode(ecmd)) {
-		userpf_err(xdev, "opcode(%d) is invalid\n", ecmd->opcode);
+		xocl_err(&XDEV(xdev), "opcode(%d) is invalid\n", ecmd->opcode);
 		return false;
 	}
 
 	if (get_size_with_timestamps_or_zero(ecmd) > xobj->base.size) {
-		userpf_err(xdev, "no space for timestamp in exec buf\n");
+		xocl_err(&XDEV(xdev), "no space for timestamp in exec buf\n");
 		return false;
 	}
 
@@ -538,7 +538,7 @@ static bool copy_and_validate_execbuf(struct xocl_dev *xdev,
 		return true;
 
 	if (kds->ert && (kds->ert->slot_size > 0) && (kds->ert->slot_size < pkg_size)) {
-		userpf_err(xdev, "payload size bigger than CQ slot size\n");
+		xocl_err(&XDEV(xdev), "payload size bigger than CQ slot size\n");
 		return false;
 	}
 
@@ -647,7 +647,7 @@ static int xocl_fill_payload_xgq(struct xocl_dev *xdev, struct kds_command *xcmd
 		}
 		break;
 	default:
-		userpf_err(xdev, "Unsupport command op(%d)\n", ecmd->opcode);
+		xocl_err(&XDEV(xdev), "Unsupport command op(%d)\n", ecmd->opcode);
 		ret = -EINVAL;
 	}
 
@@ -667,18 +667,18 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	int ret = 0;
 
 	if (!client->ctx->xclbin_id) {
-		userpf_err(xdev, "The client has no opening context\n");
+		xocl_err(&XDEV(xdev), "The client has no opening context\n");
 		return -EINVAL;
 	}
 
 	if (XDEV(xdev)->kds.bad_state) {
-		userpf_err(xdev, "KDS is in bad state\n");
+		xocl_err(&XDEV(xdev), "KDS is in bad state\n");
 		return -EDEADLK;
 	}
 
 	obj = xocl_gem_object_lookup(ddev, filp, args->exec_bo_handle);
 	if (!obj) {
-		userpf_err(xdev, "Failed to look up GEM BO %d\n",
+		xocl_err(&XDEV(xdev), "Failed to look up GEM BO %d\n",
 		args->exec_bo_handle);
 		return -ENOENT;
 	}
@@ -686,7 +686,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	xobj = to_xocl_bo(obj);
 
 	if (!xocl_bo_execbuf(xobj)) {
-		userpf_err(xdev, "Command buffer is not exec buf\n");
+		xocl_err(&XDEV(xdev), "Command buffer is not exec buf\n");
 		return false;
 	}
 
@@ -695,7 +695,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	 * It is safe to make the assumption and validate will be simpler.
 	 */
 	if (xobj->base.size < PAGE_SIZE) {
-		userpf_err(xdev, "exec buf is too small\n");
+		xocl_err(&XDEV(xdev), "exec buf is too small\n");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -708,7 +708,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 
 	/* If xobj contain a valid command, ecmd would be a copy */
 	if (!copy_and_validate_execbuf(xdev, xobj, ecmd)) {
-		userpf_err(xdev, "Invalid command\n");
+		xocl_err(&XDEV(xdev), "Invalid command\n");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -718,7 +718,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 	 */
 	xcmd = kds_alloc_command(client, ecmd->count * sizeof(u32));
 	if (!xcmd) {
-		userpf_err(xdev, "Failed to alloc xcmd\n");
+		xocl_err(&XDEV(xdev), "Failed to alloc xcmd\n");
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -812,7 +812,7 @@ static int xocl_command_ioctl(struct xocl_dev *xdev, void *data,
 		abort_ecmd2xcmd(to_abort_pkg(ecmd), xcmd);
 		break;
 	default:
-		userpf_err(xdev, "Unsupport command\n");
+		xocl_err(&XDEV(xdev), "Unsupport command\n");
 		ret = -EINVAL;
 		goto out1;
 	}
@@ -876,7 +876,7 @@ int xocl_create_client(struct xocl_dev *xdev, void **priv)
 	*priv = client;
 
 out:
-	userpf_info(xdev, "created KDS client for pid(%d), ret: %d\n",
+	xocl_info(&XDEV(xdev), "created KDS client for pid(%d), ret: %d\n",
 		    pid_nr(task_tgid(current)), ret);
 	return ret;
 }
@@ -894,7 +894,7 @@ void xocl_destroy_client(struct xocl_dev *xdev, void **priv)
 		vfree(client->ctx->xclbin_id);
 	}
 	kfree(client);
-	userpf_info(xdev, "client exits pid(%d)\n", pid);
+	xocl_info(&XDEV(xdev), "client exits pid(%d)\n", pid);
 }
 
 int xocl_poll_client(struct file *filp, poll_table *wait, void *priv)
@@ -1083,7 +1083,7 @@ static int xocl_detect_fa_cmdmem(struct xocl_dev *xdev)
 		size = FA_MEM_MAX_SIZE;
 	ret = xocl_p2p_get_bar_paddr(xdev, base_addr, size, &bar_paddr);
 	if (ret) {
-		userpf_err(xdev, "Cannot get p2p BAR address");
+		xocl_err(&XDEV(xdev), "Cannot get p2p BAR address");
 		goto done;
 	}
 
@@ -1094,19 +1094,19 @@ static int xocl_detect_fa_cmdmem(struct xocl_dev *xdev)
 	args.flags = XCL_BO_FLAGS_P2P | mem_idx;
 	bo = xocl_drm_create_bo(XOCL_DRM(xdev), size, args.flags);
 	if (IS_ERR(bo)) {
-		userpf_err(xdev, "Cannot create bo for fast adapter");
+		xocl_err(&XDEV(xdev), "Cannot create bo for fast adapter");
 		ret = -ENOMEM;
 		goto done;
 	}
 
 	vaddr = ioremap_wc(bar_paddr, size);
 	if (!vaddr) {
-		userpf_err(xdev, "Map failed");
+		xocl_err(&XDEV(xdev), "Map failed");
 		ret = -ENOMEM;
 		goto done;
 	}
 
-	userpf_info(xdev, "fast adapter memory on bank(%d), size 0x%llx",
+	xocl_info(&XDEV(xdev), "fast adapter memory on bank(%d), size 0x%llx",
 		   mem_idx, size);
 
 	XDEV(xdev)->kds.cmdmem.bo = bo;
@@ -1206,7 +1206,7 @@ static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 
 	xcmd = kds_alloc_command(client, ecmd->count * sizeof(u32));
 	if (!xcmd) {
-		userpf_err(xdev, "Failed to alloc xcmd\n");
+		xocl_err(&XDEV(xdev), "Failed to alloc xcmd\n");
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -1224,7 +1224,7 @@ static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 		goto out;
 
 	if (ecmd->state != ERT_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Cfg command state %d. ERT will be disabled",
+		xocl_err(&XDEV(xdev), "Cfg command state %d. ERT will be disabled",
 			   ecmd->state);
 		ret = 0;
 		kds->ert_disable = true;
@@ -1235,7 +1235,7 @@ static int xocl_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 	if (!kds->ini_disable)
 		kds->ert_disable = cfg->ert ? false : true;
 
-	userpf_info(xdev, "Cfg command completed");
+	xocl_info(&XDEV(xdev), "Cfg command completed");
 
 out:
 	return ret;
@@ -1281,7 +1281,7 @@ static int xocl_scu_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 
 	xcmd = kds_alloc_command(client, ecmd->count * sizeof(u32));
 	if (!xcmd) {
-		userpf_err(xdev, "Failed to alloc xcmd\n");
+		xocl_err(&XDEV(xdev), "Failed to alloc xcmd\n");
 		ret = -ENOMEM;
 		goto out;
 	}
@@ -1304,11 +1304,11 @@ static int xocl_scu_cfg_cmd(struct xocl_dev *xdev, struct kds_client *client,
 		goto out;
 
 	if (ecmd->state > ERT_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "PS kernel cfg command state %d", ecmd->state);
+		xocl_err(&XDEV(xdev), "PS kernel cfg command state %d", ecmd->state);
 		ret = 0;
 		kds->ert_disable = true;
 	} else
-		userpf_info(xdev, "PS kernel cfg command completed");
+		xocl_info(&XDEV(xdev), "PS kernel cfg command completed");
 
 out:
 	return ret;
@@ -1330,13 +1330,13 @@ static int xocl_config_ert(struct xocl_dev *xdev, struct drm_xocl_kds cfg,
 	client = kds->anon_client;
 	ret = xocl_cfg_cmd(xdev, client, ecmd, &cfg);
 	if (ret) {
-		userpf_err(xdev, "ERT config command failed");
+		xocl_err(&XDEV(xdev), "ERT config command failed");
 		goto out;
 	}
 
 	ret = xocl_scu_cfg_cmd(xdev, client, ecmd, ps_kernel);
 	if (ret)
-		userpf_err(xdev, "PS kernel config failed");
+		xocl_err(&XDEV(xdev), "PS kernel config failed");
 
 out:
 	vfree(ecmd);
@@ -1374,7 +1374,7 @@ xocl_kds_fill_cu_info(struct xocl_dev *xdev, int slot_hdl, struct ip_layout *ip_
 	for (i = 0; i < num_cus; i++) {
 		krnl_info = xocl_query_kernel(xdev, cu_info[i].kname);
 		if (!krnl_info) {
-			userpf_info(xdev, "%s has no metadata. Ignore", cu_info[i].kname);
+			xocl_info(&XDEV(xdev), "%s has no metadata. Ignore", cu_info[i].kname);
 			continue;
 		}
 
@@ -1434,7 +1434,7 @@ xocl_kds_fill_scu_info(struct xocl_dev *xdev, int slot_hdl, struct ip_layout *ip
 		krnl_info = xocl_query_kernel(xdev, cu_info[i].kname);
 		if (!krnl_info) {
 			/* Workaround for U30, maybe we can remove this in the future */
-			userpf_info(xdev, "%s has no metadata. Use default", cu_info[i].kname);
+			xocl_info(&XDEV(xdev), "%s has no metadata. Use default", cu_info[i].kname);
 			continue;
 		}
 
@@ -1467,7 +1467,7 @@ xocl_kds_create_cus(struct xocl_dev *xdev, struct xrt_cu_info *cu_info,
 		subdev_info.data_len = sizeof(struct xrt_cu_info);
 		subdev_info.override_idx = i;
 		if (xocl_subdev_create(xdev, &subdev_info))
-			userpf_info(xdev, "Create CU %s failed. Skip", cu_info[i].iname);
+			xocl_info(&XDEV(xdev), "Create CU %s failed. Skip", cu_info[i].iname);
 	}
 }
 
@@ -1484,7 +1484,7 @@ xocl_kds_create_scus(struct xocl_dev *xdev, struct xrt_cu_info *cu_info,
 		subdev_info.data_len = sizeof(struct xrt_cu_info);
 		subdev_info.override_idx = i;
 		if (xocl_subdev_create(xdev, &subdev_info))
-			userpf_info(xdev, "Create SCU %s failed. Skip", cu_info[i].iname);
+			xocl_info(&XDEV(xdev), "Create SCU %s failed. Skip", cu_info[i].iname);
 	}
 }
 
@@ -1512,10 +1512,10 @@ static int xocl_kds_update_legacy(struct xocl_dev *xdev, struct drm_xocl_kds cfg
 	 */
 	if (ret == -ENODEV || !brd.cap.cu_intr) {
 		ret = 0;
-		userpf_info(xdev, "Not support CU to host interrupt");
+		xocl_info(&XDEV(xdev), "Not support CU to host interrupt");
 		XDEV(xdev)->kds.cu_intr_cap = 0;
 	} else {
-		userpf_info(xdev, "Shell supports CU to host interrupt");
+		xocl_info(&XDEV(xdev), "Shell supports CU to host interrupt");
 		XDEV(xdev)->kds.cu_intr_cap = 1;
 	}
 
@@ -1523,7 +1523,7 @@ static int xocl_kds_update_legacy(struct xocl_dev *xdev, struct drm_xocl_kds cfg
 	xocl_ert_user_enable(xdev);
 	ret = xocl_config_ert(xdev, cfg, ps_kernel);
 	if (ret)
-		userpf_info(xdev, "ERT configure failed, ret %d", ret);
+		xocl_info(&XDEV(xdev), "ERT configure failed, ret %d", ret);
 
 	kfree(cu_info);
 	return ret;
@@ -1579,7 +1579,7 @@ xocl_kds_xgq_identify(struct xocl_dev *xdev, int *major, int *minor)
 		return ret;
 
 	if (resp.hdr.cstate != XGQ_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Config start failed cstate(%d) rcode(%d)",
+		xocl_err(&XDEV(xdev), "Config start failed cstate(%d) rcode(%d)",
 			   resp.hdr.cstate, resp.rcode);
 		return -EINVAL;
 	}
@@ -1632,12 +1632,12 @@ xocl_kds_xgq_cfg_start(struct xocl_dev *xdev, struct drm_xocl_kds cfg, int num_c
 		return ret;
 
 	if (resp.hdr.cstate != XGQ_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Config start failed cstate(%d) rcode(%d)",
+		xocl_err(&XDEV(xdev), "Config start failed cstate(%d) rcode(%d)",
 			   resp.hdr.cstate, resp.rcode);
 		return -EINVAL;
 	}
 
-	userpf_info(xdev, "Config start completed, num_cus(%d), num_scus(%d)\n",
+	xocl_info(&XDEV(xdev), "Config start completed, num_cus(%d), num_scus(%d)\n",
 		    cfg_start->num_cus, cfg_start->num_scus);
 	return 0;
 }
@@ -1676,11 +1676,11 @@ xocl_kds_xgq_cfg_end(struct xocl_dev *xdev)
 		return ret;
 
 	if (resp.hdr.cstate != XGQ_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Config end failed cstate(%d) rcode(%d)",
+		xocl_err(&XDEV(xdev), "Config end failed cstate(%d) rcode(%d)",
 			   resp.hdr.cstate, resp.rcode);
 		return -EINVAL;
 	}
-	userpf_info(xdev, "Config end completed\n");
+	xocl_info(&XDEV(xdev), "Config end completed\n");
 	return 0;
 }
 
@@ -1755,12 +1755,12 @@ xocl_kds_xgq_cfg_cu(struct xocl_dev *xdev, xuid_t *xclbin_id, struct xrt_cu_info
 			break;
 
 		if (resp.hdr.cstate != XGQ_CMD_STATE_COMPLETED) {
-			userpf_err(xdev, "Config CU failed cstate(%d) rcode(%d)",
+			xocl_err(&XDEV(xdev), "Config CU failed cstate(%d) rcode(%d)",
 				   resp.hdr.cstate, resp.rcode);
 			ret = -EINVAL;
 			break;
 		}
-		userpf_info(xdev, "Config CU(%d) completed\n", cfg_cu->cu_idx);
+		xocl_info(&XDEV(xdev), "Config CU(%d) completed\n", cfg_cu->cu_idx);
 	}
 
 	return ret;
@@ -1823,7 +1823,7 @@ xocl_kds_xgq_cfg_scu(struct xocl_dev *xdev, xuid_t *xclbin_id, struct xrt_cu_inf
 			break;
 
 		if (xcmd->status != KDS_COMPLETED) {
-			userpf_err(xdev, "Configure XGQ ERT failed");
+			xocl_err(&XDEV(xdev), "Configure XGQ ERT failed");
 			ret = -EINVAL;
 			break;
 		}
@@ -1868,15 +1868,15 @@ static int xocl_kds_xgq_query_cu(struct xocl_dev *xdev, u32 cu_idx, u32 cu_domai
 		return ret;
 
 	if (resp->hdr.cstate != XGQ_CMD_STATE_COMPLETED) {
-		userpf_err(xdev, "Query CU(%d) failed cstate(%d) rcode(%d)",
+		xocl_err(&XDEV(xdev), "Query CU(%d) failed cstate(%d) rcode(%d)",
 			   cu_idx, resp->hdr.cstate, resp->rcode);
 		return -EINVAL;
 	}
 
-	userpf_info(xdev, "Query Doamin(%d) CU(%d) completed\n", query_cu->cu_domain, query_cu->cu_idx);
-	userpf_info(xdev, "xgq_id %d\n", resp->xgq_id);
-	userpf_info(xdev, "size %d\n", resp->size);
-	userpf_info(xdev, "offset 0x%x\n", resp->offset);
+	xocl_info(&XDEV(xdev), "Query Doamin(%d) CU(%d) completed\n", query_cu->cu_domain, query_cu->cu_idx);
+	xocl_info(&XDEV(xdev), "xgq_id %d\n", resp->xgq_id);
+	xocl_info(&XDEV(xdev), "size %d\n", resp->size);
+	xocl_info(&XDEV(xdev), "offset 0x%x\n", resp->offset);
 	return 0;
 }
 
@@ -1903,7 +1903,7 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 	  * We will re-looking at this once at supporting multiple xclbins.
 	  */
 	if (num_cus > 64) {
-		userpf_err(xdev, "More than 64 CUs found\n");
+		xocl_err(&XDEV(xdev), "More than 64 CUs found\n");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -1928,9 +1928,9 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 	 * can help host to know the different behaviors of the firmware.
 	 */
 	xocl_kds_xgq_identify(xdev, &major, &minor);
-	userpf_info(xdev, "Got ERT XGQ command version %d.%d\n", major, minor);
+	xocl_info(&XDEV(xdev), "Got ERT XGQ command version %d.%d\n", major, minor);
 	if (major != 1 && minor != 0) {
-		userpf_err(xdev, "Only support ERT XGQ command 1.0\n");
+		xocl_err(&XDEV(xdev), "Only support ERT XGQ command 1.0\n");
 		ret = -EINVAL;
 		goto out;
 	}
@@ -1965,7 +1965,7 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 
 		xgq = xocl_ert_ctrl_setup_xgq(xdev, resp.xgq_id, resp.offset);
 		if (IS_ERR(xgq)) {
-			userpf_err(xdev, "Setup XGQ failed\n");
+			xocl_err(&XDEV(xdev), "Setup XGQ failed\n");
 			ret = PTR_ERR(xgq);
 			goto create_regular_cu;
 		}
@@ -1985,7 +1985,7 @@ static int xocl_kds_update_xgq(struct xocl_dev *xdev, int slot_hdl,
 
 		xgq = xocl_ert_ctrl_setup_xgq(xdev, resp.xgq_id, resp.offset);
 		if (IS_ERR(xgq)) {
-			userpf_err(xdev, "Setup XGQ failed\n");
+			xocl_err(&XDEV(xdev), "Setup XGQ failed\n");
 			ret = PTR_ERR(xgq);
 			goto create_regular_cu;
 		}
@@ -2003,7 +2003,7 @@ create_regular_cu:
 	XDEV(xdev)->kds.xgq_enable = false;
 
 out:
-	userpf_info(xdev, "scheduler config ert(%d)\n",
+	xocl_info(&XDEV(xdev), "scheduler config ert(%d)\n",
 		    XDEV(xdev)->kds.xgq_enable);
 	kfree(cu_info);
 	kfree(scu_info);
@@ -2021,7 +2021,7 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 
 	ret = xocl_detect_fa_cmdmem(xdev);
 	if (ret) {
-		userpf_info(xdev, "Detect FA cmdmem failed, ret %d", ret);
+		xocl_info(&XDEV(xdev), "Detect FA cmdmem failed, ret %d", ret);
 		goto out;
 	}
 
@@ -2032,7 +2032,7 @@ int xocl_kds_update(struct xocl_dev *xdev, struct drm_xocl_kds cfg)
 		XDEV(xdev)->kds.cu_intr = 0;
 	ret = kds_cfg_update(&XDEV(xdev)->kds);
 	if (ret)
-		userpf_err(xdev, "KDS configure update failed, ret %d", ret);
+		xocl_err(&XDEV(xdev), "KDS configure update failed, ret %d", ret);
 
 out:
 	return ret;
@@ -2058,10 +2058,10 @@ int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hdl, xuid_t *uuid,
 	XDEV(xdev)->kds.xgq_enable = false;
 	ret = xocl_ert_ctrl_connect(xdev);
 	if (ret == -ENODEV) {
-		userpf_info(xdev, "ERT will be disabled, ret %d\n", ret);
+		xocl_info(&XDEV(xdev), "ERT will be disabled, ret %d\n", ret);
 		XDEV(xdev)->kds.ert_disable = true;
 	} else if (ret < 0) {
-		userpf_info(xdev, "ERT connect failed, ret %d\n", ret);
+		xocl_info(&XDEV(xdev), "ERT connect failed, ret %d\n", ret);
 		ret = -EINVAL;
 		goto out;
 	}
@@ -2069,7 +2069,7 @@ int xocl_kds_register_cus(struct xocl_dev *xdev, int slot_hdl, xuid_t *uuid,
 	/* Try config legacy ERT firmware */
 	if (!xocl_ert_ctrl_is_version(xdev, 1, 0)) {
 		if (slot_hdl) {
-			userpf_err(xdev, "legacy ERT only support one xclbin\n");
+			xocl_err(&XDEV(xdev), "legacy ERT only support one xclbin\n");
 			ret = -EINVAL;
 			goto out;
 		}
@@ -2089,7 +2089,7 @@ void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 	XDEV(xdev)->kds.xgq_enable = false;
 	ret = xocl_ert_ctrl_connect(xdev);
 	if (ret) {
-		userpf_info(xdev, "ERT will be disabled, ret %d\n", ret);
+		xocl_info(&XDEV(xdev), "ERT will be disabled, ret %d\n", ret);
 		XDEV(xdev)->kds.ert_disable = true;
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -242,25 +242,14 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define PDEV(dev)	(((dev)->bus == &platform_bus_type && (dev)->parent) ? (dev)->parent : (dev))
 #define PNAME(dev)	(((dev)->bus == &pci_bus_type) ? "" : dev_name(dev))
 
-/*
- * Proposed changes for displaying messages
- *
- * function       in dmesg    in debugfs   carrying 'dev' info	
- * xocl_info 	       n	          y             y	
- * xocl_warn         y            n             y
- * xocl_err          y            n             y
- * xocl_dbg          n            y             y
- * xocl_printk       y            y             y
- * xocl_info_generic n            y             n
- *
- */
-
 #define xocl_err(dev, fmt, args...)			\
 	dev_err(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_warn(dev, fmt, args...)			\
 	dev_warn(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_info(dev, fmt, args...)			\
 	do {						\
+    dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt,    \
+              PNAME(dev), (u64)dev, __func__, ##args);      \
 		xocl_dbg_trace(XOCL_SUBDEV_DBG_HDL(dev), XRT_TRACE_LEVEL_INFO,\
 			       "%s %s %llx %s: "fmt"\n", PNAME(dev),	\
 			       dev_name(dev), (u64)dev, __func__, ##args);\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -248,8 +248,8 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 	dev_warn(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_info(dev, fmt, args...)			\
 	do {						\
-		dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt,    \
-				PNAME(dev), (u64)dev, __func__, ##args);      \
+		dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt, 	\
+			   PNAME(dev), (u64)dev, __func__, ##args);	\
 		xocl_dbg_trace(XOCL_SUBDEV_DBG_HDL(dev), XRT_TRACE_LEVEL_INFO,\
 			       "%s %s %llx %s: "fmt"\n", PNAME(dev),	\
 			       dev_name(dev), (u64)dev, __func__, ##args);\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -248,8 +248,8 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 	dev_warn(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_info(dev, fmt, args...)			\
 	do {						\
-    dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt,    \
-              PNAME(dev), (u64)dev, __func__, ##args);      \
+		dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt,    \
+				PNAME(dev), (u64)dev, __func__, ##args);      \
 		xocl_dbg_trace(XOCL_SUBDEV_DBG_HDL(dev), XRT_TRACE_LEVEL_INFO,\
 			       "%s %s %llx %s: "fmt"\n", PNAME(dev),	\
 			       dev_name(dev), (u64)dev, __func__, ##args);\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -242,14 +242,25 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 #define PDEV(dev)	(((dev)->bus == &platform_bus_type && (dev)->parent) ? (dev)->parent : (dev))
 #define PNAME(dev)	(((dev)->bus == &pci_bus_type) ? "" : dev_name(dev))
 
+/*
+ * Proposed changes for displaying messages
+ *
+ * function       in dmesg    in debugfs   carrying 'dev' info	
+ * xocl_info 	       n	          y             y	
+ * xocl_warn         y            n             y
+ * xocl_err          y            n             y
+ * xocl_dbg          n            y             y
+ * xocl_printk       y            y             y
+ * xocl_info_generic n            y             n
+ *
+ */
+
 #define xocl_err(dev, fmt, args...)			\
 	dev_err(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_warn(dev, fmt, args...)			\
 	dev_warn(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_info(dev, fmt, args...)			\
 	do {						\
-		dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt,	\
-			   PNAME(dev), (u64)dev, __func__, ##args);	\
 		xocl_dbg_trace(XOCL_SUBDEV_DBG_HDL(dev), XRT_TRACE_LEVEL_INFO,\
 			       "%s %s %llx %s: "fmt"\n", PNAME(dev),	\
 			       dev_name(dev), (u64)dev, __func__, ##args);\
@@ -265,13 +276,13 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 		       "%s %s %llx %s: "fmt"\n", PNAME(dev),		\
 		       dev_name(dev), (u64)dev, __func__, ##args)
 
-#define xocl_xdev_info(xdev, fmt, args...)		\
+/*#define xocl_xdev_info(xdev, fmt, args...)		\
 	xocl_info(XDEV2DEV(xdev), fmt, ##args)
 #define xocl_xdev_err(xdev, fmt, args...)		\
 	xocl_err(XDEV2DEV(xdev), fmt, ##args)
 #define xocl_xdev_dbg(xdev, fmt, args...)		\
 	xocl_dbg(XDEV2DEV(xdev), fmt, ##args)
-
+*/
 #define	XOCL_DRV_VER_NUM(ma, mi, p)		\
 	((ma) * 1000 + (mi) * 100 + (p))
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -248,7 +248,7 @@ static inline void xocl_memcpy_toio(void *iomem, void *buf, u32 size)
 	dev_warn(PDEV(dev), "%s %llx %s: "fmt, PNAME(dev), (u64)dev, __func__, ##args)
 #define xocl_info(dev, fmt, args...)			\
 	do {						\
-		dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt, 	\
+		dev_printk(KERN_DEBUG, PDEV(dev), "%s %llx %s: "fmt,	\
 			   PNAME(dev), (u64)dev, __func__, ##args);	\
 		xocl_dbg_trace(XOCL_SUBDEV_DBG_HDL(dev), XRT_TRACE_LEVEL_INFO,\
 			       "%s %s %llx %s: "fmt"\n", PNAME(dev),	\

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_fdt.c
@@ -47,7 +47,7 @@ static void *msix_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	if (node < 0)
 		node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_MSIX_MGMT);
 	if (node < 0) {
-		xocl_xdev_err(xdev_hdl, "did not find msix node in %s", NODE_ENDPOINTS);
+		xocl_err(XDEV2DEV(xdev_hdl), "did not find msix node in %s", NODE_ENDPOINTS);
 		return NULL;
 	}
 
@@ -84,7 +84,7 @@ static void *ert_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 
         node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_ERT_SCHED);
         if (node < 0) {
-                xocl_xdev_err(xdev_hdl, "did not find ert sched node in %s", NODE_ENDPOINTS);
+                xocl_err(XDEV2DEV(xdev_hdl), "did not find ert sched node in %s", NODE_ENDPOINTS);
                 return NULL;
         }
 
@@ -116,12 +116,12 @@ static void *rom_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 
 	vrom = fdt_getprop(blob, 0, "vrom", &proplen);
 	if (!vrom) {
-		xocl_xdev_err(xdev_hdl, "did not find vrom prop");
+		xocl_err(XDEV2DEV(xdev_hdl), "did not find vrom prop");
 		goto failed;
 	}
 
 	if (proplen > sizeof(struct FeatureRomHeader)) {
-		xocl_xdev_err(xdev_hdl, "invalid vrom length");
+		xocl_err(XDEV2DEV(xdev_hdl), "invalid vrom length");
 		goto failed;
 	}
 
@@ -153,7 +153,7 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 
 	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_FLASH);
 	if (node < 0) {
-		xocl_xdev_err(xdev_hdl, "did not find flash node");
+		xocl_err(XDEV2DEV(xdev_hdl), "did not find flash node");
 		return NULL;
 	}
 
@@ -164,7 +164,7 @@ static void *flash_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 	else if (!fdt_node_check_compatible(blob, node, "qspi_ps_x2_single"))
 		flash_type = FLASH_TYPE_QSPIPS_X2_SINGLE;
 	else {
-		xocl_xdev_err(xdev_hdl, "UNKNOWN flash type");
+		xocl_err(XDEV2DEV(xdev_hdl), "UNKNOWN flash type");
 		return NULL;
 	}
 
@@ -199,13 +199,13 @@ static void *xmc_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t *len)
 
 	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_CMC_CLK_SCALING_REG);
 	if (node < 0)
-		xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_CMC_CLK_SCALING_REG, NODE_ENDPOINTS);
+		xocl_dbg(XDEV2DEV(xdev_hdl), "not found %s in %s", NODE_CMC_CLK_SCALING_REG, NODE_ENDPOINTS);
 	else
 		xmc_priv->flags = XOCL_XMC_CLK_SCALING;
 
 	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_CMC_FW_MEM);
 	if (node < 0) {
-		xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_CMC_FW_MEM, NODE_ENDPOINTS);
+		xocl_dbg(XDEV2DEV(xdev_hdl), "not found %s in %s", NODE_CMC_FW_MEM, NODE_ENDPOINTS);
 		xmc_priv->flags |= XOCL_XMC_IN_BITFILE;
 	}
 
@@ -260,18 +260,18 @@ static void *icap_cntrl_build_priv(xdev_handle_t xdev_hdl, void *subdev, size_t 
 
 	node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_ICAP_CONTROLLER);
 	if (node < 0) {
-		xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_ICAP_CONTROLLER, NODE_ENDPOINTS);
+		xocl_dbg(XDEV2DEV(xdev_hdl), "not found %s in %s", NODE_ICAP_CONTROLLER, NODE_ENDPOINTS);
 		return NULL;
 	}
 
 	{
 		node = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_ULP);
 		if (node < 0)
-			xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_ULP, NODE_ENDPOINTS);
+			xocl_dbg(XDEV2DEV(xdev_hdl), "not found %s in %s", NODE_GATE_ULP, NODE_ENDPOINTS);
 
 		node1 = fdt_path_offset(blob, "/" NODE_ENDPOINTS "/" NODE_GATE_PLP);
 		if (node1 < 0)
-			xocl_xdev_dbg(xdev_hdl, "not found %s in %s", NODE_GATE_PLP, NODE_ENDPOINTS);
+			xocl_dbg(XDEV2DEV(xdev_hdl), "not found %s in %s", NODE_GATE_PLP, NODE_ENDPOINTS);
 
 		if ((node < 0) && (node1 < 0))
 			priv->flags |= XOCL_IC_FLAT_SHELL;
@@ -1053,7 +1053,7 @@ static int xocl_fdt_parse_intr_alias(xdev_handle_t xdev_hdl, char *blob,
 			intr = fdt_getprop(blob, intr_node, PROP_INTERRUPTS,
 					NULL);
 			if (!intr) {
-				xocl_xdev_err(xdev_hdl,
+				xocl_err(XDEV2DEV(xdev_hdl),
 				    "intrrupts not found, %s", alias);
 				return -EINVAL;
 			}
@@ -1082,7 +1082,7 @@ static int xocl_fdt_parse_ip(xdev_handle_t xdev_hdl, char *blob,
 	/* Get PF index */
 	pfnum = fdt_getprop(blob, off, PROP_PF_NUM, NULL);
 	if (!pfnum) {
-		xocl_xdev_err(xdev_hdl,
+		xocl_err(XDEV2DEV(xdev_hdl),
 			"IP %s, PF index not found", ip->name);
 		return -EINVAL;
 	}
@@ -1254,7 +1254,7 @@ static int xocl_fdt_res_lookup(xdev_handle_t xdev_hdl, char *blob,
 
 	ret = xocl_fdt_parse_ip(xdev_hdl, blob, ip, subdev);
 	if (ret) {
-		xocl_xdev_err(xdev_hdl, "parse ip failed, Node %s, ip %s",
+		xocl_err(XDEV2DEV(xdev_hdl), "parse ip failed, Node %s, ip %s",
 			ip->name, ipname);
 		return ret;
 	}
@@ -1269,11 +1269,11 @@ static void xocl_fdt_dump_subdev(xdev_handle_t xdev_hdl,
 {
 	int i;
 
-	xocl_xdev_dbg(xdev_hdl, "Device %s, PF%d, level %d",
+	xocl_dbg(XDEV2DEV(xdev_hdl), "Device %s, PF%d, level %d",
 		subdev->info.name, subdev->pf, subdev->info.level);
 
 	for (i = 0; i < subdev->info.num_res; i++) {
-		xocl_xdev_dbg(xdev_hdl, "Res%d: %s %pR", i,
+		xocl_dbg(XDEV2DEV(xdev_hdl), "Res%d: %s %pR", i,
 			subdev->info.res[i].name, &subdev->info.res[i]);
 	}
 }
@@ -1317,7 +1317,7 @@ static int xocl_fdt_get_devinfo(xdev_handle_t xdev_hdl, char *blob,
 		    subdev, ip, ip_num, res->regmap_name);
 
 		if (ret) {
-			xocl_xdev_err(xdev_hdl, "lookup dev %s, ip %s failed",
+			xocl_err(XDEV2DEV(xdev_hdl), "lookup dev %s, ip %s failed",
 			    map_p->dev_name, res->res_name);
 			num = ret;
 			goto failed;
@@ -1401,7 +1401,7 @@ static int xocl_fdt_parse_subdevs(xdev_handle_t xdev_hdl, char *blob,
 			num = xocl_fdt_get_devinfo(xdev_hdl, blob, map_p,
 					ip, ip_num, subdevs);
 			if (num < 0) {
-				xocl_xdev_err(xdev_hdl,
+				xocl_err(XDEV2DEV(xdev_hdl),
 					"get subdev info failed, dev name: %s",
 					map_p->dev_name);
 				vfree(ip);
@@ -1483,13 +1483,13 @@ static int xocl_fdt_get_pci_addr(xdev_handle_t xdev_hdl)
 #endif
 
         if (!core->fdt_blob) {
-                xocl_xdev_err(xdev_hdl, "fdt blob is empty");
+                xocl_err(XDEV2DEV(xdev_hdl), "fdt blob is empty");
                 return -EINVAL;
         }
 
         offset = fdt_path_offset(core->fdt_blob, "/" NODE_PCIE "/" NODE_BARS);
         if (offset < 0) {
-                xocl_xdev_dbg(xdev_hdl, "pcie bars nodes are not present in firmware data");
+                xocl_dbg(XDEV2DEV(xdev_hdl), "pcie bars nodes are not present in firmware data");
                 return -EINVAL;
         }
 
@@ -1506,7 +1506,7 @@ static int xocl_fdt_get_pci_addr(xdev_handle_t xdev_hdl)
 
                 pfn = fdt_getprop(core->fdt_blob, offset, PROP_PF_NUM, NULL);
                 if (!pfn) {
-                        xocl_xdev_err(xdev_hdl, "failed to get physical_function of pci node");
+                        xocl_err(XDEV2DEV(xdev_hdl), "failed to get physical_function of pci node");
                         ret = -EINVAL;
                         goto done;
                 }
@@ -1515,13 +1515,13 @@ static int xocl_fdt_get_pci_addr(xdev_handle_t xdev_hdl)
 
                 bar = fdt_getprop(core->fdt_blob, offset, PROP_BAR_IDX, NULL);
                 if (!bar) {
-                        xocl_xdev_err(xdev_hdl, "failed to get bar idx");
+                        xocl_err(XDEV2DEV(xdev_hdl), "failed to get bar idx");
                         ret = -EINVAL;
                         goto done;
                 }
                 io_off = fdt_getprop(core->fdt_blob, offset, PROP_IO_OFFSET, NULL);
                 if (!io_off) {
-                        xocl_xdev_err(xdev_hdl, "failed to get offset, range of pci node");
+                        xocl_err(XDEV2DEV(xdev_hdl), "failed to get offset, range of pci node");
                         ret = -EINVAL;
                         goto done;
                 }
@@ -1551,13 +1551,13 @@ int xocl_fdt_parse_blob(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 		return -EINVAL;
 
 	if (fdt_totalsize(blob) > blob_sz) {
-		xocl_xdev_err(xdev_hdl, "Invalid blob inbut size");
+		xocl_err(XDEV2DEV(xdev_hdl), "Invalid blob inbut size");
 		return -EINVAL;
 	}
 
 	dev_num = xocl_fdt_parse_subdevs(xdev_hdl, blob, NULL, 0);
 	if (dev_num < 0) {
-		xocl_xdev_err(xdev_hdl, "parse dev failed, ret = %d", dev_num);
+		xocl_err(XDEV2DEV(xdev_hdl), "parse dev failed, ret = %d", dev_num);
 		goto failed;
 	}
 
@@ -1582,7 +1582,7 @@ int xocl_fdt_parse_blob(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 	xocl_fdt_parse_subdevs(xdev_hdl, blob, *subdevs, dev_num);
 
 	for (i = 0; i < dev_num; i++) {
-		xocl_xdev_info(xdev_hdl, "%s: dyn_subdev_num: %d",
+		xocl_info(XDEV2DEV(xdev_hdl), "%s: dyn_subdev_num: %d",
 			(*subdevs + i)->info.name, (*subdevs + i)->info.num_res);
 		xocl_pack_subdev(xdev_hdl, *subdevs + i);
 	}
@@ -1632,7 +1632,7 @@ int xocl_fdt_check_uuids(xdev_handle_t xdev_hdl, const void *blob,
 	 * metadata
 	 */
 	if (!subset_blob || fdt_check_header(subset_blob)) {
-		xocl_xdev_err(xdev_hdl, "invalid subset blob");
+		xocl_err(XDEV2DEV(xdev_hdl), "invalid subset blob");
 		return -EINVAL;
 	}
 
@@ -1657,7 +1657,7 @@ int xocl_fdt_check_uuids(xdev_handle_t xdev_hdl, const void *blob,
 	 * there is interface uuid in xclbin. we need to check blp/plp
 	 */
 	if (!blob || fdt_check_header(blob)) {
-		xocl_xdev_err(xdev_hdl, "invalid blob");
+		xocl_err(XDEV2DEV(xdev_hdl), "invalid blob");
 		return -EINVAL;
 	}
 
@@ -1666,12 +1666,12 @@ int xocl_fdt_check_uuids(xdev_handle_t xdev_hdl, const void *blob,
 		subset_int_uuid = fdt_getprop(subset_blob, subset_offset,
 				"interface_uuid", NULL);
 		if (!subset_int_uuid) {
-			xocl_xdev_err(xdev_hdl, "failed to get subset uuid");
+			xocl_err(XDEV2DEV(xdev_hdl), "failed to get subset uuid");
 			return -EINVAL;
 		}
 		offset = fdt_path_offset(blob, INTERFACES_PATH);
 		if (offset < 0) {
-			xocl_xdev_err(xdev_hdl, "Invalid offset %d",
+			xocl_err(XDEV2DEV(xdev_hdl), "Invalid offset %d",
 			       	offset);
 			return -EINVAL;
 		}
@@ -1682,14 +1682,14 @@ int xocl_fdt_check_uuids(xdev_handle_t xdev_hdl, const void *blob,
 			int_uuid = fdt_getprop(blob, offset, "interface_uuid",
 					NULL);
 			if (!int_uuid) {
-				xocl_xdev_err(xdev_hdl, "failed to get uuid");
+				xocl_err(XDEV2DEV(xdev_hdl), "failed to get uuid");
 				return -EINVAL;
 			}
 			if (!strcmp(int_uuid, subset_int_uuid))
 				break;
 		}
 		if (offset < 0) {
-			xocl_xdev_err(xdev_hdl, "Can not find uuid %s",
+			xocl_err(XDEV2DEV(xdev_hdl), "Can not find uuid %s",
 				subset_int_uuid);
 			return -ENOENT;
 		}
@@ -1705,7 +1705,7 @@ int xocl_fdt_add_pair(xdev_handle_t xdev_hdl, void *blob, char *name,
 
 	ret = fdt_setprop(blob, 0, name, val, size);
 	if (ret)
-		xocl_xdev_err(xdev_hdl, "set %s prop failed %d", name, ret);
+		xocl_err(XDEV2DEV(xdev_hdl), "set %s prop failed %d", name, ret);
 
 	return ret;
 }
@@ -1736,7 +1736,7 @@ int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 
 	len = fdt_totalsize(blob);
 	if (len > blob_sz) {
-		xocl_xdev_err(xdev_hdl, "Invalid blob inbut size");
+		xocl_err(XDEV2DEV(xdev_hdl), "Invalid blob inbut size");
 		return -EINVAL;
 	}
 
@@ -1750,7 +1750,7 @@ int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 
 	ret = fdt_create_empty_tree(output_blob, len);
 	if (ret) {
-		xocl_xdev_err(xdev_hdl, "create output blob failed %d", ret);
+		xocl_err(XDEV2DEV(xdev_hdl), "create output blob failed %d", ret);
 		goto failed;
 	}
 
@@ -1758,7 +1758,7 @@ int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 		ret = xocl_fdt_overlay(output_blob, 0, core->fdt_blob, 0,
 				XOCL_FDT_ALL, -1);
 		if (ret) {
-			xocl_xdev_err(xdev_hdl, "overlay fdt_blob failed %d", ret);
+			xocl_err(XDEV2DEV(xdev_hdl), "overlay fdt_blob failed %d", ret);
 			goto failed;
 		}
 	}
@@ -1766,16 +1766,16 @@ int xocl_fdt_blob_input(xdev_handle_t xdev_hdl, char *blob, u32 blob_sz,
 	ret = xocl_fdt_overlay(output_blob, 0, blob, 0,
 			XOCL_FDT_ALL, part_level);
 	if (ret) {
-		xocl_xdev_err(xdev_hdl, "Overlay output blob failed %d", ret);
+		xocl_err(XDEV2DEV(xdev_hdl), "Overlay output blob failed %d", ret);
 		goto failed;
 	}
 
 	if (vbnv && strlen(vbnv) > 0) {
-		xocl_xdev_dbg(xdev_hdl, "Board VBNV: %s", vbnv);
+		xocl_dbg(XDEV2DEV(xdev_hdl), "Board VBNV: %s", vbnv);
 		ret = xocl_fdt_add_pair(xdev_hdl, output_blob, "vbnv", vbnv,
 			strlen(vbnv) + 1);
 		if (ret) {
-			xocl_xdev_err(xdev_hdl, "Adding VBNV pair failed, %d",
+			xocl_err(XDEV2DEV(xdev_hdl), "Adding VBNV pair failed, %d",
 				ret);
 			goto failed;
 		}
@@ -1952,7 +1952,7 @@ int xocl_fdt_build_priv_data(xdev_handle_t xdev_hdl, struct xocl_subdev *subdev,
 
 	if (j == ARRAY_SIZE(subdev_map)) {
 		/* should never hit */
-		xocl_xdev_err(xdev_hdl, "did not find dev map");
+		xocl_err(XDEV2DEV(xdev_hdl), "did not find dev map");
 		return -EFAULT;
 	}
 
@@ -1974,16 +1974,16 @@ const struct axlf_section_header *xocl_axlf_section_header(
 	int	i;
 	u32 num_sect = top->m_header.m_numSections;
 
-	xocl_xdev_dbg(xdev_hdl,
+	xocl_dbg(XDEV2DEV(xdev_hdl),
 		"trying to find section header for axlf section %d", kind);
 
 	if (num_sect > XCLBIN_MAX_NUM_SECTION) {
-		xocl_xdev_err(xdev_hdl, "too many sections: %d", num_sect);
+		xocl_err(XDEV2DEV(xdev_hdl), "too many sections: %d", num_sect);
 		return NULL;
 	}
 
 	for (i = 0; i < num_sect; i++) {
-		xocl_xdev_dbg(xdev_hdl, "saw section header: %d",
+		xocl_dbg(XDEV2DEV(xdev_hdl), "saw section header: %d",
 			top->m_sections[i].m_sectionKind);
 		if (top->m_sections[i].m_sectionKind == kind) {
 			hdr = &top->m_sections[i];
@@ -1994,14 +1994,14 @@ const struct axlf_section_header *xocl_axlf_section_header(
 	if (hdr) {
 		if ((hdr->m_sectionOffset + hdr->m_sectionSize) >
 				 top->m_header.m_length) {
-			xocl_xdev_err(xdev_hdl, "found section is invalid");
+			xocl_err(XDEV2DEV(xdev_hdl), "found section is invalid");
 			hdr = NULL;
 		} else
-			xocl_xdev_dbg(xdev_hdl,
+			xocl_dbg(XDEV2DEV(xdev_hdl),
 				"header offset: %llu, size: %llu",
 				hdr->m_sectionOffset, hdr->m_sectionSize);
 	} else
-		xocl_xdev_dbg(xdev_hdl, "skip section header %d",
+		xocl_dbg(XDEV2DEV(xdev_hdl), "skip section header %d",
 				kind);
 
 	return hdr;
@@ -2081,7 +2081,7 @@ const char *xocl_fdt_get_ert_fw_ver(xdev_handle_t xdev_hdl, void *blob)
 		}
 	}
 	if (fw_ver)
-		xocl_xdev_dbg(xdev_hdl, "Load embedded scheduler firmware %s", fw_ver);
+		xocl_dbg(XDEV2DEV(xdev_hdl), "Load embedded scheduler firmware %s", fw_ver);
 
 	return fw_ver;
 }


### PR DESCRIPTION
#### Problem solved by the commit
xocl/xclmgmt drivers exposes too many information to dmesg, many of the which are only for developers debug purpose, and end users may never need them or they don't even understand the meaning of those messages.

Due to that, some critical and useful warnings/errors which would otherwise have been easy to see are hidden in the flood of dmesg. This makes hard for the users report what has been wrong when something happens.
The PR is to cleanup the dmesg, and put those debug messages for developers to debugfs.

As the starting step, all message calls are converted such that only xocl_err/warn/info or mgmt_info/warn/err are present. Subsequent changes will be made in future PRs

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

Ease of Use

#### How problem was solved, alternative solutions (if any) and why they were rejected

 xocl_xdev_info, xocl_xdev_err, xocl_xdev_dbg calls are converted to xocl_info, xocl_err, xocl_dbg calls respectively to keep track of what is displayed in dmesg and debugfs
 userpf_info, userpf_err, userpf_dbg calls are converted to xocl_info, xocl_err, xocl_dbg calls respectively to keep track of what is displayed in dmesg and debugfs
 
```
In the end, following calls will be present :
1. xocl_info, xocl_err, xocl_dbg, xocl_warn
2. mgmt_info, mgmt_err, mgmt_dbg, mgmt_warn
```

#### Risks (if any) associated the changes in the commit
Low Risk

#### What has been tested and how, request additional testing if necessary
Built XRT locally with changes

#### Documentation impact (if any)
