### PR TITLE
Fix multiple PS kernel instance issue and some compile warning on zocl

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1641,8 +1641,9 @@ int kds_cfg_update(struct kds_sched *kds)
 			if (!xcu)
 				continue;
 			if (!xcu->info.intr_enable) {
-				kds->cu_intr = false;
 				u32 cu_idx = xcu->info.cu_idx;
+
+				kds->cu_intr = false;
 				xcu_info(xcu, "CU(%d) doesnt support interrupt, running polling thread for all cus", cu_idx);
 				goto run_polling;
 			}

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -777,7 +777,7 @@ kds_add_scu_context(struct kds_sched *kds, struct kds_client *client,
 		   struct kds_ctx_info *info)
 {
 	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
-	u32 cu_idx = 0;
+	u32 cu_idx = info->cu_idx;
 	u32 prop = 0;
 	bool shared;
 	int ret = 0;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -200,7 +200,7 @@ zocl_load_pskernel(struct drm_zocl_dev *zdev, struct axlf *axlf)
 	header = xrt_xclbin_get_section_hdr_next(axlf, EMBEDDED_METADATA, header);
 	if(header) {
 		DRM_INFO("Found EMBEDDED_METADATA section\n");
-		DRM_INFO("EMBEDDED_METADATA section size = %d\n",header->m_sectionSize);
+		DRM_INFO("EMBEDDED_METADATA section size = %lld\n",header->m_sectionSize);
 	} else {
 		DRM_ERROR("EMBEDDED_METADATA section not found!\n");
 		mutex_unlock(&sk->sk_lock);
@@ -223,12 +223,12 @@ zocl_load_pskernel(struct drm_zocl_dev *zdev, struct axlf *axlf)
 
 	header = xrt_xclbin_get_section_hdr_next(axlf, SOFT_KERNEL, header);
 	while (header) {
-		DRM_INFO("Found soft kernel %d\n",sec_idx);
 		struct soft_kernel *sp =
 		    (struct soft_kernel *)&xclbin[header->m_sectionOffset];
 		char *begin = (char *)sp;
 		struct scu_image *sip = &sk->sk_img[sec_idx++];
 
+		DRM_INFO("Found soft kernel %d\n",sec_idx);
 		sip->si_start = scu_idx;
 		sip->si_end = scu_idx + sp->m_num_instances - 1;
 		if (sip->si_end >= MAX_SOFT_KERNEL) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. When open SCU context on zocl, the CU index is always 0. This will lead to open context failure when open more than 1 scu context.
2. Cleanup some compile warnings, like unused variable, mixed declarations and code.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
#6316 introduced the bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Assign cu_idx local variable.

#### Risks (if any) associated the changes in the commit
No.

#### What has been tested and how, request additional testing if necessary
vck5000

#### Documentation impact (if any)
