### PR TITLE
CR-1120081 Display simulate log specific messages on to the console i…

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -204,10 +204,12 @@ namespace xclhwemhal2 {
     return {std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
   }
 
-  int HwEmShim::parseLog(std::ifstream &ifs)
+  int HwEmShim::parseLog()
   {
     std::vector<std::string> myvector = {"SIM-IPC's external process can be connected to instance",
                                          "SystemC TLM functional mode"};
+
+    std::ifstream ifs(getSimPath() + "/simulate.log");
 
     if (ifs.is_open()) {
       std::string line;
@@ -215,9 +217,10 @@ namespace xclhwemhal2 {
         for (auto matchString : myvector) {
           std::string::size_type index = line.find(matchString);
           if (index != std::string::npos) {
-            logMessage(line);
-            std::iostream::pos_type savedLocation = ifs.tellg();
-            ifs.seekg(savedLocation);            
+            if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
+              logMessage(line);
+              parsedMsgs.push_back(line);
+            }
           }
         }
       }
@@ -691,14 +694,14 @@ namespace xclhwemhal2 {
 
         if (boost::filesystem::exists(sim_path) != false) {
           waveformDebugfilePath = sim_path + "/waveform_debug_enable.txt";
-	        if (simulatorType == "xsim") {
-                cmdLineOption << " -g --wdb " << wdbFileName << ".wdb"
-                << " --protoinst " << protoFileName;
-                launcherArgs = launcherArgs + cmdLineOption.str();
-	        } else {
-                cmdLineOption << " gui ";
-                launcherArgs = launcherArgs + cmdLineOption.str();
-	        }
+          if (simulatorType == "xsim") {
+            cmdLineOption << " -g --wdb " << wdbFileName << ".wdb"
+                          << " --protoinst " << protoFileName;
+            launcherArgs = launcherArgs + cmdLineOption.str();
+          } else {
+            cmdLineOption << " gui ";
+            launcherArgs = launcherArgs + cmdLineOption.str();
+          }
         }
 
         std::string generatedWcfgFileName = sim_path + "/" + bdName + "_behav.wcfg";
@@ -1628,10 +1631,7 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     }
 
-    std::string logPath = getSimPath() + "/" + "simulate.log";
-    std::ifstream ifs;
-    ifs.open(logPath);
-    parseLog(ifs);
+    parseLog();
 
     for (auto& it: mFdToFileNameMap) {
       int fd=it.first;
@@ -1700,6 +1700,9 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     {
       std::string waitingMsg ="INFO: [HW-EMU 06-1] All the simulator processes exited successfully";
       logMessage(waitingMsg);
+
+      std::string consoleMsg = "INFO: [HW-EMU 07-0] Please refer the path \"" + getSimPath() + "/simulate.log\" for more detailed simulation infos, errors and warnings.";
+      logMessage(consoleMsg);
     }
 
     saveWaveDataBase();
@@ -1876,6 +1879,8 @@ uint32_t HwEmShim::getAddressSpace (uint32_t topology)
     free(ci_buf);
     free(ri_buf);
     free(buf);
+    parsedMsgs.clear();
+
     if (mLogStream.is_open()) {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
       mLogStream.close();

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -246,6 +246,8 @@ using addr_type = uint64_t;
        */
       std::string mRunDeviceBinDir;
 
+      std::vector<std::string> parsedMsgs;
+
       //QDMA Support
       int xclCreateWriteQueue(xclQueueContext *q_ctx, uint64_t *q_hdl);
       int xclCreateReadQueue(xclQueueContext *q_ctx, uint64_t *q_hdl);
@@ -282,7 +284,7 @@ using addr_type = uint64_t;
       //CR-1120081
       void parseString(const std::string& simPath , const std::string& searchString);
       //CR-1120700
-      int parseLog(std::ifstream& ifs);
+      int parseLog();
       void parseSimulateLog();
       void setSimPath(std::string simPath) { sim_path = simPath; }
       std::string getSimPath () { return sim_path; }


### PR DESCRIPTION
CR-1120081 Display simulate log specific messages on to the console in a non repeated way.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
Its an enhancement request to dump addition messages from simulate.log in a controlled way

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is not a bug, new enhancement requested for the HLS functional model PR

#### How problem was solved, alternative solutions (if any) and why they were rejected
Nope

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Canary is clean and ran few appropriate designs

#### Documentation impact (if any)
No
