### PR TITLE
fixed typo in the example command line for XRT native APIs

### DIFF
--- a/src/runtime_src/doc/toc/xrt_native_apis.rst
+++ b/src/runtime_src/doc/toc/xrt_native_apis.rst
@@ -17,7 +17,7 @@ Example g++ command
 
 .. code-block:: shell
 
-    g++ -g -std=c++14 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o host.exe host.cpp -lxrt_coreutil -pthread
+    g++ -g -std=c++17 -I$XILINX_XRT/include -L$XILINX_XRT/lib -o host.exe host.cpp -lxrt_coreutil -pthread
 
 
 The XRT native API supports both the C and C++ flavor of APIs. For general host code development, C++-based APIs are recommended, hence this document only describes the C++-based API interfaces. The full Doxygen generated C and C++ API documentation can be found in :doc: `xrt_native.main`.


### PR DESCRIPTION

#### Problem solved by the commit

Fixed typo in the example command line, cpp14 --> cpp17


#### Risks (if any) associated the changes in the commit

None 
