### PR TITLE
CR-1110481 xbutil validate doesn't display test that is running

### DIFF
--- a/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
+++ b/src/runtime_src/core/tools/xbutil2/SubCmdValidate.cpp
@@ -1492,7 +1492,7 @@ run_test_suite_device( const std::shared_ptr<xrt_core::device>& device,
     // Hack: Until we have an option in the tests to query SUPP/NOT SUPP
     // we need to print the test description before running the test
     auto is_black_box_test = [ptTest]() {
-      std::vector<std::string> black_box_tests = {"Verify kernel", "Bandwidth kernel", "iops", "vcu"};
+      std::vector<std::string> black_box_tests = {"verify", "mem-bw", "iops", "vcu"};
       auto test = ptTest.get<std::string>("name");
       return std::find(black_box_tests.begin(), black_box_tests.end(), test) != black_box_tests.end() ? true : false;
     };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
https://jira.xilinx.com/browse/CR-1125972
In today's daily latest XRT (2.13.424), when running xbutil validate the test that is currently running isn't displayed so the user doesn't know what test is running.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
Introduced in https://github.com/Xilinx/XRT/pull/6060 due to change in test names.

#### How problem was solved, alternative solutions (if any) and why they were rejected
Problem was solved by updating the test names in the the "hack" section which checks for tests that take time to complete. We should definitely look at finding a better solution involving testing the support for the test, perhaps a separate function handle to see if a particular node is present that is required for the test?

#### Risks (if any) associated the changes in the commit
None, this is fixing a regression.

#### What has been tested and how, request additional testing if necessary
On U280 -
verify test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -d 65:00 -r verify
Starting validation for 1 devices

Validate Device           : [0000:65:00.1]
    Platform              : xilinx_u280_xdma_201920_3
    SC Version            : 4.3.15
    Platform ID           : 0x5e278820
-------------------------------------------------------------------------------
Test 4 [0000:65:00.1]     : verify
[>                   ]  0%: Running Test... < 1s >
```
mem-bw test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -d 65:00 -r mem-bw
Starting validation for 1 devices

Validate Device           : [0000:65:00.1]
    Platform              : xilinx_u280_xdma_201920_3
    SC Version            : 4.3.15
    Platform ID           : 0x5e278820
-------------------------------------------------------------------------------
Test 7 [0000:65:00.1]     : mem-bw
[===>                ] 15%: Running Test... < 45s >
```
iops test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -d 65:00 -r iops
Starting validation for 1 devices

Validate Device           : [0000:65:00.1]
    Platform              : xilinx_u280_xdma_201920_3
    SC Version            : 4.3.15
    Platform ID           : 0x5e278820
-------------------------------------------------------------------------------
Test 1 [0000:65:00.1]     : iops
[>                   ]  0%: Running Test... < 0s >
```
vcu test:
```
dbenusov@xsjpranjal01:/proj/xsjhdstaff6/dbenusov/XRT$ xbutil validate -d 65:00 -r vcu
Starting validation for 1 devices

Validate Device           : [0000:65:00.1]
    Platform              : xilinx_u280_xdma_201920_3
    SC Version            : 4.3.15
    Platform ID           : 0x5e278820
-------------------------------------------------------------------------------
Test 1 [0000:65:00.1]     : vcu
Validation completed. Please run the command '--verbose' option for more details
```
More testing help with the vcu test would be good. Otherwise everything is behaving as expected. The issue with vcu appearing regardless of it being skipped is going to be addressed in https://jira.xilinx.com/browse/CR-1099860
#### Documentation impact (if any)
None