### PR TITLE
CR-1111561 platform meta data not written to flash with new commands

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -225,6 +225,7 @@ enum class key_type
   is_offline,
   f_flash_type,
   flash_type,
+  flash_size,
   board_name,
   interface_uuids,
   logic_uuids,
@@ -2521,6 +2522,15 @@ struct flash_type : request
   {
     return value;
   }
+};
+
+struct flash_size : request
+{
+  using result_type = uint64_t;
+  static const key_type key = key_type::flash_size;
+
+  virtual boost::any
+  get(const device*) const = 0;
 };
 
 struct board_name : request

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -982,6 +982,7 @@ initialize_query_table()
   emplace_sysfs_get<query::is_offline>                         ("", "dev_offline");
   emplace_sysfs_get<query::f_flash_type>                       ("flash", "flash_type");
   emplace_sysfs_get<query::flash_type>                         ("", "flash_type");
+  emplace_sysfs_get<query::flash_size>                         ("flash", "size");
   emplace_sysfs_get<query::board_name>                         ("", "board_name");
   emplace_sysfs_get<query::logic_uuids>                        ("", "logic_uuids");
   emplace_sysfs_get<query::interface_uuids>                    ("", "interface_uuids");

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -92,18 +92,22 @@ update_shell(unsigned int index, std::map<std::string, std::string>& image_paths
     throw xrt_core::error("No image specified.\n Usage: xbmgmt program --device='0000:00:00.0' --base [all|sc|shell]"
                             " --image=['/path/to/flash_image'|'shell name']");
 
-  auto pri = std::make_unique<firmwareImage>(image_paths["primary"].c_str(), MCS_FIRMWARE_PRIMARY);
+  auto pri = std::make_unique<firmwareImage>(image_paths["primary"], MCS_FIRMWARE_PRIMARY);
   if (pri->fail())
     throw xrt_core::error(boost::str(boost::format("Failed to read %s") % image_paths["primary"]));
 
+  auto stripped = std::make_unique<firmwareImage>(image_paths["primary"], STRIPPED_FIRMWARE);
+  if (stripped->fail())
+    stripped = nullptr;
+
   std::unique_ptr<firmwareImage> sec;
   if (image_paths.size() > 1) {
-    sec = std::make_unique<firmwareImage>(image_paths["secondary"].c_str(), MCS_FIRMWARE_SECONDARY);
+    sec = std::make_unique<firmwareImage>(image_paths["secondary"], MCS_FIRMWARE_SECONDARY);
     if (sec->fail())
       throw xrt_core::error(boost::str(boost::format("Failed to read %s") % image_paths["secondary"]));
   }
   
-  if (flasher.upgradeFirmware(flash_type, pri.get(), sec.get()) != 0)
+  if (flasher.upgradeFirmware(flash_type, pri.get(), sec.get(), stripped.get()) != 0)
     throw xrt_core::error("Failed to update base");
   
   std::cout << boost::format("%-8s : %s \n") % "INFO" % "Base flash image has been programmed successfully.";
@@ -146,7 +150,7 @@ update_SC(unsigned int  index, const std::string& file)
   //if factory image, update SC
   auto is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(dev);
   if (is_mfg) {
-    std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file.c_str(), BMC_FIRMWARE);
+    std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file, BMC_FIRMWARE);
     if (bmc->fail())
       throw xrt_core::error(boost::str(boost::format("Failed to read %s") % file));
 
@@ -186,7 +190,7 @@ update_SC(unsigned int  index, const std::string& file)
     throw xrt_core::error("Only proceed with SC update if all user applications for the target card(s) are stopped.");
 #endif
 
-  std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file.c_str(), BMC_FIRMWARE);
+  std::unique_ptr<firmwareImage> bmc = std::make_unique<firmwareImage>(file, BMC_FIRMWARE);
 
   if (bmc->fail())
     throw xrt_core::error(boost::str(boost::format("Failed to read %s") % file));
@@ -938,7 +942,7 @@ SubCmdProgram::execute(const SubCmdOptions& _options) const
       throw xrt_core::error(std::errc::operation_canceled);
     
     for (auto& f : flasher_list) {
-      if (!f.upgradeFirmware(flash_type, nullptr, nullptr)) {
+      if (!f.upgradeFirmware(flash_type, nullptr, nullptr, nullptr)) {
         std::cout << boost::format("%-8s : %s %s %s\n") % "INFO" % "Shell on [" % f.sGetDBDF() % "]"
                                    " is reset successfully.";
         has_reset = true;

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.cpp
@@ -459,7 +459,106 @@ std::ostream& operator<<(std::ostream& stream, const DSAInfo& dsa)
     return stream;
 }
 
-firmwareImage::firmwareImage(const char *file, imageType type) :
+static void 
+remove_xsabin_mirror(void * xsabin_buffer)
+{
+  static const std::string mirror_data_start = "XCLBIN_MIRROR_DATA_START";
+  static const std::string mirror_data_end = "XCLBIN_MIRROR_DATA_END";
+
+  axlf *axlf_header = reinterpret_cast<struct axlf *>(xsabin_buffer);
+  uint64_t bufferSize = axlf_header->m_header.m_length;
+
+  std::stringstream strm;
+  strm << xsabin_buffer;
+  std::string str_xsabin_buffer = strm.str();
+
+  auto start_offset = str_xsabin_buffer.find(mirror_data_start);
+  if (start_offset == std::string::npos)
+    return; // No MIRROR DATA
+
+  auto end_offset = str_xsabin_buffer.find(mirror_data_end);
+  if (end_offset == std::string::npos)
+    return; // Badly formed mirror data (we have a start, but no end)
+
+  if (end_offset <= start_offset)
+    return;   // Tags are in the wrong order
+
+  // Zero out memory (not really needed but done for completeness)
+  uint64_t bytesRemoved = end_offset - start_offset;
+  std::memset(reinterpret_cast<unsigned char *>(xsabin_buffer) + start_offset, 0, bytesRemoved);
+
+  // Compress the image
+  uint64_t bytesToCopy = bufferSize - end_offset;
+  if (bytesToCopy != 0) 
+    std::memcpy(reinterpret_cast<unsigned char *>(xsabin_buffer) + start_offset, reinterpret_cast<unsigned char *>(xsabin_buffer) + end_offset, bytesToCopy);
+
+  // Update length of the buffer
+  axlf_header->m_header.m_length = bufferSize - bytesRemoved;
+}
+
+static void 
+remove_xsabin_section(void * xsabin_buffer, enum axlf_section_kind section_to_remove)
+{
+  // Simple DRC check
+  if (xsabin_buffer == nullptr)
+    throw std::runtime_error("ERROR: Buffer pointer is a nullptr.");
+  axlf *axlf_header = reinterpret_cast<struct axlf *>(xsabin_buffer);
+
+  // This loop does need to re-evaluate the m_numSections for it will be 
+  // reduced as sections are removed.  In addition, we need to start again from
+  // the start for there could be multiple sections of the same type that
+  // need to be removed.
+  for (uint64_t index = 0; index < axlf_header->m_header.m_numSections; ++index) {
+    axlf_section_header *sectionHeaderArray = &axlf_header->m_sections[0];
+    // Is this a section of interest, if not then go to the next section
+    if (sectionHeaderArray[index].m_sectionKind != section_to_remove)
+      continue;
+    // Record the buffer size
+    uint64_t bufferSize = axlf_header->m_header.m_length;
+
+    // Determine the data to be removed.
+    uint64_t startToOffset = sectionHeaderArray[index].m_sectionOffset;
+    uint64_t startFromOffset = ((index + 1) == axlf_header->m_header.m_numSections) ?
+                                sectionHeaderArray[index].m_sectionOffset + sectionHeaderArray[index].m_sectionSize:
+                                sectionHeaderArray[index + 1].m_sectionOffset;
+    uint64_t bytesToCopy = bufferSize - startFromOffset;
+    uint64_t bytesRemoved = startFromOffset - startToOffset;
+
+    if (bytesToCopy != 0) {
+      std::memcpy(reinterpret_cast<unsigned char *>(xsabin_buffer) + startToOffset, 
+                    reinterpret_cast<unsigned char *>(xsabin_buffer) + startFromOffset, bytesToCopy);
+    }
+    // -- Now do some incremental clean up of the data structures
+    // Update the length and offsets AFTER this entry
+    axlf_header->m_header.m_length -= bytesRemoved;
+    for (uint64_t idx = index + 1; idx < axlf_header->m_header.m_numSections; ++idx) {
+      sectionHeaderArray[idx].m_sectionOffset -= bytesRemoved;
+    }
+    // Are we removing the last section.  If so just update the count and leave
+    if (axlf_header->m_header.m_numSections == 1) {
+      axlf_header->m_header.m_numSections = 0;
+      sectionHeaderArray[0].m_sectionKind = 0;
+      sectionHeaderArray[0].m_sectionOffset = 0;
+      sectionHeaderArray[0].m_sectionSize = 0;
+      continue;
+    }
+    // Remove the array entry
+    void * ptrStartTo = &sectionHeaderArray[index];
+    void * ptrStartFrom = &sectionHeaderArray[index+1];
+    uint64_t bytesToShift = axlf_header->m_header.m_length - 
+                            (reinterpret_cast<unsigned char *>(ptrStartFrom) - reinterpret_cast<unsigned char *>(xsabin_buffer));
+    std::memcpy(reinterpret_cast<unsigned char *>(ptrStartTo), reinterpret_cast<unsigned char *>(ptrStartFrom), bytesToShift);
+
+    // Update data elements
+    axlf_header->m_header.m_numSections -= 1;
+    axlf_header->m_header.m_length -= sizeof(axlf_section_header);
+    for (uint64_t idx = 0; idx < axlf_header->m_header.m_numSections; ++idx) {
+      sectionHeaderArray[idx].m_sectionOffset -= sizeof(axlf_section_header);
+    }
+  }
+}
+
+firmwareImage::firmwareImage(const std::string& file, imageType type) :
     mType(type), mBuf(nullptr)
 {
     std::ifstream in_file(file, std::ios::binary | std::ios::ate);
@@ -531,6 +630,28 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
             mBuf = new char[bufsize];
             in_file.seekg(bmcSection->m_sectionOffset + bmc->m_offset);
             in_file.read(mBuf, bufsize);
+        }
+        else if (type == STRIPPED_FIRMWARE)
+        {
+            std::vector<char> full(ap->m_header.m_length);
+            const axlf *fp = reinterpret_cast<const axlf *>(full.data());
+            try {
+                in_file.seekg(0);
+                in_file.read(full.data(), full.size());
+                remove_xsabin_section(full.data(), ASK_FLASH);
+                remove_xsabin_section(full.data(), PDI);
+                remove_xsabin_section(full.data(), MCS);
+                remove_xsabin_mirror(full.data());
+            } catch (const std::exception &e) {
+                this->setstate(failbit);
+                std::cout << "failed to remove section from "<< file << ": "
+                    << e.what() << std::endl;
+                return;
+            }
+            // Load data into stream.
+            bufsize = fp->m_header.m_length;
+            mBuf = new char[bufsize];
+            std::memcpy(mBuf, full.data(), bufsize);
         }
         else
         {
@@ -631,6 +752,13 @@ firmwareImage::firmwareImage(const char *file, imageType type) :
     }
     else
     {
+        if (type != MCS_FIRMWARE_PRIMARY)
+        {
+            this->setstate(failbit);
+            std::cout << "non-dsabin supports only primary bitstream: "
+                << file << std::endl;
+            return;
+        }
         // For non-dsabin file, the entire file is the image.
         mBuf = new char[bufsize];
         in_file.seekg(0);

--- a/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/firmware_image.h
@@ -84,12 +84,13 @@ enum imageType
     BMC_FIRMWARE,
     MCS_FIRMWARE_PRIMARY,
     MCS_FIRMWARE_SECONDARY,
+    STRIPPED_FIRMWARE
 };
 
 class firmwareImage : public std::istringstream
 {
 public:
-    firmwareImage(const char *file, imageType type);
+    firmwareImage(const std::string& file, imageType type);
     ~firmwareImage();
     static std::vector<DSAInfo> getIntalledDSAs();
 private:

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -97,7 +97,7 @@ Flasher::E_FlasherType Flasher::getFlashType(std::string typeStr)
  * upgradeFirmware
  */
 int Flasher::upgradeFirmware(E_FlasherType flash_type,
-    firmwareImage *primary, firmwareImage *secondary)
+    firmwareImage *primary, firmwareImage *secondary, firmwareImage* stripped)
 {
     int retVal = -EINVAL;
 
@@ -112,11 +112,11 @@ int Flasher::upgradeFirmware(E_FlasherType flash_type,
         }
         else if(secondary == nullptr)
         {
-            retVal = xspi.xclUpgradeFirmware1(*primary);
+            retVal = xspi.xclUpgradeFirmware1(*primary, *stripped);
         }
         else
         {
-            retVal = xspi.xclUpgradeFirmware2(*primary, *secondary);
+            retVal = xspi.xclUpgradeFirmware2(*primary, *secondary, *stripped);
         }
 
         // program icap controller for webstar flow. Required only for U.2

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.h
@@ -79,7 +79,7 @@ public:
 
     Flasher(unsigned int index);
     E_FlasherType getFlashType(std::string typeStr = "");
-    int upgradeFirmware(E_FlasherType flash_type, firmwareImage* primary, firmwareImage* secondary);
+    int upgradeFirmware(E_FlasherType flash_type, firmwareImage* primary, firmwareImage* secondary, firmwareImage* stripped);
     int upgradeBMCFirmware(firmwareImage* bmc);
     void readBack(const std::string& output);
     bool isValid(void) { return m_device != nullptr; }

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xspi.h
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xspi.h
@@ -42,8 +42,8 @@ class XSPI_Flasher
  public:
   XSPI_Flasher(std::shared_ptr<xrt_core::device> dev);
   ~XSPI_Flasher();
-  int xclUpgradeFirmware1(std::istream& mcsStream1);
-  int xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mcsStream2);
+  int xclUpgradeFirmware1(std::istream& mcsStream1, std::istream& stripped);
+  int xclUpgradeFirmware2(std::istream& mcsStream1, std::istream& mcsStream2, std::istream& stripped);
   int revertToMFG(void);
 
  private:
@@ -77,8 +77,11 @@ class XSPI_Flasher
   unsigned int getSector(unsigned int address);
 
   // Upgrade firmware via driver.
-  int upgradeFirmware1Drv(std::istream& mcsStream1);
-  int upgradeFirmware2Drv(std::istream& mcsStream1, std::istream& mcsStream2);
+  int upgradeFirmware1Drv(std::istream& mcsStream1, std::istream& stripped);
+  int upgradeFirmware2Drv(std::istream& mcsStream1, std::istream& mcsStream2, std::istream& stripped);
+
+  int xclReadData(std::vector<unsigned char>& data);
+  int xclWriteData(const std::vector<unsigned char>& data);
 };
 
 #endif


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
flash the shell through driver so that the metadata gets written on the device

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
This has been ported from xbmgmt1 and is needed for removing legacy tools support

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary
<to-be-added>

#### Documentation impact (if any)
None