### PR TITLE
Disabling AIE resources and AIE error notification for AIE-ML

### DIFF
--- a/src/runtime_src/core/edge/common/aie_parser.cpp
+++ b/src/runtime_src/core/edge/common/aie_parser.cpp
@@ -66,6 +66,12 @@ get_driver_config(const pt::ptree& aie_meta)
   return driver_config;
 }
 
+uint8_t
+get_hw_gen(const pt::ptree& aie_meta)
+{
+  return aie_meta.get<uint8_t>("aie_metadata.driver_config.hw_gen");
+}
+
 adf::aiecompiler_options
 get_aiecompiler_options(const pt::ptree& aie_meta)
 {
@@ -563,6 +569,18 @@ get_trace_gmios(const xrt_core::device* device)
   pt::ptree aie_meta;
   read_aie_metadata(data.first, data.second, aie_meta);
   return ::get_trace_gmio(aie_meta);
+}
+/* hw_gen represents aie version 1.aie, 2.aie-ml etc */
+uint8_t
+get_hw_gen(const xrt_core::device* device)
+{
+  auto data = device->get_axlf_section(AIE_METADATA);
+  if (!data.first || !data.second)
+    return 1; // default is aie-1
+
+  pt::ptree aie_meta;
+  read_aie_metadata(data.first, data.second, aie_meta);
+  return ::get_hw_gen(aie_meta);
 }
 
 }}} // aie, edge, xrt_core

--- a/src/runtime_src/core/edge/common/aie_parser.h
+++ b/src/runtime_src/core/edge/common/aie_parser.h
@@ -186,6 +186,14 @@ struct gmio_type
 };
 
 /**
+ * get_hw_gen - get aie hw_gen from xclbin AIE metadata
+ *
+ * @device: device with loaded meta data
+ */
+uint8_t
+get_hw_gen(const xrt_core::device* device);
+
+/**
  * get_trace_gmios() - get trace gmio data from xclbin AIE metadata
  *
  * @device: device with loaded meta data

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_drv.h
@@ -239,7 +239,7 @@ void zocl_init_mem(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot);
 void zocl_clear_mem(struct drm_zocl_dev *zdev);
 void zocl_clear_mem_slot(struct drm_zocl_dev *zdev, u32 slot_idx);
 int zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf,
-		void *aie_res);
+		void *aie_res, uint8_t hw_gen);
 void zocl_destroy_aie(struct drm_zocl_dev *zdev);
 int zocl_aie_request_part_fd(struct drm_zocl_dev *zdev, void *data);
 int zocl_aie_reset(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_aie.c
@@ -225,7 +225,7 @@ done:
 }
 
 int
-zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res)
+zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res, uint8_t hw_gen)
 {
 	uint64_t offset;
 	uint64_t size;
@@ -279,7 +279,9 @@ zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res)
 	/* TODO figure out the partition id and uid from xclbin or PDI */
 	req.partition_id = 1;
 	req.uid = 0;
-	req.meta_data = (u64)aie_res;
+	/* only aie-1 supports resources */
+	if (hw_gen == 1)
+		req.meta_data = (u64)aie_res;
 
 	if (zdev->aie->aie_dev) {
 		DRM_INFO("Partition %d already requested\n",
@@ -300,9 +302,11 @@ zocl_create_aie(struct drm_zocl_dev *zdev, struct axlf *axlf, void *aie_res)
 	zdev->aie->uid = req.uid;
 
 	/* Register AIE error call back function. */
-	rval = aie_register_error_notification(zdev->aie->aie_dev,
-	    zocl_aie_error_cb, zdev);
-
+	/* only aie-1 supports error management*/
+	if (hw_gen == 1) {
+		rval = aie_register_error_notification(zdev->aie->aie_dev,
+		zocl_aie_error_cb, zdev);
+	}
 	mutex_unlock(&zdev->aie_lock);
 
 	zocl_init_aie(zdev);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -915,7 +915,8 @@ zocl_xclbin_load_pskernel(struct drm_zocl_dev *zdev, void *data)
 
 	// Cache full xclbin
 	write_unlock(&zdev->attr_rwlock);
-	zocl_create_aie(zdev, axlf, aie_res);
+	//last argument represents aie generation. 1. aie, 2. aie-ml ...
+	zocl_create_aie(zdev, axlf, aie_res,1);
 	write_lock(&zdev->attr_rwlock);
 
 	count = xrt_xclbin_get_section_num(axlf, SOFT_KERNEL);
@@ -1162,6 +1163,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	int ret = 0;
 	struct drm_zocl_slot *slot = NULL;
 	int slot_id = axlf_obj->za_slot_id;
+	uint8_t hw_gen = axlf_obj->hw_gen;
 
 	if (slot_id > zdev->num_pr_slot) {
 		DRM_ERROR("Invalid Slot[%d]", slot_id);
@@ -1237,7 +1239,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 					DRM_WARN("read xclbin: fail to load AIE");
 				else {
 					write_unlock(&zdev->attr_rwlock);
-					zocl_create_aie(zdev, axlf, aie_res);
+					zocl_create_aie(zdev, axlf, aie_res,hw_gen);
 					write_lock(&zdev->attr_rwlock);
 					zocl_cache_xclbin(slot, axlf, xclbin);
 				}
@@ -1456,7 +1458,7 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 
 	/* Createing AIE Partition */
 	write_unlock(&zdev->attr_rwlock);
-	zocl_create_aie(zdev, axlf, aie_res);
+	zocl_create_aie(zdev, axlf, aie_res,hw_gen);
 	write_lock(&zdev->attr_rwlock);
 
 	/*

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -415,6 +415,8 @@ struct drm_zocl_kds {
  * @za_flags:   platform flags
  * @za_ksize:	size of kernels in bytes
  * @za_kernels:	pointer of argument array
+ * @za_slot_id:	xclbin slot
+ * @hw_gen:	aie generation
  **/
 struct drm_zocl_axlf {
 	struct axlf		*za_xclbin_ptr;
@@ -423,6 +425,7 @@ struct drm_zocl_axlf {
 	char			*za_kernels;
 	uint32_t		za_slot_id;
 	char			*za_dtbo_path;
+	uint8_t		        hw_gen;
 	struct drm_zocl_kds	kds_cfg;
 };
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -28,7 +28,11 @@
 #include "core/common/config_reader.h"
 #include "core/common/query_requests.h"
 #include "core/common/error.h"
+<<<<<<< HEAD
 #include "core/include/xrt/xrt_uuid.h"
+=======
+#include "core/edge/common/aie_parser.h"
+>>>>>>> 637c47c... Disabling resources and error managemen for aie-ml
 
 #include <cerrno>
 #include <iostream>
@@ -707,6 +711,9 @@ xclLoadAxlf(const axlf *buffer)
 
 #endif
 
+    /* Get the AIE_METADATA and get the hw_gen information */
+    uint8_t hw_gen = xrt_core::edge::aie::get_hw_gen(mCoreDevice.get());
+
     drm_zocl_axlf axlf_obj = {
       .za_xclbin_ptr = const_cast<axlf *>(buffer),
       .za_flags = flags,
@@ -714,6 +721,7 @@ xclLoadAxlf(const axlf *buffer)
       .za_kernels = NULL,
       .za_slot_id = 0, // TODO Cleanup: Once uuid interface id available we need to remove this
       .za_dtbo_path = const_cast<char *>(dtbo_path.c_str()),
+      .hw_gen = hw_gen,
     };
 
   axlf_obj.kds_cfg.polling = xrt_core::config::get_ert_polling();

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -28,11 +28,8 @@
 #include "core/common/config_reader.h"
 #include "core/common/query_requests.h"
 #include "core/common/error.h"
-<<<<<<< HEAD
 #include "core/include/xrt/xrt_uuid.h"
-=======
 #include "core/edge/common/aie_parser.h"
->>>>>>> 637c47c... Disabling resources and error managemen for aie-ml
 
 #include <cerrno>
 #include <iostream>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
AIE-ML doesnt support AIE resources and error management, Disabled both of them for AIE gen-2

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
 Disabled both of them for AIE gen-2 after reading xclbin

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified both AIE-1 and AIE-2 

#### Documentation impact (if any)
NA