### PR TITLE
CR-1124025 Remove flush_default_only restriction when upgrading from backup

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -444,7 +444,7 @@ update_default_only(xrt_core::device* device, bool value)
       if(boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
         // if backup is booted, then do not proceed
         if(std::stoi(vmr_stat.get<std::string>("value")) != 1) {
-          std::cout << "Backup image booted. Action will be performed only on deafult image." <<std::endl;
+          std::cout << "Backup image booted. Action will be performed only on default image.\n";
         }
         break;
       }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -444,8 +444,7 @@ update_default_only(xrt_core::device* device, bool value)
       if(boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
         // if backup is booted, then do not proceed
         if(std::stoi(vmr_stat.get<std::string>("value")) != 1) {
-          std::cout << "ERROR: Please load default boot to use this option" <<std::endl;
-          throw xrt_core::error(std::errc::operation_canceled);
+          std::cout << "Backup boot booted. Action will be performed only on deafult image." <<std::endl;
         }
         break;
       }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -444,7 +444,7 @@ update_default_only(xrt_core::device* device, bool value)
       if(boost::iequals(vmr_stat.get<std::string>("label"), "Boot on default")) {
         // if backup is booted, then do not proceed
         if(std::stoi(vmr_stat.get<std::string>("value")) != 1) {
-          std::cout << "Backup boot booted. Action will be performed only on deafult image." <<std::endl;
+          std::cout << "Backup image booted. Action will be performed only on deafult image." <<std::endl;
         }
         break;
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Allow operations even if the backup image is booted

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This was introduced during the initial implementation of a/b boot 

#### How problem was solved, alternative solutions (if any) and why they were rejected
remove error throw

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
