### PR TITLE
CR-1118968 Disable PDI reload on warm reboot

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/mgmtpf/mgmt-utils.c
@@ -607,8 +607,6 @@ static void xclmgmt_reset_pci(struct xclmgmt_dev *lro)
 	xocl_pci_restore_config_all(lro);
 
 	xclmgmt_config_pci(lro);
-
-	xocl_pmc_enable_reset(lro);
 }
 
 int xclmgmt_update_userpf_blob(struct xclmgmt_dev *lro)

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -90,7 +90,7 @@ static DEFINE_IDR(xocl_xgq_vmr_cid_idr);
  * reserved shared memory size and number for log page.
  * currently, only 1 resource controlled by sema. Can be extended to n.
  */
-#define LOG_PAGE_SIZE	(1024 * 64)
+#define LOG_PAGE_SIZE	(1024 * 1024)
 #define LOG_PAGE_NUM	1
 
 /*


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

1. With new approach, this line should be removed after hot reset. The pmc mutex register should be cleared in case of warm reboot cause system crash.

2. second fix is due to the log page reserved shared memory is too small 64k, but the xsabin firmware size can be up to 400k, so reserved more space for now. In the future, we should enhance multiple transactions but it is too risky to introduce such mechanism. 1024k should be good enough.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
