### PR TITLE
CR-1123962 Inform of caveats in advance of SC flashing

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -631,8 +631,11 @@ find_flash_image_paths(const std::vector<std::string>& image_list)
   for(const auto& img : image_list) {
     // Check if the passed in image is absolute path
     if (boost::filesystem::is_regular_file(img)){
-      if (boost::filesystem::extension(img).compare(".xsabin") != 0)
-        std::cout << "Warning: Development usage, this may damage the card. Proceed with caution\n";
+      if (boost::filesystem::extension(img).compare(".xsabin") != 0) {
+        std::cout << "Warning: Non-xsabin file detected. Development usage, this may damage the card\n";
+        if(!XBU::can_proceed(XBU::getForce()))
+          throw xrt_core::error(std::errc::operation_canceled);
+      }
       path_list.push_back(img);
     }
     // Search through the installed shells and get the complete path
@@ -836,6 +839,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   if (!flashType.empty()) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", 
         "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
+      if(!XBU::can_proceed(XBU::getForce()))
+        throw xrt_core::error(std::errc::operation_canceled);
   } 
   Flasher working_flasher(working_device->get_device_id());
   auto flash_type = working_flasher.getFlashType(flashType);
@@ -861,8 +866,8 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
 
     // All other cases have a specified image
     // Get a list of images known exist
-    const auto validated_images = find_flash_image_paths(image);
 
+    const auto validated_images = find_flash_image_paths(image);
     // Fail early here to reduce additional conditions below
     // Technically validated_images will never be empty as: if image is not empty but has a bad
     // path or bad shell name find_flash_image_paths exits early. This statement can be removed

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -839,8 +839,6 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
   if (!flashType.empty()) {
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", 
         "Overriding flash mode is not recommended.\nYou may damage your device with this option.");
-      if(!XBU::can_proceed(XBU::getForce()))
-        throw xrt_core::error(std::errc::operation_canceled);
   } 
   Flasher working_flasher(working_device->get_device_id());
   auto flash_type = working_flasher.getFlashType(flashType);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When the user goes to run the SC flash using a non-xsabin file a scary warning appears:
`Warning: Development usage, this may damage the card. Proceed with caution`
It would be nice to have an opt-out option if the user got here by mistake

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added an opt out call to the existing xbutilities function

#### Risks (if any) associated the changes in the commit
If the user passes in multiple invalid files as images they will be prompted more than once to proceed. Since this is a new feature it should not affect any scripts, although if a script did rely on getting through this stage they must add a --force to the command.

#### What has been tested and how, request additional testing if necessary
Manual testing:
```
root@xsjpranjal01:~# xbmgmt program -b sc --image /tmp/x.txt -d 65:00
Warning: Non-xsabin file detected. Development usage, this may damage the card
Are you sure you wish to proceed? [Y/n]: n
Action canceled.
root@xsjpranjal01:~# xbmgmt program -b sc --image /tmp/x.txt -d 65:00
Warning: Non-xsabin file detected. Development usage, this may damage the card
Are you sure you wish to proceed? [Y/n]: Y
Stopping user function...
XRT build version: 2.13.0
Build hash: 8d0d49099763abf9b15bb5675693b9b207a4cfdf
Build date: 2022-03-07 17:25:40
Git branch: CR-1123962
PID: 649002
UID: 0
[Tue Mar  8 02:19:44 2022 GMT]
HOST: xsjpranjal01
EXE: /proj/xsjhdstaff6/dbenusov/XRT/build/Debug/opt/xilinx/xrt/bin/unwrapped/xbmgmt2
[xbmgmt] ERROR: Bad firmware file format.: Invalid argument
```

#### Documentation impact (if any)
None