### PR TITLE
CR-1126419 add warning when no aie status files were written

### DIFF
--- a/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
@@ -96,6 +96,7 @@ namespace xdp {
     return true;
   }
 
+  // Warn if application exits without writing valid data
   AIEDebugWriter::~AIEDebugWriter()
   {
     if (!mWroteValidData) {
@@ -175,6 +176,7 @@ namespace xdp {
     return true;
   }
 
+  // Warn if application exits without writing valid data
   AIEShimDebugWriter::~AIEShimDebugWriter()
   {
     if (!mWroteValidData) {

--- a/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
@@ -176,7 +176,7 @@ namespace xdp {
     return true;
   }
 
-  // Warn if application exits without writing valid data
+  // Warn if application exits without writing valid shim data
   AIEShimDebugWriter::~AIEShimDebugWriter()
   {
     if (!mWroteValidData) {

--- a/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
@@ -17,6 +17,8 @@
 #include "xdp/profile/writer/aie_debug/aie_debug_writer.h"
 #include "xdp/profile/database/database.h"
 
+#include "core/common/message.h"
+
 #include <vector>
 #include <boost/optional/optional.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -32,6 +34,7 @@ namespace xdp {
     : VPWriter(fileName)
     , mDeviceName(deviceName)
     , mDeviceIndex(deviceIndex)
+    , mWroteValidData(false)
   {
   }
 
@@ -57,6 +60,7 @@ namespace xdp {
     // Write approved AIE report to file
     refreshFile();
     fout << aieInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
@@ -85,10 +89,19 @@ namespace xdp {
     // Write approved AIE report to file
     refreshFile();
     fout << aieInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
     return true;
+  }
+
+  AIEDebugWriter::~AIEDebugWriter()
+  {
+    if (!mWroteValidData) {
+      std::string msg("No valid data found for AIE status. Please run xbutil.");
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+    }
   }
 
   /*
@@ -100,6 +113,7 @@ namespace xdp {
     : VPWriter(fileName)
     , mDeviceName(deviceName)
     , mDeviceIndex(deviceIndex)
+    , mWroteValidData(false)
   {
   }
 
@@ -125,6 +139,7 @@ namespace xdp {
     // Write approved AIE shim report to file
     refreshFile();
     fout << aieShimInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
@@ -153,10 +168,19 @@ namespace xdp {
     // Write approved AIE shim report to file
     refreshFile();
     fout << aieShimInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
     return true;
+  }
+
+  AIEShimDebugWriter::~AIEShimDebugWriter()
+  {
+    if (!mWroteValidData) {
+      std::string msg("No valid data found for AIE Shim status. Please run xbutil.");
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+    }
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.h
@@ -30,6 +30,7 @@ namespace xdp {
   public:
     AIEDebugWriter(const char* fileName, const char* deviceName,
                    uint64_t deviceIndex);
+    ~AIEDebugWriter();
 
     virtual bool write(bool openNewFile);
     virtual bool write(bool openNewFile, void* handle);
@@ -37,6 +38,7 @@ namespace xdp {
   private:
     std::string mDeviceName;
     uint64_t mDeviceIndex;
+    bool mWroteValidData;
   };
 
   /*
@@ -47,6 +49,7 @@ namespace xdp {
   public:
     AIEShimDebugWriter(const char* fileName, const char* deviceName,
                        uint64_t deviceIndex);
+    ~AIEShimDebugWriter();
 
     virtual bool write(bool openNewFile);
     virtual bool write(bool openNewFile, void* handle);
@@ -54,6 +57,7 @@ namespace xdp {
   private:
     std::string mDeviceName;
     uint64_t mDeviceIndex;
+    bool mWroteValidData;
   };
 
 } // end namespace xdp


### PR DESCRIPTION
If application exits too soon, we could end up with corrupt aie status data. In this case we throw a warning.