### PR TITLE
CR-1125976 ASTeR TC 17.06/07 - vck5000 - flash fails after a previous…

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/subdev/xgq.c
@@ -746,10 +746,10 @@ static ssize_t xgq_transfer_data(struct xocl_xgq_vmr *xgq, const void *buf,
 	}
 	hdr->cid = id;
 
-	/* init condition veriable */
+	/* init condition variable */
 	init_completion(&cmd->xgq_cmd_complete);
 
-	/* set timout actual jiffies */
+	/* set timeout actual jiffies */
 	cmd->xgq_cmd_timeout_jiffies = jiffies + timer;
 
 	if (submit_cmd(xgq, cmd)) {
@@ -757,11 +757,11 @@ static ssize_t xgq_transfer_data(struct xocl_xgq_vmr *xgq, const void *buf,
 		goto done;
 	}
 
-	/* wait for command completion */
-	if (wait_for_completion_killable(&cmd->xgq_cmd_complete)) {
-		XGQ_ERR(xgq, "submitted cmd killed");
-		xgq_submitted_cmd_remove(xgq, cmd);
-	}
+	/*
+	 * For pdi/xclbin data transfer, we block any cancellation and
+	 * wait till command completed and then release resources safely.
+	 */
+	wait_for_completion(&cmd->xgq_cmd_complete);
 
 	/* If return is 0, we set length as return value */
 	if (cmd->xgq_cmd_rcode) {


### PR DESCRIPTION
… flash is interrupted with SIGINT or SIGKILL

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

Discussed this with lizhi, the best way to preventing ctrl+c is to block it so that the flash will continue till finish.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
