### PR TITLE
CR-1121036 and introduce new sysfs node vmr_endpoint

### DIFF
--- a/src/runtime_src/core/include/xgq_cmd_vmr.h
+++ b/src/runtime_src/core/include/xgq_cmd_vmr.h
@@ -97,6 +97,7 @@ enum xgq_cmd_log_page_type {
 	XGQ_CMD_LOG_FW		= 0x1,
 	XGQ_CMD_LOG_INFO	= 0x2,
 	XGQ_CMD_LOG_AF_CLEAR	= 0x3,
+	XGQ_CMD_LOG_ENDPOINT	= 0x4,
 };
 
 /**


### PR DESCRIPTION
2022.1 vitis VCK5000: fix build.sh with daily_latest and apply
workaround code due to incorrect xparameters.h

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

This is the host side driver code change for showing VMR endpoints
```
VMR_EP_SYSTEM_DTB: 0x40000
VMR_EP_PR_ISOLATION: 0x80020000
VMR_EP_UCS_CONTROL: 0x80031008
VMR_EP_FIREWALL_USER_BASE: 0x80001000
VMR_EP_GAPPING_DEMAND: 0x80030000
VMR_EP_ACLK_KERNEL_0: 0x80032000
VMR_EP_ACLK_KERNEL_1: 0x80033000
VMR_EP_ACLK_FREQ_0: 0x80036000
VMR_EP_ACLK_FREQ_KERNEL_0: 0x80034000
VMR_EP_ACLK_FREQ_KERNEL_1: 0x80035000
VMR_EP_PLM_MULTIBOOT: 0xf1110004
VMR_EP_PMC_REG: 0xf1130000
VMR_EP_RPU_SHARED_MEMORY_START: 0x38000000
VMR_EP_RPU_SHARED_MEMORY_END: 0x3ffff000
VMR_EP_RPU_PRELOAD_FPT: 0x7fbf0000
VMR_EP_RPU_SQ_BASE: 0x80010000
VMR_EP_RPU_CQ_BASE: 0x80010100
VMR_EP_APU_SHARED_MEMORY_START: 0x37000000
VMR_EP_APU_SHARED_MEMORY_END: 0x37ff0000
VMR_EP_APU_SQ_BASE: 0x80011000
VMR_EP_APU_CQ_BASE: 0x80011100
VMR_EP_RPU_RING_BUFFER_BASE: 0x38001000
```
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
