### PR TITLE
Add support for full fpga programming in flat embedded platforms using libdfx apis

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -46,6 +46,10 @@ install_recipes()
         echo "inherit externalsrc" > $XRT_BB
         echo "EXTERNALSRC = \"$XRT_REPO_DIR/src\"" >> $XRT_BB
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
+        echo 'EXTRA_OECMAKE:append:versal += "-DXRT_LIBDFX=true"' >> $XRT_BB
+        echo 'EXTRA_OECMAKE:append:zynqmp += "-DXRT_LIBDFX=true"' >> $XRT_BB
+        echo 'DEPENDS:append:versal += "libdfx"' >> $XRT_BB
+        echo 'DEPENDS:append:zynqmp += "libdfx"' >> $XRT_BB
         echo "FILES:\${PN} += \"\${libdir}/ps_kernels_lib\"" >> $XRT_BB
         echo 'PACKAGE_CLASSES = "package_rpm"' >> $XRT_BB
         echo 'LICENSE = "GPLv2 & Apache-2.0"' >> $XRT_BB

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -260,7 +260,7 @@ enum class key_type
   get_xclbin_data,
   aie_get_freq,
   aie_set_freq,
-  dtbo_id,
+  dtbo_path,
 
   boot_partition,
   flush_default_only,
@@ -689,11 +689,15 @@ struct xclbin_uuid : request
   get(const device*) const = 0;
 };
 
-struct dtbo_id : request
+// dtbo_path is unique path used by libdfx library to load bitstream and device tree
+// overlay(dtbo), this query reads dtbo_path from sysfs node
+// Applicable only for embedded platforms
+struct dtbo_path : request
 {
-  using result_type = int;
+  using result_type = std::string;
+  using slot_id_type = uint32_t;
 
-  static const key_type key = key_type::dtbo_id;
+  static const key_type key = key_type::dtbo_path;
 
   virtual boost::any
   get(const device*, const boost::any& slot_id) const = 0;

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -260,6 +260,7 @@ enum class key_type
   get_xclbin_data,
   aie_get_freq,
   aie_set_freq,
+  dtbo_id,
 
   boot_partition,
   flush_default_only,
@@ -686,6 +687,16 @@ struct xclbin_uuid : request
 
   virtual boost::any
   get(const device*) const = 0;
+};
+
+struct dtbo_id : request
+{
+  using result_type = int;
+
+  static const key_type key = key_type::dtbo_id;
+
+  virtual boost::any
+  get(const device*, const boost::any& slot_id) const = 0;
 };
 
 struct group_topology : request

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -16,6 +16,7 @@
 
 struct zocl_xclbin {
 	int		zx_refcnt;
+	int		zx_dtboId;
 	void		*zx_uuid;
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_xclbin.h
@@ -16,7 +16,7 @@
 
 struct zocl_xclbin {
 	int		zx_refcnt;
-	int		zx_dtboId;
+	char		*zx_dtbo_path;
 	void		*zx_uuid;
 };
 
@@ -39,5 +39,6 @@ int zocl_xclbin_load_pdi(struct drm_zocl_dev *zdev, void *data,
 			struct drm_zocl_slot *slot);
 int zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data);
 bool zocl_xclbin_accel_adapter(int kds_mask);
+int zocl_xclbin_set_dtbo_path(struct drm_zocl_slot *slot, char *dtbo_path);
 
 #endif /* _ZOCL_XCLBIN_H_ */

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -81,6 +81,31 @@ static ssize_t xclbinid_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(xclbinid);
 
+static ssize_t dtbo_id_show(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
+	struct drm_zocl_slot *zocl_slot = NULL;
+	const char *raw_fmt = "%d %d\n";
+	ssize_t size = 0;
+	ssize_t count = 0;
+	int i = 0;
+
+	for (i = 0; i < zdev->num_pr_slot; i++) {
+		zocl_slot = zdev->pr_slot[i];
+		if (!zocl_slot || !zocl_slot->slot_xclbin ||
+		    !zocl_slot->slot_xclbin->zx_dtboId)
+			return 0;
+
+		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
+				zocl_slot->slot_xclbin->zx_dtboId);
+		size += count;
+	}
+
+	return size;
+}
+static DEVICE_ATTR_RO(dtbo_id);
+
 static ssize_t kds_numcus_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
@@ -373,6 +398,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_memstat_raw.attr,
 	&dev_attr_errors.attr,
 	&dev_attr_graph_status.attr,
+	&dev_attr_dtbo_id.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sysfs.c
@@ -81,12 +81,12 @@ static ssize_t xclbinid_show(struct device *dev,
 }
 static DEVICE_ATTR_RO(xclbinid);
 
-static ssize_t dtbo_id_show(struct device *dev,
+static ssize_t dtbo_path_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
 {
 	struct drm_zocl_dev *zdev = dev_get_drvdata(dev);
 	struct drm_zocl_slot *zocl_slot = NULL;
-	const char *raw_fmt = "%d %d\n";
+	const char *raw_fmt = "%d %s\n";
 	ssize_t size = 0;
 	ssize_t count = 0;
 	int i = 0;
@@ -94,17 +94,17 @@ static ssize_t dtbo_id_show(struct device *dev,
 	for (i = 0; i < zdev->num_pr_slot; i++) {
 		zocl_slot = zdev->pr_slot[i];
 		if (!zocl_slot || !zocl_slot->slot_xclbin ||
-		    !zocl_slot->slot_xclbin->zx_dtboId)
-			return 0;
+		    !zocl_slot->slot_xclbin->zx_dtbo_path)
+			continue;
 
 		count = sprintf(buf+size, raw_fmt, zocl_slot->slot_idx,
-				zocl_slot->slot_xclbin->zx_dtboId);
+				zocl_slot->slot_xclbin->zx_dtbo_path);
 		size += count;
 	}
 
 	return size;
 }
-static DEVICE_ATTR_RO(dtbo_id);
+static DEVICE_ATTR_RO(dtbo_path);
 
 static ssize_t kds_numcus_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
@@ -398,7 +398,7 @@ static struct attribute *zocl_attrs[] = {
 	&dev_attr_memstat_raw.attr,
 	&dev_attr_errors.attr,
 	&dev_attr_graph_status.attr,
-	&dev_attr_dtbo_id.attr,
+	&dev_attr_dtbo_path.attr,
 	NULL,
 };
 

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1162,6 +1162,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	int ret = 0;
 	struct drm_zocl_slot *slot = NULL;
 	int slot_id = axlf_obj->za_slot_id;
+	int dtbo_id = axlf_obj->za_dtbo_id;
 
 	if (slot_id > zdev->num_pr_slot) {
 		DRM_ERROR("Invalid Slot[%d]", slot_id);
@@ -1463,6 +1464,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	 * Remember xclbin_uuid for opencontext.
 	 */
 	slot->slot_xclbin->zx_refcnt = 0;
+	slot->slot_xclbin->zx_dtboId = dtbo_id;
 	zocl_xclbin_set_uuid(slot, &axlf_head.m_header.uuid);
 
 	/*
@@ -1671,6 +1673,7 @@ zocl_xclbin_init(struct drm_zocl_slot *slot)
 	}
 
 	z_xclbin->zx_refcnt = 0;
+	z_xclbin->zx_dtboId = -1;
 	z_xclbin->zx_uuid = NULL;
 
 	slot->slot_xclbin = z_xclbin;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1162,7 +1162,6 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	int ret = 0;
 	struct drm_zocl_slot *slot = NULL;
 	int slot_id = axlf_obj->za_slot_id;
-	int dtbo_id = axlf_obj->za_dtbo_id;
 
 	if (slot_id > zdev->num_pr_slot) {
 		DRM_ERROR("Invalid Slot[%d]", slot_id);
@@ -1464,7 +1463,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	 * Remember xclbin_uuid for opencontext.
 	 */
 	slot->slot_xclbin->zx_refcnt = 0;
-	slot->slot_xclbin->zx_dtboId = dtbo_id;
+	zocl_xclbin_set_dtbo_path(slot, axlf_obj->za_dtbo_path);
 	zocl_xclbin_set_uuid(slot, &axlf_head.m_header.uuid);
 
 	/*
@@ -1673,7 +1672,7 @@ zocl_xclbin_init(struct drm_zocl_slot *slot)
 	}
 
 	z_xclbin->zx_refcnt = 0;
-	z_xclbin->zx_dtboId = -1;
+	z_xclbin->zx_dtbo_path = NULL;
 	z_xclbin->zx_uuid = NULL;
 
 	slot->slot_xclbin = z_xclbin;
@@ -1703,4 +1702,33 @@ zocl_xclbin_fini(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 
 	/* Delete CU devices if exist for this slot */
 	zocl_destroy_cu_slot(zdev, slot->slot_idx);
+}
+
+/*
+ * Set dtbo path for this slot.
+ *
+ * @param       slot:   slot specific structure
+ * @param       dtbo_path: path that stores device tree overlay
+ *
+ * @return      0 on success Error code on failure.
+ */
+int
+zocl_xclbin_set_dtbo_path(struct drm_zocl_slot *slot, char *dtbo_path)
+{
+        char *path = slot->slot_xclbin->zx_dtbo_path;
+
+        if (path) {
+                vfree(path);
+                path = NULL;
+        }
+
+	if(dtbo_path) {
+		path = vmalloc(strlen(dtbo_path) + 1);
+		if (!path)
+			return -ENOMEM;
+		copy_from_user(path, dtbo_path, strlen(dtbo_path));
+	}
+
+        slot->slot_xclbin->zx_dtbo_path = path;
+        return 0;
 }

--- a/src/runtime_src/core/edge/hw_em/CMakeLists.txt
+++ b/src/runtime_src/core/edge/hw_em/CMakeLists.txt
@@ -16,7 +16,6 @@ include_directories(
   ${CMAKE_BINARY_DIR} # includes version.h
   )
 
-
 file(GLOB EM_SRC_FILES
   "${COMMON_EM_SRC_DIR}/*.h"
   "${COMMON_EM_SRC_DIR}/*.cpp"
@@ -97,6 +96,15 @@ else()
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
   )
+endif()
+
+if (DEFINED XRT_LIBDFX)
+  cmake_policy(PUSH)
+    #Setting this policy makes linking libraries simple
+    cmake_policy(SET CMP0079 NEW)
+    target_link_libraries(xrt_hwemu PRIVATE dfx)
+    target_compile_definitions(xrt_hwemu PRIVATE XRT_ENABLE_LIBDFX)
+  cmake_policy(POP)
 endif()
 
 install (TARGETS xrt_hwemu 

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -422,7 +422,7 @@ struct drm_zocl_axlf {
 	int			za_ksize;
 	char			*za_kernels;
 	uint32_t		za_slot_id;
-	int			za_dtbo_id;
+	char			*za_dtbo_path;
 	struct drm_zocl_kds	kds_cfg;
 };
 

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -422,6 +422,7 @@ struct drm_zocl_axlf {
 	int			za_ksize;
 	char			*za_kernels;
 	uint32_t		za_slot_id;
+	int			za_dtbo_id;
 	struct drm_zocl_kds	kds_cfg;
 };
 

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -89,6 +89,16 @@ else()
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     )
+
+endif()
+
+if (DEFINED XRT_LIBDFX)
+  cmake_policy(PUSH)
+    #Setting this policy makes linking libraries simple
+    cmake_policy(SET CMP0079 NEW)
+    target_link_libraries(xrt_core PRIVATE dfx)
+    target_compile_definitions(xrt_core PRIVATE XRT_ENABLE_LIBDFX)
+  cmake_policy(POP)
 endif()
 
 install (TARGETS xrt_core 

--- a/src/runtime_src/core/edge/user/CMakeLists.txt
+++ b/src/runtime_src/core/edge/user/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
 #
 include_directories(
   ${DRM_INCLUDE_DIRS}

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -680,6 +680,10 @@ struct dtbo_path
       return {};
     }
 
+    // sysfs node data eg:
+    // <slot_id> <dtbo_path>
+    //     0     <path 0>
+    //     1     <path 1>
     using tokenizer = boost::tokenizer< boost::char_separator<char> >;
     for(auto &line : dtbo_path_vec) {
       boost::char_separator<char> sep(" ");

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -512,8 +512,9 @@ libdfxHelper(std::shared_ptr<xrt_core::device> core_dev, std::string& dtbo_path,
   uint32_t slot_id = 0;
   static const std::string dtbo_dir_path = "/configfs/device-tree/overlays/";
 
-  // get dtbo_path of slot '0'
-  // TODO: read slot_id from xclbin
+  // get dtbo_path of slot '0' for now, in future when we support multi slot we need
+  // info about which slot this xclbin needs to be loaded
+  // TODO: read slot id from xclbin or get it as an arg to this function
   try {
     dtbo_path = xrt_core::device_query<xrt_core::query::dtbo_path>(core_dev, slot_id);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

- Added support for full bitstream programming of fpga with device tree overlaoding
- Used libdfx apis to achieve this
- This way helps to reprogram fpga in flat shells without need of system reboot
- This feature is added to support som use case from XRT
- xclbin is expected to have OVERLAY(dtbo), BITSTREAM(fpga bit) section to use this flow

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit
No as I added check to use this flow only when OVERLAY section is present

#### What has been tested and how, request additional testing if necessary
Tested on SOM board with multiple xclbins that has BITSTREAM section and OVERLAY section, was able to load different bitstreams without needing of system reboot

#### Documentation impact (if any)
