### PR TITLE
CR-1099703, CR-1098138 Mark "trace buffer full" at last device event in timeline trace

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_profile.h
+++ b/src/runtime_src/core/include/experimental/xrt_profile.h
@@ -123,10 +123,16 @@ namespace xrt { namespace profile {
     ~user_event() ;
     
     /**
-     * mark() - Mark a specific moment in time with a marker on the waveform
+     * mark() - Mark the current moment in time with a marker on the waveform
      */
     XCL_DRIVER_DLLESPEC
     void mark(const char* label = nullptr) ;
+
+    /**
+     * mark_time_ns() - Mark a custom moment in time with a marker on the waveform
+     */
+    XCL_DRIVER_DLLESPEC
+    void mark_time_ns(double time_ns, const char* label = nullptr) ;
   } ;
 
 } // end namespace profile
@@ -166,6 +172,17 @@ void xrtUREnd(unsigned int id) ;
  */
 XCL_DRIVER_DLLESPEC
 void xrtUEMark(const char* label) ;
+
+/**
+ * xrtUEMarkTimeNs() - Mark a custom time as when something happened
+ *
+ * @time_ns: Time in nanoseconds since application start
+ * @label:   An optional label that is added to the marker in the waveform
+ * Return:   none
+ *
+ */
+XCL_DRIVER_DLLESPEC
+void xrtUEMarkTimeNs(double time_ns, const char* label) ;
 
 #ifdef __cplusplus
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -21,6 +21,7 @@
 #include "xdp/profile/plugin/vp_base/utility.h"
 
 #include "core/common/message.h"
+#include "experimental/xrt_profile.h"
 
 #ifdef _WIN32
 #pragma warning (disable : 4244)
@@ -784,6 +785,9 @@ namespace xdp {
       if (ASMPacket) {
         addASMEvent(packet, hostTimestamp) ;
       }
+
+      // keep track of latest timestamp that comes through trace
+      mLatestHostTimestamp = hostTimestamp;
     }
 
   }
@@ -793,6 +797,19 @@ namespace xdp {
     addApproximateCUEndEvents() ;
     addApproximateDataTransferEndEvents() ;
     addApproximateStreamEndEvents() ;
+  }
+
+  void DeviceTraceLogger::addEventMarkers(bool isFIFOFull, bool isTS2MMFull)
+  {
+    if (isFIFOFull) {
+      xrt::profile::user_event events;
+      events.mark_time_ns(mLatestHostTimestamp, "Trace FIFO Full");
+    }
+
+    if (isTS2MMFull) {
+        xrt::profile::user_event events;
+        events.mark_time_ns(mLatestHostTimestamp, "Trace Buffer Full");
+    }
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.cpp
@@ -780,14 +780,14 @@ namespace xdp {
         addAMEvent(packet, hostTimestamp);
       }
       if (AIMPacket) {
-        addAIMEvent(packet, hostTimestamp) ;
+        addAIMEvent(packet, hostTimestamp);
       }
       if (ASMPacket) {
-        addASMEvent(packet, hostTimestamp) ;
+        addASMEvent(packet, hostTimestamp);
       }
 
       // keep track of latest timestamp that comes through trace
-      mLatestHostTimestamp = hostTimestamp;
+      mLatestHostTimestampMs = hostTimestamp;
     }
 
   }
@@ -801,14 +801,16 @@ namespace xdp {
 
   void DeviceTraceLogger::addEventMarkers(bool isFIFOFull, bool isTS2MMFull)
   {
+    double mark_time = mLatestHostTimestampMs * 1e6;
+
     if (isFIFOFull) {
       xrt::profile::user_event events;
-      events.mark_time_ns(mLatestHostTimestamp, "Trace FIFO Full");
+      events.mark_time_ns(mark_time, "Trace FIFO Full");
     }
 
     if (isTS2MMFull) {
         xrt::profile::user_event events;
-        events.mark_time_ns(mLatestHostTimestamp, "Trace Buffer Full");
+        events.mark_time_ns(mark_time, "Trace Buffer Full");
     }
   }
 

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.h
@@ -98,6 +98,8 @@ namespace xdp {
                                       uint64_t &asmAppxLastTransTimeStamp, bool &unfinishedASMevents);
 
     uint64_t firstTimestamp = 0 ;
+    // Used to mark timeline trace if trace buffer gets full
+    double mLatestHostTimestamp = 0;
 
   public:
 
@@ -106,6 +108,7 @@ namespace xdp {
 
     XDP_EXPORT void processTraceData(void* data, uint64_t numBytes) ;
     XDP_EXPORT void endProcessTraceData();
+    XDP_EXPORT void addEventMarkers(bool isFIFOFull, bool isTS2MMFull);
   } ;
 
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_logger.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_logger.h
@@ -99,7 +99,7 @@ namespace xdp {
 
     uint64_t firstTimestamp = 0 ;
     // Used to mark timeline trace if trace buffer gets full
-    double mLatestHostTimestamp = 0;
+    double mLatestHostTimestampMs = 0;
 
   public:
 

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -278,6 +278,12 @@ void DeviceTraceOffload::read_trace_end()
   // Trace logger will clear it's state and add approximations 
   // for pending events
   deviceTraceLogger->endProcessTraceData();
+
+  // Add event markers at end of trace data
+  bool isFIFOFull = fifo_full;
+  bool isTS2MMFull = (dev_intf->hasTs2mm() && trace_buffer_full()) ? true : false;
+  deviceTraceLogger->addEventMarkers(isFIFOFull, isTS2MMFull);
+
   if (dev_intf->hasTs2mm()) {
     reset_s2mm();
     m_initialized = false;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/device_offload_plugin.cpp
@@ -31,7 +31,6 @@
 
 #include "core/common/config_reader.h"
 #include "core/common/message.h"
-#include "experimental/xrt_profile.h"
 
 // Anonymous namespace for helper functions
 namespace {
@@ -385,17 +384,12 @@ namespace xdp {
 
     db->getDynamicInfo().setTraceBufferFull(deviceId, offloader->trace_buffer_full());
 
-    if (offloader->has_fifo() && offloader->trace_buffer_full()) {
+    if (offloader->has_fifo() && offloader->trace_buffer_full())
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", FIFO_WARN_MSG);
-      xrt::profile::user_event events;
-      events.mark("Trace FIFO Full");
-    }
 
-    if (offloader->has_ts2mm() && offloader->trace_buffer_full()) {
+    if (offloader->has_ts2mm() && offloader->trace_buffer_full())
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", TS2MM_WARN_MSG_BUF_FULL);
-        xrt::profile::user_event events;
-        events.mark("Trace Buffer Full");
-    }
+
   }
 
   void DeviceOffloadPlugin::broadcast(VPDatabase::MessageType msg, void* /*blob*/)

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.cpp
@@ -89,6 +89,19 @@ namespace xdp {
     (db->getStats()).addEventCount(label);
   }
 
+  static void user_event_time_ns_cb(double time_ns, const char* label)
+  {
+    VPDatabase* db = userEventsPluginInstance.getDatabase() ;
+
+    uint64_t l = 0 ;
+    if (label != nullptr)
+      l = (db->getDynamicInfo()).addString(label) ;
+    VTFEvent* event = new UserMarker(0, time_ns, l) ;
+
+    (db->getDynamicInfo()).addEvent(event) ;
+    (db->getStats()).addEventCount(label);
+  }
+
 } // end namespace xdp
 
 extern "C" 
@@ -109,4 +122,10 @@ extern "C"
 void user_event_happened_cb(const char* label)
 {
   xdp::user_event_happened_cb(label) ;
+}
+
+extern "C"
+void user_event_time_ns_cb(double time_ns, const char* label)
+{
+  xdp::user_event_time_ns_cb(time_ns, label) ;
 }

--- a/src/runtime_src/xdp/profile/plugin/user/user_cb.h
+++ b/src/runtime_src/xdp/profile/plugin/user/user_cb.h
@@ -30,4 +30,7 @@ void user_event_end_cb(unsigned int functionID) ;
 extern "C"
 void user_event_happened_cb(const char* label) ;
 
+extern "C"
+void user_event_time_ns_cb(double time_ns, const char* label) ;
+
 #endif


### PR DESCRIPTION
This commit adds an extension to user events API that lets users give a custom time for a marker. This is used internally to mark timeline trace when device trace data gets full.

![image](https://user-images.githubusercontent.com/2370073/156434845-86abc235-ff58-4abb-89d6-861679266650.png)
