### PR TITLE
CR-1123112: Adjustment of profiling plugin loading order to accommodate host_trace switch

### DIFF
--- a/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/xocl/api/plugin/xdp/plugin_loader.cpp
@@ -35,6 +35,12 @@ namespace plugins {
       xocl::appdebug::load_xdp_app_debug() ;
     }
 
+    if (xrt_core::config::get_opencl_trace() ||
+        xrt_core::utils::load_host_trace()) {
+      xdp::opencl_trace::load() ;
+      xocl::profile::load_xdp_opencl_counters() ;
+    }
+
     if (xrt_core::config::get_data_transfer_trace() != "off" ||
         xrt_core::config::get_device_trace() != "off" ||
         xrt_core::config::get_opencl_device_counter() ||
@@ -44,12 +50,6 @@ namespace plugins {
 
     if (xrt_core::config::get_opencl_summary()) {
       xocl::profile::load_xdp_opencl_counters() ;
-    }
-
-    if (xrt_core::config::get_opencl_trace() ||
-        xrt_core::utils::load_host_trace()) {
-      xocl::profile::load_xdp_opencl_counters() ;
-      xdp::opencl_trace::load() ;
     }
 
     if (xrt_core::config::get_lop_trace()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The xrt.ini file option "host_trace" was added as a shortcut so the user can turn on the tracing of the top-most level of XRT APIs that is used by their application.  With certain combinations of the flag, however, the first level encountered was a lower level.  For example, if an application used OpenCL APIs but turned on device level profiling, then the HAL level was the first encountered and host_trace=true turned on HAL level tracing instead of the expected OpenCL level tracing.

This pull request changes the order of how profiling plugins are loaded so that an OpenCL application will always enable OpenCL level tracing before checking device level information when using the host_trace option.
