### PR TITLE
CR-1078430: Parsing simulate.log for HLS_PRINT messages. Also dump a "SIMULATION EXITED" message when xsim exits.

### DIFF
--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -207,7 +207,10 @@ namespace xclhwemhal2 {
   int HwEmShim::parseLog()
   {
     std::vector<std::string> myvector = {"SIM-IPC's external process can be connected to instance",
-                                         "SystemC TLM functional mode"};
+                                         "SystemC TLM functional mode",
+                                         "HLS_PRINT",
+                                         "Exiting xsim",
+                                         "FATAL_ERROR"};
 
     std::ifstream ifs(getSimPath() + "/simulate.log");
 
@@ -218,6 +221,11 @@ namespace xclhwemhal2 {
           std::string::size_type index = line.find(matchString);
           if (index != std::string::npos) {
             if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
+              if (matchString == "Exiting xsim") {
+                 #ifndef _WINDOWS
+		   xclClose();
+                 #endif 
+              }
               logMessage(line);
               parsedMsgs.push_back(line);
             }

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -228,6 +228,9 @@ namespace xclhwemhal2 {
               }
               logMessage(line);
               parsedMsgs.push_back(line);
+              if (!matchString.compare("Exiting xsim") || !matchString.compare("FATAL_ERROR")) {
+                 std::cout << "SIMULATION EXITED" << std::endl; 
+              }
             }
           }
         }
@@ -250,7 +253,6 @@ namespace xclhwemhal2 {
   {
     std::string simPath = getSimPath();
     std::string content = loadFileContentsToString(simPath + "/simulate.log");
-    parseString(simPath,"HLS_PRINT");
     if (content.find("// ERROR!!! DEADLOCK DETECTED ") != std::string::npos) {
       size_t first = content.find("// ERROR!!! DEADLOCK DETECTED");
       size_t last = content.find("detected!", first);

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -223,9 +223,8 @@ namespace xclhwemhal2 {
             if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
               logMessage(line);
               parsedMsgs.push_back(line);
-              if (!matchString.compare("Exiting xsim") || !matchString.compare("FATAL_ERROR")) {
+              if (!matchString.compare("Exiting xsim") || !matchString.compare("FATAL_ERROR"))
                  std::cout << "SIMULATION EXITED" << std::endl; 
-              }
             }
           }
         }

--- a/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
+++ b/src/runtime_src/core/pcie/emulation/hw_em/generic_pcie_hal2/shim.cxx
@@ -221,11 +221,6 @@ namespace xclhwemhal2 {
           std::string::size_type index = line.find(matchString);
           if (index != std::string::npos) {
             if(std::find(parsedMsgs.begin(), parsedMsgs.end(), line) == parsedMsgs.end()) {
-              if (matchString == "Exiting xsim") {
-                 #ifndef _WINDOWS
-		   xclClose();
-                 #endif 
-              }
               logMessage(line);
               parsedMsgs.push_back(line);
               if (!matchString.compare("Exiting xsim") || !matchString.compare("FATAL_ERROR")) {


### PR DESCRIPTION
#### Description : Parsing simulate.log for HLS_PRINT messages. Also dump a "SIMULATION EXITED" message when xsim exits.

#### Bug / issue (if any) fixed : CR-1078430, CR-1123293

#### How problem was solved: Parsing simulate.log for "HLS_PRINT" messages and displaying immediately on the console.
Parsing the simulate.log for "Exiting xsim" or "FATAL_ERROR" messages and printing the message "SIMULATION EXITED" on console

#### Risks (if any) : No risk / Low

#### Testing: Canary has been run. Results are good.

#### Documentation impact (if any): No