### PR TITLE
CR-1119816 hwmon_sdm: enable hwmon_sdm driver only on versal & Fixes related to MAC address readings

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/hwmon_sdm.c
@@ -50,10 +50,10 @@ struct xocl_sdr_bdinfo {
 	uint64_t mfg_date;
 	uint64_t pcie_info;
 	uint64_t uuid;
-	uint64_t mac_addr0;
-	uint64_t mac_addr1;
-	uint64_t active_msp_ver;
-	uint64_t target_msp_ver;
+	char mac_addr0[SDR_BDINFO_ENTRY_LEN_MAX];
+	char mac_addr1[SDR_BDINFO_ENTRY_LEN_MAX];
+	char active_msp_ver[SDR_BDINFO_ENTRY_LEN_MAX];
+	char target_msp_ver[SDR_BDINFO_ENTRY_LEN_MAX];
 	uint64_t oem_id;
 	bool fan_presence;
 };
@@ -406,9 +406,9 @@ static void hwmon_sdm_load_bdinfo(struct xocl_hwmon_sdm *sdm, uint8_t repo_id,
 	else if (!strcmp(sensor_name, "UUID"))
 		memcpy(&sdm->bdinfo.uuid, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "MAC 0"))
-		memcpy(&sdm->bdinfo.mac_addr0, &sdm->sensor_data[repo_id][ins_index], val_len);
+		memcpy(sdm->bdinfo.mac_addr0, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "MAC 1"))
-		memcpy(&sdm->bdinfo.mac_addr1, &sdm->sensor_data[repo_id][ins_index], val_len);
+		memcpy(sdm->bdinfo.mac_addr1, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "Fan Presence"))
 	{
 		char sensor_val[60];
@@ -418,10 +418,10 @@ static void hwmon_sdm_load_bdinfo(struct xocl_hwmon_sdm *sdm, uint8_t repo_id,
 		else
 			sdm->bdinfo.fan_presence = false;
 	}
-	else if (!strcmp(sensor_name, "Active MSP Ver"))
-		memcpy(&sdm->bdinfo.active_msp_ver, &sdm->sensor_data[repo_id][ins_index], val_len);
-	else if (!strcmp(sensor_name, "Target MSP Ver"))
-		memcpy(&sdm->bdinfo.target_msp_ver, &sdm->sensor_data[repo_id][ins_index], val_len);
+	else if (!strcmp(sensor_name, "Active SC Ver"))
+		memcpy(sdm->bdinfo.active_msp_ver, &sdm->sensor_data[repo_id][ins_index], val_len);
+	else if (!strcmp(sensor_name, "Target SC Ver"))
+		memcpy(sdm->bdinfo.target_msp_ver, &sdm->sensor_data[repo_id][ins_index], val_len);
 	else if (!strcmp(sensor_name, "OEM ID"))
 		memcpy(&sdm->bdinfo.oem_id, &sdm->sensor_data[repo_id][ins_index], val_len);
 }
@@ -833,7 +833,10 @@ mac_addr0_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "0x%llx\n", sdm->bdinfo.mac_addr0);
+	return sprintf(buf, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX\n",
+				   sdm->bdinfo.mac_addr0[0], sdm->bdinfo.mac_addr0[1], sdm->bdinfo.mac_addr0[2],
+				   sdm->bdinfo.mac_addr0[3], sdm->bdinfo.mac_addr0[4], sdm->bdinfo.mac_addr0[5],
+				   sdm->bdinfo.mac_addr0[6], sdm->bdinfo.mac_addr0[7]);
 };
 static DEVICE_ATTR_RO(mac_addr0);
 
@@ -842,7 +845,10 @@ mac_addr1_show(struct device *dev, struct device_attribute *attr, char *buf)
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "0x%llx\n", sdm->bdinfo.mac_addr1);
+	return sprintf(buf, "%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX:%02hhX\n",
+				   sdm->bdinfo.mac_addr1[0], sdm->bdinfo.mac_addr1[1], sdm->bdinfo.mac_addr1[2],
+				   sdm->bdinfo.mac_addr1[3], sdm->bdinfo.mac_addr1[4], sdm->bdinfo.mac_addr1[5],
+				   sdm->bdinfo.mac_addr1[6], sdm->bdinfo.mac_addr1[7]);
 };
 static DEVICE_ATTR_RO(mac_addr1);
 
@@ -860,7 +866,8 @@ active_msp_ver_show(struct device *dev, struct device_attribute *attr, char *buf
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "0x%llx\n", sdm->bdinfo.active_msp_ver);
+	return sprintf(buf, "%d.%d.%d\n", sdm->bdinfo.active_msp_ver[0],
+				   sdm->bdinfo.active_msp_ver[1], sdm->bdinfo.active_msp_ver[2]);
 };
 static DEVICE_ATTR_RO(active_msp_ver);
 
@@ -869,7 +876,8 @@ target_msp_ver_show(struct device *dev, struct device_attribute *attr, char *buf
 {
 	struct xocl_hwmon_sdm *sdm = dev_get_drvdata(dev);
 
-	return sprintf(buf, "0x%llx\n", sdm->bdinfo.target_msp_ver);
+	return sprintf(buf, "%d.%d.%d\n", sdm->bdinfo.target_msp_ver[0],
+				   sdm->bdinfo.target_msp_ver[1], sdm->bdinfo.target_msp_ver[2]);
 };
 static DEVICE_ATTR_RO(target_msp_ver);
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -1932,6 +1932,7 @@ static int xgq_ospi_close(struct inode *inode, struct file *file)
 
 static int xgq_vmr_remove(struct platform_device *pdev)
 {
+	xdev_handle_t xdev = xocl_get_xdev(pdev);
 	struct xocl_xgq_vmr	*xgq;
 	void *hdl;
 
@@ -1950,6 +1951,8 @@ static int xgq_vmr_remove(struct platform_device *pdev)
 		iounmap(xgq->xgq_payload_base);
 	if (xgq->xgq_sq_base)
 		iounmap(xgq->xgq_sq_base);
+
+	xocl_subdev_destroy_by_id(xdev, XOCL_SUBDEV_HWMON_SDM);
 
 	sysfs_remove_group(&pdev->dev.kobj, &xgq_attr_group);
 	mutex_destroy(&xgq->xgq_lock);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -953,7 +953,7 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 		ret = xocl_hwmon_sdm_init(xdev);
 		if (ret) {
 			userpf_err(xdev, "failed to init hwmon_sdm driver, err: %d", ret);
-			ret = 0;
+			goto failed;
 		}
 	}
 

--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -948,10 +948,13 @@ int xocl_refresh_subdevs(struct xocl_dev *xdev)
 		goto failed;
 	}
 
-	ret = xocl_hwmon_sdm_init(xdev);
-	if (ret) {
-		userpf_err(xdev, "failed to init hwmon_sdm driver, err: %d", ret);
-		ret = 0;
+	if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
+		//probe & initialize hwmon_sdm driver only on versal
+		ret = xocl_hwmon_sdm_init(xdev);
+		if (ret) {
+			userpf_err(xdev, "failed to init hwmon_sdm driver, err: %d", ret);
+			ret = 0;
+		}
 	}
 
 	(void) xocl_peer_listen(xdev, xocl_mailbox_srv, (void *)xdev);


### PR DESCRIPTION
Probe and initialize hwmon_sdm driver only on versal device.
Fix MAC address and SC version readings in hwmon_sdm driver.
Fix reloading hwmon_sdm driver during xbutil reset sequence. hwmon_sdm driver has to be removed as part of xgq driver removal.

Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
hwmon_sdm driver will only initialized on versal device. Fixing MAC address readings.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1119816. Also, hwmon_sdm is getting initialized on non-versal platforms which is not expected behavior.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added changes in hwmon_sdm driver.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
Read hwmon_sdm sysfs nodes.

#### Documentation impact (if any)
NA