### PR TITLE
Support building XRT as git submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2022 Xilinx, Inc. All rights reserved.
+cmake_minimum_required(VERSION 3.5.0)
+
+if (NOT WIN32)
+  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "/opt/xilinx" CACHE PATH "..." FORCE)
+    message("-- Install prefix is default initialized to ${CMAKE_INSTALL_PREFIX}")
+  endif()
+else()
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/xilinx" CACHE PATH "..." FORCE)
+  message("-- Install prefix is default initialized to ${CMAKE_INSTALL_PREFIX}")
+endif()
+
+message("-- CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
+
+
+# Enable testing for this directory and below.  This command should be
+# in the source directory root because ctest expects to find a test
+# file in the build directory root.
+enable_testing()
+
+add_subdirectory(src)

--- a/build/build-win.sh
+++ b/build/build-win.sh
@@ -7,7 +7,6 @@
 set -e
 
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
-SRCDIR=$(readlink -f $BUILDDIR/../src)
 CORE=7
 
 CMAKE="/mnt/c/Program Files/CMake/bin/cmake.exe"

--- a/build/build-win19.sh
+++ b/build/build-win19.sh
@@ -7,7 +7,6 @@
 set -e
 
 BUILDDIR=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
-SRCDIR=$(readlink -f $BUILDDIR/../src)
 CORE=7
 
 CMAKE="/mnt/c/Program Files/CMake/bin/cmake.exe"

--- a/src/CMake/changelog.cmake
+++ b/src/CMake/changelog.cmake
@@ -4,11 +4,11 @@
 # Custom variables imported by this CMake stub which should be defined by parent CMake:
 # XRT_INSTALL_DIR
 
-install(FILES "${CMAKE_SOURCE_DIR}/../CHANGELOG.rst"
+install(FILES "${XRT_SOURCE_DIR}/../CHANGELOG.rst"
   DESTINATION "${XRT_INSTALL_DIR}/share/doc")
 
-install(FILES "${CMAKE_SOURCE_DIR}/../CONTRIBUTING.rst"
+install(FILES "${XRT_SOURCE_DIR}/../CONTRIBUTING.rst"
   DESTINATION "${XRT_INSTALL_DIR}/share/doc")
 
-install(FILES "${CMAKE_SOURCE_DIR}/../NOTICE"
+install(FILES "${XRT_SOURCE_DIR}/../NOTICE"
   DESTINATION "${XRT_INSTALL_DIR}/share/doc")

--- a/src/CMake/cpackLin.cmake
+++ b/src/CMake/cpackLin.cmake
@@ -52,7 +52,7 @@ if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
 
   if( (${CMAKE_VERSION} VERSION_LESS "3.6.0") AND (${CPACK_DEBIAN_PACKAGE_SHLIBDEPS} STREQUAL "yes") )
     # Fix bug in CPackDeb.cmake in use of dpkg-shlibdeps
-    SET(CMAKE_MODULE_PATH ${XRT_SRC_DIR}/CMake/patch ${CMAKE_MODULE_PATH})
+    SET(CMAKE_MODULE_PATH ${XRT_SOURCE_DIR}/CMake/patch ${CMAKE_MODULE_PATH})
   endif()
 
   SET(CPACK_DEBIAN_AWS_PACKAGE_DEPENDS "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})")
@@ -67,7 +67,7 @@ if (${LINUX_FLAVOR} MATCHES "^(Ubuntu|Debian)")
   else()
     # xrt development package
     SET(CPACK_DEBIAN_XRT-DEV_PACKAGE_NAME ${XRT_DEV_COMPONENT})
-    SET(CPACK_DEBIAN_XRT-DEV_PACKAGE_DEPENDS 
+    SET(CPACK_DEBIAN_XRT-DEV_PACKAGE_DEPENDS
       "xrt (>= ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH}), \
       ocl-icd-opencl-dev (>= 2.2.0), \
       uuid-dev (>= 2.27.1)")
@@ -152,7 +152,7 @@ message("-- ${CMAKE_BUILD_TYPE} ${PACKAGE_KIND} package")
 SET(CPACK_PACKAGE_VENDOR "Xilinx Inc")
 SET(CPACK_PACKAGE_CONTACT "sonal.santan@xilinx.com")
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Xilinx RunTime stack for use with Xilinx FPGA platforms")
-SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/../LICENSE")
+SET(CPACK_RESOURCE_FILE_LICENSE "${XRT_SOURCE_DIR}/../LICENSE")
 
 add_custom_target(xrtpkg
   echo "COMMAND ${CMAKE_CPACK_COMMAND}"
@@ -164,4 +164,3 @@ add_custom_target(xrtpkg
 )
 
 INCLUDE(CPack)
-

--- a/src/CMake/cpackWin.cmake
+++ b/src/CMake/cpackWin.cmake
@@ -29,7 +29,7 @@ SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${XRT_VERSION_RELEASE}.${CPAC
 message("-- ${CMAKE_BUILD_TYPE} ${PACKAGE_KIND} package")
 
 # Neet to have an extention
-file(COPY "${CMAKE_SOURCE_DIR}/../LICENSE" DESTINATION "${PROJECT_BINARY_DIR}")
+file(COPY "${XRT_SOURCE_DIR}/../LICENSE" DESTINATION "${PROJECT_BINARY_DIR}")
 file(RENAME "${PROJECT_BINARY_DIR}/LICENSE" "${PROJECT_BINARY_DIR}/license.txt")
 SET(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_BINARY_DIR}/license.txt")
 
@@ -53,7 +53,7 @@ cpack_add_component(runtime_libraries
 
 
 # -- Boost shared libraries --
-file(GLOB XRT_BOOST_DLL_LIB_FILES 
+file(GLOB XRT_BOOST_DLL_LIB_FILES
   "${Boost_LIBRARY_DIRS}/boost_system*.dll"
   "${Boost_LIBRARY_DIRS}/boost_program_options*.dll"
   "${Boost_LIBRARY_DIRS}/boost_filesystem*.dll"
@@ -71,7 +71,7 @@ cpack_add_component(boost_libraries
 )
 
 # -- Khronos shared libraries --
-file(GLOB XRT_OPENCL_DLL_LIB_FILES 
+file(GLOB XRT_OPENCL_DLL_LIB_FILES
   "${KHRONOS}/bin/OpenCL.dll"
   )
   install(FILES ${XRT_OPENCL_DLL_LIB_FILES}
@@ -97,13 +97,13 @@ cpack_add_component_group(THIRD_PARTY_LIBRARIES
 # -- XCL Managment Driver --
 if (DEFINED XCL_MGMT)
   if (NOT XCL_MGMT STREQUAL "")
-    file(GLOB XCL_MGMT_DRIVER 
+    file(GLOB XCL_MGMT_DRIVER
       "${XCL_MGMT}/*"
       )
       install(FILES ${XCL_MGMT_DRIVER}
             DESTINATION xrt/drivers/xcl_mgmt
             COMPONENT xcl_mgmt_driver)
-    
+
     cpack_add_component(xcl_mgmt_driver
       DISPLAY_NAME "XclMgmt Driver"
       DESCRIPTION "XCL Managment Driver"
@@ -117,7 +117,7 @@ ENDIF(DEFINED XCL_MGMT)
 # -- XCL Managment2 Driver --
 if (DEFINED XCL_MGMT2)
   if (NOT XCL_MGMT2 STREQUAL "")
-    file(GLOB XCL_MGMT2_DRIVER 
+    file(GLOB XCL_MGMT2_DRIVER
       "${XCL_MGMT2}/*"
       )
       install(FILES ${XCL_MGMT2_DRIVER}
@@ -138,13 +138,13 @@ ENDIF(DEFINED XCL_MGMT2)
 # -- Xocl User Driver --
 if (DEFINED XOCL_USER)
   if (NOT XOCL_USER STREQUAL "")
-    file(GLOB XOCL_USER_DRIVER 
+    file(GLOB XOCL_USER_DRIVER
       "${XOCL_USER}/*"
       )
       install(FILES ${XOCL_USER_DRIVER}
             DESTINATION xrt/drivers/xocl_user
             COMPONENT xocl_user_driver)
-  
+
     cpack_add_component(xocl_user_driver
       DISPLAY_NAME "XoclUser Driver"
       DESCRIPTION "XoclUser Driver"
@@ -158,7 +158,7 @@ ENDIF(DEFINED XOCL_USER)
 # -- Xocl User2 Driver --
 if (DEFINED XOCL_USER2)
   if (NOT XOCL_USER2 STREQUAL "")
-    file(GLOB XOCL_USER2_DRIVER 
+    file(GLOB XOCL_USER2_DRIVER
       "${XOCL_USER2}/*"
       )
       install(FILES ${XOCL_USER2_DRIVER}
@@ -197,8 +197,8 @@ cpack_add_component(xrt
 # Set the Packaging directory
 SET(CPACK_PACKAGE_INSTALL_DIRECTORY "Xilinx")
 SET(CPACK_WIX_SKIP_PROGRAM_FOLDER TRUE)
-SET(CPACK_WIX_UI_BANNER "${CMAKE_SOURCE_DIR}/CMake/resources/XilinxBanner.bmp")
-SET(CPACK_WIX_UI_DIALOG "${CMAKE_SOURCE_DIR}/CMake/resources/XilinxDialog.bmp")
+SET(CPACK_WIX_UI_BANNER "${XRT_SOURCE_DIR}/CMake/resources/XilinxBanner.bmp")
+SET(CPACK_WIX_UI_DIALOG "${XRT_SOURCE_DIR}/CMake/resources/XilinxDialog.bmp")
 
 
 add_custom_target(xrtpkg

--- a/src/CMake/dkms-aws.cmake
+++ b/src/CMake/dkms-aws.cmake
@@ -16,19 +16,19 @@ set(DKMS_POSTINST "postinst-aws")
 set(DKMS_PRERM "prerm-aws")
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/dkms-awsmgmt/${DKMS_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/dkms-awsmgmt/${DKMS_FILE_NAME}.in"
   "aws/${DKMS_FILE_NAME}"
   @ONLY
   )
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
   "aws/postinst"
   @ONLY
   )
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
   "aws/prerm"
   @ONLY
   )

--- a/src/CMake/dkms-azure.cmake
+++ b/src/CMake/dkms-azure.cmake
@@ -7,19 +7,19 @@ set(DKMS_POSTINST "postinst-azure")
 set(DKMS_PRERM "prerm-azure")
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_FILE_NAME}.in"
   "azure/${DKMS_FILE_NAME}"
   @ONLY
   )
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
   "azure/postinst"
   @ONLY
   )
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
   "azure/prerm"
   @ONLY
   )

--- a/src/CMake/dkms-container.cmake
+++ b/src/CMake/dkms-container.cmake
@@ -7,19 +7,19 @@ set(DKMS_POSTINST "postinst-container")
 set(DKMS_PRERM "prerm-container")
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_FILE_NAME}.in"
   "container/${DKMS_FILE_NAME}"
   @ONLY
   )
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
   "container/postinst"
   @ONLY
   )
 
 configure_file(
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
   "container/prerm"
   @ONLY
   )

--- a/src/CMake/dkms-edge.cmake
+++ b/src/CMake/dkms-edge.cmake
@@ -14,19 +14,19 @@ SET (DKMS_POSTINST "postinst-edge")
 SET (DKMS_PRERM "prerm-edge")
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/dkms-zocl/${DKMS_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/dkms-zocl/${DKMS_FILE_NAME}.in"
   ${DKMS_FILE_NAME}
   @ONLY
   )
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
   "postinst"
   @ONLY
   )
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
   "prerm"
   @ONLY
   )
@@ -115,7 +115,7 @@ foreach (DKMS_FILE ${XRT_DKMS_DRIVER_SRCS})
   get_filename_component(DKMS_DIR ${DKMS_FILE} DIRECTORY)
   install (FILES ${XRT_DKMS_DRIVER_SRC_DIR}/${DKMS_FILE} DESTINATION ${XRT_DKMS_INSTALL_DRIVER_DIR}/${DKMS_DIR})
 endforeach()
-  
+
 foreach (DKMS_FILE ${XRT_DKMS_CORE_INCLUDES})
   get_filename_component(DKMS_DIR ${DKMS_FILE} DIRECTORY)
   install (FILES ${XRT_DKMS_CORE_DIR}/${DKMS_FILE} DESTINATION ${XRT_DKMS_INSTALL_DRIVER_DIR}/zocl/${DKMS_DIR})
@@ -134,4 +134,3 @@ foreach (DKMS_FILE ${XRT_DKMS_CORE_EDGE_INCLUDES})
 endforeach()
 
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${DKMS_FILE_NAME} DESTINATION ${XRT_DKMS_INSTALL_DIR})
-

--- a/src/CMake/dkms.cmake
+++ b/src/CMake/dkms.cmake
@@ -18,19 +18,19 @@ SET (DKMS_POSTINST "postinst")
 SET (DKMS_PRERM "prerm")
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/dkms-xocl/${DKMS_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/dkms-xocl/${DKMS_FILE_NAME}.in"
   ${DKMS_FILE_NAME}
   @ONLY
   )
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_POSTINST}.in"
   ${DKMS_POSTINST}
   @ONLY
   )
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${DKMS_PRERM}.in"
   ${DKMS_PRERM}
   @ONLY
   )
@@ -314,12 +314,12 @@ foreach (DKMS_FILE ${XRT_DKMS_DRIVER_SRCS})
   get_filename_component(DKMS_DIR ${DKMS_FILE} DIRECTORY)
   install (FILES ${XRT_DKMS_DRIVER_SRC_DIR}/${DKMS_FILE} DESTINATION ${XRT_DKMS_INSTALL_DRIVER_DIR}/${DKMS_DIR})
 endforeach()
-  
+
 foreach (DKMS_FILE ${XRT_DKMS_DRIVER_INCLUDES})
   get_filename_component(DKMS_DIR ${DKMS_FILE} DIRECTORY)
   install (FILES ${XRT_DKMS_DRIVER_INCLUDE_DIR}/${DKMS_FILE} DESTINATION ${XRT_DKMS_INSTALL_DRIVER_DIR}/${DKMS_DIR})
 endforeach()
-  
+
 foreach (DKMS_FILE ${XRT_DKMS_CORE_INCLUDES})
   get_filename_component(DKMS_DIR ${DKMS_FILE} DIRECTORY)
   install (FILES ${XRT_DKMS_CORE_DIR}/${DKMS_FILE} DESTINATION ${XRT_DKMS_INSTALL_DRIVER_DIR}/${DKMS_DIR})
@@ -334,4 +334,3 @@ foreach (DKMS_FILE ${XRT_DKMS_COMMON_XRT_DRV_INCLUDES})
 endforeach()
 
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/${DKMS_FILE_NAME} DESTINATION ${XRT_DKMS_INSTALL_DIR})
-

--- a/src/CMake/embedded_system.cmake
+++ b/src/CMake/embedded_system.cmake
@@ -108,7 +108,7 @@ message("-- Preparing XRT pkg-config")
 set(XRT_PKG_CONFIG_DIR "/usr/lib/pkgconfig")
 
 configure_file (
-  ${CMAKE_SOURCE_DIR}/CMake/config/xrt.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/xrt.pc.in
   xrt.pc
   @ONLY
   )

--- a/src/CMake/findpackage.cmake
+++ b/src/CMake/findpackage.cmake
@@ -12,13 +12,13 @@ string(TOLOWER ${PROJECT_NAME} LOWER_NAME)
 # For use by xrt consumers (using cmake) to import xrt libraries
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
   configure_package_config_file (
-    ${CMAKE_SOURCE_DIR}/CMake/config/xrt.fp.in
+    ${XRT_SOURCE_DIR}/CMake/config/xrt.fp.in
     ${CMAKE_CURRENT_BINARY_DIR}/${LOWER_NAME}-config.cmake
     INSTALL_DESTINATION ${XRT_INSTALL_DIR}/share/cmake/${PROJECT_NAME}
     )
 else()
   configure_package_config_file (
-    ${CMAKE_SOURCE_DIR}/CMake/config/xrt-edge.fp.in
+    ${XRT_SOURCE_DIR}/CMake/config/xrt-edge.fp.in
     ${CMAKE_CURRENT_BINARY_DIR}/${LOWER_NAME}-config.cmake
     INSTALL_DESTINATION ${XRT_INSTALL_DIR}/share/cmake/${PROJECT_NAME}
     )

--- a/src/CMake/icd.cmake
+++ b/src/CMake/icd.cmake
@@ -6,7 +6,7 @@ SET (ICD_FILE_NAME "xilinx.icd")
 message("-- Preparing OpenCL ICD ${ICD_FILE_NAME}")
 
 configure_file (
-  "${CMAKE_SOURCE_DIR}/CMake/config/${ICD_FILE_NAME}.in"
+  "${XRT_SOURCE_DIR}/CMake/config/${ICD_FILE_NAME}.in"
   ${ICD_FILE_NAME}
   )
 

--- a/src/CMake/nativeLnx.cmake
+++ b/src/CMake/nativeLnx.cmake
@@ -121,6 +121,7 @@ set (XRT_INSTALL_UNWRAPPED_DIR "${XRT_INSTALL_BIN_DIR}/unwrapped")
 set (XRT_INSTALL_INCLUDE_DIR   "${XRT_INSTALL_DIR}/include")
 set (XRT_INSTALL_LIB_DIR       "${XRT_INSTALL_DIR}/lib${LIB_SUFFIX}")
 set (XRT_INSTALL_PYTHON_DIR    "${XRT_INSTALL_DIR}/python")
+set (XRT_BUILD_INSTALL_DIR     "${CMAKE_BINARY_DIR}${CMAKE_INSTALL_PREFIX}/${XRT_INSTALL_DIR}")
 set (XRT_VALIDATE_DIR          "${XRT_INSTALL_DIR}/test")
 set (XRT_NAMELINK_ONLY NAMELINK_ONLY)
 set (XRT_NAMELINK_SKIP NAMELINK_SKIP)
@@ -159,7 +160,7 @@ add_subdirectory(runtime_src)
 
 #XMA settings START
 set(XMA_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-set(XMA_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/xrt")
+set(XMA_INSTALL_DIR "${XRT_INSTALL_DIR}")
 set(XMA_VERSION_STRING ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})
 set(XMA_SOVERSION ${XRT_SOVERSION})
 add_subdirectory(xma)
@@ -208,5 +209,5 @@ include (CMake/coverity.cmake)
 # --- Find Package Support ---
 include (CMake/findpackage.cmake)
 
-set (CTAGS "${CMAKE_SOURCE_DIR}/runtime_src/tools/scripts/tags.sh")
+set (CTAGS "${XRT_SOURCE_DIR}/runtime_src/tools/scripts/tags.sh")
 include (CMake/tags.cmake)

--- a/src/CMake/nativeTests.cmake
+++ b/src/CMake/nativeTests.cmake
@@ -5,28 +5,35 @@
 # Custom variables imported by this CMake stub which should be defined by parent CMake:
 # XRT_INSTALL_BIN_DIR
 
-enable_testing()
+message("----CMAKE_CURRENT_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}")
+message("----CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
+message("----CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}")
+message("----PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}")
+message("----XRT_BINARY_DIR=${XRT_BINARY_DIR}")
+message("----XRT_INSTALL_DIR=${XRT_INSTALL_DIR}")
+message("----XRT_BUILD_INSTALL_DIR=${XRT_BUILD_INSTALL_DIR}")
+#enable_testing()
 add_test(NAME xbmgmt
-  COMMAND ${CMAKE_BINARY_DIR}/runtime_src/core/pcie/tools/xbmgmt/xbmgmt scan
+  COMMAND ${XRT_BINARY_DIR}/runtime_src/core/pcie/tools/xbmgmt/xbmgmt scan
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME xbutil
-  COMMAND ${CMAKE_BINARY_DIR}/runtime_src/core/pcie/tools/xbutil/xbutil scan
+  COMMAND ${XRT_BINARY_DIR}/runtime_src/core/pcie/tools/xbutil/xbutil scan
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME xbutil2
-  COMMAND ${CMAKE_BINARY_DIR}/runtime_src/core/tools/xbutil2/xbutil2 examine
+  COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbutil2/xbutil2 examine
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME xbmgmt2
-  COMMAND ${CMAKE_BINARY_DIR}/runtime_src/core/tools/xbmgmt2/xbmgmt2 examine -r host
+  COMMAND ${XRT_BINARY_DIR}/runtime_src/core/tools/xbmgmt2/xbmgmt2 examine -r host
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(NAME python_binding
-  COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/../tests/python/200_binding/200_main.py"
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  COMMAND ${PYTHON_EXECUTABLE} "${XRT_SOURCE_DIR}/../tests/python/200_binding/200_main.py"
+  WORKING_DIRECTORY ${XRT_BINARY_DIR})
 
 set_tests_properties(python_binding PROPERTIES ENVIRONMENT
-  "PYTHONPATH=.${CMAKE_INSTALL_PREFIX}/${XRT_INSTALL_DIR}/python;XILINX_XRT=.${CMAKE_INSTALL_PREFIX}/${XRT_INSTALL_DIR}")
+  "PYTHONPATH=${XRT_BUILD_INSTALL_DIR}/python;XILINX_XRT=${XRT_BUILD_INSTALL_DIR}")
 
 set_tests_properties(xbutil xbmgmt PROPERTIES ENVIRONMENT INTERNAL_BUILD=1)

--- a/src/CMake/nativeWin.cmake
+++ b/src/CMake/nativeWin.cmake
@@ -60,9 +60,8 @@ set (XRT_INSTALL_PYTHON_DIR    "${XRT_INSTALL_DIR}/python")
 file(GLOB XRT_EULA
   "license/*.txt"
   )
-#install (FILES ${XRT_EULA} DESTINATION ${XRT_INSTALL_DIR}/license)
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE DESTINATION ${XRT_INSTALL_DIR}/license)
-message("-- XRT EA eula files  ${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE")
+install (FILES ${XRT_SOURCE_DIR}/../LICENSE DESTINATION ${XRT_INSTALL_DIR}/license)
+message("-- XRT EA eula files  ${XRT_SOURCE_DIR}/../LICENSE")
 
 # -- CPack
 include (CMake/cpackWin.cmake)

--- a/src/CMake/pkgconfig.cmake
+++ b/src/CMake/pkgconfig.cmake
@@ -12,7 +12,7 @@ else ()
 endif ()
 
 configure_file (
-  ${CMAKE_SOURCE_DIR}/CMake/config/xrt.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/xrt.pc.in
   xrt.pc
   @ONLY
   )
@@ -23,7 +23,7 @@ install (
   )
 
 configure_file (
-  ${CMAKE_SOURCE_DIR}/CMake/config/libxmaapi.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/libxmaapi.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libxmaapi.pc
   @ONLY
   )
@@ -34,7 +34,7 @@ install (
   )
 
 configure_file (
-  ${CMAKE_SOURCE_DIR}/CMake/config/libxmaplugin.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/libxmaplugin.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libxmaplugin.pc
   @ONLY
   )
@@ -45,7 +45,7 @@ install (
   )
 
 configure_file (
-  ${CMAKE_SOURCE_DIR}/CMake/config/libxma2api.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/libxma2api.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libxma2api.pc
   @ONLY
   )
@@ -56,7 +56,7 @@ install (
   )
 
 configure_file (
-  ${CMAKE_SOURCE_DIR}/CMake/config/libxma2plugin.pc.in
+  ${XRT_SOURCE_DIR}/CMake/config/libxma2plugin.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/libxma2plugin.pc
   @ONLY
   )
@@ -65,5 +65,3 @@ install (
   DESTINATION ${XRT_PKG_CONFIG_DIR}
   COMPONENT ${XRT_DEV_COMPONENT}
   )
-
-

--- a/src/CMake/tags.cmake
+++ b/src/CMake/tags.cmake
@@ -4,7 +4,7 @@
 add_custom_target(
   tags
   COMMAND ${CTAGS}
-  --root ${CMAKE_SOURCE_DIR}
+  --root ${XRT_SOURCE_DIR}
   --etags
   -f TAGS
   )

--- a/src/CMake/unitTestSupport.cmake
+++ b/src/CMake/unitTestSupport.cmake
@@ -9,7 +9,7 @@ execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${UNITTEST_RUN_BAS
 
 
 #------------------------------------------------------------------------------
-# Function: xrt_create_unittest_wrapper 
+# Function: xrt_create_unittest_wrapper
 #
 # This function will create the unit test wrapper script used to:
 #    1) Encapulate the entire test in 1 bash script.
@@ -31,12 +31,12 @@ function(xrt_util_create_unittest_wrapper TEST_DIRECTORY TEST_COMMAND WRAPPER_FI
   if(BASH)
     set(RUN_BASE_EXECUTABLE "${RUN_BASE_NAME}.sh")
     set(RUN_BASE_WRAPPER_FILE "testBashWrapper.sh.in")
-    set(SETUP_SCRIPT "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_PREFIX}/${XRT_INSTALL_DIR}/setup.sh")
+    set(SETUP_SCRIPT "${XRT_BUILD_INSTALL_DIR}/setup.sh")
   else()
     if(WIN32)
       set(RUN_BASE_EXECUTABLE "${RUN_BASE_NAME}.bat")
       set(RUN_BASE_WRAPPER_FILE "testBatchWrapper.bat.in")
-      set(SETUP_SCRIPT "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_PREFIX}/${XRT_INSTALL_DIR}/setup.bat")
+      set(SETUP_SCRIPT "${XRT_BUILD_INSTALL_DIR}/setup.bat")
     else()
       message(FATAL_ERROR "Error: No shell found.")
     endif()
@@ -56,7 +56,7 @@ function(xrt_util_create_unittest_wrapper TEST_DIRECTORY TEST_COMMAND WRAPPER_FI
 
   # Step 1b: Create the script in the temporary directory
   configure_file(
-    "${CMAKE_SOURCE_DIR}/CMake/config/testBashWrapper.sh.in"
+    "${XRT_SOURCE_DIR}/CMake/config/testBashWrapper.sh.in"
     "${TEMP_DIR}/${RUN_BASE_EXECUTABLE}"
   )
 
@@ -78,29 +78,26 @@ endfunction()
 
 function(xrt_util_create_unittest_dir TEST_SUITE_NAME TEST_NAME UNIT_TEST_DIR)
   # Create the test working directory
-    if ("${TEST_SUITE_NAME}" STREQUAL "")
-      set(${UNIT_TEST_DIR} "${UNITTEST_RUN_BASE_DIR}/${TEST_NAME}" PARENT_SCOPE)
-    else()
-      set(${UNIT_TEST_DIR} "${UNITTEST_RUN_BASE_DIR}/${TEST_SUITE_NAME}/${TEST_NAME}" PARENT_SCOPE)
-    endif()
-
-    # Create the test directory
-    execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${UNIT_TEST_DIR}")
+  if ("${TEST_SUITE_NAME}" STREQUAL "")
+    set(${UNIT_TEST_DIR} "${UNITTEST_RUN_BASE_DIR}/${TEST_NAME}" PARENT_SCOPE)
+  else()
+    set(${UNIT_TEST_DIR} "${UNITTEST_RUN_BASE_DIR}/${TEST_SUITE_NAME}/${TEST_NAME}" PARENT_SCOPE)
+  endif()
 endfunction()
 
 function(xrt_util_create_cmake_test_name TEST_SUITE_NAME TEST_NAME CMAKE_TEST_NAME)
   # Create the test working directory
-    if ("${TEST_SUITE_NAME}" STREQUAL "")
-      set(${CMAKE_TEST_NAME} "${TEST_NAME}" PARENT_SCOPE)
-    else()
-      set(${CMAKE_TEST_NAME} "[${TEST_SUITE_NAME}]:${TEST_NAME}" PARENT_SCOPE)
-    endif()
+  if ("${TEST_SUITE_NAME}" STREQUAL "")
+    set(${CMAKE_TEST_NAME} "${TEST_NAME}" PARENT_SCOPE)
+  else()
+    set(${CMAKE_TEST_NAME} "[${TEST_SUITE_NAME}]:${TEST_NAME}" PARENT_SCOPE)
+  endif()
 endfunction()
 
 function(xrt_helper_add_test TEST_SUITE_NAME TEST_NAME TEST_COMMAND)
   # Create the test working directory
   xrt_util_create_unittest_dir("${TEST_SUITE_NAME}" "${TEST_NAME}" TEST_WORKING_DIR)
-  
+
   # Create the test wrapper script
   xrt_util_create_unittest_wrapper("${TEST_WORKING_DIR}" "${TEST_COMMAND}" WRAPPER_FILE)
 
@@ -127,7 +124,7 @@ endfunction()
 
 
 #------------------------------------------------------------------------------
-# Function: xrt_add_test 
+# Function: xrt_add_test
 #
 #------------------------------------------------------------------------------
 function(xrt_add_test TEST_NAME TEST_EXECUTABLE TEST_OPTIONS )

--- a/src/CMake/version.cmake
+++ b/src/CMake/version.cmake
@@ -4,7 +4,7 @@
 # Get the branch
 execute_process(
   COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${XRT_SOURCE_DIR}
   OUTPUT_VARIABLE XRT_BRANCH
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -13,7 +13,7 @@ execute_process(
 # Get the latest abbreviated commit hash of the working branch
 execute_process(
   COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${XRT_SOURCE_DIR}
   OUTPUT_VARIABLE XRT_HASH
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -21,7 +21,7 @@ execute_process(
 # Get the latest abbreviated commit hash date of the working branch
 execute_process(
   COMMAND ${GIT_EXECUTABLE} log -1 --pretty=format:%cD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${XRT_SOURCE_DIR}
   OUTPUT_VARIABLE XRT_HASH_DATE
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -29,7 +29,7 @@ execute_process(
 # Get all of the modified files in the current git environment
 execute_process(
   COMMAND ${GIT_EXECUTABLE} status --porcelain -u no
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${XRT_SOURCE_DIR}
   OUTPUT_VARIABLE XRT_MODIFIED_FILES
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -38,33 +38,31 @@ string(REPLACE "\n" "," XRT_MODIFIED_FILES "${XRT_MODIFIED_FILES}")
 # Get the build date RFC format
 execute_process(
   COMMAND date -R
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${XRT_SOURCE_DIR}
   OUTPUT_VARIABLE XRT_DATE_RFC
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-
 string(TIMESTAMP XRT_DATE "%Y-%m-%d %H:%M:%S")
 
-
 configure_file(
-  ${CMAKE_SOURCE_DIR}/CMake/config/version.h.in
-  ${CMAKE_BINARY_DIR}/gen/version.h
+  ${XRT_SOURCE_DIR}/CMake/config/version.h.in
+  ${XRT_BINARY_DIR}/gen/version.h
 )
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/CMake/config/version.json.in
-  ${CMAKE_BINARY_DIR}/gen/version.json
+  ${XRT_SOURCE_DIR}/CMake/config/version.json.in
+  ${XRT_BINARY_DIR}/gen/version.json
 )
 
-install(FILES ${CMAKE_BINARY_DIR}/gen/version.h DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
+install(FILES ${XRT_BINARY_DIR}/gen/version.h DESTINATION ${XRT_INSTALL_INCLUDE_DIR})
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
-install(FILES ${CMAKE_BINARY_DIR}/gen/version.json DESTINATION ${XRT_INSTALL_DIR})
+install(FILES ${XRT_BINARY_DIR}/gen/version.json DESTINATION ${XRT_INSTALL_DIR})
 endif()
 
 # This is not required on MPSoC platform. To avoid yocto error, do NOT intall
 if ((${XRT_NATIVE_BUILD} STREQUAL "yes") AND (NOT WIN32))
   # Copied over from dkms.cmake. TODO: cleanup
   set (XRT_DKMS_INSTALL_DIR "/usr/src/xrt-${XRT_VERSION_STRING}")
-  install(FILES ${CMAKE_BINARY_DIR}/gen/version.h DESTINATION ${XRT_DKMS_INSTALL_DIR}/driver/include)
+  install(FILES ${XRT_BINARY_DIR}/gen/version.h DESTINATION ${XRT_DKMS_INSTALL_DIR}/driver/include)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2018-2022 Xilinx, Inc. All rights reserved.
-#
-
-PROJECT(XRT)
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5.0)
-
-ENABLE_TESTING()
-
-SET(PROJECT_DESCRIPTION "https://github.com/Xilinx/XRT")
+cmake_minimum_required(VERSION 3.5.0)
+project(XRT)
+set(PROJECT_DESCRIPTION "https://github.com/Xilinx/XRT")
 
 # Include supporting CMake functions
 include(CMake/unitTestSupport.cmake)
@@ -16,7 +11,8 @@ include(CMake/unitTestSupport.cmake)
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src
   ${CMAKE_CURRENT_SOURCE_DIR}/runtime_src/core/include
-  ${CMAKE_BINARY_DIR}/gen
+  ${XRT_BINARY_DIR}/gen
+  ${XRT_BINARY_DIR}
   )
 
 if (NOT CMAKE_CXX_STANDARD)
@@ -91,8 +87,6 @@ set (CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "xrt")
 #set (XRT_DEV_COMPONENT "xrt-dev")
 set (XRT_DEV_COMPONENT "xrt")
 
-set (XRT_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-
 # Version adjusted to 2.14 for 2022.2
 set(XRT_VERSION_RELEASE 202220)
 SET(XRT_VERSION_MAJOR 2)
@@ -108,9 +102,14 @@ endif(DEFINED ENV{XRT_VERSION_PATCH})
 set(XRT_SOVERSION ${XRT_VERSION_MAJOR})
 set(XRT_VERSION_STRING ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH})
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${XRT_SOURCE_DIR}/CMake/")
 
 if (${XRT_NATIVE_BUILD} STREQUAL "yes")
+  # Enable testing for this directory and below.  This command should be
+  # in the source directory root because ctest expects to find a test
+  # file in the build directory root.
+  enable_testing()
+
   # Temporary native wrapper while Linux code is being ported to windows.
   # When completed the two build flows will once again be merged into one
   # common file

--- a/src/runtime_src/core/common/CMakeLists.txt
+++ b/src/runtime_src/core/common/CMakeLists.txt
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2019-2022 Xilinx, Inc. All rights reserved.
-#
-include_directories(
-  ${CMAKE_BINARY_DIR} # includes version.h
-  )
 
 if (NOT WIN32)
 include_directories(${DRM_INCLUDE_DIRS})

--- a/src/runtime_src/core/edge/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/edge/tools/xbutil/xbutil.h
@@ -35,7 +35,7 @@
 #include "core/edge/include/zynq_ioctl.h"
 #include "core/edge/user/zynq_dev.h"
 #include "xclbin.h"
-#include <version.h>
+#include "gen/version.h"
 #include <fcntl.h>
 #include <chrono>
 using Clock = std::chrono::high_resolution_clock;

--- a/src/runtime_src/core/pcie/tools/xbmgmt/cmd_version.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/cmd_version.cpp
@@ -15,9 +15,9 @@
  */
 
 #include <string>
-#include <version.h>
 #include <fstream>
 #include "xbmgmt.h"
+#include "gen/version.h"
 
 const char *subCmdVersionDesc = "Print out xrt build version";
 const char *subCmdVersionUsage = "(no options supported)";
@@ -41,7 +41,7 @@ int versionHandler(int argc, char *argv[])
 
     xrt::version::print(std::cout);
     std::cout.width(26); std::cout << std::internal << "XOCL: " << driver_version("xocl") << std:: endl;
-    std::cout.width(26); std::cout << std::internal << "XCLMGMT: " << driver_version("xclmgmt") << std::endl;    
+    std::cout.width(26); std::cout << std::internal << "XCLMGMT: " << driver_version("xclmgmt") << std::endl;
 
     if ( !getenv_or_null("INTERNAL_BUILD") )
         xrt_xbmgmt_version_cmp();

--- a/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
+++ b/src/runtime_src/core/pcie/tools/xbmgmt/xbmgmt.cpp
@@ -17,6 +17,7 @@
 
 #include "xbmgmt.h"
 #include "core/pcie/linux/scan.h"
+#include "gen/version.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -26,7 +27,6 @@
 #include <sstream>
 #include <algorithm>
 #include <climits>
-#include <version.h>
 #include <fstream>
 
 struct subCmd {
@@ -166,7 +166,7 @@ void printSubCmdHelp(const std::string& subCmd, bool show_expert)
     }
 }
 
-int xrt_xbmgmt_version_cmp() 
+int xrt_xbmgmt_version_cmp()
 {
     /* Check XRT libs and driver versions. */
     std::string xrt = std::string(xrt_build_version) + "," + std::string(xrt_build_version_hash);
@@ -181,8 +181,8 @@ int xrt_xbmgmt_version_cmp()
 }
 
 bool getenv_or_null(const char* env)
-{ 
-    return getenv(env) ? true : false; 
+{
+    return getenv(env) ? true : false;
 }
 
 int main(int argc, char *argv[])
@@ -195,10 +195,10 @@ int main(int argc, char *argv[])
     std::string subCmd(argv[1]);
     auto cmd = subCmdList.find(subCmd);
 
-    //do not proceed if xbmgmt and xrt versions don't match 
+    //do not proceed if xbmgmt and xrt versions don't match
     //unless cmd is version or help or INTERNAL_BUILD is set
-    if ( subCmd.find("version") == std::string::npos && subCmd.compare("help") != 0 
-            && !getenv_or_null("INTERNAL_BUILD") ) { 
+    if ( subCmd.find("version") == std::string::npos && subCmd.compare("help") != 0
+            && !getenv_or_null("INTERNAL_BUILD") ) {
         if ( xrt_xbmgmt_version_cmp() != 0 )
         return -EINVAL;
     }

--- a/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
+++ b/src/runtime_src/core/pcie/tools/xbutil/xbutil.h
@@ -44,7 +44,7 @@
 #include "ps_kernel.h"
 #include "xclbin.h"
 #include "core/common/xrt_profiling.h"
-#include <version.h>
+#include "gen/version.h"
 
 #include <chrono>
 using Clock = std::chrono::high_resolution_clock;
@@ -1568,11 +1568,11 @@ public:
 
               ostr << std::left << std::setw(60) << cu_n
                    << "@" << std::setw(18) << cu_ba
-                   << std::setw(14) << cu_s 
+                   << std::setw(14) << cu_s
                    << std::setw(14) << cu_u << std::endl;
             }
           }
-          
+
           uint32_t scu_index = 0;
           for (auto& v : sensor_tree::get_child( "board.ps_compute_unit" )) {
             int index = std::stoi(v.first);
@@ -1601,7 +1601,7 @@ public:
 
               ostr << std::left << std::setw(32) << scu_n
                    << "@" << std::setw(18) << scu_ba
-                   << std::setw(14) << scu_s 
+                   << std::setw(14) << scu_s
                    << std::setw(14) << scu_u << std::endl;
             }
           }

--- a/src/runtime_src/core/tools/xbtop/CMakeLists.txt
+++ b/src/runtime_src/core/tools/xbtop/CMakeLists.txt
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2022 Xilinx, Inc. All rights reserved.
-#
 
-message(${LINUX_FLAVOR} ${LINUX_VERSION})
 string(SUBSTRING "${LINUX_VERSION}" 0 1 major_version)
 set (PYTHON_3 TRUE)
 

--- a/src/runtime_src/tools/xclbinutil/CMakeLists.txt
+++ b/src/runtime_src/tools/xclbinutil/CMakeLists.txt
@@ -29,7 +29,7 @@ find_package(Threads REQUIRED)
 
 # -----------------------------------------------------------------------------
 # Include the generated header files (e.g., version.h)
-include_directories(${CMAKE_BINARY_DIR}/gen)
+include_directories(${XRT_BINARY_DIR}/gen)
 
 # ==-- x c l b i n u t i l --==================================================
 
@@ -114,11 +114,11 @@ if(NOT WIN32)
   set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata")
   xrt_add_test("partition_metadata" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PartitionMetadata/SectionPartitionMetadata.py ${TEST_OPTIONS}")
 
-  # -- Fixed Kernels 
+  # -- Fixed Kernels
   set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/FixedKernel")
   xrt_add_test("fixed-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/FixedKernel/FixedKernel.py ${TEST_OPTIONS}")
 
-  # -- PS Kernels 
+  # -- PS Kernels
   set(TEST_OPTIONS " --resource-dir ${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel")
   xrt_add_test("ps-kernel" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/unittests/PSKernel/PSKernel.py ${TEST_OPTIONS}")
 

--- a/src/runtime_src/xdp/CMakeLists.txt
+++ b/src/runtime_src/xdp/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT WIN32)
 
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${XRT_SRC_DIR}/include/1_2
+  ${XRT_SOURCE_DIR}/include/1_2
   )
 
 else()
@@ -14,7 +14,7 @@ else()
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${Boost_INCLUDE_DIRS}
-  ${XRT_SRC_DIR}/include/1_2
+  ${XRT_SOURCE_DIR}/include/1_2
   ${KHRONOS}/include
   )
 endif()

--- a/src/runtime_src/xocl/CMakeLists.txt
+++ b/src/runtime_src/xocl/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 include_directories(
   ${Boost_INCLUDE_DIRS}
-  ${XRT_SRC_DIR}/include/1_2
+  ${XRT_SOURCE_DIR}/include/1_2
 )
 
 set(XRT_XOCL_API_DIR       "${CMAKE_CURRENT_SOURCE_DIR}/api")
@@ -114,9 +114,9 @@ install(TARGETS xilinxopencl xilinxopencl_static
 
 # Release OpenCL extension headers
 install (FILES
-  ${XRT_SRC_DIR}/include/1_2/CL/cl_ext_xilinx.h
-  ${XRT_SRC_DIR}/include/1_2/CL/cl_ext.h
-  ${XRT_SRC_DIR}/include/1_2/CL/cl2xrt.hpp
+  ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext_xilinx.h
+  ${XRT_SOURCE_DIR}/include/1_2/CL/cl_ext.h
+  ${XRT_SOURCE_DIR}/include/1_2/CL/cl2xrt.hpp
   DESTINATION ${XRT_INSTALL_INCLUDE_DIR}/CL
   COMPONENT ${XRT_DEV_COMPONENT}
 )

--- a/src/xma/src/CMakeLists.txt
+++ b/src/xma/src/CMakeLists.txt
@@ -3,9 +3,7 @@
 #
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
-  ${CMAKE_SOURCE_DIR}/runtime_src
   )
 
 add_subdirectory(xmaplugin)
 add_subdirectory(xmaapi)
-


### PR DESCRIPTION
#### Problem solved by the commit
Support hosting XRT as a git submodule in a different project, such that XRT can be 
built as a sub directory in the host project's CMakeLists.txt file.

#### How problem was solved, alternative solutions (if any) and why they were rejected
This is hacking existing hacks to make them slightly less ugly.
Our entire CMake generator code should be redesigned to use modules rather
than setting of various global variables.

#### Risks (if any) associated the changes in the commit
Some risk that untested flows breaks as part of these changes.

#### What has been tested and how, request additional testing if necessary
Building optimized and debug on Linux, Windows, and Edge.
Comparing package content to before changes.
Comparing staged install directory before and after changes.