### PR TITLE
Fix seg fault while running application in zynq edge platforms

### DIFF
--- a/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
+++ b/src/runtime_src/core/edge/drm/zocl/zocl_xclbin.c
@@ -1444,7 +1444,8 @@ zocl_xclbin_read_axlf(struct drm_zocl_dev *zdev, struct drm_zocl_axlf *axlf_obj,
 	 * Remember xclbin_uuid for opencontext.
 	 */
 	slot->slot_xclbin->zx_refcnt = 0;
-	zocl_xclbin_set_dtbo_path(slot, axlf_obj->za_dtbo_path);
+	if(ZOCL_PLATFORM_ARM64)
+		zocl_xclbin_set_dtbo_path(slot, axlf_obj->za_dtbo_path);
 	zocl_xclbin_set_uuid(slot, &axlf_head.m_header.uuid);
 
 	/*


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Fix segmentation fault when running application in zynq(zc706).

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue was introduced because of PR - https://github.com/Xilinx/XRT/pull/6365 and the issue was caught in embedded pipeline

#### How problem was solved, alternative solutions (if any) and why they were rejected
As there is no support in libdfx apis for zynq platforms added a check in zocl code to not set dtbo_path for zynq devices

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Ran vadd application on zc706 board and the test is passing

#### Documentation impact (if any)
NA