### PR TITLE
CR-1124025 Clone of issue with summary: Remove flush_default_only res…

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -172,15 +172,15 @@ struct xgq_cmd_data_payload {
 	uint32_t size;
 	uint32_t remain_size;
 	uint32_t addr_type:4;
-	uint32_t flush_type:4;
+	uint32_t flash_type:4;
 	uint32_t rsvd1:24;
 	uint32_t pad1;
 };
 
-enum xgq_cmd_flush_type {
-	XGQ_CMD_FLUSH_DEFAULT		= 0x0,
-	XGQ_CMD_FLUSH_NO_BACKUP		= 0x1,
-	XGQ_CMD_FLUSH_TO_LEGACY		= 0x2,
+enum xgq_cmd_flash_type {
+	XGQ_CMD_FLASH_DEFAULT		= 0x0,
+	XGQ_CMD_FLASH_NO_BACKUP		= 0x1,
+	XGQ_CMD_FLASH_TO_LEGACY		= 0x2,
 };
 
 /**


### PR DESCRIPTION
…triction when upgrading from backup

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- this is for fixing the typo from flush to flash. people gets confused about the name in sysfs and XGQ interfaces

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
