### PR TITLE
xclbinutil - Added Vender Metadata section support

### DIFF
--- a/src/runtime_src/core/include/xclbin.h
+++ b/src/runtime_src/core/include/xclbin.h
@@ -1,5 +1,6 @@
 /**
  *  Copyright (C) 2015-2022, Xilinx Inc
+ *  Copyright (C) 2022 Advanced Micro Devices, Inc.
  *
  *  This file is dual licensed.  It may be redistributed and/or modified
  *  under the terms of the Apache 2.0 License OR version 2 of the GNU
@@ -173,6 +174,7 @@ extern "C" {
         SMARTNIC               = 28,
         AIE_RESOURCES          = 29,
         OVERLAY                = 30,
+        VENDER_METADATA        = 31,
     };
 
     enum MEM_TYPE {
@@ -499,6 +501,21 @@ extern "C" {
         CST_SDBM = 1,
         CST_LAST
     };
+
+    struct vender_metadata {                   /* vender metadata section  */
+        // Prefix Syntax:
+        //   mpo - member, pointer, offset
+        //     This variable represents a zero terminated string
+        //     that is offseted from the beginning of the section.
+        //
+        //     The pointer to access the string is initialized as follows:
+        //     char * pCharString = (address_of_section) + (mpo value)
+        uint32_t mpo_name;         // Name of the the vender metadata section
+        uint32_t m_image_offset;   // Image offset
+        uint32_t m_image_size;     // Image size
+        uint8_t padding[36];       // Reserved for future use
+    };
+    XCLBIN_STATIC_ASSERT(sizeof(struct vender_metadata) == 48, "vender metadata kernel structure no longer is 48 bytes in size");
 
     /**** END : Xilinx internal section *****/
 

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -126,6 +126,10 @@ if(NOT WIN32)
   set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages")
   xrt_add_test("binary-images" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/BinaryImages/BinaryImages.py ${TEST_OPTIONS}")
 
+  # -- Binary Images
+  set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/SingleSubsection")
+  xrt_add_test("single-subsection" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/SingleSubsection/SingleSubsection.py ${TEST_OPTIONS}")
+
 endif()
 
 

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.cxx
@@ -1,0 +1,354 @@
+/**
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "SectionVenderMetadata.h"
+
+#include "XclBinUtilities.h"
+namespace XUtil = XclBinUtilities;
+
+#include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+// Disable windows compiler warnings
+#ifdef _WIN32
+#pragma warning( disable : 4100 4267 4244)
+#endif
+
+// Static Variables / Classes
+SectionVenderMetadata::_init SectionVenderMetadata::_initializer;
+
+// -------------------------------------------------------------------------
+
+SectionVenderMetadata::SectionVenderMetadata()
+{
+  // Empty
+}
+
+// -------------------------------------------------------------------------
+
+SectionVenderMetadata::~SectionVenderMetadata()
+{
+  // Empty
+}
+
+// -------------------------------------------------------------------------
+
+bool
+SectionVenderMetadata::doesSupportAddFormatType(FormatType _eFormatType) const
+{
+  // The Vender Metadata top-level section does support any add syntax.
+  // Must use sub-sections
+  return false;
+}
+
+// -------------------------------------------------------------------------
+
+bool
+SectionVenderMetadata::subSectionExists(const std::string& _sSubSectionName) const
+{
+  // No buffer no subsections
+  return  (m_pBuffer != nullptr);
+}
+
+// -------------------------------------------------------------------------
+
+bool
+SectionVenderMetadata::supportsSubSection(const std::string& _sSubSectionName) const
+{
+  // There is only one-subsection that is supported.  By default it is not named.
+  return _sSubSectionName.empty();
+}
+
+
+// -------------------------------------------------------------------------
+void
+SectionVenderMetadata::copyBufferUpdateMetadata(const char* _pOrigDataSection,
+                                                unsigned int _origSectionSize,
+                                                std::istream& _istream,
+                                                std::ostringstream& _buffer) const
+{
+  XUtil::TRACE("SectionVenderMetadata::CopyBufferUpdateMetadata");
+
+  // Do we have enough room to overlay the header structure
+  if (_origSectionSize < sizeof(vender_metadata)) {
+    const auto& errMsg = boost::str(boost::format(
+                                        "ERROR: Segment size (%d) is smaller than the size of the vender_metadata structure (%d)")
+                                    % _origSectionSize % sizeof(vender_metadata));
+    throw std::runtime_error(errMsg);
+  }
+
+  // Prepare our destination header buffer
+  vender_metadata venderMetadataHdr = { 0 };   // Header buffer
+  std::ostringstream stringBlock;              // String block (stored immediately after the header)
+
+  const vender_metadata* pHdr = reinterpret_cast<const vender_metadata*>(_pOrigDataSection);
+
+  XUtil::TRACE_BUF("vender_metadata-original", reinterpret_cast<const char*>(pHdr), sizeof(vender_metadata));
+  XUtil::TRACE(boost::str(boost::format(
+                              "Original: \n"
+                              "  mpo_name (0x%lx): '%s'\n"
+                              "  m_image_offset: 0x%lx, m_image_size: 0x%lx\n")
+                          % pHdr->mpo_name % (reinterpret_cast<const char*>(pHdr) + pHdr->mpo_name)
+                          % pHdr->m_image_offset % pHdr->m_image_size));
+
+  // Get the JSON metadata
+  _istream.seekg(0, _istream.end);             // Go to the beginning
+  std::streampos fileSize = _istream.tellg();  // Go to the end
+
+  // Copy the buffer into memory
+  std::unique_ptr<unsigned char> memBuffer(new unsigned char[fileSize]);
+  _istream.clear();                                // Clear any previous errors
+  _istream.seekg(0);                               // Go to the beginning
+  _istream.read((char*)memBuffer.get(), fileSize); // Read in the buffer into memory
+
+  XUtil::TRACE_BUF("Buffer", (char*)memBuffer.get(), fileSize);
+
+  // Convert JSON memory image into a boost property tree
+  std::stringstream ss;
+  ss.write((char*)memBuffer.get(), fileSize);
+
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(ss, pt);
+
+  // Extract and update the data
+  boost::property_tree::ptree& ptSK = pt.get_child("vender_metadata");
+
+  // Update and record the variables
+  // mpo_name
+  {
+    std::string sDefault = reinterpret_cast<const char*>(pHdr) + sizeof(vender_metadata) + pHdr->mpo_name;
+    std::string sValue = ptSK.get<std::string>("mpo_name", sDefault);
+
+    if (sValue.compare(getSectionIndexName()) != 0) {
+      const auto& errMsg = boost::str(boost::format(
+                                          "ERROR: Metadata data mpo_name '%s' does not match expected section name '%s'")
+                                      % sValue % getSectionIndexName());
+      throw std::runtime_error(errMsg);
+    }
+
+    venderMetadataHdr.mpo_name = sizeof(vender_metadata) + stringBlock.tellp();
+    stringBlock << sValue << '\0';
+    XUtil::TRACE(boost::str(boost::format("  mpo_name (0x%lx): '%s'") % venderMetadataHdr.mpo_name % sValue));
+  }
+
+  // Last item to be initialized
+  {
+    venderMetadataHdr.m_image_offset = sizeof(vender_metadata) + stringBlock.tellp();
+    venderMetadataHdr.m_image_size = pHdr->m_image_size;
+    XUtil::TRACE(boost::str(boost::format("  m_image_offset: 0x%lx") % venderMetadataHdr.m_image_offset));
+    XUtil::TRACE(boost::str(boost::format("    m_image_size: 0x%lx") % venderMetadataHdr.m_image_size));
+  }
+
+  // Copy the output to the output buffer.
+  // Header
+  _buffer.write(reinterpret_cast<const char*>(&venderMetadataHdr), sizeof(vender_metadata));
+
+  // String block
+  std::string sStringBlock = stringBlock.str();
+  _buffer.write(sStringBlock.c_str(), sStringBlock.size());
+
+  // Image
+  _buffer.write(reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset, pHdr->m_image_size);
+}
+
+// -------------------------------------------------------------------------
+
+void
+SectionVenderMetadata::createDefaultImage(std::istream& _istream, std::ostringstream& _buffer) const
+{
+  XUtil::TRACE("VENDER_METADATA IMAGE");
+
+  vender_metadata venderMetadataHdr = vender_metadata{0};
+  std::ostringstream stringBlock;       // String block (stored immediately after the header)
+
+  // Initialize default values
+  {
+    venderMetadataHdr.mpo_name = sizeof(vender_metadata) + stringBlock.tellp();
+    stringBlock << getSectionIndexName() << '\0';
+  }
+
+  // Initialize the object image values (last)
+  {
+    _istream.seekg(0, _istream.end);
+    venderMetadataHdr.m_image_size = _istream.tellg();
+    venderMetadataHdr.m_image_offset = sizeof(vender_metadata) + stringBlock.tellp();
+  }
+
+  XUtil::TRACE_BUF("vender_metadata", reinterpret_cast<const char*>(&venderMetadataHdr), sizeof(vender_metadata));
+
+  // Write the header information
+  _buffer.write(reinterpret_cast<const char*>(&venderMetadataHdr), sizeof(vender_metadata));
+
+  // String block
+  std::string sStringBlock = stringBlock.str();
+  _buffer.write(sStringBlock.c_str(), sStringBlock.size());
+
+  // Write Data
+  {
+    std::unique_ptr<unsigned char> memBuffer(new unsigned char[venderMetadataHdr.m_image_size]);
+    _istream.seekg(0);
+    _istream.clear();
+    _istream.read(reinterpret_cast<char*>(memBuffer.get()), venderMetadataHdr.m_image_size);
+
+    _buffer.write(reinterpret_cast<const char*>(memBuffer.get()), venderMetadataHdr.m_image_size);
+  }
+}
+
+// -------------------------------------------------------------------------
+
+void
+SectionVenderMetadata::readSubPayload(const char* _pOrigDataSection,
+                                      unsigned int _origSectionSize,
+                                      std::istream& _istream,
+                                      const std::string& _sSubSectionName,
+                                      enum Section::FormatType _eFormatType,
+                                      std::ostringstream& _buffer) const
+{
+  // Only default (e.g. empty) sub sections are supported
+  if (!_sSubSectionName.empty()) {
+    const auto& errMsg = boost::str(boost::format(
+                                        "ERROR: Subsection '%s' not support by section '%s")
+                                    % _sSubSectionName % getSectionKindAsString());
+    throw std::runtime_error(errMsg);
+  }
+
+  // Some basic DRC checks
+  if (_pOrigDataSection != nullptr) {
+    std::string errMsg = "ERROR: Vendor Metadata image already exists.";
+    throw std::runtime_error(errMsg);
+  }
+
+  if (_eFormatType != Section::FT_RAW) {
+    std::string errMsg = "ERROR: Vendor Metadata only supports the RAW format.";
+    throw std::runtime_error(errMsg);
+  }
+
+  createDefaultImage(_istream, _buffer);
+}
+
+// -------------------------------------------------------------------------
+
+void
+SectionVenderMetadata::writeObjImage(std::ostream& _oStream) const
+{
+  XUtil::TRACE("SectionVenderMetadata::writeObjImage");
+
+  // Overlay the structure
+  // Do we have enough room to overlay the header structure
+  if (m_bufferSize < sizeof(vender_metadata)) {
+    const auto& errMsg = boost::str(boost::format("ERROR: Segment size (%d) is smaller than the size of the bmc structure (%d)") % m_bufferSize % sizeof(vender_metadata));
+    throw std::runtime_error(errMsg);
+  }
+
+  // No look at the data
+  vender_metadata* pHdr = reinterpret_cast<vender_metadata*>(m_pBuffer);
+
+  const char* pFWBuffer = reinterpret_cast<const char*>(pHdr) + pHdr->m_image_offset;
+  _oStream.write(pFWBuffer, pHdr->m_image_size);
+}
+
+// -------------------------------------------------------------------------
+
+void
+SectionVenderMetadata::writeMetadata(std::ostream& _oStream) const
+{
+  XUtil::TRACE("VENDER_METADATA -METADATA");
+
+  // Overlay the structure
+  // Do we have enough room to overlay the header structure
+  if (m_bufferSize < sizeof(vender_metadata)) {
+    const auto& errMsg = boost::str(boost::format(
+                                        "ERROR: Segment size (%d) is smaller than the size of the vender_metadata structure (%d)")
+                                    % m_bufferSize % sizeof(vender_metadata));
+    throw std::runtime_error(errMsg);
+  }
+
+  vender_metadata* pHdr = reinterpret_cast<vender_metadata*>(m_pBuffer);
+
+  XUtil::TRACE(boost::str(boost::format(
+                              "Original: \n"
+                              "  mpo_name (0x%lx): '%s'\n"
+                              "  m_image_offset: 0x%lx, m_image_size: 0x%lx")
+                          % pHdr->mpo_name % (reinterpret_cast<char*>(pHdr) + pHdr->mpo_name)
+                          % pHdr->m_image_offset % pHdr->m_image_size));
+
+  // Convert the data from the binary format to JSON
+  boost::property_tree::ptree ptVenderMetadata;
+
+  ptVenderMetadata.put("mpo_name", reinterpret_cast<char*>(pHdr) + pHdr->mpo_name);
+
+  boost::property_tree::ptree root;
+  root.put_child("vender_metadata", ptVenderMetadata);
+
+  boost::property_tree::write_json(_oStream, root);
+}
+
+// -------------------------------------------------------------------------
+
+void
+SectionVenderMetadata::writeSubPayload(const std::string& _sSubSectionName,
+                                       FormatType _eFormatType,
+                                       std::fstream&  _oStream) const
+{
+  // Some basic DRC checks
+  if (m_pBuffer == nullptr) {
+    std::string errMsg = "ERROR: Vendor Metadata section does not exist.";
+    throw std::runtime_error(errMsg);
+  }
+
+  if (!_sSubSectionName.empty()) {
+    const auto& errMsg = boost::str(boost::format(
+                                        "ERROR: Subsection '%s' not support by section '%s")
+                                    % _sSubSectionName % getSectionKindAsString());
+    throw std::runtime_error(errMsg);
+  }
+
+  // Some basic DRC checks
+  if (_eFormatType != Section::FT_RAW) {
+    std::string errMsg = "ERROR: Vendor Metadata section only supports the RAW format.";
+    throw std::runtime_error(errMsg);
+  }
+
+  writeObjImage(_oStream);
+}
+
+void
+SectionVenderMetadata::readXclBinBinary(std::fstream& _istream, const axlf_section_header& _sectionHeader)
+{
+  Section::readXclBinBinary(_istream, _sectionHeader);
+
+  // Extract the binary data as a JSON string
+  std::ostringstream buffer;
+  writeMetadata(buffer);
+
+  std::stringstream ss;
+  const std::string& sBuffer = buffer.str();
+  XUtil::TRACE_BUF("String Image", sBuffer.c_str(), sBuffer.size());
+
+  ss.write((char*)sBuffer.c_str(), sBuffer.size());
+
+  // Create a property tree and determine if the variables are all default values
+  boost::property_tree::ptree pt;
+  boost::property_tree::read_json(ss, pt);
+
+  boost::property_tree::ptree& ptVenderMetadata = pt.get_child("vender_metadata");
+
+  XUtil::TRACE_PrintTree("Current VENDER_METADATA contents", pt);
+  std::string sName = ptVenderMetadata.get<std::string>("mpo_name");
+
+  Section::m_sIndexName = sName;
+}

--- a/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
+++ b/src/runtime_src/tools/xclbinutil/SectionVenderMetadata.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may
+ * not use this file except in compliance with the License. A copy of the
+ * License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef __SectionVenderMetadata_h_
+#define __SectionVenderMetadata_h_
+
+// #includes here - please keep these to a bare minimum!
+#include "Section.h"
+#include <boost/functional/factory.hpp>
+
+
+
+class SectionVenderMetadata : public Section {
+ public:
+  SectionVenderMetadata();
+  virtual ~SectionVenderMetadata();
+
+ public:
+  virtual bool doesSupportAddFormatType(FormatType _eFormatType) const;
+  virtual bool supportsSubSection(const std::string& _sSubSectionName) const;
+  virtual bool subSectionExists(const std::string& _sSubSectionName) const;
+  virtual void readXclBinBinary(std::fstream& _istream, const struct axlf_section_header& _sectionHeader);
+
+ protected:
+  virtual void readSubPayload(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, const std::string& _sSubSection, enum Section::FormatType _eFormatType, std::ostringstream& _buffer) const;
+  virtual void writeSubPayload(const std::string& _sSubSectionName, FormatType _eFormatType, std::fstream&  _oStream) const;
+
+ protected:
+  void copyBufferUpdateMetadata(const char* _pOrigDataSection, unsigned int _origSectionSize,  std::istream& _istream, std::ostringstream& _buffer) const;
+  void createDefaultImage(std::istream& _istream, std::ostringstream& _buffer) const;
+  void writeObjImage(std::ostream& _oStream) const;
+  void writeMetadata(std::ostream& _oStream) const;
+
+ private:
+  SectionVenderMetadata(const SectionVenderMetadata& obj) = delete;
+  SectionVenderMetadata& operator=(const SectionVenderMetadata& obj) = delete;
+
+ private:
+  // Static initializer helper class
+  static class _init {
+   public:
+    _init() { registerSectionCtor(VENDER_METADATA, "VENDER_METADATA", "", true, true, boost::factory<SectionVenderMetadata*>()); }
+  } _initializer;
+};
+
+#endif

--- a/src/runtime_src/tools/xclbinutil/unittests/SingleSubsection/SingleSubsection.py
+++ b/src/runtime_src/tools/xclbinutil/unittests/SingleSubsection/SingleSubsection.py
@@ -1,0 +1,141 @@
+import subprocess
+import os
+import argparse
+from argparse import RawDescriptionHelpFormatter
+import filecmp
+import json
+import binascii
+
+# Start of our unit test
+# -- main() -------------------------------------------------------------------
+#
+# The entry point to this script.
+#
+# Note: It is called at the end of this script so that the other functions
+#       and classes have been defined and the syntax validated
+def main():
+  # -- Configure the argument parser
+  parser = argparse.ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description='description:\n  Unit test wrapper use to validated single subsection sections')
+  parser.add_argument('--resource-dir', nargs='?', default=".", help='directory containing data to be used by this unit test')
+  args = parser.parse_args()
+
+  # Validate that the resource directory is valid
+  if not os.path.exists(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' does not exist")
+
+  if not os.path.isdir(args.resource_dir):
+      raise Exception("Error: The resource-dir '" + args.resource_dir +"' is not a directory")
+
+  # Prepare for testing
+  xclbinutil = "xclbinutil"
+
+  # Start the tests
+  print ("Starting test")
+
+  # ---------------------------------------------------------------------------
+
+  step = "1) Create working xclbin container with multiple single vender sections"
+
+  inputVenderMetadata1 = os.path.join(args.resource_dir, "sample_data1.txt")
+  inputVenderMetadata1Name = "ACME";
+  inputVenderMetadata2 = os.path.join(args.resource_dir, "sample_data2.txt")
+  inputVenderMetadata2Name = "Xilinx";
+  workingXCLBIN = "working.xclbin"
+
+  cmd = [xclbinutil, "--add-section", "VENDER_METADATA[" + inputVenderMetadata1Name + "]:RAW:" + inputVenderMetadata1, 
+                     "--add-section", "VENDER_METADATA[" + inputVenderMetadata2Name + "]:RAW:" + inputVenderMetadata2, 
+                     "--output", workingXCLBIN, 
+                     "--force"]
+  execCmd(step, cmd)
+
+
+  # ---------------------------------------------------------------------------
+
+  step = "2) Read in a PS kernel, updated and validate the sections"
+  outputVenderMetadata1 = "output_sample_data1.txt";
+  outputVenderMetadata2 = "output_sample_data2.txt";
+
+  cmd = [xclbinutil, "--input", workingXCLBIN,
+                     "--dump-section", "VENDER_METADATA[" + inputVenderMetadata1Name + "]:RAW:" + outputVenderMetadata1, 
+                     "--dump-section", "VENDER_METADATA[" + inputVenderMetadata2Name + "]:RAW:" + outputVenderMetadata2, 
+                     "--force"
+                     ]
+  execCmd(step, cmd)
+
+  # Validate the contents of the various sections
+  textFileCompare(inputVenderMetadata1, outputVenderMetadata1)
+  textFileCompare(inputVenderMetadata2, outputVenderMetadata2)
+
+  # ---------------------------------------------------------------------------
+
+  # If the code gets this far, all is good.
+  return False
+
+  # ---- Helper procedures ----------------------------------------------------
+
+
+def textFileCompare(file1, file2):
+    if not os.path.isfile(file1):
+      raise Exception("Error: The following file does not exist: '" + file1 +"'")
+
+    with open(file1) as f:
+      data1 = f.read()
+
+    if not os.path.isfile(file2):
+      raise Exception("Error: The following file does not exist: '" + file2 +"'")
+
+    with open(file2) as f:
+      data2 = f.read()
+
+    if data1 != data2:
+        # Print out the contents of file 1
+        print ("\nFile1 : "+ file1)
+        print ("vvvvv")
+        print (data1)
+        print ("^^^^^")
+
+        # Print out the contents of file 1
+        print ("\nFile2 : "+ file2)
+        print ("vvvvv")
+        print (data2)
+        print ("^^^^^")
+
+        raise Exception("Error: The given files are not the same")
+
+
+def testDivider():
+  print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+
+
+def execCmd(pretty_name, cmd):
+  testDivider()
+  print(pretty_name)
+  testDivider()
+  cmdLine = ' '.join(cmd)
+  print(cmdLine)
+  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  o, e = proc.communicate()
+  print(o.decode('ascii'))
+  print(e.decode('ascii'))
+  errorCode = proc.returncode
+
+  if errorCode != 0:
+    raise Exception("Operation failed with the return code: " + str(errorCode))
+
+# -- Start executing the script functions
+if __name__ == '__main__':
+  try:
+    if main() == True:
+      print ("\nError(s) occurred.")
+      print("Test Status: FAILED")
+      exit(1)
+  except Exception as error:
+    print(repr(error))
+    print("Test Status: FAILED")
+    exit(1)
+
+
+# If the code get this far then no errors occured
+print("Test Status: PASSED")
+exit(0)
+

--- a/src/runtime_src/tools/xclbinutil/unittests/SingleSubsection/sample_data1.txt
+++ b/src/runtime_src/tools/xclbinutil/unittests/SingleSubsection/sample_data1.txt
@@ -1,0 +1,2 @@
+Sample Data 1
+This is a sample text entry that represents a generic image.

--- a/src/runtime_src/tools/xclbinutil/unittests/SingleSubsection/sample_data2.txt
+++ b/src/runtime_src/tools/xclbinutil/unittests/SingleSubsection/sample_data2.txt
@@ -1,0 +1,2 @@
+Sample Data 2
+This is a sample text entry that represents a generic image.


### PR DESCRIPTION
#### Problem solved by the commit
It has been requested for a new section to allow venders to be able to add additional information to an xclbin container.  As part of the request the following requirements were also given:
1. This new data needs to be uniquely identified per-vender.
2. There shall be one or more uniquely defined sections.
3. It needs to use the existing xclbinutil options

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a

#### How problem was solved, alternative solutions (if any) and why they were rejected
A new section was created, VENDER_METADATA that supports:
1. Uniquely identify each section via a section index.  
> This value is defined by a string between brackets (e.g., []) after the section type.  For example:  `--add-section VENDER_METADATA[xilinx]:RAW:./mydata.txt` will add the file "mydata.txt" to a new VENDER_METADATA section with the string key "xilinx".
2. Multiple vender sections. 

> The VENDER_METADATA section is uniquely defined using a string key.  This string key doesn't have any length limitations.  The only limitation is that there can only be 1 unique key for xclbin containers. 

3. Using the existing xclbin commands, which include:
```
--add-section VENDER_METADATA[<key>]:RAW:<file_name>
--remove-section VENDER_METADATA[<key>]
--dump-section  VENDER_METADATA[<key>]:RAW:<file_name>
```

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manual testing and unit tests (added as part of this PR)

#### Documentation impact (if any)
The XRT documents need to be updated to indicate that this new section is available.