### PR TITLE
Add build via Docker

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=ubuntu:18.04
+FROM $BASE_IMAGE
+
+ENV LANG C.UTF-8
+ENV LC_ALL=C
+ENV DEBIAN_FRONTEND="noninteractive"
+COPY xrtdeps.sh .
+
+RUN apt-get update \
+    && ./xrtdeps.sh -docker \
+    && rm -rf /var/lib/apt/lists/* xrtdeps.sh;

--- a/build/build.sh
+++ b/build/build.sh
@@ -57,6 +57,7 @@ usage()
     echo "[-checkpatch]               Run checkpatch.pl on driver code"
     echo "[-verbose]                  Turn on verbosity when compiling"
     echo "[-ertfw <dir>]              Path to directory with pre-built ert firmware (default: build the firmware)"
+    echo "[-docker <base_image>       Build using docker to avoid disturbing system dependencies"
     echo ""
     echo "ERT firmware is built if and only if MicroBlaze gcc compiler can be located."
     echo "When compiler is not accesible, use -ertfw to specify path to directory with"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Provide a way for users to build XRT with docker as opposed to changing the dependencies in a system.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Modified existing build.sh by adding new -docker flag. Script supports using ubuntu:18.04 or ubuntu:20.04.
Provided single Dockerfile that supports using any Ubuntu.
An alternative solution would be to provide a directory of different Dockerfiles for every supported OS, however this seems to be overkill.

#### Risks (if any) associated the changes in the commit
None.

#### What has been tested and how, request additional testing if necessary
The two supported base images have been tested. Ubuntu:18.04 and Ubuntu:20.04.

#### Documentation impact (if any)
If we choose to document this special way of building, we would have to document the required version of docker.

I tested with: 
```$ docker --version
Docker version 19.03.8, build afacb8b7f0
```

In reference to discussion with @mgehre-amd in https://github.com/Xilinx/XRT/issues/6282