### PR TITLE
CR-1123956: Debug page commands fix (from legacy to new command)

### DIFF
--- a/src/runtime_src/doc/toc/debug-faq.rst
+++ b/src/runtime_src/doc/toc/debug-faq.rst
@@ -105,7 +105,7 @@ Platform Bugs
 
 Bitsream Download Failures
   Bitstream download failures are usually
-  caused because of incompatible ``xclbin``\ s. ``dmesg`` log would
+  caused because of incompatible xclbin(s). ``dmesg`` log would
   provide more insight into why the download failed. At OpenCL level
   they usually manifest as Invalid Binary (error -44).
 


### PR DESCRIPTION

#### Problem solved by the commit

The debug-faq document was still referring to old commands, hence fixed to new commands. 

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

CR-1123956


#### Risks (if any) associated the changes in the commit

None
