### PR TITLE
Fix 1098396 : Skip adding rollover results as new profile monitors have 64 bit counter and unlikely to overflow

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.cpp
@@ -90,9 +90,6 @@ namespace xdp {
 
   void HALAPIInterface::stopCounters()
   {
-    for(auto itr : devices) {
-      itr.second->stopCounters();
-    }
   }
 
   void HALAPIInterface::readCounters()
@@ -187,85 +184,16 @@ namespace xdp {
       }
     }
   }
-  
-  void HALAPIInterface::calculateAIMRolloverResult(const std::string& key, unsigned int numAIM, xclCounterResults& counterResult, bool firstReadAfterProgram)
-  {
-    xclCounterResults& loggedResult = mFinalCounterResultsMap[key];
-    xclCounterResults& rollOverCount = mRolloverCountsMap[key];
-    xclCounterResults& rollOverCounterResult = mRolloverCounterResultsMap[key];
-    
-    for(unsigned int i=0; i < numAIM ; ++i) {
-      // Check for rollover of byte counters; if detected, add 2^32
-      // Otherwise, if first read after program with binary, then capture bytes from previous xclbin
-      if (!firstReadAfterProgram) {
-        // Update "RollOverCount"
-        if(counterResult.WriteBytes[i]      < loggedResult.WriteBytes[i])      rollOverCount.WriteBytes[i]++;
-        if(counterResult.ReadBytes[i]       < loggedResult.ReadBytes[i])       rollOverCount.ReadBytes[i]++;
-        if(counterResult.WriteTranx[i]      < loggedResult.WriteTranx[i])      rollOverCount.WriteTranx[i]++;
-        if(counterResult.ReadTranx[i]       < loggedResult.ReadTranx[i])       rollOverCount.ReadTranx[i]++;
-        if(counterResult.WriteLatency[i]    < loggedResult.WriteLatency[i])    rollOverCount.WriteLatency[i]++;
-        if(counterResult.ReadLatency[i]     < loggedResult.ReadLatency[i])     rollOverCount.ReadLatency[i]++;
-        if(counterResult.ReadBusyCycles[i]  < loggedResult.ReadBusyCycles[i])  rollOverCount.ReadBusyCycles[i]++;
-        if(counterResult.WriteBusyCycles[i] < loggedResult.WriteBusyCycles[i]) rollOverCount.WriteBusyCycles[i]++;
-      } else {
-        // Update "RollOverCounterResults" with logged data
-        rollOverCounterResult.WriteBytes[i]      += loggedResult.WriteBytes[i];
-        rollOverCounterResult.ReadBytes[i]       += loggedResult.ReadBytes[i];
-        rollOverCounterResult.WriteTranx[i]      += loggedResult.WriteTranx[i];
-        rollOverCounterResult.ReadTranx[i]       += loggedResult.ReadTranx[i];
-        rollOverCounterResult.WriteLatency[i]    += loggedResult.WriteLatency[i];
-        rollOverCounterResult.ReadLatency[i]     += loggedResult.ReadLatency[i];
-        rollOverCounterResult.ReadBusyCycles[i]  += loggedResult.ReadBusyCycles[i];
-        rollOverCounterResult.WriteBusyCycles[i] += loggedResult.WriteBusyCycles[i];
-      }
-    }
-  }
-  
-  void HALAPIInterface::calculateAMRolloverResult(const std::string& key, unsigned int numAM, xclCounterResults& counterResult, bool firstReadAfterProgram)
-  {
-    xclCounterResults& loggedResult = mFinalCounterResultsMap[key];
-    xclCounterResults& rollOverCount = mRolloverCountsMap[key];
-    xclCounterResults& rollOverCounterResult = mRolloverCounterResultsMap[key];
-    
-    for(unsigned int i = 0; i < numAM ; ++i) {
-      // Update "RollOverCount" 
-      if (!firstReadAfterProgram) {
-        if(counterResult.CuExecCycles[i]     < loggedResult.CuExecCycles[i])     rollOverCount.CuExecCycles[i]++;
-        if(counterResult.CuBusyCycles[i]     < loggedResult.CuBusyCycles[i])     rollOverCount.CuBusyCycles[i]++;
-        if(counterResult.CuStallExtCycles[i] < loggedResult.CuStallExtCycles[i]) rollOverCount.CuStallExtCycles[i]++;
-        if(counterResult.CuStallIntCycles[i] < loggedResult.CuStallIntCycles[i]) rollOverCount.CuStallIntCycles[i]++;
-        if(counterResult.CuStallStrCycles[i] < loggedResult.CuStallStrCycles[i]) rollOverCount.CuStallStrCycles[i]++;
-      } else {
-        // Update "RollOverCounterResults" with logged data
-        rollOverCounterResult.CuExecCount[i]      += loggedResult.CuExecCount[i];
-        rollOverCounterResult.CuExecCycles[i]     += loggedResult.CuExecCycles[i];
-        rollOverCounterResult.CuBusyCycles[i]     += loggedResult.CuBusyCycles[i];
-        rollOverCounterResult.CuStallExtCycles[i] += loggedResult.CuStallExtCycles[i];
-        rollOverCounterResult.CuStallIntCycles[i] += loggedResult.CuStallIntCycles[i];
-        rollOverCounterResult.CuStallStrCycles[i] += loggedResult.CuStallStrCycles[i];
-      }
-      
-    }
-  }
-  
+ 
   void HALAPIInterface::recordAMResult(ProfileResults* results, DeviceIntf* /*currDevice*/, const std::string& key)
   {
-    //    bool deviceDataExists = (mDeviceBinaryCuSlotsMap.find(key) == mDeviceBinaryCuSlotsMap.end()) ? false : true;
-    
-    
     xclCounterResults& counterResults = mFinalCounterResultsMap[key];
-    xclCounterResults& rollOverCount = mRolloverCountsMap[key];
-    xclCounterResults& rollOverCounterResult = mRolloverCounterResultsMap[key];
     
     for(unsigned int i = 0; i < results->numAM ; ++i) {
       
-      // if counterResults.CuMaxParallelIter[i] > 0)
-      
-      results->cuExecData[i].cuExecCount = counterResults.CuExecCount[i] + rollOverCounterResult.CuExecCount[i];
-      results->cuExecData[i].cuExecCycles = counterResults.CuExecCycles[i] + rollOverCounterResult.CuExecCycles[i]
-        + (rollOverCount.CuExecCycles[i] * 4294967296UL);
-      results->cuExecData[i].cuBusyCycles = counterResults.CuBusyCycles[i] + rollOverCounterResult.CuBusyCycles[i]
-        + (rollOverCount.CuBusyCycles[i] * 4294967296UL);
+      results->cuExecData[i].cuExecCount = counterResults.CuExecCount[i];
+      results->cuExecData[i].cuExecCycles = counterResults.CuExecCycles[i];
+      results->cuExecData[i].cuBusyCycles = counterResults.CuBusyCycles[i];
       
       results->cuExecData[i].cuMaxExecCycles = counterResults.CuMaxExecCycles[i];
       results->cuExecData[i].cuMinExecCycles = counterResults.CuMinExecCycles[i];
@@ -279,23 +207,22 @@ namespace xdp {
   void HALAPIInterface::recordAIMResult(ProfileResults* results, DeviceIntf* currDevice, const std::string& key)
   {
     xclCounterResults& counterResults = mFinalCounterResultsMap[key];
-    xclCounterResults& rollOverCount  = mRolloverCountsMap[key];
-    
+   
     for(unsigned int i = 0; i < results->numAIM ; ++i) {
       if(currDevice->isHostAIM(i)) {
         continue;
       }
       
-      results->kernelTransferData[i].totalReadBytes = counterResults.ReadBytes[i] + (rollOverCount.ReadBytes[i] * 4294967296UL);
-      results->kernelTransferData[i].totalReadTranx = counterResults.ReadTranx[i] + (rollOverCount.ReadTranx[i] * 4294967296UL);
-      results->kernelTransferData[i].totalReadLatency = counterResults.ReadLatency[i] + (rollOverCount.ReadLatency[i] * 4294967296UL);
-      results->kernelTransferData[i].totalReadBusyCycles = counterResults.ReadBusyCycles[i] + (rollOverCount.ReadBusyCycles[i] * 4294967296UL);
+      results->kernelTransferData[i].totalReadBytes = counterResults.ReadBytes[i];
+      results->kernelTransferData[i].totalReadTranx = counterResults.ReadTranx[i];
+      results->kernelTransferData[i].totalReadLatency = counterResults.ReadLatency[i];
+      results->kernelTransferData[i].totalReadBusyCycles = counterResults.ReadBusyCycles[i];
       // min max readLatency
       
-      results->kernelTransferData[i].totalWriteBytes = counterResults.WriteBytes[i] + (rollOverCount.WriteBytes[i] * 4294967296UL);
-      results->kernelTransferData[i].totalWriteTranx = counterResults.WriteTranx[i] + (rollOverCount.WriteTranx[i] * 4294967296UL);
-      results->kernelTransferData[i].totalWriteLatency = counterResults.WriteLatency[i] + (rollOverCount.WriteLatency[i] * 4294967296UL);
-      results->kernelTransferData[i].totalWriteBusyCycles = counterResults.WriteBusyCycles[i] + (rollOverCount.WriteBusyCycles[i] * 4294967296UL);
+      results->kernelTransferData[i].totalWriteBytes = counterResults.WriteBytes[i];
+      results->kernelTransferData[i].totalWriteTranx = counterResults.WriteTranx[i];
+      results->kernelTransferData[i].totalWriteLatency = counterResults.WriteLatency[i];
+      results->kernelTransferData[i].totalWriteBusyCycles = counterResults.WriteBusyCycles[i];
       // min max readLatency
     }
   }
@@ -317,7 +244,7 @@ namespace xdp {
   void HALAPIInterface::getProfileResults(xclDeviceHandle deviceHandle, void* res)
   {
     // Step 1: read counters from device
-    // Step 2: log the data into counter and rollover results data-structure
+    // Step 2: log the data into counter results data-structure
     // Step 3: populate ProfileResults
     
     // check one device for now
@@ -351,26 +278,10 @@ namespace xdp {
     
     std::string key = deviceName + "|" + binaryName;
     
-    // Step 2: log the data into counter and rollover results data-structure
+    // Step 2: log the data into counter results data-structure
     
-    // If not already defined, zero out rollover values for this device
-    if (mFinalCounterResultsMap.find(key) == mFinalCounterResultsMap.end()) {
-      mFinalCounterResultsMap[key] = counterResults;
-      
-      xclCounterResults rolloverResults;
-      memset(&rolloverResults, 0, sizeof(xclCounterResults));
-      mRolloverCounterResultsMap[key] = rolloverResults;
-      mRolloverCountsMap[key] = rolloverResults;
-    } else {
-      
-      calculateAIMRolloverResult(key, results->numAIM, counterResults, true /*firstReadAfterProgram*/);
-      calculateAMRolloverResult (key, results->numAM,  counterResults, true /*firstReadAfterProgram*/);
-      
-      // Streaming IP Counters are 64 bit and unlikely to roll over
-      
-      // Log current counter result
-      mFinalCounterResultsMap[key] = counterResults;
-    }
+    // Log current counter result
+    mFinalCounterResultsMap[key] = counterResults;
     
     // record is per device
     

--- a/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.h
+++ b/src/runtime_src/xdp/profile/plugin/hal_api_interface/xdp_api_interface.h
@@ -32,21 +32,10 @@ namespace xdp {
   private:
     std::map<xclDeviceHandle, DeviceIntf*> devices;
     std::map<std::string, xclCounterResults> mFinalCounterResultsMap;
-    std::map<std::string, xclCounterResults> mRolloverCounterResultsMap;
-    std::map<std::string, xclCounterResults> mRolloverCountsMap;
 
     static bool live;
 
   private:
-    
-    void calculateAIMRolloverResult(const std::string& key, 
-				    unsigned int numAIM, 
-				    xclCounterResults& counterResult, 
-				    bool firstReadAfterProgram);
-    void calculateAMRolloverResult(const std::string& key, 
-				   unsigned int numAM, 
-				   xclCounterResults& counterResults, 
-				   bool firstReadAfterProgram);
     void recordAMResult(ProfileResults* results, 
 			DeviceIntf* currDevice, 
 			const std::string& key);


### PR DESCRIPTION
New version of profile monitors have 64 bit counters and are unlikely to overflow. So, no need to add the rollover results. This was causing unexpected increment in CU exec cycles and thus causing decreasing through put numbers reported in CR 1098396.
I found another issue during investigation. When profile_api s are enabled and executed, the profile monitor counters were getting cleared at the end of application due to call to "stopCounter". This is not desired behavior. The profile monitor counters are expected to hold their value even after end of application till the next load/reload of xclbin or board reset. This issue is also fixed here.