### PR TITLE
VITIS-4581: callback for user managed interrupts

### DIFF
--- a/src/runtime_src/core/include/experimental/xrt_ip.h
+++ b/src/runtime_src/core/include/experimental/xrt_ip.h
@@ -11,8 +11,10 @@
 #include "xrt/detail/pimpl.h"
 
 #ifdef __cplusplus
+#include <bitset>
 # include <condition_variable>
 # include <cstdint>
+#include <functional>
 # include <string>
 #endif
 
@@ -44,6 +46,18 @@ class ip_impl;
 class ip : public detail::pimpl<ip_impl>
 {
 public:
+  static constexpr size_t isr_size = 32;
+  /*!
+   * @interrupt_vector
+   *
+   * @brief
+   * xrt::ip::interrupt_vector represents an IP interrupt vector object 
+   * with value from ISR register.
+   * This object is passed to callback function as argument
+   * This has 32 bits
+   */
+  using interrupt_vector = std::bitset<isr_size>;
+
   /*!
    * @class interrupt
    *
@@ -186,6 +200,22 @@ public:
   XCL_DRIVER_DLLESPEC
   interrupt
   create_interrupt_notify();
+
+  /**
+   * add_callback() - Add a callback function for user managed interrupts
+   *
+   * @param state       State to invoke callback on
+   * @param callback    Callback function
+   * @param data        User data to pass to callback function
+   *
+   * The function is called when the interrupts change state
+   * The function object's first parameter is an interrupt object with interrupt bit values
+   *
+   */
+  XCL_DRIVER_DLLESPEC
+  void
+  add_callback(std::function<void(xrt::ip::interrupt_vector, void*)> callback, void* data);
+
 };
 
 } // xrt

--- a/src/runtime_src/core/include/experimental/xrt_ip.h
+++ b/src/runtime_src/core/include/experimental/xrt_ip.h
@@ -11,10 +11,10 @@
 #include "xrt/detail/pimpl.h"
 
 #ifdef __cplusplus
-#include <bitset>
+# include <bitset>
 # include <condition_variable>
 # include <cstdint>
-#include <functional>
+# include <functional>
 # include <string>
 #endif
 
@@ -54,7 +54,7 @@ public:
    * xrt::ip::interrupt_vector represents an IP interrupt vector object 
    * with value from ISR register.
    * This object is passed to callback function as argument
-   * This has 32 bits
+   * This has 32 bits (number of bits in ISR register)
    */
   using interrupt_vector = std::bitset<isr_size>;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
This PR implements XRT C++ API support for adding callback function for interrupts in user managed CU mode.
For user managed IP when callback function is added, it will be executed whenever an interrupt is received.

callback function type is:  std::function<void(xrt::ip::interrupt_vector, void*)>
API add_callback signature is: add_callback(std::function<void(xrt::ip::interrupt_vector, void*)> fcn, void* data)
User defined data is passed as void*
This user defined data and interrupt_vector is passed to callback function on each execution
Interrupt-vector object contains ISR register value
ISR register is automatically cleared by XRT after the callback has finished execution

Host application must setup to start XRT in user managed mode, setup CU for execution to generate interrupts,
and setup all CU control registers for appropriate execution of the CU.
Callback function will be executed in internal XRT thread

#### Problem solved by the commit
New feature
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
None
#### How problem was solved, alternative solutions (if any) and why they were rejected
Support for user defined callback to run when an interrupt is raised
#### Risks (if any) associated the changes in the commit
Currently internal feature
#### What has been tested and how, request additional testing if necessary
Tested locally on U200
#### Documentation impact (if any)
None right now