### PR TITLE
CR-1126419 add warning when no aie status files were written (#6472)

### DIFF
--- a/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
+++ b/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.cpp
@@ -17,6 +17,8 @@
 #include "xdp/profile/writer/aie_debug/aie_debug_writer.h"
 #include "xdp/profile/database/database.h"
 
+#include "core/common/message.h"
+
 #include <vector>
 #include <boost/optional/optional.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -32,6 +34,7 @@ namespace xdp {
     : VPWriter(fileName)
     , mDeviceName(deviceName)
     , mDeviceIndex(deviceIndex)
+    , mWroteValidData(false)
   {
   }
 
@@ -57,6 +60,7 @@ namespace xdp {
     // Write approved AIE report to file
     refreshFile();
     fout << aieInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
@@ -85,10 +89,20 @@ namespace xdp {
     // Write approved AIE report to file
     refreshFile();
     fout << aieInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
     return true;
+  }
+
+  // Warn if application exits without writing valid data
+  AIEDebugWriter::~AIEDebugWriter()
+  {
+    if (!mWroteValidData) {
+      std::string msg("No valid data found for AIE status. Please run xbutil.");
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+    }
   }
 
   /*
@@ -100,6 +114,7 @@ namespace xdp {
     : VPWriter(fileName)
     , mDeviceName(deviceName)
     , mDeviceIndex(deviceIndex)
+    , mWroteValidData(false)
   {
   }
 
@@ -125,6 +140,7 @@ namespace xdp {
     // Write approved AIE shim report to file
     refreshFile();
     fout << aieShimInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
@@ -153,10 +169,20 @@ namespace xdp {
     // Write approved AIE shim report to file
     refreshFile();
     fout << aieShimInfoStr << std::endl;
+    mWroteValidData = true;
 
     if (openNewFile)
       switchFiles();
     return true;
+  }
+
+  // Warn if application exits without writing valid shim data
+  AIEShimDebugWriter::~AIEShimDebugWriter()
+  {
+    if (!mWroteValidData) {
+      std::string msg("No valid data found for AIE Shim status. Please run xbutil.");
+      xrt_core::message::send(xrt_core::message::severity_level::warning, "XRT", msg);
+    }
   }
 
 } // end namespace xdp

--- a/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.h
+++ b/src/runtime_src/xdp/profile/writer/aie_debug/aie_debug_writer.h
@@ -30,6 +30,7 @@ namespace xdp {
   public:
     AIEDebugWriter(const char* fileName, const char* deviceName,
                    uint64_t deviceIndex);
+    ~AIEDebugWriter();
 
     virtual bool write(bool openNewFile);
     virtual bool write(bool openNewFile, void* handle);
@@ -37,6 +38,7 @@ namespace xdp {
   private:
     std::string mDeviceName;
     uint64_t mDeviceIndex;
+    bool mWroteValidData;
   };
 
   /*
@@ -47,6 +49,7 @@ namespace xdp {
   public:
     AIEShimDebugWriter(const char* fileName, const char* deviceName,
                        uint64_t deviceIndex);
+    ~AIEShimDebugWriter();
 
     virtual bool write(bool openNewFile);
     virtual bool write(bool openNewFile, void* handle);
@@ -54,6 +57,7 @@ namespace xdp {
   private:
     std::string mDeviceName;
     uint64_t mDeviceIndex;
+    bool mWroteValidData;
   };
 
 } // end namespace xdp


### PR DESCRIPTION
(cherry picked from commit 4c1750105a0e0446428c1addcf89838f11b003b1)

If application exits too soon, we could end up with corrupt aie status data. In this case we throw a warning.


