### PR TITLE
[CR-1078238] XRT package install should fail if .kos are not built

### DIFF
--- a/src/CMake/config/postinst.in
+++ b/src/CMake/config/postinst.in
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
+# Copyright (C) 2022 AMD, Inc. All rights reserved.
 
 #
 # UBUNTU NOTE
@@ -25,6 +26,9 @@
 #    but postinst of 2.3.0 is run. The postinst is invoked with "2" argument.
 # 3. When re-installing (say from 2.2.0 to 2.2.0) then prerm is NOT run but
 #    and postinst of 2.2.0 is run. The postinst is invoked with "2" argument.
+
+RED="\e[31m"
+ENDCOLOR="\e[0m"
 
 rmmodules()
 {
@@ -85,12 +89,12 @@ if [ $? -eq 0 ]; then
 fi
 
 if [ -z "`dkms status -m xrt -v @XRT_VERSION_STRING@ |grep installed`" ]; then
-    echo "****************************************************************"
-    echo "* DKMS failed to install XRT drivers."
-    echo "* Please check if kernel development headers are installed for OS variant used."
-    echo "* "
-    echo "* Check build logs in /var/lib/dkms/xrt/@XRT_VERSION_STRING@"
-    echo "****************************************************************"
+    echo "${RED}****************************************************************${ENDCOLOR}"
+    echo "${RED}* DKMS failed to install XRT drivers.${ENDCOLOR}"
+    echo "${RED}* Please check if kernel development headers are installed for OS variant used.${ENDCOLOR}"
+    echo "${RED}* ${ENDCOLOR}"
+    echo "${RED}* Check build logs in /var/lib/dkms/xrt/@XRT_VERSION_STRING@${ENDCOLOR}"
+    echo "${RED}****************************************************************${ENDCOLOR}"
 fi
 
 echo "Installing MSD / MPD daemons"
@@ -113,4 +117,17 @@ if [ "$mpd_active" = "active" ]; then
     systemctl start mpd > /dev/null 2>&1
 fi
 
+echo "| Components                   |      Status        |"
+echo "|------------------------------|--------------------|"
+if [ -z "`dkms status -m xrt -v @XRT_VERSION_STRING@ |grep installed`" ]; then
+    echo "| XOCL & XCLMGMT Kernel Driver | Failed. Check build log : `find /var/lib/dkms/xrt/ -iname "make.log"`"
+else
+    echo "| XOCL & XCLMGMT Kernel Driver | Success            |"
+fi
+echo "| XRT USERSPACE                | Success            |"
+if [ -f ${systemddir}/msd.service ] && [ -f ${systemdir}/mpd.service ]; then
+    echo "| MPD/MSD                      | Failed             |"
+else
+    echo "| MPD/MSD                      | Success            |"
+fi
 exit 0


### PR DESCRIPTION
#### Problem solved by the commit
In the current XRT, if xocl driving loading fails, the following message is being printed 
           ****************************************************************
           * DKMS failed to install XRT drivers.
           * Please check if kernel development headers are installed for OS variant used.
           *
           * Check build logs in /var/lib/dkms/xrt/2.8.333
           ****************************************************************
With this commit, a brief summary will also be printed with table and color for above dkms message ( RED - Failed). Users will easily identify the failure.
#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
NA
#### How problem was solved, alternative solutions (if any) and why they were rejected

Problem is solved by printed the Installation summary with table and colors
| Component                                   | Status                                                           |
|--------------------------------------|-----------------------------------------------|
| XOCL & XCLMGMT Kernel Driver  | Failed. Check build log path/to/dkms/log  |
| XRT Userspace                               | Succes                                                         |
|MPD/MSD                                      | Failed                                                           |

Other solution :

- Creating seperate packages for xrt userspace and xrt driver space :  _**Rejected**_ because present package architecture is better
- Detect that xrt is being installed in a container and skip DKMS : _**Rejected**_ because detecting if XRT is being installed in container or linux machine is not feasible.

#### Risks (if any) associated the changes in the commit
Low Risk
#### What has been tested and how, request additional testing if necessary
Build and Installed locally.
#### Documentation impact (if any)
No