### PR TITLE
CR-1126348 display Config Mode & Max Power when these are non zero values and fix mechanical error info in xbmgmt/xbutil examine reports

### DIFF
--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2022 Xilinx, Inc
+ * Copyright (C) 2018-2022 Xilinx, Inc and AMD, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -438,7 +438,10 @@ read_electrical(const xrt_core::device * device)
     if (!current.empty() || !voltage.empty() || !power.empty())
       return read_data_driven_electrical(current, voltage, power);
     else
-      is_data_driven = false;
+      return sensor_array;
+  }
+  catch(const xrt_core::query::sysfs_error&) {
+    is_data_driven = false;
   }
   catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;
@@ -465,8 +468,14 @@ read_thermals(const xrt_core::device * device)
   //Check if requested sensor data can be retrieved in data driven model.
   try {
     output = xrt_core::device_query<xq::sdm_sensor_info>(device, xq::sdm_sensor_info::sdr_req_type::thermal);
-    if (output.empty())
-      is_data_driven = false;
+    if (output.empty()) {
+      thermal_array.put("error_msg", "Information unavailable");
+      root.add_child("thermals", thermal_array);
+      return root;
+    }
+  }
+  catch(const xrt_core::query::sysfs_error&) {
+    is_data_driven = false;
   }
   catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;
@@ -494,8 +503,14 @@ read_mechanical(const xrt_core::device * device)
   //Check if requested sensor data can be retrieved in data driven model.
   try {
     output = xrt_core::device_query<xq::sdm_sensor_info>(device, xq::sdm_sensor_info::sdr_req_type::mechanical);
-    if (output.empty())
-      is_data_driven = false;
+    if (output.empty()) {
+      fan_array.put("error_msg", "Information unavailable");
+      root.add_child("fans", fan_array);
+      return root;
+    }
+  }
+  catch(const xrt_core::query::sysfs_error&) {
+    is_data_driven = false;
   }
   catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;

--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2018-2022 Xilinx, Inc and AMD, Inc
+ * Copyright (C) 2018-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -440,7 +440,7 @@ read_electrical(const xrt_core::device * device)
     else
       return sensor_array;
   }
-  catch(const xrt_core::query::sysfs_error&) {
+  catch(const xrt_core::query::exception&) {
     is_data_driven = false;
   }
   catch(const xrt_core::query::no_such_key&) {
@@ -474,7 +474,7 @@ read_thermals(const xrt_core::device * device)
       return root;
     }
   }
-  catch(const xrt_core::query::sysfs_error&) {
+  catch(const xrt_core::query::exception&) {
     is_data_driven = false;
   }
   catch(const xrt_core::query::no_such_key&) {
@@ -509,7 +509,7 @@ read_mechanical(const xrt_core::device * device)
       return root;
     }
   }
-  catch(const xrt_core::query::sysfs_error&) {
+  catch(const xrt_core::query::exception&) {
     is_data_driven = false;
   }
   catch(const xrt_core::query::no_such_key&) {

--- a/src/runtime_src/core/common/sensor.cpp
+++ b/src/runtime_src/core/common/sensor.cpp
@@ -440,10 +440,10 @@ read_electrical(const xrt_core::device * device)
     else
       return sensor_array;
   }
-  catch(const xrt_core::query::exception&) {
+  catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;
   }
-  catch(const xrt_core::query::no_such_key&) {
+  catch(const xrt_core::query::exception&) {
     is_data_driven = false;
   }
   catch (const std::exception& ex) {
@@ -474,10 +474,10 @@ read_thermals(const xrt_core::device * device)
       return root;
     }
   }
-  catch(const xrt_core::query::exception&) {
+  catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;
   }
-  catch(const xrt_core::query::no_such_key&) {
+  catch(const xrt_core::query::exception&) {
     is_data_driven = false;
   }
   catch (const std::exception& ex) {
@@ -509,10 +509,10 @@ read_mechanical(const xrt_core::device * device)
       return root;
     }
   }
-  catch(const xrt_core::query::exception&) {
+  catch(const xrt_core::query::no_such_key&) {
     is_data_driven = false;
   }
-  catch(const xrt_core::query::no_such_key&) {
+  catch(const xrt_core::query::exception&) {
     is_data_driven = false;
   }
   catch (const std::exception& ex) {

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2022 Xilinx, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc and AMD, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the
@@ -266,7 +266,7 @@ struct sdm_sensor_info
     }
 
     if (path.empty())
-      return result_type();
+      throw xrt_core::query::sysfs_error("sysfs path not found");
 
     return get_sdm_sensors(device, req_type, path);
   } //get()

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -266,7 +266,7 @@ struct sdm_sensor_info
     }
 
     if (path.empty())
-      throw xrt_core::query::sysfs_error("sysfs path not found");
+      throw xrt_core::query::sysfs_error("target hwmon_sdm sysfs path /sys/bus/pci/devices/<bdf>/hwmon/hwmon*/ not found");
 
     return get_sdm_sensors(device, req_type, path);
   } //get()

--- a/src/runtime_src/core/pcie/linux/device_linux.cpp
+++ b/src/runtime_src/core/pcie/linux/device_linux.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2022 Xilinx, Inc and AMD, Inc
+ * Copyright (C) 2019-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2022 Xilinx, Inc and AMD, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -28,6 +28,7 @@
 #include <boost/algorithm/string.hpp>
 
 static boost::format fmtBasic("  %-20s : %s\n");
+static boost::format fmtBasicHex("  %-20s : 0x%x\n");
 
 void
 ReportPlatform::getPropertyTreeInternal( const xrt_core::device * device,
@@ -342,6 +343,9 @@ ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/,
   _output << "Device properties\n";
   _output << fmtBasic % "Type" % string_or_NA(dev_properties.get<std::string>("board_type"));
   _output << fmtBasic % "Name" % string_or_NA(dev_properties.get<std::string>("board_name"));
+  auto config_mode = dev_properties.get<unsigned int>("config_mode");
+  if (config_mode != 0)
+    _output << fmtBasicHex % "Config Mode" % config_mode;
   _output << fmtBasic % "Config Mode" % string_or_NA(dev_properties.get<std::string>("config_mode"));
   _output << fmtBasic % "Max Power" % string_or_NA(dev_properties.get<std::string>("max_power_watts"));
   _output << std::endl;

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -199,7 +199,7 @@ ReportPlatform::getPropertyTree20202( const xrt_core::device * device,
   dev_prop.put("board_type", xrt_core::device_query<xrt_core::query::board_name>(device));
   dev_prop.put("board_name", info.mName.empty() ? "N/A" : info.mName);
   dev_prop.put("config_mode", info.mConfigMode);
-  dev_prop.put("max_power_watts", info.mMaxPower.empty() ? "N/A" : info.mMaxPower);
+  dev_prop.put("max_power_watts", info.mMaxPower);
   pt_platform.add_child("device_properties", dev_prop);
 
   //Flashable partition running on FPGA
@@ -346,8 +346,9 @@ ReportPlatform::writeReport( const xrt_core::device* /*_pDevice*/,
   auto config_mode = dev_properties.get<unsigned int>("config_mode");
   if (config_mode != 0)
     _output << fmtBasicHex % "Config Mode" % config_mode;
-  _output << fmtBasic % "Config Mode" % string_or_NA(dev_properties.get<std::string>("config_mode"));
-  _output << fmtBasic % "Max Power" % string_or_NA(dev_properties.get<std::string>("max_power_watts"));
+  auto max_power_str = dev_properties.get<std::string>("max_power_watts");
+  if (!max_power_str.empty())
+    _output << fmtBasic % "Max Power" % max_power_str;
   _output << std::endl;
 
   _output << "Flashable partitions running on FPGA\n";

--- a/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/ReportPlatform.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020-2022 Xilinx, Inc
+ * Copyright (C) 2020-2022 Xilinx, Inc and AMD, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may
  * not use this file except in compliance with the License. A copy of the

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -295,6 +295,7 @@ int Flasher::getBoardInfo(BoardInfo& board)
             sdr_info[BDINFO_MAC0] : std::move(std::string("Unassigned"));
         board.mMacAddr1 = sdr_info[BDINFO_MAC1].compare(unassigned_mac) ?
             sdr_info[BDINFO_MAC1] : std::move(std::string("Unassigned"));
+        board.mConfigMode = 0;
         return 0;
     }
     if (ret != 0)

--- a/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
+++ b/src/runtime_src/core/tools/xbmgmt2/flash/flasher.cpp
@@ -290,12 +290,12 @@ int Flasher::getBoardInfo(BoardInfo& board)
         board.mName = sdr_info[BDINFO_NAME];
         board.mRev = sdr_info[BDINFO_REV];
         board.mFanPresence = sdr_info[BDINFO_FAN_PRESENCE][0];
-        board.mMaxPower = sdr_info[BDINFO_MAX_PWR];
         board.mMacAddr0 = sdr_info[BDINFO_MAC0].compare(unassigned_mac) ?
             sdr_info[BDINFO_MAC0] : std::move(std::string("Unassigned"));
         board.mMacAddr1 = sdr_info[BDINFO_MAC1].compare(unassigned_mac) ?
             sdr_info[BDINFO_MAC1] : std::move(std::string("Unassigned"));
         board.mConfigMode = 0;
+        board.mMaxPower = "";
         return 0;
     }
     if (ret != 0)


### PR DESCRIPTION
Signed-off-by: Rajkumar Rampelli <rajkumar@xilinx.com>

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit
1. On versal platform, VMR doesn't send Config Mode and Max Power information. So, XRT should skip printing these information as part of xbmgmt examine reports.
2. sdm_sensor_info query request throws proper error if it is unable to find required sysfs path instead of returning empty output.

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered
CR-1126348 and CR-1121356

#### How problem was solved, alternative solutions (if any) and why they were rejected
1. Added change in XRT UI to display Config Mode & Max Power data only when it is non zero.
2. Mechanical report in xbmgmt/xbutil examine output in json formats. It shows "Information unavailable" if VMR doesn't send required sensor data on versal.

#### Risks (if any) associated the changes in the commit
NA

#### What has been tested and how, request additional testing if necessary
xbmgmt & xbutil examine reports.

#### Documentation impact (if any)
NA