### PR TITLE
ESE-52 XRT failed to find drm device in edge platforms

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -421,8 +421,8 @@ struct aie_reg_read
 
 #ifdef XRT_ENABLE_AIE
 #ifndef __AIESIM__
-  const static std::string AIE_TAG = "aie_metadata";
-  const std::string ZOCL_DEVICE = "/dev/dri/" + get_render_devname();
+  const static std::string aie_tag = "aie_metadata";
+  const std::string zocl_device = "/dev/dri/" + get_render_devname();
   const uint32_t major = 1;
   const uint32_t minor = 0;
   const uint32_t patch = 0;
@@ -431,7 +431,7 @@ struct aie_reg_read
   std::string value;
 
   // Reading the aie_metadata sysfs.
-  dev->sysfs_get(AIE_TAG, err, value);
+  dev->sysfs_get(aie_tag, err, value);
   if (!err.empty())
     throw xrt_core::query::sysfs_error
       (err + ", The loading xclbin acceleration image doesn't use the Artificial "
@@ -449,9 +449,9 @@ struct aie_reg_read
                                                              % pt.get<uint32_t>("schema_version.minor")
                                                              % pt.get<uint32_t>("schema_version.patch")));
 
-  int mKernelFD = open(ZOCL_DEVICE.c_str(), O_RDWR);
+  int mKernelFD = open(zocl_device.c_str(), O_RDWR);
   if (!mKernelFD)
-    throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % ZOCL_DEVICE));
+    throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % zocl_device));
 
   XAie_DevInst* devInst;         // AIE Device Instance
 
@@ -513,13 +513,13 @@ struct aie_reg_read
 static std::unique_ptr<drm_fd>
 aie_get_drmfd(const xrt_core::device* device, const std::string& dev_path)
 {
-  const static std::string AIE_TAG = "aie_metadata";
+  const static std::string aie_tag = "aie_metadata";
   std::string err;
   std::string value;
 
   auto dev = get_edgedev(device);
   // Reading the aie_metadata sysfs.
-  dev->sysfs_get(AIE_TAG, err, value);
+  dev->sysfs_get(aie_tag, err, value);
   if (!err.empty())
     throw xrt_core::query::sysfs_error
     (err + ", The loading xclbin acceleration image doesn't use the Artificial "
@@ -537,10 +537,10 @@ struct aie_get_freq
   {
     result_type freq = 0;
 #if defined(XRT_ENABLE_AIE)
-    const std::string ZOCL_DEVICE = "/dev/dri/" + get_render_devname();
-    auto fd_obj = aie_get_drmfd(device, ZOCL_DEVICE);
+    const std::string zocl_device = "/dev/dri/" + get_render_devname();
+    auto fd_obj = aie_get_drmfd(device, zocl_device);
     if (fd_obj->fd < 0)
-      throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % ZOCL_DEVICE));
+      throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % zocl_device));
 
     struct drm_zocl_aie_freq_scale aie_arg;
     aie_arg.partition_id = boost::any_cast<uint32_t>(partition_id);
@@ -565,10 +565,10 @@ struct aie_set_freq
   get(const xrt_core::device* device, key_type key, const boost::any& partition_id, const boost::any& freq)
   {
 #if defined(XRT_ENABLE_AIE)
-    const std::string ZOCL_DEVICE = "/dev/dri/" + get_render_devname();
-    auto fd_obj = aie_get_drmfd(device, ZOCL_DEVICE);
+    const std::string zocl_device = "/dev/dri/" + get_render_devname();
+    auto fd_obj = aie_get_drmfd(device, zocl_device);
     if (fd_obj->fd < 0)
-      throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % ZOCL_DEVICE));
+      throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % zocl_device));
 
     struct drm_zocl_aie_freq_scale aie_arg;
     aie_arg.partition_id = boost::any_cast<uint32_t>(partition_id);

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -422,7 +422,7 @@ struct aie_reg_read
 #ifdef XRT_ENABLE_AIE
 #ifndef __AIESIM__
   const static std::string AIE_TAG = "aie_metadata";
-  const static std::string ZOCL_DEVICE = "/dev/dri/renderD128";
+  const std::string ZOCL_DEVICE = "/dev/dri/" + get_render_devname();
   const uint32_t major = 1;
   const uint32_t minor = 0;
   const uint32_t patch = 0;
@@ -537,7 +537,7 @@ struct aie_get_freq
   {
     result_type freq = 0;
 #if defined(XRT_ENABLE_AIE)
-    const static std::string ZOCL_DEVICE = "/dev/dri/renderD128";
+    const std::string ZOCL_DEVICE = "/dev/dri/" + get_render_devname();
     auto fd_obj = aie_get_drmfd(device, ZOCL_DEVICE);
     if (fd_obj->fd < 0)
       throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % ZOCL_DEVICE));
@@ -565,7 +565,7 @@ struct aie_set_freq
   get(const xrt_core::device* device, key_type key, const boost::any& partition_id, const boost::any& freq)
   {
 #if defined(XRT_ENABLE_AIE)
-    const static std::string ZOCL_DEVICE = "/dev/dri/renderD128";
+    const std::string ZOCL_DEVICE = "/dev/dri/" + get_render_devname();
     auto fd_obj = aie_get_drmfd(device, ZOCL_DEVICE);
     if (fd_obj->fd < 0)
       throw xrt_core::error(-EINVAL, boost::str(boost::format("Cannot open %s") % ZOCL_DEVICE));

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -121,10 +121,10 @@ shim(unsigned index)
 {
   xclLog(XRT_INFO, "%s", __func__);
 
-  const std::string ZOCL_DRM_DEVICE = "/dev/dri/" + get_render_devname();
-  mKernelFD = open(ZOCL_DRM_DEVICE.c_str(), O_RDWR);
+  const std::string zocl_drm_device = "/dev/dri/" + get_render_devname();
+  mKernelFD = open(zocl_drm_device.c_str(), O_RDWR);
   if (mKernelFD < 0) {
-    xclLog(XRT_ERROR, "%s: Cannot open %s", __func__,ZOCL_DRM_DEVICE);
+    xclLog(XRT_ERROR, "%s: Cannot open %s", __func__,zocl_drm_device);
   }
   mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
   mDev = zynq_device::get_dev();
@@ -524,7 +524,7 @@ libdfxHelper(std::shared_ptr<xrt_core::device> core_dev, std::string& dtbo_path,
     const std::string errmsg{"Query for dtbo path failed: "};
     throw std::runtime_error(errmsg + e.what());
   }
-  if(!dtbo_path.empty()) {
+  if (!dtbo_path.empty()) {
     // remove existing libdfx node
     rmdir((dtbo_dir_path + dtbo_path).c_str());
     dtbo_path.clear();
@@ -538,7 +538,7 @@ copyBufferToFile(const std::string& file_path, const char* buf, uint64_t size)
 {
   std::ofstream file(file_path, std::ios::out | std::ios::binary);
 
-  if(!file)
+  if (!file)
     throw std::runtime_error("Failed to open " + file_path + " for writing xclbin section");
 
   file.write(buf, size);
@@ -552,7 +552,7 @@ libdfxConfig(std::string& xclbin_dir_path, const axlf *top,
   // create a temp directory to extract bitstream and dtbo
   char dir[] = "/tmp/xclbin.XXXXXX";
   char *tmpdir = mkdtemp(dir);
-  if(tmpdir == nullptr)
+  if (tmpdir == nullptr)
     throw std::runtime_error("Failed to create tmp directory for xclbin files extraction");
 
   xclbin_dir_path = tmpdir;
@@ -572,7 +572,7 @@ static void
 libdfxClean(const std::string& file_path)
 {
   try {
-    if(boost::filesystem::exists(boost::filesystem::path(file_path)))
+    if (boost::filesystem::exists(boost::filesystem::path(file_path)))
       boost::filesystem::remove_all(boost::filesystem::path(file_path));
   }
   catch(std::exception& ex) {
@@ -584,16 +584,16 @@ static int
 libdfxLoadAxlf(std::shared_ptr<xrt_core::device> core_dev, const axlf *top,
 	       const axlf_section_header *overlay_header, int& fd, int flags, std::string& dtbo_path)
 {
-  static const std::string FPGA_DEVICE = "/dev/fpga0";
+  static const std::string fpga_device = "/dev/fpga0";
 
   // check BITSTREAM section
   const axlf_section_header *bit_header = xclbin::get_axlf_section(top, axlf_section_kind::BITSTREAM);
-  if(!bit_header)
+  if (!bit_header)
     throw std::runtime_error("No BITSTREAM section in xclbin");
 
   //check if xclbin is already loaded
   try {
-    if(core_dev->get_xclbin_uuid() == xrt::uuid(top->m_header.uuid) && !(flags & DRM_ZOCL_FORCE_PROGRAM)) {
+    if (core_dev->get_xclbin_uuid() == xrt::uuid(top->m_header.uuid) && !(flags & DRM_ZOCL_FORCE_PROGRAM)) {
       xclLog(XRT_WARNING, "%s: skipping as xclbin is already loaded", __func__);
       return 1;
     }
@@ -609,12 +609,12 @@ libdfxLoadAxlf(std::shared_ptr<xrt_core::device> core_dev, const axlf *top,
   libdfxConfig(xclbin_dir_path, top, bit_header, overlay_header);
 
   // call libdfx api to load bitstream and dtbo
-  int dtbo_id = dfx_cfg_init(xclbin_dir_path.c_str(), FPGA_DEVICE.c_str(), 0);
-  if(dtbo_id <= 0) {
+  int dtbo_id = dfx_cfg_init(xclbin_dir_path.c_str(), fpga_device.c_str(), 0);
+  if (dtbo_id <= 0) {
     libdfxClean(xclbin_dir_path);
     throw std::runtime_error("Failed to initialize config with libdfx api");
   }
-  if(dfx_cfg_load(dtbo_id)){
+  if (dfx_cfg_load(dtbo_id)){
     dfx_cfg_destroy(dtbo_id);
     libdfxClean(xclbin_dir_path);
     throw std::runtime_error("Failed to load bitstream, dtbo with libdfx api");
@@ -632,19 +632,19 @@ libdfxLoadAxlf(std::shared_ptr<xrt_core::device> core_dev, const axlf *top,
   const static int timeout_sec = 10;
   int count = 0;
   const std::string render_dev_dir{"/dev/dri/"};
-  std::string ZOCL_DRM_DEVICE;
-  while(count++ < timeout_sec) {
-    ZOCL_DRM_DEVICE = render_dev_dir + get_render_devname();
-    if(boost::filesystem::exists(boost::filesystem::path(ZOCL_DRM_DEVICE)))
+  std::string zocl_drm_device;
+  while (count++ < timeout_sec) {
+    zocl_drm_device = render_dev_dir + get_render_devname();
+    if (boost::filesystem::exists(boost::filesystem::path(zocl_drm_device)))
       break;
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 
   // create drm fd
-  fd = open(ZOCL_DRM_DEVICE.c_str(), O_RDWR);
+  fd = open(zocl_drm_device.c_str(), O_RDWR);
   if (fd < 0) {
     dtbo_path.clear();
-    throw std::runtime_error("Cannot create file descriptor with device " + ZOCL_DRM_DEVICE);
+    throw std::runtime_error("Cannot create file descriptor with device " + zocl_drm_device);
   }
 
   return 0;
@@ -702,7 +702,7 @@ xclLoadAxlf(const axlf *buffer)
   if(overlay_header) {
     try {
       // if xclbin is already loaded ret val is '1', dont call ioctl in this case
-      if(libdfx::libdfxLoadAxlf(this->mCoreDevice, buffer, overlay_header, mKernelFD, flags, dtbo_path))
+      if (libdfx::libdfxLoadAxlf(this->mCoreDevice, buffer, overlay_header, mKernelFD, flags, dtbo_path))
         return 0;
     }
     catch(const std::exception& e){
@@ -1727,8 +1727,8 @@ xclProbe()
 {
   return xdp::hal::profiling_wrapper("xclProbe", [] {
 
-  const std::string ZOCL_DRM_DEVICE = "/dev/dri/" + get_render_devname();
-  int fd = open(ZOCL_DRM_DEVICE.c_str(), O_RDWR);
+  const std::string zocl_drm_device = "/dev/dri/" + get_render_devname();
+  int fd = open(zocl_drm_device.c_str(), O_RDWR);
   if (fd < 0) {
     return 0;
   }

--- a/src/runtime_src/core/edge/user/zynq_dev.cpp
+++ b/src/runtime_src/core/edge/user/zynq_dev.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -142,12 +142,37 @@ void zynq_device::sysfs_get(const std::string& entry, std::string& err_msg,
 zynq_device *zynq_device::get_dev()
 {
     // This is based on the fact that on edge devices, we only have one DRM
-    // device, which is named renderD128.
+    // device, which is named as renderD* (eg: renderD128).
     // This path is reliable. It is the same for ARM32 and ARM64.
-    static zynq_device dev("/sys/class/drm/renderD128/device/");
+    static zynq_device dev("/sys/class/drm/" + get_render_devname() + "/device/");
     return &dev;
 }
 
 zynq_device::zynq_device(const std::string& root) : sysfs_root(root)
 {
+}
+
+std::string
+get_render_devname()
+{
+    static const std::string render_dir{"/dev/dri/"};
+    static const std::string render_dev_sym_dir = render_dir + "by-path/";
+    std::string render_devname;
+
+    // On Edge platforms 'zyxclmm_drm' is the name of zocl node in device tree
+    // A symlink to render device is created based on this node name
+    const std::regex filter{"platform.*zyxclmm_drm-render"};
+
+    boost::filesystem::directory_iterator end_itr;
+    for( boost::filesystem::directory_iterator itr( render_dev_sym_dir ); itr != end_itr; ++itr) {
+        if(std::regex_match(itr->path().filename().string(), filter)) {
+	    if(boost::filesystem::is_symlink(itr->path()))
+	        render_devname = boost::filesystem::read_symlink(itr->path()).filename().string();
+	    break;
+	}
+    }
+    if(render_devname.empty())
+        render_devname = "renderD128";
+
+    return render_devname;
 }

--- a/src/runtime_src/core/edge/user/zynq_dev.h
+++ b/src/runtime_src/core/edge/user/zynq_dev.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -16,6 +16,8 @@
 #ifndef _XCL_ZYNQ_DEV_H_
 #define _XCL_ZYNQ_DEV_H_
 
+#include <boost/filesystem.hpp>
+#include <regex>
 #include <string>
 #include <vector>
 #include <fstream>
@@ -60,4 +62,5 @@ private:
     zynq_device& operator=(const zynq_device& s) = delete;
 };
 
+std::string get_render_devname();
 #endif

--- a/src/runtime_src/core/edge/user/zynq_dev.h
+++ b/src/runtime_src/core/edge/user/zynq_dev.h
@@ -16,11 +16,9 @@
 #ifndef _XCL_ZYNQ_DEV_H_
 #define _XCL_ZYNQ_DEV_H_
 
-#include <boost/filesystem.hpp>
-#include <regex>
+#include <fstream>
 #include <string>
 #include <vector>
-#include <fstream>
 
 class zynq_device {
 public:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

> DRM device file path is hardcoded as "/dev/dri/renderD128" in edge platforms
> There are other drivers(eg: display) which also use DRM framework and create drm userspace device, so we cannot guarantee zocl drm device is 'renderD128' everytime

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
> When testing XRT on som platforms this issue was discovered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
> This PR fixes this issue by checking symlink created by drm framework to get correct renderD node name
> Edge platforms have zocl node in device tree with name 'zyxclmm_drm', drm framework uses this device tree node name to create drm device, this fix is based on that concept

#### Risks (if any) associated the changes in the commit
>  none 

#### What has been tested and how, request additional testing if necessary
> Tested on hw with som platform as well as base embedded platforms

#### Documentation impact (if any)
None
