### PR TITLE
CR-1122697 xbmgmt examine returns incorrect code when missing nodes

### DIFF
--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (c) 2022 Advanced Micro Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -33,50 +33,50 @@ void
 ReportCmcStatus::getPropertyTree20202( const xrt_core::device * _pDevice,
                                            boost::property_tree::ptree &_pt) const
 {
-  boost::property_tree::ptree pt;
-  pt.put("Description", "CMC");
+  boost::property_tree::ptree cmc_tree;
+  cmc_tree.put("Description", "CMC");
 
   try {
-    boost::property_tree::ptree pth;
-    pth.put("Description", "CMC heartbeat");
-    pth.put("heartbeat_err_time", xrt_core::device_query<xrt_core::query::heartbeat_err_time>(_pDevice));
-    pth.put("heartbeat_count", xrt_core::device_query<xrt_core::query::heartbeat_count>(_pDevice));
-    pth.put("heartbeat_err_code", xrt_core::device_query<xrt_core::query::heartbeat_err_code>(_pDevice));
-    pth.put("heartbeat_stall", xrt_core::device_query<xrt_core::query::heartbeat_stall>(_pDevice));
-    pth.put("status", xrt_core::utils::parse_cmc_status(static_cast<unsigned int>(xrt_core::device_query<xrt_core::query::heartbeat_err_code>(_pDevice))));
-    pt.add_child("cmc_heartbeat", pth);
+    boost::property_tree::ptree heartbeat_data;
+    heartbeat_data.put("Description", "CMC heartbeat");
+    heartbeat_data.put("heartbeat_err_time", xrt_core::device_query<xrt_core::query::heartbeat_err_time>(_pDevice));
+    heartbeat_data.put("heartbeat_count", xrt_core::device_query<xrt_core::query::heartbeat_count>(_pDevice));
+    heartbeat_data.put("heartbeat_err_code", xrt_core::device_query<xrt_core::query::heartbeat_err_code>(_pDevice));
+    heartbeat_data.put("heartbeat_stall", xrt_core::device_query<xrt_core::query::heartbeat_stall>(_pDevice));
+    heartbeat_data.put("status", xrt_core::utils::parse_cmc_status(static_cast<unsigned int>(xrt_core::device_query<xrt_core::query::heartbeat_err_code>(_pDevice))));
+    cmc_tree.add_child("cmc_heartbeat", heartbeat_data);
   }
   catch(const xrt_core::query::no_such_key&) {}
   catch(const xrt_core::query::sysfs_error&) {}
 
-  boost::property_tree::ptree pts;
-  pts.put("Description", "Runtime Clock Scaling");
+  boost::property_tree::ptree runtime_tree;
+  runtime_tree.put("Description", "Runtime Clock Scaling");
   try {
-    pts.put("enabled", xrt_core::device_query<xrt_core::query::xmc_scaling_enabled>(_pDevice));
-    pts.put("supported", xrt_core::device_query<xrt_core::query::xmc_scaling_support>(_pDevice));
-    boost::property_tree::ptree pts1;
-    pts1.put("power_watts", xrt_core::device_query<xrt_core::query::xmc_scaling_critical_pow_threshold>(_pDevice));
-    pts1.put("temp_celsius", xrt_core::device_query<xrt_core::query::xmc_scaling_critical_temp_threshold>(_pDevice));
-    pts.add_child("shutdown_threshold_limits", pts1);
-    boost::property_tree::ptree pts2;
-    pts2.put("power_watts", xrt_core::device_query<xrt_core::query::xmc_scaling_threshold_power_limit>(_pDevice));
-    pts2.put("temp_celsius", xrt_core::device_query<xrt_core::query::xmc_scaling_threshold_temp_limit>(_pDevice));
-    pts.add_child("override_threshold_limits", pts2);
-    boost::property_tree::ptree pts3;
-    pts3.put("enabled", xrt_core::device_query<xrt_core::query::xmc_scaling_power_override_enable>(_pDevice));
-    pts3.put("power_watts", xrt_core::device_query<xrt_core::query::xmc_scaling_power_override>(_pDevice));
-    pts.add_child("power_threshold_override", pts3);
-    boost::property_tree::ptree pts4;
-    pts4.put("enabled", xrt_core::device_query<xrt_core::query::xmc_scaling_temp_override_enable>(_pDevice));
-    pts4.put("temp_celsius", xrt_core::device_query<xrt_core::query::xmc_scaling_temp_override>(_pDevice));
-    pts.add_child("temp_threshold_override", pts4);
+    runtime_tree.put("enabled", xrt_core::device_query<xrt_core::query::xmc_scaling_enabled>(_pDevice));
+    runtime_tree.put("supported", xrt_core::device_query<xrt_core::query::xmc_scaling_support>(_pDevice));
+    boost::property_tree::ptree shutdown_data;
+    shutdown_data.put("power_watts", xrt_core::device_query<xrt_core::query::xmc_scaling_critical_pow_threshold>(_pDevice));
+    shutdown_data.put("temp_celsius", xrt_core::device_query<xrt_core::query::xmc_scaling_critical_temp_threshold>(_pDevice));
+    runtime_tree.add_child("shutdown_threshold_limits", shutdown_data);
+    boost::property_tree::ptree override_data;
+    override_data.put("power_watts", xrt_core::device_query<xrt_core::query::xmc_scaling_threshold_power_limit>(_pDevice));
+    override_data.put("temp_celsius", xrt_core::device_query<xrt_core::query::xmc_scaling_threshold_temp_limit>(_pDevice));
+    runtime_tree.add_child("override_threshold_limits", override_data);
+    boost::property_tree::ptree power_threshold_data;
+    power_threshold_data.put("enabled", xrt_core::device_query<xrt_core::query::xmc_scaling_power_override_enable>(_pDevice));
+    power_threshold_data.put("power_watts", xrt_core::device_query<xrt_core::query::xmc_scaling_power_override>(_pDevice));
+    runtime_tree.add_child("power_threshold_override", power_threshold_data);
+    boost::property_tree::ptree temp_threshold_data;
+    temp_threshold_data.put("enabled", xrt_core::device_query<xrt_core::query::xmc_scaling_temp_override_enable>(_pDevice));
+    temp_threshold_data.put("temp_celsius", xrt_core::device_query<xrt_core::query::xmc_scaling_temp_override>(_pDevice));
+    runtime_tree.add_child("temp_threshold_override", temp_threshold_data);
   }
   catch(const xrt_core::query::no_such_key&) {}
   catch(const xrt_core::query::sysfs_error&) {}
-  pt.add_child("scaling", pts);
+  cmc_tree.add_child("scaling", runtime_tree);
 
   // There can only be 1 root node
-  _pt.add_child("cmc", pt);
+  _pt.add_child("cmc", cmc_tree);
 }
 
 void

--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -1,4 +1,5 @@
 /**
+ * Copyright (C) 2021 Xilinx, Inc
  * Copyright (c) 2022 Advanced Micro Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
+++ b/src/runtime_src/core/tools/common/ReportCmcStatus.cpp
@@ -102,9 +102,9 @@ ReportCmcStatus::writeReport( const xrt_core::device* /*_pDevice*/,
     _output << "  Heartbeat information unavailable\n";
   }
 
-  boost::property_tree::ptree cmc_scale = cmc.get_child("scaling");
-  _output << boost::format("  %-22s:\n") % cmc_scale.get<std::string>("Description");
   try {
+    boost::property_tree::ptree cmc_scale = cmc.get_child("scaling");
+    _output << boost::format("  %-22s:\n") % cmc_scale.get<std::string>("Description");
     _output << boost::format("    %s : %s\n") % "Supported" % cmc_scale.get<std::string>("supported");
     _output << boost::format("    %s : %s\n") % "Enabled" % cmc_scale.get<std::string>("enabled");
     cmc_scale = cmc.get_child("scaling").get_child("shutdown_threshold_limits");

--- a/src/runtime_src/core/tools/common/ReportMailbox.cpp
+++ b/src/runtime_src/core/tools/common/ReportMailbox.cpp
@@ -83,7 +83,11 @@ ReportMailbox::getPropertyTree20202( const xrt_core::device * device,
                                        boost::property_tree::ptree &pt) const
 {
   // There can only be 1 root node
-  pt.add_child("mailbox", parse_mailbox_requests(xrt_core::device_query<xrt_core::query::mailbox_metrics>(device)));
+  try {
+    pt.add_child("mailbox", parse_mailbox_requests(xrt_core::device_query<xrt_core::query::mailbox_metrics>(device)));
+  } catch (const std::exception&) {
+    // For now do not throw a warning here. Instead deal with the issue in the report function when an empty tree is detected.
+  }
 }
 
 
@@ -97,8 +101,10 @@ ReportMailbox::writeReport( const xrt_core::device* /*_pDevice*/,
 
   _output << "Mailbox" << std::endl;
 
-  if (_pt.empty()) 
+  if (_pt.empty()) {
+    _output << "  Information unavailable\n";
     return;
+  }
   
   const boost::property_tree::ptree& mailbox = _pt.get_child("mailbox.requests", empty_ptree);
   _output << boost::format("  %-22s : %s Bytes\n") % "Total bytes received" % _pt.get<std::string>("mailbox.raw_bytes");

--- a/src/runtime_src/core/tools/common/ReportMailbox.cpp
+++ b/src/runtime_src/core/tools/common/ReportMailbox.cpp
@@ -1,4 +1,5 @@
 /**
+ * Copyright (C) 2021 Xilinx, Inc
  * Copyright (c) 2022 Advanced Micro Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/tools/common/ReportMailbox.cpp
+++ b/src/runtime_src/core/tools/common/ReportMailbox.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (c) 2022 Advanced Micro Devices, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1122697
Running "xbmgmt -new examine -r all -d <bdf>" provides an incorrect return code when the card is in the manufacturing state.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Running an xbmgmt examine command on a device with a golden image would result in certain reports failing to complete, generating a non-zero return code. Also the CMC report is not displaying correctly. XRT should account for the missing node and display that the information is available rather than giving a non-zero return code.
```
root@xsjpranjal01:~# xbmgmt examine  -d 17:00 -r all
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1119432
  Hash                 : 503b24648d48cddf7ef4780845c21e2b5a33b6fc
  Hash Date            : 2022-03-16 17:27:53
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a


----------------------------------------
1/1 [0000:17:00.0] : xilinx_u250_GOLDEN
----------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : N/A

Device properties
  Type                 : u250
  Name                 : N/A
  Config Mode          : 4231162064
  Max Power            : N/A

Flashable partitions running on FPGA
  Platform             : xilinx_u250_GOLDEN_5
  SC Version           : INACTIVE
  Platform ID          : N/A

Flashable partitions installed in system
  <none found>

WARNING  : No shell is installed on the system.

Mechanical
  Fans
    Not present

Firewall
  Level -- --: -- --

Mailbox
  ERROR: Failed to find subdirectory for mailbox under /sys/bus/pci/devices/0000:17:00.0

CMC
Vmr Status
  Information Unavailable
root@xsjpranjal01:~# echo $?
1
```

#### How problem was solved, alternative solutions (if any) and why they were rejected
Fixed error in mailbox report for missing node and updated the message in to to display information unavailable. Also updated message in cmc to display information missing when nodes are not accessible.

#### Risks (if any) associated the changes in the commit
None, should be safer than before!

#### What has been tested and how, request additional testing if necessary
On functional u280:
```
root@xsjpranjal01:~# xbmgmt examine  -d 65:00 -r all
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1122697
  Hash                 : 0167e209412320729348b2db638d980947bb35aa
  Hash Date            : 2022-03-17 17:49:48
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a


-----------------------------------------------
1/1 [0000:65:00.0] : xilinx_u280_xdma_201920_3
-----------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : 21760394400G

Device properties
  Type                 : N/A
  Name                 : ALVEO U280 PQ
  Config Mode          : 7
  Max Power            : 225W

Flashable partitions running on FPGA
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820

Flashable partitions installed in system
  Platform             : xilinx_u280_xdma_201920_3
  SC Version           : 4.3.15
  Platform ID          : 0x5e278820


  Mac Address          : 01:02:03:04:05:06
                       : 01:02:03:04:05:07


Mechanical
  Fans
    FPGA Fan 1
      Critical Trigger Temp : 44 C
      Speed                 : 1335 RPM

Firewall
  Level 0 : 0x0 (GOOD)

Mailbox
  Total bytes received   : 1185664 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 2
  Firewall trip          : 0
  Download xclbin kaddr  : 2
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 9260
  User probe             : 2
  Mgmt state             : 0
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0
                         : 0

CMC
  Status : 0x0 (GOOD)
  Runtime Clock Scaling :
    Supported : false
    Enabled : false
    Critical threshold (clock shutdown) limits:
      Power : 0 W
      Temperature : 0 C
    Throttling threshold limits:
      Power : 0 W
      Temperature : 0 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
Vmr Status
  Information Unavailable
root@xsjpranjal01:~# echo $?
0
```
On golden u250:
```
root@xsjpranjal01:~# xbmgmt examine  -d 17:00 -r all
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15695 MB
  Distribution         : Ubuntu 20.04 LTS
  GLIBC                : 2.31
  Model                : Precision 5820 Tower

XRT
  Version              : 2.13.0
  Branch               : CR-1122697
  Hash                 : 0167e209412320729348b2db638d980947bb35aa
  Hash Date            : 2022-03-17 17:49:48
  XOCL                 : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c
  XCLMGMT              : 2.13.0, d3575d38cd0ca898ee3f0fb39cc43c9affd2814c

Devices present
BDF             :  Shell                      Platform UUID  Device ID
[0000:65:00.0]  :  xilinx_u280_xdma_201920_3  0x5e278820     mgmt(inst=25856)
[0000:17:00.0]  :  xilinx_u250_GOLDEN_5       n/a            n/a


----------------------------------------
1/1 [0000:17:00.0] : xilinx_u250_GOLDEN
----------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : N/A

Device properties
  Type                 : u250
  Name                 : N/A
  Config Mode          : 3710603232
  Max Power            : N/A

Flashable partitions running on FPGA
  Platform             : xilinx_u250_GOLDEN_5
  SC Version           : INACTIVE
  Platform ID          : N/A

Flashable partitions installed in system
  <none found>

WARNING  : No shell is installed on the system.

Mechanical
  Fans
    Not present

Firewall
  Level -- --: -- --

Mailbox
  Information unavailable
CMC
  Heartbeat information unavailable
  Runtime Clock Scaling :
    Information unavailable
Vmr Status
  Information Unavailable
root@xsjpranjal01:~# echo $?
0
```
On functional u200:
```
root@xsjsagarw50:~# xbmgmt examine -d b3:00 -r all
System Configuration
  OS Name              : Linux
  Release              : 5.4.0-100-generic
  Version              : #113-Ubuntu SMP Thu Feb 3 18:43:29 UTC 2022
  Machine              : x86_64
  CPU Cores            : 16
  Memory               : 15671 MB
  Distribution         : Ubuntu 20.04.1 LTS
  GLIBC                : 2.31
  Model                : Super Server

XRT
  Version              : 2.13.0
  Branch               : CR-1122697
  Hash                 : 0167e209412320729348b2db638d980947bb35aa
  Hash Date            : 2022-03-17 17:49:48
  XOCL                 : 2.13.0, 633ea98b6ad7830edd98469dec259b8ed6f9da09
  XCLMGMT              : 2.13.0, 633ea98b6ad7830edd98469dec259b8ed6f9da09

Devices present
BDF             :  Shell                            Platform UUID                         Device ID
[0000:b3:00.0]  :  xilinx_u200_gen3x16_xdma_base_2  0B095B81-FA2B-E6BD-4524-72B1C1474F18  mgmt(inst=45824)
[0000:18:00.0]  :  xilinx_u30_gen3x4_base_2         6E7C97F7-949F-5106-3075-A77784C30A4B  mgmt(inst=6144)
[0000:17:00.0]  :  xilinx_u30_gen3x4_base_2         6E7C97F7-949F-5106-3075-A77784C30A4B  mgmt(inst=5888)
[0000:65:00.0]  :  xilinx_vck5000                   0x0                                   mgmt(inst=25856)


-----------------------------------------------------
1/1 [0000:b3:00.0] : xilinx_u200_gen3x16_xdma_base_2
-----------------------------------------------------
Flash properties
  Type                 : spi
  Serial Number        : 12809621T512

Device properties
  Type                 : u200
  Name                 : A-U200-A64G
  Config Mode          : 7
  Max Power            : 75W

Flashable partitions running on FPGA
  Platform             : xilinx_u200_gen3x16_xdma_base_2
  SC Version           : 4.6.19
  Platform UUID        : 0B095B81-FA2B-E6BD-4524-72B1C1474F18
  Interface UUID       : 0DD37306-B7F6-57A3-BD57-680FE9DAD3A1

Flashable partitions installed in system
  Platform             : xilinx_u200_gen3x16_xdma_base_2
  SC Version           : 4.6.19
  Platform UUID        : 0B095B81-FA2B-E6BD-4524-72B1C1474F18


Mechanical
  Fans
    FPGA Fan 1
      Critical Trigger Temp : 35 C
      Speed                 : 1113 RPM

Firewall
  Level 0 : 0x0 (GOOD)

Mailbox
  Total bytes received   : 960 Bytes
  Unknown                : 0
  Test msg ready         : 0
  Test msg fetch         : 0
  Lock bitstream         : 0
  Unlock bitstream       : 0
  Hot reset              : 0
  Firewall trip          : 0
  Download xclbin kaddr  : 0
  Download xclbin        : 0
  Reclock                : 0
  Peer data read         : 2
  User probe             : 1
  Mgmt state             : 0
  Change shell           : 0
  Reprogram shell        : 0
  P2P bar addr           : 0
                         : 5

CMC
  Status : 0x0 (GOOD)
  Runtime Clock Scaling :
    Supported : false
    Enabled : false
    Critical threshold (clock shutdown) limits:
      Power : 0 W
      Temperature : 0 C
    Throttling threshold limits:
      Power : 0 W
      Temperature : 0 C
    Power threshold override:
      Override : false
      Override limit : 0 W
    Temperature threshold override:
      Override : false
      Override limit : 0 C
Vmr Status
  Information Unavailable
root@xsjsagarw50:~# echo $?
0
```
Other devices are not available though I'll try and add them in

#### Documentation impact (if any)
None
