### PR TITLE
Removed the limitation of xbtop from its documentation 

### DIFF
--- a/src/runtime_src/doc/toc/xbtop.rst
+++ b/src/runtime_src/doc/toc/xbtop.rst
@@ -26,4 +26,4 @@ Page 2: Dynamic Region
    - Compute Usage
 Page 3: Power
 
-**Limitation in Centos**: Currently xbtop utility is not added in CentOS package. However, it is possible to use xbtop utility to use in Centos by copying xbtop python files (copying ``ReportMemory.py``, ``ReportPower.py``, ``ReportDynamicRegions.py``, ``XBUtil.py``, ``xbtop.py``, ``xbtop`` into ``/opt/xilinx/xrt/python``) from a supported OS package.
+


### PR DESCRIPTION
As per https://github.com/Xilinx/XRT/pull/6492, we dont have any limitation of Centos now, hence removed that part from doc
