### PR TITLE
Updated petalinux build to 2022.1_02210750

### DIFF
--- a/build/petalinux.build
+++ b/build/petalinux.build
@@ -1,1 +1,4 @@
-PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_02160715/tool/petalinux-v2022.1-final"
+# When updating Petalinux build please file a SH ticket to retain the build
+# https://jira.xilinx.com/secure/CreateIssue!default.jspa
+# Current ticket - https://jira.xilinx.com/browse/SH-1819
+PETALINUX="/proj/petalinux/2022.1/petalinux-v2022.1_02210750/tool/petalinux-v2022.1-final"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Petalinux 2022.1 02160715 has been removed from the build area.
The build was not retained with a JIRA ticket.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
PR https://github.com/Xilinx/XRT/pull/6316 changed the Petalinux build
Once the build was removed build_edge.sh fails due to petalinux not found

#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved to 02210750 build

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on vck5000 discovery.

#### Documentation impact (if any)
None
