### PR TITLE
CR-1124677: Added a warning for unspecified aie_profile metrics

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_profile/aie_plugin.cpp
@@ -647,9 +647,13 @@ namespace xdp {
     // Configure core, memory, and shim counters
     for (int module=0; module < NUM_MODULES; ++module) {
       std::string metricsStr = metricSettings[module];
-      if (metricsStr.empty())
+      if (metricsStr.empty()){
+        std::string modName = moduleNames[module].substr(0, moduleNames[module].find(" "));
+        std::string metricMsg = "No metric set specified for " + modName + " module. "
+        "Please specify the aie_profile_" + modName + "_metrics setting in your xrt.ini.";
+        xrt_core::message::send(severity_level::warning, "XRT", metricMsg);
         continue;
-
+      }
       int NUM_COUNTERS       = numCounters[module];
       XAie_ModuleType mod    = falModuleTypes[module];
       std::string moduleName = moduleNames[module];


### PR DESCRIPTION
Added warning when aie_profile metrics are unspecified, as the default option for the aie_profile metrics is now empty.