### PR TITLE
CR-1119432 xbmgmt configure unexpected output

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -407,6 +407,12 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
     std::shared_ptr<xrt_core::device>& workingDevice = deviceCollection[0];
 
+    // If in factory mode the device is not ready for use
+    if (xrt_core::device_query<xrt_core::query::is_mfg>(workingDevice.get())) {
+      std::cout << boost::format("ERROR: Device is in factory mode and cannot be configured\n");
+      throw xrt_core::error(std::errc::operation_canceled);
+    }
+
     // Load Config commands
     // -- process "input" option -----------------------------------------------
     if (!path.empty()) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1119432

Running "sudo xbmgmt advanced --config --showx -d <bdf>" returns only the card's BDF, as seen below.

`0000:c1:00.0`

The expected output should normally include additional information such as security level, Runtime clock scaling enabled, Scaling threshold power override, Scaling threshold temp override and data retention


#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Most of the xbmgmt configure commands suffer when the card has a factory image.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added a check into the command to prevent the user from configuring a device with a factory image.

#### Risks (if any) associated the changes in the commit
More explicit messaging for what was previously a throw so none!

#### What has been tested and how, request additional testing if necessary
On a golden u250
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1119432
  Hash                 : aa166055d3cff40191df190442b2aa39148abc13
  Hash Date            : 2022-03-09 18:16:00
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt configure -d 17:00
ERROR: Device is in factory mode and cannot be configured
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
```
On a valid u280:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1119432
  Hash                 : aa166055d3cff40191df190442b2aa39148abc13
  Hash Date            : 2022-03-09 18:16:00
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt configure -d 65:00
ERROR: Please specify a valid option to configure the device


DESCRIPTION: Advanced options for configuring a device

USAGE: xbmgmt configure [--help] [-d arg] [input arg] [retention arg]

OPTIONS:
  -d, --device       - The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest
  --help             - Help to use this sub-command
  --input            - INI file with the memory configuration
  --retention        - Enables / Disables memory retention.  Valid values are: [ENABLE | DISABLE]

GLOBAL OPTIONS:
  --verbose          - Turn on verbosity
  --batch            - Enable batch mode (disables escape characters)
  --force            - When possible, force an operation
```
#### Documentation impact (if any)
None