### PR TITLE
setting versal DMA channel number should be after xdma_open

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xdma.c
@@ -473,11 +473,6 @@ static int xdma_probe(struct platform_device *pdev)
 		goto failed;
 	}
 
-	if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
-		xocl_info(&pdev->dev, "VERSAL ES3, set to 2 channels");
-		xdma->channel = 2;
-	}
-
 	xdma->dma_handle = xdma_device_open(XOCL_MODULE_NAME, XDEV(xdev)->pdev,
 			&xdma->max_user_intr,
 			&xdma->channel, &xdma->channel, false);
@@ -486,6 +481,12 @@ static int xdma_probe(struct platform_device *pdev)
 		ret = -EIO;
 		goto failed;
 	}
+
+	if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
+		xocl_info(&pdev->dev, "VERSAL ES3, set to 2 channels");
+		xdma->channel = 2;
+	}
+
 	xdma->user_msix_table = devm_kzalloc(&pdev->dev,
 			xdma->max_user_intr *
 			sizeof(struct xdma_irq), GFP_KERNEL);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
a workaround was introduced to set dma channel number as 2 for versal. But the setting before xdma_open will mess up interrupt allocation, so the setting should still be after xdma_open.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
