### PR TITLE
Revert "CR-1124508 userpf sub device probing wait until APU to fully …

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -298,8 +298,6 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		lro->instance, ep_name,
 		PCI_SLOT(pdev->devfn), PCI_FUNC(pdev->devfn));
 
-	xocl_thread_stop(lro);
-
 	err = xocl_enable_vmr_boot(lro);
 	if (err) {
 		mgmt_err(lro, "enable reset failed");
@@ -313,6 +311,8 @@ long xclmgmt_hot_reset(struct xclmgmt_dev *lro, bool force)
 		if (err)
 			goto failed;
 	}
+
+	xocl_thread_stop(lro);
 
 	/*
 	 * lock pci config space access from userspace,


### PR DESCRIPTION
…started. (#6358)"

This reverts commit 9eea53b76bec67d0d1f2ea0661f979888a2c3855.

Conflicts:
	src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

With latest VMR changes, this workaround code seem not needed anymore.

Tested 1 hour, no issues. Will update test result tomorrow.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
