### PR TITLE
CR-1125922: Made sure warning pops up when erroneous aie_trace_start_time is added

### DIFF
--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -448,6 +448,9 @@ namespace xdp {
         std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
       }
+    }else{  
+      std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
     }
 
     if (cycles > max_cycles) {

--- a/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/aie_trace/aie_trace_plugin.cpp
@@ -448,7 +448,7 @@ namespace xdp {
         std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
         xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
       }
-    }else{  
+    } else {  
       std::string msg("Unable to parse aie_trace_start_time. Setting start time to 0.");
       xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
     }


### PR DESCRIPTION
Added warning in case Regex cannot match start_time string at all. 
