### PR TITLE
CR-1119816 Fix mac address readings on versal

### DIFF
--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -451,7 +451,22 @@ struct mac_addr_list
     for (int i=0; i < LEGACY_COUNT; i++) {
       std::string addr, errmsg;
       pdev->sysfs_get("xmc", "mac_addr"+std::to_string(i), errmsg, addr);
-      list.push_back(addr);
+      if (!addr.empty())
+        list.push_back(addr);
+    }
+
+    if (list.empty()) {
+      //check if the data can be retrieved from vmr.
+      std::string errmsg;
+      int i = 0;
+      do {
+        std::string addr;
+        errmsg.clear();
+        pdev->sysfs_get("hwmon_sdm", "mac_addr"+std::to_string(i), errmsg, addr);
+        if (!addr.empty())
+          list.push_back(addr);
+        i++;
+      } while (errmsg.empty());
     }
 
     return list;


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fixing MAC Address data displayed through XRT tools

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1119816

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in XRT

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Run xbutil & xbmgmt tool commands

#### Documentation impact (if any)
NA