### PR TITLE
Add support for multiple xclbins in user mode XRT

### DIFF
--- a/src/runtime_src/core/common/api/bo.h
+++ b/src/runtime_src/core/common/api/bo.h
@@ -32,15 +32,15 @@ uint64_t
 address(xrtBufferHandle handle);
 
 // group_id() - Get memory bank index of argument bo
-int32_t
+uint32_t
 group_id(const xrt::bo& bo);
 
-// xcl_device_handle() - Get xcl device handle from BO 
+// xcl_device_handle() - Get xcl device handle from BO
 xclDeviceHandle
 device_handle(const xrt::bo& bo);
 
 // get_flags() - Get the flags used when BO was created
-xrt::bo::flags 
+xrt::bo::flags
 get_flags(const xrt::bo& bo);
 
 // clone() - Clone src bo into target memory bank

--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -1,8 +1,6 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+#define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "context_mgr.h"
 #include "core/common/cuidx_type.h"
 #include "core/common/debug.h"
@@ -38,7 +36,7 @@ class device_context_mgr
   xrt_core::device* m_device;
 
   // CU contexts are managed per domain where indicies are
-  // in the range [0..max_cus[.  This sllows for a compact
+  // in the range [0..max_cus[.  This allows for a compact
   // bitset representation.
   using domain_type = cuidx_type::domain_type;
   std::map<domain_type, std::bitset<max_cus>> m_d2ctx; // domain -> cxt

--- a/src/runtime_src/core/common/api/context_mgr.cpp
+++ b/src/runtime_src/core/common/api/context_mgr.cpp
@@ -23,7 +23,7 @@ constexpr size_t max_cus = 129;  // +1 for virtual CU
 constexpr auto virtual_cu_idx = std::numeric_limits<unsigned int>::max();
 
 // class device_context_mgr - synchroize open and close context for IPs
-//    
+//
 // If multiple threads share the same device object and acquire /
 // release context on the same CUs, then careful synchronization of
 // low level xclOpen/CloseContext is required.
@@ -37,15 +37,38 @@ class device_context_mgr
   std::condition_variable m_cv;
   xrt_core::device* m_device;
 
+  // CU contexts are managed per domain where indicies are
+  // in the range [0..max_cus[.  This sllows for a compact
+  // bitset representation.
   using domain_type = cuidx_type::domain_type;
   std::map<domain_type, std::bitset<max_cus>> m_d2ctx; // domain -> cxt
 
-  std::bitset<max_cus>&
+  // Get the domain context bitset that contains this ipidx
+  // Return by address since used conditionally in get_idx_ctx
+  std::bitset<max_cus>*
   get_ctx(cuidx_type ipidx)
   {
-    return m_d2ctx[ipidx.domain];
+    return &(m_d2ctx[ipidx.domain]);
   }
 
+  // Get the CU index within a domain and the domain context bitset
+  // for the CU identified by argument slot and cuname.
+  // The returned index is only valid if the context bitset is not null.
+  std::pair<size_t, std::bitset<max_cus>*>
+  get_idx_ctx(slot_id slot, const std::string& cuname)
+  {
+    try {
+      auto idx = m_device->get_cuidx(slot, cuname);
+      return {ctxidx(idx), get_ctx(idx)};
+    }
+    catch (const std::exception&) {
+      return {0, nullptr};
+    }
+  }
+
+  // Convert CU index into a domain index with special attention to
+  // the virtual context index which is represented as the last entry
+  // in the bitset.
   size_t
   ctxidx(cuidx_type ipidx)
   {
@@ -54,11 +77,37 @@ class device_context_mgr
     // virtual cu is always in default domain 0.
     return ipidx.index == virtual_cu_idx ? max_cus - 1 : ipidx.domain_index;
   }
-  
+
 public:
   device_context_mgr(xrt_core::device* device)
     : m_device(device)
   {}
+
+  // Open context on cu identified by slot, uuid, and name.
+  // Open the cu context when it is safe to do so.  Note, that usage
+  // of the context manager does not support multiple threads calling
+  // this open() function on the same ip. The intended use-case
+  // (xrt::kernel) prevents this situation.
+  void
+  open(slot_id slot, const xrt::uuid& uuid, const std::string& ipname, bool shared)
+  {
+    std::unique_lock<std::mutex> ul(m_mutex);
+    auto [idx, ctx] = get_idx_ctx(slot, ipname);
+    while (ctx && ctx->test(idx)) {
+      if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
+        throw std::runtime_error("aquiring cu context timed out");
+    }
+    m_device->open_context(slot, uuid.get(), ipname.c_str(), shared);
+
+    // Successful context creation means CU idx is now known
+    if (!ctx)
+      std::tie(idx, ctx) = get_idx_ctx(slot, ipname);
+
+    if (!ctx)
+      throw std::runtime_error("Unexpected ctx error");
+
+    ctx->set(idx);
+  }
 
   // Open the cu context when it is safe to do so.  Note, that usage
   // of the context manager does not support multiple threads calling
@@ -69,13 +118,13 @@ public:
   {
     auto idx = ctxidx(ipidx);
     std::unique_lock<std::mutex> ul(m_mutex);
-    auto& ctx = get_ctx(ipidx);
-    while (ctx.test(idx)) {
+    auto ctx = get_ctx(ipidx);
+    while (ctx->test(idx)) {
       if (m_cv.wait_for(ul, 100ms) == std::cv_status::timeout)
         throw std::runtime_error("aquiring cu context timed out");
     }
     m_device->open_context(uuid.get(), ipidx.index, shared);
-    ctx.set(idx);
+    ctx->set(idx);
   }
 
   // Close the cu context and notify threads that might be waiting
@@ -85,11 +134,11 @@ public:
   {
     auto idx = ctxidx(ipidx);
     std::lock_guard<std::mutex> lk(m_mutex);
-    auto& ctx = get_ctx(ipidx);
-    if (!ctx.test(idx))
+    auto ctx = get_ctx(ipidx);
+    if (!ctx->test(idx))
       throw std::runtime_error("ctx " + std::to_string(ipidx.index) + " not open");
     m_device->close_context(uuid.get(), ipidx.index);
-    ctx.reset(idx);
+    ctx->reset(idx);
     m_cv.notify_all();
   }
 };
@@ -109,9 +158,9 @@ get_device_context_mgr(xrt_core::device* device, bool create = false)
 }
 
 
-////////////////////////////////////////////////////////////////  
+////////////////////////////////////////////////////////////////
 // Exposed API
-////////////////////////////////////////////////////////////////  
+////////////////////////////////////////////////////////////////
 std::shared_ptr<device_context_mgr>
 create(const xrt_core::device* device)
 {
@@ -120,6 +169,19 @@ create(const xrt_core::device* device)
   return get_device_context_mgr(const_cast<xrt_core::device*>(device), true);
 }
 
+// Regular CU
+void
+open_context(xrt_core::device* device, slot_id slot, const xrt::uuid& uuid, const std::string& cuname, bool shared)
+{
+  if (auto ctxmgr = get_device_context_mgr(device)) {
+    ctxmgr->open(slot, uuid, cuname, shared);
+    return;
+  }
+
+  throw std::runtime_error("No context manager for device");
+}
+
+// Virtual CU
 void
 open_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx, bool shared)
 {

--- a/src/runtime_src/core/common/api/context_mgr.h
+++ b/src/runtime_src/core/common/api/context_mgr.h
@@ -1,7 +1,5 @@
-/*
- * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2021 Xilinx, Inc. All rights reserved.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 
 #include "core/include/xrt/xrt_uuid.h"
 #include "core/common/cuidx_type.h"
@@ -22,6 +20,7 @@ class device;
 namespace context_mgr {
 
 class device_context_mgr;
+using slot_id = uint32_t;    // xrt_core::device::slot_id
 
 // Create a context manager for a specific device The manager is
 // shared and cached so that it is constructed only if necessary.  In
@@ -29,6 +28,27 @@ class device_context_mgr;
 // context manager.
 std::shared_ptr<device_context_mgr>
 create(const xrt_core::device* device);
+
+// Open a device context a specified compute unit (ip)
+//
+// @device: device to open context on
+// @slot:   slot index with xclbin
+// @uuid:   xclbin uuid with the CU
+// @ipname: name of IP
+// @shared: open in shared (true) or exclusive mode (false)
+//
+// The function blocks until the context can be acquired.  If
+// timeout, then the function throws.
+//
+// Note that the context manager is not intended to support two or
+// more threads opening a context on the same compute unit. This
+// situation must be guarded by the client (xrt::kernel) of the
+// manager.
+//
+// The function is simply a synchronization between two threads
+// simultanous use of open_context and close_context.
+void
+open_context(xrt_core::device* device, slot_id slot, const xrt::uuid& uuid, const std::string& ipname, bool shared);
 
 // Open a device context a specified compute unit (ip)
 //
@@ -59,5 +79,5 @@ open_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx, 
 // The function throws if no context is open on specified CU.
 void
 close_context(xrt_core::device* device, const xrt::uuid& uuid, cuidx_type cuidx);
- 
+
 }} // context_mgr, xrt_core

--- a/src/runtime_src/core/common/api/xrt_bo.cpp
+++ b/src/runtime_src/core/common/api/xrt_bo.cpp
@@ -140,7 +140,7 @@ class bo_impl
 {
 public:
   static constexpr uint64_t no_addr = std::numeric_limits<uint64_t>::max();
-  static constexpr int32_t no_group = std::numeric_limits<int32_t>::max();
+  static constexpr uint32_t no_group = std::numeric_limits<uint32_t>::max();
   static constexpr bo::flags no_flags = static_cast<bo::flags>(std::numeric_limits<uint32_t>::max());
   static constexpr xclBufferHandle null_bo = XRT_NULL_BO;
   static constexpr xclBufferExportHandle null_export = XRT_NULL_BO_EXPORT;
@@ -169,7 +169,7 @@ protected:
   xclBufferHandle handle = null_bo;             // NOLINT driver bo handle
   size_t size = 0;                              // NOLINT size of buffer
   mutable uint64_t addr = no_addr;              // NOLINT bo device address
-  mutable int32_t grpid = no_group;             // NOLINT memory group index
+  mutable uint32_t grpid = no_group;             // NOLINT memory group index
   mutable bo::flags flags = no_flags;           // NOLINT flags per bo properties
   mutable xclBufferExportHandle export_handle = null_export; // NOLINT export handle if exported
   bool free_bo;                                 // NOLINT should dtor free bo
@@ -395,7 +395,7 @@ public:
     return addr;
   }
 
-  virtual uint64_t
+  virtual uint32_t
   get_group_id() const
   {
     if (grpid == no_group)
@@ -988,7 +988,7 @@ address(xrtBufferHandle handle)
   return get_boh(handle)->get_address();
 }
 
-int32_t
+uint32_t
 group_id(const xrt::bo& bo)
 {
   return bo.get_handle()->get_group_id();

--- a/src/runtime_src/core/common/api/xrt_ip.cpp
+++ b/src/runtime_src/core/common/api/xrt_ip.cpp
@@ -154,7 +154,7 @@ class ip_impl
 
       ip = ips.front();
 
-      const auto& all_cus = device->get_cus(xclbin_uuid);  // sort order
+      const auto& all_cus = device->get_cus();  // sort order
       auto itr = std::find(all_cus.begin(), all_cus.end(), ip->m_base_address);
       if (itr == all_cus.end())
         throw xrt_core::internal_error("unexpected error");
@@ -202,7 +202,7 @@ class ip_impl
       return default_address_range;
 
     // Normalize ipname to kernel name
-    std::string kname(ipname.substr(0,ipname.find(":"))); 
+    std::string kname(ipname.substr(0,ipname.find(":")));
     auto kprop = xrt_core::xclbin::get_kernel_properties(xml_section.first, xml_section.second, kname);
     return kprop.address_range;
   }

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1426,7 +1426,7 @@ public:
       if (cu.get_control_type() == xrt::xclbin::ip::control_type::none)
         throw xrt_core::error(ENOTSUP, "AP_CTRL_NONE is only supported by XRT native API xrt::ip");
 
-      auto cuidx = device->core_device->get_cuidx(cu.get_name(), xclbin_id);
+      auto cuidx = device->core_device->get_cuidx(cu.get_name());
       ipctxs.emplace_back(ip_context::open(device->get_core_device(), xclbin, cu, cuidx, am));
       cumask.set(cuidx.domain_index);
       num_cumasks = std::max<size_t>(num_cumasks, (cuidx.domain_index / cus_per_word) + 1);

--- a/src/runtime_src/core/common/api/xrt_kernel.cpp
+++ b/src/runtime_src/core/common/api/xrt_kernel.cpp
@@ -1899,7 +1899,8 @@ class run_impl
   xrt::bo
   validate_bo_at_index(size_t index, const xrt::bo& bo)
   {
-    if (validate_ip_arg_connectivity(index, xrt_core::bo::group_id(bo)))
+    xcl_bo_flags grp {xrt_core::bo::group_id(bo)};
+    if (validate_ip_arg_connectivity(index, grp.bank))
       return bo;
 
     auto fmt = boost::format

--- a/src/runtime_src/core/common/api/xrt_xclbin.cpp
+++ b/src/runtime_src/core/common/api/xrt_xclbin.cpp
@@ -52,6 +52,10 @@
 #endif
 
 namespace {
+
+// NOLINTNEXTLINE
+constexpr size_t operator"" _kb(unsigned long long v)  { return 1024u * v; }
+
 constexpr size_t max_sections = 12;
 static const std::array<axlf_section_kind, max_sections> kinds = {
   EMBEDDED_METADATA,
@@ -212,7 +216,7 @@ class xclbin::ip_impl
 public: // purposely not a struct to match decl in xrt_xclbin.h
   const ::ip_data* m_ip;            //
   int32_t m_ip_layout_idx;          // index in IP_LAYOUT seciton
-  size_t m_size = 0;                // address range of this ip (a kernel property)
+  size_t m_size = 64_kb;            // address range of this ip (a kernel property)
   std::vector<xclbin::arg> m_args;  // index by argument index
 
   void

--- a/src/runtime_src/core/common/device.cpp
+++ b/src/runtime_src/core/common/device.cpp
@@ -301,6 +301,16 @@ get_memory_type(size_t memidx) const
     : mtype;
 }
 
+const std::vector<uint64_t>&
+device::
+get_cus() const
+{
+  if (m_cu2idx.size() > 1)
+    throw error(std::errc::not_supported, "multiple xclbins not supported");
+
+  return m_cus;
+}
+
 cuidx_type
 device::
 get_cuidx(slot_id slot, const std::string& cuname) const

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -283,9 +283,13 @@ public:
     return m_xclbins.get_slots(xclbin_id);
   }
 
-  // Updates cached xclbin data based in data quieried from driver
+  // Updates cached xclbin data based in data queried from driver
   void
   update_xclbin_info();
+
+  // Updates cached compute unit data based in data queried from driver
+  void
+  update_cu_info();
 
   // This function is called after an axlf has been succesfully loaded
   // by the shim layer API xclLoadXclBin().  Since xclLoadXclBin() can
@@ -383,6 +387,11 @@ public:
   XRT_CORE_COMMON_EXPORT
   cuidx_type
   get_cuidx(slot_id slot, const std::string& cuname) const;
+
+  // get_cuidx() - As const version, but update cu indices if necessary
+  XRT_CORE_COMMON_EXPORT
+  cuidx_type
+  get_cuidx(slot_id slot, const std::string& cuname);
 
   /**
    * get_ert_slots() - Get number of ERT CQ slots

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -52,6 +52,54 @@ using device_collection = std::vector<std::shared_ptr<xrt_core::device>>;
  */
 class device : public ishim
 {
+  // class xclbin_map - container for loaded xclbins
+  //
+  // Manages xclbins loaded into specific slots
+  class xclbin_map
+  {
+    using slot_id = uint32_t;
+    std::map<slot_id, xrt::uuid> m_slot2uuid;
+    std::map<xrt::uuid, xrt::xclbin> m_xclbins;
+  public:
+
+    // Reset the slot -> uuid mapping based on quieried slot info data
+    void
+    reset(std::map<slot_id, xrt::uuid>&& slot2uuid)
+    {
+      m_slot2uuid = std::move(slot2uuid);
+    }
+
+    // Cache an xclbin
+    void
+    insert(xrt::xclbin xclbin)
+    {
+      m_xclbins[xclbin.get_uuid()] = std::move(xclbin);
+    }
+
+    // Get an xclbin with specified uuid
+    const xrt::xclbin&
+    get(const xrt::uuid& uuid) const
+    {
+      auto itr = m_xclbins.find(uuid);
+      if (itr == m_xclbins.end())
+        throw error("No xclbin with uuid '" + uuid.to_string() + "'");
+
+      return (*itr).second;
+    }
+
+    // Get the xclbin stored in specified slot
+    // It is an error if the xclbin has not been explicitly loaded.
+    const xrt::xclbin&
+    get(slot_id slot) const
+    {
+      auto itr = m_slot2uuid.find(slot);
+      if (itr == m_slot2uuid.end())
+        throw error("No xclbin in slot '" + std::to_string(slot) + "'");
+
+      return get((*itr).second);
+    }
+  };
+
 public:
   // device index type
   using id_type = unsigned int;
@@ -212,14 +260,14 @@ public:
   xrt::xclbin
   get_xclbin(const uuid& xclbin_id) const;
 
-  /**
-   * register_axlf() - Callback from shim after AXLF succesfully loaded
-   *
-   * This function is called after an axlf has been succesfully loaded
-   * by the shim layer API xclLoadXclBin().  Since xclLoadXclBin() can
-   * be called explicitly by end-user code, the callback is necessary
-   * in order to register current axlf with the device object
-   */
+  // Updates cached xclbin data based in data quieried from driver
+  void
+  update_xclbin_info();
+
+  // This function is called after an axlf has been succesfully loaded
+  // by the shim layer API xclLoadXclBin().  Since xclLoadXclBin() can
+  // be called explicitly by end-user code, the callback is necessary
+  // in order to register current axlf with the device object
   XRT_CORE_COMMON_EXPORT
   void
   register_axlf(const axlf*);
@@ -295,7 +343,7 @@ public:
   // get_cus() - Get list cu base addresses sorted by cu inidex
   XRT_CORE_COMMON_EXPORT
   const std::vector<uint64_t>&
-  get_cus(const uuid& xclbin_id = uuid()) const;
+  get_cus() const;
 
   // get_cuidx() - Get index of cu identified by name
   //
@@ -308,7 +356,7 @@ public:
   // for execution
   XRT_CORE_COMMON_EXPORT
   cuidx_type
-  get_cuidx(const std::string& cuname, const uuid& xclbin_id = uuid()) const;
+  get_cuidx(const std::string& cuname) const;
 
   /**
    * get_ert_slots() - Get number of ERT CQ slots
@@ -374,8 +422,9 @@ public:
   mutable boost::optional<bool> m_nodma = boost::none;
 
   std::map<std::string, cuidx_type> m_cu2idx; // cu name mapping to cuidx
-  std::vector<uint64_t> m_cus;           // cu base addresses in expeced sort order
-  xrt::xclbin m_xclbin;                  // currently loaded xclbin
+  std::vector<uint64_t> m_cus;                // cu base addresses in expeced sort order
+  xrt::xclbin m_xclbin;                       // currently loaded xclbin  (single-slot, default)
+  xclbin_map m_xclbins;                       // currently loaded xclbins (multi-slot)
 };
 
 /**

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -363,13 +363,12 @@ public:
   memory_type
   get_memory_type(size_t memidx) const;
 
-  // get_cus() - Get list cu base addresses sorted by cu inidex
+  // get_cus() - Get list cu base addresses sorted by cu indices
+  // This is a legacy single slot function.
+  // An exception is thrown if called in multi-xclbin flow
   XRT_CORE_COMMON_EXPORT
   const std::vector<uint64_t>&
-  get_cus() const
-  {
-    return m_cus;
-  }
+  get_cus() const;
 
   // get_cuidx() - Get index of cu identified by name and slot
   //

--- a/src/runtime_src/core/common/device.h
+++ b/src/runtime_src/core/common/device.h
@@ -57,11 +57,14 @@ class device : public ishim
   // Manages xclbins loaded into specific slots
   class xclbin_map
   {
+  public:
     using slot_id = uint32_t;
+
+  private:
     std::map<slot_id, xrt::uuid> m_slot2uuid;
     std::map<xrt::uuid, xrt::xclbin> m_xclbins;
-  public:
 
+  public:
     // Reset the slot -> uuid mapping based on quieried slot info data
     void
     reset(std::map<slot_id, xrt::uuid>&& slot2uuid)
@@ -98,11 +101,25 @@ class device : public ishim
 
       return get((*itr).second);
     }
+
+    // Return slot indices sorted
+    std::vector<slot_id>
+    get_slots(const xrt::uuid& uuid) const
+    {
+      std::vector<slot_id> slots;
+      for (auto& su : m_slot2uuid)
+        if (su.second == uuid)
+          slots.push_back(su.first);
+
+      std::sort(slots.begin(), slots.end());
+      return slots;
+    }
   };
 
 public:
   // device index type
   using id_type = unsigned int;
+  using slot_id = xclbin_map::slot_id;
   using handle_type = xclDeviceHandle;
   using memory_type = xrt::xclbin::mem::memory_type;
 
@@ -253,12 +270,18 @@ public:
   void
   load_xclbin(const uuid& xclbin_id);
 
-
   // Get the currently loaded xclbin
   // Throws if xclbin uuid does match
   XRT_CORE_COMMON_EXPORT
   xrt::xclbin
   get_xclbin(const uuid& xclbin_id) const;
+
+  // Get all slots that match xclbin uuid
+  std::vector<xclbin_map::slot_id>
+  get_slots(const uuid& xclbin_id) const
+  {
+    return m_xclbins.get_slots(xclbin_id);
+  }
 
   // Updates cached xclbin data based in data quieried from driver
   void
@@ -343,20 +366,24 @@ public:
   // get_cus() - Get list cu base addresses sorted by cu inidex
   XRT_CORE_COMMON_EXPORT
   const std::vector<uint64_t>&
-  get_cus() const;
+  get_cus() const
+  {
+    return m_cus;
+  }
 
-  // get_cuidx() - Get index of cu identified by name
+  // get_cuidx() - Get index of cu identified by name and slot
   //
-  // @return
-  //  The index of the CU represented as cuidx_type per
-  //  defintion in xrt_core::xclbin
+  // slot:   Slot for CU
+  // cuname:  Name of CU
+  // Return:  The index of the CU represented as cuidx_type per
+  //          defintion in xrt_core::xclbin
   //
   // The index is used when opening a context on this device
   // and it is used to specify the cumask in commands send
   // for execution
   XRT_CORE_COMMON_EXPORT
   cuidx_type
-  get_cuidx(const std::string& cuname) const;
+  get_cuidx(slot_id slot, const std::string& cuname) const;
 
   /**
    * get_ert_slots() - Get number of ERT CQ slots
@@ -421,7 +448,8 @@ public:
   id_type m_device_id;
   mutable boost::optional<bool> m_nodma = boost::none;
 
-  std::map<std::string, cuidx_type> m_cu2idx; // cu name mapping to cuidx
+  using name2idx_type = std::map<std::string, cuidx_type>;
+  std::map<slot_id, name2idx_type> m_cu2idx;  // slot -> cu name mapping to cuidx
   std::vector<uint64_t> m_cus;                // cu base addresses in expeced sort order
   xrt::xclbin m_xclbin;                       // currently loaded xclbin  (single-slot, default)
   xclbin_map m_xclbins;                       // currently loaded xclbins (multi-slot)

--- a/src/runtime_src/core/common/ishim.h
+++ b/src/runtime_src/core/common/ishim.h
@@ -20,10 +20,12 @@
 #include "error.h"
 #include "xcl_graph.h"
 #include "xrt.h"
+#include "core/include/shim_int.h"
 
-#include "experimental/xrt_aie.h"
-#include "experimental/xrt_bo.h"
-#include "experimental/xrt_graph.h"
+#include "xrt/xrt_aie.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_graph.h"
+
 #include "experimental/xrt-next.h"
 
 #include <stdexcept>
@@ -49,6 +51,9 @@ struct ishim
 
   virtual void
   open_context(const xuid_t xclbin_uuid, unsigned int ip_index, bool shared) = 0;
+
+  virtual void
+  open_context(uint32_t slot, const xuid_t xclbin_uuid, const char* cuname, bool shared) = 0;
 
   virtual void
   close_context(const xuid_t xclbin_uuid, unsigned int ip_index) = 0;
@@ -251,6 +256,13 @@ struct shim : public DeviceType
   open_context(const xuid_t xclbin_uuid , unsigned int ip_index, bool shared) override
   {
     if (auto ret = xclOpenContext(DeviceType::get_device_handle(), xclbin_uuid, ip_index, shared))
+      throw system_error(ret, "failed to open ip context");
+  }
+
+  void
+  open_context(uint32_t slot, const xuid_t xclbin_uuid, const char* cuname, bool shared) override
+  {
+    if (auto ret = xclOpenContextByName(DeviceType::get_device_handle(), slot, xclbin_uuid, cuname, shared))
       throw system_error(ret, "failed to open ip context");
   }
 

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -1,7 +1,5 @@
-/**
- * SPDX-License-Identifier: Apache-2.0
- * Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #define XRT_CORE_COMMON_SOURCE // in same dll as core_common
 #include "query_requests.h"
 #include "core/include/xclerr_int.h"

--- a/src/runtime_src/core/common/query_requests.cpp
+++ b/src/runtime_src/core/common/query_requests.cpp
@@ -151,5 +151,15 @@ to_errors(const std::vector<char>& buf)
 
   return errors;
 }
-  
+
+std::map<xrt_core::query::xclbin_slots::slot_id, xrt::uuid>
+xrt_core::query::xclbin_slots::
+to_map(const result_type& value)
+{
+  std::map<xrt_core::query::xclbin_slots::slot_id, xrt::uuid> s2u;
+  for (const auto& data : value)
+    s2u.emplace(data.slot, xrt::uuid{data.uuid});
+  return s2u;
+}
+
 }} // query, xrt_core

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -16,11 +16,12 @@
 
 #ifndef xrt_core_common_query_requests_h
 #define xrt_core_common_query_requests_h
+#include "error.h"
+#include "query.h"
+#include "uuid.h"
 
 #include "core/include/xclerr_int.h"
-#include "query.h"
-#include "error.h"
-#include "uuid.h"
+
 #include <iomanip>
 #include <map>
 #include <string>

--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -21,12 +21,13 @@
 #include "query.h"
 #include "error.h"
 #include "uuid.h"
-#include <string>
-#include <vector>
-#include <sstream>
 #include <iomanip>
 #include <map>
+#include <string>
+#include <sstream>
 #include <stdexcept>
+#include <vector>
+
 #include <boost/any.hpp>
 #include <boost/format.hpp>
 
@@ -259,7 +260,7 @@ enum class key_type
   lapc_status,
   spc_status,
   accel_deadlock_status,
-  get_xclbin_data,
+  xclbin_slots,
   aie_get_freq,
   aie_set_freq,
   dtbo_path,
@@ -288,7 +289,7 @@ enum class key_type
 // Provides granularity for calling code to catch errors specific to
 // query request which are often acceptable errors because some
 // devices may not support all types of query requests.
-//  
+//
 // Other non query exceptions signal a different kind of error which
 // should maybe not be caught.
 //
@@ -998,7 +999,7 @@ struct instance : request
   virtual boost::any
   get(const device*) const = 0;
 
-  static std::string 
+  static std::string
   to_string(const result_type& value)
   {
     return std::to_string(value);
@@ -1351,7 +1352,7 @@ struct aie_core_info : request
 {
   using result_type = std::string;
   static const key_type key = key_type::aie_core_info;
-  
+
   virtual boost::any
   get(const device*) const = 0;
 };
@@ -1360,7 +1361,7 @@ struct aie_shim_info : request
 {
   using result_type = std::string;
   static const key_type key = key_type::aie_shim_info;
-  
+
   virtual boost::any
   get(const device*) const = 0;
 };
@@ -2933,20 +2934,26 @@ struct extended_vmr_status : request
   get(const device*) const = 0;
 };
 
-struct get_xclbin_data : request
+// Retrieve xclbin slot information.  This is a mapping
+// from xclbin uuid to the slot index created by the driver
+struct xclbin_slots : request
 {
-  struct xclbin_data {
-    uint32_t	slot_index;
+  using slot_id = uint32_t;
+
+  struct slot_info {
+    slot_id slot;
     std::string uuid;
   };
 
-  using result_type = std::vector<struct xclbin_data>;
-  using data_type = struct xclbin_data;
-  static const key_type key = key_type::get_xclbin_data;
+  using result_type = std::vector<slot_info>;
+  static const key_type key = key_type::xclbin_slots;
+
+  // Convert raw data to associative map
+  static std::map<slot_id, xrt::uuid>
+  to_map(const result_type& value);
 
   virtual boost::any
   get(const xrt_core::device* device) const = 0;
-
 };
 
 struct hwmon_sdm_serial_num : request

--- a/src/runtime_src/core/edge/skd/sk_daemon.cpp
+++ b/src/runtime_src/core/edge/skd/sk_daemon.cpp
@@ -1,7 +1,5 @@
 /**
  * Copyright (C) 2019-2022 Xilinx, Inc
- * Author(s): Min Ma	<min.ma@xilinx.com>
- *          : Larry Liu	<yliu@xilinx.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -15,6 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+#ifdef __GNUC__
+# pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
 
 #include <dlfcn.h>
 #include <execinfo.h>
@@ -38,7 +39,7 @@ xclDeviceHandle initXRTHandle(unsigned deviceIndex)
 static void stacktrace_logger(const int sig)
 {
   const int stack_depth = STACKTRACE_DEPTH;
-  
+
   syslog(LOG_ERR, "%s - got %d\n", __func__, sig);
   if (sig == SIGCHLD)
     return;
@@ -86,7 +87,7 @@ void configSoftKernel(xclDeviceHandle handle, xclSKCmd *cmd)
       char proc_name[PNAME_LEN] = {};
       int ret;
       skd_inst = new xrt::skd(handle,cmd->meta_bohdl,cmd->bohdl,cmd->krnl_name,i,cmd->uuid);
-      
+
       /* Install Signal Handler for the Child Processes/Soft-Kernels */
       struct sigaction act;
       act.sa_handler = sigLog;

--- a/src/runtime_src/core/edge/skd/xrt_skd.cpp
+++ b/src/runtime_src/core/edge/skd/xrt_skd.cpp
@@ -17,11 +17,15 @@
 
 #include "xrt_skd.h"
 
+#ifdef __GNUC__
+# pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+
 namespace xrt {
 
   /**
    * skd() - Constructor from uuid and soft kernel section
-   * 
+   *
    * @param kernel metadata buffer handle
    *
    * @param soft kernel image buffer handle
@@ -73,7 +77,7 @@ namespace xrt {
       xclFreeBO(parent_devHdl, sk_meta_bo);
       return -1;
     }
-    
+
     buf = xclMapBO(parent_devHdl, sk_meta_bo, false);
     if (!buf) {
       syslog(LOG_ERR, "Cannot map metadata BO.\n");
@@ -84,7 +88,7 @@ namespace xrt {
     num_args = args.size();
     syslog(LOG_INFO,"Num args = %d\n",num_args);
     munmap(buf, prop.size);
-    
+
     // new device handle for the current instance
     devHdl = xclOpen(0, NULL, XCL_QUIET);
     xrtdHdl = xrtDeviceOpenFromXcl(devHdl);
@@ -117,7 +121,7 @@ namespace xrt {
       }
     }
     ffi_args = new ffi_type*[num_args];
-    
+
     // Open main soft kernel
     kernel = dlsym(sk_handle, sk_name);
     errstr = dlerror();
@@ -129,7 +133,7 @@ namespace xrt {
       syslog(LOG_ERR, "Cannot find kernel %s\n", sk_name);
       return -1;
     }
-    
+
     // Soft kernel command bohandle init
     ret = createSoftKernel(&cmd_boh);
     if (ret) {
@@ -138,23 +142,23 @@ namespace xrt {
     }
 
     syslog(LOG_INFO, "%s_%d start running, cmd_boh = %d\n", sk_name, cu_idx, cmd_boh);
-    
+
     args_from_host = (unsigned *)xclMapBO(devHdl, cmd_boh, true);;
     if (args_from_host == MAP_FAILED) {
       syslog(LOG_ERR, "Failed to map soft kernel args for %s_%d", sk_name, cu_idx);
       dlclose(sk_handle);
       return -1;
     }
-    
+
     // Prep FFI type for all kernel arguments
     for(int i=0;i<num_args;i++) {
       ffi_args[i] = convert_to_ffitype(args[i]);
     }
-    
+
     if(ffi_prep_cif(&cif,FFI_DEFAULT_ABI, num_args, &ffi_type_uint32,ffi_args) != FFI_OK) {
       syslog(LOG_ERR, "Cannot prep FFI arguments!");
       return -1;
-    }    
+    }
 
     syslog(LOG_INFO,"Finish soft kernel %s init\n",sk_name);
     return 0;
@@ -171,18 +175,18 @@ namespace xrt {
     void* bos[num_args];
     uint64_t boSize[num_args];
     std::vector<int> bo_list;
-    
+
     while (1) {
       ret = waitNextCmd();
-      
+
       if (ret) {
 	/* We are told to exit the soft kernel loop */
 	syslog(LOG_INFO, "Exit soft kernel %s\n", sk_name);
 	break;
       }
-      
+
       syslog(LOG_INFO, "Got new kernel command!\n");
-      
+
       /* Reg file indicates the kernel should not be running. */
       if (!(args_from_host[0] & 0x1))
 	continue; //AP_START bit is not set; New Cmd is not available
@@ -207,10 +211,10 @@ namespace xrt {
 	  ffi_arg_values[i] = &args_from_host[(args[i].offset+PS_KERNEL_REG_OFFSET)/4];
 	}
       }
-      
+
       ffi_call(&cif,FFI_FN(kernel), &kernel_return, ffi_arg_values);
       args_from_host[1] = (uint32_t)kernel_return;
-      
+
       // Unmap Buffers
       for(auto i:bo_list) {
 	munmap(bos[i],boSize[i]);
@@ -219,7 +223,7 @@ namespace xrt {
     }
 
   }
-  
+
   skd::~skd() {
     // Call soft kernel fini if available
     kernel_fini_t kernel_fini;
@@ -234,7 +238,7 @@ namespace xrt {
     } else {
       ret = kernel_fini(xrtHandle);
     }
-    
+
     dlclose(sk_handle);
     ret = deleteSoftKernelFile();
     if (ret) {
@@ -271,31 +275,31 @@ namespace xrt {
     void *buf = NULL;
     char path[XRT_MAX_PATH_LENGTH];
     int len, i;
-    
+
     xclBOProperties prop;
     if (xclGetBOProperties(handle, bohdl, &prop)) {
       syslog(LOG_ERR, "Cannot get SK .so BO info.\n");
       return -1;
     }
-    
+
     buf = xclMapBO(handle, bohdl, false);
     if (!buf) {
       syslog(LOG_ERR, "Cannot map softkernel BO.\n");
       return -1;
     }
-    
+
     snprintf(path, XRT_MAX_PATH_LENGTH, "%s", SOFT_KERNEL_FILE_PATH);
-    
+
     /* If not exist, create the path one by one. */
     std::filesystem::create_directories(path);
-    
+
     fptr = fopen(sk_path, "w+b");
     if (fptr == NULL) {
       syslog(LOG_ERR, "Cannot create file: %s\n", sk_path);
       munmap(buf, prop.size);
       return -1;
     }
-    
+
     /* copy the soft kernel to file */
     if (fwrite(buf, prop.size, 1, fptr) != 1) {
       syslog(LOG_ERR, "Fail to write to file %s.\n", sk_path);
@@ -304,10 +308,10 @@ namespace xrt {
       return -1;
     }
     syslog(LOG_INFO,"File created at %s\n", sk_path);
-    
+
     fclose(fptr);
     munmap(buf, prop.size);
-    
+
     return 0;
   }
 
@@ -318,7 +322,7 @@ namespace xrt {
   {
     return(remove(sk_path));
   }
-  
+
   /* Convert argument to ffi_type */
   ffi_type* skd::convert_to_ffitype(xrt_core::xclbin::kernel_argument arg) {
     ffi_type* return_type;
@@ -346,7 +350,7 @@ namespace xrt {
       { {"float", 8 }, &ffi_type_double },
       { {"double", 8 }, &ffi_type_double }
     };
-    
+
     if((arg.index == xrt_core::xclbin::kernel_argument::no_index) ||  // Argument is xrtHandles
        (arg.type == xrt_core::xclbin::kernel_argument::argtype::global)) {  // Argument is a buffer pointer
       return_type = &ffi_type_pointer;
@@ -367,4 +371,3 @@ namespace xrt {
     xclSKReport(devHdl,cu_idx,XRT_SCU_STATE_CRASH);
   }
 }
-

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -1,6 +1,5 @@
 /**
- * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,16 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-/**
- * Copyright (C) 2015 Xilinx, Inc
- */
-
 #include "shim.h"
 #include "core/common/system.h"
 #include "core/common/device.h"
 #include "xcl_graph.h"
- 
+
 xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbosityLevel level)
 {
   xclDeviceInfo2 info;
@@ -402,7 +396,7 @@ unsigned xclProbe()
       mVBNV >> deviceName;
     }
     mVBNV.close();
-  }  
+  }
 
   for(auto &it: devicesInfo)
   {
@@ -611,7 +605,7 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
   return -ENOSYS;
 }
 
-int 
+int
 xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
   return -ENOSYS;
@@ -658,6 +652,12 @@ int xclOpenContext(xclDeviceHandle handle, const uuid_t xclbinId, unsigned int i
 {
   xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
   return drv ? drv->xclOpenContext(xclbinId, ipIndex, shared) : -ENODEV;
+}
+
+int xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared)
+{
+  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+  return drv ? drv->xclOpenContext(slot, xclbinId, cuname, shared) : -ENODEV;
 }
 
 int xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
@@ -955,7 +955,7 @@ xclResetAIEArray(xclDeviceHandle handle)
 int
 xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
-  try { 
+  try {
     if (handle) {
       xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
       return drv ? drv->xrtSyncBOAIENB(bo, gmioName, dir, size, offset) : -1;
@@ -1017,4 +1017,3 @@ xclLoadXclBinMeta(xclDeviceHandle handle, const xclBin *buffer)
 {
   return 0;
 }
-

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -129,7 +129,7 @@ namespace xclcpuemhal2 {
       {
         //Give error and return from here
       }
-    }   
+    }
     // iterate devices
     count = 0;
     for (auto& xml_device : xml_project.get_child("project.platform"))
@@ -520,7 +520,7 @@ namespace xclcpuemhal2 {
             xilinxInstall = std::string(installEnvvar);
           }
         }
-        
+
         char *xilinxHLSEnvVar = getenv("XILINX_HLS");
         char *xilinxVivadoEnvVar = getenv("XILINX_VIVADO");
 
@@ -607,7 +607,7 @@ namespace xclcpuemhal2 {
   }
 
   int CpuemShim::xclLoadXclBin(const xclBin *header)
-  { 
+  {
     if (mLogStream.is_open()) mLogStream << __func__ << " begin " << std::endl;
     std::string xclBinName = "";
     if (!xclcpuemhal2::validateXclBin(header, xclBinName, mDeviceProcessInQemu, mFpgaDevice)) {
@@ -619,7 +619,7 @@ namespace xclcpuemhal2 {
 
     if (!mDeviceProcessInQemu){
       return xclLoadXclBinNewFlow(header);
-    }  
+    }
 
     std::string xmlFile = "" ;
     int result = dumpXML(header, xmlFile) ;
@@ -676,7 +676,7 @@ namespace xclcpuemhal2 {
       size_t emuDataSize = 0;
       std::unique_ptr<char[]> connectvitybuf;
       ssize_t connectvitybufsize = 0;
-     
+
       //check header
       if (!memcmp(xclbininmemory, "xclbin0", 8))
       {
@@ -697,13 +697,13 @@ namespace xclcpuemhal2 {
           memTopology = std::unique_ptr<char[]>(new char[memTopologySize]);
           memcpy(memTopology.get(), xclbininmemory + sec->m_sectionOffset, memTopologySize);
         }
-        //Extract EMULATION_DATA from XCLBIN       
+        //Extract EMULATION_DATA from XCLBIN
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, EMULATION_DATA)) {
           emuDataSize = sec->m_sectionSize;
           emuData = std::unique_ptr<char[]>(new char[emuDataSize]);
           memcpy(emuData.get(), xclbininmemory + sec->m_sectionOffset, emuDataSize);
         }
-	      //Extract CONNECTIVITY section from XCLBIN       
+	      //Extract CONNECTIVITY section from XCLBIN
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, CONNECTIVITY)) {
           connectvitybufsize = sec->m_sectionSize;
           connectvitybuf = std::unique_ptr<char[]>(new char[connectvitybufsize]);
@@ -766,7 +766,7 @@ namespace xclcpuemhal2 {
               return -1;
             uint64_t route_id = m_mem->m_mem_data[memdata_idx].route_id;
             uint64_t arg_id = m_conn->m_connection[conn_idx].arg_index;
-            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo 
+            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo
             uint64_t instanceBaseAddr = 0xFFFF0000 & flow_id;
             if (mLogStream.is_open())
               mLogStream << __func__ << " flow_id : " << flow_id << " route_id : " << route_id << " inst addr : " << instanceBaseAddr << " arg_id : " << arg_id << std::endl;
@@ -875,7 +875,7 @@ namespace xclcpuemhal2 {
 
   int CpuemShim::xclLoadXclBinNewFlow(const xclBin *header)
   {
-    if (mLogStream.is_open()) mLogStream << __func__ << " begin " << std::endl;  
+    if (mLogStream.is_open()) mLogStream << __func__ << " begin " << std::endl;
 
     // Before we spawn off the child process, we must determine
     //  if the process will be debuggable or not.  We get that
@@ -894,22 +894,22 @@ namespace xclcpuemhal2 {
         auto top = reinterpret_cast<const axlf*>(header);
         auto sec = xclbin::get_axlf_section(top, DEBUG_DATA);
         if (sec)
-        {         
+        {
           debugMode = "Yes";
         }
       }
     }
-    //Create thread for TCP socket connection    
+    //Create thread for TCP socket connection
     std::thread tcpSockThread = std::thread(&CpuemShim::socketConnection, this, true);
 
     bool simDontRun = xclemulation::config::getInstance()->isDontRun();
     if (!simDontRun) {
       if (!xclcpuemhal2::isRemotePortMapped) {
         xclcpuemhal2::initRemotePortMap(mFpgaDevice);
-      }      
+      }
       //Send the LoadXclBin
       PLLAUNCHER::OclCommand *cmd = new PLLAUNCHER::OclCommand();
-      cmd->setCommand(PLLAUNCHER::PL_OCL_LOADXCLBIN_ID); 
+      cmd->setCommand(PLLAUNCHER::PL_OCL_LOADXCLBIN_ID);
       cmd->addArg(debugMode.c_str());
       uint32_t length;
       uint8_t* buff = cmd->generateBuffer(&length);
@@ -919,7 +919,7 @@ namespace xclcpuemhal2 {
       }
       //Send the end of packet
       char cPacketEndChar = PL_OCL_PACKET_END_MARKER;
-      memcpy((char*)(xclcpuemhal2::remotePortMappedPointer), &cPacketEndChar, 1);     
+      memcpy((char*)(xclcpuemhal2::remotePortMappedPointer), &cPacketEndChar, 1);
     }
 
     std::string xmlFile = "";
@@ -933,7 +933,7 @@ namespace xclcpuemhal2 {
     systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::CREATE);
     systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777");
     binaryCounter++;
-   
+
     //Join tcp socket thread.
     if (tcpSockThread.joinable()) {
        tcpSockThread.join();
@@ -963,7 +963,7 @@ namespace xclcpuemhal2 {
       size_t sharedliblength = 0;
       char* emuData;
       size_t emuDataSize = 0;
-    
+
       //check header
       if (!memcmp(xclbininmemory, "xclbin0", 8))
       {
@@ -974,25 +974,25 @@ namespace xclcpuemhal2 {
         return -1;
       }
       else if (!memcmp(xclbininmemory, "xclbin2", 7)) {
-        auto top = reinterpret_cast<const axlf*>(header);        
+        auto top = reinterpret_cast<const axlf*>(header);
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY)) {
           memTopologySize = sec->m_sectionSize;
           memTopology = std::unique_ptr<char[]>(new char[memTopologySize]);
           memcpy(memTopology.get(), xclbininmemory + sec->m_sectionOffset, memTopologySize);
         }
-        //Extract CONNECTIVITY section from XCLBIN       
+        //Extract CONNECTIVITY section from XCLBIN
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, CONNECTIVITY)) {
           connectvitybufsize = sec->m_sectionSize;
           connectvitybuf = std::unique_ptr<char[]>(new char[connectvitybufsize]);
           memcpy(connectvitybuf.get(), xclbininmemory + sec->m_sectionOffset, connectvitybufsize);
         }
-        //Extract BITSTREAM from XCLBIN  
+        //Extract BITSTREAM from XCLBIN
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, BITSTREAM)) {
           sharedlib = xclbininmemory + sec->m_sectionOffset;
           sharedliblength = sec->m_sectionSize;
         }
-        //Extract EMULATION_DATA from XCLBIN       
-        if (auto sec = xrt_core::xclbin::get_axlf_section(top, EMULATION_DATA)) {          
+        //Extract EMULATION_DATA from XCLBIN
+        if (auto sec = xrt_core::xclbin::get_axlf_section(top, EMULATION_DATA)) {
           emuData = xclbininmemory + sec->m_sectionOffset;
           emuDataSize = sec->m_sectionSize;
         }
@@ -1031,7 +1031,7 @@ namespace xclcpuemhal2 {
               return -1;
             uint64_t route_id = m_mem->m_mem_data[memdata_idx].route_id;
             uint64_t arg_id = m_conn->m_connection[conn_idx].arg_index;
-            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo 
+            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo
             uint64_t instanceBaseAddr = 0xFFFF0000 & flow_id;
             if (mLogStream.is_open())
               mLogStream << __func__ << " flow_id : " << flow_id << " route_id : " << route_id << " inst addr : " << instanceBaseAddr << " arg_id : " << arg_id << std::endl;
@@ -2255,6 +2255,11 @@ int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool 
   return 0;
 }
 
+int CpuemShim::xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const
+{
+  return 0;
+}
+
 /*
 * xclExecWait
 */
@@ -2307,7 +2312,7 @@ int CpuemShim::xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) cons
 
 //Get CU index from IP_LAYOUT section for corresponding kernel name
 int CpuemShim::xclIPName2Index(const char *name)
-{ 
+{
   //Get IP_LAYOUT buffer from xclbin
   auto buffer = mCoreDevice->get_axlf_section(IP_LAYOUT);
   return xclemulation::getIPName2Index(name, buffer.first);
@@ -2540,7 +2545,7 @@ int CpuemShim::xrtSyncBOAIENB(xrt::bo& bo, const char *gmioname, enum xclBOSyncD
     return -1;
 
   if (mLogStream.is_open())
-    mLogStream << __func__ << ", bo.address() " << bo.address() << std::endl; 
+    mLogStream << __func__ << ", bo.address() " << bo.address() << std::endl;
 
   auto boBase = bo.address();
   xclSyncBOAIENB_RPC_CALL(xclSyncBOAIENB, gmioname, dir, size, offset, boBase);

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -1,6 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 #ifndef _SW_EMU_SHIM_H_
 #define _SW_EMU_SHIM_H_
 
@@ -159,6 +157,7 @@ namespace xclcpuemhal2 {
       ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
       int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+      int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
@@ -174,7 +173,7 @@ namespace xclcpuemhal2 {
       SWScheduler* getScheduler() { return mSWSch; }
       //******************************* XRT Graph API's **************************************************//
       /**
-      * xrtGraphInit() - Initialize graph 
+      * xrtGraphInit() - Initialize graph
       *
       * @gh:             Handle to graph previously opened with xrtGraphOpen.
       * Return:          0 on success, -1 on error
@@ -183,7 +182,7 @@ namespace xclcpuemhal2 {
       */
       int
         xrtGraphInit(void * gh);
-      
+
       /**
       * xrtGraphRun() - Start a graph execution
       *
@@ -210,7 +209,7 @@ namespace xclcpuemhal2 {
       * forever or graph that has multi-rate core(s).
       */
       int
-        xrtGraphWait(void * gh);          
+        xrtGraphWait(void * gh);
 
       /**
       * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
@@ -218,7 +217,7 @@ namespace xclcpuemhal2 {
       *                 is done before end the graph. If graph already run more
       *                 than the given cycle, stop the graph immediately and end it.
       *
-      * @gh:              Handle to graph previously opened with xrtGraphOpen.      
+      * @gh:              Handle to graph previously opened with xrtGraphOpen.
       *
       * Return:          0 on success, -1 on timeout.
       *
@@ -410,7 +409,7 @@ namespace xclcpuemhal2 {
     xclcpuemhal2::CpuemShim*  getDeviceHandle() {  return _deviceHandle;  }
     const char*  getGraphName() { return _graph; }
     unsigned int  getGraphHandle() { return graphHandle; }
-  private: 
+  private:
     xclcpuemhal2::CpuemShim*  _deviceHandle;
     //const uuid_t _xclbin_uuid;
     const char* _graph;
@@ -425,7 +424,7 @@ namespace xclcpuemhal2 {
     };
     graph_state _state;
     std::string _name;
-    uint64_t _startTime;  
+    uint64_t _startTime;
     /* This is the collections of rtps that are used. */
     std::vector<std::string> rtps;
     static unsigned int mGraphHandle;

--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -79,7 +79,7 @@ get_edgedev(const xrt_core::device* device)
   return zynq_device::get_dev();
 }
 
-struct bdf 
+struct bdf
 {
   using result_type = query::pcie_bdf::result_type;
 
@@ -91,7 +91,7 @@ struct bdf
 
 };
 
-struct board_name 
+struct board_name
 {
   using result_type = query::board_name::result_type;
 
@@ -108,7 +108,7 @@ struct board_name
   }
 };
 
-struct is_ready 
+struct is_ready
 {
   using result_type = query::is_ready::result_type;
 
@@ -181,7 +181,7 @@ struct aie_metadata
     constexpr uint32_t major = 1;
     constexpr uint32_t minor = 0;
     constexpr uint32_t patch = 0;
-    
+
     auto dev = get_edgedev(device);
 
     dev->sysfs_get(AIE_TAG, err, value);
@@ -189,7 +189,7 @@ struct aie_metadata
       throw xrt_core::query::sysfs_error(err);
 
     std::stringstream ss(value);
-    boost::property_tree::ptree pt; 
+    boost::property_tree::ptree pt;
     boost::property_tree::read_json(ss, pt);
 
     if(pt.get<uint32_t>("schema_version.major") != major ||
@@ -215,11 +215,11 @@ struct aie_core_info : aie_metadata
 
     read_aie_metadata(device, max_row, max_col);
 
-    /* Loop each all aie core tiles and collect core, dma, events, errors, locks status. */ 
+    /* Loop each all aie core tiles and collect core, dma, events, errors, locks status. */
     for(int i=0;i<max_col;i++)
       for(int j=0; j<(max_row-1);j++)
         ptarray.push_back(std::make_pair(std::to_string(i)+"_"+std::to_string(j),
-                          aie_sys_parser::get_parser()->aie_sys_read(i,(j+1)))); 
+                          aie_sys_parser::get_parser()->aie_sys_read(i,(j+1))));
 
     boost::property_tree::ptree pt;
     pt.add_child("aie_core",ptarray);
@@ -244,7 +244,7 @@ struct aie_shim_info : aie_metadata
 
     /* Loop all shim tiles and collect all dma, events, errors, locks status */
     for(int i=0;i<max_col;i++) {
-      ptarray.push_back(std::make_pair("", aie_sys_parser::get_parser()->aie_sys_read(i,0))); 
+      ptarray.push_back(std::make_pair("", aie_sys_parser::get_parser()->aie_sys_read(i,0)));
     }
 
     boost::property_tree::ptree pt;
@@ -344,10 +344,11 @@ struct xclbin_uuid
   }
 };
 
-struct get_xclbin_data
+struct xclbin_slots
 {
-  using result_type = query::get_xclbin_data::result_type;
-  using data_type = query::get_xclbin_data::data_type;
+  using result_type = query::xclbin_slots::result_type;
+  using slot_info = query::xclbin_slots::slot_info;
+  using slot_id = query::xclbin_slots::slot_id;
 
   static result_type
   get(const xrt_core::device* device, key_type)
@@ -371,9 +372,9 @@ struct get_xclbin_data
       if (std::distance(tokens.begin(), tokens.end()) != 2)
         throw xrt_core::query::sysfs_error("xclbinid sysfs node corrupted");
 
-      data_type data = { 0 };
+      slot_info data = { 0 };
       tokenizer::iterator tok_it = tokens.begin();
-      data.slot_index = std::stoi(std::string(*tok_it++));
+      data.slot = std::stoi(std::string(*tok_it++));
       data.uuid = std::string(*tok_it++);
 
       xclbin_data.push_back(std::move(data));
@@ -892,7 +893,7 @@ initialize_query_table()
 
   emplace_func0_request<query::kds_cu_info,             kds_cu_info>();
   emplace_func0_request<query::instance,                instance>();
-  emplace_func0_request<query::get_xclbin_data,         get_xclbin_data>();
+  emplace_func0_request<query::xclbin_slots,            xclbin_slots>();
 
   emplace_func4_request<query::aim_counter,             aim_counter>();
   emplace_func4_request<query::am_counter,              am_counter>();

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1109,10 +1109,10 @@ xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared)
 
 int
 shim::
-xclOpenContext(uint32_t, const uuid_t xclbin_uuid, const char* cuname, bool shared)
+xclOpenContext(uint32_t slot, const uuid_t xclbin_uuid, const char* cuname, bool shared)
 {
   // TODO: implement for full support of multiple xclbins
-  return xclOpenContext(xclbin_uuid, mCoreDevice->get_cuidx(cuname).index, shared);
+  return xclOpenContext(xclbin_uuid, mCoreDevice->get_cuidx(slot, cuname).index, shared);
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -1,7 +1,5 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Author(s): Hem C. Neema
- *          : Min Ma
  * ZNYQ XRT Library layered on top of ZYNQ zocl kernel driver
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -16,30 +14,33 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 #include "shim.h"
-#include "system_linux.h"
-#include "core/common/message.h"
-#include "core/common/scheduler.h"
-#include "core/common/xclbin_parser.h"
-#include "core/common/config_reader.h"
+#include "core/include/shim_int.h"
 #include "core/include/xcl_perfmon_parameters.h"
-#include "core/common/bo_cache.h"
-#include "core/common/config_reader.h"
-#include "core/common/query_requests.h"
-#include "core/common/error.h"
 #include "core/include/xrt/xrt_uuid.h"
+
+#include "system_linux.h"
 #include "core/edge/common/aie_parser.h"
 
+#include "core/common/bo_cache.h"
+#include "core/common/config_reader.h"
+#include "core/common/message.h"
+#include "core/common/config_reader.h"
+#include "core/common/error.h"
+#include "core/common/query_requests.h"
+#include "core/common/scheduler.h"
+#include "core/common/xclbin_parser.h"
+
+#include <cassert>
 #include <cerrno>
+#include <chrono>
+#include <cstdarg>
+#include <cstring>
 #include <iostream>
 #include <iomanip>
-#include <cstring>
 #include <thread>
-#include <chrono>
 #include <vector>
-#include <cassert>
-#include <cstdarg>
+
 #include <boost/filesystem.hpp>
 #include <regex>
 
@@ -1056,7 +1057,7 @@ xclSKCreate(int *boHandle, uint32_t cu_idx)
   if(!ret) {
     *boHandle = scmd.handle;
   }
-  
+
   return ret ? -errno : ret;
 }
 
@@ -1104,6 +1105,14 @@ xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared)
 
   ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_CTX, &ctx);
   return ret ? -errno : ret;
+}
+
+int
+shim::
+xclOpenContext(uint32_t, const uuid_t xclbin_uuid, const char* cuname, bool shared)
+{
+  // TODO: implement for full support of multiple xclbins
+  return xclOpenContext(xclbin_uuid, mCoreDevice->get_cuidx(cuname).index, shared);
 }
 
 int
@@ -2350,6 +2359,23 @@ xclOpenContext(xclDeviceHandle handle, const uuid_t xclbinId, unsigned int ipInd
 
   return drv ? drv->xclOpenContext(xclbinId, ipIndex, shared) : -EINVAL;
   }) ;
+}
+
+int
+xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared)
+{
+  try {
+    ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+    return drv ? drv->xclOpenContext(slot, xclbinId, cuname, shared) : -EINVAL;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -ENOENT;
+  }
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -15,18 +15,19 @@
  * under the License.
  */
 #include "shim.h"
+#include "system_linux.h"
+
 #include "core/include/shim_int.h"
 #include "core/include/xcl_perfmon_parameters.h"
 #include "core/include/xrt/xrt_uuid.h"
 
-#include "system_linux.h"
 #include "core/edge/common/aie_parser.h"
 
 #include "core/common/bo_cache.h"
 #include "core/common/config_reader.h"
-#include "core/common/message.h"
 #include "core/common/config_reader.h"
 #include "core/common/error.h"
+#include "core/common/message.h"
 #include "core/common/query_requests.h"
 #include "core/common/scheduler.h"
 #include "core/common/xclbin_parser.h"

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -1,7 +1,5 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
- * Author(s): Hem C. Neema
- *          : Min Ma
  * ZNYQ HAL Driver layered on top of ZYNQ kernel driver
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -78,6 +76,7 @@ public:
   int xclExecWait(int timeoutMilliSec);
 
   int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared);
+  int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared);
   int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
 
   int xclSKGetCmd(xclSKCmd *cmd);

--- a/src/runtime_src/core/include/shim_int.h
+++ b/src/runtime_src/core/include/shim_int.h
@@ -1,49 +1,12 @@
-/*
- *  Copyright (C) 2021, Xilinx Inc
- *
- *  This file is dual licensed.  It may be redistributed and/or modified
- *  under the terms of the Apache 2.0 License OR version 2 of the GNU
- *  General Public License.
- *
- *  Apache License Verbiage
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *  GPL license Verbiage:
- *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU General Public License as
- *  published by the Free Software Foundation; either version 2 of the
- *  License, or (at your option) any later version.  This program is
- *  distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or
- *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
- *  License for more details.  You should have received a copy of the
- *  GNU General Public License along with this program; if not, write
- *  to the Free Software Foundation, Inc., 59 Temple Place, Suite 330,
- *  Boston, MA 02111-1307 USA
- *
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
+#ifndef SHIM_INT_H_
+#define SHIM_INT_H_
 
-#ifndef _SHIM_INT_H_
-#define _SHIM_INT_H_
+#include "core/include/xrt.h"
 
-
-/* This file defines internal shim APIs, which is not end user visible.
- * You cannot include this file without include xrt.h.
- * This header file should not be published to xrt release include/ folder.
- */
-#ifdef _XCL_XRT_CORE_H_
+// This file defines internal shim APIs, which is not end user visible.
+// This header file should not be published to xrt release include/ folder.
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,19 +16,28 @@ extern "C" {
  * xclOpenByBDF() - Open a device and obtain its handle by PCI BDF
  *
  * @bdf:           Deice PCE BDF
- *
  * Return:         Device handle
  */
 XCL_DRIVER_DLLESPEC
 xclDeviceHandle
 xclOpenByBDF(const char *bdf);
 
+/**
+ * xclOpenContextByName() - Open a shared/exclusive context on a named compute unit
+ *
+ * @handle:        Device handle
+ * @slot:          Slot index of xclbin to service this context requiest
+ * @xclbin_uuid:   UUID of the xclbin image with the CU to open a context on
+ * @cuname:        Name of compute unit to open
+ * @shared:        Shared access or exclusive access
+ * Return:         0 on success, EAGAIN, or appropriate error number
+ */
+XCL_DRIVER_DLLESPEC
+int
+xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const xuid_t xclbin_uuid, const char* cuname, bool shared);
+
 #ifdef __cplusplus
 }
-#endif
-
-#else
-#error "Must include xrt.h before include this file"
 #endif
 
 #endif

--- a/src/runtime_src/core/include/xrt_mem.h
+++ b/src/runtime_src/core/include/xrt_mem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019, Xilinx Inc - All rights reserved.
+ * Copyright (C) 2019-2022, Xilinx Inc - All rights reserved.
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
@@ -13,15 +13,56 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations
  * under the License.
+ *
+ * GPL license Verbiage:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef _XRT_MEM_H_
 #define _XRT_MEM_H_
 
+#ifdef _WIN32
+# pragma warning( push )
+# pragma warning( disable : 4201 )
+#endif
 
 #ifdef __cplusplus
+# include <cstdint>
 extern "C" {
+#else
+# if defined(__KERNEL__)
+#  include <linux/types.h>
+# else
+#  include <stdint.h>
+# endif
 #endif
+
+/**
+ * Encoding of flags passed to xcl buffer allocation APIs
+ */
+struct xcl_bo_flags
+{
+  union {
+    uint32_t flags;
+    struct {
+      uint16_t bank;       // [15-0]
+      uint8_t  slot;       // [16-23]
+      uint8_t  boflags;    // [24-31]
+    };
+  };
+};
 
 /**
  * XCL BO Flags bits layout
@@ -67,4 +108,9 @@ enum xclDDRFlags {
 #ifdef __cplusplus
 }
 #endif
+
+#ifdef _WIN32
+# pragma warning( pop )
+#endif
+
 #endif

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -14,14 +14,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-/**
- * Copyright (C) 2015 Xilinx, Inc
- */
-
 #include "shim.h"
-#include "core/common/system.h"
+#include "core/include/shim_int.h"
 #include "core/common/device.h"
+#include "core/common/system.h"
 #include "xcl_graph.h"
 
 xclDeviceHandle xclOpen(unsigned deviceIndex, const char *logfileName, xclVerbosityLevel level)
@@ -587,6 +583,22 @@ int xclOpenContext(xclDeviceHandle handle, const uuid_t xclbinId, unsigned int i
   return drv ? drv->xclOpenContext(xclbinId, ipIndex, shared) : -ENODEV;
 }
 
+int xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared)
+{
+  try {
+    xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+    return drv ? drv->xclOpenContextByName(slot, xclbinId, cuname, shared) : -ENODEV;
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -ENOENT;
+  }
+}
+
 int xclExecWait(xclDeviceHandle handle, int timeoutMilliSec)
 {
   xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
@@ -659,7 +671,7 @@ xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t force)
   return -ENOSYS;
 }
 
-int 
+int
 xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
   return -ENOSYS;
@@ -908,7 +920,7 @@ xclResetAIEArray(xclDeviceHandle handle)
 int
 xclSyncBOAIENB(xclDeviceHandle handle, xrt::bo& bo, const char *gmioName, enum xclBOSyncDirection dir, size_t size, size_t offset)
 {
-  try { 
+  try {
     if (handle) {
       xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
       return drv ? drv->xrtSyncBOAIENB(bo, gmioName, dir, size, offset) : -1;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -2114,9 +2114,9 @@ int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool 
   return 0;
 }
 
-int CpuemShim::xclOpenContextByName(uint32_t, const uuid_t xclbinId, const char* cuname, bool shared) const
+int CpuemShim::xclOpenContextByName(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const
 {
-  return xclOpenContext(xclbinId, mCoreDevice->get_cuidx(cuname).index, shared);
+  return xclOpenContext(xclbinId, mCoreDevice->get_cuidx(slot, cuname).index, shared);
 }
 
 /*

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -13,11 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-/**
- * Copyright (C) 2015 Xilinx, Inc
- */
-
 #include "shim.h"
 #include "system_swemu.h"
 #include "xclbin.h"
@@ -410,7 +405,7 @@ namespace xclcpuemhal2 {
             xilinxInstall = std::string(installEnvvar);
           }
         }
-        
+
         char *xilinxHLSEnvVar = getenv("XILINX_HLS");
         char *xilinxVivadoEnvVar = getenv("XILINX_VIVADO");
 
@@ -438,10 +433,10 @@ namespace xclcpuemhal2 {
           sLdLibs += sVivadoBinDir + DS + "lib" + DS + "lnx64.o" + DS + "Default" + DS + ":";
           sLdLibs += sVitisBinDir + DS + "tps" + DS + "lnx64" + DS + "python-3.8.3" + DS + "lib" + DS + ":";
           sLdLibs += sVitisBinDir + DS + "lib" + DS + "lnx64.o" + DS;
-          
+
           setenv("LD_LIBRARY_PATH",sLdLibs.c_str(),true);
         }
-        
+
         if (xilinxInstall.empty()) {
           std::cerr << "ERROR : [SW-EM 10] Please make sure that the XILINX_VITIS environment variable is set correctly" << std::endl;
           exit(1);
@@ -519,7 +514,7 @@ namespace xclcpuemhal2 {
       const auto& props = xrt_core::xclbin_int::get_properties(kernel);
       //get CU's of each kernel object.iterate over CU's to get arguments
       if (props.address_range != 0 && !props.name.empty())
-        continue;       
+        continue;
       for (const auto& cu : kernel.get_cus()) {
         instance_name = cu.get_name();
         if (!instance_name.empty())
@@ -535,7 +530,7 @@ namespace xclcpuemhal2 {
     std::string xmlFile = "" ;
     int result = dumpXML(header, xmlFile) ;
     if (result != 0) return result ;
-   
+
     // Before we spawn off the child process, we must determine
     //  if the process will be debuggable or not.  We get that
     //  by checking to see if there is a DEBUG_DATA section in
@@ -584,12 +579,12 @@ namespace xclcpuemhal2 {
       char *sharedlib = nullptr;
       int sharedliblength = 0;
       std::unique_ptr<char[]> memTopology;
-      size_t memTopologySize = 0;    
+      size_t memTopologySize = 0;
       std::unique_ptr<char[]> emuData;
       size_t emuDataSize = 0;
       std::unique_ptr<char[]> connectvitybuf;
       ssize_t connectvitybufsize = 0;
-     
+
       //check header
       if (!memcmp(xclbininmemory, "xclbin0", 8))
       {
@@ -607,20 +602,20 @@ namespace xclcpuemhal2 {
           sharedliblength = sec->m_sectionSize;
         }
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, ASK_GROUP_TOPOLOGY)) {
-          memTopologySize = sec->m_sectionSize;        
+          memTopologySize = sec->m_sectionSize;
           memTopology = std::unique_ptr<char[]>(new char[memTopologySize]);
           memcpy(memTopology.get(), xclbininmemory + sec->m_sectionOffset, memTopologySize);
         }
-        //Extract EMULATION_DATA from XCLBIN       
+        //Extract EMULATION_DATA from XCLBIN
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, EMULATION_DATA)) {
-          emuDataSize = sec->m_sectionSize;        
+          emuDataSize = sec->m_sectionSize;
           emuData = std::unique_ptr<char[]>(new char[emuDataSize]);
           memcpy(emuData.get(), xclbininmemory + sec->m_sectionOffset, emuDataSize);
           getCuRangeIdx();
         }
-	      //Extract CONNECTIVITY section from XCLBIN       
+	      //Extract CONNECTIVITY section from XCLBIN
         if (auto sec = xrt_core::xclbin::get_axlf_section(top, CONNECTIVITY)) {
-          connectvitybufsize = sec->m_sectionSize;       
+          connectvitybufsize = sec->m_sectionSize;
           connectvitybuf = std::unique_ptr<char[]>(new char[connectvitybufsize]);
           memcpy(connectvitybuf.get(), xclbininmemory + sec->m_sectionOffset, connectvitybufsize);
         }
@@ -681,7 +676,7 @@ namespace xclcpuemhal2 {
               return -1;
             uint64_t route_id = m_mem->m_mem_data[memdata_idx].route_id;
             uint64_t arg_id = m_conn->m_connection[conn_idx].arg_index;
-            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo 
+            uint64_t flow_id = m_mem->m_mem_data[memdata_idx].flow_id;//base address + flow_id combo
             uint64_t instanceBaseAddr = 0xFFFF0000 & flow_id;
             if (mLogStream.is_open())
               mLogStream << __func__ << " flow_id : " << flow_id << " route_id : " << route_id << " inst addr : " << instanceBaseAddr << " arg_id : " << arg_id << std::endl;
@@ -732,7 +727,7 @@ namespace xclcpuemhal2 {
         isVersal = true;
         std::string emuDataFilePath = binaryDirectory + "/emuDataFile";
         std::ofstream os(emuDataFilePath);
-        os.write(emuData.get(), emuDataSize);             
+        os.write(emuData.get(), emuDataSize);
         std::cout << "emuDataFilePath : " << emuDataFilePath << std::endl;
         systemUtil::makeSystemCall(emuDataFilePath, systemUtil::systemOperation::UNZIP, binaryDirectory, std::to_string(__LINE__));
         systemUtil::makeSystemCall(binaryDirectory, systemUtil::systemOperation::PERMISSIONS, "777", std::to_string(__LINE__));
@@ -872,7 +867,7 @@ namespace xclcpuemhal2 {
       return 0;
     }
 
-    DEBUG_MSGS("%s, %d(ENDED)\n", __func__, __LINE__);  
+    DEBUG_MSGS("%s, %d(ENDED)\n", __func__, __LINE__);
     PRINTENDFUNC;
     return result;
   }
@@ -927,8 +922,8 @@ namespace xclcpuemhal2 {
     PRINTENDFUNC;
     return size;
   }
-  
-  bool CpuemShim::isValidCu(uint32_t cu_index) {  
+
+  bool CpuemShim::isValidCu(uint32_t cu_index) {
     // get sorted cu addresses to match up with cu_index
     const auto& cuidx2addr = mCoreDevice->get_cus();
     if (cu_index >= cuidx2addr.size()) {
@@ -949,12 +944,12 @@ namespace xclcpuemhal2 {
       if (tmpCuIdx == cuIdx) {
         cuAddRange = cuInfo.second;
         mLogStream << __func__ << " , cuAddRange :  " << cuAddRange << std::endl;
-      }  
+      }
     }
-    return cuAddRange;	  
+    return cuAddRange;
   }
-  
-  bool CpuemShim::isValidOffset(uint32_t offset, uint64_t cuAddRange) { 
+
+  bool CpuemShim::isValidOffset(uint32_t offset, uint64_t cuAddRange) {
     if (offset >= cuAddRange || (offset & (sizeof(uint32_t) - 1)) != 0) {
       std::string strMsg = "ERROR: [SW-EMU 21] xclRegRW - invalid CU offset: " + std::to_string(offset);
       mLogStream << __func__ << strMsg << std::endl;
@@ -962,22 +957,22 @@ namespace xclcpuemhal2 {
     }
     return true;
   }
-  
+
   int CpuemShim::xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap)
   {
     if (mLogStream.is_open())
       mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << "CU Idx : " << cu_index << " Offset : " << offset << " Datap : " << (*datap) << std::endl;
-  
+
     if (!isValidCu(cu_index))
       return -EINVAL;
-  
+
     const auto& cuidx2addr = mCoreDevice->get_cus();
-	
+
     uint64_t cuAddRange = getCuAddRange(cu_index);
-	
+
     if (!isValidOffset(offset, cuAddRange))
-      return -EINVAL;	
-  
+      return -EINVAL;
+
     const unsigned REG_BUFF_SIZE = 0x4;
     std::array<char, REG_BUFF_SIZE> buff;
     uint64_t baseAddr = cuidx2addr[cu_index];
@@ -991,7 +986,7 @@ namespace xclcpuemhal2 {
       uint32_t * tmp_buff = reinterpret_cast<uint32_t*>(buff.data());
       tmp_buff[0] = *datap;
       xclRegWrite_RPC_CALL(xclRegWrite,baseAddr,offset,tmp_buff,0,0);
-    }	
+    }
     return 0;
   }
 
@@ -1052,7 +1047,7 @@ namespace xclcpuemhal2 {
 
     if(!sock)
       launchTempProcess();
-    
+
     src = (unsigned char*)src + seek;
     dest += seek;
 
@@ -1199,7 +1194,7 @@ namespace xclcpuemhal2 {
 
       mFdToFileNameMap.clear();
     }
- 
+
     if (mLogStream.is_open()) {
       mLogStream << __func__ << ", " << std::this_thread::get_id() << std::endl;
     }
@@ -1542,7 +1537,7 @@ unsigned int CpuemShim::xclImportBO(int boGlobalHandle, unsigned flags)
 
     mImportedBOs.insert(importedBo);
     bo->fd = boGlobalHandle;
-    
+
     bool ack;
     xclImportBO_RPC_CALL(xclImportBO, fileName, bo->base, size);
 
@@ -1550,7 +1545,7 @@ unsigned int CpuemShim::xclImportBO(int boGlobalHandle, unsigned flags)
       return -1;
 
     PRINTENDFUNC;
-    
+
     DEBUG_MSGS("%s, %d( ENDED )\n", __func__, __LINE__);
     return importedBo;
   }
@@ -1565,7 +1560,7 @@ int CpuemShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, s
   //TODO
   if (mLogStream.is_open()) {
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << dst_boHandle
-      << ", "<< src_boHandle << ", "<< size <<"," << dst_offset << ", " << src_offset << std::endl;   
+      << ", "<< src_boHandle << ", "<< size <<"," << dst_offset << ", " << src_offset << std::endl;
   }
 
   DEBUG_MSGS("%s, %d( src_boHandle: %x size: %zx  dst_offset: %zx src_offset: %zx )\n", __func__, __LINE__, src_boHandle, size, dst_offset, src_offset);
@@ -1654,8 +1649,8 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
   if (mLogStream.is_open())
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << ", " << write << std::endl;
 
-  DEBUG_MSGS("%s, %d(boHandle: %x write: %s)\n", __func__, __LINE__, boHandle, write ? "true" : "false");    
-  
+  DEBUG_MSGS("%s, %d(boHandle: %x write: %s)\n", __func__, __LINE__, boHandle, write ? "true" : "false");
+
   xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
   if (!bo) {
     PRINTENDFUNC;
@@ -1676,12 +1671,12 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
     auto ismMapEnabled= std::getenv("VITIS_SW_EMU_ENABLE_SINGLE_MMAP");
     if (ismMapEnabled) {
       data = (char*) mmap(0, MEMSIZE, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
-      data += bo->base; 
+      data += bo->base;
 
       if(!data)
         return nullptr;
 
-      mFdToFileNameMap[fd] = std::make_tuple(sFileName, MEMSIZE, (void*)data);        
+      mFdToFileNameMap[fd] = std::make_tuple(sFileName, MEMSIZE, (void*)data);
 
     } else {
       data = (char*) mmap(0, bo->size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_SHARED, fd, 0);
@@ -1697,13 +1692,13 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
       }
       mFdToFileNameMap[fd] = std::make_tuple(sFileName, bo->size, (void*)data);
     }
-    
+
     bo->buf = data;
 
     DEBUG_MSGS("%s, %d(bo->base: %lx bo->buf: %p fd: %d)\n", __func__, __LINE__, bo->base, bo->buf, fd);
     PRINTENDFUNC;
 
-    DEBUG_MSGS("%s, %d(ENDED )\n", __func__, __LINE__); 
+    DEBUG_MSGS("%s, %d(ENDED )\n", __func__, __LINE__);
     return data;
   }
   else { // NON P2P cacheable scenario
@@ -1712,7 +1707,7 @@ void *CpuemShim::xclMapBO(unsigned int boHandle, bool write)
     if (posix_memalign(&pBuf, getpagesize(), bo->size)) {
       if (mLogStream.is_open())
         mLogStream << "posix_memalign failed" << std::endl;
-      PRINTENDFUNC;  
+      PRINTENDFUNC;
       return nullptr;
     }
 
@@ -1742,8 +1737,8 @@ int CpuemShim::xclSyncBO(unsigned int boHandle, xclBOSyncDirection dir, size_t s
   if (mLogStream.is_open())
     mLogStream << __func__ << ", " << std::this_thread::get_id() << ", " << std::hex << boHandle << " , " << std::endl;
 
-  DEBUG_MSGS("%s, %d(boHandle: %x offset: %zx)\n", __func__, __LINE__, boHandle, offset);   
-  
+  DEBUG_MSGS("%s, %d(boHandle: %x offset: %zx)\n", __func__, __LINE__, boHandle, offset);
+
   xclemulation::drm_xocl_bo* bo = xclGetBoByHandle(boHandle);
   if(!bo) {
     PRINTENDFUNC;
@@ -2119,6 +2114,11 @@ int CpuemShim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool 
   return 0;
 }
 
+int CpuemShim::xclOpenContextByName(uint32_t, const uuid_t xclbinId, const char* cuname, bool shared) const
+{
+  return xclOpenContext(xclbinId, mCoreDevice->get_cuidx(cuname).index, shared);
+}
+
 /*
 * xclExecWait
 */
@@ -2171,7 +2171,7 @@ int CpuemShim::xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) cons
 
 //Get CU index from IP_LAYOUT section for corresponding kernel name
 int CpuemShim::xclIPName2Index(const char *name)
-{ 
+{
   //Get IP_LAYOUT buffer from xclbin
   auto buffer = mCoreDevice->get_axlf_section(IP_LAYOUT);
   return xclemulation::getIPName2Index(name, buffer.first);
@@ -2194,7 +2194,7 @@ void CpuemShim::constructQueryTable() {
 
 int CpuemShim::deviceQuery(key_type queryKey) {
   if(mQueryTable.find(queryKey) != mQueryTable.end())
-    return (mQueryTable[queryKey] == "enabled" ? 1 : 0);    
+    return (mQueryTable[queryKey] == "enabled" ? 1 : 0);
   return 0;
 }
 
@@ -2308,7 +2308,7 @@ int CpuemShim::xrtGraphEnd(void * gh) {
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
     return -1;
-  
+
   DEBUG_MSGS("%s, %d()\n", __func__, __LINE__);
   auto graphhandle = ghPtr->getGraphHandle();
   xclGraphEnd_RPC_CALL(xclGraphEnd, graphhandle);
@@ -2388,7 +2388,7 @@ int CpuemShim::xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
     return -1;
-  
+
   DEBUG_MSGS("%s, %d(size: %zx hierPathPort: %s)\n", __func__, __LINE__, size, hierPathPort);
   auto graphhandle = ghPtr->getGraphHandle();
   xclGraphUpdateRTP_RPC_CALL(xclGraphUpdateRTP, graphhandle, hierPathPort, buffer, size);
@@ -2413,7 +2413,7 @@ int CpuemShim::xrtGraphReadRTP(void * gh, const char *hierPathPort, char *buffer
   auto ghPtr = (xclcpuemhal2::GraphType*)gh;
   if (!ghPtr)
     return -1;
-  
+
   DEBUG_MSGS("%s, %d(size: %zx hierPathPort: %s)\n", __func__, __LINE__, size, hierPathPort);
   auto graphhandle = ghPtr->getGraphHandle();
   xclGraphReadRTP_RPC_CALL(xclGraphReadRTP, graphhandle, hierPathPort, buffer, size);
@@ -2448,7 +2448,7 @@ int CpuemShim::xrtSyncBOAIENB(xrt::bo& bo, const char *gmioname, enum xclBOSyncD
   auto boBase = bo.address();
   //bool isCacheable = bo.flags & XCL_BO_FLAGS_CACHEABLE;
   DEBUG_MSGS("%s, %d(gmioname: %s size: %zx offset: %zx boBase: %lx)\n", __func__, __LINE__, gmioname, size, offset, boBase);
-  
+
   xclSyncBOAIENB_RPC_CALL(xclSyncBOAIENB, gmioname, dir, size, offset, boBase);
   if (!ack) {
     PRINTENDFUNC;

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -1,6 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -14,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 #ifndef _SW_EMU_SHIM_H_
 #define _SW_EMU_SHIM_H_
 
@@ -147,7 +145,7 @@ namespace xclcpuemhal2 {
 
 
       ~CpuemShim();
-      CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool bUnified, 
+      CpuemShim(unsigned int deviceIndex, xclDeviceInfo2 &info, std::list<xclemulation::DDRBank>& DDRBankList, bool bUnified,
         bool bXPR, FeatureRomHeader &featureRom, const boost::property_tree::ptree & platformData);
 
       static CpuemShim *handleCheck(void *handle);
@@ -163,6 +161,7 @@ namespace xclcpuemhal2 {
       ssize_t xclReadQueue(uint64_t q_hdl, xclQueueRequest *wr);
       int xclPollCompletion(int min_compl, int max_compl, xclReqCompletion *comps, int* actual, int timeout);
       int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+      int xclOpenContextByName(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
       int xclExecWait(int timeoutMilliSec);
       int xclExecBuf(unsigned int cmdBO);
       int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex) const;
@@ -175,7 +174,7 @@ namespace xclcpuemhal2 {
       int xclRegRW(bool rd, uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegRead(uint32_t cu_index, uint32_t offset, uint32_t *datap);
       int xclRegWrite(uint32_t cu_index, uint32_t offset, uint32_t data);
-      
+
       bool isImported(unsigned int _bo)
       {
         if (mImportedBOs.find(_bo) != mImportedBOs.end())
@@ -191,7 +190,7 @@ namespace xclcpuemhal2 {
 
       //******************************* XRT Graph API's **************************************************//
       /**
-      * xrtGraphInit() - Initialize graph 
+      * xrtGraphInit() - Initialize graph
       *
       * @gh:             Handle to graph previously opened with xrtGraphOpen.
       * Return:          0 on success, -1 on error
@@ -200,7 +199,7 @@ namespace xclcpuemhal2 {
       */
       int
         xrtGraphInit(void * gh);
-      
+
       /**
       * xrtGraphRun() - Start a graph execution
       *
@@ -227,7 +226,7 @@ namespace xclcpuemhal2 {
       * forever or graph that has multi-rate core(s).
       */
       int
-        xrtGraphWait(void * gh);          
+        xrtGraphWait(void * gh);
 
       /**
       * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
@@ -235,7 +234,7 @@ namespace xclcpuemhal2 {
       *                 is done before end the graph. If graph already run more
       *                 than the given cycle, stop the graph immediately and end it.
       *
-      * @gh:              Handle to graph previously opened with xrtGraphOpen.      
+      * @gh:              Handle to graph previously opened with xrtGraphOpen.
       *
       * Return:          0 on success, -1 on timeout.
       *
@@ -329,7 +328,7 @@ namespace xclcpuemhal2 {
 
       // //******************************* XRT Graph API's **************************************************//
       // /**
-      // * xrtGraphInit() - Initialize graph 
+      // * xrtGraphInit() - Initialize graph
       // *
       // * @gh:             Handle to graph previously opened with xrtGraphOpen.
       // * Return:          0 on success, -1 on error
@@ -338,7 +337,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphInit(void * gh);
-      // 
+      //
       // /**
       // * xrtGraphRun() - Start a graph execution
       // *
@@ -350,7 +349,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphRun(void * gh, uint32_t iterations);
-      // 
+      //
       // /**
       // * xrtGraphWait() -  Wait a given AIE cycle since the last xrtGraphRun and
       // *                   then stop the graph. If cycle is 0, busy wait until graph
@@ -365,15 +364,15 @@ namespace xclcpuemhal2 {
       // * forever or graph that has multi-rate core(s).
       // */
       // int
-      //   xrtGraphWait(void * gh);          
-      // 
+      //   xrtGraphWait(void * gh);
+      //
       // /**
       // * xrtGraphEnd() - Wait a given AIE cycle since the last xrtGraphRun and
       // *                 then end the graph. busy wait until graph
       // *                 is done before end the graph. If graph already run more
       // *                 than the given cycle, stop the graph immediately and end it.
       // *
-      // * @gh:              Handle to graph previously opened with xrtGraphOpen.      
+      // * @gh:              Handle to graph previously opened with xrtGraphOpen.
       // *
       // * Return:          0 on success, -1 on timeout.
       // *
@@ -382,7 +381,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphEnd(void * gh);
-      // 
+      //
       // /**
       // * xrtGraphUpdateRTP() - Update RTP value of port with hierarchical name
       // *
@@ -395,7 +394,7 @@ namespace xclcpuemhal2 {
       // */
       // int
       //   xrtGraphUpdateRTP(void * gh, const char *hierPathPort, const char *buffer, size_t size);
-      // 
+      //
       // /**
       // * xrtGraphUpdateRTP() - Read RTP value of port with hierarchical name
       // *
@@ -514,7 +513,7 @@ namespace xclcpuemhal2 {
     xclcpuemhal2::CpuemShim*  getDeviceHandle() {  return _deviceHandle;  }
     const char*  getGraphName() { return _graph; }
     unsigned int  getGraphHandle() { return graphHandle; }
-  private: 
+  private:
     xclcpuemhal2::CpuemShim*  _deviceHandle;
     //const uuid_t _xclbin_uuid;
     const char* _graph;
@@ -529,7 +528,7 @@ namespace xclcpuemhal2 {
     };
     graph_state _state;
     std::string _name;
-    uint64_t _startTime;  
+    uint64_t _startTime;
     /* This is the collections of rtps that are used. */
     std::vector<std::string> rtps;
     static unsigned int mGraphHandle;

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -13,14 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
-/**
- * Copyright (C) 2015 Xilinx, Inc
- */
-
 #include "shim.h"
-#include "core/common/system.h"
+#include "core/include/shim_int.h"
+
 #include "core/common/device.h"
+#include "core/common/system.h"
 #include "plugin/xdp/device_offload.h"
 #include "plugin/xdp/hal_trace.h"
 
@@ -179,14 +176,18 @@ int xclExecBuf(xclDeviceHandle handle, unsigned int cmdBO)
 int xclExecBufWithWaitList(xclDeviceHandle handle, unsigned int cmdBO, size_t num_bo_in_wait_list, unsigned int *bo_wait_list)
 {
     xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
-    if (!drv) 
+    if (!drv)
       return -1;
     return drv->xclExecBuf(cmdBO,num_bo_in_wait_list,bo_wait_list);
 }
 
 //defining following two functions as they gets called in scheduler init call
 int xclOpenContext(xclDeviceHandle handle, const uuid_t xclbinId, unsigned int ipIndex, bool shared)
+{
+  return 0;
+}
 
+int xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared)
 {
   return 0;
 }
@@ -599,7 +600,7 @@ int xclGetSubdevPath(xclDeviceHandle handle,  const char* subdev,
 {
   return 0;
 }
-//Mapped CU register space for xclRegRead/Write()  
+//Mapped CU register space for xclRegRead/Write()
 int xclRegWrite(xclDeviceHandle handle, uint32_t cu_index, uint32_t offset, uint32_t data)
 {
   return xdp::hw_emu::trace::profiling_wrapper("xclRegWrite", [=] {
@@ -628,7 +629,7 @@ xclCmaEnable(xclDeviceHandle handle, bool enable, uint64_t force)
   return -ENOSYS;
 }
 
-int 
+int
 xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
   return -ENOSYS;

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -1756,11 +1756,11 @@ int shim::xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool share
 }
 
 int shim::
-xclOpenContext(uint32_t, const uuid_t xclbin_uuid, const char* cuname, bool shared) const
+xclOpenContext(uint32_t slot, const uuid_t xclbin_uuid, const char* cuname, bool shared) const
 {
   // Alveo Linux PCIE does not yet support multiple xclbins.
   // Call regular flow
-  return xclOpenContext(xclbin_uuid, mCoreDevice->get_cuidx(cuname).index, shared);
+  return xclOpenContext(xclbin_uuid, mCoreDevice->get_cuidx(slot, cuname).index, shared);
 }
 
 /*

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -15,14 +15,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#include "xrt.h"
-#include "shim.h"
-#include "core/include/shim_int.h"
+#include "shim.h"  // This file implements shim.h
+#include "xrt.h"   // This file implements xrt.h
 
 #include "ert.h"
 #include "scan.h"
 #include "system_linux.h"
 #include "xclbin.h"
+
+#include "core/include/shim_int.h"
 
 #include "core/common/bo_cache.h"
 #include "core/common/config_reader.h"
@@ -40,34 +41,30 @@
 
 #include "core/pcie/driver/linux/include/mgmt-reg.h"
 
+#include <cassert>
+#include <cerrno>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <condition_variable>
+#include <fstream>
 #include <iostream>
 #include <iomanip>
-#include <fstream>
 #include <sstream>
-#include <vector>
-#include <cstring>
 #include <thread>
-#include <chrono>
-#include <cstdio>
-#include <cstdarg>
-#include <cerrno>
-#include <condition_variable>
+#include <vector>
 
 #include <unistd.h>
 #include <poll.h>
 
+#include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <sys/uio.h>
 #include <sys/syscall.h>
-#include <sys/file.h>
-#include <linux/aio_abi.h>
+#include <sys/uio.h>
 #include <asm/mman.h>
-
-#ifdef NDEBUG
-# undef NDEBUG
-# include<cassert>
-#endif
+#include <linux/aio_abi.h>
 
 #if defined(__GNUC__)
 #define SHIM_UNUSED __attribute__((unused))

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -1,47 +1,29 @@
-#ifndef _XOCL_GEM_SHIM_H_
-#define _XOCL_GEM_SHIM_H_
-
-/**
- * Copyright (C) 2016-2020 Xilinx, Inc
- * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
- * Author(s): Umang Parekh
- *          : Sonal Santan
- *          : Ryan Radjabi
- *
- * XRT PCIe library layered on top of xocl kernel driver
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2016-2022 Xilinx, Inc. All rights reserved.
+#ifndef PCIE_LINUX_SHIM_H_
+#define PCIE_LINUX_SHIM_H_
 
 #include "scan.h"
-#include "core/common/system.h"
-#include "core/common/device.h"
 #include "xclhal2.h"
-#include "core/pcie/driver/linux/include/xocl_ioctl.h"
-#include "core/pcie/driver/linux/include/qdma_ioctl.h"
+
+#include "core/common/device.h"
+#include "core/common/system.h"
 #include "core/common/xrt_profiling.h"
+#include "core/pcie/driver/linux/include/qdma_ioctl.h"
+#include "core/pcie/driver/linux/include/xocl_ioctl.h"
+
 #include "core/include/xstream.h" /* for stream_opt_type */
 
 #include <linux/aio_abi.h>
 #include <libdrm/drm.h>
 
-#include <mutex>
+#include <cassert>
 #include <fstream>
 #include <list>
 #include <map>
-#include <cassert>
-#include <vector>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 // Forward declaration
 namespace xrt_core {

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -147,6 +147,7 @@ public:
     int xclRegisterEventNotify(unsigned int userInterrupt, int fd);
     int xclExecWait(int timeoutMilliSec);
     int xclOpenContext(const uuid_t xclbinId, unsigned int ipIndex, bool shared) const;
+    int xclOpenContext(uint32_t slot, const uuid_t xclbinId, const char* cuname, bool shared) const;
     int xclCloseContext(const uuid_t xclbinId, unsigned int ipIndex);
 
     int getBoardNumber( void ) { return mBoardNumber; }

--- a/src/runtime_src/core/pcie/noop/device_noop.cpp
+++ b/src/runtime_src/core/pcie/noop/device_noop.cpp
@@ -1,29 +1,87 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
 #include "device_noop.h"
 #include "shim.h"
+
+#include "core/common/query_requests.h"
 
 #include <string>
 
 namespace {
 
+using key_type = xrt_core::query::key_type;
+
+struct kds_cu_info
+{
+  using result_type = xrt_core::query::kds_cu_info::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    return userpf::kds_cu_info(device);
+  }
+};
+
+struct xclbin_slots
+{
+  using result_type = xrt_core::query::xclbin_slots::result_type;
+
+  static result_type
+  get(const xrt_core::device* device, key_type)
+  {
+    return userpf::xclbin_slots(device);
+  }
+};
+
+static std::map<xrt_core::query::key_type, std::unique_ptr<xrt_core::query::request>> query_tbl;
+
+template <typename QueryRequestType, typename Getter>
+struct function0_getter : QueryRequestType
+{
+  static_assert(std::is_same<typename Getter::result_type, typename QueryRequestType::result_type>::value
+             || std::is_same<typename Getter::result_type, boost::any>::value, "type mismatch");
+
+  boost::any
+  get(const xrt_core::device* device) const
+  {
+    auto k = QueryRequestType::key;
+    return Getter::get(device, k);
+  }
+};
+
+template <typename QueryRequestType, typename Getter>
+static void
+emplace_function0_getter()
+{
+  auto k = QueryRequestType::key;
+  query_tbl.emplace(k, std::make_unique<function0_getter<QueryRequestType, Getter>>());
+}
+
+static void
+initialize_query_table()
+{
+  emplace_function0_getter<xrt_core::query::kds_cu_info,               kds_cu_info>();
+  emplace_function0_getter<xrt_core::query::xclbin_slots,              xclbin_slots>();
+}
+
+struct X { X() { initialize_query_table(); }};
+static X x;
+
 }
 
 namespace xrt_core { namespace noop {
 
+const query::request&
+device::
+lookup_query(query::key_type query_key) const
+{
+  auto it = query_tbl.find(query_key);
+
+  if (it == query_tbl.end())
+    throw query::no_such_key(query_key);
+
+  return *(it->second);
+}
 
 device::
 device(handle_type device_handle, id_type device_id, bool user)

--- a/src/runtime_src/core/pcie/noop/device_noop.h
+++ b/src/runtime_src/core/pcie/noop/device_noop.h
@@ -1,19 +1,5 @@
-/**
- * Copyright (C) 2020 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2020-2022 Xilinx, Inc. All rights reserved.
 #ifndef PCIE_NOOP_DEVICE_LINUX_H
 #define PCIE_NOOP_DEVICE_LINUX_H
 
@@ -33,10 +19,7 @@ public:
 private:
   // Private look up function for concrete query::request
   virtual const query::request&
-  lookup_query(query::key_type query_key) const
-  {
-    throw query::no_such_key(query_key);
-  }
+  lookup_query(query::key_type query_key) const override;
 };
 
 }} // noop, xrt_core

--- a/src/runtime_src/core/pcie/noop/shim.h
+++ b/src/runtime_src/core/pcie/noop/shim.h
@@ -1,27 +1,20 @@
-/**
- * Copyright (C) 2021 Xilinx, Inc
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may
- * not use this file except in compliance with the License. A copy of the
- * License is located at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2021-2022 Xilinx, Inc. All rights reserved.
 #ifndef XRT_CORE_PCIE_NOOP_SHIM_H
 #define XRT_CORE_PCIE_NOOP_SHIM_H
 
 #include "core/pcie/noop/config.h"
+#include "core/common/device.h"
+#include "core/common/query_requests.h"
 #include "xrt.h"
 
 namespace userpf {
 
+xrt_core::query::kds_cu_info::result_type
+kds_cu_info(const xrt_core::device* device);
+
+xrt_core::query::xclbin_slots::result_type
+xclbin_slots(const xrt_core::device* device);
 
 } // userpf
 

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -415,11 +415,11 @@ done:
   }
 
   int
-  open_context(uint32_t, const xuid_t xclbin_id, const char* cuname, bool shared)
+  open_context(uint32_t slot, const xuid_t xclbin_id, const char* cuname, bool shared)
   {
     // Alveo Windows PCIE does not yet support multiple xclbins.
     // Call regular flow
-    return open_context(xclbin_id, m_core_device->get_cuidx(cuname).index, shared);
+    return open_context(xclbin_id, m_core_device->get_cuidx(slot, cuname).index, shared);
   }
 
   int

--- a/src/runtime_src/core/pcie/windows/alveo/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/shim.cpp
@@ -17,8 +17,10 @@
 #define XCL_DRIVER_DLL_EXPORT
 #define XRT_CORE_PCIE_WINDOWS_SOURCE
 #include "shim.h"
-#include "xrt_mem.h"
+#include "core/include/shim_int.h"
+
 #include "xclfeatures.h"
+#include "xrt_mem.h"
 
 #include "core/common/config_reader.h"
 #include "core/common/device.h"
@@ -410,6 +412,14 @@ done:
     }
 
     return 0;
+  }
+
+  int
+  open_context(uint32_t, const xuid_t xclbin_id, const char* cuname, bool shared)
+  {
+    // Alveo Windows PCIE does not yet support multiple xclbins.
+    // Call regular flow
+    return open_context(xclbin_id, m_core_device->get_cuidx(cuname).index, shared);
   }
 
   int
@@ -1745,7 +1755,25 @@ xclOpenContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipInd
 	  : shim->open_context(xclbinId, ipIndex, shared);
 }
 
-int xclCloseContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipIndex)
+int
+xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const xuid_t xclbin_uuid, const char* cuname, bool shared)
+{
+  try {
+    auto shim = get_shim_object(handle);
+    return shim->open_context(slot, xclbin_uuid, cuname, shared);
+  }
+  catch (const xrt_core::error& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return ex.get_code();
+  }
+  catch (const std::exception& ex) {
+    xrt_core::send_exception_message(ex.what());
+    return -ENOENT;
+  }
+}
+
+int
+xclCloseContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipIndex)
 {
   xrt_core::message::
     send(xrt_core::message::severity_level::debug, "XRT", "xclCloseContext()");
@@ -2047,9 +2075,8 @@ xclUpdateSchedulerStat(xclDeviceHandle handle)
   return 1; // -ENOSYS;
 }
 
-int 
+int
 xclInternalResetDevice(xclDeviceHandle handle, xclResetKind kind)
 {
   return 1; // -ENOSYS;
 }
-

--- a/src/runtime_src/core/pcie/windows/mcdm/shim.cpp
+++ b/src/runtime_src/core/pcie/windows/mcdm/shim.cpp
@@ -3,6 +3,7 @@
 #define XCL_DRIVER_DLL_EXPORT
 
 #include "shim.h"
+#include "core/include/shim_int.h"
 #include "core/include/experimental/xrt-next.h"
 #include "core/common/dlfcn.h"
 #include "core/common/device.h"
@@ -363,6 +364,13 @@ xclReClock2(xclDeviceHandle handle, unsigned short region,
 // Compute Unit Execution Management APIs
 int
 xclOpenContext(xclDeviceHandle handle, const xuid_t xclbinId, unsigned int ipIndex, bool shared)
+{
+  not_supported(__func__);
+  return -1;
+}
+
+int
+xclOpenContextByName(xclDeviceHandle handle, uint32_t slot, const xuid_t xclbinId, const char* cuname, bool shared)
 {
   not_supported(__func__);
   return -1;

--- a/src/runtime_src/xocl/core/device.cpp
+++ b/src/runtime_src/xocl/core/device.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2016-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -38,7 +38,6 @@
 #ifdef _WIN32
 #pragma warning ( disable : 4244 4245 4267 4996 4505 )
 #endif
-
 
 namespace {
 
@@ -844,7 +843,7 @@ load_program(program* program)
   // Add compute units for each kernel in the program.
   clear_cus();
   m_cu_memidx = -2;
-  auto cu2addr = m_cdevice->get_cus(uuid);
+  auto cu2addr = m_cdevice->get_cus();
   for (const auto& xkernel : m_xclbin.get_kernels()) {
     for (const auto& xcu : xkernel.get_cus()) {
       if (auto cu = compute_unit::create(xkernel, xcu, this, cu2addr))


### PR DESCRIPTION
#### Problem solved by the commit
Support for multiple xclbins

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is a monster PR with many changes.   The changes are described in each commit to this PR.
Briefly:

- shim level changes to add xclOpenContextByName
- core infrastructure changes to manage multiple xclbins assigned to a slot
- core infrastructure changes to encode slot index in BO allocation flags
- leverage driver data for 'kds_cu_info' and 'xclbin_slots'
- compute unit indices are per 'kds_cu_info' which is assumed to be valid for a given cu only after a context is successfully acquired on that cu.

#### Risks (if any) associated the changes in the commit
This is a significant departure from single xclbin assumption.   For existing flows that support 
only a single xclbin, the xclbin will be managed in a single slot.

#### What has been tested and how, request additional testing if necessary
The shim level 'noop' driver was updated to support multiple xclbins that can be loaded into
slots.   This was leveraged during testing and debugging of this feature.