### PR TITLE
Fix the kernel filename in the testinfo.yml

### DIFF
--- a/tests/xrt/22_verify/testinfo.yml
+++ b/tests/xrt/22_verify/testinfo.yml
@@ -15,10 +15,10 @@ user:
   host_exe: host.exe
   host_src: main.cpp
   kernels:
-  - {cflags: {add: ' -I.'}, file: hello.xo, ksrc: hello.cl, name: hello, type: C}
+  - {cflags: {add: ' -I.'}, file: kernel.xo, ksrc: kernel.cl, name: hello, type: C}
   name: 22_verify
   xclbins:
-  - files: 'hello.xo '
+  - files: 'kernel.xo '
     kernels:
     - cus: [hello_1]
       name: hello


### PR DESCRIPTION
Due to the https://github.com/Xilinx/XRT/pull/6187, the existing kernel source filename in testinfo.yml is not valid anymore.
So, this pull request to update the filenames in testinfo.yml file.

No source code change, so no or minimal impact.