### PR TITLE
CR-1119432 xbmgmt configure missing data printouts

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -407,6 +407,12 @@ SubCmdConfigure::execute(const SubCmdOptions& _options) const
 
     std::shared_ptr<xrt_core::device>& workingDevice = deviceCollection[0];
 
+    // If in factory mode the device is not ready for use
+    if (xrt_core::device_query<xrt_core::query::is_mfg>(workingDevice.get())) {
+      std::cout << boost::format("ERROR: Device is in factory mode and cannot be configured\n");
+      throw xrt_core::error(std::errc::operation_canceled);
+    }
+
     // Load Config commands
     // -- process "input" option -----------------------------------------------
     if (!path.empty()) {

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -183,8 +183,8 @@ show_device_conf(xrt_core::device* device)
   if (is_mfg || is_recovery)
     throw xrt_core::error(std::errc::operation_canceled, "This operation is not supported with manufacturing image.\n");
 
-  boost::format sysfs_format("  %-33s: %s\n");
-  const std::string not_supported = "Not supported";
+  boost::format node_data_format("  %-33s: %s\n");
+  std::string not_supported = "Not supported";
   std::string sec_level = not_supported;
   try {
     sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
@@ -192,7 +192,7 @@ show_device_conf(xrt_core::device* device)
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for vck5000 
   }
-  std::cout << sysfs_format % "Security level" % sec_level;
+  std::cout << node_data_format % "Security level" % sec_level;
 
   std::string scaling_enabled = not_supported;
   try {
@@ -201,7 +201,7 @@ show_device_conf(xrt_core::device* device)
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for u30 and vck5000
   }
-  std::cout << sysfs_format % "Runtime clock scaling enabled" % scaling_enabled;
+  std::cout << node_data_format % "Runtime clock scaling enabled" % scaling_enabled;
 
   std::string scaling_power_override = not_supported;
   try {
@@ -210,7 +210,7 @@ show_device_conf(xrt_core::device* device)
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for u30 and vck5000
   }
-  std::cout << sysfs_format % "Scaling threshold power override" % scaling_power_override;
+  std::cout << node_data_format % "Scaling threshold power override" % scaling_power_override;
 
   std::string scaling_temp_override = not_supported;
   try {
@@ -219,7 +219,7 @@ show_device_conf(xrt_core::device* device)
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for u30 and vck5000
   }
-  std::cout << sysfs_format % "Scaling threshold temp override" % scaling_temp_override;
+  std::cout << node_data_format % "Scaling threshold temp override" % scaling_temp_override;
 
   std::string data_retention_string = not_supported;
   try {
@@ -230,7 +230,7 @@ show_device_conf(xrt_core::device* device)
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for vck5000 
   }
-  std::cout << sysfs_format % "Data retention" % data_retention_string;
+  std::cout << node_data_format % "Data retention" % data_retention_string;
 
   std::cout << std::flush;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -185,7 +185,7 @@ show_device_conf(xrt_core::device* device)
 
   boost::format node_data_format("  %-33s: %s\n");
   std::string not_supported = "Not supported";
-  uint16_t sec_level = not_supported;
+  std::string sec_level = not_supported;
   try {
     sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -183,46 +183,54 @@ show_device_conf(xrt_core::device* device)
   if (is_mfg || is_recovery)
     throw xrt_core::error(std::errc::operation_canceled, "This operation is not supported with manufacturing image.\n");
 
+  boost::format sysfs_format("  %-33s: %s\n");
+  const std::string not_supported = "Not supported";
+  std::string sec_level = not_supported;
   try {
-    auto sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
-    std::cout << boost::format("  %-33s: %s\n") % "Security level" % sec_level;
+    sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
   }
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for vck5000 
   }
+  std::cout << sysfs_format % "Security level" % sec_level;
 
+  std::string scaling_enabled = not_supported;
   try {
-    auto scaling_enabled = xrt_core::device_query<xrt_core::query::xmc_scaling_enabled>(device);
-    std::cout << boost::format("  %-33s: %s\n") % "Runtime clock scaling enabled" % scaling_enabled;
+    scaling_enabled = xrt_core::device_query<xrt_core::query::xmc_scaling_enabled>(device);
   }
   catch (xrt_core::query::exception&) {
-    //safe to ignore. These sysfs nodes are not present for u30
+    //safe to ignore. These sysfs nodes are not present for u30 and vck5000
   }
+  std::cout << sysfs_format % "Runtime clock scaling enabled" % scaling_enabled;
 
+  std::string scaling_power_override = not_supported;
   try {
-    auto scaling_override = xrt_core::device_query<xrt_core::query::xmc_scaling_power_override>(device);
-    std::cout << boost::format("  %-33s: %s\n") % "Scaling threshold power override" % scaling_override;
+    scaling_power_override = xrt_core::device_query<xrt_core::query::xmc_scaling_power_override>(device);
   }
   catch (xrt_core::query::exception&) {
-    //safe to ignore. These sysfs nodes are not present for u30
+    //safe to ignore. These sysfs nodes are not present for u30 and vck5000
   }
+  std::cout << sysfs_format % "Scaling threshold power override" % scaling_power_override;
 
+  std::string scaling_temp_override = not_supported;
   try {
-    auto scaling_override = xrt_core::device_query<xrt_core::query::xmc_scaling_temp_override>(device);
-    std::cout << boost::format("  %-33s: %s\n") % "Scaling threshold temp override" % scaling_override;
+    scaling_temp_override = xrt_core::device_query<xrt_core::query::xmc_scaling_temp_override>(device);
   }
   catch (xrt_core::query::exception&) {
-    //safe to ignore. These sysfs nodes are not present for u30
+    //safe to ignore. These sysfs nodes are not present for u30 and vck5000
   }
+  std::cout << sysfs_format % "Scaling threshold temp override" % scaling_temp_override;
 
+  std::string data_retention_string = not_supported;
   try {
     auto value = xrt_core::device_query<xrt_core::query::data_retention>(device);
     auto data_retention = xrt_core::query::data_retention::to_bool(value);
-    std::cout << boost::format("  %-33s: %s\n") % "Data retention" % (data_retention ? "enabled" : "disabled");
+    data_retention_string = (data_retention ? "enabled" : "disabled");
   }
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for vck5000 
   }
+  std::cout << sysfs_format % "Data retention" % data_retention_string;
 
   std::cout << std::flush;
 }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -187,7 +187,7 @@ show_device_conf(xrt_core::device* device)
   std::string not_supported = "Not supported";
   std::string sec_level = not_supported;
   try {
-    sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
+    sec_level = std::to_string(xrt_core::device_query<xrt_core::query::sec_level>(device));
   }
   catch (xrt_core::query::exception&) {
     //safe to ignore. These sysfs nodes are not present for vck5000 

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -185,7 +185,7 @@ show_device_conf(xrt_core::device* device)
 
   boost::format node_data_format("  %-33s: %s\n");
   std::string not_supported = "Not supported";
-  std::string sec_level = not_supported;
+  uint16_t sec_level = not_supported;
   try {
     sec_level = xrt_core::device_query<xrt_core::query::sec_level>(device);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1119432
This is the second half of the CR after the issue was not initially solved! Specifically the VCK5000 was not outputting data correctly. This extended to the U30 as well after further testing.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The exception handling for the missing sysfs nodes output nothing instead of printing a not supported message. This has been present for a long while.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Moved printouts and set initial values for output to better mirror the state of the devices when data is requested.

#### Risks (if any) associated the changes in the commit
None, just adding output. There is a separate issue of the security and runtime clock nodes not outputting any data if the value which should be noted in another CR.

#### What has been tested and how, request additional testing if necessary
On u280 with full support:
```
root@xsjpranjal01:~# xbmgmt configure --showx -d 65:00
0000:65:00.0
  Security level                   :
  Runtime clock scaling enabled    :
  Scaling threshold power override : 0
  Scaling threshold temp override  : 0
  Data retention                   : disabled

```
On vck5000 with no support:
```
dbenusov@xsjsagarw50:~$ xbmgmt configure --showx -d 65:00
0000:65:00.0
  Security level                   : Not supported
  Runtime clock scaling enabled    : Not supported
  Scaling threshold power override : Not supported
  Scaling threshold temp override  : Not supported
  Data retention                   : Not supported
```
On u30 with limited support:
```
dbenusov@xsjsagarw50:~$ xbmgmt configure --showx -d 17:00
0000:17:00.0
  Security level                   :
  Runtime clock scaling enabled    : Not supported
  Scaling threshold power override : Not supported
  Scaling threshold temp override  : Not supported
  Data retention                   : disabled
```
*Note the blank values! That will be a different CR that is soon to be filed.
#### Documentation impact (if any)
None