### PR TITLE
CR-1119346 xbmgmt/xbutil require additional warnings for non-ready devices

### DIFF
--- a/src/runtime_src/core/tools/common/ReportBOStats.cpp
+++ b/src/runtime_src/core/tools/common/ReportBOStats.cpp
@@ -134,5 +134,5 @@ ReportBOStats::writeReport(const xrt_core::device* /*pDevice*/,
     bo_table.addEntry(entry_data);
   }
 
-  output << bo_table << std::endl;
+  output << boost::str(boost::format("%s\n") % bo_table);
 }

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -113,12 +113,12 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   if (available_devices.empty())
     _output << "  0 devices found" << std::endl;
 
-  Table2D::HeaderData bdf = {"BDF", Table2D::Justification::right};
-  Table2D::HeaderData colon = {":", Table2D::Justification::right};
-  Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::right};
-  Table2D::HeaderData id = {"Platform UUID", Table2D::Justification::right};
-  Table2D::HeaderData instance = {"Device ID", Table2D::Justification::right};
-  Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::right};
+  const Table2D::HeaderData bdf = {"BDF", Table2D::Justification::right};
+  const Table2D::HeaderData colon = {":", Table2D::Justification::right};
+  const Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::right};
+  const Table2D::HeaderData id = {"Platform UUID", Table2D::Justification::right};
+  const Table2D::HeaderData instance = {"Device ID", Table2D::Justification::right};
+  const Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::right};
   const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance, ready};
   Table2D device_table(table_headers);
 

--- a/src/runtime_src/core/tools/common/ReportHost.cpp
+++ b/src/runtime_src/core/tools/common/ReportHost.cpp
@@ -118,15 +118,18 @@ ReportHost::writeReport(const xrt_core::device* /*_pDevice*/,
   Table2D::HeaderData vbnv = {"Shell", Table2D::Justification::right};
   Table2D::HeaderData id = {"Platform UUID", Table2D::Justification::right};
   Table2D::HeaderData instance = {"Device ID", Table2D::Justification::right};
-  std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance};
+  Table2D::HeaderData ready = {"Device Ready*", Table2D::Justification::right};
+  const std::vector<Table2D::HeaderData> table_headers = {bdf, colon, vbnv, id, instance, ready};
   Table2D device_table(table_headers);
 
-  for (auto& kd : available_devices) {
+  for (const auto& kd : available_devices) {
     const boost::property_tree::ptree& dev = kd.second;
-    std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
-    std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a")};
+    const std::string bdf_string = "[" + dev.get<std::string>("bdf") + "]";
+    const std::string ready_string = dev.get<bool>("is_ready", false) ? "Yes" : "No";
+    const std::vector<std::string> entry_data = {bdf_string, ":", dev.get<std::string>("vbnv", "n/a"), dev.get<std::string>("id", "n/a"), dev.get<std::string>("instance", "n/a"), ready_string};
     device_table.addEntry(entry_data);
   }
 
-  _output << device_table << std::endl;
+  _output << boost::str(boost::format("%s\n") % device_table);
+  _output << "* Devices that are not ready will have reduced functionality when using XRT tools\n";
 }

--- a/src/runtime_src/core/tools/common/Table2D.cpp
+++ b/src/runtime_src/core/tools/common/Table2D.cpp
@@ -45,7 +45,7 @@ Table2D::addEntry(const std::vector<std::string>& entry)
 }
 
 void
-Table2D::appendToOutput(std::string& output, const ColumnData& column, const std::string& data)
+Table2D::appendToOutput(std::string& output, const ColumnData& column, const std::string& data) const
 {
     // Format for table data
     boost::format fmt("%s%s%s  ");
@@ -56,7 +56,7 @@ Table2D::appendToOutput(std::string& output, const ColumnData& column, const std
 }
 
 std::ostream&
-Table2D::print(std::ostream& os)
+Table2D::print(std::ostream& os) const
 {
     // Iterate through each row and column of the table to format the output
     // Add one to account for the header row
@@ -80,7 +80,7 @@ Table2D::print(std::ostream& os)
 }
 
 void
-Table2D::getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks)
+Table2D::getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks) const
 {
     const size_t required_buffer = col_data.max_element_size - string_size;
     switch (col_data.header.justification) {

--- a/src/runtime_src/core/tools/common/Table2D.h
+++ b/src/runtime_src/core/tools/common/Table2D.h
@@ -57,15 +57,15 @@ class Table2D {
 
     std::vector<ColumnData> m_table;
 
-    std::ostream& print(std::ostream& os);
+    std::ostream& print(std::ostream& os) const;
 
-    void getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks);
+    void getBlankSizes(ColumnData col_data, size_t string_size, size_t& left_blanks, size_t& right_blanks) const;
     void addHeader(const HeaderData& header);
-    void appendToOutput(std::string& output, const ColumnData& column, const std::string& data);
+    void appendToOutput(std::string& output, const ColumnData& column, const std::string& data) const;
 
  public:
     friend std::ostream&
-    operator<<(std::ostream& os, Table2D& table)
+    operator<<(std::ostream& os, const Table2D& table)
     {
         return table.print(os);
     };

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -251,13 +251,13 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         // proceed even if the platform name is not available
         platform = "<not defined>";
       }
-      std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
+      const std::string dev_desc = (boost::format("%d/%d [%s] : %s\n") % ++dev_idx % devices.size() % ptDevice.get<std::string>("device_id") % platform).str();
       consoleStream << std::endl;
       consoleStream << std::string(dev_desc.length(), '-') << std::endl;
       consoleStream << dev_desc;
       consoleStream << std::string(dev_desc.length(), '-') << std::endl;
 
-      auto is_ready = xrt_core::device_query<xrt_core::query::is_ready>(device);
+      const auto is_ready = xrt_core::device_query<xrt_core::query::is_ready>(device);
       bool is_recovery = false;
       try {
         is_recovery = xrt_core::device_query<xrt_core::query::is_recovery>(device);
@@ -266,21 +266,25 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
         is_recovery = false;
       }
 
+      // Process the tests that require a device
+      // If the device is either of the following, most tests cannot be completed fully:
+      // 1. Is in factory mode and is not in recovery mode
+      // 2. Is not ready and is not in recovery mode
+      if((is_mfg || !is_ready) && !is_recovery) {
+        std::cerr << "Error: Device is not ready - Limited functionality available with XRT tools.\n\n";
+        is_report_output_valid = false;
+      }
+
       for (auto &report : reportsToProcess) {
         if (report->isDeviceRequired() == false)
           continue;
-        //if the device is either of the following, continue to create reports:
-        // 1. not in factory mode and is ready to use
-        // 2. is in recovery mode
-        if((!is_mfg && !is_ready) && !is_recovery)
-          continue;
+
         boost::property_tree::ptree ptReport;
         try {
           report->getFormattedReport(device.get(), schemaVersion, elementFilter, consoleStream, ptReport);
         } catch (const std::exception&) {
           is_report_output_valid = false;
         }
-        
 
         // Only support 1 node on the root
         if (ptReport.size() > 1)
@@ -288,9 +292,8 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
 
         // We have 1 node, copy the child to the root property tree
         if (ptReport.size() == 1) {
-          for (const auto & ptChild : ptReport) {
+          for (const auto & ptChild : ptReport)
             ptDevice.add_child(ptChild.first, ptChild.second);
-          }
         }
       }
       if (!ptDevice.empty()) 

--- a/src/runtime_src/core/tools/common/XBHelpMenus.cpp
+++ b/src/runtime_src/core/tools/common/XBHelpMenus.cpp
@@ -271,12 +271,11 @@ XBUtilities::produce_reports( xrt_core::device_collection devices,
       // 1. Is in factory mode and is not in recovery mode
       // 2. Is not ready and is not in recovery mode
       if((is_mfg || !is_ready) && !is_recovery) {
-        std::cerr << "Error: Device is not ready - Limited functionality available with XRT tools.\n\n";
-        is_report_output_valid = false;
+        std::cout << "Warning: Device is not ready - Limited functionality available with XRT tools.\n\n";
       }
 
       for (auto &report : reportsToProcess) {
-        if (report->isDeviceRequired() == false)
+        if (!report->isDeviceRequired())
           continue;
 
         boost::property_tree::ptree ptReport;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1119346
In some situations, the previous shell pkgs are removed from the host or updated to a new version or there are many other older shells matching this card. With xbmgmt1 will can see all these info, but with xbmgmt2, only see part of that. See step to reproduce.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
 When a card goes in a not usable state, xbutil/xbmgmt don't function properly

#### How problem was solved, alternative solutions (if any) and why they were rejected
Have xbutil/xbmgmt produce additional warning messages

#### Risks (if any) associated the changes in the commit
None, this is adding additional output text using existing sysfs nodes. Some internal logic was changed to no longer skip tests and instead display a warning message if the card is not ready.

#### What has been tested and how, request additional testing if necessary
Needs additional testing with a card that has a recoverable image, to be added soon!
u250 with golden image for all reports:
```

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -d 17:00 -r all
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1119346
  Hash                 : 454cc2aaefe4fa24f14ebe47cd70611fe665d559
  Hash Date            : 2022-03-16 14:40:13
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID         Device Ready*
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)  Yes
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a               No

* Devices that are not ready will have reduced functionality when using XRT tools

----------------------------------------
1/1 [0000:17:00.0] : xilinx_u250_GOLDEN
----------------------------------------
Warning: Device is not ready - Limited functionality available with XRT tools.

Flash properties
  Type                 : spi
  Serial Number        : N/A

Device properties
  Type                 : u250
  Name                 : N/A
  Config Mode          : 3977770208
  Max Power            : N/A

Flashable partitions running on FPGA
  Platform             : xilinx_u250_GOLDEN_5
  SC Version           : INACTIVE
  Platform ID          : N/A

Flashable partitions installed in system
  <none found>

WARNING  : No shell is installed on the system.

Mechanical
  Fans
    Not present

Firewall
  Level -- --: -- --

Mailbox
  ERROR: Failed to find subdirectory for mailbox under /sys/bus/pci/devices/0000:17:00.0

CMC
Vmr Status
  Information Unavailable
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
1
```
u250 with golden image for only device reports:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt examine -d 17:00

----------------------------------------
1/1 [0000:17:00.0] : xilinx_u250_GOLDEN
----------------------------------------
Warning: Device is not ready - Limited functionality available with XRT tools.

Flash properties
  Type                 : spi
  Serial Number        : N/A

Device properties
  Type                 : u250
  Name                 : N/A
  Config Mode          : 2766119200
  Max Power            : N/A

Flashable partitions running on FPGA
  Platform             : xilinx_u250_GOLDEN_5
  SC Version           : INACTIVE
  Platform ID          : N/A

Flashable partitions installed in system
  <none found>

WARNING  : No shell is installed on the system.

dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ echo $?
0
```
u280 with valid image for all reports:
```
root@xsjpranjal01:~# xbmgmt examine -d 65:00 -r all
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1119346
  Hash                 : 454cc2aaefe4fa24f14ebe47cd70611fe665d559
  Hash Date            : 2022-03-16 14:40:13
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID         Device Ready*
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)  Yes
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a               No

* Devices that are not ready will have reduced functionality when using XRT tools

-----------------------------------------------
1/1 [0000:65:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : 21760394400G

Device properties
  Type                 : N/A
  Name                 : ALVEO U280 PQ
  Config Mode          : 7
  Max Power            : 225W

Flashable partitions running on FPGA
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820

Flashable partitions installed in system
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820


  Mac Address          : 01:02:03:04:05:06
                       : 01:02:03:04:05:07


Mechanical
  Fans
    FPGA Fan 1
      Critical Trigger Temp : 44 C
      Speed                 : 1328 RPM

Firewall
  Level 0 : 0x0 (GOOD)

Mailbox
  Total bytes received   : 1185664 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 2
  Firewall trip          : 0
  Download xclbin kaddr  : 2
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 9260
  User probe             : 2
  Mgmt state             : 0
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0
                         : 0

CMC
  Status : 0x0 (GOOD)
  Runtime clock scaling feature :
    Supported : false
    Enabled : false
    Critical threshold (clock shutdown) limits:
      Power : 0 W
      Temperature : 0 C
    Throttling threshold limits:
      Power : 0 W
      Temperature : 0 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
Vmr Status
  Information Unavailable
root@xsjpranjal01:~# echo $?
0
```
u280 with valid image device only:
```
root@xsjpranjal01:~# xbmgmt examine -d 65:00

-----------------------------------------------
1/1 [0000:65:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : 21760394400G

Device properties
  Type                 : N/A
  Name                 : ALVEO U280 PQ
  Config Mode          : 7
  Max Power            : 225W

Flashable partitions running on FPGA
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820

Flashable partitions installed in system
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820


  Mac Address          : 01:02:03:04:05:06
                       : 01:02:03:04:05:07


root@xsjpranjal01:~# echo $?
0
```
#### Documentation impact (if any)
It might be good to document the device golden/recovery caveat somewhere in the documentation. Not sure where though, suggestions are welcome!