### PR TITLE
CR-1114407 False positive on host_mem for u250_xdma_201830_2

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1165,6 +1165,7 @@ hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost:
   auto shared_host_mem = xrt_core::device_query<xrt_core::query::shared_host_mem>(_dev);
 
   try {
+    /* check if shell supports host mem */
     xrt_core::device_query<xrt_core::query::enabled_host_mem>(_dev);
   } catch(...) {
     if (shared_host_mem) {

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1162,16 +1162,16 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  uint64_t shared_host_mem = 0;
+  uint64_t enabled_host_mem = 0;
   try {
-    shared_host_mem = xrt_core::device_query<xrt_core::query::shared_host_mem>(_dev);
+    enabled_host_mem = xrt_core::device_query<xrt_core::query::enabled_host_mem>(_dev);
   } catch(...) {
     logger(_ptTest, "Details", "Address translator IP is not available");
     _ptTest.put("status", test_token_skipped);
     return;
   }
 
-  if (!shared_host_mem) {
+  if (!enabled_host_mem) {
       logger(_ptTest, "Details", "Host memory is not enabled");
       _ptTest.put("status", test_token_skipped);
       return;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1162,16 +1162,22 @@ m2mTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 void
 hostMemBandwidthKernelTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptree& _ptTest)
 {
-  uint64_t enabled_host_mem = 0;
+  auto shared_host_mem = xrt_core::device_query<xrt_core::query::shared_host_mem>(_dev);
+
   try {
-    enabled_host_mem = xrt_core::device_query<xrt_core::query::enabled_host_mem>(_dev);
+    xrt_core::device_query<xrt_core::query::enabled_host_mem>(_dev);
   } catch(...) {
-    logger(_ptTest, "Details", "Address translator IP is not available");
-    _ptTest.put("status", test_token_skipped);
+    if (shared_host_mem) {
+        logger(_ptTest, "Details", "Host memory is enabled, device does not support the feature");
+        _ptTest.put("status", test_token_failed);
+    } else {
+        logger(_ptTest, "Details", "Address translator IP is not available");
+        _ptTest.put("status", test_token_skipped);
+    }
     return;
   }
 
-  if (!enabled_host_mem) {
+  if (!shared_host_mem) {
       logger(_ptTest, "Details", "Host memory is not enabled");
       _ptTest.put("status", test_token_skipped);
       return;


### PR DESCRIPTION
#### Problem solved by the commit
A false positive of host memory bandwidth test result. 

We check the entry "shared_host_mem" to decide whether we should test hostmem_bandwidth test, it sometime will be N/A if the shell has no address translator IP or not enable HOST[0].

#### How problem was solved, alternative solutions (if any) and why they were rejected
we should check the entry "enabled_host_mem" to decide whether we should test the hostmem_bandwidth test.

The entry "enabled_host_mem" is determined by the existence of address translator IP and HOST[0].

If it has non-zero value, it means the shell has address translator IP, HOST[0] is enabled and user enables host memory by xbutil configure --host-mem