### PR TITLE
CR-1112575 Enable Software resettable kernels on Edge platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_kds.c
@@ -714,6 +714,7 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 	xcmd->cb.notify_host = notify_execbuf;
 	xcmd->execbuf = (u32 *)ecmd;
 	xcmd->gem_obj = gem_obj;
+	xcmd->exec_bo_handle = args->exec_bo_handle;
 
 	//print_ecmd_info(ecmd);
 
@@ -744,6 +745,9 @@ int zocl_command_ioctl(struct drm_zocl_dev *zdev, void *data,
 		if (ret)
 			goto out1;
 		goto out;
+	case ERT_ABORT:
+		abort_ecmd2xcmd(to_abort_pkg(ecmd), xcmd);
+		break;
 	default:
 		DRM_ERROR("Unsupport command\n");
 		ret = -EINVAL;

--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -608,17 +608,8 @@ zocl_create_cu(struct drm_zocl_dev *zdev, struct drm_zocl_slot *slot)
 			cu_info[i].size = krnl_info->range;
 		}
 
-		krnl_info = zocl_query_kernel(slot, cu_info[i].kname);
-		if (!krnl_info) {
-			DRM_WARN("%s CU has no metadata, using default",cu_info[i].kname);
-			cu_info[i].args = NULL;
-			cu_info[i].num_args = 0;
-			cu_info[i].size = 0x10000;
-		} else {
-			cu_info[i].args = (struct xrt_cu_arg *)&krnl_info->args[i];
-			cu_info[i].num_args = krnl_info->anums;
-			cu_info[i].size = krnl_info->range;
-		}
+		if (krnl_info->features & KRNL_SW_RESET)
+			cu_info[i].sw_reset = true;
 
 		/* CU sub device is a virtual device, which means there is no
 		 * device tree nodes

--- a/src/runtime_src/core/edge/include/zynq_ioctl.h
+++ b/src/runtime_src/core/edge/include/zynq_ioctl.h
@@ -382,6 +382,9 @@ struct argument_info {
 	uint32_t	dir;
 };
 
+/* Kernel features macro */
+#define KRNL_SW_RESET	(1 << 0)
+
 /**
  * struct kernel_info - Kernel information
  *
@@ -394,6 +397,7 @@ struct kernel_info {
 	char                     name[64];
 	uint32_t		 range;
 	int		         anums;
+	int			 features;
 	struct argument_info	 args[];
 };
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -756,6 +756,10 @@ xclLoadAxlf(const axlf *buffer)
       krnl->range = kernel.range;
       krnl->anums = kernel.args.size();
 
+      krnl->features = 0;
+      if (kernel.sw_reset)
+        krnl->features |= KRNL_SW_RESET;
+
       int ai = 0;
       for (auto& arg : kernel.args) {
         if (arg.name.size() > sizeof(krnl->args[ai].name)) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
KDS support for abort command from user space is enabled in common code, this PR adds code to enable this feature in edge platforms.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Not a Bug.

#### How problem was solved, alternative solutions (if any) and why they were rejected
We pass down the sw_reset bit to CU subdevice when xclbin is loaded, KDS will submit abort command to each CU and CU will be reset.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested on zcu102_base Vitis Embedded platform with abort test case (XRT/tests/xrt/abort) and things are working as expected

#### Documentation impact (if any)
NA