### PR TITLE
CR-1125346 : VCK190_DFX: Second app is hanging on board

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -1404,6 +1404,7 @@ int kds_del_cu(struct kds_sched *kds, struct xrt_cu *xcu)
 			continue;
 
 		cu_mgmt->xcus[i] = NULL;
+		cu_mgmt->cu_intr[i] = 0;
 		--cu_mgmt->num_cus;
 		cu_stat_write(cu_mgmt, usage[i], 0);
 		break;


### PR DESCRIPTION
Issue : 
on DFX platform, We took two applications that are independently passing on vck190_dfx platform on board. Tried running two applications  one after the other without rebooting the board to check the true DFX functionality and observed that the second application is hanging. 

Root cause:
Cleanup is missing. While loading the next xclbin the cleanup should be done for the CUs.

Test: 
Working fine with this changes
