### PR TITLE
Workaround: limit versal to use 2 DMA channels

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -473,6 +473,11 @@ static int xdma_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
+	if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
+		xocl_info(&pdev->dev, "VERSAL ES3, set to 2 channels");
+		xdma->channel = 2;
+	}
+
 	xdma->dma_handle = xdma_device_open(XOCL_MODULE_NAME, XDEV(xdev)->pdev,
 			&xdma->max_user_intr,
 			&xdma->channel, &xdma->channel, false);
@@ -481,11 +486,6 @@ static int xdma_probe(struct platform_device *pdev)
 		ret = -EIO;
 		goto failed;
 	}
-	if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
-		xocl_info(&pdev->dev, "VERSAL ES3, set to 2 channels");
-		xdma->channel = 2;
-	}
-
 	xdma->user_msix_table = devm_kzalloc(&pdev->dev,
 			xdma->max_user_intr *
 			sizeof(struct xdma_irq), GFP_KERNEL);

--- a/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/xocl_subdev.c
@@ -1791,6 +1791,10 @@ void xocl_fill_dsa_priv(xdev_handle_t xdev_hdl, struct xocl_board_private *in)
 				ptype);
 		xocl_fetch_dynamic_platform(core, &in, ptype);
 		vsec = true;
+	} else if (ret == -ENOENT) {
+		/* VSEC is found but PLATFORM_INFO does not exist. (versal) */
+		xocl_fetch_dynamic_platform(core, &in, -1);
+		vsec = true;
 	}
 		
 	/* workaround firewall completer abort issue */


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
On versal platform, there are 4 XDMA channels. It seems only the first 2 are stable. This commit to disable the last 2 channels.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
[CR-1121139](https://jira.xilinx.com/browse/CR-1121139)
#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
