### PR TITLE
CR-1124508 userpf sub device probing wait until APU to fully started.

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -298,6 +298,8 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		lro->instance, ep_name,
 		PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
 
+	xocl_thread_stop(lro);
+
 	err = xocl_enable_vmr_boot(lro);
 	if (err) {
 		mgmt_err(lro, "enable reset failed");
@@ -311,8 +313,6 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		if (err)
 			goto failed;
 	}
-
-	xocl_thread_stop(lro);
 
 	/*
 	 * lock pci config space access from userspace,
@@ -380,12 +380,13 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 
 	xocl_clear_pci_errors(lro);
 	store_pcie_link_info(lro);
+
+	(void) xocl_reload_vmr(lro);
+
 	if (xrt_reset_syncup)
 		xocl_set_master_on(lro);
 	else if (!force)
 		xclmgmt_connect_notify(lro, true);
-
-	(void) xocl_reload_vmr(lro);
 
 	return 0;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
VMR hangs during xbutil reset
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
make sure xbutil reset wait longer enough to make sure APU is boot completely before reset returns.
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
Tested xbutil reset on a supermicro machine for more than 10 times
#### Documentation impact (if any)
