### PR TITLE
XMA checking multiple run objects for completion after one execwait call

### DIFF
--- a/src/xma/src/xmaapi/xma_utils.cpp
+++ b/src/xma/src/xmaapi/xma_utils.cpp
@@ -127,6 +127,7 @@ namespace xma_core {
                 std::string inst_name = cu_name.substr(pos + 1);
                 std::string updated_cu_name = kernel_name + ":{" + inst_name + "}";
                 dev_execbo.xrt_kernel = xrt::kernel(priv->dev_handle, priv->dev_handle.get_xclbin_uuid(), updated_cu_name);
+                dev_execbo.xrt_run = xrt::run(dev_execbo.xrt_kernel);
             }
             return XMA_SUCCESS;
         }

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -440,8 +440,7 @@ XmaCUCmdObj xma_plg_schedule_work_item(XmaSession s_handle,
             return cmd_obj_error;
             */
         }
-    }
-    //priv1->kernel_execbos[bo_idx].xrt_run = xrt::run(priv1->kernel_execbos[bo_idx].xrt_kernel);
+    }    
     auto cu_cmd = reinterpret_cast<ert_start_kernel_cmd*>(priv1->kernel_execbos[bo_idx].xrt_run.get_ert_packet());
     // Copy reg_map into execBO buffer 
     memcpy(&cu_cmd->data + cu_cmd->extra_cu_masks, src, regmap_size);
@@ -633,8 +632,7 @@ XmaCUCmdObj xma_plg_schedule_cu_cmd(XmaSession s_handle,
             return cmd_obj_error;
             */
         }
-    }
-    //priv1->kernel_execbos[bo_idx].xrt_run = xrt::run(priv1->kernel_execbos[bo_idx].xrt_kernel);
+    }    
     auto cu_cmd = reinterpret_cast<ert_start_kernel_cmd*>(priv1->kernel_execbos[bo_idx].xrt_run.get_ert_packet());
     // Copy reg_map into execBO buffer 
     memcpy(&cu_cmd->data + cu_cmd->extra_cu_masks, src, regmap_size);
@@ -810,7 +808,6 @@ int32_t xma_plg_cu_cmd_status(XmaSession s_handle, XmaCUCmdObj* cmd_obj_array, i
             } else if (g_xma_singleton->cpu_mode == XMA_CPU_MODE2) {
                 std::this_thread::yield();
             } else {
-               // priv1->dev_handle.get_handle()->exec_wait(100); // Created CR-1120629 to handle this, supposed to use xrt::run::wait() call.
                 xrt_core::device_int::exec_wait(dev_tmp1->xrt_device, 100ms);
             }
         }
@@ -995,7 +992,6 @@ int32_t xma_plg_is_work_item_done(XmaSession s_handle, uint32_t timeout_ms)
             if (tmp_num_cmds == 0 && count == 0) {
                 xma_logmsg(XMA_WARNING_LOG, XMAPLUGIN_MOD, "Session id: %d, type: %s. There may not be any outstandng CU command to wait for\n", s_handle.session_id, xma_core::get_session_name(s_handle.session_type).c_str());
             }
-            //priv1->dev_handle.get_handle()->exec_wait(timeout1); // Created CR-1120629 to handle this, supposed to use xrt::run::wait() call.
             xrt_core::device_int::exec_wait(dev_tmp1->xrt_device, std::chrono::milliseconds(timeout1));
             iter1--;
         }
@@ -1043,7 +1039,6 @@ int32_t xma_plg_is_work_item_done(XmaSession s_handle, uint32_t timeout_ms)
     
         // Wait for a notification
         if (give_up > 10) {
-            //priv1->dev_handle.get_handle()->exec_wait(timeout1);
             xrt_core::device_int::exec_wait(dev_tmp1->xrt_device, std::chrono::milliseconds(timeout1));
             tmp_num_cmds = priv1->num_cu_cmds;
             count = priv1->kernel_complete_count;

--- a/src/xma/src/xmaplugin/xmaplugin.cpp
+++ b/src/xma/src/xmaplugin/xmaplugin.cpp
@@ -23,6 +23,7 @@
 #include "lib/xma_utils.hpp"
 #include "core/common/api/bo.h"
 #include "core/common/api/kernel_int.h"
+#include "core/common/api/device_int.h"
 #include "core/common/device.h"
 
 #include <algorithm>
@@ -31,14 +32,6 @@
 #include <cstring>
 #include <iostream>
 #include <thread>
-
- // decl internal non public function
-namespace xrt_core {
-    namespace device_int {
-        std::cv_status
-            exec_wait(const xrt::device& device, const std::chrono::milliseconds& timeout_ms);
-    }
-}
 
 using namespace std;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Reusing the xrt::run objects in XMA. XMA used to create new run object every time.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
https://jira.xilinx.com/browse/CR-1120629

#### How problem was solved, alternative solutions (if any) and why they were rejected
Infra support for this requirement done by Soren in [#6310](https://github.com/Xilinx/XRT/pull/6310) 

#### Risks (if any) associated the changes in the commit
n/a

#### What has been tested and how, request additional testing if necessary
All XMA sprite testcases ran locally with this change, all are passing.

#### Documentation impact (if any)
n/a