### PR TITLE
Fix reading aie clock frequency

### DIFF
--- a/src/runtime_src/core/edge/user/device_linux.cpp
+++ b/src/runtime_src/core/edge/user/device_linux.cpp
@@ -535,6 +535,7 @@ struct aie_get_freq
   static result_type
   get(const xrt_core::device* device, key_type key, const boost::any& partition_id)
   {
+    result_type freq = 0;
 #if defined(XRT_ENABLE_AIE)
     const std::string zocl_device = "/dev/dri/" + get_render_devname();
     auto fd_obj = aie_get_drmfd(device, zocl_device);
@@ -549,10 +550,11 @@ struct aie_get_freq
     if (ioctl(fd_obj->fd, DRM_IOCTL_ZOCL_AIE_FREQSCALE, &aie_arg))
       throw xrt_core::error(-errno, boost::str(boost::format("Reading clock frequency from AIE partition(%d) failed") % aie_arg.partition_id));
 
+    freq = aie_arg.freq;
 #else
     throw xrt_core::error(-EINVAL, "AIE is not enabled for this device");
 #endif
-    return boost::any_cast<result_type>(aie_arg.freq);
+    return freq;
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Returning proper value when 'xbutil advanced --aie-clock --get' is called

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Aie clock frequency is shown 0 every time because of wrong return value in PR - https://github.com/Xilinx/XRT/pull/6272

#### How problem was solved, alternative solutions (if any) and why they were rejected
Returning proper value solved the issue

#### Risks (if any) associated the changes in the commit
none

#### What has been tested and how, request additional testing if necessary
Tested on vck190 board with aie test case
root@versal-rootfs-common-20221:~# xbutil advanced --aie-clock --get 
WARNING: 'partition' option is not provided, using default partition id value '1'
INFO: Clock frequency of AIE partition(1) is: **1250.00 MHz**

#### Documentation impact (if any)
NA