### PR TITLE
Customized warnings in cmake so XRT compiles with clang.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,6 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   -Wno-unused-variable
   -Wno-parentheses     
   # These are dangerous and should be reviewed
-  -Wno-inconsistent-missing-override
   -Wno-delete-non-abstract-non-virtual-dtor
   -Wno-overloaded-virtual 
   -Wno-string-plus-int

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,7 +47,6 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   # These are dangerous and should be reviewed
   -Wno-delete-non-abstract-non-virtual-dtor
   -Wno-overloaded-virtual 
-  -Wno-string-plus-int
   -Wno-non-pod-varargs 
   -Wno-dangling        
   -Wno-shift-negative-value

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,6 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   -Wno-parentheses     
   # These are dangerous and should be reviewed
   -Wno-overloaded-virtual
-  -Wno-shift-negative-value
    )
 else()
   set(XRT_WARN_OPTS -Wall -Werror )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,6 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   -Wno-unused-variable
   -Wno-parentheses     
   # These are dangerous and should be reviewed
-  -Wno-delete-non-abstract-non-virtual-dtor
   -Wno-overloaded-virtual
   -Wno-shift-negative-value
    )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,6 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   -Wno-delete-non-abstract-non-virtual-dtor
   -Wno-overloaded-virtual 
   -Wno-non-pod-varargs 
-  -Wno-dangling        
   -Wno-shift-negative-value
    )
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,8 +46,7 @@ if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
   -Wno-parentheses     
   # These are dangerous and should be reviewed
   -Wno-delete-non-abstract-non-virtual-dtor
-  -Wno-overloaded-virtual 
-  -Wno-non-pod-varargs 
+  -Wno-overloaded-virtual
   -Wno-shift-negative-value
    )
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,31 @@ if (NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR})
   set(XRT_NATIVE_BUILD "no")
 endif()
 
+if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" )
+  set(XRT_WARN_OPTS 
+  -Wall -Werror
+  -Wno-mismatched-tags 
+  -Wno-unused-const-variable
+  -Wno-unused-private-field 
+  -Wno-missing-braces
+  -Wno-self-assign
+  -Wno-pessimizing-move 
+  -Wno-unused-function 
+  -Wno-unused-variable
+  -Wno-parentheses     
+  # These are dangerous and should be reviewed
+  -Wno-inconsistent-missing-override
+  -Wno-delete-non-abstract-non-virtual-dtor
+  -Wno-overloaded-virtual 
+  -Wno-string-plus-int
+  -Wno-non-pod-varargs 
+  -Wno-dangling        
+  -Wno-shift-negative-value
+   )
+else()
+  set(XRT_WARN_OPTS -Wall -Werror )
+endif()
+
 if (DEFINED ENV{XRT_NATIVE_BUILD})
   set(XRT_NATIVE_BUILD $ENV{XRT_NATIVE_BUILD})
 endif()

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -25,7 +25,7 @@ add_compile_options("-fPIC")
 
 # TODO CL_TARGET_OPENCL_VERSION is not defined..
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
-  add_compile_options("-Wall" "-Werror")
+  add_compile_options( ${XRT_WARN_OPTS} )
 endif()
 add_subdirectory(xdp)
 
@@ -64,7 +64,7 @@ else()
   else()
     # lots of warnings and all warnings as errors
     # add_compile_options(-Wall -Wextra -pedantic -Werror)
-    add_compile_options("-Wall" "-Werror")
+    add_compile_options( ${XRT_WARN_OPTS} )
   endif()
 
   # Build Subdirectories

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -802,7 +802,7 @@ public:
   }
 
   xclbin::target_type
-  get_target_type() const
+  get_target_type() const override
   {
     switch (m_top->m_header.m_mode) {
     case XCLBIN_FLAT:

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -430,19 +430,21 @@ namespace xclcpuemhal2 {
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "fpo_v7_0" + ":";
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "dds_v6_0" + ":";
           sLdLibs += sHlsBinDir +  DS + sPlatform + DS + "tools" + DS + "opencv"   + ":";
-          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "lib" + DS + "csim" + ":";         
+          sLdLibs += sHlsBinDir + DS + sPlatform + DS + "lib" + DS + "csim" + ":";
           sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS + ":";
           sLdLibs += sHlsBinDir + DS + "lib" + DS + "lnx64.o" + DS + ":";
+          sLdLibs += sVivadoBinDir + DS + "data" + DS + "emulation" + DS + "ip_utils" + DS + "xtlm_ipc" + DS + "xtlm_ipc_v1_0" + DS + "cpp" + DS + "lib" + DS + ":";
           sLdLibs += sVivadoBinDir + DS + "lib" + DS + "lnx64.o" + DS + ":";
           sLdLibs += sVivadoBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS + ":";
+          sLdLibs += sVitisBinDir + DS + "tps" + DS + "lnx64" + DS + "python-3.8.3" + DS + "lib" + DS + ":";
           sLdLibs += sVitisBinDir + DS + "lib" + DS + "lnx64.o" + DS;
           
           setenv("LD_LIBRARY_PATH",sLdLibs.c_str(),true);
         }
         
         if (xilinxInstall.empty()) {
-           std::cerr << "ERROR : [SW-EM 10] Please make sure that the XILINX_VITIS environment variable is set correctly" << std::endl;
-           exit(1);
+          std::cerr << "ERROR : [SW-EM 10] Please make sure that the XILINX_VITIS environment variable is set correctly" << std::endl;
+          exit(1);
         }
 
         std::string modelDirectory("");
@@ -1465,6 +1467,7 @@ int CpuemShim::xclExportBO(unsigned int boHandle)
     return -1;
 
   std::string sFileName = bo->filename;
+  DEBUG_MSGS("%s, %d(sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
   if(sFileName.empty()) {
     std::cout<<"Exported Buffer is not P2P "<<std::endl;
     PRINTENDFUNC;
@@ -1660,6 +1663,7 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
   }
 
   std::string sFileName = bo->filename;
+  DEBUG_MSGS("%s, %d(sFileName: %s)\n", __func__, __LINE__, sFileName.c_str());
   if(!sFileName.empty()) //P2P or non cacheable scenario: TODO: modify the condition to check for flags instead of filename empty check
   {
     int fd = open(sFileName.c_str(), (O_CREAT | O_RDWR), 0666);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mem_model.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/mem_model.cxx
@@ -38,13 +38,13 @@ mem_model::mem_model(std::string deviceName):
           uint64_t src_offset = written_bytes;
 
           unsigned char* page_ptr  = get_page(addr);
-          uint64_t       page_addr = addr & ~(-1 << ADDRBITS);
+          uint64_t       page_addr = addr & ~( ~uint64_t(0) << ADDRBITS);
 
           unsigned char* dest_buf_ptr = page_ptr + page_addr;
           unsigned char* src_buf_ptr  = (unsigned char*)(src)      + src_offset;
 
           uint64_t remaining_bytes_to_write = size - written_bytes;
-          uint64_t unaligned_bytes_in_addr = (addr & ~(-1 << ADDRBITS));
+          uint64_t unaligned_bytes_in_addr = (addr & ~(~uint64_t(0) << ADDRBITS));
           uint64_t bytes_upto_next_alignment = (0x1 << ADDRBITS) - unaligned_bytes_in_addr;
 
           uint64_t buf_size = 0;
@@ -85,13 +85,13 @@ mem_model::mem_model(std::string deviceName):
 		  uint64_t dest_offset = read_bytes;
 
 		  unsigned char* page_ptr  = get_page(addr);
-		  uint64_t       page_addr = addr & ~(-1 << ADDRBITS);
+		  uint64_t       page_addr = addr & ~(~uint64_t(0) << ADDRBITS);
 
 		  unsigned char* src_buf_ptr = page_ptr + page_addr;
 		  unsigned char* dest_buf_ptr  = (unsigned char*)(dest)      + dest_offset;
 
 		  uint64_t remaining_bytes_to_read = size - read_bytes;
-		  uint64_t unaligned_bytes_in_addr = (addr & ~(-1 << ADDRBITS));
+		  uint64_t unaligned_bytes_in_addr = (addr & ~(~uint64_t(0) << ADDRBITS));
 		  uint64_t bytes_upto_next_alignment = (0x1 << ADDRBITS) - unaligned_bytes_in_addr;
 
 		  uint64_t buf_size = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.h
+++ b/src/runtime_src/core/pcie/linux/device_linux.h
@@ -32,12 +32,12 @@ public:
   // query functions
   virtual void read_dma_stats(boost::property_tree::ptree& pt) const;
 
-  virtual void read(uint64_t addr, void* buf, uint64_t len) const;
-  virtual void write(uint64_t addr, const void* buf, uint64_t len) const;
-  virtual int  open(const std::string& subdev, int flag) const;
-  virtual void close(int dev_handle) const;
-  virtual void reset(query::reset_type&) const;
-  virtual void xclmgmt_load_xclbin(const char* buffer) const;
+  virtual void read(uint64_t addr, void* buf, uint64_t len) const override;
+  virtual void write(uint64_t addr, const void* buf, uint64_t len) const override;
+  virtual int  open(const std::string& subdev, int flag) const override;
+  virtual void close(int dev_handle) const override;
+  virtual void reset(query::reset_type&) const override;
+  virtual void xclmgmt_load_xclbin(const char* buffer) const override;
 
 public:
   ////////////////////////////////////////////////////////////////
@@ -70,7 +70,7 @@ public:
 private:
   // Private look up function for concrete query::request
   virtual const query::request&
-  lookup_query(query::key_type query_key) const;
+  lookup_query(query::key_type query_key) const override;
 };
 
 } // xrt_core

--- a/src/runtime_src/core/pcie/linux/scan.h
+++ b/src/runtime_src/core/pcie/linux/scan.h
@@ -93,7 +93,7 @@ public:
   bool is_ready =             false;
 
   pci_device(const std::string& drv_name, const std::string& sysfs_name);
-  ~pci_device();
+  virtual ~pci_device();
 
   virtual void
   sysfs_get(const std::string& subdev, const std::string& entry,

--- a/src/runtime_src/core/tools/common/Report.h
+++ b/src/runtime_src/core/tools/common/Report.h
@@ -60,6 +60,9 @@ class Report {
 
   void getFormattedReport(const xrt_core::device *_pDevice, SchemaVersion _schemaVersion, const std::vector<std::string> & _elementFilter, std::ostream & consoleStream, boost::property_tree::ptree & pt) const;
 
+ // Needs a virtual destructor
+  virtual ~Report() {};
+
  // Child methods that need to be implemented
  protected:
   virtual void writeReport(const xrt_core::device* _pDevice, const boost::property_tree::ptree& pt, const std::vector<std::string>& _elementsFilter,std::ostream & _output) const = 0;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -420,7 +420,7 @@ std::vector<DSAInfo> firmwareImage::getIntalledDSAs()
 {
     std::vector<DSAInfo> installedDSA;
     // Obtain installed DSA info.
-    for (auto root : std::initializer_list<const char*>(FIRMWARE_DIRS)) {
+    for (auto root : FIRMWARE_DIRS) {
       try {
         if (!boost::filesystem::exists(root) || !boost::filesystem::is_directory(root))
             continue;

--- a/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.h
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/opencl/opencl_device_info_plugin.h
@@ -43,18 +43,18 @@ namespace xdp {
     void updateOpenCLInfo(uint64_t deviceId) ;
     void updateSWEmulationGuidance() ;
 
-    XDP_EXPORT virtual void readTrace() ;
+    XDP_EXPORT virtual void readTrace() override;
 
   public:
     XDP_EXPORT OpenCLDeviceInfoPlugin() ;
     XDP_EXPORT virtual ~OpenCLDeviceInfoPlugin() override ;
 
     // Virtual functions from XDPPlugin
-    XDP_EXPORT virtual void writeAll(bool openNewFiles) ;
+    XDP_EXPORT virtual void writeAll(bool openNewFiles) override;
 
     // Virtual functions from DeviceOffloadPlugin
-    XDP_EXPORT virtual void flushDevice(void* device) ;
-    XDP_EXPORT virtual void updateDevice(void* device) ;
+    XDP_EXPORT virtual void flushDevice(void* device) override;
+    XDP_EXPORT virtual void updateDevice(void* device) override;
   } ;
 
 } // end namespace xdp

--- a/src/runtime_src/xocl/core/memory.h
+++ b/src/runtime_src/xocl/core/memory.h
@@ -673,67 +673,67 @@ public:
   }
 
   virtual cl_mem_object_type
-  get_type() const
+  get_type() const override
   {
     return m_image_type;
   }
 
   virtual cl_image_format
-  get_image_format()
+  get_image_format() override
   {
     return m_format;
   }
 
   virtual size_t
-  get_image_data_offset() const
+  get_image_data_offset() const override
   {
     return sizeof(image_info);
   }
 
   virtual size_t
-  get_image_width() const
+  get_image_width() const override
   {
     return m_width;
   }
 
   virtual size_t
-  get_image_height() const
+  get_image_height() const override
   {
     return m_height;
   }
 
   virtual size_t
-  get_image_depth() const
+  get_image_depth() const override
   {
     return m_depth;
   }
 
   virtual size_t
-  get_image_bytes_per_pixel() const
+  get_image_bytes_per_pixel() const override
   {
     return m_bpp;
   }
 
   virtual size_t
-  get_image_row_pitch() const
+  get_image_row_pitch() const override
   {
     return m_row_pitch;
   }
 
   virtual size_t
-  get_image_slice_pitch() const
+  get_image_slice_pitch() const override
   {
     return m_slice_pitch;
   }
 
   virtual void
-  set_image_row_pitch(size_t pitch)
+  set_image_row_pitch(size_t pitch) override
   {
     m_row_pitch = pitch;
   }
 
   virtual void
-  set_image_slice_pitch(size_t pitch)
+  set_image_slice_pitch(size_t pitch) override
   {
     m_slice_pitch = pitch;
   }

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -65,7 +65,7 @@ public:
     : m_hal(std::move(rhs.m_hal)), m_setup_done(rhs.m_setup_done)
   {}
 
-  ~device()
+  virtual ~device()
   {}
 
   device(const device &dev) = delete;

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -156,8 +156,8 @@ public:
    * If the device supports DMA threads then they are started by
    * this function.
    */
-  void
-  setup();
+  virtual void
+  setup() override;
 
   /**
    * Open the device.
@@ -167,55 +167,55 @@ public:
    * Throws if device could not be opened
    */
   virtual bool
-  open();
+  open() override;
 
   virtual void
-  close();
+  close() override;
 
   virtual xclDeviceHandle
-  get_xcl_handle() const
+  get_xcl_handle() const override
   {
     return m_handle; // cast to xclDeviceHandle
   }
 
   xrt::device
-  get_xrt_device() const
+  get_xrt_device() const override
   {
     return m_handle;
   }
 
   std::shared_ptr<xrt_core::device>
-  get_core_device() const;
+  get_core_device() const override;
 
   bool
   is_nodma() const;
 
   virtual void
-  acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared);
+  acquire_cu_context(const uuid& uuid,size_t cuidx,bool shared) override;
 
   virtual void
-  release_cu_context(const uuid& uuid,size_t cuidx);
+  release_cu_context(const uuid& uuid,size_t cuidx) override;
 
   virtual task::queue*
-  getQueue(hal::queue_type qt)
+  getQueue(hal::queue_type qt) override
   {
     return &m_queue[static_cast<qtype>(qt)];
   }
 
   virtual std::string
-  getDriverLibraryName() const
+  getDriverLibraryName() const override
   {
     return m_ops->getFileName();
   }
 
   virtual std::string
-  getName() const
+  getName() const override
   {
     return get_device_info()->mName;
   }
 
   virtual unsigned int
-  getBankCount() const
+  getBankCount() const override
   {
     return get_device_info()->mDDRBankCount;
   }
@@ -227,103 +227,103 @@ public:
   }
 
   virtual size_t
-  getAlignment() const
+  getAlignment() const override
   {
     return get_device_info()->mDataAlignment;
   }
 
   virtual range<const unsigned short*>
-  getClockFrequencies() const
+  getClockFrequencies() const override
   {
     return {get_device_info()->mOCLFrequency,get_device_info()->mOCLFrequency+4};
   }
 
   virtual std::ostream&
-  printDeviceInfo(std::ostream& ostr) const;
+  printDeviceInfo(std::ostream& ostr) const override;
 
   virtual size_t
-  get_cdma_count() const
+  get_cdma_count() const override
   {
     return get_device_info()->mNumCDMA;
   }
 
   virtual execbuffer_object_handle
-  allocExecBuffer(size_t sz);
+  allocExecBuffer(size_t sz) override;
 
   virtual buffer_object_handle
-  alloc(size_t sz, Domain domain, uint64_t memoryIndex, void* user_ptr);
+  alloc(size_t sz, Domain domain, uint64_t memoryIndex, void* user_ptr) override;
 
   virtual buffer_object_handle
-  alloc(const buffer_object_handle& bo, size_t sz, size_t offset);
+  alloc(const buffer_object_handle& bo, size_t sz, size_t offset) override;
 
   buffer_object_handle
   alloc_nodma(size_t sz, Domain domain, uint64_t memory_index, void* userptr);
 
   virtual void*
-  alloc_svm(size_t sz);
+  alloc_svm(size_t sz) override;
 
   virtual void
-  free_svm(void* svm_ptr);
+  free_svm(void* svm_ptr) override;
 
   virtual event
-  write(const buffer_object_handle& bo, const void* buffer, size_t sz, size_t offset,bool async);
+  write(const buffer_object_handle& bo, const void* buffer, size_t sz, size_t offset,bool async) override;
 
   virtual event
-  read(const buffer_object_handle& bo, void* buffer, size_t sz, size_t offset,bool async);
+  read(const buffer_object_handle& bo, void* buffer, size_t sz, size_t offset,bool async) override;
 
   virtual event
-  sync(const buffer_object_handle& bo, size_t sz, size_t offset, direction dir, bool async);
+  sync(const buffer_object_handle& bo, size_t sz, size_t offset, direction dir, bool async) override;
 
   virtual event
-  copy(const buffer_object_handle& dst_bo, const buffer_object_handle& src_bo, size_t sz, size_t dst_offset, size_t src_offset);
+  copy(const buffer_object_handle& dst_bo, const buffer_object_handle& src_bo, size_t sz, size_t dst_offset, size_t src_offset) override;
 
   virtual void
   fill_copy_pkt(const buffer_object_handle& dst_boh, const buffer_object_handle& src_boh
-                ,size_t sz, size_t dst_offset, size_t src_offset,ert_start_copybo_cmd* pkt);
+                ,size_t sz, size_t dst_offset, size_t src_offset,ert_start_copybo_cmd* pkt) override;
 
   virtual size_t
-  read_register(size_t offset, void* buffer, size_t size);
+  read_register(size_t offset, void* buffer, size_t size) override;
 
   virtual size_t
-  write_register(size_t offset, const void* buffer, size_t size);
+  write_register(size_t offset, const void* buffer, size_t size) override;
 
   virtual void*
-  map(const buffer_object_handle& bo);
+  map(const buffer_object_handle& bo) override;
 
   virtual void
-  unmap(const buffer_object_handle& bo);
+  unmap(const buffer_object_handle& bo) override;
 
   virtual void*
-  map(const execbuffer_object_handle& bo);
+  map(const execbuffer_object_handle& bo) override;
 
   virtual void
-  unmap(const execbuffer_object_handle& bo);
+  unmap(const execbuffer_object_handle& bo) override;
 
   virtual int
-  exec_buf(const execbuffer_object_handle& bo);
+  exec_buf(const execbuffer_object_handle& bo) override;
 
   virtual int
-  exec_wait(int timeout_ms) const;
+  exec_wait(int timeout_ms) const override;
 
 public:
   virtual bool
-  is_imported(const buffer_object_handle& boh) const;
+  is_imported(const buffer_object_handle& boh) const override;
 
   virtual uint64_t
-  getDeviceAddr(const buffer_object_handle& boh);
+  getDeviceAddr(const buffer_object_handle& boh) override;
 
   virtual int
-  getMemObjectFd(const buffer_object_handle& boh);
+  getMemObjectFd(const buffer_object_handle& boh) override;
 
   virtual buffer_object_handle
-  getBufferFromFd(const int fd, size_t& size, unsigned flags);
+  getBufferFromFd(const int fd, size_t& size, unsigned flags) override;
 
 public:
   virtual hal::operations_result<int>
-  loadXclBin(const xclBin* xclbin);
+  loadXclBin(const xclBin* xclbin) override;
 
   virtual bool
-  hasBankAlloc() const
+  hasBankAlloc() const override
   {
     // PCIe DSAs have device DDRs which allow bank allocation/selection
     // Zynq PL based devices set device id to 0xffff.
@@ -331,7 +331,7 @@ public:
   }
 
   virtual hal::operations_result<ssize_t>
-  readKernelCtrl(uint64_t offset,void* hbuf,size_t size)
+  readKernelCtrl(uint64_t offset,void* hbuf,size_t size) override
   {
     if (!m_ops->mRead)
       return hal::operations_result<ssize_t>();
@@ -339,7 +339,7 @@ public:
   }
 
   virtual hal::operations_result<ssize_t>
-  writeKernelCtrl(uint64_t offset,const void* hbuf,size_t size)
+  writeKernelCtrl(uint64_t offset,const void* hbuf,size_t size) override
   {
     if (!m_ops->mWrite)
       return hal::operations_result<ssize_t>();
@@ -347,7 +347,7 @@ public:
   }
 
   virtual hal::operations_result<int>
-  reClock2(unsigned short region, unsigned short *freqMHz)
+  reClock2(unsigned short region, unsigned short *freqMHz) override
   {
     if (!m_ops->mReClock2)
       return hal::operations_result<int>();
@@ -356,7 +356,7 @@ public:
 
   // Following functions are profiling functions
   virtual hal::operations_result<size_t>
-  clockTraining(xclPerfMonType type)
+  clockTraining(xclPerfMonType type) override
   {
     if (!m_ops->mClockTraining)
       return hal::operations_result<size_t>();
@@ -364,7 +364,7 @@ public:
   }
 
   virtual hal::operations_result<uint32_t>
-  countTrace(xclPerfMonType type)
+  countTrace(xclPerfMonType type) override
   {
     if (!m_ops->mCountTrace)
       return hal::operations_result<uint32_t>();
@@ -372,7 +372,7 @@ public:
   }
 
   virtual hal::operations_result<double>
-  getDeviceClock()
+  getDeviceClock() override
   {
     if (!m_ops->mGetDeviceClock)
       return hal::operations_result<double>();
@@ -380,7 +380,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  getDeviceTime()
+  getDeviceTime() override
   {
     if (!m_ops->mGetDeviceTime)
       return hal::operations_result<size_t>();
@@ -388,7 +388,7 @@ public:
   }
 
   virtual hal::operations_result<double>
-  getDeviceMaxRead()
+  getDeviceMaxRead() override
   {
     if (!m_ops->mGetDeviceMaxRead)
       return hal::operations_result<double>();
@@ -396,7 +396,7 @@ public:
   }
 
   virtual hal::operations_result<double>
-  getDeviceMaxWrite()
+  getDeviceMaxWrite() override
   {
     if (!m_ops->mGetDeviceMaxWrite)
       return hal::operations_result<double>();
@@ -404,7 +404,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  readCounters(xclPerfMonType type, xclCounterResults& results)
+  readCounters(xclPerfMonType type, xclCounterResults& results) override
   {
     if (!m_ops->mReadCounters)
       return hal::operations_result<size_t>();
@@ -412,7 +412,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  debugReadIPStatus(xclDebugReadType type, void* results)
+  debugReadIPStatus(xclDebugReadType type, void* results) override
   {
     if (!m_ops->mDebugReadIPStatus)
       return hal::operations_result<size_t>();
@@ -420,7 +420,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  readTrace(xclPerfMonType type, xclTraceResultsVector& vec)
+  readTrace(xclPerfMonType type, xclTraceResultsVector& vec) override
   {
     if (!m_ops->mReadTrace)
       return hal::operations_result<size_t>();
@@ -428,7 +428,7 @@ public:
   }
 
   virtual hal::operations_result<void>
-  xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size)
+  xclRead(xclAddressSpace space, uint64_t offset, void *hostBuf, size_t size) override
   {
     if (!m_ops->mRead)
       return hal::operations_result<void>();
@@ -437,7 +437,7 @@ public:
   }
 
   virtual hal::operations_result<void>
-  xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size)
+  xclWrite(xclAddressSpace space, uint64_t offset, const void *hostBuf, size_t size) override
   {
     if (!m_ops->mWrite)
       return hal::operations_result<void>();
@@ -446,7 +446,7 @@ public:
   }
 
   virtual hal::operations_result<ssize_t>
-  xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset)
+  xclUnmgdPread(unsigned flags, void *buf, size_t count, uint64_t offset) override
   {
     if (!m_ops->mUnmgdPread)
       return hal::operations_result<ssize_t>();
@@ -454,7 +454,7 @@ public:
   }
 
   virtual hal::operations_result<void>
-  setProfilingSlots(xclPerfMonType type, uint32_t slots)
+  setProfilingSlots(xclPerfMonType type, uint32_t slots) override
   {
     if (!m_ops->mSetProfilingSlots)
       return hal::operations_result<void>();
@@ -463,7 +463,7 @@ public:
   }
 
   virtual hal::operations_result<uint32_t>
-  getProfilingSlots(xclPerfMonType type)
+  getProfilingSlots(xclPerfMonType type) override
   {
     if (!m_ops->mGetProfilingSlots)
       return hal::operations_result<uint32_t>();
@@ -472,7 +472,7 @@ public:
 
   virtual hal::operations_result<void>
   getProfilingSlotName(xclPerfMonType type, uint32_t slotnum,
-                       char* slotName, uint32_t length)
+                       char* slotName, uint32_t length) override
   {
     if (!m_ops->mGetProfilingSlotName)
       return hal::operations_result<void>();
@@ -481,7 +481,7 @@ public:
   }
 
   virtual hal::operations_result<uint32_t>
-  getProfilingSlotProperties(xclPerfMonType type, uint32_t slotnum)
+  getProfilingSlotProperties(xclPerfMonType type, uint32_t slotnum) override
   {
     if (!m_ops->mGetProfilingSlotProperties)
       return hal::operations_result<uint32_t>();
@@ -489,7 +489,7 @@ public:
   }
 
   virtual hal::operations_result<void>
-  configureDataflow(xclPerfMonType type, unsigned *ip_config)
+  configureDataflow(xclPerfMonType type, unsigned *ip_config) override
   {
     if (!m_ops->mConfigureDataflow)
       return hal::operations_result<void>();
@@ -498,7 +498,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  startCounters(xclPerfMonType type)
+  startCounters(xclPerfMonType type) override
   {
     if (!m_ops->mStartCounters)
       return hal::operations_result<size_t>();
@@ -506,7 +506,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  startTrace(xclPerfMonType type, uint32_t options)
+  startTrace(xclPerfMonType type, uint32_t options) override
   {
     if (!m_ops->mStartTrace)
       return hal::operations_result<size_t>();
@@ -514,7 +514,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  stopCounters(xclPerfMonType type)
+  stopCounters(xclPerfMonType type) override
   {
     if (!m_ops->mStopCounters)
       return hal::operations_result<size_t>();
@@ -522,7 +522,7 @@ public:
   }
 
   virtual hal::operations_result<size_t>
-  stopTrace(xclPerfMonType type)
+  stopTrace(xclPerfMonType type) override
   {
     if (!m_ops->mStopTrace)
       return hal::operations_result<size_t>();
@@ -530,12 +530,12 @@ public:
   }
 
   virtual void*
-  getHalDeviceHandle() {
+  getHalDeviceHandle() override {
     return m_handle;
   }
 
   virtual hal::operations_result<uint32_t>
-  getNumLiveProcesses()
+  getNumLiveProcesses() override
   {
     if(!m_ops->mGetNumLiveProcesses)
       return hal::operations_result<uint32_t>();
@@ -543,7 +543,7 @@ public:
   }
 
   virtual hal::operations_result<std::string>
-  getSysfsPath(const std::string& subdev, const std::string& entry)
+  getSysfsPath(const std::string& subdev, const std::string& entry) override
   {
     if (!m_ops->mGetSysfsPath)
       return hal::operations_result<std::string>("");
@@ -558,7 +558,7 @@ public:
   }
 
   virtual hal::operations_result<std::string>
-  getSubdevPath(const std::string& subdev, uint32_t idx)
+  getSubdevPath(const std::string& subdev, uint32_t idx) override
   {
     if (!m_ops->mGetSubdevPath)
       return hal::operations_result<std::string>("");
@@ -573,7 +573,7 @@ public:
   }
 
   virtual hal::operations_result<std::string>
-  getDebugIPlayoutPath()
+  getDebugIPlayoutPath() override
   {
     if(!m_ops->mGetDebugIPlayoutPath)
       return hal::operations_result<std::string>("");
@@ -589,7 +589,7 @@ public:
   }
 
   virtual hal::operations_result<int>
-  getTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz)
+  getTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz) override
   {
     if(!m_ops->mGetTraceBufferInfo)
       return hal::operations_result<int>();
@@ -597,7 +597,7 @@ public:
   }
 
   hal::operations_result<int>
-  readTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample)
+  readTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample) override
   {
     if(!m_ops->mReadTraceData)
       return hal::operations_result<int>();
@@ -605,7 +605,7 @@ public:
   }
 
   hal::operations_result<void>
-  getDebugIpLayout(char* buffer, size_t size, size_t* size_ret)
+  getDebugIpLayout(char* buffer, size_t size, size_t* size_ret) override
   {
     if(!m_ops->mGetDebugIpLayout) {
       return hal::operations_result<void>();

--- a/src/xma/CMakeLists.txt
+++ b/src/xma/CMakeLists.txt
@@ -8,7 +8,7 @@ if (XMA_VERBOSE)
 endif()
 
 add_compile_options("-fPIC")
-add_compile_options("-Wall" "-Werror")
+add_compile_options( ${XRT_WARN_OPTS} )
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 

--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -120,7 +120,7 @@ namespace xma_core {
                 std::string cu_name{ reinterpret_cast<char*>(priv->kernel_info->name) };
                 auto pos = cu_name.find(":");
                 if (pos == std::string::npos) {
-                    xma_logmsg(XMA_ERROR_LOG, XMAUTILS_MOD, "create_session_execbo - Invalid cu name %s\n", cu_name);
+                    xma_logmsg(XMA_ERROR_LOG, XMAUTILS_MOD, "create_session_execbo - Invalid cu name %s\n", cu_name.c_str());
                     return XMA_ERROR;
                 }
                 std::string kernel_name = cu_name.substr(0, pos);

--- a/tests/validate/common/includes/cmdparser/cmdlineparser.cpp
+++ b/tests/validate/common/includes/cmdparser/cmdlineparser.cpp
@@ -93,12 +93,12 @@ bool CmdLineParser::addSwitch(const CmdSwitch &s) {
 
   if (cmd.shortcut.length() == 0) {
 
-    string temp = "-" + cmd.key[2];
+    string temp = string("-") + cmd.key[2];
 
     int i = 3;
     while (m_mapShortcutKeys.find(temp) != m_mapShortcutKeys.end() &&
            (size_t)i < cmd.key.length()) {
-      temp = "-" + s.key[i];
+      temp = string("-") + s.key[i];
       i++;
     }
 

--- a/tests/validate/xcl_vcu_test/src/plugin_dec.cpp
+++ b/tests/validate/xcl_vcu_test/src/plugin_dec.cpp
@@ -944,8 +944,9 @@ xrt_initialization (XrtIvas_XVCUDec *dec)
   priv = dec->priv;
   dev_index = dec->dev_index;
 
-  if (iret = download_xclbin (dec->xclbin_path, dev_index, &cu_index, &(priv->xcl_handle),
-          &(priv->xclbinId))) {
+  iret = download_xclbin (dec->xclbin_path, dev_index, &cu_index, &(priv->xcl_handle),
+          &(priv->xclbinId)); 
+  if ( iret!=0 ) {
     if (iret < 0)
       ERROR_PRINT ("failed to download xclbin %s]", dec->xclbin_path);
 


### PR DESCRIPTION
Signed-off-by: Henrique Bucher <henry@vitorian.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

XRT now compiles with clang

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

This solves issue #6278 
https://github.com/Xilinx/XRT/issues/6278

#### How problem was solved, alternative solutions (if any) and why they were rejected

Clang issues many more warnings than Gcc. As you're compiling with -Werror it breaks the build. The solution was to detect that when the compiler is Clang, it adds "-Wno-*" statements so that these warnings dont end up as errors, allowing the compilation to proceed. 

#### Risks (if any) associated the changes in the commit

The change only affects the build if the compiler is clang, which was not supported up to this point anyway. For GCC the substitution should yield exactly the same result.

#### What has been tested and how, request additional testing if necessary

This was tested with current master XRT and clang-12 on Ubuntu 20.04.03 LTS. 

