### PR TITLE
fixed xbmgmt configure daemon functionality & added missing -purge option 

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -245,9 +245,9 @@ remove_daemon_config()
      */
     bool is_removed = std::filesystem::remove(config_file);
     if(is_removed)
-      std::cout << boost::format("INFO: Daemon configuration file is removed successfully\n");
+      std::cout << boost::format("Succesfully removed the Daemon configuration file.\n");
     else
-      std::cout << boost::format("WARNING: Daemon configuration file does not exist\n");
+      std::cout << boost::format("WARNING: Daemon configuration file does not exist.\n");
 
   } catch (std::filesystem::filesystem_error &e) {
       std::cerr << boost::format("ERROR: %s\n") % e.what();
@@ -270,10 +270,9 @@ update_daemon_config(const std::string& host)
     throw xrt_core::system_error(std::errc::invalid_argument, "Missing '" + std::string(config_file) + "'.  Cannot update");
 
   cfg.host = host;
-  std::cout << boost::str(boost::format("%s\n") % cfg);
   // update the configuration file
   cfile << boost::str(boost::format("%s\n") % cfg);
-  std::cout << boost::format("INFO: Daemon configuration is updated successfully\n");
+  std::cout << boost::format("Successfully updated the Daemon configuration.\n");
 }
 
 /*

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -241,13 +241,12 @@ remove_daemon_config()
     throw xrt_core::error(std::errc::operation_canceled);
 
   try {
-    bool is_removed = boost::filesystem::remove(config_file);
-    if(is_removed)
+    if (boost::filesystem::remove(config_file))
       std::cout << boost::format("Succesfully removed the Daemon configuration file.\n");
     else
       std::cout << boost::format("WARNING: Daemon configuration file does not exist.\n");
 
-  } catch (boost::filesystem::filesystem_error &e) {
+  } catch (const boost::filesystem::filesystem_error &e) {
       std::cerr << boost::format("ERROR: %s\n") % e.what();
       throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -243,6 +243,8 @@ update_daemon_config(const std::string& host)
 
   cfg.host = host;
   std::cout << boost::str(boost::format("%s\n") % cfg);
+  // update the configuration file
+  cfile << boost::str(boost::format("%s\n") % cfg);
 }
 
 /*

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -32,7 +32,6 @@ namespace po = boost::program_options;
 
 // System - Include Files
 #include <iostream>
-#include <filesystem>
 
 constexpr const char* config_file  = "/etc/msd.conf";
 
@@ -238,18 +237,18 @@ remove_daemon_config()
   XBU::sudo_or_throw("Removing daemon configuration file requires sudo");
   try {
     /* 
-     * std::filesyste::remove function returns 
+     * boost::filesystem::remove function returns 
      * True  : if file is removed succesfully
-     * False : if file is not available
+     * False : if file does not exist
      * Throws an exception if there are some other errors 
      */
-    bool is_removed = std::filesystem::remove(config_file);
+    bool is_removed = boost::filesystem::remove(config_file);
     if(is_removed)
       std::cout << boost::format("Succesfully removed the Daemon configuration file.\n");
     else
       std::cout << boost::format("WARNING: Daemon configuration file does not exist.\n");
 
-  } catch (std::filesystem::filesystem_error &e) {
+  } catch (boost::filesystem::filesystem_error &e) {
       std::cerr << boost::format("ERROR: %s\n") % e.what();
       throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -234,14 +234,13 @@ show_device_conf(xrt_core::device* device)
 static void 
 remove_daemon_config()
 {
-  XBU::sudo_or_throw("Removing daemon configuration file requires sudo");
+  XBU::sudo_or_throw("Removing Daemon configuration file requires sudo");
+  
+  std::cout << boost::format("Removing Daemon configuration file \"%s\"\n") % config_file;
+  if(!XBU::can_proceed(XBU::getForce()))
+    throw xrt_core::error(std::errc::operation_canceled);
+
   try {
-    /* 
-     * boost::filesystem::remove function returns 
-     * True  : if file is removed succesfully
-     * False : if file does not exist
-     * Throws an exception if there are some other errors 
-     */
     bool is_removed = boost::filesystem::remove(config_file);
     if(is_removed)
       std::cout << boost::format("Succesfully removed the Daemon configuration file.\n");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -245,7 +245,6 @@ remove_daemon_config()
       std::cout << boost::format("Succesfully removed the Daemon configuration file.\n");
     else
       std::cout << boost::format("WARNING: Daemon configuration file does not exist.\n");
-
   } catch (const boost::filesystem::filesystem_error &e) {
       std::cerr << boost::format("ERROR: %s\n") % e.what();
       throw xrt_core::error(std::errc::operation_canceled);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbmgmt configure --daemon --host <> is not updating the daemon configuration file. Fixing that issue
Added missing -purge option which deletes the daemon configuration file

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://github.com/Xilinx/XRT/pull/6288

#### How problem was solved, alternative solutions (if any) and why they were rejected
Writing to config file while configuring & removing file in a new option(-purge)

#### Risks (if any) associated the changes in the commit
No

#### What has been tested and how, request additional testing if necessary
Verified
verified the file content 
```
root@localhost build]# xbmgmt configure --daemon --host 172.23.80.113 -d 
Successfully updated the Daemon configuration.

[root@localhost build]# xbmgmt configure --purge -d 
Removing Daemon configuration file "/etc/msd.conf"
Are you sure you wish to proceed? [Y/n]: Y
Succesfully removed the Daemon configuration file.

[root@localhost build]# xbmgmt configure --daemon --host 172.23.80.113 -d 
Successfully updated the Daemon configuration.

[root@localhost build]# xbmgmt configure --purge -d --force
Removing Daemon configuration file "/etc/msd.conf"
Are you sure you wish to proceed? [Y/n]: Y (Force override)
Succesfully removed the Daemon configuration file.

[root@localhost build]# xbmgmt configure --purge -d 
Removing Daemon configuration file "/etc/msd.conf"
Are you sure you wish to proceed? [Y/n]: Y
WARNING: Daemon configuration file does not exist.

```
#### Documentation impact (if any)
NA. This is a hidden option
