### PR TITLE
CR-1125596 set fifo full flag only in hw flow

### DIFF
--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -253,7 +253,7 @@ read_trace_fifo(bool)
   if (!fifo_full) {
     auto fifo_size = dev_intf->getFifoSize();
 
-    if (num_packets >= fifo_size)
+    if ((num_packets >= fifo_size) && (has_finite_fifo()))
       fifo_full = true;
   }
 }
@@ -452,9 +452,10 @@ init_s2mm(bool circ_buf, const std::vector<uint64_t> &buf_sizes)
     // Data Mover will write input stream to this address
     ts2mm_info.buffers[i].address = dev_intf->getDeviceAddr(ts2mm_info.buffers[i].buf);
     dev_intf->initTS2MM(i, ts2mm_info.buffers[i].buf_size, ts2mm_info.buffers[i].address, ts2mm_info.use_circ_buf);
-  debug_stream
-    << "DeviceTraceOffload::init_s2mm with each size : " << ts2mm_info.buffers[i].buf_size << " initiated " << i << " ts2mm "
-    << std::endl;
+
+    debug_stream
+    << "DeviceTraceOffload::init_s2mm with each size : " << ts2mm_info.buffers[i].buf_size
+    << " initiated " << i << " ts2mm " << std::endl;
   }
   return true;
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.cpp
@@ -253,7 +253,8 @@ read_trace_fifo(bool)
   if (!fifo_full) {
     auto fifo_size = dev_intf->getFifoSize();
 
-    if ((num_packets >= fifo_size) && (has_finite_fifo()))
+    // hw emulation has infinite fifo
+    if ((num_packets >= fifo_size) && (xdp::getFlowMode() == xdp::Flow::HW))
       fifo_full = true;
   }
 }

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -170,11 +170,6 @@ private:
   void process_trace_continuous();
   void read_leftover_circular_buf();
 
-private:
-  bool has_finite_fifo() {
-    return (xdp::getFlowMode() == xdp::Flow::HW);
-  };
-
 protected:
   DeviceIntf* dev_intf;
   bool m_initialized = false;

--- a/src/runtime_src/xdp/profile/device/device_trace_offload.h
+++ b/src/runtime_src/xdp/profile/device/device_trace_offload.h
@@ -22,6 +22,7 @@
 #include "xdp/profile/device/device_intf.h"
 #include "xdp/profile/device/device_trace_logger.h"
 #include "xdp/profile/device/tracedefs.h"
+#include "xdp/profile/plugin/vp_base/utility.h"
 
 #include <atomic>
 #include <chrono>
@@ -37,15 +38,15 @@
 namespace xdp {
 
 enum class OffloadThreadStatus {
-    IDLE,
-    RUNNING,
-    STOPPING,
-    STOPPED
+  IDLE,
+  RUNNING,
+  STOPPING,
+  STOPPED
 };
 
 enum class OffloadThreadType {
-    TRACE,
-    CLOCK_TRAIN
+  TRACE,
+  CLOCK_TRAIN
 };
 
 struct TraceBufferInfo {
@@ -107,107 +108,106 @@ if(!m_debug); else std::cout
 
 class DeviceTraceOffload {
 public:
-    XDP_EXPORT
-    DeviceTraceOffload(DeviceIntf* dInt, DeviceTraceLogger* dTraceLogger,
-                       uint64_t offload_sleep_ms, uint64_t trbuf_sz);
-    XDP_EXPORT
-    virtual ~DeviceTraceOffload();
-    XDP_EXPORT
-    void start_offload(OffloadThreadType type);
-    XDP_EXPORT
-    void stop_offload();
+  XDP_EXPORT
+  DeviceTraceOffload(DeviceIntf* dInt, DeviceTraceLogger* dTraceLogger,
+                     uint64_t offload_sleep_ms, uint64_t trbuf_sz);
+  XDP_EXPORT
+  virtual ~DeviceTraceOffload();
+  XDP_EXPORT
+  void start_offload(OffloadThreadType type);
+  XDP_EXPORT
+  void stop_offload();
+  XDP_EXPORT
+  virtual bool read_trace_init(bool circ_buf, const std::vector<uint64_t>&);
+  XDP_EXPORT
+  virtual void read_trace_end();
+  XDP_EXPORT
+  void train_clock();
+  XDP_EXPORT
+  void process_trace();
+  XDP_EXPORT
+  bool trace_buffer_full();
 
-    XDP_EXPORT
-    virtual bool read_trace_init(bool circ_buf, const std::vector<uint64_t>&);
-    XDP_EXPORT
-    virtual void read_trace_end();
-    XDP_EXPORT
-    void train_clock();
-    XDP_EXPORT
-    void process_trace();
-    XDP_EXPORT
-    bool trace_buffer_full();
+public:
+  bool has_fifo() {
+    return dev_intf->hasFIFO();
+  };
 
-    bool has_fifo() {
-      return dev_intf->hasFIFO();
-    };
+  bool has_ts2mm() {
+    return dev_intf->hasTs2mm();
+  };
 
-    bool has_ts2mm() {
-      return dev_intf->hasTs2mm();
-    };
+  void read_trace() {
+    m_read_trace(true);
+  };
 
-    void read_trace() {
-      m_read_trace(true);
-    };
+  bool using_circular_buffer( uint64_t& min_offload_rate,
+                              uint64_t& requested_offload_rate) {
+    min_offload_rate = ts2mm_info.circ_buf_min_rate;
+    requested_offload_rate = ts2mm_info.circ_buf_cur_rate;
+    return ts2mm_info.use_circ_buf;
+  };
 
-    bool using_circular_buffer( uint64_t& min_offload_rate,
-                                uint64_t& requested_offload_rate) {
-      min_offload_rate = ts2mm_info.circ_buf_min_rate;
-      requested_offload_rate = ts2mm_info.circ_buf_cur_rate;
-      return ts2mm_info.use_circ_buf;
-    };
+  inline OffloadThreadStatus get_status() {
+    std::lock_guard<std::mutex> lock(status_lock);
+    return status;
+  };
 
-    inline OffloadThreadStatus get_status() {
-      std::lock_guard<std::mutex> lock(status_lock);
-      return status;
-    };
-
-    inline bool continuous_offload() { return continuous ; }
-    inline void set_continuous(bool value = true) { continuous = value ; }
+  inline bool continuous_offload() { return continuous ; }
+  inline void set_continuous(bool value = true) { continuous = value ; }
 
 private:
-    void read_trace_fifo(bool force=true);
+  void read_trace_fifo(bool force=true);
+  void read_trace_s2mm(bool force=true);
+  uint64_t read_trace_s2mm_partial();
+  bool config_s2mm_reader(uint64_t i, uint64_t wordCount);
+  bool init_s2mm(bool circ_buf, const std::vector<uint64_t> &);
+  void reset_s2mm();
+  bool should_continue();
+  void train_clock_continuous();
+  void offload_device_continuous();
+  void offload_finished();
+  void process_trace_continuous();
+  void read_leftover_circular_buf();
 
-    void read_trace_s2mm(bool force=true);
-    uint64_t read_trace_s2mm_partial();
-    bool config_s2mm_reader(uint64_t i, uint64_t wordCount);
-    bool init_s2mm(bool circ_buf, const std::vector<uint64_t> &);
-    void reset_s2mm();
-
-    bool should_continue();
-    void train_clock_continuous();
-    void offload_device_continuous();
-    void offload_finished();
-    void process_trace_continuous();
-    
-    void read_leftover_circular_buf();
+private:
+  bool has_finite_fifo() {
+    return (xdp::getFlowMode() == xdp::Flow::HW);
+  };
 
 protected:
-    DeviceIntf* dev_intf;
-    bool m_initialized = false;
-    // Default dma chunk size
-//    uint64_t m_trbuf_chunk_sz = MAX_TRACE_NUMBER_SAMPLES * TRACE_PACKET_SIZE;
-    bool m_debug = false; /* Enable Output stream for log */
+  DeviceIntf* dev_intf;
+  bool m_initialized = false;
+  bool m_debug = false; /* Enable Output stream for log */
 
 private:
-    DeviceTraceLogger* deviceTraceLogger;
-    std::function<void(bool)> m_read_trace;
+  DeviceTraceLogger* deviceTraceLogger;
+  std::function<void(bool)> m_read_trace;
+  Ts2mmInfo ts2mm_info;
 
-    // When using a FIFO for offload, if the FIFO fills up, we cannot
-    //  read from it again (circular buffer in FIFO is not supported).
-    //  The fifo_full flag will keep track if we have seen the FIFO full.
-    bool fifo_full = false;
+  // fifo doesn't support circular buffer mode
+  bool fifo_full = false;
 
-    uint64_t sleep_interval_ms;
-    Ts2mmInfo ts2mm_info;
+  // Continuous offload
+  std::mutex status_lock;
+  uint64_t sleep_interval_ms;
+  OffloadThreadStatus status = OffloadThreadStatus::IDLE;
+  std::thread offload_thread;
+  std::thread process_thread;
+  bool continuous = false;
 
-    // Continuous offload
-    std::mutex status_lock;
-    OffloadThreadStatus status = OffloadThreadStatus::IDLE;
-    std::thread offload_thread;
-    std::thread process_thread;
-    bool continuous = false;
-    std::once_flag ts2mm_queue_warning_flag;
-    std::once_flag fifo_full_warning_flag;
-    std::once_flag ts2mm_full_warning_flag;
+  // Clock Training Params
+  bool m_force_clk_train = true;
+  std::chrono::time_point<std::chrono::system_clock> m_prev_clk_train_time;
 
-    // Clock Training Params
-    bool m_force_clk_train = true;
-    std::chrono::time_point<std::chrono::system_clock> m_prev_clk_train_time;
+  // Internal flags to end trace processing thread
+  std::atomic<bool> m_process_trace;
+  std::atomic<bool> m_process_trace_done;
 
-    // Internal flag to end trace processing thread
-    std::atomic<bool> m_process_trace;
-    std::atomic<bool> m_process_trace_done;
+  // Internal flags to keep track of warnings
+  std::once_flag ts2mm_queue_warning_flag;
+  std::once_flag fifo_full_warning_flag;
+  std::once_flag ts2mm_full_warning_flag;
 };
 
 }


### PR DESCRIPTION
Problem : device trace full markers are being set in hw_emulation
Fix: Trace offloaders only set fifo_full flag for hw flow

Also includes some rearranging of code to make it cleaner.