### PR TITLE
CR-1125486 Xbmgmt on windows in 22.1 fail to detect u250 2_1 on ZT server

### DIFF
--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -124,7 +124,7 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   for (auto& kd : available_devices) {
     const boost::property_tree::ptree& dev = kd.second;
     std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
-    std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv"), dev.get<std::string>("id"), dev.get<std::string>("instance")};
+    std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a")};
     device_table.addEntry(entry_data);
   }
 

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -120,6 +120,7 @@ XBUtilities::get_available_devices(bool inUserDomain)
        pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));
      } catch(const xrt_core::query::exception&) {
          // The instance wasn't added
+         pt_dev.put("instance", "n/a");
        }
 
     }

--- a/src/runtime_src/core/tools/common/XBUtilities.cpp
+++ b/src/runtime_src/core/tools/common/XBUtilities.cpp
@@ -120,7 +120,6 @@ XBUtilities::get_available_devices(bool inUserDomain)
        pt_dev.put("instance",boost::str(boost::format("%s(inst=%d)") % pf % instance));
      } catch(const xrt_core::query::exception&) {
          // The instance wasn't added
-         pt_dev.put("instance", "n/a");
        }
 
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
[CR-1125486](https://jira.xilinx.com/browse/CR-1125486): Xbmgmt on windows in 22.1 fail to detect u250 2_1 on ZT server
This is because we don't have "instance" for windows. For this case, we should simply populate the ptree with "n/a"

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
DSV testing for windows

#### How problem was solved, alternative solutions (if any) and why they were rejected
if "instance" is not available then we populate with "n/a"

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
Manually by faking the fact that instance doesn't exists:
```
$ ./xbutil2 examine
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15671 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Super Server

XRT
  Version              : 2.13.0
  Branch               : int_7
  Hash                 : 633ea98b6ad7830edd98469dec259b8ed6f9da09
  Hash Date            : 2022-03-03 06:04:45
  XOCL                 : 2.13.0, 633ea98b6ad7830edd98469dec259b8ed6f9da09
  XCLMGMT              : 2.13.0, 633ea98b6ad7830edd98469dec259b8ed6f9da09

Devices present
BDF             :  Shell                            Platform UUID                         Device ID     
[0000:b3:00.1]  :  xilinx_u200_gen3x16_xdma_base_1  A2D4F3CF-5B7A-0B7B-70F9-DA589CB5B3CD  user(inst=0)  
[0000:18:00.1]  :  xilinx_u30_gen3x4_base_2         6E7C97F7-949F-5106-3075-A77784C30A4B  n/a           
[0000:17:00.1]  :  xilinx_u30_gen3x4_base_2         6E7C97F7-949F-5106-3075-A77784C30A4B  n/a           
[0000:65:00.1]  :                                   0x0                                   n/a 
```

#### Documentation impact (if any)
None