### PR TITLE
CR-1121993 Added the WARNING for embedded hw_emu design when more tha…

### DIFF
--- a/src/runtime_src/core/edge/user/shim.cpp
+++ b/src/runtime_src/core/edge/user/shim.cpp
@@ -781,6 +781,19 @@ xclLoadAxlf(const axlf *buffer)
     }
   }
 
+  #ifdef __HWEM__
+    static int xclbin_count = 0;
+    xclbin_count++;
+
+    //Fix for CR- 1121993 - if xclbin is already loaded, dont call ioctl in this case
+    if (xclbin_count > 1) {
+      xclLog(XRT_WARNING, "%s: skipping as xclbin is already loaded. Only single XCLBIN load is supported for hw_emu.", __func__);
+      return 0;
+    } else {
+      xclLog(XRT_INFO, "%s: Loading the XCLBIN", __func__);
+    }
+  #endif
+
   ret = ioctl(mKernelFD, DRM_IOCTL_ZOCL_READ_AXLF, &axlf_obj);
 
   xclLog(XRT_INFO, "%s: flags 0x%x, return %d", __func__, flags, ret);

--- a/src/runtime_src/core/edge/user/shim.h
+++ b/src/runtime_src/core/edge/user/shim.h
@@ -133,6 +133,7 @@ public:
 
   int xclErrorInject(uint16_t num, uint16_t driver, uint16_t  severity, uint16_t module, uint16_t eclass);
   int xclErrorClear();
+  int secondXclbinLoadCheck(std::shared_ptr<xrt_core::device> core_dev, const axlf *top);
 
 #ifdef XRT_ENABLE_AIE
   zynqaie::Aie* getAieArray();


### PR DESCRIPTION
CR-1121993 Added the WARNING for embedded hw_emu design when more than one xclbin is tried to load.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Indicated the user about the mutiple xclbin load is not supported for hw_emu

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This is minor enhancement request. This is long pending issue, not introduced by any PR

#### How problem was solved, alternative solutions (if any) and why they were rejected
Enhancement request

#### Risks (if any) associated the changes in the commit
nope

#### What has been tested and how, request additional testing if necessary
Ran the designs where we have multiple xclbins

#### Documentation impact (if any)
nope
