### PR TITLE
CR 1116352 - xclbinutil failure ( possibly a regression from a previous CR1030259)

### DIFF
--- a/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
+++ b/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018, 2021Xilinx, Inc
+ * Copyright (C) 2018, 2021, 2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -205,9 +205,10 @@ SectionMemTopology::marshalFromJSON(const boost::property_tree::ptree& _ptSectio
     memData.m_used = ptMemData.get<uint8_t>("m_used");
 
     std::string sm_tag = ptMemData.get<std::string>("m_tag");
-    if (sm_tag.length() >= sizeof(mem_data::m_tag)) {
-      std::string errMsg = XUtil::format("ERROR: The m_tag entry length (%d), exceeds the allocated space (%d).  Name: '%s'",
-                                         (unsigned int)sm_tag.length(), (unsigned int)sizeof(mem_data::m_tag), sm_tag.c_str());
+    size_t maxTagLength = sizeof(mem_data::m_tag) - 1;
+    if (sm_tag.length() > maxTagLength) {
+      std::string errMsg = XUtil::format("ERROR: The m_tag entry length (%d), exceeds the allocated space (%d) available.  Name: '%s'",
+                                         (unsigned int)sm_tag.length(), ((unsigned int)maxTagLength), sm_tag.c_str());
       throw std::runtime_error(errMsg);
     }
 


### PR DESCRIPTION
#### Problem solved by the commit
The error message produced by xclbin was misleading.  It indicated that a tag string could fit in the allocated space when in reality it couldn't.  This was because it didn't take into account the null terminated character.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
n/a

#### How problem was solved, alternative solutions (if any) and why they were rejected
Updated error message to correctly reflect how much space is available.

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Manual testing

#### Documentation impact (if any)
n/a