### PR TITLE
hwmon_sdm: reinit hwmon_sdm driver during reset

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_drv.c
@@ -257,6 +257,14 @@ void xocl_reset_notify(struct pci_dev *pdev, bool prepare)
 			return;
 		}
 
+		if (XOCL_DSA_IS_VERSAL_ES3(xdev)) {
+			ret = xocl_hwmon_sdm_init(xdev);
+			if (ret) {
+				userpf_err(xdev, "failed to init hwmon_sdm driver, err: %d", ret);
+				return;
+			}
+		}
+
 		xocl_kds_reset(xdev, xclbin_id);
 		XOCL_PUT_XCLBIN_ID(xdev);
 		if (!xdev->core.drm) {
@@ -1078,7 +1086,7 @@ int xocl_hwmon_sdm_init(struct xocl_dev *xdev)
 	(void) xocl_hwmon_sdm_init_sysfs(xdev, XCL_SDR_POWER);
 	(void) xocl_hwmon_sdm_init_sysfs(xdev, XCL_SDR_VOLTAGE);
 
-	return ret;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
This PR fixes reinit of hwmon_sdm driver during xbutil reset.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
hwmon_sdm driver is not initialized during reset sequence.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Added change in reset flow to init hwmon_sdm driver.

#### Risks (if any) associated the changes in the commit
NA
#### What has been tested and how, request additional testing if necessary
$xbutil reset -d
$#checked dmesg log of reset.
$xbutil examine -r all -d
$#expected output observed

#### Documentation impact (if any)
NA