### PR TITLE
CR-1126538 ASTeR TC1.06 - u50 - cannot upgrade from factory SC version, xocl and SC left in abnormal state

### DIFF
--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -464,7 +464,10 @@ int XMC_Flasher::sendPkt(bool print_dot)
 
 int XMC_Flasher::waitTillIdle()
 {
-    // In total, wait for 5000 * 10ms
+    /* In total, wait for 5000 * 10ms
+     * SC in factory mode takes nearly 30 seconds to be idle
+     * We relax the waiting time here to up to 50 seconds.
+     */
     int retry = 5000;
     unsigned int err = 0;
 

--- a/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/xmc.cpp
@@ -464,8 +464,8 @@ int XMC_Flasher::sendPkt(bool print_dot)
 
 int XMC_Flasher::waitTillIdle()
 {
-    // In total, wait for 500 * 10ms
-    int retry = 500;
+    // In total, wait for 5000 * 10ms
+    int retry = 5000;
     unsigned int err = 0;
 
 #if  XMC_DEBUG


### PR DESCRIPTION
#### Problem solved by the commit
Compare to normal SC,  SC in factory mode takes way longer time to be ready. 

It takes nearly 30 seconds. However, we only wait 5 secs in xbmgmt2.

Don't have the issue in xbmgmt, it goes through xmc driver to flash sc firmware and waits up to 60 secs.

#### Risks (if any) associated the changes in the commit
Low