### PR TITLE
CR-1126883 xbutil validate is crashing host for DSA xilinx:u25:gen3x8-xdma-base:1--221221

### DIFF
--- a/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
+++ b/src/runtime_src/core/pcie/driver/linux/xocl/userpf/xocl_kds.c
@@ -2101,8 +2101,9 @@ void xocl_kds_unregister_cus(struct xocl_dev *xdev, int slot_hdl)
 	XDEV(xdev)->kds.xgq_enable = false;
 	ret = xocl_ert_ctrl_connect(xdev);
 	if (ret) {
-		userpf_info(xdev, "ERT will be disabled, ret %d\n", ret);
+		userpf_info_once(xdev, "ERT will be disabled, ret %d\n", ret);
 		XDEV(xdev)->kds.ert_disable = true;
+		return;
 	}
 
 	// Work-around to unconfigure PS kernel


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
System crash with u25 + 2022.1/master XRT

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
This bug is reported on CR-1126883. This only happened on a shell doesn't have ERT, or disabled in device.

#### How problem was solved, alternative solutions (if any) and why they were rejected
If ert_ctrl subdev doesn't present, return from xocl_kds_unregister_cus().

#### Risks (if any) associated the changes in the commit
No obviously risk.

#### What has been tested and how, request additional testing if necessary
xbutil validate on u25

#### Documentation impact (if any)
No