### PR TITLE
Enabled xclbinutil for edge

### DIFF
--- a/build/build_edge.sh
+++ b/build/build_edge.sh
@@ -48,6 +48,7 @@ install_recipes()
         echo 'EXTERNALSRC_BUILD = "${WORKDIR}/build"' >> $XRT_BB
         echo 'EXTRA_OECMAKE:append:versal += "-DXRT_LIBDFX=true"' >> $XRT_BB
         echo 'EXTRA_OECMAKE:append:zynqmp += "-DXRT_LIBDFX=true"' >> $XRT_BB
+        echo 'DEPENDS += "rapidjson"' >> $XRT_BB
         echo 'DEPENDS:append:versal += "libdfx"' >> $XRT_BB
         echo 'DEPENDS:append:zynqmp += "libdfx"' >> $XRT_BB
         echo "FILES:\${PN} += \"\${libdir}/ps_kernels_lib\"" >> $XRT_BB

--- a/src/runtime_src/CMakeLists.txt
+++ b/src/runtime_src/CMakeLists.txt
@@ -29,11 +29,7 @@ if (${XRT_NATIVE_BUILD} STREQUAL "yes")
 endif()
 add_subdirectory(xdp)
 
-# TODO version.h was included.
-# Remove this limitation once we can generate version.h for mpsoc.
-if (${XRT_NATIVE_BUILD} STREQUAL "yes")
-  add_subdirectory(tools/xclbinutil)
-endif()
+add_subdirectory(tools/xclbinutil)
 add_subdirectory(xocl)
 add_subdirectory(xrt)
 add_subdirectory(ert)

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -91,45 +91,41 @@ SET(TEST_SUITE_NAME "xclbinutil")
 
 # OpenSSL encryption is only supported on linux
 if(NOT WIN32)
-  # Python is currently not installed on Edge builds
-  if (${XRT_NATIVE_BUILD} STREQUAL "yes")
-    # -- Test Signing of the xclbin image using a CER formatted certificate
-    xrt_add_test("signing-xclbin_CER" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/signXclbinCER.py")
+  # -- Test Signing of the xclbin image using a CER formatted certificate
+  xrt_add_test("signing-xclbin_CER" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/signXclbinCER.py")
 
-    # -- Test Signing of the xclbin image using a DER formatted certificate
-    xrt_add_test("signing-xclbin_DER" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/signXclbinDER.py")
+  # -- Test Signing of the xclbin image using a DER formatted certificate
+  xrt_add_test("signing-xclbin_DER" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/signXclbinDER.py")
 
-    # -- Test SmartNic
-    # Test: SmartNic Syntax
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic")
-    xrt_add_test("smartnic-syntax" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic/SectionSmartNicSyntax.py ${TEST_OPTIONS}")
+  # -- Test SmartNic
+  # Test: SmartNic Syntax
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic")
+  xrt_add_test("smartnic-syntax" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic/SectionSmartNicSyntax.py ${TEST_OPTIONS}")
 
-    # Test: SmartNic Schema
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic")
-    xrt_add_test("smartnic-format" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic/SectionSmartNicFormat.py ${TEST_OPTIONS}")
+  # Test: SmartNic Schema
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic")
+  xrt_add_test("smartnic-format" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SmartNic/SectionSmartNicFormat.py ${TEST_OPTIONS}")
 
-    # -- SoftKernel
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SoftKernel")
-    xrt_add_test("soft-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SoftKernel/SectionSoftKernel.py ${TEST_OPTIONS}")
+  # -- SoftKernel
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SoftKernel")
+  xrt_add_test("soft-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SoftKernel/SectionSoftKernel.py ${TEST_OPTIONS}")
 
-    # -- Partion Metadata
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata")
-    xrt_add_test("partition_metadata" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata/SectionPartitionMetadata.py ${TEST_OPTIONS}")
+  # -- Partion Metadata
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata")
+  xrt_add_test("partition_metadata" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata/SectionPartitionMetadata.py ${TEST_OPTIONS}")
 
-    # -- Fixed Kernels 
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/FixedKernel")
-    xrt_add_test("fixed-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/FixedKernel/FixedKernel.py ${TEST_OPTIONS}")
+  # -- Fixed Kernels 
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/FixedKernel")
+  xrt_add_test("fixed-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/FixedKernel/FixedKernel.py ${TEST_OPTIONS}")
 
-    # -- PS Kernels 
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel")
-    xrt_add_test("ps-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel/PSKernel.py ${TEST_OPTIONS}")
+  # -- PS Kernels 
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel")
+  xrt_add_test("ps-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel/PSKernel.py ${TEST_OPTIONS}")
 
-    # -- Binary Images
-    set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages")
-    xrt_add_test("binary-images" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages/BinaryImages.py ${TEST_OPTIONS}")
+  # -- Binary Images
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages")
+  xrt_add_test("binary-images" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages/BinaryImages.py ${TEST_OPTIONS}")
 
-
-    endif()
 endif()
 
 

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Windows support coming soon
 if(NOT WIN32)
   # On Ubuntu 16.04 CMake support is limited
-  if ((${LINUX_FLAVOR} STREQUAL "Ubuntu") AND (${LINUX_VERSION} STREQUAL "16.04"))
+  if ((${LINUX_FLAVOR} STREQUAL "Ubuntu") AND ("x${LINUX_VERSION}x" STREQUAL "x16.04x"))
     set(RapidJSON_VERSION_MAJOR 0)
   else()
     find_package(RapidJSON REQUIRED)

--- a/src/runtime_src/tools/xclbinutil/xclbinutil
+++ b/src/runtime_src/tools/xclbinutil/xclbinutil
@@ -30,8 +30,18 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# -- Find and call the loader
-XRT_LOADER="`dirname \"$0\"`/unwrapped/loader"
+# -- Find loader directory
+XRT_LOADER_DIR="`dirname \"$0\"`"
+
+# For edge platforms loader is not required as tools are in standard location(/usr).
+# So calling unwrapped tool from this script itself.
+if [[ $XRT_LOADER_DIR =~ "/usr" ]]; then
+    "${XRT_LOADER_DIR}/unwrapped/${XRT_PROG}" "${XRTWRAP_PROG_ARGS[@]}"
+    exit 0
+fi
+
+# Call loader for dc platforms
+XRT_LOADER="${XRT_LOADER_DIR}/unwrapped/loader"
 
 if [ ! -f "$XRT_LOADER" ]; then
   echo "ERROR: Could not find 64-bit loader executable."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xclbinutil is currently not enabled for edge. This is useful while debugging on target. We have removed the native build checks to build xclbinutil

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enabled xclbinutil for edge

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified on edge Target 

#### Documentation impact (if any)
NA