### PR TITLE
CR-1118968 Disable PDI reload on warm reboot

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-core.c
@@ -1431,8 +1431,6 @@ static int xclmgmt_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 	(void) xocl_subdev_create_by_level(lro, XOCL_SUBDEV_LEVEL_BLD);
 	(void) xocl_subdev_create_vsec_devs(lro);
 
-	(void) xocl_download_apu_firmware(lro);
-
 	/*
 	 * For u30 whose reset relies on SC, and the cmc is running on ps, we
 	 * need to wait for ps ready and read & save the S/N from SC.

--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -381,8 +381,6 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 	xocl_clear_pci_errors(lro);
 	store_pcie_link_info(lro);
 
-	(void) xocl_reload_vmr(lro);
-
 	if (xrt_reset_syncup)
 		xocl_set_master_on(lro);
 	else if (!force)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -2103,13 +2103,19 @@ static int xgq_vmr_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	XGQ_INFO(xgq, "Initialized xgq subdev, polling (%d)", xgq->xgq_polling);
-
-	ret = xocl_subdev_create(xdev, &subdev_info);
+	ret = xgq_download_apu_firmware(pdev);
 	if (ret) {
-		xocl_err(&pdev->dev, "unable to create HWMON_SDM subdev, ret: %d", ret);
+		XGQ_WARN(xgq, "unable to download APU, ret: %d", ret);
 		ret = 0;
 	}
+		
+	ret = xocl_subdev_create(xdev, &subdev_info);
+	if (ret) {
+		XGQ_WARN(xgq, "unable to create HWMON_SDM subdev, ret: %d", ret);
+		ret = 0;
+	}
+
+	XGQ_INFO(xgq, "Initialized xgq subdev, polling (%d)", xgq->xgq_polling);
 
 	return ret;
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_drv.h
@@ -2379,7 +2379,6 @@ int xocl_alloc_dev_minor(xdev_handle_t xdev_hdl);
 void xocl_free_dev_minor(xdev_handle_t xdev_hdl);
 
 int xocl_enable_vmr_boot(xdev_handle_t xdev_hdl);
-void xocl_reload_vmr(xdev_handle_t xdev_hdl);
 
 int xocl_count_iores_byname(struct platform_device *pdev, char *name);
 struct resource *xocl_get_iores_with_idx_byname(struct platform_device *pdev,

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1905,12 +1905,6 @@ void xocl_free_dev_minor(xdev_handle_t xdev_hdl)
  *       if any of this procedure fails due to fatal error, a hot reset warning
  *       will be reported.
  */
-void xocl_reload_vmr(xdev_handle_t xdev)
-{
-	if (!xocl_enable_vmr_boot(xdev))
-		(void) xocl_download_apu_firmware(xdev);
-}
-
 int xocl_enable_vmr_boot(xdev_handle_t xdev)
 {
 	int err = 0;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
- we should not touch the GPIO after hot_reset because touching those GPIO will cause warm reboot hung.
- we defer this operation till we start hot_reset from host side
- 
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
- got agreement with lizhi that we should move those loading APU into xgq_probe
- in the future, we can make this async but for now, let's use the straight way
- 
#### What has been tested and how, request additional testing if necessary
tested on multiple servers
1) hot reset 2) warm reboot

make sure card can comes back after warm reboot


#### Documentation impact (if any)
