### PR TITLE
Fixed PS Kernels - Added support to add extended metadata

### DIFF
--- a/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/KernelUtilities.cxx
@@ -111,6 +111,8 @@ void buildXMLKernelEntry(const boost::property_tree::ptree& ptKernel,
                          bool isFixedPS,
                          boost::property_tree::ptree& ptKernelXML)
 {
+  const boost::property_tree::ptree ptEmpty;
+
   const std::string& kernelName = ptKernel.get<std::string>("name", "");
   if (kernelName.empty())
     throw std::runtime_error("Missing kernel name");
@@ -122,8 +124,16 @@ void buildXMLKernelEntry(const boost::property_tree::ptree& ptKernel,
   ptKernelAttributes.put("type", isFixedPS ? "dpu" : "ps");
   ptKernelXML.add_child("<xmlattr>", ptKernelAttributes);
 
+  // -- Extended-data
+  // Blindly add it.  In the future add a JSON schema to validate it
+  const boost::property_tree::ptree& ptExtendedData = ptKernel.get_child("extended-data", ptEmpty);
+  if (!ptExtendedData.empty()) {
+    boost::property_tree::ptree ptEntry;
+    ptEntry.add_child("<xmlattr>", ptExtendedData);
+    ptKernelXML.add_child("extended-data", ptEntry);
+  }
+
   // -- Build kernel arguments
-  const boost::property_tree::ptree ptEmpty;
   const boost::property_tree::ptree& ptArguments = ptKernel.get_child("arguments", ptEmpty);
 
   unsigned int argID = 0;

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/embedded_metadata_expected.xml
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/embedded_metadata_expected.xml
@@ -67,6 +67,7 @@
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_32_0_M13_AXI" dstType="kernel" dstInst="vadd_1" dstPort="S_AXI_CONTROL"/>
         <connection srcType="core" srcInst="OCL_REGION_0" srcPort="noc_64_0_S02_AXI" dstType="kernel" dstInst="vadd_1" dstPort="M_AXI_GMEM"/>
         <kernel name="DPU" language="c" type="dpu">
+          <extended-data functional="0"/>
           <arg name="ifm" addressQualifier="1" id="0" size="0x8" offset="0x00" hostOffset="0x0" hostSize="0x8" type="char *"/>
           <arg name="param" addressQualifier="1" id="1" size="0x8" offset="0x08" hostOffset="0x0" hostSize="0x8" type="char *"/>
           <arg name="ofm" addressQualifier="1" id="2" size="0x8" offset="0x10" hostOffset="0x0" hostSize="0x8" type="char *"/>

--- a/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/fixed_kernel_add.json
+++ b/src/runtime_src/tools/xclbinutil/unittests/FixedKernel/fixed_kernel_add.json
@@ -2,7 +2,11 @@
   "ps-kernels" : {             
     "kernels" : [
       {
-        "name" : "DPU",          
+        "name" : "DPU",   
+        "type" : "dpu",
+        "extended-data" : {
+            "functional" : "0"
+        },
         "arguments" : [         
           {
             "name" : "ifm",


### PR DESCRIPTION
#### Problem solved by the commit
For fixed PS Kernels, there is a need to pass to the called function additional metadata describing if the given PS kernel is to be used in the setup or teardown phases.  

This pull request also contains syntax describing if the kernel is fixed or not.  The support for this syntax will be added in a future release.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a - new functionality

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated xclbinutil to be aware of the following "add-kernel" JSON schema:
```
        "type" : "dpu",
        "extended-data" : {
            "functional" : "0"
        },
```

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manual and unit testing

#### Documentation impact (if any)
n/a
