### PR TITLE
CR-1122060 XRT tool support for in-band SC-FW program

### DIFF
--- a/src/runtime_src/core/common/query_requests.h
+++ b/src/runtime_src/core/common/query_requests.h
@@ -265,6 +265,7 @@ enum class key_type
 
   boot_partition,
   flush_default_only,
+  program_sc,
   vmr_status,
 
   hwmon_sdm_serial_num,
@@ -2881,6 +2882,19 @@ struct flush_default_only : request
   using result_type = uint32_t;
   using value_type = uint32_t;
   static const key_type key = key_type::flush_default_only;
+
+  virtual boost::any
+  get(const device*) const = 0;
+
+  virtual void
+  put(const device*, const boost::any&) const = 0;
+};
+
+struct program_sc : request
+{
+  using result_type = uint32_t;
+  using value_type = uint32_t;
+  static const key_type key = key_type::program_sc;
 
   virtual boost::any
   get(const device*) const = 0;

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1021,6 +1021,7 @@ initialize_query_table()
 
   emplace_sysfs_getput<query::boot_partition>                  ("xgq_vmr", "boot_from_backup");
   emplace_sysfs_getput<query::flush_default_only>              ("xgq_vmr", "flush_default_only");
+  emplace_sysfs_getput<query::program_sc>                      ("xgq_vmr", "program_sc");
   emplace_sysfs_get<query::vmr_status>                         ("xgq_vmr", "vmr_status");
 
   emplace_func4_request<query::sdm_sensor_info,                sdm_sensor_info>();

--- a/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/SubCmdProgram.cpp
@@ -142,6 +142,17 @@ update_SC(unsigned int  index, const std::string& file)
     throw xrt_core::error(boost::str(boost::format("%d is an invalid index") % index));
 
   auto dev = xrt_core::get_mgmtpf_device(index);
+
+  //versal flow to flash sc
+  try {
+    uint32_t val = xrt_core::query::program_sc::value_type(1);
+    xrt_core::device_update<xrt_core::query::program_sc>(dev.get(), val);
+    return;
+  }
+  catch (const xrt_core::query::exception&) { 
+    // this flow is not supported on the device
+    // continue with the other flow
+  }
   
   //if factory image, update SC
   auto is_mfg = xrt_core::device_query<xrt_core::query::is_mfg>(dev);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Versal cards should not flash bmc coming from the the xsabin

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
If the program_sc sysfs node is available, set it and exit sc flashing. The driver will take care of the rest

#### Risks (if any) associated the changes in the commit
Low to None. Probably needs more testing

#### What has been tested and how, request additional testing if necessary
Locally
```
# xbmgmt program -b -d --force
----------------------------------------------------
Device : [0000:09:00.0]

Current Configuration
  Platform             : xilinx_vck5000_gen4x8_xdma_base_2
  SC Version           : 4.4.32
  Platform ID          : 0x539c76acf2192cdc


Incoming Configuration
  Deployment File      : partition.xsabin
  Deployment Directory : /lib/firmware/xilinx/539c76acf2192cdcb9db69a6450407c0
  Size                 : 7,751,464 bytes
  Timestamp            : Tue Mar  8 15:13:27 2022

  Platform             : xilinx_vck5000_gen4x8_xdma_base_2
  SC Version           : 4.4.32
  Platform UUID        : 539C76AC-F219-2CDC-B9DB-69A6450407C0
----------------------------------------------------
Actions to perform:
  [0000:09:00.0] : Program base (FLASH) image
  [0000:09:00.0] : Program Satellite Controller (SC) image
----------------------------------------------------
Are you sure you wish to proceed? [Y/n]: Y (Force override)

INFO: Forcing flashing of the Satellite Controller (SC) image (Force flag is set).
[0000:09:00.0] : Updating Satellite Controller (SC) firmware flash image...

INFO: Forcing flashing of the base (e.g., shell) image (Force flag is set).
[0000:09:00.0] : Updating base (e.g., shell) flash image...
INFO: ***xsabin has 7751464 bytes
INFO: ***Write 7751464 bytes
INFO     : Base flash image has been programmed successfully. 
----------------------------------------------------
Report
  [0000:09:00.0] : Successfully flashed the Satellite Controller (SC) image
  [0000:09:00.0] : Successfully flashed the base (e.g., shell) image

Device flashed successfully.
****************************************************
Cold reboot machine to load the new image on device.
****************************************************
# xbmgmt examine -d

-------------------------------------------------------
1/1 [0000:09:00.0] : xilinx_vck5000_gen4x8_xdma_base_2
-------------------------------------------------------
Flash properties
  Type                 : ospi_xgq
  Serial Number        : XFL1BV5HGXGA

Device properties
  Type                 : vck5000
  Name                 : VCK5000-PP
  Config Mode          : 2913264768
  Max Power            : N/A

Flashable partitions running on FPGA
  Platform             : xilinx_vck5000_gen4x8_xdma_base_2
  SC Version           : 4.4.32
  Platform UUID        : 539C76AC-F219-2CDC-B9DB-69A6450407C0
  Interface UUID       : 1782B562-019C-AB41-EE85-7964621BB773

Flashable partitions installed in system
  Platform             : xilinx_vck5000_gen4x8_xdma_base_2
  SC Version           : 4.4.32
  Platform UUID        : 539C76AC-F219-2CDC-B9DB-69A6450407C0

Bootable Partitions:
  Default              : ACTIVE
  Backup               : INACTIVE


  Mac Address          : 00:0A:35:0A:7F:AE:00:F9
                       : 00:0A:35:0A:7F:AF:00:00

```

#### Documentation impact (if any)
