### PR TITLE
Support flat platform xclbin programming from userspace in edge

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -41,6 +41,7 @@
 #include <cassert>
 #include <cstdarg>
 #include <boost/filesystem.hpp>
+#include <regex>
 
 #include <fcntl.h>
 #include <poll.h>

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -122,10 +122,19 @@ shim(unsigned index)
   xclLog(XRT_INFO, "%s", __func__);
 
   const std::string zocl_drm_device = "/dev/dri/" + get_render_devname();
-  mKernelFD = open(zocl_drm_device.c_str(), O_RDWR);
-  if (mKernelFD < 0) {
-    xclLog(XRT_ERROR, "%s: Cannot open %s", __func__,zocl_drm_device);
+  if (boost::filesystem::exists(zocl_drm_device)) {
+    mKernelFD = open(zocl_drm_device.c_str(), O_RDWR);
+    if (mKernelFD < 0)
+      xclLog(XRT_ERROR, "%s: Cannot open %s", __func__,zocl_drm_device);
   }
+  /*
+   * Zocl node is not present in some platforms static dtb, it gets loaded
+   * using overlay dtb, drm device node is not created until zocl is present
+   * So if enable_flat=true return 1 valid device
+   */
+  else if (!xrt_core::config::get_enable_flat())
+    xclLog(XRT_ERROR, "%s: File '%s' does not exist", __func__,zocl_drm_device);
+
   mCmdBOCache = std::make_unique<xrt_core::bo_cache>(this, xrt_core::config::get_cmdbo_cache());
   mDev = zynq_device::get_dev();
 }
@@ -514,9 +523,15 @@ libdfxHelper(std::shared_ptr<xrt_core::device> core_dev, std::string& dtbo_path,
   uint32_t slot_id = 0;
   static const std::string dtbo_dir_path = "/configfs/device-tree/overlays/";
 
-  // get dtbo_path of slot '0' for now, in future when we support multi slot we need
-  // info about which slot this xclbin needs to be loaded
-  // TODO: read slot id from xclbin or get it as an arg to this function
+  // root privileges are needed for loading and unloading dtbo and bitstream
+  if (getuid() && geteuid())
+    throw std::runtime_error("Root privileges required");
+
+  /*
+   * get dtbo_path of slot '0' for now, in future when we support multi slot we need
+   * info about which slot this xclbin needs to be loaded
+   * TODO: read slot id from xclbin or get it as an arg to this function
+   */
   try {
     dtbo_path = xrt_core::device_query<xrt_core::query::dtbo_path>(core_dev, slot_id);
   }
@@ -530,6 +545,18 @@ libdfxHelper(std::shared_ptr<xrt_core::device> core_dev, std::string& dtbo_path,
     dtbo_path.clear();
     // close drm fd as zocl driver will be reloaded
     close(fd);
+  }
+  else {
+    // bitstream is loaded for first time
+    boost::filesystem::directory_iterator end_itr;
+    static const std::regex filter{".*_image_[0-9]+"};
+    for (boost::filesystem::directory_iterator itr( dtbo_dir_path ); itr != end_itr; ++itr) {
+      if (!std::regex_match(itr->path().filename().string(), filter))
+        continue;
+
+      // remove existing libdfx node loaded by libdfx daemon
+      rmdir((dtbo_dir_path + itr->path().filename().string()).c_str());
+    }
   }
 }
 
@@ -662,33 +689,20 @@ xclLoadAxlf(const axlf *buffer)
   int off = 0;
   std::string dtbo_path("");
 
-  /*
-   * If platform is a non-PR-platform, Following check will fail. Dont download
-   * the partial bitstream
-   *
-   * If Platform is a PR-platform, Following check passes as enable_pr value is
-   * true by default. Download the partial bitstream.
-   *
-   * If platform is a PR-platform, but v++ generated a full bitstream (using
-   * some v++ param).  User need to add enable_pr=false in xrt.ini.
-   */
 #ifndef __HWEM__
   auto is_pr_platform = (buffer->m_header.m_mode == XCLBIN_PR ) ? true : false;
-  auto is_flat_platform = (buffer->m_header.m_mode == XCLBIN_FLAT ) ? true : false;
-  auto is_pr_enabled = xrt_core::config::get_enable_pr(); //default value is true
   auto is_flat_enabled = xrt_core::config::get_enable_flat(); //default value is false
   auto force_program = xrt_core::config::get_force_program_xclbin(); //default value is false
+  auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
 
-  if (is_pr_platform && is_pr_enabled)
+  if (is_pr_platform)
     flags = DRM_ZOCL_PLATFORM_PR;
   /*
-   * If platform is a PR-platform, Following check will fail. Dont download the
-   * full bitstream
-   *
-   * If its non-PR-platform and enable_flat=true in xrt.ini. Download the full
-   * bitstream.
+   * If its non-PR-platform and enable_flat=true in xrt.ini, download the full
+   * bitstream. But if OVERLAY section is present in xclbin, userspace apis are
+   * used to download full bitstream
    */
-  else if (is_flat_platform && is_flat_enabled)
+  else if (is_flat_enabled && !overlay_header)
     flags = DRM_ZOCL_PLATFORM_FLAT;
 
   if (force_program) {
@@ -696,9 +710,7 @@ xclLoadAxlf(const axlf *buffer)
   }
 
 #if defined(XRT_ENABLE_LIBDFX)
-  // check OVERLAY section
-  // if present use libdfx apis to load bitstream and dtbo(overlay)
-  auto overlay_header = xclbin::get_axlf_section(buffer, axlf_section_kind::OVERLAY);
+  // if OVERLAY section is present use libdfx apis to load bitstream and dtbo(overlay)
   if(overlay_header) {
     try {
       // if xclbin is already loaded ret val is '1', dont call ioctl in this case
@@ -1728,10 +1740,20 @@ xclProbe()
   return xdp::hal::profiling_wrapper("xclProbe", [] {
 
   const std::string zocl_drm_device = "/dev/dri/" + get_render_devname();
-  int fd = open(zocl_drm_device.c_str(), O_RDWR);
-  if (fd < 0) {
-    return 0;
+  int fd;
+  if (boost::filesystem::exists(zocl_drm_device)) {
+    fd = open(zocl_drm_device.c_str(), O_RDWR);
+    if (fd < 0)
+      return 0;
   }
+  /*
+   * Zocl node is not present in some platforms static dtb, it gets loaded
+   * using overlay dtb, drm device node is not created until zocl is present
+   * So if enable_flat is set return 1 valid device
+   */
+  else if (xrt_core::config::get_enable_flat())
+    return 1;
+
   std::vector<char> name(128,0);
   std::vector<char> desc(512,0);
   std::vector<char> date(128,0);

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -115,7 +115,7 @@ public:
   int xclCloseIPInterruptNotify(int fd);
 
   bool isGood() const;
-  static shim *handleCheck(void *handle);
+  static shim *handleCheck(void *handle, bool checkDrmFd = true);
   int xclIPName2Index(const char *name);
 
   // Application debug path functionality for xbutil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
> Platforms without zocl node in static dtb cannot be programmed using current flow
> In such platforms zocl will be loaded using overlay(dtbo), DRM fd is not created yet in such case
> When enable_flat ini option is set, added changes to not check DRM fd and continue program operation from userspace

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Discovered in SOM platforms as they dont have zocl in static dtb, but is present in overlay(dtbo)

#### How problem was solved, alternative solutions (if any) and why they were rejected
When enable_flat ini option is set, xclLoadxclbin api doesnot check drm fd

#### Risks (if any) associated the changes in the commit
None as this code is under xrt ini option

#### What has been tested and how, request additional testing if necessary
Tested by programming bitstream on SOM platforms as well as other Vitis embedded platforms

#### Documentation impact (if any)
None