### PR TITLE
CR-1126093 - PS Kernel - int32_t data type not recognized

### DIFF
--- a/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
+++ b/src/runtime_src/tools/xclbinutil/ElfUtilities.cxx
@@ -465,6 +465,7 @@ evaluate_DW_TAG_type(const std::string& typeOffset,
       break;
 
     case DW_TAG::_typedef:
+      evaluate_DW_TAG_type(ptTag.get<std::string>("DW_AT_type",""), argTags, ptArgument);
       ptArgument.put("type", ptTag.get<std::string>("DW_AT_name"));
       break;
 


### PR DESCRIPTION
#### Problem solved by the commit
When parsing the readelf (DWARF) metadata, the xclbinutil parser did not take into accout that DW_AT_typedef primitive argument size could be at a lower nested node.  This PR fixes this issue by parsing these metadata nodes.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
The algorithm was created initially to no look at lower level nodes.  It was only when users started to explore the various levels of argument indirections (e.g., uint32_t -> __int32_t -> int) was this issue discovered.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated the algorihtm to support recursion of these nodes.

#### Risks (if any) associated the changes in the commit
Low to none

#### What has been tested and how, request additional testing if necessary
Manual testing against user supplies test case

#### Documentation impact (if any)
n/a