### PR TITLE
CR-1124854 Updated the LD_LIBRARY_PATH settings before launching the …

### DIFF
--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -430,19 +430,21 @@ namespace xclcpuemhal2 {
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "fpo_v7_0" + ":";
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "dds_v6_0" + ":";
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "opencv"   + ":";
-          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "lib" + DS + "csim" + ":";         
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "lib" + DS + "csim" + ":";
           sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS + ":";
           sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + ":";
+          sLdLibs += sVivadoBinDir + DS + "data" + DS + "emulation" + DS + "ip_utils" + DS + "xtlm_ipc" + DS + "xtlm_ipc_v1_0" + DS + "cpp" + DS + "lib" + DS + ":";
           sLdLibs += sVivadoBinDir + DS + "lib" + DS + "lnx64.o" + DS + ":";
           sLdLibs += sVivadoBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS + ":";
+          sLdLibs += sVitisBinDir + DS + "tps" + DS + "lnx64" + DS + "python-3.8.3" + DS + "lib" + DS + ":";
           sLdLibs += sVitisBinDir + DS + "lib" + DS + "lnx64.o" + DS;
           
           setenv("LD_LIBRARY_PATH",sLdLibs.c_str(),true);
         }
         
         if (xilinxInstall.empty()) {
-           std::cerr << "ERROR : [SW-EM 10] Please make sure that the XILINX_VITIS environment variable is set correctly" << std::endl;
-           exit(1);
+          std::cerr << "ERROR : [SW-EM 10] Please make sure that the XILINX_VITIS environment variable is set correctly" << std::endl;
+          exit(1);
         }
 
         std::string modelDirectory("");
@@ -1465,6 +1467,7 @@ int CpuemShim::xclExportBO(unsigned int boHandle)
     return -1;
 
   std::string sFileName = bo->filename;
+  DEBUG_MSGS("%s, %d(sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
   if(sFileName.empty()) {
     std::cout<<"Exported Buffer is not P2P "<<std::endl;
     PRINTENDFUNC;
@@ -1660,6 +1663,7 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
   }
 
   std::string sFileName = bo->filename;
+  DEBUG_MSGS("%s, %d(sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
   if(!sFileName.empty()) //P2P or non cacheable scenario: TODO: modify the condition to check for flags instead of filename empty check
   {
     int fd = open(sFileName.c_str(), (O_CREAT | O_RDWR), 0666);


### PR DESCRIPTION
CR-1124854 Updated the LD_LIBRARY_PATH settings before launching thesw_emu device model from PCIe sw_emu driver. This enables the support for External TG.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Enabled the support to run the External TG designs for ps_on_x86 designs

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Vitis PR-3745, where we enabled to run the PS app as x86 process. As part of verifying the feature, it is identified

#### How problem was solved, alternative solutions (if any) and why they were rejected
for xtlm_ipc modules, we should provide the proper LD_LIBRARY_PATH before launching the sw_emu device model

#### Risks (if any) associated the changes in the commit
Nope

#### What has been tested and how, request additional testing if necessary
Ran the specific test case added as part of the CR and Ran the Canary suite which is clean.

#### Documentation impact (if any)
Nope