### PR TITLE
CR-1122265:: Removing 'mKernelOffsetArgsInfoMap' map populating and fetching logic.

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -308,7 +308,6 @@ using addr_type = uint64_t;
       std::vector<xclemulation::MemoryManager *> mDDRMemoryManager;
       xclemulation::MemoryManager* mDataSpace;
       std::list<xclemulation::DDRBank> mDdrBanks;
-      std::map<uint64_t,std::map<uint64_t, KernelArg>> mKernelOffsetArgsInfoMap;
       std::map<uint64_t,uint64_t> mAddrMap;
       std::map<std::string,std::string> mBinaryDirectories;
       std::map<uint64_t , std::ofstream*> mOffsetInstanceStreamMap;


### PR DESCRIPTION
#### Problem solved by the commit
Fixing crash when using API xclRegWrite in HOST to start kernel

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1122265

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed 'mKernelOffsetArgsInfoMap’  map population and fetching logic

#### Risks (if any) associated the changes in the commit
Low Risk

#### What has been tested and how, request additional testing if necessary
Verified with 'simple_counted_autorestart_mailbox','hello_world','streaming_k2k_mm','kernel_swap'and 'mult_compute_units' examples.
Canary is neat.

#### Documentation impact (if any)
NA