### PR TITLE
CR-1123255 xbutil examine report warning unclear

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -191,6 +191,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     }
 
     if (!missingReports.empty()) {
+      // Exception is thrown at the end of this function to allow for report writing
       is_report_output_valid = false;
       // Print error message
       std::cerr << boost::format("Error: The following report(s) require specifying a device using the --device option:\n");
@@ -217,6 +218,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   try {
     XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
   } catch (const std::exception&) {
+    // Exception is thrown at the end of this function to allow for report writing
     is_report_output_valid = false;
   }
 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -96,7 +96,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   // -- Retrieve and parse the subcommand options -----------------------------
   po::options_description commonOptions("Common Options");  
   commonOptions.add_options()
-    ("device,d", boost::program_options::value<decltype(devices)>(&devices)->multitoken(), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
+    ("device,d", boost::program_options::value<decltype(devices)>(&devices), "The Bus:Device.Function (e.g., 0000:d8:00.0) device of interest")
     ("report,r", boost::program_options::value<decltype(reportNames)>(&reportNames)->multitoken(), (std::string("The type of report to be produced. Reports currently available are:\n") + reportOptionValues).c_str() )
     ("format,f", boost::program_options::value<decltype(sFormat)>(&sFormat), (std::string("Report output format. Valid values are:\n") + formatOptionValues).c_str() )
     ("output,o", boost::program_options::value<decltype(sOutput)>(&sOutput), "Direct the output to the given file")
@@ -129,94 +129,91 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     return;
   }
 
-  // Determine report level
-  if (devices.size() == 0 && reportNames.size() == 0)
-    reportNames.push_back("host");
-
-  if (devices.size() != 0 && reportNames.size() == 0) {
-    reportNames.push_back("platform");
+  // Determine report leveld
+  if (reportNames.empty()) {
+    if (devices.empty())
+      reportNames.push_back("host");
+    else
+      reportNames.push_back("platform");
   }
-
-  // Determine default values
-  if (devices.size() == 0)
-    devices.push_back("_all_");
-
-  if (reportNames.size() == 0)
-    reportNames.push_back("host");
 
   // -- Process the options --------------------------------------------
   ReportCollection reportsToProcess;            // Reports of interest
   xrt_core::device_collection deviceCollection;  // The collection of devices to examine
   Report::SchemaVersion schemaVersion = Report::SchemaVersion::unknown;    // Output schema version
 
-  try {
-    // Collect the reports to be processed
-    XBU::collect_and_validate_reports(fullReportCollection, reportNames, reportsToProcess);
+  // Collect the reports to be processed
+  XBU::collect_and_validate_reports(fullReportCollection, reportNames, reportsToProcess);
 
-    // when json is specified, make sure an accompanying output file is also specified
-    if (!sFormat.empty() && sOutput.empty())
-      throw xrt_core::error("Please specify an output file to redirect the json to");
+  // when json is specified, make sure an accompanying output file is also specified
+  if (!sFormat.empty() && sOutput.empty())
+    throw xrt_core::error("Please specify an output file to redirect the json to");
 
-    if(sFormat.empty())
-      sFormat = "json";
+  if(sFormat.empty())
+    sFormat = "json";
 
-    // Output Format
-    schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
-    if (schemaVersion == Report::SchemaVersion::unknown) 
-      throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
+  // Output Format
+  schemaVersion = Report::getSchemaDescription(sFormat).schemaVersion;
+  if (schemaVersion == Report::SchemaVersion::unknown) 
+    throw xrt_core::error((boost::format("Unknown output format: '%s'") % sFormat).str());
 
-    // Output file
-    if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 
-        throw xrt_core::error((boost::format("Output file already exists: '%s'") % sOutput).str());
+  // Output file
+  if (!sOutput.empty() && boost::filesystem::exists(sOutput) && !XBU::getForce()) 
+      throw xrt_core::error((boost::format("Output file already exists: '%s'") % sOutput).str());
 
-    // Collect all of the devices of interest
-    std::set<std::string> deviceNames;
-    for (const auto & deviceName : devices) 
-      deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
+  // Collect all of the devices of interest
+  std::set<std::string> deviceNames;
+  for (const auto & deviceName : devices) 
+    deviceNames.insert(boost::algorithm::to_lower_copy(deviceName));
 
-    XBU::collect_devices(deviceNames, false /*inUserDomain*/, deviceCollection);
+  XBU::collect_devices(deviceNames, false /*inUserDomain*/, deviceCollection);
 
-    // DRC check on devices and reports
-    if (deviceCollection.empty()) {
-      std::vector<std::string> missingReports;
-      for (const auto & report : reportsToProcess) {
-        if (report->isDeviceRequired())
-          missingReports.push_back(report->getReportName());
-      }
-      if (!missingReports.empty()) {
-        std::cout << boost::format("Warning: Due to missing devices, the following reports will not be generated:\n");
-        for (const auto & report : missingReports) 
-          std::cout << boost::format("         - %s\n") % report;
-      }
+  // enforce 1 device specification if multiple reports are requested
+  if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)) {
+    std::cerr << "\nERROR: Examining multiple devices is not supported. Please specify a single device using --device option\n\n";
+    std::cout << "List of available devices:" << std::endl;
+    boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
+    for(auto& kd : available_devices) {
+      boost::property_tree::ptree& _dev = kd.second;
+      std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
     }
-
-    // enforce 1 device specification if multiple reports are requested
-    if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)) {
-      std::cerr << "\nERROR: Examining multiple devices is not supported. Please specify a single device using --device option\n\n";
-      std::cout << "List of available devices:" << std::endl;
-      boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
-      for(auto& kd : available_devices) {
-        boost::property_tree::ptree& _dev = kd.second;
-        std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
-      }
-      std::cout << std::endl;
-      throw xrt_core::error(std::errc::operation_canceled);
-    }
-  } catch (const xrt_core::error& e) {
-    // Catch only the exceptions that we have generated earlier
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    printHelp(commonOptions, hiddenOptions);
+    std::cout << std::endl;
     throw xrt_core::error(std::errc::operation_canceled);
   }
-  catch (const std::runtime_error& e) {
-    // Catch only the exceptions that we have generated earlier
-    std::cerr << boost::format("ERROR: %s\n") % e.what();
-    throw xrt_core::error(std::errc::operation_canceled);
+
+  bool is_report_output_valid = true;
+  // DRC check on devices and reports
+  if (deviceCollection.empty()) {
+    std::vector<std::string> missingReports;
+    for (const auto & report : reportsToProcess) {
+      if (report->isDeviceRequired())
+        missingReports.push_back(report->getReportName());
+    }
+
+    if (!missingReports.empty()) {
+      is_report_output_valid = false;
+      // Print error message
+      std::cerr << boost::format("Error: The following report(s) require specifying a device using the --device option:\n");
+      for (const auto & report : missingReports)
+        std::cout << boost::format("         - %s\n") % report;
+
+      // Print available devices
+      auto dev_pt = XBU::get_available_devices(true);
+      if(dev_pt.empty())
+        std::cout << "0 devices found" << std::endl;
+      else
+        std::cout << "Device list" << std::endl;
+
+      for(auto& kd : dev_pt) {
+        boost::property_tree::ptree& dev = kd.second;
+        std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
+        std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
+      }
+    }
   }
 
   // Create the report
   std::ostringstream oSchemaOutput;
-  bool is_report_output_valid = true;
   try {
     XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
   } catch (const std::exception&) {

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdExamine.cpp
@@ -172,9 +172,9 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)) {
     std::cerr << "\nERROR: Examining multiple devices is not supported. Please specify a single device using --device option\n\n";
     std::cout << "List of available devices:" << std::endl;
-    boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
-    for(auto& kd : available_devices) {
-      boost::property_tree::ptree& _dev = kd.second;
+    const boost::property_tree::ptree available_devices = XBU::get_available_devices(false);
+    for(const auto& kd : available_devices) {
+      const boost::property_tree::ptree& _dev = kd.second;
       std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
     }
     std::cout << std::endl;
@@ -199,15 +199,15 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
         std::cout << boost::format("         - %s\n") % report;
 
       // Print available devices
-      auto dev_pt = XBU::get_available_devices(true);
+      const auto dev_pt = XBU::get_available_devices(true);
       if(dev_pt.empty())
         std::cout << "0 devices found" << std::endl;
       else
         std::cout << "Device list" << std::endl;
 
-      for(auto& kd : dev_pt) {
-        boost::property_tree::ptree& dev = kd.second;
-        std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
+      for(const auto& kd : dev_pt) {
+        const boost::property_tree::ptree& dev = kd.second;
+        const std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
         std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
       }
     }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -229,7 +229,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
           std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
         }
 
-        std::cout << boost::format("Warning: Due to missing device, the following reports will not be generated:\n");
+        std::cout << boost::format("Error: The following reports require specifying a device using the --device option:\n");
         for (const auto & report : missingReports)
           std::cout << boost::format("         - %s\n") % report;
       }

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -230,6 +230,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
     }
 
     if (!missingReports.empty()) {
+      // Exception is thrown at the end of this function to allow for report writing
       is_report_output_valid = false;
       // Print error message
       std::cerr << boost::format("Error: The following report(s) require specifying a device using the --device option:\n");
@@ -256,6 +257,7 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   try {
     XBU::produce_reports(deviceCollection, reportsToProcess, schemaVersion, elementsFilter, std::cout, oSchemaOutput);
   } catch (const std::exception&) {
+    // Exception is thrown at the end of this function to allow for report writing
     is_report_output_valid = false;
   }
 

--- a/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdExamine.cpp
@@ -212,9 +212,9 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
   if(deviceCollection.size() > 1 && (reportsToProcess.size() > 1 || reportNames.front().compare("host") != 0)) {
     std::cerr << "\nERROR: Programming multiple device is not supported. Please specify a single device using --device option\n\n";
     std::cout << "List of available devices:" << std::endl;
-    boost::property_tree::ptree available_devices = XBU::get_available_devices(true);
-    for(auto& kd : available_devices) {
-      boost::property_tree::ptree& _dev = kd.second;
+    const boost::property_tree::ptree available_devices = XBU::get_available_devices(true);
+    for(const auto& kd : available_devices) {
+      const boost::property_tree::ptree& _dev = kd.second;
       std::cout << boost::format("  [%s] : %s\n") % _dev.get<std::string>("bdf") % _dev.get<std::string>("vbnv");
     }
     std::cout << std::endl;
@@ -238,15 +238,15 @@ SubCmdExamine::execute(const SubCmdOptions& _options) const
         std::cout << boost::format("         - %s\n") % report;
 
       // Print available devices
-      auto dev_pt = XBU::get_available_devices(true);
+      const auto dev_pt = XBU::get_available_devices(true);
       if(dev_pt.empty())
         std::cout << "0 devices found" << std::endl;
       else
         std::cout << "Device list" << std::endl;
 
       for(auto& kd : dev_pt) {
-        boost::property_tree::ptree& dev = kd.second;
-        std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
+        const boost::property_tree::ptree& dev = kd.second;
+        const std::string note = dev.get<bool>("is_ready") ? "" : "NOTE: Device not ready for use";
         std::cout << boost::format("  [%s] : %s %s\n") % dev.get<std::string>("bdf") % dev.get<std::string>("vbnv") % note;
       }
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
The error displayed when running xbutil examine reports without the --device switch is unclear about the issue. Please update to match the error seen when running xbmgmt examine reports without the --device switch, which is more clear for the user.

```
$ xbutil examine -r electrical 
Device list 
 [0000:af:00.1] : xilinx_u50lv_gen3x4_xdma_base_2
 [0000:18:00.1] : xilinx_u50_gen3x16_xdma_201920_3
Warning: Due to missing device, the following reports will not be generated:
    - electrical
```

Instead of Warning, give an error with a better explanation of what to do.
#### How problem was solved, alternative solutions (if any) and why they were rejected
Change output message for reports that require devices

#### Risks (if any) associated the changes in the commit
None, just an output text change

#### What has been tested and how, request additional testing if necessary
Manual testing on u280
Only invalid test
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r electrical
Error: The following report(s) require specifying a device using the --device option:
         - electrical
Device list
  [0000:65:00.1] : xilinx_u280_xdma_201920_3
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
```
**Note that the returned status is 0 and not 1** as this is not an "error" due to the case below. This is how the original code works and I did not want to change too much. Personally I think a status of 1 if a test fails to generate is correct. The change can be made very simply to return 1, so please let me know your thoughts!

Host test and invalid test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r electrical host
Error: The following report(s) require specifying a device using the --device option:
         - electrical
Device list
  [0000:65:00.1] : xilinx_u280_xdma_201920_3
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1123255
  Hash                 : 64a8abdae903e035d7b78684dc3abb5de974b72c
  Hash Date            : 2022-03-11 11:33:02
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.1]  :  xilinx_u280_xdma_201920_3  0x5e278820     user(inst=128)

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
```
Device specified test
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil examine -r electrical -d 65:00

-----------------------------------------------
1/1 [0000:65:00.1] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Electrical
  Max Power              : 225 Watts
  Power                  : 34.864306 Watts
  Power Warning          : false

  Power Rails            : Voltage   Current
  12 Volts Auxillary     : 12.238 V,  1.257 A
  12 Volts PCI Express   : 12.260 V,  1.589 A
  3.3 Volts PCI Express  :  3.288 V
  3.3 Volts Auxillary    :  3.313 V
  Internal FPGA Vcc      :  0.850 V, 13.032 A
  DDR Vpp Bottom         :  2.500 V
  DDR Vpp Top            :  2.500 V
  5.5 Volts System       :  5.461 V
  Vcc 1.2 Volts Top      :  1.203 V
  Vcc 1.2 Volts Bottom   :  1.202 V
  1.8 Volts Top          :  1.800 V
  0.9 Volts Vcc          :  0.901 V
  12 Volts SW            : 12.231 V
  Mgt Vtt                :  1.208 V

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
```
xbmgmt invalid test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -r platform
Error: The following report(s) require specifying a device using the --device option:
         - platform
Device list
  [0000:65:00.1] : xilinx_u280_xdma_201920_3
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
```
xbmgmt host and invalid test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -r platform host
Error: The following report(s) require specifying a device using the --device option:
         - platform
Device list
  [0000:65:00.1] : xilinx_u280_xdma_201920_3
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1123255
  Hash                 : 64a8abdae903e035d7b78684dc3abb5de974b72c
  Hash Date            : 2022-03-11 11:33:02
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
```
xbmgmt device specified:
```
root@xsjpranjal01:~# xbmgmt examine -d 65:00 -r platform

-----------------------------------------------
1/1 [0000:65:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : 21760394400G

Device properties
  Type                 : N/A
  Name                 : ALVEO U280 PQ
  Config Mode          : 7
  Max Power            : 225W

Flashable partitions running on FPGA
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820

Flashable partitions installed in system
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820


  Mac Address          : 01:02:03:04:05:06
                       : 01:02:03:04:05:07


root@xsjpranjal01:~# echo $?
0
```
#### Documentation impact (if any)
None