### PR TITLE
Cr 1122454 enable system compiler in HW_EMU 

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/plugin_loader.cpp
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/plugin_loader.cpp
@@ -19,10 +19,10 @@
 
 #include "device_offload.h"
 #include "hal_trace.h"
+#include "sc_profile.h"
 #include "plugin_loader.h"
 
-namespace xdp {
-namespace hw_emu {
+namespace xdp::hw_emu {
 
   // This function is responsible for checking all of the relevant xrt.ini file
   //  options and loading the appropriate debug/profile plugins.
@@ -35,7 +35,8 @@ namespace hw_emu {
         xrt_core::config::get_device_trace() != "off" ||
         xrt_core::config::get_device_counters())
       xdp::hw_emu::device_offload::load() ;
+    if (xrt_core::config::get_sc_profile())
+      xdp::hw_emu::sc::load();
   }
 
-} // end namespace hw_emu
-} // end namespace xdp
+} // end namespace xdp::hw_emu

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.cpp
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.cpp
@@ -1,0 +1,4 @@
+//
+// Created by rogerng on 3/3/22.
+//
+

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.cpp
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.cpp
@@ -1,4 +1,40 @@
-//
-// Created by rogerng on 3/3/22.
-//
+/**
+ * Copyright (C) 2022 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
+#include "sc_profile.h"
+#include "core/common/module_loader.h"
+
+namespace xdp::hw_emu::sc
+{
+  void load()
+  {
+    static xrt_core::module_loader xdp_sc_loader("xdp_system_compiler_plugin",
+                                                 register_callbacks,
+                                                 warning_callbacks) ;
+  }
+
+  void register_callbacks(void* /* handle*/)
+  {
+    // No callbacks in System Compiler plugin
+  }
+
+  void warning_callbacks()
+  {
+    // No warnings in System Compiler plugin
+  }
+
+
+} // end xdp::hw_emu::sc

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/plugin/xdp/sc_profile.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2021 Xilinx, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef XRT_HW_EMU_SC_H
+#define XRT_HW_EMU_SC_H
+
+namespace xdp::hw_emu::sc
+{
+  void load();
+  void register_callbacks(void* handle);
+  void warning_callbacks();
+} // end namespace xdp::hw_emu::sc
+
+#endif //XRT_HW_EMU_SC_H


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
It adds system compiler trace for hw_emu in the xrt run summary
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1122454
#### Risks (if any) associated the changes in the commit
Low risk
#### What has been tested and how, request additional testing if necessary
Test a system compiler hw_emu design.
