### PR TITLE
Fix compatible issue on latest XRT host and U30 released shell

### DIFF
--- a/src/runtime_src/core/common/drv/kds_core.c
+++ b/src/runtime_src/core/common/drv/kds_core.c
@@ -606,16 +606,9 @@ kds_submit_ert(struct kds_sched *kds, struct kds_command *xcmd)
 		}
 		break;
 	case OP_CONFIG:
+	case OP_START_SK:
 	case OP_CLK_CALIB:
 	case OP_VALIDATE:
-		break;
-	case OP_START_SK:
-		/* KDS should select a CU and set it in cu_mask */
-		do {
-			cu_idx = acquire_scu_idx(&kds->scu_mgmt, xcmd);
-		} while(cu_idx == -EAGAIN);
-		if (cu_idx < 0)
-			return cu_idx;
 		break;
 	default:
 		kds_err(xcmd->client, "Unknown opcode");

--- a/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
+++ b/src/runtime_src/core/edge/drm/zocl/include/zocl_sk.h
@@ -80,7 +80,7 @@ struct soft_krnl {
 struct soft_krnl_cmd {
 	struct list_head	skc_list;
 	uint32_t		skc_opcode;
-	struct config_sk_image	*skc_packet;
+	struct config_sk_image_uuid	*skc_packet;
 };
 
 int zocl_init_soft_kernel(struct drm_zocl_dev *zdev);

--- a/src/runtime_src/core/edge/drm/zocl/scu.c
+++ b/src/runtime_src/core/edge/drm/zocl/scu.c
@@ -93,9 +93,9 @@ static int configure_soft_kernel(u32 cuidx, char kname[64], unsigned char uuid[1
 	struct drm_zocl_dev *zdev = zocl_get_zdev();
 	struct soft_krnl *sk = zdev->soft_kernel;
 	struct soft_krnl_cmd *scmd = NULL;
-	struct config_sk_image *cp = NULL;
+	struct config_sk_image_uuid *cp = NULL;
 
-	cp = kmalloc(sizeof(struct config_sk_image), GFP_KERNEL);
+	cp = kmalloc(sizeof(struct config_sk_image_uuid), GFP_KERNEL);
 	cp->start_cuidx = cuidx;
 	cp->num_cus = 1;
 	strncpy((char *)cp->sk_name,kname,PS_KERNEL_NAME_LENGTH);

--- a/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_sk.c
@@ -45,7 +45,7 @@ zocl_sk_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 	kdata->opcode = scmd->skc_opcode;
 
 	if (kdata->opcode == ERT_SK_CONFIG) {
-		struct config_sk_image *cmd = NULL;
+		struct config_sk_image_uuid *cmd = NULL;
 		u32 bohdl = 0xffffffff;
 		u32 meta_bohdl = 0xffffffff;
 		int i, ret;
@@ -103,7 +103,7 @@ zocl_sk_getcmd_ioctl(struct drm_device *dev, void *data, struct drm_file *filp)
 		kdata->bohdl = bohdl;
 		kdata->meta_bohdl = meta_bohdl;
 		memcpy(kdata->uuid,cmd->sk_uuid,sizeof(kdata->uuid));
-		
+
 		snprintf(kdata->name, ZOCL_MAX_NAME_LENGTH, "%s",
 		    (char *)cmd->sk_name);
 	} else

--- a/src/runtime_src/core/include/ert.h
+++ b/src/runtime_src/core/include/ert.h
@@ -282,11 +282,30 @@ struct ert_configure_cmd {
  *       in one config command (1024 DWs including header).
  *       So each one needs to be smaller than 8 DWs.
  *
+ * This data struct is obsoleted. Only used in legacy ERT firmware.
+ * Use 'struct config_sk_image_uuid' instead on XGQ based ERT.
+ *
  * @start_cuidx:     start index of compute units of each image
  * @num_cus:         number of compute units of each image
  * @sk_name:         symbol name of soft kernel of each image
  */
 struct config_sk_image {
+  uint32_t start_cuidx;
+  uint32_t num_cus;
+  uint32_t sk_name[5];
+};
+
+/*
+ * Note: We need to put maximum 128 soft kernel image
+ *       in one config command (1024 DWs including header).
+ *       So each one needs to be smaller than 8 DWs.
+ *
+ * @start_cuidx:     start index of compute units of each image
+ * @num_cus:         number of compute units of each image
+ * @sk_name:         symbol name of soft kernel of each image
+ * @sk_uuid:         xclbin uuid that this soft kernel image belones to
+ */
+struct config_sk_image_uuid {
   uint32_t start_cuidx;
   uint32_t num_cus;
   uint32_t sk_name[5];


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Latest XRT host doesn't compatible with U30 released shell

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
By try latest XRT with U30 released shell

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. sk_uuid is versal specific. Create an new struct instead of change the old one
2. kds_submit_ert(), which is used with legacy ERT firmware. It doesn't need to select scu. 

#### Risks (if any) associated the changes in the commit
No.

#### What has been tested and how, request additional testing if necessary
On U30: xbutil validate passed
On VCK5000: xbutil validate passed and some local PS kernel test cases

#### Documentation impact (if any)
No