### PR TITLE
CR-1112059 xbutil validate 'Host memory bandwidth test' is not exercising slave bridge.

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -265,12 +265,14 @@ runTestCase( const std::shared_ptr<xrt_core::device>& _dev, const std::string& p
     return;
   }
 
-  // log xclbin path for debugging purposes
-  logger(_ptTest, "Xclbin", xclbinPath);
-  auto json_exists = [xclbinPath]() {
+  // log xclbin test dir for debugging purposes
+  boost::filesystem::path xclbin_path(xclbinPath);
+  auto test_dir = xclbin_path.parent_path().string();
+  logger(_ptTest, "Xclbin", test_dir);
+
+  auto json_exists = [test_dir]() {
     const static std::string platform_metadata = "/platform.json";
-    boost::filesystem::path test_dir(xclbinPath);
-    std::string platform_json_path(test_dir.parent_path().string() + platform_metadata);
+    std::string platform_json_path(test_dir + platform_metadata);
     return boost::filesystem::exists(platform_json_path) ? true : false;
   };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
xbutil validate doesn't know which xclbin is executed. Only the host code has that information. It is better not to print out any xclbin name as it confuses the user

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Removed xclbin name from being printed. Only the xclbin directory is printed

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Locally
```
...
Test 4 [0000:b3:00.1]     : verify 
    Description           : Run 'Hello World' kernel test
    xclbin                : /opt/xilinx/firmware/u200/gen3x16-xdma/base/test
    Testcase              : /opt/xilinx/xrt/test/validate.exe
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 5 [0000:b3:00.1]     : dma 
    Description           : Run dma test
    Details               : Buffer size - '16 MB'
                            Host -> PCIe -> FPGA write bandwidth = 9128.4 MB/s
                            Host <- PCIe <- FPGA read bandwidth = 11999.6 MB/s
    Test Status           : [PASSED]
-------------------------------------------------------------------------------
Test 6 [0000:b3:00.1]     : iops 
    Description           : Run scheduler performance measure test
    xclbin                : /opt/xilinx/firmware/u200/gen3x16-xdma/base/test
    Testcase              : /opt/xilinx/xrt/test/xcl_iops_test.exe
    Details               : IOPS: 387181 (verify)
    Test Status           : [PASSED]
...
```

#### Documentation impact (if any)
None