### PR TITLE
CR-1122334: pyxrt test fails with compile time errors

### DIFF
--- a/src/python/pybind11/src/pyxrt.cpp
+++ b/src/python/pybind11/src/pyxrt.cpp
@@ -188,6 +188,9 @@ PYBIND11_MODULE(pyxrt, m) {
                           xrt::kernel::cu_access_mode m) {
                            return new xrt::kernel(d, u, n, m);
                        }))
+  	.def(py::init([](const xrt::device& d, const xrt::uuid& u, const std::string& n) {
+                           return new xrt::kernel(d, u, n);
+                       }))
         .def("__call__", [](xrt::kernel& k, py::args args) -> xrt::run {
                              int i = 0;
                              xrt::run r(k);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Currently pyxrt.kernel constructor has 4 arguments (device, uui, kernel-name, access_mode). All python applications has to provide all 4 arguments wheras xrt::kernel can be called with 3/4 arguments (access_mode value is shared by default).
We are providing one more constructor in pybind to support 3 arguments similar to cpp. 
    
   ```
__init__():  constructor arguments. The following argument types are supported:
    1. pyxrt.kernel(arg0: pyxrt.device, arg1: pyxrt.uuid, arg2: str, arg3: pyxrt.kernel.cu_access_mode)
    2. pyxrt.kernel(arg0: pyxrt.device, arg1: pyxrt.uuid, arg2: str)
```
Note: I didnt find a good solution for adding a default argument in existing  constructor. it seems, It is not straight forward in pybind11

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
when we made pybind11 integration

#### How problem was solved, alternative solutions (if any) and why they were rejected
Provided one more constructor

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified with 3 and 4 arguments

#### Documentation impact (if any)
NA