### PR TITLE
CR-1125492 Incorrect Transfer Rate BW reported on the DDR in Kernel Data Transfer

### DIFF
--- a/src/runtime_src/core/common/xrt_profiling.h
+++ b/src/runtime_src/core/common/xrt_profiling.h
@@ -37,9 +37,13 @@ XCL_DRIVER_DLLESPEC size_t xclGetDeviceTimestamp(xclDeviceHandle handle);
 
 XCL_DRIVER_DLLESPEC double xclGetDeviceClockFreqMHz(xclDeviceHandle handle);
 
-XCL_DRIVER_DLLESPEC double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle);
+XCL_DRIVER_DLLESPEC double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle);
 
-XCL_DRIVER_DLLESPEC double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle);
+XCL_DRIVER_DLLESPEC double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle);
+
+XCL_DRIVER_DLLESPEC double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle);
+
+XCL_DRIVER_DLLESPEC double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle);
 
 XCL_DRIVER_DLLESPEC void xclGetDebugIpLayout(xclDeviceHandle hdl, char* buffer, size_t size, size_t* size_ret);
 

--- a/src/runtime_src/core/common/xrt_profiling.h
+++ b/src/runtime_src/core/common/xrt_profiling.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2019, Xilinx Inc - All rights reserved
+ * Copyright (C) 2019, Xilinx Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Xilinx Runtime (XRT) APIs
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -314,45 +314,30 @@ size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTrace
 
 double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/halapi.cxx
@@ -320,7 +320,7 @@ double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 }
 
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
 //  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
 //  if (!drv)
@@ -329,7 +329,25 @@ double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
 }
 
 
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+//  if (!drv)
+//    return 0.0;
+  return 0.0;
+}
+
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+//  if (!drv)
+//    return 0.0;
+  return 0.0;
+}
+
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
 //  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
 //  if (!drv)

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/edge/sw_em/generic_pcie_hal2/shim.h
@@ -116,8 +116,10 @@ namespace xclcpuemhal2 {
       // Performance monitoring
       // Control
       double xclGetDeviceClockFreqMHz();
-      double xclGetReadMaxBandwidthMBps();
-      double xclGetWriteMaxBandwidthMBps();
+      double xclGetHostReadMaxBandwidthMBps();
+      double xclGetHostWriteMaxBandwidthMBps();
+      double xclGetKernelReadMaxBandwidthMBps();
+      double xclGetKemrnelWriteMaxBandwidthMBps();
       void xclSetProfilingNumberSlots(xclPerfMonType type, uint32_t numSlots);
       size_t xclPerfMonClockTraining(xclPerfMonType type);
       // Counters

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -738,22 +738,20 @@ xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint6
   return 0;
 }
 
-// For PCIe gen 3x16 or 4x8:
-// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+// For DDR4: Max BW = 21.3 GB/s
 double 
 shim::
 xclGetHostReadMaxBandwidthMBps()
 {
-  return 15753.85;
+  return 21300.00;
 }
 
-// For PCIe gen 3x16 or 4x8:
-// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+// For DDR4: Max BW = 21.3 GB/s
 double 
 shim::
 xclGetHostWriteMaxBandwidthMBps()
 {
-  return 15753.85;
+  return 21300.00;
 }
 
 // For DDR4: Max BW = 21.3 GB/s

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -738,24 +738,38 @@ xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint6
   return 0;
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/s)
-// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
-//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
-double
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double 
 shim::
-xclGetReadMaxBandwidthMBps()
+xclGetHostReadMaxBandwidthMBps()
 {
   return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/s)
-// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
-//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
-double
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double 
 shim::
-xclGetWriteMaxBandwidthMBps()
+xclGetHostWriteMaxBandwidthMBps()
 {
   return 15753.85;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double 
+shim::
+xclGetKernelReadMaxBandwidthMBps()
+{
+  return 21300.00;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double 
+shim::
+xclGetKernelWriteMaxBandwidthMBps()
+{
+  return 21300.00;
 }
 
 int
@@ -2007,18 +2021,34 @@ xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 }
 
 double
-xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
-  return drv ? drv->xclGetReadMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostReadMaxBandwidthMBps() : 0.0;
 }
 
 
 double
-xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
-  return drv ? drv->xclGetWriteMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostWriteMaxBandwidthMBps() : 0.0;
+}
+
+
+double
+xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  return drv ? drv->xclGetKernelReadMaxBandwidthMBps() : 0.0;
+}
+
+
+double
+xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  ZYNQ::shim *drv = ZYNQ::shim::handleCheck(handle);
+  return drv ? drv->xclGetKernelWriteMaxBandwidthMBps() : 0.0;
 }
 
 

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -932,36 +932,36 @@ xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint6
   return 0;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double 
 shim::
 xclGetHostReadMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double 
 shim::
 xclGetHostWriteMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double 
 shim::
 xclGetKernelReadMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double 
 shim::
 xclGetKernelWriteMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -738,22 +738,24 @@ xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint6
   return 0;
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
+// Get the maximum bandwidth for host reads from the device (in MB/s)
+// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
+//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
 double
 shim::
 xclGetReadMaxBandwidthMBps()
 {
-  return 9600.0;
+  return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
+// Get the maximum bandwidth for host writes to the device (in MB/s)
+// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
+//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
 double
 shim::
 xclGetWriteMaxBandwidthMBps()
 {
-  return 9600.0;
+  return 15753.85;
 }
 
 int

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -97,8 +97,10 @@ public:
   int xclGetTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz);
   int xclReadTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample);
 
-  double xclGetReadMaxBandwidthMBps();
-  double xclGetWriteMaxBandwidthMBps();
+  double xclGetHostReadMaxBandwidthMBps();
+  double xclGetHostWriteMaxBandwidthMBps();
+  double xclGetKernelReadMaxBandwidthMBps();
+  double xclGetKernelWriteMaxBandwidthMBps();
 
   // Bitstream/bin download
   int xclLoadXclBin(const xclBin *buffer);

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -291,45 +291,24 @@ size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTrace
 
 double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 
 
 double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
-  return 0.0;
-}
-
-
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
-{
-//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
-//  if (!drv)
-//    return 0.0;
   return 0.0;
 }
 

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/halapi.cxx
@@ -288,7 +288,7 @@ size_t xclPerfMonReadTrace(xclDeviceHandle handle, xclPerfMonType type, xclTrace
 }
 
 
-double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
 //  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
 //  if (!drv)
@@ -297,7 +297,25 @@ double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
 }
 
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+//  if (!drv)
+//    return 0.0;
+  return 0.0;
+}
+
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+//  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
+//  if (!drv)
+//    return 0.0;
+  return 0.0;
+}
+
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
 //  xclcpuemhal2::CpuemShim *drv = xclcpuemhal2::CpuemShim::handleCheck(handle);
 //  if (!drv)

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -119,8 +119,10 @@ namespace xclcpuemhal2 {
       // Performance monitoring
       // Control
       double xclGetDeviceClockFreqMHz();
-      double xclGetReadMaxBandwidthMBps();
-      double xclGetWriteMaxBandwidthMBps();
+      double xclGetHostReadMaxBandwidthMBps();
+      double xclGetHostWriteMaxBandwidthMBps();
+      double xclGetKernelReadMaxBandwidthMBps();
+      double xclGetKernelWriteMaxBandwidthMBps();
       void xclSetProfilingNumberSlots(xclPerfMonType type, uint32_t numSlots);
       size_t xclPerfMonClockTraining(xclPerfMonType type);
       // Counters

--- a/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/cpu_em/generic_pcie_hal2/shim.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2019 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/halapi.cxx
@@ -497,20 +497,36 @@ double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
   return drv->xclGetDeviceClockFreqMHz();
 }
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
   if (!drv)
     return -1;
-  return drv->xclGetReadMaxBandwidthMBps();
+  return drv->xclGetHostReadMaxBandwidthMBps();
 }
 
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
   if (!drv)
     return -1;
-  return drv->xclGetWriteMaxBandwidthMBps();
+  return drv->xclGetHostWriteMaxBandwidthMBps();
+}
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
+  if (!drv)
+    return -1;
+  return drv->xclGetKernelReadMaxBandwidthMBps();
+}
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xclhwemhal2::HwEmShim *drv = xclhwemhal2::HwEmShim::handleCheck(handle);
+  if (!drv)
+    return -1;
+  return drv->xclGetKernelWriteMaxBandwidthMBps();
 }
 
 /*

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -3290,16 +3290,16 @@ double HwEmShim::xclGetHostWriteMaxBandwidthMBps()
   return 15753.85;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double HwEmShim::xclGetKernelReadMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double HwEmShim::xclGetKernelWriteMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
 uint32_t HwEmShim::getPerfMonNumberSlots(xclPerfMonType type)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -3255,18 +3255,30 @@ double HwEmShim::xclGetDeviceClockFreqMHz()
   return clockSpeed;
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/sec)
-// NOTE: for now, just return 8.0 GBps (the max achievable for PCIe Gen3)
-double HwEmShim::xclGetReadMaxBandwidthMBps()
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double HwEmShim::xclGetHostReadMaxBandwidthMBps()
 {
-  return 8000.0;
+  return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/sec)
-// NOTE: for now, just return 8.0 GBps (the max achievable for PCIe Gen3)
-double HwEmShim::xclGetWriteMaxBandwidthMBps()
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double HwEmShim::xclGetHostWriteMaxBandwidthMBps()
 {
-  return 8000.0;
+  return 15753.85;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double HwEmShim::xclGetKernelReadMaxBandwidthMBps()
+{
+  return 21300.00;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double HwEmShim::xclGetKernelWriteMaxBandwidthMBps()
+{
+  return 21300.00;
 }
 
 uint32_t HwEmShim::getPerfMonNumberSlots(xclPerfMonType type)

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.h
@@ -172,8 +172,10 @@ using addr_type = uint64_t;
 
       //Performance Monitor APIs
       double xclGetDeviceClockFreqMHz();
-      double xclGetReadMaxBandwidthMBps();
-      double xclGetWriteMaxBandwidthMBps();
+      double xclGetHostReadMaxBandwidthMBps();
+      double xclGetHostWriteMaxBandwidthMBps();
+      double xclGetKernelReadMaxBandwidthMBps();
+      double xclGetKernelWriteMaxBandwidthMBps();
       size_t xclGetDeviceTimestamp();
       void xclReadBusStatus(xclPerfMonType type);
       void xclGetDebugMessages(bool force = false);

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2166,16 +2166,16 @@ double shim::xclGetHostWriteMaxBandwidthMBps()
   return 15753.85;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double shim::xclGetKernelReadMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
 double shim::xclGetKernelWriteMaxBandwidthMBps()
 {
-  return 21300.00;
+  return 19250.00;
 }
 
 int shim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2152,19 +2152,30 @@ double shim::xclGetDeviceClockFreqMHz()
   return ((double)clockFreq);
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/s)
-// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
-//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
-double shim::xclGetReadMaxBandwidthMBps()
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double shim::xclGetHostReadMaxBandwidthMBps()
 {
   return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/s)
-// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
-//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
-double shim::xclGetWriteMaxBandwidthMBps() {
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double shim::xclGetHostWriteMaxBandwidthMBps()
+{
   return 15753.85;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double shim::xclGetKernelReadMaxBandwidthMBps()
+{
+  return 21300.00;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double shim::xclGetKernelWriteMaxBandwidthMBps()
+{
+  return 21300.00;
 }
 
 int shim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)
@@ -2944,17 +2955,28 @@ double xclGetDeviceClockFreqMHz(xclDeviceHandle handle)
   return drv ? drv->xclGetDeviceClockFreqMHz() : 0.0;
 }
 
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xocl::shim *drv = xocl::shim::handleCheck(handle);
-  return drv ? drv->xclGetReadMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostReadMaxBandwidthMBps() : 0.0;
 }
 
-
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   xocl::shim *drv = xocl::shim::handleCheck(handle);
-  return drv ? drv->xclGetWriteMaxBandwidthMBps() : 0.0;
+  return drv ? drv->xclGetHostWriteMaxBandwidthMBps() : 0.0;
+}
+
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xocl::shim *drv = xocl::shim::handleCheck(handle);
+  return drv ? drv->xclGetKernelReadMaxBandwidthMBps() : 0.0;
+}
+
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  xocl::shim *drv = xocl::shim::handleCheck(handle);
+  return drv ? drv->xclGetKernelWriteMaxBandwidthMBps() : 0.0;
 }
 
 int xclGetSysfsPath(xclDeviceHandle handle, const char* subdev,

--- a/src/runtime_src/core/pcie/linux/shim.cpp
+++ b/src/runtime_src/core/pcie/linux/shim.cpp
@@ -2152,17 +2152,19 @@ double shim::xclGetDeviceClockFreqMHz()
   return ((double)clockFreq);
 }
 
-// Get the maximum bandwidth for host reads from the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
+// Get the maximum bandwidth for host reads from the device (in MB/s)
+// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
+//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
 double shim::xclGetReadMaxBandwidthMBps()
 {
-  return 9600.0;
+  return 15753.85;
 }
 
-// Get the maximum bandwidth for host writes to the device (in MB/sec)
-// NOTE: for now, set to: (256/8 bytes) * 300 MHz = 9600 MBps
+// Get the maximum bandwidth for host writes to the device (in MB/s)
+// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
+//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
 double shim::xclGetWriteMaxBandwidthMBps() {
-  return 9600.0;
+  return 15753.85;
 }
 
 int shim::xclGetSysfsPath(const char* subdev, const char* entry, char* sysfsPath, size_t size)

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -107,8 +107,10 @@ public:
     int xclGetSectionInfo(void *section_info, size_t *section_size, enum axlf_section_kind, int index);
 
     double xclGetDeviceClockFreqMHz();
-    double xclGetReadMaxBandwidthMBps();
-    double xclGetWriteMaxBandwidthMBps();
+    double xclGetHostReadMaxBandwidthMBps();
+    double xclGetHostWriteMaxBandwidthMBps();
+    double xclGetKernelReadMaxBandwidthMBps();
+    double xclGetKernelWriteMaxBandwidthMBps();
     //debug related
     uint32_t getCheckerNumberSlots(int type);
     uint32_t getIPCountAddrNames(int type, uint64_t *baseAddress, std::string * portNames,

--- a/src/runtime_src/core/pcie/linux/shim.h
+++ b/src/runtime_src/core/pcie/linux/shim.h
@@ -3,6 +3,7 @@
 
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Author(s): Umang Parekh
  *          : Sonal Santan
  *          : Ryan Radjabi

--- a/src/runtime_src/core/pcie/windows/alveo/perf.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/perf.cpp
@@ -1,6 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (C) 2019-2021 Xilinx, Inc. All rights reserved.
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  */
 #define XCL_DRIVER_DLL_EXPORT
 #define XRT_CORE_PCIE_WINDOWS_SOURCE
@@ -41,12 +42,6 @@ double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
   return 15753.85;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
-double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
-{
-  return 21300.00;
-}
-
 // For PCIe gen 3x16 or 4x8:
 // Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
 double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
@@ -54,10 +49,16 @@ double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
   return 15753.85;
 }
 
-// For DDR4: Max BW = 21.3 GB/s
+// For DDR4: Typical Max BW = 19.25 GB/s
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 19250.00;
+}
+
+// For DDR4: Typical Max BW = 19.25 GB/s
 double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 21300.00;
+  return 19250.00;
 }
 
 #if 0

--- a/src/runtime_src/core/pcie/windows/alveo/perf.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/perf.cpp
@@ -34,14 +34,18 @@ xclGetDeviceTimestamp(xclDeviceHandle handle)
   return 0;
 }
 
+// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
+//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
 double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 9600.0;
+  return 15753.85;
 }
 
+// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
+//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
 double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
-  return 9600.0;
+  return 15753.85;
 }
 
 #if 0

--- a/src/runtime_src/core/pcie/windows/alveo/perf.cpp
+++ b/src/runtime_src/core/pcie/windows/alveo/perf.cpp
@@ -34,18 +34,30 @@ xclGetDeviceTimestamp(xclDeviceHandle handle)
   return 0;
 }
 
-// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
-//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
-double xclGetReadMaxBandwidthMBps(xclDeviceHandle handle)
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double xclGetHostReadMaxBandwidthMBps(xclDeviceHandle handle)
 {
   return 15753.85;
 }
 
-// NOTE: For now, this is limited to PCIe gen 3x16 or 4x8, where:
-//       Max bandwidth = 16000 * (128b/130b encoding) = 15753.85 MB/s
-double xclGetWriteMaxBandwidthMBps(xclDeviceHandle handle)
+// For DDR4: Max BW = 21.3 GB/s
+double xclGetKernelReadMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 21300.00;
+}
+
+// For PCIe gen 3x16 or 4x8:
+// Max BW = 16.0 * (128b/130b encoding) = 15.75385 GB/s
+double xclGetHostWriteMaxBandwidthMBps(xclDeviceHandle handle)
 {
   return 15753.85;
+}
+
+// For DDR4: Max BW = 21.3 GB/s
+double xclGetKernelWriteMaxBandwidthMBps(xclDeviceHandle handle)
+{
+  return 21300.00;
 }
 
 #if 0

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
+++ b/src/runtime_src/xdp/profile/database/static_info/xclbin_info.h
@@ -42,12 +42,13 @@ namespace xdp {
   struct PLInfo
   {
     // Max read/write bandwidth information is retrieved from either
-    //  a call to the shim functions xclGetReadMaxBandwidthMBps and
-    //  xclGetWriteMaxBandwidthMBps, or from from the higher level 
-    //  xrt_xocl::device functions getDeviceMaxRead and getDeviceMaxWrite
-    //  in OpenCL applications.
-    double maxReadBW  = 0.0 ;
-    double maxWriteBW = 0.0 ;
+    //  a call to the shim functions xclGet*MaxBandwidthMBps, or from 
+    //  the higher level xrt_xocl::device functions getHostMax* and 
+    //  getKernelMax* in OpenCL applications.
+    double hostMaxReadBW    = 0.0 ;
+    double hostMaxWriteBW   = 0.0 ;
+    double kernelMaxReadBW  = 0.0 ;
+    double kernelMaxWriteBW = 0.0 ;
 
     // By default, we assume a PL clock rate of 300 MHz.  We try to set this
     //  to the true value based on device information gotten from either the

--- a/src/runtime_src/xdp/profile/database/static_info_database.cpp
+++ b/src/runtime_src/xdp/profile/database/static_info_database.cpp
@@ -409,7 +409,7 @@ namespace xdp {
     return deviceInfo[deviceId]->kdmaCount ;
   }
 
-  void VPStaticDatabase::setMaxReadBW(uint64_t deviceId, double bw)
+  void VPStaticDatabase::setHostMaxReadBW(uint64_t deviceId, double bw)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
@@ -418,10 +418,10 @@ namespace xdp {
     XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
     if (!xclbin)
       return ;
-    xclbin->pl.maxReadBW = bw ;
+    xclbin->pl.hostMaxReadBW = bw ;
   }
 
-  double VPStaticDatabase::getMaxReadBW(uint64_t deviceId)
+  double VPStaticDatabase::getHostMaxReadBW(uint64_t deviceId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
@@ -432,10 +432,10 @@ namespace xdp {
     if (!xclbin)
       return 0.0 ;
 
-    return xclbin->pl.maxReadBW ;
+    return xclbin->pl.hostMaxReadBW ;
   }
 
-  void VPStaticDatabase::setMaxWriteBW(uint64_t deviceId, double bw)
+  void VPStaticDatabase::setHostMaxWriteBW(uint64_t deviceId, double bw)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
@@ -446,10 +446,10 @@ namespace xdp {
     if (!xclbin)
       return ;
 
-    xclbin->pl.maxWriteBW = bw ;
+    xclbin->pl.hostMaxWriteBW = bw ;
   }
 
-  double VPStaticDatabase::getMaxWriteBW(uint64_t deviceId)
+  double VPStaticDatabase::getHostMaxWriteBW(uint64_t deviceId)
   {
     std::lock_guard<std::mutex> lock(deviceLock) ;
 
@@ -460,7 +460,61 @@ namespace xdp {
     if (!xclbin)
       return 0.0 ;
 
-    return xclbin->pl.maxWriteBW ;
+    return xclbin->pl.hostMaxWriteBW ;
+  }
+
+  void VPStaticDatabase::setKernelMaxReadBW(uint64_t deviceId, double bw)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return ;
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return ;
+    xclbin->pl.kernelMaxReadBW = bw ;
+  }
+
+  double VPStaticDatabase::getKernelMaxReadBW(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return 0.0 ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return 0.0 ;
+
+    return xclbin->pl.kernelMaxReadBW ;
+  }
+
+  void VPStaticDatabase::setKernelMaxWriteBW(uint64_t deviceId, double bw)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return ;
+
+    xclbin->pl.kernelMaxWriteBW = bw ;
+  }
+
+  double VPStaticDatabase::getKernelMaxWriteBW(uint64_t deviceId)
+  {
+    std::lock_guard<std::mutex> lock(deviceLock) ;
+
+    if (deviceInfo.find(deviceId) == deviceInfo.end())
+      return 0.0 ;
+
+    XclbinInfo* xclbin = deviceInfo[deviceId]->currentXclbin() ;
+    if (!xclbin)
+      return 0.0 ;
+
+    return xclbin->pl.kernelMaxWriteBW ;
   }
 
   std::string VPStaticDatabase::getXclbinName(uint64_t deviceId)

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/database/static_info_database.h
+++ b/src/runtime_src/xdp/profile/database/static_info_database.h
@@ -220,10 +220,14 @@ namespace xdp {
     XDP_EXPORT DeviceIntf* getDeviceIntf(uint64_t deviceId) ;
     XDP_EXPORT void setKDMACount(uint64_t deviceId, uint64_t num) ;
     XDP_EXPORT uint64_t getKDMACount(uint64_t deviceId) ;
-    XDP_EXPORT void setMaxReadBW(uint64_t deviceId, double bw) ;
-    XDP_EXPORT double getMaxReadBW(uint64_t deviceId) ;
-    XDP_EXPORT void setMaxWriteBW(uint64_t deviceId, double bw) ;
-    XDP_EXPORT double getMaxWriteBW(uint64_t deviceId) ;
+    XDP_EXPORT void setHostMaxReadBW(uint64_t deviceId, double bw) ;
+    XDP_EXPORT double getHostMaxReadBW(uint64_t deviceId) ;
+    XDP_EXPORT void setHostMaxWriteBW(uint64_t deviceId, double bw) ;
+    XDP_EXPORT double getHostMaxWriteBW(uint64_t deviceId) ;
+    XDP_EXPORT void setKernelMaxReadBW(uint64_t deviceId, double bw) ;
+    XDP_EXPORT double getKernelMaxReadBW(uint64_t deviceId) ;
+    XDP_EXPORT void setKernelMaxWriteBW(uint64_t deviceId, double bw) ;
+    XDP_EXPORT double getKernelMaxWriteBW(uint64_t deviceId) ;
     XDP_EXPORT std::string getXclbinName(uint64_t deviceId) ;
     XDP_EXPORT std::vector<XclbinInfo*> getLoadedXclbins(uint64_t deviceId) ;
     XDP_EXPORT ComputeUnitInstance* getCU(uint64_t deviceId, int32_t cuId) ;

--- a/src/runtime_src/xdp/profile/device/device_intf.cpp
+++ b/src/runtime_src/xdp/profile/device/device_intf.cpp
@@ -960,14 +960,24 @@ DeviceIntf::~DeviceIntf()
     return mAieTraceDmaList[index]->getMemIndex();
   }
 
-  void DeviceIntf::setMaxBwRead()
+  void DeviceIntf::setHostMaxBwRead()
   {
-    mMaxReadBW = mDevice->getMaxBwRead();
+    mHostMaxReadBW = mDevice->getHostMaxBwRead();
   }
 
-  void DeviceIntf::setMaxBwWrite()
+  void DeviceIntf::setHostMaxBwWrite()
   {
-    mMaxWriteBW = mDevice->getMaxBwWrite();
+    mHostMaxWriteBW = mDevice->getHostMaxBwWrite();
+  }
+
+  void DeviceIntf::setKernelMaxBwRead()
+  {
+    mKernelMaxReadBW = mDevice->getKernelMaxBwRead();
+  }
+
+  void DeviceIntf::setKernelMaxBwWrite()
+  {
+    mKernelMaxWriteBW = mDevice->getKernelMaxBwWrite();
   }
 
   uint32_t DeviceIntf::getDeadlockStatus()

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -201,11 +201,12 @@ class DeviceIntf {
      *   bw_per_lane = 985 MB/s (Wikipedia on PCIE 3.0)
      *   num_lanes = 16/8/4 depending on host system
      *   total bw = bw_per_lane * num_lanes
+     *   encoding = 128b/130b
      * For Edge Device:
      *  total bw = DDR4 memory bandwidth
      */
-    double mMaxReadBW  = 9600.0;
-    double mMaxWriteBW = 9600.0;
+    double mMaxReadBW  = 15753.85;
+    double mMaxWriteBW = 15753.85;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -154,12 +154,18 @@ class DeviceIntf {
     XDP_EXPORT
     uint8_t  getAIETs2mmMemIndex(uint64_t index);
     
-    double getMaxBwRead() const {return mMaxReadBW;}
-    double getMaxBwWrite() const {return mMaxWriteBW;}
+    double getHostMaxBwRead() const {return mHostMaxReadBW;}
+    double getHostMaxBwWrite() const {return mHostMaxWriteBW;}
+    double getKernelMaxBwRead() const {return mKernelMaxReadBW;}
+    double getKernelMaxBwWrite() const {return mKernelMaxWriteBW;}
     XDP_EXPORT
-    void setMaxBwRead();
+    void setHostMaxBwRead();
     XDP_EXPORT
-    void setMaxBwWrite();
+    void setHostMaxBwWrite();
+    XDP_EXPORT
+    void setKernelMaxBwRead();
+    XDP_EXPORT
+    void setKernelMaxBwWrite();
 
     XDP_EXPORT
     uint32_t getDeadlockStatus();
@@ -196,17 +202,17 @@ class DeviceIntf {
     DeadlockDetector*     mDeadlockDetector  = nullptr;
 
     /*
-     * Set bandwidth number to a reasonable default
+     * Set max bandwidths to reasonable defaults
      * For PCIE Device:
-     *   bw_per_lane = 985 MB/s (Wikipedia on PCIE 3.0)
-     *   num_lanes = 16/8/4 depending on host system
-     *   total bw = bw_per_lane * num_lanes
-     *   encoding = 128b/130b
+     *   configuration: gen 3x16, gen 4x8 
+     *   encoding: 128b/130b
      * For Edge Device:
-     *  total bw = DDR4 memory bandwidth
+     *  total BW: DDR4 memory bandwidth
      */
-    double mMaxReadBW  = 15753.85;
-    double mMaxWriteBW = 15753.85;
+    double mHostMaxReadBW    = 15753.85;
+    double mHostMaxWriteBW   = 15753.85;
+    double mKernelMaxReadBW  = 21300.00;
+    double mKernelMaxWriteBW = 21300.00;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/device_intf.h
+++ b/src/runtime_src/xdp/profile/device/device_intf.h
@@ -3,7 +3,7 @@
 
 /**
  * Copyright (C) 2016-2022 Xilinx, Inc
-
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  * Author(s): Paul Schumacher
  *          : Anurag Dubey
  *          : Tianhao Zhou
@@ -211,8 +211,8 @@ class DeviceIntf {
      */
     double mHostMaxReadBW    = 15753.85;
     double mHostMaxWriteBW   = 15753.85;
-    double mKernelMaxReadBW  = 21300.00;
-    double mKernelMaxWriteBW = 21300.00;
+    double mKernelMaxReadBW  = 19250.00;
+    double mKernelMaxWriteBW = 19250.00;
 
 }; /* DeviceIntf */
 

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.cpp
@@ -153,14 +153,24 @@ uint64_t HalDevice::getDeviceAddr(size_t id)
   return xrt_bos[boIndex].address();
 }
 
-double HalDevice::getMaxBwRead()
+double HalDevice::getHostMaxBwRead()
 {
-  return xclGetReadMaxBandwidthMBps(mHalDevice);
+  return xclGetHostReadMaxBandwidthMBps(mHalDevice);
 }
 
-double HalDevice::getMaxBwWrite()
+double HalDevice::getHostMaxBwWrite()
 {
-   return xclGetWriteMaxBandwidthMBps(mHalDevice);
+   return xclGetHostWriteMaxBandwidthMBps(mHalDevice);
+}
+
+double HalDevice::getKernelMaxBwRead()
+{
+  return xclGetKernelReadMaxBandwidthMBps(mHalDevice);
+}
+
+double HalDevice::getKernelMaxBwWrite()
+{
+   return xclGetKernelWriteMaxBandwidthMBps(mHalDevice);
 }
 
 std::string HalDevice::getSubDevicePath(std::string& subdev, uint32_t index)

--- a/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
+++ b/src/runtime_src/xdp/profile/device/hal_device/xdp_hal_device.h
@@ -55,8 +55,10 @@ public:
   virtual uint64_t getDeviceAddr(size_t xdpBoHandle);
   virtual void* getRawDevice() { return mHalDevice ; }
 
-  virtual double getMaxBwRead();
-  virtual double getMaxBwWrite();
+  virtual double getHostMaxBwRead();
+  virtual double getHostMaxBwWrite();
+  virtual double getKernelMaxBwRead();
+  virtual double getKernelMaxBwWrite();
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index);
 };

--- a/src/runtime_src/xdp/profile/device/xdp_base_device.h
+++ b/src/runtime_src/xdp/profile/device/xdp_base_device.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/device/xdp_base_device.h
+++ b/src/runtime_src/xdp/profile/device/xdp_base_device.h
@@ -58,8 +58,10 @@ public:
   virtual int getTraceBufferInfo(uint32_t nSamples, uint32_t& traceSamples, uint32_t& traceBufSz) = 0;
   virtual int readTraceData(void* traceBuf, uint32_t traceBufSz, uint32_t numSamples, uint64_t ipBaseAddress, uint32_t& wordsPerSample) = 0;
 
-  virtual double getMaxBwRead() = 0;
-  virtual double getMaxBwWrite() = 0;
+  virtual double getHostMaxBwRead() = 0;
+  virtual double getHostMaxBwWrite() = 0;
+  virtual double getKernelMaxBwRead() = 0;
+  virtual double getKernelMaxBwWrite() = 0;
 
   virtual void* getRawDevice() = 0 ;
 

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
@@ -140,14 +140,24 @@ uint64_t XrtDevice::getDeviceAddr(size_t xdpBoHandle)
   return mXrtDevice->getDeviceAddr(m_bos[idx]);
 }
 
-double XrtDevice::getMaxBwRead()
+double XrtDevice::getHostMaxBwRead()
 {
-  return mXrtDevice->getDeviceMaxRead().get();
+  return mXrtDevice->getHostMaxRead().get();
 }
 
-double XrtDevice::getMaxBwWrite()
+double XrtDevice::getHostMaxBwWrite()
 {
-  return mXrtDevice->getDeviceMaxWrite().get();
+  return mXrtDevice->getHostMaxWrite().get();
+}
+
+double XrtDevice::getKernelMaxBwRead()
+{
+  return mXrtDevice->getKernelMaxRead().get();
+}
+
+double XrtDevice::getKernelMaxBwWrite()
+{
+  return mXrtDevice->getKernelMaxWrite().get();
 }
 
 std::string XrtDevice::getSubDevicePath(std::string& subdev, uint32_t index)

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.cpp
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
@@ -1,5 +1,6 @@
 /**
- * Copyright (C) 2019-2020 Xilinx, Inc
+ * Copyright (C) 2019-2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
+++ b/src/runtime_src/xdp/profile/device/xrt_device/xdp_xrt_device.h
@@ -61,8 +61,10 @@ public:
   virtual uint64_t getDeviceAddr(size_t xdpBoHandle);
   virtual void* getRawDevice() { return mXrtDevice ; } 
 
-  virtual double getMaxBwRead();
-  virtual double getMaxBwWrite();
+  virtual double getHostMaxBwRead();
+  virtual double getHostMaxBwWrite();
+  virtual double getKernelMaxBwRead();
+  virtual double getKernelMaxBwWrite();
 
   virtual std::string getSubDevicePath(std::string& subdev, uint32_t index);
 };

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hal/hal_device_offload_plugin.cpp
@@ -199,8 +199,10 @@ namespace xdp {
 
     // Once the device has been set up, add additional information to 
     //  the static database
-    (db->getStaticInfo()).setMaxReadBW(deviceId, devInterface->getMaxBwRead()) ;
-    (db->getStaticInfo()).setMaxWriteBW(deviceId, devInterface->getMaxBwWrite());
+    (db->getStaticInfo()).setHostMaxReadBW(deviceId, devInterface->getHostMaxBwRead()) ;
+    (db->getStaticInfo()).setHostMaxWriteBW(deviceId, devInterface->getHostMaxBwWrite());
+    (db->getStaticInfo()).setKernelMaxReadBW(deviceId, devInterface->getKernelMaxBwRead()) ;
+    (db->getStaticInfo()).setKernelMaxWriteBW(deviceId, devInterface->getKernelMaxBwWrite());
   }
   
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
+++ b/src/runtime_src/xdp/profile/plugin/device_offload/hw_emu/hw_emu_device_offload_plugin.cpp
@@ -172,8 +172,10 @@ namespace xdp {
 
     // Once the device has been set up, add additional information to 
     //  the static database
-    (db->getStaticInfo()).setMaxReadBW(deviceId, devInterface->getMaxBwRead()) ;
-    (db->getStaticInfo()).setMaxWriteBW(deviceId, devInterface->getMaxBwWrite());
+    (db->getStaticInfo()).setHostMaxReadBW(deviceId, devInterface->getHostMaxBwRead()) ;
+    (db->getStaticInfo()).setHostMaxWriteBW(deviceId, devInterface->getHostMaxBwWrite());
+    (db->getStaticInfo()).setKernelMaxReadBW(deviceId, devInterface->getKernelMaxBwRead()) ;
+    (db->getStaticInfo()).setKernelMaxWriteBW(deviceId, devInterface->getKernelMaxBwWrite());
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -909,6 +909,7 @@ namespace xdp {
 
         double maxReadBW = db->getStaticInfo().getMaxReadBW(deviceID);
         double aveBWUtil = (one_hundred * transferRate) / maxReadBW;
+        if (aveBWUtil > one_hundred) aveBWUtil = one_hundred;
 
         printNA ? (fout << "N/A,") : (fout << transferRate << ",");
         printNA ? (fout << "N/A,") : (fout << aveBWUtil << ",");

--- a/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/vp_base/summary_writer.cpp
@@ -873,7 +873,7 @@ namespace xdp {
          << "Average Time (ms)"                 << ",\n";
 
     std::string types[2] = { "READ", "WRITE" };
-    uint64_t i = 0 ;
+    uint64_t i = 0;
 
     for (auto& map : { hostReads, hostWrites }) {
       for (auto entry : map) {
@@ -907,8 +907,9 @@ namespace xdp {
           static_cast<double>(stats.totalSize / one_million);
         double transferRate  = totalSizeInMB / totalTimeInS; 
 
-        double maxReadBW = db->getStaticInfo().getMaxReadBW(deviceID);
-        double aveBWUtil = (one_hundred * transferRate) / maxReadBW;
+        double maxBW = (i == 0) ? db->getStaticInfo().getHostMaxReadBW(deviceID)
+                                : db->getStaticInfo().getHostMaxWriteBW(deviceID);
+        double aveBWUtil = (one_hundred * transferRate) / maxBW;
         if (aveBWUtil > one_hundred) aveBWUtil = one_hundred;
 
         printNA ? (fout << "N/A,") : (fout << transferRate << ",");
@@ -977,12 +978,11 @@ namespace xdp {
       fout << ((double)(stats.minSize) / one_thousand) << "," ;
       fout << ((double)(stats.averageSize) / one_thousand) << "," ;
       if (getFlowMode() == HW) {
-        auto totalTimeInS  = (double)(stats.totalTime / one_billion);
-        auto totalSizeInMB = (double)(stats.totalSize / one_million);
-        double transferRate  = totalSizeInMB / totalTimeInS; 
-        double maxReadBW =
-          (db->getStaticInfo()).getMaxReadBW(deviceId) ;
-        double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        auto totalTimeInS   = (double)(stats.totalTime / one_billion);
+        auto totalSizeInMB  = (double)(stats.totalSize / one_million);
+        double transferRate = totalSizeInMB / totalTimeInS; 
+        double maxReadBW    = (db->getStaticInfo()).getHostMaxReadBW(deviceId);
+        double aveBWUtil    = (one_hundred * transferRate) / maxReadBW;
 
         fout << transferRate << "," ;
         fout << aveBWUtil << "," ;
@@ -1041,12 +1041,11 @@ namespace xdp {
       fout << ((double)(stats.minSize) / one_thousand) << "," ;
       fout << ((double)(stats.averageSize) / one_thousand) << "," ;
       if (getFlowMode() == HW) {
-        auto totalTimeInS  = (double)(stats.totalTime / one_billion);
-        auto totalSizeInMB = (double)(stats.totalSize / one_million);
-        double transferRate  = totalSizeInMB / totalTimeInS; 
-        double maxReadBW =
-          (db->getStaticInfo()).getMaxReadBW(deviceId) ;
-        double aveBWUtil = (one_hundred * transferRate) / maxReadBW ;
+        auto totalTimeInS   = (double)(stats.totalTime / one_billion);
+        auto totalSizeInMB  = (double)(stats.totalSize / one_million);
+        double transferRate = totalSizeInMB / totalTimeInS; 
+        double maxWriteBW   = (db->getStaticInfo()).getHostMaxWriteBW(deviceId);
+        double aveBWUtil    = (one_hundred * transferRate) / maxWriteBW;
 
         fout << transferRate << "," ;
         fout << aveBWUtil << "," ;
@@ -1733,9 +1732,8 @@ namespace xdp {
           if (writeTranx > 0) {
             double transferRate = (totalWriteTime == zero) ? 0 :
               (double)(values.WriteBytes[monitorId]) / (one_thousand * totalWriteTime);
-            double aveBW =
-              (one_hundred * transferRate) / xclbin->pl.maxWriteBW ;
-            if (aveBW > one_hundred) aveBW = one_hundred ;
+            double aveBW = (one_hundred * transferRate) / xclbin->pl.kernelMaxWriteBW;
+            if (aveBW > one_hundred) aveBW = one_hundred;
             auto aveLatency =
               static_cast<double>(values.WriteLatency[monitorId]) /
               static_cast<double>(writeTranx) ;
@@ -1755,12 +1753,11 @@ namespace xdp {
           if (readTranx > 0) {
               double transferRate = (totalReadTime == zero) ? 0 :
                 (double)(values.ReadBytes[monitorId]) / (one_thousand * totalReadTime);
-              double aveBW =
-                (one_hundred * transferRate) / xclbin->pl.maxReadBW ;
-              if (aveBW > one_hundred) aveBW = one_hundred ;
+              double aveBW = (one_hundred * transferRate) / xclbin->pl.kernelMaxReadBW;
+              if (aveBW > one_hundred) aveBW = one_hundred;
               auto aveLatency =
                 static_cast<double>(values.ReadLatency[monitorId]) /
-                static_cast<double>(readTranx) ;
+                static_cast<double>(readTranx);
 
               fout << device->getUniqueDeviceName() << ","
                    << xclbin->pl.cus[monitor->cuIndex]->getName() << "/"

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -613,15 +613,27 @@ public:
   }
 
   hal::operations_result<double>
-  getDeviceMaxRead()
+  getHostMaxRead()
   {
-    return m_hal->getDeviceMaxRead();
+    return m_hal->getHostMaxRead();
   }
 
   hal::operations_result<double>
-  getDeviceMaxWrite()
+  getHostMaxWrite()
   {
-    return m_hal->getDeviceMaxWrite();
+    return m_hal->getHostMaxWrite();
+  }
+
+  hal::operations_result<double>
+  getKernelMaxRead()
+  {
+    return m_hal->getKernelMaxRead();
+  }
+
+  hal::operations_result<double>
+  getKernelMaxWrite()
+  {
+    return m_hal->getKernelMaxWrite();
   }
 
   hal::operations_result<size_t>

--- a/src/runtime_src/xrt/device/device.h
+++ b/src/runtime_src/xrt/device/device.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xrt/device/hal.h
+++ b/src/runtime_src/xrt/device/hal.h
@@ -487,13 +487,25 @@ public:
   }
 
   virtual operations_result<double>
-  getDeviceMaxRead()
+  getHostMaxRead()
   {
     return operations_result<double>();
   }
 
   virtual operations_result<double>
-  getDeviceMaxWrite()
+  getHostMaxWrite()
+  {
+    return operations_result<double>();
+  }
+
+  virtual operations_result<double>
+  getKernelMaxRead()
+  {
+    return operations_result<double>();
+  }
+
+  virtual operations_result<double>
+  getKernelMaxWrite()
   {
     return operations_result<double>();
   }

--- a/src/runtime_src/xrt/device/hal2.h
+++ b/src/runtime_src/xrt/device/hal2.h
@@ -388,19 +388,35 @@ public:
   }
 
   virtual hal::operations_result<double>
-  getDeviceMaxRead()
+  getHostMaxRead()
   {
-    if (!m_ops->mGetDeviceMaxRead)
+    if (!m_ops->mGetHostMaxRead)
       return hal::operations_result<double>();
-    return m_ops->mGetDeviceMaxRead(m_handle);
+    return m_ops->mGetHostMaxRead(m_handle);
   }
 
   virtual hal::operations_result<double>
-  getDeviceMaxWrite()
+  getHostMaxWrite()
   {
-    if (!m_ops->mGetDeviceMaxWrite)
+    if (!m_ops->mGetHostMaxWrite)
       return hal::operations_result<double>();
-    return m_ops->mGetDeviceMaxWrite(m_handle);
+    return m_ops->mGetHostMaxWrite(m_handle);
+  }
+
+  virtual hal::operations_result<double>
+  getKernelMaxRead()
+  {
+    if (!m_ops->mGetKernelMaxRead)
+      return hal::operations_result<double>();
+    return m_ops->mGetKernelMaxRead(m_handle);
+  }
+
+  virtual hal::operations_result<double>
+  getKernelMaxWrite()
+  {
+    if (!m_ops->mGetKernelMaxWrite)
+      return hal::operations_result<double>();
+    return m_ops->mGetKernelMaxWrite(m_handle);
   }
 
   virtual hal::operations_result<size_t>

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -53,8 +53,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mGetDeviceInfo(0)
   ,mGetDeviceTime(0)
   ,mGetDeviceClock(0)
-  ,mGetDeviceMaxRead(0)
-  ,mGetDeviceMaxWrite(0)
+  ,mGetHostMaxRead(0)
+  ,mGetHostMaxWrite(0)
+  ,mGetKernelMaxRead(0)
+  ,mGetKernelMaxWrite(0)
   ,mSetProfilingSlots(0)
   ,mGetProfilingSlots(0)
   ,mGetProfilingSlotName(0)
@@ -111,8 +113,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   // Profiling Functions
   mGetDeviceTime = (getDeviceTimeFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetDeviceTimestamp");
   mGetDeviceClock = (getDeviceClockFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetDeviceClockFreqMHz");
-  mGetDeviceMaxRead = (getDeviceMaxReadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetReadMaxBandwidthMBps");
-  mGetDeviceMaxWrite = (getDeviceMaxWriteFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetWriteMaxBandwidthMBps");
+  mGetHostMaxRead = (getHostMaxReadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetHostReadMaxBandwidthMBps");
+  mGetHostMaxWrite = (getHostMaxWriteFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetHostWriteMaxBandwidthMBps");
+  mGetKernelMaxRead = (getKernelMaxReadFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetKernelReadMaxBandwidthMBps");
+  mGetKernelMaxWrite = (getKernelMaxWriteFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetKernelWriteMaxBandwidthMBps");
   mSetProfilingSlots = (setSlotFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclSetProfilingNumberSlots");
   mGetProfilingSlots = (getSlotFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetProfilingNumberSlots");
   mGetProfilingSlotName = (getSlotNameFuncType)xrt_core::dlsym(const_cast<void *>(mDriverHandle), "xclGetProfilingSlotName");

--- a/src/runtime_src/xrt/device/halops2.cpp
+++ b/src/runtime_src/xrt/device/halops2.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2020 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2016-2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xrt/device/halops2.h
+++ b/src/runtime_src/xrt/device/halops2.h
@@ -94,8 +94,10 @@ private:
 
   typedef size_t (* getDeviceTimeFuncType)(xclDeviceHandle handle);
   typedef double (* getDeviceClockFuncType)(xclDeviceHandle handle);
-  typedef double (* getDeviceMaxReadFuncType)(xclDeviceHandle handle);
-  typedef double (* getDeviceMaxWriteFuncType)(xclDeviceHandle handle);
+  typedef double (* getHostMaxReadFuncType)(xclDeviceHandle handle);
+  typedef double (* getHostMaxWriteFuncType)(xclDeviceHandle handle);
+  typedef double (* getKernelMaxReadFuncType)(xclDeviceHandle handle);
+  typedef double (* getKernelMaxWriteFuncType)(xclDeviceHandle handle);
   typedef void (* setSlotFuncType)(xclDeviceHandle handle, xclPerfMonType type, uint32_t numSlots);
   typedef uint32_t (* getSlotFuncType)(xclDeviceHandle handle, xclPerfMonType type);
   typedef void (* getSlotNameFuncType)(xclDeviceHandle handle, xclPerfMonType type, uint32_t slotnum,
@@ -173,8 +175,10 @@ public:
 
   getDeviceTimeFuncType mGetDeviceTime;
   getDeviceClockFuncType mGetDeviceClock;
-  getDeviceMaxReadFuncType mGetDeviceMaxRead;
-  getDeviceMaxWriteFuncType mGetDeviceMaxWrite;
+  getHostMaxReadFuncType mGetHostMaxRead;
+  getHostMaxWriteFuncType mGetHostMaxWrite;
+  getKernelMaxReadFuncType mGetKernelMaxRead;
+  getKernelMaxWriteFuncType mGetKernelMaxWrite;
   setSlotFuncType mSetProfilingSlots;
   getSlotFuncType mGetProfilingSlots;
   getSlotNameFuncType mGetProfilingSlotName;

--- a/src/runtime_src/xrt/device/halops2_static.cpp
+++ b/src/runtime_src/xrt/device/halops2_static.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2021 Xilinx, Inc
+ * Copyright (C) 2022 Advanced Micro Devices, Inc. - All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/xrt/device/halops2_static.cpp
+++ b/src/runtime_src/xrt/device/halops2_static.cpp
@@ -52,8 +52,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   ,mGetDeviceInfo(0)
   ,mGetDeviceTime(0)
   ,mGetDeviceClock(0)
-  ,mGetDeviceMaxRead(0)
-  ,mGetDeviceMaxWrite(0)
+  ,mGetHostMaxRead(0)
+  ,mGetHostMaxWrite(0)
+  ,mGetKernelMaxRead(0)
+  ,mGetKernelMaxWrite(0)
   ,mSetProfilingSlots(0)
   ,mGetProfilingSlots(0)
   ,mGetProfilingSlotName(0)
@@ -115,8 +117,10 @@ operations(const std::string &fileName, void *fileHandle, unsigned int count)
   // Profiling Functions
   mGetDeviceTime = &xclGetDeviceTimestamp;
   mGetDeviceClock = &xclGetDeviceClockFreqMHz;
-  mGetDeviceMaxRead = &xclGetReadMaxBandwidthMBps;
-  mGetDeviceMaxWrite = &xclGetWriteMaxBandwidthMBps;
+  mGetHostMaxRead = &xclGetHostReadMaxBandwidthMBps;
+  mGetHostMaxWrite = &xclGetHostWriteMaxBandwidthMBps;
+  mGetKernelMaxRead = &xclGetKernelReadMaxBandwidthMBps;
+  mGetKernelMaxWrite = &xclGetKernelWriteMaxBandwidthMBps;
   mSetProfilingSlots = &xclSetProfilingNumberSlots;
   mGetProfilingSlots = &xclGetProfilingNumberSlots;
   mGetProfilingSlotName = &xclGetProfilingSlotName;


### PR DESCRIPTION
* Split max BW functions between kernel and host
* Set different maxes for edge vs. pcie
* Use new functions in profile reporting