### PR TITLE
CR-1123904 XRT - Request a hot reset if XMC packet error received during SC upgrade

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1508,7 +1508,9 @@ static ssize_t status_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
-	u32 val = READ_REG32(xmc, XMC_STATUS_REG);
+	u32 val;
+
+	safe_read32(xmc, XMC_STATUS_REG, &val);
 
 	return sprintf(buf, "0x%x\n", val);
 }
@@ -1518,7 +1520,9 @@ static ssize_t core_version_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
-	u32 val = READ_REG32(xmc, XMC_CORE_VERSION_REG);
+	u32 val;
+
+	safe_read32(xmc, XMC_CORE_VERSION_REG, &val);
 
 	return sprintf(buf, "%u.%u.%u\n",
 	    (val & 0xff0000) >> 16, (val & 0xff00) >> 8, (val & 0xff));
@@ -4217,6 +4221,8 @@ static int xmc_mailbox_wait(struct xocl_xmc *xmc)
 
 	if (val) {
 		xocl_err(&xmc->pdev->dev, "XMC packet error: %d\n", val);
+		xocl_err(&xmc->pdev->dev, "Card requires pci hot reset\n");
+		xmc->state = XMC_STATE_ERROR;
 		safe_read32(xmc, XMC_CONTROL_REG, &ctrl_val);
 		safe_write32(xmc, XMC_CONTROL_REG, ctrl_val | XMC_CTRL_ERR_CLR);
 		return -EIO;
@@ -5065,6 +5071,15 @@ xmc_update_sc_firmware(struct file *file, const char __user *ubuf,
 	ssize_t ret = 0;
 	u8 *kbuf;
 
+	mutex_lock(&xmc->xmc_lock);
+	if (xmc->state != XMC_STATE_ENABLED) {
+		xocl_err(&xmc->pdev->dev, "Card requires pci hot reset\n");
+		ret = -EACCES;
+	}
+	mutex_unlock(&xmc->xmc_lock);
+
+	if (ret)
+		return ret;
 	/* Sanity check input 'n' */
 	if (n == 0 || n > jump_offset || n > 100 * 1024 * 1024)
 		return -EINVAL;

--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xmc.c
@@ -1,7 +1,7 @@
 /*
  * A GEM style device manager for PCIe based OpenCL accelerators.
  *
- * Copyright (C) 2016-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
  *
  * Authors: chienwei@xilinx.com
  *
@@ -1508,7 +1508,7 @@ static ssize_t status_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
-	u32 val;
+	u32 val = 0;
 
 	safe_read32(xmc, XMC_STATUS_REG, &val);
 
@@ -1520,7 +1520,7 @@ static ssize_t core_version_show(struct device *dev,
 	struct device_attribute *da, char *buf)
 {
 	struct xocl_xmc *xmc = dev_get_drvdata(dev);
-	u32 val;
+	u32 val = 0;
 
 	safe_read32(xmc, XMC_CORE_VERSION_REG, &val);
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -231,11 +231,10 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
         sc_flash.update(counter++);
     }
 
-    if (ret == 0) {
+    if (ret == 0)
         sc_flash.finish(true, "SC successfully updated");
-    } else {
+    else
         sc_flash.finish(false, "Failed to flash firmware");
-    }
 
     // End of flashing BMC firmware
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -235,7 +235,7 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
     if (ret == 0) {
         sc_flash.finish(true, "SC successfully updated");
     } else {
-        sc_flash.finish(false, "WARN: Failed to flash firmware");
+        sc_flash.finish(false, "Failed to flash firmware");
     }
 
     // End of flashing BMC firmware

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -129,7 +129,6 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
     ELARecord record;
     bool endRecordFound = false;
     bool errorFound = false;
-    int retries = 5;
     int ret = 0;
 
     if (!isXMCReady())
@@ -223,25 +222,22 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
 
     // Start of flashing BMC firmware
     std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "found" % mRecordList.size() % "sections";
-    while(retries != 0) {
-        retries--;
 
-        ret = erase();
-        XBU::ProgressBar sc_flash("Programming SC", static_cast<unsigned int>(mRecordList.size()), XBU::is_escape_codes_disabled(), std::cout);
-        int counter = 0;
-        for (auto i = mRecordList.begin(); ret == 0 && i != mRecordList.end(); ++i) {
-            ret = program(tiTxtStream, *i);
-            sc_flash.update(counter);
-            counter++;
-        }
-
-        if(ret == 0) {
-            sc_flash.finish(true, "SC successfully updated");
-            break;
-        } else {
-            sc_flash.finish(false, "WARN: Failed to flash firmware, retrying...");
-        }
+    ret = erase();
+    XBU::ProgressBar sc_flash("Programming SC", static_cast<unsigned int>(mRecordList.size()), XBU::is_escape_codes_disabled(), std::cout);
+    int counter = 0;
+    for (auto i = mRecordList.begin(); ret == 0 && i != mRecordList.end(); ++i) {
+        ret = program(tiTxtStream, *i);
+        sc_flash.update(counter);
+        counter++;
     }
+
+    if (ret == 0) {
+        sc_flash.finish(true, "SC successfully updated");
+    } else {
+        sc_flash.finish(false, "WARN: Failed to flash firmware");
+    }
+
     // End of flashing BMC firmware
 
     if (ret != 0)

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -228,8 +228,7 @@ int XMC_Flasher::xclUpgradeFirmware(std::istream& tiTxtStream) {
     int counter = 0;
     for (auto i = mRecordList.begin(); ret == 0 && i != mRecordList.end(); ++i) {
         ret = program(tiTxtStream, *i);
-        sc_flash.update(counter);
-        counter++;
+        sc_flash.update(counter++);
     }
 
     if (ret == 0) {


### PR DESCRIPTION
#### Problem solved by the commit
During an SC upgrade, if XRT receives a CMC_HOST_MSG_SAT_FW_WRITE_FAIL(XMC Packet Error 4), it will resend the failed segment again which is not ideal. We should halt the upgrade and hot reset the board instead of resending the firmware segment.

#### How problem was solved, alternative solutions (if any) and why they were rejected
XRT provides two ways to upgrade SC, one is via host by mapping the bar, the other one is via xmc driver.

1. Remove the retry part, when error happens during SC upgrade, we should stop upgrading SC instead of resending 
2. Set xmc state to XMC_STATE_ERROR in xmc driver and promote hot reset in dmesg
