### PR TITLE
CR 1123673 - ERROR: Property 'reg' data value '0x0000000000920000' exceeds the maximum uint64_t storage space.

### DIFF
--- a/src/runtime_src/tools/xclbinutil/FDTProperty.cxx
+++ b/src/runtime_src/tools/xclbinutil/FDTProperty.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019 Xilinx, Inc
+ * Copyright (C) 2019, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -507,6 +507,7 @@ FDTProperty::writeDataWord(DataFormat _eDataFormat,
     case DF_au64:
     case DF_u64:
       {
+        errno = 0; 
         uint64_t dataWord = std::strtoul(_sData.c_str(), NULL, 0);
         if (errno == ERANGE) {
           std::string err = XUtil::format("ERROR: Property '%s' data value '%s' exceeds the maximum uint64_t storage space.", m_name.c_str(), _sData.c_str());


### PR DESCRIPTION
#### Problem solved by the commit
There was a false error that occured when checking the return value from std::strtoul().  This function only sets the `errno `variable if an range error occured.  In this case, a previous math function was called that set this value.  It unfortunately wasn't cleared after being resolved, hence this issue.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This issue has been in the code base since the original creation of the partition_metadata section (many years).

#### How problem was solved, alternative solutions (if any) and why they were rejected
The fix was to set the errno value to zero prior to calling std::strtol().  

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manual testing

#### Documentation impact (if any)
None