### PR TITLE
CR-1123552 Firewall tripped and kernel paniced on xilinx_u250_gen3x16_xdma_shell_4_1

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -830,7 +830,7 @@ kds_del_scu_context(struct kds_sched *kds, struct kds_client *client,
 		   struct kds_ctx_info *info)
 {
 	struct kds_scu_mgmt *scu_mgmt = &kds->scu_mgmt;
-	u32 cu_idx = 0;
+	u32 cu_idx = info->cu_idx;
 	unsigned long submitted = 0;
 	unsigned long completed = 0;
 

--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -707,7 +707,7 @@ kds_del_cu_context(struct kds_sched *kds, struct kds_client *client,
 	if (submitted == completed)
 		goto skip;
 
-	if (kds->ert_disable) {
+	if (kds->ert_disable || kds->xgq_enable) {
 		wait_ms = 500;
 		xrt_cu_abort(cu_mgmt->xcus[cu_idx], client);
 

--- a/src/runtime_src/core/common/drv/xrt_cu.c
+++ b/src/runtime_src/core/common/drv/xrt_cu.c
@@ -819,6 +819,7 @@ int xrt_cu_init(struct xrt_cu *xcu)
 	atomic_set(&xcu->tick, 0);
 	xcu->thread = NULL;
 
+	mod_timer(&xcu->timer, jiffies + CU_TIMER);
 	return err;
 }
 
@@ -834,6 +835,7 @@ void xrt_cu_fini(struct xrt_cu *xcu)
 	if (xcu->thread && !IS_ERR(xcu->thread))
 		(void) kthread_stop(xcu->thread);
 
+	del_timer_sync(&xcu->timer);
 	return;
 }
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -984,6 +984,7 @@ int xocl_kds_reset(struct xocl_dev *xdev, const xuid_t *xclbin_id)
 {
 	xocl_kds_fa_clear(xdev);
 
+	XDEV(xdev)->kds.bad_state = 0;
 	return 0;
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
When firewall tripped, the kernel panic for DRM report "Memory manager not clean during takedown".

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug is introduce when we move to XGQ base ERT. This is only happened when something goes wrong on the device.

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Abort outstanding command to CU subdevice.
2. CU timer is not running to calculate command timeout.

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
The bug case on U250.

#### Documentation impact (if any)
No