### PR TITLE
CR-1126301 ASTeR TC18.01 - xbutil validate dma test - *ERROR* object creation failed user_flags 31, size 0x1000000

### DIFF
--- a/src/runtime_src/core/common/info_memory.cpp
+++ b/src/runtime_src/core/common/info_memory.cpp
@@ -243,7 +243,7 @@ struct memory_info_collector
     pt_mem.put("tag", mem->m_tag);
     pt_mem.put("enabled", mem->m_used ? true : false);
     pt_mem.put("base_address", boost::format("0x%x") % mem->m_base_address);
-    pt_mem.put("range_bytes", boost::format("0x%x") % (mem->m_size << 10)); // magic 10
+    pt_mem.put("range_bytes", boost::format("0x%x") % (mem->m_size * 1024)); // convert KB to bytes
   }
 
   // Add mem usage info for specified mem entry.

--- a/src/runtime_src/core/pcie/common/dmatest.h
+++ b/src/runtime_src/core/pcie/common/dmatest.h
@@ -117,7 +117,7 @@ namespace xcldev {
         DMARunner(xclDeviceHandle handle, size_t size, unsigned flags = 0, size_t totalSize = 0) :
                 mHandle(handle),
                 mSize(size),
-                mTotalSize(totalSize ? totalSize : 0x100000000),
+                mTotalSize(totalSize),
                 mFlags(flags),
                 mPattern('x') {
             long long count = mTotalSize / mSize;

--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -997,9 +997,9 @@ dmaTest(const std::shared_ptr<xrt_core::device>& _dev, boost::property_tree::ptr
 
     size_t totalSize = 0;
     if (xrt_core::device_query<xrt_core::query::pcie_vendor>(_dev) == ARISTA_ID)
-      totalSize = 0x20000000;
+      totalSize = 0x20000000; // 512 MB 
     else
-      totalSize = mem.m_size * 1024; // convert to bytes
+      totalSize = std::min((mem.m_size * 1024), XBU::string_to_bytes("2G")); // minimum of mem size in bytes and 2 GB
 
     xcldev::DMARunner runner(_dev->get_device_handle(), block_size, static_cast<unsigned int>(midx), totalSize);
     try {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
Don't allocate 4GB as the bank can be smaller than that

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected
Instead of blindly allocating 4GB, we allocate the total size of the bank

#### Risks (if any) associated the changes in the commit
None

#### What has been tested and how, request additional testing if necessary
Tested locally and checked the dmesg

#### Documentation impact (if any)
None
