### PR TITLE
CR-1120043 : Enhanced xbutil2 to show core information which is not enabled but buffer exists

### DIFF
--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -537,8 +537,8 @@ populate_aie_core_gmio(const boost::property_tree::ptree& pt, boost::property_tr
 bool
 is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property_tree::ptree& tile)
 {
-  int row = tile.get<int>("row");
-  int col = tile.get<int>("column");
+  auto row = tile.get<int>("row");
+  auto col = tile.get<int>("column");
   for (auto& node : tile_array) {
       if ((node.second.get<int>("column") == col) && (node.second.get<int>("row") == row))
         return true;

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -540,8 +540,8 @@ is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property
   const auto row = tile.get<int>("row");
   const auto col = tile.get<int>("column");
   for (auto& node : tile_array) {
-      if ((node.second.get<int>("column") == col) && (node.second.get<int>("row") == row))
-        return true;
+    if ((node.second.get<int>("column") == col) && (node.second.get<int>("row") == row))
+      return true;
   }
 
   return false;
@@ -550,8 +550,8 @@ is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property
 // Populate a specific AIE core which is unused but memory buffers exist [row:col]
 void
 populate_buffer_only_cores(const boost::property_tree::ptree& pt,
-			    const boost::property_tree::ptree& core_info, int gr_id,
-		  	  boost::property_tree::ptree& tile_array)
+			   const boost::property_tree::ptree& core_info, int gr_id,
+			   boost::property_tree::ptree& tile_array)
 {
   const boost::property_tree::ptree empty_pt;
 
@@ -562,16 +562,22 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
     boost::property_tree::ptree igraph;
     auto dma_row_it = g_node.second.get_child("dma_rows", empty_pt).begin();
     for (const auto& node : g_node.second.get_child("dma_columns", empty_pt)) {
-      boost::property_tree::ptree tile;
-      tile.put("column", node.second.data());
-      tile.put("row", dma_row_it->second.data());
-      // Check whether this core is already added
-      if (is_duplicate_core(tile_array, tile))
-        continue;
+      try {
+        boost::property_tree::ptree tile;
+        tile.put("column", node.second.data());
+        tile.put("row", dma_row_it->second.data());
+        // Check whether this core is already added
+        if (is_duplicate_core(tile_array, tile))
+          continue;
 
-      populate_aie_core(core_info, tile);
-      dma_row_it++;
-      tile_array.push_back(std::make_pair("", tile));
+        populate_aie_core(core_info, tile);
+        tile_array.push_back(std::make_pair("", tile));
+	if (dma_row_it != g_node.second.end())
+          dma_row_it++;
+      } catch (const std::exception& ex) {
+        pt.put("error_msg", ex.what());
+        return;
+      }
     }
   }
 }

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -420,7 +420,7 @@ populate_aie_shim(const xrt_core::device *device, const std::string& desc)
         ....
 */
 
-// This function populate a specific AIE core given as an input of [row:col]
+// Populate a specific AIE core given as an input of [row:col]
 void
 populate_aie_core(const boost::property_tree::ptree& pt_core, boost::property_tree::ptree& tile)
 {

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -547,7 +547,7 @@ is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property
   return false;
 }
 
-// This function populate a specific AIE core which is unused but memory buffers exists [row:col]
+// Populate a specific AIE core which is unused but memory buffers exist [row:col]
 void
 populate_buffer_only_cores(const boost::property_tree::ptree& pt,
 			  const boost::property_tree::ptree& core_info, int gr_id,

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -428,8 +428,8 @@ populate_aie_core(const boost::property_tree::ptree& pt_core, boost::property_tr
     boost::property_tree::ptree pt;
     boost::property_tree::ptree empty_pt;
 
-    int row = tile.get<int>("row");
-    int col = tile.get<int>("column");
+    auto row = tile.get<int>("row");
+    auto col = tile.get<int>("column");
     pt = pt_core.get_child("aie_core." + std::to_string(col) + "_" + std::to_string(row));
 
     std::string status;

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -538,7 +538,7 @@ bool
 is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property_tree::ptree& tile)
 {
   const auto row = tile.get<int>("row");
-  auto col = tile.get<int>("column");
+  const auto col = tile.get<int>("column");
   for (auto& node : tile_array) {
       if ((node.second.get<int>("column") == col) && (node.second.get<int>("row") == row))
         return true;

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -551,7 +551,7 @@ is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property
 void
 populate_buffer_only_cores(const boost::property_tree::ptree& pt,
 			    const boost::property_tree::ptree& core_info, int gr_id,
-			  boost::property_tree::ptree& tile_array)
+		  	  boost::property_tree::ptree& tile_array)
 {
   const boost::property_tree::ptree empty_pt;
 

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -565,9 +565,6 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
       boost::property_tree::ptree tile;
       tile.put("column", node.second.data());
       tile.put("row", dma_row_it->second.data());
-      int row = tile.get<int>("row");
-      int col = tile.get<int>("column");
-
       // Check whether this core is already added
       if (is_duplicate_core(tile_array, tile))
         continue;

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -533,7 +533,7 @@ populate_aie_core_gmio(const boost::property_tree::ptree& pt, boost::property_tr
   pt_array.add_child("gmios",gmio_array);
 }
 
-// This function check the duplicate entry in tile_aaray for the same core [row:col]
+// Check for duplicate entry in tile_array for the same core [row:col]
 bool
 is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property_tree::ptree& tile)
 {

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -537,7 +537,7 @@ populate_aie_core_gmio(const boost::property_tree::ptree& pt, boost::property_tr
 bool
 is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property_tree::ptree& tile)
 {
-  auto row = tile.get<int>("row");
+  const auto row = tile.get<int>("row");
   auto col = tile.get<int>("column");
   for (auto& node : tile_array) {
       if ((node.second.get<int>("column") == col) && (node.second.get<int>("row") == row))

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -562,22 +562,17 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
     boost::property_tree::ptree igraph;
     auto dma_row_it = g_node.second.get_child("dma_rows", empty_pt).begin();
     for (const auto& node : g_node.second.get_child("dma_columns", empty_pt)) {
-      try {
-        boost::property_tree::ptree tile;
-        tile.put("column", node.second.data());
-        tile.put("row", dma_row_it->second.data());
-        // Check whether this core is already added
-        if (is_duplicate_core(tile_array, tile))
-          continue;
+      boost::property_tree::ptree tile;
+      tile.put("column", node.second.data());
+      tile.put("row", dma_row_it->second.data());
+      // Check whether this core is already added
+      if (is_duplicate_core(tile_array, tile))
+        continue;
 
-        populate_aie_core(core_info, tile);
-        tile_array.push_back(std::make_pair("", tile));
-	if (dma_row_it != g_node.second.end())
-          dma_row_it++;
-      } catch (const std::exception& ex) {
-        pt.put("error_msg", ex.what());
-        return;
-      }
+      populate_aie_core(core_info, tile);
+      tile_array.push_back(std::make_pair("", tile));
+      if (dma_row_it != g_node.second.end())
+        dma_row_it++;
     }
   }
 }

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -560,7 +560,7 @@ populate_buffer_only_cores(const boost::property_tree::ptree& pt,
       continue;
 
     boost::property_tree::ptree igraph;
-    auto dma_row_it = g_node.second.get_child("dma_rows").begin();
+    auto dma_row_it = g_node.second.get_child("dma_rows", empty_pt).begin();
     for (const auto& node : g_node.second.get_child("dma_columns", empty_pt)) {
       boost::property_tree::ptree tile;
       tile.put("column", node.second.data());

--- a/src/runtime_src/core/common/info_aie.cpp
+++ b/src/runtime_src/core/common/info_aie.cpp
@@ -550,7 +550,7 @@ is_duplicate_core(const boost::property_tree::ptree& tile_array, boost::property
 // Populate a specific AIE core which is unused but memory buffers exist [row:col]
 void
 populate_buffer_only_cores(const boost::property_tree::ptree& pt,
-			  const boost::property_tree::ptree& core_info, int gr_id,
+			    const boost::property_tree::ptree& core_info, int gr_id,
 			  boost::property_tree::ptree& tile_array)
 {
   const boost::property_tree::ptree empty_pt;

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -212,7 +212,8 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
     }
 
     count = 0;
-    for (auto& rtp_node : _pt.get_child("aie_metadata.rtps")) {
+    for (const auto& rtp_node : _pt.get_child("aie_metadata.rtps")) {
+
       _output << boost::format("  %-3s:[%2d]\n") % "RTP" % count;
       _output << fmtCommon("%s") % "Port Name" % rtp_node.second.get<std::string>("port_name");
       _output << fmtCommon("%d") % "Selector Row" % rtp_node.second.get<uint16_t>("selector_row");

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -140,7 +140,7 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 
 	  if(tile.second.find("dma.fifo") != tile.second.not_found()) {
             _output << boost::format("%12s:\n") % "FIFO";
-            for(auto& node : tile.second.get_child("dma.fifo.counters")) {
+            for(const auto& node : tile.second.get_child("dma.fifo.counters")) {
               _output << fmt16("%s") % node.second.get<std::string>("index")
 		    % node.second.get<std::string>("count");
 	    }
@@ -149,7 +149,7 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
           _output << boost::format("        %s:\n") % "MM2S";
 
           _output << boost::format("            %s:\n") % "Channel";
-          for(auto& node : tile.second.get_child("dma.mm2s.channel")) {
+          for(const auto& node : tile.second.get_child("dma.mm2s.channel")) {
             _output << fmt16("%s") % "Id" % node.second.get<std::string>("id");
             _output << fmt16("%s") % "Channel Status" % node.second.get<std::string>("channel_status");
             _output << fmt16("%s") % "Queue Size" % node.second.get<std::string>("queue_size");
@@ -161,7 +161,7 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
           _output << boost::format("        %s:\n") % "S2MM";
 
           _output << boost::format("            %s:\n") % "Channel";
-          for(auto& node : tile.second.get_child("dma.s2mm.channel")) {
+          for(const auto& node : tile.second.get_child("dma.s2mm.channel")) {
             _output << fmt16("%s") % "Id" % node.second.get<std::string>("id");
             _output << fmt16("%s") % "Channel Status" % node.second.get<std::string>("channel_status");
             _output << fmt16("%s") % "Queue Size" % node.second.get<std::string>("queue_size");
@@ -173,7 +173,7 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 
         if(tile.second.find("locks") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "Locks";
-          for(auto& node : tile.second.get_child("locks", empty_ptree)) {
+          for(const auto& node : tile.second.get_child("locks", empty_ptree)) {
             _output << fmt8("%s")  % node.second.get<std::string>("name")
                                    % node.second.get<std::string>("value");
           }
@@ -182,9 +182,9 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 
         if(tile.second.find("errors") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "Errors";
-          for(auto& node : tile.second.get_child("errors", empty_ptree)) {
+          for(const auto& node : tile.second.get_child("errors", empty_ptree)) {
             _output << boost::format("        %s:\n") % node.second.get<std::string>("module");
-            for(auto& enode : node.second.get_child("error", empty_ptree)) {
+            for(const auto& enode : node.second.get_child("error", empty_ptree)) {
               _output << fmt12("%s")  % enode.second.get<std::string>("name")
                                      % enode.second.get<std::string>("value");
             }
@@ -194,7 +194,7 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
 
         if(tile.second.find("events") != tile.second.not_found()) {
           _output << boost::format("    %s:\n") % "Events";
-          for(auto& node : tile.second.get_child("events", empty_ptree)) {
+          for(const auto& node : tile.second.get_child("events", empty_ptree)) {
             _output << fmt8("%s")  % node.second.get<std::string>("name")
                                    % node.second.get<std::string>("value");
           }
@@ -205,9 +205,8 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
       const boost::property_tree::ptree& pl_kernel = graph.get_child("pl_kernel");
       if (!pl_kernel.empty()) {
         _output << boost::format("    %s\n") % "Pl Kernel Instances in Graph:";
-        for (auto& node : graph.get_child("pl_kernel")) {
+        for (auto& node : graph.get_child("pl_kernel"))
           _output << boost::format("      %s\n") % node.second.data();
-        }
       }
       _output << std::endl;
     }

--- a/src/runtime_src/core/tools/common/ReportAie.cpp
+++ b/src/runtime_src/core/tools/common/ReportAie.cpp
@@ -101,12 +101,17 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
            % "Iteration_Memory [C:R]" % "Iteration_Memory_Addresses";
       for (auto& node : graph.get_child("tile")) {
         const boost::property_tree::ptree& tile = node.second;
+
+	if (tile.get<std::string>("memory_column", "") == "")
+	  continue;
+
         _output << boost::format("    [%2d]   %-20s%-30s%-30d\n") % count
             % (tile.get<std::string>("column") + ":" + tile.get<std::string>("row"))
             % (tile.get<std::string>("memory_column") + ":" + tile.get<std::string>("memory_row"))
             % node.second.get<uint16_t>("memory_address");
         count++;
       }
+
       _output << std::endl;
       count = 0;
       for (auto& tile : graph.get_child("tile")) {
@@ -205,91 +210,6 @@ ReportAie::writeReport(const xrt_core::device* /*_pDevice*/,
         }
       }
       _output << std::endl;
-    }
-
-    for (auto& cores : _pt.get_child("aie_metadata.buf_only_cores", empty_ptree)) {
-      const boost::property_tree::ptree& tiles = cores.second;
-      for (auto& tile : tiles.get_child("tile")) {
-        int curr_core = count++;
-        if(aieCoreList.size() && (std::find(aieCoreList.begin(), aieCoreList.end(),
-		     std::to_string(curr_core)) == aieCoreList.end()))
-          continue;
-
-        _output << boost::format("Core [Buffer Only]\n");
-        _output << fmt4("%d") % "Column" % tile.second.get<int>("column");
-        _output << fmt4("%d") % "Row" % tile.second.get<int>("row");
-
-	if(is_less) {
-	  _output << std::endl;
-	  continue;
-	}
-
-	if(tile.second.find("dma") != tile.second.not_found()) {
-          _output << boost::format("    %s:\n") % "DMA";
-
-	  if(tile.second.find("dma.fifo") != tile.second.not_found()) {
-            _output << boost::format("%12s:\n") % "FIFO";
-            for(auto& node : tile.second.get_child("dma.fifo.counters")) {
-              _output << fmt16("%s") % node.second.get<std::string>("index")
-		    % node.second.get<std::string>("count");
-            }
-	  }
-
-          _output << boost::format("        %s:\n") % "MM2S";
-
-          _output << boost::format("            %s:\n") % "Channel";
-          for(auto& node : tile.second.get_child("dma.mm2s.channel")) {
-            _output << fmt16("%s") % "Id" % node.second.get<std::string>("id");
-            _output << fmt16("%s") % "Channel Status" % node.second.get<std::string>("channel_status");
-            _output << fmt16("%s") % "Queue Size" % node.second.get<std::string>("queue_size");
-            _output << fmt16("%s") % "Queue Status" % node.second.get<std::string>("queue_status");
-            _output << fmt16("%s") % "Current BD" % node.second.get<std::string>("current_bd");
-            _output << std::endl;
-          }
-
-          _output << boost::format("        %s:\n") % "S2MM";
-
-          _output << boost::format("            %s:\n") % "Channel";
-          for(auto& node : tile.second.get_child("dma.s2mm.channel")) {
-            _output << fmt16("%s") % "Id" % node.second.get<std::string>("id");
-            _output << fmt16("%s") % "Channel Status" % node.second.get<std::string>("channel_status");
-            _output << fmt16("%s") % "Queue Size" % node.second.get<std::string>("queue_size");
-            _output << fmt16("%s") % "Queue Status" % node.second.get<std::string>("queue_status");
-            _output << fmt16("%s") % "Current BD" % node.second.get<std::string>("current_bd");
-            _output << std::endl;
-          }
-        }
-
-        if(tile.second.find("locks") != tile.second.not_found()) {
-          _output << boost::format("    %s:\n") % "Locks";
-          for(auto& node : tile.second.get_child("locks",empty_ptree)) {
-            _output << fmt8("%s")  % node.second.get<std::string>("name")
-                                   % node.second.get<std::string>("value");
-          }
-          _output << std::endl;
-        }
-
-        if(tile.second.find("errors") != tile.second.not_found()) {
-          _output << boost::format("    %s:\n") % "Errors";
-          for(auto& node : tile.second.get_child("errors",empty_ptree)) {
-            _output << boost::format("        %s:\n") % node.second.get<std::string>("module");
-            for(auto& enode : node.second.get_child("error",empty_ptree)) {
-              _output << fmt12("%s")  % enode.second.get<std::string>("name")
-                                     % enode.second.get<std::string>("value");
-            }
-          }
-          _output << std::endl;
-        }
-
-        if(tile.second.find("events") != tile.second.not_found()) {
-          _output << boost::format("    %s:\n") % "Events";
-          for(auto& node : tile.second.get_child("events",empty_ptree)) {
-            _output << fmt8("%s")  % node.second.get<std::string>("name")
-                                   % node.second.get<std::string>("value");
-          }
-          _output << std::endl;
-        }
-      }
     }
 
     count = 0;


### PR DESCRIPTION
This PR cover both the following CRs:
[CR-1120043] Missing "locks" section in aie_status_edge.json when Core is unused but buffers exists
[CR-1114191] Please remove the sentence "Pl Kernel Instances in Graph:" from xbutil report.

In AIE, there are some cores which is not enabled but memory buffer exists on those cores.
In AIE metadata "dma_columns", "dma_row", which tells about all the cores where memory buffer present.

We traverse all of that and show the lock, DMA information of those cores, even though those cores are not enable.

No output change for xbutil. It will additionally show more Cores.