### PR TITLE
Update XRT native API document to reflect latest -std=c++17 requirement

### DIFF
--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -11,8 +11,7 @@ XRT Native APIs
 From 2020.2 release XRT provides a new XRT API set in C, C++, and Python flavor. 
 
 To use the native XRT APIs, the host application must link with the **xrt_coreutil** library. 
-Compiling host code with XRT native C++ API requires C++ standard with -std=c++14 or newer. 
-On GCC version older than 4.9.0, please use -std=c++1y instead because -std=c++14 is introduced to GCC from 4.9.0.
+Compiling host code with XRT native C++ API requires C++ standard with -std=c++17 (or newer). 
 
 Example g++ command
 


### PR DESCRIPTION

#### Problem solved by the commit

From 22.1 release the requirement of compiling host-code with XRT native API requires std=c++17 (as the previous boost dependency was removed). The doc change is done to reflect this. 

