### PR TITLE
CR-1119433 Improve error message for xbmgmt configure commands

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -287,7 +287,7 @@ update_device_conf(xrt_core::device* device, const std::string& value, config_ty
         xrt_core::device_update<xrt_core::query::xmc_scaling_reset>(device, value);
         break;
     }
-  } catch (const std::exception& ex) {
+  } catch (const std::exception&) {
     std::cerr << boost::format("ERROR: Device does not support %s\n\n") % config_to_string(cfg);
     throw xrt_core::error(std::errc::operation_canceled);
   }
@@ -305,7 +305,7 @@ memory_retention(xrt_core::device* device, bool enable)
   try {
     auto value = xrt_core::query::data_retention::value_type(enable);
     xrt_core::device_update<xrt_core::query::data_retention>(device, value);
-  } catch (const std::exception& ex) {
+  } catch (const std::exception&) {
     std::cerr << boost::format("ERROR: Device does not support memory retention\n\n");
     throw xrt_core::error(std::errc::operation_canceled);
   }

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -45,7 +45,7 @@ enum class config_type {
 
 static
 std::string
-to_string(config_type value)
+config_to_string(config_type value)
 {
   static std::map<config_type, std::string> config_map =
   {
@@ -53,7 +53,7 @@ to_string(config_type value)
    { config_type::clk_scaling,                "runtime clock scaling" },
    { config_type::threshold_power_override,   "threshold power override" },
    { config_type::threshold_temp_override,    "threshold temp override" },
-   { config_type::reset,                      "reset" },
+   { config_type::reset,                      "clock scaling option reset" },
   };
 
   return config_map[value];
@@ -268,27 +268,27 @@ update_daemon_config(const std::string& host)
 static bool 
 update_device_conf(xrt_core::device* device, const std::string& value, config_type cfg)
 {
-  XBU::sudo_or_throw("Updating daemon configuration requires sudo");
+  XBU::sudo_or_throw("Updating device configuration requires sudo");
   try {
-  switch(cfg) {
-  case config_type::security:
-    xrt_core::device_update<xrt_core::query::sec_level>(device, value);
-    break;
-  case config_type::clk_scaling:
-    xrt_core::device_update<xrt_core::query::xmc_scaling_enabled>(device, value);
-    break;
-  case config_type::threshold_power_override:
-    xrt_core::device_update<xrt_core::query::xmc_scaling_power_override>(device, value);
-    break;
-  case config_type::threshold_temp_override:
-    xrt_core::device_update<xrt_core::query::xmc_scaling_temp_override>(device, value);
-    break;
-  case config_type::reset:
-    xrt_core::device_update<xrt_core::query::xmc_scaling_reset>(device, value);
-    break;
-  }
+    switch(cfg) {
+      case config_type::security:
+        xrt_core::device_update<xrt_core::query::sec_level>(device, value);
+        break;
+      case config_type::clk_scaling:
+        xrt_core::device_update<xrt_core::query::xmc_scaling_enabled>(device, value);
+        break;
+      case config_type::threshold_power_override:
+        xrt_core::device_update<xrt_core::query::xmc_scaling_power_override>(device, value);
+        break;
+      case config_type::threshold_temp_override:
+        xrt_core::device_update<xrt_core::query::xmc_scaling_temp_override>(device, value);
+        break;
+      case config_type::reset:
+        xrt_core::device_update<xrt_core::query::xmc_scaling_reset>(device, value);
+        break;
+    }
   } catch (const std::exception& ex) {
-    std::cerr << boost::format("ERROR: Device does not support %s\n\n") % to_string(cfg);
+    std::cerr << boost::format("ERROR: Device does not support %s\n\n") % config_to_string(cfg);
     throw xrt_core::error(std::errc::operation_canceled);
   }
   return true;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -43,20 +43,29 @@ enum class config_type {
     reset
 };
 
-static
-std::string
-config_to_string(config_type value)
+std::ostream&
+operator<<(std::ostream& os, const config_type& value)
 {
-  static std::map<config_type, std::string> config_map =
-  {
-   { config_type::security,                   "security" },
-   { config_type::clk_scaling,                "runtime clock scaling" },
-   { config_type::threshold_power_override,   "threshold power override" },
-   { config_type::threshold_temp_override,    "threshold temp override" },
-   { config_type::reset,                      "clock scaling option reset" },
-  };
-
-  return config_map[value];
+  switch (value) {
+    case config_type::security:
+      os << "security";
+      break;
+    case config_type::clk_scaling:
+      os << "runtime clock scaling";
+      break;
+    case config_type::threshold_power_override:
+      os << "threshold power override";
+      break;
+    case config_type::threshold_temp_override:
+      os << "threshold temp override";
+      break;
+    case config_type::reset:
+      os << "clock scaling option reset";
+      break;
+    default:
+      throw std::runtime_error("Configuration missing enumeration conversion");
+  }
+  return os;
 }
 
 enum class mem_type {
@@ -288,7 +297,7 @@ update_device_conf(xrt_core::device* device, const std::string& value, config_ty
         break;
     }
   } catch (const std::exception&) {
-    std::cerr << boost::format("ERROR: Device does not support %s\n\n") % config_to_string(cfg);
+    std::cerr << boost::format("ERROR: Device does not support %s\n\n") % cfg;
     throw xrt_core::error(std::errc::operation_canceled);
   }
   return true;

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdConfigure.cpp
@@ -303,8 +303,8 @@ memory_retention(xrt_core::device* device, bool enable)
 {
   XBU::sudo_or_throw("Updating memory retention requires sudo");
   try {
-  auto value = xrt_core::query::data_retention::value_type(enable);
-  xrt_core::device_update<xrt_core::query::data_retention>(device, value);
+    auto value = xrt_core::query::data_retention::value_type(enable);
+    xrt_core::device_update<xrt_core::query::data_retention>(device, value);
   } catch (const std::exception& ex) {
     std::cerr << boost::format("ERROR: Device does not support memory retention\n\n");
     throw xrt_core::error(std::errc::operation_canceled);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Running "sudo xbmgmt configure --runtime_clk_scale enable" returns:
```
XRT build version: 2.13.260
Build hash: 6820e65a07311528963d49cf3195821069a72ed4
Build date: 2021-12-16 21:24:14
Git branch: master
PID: 30334
UID: 0
[Wed Jan 12 10:59:12 2022 GMT]
HOST: xniengxbb39
EXE: /opt/xilinx/xrt/bin/unwrapped/xbmgmt2
[xbmgmt] ERROR: Failed to find subdirectory for xmc under /sys/bus/pci/devices/0000:c1:00.0
```
This is applicable to the retention option and all the hidden options for the xbmgmt configure command.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
If a sysfs node is missing when the xbmgmt configure command is run an access error would occur vs a graceful stop to the program.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added try/catch handling for any missing sysfs nodes and printed a more helpful message within xbmgmt configure.

#### Risks (if any) associated the changes in the commit
None, added better error handling.

#### What has been tested and how, request additional testing if necessary
Tested on vck5000
Runtime Clock Scaling
```
root@xsjsagarw50:~# xbmgmt configure -d 65:00 --runtime_clk_scale enable
ERROR: Device does not support runtime clock scaling

root@xsjsagarw50:~# echo $?
1
```
Security
```
root@xsjsagarw50:~# xbmgmt configure -d 65:00 --security enable
ERROR: Device does not support security

root@xsjsagarw50:~# echo $?
1
```
Threshold Power Override
```
root@xsjsagarw50:~# xbmgmt configure -d 65:00 --cs_threshold_power_override enable
ERROR: Device does not support threshold power override

root@xsjsagarw50:~# echo $?
1
```
Threshold Temperature Override
```
root@xsjsagarw50:~# xbmgmt configure -d 65:00 --cs_threshold_temp_override enable
ERROR: Device does not support threshold temp override

root@xsjsagarw50:~# echo $?
1
```
Clock Scaling Option Reset
```
root@xsjsagarw50:~# xbmgmt configure -d 65:00 --cs_reset enable
ERROR: Device does not support clock scaling option reset

root@xsjsagarw50:~# echo $?
1
```
Memory Retention
```
root@xsjsagarw50:~# xbmgmt configure -d 65:00 --retention ENABLE
ERROR: Device does not support memory retention

root@xsjsagarw50:~# echo $?
1
```
Non-root attempts to configure
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt configure -d 65:00 --retention enable
ERROR: Updating memory retention requires sudo
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbmgmt configure -d 65:00 --cs_reset enable
ERROR: Updating device configuration requires sudo
```
#### Documentation impact (if any)
None