### PR TITLE
CR-1124522 handle VMR endpoints when it is both in

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1718,12 +1718,10 @@ int xocl_subdev_create_vsec_devs(xdev_handle_t xdev)
 		xocl_xdev_dbg(xdev, "xdev flash_type %s", core->priv.flash_type);
 
 		ret = xocl_subdev_create(xdev, &subdev_info);
-		if (ret) {
-			xocl_xdev_err(xdev, "Create VMR subdev failed. %d", ret);
+		if (ret)
 			goto done;
-		}
 
-		xocl_xdev_dbg(xdev, "VSEC VMR created.");
+		xocl_xdev_info(xdev, "VSEC VMR created.");
 	}
 
 	ret = xocl_subdev_vsec(xdev, XOCL_VSEC_MAILBOX, &bar, &offset, NULL);


### PR DESCRIPTION
partition_metadata and VSEC

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
- the VMR xgq is the same as mailbox, so skip if it is already being loaded with return error -17.
- 
#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
