### PR TITLE
Resolved the result mismatch issue for CR-1126579

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -2725,7 +2725,7 @@ int HwEmShim::xclCopyBO(unsigned int dst_boHandle, unsigned int src_boHandle, si
   }
    
   // Copy buffer thru the M2M.
-    if (deviceQuery(key_type::m2m) && getM2MAddress() != 0) {
+    if ((deviceQuery(key_type::m2m) && getM2MAddress() != 0) && !((sBO->fd >= 0) || (dBO->fd >= 0))) {
 
       char hostBuf[M2M_KERNEL_ARGS_SIZE];
       std::memset(hostBuf, 0, M2M_KERNEL_ARGS_SIZE);


### PR DESCRIPTION
Resolved the result mismatch for P2P testcases by adding condition in xclCopyBO such that the control will not go to m2m logic when P2P transfer is involved
This is an issue which was caught as part of the CR-1126579
There is no workaround for the solution
Low Risk
We have run the Canary suite and also verified various combination testcases of P2P & M2M manually
No impact on Documentation

